### PR TITLE
libraries/doltcore/merge: fix dropped errors

### DIFF
--- a/go/libraries/doltcore/merge/merge.go
+++ b/go/libraries/doltcore/merge/merge.go
@@ -143,6 +143,9 @@ func (merger *Merger) MergeTable(ctx context.Context, tblName string, sess *edit
 			ms := MergeStats{Operation: TableModified}
 			if h != mh {
 				ms, err = calcTableMergeStats(ctx, tbl, mergeTbl)
+				if err != nil {
+					return nil, nil, err
+				}
 			}
 			// force load the table editor since this counts as a change
 			_, err := sess.GetTableEditor(ctx, tblName, nil)
@@ -183,6 +186,9 @@ func (merger *Merger) MergeTable(ctx context.Context, tblName string, sess *edit
 	err = sess.UpdateRoot(ctx, func(ctx context.Context, root *doltdb.RootValue) (*doltdb.RootValue, error) {
 		return root.PutTable(ctx, tblName, updatedTbl)
 	})
+	if err != nil {
+		return nil, nil, err
+	}
 
 	updatedTblEditor, err := sess.GetTableEditor(ctx, tblName, nil)
 	if err != nil {
@@ -542,6 +548,9 @@ func applyKeylessChange(ctx context.Context, sch schema.Schema, tableEditor edit
 
 	var card uint64
 	change, card, err = convertValueChanged(change)
+	if err != nil {
+		return err
+	}
 
 	for card > 0 {
 		if err = apply(change); err != nil {
@@ -791,6 +800,9 @@ func MergeRoots(ctx context.Context, ourRoot, theirRoot, ancRoot *doltdb.RootVal
 			err = tableEditSession.UpdateRoot(ctx, func(ctx context.Context, root *doltdb.RootValue) (*doltdb.RootValue, error) {
 				return root.RemoveTables(ctx, tblName)
 			})
+			if err != nil {
+				return nil, nil, err
+			}
 			newRoot, err = tableEditSession.Flush(ctx)
 			if err != nil {
 				return nil, nil, err

--- a/go/libraries/doltcore/merge/merge_schema.go
+++ b/go/libraries/doltcore/merge/merge_schema.go
@@ -178,9 +178,16 @@ func ForeignKeysMerge(ctx context.Context, mergedRoot, ourRoot, theirRoot, ancRo
 	err = ourNewFKs.Iter(func(ourFK doltdb.ForeignKey) (stop bool, err error) {
 		return false, common.AddKeys(ourFK)
 	})
+	if err != nil {
+		return nil, nil, err
+	}
+
 	err = theirNewFKs.Iter(func(theirFK doltdb.ForeignKey) (stop bool, err error) {
 		return false, common.AddKeys(theirFK)
 	})
+	if err != nil {
+		return nil, nil, err
+	}
 
 	common, err = pruneInvalidForeignKeys(ctx, common, mergedRoot)
 	if err != nil {

--- a/go/libraries/doltcore/merge/merge_test.go
+++ b/go/libraries/doltcore/merge/merge_test.go
@@ -326,6 +326,7 @@ func setupMergeTest(t *testing.T) (types.ValueReadWriter, *doltdb.Commit, *doltd
 		keyTuples[11], mustGetValue(updatedRows.MaybeGet(context.Background(), keyTuples[11])), // added same in both
 		keyTuples[12], mustGetValue(updatedRows.MaybeGet(context.Background(), keyTuples[12])), // conflict
 	)
+	require.NoError(t, err)
 
 	updateConflict := doltdb.NewConflict(
 		mustGetValue(initialRows.MaybeGet(context.Background(), keyTuples[8])),

--- a/go/libraries/doltcore/merge/schema_integration_test.go
+++ b/go/libraries/doltcore/merge/schema_integration_test.go
@@ -579,4 +579,5 @@ func testMergeForeignKeys(t *testing.T, test mergeForeignKeyTest) {
 		assert.Equal(t, expFK, actFK)
 		return false, nil
 	})
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
This fixes dropped code and test `err` variables in `libraries/doltcore/merge`.