### PR TITLE
Prevent server start if port in use

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"strconv"
 	"time"
+	"fmt"
 
 	sqle "github.com/dolthub/go-mysql-server"
 	"github.com/dolthub/go-mysql-server/auth"
@@ -124,7 +125,14 @@ func Serve(ctx context.Context, version string, serverConfig ServerConfig, serve
 
 	sqlEngine.AddDatabase(information_schema.NewInformationSchemaDatabase(sqlEngine.Catalog))
 
-	hostPort := net.JoinHostPort(serverConfig.Host(), strconv.Itoa(serverConfig.Port()))
+	portAsString := strconv.Itoa(serverConfig.Port())
+	hostPort := net.JoinHostPort(serverConfig.Host(), portAsString)
+
+	if (IsPortInUse(hostPort)) {
+		portInUseError := fmt.Errorf("Port %s already in use.", portAsString)
+		return portInUseError, nil
+	}
+
 	readTimeout := time.Duration(serverConfig.ReadTimeout()) * time.Millisecond
 	writeTimeout := time.Duration(serverConfig.WriteTimeout()) * time.Millisecond
 	mySQLServer, startError = server.NewServer(

--- a/go/cmd/dolt/commands/sqlserver/server_test.go
+++ b/go/cmd/dolt/commands/sqlserver/server_test.go
@@ -221,7 +221,11 @@ func TestServerSelect(t *testing.T) {
 // If a port is already in use, throw error "Port XXXX already in use."
 func TestServerFailsIfPortInUse(t *testing.T) {
 	serverController := CreateServerController()
-	go http.ListenAndServe(":15200", nil)
+	server := &http.Server{
+        Addr:    ":15200",
+        Handler: http.DefaultServeMux,
+    }
+    go server.ListenAndServe()
 	go func() {
 		startServer(context.Background(), "test", "dolt sql-server", []string{
 			"-H", "localhost",
@@ -235,4 +239,5 @@ func TestServerFailsIfPortInUse(t *testing.T) {
 	}()
 	err := serverController.WaitForStart()
 	require.Error(t, err)
+	server.Close()
 }

--- a/go/cmd/dolt/commands/sqlserver/utils.go
+++ b/go/cmd/dolt/commands/sqlserver/utils.go
@@ -14,5 +14,3 @@ func IsPortInUse(hostPort string) bool {
     }
 	return false
 }
-
-

--- a/go/cmd/dolt/commands/sqlserver/utils.go
+++ b/go/cmd/dolt/commands/sqlserver/utils.go
@@ -1,0 +1,18 @@
+package sqlserver
+
+import (
+	"net"
+	"time"
+)
+
+func IsPortInUse(hostPort string) bool {
+    timeout := time.Second
+    conn, _ := net.DialTimeout("tcp", hostPort, timeout)
+    if conn != nil {
+        defer conn.Close()
+        return true
+    }
+	return false
+}
+
+


### PR DESCRIPTION
Closes #1160 

- Adds a check to see if a port is already in use in the specified host and prevent `sql-server` from starting if that's the case
- Adds a test for this behavior