### PR TITLE
 Addresses different types of panics with remotes/fetches Issue: #2048

### DIFF
--- a/go/cmd/dolt/commands/fetch.go
+++ b/go/cmd/dolt/commands/fetch.go
@@ -193,10 +193,13 @@ func fetchRefSpecs(ctx context.Context, mode ref.UpdateMode, dEnv *env.DoltEnv, 
 			return errhand.BuildDError("error: failed to read from ").AddCause(err).Build()
 		}
 
+		rsSeen := false
+
 		for _, branchRef := range branchRefs {
 			remoteTrackRef := rs.DestRef(branchRef)
 
 			if remoteTrackRef != nil {
+				rsSeen = true
 				srcDBCommit, verr := fetchRemoteBranch(ctx, dEnv, rem, srcDB, dEnv.DoltDB, branchRef, remoteTrackRef)
 
 				if verr != nil {
@@ -225,6 +228,14 @@ func fetchRefSpecs(ctx context.Context, mode ref.UpdateMode, dEnv *env.DoltEnv, 
 					}
 				}
 			}
+		}
+
+		if !rsSeen {
+			if rb, ok := rs.(ref.BranchToTrackingBranchRefSpec); ok {
+				return errhand.BuildDError("error: %s does not appear to be a dolt database. could not read from the remote database. please make sure you have the correct access rights and the database exists", rb.GetRemRefToLocal()).Build()
+			}
+
+			return errhand.BuildDError("error: remote does not appear to be a dolt database. could not read from the remote database. lease make sure you have the correct access rights and the database exists").Build()
 		}
 	}
 

