### PR TITLE
Max/dsess

### DIFF
--- a/go/cmd/dolt/commands/filter-branch.go
+++ b/go/cmd/dolt/commands/filter-branch.go
@@ -271,7 +271,7 @@ func monoSqlEngine(ctx context.Context, dEnv *env.DoltEnv, cm *doltdb.Commit) (*
 		Db:         db,
 		HeadCommit: headCommit,
 		WorkingSet: ws,
-		DbData: dEnv.DbData(),
+		DbData:     dEnv.DbData(),
 	}
 
 	err = dsess.AddDB(sqlCtx, dbState)

--- a/go/cmd/dolt/commands/filter-branch.go
+++ b/go/cmd/dolt/commands/filter-branch.go
@@ -17,6 +17,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"io"
 	"runtime"
 	"strings"
@@ -230,10 +231,10 @@ func processFilterQuery(ctx context.Context, dEnv *env.DoltEnv, cm *doltdb.Commi
 
 // monoSqlEngine packages up the context necessary to run sql queries against single root.
 func monoSqlEngine(ctx context.Context, dEnv *env.DoltEnv, cm *doltdb.Commit) (*sql.Context, *sqlEngine, error) {
-	dsess := dsqle.DefaultDoltSession()
+	sess := dsess.DefaultSession()
 
 	sqlCtx := sql.NewContext(ctx,
-		sql.WithSession(dsess),
+		sql.WithSession(sess),
 		sql.WithIndexRegistry(sql.NewIndexRegistry()),
 		sql.WithViewRegistry(sql.NewViewRegistry()),
 		sql.WithTracer(tracing.Tracer(ctx)))
@@ -267,14 +268,14 @@ func monoSqlEngine(ctx context.Context, dEnv *env.DoltEnv, cm *doltdb.Commit) (*
 		return nil, nil, err
 	}
 
-	dbState := dsqle.InitialDbState{
+	dbState := dsess.InitialDbState{
 		Db:         db,
 		HeadCommit: headCommit,
 		WorkingSet: ws,
 		DbData:     dEnv.DbData(),
 	}
 
-	err = dsess.AddDB(sqlCtx, dbState)
+	err = sess.AddDB(sqlCtx, dbState)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/cmd/dolt/commands/merge.go
+++ b/go/cmd/dolt/commands/merge.go
@@ -305,11 +305,11 @@ func applyChanges(ctx context.Context, root *doltdb.RootValue, workingDiffs map[
 }
 
 func executeFFMerge(
-		ctx context.Context,
-		squash bool,
-		dEnv *env.DoltEnv,
-		mergeCommit *doltdb.Commit,
-		workingDiffs map[string]hash.Hash,
+	ctx context.Context,
+	squash bool,
+	dEnv *env.DoltEnv,
+	mergeCommit *doltdb.Commit,
+	workingDiffs map[string]hash.Hash,
 ) errhand.VerboseError {
 	cli.Println("Fast-forward")
 
@@ -482,13 +482,13 @@ func fkConstraintWarning(ctx context.Context, cm1, cm2 *doltdb.Commit) errhand.V
 
 // TODO: change this to be functional and not write to repo state
 func mergedRootToWorking(
-		ctx context.Context,
-		squash bool,
-		dEnv *env.DoltEnv,
-		mergedRoot *doltdb.RootValue,
-		workingDiffs map[string]hash.Hash,
-		cm2 *doltdb.Commit,
-		tblToStats map[string]*merge.MergeStats,
+	ctx context.Context,
+	squash bool,
+	dEnv *env.DoltEnv,
+	mergedRoot *doltdb.RootValue,
+	workingDiffs map[string]hash.Hash,
+	cm2 *doltdb.Commit,
+	tblToStats map[string]*merge.MergeStats,
 ) errhand.VerboseError {
 	var err error
 

--- a/go/cmd/dolt/commands/reset.go
+++ b/go/cmd/dolt/commands/reset.go
@@ -89,42 +89,42 @@ func (cmd ResetCmd) Exec(ctx context.Context, commandStr string, args []string, 
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-		if apr.ContainsAll(HardResetParam, SoftResetParam) {
-			verr := errhand.BuildDError("error: --%s and --%s are mutually exclusive options.", HardResetParam, SoftResetParam).Build()
-			HandleVErrAndExitCode(verr, usage)
-		} else if apr.Contains(HardResetParam) {
-			arg := ""
-			if apr.NArg() > 1 {
-				return handleResetError(fmt.Errorf("--hard supports at most one additional param"), usage)
-			} else if apr.NArg() == 1 {
-				arg = apr.Arg(0)
-			}
+	if apr.ContainsAll(HardResetParam, SoftResetParam) {
+		verr := errhand.BuildDError("error: --%s and --%s are mutually exclusive options.", HardResetParam, SoftResetParam).Build()
+		HandleVErrAndExitCode(verr, usage)
+	} else if apr.Contains(HardResetParam) {
+		arg := ""
+		if apr.NArg() > 1 {
+			return handleResetError(fmt.Errorf("--hard supports at most one additional param"), usage)
+		} else if apr.NArg() == 1 {
+			arg = apr.Arg(0)
+		}
 
-			err = actions.ResetHard(ctx, dEnv, arg, roots)
-		} else {
-			// Check whether the input argument is a ref.
-			if apr.NArg() == 1 {
-				argToCheck := apr.Arg(0)
+		err = actions.ResetHard(ctx, dEnv, arg, roots)
+	} else {
+		// Check whether the input argument is a ref.
+		if apr.NArg() == 1 {
+			argToCheck := apr.Arg(0)
 
-				ok := actions.ValidateIsRef(ctx, argToCheck, dEnv.DoltDB, dEnv.RepoStateReader())
+			ok := actions.ValidateIsRef(ctx, argToCheck, dEnv.DoltDB, dEnv.RepoStateReader())
 
-				// This is a valid ref
-				if ok {
-					err = actions.ResetSoftToRef(ctx, dEnv.DbData(), apr.Arg(0))
-					return handleResetError(err, usage)
-				}
-			}
-
-			tables := apr.Args()
-
-			roots.Staged, err = actions.ResetSoft(ctx, dEnv.DbData(), tables, roots)
-
-			if err != nil {
+			// This is a valid ref
+			if ok {
+				err = actions.ResetSoftToRef(ctx, dEnv.DbData(), apr.Arg(0))
 				return handleResetError(err, usage)
 			}
-
-			printNotStaged(ctx, dEnv, roots.Staged)
 		}
+
+		tables := apr.Args()
+
+		roots.Staged, err = actions.ResetSoft(ctx, dEnv.DbData(), tables, roots)
+
+		if err != nil {
+			return handleResetError(err, usage)
+		}
+
+		printNotStaged(ctx, dEnv, roots.Staged)
+	}
 
 	return handleResetError(err, usage)
 }

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -17,6 +17,7 @@ package sqlserver
 import (
 	"context"
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"net"
 	"strconv"
 	"time"
@@ -177,7 +178,7 @@ func newSessionBuilder(sqlEngine *sqle.Engine, username, email string, mrEnv env
 			return nil, nil, nil, err
 		}
 
-		doltSess, err := dsqle.NewDoltSession(tmpSqlCtx, mysqlSess, username, email, dbStates...)
+		doltSess, err := dsess.NewSession(tmpSqlCtx, mysqlSess, username, email, dbStates...)
 
 		if err != nil {
 			return nil, nil, nil, err
@@ -231,8 +232,8 @@ func dbsAsDSQLDBs(dbs []sql.Database) []dsqle.Database {
 	return dsqlDBs
 }
 
-func getDbStates(ctx context.Context, mrEnv env.MultiRepoEnv, dbs []dsqle.Database) ([]dsqle.InitialDbState, error) {
-	var dbStates []dsqle.InitialDbState
+func getDbStates(ctx context.Context, mrEnv env.MultiRepoEnv, dbs []dsqle.Database) ([]dsess.InitialDbState, error) {
+	var dbStates []dsess.InitialDbState
 
 	for _, db := range dbs {
 		var dEnv *env.DoltEnv
@@ -259,7 +260,7 @@ func getDbStates(ctx context.Context, mrEnv env.MultiRepoEnv, dbs []dsqle.Databa
 			return nil, err
 		}
 
-		dbStates = append(dbStates, dsqle.InitialDbState{
+		dbStates = append(dbStates, dsess.InitialDbState{
 			Db:         db,
 			HeadCommit: headCommit,
 			WorkingSet: ws,

--- a/go/libraries/doltcore/diff/docs_diff_test.go
+++ b/go/libraries/doltcore/diff/docs_diff_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	filesys2 "github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
@@ -26,6 +25,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
+	filesys2 "github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/store/types"
 )
 

--- a/go/libraries/doltcore/doltdb/workingset.go
+++ b/go/libraries/doltcore/doltdb/workingset.go
@@ -96,8 +96,8 @@ type WorkingSet struct {
 
 func EmptyWorkingSet(wsRef ref.WorkingSetRef) *WorkingSet {
 	return &WorkingSet{
-		Name: wsRef.GetPath(),
-		format:      types.Format_Default,
+		Name:   wsRef.GetPath(),
+		format: types.Format_Default,
 	}
 }
 
@@ -255,11 +255,11 @@ func (ws *WorkingSet) Ref() ref.WorkingSetRef {
 
 // writeValues write the values in this working set to the database and returns them
 func (ws *WorkingSet) writeValues(ctx context.Context, db *DoltDB) (
-		workingRoot types.Ref,
-		stagedRoot *types.Ref,
-		mergeState *types.Ref,
-		err error,
-){
+	workingRoot types.Ref,
+	stagedRoot *types.Ref,
+	mergeState *types.Ref,
+	err error,
+) {
 
 	workingRoot, err = db.writeRootValue(ctx, ws.workingRoot)
 	if err != nil {

--- a/go/libraries/doltcore/doltdocs/docs_test.go
+++ b/go/libraries/doltcore/doltdocs/docs_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	filesys2 "github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -26,6 +25,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
+	filesys2 "github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/store/types"
 )
 

--- a/go/libraries/doltcore/env/actions/staged.go
+++ b/go/libraries/doltcore/env/actions/staged.go
@@ -115,10 +115,10 @@ func stageTablesNoEnvUpdate(
 }
 
 func stageTables(
-		ctx context.Context,
-		roots doltdb.Roots,
-		rsw env.RepoStateWriter,
-		tbls []string,
+	ctx context.Context,
+	roots doltdb.Roots,
+	rsw env.RepoStateWriter,
+	tbls []string,
 ) error {
 	var err error
 	roots, err = stageTablesNoEnvUpdate(ctx, roots, tbls)

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -643,12 +643,12 @@ func (dEnv *DoltEnv) DbData() DbData {
 
 // StagedRoot returns the staged root value in the current working set
 func (dEnv *DoltEnv) StagedRoot(ctx context.Context) (*doltdb.RootValue, error) {
-		workingSet, err := dEnv.WorkingSet(ctx)
-		if err != nil {
-			return nil, err
-		}
+	workingSet, err := dEnv.WorkingSet(ctx)
+	if err != nil {
+		return nil, err
+	}
 
-		return workingSet.StagedRoot(), nil
+	return workingSet.StagedRoot(), nil
 }
 
 // UpdateStagedRoot updates the staged root for the current working branch. This can fail if multiple clients attempt
@@ -681,7 +681,7 @@ func (dEnv *DoltEnv) UpdateStagedRoot(ctx context.Context, newRoot *doltdb.RootV
 
 func (dEnv *DoltEnv) AbortMerge(ctx context.Context) error {
 	ws, err := dEnv.WorkingSet(ctx)
-   if err != nil {
+	if err != nil {
 		return err
 	}
 

--- a/go/libraries/doltcore/env/environment_test.go
+++ b/go/libraries/doltcore/env/environment_test.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -31,6 +30,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdocs"
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
+	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/types"
 )
 

--- a/go/libraries/doltcore/env/repo_state.go
+++ b/go/libraries/doltcore/env/repo_state.go
@@ -85,9 +85,9 @@ type repoStateLegacy struct {
 	Head     ref.MarshalableRef      `json:"head"`
 	Remotes  map[string]Remote       `json:"remotes"`
 	Branches map[string]BranchConfig `json:"branches"`
-	Staged  string                   `json:"staged,omitempty"`
-	Working string                   `json:"working,omitempty"`
-	Merge   *mergeState              `json:"merge,omitempty"`
+	Staged   string                  `json:"staged,omitempty"`
+	Working  string                  `json:"working,omitempty"`
+	Merge    *mergeState             `json:"merge,omitempty"`
 }
 
 // repoStateLegacyFromRepoState creates a new repoStateLegacy from a RepoState file. Only for testing.

--- a/go/libraries/doltcore/merge/merge.go
+++ b/go/libraries/doltcore/merge/merge.go
@@ -20,12 +20,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
+	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
@@ -872,8 +872,8 @@ func getWorkingRoot(ctx context.Context, ddb *doltdb.DoltDB, rsr env.RepoStateRe
 }
 
 func GetTablesInConflict(ctx context.Context, roots doltdb.Roots) (
-		workingInConflict, stagedInConflict, headInConflict []string,
-		err error,
+	workingInConflict, stagedInConflict, headInConflict []string,
+	err error,
 ) {
 	headInConflict, err = roots.Head.TablesInConflict(ctx)
 	if err != nil {

--- a/go/libraries/doltcore/merge/merge_test.go
+++ b/go/libraries/doltcore/merge/merge_test.go
@@ -19,7 +19,6 @@ import (
 	"strconv"
 	"testing"
 
-	filesys2 "github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,6 +28,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
+	filesys2 "github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/store/types"
 )
 

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -1076,22 +1076,22 @@ func (db Database) GetAllTemporaryTables(ctx *sql.Context) ([]sql.Table, error) 
 
 	root := dsess.dbStates[db.name].tempTableRoot
 	if root != nil {
-			tNames, err := root.GetTableNames(ctx)
+		tNames, err := root.GetTableNames(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, tName := range tNames {
+			tbl, ok, err := db.GetTableInsensitive(ctx, tName)
 			if err != nil {
 				return nil, err
 			}
 
-			for _, tName := range tNames {
-				tbl, ok, err := db.GetTableInsensitive(ctx, tName)
-				if err != nil {
-					return nil, err
-				}
-
-				if ok {
-					tables = append(tables, tbl)
-				}
+			if ok {
+				tables = append(tables, tbl)
 			}
 		}
+	}
 
 	return tables, nil
 }

--- a/go/libraries/doltcore/sqle/database_test.go
+++ b/go/libraries/doltcore/sqle/database_test.go
@@ -15,6 +15,7 @@
 package sqle
 
 import (
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,10 +28,10 @@ func testKeyFunc(t *testing.T, keyFunc func(string) (bool, string), testVal stri
 }
 
 func TestIsKeyFuncs(t *testing.T) {
-	testKeyFunc(t, IsHeadKey, "", false, "")
-	testKeyFunc(t, IsWorkingKey, "", false, "")
-	testKeyFunc(t, IsHeadKey, "dolt_head", true, "dolt")
-	testKeyFunc(t, IsWorkingKey, "dolt_head", false, "")
-	testKeyFunc(t, IsHeadKey, "dolt_working", false, "")
-	testKeyFunc(t, IsWorkingKey, "dolt_working", true, "dolt")
+	testKeyFunc(t, dsess.IsHeadKey, "", false, "")
+	testKeyFunc(t, dsess.IsWorkingKey, "", false, "")
+	testKeyFunc(t, dsess.IsHeadKey, "dolt_head", true, "dolt")
+	testKeyFunc(t, dsess.IsWorkingKey, "dolt_head", false, "")
+	testKeyFunc(t, dsess.IsHeadKey, "dolt_working", false, "")
+	testKeyFunc(t, dsess.IsWorkingKey, "dolt_working", true, "dolt")
 }

--- a/go/libraries/doltcore/sqle/dfunctions/active_branch.go
+++ b/go/libraries/doltcore/sqle/dfunctions/active_branch.go
@@ -16,11 +16,11 @@ package dfunctions
 
 import (
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 )
 
 const ActiveBranchFuncName = "active_branch"
@@ -36,7 +36,7 @@ func NewActiveBranchFunc(ctx *sql.Context) sql.Expression {
 // Eval implements the Expression interface.
 func (ab *ActiveBranchFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	dbName := ctx.GetCurrentDatabase()
-	dSess := sqle.DSessFromSess(ctx.Session)
+	dSess := dsess.DSessFromSess(ctx.Session)
 
 	ddb, ok := dSess.GetDoltDB(dbName)
 

--- a/go/libraries/doltcore/sqle/dfunctions/commit.go
+++ b/go/libraries/doltcore/sqle/dfunctions/commit.go
@@ -18,10 +18,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/dolthub/go-mysql-server/sql"
+
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
-	"github.com/dolthub/go-mysql-server/sql"
 )
 
 const CommitFuncName = "commit"

--- a/go/libraries/doltcore/sqle/dfunctions/commit.go
+++ b/go/libraries/doltcore/sqle/dfunctions/commit.go
@@ -16,13 +16,13 @@ package dfunctions
 
 import (
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 )
 
 const CommitFuncName = "commit"
@@ -39,7 +39,7 @@ func NewCommitFunc(ctx *sql.Context, args ...sql.Expression) (sql.Expression, er
 // Eval implements the Expression interface.
 func (cf *CommitFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	dbName := ctx.GetCurrentDatabase()
-	dSess := sqle.DSessFromSess(ctx.Session)
+	dSess := dsess.DSessFromSess(ctx.Session)
 
 	//  Get the params associated with COMMIT.
 	ap := cli.CreateCommitArgParser()

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_add.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_add.go
@@ -18,11 +18,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/dolthub/go-mysql-server/sql"
+
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
-	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/sirupsen/logrus"
 )
 
 const DoltAddFuncName = "dolt_add"

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_add.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_add.go
@@ -16,13 +16,13 @@ package dfunctions
 
 import (
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 )
 
 const DoltAddFuncName = "dolt_add"
@@ -52,7 +52,7 @@ func (d DoltAddFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 
 	allFlag := apr.Contains(cli.AllFlag)
 
-	dSess := sqle.DSessFromSess(ctx.Session)
+	dSess := dsess.DSessFromSess(ctx.Session)
 	roots, ok := dSess.GetRoots(dbName)
 	if apr.NArg() == 0 && !allFlag {
 		return 1, fmt.Errorf("Nothing specified, nothing added. Maybe you wanted to say 'dolt add .'?")

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_checkout.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_checkout.go
@@ -19,14 +19,14 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
-	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
+	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 )
 
@@ -215,7 +215,6 @@ func updateHeadAndWorkingSessionVars(ctx *sql.Context, dbName string, roots dolt
 	dSess := sqle.DSessFromSess(ctx.Session)
 	return dSess.SetRoots(ctx, dbName, roots)
 }
-
 
 func (d DoltCheckoutFunc) String() string {
 	childrenStrings := make([]string, len(d.Children()))

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_checkout.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_checkout.go
@@ -17,6 +17,7 @@ package dfunctions
 import (
 	"errors"
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -27,7 +28,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 )
 
 const DoltCheckoutFuncName = "dolt_checkout"
@@ -64,7 +64,7 @@ func (d DoltCheckoutFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, erro
 	}
 
 	// Checking out new branch.
-	dSess := sqle.DSessFromSess(ctx.Session)
+	dSess := dsess.DSessFromSess(ctx.Session)
 	dbData, ok := dSess.GetDbData(dbName)
 	if !ok {
 		return 1, fmt.Errorf("Could not load database %s", dbName)
@@ -186,7 +186,7 @@ func checkoutBranch(ctx *sql.Context, dbName string, roots doltdb.Roots, dbData 
 		return err
 	}
 
-	dSess := sqle.DSessFromSess(ctx.Session)
+	dSess := dsess.DSessFromSess(ctx.Session)
 	// TODO: this may not be right for the SQL context, need to not take working set changes with us, maybe die if the
 	//  working set is dirty, or force a commit first
 	newWorkingSet := ws.WithWorkingRoot(roots.Working).WithStagedRoot(roots.Staged)
@@ -212,7 +212,7 @@ func checkoutTables(ctx *sql.Context, roots doltdb.Roots, name string, tables []
 
 // updateHeadAndWorkingSessionVars explicitly sets the head and working hash.
 func updateHeadAndWorkingSessionVars(ctx *sql.Context, dbName string, roots doltdb.Roots) error {
-	dSess := sqle.DSessFromSess(ctx.Session)
+	dSess := dsess.DSessFromSess(ctx.Session)
 	return dSess.SetRoots(ctx, dbName, roots)
 }
 

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_commit.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_commit.go
@@ -17,11 +17,11 @@ package dfunctions
 import (
 	"fmt"
 
-	"github.com/dolthub/dolt/go/cmd/dolt/cli"
-	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/vitess/go/vt/proto/query"
 
+	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 )
 
@@ -107,7 +107,7 @@ func (d DoltCommitFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error)
 	commit, err := actions.CommitStaged(ctx, roots, dbData, actions.CommitStagedProps{
 		Message:          msg,
 		Date:             t,
-		AllowEmpty: apr.Contains(cli.AllowEmptyFlag),
+		AllowEmpty:       apr.Contains(cli.AllowEmptyFlag),
 		CheckForeignKeys: !apr.Contains(cli.ForceFlag),
 		Name:             name,
 		Email:            email,

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_commit.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_commit.go
@@ -16,13 +16,13 @@ package dfunctions
 
 import (
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/vitess/go/vt/proto/query"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 )
 
 const DoltCommitFuncName = "dolt_commit"
@@ -55,7 +55,7 @@ func (d DoltCommitFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error)
 		return nil, err
 	}
 
-	dSess := sqle.DSessFromSess(ctx.Session)
+	dSess := dsess.DSessFromSess(ctx.Session)
 	dbData, ok := dSess.GetDbData(dbName)
 	if !ok {
 		return nil, fmt.Errorf("Could not load database %s", dbName)

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_merge.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_merge.go
@@ -17,6 +17,7 @@ package dfunctions
 import (
 	"errors"
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -27,7 +28,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/merge"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 )
 
@@ -44,7 +44,7 @@ func (d DoltMergeFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) 
 		return 1, fmt.Errorf("Empty database name.")
 	}
 
-	sess := sqle.DSessFromSess(ctx.Session)
+	sess := dsess.DSessFromSess(ctx.Session)
 	dbData, ok := sess.GetDbData(dbName)
 
 	if !ok {
@@ -198,7 +198,7 @@ func executeMerge(ctx *sql.Context, squash bool, head, cm *doltdb.Commit, name s
 	return mergeRootToWorking(squash, ws, mergeRoot, cm, mergeStats)
 }
 
-func executeFFMerge(ctx *sql.Context, sess *sqle.DoltSession, squash bool, dbName string, ws *doltdb.WorkingSet, dbData env.DbData, cm2 *doltdb.Commit) error {
+func executeFFMerge(ctx *sql.Context, sess *dsess.Session, squash bool, dbName string, ws *doltdb.WorkingSet, dbData env.DbData, cm2 *doltdb.Commit) error {
 	rv, err := cm2.GetRootValue()
 	if err != nil {
 		return err
@@ -221,7 +221,7 @@ func executeFFMerge(ctx *sql.Context, sess *sqle.DoltSession, squash bool, dbNam
 
 func executeNoFFMerge(
 	ctx *sql.Context,
-	dSess *sqle.DoltSession,
+	dSess *dsess.Session,
 	apr *argparser.ArgParseResults,
 	dbName string,
 	ws *doltdb.WorkingSet,

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_merge.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_merge.go
@@ -19,13 +19,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
+	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/merge"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_merge_base.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_merge_base.go
@@ -16,13 +16,13 @@ package dfunctions
 
 import (
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/merge"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 )
 
 const DoltMergeBaseFuncName = "dolt_merge_base"
@@ -81,7 +81,7 @@ func resolveRefSpecs(ctx *sql.Context, leftSpec, rightSpec string) (left, right 
 		return nil, nil, err
 	}
 
-	sess := sqle.DSessFromSess(ctx.Session)
+	sess := dsess.DSessFromSess(ctx.Session)
 	dbName := ctx.GetCurrentDatabase()
 
 	dbData, ok := sess.GetDbData(dbName)

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_reset.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_reset.go
@@ -16,6 +16,7 @@ package dfunctions
 
 import (
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -23,7 +24,6 @@ import (
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 )
 
 const DoltResetFuncName = "dolt_reset"
@@ -39,7 +39,7 @@ func (d DoltResetFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) 
 		return 1, fmt.Errorf("Empty database name.")
 	}
 
-	dSess := sqle.DSessFromSess(ctx.Session)
+	dSess := dsess.DSessFromSess(ctx.Session)
 	dbData, ok := dSess.GetDbData(dbName)
 
 	if !ok {

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_reset.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_reset.go
@@ -18,11 +18,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/dolthub/go-mysql-server/sql"
+
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
-	"github.com/dolthub/go-mysql-server/sql"
 )
 
 const DoltResetFuncName = "dolt_reset"

--- a/go/libraries/doltcore/sqle/dfunctions/hashof.go
+++ b/go/libraries/doltcore/sqle/dfunctions/hashof.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -25,7 +26,6 @@ import (
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 )
 
 const HashOfFuncName = "hashof"
@@ -63,14 +63,14 @@ func (t *HashOf) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	}
 
 	dbName := ctx.GetCurrentDatabase()
-	ddb, ok := sqle.DSessFromSess(ctx.Session).GetDoltDB(dbName)
+	ddb, ok := dsess.DSessFromSess(ctx.Session).GetDoltDB(dbName)
 	if !ok {
 		return nil, sql.ErrDatabaseNotFound.New(dbName)
 	}
 
 	var cm *doltdb.Commit
 	if strings.ToUpper(name) == "HEAD" {
-		sess := sqle.DSessFromSess(ctx.Session)
+		sess := dsess.DSessFromSess(ctx.Session)
 
 		cm, err = sess.GetHeadCommit(ctx, dbName)
 		if err != nil {

--- a/go/libraries/doltcore/sqle/dfunctions/merge.go
+++ b/go/libraries/doltcore/sqle/dfunctions/merge.go
@@ -17,6 +17,7 @@ package dfunctions
 import (
 	"errors"
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -24,7 +25,6 @@ import (
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/merge"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 	"github.com/dolthub/dolt/go/store/hash"
 )
 
@@ -41,7 +41,7 @@ func NewMergeFunc(ctx *sql.Context, args ...sql.Expression) (sql.Expression, err
 
 // Eval implements the Expression interface.
 func (cf *MergeFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	sess := sqle.DSessFromSess(ctx.Session)
+	sess := dsess.DSessFromSess(ctx.Session)
 
 	// TODO: Move to a separate MERGE argparser.
 	ap := cli.CreateCommitArgParser()
@@ -185,7 +185,7 @@ func getBranchCommit(ctx *sql.Context, val interface{}, ddb *doltdb.DoltDB) (*do
 	return cm, cmh, nil
 }
 
-func getHead(ctx *sql.Context, sess *sqle.DoltSession, dbName string) (*doltdb.Commit, hash.Hash, *doltdb.RootValue, error) {
+func getHead(ctx *sql.Context, sess *dsess.Session, dbName string) (*doltdb.Commit, hash.Hash, *doltdb.RootValue, error) {
 	head, err := sess.GetHeadCommit(ctx, dbName)
 	if err != nil {
 		return nil, hash.Hash{}, nil, err

--- a/go/libraries/doltcore/sqle/dfunctions/reset.go
+++ b/go/libraries/doltcore/sqle/dfunctions/reset.go
@@ -16,12 +16,12 @@ package dfunctions
 
 import (
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 	"github.com/dolthub/dolt/go/store/hash"
 )
 
@@ -53,7 +53,7 @@ func (rf ResetFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	}
 
 	dbName := ctx.GetCurrentDatabase()
-	dSess := sqle.DSessFromSess(ctx.Session)
+	dSess := dsess.DSessFromSess(ctx.Session)
 
 	var h hash.Hash
 	if strings.ToLower(arg) != resetHardParameter {

--- a/go/libraries/doltcore/sqle/dfunctions/squash.go
+++ b/go/libraries/doltcore/sqle/dfunctions/squash.go
@@ -16,12 +16,12 @@ package dfunctions
 
 import (
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/merge"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 )
 
 const SquashFuncName = "squash"
@@ -35,7 +35,7 @@ func NewSquashFunc(ctx *sql.Context, child sql.Expression) sql.Expression {
 }
 
 func (s SquashFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	sess := sqle.DSessFromSess(ctx.Session)
+	sess := dsess.DSessFromSess(ctx.Session)
 
 	branchVal, err := s.Child.Eval(ctx, row)
 	if err != nil {

--- a/go/libraries/doltcore/sqle/dolt_session.go
+++ b/go/libraries/doltcore/sqle/dolt_session.go
@@ -593,7 +593,7 @@ func (sess *DoltSession) SetWorkingSet(
 		}
 	}
 
-	if headRoot != nil{
+	if headRoot != nil {
 		sessionState.headRoot = headRoot
 	}
 
@@ -615,7 +615,6 @@ func (sess *DoltSession) WorkingSet(ctx *sql.Context, dbName string) *doltdb.Wor
 	sessionState := sess.dbStates[dbName]
 	return sessionState.workingSet
 }
-
 
 func (sess *DoltSession) GetTempTableRootValue(ctx *sql.Context, dbName string) (*doltdb.RootValue, bool) {
 	dbstate, ok := sess.dbStates[dbName]

--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -179,21 +179,6 @@ type InitialDbState struct {
 
 // NewSession creates a Session object from a standard sql.Session and 0 or more Database objects.
 func NewSession(ctx *sql.Context, sqlSess sql.Session, username, email string, dbs ...InitialDbState) (*Session, error) {
-
-	// TODO: kill this with fire
-	//dbDatas := make(map[string]env.DbData)
-	//editSessions := make(map[string]*editor.TableEditSession)
-
-	//for _, state := range dbs {
-		//db, ok := state.Db.(Database)
-		//if !ok {
-			//return nil, fmt.Errorf("expected a sqle.Database, but got %T", state.Db)
-		//}
-
-		//dbDatas[db.Name()] = env.DbData{Rsw: db.rsw, Ddb: db.ddb, Rsr: db.rsr, Drw: db.drw}
-		//editSessions[db.Name()] = editor.CreateTableEditSession(nil, editor.TableEditSessionProps{})
-	//}
-
 	sess := &Session{
 		Session:  sqlSess,
 		Username: username,

--- a/go/libraries/doltcore/sqle/dsess/transactions.go
+++ b/go/libraries/doltcore/sqle/dsess/transactions.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sqle
+package dsess
 
 import (
 	"fmt"

--- a/go/libraries/doltcore/sqle/dtables/status_table.go
+++ b/go/libraries/doltcore/sqle/dtables/status_table.go
@@ -18,13 +18,14 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/dolthub/go-mysql-server/sql"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/merge"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlutil"
 	"github.com/dolthub/dolt/go/store/types"
-	"github.com/dolthub/go-mysql-server/sql"
 )
 
 // StatusTable is a sql.Table implementation that implements a system table which shows the dolt branches

--- a/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
@@ -20,12 +20,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/go-mysql-server/enginetest"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/dtestutils"
+	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dfunctions"
 )

--- a/go/libraries/doltcore/sqle/logictest/dolt/doltharness.go
+++ b/go/libraries/doltcore/sqle/logictest/dolt/doltharness.go
@@ -17,6 +17,7 @@ package dolt
 import (
 	"context"
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"io"
 	"math/rand"
 	"strconv"
@@ -49,7 +50,7 @@ type DoltHarness struct {
 	Version string
 	engine  *sqle.Engine
 
-	sess    *dsql.DoltSession
+	sess    *dsess.Session
 	idxReg  *sql.IndexRegistry
 	viewReg *sql.ViewRegistry
 }
@@ -138,7 +139,7 @@ func innerInit(h *DoltHarness, dEnv *env.DoltEnv) error {
 		return err
 	}
 
-	h.sess = dsql.DefaultDoltSession()
+	h.sess = dsess.DefaultSession()
 	h.idxReg = sql.NewIndexRegistry()
 	h.viewReg = sql.NewViewRegistry()
 
@@ -154,7 +155,7 @@ func innerInit(h *DoltHarness, dEnv *env.DoltEnv) error {
 		dsqlDB := db.(dsql.Database)
 		dsqlDBs[i] = dsqlDB
 
-		sess := dsql.DSessFromSess(ctx.Session)
+		sess := dsess.DSessFromSess(ctx.Session)
 		err := sess.AddDB(ctx, getDbState(db, dEnv))
 
 		if err != nil {
@@ -186,7 +187,7 @@ func innerInit(h *DoltHarness, dEnv *env.DoltEnv) error {
 	return nil
 }
 
-func getDbState(db sql.Database, dEnv *env.DoltEnv) dsql.InitialDbState {
+func getDbState(db sql.Database, dEnv *env.DoltEnv) dsess.InitialDbState {
 	ctx := context.Background()
 
 	head := dEnv.RepoStateReader().CWBHeadSpec()
@@ -200,7 +201,7 @@ func getDbState(db sql.Database, dEnv *env.DoltEnv) dsql.InitialDbState {
 		panic(err)
 	}
 
-	return dsql.InitialDbState{
+	return dsess.InitialDbState{
 		Db:         db,
 		HeadCommit: headCommit,
 		WorkingSet: ws,

--- a/go/libraries/doltcore/sqle/logictest/dolt/doltharness.go
+++ b/go/libraries/doltcore/sqle/logictest/dolt/doltharness.go
@@ -23,18 +23,19 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dolthub/dolt/go/cmd/dolt/commands"
-	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
-	"github.com/dolthub/dolt/go/libraries/doltcore/env"
-	dsql "github.com/dolthub/dolt/go/libraries/doltcore/sqle"
-	"github.com/dolthub/dolt/go/libraries/utils/filesys"
-	"github.com/dolthub/dolt/go/store/types"
 	sqle "github.com/dolthub/go-mysql-server"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/sqllogictest/go/logictest"
 	"github.com/dolthub/vitess/go/vt/proto/query"
 	"github.com/dolthub/vitess/go/vt/sqlparser"
 	"github.com/shopspring/decimal"
+
+	"github.com/dolthub/dolt/go/cmd/dolt/commands"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/env"
+	dsql "github.com/dolthub/dolt/go/libraries/doltcore/sqle"
+	"github.com/dolthub/dolt/go/libraries/utils/filesys"
+	"github.com/dolthub/dolt/go/store/types"
 )
 
 var _ logictest.Harness = &DoltHarness{}

--- a/go/libraries/doltcore/sqle/mergeable_indexes_setup_test.go
+++ b/go/libraries/doltcore/sqle/mergeable_indexes_setup_test.go
@@ -17,6 +17,7 @@ package sqle
 import (
 	"context"
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"strings"
 	"testing"
 
@@ -99,7 +100,7 @@ func setupMergeableIndexes(t *testing.T, tableName, insertQuery string) (*sqle.E
 	engine.AddDatabase(mergeableDb)
 
 	// Get an updated root to use for the rest of the test
-	root, _ = DSessFromSess(sqlCtx.Session).GetRoot(mergeableDb.Name())
+	root, _ = dsess.DSessFromSess(sqlCtx.Session).GetRoot(mergeableDb.Name())
 
 	return engine, dEnv, mergeableDb, []*indexTuple{
 		idxv1ToTuple,

--- a/go/libraries/doltcore/sqle/mergeable_indexes_test.go
+++ b/go/libraries/doltcore/sqle/mergeable_indexes_test.go
@@ -17,6 +17,7 @@ package sqle
 import (
 	"context"
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"testing"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -1355,7 +1356,7 @@ func TestMergeableIndexes(t *testing.T) {
 
 			ctx := context.Background()
 			sqlCtx := NewTestSQLCtx(ctx)
-			session := DSessFromSess(sqlCtx.Session)
+			session := dsess.DSessFromSess(sqlCtx.Session)
 			dbState := getDbState(t, db, denv)
 			err := session.AddDB(sqlCtx, dbState)
 
@@ -1563,7 +1564,7 @@ func TestMergeableIndexesNulls(t *testing.T) {
 
 			ctx := context.Background()
 			sqlCtx := NewTestSQLCtx(ctx)
-			session := DSessFromSess(sqlCtx.Session)
+			session := dsess.DSessFromSess(sqlCtx.Session)
 			dbState := getDbState(t, db, denv)
 			err := session.AddDB(sqlCtx, dbState)
 			require.NoError(t, err)

--- a/go/libraries/doltcore/sqle/schema_table_test.go
+++ b/go/libraries/doltcore/sqle/schema_table_test.go
@@ -16,6 +16,7 @@ package sqle
 
 import (
 	"context"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"testing"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -34,7 +35,7 @@ func TestSchemaTableRecreation(t *testing.T) {
 	dEnv := dtestutils.CreateTestEnv()
 	db := NewDatabase("dolt", dEnv.DbData())
 	dbState := getDbState(t, db, dEnv)
-	err := DSessFromSess(ctx.Session).AddDB(ctx, dbState)
+	err := dsess.DSessFromSess(ctx.Session).AddDB(ctx, dbState)
 	require.NoError(t, err)
 	ctx.SetCurrentDatabase(db.Name())
 

--- a/go/libraries/doltcore/sqle/session_state_adapter.go
+++ b/go/libraries/doltcore/sqle/session_state_adapter.go
@@ -26,7 +26,7 @@ import (
 // from the session.
 type SessionStateAdapter struct {
 	session *DoltSession
-	dbName string
+	dbName  string
 }
 
 var _ env.RepoStateReader = SessionStateAdapter{}
@@ -71,5 +71,3 @@ func (s SessionStateAdapter) GetMergeCommit(ctx context.Context) (*doltdb.Commit
 func (s SessionStateAdapter) GetPreMergeWorking(ctx context.Context) (*doltdb.RootValue, error) {
 	panic("implement me")
 }
-
-

--- a/go/libraries/doltcore/sqle/session_state_adapter.go
+++ b/go/libraries/doltcore/sqle/session_state_adapter.go
@@ -16,6 +16,7 @@ package sqle
 
 import (
 	"context"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
@@ -25,23 +26,23 @@ import (
 // SessionStateAdapter is an adapter for env.RepoStateReader in SQL contexts, getting information about the repo state
 // from the session.
 type SessionStateAdapter struct {
-	session *DoltSession
+	session *dsess.Session
 	dbName  string
 }
 
 var _ env.RepoStateReader = SessionStateAdapter{}
 var _ env.RootsProvider = SessionStateAdapter{}
 
-func NewSessionStateAdapter(session *DoltSession, dbName string) SessionStateAdapter {
+func NewSessionStateAdapter(session *dsess.Session, dbName string) SessionStateAdapter {
 	return SessionStateAdapter{session: session, dbName: dbName}
 }
 
 func (s SessionStateAdapter) GetRoots(ctx context.Context) (doltdb.Roots, error) {
-	return s.session.dbStates[s.dbName].GetRoots(), nil
+	return s.session.DbStates[s.dbName].GetRoots(), nil
 }
 
 func (s SessionStateAdapter) CWBHeadRef() ref.DoltRef {
-	workingSet := s.session.dbStates[s.dbName].workingSet
+	workingSet := s.session.DbStates[s.dbName].WorkingSet
 	headRef, err := workingSet.Ref().ToHeadRef()
 	// TODO: fix this interface
 	if err != nil {

--- a/go/libraries/doltcore/sqle/show_create_table.go
+++ b/go/libraries/doltcore/sqle/show_create_table.go
@@ -17,6 +17,7 @@ package sqle
 import (
 	"context"
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 
 	sqle "github.com/dolthub/go-mysql-server"
 	"github.com/dolthub/go-mysql-server/sql"
@@ -26,17 +27,17 @@ import (
 
 // These functions cannot be in the sqlfmt package as the reliance on the sqle package creates a circular reference.
 
-func PrepareCreateTableStmt(ctx context.Context, sqlDb sql.Database) (*sql.Context, *sqle.Engine, *DoltSession) {
-	dsess := DefaultDoltSession()
+func PrepareCreateTableStmt(ctx context.Context, sqlDb sql.Database) (*sql.Context, *sqle.Engine, *dsess.Session) {
+	sess := dsess.DefaultSession()
 	sqlCtx := sql.NewContext(ctx,
-		sql.WithSession(dsess),
+		sql.WithSession(sess),
 		sql.WithIndexRegistry(sql.NewIndexRegistry()),
 		sql.WithViewRegistry(sql.NewViewRegistry()),
 		sql.WithTracer(tracing.Tracer(ctx)))
 	engine := sqle.NewDefault()
 	engine.AddDatabase(sqlDb)
-	dsess.SetCurrentDatabase(sqlDb.Name())
-	return sqlCtx, engine, dsess
+	sqlCtx.SetCurrentDatabase(sqlDb.Name())
+	return sqlCtx, engine, sess
 }
 
 func GetCreateTableStmt(ctx *sql.Context, engine *sqle.Engine, tableName string) (string, error) {

--- a/go/libraries/doltcore/sqle/sqlbatch_test.go
+++ b/go/libraries/doltcore/sqle/sqlbatch_test.go
@@ -17,6 +17,7 @@ package sqle
 import (
 	"context"
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"math/rand"
 	"testing"
 
@@ -66,7 +67,7 @@ func TestSqlBatchInserts(t *testing.T) {
 	db := NewDatabase("dolt", dEnv.DbData())
 	engine, sqlCtx, err := NewTestEngine(t, dEnv, ctx, db, root)
 	require.NoError(t, err)
-	DSessFromSess(sqlCtx.Session).EnableBatchedMode()
+	dsess.DSessFromSess(sqlCtx.Session).EnableBatchedMode()
 
 	for _, stmt := range insertStatements {
 		_, rowIter, err := engine.Query(sqlCtx, stmt)
@@ -155,7 +156,7 @@ func TestSqlBatchInsertIgnoreReplace(t *testing.T) {
 	db := NewDatabase("dolt", dEnv.DbData())
 	engine, sqlCtx, err := NewTestEngine(t, dEnv, ctx, db, root)
 	require.NoError(t, err)
-	DSessFromSess(sqlCtx.Session).EnableBatchedMode()
+	dsess.DSessFromSess(sqlCtx.Session).EnableBatchedMode()
 
 	for _, stmt := range insertStatements {
 		_, rowIter, err := engine.Query(sqlCtx, stmt)
@@ -194,7 +195,7 @@ func TestSqlBatchInsertErrors(t *testing.T) {
 	db := NewDatabase("dolt", dEnv.DbData())
 	engine, sqlCtx, err := NewTestEngine(t, dEnv, ctx, db, root)
 	require.NoError(t, err)
-	DSessFromSess(sqlCtx.Session).EnableBatchedMode()
+	dsess.DSessFromSess(sqlCtx.Session).EnableBatchedMode()
 
 	_, rowIter, err := engine.Query(sqlCtx, `insert into people (id, first_name, last_name, is_married, age, rating, uuid, num_episodes) values
 					(0, "Maggie", "Simpson", false, 1, 5.1, '00000000-0000-0000-0000-000000000007', 677)`)

--- a/go/libraries/doltcore/sqle/table_editor.go
+++ b/go/libraries/doltcore/sqle/table_editor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"github.com/dolthub/dolt/go/store/types"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -145,10 +146,10 @@ func (te *sqlTableEditor) SetAutoIncrementValue(ctx *sql.Context, val interface{
 
 // Close implements Closer
 func (te *sqlTableEditor) Close(ctx *sql.Context) error {
-	sess := DSessFromSess(ctx.Session)
+	sess := dsess.DSessFromSess(ctx.Session)
 
 	// If we're running in batched mode, don't flush the edits until explicitly told to do so
-	if sess.batchMode == batched {
+	if sess.BatchMode == dsess.Batched {
 		return nil
 	}
 	return te.flush(ctx)
@@ -179,11 +180,11 @@ func (te *sqlTableEditor) flush(ctx *sql.Context) error {
 }
 
 func (te *sqlTableEditor) setRoot(ctx *sql.Context, newRoot *doltdb.RootValue) error {
-	dSess := DSessFromSess(ctx.Session)
+	sess := dsess.DSessFromSess(ctx.Session)
 
 	if te.temporary {
-		return dSess.SetTempTableRoot(ctx, te.dbName, newRoot)
+		return sess.SetTempTableRoot(ctx, te.dbName, newRoot)
 	}
 
-	return dSess.SetRoot(ctx, te.dbName, newRoot)
+	return sess.SetRoot(ctx, te.dbName, newRoot)
 }

--- a/go/libraries/doltcore/sqle/table_editor_test.go
+++ b/go/libraries/doltcore/sqle/table_editor_test.go
@@ -16,6 +16,7 @@ package sqle
 
 import (
 	"context"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"testing"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -159,7 +160,7 @@ func TestTableEditor(t *testing.T) {
 			ctx := NewTestSQLCtx(context.Background())
 			root, _ := dEnv.WorkingRoot(context.Background())
 			db := NewDatabase("dolt", dEnv.DbData())
-			err := DSessFromSess(ctx.Session).AddDB(ctx, getDbState(t, db, dEnv))
+			err := dsess.DSessFromSess(ctx.Session).AddDB(ctx, getDbState(t, db, dEnv))
 			require.NoError(t, err)
 
 			ctx.SetCurrentDatabase(db.Name())

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"io"
 	"os"
 	"runtime"
@@ -501,10 +502,10 @@ func (t *WritableDoltTable) Inserter(ctx *sql.Context) sql.RowInserter {
 }
 
 func (t *WritableDoltTable) getTableEditor(ctx *sql.Context) (*sqlTableEditor, error) {
-	sess := DSessFromSess(ctx.Session)
+	sess := dsess.DSessFromSess(ctx.Session)
 
 	// In batched mode, reuse the same table editor. Otherwise, hand out a new one
-	if sess.batchMode == batched {
+	if sess.BatchMode == dsess.Batched {
 		if t.ed != nil {
 			return t.ed, nil
 		}

--- a/go/store/datas/workingset.go
+++ b/go/store/datas/workingset.go
@@ -48,10 +48,10 @@ var valueWorkingSetType = nomdl.MustParseType(`Struct WorkingSet {
 var mergeStateTemplate = types.MakeStructTemplate(MergeStateName, []string{MergeStateCommitField, MergeStateWorkingPreMergeField})
 
 type WorkingSetSpec struct {
-	Meta WorkingSetMeta
+	Meta        WorkingSetMeta
 	WorkingRoot types.Ref
-	StagedRoot *types.Ref
-	MergeState *types.Ref
+	StagedRoot  *types.Ref
+	MergeState  *types.Ref
 }
 
 // NewWorkingSet creates a new working set object.
@@ -84,7 +84,7 @@ func NewWorkingSet(_ context.Context, workingRef types.Ref, stagedRef, mergeStat
 }
 
 func NewMergeState(_ context.Context, preMergeWorking types.Ref, commit types.Struct) (types.Struct, error) {
-		return mergeStateTemplate.NewStruct(preMergeWorking.Format(), []types.Value{commit, preMergeWorking})
+	return mergeStateTemplate.NewStruct(preMergeWorking.Format(), []types.Value{commit, preMergeWorking})
 }
 
 func IsWorkingSet(v types.Value) (bool, error) {


### PR DESCRIPTION
- DoltSession moved to new package, `sqle/dsess`
- Renamed `dsess.Session` at most points of reference
- Exposes necessary Session and State variables as public
- Exposes certain constats (like `batched -> Batched`) as constant 