### PR TITLE
Refactor the Export path to read from the engine

### DIFF
--- a/benchmark/import_tester/run_importer.sh
+++ b/benchmark/import_tester/run_importer.sh
@@ -39,3 +39,10 @@ time dolt table import -c --pk=pk current_version benchmark.csv
 # Run the old version of dolt
 echo "Running version 0.34.5"
 time ./old-dolt table import -c --pk=pk old_version benchmark.csv
+
+# Run the current version of export
+echo "Running the current version of export"
+time dolt table export current_version export.csv
+
+# Run the old version of export
+time ./old-dolt table export -f old_version export.csv

--- a/go/cmd/dolt/commands/tblcmds/export.go
+++ b/go/cmd/dolt/commands/tblcmds/export.go
@@ -16,17 +16,14 @@ package tblcmds
 
 import (
 	"context"
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlutil"
-	"github.com/dolthub/dolt/go/libraries/doltcore/table"
-	"github.com/dolthub/dolt/go/store/types"
-	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/fatih/color"
-	"golang.org/x/sync/errgroup"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/fatih/color"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands"
@@ -35,12 +32,16 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/mvdata"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlutil"
+	"github.com/dolthub/dolt/go/libraries/doltcore/table"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/typed/noms"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/libraries/utils/funcitr"
 	"github.com/dolthub/dolt/go/libraries/utils/iohelp"
+	"github.com/dolthub/dolt/go/store/types"
 )
 
 var exportDocs = cli.CommandDocumentationContent{
@@ -321,7 +322,7 @@ func export(ctx context.Context, rd table.TableReadCloser, wr table.TableWriteCl
 			}
 
 			select {
-			case <- ctx.Done():
+			case <-ctx.Done():
 				return ctx.Err()
 			case parsedRowChan <- row:
 			}
@@ -333,7 +334,7 @@ func export(ctx context.Context, rd table.TableReadCloser, wr table.TableWriteCl
 
 		for r := range parsedRowChan {
 			select {
-			case <- ctx.Done():
+			case <-ctx.Done():
 				return ctx.Err()
 			default:
 				err := writeRow(wr, r)

--- a/go/cmd/dolt/commands/tblcmds/export.go
+++ b/go/cmd/dolt/commands/tblcmds/export.go
@@ -339,9 +339,7 @@ func export(ctx context.Context, rd table.TableReadCloser, wr table.TableWriteCl
 			default:
 				err := writeRow(wr, r)
 				if err != nil {
-					if err == io.EOF {
-						return nil
-					}
+					return err
 				}
 			}
 		}

--- a/go/libraries/doltcore/mvdata/engine_mover.go
+++ b/go/libraries/doltcore/mvdata/engine_mover.go
@@ -298,7 +298,7 @@ func (s *sqlEngineMover) getInsertNode(inputChannel chan sql.Row) (sql.Node, err
 	}
 }
 
-// createInsertImportNode creates the relevant/analyzed insert node given the import option. This insert node is wrapped
+// createInsertImportNode creates the relevant/analyzed insert iter given the import option. This insert iter is wrapped
 // with an error handler.
 func (s *sqlEngineMover) createInsertImportNode(source chan sql.Row, ignore bool, replace bool, onDuplicateExpression []sql.Expression) (sql.Node, error) {
 	src := NewChannelRowSource(s.wrSch.Schema, source)

--- a/go/libraries/doltcore/mvdata/engine_mover.go
+++ b/go/libraries/doltcore/mvdata/engine_mover.go
@@ -298,7 +298,7 @@ func (s *sqlEngineMover) getInsertNode(inputChannel chan sql.Row) (sql.Node, err
 	}
 }
 
-// createInsertImportNode creates the relevant/analyzed insert node given the import option. This insert iter is wrapped
+// createInsertImportNode creates the relevant/analyzed insert node given the import option. This insert node is wrapped
 // with an error handler.
 func (s *sqlEngineMover) createInsertImportNode(source chan sql.Row, ignore bool, replace bool, onDuplicateExpression []sql.Expression) (sql.Node, error) {
 	src := NewChannelRowSource(s.wrSch.Schema, source)

--- a/go/libraries/doltcore/mvdata/engine_mover.go
+++ b/go/libraries/doltcore/mvdata/engine_mover.go
@@ -298,7 +298,7 @@ func (s *sqlEngineMover) getInsertNode(inputChannel chan sql.Row) (sql.Node, err
 	}
 }
 
-// createInsertImportNode creates the relevant/analyzed insert iter given the import option. This insert iter is wrapped
+// createInsertImportNode creates the relevant/analyzed insert node given the import option. This insert iter is wrapped
 // with an error handler.
 func (s *sqlEngineMover) createInsertImportNode(source chan sql.Row, ignore bool, replace bool, onDuplicateExpression []sql.Expression) (sql.Node, error) {
 	src := NewChannelRowSource(s.wrSch.Schema, source)

--- a/go/libraries/doltcore/mvdata/engine_table_reader.go
+++ b/go/libraries/doltcore/mvdata/engine_table_reader.go
@@ -1,0 +1,105 @@
+// Copyright 2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mvdata
+
+import (
+	"context"
+	"fmt"
+	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
+	"github.com/dolthub/dolt/go/libraries/doltcore/env"
+	"github.com/dolthub/dolt/go/libraries/doltcore/row"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlutil"
+	"github.com/dolthub/go-mysql-server/auth"
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+type sqlEngineTableReader struct {
+	se     *engine.SqlEngine
+	sqlCtx *sql.Context
+
+	sch       schema.Schema
+	iter      sql.RowIter
+	// contOnError // TODO
+}
+
+func NewSqlEngineReader(ctx context.Context, dEnv *env.DoltEnv, tableName string) (*sqlEngineTableReader, error) {
+	mrEnv, err := env.DoltEnvAsMultiEnv(ctx, dEnv)
+	if err != nil {
+		return nil, err
+	}
+
+	// Choose the first DB as the current one. This will be the DB in the working dir if there was one there
+	var dbName string
+	mrEnv.Iter(func(name string, _ *env.DoltEnv) (stop bool, err error) {
+		dbName = name
+		return true, nil
+	})
+
+	se, err := engine.NewSqlEngine(ctx, mrEnv, engine.FormatCsv, dbName, new(auth.None), false)
+	if err != nil {
+		return nil, err
+	}
+
+	sqlCtx, err := se.NewContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	sch, iter, err := se.Query(sqlCtx, fmt.Sprintf("SELECT * FROM %s", tableName))
+	if err != nil {
+		return nil, err // TODO: Handle table not found error (Maybe use catalog instead)
+	}
+
+	root, err := dEnv.WorkingRoot(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	doltSchema, err := sqlutil.ToDoltSchema(ctx, root, tableName, sql.NewPrimaryKeySchema(sch), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sqlEngineTableReader{
+		se: se,
+		sqlCtx: sqlCtx,
+
+		sch:       doltSchema,
+		iter:      iter,
+	}, nil
+}
+
+func (s *sqlEngineTableReader) GetSchema() schema.Schema {
+	return s.sch
+}
+
+func (s *sqlEngineTableReader) ReadRow(ctx context.Context) (row.Row, error) {
+	panic("deprecated")
+}
+
+func (s *sqlEngineTableReader) ReadSqlRow(ctx context.Context) (sql.Row, error) {
+	next, err := s.iter.Next()
+	if err != nil {
+		return nil, err
+	}
+
+	return next, nil
+}
+
+func (s *sqlEngineTableReader) Close(ctx context.Context) error {
+	return s.iter.Close(s.sqlCtx)
+}
+

--- a/go/libraries/doltcore/mvdata/engine_table_reader.go
+++ b/go/libraries/doltcore/mvdata/engine_table_reader.go
@@ -17,21 +17,23 @@ package mvdata
 import (
 	"context"
 	"fmt"
+
+	"github.com/dolthub/go-mysql-server/auth"
+	"github.com/dolthub/go-mysql-server/sql"
+
 	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlutil"
-	"github.com/dolthub/go-mysql-server/auth"
-	"github.com/dolthub/go-mysql-server/sql"
 )
 
 type sqlEngineTableReader struct {
 	se     *engine.SqlEngine
 	sqlCtx *sql.Context
 
-	sch       schema.Schema
-	iter      sql.RowIter
+	sch  schema.Schema
+	iter sql.RowIter
 }
 
 func NewSqlEngineReader(ctx context.Context, dEnv *env.DoltEnv, tableName string) (*sqlEngineTableReader, error) {
@@ -73,11 +75,11 @@ func NewSqlEngineReader(ctx context.Context, dEnv *env.DoltEnv, tableName string
 	}
 
 	return &sqlEngineTableReader{
-		se: se,
+		se:     se,
 		sqlCtx: sqlCtx,
 
-		sch:       doltSchema,
-		iter:      iter,
+		sch:  doltSchema,
+		iter: iter,
 	}, nil
 }
 
@@ -101,4 +103,3 @@ func (s *sqlEngineTableReader) ReadSqlRow(ctx context.Context) (sql.Row, error) 
 func (s *sqlEngineTableReader) Close(ctx context.Context) error {
 	return s.iter.Close(s.sqlCtx)
 }
-

--- a/go/libraries/doltcore/mvdata/engine_table_reader.go
+++ b/go/libraries/doltcore/mvdata/engine_table_reader.go
@@ -59,7 +59,7 @@ func NewSqlEngineReader(ctx context.Context, dEnv *env.DoltEnv, tableName string
 
 	sch, iter, err := se.Query(sqlCtx, fmt.Sprintf("SELECT * FROM %s", tableName))
 	if err != nil {
-		return nil, err // TODO: Handle table not found error (Maybe use catalog instead)
+		return nil, err
 	}
 
 	root, err := dEnv.WorkingRoot(ctx)

--- a/go/libraries/doltcore/mvdata/engine_table_reader.go
+++ b/go/libraries/doltcore/mvdata/engine_table_reader.go
@@ -32,7 +32,6 @@ type sqlEngineTableReader struct {
 
 	sch       schema.Schema
 	iter      sql.RowIter
-	// contOnError // TODO
 }
 
 func NewSqlEngineReader(ctx context.Context, dEnv *env.DoltEnv, tableName string) (*sqlEngineTableReader, error) {

--- a/go/libraries/doltcore/table/table_writer.go
+++ b/go/libraries/doltcore/table/table_writer.go
@@ -16,9 +16,11 @@ package table
 
 import (
 	"context"
+
+	"github.com/dolthub/go-mysql-server/sql"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
-	"github.com/dolthub/go-mysql-server/sql"
 )
 
 // TableWriteCloser is an interface for writing rows to a table
@@ -29,7 +31,6 @@ type TableWriter interface {
 	// WriteRow will write a row to a table
 	WriteRow(ctx context.Context, r row.Row) error
 }
-
 
 // TableWriteCloser is an interface for writing rows to a table, that can be closed
 type TableWriteCloser interface {

--- a/go/libraries/doltcore/table/table_writer.go
+++ b/go/libraries/doltcore/table/table_writer.go
@@ -16,9 +16,9 @@ package table
 
 import (
 	"context"
-
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/go-mysql-server/sql"
 )
 
 // TableWriteCloser is an interface for writing rows to a table
@@ -30,8 +30,14 @@ type TableWriter interface {
 	WriteRow(ctx context.Context, r row.Row) error
 }
 
+
 // TableWriteCloser is an interface for writing rows to a table, that can be closed
 type TableWriteCloser interface {
 	TableWriter
 	TableCloser
+}
+
+type SqlTableWriter interface {
+	TableWriteCloser
+	WriteSqlRow(ctx context.Context, r sql.Row) error
 }

--- a/go/libraries/doltcore/table/typed/json/writer.go
+++ b/go/libraries/doltcore/table/typed/json/writer.go
@@ -19,15 +19,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/vitess/go/sqltypes"
 	"io"
 	"time"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/vitess/go/sqltypes"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
 	"github.com/dolthub/dolt/go/libraries/utils/iohelp"
 	"github.com/dolthub/dolt/go/store/types"
 )
@@ -37,6 +37,7 @@ const jsonFooter = `]}`
 
 var WriteBufSize = 256 * 1024
 var defaultString = sql.MustCreateStringWithDefaults(sqltypes.VarChar, 16383)
+
 type JSONWriter struct {
 	closer      io.Closer
 	bWr         *bufio.Writer

--- a/go/libraries/doltcore/table/typed/parquet/writer.go
+++ b/go/libraries/doltcore/table/typed/parquet/writer.go
@@ -17,9 +17,9 @@ package parquet
 import (
 	"context"
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql"
 	"time"
 
+	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/xitongsys/parquet-go-source/local"
 	"github.com/xitongsys/parquet-go/source"
 	"github.com/xitongsys/parquet-go/writer"

--- a/go/libraries/doltcore/table/typed/parquet/writer.go
+++ b/go/libraries/doltcore/table/typed/parquet/writer.go
@@ -17,6 +17,7 @@ package parquet
 import (
 	"context"
 	"fmt"
+	"github.com/dolthub/go-mysql-server/sql"
 	"time"
 
 	"github.com/xitongsys/parquet-go-source/local"
@@ -123,6 +124,37 @@ func (pwr *ParquetWriter) WriteRow(ctx context.Context, r row.Row) error {
 	}
 
 	err = pwr.pwriter.WriteString(colValStrs)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (pwr *ParquetWriter) WriteSqlRow(ctx context.Context, r sql.Row) error {
+	colValStrs := make([]*string, pwr.sch.GetAllCols().Size())
+
+	for i, val := range r {
+		colT := pwr.sch.GetAllCols().GetByIndex(i)
+		if val == nil {
+			colValStrs[i] = nil
+		} else {
+			// convert datetime and time types to int64
+			switch colT.TypeInfo.GetTypeIdentifier() {
+			case typeinfo.DatetimeTypeIdentifier:
+				val = val.(time.Time).Unix()
+			case typeinfo.TimeTypeIdentifier:
+				colVal, err := sql.Time.Marshal(val)
+				if err != nil {
+					return err
+				}
+				val = colVal
+			}
+			v := sqlutil.SqlColToStr(ctx, val)
+			colValStrs[i] = &v
+		}
+	}
+
+	err := pwr.pwriter.WriteString(colValStrs)
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/table/untyped/csv/writer.go
+++ b/go/libraries/doltcore/table/untyped/csv/writer.go
@@ -18,16 +18,16 @@ import (
 	"bufio"
 	"context"
 	"errors"
-	"github.com/dolthub/go-mysql-server/sql"
 	"io"
 	"strings"
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlutil"
+	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlutil"
 )
 
 // writeBufSize is the size of the buffer used when writing a csv file.  It is set at the package level and all

--- a/go/libraries/doltcore/table/untyped/csv/writer.go
+++ b/go/libraries/doltcore/table/untyped/csv/writer.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"context"
 	"errors"
+	"github.com/dolthub/go-mysql-server/sql"
 	"io"
 	"strings"
 	"unicode"
@@ -92,6 +93,20 @@ func (csvw *CSVWriter) WriteRow(ctx context.Context, r row.Row) error {
 	}
 
 	for i, val := range sqlRow {
+		if val == nil {
+			colValStrs[i] = nil
+		} else {
+			v := sqlutil.SqlColToStr(ctx, val)
+			colValStrs[i] = &v
+		}
+	}
+
+	return csvw.write(colValStrs)
+}
+
+func (csvw *CSVWriter) WriteSqlRow(ctx context.Context, r sql.Row) error {
+	colValStrs := make([]*string, csvw.sch.GetAllCols().Size())
+	for i, val := range r {
 		if val == nil {
 			colValStrs[i] = nil
 		} else {


### PR DESCRIPTION
This pr removes the need of TableDataLoc from export and moves it towards an engine based table reader. It also modifies the writer implementations to work with sql.Row

TODO: I don't think export should support either --continue or --mapping. They were never tested nor are they relevant. If there is an error reading a row from a table, you should fail hard. 