### PR TITLE
Revert "[no-release-notes] /.github/workflows/cd-release.yaml: bump version and commit"

### DIFF
--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -35,6 +35,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.15
       - name: Checkout release tag
         run: |
           git fetch --tags --all

--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -14,16 +14,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Update dolt version
-        run: sed -i 's/Version =.*/Version = "'"$VERSION"'"/' "$FILE"
-        env:
-          FILE: ${{ format('{0}/go/cmd/dolt/dolt.go', github.workspace) }}
-          VERSION: ${{ github.event.inputs.version }}
-      - uses: EndBug/add-and-commit@v7
-        with:
-          message: ${{ format('[ga-bump-release] update dolt version to {0}', github.event.inputs.version) }}
-          add: ${{ format('{0}/go/cmd/dolt/dolt.go', github.workspace) }}
-          cwd: "."
+      - name: Bump Version
+        id: bump-version
+        run: |
+          git config --global user.name dolt-release-bot
+          git config --global user.email dolt-release-bot@dolthub.com
+          ./go/utils/publishrelease/bump-version.sh ${{ github.event.inputs.version }}
       - name: Discord Notify
         if: always()
         uses: dolthub/ga-discord-notify@master
@@ -39,10 +35,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v2
-        with:
-          go-version: ^1.15
       - name: Checkout release tag
         run: |
           git fetch --tags --all

--- a/go/utils/publishrelease/bump-version.sh
+++ b/go/utils/publishrelease/bump-version.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+script_dir=$(dirname "$0")
+cd $script_dir
+
+[ ! -z "$1" ] || (echo "Please supply version string as first parameter"; exit 1)
+version_str=$1
+
+dolt_cmd_entry_point="../../cmd/dolt/dolt.go"
+release_tag="v$version_str"
+release_branch="$release_tag-release"
+
+echo "Checking out release branch $release_branch"
+git checkout -b $release_branch
+
+echo "Updating the version to $version_str"
+# Note this if statement is for cross platform support between Linux/OSX
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' -e 's/Version = ".*"/Version = "'"$version_str"'"/' $dolt_cmd_entry_point
+else
+  sed -i -e 's/Version = ".*"/Version = "'"$version_str"'"/' $dolt_cmd_entry_point
+fi
+
+echo "Creating commit for $release_branch"
+git add $dolt_cmd_entry_point
+git commit -m "Updated version for release of version $version_str"
+
+echo "Pushing $release_branch"
+git push origin $release_branch
+
+echo "Creating and pushing tag for version $version_str"
+git tag -a "$release_tag" -m "Tag Dolt version $version_str"
+git push origin $release_tag


### PR DESCRIPTION
Reverts dolthub/dolt#1296, needs some coordination work in order to fetch the newly created tag