### PR TITLE
fix: userNameRequiredError message in CLI

### DIFF
--- a/go/cmd/dolt/cli/command.go
+++ b/go/cmd/dolt/cli/command.go
@@ -259,8 +259,8 @@ const (
 
 Run
 
-  dolt config --global user.email "you@example.com"
-  dolt config --global user.name "Your Name"
+  dolt config --global --add user.email "you@example.com"
+  dolt config --global --add user.name "Your Name"
 
 to set your account's default identity.
 Omit --global to set the identity only in this repository.

--- a/integration-tests/bats/config.bats
+++ b/integration-tests/bats/config.bats
@@ -15,6 +15,12 @@ teardown() {
     stop_sql_server
 }
 
+@test "config: make sure no dolt configuration for simulated fresh user" {
+    run dolt config --list
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
 @test "config: try to initialize a repository with no configuration with correct hint" {
     run dolt init
     [ "$status" -eq 1 ]
@@ -23,12 +29,6 @@ teardown() {
     [[ "$output" =~ "Please tell me who you are" ]] || false
     [[ "$output" =~ "$name" ]] || false
     [[ "$output" =~ "$email" ]] || false
-}
-
-@test "config: try to initialize a repository with no configuration" {
-    run dolt init
-    [ "$status" -eq 1 ]
-    [[ "$output" =~ "Please tell me who you are" ]] || false
 }
 
 @test "config: set a global config variable" {

--- a/integration-tests/bats/config.bats
+++ b/integration-tests/bats/config.bats
@@ -15,10 +15,14 @@ teardown() {
     stop_sql_server
 }
 
-@test "config: make sure no dolt configuration for simulated fresh user" {
-    run dolt config --list
-    [ "$status" -eq 0 ]
-    [ "$output" = "" ]
+@test "config: try to initialize a repository with no configuration with correct hint" {
+    run dolt init
+    [ "$status" -eq 1 ]
+    name='dolt config --global --add user.email "you@example.com"'
+    email='dolt config --global --add user.name "Your Name"'
+    [[ "$output" =~ "Please tell me who you are" ]] || false
+    [[ "$output" =~ "$name" ]] || false
+    [[ "$output" =~ "$email" ]] || false
 }
 
 @test "config: try to initialize a repository with no configuration" {


### PR DESCRIPTION
Running `dolt init` before configuring `user.email` and `user.name` results (correctly) in error; however, the CLI hint itself is incorrect:

```text
Author identity unknown

*** Please tell me who you are.

Run

  dolt config --global user.email "you@example.com"
  dolt config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: empty ident name not allowed
```

The proposed commands for identity configuration do not include the `--add` flag, resulting in a new error message: `Exactly one of the -add, -get, -unset, -list flags must be set.`

This PR fixes the CLI message by adding the `--add` flag to the proposed commands.