### PR TITLE
libraries/doltcore/env/actions: error handling

### DIFF
--- a/go/libraries/doltcore/env/actions/branch.go
+++ b/go/libraries/doltcore/env/actions/branch.go
@@ -211,6 +211,9 @@ func createBranch(ctx context.Context, dbData env.DbData, newBranch, startingPoi
 // updateRootsForBranch writes the roots needed for a checkout and returns the updated work and staged hash.
 func updateRootsForBranch(ctx context.Context, dbData env.DbData, dref ref.DoltRef, brName string) (wrkHash hash.Hash, stgHash hash.Hash, err error) {
 	hasRef, err := dbData.Ddb.HasRef(ctx, dref)
+	if err != nil {
+		return hash.Hash{}, hash.Hash{}, err
+	}
 	if !hasRef {
 		return hash.Hash{}, hash.Hash{}, doltdb.ErrBranchNotFound
 	}

--- a/go/libraries/doltcore/env/actions/infer_schema_test.go
+++ b/go/libraries/doltcore/env/actions/infer_schema_test.go
@@ -494,7 +494,7 @@ func TestInferSchema(t *testing.T) {
 				assert.Equal(t, expectedType, col.TypeInfo, "column: %s - expected: %s got: %s", col.Name, expectedType.String(), col.TypeInfo.String())
 				return false, nil
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			if test.nullableCols == nil {
 				test.nullableCols = set.NewStrSet(nil)
@@ -505,7 +505,7 @@ func TestInferSchema(t *testing.T) {
 				assert.True(t, idx == -1 == test.nullableCols.Contains(col.Name), "%s unexpected nullability", col.Name)
 				return false, nil
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	}
 }

--- a/go/libraries/doltcore/env/actions/reset.go
+++ b/go/libraries/doltcore/env/actions/reset.go
@@ -227,6 +227,9 @@ func getUnionedTables(ctx context.Context, tables []string, stagedRoot, headRoot
 // resetDocs resets the working and staged docs with docs from head.
 func resetDocs(ctx context.Context, dbData env.DbData, headRoot *doltdb.RootValue, staged *doltdb.RootValue, docs doltdocs.Docs) (newStgRoot *doltdb.RootValue, err error) {
 	docs, err = doltdocs.GetDocsFromRoot(ctx, headRoot, doltdocs.GetDocNamesFromDocs(docs)...)
+	if err != nil {
+		return nil, err
+	}
 
 	working, err := env.WorkingRoot(ctx, dbData.Ddb, dbData.Rsr)
 	if err != nil {


### PR DESCRIPTION
This fixes dropped errors in `libraries/doltcore/env/actions` and replaces use of `assert.NoError()` with `require.NoError()`.