### PR TITLE
go/utils/publishrelease/buildbinaries.sh: Use CGO_ENABLED=0 to statically link release binaries on Linux.

### DIFF
--- a/go/utils/publishrelease/buildbinaries.sh
+++ b/go/utils/publishrelease/buildbinaries.sh
@@ -26,7 +26,7 @@ for os in $OSES; do
       if [ "$os" = windows ]; then
         obin="$bin.exe"
       fi
-      GOOS="$os" GOARCH="$arch" go build -o "$o/bin/$obin" "./cmd/$bin/"
+      CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" go build -o "$o/bin/$obin" "./cmd/$bin/"
     done
     if [ "$os" = windows ]; then
       (cd out && zip -r "dolt-$os-$arch" "dolt-$os-$arch")


### PR DESCRIPTION
This lets Dolt release binaries work on Linux distributions that do not use glibc, like Alpine.

Fixes #1489.