### PR TITLE
drop primary key does not fail of foreign key constraint if fallback index exists

### DIFF
--- a/go/libraries/doltcore/doltdb/table.go
+++ b/go/libraries/doltcore/doltdb/table.go
@@ -366,7 +366,6 @@ func (t *Table) GetSchema(ctx context.Context) (schema.Schema, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	schemaRef := schemaRefVal.(types.Ref)
 	return RefToSchema(ctx, t.vrw, schemaRef)
 }

--- a/go/libraries/doltcore/doltdb/table.go
+++ b/go/libraries/doltcore/doltdb/table.go
@@ -366,6 +366,7 @@ func (t *Table) GetSchema(ctx context.Context) (schema.Schema, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	schemaRef := schemaRefVal.(types.Ref)
 	return RefToSchema(ctx, t.vrw, schemaRef)
 }

--- a/go/libraries/doltcore/schema/alterschema/droppk.go
+++ b/go/libraries/doltcore/schema/alterschema/droppk.go
@@ -48,6 +48,9 @@ func DropPrimaryKeyFromTable(ctx context.Context, table *doltdb.Table, nbf *type
 	}
 
 	newSchema.Indexes().AddIndex(sch.Indexes().AllIndexes()...)
+	if err != nil {
+		return nil, err
+	}
 
 	table, err = table.UpdateSchema(ctx, newSchema)
 	if err != nil {

--- a/go/libraries/doltcore/schema/alterschema/droppk_test.go
+++ b/go/libraries/doltcore/schema/alterschema/droppk_test.go
@@ -124,3 +124,152 @@ func TestDropPk(t *testing.T) {
 		assert.True(t, ok)
 	})
 }
