### PR TITLE
Support GetDiffsWithFilter for keyless tables

### DIFF
--- a/go/libraries/doltcore/diff/async_differ.go
+++ b/go/libraries/doltcore/diff/async_differ.go
@@ -35,6 +35,9 @@ type RowDiffer interface {
 	// GetDiffs returns the requested number of diff.Differences, or times out.
 	GetDiffs(numDiffs int, timeout time.Duration) ([]*diff.Difference, bool, error)
 
+	// GetDiffsWithFilter returns the requested number of filtered diff.Differences, or times out.
+	GetDiffsWithFilter(numDiffs int, timeout time.Duration, filterByChangeType types.DiffChangeType) ([]*diff.Difference, bool, error)
+
 	// Close closes the RowDiffer.
 	Close() error
 }
@@ -183,8 +186,7 @@ type keylessDiffer struct {
 
 var _ RowDiffer = &keylessDiffer{}
 
-func (kd *keylessDiffer) GetDiffs(numDiffs int, timeout time.Duration) (diffs []*diff.Difference, more bool, err error) {
-	timeoutChan := time.After(timeout)
+func (kd *keylessDiffer) getDiffs(numDiffs int, timeoutChan <-chan time.Time, pred diffPredicate) (diffs []*diff.Difference, more bool, err error) {
 	diffs = make([]*diff.Difference, numDiffs)
 	idx := 0
 
@@ -192,7 +194,6 @@ func (kd *keylessDiffer) GetDiffs(numDiffs int, timeout time.Duration) (diffs []
 		// first populate |diffs| with copies of |kd.df|
 		for (idx < numDiffs) && (kd.copiesLeft > 0) {
 			diffs[idx] = &kd.df
-
 			idx++
 			kd.copiesLeft--
 		}
@@ -214,13 +215,30 @@ func (kd *keylessDiffer) GetDiffs(numDiffs int, timeout time.Duration) (diffs []
 				return diffs[:idx], more, nil
 			}
 
-			kd.df, kd.copiesLeft, err = convertDiff(d)
+			df, copiesLeft, err := convertDiff(d)
 			if err != nil {
 				return nil, false, err
 			}
+			if pred(&df) {
+				kd.df = df
+			}
+			kd.copiesLeft = copiesLeft
 		}
 	}
+}
 
+func (kd *keylessDiffer) GetDiffs(numDiffs int, timeout time.Duration) ([]*diff.Difference, bool, error) {
+	if timeout < 0 {
+		return kd.getDiffs(numDiffs, forever, alwaysTruePredicate)
+	}
+	return kd.getDiffs(numDiffs, time.After(timeout), alwaysTruePredicate)
+}
+
+func (kd *keylessDiffer) GetDiffsWithFilter(numDiffs int, timeout time.Duration, filterByChangeType types.DiffChangeType) ([]*diff.Difference, bool, error) {
+	if timeout < 0 {
+		return kd.getDiffs(numDiffs, forever, hasChangeTypePredicate(filterByChangeType))
+	}
+	return kd.getDiffs(numDiffs, time.After(timeout), hasChangeTypePredicate(filterByChangeType))
 }
 
 // convertDiff reports the cardinality of a change,
@@ -278,6 +296,10 @@ func (e EmptyRowDiffer) Start(ctx context.Context, from, to types.Map) {
 }
 
 func (e EmptyRowDiffer) GetDiffs(numDiffs int, timeout time.Duration) ([]*diff.Difference, bool, error) {
+	return nil, false, nil
+}
+
+func (e EmptyRowDiffer) GetDiffsWithFilter(numDiffs int, timeout time.Duration, filterByChangeType types.DiffChangeType) ([]*diff.Difference, bool, error) {
 	return nil, false, nil
 }
 

--- a/go/libraries/doltcore/diff/async_differ.go
+++ b/go/libraries/doltcore/diff/async_differ.go
@@ -215,14 +215,21 @@ func (kd *keylessDiffer) getDiffs(numDiffs int, timeoutChan <-chan time.Time, pr
 				return diffs[:idx], more, nil
 			}
 
-			df, copiesLeft, err := convertDiff(d)
-			if err != nil {
-				return nil, false, err
+			ok := false
+			for !ok {
+				kd.df, kd.copiesLeft, err = convertDiff(d)
+				if err != nil {
+					return nil, false, err
+				}
+
+				ok = pred(&kd.df)
+
+				if !ok {
+					if d, more = <-kd.diffChan; !more {
+						return diffs[:idx], more, nil
+					}
+				}
 			}
-			if pred(&df) {
-				kd.df = df
-			}
-			kd.copiesLeft = copiesLeft
 		}
 	}
 }


### PR DESCRIPTION
On dolthub we're using `diff.NewAsyncDiffer` instead of `diff.NewRowDiffer` to list row diffs (see [here](https://github.com/dolthub/ld/blob/master/go/services/dolthubapi/pkg/domain/repositorydata.go#L1534)), which doesn't have support for diffing keyless tables (https://www.dolthub.com/repositories/ttest/keyless/pulls/1/compare). In order to use `NewRowDiffer`, we need to add a `GetDiffsWithFilter` method for keyless tables.

I tried writing tests for this, but was having a hard time figuring out what the rows map for keyless tables should look like