### PR TITLE
libraries/doltcore/rebase: fix dropped errors

### DIFF
--- a/go/libraries/doltcore/rebase/rebase.go
+++ b/go/libraries/doltcore/rebase/rebase.go
@@ -234,6 +234,9 @@ func rebaseRecursive(ctx context.Context, ddb *doltdb.DoltDB, replay ReplayCommi
 	}
 
 	allParents, err := ddb.ResolveAllParents(ctx, commit)
+	if err != nil {
+		return nil, err
+	}
 
 	if len(allParents) < 1 {
 		panic(fmt.Sprintf("commit: %s has no parents", commitHash.String()))

--- a/go/libraries/doltcore/rebase/rebase_tag.go
+++ b/go/libraries/doltcore/rebase/rebase_tag.go
@@ -247,6 +247,9 @@ func replayCommitWithNewTag(ctx context.Context, root, parentRoot, rebasedParent
 
 		if !tableNeedsRebasing {
 			newRoot, err = newRoot.PutTable(ctx, tblName, tbl)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		parentTblName := tblName
@@ -293,10 +296,17 @@ func replayCommitWithNewTag(ctx context.Context, root, parentRoot, rebasedParent
 		}
 
 		rebasedSS, err := ss.RebaseTag(tableMapping)
+		if err != nil {
+			return nil, err
+		}
 
 		// row rebase
 		var parentRows types.Map
 		parentTbl, found, err := parentRoot.GetTable(ctx, tblName)
+		if err != nil {
+			return nil, err
+		}
+
 		if found && parentTbl != nil {
 			parentRows, err = parentTbl.GetRowData(ctx)
 		} else {
@@ -311,6 +321,9 @@ func replayCommitWithNewTag(ctx context.Context, root, parentRoot, rebasedParent
 		var rebasedParentRows types.Map
 		var rebasedParentSch schema.Schema
 		rebasedParentTbl, found, err := rebasedParentRoot.GetTable(ctx, parentTblName)
+		if err != nil {
+			return nil, err
+		}
 		if found && rebasedParentTbl != nil {
 			rebasedParentRows, err = rebasedParentTbl.GetRowData(ctx)
 			if err != nil {


### PR DESCRIPTION
This fixes dropped `err` variables in `libraries/doltcore/rebase`.