### PR TITLE
Fixed panic when merging a branch that still contains a table that was deleted in the target

### DIFF
--- a/go/cmd/dolt/commands/remote.go
+++ b/go/cmd/dolt/commands/remote.go
@@ -49,13 +49,14 @@ AWS cloud remote urls should be of the form {{.EmphasisLeft}}aws://[dynamo-table
 
 aws-creds-type specifies the means by which credentials should be retrieved in order to access the specified cloud resources (specifically the dynamo table, and the s3 bucket). Valid values are 'role', 'env', or 'file'.
 
-	\trole: Use the credentials installed for the current user
-	\tenv: Looks for environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
-	\tfile: Uses the credentials file specified by the parameter aws-creds-file
+	role: Use the credentials installed for the current user
+	env: Looks for environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+	file: Uses the credentials file specified by the parameter aws-creds-file
 	
 GCP remote urls should be of the form gs://gcs-bucket/database and will use the credentials setup using the gcloud command line available from Google +
 
-The local filesystem can be used as a remote by providing a repository url in the format file://absolute path. See https://en.wikipedia.org/wiki/File_URI_schemethi
+The local filesystem can be used as a remote by providing a repository url in the format file://absolute path. See https://en.wikipedia.org/wiki/File_URI_scheme
+
 {{.EmphasisLeft}}remove{{.EmphasisRight}}, {{.EmphasisLeft}}rm{{.EmphasisRight}}, 
 Remove the remote named {{.LessThan}}name{{.GreaterThan}}. All remote-tracking branches and configuration settings for the remote are removed.`,
 

--- a/go/libraries/doltcore/merge/merge.go
+++ b/go/libraries/doltcore/merge/merge.go
@@ -877,9 +877,9 @@ func MergeRoots(ctx context.Context, ourRoot, theirRoot, ancRoot *doltdb.RootVal
 			if err != nil {
 				return nil, nil, err
 			}
-		} else if has, err := newRoot.HasTable(ctx, tblName); err != nil {
+		} else if newRootHasTable, err := newRoot.HasTable(ctx, tblName); err != nil {
 			return nil, nil, err
-		} else if has {
+		} else if newRootHasTable {
 			tblToStats[tblName] = &MergeStats{Operation: TableRemoved}
 			err = tableEditSession.UpdateRoot(ctx, func(ctx context.Context, root *doltdb.RootValue) (*doltdb.RootValue, error) {
 				return root.RemoveTables(ctx, tblName)

--- a/go/libraries/doltcore/merge/merge.go
+++ b/go/libraries/doltcore/merge/merge.go
@@ -53,32 +53,6 @@ func NewMerger(ctx context.Context, root, mergeRoot, ancRoot *doltdb.RootValue, 
 	return &Merger{root, mergeRoot, ancRoot, vrw}
 }
 
-func getTableInfoFromRoot(ctx context.Context, tblName string, root *doltdb.RootValue) (
-	ok bool,
-	table *doltdb.Table,
-	sch schema.Schema,
-	h hash.Hash,
-	err error,
-) {
-	table, ok, err = root.GetTable(ctx, tblName)
-	if err != nil {
-		return false, nil, nil, hash.Hash{}, err
-	}
-
-	if ok {
-		h, err = table.HashOf()
-		if err != nil {
-			return false, nil, nil, hash.Hash{}, err
-		}
-		sch, err = table.GetSchema(ctx)
-		if err != nil {
-			return false, nil, nil, hash.Hash{}, err
-		}
-	}
-
-	return ok, table, sch, h, nil
-}
-
 // MergeTable merges schema and table data for the table tblName.
 func (merger *Merger) MergeTable(ctx context.Context, tblName string, sess *editor.TableEditSession) (*doltdb.Table, *MergeStats, error) {
 	rootHasTable, tbl, rootSchema, rootHash, err := getTableInfoFromRoot(ctx, tblName, merger.root)
@@ -262,6 +236,32 @@ func (merger *Merger) MergeTable(ctx context.Context, tblName string, sess *edit
 	}
 
 	return resultTbl, stats, nil
+}
+
+func getTableInfoFromRoot(ctx context.Context, tblName string, root *doltdb.RootValue) (
+	ok bool,
+	table *doltdb.Table,
+	sch schema.Schema,
+	h hash.Hash,
+	err error,
+) {
+	table, ok, err = root.GetTable(ctx, tblName)
+	if err != nil {
+		return false, nil, nil, hash.Hash{}, err
+	}
+
+	if ok {
+		h, err = table.HashOf()
+		if err != nil {
+			return false, nil, nil, hash.Hash{}, err
+		}
+		sch, err = table.GetSchema(ctx)
+		if err != nil {
+			return false, nil, nil, hash.Hash{}, err
+		}
+	}
+
+	return ok, table, sch, h, nil
 }
 
 func calcTableMergeStats(ctx context.Context, tbl *doltdb.Table, mergeTbl *doltdb.Table) (MergeStats, error) {

--- a/integration-tests/bats/merge.bats
+++ b/integration-tests/bats/merge.bats
@@ -462,9 +462,10 @@ SQL
     [ "$status" -eq 0 ]
     [[ ! "$output" =~ "test2" ]] || false
 
-    run dolt sql -q "select * from test1"
+    run dolt sql -q "select * from test1" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ 2 ]] || false
+    [[ "$output" =~ "1,1,1" ]] || false
+    [[ "$output" =~ "2,2,2" ]] || false
 }
 
 

--- a/integration-tests/bats/merge.bats
+++ b/integration-tests/bats/merge.bats
@@ -502,6 +502,11 @@ SQL
     run dolt sql -q "show tables"
     [ "$status" -eq 0 ]
     [[ ! "$output" =~ "test2" ]] || false
+
+    run dolt sql -q "select * from test1" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "1,1,1" ]] || false
+    [[ "$output" =~ "2,2,2" ]] || false
 }
 
 @test "merge: merge a branch that edits a deleted table" {


### PR DESCRIPTION
Also some other panics, and added more merge tests. Cleaned up merge short circuit code, and clarified the behavior when one branch edits a table another deletes during a merge.