### PR TITLE
libraries/doltcore/fkconstrain: fix dropped errors

### DIFF
--- a/go/libraries/doltcore/fkconstrain/validate.go
+++ b/go/libraries/doltcore/fkconstrain/validate.go
@@ -201,6 +201,9 @@ func parseDiff(d *nomsdiff.Difference) (oldTV, newTV row.TaggedValues, changes m
 				currNewTag = MaxTag
 			} else {
 				currNewTag, currNewVal, err = nextTagAndValue(newItr)
+				if err != nil {
+					return nil, nil, nil, err
+				}
 			}
 		}
 
@@ -213,6 +216,9 @@ func parseDiff(d *nomsdiff.Difference) (oldTV, newTV row.TaggedValues, changes m
 				currOldTag = MaxTag
 			} else {
 				currOldTag, currOldVal, err = nextTagAndValue(oldItr)
+				if err != nil {
+					return nil, nil, nil, err
+				}
 			}
 		}
 


### PR DESCRIPTION
This fixes two dropped error variables in `libraries/doltcore/fkconstrain`.