### PR TITLE
go.mod: Bump go-mysql-server to pick up date handling for YYYY-M-D format.

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20201005193433-3ee972b1d078
 	github.com/dolthub/fslock v0.0.3
-	github.com/dolthub/go-mysql-server v0.10.1-0.20210902171148-fadb8c4592ec
+	github.com/dolthub/go-mysql-server v0.10.1-0.20210902175808-c05838e8d173
 	github.com/dolthub/ishell v0.0.0-20210205014355-16a4ce758446
 	github.com/dolthub/mmap-go v1.0.4-0.20201107010347-f9f2a9588a66
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81

--- a/go/go.mod
+++ b/go/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20201005193433-3ee972b1d078
 	github.com/dolthub/fslock v0.0.3
-	github.com/dolthub/go-mysql-server v0.10.1-0.20210902033752-29461bcf94ce
+	github.com/dolthub/go-mysql-server v0.10.1-0.20210902171148-fadb8c4592ec
 	github.com/dolthub/ishell v0.0.0-20210205014355-16a4ce758446
 	github.com/dolthub/mmap-go v1.0.4-0.20201107010347-f9f2a9588a66
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81

--- a/go/go.mod
+++ b/go/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20201005193433-3ee972b1d078
 	github.com/dolthub/fslock v0.0.3
-	github.com/dolthub/go-mysql-server v0.10.1-0.20210901221611-9e2a5fe1b09b
+	github.com/dolthub/go-mysql-server v0.10.1-0.20210902033752-29461bcf94ce
 	github.com/dolthub/ishell v0.0.0-20210205014355-16a4ce758446
 	github.com/dolthub/mmap-go v1.0.4-0.20201107010347-f9f2a9588a66
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81

--- a/go/go.sum
+++ b/go/go.sum
@@ -152,6 +152,8 @@ github.com/dolthub/go-mysql-server v0.10.1-0.20210901221611-9e2a5fe1b09b h1:ITm6
 github.com/dolthub/go-mysql-server v0.10.1-0.20210901221611-9e2a5fe1b09b/go.mod h1:cPg39xeFH8/+McnJxncb79SgUuREeIqR+eTvxE6OmXc=
 github.com/dolthub/go-mysql-server v0.10.1-0.20210902033752-29461bcf94ce h1:jQ9XbRUBZlx8cTZKOb64m2kMnKMuktes7KtwuF+0j+o=
 github.com/dolthub/go-mysql-server v0.10.1-0.20210902033752-29461bcf94ce/go.mod h1:cPg39xeFH8/+McnJxncb79SgUuREeIqR+eTvxE6OmXc=
+github.com/dolthub/go-mysql-server v0.10.1-0.20210902171148-fadb8c4592ec h1:jAq5bstT/GaWYhDy46B92wOf3MTPsZEzLkv4qUBFxm0=
+github.com/dolthub/go-mysql-server v0.10.1-0.20210902171148-fadb8c4592ec/go.mod h1:cPg39xeFH8/+McnJxncb79SgUuREeIqR+eTvxE6OmXc=
 github.com/dolthub/ishell v0.0.0-20210205014355-16a4ce758446 h1:0ol5pj+QlKUKAtqs1LiPM3ZJKs+rHPgLSsMXmhTrCAM=
 github.com/dolthub/ishell v0.0.0-20210205014355-16a4ce758446/go.mod h1:dhGBqcCEfK5kuFmeO5+WOx3hqc1k3M29c1oS/R7N4ms=
 github.com/dolthub/mmap-go v1.0.4-0.20201107010347-f9f2a9588a66 h1:WRPDbpJWEnPxPmiuOTndT+lUWUeGjx6eoNOK9O4tQQQ=

--- a/go/go.sum
+++ b/go/go.sum
@@ -154,6 +154,8 @@ github.com/dolthub/go-mysql-server v0.10.1-0.20210902033752-29461bcf94ce h1:jQ9X
 github.com/dolthub/go-mysql-server v0.10.1-0.20210902033752-29461bcf94ce/go.mod h1:cPg39xeFH8/+McnJxncb79SgUuREeIqR+eTvxE6OmXc=
 github.com/dolthub/go-mysql-server v0.10.1-0.20210902171148-fadb8c4592ec h1:jAq5bstT/GaWYhDy46B92wOf3MTPsZEzLkv4qUBFxm0=
 github.com/dolthub/go-mysql-server v0.10.1-0.20210902171148-fadb8c4592ec/go.mod h1:cPg39xeFH8/+McnJxncb79SgUuREeIqR+eTvxE6OmXc=
+github.com/dolthub/go-mysql-server v0.10.1-0.20210902175808-c05838e8d173 h1:gM1YsiCfQMVcaSQrj9ZZMvJStGi0/TZc7zwsf9KbweI=
+github.com/dolthub/go-mysql-server v0.10.1-0.20210902175808-c05838e8d173/go.mod h1:cPg39xeFH8/+McnJxncb79SgUuREeIqR+eTvxE6OmXc=
 github.com/dolthub/ishell v0.0.0-20210205014355-16a4ce758446 h1:0ol5pj+QlKUKAtqs1LiPM3ZJKs+rHPgLSsMXmhTrCAM=
 github.com/dolthub/ishell v0.0.0-20210205014355-16a4ce758446/go.mod h1:dhGBqcCEfK5kuFmeO5+WOx3hqc1k3M29c1oS/R7N4ms=
 github.com/dolthub/mmap-go v1.0.4-0.20201107010347-f9f2a9588a66 h1:WRPDbpJWEnPxPmiuOTndT+lUWUeGjx6eoNOK9O4tQQQ=

