### PR TITLE
Added DELIMITER newline termination

### DIFF
--- a/go/cmd/dolt/commands/sql_statement_scanner.go
+++ b/go/cmd/dolt/commands/sql_statement_scanner.go
@@ -17,6 +17,7 @@ package commands
 import (
 	"bufio"
 	"io"
+	"regexp"
 	"unicode"
 )
 
@@ -53,6 +54,8 @@ const (
 	backtick       = '`'
 )
 
+var scannerDelimiterRegex = regexp.MustCompile(`(?i)^\s*DELIMITER\s+(\S+)[ \t]*([\n]+|\S+\s*)?`)
+
 // ScanStatements is a split function for a Scanner that returns each SQL statement in the input as a token.
 func (s *statementScanner) scanStatements(data []byte, atEOF bool) (advance int, token []byte, err error) {
 	if atEOF && len(data) == 0 {
@@ -69,6 +72,10 @@ func (s *statementScanner) scanStatements(data []byte, atEOF bool) (advance int,
 	)
 
 	s.startLineNum = s.lineNum
+
+	if idxs := scannerDelimiterRegex.FindIndex(data); len(idxs) == 2 {
+		return idxs[1], data[0:idxs[1]], nil
+	}
 
 	for i := 0; i < len(data); i++ {
 		if !ignoreNextChar {

--- a/integration-tests/bats/sql.bats
+++ b/integration-tests/bats/sql.bats
@@ -810,7 +810,9 @@ DELIMITER ;   $
 INSERT INTO test VALUES (3, 3, 3);
 DELIMITER ********** ;
 INSERT INTO test VALUES (4, 4, 4)**********
-INSERT INTO test VALUES (5, 5, 5)
+DELIMITER &
+INSERT INTO test VALUES (5, 5, 5)&
+INSERT INTO test VALUES (6, 6, 6)
 SQL
     run dolt sql -q "CALL p1(3)" -r=csv
     [ "$status" -eq "0" ]
@@ -820,7 +822,8 @@ SQL
     [[ "$output" =~ "13,13,13" ]] || false
     [[ "$output" =~ "14,14,14" ]] || false
     [[ "$output" =~ "15,15,15" ]] || false
-    [[ "${#lines[@]}" = "6" ]] || false
+    [[ "$output" =~ "16,16,16" ]] || false
+    [[ "${#lines[@]}" = "7" ]] || false
 
     run dolt sql -q "CALL p1(20)" -r=csv
     [ "$status" -eq "0" ]
@@ -830,7 +833,8 @@ SQL
     [[ "$output" =~ "23,23,23" ]] || false
     [[ "$output" =~ "24,24,24" ]] || false
     [[ "$output" =~ "25,25,25" ]] || false
-    [[ "${#lines[@]}" = "6" ]] || false
+    [[ "$output" =~ "26,26,26" ]] || false
+    [[ "${#lines[@]}" = "7" ]] || false
 
     dolt sql <<SQL
 DELIMITER // ;


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/1495
`DELIMITER` had to be terminated by the previous delimiter, similar to other statements. However, MySQL does not have this requirement (a newline is adequate for termination). This PR removes this requirement.