### PR TITLE
Replace assert.NoError with require.NoError in tests

### DIFF
--- a/go/store/nbs/aws_chunk_source_test.go
+++ b/go/store/nbs/aws_chunk_source_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAWSChunkSource(t *testing.T) {
@@ -35,7 +36,7 @@ func TestAWSChunkSource(t *testing.T) {
 		[]byte("badbye2"),
 	}
 	tableData, h, err := buildTable(chunks)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	s3 := makeFakeS3(t)
 	ddb := makeFakeDDB(t)
@@ -58,7 +59,7 @@ func TestAWSChunkSource(t *testing.T) {
 			},
 		)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		return cs
 	}
@@ -74,7 +75,7 @@ func TestAWSChunkSource(t *testing.T) {
 		t.Run("WithIndexCache", func(t *testing.T) {
 			assert := assert.New(t)
 			index, err := parseTableIndex(tableData)
-			assert.NoError(err)
+			require.NoError(t, err)
 			cache := newIndexCache(1024)
 			cache.put(h, index)
 
@@ -98,7 +99,7 @@ func TestAWSChunkSource(t *testing.T) {
 		t.Run("WithIndexCache", func(t *testing.T) {
 			assert := assert.New(t)
 			index, err := parseTableIndex(tableData)
-			assert.NoError(err)
+			require.NoError(t, err)
 			cache := newIndexCache(1024)
 			cache.put(h, index)
 

--- a/go/store/nbs/block_store_test.go
+++ b/go/store/nbs/block_store_test.go
@@ -33,6 +33,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/dolthub/dolt/go/libraries/utils/osutil"
@@ -416,12 +417,12 @@ func TestBlockStoreConjoinOnCommit(t *testing.T) {
 		}
 		chunkChan := make(chan extractRecord, mustUint32(rdrs.count()))
 		err := rdrs.extract(context.Background(), chunkChan)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		close(chunkChan)
 
 		for rec := range chunkChan {
 			ok, err := store.Has(context.Background(), hash.Hash(rec.a))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.True(t, ok)
 		}
 	}
@@ -438,18 +439,18 @@ func TestBlockStoreConjoinOnCommit(t *testing.T) {
 		c := &fakeConjoiner{}
 
 		smallTableStore, err := newNomsBlockStore(context.Background(), constants.FormatDefaultString, mm, p, c, testMemTableSize)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		root, err := smallTableStore.Root(context.Background())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		err = smallTableStore.Put(context.Background(), newChunk)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		success, err := smallTableStore.Commit(context.Background(), newChunk.Hash(), root)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, success)
 
 		ok, err := smallTableStore.Has(context.Background(), newChunk.Hash())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, ok)
 	})
 
@@ -457,11 +458,11 @@ func TestBlockStoreConjoinOnCommit(t *testing.T) {
 		srcs := chunkSources{}
 		for _, sp := range conjoinees {
 			cs, err := p.Open(context.Background(), sp.name, sp.chunkCount, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			srcs = append(srcs, cs)
 		}
 		conjoined, err := p.ConjoinAll(context.Background(), srcs, stats)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		cannedSpecs := []tableSpec{{mustAddr(conjoined.hash()), mustUint32(conjoined.count())}}
 		return cannedConjoin{true, append(cannedSpecs, keepers...)}
 	}
@@ -472,29 +473,29 @@ func TestBlockStoreConjoinOnCommit(t *testing.T) {
 
 		srcs := makeTestSrcs(t, []uint32{1, 1, 3, 7}, p)
 		upstream, err := toSpecs(srcs)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		fm.set(constants.NomsVersion, computeAddr([]byte{0xbe}), hash.Of([]byte{0xef}), upstream)
 		c := &fakeConjoiner{
 			[]cannedConjoin{makeCanned(upstream[:2], upstream[2:], p)},
 		}
 
 		smallTableStore, err := newNomsBlockStore(context.Background(), constants.FormatDefaultString, makeManifestManager(fm), p, c, testMemTableSize)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		root, err := smallTableStore.Root(context.Background())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		err = smallTableStore.Put(context.Background(), newChunk)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		success, err := smallTableStore.Commit(context.Background(), newChunk.Hash(), root)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, success)
 		ok, err := smallTableStore.Has(context.Background(), newChunk.Hash())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, ok)
 		assertContainAll(t, smallTableStore, srcs...)
 		for _, src := range srcs {
 			err := src.Close()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}
 	})
 
