### PR TITLE
Make hasNull true when val is types.NullValue

### DIFF
--- a/go/libraries/doltcore/table/editor/sessioned_table_editor.go
+++ b/go/libraries/doltcore/table/editor/sessioned_table_editor.go
@@ -469,7 +469,7 @@ func (ste *sessionedTableEditor) reduceRowAndConvert(nbf *types.NomsBinFormat, o
 	keyVals := make([]types.Value, len(originalTags)*2)
 	for i, colTag := range originalTags {
 		val, ok := taggedVals[colTag]
-		if !ok {
+		if !ok || val == types.NullValue {
 			return types.EmptyTuple(nbf), true, nil
 		}
 		newTag := newTags[i]


### PR DESCRIPTION
Closes #2108. I believe my fix is a hack and that `ok` should be `false` when `value` is `null_value` but isn't being set due to some underlying bug.