### PR TITLE
libraries/doltcore/table/untyped: fix dropped errors

### DIFF
--- a/go/libraries/doltcore/table/untyped/csv/writer_test.go
+++ b/go/libraries/doltcore/table/untyped/csv/writer_test.go
@@ -101,6 +101,9 @@ Andy Anderson,27,
 	writeToCSV(csvWr, rows, t)
 
 	results, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if string(results) != expected {
 		t.Errorf(`%s != %s`, results, expected)
 	}
@@ -130,6 +133,9 @@ Andy Anderson|27|
 	writeToCSV(csvWr, rows, t)
 
 	results, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if string(results) != expected {
 		t.Errorf(`%s != %s`, results, expected)
 	}

--- a/go/libraries/doltcore/table/untyped/xlsx/reader.go
+++ b/go/libraries/doltcore/table/untyped/xlsx/reader.go
@@ -78,6 +78,9 @@ func OpenXLSXReader(ctx context.Context, vrw types.ValueReadWriter, path string,
 	br := bufio.NewReaderSize(r, ReadBufSize)
 
 	colStrs, err := getColHeadersFromPath(path, info.SheetName)
+	if err != nil {
+		return nil, err
+	}
 
 	data, err := getXlsxRowsFromPath(path, info.SheetName)
 	if err != nil {


### PR DESCRIPTION
This fixes dropped errors in `libraries/doltcore/table/untyped/csv` and `libraries/doltcore/table/untyped/xlsx`.