### PR TITLE
Fixed bug with unresolved foreign keys being resolved in transactions

### DIFF
--- a/go/libraries/doltcore/merge/merge_schema.go
+++ b/go/libraries/doltcore/merge/merge_schema.go
@@ -143,22 +143,29 @@ func ForeignKeysMerge(ctx context.Context, mergedRoot, ourRoot, theirRoot, ancRo
 		return nil, nil, err
 	}
 
+	ancSchs, err := ancRoot.GetAllSchemas(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	common, conflicts, err := foreignKeysInCommon(ours, theirs, anc)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	ourNewFKs, err := fkCollSetDifference(ours, anc)
+	ourNewFKs, err := fkCollSetDifference(ours, anc, ancSchs)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	theirNewFKs, err := fkCollSetDifference(theirs, anc)
+	theirNewFKs, err := fkCollSetDifference(theirs, anc, ancSchs)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// check for conflicts between foreign keys added on each branch since the ancestor
+	//TODO: figure out the best way to handle unresolved foreign keys here if one branch added an unresolved one and
+	// another branch added the same one but resolved
 	_ = ourNewFKs.Iter(func(ourFK doltdb.ForeignKey) (stop bool, err error) {
 		theirFK, ok := theirNewFKs.GetByTags(ourFK.TableColumns, ourFK.ReferencedTableColumns)
 		if ok && !ourFK.DeepEquals(theirFK) {
@@ -316,7 +323,8 @@ func mergeIndexes(mergedCC *schema.ColCollection, ourSch, theirSch, ancSch schem
 	// check for conflicts between indexes added on each branch since the ancestor
 	_ = ourNewIdxs.Iter(func(ourIdx schema.Index) (stop bool, err error) {
 		theirIdx, ok := theirNewIdxs.GetByNameCaseInsensitive(ourIdx.Name())
-		if ok {
+		// If both indexes are exactly equal then there isn't a conflict
+		if ok && !ourIdx.DeepEquals(theirIdx) {
 			conflicts = append(conflicts, IdxConflict{
 				Kind:   NameCollision,
 				Ours:   ourIdx,
@@ -497,10 +505,13 @@ func foreignKeysInCommon(ourFKs, theirFKs, ancFKs *doltdb.ForeignKeyCollection) 
 	return common, conflicts, nil
 }
 
-func fkCollSetDifference(left, right *doltdb.ForeignKeyCollection) (d *doltdb.ForeignKeyCollection, err error) {
+// fkCollSetDifference returns a collection of all foreign keys that are in the given collection but not the ancestor
+// collection. This is specifically for finding differences between a descendant and an ancestor, and therefore should
+// not be used in the general case.
+func fkCollSetDifference(fkColl, ancestorFkColl *doltdb.ForeignKeyCollection, ancSchs map[string]schema.Schema) (d *doltdb.ForeignKeyCollection, err error) {
 	d, _ = doltdb.NewForeignKeyCollection()
-	err = left.Iter(func(fk doltdb.ForeignKey) (stop bool, err error) {
-		_, ok := right.GetByTags(fk.TableColumns, fk.ReferencedTableColumns)
+	err = fkColl.Iter(func(fk doltdb.ForeignKey) (stop bool, err error) {
+		_, ok := ancestorFkColl.GetMatchingKey(fk, ancSchs)
 		if !ok {
 			err = d.AddKeys(fk)
 		}


### PR DESCRIPTION
The logic that handled foreign key merging during transaction commits did not take unresolved foreign keys into consideration, therefore errors were produced. This fixes that bug.