### PR TITLE
sql-server: Fix regression: Respect autocommit config.

### DIFF
--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -115,7 +115,7 @@ func NewSqlEngine(
 	return &SqlEngine{
 		dbs:            nameToDB,
 		contextFactory: newSqlContext(sess, initialDb),
-		dsessFactory:   newDoltSession(pro, mrEnv.Config()),
+		dsessFactory:   newDoltSession(pro, mrEnv.Config(), autocommit),
 		engine:         engine,
 		resultFormat:   format,
 	}, nil
@@ -256,7 +256,7 @@ func newSqlContext(sess *dsess.DoltSession, initialDb string) func(ctx context.C
 	}
 }
 
-func newDoltSession(pro dsqle.DoltDatabaseProvider, config config.ReadWriteConfig) func(ctx context.Context, mysqlSess *sql.BaseSession, dbs []sql.Database) (*dsess.DoltSession, error) {
+func newDoltSession(pro dsqle.DoltDatabaseProvider, config config.ReadWriteConfig, autocommit bool) func(ctx context.Context, mysqlSess *sql.BaseSession, dbs []sql.Database) (*dsess.DoltSession, error) {
 	return func(ctx context.Context, mysqlSess *sql.BaseSession, dbs []sql.Database) (*dsess.DoltSession, error) {
 		ddbs := dsqle.DbsAsDSQLDBs(dbs)
 		states, err := getDbStates(ctx, ddbs)
@@ -270,7 +270,7 @@ func newDoltSession(pro dsqle.DoltDatabaseProvider, config config.ReadWriteConfi
 		}
 
 		// TODO: this should just be the session default like it is with MySQL
-		err = dsess.SetSessionVariable(sql.NewContext(ctx), sql.AutoCommitSessionVar, true)
+		err = dsess.SetSessionVariable(sql.NewContext(ctx), sql.AutoCommitSessionVar, autocommit)
 		if err != nil {
 			return nil, err
 		}

--- a/integration-tests/bats/sql-server-mysql.expect
+++ b/integration-tests/bats/sql-server-mysql.expect
@@ -42,7 +42,12 @@ expect {
   failed { exit 1; }
 }
 expect {
-  "*4*" { send "exit\r"; }
+  "*4*" { send "select @@autocommit;\r"; }
+  timeout { exit 1; }
+  failed { exit 1; }
+}
+expect {
+  "*0 |*" { send "exit\r"; }
   timeout { exit 1; }
   failed { exit 1; }
 }

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -1419,6 +1419,9 @@ databases:
 
 @test "sql-server: run mysql from shell" {
     skiponwindows "Has dependencies that are not installed on Windows CI"
+    if [[ `uname` == 'Darwin' ]]; then
+      skip "Unsupported in MacOS CI"
+    fi
 
     cd repo1
     dolt sql -q "create table r1t_one (id1 int primary key, col1 varchar(20));"

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -1418,7 +1418,7 @@ databases:
 }
 
 @test "sql-server: run mysql from shell" {
-    skip "test mysql client from shell fails after v0.34.9"
+    skiponwindows "Has dependencies that are not installed on Windows CI"
 
     cd repo1
     dolt sql -q "create table r1t_one (id1 int primary key, col1 varchar(20));"
@@ -1434,8 +1434,7 @@ databases:
     dolt commit -am "create three tables"
 
     cd ..
-    start_sql_server
-    # server_query "repo1" 1 "show databases" "Database\ninformation_schema\nrepo1\nrepo2"
+    start_sql_server_with_args --user dolt -ltrace --no-auto-commit
 
     run expect $BATS_TEST_DIRNAME/sql-server-mysql.expect $PORT repo1
     [ "$status" -eq 0 ]


### PR DESCRIPTION
In the migration to *SqlEngine in 0.34.4 to 0.34.5, the server config's respect
for the default value for autocommit regressed. In 0.34.5 - 0.35.3,
`autocommit` is always turned on by default for incoming connections,
regardless of the setting in the config.yaml file or the flag
`--no-auto-commit` being passed at the command line.