### PR TITLE
libraries/doltcore/schema/alterschema: fix dropped errors

### DIFF
--- a/go/libraries/doltcore/schema/alterschema/dropcolumn_test.go
+++ b/go/libraries/doltcore/schema/alterschema/dropcolumn_test.go
@@ -92,6 +92,7 @@ func TestDropColumn(t *testing.T) {
 			var foundRows []row.Row
 			err = rowData.Iter(ctx, func(key, value types.Value) (stop bool, err error) {
 				tpl, err := row.FromNoms(dtestutils.TypedSchema, key.(types.Tuple), value.(types.Tuple))
+				assert.NoError(t, err)
 				foundRows = append(foundRows, tpl)
 				return false, nil
 			})
@@ -170,6 +171,7 @@ func TestDropColumnUsedByIndex(t *testing.T) {
 			var foundRows []row.Row
 			err = rowData.Iter(ctx, func(key, value types.Value) (stop bool, err error) {
 				tpl, err := row.FromNoms(dtestutils.TypedSchema, key.(types.Tuple), value.(types.Tuple))
+				assert.NoError(t, err)
 				foundRows = append(foundRows, tpl)
 				return false, nil
 			})


### PR DESCRIPTION
This fixes dropped test errors in `libraries/doltcore/schema/alterschema`.