### PR TITLE
Write to root on every loop of sql shell.

### DIFF
--- a/bats/sql-shell.bats
+++ b/bats/sql-shell.bats
@@ -33,11 +33,12 @@ teardown() {
     echo "$output"
 
     # 2 tables are created. 1 from above and 1 in the expect file.
-    [[ "$output" =~ "+----------+" ]] || false
-    [[ "$output" =~ "| COUNT(*) |" ]] || false
-    [[ "$output" =~ "+----------+" ]] || false
-    [[ "$output" =~ "| 2        |" ]] || false
-    [[ "$output" =~ "+----------+" ]] || false
+    [[ "$output" =~ "+-------------+" ]] || false
+    [[ "$output" =~ "| Table       |" ]] || false
+    [[ "$output" =~ "+-------------+" ]] || false
+    [[ "$output" =~ "| test        |" ]] || false
+    [[ "$output" =~ "| test_expect |" ]] || false
+    [[ "$output" =~ "+-------------+" ]] || false
 }
 
 @test "bad sql in sql shell should error" {

--- a/bats/sql-shell.bats
+++ b/bats/sql-shell.bats
@@ -27,6 +27,19 @@ teardown() {
     [[ "$output" =~ "pk" ]] || false
 }
 
+@test "sql shell writes to disk after every iteration (autocommit)" {
+    skiponwindows "Need to install expect and make this script work on windows."
+    run $BATS_TEST_DIRNAME/sql-shell.expect
+    echo "$output"
+
+    # 2 tables are created. 1 from above and 1 in the expect file.
+    [[ "$output" =~ "+----------+" ]] || false
+    [[ "$output" =~ "| COUNT(*) |" ]] || false
+    [[ "$output" =~ "+----------+" ]] || false
+    [[ "$output" =~ "| 2        |" ]] || false
+    [[ "$output" =~ "+----------+" ]] || false
+}
+
 @test "bad sql in sql shell should error" {
     run dolt sql <<< "This is bad sql"
     [ $status -eq 1 ]

--- a/bats/sql-shell.expect
+++ b/bats/sql-shell.expect
@@ -2,11 +2,20 @@
 
 set timeout 1
 spawn dolt sql
+set id $spawn_id
 
-expect "doltsql> "
-send "CREATE TABLE test_expect (pk int primary key);\r"
+expect -i id "doltsql> "
+send -i id "CREATE TABLE test_expect (pk int primary key);\r"
 
-expect "doltsql> "
-send "select COUNT(*) from dolt_status;\r"
+expect -i id "doltsql> "
 
-expect eof
+# spawn the second process
+spawn dolt sql
+set id2 $spawn_id
+
+# Todo: Should this be a dolt ls instead ?
+expect -i id2 "doltsql> "
+send -i id2 "select COUNT(*) from dolt_status;\r"
+
+expect -i id eof
+expect -i id2 eof

--- a/bats/sql-shell.expect
+++ b/bats/sql-shell.expect
@@ -1,0 +1,12 @@
+#!/usr/bin/expect
+
+set timeout 1
+spawn dolt sql
+
+expect "doltsql> "
+send "CREATE TABLE test_expect (pk int primary key);\r"
+
+expect "doltsql> "
+send "select COUNT(*) from dolt_status;\r"
+
+expect eof

--- a/bats/sql-shell.expect
+++ b/bats/sql-shell.expect
@@ -15,7 +15,7 @@ set id2 $spawn_id
 
 # Todo: Should this be a dolt ls instead ?
 expect -i id2 "doltsql> "
-send -i id2 "select COUNT(*) from dolt_status;\r"
+send -i id2 "show tables;\r"
 
 expect -i id eof
 expect -i id2 eof

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -827,7 +827,9 @@ func processQuery(ctx *sql.Context, query string, se *sqlEngine) (sql.Schema, sq
 	switch s := sqlStatement.(type) {
 	case *sqlparser.Select, *sqlparser.Insert, *sqlparser.Update, *sqlparser.OtherRead, *sqlparser.Show, *sqlparser.Explain, *sqlparser.Union:
 		return se.query(ctx, query)
-	case *sqlparser.Use, *sqlparser.Set:
+	case *sqlparser.Set:
+		return nil, nil, fmt.Errorf("SET is not yet supported in the shell.")
+	case *sqlparser.Use:
 		sch, rowIter, err := se.query(ctx, query)
 
 		if rowIter != nil {

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -658,7 +658,6 @@ func runShell(ctx *sql.Context, se *sqlEngine, mrEnv env.MultiRepoEnv, initialRo
 			returnedVerr = writeRoots(ctx, se, mrEnv, initialRoots)
 
 			if returnedVerr != nil {
-				shell.Println(returnedVerr.Verbose())
 				return
 			}
 		}

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -263,7 +263,8 @@ func (cmd SqlCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 
 			if saveName != "" {
 				saveMessage := apr.GetValueOrDefault(messageFlag, "")
-				roots[currentDB], verr = saveQuery(ctx, roots[currentDB], dEnv, query, saveName, saveMessage)
+				roots[currentDB], verr = saveQuery(ctx, roots[currentDB], query, saveName, saveMessage)
+				verr = UpdateWorkingWithVErr(mrEnv[currentDB], roots[currentDB])
 			}
 		}
 	} else if savedQueryName, exOk := apr.GetValue(executeFlag); exOk {
@@ -540,7 +541,7 @@ func validateSqlArgs(apr *argparser.ArgParseResults) error {
 }
 
 // Saves the query given to the catalog with the name and message given.
-func saveQuery(ctx context.Context, root *doltdb.RootValue, dEnv *env.DoltEnv, query string, name string, message string) (*doltdb.RootValue, errhand.VerboseError) {
+func saveQuery(ctx context.Context, root *doltdb.RootValue, query string, name string, message string) (*doltdb.RootValue, errhand.VerboseError) {
 	_, newRoot, err := dtables.NewQueryCatalogEntryWithNameAsID(ctx, root, name, query, message)
 	if err != nil {
 		return nil, errhand.BuildDError("Couldn't save query").AddCause(err).Build()

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -625,6 +625,7 @@ func runShell(ctx *sql.Context, se *sqlEngine, mrEnv env.MultiRepoEnv, initialRo
 		}
 	})
 
+	var returnedVerr errhand.VerboseError = nil // Verr that cannot be just printed but needs to be returned.
 	shell.Uninterpreted(func(c *ishell.Context) {
 		query := c.Args[0]
 		if len(strings.TrimSpace(query)) == 0 {
@@ -654,10 +655,10 @@ func runShell(ctx *sql.Context, se *sqlEngine, mrEnv env.MultiRepoEnv, initialRo
 		}
 
 		if err == nil {
-			verr := writeRoots(ctx, se, mrEnv, initialRoots)
+			returnedVerr = writeRoots(ctx, se, mrEnv, initialRoots)
 
-			if verr != nil {
-				shell.Println(verr.Verbose())
+			if returnedVerr != nil {
+				shell.Println(returnedVerr.Verbose())
 				return
 			}
 		}
@@ -670,7 +671,7 @@ func runShell(ctx *sql.Context, se *sqlEngine, mrEnv env.MultiRepoEnv, initialRo
 	shell.Run()
 	_ = iohelp.WriteLine(cli.CliOut, "Bye")
 
-	return nil
+	return returnedVerr
 }
 
 // writeRoots updates the working root values using the sql context, the sql engine, a multi repo env and a root_val map.


### PR DESCRIPTION
This pr fixes a bug where the root gets written on every loop of the dolt sql shell. 
