### PR TITLE
Fix bug with import update dropping rows

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20201005193433-3ee972b1d078
 	github.com/dolthub/fslock v0.0.3
-	github.com/dolthub/go-mysql-server v0.11.1-0.20220104212114-db9d02cf0b10
+	github.com/dolthub/go-mysql-server v0.11.1-0.20220105235252-5eb0285b73f6
 	github.com/dolthub/ishell v0.0.0-20210205014355-16a4ce758446
 	github.com/dolthub/mmap-go v1.0.4-0.20201107010347-f9f2a9588a66
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81

--- a/go/go.mod
+++ b/go/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20201005193433-3ee972b1d078
 	github.com/dolthub/fslock v0.0.3
-	github.com/dolthub/go-mysql-server v0.11.1-0.20220103192829-bdff166f70e6
+	github.com/dolthub/go-mysql-server v0.11.1-0.20220104212114-db9d02cf0b10
 	github.com/dolthub/ishell v0.0.0-20210205014355-16a4ce758446
 	github.com/dolthub/mmap-go v1.0.4-0.20201107010347-f9f2a9588a66
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81

--- a/go/go.sum
+++ b/go/go.sum
@@ -175,8 +175,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dolthub/fslock v0.0.3 h1:iLMpUIvJKMKm92+N1fmHVdxJP5NdyDK5bK7z7Ba2s2U=
 github.com/dolthub/fslock v0.0.3/go.mod h1:QWql+P17oAAMLnL4HGB5tiovtDuAjdDTPbuqx7bYfa0=
-github.com/dolthub/go-mysql-server v0.11.1-0.20220104212114-db9d02cf0b10 h1:uOb44Ies+iJRkBKfQysgsSyD4v2mXcarXh5v9xd1x7U=
-github.com/dolthub/go-mysql-server v0.11.1-0.20220104212114-db9d02cf0b10/go.mod h1:oHCr0dEOZtZ8MzaGv5OvyODL6/tNGwmcVKswNQEmL/M=
+github.com/dolthub/go-mysql-server v0.11.1-0.20220105235252-5eb0285b73f6 h1:BE2pSI+ACQDnidmRV7hIld5FQqOpGn8aKldLvJ2mRy8=
+github.com/dolthub/go-mysql-server v0.11.1-0.20220105235252-5eb0285b73f6/go.mod h1:tyrWU1vUzj/ilniOAefGJquvOpHNSrFSUHVWJqlSIFc=
 github.com/dolthub/ishell v0.0.0-20210205014355-16a4ce758446 h1:0ol5pj+QlKUKAtqs1LiPM3ZJKs+rHPgLSsMXmhTrCAM=
 github.com/dolthub/ishell v0.0.0-20210205014355-16a4ce758446/go.mod h1:dhGBqcCEfK5kuFmeO5+WOx3hqc1k3M29c1oS/R7N4ms=
 github.com/dolthub/jsonpath v0.0.0-20210609232853-d49537a30474 h1:xTrR+l5l+1Lfq0NvhiEsctylXinUMFhhsqaEcl414p8=

--- a/go/go.sum
+++ b/go/go.sum
@@ -175,8 +175,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dolthub/fslock v0.0.3 h1:iLMpUIvJKMKm92+N1fmHVdxJP5NdyDK5bK7z7Ba2s2U=
 github.com/dolthub/fslock v0.0.3/go.mod h1:QWql+P17oAAMLnL4HGB5tiovtDuAjdDTPbuqx7bYfa0=
-github.com/dolthub/go-mysql-server v0.11.1-0.20220103192829-bdff166f70e6 h1:BFH+3wESDAYy1tP1+5uVDRJDhl+WYSUtVdD+GhGohXo=
-github.com/dolthub/go-mysql-server v0.11.1-0.20220103192829-bdff166f70e6/go.mod h1:tyrWU1vUzj/ilniOAefGJquvOpHNSrFSUHVWJqlSIFc=
+github.com/dolthub/go-mysql-server v0.11.1-0.20220104212114-db9d02cf0b10 h1:uOb44Ies+iJRkBKfQysgsSyD4v2mXcarXh5v9xd1x7U=
+github.com/dolthub/go-mysql-server v0.11.1-0.20220104212114-db9d02cf0b10/go.mod h1:oHCr0dEOZtZ8MzaGv5OvyODL6/tNGwmcVKswNQEmL/M=
 github.com/dolthub/ishell v0.0.0-20210205014355-16a4ce758446 h1:0ol5pj+QlKUKAtqs1LiPM3ZJKs+rHPgLSsMXmhTrCAM=
 github.com/dolthub/ishell v0.0.0-20210205014355-16a4ce758446/go.mod h1:dhGBqcCEfK5kuFmeO5+WOx3hqc1k3M29c1oS/R7N4ms=
 github.com/dolthub/jsonpath v0.0.0-20210609232853-d49537a30474 h1:xTrR+l5l+1Lfq0NvhiEsctylXinUMFhhsqaEcl414p8=

