### PR TITLE
Add go routine to clone

### DIFF
--- a/go/cmd/dolt/commands/clone.go
+++ b/go/cmd/dolt/commands/clone.go
@@ -285,7 +285,6 @@ func cloneRemote(ctx context.Context, srcDB *doltdb.DoltDB, remoteName, branch s
 	}()
 
 	err := actions.Clone(ctx, srcDB, dEnv.DoltDB, eventCh)
-
 	close(eventCh)
 	wg.Wait()
 

--- a/go/cmd/dolt/commands/clone.go
+++ b/go/cmd/dolt/commands/clone.go
@@ -247,6 +247,7 @@ func cloneProg(eventCh <-chan datas.TableFileEvent) {
 		chunksDownloaded  int64
 		cliPos            int
 	)
+
 	cliPos = cli.DeleteAndPrint(cliPos, "Retrieving remote information.")
 	for tblFEvt := range eventCh {
 		switch tblFEvt.EventType {
@@ -286,6 +287,7 @@ func cloneRemote(ctx context.Context, srcDB *doltdb.DoltDB, remoteName, branch s
 
 	err := actions.Clone(ctx, srcDB, dEnv.DoltDB, eventCh)
 	close(eventCh)
+
 	wg.Wait()
 
 	if err != nil {

--- a/go/cmd/dolt/commands/clone.go
+++ b/go/cmd/dolt/commands/clone.go
@@ -247,7 +247,6 @@ func cloneProg(eventCh <-chan datas.TableFileEvent) {
 		chunksDownloaded  int64
 		cliPos            int
 	)
-
 	cliPos = cli.DeleteAndPrint(cliPos, "Retrieving remote information.")
 	for tblFEvt := range eventCh {
 		switch tblFEvt.EventType {
@@ -286,8 +285,8 @@ func cloneRemote(ctx context.Context, srcDB *doltdb.DoltDB, remoteName, branch s
 	}()
 
 	err := actions.Clone(ctx, srcDB, dEnv.DoltDB, eventCh)
-	close(eventCh)
 
+	close(eventCh)
 	wg.Wait()
 
 	if err != nil {

--- a/go/go.mod
+++ b/go/go.mod
@@ -80,7 +80,7 @@ require (
 	go.uber.org/zap v1.15.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20200904194848-62affa334b73
-	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
+	golang.org/x/sync v0.0.0-20201008141435-b3e1573b7520
 	golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f
 	google.golang.org/api v0.32.0
 	google.golang.org/grpc v1.32.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -806,6 +806,8 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a h1:WXEvlFVvvGxCJLG6REjsT03i
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201008141435-b3e1573b7520 h1:Bx6FllMpG4NWDOfhMBz1VR2QYNp/SAOHPIAsaVmxfPo=
+golang.org/x/sync v0.0.0-20201008141435-b3e1573b7520/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/go/store/datas/pull.go
+++ b/go/store/datas/pull.go
@@ -29,15 +29,15 @@ import (
 	"math"
 	"math/rand"
 
+	"github.com/cenkalti/backoff"
+	"github.com/golang/snappy"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/cenkalti/backoff"
 	"github.com/dolthub/dolt/go/store/atomicerr"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/nbs"
 	"github.com/dolthub/dolt/go/store/types"
-	"github.com/golang/snappy"
 )
 
 type PullProgress struct {

--- a/go/store/datas/pull.go
+++ b/go/store/datas/pull.go
@@ -121,7 +121,6 @@ func mapTableFiles(tblFiles []nbs.TableFile) ([]string, map[string]nbs.TableFile
 }
 
 func clone(ctx context.Context, srcTS, sinkTS nbs.TableFileStore, eventCh chan<- TableFileEvent) error {
-	//cli.DeleteAndPrint(0, "HEREEEE\n")
 	root, tblFiles, err := srcTS.Sources(ctx)
 
 	if err != nil {

--- a/go/store/datas/pull.go
+++ b/go/store/datas/pull.go
@@ -32,13 +32,12 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/cenkalti/backoff"
-	"github.com/golang/snappy"
-
 	"github.com/dolthub/dolt/go/store/atomicerr"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/nbs"
 	"github.com/dolthub/dolt/go/store/types"
+	"github.com/golang/snappy"
 )
 
 type PullProgress struct {


### PR DESCRIPTION
I parallelized the table file writing process by using go routines. Specifically, I made use of the "golang.org/x/sync/errgroup" package which allows for convenient error management across a waitgroup.

A couple of benchmarks I tested this on were 

1. Dolt-benchmarks-test: No difference in speed really
2. Coronavirus: Original ~30sec. Current 15sec
3. Tatoeba Sentence Translation: Original: ~17mins Current: 10mins