### PR TITLE
Patched random ACCESS DENIED error on Windows

### DIFF
--- a/go/store/datas/database_common.go
+++ b/go/store/datas/database_common.go
@@ -640,7 +640,7 @@ func (db *database) doDelete(ctx context.Context, datasetIDstr string) error {
 
 	var initialHead types.Ref
 	if r, hasHead, err := currentDatasets.MaybeGet(ctx, datasetID); err != nil {
-
+		return err
 	} else if !hasHead {
 		return nil
 	} else {


### PR DESCRIPTION
This patches the random `ACCESS DENIED` error that may occur on Windows when noms attempts to rename the manifest.