### PR TITLE
std out and err redirects

### DIFF
--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -134,8 +134,7 @@ func runMain() int {
 	if len(args) > 0 {
 		var doneDebugFlags bool
 		for !doneDebugFlags {
-			current := args[0]
-			switch current {
+			switch args[0] {
 			case profFlag:
 				switch args[1] {
 				case cpuProf:
@@ -240,7 +239,7 @@ func runMain() int {
 					return 1
 				}
 
-				switch current {
+				switch args[0] {
 				case stdOutFlag:
 					cli.Println("Stdout being written to", filename)
 					os.Stdout = f

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -133,7 +133,7 @@ func runMain() int {
 	csMetrics := false
 	if len(args) > 0 {
 		var doneDebugFlags bool
-		for !doneDebugFlags {
+		for !doneDebugFlags && len(args) > 0 {
 			switch args[0] {
 			case profFlag:
 				switch args[1] {
@@ -242,16 +242,17 @@ func runMain() int {
 				switch args[0] {
 				case stdOutFlag:
 					cli.Println("Stdout being written to", filename)
-					os.Stdout = f
+					cli.CliOut = f
 				case stdErrFlag:
 					cli.Println("Stderr being written to", filename)
-					os.Stderr = f
+					cli.CliErr = f
 				case stdOutAndErrFlag:
 					cli.Println("Stdout and Stderr being written to", filename)
-					os.Stdout = f
-					os.Stderr = f
+					cli.CliOut = f
+					cli.CliErr = f
 				}
 
+				color.NoColor = true
 				args = args[2:]
 
 			case csMetricsFlag:


### PR DESCRIPTION
Allow for stdout and stderr to be redirected to a file via a command line argument.  When running outside of a terminal window it can be really inconvenient to redirect io.  These parameters were added to make that easier.