### PR TITLE
Increase maxiumum SQL statement length to 100MB (initially 512K)

### DIFF
--- a/go/cmd/dolt/commands/sql_statement_scanner.go
+++ b/go/cmd/dolt/commands/sql_statement_scanner.go
@@ -27,11 +27,13 @@ type statementScanner struct {
 	lineNum            int // the current line number being parsed
 }
 
+const maxStatementBufferBytes = 100 * 1024 * 1024
+
 func NewSqlStatementScanner(input io.Reader) *statementScanner {
 	scanner := bufio.NewScanner(input)
-	const maxCapacity = 512 * 1024
-	buf := make([]byte, maxCapacity)
-	scanner.Buffer(buf, maxCapacity)
+	const initialCapacity = 512 * 1024
+	buf := make([]byte, initialCapacity)
+	scanner.Buffer(buf, maxStatementBufferBytes)
 
 	s := &statementScanner{
 		Scanner: scanner,


### PR DESCRIPTION
Signed-off-by: Zach Musgrave <zach@liquidata.co>