### PR TITLE
Diff based foreign key validation

### DIFF
--- a/bats/foreign-keys.bats
+++ b/bats/foreign-keys.bats
@@ -64,7 +64,7 @@ SQL
       UPDATE colors SET color='orange' WHERE color = 'green';
       UPDATE objects SET color='orange' WHERE color = 'green';
       INSERT INTO objects (id,name,color) VALUES (4,'car','red'),(5,'dress','orange');
-      --INSERT INTO objects (id,name) VALUES (6,'glass slipper')
+      INSERT INTO objects (id,name) VALUES (6,'glass slipper')
 SQL
 
     dolt sql -q 'select * from colors'
@@ -102,8 +102,8 @@ SQL
           FOREIGN KEY (color,material) REFERENCES materials(color,material)
       );
       INSERT INTO colors (id,color) VALUES (1,'red'),(2,'green'),(3,'blue'),(4,'purple'),(10,'brown');
-      INSERT INTO materials (id,material,color) VALUES (1,'steel','red'),(2,'rubber','green'),(3,'leather','blue'),(10,'dirt','brown');
-      INSERT INTO objects (id,name,color,material) VALUES (1,'truck','red','steel'),(2,'ball','green','rubber'),(3,'shoe','blue','leather');
+      INSERT INTO materials (id,material,color) VALUES (1,'steel','red'),(2,'rubber','green'),(3,'leather','blue'),(10,'dirt','brown'),(11,'air',NULL);
+      INSERT INTO objects (id,name,color,material) VALUES (1,'truck','red','steel'),(2,'ball','green','rubber'),(3,'shoe','blue','leather'),(11,'tornado',NULL,'air');
 SQL
 
     dolt add .
@@ -119,8 +119,10 @@ SQL
       UPDATE materials SET color='orange' WHERE color = 'green';
       UPDATE objects SET color='orange' WHERE color = 'green';
       INSERT INTO objects (id,name,color,material) VALUES (4,'car','red','fiber glass'),(5,'dress','orange','cotton');
-      --INSERT INTO materials (id,name) VALUES (6,'glass')
-      --INSERT INTO objects (id,name,material) VALUES (6,'glass slipper','glass')
+      INSERT INTO materials (id,material) VALUES (7,'glass');
+      INSERT INTO objects (id,name,material) VALUES (6,'glass slipper','glass');
+      DELETE FROM objects WHERE material = 'air';
+      DELETE FROM materials WHERE material = 'air'
 SQL
 
     dolt sql -q 'select * from colors'

--- a/bats/foreign-keys.bats
+++ b/bats/foreign-keys.bats
@@ -25,6 +25,111 @@ teardown() {
     teardown_common
 }
 
