### PR TITLE
bats/git-dolt.bats: Use cp instead of ln to fix test on windows

### DIFF
--- a/bats/git-dolt.bats
+++ b/bats/git-dolt.bats
@@ -136,8 +136,8 @@ teardown() {
 @test "git dolt fails helpfully when dolt is not installed" {
     mkdir TMP_PATH
     pushd TMP_PATH
-    which git | xargs ln -sf
-    which git-dolt | xargs ln -sf
+    cp `which git` ./git
+    cp `which git-dolt` ./git-dolt
     if [ $IS_WINDOWS = true ]; then
         ORIGINAL_PATH=$PATH
         export PATH=""


### PR DESCRIPTION
This change was the one thing causing a conflict in https://github.com/liquidata-inc/ld/pull/1865. When this PR is merged, we can rebase `git-dolt.bats` out of `ld`.