### PR TITLE
Andy/merge dupe tables

### DIFF
--- a/bats/merge.bats
+++ b/bats/merge.bats
@@ -277,7 +277,7 @@ INSERT INTO quiz VALUES (10),(11),(12);
 SQL
     dolt add . && dolt commit -m "added table quiz on master";
 
-    dolt checkout other
+    dolt checkout master
     dolt sql <<SQL
 CREATE TABLE quiz (pk int PRIMARY KEY);
 INSERT INTO quiz VALUES (20),(21),(22);

--- a/go/cmd/dolt/commands/blame.go
+++ b/go/cmd/dolt/commands/blame.go
@@ -430,11 +430,7 @@ func rowChanged(ctx context.Context, input blameInput, rowPK types.Value) (bool,
 	}
 
 	// if the table schema has changed, every row has changed (according to our current definition of blame)
-	schemasEql, err := schema.SchemasAreEqual(input.ParentSchema, input.Schema)
-	if err != nil {
-		return false, err
-	}
-	if !schemasEql {
+	if !schema.SchemasAreEqual(input.ParentSchema, input.Schema) {
 		return true, nil
 	}
 

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -481,7 +481,7 @@ func tabularSchemaDiff(ctx context.Context, td diff.TableDelta, fromSchemas, toS
 		return errhand.BuildDError("cannot retrieve schema for table %s", td.ToName).AddCause(err).Build()
 	}
 
-	eq, _ := schema.SchemasAreEqual(fromSch, toSch)
+	eq := schema.SchemasAreEqual(fromSch, toSch)
 	if eq && !td.HasFKChanges() {
 		return nil
 	}
@@ -588,7 +588,7 @@ func sqlSchemaDiff(ctx context.Context, td diff.TableDelta, toSchemas map[string
 			cli.Println(sqlfmt.RenameTableStmt(td.FromName, td.ToName))
 		}
 
-		eq, _ := schema.SchemasAreEqual(fromSch, toSch)
+		eq := schema.SchemasAreEqual(fromSch, toSch)
 		if eq && !td.HasFKChanges() {
 			return nil
 		}

--- a/go/libraries/doltcore/merge/integration_test.go
+++ b/go/libraries/doltcore/merge/integration_test.go
@@ -16,16 +16,16 @@ package merge_test
 
 import (
 	"context"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
+	"testing"
+
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 
 	cmd "github.com/dolthub/dolt/go/cmd/dolt/commands"
 	dtu "github.com/dolthub/dolt/go/libraries/doltcore/dtestutils"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 )
-
 
 func TestMerge(t *testing.T) {
 
@@ -35,14 +35,14 @@ func TestMerge(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		setup    []testCommand
+		name  string
+		setup []testCommand
 
 		query    string
 		expected []sql.Row
 	}{
 		{
-			name: "smoke test",
+			name:  "smoke test",
 			query: "SELECT * FROM test;",
 		},
 		{

--- a/go/libraries/doltcore/merge/integration_test.go
+++ b/go/libraries/doltcore/merge/integration_test.go
@@ -1,0 +1,108 @@
+// Copyright 2020 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package merge_test
+
+import (
+	"context"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+
+	cmd "github.com/dolthub/dolt/go/cmd/dolt/commands"
+	dtu "github.com/dolthub/dolt/go/libraries/doltcore/dtestutils"
+)
+
+
+func TestMerge(t *testing.T) {
+
+	setupCommon := []testCommand{
+		{cmd.SqlCmd{}, args{"-q", "CREATE TABLE test (pk int PRIMARY KEY, c0 int);"}},
+		{cmd.CommitCmd{}, args{"-am", "created table test"}},
+	}
+
+	tests := []struct {
+		name     string
+		setup    []testCommand
+
+		query    string
+		expected []sql.Row
+	}{
+		{
+			name: "smoke test",
+			query: "SELECT * FROM test;",
+		},
+		{
+			name: "fast-forward merge",
+			setup: []testCommand{
+				{cmd.CheckoutCmd{}, args{"-b", "other"}},
+				{cmd.SqlCmd{}, args{"-q", "INSERT INTO test VALUES (1,1),(2,2);"}},
+				{cmd.CommitCmd{}, args{"-am", "added rows on other"}},
+				{cmd.CheckoutCmd{}, args{"master"}},
+				{cmd.MergeCmd{}, args{"other"}},
+			},
+			query: "SELECT * FROM test",
+			expected: []sql.Row{
+				{int32(1), int32(1)},
+				{int32(2), int32(2)},
+			},
+		},
+		{
+			name: "three-way merge",
+			setup: []testCommand{
+				{cmd.BranchCmd{}, args{"other"}},
+				{cmd.SqlCmd{}, args{"-q", "INSERT INTO test VALUES (11,11),(22,22);"}},
+				{cmd.CommitCmd{}, args{"-am", "added rows on master"}},
+				{cmd.CheckoutCmd{}, args{"other"}},
+				{cmd.SqlCmd{}, args{"-q", "INSERT INTO test VALUES (1,1),(2,2);"}},
+				{cmd.CommitCmd{}, args{"-am", "added rows on other"}},
+				{cmd.CheckoutCmd{}, args{"master"}},
+				{cmd.MergeCmd{}, args{"other"}},
+			},
+			query: "SELECT * FROM test",
+			expected: []sql.Row{
+				{int32(1), int32(1)},
+				{int32(2), int32(2)},
+				{int32(11), int32(11)},
+				{int32(22), int32(22)},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			dEnv := dtu.CreateTestEnv()
+
+			for _, tc := range setupCommon {
+				tc.exec(t, ctx, dEnv)
+			}
+			for _, tc := range test.setup {
+				tc.exec(t, ctx, dEnv)
+			}
+
+			root, err := dEnv.WorkingRoot(ctx)
+			require.NoError(t, err)
+			actRows, err := sqle.ExecuteSelect(dEnv, dEnv.DoltDB, root, test.query)
+			require.NoError(t, err)
+
+			require.Equal(t, len(test.expected), len(actRows))
+			for i := range test.expected {
+				assert.Equal(t, test.expected[i], actRows[i])
+			}
+		})
+	}
+}

--- a/go/libraries/doltcore/merge/integration_test.go
+++ b/go/libraries/doltcore/merge/integration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	cmd "github.com/dolthub/dolt/go/cmd/dolt/commands"
+	"github.com/dolthub/dolt/go/cmd/dolt/commands/cnfcmds"
 	dtu "github.com/dolthub/dolt/go/libraries/doltcore/dtestutils"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 )
@@ -102,6 +103,119 @@ func TestMerge(t *testing.T) {
 				{"x"},
 				{"y"},
 				{"z"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			dEnv := dtu.CreateTestEnv()
+
+			for _, tc := range setupCommon {
+				tc.exec(t, ctx, dEnv)
+			}
+			for _, tc := range test.setup {
+				tc.exec(t, ctx, dEnv)
+			}
+
+			root, err := dEnv.WorkingRoot(ctx)
+			require.NoError(t, err)
+			actRows, err := sqle.ExecuteSelect(dEnv, dEnv.DoltDB, root, test.query)
+			require.NoError(t, err)
+
+			require.Equal(t, len(test.expected), len(actRows))
+			for i := range test.expected {
+				assert.Equal(t, test.expected[i], actRows[i])
+			}
+		})
+	}
+}
+
+func TestMergeConflicts(t *testing.T) {
+
+	setupCommon := []testCommand{
+		{cmd.SqlCmd{}, args{"-q", "CREATE TABLE test (pk int PRIMARY KEY, c0 int);"}},
+		{cmd.CommitCmd{}, args{"-am", "created table test"}},
+	}
+
+	tests := []struct {
+		name  string
+		setup []testCommand
+
+		query    string
+		expected []sql.Row
+	}{
+		{
+			name: "conflict on merge",
+			setup: []testCommand{
+				{cmd.CheckoutCmd{}, args{"-b", "other"}},
+				{cmd.SqlCmd{}, args{"-q", "INSERT INTO test VALUES (1,1),(2,2);"}},
+				{cmd.CommitCmd{}, args{"-am", "added rows on other"}},
+				{cmd.CheckoutCmd{}, args{"master"}},
+				{cmd.SqlCmd{}, args{"-q", "INSERT INTO test VALUES (1,11),(2,22);"}},
+				{cmd.CommitCmd{}, args{"-am", "added the same rows on master"}},
+				{cmd.MergeCmd{}, args{"other"}},
+			},
+			query: "SELECT * FROM dolt_conflicts",
+			expected: []sql.Row{
+				{"test", uint64(2)},
+			},
+		},
+		{
+			name: "conflict on merge, resolve with ours",
+			setup: []testCommand{
+				{cmd.CheckoutCmd{}, args{"-b", "other"}},
+				{cmd.SqlCmd{}, args{"-q", "INSERT INTO test VALUES (1,1),(2,2);"}},
+				{cmd.CommitCmd{}, args{"-am", "added rows on other"}},
+				{cmd.CheckoutCmd{}, args{"master"}},
+				{cmd.SqlCmd{}, args{"-q", "INSERT INTO test VALUES (1,11),(2,22);"}},
+				{cmd.CommitCmd{}, args{"-am", "added the same rows on master"}},
+				{cmd.MergeCmd{}, args{"other"}},
+				{cnfcmds.ResolveCmd{}, args{"--ours", "test"}},
+			},
+			query: "SELECT * FROM test",
+			expected: []sql.Row{
+				{int32(1), int32(11)},
+				{int32(2), int32(22)},
+			},
+		},
+		{
+			name: "conflict on merge, no table in ancestor",
+			setup: []testCommand{
+				{cmd.CheckoutCmd{}, args{"-b", "other"}},
+				{cmd.SqlCmd{}, args{"-q", "CREATE TABLE quiz (pk int PRIMARY KEY, c0 int);"}},
+				{cmd.SqlCmd{}, args{"-q", "INSERT INTO quiz VALUES (1,1),(2,2);"}},
+				{cmd.CommitCmd{}, args{"-am", "added rows on other"}},
+				{cmd.CheckoutCmd{}, args{"master"}},
+				{cmd.SqlCmd{}, args{"-q", "CREATE TABLE quiz (pk int PRIMARY KEY, c0 int);"}},
+				{cmd.SqlCmd{}, args{"-q", "INSERT INTO quiz VALUES (1,11),(2,22);"}},
+				{cmd.CommitCmd{}, args{"-am", "added the same rows on master"}},
+				{cmd.MergeCmd{}, args{"other"}},
+			},
+			query: "SELECT * FROM dolt_conflicts",
+			expected: []sql.Row{
+				{"quiz", uint64(2)},
+			},
+		},
+		{
+			name: "conflict on merge, no table in ancestor, resolve with theirs",
+			setup: []testCommand{
+				{cmd.CheckoutCmd{}, args{"-b", "other"}},
+				{cmd.SqlCmd{}, args{"-q", "CREATE TABLE quiz (pk int PRIMARY KEY, c0 int);"}},
+				{cmd.SqlCmd{}, args{"-q", "INSERT INTO quiz VALUES (1,1),(2,2);"}},
+				{cmd.CommitCmd{}, args{"-am", "added rows on other"}},
+				{cmd.CheckoutCmd{}, args{"master"}},
+				{cmd.SqlCmd{}, args{"-q", "CREATE TABLE quiz (pk int PRIMARY KEY, c0 int);"}},
+				{cmd.SqlCmd{}, args{"-q", "INSERT INTO quiz VALUES (1,11),(2,22);"}},
+				{cmd.CommitCmd{}, args{"-am", "added the same rows on master"}},
+				{cmd.MergeCmd{}, args{"other"}},
+				{cnfcmds.ResolveCmd{}, args{"--theirs", "quiz"}},
+			},
+			query: "SELECT * FROM quiz",
+			expected: []sql.Row{
+				{int32(1), int32(1)},
+				{int32(2), int32(2)},
 			},
 		},
 	}

--- a/go/libraries/doltcore/merge/integration_test.go
+++ b/go/libraries/doltcore/merge/integration_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Dolthub, Inc.
+// Copyright 2021 Dolthub, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/go/libraries/doltcore/merge/schema_integration_test.go
+++ b/go/libraries/doltcore/merge/schema_integration_test.go
@@ -33,8 +33,15 @@ import (
 
 type testCommand struct {
 	cmd  cli.Command
-	args []string
+	args args
 }
+
+func (tc testCommand) exec(t *testing.T, ctx context.Context, dEnv *env.DoltEnv) {
+	exitCode := tc.cmd.Exec(ctx, tc.cmd.Name(), tc.args, dEnv)
+	require.Equal(t, 0, exitCode)
+}
+
+type args []string
 
 func TestMergeSchemas(t *testing.T) {
 	for _, test := range mergeSchemaTests {
@@ -451,12 +458,10 @@ func testMergeSchemas(t *testing.T, test mergeSchemaTest) {
 	dEnv := dtestutils.CreateTestEnv()
 	ctx := context.Background()
 	for _, c := range setupCommon {
-		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv)
-		require.Equal(t, 0, exitCode)
+		c.exec(t, ctx, dEnv)
 	}
 	for _, c := range test.setup {
-		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv)
-		require.Equal(t, 0, exitCode)
+		c.exec(t, ctx, dEnv)
 	}
 
 	// assert that we're on master
@@ -495,15 +500,13 @@ func testMergeSchemasWithConflicts(t *testing.T, test mergeSchemaConflictTest) {
 	dEnv := dtestutils.CreateTestEnv()
 	ctx := context.Background()
 	for _, c := range setupCommon {
-		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv)
-		require.Equal(t, 0, exitCode)
+		c.exec(t, ctx, dEnv)
 	}
 
 	ancSch := getSchema(t, dEnv)
 
 	for _, c := range test.setup {
-		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv)
-		require.Equal(t, 0, exitCode)
+		c.exec(t, ctx, dEnv)
 	}
 
 	// assert that we're on master
@@ -540,16 +543,14 @@ func testMergeForeignKeys(t *testing.T, test mergeForeignKeyTest) {
 	dEnv := dtestutils.CreateTestEnv()
 	ctx := context.Background()
 	for _, c := range setupForeignKeyTests {
-		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv)
-		assert.Equal(t, 0, exitCode)
+		c.exec(t, ctx, dEnv)
 	}
 
 	ancRoot, err := dEnv.WorkingRoot(ctx)
 	require.NoError(t, err)
 
 	for _, c := range test.setup {
-		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv)
-		require.Equal(t, 0, exitCode)
+		c.exec(t, ctx, dEnv)
 	}
 
 	// assert that we're on master

--- a/go/libraries/doltcore/schema/encoding/schema_marshaling_test.go
+++ b/go/libraries/doltcore/schema/encoding/schema_marshaling_test.go
@@ -160,8 +160,7 @@ func TestTypeInfoMarshalling(t *testing.T) {
 			require.NoError(t, err)
 			unmarshalledSch, err := UnmarshalSchemaNomsValue(context.Background(), nbf, val)
 			require.NoError(t, err)
-			ok, err := schema.SchemasAreEqual(originalSch, unmarshalledSch)
-			assert.NoError(t, err)
+			ok := schema.SchemasAreEqual(originalSch, unmarshalledSch)
 			assert.True(t, ok)
 		})
 	}

--- a/go/libraries/doltcore/schema/schema.go
+++ b/go/libraries/doltcore/schema/schema.go
@@ -70,19 +70,18 @@ func HasAutoIncrement(sch Schema) (ok bool) {
 	return
 }
 
-// TODO: this function never returns an error
 // SchemasAreEqual tests equality of two schemas.
-func SchemasAreEqual(sch1, sch2 Schema) (bool, error) {
+func SchemasAreEqual(sch1, sch2 Schema) bool {
 	if sch1 == nil && sch2 == nil {
-		return true, nil
+		return true
 	} else if sch1 == nil || sch2 == nil {
-		return false, nil
+		return false
 	}
 	colCollIsEqual := ColCollsAreEqual(sch1.GetAllCols(), sch2.GetAllCols())
 	if !colCollIsEqual {
-		return false, nil
+		return false
 	}
-	return sch1.Indexes().Equals(sch2.Indexes()), nil
+	return sch1.Indexes().Equals(sch2.Indexes())
 }
 
 // TODO: this function never returns an error

--- a/go/libraries/doltcore/schema/schema_test.go
+++ b/go/libraries/doltcore/schema/schema_test.go
@@ -73,8 +73,7 @@ func TestSchema(t *testing.T) {
 
 	testSchema("SchemaFromPKAndNonPKCols", schFromPKAndNonPKCols, t)
 
-	eq, err := SchemasAreEqual(schFromCols, schFromPKAndNonPKCols)
-	assert.NoError(t, err)
+	eq := SchemasAreEqual(schFromCols, schFromPKAndNonPKCols)
 	assert.True(t, eq, "schemas should be equal")
 }
 

--- a/go/libraries/doltcore/schema/super_schema_test.go
+++ b/go/libraries/doltcore/schema/super_schema_test.go
@@ -178,7 +178,7 @@ func testSuperSchema(t *testing.T, test SuperSchemaTest) {
 		require.NoError(t, err)
 		assert.Equal(t, test.ExpectedGeneratedSchema, gs)
 
-		eq, err := SchemasAreEqual(test.ExpectedGeneratedSchema, gs)
+		eq := SchemasAreEqual(test.ExpectedGeneratedSchema, gs)
 		require.NoError(t, err)
 		assert.True(t, eq)
 	}

--- a/go/libraries/doltcore/sqle/dtables/diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/diff_table.go
@@ -557,11 +557,7 @@ func (dp *diffPartitions) Close() error {
 
 // creates a RowConverter for transforming rows with the the given schema to this super schema.
 func rowConvForSchema(ctx context.Context, vrw types.ValueReadWriter, ss *schema.SuperSchema, sch schema.Schema) (*rowconv.RowConverter, error) {
-	eq, err := schema.SchemasAreEqual(sch, schema.EmptySchema)
-	if err != nil {
-		return nil, err
-	}
-	if eq {
+	if schema.SchemasAreEqual(sch, schema.EmptySchema) {
 		return rowconv.IdentityConverter, nil
 	}
 

--- a/go/libraries/doltcore/table/composite_table_reader.go
+++ b/go/libraries/doltcore/table/composite_table_reader.go
@@ -39,11 +39,7 @@ func NewCompositeTableReader(readers []TableReadCloser) (*CompositeTableReader, 
 	sch := readers[0].GetSchema()
 	for i := 1; i < len(readers); i++ {
 		otherSch := readers[i].GetSchema()
-		eq, err := schema.SchemasAreEqual(sch, otherSch)
-
-		if err != nil {
-			return nil, err
-		} else if !eq {
+		if !schema.SchemasAreEqual(sch, otherSch) {
 			panic("readers must have the same schema")
 		}
 	}

--- a/go/libraries/doltcore/table/editor/table_edit_session.go
+++ b/go/libraries/doltcore/table/editor/table_edit_session.go
@@ -208,7 +208,7 @@ func (tes *TableEditSession) getTableEditor(ctx context.Context, tableName strin
 	if ok {
 		if tableSch == nil {
 			return localTableEditor, nil
-		} else if ok, err = schema.SchemasAreEqual(tableSch, localTableEditor.tableEditor.Schema()); err == nil && ok {
+		} else if schema.SchemasAreEqual(tableSch, localTableEditor.tableEditor.Schema()) {
 			return localTableEditor, nil
 		}
 		// Any existing references to this localTableEditor should be preserved, so we just change the underlying values


### PR DESCRIPTION
Quick fix to address views bug. Repro is described in the bats test `@test "Add views on two branches, merge" `.

This PR only addresses the case where a table created on two branches has the exact same schema. Further work is needed to merge tables when the schema is "overlapping" but not equal.