### PR TITLE
/.github/workflows/ci-go-tests.yaml: run go tests only when go/ changes

### DIFF
--- a/.github/workflows/ci-go-tests.yaml
+++ b/.github/workflows/ci-go-tests.yaml
@@ -3,6 +3,8 @@ name: Test Go
 on:
   pull_request:
     branches: [ master ]
+    paths:
+      - 'go/**'
 
 jobs:
   test:


### PR DESCRIPTION
I think this might be a good addition... will only run go tests when there are go changes