### PR TITLE
store/type: fix dropped test errors

### DIFF
--- a/go/store/types/edits/disk_edit_flusher_test.go
+++ b/go/store/types/edits/disk_edit_flusher_test.go
@@ -58,6 +58,7 @@ func TestEditFlusher(t *testing.T) {
 	for i := 0; i < numEditors; i++ {
 		require.Equal(t, uint64(i), eps[i].ID)
 		kvp, err := eps[i].Edits.Next()
+		require.NoError(t, err)
 		key, err := kvp.Key.Value(ctx)
 		require.NoError(t, err)
 		keyTuplvals, err := key.(types.Tuple).AsSlice()

--- a/go/store/types/map_test.go
+++ b/go/store/types/map_test.go
@@ -665,6 +665,7 @@ func TestMapHas(t *testing.T) {
 		ref, err := vrw.WriteValue(context.Background(), m)
 		require.NoError(t, err)
 		mval2, err := vrw.ReadValue(context.Background(), ref.TargetHash())
+		require.NoError(t, err)
 		m2 := mval2.(Map)
 		for _, entry := range tm.entries.entries {
 			k, v := entry.key, entry.value


### PR DESCRIPTION
This fixes dropped test errors in `store/type` and its subpackage `edits`.