### PR TITLE
Fix bug with conflicts for DOLT_MERGE

### DIFF
--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -150,7 +150,7 @@ func (cmd SqlCmd) createArgParser() *argparser.ArgParser {
 	ap.SupportsString(messageFlag, "m", "saved query description", "Used with --query and --save, saves the query with the descriptive message given. See also --name")
 	ap.SupportsFlag(BatchFlag, "b", "batch mode, to run more than one query with --query, separated by ';'. Piping input to sql with no arguments also uses batch mode")
 	ap.SupportsString(multiDBDirFlag, "", "directory", "Defines a directory whose subdirectories should all be dolt data repositories accessible as independent databases within ")
-	ap.SupportsFlag(continueFlag, "c", "continue running queries on an error. used for batch mode only.")
+	ap.SupportsFlag(continueFlag, "c", "continue running queries on an error. Used for batch mode only.")
 	return ap
 }
 

--- a/go/libraries/doltcore/doltdb/errors.go
+++ b/go/libraries/doltcore/doltdb/errors.go
@@ -47,7 +47,7 @@ var ErrUpToDate = errors.New("up to date")
 var ErrIsAhead = errors.New("current fast forward from a to b. a is ahead of b already")
 var ErrIsBehind = errors.New("cannot reverse from b to a. b is a is behind a already")
 
-var ErrUnresolvedConflicts = errors.New("merge has unresolved conflicts")
+var ErrUnresolvedConflicts = errors.New("merge has unresolved conflicts. please use the dolt_conflicts table to resolve")
 var ErrMergeActive = errors.New("merging is not possible because you have not committed an active merge")
 
 type ErrClientOutOfDate struct {

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_merge.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_merge.go
@@ -333,7 +333,7 @@ func mergeRootToWorking(
 	hasConflicts := checkForConflicts(mergeStats)
 
 	if hasConflicts {
-		// If there are conflicts write them to the work root anyway too allow for merge resolution via the dolt_conflicts
+		// If there are conflicts write them to the working root anyway too allow for merge resolution via the dolt_conflicts
 		// table.
 		err := ctx.SetSessionVariable(ctx, sqle.WorkingKey(dbName), workingHash.String())
 		if err != nil {

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_merge.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_merge.go
@@ -333,6 +333,13 @@ func mergeRootToWorking(
 	hasConflicts := checkForConflicts(mergeStats)
 
 	if hasConflicts {
+		// If there are conflicts write them to the work root anyway too allow for merge resolution via the dolt_conflicts
+		// table.
+		err := ctx.SetSessionVariable(ctx, sqle.WorkingKey(dbName), workingHash.String())
+		if err != nil {
+			return err
+		}
+
 		return doltdb.ErrUnresolvedConflicts
 	}
 

--- a/integration-tests/bats/sql-merge.bats
+++ b/integration-tests/bats/sql-merge.bats
@@ -462,7 +462,7 @@ SQL
     [[ "$output" =~ "6" ]] || false
 }
 
-@test "sql-merge: DOLT_MERGE with conflicts renders the conflicts table" {
+@test "sql-merge: DOLT_MERGE with conflicts renders the dolt_conflicts table" {
       run dolt sql --continue << SQL
 CREATE TABLE one_pk (
   pk1 BIGINT NOT NULL,
@@ -483,7 +483,7 @@ SELECT DOLT_MERGE('feature-branch');
 SELECT COUNT(*) FROM dolt_conflicts;
 SQL
     [ $status -eq 0 ]
-    [[ $output =~ "merge has unresolved conflicts" ]] || false
+    [[ $output =~ "merge has unresolved conflicts. please use the dolt_conflicts table to resolve" ]] || false
     [[ "$output" =~ "| COUNT(*) |" ]] || false
     [[ "$output" =~ "| 1        |" ]] || false
 }

--- a/integration-tests/bats/sql-merge.bats
+++ b/integration-tests/bats/sql-merge.bats
@@ -480,7 +480,7 @@ INSERT INTO one_pk (pk1,c1,c2) VALUES (0,1,1);
 SELECT DOLT_COMMIT('-a', '-m', 'changed feature branch');
 SELECT DOLT_CHECKOUT('master');
 SELECT DOLT_MERGE('feature-branch');
-SELECT COUNT(*) FROM dolt_conflicts;
+SELECT COUNT(*) FROM dolt_conflicts where num_conflicts > 0;
 SQL
     [ $status -eq 0 ]
     [[ $output =~ "merge has unresolved conflicts. please use the dolt_conflicts table to resolve" ]] || false

--- a/integration-tests/bats/sql-merge.bats
+++ b/integration-tests/bats/sql-merge.bats
@@ -462,6 +462,33 @@ SQL
     [[ "$output" =~ "6" ]] || false
 }
 
+@test "sql-merge: DOLT_MERGE with conflicts renders the conflicts table" {
+      run dolt sql --continue << SQL
+CREATE TABLE one_pk (
+  pk1 BIGINT NOT NULL,
+  c1 BIGINT,
+  c2 BIGINT,
+  PRIMARY KEY (pk1)
+);
+SELECT DOLT_COMMIT('-a', '-m', 'add tables');
+SELECT DOLT_CHECKOUT('-b', 'feature-branch');
+SELECT DOLT_CHECKOUT('master');
+INSERT INTO one_pk (pk1,c1,c2) VALUES (0,0,0);
+SELECT DOLT_COMMIT('-a', '-m', 'changed master');
+SELECT DOLT_CHECKOUT('feature-branch');
+INSERT INTO one_pk (pk1,c1,c2) VALUES (0,1,1);
+SELECT DOLT_COMMIT('-a', '-m', 'changed feature branch');
+SELECT DOLT_CHECKOUT('master');
+SELECT DOLT_MERGE('feature-branch');
+SELECT COUNT(*) FROM dolt_conflicts;
+SQL
+    [ $status -eq 0 ]
+    [[ $output =~ "merge has unresolved conflicts" ]] || false
+    [[ "$output" =~ "| COUNT(*) |" ]] || false
+    [[ "$output" =~ "| 1        |" ]] || false
+}
+
+
 get_head_commit() {
     dolt log -n 1 | grep -m 1 commit | cut -c 8-
 }


### PR DESCRIPTION
Previously when DOLT_MERGE would face conflicts on the merge root it would error out and not update the working session root. With this pr, when a merge conflicts occurs we write to the working session root thereby rendering the dolt_conflicts table appropriately. 