### PR TITLE
Remove doltpy from CI

### DIFF
--- a/.github/workflows/ci-bats-unix.yaml
+++ b/.github/workflows/ci-bats-unix.yaml
@@ -58,6 +58,9 @@ jobs:
           npm i bats
           echo "$(pwd)/node_modules/.bin" >> $GITHUB_PATH
         working-directory: ./.ci_bin
+      - name: Install Python Deps
+        run: |
+          pip install mysql-connector-python
       - name: Install Dolt
         working-directory: ./go
         run: |

--- a/.github/workflows/ci-bats-unix.yaml
+++ b/.github/workflows/ci-bats-unix.yaml
@@ -58,9 +58,6 @@ jobs:
           npm i bats
           echo "$(pwd)/node_modules/.bin" >> $GITHUB_PATH
         working-directory: ./.ci_bin
-      - name: Install Doltpy
-        run: |
-          pip install doltpy
       - name: Install Dolt
         working-directory: ./go
         run: |

--- a/.github/workflows/ci-bats-windows.yaml
+++ b/.github/workflows/ci-bats-windows.yaml
@@ -111,6 +111,8 @@ jobs:
           chmod 755 wslpath
           mv wslpath /usr/bin/
           cp /c/tools/php/php /usr/bin/
+        run: |
+          pip install mysql-connector-python
       - name: Install Dolt
         working-directory: ./go
         run: |

--- a/.github/workflows/ci-bats-windows.yaml
+++ b/.github/workflows/ci-bats-windows.yaml
@@ -111,6 +111,7 @@ jobs:
           chmod 755 wslpath
           mv wslpath /usr/bin/
           cp /c/tools/php/php /usr/bin/
+      - name: Install Python Deps
         run: |
           pip install mysql-connector-python
       - name: Install Dolt

--- a/.github/workflows/ci-bats-windows.yaml
+++ b/.github/workflows/ci-bats-windows.yaml
@@ -111,9 +111,6 @@ jobs:
           chmod 755 wslpath
           mv wslpath /usr/bin/
           cp /c/tools/php/php /usr/bin/
-      - name: Install Doltpy
-        run: |
-          pip install doltpy
       - name: Install Dolt
         working-directory: ./go
         run: |


### PR DESCRIPTION
This should shave 1-6 minutes off of every bats job, including the ~90 windows ones which were 8-9 minutes.