### PR TITLE
Modify bad row error format

### DIFF
--- a/go/libraries/doltcore/row/row.go
+++ b/go/libraries/doltcore/row/row.go
@@ -201,7 +201,7 @@ func findInvalidCol(r Row, sch schema.Schema) (*schema.Column, schema.ColConstra
 
 		if !col.TypeInfo.IsValid(val) {
 			badCol = &col
-			return true, fmt.Errorf(`"%v" is not valid for "%v"`, val, col.TypeInfo.String())
+			return true, fmt.Errorf(`"%v" is not valid for column "%s" (type "%s")`, val, col.Name, col.TypeInfo.String())
 		}
 
 		if len(col.Constraints) > 0 {

--- a/go/libraries/doltcore/row/row.go
+++ b/go/libraries/doltcore/row/row.go
@@ -201,7 +201,7 @@ func findInvalidCol(r Row, sch schema.Schema) (*schema.Column, schema.ColConstra
 
 		if !col.TypeInfo.IsValid(val) {
 			badCol = &col
-			return true, fmt.Errorf(`"%v" is not valid for column "%s" (type "%s")`, val, col.Name, col.TypeInfo.String())
+			return true, fmt.Errorf(`"%v" is not valid for column "%s" (type "%s")`, val, col.Name, col.TypeInfo.ToSqlType().String())
 		}
 
 		if len(col.Constraints) > 0 {

--- a/integration-tests/bats/import-update-tables.bats
+++ b/integration-tests/bats/import-update-tables.bats
@@ -19,7 +19,7 @@ SQL
     cat <<SQL > 1pk1col-char-sch.sql
 CREATE TABLE test (
   pk BIGINT NOT NULL COMMENT 'tag:0',
-  c char(5) COMMENT 'tag:1',
+  c CHAR(5) COMMENT 'tag:1',
   PRIMARY KEY (pk)
 );
 SQL


### PR DESCRIPTION
Closes #2103.

Before:
```python
A bad row was encountered while moving data.
Bad Row: 
"03AGDBQ24TPRIFU0LRPRHLHU8KBOK5SQSMCT8BMVFJNANULFUG4RDHNZPOV4PJNMN0DOD1PM2V5AQQTFP1HZXZG5J5BJTP7BN0A8WLBZYMBJIRU7BWTYCNXTCQUD1UYWITEJIZR5EWWP1NM4OR40P6FTQL4NHKIA870UAFXSPRF0AIK_45YNRU98ZQOZQNJFKNF89FW9" is not valid for "VarString(utf8mb4_0900_ai_ci, 180, SQL: VarChar)"
These can be ignored using the '--continue'
```

After:
```python
A bad row was encountered while moving data.
Bad Row: 
"03AGDBQ24TPRIFU0LRPRHLHU8KBOK5SQSMCT8BMVFJNANULFUG4RDHNZPOV4PJNMN0DOD1PM2V5AQQTFP1HZXZG5J5BJTP7BN0A8WLBZYMBJIRU7BWTYCNXTCQUD1UYWITEJIZR5EWWP1NM4OR40P6FTQL4NHKIA870UAFXSPRF0AIK_45YNRU98ZQOZQNJFKNF89FW9" is not valid for column "street_physical" (type "VarString(utf8mb4_0900_ai_ci, 180, SQL: VarChar)")
These can be ignored using the '--continue'
```

WIP: BATS test still needs to be written