### PR TITLE
go/libraries/doltcore/{doltdb,table}: remove row access methods from doltdb.Table

### DIFF
--- a/go/libraries/doltcore/doltdb/dolt_docs.go
+++ b/go/libraries/doltcore/doltdb/dolt_docs.go
@@ -1,0 +1,43 @@
+// Copyright 2020 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package doltdb
+
+import (
+	"context"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/row"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/dolt/go/store/types"
+)
+
+func DocTblKeyFromName(fmt *types.NomsBinFormat, name string) (types.Tuple, error) {
+	return types.NewTuple(fmt, types.Uint(DocNameTag), types.String(name))
+}
+
+func getDocRow(ctx context.Context, docTbl *Table, sch schema.Schema, key types.Tuple) (r row.Row, ok bool, err error) {
+	rowMap, err := docTbl.GetRowData(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+
+	var fields types.Value
+	fields, ok, err = rowMap.MaybeGet(ctx, key)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+
+	r, err = row.FromNoms(sch, key, fields.(types.Tuple))
+	return
+}

--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -1366,11 +1366,12 @@ func addValuesToDocs(ctx context.Context, tbl *Table, sch *schema.Schema, docDet
 // AddValueToDocFromTbl updates the Value field of a docDetail using the provided table and schema.
 func AddValueToDocFromTbl(ctx context.Context, tbl *Table, sch *schema.Schema, docDetail DocDetails) (DocDetails, error) {
 	if tbl != nil && sch != nil {
-		pkTaggedVal := row.TaggedValues{
-			DocNameTag: types.String(docDetail.DocPk),
+		key, err := DocTblKeyFromName(tbl.Format(), docDetail.DocPk)
+		if err != nil {
+			return DocDetails{}, err
 		}
 
-		docRow, ok, err := tbl.GetRowByPKVals(ctx, pkTaggedVal, *sch)
+		docRow, ok, err := getDocRow(ctx, tbl, *sch, key)
 		if err != nil {
 			return DocDetails{}, err
 		}
@@ -1390,11 +1391,12 @@ func AddValueToDocFromTbl(ctx context.Context, tbl *Table, sch *schema.Schema, d
 // AddNewerTextToDocFromTbl updates the NewerText field of a docDetail using the provided table and schema.
 func AddNewerTextToDocFromTbl(ctx context.Context, tbl *Table, sch *schema.Schema, doc DocDetails) (DocDetails, error) {
 	if tbl != nil && sch != nil {
-		pkTaggedVal := row.TaggedValues{
-			DocNameTag: types.String(doc.DocPk),
+		key, err := DocTblKeyFromName(tbl.Format(), doc.DocPk)
+		if err != nil {
+			return DocDetails{}, err
 		}
 
-		docRow, ok, err := tbl.GetRowByPKVals(ctx, pkTaggedVal, *sch)
+		docRow, ok, err := getDocRow(ctx, tbl, *sch, key)
 		if err != nil {
 			return DocDetails{}, err
 		}

--- a/go/libraries/doltcore/doltdb/root_val_test.go
+++ b/go/libraries/doltcore/doltdb/root_val_test.go
@@ -136,7 +136,7 @@ func TestDocDiff(t *testing.T) {
 
 	// Create tbl1 with one license row
 	sch := createTestDocsSchema()
-	licRow := getDocRow(t, sch, LicensePk, types.String("license row"))
+	licRow := makeDocRow(t, sch, LicensePk, types.String("license row"))
 	m, _ := createTestRows(t, ddb.ValueReadWriter(), sch, []row.Row{licRow})
 	tbl1, err := createTestTable(ddb.ValueReadWriter(), sch, m)
 	assert.NoError(t, err)
@@ -154,7 +154,7 @@ func TestDocDiff(t *testing.T) {
 	}
 
 	// Create tbl2 with one readme row
-	readmeRow := getDocRow(t, sch, ReadmePk, types.String("readme row"))
+	readmeRow := makeDocRow(t, sch, ReadmePk, types.String("readme row"))
 	m, _ = createTestRows(t, ddb.ValueReadWriter(), sch, []row.Row{readmeRow})
 	tbl2, err := createTestTable(ddb.ValueReadWriter(), sch, m)
 	assert.NoError(t, err)
@@ -172,7 +172,7 @@ func TestDocDiff(t *testing.T) {
 	}
 
 	// Create tbl3 with 2 doc rows (readme, license)
-	readmeRowUpdated := getDocRow(t, sch, ReadmePk, types.String("a different readme"))
+	readmeRowUpdated := makeDocRow(t, sch, ReadmePk, types.String("a different readme"))
 	m, _ = createTestRows(t, ddb.ValueReadWriter(), sch, []row.Row{readmeRowUpdated, licRow})
 	tbl3, err := createTestTable(ddb.ValueReadWriter(), sch, m)
 	assert.NoError(t, err)
@@ -319,15 +319,15 @@ func createTestDocsSchema() schema.Schema {
 
 func getDocRows(t *testing.T, sch schema.Schema, rowVal types.Value) []row.Row {
 	rows := make([]row.Row, 2)
-	row1 := getDocRow(t, sch, LicensePk, rowVal)
+	row1 := makeDocRow(t, sch, LicensePk, rowVal)
 	rows[0] = row1
-	row2 := getDocRow(t, sch, ReadmePk, rowVal)
+	row2 := makeDocRow(t, sch, ReadmePk, rowVal)
 	rows[1] = row2
 
 	return rows
 }
 
-func getDocRow(t *testing.T, sch schema.Schema, pk string, rowVal types.Value) row.Row {
+func makeDocRow(t *testing.T, sch schema.Schema, pk string, rowVal types.Value) row.Row {
 	row, err := row.New(types.Format_7_18, sch, row.TaggedValues{
 		DocNameTag: types.String(pk),
 		DocTextTag: rowVal,

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -1039,7 +1039,12 @@ func updateDocsOnRoot(ctx context.Context, dEnv *DoltEnv, root *doltdb.RootValue
 
 	me := m.Edit()
 	for _, doc := range docDetails {
-		docRow, exists, err := docTbl.GetRowByPKVals(context.Background(), row.TaggedValues{doltdb.DocNameTag: types.String(doc.DocPk)}, sch)
+		key, err := doltdb.DocTblKeyFromName(docTbl.Format(), doc.DocPk)
+		if err != nil {
+			return nil, err
+		}
+
+		docRow, exists, err := table.GetRow(ctx, docTbl, sch, key)
 		if err != nil {
 			return nil, err
 		}

--- a/go/libraries/doltcore/mvdata/data_mover.go
+++ b/go/libraries/doltcore/mvdata/data_mover.go
@@ -211,7 +211,7 @@ func NameMapTransform(inSch schema.Schema, outSch schema.Schema, mapper rowconv.
 
 	transforms := pipeline.NewTransformCollection()
 	if !rconv.IdentityConverter {
-		nt := pipeline.NewNamedTransform("Mapping transform", rowconv.GetRowConvTransformFunc(rconv))
+		nt := pipeline.NewNamedTransform("Mapping transform", pipeline.GetRowConvTransformFunc(rconv))
 		transforms.AppendTransforms(nt)
 	}
 

--- a/go/libraries/doltcore/rowconv/row_converter_test.go
+++ b/go/libraries/doltcore/rowconv/row_converter_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
-	"github.com/dolthub/dolt/go/libraries/doltcore/table/pipeline"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/untyped"
 	"github.com/dolthub/dolt/go/store/types"
 )
@@ -67,8 +66,8 @@ func TestRowConverter(t *testing.T) {
 	})
 
 	assert.NoError(t, err)
-	results, _ := GetRowConvTransformFunc(rConv)(inRow, pipeline.ImmutableProperties{})
-	outData := results[0].RowData
+	outData, err := rConv.Convert(inRow)
+	assert.NoError(t, err)
 
 	destSch := mapping.DestSch
 	expected, err := row.New(types.Format_7_18, destSch, row.TaggedValues{
@@ -122,10 +121,9 @@ func TestSpecialBoolHandling(t *testing.T) {
 		1: types.String("true"),
 	})
 	require.NoError(t, err)
-	results, errStr := GetRowConvTransformFunc(rconv)(inRow, pipeline.ImmutableProperties{})
-	require.NotNil(t, results)
-	require.Empty(t, errStr)
-	outData := results[0].RowData
+	outData, err := rconv.Convert(inRow)
+	require.NoError(t, err)
+	require.NotNil(t, outData)
 
 	expected, err := row.New(types.Format_7_18, mapping.DestSch, row.TaggedValues{
 		0: types.Int(76),
@@ -136,7 +134,7 @@ func TestSpecialBoolHandling(t *testing.T) {
 
 	rconvNoHandle, err := NewRowConverter(mapping)
 	require.NoError(t, err)
-	results, errStr = GetRowConvTransformFunc(rconvNoHandle)(inRow, pipeline.ImmutableProperties{})
+	results, errStr := rconvNoHandle.Convert(inRow)
 	assert.Nil(t, results)
 	assert.NotEmpty(t, errStr)
 }

--- a/go/libraries/doltcore/schema/alterschema/addcolumn.go
+++ b/go/libraries/doltcore/schema/alterschema/addcolumn.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
@@ -72,13 +73,11 @@ func updateTableWithNewSchema(ctx context.Context, tblName string, tbl *doltdb.T
 	}
 
 	rowData, err := tbl.GetRowData(ctx)
-
 	if err != nil {
 		return nil, err
 	}
 
 	indexData, err := tbl.GetIndexData(ctx)
-
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +104,7 @@ func updateTableWithNewSchema(ctx context.Context, tblName string, tbl *doltdb.T
 	}
 
 	err = rowData.Iter(ctx, func(k, v types.Value) (stop bool, err error) {
-		oldRow, _, err := tbl.GetRow(ctx, k.(types.Tuple), newSchema)
+		oldRow, err := row.FromNoms(newSchema, k.(types.Tuple), v.(types.Tuple))
 		if err != nil {
 			return true, err
 		}

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -33,6 +33,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlutil"
+	"github.com/dolthub/dolt/go/libraries/doltcore/table"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
 	"github.com/dolthub/dolt/go/libraries/utils/set"
 	"github.com/dolthub/dolt/go/store/types"
@@ -882,7 +883,7 @@ func (t *AlterableDoltTable) CreateForeignKey(
 	if err != nil {
 		return err
 	}
-	err = foreignKey.ConstraintIsSatisfied(ctx, tableIndexData, refTableIndexData, tableIndex, refTableIndex)
+	err = table.ForeignKeyIsSatisfied(ctx, foreignKey, tableIndexData, refTableIndexData, tableIndex, refTableIndex)
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/table/access.go
+++ b/go/libraries/doltcore/table/access.go
@@ -1,0 +1,116 @@
+// Copyright 2020 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package table
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/row"
+	"github.com/dolthub/dolt/go/libraries/doltcore/rowconv"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/dolt/go/libraries/doltcore/table/typed/noms"
+	"github.com/dolthub/dolt/go/store/types"
+)
+
+// GetRow returns a row from |tbl| corresponding to |key| if it exists.
+func GetRow(ctx context.Context, tbl *doltdb.Table, sch schema.Schema, key types.Tuple) (r row.Row, ok bool, err error) {
+	rowMap, err := tbl.GetRowData(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+
+	var fields types.Value
+	fields, ok, err = rowMap.MaybeGet(ctx, key)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+
+	r, err = row.FromNoms(sch, key, fields.(types.Tuple))
+	return
+}
+
+// ForeignKeyIsSatisfied ensures that the foreign key is valid by comparing the index data from the given table
+// against the index data from the referenced table.
+func ForeignKeyIsSatisfied(ctx context.Context, fk doltdb.ForeignKey, childIdx, parentIdx types.Map, childDef, parentDef schema.Index) error {
+	if fk.ReferencedTableIndex != parentDef.Name() {
+		return fmt.Errorf("cannot validate data as wrong referenced index was given: expected `%s` but received `%s`",
+			fk.ReferencedTableIndex, parentDef.Name())
+	}
+
+	tagMap := make(map[uint64]uint64, len(fk.TableColumns))
+	for i, childTag := range fk.TableColumns {
+		tagMap[childTag] = fk.ReferencedTableColumns[i]
+	}
+
+	// FieldMappings ignore columns not in the tagMap
+	fm, err := rowconv.NewFieldMapping(childDef.Schema(), parentDef.Schema(), tagMap)
+	if err != nil {
+		return err
+	}
+
+	rc, err := rowconv.NewRowConverter(fm)
+	if err != nil {
+		return err
+	}
+
+	rdr, err := noms.NewNomsMapReader(ctx, childIdx, childDef.Schema())
+	if err != nil {
+		return err
+	}
+
+	for {
+		childIdxRow, err := rdr.ReadRow(ctx)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		parentIdxRow, err := rc.Convert(childIdxRow)
+		if err != nil {
+			return err
+		}
+		if row.IsEmpty(parentIdxRow) {
+			continue
+		}
+
+		partial, err := parentIdxRow.ReduceToIndexPartialKey(parentDef)
+		if err != nil {
+			return err
+		}
+
+		indexIter := noms.NewNomsRangeReader(parentDef.Schema(), parentIdx,
+			[]*noms.ReadRange{{Start: partial, Inclusive: true, Reverse: false, Check: func(tuple types.Tuple) (bool, error) {
+				return tuple.StartsWith(partial), nil
+			}}},
+		)
+
+		switch _, err = indexIter.ReadRow(ctx); err {
+		case nil:
+			continue // parent table contains child key
+		case io.EOF:
+			indexKeyStr, _ := types.EncodedValue(ctx, partial)
+			return fmt.Errorf("foreign key violation on `%s`.`%s`: `%s`", fk.Name, fk.TableName, indexKeyStr)
+		default:
+			return err
+		}
+	}
+
+	return nil
+}

--- a/go/libraries/doltcore/table/editor/sessioned_table_editor.go
+++ b/go/libraries/doltcore/table/editor/sessioned_table_editor.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
-
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/dolt/go/libraries/doltcore/table"
 	"github.com/dolthub/dolt/go/store/types"
 )
 
@@ -61,7 +61,7 @@ func (ste *sessionedTableEditor) DeleteKey(ctx context.Context, key types.Tuple)
 		}
 		sch := ste.tableEditor.Schema()
 
-		dRow, ok, err := tbl.GetRow(ctx, key, sch)
+		dRow, ok, err := table.GetRow(ctx, tbl, sch, key)
 		if err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/table/writer.go
+++ b/go/libraries/doltcore/table/writer.go
@@ -12,17 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package noms
+package table
 
 import (
-	"github.com/dolthub/dolt/go/libraries/doltcore/table"
 	"github.com/dolthub/dolt/go/store/types"
 )
 
 // NomsMapWriteCloser is a TableWriteCloser where the resulting map that is being written from can be retrieved after
 // it is closed.
 type NomsMapWriteCloser interface {
-	table.TableWriteCloser
+	TableWriteCloser
 
 	// GetMap retrieves the resulting types.Map once close is called
 	GetMap() types.Map


### PR DESCRIPTION
Removed:
- Table.GetRowByPKVals()
- Table.GetRow()
- Table.GetRows()

Had do to some refactoring along the way to fix dependency cycles. 
Reversed dependency `rowconv -> pipeline` to `pipeline -> rowconv`