### PR TITLE
store/perf/suite: errors and tests

### DIFF
--- a/go/store/perf/suite/suite.go
+++ b/go/store/perf/suite/suite.go
@@ -268,14 +268,14 @@ func Run(datasetID string, t *testing.T, suiteT perfSuiteT) {
 					"total":   types.Float(info.total.Nanoseconds()),
 				})
 
-				assert.NoError(err)
+				require.NoError(t, err)
 				timesSlice = append(timesSlice, types.String(name), st)
 			}
 			reps[i], err = types.NewMap(context.Background(), db, timesSlice...)
 		}
 
 		l, err := types.NewList(context.Background(), db, reps...)
-		assert.NoError(err)
+		require.NoError(t, err)
 		record, err := types.NewStruct(db.Format(), "", map[string]types.Value{
 			"environment":      suite.getEnvironment(db),
 			"nomsRevision":     types.String(suite.getGitHead(path.Join(suite.AtticLabs, "noms"))),
@@ -285,9 +285,9 @@ func Run(datasetID string, t *testing.T, suiteT perfSuiteT) {
 		require.NoError(t, err)
 
 		ds, err := db.GetDataset(context.Background(), *perfPrefixFlag+datasetID)
-		assert.NoError(err)
+		require.NoError(t, err)
 		_, err = db.CommitValue(context.Background(), ds, record)
-		assert.NoError(err)
+		require.NoError(t, err)
 	}()
 
 	if t, ok := suiteT.(testifySuite.SetupAllSuite); ok {
@@ -382,7 +382,7 @@ func (suite *PerfSuite) NewAssert() *assert.Assertions {
 // the perf test suite. Files will be prefixed with the test's dataset ID
 func (suite *PerfSuite) TempFile() *os.File {
 	f, err := ioutil.TempFile("", suite.tempPrefix())
-	assert.NoError(suite.T, err)
+	require.NoError(suite.T, err)
 	suite.tempFiles = append(suite.tempFiles, f)
 	return f
 }
@@ -392,7 +392,7 @@ func (suite *PerfSuite) TempFile() *os.File {
 // dataset ID.
 func (suite *PerfSuite) TempDir() string {
 	d, err := ioutil.TempDir("", suite.tempPrefix())
-	assert.NoError(suite.T, err)
+	require.NoError(suite.T, err)
 	suite.tempDirs = append(suite.tempDirs, d)
 	return d
 }
@@ -415,15 +415,13 @@ func (suite *PerfSuite) Pause(fn func()) {
 // Large CSV files in testdata are broken up into foo.a, foo.b, etc to get
 // around GitHub file size restrictions.
 func (suite *PerfSuite) OpenGlob(pattern ...string) []io.Reader {
-	assert := suite.NewAssert()
-
 	glob, err := filepath.Glob(path.Join(pattern...))
-	assert.NoError(err)
+	require.NoError(suite.T, err)
 
 	files := make([]io.Reader, len(glob))
 	for i, m := range glob {
 		f, err := os.Open(m)
-		assert.NoError(err)
+		require.NoError(suite.T, err)
 		files[i] = f
 	}
 
@@ -432,9 +430,8 @@ func (suite *PerfSuite) OpenGlob(pattern ...string) []io.Reader {
 
 // CloseGlob closes all of the files, designed to be used with OpenGlob.
 func (suite *PerfSuite) CloseGlob(files []io.Reader) {
-	assert := suite.NewAssert()
 	for _, f := range files {
-		assert.NoError(f.(*os.File).Close())
+		require.NoError(suite.T, f.(*os.File).Close())
 	}
 }
 
@@ -455,8 +452,6 @@ func callSafe(name string, fun reflect.Value, args ...interface{}) (err error) {
 }
 
 func (suite *PerfSuite) getEnvironment(vrw types.ValueReadWriter) types.Value {
-	assert := suite.NewAssert()
-
 	env := environment{
 		DiskUsages: map[string]disk.UsageStat{},
 		Cpus:       map[int]cpu.InfoStat{},
@@ -464,30 +459,30 @@ func (suite *PerfSuite) getEnvironment(vrw types.ValueReadWriter) types.Value {
 	}
 
 	partitions, err := disk.Partitions(false)
-	assert.NoError(err)
+	require.NoError(suite.T, err)
 	for _, p := range partitions {
 		usage, err := disk.Usage(p.Mountpoint)
-		assert.NoError(err)
+		require.NoError(suite.T, err)
 		env.DiskUsages[p.Mountpoint] = *usage
 		env.Partitions[p.Device] = p
 	}
 
 	cpus, err := cpu.Info()
-	assert.NoError(err)
+	require.NoError(suite.T, err)
 	for i, c := range cpus {
 		env.Cpus[i] = c
 	}
 
 	mem, err := mem.VirtualMemory()
-	assert.NoError(err)
+	require.NoError(suite.T, err)
 	env.Mem = *mem
 
 	hostInfo, err := host.Info()
-	assert.NoError(err)
+	require.NoError(suite.T, err)
 	env.Host = *hostInfo
 
 	envStruct, err := marshal.Marshal(context.Background(), vrw, env)
-	assert.NoError(err)
+	require.NoError(suite.T, err)
 	return envStruct
 }
 

--- a/go/store/perf/suite/suite.go
+++ b/go/store/perf/suite/suite.go
@@ -108,6 +108,7 @@ import (
 	"github.com/shirou/gopsutil/host"
 	"github.com/shirou/gopsutil/mem"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	testifySuite "github.com/stretchr/testify/suite"
 
 	"github.com/dolthub/dolt/go/libraries/utils/osutil"
@@ -281,6 +282,7 @@ func Run(datasetID string, t *testing.T, suiteT perfSuiteT) {
 			"testdataRevision": types.String(suite.getGitHead(suite.Testdata)),
 			"reps":             l,
 		})
+		require.NoError(t, err)
 
 		ds, err := db.GetDataset(context.Background(), *perfPrefixFlag+datasetID)
 		assert.NoError(err)

--- a/go/store/perf/suite/suite_test.go
+++ b/go/store/perf/suite/suite_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/dolt/go/store/spec"
 	"github.com/dolthub/dolt/go/store/types"
@@ -54,9 +55,9 @@ func (s *testSuite) TestDatabase() {
 	assert := s.NewAssert()
 	val := types.Bool(true)
 	r, err := s.Database.WriteValue(context.Background(), val)
-	assert.NoError(err)
+	require.NoError(s.T, err)
 	v2, err := s.Database.ReadValue(context.Background(), r.TargetHash())
-	assert.NoError(err)
+	require.NoError(s.T, err)
 	assert.True(v2.Equals(val))
 }
 
@@ -70,15 +71,21 @@ func (s *testSuite) TestGlob() {
 	f := s.TempFile()
 	f.Close()
 
-	create := func(suffix string) {
+	create := func(suffix string) error {
 		f, err := os.Create(f.Name() + suffix)
-		assert.NoError(err)
+		if err != nil {
+			return err
+		}
 		f.Close()
+		return nil
 	}
 
-	create("a")
-	create(".a")
-	create(".b")
+	err := create("a")
+	require.NoError(s.T, err)
+	err = create(".a")
+	require.NoError(s.T, err)
+	err = create(".b")
+	require.NoError(s.T, err)
 
 	glob := s.OpenGlob(f.Name() + ".*")
 	assert.Equal(2, len(glob))
@@ -87,7 +94,7 @@ func (s *testSuite) TestGlob() {
 
 	s.CloseGlob(glob)
 	b := make([]byte, 16)
-	_, err := glob[0].Read(b)
+	_, err = glob[0].Read(b)
 	assert.Error(err)
 	_, err = glob[1].Read(b)
 	assert.Error(err)
@@ -167,7 +174,7 @@ func runTestSuite(t *testing.T, mem bool) {
 
 	// Write test results to our own temporary LDB database.
 	ldbDir, err := ioutil.TempDir("", "suite.TestSuite")
-	assert.NoError(err)
+	require.NoError(t, err)
 	defer os.RemoveAll(ldbDir)
 
 	flagVal, repeatFlagVal, memFlagVal := *perfFlag, *perfRepeatFlag, *perfMemFlag
@@ -207,10 +214,10 @@ func runTestSuite(t *testing.T, mem bool) {
 
 	// The results should have been written to the "ds" dataset.
 	sp, err := spec.ForDataset(ldbDir + "::ds")
-	assert.NoError(err)
+	require.NoError(t, err)
 	defer sp.Close()
 	headVal, ok, err := sp.GetDataset(context.Background()).MaybeHeadValue()
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.True(ok)
 	head := headVal.(types.Struct)
 
@@ -218,7 +225,7 @@ func runTestSuite(t *testing.T, mem bool) {
 
 	getOrFail := func(s types.Struct, f string) types.Value {
 		val, ok, err := s.MaybeGet(f)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.True(ok)
 		return val
 	}
@@ -268,12 +275,12 @@ func runTestSuite(t *testing.T, mem bool) {
 			return nil
 		})
 
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Equal(i, len(expectedTests))
 		return nil
 	})
 
-	assert.NoError(err)
+	require.NoError(t, err)
 }
 
 func TestPrefixFlag(t *testing.T) {
@@ -282,7 +289,7 @@ func TestPrefixFlag(t *testing.T) {
 
 	// Write test results to a temporary database.
 	ldbDir, err := ioutil.TempDir("", "suite.TestSuite")
-	assert.NoError(err)
+	require.NoError(t, err)
 	defer os.RemoveAll(ldbDir)
 
 	flagVal, prefixFlagVal := *perfFlag, *perfPrefixFlag
@@ -295,16 +302,16 @@ func TestPrefixFlag(t *testing.T) {
 
 	// The results should have been written to "foo/my-prefix/test" not "my-prefix/test".
 	sp, err := spec.ForDataset(ldbDir + "::my-prefix/test")
-	assert.NoError(err)
+	require.NoError(t, err)
 	defer sp.Close()
 	_, ok := sp.GetDataset(context.Background()).MaybeHead()
 	assert.False(ok)
 
 	sp, err = spec.ForDataset(ldbDir + "::foo/my-prefix/test")
-	assert.NoError(err)
+	require.NoError(t, err)
 	defer sp.Close()
 	_, ok, err = sp.GetDataset(context.Background()).MaybeHeadValue()
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.True(ok)
 }
 


### PR DESCRIPTION
This fixes a dropped error and replaces most `assert.NoError()` with `require.NoError()`.