### PR TITLE
/.github/workflows: use ubuntu-18.04 as ubuntu-latest will soon be 20.04

### DIFF
--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   bump-version:
     name: Bump Version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
   create-release:
     needs: bump-version
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -103,7 +103,7 @@ jobs:
   homebrew-bump:
     needs: create-release
     name: Bump Dolt Homebrew formula
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Create Homebrew PR
         uses: mislav/bump-homebrew-formula-action@v1

--- a/.github/workflows/ci-bats-tests.yaml
+++ b/.github/workflows/ci-bats-tests.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-18.04, macos-latest ]
     env:
       use_credentials: ${{ secrets.AWS_SECRET_ACCESS_KEY != '' && secrets.AWS_ACCESS_KEY_ID != '' }}
     steps:
@@ -71,7 +71,7 @@ jobs:
           dolt config --global --add user.name 'Dolthub Actions'
           dolt config --global --add user.email 'actions@dolthub.com'
       - name: Install expect
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-18.04'
         run: sudo apt-get install -y expect
       - name: Check expect
         run: expect -v

--- a/.github/workflows/ci-check-repo.yaml
+++ b/.github/workflows/ci-check-repo.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   verify:
     name: Verify format and commiters
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Setup Go 1.x
         uses: actions/setup-go@v2

--- a/.github/workflows/ci-compatibility-tests.yaml
+++ b/.github/workflows/ci-compatibility-tests.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-18.04 ]
     steps:
       - name: Setup Go 1.x
         uses: actions/setup-go@v2

--- a/.github/workflows/ci-go-tests.yaml
+++ b/.github/workflows/ci-go-tests.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-18.04, windows-latest]
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2

--- a/.github/workflows/ci-mysql-client-tests.yaml
+++ b/.github/workflows/ci-mysql-client-tests.yaml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   mysql_client_integrations_job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     name: Run tests
     steps:
       - name: Checkout

--- a/.github/workflows/ci-performance-benchmarks.yaml
+++ b/.github/workflows/ci-performance-benchmarks.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   validate-commentor:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     outputs:
       valid: ${{ steps.set_valid.outputs.valid }}
     steps:
@@ -20,7 +20,7 @@ jobs:
           ACTOR: ${{ github.actor }}
 
   check-comments:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: validate-commentor
     if: ${{ needs.validate-commentor.outputs.valid == 'true' }}
     outputs:
@@ -42,7 +42,7 @@ jobs:
           echo "::set-output name=benchmark::true"
 
   performance:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: [validate-commentor, check-comments]
     if: ${{ needs.check-comments.outputs.benchmark == 'true' }}
     name: Benchmark Performance


### PR DESCRIPTION
This PR pins the Github-hosted runners at ubuntu-18.04.