### PR TITLE
Fetch refactor

### DIFF
--- a/go/cmd/dolt/commands/fetch.go
+++ b/go/cmd/dolt/commands/fetch.go
@@ -76,15 +76,16 @@ func (cmd FetchCmd) Exec(ctx context.Context, commandStr string, args []string, 
 	}
 	updateMode := ref.UpdateMode{Force: apr.Contains(cli.ForceFlag)}
 
-	var verr errhand.VerboseError
-
 	err = actions.FetchRefSpecs(ctx, dEnv.DbData(), refSpecs, r, updateMode, runProgFuncs, stopProgFuncs)
 	switch err {
 	case doltdb.ErrUpToDate:
+		return HandleVErrAndExitCode(nil, usage)
 	case actions.ErrCantFF:
-		verr = errhand.BuildDError("error: fetch failed, can't fast forward remote tracking ref").AddCause(err).Build()
-	default:
-		verr = errhand.VerboseErrorFromError(err)
+		verr := errhand.BuildDError("error: fetch failed, can't fast forward remote tracking ref").AddCause(err).Build()
+		return HandleVErrAndExitCode(verr, usage)
 	}
-	return HandleVErrAndExitCode(verr, usage)
+	if err != nil {
+		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+	}
+	return HandleVErrAndExitCode(nil, usage)
 }

