### PR TITLE
libraries/doltcore/schema/typeinfo: fix dropped errors

### DIFF
--- a/go/libraries/doltcore/schema/typeinfo/typeinfo_test.go
+++ b/go/libraries/doltcore/schema/typeinfo/typeinfo_test.go
@@ -138,6 +138,7 @@ func testTypeInfoConvertRoundTrip(t *testing.T, tiArrays [][]TypeInfo, vaArrays 
 								require.Equal(t, uint64(1), n)
 
 								readVal, err := ti.ReadFrom(nbf, reader)
+								require.NoError(t, err)
 								require.Equal(t, readVal, vInterface)
 							}
 						})

--- a/go/libraries/doltcore/schema/typeinfo/varstring.go
+++ b/go/libraries/doltcore/schema/typeinfo/varstring.go
@@ -57,6 +57,10 @@ func CreateVarStringTypeFromParams(params map[string]string) (TypeInfo, error) {
 	}
 	if maxLengthStr, ok := params[varStringTypeParam_Length]; ok {
 		length, err = strconv.ParseInt(maxLengthStr, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+
 	} else {
 		return nil, fmt.Errorf(`create varstring type info is missing param "%v"`, varStringTypeParam_Length)
 	}


### PR DESCRIPTION
This fixes a dropped test error and a dropped code error in `libraries/doltcore/schema/typeinfo`.