### PR TITLE
Add a warning for CREATE DATABASE

### DIFF
--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -128,6 +128,9 @@ func (p DoltDatabaseProvider) CreateDatabase(ctx *sql.Context, name string) erro
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	// Throw warning to users that this is a temporary database that does not persist after the session exits.
+	ctx.Warn(0, "CREATE DATABASE creates an inmemory database that does not persist after the server exits.")
+
 	mem, err := env.NewMemoryDbData(ctx, p.cfg)
 	if err != nil {
 		return err

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -47,6 +47,8 @@ var _ sql.FunctionProvider = DoltDatabaseProvider{}
 var _ sql.MutableDatabaseProvider = DoltDatabaseProvider{}
 var _ dsess.RevisionDatabaseProvider = DoltDatabaseProvider{}
 
+const createDbWC = 1105 // 1105 represents an unknown error.
+
 // NewDoltDatabaseProvider returns a provider for the databases given
 func NewDoltDatabaseProvider(config config.ReadableConfig, databases ...sql.Database) DoltDatabaseProvider {
 	dbs := make(map[string]sql.Database, len(databases))
@@ -129,7 +131,7 @@ func (p DoltDatabaseProvider) CreateDatabase(ctx *sql.Context, name string) erro
 	defer p.mu.Unlock()
 
 	// Throw warning to users that this is a temporary database that does not persist after the session exits.
-	ctx.Warn(0, "CREATE DATABASE creates an inmemory database that does not persist after the server exits.")
+	ctx.Warn(createDbWC, "CREATE DATABASE creates an inmemory database that does not persist after the server exits.")
 
 	mem, err := env.NewMemoryDbData(ctx, p.cfg)
 	if err != nil {

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -131,7 +131,7 @@ func (p DoltDatabaseProvider) CreateDatabase(ctx *sql.Context, name string) erro
 	defer p.mu.Unlock()
 
 	// Throw warning to users that this is a temporary database that does not persist after the session exits.
-	ctx.Warn(createDbWC, "CREATE DATABASE creates an inmemory database that does not persist after the server exits.")
+	ctx.Warn(createDbWC, "CREATE DATABASE creates an inmemory database that does not persist after the server exits. Dolt currently only supports a single disk backed database created by `dolt init`")
 
 	mem, err := env.NewMemoryDbData(ctx, p.cfg)
 	if err != nil {

--- a/integration-tests/bats/sql-create-database.bats
+++ b/integration-tests/bats/sql-create-database.bats
@@ -28,7 +28,6 @@ SQL
     [[ "$output" =~ "mydb" ]] || false
     # From COUNT
     [[ "$output" =~ "1" ]] || false
-    echo $output
     # Validate that CREATE DATABASE throws a warning
     [[ "$output" =~ "CREATE DATABASE creates an inmemory database that does not persist after the server exits." ]] || false
 

--- a/integration-tests/bats/sql-create-database.bats
+++ b/integration-tests/bats/sql-create-database.bats
@@ -29,7 +29,7 @@ SQL
     # From COUNT
     [[ "$output" =~ "1" ]] || false
     # Validate that CREATE DATABASE throws a warning
-    [[ "$output" =~ "CREATE DATABASE creates an inmemory database that does not persist after the server exits." ]] || false
+    [[ "$output" =~ 'CREATE DATABASE creates an inmemory database that does not persist after the server exits. Dolt currently only supports a single disk backed database created by `dolt init`' ]] || false
 
     run dolt sql -q "SHOW DATABASES"
     [[ ! "$output" =~ "mydb" ]] || false
@@ -62,7 +62,7 @@ DROP DATABASE mydb;
 USE mydb;
 SQL
     # Validate that CREATE DATABASE throws a warning
-    [[ "$output" =~ "CREATE DATABASE creates an inmemory database that does not persist after the server exits." ]] || false
+    [[ "$output" =~ 'CREATE DATABASE creates an inmemory database that does not persist after the server exits. Dolt currently only supports a single disk backed database created by `dolt init`' ]] || false
 
     [ "$status" -eq 1 ]
     [[ "$output" =~ "database not found: mydb" ]] || false

--- a/integration-tests/bats/sql-create-database.bats
+++ b/integration-tests/bats/sql-create-database.bats
@@ -12,6 +12,7 @@ teardown() {
 @test "sql-create-database: create new database" {
     run dolt sql << SQL
 CREATE DATABASE mydb;
+SHOW WARNINGS;
 SHOW DATABASES;
 USE mydb;
 CREATE TABLE test (
@@ -27,6 +28,9 @@ SQL
     [[ "$output" =~ "mydb" ]] || false
     # From COUNT
     [[ "$output" =~ "1" ]] || false
+    echo $output
+    # Validate that CREATE DATABASE throws a warning
+    [[ "$output" =~ "CREATE DATABASE creates an inmemory database that does not persist after the server exits." ]] || false
 
     run dolt sql -q "SHOW DATABASES"
     [[ ! "$output" =~ "mydb" ]] || false
@@ -40,7 +44,6 @@ SQL
 
     [ "$status" -eq 1 ]
     [[ "$output" =~ "can't create database mydb; database exists" ]] || false
-
 }
 
 @test "sql-create-database: create database IF NOT EXISTS on database that already exists doesn't throw an error" {
@@ -55,9 +58,13 @@ SQL
 @test "sql-create-database: create and drop new database" {
     run dolt sql << SQL
 CREATE DATABASE mydb;
+SHOW WARNINGS;
 DROP DATABASE mydb;
 USE mydb;
 SQL
+    # Validate that CREATE DATABASE throws a warning
+    [[ "$output" =~ "CREATE DATABASE creates an inmemory database that does not persist after the server exits." ]] || false
+
     [ "$status" -eq 1 ]
     [[ "$output" =~ "database not found: mydb" ]] || false
 }
@@ -140,7 +147,7 @@ SQL
     [[ ! "$output" =~ "mydb" ]] || false
 }
 
-@test "sql-create-database: use for non existing datbase throws an error" {
+@test "sql-create-database: use for non existing database throws an error" {
     run dolt sql -q "USE test"
     [ "$status" -eq 1 ]
     [[ "$output" =~ "database not found: test" ]] || false


### PR DESCRIPTION
Warning is due to CREATE DATABASE not persisting after the server exits