### PR TITLE
/go/libraries/doltcore/diff: Ignore NULLs in cell-wise diff

### DIFF
--- a/go/libraries/doltcore/diff/diff_summary.go
+++ b/go/libraries/doltcore/diff/diff_summary.go
@@ -19,6 +19,8 @@ import (
 	"errors"
 	"time"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/row"
+
 	"github.com/dolthub/dolt/go/store/diff"
 	"github.com/dolthub/dolt/go/store/types"
 )
@@ -64,7 +66,7 @@ func reportChanges(change *diff.Difference, ch chan<- DiffSummaryProgress) error
 	case types.DiffChangeModified:
 		oldTuple := change.OldValue.(types.Tuple)
 		newTuple := change.NewValue.(types.Tuple)
-		cellChanges, err := oldTuple.CountDifferencesBetweenTupleFields(newTuple)
+		cellChanges, err := row.CountCellDiffs(oldTuple, newTuple)
 		if err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/row/tagged_values.go
+++ b/go/libraries/doltcore/row/tagged_values.go
@@ -199,3 +199,30 @@ func (tt TaggedValues) String() string {
 	str += "\n}"
 	return str
 }
+
+// CountCellDiffs returns the number of fields that are different between two
+// tuples and does not panic if tuples are different lengths.
+func CountCellDiffs(from, to types.Tuple) (uint64, error) {
+	changed := 0
+	f, err := ParseTaggedValues(from)
+	t, err := ParseTaggedValues(to)
+
+	if err != nil {
+		return 0, err
+	}
+
+	for i, v := range f {
+		ov, ok := t[i]
+		if !ok || !v.Equals(ov) {
+			changed++
+		}
+	}
+
+	for i := range t {
+		if f[i] == nil {
+			changed++
+		}
+	}
+
+	return uint64(changed), nil
+}

--- a/go/store/types/tuple.go
+++ b/go/store/types/tuple.go
@@ -578,7 +578,9 @@ func (t Tuple) fieldsToMap() (map[Value]Value, error) {
 			if err != nil {
 				return true, err
 			}
-			valMap[val] = value
+			if value.Kind() != NullKind {
+				valMap[val] = value
+			}
 		}
 
 		return false, nil

--- a/go/store/types/tuple.go
+++ b/go/store/types/tuple.go
@@ -542,57 +542,6 @@ func (t Tuple) Less(nbf *NomsBinFormat, other LesserValuable) (bool, error) {
 	return TupleKind < other.Kind(), nil
 }
 
-// CountDifferencesBetweenTupleFields returns the number of fields that are different between two
-// tuples and does not panic if tuples are different lengths.
-func (t Tuple) CountDifferencesBetweenTupleFields(other Tuple) (uint64, error) {
-	changed := 0
-	tMap, err := t.fieldsToMap()
-	otherMap, err := other.fieldsToMap()
-
-	if err != nil {
-		return 0, err
-	}
-
-	for i, v := range tMap {
-		ov, ok := otherMap[i]
-		if !ok || !v.Equals(ov) {
-			changed++
-		}
-	}
-
-	for i := range otherMap {
-		if tMap[i] == nil {
-			changed++
-		}
-	}
-
-	return uint64(changed), nil
-}
-
-func (t Tuple) fieldsToMap() (map[Value]Value, error) {
-	valMap := make(map[Value]Value)
-
-	err := t.IterFields(func(index uint64, val Value) (stop bool, err error) {
-		if index%2 == 0 {
-			value, err := t.Get(index + 1)
-			if err != nil {
-				return true, err
-			}
-			if value.Kind() != NullKind {
-				valMap[val] = value
-			}
-		}
-
-		return false, nil
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return valMap, nil
-}
-
 func (t Tuple) StartsWith(otherTuple Tuple) bool {
 	tplDec, _ := t.decoderSkipToFields()
 	otherDec, _ := otherTuple.decoderSkipToFields()


### PR DESCRIPTION
fix for https://github.com/dolthub/dolt/issues/899

The from root in this repo has NULL values written to the map which causes erroneous diffs.
https://www.dolthub.com/repositories/dolthub/us-supreme-court-cases/compare/master/hb502v6tf3uj43ijfhot6dopmgdm1muk