+
+@test "test foreign-key on commit checks" {
+    dolt reset --hard
+    dolt sql <<SQL
+      CREATE TABLE colors (
+          id INT NOT NULL,
+          color VARCHAR(32) NOT NULL,
+
+          PRIMARY KEY (id),
+          INDEX color_index(color)
+      );
+      CREATE TABLE objects (
+          id INT NOT NULL,
+          name VARCHAR(64) NOT NULL,
+          color VARCHAR(32),
+
+          PRIMARY KEY(id),
+          FOREIGN KEY (color) REFERENCES colors(color)
+      );
+      INSERT INTO colors (id,color) VALUES (1,'red'),(2,'green'),(3,'blue'),(4,'purple');
+      INSERT INTO objects (id,name,color) VALUES (1,'truck','red'),(2,'ball','green'),(3,'shoe','blue');
+SQL
+
+    dolt add .
+    dolt commit -m "initialize"
+
+    # delete a color that isn't used
+    # delete a color that is used, and replace it with a new row with the same value
+    # modify a used color and the corresponding object using it
+    # add an object and point to an old color that has not been modified
+    # add an object and point to the new color
+    # add an object with a null color
+    dolt sql <<SQL
+      SET FOREIGN_KEY_CHECKS=0;
+      DELETE FROM colors where id = 3 or id = 4;
+      INSERT INTO colors (id,color) VALUES (5,'blue');
+      UPDATE colors SET color='orange' WHERE color = 'green';
+      UPDATE objects SET color='orange' WHERE color = 'green';
+      INSERT INTO objects (id,name,color) VALUES (4,'car','red'),(5,'dress','orange');
+      --INSERT INTO objects (id,name) VALUES (6,'glass slipper')
+SQL
+
+    dolt sql -q 'select * from colors'
+    dolt sql -q 'select * from objects'
+    dolt add .
+    dolt commit -m 'update 1'
+}
+
+@test "test multi-field foreign-key on commit checks" {
+    dolt reset --hard
+    dolt sql <<SQL
+      CREATE TABLE colors (
+          id INT NOT NULL,
+          color VARCHAR(32) NOT NULL,
+
+          PRIMARY KEY (id),
+          INDEX color_index(color)
+      );
+      CREATE TABLE materials (
+          id INT NOT NULL,
+          material VARCHAR(32) NOT NULL,
+          color VARCHAR(32),
+
+          PRIMARY KEY(id),
+          FOREIGN KEY (color) REFERENCES colors(color),
+          INDEX color_mat_index(color, material)
+      );
+      CREATE TABLE objects (
+          id INT NOT NULL,
+          name VARCHAR(64) NOT NULL,
+          color VARCHAR(32),
+          material VARCHAR(32),
+
+          PRIMARY KEY(id),
+          FOREIGN KEY (color,material) REFERENCES materials(color,material)
+      );
+      INSERT INTO colors (id,color) VALUES (1,'red'),(2,'green'),(3,'blue'),(4,'purple'),(10,'brown');
+      INSERT INTO materials (id,material,color) VALUES (1,'steel','red'),(2,'rubber','green'),(3,'leather','blue'),(10,'dirt','brown');
+      INSERT INTO objects (id,name,color,material) VALUES (1,'truck','red','steel'),(2,'ball','green','rubber'),(3,'shoe','blue','leather');
+SQL
+
+    dolt add .
+    dolt commit -m "initialize"
+
+    dolt sql <<SQL
+      SET FOREIGN_KEY_CHECKS=0;
+      DELETE FROM colors where id = 3 or id = 4;
+      INSERT INTO colors (id,color) VALUES (5,'blue');
+      DELETE FROM materials WHERE id IN (1,10);
+      INSERT INTO materials (id,material,color) VALUES (4,'steel','red'),(5,'fiber glass','red'),(6,'cotton','orange');
+      UPDATE colors SET color='orange' WHERE color = 'green';
+      UPDATE materials SET color='orange' WHERE color = 'green';
+      UPDATE objects SET color='orange' WHERE color = 'green';
+      INSERT INTO objects (id,name,color,material) VALUES (4,'car','red','fiber glass'),(5,'dress','orange','cotton');
+      --INSERT INTO materials (id,name) VALUES (6,'glass')
+      --INSERT INTO objects (id,name,material) VALUES (6,'glass slipper','glass')
+SQL
+
+    dolt sql -q 'select * from colors'
+    dolt sql -q 'select * from materials'
+    dolt sql -q 'select * from objects'
+    dolt add .
+    dolt commit -m 'update 1'
+}
+
 @test "foreign-keys: ALTER TABLE Single Named FOREIGN KEY" {
     dolt sql <<SQL
 ALTER TABLE child ADD CONSTRAINT fk_named FOREIGN KEY (v1) REFERENCES parent(v1);
@@ -1238,3 +1343,4 @@ SQL
     skip "foreign keys don't travel with the working set when checking out a new branch"
     [[ "$output" =~ "fk_v1" ]] || false
 }
+

--- a/bats/foreign-keys.bats
+++ b/bats/foreign-keys.bats
@@ -132,6 +132,91 @@ SQL
     dolt commit -m 'update 1'
 }
 
