### PR TITLE
Fix dropped errors in libraries/doltcore/doltdocs

### DIFF
--- a/go/libraries/doltcore/doltdocs/docs.go
+++ b/go/libraries/doltcore/doltdocs/docs.go
@@ -237,6 +237,9 @@ func UpdateRootWithDocs(ctx context.Context, root *doltdb.RootValue, docs Docs) 
 
 	if errors.Is(ErrEmptyDocsTable, err) {
 		root, err = root.RemoveTables(ctx, doltdb.DocTableName)
+		if err != nil {
+			return nil, err
+		}
 	} else if err != nil {
 		return nil, err
 	}
@@ -244,6 +247,9 @@ func UpdateRootWithDocs(ctx context.Context, root *doltdb.RootValue, docs Docs) 
 	// There might not need be a need to create docs table if not docs have been created yet so check if docTbl != nil.
 	if docTbl != nil {
 		root, err = root.PutTable(ctx, doltdb.DocTableName, docTbl)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return root, nil

--- a/go/libraries/doltcore/doltdocs/docs_table.go
+++ b/go/libraries/doltcore/doltdocs/docs_table.go
@@ -68,6 +68,9 @@ func updateDocsTable(ctx context.Context, docTbl *doltdb.Table, docs Docs) (*dol
 		}
 	}
 	updatedMap, err := me.Map(ctx)
+	if err != nil {
+		return nil, err
+	}
 	if updatedMap.Len() == 0 {
 		return nil, ErrEmptyDocsTable
 	}

--- a/go/libraries/doltcore/doltdocs/docs_test.go
+++ b/go/libraries/doltcore/doltdocs/docs_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
@@ -35,7 +36,7 @@ func TestAddNewerTextAndValueFromTable(t *testing.T) {
 	// If no tbl/schema is provided, doc Text and Value should be nil.
 	doc1 := Doc{DocPk: LicenseDoc}
 	doc1Text, err := getDocTextFromTbl(ctx, nil, nil, doc1.DocPk)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	doc1.Text = doc1Text
 	assert.Nil(t, doc1.Text)
 
@@ -44,19 +45,19 @@ func TestAddNewerTextAndValueFromTable(t *testing.T) {
 	rows := []row.Row{}
 	m, _ := createTestRows(t, ddb.ValueReadWriter(), sch, rows)
 	tbl, err := CreateTestTable(ddb.ValueReadWriter(), sch, m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// If a table doesn't have doc row, doc Text and Value should remain nil
 	doc2 := Doc{DocPk: LicenseDoc}
 	doc2Text, err := getDocTextFromTbl(ctx, tbl, &sch, doc2.DocPk)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	doc2.Text = doc2Text
 	assert.Nil(t, doc2.Text)
 
 	// If a table doesn't have doc row, and Text and Value are originally non-nil, they should be updated to nil.
 	doc3 := Doc{DocPk: LicenseDoc, Text: []byte("Something in newer text field")}
 	doc3Text, err := getDocTextFromTbl(ctx, tbl, &sch, doc3.DocPk)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	doc3.Text = doc3Text
 	assert.Nil(t, doc3.Text)
 
@@ -64,19 +65,19 @@ func TestAddNewerTextAndValueFromTable(t *testing.T) {
 	rows = getDocRows(t, sch, types.String("text in doc_text"))
 	m, _ = createTestRows(t, ddb.ValueReadWriter(), sch, rows)
 	tbl, err = CreateTestTable(ddb.ValueReadWriter(), sch, m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// If a table has a doc row, Text and Value and should be updated to the `doc_text` value in that row.
 	doc4 := Doc{DocPk: LicenseDoc, Text: []byte("Something in newer text field")}
 	doc4Text, err := getDocTextFromTbl(ctx, tbl, &sch, doc4.DocPk)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	doc4.Text = doc4Text
 	assert.Equal(t, "text in doc_text", string(doc4.Text))
 
 	// If a table has a doc row, and Text and Value are originally non-nil, they should be updated to the `doc_text` value.
 	doc5 := Doc{DocPk: LicenseDoc}
 	doc5Text, err := getDocTextFromTbl(ctx, tbl, &sch, doc5.DocPk)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	doc5.Text = doc5Text
 	assert.Equal(t, "text in doc_text", string(doc5.Text))
 }
@@ -89,15 +90,15 @@ func TestAddNewerTextAndDocPkFromRow(t *testing.T) {
 	sch := createTestDocsSchema()
 
 	emptyRow, err := row.New(types.Format_7_18, sch, row.TaggedValues{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Text and DocName should be nil from an empty row
 	doc1 := Doc{}
 	text, err := getDocTextFromRow(emptyRow)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, text)
 	docPk, err := getDocPKFromRow(emptyRow)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	doc1.DocPk = docPk
 	assert.Equal(t, "", doc1.DocPk)
 
@@ -105,27 +106,27 @@ func TestAddNewerTextAndDocPkFromRow(t *testing.T) {
 		schema.DocNameTag: types.String(LicenseDoc),
 		schema.DocTextTag: types.String("license!"),
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Text and DocName should be added to doc from row
 	doc2 := Doc{}
 	text, err = getDocTextFromRow(licenseRow)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	doc2.Text = text
 	assert.Equal(t, "license!", string(doc2.Text))
 	docPk, err = getDocPKFromRow(licenseRow)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	doc2.DocPk = docPk
 	assert.Equal(t, LicenseDoc, doc2.DocPk)
 
 	// When Text and DocName are non-nil, they should be updated from the row provided.
 	doc3 := Doc{DocPk: "invalid", Text: []byte("something")}
 	text, err = getDocTextFromRow(licenseRow)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	doc3.Text = text
 	assert.Equal(t, "license!", string(doc3.Text))
 	docPk, err = getDocPKFromRow(licenseRow)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	doc3.DocPk = docPk
 	assert.Equal(t, LicenseDoc, doc3.DocPk)
 }
@@ -174,7 +175,7 @@ func makeDocRow(t *testing.T, sch schema.Schema, pk string, rowVal types.Value) 
 		schema.DocNameTag: types.String(pk),
 		schema.DocTextTag: rowVal,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return row
 }
@@ -184,7 +185,7 @@ func createTestRows(t *testing.T, vrw types.ValueReadWriter, sch schema.Schema, 
 	var err error
 
 	m, err := types.NewMap(ctx, vrw)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ed := m.Edit()
 
 	for _, r := range rows {
@@ -192,7 +193,7 @@ func createTestRows(t *testing.T, vrw types.ValueReadWriter, sch schema.Schema, 
 	}
 
 	m, err = ed.Map(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return m, rows
 }

--- a/go/libraries/doltcore/doltdocs/docs_test.go
+++ b/go/libraries/doltcore/doltdocs/docs_test.go
@@ -89,6 +89,7 @@ func TestAddNewerTextAndDocPkFromRow(t *testing.T) {
 	sch := createTestDocsSchema()
 
 	emptyRow, err := row.New(types.Format_7_18, sch, row.TaggedValues{})
+	assert.NoError(t, err)
 
 	// Text and DocName should be nil from an empty row
 	doc1 := Doc{}


### PR DESCRIPTION
Fixes dropped errors, changes tests to use `require.NoError()`.