### PR TITLE
dump_docs.go now includes verifyConstraintsDocs

### DIFF
--- a/go/cmd/dolt/commands/cvcmds/verify_constraints.go
+++ b/go/cmd/dolt/commands/cvcmds/verify_constraints.go
@@ -58,7 +58,8 @@ func (cmd VerifyConstraintsCmd) Description() string {
 }
 
 func (cmd VerifyConstraintsCmd) CreateMarkdown(wr io.Writer, commandStr string) error {
-	return nil
+	ap := cmd.ArgParser()
+	return commands.CreateMarkdown(wr, cli.GetCommandDocumentation(commandStr, verifyConstraintsDocs, ap))
 }
 
 func (cmd VerifyConstraintsCmd) ArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/dump_docs.go
+++ b/go/cmd/dolt/commands/dump_docs.go
@@ -34,7 +34,7 @@ type DumpDocsCmd struct {
 	DoltCommand cli.SubCommandHandler
 }
 
-// Name is returns the name of the Dolt cli command. This is what is used on the command line to invoke the command
+// Name returns the name of the Dolt cli command. This is what is used on the command line to invoke the command
 func (cmd *DumpDocsCmd) Name() string {
 	return "dump-docs"
 }


### PR DESCRIPTION
`dump_docs` doesn't dump the docs for `verify constraints`, which means they're not visible in the online documentation. Hopefully this fixes that.

After building I checked that it worked locally and seemed to produce the right output.

Context: this is my first PR and my first time editing go code. Entering the great unknown here.  :-)