+@test "test foreign-key on commit errors" {
+    dolt reset --hard
+    dolt sql <<SQL
+      CREATE TABLE colors (
+          id INT NOT NULL,
+          color VARCHAR(32) NOT NULL,
+
+          PRIMARY KEY (id),
+          INDEX color_index(color)
+      );
+      CREATE TABLE materials (
+          id INT NOT NULL,
+          material VARCHAR(32) NOT NULL,
+          color VARCHAR(32),
+
+          PRIMARY KEY(id),
+          FOREIGN KEY (color) REFERENCES colors(color),
+          INDEX color_mat_index(color, material)
+      );
+      CREATE TABLE objects (
+          id INT NOT NULL,
+          name VARCHAR(64) NOT NULL,
+          color VARCHAR(32),
+          material VARCHAR(32),
+
+          PRIMARY KEY(id),
+          FOREIGN KEY (color,material) REFERENCES materials(color,material)
+      );
+      INSERT INTO colors (id,color) VALUES (1,'red'),(2,'green'),(3,'blue'),(4,'purple'),(10,'brown');
+      INSERT INTO materials (id,material,color) VALUES (1,'steel','red'),(2,'rubber','green'),(3,'leather','blue'),(10,'dirt','brown'),(11,'air',NULL);
+      INSERT INTO objects (id,name,color,material) VALUES (1,'truck','red','steel'),(2,'ball','green','rubber'),(3,'shoe','blue','leather'),(11,'tornado',NULL,'air');
+SQL
+
+    dolt add .
+    dolt commit -m "initialize"
+
+    # delete a referenced color
+    dolt sql <<SQL
+      SET FOREIGN_KEY_CHECKS=0;
+      DELETE FROM colors where id = 1;
+SQL
+
+    dolt add .
+    run dolt commit -m 'expect failure'
+    [ "$status" -eq "1" ]
+    [[ "$output" =~ "Foreign key violation" ]] || false
+    dolt reset --hard
+
+    # delete a referenced material
+    dolt sql <<SQL
+      SET FOREIGN_KEY_CHECKS=0;
+      DELETE FROM materials WHERE material = 'rubber'
+SQL
+
+    dolt add .
+    run dolt commit -m 'expect failure'
+    [ "$status" -eq "1" ]
+    [[ "$output" =~ "Foreign key violation" ]] || false
+    dolt reset --hard
+
+    # add a material referencing non-existant color
+    dolt sql <<SQL
+      SET FOREIGN_KEY_CHECKS=0;
+      INSERT INTO materials (id,material,color) VALUES (100,'aluminum','silver')
+SQL
+
+    dolt add .
+    run dolt commit -m 'expect failure'
+    [ "$status" -eq "1" ]
+    [[ "$output" =~ "Foreign key violation" ]] || false
+    dolt reset --hard
+
+    # add an object referencing non-existant material
+    dolt sql <<SQL
+      SET FOREIGN_KEY_CHECKS=0;
+      INSERT INTO objects (id,name,color,material) VALUES (100,'truck','red','plastic')
+SQL
+
+    dolt add .
+    run dolt commit -m 'expect failure'
+    [ "$status" -eq "1" ]
+    [[ "$output" =~ "Foreign key violation" ]] || false
+    dolt reset --hard
+}
+
 @test "foreign-keys: ALTER TABLE Single Named FOREIGN KEY" {
     dolt sql <<SQL
 ALTER TABLE child ADD CONSTRAINT fk_named FOREIGN KEY (v1) REFERENCES parent(v1);

--- a/bats/foreign-keys.bats
+++ b/bats/foreign-keys.bats
@@ -962,7 +962,7 @@ SQL
     dolt add child
     run dolt commit -m "should fail"
     [ "$status" -eq "1" ]
-    [[ "$output" =~ "foreign key violation" ]] || false
+    [[ "$output" =~ "Foreign key violation" ]] || false
 }
 
 @test "foreign-keys: Merge valid onto parent" {

--- a/go/libraries/doltcore/env/actions/commit.go
+++ b/go/libraries/doltcore/env/actions/commit.go
@@ -18,9 +18,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/dolthub/dolt/go/libraries/doltcore/fkconstrain"
 	"sort"
 	"time"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/fkconstrain"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"

--- a/go/libraries/doltcore/fkconstrain/checks.go
+++ b/go/libraries/doltcore/fkconstrain/checks.go
@@ -136,7 +136,8 @@ func (declFKC declaredFKCheck) Check(ctx context.Context, _, newTV row.TaggedVal
 		if val, ok := newTV[declTag]; ok {
 			keyTupVals[i*2+1] = val
 		} else {
-			keyTupVals[i*2+1] = types.NullValue
+			// full key is not present.  skip check
+			return nil
 		}
 	}
 
@@ -186,7 +187,8 @@ func (refFKC referencedFKCheck) Check(ctx context.Context, oldTV, _ row.TaggedVa
 		if val, ok := oldTV[tag]; ok {
 			keyTupVals[i*2+1] = val
 		} else {
-			keyTupVals[i*2+1] = types.NullValue
+			// full key is not present.  skip check
+			return nil
 		}
 	}
 

--- a/go/libraries/doltcore/fkconstrain/checks.go
+++ b/go/libraries/doltcore/fkconstrain/checks.go
@@ -1,0 +1,261 @@
+// Copyright 2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fkconstrain
+
+import (
+	"context"
+	"io"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/row"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/dolt/go/store/types"
+)
+
+type fkCheck interface {
+	ColsIntersectChanges(changes map[uint64]bool) bool
+	Check(ctx context.Context, oldTV, newTV row.TaggedValues) error
+}
+
+type check struct {
+	nbf                 *types.NomsBinFormat
+	fk                  doltdb.ForeignKey
+	declaredIndex       schema.Index
+	declaredIndexRows   types.Map
+	referencedIndex     schema.Index
+	referencedIndexRows types.Map
+
+	colTags           []uint64
+	declTagsToRefTags map[uint64]uint64
+	refTagsToDeclTags map[uint64]uint64
+}
+
+func newCheck(ctx context.Context, root *doltdb.RootValue, colTags []uint64, fk doltdb.ForeignKey) (check, error) {
+	declTable, declSch, err := getTableAndSchema(ctx, root, fk.TableName)
+
+	if err != nil {
+		return check{}, err
+	}
+
+	refTable, refSch, err := getTableAndSchema(ctx, root, fk.ReferencedTableName)
+
+	if err != nil {
+		return check{}, err
+	}
+
+	refIdx := refSch.Indexes().GetByName(fk.ReferencedTableIndex)
+	refIdxRowData, err := refTable.GetIndexRowData(ctx, fk.ReferencedTableIndex)
+
+	if err != nil {
+		return check{}, err
+	}
+
+	declIdx := declSch.Indexes().GetByName(fk.TableIndex)
+	declIdxRowData, err := declTable.GetIndexRowData(ctx, fk.TableIndex)
+
+	if err != nil {
+		return check{}, err
+	}
+
+	declTagsToRefTags := make(map[uint64]uint64)
+	refTagsToDeclTags := make(map[uint64]uint64)
+	for i, declTag := range fk.TableColumns {
+		refTag := fk.ReferencedTableColumns[i]
+		declTagsToRefTags[declTag] = refTag
+		refTagsToDeclTags[refTag] = declTag
+	}
+
+	return check{
+		nbf:                 root.VRW().Format(),
+		fk:                  fk,
+		declaredIndex:       declIdx,
+		declaredIndexRows:   declIdxRowData,
+		referencedIndex:     refIdx,
+		referencedIndexRows: refIdxRowData,
+		colTags:             colTags,
+		declTagsToRefTags:   declTagsToRefTags,
+		refTagsToDeclTags:   refTagsToDeclTags,
+	}, nil
+}
+
+func (chk check) ColsIntersectChanges(changes map[uint64]bool) bool {
+	for _, tag := range chk.colTags {
+		if changes[tag] {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (chk check) NewErrForKey(key types.Tuple) error {
+	return &ForeignKeyError{
+		tableName:           chk.fk.TableName,
+		referencedTableName: chk.fk.ReferencedTableName,
+		fkName:              chk.fk.Name,
+		keyStr:              key.String(),
+	}
+}
+
+type declaredFKCheck struct {
+	check
+}
+
+func newDeclaredFKCheck(ctx context.Context, root *doltdb.RootValue, fk doltdb.ForeignKey) (declaredFKCheck, error) {
+	chk, err := newCheck(ctx, root, fk.TableColumns, fk)
+
+	if err != nil {
+		return declaredFKCheck{}, err
+	}
+
+	return declaredFKCheck{
+		check: chk,
+	}, nil
+}
+
+// Check checks that the new tagged values coming from the declared table are present in the referenced index
+func (declFKC declaredFKCheck) Check(ctx context.Context, _, newTV row.TaggedValues) error {
+	indexColTags := declFKC.referencedIndex.IndexedColumnTags()
+	keyTupVals := make([]types.Value, len(indexColTags)*2)
+	for i, refTag := range indexColTags {
+		declTag := declFKC.refTagsToDeclTags[refTag]
+		keyTupVals[i*2] = types.Uint(refTag)
+
+		if val, ok := newTV[declTag]; ok {
+			keyTupVals[i*2+1] = val
+		} else {
+			keyTupVals[i*2+1] = types.NullValue
+		}
+	}
+
+	key, err := types.NewTuple(declFKC.nbf, keyTupVals...)
+
+	if err != nil {
+		return err
+	}
+
+	found, err := indexHasKey(ctx, declFKC.referencedIndexRows, key)
+
+	if err != nil {
+		return err
+	}
+
+	if !found {
+		return declFKC.NewErrForKey(key)
+	}
+
+	return nil
+}
+
+type referencedFKCheck struct {
+	check
+}
+
+func newRefFKCheck(ctx context.Context, root *doltdb.RootValue, fk doltdb.ForeignKey) (referencedFKCheck, error) {
+	chk, err := newCheck(ctx, root, fk.ReferencedTableColumns, fk)
+
+	if err != nil {
+		return referencedFKCheck{}, err
+	}
+
+	return referencedFKCheck{
+		check: chk,
+	}, nil
+}
+
+// Check checks that either the value coming from the old tagged values is present in a new row in the referenced index
+// or the value is no longer referenced by rows in the declared index.
+func (refFKC referencedFKCheck) Check(ctx context.Context, oldTV, newTV row.TaggedValues) error {
+	indexColTags := refFKC.referencedIndex.IndexedColumnTags()
+	keyTupVals := make([]types.Value, len(refFKC.fk.ReferencedTableColumns)*2)
+	for i, tag := range indexColTags {
+		keyTupVals[i*2] = types.Uint(tag)
+
+		if val, ok := oldTV[tag]; ok {
+			keyTupVals[i*2+1] = val
+		} else {
+			keyTupVals[i*2+1] = types.NullValue
+		}
+	}
+
+	key, err := types.NewTuple(refFKC.nbf, keyTupVals...)
+
+	if err != nil {
+		return err
+	}
+
+	found, err := indexHasKey(ctx, refFKC.referencedIndexRows, key)
+
+	if err != nil {
+		return err
+	}
+
+	if found {
+		return nil
+	}
+
+	if newTV == nil {
+		return refFKC.NewErrForKey(key)
+	}
+
+	declIndexTags := refFKC.declaredIndex.IndexedColumnTags()
+	keyTupVals = make([]types.Value, len(indexColTags)*2)
+	for i, declTag := range declIndexTags {
+		refTag := refFKC.declTagsToRefTags[declTag]
+		keyTupVals[i*2] = types.Uint(declTag)
+
+		if val, ok := newTV[refTag]; ok {
+			keyTupVals[i*2+1] = val
+		} else {
+			keyTupVals[i*2+1] = types.NullValue
+		}
+	}
+
+	key, err = types.NewTuple(refFKC.nbf, keyTupVals...)
+
+	if err != nil {
+		return err
+	}
+
+	found, err = indexHasKey(ctx, refFKC.declaredIndexRows, key)
+
+	if err != nil {
+		return err
+	}
+
+	if !found {
+		return refFKC.NewErrForKey(key)
+	}
+
+	return nil
+}
+
+func indexHasKey(ctx context.Context, indexRows types.Map, key types.Tuple) (bool, error) {
+	itr, err := indexRows.IteratorFrom(ctx, key)
+
+	if err != nil {
+		return false, err
+	}
+
+	refKey, _, err := itr.NextTuple(ctx)
+
+	if err == io.EOF {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	return refKey.StartsWith(key), nil
+}

--- a/go/libraries/doltcore/fkconstrain/diffitr.go
+++ b/go/libraries/doltcore/fkconstrain/diffitr.go
@@ -1,0 +1,124 @@
+// Copyright 2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fkconstrain
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	nomsdiff "github.com/dolthub/dolt/go/store/diff"
+	"github.com/dolthub/dolt/go/store/types"
+)
+
+type mapIterAsRowDiffer struct {
+	itr types.MapIterator
+	ctx context.Context
+}
+
+// Start starts the RowDiffer.
+func (mitr mapIterAsRowDiffer) Start(_ context.Context, _, _ types.Map) {}
+
+// GetDiffs returns the requested number of diff.Differences, or times out.
+func (mitr mapIterAsRowDiffer) GetDiffs(_ int, _ time.Duration) ([]*nomsdiff.Difference, bool, error) {
+	k, v, err := mitr.itr.Next(mitr.ctx)
+
+	if err != nil {
+		return nil, false, err
+	}
+
+	if k == nil {
+		return nil, false, nil
+	}
+
+	return []*nomsdiff.Difference{{
+		ChangeType:  types.DiffChangeAdded,
+		OldValue:    nil,
+		NewValue:    v,
+		NewKeyValue: k,
+		KeyValue:    k,
+	}}, true, nil
+}
+
+// Close closes the RowDiffer.
+func (mitr mapIterAsRowDiffer) Close() error {
+	return nil
+}
+
+func getDiffItr(ctx context.Context, parentCommitRoot, root *doltdb.RootValue, tblName string) (diff.RowDiffer, error) {
+	parentOK := true
+	pTbl, pSch, err := getTableAndSchema(ctx, parentCommitRoot, tblName)
+
+	if errors.Is(err, doltdb.ErrTableNotFound) {
+		parentOK = false
+	} else if err != nil {
+		return nil, err
+	}
+
+	tbl, sch, err := getTableAndSchema(ctx, root, tblName)
+
+	if err != nil {
+		return nil, err
+	}
+
+	rowData, err := tbl.GetRowData(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if !parentOK {
+		itr, err := rowData.Iterator(ctx)
+
+		if err != nil {
+			return nil, err
+		}
+
+		return mapIterAsRowDiffer{itr: itr, ctx: ctx}, nil
+	}
+
+	pRowData, err := pTbl.GetRowData(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	rd := diff.NewRowDiffer(ctx, pSch, sch, 1024)
+	rd.Start(ctx, pRowData, rowData)
+
+	return rd, nil
+}
+
+func getTableAndSchema(ctx context.Context, root *doltdb.RootValue, tableName string) (*doltdb.Table, schema.Schema, error) {
+	tbl, _, ok, err := root.GetTableInsensitive(ctx, tableName)
+
+	if err != nil {
+		return nil, nil, err
+	} else if !ok {
+		return nil, nil, fmt.Errorf("%w: %s", doltdb.ErrTableNotFound, tableName)
+	}
+
+	sch, err := tbl.GetSchema(ctx)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return tbl, sch, nil
+}

--- a/go/libraries/doltcore/fkconstrain/errors.go
+++ b/go/libraries/doltcore/fkconstrain/errors.go
@@ -1,0 +1,37 @@
+// Copyright 2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fkconstrain
+
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrForeignKeyConstraintViolation = errors.New("foreign key constraint violation")
+
+type ForeignKeyError struct {
+	tableName           string
+	referencedTableName string
+	fkName              string
+	keyStr              string
+}
+
+func (err *ForeignKeyError) Error() string {
+	return fmt.Sprintf("Foreign key violation on fk: `%s`, table: `%s`, referenced table: `%s`, key: `%s`", err.fkName, err.tableName, err.referencedTableName, err.keyStr)
+}
+
+func (err *ForeignKeyError) Unwrap() error {
+	return ErrForeignKeyConstraintViolation
+}

--- a/go/libraries/doltcore/fkconstrain/validate.go
+++ b/go/libraries/doltcore/fkconstrain/validate.go
@@ -234,7 +234,7 @@ func parseDiff(d *nomsdiff.Difference) (oldTV, newTV row.TaggedValues, changes m
 		}
 	}
 
-	return newTV, oldTV, changes, nil
+	return oldTV, newTV, changes, nil
 }
 
 type fkValidationInfo struct {

--- a/go/libraries/doltcore/fkconstrain/validate.go
+++ b/go/libraries/doltcore/fkconstrain/validate.go
@@ -1,0 +1,290 @@
+// Copyright 2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fkconstrain
+
+import (
+	"context"
+	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/row"
+	nomsdiff "github.com/dolthub/dolt/go/store/diff"
+	"github.com/dolthub/dolt/go/store/types"
+	"time"
+)
+
+func Validate(ctx context.Context, parentCommitRoot, root *doltdb.RootValue) error {
+	tblNames, err := root.GetTableNames(ctx)
+
+	if err != nil {
+		return err
+	}
+
+	tblNameToValidationInfo, err := getFKValidationInfo(ctx, root, tblNames)
+
+	if err != nil {
+		return err
+	}
+
+	for _, tblName := range tblNames {
+		// skip tables that don't have foreign key constraints
+		validationInfo, ok := tblNameToValidationInfo[tblName]
+
+		if !ok || len(validationInfo.allChecks) == 0 {
+			continue
+		}
+
+		// get iterator that, when possible, only iterates over changes
+		diffItr, err := getDiffItr(ctx, parentCommitRoot, root, tblName)
+
+		if err != nil {
+			return err
+		}
+
+		err = validateFKForDiffs(ctx, diffItr, validationInfo)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateFKForDiffs(ctx context.Context, itr diff.RowDiffer, info fkValidationInfo) error {
+	for {
+		diffs, ok, err := itr.GetDiffs(1, time.Minute)
+
+		if err != nil {
+			return err
+		}
+
+		if !ok {
+			return nil
+		}
+
+		d := diffs[0]
+		switch d.ChangeType {
+		case types.DiffChangeRemoved:
+			if len(info.referencedFK) == 0 {
+				break
+			}
+
+			tv, err := row.TaggedValuesFromTupleKeyAndValue(d.KeyValue.(types.Tuple), d.OldValue.(types.Tuple))
+
+			if err != nil {
+				return err
+			}
+
+			// when a row is removed we need to check that no rows were referencing that value
+			for _, check := range info.referencedFK {
+				err = check.Check(ctx, tv, nil)
+
+				if err != nil {
+					return err
+				}
+			}
+
+		case types.DiffChangeAdded:
+			if len(info.declaredFK) == 0 {
+				break
+			}
+
+			tv, err := row.TaggedValuesFromTupleKeyAndValue(d.KeyValue.(types.Tuple), d.NewValue.(types.Tuple))
+
+			if err != nil {
+				return err
+			}
+
+			// when a row is added we need to check that all the foreign key constraints declared on the table
+			// are satisfied
+			for _, check := range info.declaredFK {
+				err = check.Check(ctx, nil, tv)
+
+				if err != nil {
+					return err
+				}
+			}
+
+		case types.DiffChangeModified:
+			oldTV, newTV, colsChanged, err := parseDiff(d)
+
+			if err != nil {
+				return err
+			}
+
+			for _, check := range info.allChecks {
+				if check.ColsIntersectChanges(colsChanged) {
+					err = check.Check(ctx, oldTV, newTV)
+
+					if err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+}
+
+func nextTagAndValue(itr *types.TupleIterator) (uint64, types.Value, error) {
+	_, tag, err := itr.NextUint64()
+
+	if err != nil {
+		return 0, nil, err
+	}
+
+	_, val, err := itr.Next()
+
+	if err != nil {
+		return 0, nil, err
+	}
+
+	return tag, val, nil
+}
+
+func parseDiff(d *nomsdiff.Difference) (oldTV, newTV row.TaggedValues, changes map[uint64]bool, err error) {
+	const MaxTag uint64 = (1 << 64) - 1
+
+	newTV = make(row.TaggedValues)
+	oldTV = make(row.TaggedValues)
+	changes = make(map[uint64]bool)
+
+	itr, err := d.KeyValue.(types.Tuple).Iterator()
+
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	for itr.HasMore() {
+		tag, val, err := nextTagAndValue(itr)
+
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		newTV[tag] = val
+		oldTV[tag] = val
+	}
+
+	oldVal := d.OldValue.(types.Tuple)
+	newVal := d.NewValue.(types.Tuple)
+
+	oldItr, err := oldVal.Iterator()
+
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	newItr, err := newVal.Iterator()
+
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	var currNewTag, currOldTag uint64
+	var currNewVal, currOldVal types.Value
+	for {
+		if currNewVal == nil {
+			if !newItr.HasMore() {
+				currNewTag = MaxTag
+			} else {
+				currNewTag, currNewVal, err = nextTagAndValue(newItr)
+			}
+		}
+
+		if currOldVal == nil {
+			if !oldItr.HasMore() {
+				if currNewTag == MaxTag {
+					break
+				}
+
+				currOldTag = MaxTag
+			} else {
+				currOldTag, currOldVal, err = nextTagAndValue(oldItr)
+			}
+		}
+
+		if currNewTag < currOldTag {
+			newTV[currNewTag] = currNewVal
+			oldTV[currNewTag] = types.NullValue
+			changes[currNewTag] = true
+			currNewVal = nil
+		} else if currOldTag < currNewTag {
+			newTV[currOldTag] = types.NullValue
+			oldTV[currOldTag] = currOldVal
+			changes[currOldTag] = true
+			currOldVal = nil
+		} else {
+			newTV[currNewTag] = currNewVal
+			oldTV[currOldTag] = currOldVal
+			changes[currNewTag] = !currOldVal.Equals(currNewVal)
+			currNewVal, currOldVal = nil, nil
+		}
+	}
+
+	return newTV, oldTV, changes, nil
+}
+
+type fkValidationInfo struct {
+	declaredFK   []declaredFKCheck
+	referencedFK []referencedFKCheck
+	allChecks    []fkCheck
+}
+
+func getFKValidationInfo(ctx context.Context, root *doltdb.RootValue, tblNames []string) (map[string]fkValidationInfo, error) {
+	tblToValInfo := make(map[string]fkValidationInfo)
+
+	fkColl, err := root.GetForeignKeyCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, tblName := range tblNames {
+		declaredFk, referencedByFk := fkColl.KeysForTable(tblName)
+
+		declaredFKChecks := make([]declaredFKCheck, 0, len(declaredFk))
+		referencedFKChecks := make([]referencedFKCheck, 0, len(referencedByFk))
+		allFKChecks := make([]fkCheck, 0, len(declaredFKChecks)+len(referencedFKChecks))
+
+		for _, dfk := range declaredFk {
+			chk, err := newDeclaredFKCheck(ctx, root, dfk)
+
+			if err != nil {
+				return nil, err
+			}
+
+			declaredFKChecks = append(declaredFKChecks, chk)
+			allFKChecks = append(allFKChecks, chk)
+		}
+
+		for _, rfk := range referencedByFk {
+			chk, err := newRefFKCheck(ctx, root, rfk)
+
+			if err != nil {
+				return nil, err
+			}
+
+			referencedFKChecks = append(referencedFKChecks, chk)
+			allFKChecks = append(allFKChecks, chk)
+		}
+
+		tblToValInfo[tblName] = fkValidationInfo{
+			declaredFK:   declaredFKChecks,
+			referencedFK: referencedFKChecks,
+			allChecks:    allFKChecks,
+		}
+	}
+
+	return tblToValInfo, nil
+}

--- a/go/libraries/doltcore/fkconstrain/validate.go
+++ b/go/libraries/doltcore/fkconstrain/validate.go
@@ -16,12 +16,13 @@ package fkconstrain
 
 import (
 	"context"
+	"time"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	nomsdiff "github.com/dolthub/dolt/go/store/diff"
 	"github.com/dolthub/dolt/go/store/types"
-	"time"
 )
 
 func Validate(ctx context.Context, parentCommitRoot, root *doltdb.RootValue) error {

--- a/go/libraries/doltcore/row/tagged_values.go
+++ b/go/libraries/doltcore/row/tagged_values.go
@@ -184,6 +184,49 @@ func TaggedValuesFromTupleValueSlice(vals types.TupleValueSlice) (TaggedValues, 
 	return taggedTuple, nil
 }
 
+func TaggedValuesFromTupleKeyAndValue(key, value types.Tuple) (TaggedValues, error) {
+	tv := make(TaggedValues)
+	err := AddToTaggedVals(tv, key)
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = AddToTaggedVals(tv, value)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tv, nil
+}
+
+func AddToTaggedVals(tv TaggedValues, t types.Tuple) error {
+	itr, err := t.Iterator()
+
+	if err != nil {
+		return err
+	}
+
+	for itr.HasMore() {
+		_, tag, err := itr.NextUint64()
+
+		if err != nil {
+			return err
+		}
+
+		_, currVal, err := itr.Next()
+
+		if err != nil {
+			return err
+		}
+
+		tv[tag] = currVal
+	}
+
+	return nil
+}
+
 func (tt TaggedValues) String() string {
 	str := "{"
 	for k, v := range tt {


### PR DESCRIPTION
Previous validation implementation did full scans for every foreign key constraint.  New implementation only validates against rows that have changed from the previous commit.