### PR TITLE
fixes infinite loop

### DIFF
--- a/go/store/types/value_store.go
+++ b/go/store/types/value_store.go
@@ -410,10 +410,6 @@ func (lvs *ValueStore) bufferChunk(ctx context.Context, v Value, c chunks.Chunk,
 
 	// Enforce invariant (2)
 	for lvs.bufferedChunkSize > lvs.bufferedChunksMax {
-		if len(lvs.withBufferedChildren) == 0 {
-			panic("deadlock detected")
-		}
-
 		var tallest hash.Hash
 		var height uint64 = 0
 		for parent, ht := range lvs.withBufferedChildren {


### PR DESCRIPTION
A deadlock can occur when the chunk size is greater than the maximum chunk size and a chunk with children gets removed, but it isn't removed from the withBufferedChildren map.