### PR TITLE
Testing Repository Dispatch workflows

### DIFF
--- a/.github/workflows/ci-workflow-receiver.yaml
+++ b/.github/workflows/ci-workflow-receiver.yaml
@@ -5,4 +5,6 @@ jobs:
   test-reception:
     runs-on: ubuntu-latest
     steps:
-      - run: echo ${{ github.event.client_payload.version }}
+      - run: |
+        echo ${{ github.event.client_payload.version }}
+        echo ${{ github.event.client_payload.actor }}

--- a/.github/workflows/ci-workflow-receiver.yaml
+++ b/.github/workflows/ci-workflow-receiver.yaml
@@ -1,0 +1,8 @@
+on:
+  repository_dispatch:
+    types: [release-dolt]
+jobs:
+  test-reception:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${{ github.event.client_payload.version }}

--- a/.github/workflows/ci-workflow-trigger.yaml
+++ b/.github/workflows/ci-workflow-trigger.yaml
@@ -12,4 +12,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: dolthub/dolt
           event-type: release-dolt
-          client-payload: '{"version": "fake-version-1.0.0"}'
+          client-payload: '{"version": "fake-version-1.0.0", "actor": "${{ github.actor }}"}'

--- a/.github/workflows/ci-workflow-trigger.yaml
+++ b/.github/workflows/ci-workflow-trigger.yaml
@@ -1,0 +1,15 @@
+on:
+  push:
+    branches:
+      - 'db/*'
+jobs:
+  test-trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: dolthub/dolt
+          event-type: release-dolt
+          client-payload: '{"version": "fake-version-1.0.0"}'


### PR DESCRIPTION
This PR adds two temporary workflow files used for testing the `repository_dispatch` github actions event. Once the work successfully for this repository, this files will be removed, and the performance-benchmarking-release and release workflows will be updated.