### PR TITLE
store/datas: fix dropped error

### DIFF
--- a/go/store/datas/database_common.go
+++ b/go/store/datas/database_common.go
@@ -192,6 +192,9 @@ func getParentsClosure(ctx context.Context, vrw types.ValueReadWriter, parentRef
 			}
 		}
 		v, ok, err = p.MaybeGet(ParentsListField)
+		if err != nil {
+			return types.Ref{}, false, err
+		}
 		if !ok || types.IsNull(v) {
 			empty, err := types.NewList(ctx, vrw)
 			if err != nil {


### PR DESCRIPTION
This fixes a dropped `err` variable in the `store/datas` package.