### PR TITLE
Fixed dropped errors in libraries/doltcore/row

### DIFF
--- a/go/libraries/doltcore/row/fmt_test.go
+++ b/go/libraries/doltcore/row/fmt_test.go
@@ -18,16 +18,16 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFmt(t *testing.T) {
 	r, err := newTestRow()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expected := `first:"rick" | last:"astley" | age:53 | address:"123 Fake St" | title:null_value | `
 	actual := Fmt(context.Background(), r, sch)
 	if expected != actual {
-		t.Errorf("expected: '%s', actual: '%s'", expected, actual)
+		t.Fatalf("expected: '%s', actual: '%s'", expected, actual)
 	}
 }

--- a/go/libraries/doltcore/row/noms_row_test.go
+++ b/go/libraries/doltcore/row/noms_row_test.go
@@ -83,14 +83,14 @@ func newTestRow() (Row, error) {
 
 func TestItrRowCols(t *testing.T) {
 	r, err := newTestRow()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	itrVals := make(TaggedValues)
 	_, err = r.IterCols(func(tag uint64, val types.Value) (stop bool, err error) {
 		itrVals[tag] = val
 		return false, nil
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, TaggedValues{
 		lnColTag:    lnVal,
@@ -110,14 +110,14 @@ func TestFromNoms(t *testing.T) {
 		addrColTag: addrVal,
 		ageColTag:  ageVal,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("all values specified", func(t *testing.T) {
 		keys, err := types.NewTuple(types.Format_Default,
 			types.Uint(fnColTag), fnVal,
 			types.Uint(lnColTag), lnVal,
 		)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		vals, err := types.NewTuple(types.Format_Default,
 			types.Uint(addrColTag), addrVal,
@@ -125,10 +125,10 @@ func TestFromNoms(t *testing.T) {
 			types.Uint(titleColTag), titleVal,
 		)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		r, err := FromNoms(sch, keys, vals)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, expectedRow, r)
 	})
 
@@ -137,18 +137,18 @@ func TestFromNoms(t *testing.T) {
 			types.Uint(fnColTag), fnVal,
 			types.Uint(lnColTag), lnVal,
 		)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		vals, err := types.NewTuple(types.Format_Default)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		expectedRow, err := New(types.Format_Default, sch, TaggedValues{
 			fnColTag: fnVal,
 			lnColTag: lnVal,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		r, err := FromNoms(sch, keys, vals)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, expectedRow, r)
 	})
 
@@ -158,7 +158,7 @@ func TestFromNoms(t *testing.T) {
 			types.Uint(lnColTag), lnVal,
 		)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		vals, err := types.NewTuple(types.Format_Default,
 			types.Uint(addrColTag), addrVal,
@@ -167,10 +167,10 @@ func TestFromNoms(t *testing.T) {
 			types.Uint(unusedTag), fnVal,
 		)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		r, err := FromNoms(sch, keys, vals)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, expectedRow, r)
 	})
 
@@ -179,12 +179,12 @@ func TestFromNoms(t *testing.T) {
 			types.Uint(fnColTag), fnVal,
 			types.Uint(lnColTag), lnVal,
 		)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		vals, err := types.NewTuple(types.Format_Default,
 			types.Uint(addrColTag), addrVal,
 			types.Uint(ageColTag), fnVal,
 		)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		_, err = FromNoms(sch, keys, vals)
 		assert.Error(t, err)
@@ -195,12 +195,12 @@ func TestFromNoms(t *testing.T) {
 			types.Uint(fnColTag), fnVal,
 			types.Uint(lnColTag), lnVal,
 		)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		vals, err := types.NewTuple(types.Format_Default,
 			types.Uint(addrColTag), addrVal,
 			types.Uint(fnColTag), fnVal,
 		)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		_, err = FromNoms(sch, keys, vals)
 		assert.Error(t, err)
@@ -213,7 +213,7 @@ func TestFromNoms(t *testing.T) {
 			types.Uint(unusedTag), fnVal,
 		)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		vals, err := types.NewTuple(types.Format_Default,
 			types.Uint(addrColTag), addrVal,
@@ -221,7 +221,7 @@ func TestFromNoms(t *testing.T) {
 			types.Uint(titleColTag), titleVal,
 		)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		_, err = FromNoms(sch, keys, vals)
 		assert.Error(t, err)
@@ -234,14 +234,14 @@ func TestFromNoms(t *testing.T) {
 			types.Uint(ageColTag), ageVal,
 		)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		vals, err := types.NewTuple(types.Format_Default,
 			types.Uint(addrColTag), addrVal,
 			types.Uint(titleColTag), titleVal,
 		)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		_, err = FromNoms(sch, keys, vals)
 		assert.Error(t, err)
@@ -260,17 +260,17 @@ func TestSetColVal(t *testing.T) {
 		updatedVal := types.String("sanchez")
 
 		r, err := newTestRow()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		r2, err := New(types.Format_Default, sch, expected)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, r, r2)
 
 		updated, err := r.SetColVal(lnColTag, updatedVal, sch)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// validate calling set does not mutate the original row
 		r3, err := New(types.Format_Default, sch, expected)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, r, r3)
 		expected[lnColTag] = updatedVal
 		r4, err := New(types.Format_Default, sch, expected)
@@ -279,7 +279,7 @@ func TestSetColVal(t *testing.T) {
 
 		// set to a nil value
 		updated, err = updated.SetColVal(titleColTag, nil, sch)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		delete(expected, titleColTag)
 		r5, err := New(types.Format_Default, sch, expected)
 		require.NoError(t, err)
@@ -295,27 +295,27 @@ func TestSetColVal(t *testing.T) {
 			titleColTag: titleVal}
 
 		r, err := newTestRow()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		r2, err := New(types.Format_Default, sch, expected)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, r, r2)
 
 		// SetColVal allows an incorrect type to be set for a column
 		updatedRow, err := r.SetColVal(lnColTag, types.Bool(true), sch)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		// IsValid fails for the type problem
 		isv, err := IsValid(updatedRow, sch)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.False(t, isv)
 		invalidCol, err := GetInvalidCol(updatedRow, sch)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, invalidCol)
 		assert.Equal(t, uint64(lnColTag), invalidCol.Tag)
 
 		// validate calling set does not mutate the original row
 		r3, err := New(types.Format_Default, sch, expected)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, r, r3)
 	})
 }
