### PR TITLE
Skipped bats test for non-deterministic table import behavior 

### DIFF
--- a/integration-tests/bats/import-update-tables.bats
+++ b/integration-tests/bats/import-update-tables.bats
@@ -236,7 +236,7 @@ DELIM
     [[ "$output" =~ "1,1,2,3,4,8" ]] || false
 }
 
-@test "subsequent runs of same import with duplicate keys produces no modifications" {
+@test "import-update-tables: subsequent runs of same import with duplicate keys produces no modifications" {
     cat <<DELIM > 1pk5col-rpt-ints.csv
 pk,c1,c2,c3,c4,c5
 1,1,2,3,4,5

--- a/integration-tests/bats/import-update-tables.bats
+++ b/integration-tests/bats/import-update-tables.bats
@@ -230,9 +230,24 @@ DELIM
     # Output to a file from the error stderr
     dolt sql -q "DELETE FROM test WHERE pk = 1"
     run dolt table import -u --continue test 1pk5col-rpt-ints.csv
-    echo $output
     [ "$status" -eq 0 ]
     [[ "$output" =~ "The following rows were skipped:" ]] || false
     [[ "$output" =~ "1,1,2,3,4,7" ]] || false
     [[ "$output" =~ "1,1,2,3,4,8" ]] || false
+}
+
+@test "subsequent runs of same import with duplicate keys produces no modifications" {
+    cat <<DELIM > 1pk5col-rpt-ints.csv
+pk,c1,c2,c3,c4,c5
+1,1,2,3,4,5
+1,1,2,3,4,7
+1,1,2,3,4,8
+DELIM
+
+    dolt sql < 1pk5col-ints-sch.sql
+    dolt table import -u --continue test 1pk5col-rpt-ints.csv
+    run dolt table import -u --continue test 1pk5col-rpt-ints.csv
+    [ "$status" -eq 0 ]
+    skip "Running this file on repeat produces modifications"
+    ! [[ "$output" =~ "Modifications: 2" ]] || falsa 
 }


### PR DESCRIPTION
Skipped bats test for duplicate rows in a table import -u --continue producing non-deterministic imports when repeated