### PR TITLE
Andy/keyless import/export

### DIFF
--- a/bats/arg-parsing.bats
+++ b/bats/arg-parsing.bats
@@ -48,7 +48,7 @@ DELIM
 
 @test "dolt supports chaining of modal arguments" {
     dolt sql -q "create table test(pk int, primary key (pk))"
-    dolt table import -fc test `batshelper 1pk5col-ints.csv`
+    dolt table import -fc -pk=pk test `batshelper 1pk5col-ints.csv`
 }
 
 @test "dolt checkout with empty string returns error" {

--- a/bats/column_tags.bats
+++ b/bats/column_tags.bats
@@ -225,7 +225,7 @@ pk,c1,c2,c3,c4,c5
 0,1,2,3,4,5
 a,b,c,d,e,f
 DELIM
-    run dolt table import -c ints_table data.csv
+    run dolt table import -c -pk=pk ints_table data.csv
     [ $status -eq 0 ]
     run dolt schema tags -r=csv
     [ $status -eq 0 ]

--- a/bats/compatibility/test_files/bats/compatibility.bats
+++ b/bats/compatibility/test_files/bats/compatibility.bats
@@ -158,7 +158,7 @@ teardown() {
     # this will fail for older dolt versions but BATS will swallow the error
     run dolt migrate
 
-    run dolt table import -c abc2 abc.csv
+    run dolt table import -c -pk=pk abc2 abc.csv
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Import completed successfully." ]] || false
 

--- a/bats/import-create-tables.bats
+++ b/bats/import-create-tables.bats
@@ -203,7 +203,7 @@ pk||c1||c2||c3||c4||c5
 0||1||2||3||4||5
 1||1||2||3||4||5
 DELIM
-    run dolt table import -c --delim="||" test 1pk5col-ints.csv
+    run dolt table import -c -pk=pk --delim="||" test 1pk5col-ints.csv
     [ "$status" -eq 0 ]
     run dolt sql -r csv -q "select * from test"
     [ "$status" -eq 0 ]
@@ -355,7 +355,7 @@ SQL
 }
 
 @test "create a table with null values from csv import" {
-    run dolt table import -c test empty-strings-null-values.csv
+    run dolt table import -c -pk=pk test empty-strings-null-values.csv
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Import completed successfully." ]] || false
     run dolt ls

--- a/bats/keyless.bats
+++ b/bats/keyless.bats
@@ -148,6 +148,33 @@ CSV
     [[ "${lines[8]}" = "2,2" ]] || false
 }
 
+@test "keyless table export CSV" {
+    dolt --keyless table export keyless
+    run dolt --keyless table export keyless
+    [ $status -eq 0 ]
+    [[ "${lines[0]}" = "c0,c1" ]] || false
+    [[ "${lines[1]}" = "1,1" ]] || false
+    [[ "${lines[2]}" = "1,1" ]] || false
+    [[ "${lines[3]}" = "0,0" ]] || false
+    [[ "${lines[4]}" = "2,2" ]] || false
+}
+
+@test "keyless table export SQL" {
+    dolt --keyless table export keyless export.sql
+    cat export.sql
+    run cat export.sql
+    [[ "${lines[0]}" = "DROP TABLE IF EXISTS \`keyless\`;"   ]] || false
+    [[ "${lines[1]}" = "CREATE TABLE \`keyless\` ("          ]] || false
+    [[ "${lines[2]}" = "  \`c0\` int,"  ]] || false
+    [[ "${lines[3]}" = "  \`c1\` int"   ]] || false
+    [[ "${lines[4]}" = ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;"     ]] || false
+    [[ "${lines[5]}" = "INSERT INTO \`keyless\` (\`c0\`,\`c1\`) VALUES (1,1);" ]] || false
+    [[ "${lines[6]}" = "INSERT INTO \`keyless\` (\`c0\`,\`c1\`) VALUES (1,1);" ]] || false
+    [[ "${lines[7]}" = "INSERT INTO \`keyless\` (\`c0\`,\`c1\`) VALUES (0,0);" ]] || false
+    [[ "${lines[8]}" = "INSERT INTO \`keyless\` (\`c0\`,\`c1\`) VALUES (2,2);" ]] || false
+
+}
+
 @test "keyless diff against working set" {
     dolt --keyless sql <<SQL
 DELETE FROM keyless WHERE c0 = 0;

--- a/bats/keyless.bats
+++ b/bats/keyless.bats
@@ -107,18 +107,29 @@ c0,c1
 2,2
 1,1
 1,1
+,9
 CSV
     dolt --keyless table import -c imported data.csv
     run dolt --keyless sql -q "SELECT count(*) FROM imported;" -r csv
     [ $status -eq 0 ]
-    [[ "${lines[1]}" = "4" ]] || false
-    dolt --keyless sql -q "SELECT c0,c1 FROM imported ORDER BY c0;" -r csv
-    run dolt --keyless sql -q "SELECT c0,c1 FROM imported ORDER BY c0;" -r csv
+    [[ "${lines[1]}" = "5" ]] || false
+    run dolt --keyless sql -q "SELECT c0,c1 FROM imported ORDER BY c1;" -r csv
     [ $status -eq 0 ]
     [[ "${lines[1]}" = "0,0" ]] || false
     [[ "${lines[2]}" = "1,1" ]] || false
     [[ "${lines[3]}" = "1,1" ]] || false
     [[ "${lines[4]}" = "2,2" ]] || false
+    [[ "${lines[5]}" = ",9" ]] || false
+
+    # tests for NULL hashing in keyless tables
+    dolt --keyless sql -q "UPDATE imported SET c1 = c1 + 10"
+    run dolt --keyless sql -q "SELECT c0,c1 FROM imported ORDER BY c1;" -r csv
+    [ $status -eq 0 ]
+    [[ "${lines[1]}" = "0,10" ]] || false
+    [[ "${lines[2]}" = "1,11" ]] || false
+    [[ "${lines[3]}" = "1,11" ]] || false
+    [[ "${lines[4]}" = "2,12" ]] || false
+    [[ "${lines[5]}" = ",19" ]] || false
 }
 
 # updates are always appends

--- a/bats/keyless.bats
+++ b/bats/keyless.bats
@@ -221,10 +221,6 @@ DELETE FROM keyless WHERE c0 = 0;
 INSERT INTO keyless VALUES (8,8);
 UPDATE keyless SET c1 = 9 WHERE c0 = 1;
 SQL
-    dolt --keyless sql -q "
-        SELECT to_c0, to_c1, from_c0, from_c1
-        FROM dolt_diff_keyless
-        ORDER BY to_commit_date" -r csv
     run dolt --keyless sql -q "
         SELECT to_c0, to_c1, from_c0, from_c1
         FROM dolt_diff_keyless

--- a/go/libraries/doltcore/mvdata/data_loc_test.go
+++ b/go/libraries/doltcore/mvdata/data_loc_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/typed/json"
-	"github.com/dolthub/dolt/go/libraries/doltcore/table/typed/noms"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/untyped/csv"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/store/types"
@@ -182,7 +181,6 @@ func TestCreateRdWr(t *testing.T) {
 		expectedRdT reflect.Type
 		expectedWrT reflect.Type
 	}{
-		{NewDataLocation(testTableName, ""), reflect.TypeOf((*noms.NomsMapReader)(nil)).Elem(), reflect.TypeOf((*tableEditorWriteCloser)(nil)).Elem()},
 		{NewDataLocation("file.csv", ""), reflect.TypeOf((*csv.CSVReader)(nil)).Elem(), reflect.TypeOf((*csv.CSVWriter)(nil)).Elem()},
 		{NewDataLocation("file.psv", ""), reflect.TypeOf((*csv.CSVReader)(nil)).Elem(), reflect.TypeOf((*csv.CSVWriter)(nil)).Elem()},
 		{NewDataLocation("file.json", ""), reflect.TypeOf((*json.JSONReader)(nil)).Elem(), reflect.TypeOf((*json.JSONWriter)(nil)).Elem()},

--- a/go/libraries/doltcore/mvdata/data_mover.go
+++ b/go/libraries/doltcore/mvdata/data_mover.go
@@ -242,10 +242,6 @@ func SchAndTableNameFromFile(ctx context.Context, path string, fs filesys.Readab
 func InferSchema(ctx context.Context, root *doltdb.RootValue, rd table.TableReadCloser, tableName string, pks []string, args actions.InferenceArgs) (schema.Schema, error) {
 	var err error
 
-	if len(pks) == 0 {
-		pks = rd.GetSchema().GetPKCols().GetColumnNames()
-	}
-
 	infCols, err := actions.InferColumnTypesFromTableReader(ctx, root, rd, args)
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/mvdata/table_data_loc.go
+++ b/go/libraries/doltcore/mvdata/table_data_loc.go
@@ -92,10 +92,6 @@ func (dl TableDataLocation) NewReader(ctx context.Context, root *doltdb.RootValu
 // NewCreatingWriter will create a TableWriteCloser for a DataLocation that will create a new table, or overwrite
 // an existing table.
 func (dl TableDataLocation) NewCreatingWriter(ctx context.Context, _ DataMoverOptions, dEnv *env.DoltEnv, root *doltdb.RootValue, _ bool, outSch schema.Schema, statsCB noms.StatsCB, useGC bool) (table.TableWriteCloser, error) {
-	if outSch.GetPKCols().Size() == 0 {
-		return nil, ErrNoPK
-	}
-
 	updatedRoot, err := root.CreateEmptyTable(ctx, dl.Name, outSch)
 	if err != nil {
 		return nil, err
@@ -145,9 +141,12 @@ func (dl TableDataLocation) NewUpdatingWriter(ctx context.Context, _ DataMoverOp
 		return nil, err
 	}
 
+	// keyless tables are updated as append only
+	insertOnly := schema.IsKeyless(tblSch)
+
 	return &tableEditorWriteCloser{
 		dEnv:        dEnv,
-		insertOnly:  false,
+		insertOnly:  insertOnly,
 		initialData: m,
 		statsCB:     statsCB,
 		tableEditor: tableEditor,

--- a/go/libraries/doltcore/mvdata/table_data_loc.go
+++ b/go/libraries/doltcore/mvdata/table_data_loc.go
@@ -59,29 +59,14 @@ func (dl TableDataLocation) Exists(ctx context.Context, root *doltdb.RootValue, 
 // NewReader creates a TableReadCloser for the DataLocation
 func (dl TableDataLocation) NewReader(ctx context.Context, root *doltdb.RootValue, _ filesys.ReadableFS, _ interface{}) (rdCl table.TableReadCloser, sorted bool, err error) {
 	tbl, ok, err := root.GetTable(ctx, dl.Name)
-
 	if err != nil {
 		return nil, false, err
 	}
-
 	if !ok {
 		return nil, false, doltdb.ErrTableNotFound
 	}
 
-	sch, err := tbl.GetSchema(ctx)
-
-	if err != nil {
-		return nil, false, err
-	}
-
-	rowData, err := tbl.GetRowData(ctx)
-
-	if err != nil {
-		return nil, false, err
-	}
-
-	rd, err := noms.NewNomsMapReader(ctx, rowData, sch)
-
+	rd, err := table.NewDoltTableReader(ctx, tbl)
 	if err != nil {
 		return nil, false, err
 	}

--- a/go/libraries/doltcore/row/keyless_row.go
+++ b/go/libraries/doltcore/row/keyless_row.go
@@ -73,7 +73,8 @@ func keylessRowFromTaggedValued(nbf *types.NomsBinFormat, sch schema.Schema, tv 
 	i := 0
 
 	err := sch.GetAllCols().Iter(func(tag uint64, col schema.Column) (stop bool, err error) {
-		if v, ok := tv[tag]; ok {
+		v, ok := tv[tag]
+		if ok && v.Kind() != types.NullKind {
 			vals[i] = types.Uint(tag)
 			vals[i+1] = v
 			i += 2
@@ -84,7 +85,7 @@ func keylessRowFromTaggedValued(nbf *types.NomsBinFormat, sch schema.Schema, tv 
 		return nil, err
 	}
 
-	return keylessRowWithCardinality(nbf, 1, vals...)
+	return keylessRowWithCardinality(nbf, 1, vals[:i]...)
 }
 
 func keylessRowWithCardinality(nbf *types.NomsBinFormat, card uint64, vals ...types.Value) (Row, error) {

--- a/go/libraries/doltcore/row/noms_row.go
+++ b/go/libraries/doltcore/row/noms_row.go
@@ -152,7 +152,7 @@ func (nr nomsRow) Format() *types.NomsBinFormat {
 	return nr.nbf
 }
 
-func New(nbf *types.NomsBinFormat, sch schema.Schema, colVals TaggedValues) (Row, error) {
+func pkRowFromTaggedValues(nbf *types.NomsBinFormat, sch schema.Schema, colVals TaggedValues) (Row, error) {
 	allCols := sch.GetAllCols()
 
 	keyVals := make(TaggedValues)

--- a/go/libraries/doltcore/row/row.go
+++ b/go/libraries/doltcore/row/row.go
@@ -55,6 +55,13 @@ type Row interface {
 	NomsMapValue(sch schema.Schema) types.Valuable
 }
 
+func New(nbf *types.NomsBinFormat, sch schema.Schema, colVals TaggedValues) (Row, error) {
+	if schema.IsKeyless(sch) {
+		return keylessRowFromTaggedValued(nbf, sch, colVals)
+	}
+	return pkRowFromTaggedValues(nbf, sch, colVals)
+}
+
 func FromNoms(sch schema.Schema, nomsKey, nomsVal types.Tuple) (Row, error) {
 	if schema.IsKeyless(sch) {
 		row, _, err := KeylessRowsFromTuples(nomsKey, nomsVal)

--- a/go/libraries/doltcore/table/keyless_reader.go
+++ b/go/libraries/doltcore/table/keyless_reader.go
@@ -36,6 +36,7 @@ type keylessTableReader struct {
 }
 
 var _ SqlTableReader = &keylessTableReader{}
+var _ TableReadCloser = &keylessTableReader{}
 
 // GetSchema implements the TableReader interface.
 func (rdr *keylessTableReader) GetSchema() schema.Schema {
@@ -76,7 +77,12 @@ func (rdr *keylessTableReader) ReadSqlRow(ctx context.Context) (sql.Row, error) 
 	return sqlutil.DoltRowToSqlRow(r, rdr.sch)
 }
 
-func newKeylessTableReader(ctx context.Context, tbl *doltdb.Table, sch schema.Schema, buffered bool) (SqlTableReader, error) {
+// Close implements the TableReadCloser interface.
+func (rdr *keylessTableReader) Close(_ context.Context) error {
+	return nil
+}
+
+func newKeylessTableReader(ctx context.Context, tbl *doltdb.Table, sch schema.Schema, buffered bool) (*keylessTableReader, error) {
 	rows, err := tbl.GetRowData(ctx)
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/table/pk_reader.go
+++ b/go/libraries/doltcore/table/pk_reader.go
@@ -67,7 +67,7 @@ func (rdr pkTableReader) ReadSqlRow(ctx context.Context) (sql.Row, error) {
 }
 
 // Close implements the TableReadCloser interface.
-func (rdr pkTableReader) Close (_ context.Context) error {
+func (rdr pkTableReader) Close(_ context.Context) error {
 	return nil
 }
 

--- a/go/libraries/doltcore/table/pk_reader.go
+++ b/go/libraries/doltcore/table/pk_reader.go
@@ -33,6 +33,7 @@ type pkTableReader struct {
 }
 
 var _ SqlTableReader = pkTableReader{}
+var _ TableReadCloser = pkTableReader{}
 
 // GetSchema implements the TableReader interface.
 func (rdr pkTableReader) GetSchema() schema.Schema {
@@ -65,10 +66,15 @@ func (rdr pkTableReader) ReadSqlRow(ctx context.Context) (sql.Row, error) {
 	return noms.SqlRowFromTuples(rdr.sch, key.(types.Tuple), val.(types.Tuple))
 }
 
-func newPkTableReader(ctx context.Context, tbl *doltdb.Table, sch schema.Schema, buffered bool) (SqlTableReader, error) {
+// Close implements the TableReadCloser interface.
+func (rdr pkTableReader) Close (_ context.Context) error {
+	return nil
+}
+
+func newPkTableReader(ctx context.Context, tbl *doltdb.Table, sch schema.Schema, buffered bool) (pkTableReader, error) {
 	rows, err := tbl.GetRowData(ctx)
 	if err != nil {
-		return nil, err
+		return pkTableReader{}, err
 	}
 
 	var iter types.MapIterator
@@ -78,7 +84,7 @@ func newPkTableReader(ctx context.Context, tbl *doltdb.Table, sch schema.Schema,
 		iter, err = rows.BufferedIterator(ctx)
 	}
 	if err != nil {
-		return nil, err
+		return pkTableReader{}, err
 	}
 
 	return pkTableReader{

--- a/go/libraries/doltcore/table/table_reader.go
+++ b/go/libraries/doltcore/table/table_reader.go
@@ -71,6 +71,19 @@ func NewTableReader(ctx context.Context, tbl *doltdb.Table) (SqlTableReader, err
 	return newPkTableReader(ctx, tbl, sch, false)
 }
 
+// NewDoltTableReader creates a SqlTableReader from |tbl| starting from the first record.
+func NewDoltTableReader(ctx context.Context, tbl *doltdb.Table) (TableReadCloser, error) {
+	sch, err := tbl.GetSchema(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if schema.IsKeyless(sch) {
+		return newKeylessTableReader(ctx, tbl, sch, false)
+	}
+	return newPkTableReader(ctx, tbl, sch, false)
+}
+
 // NewBufferedTableReader creates a buffered SqlTableReader from |tbl| starting from the first record.
 func NewBufferedTableReader(ctx context.Context, tbl *doltdb.Table) (SqlTableReader, error) {
 	sch, err := tbl.GetSchema(ctx)

--- a/go/store/types/uuid.go
+++ b/go/store/types/uuid.go
@@ -17,7 +17,6 @@ package types
 import (
 	"bytes"
 	"context"
-
 	"github.com/google/uuid"
 
 	"github.com/dolthub/dolt/go/store/hash"
@@ -32,6 +31,9 @@ const (
 func UUIDHashedFromValues(nbf *NomsBinFormat, vals ...Value) (UUID, error) {
 	w := binaryNomsWriter{make([]byte, 4), 0}
 	for _, v := range vals {
+		if v == nil || v.Kind() == NullKind {
+			continue
+		}
 		if err := v.writeTo(&w, nbf); err != nil {
 			return [16]byte{}, err
 		}

--- a/go/store/types/uuid.go
+++ b/go/store/types/uuid.go
@@ -17,6 +17,7 @@ package types
 import (
 	"bytes"
 	"context"
+
 	"github.com/google/uuid"
 
 	"github.com/dolthub/dolt/go/store/hash"


### PR DESCRIPTION
Adds keyless table support for `dolt table import ...`. `table import -c` now creates keyless tables if the `-pk` option is not provided.