### PR TITLE
Fix csv export types

### DIFF
--- a/go/libraries/doltcore/table/untyped/csv/writer.go
+++ b/go/libraries/doltcore/table/untyped/csv/writer.go
@@ -18,13 +18,14 @@ import (
 	"bufio"
 	"context"
 	"errors"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlutil"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlutil"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"

--- a/go/libraries/doltcore/table/untyped/csv/writer.go
+++ b/go/libraries/doltcore/table/untyped/csv/writer.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"context"
 	"errors"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlutil"
 	"io"
 	"os"
 	"path/filepath"
@@ -28,7 +29,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
-	"github.com/dolthub/dolt/go/store/types"
 )
 
 // writeBufSize is the size of the buffer used when writing a csv file.  It is set at the package level and all
@@ -104,31 +104,20 @@ func (csvw *CSVWriter) GetSchema() schema.Schema {
 // WriteRow will write a row to a table
 func (csvw *CSVWriter) WriteRow(ctx context.Context, r row.Row) error {
 	allCols := csvw.sch.GetAllCols()
+	colValStrs := make([]*string, allCols.Size())
 
-	colValStrs := make([]*string, 0, allCols.Size())
-	_, err := r.IterSchema(csvw.sch, func(tag uint64, val types.Value) (stop bool, err error) {
-		val, ok := r.GetColVal(tag)
-		if !ok || types.IsNull(val) {
-			colValStrs = append(colValStrs, nil)
-			return false, nil
-		}
-
-		var v string
-		if val.Kind() == types.StringKind {
-			v = string(val.(types.String))
-		} else {
-			v, err = types.EncodedValue(ctx, val)
-			if err != nil {
-				return false, err
-			}
-		}
-		colValStrs = append(colValStrs, &v)
-
-		return false, nil
-	})
-
+	sqlRow, err := sqlutil.DoltRowToSqlRow(r, csvw.GetSchema())
 	if err != nil {
 		return err
+	}
+
+	for i, val := range sqlRow {
+		if val == nil {
+			colValStrs[i] = nil
+		} else {
+			v := sqlutil.SqlColToStr(ctx, val)
+			colValStrs[i] = &v
+		}
 	}
 
 	return csvw.write(colValStrs)

--- a/go/libraries/doltcore/table/untyped/csv/writer_test.go
+++ b/go/libraries/doltcore/table/untyped/csv/writer_test.go
@@ -18,9 +18,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
+	"github.com/dolthub/dolt/go/libraries/doltcore/table/untyped"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
-	"github.com/dolthub/dolt/go/libraries/doltcore/table/untyped"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/store/types"
 )
@@ -35,15 +37,15 @@ const (
 )
 
 var _, outSch = untyped.NewUntypedSchema(nameColName, ageColName, titleColName)
+var inCols = []schema.Column{
+	{Name: nameColName, Tag: nameColTag, Kind: types.StringKind, IsPartOfPK: true, Constraints: nil, TypeInfo: typeinfo.StringDefaultType},
+	{Name: ageColName, Tag: ageColTag, Kind: types.UintKind, IsPartOfPK: false, Constraints: nil, TypeInfo: typeinfo.Uint64Type},
+	{Name: titleColName, Tag: titleColTag, Kind: types.StringKind, IsPartOfPK: false, Constraints: nil, TypeInfo: typeinfo.StringDefaultType},
+}
+var colColl = schema.NewColCollection(inCols...)
+var rowSch = schema.MustSchemaFromCols(colColl)
 
 func getSampleRows() (rows []row.Row) {
-	var inCols = []schema.Column{
-		{Name: nameColName, Tag: nameColTag, Kind: types.StringKind, IsPartOfPK: true, Constraints: nil},
-		{Name: ageColName, Tag: ageColTag, Kind: types.UintKind, IsPartOfPK: false, Constraints: nil},
-		{Name: titleColName, Tag: titleColTag, Kind: types.StringKind, IsPartOfPK: false, Constraints: nil},
-	}
-	colColl := schema.NewColCollection(inCols...)
-	rowSch := schema.MustSchemaFromCols(colColl)
 	return []row.Row{
 		mustRow(row.New(types.Format_Default, rowSch, row.TaggedValues{
 			nameColTag:  types.String("Bill Billerson"),
@@ -92,7 +94,7 @@ Andy Anderson,27,
 	rows := getSampleRows()
 
 	fs := filesys.NewInMemFS(nil, nil, root)
-	csvWr, err := OpenCSVWriter(path, fs, outSch, info)
+	csvWr, err := OpenCSVWriter(path, fs, rowSch, info)
 
 	if err != nil {
 		t.Fatal("Could not open CSVWriter", err)
@@ -124,7 +126,7 @@ Andy Anderson|27|
 	rows := getSampleRows()
 
 	fs := filesys.NewInMemFS(nil, nil, root)
-	csvWr, err := OpenCSVWriter(path, fs, outSch, info)
+	csvWr, err := OpenCSVWriter(path, fs, rowSch, info)
 
 	if err != nil {
 		t.Fatal("Could not open CSVWriter", err)

--- a/go/libraries/doltcore/table/untyped/csv/writer_test.go
+++ b/go/libraries/doltcore/table/untyped/csv/writer_test.go
@@ -18,11 +18,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
-	"github.com/dolthub/dolt/go/libraries/doltcore/table/untyped"
-
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/store/types"
 )
@@ -36,7 +34,6 @@ const (
 	titleColTag  = 2
 )
 
-var _, outSch = untyped.NewUntypedSchema(nameColName, ageColName, titleColName)
 var inCols = []schema.Column{
 	{Name: nameColName, Tag: nameColTag, Kind: types.StringKind, IsPartOfPK: true, Constraints: nil, TypeInfo: typeinfo.StringDefaultType},
 	{Name: ageColName, Tag: ageColTag, Kind: types.UintKind, IsPartOfPK: false, Constraints: nil, TypeInfo: typeinfo.Uint64Type},

--- a/integration-tests/bats/export-tables.bats
+++ b/integration-tests/bats/export-tables.bats
@@ -169,8 +169,20 @@ if rows[2] != "9,8,7,6,5,4".split(","):
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Successfully exported data." ]] ||  false
 
-    # output will be slit over two lines
-    cat export.csv
+    # output will be split over two lines
     grep 'id,j' export.csv
     tail -n 1 export.csv | awk -F "," '{print $2}' | jq --slurp '.[1]' | grep "hi"
+}
+
+@test "export-tables: uint schema parsing for writer_test.go backwards compatibility" {
+    dolt sql -q "create table t2 (name text, age int unsigned, title text)"
+    dolt sql -q "insert into t2 values ('Bill Billerson', 32, 'Senior Dufus')"
+
+    run dolt table export t2 export.csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Successfully exported data." ]] ||  false
+
+    # output will be split over two lines
+    grep 'name,age,title' export.csv
+    grep 'Bill Billerson,32,Senior Dufus' export.csv
 }

--- a/integration-tests/bats/export-tables.bats
+++ b/integration-tests/bats/export-tables.bats
@@ -160,3 +160,17 @@ if rows[2] != "9,8,7,6,5,4".split(","):
     run dolt table import -u person_info export-csv.csv
     [ "$status" -eq 0 ]
 }
+
+@test "export-tables: export a table with a json string to csv" {
+    dolt sql -q "create table t2 (id int primary key, j JSON)"
+    dolt sql -q "insert into t2 values (0, '[\"hi\"]')"
+
+    run dolt table export t2 export.csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Successfully exported data." ]] ||  false
+
+    # output will be slit over two lines
+    cat export.csv
+    grep 'id,j' export.csv
+    tail -n 1 export.csv | awk -F "," '{print $2}' | jq --slurp '.[1]' | grep "hi"
+}


### PR DESCRIPTION
- JSON strings were not serialized in CSV writing
- convert Dolt rows to SQL Rows, and lean on the `SqlColToStr` to correctly parse values to strings.
- manually handle nil values to match bats tests CSV export format