### PR TITLE
global system var for sql-server session branch

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/server_test.go
+++ b/go/cmd/dolt/commands/sqlserver/server_test.go
@@ -276,7 +276,7 @@ func TestServerCheckout(t *testing.T) {
 		},
 		{
 			query: func() *dbr.SelectStmt {
-				return sess.SelectBySql("set GLOBAL dolt_sql_server_branch_ref = 'refs/heads/new'")
+				return sess.SelectBySql("set GLOBAL dolt_default_branch = 'refs/heads/new'")
 			},
 			expectedRes: []testBranch{},
 		},

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -870,6 +870,7 @@ SQL
     server_query repo1 1 "SHOW tables" "" # no tables on master
 
     server_query repo1 1 "set GLOBAL dolt_sql_server_branch_ref = 'refs/heads/new';" ""
+    server_query repo1 1 "select @@GLOBAL.dolt_sql_server_branch_ref;" "@@GLOBAL.dolt_sql_server_branch_ref\nrefs/heads/new"
     server_query repo1 1 "select active_branch()" "active_branch()\nnew"
     server_query repo1 1 "SHOW tables" "Table\nt"
 }

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -27,7 +27,7 @@ teardown() {
     dolt sql-server --host 0.0.0.0 --port=$PORT --user dolt &
     SERVER_PID=$! # will get killed by teardown_common
     sleep 5 # not using python wait so this works on windows
-    
+
     run dolt sql-server --host 0.0.0.0 --port=$PORT --user dolt
     [ "$status" -eq 1 ]
     [[ "$output" =~ "in use" ]] || false
@@ -869,8 +869,8 @@ SQL
 
     server_query repo1 1 "SHOW tables" "" # no tables on master
 
-    server_query repo1 1 "set GLOBAL dolt_sql_server_branch_ref = 'refs/heads/new';" ""
-    server_query repo1 1 "select @@GLOBAL.dolt_sql_server_branch_ref;" "@@GLOBAL.dolt_sql_server_branch_ref\nrefs/heads/new"
+    server_query repo1 1 "set GLOBAL dolt_default_branch = 'refs/heads/new';" ""
+    server_query repo1 1 "select @@GLOBAL.dolt_default_branch;" "@@GLOBAL.dolt_default_branch\nrefs/heads/new"
     server_query repo1 1 "select active_branch()" "active_branch()\nnew"
     server_query repo1 1 "SHOW tables" "Table\nt"
 }
@@ -891,9 +891,10 @@ SQL
     server_query repo1 1 "SHOW tables" "" # no tables on master
 
     multi_query repo1 1 '
-    set GLOBAL dolt_sql_server_branch_ref = "refs/heads/new";
+    set GLOBAL dolt_default_branch = "refs/heads/new";
     show tables;' "" # SET GLOBAL does not affect current connection
 
     server_query repo1 1 "select active_branch()" "active_branch()\nnew"
+    server_query repo1 1 "select @@GLOBAL.dolt_default_branch;" "@@GLOBAL.dolt_default_branch\nrefs/heads/new"
     server_query repo1 1 "SHOW tables" "Table\nt"
 }

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -829,7 +829,7 @@ SQL
     # fails
     server_query "repo1/$hash" 1 "insert into test values (7)" "" "read-only"
 
-    # server should still be alive afexchange.goter an error
+    # server should still be alive after an error
     server_query "repo1/$hash" 1 "select count(*) from test" "count(*)\n3"
 }
 

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -854,7 +854,7 @@ SQL
     server_query "repo1/feature-branch" 1 "SHOW Tables" "Table\ntest"
 }
 
-@test "sql-server: SET GLOBAL default branch" {
+@test "sql-server: SET GLOBAL default branch as ref" {
     skiponwindows "Has dependencies that are missing on the Jenkins Windows installation."
 
     cd repo1
@@ -868,14 +868,13 @@ SQL
     INSERT INTO t VALUES (2,2),(3,3);' ""
 
     server_query repo1 1 "SHOW tables" "" # no tables on master
-
     server_query repo1 1 "set GLOBAL dolt_default_branch = 'refs/heads/new';" ""
     server_query repo1 1 "select @@GLOBAL.dolt_default_branch;" "@@GLOBAL.dolt_default_branch\nrefs/heads/new"
     server_query repo1 1 "select active_branch()" "active_branch()\nnew"
     server_query repo1 1 "SHOW tables" "Table\nt"
 }
 
-@test "sql-server: SET GLOBAL default branch does not affect current session" {
+@test "sql-server: SET GLOBAL default branch as branch name" {
     skiponwindows "Has dependencies that are missing on the Jenkins Windows installation."
 
     cd repo1
@@ -889,12 +888,8 @@ SQL
     INSERT INTO t VALUES (2,2),(3,3);' ""
 
     server_query repo1 1 "SHOW tables" "" # no tables on master
-
-    multi_query repo1 1 '
-    set GLOBAL dolt_default_branch = "refs/heads/new";
-    show tables;' "" # SET GLOBAL does not affect current connection
-
+    server_query repo1 1 "set GLOBAL dolt_default_branch = 'new';" ""
+    server_query repo1 1 "select @@GLOBAL.dolt_default_branch;" "@@GLOBAL.dolt_default_branch\nnew"
     server_query repo1 1 "select active_branch()" "active_branch()\nnew"
-    server_query repo1 1 "select @@GLOBAL.dolt_default_branch;" "@@GLOBAL.dolt_default_branch\nrefs/heads/new"
     server_query repo1 1 "SHOW tables" "Table\nt"
 }


### PR DESCRIPTION
setting `@@GLOBAL.dolt_sql_server_branch_ref` overwrites the branch for new sql-server connections. Setting the variable does not change the current connection's branch. If the variable is set to an invalid ref (ex: branch does not exist), the behavior is undefined for new connections.

```
> set GLOBAL dolt_sql_server_branch_ref = 'refs/heads/new'
Query OK, 1 row affected (0.00 sec)
mysql> select @@GLOBAL.dolt_sql_server_branch_ref;
+-------------------------------------+
| @@GLOBAL.dolt_sql_server_branch_ref |
+-------------------------------------+
| refs/heads/new                      |
+-------------------------------------+
1 row in set (0.00 sec)
mysql> select active_branch();
+-----------------+
| active_branch() |
+-----------------+
| master          |
+-----------------+
mysql> exit
Bye
$ mysql --user root --host=0.0.0.0 -p tmp1

mysql> select active_branch();
+-----------------+
| active_branch() |
+-----------------+
| new             |
+-----------------+
1 row in set (0.00 sec)
```