### PR TITLE
Add mean multiplier query to performance benchmarks on release

### DIFF
--- a/.github/scripts/performance-benchmarking/get-mysql-dolt-job-json.sh
+++ b/.github/scripts/performance-benchmarking/get-mysql-dolt-job-json.sh
@@ -17,6 +17,7 @@ actorprefix="$7"
 format="$8"
 
 medianLatencyMultiplierQuery="select f.test_name as test_name, f.server_name, f.server_version, avg(f.latency_percentile) as from_latency_median, t.server_name, t.server_version, avg(t.latency_percentile) as to_latency_median, ROUND(avg(t.latency_percentile) / (avg(f.latency_percentile) + .000001)) as multiplier from from_results as f join to_results as t on f.test_name = t.test_name group by f.test_name;"
+meanMultiplierQuery="select round(avg(multipliers)) as mean_multiplier from (select (round(avg(t.latency_percentile) / (avg(f.latency_percentile) + .000001))) as multipliers from from_results as f join to_results as t on f.test_name = t.test_name group by f.test_name)"
 
 echo '
 {
@@ -49,7 +50,8 @@ echo '
               "--region=us-west-2",
               "--results-dir='$timeprefix'",
               "--results-prefix='$actorprefix'",
-              "'"$medianLatencyMultiplierQuery"'"
+              "'"$medianLatencyMultiplierQuery"'",
+              "'"$meanMultiplierQuery"'"
             ]
           }
         ],


### PR DESCRIPTION
This PR adds a mean multiplier query to the performance benchmarks email on release.