### PR TITLE
/go/libraries/doltcore/sqle: move table cache to DoltSession, purge on root change

### DIFF
--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -73,7 +73,6 @@ func IsWorkingKey(key string) (bool, string) {
 	return false, ""
 }
 
-
 type SqlDatabase interface {
 	sql.Database
 	GetRoot(*sql.Context) (*doltdb.RootValue, error)

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -74,57 +73,6 @@ func IsWorkingKey(key string) (bool, string) {
 	return false, ""
 }
 
-type tableCache struct {
-	mu     *sync.Mutex
-	tables map[*doltdb.RootValue]map[string]sql.Table
-}
-
-func (tc *tableCache) Get(tableName string, root *doltdb.RootValue) (sql.Table, bool) {
-	tc.mu.Lock()
-	defer tc.mu.Unlock()
-
-	tablesForRoot, ok := tc.tables[root]
-
-	if !ok {
-		return nil, false
-	}
-
-	tbl, ok := tablesForRoot[tableName]
-
-	return tbl, ok
-}
-
-func (tc *tableCache) Put(tableName string, root *doltdb.RootValue, tbl sql.Table) {
-	tc.mu.Lock()
-	defer tc.mu.Unlock()
-
-	tablesForRoot, ok := tc.tables[root]
-
-	if !ok {
-		tablesForRoot = make(map[string]sql.Table)
-		tc.tables[root] = tablesForRoot
-	}
-
-	tablesForRoot[tableName] = tbl
-}
-
-func (tc *tableCache) AllForRoot(root *doltdb.RootValue) (map[string]sql.Table, bool) {
-	tc.mu.Lock()
-	defer tc.mu.Unlock()
-
-	tablesForRoot, ok := tc.tables[root]
-
-	if ok {
-		copyOf := make(map[string]sql.Table, len(tablesForRoot))
-		for name, tbl := range tablesForRoot {
-			copyOf[name] = tbl
-		}
-
-		return copyOf, true
-	}
-
-	return nil, false
-}
 
 type SqlDatabase interface {
 	sql.Database
@@ -139,7 +87,6 @@ type Database struct {
 	rsw       env.RepoStateWriter
 	drw       env.DocsReadWriter
 	batchMode commitBehavior
-	tc        *tableCache
 }
 
 var _ SqlDatabase = Database{}
@@ -158,7 +105,6 @@ func NewDatabase(name string, dbData env.DbData) Database {
 		rsw:       dbData.Rsw,
 		drw:       dbData.Drw,
 		batchMode: single,
-		tc:        &tableCache{&sync.Mutex{}, make(map[*doltdb.RootValue]map[string]sql.Table)},
 	}
 }
 
@@ -172,7 +118,6 @@ func NewBatchedDatabase(name string, dbData env.DbData) Database {
 		rsw:       dbData.Rsw,
 		drw:       dbData.Drw,
 		batchMode: batched,
-		tc:        &tableCache{&sync.Mutex{}, make(map[*doltdb.RootValue]map[string]sql.Table)},
 	}
 }
 
@@ -370,8 +315,9 @@ func (db Database) GetTableNamesAsOf(ctx *sql.Context, time interface{}) ([]stri
 
 // getTable gets the table with the exact name given at the root value given. The database caches tables for all root
 // values to avoid doing schema lookups on every table lookup, which are expensive.
-func (db Database) getTable(ctx context.Context, root *doltdb.RootValue, tableName string) (sql.Table, bool, error) {
-	if table, ok := db.tc.Get(tableName, root); ok {
+func (db Database) getTable(ctx *sql.Context, root *doltdb.RootValue, tableName string) (sql.Table, bool, error) {
+	cache := TableCacheFromSess(ctx.Session, db.name)
+	if table, ok := cache.Get(tableName, root); ok {
 		return table, true, nil
 	}
 
@@ -409,7 +355,7 @@ func (db Database) getTable(ctx context.Context, root *doltdb.RootValue, tableNa
 		table = &AlterableDoltTable{WritableDoltTable{DoltTable: readonlyTable, db: db}}
 	}
 
-	db.tc.Put(tableName, root, table)
+	cache.Put(tableName, root, table)
 
 	return table, true, nil
 }
@@ -683,12 +629,12 @@ func (db Database) RenameTable(ctx *sql.Context, oldName, newName string) error 
 // Flush flushes the current batch of outstanding changes and returns any errors.
 func (db Database) Flush(ctx *sql.Context) error {
 	root, err := db.GetRoot(ctx)
-
 	if err != nil {
 		return err
 	}
 
-	tables, ok := db.tc.AllForRoot(root)
+	cache := TableCacheFromSess(ctx.Session, db.name)
+	tables, ok := cache.AllForRoot(root)
 
 	if ok {
 		for _, table := range tables {

--- a/go/libraries/doltcore/sqle/dolt_session.go
+++ b/go/libraries/doltcore/sqle/dolt_session.go
@@ -59,7 +59,7 @@ type TableCache interface {
 	AllForRoot(root *doltdb.RootValue) (map[string]sql.Table, bool)
 
 	// Purge removes all entries from the cache.
-	Purge()
+	Clear()
 }
 
 // DefaultDoltSession creates a DoltSession object with default values
@@ -311,7 +311,7 @@ func (sess *DoltSession) Set(ctx context.Context, key string, typ sql.Type, valu
 			return err
 		}
 
-		sess.caches[dbName].Purge()
+		sess.caches[dbName].Clear()
 
 		return nil
 	}
@@ -429,7 +429,7 @@ func (tc tableCache) AllForRoot(root *doltdb.RootValue) (map[string]sql.Table, b
 	return nil, false
 }
 
-func (tc tableCache) Purge() {
+func (tc tableCache) Clear() {
 	for rt := range tc.tables {
 		delete(tc.tables, rt)
 	}

--- a/go/libraries/doltcore/sqle/dolt_session.go
+++ b/go/libraries/doltcore/sqle/dolt_session.go
@@ -370,7 +370,7 @@ func (sess *DoltSession) AddDB(ctx context.Context, db Database) error {
 
 func newTableCache() TableCache {
 	return tableCache{
-		mu: &sync.Mutex{},
+		mu:     &sync.Mutex{},
 		tables: make(map[*doltdb.RootValue]map[string]sql.Table),
 	}
 }


### PR DESCRIPTION
I'm ambivalent about where the table cache lives, but we need to have access to it when we change the root of a `sqle.Database`

This PR purges the table cache when we change roots. IE `SET @@dolt_head = hashof(...)`. The intention is to limit the scope of edit sessions, and table mutations in general, and contain them to the working root of a `sqle.Database`. 

Currently there is a tricky reference chain within the table cache: `sqle.tableCache` -> `sqle.WritableDoltTable` -> `sqle.sqlTableEditor` -> `table/editor.TableEditSesson`

When we change roots in the database we also change the root within the `TableEditSession`. They're both referencing the new working root. Without purging the cache, we will keep old tables from the previous working root that still have a reference to the `TableEditSession`. 

This hasn't caused any issues (yet), but I think it's prudent to limit the scope and lifetime of these interconnected pieces of state. The next step is to create a fresh `TableEditSession` each time we switch roots.