### PR TITLE
Update performance benchmarking queries and timeout

### DIFF
--- a/.github/scripts/performance-benchmarking/get-dolt-dolt-job-json.sh
+++ b/.github/scripts/performance-benchmarking/get-dolt-dolt-job-json.sh
@@ -16,7 +16,7 @@ timePrefix="$6"
 actorPrefix="$7"
 format="$8"
 
-averageTimeChangeQuery="select f.test_name as test_name, ROUND(100 * (1.0 - ((AVG(t.latency_sum_ms) / (AVG(cast(t.sql_transactions_total as decimal)) + .000001)) / (AVG(f.latency_sum_ms) / (AVG(cast(f.sql_transactions_total as decimal)) + .000001))))) as average_time_percent_change, case when (100 * (1.0 - ((AVG(t.latency_sum_ms) / (AVG(cast(t.sql_transactions_total as decimal)) + .000001)) / (AVG(f.latency_sum_ms) / (AVG(cast(f.sql_transactions_total as decimal)) + .000001))))) < 0 then true else false end as is_faster from from_results as f join to_results as t on f.test_name = t.test_name group by f.test_name;"
+medianLatencyChangeQuery="select f.test_name as test_name, avg(f.latency_percentile) as from_latency_median, avg(t.latency_percentile) as to_latency_median, case when ((avg(t.latency_percentile) - avg(f.latency_percentile)) / (avg(f.latency_percentile) + .0000001)) < -10.0 then 1 when ((avg(t.latency_percentile) - avg(f.latency_percentile)) / (avg(f.latency_percentile) + .0000001)) > 10.0 then -1 else 0 end as is_faster from from_results as f join to_results as t on f.test_name = t.test_name group by f.test_name;"
 
 echo '
 {
@@ -46,7 +46,7 @@ echo '
               "--region=us-west-2",
               "--results-dir='$timePrefix'",
               "--results-prefix='$actorPrefix'",
-              "'"$averageTimeChangeQuery"'"
+              "'"$medianLatencyChangeQuery"'"
             ]
           }
         ],

--- a/.github/scripts/performance-benchmarking/get-mysql-dolt-job-json.sh
+++ b/.github/scripts/performance-benchmarking/get-mysql-dolt-job-json.sh
@@ -16,7 +16,7 @@ timeprefix="$6"
 actorprefix="$7"
 format="$8"
 
-average_time_change_query="select f.test_name as test_name, ROUND(100 * (1.0 - ((AVG(t.latency_sum_ms) / (AVG(cast(t.sql_transactions_total as decimal)) + .000001)) / (AVG(f.latency_sum_ms) / (AVG(cast(f.sql_transactions_total as decimal)) + .000001))))) as average_time_percent_change, case when (100 * (1.0 - ((AVG(t.latency_sum_ms) / (AVG(cast(t.sql_transactions_total as decimal)) + .000001)) / (AVG(f.latency_sum_ms) / (AVG(cast(f.sql_transactions_total as decimal)) + .000001))))) < 0 then true else false end as is_faster from from_results as f join to_results as t on f.test_name = t.test_name group by f.test_name;"
+medianLatencyMultiplierQuery="select f.test_name as test_name, avg(f.latency_percentile) as from_latency_median, avg(t.latency_percentile) as to_latency_median, ROUND(avg(f.latency_percentile) / (avg(t.latency_percentile) + .000001)) as multiplier from from_results as f join to_results as t on f.test_name = t.test_name group by f.test_name;"
 
 echo '
 {
@@ -48,7 +48,7 @@ echo '
               "--region=us-west-2",
               "--results-dir='$timeprefix'",
               "--results-prefix='$actorprefix'",
-              "'"$average_time_change_query"'"
+              "'"$medianLatencyMultiplierQuery"'"
             ]
           }
         ],

--- a/.github/scripts/performance-benchmarking/run-benchmarks.sh
+++ b/.github/scripts/performance-benchmarking/run-benchmarks.sh
@@ -45,7 +45,7 @@ source "$TEMPLATE_SCRIPT" "$jobname" "$FROM_SERVER" "$FROM_VERSION" "$TO_SERVER"
 
 KUBECONFIG="$KUBECONFIG" kubectl apply -f job.json
 
-out=$(KUBECONFIG="$KUBECONFIG" kubectl wait job/"$jobname" --for=condition=complete -n performance-benchmarking --timeout=1500s || true)
+out=$(KUBECONFIG="$KUBECONFIG" kubectl wait job/"$jobname" --for=condition=complete -n performance-benchmarking --timeout=5400s || true)
 
 if [ "$out" != "job.batch/$jobname condition met" ]; then
   echo "output of kubectl wait: $out"


### PR DESCRIPTION
This PR updates performance benchmarking queries to display the more stable latency median for each sysbench test. It also increases the PR benchmarking timeout to 90mins, since a job now takes ~52 mins. 