### PR TITLE
Extract some import logic to be used in dolthubapi

### DIFF
--- a/bats/import-create-tables.bats
+++ b/bats/import-create-tables.bats
@@ -152,9 +152,9 @@ DELIM
 
 @test "try to table import with nonexistant --pk arg" {
     run dolt table import -c -pk="batmansparents" test 1pk5col-ints.csv
-    [ "$status" -ne 1 ]
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Error determining the output schema." ]] || false
     skip "--pk args is not validated to be an existing column"
-    [[ ! "$output" =~ "panic" ]] || false
     [[ "$output" =~ "column 'batmansparents' not found" ]] || false
 }
 

--- a/go/cmd/dolt/cli/arg_helpers_test.go
+++ b/go/cmd/dolt/cli/arg_helpers_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/store/types"
+	"github.com/stretchr/testify/require"
 )
 
 func mustValue(v types.Value, err error) types.Value {
@@ -57,13 +58,15 @@ func TestParseKeyValues(t *testing.T) {
 		schema.NewColumn(mnColName, mnColTag, types.StringKind, true),
 	)
 
-	sch := schema.SchemaFromCols(testKeyColColl)
+	sch, err := schema.SchemaFromCols(testKeyColColl)
+	require.NoError(t, err)
 
 	singleKeyColColl, _ := schema.NewColCollection(
 		schema.NewColumn(lnColName, lnColTag, types.StringKind, true),
 	)
 
-	singleKeySch := schema.SchemaFromCols(singleKeyColColl)
+	singleKeySch, err := schema.SchemaFromCols(singleKeyColColl)
+	require.NoError(t, err)
 
 	tests := []struct {
 		sch          schema.Schema

--- a/go/cmd/dolt/cli/arg_helpers_test.go
+++ b/go/cmd/dolt/cli/arg_helpers_test.go
@@ -18,10 +18,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/store/types"
-	"github.com/stretchr/testify/require"
 )
 
 func mustValue(v types.Value, err error) types.Value {

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -620,7 +620,7 @@ func dumbDownSchema(in schema.Schema) (schema.Schema, error) {
 
 	dumbColColl, _ := schema.NewColCollection(dumbCols...)
 
-	return schema.SchemaFromCols(dumbColColl), nil
+	return schema.SchemaFromCols(dumbColColl)
 }
 
 func toNamer(name string) string {

--- a/go/cmd/dolt/commands/query_diff.go
+++ b/go/cmd/dolt/commands/query_diff.go
@@ -79,7 +79,11 @@ func doltSchWithPKFromSqlSchema(sch sql.Schema) schema.Schema {
 		}
 		return col, nil
 	})
-	return schema.SchemaFromCols(newCC)
+	s, err := schema.SchemaFromCols(newCC)
+	if err != nil {
+		panic(err)
+	}
+	return s
 }
 
 func nextQueryDiff(qd *querydiff.QueryDiffer, joiner *rowconv.Joiner) (row.Row, pipeline.ImmutableProperties, error) {

--- a/go/cmd/dolt/commands/query_diff.go
+++ b/go/cmd/dolt/commands/query_diff.go
@@ -79,11 +79,7 @@ func doltSchWithPKFromSqlSchema(sch sql.Schema) schema.Schema {
 		}
 		return col, nil
 	})