@@ -504,7 +505,7 @@ func TestBlockStoreConjoinOnCommit(t *testing.T) {
 
 		srcs := makeTestSrcs(t, []uint32{1, 1, 3, 7, 13}, p)
 		upstream, err := toSpecs(srcs)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		fm.set(constants.NomsVersion, computeAddr([]byte{0xbe}), hash.Of([]byte{0xef}), upstream)
 		c := &fakeConjoiner{
 			[]cannedConjoin{
@@ -514,22 +515,22 @@ func TestBlockStoreConjoinOnCommit(t *testing.T) {
 		}
 
 		smallTableStore, err := newNomsBlockStore(context.Background(), constants.FormatDefaultString, makeManifestManager(fm), p, c, testMemTableSize)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		root, err := smallTableStore.Root(context.Background())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		err = smallTableStore.Put(context.Background(), newChunk)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		success, err := smallTableStore.Commit(context.Background(), newChunk.Hash(), root)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, success)
 		ok, err := smallTableStore.Has(context.Background(), newChunk.Hash())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, ok)
 		assertContainAll(t, smallTableStore, srcs...)
 		for _, src := range srcs {
 			err := src.Close()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}
 	})
 }

--- a/go/store/nbs/byte_sink_test.go
+++ b/go/store/nbs/byte_sink_test.go
@@ -97,7 +97,7 @@ func (suite *TableSinkSuite) TestWriteAndFlush() {
 
 	bb := bytes.NewBuffer(nil)
 	err = sink.Flush(bb)
-	assert.NoError(suite.t, err)
+	require.NoError(suite.t, err)
 
 	verifyContents(suite.t, bb.Bytes())
 }

