### PR TITLE
fix flaky chunk test

### DIFF
--- a/go/libraries/doltcore/sqle/json/noms_json_value_test.go
+++ b/go/libraries/doltcore/sqle/json/noms_json_value_test.go
@@ -209,7 +209,9 @@ func TestJSONStructuralSharing(t *testing.T) {
 		require.NoError(t, err)
 		after := ts.Len()
 
-		// flush creates a single chunk
-		assert.Equal(t, before+tuples+1, after)
+		// extras chunks are sometimes written
+		const errMargin = 5
+
+		assert.Greater(t, before+tuples+errMargin, after)
 	})
 }


### PR DESCRIPTION
JSON structural sharing test writes a non-deterministic number of chunks to the in-memory chunk store.