### PR TITLE
Additional Constraint Violation Fixes

### DIFF
--- a/go/cmd/dolt/commands/add.go
+++ b/go/cmd/dolt/commands/add.go
@@ -110,7 +110,7 @@ func toAddVErr(err error) errhand.VerboseError {
 
 		return bdr.Build()
 
-	case actions.IsTblInConflict(err):
+	case actions.IsTblInConflict(err) || actions.IsTblViolatesConstraints(err):
 		tbls := actions.GetTablesForError(err)
 		bdr := errhand.BuildDError("error: not all tables merged")
 

--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -169,7 +169,7 @@ func handleCommitErr(ctx context.Context, dEnv *env.DoltEnv, err error, usage cl
 	if actions.IsNothingStaged(err) {
 		notStagedTbls := actions.NothingStagedTblDiffs(err)
 		notStagedDocs := actions.NothingStagedDocsDiffs(err)
-		n := printDiffsNotStaged(ctx, dEnv, cli.CliOut, notStagedTbls, notStagedDocs, false, 0, []string{})
+		n := printDiffsNotStaged(ctx, dEnv, cli.CliOut, notStagedTbls, notStagedDocs, false, 0, nil, nil)
 
 		if n == 0 {
 			bdr := errhand.BuildDError(`no changes added to commit (use "dolt add")`)
@@ -219,12 +219,16 @@ func buildInitalCommitMsg(ctx context.Context, dEnv *env.DoltEnv) string {
 	if err != nil {
 		workingTblsInConflict = []string{}
 	}
+	workingTblsWithViolations, _, _, err := merge.GetTablesWithConstraintViolations(ctx, roots)
+	if err != nil {
+		workingTblsWithViolations = []string{}
+	}
 
 	stagedDocDiffs, notStagedDocDiffs, _ := diff.GetDocDiffs(ctx, roots, dEnv.DocsReadWriter())
 
 	buf := bytes.NewBuffer([]byte{})
 	n := printStagedDiffs(buf, stagedTblDiffs, stagedDocDiffs, true)
-	n = printDiffsNotStaged(ctx, dEnv, buf, notStagedTblDiffs, notStagedDocDiffs, true, n, workingTblsInConflict)
+	n = printDiffsNotStaged(ctx, dEnv, buf, notStagedTblDiffs, notStagedDocDiffs, true, n, workingTblsInConflict, workingTblsWithViolations)
 
 	currBranch := dEnv.RepoStateReader().CWBHeadRef()
 	initialCommitMessage := "\n" + "# Please enter the commit message for your changes. Lines starting" + "\n" +

--- a/go/libraries/doltcore/doltdb/foreign_key_coll.go
+++ b/go/libraries/doltcore/doltdb/foreign_key_coll.go
@@ -406,6 +406,16 @@ func (fkc *ForeignKeyCollection) Stage(ctx context.Context, fksToAdd []ForeignKe
 	}
 }
 
+// Tables returns the set of all tables that either declare a foreign key or are referenced by a foreign key.
+func (fkc *ForeignKeyCollection) Tables() map[string]struct{} {
+	tables := make(map[string]struct{})
+	for _, fk := range fkc.foreignKeys {
+		tables[fk.TableName] = struct{}{}
+		tables[fk.ReferencedTableName] = struct{}{}
+	}
+	return tables
+}
+
 // String returns the SQL reference option in uppercase.
 func (refOp ForeignKeyReferenceOption) String() string {
 	switch refOp {

--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -1261,3 +1261,23 @@ func (root *RootValue) DebugString(ctx context.Context, transitive bool) string 
 
 	return buf.String()
 }
+
+// MapTableHashes returns a map of each table name and hash.
+func (root *RootValue) MapTableHashes(ctx context.Context) (map[string]hash.Hash, error) {
+	names, err := root.GetTableNames(ctx)
+	if err != nil {
+		return nil, err
+	}
+	nameToHash := make(map[string]hash.Hash)
+	for _, name := range names {
+		h, ok, err := root.GetTableHash(ctx, name)
+		if err != nil {
+			return nil, err
+		} else if !ok {
+			return nil, fmt.Errorf("root found a table with name '%s' but no hash", name)
+		} else {
+			nameToHash[name] = h
+		}
+	}
+	return nameToHash, nil
+}

--- a/go/libraries/doltcore/env/actions/staged.go
+++ b/go/libraries/doltcore/env/actions/staged.go
@@ -111,6 +111,9 @@ func stageTablesNoEnvUpdate(
 		return doltdb.Roots{}, err
 	}
 	roots.Staged, err = MoveTablesBetweenRoots(ctx, tbls, roots.Working, roots.Staged)
+	if err != nil {
+		return doltdb.Roots{}, err
+	}
 
 	return roots, nil
 }

--- a/go/libraries/doltcore/env/repo_state.go
+++ b/go/libraries/doltcore/env/repo_state.go
@@ -257,17 +257,17 @@ func MergeWouldStompChanges(ctx context.Context, workingRoot *doltdb.RootValue, 
 		return nil, nil, err
 	}
 
-	headTableHashes, err := mapTableHashes(ctx, headRoot)
+	headTableHashes, err := headRoot.MapTableHashes(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	workingTableHashes, err := mapTableHashes(ctx, workingRoot)
+	workingTableHashes, err := workingRoot.MapTableHashes(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	mergeTableHashes, err := mapTableHashes(ctx, mergeRoot)
+	mergeTableHashes, err := mergeRoot.MapTableHashes(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -341,29 +341,6 @@ func GetGCKeepers(ctx context.Context, env *DoltEnv) ([]hash.Hash, error) {
 	}
 
 	return keepers, nil
-}
-
-func mapTableHashes(ctx context.Context, root *doltdb.RootValue) (map[string]hash.Hash, error) {
-	names, err := root.GetTableNames(ctx)
-
-	if err != nil {
-		return nil, err
-	}
-
-	nameToHash := make(map[string]hash.Hash)
-	for _, name := range names {
-		h, ok, err := root.GetTableHash(ctx, name)
-
-		if err != nil {
-			return nil, err
-		} else if !ok {
-			panic("GetTableNames returned a table that GetTableHash says isn't there.")
-		} else {
-			nameToHash[name] = h
-		}
-	}
-
-	return nameToHash, nil
 }
 
 func diffTableHashes(headTableHashes, otherTableHashes map[string]hash.Hash) map[string]hash.Hash {

--- a/go/libraries/doltcore/merge/constraint_violations.go
+++ b/go/libraries/doltcore/merge/constraint_violations.go
@@ -56,7 +56,7 @@ const (
 )
 
 // AddConstraintViolations adds all constraint violations to each table.
-func AddConstraintViolations(ctx context.Context, newRoot, ourRoot, baseRoot *doltdb.RootValue) (*doltdb.RootValue, error) {
+func AddConstraintViolations(ctx context.Context, newRoot, baseRoot *doltdb.RootValue) (*doltdb.RootValue, error) {
 	fkColl, err := newRoot.GetForeignKeyCollection(ctx)
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/merge/merge_stats.go
+++ b/go/libraries/doltcore/merge/merge_stats.go
@@ -24,9 +24,10 @@ const (
 )
 
 type MergeStats struct {
-	Operation     TableMergeOp
-	Adds          int
-	Deletes       int
-	Modifications int
-	Conflicts     int
+	Operation            TableMergeOp
+	Adds                 int
+	Deletes              int
+	Modifications        int
+	Conflicts            int
+	ConstraintViolations int
 }

--- a/go/libraries/doltcore/sqle/dfunctions/merge.go
+++ b/go/libraries/doltcore/sqle/dfunctions/merge.go
@@ -103,7 +103,19 @@ func (cf *MergeFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	}
 
 	if canFF {
-		return cmh.String(), nil
+		ancRoot, err := head.GetRootValue()
+		if err != nil {
+			return nil, err
+		}
+		mergedRoot, err := cm.GetRootValue()
+		if err != nil {
+			return nil, err
+		}
+		if cvPossible, err := merge.MayHaveConstraintViolations(ctx, ancRoot, mergedRoot); err != nil {
+			return nil, err
+		} else if !cvPossible {
+			return cmh.String(), nil
+		}
 	}
 
 	mergeRoot, _, err := merge.MergeCommits(ctx, head, cm)

--- a/go/libraries/doltcore/sqle/dtables/constraint_violations.go
+++ b/go/libraries/doltcore/sqle/dtables/constraint_violations.go
@@ -79,7 +79,7 @@ func NewConstraintViolationsTable(ctx *sql.Context, tblName string, root *doltdb
 	if err != nil {
 		return nil, err
 	}
-	sqlSch, err := sqlutil.FromDoltSchema(doltdb.DoltConfTablePrefix+tblName, dSch)
+	sqlSch, err := sqlutil.FromDoltSchema(doltdb.DoltConstViolTablePrefix+tblName, dSch)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/utils/set/strset.go
+++ b/go/libraries/utils/set/strset.go
@@ -120,8 +120,8 @@ func (s *StrSet) Size() int {
 	return len(s.items)
 }
 
-// AsSlice converts the set to a slice of strings.  If this is an insensitive set the resulting slice will be lowercase
-// regardless of the case that was used when adding the string to the set
+// AsSlice converts the set to a slice of strings. If this is an insensitive set the resulting slice will be lowercase
+// regardless of the case that was used when adding the string to the set.
 func (s *StrSet) AsSlice() []string {
 	size := len(s.items)
 	sl := make([]string, size)
@@ -135,6 +135,16 @@ func (s *StrSet) AsSlice() []string {
 	return sl
 }
 
+// AsSortedSlice converts the set to a slice of strings. If this is an insensitive set the resulting slice will be lowercase
+// regardless of the case that was used when adding the string to the set. The slice is sorted in ascending order.
+func (s *StrSet) AsSortedSlice() []string {
+	slice := s.AsSlice()
+	sort.Slice(slice, func(i, j int) bool {
+		return slice[i] < slice[j]
+	})
+	return slice
+}
+
 // Iterate accepts a callback which will be called once for each element in the set until all items have been
 // exhausted or callback returns false.
 func (s *StrSet) Iterate(callBack func(string) (cont bool)) {
@@ -145,7 +155,7 @@ func (s *StrSet) Iterate(callBack func(string) (cont bool)) {
 	}
 }
 
-// IntersectionAndMissing takes a slice of strings and returns a slice of strings containing the intersection with the
+// LeftIntersectionRight takes a slice of strings and returns a slice of strings containing the intersection with the
 // set, and a slice of strings for the ones missing from the set.
 func (s *StrSet) LeftIntersectionRight(other *StrSet) (left *StrSet, intersection *StrSet, right *StrSet) {
 	left = NewStrSet(nil)

--- a/integration-tests/bats/1pk5col-ints.bats
+++ b/integration-tests/bats/1pk5col-ints.bats
@@ -453,7 +453,7 @@ teardown() {
     [[ ! "$output" =~ "ours" ]] || false
     [[ ! "$output" =~ "theirs" ]] || false
     run dolt status
-    [[ "$output" =~ "All conflicts fixed but you are still merging." ]] || false
+    [[ "$output" =~ "All conflicts and constraint violations fixed but you are still merging." ]] || false
     run dolt merge --abort
     [ "$status" -eq 0 ]
     [ "$output" = "" ]

--- a/integration-tests/bats/conflict-detection.bats
+++ b/integration-tests/bats/conflict-detection.bats
@@ -89,7 +89,7 @@ SQL
     [[ "$output" =~ "1 rows modified" ]] || false
     [[ ! "$output" =~ "CONFLICT" ]] || false
     run dolt status
-    [[ "$output" =~ "All conflicts fixed" ]] || false
+    [[ "$output" =~ "All conflicts and constraint violations fixed" ]] || false
     [[ "$output" =~ "Changes to be committed:" ]] || false
 }
 
@@ -124,7 +124,7 @@ SQL
     [[ "$output" =~ "1 rows modified" ]] || false
     [[ ! "$output" =~ "CONFLICT" ]] || false
     run dolt status
-    [[ "$output" =~ "All conflicts fixed" ]] || false
+    [[ "$output" =~ "All conflicts and constraint violations fixed" ]] || false
     [[ "$output" =~ "Changes to be committed:" ]] || false
 }
 

--- a/integration-tests/bats/docs.bats
+++ b/integration-tests/bats/docs.bats
@@ -833,7 +833,7 @@ SQL
     [[ "$output" =~ "one-more-time" ]] || false
     run dolt status
     echo "output = $output"
-    [[ "$output" =~ "All conflicts fixed" ]] || false
+    [[ "$output" =~ "All conflicts and constraint violations fixed" ]] || false
     [[ "$output" =~ "Changes to be committed:" ]] || false
     [[ "$output" =~ "README.md" ]] || false
 }

--- a/integration-tests/bats/sql-merge.bats
+++ b/integration-tests/bats/sql-merge.bats
@@ -137,7 +137,7 @@ SQL
     [[ "$output" =~ "3" ]] || false
 
     run dolt status
-    [[ "$output" =~ "All conflicts fixed but you are still merging" ]] || false
+    [[ "$output" =~ "All conflicts and constraint violations fixed but you are still merging" ]] || false
     [[ "$output" =~ "Changes to be committed:" ]] || false
     [[ "$output" =~ ([[:space:]]*modified:[[:space:]]*test) ]] || false
 


### PR DESCRIPTION
This PR has a few things. Most notably, we no longer allow fast forward merges if a merge may cause a constraint violation. This decision was discussed internally. Additionally, I've modified the command line messages to properly respond to the presence of constraint violations, which includes blocking some functionality until they have been resolved. Lastly are general fixes and whatnot.