### PR TITLE
gc changes for import

### DIFF
--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -55,6 +55,7 @@ const (
 	primaryKeyParam  = "pk"
 	fileTypeParam    = "file-type"
 	delimParam       = "delim"
+	noGCParam        = "no-gc"
 )
 
 var importDocs = cli.CommandDocumentationContent{
@@ -99,6 +100,7 @@ type importOptions struct {
 	tableName   string
 	contOnErr   bool
 	force       bool
+	disableGC   bool
 	schFile     string
 	primaryKeys []string
 	nameMapper  rowconv.NameMapper
@@ -237,6 +239,7 @@ func getImportMoveOptions(ctx context.Context, apr *argparser.ArgParseResults, d
 		tableName:   tableName,
 		contOnErr:   contOnErr,
 		force:       force,
+		disableGC:   apr.Contains(noGCParam),
 		schFile:     schemaFile,
 		nameMapper:  colMapper,
 		primaryKeys: pks,
@@ -398,6 +401,7 @@ func createArgParser() *argparser.ArgParser {
 	ap.SupportsFlag(forceParam, "f", "If a create operation is being executed, data already exists in the destination, the force flag will allow the target to be overwritten.")
 	ap.SupportsFlag(replaceParam, "r", "Replace existing table with imported data while preserving the original schema.")
 	ap.SupportsFlag(contOnErrParam, "", "Continue importing when row import errors are encountered.")
+	ap.SupportsFlag(noGCParam, "", "Don't run garbage collection automatically as part of the import.")
 	ap.SupportsString(schemaParam, "s", "schema_file", "The schema for the output data.")
 	ap.SupportsString(mappingFileParam, "m", "mapping_file", "A file that lays out how fields should be mapped from input data to output data.")
 	ap.SupportsString(primaryKeyParam, "pk", "primary_key", "Explicitly define the name of the field in the schema which should be used as the primary key.")
@@ -464,11 +468,11 @@ func newImportDataMover(ctx context.Context, root *doltdb.RootValue, dEnv *env.D
 	var wr table.TableWriteCloser
 	switch impOpts.operation {
 	case CreateOp:
-		wr, err = impOpts.dest.NewCreatingWriter(ctx, impOpts, dEnv, root, srcIsSorted, wrSch, statsCB, true)
+		wr, err = impOpts.dest.NewCreatingWriter(ctx, impOpts, dEnv, root, srcIsSorted, wrSch, statsCB, !impOpts.disableGC)
 	case ReplaceOp:
-		wr, err = impOpts.dest.NewReplacingWriter(ctx, impOpts, dEnv, root, srcIsSorted, wrSch, statsCB, true)
+		wr, err = impOpts.dest.NewReplacingWriter(ctx, impOpts, dEnv, root, srcIsSorted, wrSch, statsCB, !impOpts.disableGC)
 	case UpdateOp:
-		wr, err = impOpts.dest.NewUpdatingWriter(ctx, impOpts, dEnv, root, srcIsSorted, wrSch, statsCB, true)
+		wr, err = impOpts.dest.NewUpdatingWriter(ctx, impOpts, dEnv, root, srcIsSorted, wrSch, statsCB, !impOpts.disableGC)
 	default:
 		err = errors.New("invalid move operation")
 	}
@@ -477,7 +481,12 @@ func newImportDataMover(ctx context.Context, root *doltdb.RootValue, dEnv *env.D
 		return nil, &mvdata.DataMoverCreationError{ErrType: mvdata.CreateWriterErr, Cause: err}
 	}
 
-	imp := &mvdata.DataMover{Rd: rd, Transforms: transforms, Wr: wr, ContOnErr: impOpts.contOnErr}
+	imp := &mvdata.DataMover{
+		Rd:         rd,
+		Transforms: transforms,
+		Wr:         wr,
+		ContOnErr:  impOpts.contOnErr,
+	}
 	rd = nil
 
 	return imp, nil

--- a/go/libraries/doltcore/mvdata/table_data_loc.go
+++ b/go/libraries/doltcore/mvdata/table_data_loc.go
@@ -17,8 +17,9 @@ package mvdata
 import (
 	"context"
 	"errors"
-	"github.com/dolthub/dolt/go/store/datas"
 	"sync/atomic"
+
+	"github.com/dolthub/dolt/go/store/datas"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"


### PR DESCRIPTION
New `dolt table import` flag --no-gc, and parameter tuning to run gcs less during import.