### PR TITLE
go/libraries/doltcore/sqle/async_indexed_lookups.go: Fix leaking of results from one index lookup to another.

### DIFF
--- a/go/libraries/utils/async/ring_buffer.go
+++ b/go/libraries/utils/async/ring_buffer.go
@@ -15,6 +15,7 @@
 package async
 
 import (
+	"errors"
 	"io"
 	"os"
 	"sync"
@@ -34,6 +35,10 @@ type RingBuffer struct {
 
 	items [][]interface{}
 }
+
+// Returned from Push() when the supplied epoch does not match the
+// buffer's current epoch.
+var ErrWrongEpoch = errors.New("ring buffer: wrong epoch")
 
 // NewRingBuffer creates a new RingBuffer instance
 func NewRingBuffer(allocSize int) *RingBuffer {
@@ -93,7 +98,7 @@ func (rb *RingBuffer) Push(item interface{}, epoch int) error {
 		return os.ErrClosed
 	}
 	if epoch != rb.epoch {
-		return nil
+		return ErrWrongEpoch
 	}
 
 	rb.items[rb.headSlice][rb.headPos] = item

--- a/go/libraries/utils/async/ring_buffer_test.go
+++ b/go/libraries/utils/async/ring_buffer_test.go
@@ -39,7 +39,7 @@ func TestSingleThread(t *testing.T) {
 			rb := NewRingBuffer(test.allocSize)
 
 			for i := 0; i < test.numItems; i++ {
-				err := rb.Push(i)
+				err := rb.Push(i, rb.epoch)
 				assert.NoError(t, err)
 			}
 
@@ -75,7 +75,7 @@ func TestOneProducerOneConsumer(t *testing.T) {
 				defer rb.Close()
 
 				for i := 0; i < test.numItems; i++ {
-					err := rb.Push(i)
+					err := rb.Push(i, rb.epoch)
 					assert.NoError(t, err)
 				}
 			}()
@@ -118,7 +118,7 @@ func TestNProducersNConsumers(t *testing.T) {
 				go func() {
 					defer producerGroup.Done()
 					for i := 0; i < test.itemsPerProducer; i++ {
-						err := rb.Push(i)
+						err := rb.Push(i, rb.epoch)
 						assert.NoError(t, err)
 					}
 				}()

--- a/go/libraries/utils/async/ring_buffer_test.go
+++ b/go/libraries/utils/async/ring_buffer_test.go
@@ -161,3 +161,20 @@ func TestNProducersNConsumers(t *testing.T) {
 		})
 	}
 }
+
+func TestRingBufferEpoch(t *testing.T) {
+	rb := NewRingBuffer(1024)
+	epoch := rb.Reset()
+	err := rb.Push(1, epoch)
+	assert.NoError(t, err)
+	err = rb.Push(2, epoch+1)
+	assert.Error(t, err)
+	assert.Equal(t, ErrWrongEpoch, err)
+	v, ok := rb.TryPop()
+	assert.True(t, ok)
+	assert.Equal(t, 1, v)
+	_, ok = rb.TryPop()
+	assert.False(t, ok)
+	newEpoch := rb.Reset()
+	assert.NotEqual(t, epoch, newEpoch)
+}


### PR DESCRIPTION
When a query with an index lookup as a LIMIT, it's possible for the result
iterator to be closed before all the index results have been streamed. When
that happens, we can end up with queueRows goroutine which is enqueuing rows
into a ring buffer that is going to be used by a different query later.

This PR adds two mechanisms, one to stop the wrong results from being seen and
to cancel the unnecessary work.

1. RingBuffer gets an epoch, which is incremented on each Reset(). If a given
   Push does not match the current epoch, then nothing is added to the ring
   buffer.

2. queueRows is run with a cancelable (sub-)Context, and that Context is
   canceled when the corresponding iterator is Closed().