--- a/go/cmd/dolt/commands/migrate.go
+++ b/go/cmd/dolt/commands/migrate.go
@@ -258,7 +258,7 @@ func fetchMigratedRemoteBranches(ctx context.Context, dEnv *env.DoltEnv, apr *ar
 	r, refSpecs, err := env.NewFetchOpts(apr.Args(), dEnv.RepoStateReader())
 
 	if err == nil {
-		err = fetchRefSpecs(ctx, ref.UpdateMode{Force: true}, dEnv, r, refSpecs)
+		err = actions.FetchRefSpecs(ctx, dEnv.DbData(), refSpecs, r, ref.UpdateMode{Force: true}, runProgFuncs, stopProgFuncs)
 	}
 
 	return err

--- a/go/libraries/doltcore/env/actions/remotes.go
+++ b/go/libraries/doltcore/env/actions/remotes.go
@@ -359,6 +359,7 @@ func FetchRemoteBranch(ctx context.Context, tempTablesDir string, rem env.Remote
 	return srcDBCommit, nil
 }
 
+// FetchRefSpecs is the common SQL and CLI entrypoint for fetching branches, tags, and heads from a remote.
 func FetchRefSpecs(ctx context.Context, dbData env.DbData, refSpecs []ref.RemoteRefSpec, remote env.Remote, mode ref.UpdateMode, progStarter ProgStarter, progStopper ProgStopper) error {
 	srcDB, err := remote.GetRemoteDBWithoutCaching(ctx, dbData.Ddb.ValueReadWriter().Format())
 	if err != nil {
@@ -385,6 +386,7 @@ func FetchRefSpecs(ctx context.Context, dbData env.DbData, refSpecs []ref.Remote
 
 				switch mode {
 				case ref.ForceUpdate:
+					// TODO: can't be used safely in a SQL context
 					err := dbData.Ddb.SetHeadToCommit(ctx, remoteTrackRef, srcDBCommit)
 					if err != nil {
 						return err
@@ -401,6 +403,7 @@ func FetchRefSpecs(ctx context.Context, dbData env.DbData, refSpecs []ref.Remote
 					switch err {
 					case doltdb.ErrUpToDate:
 					case doltdb.ErrIsAhead, nil:
+						// TODO: can't be used safely in a SQL context
 						err = dbData.Ddb.FastForward(ctx, remoteTrackRef, srcDBCommit)
 						if err != nil && !errors.Is(err, doltdb.ErrUpToDate) {
 							return fmt.Errorf("%w: %s", ErrCantFF, err.Error())

--- a/go/libraries/doltcore/env/remotes.go
+++ b/go/libraries/doltcore/env/remotes.go
@@ -241,20 +241,18 @@ func NewFetchOpts(args []string, rsr RepoStateReader) (Remote, []ref.RemoteRefSp
 		return NoRemote, nil, ErrNoRemote
 	}
 
-	remName := "origin"
-	remote, remoteOK := remotes[remName]
-
-	if len(args) != 0 {
-		if val, ok := remotes[args[0]]; ok {
-			remName = args[0]
-			remote = val
-			remoteOK = true
-			args = args[1:]
-		}
+	var remName string
+	if len(args) == 0 {
+		remName = "origin"
+	} else {
+		remName = args[0]
+		args = args[1:]
 	}
-	if !remoteOK {
+
+	remote, ok := remotes[remName]
+	if !ok {
 		msg := "does not appear to be a dolt database. could not read from the remote database. please make sure you have the correct access rights and the database exists"
-		return NoRemote, nil, fmt.Errorf("%w: %s %s", ErrUnknownRemote, remName, msg)
+		return NoRemote, nil, fmt.Errorf("%w; '%s' %s", ErrUnknownRemote, remName, msg)
 	}
 
 	var rs []ref.RemoteRefSpec

--- a/integration-tests/bats/localbs-remotes.bats
+++ b/integration-tests/bats/localbs-remotes.bats
@@ -98,7 +98,7 @@ SQL
     dolt fetch
 
     # fetch master into some garbage tracking branches
-    dolt fetch refs/heads/notmaster:refs/remotes/anything/master
+    dolt fetch origin refs/heads/notmaster:refs/remotes/anything/master
     dolt fetch remote2 refs/heads/master:refs/remotes/something/master
 
     run dolt branch -a

--- a/integration-tests/bats/remotes-file-system.bats
+++ b/integration-tests/bats/remotes-file-system.bats
@@ -110,7 +110,7 @@ SQL
     dolt fetch
 
     # fetch master into some garbage tracking branches
-    dolt fetch refs/heads/notmaster:refs/remotes/anything/master
+    dolt fetch origin refs/heads/notmaster:refs/remotes/anything/master
     dolt fetch remote2 refs/heads/master:refs/remotes/something/master
 
     run dolt branch -a

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -1085,7 +1085,7 @@ setup_ref_test() {
     run dolt fetch remotes/dasdas
     [ "$status" -eq 1 ]
     [[ ! "$output" =~ "panic" ]] || false
-    [[ "$output" =~ "invalid fetch spec: 'remotes/dasdas'" ]] || false
+    [[ "$output" =~ "'remotes/dasdas' does not appear to be a dolt database" ]] || false
 }
 
 @test "remotes: fetching added invalid remote correctly errors" {
@@ -1104,10 +1104,8 @@ setup_ref_test() {
    setup_ref_test
    cd ../../
    cd dolt-repo-clones/test-repo
-   # Add a dummy remove to allow for fetching
-   dolt remote add myremote dolthub/fake
 
-   run dolt fetch dadasdfasdfa
+   run dolt fetch origin dadasdfasdfa
    [ "$status" -eq 1 ]
-   [[ "$output" =~ "error: dadasdfasdfa does not appear to be a dolt database" ]] || false
+   [[ "$output" =~ "invalid ref spec: 'dadasdfasdfa'" ]] || false
 }

--- a/integration-tests/bats/sql-fetch.bats
+++ b/integration-tests/bats/sql-fetch.bats
@@ -217,7 +217,7 @@ teardown() {
 @test "sql-fetch: dolt_fetch unknown remote fails" {
     cd repo2
     dolt remote remove origin
-    run dolt sql -q "select dolt_fetch('unknown', 'master')"
+    run dolt sql -q "select dolt_fetch('unknown')"
     [ "$status" -eq 1 ]
     [[ "$output" =~ "unknown remote" ]] || false
 }

--- a/integration-tests/bats/sql-fetch.bats
+++ b/integration-tests/bats/sql-fetch.bats
@@ -222,6 +222,14 @@ teardown() {
     [[ "$output" =~ "unknown remote" ]] || false
 }
 
+@test "sql-fetch: dolt_fetch unknown remote with fetchspec fails" {
+    cd repo2
+    dolt remote remove origin
+    run dolt sql -q "select dolt_fetch('unknown', 'master')"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "unknown remote" ]] || false
+}
+
 @test "sql-fetch: dolt_fetch unknown ref fails" {
     cd repo2
     run dolt sql -q "select dolt_fetch('origin', 'unknown')"


### PR DESCRIPTION
- consolidate `getRefSpecs` functions from cli/env
- fetch argument switching matches git more closely -- specifying the remote is necessary, no default to origin