### PR TITLE
Fix typo in brew bump

### DIFF
--- a/.github/workflows/bump-brew-formula.yml
+++ b/.github/workflows/bump-brew-formula.yml
@@ -16,7 +16,7 @@ jobs:
           formula-name: dolt
           homebrew-tap: Homebrew/homebrew-core
           base-branch: release
-          download-url: ${{format('https://github.com/dolthub/dolt/archive/v{0}.tar.gz', steps.get_version.outputs.VERSION)}}
+          download-url: ${{format('https://github.com/dolthub/dolt/archive/{0}.tar.gz', steps.get_version.outputs.VERSION)}}
           commit-message: ${{format('dolt {0}', steps.get_version.outputs.VERSION)}}
         env:
           COMMITTER_TOKEN: ${{secrets.HOMEBREW_GITHUB_TOKEN}}


### PR DESCRIPTION
From failed run on most recent release:
<img width="1123" alt="Screen Shot 2020-11-05 at 6 29 02 PM" src="https://user-images.githubusercontent.com/1596348/98319208-1b16cf80-1f95-11eb-8bd1-164be07adee1.png">