--- a/go/go.sum
+++ b/go/go.sum
@@ -150,6 +150,8 @@ github.com/dolthub/go-mysql-server v0.10.1-0.20210831222740-e2d8eb761ecd h1:inMC
 github.com/dolthub/go-mysql-server v0.10.1-0.20210831222740-e2d8eb761ecd/go.mod h1:cPg39xeFH8/+McnJxncb79SgUuREeIqR+eTvxE6OmXc=
 github.com/dolthub/go-mysql-server v0.10.1-0.20210901221611-9e2a5fe1b09b h1:ITm6QsoE0lcxSjQfMJ0xhXIZNm+zKvFwk5iGfBsplAQ=
 github.com/dolthub/go-mysql-server v0.10.1-0.20210901221611-9e2a5fe1b09b/go.mod h1:cPg39xeFH8/+McnJxncb79SgUuREeIqR+eTvxE6OmXc=
+github.com/dolthub/go-mysql-server v0.10.1-0.20210902033752-29461bcf94ce h1:jQ9XbRUBZlx8cTZKOb64m2kMnKMuktes7KtwuF+0j+o=
+github.com/dolthub/go-mysql-server v0.10.1-0.20210902033752-29461bcf94ce/go.mod h1:cPg39xeFH8/+McnJxncb79SgUuREeIqR+eTvxE6OmXc=
 github.com/dolthub/ishell v0.0.0-20210205014355-16a4ce758446 h1:0ol5pj+QlKUKAtqs1LiPM3ZJKs+rHPgLSsMXmhTrCAM=
 github.com/dolthub/ishell v0.0.0-20210205014355-16a4ce758446/go.mod h1:dhGBqcCEfK5kuFmeO5+WOx3hqc1k3M29c1oS/R7N4ms=
 github.com/dolthub/mmap-go v1.0.4-0.20201107010347-f9f2a9588a66 h1:WRPDbpJWEnPxPmiuOTndT+lUWUeGjx6eoNOK9O4tQQQ=

--- a/integration-tests/bats/types.bats
+++ b/integration-tests/bats/types.bats
@@ -261,6 +261,22 @@ SQL
     run dolt sql -q "SELECT * FROM test"
     [ "$status" -eq "0" ]
     [[ "${lines[3]}" =~ " 1000-01-01 00:00:00 +0000 UTC " ]] || false
+    dolt sql -q "REPLACE INTO test VALUES (1, '1000-01-02');"
+    run dolt sql -q "SELECT * FROM test"
+    [ "$status" -eq "0" ]
+    [[ "${lines[3]}" =~ " 1000-01-02 00:00:00 +0000 UTC " ]] || false
+    dolt sql -q "REPLACE INTO test VALUES (1, '1000-01-3');"
+    run dolt sql -q "SELECT * FROM test"
+    [ "$status" -eq "0" ]
+    [[ "${lines[3]}" =~ " 1000-01-03 00:00:00 +0000 UTC " ]] || false
+    dolt sql -q "REPLACE INTO test VALUES (1, '1000-1-04');"
+    run dolt sql -q "SELECT * FROM test"
+    [ "$status" -eq "0" ]
+    [[ "${lines[3]}" =~ " 1000-01-04 00:00:00 +0000 UTC " ]] || false
+    dolt sql -q "REPLACE INTO test VALUES (1, '1000-1-5');"
+    run dolt sql -q "SELECT * FROM test"
+    [ "$status" -eq "0" ]
+    [[ "${lines[3]}" =~ " 1000-01-05 00:00:00 +0000 UTC " ]] || false
     dolt sql -q "REPLACE INTO test VALUES (1, '9999-01-01 23:59:59.999999');"
     run dolt sql -q "SELECT * FROM test"
     [ "$status" -eq "0" ]
@@ -290,6 +306,22 @@ SQL
     run dolt sql -q "SELECT * FROM test"
     [ "$status" -eq "0" ]
     [[ "${lines[3]}" =~ " 1000-01-01 00:00:00 +0000 UTC " ]] || false
+    dolt sql -q "REPLACE INTO test VALUES (1, '1000-01-02');"
+    run dolt sql -q "SELECT * FROM test"
+    [ "$status" -eq "0" ]
+    [[ "${lines[3]}" =~ " 1000-01-02 00:00:00 +0000 UTC " ]] || false
+    dolt sql -q "REPLACE INTO test VALUES (1, '1000-01-3');"
+    run dolt sql -q "SELECT * FROM test"
+    [ "$status" -eq "0" ]
+    [[ "${lines[3]}" =~ " 1000-01-03 00:00:00 +0000 UTC " ]] || false
+    dolt sql -q "REPLACE INTO test VALUES (1, '1000-1-04');"
+    run dolt sql -q "SELECT * FROM test"
+    [ "$status" -eq "0" ]
+    [[ "${lines[3]}" =~ " 1000-01-04 00:00:00 +0000 UTC " ]] || false
+    dolt sql -q "REPLACE INTO test VALUES (1, '1000-1-5');"
+    run dolt sql -q "SELECT * FROM test"
+    [ "$status" -eq "0" ]
+    [[ "${lines[3]}" =~ " 1000-01-05 00:00:00 +0000 UTC " ]] || false
     dolt sql -q "REPLACE INTO test VALUES (1, '9999-01-01 23:59:59.999999');"
     run dolt sql -q "SELECT * FROM test"
     [ "$status" -eq "0" ]


### PR DESCRIPTION
Fixes #2088.