### PR TITLE
Temporary parallelism implementation on indexes

### DIFF
--- a/go/libraries/doltcore/sqle/index_lookup.go
+++ b/go/libraries/doltcore/sqle/index_lookup.go
@@ -134,13 +134,9 @@ func (il *doltIndexLookup) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	for i, lookupRange := range il.ranges {
 		readRanges[i] = lookupRange.ToReadRange()
 	}
-	return &indexLookupRowIterAdapter{
-		idx: il.idx,
-		keyIter: &doltIndexKeyIter{
-			indexMapIter: noms.NewNomsRangeReader(il.idx.IndexSchema(), il.idx.IndexRowData(), readRanges),
-		},
-		ctx: ctx,
-	}, nil
+	return NewIndexLookupRowIterAdapter(ctx, il.idx, &doltIndexKeyIter{
+		indexMapIter: noms.NewNomsRangeReader(il.idx.IndexSchema(), il.idx.IndexRowData(), readRanges),
+	}), nil
 }
 
 type doltIndexKeyIter struct {

--- a/go/libraries/doltcore/sqle/index_row_iter.go
+++ b/go/libraries/doltcore/sqle/index_row_iter.go
@@ -15,50 +15,138 @@
 package sqle
 
 import (
+	"context"
 	"io"
-
-	"github.com/dolthub/go-mysql-server/sql"
+	"runtime"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlutil"
+	"github.com/dolthub/dolt/go/libraries/utils/async"
 	"github.com/dolthub/dolt/go/store/types"
+
+	"github.com/dolthub/go-mysql-server/sql"
 )
 
 type indexLookupRowIterAdapter struct {
 	idx     DoltIndex
 	keyIter IndexLookupKeyIterator
 	ctx     *sql.Context
+	rowChan chan sql.Row
+	err     error
+	buffer  []sql.Row
 }
 
-func (i *indexLookupRowIterAdapter) Next() (sql.Row, error) {
-	key, err := i.keyIter.NextKey(i.ctx)
-	if err != nil {
-		return nil, err
+type keyPos struct {
+	key      row.TaggedValues
+	position int
+}
+
+// NewIndexLookupRowIterAdapter returns a new indexLookupRowIterAdapter.
+func NewIndexLookupRowIterAdapter(ctx *sql.Context, idx DoltIndex, keyIter IndexLookupKeyIterator) *indexLookupRowIterAdapter {
+	iter := &indexLookupRowIterAdapter{
+		idx:     idx,
+		keyIter: keyIter,
+		ctx:     ctx,
+		rowChan: make(chan sql.Row, runtime.NumCPU()*10),
+		buffer:  make([]sql.Row, runtime.NumCPU()*5),
 	}
+	go iter.queueRows()
+	return iter
+}
+
+// Next returns the next row from the iterator.
+func (i *indexLookupRowIterAdapter) Next() (sql.Row, error) {
+	r, ok := <-i.rowChan
+	if !ok { // Only closes when we are finished iterating over the keys or an error has occurred.
+		if i.err != nil {
+			return nil, i.err
+		}
+		return nil, io.EOF
+	}
+	return r, nil
+}
+
+func (*indexLookupRowIterAdapter) Close() error {
+	return nil
+}
+
+// queueRows reads each key from the key iterator and runs a goroutine for each logical processor to process the keys.
+func (i *indexLookupRowIterAdapter) queueRows() {
+	defer close(i.rowChan)
+	exec := async.NewActionExecutor(i.ctx, i.processKey, uint32(runtime.NumCPU()), 0)
+
+	var err error
+	for {
+		shouldBreak := false
+		pos := 0
+		for ; pos < len(i.buffer); pos++ {
+			var indexKey row.TaggedValues
+			indexKey, err = i.keyIter.NextKey(i.ctx)
+			if err != nil {
+				break
+			}
+			exec.Execute(keyPos{
+				key:      indexKey,
+				position: pos,
+			})
+		}
+		if err != nil {
+			if err == io.EOF {
+				shouldBreak = true
+			} else {
+				i.err = err
+				return
+			}
+		}
+		i.err = exec.WaitForEmpty()
+		if err != nil {
+			if err == io.EOF {
+				shouldBreak = true
+			} else {
+				i.err = err
+				return
+			}
+		}
+		for idx, r := range i.buffer {
+			if idx == pos {
+				break
+			}
+			i.rowChan <- r
+		}
+		if shouldBreak {
+			break
+		}
+	}
+}
+
+// processKey is called within queueRows and processes each key, sending the resulting row to the row channel.
+func (i *indexLookupRowIterAdapter) processKey(_ context.Context, valInt interface{}) error {
+	val := valInt.(keyPos)
 
 	tableData := i.idx.TableData()
-	pkTuple := key.NomsTupleForPKCols(tableData.Format(), i.idx.Schema().GetPKCols())
+	pkTuple := val.key.NomsTupleForPKCols(tableData.Format(), i.idx.Schema().GetPKCols())
 	pkTupleVal, err := pkTuple.Value(i.ctx)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	fieldsVal, _, err := tableData.MaybeGet(i.ctx, pkTupleVal)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if fieldsVal == nil {
-		return nil, io.EOF
+		return nil
 	}
 
 	r, err := row.FromNoms(i.idx.Schema(), pkTupleVal.(types.Tuple), fieldsVal.(types.Tuple))
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return sqlutil.DoltRowToSqlRow(r, i.idx.Schema())
-}
-
-func (*indexLookupRowIterAdapter) Close() error {
+	sqlRow, err := sqlutil.DoltRowToSqlRow(r, i.idx.Schema())
+	if err != nil {
+		return err
+	}
+	i.buffer[val.position] = sqlRow
 	return nil
 }


### PR DESCRIPTION
A better implementation would make use of partitions of some form. My current idea is to split up the ranges so that each partition handles a subsection of a range, however I'd likely rewrite a portion of the ranges to facilitate this, along with some additions to the Value types (such as a new interface). In the meantime, this is a rather quick and dirty implementation of parallelizing reads on an index so that queries don't come to a standstill when adding an index.

I initially had a faster and less ugly implementation, but it completely changed the order of the output (still correct since order is arbitrary without an `ORDER BY` clause). Instead of rewriting every test, I changed it so that the old order is preserved by writing into a buffer. It's still far, far faster than the old single-threaded implementation. The following issue now has indexes performing faster than the full table scan on my machine: https://github.com/dolthub/dolt/issues/1005. Still not as fast as it could be, but it's no longer many times slower. Of note, running with `GOMAXPROCS=1` takes roughly the same time as before.

I didn't add any tests since this is a fairly deep change, and is touched by every single test above it that uses indexes.