### PR TITLE
First cut of Discrod notifications

### DIFF
--- a/.github/workflows/cd-release-notify.yaml
+++ b/.github/workflows/cd-release-notify.yaml
@@ -1,0 +1,15 @@
+name: Release Notification
+
+on: release
+
+jobs:
+  notify:
+    name: Release Notification
+    steps:
+      - name: Discord Notify
+        if: always()
+        uses: dolthub/ga-discord-notify@master
+        with:
+          job-status: ${{ job.status }}
+          webhook-url: ${{ secrets.DISCORD_RELEASES_WEBHOOK }}
+          notify-on-success: true

--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -20,6 +20,13 @@ jobs:
           git config --global user.name dolt-release-bot
           git config --global user.email dolt-release-bot@dolthub.com
           ./go/utils/publishrelease/bump-version.sh ${{ github.event.inputs.version }}
+      - name: Discord Notify
+        if: always()
+        uses: dolthub/ga-discord-notify@master
+        with:
+          job-status: ${{ job.status }}
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          notify-on-success: false
 
   create-release:
     needs: bump-version
@@ -85,6 +92,13 @@ jobs:
           asset_path: go/out/install.sh
           asset_name: install.sh
           asset_content_type: text/plain
+      - name: Discord Notify
+        if: always()
+        uses: dolthub/ga-discord-notify@master
+        with:
+          job-status: ${{ job.status }}
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          notify-on-success: false
 
   homebrew-bump:
     needs: create-release
@@ -101,3 +115,10 @@ jobs:
           commit-message: ${{format('dolt v{0}', github.event.inputs.version)}}
         env:
           COMMITTER_TOKEN: ${{secrets.HOMEBREW_GITHUB_TOKEN}}
+      - name: Discord Notify
+        if: always()
+        uses: dolthub/ga-discord-notify@master
+        with:
+          job-status: ${{ job.status }}
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          notify-on-success: false

--- a/.github/workflows/ci-bats-tests.yaml
+++ b/.github/workflows/ci-bats-tests.yaml
@@ -79,3 +79,10 @@ jobs:
         run: |
           bats --tap .
         working-directory: ./bats
+      - name: Discord Notify
+        if: always()
+        uses: dolthub/ga-discord-notify@master
+        with:
+          job-status: ${{ job.status }}
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          notify-on-success: false

--- a/.github/workflows/ci-check-repo.yaml
+++ b/.github/workflows/ci-check-repo.yaml
@@ -29,3 +29,10 @@ jobs:
         env:
           BRANCH_NAME: ${{ github.head_ref }}
           CHANGE_TARGET: ${{ github.base_ref }}
+      - name: Discord Notify
+        if: always()
+        uses: dolthub/ga-discord-notify@master
+        with:
+          job-status: ${{ job.status }}
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          notify-on-success: false

--- a/.github/workflows/ci-compatibility-tests.yaml
+++ b/.github/workflows/ci-compatibility-tests.yaml
@@ -42,3 +42,10 @@ jobs:
       - name: Test all
         run: ./runner.sh
         working-directory: ./bats/compatibility
+      - name: Discord Notify
+        if: always()
+        uses: dolthub/ga-discord-notify@master
+        with:
+          job-status: ${{ job.status }}
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          notify-on-success: false

--- a/.github/workflows/ci-go-tests.yaml
+++ b/.github/workflows/ci-go-tests.yaml
@@ -24,3 +24,10 @@ jobs:
     - name: Test All
       working-directory: ./go
       run: go test -race ./...
+    - name: Discord Notify
+        if: always()
+        uses: dolthub/ga-discord-notify@master
+        with:
+          job-status: ${{ job.status }}
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          notify-on-success: false

--- a/.github/workflows/ci-mysql-client-tests.yaml
+++ b/.github/workflows/ci-mysql-client-tests.yaml
@@ -11,3 +11,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Test mysql client integrations
         uses: ./.github/actions/mysql-client-tests
+      - name: Discord Notify
+        if: always()
+        uses: dolthub/ga-discord-notify@master
+        with:
+          job-status: ${{ job.status }}
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          notify-on-success: false


### PR DESCRIPTION
This implements the following policy:
- notify on cancellation or failure of any job
- notify on release, including success

Currently release notifications are broken by a shortcoming in GitHub Actions, namely that one workflow cannot kick of another when using `GITHUB_TOKEN`. We will devise a workaround.