-	s, err := schema.SchemaFromCols(newCC)
-	if err != nil {
-		panic(err)
-	}
-	return s
+	return schema.MustSchemaFromCols(newCC)
 }
 
 func nextQueryDiff(qd *querydiff.QueryDiffer, joiner *rowconv.Joiner) (row.Row, pipeline.ImmutableProperties, error) {

--- a/go/cmd/dolt/commands/schcmds/import.go
+++ b/go/cmd/dolt/commands/schcmds/import.go
@@ -418,8 +418,11 @@ func CombineColCollections(ctx context.Context, root *doltdb.RootValue, inferred
 	if err != nil {
 		return nil, errhand.BuildDError("failed to generate new schema").AddCause(err).Build()
 	}
-
-	return schema.SchemaFromCols(combined), nil
+	sch, err := schema.SchemaFromCols(combined)
+	if err != nil {
+		return nil, errhand.BuildDError("failed to get schema from cols").AddCause(err).Build()
+	}
+	return sch, nil
 }
 
 func columnsForSchemaCreate(inferredCols *schema.ColCollection, pkNames []string) (newCols *schema.ColCollection) {

--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -30,7 +30,6 @@ import (
 	eventsapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
-	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/mvdata"
 	"github.com/dolthub/dolt/go/libraries/doltcore/rowconv"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
@@ -40,7 +39,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/libraries/utils/funcitr"
 	"github.com/dolthub/dolt/go/libraries/utils/iohelp"
-	"github.com/dolthub/dolt/go/libraries/utils/set"
 	"github.com/dolthub/dolt/go/store/types"
 )
 
@@ -481,7 +479,6 @@ func newImportDataMover(ctx context.Context, root *doltdb.RootValue, fs filesys.
 }
 
 func getImportSchema(ctx context.Context, root *doltdb.RootValue, fs filesys.Filesys, impOpts *importOptions) (schema.Schema, *mvdata.DataMoverCreationError) {
-
 	if impOpts.schFile != "" {
 		tn, out, err := mvdata.SchAndTableNameFromFile(ctx, impOpts.schFile, fs, root)
 
@@ -512,7 +509,7 @@ func getImportSchema(ctx context.Context, root *doltdb.RootValue, fs filesys.Fil
 			return rd.GetSchema(), nil
 		}
 
-		outSch, err := inferSchema(ctx, root, rd, impOpts)
+		outSch, err := mvdata.InferSchema(ctx, root, rd, impOpts.tableName, impOpts.primaryKeys, impOpts)
 
 		if err != nil {
 			return nil, &mvdata.DataMoverCreationError{ErrType: mvdata.SchemaErr, Cause: err}
@@ -529,34 +526,6 @@ func getImportSchema(ctx context.Context, root *doltdb.RootValue, fs filesys.Fil
 	defer tblRd.Close(ctx)
 
 	return tblRd.GetSchema(), nil
-}
-
-func inferSchema(ctx context.Context, root *doltdb.RootValue, rd table.TableReadCloser, impOpts *importOptions) (schema.Schema, error) {
-	var err error
-
-	pks := impOpts.primaryKeys
-	if len(pks) == 0 {
-		pks = rd.GetSchema().GetPKCols().GetColumnNames()
-	}
-
-	infCols, err := actions.InferColumnTypesFromTableReader(ctx, root, rd, impOpts)
-
-	if err != nil {
-		return nil, err
-	}
-
-	pkSet := set.NewStrSet(pks)
-	newCols, _ := schema.MapColCollection(infCols, func(col schema.Column) (schema.Column, error) {
-		col.IsPartOfPK = pkSet.Contains(col.Name)
-		return col, nil
-	})
-
-	newCols, err = root.GenerateTagsForNewColColl(ctx, impOpts.tableName, newCols)
-	if err != nil {
-		return nil, errhand.BuildDError("failed to generate new schema").AddCause(err).Build()
-	}
-
-	return schema.SchemaFromCols(newCols), nil
 }
 
 func newDataMoverErrToVerr(mvOpts *importOptions, err *mvdata.DataMoverCreationError) errhand.VerboseError {

--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -366,6 +366,7 @@ func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string,
 	mover, nDMErr := newImportDataMover(ctx, root, dEnv.FS, mvOpts, importStatsCB)
 
 	if nDMErr != nil {
+
 		verr = newDataMoverErrToVerr(mvOpts, nDMErr)
 		return commands.HandleVErrAndExitCode(verr, usage)
 	}
@@ -420,13 +421,11 @@ func newImportDataMover(ctx context.Context, root *doltdb.RootValue, fs filesys.
 	}
 
 	wrSch, dmce := getImportSchema(ctx, root, fs, impOpts)
-
 	if dmce != nil {
 		return nil, dmce
 	}
 
 	rd, srcIsSorted, err := impOpts.src.NewReader(ctx, root, fs, impOpts.srcOptions)
-
 	if err != nil {
 		return nil, &mvdata.DataMoverCreationError{ErrType: mvdata.CreateReaderErr, Cause: err}
 	}
@@ -510,7 +509,6 @@ func getImportSchema(ctx context.Context, root *doltdb.RootValue, fs filesys.Fil
 		}
 
 		outSch, err := mvdata.InferSchema(ctx, root, rd, impOpts.tableName, impOpts.primaryKeys, impOpts)
-
 		if err != nil {
 			return nil, &mvdata.DataMoverCreationError{ErrType: mvdata.SchemaErr, Cause: err}
 		}

--- a/go/libraries/doltcore/diff/schema_diff_test.go
+++ b/go/libraries/doltcore/diff/schema_diff_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/store/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDiffSchemas(t *testing.T) {
@@ -44,8 +45,10 @@ func TestDiffSchemas(t *testing.T) {
 	oldColColl, _ := schema.NewColCollection(oldCols...)
 	newColColl, _ := schema.NewColCollection(newCols...)
 
-	oldSch := schema.SchemaFromCols(oldColColl)
-	newSch := schema.SchemaFromCols(newColColl)
+	oldSch, err := schema.SchemaFromCols(oldColColl)
+	require.NoError(t, err)
+	newSch, err := schema.SchemaFromCols(newColColl)
+	require.NoError(t, err)
 	diffs, _ := DiffSchColumns(oldSch, newSch)
 
 	expected := map[uint64]ColumnDifference{

--- a/go/libraries/doltcore/diff/schema_diff_test.go
+++ b/go/libraries/doltcore/diff/schema_diff_test.go
@@ -18,9 +18,10 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/store/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestDiffSchemas(t *testing.T) {

--- a/go/libraries/doltcore/doltdb/doltdb_test.go
+++ b/go/libraries/doltcore/doltdb/doltdb_test.go
@@ -52,8 +52,9 @@ func createTestSchema(t *testing.T) schema.Schema {
 		schema.NewColumn("age", ageTag, types.UintKind, false),
 		schema.NewColumn("empty", emptyTag, types.IntKind, false),
 	)
-	sch := schema.SchemaFromCols(colColl)
-	_, err := sch.Indexes().AddIndexByColTags(testSchemaIndexName, []uint64{firstTag, lastTag}, schema.IndexProperties{IsUnique: false, Comment: ""})
+	sch, err := schema.SchemaFromCols(colColl)
+	require.NoError(t, err)
+	_, err = sch.Indexes().AddIndexByColTags(testSchemaIndexName, []uint64{firstTag, lastTag}, schema.IndexProperties{IsUnique: false, Comment: ""})
 	require.NoError(t, err)
 	_, err = sch.Indexes().AddIndexByColTags(testSchemaIndexAge, []uint64{ageTag}, schema.IndexProperties{IsUnique: false, Comment: ""})
 	require.NoError(t, err)

--- a/go/libraries/doltcore/doltdb/index_editor_test.go
+++ b/go/libraries/doltcore/doltdb/index_editor_test.go
@@ -43,7 +43,8 @@ func TestIndexEditorConcurrency(t *testing.T) {
 		schema.NewColumn("v1", 1, types.IntKind, false),
 		schema.NewColumn("v2", 2, types.IntKind, false))
 	require.NoError(t, err)
-	tableSch := schema.SchemaFromCols(colColl)
+	tableSch, err := schema.SchemaFromCols(colColl)
+	require.NoError(t, err)
 	index, err := tableSch.Indexes().AddIndexByColNames("idx_concurrency", []string{"v1"}, schema.IndexProperties{IsUnique: false, Comment: ""})
 	require.NoError(t, err)
 	indexSch := index.Schema()
@@ -130,7 +131,8 @@ func TestIndexEditorConcurrencyPostInsert(t *testing.T) {
 		schema.NewColumn("v1", 1, types.IntKind, false),
 		schema.NewColumn("v2", 2, types.IntKind, false))
 	require.NoError(t, err)
-	tableSch := schema.SchemaFromCols(colColl)
+	tableSch, err := schema.SchemaFromCols(colColl)
+	require.NoError(t, err)
 	index, err := tableSch.Indexes().AddIndexByColNames("idx_concurrency", []string{"v1"}, schema.IndexProperties{IsUnique: false, Comment: ""})
 	require.NoError(t, err)
 	indexSch := index.Schema()
@@ -214,7 +216,8 @@ func TestIndexEditorConcurrencyUnique(t *testing.T) {
 		schema.NewColumn("v1", 1, types.IntKind, false),
 		schema.NewColumn("v2", 2, types.IntKind, false))
 	require.NoError(t, err)
-	tableSch := schema.SchemaFromCols(colColl)
+	tableSch, err := schema.SchemaFromCols(colColl)
+	require.NoError(t, err)
 	index, err := tableSch.Indexes().AddIndexByColNames("idx_concurrency", []string{"v1"}, schema.IndexProperties{IsUnique: true, Comment: ""})
 	require.NoError(t, err)
 	indexSch := index.Schema()
@@ -300,7 +303,8 @@ func TestIndexEditorUniqueMultipleNil(t *testing.T) {
 		schema.NewColumn("pk", 0, types.IntKind, true),
 		schema.NewColumn("v1", 1, types.IntKind, false))
 	require.NoError(t, err)
-	tableSch := schema.SchemaFromCols(colColl)
+	tableSch, err := schema.SchemaFromCols(colColl)
+	require.NoError(t, err)
 	index, err := tableSch.Indexes().AddIndexByColNames("idx_unique", []string{"v1"}, schema.IndexProperties{IsUnique: true, Comment: ""})
 	require.NoError(t, err)
 	indexSch := index.Schema()
@@ -343,7 +347,8 @@ func TestIndexEditorWriteAfterFlush(t *testing.T) {
 		schema.NewColumn("v1", 1, types.IntKind, false),
 		schema.NewColumn("v2", 2, types.IntKind, false))
 	require.NoError(t, err)
-	tableSch := schema.SchemaFromCols(colColl)
+	tableSch, err := schema.SchemaFromCols(colColl)
+	require.NoError(t, err)
 	index, err := tableSch.Indexes().AddIndexByColNames("idx_concurrency", []string{"v1"}, schema.IndexProperties{IsUnique: false, Comment: ""})
 	require.NoError(t, err)
 	indexSch := index.Schema()

--- a/go/libraries/doltcore/doltdb/root_val_test.go
+++ b/go/libraries/doltcore/doltdb/root_val_test.go
@@ -89,7 +89,9 @@ func TestTableDiff(t *testing.T) {
 	cc, _ := schema.NewColCollection(
 		schema.NewColumn("id", uint64(100), types.UUIDKind, true, schema.NotNullConstraint{}),
 	)
-	tbl2, err := createTestTable(ddb.ValueReadWriter(), schema.SchemaFromCols(cc), m)
+	tableSch, err := schema.SchemaFromCols(cc)
+	assert.NoError(t, err)
+	tbl2, err := createTestTable(ddb.ValueReadWriter(), tableSch, m)
 	assert.NoError(t, err)
 
 	root4, err := root3.PutTable(ctx, "tbl2", tbl2)
@@ -308,7 +310,11 @@ func createTestDocsSchema() schema.Schema {
 		schema.NewColumn(DocPkColumnName, DocNameTag, types.StringKind, true, schema.NotNullConstraint{}),
 		schema.NewColumn(DocTextColumnName, DocTextTag, types.StringKind, false),
 	)
-	return schema.SchemaFromCols(typedColColl)
+	sch, err := schema.SchemaFromCols(typedColColl)
+	if err != nil {
+		panic(err)
+	}
+	return sch
 }
 
 func getDocRows(t *testing.T, sch schema.Schema, rowVal types.Value) []row.Row {

--- a/go/libraries/doltcore/doltdb/table_editor_test.go
+++ b/go/libraries/doltcore/doltdb/table_editor_test.go
@@ -44,7 +44,8 @@ func TestTableEditorConcurrency(t *testing.T) {
 		schema.NewColumn("v1", 1, types.IntKind, false),
 		schema.NewColumn("v2", 2, types.IntKind, false))
 	require.NoError(t, err)
-	tableSch := schema.SchemaFromCols(colColl)
+	tableSch, err := schema.SchemaFromCols(colColl)
+	require.NoError(t, err)
 	tableSchVal, err := encoding.MarshalSchemaAsNomsValue(context.Background(), db, tableSch)
 	require.NoError(t, err)
 	emptyMap, err := types.NewMap(context.Background(), db)
@@ -140,7 +141,8 @@ func TestTableEditorConcurrencyPostInsert(t *testing.T) {
 		schema.NewColumn("v1", 1, types.IntKind, false),
 		schema.NewColumn("v2", 2, types.IntKind, false))
 	require.NoError(t, err)
-	tableSch := schema.SchemaFromCols(colColl)
+	tableSch, err := schema.SchemaFromCols(colColl)
+	require.NoError(t, err)
 	tableSchVal, err := encoding.MarshalSchemaAsNomsValue(context.Background(), db, tableSch)
 	require.NoError(t, err)
 	emptyMap, err := types.NewMap(context.Background(), db)
@@ -234,7 +236,8 @@ func TestTableEditorWriteAfterFlush(t *testing.T) {
 		schema.NewColumn("v1", 1, types.IntKind, false),
 		schema.NewColumn("v2", 2, types.IntKind, false))
 	require.NoError(t, err)
-	tableSch := schema.SchemaFromCols(colColl)
+	tableSch, err := schema.SchemaFromCols(colColl)
+	require.NoError(t, err)
 	tableSchVal, err := encoding.MarshalSchemaAsNomsValue(context.Background(), db, tableSch)
 	require.NoError(t, err)
 	emptyMap, err := types.NewMap(context.Background(), db)
@@ -305,7 +308,8 @@ func TestTableEditorDuplicateKeyHandling(t *testing.T) {
 		schema.NewColumn("v1", 1, types.IntKind, false),
 		schema.NewColumn("v2", 2, types.IntKind, false))
 	require.NoError(t, err)
-	tableSch := schema.SchemaFromCols(colColl)
+	tableSch, err := schema.SchemaFromCols(colColl)
+	require.NoError(t, err)
 	tableSchVal, err := encoding.MarshalSchemaAsNomsValue(context.Background(), db, tableSch)
 	require.NoError(t, err)
 	emptyMap, err := types.NewMap(context.Background(), db)

--- a/go/libraries/doltcore/doltdb/table_test.go
+++ b/go/libraries/doltcore/doltdb/table_test.go
@@ -368,7 +368,8 @@ func TestIndexRebuildingUniqueSuccessOneCol(t *testing.T) {
 		schema.NewColumn("v1", 2, types.IntKind, false),
 		schema.NewColumn("v2", 3, types.IntKind, false),
 	)
-	sch := schema.SchemaFromCols(colColl)
+	sch, err := schema.SchemaFromCols(colColl)
+	require.NoError(t, err)
 	rowData, _ := createTestRowDataFromTaggedValues(t, db, sch,
 		row.TaggedValues{1: types.Int(1), 2: types.Int(1), 3: types.Int(1)},
 		row.TaggedValues{1: types.Int(2), 2: types.Int(2), 3: types.Int(2)},
@@ -398,7 +399,8 @@ func TestIndexRebuildingUniqueSuccessTwoCol(t *testing.T) {
 		schema.NewColumn("v1", 2, types.IntKind, false),
 		schema.NewColumn("v2", 3, types.IntKind, false),
 	)
-	sch := schema.SchemaFromCols(colColl)
+	sch, err := schema.SchemaFromCols(colColl)
+	require.NoError(t, err)
 	rowData, _ := createTestRowDataFromTaggedValues(t, db, sch,
 		row.TaggedValues{1: types.Int(1), 2: types.Int(1), 3: types.Int(1)},
 		row.TaggedValues{1: types.Int(2), 2: types.Int(1), 3: types.Int(2)},
@@ -428,7 +430,8 @@ func TestIndexRebuildingUniqueFailOneCol(t *testing.T) {
 		schema.NewColumn("v1", 2, types.IntKind, false),
 		schema.NewColumn("v2", 3, types.IntKind, false),
 	)
-	sch := schema.SchemaFromCols(colColl)
+	sch, err := schema.SchemaFromCols(colColl)
+	require.NoError(t, err)
 	rowData, _ := createTestRowDataFromTaggedValues(t, db, sch,
 		row.TaggedValues{1: types.Int(1), 2: types.Int(1), 3: types.Int(1)},
 		row.TaggedValues{1: types.Int(2), 2: types.Int(2), 3: types.Int(2)},
@@ -458,7 +461,8 @@ func TestIndexRebuildingUniqueFailTwoCol(t *testing.T) {
 		schema.NewColumn("v1", 2, types.IntKind, false),
 		schema.NewColumn("v2", 3, types.IntKind, false),
 	)
-	sch := schema.SchemaFromCols(colColl)
+	sch, err := schema.SchemaFromCols(colColl)
+	require.NoError(t, err)
 	rowData, _ := createTestRowDataFromTaggedValues(t, db, sch,
 		row.TaggedValues{1: types.Int(1), 2: types.Int(1), 3: types.Int(1)},
 		row.TaggedValues{1: types.Int(2), 2: types.Int(1), 3: types.Int(2)},

--- a/go/libraries/doltcore/dtestutils/data.go
+++ b/go/libraries/doltcore/dtestutils/data.go
@@ -57,7 +57,7 @@ var typedColColl, _ = schema.NewColCollection(
 	schema.NewColumn("title", TitleTag, types.StringKind, false),
 )
 
-var TypedSchema = schema.SchemaFromCols(typedColColl)
+var TypedSchema = schema.MustSchemaFromCols(typedColColl)
 var UntypedSchema, _ = untyped.UntypeSchema(TypedSchema)
 var TypedRows []row.Row
 var UntypedRows []row.Row

--- a/go/libraries/doltcore/dtestutils/schema.go
+++ b/go/libraries/doltcore/dtestutils/schema.go
@@ -33,7 +33,7 @@ import (
 // CreateSchema returns a schema from the columns given, panicking on any errors.
 func CreateSchema(columns ...schema.Column) schema.Schema {
 	colColl, _ := schema.NewColCollection(columns...)
-	return schema.SchemaFromCols(colColl)
+	return schema.MustSchemaFromCols(colColl)
 }
 
 // Creates a row with the schema given, having the values given. Starts at tag 0 and counts up.
@@ -59,7 +59,7 @@ func AddColumnToSchema(sch schema.Schema, col schema.Column) schema.Schema {
 	if err != nil {
 		panic(err)
 	}
-	return schema.SchemaFromCols(columns)
+	return schema.MustSchemaFromCols(columns)
 }
 
 // RemoveColumnFromSchema returns a new schema with the given tag missing, but otherwise identical. At least one
@@ -81,7 +81,7 @@ func RemoveColumnFromSchema(sch schema.Schema, tagToRemove uint64) schema.Schema
 	if err != nil {
 		panic(err)
 	}
-	return schema.SchemaFromCols(columns)
+	return schema.MustSchemaFromCols(columns)
 }
 
 // Compares two noms Floats for approximate equality
@@ -133,6 +133,6 @@ func MustSchema(cols ...schema.Column) schema.Schema {
 	if !hasPKCols {
 		return schema.UnkeyedSchemaFromCols(colColl)
 	} else {
-		return schema.SchemaFromCols(colColl)
+		return schema.MustSchemaFromCols(colColl)
 	}
 }

--- a/go/libraries/doltcore/env/dolt_docs.go
+++ b/go/libraries/doltcore/env/dolt_docs.go
@@ -27,7 +27,7 @@ var doltDocsColumns, _ = schema.NewColCollection(
 	schema.NewColumn(doltdb.DocPkColumnName, doltdb.DocNameTag, types.StringKind, true, schema.NotNullConstraint{}),
 	schema.NewColumn(doltdb.DocTextColumnName, doltdb.DocTextTag, types.StringKind, false),
 )
-var DoltDocsSchema = schema.SchemaFromCols(doltDocsColumns)
+var DoltDocsSchema = schema.MustSchemaFromCols(doltDocsColumns)
 
 // AllValidDocDetails is a list of all valid docs with static fields DocPk and File. All other DocDetail fields
 // are dynamic and must be added, modified or removed as needed.
@@ -99,4 +99,12 @@ func IsValidDoc(docName string) bool {
 func hasDocFile(fs filesys.ReadWriteFS, file string) bool {
 	exists, isDir := fs.Exists(getDocFile(file))
 	return exists && !isDir
+}
+
+func MustSchemaFromCols(typedColColl *schema.ColCollection) schema.Schema {
+	sch, err := schema.SchemaFromCols(typedColColl)
+	if err != nil {
+		panic(err)
+	}
+	return sch
 }

--- a/go/libraries/doltcore/env/dolt_docs.go
+++ b/go/libraries/doltcore/env/dolt_docs.go
@@ -100,11 +100,3 @@ func hasDocFile(fs filesys.ReadWriteFS, file string) bool {
 	exists, isDir := fs.Exists(getDocFile(file))
 	return exists && !isDir
 }
-
-func MustSchemaFromCols(typedColColl *schema.ColCollection) schema.Schema {
-	sch, err := schema.SchemaFromCols(typedColColl)
-	if err != nil {
-		panic(err)
-	}
-	return sch
-}

--- a/go/libraries/doltcore/envtestutils/rebase_tag_test.go
+++ b/go/libraries/doltcore/envtestutils/rebase_tag_test.go
@@ -82,7 +82,7 @@ func columnCollection(cols ...schema.Column) *schema.ColCollection {
 }
 
 func newRow(vals row.TaggedValues, cc *schema.ColCollection) row.Row {
-	r, err := row.New(types.Format_7_18, env.MustSchemaFromCols(cc), vals)
+	r, err := row.New(types.Format_7_18, schema.MustSchemaFromCols(cc), vals)
 	if err != nil {
 		panic(err)
 	}
@@ -134,7 +134,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    env.MustSchemaFromCols(people),
+		ExpectedSchema:    schema.MustSchemaFromCols(people),
 		ExpectedRows:      []row.Row{},
 	},
 	{
@@ -150,7 +150,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    env.MustSchemaFromCols(peopleWithDrip),
+		ExpectedSchema:    schema.MustSchemaFromCols(peopleWithDrip),
 		ExpectedRows: []row.Row{
 			newRow(row.TaggedValues{IdTag: types.Int(10), NameTag: types.String("Patty Bouvier"), AgeTag: types.Int(40), DripTagRebased: types.Float(8.5)}, peopleWithDrip),
 			newRow(row.TaggedValues{IdTag: types.Int(11), NameTag: types.String("Selma Bouvier"), AgeTag: types.Int(40), DripTagRebased: types.Float(8.5)}, peopleWithDrip),
@@ -167,7 +167,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    env.MustSchemaFromCols(peopleWithDrip),
+		ExpectedSchema:    schema.MustSchemaFromCols(peopleWithDrip),
 		ExpectedRows:      []row.Row{},
 	},
 	{
@@ -183,7 +183,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    env.MustSchemaFromCols(peopleWithDrip),
+		ExpectedSchema:    schema.MustSchemaFromCols(peopleWithDrip),
 		ExpectedRows: []row.Row{
 			newRow(row.TaggedValues{IdTag: types.Int(9), NameTag: types.String("Jacqueline Bouvier"), AgeTag: types.Int(80)}, people),
 			newRow(row.TaggedValues{IdTag: types.Int(11), NameTag: types.String("Selma Bouvier"), AgeTag: types.Int(40), DripTagRebased: types.Float(8.5)}, peopleWithDrip),
@@ -202,7 +202,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    env.MustSchemaFromCols(peopleWithDrip),
+		ExpectedSchema:    schema.MustSchemaFromCols(peopleWithDrip),
 		ExpectedRows: []row.Row{
 			newRow(row.TaggedValues{IdTag: types.Int(9), NameTag: types.String("Jacqueline Bouvier"), AgeTag: types.Int(80), DripTagRebased: types.Float(9.9)}, peopleWithDrip),
 		},
@@ -222,7 +222,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    env.MustSchemaFromCols(peopleWithDrip),
+		ExpectedSchema:    schema.MustSchemaFromCols(peopleWithDrip),
 		ExpectedRows: []row.Row{
 			newRow(row.TaggedValues{IdTag: types.Int(9), NameTag: types.String("Jacqueline Bouvier"), AgeTag: types.Int(80)}, people),
 			newRow(row.TaggedValues{IdTag: types.Int(11), NameTag: types.String("Selma Bouvier"), AgeTag: types.Int(40), DripTagRebased: types.Float(9.9)}, peopleWithDrip),
@@ -244,7 +244,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    env.MustSchemaFromCols(peopleWithDrip),
+		ExpectedSchema:    schema.MustSchemaFromCols(peopleWithDrip),
 		ExpectedRows: []row.Row{
 			newRow(row.TaggedValues{IdTag: types.Int(9), NameTag: types.String("Jacqueline Bouvier"), AgeTag: types.Int(80), DripTagRebased: types.Float(1.1)}, peopleWithDrip),
 			newRow(row.TaggedValues{IdTag: types.Int(11), NameTag: types.String("Selma Bouvier"), AgeTag: types.Int(40), DripTagRebased: types.Float(9.9)}, peopleWithDrip),
@@ -268,7 +268,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    env.MustSchemaFromCols(peopleWithDrip),
+		ExpectedSchema:    schema.MustSchemaFromCols(peopleWithDrip),
 		ExpectedRows: []row.Row{
 			newRow(row.TaggedValues{IdTag: types.Int(7), NameTag: types.String("Maggie Simpson"), AgeTag: types.Int(2)}, people),
 			newRow(row.TaggedValues{IdTag: types.Int(9), NameTag: types.String("Jacqueline Bouvier"), AgeTag: types.Int(80)}, people),
@@ -294,7 +294,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    env.MustSchemaFromCols(peopleWithDrip),
+		ExpectedSchema:    schschema.MustSchemaFromCols(peopleWithDrip),
 		ExpectedRows: []row.Row{
 			newRow(row.TaggedValues{IdTag: types.Int(9), NameTag: types.String("Jacqueline Bouvier"), AgeTag: types.Int(80)}, people),
 			newRow(row.TaggedValues{IdTag: types.Int(11), NameTag: types.String("Selma Bouvier"), AgeTag: types.Int(40), DripTagRebased: types.Float(8.5)}, peopleWithDrip),
@@ -328,7 +328,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    env.MustSchemaFromCols(peopleWithDrip),
+		ExpectedSchema:    schema.MustSchemaFromCols(peopleWithDrip),
 		ExpectedRows: []row.Row{
 			newRow(row.TaggedValues{IdTag: types.Int(7), NameTag: types.String("Maggie Simpson"), AgeTag: types.Int(1), DripTagRebased: types.Float(99.9)}, peopleWithDrip),
 			newRow(row.TaggedValues{IdTag: types.Int(9), NameTag: types.String("Jacqueline Bouvier"), AgeTag: types.Int(40)}, people),
@@ -355,7 +355,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    env.MustSchemaFromCols(peopleWithDrip),
+		ExpectedSchema:    schema.MustSchemaFromCols(peopleWithDrip),
 		ExpectedRows: []row.Row{
 			newRow(row.TaggedValues{IdTag: types.Int(9), NameTag: types.String("Jacqueline Bouvier"), AgeTag: types.Int(80)}, people),
 			newRow(row.TaggedValues{IdTag: types.Int(11), NameTag: types.String("Selma Bouvier"), AgeTag: types.Int(40), DripTagRebased: types.Float(8.5)}, peopleWithDrip),
@@ -382,7 +382,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    env.MustSchemaFromCols(peopleWithDrip),
+		ExpectedSchema:    schema.MustSchemaFromCols(peopleWithDrip),
 		ExpectedRows: []row.Row{
 			newRow(row.TaggedValues{IdTag: types.Int(9), NameTag: types.String("Jacqueline Bouvier"), AgeTag: types.Int(80), DripTagRebased: types.Float(8.5)}, peopleWithDrip),
 			newRow(row.TaggedValues{IdTag: types.Int(10), NameTag: types.String("Patty Bouvier"), AgeTag: types.Int(40), DripTagRebased: types.Float(8.5)}, peopleWithDrip),
@@ -407,7 +407,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    env.MustSchemaFromCols(people),
+		ExpectedSchema:    schema.MustSchemaFromCols(people),
 		ExpectedRows: []row.Row{
 			newRow(row.TaggedValues{IdTag: types.Int(7), NameTag: types.String("Maggie Simpson"), AgeTag: types.Int(1)}, people),
 		},
@@ -485,7 +485,7 @@ func testRebaseTagHistory(t *testing.T) {
 	newMasterCm, err := rebase.TagRebaseForRef(context.Background(), bs[0], dEnv.DoltDB, rebase.TagMapping{"people": map[uint64]uint64{DripTag: DripTagRebased}})
 	require.NoError(t, err)
 
-	expectedSch := env.MustSchemaFromCols(peopleWithDrip)
+	expectedSch := schema.MustSchemaFromCols(peopleWithDrip)
 	rebasedRoot, _ := newMasterCm.GetRootValue()
 	checkSchema(t, rebasedRoot, "people", expectedSch)
 	checkRows(t, dEnv, rebasedRoot, "people", expectedSch, "select * from people;", []row.Row{

--- a/go/libraries/doltcore/envtestutils/rebase_tag_test.go
+++ b/go/libraries/doltcore/envtestutils/rebase_tag_test.go
@@ -82,7 +82,7 @@ func columnCollection(cols ...schema.Column) *schema.ColCollection {
 }
 
 func newRow(vals row.TaggedValues, cc *schema.ColCollection) row.Row {
-	r, err := row.New(types.Format_7_18, schema.SchemaFromCols(cc), vals)
+	r, err := row.New(types.Format_7_18, env.MustSchemaFromCols(cc), vals)
 	if err != nil {
 		panic(err)
 	}
@@ -134,7 +134,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    schema.SchemaFromCols(people),
+		ExpectedSchema:    env.MustSchemaFromCols(people),
 		ExpectedRows:      []row.Row{},
 	},
 	{
@@ -150,7 +150,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    schema.SchemaFromCols(peopleWithDrip),
+		ExpectedSchema:    env.MustSchemaFromCols(peopleWithDrip),
 		ExpectedRows: []row.Row{
 			newRow(row.TaggedValues{IdTag: types.Int(10), NameTag: types.String("Patty Bouvier"), AgeTag: types.Int(40), DripTagRebased: types.Float(8.5)}, peopleWithDrip),
 			newRow(row.TaggedValues{IdTag: types.Int(11), NameTag: types.String("Selma Bouvier"), AgeTag: types.Int(40), DripTagRebased: types.Float(8.5)}, peopleWithDrip),
@@ -167,7 +167,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    schema.SchemaFromCols(peopleWithDrip),
+		ExpectedSchema:    env.MustSchemaFromCols(peopleWithDrip),
 		ExpectedRows:      []row.Row{},
 	},
 	{
@@ -183,7 +183,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    schema.SchemaFromCols(peopleWithDrip),
+		ExpectedSchema:    env.MustSchemaFromCols(peopleWithDrip),
 		ExpectedRows: []row.Row{
 			newRow(row.TaggedValues{IdTag: types.Int(9), NameTag: types.String("Jacqueline Bouvier"), AgeTag: types.Int(80)}, people),
 			newRow(row.TaggedValues{IdTag: types.Int(11), NameTag: types.String("Selma Bouvier"), AgeTag: types.Int(40), DripTagRebased: types.Float(8.5)}, peopleWithDrip),
@@ -202,7 +202,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    schema.SchemaFromCols(peopleWithDrip),
+		ExpectedSchema:    env.MustSchemaFromCols(peopleWithDrip),
 		ExpectedRows: []row.Row{
 			newRow(row.TaggedValues{IdTag: types.Int(9), NameTag: types.String("Jacqueline Bouvier"), AgeTag: types.Int(80), DripTagRebased: types.Float(9.9)}, peopleWithDrip),
 		},
@@ -222,7 +222,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    schema.SchemaFromCols(peopleWithDrip),
+		ExpectedSchema:    env.MustSchemaFromCols(peopleWithDrip),
 		ExpectedRows: []row.Row{
 			newRow(row.TaggedValues{IdTag: types.Int(9), NameTag: types.String("Jacqueline Bouvier"), AgeTag: types.Int(80)}, people),
 			newRow(row.TaggedValues{IdTag: types.Int(11), NameTag: types.String("Selma Bouvier"), AgeTag: types.Int(40), DripTagRebased: types.Float(9.9)}, peopleWithDrip),
@@ -244,7 +244,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    schema.SchemaFromCols(peopleWithDrip),
+		ExpectedSchema:    env.MustSchemaFromCols(peopleWithDrip),
 		ExpectedRows: []row.Row{
 			newRow(row.TaggedValues{IdTag: types.Int(9), NameTag: types.String("Jacqueline Bouvier"), AgeTag: types.Int(80), DripTagRebased: types.Float(1.1)}, peopleWithDrip),
 			newRow(row.TaggedValues{IdTag: types.Int(11), NameTag: types.String("Selma Bouvier"), AgeTag: types.Int(40), DripTagRebased: types.Float(9.9)}, peopleWithDrip),
@@ -268,7 +268,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    schema.SchemaFromCols(peopleWithDrip),
+		ExpectedSchema:    env.MustSchemaFromCols(peopleWithDrip),
 		ExpectedRows: []row.Row{
 			newRow(row.TaggedValues{IdTag: types.Int(7), NameTag: types.String("Maggie Simpson"), AgeTag: types.Int(2)}, people),
 			newRow(row.TaggedValues{IdTag: types.Int(9), NameTag: types.String("Jacqueline Bouvier"), AgeTag: types.Int(80)}, people),
@@ -294,7 +294,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    schema.SchemaFromCols(peopleWithDrip),
+		ExpectedSchema:    env.MustSchemaFromCols(peopleWithDrip),
 		ExpectedRows: []row.Row{
 			newRow(row.TaggedValues{IdTag: types.Int(9), NameTag: types.String("Jacqueline Bouvier"), AgeTag: types.Int(80)}, people),
 			newRow(row.TaggedValues{IdTag: types.Int(11), NameTag: types.String("Selma Bouvier"), AgeTag: types.Int(40), DripTagRebased: types.Float(8.5)}, peopleWithDrip),
@@ -328,7 +328,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    schema.SchemaFromCols(peopleWithDrip),
+		ExpectedSchema:    env.MustSchemaFromCols(peopleWithDrip),
 		ExpectedRows: []row.Row{
 			newRow(row.TaggedValues{IdTag: types.Int(7), NameTag: types.String("Maggie Simpson"), AgeTag: types.Int(1), DripTagRebased: types.Float(99.9)}, peopleWithDrip),
 			newRow(row.TaggedValues{IdTag: types.Int(9), NameTag: types.String("Jacqueline Bouvier"), AgeTag: types.Int(40)}, people),
@@ -355,7 +355,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    schema.SchemaFromCols(peopleWithDrip),
+		ExpectedSchema:    env.MustSchemaFromCols(peopleWithDrip),
 		ExpectedRows: []row.Row{
 			newRow(row.TaggedValues{IdTag: types.Int(9), NameTag: types.String("Jacqueline Bouvier"), AgeTag: types.Int(80)}, people),
 			newRow(row.TaggedValues{IdTag: types.Int(11), NameTag: types.String("Selma Bouvier"), AgeTag: types.Int(40), DripTagRebased: types.Float(8.5)}, peopleWithDrip),
@@ -382,7 +382,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    schema.SchemaFromCols(peopleWithDrip),
+		ExpectedSchema:    env.MustSchemaFromCols(peopleWithDrip),
 		ExpectedRows: []row.Row{
 			newRow(row.TaggedValues{IdTag: types.Int(9), NameTag: types.String("Jacqueline Bouvier"), AgeTag: types.Int(80), DripTagRebased: types.Float(8.5)}, peopleWithDrip),
 			newRow(row.TaggedValues{IdTag: types.Int(10), NameTag: types.String("Patty Bouvier"), AgeTag: types.Int(40), DripTagRebased: types.Float(8.5)}, peopleWithDrip),
@@ -407,7 +407,7 @@ var RebaseTagTests = []RebaseTagTest{
 		OldTag:            DripTag,
 		NewTag:            DripTagRebased,
 		SelectResultQuery: "select * from people;",
-		ExpectedSchema:    schema.SchemaFromCols(people),
+		ExpectedSchema:    env.MustSchemaFromCols(people),
 		ExpectedRows: []row.Row{
 			newRow(row.TaggedValues{IdTag: types.Int(7), NameTag: types.String("Maggie Simpson"), AgeTag: types.Int(1)}, people),
 		},
@@ -485,7 +485,7 @@ func testRebaseTagHistory(t *testing.T) {
 	newMasterCm, err := rebase.TagRebaseForRef(context.Background(), bs[0], dEnv.DoltDB, rebase.TagMapping{"people": map[uint64]uint64{DripTag: DripTagRebased}})
 	require.NoError(t, err)
 
-	expectedSch := schema.SchemaFromCols(peopleWithDrip)
+	expectedSch := env.MustSchemaFromCols(peopleWithDrip)
 	rebasedRoot, _ := newMasterCm.GetRootValue()
 	checkSchema(t, rebasedRoot, "people", expectedSch)
 	checkRows(t, dEnv, rebasedRoot, "people", expectedSch, "select * from people;", []row.Row{

--- a/go/libraries/doltcore/envtestutils/super_schema_test.go
+++ b/go/libraries/doltcore/envtestutils/super_schema_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/dtestutils"
 	tc "github.com/dolthub/dolt/go/libraries/doltcore/dtestutils/testcommands"
-	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
 )
@@ -64,7 +63,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.CommitAll{Message: "created table testable"},
 		},
 		ExpectedBranch: "master",
-		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
+		ExpectedSchema: schema.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 		)),
 		ExpectedSuperSchema: superSchemaFromCols(columnCollection(
@@ -78,7 +77,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.Query{Query: testableDef},
 		},
 		ExpectedBranch: "master",
-		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
+		ExpectedSchema: schema.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 		)),
 		ExpectedSuperSchema: superSchemaFromCols(columnCollection(
@@ -94,7 +93,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.Query{Query: fmt.Sprintf("alter table testable add column c0 int;")},
 		},
 		ExpectedBranch: "master",
-		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
+		ExpectedSchema: schema.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 			newColTypeInfo("c0", c0Tag, typeinfo.Int32Type, false),
 		)),
@@ -114,7 +113,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.CommitAll{Message: "dropped column c0"},
 		},
 		ExpectedBranch: "master",
-		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
+		ExpectedSchema: schema.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 		)),
 		ExpectedSuperSchema: superSchemaFromCols(columnCollection(
@@ -132,7 +131,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.Query{Query: "alter table testable drop column c0"},
 		},
 		ExpectedBranch: "master",
-		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
+		ExpectedSchema: schema.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 		)),
 		ExpectedSuperSchema: superSchemaFromCols(columnCollection(
@@ -149,7 +148,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.Query{Query: "alter table testable drop column c0"},
 		},
 		ExpectedBranch: "master",
-		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
+		ExpectedSchema: schema.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 		)),
 		ExpectedSuperSchema: superSchemaFromCols(columnCollection(
@@ -169,7 +168,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.ResetHard{},
 		},
 		ExpectedBranch: "master",
-		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
+		ExpectedSchema: schema.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 			newColTypeInfo("c0", c0Tag, typeinfo.Int32Type, false),
 		)),
@@ -193,7 +192,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.Query{Query: fmt.Sprintf("alter table testable add column c1 int;")},
 		},
 		ExpectedBranch: "master",
-		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
+		ExpectedSchema: schema.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 			newColTypeInfo("c0", c0Tag, typeinfo.Int32Type, false),
 			newColTypeInfo("c1", c1Tag, typeinfo.Int32Type, false),
@@ -221,7 +220,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.Checkout{BranchName: "other"},
 		},
 		ExpectedBranch: "other",
-		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
+		ExpectedSchema: schema.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 			newColTypeInfo("c0", c0Tag, typeinfo.Int32Type, false),
 			newColTypeInfo("c11", c11Tag, typeinfo.Int32Type, false),
@@ -250,7 +249,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.Merge{BranchName: "other"},
 		},
 		ExpectedBranch: "master",
-		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
+		ExpectedSchema: schema.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 			newColTypeInfo("c0", c0Tag, typeinfo.Int32Type, false),
 			newColTypeInfo("c1", c1Tag, typeinfo.Int32Type, false),
@@ -284,7 +283,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.CommitAll{Message: "Merged other into master"},
 		},
 		ExpectedBranch: "master",
-		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
+		ExpectedSchema: schema.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 			newColTypeInfo("c0", c0Tag, typeinfo.Int32Type, false),
 			newColTypeInfo("c1", c1Tag, typeinfo.Int32Type, false),
@@ -312,7 +311,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.CommitAll{Message: "added column c1 on branch master, created table qux, dropped table foo"},
 		},
 		ExpectedBranch: "master",
-		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
+		ExpectedSchema: schema.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 			newColTypeInfo("c0", c0Tag, typeinfo.Int32Type, false),
 			newColTypeInfo("c1", c1Tag, typeinfo.Int32Type, false),
@@ -340,7 +339,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.Checkout{BranchName: "first"},
 		},
 		ExpectedBranch: "first",
-		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
+		ExpectedSchema: schema.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 		)),
 		ExpectedSuperSchema: superSchemaFromCols(columnCollection(
@@ -392,7 +391,7 @@ func testSuperSchema(t *testing.T, test SuperSchemaTest) {
 }
 
 func superSchemaFromCols(cols *schema.ColCollection) *schema.SuperSchema {
-	sch := env.MustSchemaFromCols(cols)
+	sch := schema.MustSchemaFromCols(cols)
 	ss, _ := schema.NewSuperSchema(sch)
 	return ss
 }

--- a/go/libraries/doltcore/envtestutils/super_schema_test.go
+++ b/go/libraries/doltcore/envtestutils/super_schema_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/dtestutils"
 	tc "github.com/dolthub/dolt/go/libraries/doltcore/dtestutils/testcommands"
+	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
 )
@@ -63,7 +64,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.CommitAll{Message: "created table testable"},
 		},
 		ExpectedBranch: "master",
-		ExpectedSchema: schema.SchemaFromCols(columnCollection(
+		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 		)),
 		ExpectedSuperSchema: superSchemaFromCols(columnCollection(
@@ -77,7 +78,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.Query{Query: testableDef},
 		},
 		ExpectedBranch: "master",
-		ExpectedSchema: schema.SchemaFromCols(columnCollection(
+		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 		)),
 		ExpectedSuperSchema: superSchemaFromCols(columnCollection(
@@ -93,7 +94,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.Query{Query: fmt.Sprintf("alter table testable add column c0 int;")},
 		},
 		ExpectedBranch: "master",
-		ExpectedSchema: schema.SchemaFromCols(columnCollection(
+		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 			newColTypeInfo("c0", c0Tag, typeinfo.Int32Type, false),
 		)),
@@ -113,7 +114,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.CommitAll{Message: "dropped column c0"},
 		},
 		ExpectedBranch: "master",
-		ExpectedSchema: schema.SchemaFromCols(columnCollection(
+		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 		)),
 		ExpectedSuperSchema: superSchemaFromCols(columnCollection(
@@ -131,7 +132,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.Query{Query: "alter table testable drop column c0"},
 		},
 		ExpectedBranch: "master",
-		ExpectedSchema: schema.SchemaFromCols(columnCollection(
+		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 		)),
 		ExpectedSuperSchema: superSchemaFromCols(columnCollection(
@@ -148,7 +149,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.Query{Query: "alter table testable drop column c0"},
 		},
 		ExpectedBranch: "master",
-		ExpectedSchema: schema.SchemaFromCols(columnCollection(
+		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 		)),
 		ExpectedSuperSchema: superSchemaFromCols(columnCollection(
@@ -168,7 +169,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.ResetHard{},
 		},
 		ExpectedBranch: "master",
-		ExpectedSchema: schema.SchemaFromCols(columnCollection(
+		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 			newColTypeInfo("c0", c0Tag, typeinfo.Int32Type, false),
 		)),
@@ -192,7 +193,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.Query{Query: fmt.Sprintf("alter table testable add column c1 int;")},
 		},
 		ExpectedBranch: "master",
-		ExpectedSchema: schema.SchemaFromCols(columnCollection(
+		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 			newColTypeInfo("c0", c0Tag, typeinfo.Int32Type, false),
 			newColTypeInfo("c1", c1Tag, typeinfo.Int32Type, false),
@@ -220,7 +221,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.Checkout{BranchName: "other"},
 		},
 		ExpectedBranch: "other",
-		ExpectedSchema: schema.SchemaFromCols(columnCollection(
+		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 			newColTypeInfo("c0", c0Tag, typeinfo.Int32Type, false),
 			newColTypeInfo("c11", c11Tag, typeinfo.Int32Type, false),
@@ -249,7 +250,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.Merge{BranchName: "other"},
 		},
 		ExpectedBranch: "master",
-		ExpectedSchema: schema.SchemaFromCols(columnCollection(
+		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 			newColTypeInfo("c0", c0Tag, typeinfo.Int32Type, false),
 			newColTypeInfo("c1", c1Tag, typeinfo.Int32Type, false),
@@ -283,7 +284,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.CommitAll{Message: "Merged other into master"},
 		},
 		ExpectedBranch: "master",
-		ExpectedSchema: schema.SchemaFromCols(columnCollection(
+		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 			newColTypeInfo("c0", c0Tag, typeinfo.Int32Type, false),
 			newColTypeInfo("c1", c1Tag, typeinfo.Int32Type, false),
@@ -311,7 +312,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.CommitAll{Message: "added column c1 on branch master, created table qux, dropped table foo"},
 		},
 		ExpectedBranch: "master",
-		ExpectedSchema: schema.SchemaFromCols(columnCollection(
+		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 			newColTypeInfo("c0", c0Tag, typeinfo.Int32Type, false),
 			newColTypeInfo("c1", c1Tag, typeinfo.Int32Type, false),
@@ -339,7 +340,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			tc.Checkout{BranchName: "first"},
 		},
 		ExpectedBranch: "first",
-		ExpectedSchema: schema.SchemaFromCols(columnCollection(
+		ExpectedSchema: env.MustSchemaFromCols(columnCollection(
 			newColTypeInfo("pk", pkTag, typeinfo.Int32Type, true, schema.NotNullConstraint{}),
 		)),
 		ExpectedSuperSchema: superSchemaFromCols(columnCollection(
@@ -391,7 +392,7 @@ func testSuperSchema(t *testing.T, test SuperSchemaTest) {
 }
 
 func superSchemaFromCols(cols *schema.ColCollection) *schema.SuperSchema {
-	sch := schema.SchemaFromCols(cols)
+	sch := env.MustSchemaFromCols(cols)
 	ss, _ := schema.NewSuperSchema(sch)
 	return ss
 }

--- a/go/libraries/doltcore/merge/merge_schema.go
+++ b/go/libraries/doltcore/merge/merge_schema.go
@@ -106,7 +106,10 @@ func SchemaMerge(ourSch, theirSch, ancSch schema.Schema, tblName string) (sch sc
 		return nil, sc, nil
 	}
 
-	sch = schema.SchemaFromCols(mergedCC)
+	sch, err = schema.SchemaFromCols(mergedCC)
+	if err != nil {
+		return nil, sc, err
+	}
 	_ = mergedIdxs.Iter(func(index schema.Index) (stop bool, err error) {
 		sch.Indexes().AddIndex(index)
 		return false, nil

--- a/go/libraries/doltcore/merge/merge_schema_test.go
+++ b/go/libraries/doltcore/merge/merge_schema_test.go
@@ -430,10 +430,7 @@ func colCollection(cols ...schema.Column) *schema.ColCollection {
 
 // SchemaFromColsAndIdxs creates a Schema from a ColCollection and an IndexCollection.
 func schemaFromColsAndIdxs(allCols *schema.ColCollection, indexes ...schema.Index) schema.Schema {
-	sch, err := schema.SchemaFromCols(allCols)
-	if err != nil {
-		panic(err)
-	}
+	sch := schema.MustSchemaFromCols(allCols)
 	sch.Indexes().AddIndex(indexes...)
 	return sch
 }

--- a/go/libraries/doltcore/merge/merge_schema_test.go
+++ b/go/libraries/doltcore/merge/merge_schema_test.go
@@ -430,7 +430,10 @@ func colCollection(cols ...schema.Column) *schema.ColCollection {
 
 // SchemaFromColsAndIdxs creates a Schema from a ColCollection and an IndexCollection.
 func schemaFromColsAndIdxs(allCols *schema.ColCollection, indexes ...schema.Index) schema.Schema {
-	sch := schema.SchemaFromCols(allCols)
+	sch, err := schema.SchemaFromCols(allCols)
+	if err != nil {
+		panic(err)
+	}
 	sch.Indexes().AddIndex(indexes...)
 	return sch
 }

--- a/go/libraries/doltcore/merge/merge_test.go
+++ b/go/libraries/doltcore/merge/merge_test.go
@@ -111,7 +111,7 @@ func createRowMergeStruct(name string, vals, mergeVals, ancVals, expected []type
 	}
 
 	colColl, _ := schema.NewColCollection(cols...)
-	sch := schema.SchemaFromCols(colColl)
+	sch := schema.MustSchemaFromCols(colColl)
 
 	tpl := valsToTestTupleWithPks(vals)
 	mergeTpl := valsToTestTupleWithPks(mergeVals)
@@ -229,7 +229,7 @@ var colColl, _ = schema.NewColCollection(
 	schema.NewColumn("name", nameTag, types.StringKind, false, schema.NotNullConstraint{}),
 	schema.NewColumn("title", titleTag, types.StringKind, false),
 )
-var sch = schema.SchemaFromCols(colColl)
+var sch = schema.MustSchemaFromCols(colColl)
 
 var uuids = []types.UUID{
 	types.UUID(uuid.MustParse("00000000-0000-0000-0000-000000000000")),

--- a/go/libraries/doltcore/mvdata/data_loc_test.go
+++ b/go/libraries/doltcore/mvdata/data_loc_test.go
@@ -113,7 +113,7 @@ var imt *table.InMemTable
 var imtRows []row.Row
 
 func init() {
-	fakeSchema = schema.SchemaFromCols(fakeFields)
+	fakeSchema = schema.MustSchemaFromCols(fakeFields)
 
 	imtRows = []row.Row{
 		mustRow(row.New(types.Format_7_18, fakeSchema, row.TaggedValues{0: types.String("a"), 1: types.String("1")})),

--- a/go/libraries/doltcore/mvdata/data_mover.go
+++ b/go/libraries/doltcore/mvdata/data_mover.go
@@ -20,12 +20,12 @@ import (
 	"fmt"
 	"sync/atomic"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	sqleSchema "github.com/dolthub/dolt/go/libraries/doltcore/sqle/schema"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
-	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/rowconv"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table"
@@ -129,9 +129,10 @@ func (imp *DataMover) Move(ctx context.Context) (badRowCount int64, err error) {
 	return badCount, nil
 }
 
-func MoveData(ctx context.Context, dEnv *env.DoltEnv, mover *DataMover, mvOpts DataMoverOptions) (int64, errhand.VerboseError) {
+func MoveDataToRoot(ctx context.Context, mover *DataMover, mvOpts DataMoverOptions, root *doltdb.RootValue, updateRoot func(c context.Context, r *doltdb.RootValue) error) (*doltdb.RootValue, int64, errhand.VerboseError) {
 	var badCount int64
 	var err error
+	newRoot := &doltdb.RootValue{}
 
 	badCount, err = mover.Move(ctx)
 
@@ -149,37 +150,44 @@ func MoveData(ctx context.Context, dEnv *env.DoltEnv, mover *DataMover, mvOpts D
 			bdr.AddDetails(details)
 			bdr.AddDetails("These can be ignored using the '--continue'")
 
-			return badCount, bdr.Build()
+			return nil, badCount, bdr.Build()
 		}
-		return badCount, errhand.BuildDError("An error occurred moving data:\n").AddCause(err).Build()
+		return nil, badCount, errhand.BuildDError("An error occurred moving data:\n").AddCause(err).Build()
 	}
 
 	if mvOpts.WritesToTable() {
 		wr := mover.Wr.(DataMoverCloser)
-		newRoot, err := wr.Flush(ctx)
+		newRoot, err = wr.Flush(ctx)
 		if err != nil {
-			return badCount, errhand.BuildDError("Failed to apply changes to the table.").AddCause(err).Build()
-		}
-
-		root, err := dEnv.WorkingRoot(ctx)
-		if err != nil {
-			return badCount, errhand.BuildDError("Failed to fetch the working value.").AddCause(err).Build()
+			return nil, badCount, errhand.BuildDError("Failed to apply changes to the table.").AddCause(err).Build()
 		}
 
 		rootHash, err := root.HashOf()
 		if err != nil {
-			return badCount, errhand.BuildDError("Failed to hash the working value.").AddCause(err).Build()
+			return nil, badCount, errhand.BuildDError("Failed to hash the working value.").AddCause(err).Build()
 		}
 
 		newRootHash, err := newRoot.HashOf()
 		if rootHash != newRootHash {
-			err = dEnv.UpdateWorkingRoot(ctx, newRoot)
+			err = updateRoot(ctx, newRoot)
 			if err != nil {
-				return badCount, errhand.BuildDError("Failed to update the working value.").AddCause(err).Build()
+				return nil, badCount, errhand.BuildDError("Failed to update the working value.").AddCause(err).Build()
 			}
 		}
 	}
 
+	return newRoot, badCount, nil
+}
+
+func MoveData(ctx context.Context, dEnv *env.DoltEnv, mover *DataMover, mvOpts DataMoverOptions) (int64, errhand.VerboseError) {
+	root, err := dEnv.WorkingRoot(ctx)
+	if err != nil {
+		return 0, errhand.BuildDError("Failed to fetch the working value.").AddCause(err).Build()
+	}
+	_, badCount, moveErr := MoveDataToRoot(ctx, mover, mvOpts, root, dEnv.UpdateWorkingRoot)
+	if moveErr != nil {
+		return badCount, moveErr
+	}
 	return badCount, nil
 }
 

--- a/go/libraries/doltcore/mvdata/data_mover.go
+++ b/go/libraries/doltcore/mvdata/data_mover.go
@@ -260,5 +260,10 @@ func InferSchema(ctx context.Context, root *doltdb.RootValue, rd table.TableRead
 		return nil, errhand.BuildDError("failed to generate new schema").AddCause(err).Build()
 	}
 
-	return schema.SchemaFromCols(newCols), nil
+	sch, err := schema.SchemaFromCols(newCols)
+	if err != nil {
+		return nil, errhand.BuildDError("failed to get schema from cols").AddCause(err).Build()
+	}
+
+	return sch, nil
 }

--- a/go/libraries/doltcore/mvdata/data_mover.go
+++ b/go/libraries/doltcore/mvdata/data_mover.go
@@ -255,14 +255,6 @@ func InferSchema(ctx context.Context, root *doltdb.RootValue, rd table.TableRead
 		return col, nil
 	})
 
-	// Verify all provided primary keys are being used
-	for _, pk := range pks {
-		col, ok := newCols.GetByName(pk)
-		if !ok || !col.IsPartOfPK {
-			return nil, errhand.BuildDError("provided primary keys do not match data schema").Build()
-		}
-	}
-
 	newCols, err = root.GenerateTagsForNewColColl(ctx, tableName, newCols)
 	if err != nil {
 		return nil, errhand.BuildDError("failed to generate new schema").AddCause(err).Build()

--- a/go/libraries/doltcore/rebase/rebase_tag.go
+++ b/go/libraries/doltcore/rebase/rebase_tag.go
@@ -360,7 +360,10 @@ func replayCommitWithNewTag(ctx context.Context, root, parentRoot, rebasedParent
 			return nil, err
 		}
 
-		rebasedSch := schema.SchemaFromCols(schCC)
+		rebasedSch, err := schema.SchemaFromCols(schCC)
+		if err != nil {
+			return nil, err
+		}
 
 		for _, index := range sch.Indexes().AllIndexes() {
 			_, err = rebasedSch.Indexes().AddIndexByColNames(

--- a/go/libraries/doltcore/rowconv/field_mapping_test.go
+++ b/go/libraries/doltcore/rowconv/field_mapping_test.go
@@ -44,11 +44,11 @@ var fieldsD, _ = schema.NewColCollection(
 	schema.NewColumn("key", 3, types.StringKind, true),
 	schema.NewColumn("value", 4, types.StringKind, false))
 
-var schemaA = schema.SchemaFromCols(fieldsA)
-var schemaB = schema.SchemaFromCols(fieldsB)
-var schemaC = schema.SchemaFromCols(fieldsC)
-var schemaCNoPK = schema.SchemaFromCols(fieldsCNoPK)
-var schemaD = schema.SchemaFromCols(fieldsD)
+var schemaA = schema.MustSchemaFromCols(fieldsA)
+var schemaB = schema.MustSchemaFromCols(fieldsB)
+var schemaC = schema.MustSchemaFromCols(fieldsC)
+var schemaCNoPK = schema.MustSchemaFromCols(fieldsCNoPK)
+var schemaD = schema.MustSchemaFromCols(fieldsD)
 
 func TestFieldMapping(t *testing.T) {
 	tests := []struct {

--- a/go/libraries/doltcore/rowconv/joiner_test.go
+++ b/go/libraries/doltcore/rowconv/joiner_test.go
@@ -38,7 +38,7 @@ var peopleCols, _ = schema.NewColCollection(
 	schema.NewColumn("city", cityTag, types.StringKind, false),
 )
 
-var peopleSch = schema.SchemaFromCols(peopleCols)
+var peopleSch = schema.MustSchemaFromCols(peopleCols)
 
 type toJoinAndExpectedResult struct {
 	toJoinVals map[string]row.TaggedValues

--- a/go/libraries/doltcore/rowconv/row_converter_test.go
+++ b/go/libraries/doltcore/rowconv/row_converter_test.go
@@ -41,7 +41,7 @@ var srcCols, _ = schema.NewColCollection(
 	schema.NewColumn("timestamptostr", 6, types.TimestampKind, false),
 )
 
-var srcSch = schema.SchemaFromCols(srcCols)
+var srcSch = schema.MustSchemaFromCols(srcCols)
 
 func TestRowConverter(t *testing.T) {
 	mapping, err := TypedToUntypedMapping(srcSch)
@@ -108,7 +108,8 @@ func TestSpecialBoolHandling(t *testing.T) {
 	col2, err := schema.NewColumnWithTypeInfo("v", 1, typeinfo.PseudoBoolType, false, "", false, "")
 	require.NoError(t, err)
 	colColl, _ := schema.NewColCollection(col1, col2)
-	sch := schema.SchemaFromCols(colColl)
+	sch, err := schema.SchemaFromCols(colColl)
+	require.NoError(t, err)
 	untypedSch, err := untyped.UntypeSchema(sch)
 	require.NoError(t, err)
 

--- a/go/libraries/doltcore/schema/alterschema/addcolumn.go
+++ b/go/libraries/doltcore/schema/alterschema/addcolumn.go
@@ -156,7 +156,10 @@ func addColumnToSchema(sch schema.Schema, tag uint64, newColName string, typeInf
 	if err != nil {
 		return nil, err
 	}
-	newSch := schema.SchemaFromCols(collection)
+	newSch, err := schema.SchemaFromCols(collection)
+	if err != nil {
+		return nil, err
+	}
 	newSch.Indexes().AddIndex(sch.Indexes().AllIndexes()...)
 
 	return newSch, nil

--- a/go/libraries/doltcore/schema/alterschema/dropcolumn.go
+++ b/go/libraries/doltcore/schema/alterschema/dropcolumn.go
@@ -88,7 +88,10 @@ func DropColumn(ctx context.Context, tbl *doltdb.Table, colName string, foreignK
 		return nil, err
 	}
 
-	newSch := schema.SchemaFromCols(colColl)
+	newSch, err := schema.SchemaFromCols(colColl)
+	if err != nil {
+		return nil, err
+	}
 	newSch.Indexes().AddIndex(tblSch.Indexes().AllIndexes()...)
 
 	vrw := tbl.ValueReadWriter()

--- a/go/libraries/doltcore/schema/alterschema/modifycolumn.go
+++ b/go/libraries/doltcore/schema/alterschema/modifycolumn.go
@@ -195,7 +195,10 @@ func replaceColumnInSchema(sch schema.Schema, oldCol schema.Column, newCol schem
 		return nil, err
 	}
 
-	newSch := schema.SchemaFromCols(collection)
+	newSch, err := schema.SchemaFromCols(collection)
+	if err != nil {
+		return nil, err
+	}
 	newSch.Indexes().AddIndex(sch.Indexes().AllIndexes()...)
 	return newSch, nil
 }

--- a/go/libraries/doltcore/schema/alterschema/renametable_test.go
+++ b/go/libraries/doltcore/schema/alterschema/renametable_test.go
@@ -33,7 +33,8 @@ func TestRenameTable(t *testing.T) {
 	cc, _ := schema.NewColCollection(
 		schema.NewColumn("id", uint64(100), types.UUIDKind, true, schema.NotNullConstraint{}),
 	)
-	otherSch := schema.SchemaFromCols(cc)
+	otherSch, err := schema.SchemaFromCols(cc)
+	require.NoError(t, err)
 
 	tests := []struct {
 		name           string

--- a/go/libraries/doltcore/schema/col_coll.go
+++ b/go/libraries/doltcore/schema/col_coll.go
@@ -31,7 +31,7 @@ var ErrColNotFound = errors.New("column not found")
 // different type or tag
 var ErrColNameCollision = errors.New("two different columns with the same name exist")
 
-// ErrNoPrimaryKeyColumns is an error that is returned when wo
+// ErrNoPrimaryKeyColumns is an error that is returned when no primary key columns are found
 var ErrNoPrimaryKeyColumns = errors.New("no primary key columns")
 
 var EmptyColColl = &ColCollection{

--- a/go/libraries/doltcore/schema/encoding/schema_marshaling.go
+++ b/go/libraries/doltcore/schema/encoding/schema_marshaling.go
@@ -199,7 +199,10 @@ func (sd schemaData) decodeSchema() (schema.Schema, error) {
 		return nil, err
 	}
 
-	sch := schema.SchemaFromCols(colColl)
+	sch, err := schema.SchemaFromCols(colColl)
+	if err != nil {
+		return nil, err
+	}
 
 	for _, encodedIndex := range sd.IndexCollection {
 		_, err = sch.Indexes().UnsafeAddIndexByColTags(

--- a/go/libraries/doltcore/schema/encoding/schema_marshaling_test.go
+++ b/go/libraries/doltcore/schema/encoding/schema_marshaling_test.go
@@ -43,7 +43,10 @@ func createTestSchema() schema.Schema {
 	}
 
 	colColl, _ := schema.NewColCollection(columns...)
-	sch := schema.SchemaFromCols(colColl)
+	sch, err := schema.SchemaFromCols(colColl)
+	if err != nil {
+		panic(err)
+	}
 	_, _ = sch.Indexes().AddIndexByColTags("idx_age", []uint64{3}, schema.IndexProperties{IsUnique: false, Comment: ""})
 	return sch
 }
@@ -150,7 +153,8 @@ func TestTypeInfoMarshalling(t *testing.T) {
 			require.NoError(t, err)
 			colColl, err := schema.NewColCollection(col)
 			require.NoError(t, err)
-			originalSch := schema.SchemaFromCols(colColl)
+			originalSch, err := schema.SchemaFromCols(colColl)
+			require.NoError(t, err)
 
 			nbf, err := types.GetFormatForVersionString(constants.FormatDefaultString)
 			require.NoError(t, err)
@@ -262,7 +266,10 @@ func (tsd testSchemaData) decodeSchema() (schema.Schema, error) {
 		return nil, err
 	}
 
-	sch := schema.SchemaFromCols(colColl)
+	sch, err := schema.SchemaFromCols(colColl)
+	if err != nil {
+		return nil, err
+	}
 
 	for _, encodedIndex := range tsd.IndexCollection {
 		_, err = sch.Indexes().AddIndexByColTags(encodedIndex.Name, encodedIndex.Tags, schema.IndexProperties{IsUnique: encodedIndex.Unique, Comment: encodedIndex.Comment})

--- a/go/libraries/doltcore/schema/encoding/schema_marshaling_test.go
+++ b/go/libraries/doltcore/schema/encoding/schema_marshaling_test.go
@@ -43,10 +43,7 @@ func createTestSchema() schema.Schema {
 	}
 
 	colColl, _ := schema.NewColCollection(columns...)
-	sch, err := schema.SchemaFromCols(colColl)
-	if err != nil {
-		panic(err)
-	}
+	sch := schema.MustSchemaFromCols(colColl)
 	_, _ = sch.Indexes().AddIndexByColTags("idx_age", []uint64{3}, schema.IndexProperties{IsUnique: false, Comment: ""})
 	return sch
 }

--- a/go/libraries/doltcore/schema/schema_impl.go
+++ b/go/libraries/doltcore/schema/schema_impl.go
@@ -33,7 +33,7 @@ type schemaImpl struct {
 }
 
 // SchemaFromCols creates a Schema from a collection of columns
-func SchemaFromCols(allCols *ColCollection) Schema {
+func SchemaFromCols(allCols *ColCollection) (Schema, error) {
 	var pkCols []Column
 	var nonPKCols []Column
 
@@ -46,7 +46,7 @@ func SchemaFromCols(allCols *ColCollection) Schema {
 	}
 
 	if len(pkCols) == 0 {
-		panic("no primary key columns specified")
+		return nil, ErrNoPrimaryKeyColumns
 	}
 
 	pkColColl, _ := NewColCollection(pkCols...)
@@ -57,7 +57,15 @@ func SchemaFromCols(allCols *ColCollection) Schema {
 		nonPKCols:       nonPKColColl,
 		allCols:         allCols,
 		indexCollection: NewIndexCollection(allCols),
+	}, nil
+}
+
+func MustSchemaFromCols(typedColColl *ColCollection) Schema {
+	sch, err := SchemaFromCols(typedColColl)
+	if err != nil {
+		panic(err)
 	}
+	return sch
 }
 
 // ValidateForInsert returns an error if the given schema cannot be written to the dolt database.

--- a/go/libraries/doltcore/schema/schema_test.go
+++ b/go/libraries/doltcore/schema/schema_test.go
@@ -83,7 +83,7 @@ func TestSchemaWithNoPKs(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = SchemaFromCols(colColl)
-	assert.Error(t, err)
+	assert.Equal(t, ErrNoPrimaryKeyColumns, err)
 
 	assert.NotPanics(t, func() {
 		UnkeyedSchemaFromCols(colColl)

--- a/go/libraries/doltcore/schema/schema_test.go
+++ b/go/libraries/doltcore/schema/schema_test.go
@@ -62,7 +62,8 @@ var allCols = append(append([]Column(nil), pkCols...), nonPkCols...)
 func TestSchema(t *testing.T) {
 	colColl, err := NewColCollection(allCols...)
 	require.NoError(t, err)
-	schFromCols := SchemaFromCols(colColl)
+	schFromCols, err := SchemaFromCols(colColl)
+	require.NoError(t, err)
 
 	testSchema("SchemaFromCols", schFromCols, t)
 
@@ -81,9 +82,8 @@ func TestSchemaWithNoPKs(t *testing.T) {
 	colColl, err := NewColCollection(nonPkCols...)
 	require.NoError(t, err)
 
-	assert.Panics(t, func() {
-		SchemaFromCols(colColl)
-	})
+	_, err = SchemaFromCols(colColl)
+	assert.Error(t, err)
 
 	assert.NotPanics(t, func() {
 		UnkeyedSchemaFromCols(colColl)

--- a/go/libraries/doltcore/schema/super_schema.go
+++ b/go/libraries/doltcore/schema/super_schema.go
@@ -226,7 +226,7 @@ func (ss *SuperSchema) GenerateSchema() (Schema, error) {
 	if err != nil {
 		return nil, err
 	}
-	return SchemaFromCols(cc), nil
+	return SchemaFromCols(cc)
 }
 
 // NameMapForSchema creates a field name mapping needed to construct a rowconv.RowConverter

--- a/go/libraries/doltcore/schema/super_schema_test.go
+++ b/go/libraries/doltcore/schema/super_schema_test.go
@@ -226,7 +226,7 @@ func superSchemaDeepEqual(t *testing.T, ss1, ss2 *SuperSchema) {
 }
 
 func mustSchema(cols []Column) Schema {
-	return SchemaFromCols(mustColColl(cols))
+	return MustSchemaFromCols(mustColColl(cols))
 }
 
 func mustColColl(cols []Column) *ColCollection {

--- a/go/libraries/doltcore/sql/sqltestutil/data.go
+++ b/go/libraries/doltcore/sql/sqltestutil/data.go
@@ -96,7 +96,7 @@ func createPeopleTestSchema() schema.Schema {
 		schema.NewColumn("uuid", UuidTag, types.UUIDKind, false),
 		schema.NewColumn("num_episodes", NumEpisodesTag, types.UintKind, false),
 	)
-	return schema.SchemaFromCols(colColl)
+	return schema.MustSchemaFromCols(colColl)
 }
 
 func createEpisodesTestSchema() schema.Schema {
@@ -106,7 +106,7 @@ func createEpisodesTestSchema() schema.Schema {
 		newColumnWithTypeInfo("air_date", EpAirDateTag, typeinfo.DatetimeType, false),
 		schema.NewColumn("rating", EpRatingTag, types.FloatKind, false),
 	)
-	return schema.SchemaFromCols(colColl)
+	return schema.MustSchemaFromCols(colColl)
 }
 
 func createAppearancesTestSchema() schema.Schema {
@@ -115,7 +115,7 @@ func createAppearancesTestSchema() schema.Schema {
 		schema.NewColumn("episode_id", AppEpTag, types.IntKind, true, schema.NotNullConstraint{}),
 		schema.NewColumn("comments", AppCommentsTag, types.StringKind, false),
 	)
-	return schema.SchemaFromCols(colColl)
+	return schema.MustSchemaFromCols(colColl)
 }
 
 func newColumnWithTypeInfo(name string, tag uint64, info typeinfo.TypeInfo, partOfPk bool, constraints ...schema.ColConstraint) schema.Column {

--- a/go/libraries/doltcore/sqle/expreval/expression_evaluator_test.go
+++ b/go/libraries/doltcore/sqle/expreval/expression_evaluator_test.go
@@ -208,7 +208,8 @@ func TestNewComparisonFunc(t *testing.T) {
 		schema.NewColumn("col1", 1, types.IntKind, false),
 		schema.NewColumn("date", 2, types.TimestampKind, false),
 	)
-	testSch := schema.SchemaFromCols(colColl)
+	testSch, err := schema.SchemaFromCols(colColl)
+	require.NoError(t, err)
 
 	const (
 		eq  string = "eq"

--- a/go/libraries/doltcore/sqle/filtered_reader_test.go
+++ b/go/libraries/doltcore/sqle/filtered_reader_test.go
@@ -39,11 +39,11 @@ const (
 	c1Tag   = 2
 )
 
-var oneIntPKSch = schema.SchemaFromCols(mustColColl(schema.NewColCollection(
+var oneIntPKSch = schema.MustSchemaFromCols(mustColColl(schema.NewColCollection(
 	schema.NewColumn(pk0Name, pk0Tag, types.IntKind, true),
 	schema.NewColumn(c1Name, c1Tag, types.IntKind, false))))
 
-var twoIntPKSch = schema.SchemaFromCols(mustColColl(schema.NewColCollection(
+var twoIntPKSch = schema.MustSchemaFromCols(mustColColl(schema.NewColCollection(
 	schema.NewColumn(pk0Name, pk0Tag, types.IntKind, true),
 	schema.NewColumn(pk1Name, pk1Tag, types.IntKind, true),
 	schema.NewColumn(c1Name, c1Tag, types.IntKind, false))))

--- a/go/libraries/doltcore/sqle/query_catalog_table.go
+++ b/go/libraries/doltcore/sqle/query_catalog_table.go
@@ -82,7 +82,7 @@ func (sq SavedQuery) asRow() (row.Row, error) {
 	return row.New(types.Format_Default, DoltQueryCatalogSchema, taggedVals)
 }
 
-var DoltQueryCatalogSchema = schema.SchemaFromCols(queryCatalogCols)
+var DoltQueryCatalogSchema = schema.MustSchemaFromCols(queryCatalogCols)
 
 // Creates the query catalog table if it doesn't exist.
 func createQueryCatalogIfNotExists(ctx context.Context, root *doltdb.RootValue) (*doltdb.RootValue, error) {

--- a/go/libraries/doltcore/sqle/schema/schema.go
+++ b/go/libraries/doltcore/sqle/schema/schema.go
@@ -192,7 +192,7 @@ func ToDoltSchema(ctx context.Context, root *doltdb.RootValue, tableName string,
 		return nil, err
 	}
 
-	return schema.SchemaFromCols(colColl), nil
+	return schema.SchemaFromCols(colColl)
 }
 
 // ToDoltCol returns the dolt column corresponding to the SQL column given

--- a/go/libraries/doltcore/sqle/schema_table.go
+++ b/go/libraries/doltcore/sqle/schema_table.go
@@ -47,7 +47,7 @@ func SchemasTableSchema() schema.Schema {
 	if err != nil {
 		panic(err) // should never happen
 	}
-	return schema.SchemaFromCols(colColl)
+	return schema.MustSchemaFromCols(colColl)
 }
 
 // GetOrCreateDoltSchemasTable returns the `dolt_schemas` table in `db`, creating it if it does not already exist.

--- a/go/libraries/doltcore/sqle/schema_util_test.go
+++ b/go/libraries/doltcore/sqle/schema_util_test.go
@@ -102,7 +102,7 @@ func NewRowWithPks(pkColVals []types.Value, nonPkVals ...types.Value) row.Row {
 		panic(err.Error())
 	}
 
-	sch := schema.SchemaFromCols(colColl)
+	sch := schema.MustSchemaFromCols(colColl)
 
 	r, err := row.New(types.Format_7_18, sch, taggedVals)
 
@@ -170,7 +170,7 @@ func NewSchemaForTable(tableName string, colNamesAndTypes ...interface{}) schema
 		panic(err.Error())
 	}
 
-	return schema.SchemaFromCols(colColl)
+	return schema.MustSchemaFromCols(colColl)
 }
 
 // Returns the logical concatenation of the schemas and rows given, rewriting all tag numbers to begin at zero. The row

--- a/go/libraries/doltcore/table/composite_table_reader_test.go
+++ b/go/libraries/doltcore/table/composite_table_reader_test.go
@@ -40,7 +40,8 @@ func TestCompositeTableReader(t *testing.T) {
 		schema.NewColumn("val", 1, types.IntKind, false),
 	)
 	require.NoError(t, err)
-	sch := schema.SchemaFromCols(coll)
+	sch, err := schema.SchemaFromCols(coll)
+	require.NoError(t, err)
 
 	var readers []TableReadCloser
 	var expectedKeys []uint64

--- a/go/libraries/doltcore/table/errors_test.go
+++ b/go/libraries/doltcore/table/errors_test.go
@@ -26,9 +26,10 @@ import (
 
 func TestBadRow(t *testing.T) {
 	cols, _ := schema.NewColCollection(schema.NewColumn("id", 0, types.IntKind, true))
-	sch := schema.SchemaFromCols(cols)
-	emptyRow, err := row.New(types.Format_7_18, sch, row.TaggedValues{})
+	sch, err := schema.SchemaFromCols(cols)
+	assert.NoError(t, err)
 
+	emptyRow, err := row.New(types.Format_7_18, sch, row.TaggedValues{})
 	assert.NoError(t, err)
 
 	err = NewBadRow(emptyRow, "details")

--- a/go/libraries/doltcore/table/inmem_table_test.go
+++ b/go/libraries/doltcore/table/inmem_table_test.go
@@ -39,7 +39,7 @@ var fields, _ = schema.NewColCollection(
 	schema.Column{Name: "is_great", Tag: greatTag, Kind: types.BoolKind, IsPartOfPK: true, TypeInfo: typeinfo.BoolType, Constraints: nil},
 )
 
-var rowSch = schema.SchemaFromCols(fields)
+var rowSch = schema.MustSchemaFromCols(fields)
 
 func mustRow(r row.Row, err error) row.Row {
 	if err != nil {

--- a/go/libraries/doltcore/table/typed/json/reader_test.go
+++ b/go/libraries/doltcore/table/typed/json/reader_test.go
@@ -73,7 +73,8 @@ func TestReader(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	sch := schema.SchemaFromCols(colColl)
+	sch, err := schema.SchemaFromCols(colColl)
+	require.NoError(t, err)
 
 	reader, err := OpenJSONReader(types.Format_LD_1, "file.json", fs, sch)
 	require.NoError(t, err)
@@ -152,7 +153,8 @@ func TestReaderBadJson(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	sch := schema.SchemaFromCols(colColl)
+	sch, err := schema.SchemaFromCols(colColl)
+	require.NoError(t, err)
 
 	reader, err := OpenJSONReader(types.Format_LD_1, "file.json", fs, sch)
 	require.NoError(t, err)

--- a/go/libraries/doltcore/table/typed/noms/range_reader_test.go
+++ b/go/libraries/doltcore/table/typed/noms/range_reader_test.go
@@ -105,7 +105,8 @@ func TestRangeReader(t *testing.T) {
 		schema.NewColumn("val", valTag, types.IntKind, false))
 	require.NoError(t, err)
 
-	sch := schema.SchemaFromCols(colColl)
+	sch, err := schema.SchemaFromCols(colColl)
+	require.NoError(t, err)
 
 	var db datas.Database
 	storage := &chunks.MemoryStorage{}
@@ -162,7 +163,8 @@ func TestRangeReaderOnEmptyMap(t *testing.T) {
 		schema.NewColumn("val", valTag, types.IntKind, false))
 	require.NoError(t, err)
 
-	sch := schema.SchemaFromCols(colColl)
+	sch, err := schema.SchemaFromCols(colColl)
+	require.NoError(t, err)
 
 	var db datas.Database
 	storage := &chunks.MemoryStorage{}

--- a/go/libraries/doltcore/table/typed/noms/read_write_test.go
+++ b/go/libraries/doltcore/table/typed/noms/read_write_test.go
@@ -45,7 +45,7 @@ var colColl, _ = schema.NewColCollection(
 	schema.NewColumn(ageCol, ageColTag, types.UintKind, false),
 	schema.NewColumn(titleCol, titleColTag, types.StringKind, false),
 )
-var sch = schema.SchemaFromCols(colColl)
+var sch = schema.MustSchemaFromCols(colColl)
 
 var uuids = []uuid.UUID{
 	uuid.Must(uuid.Parse("00000000-0000-0000-0000-000000000000")),

--- a/go/libraries/doltcore/table/typed/noms/reader_for_keys_test.go
+++ b/go/libraries/doltcore/table/typed/noms/reader_for_keys_test.go
@@ -41,7 +41,8 @@ func TestReaderForKeys(t *testing.T) {
 		schema.NewColumn("val", valTag, types.IntKind, false))
 	require.NoError(t, err)
 
-	sch := schema.SchemaFromCols(colColl)
+	sch, err := schema.SchemaFromCols(colColl)
+	require.NoError(t, err)
 
 	var db datas.Database
 	storage := &chunks.MemoryStorage{}

--- a/go/libraries/doltcore/table/typed/schema.go
+++ b/go/libraries/doltcore/table/typed/schema.go
@@ -38,6 +38,5 @@ func TypedSchemaUnion(schemas ...schema.Schema) (schema.Schema, error) {
 		return nil, err
 	}
 
-	sch := schema.SchemaFromCols(allColColl)
-	return sch, nil
+	return schema.SchemaFromCols(allColColl)
 }

--- a/go/libraries/doltcore/table/untyped/csv/writer_test.go
+++ b/go/libraries/doltcore/table/untyped/csv/writer_test.go
@@ -56,7 +56,7 @@ Andy Anderson,27,
 		{Name: titleColName, Tag: titleColTag, Kind: types.StringKind, IsPartOfPK: false, Constraints: nil},
 	}
 	colColl, _ := schema.NewColCollection(inCols...)
-	rowSch := schema.SchemaFromCols(colColl)
+	rowSch := schema.MustSchemaFromCols(colColl)
 	rows := []row.Row{
 		mustRow(row.New(types.Format_7_18, rowSch, row.TaggedValues{
 			nameColTag:  types.String("Bill Billerson"),

--- a/go/libraries/doltcore/table/untyped/untyped_rows.go
+++ b/go/libraries/doltcore/table/untyped/untyped_rows.go
@@ -42,7 +42,7 @@ func NewUntypedSchemaWithFirstTag(firstTag uint64, colNames ...string) (map[stri
 	}
 
 	colColl, _ := schema.NewColCollection(cols...)
-	sch := schema.SchemaFromCols(colColl)
+	sch := schema.MustSchemaFromCols(colColl)
 
 	return nameToTag, sch
 }
@@ -98,7 +98,7 @@ func UntypeSchema(sch schema.Schema) (schema.Schema, error) {
 		return nil, err
 	}
 
-	return schema.SchemaFromCols(colColl), nil
+	return schema.SchemaFromCols(colColl)
 }
 
 // UnkeySchema takes a schema and returns a schema with the same columns and types, but stripped of constraints and

--- a/go/libraries/doltcore/table/untyped/untyped_rows_test.go
+++ b/go/libraries/doltcore/table/untyped/untyped_rows_test.go
@@ -115,7 +115,7 @@ func TestUntypedSchemaUnion(t *testing.T) {
 	unequalColCollumn := cols[1]
 	unequalColCollumn.Name = "bad"
 
-	untypedSch := schema.SchemaFromCols(untypedColColl)
+	untypedSch := schema.MustSchemaFromCols(untypedColColl)
 
 	tests := []struct {
 		colsA     []schema.Column
@@ -130,8 +130,8 @@ func TestUntypedSchemaUnion(t *testing.T) {
 	for i, test := range tests {
 		colCollA, _ := schema.NewColCollection(test.colsA...)
 		colCollB, _ := schema.NewColCollection(test.colsB...)
-		schA := schema.SchemaFromCols(colCollA)
-		schB := schema.SchemaFromCols(colCollB)
+		schA := schema.MustSchemaFromCols(colCollA)
+		schB := schema.MustSchemaFromCols(colCollB)
 
 		union, err := UntypedSchemaUnion(schA, schB)
 


### PR DESCRIPTION
In reference to this comment https://github.com/dolthub/ld/pull/5262#discussion_r514465176

I had some duplicate logic in `dolthubapi` for the import table api. I extracted some logic so that I can use `InferSchema` and `MoveDataToRoot` to root to reduce some of the duplications