--- a/go/store/nbs/fd_cache_test.go
+++ b/go/store/nbs/fd_cache_test.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFDCache(t *testing.T) {
@@ -42,12 +43,12 @@ func TestFDCache(t *testing.T) {
 		name := fmt.Sprintf("file%d", i)
 		paths[i] = filepath.Join(dir, name)
 		err := ioutil.WriteFile(paths[i], []byte(name), 0644)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	refNoError := func(fc *fdCache, p string, assert *assert.Assertions) *os.File {
 		f, err := fc.RefFile(p)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.NotNil(f)
 		return f
 	}
@@ -110,7 +111,7 @@ func TestFDCache(t *testing.T) {
 
 		// Unreffing f1 now should evict it
 		err := fc.UnrefFile(paths[1])
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.EqualValues(paths[:1], fc.reportEntries())
 
 		// Bring f1 back so we can test multiple evictions in a row
@@ -123,11 +124,11 @@ func TestFDCache(t *testing.T) {
 		assert.NotEqual(f1, f2)
 
 		err = fc.UnrefFile(paths[0])
-		assert.NoError(err)
+		require.NoError(t, err)
 		err = fc.UnrefFile(paths[0])
-		assert.NoError(err)
+		require.NoError(t, err)
 		err = fc.UnrefFile(paths[1])
-		assert.NoError(err)
+		require.NoError(t, err)
 
 		assert.EqualValues(paths[2:], fc.reportEntries())
 	})

--- a/go/store/nbs/file_manifest.go
+++ b/go/store/nbs/file_manifest.go
@@ -245,18 +245,19 @@ func (fm5 fileManifestV5) parseManifest(r io.Reader) (manifestContents, error) {
 	}
 
 	specs, err := parseSpecs(slices[prefixLen:])
-
 	if err != nil {
 		return manifestContents{}, err
 	}
 
 	lock, err := parseAddr(slices[2])
-
 	if err != nil {
 		return manifestContents{}, err
 	}
 
 	gcGen, err := parseAddr(slices[4])
+	if err != nil {
+		return manifestContents{}, err
+	}
 
 	return manifestContents{
 		vers:  slices[1],

--- a/go/store/nbs/fs_table_cache_test.go
+++ b/go/store/nbs/fs_table_cache_test.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFSTableCache(t *testing.T) {
@@ -48,15 +49,15 @@ func TestFSTableCache(t *testing.T) {
 		}
 
 		tc, err := newFSTableCache(dir, uint64(sum), len(datas))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		for _, d := range datas {
 			err := tc.store(computeAddr(d), bytes.NewReader(d), uint64(len(d)))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}
 
 		expiredName := computeAddr(datas[0])
 		r, err := tc.checkout(expiredName)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Nil(t, r)
 		_, fserr := os.Stat(filepath.Join(dir, expiredName.String()))
 		assert.True(t, os.IsNotExist(fserr))
@@ -64,7 +65,7 @@ func TestFSTableCache(t *testing.T) {
 		for _, d := range datas[1:] {
 			name := computeAddr(d)
 			r, err := tc.checkout(name)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, r)
 			assertDataInReaderAt(t, d, r)
 			_, fserr := os.Stat(filepath.Join(dir, name.String()))
@@ -82,12 +83,12 @@ func TestFSTableCache(t *testing.T) {
 			var names []addr
 			for i := byte(0); i < 4; i++ {
 				name := computeAddr([]byte{i})
-				assert.NoError(ioutil.WriteFile(filepath.Join(dir, name.String()), nil, 0666))
+				require.NoError(t, ioutil.WriteFile(filepath.Join(dir, name.String()), nil, 0666))
 				names = append(names, name)
 			}
 
 			ftc, err := newFSTableCache(dir, 1024, 4)
-			assert.NoError(err)
+			require.NoError(t, err)
 			assert.NotNil(ftc)
 
 			for _, name := range names {
@@ -100,7 +101,7 @@ func TestFSTableCache(t *testing.T) {
 			dir := makeTempDir(t)
 			defer os.RemoveAll(dir)
 
-			assert.NoError(t, ioutil.WriteFile(filepath.Join(dir, "boo"), nil, 0666))
+			require.NoError(t, ioutil.WriteFile(filepath.Join(dir, "boo"), nil, 0666))
 			_, err := newFSTableCache(dir, 1024, 4)
 			assert.Error(t, err)
 		})
@@ -111,9 +112,9 @@ func TestFSTableCache(t *testing.T) {
 			defer os.RemoveAll(dir)
 
 			tempFile := filepath.Join(dir, tempTablePrefix+"boo")
-			assert.NoError(t, ioutil.WriteFile(tempFile, nil, 0666))
+			require.NoError(t, ioutil.WriteFile(tempFile, nil, 0666))
 			_, err := newFSTableCache(dir, 1024, 4)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			_, fserr := os.Stat(tempFile)
 			assert.True(t, os.IsNotExist(fserr))
 		})
@@ -122,7 +123,7 @@ func TestFSTableCache(t *testing.T) {
 			t.Parallel()
 			dir := makeTempDir(t)
 			defer os.RemoveAll(dir)
-			assert.NoError(t, os.Mkdir(filepath.Join(dir, "sub"), 0777))
+			require.NoError(t, os.Mkdir(filepath.Join(dir, "sub"), 0777))
 			_, err := newFSTableCache(dir, 1024, 4)
 			assert.Error(t, err)
 		})
@@ -132,7 +133,7 @@ func TestFSTableCache(t *testing.T) {
 func assertDataInReaderAt(t *testing.T, data []byte, r io.ReaderAt) {
 	p := make([]byte, len(data))
 	n, err := r.ReadAt(p, 0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, len(data), n)
 	assert.Equal(t, data, p)
 }

--- a/go/store/nbs/manifest_cache_test.go
+++ b/go/store/nbs/manifest_cache_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSizeCache(t *testing.T) {
@@ -40,9 +41,9 @@ func TestSizeCache(t *testing.T) {
 		dbB, contentsB := "dbB", manifestContents{lock: computeAddr([]byte("lockB"))}
 
 		err := c.Put(dbA, contentsA, t1)
-		assert.NoError(err)
+		require.NoError(t, err)
 		err = c.Put(dbB, contentsB, t1)
-		assert.NoError(err)
+		require.NoError(t, err)
 
 		cont, _, present := c.Get(dbA)
 		assert.True(present)
@@ -61,7 +62,7 @@ func TestSizeCache(t *testing.T) {
 		keys := []string{"db1", "db2", "db3", "db4", "db5", "db6", "db7", "db8", "db9"}
 		for i, v := range keys {
 			err := c.Put(v, manifestContents{}, time.Now())
-			assert.NoError(err)
+			require.NoError(t, err)
 			expected := uint64(i + 1)
 			if expected >= capacity {
 				expected = capacity
@@ -84,7 +85,7 @@ func TestSizeCache(t *testing.T) {
 		assert.True(ok)
 		lru++
 		err := c.Put("novel", manifestContents{}, time.Now())
-		assert.NoError(err)
+		require.NoError(t, err)
 		_, _, ok = c.Get(keys[lru])
 		assert.False(ok)
 		// |keys[lru]| is gone, so |keys[lru+1]| is next
@@ -92,7 +93,7 @@ func TestSizeCache(t *testing.T) {
 
 		// Putting a bigger value will dump multiple existing entries
 		err = c.Put("big", manifestContents{vers: "big version"}, time.Now())
-		assert.NoError(err)
+		require.NoError(t, err)
 		_, _, ok = c.Get(keys[lru])
 		assert.False(ok)
 		lru++
@@ -114,7 +115,7 @@ func TestSizeCache(t *testing.T) {
 	t.Run("TooLargeValue", func(t *testing.T) {
 		c := newManifestCache(16)
 		err := c.Put("db", manifestContents{}, time.Now())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, ok := c.Get("db")
 		assert.False(t, ok)
 	})
@@ -122,7 +123,7 @@ func TestSizeCache(t *testing.T) {
 	t.Run("ZeroSizeCache", func(t *testing.T) {
 		c := newManifestCache(0)
 		err := c.Put("db", manifestContents{}, time.Now())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, ok := c.Get("db")
 		assert.False(t, ok)
 	})

--- a/go/store/nbs/mem_table_test.go
+++ b/go/store/nbs/mem_table_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/golang/snappy"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/dolthub/dolt/go/store/chunks"
@@ -96,7 +97,7 @@ func TestMemTableAddHasGetChunk(t *testing.T) {
 
 	for _, c := range chunks {
 		data, err := mt.get(context.Background(), computeAddr(c), &Stats{})
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Equal(bytes.Compare(c, data), 0)
 	}
 
@@ -149,25 +150,25 @@ func TestMemTableWrite(t *testing.T) {
 	}
 
 	td1, _, err := buildTable(chunks[1:2])
-	assert.NoError(err)
+	require.NoError(t, err)
 	ti1, err := parseTableIndex(td1)
-	assert.NoError(err)
+	require.NoError(t, err)
 	tr1 := newTableReader(ti1, tableReaderAtFromBytes(td1), fileBlockSize)
 	assert.True(tr1.has(computeAddr(chunks[1])))
 
 	td2, _, err := buildTable(chunks[2:])
-	assert.NoError(err)
+	require.NoError(t, err)
 	ti2, err := parseTableIndex(td2)
-	assert.NoError(err)
+	require.NoError(t, err)
 	tr2 := newTableReader(ti2, tableReaderAtFromBytes(td2), fileBlockSize)
 	assert.True(tr2.has(computeAddr(chunks[2])))
 
 	_, data, count, err := mt.write(chunkReaderGroup{tr1, tr2}, &Stats{})
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.Equal(uint32(1), count)
 
 	ti, err := parseTableIndex(data)
-	assert.NoError(err)
+	require.NoError(t, err)
 	outReader := newTableReader(ti, tableReaderAtFromBytes(data), fileBlockSize)
 	assert.True(outReader.has(computeAddr(chunks[0])))
 	assert.False(outReader.has(computeAddr(chunks[1])))

--- a/go/store/nbs/mmap_table_reader_test.go
+++ b/go/store/nbs/mmap_table_reader_test.go
@@ -28,12 +28,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMmapTableReader(t *testing.T) {
 	assert := assert.New(t)
 	dir, err := ioutil.TempDir("", "")
-	assert.NoError(err)
+	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
 	fc := newFDCache(1)
@@ -46,11 +47,11 @@ func TestMmapTableReader(t *testing.T) {
 	}
 
 	tableData, h, err := buildTable(chunks)
-	assert.NoError(err)
+	require.NoError(t, err)
 	err = ioutil.WriteFile(filepath.Join(dir, h.String()), tableData, 0666)
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	trc, err := newMmapTableReader(dir, h, uint32(len(chunks)), nil, fc)
-	assert.NoError(err)
+	require.NoError(t, err)
 	assertChunksInReader(chunks, trc, assert)
 }

--- a/go/store/nbs/persisting_chunk_source_test.go
+++ b/go/store/nbs/persisting_chunk_source_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPersistingChunkStoreEmpty(t *testing.T) {
@@ -33,7 +34,7 @@ func TestPersistingChunkStoreEmpty(t *testing.T) {
 	ccs := newPersistingChunkSource(context.Background(), mt, nil, newFakeTablePersister(), make(chan struct{}, 1), &Stats{})
 
 	h, err := ccs.hash()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, addr{}, h)
 	assert.Zero(t, mustUint32(ccs.count()))
 }

--- a/go/store/nbs/store_test.go
+++ b/go/store/nbs/store_test.go
@@ -180,7 +180,7 @@ func TestNBSPruneTableFiles(t *testing.T) {
 	}
 
 	err = st.PruneTableFiles(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	postGC := currTableFiles(nomsDir)
 	for _, tf := range sources {
@@ -227,11 +227,11 @@ func TestNBSCopyGC(t *testing.T) {
 
 	for _, c := range keepers {
 		err := st.Put(ctx, c)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 	for h, c := range keepers {
 		out, err := st.Get(ctx, h)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, c, out)
 	}
 
@@ -243,16 +243,16 @@ func TestNBSCopyGC(t *testing.T) {
 	}
 	for _, c := range tossers {
 		err := st.Put(ctx, c)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 	for h, c := range tossers {
 		out, err := st.Get(ctx, h)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, c, out)
 	}
 
 	r, err := st.Root(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	keepChan := make(chan []hash.Hash, 16)
 	var msErr error
@@ -267,7 +267,7 @@ func TestNBSCopyGC(t *testing.T) {
 	}
 	close(keepChan)
 	wg.Wait()
-	assert.NoError(t, msErr)
+	require.NoError(t, msErr)
 
 	for h, c := range keepers {
 		out, err := st.Get(ctx, h)

--- a/go/store/nbs/table_persister_test.go
+++ b/go/store/nbs/table_persister_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPlanCompaction(t *testing.T) {
@@ -43,16 +44,16 @@ func TestPlanCompaction(t *testing.T) {
 			totalUnc += uint64(len(chnk))
 		}
 		data, name, err := buildTable(content)
-		assert.NoError(err)
+		require.NoError(t, err)
 		ti, err := parseTableIndex(data)
-		assert.NoError(err)
+		require.NoError(t, err)
 		src := chunkSourceAdapter{newTableReader(ti, tableReaderAtFromBytes(data), fileBlockSize), name}
 		dataLens = append(dataLens, uint64(len(data))-indexSize(mustUint32(src.count()))-footerSize)
 		sources = append(sources, src)
 	}
 
 	plan, err := planConjoin(sources, &Stats{})
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	var totalChunks uint32
 	for i, src := range sources {
@@ -61,7 +62,7 @@ func TestPlanCompaction(t *testing.T) {
 	}
 
 	idx, err := parseTableIndex(plan.mergedIndex)
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	assert.Equal(totalChunks, idx.chunkCount)
 	assert.Equal(totalUnc, idx.totalUncompressedData)

--- a/go/store/nbs/table_set_test.go
+++ b/go/store/nbs/table_set_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var testChunks = [][]byte{[]byte("hello2"), []byte("goodbye2"), []byte("badbye2")}
@@ -33,7 +34,7 @@ var testChunks = [][]byte{[]byte("hello2"), []byte("goodbye2"), []byte("badbye2"
 func TestTableSetPrependEmpty(t *testing.T) {
 	ts := newFakeTableSet().Prepend(context.Background(), newMemTable(testMemTableSize), &Stats{})
 	specs, err := ts.ToSpecs()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, specs)
 }
 
@@ -41,14 +42,14 @@ func TestTableSetPrepend(t *testing.T) {
 	assert := assert.New(t)
 	ts := newFakeTableSet()
 	specs, err := ts.ToSpecs()
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.Empty(specs)
 	mt := newMemTable(testMemTableSize)
 	mt.addChunk(computeAddr(testChunks[0]), testChunks[0])
 	ts = ts.Prepend(context.Background(), mt, &Stats{})
 
 	firstSpecs, err := ts.ToSpecs()
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.Len(firstSpecs, 1)
 
 	mt = newMemTable(testMemTableSize)
@@ -57,7 +58,7 @@ func TestTableSetPrepend(t *testing.T) {
 	ts = ts.Prepend(context.Background(), mt, &Stats{})
 
 	secondSpecs, err := ts.ToSpecs()
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.Len(secondSpecs, 2)
 	assert.Equal(firstSpecs, secondSpecs[1:])
 }
@@ -80,7 +81,7 @@ func TestTableSetToSpecsExcludesEmptyTable(t *testing.T) {
 	ts = ts.Prepend(context.Background(), mt, &Stats{})
 
 	specs, err = ts.ToSpecs()
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.Len(specs, 2)
 }
 
@@ -88,7 +89,7 @@ func TestTableSetFlattenExcludesEmptyTable(t *testing.T) {
 	assert := assert.New(t)
 	ts := newFakeTableSet()
 	specs, err := ts.ToSpecs()
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.Empty(specs)
 	mt := newMemTable(testMemTableSize)
 	mt.addChunk(computeAddr(testChunks[0]), testChunks[0])
@@ -103,7 +104,7 @@ func TestTableSetFlattenExcludesEmptyTable(t *testing.T) {
 	ts = ts.Prepend(context.Background(), mt, &Stats{})
 
 	ts, err = ts.Flatten()
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.EqualValues(ts.Size(), 2)
 }
 
@@ -111,7 +112,7 @@ func TestTableSetExtract(t *testing.T) {
 	assert := assert.New(t)
 	ts := newFakeTableSet()
 	specs, err := ts.ToSpecs()
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.Empty(specs)
 
 	// Put in one table
@@ -130,7 +131,7 @@ func TestTableSetExtract(t *testing.T) {
 		defer close(chunkChan)
 		err := ts.extract(context.Background(), chunkChan)
 
-		assert.NoError(err)
+		require.NoError(t, err)
 	}()
 	i := 0
 	for rec := range chunkChan {
@@ -156,22 +157,22 @@ func TestTableSetRebase(t *testing.T) {
 	}
 	fullTS := newTableSet(persister)
 	specs, err := fullTS.ToSpecs()
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.Empty(specs)
 	fullTS = insert(fullTS, testChunks...)
 	fullTS, err = fullTS.Flatten()
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	ts := newTableSet(persister)
 	ts = insert(ts, testChunks[0])
 	assert.Equal(1, ts.Size())
 	ts, err = ts.Flatten()
-	assert.NoError(err)
+	require.NoError(t, err)
 	ts = insert(ts, []byte("novel"))
 
 	specs, err = fullTS.ToSpecs()
 	ts, err = ts.Rebase(context.Background(), specs, nil)
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.Equal(4, ts.Size())
 }
 
@@ -179,7 +180,7 @@ func TestTableSetPhysicalLen(t *testing.T) {
 	assert := assert.New(t)
 	ts := newFakeTableSet()
 	specs, err := ts.ToSpecs()
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.Empty(specs)
 	mt := newMemTable(testMemTableSize)
 	mt.addChunk(computeAddr(testChunks[0]), testChunks[0])

--- a/go/store/nbs/table_set_test.go
+++ b/go/store/nbs/table_set_test.go
@@ -67,6 +67,7 @@ func TestTableSetToSpecsExcludesEmptyTable(t *testing.T) {
 	assert := assert.New(t)
 	ts := newFakeTableSet()
 	specs, err := ts.ToSpecs()
+	require.NoError(t, err)
 	assert.Empty(specs)
 	mt := newMemTable(testMemTableSize)
 	mt.addChunk(computeAddr(testChunks[0]), testChunks[0])
@@ -171,6 +172,7 @@ func TestTableSetRebase(t *testing.T) {
 	ts = insert(ts, []byte("novel"))
 
 	specs, err = fullTS.ToSpecs()
+	require.NoError(t, err)
 	ts, err = ts.Rebase(context.Background(), specs, nil)
 	require.NoError(t, err)
 	assert.Equal(4, ts.Size())


### PR DESCRIPTION
This replaces most instances of `assert.NoError()` with `require.NoError()`, and picks up several dropped `err` variables in code and tests.