### PR TITLE
Unblock Keyless SQL Diffs and Minimize SQL Diffs

### DIFF
--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -390,18 +390,6 @@ func diffUserTables(ctx context.Context, fromRoot, toRoot *doltdb.RootValue, dAr
 		return strings.Compare(tableDeltas[i].ToName, tableDeltas[j].ToName) < 0
 	})
 	for _, td := range tableDeltas {
-		if dArgs.diffOutput == SQLDiffOutput {
-			ok, err := td.IsKeyless(ctx)
-			if err != nil {
-				return errhand.VerboseErrorFromError(err)
-			}
-			if ok {
-				// todo: implement keyless SQL diff
-				// todo: should there be a waring here?
-				continue
-			}
-		}
-
 		if !dArgs.tableSet.Contains(td.FromName) && !dArgs.tableSet.Contains(td.ToName) {
 			continue
 		}

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -397,6 +397,7 @@ func diffUserTables(ctx context.Context, fromRoot, toRoot *doltdb.RootValue, dAr
 			}
 			if ok {
 				// todo: implement keyless SQL diff
+				// todo: should there be a waring here?
 				continue
 			}
 		}

--- a/go/libraries/doltcore/diff/sql_diff.go
+++ b/go/libraries/doltcore/diff/sql_diff.go
@@ -101,7 +101,6 @@ func (sds *SQLDiffSink) ProcRowWithProps(r row.Row, props pipeline.ReadableMap) 
 					colDiffsInter[k] = v
 				}
 
