### PR TITLE
go/libraries/doltcore/table/editor: Thread some TupleFactories to places that allocate tuples.

### DIFF
--- a/go/libraries/doltcore/schema/alterschema/addpk.go
+++ b/go/libraries/doltcore/schema/alterschema/addpk.go
@@ -124,7 +124,9 @@ func insertKeyedData(ctx context.Context, nbf *types.NomsBinFormat, oldTable *do
 	}
 
 	// Create the table editor and insert all of the new data into it
-	tableEditor, err := editor.NewTableEditor(ctx, newTable, newSchema, name, opts)
+	tf := types.NewTupleFactory(64)
+	tf.Reset(nbf)
+	tableEditor, err := editor.NewTableEditor(ctx, newTable, newSchema, name, opts, tf)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/sqlutil/sql_row.go
+++ b/go/libraries/doltcore/sqle/sqlutil/sql_row.go
@@ -94,7 +94,7 @@ func SqlRowToDoltRow(ctx context.Context, vrw types.ValueReadWriter, r sql.Row, 
 
 // DoltKeyValueAndMappingFromSqlRow converts a sql.Row to key and value tuples and keeps a mapping from tag to value that
 // can be used to speed up index key generation for foreign key checks.
-func DoltKeyValueAndMappingFromSqlRow(ctx context.Context, vrw types.ValueReadWriter, r sql.Row, doltSchema schema.Schema) (types.Tuple, types.Tuple, map[uint64]types.Value, error) {
+func DoltKeyValueAndMappingFromSqlRow(ctx context.Context, vrw types.ValueReadWriter, r sql.Row, doltSchema schema.Schema, tf *types.TupleFactory) (types.Tuple, types.Tuple, map[uint64]types.Value, error) {
 	allCols := doltSchema.GetAllCols()
 	nonPKCols := doltSchema.GetNonPKCols()
 
@@ -155,14 +155,13 @@ func DoltKeyValueAndMappingFromSqlRow(ctx context.Context, vrw types.ValueReadWr
 
 	nonPKVals = nonPKVals[:nonPKIdx]
 
-	nbf := vrw.Format()
-	keyTuple, err := types.NewTuple(nbf, pkVals...)
+	keyTuple, err := tf.Create(pkVals...)
 
 	if err != nil {
 		return types.Tuple{}, types.Tuple{}, nil, err
 	}
 
-	valTuple, err := types.NewTuple(nbf, nonPKVals...)
+	valTuple, err := tf.Create(nonPKVals...)
 
 	if err != nil {
 		return types.Tuple{}, types.Tuple{}, nil, err
@@ -173,7 +172,7 @@ func DoltKeyValueAndMappingFromSqlRow(ctx context.Context, vrw types.ValueReadWr
 
 // DoltKeyValueAndMappingFromSqlRow converts a sql.Row to key tuple and keeps a mapping from tag to value that
 // can be used to speed up index key generation for foreign key checks.
-func DoltKeyAndMappingFromSqlRow(ctx context.Context, vrw types.ValueReadWriter, r sql.Row, doltSchema schema.Schema) (types.Tuple, map[uint64]types.Value, error) {
+func DoltKeyAndMappingFromSqlRow(ctx context.Context, vrw types.ValueReadWriter, r sql.Row, doltSchema schema.Schema, tf *types.TupleFactory) (types.Tuple, map[uint64]types.Value, error) {
 	allCols := doltSchema.GetAllCols()
 	pkCols := doltSchema.GetPKCols()
 
@@ -219,8 +218,7 @@ func DoltKeyAndMappingFromSqlRow(ctx context.Context, vrw types.ValueReadWriter,
 		return types.Tuple{}, nil, errors.New("not all pk columns have a value")
 	}
 
-	nbf := vrw.Format()
-	keyTuple, err := types.NewTuple(nbf, pkVals...)
+	keyTuple, err := tf.Create(pkVals...)
 
 	if err != nil {
 		return types.Tuple{}, nil, err

--- a/go/libraries/doltcore/sqle/table_editor.go
+++ b/go/libraries/doltcore/sqle/table_editor.go
@@ -105,7 +105,7 @@ func (te *sqlTableEditor) duplicateKeyErrFunc(keyString, indexName string, k, v 
 
 func (te *sqlTableEditor) Insert(ctx *sql.Context, sqlRow sql.Row) error {
 	if !schema.IsKeyless(te.sch) {
-		k, v, tagToVal, err := sqlutil.DoltKeyValueAndMappingFromSqlRow(ctx, te.vrw, sqlRow, te.sch)
+		k, v, tagToVal, err := sqlutil.DoltKeyValueAndMappingFromSqlRow(ctx, te.vrw, sqlRow, te.sch, te.sess.TupleFactory())
 		if err != nil {
 			return err
 		}
@@ -134,7 +134,7 @@ func (te *sqlTableEditor) Insert(ctx *sql.Context, sqlRow sql.Row) error {
 
 func (te *sqlTableEditor) Delete(ctx *sql.Context, sqlRow sql.Row) error {
 	if !schema.IsKeyless(te.sch) {
-		k, tagToVal, err := sqlutil.DoltKeyAndMappingFromSqlRow(ctx, te.vrw, sqlRow, te.sch)
+		k, tagToVal, err := sqlutil.DoltKeyAndMappingFromSqlRow(ctx, te.vrw, sqlRow, te.sch, te.sess.TupleFactory())
 		if err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/table/editor/keyless_table_editor_test.go
+++ b/go/libraries/doltcore/table/editor/keyless_table_editor_test.go
@@ -50,7 +50,7 @@ func TestKeylessTableEditorConcurrency(t *testing.T) {
 
 	opts := TestEditorOptions(db)
 	for i := 0; i < tableEditorConcurrencyIterations; i++ {
-		tableEditor, err := newKeylessTableEditor(context.Background(), table, tableSch, tableName, opts)
+		tableEditor, err := newKeylessTableEditor(context.Background(), table, tableSch, tableName, opts, types.NewTupleFactory(64))
 		require.NoError(t, err)
 		wg := &sync.WaitGroup{}
 
@@ -159,7 +159,7 @@ func TestKeylessTableEditorConcurrencyPostInsert(t *testing.T) {
 	require.NoError(t, err)
 
 	opts := TestEditorOptions(db)
-	tableEditor, err := newKeylessTableEditor(context.Background(), table, tableSch, tableName, opts)
+	tableEditor, err := newKeylessTableEditor(context.Background(), table, tableSch, tableName, opts, types.NewTupleFactory(64))
 	require.NoError(t, err)
 	for i := 0; i < tableEditorConcurrencyFinalCount*2; i++ {
 		dRow, err := row.New(format, tableSch, row.TaggedValues{
@@ -174,7 +174,7 @@ func TestKeylessTableEditorConcurrencyPostInsert(t *testing.T) {
 	require.NoError(t, err)
 
 	for i := 0; i < tableEditorConcurrencyIterations; i++ {
-		tableEditor, err := newKeylessTableEditor(context.Background(), table, tableSch, tableName, opts)
+		tableEditor, err := newKeylessTableEditor(context.Background(), table, tableSch, tableName, opts, types.NewTupleFactory(64))
 		require.NoError(t, err)
 		wg := &sync.WaitGroup{}
 
@@ -268,7 +268,7 @@ func TestKeylessTableEditorWriteAfterFlush(t *testing.T) {
 	require.NoError(t, err)
 
 	opts := TestEditorOptions(db)
-	tableEditor, err := newKeylessTableEditor(context.Background(), table, tableSch, tableName, opts)
+	tableEditor, err := newKeylessTableEditor(context.Background(), table, tableSch, tableName, opts, types.NewTupleFactory(64))
 	require.NoError(t, err)
 
 	for i := 0; i < 20; i++ {
@@ -351,7 +351,7 @@ func TestKeylessTableEditorDuplicateKeyHandling(t *testing.T) {
 	require.NoError(t, err)
 
 	opts := TestEditorOptions(db)
-	tableEditor, err := newKeylessTableEditor(context.Background(), table, tableSch, tableName, opts)
+	tableEditor, err := newKeylessTableEditor(context.Background(), table, tableSch, tableName, opts, types.NewTupleFactory(64))
 	require.NoError(t, err)
 
 	for i := 0; i < 3; i++ {
@@ -452,7 +452,7 @@ func TestKeylessTableEditorMultipleIndexErrorHandling(t *testing.T) {
 	require.NoError(t, err)
 	table, err = RebuildAllIndexes(ctx, table, opts)
 	require.NoError(t, err)
-	tableEditor, err := newKeylessTableEditor(ctx, table, tableSch, tableName, opts)
+	tableEditor, err := newKeylessTableEditor(ctx, table, tableSch, tableName, opts, types.NewTupleFactory(64))
 	require.NoError(t, err)
 
 	for i := 0; i < 3; i++ {
@@ -611,7 +611,7 @@ func TestKeylessTableEditorIndexCardinality(t *testing.T) {
 	require.NoError(t, err)
 	table, err = RebuildAllIndexes(ctx, table, opts)
 	require.NoError(t, err)
-	tableEditor, err := newKeylessTableEditor(ctx, table, tableSch, tableName, opts)
+	tableEditor, err := newKeylessTableEditor(ctx, table, tableSch, tableName, opts, types.NewTupleFactory(64))
 	require.NoError(t, err)
 
 	for i := 0; i < 3; i++ {

--- a/go/libraries/doltcore/table/editor/pk_table_editor_test.go
+++ b/go/libraries/doltcore/table/editor/pk_table_editor_test.go
@@ -60,7 +60,7 @@ func TestTableEditorConcurrency(t *testing.T) {
 	require.NoError(t, err)
 
 	for i := 0; i < tableEditorConcurrencyIterations; i++ {
-		tableEditor, err := newPkTableEditor(context.Background(), table, tableSch, tableName, opts)
+		tableEditor, err := newPkTableEditor(context.Background(), table, tableSch, tableName, opts, types.NewTupleFactory(64))
 		require.NoError(t, err)
 		wg := &sync.WaitGroup{}
 
@@ -156,7 +156,7 @@ func TestTableEditorConcurrencyPostInsert(t *testing.T) {
 	table, err := doltdb.NewTable(context.Background(), db, tableSchVal, emptyMap, emptyMap, nil)
 	require.NoError(t, err)
 
-	tableEditor, err := newPkTableEditor(context.Background(), table, tableSch, tableName, opts)
+	tableEditor, err := newPkTableEditor(context.Background(), table, tableSch, tableName, opts, types.NewTupleFactory(64))
 	require.NoError(t, err)
 	for i := 0; i < tableEditorConcurrencyFinalCount*2; i++ {
 		dRow, err := row.New(format, tableSch, row.TaggedValues{
@@ -171,7 +171,7 @@ func TestTableEditorConcurrencyPostInsert(t *testing.T) {
 	require.NoError(t, err)
 
 	for i := 0; i < tableEditorConcurrencyIterations; i++ {
-		tableEditor, err := newPkTableEditor(context.Background(), table, tableSch, tableName, opts)
+		tableEditor, err := newPkTableEditor(context.Background(), table, tableSch, tableName, opts, types.NewTupleFactory(64))
 		require.NoError(t, err)
 		wg := &sync.WaitGroup{}
 
@@ -251,7 +251,7 @@ func TestTableEditorWriteAfterFlush(t *testing.T) {
 	table, err := doltdb.NewTable(context.Background(), db, tableSchVal, emptyMap, emptyMap, nil)
 	require.NoError(t, err)
 
-	tableEditor, err := newPkTableEditor(context.Background(), table, tableSch, tableName, opts)
+	tableEditor, err := newPkTableEditor(context.Background(), table, tableSch, tableName, opts, types.NewTupleFactory(64))
 	require.NoError(t, err)
 
 	for i := 0; i < 20; i++ {
@@ -323,7 +323,7 @@ func TestTableEditorDuplicateKeyHandling(t *testing.T) {
 	table, err := doltdb.NewTable(context.Background(), db, tableSchVal, emptyMap, emptyMap, nil)
 	require.NoError(t, err)
 
-	tableEditor, err := newPkTableEditor(context.Background(), table, tableSch, tableName, opts)
+	tableEditor, err := newPkTableEditor(context.Background(), table, tableSch, tableName, opts, types.NewTupleFactory(64))
 	require.NoError(t, err)
 
 	for i := 0; i < 3; i++ {
@@ -413,7 +413,7 @@ func TestTableEditorMultipleIndexErrorHandling(t *testing.T) {
 	require.NoError(t, err)
 	table, err = RebuildAllIndexes(ctx, table, opts)
 	require.NoError(t, err)
-	tableEditor, err := newPkTableEditor(ctx, table, tableSch, tableName, opts)
+	tableEditor, err := newPkTableEditor(ctx, table, tableSch, tableName, opts, types.NewTupleFactory(64))
 	require.NoError(t, err)
 
 	for i := 0; i < 3; i++ {

--- a/go/store/types/tuple.go
+++ b/go/store/types/tuple.go
@@ -273,6 +273,7 @@ type TupleFactory struct {
 	nbf            *NomsBinFormat
 	biggestTuple   int
 	approxCapacity int
+	mu             sync.Mutex
 
 	pos    int
 	buffer []byte
@@ -305,6 +306,8 @@ func (tf *TupleFactory) newBuffer() {
 
 // Create creates a new Tuple using the TupleFactory
 func (tf *TupleFactory) Create(values ...Value) (Tuple, error) {
+	tf.mu.Lock()
+	defer tf.mu.Unlock()
 	remaining := len(tf.buffer) - tf.pos
 	// somewhat wasteful, but it's costly if there isn't enough room to store a tuple in the tf's buffer so make it a rare case
 	if remaining < tf.biggestTuple {


### PR DESCRIPTION
Makes types.TupleFactory thread-safe. Allocates a new TupleFactory when we construct a SessionTableEditor, and threads that TupleFactory through to individual table editors that can use it to do their editing. Makes that TupleFactory available through an accessor that sqlTableEditor uses for a few tuple manipulations.