### PR TITLE
ALTER TABLE MODIFY COLUMN Pt. 1

### DIFF
--- a/bats/foreign-keys.bats
+++ b/bats/foreign-keys.bats
@@ -442,6 +442,19 @@ SQL
     [[ `echo "$output" | tr -d "\n" | tr -s " "` =~ 'CONSTRAINT `fk1` FOREIGN KEY (`v1_new`) REFERENCES `parent` (`v1_new`)' ]] || false
 }
 
+@test "foreign-keys: ALTER TABLE MODIFY COLUMN" {
+    dolt sql <<SQL
+ALTER TABLE child ADD CONSTRAINT fk1 FOREIGN KEY (v1) REFERENCES parent(v1);
+SQL
+
+    run dolt sql -q "ALTER TABLE parent MODIFY v1 MEDIUMINT;"
+    [ "$status" -eq "1" ]
+    [[ "$output" =~ "type" ]] || false
+    run dolt sql -q "ALTER TABLE child MODIFY v1 MEDIUMINT;"
+    [ "$status" -eq "1" ]
+    [[ "$output" =~ "type" ]] || false
+}
+
 @test "foreign-keys: DROP COLUMN" {
     dolt sql -q "ALTER TABLE child ADD CONSTRAINT fk_name FOREIGN KEY (v1) REFERENCES parent(v1)"
     dolt add -A
@@ -462,15 +475,12 @@ SQL
 
 @test "foreign-keys: Disallow change column type when SET NULL" {
     dolt sql -q "ALTER TABLE child ADD CONSTRAINT fk_name FOREIGN KEY (v1) REFERENCES parent(v1) ON DELETE SET NULL ON UPDATE SET NULL"
-    skip "column type changes are not yet supported"
     run dolt sql -q "ALTER TABLE child CHANGE COLUMN parent_extra parent_extra BIGINT"
     [ "$status" -eq "1" ]
-    [[ "$output" =~ "SET NULL" ]] || false
     [[ "$output" =~ "parent_extra" ]] || false
     
     run dolt sql -q "ALTER TABLE child CHANGE COLUMN parent_extra parent_extra BIGINT NULL"
     [ "$status" -eq "1" ]
-    [[ "$output" =~ "SET NULL" ]] || false
     [[ "$output" =~ "parent_extra" ]] || false
 }
 

--- a/bats/sql.bats
+++ b/bats/sql.bats
@@ -510,12 +510,6 @@ SQL
     [[ "$output" =~ "c6" ]] || false
 }
 
-@test "sql alter table to change column type not supported" {
-    run dolt sql -q "alter table one_pk modify column c5 varchar(80)"
-    [ $status -eq 1 ]
-    [[ "$output" =~ "unsupported feature: column types cannot be changed" ]] || false
-}
-
 @test "sql alter table modify column with no actual change" {
     # this specifically tests a previous bug where we would get a name collision and fail
     dolt sql -q "alter table one_pk modify column c5 bigint"

--- a/go/libraries/doltcore/schema/alterschema/modifycolumn.go
+++ b/go/libraries/doltcore/schema/alterschema/modifycolumn.go
@@ -16,16 +16,15 @@ package alterschema
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
+	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
 	"github.com/dolthub/dolt/go/store/types"
 )
 
