### PR TITLE
Modified bats for SQL checkout to assert that the branch should not change on the CLI. 

### DIFF
--- a/integration-tests/bats/sql-checkout.bats
+++ b/integration-tests/bats/sql-checkout.bats
@@ -29,6 +29,10 @@ teardown() {
     [ $status -eq 0 ]
     [[ "$output" =~ "main" ]] || false
 
+    run dolt branch
+    [ $status -eq 0 ]
+    [[ "$output" =~ "feature-branch" ]] || false
+
     run dolt sql -q "SELECT DOLT_CHECKOUT('main');"
     [ $status -eq 0 ]
 

--- a/integration-tests/bats/sql-checkout.bats
+++ b/integration-tests/bats/sql-checkout.bats
@@ -22,10 +22,12 @@ teardown() {
     run dolt sql -q "SELECT DOLT_CHECKOUT('-b', 'feature-branch')"
     [ $status -eq 0 ]
 
-    skip "This is an embarassingly bad test without this check which fails"
+    # dolt sql -q "select dolt_checkout() should not change the branch
+    # It changes the branch for that session which ends after the SQL
+    # statements are executed. 
     run dolt status
     [ $status -eq 0 ]
-    [[ "$output" =~ "feature-branch" ]] || false
+    [[ "$output" =~ "main" ]] || false
 
     run dolt sql -q "SELECT DOLT_CHECKOUT('main');"
     [ $status -eq 0 ]

--- a/integration-tests/bats/sql-checkout.bats
+++ b/integration-tests/bats/sql-checkout.bats
@@ -22,8 +22,17 @@ teardown() {
     run dolt sql -q "SELECT DOLT_CHECKOUT('-b', 'feature-branch')"
     [ $status -eq 0 ]
 
+    skip "This is an embarassingly bad test without this check which fails"
+    run dolt status
+    [ $status -eq 0 ]
+    [[ "$output" =~ "feature-branch" ]] || false
+
     run dolt sql -q "SELECT DOLT_CHECKOUT('main');"
     [ $status -eq 0 ]
+
+    run dolt status
+    [ $status -eq 0 ]
+    [[ "$output" =~ "main" ]] || false
 }
 
 @test "sql-checkout: DOLT_CHECKOUT -b throws error on branches that already exist" {


### PR DESCRIPTION
SQL Checkout should not change the branch in command line context. It only changes the branch for the session which ends after the statement. Resolves #2468.