### PR TITLE
Added test to CI for bats test names

### DIFF
--- a/.github/workflows/ci-check-repo.yaml
+++ b/.github/workflows/ci-check-repo.yaml
@@ -1,4 +1,4 @@
-name: Check Formatting and Commiters
+name: Check Formatting and Committers
 
 on:
   pull_request:
@@ -26,6 +26,7 @@ jobs:
           go run -mod=readonly ./utils/copyrightshdrs/
           ./utils/repofmt/check_fmt.sh
           ./Godeps/verify.sh
+          ./utils/repofmt/check_bats_fmt.sh
         env:
           BRANCH_NAME: ${{ github.head_ref }}
           CHANGE_TARGET: ${{ github.base_ref }}

--- a/go/utils/repofmt/check_bats_fmt.sh
+++ b/go/utils/repofmt/check_bats_fmt.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+script_dir=$(dirname "$0")
+cd $script_dir/../../../integration-tests/bats
+
+ERRORS_FOUND=0
+for FILENAME_WITH_EXT in *.bats; do
+    FILENAME=${FILENAME_WITH_EXT%".bats"}
+    while read -r LINE; do
+        if [[ ! "$LINE" =~ "@test \"$FILENAME:" ]]; then
+            TESTNAME=$(echo "$LINE" | cut -d'"' -f 2)
+            echo -e "ERROR: test \"$TESTNAME\" in \"$FILENAME_WITH_EXT\" must start with \"$FILENAME:\" in the title"
+            ERRORS_FOUND=1
+        fi
+    done <<< $(grep '@test "' "$FILENAME_WITH_EXT")
+done
+if [[ $ERRORS_FOUND -eq 1 ]]; then
+    exit 1
+fi
+exit 0

--- a/integration-tests/bats/common.bash.bats
+++ b/integration-tests/bats/common.bash.bats
@@ -9,7 +9,7 @@ teardown() {
     teardown_common
 }
 
