### PR TITLE
replication with multi-db mode

### DIFF
--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -471,14 +471,14 @@ func newDatabase(name string, dEnv *env.DoltEnv) dsqle.Database {
 // newReplicaDatabase creates a new dsqle.ReadReplicaDatabase. If the doltdb.SkipReplicationErrorsKey global variable is set,
 // skip errors related to database construction only and return a partially functional dsqle.ReadReplicaDatabase
 // that will log warnings when attempting to perform replica commands.
-func newReplicaDatabase(ctx context.Context, name string, remoteName string, dEnv *env.DoltEnv, isMulti bool) (dsqle.ReadReplicaDatabase, error) {
+func newReplicaDatabase(ctx context.Context, name string, remoteName string, dEnv *env.DoltEnv) (dsqle.ReadReplicaDatabase, error) {
 	opts := editor.Options{
 		Deaf: dEnv.DbEaFactory(),
 	}
 
 	db := dsqle.NewDatabase(name, dEnv.DbData(), opts)
 
-	rrd, err := dsqle.NewReadReplicaDatabase(ctx, db, remoteName, dEnv, isMulti)
+	rrd, err := dsqle.NewReadReplicaDatabase(ctx, db, remoteName, dEnv)
 	if err != nil {
 		err = fmt.Errorf("%w from remote '%s'; %s", dsqle.ErrFailedToLoadReplicaDB, remoteName, err.Error())
 		if !dsqle.SkipReplicationWarnings() {
@@ -596,7 +596,7 @@ func CollectDBs(ctx context.Context, mrEnv *env.MultiRepoEnv) ([]dsqle.SqlDataba
 			if !ok {
 				return true, sql.ErrInvalidSystemVariableValue.New(remote)
 			}
-			db, err = newReplicaDatabase(ctx, name, remoteName, dEnv, mrEnv.Size() > 1)
+			db, err = newReplicaDatabase(ctx, name, remoteName, dEnv)
 			if err != nil {
 				return true, err
 			}

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -305,11 +305,12 @@ func runMain() int {
 
 	defer tempfiles.MovableTempFileProvider.Clean()
 
+	err = dsess.InitPersistedSystemVars(dEnv)
+	if err != nil {
+		cli.Printf("error: failed to load persisted global variables: %s\n", err.Error())
+	}
+
 	if dEnv.DoltDB != nil {
-		err := dsess.InitPersistedSystemVars(dEnv)
-		if err != nil {
-			cli.Printf("error: failed to load persisted global variables: %s\n", err.Error())
-		}
 		dEnv.DoltDB.SetCommitHookLogger(ctx, cli.OutStream)
 	}
 

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -310,10 +310,6 @@ func runMain() int {
 		cli.Printf("error: failed to load persisted global variables: %s\n", err.Error())
 	}
 
-	if dEnv.DoltDB != nil {
-		dEnv.DoltDB.SetCommitHookLogger(ctx, cli.OutStream)
-	}
-
 	start := time.Now()
 	res := doltCommand.Exec(ctx, "dolt", args, dEnv)
 

--- a/go/libraries/doltcore/env/multi_repo_env.go
+++ b/go/libraries/doltcore/env/multi_repo_env.go
@@ -59,6 +59,10 @@ func (mrEnv *MultiRepoEnv) Config() config.ReadWriteConfig {
 	return mrEnv.cfg
 }
 
+func (mrEnv *MultiRepoEnv) Size() int {
+	return len(mrEnv.envs)
+}
+
 // TODO: un export
 // AddEnv adds an environment to the MultiRepoEnv by name
 func (mrEnv *MultiRepoEnv) AddEnv(name string, dEnv *DoltEnv) {

--- a/go/libraries/doltcore/env/multi_repo_env.go
+++ b/go/libraries/doltcore/env/multi_repo_env.go
@@ -59,10 +59,6 @@ func (mrEnv *MultiRepoEnv) Config() config.ReadWriteConfig {
 	return mrEnv.cfg
 }
 
-func (mrEnv *MultiRepoEnv) Size() int {
-	return len(mrEnv.envs)
-}
-
 // TODO: un export
 // AddEnv adds an environment to the MultiRepoEnv by name
 func (mrEnv *MultiRepoEnv) AddEnv(name string, dEnv *DoltEnv) {

--- a/go/libraries/doltcore/sqle/read_replica_database.go
+++ b/go/libraries/doltcore/sqle/read_replica_database.go
@@ -55,8 +55,8 @@ var ErrCannotCreateReplicaRevisionDbForCommit = errors.New("cannot create replic
 
 var EmptyReadReplica = ReadReplicaDatabase{}
 
-func NewReadReplicaDatabase(ctx context.Context, db Database, remoteName string, rsr env.RepoStateReader, tmpDir string) (ReadReplicaDatabase, error) {
-	remotes, err := rsr.GetRemotes()
+func NewReadReplicaDatabase(ctx context.Context, db Database, remoteName string, dEnv *env.DoltEnv, isMultiDb bool) (ReadReplicaDatabase, error) {
+	remotes, err := dEnv.GetRemotes()
 	if err != nil {
 		return EmptyReadReplica, err
 	}
@@ -66,6 +66,11 @@ func NewReadReplicaDatabase(ctx context.Context, db Database, remoteName string,
 		return EmptyReadReplica, fmt.Errorf("%w: '%s'", env.ErrRemoteNotFound, remoteName)
 	}
 
+	// TODO: new remote if multidb, append database name to url
+	//if isMultiDb {
+	//	remote = env.NewRemote(remote.Name, path.Join(remote.Url, remote.Name), remote.Params, dEnv)
+	//}
+
 	srcDB, err := remote.GetRemoteDB(ctx, types.Format_Default)
 	if err != nil {
 		return EmptyReadReplica, err
@@ -74,9 +79,9 @@ func NewReadReplicaDatabase(ctx context.Context, db Database, remoteName string,
 	return ReadReplicaDatabase{
 		Database: db,
 		remote:   remote,
-		tmpDir:   tmpDir,
+		tmpDir:   dEnv.TempTableFilesDir(),
 		srcDB:    srcDB,
-		headRef:  rsr.CWBHeadRef(),
+		headRef:  dEnv.RepoStateReader().CWBHeadRef(),
 	}, nil
 }
 

--- a/go/libraries/doltcore/sqle/read_replica_database.go
+++ b/go/libraries/doltcore/sqle/read_replica_database.go
@@ -55,7 +55,7 @@ var ErrCannotCreateReplicaRevisionDbForCommit = errors.New("cannot create replic
 
 var EmptyReadReplica = ReadReplicaDatabase{}
 
-func NewReadReplicaDatabase(ctx context.Context, db Database, remoteName string, dEnv *env.DoltEnv, isMultiDb bool) (ReadReplicaDatabase, error) {
+func NewReadReplicaDatabase(ctx context.Context, db Database, remoteName string, dEnv *env.DoltEnv) (ReadReplicaDatabase, error) {
 	remotes, err := dEnv.GetRemotes()
 	if err != nil {
 		return EmptyReadReplica, err

--- a/go/libraries/doltcore/sqle/read_replica_database.go
+++ b/go/libraries/doltcore/sqle/read_replica_database.go
@@ -66,11 +66,6 @@ func NewReadReplicaDatabase(ctx context.Context, db Database, remoteName string,
 		return EmptyReadReplica, fmt.Errorf("%w: '%s'", env.ErrRemoteNotFound, remoteName)
 	}
 
-	// TODO: new remote if multidb, append database name to url
-	//if isMultiDb {
-	//	remote = env.NewRemote(remote.Name, path.Join(remote.Url, remote.Name), remote.Params, dEnv)
-	//}
-
 	srcDB, err := remote.GetRemoteDB(ctx, types.Format_Default)
 	if err != nil {
 		return EmptyReadReplica, err

--- a/integration-tests/bats/replication-multidb.bats
+++ b/integration-tests/bats/replication-multidb.bats
@@ -38,8 +38,10 @@ clone_helper() {
 push_helper() {
     TMPDIRS=$1
     for i in {1..3}; do
-        cd "${TMPDIRS}/dbs2/repo${i}"
+        cd "${TMPDIRS}/dbs1/repo${i}"
+        dolt push remote1 main
     done
+    cd $TMPDIRS
     #dolt push remote1 main
 }
 
@@ -49,83 +51,43 @@ teardown() {
     cd $BATS_TMPDIR
 }
 
-@test "replication-multidb: load global vars" {
-    dolt config --global --add sqlserver.global.dolt_replicate_to_remote remote1
-    cd dbs1/repo1
-    dolt config --local --add sqlserver.global.dolt_replicate_to_remote unknown
-    cd ../..
-    run dolt sql --multi-db-dir=dbs1 -b -q "select @@GLOBAL.dolt_replicate_to_remote"
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ "remote1" ]] || false
-}
+#@test "replication-multidb: load global vars" {
+    #dolt config --global --add sqlserver.global.dolt_replicate_to_remote remote1
+    #cd dbs1/repo1
+    #dolt config --local --add sqlserver.global.dolt_replicate_to_remote unknown
+    #cd ../..
+    #run dolt sql --multi-db-dir=dbs1 -b -q "select @@GLOBAL.dolt_replicate_to_remote"
+    #[ "$status" -eq 0 ]
+    #[[ "$output" =~ "remote1" ]] || false
+#}
 
-@test "replication-multidb: push on sqlengine commit" {
-    dolt config --global --add sqlserver.global.dolt_replicate_to_remote remote1
+#@test "replication-multidb: push on sqlengine commit" {
+    #dolt config --global --add sqlserver.global.dolt_replicate_to_remote remote1
+    #dolt sql --multi-db-dir=dbs1 -b -q "use repo1; create table t1 (a int primary key)"
+    #dolt sql --multi-db-dir=dbs1 -b -q "use repo1; select dolt_commit('-am', 'cm')"
+
+    #clone_helper $TMPDIRS
+    #run dolt sql --multi-db-dir=dbs2 -b -q "use repo1; show tables" -r csv
+    #[ "$status" -eq 0 ]
+    #[ "${#lines[@]}" -eq 4 ]
+    #[[ "$output" =~ "t1" ]] || false
+#}
+
+@test "replication-multidb: pull on read" {
+    push_helper $TMPDIRS
     dolt sql --multi-db-dir=dbs1 -b -q "use repo1; create table t1 (a int primary key)"
     dolt sql --multi-db-dir=dbs1 -b -q "use repo1; select dolt_commit('-am', 'cm')"
 
     clone_helper $TMPDIRS
+    push_helper $TMPDIRS
+
+    dolt config --global --add sqlserver.global.dolt_read_replica_remote remote1
+    dolt config --global --add sqlserver.global.dolt_replicate_heads main
     run dolt sql --multi-db-dir=dbs2 -b -q "use repo1; show tables" -r csv
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" -eq 4 ]
     [[ "$output" =~ "t1" ]] || false
 }
-
-#@test "replication-multidb: no push on cli commit" {
-
-    #cd repo1
-    #dolt config --local --add sqlserver.global.dolt_replicate_to_remote backup1
-    #dolt sql -q "create table t1 (a int primary key)"
-    #dolt commit -am "cm"
-
-    #cd ..
-    #run dolt clone file://./bac1 repo2
-    #[ "$status" -eq 1 ]
-#}
-
-#@test "replication-multidb: push on cli engine commit" {
-    #cd repo1
-    #dolt config --local --add sqlserver.global.dolt_replicate_to_remote backup1
-    #dolt sql -q "create table t1 (a int primary key)"
-    #dolt sql -q "select dolt_commit('-am', 'cm')"
-
-    #cd ..
-    #dolt clone file://./bac1 repo2
-    #cd repo2
-    #run dolt ls
-    #[ "$status" -eq 0 ]
-    #[ "${#lines[@]}" -eq 2 ]
-    #[[ "$output" =~ "t1" ]] || false
-#}
-
-#@test "replication-multidb: tag does not trigger replication-multidb" {
-    #cd repo1
-    #dolt config --local --add sqlserver.global.dolt_replicate_to_remote backup1
-    #dolt tag
-
-    #[ ! -d "../bac1/.dolt" ] || false
-#}
-
-#@test "replication-multidb: pull on read" {
-    #dolt clone file://./rem1 repo2
-    #cd repo2
-    #dolt sql -q "create table t1 (a int primary key)"
-    #dolt commit -am "new commit"
-    #dolt push origin main
-
-    #cd ../repo1
-    #run dolt sql -q "show tables" -r csv
-    #[ "$status" -eq 0 ]
-    #[ "${#lines[@]}" -eq 1 ]
-    #[[ ! "$output" =~ "t1" ]] || false
-
-    #dolt config --local --add sqlserver.global.dolt_read_replica_remote remote1
-    #dolt config --local --add sqlserver.global.dolt_replicate_heads main
-    #run dolt sql -q "show tables" -r csv
-    #[ "$status" -eq 0 ]
-    #[ "${#lines[@]}" -eq 2 ]
-    #[[ "$output" =~ "t1" ]] || false
-#}
 
 #@test "replication-multidb: push on branch table update" {
     #cd repo1
@@ -189,87 +151,6 @@ teardown() {
     #[[ "${lines[1]}" =~ "t2" ]] || false
 #}
 
-#@test "replication-multidb: pull with unknown head" {
-    #dolt clone file://./rem1 repo2
-    #cd repo2
-    #dolt branch new_feature
-    #dolt push origin new_feature
-
-    #cd ../repo1
-    #dolt config --local --add sqlserver.global.dolt_replicate_heads main,unknown
-    #dolt config --local --add sqlserver.global.dolt_read_replica_remote remote1
-    #run dolt sql -q "show tables"
-    #[ "$status" -eq 1 ]
-    #[[ ! "$output" =~ "panic" ]] || false
-    #[[ "$output" =~ "replication-multidb failed: unable to find 'unknown' on 'remote1'; branch not found" ]] || false
-#}
-
-#@test "replication-multidb: pull multiple heads, one invalid branch name" {
-    #dolt clone file://./rem1 repo2
-    #cd repo2
-    #dolt branch new_feature
-    #dolt push origin new_feature
-
-    #cd ../repo1
-    #dolt config --local --add sqlserver.global.dolt_replicate_heads main,unknown
-    #dolt config --local --add sqlserver.global.dolt_read_replica_remote remote1
-    #run dolt sql -q "show tables"
-    #[ "$status" -eq 1 ]
-    #[[ ! "$output" =~ "panic" ]] || false
-    #[[ "$output" =~ "unable to find 'unknown' on 'remote1'; branch not found" ]] || false
-#}
-
-#@test "replication-multidb: pull with no head configuration fails" {
-    #dolt clone file://./rem1 repo2
-    #cd repo2
-    #dolt branch new_feature
-    #dolt push origin new_feature
-
-    #cd ../repo1
-    #dolt config --local --add sqlserver.global.dolt_read_replica_remote remote1
-    #run dolt sql -q "show tables"
-    #[ "$status" -eq 1 ]
-    #[[ ! "$output" =~ "panic" ]] || false
-    #[[ "$output" =~ "invalid replicate heads setting: dolt_replicate_heads not set" ]] || false
-#}
-
-#@test "replication-multidb: replica pull conflicting head configurations" {
-    #dolt clone file://./rem1 repo2
-    #cd repo2
-    #dolt branch new_feature
-    #dolt push origin new_feature
-
-    #cd ../repo1
-    #dolt config --local --add sqlserver.global.dolt_replicate_heads main,unknown
-    #dolt config --local --add sqlserver.global.dolt_replicate_all_heads 1
-    #dolt config --local --add sqlserver.global.dolt_read_replica_remote remote1
-    #run dolt sql -q "show tables"
-    #[ "$status" -eq 1 ]
-    #[[ ! "$output" =~ "panic" ]] || false
-    #[[ "$output" =~ "invalid replicate heads setting; cannot set both" ]] || false
-#}
-
-
-#@test "replication-multidb: replica pull multiple heads quiet warnings" {
-    #dolt clone file://./rem1 repo2
-    #cd repo2
-    #dolt branch new_feature
-    #dolt push origin new_feature
-
-    #cd ../repo1
-    #dolt config --local --add sqlserver.global.dolt_skip_replication-multidb_errors 1
-    #dolt config --local --add sqlserver.global.dolt_replicate_heads unknown
-    #dolt config --local --add sqlserver.global.dolt_read_replica_remote remote1
-    #run dolt sql -q "show tables"
-    #[ "$status" -eq 0 ]
-    #[[ ! "$output" =~ "panic" ]] || false
-    #[[ "$output" =~ "replication-multidb failed: unable to find 'unknown' on 'remote1'; branch not found" ]] || false
-
-    #run dolt checkout new_feature
-    #[ "$status" -eq 1 ]
-    #[[ ! "$output" =~ "panic" ]] || false
-#}
-
 #@test "replication-multidb: pull all heads" {
     #dolt clone file://./rem1 repo2
     #cd repo2
@@ -288,131 +169,3 @@ teardown() {
     #[[ "${lines[1]}" =~ "t1" ]] || false
 #}
 
-#@test "replication-multidb: pull all heads pulls tags" {
-    #dolt clone file://./rem1 repo2
-    #cd repo2
-    #dolt checkout -b new_feature
-    #dolt tag v1
-    #dolt push origin new_feature
-    #dolt push origin v1
-
-    #cd ../repo1
-    #dolt config --local --add sqlserver.global.dolt_replicate_all_heads 1
-    #dolt config --local --add sqlserver.global.dolt_read_replica_remote remote1
-    #dolt sql -q "START TRANSACTION"
-    #run dolt tag
-    #[ "$status" -eq 0 ]
-    #[ "${#lines[@]}" -eq 1 ]
-    #[[ "$output" =~ "v1" ]] || false
-#}
-
-#@test "replication-multidb: push feature head" {
-    #cd repo1
-    #dolt config --local --add sqlserver.global.dolt_replicate_to_remote remote1
-    #dolt checkout -b new_feature
-    #dolt sql -q "create table t1 (a int primary key)"
-    #dolt sql -q "select dolt_commit('-am', 'cm')"
-
-    #cd ..
-    #dolt clone file://./rem1 repo2
-    #cd repo2
-    #dolt fetch origin new_feature
-#}
-
-#@test "replication-multidb: push to unknown remote error" {
-    #cd repo1
-    #dolt config --local --add sqlserver.global.dolt_replicate_to_remote unknown
-    #run dolt sql -q "create table t1 (a int primary key)"
-    #[ "$status" -eq 1 ]
-    #[[ ! "$output" =~ "panic" ]] || false
-    #[[ "$output" =~ "failure loading hook; remote not found: 'unknown'" ]] || false
-#}
-
-#@test "replication-multidb: quiet push to unknown remote warnings" {
-    #cd repo1
-    #dolt config --local --add sqlserver.global.dolt_skip_replication-multidb_errors 1
-    #dolt config --local --add sqlserver.global.dolt_replicate_to_remote unknown
-    #run dolt sql -q "create table t1 (a int primary key)"
-    #[ "$status" -eq 0 ]
-    #[[ ! "$output" =~ "remote not found" ]] || false
-
-    #run dolt sql -q "select dolt_commit('-am', 'cm')"
-    #[ "$status" -eq 0 ]
-    #[[ "$output" =~ "failure loading hook; remote not found: 'unknown'" ]] || false
-    #[[ "$output" =~ "dolt_commit('-am', 'cm')" ]] || false
-#}
-
-#@test "replication-multidb: bad source doesn't error during non-transactional commands" {
-    #cd repo1
-    #dolt config --local --add sqlserver.global.dolt_read_replica_remote unknown
-    #dolt config --local --add sqlserver.global.dolt_replicate_heads main
-
-    #run dolt status
-    #[ "$status" -eq 0 ]
-    #[[ ! "$output" =~ "remote not found: 'unknown'" ]] || false
-#}
-
-#@test "replication-multidb: pull bad remote errors" {
-    #cd repo1
-    #dolt config --local --add sqlserver.global.dolt_read_replica_remote unknown
-    #dolt config --local --add sqlserver.global.dolt_replicate_heads main
-
-    #run dolt sql -q "show tables"
-    #[ "$status" -eq 1 ]
-    #[[ ! "$output" =~ "panic" ]]
-    #[[ "$output" =~ "remote not found: 'unknown'" ]] || false
-#}
-
-#@test "replication-multidb: pull bad remote quiet warning" {
-    #cd repo1
-    #dolt config --local --add sqlserver.global.dolt_read_replica_remote unknown
-    #dolt config --local --add sqlserver.global.dolt_replicate_heads main
-    #dolt config --local --add sqlserver.global.dolt_skip_replication-multidb_errors 1
-
-    #run dolt sql -q "show tables"
-    #[ "$status" -eq 0 ]
-    #[[ ! "$output" =~ "panic" ]]
-    #[[ "$output" =~ "remote not found: 'unknown'" ]] || false
-    #[[ "$output" =~ "dolt_replication-multidb_remote value is misconfigured" ]] || false
-#}
-
-#@test "replication-multidb: use database syntax fetches missing branch" {
-    #dolt clone file://./rem1 repo2
-    #cd repo2
-    #dolt checkout -b feature-branch
-    #dolt sql -q "create table t1 (a int primary key)"
-    #dolt commit -am "new commit"
-    #dolt push origin feature-branch
-
-    #cd ../repo1
-    #dolt config --local --add sqlserver.global.dolt_read_replica_remote remote1
-    #dolt config --local --add sqlserver.global.dolt_replicate_heads main
-    #run dolt sql -b -q "USE \`repo1/feature-branch\`; show tables" -r csv
-    #[ "$status" -eq 0 ]
-    #[ "${#lines[@]}" -eq 4 ]
-    #[[ "${lines[1]}" =~ "Table" ]] || false
-    #[[ "${lines[2]}" =~ "t1" ]] || false
-#}
-
-#@test "replication-multidb: database autofetch doesn't change replication-multidb heads setting" {
-    #dolt clone file://./rem1 repo2
-    #cd repo2
-    #dolt branch feature-branch
-    #dolt push origin feature-branch
-
-    #cd ../repo1
-    #dolt config --local --add sqlserver.global.dolt_read_replica_remote remote1
-    #dolt config --local --add sqlserver.global.dolt_replicate_heads main
-    #run dolt sql -q "use \`repo1/feature-branch\`"
-
-    #cd ../repo2
-    #dolt checkout feature-branch
-    #dolt sql -q "create table t1 (a int primary key)"
-    #dolt commit -am "new commit"
-    #dolt push origin feature-branch
-
-    #cd ../repo1
-    #dolt sql -b -q "show tables" -r csv
-    #[ "$status" -eq 0 ]
-    #[[ ! "output" =~ "t1" ]] || false
-#}

--- a/integration-tests/bats/replication-multidb.bats
+++ b/integration-tests/bats/replication-multidb.bats
@@ -1,0 +1,418 @@
+#!/usr/bin/env bats
+load $BATS_TEST_DIRNAME/helper/common.bash
+
+setup() {
+    setup_common
+    TMPDIRS=$(pwd)/tmpdirs
+
+    init_helper $TMPDIRS
+    cd $TMPDIRS
+}
+
+init_helper() {
+    TMPDIRS=$1
+    mkdir -p "${TMPDIRS}/dbs1"
+    for i in {1..3}; do
+        mkdir "${TMPDIRS}/dbs1/repo${i}"
+        cd "${TMPDIRS}/dbs1/repo${i}"
+        dolt init
+        mkdir -p "${TMPDIRS}/rem1/repo${i}"
+        dolt remote add remote1 "file://../../rem1/repo${i}"
+    done
+}
+
+clone_helper() {
+    TMPDIRS=$1
+    mkdir -p "${TMPDIRS}/dbs2"
+    for i in {1..3}; do
+        cd $TMPDIRS
+        if [ -f "rem1/repo${i}/manifest" ]; then
+            dolt clone "file://./rem1/repo${i}" "dbs2/repo${i}"
+            cd "dbs2/repo${i}"
+            dolt remote add remote1 "file://../../rem1/repo${i}"
+        fi
+    done
+    cd $TMPDIRS
+}
+
+push_helper() {
+    TMPDIRS=$1
+    for i in {1..3}; do
+        cd "${TMPDIRS}/dbs2/repo${i}"
+    done
+    #dolt push remote1 main
+}
+
+teardown() {
+    teardown_common
+    rm -rf $TMPDIRS
+    cd $BATS_TMPDIR
+}
+
+@test "replication-multidb: load global vars" {
+    dolt config --global --add sqlserver.global.dolt_replicate_to_remote remote1
+    cd dbs1/repo1
+    dolt config --local --add sqlserver.global.dolt_replicate_to_remote unknown
+    cd ../..
+    run dolt sql --multi-db-dir=dbs1 -b -q "select @@GLOBAL.dolt_replicate_to_remote"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "remote1" ]] || false
+}
+
+@test "replication-multidb: push on sqlengine commit" {
+    dolt config --global --add sqlserver.global.dolt_replicate_to_remote remote1
+    dolt sql --multi-db-dir=dbs1 -b -q "use repo1; create table t1 (a int primary key)"
+    dolt sql --multi-db-dir=dbs1 -b -q "use repo1; select dolt_commit('-am', 'cm')"
+
+    clone_helper $TMPDIRS
+    run dolt sql --multi-db-dir=dbs2 -b -q "use repo1; show tables" -r csv
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 4 ]
+    [[ "$output" =~ "t1" ]] || false
+}
+
+#@test "replication-multidb: no push on cli commit" {
+
+    #cd repo1
+    #dolt config --local --add sqlserver.global.dolt_replicate_to_remote backup1
+    #dolt sql -q "create table t1 (a int primary key)"
+    #dolt commit -am "cm"
+
+    #cd ..
+    #run dolt clone file://./bac1 repo2
+    #[ "$status" -eq 1 ]
+#}
+
+#@test "replication-multidb: push on cli engine commit" {
+    #cd repo1
+    #dolt config --local --add sqlserver.global.dolt_replicate_to_remote backup1
+    #dolt sql -q "create table t1 (a int primary key)"
+    #dolt sql -q "select dolt_commit('-am', 'cm')"
+
+    #cd ..
+    #dolt clone file://./bac1 repo2
+    #cd repo2
+    #run dolt ls
+    #[ "$status" -eq 0 ]
+    #[ "${#lines[@]}" -eq 2 ]
+    #[[ "$output" =~ "t1" ]] || false
+#}
+
+#@test "replication-multidb: tag does not trigger replication-multidb" {
+    #cd repo1
+    #dolt config --local --add sqlserver.global.dolt_replicate_to_remote backup1
+    #dolt tag
+
+    #[ ! -d "../bac1/.dolt" ] || false
+#}
+
+#@test "replication-multidb: pull on read" {
+    #dolt clone file://./rem1 repo2
+    #cd repo2
+    #dolt sql -q "create table t1 (a int primary key)"
+    #dolt commit -am "new commit"
+    #dolt push origin main
+
+    #cd ../repo1
+    #run dolt sql -q "show tables" -r csv
+    #[ "$status" -eq 0 ]
+    #[ "${#lines[@]}" -eq 1 ]
+    #[[ ! "$output" =~ "t1" ]] || false
+
+    #dolt config --local --add sqlserver.global.dolt_read_replica_remote remote1
+    #dolt config --local --add sqlserver.global.dolt_replicate_heads main
+    #run dolt sql -q "show tables" -r csv
+    #[ "$status" -eq 0 ]
+    #[ "${#lines[@]}" -eq 2 ]
+    #[[ "$output" =~ "t1" ]] || false
+#}
+
+#@test "replication-multidb: push on branch table update" {
+    #cd repo1
+    #dolt config --local --add sqlserver.global.dolt_replicate_to_remote backup1
+    #dolt sql -q "create table t1 (a int primary key)"
+    #dolt sql -q "UPDATE dolt_branches SET hash = COMMIT('--author', '{user_name} <{email_address}>','-m', 'cm') WHERE name = 'main' AND hash = @@repo1_head"
+
+    #cd ..
+    #dolt clone file://./bac1 repo2
+    #cd repo2
+    #run dolt ls
+    #[ "$status" -eq 0 ]
+    #[ "${#lines[@]}" -eq 2 ]
+    #[[ "$output" =~ "t1" ]] || false
+#}
+
+#@test "replication-multidb: pull non-main head" {
+    #dolt clone file://./rem1 repo2
+    #cd repo2
+    #dolt checkout -b new_feature
+    #dolt sql -q "create table t1 (a int)"
+    #dolt commit -am "cm"
+    #dolt push origin new_feature
+
+    #cd ../repo1
+    #dolt config --local --add sqlserver.global.dolt_replicate_heads new_feature
+    #dolt config --local --add sqlserver.global.dolt_read_replica_remote remote1
+    #run dolt sql -q "show tables as of hashof('new_feature')" -r csv
+    #[ "$status" -eq 0 ]
+    #[ "${#lines[@]}" -eq 2 ]
+    #[[ "${lines[0]}" =~ "Table" ]] || false
+    #[[ "${lines[1]}" =~ "t1" ]] || false
+#}
+
+#@test "replication-multidb: pull multiple heads" {
+    #dolt clone file://./rem1 repo2
+    #cd repo2
+    #dolt checkout -b new_feature
+    #dolt sql -q "create table t1 (a int)"
+    #dolt commit -am "cm"
+    #dolt push origin new_feature
+    #dolt checkout main
+    #dolt sql -q "create table t2 (a int)"
+    #dolt commit -am "cm"
+    #dolt push origin main
+
+    #cd ../repo1
+    #dolt config --local --add sqlserver.global.dolt_replicate_heads main,new_feature
+    #dolt config --local --add sqlserver.global.dolt_read_replica_remote remote1
+
+    #run dolt sql -q "show tables as of hashof('new_feature')" -r csv
+    #[ "$status" -eq 0 ]
+    #[ "${#lines[@]}" -eq 2 ]
+    #[[ "${lines[0]}" =~ "Table" ]] || false
+    #[[ "${lines[1]}" =~ "t1" ]] || false
+
+    #run dolt sql -q "show tables as of hashof('main')" -r csv
+    #[ "$status" -eq 0 ]
+    #[ "${#lines[@]}" -eq 2 ]
+    #[[ "${lines[0]}" =~ "Table" ]] || false
+    #[[ "${lines[1]}" =~ "t2" ]] || false
+#}
+
+#@test "replication-multidb: pull with unknown head" {
+    #dolt clone file://./rem1 repo2
+    #cd repo2
+    #dolt branch new_feature
+    #dolt push origin new_feature
+
+    #cd ../repo1
+    #dolt config --local --add sqlserver.global.dolt_replicate_heads main,unknown
+    #dolt config --local --add sqlserver.global.dolt_read_replica_remote remote1
+    #run dolt sql -q "show tables"
+    #[ "$status" -eq 1 ]
+    #[[ ! "$output" =~ "panic" ]] || false
+    #[[ "$output" =~ "replication-multidb failed: unable to find 'unknown' on 'remote1'; branch not found" ]] || false
+#}
+
+#@test "replication-multidb: pull multiple heads, one invalid branch name" {
+    #dolt clone file://./rem1 repo2
+    #cd repo2
+    #dolt branch new_feature
+    #dolt push origin new_feature
+
+    #cd ../repo1
+    #dolt config --local --add sqlserver.global.dolt_replicate_heads main,unknown
+    #dolt config --local --add sqlserver.global.dolt_read_replica_remote remote1
+    #run dolt sql -q "show tables"
+    #[ "$status" -eq 1 ]
+    #[[ ! "$output" =~ "panic" ]] || false
+    #[[ "$output" =~ "unable to find 'unknown' on 'remote1'; branch not found" ]] || false
+#}
+
+#@test "replication-multidb: pull with no head configuration fails" {
+    #dolt clone file://./rem1 repo2
+    #cd repo2
+    #dolt branch new_feature
+    #dolt push origin new_feature
+
+    #cd ../repo1
+    #dolt config --local --add sqlserver.global.dolt_read_replica_remote remote1
+    #run dolt sql -q "show tables"
+    #[ "$status" -eq 1 ]
+    #[[ ! "$output" =~ "panic" ]] || false
+    #[[ "$output" =~ "invalid replicate heads setting: dolt_replicate_heads not set" ]] || false
+#}
+
+#@test "replication-multidb: replica pull conflicting head configurations" {
+    #dolt clone file://./rem1 repo2
+    #cd repo2
+    #dolt branch new_feature
+    #dolt push origin new_feature
+
+    #cd ../repo1
+    #dolt config --local --add sqlserver.global.dolt_replicate_heads main,unknown
+    #dolt config --local --add sqlserver.global.dolt_replicate_all_heads 1
+    #dolt config --local --add sqlserver.global.dolt_read_replica_remote remote1
+    #run dolt sql -q "show tables"
+    #[ "$status" -eq 1 ]
+    #[[ ! "$output" =~ "panic" ]] || false
+    #[[ "$output" =~ "invalid replicate heads setting; cannot set both" ]] || false
+#}
+
+
+#@test "replication-multidb: replica pull multiple heads quiet warnings" {
+    #dolt clone file://./rem1 repo2
+    #cd repo2
+    #dolt branch new_feature
+    #dolt push origin new_feature
+
+    #cd ../repo1
+    #dolt config --local --add sqlserver.global.dolt_skip_replication-multidb_errors 1
+    #dolt config --local --add sqlserver.global.dolt_replicate_heads unknown
+    #dolt config --local --add sqlserver.global.dolt_read_replica_remote remote1
+    #run dolt sql -q "show tables"
+    #[ "$status" -eq 0 ]
+    #[[ ! "$output" =~ "panic" ]] || false
+    #[[ "$output" =~ "replication-multidb failed: unable to find 'unknown' on 'remote1'; branch not found" ]] || false
+
+    #run dolt checkout new_feature
+    #[ "$status" -eq 1 ]
+    #[[ ! "$output" =~ "panic" ]] || false
+#}
+
+#@test "replication-multidb: pull all heads" {
+    #dolt clone file://./rem1 repo2
+    #cd repo2
+    #dolt checkout -b new_feature
+    #dolt sql -q "create table t1 (a int)"
+    #dolt commit -am "cm"
+    #dolt push origin new_feature
+
+    #cd ../repo1
+    #dolt config --local --add sqlserver.global.dolt_replicate_all_heads 1
+    #dolt config --local --add sqlserver.global.dolt_read_replica_remote remote1
+    #run dolt sql -q "show tables as of hashof('new_feature')" -r csv
+    #[ "$status" -eq 0 ]
+    #[ "${#lines[@]}" -eq 2 ]
+    #[[ "${lines[0]}" =~ "Table" ]] || false
+    #[[ "${lines[1]}" =~ "t1" ]] || false
+#}
+
+#@test "replication-multidb: pull all heads pulls tags" {
+    #dolt clone file://./rem1 repo2
+    #cd repo2
+    #dolt checkout -b new_feature
+    #dolt tag v1
+    #dolt push origin new_feature
+    #dolt push origin v1
+
+    #cd ../repo1
+    #dolt config --local --add sqlserver.global.dolt_replicate_all_heads 1
+    #dolt config --local --add sqlserver.global.dolt_read_replica_remote remote1
+    #dolt sql -q "START TRANSACTION"
+    #run dolt tag
+    #[ "$status" -eq 0 ]
+    #[ "${#lines[@]}" -eq 1 ]
+    #[[ "$output" =~ "v1" ]] || false
+#}
+
+#@test "replication-multidb: push feature head" {
+    #cd repo1
+    #dolt config --local --add sqlserver.global.dolt_replicate_to_remote remote1
+    #dolt checkout -b new_feature
+    #dolt sql -q "create table t1 (a int primary key)"
+    #dolt sql -q "select dolt_commit('-am', 'cm')"
+
+    #cd ..
+    #dolt clone file://./rem1 repo2
+    #cd repo2
+    #dolt fetch origin new_feature
+#}
+
+#@test "replication-multidb: push to unknown remote error" {
+    #cd repo1
+    #dolt config --local --add sqlserver.global.dolt_replicate_to_remote unknown
+    #run dolt sql -q "create table t1 (a int primary key)"
+    #[ "$status" -eq 1 ]
+    #[[ ! "$output" =~ "panic" ]] || false
+    #[[ "$output" =~ "failure loading hook; remote not found: 'unknown'" ]] || false
+#}
+
+#@test "replication-multidb: quiet push to unknown remote warnings" {
+    #cd repo1
+    #dolt config --local --add sqlserver.global.dolt_skip_replication-multidb_errors 1
+    #dolt config --local --add sqlserver.global.dolt_replicate_to_remote unknown
+    #run dolt sql -q "create table t1 (a int primary key)"
+    #[ "$status" -eq 0 ]
+    #[[ ! "$output" =~ "remote not found" ]] || false
+
+    #run dolt sql -q "select dolt_commit('-am', 'cm')"
+    #[ "$status" -eq 0 ]
+    #[[ "$output" =~ "failure loading hook; remote not found: 'unknown'" ]] || false
+    #[[ "$output" =~ "dolt_commit('-am', 'cm')" ]] || false
+#}
+
+#@test "replication-multidb: bad source doesn't error during non-transactional commands" {
+    #cd repo1
+    #dolt config --local --add sqlserver.global.dolt_read_replica_remote unknown
+    #dolt config --local --add sqlserver.global.dolt_replicate_heads main
+
+    #run dolt status
+    #[ "$status" -eq 0 ]
+    #[[ ! "$output" =~ "remote not found: 'unknown'" ]] || false
+#}
+
+#@test "replication-multidb: pull bad remote errors" {
+    #cd repo1
+    #dolt config --local --add sqlserver.global.dolt_read_replica_remote unknown
+    #dolt config --local --add sqlserver.global.dolt_replicate_heads main
+
+    #run dolt sql -q "show tables"
+    #[ "$status" -eq 1 ]
+    #[[ ! "$output" =~ "panic" ]]
+    #[[ "$output" =~ "remote not found: 'unknown'" ]] || false
+#}
+
+#@test "replication-multidb: pull bad remote quiet warning" {
+    #cd repo1
+    #dolt config --local --add sqlserver.global.dolt_read_replica_remote unknown
+    #dolt config --local --add sqlserver.global.dolt_replicate_heads main
+    #dolt config --local --add sqlserver.global.dolt_skip_replication-multidb_errors 1
+
+    #run dolt sql -q "show tables"
+    #[ "$status" -eq 0 ]
+    #[[ ! "$output" =~ "panic" ]]
+    #[[ "$output" =~ "remote not found: 'unknown'" ]] || false
+    #[[ "$output" =~ "dolt_replication-multidb_remote value is misconfigured" ]] || false
+#}
+
+#@test "replication-multidb: use database syntax fetches missing branch" {
+    #dolt clone file://./rem1 repo2
+    #cd repo2
+    #dolt checkout -b feature-branch
+    #dolt sql -q "create table t1 (a int primary key)"
+    #dolt commit -am "new commit"
+    #dolt push origin feature-branch
+
+    #cd ../repo1
+    #dolt config --local --add sqlserver.global.dolt_read_replica_remote remote1
+    #dolt config --local --add sqlserver.global.dolt_replicate_heads main
+    #run dolt sql -b -q "USE \`repo1/feature-branch\`; show tables" -r csv
+    #[ "$status" -eq 0 ]
+    #[ "${#lines[@]}" -eq 4 ]
+    #[[ "${lines[1]}" =~ "Table" ]] || false
+    #[[ "${lines[2]}" =~ "t1" ]] || false
+#}
+
+#@test "replication-multidb: database autofetch doesn't change replication-multidb heads setting" {
+    #dolt clone file://./rem1 repo2
+    #cd repo2
+    #dolt branch feature-branch
+    #dolt push origin feature-branch
+
+    #cd ../repo1
+    #dolt config --local --add sqlserver.global.dolt_read_replica_remote remote1
+    #dolt config --local --add sqlserver.global.dolt_replicate_heads main
+    #run dolt sql -q "use \`repo1/feature-branch\`"
+
+    #cd ../repo2
+    #dolt checkout feature-branch
+    #dolt sql -q "create table t1 (a int primary key)"
+    #dolt commit -am "new commit"
+    #dolt push origin feature-branch
+
+    #cd ../repo1
+    #dolt sql -b -q "show tables" -r csv
+    #[ "$status" -eq 0 ]
+    #[[ ! "output" =~ "t1" ]] || false
+#}

--- a/integration-tests/bats/replication-multidb.bats
+++ b/integration-tests/bats/replication-multidb.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 load $BATS_TEST_DIRNAME/helper/common.bash
+load $BATS_TEST_DIRNAME/helper/query-server-common.bash
 
 setup() {
     setup_common
@@ -42,36 +43,36 @@ push_helper() {
         dolt push remote1 main
     done
     cd $TMPDIRS
-    #dolt push remote1 main
 }
 
 teardown() {
+    stop_sql_server
     teardown_common
     rm -rf $TMPDIRS
     cd $BATS_TMPDIR
 }
 
-#@test "replication-multidb: load global vars" {
-    #dolt config --global --add sqlserver.global.dolt_replicate_to_remote remote1
-    #cd dbs1/repo1
-    #dolt config --local --add sqlserver.global.dolt_replicate_to_remote unknown
-    #cd ../..
-    #run dolt sql --multi-db-dir=dbs1 -b -q "select @@GLOBAL.dolt_replicate_to_remote"
-    #[ "$status" -eq 0 ]
-    #[[ "$output" =~ "remote1" ]] || false
-#}
+@test "replication-multidb: load global vars" {
+    dolt config --global --add sqlserver.global.dolt_replicate_to_remote remote1
+    cd dbs1/repo1
+    dolt config --local --add sqlserver.global.dolt_replicate_to_remote unknown
+    cd ../..
+    run dolt sql --multi-db-dir=dbs1 -b -q "select @@GLOBAL.dolt_replicate_to_remote"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "remote1" ]] || false
+}
 
-#@test "replication-multidb: push on sqlengine commit" {
-    #dolt config --global --add sqlserver.global.dolt_replicate_to_remote remote1
-    #dolt sql --multi-db-dir=dbs1 -b -q "use repo1; create table t1 (a int primary key)"
-    #dolt sql --multi-db-dir=dbs1 -b -q "use repo1; select dolt_commit('-am', 'cm')"
+@test "replication-multidb: push on sqlengine commit" {
+    dolt config --global --add sqlserver.global.dolt_replicate_to_remote remote1
+    dolt sql --multi-db-dir=dbs1 -b -q "use repo1; create table t1 (a int primary key)"
+    dolt sql --multi-db-dir=dbs1 -b -q "use repo1; select dolt_commit('-am', 'cm')"
 
-    #clone_helper $TMPDIRS
-    #run dolt sql --multi-db-dir=dbs2 -b -q "use repo1; show tables" -r csv
-    #[ "$status" -eq 0 ]
-    #[ "${#lines[@]}" -eq 4 ]
-    #[[ "$output" =~ "t1" ]] || false
-#}
+    clone_helper $TMPDIRS
+    run dolt sql --multi-db-dir=dbs2 -b -q "use repo1; show tables" -r csv
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 4 ]
+    [[ "$output" =~ "t1" ]] || false
+}
 
 @test "replication-multidb: pull on read" {
     push_helper $TMPDIRS
@@ -89,83 +90,33 @@ teardown() {
     [[ "$output" =~ "t1" ]] || false
 }
 
-#@test "replication-multidb: push on branch table update" {
-    #cd repo1
-    #dolt config --local --add sqlserver.global.dolt_replicate_to_remote backup1
-    #dolt sql -q "create table t1 (a int primary key)"
-    #dolt sql -q "UPDATE dolt_branches SET hash = COMMIT('--author', '{user_name} <{email_address}>','-m', 'cm') WHERE name = 'main' AND hash = @@repo1_head"
+@test "replication-multidb: sql-server push on commit" {
+    dolt config --global --add sqlserver.global.dolt_replicate_to_remote remote1
+    cd dbs1
+    start_multi_db_server repo1
+    cd ..
 
-    #cd ..
-    #dolt clone file://./bac1 repo2
-    #cd repo2
-    #run dolt ls
-    #[ "$status" -eq 0 ]
-    #[ "${#lines[@]}" -eq 2 ]
-    #[[ "$output" =~ "t1" ]] || false
-#}
+    server_query repo1 1 "create table t1 (a int primary key)"
+    multi_query repo1 1 "select dolt_commit('-am', 'cm')"
 
-#@test "replication-multidb: pull non-main head" {
-    #dolt clone file://./rem1 repo2
-    #cd repo2
-    #dolt checkout -b new_feature
-    #dolt sql -q "create table t1 (a int)"
-    #dolt commit -am "cm"
-    #dolt push origin new_feature
+    clone_helper $TMPDIRS
+    run dolt sql --multi-db-dir=dbs2 -b -q "use repo1; show tables" -r csv
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 4 ]
+    [[ "$output" =~ "t1" ]] || false
+}
 
-    #cd ../repo1
-    #dolt config --local --add sqlserver.global.dolt_replicate_heads new_feature
-    #dolt config --local --add sqlserver.global.dolt_read_replica_remote remote1
-    #run dolt sql -q "show tables as of hashof('new_feature')" -r csv
-    #[ "$status" -eq 0 ]
-    #[ "${#lines[@]}" -eq 2 ]
-    #[[ "${lines[0]}" =~ "Table" ]] || false
-    #[[ "${lines[1]}" =~ "t1" ]] || false
-#}
+@test "replication-multidb: sql-server pull on read" {
+    push_helper $TMPDIRS
+    dolt sql --multi-db-dir=dbs1 -b -q "use repo1; create table t1 (a int primary key)"
+    dolt sql --multi-db-dir=dbs1 -b -q "use repo1; select dolt_commit('-am', 'cm')"
 
-#@test "replication-multidb: pull multiple heads" {
-    #dolt clone file://./rem1 repo2
-    #cd repo2
-    #dolt checkout -b new_feature
-    #dolt sql -q "create table t1 (a int)"
-    #dolt commit -am "cm"
-    #dolt push origin new_feature
-    #dolt checkout main
-    #dolt sql -q "create table t2 (a int)"
-    #dolt commit -am "cm"
-    #dolt push origin main
+    clone_helper $TMPDIRS
+    push_helper $TMPDIRS
 
-    #cd ../repo1
-    #dolt config --local --add sqlserver.global.dolt_replicate_heads main,new_feature
-    #dolt config --local --add sqlserver.global.dolt_read_replica_remote remote1
-
-    #run dolt sql -q "show tables as of hashof('new_feature')" -r csv
-    #[ "$status" -eq 0 ]
-    #[ "${#lines[@]}" -eq 2 ]
-    #[[ "${lines[0]}" =~ "Table" ]] || false
-    #[[ "${lines[1]}" =~ "t1" ]] || false
-
-    #run dolt sql -q "show tables as of hashof('main')" -r csv
-    #[ "$status" -eq 0 ]
-    #[ "${#lines[@]}" -eq 2 ]
-    #[[ "${lines[0]}" =~ "Table" ]] || false
-    #[[ "${lines[1]}" =~ "t2" ]] || false
-#}
-
-#@test "replication-multidb: pull all heads" {
-    #dolt clone file://./rem1 repo2
-    #cd repo2
-    #dolt checkout -b new_feature
-    #dolt sql -q "create table t1 (a int)"
-    #dolt commit -am "cm"
-    #dolt push origin new_feature
-
-    #cd ../repo1
-    #dolt config --local --add sqlserver.global.dolt_replicate_all_heads 1
-    #dolt config --local --add sqlserver.global.dolt_read_replica_remote remote1
-    #run dolt sql -q "show tables as of hashof('new_feature')" -r csv
-    #[ "$status" -eq 0 ]
-    #[ "${#lines[@]}" -eq 2 ]
-    #[[ "${lines[0]}" =~ "Table" ]] || false
-    #[[ "${lines[1]}" =~ "t1" ]] || false
-#}
-
+    dolt config --global --add sqlserver.global.dolt_read_replica_remote remote1
+    dolt config --global --add sqlserver.global.dolt_replicate_heads main
+    cd dbs1
+    start_multi_db_server repo1
+    server_query repo1 1 "show tables" "Table\nt1"
+}

--- a/integration-tests/bats/replication-multidb.bats
+++ b/integration-tests/bats/replication-multidb.bats
@@ -50,6 +50,8 @@ teardown() {
     teardown_common
     rm -rf $TMPDIRS
     cd $BATS_TMPDIR
+
+    dolt config --list | awk '{ print $1 }' | grep sqlserver.global | xargs dolt config --global --unset
 }
 
 @test "replication-multidb: load global vars" {

--- a/integration-tests/bats/replication-multidb.bats
+++ b/integration-tests/bats/replication-multidb.bats
@@ -90,6 +90,20 @@ teardown() {
     [[ "$output" =~ "t1" ]] || false
 }
 
+@test "replication-multidb: missing database config" {
+    dolt config --global --add sqlserver.global.dolt_replicate_to_remote unknown
+    run dolt sql --multi-db-dir=dbs1 -b -q "use repo1; create table t1 (a int primary key)"
+    [ "$status" -eq 1 ]
+    [[ ! "$output" =~ "panic" ]] || false
+    [[ "$output" =~ "remote not found: 'unknown'" ]] || false
+}
+
+@test "replication-multidb: missing database config quiet warning" {
+    dolt config --global --add sqlserver.global.dolt_replicate_to_remote unknown
+    dolt config --global --add sqlserver.global.dolt_skip_replication_errors 1
+    dolt sql --multi-db-dir=dbs1 -b -q "use repo1; create table t1 (a int primary key)"
+}
+
 @test "replication-multidb: sql-server push on commit" {
     dolt config --global --add sqlserver.global.dolt_replicate_to_remote remote1
     cd dbs1


### PR DESCRIPTION
- Multidb uses global dolt config
- Each database locally sets the url for the named remote
- Error handling and async will work the same as single db

Consider a multidb dir `dbs` with a repo in `dbs/repo`. We initialize multidb replication in the global config:
```
$ dolt config --global sqlserver.global.dolt_replication_to_remote replication_middleman
```

`repo` is responsible for setting the replication remote endpoint:

```
$ cd dbs/repo
$ dolt remote add replication_middleman file://../remotes/repo1-middleman
```