### PR TITLE
libraries/doltcore/sqle: fix dropped errors

### DIFF
--- a/go/libraries/doltcore/sqle/dtables/diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/diff_table.go
@@ -194,9 +194,11 @@ func tableData(ctx *sql.Context, tbl *doltdb.Table, ddb *doltdb.DoltDB) (types.M
 	var err error
 	if tbl == nil {
 		data, err = types.NewMap(ctx, ddb.ValueReadWriter())
+		if err != nil {
+			return types.EmptyMap, nil, err
+		}
 	} else {
 		data, err = tbl.GetRowData(ctx)
-
 		if err != nil {
 			return types.EmptyMap, nil, err
 		}
@@ -243,11 +245,13 @@ func (itr *diffRowItr) Next() (sql.Row, error) {
 	}
 
 	toAndFromRows, err := itr.joiner.Split(r)
+	if err != nil {
+		return nil, err
+	}
 	_, hasTo := toAndFromRows[diff.To]
 	_, hasFrom := toAndFromRows[diff.From]
 
 	r, err = r.SetColVal(itr.toCommitInfo.nameTag, types.String(itr.toCommitInfo.name), itr.sch)
-
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/sqlddl_test.go
+++ b/go/libraries/doltcore/sqle/sqlddl_test.go
@@ -1025,6 +1025,7 @@ func TestRenameColumn(t *testing.T) {
 			table, _, err := updatedRoot.GetTable(ctx, PeopleTableName)
 			assert.NoError(t, err)
 			sch, err := table.GetSchema(ctx)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expectedSchema, sch)
 
 			updatedTable, ok, err := updatedRoot.GetTable(ctx, "people")

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -407,6 +407,9 @@ func (t *WritableDoltTable) Truncate(ctx *sql.Context) (int, error) {
 		return 0, err
 	}
 	newTable, err = editor.RebuildAllIndexes(ctx, newTable)
+	if err != nil {
+		return 0, err
+	}
 
 	root, err := t.db.GetRoot(ctx)
 	if err != nil {
@@ -1099,6 +1102,9 @@ func (t *AlterableDoltTable) DropForeignKey(ctx *sql.Context, fkName string) err
 		return err
 	}
 	newRoot, err := root.PutForeignKeyCollection(ctx, fkc)
+	if err != nil {
+		return err
+	}
 
 	err = t.db.SetRoot(ctx, newRoot)
 	if err != nil {


### PR DESCRIPTION
This fixes two dropped code `err` variables and a test `err` variable in `libraries/doltcore/sqle`.