-@test "common: stashing, setting, and restoring dolt users" {
+@test "common.bash: stashing, setting, and restoring dolt users" {
   stash_current_dolt_user
   [ "$STASHED_DOLT_USER_NAME" = "Bats Tests" ]
   [ "$STASHED_DOLT_USER_EMAIL" = "bats@email.fake" ]

--- a/integration-tests/bats/sql-load-data.bats
+++ b/integration-tests/bats/sql-load-data.bats
@@ -10,7 +10,7 @@ teardown() {
     teardown_common
 }
 
-@test "simple load data from file into table" {
+@test "sql-load-data: simple load from file into table" {
     cat <<DELIM > 1pk5col-ints.csv
 pk||c1||c2||c3||c4||c5
 0||1||2||3||4||5
@@ -33,7 +33,7 @@ SQL
     [ "${lines[2]}" = "1,1,2,3,4,5" ]
 }
 
-@test "load data into unknown table throws error" {
+@test "sql-load-data: load into unknown table throws error" {
     run dolt sql << SQL
 SET secure_file_priv='./';
 LOAD DATA INFILE '1pk5col-ints.csv' INTO TABLE test CHARACTER SET UTF8MB4 FIELDS TERMINATED BY '||' ESCAPED BY '' LINES TERMINATED BY '\n' IGNORE 1 LINES;
@@ -43,7 +43,7 @@ SQL
     [[ "$output" =~  "table not found: test" ]] || false
 }
 
-@test "load data with unknown file throws error" {
+@test "sql-load-data: load with unknown file throws error" {
     skip "Different error msg on windows."
     run dolt sql << SQL
 SET secure_file_priv='./';
@@ -55,7 +55,7 @@ SQL
     [[ "$output" =~  "no such file or directory" ]] || false
 }
 
-@test "load data works with enclosed terms" {
+@test "sql-load-data: works with enclosed terms" {
     cat <<DELIM > 1pk5col-ints.csv
 pk||c1||c2||c3||c4||c5
 "0"||"1"||"2"||"3"||"4"||"5"
@@ -78,7 +78,7 @@ SQL
     [ "${lines[2]}" = "1,1,2,3,4,5" ]
 }
 
-@test "load data works with prefixed terms" {
+@test "sql-load-data: works with prefixed terms" {
     cat <<DELIM > prefixed.txt
 pk
 sssHi
@@ -104,7 +104,7 @@ SQL
     [ "${lines[3]}" = "Yo" ]
 }
 
-@test "load data works when the number of input columns in the file is less than the number of schema columns" {
+@test "sql-load-data: works when the number of input columns in the file is less than the number of schema columns" {
     cat <<DELIM > 1pk2col-ints.csv
 pk,c1
 0,1
@@ -127,7 +127,7 @@ SQL
     [ "${lines[2]}" = "1,1," ]
 }
 
-@test "load data works with fields separated by tabs" {
+@test "sql-load-data: works with fields separated by tabs" {
     skip "This needs to be fixed."
     cat <<DELIM > 1pk2col-ints.csv
 pk  c1
@@ -151,7 +151,7 @@ SQL
     [ "${lines[2]}" = "1,1" ]
 }
 
-@test "load data recognizes certain nulls" {
+@test "sql-load-data: recognizes certain nulls" {
     cat <<DELIM > 1pk2col-ints.csv
 pk
 \N
@@ -171,7 +171,7 @@ SQL
     [[ "$output" =~  "2" ]] || false
 }
 
-@test "load data works when column order is mismatched" {
+@test "sql-load-data: works when column order is mismatched" {
     skip "This needs to be fixed."
 
     cat <<DELIM > 1pk2col-ints.csv
@@ -196,7 +196,7 @@ SQL
     [ "${lines[2]}" = "2,hello" ]
 }
 
-@test "load data with different column types that uses optionally" {
+@test "sql-load-data: with different column types that uses optionally" {
     skip "This functionality is not present yet."
     cat <<DELIM > complex.csv
 1,"a string",100.20
@@ -223,7 +223,7 @@ SQL
     [ "${lines[4]}" = "4,a string containing a \", quote and comma,100.20" ]
 }
 
-@test "load data works with escaped columns" {
+@test "sql-load-data: works with escaped columns" {
     skip "This functionality is not present yet."
     cat <<DELIM > escape.txt
 "hi"
@@ -250,7 +250,7 @@ SQL
     [ "${lines[4]}" = "new\ns" ]
 }
 
-@test "load data when the number of input columns in the file is greater than the number of schema columns" {
+@test "sql-load-data: when the number of input columns in the file is greater than the number of schema columns" {
    skip "This functionality is not present yet."
    cat <<DELIM > 1pk5col-ints.csv
 pk||c1||c2||c3||c4||c5

--- a/integration-tests/bats/sql-show.bats
+++ b/integration-tests/bats/sql-show.bats
@@ -10,7 +10,7 @@ teardown() {
     teardown_common
 }
 
-@test "show table status on auto-increment table" {
+@test "sql-show: show table status on auto-increment table" {
     dolt sql -q "CREATE TABLE test(pk int NOT NULL AUTO_INCREMENT, c1 int, PRIMARY KEY (pk))"
 
     run dolt sql -q "show table status where \`Auto_increment\`=1;"
@@ -23,7 +23,7 @@ teardown() {
     [[ "$output" =~ "test" ]] || false
 }
 
-@test "show table status has null auto-increment column when table does not auto-increment" {
+@test "sql-show: show table status has null auto-increment column when table does not auto-increment" {
     dolt sql -q "CREATE TABLE test(pk int NOT NULL, c1 int, PRIMARY KEY (pk))"
 
     run dolt sql -q "show table status where \`Auto_increment\`=1;"
@@ -37,7 +37,7 @@ teardown() {
 }
 
 
-@test "show table status has number of rows correct" {
+@test "sql-show: show table status has number of rows correct" {
     dolt sql -q "CREATE TABLE test(pk int NOT NULL AUTO_INCREMENT, c1 int, PRIMARY KEY (pk))"
 
     run dolt sql -q "show table status where Rows=0"
@@ -50,7 +50,7 @@ teardown() {
     [[ "$output" =~ "test" ]] || false
 }
 
-@test "show table status shows a data length > 0" {
+@test "sql-show: show table status shows a data length > 0" {
     dolt sql -q "CREATE TABLE test(pk int NOT NULL AUTO_INCREMENT, c1 int, PRIMARY KEY (pk))"
 
     run dolt sql -q "show table status where \`Data_length\`=0"


### PR DESCRIPTION
This enforces the new naming scheme for bats tests that I implemented in https://github.com/dolthub/dolt/pull/1386. This just adds a check to the `Check Formatting and Committers` task to ensure that future tests continue to follow the naming scheme.