### PR TITLE
Mark the session state clean upon init

### DIFF
--- a/go/libraries/doltcore/sqle/dolt_session.go
+++ b/go/libraries/doltcore/sqle/dolt_session.go
@@ -619,6 +619,9 @@ func (sess *DoltSession) AddDB(ctx *sql.Context, db sql.Database, dbData env.DbD
 		return err
 	}
 
+	// After setting the initial root we have no state to commit
+	sess.dirty[db.Name()] = false
+
 	return nil
 }
 


### PR DESCRIPTION
I don't love this... it's meant to address this failure in dolthub:

https://github.com/dolthub/ld/pull/6605

Read-only is also kind of a bad name, it still writes to the chunk store if you issue a write query, it just won't call WriteRootValue when a transaction is committed

Thoughts?