### PR TITLE
disable foreign key checks on merge with warning

### DIFF
--- a/bats/foreign-keys.bats
+++ b/bats/foreign-keys.bats
@@ -1227,9 +1227,8 @@ SQL
     dolt commit --force -m "updated parent"
     dolt checkout master
     run dolt merge other
-    [ "$status" -eq "1" ]
-    [[ "$output" =~ "violation" ]] || false
-    [[ "$output" =~ "3" ]] || false
+    [ "$status" -eq "0" ]
+    [[ "$output" =~ "Warning" ]] || false
 }
 
 @test "foreign-keys: Merge valid onto child" {
@@ -1302,9 +1301,8 @@ SQL
     dolt commit --force -m "updated child"
     dolt checkout master
     run dolt merge other
-    [ "$status" -eq "1" ]
-    [[ "$output" =~ "violation" ]] || false
-    [[ "$output" =~ "0" ]] || false
+    [ "$status" -eq "0" ]
+    [[ "$output" =~ "Warning" ]] || false
 }
 
 @test "foreign-keys: Merge valid onto parent and child" {
@@ -1380,9 +1378,8 @@ SQL
     dolt commit --force -m "updated both"
     dolt checkout master
     run dolt merge other
-    [ "$status" -eq "1" ]
-    [[ "$output" =~ "violation" ]] || false
-    [[ "$output" =~ "4" ]] || false
+    [ "$status" -eq "0" ]
+    [[ "$output" =~ "Warning" ]] || false
 }
 
 @test "foreign-keys: Resolve catches violations" {
@@ -1431,3 +1428,86 @@ SQL
     [[ "$output" =~ "fk_v1" ]] || false
 }
 
+@test "fk constraint merge warning only for merges with fk constraints" {
+  dolt reset --hard
+
+  dolt checkout -b no_fk
+  dolt sql <<SQL
+    CREATE TABLE colors (
+        id INT NOT NULL,
+        color VARCHAR(32) NOT NULL,
+
+        PRIMARY KEY (id),
+        INDEX color_index(color)
+    );
+    CREATE TABLE objects (
+        id INT NOT NULL,
+        name VARCHAR(64) NOT NULL,
+        color VARCHAR(32),
+
+        PRIMARY KEY(id)
+    );
+SQL
+  dolt add .
+  dolt commit -m "schema added"
+
+  dolt checkout -b b1_no_fk
+  dolt sql -b -q "INSERT INTO colors (id,color) VALUES (1,'red');
+    INSERT INTO objects (id,name,color) VALUES (1,'truck','red');"
+  dolt add .
+  dolt commit -m 'person 1 changes'
+
+  dolt branch b2_no_fk no_fk
+  dolt checkout b2_no_fk
+  dolt sql -b -q "INSERT INTO colors (id,color) VALUES (1,'blue');
+    INSERT INTO objects (id,name,color) VALUES (1,'ball','blue'),(2,'shoe','blue');"
+  dolt add .
+  dolt commit -m 'person 2 changes'
+
+  dolt checkout b1_no_fk
+  run dolt merge b2_no_fk
+  [ "$status" -eq "0" ]
+  [[ ! "$output" =~ "Warning" ]] || false
+
+  dolt reset --hard
+
+  dolt branch fk master
+  dolt checkout fk
+  dolt sql <<SQL
+    CREATE TABLE colors (
+        id INT NOT NULL,
+        color VARCHAR(32) NOT NULL,
+
+        PRIMARY KEY (id),
+        INDEX color_index(color)
+    );
+    CREATE TABLE objects (
+        id INT NOT NULL,
+        name VARCHAR(64) NOT NULL,
+        color VARCHAR(32),
+
+        PRIMARY KEY(id),
+        FOREIGN KEY (color) REFERENCES colors(color)
+    );
+SQL
+  dolt add .
+  dolt commit -m "schema added"
+
+  dolt checkout -b b1_fk
+  dolt sql -b -q "INSERT INTO colors (id,color) VALUES (1,'red');
+    INSERT INTO objects (id,name,color) VALUES (1,'truck','red');"
+  dolt add .
+  dolt commit -m 'person 1 changes'
+
+  dolt branch b2_fk fk
+  dolt checkout b2_fk
+  dolt sql -b -q "INSERT INTO colors (id,color) VALUES (1,'blue');
+    INSERT INTO objects (id,name,color) VALUES (1,'ball','blue'),(2,'shoe','blue');"
+  dolt add .
+  dolt commit -m 'person 2 changes'
+
+  dolt checkout b1_fk
+  run dolt merge b2_fk
+  [ "$status" -eq "0" ]
+  [[ "$output" =~ "Warning" ]] || false
+}

--- a/go/cmd/dolt/commands/merge.go
+++ b/go/cmd/dolt/commands/merge.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/fatih/color"
 
@@ -31,6 +32,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/merge"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
+	"github.com/dolthub/dolt/go/libraries/utils/set"
 	"github.com/dolthub/dolt/go/store/hash"
 )
 
@@ -49,6 +51,10 @@ The second syntax ({{.LessThan}}dolt merge --abort{{.GreaterThan}}) can only be 
 		"--abort",
 	},
 }
+
+var fkWarningMessage = "Warning: This merge is being applied to tables that have foreign key constraints. These constraints " +
+	"will not be enforced during the merge process to allow you to fix constraint issues that arise from merge conflicts. " +
+	"to check for foreign key constraint violations run `dolt verify-constraints` on this repo after merging."
 
 type MergeCmd struct{}
 