-				// TODO: minimize update statement to modified rows
 				stmt, err := sqlfmt.RowAsUpdateStmt(r, sds.tableName, sds.sch, colDiffsInter)
 
 				if err != nil {

--- a/go/libraries/doltcore/diff/sql_diff.go
+++ b/go/libraries/doltcore/diff/sql_diff.go
@@ -16,13 +16,14 @@ package diff
 
 import (
 	"errors"
+	"io"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlfmt"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/pipeline"
 	"github.com/dolthub/dolt/go/libraries/utils/iohelp"
 	"github.com/dolthub/dolt/go/store/types"
-	"io"
 )
 
 type SQLDiffSink struct {

--- a/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
@@ -120,7 +120,7 @@ func RowAsDeleteStmt(r row.Row, tableName string, tableSch schema.Schema) (strin
 	return b.String(), nil
 }
 
-func RowAsUpdateStmt(r row.Row, tableName string, tableSch schema.Schema) (string, error) {
+func RowAsUpdateStmt(r row.Row, tableName string, tableSch schema.Schema, colDiffs map[string]interface{}) (string, error) {
 	var b strings.Builder
 	b.WriteString("UPDATE ")
 	b.WriteString(QuoteIdentifier(tableName))
@@ -130,7 +130,8 @@ func RowAsUpdateStmt(r row.Row, tableName string, tableSch schema.Schema) (strin
 	seenOne := false
 	_, err := r.IterSchema(tableSch, func(tag uint64, val types.Value) (stop bool, err error) {
 		col, _ := tableSch.GetAllCols().GetByTag(tag)
-		if !col.IsPartOfPK {
+		_, exists := colDiffs[col.Name]
+		if !col.IsPartOfPK && exists {
 			if seenOne {
 				b.WriteRune(',')
 			}

--- a/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
+	"github.com/dolthub/dolt/go/libraries/utils/set"
 	"github.com/dolthub/dolt/go/store/types"
 )
 
@@ -121,7 +122,7 @@ func RowAsDeleteStmt(r row.Row, tableName string, tableSch schema.Schema) (strin
 	return b.String(), nil
 }
 
-func RowAsUpdateStmt(r row.Row, tableName string, tableSch schema.Schema, colDiffs map[string]interface{}) (string, error) {
+func RowAsUpdateStmt(r row.Row, tableName string, tableSch schema.Schema, colDiffs *set.StrSet) (string, error) {
 	var b strings.Builder
 	b.WriteString("UPDATE ")
 	b.WriteString(QuoteIdentifier(tableName))
@@ -131,7 +132,7 @@ func RowAsUpdateStmt(r row.Row, tableName string, tableSch schema.Schema, colDif
 	seenOne := false
 	_, err := r.IterSchema(tableSch, func(tag uint64, val types.Value) (stop bool, err error) {
 		col, _ := tableSch.GetAllCols().GetByTag(tag)
-		_, exists := colDiffs[col.Name]
+		exists := colDiffs.Contains(col.Name)
 		if !col.IsPartOfPK && exists {
 			if seenOne {
 				b.WriteRune(',')

--- a/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
@@ -94,9 +94,10 @@ func RowAsDeleteStmt(r row.Row, tableName string, tableSch schema.Schema) (strin
 
 	b.WriteString(" WHERE (")
 	seenOne := false
+	isKeyless := tableSch.GetPKCols().Size() == 0
 	_, err := r.IterSchema(tableSch, func(tag uint64, val types.Value) (stop bool, err error) {
 		col, _ := tableSch.GetAllCols().GetByTag(tag)
-		if col.IsPartOfPK {
+		if col.IsPartOfPK || isKeyless {
 			if seenOne {
 				b.WriteString(" AND ")
 			}

--- a/go/libraries/doltcore/sqle/sqlfmt/row_fmt_test.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/row_fmt_test.go
@@ -162,7 +162,7 @@ func TestRowAsUpdateStmt(t *testing.T) {
 	id := uuid.MustParse("00000000-0000-0000-0000-000000000000")
 	tableName := "people"
 
-	createColDiffs := func (cols []string) map[string]interface{} {
+	createColDiffs := func(cols []string) map[string]interface{} {
 		ret := make(map[string]interface{})
 		for _, v := range cols {
 			ret[v] = true
@@ -177,7 +177,7 @@ func TestRowAsUpdateStmt(t *testing.T) {
 			row:            dtestutils.NewTypedRow(id, "some guy", 100, false, strPointer("normie")),
 			sch:            dtestutils.TypedSchema,
 			expectedOutput: "UPDATE `people` SET `name`='some guy',`age`=100,`is_married`=FALSE,`title`='normie' WHERE (`id`='00000000-0000-0000-0000-000000000000');",
-			collDiff:        createColDiffs([]string{"name", "age", "is_married", "title"}),
+			collDiff:       createColDiffs([]string{"name", "age", "is_married", "title"}),
 		},
 		{
 			name:           "embedded quotes",
@@ -194,7 +194,7 @@ func TestRowAsUpdateStmt(t *testing.T) {
 			collDiff:       createColDiffs([]string{"name", "age", "is_married", "title"}),
 		},
 		{
-			name: 			"partial update",
+			name:           "partial update",
 			row:            dtestutils.NewTypedRow(id, "some guy", 100, false, nil),
 			sch:            dtestutils.TypedSchema,
 			expectedOutput: "UPDATE `people` SET `name`='some guy' WHERE (`id`='00000000-0000-0000-0000-000000000000');",

--- a/go/libraries/doltcore/sqle/sqlfmt/schema_fmt.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/schema_fmt.go
@@ -188,6 +188,33 @@ func AlterTableRenameColStmt(tableName string, oldColName string, newColName str
 	return b.String()
 }
 
+func AlterTableDropPks(tableName string) string {
+	var b strings.Builder
+	b.WriteString("ALTER TABLE ")
+	b.WriteString(QuoteIdentifier(tableName))
+	b.WriteString(" DROP PRIMARY KEY")
+	b.WriteRune(';')
+	return b.String()
+}
+
+func AlterTableAddPrimaryKeys(tableName string, pks *schema.ColCollection) string {
+	var b strings.Builder
+	b.WriteString("ALTER TABLE ")
+	b.WriteString(QuoteIdentifier(tableName))
+	b.WriteString(" ADD PRIMARY KEY (")
+
+	for i := 0; i < pks.Size(); i++ {
+		if i == 0 {
+			b.WriteString(pks.GetAtIndex(i).Name)
+		} else {
+			b.WriteString("," + pks.GetAtIndex(i).Name)
+		}
+	}
+	b.WriteRune(')')
+	b.WriteRune(';')
+	return b.String()
+}
+
 func RenameTableStmt(fromName string, toName string) string {
 	var b strings.Builder
 	b.WriteString("RENAME TABLE ")

--- a/integration-tests/bats/diff.bats
+++ b/integration-tests/bats/diff.bats
@@ -535,4 +535,25 @@ SQL
     [ $status -eq 0 ]
     [ "${lines[0]}" = 'DELETE FROM `t` WHERE (`pk`=1 AND `val`=2);' ]
     [ "${lines[1]}" = 'DELETE FROM `t` WHERE (`pk`=1 AND `val`=2);' ]
+
+    dolt commit -am "cm5"
+
+    dolt sql -q "alter table t add primary key (pk)"
+    run dolt diff -r sql
+    [ $status -eq 0 ]
+    [ "${lines[0]}" = 'ALTER TABLE `t` DROP PRIMARY KEY;' ]
+    [ "${lines[1]}" = 'ALTER TABLE `t` ADD PRIMARY KEY (pk);' ]
+    [ "${lines[2]}" = 'warning: skipping data diff due to primary key set change' ]
+
+    dolt commit -am "cm6"
+
+    dolt sql -q "alter table t add column pk2 int"
+    dolt sql -q "alter table t drop primary key"
+    dolt sql -q "alter table t add primary key (pk, val)"
+    run dolt diff -r sql
+    [ $status -eq 0 ]
+    [ "${lines[0]}" = 'ALTER TABLE `t` ADD `pk2` INT;' ]
+    [ "${lines[1]}" = 'ALTER TABLE `t` DROP PRIMARY KEY;' ]
+    [ "${lines[2]}" = 'ALTER TABLE `t` ADD PRIMARY KEY (pk,val);' ]
+    [ "${lines[3]}" = 'warning: skipping data diff due to primary key set change' ]
 }

--- a/integration-tests/bats/diff.bats
+++ b/integration-tests/bats/diff.bats
@@ -500,6 +500,28 @@ SQL
     run dolt diff -r sql
     [ $status -eq 0 ]
     [[ "$output" = 'UPDATE `t` SET `val1`=2 WHERE (`pk`=1);' ]] || false
+
+    dolt commit -am "cm2"
+
+    dolt sql -q "UPDATE t SET val1=3, val2=4 where pk = 1"
+    run dolt diff -r sql
+    [ $status -eq 0 ]
+    [[ "$output" = 'UPDATE `t` SET `val1`=3,`val2`=4 WHERE (`pk`=1);' ]] || false
+
+    dolt commit -am "cm3"
+
+    dolt sql -q "UPDATE t SET val1=3 where (pk=1);"
+    run dolt diff -r sql
+    [ $status -eq 0 ]
+    [[ "$output" = '' ]] || false
+
+    dolt sql -q "alter table t add val3 int"
+    dolt commit -am "cm4"
+
+    dolt sql -q "update t set val1=30,val3=4 where pk=1"
+    run dolt diff -r sql
+    [ $status -eq 0 ]
+    [[ "$output" = 'UPDATE `t` SET `val1`=30,`val3`=4 WHERE (`pk`=1);' ]] || false
 }
 
 @test "diff: run through some keyless sql diffs" {

--- a/integration-tests/bats/diff.bats
+++ b/integration-tests/bats/diff.bats
@@ -489,3 +489,15 @@ SQL
     [[ "$output" =~ "cv1" ]] || false
     [ $status -eq 0 ]
 }
+
+@test "diff: sql update queries only show changed columns" {
+    dolt sql -q "create table t(pk int primary key, val1 int, val2 int)"
+    dolt sql -q "INSERT INTO t VALUES (1, 1, 1)"
+
+    dolt commit -am "cm1"
+
+    dolt sql -q "UPDATE t SET val1=2 where pk=1"
+    run dolt diff -r sql
+    [ $status -eq 0 ]
+    [[ "$output" = 'UPDATE `t` SET `val1`=2 WHERE (`pk`=1);' ]] || false
+}


### PR DESCRIPTION
Allows for dolt diff -sql to be used for keyless tables and add alter pk support for sql diffs. 