### PR TITLE
Skipped bats for --multi-db-dir bug

### DIFF
--- a/integration-tests/bats/sql-multi-db.bats
+++ b/integration-tests/bats/sql-multi-db.bats
@@ -83,3 +83,15 @@ seed_repos_with_tables_with_use_statements() {
     [ "$status" -eq 0 ]
     [[ "$output" =~ "$EXPECTED" ]] || false
 }
+
+@test "sql-multi-db: join on multiple databases with same name" {
+    seed_repos_with_tables_with_use_statements
+    dolt sql --multi-db-dir ./ -b -q "
+    	    USE repo1;
+            CREATE TABLE r2_t1 (pk BIGINT, c1 BIGINT, PRIMARY KEY(pk));
+            INSERT INTO r2_t1 (pk, c1) values (2,200),(3,300),(4,400);"
+    run dolt sql --multi-db-dir ./ -q "select * from repo1.r2_t1 join repo2.r2_t1 on repo1.r2_t1.pk=repo2.r2_t1.pk"
+    skip "Fails on Not unique table/alias"
+    [ "$status" -eq 0 ]
+    [[ ! $output =~ "Not unique table/alias" ]] || false
+}


### PR DESCRIPTION
Added skipped bats tests for a bug in multi db mode when joining two tables of the same name in two different databases