### PR TITLE
Fixed VRW reference issues

### DIFF
--- a/go/cmd/dolt/commands/cnfcmds/cat.go
+++ b/go/cmd/dolt/commands/cnfcmds/cat.go
@@ -33,7 +33,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/libraries/utils/iohelp"
-	"github.com/dolthub/dolt/go/store/types"
 )
 
 var catDocs = cli.CommandDocumentationContent{
@@ -165,8 +164,7 @@ func printConflicts(ctx context.Context, root *doltdb.RootValue, tblNames []stri
 
 			defer cnfRd.Close()
 
-			vrw := types.NewMemoryValueStore() // Some types require a vrw but we're just displaying, so we use an internal store
-			splitter, err := merge.NewConflictSplitter(ctx, vrw, cnfRd.GetJoiner())
+			splitter, err := merge.NewConflictSplitter(ctx, tbl.ValueReadWriter(), cnfRd.GetJoiner())
 
 			if err != nil {
 				return errhand.BuildDError("error: unable to handle schemas").AddCause(err).Build()

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -447,7 +447,7 @@ func diffUserTables(ctx context.Context, fromRoot, toRoot *doltdb.RootValue, dAr
 			} else if td.IsAdd() {
 				fromSch = toSch
 			}
-			verr = diffRows(ctx, td, dArgs)
+			verr = diffRows(ctx, td, dArgs, toRoot.VRW())
 		}
 
 		if verr != nil {
@@ -678,7 +678,7 @@ func fromNamer(name string) string {
 	return diff.From + "_" + name
 }
 
-func diffRows(ctx context.Context, td diff.TableDelta, dArgs *diffArgs) errhand.VerboseError {
+func diffRows(ctx context.Context, td diff.TableDelta, dArgs *diffArgs, vrw types.ValueReadWriter) errhand.VerboseError {
 	fromSch, toSch, err := td.GetSchemas(ctx)
 	if err != nil {
 		return errhand.BuildDError("cannot retrieve schema for table %s", td.ToName).AddCause(err).Build()
@@ -704,7 +704,6 @@ func diffRows(ctx context.Context, td diff.TableDelta, dArgs *diffArgs) errhand.
 		return errhand.BuildDError("").AddCause(err).Build()
 	}
 
-	vrw := types.NewMemoryValueStore() // We don't want to persist anything, so we use an internal store
 	unionSch, ds, verr := createSplitter(ctx, vrw, fromSch, toSch, joiner, dArgs)
 	if verr != nil {
 		return verr

--- a/go/libraries/doltcore/doltdb/foreign_key_coll.go
+++ b/go/libraries/doltcore/doltdb/foreign_key_coll.go
@@ -505,6 +505,7 @@ func (fk ForeignKey) ValidateData(
 	childSch schema.Schema,
 	childRowData, childIdxData, parentIdxData types.Map,
 	childDef, parentDef schema.Index,
+	vrw types.ValueReadWriter,
 ) error {
 	if fk.ReferencedTableIndex != parentDef.Name() {
 		return fmt.Errorf("cannot validate data as wrong referenced index was given: expected `%s` but received `%s`",
@@ -522,7 +523,6 @@ func (fk ForeignKey) ValidateData(
 		return err
 	}
 
-	vrw := types.NewMemoryValueStore() // We are checking fks rather than persisting any values, so an internal VRW can be used
 	rc, err := rowconv.NewRowConverter(ctx, vrw, fm)
 	if err != nil {
 		return err

--- a/go/libraries/doltcore/sqle/dolt_index.go
+++ b/go/libraries/doltcore/sqle/dolt_index.go
@@ -265,8 +265,7 @@ func (di *doltIndex) keysToTuple(keys []interface{}) (types.Tuple, error) {
 	for i, col := range di.cols {
 		// As an example, if our TypeInfo is Int8, we should not fail to create a tuple if we are returning all keys
 		// that have a value of less than 9001, thus we promote the TypeInfo to the widest type.
-		vrw := types.NewMemoryValueStore() // We are creating index keys, therefore we can use an internal store
-		val, err := col.TypeInfo.Promote().ConvertValueToNomsValue(context.Background(), vrw, keys[i])
+		val, err := col.TypeInfo.Promote().ConvertValueToNomsValue(context.Background(), di.table.ValueReadWriter(), keys[i])
 		if err != nil {
 			return types.EmptyTuple(nbf), err
 		}

--- a/go/libraries/doltcore/sqle/dtables/diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/diff_table.go
@@ -353,15 +353,13 @@ func (dp diffPartition) getRowIter(ctx *sql.Context, ddb *doltdb.DoltDB, ss *sch
 		return nil, err
 	}
 
-	vrw := types.NewMemoryValueStore() // We're displaying here, so all values that require a VRW will use an internal one
-
-	fromConv, err := rowConvForSchema(ctx, vrw, ss, fromSch)
+	fromConv, err := rowConvForSchema(ctx, ddb.ValueReadWriter(), ss, fromSch)
 
 	if err != nil {
 		return nil, err
 	}
 
-	toConv, err := rowConvForSchema(ctx, vrw, ss, toSch)
+	toConv, err := rowConvForSchema(ctx, ddb.ValueReadWriter(), ss, toSch)
 
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/sqle/dtables/history_table.go
+++ b/go/libraries/doltcore/sqle/dtables/history_table.go
@@ -347,9 +347,7 @@ func newRowItrForTableAtCommit(
 		return nil, err
 	}
 
-	vrw := types.NewMemoryValueStore() // We're displaying here, so all values that require a VRW will use an internal one
-
-	toSuperSchConv, err := rowConvForSchema(ctx, vrw, ss, tblSch)
+	toSuperSchConv, err := rowConvForSchema(ctx, tbl.ValueReadWriter(), ss, tblSch)
 
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -1328,7 +1328,7 @@ func (t *AlterableDoltTable) CreateForeignKey(
 	if err != nil {
 		return err
 	}
-	err = foreignKey.ValidateData(ctx, t.sch, tableData, tableIndexData, refTableIndexData, tableIndex, refTableIndex)
+	err = foreignKey.ValidateData(ctx, t.sch, tableData, tableIndexData, refTableIndexData, tableIndex, refTableIndex, table.ValueReadWriter())
 	if err != nil {
 		return err
 	}

--- a/integration-tests/bats/regression-tests.bats
+++ b/integration-tests/bats/regression-tests.bats
@@ -150,3 +150,16 @@ SQL
     [[ "$output" =~ "1" ]] || false
     [[ "${#lines[@]}" = "2" ]] || false
 }
+
+@test "regression-tests: some rows are not found by WHERE filter" {
+    # caught by fuzzer
+    dolt sql <<"SQL"
+CREATE TABLE `grwzHfTFle` (`oyBEOq` TINYTEXT COLLATE utf8mb4_bin, `hrbo0L` BLOB, `stSIYd` SMALLINT, `qTiF9V` TINYBLOB, `10a9ox` DOUBLE, `T2p7cl` ENUM('lE','K4drH9','s4y2zIBiGwjL4Rc','J0saTK','wPxfdWEVqYaiGS','QrClJ8DJlSQ','BQ_J2QInKTd','3o8GpiOD','C6OzkhR2GCavFB4','KoW_P86ig8Lb','rmYEkq','7xEAI_zTH8tx','esL8ebM1nALu','yvaI1Q','OmMrF6HVewJC','s_vzApJccj0','95mHsEDfQwP28k','G_CWMFqLM5sUkh5','0vNld','St36B4u','bVCCAq0K2WA_S0','qLjfEKNzOOincWaJ','a9FswYo','OdjFO','yDPuq','BxTQ9Mi_9u4ZA2Q','fpCPGA','uVJnla5','F_RlXpYT03TKdIU6','ytFjALpsQywkTV'), `21sKwG` SMALLINT UNSIGNED, PRIMARY KEY (`oyBEOq`(60), `hrbo0L`(60), `stSIYd`, `qTiF9V`(60), `10a9ox`));
+INSERT INTO `grwzHfTFle` VALUES ('!JYs-wbJ$34K3g$Y 4 CVaSukaFAt-!onw!%fPZ^a=8','E2mE%FWZ$Dnqj!@1gdztO4R5t:JS9~YCqHO#+*TabR$Wxa*eEi7xwf8nwS572Nm^9!0I.X!%-gQlpzaozZpb~u#bqHF!r7wsY1W=SL7UyYhB8J1%8y:hRD+7~5LzMcIh-WO5HbviWjo0$2Fd2#5hg#==c+=MjuN-ZCt*@285e5N_K4vsps2eY9$uHH3LCrUrHIek8X$#WXtG^a%hpH2VDm PJx1StxK|cF4NI@PWH*1iC!M%w$:!C9-o~FFq6wQW%9xn661!_tm2oWu:b!aS#0G5YW0x-W2Q!XEP@f3CNY4xQ3IoO9|:4Hbc4iw$PnYT_%pL!byJ*=:.8e~p h Syn- SM aFjDm3d-8U#IiN3:jaB1%szEYPoGIsHAZ*Zd56vY7V#BoE%:FZ =-~YJ8_.5AcMDj.x@jm*9HMQ4_u9x6I5$h0PjLp2$+=Bf%Vj_i!*lM es.oHJ@72Ksjb1|:ntzcsm2n+y4EX+A43L|W4!Ukgt43W3!nDf2s-#JqHR%MUycA95tc.uR*xy07iX-03mk',-28878,'V6=Mhy%_PO-!D:8Lg#l6u|8.+=uwERz6F8gf44$dl6THpGp7|4F!#TveAY vR_h7WrWzJKw~f Q1pRXwMN9IfUd6LC:#cXH+@i.v_0P8h%4mVVLcfV!@!ua57','-0.809039007248521',12,25759);
+DELETE FROM `grwzHfTFle` WHERE `oyBEOq` = '!JYs-wbJ$34K3g$Y 4 CVaSukaFAt-!onw!%fPZ^a=8' AND `hrbo0L` = 'E2mE%FWZ$Dnqj!@1gdztO4R5t:JS9~YCqHO#+*TabR$Wxa*eEi7xwf8nwS572Nm^9!0I.X!%-gQlpzaozZpb~u#bqHF!r7wsY1W=SL7UyYhB8J1%8y:hRD+7~5LzMcIh-WO5HbviWjo0$2Fd2#5hg#==c+=MjuN-ZCt*@285e5N_K4vsps2eY9$uHH3LCrUrHIek8X$#WXtG^a%hpH2VDm PJx1StxK|cF4NI@PWH*1iC!M%w$:!C9-o~FFq6wQW%9xn661!_tm2oWu:b!aS#0G5YW0x-W2Q!XEP@f3CNY4xQ3IoO9|:4Hbc4iw$PnYT_%pL!byJ*=:.8e~p h Syn- SM aFjDm3d-8U#IiN3:jaB1%szEYPoGIsHAZ*Zd56vY7V#BoE%:FZ =-~YJ8_.5AcMDj.x@jm*9HMQ4_u9x6I5$h0PjLp2$+=Bf%Vj_i!*lM es.oHJ@72Ksjb1|:ntzcsm2n+y4EX+A43L|W4!Ukgt43W3!nDf2s-#JqHR%MUycA95tc.uR*xy07iX-03mk' AND `stSIYd` = -28878 AND `qTiF9V` = 'V6=Mhy%_PO-!D:8Lg#l6u|8.+=uwERz6F8gf44$dl6THpGp7|4F!#TveAY vR_h7WrWzJKw~f Q1pRXwMN9IfUd6LC:#cXH+@i.v_0P8h%4mVVLcfV!@!ua57' AND `10a9ox` = '-0.809039007248521';
+SQL
+    run dolt sql -q 'SELECT COUNT(*) FROM grwzHfTFle WHERE oyBEOq LIKE "!JYs%"' -r=csv
+    [ "$status" -eq "0" ]
+    [[ "$output" =~ "0" ]] || false
+    [[ "${#lines[@]}" = "2" ]] || false
+}


### PR DESCRIPTION
Previously we were using memory value stores in some places, and everything seemed to be working, but I think our garbage collection changes exposed some inconsistencies that were causing bugs. This PR threads values stores to where they need to be and removes the majority of the places where we were using memory value stores.

This also solves a multitude of fuzzer issues, including the `corrupted database` error:
https://github.com/dolthub/fuzzer/issues/337
And also the cause of some rows not being found and silently causing some operations to no-op (bats test included):
https://github.com/dolthub/fuzzer/issues/597