### PR TITLE
Skipped test for Index overuse issue

### DIFF
--- a/integration-tests/bats/index.bats
+++ b/integration-tests/bats/index.bats
@@ -2547,3 +2547,50 @@ SQL
     [[ "$output" =~ "1,jon" ]] || false
     ! [[ "$output" =~ "2,jon" ]] || false
 }
+
+@test "index: indexes should not be used when functions modify the column" {
+    dolt sql -q "create table test (id int, c1 varchar(255), primary key(id))"
+    dolt sql -q "insert into test values (1, 'Aaaa'), (2, 'aAaa')"
+
+    run dolt sql -q "select * from test"
+    [ $status -eq 0 ]
+    [[ "$output" =~ "Aaaa" ]] || false
+    [[ "$output" =~ "aAaa" ]] || false
+    
+    run dolt sql -q "select * from test where lower(c1)='aaaa'"
+    [ $status -eq 0 ]
+    [[ "$output" =~ "Aaaa" ]] || false
+    [[ "$output" =~ "aAaa" ]] || false
+
+    dolt sql -q "create index test on test (c1)"
+    dolt sql -q "select * from test where lower(c1)='aaaa'"
+    [ $status -eq 0 ]
+    [[ "$output" =~ "Aaaa" ]] || false
+    [[ "$output" =~ "aAaa" ]] || false
+
+    dolt sql -q "create table test2 (id int, c1 varchar(255), c2 varchar(255), primary key(id))"
+    dolt sql -q "insert into test2 values (1, 'Aaaa', 'Bbbb'), (2, 'aAaa', 'bBbb')"
+
+    run dolt sql -q "select * from test2"
+    [ $status -eq 0 ]
+    [[ "$output" =~ "Aaaa" ]] || false
+    [[ "$output" =~ "aAaa" ]] || false
+    [[ "$output" =~ "Bbbb" ]] || false
+    [[ "$output" =~ "bBbb" ]] || false
+
+    run dolt sql -q "select * from test2 where lower(c1)='aaaa' and lower(c2)='bbbb'"
+    [ $status -eq 0 ]
+    [[ "$output" =~ "Aaaa" ]] || false
+    [[ "$output" =~ "aAaa" ]] || false
+    [[ "$output" =~ "Bbbb" ]] || false
+    [[ "$output" =~ "bBbb" ]] || false
+
+    dolt sql -q "create index test2 on test2 (c1,c2)"
+    skip "This returns no results right now because uses the index"
+    run dolt sql -q "select * from test2 where lower(c1)='aaaa' and lower(c2)='bbbb'"
+    [ $status -eq 0 ]
+    [[ "$output" =~ "Aaaa" ]] || false
+    [[ "$output" =~ "aAaa" ]] || false
+    [[ "$output" =~ "Bbbb" ]] || false
+    [[ "$output" =~ "bBbb" ]] || false
+}


### PR DESCRIPTION
Added skipped bats test for the issue where an index is used inappropriately when a function modifies the column producing incorrect results.