### PR TITLE
Read Tuple Perf Improvements

### DIFF
--- a/go/libraries/doltcore/schema/typeinfo/bit.go
+++ b/go/libraries/doltcore/schema/typeinfo/bit.go
@@ -64,12 +64,12 @@ func (ti *bitType) ConvertNomsValueToValue(v types.Value) (interface{}, error) {
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
-func (ti *bitType) ReadNomsPrimitiveAsSql(reader types.PrimitiveNomsReader) (interface{}, error) {
+func (ti *bitType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
 	k := reader.ReadKind()
 	switch k {
 	case types.UintKind:
-		n := reader.ReadUint()
-		return n, nil
+		val := reader.ReadUint()
+		return val, nil
 	case types.NullKind:
 		return nil, nil
 	}

--- a/go/libraries/doltcore/schema/typeinfo/bit.go
+++ b/go/libraries/doltcore/schema/typeinfo/bit.go
@@ -64,6 +64,19 @@ func (ti *bitType) ConvertNomsValueToValue(v types.Value) (interface{}, error) {
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
+func (ti *bitType) ReadNomsPrimitiveAsSql(reader types.PrimitiveNomsReader) (interface{}, error) {
+	k := reader.ReadKind()
+	switch k {
+	case types.UintKind:
+		n := reader.ReadUint()
+		return n, nil
+	case types.NullKind:
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), k)
+}
+
 // ConvertValueToNomsValue implements TypeInfo interface.
 func (ti *bitType) ConvertValueToNomsValue(v interface{}) (types.Value, error) {
 	if v == nil {

--- a/go/libraries/doltcore/schema/typeinfo/bit.go
+++ b/go/libraries/doltcore/schema/typeinfo/bit.go
@@ -64,6 +64,7 @@ func (ti *bitType) ConvertNomsValueToValue(v types.Value) (interface{}, error) {
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
+// ReadFrom reads a go value from a noms types.CodecReader directly
 func (ti *bitType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
 	k := reader.ReadKind()
 	switch k {

--- a/go/libraries/doltcore/schema/typeinfo/bool.go
+++ b/go/libraries/doltcore/schema/typeinfo/bool.go
@@ -46,6 +46,7 @@ func (ti *boolType) ConvertNomsValueToValue(v types.Value) (interface{}, error) 
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
+// ReadFrom reads a go value from a noms types.CodecReader directly
 func (ti *boolType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
 	k := reader.ReadKind()
 	switch k {

--- a/go/libraries/doltcore/schema/typeinfo/bool.go
+++ b/go/libraries/doltcore/schema/typeinfo/bool.go
@@ -46,6 +46,24 @@ func (ti *boolType) ConvertNomsValueToValue(v types.Value) (interface{}, error) 
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
+func (ti *boolType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
+	k := reader.ReadKind()
+	switch k {
+	case types.BoolKind:
+		b := reader.ReadBool()
+		if b {
+			return uint64(1), nil
+		}
+
+		return uint64(0), nil
+
+	case types.NullKind:
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), k)
+}
+
 // ConvertValueToNomsValue implements TypeInfo interface.
 func (ti *boolType) ConvertValueToNomsValue(v interface{}) (types.Value, error) {
 	switch val := v.(type) {

--- a/go/libraries/doltcore/schema/typeinfo/datetime.go
+++ b/go/libraries/doltcore/schema/typeinfo/datetime.go
@@ -70,7 +70,7 @@ func (ti *datetimeType) ConvertNomsValueToValue(v types.Value) (interface{}, err
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
-
+// ReadFrom reads a go value from a noms types.CodecReader directly
 func (ti *datetimeType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
 	k := reader.ReadKind()
 	switch k {

--- a/go/libraries/doltcore/schema/typeinfo/datetime.go
+++ b/go/libraries/doltcore/schema/typeinfo/datetime.go
@@ -70,6 +70,25 @@ func (ti *datetimeType) ConvertNomsValueToValue(v types.Value) (interface{}, err
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
+
+func (ti *datetimeType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
+	k := reader.ReadKind()
+	switch k {
+	case types.UintKind:
+		t, err := reader.ReadTimestamp()
+
+		if err != nil {
+			return nil, err
+		}
+
+		return t.UTC(), nil
+	case types.NullKind:
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), k)
+}
+
 // ConvertValueToNomsValue implements TypeInfo interface.
 func (ti *datetimeType) ConvertValueToNomsValue(v interface{}) (types.Value, error) {
 	//TODO: handle the zero value as a special case that is valid for all ranges

--- a/go/libraries/doltcore/schema/typeinfo/datetime.go
+++ b/go/libraries/doltcore/schema/typeinfo/datetime.go
@@ -74,7 +74,7 @@ func (ti *datetimeType) ConvertNomsValueToValue(v types.Value) (interface{}, err
 func (ti *datetimeType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
 	k := reader.ReadKind()
 	switch k {
-	case types.UintKind:
+	case types.TimestampKind:
 		t, err := reader.ReadTimestamp()
 
 		if err != nil {

--- a/go/libraries/doltcore/schema/typeinfo/decimal.go
+++ b/go/libraries/doltcore/schema/typeinfo/decimal.go
@@ -76,6 +76,25 @@ func (ti *decimalType) ConvertNomsValueToValue(v types.Value) (interface{}, erro
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
+
+func (ti *decimalType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
+	k := reader.ReadKind()
+	switch k {
+	case types.DecimalKind:
+		dec, err := reader.ReadDecimal()
+
+		if err != nil {
+			return nil, err
+		}
+
+		return dec.StringFixed(int32(ti.sqlDecimalType.Scale())), nil
+	case types.NullKind:
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), k)
+}
+
 // ConvertValueToNomsValue implements TypeInfo interface.
 func (ti *decimalType) ConvertValueToNomsValue(v interface{}) (types.Value, error) {
 	if v == nil {

--- a/go/libraries/doltcore/schema/typeinfo/decimal.go
+++ b/go/libraries/doltcore/schema/typeinfo/decimal.go
@@ -76,7 +76,7 @@ func (ti *decimalType) ConvertNomsValueToValue(v types.Value) (interface{}, erro
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
-
+// ReadFrom reads a go value from a noms types.CodecReader directly
 func (ti *decimalType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
 	k := reader.ReadKind()
 	switch k {

--- a/go/libraries/doltcore/schema/typeinfo/enum.go
+++ b/go/libraries/doltcore/schema/typeinfo/enum.go
@@ -80,6 +80,25 @@ func (ti *enumType) ConvertNomsValueToValue(v types.Value) (interface{}, error) 
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
+
+func (ti *enumType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
+	k := reader.ReadKind()
+	switch k {
+	case types.UintKind:
+		n := reader.ReadUint()
+		res, err := ti.sqlEnumType.Unmarshal(int64(n))
+		if err != nil {
+			return nil, nil
+		}
+
+		return res, nil
+	case types.NullKind:
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), k)
+}
+
 // ConvertValueToNomsValue implements TypeInfo interface.
 func (ti *enumType) ConvertValueToNomsValue(v interface{}) (types.Value, error) {
 	if v == nil {

--- a/go/libraries/doltcore/schema/typeinfo/enum.go
+++ b/go/libraries/doltcore/schema/typeinfo/enum.go
@@ -80,7 +80,7 @@ func (ti *enumType) ConvertNomsValueToValue(v types.Value) (interface{}, error) 
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
-
+// ReadFrom reads a go value from a noms types.CodecReader directly
 func (ti *enumType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
 	k := reader.ReadKind()
 	switch k {

--- a/go/libraries/doltcore/schema/typeinfo/float.go
+++ b/go/libraries/doltcore/schema/typeinfo/float.go
@@ -72,6 +72,25 @@ func (ti *floatType) ConvertNomsValueToValue(v types.Value) (interface{}, error)
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
+
+func (ti *floatType) ReadFrom(nbf *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
+	k := reader.ReadKind()
+	switch k {
+	case types.FloatKind:
+		f := reader.ReadFloat(nbf)
+		switch ti.sqlFloatType {
+		case sql.Float32:
+			return float32(f), nil
+		case sql.Float64:
+			return f, nil
+		}
+	case types.NullKind:
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), k)
+}
+
 // ConvertValueToNomsValue implements TypeInfo interface.
 func (ti *floatType) ConvertValueToNomsValue(v interface{}) (types.Value, error) {
 	if v == nil {

--- a/go/libraries/doltcore/schema/typeinfo/float.go
+++ b/go/libraries/doltcore/schema/typeinfo/float.go
@@ -72,7 +72,7 @@ func (ti *floatType) ConvertNomsValueToValue(v types.Value) (interface{}, error)
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
-
+// ReadFrom reads a go value from a noms types.CodecReader directly
 func (ti *floatType) ReadFrom(nbf *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
 	k := reader.ReadKind()
 	switch k {

--- a/go/libraries/doltcore/schema/typeinfo/inlineblob.go
+++ b/go/libraries/doltcore/schema/typeinfo/inlineblob.go
@@ -43,6 +43,7 @@ func (ti *inlineBlobType) ConvertNomsValueToValue(v types.Value) (interface{}, e
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
+// ReadFrom reads a go value from a noms types.CodecReader directly
 func (ti *inlineBlobType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
 	k := reader.ReadKind()
 	switch k {

--- a/go/libraries/doltcore/schema/typeinfo/inlineblob.go
+++ b/go/libraries/doltcore/schema/typeinfo/inlineblob.go
@@ -43,6 +43,19 @@ func (ti *inlineBlobType) ConvertNomsValueToValue(v types.Value) (interface{}, e
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
+func (ti *inlineBlobType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
+	k := reader.ReadKind()
+	switch k {
+	case types.InlineBlobKind:
+		bytes := reader.ReadInlineBlob()
+		return bytes, nil
+	case types.NullKind:
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), k)
+}
+
 // ConvertValueToNomsValue implements TypeInfo interface.
 func (ti *inlineBlobType) ConvertValueToNomsValue(v interface{}) (types.Value, error) {
 	if v == nil {

--- a/go/libraries/doltcore/schema/typeinfo/inlineblob.go
+++ b/go/libraries/doltcore/schema/typeinfo/inlineblob.go
@@ -49,7 +49,7 @@ func (ti *inlineBlobType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecRea
 	switch k {
 	case types.InlineBlobKind:
 		bytes := reader.ReadInlineBlob()
-		return bytes, nil
+		return string(bytes), nil
 	case types.NullKind:
 		return nil, nil
 	}

--- a/go/libraries/doltcore/schema/typeinfo/int.go
+++ b/go/libraries/doltcore/schema/typeinfo/int.go
@@ -87,6 +87,29 @@ func (ti *intType) ConvertNomsValueToValue(v types.Value) (interface{}, error) {
 	}
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
+func (ti *intType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
+	k := reader.ReadKind()
+	switch k {
+	case types.IntKind:
+		val := reader.ReadInt()
+		switch ti.sqlIntType {
+		case sql.Int8:
+			return int8(val), nil
+		case sql.Int16:
+			return int16(val), nil
+		case sql.Int24:
+			return int32(val), nil
+		case sql.Int32:
+			return int32(val), nil
+		case sql.Int64:
+			return int64(val), nil
+		}
+	case types.NullKind:
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), k)
+}
 
 // ConvertValueToNomsValue implements TypeInfo interface.
 func (ti *intType) ConvertValueToNomsValue(v interface{}) (types.Value, error) {

--- a/go/libraries/doltcore/schema/typeinfo/int.go
+++ b/go/libraries/doltcore/schema/typeinfo/int.go
@@ -87,6 +87,8 @@ func (ti *intType) ConvertNomsValueToValue(v types.Value) (interface{}, error) {
 	}
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
+
+// ReadFrom reads a go value from a noms types.CodecReader directly
 func (ti *intType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
 	k := reader.ReadKind()
 	switch k {

--- a/go/libraries/doltcore/schema/typeinfo/set.go
+++ b/go/libraries/doltcore/schema/typeinfo/set.go
@@ -80,6 +80,23 @@ func (ti *setType) ConvertNomsValueToValue(v types.Value) (interface{}, error) {
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
+func (ti *setType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
+	k := reader.ReadKind()
+	switch k {
+	case types.UintKind:
+		val := reader.ReadUint()
+		res, err := ti.sqlSetType.Unmarshal(uint64(val))
+		if err != nil {
+			return nil, fmt.Errorf(`"%v" cannot convert "%v" to value`, ti.String(), val)
+		}
+		return res, nil
+	case types.NullKind:
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), k)
+}
+
 // ConvertValueToNomsValue implements TypeInfo interface.
 func (ti *setType) ConvertValueToNomsValue(v interface{}) (types.Value, error) {
 	if v == nil {

--- a/go/libraries/doltcore/schema/typeinfo/set.go
+++ b/go/libraries/doltcore/schema/typeinfo/set.go
@@ -80,6 +80,7 @@ func (ti *setType) ConvertNomsValueToValue(v types.Value) (interface{}, error) {
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
+// ReadFrom reads a go value from a noms types.CodecReader directly
 func (ti *setType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
 	k := reader.ReadKind()
 	switch k {

--- a/go/libraries/doltcore/schema/typeinfo/time.go
+++ b/go/libraries/doltcore/schema/typeinfo/time.go
@@ -43,6 +43,7 @@ func (ti *timeType) ConvertNomsValueToValue(v types.Value) (interface{}, error) 
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
+// ReadFrom reads a go value from a noms types.CodecReader directly
 func (ti *timeType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
 	k := reader.ReadKind()
 	switch k {

--- a/go/libraries/doltcore/schema/typeinfo/time.go
+++ b/go/libraries/doltcore/schema/typeinfo/time.go
@@ -43,6 +43,19 @@ func (ti *timeType) ConvertNomsValueToValue(v types.Value) (interface{}, error) 
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
+func (ti *timeType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
+	k := reader.ReadKind()
+	switch k {
+	case types.IntKind:
+		val := reader.ReadInt()
+		return ti.sqlTimeType.Unmarshal(val), nil
+	case types.NullKind:
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), k)
+}
+
 // ConvertValueToNomsValue implements TypeInfo interface.
 func (ti *timeType) ConvertValueToNomsValue(v interface{}) (types.Value, error) {
 	if v == nil {

--- a/go/libraries/doltcore/schema/typeinfo/tuple.go
+++ b/go/libraries/doltcore/schema/typeinfo/tuple.go
@@ -37,6 +37,7 @@ func (ti *tupleType) ConvertNomsValueToValue(v types.Value) (interface{}, error)
 	return v, nil
 }
 
+// ReadFrom reads a go value from a noms types.CodecReader directly
 func (ti *tupleType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
 	k := reader.ReadKind()
 	switch k {

--- a/go/libraries/doltcore/schema/typeinfo/tuple.go
+++ b/go/libraries/doltcore/schema/typeinfo/tuple.go
@@ -37,6 +37,16 @@ func (ti *tupleType) ConvertNomsValueToValue(v types.Value) (interface{}, error)
 	return v, nil
 }
 
+func (ti *tupleType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
+	k := reader.ReadKind()
+	switch k {
+	case types.NullKind:
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), k)
+}
+
 // ConvertValueToNomsValue implements TypeInfo interface.
 func (ti *tupleType) ConvertValueToNomsValue(v interface{}) (types.Value, error) {
 	if tVal, ok := v.(types.Value); ok {

--- a/go/libraries/doltcore/schema/typeinfo/typeinfo.go
+++ b/go/libraries/doltcore/schema/typeinfo/typeinfo.go
@@ -74,7 +74,7 @@ type TypeInfo interface {
 	ConvertNomsValueToValue(v types.Value) (interface{}, error)
 
 	// ReadFrom reads a go value from a noms types.CodecReader directly
-    ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error)
+	ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error)
 
 	// ConvertValueToNomsValue converts a go value or Noms value to a Noms value. The type of the Noms
 	// value will be equivalent to the NomsKind returned from NomsKind.

--- a/go/libraries/doltcore/schema/typeinfo/typeinfo.go
+++ b/go/libraries/doltcore/schema/typeinfo/typeinfo.go
@@ -73,7 +73,8 @@ type TypeInfo interface {
 	// the given type.
 	ConvertNomsValueToValue(v types.Value) (interface{}, error)
 
-	ReadNomsPrimitiveAsSql(reader types.PrimitiveNomsReader) (interface{}, error) {
+	// ReadFrom reads a go value from a noms types.CodecReader directly
+    ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error)
 
 	// ConvertValueToNomsValue converts a go value or Noms value to a Noms value. The type of the Noms
 	// value will be equivalent to the NomsKind returned from NomsKind.

--- a/go/libraries/doltcore/schema/typeinfo/typeinfo.go
+++ b/go/libraries/doltcore/schema/typeinfo/typeinfo.go
@@ -74,7 +74,7 @@ type TypeInfo interface {
 	ConvertNomsValueToValue(v types.Value) (interface{}, error)
 
 	// ReadFrom reads a go value from a noms types.CodecReader directly
-	ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error)
+	ReadFrom(nbf *types.NomsBinFormat, reader types.CodecReader) (interface{}, error)
 
 	// ConvertValueToNomsValue converts a go value or Noms value to a Noms value. The type of the Noms
 	// value will be equivalent to the NomsKind returned from NomsKind.

--- a/go/libraries/doltcore/schema/typeinfo/typeinfo.go
+++ b/go/libraries/doltcore/schema/typeinfo/typeinfo.go
@@ -73,6 +73,8 @@ type TypeInfo interface {
 	// the given type.
 	ConvertNomsValueToValue(v types.Value) (interface{}, error)
 
+	ReadNomsPrimitiveAsSql(reader types.PrimitiveNomsReader) (interface{}, error) {
+
 	// ConvertValueToNomsValue converts a go value or Noms value to a Noms value. The type of the Noms
 	// value will be equivalent to the NomsKind returned from NomsKind.
 	ConvertValueToNomsValue(v interface{}) (types.Value, error)

--- a/go/libraries/doltcore/schema/typeinfo/uint.go
+++ b/go/libraries/doltcore/schema/typeinfo/uint.go
@@ -88,6 +88,30 @@ func (ti *uintType) ConvertNomsValueToValue(v types.Value) (interface{}, error) 
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
+func (ti *uintType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
+	k := reader.ReadKind()
+	switch k {
+	case types.UintKind:
+		val := reader.ReadUint()
+		switch ti.sqlUintType {
+		case sql.Uint8:
+			return uint8(val), nil
+		case sql.Uint16:
+			return uint16(val), nil
+		case sql.Uint24:
+			return uint32(val), nil
+		case sql.Uint32:
+			return uint32(val), nil
+		case sql.Uint64:
+			return val, nil
+		}
+	case types.NullKind:
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), k)
+}
+
 // ConvertValueToNomsValue implements TypeInfo interface.
 func (ti *uintType) ConvertValueToNomsValue(v interface{}) (types.Value, error) {
 	if v == nil {

--- a/go/libraries/doltcore/schema/typeinfo/uint.go
+++ b/go/libraries/doltcore/schema/typeinfo/uint.go
@@ -88,6 +88,7 @@ func (ti *uintType) ConvertNomsValueToValue(v types.Value) (interface{}, error) 
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
+// ReadFrom reads a go value from a noms types.CodecReader directly
 func (ti *uintType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
 	k := reader.ReadKind()
 	switch k {

--- a/go/libraries/doltcore/schema/typeinfo/unknown.go
+++ b/go/libraries/doltcore/schema/typeinfo/unknown.go
@@ -32,6 +32,8 @@ var UnknownType TypeInfo = &unknownImpl{}
 func (ti *unknownImpl) ConvertNomsValueToValue(types.Value) (interface{}, error) {
 	return nil, fmt.Errorf(`"Unknown" cannot convert any Noms value to a go value`)
 }
+
+// ReadFrom reads a go value from a noms types.CodecReader directly
 func (ti *unknownImpl) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
 	return nil, fmt.Errorf(`"Unknown" cannot read any Noms value to a go value`)
 }

--- a/go/libraries/doltcore/schema/typeinfo/unknown.go
+++ b/go/libraries/doltcore/schema/typeinfo/unknown.go
@@ -32,6 +32,9 @@ var UnknownType TypeInfo = &unknownImpl{}
 func (ti *unknownImpl) ConvertNomsValueToValue(types.Value) (interface{}, error) {
 	return nil, fmt.Errorf(`"Unknown" cannot convert any Noms value to a go value`)
 }
+func (ti *unknownImpl) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
+	return nil, fmt.Errorf(`"Unknown" cannot read any Noms value to a go value`)
+}
 
 // ConvertValueToNomsValue implements TypeInfo interface.
 func (ti *unknownImpl) ConvertValueToNomsValue(interface{}) (types.Value, error) {

--- a/go/libraries/doltcore/schema/typeinfo/uuid.go
+++ b/go/libraries/doltcore/schema/typeinfo/uuid.go
@@ -43,6 +43,19 @@ func (ti *uuidType) ConvertNomsValueToValue(v types.Value) (interface{}, error) 
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
+func (ti *uuidType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
+	k := reader.ReadKind()
+	switch k {
+	case types.UUIDKind:
+		val := reader.ReadUUID()
+		return val.String(), nil
+	case types.NullKind:
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), k)
+}
+
 // ConvertValueToNomsValue implements TypeInfo interface.
 func (ti *uuidType) ConvertValueToNomsValue(v interface{}) (types.Value, error) {
 	switch val := v.(type) {

--- a/go/libraries/doltcore/schema/typeinfo/uuid.go
+++ b/go/libraries/doltcore/schema/typeinfo/uuid.go
@@ -43,6 +43,7 @@ func (ti *uuidType) ConvertNomsValueToValue(v types.Value) (interface{}, error) 
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
+// ReadFrom reads a go value from a noms types.CodecReader directly
 func (ti *uuidType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
 	k := reader.ReadKind()
 	switch k {

--- a/go/libraries/doltcore/schema/typeinfo/varbinary.go
+++ b/go/libraries/doltcore/schema/typeinfo/varbinary.go
@@ -85,6 +85,7 @@ func (ti *varBinaryType) ConvertNomsValueToValue(v types.Value) (interface{}, er
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
+// ReadFrom reads a go value from a noms types.CodecReader directly
 func (ti *varBinaryType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
 	k := reader.ReadKind()
 	switch k {

--- a/go/libraries/doltcore/schema/typeinfo/varbinary.go
+++ b/go/libraries/doltcore/schema/typeinfo/varbinary.go
@@ -87,16 +87,8 @@ func (ti *varBinaryType) ConvertNomsValueToValue(v types.Value) (interface{}, er
 
 // ReadFrom reads a go value from a noms types.CodecReader directly
 func (ti *varBinaryType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
-	k := reader.ReadKind()
-	switch k {
-	case types.StringKind:
-		val := reader.ReadString()
-		return val, nil
-	case types.NullKind:
-		return nil, nil
-	}
-
-	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), k)
+	// todo - implement
+	panic("not implemented yet")
 }
 
 // ConvertValueToNomsValue implements TypeInfo interface.

--- a/go/libraries/doltcore/schema/typeinfo/varbinary.go
+++ b/go/libraries/doltcore/schema/typeinfo/varbinary.go
@@ -85,6 +85,19 @@ func (ti *varBinaryType) ConvertNomsValueToValue(v types.Value) (interface{}, er
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
+func (ti *varBinaryType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
+	k := reader.ReadKind()
+	switch k {
+	case types.StringKind:
+		val := reader.ReadString()
+		return val, nil
+	case types.NullKind:
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), k)
+}
+
 // ConvertValueToNomsValue implements TypeInfo interface.
 func (ti *varBinaryType) ConvertValueToNomsValue(v interface{}) (types.Value, error) {
 	if v == nil {

--- a/go/libraries/doltcore/schema/typeinfo/varstring.go
+++ b/go/libraries/doltcore/schema/typeinfo/varstring.go
@@ -98,6 +98,26 @@ func (ti *varStringType) ConvertNomsValueToValue(v types.Value) (interface{}, er
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
+func (ti *varStringType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
+	k := reader.ReadKind()
+	switch k {
+	case types.StringKind:
+		val := reader.ReadString()
+		// As per the MySQL documentation, trailing spaces are removed when retrieved for CHAR types only.
+		// This function is used to retrieve dolt values, hence its inclusion here and not elsewhere.
+		// https://dev.mysql.com/doc/refman/8.0/en/char.html
+		if ti.sqlStringType.Type() == sqltypes.Char {
+			val = strings.TrimRightFunc(val, unicode.IsSpace)
+		}
+		return val, nil
+
+	case types.NullKind:
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), k)
+}
+
 // ConvertValueToNomsValue implements TypeInfo interface.
 func (ti *varStringType) ConvertValueToNomsValue(v interface{}) (types.Value, error) {
 	if v == nil {

--- a/go/libraries/doltcore/schema/typeinfo/varstring.go
+++ b/go/libraries/doltcore/schema/typeinfo/varstring.go
@@ -98,6 +98,7 @@ func (ti *varStringType) ConvertNomsValueToValue(v types.Value) (interface{}, er
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
+// ReadFrom reads a go value from a noms types.CodecReader directly
 func (ti *varStringType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
 	k := reader.ReadKind()
 	switch k {

--- a/go/libraries/doltcore/schema/typeinfo/year.go
+++ b/go/libraries/doltcore/schema/typeinfo/year.go
@@ -44,6 +44,19 @@ func (ti *yearType) ConvertNomsValueToValue(v types.Value) (interface{}, error) 
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
+func (ti *yearType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
+	k := reader.ReadKind()
+	switch k {
+	case types.IntKind:
+		val := reader.ReadInt()
+		return int16(val), nil
+	case types.NullKind:
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), k)
+}
+
 // ConvertValueToNomsValue implements TypeInfo interface.
 func (ti *yearType) ConvertValueToNomsValue(v interface{}) (types.Value, error) {
 	if v == nil {

--- a/go/libraries/doltcore/schema/typeinfo/year.go
+++ b/go/libraries/doltcore/schema/typeinfo/year.go
@@ -44,6 +44,7 @@ func (ti *yearType) ConvertNomsValueToValue(v types.Value) (interface{}, error) 
 	return nil, fmt.Errorf(`"%v" cannot convert NomsKind "%v" to a value`, ti.String(), v.Kind())
 }
 
+// ReadFrom reads a go value from a noms types.CodecReader directly
 func (ti *yearType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
 	k := reader.ReadKind()
 	switch k {

--- a/go/libraries/doltcore/sqle/dolt_map_iter.go
+++ b/go/libraries/doltcore/sqle/dolt_map_iter.go
@@ -158,7 +158,7 @@ func (conv *KVToSqlRowConverter) processTuple(cols []interface{}, valsToFill int
 		}
 
 		if sqlColIdx, ok := conv.tagToSqlColIdx[tag64]; !ok {
-			err = tupItr.Skip()
+			err = primReader.SkipValue(nbf)
 
 			if err != nil {
 				return err

--- a/go/libraries/doltcore/sqle/dolt_map_iter.go
+++ b/go/libraries/doltcore/sqle/dolt_map_iter.go
@@ -141,7 +141,7 @@ func (conv *KVToSqlRowConverter) processTuple(cols []interface{}, valsToFill int
 	primReader, numPrimitives := tupItr.CodecReader()
 
 	filled := 0
-	for pos := uint64(0); pos + 1 < numPrimitives; pos += 2 {
+	for pos := uint64(0); pos+1 < numPrimitives; pos += 2 {
 		if filled >= valsToFill {
 			break
 		}

--- a/go/store/types/bool.go
+++ b/go/store/types/bool.go
@@ -88,7 +88,7 @@ func (b Bool) writeTo(w nomsWriter, nbf *NomsBinFormat) error {
 }
 
 func (b Bool) readFrom(nbf *NomsBinFormat, bnr *binaryNomsReader) (Value, error) {
-	return Bool(bnr.readBool()), nil
+	return Bool(bnr.ReadBool()), nil
 }
 
 func (b Bool) skip(nbf *NomsBinFormat, bnr *binaryNomsReader) {

--- a/go/store/types/codec.go
+++ b/go/store/types/codec.go
@@ -94,21 +94,6 @@ type nomsWriter interface {
 	writeRaw(buff []byte)
 }
 
-type CodecReader interface {
-	ReadKind() NomsKind
-	ReadUint() uint64
-	ReadInt() int64
-	ReadFloat(nbf *NomsBinFormat) float64
-	ReadBool() bool
-	ReadUUID() uuid.UUID
-	ReadString() string
-	ReadInlineBlob() []byte
-	ReadTimestamp() (time.Time, error)
-	ReadDecimal() (decimal.Decimal, error)
-}
-
-var _ CodecReader = (*binaryNomsReader)(nil)
-
 type binaryNomsReader struct {
 	buff   []byte
 	offset uint32

--- a/go/store/types/codec.go
+++ b/go/store/types/codec.go
@@ -23,10 +23,11 @@ package types
 
 import (
 	"encoding/binary"
-	"github.com/google/uuid"
-	"github.com/shopspring/decimal"
 	"math"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
 
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/d"

--- a/go/store/types/codec_test.go
+++ b/go/store/types/codec_test.go
@@ -56,7 +56,7 @@ func TestCodecWriteFloat(t *testing.T) {
 func TestCodecReadFloat(t *testing.T) {
 	test := func(data []byte, exp float64) {
 		r := binaryNomsReader{buff: data}
-		n := r.readFloat(Format_7_18)
+		n := r.ReadFloat(Format_7_18)
 		assert.Equal(t, exp, n)
 		assert.Equal(t, len(data), int(r.offset))
 	}

--- a/go/store/types/compare_test.go
+++ b/go/store/types/compare_test.go
@@ -139,9 +139,9 @@ func compareEncodedNomsValues(a, b []byte) int {
 		return bytes.Compare(a, b)
 	case IntKind:
 		reader := binaryNomsReader{a[1:], 0}
-		aNum := Int(reader.readInt())
+		aNum := Int(reader.ReadInt())
 		reader.buff, reader.offset = b[1:], 0
-		bNum := Int(reader.readInt())
+		bNum := Int(reader.ReadInt())
 		if aNum == bNum {
 			return 0
 		}
@@ -151,9 +151,9 @@ func compareEncodedNomsValues(a, b []byte) int {
 		return 1
 	case UintKind:
 		reader := binaryNomsReader{a[1:], 0}
-		aNum := Uint(reader.readUint())
+		aNum := Uint(reader.ReadUint())
 		reader.buff, reader.offset = b[1:], 0
-		bNum := Uint(reader.readUint())
+		bNum := Uint(reader.ReadUint())
 		if aNum == bNum {
 			return 0
 		}
@@ -163,9 +163,9 @@ func compareEncodedNomsValues(a, b []byte) int {
 		return 1
 	case FloatKind:
 		reader := binaryNomsReader{a[1:], 0}
-		aNum := Float(reader.readFloat(Format_7_18))
+		aNum := Float(reader.ReadFloat(Format_7_18))
 		reader.buff, reader.offset = b[1:], 0
-		bNum := Float(reader.readFloat(Format_7_18))
+		bNum := Float(reader.ReadFloat(Format_7_18))
 		if aNum == bNum {
 			return 0
 		}

--- a/go/store/types/decimal.go
+++ b/go/store/types/decimal.go
@@ -89,10 +89,7 @@ func (v Decimal) writeTo(w nomsWriter, nbf *NomsBinFormat) error {
 }
 
 func (v Decimal) readFrom(nbf *NomsBinFormat, b *binaryNomsReader) (Value, error) {
-	size := uint32(b.readUint16())
-	db := b.readBytes(size)
-	dec := decimal.Decimal{}
-	err := dec.GobDecode(db)
+	dec, err := b.ReadDecimal()
 	if err != nil {
 		return nil, err
 	}

--- a/go/store/types/float.go
+++ b/go/store/types/float.go
@@ -87,7 +87,7 @@ func (v Float) writeTo(w nomsWriter, nbf *NomsBinFormat) error {
 }
 
 func (v Float) readFrom(nbf *NomsBinFormat, b *binaryNomsReader) (Value, error) {
-	return Float(b.readFloat(nbf)), nil
+	return Float(b.ReadFloat(nbf)), nil
 }
 
 func (v Float) skip(nbf *NomsBinFormat, b *binaryNomsReader) {

--- a/go/store/types/inlineblob.go
+++ b/go/store/types/inlineblob.go
@@ -92,9 +92,8 @@ func (v InlineBlob) writeTo(w nomsWriter, nbf *NomsBinFormat) error {
 }
 
 func (v InlineBlob) readFrom(nbf *NomsBinFormat, b *binaryNomsReader) (Value, error) {
-	size := uint32(b.readUint16())
-	ib := b.readBytes(size)
-	return InlineBlob(ib), nil
+	bytes := b.ReadInlineBlob()
+	return InlineBlob(bytes), nil
 }
 
 func (v InlineBlob) skip(nbf *NomsBinFormat, b *binaryNomsReader) {

--- a/go/store/types/int.go
+++ b/go/store/types/int.go
@@ -88,7 +88,7 @@ func (v Int) writeTo(w nomsWriter, nbf *NomsBinFormat) error {
 }
 
 func (v Int) readFrom(nbf *NomsBinFormat, b *binaryNomsReader) (Value, error) {
-	return Int(b.readInt()), nil
+	return Int(b.ReadInt()), nil
 }
 
 func (v Int) skip(nbf *NomsBinFormat, b *binaryNomsReader) {

--- a/go/store/types/leaf_sequence.go
+++ b/go/store/types/leaf_sequence.go
@@ -116,7 +116,7 @@ func (seq leafSequence) getCompareFn(other sequence) compareFn {
 
 func (seq leafSequence) typeOf() (*Type, error) {
 	dec := seq.decoder()
-	kind := dec.readKind()
+	kind := dec.ReadKind()
 	dec.skipCount() // level
 	count := dec.readCount()
 	ts := make(typeSlice, 0, count)

--- a/go/store/types/map_leaf_sequence.go
+++ b/go/store/types/map_leaf_sequence.go
@@ -316,7 +316,7 @@ func (ml mapLeafSequence) search(key orderedKey) (int, error) {
 
 func (ml mapLeafSequence) getValue(idx int) (Value, error) {
 	dec := ml.decoderSkipToIndex(idx)
-	err := dec.skipValue(ml.format())
+	err := dec.SkipValue(ml.format())
 
 	if err != nil {
 		return nil, err

--- a/go/store/types/meta_sequence.go
+++ b/go/store/types/meta_sequence.go
@@ -232,7 +232,7 @@ func (ms metaSequence) tuples() ([]metaTuple, error) {
 
 func (ms metaSequence) getKey(idx int) (orderedKey, error) {
 	dec := ms.decoderSkipToIndex(idx)
-	err := dec.skipValue(ms.format()) // ref
+	err := dec.SkipValue(ms.format()) // ref
 
 	if err != nil {
 		return orderedKey{}, err
@@ -269,13 +269,13 @@ func (ms metaSequence) cumulativeNumberOfLeaves(idx int) (uint64, error) {
 	cum := uint64(0)
 	dec, _ := ms.decoderSkipToValues()
 	for i := 0; i <= idx; i++ {
-		err := dec.skipValue(ms.format()) // ref
+		err := dec.SkipValue(ms.format()) // ref
 
 		if err != nil {
 			return 0, err
 		}
 
-		err = dec.skipValue(ms.format()) // v
+		err = dec.SkipValue(ms.format()) // v
 
 		if err != nil {
 			return 0, err
@@ -337,7 +337,7 @@ func (ms metaSequence) getRefAt(dec *valueDecoder, idx int) (Ref, error) {
 
 func (ms metaSequence) getNumLeavesAt(idx int) (uint64, error) {
 	dec := ms.decoderSkipToIndex(idx)
-	err := dec.skipValue(ms.format())
+	err := dec.SkipValue(ms.format())
 
 	if err != nil {
 		return 0, err

--- a/go/store/types/string.go
+++ b/go/store/types/string.go
@@ -90,7 +90,7 @@ func (s String) writeTo(w nomsWriter, nbf *NomsBinFormat) error {
 }
 
 func (s String) readFrom(nbf *NomsBinFormat, b *binaryNomsReader) (Value, error) {
-	return String(b.readString()), nil
+	return String(b.ReadString()), nil
 }
 
 func (s String) skip(nbf *NomsBinFormat, b *binaryNomsReader) {

--- a/go/store/types/struct.go
+++ b/go/store/types/struct.go
@@ -242,11 +242,11 @@ func (s Struct) typeOf() (*Type, error) {
 
 func readStructTypeOfValue(nbf *NomsBinFormat, dec *valueDecoder) (*Type, error) {
 	dec.skipKind()
-	name := dec.readString()
+	name := dec.ReadString()
 	count := dec.readCount()
 	typeFields := make(structTypeFields, count)
 	for i := uint64(0); i < count; i++ {
-		fname := dec.readString()
+		fname := dec.ReadString()
 		t, err := dec.readTypeOfValue(nbf)
 
 		if err != nil {
@@ -281,7 +281,7 @@ func (s Struct) Len() int {
 func (s Struct) Name() string {
 	dec := s.decoder()
 	dec.skipKind()
-	return dec.readString()
+	return dec.ReadString()
 }
 
 // IterFields iterates over the fields, calling cb for every field in the
@@ -289,7 +289,7 @@ func (s Struct) Name() string {
 func (s Struct) IterFields(cb func(name string, value Value) error) error {
 	dec, count := s.decoderSkipToFields()
 	for i := uint64(0); i < count; i++ {
-		fldName := dec.readString()
+		fldName := dec.ReadString()
 		val, err := dec.readValue(s.format())
 
 		if err != nil {
@@ -317,11 +317,11 @@ type structPartCallbacks interface {
 func (s Struct) iterParts(ctx context.Context, cbs structPartCallbacks) error {
 	dec := s.decoder()
 	dec.skipKind()
-	cbs.name(ctx, dec.readString())
+	cbs.name(ctx, dec.ReadString())
 	count := dec.readCount()
 	cbs.count(count)
 	for i := uint64(0); i < count; i++ {
-		cbs.fieldName(dec.readString())
+		cbs.fieldName(dec.ReadString())
 		val, err := dec.readValue(s.format())
 
 		if err != nil {
@@ -343,7 +343,7 @@ func (s Struct) iterParts(ctx context.Context, cbs structPartCallbacks) error {
 func (s Struct) MaybeGet(n string) (v Value, found bool, err error) {
 	dec, count := s.decoderSkipToFields()
 	for i := uint64(0); i < count; i++ {
-		name := dec.readString()
+		name := dec.ReadString()
 		if name == n {
 			found = true
 			v, err = dec.readValue(s.format())
@@ -413,7 +413,7 @@ func (s Struct) splitFieldsAt(name string) (prolog, head, tail []byte, count uin
 
 	for i := uint64(0); i < count; i++ {
 		beforeCurrent := dec.offset
-		fn := dec.readString()
+		fn := dec.ReadString()
 		err = dec.skipValue(s.format())
 
 		if err != nil {
@@ -478,10 +478,10 @@ func (s Struct) Diff(ctx context.Context, last Struct, changes chan<- ValueChang
 
 	for i1 < count1 && i2 < count2 {
 		if fn1 == "" {
-			fn1 = dec1.readString()
+			fn1 = dec1.ReadString()
 		}
 		if fn2 == "" {
-			fn2 = dec2.readString()
+			fn2 = dec2.ReadString()
 		}
 		var change ValueChanged
 		if fn1 == fn2 {
@@ -534,7 +534,7 @@ func (s Struct) Diff(ctx context.Context, last Struct, changes chan<- ValueChang
 
 	for ; i1 < count1; i1++ {
 		if fn1 == "" {
-			fn1 = dec1.readString()
+			fn1 = dec1.ReadString()
 			fmt.Println(fn1)
 		}
 		v1, err := dec1.readValue(s.format())
@@ -550,7 +550,7 @@ func (s Struct) Diff(ctx context.Context, last Struct, changes chan<- ValueChang
 
 	for ; i2 < count2; i2++ {
 		if fn2 == "" {
-			fn2 = dec2.readString()
+			fn2 = dec2.ReadString()
 		}
 
 		v2, err := dec2.readValue(s.format())

--- a/go/store/types/struct.go
+++ b/go/store/types/struct.go
@@ -64,7 +64,7 @@ func skipStruct(nbf *NomsBinFormat, dec *valueDecoder) error {
 	count := dec.readCount()
 	for i := uint64(0); i < count; i++ {
 		dec.skipString()
-		err := dec.skipValue(nbf)
+		err := dec.SkipValue(nbf)
 
 		if err != nil {
 			return err
@@ -359,7 +359,7 @@ func (s Struct) MaybeGet(n string) (v Value, found bool, err error) {
 			return
 		}
 
-		err = dec.skipValue(s.format())
+		err = dec.SkipValue(s.format())
 
 		if err != nil {
 			return nil, false, err
@@ -414,7 +414,7 @@ func (s Struct) splitFieldsAt(name string) (prolog, head, tail []byte, count uin
 	for i := uint64(0); i < count; i++ {
 		beforeCurrent := dec.offset
 		fn := dec.ReadString()
-		err = dec.skipValue(s.format())
+		err = dec.SkipValue(s.format())
 
 		if err != nil {
 			return nil, nil, nil, 0, false, err

--- a/go/store/types/timestamp.go
+++ b/go/store/types/timestamp.go
@@ -92,13 +92,12 @@ func (v Timestamp) writeTo(w nomsWriter, nbf *NomsBinFormat) error {
 }
 
 func (v Timestamp) readFrom(nbf *NomsBinFormat, b *binaryNomsReader) (Value, error) {
-	data := b.readBytes(timestampNumBytes)
-	t := time.Time{}
-	err := t.UnmarshalBinary(data)
+	t, err := b.ReadTimestamp()
 	if err != nil {
 		return nil, err
 	}
 	return Timestamp(t), nil
+
 }
 
 func (v Timestamp) skip(nbf *NomsBinFormat, b *binaryNomsReader) {

--- a/go/store/types/tuple.go
+++ b/go/store/types/tuple.go
@@ -136,6 +136,10 @@ func (itr *TupleIterator) Next() (uint64, Value, error) {
 	return itr.count, nil, nil
 }
 
+func (itr *TupleIterator) PrimitiveReader() (PrimitiveNomsReader, uint64) {
+	return (&itr.dec.binaryNomsReader, itr.count-itr.pos)
+}
+
 func (itr *TupleIterator) Skip() error {
 	if itr.pos < itr.count {
 		err := itr.dec.skipValue(itr.nbf)

--- a/go/store/types/tuple.go
+++ b/go/store/types/tuple.go
@@ -136,8 +136,8 @@ func (itr *TupleIterator) Next() (uint64, Value, error) {
 	return itr.count, nil, nil
 }
 
-func (itr *TupleIterator) PrimitiveReader() (PrimitiveNomsReader, uint64) {
-	return (&itr.dec.binaryNomsReader, itr.count-itr.pos)
+func (itr *TupleIterator) CodecReader() (CodecReader, uint64) {
+	return &itr.dec.binaryNomsReader, itr.count - itr.pos
 }
 
 func (itr *TupleIterator) Skip() error {

--- a/go/store/types/tuple.go
+++ b/go/store/types/tuple.go
@@ -137,12 +137,12 @@ func (itr *TupleIterator) Next() (uint64, Value, error) {
 }
 
 func (itr *TupleIterator) CodecReader() (CodecReader, uint64) {
-	return &itr.dec.binaryNomsReader, itr.count - itr.pos
+	return itr.dec, itr.count - itr.pos
 }
 
 func (itr *TupleIterator) Skip() error {
 	if itr.pos < itr.count {
-		err := itr.dec.skipValue(itr.nbf)
+		err := itr.dec.SkipValue(itr.nbf)
 
 		if err != nil {
 			return err
@@ -184,7 +184,7 @@ func (itr *TupleIterator) InitForTupleAt(t Tuple, pos uint64) error {
 	count := itr.dec.readCount()
 
 	for i := uint64(0); i < pos; i++ {
-		err := itr.dec.skipValue(t.format())
+		err := itr.dec.SkipValue(t.format())
 
 		if err != nil {
 			return err
@@ -217,7 +217,7 @@ func skipTuple(nbf *NomsBinFormat, dec *valueDecoder) error {
 	dec.skipKind()
 	count := dec.readCount()
 	for i := uint64(0); i < count; i++ {
-		err := dec.skipValue(nbf)
+		err := dec.SkipValue(nbf)
 
 		if err != nil {
 			return err
@@ -460,7 +460,7 @@ func (t Tuple) Get(n uint64) (Value, error) {
 	}
 
 	for i := uint64(0); i < n; i++ {
-		err := dec.skipValue(t.format())
+		err := dec.SkipValue(t.format())
 
 		if err != nil {
 			return nil, err
@@ -534,7 +534,7 @@ func (t Tuple) splitFieldsAt(n uint64) (prolog, head, tail []byte, count uint64,
 	fieldsOffset := dec.offset
 
 	for i := uint64(0); i < n; i++ {
-		err := dec.skipValue(t.format())
+		err := dec.SkipValue(t.format())
 
 		if err != nil {
 			return nil, nil, nil, 0, false, err
@@ -544,7 +544,7 @@ func (t Tuple) splitFieldsAt(n uint64) (prolog, head, tail []byte, count uint64,
 	head = dec.buff[fieldsOffset:dec.offset]
 
 	if n != count-1 {
-		err := dec.skipValue(t.format())
+		err := dec.SkipValue(t.format())
 
 		if err != nil {
 			return nil, nil, nil, 0, false, err

--- a/go/store/types/uint.go
+++ b/go/store/types/uint.go
@@ -89,7 +89,7 @@ func (v Uint) writeTo(w nomsWriter, nbf *NomsBinFormat) error {
 }
 
 func (v Uint) readFrom(nbf *NomsBinFormat, b *binaryNomsReader) (Value, error) {
-	return Uint(b.readUint()), nil
+	return Uint(b.ReadUint()), nil
 }
 
 func (v Uint) skip(nbf *NomsBinFormat, b *binaryNomsReader) {

--- a/go/store/types/uuid.go
+++ b/go/store/types/uuid.go
@@ -103,10 +103,9 @@ func (v UUID) writeTo(w nomsWriter, nbf *NomsBinFormat) error {
 	return nil
 }
 
-func (v UUID) readFrom(nbf *NomsBinFormat, b *binaryNomsReader) (Value, error) {
-	id := UUID{}
-	copy(id[:uuidNumBytes], b.readBytes(uuidNumBytes))
-	return id, nil
+func (v UUID) readFrom(_ *NomsBinFormat, b *binaryNomsReader) (Value, error) {
+	id := b.ReadUUID()
+	return UUID(id), nil
 }
 
 func (v UUID) skip(nbf *NomsBinFormat, b *binaryNomsReader) {

--- a/go/store/types/value_decoder.go
+++ b/go/store/types/value_decoder.go
@@ -275,22 +275,22 @@ func (r *valueDecoder) readValue(nbf *NomsBinFormat) (Value, error) {
 	// these very common primitive types.
 	case BoolKind:
 		r.skipKind()
-		return Bool(r.readBool()), nil
+		return Bool(r.ReadBool()), nil
 	case FloatKind:
 		r.skipKind()
-		return Float(r.readFloat(nbf)), nil
+		return Float(r.ReadFloat(nbf)), nil
 	case IntKind:
 		r.skipKind()
-		return Int(r.readInt()), nil
+		return Int(r.ReadInt()), nil
 	case UintKind:
 		r.skipKind()
-		return Uint(r.readUint()), nil
+		return Uint(r.ReadUint()), nil
 	case NullKind:
 		r.skipKind()
 		return NullValue, nil
 	case StringKind:
 		r.skipKind()
-		return String(r.readString()), nil
+		return String(r.ReadString()), nil
 	case ListKind:
 		seq, err := r.readListSequence(nbf)
 		if err != nil {
@@ -585,7 +585,7 @@ func (r *typedBinaryNomsReader) skipType() error {
 }
 
 func (r *typedBinaryNomsReader) readTypeInner(seenStructs map[string]*Type) (*Type, error) {
-	k := r.readKind()
+	k := r.ReadKind()
 
 	if supported := SupportedKinds[k]; !supported {
 		return nil, ErrUnknownType
@@ -649,7 +649,7 @@ func (r *typedBinaryNomsReader) readTypeInner(seenStructs map[string]*Type) (*Ty
 
 		return t, nil
 	case CycleKind:
-		name := r.readString()
+		name := r.ReadString()
 		d.PanicIfTrue(name == "") // cycles to anonymous structs are disallowed
 		t, ok := seenStructs[name]
 		d.PanicIfFalse(ok)
@@ -661,7 +661,7 @@ func (r *typedBinaryNomsReader) readTypeInner(seenStructs map[string]*Type) (*Ty
 }
 
 func (r *typedBinaryNomsReader) skipTypeInner() {
-	k := r.readKind()
+	k := r.ReadKind()
 	switch k {
 	case ListKind, RefKind, SetKind, TupleKind:
 		r.skipTypeInner()
@@ -680,7 +680,7 @@ func (r *typedBinaryNomsReader) skipTypeInner() {
 }
 
 func (r *typedBinaryNomsReader) readStructType(seenStructs map[string]*Type) (*Type, error) {
-	name := r.readString()
+	name := r.ReadString()
 	count := r.readCount()
 	fields := make(structTypeFields, count)
 
@@ -689,7 +689,7 @@ func (r *typedBinaryNomsReader) readStructType(seenStructs map[string]*Type) (*T
 
 	for i := uint64(0); i < count; i++ {
 		t.Desc.(StructDesc).fields[i] = StructField{
-			Name: r.readString(),
+			Name: r.ReadString(),
 		}
 	}
 	for i := uint64(0); i < count; i++ {
@@ -702,7 +702,7 @@ func (r *typedBinaryNomsReader) readStructType(seenStructs map[string]*Type) (*T
 		t.Desc.(StructDesc).fields[i].Type = inType
 	}
 	for i := uint64(0); i < count; i++ {
-		t.Desc.(StructDesc).fields[i].Optional = r.readBool()
+		t.Desc.(StructDesc).fields[i].Optional = r.ReadBool()
 	}
 
 	return t, nil

--- a/go/store/types/value_decoder.go
+++ b/go/store/types/value_decoder.go
@@ -23,9 +23,10 @@ package types
 
 import (
 	"errors"
+	"time"
+
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
-	"time"
 
 	"github.com/dolthub/dolt/go/store/d"
 )


### PR DESCRIPTION
Old implementation read fields of a tuple to types.Values, converted those values to go values, and then returned those as an interface{}.
New implementation skips types.Values stage and goes directly to interface{}