### PR TITLE
Optimize merge by skipping tables without edits

### DIFF
--- a/go/libraries/doltcore/table/editor/keyless_table_editor.go
+++ b/go/libraries/doltcore/table/editor/keyless_table_editor.go
@@ -236,6 +236,10 @@ func (kte *keylessTableEditor) UpdateRow(ctx context.Context, old row.Row, new r
 	return kte.acc.increment(key, val)
 }
 
+func (kte *keylessTableEditor) hasEdits() bool {
+	return len(kte.acc.deltas) > 0
+}
+
 // GetAutoIncrementValue implements TableEditor, AUTO_INCREMENT is not yet supported for keyless tables.
 func (kte *keylessTableEditor) GetAutoIncrementValue() types.Value {
 	return types.NullValue

--- a/go/libraries/doltcore/table/editor/keyless_table_editor.go
+++ b/go/libraries/doltcore/table/editor/keyless_table_editor.go
@@ -39,6 +39,7 @@ type keylessTableEditor struct {
 	acc      keylessEditAcc
 	indexEds []*IndexEditor
 	cvEditor *types.MapEditor
+	dirty    bool
 
 	eg *errgroup.Group
 	mu *sync.Mutex
@@ -129,6 +130,7 @@ func newKeylessTableEditor(ctx context.Context, tbl *doltdb.Table, sch schema.Sc
 		name:     name,
 		acc:      acc,
 		indexEds: make([]*IndexEditor, sch.Indexes().Count()),
+		dirty:    false,
 		eg:       eg,
 		mu:       &sync.Mutex{},
 	}
@@ -144,7 +146,11 @@ func newKeylessTableEditor(ctx context.Context, tbl *doltdb.Table, sch schema.Sc
 }
 
 func (kte *keylessTableEditor) InsertKeyVal(ctx context.Context, key, val types.Tuple, tagToVal map[uint64]types.Value, errFunc PKDuplicateErrFunc) error {
-	panic("not implemented")
+	dRow, err := row.FromNoms(kte.sch, key, val)
+	if err != nil {
+		return err
+	}
+	return kte.InsertRow(ctx, dRow, errFunc)
 }
 
 func (kte *keylessTableEditor) DeleteByKey(ctx context.Context, key types.Tuple, tagToVal map[uint64]types.Value) (err error) {
@@ -175,6 +181,7 @@ func (kte *keylessTableEditor) DeleteByKey(ctx context.Context, key types.Tuple,
 		return err
 	}
 
+	kte.dirty = true
 	return kte.acc.decrement(key, val)
 }
 
@@ -191,6 +198,7 @@ func (kte *keylessTableEditor) InsertRow(ctx context.Context, r row.Row, _ PKDup
 		return err
 	}
 
+	kte.dirty = true
 	return kte.acc.increment(key, val)
 }
 
@@ -207,6 +215,7 @@ func (kte *keylessTableEditor) DeleteRow(ctx context.Context, r row.Row) (err er
 		return err
 	}
 
+	kte.dirty = true
 	return kte.acc.decrement(key, val)
 }
 
@@ -233,11 +242,12 @@ func (kte *keylessTableEditor) UpdateRow(ctx context.Context, old row.Row, new r
 		return err
 	}
 
+	kte.dirty = true
 	return kte.acc.increment(key, val)
 }
 
 func (kte *keylessTableEditor) hasEdits() bool {
-	return len(kte.acc.deltas) > 0
+	return kte.dirty
 }
 
 // GetAutoIncrementValue implements TableEditor, AUTO_INCREMENT is not yet supported for keyless tables.
@@ -247,6 +257,7 @@ func (kte *keylessTableEditor) GetAutoIncrementValue() types.Value {
 
 // SetAutoIncrementValue implements TableEditor, AUTO_INCREMENT is not yet supported for keyless tables.
 func (kte *keylessTableEditor) SetAutoIncrementValue(v types.Value) (err error) {
+	kte.dirty = true
 	return fmt.Errorf("keyless tables do not support AUTO_INCREMENT")
 }
 
@@ -254,6 +265,10 @@ func (kte *keylessTableEditor) SetAutoIncrementValue(v types.Value) (err error) 
 func (kte *keylessTableEditor) Table(ctx context.Context) (*doltdb.Table, error) {
 	kte.mu.Lock()
 	defer kte.mu.Unlock()
+
+	if !kte.dirty {
+		return kte.tbl, nil
+	}
 
 	err := kte.flush(ctx)
 	if err != nil {
@@ -308,6 +323,7 @@ func (kte *keylessTableEditor) SetConstraintViolation(ctx context.Context, k typ
 		kte.cvEditor = cvMap.Edit()
 	}
 	kte.cvEditor.Set(k, v)
+	kte.dirty = true
 	return nil
 }
 

--- a/go/libraries/doltcore/table/editor/sessioned_table_editor.go
+++ b/go/libraries/doltcore/table/editor/sessioned_table_editor.go
@@ -107,6 +107,10 @@ func (ste *sessionedTableEditor) UpdateRow(ctx context.Context, dOldRow row.Row,
 	return ste.updateRow(ctx, dOldRow, dNewRow, true, errFunc)
 }
 
+func (ste *sessionedTableEditor) hasEdits() bool {
+	return ste.tableEditor.hasEdits()
+}
+
 // GetAutoIncrementValue implements TableEditor.
 func (ste *sessionedTableEditor) GetAutoIncrementValue() types.Value {
 	return ste.tableEditor.GetAutoIncrementValue()

--- a/go/libraries/doltcore/table/editor/table_edit_session.go
+++ b/go/libraries/doltcore/table/editor/table_edit_session.go
@@ -169,6 +169,11 @@ func (tes *TableEditSession) flush(ctx context.Context) (*doltdb.RootValue, erro
 	var tableErr error
 	var rootErr error
 	for tableName, ste := range tes.tables {
+		if !ste.hasEdits() {
+			wg.Done()
+			continue
+		}
+
 		// we can run all of the Table calls concurrently as long as we guard updating the root
 		go func(tableName string, ste *sessionedTableEditor) {
 			defer wg.Done()


### PR DESCRIPTION
10x speedup for the Nautobot database:

before:
```bash
% time dolt --prof cpu merge add-ipaddress                                                      
Updating uaimen5cq6jucq3abr85klgj0g594qc1..d3922cbd8fop4ast7ohl9mm4d3dn3632
extras_objectchange | 1 +
ipam_ipaddress      | 1 +
2 tables changed, 2 rows added(+), 0 rows modified(*), 0 rows deleted(-)
dolt --prof cpu merge add-ipaddress  83.78s user 3.75s system 567% cpu 15.433 total
```

after:
```bash
% time dolt --prof cpu merge add-ipaddress
Updating uaimen5cq6jucq3abr85klgj0g594qc1..d3922cbd8fop4ast7ohl9mm4d3dn3632
extras_objectchange | 1 +
ipam_ipaddress      | 1 +
2 tables changed, 2 rows added(+), 0 rows modified(*), 0 rows deleted(-)
dolt --prof cpu merge add-ipaddress  2.27s user 0.17s system 158% cpu 1.545 total
```