### PR TITLE
libraries/doltcore/rowconv: error handling

### DIFF
--- a/go/libraries/doltcore/rowconv/field_mapping.go
+++ b/go/libraries/doltcore/rowconv/field_mapping.go
@@ -229,6 +229,9 @@ func NameMapperFromFile(mappingFile string, FS filesys.ReadableFS) (NameMapper, 
 // TypedToUntypedMapping takes a schema and creates a mapping to an untyped schema with all the same columns.
 func TypedToUntypedMapping(sch schema.Schema) (*FieldMapping, error) {
 	untypedSch, err := untyped.UntypeSchema(sch)
+	if err != nil {
+		return nil, err
+	}
 
 	identityMap := make(map[uint64]uint64)
 	err = sch.GetAllCols().Iter(func(tag uint64, col schema.Column) (stop bool, err error) {

--- a/go/libraries/doltcore/rowconv/joiner_test.go
+++ b/go/libraries/doltcore/rowconv/joiner_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
@@ -123,20 +124,20 @@ func TestJoiner(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			j, err := NewJoiner(test.namedSchemas, test.namers)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			for _, tj := range test.toJoin {
 				rows := map[string]row.Row{}
 
 				for _, namedSch := range test.namedSchemas {
 					r, err := row.New(types.Format_Default, namedSch.Sch, tj.toJoinVals[namedSch.Name])
-					assert.NoError(t, err)
+					require.NoError(t, err)
 
 					rows[namedSch.Name] = r
 				}
 
 				joinedRow, err := j.Join(rows)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				joinedSch := j.GetSchema()
 				_, err = joinedRow.IterCols(func(tag uint64, val types.Value) (stop bool, err error) {
@@ -149,10 +150,10 @@ func TestJoiner(t *testing.T) {
 					return false, nil
 				})
 
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				splitRows, err := j.Split(joinedRow)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				assert.Equal(t, len(tj.toJoinVals), len(splitRows))
 
@@ -169,7 +170,7 @@ func TestJoiner(t *testing.T) {
 					assert.False(t, actual == nil || expectedVals == nil)
 
 					expected, err := row.New(types.Format_Default, sch, expectedVals)
-					assert.NoError(t, err)
+					require.NoError(t, err)
 					assert.True(t, row.AreEqual(actual, expected, sch))
 				}
 			}

--- a/go/libraries/doltcore/rowconv/row_converter_test.go
+++ b/go/libraries/doltcore/rowconv/row_converter_test.go
@@ -90,16 +90,17 @@ func TestRowConverter(t *testing.T) {
 
 func TestUnneccessaryConversion(t *testing.T) {
 	mapping, err := TagMapping(srcSch, srcSch)
-
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	vrw := types.NewMemoryValueStore()
 	rconv, err := NewRowConverter(context.Background(), vrw, mapping)
-
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !rconv.IdentityConverter {
-		t.Error("expected identity converter")
+		t.Fatal("expected identity converter")
 	}
 }
 

--- a/go/libraries/doltcore/rowconv/row_converter_test.go
+++ b/go/libraries/doltcore/rowconv/row_converter_test.go
@@ -45,7 +45,7 @@ var srcSch = schema.MustSchemaFromCols(srcCols)
 func TestRowConverter(t *testing.T) {
 	mapping, err := TypedToUntypedMapping(srcSch)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	vrw := types.NewMemoryValueStore()
 	rConv, err := NewRowConverter(context.Background(), vrw, mapping)
@@ -66,9 +66,9 @@ func TestRowConverter(t *testing.T) {
 		6: tt,
 	})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	outData, err := rConv.Convert(inRow)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	destSch := mapping.DestSch
 	expected, err := row.New(vrw.Format(), destSch, row.TaggedValues{
@@ -81,7 +81,7 @@ func TestRowConverter(t *testing.T) {
 		6: types.String(tt.String()),
 	})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	if !row.AreEqual(outData, expected, destSch) {
 		t.Error("\n", row.Fmt(context.Background(), expected, destSch), "!=\n", row.Fmt(context.Background(), outData, destSch))


### PR DESCRIPTION
This fixes dropped errors in `libraries/doltcore/rowconv` and replaces `assert.NoError()` with `require.NoError()` in tests.