### PR TITLE
Improve fetch and pull performance and reliability.

### DIFF
--- a/go/libraries/doltcore/remotestorage/chunk_store.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store.go
@@ -323,6 +323,12 @@ func (gr *GetRange) ChunkByteRange(i int) (uint64, uint64) {
 	return start, end
 }
 
+func sortRangesBySize(ranges []*GetRange) {
+	sort.Slice(ranges, func(i, j int) bool {
+		return ranges[j].RangeLen() < ranges[i].RangeLen()
+	})
+}
+
 type resourcePathToUrlFunc func(ctx context.Context, resourcePath string) (url string, err error)
 
 func (gr *GetRange) GetDownloadFunc(ctx context.Context, fetcher HTTPFetcher, chunkChan chan nbs.CompressedChunk, pathToUrl resourcePathToUrlFunc) func() error {
@@ -930,6 +936,8 @@ func (dcs *DoltChunkStore) downloadChunks(ctx context.Context, dlLocs dlLocation
 
 	gets := aggregateDownloads(chunkAggDistance, resourceGets)
 	logDownloadStats(span, resourceGets, gets)
+
+	sortRangesBySize(gets)
 
 	toUrl := func(ctx context.Context, resourcePath string) (string, error) {
 		return dlLocs.refreshes[resourcePath].GetURL(ctx, dcs.csClient)

--- a/go/libraries/doltcore/remotestorage/chunk_store.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store.go
@@ -414,7 +414,7 @@ func (r *locationRefresh) GetURL(ctx context.Context, lastError error, client re
 	if r.RefreshRequest != nil {
 		now := time.Now()
 		wantsRefresh := now.After(r.RefreshAfter) || errors.Is(lastError, HttpError)
-		canRefresh := now.After(r.lastRefresh.Add(refreshTableFileURLRetryDuration))
+		canRefresh := time.Since(r.lastRefresh) > refreshTableFileURLRetryDuration
 		if wantsRefresh && canRefresh {
 			resp, err := client.RefreshTableFileUrl(ctx, r.RefreshRequest)
 			if err != nil {

--- a/go/libraries/doltcore/remotestorage/concurrency.go
+++ b/go/libraries/doltcore/remotestorage/concurrency.go
@@ -23,7 +23,11 @@ import (
 func concurrentExec(work []func() error, concurrency int) error {
 	if concurrency <= 0 {
 		panic("Invalid argument")
-	} else if len(work) < concurrency {
+	}
+	if len(work) == 0 {
+		return nil
+	}
+	if len(work) < concurrency {
 		concurrency = len(work)
 	}
 

--- a/go/libraries/doltcore/remotestorage/hedge.go
+++ b/go/libraries/doltcore/remotestorage/hedge.go
@@ -145,6 +145,8 @@ func (ms *MinStrategy) Observe(sz, n int, d time.Duration, err error) {
 	}
 }
 
+var MaxHedgesPerRequest = 1
+
 // Do runs |w| to completion, potentially spawning concurrent hedge runs of it.
 // Returns the results from the first invocation that completes, and cancels
 // the contexts of all invocations.
@@ -160,6 +162,9 @@ func (h *Hedger) Do(ctx context.Context, w Work) (interface{}, error) {
 	try := func() {
 		n := len(cancels) + 1
 		finalize := func() {}
+		if n - 1 > MaxHedgesPerRequest {
+			return
+		}
 		if n > 1 {
 			if !h.sema.TryAcquire(1) {
 				// Too many outstanding hedges. Do nothing.

--- a/go/libraries/doltcore/remotestorage/hedge.go
+++ b/go/libraries/doltcore/remotestorage/hedge.go
@@ -162,7 +162,7 @@ func (h *Hedger) Do(ctx context.Context, w Work) (interface{}, error) {
 	try := func() {
 		n := len(cancels) + 1
 		finalize := func() {}
-		if n - 1 > MaxHedgesPerRequest {
+		if n-1 > MaxHedgesPerRequest {
 			return
 		}
 		if n > 1 {

--- a/go/libraries/doltcore/remotestorage/hedge_test.go
+++ b/go/libraries/doltcore/remotestorage/hedge_test.go
@@ -23,6 +23,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func init() {
+	MaxHedgesPerRequest = 1024
+}
+
 func TestPercentileStrategy(t *testing.T) {
 	s := NewPercentileStrategy(0, 1*time.Hour, 95.0)
 	for i := 0; i < 90; i++ {
@@ -88,8 +92,6 @@ func TestHedgerObeysMaxHedges(t *testing.T) {
 	try := func(max int) {
 		h := NewHedger(int64(max), NewMinStrategy(1*time.Millisecond, nil))
 		cnt := int32(0)
-		ch := make(chan int, 1)
-		ch <- 1
 		i, err := h.Do(context.Background(), Work{
 			Work: func(ctx context.Context) (interface{}, error) {
 				cur := atomic.AddInt32(&cnt, 1)
@@ -109,6 +111,49 @@ func TestHedgerObeysMaxHedges(t *testing.T) {
 	try(1)
 	try(2)
 	try(3)
+}
+
+func TestMaxHedgesPerRequestObeyed(t *testing.T) {
+	before := MaxHedgesPerRequest
+	defer func() {
+		MaxHedgesPerRequest = before
+	}()
+
+	MaxHedgesPerRequest = 0
+	h := NewHedger(int64(32), NewMinStrategy(1*time.Millisecond, nil))
+	cnt := int32(0)
+	i, err := h.Do(context.Background(), Work{
+		Work: func(ctx context.Context) (interface{}, error) {
+			cur := atomic.AddInt32(&cnt, 1)
+			if cur == int32(1) {
+				time.Sleep(100 * time.Millisecond)
+				return 1, nil
+			} else {
+				return 2, nil
+			}
+		},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, i.(int))
+
+	MaxHedgesPerRequest = 1
+	cnt = int32(0)
+	i, err = h.Do(context.Background(), Work{
+		Work: func(ctx context.Context) (interface{}, error) {
+			cur := atomic.AddInt32(&cnt, 1)
+			if cur == int32(1) {
+				time.Sleep(2 * time.Second)
+				return 1, nil
+			} else if cur == int32(2) {
+				time.Sleep(100 * time.Millisecond)
+				return 2, nil
+			} else {
+				return 3, nil
+			}
+		},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, i.(int))
 }
 
 func TestHedgerContextCancelObeyed(t *testing.T) {

--- a/go/libraries/doltcore/remotestorage/hedge_test.go
+++ b/go/libraries/doltcore/remotestorage/hedge_test.go
@@ -126,7 +126,7 @@ func TestMaxHedgesPerRequestObeyed(t *testing.T) {
 		Work: func(ctx context.Context) (interface{}, error) {
 			cur := atomic.AddInt32(&cnt, 1)
 			if cur == int32(1) {
-				time.Sleep(100 * time.Millisecond)
+				time.Sleep(500 * time.Millisecond)
 				return 1, nil
 			} else {
 				return 2, nil
@@ -142,10 +142,10 @@ func TestMaxHedgesPerRequestObeyed(t *testing.T) {
 		Work: func(ctx context.Context) (interface{}, error) {
 			cur := atomic.AddInt32(&cnt, 1)
 			if cur == int32(1) {
-				time.Sleep(2 * time.Second)
+				time.Sleep(30 * time.Second)
 				return 1, nil
 			} else if cur == int32(2) {
-				time.Sleep(100 * time.Millisecond)
+				time.Sleep(500 * time.Millisecond)
 				return 2, nil
 			} else {
 				return 3, nil


### PR DESCRIPTION
Allow URLs to be refreshed when signing credentials are expired or revoked. Increase small fetch concurrency. Limit hedged downloads to one per fetch. Avoid hedging large downloads for now.