### PR TITLE
Fixed some VARBINARY strings reading their length incorrectly

### DIFF
--- a/go/store/types/tuple.go
+++ b/go/store/types/tuple.go
@@ -654,8 +654,15 @@ func (t Tuple) TupleLess(nbf *NomsBinFormat, otherTuple Tuple) (bool, error) {
 			dec.offset += 1
 			otherDec.offset += 1
 
-		case StringKind, InlineBlobKind:
+		case StringKind:
 			size, otherSize := uint32(dec.readCount()), uint32(otherDec.readCount())
+			start, otherStart := dec.offset, otherDec.offset
+			dec.offset += size
+			otherDec.offset += otherSize
+			res = bytes.Compare(dec.buff[start:dec.offset], otherDec.buff[otherStart:otherDec.offset])
+
+		case InlineBlobKind:
+			size, otherSize := uint32(dec.readUint16()), uint32(otherDec.readUint16())
 			start, otherStart := dec.offset, otherDec.offset
 			dec.offset += size
 			otherDec.offset += otherSize

--- a/integration-tests/bats/regression-tests.bats
+++ b/integration-tests/bats/regression-tests.bats
@@ -53,3 +53,25 @@ SELECT DISTINCT YM.YW AS YW, (SELECT YW FROM YF WHERE YF.XB = YM.XB) AS YF_YW,
     [[ "$output" =~ '"","",,"","","","",""' ]] || false
     [[ "${#lines[@]}" = "2" ]] || false
 }
+
+@test "regression-tests: VARBINARY incorrect length reading" {
+    # caught by fuzzer
+    dolt sql <<SQL
+CREATE TABLE TBXjogjbUk (
+  pKVZ7F set('rxb9@ud94.t','py1lf7n1t*dfr') NOT NULL,
+  OrYQI7 mediumint NOT NULL,
+  wEU2wL varbinary(9219) NOT NULL,
+  nE3O6H int NOT NULL,
+  iIMgVg varchar(11833),
+  PRIMARY KEY (pKVZ7F,OrYQI7,wEU2wL,nE3O6H)
+);
+SQL
+    dolt sql -q "REPLACE INTO TBXjogjbUk VALUES (1,-5667274,'wRL',-1933632415,'H');"
+    dolt sql -q "REPLACE INTO TBXjogjbUk VALUES (1,-5667274,'wR',-1933632415,'H');"
+    run dolt sql -q "SELECT * FROM TBXjogjbUk;" -r=csv
+    [ "$status" -eq "0" ]
+    [[ "$output" =~ "pKVZ7F,OrYQI7,wEU2wL,nE3O6H,iIMgVg" ]] || false
+    [[ "$output" =~ "rxb9@ud94.t,-5667274,wR,-1933632415,H" ]] || false
+    [[ "$output" =~ "rxb9@ud94.t,-5667274,wRL,-1933632415,H" ]] || false
+    [[ "${#lines[@]}" = "3" ]] || false
+}


### PR DESCRIPTION
Some `VARBINARY` strings were misreading their length, leading to other values reading garbage and erroring. Not sure how some `VARBINARY` strings were reading correctly, but this fixes the issue. Was caught by the fuzzer, but I stripped out the other queries for the bats test (still reproduces without them).