@@ -38,7 +37,6 @@ func ModifyColumn(
 	newCol schema.Column,
 	order *ColumnOrder,
 ) (*doltdb.Table, error) {
-
 	sch, err := tbl.GetSchema(ctx)
 	if err != nil {
 		return nil, err
@@ -58,23 +56,9 @@ func ModifyColumn(
 		return nil, err
 	}
 
-	updatedTable, err := updateTableWithModifiedColumn(ctx, tbl, newSchema, newCol)
+	updatedTable, err := updateTableWithModifiedColumn(ctx, tbl, sch, newSchema, existingCol, newCol)
 	if err != nil {
 		return nil, err
-	}
-
-	if !newCol.TypeInfo.Equals(existingCol.TypeInfo) ||
-		newCol.IsNullable() != existingCol.IsNullable() {
-		for _, index := range sch.Indexes().IndexesWithTag(existingCol.Tag) {
-			rebuiltIndexData, err := editor.RebuildIndex(ctx, updatedTable, index.Name())
-			if err != nil {
-				return nil, err
-			}
-			updatedTable, err = updatedTable.SetIndexRowData(ctx, index.Name(), rebuiltIndexData)
-			if err != nil {
-				return nil, err
-			}
-		}
 	}
 
 	return updatedTable, nil
@@ -87,33 +71,30 @@ func validateModifyColumn(ctx context.Context, tbl *doltdb.Table, existingCol sc
 		return err
 	}
 
-	if existingCol.Kind != modifiedCol.Kind || !existingCol.TypeInfo.Equals(modifiedCol.TypeInfo) {
-		return errors.New("unsupported feature: column types cannot be changed")
-	}
+	if existingCol.Name != modifiedCol.Name {
+		cols := sch.GetAllCols()
+		err = cols.Iter(func(currColTag uint64, currCol schema.Column) (stop bool, err error) {
+			if currColTag == modifiedCol.Tag {
+				return false, nil
+			} else if strings.ToLower(currCol.Name) == strings.ToLower(modifiedCol.Name) {
+				return true, fmt.Errorf("A column with the name %s already exists.", modifiedCol.Name)
+			}
 
-	cols := sch.GetAllCols()
-	err = cols.Iter(func(currColTag uint64, currCol schema.Column) (stop bool, err error) {
-		if currColTag == modifiedCol.Tag {
 			return false, nil
-		} else if strings.ToLower(currCol.Name) == strings.ToLower(modifiedCol.Name) {
-			return true, fmt.Errorf("A column with the name %s already exists.", modifiedCol.Name)
+		})
+		if err != nil {
+			return err
 		}
-
-		return false, nil
-	})
-
-	if err != nil {
-		return err
 	}
 
 	return nil
 }
 
-// updateTableWithModifiedColumn updates the existing table with the new schema. No data is changed.
-// TODO: type changes
-func updateTableWithModifiedColumn(ctx context.Context, tbl *doltdb.Table, newSchema schema.Schema, modifiedCol schema.Column) (*doltdb.Table, error) {
+// updateTableWithModifiedColumn updates the existing table with the new schema. If the column type has changed, then
+// the data is updated.
+func updateTableWithModifiedColumn(ctx context.Context, tbl *doltdb.Table, oldSch, newSch schema.Schema, oldCol, modifiedCol schema.Column) (*doltdb.Table, error) {
 	vrw := tbl.ValueReadWriter()
-	newSchemaVal, err := encoding.MarshalSchemaAsNomsValue(ctx, vrw, newSchema)
+	newSchemaVal, err := encoding.MarshalSchemaAsNomsValue(ctx, vrw, newSch)
 	if err != nil {
 		return nil, err
 	}
@@ -123,21 +104,23 @@ func updateTableWithModifiedColumn(ctx context.Context, tbl *doltdb.Table, newSc
 		return nil, err
 	}
 
-	// Iterate over the rows in the table, checking for nils (illegal if the column is declared not null)
-	if !modifiedCol.IsNullable() {
+	if !oldCol.TypeInfo.Equals(modifiedCol.TypeInfo) {
+		rowData, err = updateRowDataWithNewType(ctx, rowData, tbl.ValueReadWriter(), oldSch, newSch, oldCol, modifiedCol)
+		if err != nil {
+			return nil, err
+		}
+	} else if !modifiedCol.IsNullable() {
 		err = rowData.Iter(ctx, func(key, value types.Value) (stop bool, err error) {
-			row, err := row.FromNoms(newSchema, key.(types.Tuple), value.(types.Tuple))
+			r, err := row.FromNoms(newSch, key.(types.Tuple), value.(types.Tuple))
 			if err != nil {
 				return false, err
 			}
-			val, ok := row.GetColVal(modifiedCol.Tag)
-			if (!ok || val == nil) && !modifiedCol.IsNullable() {
+			val, ok := r.GetColVal(modifiedCol.Tag)
+			if !ok || val == nil || val == types.NullValue {
 				return true, fmt.Errorf("cannot change column to NOT NULL when one or more values is NULL")
 			}
-
 			return false, nil
 		})
-
 		if err != nil {
 			return nil, err
 		}
@@ -147,8 +130,114 @@ func updateTableWithModifiedColumn(ctx context.Context, tbl *doltdb.Table, newSc
 	if err != nil {
 		return nil, err
 	}
+	updatedTable, err := doltdb.NewTable(ctx, vrw, newSchemaVal, rowData, indexData)
+	if err != nil {
+		return nil, err
+	}
 
-	return doltdb.NewTable(ctx, vrw, newSchemaVal, rowData, indexData)
+	if !oldCol.TypeInfo.Equals(modifiedCol.TypeInfo) {
+		// If we're modifying the primary key then all indexes are affected. Otherwise we just want to update the
+		// touched ones.
+		if modifiedCol.IsPartOfPK {
+			for _, index := range newSch.Indexes().AllIndexes() {
+				indexRowData, err := editor.RebuildIndex(ctx, updatedTable, index.Name())
+				if err != nil {
+					return nil, err
+				}
+				updatedTable, err = updatedTable.SetIndexRowData(ctx, index.Name(), indexRowData)
+				if err != nil {
+					return nil, err
+				}
+			}
+		} else {
+			for _, index := range newSch.Indexes().IndexesWithTag(modifiedCol.Tag) {
+				indexRowData, err := editor.RebuildIndex(ctx, updatedTable, index.Name())
+				if err != nil {
+					return nil, err
+				}
+				updatedTable, err = updatedTable.SetIndexRowData(ctx, index.Name(), indexRowData)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
+	return updatedTable, nil
+}
+
+// updateRowDataWithNewType returns a new map of row data containing the updated rows from the changed schema column type.
+func updateRowDataWithNewType(
+	ctx context.Context,
+	rowData types.Map,
+	vrw types.ValueReadWriter,
+	oldSch, newSch schema.Schema,
+	oldCol, newCol schema.Column,
+) (types.Map, error) {
+	// If there are no rows then we can immediately return. All type conversions are valid for tables without rows, but
+	// when rows are present then it is no longer true. GetTypeConverter assumes that there are rows present, so it
+	// will return a failure on a type conversion that should work for the empty table.
+	if rowData.Len() == 0 {
+		return rowData, nil
+	}
+	convFunc, _, err := typeinfo.GetTypeConverter(ctx, oldCol.TypeInfo, newCol.TypeInfo)
+	if err != nil {
+		return types.EmptyMap, err
+	}
+
+	if !newCol.IsNullable() {
+		originalConvFunc := convFunc
+		convFunc = func(ctx context.Context, vrw types.ValueReadWriter, v types.Value) (types.Value, error) {
+			if v == nil || v == types.NullValue {
+				return nil, fmt.Errorf("cannot change column to NOT NULL when one or more values is NULL")
+			}
+			return originalConvFunc(ctx, vrw, v)
+		}
+	}
+
+	var lastKey types.Value
+	mapEditor := rowData.Edit()
+	err = rowData.Iter(ctx, func(key, value types.Value) (stop bool, err error) {
+		r, err := row.FromNoms(oldSch, key.(types.Tuple), value.(types.Tuple))
+		if err != nil {
+			return true, err
+		}
+		taggedVals, err := row.GetTaggedVals(r)
+		if err != nil {
+			return true, err
+		}
+		// We skip the "ok" check as nil is returned if the value does not exist, and we still want to check nil.
+		// The underscore is important, otherwise a missing value would result in a panic.
+		val, _ := taggedVals[oldCol.Tag]
+		delete(taggedVals, oldCol.Tag) // If there was no value then delete is a no-op so this is safe
+		newVal, err := convFunc(ctx, vrw, val)
+		if err != nil {
+			return true, err
+		}
+		taggedVals[newCol.Tag] = newVal
+		r, err = row.New(rowData.Format(), newSch, taggedVals)
+		if err != nil {
+			return true, err
+		}
+
+		newRowKey, err := r.NomsMapKey(newSch).Value(ctx)
+		if err != nil {
+			return true, err
+		}
+		if newCol.IsPartOfPK {
+			mapEditor.Remove(key)
+			if newRowKey.Equals(lastKey) {
+				return true, fmt.Errorf("pk violation when altering column type and rewriting values")
+			}
+		}
+		lastKey = newRowKey
+		mapEditor.Set(newRowKey, r.NomsMapValue(newSch))
+		return false, nil
+	})
+	if err != nil {
+		return types.EmptyMap, err
+	}
+	return mapEditor.Map(ctx)
 }
 
 // replaceColumnInSchema replaces the column with the name given with its new definition, optionally reordering it.
@@ -204,6 +293,21 @@ func replaceColumnInSchema(sch schema.Schema, oldCol schema.Column, newCol schem
 	if err != nil {
 		return nil, err
 	}
-	newSch.Indexes().AddIndex(sch.Indexes().AllIndexes()...)
+	for _, index := range sch.Indexes().AllIndexes() {
+		tags := index.IndexedColumnTags()
+		for i := range tags {
+			if tags[i] == oldCol.Tag {
+				tags[i] = newCol.Tag
+			}
+		}
+		_, err = newSch.Indexes().AddIndexByColTags(index.Name(), tags, schema.IndexProperties{
+			IsUnique:      index.IsUnique(),
+			IsUserDefined: index.IsUserDefined(),
+			Comment:       index.Comment(),
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
 	return newSch, nil
 }

--- a/go/libraries/doltcore/schema/alterschema/modifycolumn_test.go
+++ b/go/libraries/doltcore/schema/alterschema/modifycolumn_test.go
@@ -29,6 +29,14 @@ import (
 )
 
 func TestModifyColumn(t *testing.T) {
+	alteredTypeSch := dtestutils.CreateSchema(
+		schema.NewColumn("newId", dtestutils.IdTag, types.StringKind, true, schema.NotNullConstraint{}),
+		schema.NewColumn("name", dtestutils.NameTag, types.StringKind, false, schema.NotNullConstraint{}),
+		schema.NewColumn("age", dtestutils.AgeTag, types.UintKind, false, schema.NotNullConstraint{}),
+		schema.NewColumn("is_married", dtestutils.IsMarriedTag, types.BoolKind, false, schema.NotNullConstraint{}),
+		schema.NewColumn("title", dtestutils.TitleTag, types.StringKind, false),
+	)
+
 	tests := []struct {
 		name           string
 		existingColumn schema.Column
@@ -108,7 +116,33 @@ func TestModifyColumn(t *testing.T) {
 			name:           "type change",
 			existingColumn: schema.NewColumn("id", dtestutils.IdTag, types.UUIDKind, true, schema.NotNullConstraint{}),
 			newColumn:      schema.NewColumn("newId", dtestutils.IdTag, types.StringKind, true, schema.NotNullConstraint{}),
-			expectedErr:    "unsupported feature: column types cannot be changed",
+			expectedSchema: alteredTypeSch,
+			expectedRows: []row.Row{
+				dtestutils.NewRow(
+					alteredTypeSch,
+					types.String("00000000-0000-0000-0000-000000000000"),
+					types.String("Bill Billerson"),
+					types.Uint(32),
+					types.Bool(true),
+					types.String("Senior Dufus"),
+				),
+				dtestutils.NewRow(
+					alteredTypeSch,
+					types.String("00000000-0000-0000-0000-000000000001"),
+					types.String("John Johnson"),
+					types.Uint(25),
+					types.Bool(false),
+					types.String("Dufus"),
+				),
+				dtestutils.NewRow(
+					alteredTypeSch,
+					types.String("00000000-0000-0000-0000-000000000002"),
+					types.String("Rob Robertson"),
+					types.Uint(21),
+					types.Bool(false),
+					types.String(""),
+				),
+			},
 		},
 	}
 

--- a/go/libraries/doltcore/schema/typeinfo/bit.go
+++ b/go/libraries/doltcore/schema/typeinfo/bit.go
@@ -193,3 +193,45 @@ func (ti *bitType) String() string {
 func (ti *bitType) ToSqlType() sql.Type {
 	return ti.sqlBitType
 }
+
+// bitTypeConverter is an internal function for GetTypeConverter that handles the specific type as the source TypeInfo.
+func bitTypeConverter(ctx context.Context, src *bitType, destTi TypeInfo) (tc TypeConverter, needsConversion bool, err error) {
+	switch dest := destTi.(type) {
+	case *bitType:
+		if src.sqlBitType.NumberOfBits() <= dest.sqlBitType.NumberOfBits() {
+			return identityTypeConverter, false, nil
+		} else {
+			return wrapIsValid(dest.IsValid, src, dest)
+		}
+	case *boolType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *datetimeType:
+		return nil, false, IncompatibleTypeConversion.New(src.String(), destTi.String())
+	case *decimalType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *enumType:
+		return wrapIsValid(dest.IsValid, src, dest)
+	case *floatType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *inlineBlobType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *intType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *setType:
+		return wrapIsValid(dest.IsValid, src, dest)
+	case *timeType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *uintType:
+		return wrapIsValid(dest.IsValid, src, dest)
+	case *uuidType:
+		return nil, false, IncompatibleTypeConversion.New(src.String(), destTi.String())
+	case *varBinaryType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *varStringType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *yearType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	default:
+		return nil, false, UnhandledTypeConversion.New(src.String(), destTi.String())
+	}
+}

--- a/go/libraries/doltcore/schema/typeinfo/datetime.go
+++ b/go/libraries/doltcore/schema/typeinfo/datetime.go
@@ -216,3 +216,41 @@ func (ti *datetimeType) String() string {
 func (ti *datetimeType) ToSqlType() sql.Type {
 	return ti.sqlDatetimeType
 }
+
+// datetimeTypeConverter is an internal function for GetTypeConverter that handles the specific type as the source TypeInfo.
+func datetimeTypeConverter(ctx context.Context, src *datetimeType, destTi TypeInfo) (tc TypeConverter, needsConversion bool, err error) {
+	switch dest := destTi.(type) {
+	case *bitType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *boolType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *datetimeType:
+		return wrapIsValid(dest.IsValid, src, dest)
+	case *decimalType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *enumType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *floatType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *inlineBlobType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *intType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *setType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *timeType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *uintType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *uuidType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *varBinaryType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *varStringType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *yearType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	default:
+		return nil, false, UnhandledTypeConversion.New(src.String(), destTi.String())
+	}
+}

--- a/go/libraries/doltcore/schema/typeinfo/decimal.go
+++ b/go/libraries/doltcore/schema/typeinfo/decimal.go
@@ -194,3 +194,41 @@ func (ti *decimalType) String() string {
 func (ti *decimalType) ToSqlType() sql.Type {
 	return ti.sqlDecimalType
 }
+
+// decimalTypeConverter is an internal function for GetTypeConverter that handles the specific type as the source TypeInfo.
+func decimalTypeConverter(ctx context.Context, src *decimalType, destTi TypeInfo) (tc TypeConverter, needsConversion bool, err error) {
+	switch dest := destTi.(type) {
+	case *bitType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *boolType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *datetimeType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *decimalType:
+		return wrapIsValid(dest.IsValid, src, dest)
+	case *enumType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *floatType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *inlineBlobType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *intType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *setType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *timeType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *uintType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *uuidType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *varBinaryType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *varStringType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *yearType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	default:
+		return nil, false, UnhandledTypeConversion.New(src.String(), destTi.String())
+	}
+}

--- a/go/libraries/doltcore/schema/typeinfo/enum.go
+++ b/go/libraries/doltcore/schema/typeinfo/enum.go
@@ -212,3 +212,41 @@ func (ti *enumType) String() string {
 func (ti *enumType) ToSqlType() sql.Type {
 	return ti.sqlEnumType
 }
+
+// enumTypeConverter is an internal function for GetTypeConverter that handles the specific type as the source TypeInfo.
+func enumTypeConverter(ctx context.Context, src *enumType, destTi TypeInfo) (tc TypeConverter, needsConversion bool, err error) {
+	switch dest := destTi.(type) {
+	case *bitType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *boolType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *datetimeType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *decimalType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *enumType:
+		return wrapIsValid(dest.IsValid, src, dest)
+	case *floatType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *inlineBlobType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *intType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *setType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *timeType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *uintType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *uuidType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *varBinaryType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *varStringType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *yearType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	default:
+		return nil, false, UnhandledTypeConversion.New(src.String(), destTi.String())
+	}
+}

--- a/go/libraries/doltcore/schema/typeinfo/float.go
+++ b/go/libraries/doltcore/schema/typeinfo/float.go
@@ -211,3 +211,41 @@ func (ti *floatType) String() string {
 func (ti *floatType) ToSqlType() sql.Type {
 	return ti.sqlFloatType
 }
+
+// floatTypeConverter is an internal function for GetTypeConverter that handles the specific type as the source TypeInfo.
+func floatTypeConverter(ctx context.Context, src *floatType, destTi TypeInfo) (tc TypeConverter, needsConversion bool, err error) {
+	switch dest := destTi.(type) {
+	case *bitType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *boolType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *datetimeType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *decimalType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *enumType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *floatType:
+		return wrapIsValid(dest.IsValid, src, dest)
+	case *inlineBlobType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *intType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *setType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *timeType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *uintType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *uuidType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *varBinaryType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *varStringType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *yearType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	default:
+		return nil, false, UnhandledTypeConversion.New(src.String(), destTi.String())
+	}
+}

--- a/go/libraries/doltcore/schema/typeinfo/inlineblob.go
+++ b/go/libraries/doltcore/schema/typeinfo/inlineblob.go
@@ -216,3 +216,41 @@ func (ti *inlineBlobType) String() string {
 func (ti *inlineBlobType) ToSqlType() sql.Type {
 	return ti.sqlBinaryType
 }
+
+// inlineBlobTypeConverter is an internal function for GetTypeConverter that handles the specific type as the source TypeInfo.
+func inlineBlobTypeConverter(ctx context.Context, src *inlineBlobType, destTi TypeInfo) (tc TypeConverter, needsConversion bool, err error) {
+	switch dest := destTi.(type) {
+	case *bitType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *boolType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *datetimeType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *decimalType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *enumType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *floatType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *inlineBlobType:
+		return wrapIsValid(dest.IsValid, src, dest)
+	case *intType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *setType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *timeType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *uintType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *uuidType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *varBinaryType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *varStringType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *yearType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	default:
+		return nil, false, UnhandledTypeConversion.New(src.String(), destTi.String())
+	}
+}

--- a/go/libraries/doltcore/schema/typeinfo/int.go
+++ b/go/libraries/doltcore/schema/typeinfo/int.go
@@ -255,3 +255,41 @@ func (ti *intType) String() string {
 func (ti *intType) ToSqlType() sql.Type {
 	return ti.sqlIntType
 }
+
+// intTypeConverter is an internal function for GetTypeConverter that handles the specific type as the source TypeInfo.
+func intTypeConverter(ctx context.Context, src *intType, destTi TypeInfo) (tc TypeConverter, needsConversion bool, err error) {
+	switch dest := destTi.(type) {
+	case *bitType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *boolType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *datetimeType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *decimalType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *enumType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *floatType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *inlineBlobType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *intType:
+		return wrapIsValid(dest.IsValid, src, dest)
+	case *setType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *timeType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *uintType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *uuidType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *varBinaryType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *varStringType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *yearType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	default:
+		return nil, false, UnhandledTypeConversion.New(src.String(), destTi.String())
+	}
+}

--- a/go/libraries/doltcore/schema/typeinfo/set.go
+++ b/go/libraries/doltcore/schema/typeinfo/set.go
@@ -211,3 +211,41 @@ func (ti *setType) String() string {
 func (ti *setType) ToSqlType() sql.Type {
 	return ti.sqlSetType
 }
+
+// setTypeConverter is an internal function for GetTypeConverter that handles the specific type as the source TypeInfo.
+func setTypeConverter(ctx context.Context, src *setType, destTi TypeInfo) (tc TypeConverter, needsConversion bool, err error) {
+	switch dest := destTi.(type) {
+	case *bitType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *boolType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *datetimeType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *decimalType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *enumType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *floatType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *inlineBlobType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *intType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *setType:
+		return wrapIsValid(dest.IsValid, src, dest)
+	case *timeType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *uintType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *uuidType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *varBinaryType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *varStringType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *yearType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	default:
+		return nil, false, UnhandledTypeConversion.New(src.String(), destTi.String())
+	}
+}

--- a/go/libraries/doltcore/schema/typeinfo/time.go
+++ b/go/libraries/doltcore/schema/typeinfo/time.go
@@ -147,3 +147,41 @@ func (ti *timeType) String() string {
 func (ti *timeType) ToSqlType() sql.Type {
 	return ti.sqlTimeType
 }
+
+// timeTypeConverter is an internal function for GetTypeConverter that handles the specific type as the source TypeInfo.
+func timeTypeConverter(ctx context.Context, src *timeType, destTi TypeInfo) (tc TypeConverter, needsConversion bool, err error) {
+	switch dest := destTi.(type) {
+	case *bitType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *boolType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *datetimeType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *decimalType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *enumType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *floatType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *inlineBlobType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *intType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *setType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *timeType:
+		return identityTypeConverter, false, nil
+	case *uintType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *uuidType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *varBinaryType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *varStringType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *yearType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	default:
+		return nil, false, UnhandledTypeConversion.New(src.String(), destTi.String())
+	}
+}

--- a/go/libraries/doltcore/schema/typeinfo/typeconverter.go
+++ b/go/libraries/doltcore/schema/typeinfo/typeconverter.go
@@ -1,0 +1,148 @@
+// Copyright 2020 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package typeinfo
+
+import (
+	"context"
+	"fmt"
+	"time"
+	"unsafe"
+
+	"github.com/shopspring/decimal"
+	"gopkg.in/src-d/go-errors.v1"
+
+	"github.com/dolthub/dolt/go/store/types"
+)
+
+var IncompatibleTypeConversion = errors.NewKind("`%s` cannot convert any values to `%s`")
+var UnhandledTypeConversion = errors.NewKind("`%s` does not know how to handle type conversions to `%s`")
+var InvalidTypeConversion = errors.NewKind("`%s` cannot convert the value `%v` to `%s`")
+
+// TypeConverter is a function that is used to convert a Noms value from one TypeInfo to another.
+type TypeConverter func(ctx context.Context, vrw types.ValueReadWriter, v types.Value) (types.Value, error)
+
+// GetTypeConverter returns a TypeConverter that will convert a Noms value from the source type to the destination type.
+// If the source type does not have a valid converter for the destination type, then this returns an error. When the
+// given types are similar enough, no conversion is needed, thus this will return false. In such cases, although a valid
+// TypeConverter will still be returned, it is equivalent to calling IsValid on the destination TypeInfo.
+func GetTypeConverter(ctx context.Context, srcTi TypeInfo, destTi TypeInfo) (tc TypeConverter, needsConversion bool, err error) {
+	switch dest := destTi.(type) {
+	case *tupleType, *unknownType:
+		return nil, false, fmt.Errorf("'%s' can not be converted to by any type", dest.String())
+	}
+
+	if srcTi.Equals(destTi) {
+		return identityTypeConverter, false, nil
+	}
+
+	switch src := srcTi.(type) {
+	case *bitType:
+		return bitTypeConverter(ctx, src, destTi)
+	case *boolType:
+		return boolTypeConverter(ctx, src, destTi)
+	case *datetimeType:
+		return datetimeTypeConverter(ctx, src, destTi)
+	case *decimalType:
+		return decimalTypeConverter(ctx, src, destTi)
+	case *enumType:
+		return enumTypeConverter(ctx, src, destTi)
+	case *floatType:
+		return floatTypeConverter(ctx, src, destTi)
+	case *inlineBlobType:
+		return inlineBlobTypeConverter(ctx, src, destTi)
+	case *intType:
+		return intTypeConverter(ctx, src, destTi)
+	case *setType:
+		return setTypeConverter(ctx, src, destTi)
+	case *timeType:
+		return timeTypeConverter(ctx, src, destTi)
+	case *uintType:
+		return uintTypeConverter(ctx, src, destTi)
+	case *uuidType:
+		return uuidTypeConverter(ctx, src, destTi)
+	case *varBinaryType:
+		return varBinaryTypeConverter(ctx, src, destTi)
+	case *varStringType:
+		return varStringTypeConverter(ctx, src, destTi)
+	case *yearType:
+		return yearTypeConverter(ctx, src, destTi)
+	case *tupleType, *unknownType:
+		return nil, false, fmt.Errorf("'%s' can not be converted from", src.String())
+	default:
+		return nil, false, UnhandledTypeConversion.New(src.String(), destTi.String())
+	}
+}
+
+// identityTypeConverter immediately returns the given value.
+func identityTypeConverter(ctx context.Context, vrw types.ValueReadWriter, v types.Value) (types.Value, error) {
+	return v, nil
+}
+
+// wrapConvertValueToNomsValue is a helper function that takes a ConvertValueToNomsValue function and returns a TypeConverter.
+func wrapConvertValueToNomsValue(
+	cvtnv func(ctx context.Context, vrw types.ValueReadWriter, v interface{}) (types.Value, error),
+) (tc TypeConverter, needsConversion bool, err error) {
+	return func(ctx context.Context, vrw types.ValueReadWriter, v types.Value) (types.Value, error) {
+		if v == nil || v == types.NullValue {
+			return types.NullValue, nil
+		}
+
+		// Handle converting each Noms value to its representative go type.
+		var vInt interface{}
+		switch val := v.(type) {
+		case types.Blob:
+			str, err := fromBlob(val)
+			if err != nil {
+				return nil, err
+			}
+			vInt = str
+		case types.Bool:
+			vInt = bool(val)
+		case types.Decimal:
+			vInt = decimal.Decimal(val).String()
+		case types.Float:
+			vInt = float64(val)
+		case types.InlineBlob:
+			vInt = *(*string)(unsafe.Pointer(&val))
+		case types.Int:
+			vInt = int64(val)
+		case types.String:
+			vInt = string(val)
+		case types.Timestamp:
+			vInt = time.Time(val)
+		case types.UUID:
+			vInt = val.String()
+		case types.Uint:
+			vInt = uint64(val)
+		default:
+			return nil, fmt.Errorf("unknown type in conversion: `%s`", val.Kind().String())
+		}
+
+		return cvtnv(ctx, vrw, vInt)
+	}, true, nil
+}
+
+// wrapIsValid is a helper function that takes an IsValid function and returns a TypeConverter.
+func wrapIsValid(isValid func(v types.Value) bool, srcTi TypeInfo, destTi TypeInfo) (tc TypeConverter, needsConversion bool, err error) {
+	return func(ctx context.Context, vrw types.ValueReadWriter, v types.Value) (types.Value, error) {
+		if v == nil || v == types.NullValue {
+			return types.NullValue, nil
+		}
+		if !isValid(v) {
+			return nil, InvalidTypeConversion.New(srcTi.String(), v, destTi.String())
+		}
+		return v, nil
+	}, false, nil
+}

--- a/go/libraries/doltcore/schema/typeinfo/typeinfo.go
+++ b/go/libraries/doltcore/schema/typeinfo/typeinfo.go
@@ -262,6 +262,8 @@ func FromTypeParams(id Identifier, params map[string]string) (TypeInfo, error) {
 // FromKind returns the default TypeInfo for a given types.Value.
 func FromKind(kind types.NomsKind) TypeInfo {
 	switch kind {
+	case types.BlobKind:
+		return &varBinaryType{sql.LongBlob}
 	case types.BoolKind:
 		return BoolType
 	case types.FloatKind:

--- a/go/libraries/doltcore/schema/typeinfo/uint.go
+++ b/go/libraries/doltcore/schema/typeinfo/uint.go
@@ -255,3 +255,41 @@ func (ti *uintType) String() string {
 func (ti *uintType) ToSqlType() sql.Type {
 	return ti.sqlUintType
 }
+
+// uintTypeConverter is an internal function for GetTypeConverter that handles the specific type as the source TypeInfo.
+func uintTypeConverter(ctx context.Context, src *uintType, destTi TypeInfo) (tc TypeConverter, needsConversion bool, err error) {
+	switch dest := destTi.(type) {
+	case *bitType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *boolType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *datetimeType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *decimalType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *enumType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *floatType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *inlineBlobType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *intType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *setType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *timeType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *uintType:
+		return wrapIsValid(dest.IsValid, src, dest)
+	case *uuidType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *varBinaryType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *varStringType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *yearType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	default:
+		return nil, false, UnhandledTypeConversion.New(src.String(), destTi.String())
+	}
+}

--- a/go/libraries/doltcore/schema/typeinfo/unknown.go
+++ b/go/libraries/doltcore/schema/typeinfo/unknown.go
@@ -23,73 +23,73 @@ import (
 	"github.com/dolthub/dolt/go/store/types"
 )
 
-type unknownImpl struct{}
+type unknownType struct{}
 
-var _ TypeInfo = (*unknownImpl)(nil)
+var _ TypeInfo = (*unknownType)(nil)
 
-var UnknownType TypeInfo = &unknownImpl{}
+var UnknownType TypeInfo = &unknownType{}
 
 // ConvertNomsValueToValue implements TypeInfo interface.
-func (ti *unknownImpl) ConvertNomsValueToValue(types.Value) (interface{}, error) {
+func (ti *unknownType) ConvertNomsValueToValue(types.Value) (interface{}, error) {
 	return nil, fmt.Errorf(`"Unknown" cannot convert any Noms value to a go value`)
 }
 
 // ReadFrom reads a go value from a noms types.CodecReader directly
-func (ti *unknownImpl) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
+func (ti *unknownType) ReadFrom(_ *types.NomsBinFormat, reader types.CodecReader) (interface{}, error) {
 	return nil, fmt.Errorf(`"Unknown" cannot read any Noms value to a go value`)
 }
 
 // ConvertValueToNomsValue implements TypeInfo interface.
-func (ti *unknownImpl) ConvertValueToNomsValue(context.Context, types.ValueReadWriter, interface{}) (types.Value, error) {
+func (ti *unknownType) ConvertValueToNomsValue(context.Context, types.ValueReadWriter, interface{}) (types.Value, error) {
 	return nil, fmt.Errorf(`"Unknown" cannot convert any go value to a Noms value`)
 }
 
 // Equals implements TypeInfo interface.
-func (ti *unknownImpl) Equals(TypeInfo) bool {
+func (ti *unknownType) Equals(TypeInfo) bool {
 	return false
 }
 
 // FormatValue implements TypeInfo interface.
-func (ti *unknownImpl) FormatValue(types.Value) (*string, error) {
+func (ti *unknownType) FormatValue(types.Value) (*string, error) {
 	return nil, fmt.Errorf(`"Unknown" cannot convert any Noms value to a string`)
 }
 
 // GetTypeIdentifier implements TypeInfo interface.
-func (ti *unknownImpl) GetTypeIdentifier() Identifier {
+func (ti *unknownType) GetTypeIdentifier() Identifier {
 	return UnknownTypeIdentifier
 }
 
 // GetTypeParams implements TypeInfo interface.
-func (ti *unknownImpl) GetTypeParams() map[string]string {
+func (ti *unknownType) GetTypeParams() map[string]string {
 	panic("cannot persist unknown type")
 }
 
 // IsValid implements TypeInfo interface.
-func (ti *unknownImpl) IsValid(types.Value) bool {
+func (ti *unknownType) IsValid(types.Value) bool {
 	return false
 }
 
 // NomsKind implements TypeInfo interface.
-func (ti *unknownImpl) NomsKind() types.NomsKind {
+func (ti *unknownType) NomsKind() types.NomsKind {
 	return types.UnknownKind
 }
 
 // ParseValue implements TypeInfo interface.
-func (ti *unknownImpl) ParseValue(context.Context, types.ValueReadWriter, *string) (types.Value, error) {
+func (ti *unknownType) ParseValue(context.Context, types.ValueReadWriter, *string) (types.Value, error) {
 	return nil, fmt.Errorf(`"Unknown" cannot convert any strings to a Noms value`)
 }
 
 // Promote implements TypeInfo interface.
-func (ti *unknownImpl) Promote() TypeInfo {
+func (ti *unknownType) Promote() TypeInfo {
 	return ti
 }
 
 // String implements TypeInfo interface.
-func (ti *unknownImpl) String() string {
+func (ti *unknownType) String() string {
 	return "Unknown"
 }
 
 // ToSqlType implements TypeInfo interface.
-func (ti *unknownImpl) ToSqlType() sql.Type {
+func (ti *unknownType) ToSqlType() sql.Type {
 	panic(fmt.Errorf("unknown type info does not have a relevant SQL type"))
 }

--- a/go/libraries/doltcore/schema/typeinfo/uuid.go
+++ b/go/libraries/doltcore/schema/typeinfo/uuid.go
@@ -149,3 +149,41 @@ func (ti *uuidType) String() string {
 func (ti *uuidType) ToSqlType() sql.Type {
 	return ti.sqlCharType
 }
+
+// uuidTypeConverter is an internal function for GetTypeConverter that handles the specific type as the source TypeInfo.
+func uuidTypeConverter(ctx context.Context, src *uuidType, destTi TypeInfo) (tc TypeConverter, needsConversion bool, err error) {
+	switch dest := destTi.(type) {
+	case *bitType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *boolType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *datetimeType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *decimalType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *enumType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *floatType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *inlineBlobType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *intType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *setType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *timeType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *uintType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *uuidType:
+		return wrapIsValid(dest.IsValid, src, dest)
+	case *varBinaryType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *varStringType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *yearType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	default:
+		return nil, false, UnhandledTypeConversion.New(src.String(), destTi.String())
+	}
+}

--- a/go/libraries/doltcore/schema/typeinfo/varstring.go
+++ b/go/libraries/doltcore/schema/typeinfo/varstring.go
@@ -244,3 +244,41 @@ func (ti *varStringType) String() string {
 func (ti *varStringType) ToSqlType() sql.Type {
 	return ti.sqlStringType
 }
+
+// varStringTypeConverter is an internal function for GetTypeConverter that handles the specific type as the source TypeInfo.
+func varStringTypeConverter(ctx context.Context, src *varStringType, destTi TypeInfo) (tc TypeConverter, needsConversion bool, err error) {
+	switch dest := destTi.(type) {
+	case *bitType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *boolType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *datetimeType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *decimalType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *enumType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *floatType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *inlineBlobType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *intType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *setType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *timeType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *uintType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *uuidType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *varBinaryType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *varStringType:
+		return wrapIsValid(dest.IsValid, src, dest)
+	case *yearType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	default:
+		return nil, false, UnhandledTypeConversion.New(src.String(), destTi.String())
+	}
+}

--- a/go/libraries/doltcore/schema/typeinfo/year.go
+++ b/go/libraries/doltcore/schema/typeinfo/year.go
@@ -163,3 +163,41 @@ func (ti *yearType) String() string {
 func (ti *yearType) ToSqlType() sql.Type {
 	return ti.sqlYearType
 }
+
+// yearTypeConverter is an internal function for GetTypeConverter that handles the specific type as the source TypeInfo.
+func yearTypeConverter(ctx context.Context, src *yearType, destTi TypeInfo) (tc TypeConverter, needsConversion bool, err error) {
+	switch dest := destTi.(type) {
+	case *bitType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *boolType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *datetimeType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *decimalType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *enumType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *floatType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *inlineBlobType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *intType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *setType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *timeType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *uintType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *uuidType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *varBinaryType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *varStringType:
+		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+	case *yearType:
+		return identityTypeConverter, false, nil
+	default:
+		return nil, false, UnhandledTypeConversion.New(src.String(), destTi.String())
+	}
+}

--- a/go/libraries/doltcore/sqle/sqlddl_test.go
+++ b/go/libraries/doltcore/sqle/sqlddl_test.go
@@ -613,11 +613,6 @@ func TestModifyAndChangeColumn(t *testing.T) {
 			expectedErr: "incompatible type for default value",
 		},
 		{
-			name:        "alter modify column with type change",
-			query:       "alter table people modify rating varchar(10)",
-			expectedErr: "column types cannot be changed",
-		},
-		{
 			name:        "alter modify column not null, existing null values",
 			query:       "alter table people modify num_episodes bigint unsigned not null",
 			expectedErr: "cannot change column to NOT NULL",
@@ -664,6 +659,194 @@ func TestModifyAndChangeColumn(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedRows, foundRows)
+		})
+	}
+}
+
+func TestModifyColumnType(t *testing.T) {
+	tests := []struct {
+		name            string
+		setupStmts      []string
+		alterStmt       string
+		tableName       string
+		expectedRows    [][]types.Value
+		expectedIdxRows [][]types.Value
+		expectedErr     bool
+	}{
+		{
+			name: "alter modify column type similar types",
+			setupStmts: []string{
+				"create table test(pk bigint primary key, v1 bigint, index (v1))",
+				"insert into test values (0, 3), (1, 2)",
+			},
+			alterStmt: "alter table test modify column v1 int",
+			tableName: "test",
+			expectedRows: [][]types.Value{
+				{types.Int(0), types.Int(3)},
+				{types.Int(1), types.Int(2)},
+			},
+			expectedIdxRows: [][]types.Value{
+				{types.Int(2), types.Int(1)},
+				{types.Int(3), types.Int(0)},
+			},
+		},
+		{
+			name: "alter modify column type different types",
+			setupStmts: []string{
+				"create table test(pk bigint primary key, v1 bigint, index (v1))",
+				"insert into test values (0, 3), (1, 2)",
+			},
+			alterStmt: "alter table test modify column v1 varchar(20)",
+			tableName: "test",
+			expectedRows: [][]types.Value{
+				{types.Int(0), types.String("3")},
+				{types.Int(1), types.String("2")},
+			},
+			expectedIdxRows: [][]types.Value{
+				{types.String("2"), types.Int(1)},
+				{types.String("3"), types.Int(0)},
+			},
+		},
+		{
+			name: "alter modify column type different types reversed",
+			setupStmts: []string{
+				"create table test(pk bigint primary key, v1 varchar(20), index (v1))",
+				"insert into test values (0, 3), (1, 2)",
+			},
+			alterStmt: "alter table test modify column v1 bigint",
+			tableName: "test",
+			expectedRows: [][]types.Value{
+				{types.Int(0), types.Int(3)},
+				{types.Int(1), types.Int(2)},
+			},
+			expectedIdxRows: [][]types.Value{
+				{types.Int(2), types.Int(1)},
+				{types.Int(3), types.Int(0)},
+			},
+		},
+		{
+			name: "alter modify column type primary key",
+			setupStmts: []string{
+				"create table test(pk bigint primary key, v1 bigint, index (v1))",
+				"insert into test values (0, 3), (1, 2)",
+			},
+			alterStmt: "alter table test modify column pk varchar(20)",
+			tableName: "test",
+			expectedRows: [][]types.Value{
+				{types.String("0"), types.Int(3)},
+				{types.String("1"), types.Int(2)},
+			},
+			expectedIdxRows: [][]types.Value{
+				{types.Int(2), types.String("1")},
+				{types.Int(3), types.String("0")},
+			},
+		},
+		{
+			name: "alter modify column type incompatible types with empty table",
+			setupStmts: []string{
+				"create table test(pk bigint primary key, v1 bit(20), index (v1))",
+			},
+			alterStmt:       "alter table test modify column pk datetime",
+			tableName:       "test",
+			expectedRows:    [][]types.Value(nil),
+			expectedIdxRows: [][]types.Value(nil),
+		},
+		{
+			name: "alter modify column type incompatible types with non-empty table",
+			setupStmts: []string{
+				"create table test(pk bigint primary key, v1 bit(20), index (v1))",
+				"insert into test values (1, 1)",
+			},
+			alterStmt:   "alter table test modify column pk datetime",
+			expectedErr: true,
+		},
+		{
+			name: "alter modify column type different types incompatible values",
+			setupStmts: []string{
+				"create table test(pk bigint primary key, v1 varchar(20), index (v1))",
+				"insert into test values (0, 3), (1, 'a')",
+			},
+			alterStmt:   "alter table test modify column v1 bigint",
+			expectedErr: true,
+		},
+		{
+			name: "alter modify column type foreign key parent",
+			setupStmts: []string{
+				"create table test(pk bigint primary key, v1 bigint, index (v1))",
+				"create table test2(pk bigint primary key, v1 bigint, index (v1), foreign key (v1) references test(v1))",
+			},
+			alterStmt:   "alter table test modify column v1 varchar(20)",
+			expectedErr: true,
+		},
+		{
+			name: "alter modify column type foreign key child",
+			setupStmts: []string{
+				"create table test(pk bigint primary key, v1 bigint, index (v1))",
+				"create table test2(pk bigint primary key, v1 bigint, index (v1), foreign key (v1) references test(v1))",
+			},
+			alterStmt:   "alter table test2 modify column v1 varchar(20)",
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dEnv := dtestutils.CreateTestEnv()
+			ctx := context.Background()
+			root, _ := dEnv.WorkingRoot(ctx)
+			var err error
+
+			for _, stmt := range test.setupStmts {
+				root, err = ExecuteSql(dEnv, root, stmt)
+				require.NoError(t, err)
+			}
+			root, err = ExecuteSql(dEnv, root, test.alterStmt)
+			if test.expectedErr == false {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				return
+			}
+
+			table, _, err := root.GetTable(ctx, test.tableName)
+			require.NoError(t, err)
+			sch, err := table.GetSchema(ctx)
+			require.NoError(t, err)
+			rowData, err := table.GetRowData(ctx)
+			require.NoError(t, err)
+
+			var foundRows [][]types.Value
+			err = rowData.Iter(ctx, func(key, value types.Value) (stop bool, err error) {
+				r, err := row.FromNoms(sch, key.(types.Tuple), value.(types.Tuple))
+				require.NoError(t, err)
+				var vals []types.Value
+				_, _ = r.IterSchema(sch, func(tag uint64, val types.Value) (stop bool, err error) {
+					vals = append(vals, val)
+					return false, nil
+				})
+				foundRows = append(foundRows, vals)
+				return false, nil
+			})
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedRows, foundRows)
+
+			foundRows = nil
+			idx := sch.Indexes().AllIndexes()[0]
+			idxRowData, err := table.GetIndexRowData(ctx, idx.Name())
+			require.NoError(t, err)
+			err = idxRowData.Iter(ctx, func(key, value types.Value) (stop bool, err error) {
+				r, err := row.FromNoms(idx.Schema(), key.(types.Tuple), value.(types.Tuple))
+				require.NoError(t, err)
+				var vals []types.Value
+				_, _ = r.IterSchema(idx.Schema(), func(tag uint64, val types.Value) (stop bool, err error) {
+					vals = append(vals, val)
+					return false, nil
+				})
+				foundRows = append(foundRows, vals)
+				return false, nil
+			})
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedIdxRows, foundRows)
 		})
 	}
 }


### PR DESCRIPTION
Here you can see the core idea of the approach: each type handling every other type. Before, we were using `FormatValue` and `ParseValue` to convert between types, which worked decently for importing from CSVs (where you could pretend everything is coming from a `varchar`), but that approach won't work between other types. Even within types (such as `ENUM('a','b','c')` to `ENUM('a','c')`) you can have altered values, so we have to be able to handle all of these special (and largely undocumented) behaviors. This way is easily the most tedious, but we can guarantee correct behavior with it (plus once it's done it's done).

The other approach I thought about was to just special case all of them within the current `Convert` function, but it looked like it would balloon into a less structured version of this approach anyway.

As a result, I'm also going to remove `ParseValue`, as its sole reason for existence was for type conversion, so the additional function would just cause confusion (we can resort to converting random strings by pretending they're `varchar`s as mentioned before). Along with that change, I also need to handle primary key column changes and foreign keys. And of course the ridiculous amount of testing (I may make use of the test harnesses, which I'll then translate to go and bats tests), which will modify some/most of the placeholder conversion logic.

Of note, I looked into keeping the row data (and therefore tag) the same for type conversions that would not fundamentally change the underlying data (such as `int` to `bigint`). I determined it's outside of the scope of this set of PRs, but it's something I'd like to look more into in the future, as it would open up better diff behavior for some conversions.