@@ -324,16 +324,16 @@ func TestConvToAndFromTuple(t *testing.T) {
 	ctx := context.Background()
 
 	r, err := newTestRow()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	keyTpl := r.NomsMapKey(sch).(TupleVals)
 	valTpl := r.NomsMapValue(sch).(TupleVals)
 	keyVal, err := keyTpl.Value(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	valVal, err := valTpl.Value(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	r2, err := FromNoms(sch, keyVal.(types.Tuple), valVal.(types.Tuple))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	fmt.Println(Fmt(context.Background(), r, sch))
 	fmt.Println(Fmt(context.Background(), r2, sch))
@@ -402,7 +402,7 @@ func TestReduceToIndex(t *testing.T) {
 		expectedIndex, err := New(types.Format_Default, index.Schema(), tvCombo.expectedIndex)
 		require.NoError(t, err)
 		indexRow, err := ReduceToIndex(index, row)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, AreEqual(expectedIndex, indexRow, index.Schema()))
 	}
 }

--- a/go/libraries/doltcore/row/noms_row_test.go
+++ b/go/libraries/doltcore/row/noms_row_test.go
@@ -274,6 +274,7 @@ func TestSetColVal(t *testing.T) {
 		assert.Equal(t, r, r3)
 		expected[lnColTag] = updatedVal
 		r4, err := New(types.Format_Default, sch, expected)
+		require.NoError(t, err)
 		assert.Equal(t, updated, r4)
 
 		// set to a nil value
@@ -281,6 +282,7 @@ func TestSetColVal(t *testing.T) {
 		assert.NoError(t, err)
 		delete(expected, titleColTag)
 		r5, err := New(types.Format_Default, sch, expected)
+		require.NoError(t, err)
 		assert.Equal(t, updated, r5)
 	})
 

--- a/go/libraries/doltcore/row/row_test.go
+++ b/go/libraries/doltcore/row/row_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestGetFieldByName(t *testing.T) {
 	r, err := newTestRow()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	val, ok := GetFieldByName(lnColName, r, sch)
 
@@ -47,7 +47,7 @@ func TestGetFieldByName(t *testing.T) {
 
 func TestGetFieldByNameWithDefault(t *testing.T) {
 	r, err := newTestRow()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defVal := types.String("default")
 
 	val := GetFieldByNameWithDefault(lnColName, defVal, r, sch)
@@ -65,33 +65,33 @@ func TestGetFieldByNameWithDefault(t *testing.T) {
 
 func TestIsValid(t *testing.T) {
 	r, err := newTestRow()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	isv, err := IsValid(r, sch)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, isv)
 	invCol, err := GetInvalidCol(r, sch)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, invCol)
 	column, colConstraint, err := GetInvalidConstraint(r, sch)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, column)
 	assert.Nil(t, colConstraint)
 
 	updatedRow, err := r.SetColVal(lnColTag, nil, sch)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	isv, err = IsValid(updatedRow, sch)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, isv)
 
 	col, err := GetInvalidCol(updatedRow, sch)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, col)
 	assert.Equal(t, col.Tag, uint64(lnColTag))
 
 	col, cnst, err := GetInvalidConstraint(updatedRow, sch)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, col)
 	assert.Equal(t, col.Tag, uint64(lnColTag))
 	assert.Equal(t, cnst, schema.NotNullConstraint{})
