### PR TITLE
cmd/dolt/commands: fix dropped errors

### DIFF
--- a/go/cmd/dolt/commands/fetch.go
+++ b/go/cmd/dolt/commands/fetch.go
@@ -203,11 +203,12 @@ func fetchRefSpecs(ctx context.Context, mode ref.RefUpdateMode, dEnv *env.DoltEn
 					return verr
 				}
 
+				var ok bool
 				switch mode {
 				case ref.ForceUpdate:
 					err = dEnv.DoltDB.SetHeadToCommit(ctx, remoteTrackRef, srcDBCommit)
 				case ref.FastForwardOnly:
-					ok, err := dEnv.DoltDB.CanFastForward(ctx, remoteTrackRef, srcDBCommit)
+					ok, err = dEnv.DoltDB.CanFastForward(ctx, remoteTrackRef, srcDBCommit)
 					if !ok {
 						return errhand.BuildDError("error: fetch failed, can't fast forward remote tracking ref").Build()
 					}

--- a/go/cmd/dolt/commands/filter-branch.go
+++ b/go/cmd/dolt/commands/filter-branch.go
@@ -190,6 +190,9 @@ func processFilterQuery(ctx context.Context, dEnv *env.DoltEnv, cm *doltdb.Commi
 		}
 		// ddl returns a nil itr
 		_, _, err = eng.ddl(sqlCtx, s, query)
+		if err != nil {
+			return nil, fmt.Errorf("error executing DDL: %w", err)
+		}
 
 	case *sqlparser.Select, *sqlparser.OtherRead, *sqlparser.Show, *sqlparser.Explain, *sqlparser.Union:
 		return nil, fmt.Errorf("filter-branch queries must be write queries: '%s'", query)

--- a/go/cmd/dolt/commands/schcmds/import.go
+++ b/go/cmd/dolt/commands/schcmds/import.go
@@ -296,15 +296,16 @@ func importSchema(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.ArgPars
 
 	if !apr.Contains(dryRunFlag) {
 		tbl, tblExists, err := root.GetTable(ctx, tblName)
+		if err != nil {
+			return errhand.BuildDError("error: failed to get table.").AddCause(err).Build()
+		}
 
 		schVal, err := encoding.MarshalSchemaAsNomsValue(context.Background(), root.VRW(), sch)
-
 		if err != nil {
 			return errhand.BuildDError("error: failed to encode schema.").AddCause(err).Build()
 		}
 
 		empty, err := types.NewMap(ctx, root.VRW())
-
 		if err != nil {
 			return errhand.BuildDError("error: failed to create table.").AddCause(err).Build()
 		}
@@ -318,19 +319,16 @@ func importSchema(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.ArgPars
 		}
 
 		tbl, err = doltdb.NewTable(ctx, root.VRW(), schVal, empty, indexData, nil)
-
 		if err != nil {
 			return errhand.BuildDError("error: failed to create table.").AddCause(err).Build()
 		}
 
 		root, err = root.PutTable(ctx, tblName, tbl)
-
 		if err != nil {
 			return errhand.BuildDError("error: failed to add table.").AddCause(err).Build()
 		}
 
 		err = dEnv.UpdateWorkingRoot(ctx, root)
-
 		if err != nil {
 			return errhand.BuildDError("error: failed to update the working set.").AddCause(err).Build()
 		}


### PR DESCRIPTION
This fixes the straightforward-looking dropped errors in `cmd/dolt/commands` and its subpackages.