### PR TITLE
Fixed index editors getting to an invalid state on error

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -183,7 +183,6 @@ func TestTruncate(t *testing.T) {
 }
 
 func TestScripts(t *testing.T) {
-	t.Skip("select * from unionView is not working anymore")
 	enginetest.TestScripts(t, newDoltHarness(t))
 }
 

--- a/go/libraries/doltcore/table/editor/index_operation_stack.go
+++ b/go/libraries/doltcore/table/editor/index_operation_stack.go
@@ -1,0 +1,59 @@
+// Copyright 2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package editor
+
+import "github.com/dolthub/dolt/go/store/types"
+
+// indexOperationStack is a limited-size stack, intended for usage with the index editor and its undo functionality.
+// As operations are added, the internal array is filled up. Once it is full, new operations replace the oldest ones.
+// This reduces memory usage compared to a traditional stack with an unbounded size, as undo should always come
+// immediately after an operation is added.
+type indexOperationStack struct {
+	// entries has a length of 4 as an UPDATE on a table is a Delete & Insert on the index, so we double it for safety.
+	entries [4]indexOperation
+	// This is the index of the next item we are adding. Add at this index, then increment.
+	currentIndex uint64
+	// Represents the number of items relative to the "stack size".
+	numOfItems uint64
+}
+
+// indexOperation is an operation performed by the index editor, along with the key used.
+type indexOperation struct {
+	isInsert   bool
+	fullKey    types.Tuple
+	partialKey types.Tuple
+}
+
+// Push adds the given keys to the top of the stack.
+func (ios *indexOperationStack) Push(isInsert bool, fullKey, partialKey types.Tuple) {
+	ios.entries[ios.currentIndex].isInsert = isInsert
+	ios.entries[ios.currentIndex].fullKey = fullKey
+	ios.entries[ios.currentIndex].partialKey = partialKey
+	ios.currentIndex = (ios.currentIndex + 1) % uint64(len(ios.entries))
+	ios.numOfItems++
+	if ios.numOfItems > uint64(len(ios.entries)) {
+		ios.numOfItems = uint64(len(ios.entries))
+	}
+}
+
+// Pop removes and returns the keys from the top of the stack. Returns false if the stack is empty.
+func (ios *indexOperationStack) Pop() (indexOperation, bool) {
+	if ios.numOfItems == 0 {
+		return indexOperation{}, false
+	}
+	ios.numOfItems--
+	ios.currentIndex = (ios.currentIndex - 1) % uint64(len(ios.entries))
+	return ios.entries[ios.currentIndex], true
+}

--- a/go/libraries/doltcore/table/editor/index_operation_stack_test.go
+++ b/go/libraries/doltcore/table/editor/index_operation_stack_test.go
@@ -1,0 +1,93 @@
+// Copyright 2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package editor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/store/types"
+)
+
+func TestIndexOperationStack(t *testing.T) {
+	ios := &indexOperationStack{}
+	require.True(t, len(ios.entries) >= 2) // Entries should always at least have a length of 2
+
+	ios.Push(true, iosTuple(t, 100, 100), iosTuple(t, 100))
+	entry, ok := ios.Pop()
+	require.True(t, ok)
+	iosTupleComp(t, entry.fullKey, 100, 100)
+	iosTupleComp(t, entry.partialKey, 100)
+	require.True(t, entry.isInsert)
+	_, ok = ios.Pop()
+	require.False(t, ok)
+
+	for i := 0; i < len(ios.entries); i++ {
+		ios.Push(false, iosTuple(t, i, i), iosTuple(t, i))
+	}
+	for i := len(ios.entries) - 1; i >= 0; i-- {
+		entry, ok = ios.Pop()
+		require.True(t, ok)
+		iosTupleComp(t, entry.fullKey, i, i)
+		iosTupleComp(t, entry.partialKey, i)
+		require.False(t, entry.isInsert)
+	}
+	_, ok = ios.Pop()
+	require.False(t, ok)
+
+	for i := 0; i < (len(ios.entries)*2)+1; i++ {
+		ios.Push(true, iosTuple(t, i, i), iosTuple(t, i))
+	}
+	for i := len(ios.entries) - 1; i >= 0; i-- {
+		entry, ok = ios.Pop()
+		require.True(t, ok)
+		val := ((len(ios.entries) * 2) + 1) - i
+		iosTupleComp(t, entry.fullKey, val, val)
+		iosTupleComp(t, entry.partialKey, val)
+		require.True(t, entry.isInsert)
+	}
+	_, ok = ios.Pop()
+	require.False(t, ok)
+}
+
+func iosTuple(t *testing.T, vals ...int) types.Tuple {
+	typeVals := make([]types.Value, len(vals))
+	for i, val := range vals {
+		typeVals[i] = types.Int(val)
+	}
+	tpl, err := types.NewTuple(types.Format_Default, typeVals...)
+	if err != nil {
+		require.NoError(t, err)
+	}
+	return tpl
+}
+
+func iosTupleComp(t *testing.T, tpl types.Tuple, vals ...int) bool {
+	if tpl.Len() != uint64(len(vals)) {
+		return false
+	}
+	iter, err := tpl.Iterator()
+	require.NoError(t, err)
+	var i uint64
+	var val types.Value
+	for i, val, err = iter.Next(); i < uint64(len(vals)) && err == nil; i, val, err = iter.Next() {
+		if !types.Int(vals[i]).Equals(val) {
+			return false
+		}
+	}
+	require.NoError(t, err)
+	return true
+}


### PR DESCRIPTION
Previously, if you had two or more indexes on a table and one of the indexes threw an error (such as a `UNIQUE` violation), the other index(es) would have whatever it was written to it still, leaving the table and index in an inconsistent state. This adds a small stack to index editors that allow one to undo the last few operations. In addition, the pk table editor tracks how many successful operations have been made per index editor and calls the equivalent number of undo statements, so that they're reset.

I chose to panic rather than error as, if these fail for whatever reason, we need to completely start over since things are broken and it's not really recoverable without rebuilding the entire index.