### PR TITLE
store/datas: fix dropped errors

### DIFF
--- a/go/store/datas/commit.go
+++ b/go/store/datas/commit.go
@@ -163,6 +163,9 @@ func parentsToQueue(ctx context.Context, refs types.RefSlice, q *types.RefByHeig
 				q.PushBack(v.(types.Ref))
 				return
 			})
+			if err != nil {
+				return err
+			}
 		} else {
 			ps, ok, err := c.MaybeGet(ParentsField)
 			if err != nil {
@@ -174,6 +177,9 @@ func parentsToQueue(ctx context.Context, refs types.RefSlice, q *types.RefByHeig
 					q.PushBack(v.(types.Ref))
 					return
 				})
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/go/store/datas/database_common.go
+++ b/go/store/datas/database_common.go
@@ -551,6 +551,9 @@ func (db *database) doDelete(ctx context.Context, datasetIDstr string) error {
 
 	for {
 		currentDatasets, err = currentDatasets.Edit().Remove(datasetID).Map(ctx)
+		if err != nil {
+			return err
+		}
 		err = db.tryCommitChunks(ctx, currentDatasets, currentRootHash)
 		if err != ErrOptimisticLockFailed {
 			break

--- a/go/store/datas/database_test.go
+++ b/go/store/datas/database_test.go
@@ -302,6 +302,7 @@ func (suite *DatabaseSuite) TestDatasetsMapType() {
 	_, err = suite.db.Delete(context.Background(), ds)
 	suite.NoError(err)
 	dss, err = suite.db.Datasets(context.Background())
+	suite.NoError(err)
 	assertMapOfStringToRefOfCommit(context.Background(), dss, datasets, suite.db)
 }
 

--- a/go/store/datas/puller_test.go
+++ b/go/store/datas/puller_test.go
@@ -336,6 +336,7 @@ func TestPuller(t *testing.T) {
 			wg.Wait()
 
 			sinkDS, err := sinkdb.GetDataset(ctx, "ds")
+			require.NoError(t, err)
 			sinkDS, err = sinkdb.FastForward(ctx, sinkDS, rootRef)
 			require.NoError(t, err)
 
@@ -382,9 +383,19 @@ func pullerRefEquality(ctx context.Context, expectad, actual types.Ref, srcDB, s
 	}
 
 	actualVal, err := actual.TargetValue(ctx, sinkDB)
+	if err != nil {
+		return false, err
+	}
 
 	exPs, exTbls, err := parentsAndTables(expectedVal.(types.Struct))
+	if err != nil {
+		return false, err
+	}
+
 	actPs, actTbls, err := parentsAndTables(actualVal.(types.Struct))
+	if err != nil {
+		return false, err
+	}
 
 	if !exPs.Equals(actPs) {
 		return false, nil

--- a/go/store/datas/tag_test.go
+++ b/go/store/datas/tag_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/types"
@@ -43,6 +44,7 @@ func TestNewTag(t *testing.T) {
 	cmRef, err := types.NewRef(commit, types.Format_7_18)
 	assert.NoError(err)
 	tag, err := NewTag(context.Background(), cmRef, types.EmptyStruct(types.Format_7_18))
+	require.NoError(t, err)
 
 	ct, err := makeCommitStructType(
 		types.EmptyStructType,

--- a/go/store/datas/tag_test.go
+++ b/go/store/datas/tag_test.go
@@ -39,10 +39,10 @@ func TestNewTag(t *testing.T) {
 
 	parents := mustList(types.NewList(context.Background(), db))
 	commit, err := NewCommit(context.Background(), types.Float(1), parents, types.EmptyStruct(types.Format_7_18))
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	cmRef, err := types.NewRef(commit, types.Format_7_18)
-	assert.NoError(err)
+	require.NoError(t, err)
 	tag, err := NewTag(context.Background(), cmRef, types.EmptyStruct(types.Format_7_18))
 	require.NoError(t, err)
 
@@ -52,14 +52,14 @@ func TestNewTag(t *testing.T) {
 		mustType(types.MakeListType(mustType(types.MakeUnionType()))),
 		types.PrimitiveTypeMap[types.FloatKind],
 	)
-	assert.NoError(err)
+	require.NoError(t, err)
 	et, err := makeTagStructType(
 		types.EmptyStructType,
 		mustType(types.MakeRefType(ct)),
 	)
-	assert.NoError(err)
+	require.NoError(t, err)
 	at, err := types.TypeOf(tag)
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	assertTypeEquals(et, at)
 }


### PR DESCRIPTION
This fixes dropped `err` variables in the `store/datas` package.