### PR TITLE
index schema cache

### DIFF
--- a/go/libraries/doltcore/table/editor/pk_table_editor.go
+++ b/go/libraries/doltcore/table/editor/pk_table_editor.go
@@ -249,19 +249,18 @@ func ContainsIndexedKey(ctx context.Context, te TableEditor, key types.Tuple, in
 
 // GetIndexedRows returns all matching rows for the given key on the index. The key is assumed to be in the format
 // expected of the index, similar to searching on the index map itself.
-func GetIndexedRows(ctx context.Context, te TableEditor, key types.Tuple, indexName string) ([]row.Row, error) {
+func GetIndexedRows(ctx context.Context, te TableEditor, key types.Tuple, indexName string, idxSch schema.Schema) ([]row.Row, error) {
 	tbl, err := te.Table(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	idxSch := te.Schema().Indexes().GetByName(indexName)
 	idxMap, err := tbl.GetIndexRowData(ctx, indexName)
 	if err != nil {
 		return nil, err
 	}
 
-	indexIter := noms.NewNomsRangeReader(idxSch.Schema(), idxMap,
+	indexIter := noms.NewNomsRangeReader(idxSch, idxMap,
 		[]*noms.ReadRange{{Start: key, Inclusive: true, Reverse: false, Check: func(tuple types.Tuple) (bool, error) {
 			return tuple.StartsWith(key), nil
 		}}},

--- a/go/libraries/doltcore/table/editor/pk_table_editor.go
+++ b/go/libraries/doltcore/table/editor/pk_table_editor.go
@@ -220,19 +220,18 @@ func (tea *tableEditAccumulator) Has(ctx context.Context, keyHash hash.Hash, key
 
 // ContainsIndexedKey returns whether the given key is contained within the index. The key is assumed to be in the
 // format expected of the index, similar to searching on the index map itself.
-func ContainsIndexedKey(ctx context.Context, te TableEditor, key types.Tuple, indexName string) (bool, error) {
+func ContainsIndexedKey(ctx context.Context, te TableEditor, key types.Tuple, indexName string, idxSch schema.Schema) (bool, error) {
 	tbl, err := te.Table(ctx)
 	if err != nil {
 		return false, err
 	}
 
-	idxSch := te.Schema().Indexes().GetByName(indexName)
 	idxMap, err := tbl.GetIndexRowData(ctx, indexName)
 	if err != nil {
 		return false, err
 	}
 
-	indexIter := noms.NewNomsRangeReader(idxSch.Schema(), idxMap,
+	indexIter := noms.NewNomsRangeReader(idxSch, idxMap,
 		[]*noms.ReadRange{{Start: key, Inclusive: true, Reverse: false, Check: func(tuple types.Tuple) (bool, error) {
 			return tuple.StartsWith(key), nil
 		}}},

--- a/go/libraries/doltcore/table/editor/sessioned_table_editor.go
+++ b/go/libraries/doltcore/table/editor/sessioned_table_editor.go
@@ -160,10 +160,13 @@ func (ste *sessionedTableEditor) handleReferencingRowsOnDelete(ctx context.Conte
 		if hasNulls {
 			continue
 		}
-		idxSch, ok := ste.indexSchemaCache[foreignKey.TableIndex]
+
+		tblName := referencingSte.tableEditor.Name()
+		cacheKey := tblName + "->" + foreignKey.TableIndex
+		idxSch, ok := ste.indexSchemaCache[cacheKey]
 		if !ok {
 			idxSch = referencingSte.tableEditor.Schema().Indexes().GetByName(foreignKey.TableIndex).Schema()
-			ste.indexSchemaCache[foreignKey.TableIndex] = idxSch
+			ste.indexSchemaCache[cacheKey] = idxSch
 		}
 		referencingRows, err := GetIndexedRows(ctx, referencingSte.tableEditor, indexKey, foreignKey.TableIndex, idxSch)
 		if err != nil {
@@ -243,10 +246,12 @@ func (ste *sessionedTableEditor) handleReferencingRowsOnUpdate(ctx context.Conte
 		if hasNulls {
 			continue
 		}
-		idxSch, ok := ste.indexSchemaCache[foreignKey.TableIndex]
+		tblName := referencingSte.tableEditor.Name()
+		cacheKey := tblName + "->" + foreignKey.TableIndex
+		idxSch, ok := ste.indexSchemaCache[cacheKey]
 		if !ok {
 			idxSch = referencingSte.tableEditor.Schema().Indexes().GetByName(foreignKey.TableIndex).Schema()
-			ste.indexSchemaCache[foreignKey.TableIndex] = idxSch
+			ste.indexSchemaCache[cacheKey] = idxSch
 		}
 		referencingRows, err := GetIndexedRows(ctx, referencingSte.tableEditor, indexKey, foreignKey.TableIndex, idxSch)
 		if err != nil {
@@ -443,10 +448,12 @@ func (ste *sessionedTableEditor) validateForInsert(ctx context.Context, taggedVa
 			return fmt.Errorf("unable to get table editor as `%s` is missing", foreignKey.ReferencedTableName)
 		}
 
-		idxSch, ok := ste.indexSchemaCache[foreignKey.ReferencedTableIndex]
+		tblName := referencingSte.tableEditor.Name()
+		cacheKey := tblName + "->" + foreignKey.ReferencedTableIndex
+		idxSch, ok := ste.indexSchemaCache[cacheKey]
 		if !ok {
 			idxSch = referencingSte.tableEditor.Schema().Indexes().GetByName(foreignKey.ReferencedTableIndex).Schema()
-			ste.indexSchemaCache[foreignKey.ReferencedTableIndex] = idxSch
+			ste.indexSchemaCache[cacheKey] = idxSch
 		}
 
 		exists, err := ContainsIndexedKey(ctx, referencingSte.tableEditor, indexKey, foreignKey.ReferencedTableIndex, idxSch)


### PR DESCRIPTION
Optimization decreases the amount of time spent calculating index schemas.