### PR TITLE
Fixed dropped errors in libraries/doltcore/sqle/dfunctions

### DIFF
--- a/go/libraries/doltcore/sqle/dfunctions/commit.go
+++ b/go/libraries/doltcore/sqle/dfunctions/commit.go
@@ -44,6 +44,9 @@ func (cf *CommitFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	//  Get the params associated with COMMIT.
 	ap := cli.CreateCommitArgParser()
 	args, err := getDoltArgs(ctx, row, cf.Children())
+	if err != nil {
+		return nil, err
+	}
 	apr := cli.ParseArgs(ap, args, nil)
 
 	var name, email string

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_commit.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_commit.go
@@ -129,6 +129,9 @@ func (d DoltCommitFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error)
 		Name:             name,
 		Email:            email,
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	if allFlag {
 		err = setHeadAndWorkingSessionRoot(ctx, h)

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_merge.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_merge.go
@@ -104,7 +104,7 @@ func (d DoltMergeFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) 
 		return 1, errors.New("error: merging is not possible because you have not committed an active merge")
 	}
 
-	parent, ph, parentRoot, err := getParent(ctx, err, sess, dbName)
+	parent, ph, parentRoot, err := getParent(ctx, sess, dbName)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_merge.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_merge.go
@@ -114,7 +114,7 @@ func (d DoltMergeFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) 
 		return nil, err
 	}
 
-	cm, cmh, err := getBranchCommit(ctx, ok, branchName, err, ddb)
+	cm, cmh, err := getBranchCommit(ctx, branchName, ddb)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_reset.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_reset.go
@@ -62,7 +62,6 @@ func (d DoltResetFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) 
 
 	// Get all the needed roots.
 	working, staged, head, err := env.GetRoots(ctx, dbData.Ddb, dbData.Rsr)
-
 	if err != nil {
 		return 1, err
 	}
@@ -81,22 +80,24 @@ func (d DoltResetFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) 
 			}
 
 			h = headHash.String()
-			err = setSessionRootExplicit(ctx, h, sqle.HeadKeySuffix)
-			if err != nil {
+			if err := setSessionRootExplicit(ctx, h, sqle.HeadKeySuffix); err != nil {
 				return 1, err
 			}
 
 			workingHash := dbData.Rsr.WorkingHash()
-			err = setSessionRootExplicit(ctx, workingHash.String(), sqle.WorkingKeySuffix)
+			if err := setSessionRootExplicit(ctx, workingHash.String(), sqle.WorkingKeySuffix); err != nil {
+				return 1, err
+			}
 		} else {
-			err = setHeadAndWorkingSessionRoot(ctx, h)
+			if err := setHeadAndWorkingSessionRoot(ctx, h); err != nil {
+				return 1, err
+			}
 		}
 	} else {
 		_, err = actions.ResetSoftTables(ctx, dbData, apr, staged, head)
-	}
-
-	if err != nil {
-		return 1, err
+		if err != nil {
+			return 1, err
+		}
 	}
 
 	return 0, nil

--- a/go/libraries/doltcore/sqle/dfunctions/hashof.go
+++ b/go/libraries/doltcore/sqle/dfunctions/hashof.go
@@ -58,7 +58,6 @@ func (t *HashOf) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	}
 
 	name, as, err := doltdb.SplitAncestorSpec(paramStr)
-
 	if err != nil {
 		return nil, err
 	}
@@ -74,28 +73,27 @@ func (t *HashOf) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		sess := sqle.DSessFromSess(ctx.Session)
 
 		cm, _, err = sess.GetParentCommit(ctx, dbName)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		branchRef, err := getBranchInsensitive(ctx, name, ddb)
-
 		if err != nil {
 			return nil, err
 		}
 
 		cm, err = ddb.ResolveRef(ctx, branchRef)
