### PR TITLE
Fixed dolt status output incorrectly displayed for staged files

### DIFF
--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -185,6 +185,7 @@ func printStagedDiffs(wr io.Writer, stagedTbls []diff.TableDelta, stagedDocs *di
 		}
 
 		iohelp.WriteLine(wr, color.GreenString(strings.Join(lines, "\n")))
+		return len(stagedTbls) + stagedDocs.Len()
 	}
 
 	return 0


### PR DESCRIPTION
The function `printStagedDiffs` always returned 0, even when there were diffs not staged. This return was also causing it to print in `printStatus ` "nothing to commit, working tree clean". This was not the case.  

I changed  `printStagedDiffs` to return the number of the staged tables plus the number of staged docs instead. This prevents it from entering the if statement with the print also.

I've attached a picture of the bug with debug statements: 

![Bug](https://user-images.githubusercontent.com/4577266/101877827-78c5ab00-3b43-11eb-8e55-9cb0e215be37.PNG)

and here is it after the fix:

![Fixed](https://user-images.githubusercontent.com/4577266/101877831-795e4180-3b43-11eb-9217-8d6ae5de379e.PNG)

 
