### PR TITLE
[no-release-notes] /go/libraries/doltcore/table/typed/schema.go: revert removal of schema.go file

### DIFF
--- a/go/libraries/doltcore/table/typed/schema.go
+++ b/go/libraries/doltcore/table/typed/schema.go
@@ -1,0 +1,37 @@
+// Copyright 2019 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package typed
+
+import (
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+)
+
+//
+func TypedSchemaUnion(schemas ...schema.Schema) (schema.Schema, error) {
+	var allCols []schema.Column
+
+	for _, sch := range schemas {
+		err := sch.GetAllCols().Iter(func(tag uint64, col schema.Column) (stop bool, err error) {
+			allCols = append(allCols, col)
+			return false, nil
+		})
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return schema.SchemaFromCols(schema.NewColCollection(allCols...))
+}


### PR DESCRIPTION
Not sure this should live in dolt... maybe we just move to ld and leave this out?