### PR TITLE
Update performance benchmarking job specs with container limits

### DIFF
--- a/.github/scripts/performance-benchmarking/get-dolt-dolt-job-json.sh
+++ b/.github/scripts/performance-benchmarking/get-dolt-dolt-job-json.sh
@@ -35,6 +35,17 @@ echo '
           {
             "name": "performance-benchmarking",
             "image": "407903926827.dkr.ecr.us-west-2.amazonaws.com/liquidata/performance-benchmarking:latest",
+            "resources": {
+              "limits": {
+                "cpu": "7000m"
+              }
+            },
+            "env": [
+              {
+                "name": "GOMAXPROCS",
+                "value": "7"
+              }
+            ],
             "args": [
               "--schema=/schema.sql",
               "--script-dir=/scripts/lua",

--- a/.github/scripts/performance-benchmarking/get-mysql-dolt-job-json.sh
+++ b/.github/scripts/performance-benchmarking/get-mysql-dolt-job-json.sh
@@ -36,6 +36,17 @@ echo '
           {
             "name": "performance-benchmarking",
             "image": "407903926827.dkr.ecr.us-west-2.amazonaws.com/liquidata/performance-benchmarking:latest",
+            "resources": {
+              "limits": {
+                "cpu": "7000m"
+              }
+            },
+            "env": [
+              {
+                "name": "GOMAXPROCS",
+                "value": "7"
+              }
+            ],
             "args": [
               "--schema=/schema.sql",
               "--script-dir=/scripts/lua",


### PR DESCRIPTION
This PR updates the job specs used in performance benchmarking by specifying the limits that ensure each pod receives its own node.