@@ -106,16 +106,16 @@ func TestIsValid(t *testing.T) {
 		require.NoError(t, err)
 
 		isv, err := IsValid(r, newSch)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.False(t, isv)
 
 		col, err = GetInvalidCol(r, newSch)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		require.NotNil(t, col)
 		assert.Equal(t, col.Tag, uint64(addrColTag))
 
 		col, cnst, err = GetInvalidConstraint(r, newSch)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Nil(t, cnst)
 		assert.Equal(t, col.Tag, uint64(addrColTag))
 	})
@@ -123,10 +123,10 @@ func TestIsValid(t *testing.T) {
 
 func TestAreEqual(t *testing.T) {
 	r, err := newTestRow()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	updatedRow, err := r.SetColVal(lnColTag, types.String("new"), sch)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.True(t, AreEqual(r, r, sch))
 	assert.False(t, AreEqual(r, updatedRow, sch))

--- a/go/libraries/doltcore/row/tagged_values.go
+++ b/go/libraries/doltcore/row/tagged_values.go
@@ -259,8 +259,11 @@ func (tt TaggedValues) String() string {
 func CountCellDiffs(from, to types.Tuple) (uint64, error) {
 	changed := 0
 	f, err := ParseTaggedValues(from)
-	t, err := ParseTaggedValues(to)
+	if err != nil {
+		return 0, err
+	}
 
+	t, err := ParseTaggedValues(to)
 	if err != nil {
 		return 0, err
 	}

--- a/go/libraries/doltcore/row/tagged_values_test.go
+++ b/go/libraries/doltcore/row/tagged_values_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/dolt/go/store/types"
 )
@@ -99,22 +100,21 @@ func TestTupleValsLess(t *testing.T) {
 			greaterTplVals := test.greaterTVs.nomsTupleForTags(types.Format_Default, test.tags, true)
 
 			lessLTGreater, err := lesserTplVals.Less(types.Format_Default, greaterTplVals)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			greaterLTLess, err := greaterTplVals.Less(types.Format_Default, lesserTplVals)
-			assert.NoError(t, err)
-
+			require.NoError(t, err)
 			assert.True(t, test.areEqual && !lessLTGreater || !test.areEqual && lessLTGreater)
 			assert.True(t, !greaterLTLess)
 
 			lesserTpl, err := lesserTplVals.Value(ctx)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			greaterTpl, err := greaterTplVals.Value(ctx)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			lesserLess, err := lesserTpl.Less(types.Format_Default, greaterTpl)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			greaterLess, err := greaterTpl.Less(types.Format_Default, lesserTpl)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// needs to match with the types.Tuple Less implementation.
 			assert.True(t, lessLTGreater == lesserLess)
@@ -191,7 +191,7 @@ func TestTaggedTuple_Iter(t *testing.T) {
 		return false, nil
 	})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	if sum != 6 {
 		t.Error("Did not iterate all tags.")


### PR DESCRIPTION
This fixes dropped errors in `libraries/doltcore/row`, as well as replacing `assert.NoError()` with `require.NoError()`.