### PR TITLE
Added dolt_version()

### DIFF
--- a/bats/sql.bats
+++ b/bats/sql.bats
@@ -743,3 +743,9 @@ SQL
     [ $status -eq 0 ]
     [[ "$output" =~ "2020-02-17 00:00:00" ]] || false
 }
+
+@test "dolt_version() func" {
+    SQL=$(dolt sql -q 'select dolt_version() from dual;' -r csv | tail -n 1)
+    CLI=$(dolt version | cut -f 3 -d ' ')
+    [ "$SQL" == "$CLI" ]
+}

--- a/go/cmd/dolt/commands/sqlserver/serverconfig.go
+++ b/go/cmd/dolt/commands/sqlserver/serverconfig.go
@@ -24,8 +24,6 @@ import (
 // LogLevel defines the available levels of logging for the server.
 type LogLevel string
 
-var CliVersion = "test"
-
 const (
 	LogLevel_Trace   LogLevel = "trace"
 	LogLevel_Debug   LogLevel = "debug"

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -36,6 +36,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dfunctions"
 	"github.com/dolthub/dolt/go/libraries/events"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/store/util/tempfiles"
@@ -85,7 +86,7 @@ var doltCommand = cli.NewSubCommandHandler("dolt", "it's git for data", []cli.Co
 
 func init() {
 	dumpDocsCommand.DoltCommand = doltCommand
-	sqlserver.CliVersion = Version
+	dfunctions.VersionString = Version
 }
 
 const chdirFlag = "--chdir"

--- a/go/libraries/doltcore/sqle/dfunctions/init.go
+++ b/go/libraries/doltcore/sqle/dfunctions/init.go
@@ -21,4 +21,5 @@ var DoltFunctions = []sql.Function{
 	sql.Function1{Name: CommitFuncName, Fn: NewCommitFunc},
 	sql.Function1{Name: MergeFuncName, Fn: NewMergeFunc},
 	sql.Function1{Name: resetFuncName, Fn: NewDoltResetFunc},
+	sql.Function0{Name: VersionFuncName, Fn: NewVersion},
 }

--- a/go/libraries/doltcore/sqle/dfunctions/version.go
+++ b/go/libraries/doltcore/sqle/dfunctions/version.go
@@ -1,0 +1,66 @@
+// Copyright 2020 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dfunctions
+
+import "github.com/dolthub/go-mysql-server/sql"
+
+const VersionFuncName = "dolt_version"
+
+var VersionString = "SET_BY_INIT"
+
+type Version struct{}
+
+// NewVersion creates a new Version expression.
+func NewVersion() sql.Expression {
+	return &Version{}
+}
+
+// Children implements the Expression interface.
+func (*Version) Children() []sql.Expression {
+	return nil
+}
+
+// Eval implements the Expression interface.
+func (*Version) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	return VersionString, nil
+}
+
+// IsNullable implements the Expression interface.
+func (*Version) IsNullable() bool {
+	return false
+}
+
+// Resolved implements the Expression interface.
+func (*Version) Resolved() bool {
+	return true
+}
+
+// String implements the Stringer interface.
+func (*Version) String() string {
+	return "DOLT_VERSION"
+}
+
+// Type implements the Expression interface.
+func (*Version) Type() sql.Type {
+	return sql.Text
+}
+
+// WithChildren implements the Expression interface.
+func (v *Version) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(v, len(children), 0)
+	}
+	return NewVersion(), nil
+}


### PR DESCRIPTION
As `version()` is used to emulate the target MySQL version, I've added `dolt_version()` so that one may specifically query the dolt version.