### PR TITLE
Add -a flag to cli and DOLT_COMMIT

### DIFF
--- a/bats/multiple-tables.bats
+++ b/bats/multiple-tables.bats
@@ -98,6 +98,18 @@ teardown() {
     [[ ! "$output" =~ "Untracked files" ]] || false
 }
 
+@test "dolt commit with -a flag adds all changes" {
+    dolt sql -q "insert into test1 values (0, 1, 2, 3, 4, 5)"
+    dolt sql -q "insert into test2 values (0, 1, 2, 3, 4, 5)"
+    run dolt commit -a -m "Commit1"
+    [[ "$output" =~ "Commit1" ]] || false
+
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "nothing to commit, working tree clean" ]] || false
+    [[ ! "$output" =~ "Untracked files" ]] || false
+}
+
 @test "dolt reset . resets all tables" {
     dolt add --all
     run dolt status

--- a/bats/sql-commit.bats
+++ b/bats/sql-commit.bats
@@ -26,6 +26,11 @@ teardown() {
     [ $status -eq 0 ]
     DCOMMIT=$output
 
+    # Check that everything was added
+    run dolt diff
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+
     run dolt log
     [ $status -eq 0 ]
     [[ "$output" =~ "Commit1" ]] || false
@@ -65,10 +70,14 @@ teardown() {
     dolt config --global --unset user.name
     dolt config --global --unset user.email
 
-    dolt add .
     run dolt sql -q "SELECT DOLT_COMMIT('-a', '-m', 'Commit1', '--author', 'John Doe <john@doe.com>')"
     [ "$status" -eq 0 ]
     DCOMMIT=$output
+
+    # Check that everything was added
+    run dolt diff
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
 
     run dolt log
     [ "$status" -eq 0 ]

--- a/bats/sql-commit.bats
+++ b/bats/sql-commit.bats
@@ -21,34 +21,10 @@ teardown() {
     teardown_common
 }
 
-@test "DOLT_COMMIT with all flag, message and author" {
-    run dolt sql -q "SELECT DOLT_COMMIT('-a', '-m', 'Commit1', '--author', 'John Doe <john@doe.com>')"
-    [ $status -eq 0 ]
-    DCOMMIT=$output
-
-    # Check that everything was added
-    run dolt diff
-    [ "$status" -eq 0 ]
-    [ "$output" = "" ]
-
-    run dolt log
-    [ $status -eq 0 ]
-    [[ "$output" =~ "Commit1" ]] || false
-    regex='John Doe <john@doe.com>'
-    [[ "$output" =~ "$regex" ]] || false
-
-    # Check that dolt_log has the same hash as the output of DOLT_COMMIT
-    run dolt sql -q "SELECT commit_hash from dolt_log LIMIT 1"
-    [ $status -eq 0 ]
-    [[ "$output" =~ "$DCOMMIT" ]] || false
-
-    run dolt sql -q "SELECT * from dolt_commits ORDER BY Date DESC;"
-    [ $status -eq 0 ]
-    [[ "$output" =~ "Commit1" ]] || false
-}
-
 @test "DOLT_COMMIT without a message throws error" {
-    run dolt sql -q "SELECT DOLT_COMMIT('-a')"
+    dolt add .
+
+    run dolt sql -q "SELECT DOLT_COMMIT()"
     [ $status -eq 1 ]
     run dolt log
     [ $status -eq 0 ]
@@ -81,6 +57,32 @@ teardown() {
     [[ "$output" =~ "Commit1" ]] || false
     regex='Bats Tests <bats@email.fake>'
     [[ "$output" =~ "$regex" ]] || false
+}
+
+@test "DOLT_COMMIT with all flag, message and author" {
+    run dolt sql -q "SELECT DOLT_COMMIT('-a', '-m', 'Commit1', '--author', 'John Doe <john@doe.com>')"
+    [ $status -eq 0 ]
+    DCOMMIT=$output
+
+    # Check that everything was added
+    run dolt diff
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+
+    run dolt log
+    [ $status -eq 0 ]
+    [[ "$output" =~ "Commit1" ]] || false
+    regex='John Doe <john@doe.com>'
+    [[ "$output" =~ "$regex" ]] || false
+
+    # Check that dolt_log has the same hash as the output of DOLT_COMMIT
+    run dolt sql -q "SELECT commit_hash from dolt_log LIMIT 1"
+    [ $status -eq 0 ]
+    [[ "$output" =~ "$DCOMMIT" ]] || false
+
+    run dolt sql -q "SELECT * from dolt_commits ORDER BY Date DESC;"
+    [ $status -eq 0 ]
+    [[ "$output" =~ "Commit1" ]] || false
 }
 
 @test "DOLT_COMMIT works with --author without config variables set" {

--- a/bats/sql-commit.bats
+++ b/bats/sql-commit.bats
@@ -21,7 +21,7 @@ teardown() {
     teardown_common
 }
 
-@test "DOLT_COMMIT with a message and author" {
+@test "DOLT_COMMIT with all flag, message and author" {
     run dolt sql -q "SELECT DOLT_COMMIT('-a', '-m', 'Commit1', '--author', 'John Doe <john@doe.com>')"
     [ $status -eq 0 ]
     DCOMMIT=$output
@@ -57,8 +57,25 @@ teardown() {
 }
 
 @test "DOLT_COMMIT with just a message reads session parameters" {
-    run dolt sql -q "SELECT DOLT_COMMIT('-a', '-m', 'Commit1')"
+    dolt add .
+
+    run dolt sql -q "SELECT DOLT_COMMIT('-m', 'Commit1')"
     [ $status -eq 0 ]
+    run dolt log
+    [ $status -eq 0 ]
+    [[ "$output" =~ "Commit1" ]] || false
+    regex='Bats Tests <bats@email.fake>'
+    [[ "$output" =~ "$regex" ]] || false
+}
+
+@test "DOLT_COMMIT with the all flag performs properly" {
+    run dolt sql -q "SELECT DOLT_COMMIT('-a', '-m', 'Commit1')"
+
+    # Check that everything was added
+    run dolt diff
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+
     run dolt log
     [ $status -eq 0 ]
     [[ "$output" =~ "Commit1" ]] || false
@@ -70,14 +87,11 @@ teardown() {
     dolt config --global --unset user.name
     dolt config --global --unset user.email
 
-    run dolt sql -q "SELECT DOLT_COMMIT('-a', '-m', 'Commit1', '--author', 'John Doe <john@doe.com>')"
+    dolt add .
+
+    run dolt sql -q "SELECT DOLT_COMMIT('-m', 'Commit1', '--author', 'John Doe <john@doe.com>')"
     [ "$status" -eq 0 ]
     DCOMMIT=$output
-
-    # Check that everything was added
-    run dolt diff
-    [ "$status" -eq 0 ]
-    [ "$output" = "" ]
 
     run dolt log
     [ "$status" -eq 0 ]

--- a/bats/sql-commit.bats
+++ b/bats/sql-commit.bats
@@ -15,7 +15,6 @@ SQL
 DELETE FROM test WHERE pk = 0;
 INSERT INTO test VALUES (3);
 SQL
-    dolt add .
 }
 
 teardown() {
@@ -23,7 +22,7 @@ teardown() {
 }
 
 @test "DOLT_COMMIT with a message and author" {
-    run dolt sql -q "SELECT DOLT_COMMIT('-m', 'Commit1', '--author', 'John Doe <john@doe.com>')"
+    run dolt sql -q "SELECT DOLT_COMMIT('-a', '-m', 'Commit1', '--author', 'John Doe <john@doe.com>')"
     [ $status -eq 0 ]
     DCOMMIT=$output
 
@@ -44,7 +43,7 @@ teardown() {
 }
 
 @test "DOLT_COMMIT without a message throws error" {
-    run dolt sql -q "SELECT DOLT_COMMIT()"
+    run dolt sql -q "SELECT DOLT_COMMIT('-a')"
     [ $status -eq 1 ]
     run dolt log
     [ $status -eq 0 ]
@@ -53,7 +52,7 @@ teardown() {
 }
 
 @test "DOLT_COMMIT with just a message reads session parameters" {
-    run dolt sql -q "SELECT DOLT_COMMIT('-m', 'Commit1')"
+    run dolt sql -q "SELECT DOLT_COMMIT('-a', '-m', 'Commit1')"
     [ $status -eq 0 ]
     run dolt log
     [ $status -eq 0 ]
@@ -67,7 +66,7 @@ teardown() {
     dolt config --global --unset user.email
 
     dolt add .
-    run dolt sql -q "SELECT DOLT_COMMIT('-m', 'Commit1', '--author', 'John Doe <john@doe.com>')"
+    run dolt sql -q "SELECT DOLT_COMMIT('-a', '-m', 'Commit1', '--author', 'John Doe <john@doe.com>')"
     [ "$status" -eq 0 ]
     DCOMMIT=$output
 

--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -88,6 +88,6 @@ func CreateCommitArgParser() *argparser.ArgParser {
 	ap.SupportsString(DateParam, "", "date", "Specify the date used in the commit. If not specified the current system time is used.")
 	ap.SupportsFlag(ForceFlag, "f", "Ignores any foreign key warnings and proceeds with the commit.")
 	ap.SupportsString(AuthorParam, "", "author", "Specify an explicit author using the standard A U Thor <author@example.com> format.")
-	ap.SupportsString(AllFlag, "a", "all", "Adds all edited files in working to staged.")
+	ap.SupportsFlag(AllFlag, "a", "Adds all edited files in working to staged.")
 	return ap
 }

--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -77,6 +77,7 @@ const (
 	CommitMessageArg = "message"
 	AuthorParam      = "author"
 	ForceFlag        = "force"
+	AllFlag		     = "all"
 )
 
 // Creates the argparser shared dolt commit cli and DOLT_COMMIT.
@@ -87,5 +88,6 @@ func CreateCommitArgParser() *argparser.ArgParser {
 	ap.SupportsString(DateParam, "", "date", "Specify the date used in the commit. If not specified the current system time is used.")
 	ap.SupportsFlag(ForceFlag, "f", "Ignores any foreign key warnings and proceeds with the commit.")
 	ap.SupportsString(AuthorParam, "", "author", "Specify an explicit author using the standard A U Thor <author@example.com> format.")
+	ap.SupportsString(AllFlag, "a", "all", "Adds all edited files in working to staged.")
 	return ap
 }

--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -77,7 +77,7 @@ const (
 	CommitMessageArg = "message"
 	AuthorParam      = "author"
 	ForceFlag        = "force"
-	AllFlag		     = "all"
+	AllFlag          = "all"
 )
 
 // Creates the argparser shared dolt commit cli and DOLT_COMMIT.

--- a/go/cmd/dolt/commands/add.go
+++ b/go/cmd/dolt/commands/add.go
@@ -89,7 +89,7 @@ func (cmd AddCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 	if apr.NArg() == 0 && !allFlag {
 		cli.Println("Nothing specified, nothing added.\n Maybe you wanted to say 'dolt add .'?")
 	} else if allFlag || apr.NArg() == 1 && apr.Arg(0) == "." {
-		err = actions.StageAllTables(ctx, dEnv)
+		err = actions.StageAllTables(ctx, dEnv.DoltDB, dEnv.RepoStateReader(), dEnv.RepoStateWriter())
 	} else {
 		err = actions.StageTables(ctx, dEnv, apr.Args())
 	}

--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -78,7 +78,7 @@ func (cmd CommitCmd) Exec(ctx context.Context, commandStr string, args []string,
 
 	var err error
 	if allFlag {
-		err = actions.StageAllTables(ctx, dEnv)
+		err = actions.StageAllTables(ctx, dEnv.DoltDB, dEnv.RepoStateReader(), dEnv.RepoStateWriter())
 	}
 
 	if err != nil {

--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -73,9 +73,19 @@ func (cmd CommitCmd) Exec(ctx context.Context, commandStr string, args []string,
 	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, commitDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
-	var name, email string
-	var err error
+	// Check if the -all param is provided. Stage all tables if so.
+	allFlag := apr.Contains(cli.AllFlag)
 
+	var err error
+	if allFlag {
+		err = actions.StageAllTables(ctx, dEnv)
+	}
+
+	if err != nil {
+		return handleCommitErr(ctx, dEnv, err, help)
+	}
+
+	var name, email string
 	// Check if the author flag is provided otherwise get the name and email stored in configs
 	if authorStr, ok := apr.GetValue(cli.AuthorParam); ok {
 		name, email, err = cli.ParseAuthor(authorStr)

--- a/go/libraries/doltcore/diff/diffs.go
+++ b/go/libraries/doltcore/diff/diffs.go
@@ -142,7 +142,7 @@ func GetDocDiffs(ctx context.Context, ddb *doltdb.DoltDB, rsr env.RepoStateReade
 		return nil, nil, err
 	}
 
-	workingRoot, err := env.WorkingRoot(ctx, ddb, rsr)
+	workingRoot, err := rsr.WorkingRoot(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -152,12 +152,12 @@ func GetDocDiffs(ctx context.Context, ddb *doltdb.DoltDB, rsr env.RepoStateReade
 		return nil, nil, err
 	}
 
-	headRoot, err := env.HeadRoot(ctx, ddb, rsr)
+	headRoot, err := rsr.HeadRoot(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	stagedRoot, err := env.StagedRoot(ctx, ddb, rsr)
+	stagedRoot, err := rsr.StagedRoot(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -289,17 +289,17 @@ func GetTableDeltas(ctx context.Context, fromRoot, toRoot *doltdb.RootValue) (de
 }
 
 func GetStagedUnstagedTableDeltas(ctx context.Context, ddb *doltdb.DoltDB, rsr env.RepoStateReader) (staged, unstaged []TableDelta, err error) {
-	headRoot, err := env.HeadRoot(ctx, ddb, rsr)
+	headRoot, err := rsr.HeadRoot(ctx)
 	if err != nil {
 		return nil, nil, RootValueUnreadable{HeadRoot, err}
 	}
 
-	stagedRoot, err := env.StagedRoot(ctx, ddb, rsr)
+	stagedRoot, err := rsr.StagedRoot(ctx)
 	if err != nil {
 		return nil, nil, RootValueUnreadable{StagedRoot, err}
 	}
 
-	workingRoot, err := env.WorkingRoot(ctx, ddb, rsr)
+	workingRoot, err := rsr.WorkingRoot(ctx)
 	if err != nil {
 		return nil, nil, RootValueUnreadable{WorkingRoot, err}
 	}

--- a/go/libraries/doltcore/dtestutils/testcommands/command.go
+++ b/go/libraries/doltcore/dtestutils/testcommands/command.go
@@ -45,7 +45,7 @@ func (a StageAll) CommandString() string { return "stage_all" }
 
 // Exec executes a StageAll command on a test dolt environment.
 func (a StageAll) Exec(t *testing.T, dEnv *env.DoltEnv) error {
-	return actions.StageAllTables(context.Background(), dEnv)
+	return actions.StageAllTables(context.Background(), dEnv.DoltDB, dEnv.RepoStateReader(), dEnv.RepoStateWriter())
 }
 
 type CommitStaged struct {
@@ -84,7 +84,7 @@ func (c CommitAll) CommandString() string { return fmt.Sprintf("commit: %s", c.M
 
 // Exec executes a CommitAll command on a test dolt environment.
 func (c CommitAll) Exec(t *testing.T, dEnv *env.DoltEnv) error {
-	err := actions.StageAllTables(context.Background(), dEnv)
+	err := actions.StageAllTables(context.Background(), dEnv.DoltDB, dEnv.RepoStateReader(), dEnv.RepoStateWriter())
 	require.NoError(t, err)
 
 	name, email, err := actions.GetNameAndEmail(dEnv.Config)

--- a/go/libraries/doltcore/env/actions/commit.go
+++ b/go/libraries/doltcore/env/actions/commit.go
@@ -91,7 +91,7 @@ func CommitStaged(ctx context.Context, ddb *doltdb.DoltDB, rsr env.RepoStateRead
 
 	var mergeCmSpec []*doltdb.CommitSpec
 	if rsr.IsMergeActive() {
-		root, err := env.WorkingRoot(ctx, ddb, rsr)
+		root, err := rsr.WorkingRoot(ctx)
 		if err != nil {
 			return "", err
 		}
@@ -112,7 +112,7 @@ func CommitStaged(ctx context.Context, ddb *doltdb.DoltDB, rsr env.RepoStateRead
 		mergeCmSpec = []*doltdb.CommitSpec{spec}
 	}
 
-	srt, err := env.StagedRoot(ctx, ddb, rsr)
+	srt, err := rsr.StagedRoot(ctx)
 
 	if err != nil {
 		return "", err
@@ -137,7 +137,7 @@ func CommitStaged(ctx context.Context, ddb *doltdb.DoltDB, rsr env.RepoStateRead
 		return "", err
 	}
 
-	wrt, err := env.WorkingRoot(ctx, ddb, rsr)
+	wrt, err := rsr.WorkingRoot(ctx)
 
 	if err != nil {
 		return "", err
@@ -149,7 +149,7 @@ func CommitStaged(ctx context.Context, ddb *doltdb.DoltDB, rsr env.RepoStateRead
 		return "", err
 	}
 
-	err = env.UpdateWorkingRoot(ctx, ddb, rsw, wrt)
+	err = rsw.UpdateWorkingRoot(ctx, wrt)
 
 	if err != nil {
 		return "", err

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -419,7 +419,7 @@ type repoStateWriter struct {
 	dEnv *DoltEnv
 }
 
-func  (r *repoStateWriter) SetStagedHash(ctx context.Context, h hash.Hash) error {
+func (r *repoStateWriter) SetStagedHash(ctx context.Context, h hash.Hash) error {
 	r.dEnv.RepoState.Staged = h.String()
 	err := r.dEnv.RepoState.Save(r.dEnv.FS)
 

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -399,6 +399,18 @@ func (r *repoStateReader) GetAllValidDocDetails() ([]doltdb.DocDetails, error) {
 	return r.dEnv.GetAllValidDocDetails()
 }
 
+func (r *repoStateReader) WorkingRoot(ctx context.Context) (*doltdb.RootValue, error) {
+	return r.dEnv.WorkingRoot(ctx)
+}
+
+func (r *repoStateReader) HeadRoot(ctx context.Context) (*doltdb.RootValue, error) {
+	return r.dEnv.HeadRoot(ctx)
+}
+
+func (r *repoStateReader) StagedRoot(ctx context.Context) (*doltdb.RootValue, error) {
+	return r.dEnv.StagedRoot(ctx)
+}
+
 func (dEnv *DoltEnv) RepoStateReader() RepoStateReader {
 	return &repoStateReader{dEnv}
 }
@@ -420,6 +432,10 @@ func (r *repoStateWriter) SetWorkingHash(ctx context.Context, h hash.Hash) error
 
 func (r *repoStateWriter) UpdateStagedRoot(ctx context.Context, newRoot *doltdb.RootValue) (hash.Hash, error) {
 	return r.dEnv.UpdateStagedRoot(ctx, newRoot)
+}
+
+func (r *repoStateWriter) UpdateWorkingRoot(ctx context.Context, newRoot *doltdb.RootValue) error {
+	return r.dEnv.UpdateWorkingRoot(ctx, newRoot)
 }
 
 func (r *repoStateWriter) ClearMerge() error {

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -419,6 +419,17 @@ type repoStateWriter struct {
 	dEnv *DoltEnv
 }
 
+func  (r *repoStateWriter) SetStagedHash(ctx context.Context, h hash.Hash) error {
+	r.dEnv.RepoState.Staged = h.String()
+	err := r.dEnv.RepoState.Save(r.dEnv.FS)
+
+	if err != nil {
+		return ErrStateUpdate
+	}
+
+	return nil
+}
+
 func (r *repoStateWriter) SetWorkingHash(ctx context.Context, h hash.Hash) error {
 	r.dEnv.RepoState.Working = h.String()
 	err := r.dEnv.RepoState.Save(r.dEnv.FS)
@@ -440,6 +451,14 @@ func (r *repoStateWriter) UpdateWorkingRoot(ctx context.Context, newRoot *doltdb
 
 func (r *repoStateWriter) ClearMerge() error {
 	return r.dEnv.RepoState.ClearMerge(r.dEnv.FS)
+}
+
+func (r *repoStateWriter) PutDocsToWorking(ctx context.Context, docDetails []doltdb.DocDetails) error {
+	return r.dEnv.PutDocsToWorking(ctx, docDetails)
+}
+
+func (r *repoStateWriter) ResetWorkingDocsToStagedDos(ctx context.Context) error {
+	return r.dEnv.ResetWorkingDocsToStagedDocs(ctx)
 }
 
 func (dEnv *DoltEnv) RepoStateWriter() RepoStateWriter {

--- a/go/libraries/doltcore/env/repo_state.go
+++ b/go/libraries/doltcore/env/repo_state.go
@@ -40,11 +40,13 @@ type RepoStateReader interface {
 type RepoStateWriter interface {
 	// SetCWBHeadRef(context.Context, ref.DoltRef) error
 	// SetCWBHeadSpec(context.Context, *doltdb.CommitSpec) error
-	//	SetStagedHash(context.Context, hash.Hash) error
+	SetStagedHash(context.Context, hash.Hash) error
 	SetWorkingHash(context.Context, hash.Hash) error
 	UpdateStagedRoot(ctx context.Context, newRoot *doltdb.RootValue) (hash.Hash, error)
 	ClearMerge() error
 	UpdateWorkingRoot(ctx context.Context, newRoot *doltdb.RootValue) error
+	PutDocsToWorking(ctx context.Context, docDetails []doltdb.DocDetails) error
+	ResetWorkingDocsToStagedDos(ctx context.Context) error
 }
 
 type BranchConfig struct {

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_commit.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_commit.go
@@ -81,9 +81,16 @@ func (d DoltCommitFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error)
 
 	apr := cli.ParseArgs(ap, args, nil)
 
+	// Check if the -all param is provided. Stage all tables if so.
+	allFlag := apr.Contains(cli.AllFlag)
+
+	var err error
+	if allFlag {
+		err = actions.StageAllTables(ctx, ddb, rsr, rsw)
+	}
+
 	// Parse the author flag. Return an error if not.
 	var name, email string
-	var err error
 	if authorStr, ok := apr.GetValue(cli.AuthorParam); ok {
 		name, email, err = cli.ParseAuthor(authorStr)
 		if err != nil {

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_commit.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_commit.go
@@ -89,6 +89,10 @@ func (d DoltCommitFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error)
 		err = actions.StageAllTables(ctx, ddb, rsr, rsw)
 	}
 
+	if err != nil {
+		return nil, fmt.Errorf(err.Error())
+	}
+
 	// Parse the author flag. Return an error if not.
 	var name, email string
 	if authorStr, ok := apr.GetValue(cli.AuthorParam); ok {


### PR DESCRIPTION
This pr adds a `-a` flag to `dolt commit` and `DOLT_COMMIT`. It stages all tables. 

It also cleans up some of the previous work done in #1056 by removing all method handlers in repo_state and moving them to the RepoStateReader and RepoStateWriter

It does not refactor the RSR/RSW interfaces in environment.go. This will be done in a subsequent pr. 