### PR TITLE
replace io.Copy to improve clone perf

### DIFF
--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -1329,10 +1329,6 @@ func (nbs *NomsBlockStore) WriteTableFile(ctx context.Context, fileId string, nu
 			}
 		}()
 
-		// so slow
-		// _, err = io.Copy(f, rd)
-		// return err
-
 		return writeTo(f, rd, copyTableFileBufferSize)
 	}()
 


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/1530 by replacing a call to io.Copy with a new function writeTo.  Existing reader implementation replaces read calls to HTTP requests and larger read sizes here has a very big impact on Perf.

takes gcs clone of 600MB repo from 

```
real    28m2.168s
user    0m21.606s
sys     0m15.104s
```

to

```
real	0m17.885s
user	0m1.607s
sys	0m2.443s
```

has similar performance improvements for AWS repos and has small Dolthub clone perf improvements.

