### PR TITLE
fixed dropped errors in libraries/doltcore/env

### DIFF
--- a/go/libraries/doltcore/env/config.go
+++ b/go/libraries/doltcore/env/config.go
@@ -88,10 +88,13 @@ func loadDoltCliConfig(hdp HomeDirProvider, fs filesys.ReadWriteFS) (*DoltCliCon
 	ch := config.NewConfigHierarchy()
 
 	gPath, err := getGlobalCfgPath(hdp)
+	if err != nil {
+		return nil, err
+	}
+
 	lPath := getLocalConfigPath()
 
 	gCfg, err := ensureGlobalConfig(gPath, fs)
-
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -522,38 +522,35 @@ func (dEnv *DoltEnv) UpdateStagedRoot(ctx context.Context, newRoot *doltdb.RootV
 // todo: move this out of env to actions
 func (dEnv *DoltEnv) PutTableToWorking(ctx context.Context, sch schema.Schema, rows types.Map, indexData types.Map, tableName string, autoVal types.Value) error {
 	root, err := dEnv.WorkingRoot(ctx)
-
 	if err != nil {
 		return doltdb.ErrNomsIO
 	}
 
 	vrw := dEnv.DoltDB.ValueReadWriter()
 	schVal, err := encoding.MarshalSchemaAsNomsValue(ctx, vrw, sch)
-
 	if err != nil {
 		return ErrMarshallingSchema
 	}
 
 	tbl, err := doltdb.NewTable(ctx, vrw, schVal, rows, indexData, autoVal)
-
 	if err != nil {
 		return err
 	}
 
 	newRoot, err := root.PutTable(ctx, tableName, tbl)
-
 	if err != nil {
 		return err
 	}
 
 	rootHash, err := root.HashOf()
-
 	if err != nil {
 		return err
 	}
 
 	newRootHash, err := newRoot.HashOf()
-
+	if err != nil {
+		return err
+	}
 	if rootHash == newRootHash {
 		return nil
 	}

--- a/go/libraries/doltcore/envtestutils/history.go
+++ b/go/libraries/doltcore/envtestutils/history.go
@@ -142,6 +142,7 @@ func UpdateTables(t *testing.T, ctx context.Context, root *doltdb.RootValue, tbl
 		}
 
 		schVal, err := encoding.MarshalSchemaAsNomsValue(ctx, root.VRW(), sch)
+		require.NoError(t, err)
 
 		indexData, err := types.NewMap(ctx, root.VRW())
 		require.NoError(t, err)


### PR DESCRIPTION
This fixes dropped errors in `libraries/doltcore/env` and `libraries/doltcore/envtestutils`.