@@ -339,6 +345,12 @@ and take the hash for your current branch and use it for the value for "staged" 
 }
 
 func executeMerge(ctx context.Context, squash bool, dEnv *env.DoltEnv, cm1, cm2 *doltdb.Commit, workingDiffs map[string]hash.Hash) errhand.VerboseError {
+	verr := fkConstraintWarning(ctx, cm1, cm2)
+
+	if verr != nil {
+		return verr
+	}
+
 	mergedRoot, tblToStats, err := merge.MergeCommits(ctx, cm1, cm2)
 
 	if err != nil {
@@ -353,6 +365,98 @@ func executeMerge(ctx context.Context, squash bool, dEnv *env.DoltEnv, cm1, cm2 
 	}
 
 	return mergedRootToWorking(ctx, squash, dEnv, mergedRoot, workingDiffs, cm2, tblToStats)
+}
+
+func fkConstraintWarning(ctx context.Context, cm1, cm2 *doltdb.Commit) errhand.VerboseError {
+	verrBuild := errhand.BuildDError("failed to read from database.")
+	r1, err := cm1.GetRootValue()
+
+	if err != nil {
+		return verrBuild.AddCause(err).Build()
+	}
+
+	r2, err := cm2.GetRootValue()
+
+	if err != nil {
+		return verrBuild.AddCause(err).Build()
+	}
+
+	fks1, err := r1.GetForeignKeyCollection(ctx)
+
+	if err != nil {
+		return verrBuild.AddCause(err).Build()
+	}
+
+	fks2, err := r2.GetForeignKeyCollection(ctx)
+
+	if err != nil {
+		return verrBuild.AddCause(err).Build()
+	}
+
+	tblNames1, err := r1.GetTableNames(ctx)
+
+	if err != nil {
+		return verrBuild.AddCause(err).Build()
+	}
+
+	tblNames2, err := r2.GetTableNames(ctx)
+
+	if err != nil {
+		return verrBuild.AddCause(err).Build()
+	}
+
+	allNames := set.NewStrSet(tblNames1)
+	allNames.Add(tblNames2...)
+
+	var warnTables []string
+	for _, name := range allNames.AsSlice() {
+		tbl1, ok1, err := r1.GetTable(ctx, name)
+
+		if err != nil {
+			return verrBuild.AddCause(err).Build()
+		}
+
+		tbl2, ok2, err := r2.GetTable(ctx, name)
+
+		if err != nil {
+			return verrBuild.AddCause(err).Build()
+		}
+
+		var h1, h2 hash.Hash
+		var fkOnTbl1, fkOnTbl2 bool
+		if ok1 {
+			h1, err = tbl1.HashOf()
+
+			if err != nil {
+				return verrBuild.AddCause(err).Build()
+			}
+
+			decl, refd := fks1.KeysForTable(name)
+			fkOnTbl1 = (len(decl) + len(refd)) > 0
+		}
+
+		if ok2 {
+			h2, err = tbl2.HashOf()
+
+			if err != nil {
+				return verrBuild.AddCause(err).Build()
+			}
+
+			decl, refd := fks2.KeysForTable(name)
+			fkOnTbl2 = (len(decl) + len(refd)) > 0
+		}
+
+		if h1 != h2 && (fkOnTbl1 || fkOnTbl2) {
+			warnTables = append(warnTables, name)
+		}
+	}
+
+	if len(warnTables) > 0 {
+		cli.Println(color.YellowString(fkWarningMessage))
+		cli.Println(color.YellowString("You are seeing this message due to changes in the following table(s): " + strings.Join(warnTables, ",")))
+	}
+
+	return nil
 }
 
 func mergedRootToWorking(ctx context.Context, squash bool, dEnv *env.DoltEnv, mergedRoot *doltdb.RootValue, workingDiffs map[string]hash.Hash, cm2 *doltdb.Commit, tblToStats map[string]*merge.MergeStats) errhand.VerboseError {

--- a/go/cmd/dolt/commands/verify_constraints.go
+++ b/go/cmd/dolt/commands/verify_constraints.go
@@ -35,7 +35,6 @@ var verifyConstraintsDocs = cli.CommandDocumentationContent{
 type VerifyConstraintsCmd struct{}
 
 var _ cli.Command = VerifyConstraintsCmd{}
-var _ cli.HiddenCommand = VerifyConstraintsCmd{}
 
 func (cmd VerifyConstraintsCmd) Name() string {
 	return "verify-constraints"
@@ -126,8 +125,4 @@ func (cmd VerifyConstraintsCmd) Exec(ctx context.Context, commandStr string, arg
 		return HandleVErrAndExitCode(dErr.Build(), nil)
 	}
 	return 0
-}
-
-func (cmd VerifyConstraintsCmd) Hidden() bool {
-	return true
 }

--- a/go/libraries/doltcore/merge/merge.go
+++ b/go/libraries/doltcore/merge/merge.go
@@ -816,11 +816,6 @@ func MergeRoots(ctx context.Context, ourRoot, theirRoot, ancRoot *doltdb.RootVal
 		return root.PutForeignKeyCollection(ctx, mergedFKColl)
 	})
 
-	err = tableEditSession.ValidateForeignKeys(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	newRoot, err = newRoot.UpdateSuperSchemasFromOther(ctx, unconflicted, theirRoot)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Foreign key constraint violations on merge had the potential to make resolving conflicts between two commits impossible.  Merges are now done without foreign key constraint validation.  A new warning message was added when there is potential for this to be an issue.  Foreign key constraint validation is enforced on commit.