### PR TITLE
fixes panic in the atomic package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 **/.idea/
 .vscode
+.run
 venv
 
 go.sum

--- a/go/store/metrics/histogram.go
+++ b/go/store/metrics/histogram.go
@@ -23,10 +23,11 @@ package metrics
 
 import (
 	"fmt"
-	"github.com/dustin/go-humanize"
 	"strconv"
 	"sync/atomic"
 	"time"
+
+	"github.com/dustin/go-humanize"
 
 	"github.com/dolthub/dolt/go/store/d"
 )

--- a/go/store/metrics/histogram.go
+++ b/go/store/metrics/histogram.go
@@ -23,10 +23,10 @@ package metrics
 
 import (
 	"fmt"
+	"github.com/dustin/go-humanize"
+	"strconv"
 	"sync/atomic"
 	"time"
-
-	"github.com/dustin/go-humanize"
 
 	"github.com/dolthub/dolt/go/store/d"
 )
@@ -47,20 +47,20 @@ import (
 
 const bucketCount = 64
 
+type HistogramType uint64
+
+const (
+	UnspecifiedHistogram HistogramType = iota
+	TimeHistogram
+	ByteHistogram
+)
+
 type Histogram struct {
+	// this structure needs to be a multiple of 8 bytes in size. This is necessary for 32-bit architectures and
+	// guarantees 8 byte alignment for multiple Histograms laid out side by side in memory.
 	sum      uint64
 	buckets  [bucketCount]uint64
-	ToString ToStringFunc
-
-	// padding this structure so it is a multiple of 8 bytes in size. This is necessary for 32-bit architectures and
-	// guarantees 8 byte alignment for multiple Histograms laid out side by side in memory.
-	pad32 uint32
-}
-
-type ToStringFunc func(v uint64) string
-
-func identToString(v uint64) string {
-	return fmt.Sprintf("%d", v)
+	histType HistogramType
 }
 
 // Sample adds a uint64 data point to the histogram
@@ -134,23 +134,33 @@ func (h Histogram) Samples() uint64 {
 	return s
 }
 
-func (h Histogram) String() string {
-	f := h.ToString
-	if f == nil {
-		f = identToString
-	}
-	return fmt.Sprintf("Mean: %s, Sum: %s, Samples: %d", f(h.Mean()), f(h.Sum()), h.Samples())
-}
-
-func NewTimeHistogram() Histogram {
-	return Histogram{ToString: timeToString}
+func uintToString(v uint64) string {
+	return strconv.FormatUint(v, 10)
 }
 
 func timeToString(v uint64) string {
 	return time.Duration(v).String()
 }
 
+func (h Histogram) String() string {
+	var f func(uint64) string
+	switch h.histType {
+	case UnspecifiedHistogram:
+		f = uintToString
+	case ByteHistogram:
+		f = humanize.Bytes
+	case TimeHistogram:
+		f = timeToString
+	}
+
+	return fmt.Sprintf("Mean: %s, Sum: %s, Samples: %d", f(h.Mean()), f(h.Sum()), h.Samples())
+}
+
+func NewTimeHistogram() Histogram {
+	return Histogram{histType: TimeHistogram}
+}
+
 // NewByteHistogram stringifies values using humanize over byte values
 func NewByteHistogram() Histogram {
-	return Histogram{ToString: humanize.Bytes}
+	return Histogram{histType: ByteHistogram}
 }

--- a/go/store/metrics/histogram.go
+++ b/go/store/metrics/histogram.go
@@ -51,6 +51,10 @@ type Histogram struct {
 	sum      uint64
 	buckets  [bucketCount]uint64
 	ToString ToStringFunc
+
+	// padding this structure so it is a multiple of 8 bytes in size. This is necessary for 32-bit architectures and
+	// guarantees 8 byte alignment for multiple Histograms laid out side by side in memory.
+	pad32 uint32
 }
 
 type ToStringFunc func(v uint64) string

--- a/go/store/metrics/histogram_test.go
+++ b/go/store/metrics/histogram_test.go
@@ -23,6 +23,7 @@ package metrics
 
 import (
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -110,4 +111,9 @@ func TestHistogramString(t *testing.T) {
 	bh := NewByteHistogram()
 	bh.Add(h)
 	assert.Equal("Mean: 758 MB, Sum: 3.0 GB, Samples: 4", bh.String())
+}
+
+func TestHistogramStructSize(t *testing.T) {
+	size := unsafe.Sizeof(Histogram{})
+	assert.True(t, size%8 == 0)
 }


### PR DESCRIPTION
The `atomic` package has the following [limitation on 32-bit platforms:](https://golang.org/pkg/sync/atomic/#pkg-note-BUG)

> On both ARM and x86-32, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically. The first word in a variable or in an allocated struct, array, or slice can be relied upon to be 64-bit aligned.