-	}
-
-	if err != nil {
-		return nil, err
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	cm, err = cm.GetAncestor(ctx, as)
-
 	if err != nil {
 		return nil, err
 	}
 
 	h, err := cm.HashOf()
-
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/dfunctions/merge.go
+++ b/go/libraries/doltcore/sqle/dfunctions/merge.go
@@ -78,7 +78,7 @@ func (cf *MergeFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, sql.ErrDatabaseNotFound.New(dbName)
 	}
 
-	parent, ph, parentRoot, err := getParent(ctx, err, sess, dbName)
+	parent, ph, parentRoot, err := getParent(ctx, sess, dbName)
 	if err != nil {
 		return nil, err
 	}
@@ -181,19 +181,13 @@ func getBranchCommit(ctx *sql.Context, val interface{}, ddb *doltdb.DoltDB) (*do
 	return cm, cmh, nil
 }
 
-func getParent(ctx *sql.Context, err error, sess *sqle.DoltSession, dbName string) (*doltdb.Commit, hash.Hash, *doltdb.RootValue, error) {
-	if err != nil {
-		return nil, hash.Hash{}, nil, err
-	}
-
+func getParent(ctx *sql.Context, sess *sqle.DoltSession, dbName string) (*doltdb.Commit, hash.Hash, *doltdb.RootValue, error) {
 	parent, ph, err := sess.GetParentCommit(ctx, dbName)
-
 	if err != nil {
 		return nil, hash.Hash{}, nil, err
 	}
 
 	parentRoot, err := parent.GetRootValue()
-
 	if err != nil {
 		return nil, hash.Hash{}, nil, err
 	}

--- a/go/libraries/doltcore/sqle/dfunctions/merge.go
+++ b/go/libraries/doltcore/sqle/dfunctions/merge.go
@@ -154,6 +154,10 @@ func checkForUncommittedChanges(root *doltdb.RootValue, parentRoot *doltdb.RootV
 }
 
 func getBranchCommit(ctx *sql.Context, ok bool, val interface{}, err error, ddb *doltdb.DoltDB) (*doltdb.Commit, hash.Hash, error) {
+	if err != nil {
+		return nil, hash.Hash{}, err
+	}
+
 	paramStr, ok := val.(string)
 
 	if !ok {
@@ -182,6 +186,10 @@ func getBranchCommit(ctx *sql.Context, ok bool, val interface{}, err error, ddb 
 }
 
 func getParent(ctx *sql.Context, err error, sess *sqle.DoltSession, dbName string) (*doltdb.Commit, hash.Hash, *doltdb.RootValue, error) {
+	if err != nil {
+		return nil, hash.Hash{}, nil, err
+	}
+
 	parent, ph, err := sess.GetParentCommit(ctx, dbName)
 
 	if err != nil {

--- a/go/libraries/doltcore/sqle/dfunctions/merge.go
+++ b/go/libraries/doltcore/sqle/dfunctions/merge.go
@@ -88,7 +88,7 @@ func (cf *MergeFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, err
 	}
 
-	cm, cmh, err := getBranchCommit(ctx, ok, branchName, err, ddb)
+	cm, cmh, err := getBranchCommit(ctx, branchName, ddb)
 	if err != nil {
 		return nil, err
 	}
@@ -153,11 +153,7 @@ func checkForUncommittedChanges(root *doltdb.RootValue, parentRoot *doltdb.RootV
 	return nil
 }
 
-func getBranchCommit(ctx *sql.Context, ok bool, val interface{}, err error, ddb *doltdb.DoltDB) (*doltdb.Commit, hash.Hash, error) {
-	if err != nil {
-		return nil, hash.Hash{}, err
-	}
-
+func getBranchCommit(ctx *sql.Context, val interface{}, ddb *doltdb.DoltDB) (*doltdb.Commit, hash.Hash, error) {
 	paramStr, ok := val.(string)
 
 	if !ok {


### PR DESCRIPTION
This fixes dropped test & code `err` variables, as well as some `err` variables that were being passed into functions and then dropped immediately.

This PR goes beyond straightforward `err` drop fixes into spookier territory.