--- a/go/libraries/doltcore/dbfactory/grpc.go
+++ b/go/libraries/doltcore/dbfactory/grpc.go
@@ -88,6 +88,8 @@ func (fact DoltRemoteFactory) newChunkStore(ctx context.Context, nbf *types.Noms
 
 	if err == remotestorage.ErrInvalidDoltSpecPath {
 		return nil, fmt.Errorf("invalid dolt url '%s'", urlObj.String())
+	} else if err != nil {
+		return nil, err
 	}
 
 	if _, ok := params[NoCachingParameter]; ok {

--- a/go/libraries/doltcore/dbfactory/grpc.go
+++ b/go/libraries/doltcore/dbfactory/grpc.go
@@ -89,6 +89,7 @@ func (fact DoltRemoteFactory) newChunkStore(ctx context.Context, nbf *types.Noms
 	if err == remotestorage.ErrInvalidDoltSpecPath {
 		return nil, fmt.Errorf("invalid dolt url '%s'", urlObj.String())
 	} else if err != nil {
+		// TODO: Make this error more expressive
 		return nil, err
 	}
 

--- a/go/libraries/doltcore/ref/ref_spec.go
+++ b/go/libraries/doltcore/ref/ref_spec.go
@@ -280,3 +280,8 @@ func (rs BranchToTrackingBranchRefSpec) DestRef(branchRef DoltRef) DoltRef {
 func (rs BranchToTrackingBranchRefSpec) GetRemote() string {
 	return rs.remote
 }
+
+// GetRemRefToLocal returns the local tracking branch.
+func (rs BranchToTrackingBranchRefSpec) GetRemRefToLocal() branchMapper {
+	return rs.remRefToLocal
+}

--- a/go/libraries/doltcore/ref/remote_ref.go
+++ b/go/libraries/doltcore/ref/remote_ref.go
@@ -77,6 +77,10 @@ func NewRemoteRefFromPathStr(remoteAndPath string) (DoltRef, error) {
 		return nil, ErrInvalidRefSpec
 	}
 
+	if len(remote)+1 > len(remoteAndPath) {
+		return nil, ErrInvalidRefSpec
+	}
+
 	branch := remoteAndPath[len(remote)+1:]
 
 	if remote == "" || branch == "" {

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -1041,14 +1041,18 @@ setup_ref_test() {
 
 @test "remotes: fetching unknown remotes doesn't error" {
     setup_ref_test
+    cd ../../
+    cd dolt-repo-clones/test-repo
     run dolt fetch remotes/dasdas
     [ "$status" -eq 1 ]
     [[ ! "$output" =~ "panic" ]] || false
     [[ "$output" =~ "error: invalid refspec ''" ]] || false
 }
 
-@test "remotes: fetching added invalid remotes correctly errors"{
+@test "remotes: fetching added invalid remotes correctly errors" {
     setup_ref_test
+    cd ../../
+    cd dolt-repo-clones/test-repo
     run dolt remote add myremote http://localhost:50051/test-org/fake
     [ "$status" -eq 1 ]
     [[ ! "$output" =~ "panic" ]] || false

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -1049,7 +1049,7 @@ setup_ref_test() {
     [[ "$output" =~ "error: 'remotes/dasdas' is not a valid refspec." ]] || false
 }
 
-@test "remotes: fetching added invalid remotes correctly errors" {
+@test "remotes: fetching added invalid remote correctly errors" {
     setup_ref_test
     cd ../../
     cd dolt-repo-clones/test-repo

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -1078,7 +1078,7 @@ setup_ref_test() {
     ! [[ "$output" =~ ".dolt" ]] || false
 }
 
-@test "remotes: fetching unknown remotes doesn't error" {
+@test "remotes: fetching unknown remotes should error" {
     setup_ref_test
     cd ../../
     cd dolt-repo-clones/test-repo
@@ -1098,4 +1098,16 @@ setup_ref_test() {
     [ "$status" -eq 1 ]
     [[ ! "$output" =~ "panic" ]] || false
     [[ "$output" =~ "permission denied" ]] || false
+}
+
+@test "remotes: fetching unknown remote ref errors accordingly" {
+   setup_ref_test
+   cd ../../
+   cd dolt-repo-clones/test-repo
+   # Add a dummy remove to allow for fetching
+   dolt remote add myremote dolthub/fake
+
+   run dolt fetch dadasdfasdfa
+   [ "$status" -eq 1 ]
+   [[ "$output" =~ "error: dadasdfasdfa does not appear to be a dolt database" ]] || false
 }

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -1038,3 +1038,10 @@ setup_ref_test() {
     [ "$status" -eq 1 ]
     [[ "$output" =~ "error: invalid refspec ''" ]] || false
 }
+
+@test "remotes: fetching unknown remotes doesn't error" {
+    setup_ref_test
+    run dolt fetch remotes/dasdas
+    [ "$status" -eq 1 ]
+    [[ ! "$output" =~ "panic" ]] || false
+}

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -1046,14 +1046,16 @@ setup_ref_test() {
     run dolt fetch remotes/dasdas
     [ "$status" -eq 1 ]
     [[ ! "$output" =~ "panic" ]] || false
-    [[ "$output" =~ "error: invalid refspec ''" ]] || false
+    [[ "$output" =~ "error: 'remotes/dasdas' is not a valid refspec." ]] || false
 }
 
 @test "remotes: fetching added invalid remotes correctly errors" {
     setup_ref_test
     cd ../../
     cd dolt-repo-clones/test-repo
-    run dolt remote add myremote http://localhost:50051/test-org/fake
+    dolt remote add myremote dolthub/fake
+
+    run dolt fetch myremote
     [ "$status" -eq 1 ]
     [[ ! "$output" =~ "panic" ]] || false
     [[ "$output" =~ "permission denied" ]] || false

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -1046,3 +1046,11 @@ setup_ref_test() {
     [[ ! "$output" =~ "panic" ]] || false
     [[ "$output" =~ "error: invalid refspec ''" ]] || false
 }
+
+@test "remotes: fetching added invalid remotes correctly errors"{
+    setup_ref_test
+    run dolt remote add myremote http://localhost:50051/test-org/fake
+    [ "$status" -eq 1 ]
+    [[ ! "$output" =~ "panic" ]] || false
+    [[ "$output" =~ "permission denied" ]] || false
+}

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -1044,4 +1044,5 @@ setup_ref_test() {
     run dolt fetch remotes/dasdas
     [ "$status" -eq 1 ]
     [[ ! "$output" =~ "panic" ]] || false
+    [[ "$output" =~ "error: invalid refspec ''" ]] || false
 }


### PR DESCRIPTION
This pr addresses three issues with fetching remotes. 

1. A panic with fetching a remote in the form "remotes/.." that is invalid 
2. A panic when an added remote that is then fetched is invalid
3. A lack of error when fetching an invalid remote