### PR TITLE
Andy/gc chunks

### DIFF
--- a/bats/garbage_collection.bats
+++ b/bats/garbage_collection.bats
@@ -128,5 +128,7 @@ SQL
     AFTER=$(du .dolt/noms/ | sed 's/[^0-9]*//g')
 
     # assert space was reclaimed
+    echo "$BEFORE"
+    echo "$AFTER"
     [ "$BEFORE" -gt "$AFTER" ]
 }

--- a/bats/garbage_collection.bats
+++ b/bats/garbage_collection.bats
@@ -25,6 +25,12 @@ teardown() {
     ps -p $remotesrv_pid | grep remotesrv
 }
 
+@test "gc on empty dir" {
+    dolt gc
+    dolt gc
+    dolt gc -s
+}
+
 @test "dolt gc smoke test" {
     dolt sql <<SQL
 CREATE TABLE test (pk int PRIMARY KEY);
@@ -35,6 +41,8 @@ SQL
     [ "$status" -eq "0" ]
     [[ "$output" =~ "5" ]] || false
 
+    dolt gc
+    dolt gc
     run dolt gc
     [ "$status" -eq "0" ]
     run dolt status

--- a/bats/no-repo.bats
+++ b/bats/no-repo.bats
@@ -50,6 +50,7 @@ teardown() {
     [[ "$output" =~ "table - Commands for copying, renaming, deleting, and exporting tables." ]] || false
     [[ "$output" =~ "conflicts - Commands for viewing and resolving merge conflicts." ]] || false
     [[ "$output" =~ "migrate - Executes a repository migration to update to the latest format." ]] || false
+    [[ "$output" =~ "gc - Cleans up unreferenced data from the repository." ]] || false
 }
 
 @test "testing dolt version output" {

--- a/go/Godeps/LICENSES
+++ b/go/Godeps/LICENSES
@@ -5324,6 +5324,40 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ================================================================================
 
 ================================================================================
+= golang.org/x/sync licensed under: =
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+= LICENSE ed6066ae50f153e2965216c6d4b9335900f1f8b2b526527f49a619d7 =
+================================================================================
+
+================================================================================
 = golang.org/x/sys licensed under: =
 
 Copyright (c) 2009 The Go Authors. All rights reserved.

--- a/go/cmd/dolt/commands/gc.go
+++ b/go/cmd/dolt/commands/gc.go
@@ -33,9 +33,13 @@ const (
 )
 
 var gcDocs = cli.CommandDocumentationContent{
-	ShortDesc: "",
-	LongDesc:  ``,
-	Synopsis:  []string{},
+	ShortDesc: "Cleans up unreferenced data from the repository.",
+	LongDesc: `Searches the repository for data that is no longer referenced and no longer needed
+
+If the {{.EmphasisLeft}}--shallow{{.EmphasisRight}} flag is supplied, a faster but less thorough garbage collection will be performed.`,
+	Synopsis: []string{
+		"[--shallow]",
+	},
 }
 
 type GarbageCollectionCmd struct{}
@@ -47,12 +51,12 @@ func (cmd GarbageCollectionCmd) Name() string {
 
 // Description returns a description of the command
 func (cmd GarbageCollectionCmd) Description() string {
-	return "Cleans up unreferenced data from the database."
+	return gcDocs.ShortDesc
 }
 
 // Hidden should return true if this command should be hidden from the help text
 func (cmd GarbageCollectionCmd) Hidden() bool {
-	return true
+	return false
 }
 
 // RequiresRepo should return false if this interface is implemented, and the command does not have the requirement
@@ -69,7 +73,7 @@ func (cmd GarbageCollectionCmd) CreateMarkdown(fs filesys.Filesys, path, command
 
 func (cmd GarbageCollectionCmd) createArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParser()
-	ap.SupportsFlag(gcShallowFlag, "s", "reclaim compaction garbage, but don't traverse the commit graph")
+	ap.SupportsFlag(gcShallowFlag, "s", "perform a fast, but incomplete garbage collection pass")
 	return ap
 }
 

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -154,7 +154,6 @@ func runMain() int {
 	warnIfMaxFilesTooLow()
 
 	ctx := context.Background()
-
 	dEnv := env.Load(ctx, env.GetCurrentUserHomeDir, filesys.LocalFS, doltdb.LocalDirDoltDB, Version)
 
 	if dEnv.DBLoadError == nil && commandNeedsMigrationCheck(args) {

--- a/go/go.mod
+++ b/go/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/codahale/blake2 v0.0.0-20150924215134-8d10d0420cbf
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20201005193433-3ee972b1d078
+	github.com/dolthub/fslock v0.0.2
 	github.com/dolthub/go-mysql-server v0.6.1-0.20201001225250-48db640bd4d5
 	github.com/dolthub/vitess v0.0.0-20200925174744-823c7e177c3f
 	github.com/dustin/go-humanize v1.0.0
@@ -43,7 +44,6 @@ require (
 	github.com/hashicorp/memberlist v0.1.6 // indirect
 	github.com/jedib0t/go-pretty v4.3.1-0.20191104025401-85fe5d6a7c4d+incompatible
 	github.com/jpillora/backoff v1.0.0
-	github.com/dolthub/fslock v0.0.2
 	github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d
 	github.com/kch42/buzhash v0.0.0-20160816060738-9bdec3dec7c6
 	github.com/lestrrat-go/strftime v1.0.3 // indirect
@@ -80,6 +80,7 @@ require (
 	go.uber.org/zap v1.15.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20200904194848-62affa334b73
+	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f
 	google.golang.org/api v0.32.0
 	google.golang.org/grpc v1.32.0

--- a/go/libraries/doltcore/doltdb/foreign_key_test.go
+++ b/go/libraries/doltcore/doltdb/foreign_key_test.go
@@ -46,7 +46,7 @@ type testCommand struct {
 	args []string
 }
 
-var setupCommon = []testCommand{
+var fkSetupCommon = []testCommand{
 	{commands.SqlCmd{}, []string{"-q", "create table parent (" +
 		"id int," +
 		"v1 int," +
@@ -65,7 +65,7 @@ func testForeignKeys(t *testing.T, test foreignKeyTest) {
 	ctx := context.Background()
 	dEnv := dtestutils.CreateTestEnv()
 
-	for _, c := range setupCommon {
+	for _, c := range fkSetupCommon {
 		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv)
 		require.Equal(t, 0, exitCode)
 	}

--- a/go/libraries/doltcore/doltdb/gc_test.go
+++ b/go/libraries/doltcore/doltdb/gc_test.go
@@ -1,0 +1,103 @@
+// Copyright 2020 Liquidata, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package doltdb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/cmd/dolt/commands"
+	"github.com/dolthub/dolt/go/libraries/doltcore/dtestutils"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
+	"github.com/dolthub/dolt/go/store/types"
+)
+
+type gcTest struct {
+	name     string
+	setup    []testCommand
+	garbage  types.Value
+	query    string
+	expected []sql.Row
+}
+
+var gcTests = []gcTest{
+	{
+		name: "gc test",
+		setup: []testCommand{
+			{commands.SqlCmd{}, []string{"-q", "INSERT INTO test VALUES (0),(1),(2);"}},
+		},
+		garbage: types.String("supercalifragilisticexpialidocious"),
+	},
+}
+
+var gcSetupCommon = []testCommand{
+	{commands.SqlCmd{}, []string{"-q", "CREATE TABLE test (pk int PRIMARY KEY)"}},
+}
+
+func TestGarbageCollection(t *testing.T) {
+	require.True(t, true)
+	assert.True(t, true)
+
+	for _, gct := range gcTests {
+		t.Run(gct.name, func(t *testing.T) {
+			testGarbageCollection(t, gct)
+		})
+	}
+
+}
+
+func testGarbageCollection(t *testing.T, test gcTest) {
+	ctx := context.Background()
+	dEnv := dtestutils.CreateTestEnv()
+
+	for _, c := range gcSetupCommon {
+		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv)
+		require.Equal(t, 0, exitCode)
+	}
+	for _, c := range test.setup {
+		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv)
+		require.Equal(t, 0, exitCode)
+	}
+
+	garbageRef, err := dEnv.DoltDB.ValueReadWriter().WriteValue(ctx, test.garbage)
+	require.NoError(t, err)
+	val, err := dEnv.DoltDB.ValueReadWriter().ReadValue(ctx, garbageRef.TargetHash())
+	require.NoError(t, err)
+	assert.NotNil(t, val)
+
+	working, err := dEnv.WorkingRoot(ctx)
+	require.NoError(t, err)
+	h, err := working.HashOf()
+	require.NoError(t, err)
+	// save working root during GC
+	err = dEnv.DoltDB.GC(ctx, h)
+	require.NoError(t, err)
+
+	working, err = dEnv.WorkingRoot(ctx)
+	require.NoError(t, err)
+	// assert all out rows are present after gc
+	actual, err := sqle.ExecuteSelect(dEnv, dEnv.DoltDB, working, test.query)
+	require.NoError(t, err)
+	assert.Equal(t, test.expected, actual)
+
+	// assert that garbage was collected
+	val, err = dEnv.DoltDB.ValueReadWriter().ReadValue(ctx, garbageRef.TargetHash())
+	require.NoError(t, err)
+	assert.Nil(t, val)
+}

--- a/go/libraries/doltcore/remotestorage/chunk_store.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store.go
@@ -46,6 +46,7 @@ var ErrInvalidDoltSpecPath = errors.New("invalid dolt spec path")
 var globalHttpFetcher HTTPFetcher = &http.Client{}
 
 var _ nbs.TableFileStore = (*DoltChunkStore)(nil)
+var _ chunks.ChunkStore = (*DoltChunkStore)(nil)
 
 // We may need this to be configurable for users with really bad internet
 var downThroughputCheck = iohelp.MinThroughputCheckParams{
@@ -82,8 +83,6 @@ type DoltChunkStore struct {
 	nbf         *types.NomsBinFormat
 	httpFetcher HTTPFetcher
 }
-
-var _ nbs.TableFileStore = &DoltChunkStore{}
 
 func NewDoltChunkStoreFromPath(ctx context.Context, nbf *types.NomsBinFormat, path, host string, csClient remotesapi.ChunkStoreServiceClient) (*DoltChunkStore, error) {
 	tokens := strings.Split(strings.Trim(path, "/"), "/")
@@ -880,6 +879,7 @@ func (dcs *DoltChunkStore) SupportedOperations() nbs.TableFileStoreOps {
 		CanRead:  true,
 		CanWrite: true,
 		CanPrune: false,
+		CanGC:    false,
 	}
 }
 
@@ -949,7 +949,7 @@ func (dcs *DoltChunkStore) WriteTableFile(ctx context.Context, fileId string, nu
 
 // PruneTableFiles deletes old table files that are no longer referenced in the manifest.
 func (dcs *DoltChunkStore) PruneTableFiles(ctx context.Context) error {
-	return nbs.ErrUnsupportedOperation
+	return chunks.ErrUnsupportedOperation
 }
 
 // Sources retrieves the current root hash, and a list of all the table files

--- a/go/store/chunks/chunk_store.go
+++ b/go/store/chunks/chunk_store.go
@@ -25,6 +25,9 @@ import (
 	"context"
 	"errors"
 	"io"
+	"sync"
+
+	"github.com/dolthub/dolt/go/store/atomicerr"
 
 	"github.com/dolthub/dolt/go/store/hash"
 )
@@ -94,7 +97,7 @@ type ChunkStoreGarbageCollector interface {
 
 	// MarkAndSweepChunks provides a channel to send the hashes of chunks that should be kept.
 	// Clients must close |keepers| to finalize garbage collection.
-	MarkAndSweepChunks(ctx context.Context, last hash.Hash, keepChunks <-chan hash.Hash, errChan chan<- error) error
+	MarkAndSweepChunks(ctx context.Context, last hash.Hash, keepChunks <-chan hash.Hash) (*sync.WaitGroup, *atomicerr.AtomicError)
 }
 
 var ErrUnsupportedOperation = errors.New("operation not supported")

--- a/go/store/chunks/chunk_store.go
+++ b/go/store/chunks/chunk_store.go
@@ -25,9 +25,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"sync"
-
-	"github.com/dolthub/dolt/go/store/atomicerr"
 
 	"github.com/dolthub/dolt/go/store/hash"
 )
@@ -95,9 +92,12 @@ type ChunkStore interface {
 type ChunkStoreGarbageCollector interface {
 	ChunkStore
 
-	// MarkAndSweepChunks provides a channel to send the hashes of chunks that should be kept.
-	// Clients must close |keepers| to finalize garbage collection.
-	MarkAndSweepChunks(ctx context.Context, last hash.Hash, keepChunks <-chan hash.Hash) (*sync.WaitGroup, *atomicerr.AtomicError)
+	// MarkAndSweepChunks expects |keepChunks| to receive the chunk hashes
+	// that should be kept in the chunk store. Once |keepChunks| is closed
+	// and MarkAndSweepChunks returns, the chunk store will only have the
+	// chunks sent on |keepChunks| and will have removed all other content
+	// from the ChunkStore.
+	MarkAndSweepChunks(ctx context.Context, last hash.Hash, keepChunks <-chan hash.Hash) error
 }
 
 var ErrUnsupportedOperation = errors.New("operation not supported")

--- a/go/store/chunks/chunk_store.go
+++ b/go/store/chunks/chunk_store.go
@@ -23,7 +23,7 @@ package chunks
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io"
 
 	"github.com/dolthub/dolt/go/store/hash"
@@ -88,4 +88,15 @@ type ChunkStore interface {
 	io.Closer
 }
 
-var ErrGCGenerationExpired = fmt.Errorf("garbage collection generation expired")
+// ChunkStoreGarbageCollector is a ChunkStore that supports garbage collection.
+type ChunkStoreGarbageCollector interface {
+	ChunkStore
+
+	// MarkAndSweepChunks provides a channel to send the hashes of chunks that should be kept.
+	// Clients must close |keepers| to finalize garbage collection.
+	MarkAndSweepChunks(ctx context.Context, last hash.Hash, keepChunks <-chan hash.Hash, errChan chan<- error) error
+}
+
+var ErrUnsupportedOperation = errors.New("operation not supported")
+
+var ErrGCGenerationExpired = errors.New("garbage collection generation expired")

--- a/go/store/chunks/memory_store.go
+++ b/go/store/chunks/memory_store.go
@@ -228,9 +228,13 @@ func (ms *MemoryStoreView) MarkAndSweepChunks(ctx context.Context, last hash.Has
 
 	keepers := make(map[hash.Hash]Chunk, ms.storage.Len())
 
+LOOP:
 	for {
 		select {
-		case h := <-keepChunks:
+		case h, ok := <-keepChunks:
+			if !ok {
+				break LOOP
+			}
 			c, err := ms.Get(ctx, h)
 			if err != nil {
 				return err

--- a/go/store/chunks/test_utils.go
+++ b/go/store/chunks/test_utils.go
@@ -23,12 +23,10 @@ package chunks
 
 import (
 	"context"
-	"sync"
 	"sync/atomic"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/dolthub/dolt/go/store/atomicerr"
 	"github.com/dolthub/dolt/go/store/d"
 	"github.com/dolthub/dolt/go/store/hash"
 )
@@ -88,11 +86,10 @@ func (s *TestStoreView) Put(ctx context.Context, c Chunk) error {
 	return s.ChunkStore.Put(ctx, c)
 }
 
-func (s *TestStoreView) MarkAndSweepChunks(ctx context.Context, last hash.Hash, keepChunks <-chan hash.Hash) (*sync.WaitGroup, *atomicerr.AtomicError) {
+func (s *TestStoreView) MarkAndSweepChunks(ctx context.Context, last hash.Hash, keepChunks <-chan hash.Hash) error {
 	collector, ok := s.ChunkStore.(ChunkStoreGarbageCollector)
-
 	if !ok {
-		panic(ErrUnsupportedOperation)
+		return ErrUnsupportedOperation
 	}
 
 	return collector.MarkAndSweepChunks(ctx, last, keepChunks)

--- a/go/store/chunks/test_utils.go
+++ b/go/store/chunks/test_utils.go
@@ -23,10 +23,12 @@ package chunks
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/dolthub/dolt/go/store/atomicerr"
 	"github.com/dolthub/dolt/go/store/d"
 	"github.com/dolthub/dolt/go/store/hash"
 )
@@ -86,14 +88,14 @@ func (s *TestStoreView) Put(ctx context.Context, c Chunk) error {
 	return s.ChunkStore.Put(ctx, c)
 }
 
-func (s *TestStoreView) MarkAndSweepChunks(ctx context.Context, last hash.Hash, keepChunks <-chan hash.Hash, errChan chan<- error) error {
+func (s *TestStoreView) MarkAndSweepChunks(ctx context.Context, last hash.Hash, keepChunks <-chan hash.Hash) (*sync.WaitGroup, *atomicerr.AtomicError) {
 	collector, ok := s.ChunkStore.(ChunkStoreGarbageCollector)
 
 	if !ok {
-		return ErrUnsupportedOperation
+		panic(ErrUnsupportedOperation)
 	}
 
-	return collector.MarkAndSweepChunks(ctx, last, keepChunks, errChan)
+	return collector.MarkAndSweepChunks(ctx, last, keepChunks)
 }
 
 func (s *TestStoreView) Reads() int {

--- a/go/store/chunks/test_utils.go
+++ b/go/store/chunks/test_utils.go
@@ -59,6 +59,8 @@ type TestStoreView struct {
 	writes int32
 }
 
+var _ ChunkStoreGarbageCollector = &TestStoreView{}
+
 func (s *TestStoreView) Get(ctx context.Context, h hash.Hash) (Chunk, error) {
 	atomic.AddInt32(&s.reads, 1)
 	return s.ChunkStore.Get(ctx, h)
@@ -82,6 +84,16 @@ func (s *TestStoreView) HasMany(ctx context.Context, hashes hash.HashSet) (hash.
 func (s *TestStoreView) Put(ctx context.Context, c Chunk) error {
 	atomic.AddInt32(&s.writes, 1)
 	return s.ChunkStore.Put(ctx, c)
+}
+
+func (s *TestStoreView) MarkAndSweepChunks(ctx context.Context, last hash.Hash, keepChunks <-chan hash.Hash, errChan chan<- error) error {
+	collector, ok := s.ChunkStore.(ChunkStoreGarbageCollector)
+
+	if !ok {
+		return ErrUnsupportedOperation
+	}
+
+	return collector.MarkAndSweepChunks(ctx, last, keepChunks, errChan)
 }
 
 func (s *TestStoreView) Reads() int {

--- a/go/store/datas/database.go
+++ b/go/store/datas/database.go
@@ -158,6 +158,16 @@ func NewDatabase(cs chunks.ChunkStore) Database {
 	return newDatabase(cs)
 }
 
+// GarbageCollector provides a method to
+// remove unreferenced data from a store.
+type GarbageCollector interface {
+	types.ValueReadWriter
+
+	// GC traverses the database starting at the Root and removes
+	// all unreferenced data from persistent storage.
+	GC(ctx context.Context) error
+}
+
 // CanUsePuller returns true if a datas.Puller can be used to pull data from one Database into another.  Not all
 // Databases support this yet.
 func CanUsePuller(db Database) bool {

--- a/go/store/datas/database_common.go
+++ b/go/store/datas/database_common.go
@@ -61,6 +61,12 @@ func newDatabase(cs chunks.ChunkStore) *database {
 	}
 }
 
+var _ Database = &database{}
+var _ GarbageCollector = &database{}
+
+var _ rootTracker = &types.ValueStore{}
+var _ GarbageCollector = &types.ValueStore{}
+
 func (db *database) chunkStore() chunks.ChunkStore {
 	return db.ChunkStore()
 }
@@ -573,6 +579,11 @@ func (db *database) doDelete(ctx context.Context, datasetIDstr string) error {
 		}
 	}
 	return err
+}
+
+// GC traverses the database starting at the Root and removes all unreferenced data from persistent storage.
+func (db *database) GC(ctx context.Context) error {
+	return db.ValueStore.GC(ctx)
 }
 
 func (db *database) tryCommitChunks(ctx context.Context, currentDatasets types.Map, currentRootHash hash.Hash) error {

--- a/go/store/datas/garbage_collection.go
+++ b/go/store/datas/garbage_collection.go
@@ -17,6 +17,7 @@ package datas
 import (
 	"context"
 
+	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/nbs"
 )
 
@@ -24,7 +25,7 @@ func PruneTableFiles(ctx context.Context, db Database) error {
 	tfs, ok := db.chunkStore().(nbs.TableFileStore)
 
 	if !ok {
-		return nbs.ErrUnsupportedOperation
+		return chunks.ErrUnsupportedOperation
 	}
 
 	return tfs.PruneTableFiles(ctx)

--- a/go/store/datas/pull.go
+++ b/go/store/datas/pull.go
@@ -314,6 +314,8 @@ func pull(ctx context.Context, srcDB, sinkDB Database, sourceRef types.Ref, prog
 }
 
 func persistChunks(ctx context.Context, cs chunks.ChunkStore) error {
+	// todo: there is no call to rebase on an unsuccessful Commit()
+	// will  this loop forever?
 	var success bool
 	for !success {
 		r, err := cs.Root(ctx)

--- a/go/store/datas/pull_test.go
+++ b/go/store/datas/pull_test.go
@@ -455,7 +455,7 @@ func (ttfs *TestTableFileStore) SupportedOperations() nbs.TableFileStoreOps {
 }
 
 func (ttfs *TestTableFileStore) PruneTableFiles(ctx context.Context) error {
-	return nbs.ErrUnsupportedOperation
+	return chunks.ErrUnsupportedOperation
 }
 
 func TestClone(t *testing.T) {

--- a/go/store/nbs/aws_table_persister.go
+++ b/go/store/nbs/aws_table_persister.go
@@ -35,6 +35,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 
 	"github.com/dolthub/dolt/go/store/atomicerr"
+	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/util/verbose"
 )
 
@@ -605,5 +606,5 @@ func (s3p awsTablePersister) uploadPart(ctx context.Context, data []byte, key, u
 }
 
 func (s3p awsTablePersister) PruneTableFiles(ctx context.Context, contents manifestContents) error {
-	return ErrUnsupportedOperation
+	return chunks.ErrUnsupportedOperation
 }

--- a/go/store/nbs/bs_manifest.go
+++ b/go/store/nbs/bs_manifest.go
@@ -44,7 +44,7 @@ func manifestVersionAndContents(ctx context.Context, bs blobstore.Blobstore) (st
 	}
 
 	defer reader.Close()
-	contents, err := fileManifestv5{}.parseManifest(reader)
+	contents, err := fileManifestV5{}.parseManifest(reader)
 
 	if err != nil {
 		return "", manifestContents{}, err
@@ -88,7 +88,7 @@ func (bsm blobstoreManifest) Update(ctx context.Context, lastLock addr, newConte
 
 	if contents.lock == lastLock {
 		buffer := bytes.NewBuffer(make([]byte, 64*1024)[:0])
-		err := fileManifestv5{}.writeManifest(buffer, newContents)
+		err := fileManifestV5{}.writeManifest(buffer, newContents)
 
 		if err != nil {
 			return manifestContents{}, err

--- a/go/store/nbs/bs_persister.go
+++ b/go/store/nbs/bs_persister.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/dolthub/dolt/go/store/blobstore"
+	"github.com/dolthub/dolt/go/store/chunks"
 )
 
 type blobstorePersister struct {
@@ -151,5 +152,5 @@ func newBSChunkSource(ctx context.Context, bs blobstore.Blobstore, name addr, ch
 }
 
 func (bsp *blobstorePersister) PruneTableFiles(ctx context.Context, contents manifestContents) error {
-	return ErrUnsupportedOperation
+	return chunks.ErrUnsupportedOperation
 }

--- a/go/store/nbs/dynamo_fake_test.go
+++ b/go/store/nbs/dynamo_fake_test.go
@@ -148,7 +148,7 @@ func (m *fakeDDB) PutItemWithContext(ctx aws.Context, input *dynamodb.PutItemInp
 }
 
 func checkCondition(current record, expressionAttrVals map[string]*dynamodb.AttributeValue) bool {
-	return current.vers == *expressionAttrVals[":vers"].S && bytes.Equal(current.lock, expressionAttrVals[":prev"].B)
+	return current.vers == *expressionAttrVals[":nomsVers"].S && bytes.Equal(current.lock, expressionAttrVals[":prev"].B)
 }
 
 func (m *fakeDDB) NumGets() int64 {

--- a/go/store/nbs/dynamo_fake_test.go
+++ b/go/store/nbs/dynamo_fake_test.go
@@ -148,7 +148,7 @@ func (m *fakeDDB) PutItemWithContext(ctx aws.Context, input *dynamodb.PutItemInp
 }
 
 func checkCondition(current record, expressionAttrVals map[string]*dynamodb.AttributeValue) bool {
-	return current.vers == *expressionAttrVals[":nomsVers"].S && bytes.Equal(current.lock, expressionAttrVals[":prev"].B)
+	return current.vers == *expressionAttrVals[":vers"].S && bytes.Equal(current.lock, expressionAttrVals[":prev"].B)
 }
 
 func (m *fakeDDB) NumGets() int64 {

--- a/go/store/nbs/file_manifest.go
+++ b/go/store/nbs/file_manifest.go
@@ -101,10 +101,7 @@ func MaybeMigrateFileManifest(ctx context.Context, dir string) (bool, error) {
 	if err != nil {
 		return false, nil
 	}
-
-	// clear manifest cache
-	makeGlobalCaches()
-
+	
 	return true, err
 }
 

--- a/go/store/nbs/file_manifest.go
+++ b/go/store/nbs/file_manifest.go
@@ -101,7 +101,7 @@ func MaybeMigrateFileManifest(ctx context.Context, dir string) (bool, error) {
 	if err != nil {
 		return false, nil
 	}
-	
+
 	return true, err
 }
 

--- a/go/store/nbs/file_manifest.go
+++ b/go/store/nbs/file_manifest.go
@@ -54,7 +54,7 @@ type manifestChecker func(upstream, contents manifestContents) error
 
 // ParseManifest parses s a manifest file from the supplied reader
 func ParseManifest(r io.Reader) (ManifestInfo, error) {
-	fm5 := fileManifestv5{}
+	fm5 := fileManifestV5{}
 	return fm5.parseManifest(r)
 }
 
@@ -71,7 +71,7 @@ func MaybeMigrateFileManifest(ctx context.Context, dir string) (bool, error) {
 		err = f.Close()
 	}()
 
-	fm5 := fileManifestv5{dir}
+	fm5 := fileManifestV5{dir}
 	ok, _, err := fm5.ParseIfExists(ctx, &Stats{}, nil)
 	if ok && err == nil {
 		// on v5, no need to migrate
@@ -122,7 +122,7 @@ func getFileManifest(ctx context.Context, dir string) (manifest, error) {
 		err = f.Close()
 	}()
 
-	fm5 := fileManifestv5{dir}
+	fm5 := fileManifestV5{dir}
 	ok, _, err := fm5.ParseIfExists(ctx, &Stats{}, nil)
 	if ok && err == nil {
 		return fm5, nil
@@ -137,7 +137,7 @@ func getFileManifest(ctx context.Context, dir string) (manifest, error) {
 	return nil, fmt.Errorf("could not read file manifest")
 }
 
-// fileManifestv5 provides access to a NomsBlockStore manifest stored on disk in |dir|. The format
+// fileManifestV5 provides access to a NomsBlockStore manifest stored on disk in |dir|. The format
 // is currently human readable. The prefix contains 5 strings, followed by pairs of table file
 // hashes and their counts:
 //
@@ -146,7 +146,7 @@ func getFileManifest(ctx context.Context, dir string) (manifest, error) {
 //
 // |-- String --|- String --|...|-- String --|- String --|
 // :table 1 hash:table 1 cnt:...:table N hash:table N cnt|
-type fileManifestv5 struct {
+type fileManifestV5 struct {
 	dir string
 }
 
@@ -184,7 +184,7 @@ func openIfExists(path string) (*os.File, error) {
 	return f, err
 }
 
-func (fm5 fileManifestv5) Name() string {
+func (fm5 fileManifestV5) Name() string {
 	return fm5.dir
 }
 
@@ -194,7 +194,7 @@ func (fm5 fileManifestv5) Name() string {
 // that case, the other return values are undefined. If |readHook| is non-nil,
 // it will be executed while ParseIfExists() holds the manifest file lock.
 // This is to allow for race condition testing.
-func (fm5 fileManifestv5) ParseIfExists(ctx context.Context, stats *Stats, readHook func() error) (exists bool, contents manifestContents, err error) {
+func (fm5 fileManifestV5) ParseIfExists(ctx context.Context, stats *Stats, readHook func() error) (exists bool, contents manifestContents, err error) {
 	t1 := time.Now()
 	defer func() {
 		stats.ReadManifestLatency.SampleTimeSince(t1)
@@ -203,7 +203,7 @@ func (fm5 fileManifestv5) ParseIfExists(ctx context.Context, stats *Stats, readH
 	return parseIfExistsWithParser(ctx, fm5.dir, fm5.parseManifest, readHook)
 }
 
-func (fm5 fileManifestv5) Update(ctx context.Context, lastLock addr, newContents manifestContents, stats *Stats, writeHook func() error) (mc manifestContents, err error) {
+func (fm5 fileManifestV5) Update(ctx context.Context, lastLock addr, newContents manifestContents, stats *Stats, writeHook func() error) (mc manifestContents, err error) {
 	t1 := time.Now()
 	defer func() { stats.WriteManifestLatency.SampleTimeSince(t1) }()
 
@@ -217,7 +217,24 @@ func (fm5 fileManifestv5) Update(ctx context.Context, lastLock addr, newContents
 	return updateWithParseWriterAndChecker(ctx, fm5.dir, fm5.writeManifest, fm5.parseManifest, checker, lastLock, newContents, writeHook)
 }
 
-func (fm5 fileManifestv5) parseManifest(r io.Reader) (manifestContents, error) {
+func (fm5 fileManifestV5) UpdateGCGen(ctx context.Context, lastLock addr, newContents manifestContents, stats *Stats, writeHook func() error) (mc manifestContents, err error) {
+	t1 := time.Now()
+	defer func() { stats.WriteManifestLatency.SampleTimeSince(t1) }()
+
+	checker := func(upstream, contents manifestContents) error {
+		if contents.gcGen == upstream.gcGen {
+			return errors.New("UpdateGCGen() must update the garbage collection generation")
+		}
+		if contents.root != upstream.root {
+			return errors.New("UpdateGCGen() cannot update the root")
+		}
+		return nil
+	}
+
+	return updateWithParseWriterAndChecker(ctx, fm5.dir, fm5.writeManifest, fm5.parseManifest, checker, lastLock, newContents, writeHook)
+}
+
+func (fm5 fileManifestV5) parseManifest(r io.Reader) (manifestContents, error) {
 	manifest, err := ioutil.ReadAll(r)
 
 	if err != nil {
@@ -256,7 +273,7 @@ func (fm5 fileManifestv5) parseManifest(r io.Reader) (manifestContents, error) {
 	}, nil
 }
 
-func (fm5 fileManifestv5) writeManifest(temp io.Writer, contents manifestContents) error {
+func (fm5 fileManifestV5) writeManifest(temp io.Writer, contents manifestContents) error {
 	strs := make([]string, 2*len(contents.specs)+prefixLen)
 	strs[0], strs[1], strs[2], strs[3], strs[4] = StorageVersion, contents.vers, contents.lock.String(), contents.root.String(), contents.gcGen.String()
 	tableInfo := strs[prefixLen:]

--- a/go/store/nbs/file_manifest_test.go
+++ b/go/store/nbs/file_manifest_test.go
@@ -37,10 +37,10 @@ import (
 	"github.com/dolthub/dolt/go/store/hash"
 )
 
-func makeFileManifestTempDir(t *testing.T) fileManifestv5 {
+func makeFileManifestTempDir(t *testing.T) fileManifestV5 {
 	dir, err := ioutil.TempDir("", "")
 	assert.NoError(t, err)
-	return fileManifestv5{dir: dir} //, cache: newManifestCache(defaultManifestCacheSize)}
+	return fileManifestV5{dir: dir} //, cache: newManifestCache(defaultManifestCacheSize)}
 }
 
 func TestFileManifestLoadIfExists(t *testing.T) {
@@ -139,7 +139,7 @@ func TestFileManifestUpdateEmpty(t *testing.T) {
 	assert.True(upstream.root.IsEmpty())
 	assert.Empty(upstream.specs)
 
-	fm2 := fileManifestv5{fm.dir} // Open existent, but empty manifest
+	fm2 := fileManifestV5{fm.dir} // Open existent, but empty manifest
 	exists, upstream, err := fm2.ParseIfExists(context.Background(), stats, nil)
 	assert.NoError(err)
 	assert.True(exists)

--- a/go/store/nbs/file_table_persister.go
+++ b/go/store/nbs/file_table_persister.go
@@ -25,7 +25,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -39,27 +38,6 @@ import (
 )
 
 const tempTablePrefix = "nbs_table_"
-
-type gcErrAccum map[string]error
-
-var _ error = gcErrAccum{}
-
-func (ea gcErrAccum) add(path string, err error) {
-	ea[path] = err
-}
-
-func (ea gcErrAccum) isEmpty() bool {
-	return len(ea) == 0
-}
-
-func (ea gcErrAccum) Error() string {
-	var sb strings.Builder
-	sb.WriteString("error garbage collecting the following files:")
-	for filePath, err := range ea {
-		sb.WriteString(fmt.Sprintf("\t%s: %s", filePath, err.Error()))
-	}
-	return sb.String()
-}
 
 func newFSTablePersister(dir string, fc *fdCache, indexCache *indexCache) tablePersister {
 	d.PanicIfTrue(fc == nil)

--- a/go/store/nbs/gc_copier.go
+++ b/go/store/nbs/gc_copier.go
@@ -1,0 +1,108 @@
+// Copyright 2020 Liquidata, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nbs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/dolthub/dolt/go/store/util/tempfiles"
+)
+
+type gcErrAccum map[string]error
+
+var _ error = gcErrAccum{}
+
+func (ea gcErrAccum) add(path string, err error) {
+	ea[path] = err
+}
+
+func (ea gcErrAccum) isEmpty() bool {
+	return len(ea) == 0
+}
+
+func (ea gcErrAccum) Error() string {
+	var sb strings.Builder
+	sb.WriteString("error garbage collecting the following files:")
+	for filePath, err := range ea {
+		sb.WriteString(fmt.Sprintf("\t%s: %s", filePath, err.Error()))
+	}
+	return sb.String()
+}
+
+type gcCopier struct {
+	mt     *memTable
+	mtSize uint64
+
+	tables tableSet
+	ftp    *fsTablePersister
+	tmpDir string
+
+	stats *Stats
+}
+
+func newGarbageCollectionCopier(tableSize uint64) gcCopier {
+	// todo: minimize table index memory overhead
+	indexCache := newIndexCache(defaultIndexCacheSize)
+	// todo: are FD's valid after copy?
+	fdCache := newFDCache(defaultMaxTables)
+	tmpDir := tempfiles.MovableTempFileProvider.GetTempDir()
+	ftp := &fsTablePersister{tmpDir, fdCache, indexCache}
+
+	return gcCopier{
+		mtSize: tableSize,
+		tables: newTableSet(ftp),
+		ftp:    ftp,
+		tmpDir: tmpDir,
+		stats:  NewStats(),
+	}
+}
+
+func (gcc gcCopier) addChunk(ctx context.Context, h addr, data []byte) bool {
+	if gcc.mt == nil {
+		gcc.mt = newMemTable(gcc.mtSize)
+	}
+	if !gcc.mt.addChunk(h, data) {
+		gcc.tables = gcc.tables.Prepend(ctx, gcc.mt, gcc.stats)
+		gcc.mt = newMemTable(gcc.mtSize)
+		return gcc.mt.addChunk(h, data)
+	}
+	return true
+}
+
+func (gcc gcCopier) copyTablesToDir(destDir string) error {
+	specs, err := gcc.tables.ToSpecs()
+
+	if err != nil {
+		return err
+	}
+
+	for _, spec := range specs {
+		tmp := path.Join(gcc.tmpDir, spec.name.String())
+		dest := path.Join(destDir, spec.name.String())
+
+		// if copy does not complete, new files will be orphaned
+		err = os.Rename(tmp, dest)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/go/store/nbs/manifest.go
+++ b/go/store/nbs/manifest.go
@@ -87,7 +87,7 @@ type ManifestInfo interface {
 }
 
 type manifestContents struct {
-	vers  string // NBF version
+	vers  string
 	lock  addr
 	root  hash.Hash
 	gcGen addr

--- a/go/store/nbs/manifest_cache_test.go
+++ b/go/store/nbs/manifest_cache_test.go
@@ -91,7 +91,7 @@ func TestSizeCache(t *testing.T) {
 		lru++
 
 		// Putting a bigger value will dump multiple existing entries
-		err = c.Put("big", manifestContents{nomsVers: "big version"}, time.Now())
+		err = c.Put("big", manifestContents{vers: "big version"}, time.Now())
 		assert.NoError(err)
 		_, _, ok = c.Get(keys[lru])
 		assert.False(ok)

--- a/go/store/nbs/manifest_cache_test.go
+++ b/go/store/nbs/manifest_cache_test.go
@@ -91,7 +91,7 @@ func TestSizeCache(t *testing.T) {
 		lru++
 
 		// Putting a bigger value will dump multiple existing entries
-		err = c.Put("big", manifestContents{vers: "big version"}, time.Now())
+		err = c.Put("big", manifestContents{nomsVers: "big version"}, time.Now())
 		assert.NoError(err)
 		_, _, ok = c.Get(keys[lru])
 		assert.False(ok)

--- a/go/store/nbs/nbs_metrics_wrapper.go
+++ b/go/store/nbs/nbs_metrics_wrapper.go
@@ -17,10 +17,8 @@ package nbs
 import (
 	"context"
 	"io"
-	"sync"
 	"sync/atomic"
 
-	"github.com/dolthub/dolt/go/store/atomicerr"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
 )
@@ -67,7 +65,7 @@ func (nbsMW *NBSMetricWrapper) SupportedOperations() TableFileStoreOps {
 	return nbsMW.nbs.SupportedOperations()
 }
 
-func (nbsMW *NBSMetricWrapper) MarkAndSweepChunks(ctx context.Context, last hash.Hash, keepChunks <-chan hash.Hash) (*sync.WaitGroup, *atomicerr.AtomicError) {
+func (nbsMW *NBSMetricWrapper) MarkAndSweepChunks(ctx context.Context, last hash.Hash, keepChunks <-chan hash.Hash) error {
 	return nbsMW.nbs.MarkAndSweepChunks(ctx, last, keepChunks)
 }
 

--- a/go/store/nbs/nbs_metrics_wrapper.go
+++ b/go/store/nbs/nbs_metrics_wrapper.go
@@ -17,10 +17,11 @@ package nbs
 import (
 	"context"
 	"io"
+	"sync"
 	"sync/atomic"
 
+	"github.com/dolthub/dolt/go/store/atomicerr"
 	"github.com/dolthub/dolt/go/store/chunks"
-
 	"github.com/dolthub/dolt/go/store/hash"
 )
 
@@ -66,8 +67,8 @@ func (nbsMW *NBSMetricWrapper) SupportedOperations() TableFileStoreOps {
 	return nbsMW.nbs.SupportedOperations()
 }
 
-func (nbsMW *NBSMetricWrapper) MarkAndSweepChunks(ctx context.Context, last hash.Hash, keepChunks <-chan hash.Hash, errChan chan<- error) error {
-	return nbsMW.nbs.MarkAndSweepChunks(ctx, last, keepChunks, errChan)
+func (nbsMW *NBSMetricWrapper) MarkAndSweepChunks(ctx context.Context, last hash.Hash, keepChunks <-chan hash.Hash) (*sync.WaitGroup, *atomicerr.AtomicError) {
+	return nbsMW.nbs.MarkAndSweepChunks(ctx, last, keepChunks)
 }
 
 // PruneTableFiles deletes old table files that are no longer referenced in the manifest.

--- a/go/store/nbs/nbs_metrics_wrapper.go
+++ b/go/store/nbs/nbs_metrics_wrapper.go
@@ -40,6 +40,7 @@ func NewNBSMetricWrapper(nbs *NomsBlockStore) *NBSMetricWrapper {
 }
 
 var _ TableFileStore = &NBSMetricWrapper{}
+var _ chunks.ChunkStoreGarbageCollector = &NBSMetricWrapper{}
 
 // Sources retrieves the current root hash, and a list of all the table files
 func (nbsMW *NBSMetricWrapper) Sources(ctx context.Context) (hash.Hash, []TableFile, error) {
@@ -63,6 +64,10 @@ func (nbsMW *NBSMetricWrapper) SetRootChunk(ctx context.Context, root, previous 
 // Forwards SupportedOperations to wrapped block store.
 func (nbsMW *NBSMetricWrapper) SupportedOperations() TableFileStoreOps {
 	return nbsMW.nbs.SupportedOperations()
+}
+
+func (nbsMW *NBSMetricWrapper) MarkAndSweepChunks(ctx context.Context, last hash.Hash, keepChunks <-chan hash.Hash, errChan chan<- error) error {
+	return nbsMW.nbs.MarkAndSweepChunks(ctx, last, keepChunks, errChan)
 }
 
 // PruneTableFiles deletes old table files that are no longer referenced in the manifest.

--- a/go/store/nbs/root_tracker_test.go
+++ b/go/store/nbs/root_tracker_test.go
@@ -532,5 +532,5 @@ func (ftp fakeTablePersister) Open(ctx context.Context, name addr, chunkCount ui
 }
 
 func (ftp fakeTablePersister) PruneTableFiles(_ context.Context, _ manifestContents) error {
-	return ErrUnsupportedOperation
+	return chunks.ErrUnsupportedOperation
 }

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -1061,11 +1061,12 @@ func (nbs *NomsBlockStore) chunkSourcesByAddr() (map[addr]chunkSource, error) {
 }
 
 func (nbs *NomsBlockStore) SupportedOperations() TableFileStoreOps {
-	_, canwrite := nbs.p.(*fsTablePersister)
+	_, ok := nbs.p.(*fsTablePersister)
 	return TableFileStoreOps{
 		CanRead:  true,
-		CanWrite: canwrite,
-		CanPrune: canwrite,
+		CanWrite: ok,
+		CanPrune: ok,
+		CanGC:    ok,
 	}
 }
 
@@ -1154,6 +1155,127 @@ func (nbs *NomsBlockStore) PruneTableFiles(ctx context.Context) (err error) {
 	}
 
 	return nbs.p.PruneTableFiles(ctx, contents)
+}
+
+func (nbs *NomsBlockStore) MarkAndSweepChunks(ctx context.Context, last hash.Hash, keepChunks <-chan hash.Hash, errChan chan<- error) (err error) {
+	ops := nbs.SupportedOperations()
+	if !ops.CanGC || !ops.CanPrune {
+		return chunks.ErrUnsupportedOperation
+	}
+
+	if nbs.upstream.root != last {
+		return errLastRootMismatch
+	}
+
+	nbs.mu.RLock()
+	drainAndClose := func() {
+		defer nbs.mu.RUnlock()
+		defer close(errChan)
+
+		for range keepChunks {
+			// drain the channel
+		}
+
+		err := nbs.gcUnlock(ctx)
+
+		if err != nil {
+			errChan <- err
+		}
+	}
+
+	go func() {
+		defer drainAndClose()
+
+		err = nbs.copyMarkedChunks(ctx, keepChunks)
+
+		if err != nil {
+			errChan <- err
+			return
+		}
+
+		err = nbs.updateManifest(ctx, last, last)
+
+		if err != nil {
+			errChan <- err
+			return
+		}
+
+		err = nbs.PruneTableFiles(ctx)
+
+		if err != nil {
+			errChan <- err
+			return
+		}
+	}()
+
+	return nil
+}
+
+func (nbs *NomsBlockStore) gcLock(ctx context.Context) error {
+	return nil
+}
+
+func (nbs *NomsBlockStore) gcUnlock(ctx context.Context) error {
+	return nil
+}
+
+func (nbs *NomsBlockStore) copyMarkedChunks(ctx context.Context, keepChunks <-chan hash.Hash) error {
+	s, err := nbs.copyTableSize()
+
+	if err != nil {
+		return err
+	}
+
+	gcc := newGarbageCollectionCopier(s)
+
+	for h := range keepChunks {
+		// todo: batch calls to nbs.GetMany()
+		c, err := nbs.Get(ctx, h)
+
+		if err != nil {
+			return err
+		}
+
+		gcc.addChunk(ctx, addr(h), c.Data())
+	}
+
+	nomsDir := nbs.p.(*fsTablePersister).dir
+	err = gcc.copyTablesToDir(nomsDir)
+
+	if err != nil {
+		return err
+	}
+
+	old := nbs.tables
+
+	nbs.tables = gcc.tables
+	nbs.p = gcc.ftp
+	nbs.mt = gcc.mt
+
+	err = old.Close()
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// todo: what's the optimal table size to copy to?
+func (nbs *NomsBlockStore) copyTableSize() (uint64, error) {
+	total, err := nbs.tables.physicalLen()
+
+	if err != nil {
+		return 0, err
+	}
+
+	avgTableSize := total / uint64(nbs.tables.Upstream()+nbs.tables.Novel())
+
+	// max(avgTableSize, defaultMemTableSize)
+	if avgTableSize > nbs.mtSize {
+		return avgTableSize, nil
+	}
+	return nbs.mtSize, nil
 }
 
 // SetRootChunk changes the root chunk hash from the previous value to the new root.

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -1171,8 +1171,6 @@ func (nbs *NomsBlockStore) MarkAndSweepChunks(ctx context.Context, last hash.Has
 		return errLastRootMismatch
 	}
 
-	// todo: acquire manifest lock
-
 	nbs.mu.RLock()
 	drainAndClose := func() {
 		defer nbs.mu.RUnlock()
@@ -1180,12 +1178,6 @@ func (nbs *NomsBlockStore) MarkAndSweepChunks(ctx context.Context, last hash.Has
 
 		for range keepChunks {
 			// drain the channel
-		}
-
-		err := nbs.gcUnlock(ctx)
-
-		if err != nil {
-			errChan <- err
 		}
 	}
 
@@ -1226,16 +1218,8 @@ func (nbs *NomsBlockStore) MarkAndSweepChunks(ctx context.Context, last hash.Has
 	return nil
 }
 
-func (nbs *NomsBlockStore) gcLock(ctx context.Context) error {
-	return nil
-}
-
-func (nbs *NomsBlockStore) gcUnlock(ctx context.Context) error {
-	return nil
-}
-
 func (nbs *NomsBlockStore) copyMarkedChunks(ctx context.Context, keepChunks <-chan hash.Hash) ([]tableSpec, error) {
-	s, err := nbs.copyTableSize()
+	s, err := nbs.gcTableSize()
 
 	if err != nil {
 		return nil, err
@@ -1273,7 +1257,7 @@ func (nbs *NomsBlockStore) copyMarkedChunks(ctx context.Context, keepChunks <-ch
 }
 
 // todo: what's the optimal table size to copy to?
-func (nbs *NomsBlockStore) copyTableSize() (uint64, error) {
+func (nbs *NomsBlockStore) gcTableSize() (uint64, error) {
 	total, err := nbs.tables.physicalLen()
 
 	if err != nil {
@@ -1290,20 +1274,28 @@ func (nbs *NomsBlockStore) copyTableSize() (uint64, error) {
 }
 
 func (nbs *NomsBlockStore) swapTables(ctx context.Context, specs []tableSpec) error {
+	newLock := generateLockHash(nbs.upstream.root, specs)
 	newContents := manifestContents{
 		vers:  nbs.upstream.vers,
 		root:  nbs.upstream.root,
-		lock:  generateLockHash(nbs.upstream.root, specs),
+		lock:  newLock,
+		gcGen: newLock,
 		specs: specs,
 	}
 
-	// todo: lock outside of Update
-	upstream, err := nbs.mm.Update(ctx, nbs.upstream.lock, newContents, nbs.stats, nil)
+	var err error
+	nbs.mm.LockForUpdate()
+	defer func() {
+		unlockErr := nbs.mm.UnlockForUpdate()
+
+		if err == nil {
+			err = unlockErr
+		}
+	}()
+
+	upstream, err := nbs.mm.UpdateGCGen(ctx, nbs.upstream.lock, newContents, nbs.stats, nil)
 	if err != nil {
 		return err
-	}
-	if newContents.lock != upstream.lock {
-		panic("manifest was changed outside of the LOCK")
 	}
 
 	// clear memTable
@@ -1321,7 +1313,7 @@ func (nbs *NomsBlockStore) swapTables(ctx context.Context, specs []tableSpec) er
 	nbs.tables, err = nbs.tables.Rebase(ctx, specs, nbs.stats)
 
 	if err != nil {
-		return nil
+		return err
 	}
 
 	return nil

--- a/go/store/nbs/store_test.go
+++ b/go/store/nbs/store_test.go
@@ -202,6 +202,7 @@ func TestNBSPruneTableFiles(t *testing.T) {
 
 func makeChunkSet(N, size int) (s map[hash.Hash]chunks.Chunk) {
 	bb := make([]byte, size*N)
+	time.Sleep(10)
 	rand.Seed(time.Now().UnixNano())
 	rand.Read(bb)
 

--- a/go/store/nbs/store_test.go
+++ b/go/store/nbs/store_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/dolthub/dolt/go/store/util/tempfiles"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -33,14 +34,16 @@ import (
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/types"
-	"github.com/dolthub/dolt/go/store/util/tempfiles"
 )
 
 func makeTestLocalStore(t *testing.T, maxTableFiles int) (st *NomsBlockStore, nomsDir string) {
 	ctx := context.Background()
 	nomsDir = filepath.Join(tempfiles.MovableTempFileProvider.GetTempDir(), "noms_"+uuid.New().String()[:8])
-
 	err := os.MkdirAll(nomsDir, os.ModePerm)
+	require.NoError(t, err)
+
+	// create a v5 manifest
+	_, err = fileManifestV5{nomsDir}.Update(ctx, addr{}, manifestContents{}, &Stats{}, nil)
 	require.NoError(t, err)
 
 	st, err = newLocalStore(ctx, types.Format_Default.VersionString(), nomsDir, defaultMemTableSize, maxTableFiles)

--- a/go/store/nbs/store_test.go
+++ b/go/store/nbs/store_test.go
@@ -19,22 +19,26 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/dolt/go/libraries/utils/set"
+	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/types"
 	"github.com/dolthub/dolt/go/store/util/tempfiles"
 )
 
 func makeTestLocalStore(t *testing.T, maxTableFiles int) (st *NomsBlockStore, nomsDir string) {
 	ctx := context.Background()
-	nomsDir = filepath.Join(tempfiles.MovableTempFileProvider.GetTempDir(), uuid.New().String())
+	nomsDir = filepath.Join(tempfiles.MovableTempFileProvider.GetTempDir(), "noms_"+uuid.New().String()[:8])
 
 	err := os.MkdirAll(nomsDir, os.ModePerm)
 	require.NoError(t, err)
@@ -191,4 +195,84 @@ func TestNBSPruneTableFiles(t *testing.T) {
 	size, err := st.Size(ctx)
 	require.NoError(t, err)
 	require.Greater(t, size, uint64(0))
+}
+
+func makeChunkSet(N, size int) (s map[hash.Hash]chunks.Chunk) {
+	bb := make([]byte, size*N)
+	rand.Seed(time.Now().UnixNano())
+	rand.Read(bb)
+
+	s = make(map[hash.Hash]chunks.Chunk, N)
+	offset := 0
+	for i := 0; i < N; i++ {
+		c := chunks.NewChunk(bb[offset : offset+size])
+		s[c.Hash()] = c
+		offset += size
+	}
+
+	return
+}
+
+func TestNBSCopyGC(t *testing.T) {
+	ctx := context.Background()
+	st, _ := makeTestLocalStore(t, 8)
+
+	keepers := makeChunkSet(64, 64)
+	tossers := makeChunkSet(64, 64)
+
+	for _, c := range keepers {
+		err := st.Put(ctx, c)
+		assert.NoError(t, err)
+	}
+	for h, c := range keepers {
+		out, err := st.Get(ctx, h)
+		assert.NoError(t, err)
+		assert.Equal(t, c, out)
+	}
+
+	for h := range tossers {
+		// assert mutually exclusive chunk sets
+		c, ok := keepers[h]
+		require.False(t, ok)
+		assert.Equal(t, chunks.Chunk{}, c)
+	}
+	for _, c := range tossers {
+		err := st.Put(ctx, c)
+		assert.NoError(t, err)
+	}
+	for h, c := range tossers {
+		out, err := st.Get(ctx, h)
+		assert.NoError(t, err)
+		assert.Equal(t, c, out)
+	}
+
+	r, err := st.Root(ctx)
+	assert.NoError(t, err)
+
+	errChan := make(chan error)
+	keepChan := make(chan hash.Hash, 16)
+	err = st.MarkAndSweepChunks(ctx, r, keepChan, errChan)
+	require.NoError(t, err)
+
+	for h := range keepers {
+		keepChan <- h
+	}
+	close(keepChan)
+
+	select {
+	case err, ok := <-errChan:
+		assert.False(t, ok)
+		assert.Nil(t, err)
+	}
+
+	for h, c := range keepers {
+		out, err := st.Get(ctx, h)
+		require.NoError(t, err)
+		assert.Equal(t, c, out)
+	}
+	for h := range tossers {
+		out, err := st.Get(ctx, h)
+		require.NoError(t, err)
+		assert.Equal(t, chunks.EmptyChunk, out)
+	}
 }

--- a/go/store/nbs/store_test.go
+++ b/go/store/nbs/store_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/dolthub/dolt/go/store/util/tempfiles"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -34,6 +33,7 @@ import (
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/types"
+	"github.com/dolthub/dolt/go/store/util/tempfiles"
 )
 
 func makeTestLocalStore(t *testing.T, maxTableFiles int) (st *NomsBlockStore, nomsDir string) {

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -27,7 +27,6 @@ import (
 	"crypto/sha512"
 	"encoding/base32"
 	"encoding/binary"
-	"errors"
 	"hash/crc32"
 	"io"
 	"sync"
@@ -291,8 +290,6 @@ type TableFile interface {
 	Open(ctx context.Context) (io.ReadCloser, error)
 }
 
-var ErrUnsupportedOperation = errors.New("operation not supported")
-
 // Describes what is possible to do with TableFiles in a TableFileStore.
 type TableFileStoreOps struct {
 	// True is the TableFileStore supports reading table files.
@@ -301,6 +298,8 @@ type TableFileStoreOps struct {
 	CanWrite bool
 	// True is the TableFileStore supports pruning unused table files.
 	CanPrune bool
+	// True is the TableFileStore supports garbage collecting chunks.
+	CanGC bool
 }
 
 // TableFileStore is an interface for interacting with table files directly

--- a/go/store/types/value_store.go
+++ b/go/store/types/value_store.go
@@ -599,6 +599,7 @@ func (lvs *ValueStore) GC(ctx context.Context) error {
 			return err
 		}
 		hashQueue := list.New()
+		visited := hash.NewHashSet(root)
 		hashQueue.PushBack(root)
 		for hashQueue.Len() > 0 {
 			e := hashQueue.Front()
@@ -615,11 +616,15 @@ func (lvs *ValueStore) GC(ctx context.Context) error {
 
 			err = val.WalkRefs(lvs.nbf, func(reachable Ref) error {
 				h := reachable.TargetHash()
+				if visited.Has(h) {
+					return nil
+				}
 				err := sendHash(h)
 				if err != nil {
 					return err
 				}
 				hashQueue.PushBack(h)
+				visited.Insert(h)
 				return nil
 			})
 			if err != nil {

--- a/go/store/util/sizecache/size_cache.go
+++ b/go/store/util/sizecache/size_cache.go
@@ -139,3 +139,7 @@ func (c *SizeCache) Drop(key interface{}) {
 		delete(c.cache, key)
 	}
 }
+
+func (c *SizeCache) Size() uint64 {
+	return c.maxSize
+}


### PR DESCRIPTION
Implements garbage collection by traversing a `Database` from its root chunk and coping all reachable chunks to a new set of NBS tables.

While "garbage collection generation" will protect the NBS from corruption by out-of-process writers, GC is not currently thread safe for concurrent use in-process. Getting to online GC will require work around protecting in-progress writes that are not yet reachable from the root chunk.