### PR TITLE
Update PR comment benchmarking queries

### DIFF
--- a/.github/scripts/performance-benchmarking/get-job-json.sh
+++ b/.github/scripts/performance-benchmarking/get-job-json.sh
@@ -13,9 +13,7 @@ toVersion="$3"
 timeprefix="$4"
 actorprefix="$5"
 
-average_time_change_query="select f.test_name as test_name, ABS(ROUND(100 * (1.0 - ((AVG(t.latency_sum_ms) / (AVG(cast(t.sql_transactions_total as decimal)) + .000001)) / (AVG(f.latency_sum_ms) / (AVG(cast(f.sql_transactions_total as decimal)) + .000001)))))) as average_time_percent_change, case when (100 * (1.0 - ((AVG(t.latency_sum_ms) / (AVG(cast(t.sql_transactions_total as decimal)) + .000001)) / (AVG(f.latency_sum_ms) / (AVG(cast(f.sql_transactions_total as decimal)) + .000001))))) < 0 then true else false end as is_faster from from_results as f join to_results as t on f.test_name = t.test_name group by f.test_name;"
-
-transactions_change_query="select f.test_name as test_name, ROUND(100 * ((AVG(cast(t.sql_transactions_total as decimal)) - AVG(cast(f.sql_transactions_total as decimal))) / (AVG(cast(f.sql_transactions_total as decimal)) + .000001))) as sql_transactions_percent_change from from_results as f join to_results as t on f.test_name = t.test_name group by f.test_name;"
+average_time_change_query="select f.test_name as test_name, ROUND(100 * (1.0 - ((AVG(t.latency_sum_ms) / (AVG(cast(t.sql_transactions_total as decimal)) + .000001)) / (AVG(f.latency_sum_ms) / (AVG(cast(f.sql_transactions_total as decimal)) + .000001))))) as average_time_percent_change, case when (100 * (1.0 - ((AVG(t.latency_sum_ms) / (AVG(cast(t.sql_transactions_total as decimal)) + .000001)) / (AVG(f.latency_sum_ms) / (AVG(cast(f.sql_transactions_total as decimal)) + .000001))))) < 0 then true else false end as is_faster from from_results as f join to_results as t on f.test_name = t.test_name group by f.test_name;"
 
 echo '
 {
@@ -42,8 +40,7 @@ echo '
               "--region=us-west-2",
               "--results-dir='$timeprefix'",
               "--results-prefix='$actorprefix'",
-              "'"$average_time_change_query"'",
-              "'"$transactions_change_query"'"
+              "'"$average_time_change_query"'"
             ]
           }
         ],

--- a/.github/scripts/performance-benchmarking/get-job-json.sh
+++ b/.github/scripts/performance-benchmarking/get-job-json.sh
@@ -13,6 +13,10 @@ toVersion="$3"
 timeprefix="$4"
 actorprefix="$5"
 
+average_time_change_query="select f.test_name as test_name, ABS(ROUND(100 * (1.0 - ((AVG(t.latency_sum_ms) / (AVG(cast(t.sql_transactions_total as decimal)) + .000001)) / (AVG(f.latency_sum_ms) / (AVG(cast(f.sql_transactions_total as decimal)) + .000001)))))) as average_time_percent_change, case when (100 * (1.0 - ((AVG(t.latency_sum_ms) / (AVG(cast(t.sql_transactions_total as decimal)) + .000001)) / (AVG(f.latency_sum_ms) / (AVG(cast(f.sql_transactions_total as decimal)) + .000001))))) < 0 then true else false end as is_faster from from_results as f join to_results as t on f.test_name = t.test_name group by f.test_name;"
+
+transactions_change_query="select f.test_name as test_name, ROUND(100 * ((AVG(cast(t.sql_transactions_total as decimal)) - AVG(cast(f.sql_transactions_total as decimal))) / (AVG(cast(f.sql_transactions_total as decimal)) + .000001))) as sql_transactions_percent_change from from_results as f join to_results as t on f.test_name = t.test_name group by f.test_name;"
+
 echo '
 {
   "apiVersion": "batch/v1",
@@ -38,7 +42,8 @@ echo '
               "--region=us-west-2",
               "--results-dir='$timeprefix'",
               "--results-prefix='$actorprefix'",
-              "select f.test_name as test_name, f.server_version as from_version, AVG(f.latency_sum_ms) as from_latency_sum_ms, AVG(f.sql_transactions_total) as from_sql_transactions_total, (AVG(f.latency_sum_ms) / (AVG(cast(f.sql_transactions_total as decimal)) + .000001)) as from_average_time, t.server_version as to_version, AVG(t.latency_sum_ms) as to_latency_sum_ms, AVG(t.sql_transactions_total) as to_sql_transactions_total, (AVG(t.latency_sum_ms) / (AVG(cast(t.sql_transactions_total as decimal)) + .000001)) as to_average_time, (100 * (1.0 - ((AVG(t.latency_sum_ms) / (AVG(cast(t.sql_transactions_total as decimal)) + .000001)) / (AVG(f.latency_sum_ms) / (AVG(cast(f.sql_transactions_total as decimal)) + .000001))))) as from_to_average_time_percent_change from from_results as f join to_results as t on f.test_name = t.test_name group by f.test_name;"
+              "'"$average_time_change_query"'",
+              "'"$transactions_change_query"'"
             ]
           }
         ],

--- a/.github/workflows/ci-performance-benchmarks.yaml
+++ b/.github/workflows/ci-performance-benchmarks.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: dolthub/pull-request-comment-trigger@master
         id: check
         with:
-          trigger: '@benchmark'
+          trigger: '#benchmark'
           reaction: rocket
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates the query run for PR performance benchmarks and changes the comment trigger to `#benchmark`.

`average_time_change_query` measures the change in average `latency_sum`/ average `sql_transactions` for each sysbench test between `master` and the PR branch and will result in table similar to:
```
test_name              average_time_percent_change  is_faster
---------------------  ---------------------------  ---------
oltp_delete            -1.0                         1        
oltp_point_select      -2.0                         1        
oltp_read_only         7.0                          0        
oltp_read_write        3.0                          0        
oltp_update_index      1.0                          0        
oltp_update_non_index  -3.0                         1        
oltp_write_only        1.0                          0        
select_random_points   25.0                         0        
select_random_ranges   37.0                         0  