+
+func TestDropPks(t *testing.T) {
+	var dropTests = []struct {
+		name      string
+		setup     []string
+		check     []string
+		want      []row.Row
+		exit      int
+		fkIdxName string
+	}{
+		{
+			name: "no error on drop pk",
+			setup: []string{
+				"create table parent (id int, name varchar(1), age int, primary key (id))",
+				"insert into parent values (1,1,1),(2,2,2)",
+			},
+			exit: 0,
+		},
+		{
+			name: "no error if backup index",
+			setup: []string{
+				"create table parent (id int, name varchar(1), age int, primary key (id), key `backup` (id))",
+				"create table child (id int, name varchar(1), age int, primary key (id), constraint `fk` foreign key (id) references parent (id))",
+				"insert into parent values (1,1,1),(2,2,2)",
+				"insert into child values (1,1,1),(2,2,2)",
+			},
+			exit:      0,
+			fkIdxName: "backup",
+		},
+		{
+			name: "no error if backup index for single FK on compound pk drop",
+			setup: []string{
+				"create table parent (id int, name varchar(1), age int, primary key (id, age), key `backup` (age))",
+				"create table child (id int, name varchar(1), age int, primary key (id), constraint `fk` foreign key (age) references parent (age))",
+				"insert into parent values (1,1,1),(2,2,2)",
+				"insert into child values (1,1,1),(2,2,2)",
+			},
+			exit:      0,
+			fkIdxName: "backup",
+		},
+		{
+			name: "no error if compound backup index for compound FK",
+			setup: []string{
+				"create table parent (id int, name varchar(1), age int, primary key (id, age), key `backup` (id, age))",
+				"create table child (id int, name varchar(1), age int, constraint `fk` foreign key (id, age) references parent (id, age))",
+				"insert into parent values (1,1,1),(2,2,2)",
+				"insert into child values (1,1,1),(2,2,2)",
+			},
+			exit:      0,
+			fkIdxName: "backup",
+		},
+		{
+			name: "no error if both invalid and valid backup index",
+			setup: []string{
+				"create table parent (id int, name varchar(1), age int, primary key (id, age), key `bad_backup1` (id, age), key `bad_backup2` (id), key `backup` (age, id))",
+				"create table child (id int, name varchar(1), age int, constraint `fk` foreign key (age) references parent (age))",
+				"insert into parent values (1,1,1),(2,2,2)",
+				"insert into child values (1,1,1),(2,2,2)",
+			},
+			exit:      0,
+			fkIdxName: "backup",
+		},
+		{
+			name: "error if FK ref but no backup index for single pk",
+			setup: []string{
+				"create table parent (id int, name varchar(1), age int, primary key (id))",
+				"create table child (id int, name varchar(1), age int, primary key (id), constraint `fk` foreign key (id) references parent (id))",
+				"insert into parent values (1,1,1),(2,2,2)",
+				"insert into child values (1,1,1),(2,2,2)",
+			},
+			exit:      1,
+			fkIdxName: "id",
+		},
+		{
+			name: "error if FK ref but bad backup index",
+			setup: []string{
+				"create table parent (id int, name varchar(1), age int, primary key (id), key `bad_backup2` (age))",
+				"create table child (id int, name varchar(1), age int, constraint `fk` foreign key (id) references parent (id))",
+				"insert into parent values (1,1,1),(2,2,2)",
+				"insert into child values (1,1,1),(2,2,2)",
+			},
+			exit:      1,
+			fkIdxName: "id",
+		},
+		{
+			name: "error if misordered compound backup index for FK",
+			setup: []string{
+				"create table parent (id int, name varchar(1), age int, constraint `primary` primary key (id), key `backup` (age, id))",
+				"create table child (id int, name varchar(1), age int, constraint `fk` foreign key (id) references parent (id))",
+				"insert into parent values (1,1,1),(2,2,2)",
+				"insert into child values (1,1,1),(2,2,2)",
+			},
+			exit:      1,
+			fkIdxName: "id",
+		},
+		{
+			name: "error if incomplete compound backup index for FK",
+			setup: []string{
+				"create table parent (id int, name varchar(1), age int, constraint `primary` primary key (age, id), key `backup` (age, name))",
+				"create table child (id int, name varchar(1), age int, constraint `fk` foreign key (age, id) references parent (age,  id))",
+				"insert into parent values (1,1,1),(2,2,2)",
+				"insert into child values (1,1,1),(2,2,2)",
+			},
+			exit:      1,
+			fkIdxName: "ageid",
+		},
+	}
+
+	for _, tt := range dropTests {
+		childName := "child"
+		parentName := "parent"
+		childFkName := "fk"
+
+		t.Run(tt.name, func(t *testing.T) {
+			dEnv := dtestutils.CreateTestEnv()
+			ctx := context.Background()
+			for _, c := range tt.setup {
+				exitCode := commands.SqlCmd{}.Exec(ctx, "sql", []string{fmt.Sprintf("-q %s", c)}, dEnv)
+				require.Equal(t, 0, exitCode)
+			}
+			drop := "alter table parent drop primary key"
+			exitCode := commands.SqlCmd{}.Exec(ctx, "sql", []string{fmt.Sprintf("-q %s", drop)}, dEnv)
+			require.Equal(t, tt.exit, exitCode)
+
+			if tt.fkIdxName != "" {
+				wr, err := dEnv.WorkingRoot(ctx)
+				assert.NoError(t, err)
+
+				foreignKeyCollection, err := wr.GetForeignKeyCollection(ctx)
+				assert.NoError(t, err)
+
+				fk, ok := foreignKeyCollection.GetByNameCaseInsensitive(childFkName)
+				assert.True(t, ok)
+				assert.Equal(t, childName, fk.TableName)
+				assert.Equal(t, tt.fkIdxName, fk.ReferencedTableIndex)
+
+				parent, ok, err := wr.GetTable(ctx, parentName)
+				assert.NoError(t, err)
+				assert.True(t, ok)
+
+				parentSch, err := parent.GetSchema(ctx)
+				assert.NoError(t, err)
+				err = fk.ValidateReferencedTableSchema(parentSch)
+				assert.NoError(t, err)
+			}
+		})
+	}
+
+}

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -1826,7 +1826,7 @@ func (t *AlterableDoltTable) verifyCanDropPk(ctx *sql.Context, root *doltdb.Root
 	}
 
 	for _, fk := range fkc.AllKeys() {
-		// check whether or not this FK parent references a PK tag we are about to drop
+		// check if this FK references a parent PK tag we are trying to change
 		if backups, ok := pkBackups[fk.ReferencedTableColumns[0]]; ok {
 			covered := false
 			for _, idx := range backups {

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -1758,28 +1758,19 @@ func (t *AlterableDoltTable) DropPrimaryKey(ctx *sql.Context) error {
 		return sql.ErrWrongAutoKey.New()
 	}
 
-	// Ensure that any primary key column is neither a parent nor child in a fk relationship
 	root, err := t.getRoot(ctx)
 	if err != nil {
 		return err
 	}
 
-	fkc, err := root.GetForeignKeyCollection(ctx)
+	fkc, err := t.verifyCanDropPk(ctx, root)
 	if err != nil {
 		return err
 	}
-
-	err = t.sch.GetPKCols().Iter(func(tag uint64, col schema.Column) (bool, error) {
-		if fkc.ColumnHasFkRelationship(tag) {
-			return true, sql.ErrCantDropIndex.New("PRIMARY")
-		}
-
-		return false, nil
-	})
+	newRoot, err := root.PutForeignKeyCollection(ctx, fkc)
 	if err != nil {
 		return err
 	}
-
 	table, err := t.doltTable(ctx)
 	if err != nil {
 		return err
@@ -1791,7 +1782,7 @@ func (t *AlterableDoltTable) DropPrimaryKey(ctx *sql.Context) error {
 	}
 
 	// Update the root with then new table
-	newRoot, err := root.PutTable(ctx, t.tableName, table)
+	newRoot, err = newRoot.PutTable(ctx, t.tableName, table)
 	if err != nil {
 		return err
 	}
@@ -1802,4 +1793,70 @@ func (t *AlterableDoltTable) DropPrimaryKey(ctx *sql.Context) error {
 	}
 
 	return t.updateFromRoot(ctx, newRoot)
+}
+
+// canDropPk checks whether there are conflicting foreign key relationships referencing this
+// table's primary key tags
+func (t *AlterableDoltTable) verifyCanDropPk(ctx *sql.Context, root *doltdb.RootValue) (*doltdb.ForeignKeyCollection, error) {
+	fkc, err := root.GetForeignKeyCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	indexes := t.sch.Indexes().AllIndexes()
+	if err != nil {
+		return nil, err
+	}
+
+	// pkBackups is a mapping from the table's PL tags to potentially compensating indexes
+	pkBackups := make(map[uint64][]schema.Index, len(t.sch.GetPKCols().TagToIdx))
+	for tag, _ := range t.sch.GetPKCols().TagToIdx {
+		pkBackups[tag] = nil
+	}
+	for _, idx := range indexes {
+		if !idx.IsUserDefined() || !!idx.IsUnique() {
+			continue
+		}
+
+		for _, tag := range idx.AllTags() {
+			if _, ok := pkBackups[tag]; ok {
+				pkBackups[tag] = append(pkBackups[tag], idx)
+			}
+		}
+	}
+
+	for _, fk := range fkc.AllKeys() {
+		// check whether or not this FK parent references a PK tag we are about to drop
+		if backups, ok := pkBackups[fk.ReferencedTableColumns[0]]; ok {
+			covered := false
+			for _, idx := range backups {
+				idxTags := idx.AllTags()
+				if len(fk.TableColumns) > len(idxTags) {
+					continue
+				}
+				failed := false
+				for i := 0; i < len(fk.ReferencedTableColumns); i++ {
+					if idxTags[i] != fk.ReferencedTableColumns[i] {
+						failed = true
+						break
+					}
+				}
+				if failed {
+					continue
+				}
+
+				fkc.RemoveKeys(fk)
+				fk.ReferencedTableIndex = idx.Name()
+				fkc.AddKeys(fk)
+
+				err = fk.ValidateReferencedTableSchema(t.sch)
+				covered = true
+				break
+			}
+			if !covered {
+				return nil, sql.ErrCantDropIndex.New("PRIMARY")
+			}
+		}
+	}
+	return fkc, nil
 }

--- a/integration-tests/bats/primary-key-changes.bats
+++ b/integration-tests/bats/primary-key-changes.bats
@@ -439,16 +439,6 @@ SQL
     [[ "$output" =~ "error: can't drop index 'PRIMARY': needed in a foreign key constraint" ]] || false
 }
 
-@test "primary-key-changes: error dropping primary key when used as a parent in Fk relationship" {
-    dolt sql -q "CREATE TABLE child(pk int primary key)"
-    dolt sql -q "CREATE TABLE parent(pk int primary key, val int);"
-    dolt sql -q "ALTER TABLE parent ADD CONSTRAINT myfk FOREIGN KEY (pk) REFERENCES child (pk);"
-
-    run dolt sql -q "ALTER TABLE parent DROP PRIMARY KEY"
-    [ "$status" -eq 1 ]
-    [[ "$output" =~ "error: can't drop index 'PRIMARY': needed in a foreign key constraint" ]] || false
-}
-
 @test "primary-key-changes: dolt constraints verify works gracefully with schema violations" {
     dolt sql -q "CREATE table t (pk int primary key, val int)"
     dolt commit -am "cm1"


### PR DESCRIPTION
this is what I need for MLflow, which errored in the original implementation:
```bash
    dolt sql -q "CREATE table parent (pk int, val int, primary key (pk, val), key `backup` (val))"
    dolt sql -q "CREATE table child (pk int, val int, foreign key (val) references parent (val))"
    dolt sql -q "alter table parent drop primary key"
```