### PR TITLE
Remove root methods from rsr and rsw

### DIFF
--- a/go/libraries/doltcore/diff/diffs.go
+++ b/go/libraries/doltcore/diff/diffs.go
@@ -142,7 +142,7 @@ func GetDocDiffs(ctx context.Context, ddb *doltdb.DoltDB, rsr env.RepoStateReade
 		return nil, nil, err
 	}
 
-	workingRoot, err := rsr.WorkingRoot(ctx)
+	workingRoot, err := env.WorkingRoot(ctx, ddb, rsr)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -152,12 +152,12 @@ func GetDocDiffs(ctx context.Context, ddb *doltdb.DoltDB, rsr env.RepoStateReade
 		return nil, nil, err
 	}
 
-	headRoot, err := rsr.HeadRoot(ctx)
+	headRoot, err := env.HeadRoot(ctx, ddb, rsr)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	stagedRoot, err := rsr.StagedRoot(ctx)
+	stagedRoot, err := env.StagedRoot(ctx, ddb, rsr)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -289,17 +289,17 @@ func GetTableDeltas(ctx context.Context, fromRoot, toRoot *doltdb.RootValue) (de
 }
 
 func GetStagedUnstagedTableDeltas(ctx context.Context, ddb *doltdb.DoltDB, rsr env.RepoStateReader) (staged, unstaged []TableDelta, err error) {
-	headRoot, err := rsr.HeadRoot(ctx)
+	headRoot, err := env.HeadRoot(ctx, ddb, rsr)
 	if err != nil {
 		return nil, nil, RootValueUnreadable{HeadRoot, err}
 	}
 
-	stagedRoot, err := rsr.StagedRoot(ctx)
+	stagedRoot, err := env.StagedRoot(ctx, ddb, rsr)
 	if err != nil {
 		return nil, nil, RootValueUnreadable{StagedRoot, err}
 	}
 
-	workingRoot, err := rsr.WorkingRoot(ctx)
+	workingRoot, err := env.WorkingRoot(ctx, ddb, rsr)
 	if err != nil {
 		return nil, nil, RootValueUnreadable{WorkingRoot, err}
 	}

--- a/go/libraries/doltcore/env/actions/commit.go
+++ b/go/libraries/doltcore/env/actions/commit.go
@@ -91,7 +91,7 @@ func CommitStaged(ctx context.Context, ddb *doltdb.DoltDB, rsr env.RepoStateRead
 
 	var mergeCmSpec []*doltdb.CommitSpec
 	if rsr.IsMergeActive() {
-		root, err := rsr.WorkingRoot(ctx)
+		root, err := env.WorkingRoot(ctx, ddb, rsr)
 		if err != nil {
 			return "", err
 		}
@@ -112,7 +112,7 @@ func CommitStaged(ctx context.Context, ddb *doltdb.DoltDB, rsr env.RepoStateRead
 		mergeCmSpec = []*doltdb.CommitSpec{spec}
 	}
 
-	srt, err := rsr.StagedRoot(ctx)
+	srt, err := env.StagedRoot(ctx, ddb, rsr)
 
 	if err != nil {
 		return "", err
@@ -131,13 +131,13 @@ func CommitStaged(ctx context.Context, ddb *doltdb.DoltDB, rsr env.RepoStateRead
 		}
 	}
 
-	h, err := rsw.UpdateStagedRoot(ctx, srt)
+	h, err := env.UpdateStagedRoot(ctx, ddb, rsw, srt)
 
 	if err != nil {
 		return "", err
 	}
 
-	wrt, err := rsr.WorkingRoot(ctx)
+	wrt, err := env.WorkingRoot(ctx, ddb, rsr)
 
 	if err != nil {
 		return "", err
@@ -149,7 +149,7 @@ func CommitStaged(ctx context.Context, ddb *doltdb.DoltDB, rsr env.RepoStateRead
 		return "", err
 	}
 
-	err = rsw.UpdateWorkingRoot(ctx, wrt)
+	_, err = env.UpdateWorkingRoot(ctx, ddb, rsw, wrt)
 
 	if err != nil {
 		return "", err

--- a/go/libraries/doltcore/env/actions/staged.go
+++ b/go/libraries/doltcore/env/actions/staged.go
@@ -74,13 +74,13 @@ func StageAllTables(ctx context.Context, ddb *doltdb.DoltDB, rsr env.RepoStateRe
 		return err
 	}
 
-	staged, err := rsr.StagedRoot(ctx)
+	staged, err := env.StagedRoot(ctx, ddb, rsr)
 
 	if err != nil {
 		return err
 	}
 
-	working, err := rsr.WorkingRoot(ctx)
+	working, err := env.WorkingRoot(ctx, ddb, rsr)
 
 	if err != nil {
 		return err
@@ -117,8 +117,8 @@ func stageTables(ctx context.Context, db *doltdb.DoltDB, rsw env.RepoStateWriter
 		return err
 	}
 
-	if err := rsw.UpdateWorkingRoot(ctx, working); err == nil {
-		if sh, err := db.WriteRootValue(ctx, staged); err == nil {
+	if _, err := env.UpdateWorkingRoot(ctx, db, rsw, working); err == nil {
+		if sh, err :=  env.UpdateStagedRoot(ctx, db, rsw, staged); err == nil {
 			err = rsw.SetStagedHash(ctx, sh)
 
 			if err != nil {

--- a/go/libraries/doltcore/env/actions/staged.go
+++ b/go/libraries/doltcore/env/actions/staged.go
@@ -118,7 +118,7 @@ func stageTables(ctx context.Context, db *doltdb.DoltDB, rsw env.RepoStateWriter
 	}
 
 	if _, err := env.UpdateWorkingRoot(ctx, db, rsw, working); err == nil {
-		if sh, err :=  env.UpdateStagedRoot(ctx, db, rsw, staged); err == nil {
+		if sh, err := env.UpdateStagedRoot(ctx, db, rsw, staged); err == nil {
 			err = rsw.SetStagedHash(ctx, sh)
 
 			if err != nil {

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -399,18 +399,6 @@ func (r *repoStateReader) GetAllValidDocDetails() ([]doltdb.DocDetails, error) {
 	return r.dEnv.GetAllValidDocDetails()
 }
 
-func (r *repoStateReader) WorkingRoot(ctx context.Context) (*doltdb.RootValue, error) {
-	return r.dEnv.WorkingRoot(ctx)
-}
-
-func (r *repoStateReader) HeadRoot(ctx context.Context) (*doltdb.RootValue, error) {
-	return r.dEnv.HeadRoot(ctx)
-}
-
-func (r *repoStateReader) StagedRoot(ctx context.Context) (*doltdb.RootValue, error) {
-	return r.dEnv.StagedRoot(ctx)
-}
-
 func (dEnv *DoltEnv) RepoStateReader() RepoStateReader {
 	return &repoStateReader{dEnv}
 }
@@ -439,14 +427,6 @@ func (r *repoStateWriter) SetWorkingHash(ctx context.Context, h hash.Hash) error
 	}
 
 	return nil
-}
-
-func (r *repoStateWriter) UpdateStagedRoot(ctx context.Context, newRoot *doltdb.RootValue) (hash.Hash, error) {
-	return r.dEnv.UpdateStagedRoot(ctx, newRoot)
-}
-
-func (r *repoStateWriter) UpdateWorkingRoot(ctx context.Context, newRoot *doltdb.RootValue) error {
-	return r.dEnv.UpdateWorkingRoot(ctx, newRoot)
 }
 
 func (r *repoStateWriter) ClearMerge() error {

--- a/go/libraries/doltcore/env/repo_state.go
+++ b/go/libraries/doltcore/env/repo_state.go
@@ -238,9 +238,3 @@ func UpdateStagedRoot(ctx context.Context, ddb *doltdb.DoltDB, rsw RepoStateWrit
 
 	return h, nil
 }
-
-
-
-
-
-

--- a/go/libraries/doltcore/env/repo_state.go
+++ b/go/libraries/doltcore/env/repo_state.go
@@ -32,9 +32,6 @@ type RepoStateReader interface {
 	IsMergeActive() bool
 	GetMergeCommit() string
 	GetAllValidDocDetails() ([]doltdb.DocDetails, error)
-	WorkingRoot(ctx context.Context) (*doltdb.RootValue, error)
-	HeadRoot(ctx context.Context) (*doltdb.RootValue, error)
-	StagedRoot(ctx context.Context) (*doltdb.RootValue, error)
 }
 
 type RepoStateWriter interface {
@@ -42,9 +39,7 @@ type RepoStateWriter interface {
 	// SetCWBHeadSpec(context.Context, *doltdb.CommitSpec) error
 	SetStagedHash(context.Context, hash.Hash) error
 	SetWorkingHash(context.Context, hash.Hash) error
-	UpdateStagedRoot(ctx context.Context, newRoot *doltdb.RootValue) (hash.Hash, error)
 	ClearMerge() error
-	UpdateWorkingRoot(ctx context.Context, newRoot *doltdb.RootValue) error
 	PutDocsToWorking(ctx context.Context, docDetails []doltdb.DocDetails) error
 	ResetWorkingDocsToStagedDos(ctx context.Context) error
 }
@@ -188,3 +183,59 @@ func (rs *RepoState) IsMergeActive() bool {
 func (rs *RepoState) GetMergeCommit() string {
 	return rs.Merge.Commit
 }
+
+func WorkingRoot(ctx context.Context, ddb *doltdb.DoltDB, rsr RepoStateReader) (*doltdb.RootValue, error) {
+	return ddb.ReadRootValue(ctx, rsr.WorkingHash())
+}
+
+func UpdateWorkingRoot(ctx context.Context, ddb *doltdb.DoltDB, rsw RepoStateWriter, newRoot *doltdb.RootValue) (hash.Hash, error) {
+	h, err := ddb.WriteRootValue(ctx, newRoot)
+
+	if err != nil {
+		return hash.Hash{}, doltdb.ErrNomsIO
+	}
+
+	err = rsw.SetWorkingHash(ctx, h)
+
+	if err != nil {
+		return hash.Hash{}, ErrStateUpdate
+	}
+
+	return h, nil
+}
+
+func HeadRoot(ctx context.Context, ddb *doltdb.DoltDB, rsr RepoStateReader) (*doltdb.RootValue, error) {
+	commit, err := ddb.ResolveRef(ctx, rsr.CWBHeadRef())
+
+	if err != nil {
+		return nil, err
+	}
+
+	return commit.GetRootValue()
+}
+
+func StagedRoot(ctx context.Context, ddb *doltdb.DoltDB, rsr RepoStateReader) (*doltdb.RootValue, error) {
+	return ddb.ReadRootValue(ctx, rsr.StagedHash())
+}
+
+func UpdateStagedRoot(ctx context.Context, ddb *doltdb.DoltDB, rsw RepoStateWriter, newRoot *doltdb.RootValue) (hash.Hash, error) {
+	h, err := ddb.WriteRootValue(ctx, newRoot)
+
+	if err != nil {
+		return hash.Hash{}, doltdb.ErrNomsIO
+	}
+
+	err = rsw.SetStagedHash(ctx, h)
+
+	if err != nil {
+		return hash.Hash{}, ErrStateUpdate
+	}
+
+	return h, nil
+}
+
+
+
+
+
+

--- a/go/libraries/doltcore/env/repo_state.go
+++ b/go/libraries/doltcore/env/repo_state.go
@@ -184,10 +184,12 @@ func (rs *RepoState) GetMergeCommit() string {
 	return rs.Merge.Commit
 }
 
+// Returns the working root.
 func WorkingRoot(ctx context.Context, ddb *doltdb.DoltDB, rsr RepoStateReader) (*doltdb.RootValue, error) {
 	return ddb.ReadRootValue(ctx, rsr.WorkingHash())
 }
 
+// Updates the working root.
 func UpdateWorkingRoot(ctx context.Context, ddb *doltdb.DoltDB, rsw RepoStateWriter, newRoot *doltdb.RootValue) (hash.Hash, error) {
 	h, err := ddb.WriteRootValue(ctx, newRoot)
 
@@ -204,6 +206,7 @@ func UpdateWorkingRoot(ctx context.Context, ddb *doltdb.DoltDB, rsw RepoStateWri
 	return h, nil
 }
 
+// Returns the head root.
 func HeadRoot(ctx context.Context, ddb *doltdb.DoltDB, rsr RepoStateReader) (*doltdb.RootValue, error) {
 	commit, err := ddb.ResolveRef(ctx, rsr.CWBHeadRef())
 
@@ -214,10 +217,12 @@ func HeadRoot(ctx context.Context, ddb *doltdb.DoltDB, rsr RepoStateReader) (*do
 	return commit.GetRootValue()
 }
 
+// Returns the staged root.
 func StagedRoot(ctx context.Context, ddb *doltdb.DoltDB, rsr RepoStateReader) (*doltdb.RootValue, error) {
 	return ddb.ReadRootValue(ctx, rsr.StagedHash())
 }
 
+// Updates the staged root.
 func UpdateStagedRoot(ctx context.Context, ddb *doltdb.DoltDB, rsw RepoStateWriter, newRoot *doltdb.RootValue) (hash.Hash, error) {
 	h, err := ddb.WriteRootValue(ctx, newRoot)
 

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_commit.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_commit.go
@@ -16,6 +16,7 @@ package dfunctions
 
 import (
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 
 	"github.com/dolthub/go-mysql-server/sql"
 
@@ -80,7 +81,7 @@ func (d DoltCommitFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error)
 	}
 
 	// Check if there are no changes in the staged set but the -a flag is false
-	hasStagedChanges, err := hasStagedSetChanges(ctx, rsr)
+	hasStagedChanges, err := hasStagedSetChanges(ctx, ddb, rsr)
 	if err != nil {
 		return nil, err
 	}
@@ -143,8 +144,8 @@ func hasWorkingSetChanges(rsr env.RepoStateReader) bool {
 }
 
 // TODO: We should not be dealing with root objects here but commit specs.
-func hasStagedSetChanges(ctx *sql.Context, rsr env.RepoStateReader) (bool, error) {
-	root, err := rsr.HeadRoot(ctx)
+func hasStagedSetChanges(ctx *sql.Context, ddb *doltdb.DoltDB, rsr env.RepoStateReader) (bool, error) {
+	root, err := env.HeadRoot(ctx, ddb, rsr)
 
 	if err != nil {
 		return false, err

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_commit.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_commit.go
@@ -16,11 +16,11 @@ package dfunctions
 
 import (
 	"fmt"
-	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"


### PR DESCRIPTION
First step in cleaning up RepoStatReader/Writer interface. 