### PR TITLE
Max/push panic

### DIFF
--- a/go/libraries/doltcore/ref/ref_spec.go
+++ b/go/libraries/doltcore/ref/ref_spec.go
@@ -61,7 +61,9 @@ func ParseRefSpecForRemote(remote, refSpecStr string) (RefSpec, error) {
 	var fromRef DoltRef
 	var toRef DoltRef
 	var err error
-	if refSpecStr[0] == ':' {
+    if len(refSpecStr) == 0 {
+        return nil, ErrInvalidRefSpec
+    } else if refSpecStr[0] == ':' {
 		fromRef = EmptyBranchRef
 		toRef, err = Parse(refSpecStr[1:])
 

--- a/go/libraries/doltcore/ref/ref_spec.go
+++ b/go/libraries/doltcore/ref/ref_spec.go
@@ -61,9 +61,9 @@ func ParseRefSpecForRemote(remote, refSpecStr string) (RefSpec, error) {
 	var fromRef DoltRef
 	var toRef DoltRef
 	var err error
-    if len(refSpecStr) == 0 {
-        return nil, ErrInvalidRefSpec
-    } else if refSpecStr[0] == ':' {
+	if len(refSpecStr) == 0 {
+		return nil, ErrInvalidRefSpec
+	} else if refSpecStr[0] == ':' {
 		fromRef = EmptyBranchRef
 		toRef, err = Parse(refSpecStr[1:])
 

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -1032,3 +1032,9 @@ setup_ref_test() {
     [ "$status" -eq 1 ]
     [[ "$output" =~ "error: --set-upstream requires <remote> and <refspec> params." ]] || false
 }
+
+@test "remotes: pushing empty branch does not panic" {
+    run dolt push origin ''
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "error: invalid refspec ''" ]] || false
+}


### PR DESCRIPTION
found in aktify:
```
> dolt push origin ''
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/dolthub/dolt/go/libraries/doltcore/ref.ParseRefSpecForRemote(0x0, 0x0, 0x7fff638f2e23, 0x0, 0x0, 0x7fff638f2e23, 0x0, 0x0)
	/src/libraries/doltcore/ref/ref_spec.go:64 +0x8ec
github.com/dolthub/dolt/go/libraries/doltcore/ref.ParseRefSpec(...)
	/src/libraries/doltcore/ref/ref_spec.go:55
github.com/dolthub/dolt/go/cmd/dolt/commands.parsePushArgs(0x1f4d800, 0xc00009f500, 0xc00009fef0, 0xc000232630, 0xc0000f8880, 0xc00009fef0, 0x2afb310)
	/src/cmd/dolt/commands/push.go:164 +0x2ff
github.com/dolthub/dolt/go/cmd/dolt/commands.PushCmd.Exec(0x1f4d800, 0xc00009f500, 0xc0003e7e00, 0x9, 0xc00003a0a0, 0x2, 0x2, 0xc000232630, 0x9)
	/src/cmd/dolt/commands/push.go:108 +0x21a
github.com/dolthub/dolt/go/cmd/dolt/cli.SubCommandHandler.Exec(0x1c67904, 0x4, 0x1c7e4c4, 0x11, 0xc00042ac80, 0x26, 0x26, 0x0, 0x1f4d800, 0xc00009f500, ...)
	/src/cmd/dolt/cli/command.go:165 +0x4c2
main.runMain(0x0)
	/src/cmd/dolt/dolt.go:296 +0x123e
main.main()
	/src/cmd/dolt/dolt.go:131 +0x2a
```