### PR TITLE
store: more error handling

### DIFF
--- a/go/store/cmd/noms/noms_map.go
+++ b/go/store/cmd/noms/noms_map.go
@@ -69,6 +69,7 @@ func nomsMapNew(ctx context.Context, dbStr string, args []string) int {
 	d.PanicIfError(err)
 	db := sp.GetDatabase(ctx)
 	m, err := types.NewMap(ctx, db)
+	d.PanicIfError(err)
 	applyMapEdits(ctx, db, sp, m, nil, args)
 	return 0
 }

--- a/go/store/cmd/noms/noms_root.go
+++ b/go/store/cmd/noms/noms_root.go
@@ -90,6 +90,7 @@ func runRoot(ctx context.Context, args []string) int {
 	util.CheckErrorNoUsage(err)
 	defer db.Close()
 	v, err := db.ReadValue(ctx, h)
+	util.CheckErrorNoUsage(err)
 	if !validate(ctx, db.Format(), v) {
 		return 1
 	}

--- a/go/store/cmd/noms/noms_sync_test.go
+++ b/go/store/cmd/noms/noms_sync_test.go
@@ -154,6 +154,7 @@ func (s *nomsSyncTestSuite) TestSync_Issue2598() {
 	sinkDatasetSpec := spec.CreateValueSpecString("nbs", s.DBDir2, "dest")
 	sout, _ := s.MustRun(main, []string{"sync", sourceDataset, sinkDatasetSpec})
 	cs, err = nbs.NewLocalStore(context.Background(), types.Format_Default.VersionString(), s.DBDir2, clienttest.DefaultMemTableSize)
+	s.NoError(err)
 	db := datas.NewDatabase(cs)
 	dest, err := db.GetDataset(context.Background(), "dest")
 	s.NoError(err)

--- a/go/store/datas/puller.go
+++ b/go/store/datas/puller.go
@@ -367,10 +367,12 @@ func (p *Puller) getCmp(ctx context.Context, twDetails *TreeWalkEventDetails, le
 				}
 
 				refs := make(map[hash.Hash]int)
-				err = types.WalkRefs(chnk, p.fmt, func(r types.Ref) error {
+				if err := types.WalkRefs(chnk, p.fmt, func(r types.Ref) error {
 					refs[r.TargetHash()] = int(r.Height())
 					return nil
-				})
+				}); ae.SetIfError(err) {
+					return
+				}
 
 				processed <- CmpChnkAndRefs{cmpChnk: cmpChnk, refs: refs}
 			}

--- a/go/store/diff/apply_patch_test.go
+++ b/go/store/diff/apply_patch_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/d"
@@ -71,7 +72,7 @@ func TestCommonPrefixCount(t *testing.T) {
 	for i, tc := range testCases {
 		path, expected := tc[0].(string), tc[1].(int)
 		p, err := types.ParsePath(path)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Equal(expected, commonPrefixCount(lastPath, p), "failed for paths[%d]: %s", i, path)
 		lastPath = p
 	}
@@ -216,7 +217,7 @@ func TestUpdateNode(t *testing.T) {
 		stack := &patchStack{}
 		se := &stackElem{path: []types.PathPart{pp}, pathPart: pp, changeType: types.DiffChangeModified, oldValue: ov, newValue: nv}
 		updated, err := stack.updateNode(context.Background(), se, parent)
-		assert.NoError(err)
+		require.NoError(t, err)
 		testVal := f(updated)
 		assert.True(exp.Equals(testVal), "%s != %s", nv, testVal)
 	}
@@ -226,57 +227,57 @@ func TestUpdateNode(t *testing.T) {
 	newVal := types.String("YooHoo")
 
 	s1, err := types.NewStruct(types.Format_7_18, "TestStruct", types.StructData{"f1": types.Float(1), "f2": oldVal})
-	assert.NoError(err)
+	require.NoError(t, err)
 	pp = types.FieldPath{Name: "f2"}
 	doTest(pp, s1, oldVal, newVal, newVal, func(parent types.Value) types.Value {
 		return mustGetValue(parent.(types.Struct).MaybeGet("f2"))
 	})
 
 	l1, err := types.NewList(context.Background(), vs, types.String("one"), oldVal, types.String("three"))
-	assert.NoError(err)
+	require.NoError(t, err)
 	pp = types.IndexPath{Index: types.Float(1)}
 	doTest(pp, l1, oldVal, newVal, newVal, func(parent types.Value) types.Value {
 		return mustValue(parent.(types.List).Get(context.Background(), 1))
 	})
 
 	m1, err := types.NewMap(context.Background(), vs, types.String("k1"), types.Float(1), types.String("k2"), oldVal)
-	assert.NoError(err)
+	require.NoError(t, err)
 	pp = types.IndexPath{Index: types.String("k2")}
 	doTest(pp, m1, oldVal, newVal, newVal, func(parent types.Value) types.Value {
 		return mustGetValue(parent.(types.Map).MaybeGet(context.Background(), types.String("k2")))
 	})
 
 	k1, err := types.NewStruct(types.Format_7_18, "Sizes", types.StructData{"height": types.Float(200), "width": types.Float(300)})
-	assert.NoError(err)
+	require.NoError(t, err)
 	_, err = vs.WriteValue(context.Background(), k1)
-	assert.NoError(err)
+	require.NoError(t, err)
 	m1, err = types.NewMap(context.Background(), vs, k1, oldVal)
-	assert.NoError(err)
+	require.NoError(t, err)
 	h, err := k1.Hash(types.Format_7_18)
-	assert.NoError(err)
+	require.NoError(t, err)
 	pp = types.HashIndexPath{Hash: h}
 	doTest(pp, m1, oldVal, newVal, newVal, func(parent types.Value) types.Value {
 		return mustGetValue(parent.(types.Map).MaybeGet(context.Background(), k1))
 	})
 
 	set1, err := types.NewSet(context.Background(), vs, oldVal, k1)
-	assert.NoError(err)
+	require.NoError(t, err)
 	pp = types.IndexPath{Index: oldVal}
 	exp, err := types.NewSet(context.Background(), vs, newVal, k1)
-	assert.NoError(err)
+	require.NoError(t, err)
 	doTest(pp, set1, oldVal, newVal, exp, func(parent types.Value) types.Value {
 		return parent
 	})
 
 	k2, err := types.NewStruct(types.Format_7_18, "Sizes", types.StructData{"height": types.Float(300), "width": types.Float(500)})
-	assert.NoError(err)
+	require.NoError(t, err)
 	set1, err = types.NewSet(context.Background(), vs, oldVal, k1)
-	assert.NoError(err)
+	require.NoError(t, err)
 	h, err = k1.Hash(types.Format_7_18)
-	assert.NoError(err)
+	require.NoError(t, err)
 	pp = types.HashIndexPath{Hash: h}
 	exp, err = types.NewSet(context.Background(), vs, oldVal, k2)
-	assert.NoError(err)
+	require.NoError(t, err)
 	doTest(pp, set1, k1, k2, exp, func(parent types.Value) types.Value {
 		return parent
 	})

--- a/go/store/diff/diff_test.go
+++ b/go/store/diff/diff_test.go
@@ -156,7 +156,7 @@ func TestNomsDiffPrintMap(t *testing.T) {
 		assert.Equal(expected, buf.String())
 
 		paths, err := pathsFromDiff(m1, m2, leftRight)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Equal(expectedPaths, paths)
 	}
 
@@ -203,7 +203,7 @@ func TestNomsDiffPrintSet(t *testing.T) {
   }
 `
 	h3, err := mm3.Hash(types.Format_7_18)
-	assert.NoError(err)
+	require.NoError(t, err)
 	h3x, err := mm3x.Hash(types.Format_7_18)
 	require.NoError(t, err)
 	expectedPaths2 := []string{
@@ -222,16 +222,16 @@ func TestNomsDiffPrintSet(t *testing.T) {
 		assert.Equal(expected1, buf.String())
 
 		paths, err := pathsFromDiff(s1, s2, leftRight)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Equal(expectedPaths1, paths)
 
 		buf = &bytes.Buffer{}
 		err = PrintDiff(context.Background(), buf, s3, s4, leftRight)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Equal(expected2, buf.String())
 
 		paths, err = pathsFromDiff(s3, s4, leftRight)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Equal(expectedPaths2, paths)
 	}
 
@@ -334,16 +334,16 @@ func TestNomsDiffPrintStruct(t *testing.T) {
 		assert.Equal(expected1, buf.String())
 
 		paths, err := pathsFromDiff(m1, m2, leftRight)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Equal(expectedPaths1, paths)
 
 		buf = &bytes.Buffer{}
 		err = PrintDiff(context.Background(), buf, s3, s4, leftRight)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Equal(expected2, buf.String())
 
 		paths, err = pathsFromDiff(s3, s4, leftRight)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Equal(expectedPaths2, paths)
 	}
 
@@ -372,9 +372,9 @@ func TestNomsDiffPrintMapWithStructKeys(t *testing.T) {
 `
 
 	m1, err := types.NewMap(context.Background(), vs, k1, types.Bool(true))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	m2, err := types.NewMap(context.Background(), vs, k1, types.Bool(false))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tf := func(leftRight bool) {
 		buf := &bytes.Buffer{}
 		PrintDiff(context.Background(), buf, m1, m2, leftRight)
@@ -432,29 +432,29 @@ func TestNomsDiffPrintList(t *testing.T) {
 	tf := func(leftRight bool) {
 		buf := &bytes.Buffer{}
 		err := PrintDiff(context.Background(), buf, l1, l2, leftRight)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Equal(expected1, buf.String())
 
 		paths, err := pathsFromDiff(l1, l2, leftRight)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Equal(expectedPaths1, paths)
 
 		buf = &bytes.Buffer{}
 		err = PrintDiff(context.Background(), buf, l3, l4, leftRight)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Equal(expected2, buf.String())
 
 		paths, err = pathsFromDiff(l3, l4, leftRight)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Equal(expectedPaths2, paths)
 
 		buf = &bytes.Buffer{}
 		err = PrintDiff(context.Background(), buf, l5, l6, leftRight)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Equal(expected3, buf.String())
 
 		paths, err = pathsFromDiff(l5, l6, leftRight)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Equal(expectedPaths3, paths)
 	}
 
@@ -471,18 +471,18 @@ func TestNomsDiffPrintBlob(t *testing.T) {
 	expected := "-   Blob (2.0 kB)\n+   Blob (11 B)\n"
 	expectedPaths1 := []string{``}
 	b1, err := types.NewBlob(context.Background(), vs, strings.NewReader(strings.Repeat("x", 2*1024)))
-	assert.NoError(err)
+	require.NoError(t, err)
 	b2, err := types.NewBlob(context.Background(), vs, strings.NewReader("Hello World"))
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	tf := func(leftRight bool) {
 		buf := &bytes.Buffer{}
 		err = PrintDiff(context.Background(), buf, b1, b2, leftRight)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Equal(expected, buf.String())
 
 		paths, err := pathsFromDiff(b1, b2, leftRight)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Equal(expectedPaths1, paths)
 	}
 
@@ -496,34 +496,34 @@ func TestNomsDiffPrintType(t *testing.T) {
 	expected1 := "-   List<Float>\n+   List<String>\n"
 	expectedPaths1 := []string{""}
 	t1, err := types.MakeListType(types.PrimitiveTypeMap[types.FloatKind])
-	assert.NoError(err)
+	require.NoError(t, err)
 	t2, err := types.MakeListType(types.PrimitiveTypeMap[types.StringKind])
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	expected2 := "-   List<Float>\n+   Set<String>\n"
 	expectedPaths2 := []string{``}
 	t3, err := types.MakeListType(types.PrimitiveTypeMap[types.FloatKind])
-	assert.NoError(err)
+	require.NoError(t, err)
 	t4, err := types.MakeSetType(types.PrimitiveTypeMap[types.StringKind])
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	tf := func(leftRight bool) {
 		buf := &bytes.Buffer{}
 		err = PrintDiff(context.Background(), buf, t1, t2, leftRight)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Equal(expected1, buf.String())
 
 		paths, err := pathsFromDiff(t1, t2, leftRight)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Equal(expectedPaths1, paths)
 
 		buf = &bytes.Buffer{}
 		err = PrintDiff(context.Background(), buf, t3, t4, leftRight)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Equal(expected2, buf.String())
 
 		paths, err = pathsFromDiff(t3, t4, leftRight)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Equal(expectedPaths2, paths)
 	}
 
@@ -539,18 +539,18 @@ func TestNomsDiffPrintRef(t *testing.T) {
 	l1 := createList(1)
 	l2 := createList(2)
 	r1, err := types.NewRef(l1, types.Format_7_18)
-	assert.NoError(err)
+	require.NoError(t, err)
 	r2, err := types.NewRef(l2, types.Format_7_18)
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	tf := func(leftRight bool) {
 		buf := &bytes.Buffer{}
 		err := PrintDiff(context.Background(), buf, r1, r2, leftRight)
-		assert.NoError(err)
+		require.NoError(t, err)
 		test.EqualsIgnoreHashes(t, expected, buf.String())
 
 		paths, err := pathsFromDiff(r1, r2, leftRight)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Equal(expectedPaths1, paths)
 	}
 

--- a/go/store/diff/diff_test.go
+++ b/go/store/diff/diff_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/dolt/go/store/d"
 	"github.com/dolthub/dolt/go/store/types"
@@ -204,6 +205,7 @@ func TestNomsDiffPrintSet(t *testing.T) {
 	h3, err := mm3.Hash(types.Format_7_18)
 	assert.NoError(err)
 	h3x, err := mm3x.Hash(types.Format_7_18)
+	require.NoError(t, err)
 	expectedPaths2 := []string{
 		fmt.Sprintf("[#%s]", h3),
 		fmt.Sprintf("[#%s]", h3x),

--- a/go/store/diff/patch_test.go
+++ b/go/store/diff/patch_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/dolt/go/store/types"
 )
@@ -60,11 +61,11 @@ func TestPatchPathPartCompare(t *testing.T) {
 
 	for i, tc := range testCases {
 		res01, err := pathPartCompare(types.Format_7_18, tc[0], tc[1])
-		assert.NoError(err)
+		require.NoError(t, err)
 		res00, err := pathPartCompare(types.Format_7_18, tc[0], tc[0])
-		assert.NoError(err)
+		require.NoError(t, err)
 		res10, err := pathPartCompare(types.Format_7_18, tc[1], tc[0])
-		assert.NoError(err)
+		require.NoError(t, err)
 
 		assert.Equal(-1, res01, "test case %d failed, pp0: %s, pp1: %s", i, tc[0], tc[1])
 		assert.Equal(0, res00, "test case %d failed, pp0: %s, pp1: %s", i, tc[0], tc[1])
@@ -88,11 +89,11 @@ func TestPatchPathIsLess(t *testing.T) {
 		p0 := mustParsePath(assert, tc[0])
 		p1 := mustParsePath(assert, tc[1])
 		zeroLTOne, err := pathIsLess(types.Format_7_18, p0, p1)
-		assert.NoError(err)
+		require.NoError(t, err)
 		zeroLTZero, err := pathIsLess(types.Format_7_18, p0, p0)
-		assert.NoError(err)
+		require.NoError(t, err)
 		oneLTZero, err := pathIsLess(types.Format_7_18, p1, p0)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.True(zeroLTOne, "test case %d failed", i)
 		assert.False(zeroLTZero, "test case %d failed", i)
 		assert.False(oneLTZero, "test case %d failed", i)

--- a/go/store/nomdl/parser.go
+++ b/go/store/nomdl/parser.go
@@ -530,6 +530,10 @@ func (p *Parser) parseMap(ctx context.Context) (types.Map, error) {
 
 		p.lex.eat(':')
 		value, err := p.parseValue(ctx)
+		if err != nil {
+			return types.EmptyMap, err
+		}
+
 		me = me.Set(key, value)
 
 		if p.lex.eatIf(',') {

--- a/go/store/nomdl/parser_test.go
+++ b/go/store/nomdl/parser_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/d"
@@ -57,7 +58,7 @@ func newTestValueStore() *types.ValueStore {
 func assertParseType(t *testing.T, code string, expected *types.Type) {
 	t.Run(code, func(t *testing.T) {
 		actual, err := ParseType(code)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, expected.Equals(actual), "Expected: %s, Actual: %s", mustString(expected.Describe(context.Background())), mustString(actual.Describe(context.Background())))
 	})
 }


### PR DESCRIPTION
This fixes dropped errors and replaces `assert.NoError()` in multiple `store` subpackages.