--- a/integration-tests/bats/import-update-tables.bats
+++ b/integration-tests/bats/import-update-tables.bats
@@ -387,8 +387,8 @@ DELIM
     [[ "$output" =~ "Import completed successfully." ]] || false
 
     run dolt sql -r csv -q "select * from t"
-    [[ "$output" =~ "1,a" ]] || false
-    [[ "$output" =~ "2,b" ]] || false
+    [[ "${lines[1]}" = "1,a" ]] || false
+    [[ "${lines[2]}" = "2,b" ]] || false
 
     run dolt table import -u --continue t file2.csv
     [ "$status" -eq 0 ]
@@ -398,9 +398,9 @@ DELIM
     ! [[ "$output" =~ "The following rows were skipped:" ]] || false
 
     run dolt sql -r csv -q "select * from t"
-    [[ "$output" =~ "1,c" ]] || false
-    [[ "$output" =~ "2,g" ]] || false
-    [[ "$output" =~ "3,v" ]] || false
+    [[ "${lines[1]}" = "1,c" ]] || false
+    [[ "${lines[2]}" = "2,g" ]] || false
+    [[ "${lines[3]}" = "3,v" ]] || false
 
     run dolt table import -u --continue t file3.csv
     [ "$status" -eq 0 ]
@@ -409,11 +409,11 @@ DELIM
     ! [[ "$output" =~ "The following rows were skipped:" ]] || false
 
     run dolt sql -r csv -q "select * from t"
-    [[ "$output" =~ "0,d" ]] || false
-    [[ "$output" =~ "1,d" ]] || false
-    [[ "$output" =~ "2,g" ]] || false
-    [[ "$output" =~ "3,v" ]] || false
-    [[ "$output" =~ "4,f" ]] || false
+    [[ "${lines[1]}" = "0,d" ]] || false
+    [[ "${lines[2]}" = "1,d" ]] || false
+    [[ "${lines[3]}" = "2,g" ]] || false
+    [[ "${lines[4]}" = "3,v" ]] || false
+    [[ "${lines[5]}" = "4,f" ]] || false
 
     run dolt sql -q "select count(*) from t"
     [[ "$output" =~ "5" ]] || false

--- a/integration-tests/bats/import-update-tables.bats
+++ b/integration-tests/bats/import-update-tables.bats
@@ -387,8 +387,8 @@ DELIM
     [[ "$output" =~ "Import completed successfully." ]] || false
 
     run dolt sql -r csv -q "select * from t"
-    [[ "${lines[1]}" = "1,a" ]] || false
-    [[ "${lines[2]}" = "2,b" ]] || false
+    [ "${lines[1]}" = "1,a" ]
+    [ "${lines[2]}" = "2,b" ]
 
     run dolt table import -u --continue t file2.csv
     [ "$status" -eq 0 ]
@@ -398,9 +398,9 @@ DELIM
     ! [[ "$output" =~ "The following rows were skipped:" ]] || false
 
     run dolt sql -r csv -q "select * from t"
-    [[ "${lines[1]}" = "1,c" ]] || false
-    [[ "${lines[2]}" = "2,g" ]] || false
-    [[ "${lines[3]}" = "3,v" ]] || false
+    [ "${lines[1]}" = "1,c" ]
+    [ "${lines[2]}" = "2,g" ]
+    [ "${lines[3]}" = "3,v" ]
 
     run dolt table import -u --continue t file3.csv
     [ "$status" -eq 0 ]
@@ -408,12 +408,12 @@ DELIM
     [[ "$output" =~ "Import completed successfully." ]] || false
     ! [[ "$output" =~ "The following rows were skipped:" ]] || false
 
-    run dolt sql -r csv -q "select * from t"
-    [[ "${lines[1]}" = "0,d" ]] || false
-    [[ "${lines[2]}" = "1,d" ]] || false
-    [[ "${lines[3]}" = "2,g" ]] || false
-    [[ "${lines[4]}" = "3,v" ]] || false
-    [[ "${lines[5]}" = "4,f" ]] || false
+    run dolt sql -r csv -q "select * from t order by pk"
+    [ "${lines[1]}" = "0,d" ]
+    [ "${lines[2]}" = "1,d" ]
+    [ "${lines[3]}" = "2,g" ]
+    [ "${lines[4]}" = "3,v" ]
+    [ "${lines[5]}" = "4,f" ]
 
     run dolt sql -q "select count(*) from t"
     [[ "$output" =~ "5" ]] || false


### PR DESCRIPTION
This PR addresses a customer issue where --update,--continue on a table import were dropping rows. The error comes from the facts that INSERT IGNORE semantics were not correctly handling issues with data conversions (type conversions, string lengths, etc.)