### PR TITLE
go/libraries/doltcore/dbfactory: Change our GRPC remote DB factory to take the GRPC dialer through a param.

### DIFF
--- a/go/cmd/dolt/commands/clone.go
+++ b/go/cmd/dolt/commands/clone.go
@@ -123,7 +123,7 @@ func (cmd CloneCmd) Exec(ctx context.Context, commandStr string, args []string, 
 		if verr == nil {
 			var r env.Remote
 			var srcDB *doltdb.DoltDB
-			r, srcDB, verr = createRemote(ctx, remoteName, remoteUrl, params)
+			r, srcDB, verr = createRemote(ctx, remoteName, remoteUrl, params, dEnv)
 
 			if verr == nil {
 				dEnv, verr = envForClone(ctx, srcDB.ValueReadWriter().Format(), r, dir, dEnv.FS, dEnv.Version)
@@ -227,10 +227,10 @@ func envForClone(ctx context.Context, nbf *types.NomsBinFormat, r env.Remote, di
 	return dEnv, nil
 }
 
-func createRemote(ctx context.Context, remoteName, remoteUrl string, params map[string]string) (env.Remote, *doltdb.DoltDB, errhand.VerboseError) {
+func createRemote(ctx context.Context, remoteName, remoteUrl string, params map[string]string, dEnv *env.DoltEnv) (env.Remote, *doltdb.DoltDB, errhand.VerboseError) {
 	cli.Printf("cloning %s\n", remoteUrl)
 
-	r := env.NewRemote(remoteName, remoteUrl, params)
+	r := env.NewRemote(remoteName, remoteUrl, params, dEnv)
 
 	ddb, err := r.GetRemoteDB(ctx, types.Format_Default)
 

--- a/go/cmd/dolt/commands/read_tables.go
+++ b/go/cmd/dolt/commands/read_tables.go
@@ -115,7 +115,7 @@ func (cmd ReadTablesCmd) Exec(ctx context.Context, commandStr string, args []str
 		return HandleVErrAndExitCode(verr, usage)
 	}
 
-	srcDB, srcRoot, verr := getRemoteDBAtCommit(ctx, remoteUrl, remoteUrlParams, commitStr)
+	srcDB, srcRoot, verr := getRemoteDBAtCommit(ctx, remoteUrl, remoteUrlParams, commitStr, dEnv)
 	if verr != nil {
 		return HandleVErrAndExitCode(verr, usage)
 	}
@@ -194,8 +194,8 @@ func pullTableValue(ctx context.Context, dEnv *env.DoltEnv, srcDB *doltdb.DoltDB
 	return destRoot, nil
 }
 
-func getRemoteDBAtCommit(ctx context.Context, remoteUrl string, remoteUrlParams map[string]string, commitStr string) (*doltdb.DoltDB, *doltdb.RootValue, errhand.VerboseError) {
-	_, srcDB, verr := createRemote(ctx, "temp", remoteUrl, remoteUrlParams)
+func getRemoteDBAtCommit(ctx context.Context, remoteUrl string, remoteUrlParams map[string]string, commitStr string, dEnv *env.DoltEnv) (*doltdb.DoltDB, *doltdb.RootValue, errhand.VerboseError) {
+	_, srcDB, verr := createRemote(ctx, "temp", remoteUrl, remoteUrlParams, dEnv)
 
 	if verr != nil {
 		return nil, nil, verr

--- a/go/cmd/dolt/commands/remote.go
+++ b/go/cmd/dolt/commands/remote.go
@@ -173,7 +173,7 @@ func addRemote(dEnv *env.DoltEnv, apr *argparser.ArgParseResults) errhand.Verbos
 		return verr
 	}
 
-	r := env.NewRemote(remoteName, remoteUrl, params)
+	r := env.NewRemote(remoteName, remoteUrl, params, dEnv)
 	err = dEnv.AddRemote(r.Name, r.Url, r.FetchSpecs, r.Params)
 
 	switch err {

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -227,7 +227,7 @@ func runMain() int {
 	warnIfMaxFilesTooLow()
 
 	ctx, cancelF := context.WithCancel(context.Background())
-	c := make(chan os.Signal)
+	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-c

--- a/go/libraries/doltcore/dbfactory/factory.go
+++ b/go/libraries/doltcore/dbfactory/factory.go
@@ -53,7 +53,7 @@ const (
 
 // DBFactory is an interface for creating concrete datas.Database instances which may have different backing stores.
 type DBFactory interface {
-	CreateDB(ctx context.Context, nbf *types.NomsBinFormat, urlObj *url.URL, params map[string]string) (datas.Database, error)
+	CreateDB(ctx context.Context, nbf *types.NomsBinFormat, urlObj *url.URL, params map[string]interface{}) (datas.Database, error)
 }
 
 // DBFactories is a map from url scheme name to DBFactory.  Additional factories can be added to the DBFactories map
@@ -64,17 +64,13 @@ var DBFactories = map[string]DBFactory{
 	FileScheme:    FileFactory{},
 	MemScheme:     MemFactory{},
 	LocalBSScheme: LocalBSFactory{},
-}
-
-// InitializeFactories initializes any factories that rely on a GRPCConnectionProvider (Namely http and https)
-func InitializeFactories(dp GRPCDialProvider) {
-	DBFactories[HTTPScheme] = NewDoltRemoteFactory(dp, true)
-	DBFactories[HTTPSScheme] = NewDoltRemoteFactory(dp, false)
+	HTTPScheme:    NewDoltRemoteFactory(true),
+	HTTPSScheme:   NewDoltRemoteFactory(false),
 }
 
 // CreateDB creates a database based on the supplied urlStr, and creation params.  The DBFactory used for creation is
 // determined by the scheme of the url.  Naked urls will use https by default.
-func CreateDB(ctx context.Context, nbf *types.NomsBinFormat, urlStr string, params map[string]string) (datas.Database, error) {
+func CreateDB(ctx context.Context, nbf *types.NomsBinFormat, urlStr string, params map[string]interface{}) (datas.Database, error) {
 	urlObj, err := earl.Parse(urlStr)
 
 	if err != nil {

--- a/go/libraries/doltcore/dbfactory/file.go
+++ b/go/libraries/doltcore/dbfactory/file.go
@@ -43,7 +43,7 @@ type FileFactory struct {
 }
 
 // CreateDB creates an local filesys backed database
-func (fact FileFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, urlObj *url.URL, params map[string]string) (datas.Database, error) {
+func (fact FileFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, urlObj *url.URL, params map[string]interface{}) (datas.Database, error) {
 	path, err := url.PathUnescape(urlObj.Path)
 
 	if err != nil {

--- a/go/libraries/doltcore/dbfactory/gs.go
+++ b/go/libraries/doltcore/dbfactory/gs.go
@@ -32,7 +32,7 @@ type GSFactory struct {
 }
 
 // CreateDB creates an GCS backed database
-func (fact GSFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, urlObj *url.URL, params map[string]string) (datas.Database, error) {
+func (fact GSFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, urlObj *url.URL, params map[string]interface{}) (datas.Database, error) {
 	var db datas.Database
 	gcs, err := storage.NewClient(ctx)
 
@@ -57,7 +57,7 @@ type LocalBSFactory struct {
 }
 
 // CreateDB creates a local filesystem blobstore backed database
-func (fact LocalBSFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, urlObj *url.URL, params map[string]string) (datas.Database, error) {
+func (fact LocalBSFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, urlObj *url.URL, params map[string]interface{}) (datas.Database, error) {
 	var db datas.Database
 	absPath, err := filepath.Abs(filepath.Join(urlObj.Host, urlObj.Path))
 

--- a/go/libraries/doltcore/dbfactory/mem.go
+++ b/go/libraries/doltcore/dbfactory/mem.go
@@ -28,7 +28,7 @@ type MemFactory struct {
 }
 
 // CreateDB creates an in memory backed database
-func (fact MemFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, urlObj *url.URL, params map[string]string) (datas.Database, error) {
+func (fact MemFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, urlObj *url.URL, params map[string]interface{}) (datas.Database, error) {
 	var db datas.Database
 	storage := &chunks.MemoryStorage{}
 	db = datas.NewDatabase(storage.NewViewWithDefaultFormat())

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -75,7 +75,7 @@ func LoadDoltDB(ctx context.Context, nbf *types.NomsBinFormat, urlStr string, fs
 	return LoadDoltDBWithParams(ctx, nbf, urlStr, fs, nil)
 }
 
-func LoadDoltDBWithParams(ctx context.Context, nbf *types.NomsBinFormat, urlStr string, fs filesys.Filesys, params map[string]string) (*DoltDB, error) {
+func LoadDoltDBWithParams(ctx context.Context, nbf *types.NomsBinFormat, urlStr string, fs filesys.Filesys, params map[string]interface{}) (*DoltDB, error) {
 	if urlStr == LocalDirDoltDB {
 		exists, isDir := fs.Exists(dbfactory.DoltDataDir)
 

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -107,6 +107,14 @@ func Load(ctx context.Context, hdp HomeDirProvider, fs filesys.Filesys, urlStr, 
 		urlStr:      urlStr,
 		hdp:         hdp,
 	}
+	if dEnv.RepoState != nil {
+		remotes := make(map[string]Remote, len(dEnv.RepoState.Remotes))
+		for n, r := range dEnv.RepoState.Remotes {
+			r.dialer = dEnv
+			remotes[n] = r
+		}
+		dEnv.RepoState.Remotes = remotes
+	}
 
 	if dbLoadErr == nil && dEnv.HasDoltDir() {
 		if !dEnv.HasDoltTempTableDir() {
@@ -130,8 +138,6 @@ func Load(ctx context.Context, hdp HomeDirProvider, fs filesys.Filesys, urlStr, 
 			}()
 		}
 	}
-
-	dbfactory.InitializeFactories(dEnv)
 
 	if rsErr == nil && dbLoadErr == nil {
 		// If the working set isn't present in the DB, create it from the repo state. This step can be removed post 1.0.
@@ -861,7 +867,7 @@ func (dEnv *DoltEnv) AddRemote(name string, url string, fetchSpecs []string, par
 		return fmt.Errorf("%w; %s", ErrInvalidRemoteURL, err.Error())
 	}
 
-	r := Remote{name, absRemoteUrl, fetchSpecs, params}
+	r := Remote{name, absRemoteUrl, fetchSpecs, params, dEnv}
 	dEnv.RepoState.AddRemote(r)
 	err = dEnv.RepoState.Save(dEnv.FS)
 	if err != nil {

--- a/go/libraries/doltcore/env/remotes.go
+++ b/go/libraries/doltcore/env/remotes.go
@@ -54,10 +54,11 @@ type Remote struct {
 	Url        string            `json:"url"`
 	FetchSpecs []string          `json:"fetch_specs"`
 	Params     map[string]string `json:"params"`
+	dialer     dbfactory.GRPCDialProvider
 }
 
-func NewRemote(name, url string, params map[string]string) Remote {
-	return Remote{name, url, []string{"refs/heads/*:refs/remotes/" + name + "/*"}, params}
+func NewRemote(name, url string, params map[string]string, dialer dbfactory.GRPCDialProvider) Remote {
+	return Remote{name, url, []string{"refs/heads/*:refs/remotes/" + name + "/*"}, params, dialer}
 }
 
 func (r *Remote) GetParam(pName string) (string, bool) {
@@ -76,15 +77,25 @@ func (r *Remote) GetParamOrDefault(pName, defVal string) string {
 }
 
 func (r *Remote) GetRemoteDB(ctx context.Context, nbf *types.NomsBinFormat) (*doltdb.DoltDB, error) {
-	return doltdb.LoadDoltDBWithParams(ctx, nbf, r.Url, filesys2.LocalFS, r.Params)
+	params := make(map[string]interface{})
+	for k, v := range r.Params {
+		params[k] = v
+	}
+	if r.dialer != nil {
+		params[dbfactory.GRPCDialProviderParam] = r.dialer
+	}
+	return doltdb.LoadDoltDBWithParams(ctx, nbf, r.Url, filesys2.LocalFS, params)
 }
 
 func (r *Remote) GetRemoteDBWithoutCaching(ctx context.Context, nbf *types.NomsBinFormat) (*doltdb.DoltDB, error) {
-	params := make(map[string]string)
+	params := make(map[string]interface{})
 	for k, v := range r.Params {
 		params[k] = v
 	}
 	params[dbfactory.NoCachingParameter] = "true"
+	if r.dialer != nil {
+		params[dbfactory.GRPCDialProviderParam] = r.dialer
+	}
 	return doltdb.LoadDoltDBWithParams(ctx, nbf, r.Url, filesys2.LocalFS, params)
 }
 

--- a/go/utils/remotesrv/main.go
+++ b/go/utils/remotesrv/main.go
@@ -73,9 +73,8 @@ func main() {
 }
 
 func waitForSignal() {
-	c := make(chan os.Signal)
-	signal.Notify(c, os.Interrupt)
-	signal.Notify(c, os.Kill)
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, os.Kill)
 
 	<-c
 }


### PR DESCRIPTION
Prior to this change, we used to set a global variable in the dbfactory package
which referred to whichever DoltEnv was loaded most recently. It was racey and
it has pretty terrible semantics.