### PR TITLE
Memory fix for CREATE INDEX & Race Detection

### DIFF
--- a/.github/workflows/ci-race-detector.yaml
+++ b/.github/workflows/ci-race-detector.yaml
@@ -1,0 +1,24 @@
+name: Race Detection
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    name: Test race conditions
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+      id: go
+    - uses: actions/checkout@v2
+    - name: Test All
+      working-directory: ./go
+      run: go test -race ./...


### PR DESCRIPTION
Used a pre-existing 16 million row repo to test `CREATE INDEX` memory usage on.

Before:
72.47GB RAM Usage
18min 48sec

After:
1.88GB RAM Usage
2min 2sec

Copied the same strategy as used in `table_editor.go` to periodically flush the contents once some arbitrary amount of operations have been performed. I also decided to throw in the race detector tests into our GitHub Actions so that we don't have to worry about any regressions or potential race conditions (caught by testing) going forward. I can remove them if desired.