### PR TITLE
Initial tag-reuse within working

### DIFF
--- a/go/libraries/doltcore/envtestutils/rebase_tag_test.go
+++ b/go/libraries/doltcore/envtestutils/rebase_tag_test.go
@@ -540,7 +540,7 @@ func checkRows(t *testing.T, dEnv *env.DoltEnv, root *doltdb.RootValue, tableNam
 
 	s, rowIter, err := engine.Query(sqlCtx, selectQuery)
 	require.NoError(t, err)
-	_, err = sqlutil.ToDoltSchema(context.Background(), root, tableName, s)
+	_, err = sqlutil.ToDoltSchema(context.Background(), root, tableName, s, nil)
 	require.NoError(t, err)
 
 	actualRows := []row.Row{}

--- a/go/libraries/doltcore/schema/schema.go
+++ b/go/libraries/doltcore/schema/schema.go
@@ -14,6 +14,8 @@
 
 package schema
 
+import "github.com/dolthub/dolt/go/store/types"
+
 // Schema is an interface for retrieving the columns that make up a schema
 type Schema interface {
 	// GetPKCols gets the collection of columns which make the primary key.
@@ -115,4 +117,26 @@ func VerifyInSchema(inSch, outSch Schema) (bool, error) {
 	}
 
 	return match, nil
+}
+
+// GetSharedCols returns a name -> tag mapping for name/kind matches
+func GetSharedCols(schema Schema, cmpNames []string, cmpKinds []types.NomsKind) map[string]uint64 {
+	existingColKinds := make(map[string]types.NomsKind)
+	existingColTags := make(map[string]uint64)
+
+	_ = schema.GetAllCols().Iter(func(tag uint64, col Column) (stop bool, err error) {
+		existingColKinds[col.Name] = col.Kind
+		existingColTags[col.Name] = col.Tag
+		return false, nil
+	})
+
+	reuseTags := make(map[string]uint64)
+	for i, col := range cmpNames {
+		if val, ok := existingColKinds[col]; ok {
+			if val == cmpKinds[i] {
+				reuseTags[col] = existingColTags[col]
+			}
+		}
+	}
+	return reuseTags
 }

--- a/go/libraries/doltcore/schema/schema_test.go
+++ b/go/libraries/doltcore/schema/schema_test.go
@@ -86,6 +86,22 @@ func TestSchemaWithNoPKs(t *testing.T) {
 	})
 }
 
+func TestSchemaOverlap(t *testing.T) {
+	colColl := NewColCollection(nonPkCols...)
+	sch, _ := SchemaFromCols(colColl)
+
+	names := []string{addrColName, ageColName}
+	kinds := []types.NomsKind{types.StringKind, types.UintKind}
+	res := GetSharedCols(sch, names, kinds)
+
+	cmp := map[string]uint64{
+		addrColName: addrColTag,
+		ageColName:  ageColTag,
+	}
+
+	assert.Equal(t, res, cmp)
+}
+
 func TestIsKeyless(t *testing.T) {
 	cc := NewColCollection(allCols...)
 	pkSch, err := SchemaFromCols(cc)

--- a/go/libraries/doltcore/sqle/sqlinsert_test.go
+++ b/go/libraries/doltcore/sqle/sqlinsert_test.go
@@ -442,7 +442,7 @@ func mustGetDoltSchema(sch sql.Schema, tableName string, testEnv *env.DoltEnv) s
 		panic(err)
 	}
 
