### PR TITLE
Turned on strict parsing for the sql server config YAML. This catches…

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -20,15 +20,13 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fatih/color"
-	"gopkg.in/yaml.v2"
-
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands"
 	eventsapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
+	"github.com/fatih/color"
 )
 
 const (
@@ -246,14 +244,11 @@ func getCommandLineServerConfig(dEnv *env.DoltEnv, apr *argparser.ArgParseResult
 
 func getYAMLServerConfig(fs filesys.Filesys, path string) (ServerConfig, error) {
 	data, err := fs.ReadFile(path)
-
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read file '%s'. Error: %s", path, err.Error())
 	}
 
-	var cfg YAMLConfig
-	err = yaml.Unmarshal(data, &cfg)
-
+	cfg, err := newYamlConfig(data)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to parse yaml file '%s'. Error: %s", path, err.Error())
 	}

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -20,13 +20,14 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/fatih/color"
+
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands"
 	eventsapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
-	"github.com/fatih/color"
 )
 
 const (

--- a/go/cmd/dolt/commands/sqlserver/yaml_config.go
+++ b/go/cmd/dolt/commands/sqlserver/yaml_config.go
@@ -82,6 +82,12 @@ type YAMLConfig struct {
 	PerformanceConfig PerformanceYAMLConfig `yaml:"performance"`
 }
 
+func newYamlConfig(configFileData []byte) (YAMLConfig, error) {
+	var cfg YAMLConfig
+	err := yaml.UnmarshalStrict(configFileData, &cfg)
+	return cfg, err
+}
+
 func serverConfigAsYAMLConfig(cfg ServerConfig) YAMLConfig {
 	return YAMLConfig{
 		LogLevelStr:    strPtr(string(cfg.LogLevel())),

--- a/go/cmd/dolt/commands/sqlserver/yaml_config_test.go
+++ b/go/cmd/dolt/commands/sqlserver/yaml_config_test.go
@@ -61,10 +61,39 @@ databases:
 		},
 	}
 
-	config := YAMLConfig{}
-	err := yaml.Unmarshal([]byte(testStr), &config)
+	config, err := newYamlConfig([]byte(testStr))
 	require.NoError(t, err)
 	assert.Equal(t, expected, config)
+}
+
+// Tests that a common YAML error (incorrect indentation) throws an error
+func TestUnmarshallError(t *testing.T) {
+	testStr := `
+log_level: info
+
+behavior:
+read_only: false
+autocommit: true
+
+user:
+    name: root
+    password: ""
+
+listener:
+    host: localhost
+    port: 3306
+    max_connections: 1
+    read_timeout_millis: 28800000
+    write_timeout_millis: 28800000
+    
+databases:
+    - name: irs_soi
+      path: ./datasets/irs-soi
+    - name: noaa
+      path: /Users/brian/datasets/noaa
+`
+	_, err := newYamlConfig([]byte(testStr))
+	assert.Error(t, err)
 }
 
 func TestYAMLConfigDefaults(t *testing.T) {


### PR DESCRIPTION
… common indentation errors that have confused multiple users.