### PR TITLE
/go/libraries/doltcore/doltdb: Extracted Persistent Object from `doltdb.Table`

### DIFF
--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -312,7 +312,7 @@ func docCnfsOnWorkingRoot(ctx context.Context, dEnv *env.DoltEnv) (bool, error) 
 		return false, nil
 	}
 
-	return docTbl.HasConflicts()
+	return docTbl.HasConflicts(ctx)
 }
 
 func PrintDiffsNotStaged(

--- a/go/cmd/dolt/commands/schcmds/import.go
+++ b/go/cmd/dolt/commands/schcmds/import.go
@@ -34,7 +34,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/rowconv"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/untyped/csv"
@@ -297,11 +296,6 @@ func importSchema(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.ArgPars
 			return errhand.BuildDError("error: failed to get table.").AddCause(err).Build()
 		}
 
-		schVal, err := encoding.MarshalSchemaAsNomsValue(context.Background(), root.VRW(), sch)
-		if err != nil {
-			return errhand.BuildDError("error: failed to encode schema.").AddCause(err).Build()
-		}
-
 		empty, err := types.NewMap(ctx, root.VRW())
 		if err != nil {
 			return errhand.BuildDError("error: failed to create table.").AddCause(err).Build()
@@ -315,7 +309,7 @@ func importSchema(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.ArgPars
 			}
 		}
 
-		tbl, err = doltdb.NewTable(ctx, root.VRW(), schVal, empty, indexData, nil)
+		tbl, err = doltdb.NewTable(ctx, root.VRW(), sch, empty, indexData, nil)
 		if err != nil {
 			return errhand.BuildDError("error: failed to create table.").AddCause(err).Build()
 		}

--- a/go/gen/proto/dolt/services/eventsapi/v1alpha1/client_event.pb.go
+++ b/go/gen/proto/dolt/services/eventsapi/v1alpha1/client_event.pb.go
@@ -23,13 +23,14 @@
 package eventsapi
 
 import (
+	reflect "reflect"
+	sync "sync"
+
 	proto "github.com/golang/protobuf/proto"
 	duration "github.com/golang/protobuf/ptypes/duration"
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/go/gen/proto/dolt/services/eventsapi/v1alpha1/client_event_grpc.pb.go
+++ b/go/gen/proto/dolt/services/eventsapi/v1alpha1/client_event_grpc.pb.go
@@ -4,6 +4,7 @@ package eventsapi
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/go/gen/proto/dolt/services/eventsapi/v1alpha1/event_constants.pb.go
+++ b/go/gen/proto/dolt/services/eventsapi/v1alpha1/event_constants.pb.go
@@ -23,11 +23,12 @@
 package eventsapi
 
 import (
+	reflect "reflect"
+	sync "sync"
+
 	proto "github.com/golang/protobuf/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/go/gen/proto/dolt/services/remotesapi/v1alpha1/chunkstore.pb.go
+++ b/go/gen/proto/dolt/services/remotesapi/v1alpha1/chunkstore.pb.go
@@ -21,12 +21,13 @@
 package remotesapi
 
 import (
+	reflect "reflect"
+	sync "sync"
+
 	proto "github.com/golang/protobuf/proto"
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/go/gen/proto/dolt/services/remotesapi/v1alpha1/chunkstore_grpc.pb.go
+++ b/go/gen/proto/dolt/services/remotesapi/v1alpha1/chunkstore_grpc.pb.go
@@ -4,6 +4,7 @@ package remotesapi
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/go/gen/proto/dolt/services/remotesapi/v1alpha1/credentials.pb.go
+++ b/go/gen/proto/dolt/services/remotesapi/v1alpha1/credentials.pb.go
@@ -21,11 +21,12 @@
 package remotesapi
 
 import (
+	reflect "reflect"
+	sync "sync"
+
 	proto "github.com/golang/protobuf/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/go/gen/proto/dolt/services/remotesapi/v1alpha1/credentials_grpc.pb.go
+++ b/go/gen/proto/dolt/services/remotesapi/v1alpha1/credentials_grpc.pb.go
@@ -4,6 +4,7 @@ package remotesapi
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/go/libraries/doltcore/conflict/conflict.go
+++ b/go/libraries/doltcore/conflict/conflict.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package doltdb
+package conflict
 
 import (
 	"context"

--- a/go/libraries/doltcore/diff/docs_diff_test.go
+++ b/go/libraries/doltcore/diff/docs_diff_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
 	filesys2 "github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/store/types"
 )
@@ -119,14 +118,8 @@ func TestDocDiff(t *testing.T) {
 }
 
 func CreateTestTable(vrw types.ValueReadWriter, tSchema schema.Schema, rowData types.Map) (*doltdb.Table, error) {
-	schemaVal, err := encoding.MarshalSchemaAsNomsValue(context.Background(), vrw, tSchema)
-
-	if err != nil {
-		return nil, err
-	}
-
 	empty, _ := types.NewMap(context.Background(), vrw)
-	tbl, err := doltdb.NewTable(context.Background(), vrw, schemaVal, rowData, empty, nil)
+	tbl, err := doltdb.NewTable(context.Background(), vrw, tSchema, rowData, empty, nil)
 
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/doltdb/conflict.go
+++ b/go/libraries/doltcore/doltdb/conflict.go
@@ -14,7 +14,107 @@
 
 package doltdb
 
-import "github.com/dolthub/dolt/go/store/types"
+import (
+	"context"
+	"errors"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
+	"github.com/dolthub/dolt/go/store/types"
+)
+
+type ConflictSchema struct {
+	Base        schema.Schema
+	Schema      schema.Schema
+	MergeSchema schema.Schema
+}
+
+func NewConflictSchema(base, sch, mergeSch schema.Schema) ConflictSchema {
+	return ConflictSchema{
+		Base:        base,
+		Schema:      sch,
+		MergeSchema: mergeSch,
+	}
+}
+
+func ValueFromConflictSchema(ctx context.Context, vrw types.ValueReadWriter, cs ConflictSchema) (types.Value, error) {
+	b, err := serializeSchema(ctx, vrw, cs.Base)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := serializeSchema(ctx, vrw, cs.Schema)
+	if err != nil {
+		return nil, err
+	}
+
+	m, err := serializeSchema(ctx, vrw, cs.MergeSchema)
+	if err != nil {
+		return nil, err
+	}
+
+	return types.NewTuple(types.Format_Default, b, s, m)
+}
+
+func ConflictSchemaFromValue(ctx context.Context, vrw types.ValueReadWriter, v types.Value) (cs ConflictSchema, err error) {
+	tup, ok := v.(types.Tuple)
+	if !ok {
+		err = errors.New("conflict schema value must be types.Struct")
+		return ConflictSchema{}, err
+	}
+
+	b, err := tup.Get(0)
+	if err != nil {
+		return ConflictSchema{}, err
+	}
+	cs.Base, err = deserializeSchema(ctx, vrw, b)
+	if err != nil {
+		return ConflictSchema{}, err
+	}
+
+	s, err := tup.Get(1)
+	if err != nil {
+		return ConflictSchema{}, err
+	}
+	cs.Schema, err = deserializeSchema(ctx, vrw, s)
+	if err != nil {
+		return ConflictSchema{}, err
+	}
+
+	m, err := tup.Get(2)
+	if err != nil {
+		return ConflictSchema{}, err
+	}
+	cs.MergeSchema, err = deserializeSchema(ctx, vrw, m)
+	if err != nil {
+		return ConflictSchema{}, err
+	}
+
+	return cs, nil
+}
+
+func serializeSchema(ctx context.Context, vrw types.ValueReadWriter, sch schema.Schema) (types.Ref, error) {
+	st, err := encoding.MarshalSchemaAsNomsValue(ctx, vrw, sch)
+	if err != nil {
+		return types.Ref{}, err
+	}
+
+	return vrw.WriteValue(ctx, st)
+}
+
+func deserializeSchema(ctx context.Context, vrw types.ValueReadWriter, v types.Value) (schema.Schema, error) {
+	r, ok := v.(types.Ref)
+	if !ok {
+		return nil, errors.New("conflict schemas field value is unexpected type")
+	}
+
+	tv, err := r.TargetValue(ctx, vrw)
+	if err != nil {
+		return nil, err
+	}
+
+	return encoding.UnmarshalSchemaNomsValue(ctx, types.Format_Default, tv)
+}
 
 type Conflict struct {
 	Base       types.Value

--- a/go/libraries/doltcore/doltdb/doltdb_test.go
+++ b/go/libraries/doltcore/doltdb/doltdb_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/libraries/utils/test"
 	"github.com/dolthub/dolt/go/store/hash"
@@ -70,14 +69,8 @@ func createTestSchema(t *testing.T) schema.Schema {
 }
 
 func CreateTestTable(vrw types.ValueReadWriter, tSchema schema.Schema, rowData types.Map) (*Table, error) {
-	schemaVal, err := encoding.MarshalSchemaAsNomsValue(context.Background(), vrw, tSchema)
-
-	if err != nil {
-		return nil, err
-	}
-
 	empty, _ := types.NewMap(context.Background(), vrw)
-	tbl, err := NewTable(context.Background(), vrw, schemaVal, rowData, empty, nil)
+	tbl, err := NewTable(context.Background(), vrw, tSchema, rowData, empty, nil)
 
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/doltdb/doltdb_test.go
+++ b/go/libraries/doltcore/doltdb/doltdb_test.go
@@ -326,10 +326,13 @@ func TestLDNoms(t *testing.T) {
 			t.Error("Could not retrieve test table")
 		}
 
-		has, err := readTable.HasTheSameSchema(tbl)
-		assert.NoError(t, err)
+		ts, err := tbl.GetSchema(context.Background())
+		require.NoError(t, err)
 
-		if !has {
+		rs, err := readTable.GetSchema(context.Background())
+		require.NoError(t, err)
+
+		if !schema.SchemasAreEqual(ts, rs) {
 			t.Error("Unexpected schema")
 		}
 	}

--- a/go/libraries/doltcore/doltdb/durable/table.go
+++ b/go/libraries/doltcore/doltdb/durable/table.go
@@ -1,0 +1,45 @@
+// Copyright 2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package durable
+
+import (
+	"context"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/dolthub/dolt/go/store/types"
+)
+
+type Table interface {
+	GetSchemaHash(ctx context.Context) (hash.Hash, error)
+	GetSchema(ctx context.Context) (schema.Schema, error)
+	SetSchema(ctx context.Context, sch schema.Schema) error
+
+	GetTableRows(ctx context.Context) (types.Map, error)
+	SetTableRows(ctx context.Context, rows types.Map) error
+
+	GetIndexes(ctx context.Context) (types.Map, error)
+	SetIndexes(ctx context.Context, indexes types.Map) error
+
+	GetConflicts(ctx context.Context) (doltdb.ConflictSchema, types.Map, error)
+	SetConflicts(ctx context.Context, sch doltdb.ConflictSchema, conflicts types.Map) error
+
+	GetConstraintViolations(ctx context.Context) (types.Map, error)
+	SetConstraintViolations(ctx context.Context, violations types.Map) error
+
+	GetAutoIncrement(ctx context.Context) (types.Value, error)
+	SetAutoIncrement(ctx context.Context, val types.Value) error
+}

--- a/go/libraries/doltcore/doltdb/durable/table.go
+++ b/go/libraries/doltcore/doltdb/durable/table.go
@@ -16,30 +16,491 @@ package durable
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/conflict"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
 	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/types"
 )
 
+const (
+	tableStructName = "table"
+
+	schemaRefKey            = "schema_ref"
+	tableRowsKey            = "rows"
+	conflictsKey            = "conflicts"
+	conflictSchemasKey      = "conflict_schemas"
+	constraintViolationsKey = "constraint_violations"
+	indexesKey              = "indexes"
+	autoIncrementKey        = "auto_increment"
+)
+
+var (
+	ErrNoConflictsResolved  = errors.New("no conflicts resolved")
+	ErrNoAutoIncrementValue = fmt.Errorf("auto increment set for non-numeric column type")
+)
+
+func VrwFromTable(t Table) types.ValueReadWriter {
+	return t.(nomsTable).vrw
+}
+
 type Table interface {
+	HashOf() (hash.Hash, error)
+
 	GetSchemaHash(ctx context.Context) (hash.Hash, error)
 	GetSchema(ctx context.Context) (schema.Schema, error)
-	SetSchema(ctx context.Context, sch schema.Schema) error
+	SetSchema(ctx context.Context, sch schema.Schema) (Table, error)
 
 	GetTableRows(ctx context.Context) (types.Map, error)
-	SetTableRows(ctx context.Context, rows types.Map) error
+	SetTableRows(ctx context.Context, rows types.Map) (Table, error)
 
 	GetIndexes(ctx context.Context) (types.Map, error)
-	SetIndexes(ctx context.Context, indexes types.Map) error
+	SetIndexes(ctx context.Context, indexes types.Map) (Table, error)
 
-	GetConflicts(ctx context.Context) (doltdb.ConflictSchema, types.Map, error)
-	SetConflicts(ctx context.Context, sch doltdb.ConflictSchema, conflicts types.Map) error
+	GetConflicts(ctx context.Context) (conflict.ConflictSchema, types.Map, error)
+	HasConflicts(ctx context.Context) (bool, error)
+	SetConflicts(ctx context.Context, sch conflict.ConflictSchema, conflicts types.Map) (Table, error)
+	ClearConflicts(ctx context.Context) (Table, error)
 
 	GetConstraintViolations(ctx context.Context) (types.Map, error)
-	SetConstraintViolations(ctx context.Context, violations types.Map) error
+	SetConstraintViolations(ctx context.Context, violations types.Map) (Table, error)
 
 	GetAutoIncrement(ctx context.Context) (types.Value, error)
-	SetAutoIncrement(ctx context.Context, val types.Value) error
+	SetAutoIncrement(ctx context.Context, val types.Value) (Table, error)
+}
+
+type nomsTable struct {
+	vrw         types.ValueReadWriter
+	tableStruct types.Struct
+}
+
+var _ Table = nomsTable{}
+
+func NewNomsTable(ctx context.Context, vrw types.ValueReadWriter, sch schema.Schema, rowData types.Map, indexData types.Map, autoIncVal types.Value) (Table, error) {
+	schVal, err := encoding.MarshalSchemaAsNomsValue(ctx, vrw, sch)
+	if err != nil {
+		return nil, err
+	}
+
+	schemaRef, err := refFromNomsValue(ctx, vrw, schVal)
+	if err != nil {
+		return nil, err
+	}
+
+	rowDataRef, err := refFromNomsValue(ctx, vrw, rowData)
+	if err != nil {
+		return nil, err
+	}
+
+	indexesRef, err := refFromNomsValue(ctx, vrw, indexData)
+	if err != nil {
+		return nil, err
+	}
+
+	sd := types.StructData{
+		schemaRefKey: schemaRef,
+		tableRowsKey: rowDataRef,
+		indexesKey:   indexesRef,
+	}
+
+	if autoIncVal != nil {
+		sd[autoIncrementKey] = autoIncVal
+	}
+
+	tableStruct, err := types.NewStruct(vrw.Format(), tableStructName, sd)
+	if err != nil {
+		return nil, err
+	}
+
+	return nomsTable{vrw, tableStruct}, nil
+}
+
+func NomsTableFromRef(ctx context.Context, vrw types.ValueReadWriter, ref types.Ref) (Table, error) {
+	val, err := ref.TargetValue(ctx, vrw)
+	if err != nil {
+		return nil, err
+	}
+
+	st, ok := val.(types.Struct)
+	if !ok {
+		err = errors.New("table ref is unexpected noms value")
+		return nil, err
+	}
+
+	return nomsTable{vrw: vrw, tableStruct: st}, nil
+}
+
+func RefFromNomsTable(ctx context.Context, table Table) (types.Ref, error) {
+	nt := table.(nomsTable)
+	return refFromNomsValue(ctx, nt.vrw, nt.tableStruct)
+}
+
+func (t nomsTable) Format() *types.NomsBinFormat {
+	return t.vrw.Format()
+}
+
+// ValueReadWriter returns the ValueReadWriter for this table.
+func (t nomsTable) ValueReadWriter() types.ValueReadWriter {
+	return t.vrw
+}
+
+func (t nomsTable) HashOf() (hash.Hash, error) {
+	return t.tableStruct.Hash(t.vrw.Format())
+}
+
+// GetSchema will retrieve the schema being referenced from the table in noms and unmarshal it.
+func (t nomsTable) GetSchema(ctx context.Context) (schema.Schema, error) {
+	schemaRefVal, _, err := t.tableStruct.MaybeGet(schemaRefKey)
+
+	if err != nil {
+		return nil, err
+	}
+
+	schemaRef := schemaRefVal.(types.Ref)
+	return schemaFromRef(ctx, t.vrw, schemaRef)
+}
+
+func (t nomsTable) GetSchemaHash(ctx context.Context) (hash.Hash, error) {
+	r, _, err := t.tableStruct.MaybeGet(schemaRefKey)
+	if err != nil {
+		return hash.Hash{}, err
+	}
+	return r.Hash(t.vrw.Format())
+}
+
+// UpdateSchema updates the table with the schema given and returns the updated table. The original table is unchanged.
+func (t nomsTable) SetSchema(ctx context.Context, sch schema.Schema) (Table, error) {
+	newSchemaVal, err := encoding.MarshalSchemaAsNomsValue(ctx, t.vrw, sch)
+	if err != nil {
+		return nil, err
+	}
+
+	schRef, err := refFromNomsValue(ctx, t.vrw, newSchemaVal)
+	if err != nil {
+		return nil, err
+	}
+
+	newTableStruct, err := t.tableStruct.Set(schemaRefKey, schRef)
+	if err != nil {
+		return nil, err
+	}
+
+	return nomsTable{t.vrw, newTableStruct}, nil
+}
+
+// UpdateRows replaces the current row data and returns and updated Table.  Calls to UpdateRows will not be written to the
+// database.  The root must be updated with the updated table, and the root must be committed or written.
+func (t nomsTable) SetTableRows(ctx context.Context, updatedRows types.Map) (Table, error) {
+	rowDataRef, err := refFromNomsValue(ctx, t.vrw, updatedRows)
+
+	if err != nil {
+		return nil, err
+	}
+
+	updatedSt, err := t.tableStruct.Set(tableRowsKey, rowDataRef)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return nomsTable{t.vrw, updatedSt}, nil
+}
+
+// GetRowData retrieves the underlying map which is a map from a primary key to a list of field values.
+func (t nomsTable) GetTableRows(ctx context.Context) (types.Map, error) {
+	val, _, err := t.tableStruct.MaybeGet(tableRowsKey)
+
+	if err != nil {
+		return types.EmptyMap, err
+	}
+
+	rowMapRef := val.(types.Ref)
+
+	val, err = rowMapRef.TargetValue(ctx, t.vrw)
+
+	if err != nil {
+		return types.EmptyMap, err
+	}
+
+	rowMap := val.(types.Map)
+	return rowMap, nil
+}
+
+// GetIndexData returns the internal index map which goes from index name to a ref of the row data map.
+func (t nomsTable) GetIndexes(ctx context.Context) (types.Map, error) {
+	indexesVal, ok, err := t.tableStruct.MaybeGet(indexesKey)
+	if err != nil {
+		return types.EmptyMap, err
+	}
+	if !ok {
+		newEmptyMap, err := types.NewMap(ctx, t.vrw)
+		if err != nil {
+			return types.EmptyMap, err
+		}
+		return newEmptyMap, nil
+	}
+
+	indexesMap, err := indexesVal.(types.Ref).TargetValue(ctx, t.vrw)
+	if err != nil {
+		return types.EmptyMap, err
+	}
+
+	return indexesMap.(types.Map), nil
+}
+
+// SetIndexData replaces the current internal index map, and returns an updated Table.
+func (t nomsTable) SetIndexes(ctx context.Context, indexesMap types.Map) (Table, error) {
+	indexesRef, err := refFromNomsValue(ctx, t.vrw, indexesMap)
+	if err != nil {
+		return nil, err
+	}
+
+	newTableStruct, err := t.tableStruct.Set(indexesKey, indexesRef)
+	if err != nil {
+		return nil, err
+	}
+
+	return nomsTable{t.vrw, newTableStruct}, nil
+}
+
+func (t nomsTable) HasConflicts(ctx context.Context) (bool, error) {
+	_, ok, err := t.tableStruct.MaybeGet(conflictSchemasKey)
+	return ok, err
+}
+
+// GetConflicts returns a map built from ValueReadWriter when there are no conflicts in table
+func (t nomsTable) GetConflicts(ctx context.Context) (conflict.ConflictSchema, types.Map, error) {
+	schemasVal, ok, err := t.tableStruct.MaybeGet(conflictSchemasKey)
+	if err != nil {
+		return conflict.ConflictSchema{}, types.EmptyMap, err
+	}
+	if !ok {
+		confMap, _ := types.NewMap(ctx, t.ValueReadWriter())
+		return conflict.ConflictSchema{}, confMap, nil
+	}
+
+	schemas, err := conflict.ConflictSchemaFromValue(ctx, t.vrw, schemasVal)
+	if err != nil {
+		return conflict.ConflictSchema{}, types.EmptyMap, err
+	}
+
+	conflictsVal, _, err := t.tableStruct.MaybeGet(conflictsKey)
+	if err != nil {
+		return conflict.ConflictSchema{}, types.EmptyMap, err
+	}
+
+	confMap := types.EmptyMap
+	if conflictsVal != nil {
+		confMapRef := conflictsVal.(types.Ref)
+		v, err := confMapRef.TargetValue(ctx, t.vrw)
+
+		if err != nil {
+			return conflict.ConflictSchema{}, types.EmptyMap, err
+		}
+
+		confMap = v.(types.Map)
+	}
+
+	return schemas, confMap, nil
+}
+
+func (t nomsTable) SetConflicts(ctx context.Context, schemas conflict.ConflictSchema, conflictData types.Map) (Table, error) {
+	conflictsRef, err := refFromNomsValue(ctx, t.vrw, conflictData)
+	if err != nil {
+		return nil, err
+	}
+
+	tpl, err := conflict.ValueFromConflictSchema(ctx, t.vrw, schemas)
+	if err != nil {
+		return nil, err
+	}
+
+	updatedSt, err := t.tableStruct.Set(conflictSchemasKey, tpl)
+	if err != nil {
+		return nil, err
+	}
+
+	updatedSt, err = updatedSt.Set(conflictsKey, conflictsRef)
+	if err != nil {
+		return nil, err
+	}
+
+	return nomsTable{t.vrw, updatedSt}, nil
+}
+
+func (t nomsTable) GetConflictSchemas(ctx context.Context) (base, sch, mergeSch schema.Schema, err error) {
+	schemasVal, ok, err := t.tableStruct.MaybeGet(conflictSchemasKey)
+
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	if ok {
+		schemas, err := conflict.ConflictFromTuple(schemasVal.(types.Tuple))
+
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		baseRef := schemas.Base.(types.Ref)
+		valRef := schemas.Value.(types.Ref)
+		mergeRef := schemas.MergeValue.(types.Ref)
+
+		var baseSch, sch, mergeSch schema.Schema
+		if baseSch, err = schemaFromRef(ctx, t.vrw, baseRef); err == nil {
+			if sch, err = schemaFromRef(ctx, t.vrw, valRef); err == nil {
+				mergeSch, err = schemaFromRef(ctx, t.vrw, mergeRef)
+			}
+		}
+
+		return baseSch, sch, mergeSch, err
+	}
+	return nil, nil, nil, nil
+}
+
+func (t nomsTable) ClearConflicts(ctx context.Context) (Table, error) {
+	tSt, err := t.tableStruct.Delete(conflictSchemasKey)
+
+	if err != nil {
+		return nil, err
+	}
+
+	tSt, err = tSt.Delete(conflictsKey)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return nomsTable{t.vrw, tSt}, nil
+}
+
+// GetConstraintViolations returns a map of all constraint violations for this table, along with a bool indicating
+// whether the table has any violations.
+func (t nomsTable) GetConstraintViolations(ctx context.Context) (types.Map, error) {
+	constraintViolationsRefVal, ok, err := t.tableStruct.MaybeGet(constraintViolationsKey)
+	if err != nil {
+		return types.EmptyMap, err
+	}
+	if !ok {
+		emptyMap, err := types.NewMap(ctx, t.vrw)
+		return emptyMap, err
+	}
+	constraintViolationsVal, err := constraintViolationsRefVal.(types.Ref).TargetValue(ctx, t.vrw)
+	if err != nil {
+		return types.EmptyMap, err
+	}
+	return constraintViolationsVal.(types.Map), nil
+}
+
+// SetConstraintViolations sets this table's violations to the given map. If the map is empty, then the constraint
+// violations entry on the embedded struct is removed.
+func (t nomsTable) SetConstraintViolations(ctx context.Context, violationsMap types.Map) (Table, error) {
+	// We can't just call violationsMap.Empty() as we can't guarantee that the caller passed in an instantiated map
+	if violationsMap == types.EmptyMap || violationsMap.Len() == 0 {
+		updatedStruct, err := t.tableStruct.Delete(constraintViolationsKey)
+		if err != nil {
+			return nil, err
+		}
+		return nomsTable{t.vrw, updatedStruct}, nil
+	}
+	constraintViolationsRef, err := refFromNomsValue(ctx, t.vrw, violationsMap)
+	if err != nil {
+		return nil, err
+	}
+	updatedStruct, err := t.tableStruct.Set(constraintViolationsKey, constraintViolationsRef)
+	if err != nil {
+		return nil, err
+	}
+	return nomsTable{t.vrw, updatedStruct}, nil
+}
+
+func (t nomsTable) GetAutoIncrement(ctx context.Context) (types.Value, error) {
+	val, ok, err := t.tableStruct.MaybeGet(autoIncrementKey)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		return val, nil
+	}
+
+	sch, err := t.GetSchema(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	kind := types.UnknownKind
+	_ = sch.GetAllCols().Iter(func(tag uint64, col schema.Column) (stop bool, err error) {
+		if col.AutoIncrement {
+			kind = col.Kind
+			stop = true
+		}
+		return
+	})
+	switch kind {
+	case types.IntKind:
+		return types.Int(1), nil
+	case types.UintKind:
+		return types.Uint(1), nil
+	case types.FloatKind:
+		return types.Float(1), nil
+	default:
+		return nil, ErrNoAutoIncrementValue
+	}
+}
+
+func (t nomsTable) SetAutoIncrement(ctx context.Context, val types.Value) (Table, error) {
+	switch val.(type) {
+	case types.Int, types.Uint, types.Float:
+		st, err := t.tableStruct.Set(autoIncrementKey, val)
+		if err != nil {
+			return nil, err
+		}
+		return nomsTable{t.vrw, st}, nil
+
+	default:
+		return nil, fmt.Errorf("cannot set auto increment to non-numeric value")
+	}
+}
+
+func refFromNomsValue(ctx context.Context, vrw types.ValueReadWriter, val types.Value) (types.Ref, error) {
+	valRef, err := types.NewRef(val, vrw.Format())
+
+	if err != nil {
+		return types.Ref{}, err
+	}
+
+	targetVal, err := valRef.TargetValue(ctx, vrw)
+
+	if err != nil {
+		return types.Ref{}, err
+	}
+
+	if targetVal == nil {
+		_, err = vrw.WriteValue(ctx, val)
+
+		if err != nil {
+			return types.Ref{}, err
+		}
+	}
+
+	return valRef, err
+}
+
+func schemaFromRef(ctx context.Context, vrw types.ValueReadWriter, ref types.Ref) (schema.Schema, error) {
+	schemaVal, err := ref.TargetValue(ctx, vrw)
+
+	if err != nil {
+		return nil, err
+	}
+
+	schema, err := encoding.UnmarshalSchemaNomsValue(ctx, vrw.Format(), schemaVal)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return schema, nil
 }

--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -756,11 +756,6 @@ func putTable(ctx context.Context, root *RootValue, tName string, tableRef types
 
 // CreateEmptyTable creates an empty table in this root with the name and schema given, returning the new root value.
 func (root *RootValue) CreateEmptyTable(ctx context.Context, tName string, sch schema.Schema) (*RootValue, error) {
-	schVal, err := encoding.MarshalSchemaAsNomsValue(ctx, root.VRW(), sch)
-	if err != nil {
-		return nil, err
-	}
-
 	empty, err := types.NewMap(ctx, root.VRW())
 	if err != nil {
 		return nil, err
@@ -786,7 +781,7 @@ func (root *RootValue) CreateEmptyTable(ctx context.Context, tName string, sch s
 		return nil, err
 	}
 
-	tbl, err := NewTable(ctx, root.VRW(), schVal, empty, indexes, nil)
+	tbl, err := NewTable(ctx, root.VRW(), sch, empty, indexes, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1213,18 +1208,18 @@ func validateTagUniqueness(ctx context.Context, root *RootValue, tableName strin
 		return err
 	}
 	if ok {
-		prevRef, err := prev.GetSchemaRef()
+		prevHash, err := prev.GetSchemaHash(ctx)
 		if err != nil {
 			return err
 		}
 
-		newRef, err := table.GetSchemaRef()
+		newHash, err := table.GetSchemaHash(ctx)
 		if err != nil {
 			return err
 		}
 
 		// short-circuit if schema unchanged
-		if prevRef.Equals(newRef) {
+		if prevHash == newHash {
 			return nil
 		}
 	}

--- a/go/libraries/doltcore/doltdocs/docs_table.go
+++ b/go/libraries/doltcore/doltdocs/docs_table.go
@@ -22,7 +22,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/typed/noms"
 	"github.com/dolthub/dolt/go/store/types"
@@ -115,18 +114,13 @@ func createDocsTable(ctx context.Context, vrw types.ValueReadWriter, docs Docs) 
 		rd.Close(context.Background())
 		wr.Close(context.Background())
 
-		schVal, err := encoding.MarshalSchemaAsNomsValue(ctx, vrw, wr.GetSchema())
-
-		if err != nil {
-			return nil, ErrMarshallingSchema
-		}
-
 		empty, err := types.NewMap(ctx, vrw)
 		if err != nil {
 			return nil, err
 		}
+		sch := wr.GetSchema()
 
-		newDocsTbl, err := doltdb.NewTable(ctx, vrw, schVal, wr.GetMap(), empty, nil)
+		newDocsTbl, err := doltdb.NewTable(ctx, vrw, sch, wr.GetMap(), empty, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/go/libraries/doltcore/doltdocs/docs_test.go
+++ b/go/libraries/doltcore/doltdocs/docs_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
 	filesys2 "github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/store/types"
 )
@@ -135,14 +134,8 @@ func TestAddNewerTextAndDocPkFromRow(t *testing.T) {
 }
 
 func CreateTestTable(vrw types.ValueReadWriter, tSchema schema.Schema, rowData types.Map) (*doltdb.Table, error) {
-	schemaVal, err := encoding.MarshalSchemaAsNomsValue(context.Background(), vrw, tSchema)
-
-	if err != nil {
-		return nil, err
-	}
-
 	empty, _ := types.NewMap(context.Background(), vrw)
-	tbl, err := doltdb.NewTable(context.Background(), vrw, schemaVal, rowData, empty, nil)
+	tbl, err := doltdb.NewTable(context.Background(), vrw, tSchema, rowData, empty, nil)
 
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/dtestutils/environment.go
+++ b/go/libraries/doltcore/dtestutils/environment.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/typed/noms"
@@ -79,11 +78,9 @@ func CreateEnvWithSeedData(t *testing.T) *env.DoltEnv {
 	sch = wr.GetSchema()
 	sch.Indexes().Merge(ai...)
 
-	schVal, err := encoding.MarshalSchemaAsNomsValue(ctx, vrw, sch)
-	require.NoError(t, err)
 	empty, err := types.NewMap(ctx, vrw)
 	require.NoError(t, err)
-	tbl, err := doltdb.NewTable(ctx, vrw, schVal, wr.GetMap(), empty, nil)
+	tbl, err := doltdb.NewTable(ctx, vrw, sch, wr.GetMap(), empty, nil)
 	require.NoError(t, err)
 	tbl, err = editor.RebuildAllIndexes(ctx, tbl, editor.TestEditorOptions(vrw))
 	require.NoError(t, err)

--- a/go/libraries/doltcore/dtestutils/schema.go
+++ b/go/libraries/doltcore/dtestutils/schema.go
@@ -26,7 +26,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/typed/noms"
@@ -110,11 +109,9 @@ func CreateTestTable(t *testing.T, dEnv *env.DoltEnv, tableName string, sch sche
 	err = wr.Close(ctx)
 	require.NoError(t, err)
 
-	schVal, err := encoding.MarshalSchemaAsNomsValue(ctx, vrw, sch)
-	require.NoError(t, err)
 	empty, err := types.NewMap(ctx, vrw)
 	require.NoError(t, err)
-	tbl, err := doltdb.NewTable(ctx, vrw, schVal, wr.GetMap(), empty, nil)
+	tbl, err := doltdb.NewTable(ctx, vrw, sch, wr.GetMap(), empty, nil)
 	require.NoError(t, err)
 	tbl, err = editor.RebuildAllIndexes(ctx, tbl, editor.TestEditorOptions(vrw))
 	require.NoError(t, err)
@@ -136,12 +133,7 @@ func putTableToWorking(ctx context.Context, dEnv *env.DoltEnv, sch schema.Schema
 	}
 
 	vrw := dEnv.DoltDB.ValueReadWriter()
-	schVal, err := encoding.MarshalSchemaAsNomsValue(ctx, vrw, sch)
-	if err != nil {
-		return env.ErrMarshallingSchema
-	}
-
-	tbl, err := doltdb.NewTable(ctx, vrw, schVal, rows, indexData, autoVal)
+	tbl, err := doltdb.NewTable(ctx, vrw, sch, rows, indexData, autoVal)
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/dtestutils/testcommands/multienv.go
+++ b/go/libraries/doltcore/dtestutils/testcommands/multienv.go
@@ -27,7 +27,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/typed/noms"
@@ -339,15 +338,11 @@ func createTestTable(dEnv *env.DoltEnv, tableName string, sch schema.Schema, err
 	if err != nil {
 		errhand(err)
 	}
-	schVal, err := encoding.MarshalSchemaAsNomsValue(ctx, vrw, sch)
-	if err != nil {
-		errhand(err)
-	}
 	empty, err := types.NewMap(ctx, vrw)
 	if err != nil {
 		errhand(err)
 	}
-	tbl, err := doltdb.NewTable(ctx, vrw, schVal, wr.GetMap(), empty, nil)
+	tbl, err := doltdb.NewTable(ctx, vrw, sch, wr.GetMap(), empty, nil)
 	if err != nil {
 		errhand(err)
 	}
@@ -381,12 +376,7 @@ func putTableToWorking(ctx context.Context, dEnv *env.DoltEnv, sch schema.Schema
 	}
 
 	vrw := dEnv.DoltDB.ValueReadWriter()
-	schVal, err := encoding.MarshalSchemaAsNomsValue(ctx, vrw, sch)
-	if err != nil {
-		return env.ErrMarshallingSchema
-	}
-
-	tbl, err := doltdb.NewTable(ctx, vrw, schVal, rows, indexData, autoVal)
+	tbl, err := doltdb.NewTable(ctx, vrw, sch, rows, indexData, autoVal)
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/env/actions/staged.go
+++ b/go/libraries/doltcore/env/actions/staged.go
@@ -92,12 +92,15 @@ func stageTables(
 // clearEmptyConflicts clears any 0-row conflicts from the tables named, and returns a new root.
 func clearEmptyConflicts(ctx context.Context, tbls []string, working *doltdb.RootValue) (*doltdb.RootValue, error) {
 	for _, tblName := range tbls {
-		tbl, _, err := working.GetTable(ctx, tblName)
+		tbl, ok, err := working.GetTable(ctx, tblName)
 		if err != nil {
 			return nil, err
 		}
+		if !ok {
+			continue
+		}
 
-		has, err := tbl.HasConflicts()
+		has, err := tbl.HasConflicts(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -108,7 +111,7 @@ func clearEmptyConflicts(ctx context.Context, tbls []string, working *doltdb.Roo
 			}
 
 			if num == 0 {
-				clrTbl, err := tbl.ClearConflicts()
+				clrTbl, err := tbl.ClearConflicts(ctx)
 				if err != nil {
 					return nil, err
 				}

--- a/go/libraries/doltcore/merge/conflict_source.go
+++ b/go/libraries/doltcore/merge/conflict_source.go
@@ -19,6 +19,8 @@ import (
 	"errors"
 	"io"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/conflict"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/rowconv"
@@ -121,7 +123,7 @@ func (cr *ConflictReader) NextConflict(ctx context.Context) (row.Row, pipeline.I
 	}
 
 	keyTpl := key.(types.Tuple)
-	conflict, err := doltdb.ConflictFromTuple(value.(types.Tuple))
+	conflict, err := conflict.ConflictFromTuple(value.(types.Tuple))
 
 	if err != nil {
 		return nil, pipeline.NoProps, err

--- a/go/libraries/doltcore/merge/merge.go
+++ b/go/libraries/doltcore/merge/merge.go
@@ -210,23 +210,24 @@ func (merger *Merger) MergeTable(ctx context.Context, tblName string, sess *edit
 
 	if conflicts.Len() > 0 {
 
-		asr, err := ancTbl.GetSchemaRef()
+		ancSch, err := ancTbl.GetSchema(ctx)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		sr, err := tbl.GetSchemaRef()
+		sch, err := tbl.GetSchema(ctx)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		msr, err := mergeTbl.GetSchemaRef()
+		mergeSch, err := mergeTbl.GetSchema(ctx)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		schemas := doltdb.NewConflict(asr, sr, msr)
-		resultTbl, err = resultTbl.SetConflicts(ctx, schemas, conflicts)
+		cs := doltdb.NewConflictSchema(ancSch, sch, mergeSch)
+
+		resultTbl, err = resultTbl.SetConflicts(ctx, cs, conflicts)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/go/libraries/doltcore/merge/merge_test.go
+++ b/go/libraries/doltcore/merge/merge_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/conflict"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
@@ -329,12 +330,12 @@ func setupMergeTest(t *testing.T) (types.ValueReadWriter, *doltdb.Commit, *doltd
 	)
 	require.NoError(t, err)
 
-	updateConflict := doltdb.NewConflict(
+	updateConflict := conflict.NewConflict(
 		mustGetValue(initialRows.MaybeGet(context.Background(), keyTuples[8])),
 		mustGetValue(updatedRows.MaybeGet(context.Background(), keyTuples[8])),
 		mustGetValue(mergeRows.MaybeGet(context.Background(), keyTuples[8])))
 
-	addConflict := doltdb.NewConflict(
+	addConflict := conflict.NewConflict(
 		nil,
 		valsToTestTupleWithoutPks([]types.Value{types.String("person thirteen"), types.NullValue}),
 		valsToTestTupleWithoutPks([]types.Value{types.String("person number thirteen"), types.NullValue}),
@@ -440,7 +441,7 @@ func TestMergeCommits(t *testing.T) {
 	assert.NoError(t, err)
 	expected, err = editor.RebuildAllIndexes(context.Background(), expected, editor.TestEditorOptions(vrw))
 	assert.NoError(t, err)
-	conflictSchema := doltdb.NewConflictSchema(sch, sch, sch)
+	conflictSchema := conflict.NewConflictSchema(sch, sch, sch)
 	assert.NoError(t, err)
 	expected, err = expected.SetConflicts(context.Background(), conflictSchema, expectedConflicts)
 	assert.NoError(t, err)

--- a/go/libraries/doltcore/rebase/rebase_tag.go
+++ b/go/libraries/doltcore/rebase/rebase_tag.go
@@ -25,7 +25,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/typed/noms"
 	"github.com/dolthub/dolt/go/libraries/utils/set"
 	ndiff "github.com/dolthub/dolt/go/store/diff"
@@ -351,16 +350,6 @@ func replayCommitWithNewTag(ctx context.Context, root, parentRoot, rebasedParent
 			return nil, err
 		}
 
-		rebasedSchVal, err := encoding.MarshalSchemaAsNomsValue(ctx, rebasedParentRoot.VRW(), rebasedSch)
-
-		if err != nil {
-			return nil, err
-		}
-
-		rsh, _ := rebasedSchVal.Hash(newRoot.VRW().Format())
-		rshs := rsh.String()
-		fmt.Println(rshs)
-
 		emptyMap, err := types.NewMap(ctx, root.VRW()) // migration predates secondary indexes
 		if err != nil {
 			return nil, err
@@ -370,7 +359,7 @@ func replayCommitWithNewTag(ctx context.Context, root, parentRoot, rebasedParent
 		// so we don't need to copy the value here
 		var autoVal types.Value = nil
 
-		rebasedTable, err := doltdb.NewTable(ctx, rebasedParentRoot.VRW(), rebasedSchVal, rebasedRows, emptyMap, autoVal)
+		rebasedTable, err := doltdb.NewTable(ctx, rebasedParentRoot.VRW(), rebasedSch, rebasedRows, emptyMap, autoVal)
 
 		if err != nil {
 			return nil, err

--- a/go/libraries/doltcore/schema/alterschema/addpk.go
+++ b/go/libraries/doltcore/schema/alterschema/addpk.go
@@ -24,7 +24,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
 	"github.com/dolthub/dolt/go/store/types"
 )
@@ -109,18 +108,13 @@ func AddPrimaryKeyToTable(ctx context.Context, table *doltdb.Table, tableName st
 }
 
 func insertKeyedData(ctx context.Context, nbf *types.NomsBinFormat, oldTable *doltdb.Table, newSchema schema.Schema, name string, opts editor.Options) (*doltdb.Table, error) {
-	marshalledSchema, err := encoding.MarshalSchemaAsNomsValue(context.Background(), oldTable.ValueReadWriter(), newSchema)
-	if err != nil {
-		return nil, err
-	}
-
 	empty, err := types.NewMap(ctx, oldTable.ValueReadWriter())
 	if err != nil {
 		return nil, err
 	}
 
 	// Create the new Table and rebuild all the indexes
-	newTable, err := doltdb.NewTable(ctx, oldTable.ValueReadWriter(), marshalledSchema, empty, empty, nil)
+	newTable, err := doltdb.NewTable(ctx, oldTable.ValueReadWriter(), newSchema, empty, empty, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/schema/alterschema/modifycolumn.go
+++ b/go/libraries/doltcore/schema/alterschema/modifycolumn.go
@@ -23,7 +23,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
 	"github.com/dolthub/dolt/go/store/types"
@@ -111,10 +110,6 @@ func validateModifyColumn(ctx context.Context, tbl *doltdb.Table, existingCol sc
 // the data is updated.
 func updateTableWithModifiedColumn(ctx context.Context, tbl *doltdb.Table, oldSch, newSch schema.Schema, oldCol, modifiedCol schema.Column, opts editor.Options) (*doltdb.Table, error) {
 	vrw := tbl.ValueReadWriter()
-	newSchemaVal, err := encoding.MarshalSchemaAsNomsValue(ctx, vrw, newSch)
-	if err != nil {
-		return nil, err
-	}
 
 	rowData, err := tbl.GetRowData(ctx)
 	if err != nil {
@@ -159,7 +154,7 @@ func updateTableWithModifiedColumn(ctx context.Context, tbl *doltdb.Table, oldSc
 			return nil, err
 		}
 	}
-	updatedTable, err := doltdb.NewTable(ctx, vrw, newSchemaVal, rowData, indexData, autoVal)
+	updatedTable, err := doltdb.NewTable(ctx, vrw, newSch, rowData, indexData, autoVal)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/dsess/transactions.go
+++ b/go/libraries/doltcore/sqle/dsess/transactions.go
@@ -294,7 +294,7 @@ func (tx *DoltTransaction) stompConflicts(ctx *sql.Context, mergedRoot *doltdb.R
 		}
 
 		err = tableEditSession.UpdateRoot(ctx, func(ctx context.Context, root *doltdb.RootValue) (*doltdb.RootValue, error) {
-			tbl, err = tbl.ClearConflicts()
+			tbl, err = tbl.ClearConflicts(ctx)
 			if err != nil {
 				return nil, err
 			}

--- a/go/libraries/doltcore/sqle/dtables/history_table.go
+++ b/go/libraries/doltcore/sqle/dtables/history_table.go
@@ -334,15 +334,12 @@ func newRowItrForTableAtCommit(
 		return nil, err
 	}
 
-	schRef, err := tbl.GetSchemaRef()
-	schHash := schRef.TargetHash()
-
+	tblSch, err := tbl.GetSchema(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	tblSch, err := doltdb.RefToSchema(ctx, root.VRW(), schRef)
-
+	schHash, err := tbl.GetSchemaHash(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/dtables/table_of_tables_in_conflict.go
+++ b/go/libraries/doltcore/sqle/dtables/table_of_tables_in_conflict.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/dolthub/go-mysql-server/sql"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/conflict"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 )
 
@@ -59,7 +60,7 @@ type tableInConflict struct {
 	name    string
 	size    uint64
 	done    bool
-	schemas doltdb.ConflictSchema
+	schemas conflict.ConflictSchema
 	//cnfItr types.MapIterator
 }
 

--- a/go/libraries/doltcore/sqle/dtables/table_of_tables_in_conflict.go
+++ b/go/libraries/doltcore/sqle/dtables/table_of_tables_in_conflict.go
@@ -59,7 +59,7 @@ type tableInConflict struct {
 	name    string
 	size    uint64
 	done    bool
-	schemas doltdb.Conflict
+	schemas doltdb.ConflictSchema
 	//cnfItr types.MapIterator
 }
 

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -32,7 +32,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema/alterschema"
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlutil"
@@ -550,16 +549,12 @@ func (t *WritableDoltTable) Truncate(ctx *sql.Context) (int, error) {
 		return 0, err
 	}
 	numOfRows := int(rowData.Len())
-	schVal, err := encoding.MarshalSchemaAsNomsValue(ctx, table.ValueReadWriter(), t.sch)
-	if err != nil {
-		return 0, err
-	}
 	empty, err := types.NewMap(ctx, table.ValueReadWriter())
 	if err != nil {
 		return 0, err
 	}
 	// truncate table resets auto-increment value
-	newTable, err := doltdb.NewTable(ctx, table.ValueReadWriter(), schVal, empty, empty, nil)
+	newTable, err := doltdb.NewTable(ctx, table.ValueReadWriter(), t.sch, empty, empty, nil)
 	if err != nil {
 		return 0, err
 	}

--- a/go/libraries/doltcore/sqle/testdata.go
+++ b/go/libraries/doltcore/sqle/testdata.go
@@ -30,7 +30,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/untyped"
 	"github.com/dolthub/dolt/go/store/types"
@@ -534,16 +533,13 @@ func UpdateTables(t *testing.T, ctx context.Context, root *doltdb.RootValue, tbl
 			require.NoError(t, err)
 		}
 
-		schVal, err := encoding.MarshalSchemaAsNomsValue(ctx, root.VRW(), sch)
-		require.NoError(t, err)
-
 		indexData, err := types.NewMap(ctx, root.VRW())
 		require.NoError(t, err)
 		if tbl != nil {
 			indexData, err = tbl.GetIndexData(ctx)
 			require.NoError(t, err)
 		}
-		tbl, err = doltdb.NewTable(ctx, root.VRW(), schVal, rowData, indexData, nil)
+		tbl, err = doltdb.NewTable(ctx, root.VRW(), sch, rowData, indexData, nil)
 		require.NoError(t, err)
 
 		root, err = root.PutTable(ctx, tblName, tbl)

--- a/go/libraries/doltcore/table/editor/keyless_table_editor_test.go
+++ b/go/libraries/doltcore/table/editor/keyless_table_editor_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
 	"github.com/dolthub/dolt/go/store/types"
 )
 
@@ -41,11 +40,9 @@ func TestKeylessTableEditorConcurrency(t *testing.T) {
 		schema.NewColumn("v2", 2, types.IntKind, false))
 	tableSch, err := schema.SchemaFromCols(colColl)
 	require.NoError(t, err)
-	tableSchVal, err := encoding.MarshalSchemaAsNomsValue(context.Background(), db, tableSch)
-	require.NoError(t, err)
 	emptyMap, err := types.NewMap(context.Background(), db)
 	require.NoError(t, err)
-	table, err := doltdb.NewTable(context.Background(), db, tableSchVal, emptyMap, emptyMap, nil)
+	table, err := doltdb.NewTable(context.Background(), db, tableSch, emptyMap, emptyMap, nil)
 	require.NoError(t, err)
 
 	opts := TestEditorOptions(db)
@@ -151,11 +148,9 @@ func TestKeylessTableEditorConcurrencyPostInsert(t *testing.T) {
 		schema.NewColumn("v2", 2, types.IntKind, false))
 	tableSch, err := schema.SchemaFromCols(colColl)
 	require.NoError(t, err)
-	tableSchVal, err := encoding.MarshalSchemaAsNomsValue(context.Background(), db, tableSch)
-	require.NoError(t, err)
 	emptyMap, err := types.NewMap(context.Background(), db)
 	require.NoError(t, err)
-	table, err := doltdb.NewTable(context.Background(), db, tableSchVal, emptyMap, emptyMap, nil)
+	table, err := doltdb.NewTable(context.Background(), db, tableSch, emptyMap, emptyMap, nil)
 	require.NoError(t, err)
 
 	opts := TestEditorOptions(db)
@@ -260,11 +255,9 @@ func TestKeylessTableEditorWriteAfterFlush(t *testing.T) {
 		schema.NewColumn("v2", 2, types.IntKind, false))
 	tableSch, err := schema.SchemaFromCols(colColl)
 	require.NoError(t, err)
-	tableSchVal, err := encoding.MarshalSchemaAsNomsValue(context.Background(), db, tableSch)
-	require.NoError(t, err)
 	emptyMap, err := types.NewMap(context.Background(), db)
 	require.NoError(t, err)
-	table, err := doltdb.NewTable(context.Background(), db, tableSchVal, emptyMap, emptyMap, nil)
+	table, err := doltdb.NewTable(context.Background(), db, tableSch, emptyMap, emptyMap, nil)
 	require.NoError(t, err)
 
 	opts := TestEditorOptions(db)
@@ -343,11 +336,9 @@ func TestKeylessTableEditorDuplicateKeyHandling(t *testing.T) {
 		schema.NewColumn("v2", 2, types.IntKind, false))
 	tableSch, err := schema.SchemaFromCols(colColl)
 	require.NoError(t, err)
-	tableSchVal, err := encoding.MarshalSchemaAsNomsValue(context.Background(), db, tableSch)
-	require.NoError(t, err)
 	emptyMap, err := types.NewMap(context.Background(), db)
 	require.NoError(t, err)
-	table, err := doltdb.NewTable(context.Background(), db, tableSchVal, emptyMap, emptyMap, nil)
+	table, err := doltdb.NewTable(context.Background(), db, tableSch, emptyMap, emptyMap, nil)
 	require.NoError(t, err)
 
 	opts := TestEditorOptions(db)
@@ -444,11 +435,9 @@ func TestKeylessTableEditorMultipleIndexErrorHandling(t *testing.T) {
 		IsUnique: false,
 	})
 	require.NoError(t, err)
-	tableSchVal, err := encoding.MarshalSchemaAsNomsValue(ctx, db, tableSch)
-	require.NoError(t, err)
 	emptyMap, err := types.NewMap(ctx, db)
 	require.NoError(t, err)
-	table, err := doltdb.NewTable(ctx, db, tableSchVal, emptyMap, emptyMap, nil)
+	table, err := doltdb.NewTable(ctx, db, tableSch, emptyMap, emptyMap, nil)
 	require.NoError(t, err)
 	table, err = RebuildAllIndexes(ctx, table, opts)
 	require.NoError(t, err)
@@ -599,15 +588,9 @@ func TestKeylessTableEditorIndexCardinality(t *testing.T) {
 		IsUnique: false,
 	})
 	require.NoError(t, err)
-	//idxv2, err := tableSch.Indexes().AddIndexByColNames("idx_v2", []string{"v2"}, schema.IndexProperties{
-	//	IsUnique: false,
-	//})
-	//require.NoError(t, err)
-	tableSchVal, err := encoding.MarshalSchemaAsNomsValue(ctx, db, tableSch)
-	require.NoError(t, err)
 	emptyMap, err := types.NewMap(ctx, db)
 	require.NoError(t, err)
-	table, err := doltdb.NewTable(ctx, db, tableSchVal, emptyMap, emptyMap, nil)
+	table, err := doltdb.NewTable(ctx, db, tableSch, emptyMap, emptyMap, nil)
 	require.NoError(t, err)
 	table, err = RebuildAllIndexes(ctx, table, opts)
 	require.NoError(t, err)

--- a/go/libraries/doltcore/table/editor/pk_table_editor.go
+++ b/go/libraries/doltcore/table/editor/pk_table_editor.go
@@ -645,7 +645,7 @@ func (te *pkTableEditor) SetAutoIncrementValue(v types.Value) (err error) {
 
 	te.setDirty(true)
 	te.autoIncVal = v
-	te.t, err = te.t.SetAutoIncrementValue(te.autoIncVal)
+	te.t, err = te.t.SetAutoIncrementValue(nil, te.autoIncVal)
 
 	return err
 }
@@ -658,7 +658,7 @@ func (te *pkTableEditor) Table(ctx context.Context) (*doltdb.Table, error) {
 
 	var err error
 	if te.hasAutoInc {
-		te.t, err = te.t.SetAutoIncrementValue(te.autoIncVal)
+		te.t, err = te.t.SetAutoIncrementValue(nil, te.autoIncVal)
 		if err != nil {
 			return nil, err
 		}

--- a/go/libraries/doltcore/table/editor/pk_table_editor_test.go
+++ b/go/libraries/doltcore/table/editor/pk_table_editor_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
 	"github.com/dolthub/dolt/go/store/types"
 )
 
@@ -52,11 +51,9 @@ func TestTableEditorConcurrency(t *testing.T) {
 		schema.NewColumn("v2", 2, types.IntKind, false))
 	tableSch, err := schema.SchemaFromCols(colColl)
 	require.NoError(t, err)
-	tableSchVal, err := encoding.MarshalSchemaAsNomsValue(context.Background(), db, tableSch)
-	require.NoError(t, err)
 	emptyMap, err := types.NewMap(context.Background(), db)
 	require.NoError(t, err)
-	table, err := doltdb.NewTable(context.Background(), db, tableSchVal, emptyMap, emptyMap, nil)
+	table, err := doltdb.NewTable(context.Background(), db, tableSch, emptyMap, emptyMap, nil)
 	require.NoError(t, err)
 
 	for i := 0; i < tableEditorConcurrencyIterations; i++ {
@@ -149,11 +146,9 @@ func TestTableEditorConcurrencyPostInsert(t *testing.T) {
 		schema.NewColumn("v2", 2, types.IntKind, false))
 	tableSch, err := schema.SchemaFromCols(colColl)
 	require.NoError(t, err)
-	tableSchVal, err := encoding.MarshalSchemaAsNomsValue(context.Background(), db, tableSch)
-	require.NoError(t, err)
 	emptyMap, err := types.NewMap(context.Background(), db)
 	require.NoError(t, err)
-	table, err := doltdb.NewTable(context.Background(), db, tableSchVal, emptyMap, emptyMap, nil)
+	table, err := doltdb.NewTable(context.Background(), db, tableSch, emptyMap, emptyMap, nil)
 	require.NoError(t, err)
 
 	tableEditor, err := newPkTableEditor(context.Background(), table, tableSch, tableName, opts)
@@ -244,11 +239,9 @@ func TestTableEditorWriteAfterFlush(t *testing.T) {
 		schema.NewColumn("v2", 2, types.IntKind, false))
 	tableSch, err := schema.SchemaFromCols(colColl)
 	require.NoError(t, err)
-	tableSchVal, err := encoding.MarshalSchemaAsNomsValue(context.Background(), db, tableSch)
-	require.NoError(t, err)
 	emptyMap, err := types.NewMap(context.Background(), db)
 	require.NoError(t, err)
-	table, err := doltdb.NewTable(context.Background(), db, tableSchVal, emptyMap, emptyMap, nil)
+	table, err := doltdb.NewTable(context.Background(), db, tableSch, emptyMap, emptyMap, nil)
 	require.NoError(t, err)
 
 	tableEditor, err := newPkTableEditor(context.Background(), table, tableSch, tableName, opts)
@@ -316,11 +309,9 @@ func TestTableEditorDuplicateKeyHandling(t *testing.T) {
 		schema.NewColumn("v2", 2, types.IntKind, false))
 	tableSch, err := schema.SchemaFromCols(colColl)
 	require.NoError(t, err)
-	tableSchVal, err := encoding.MarshalSchemaAsNomsValue(context.Background(), db, tableSch)
-	require.NoError(t, err)
 	emptyMap, err := types.NewMap(context.Background(), db)
 	require.NoError(t, err)
-	table, err := doltdb.NewTable(context.Background(), db, tableSchVal, emptyMap, emptyMap, nil)
+	table, err := doltdb.NewTable(context.Background(), db, tableSch, emptyMap, emptyMap, nil)
 	require.NoError(t, err)
 
 	tableEditor, err := newPkTableEditor(context.Background(), table, tableSch, tableName, opts)
@@ -405,11 +396,9 @@ func TestTableEditorMultipleIndexErrorHandling(t *testing.T) {
 		IsUnique: true,
 	})
 	require.NoError(t, err)
-	tableSchVal, err := encoding.MarshalSchemaAsNomsValue(ctx, db, tableSch)
-	require.NoError(t, err)
 	emptyMap, err := types.NewMap(ctx, db)
 	require.NoError(t, err)
-	table, err := doltdb.NewTable(ctx, db, tableSchVal, emptyMap, emptyMap, nil)
+	table, err := doltdb.NewTable(ctx, db, tableSch, emptyMap, emptyMap, nil)
 	require.NoError(t, err)
 	table, err = RebuildAllIndexes(ctx, table, opts)
 	require.NoError(t, err)

--- a/go/libraries/doltcore/table/keyless_reader_test.go
+++ b/go/libraries/doltcore/table/keyless_reader_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	dtu "github.com/dolthub/dolt/go/libraries/doltcore/dtestutils"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table"
 	"github.com/dolthub/dolt/go/store/types"
 )
@@ -116,8 +115,6 @@ func TestKeylessTableReader(t *testing.T) {
 	dEnv := dtu.CreateTestEnv()
 	ctx := context.Background()
 	vrw := dEnv.DoltDB.ValueReadWriter()
-	schVal, err := encoding.MarshalSchemaAsNomsValue(ctx, vrw, sch)
-	require.NoError(t, err)
 	empty := dtu.MustMap(t, vrw)
 
 	compareRows := func(t *testing.T, expected []sql.Row, rdr table.SqlTableReader) {
@@ -134,7 +131,7 @@ func TestKeylessTableReader(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			rowMap := makeBag(vrw, sch, test.rows...)
-			tbl, err := doltdb.NewTable(ctx, vrw, schVal, rowMap, empty, nil)
+			tbl, err := doltdb.NewTable(ctx, vrw, sch, rowMap, empty, nil)
 			require.NoError(t, err)
 			rdr, err := table.NewTableReader(ctx, tbl)
 			require.NoError(t, err)
@@ -142,7 +139,7 @@ func TestKeylessTableReader(t *testing.T) {
 		})
 		t.Run(test.name+"_buffered", func(t *testing.T) {
 			rowMap := makeBag(vrw, sch, test.rows...)
-			tbl, err := doltdb.NewTable(ctx, vrw, schVal, rowMap, empty, nil)
+			tbl, err := doltdb.NewTable(ctx, vrw, sch, rowMap, empty, nil)
 			require.NoError(t, err)
 			rdr, err := table.NewBufferedTableReader(ctx, tbl)
 			require.NoError(t, err)

--- a/go/libraries/doltcore/table/untyped/sqlexport/sqlwriter_test.go
+++ b/go/libraries/doltcore/table/untyped/sqlexport/sqlwriter_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/dtestutils"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema/encoding"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlfmt"
 	"github.com/dolthub/dolt/go/store/types"
 )
@@ -80,15 +79,13 @@ func TestEndToEnd(t *testing.T) {
 			root, err := dEnv.WorkingRoot(ctx)
 			require.NoError(t, err)
 
-			schVal, err := encoding.MarshalSchemaAsNomsValue(ctx, root.VRW(), tt.sch)
-			require.NoError(t, err)
 			empty, err := types.NewMap(ctx, root.VRW())
 			require.NoError(t, err)
 			idxRef, err := types.NewRef(empty, root.VRW().Format())
 			require.NoError(t, err)
 			idxMap, err := types.NewMap(ctx, root.VRW(), types.String(dtestutils.IndexName), idxRef)
 			require.NoError(t, err)
-			tbl, err := doltdb.NewTable(ctx, root.VRW(), schVal, empty, idxMap, nil)
+			tbl, err := doltdb.NewTable(ctx, root.VRW(), tt.sch, empty, idxMap, nil)
 			require.NoError(t, err)
 			root, err = root.PutTable(ctx, tableName, tbl)
 			require.NoError(t, err)


### PR DESCRIPTION
This refactor is the first step in supporting a new storage format. The primary focus of this change is to modify `doltdb.Table` to extract its backing `types.Struct`. 

Throughout the `doltdb` package, in-memory objects are coupled with the persistent `types` objects that are used to de/serialize them to/from disk. The intention of this refactor and subsequent work is to decouple storage details from persistent objects. For example, `schema.Schema` is an in-memory abstraction that has a separate utility in the `encoding` package to read/write schemas to/from disk. This has created a clean separation of concerns for `schema.Schema`, and makes it easy to swap out serialization formats.