-	doltSchema, err := sqlutil.ToDoltSchema(context.Background(), wrt, tableName, sch)
+	doltSchema, err := sqlutil.ToDoltSchema(context.Background(), wrt, tableName, sch, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/go/libraries/doltcore/sqle/sqlutil/convert.go
+++ b/go/libraries/doltcore/sqle/sqlutil/convert.go
@@ -77,7 +77,7 @@ func FromDoltSchema(tableName string, sch schema.Schema) (sql.Schema, error) {
 
 // ToDoltSchema returns a dolt Schema from the sql schema given, suitable for use in creating a table.
 // For result set schemas, see ToDoltResultSchema.
-func ToDoltSchema(ctx context.Context, root *doltdb.RootValue, tableName string, sqlSchema sql.Schema) (schema.Schema, error) {
+func ToDoltSchema(ctx context.Context, root *doltdb.RootValue, tableName string, sqlSchema sql.Schema, headRoot *doltdb.RootValue) (schema.Schema, error) {
 	var cols []schema.Column
 	var err error
 
@@ -92,7 +92,8 @@ func ToDoltSchema(ctx context.Context, root *doltdb.RootValue, tableName string,
 		}
 		kinds = append(kinds, ti.NomsKind())
 	}
-	tags, err := root.GenerateTagsForNewColumns(ctx, tableName, names, kinds)
+
+	tags, err := root.GenerateTagsForNewColumns(ctx, tableName, names, kinds, headRoot)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/sqlutil/schema.go
+++ b/go/libraries/doltcore/sqle/sqlutil/schema.go
@@ -90,7 +90,7 @@ func ParseCreateTableStatement(ctx context.Context, root *doltdb.RootValue, quer
 	buf := sqlparser.NewTrackedBuffer(nil)
 	tn.Format(buf)
 	tableName := buf.String()
-	sch, err := ToDoltSchema(ctx, root, tableName, s)
+	sch, err := ToDoltSchema(ctx, root, tableName, s, nil)
 
 	if err != nil {
 		return "", nil, err

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -717,7 +717,7 @@ func (t *AlterableDoltTable) AddColumn(ctx *sql.Context, column *sql.Column, ord
 	if err != nil {
 		return err
 	}
-	tags, err := root.GenerateTagsForNewColumns(ctx, t.name, []string{column.Name}, []types.NomsKind{ti.NomsKind()})
+	tags, err := root.GenerateTagsForNewColumns(ctx, t.name, []string{column.Name}, []types.NomsKind{ti.NomsKind()}, nil)
 	if err != nil {
 		return err
 	}
@@ -867,7 +867,7 @@ func (t *AlterableDoltTable) ModifyColumn(ctx *sql.Context, columnName string, c
 			}
 		}
 		if existingCol.Kind != col.Kind { // We only change the tag when the underlying Noms kind changes
-			tags, err := root.GenerateTagsForNewColumns(ctx, t.name, []string{col.Name}, []types.NomsKind{col.Kind})
+			tags, err := root.GenerateTagsForNewColumns(ctx, t.name, []string{col.Name}, []types.NomsKind{col.Kind}, nil)
 			if err != nil {
 				return err
 			}

--- a/integration-tests/bats/foreign-keys.bats
+++ b/integration-tests/bats/foreign-keys.bats
@@ -1693,7 +1693,7 @@ SQL
     dolt commit -m "committed"
 }
 
-@test "foreign-keys: deleting and readding" {
+@test "foreign-keys: deleting and reading" {
     dolt sql <<SQL
 CREATE TABLE parent2 (
   pk BIGINT PRIMARY KEY
@@ -1706,6 +1706,7 @@ SQL
     dolt add -A
     dolt commit -m "parent2 and child2"
     dolt sql -q "DROP TABLE child2"
+    dolt commit -am "drop child"
     dolt sql <<SQL
 CREATE TABLE child2 (
   pk BIGINT PRIMARY KEY,

--- a/integration-tests/bats/foreign-keys.bats
+++ b/integration-tests/bats/foreign-keys.bats
@@ -1693,7 +1693,7 @@ SQL
     dolt commit -m "committed"
 }
 
-@test "foreign-keys: deleting and reading" {
+@test "foreign-keys: deleting and readding" {
     dolt sql <<SQL
 CREATE TABLE parent2 (
   pk BIGINT PRIMARY KEY

--- a/integration-tests/bats/replace.bats
+++ b/integration-tests/bats/replace.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+load $BATS_TEST_DIRNAME/helper/common.bash
+
+setup() {
+    setup_common
+
+    dolt sql -q "create table t1 (a bigint primary key, b bigint)"
+    dolt sql -q "insert into t1 values (0,0), (1,1)"
+    dolt commit -am "Init"
+    dolt sql -q "drop table t1"
+}
+
+teardown() {
+    assert_feature_version
+    teardown_common
+}
+
+@test "replace: same table gives empty diff" {
+    dolt sql -q "create table t1 (a bigint primary key, b bigint)"
+    run dolt diff -r=sql master
+    [ $status -eq 0 ]
+    [ "${#lines[@]}" -eq 2 ]
+    [[ "$output" =~ "DELETE FROM \`t1\` WHERE (\`a\`=0);" ]] || false
+    [[ "$output" =~ "DELETE FROM \`t1\` WHERE (\`a\`=1);" ]] || false
+
+    dolt sql -q "insert into t1 values (0,0), (1,1)"
+    dolt add .
+    run dolt diff -r=sql master
+    [ "$status" -eq 0 ]
+    [[ "$output" = "" ]] || false
+}
+
+@test "replace: different name generates new tags" {
+    dolt sql -q "create table t2 (a bigint primary key, b bigint)"
+    run dolt diff -r=sql master
+    [ $status -eq 0 ]
+    [ "${#lines[@]}" -eq 6 ]
+    [[ "$output" =~ "DROP TABLE \`t1\`" ]] || false
+    [[ "$output" =~ "CREATE TABLE \`t2\`" ]] || false
+}

--- a/integration-tests/mysql-client-tests/go/go-sql-driver-mysql-test.go
+++ b/integration-tests/mysql-client-tests/go/go-sql-driver-mysql-test.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"os"
-	"fmt"
 	"database/sql"
+	"fmt"
+	"os"
 
 	_ "github.com/go-sql-driver/mysql"
 )
@@ -23,12 +23,12 @@ type StmtTest struct {
 	Res   []ResFunc
 }
 
-var stmtTests []StmtTest = []StmtTest {
+var stmtTests []StmtTest = []StmtTest{
 	{
 		"select * from test where pk = ?",
 		[]interface{}{int64(0)},
 		[]ResFunc{
-			func (rows *sql.Rows) error {
+			func(rows *sql.Rows) error {
 				var pk, value int64
 				if err := rows.Scan(&pk, &value); err != nil {
 					return err


### PR DESCRIPTION
- If a table is not in working,  is in head, and has the same schema as the table in head, re-use the tags and add the empty table back.
- The diff doesn't show `TRUNCATE table` or `DELETE from table` immediately after the create. I would have to edit the SQL path to change that.
- Bats tests added

todo:
-  engine tests?
- more complicated replace workflows. ex: replace table with extra column is easy, because I can do a one-way length check on columns and use a map for name/kind checks. Replace with delete column would be the same. Change column maybe also the same? If you do a series of replaces with column tags disappearing and reappearing, is it OK to enforce the re-use? Table moves should be explicit, that isn't a concern of replace workflows.