### PR TITLE
go/libraries/doltcore/table/untyped/xlsx: Fix bug where this spammed internal representation of the imported rows to Stdout.

### DIFF
--- a/go/libraries/doltcore/table/untyped/xlsx/marshaling.go
+++ b/go/libraries/doltcore/table/untyped/xlsx/marshaling.go
@@ -99,7 +99,6 @@ func decodeXLSXRows(ctx context.Context, vrw types.ValueReadWriter, xlData [][][
 			}
 
 			rows = append(rows, r)
-			fmt.Println(rows)
 		}
 
 	}


### PR DESCRIPTION
These lines were not visible from the CLI because of color, but it still cost
performance. In an embedded context, these could end up in stdout.