### PR TITLE
cmd/dolt/commands: fix dropped errors

### DIFF
--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -282,9 +282,16 @@ func parseDiffArgs(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.ArgPar
 
 func getDiffRoots(ctx context.Context, dEnv *env.DoltEnv, args []string, isCached bool) (from, to *doltdb.RootValue, leftover []string, err error) {
 	headRoot, err := dEnv.HeadRoot(ctx)
-	stagedRoot, err := dEnv.StagedRoot(ctx)
-	workingRoot, err := dEnv.WorkingRoot(ctx)
+	if err != nil {
+		return nil, nil, nil, err
+	}
 
+	stagedRoot, err := dEnv.StagedRoot(ctx)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	workingRoot, err := dEnv.WorkingRoot(ctx)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/go/cmd/dolt/commands/ls.go
+++ b/go/cmd/dolt/commands/ls.go
@@ -196,10 +196,13 @@ func listTableVerbose(ctx context.Context, tbl string, root *doltdb.RootValue) (
 
 func printSystemTables(ctx context.Context, root *doltdb.RootValue, ddb *doltdb.DoltDB, verbose bool) errhand.VerboseError {
 	perSysTbls, err := doltdb.GetPersistedSystemTables(ctx, root)
-	genSysTbls, err := doltdb.GetGeneratedSystemTables(ctx, root)
-
 	if err != nil {
-		return errhand.BuildDError("error retrieving table names").AddCause(err).Build()
+		return errhand.BuildDError("error retrieving persisted table names").AddCause(err).Build()
+	}
+
+	genSysTbls, err := doltdb.GetGeneratedSystemTables(ctx, root)
+	if err != nil {
+		return errhand.BuildDError("error retrieving generated table names").AddCause(err).Build()
 	}
 
 	cli.Println("System tables:")


### PR DESCRIPTION
This fixes some dropped errors in `diff` and `ls`.