### PR TITLE
Removed Parse from typeinfo, some type conversion fixes

### DIFF
--- a/go/cmd/dolt/commands/select_where.go
+++ b/go/cmd/dolt/commands/select_where.go
@@ -75,7 +75,7 @@ func ParseWhere(sch schema.Schema, whereClause string) (FilterFn, error) {
 		} else {
 			var err error
 			vrw := types.NewMemoryValueStore() // We don't want to persist anything, so we use an internal VRW
-			val, err = cols[0].TypeInfo.ParseValue(context.Background(), vrw, &valStr)
+			val, err = typeinfo.StringDefaultType.ConvertToType(context.Background(), vrw, cols[0].TypeInfo, types.String(valStr))
 			if err != nil {
 				return nil, errors.New("unable to convert '" + valStr + "' to " + col.TypeInfo.String())
 			}

--- a/go/libraries/doltcore/env/actions/infer_schema.go
+++ b/go/libraries/doltcore/env/actions/infer_schema.go
@@ -243,7 +243,7 @@ func leastPermissiveChronoType(strVal string) typeinfo.TypeInfo {
 		return typeinfo.UnknownType
 	}
 
-	dt, err := typeinfo.DatetimeType.ParseValue(context.Background(), nil, &strVal)
+	dt, err := typeinfo.StringDefaultType.ConvertToType(context.Background(), nil, typeinfo.DatetimeType, types.String(strVal))
 	if err == nil {
 		t := time.Time(dt.(types.Timestamp))
 		if t.Hour() == 0 && t.Minute() == 0 && t.Second() == 0 {
@@ -253,7 +253,7 @@ func leastPermissiveChronoType(strVal string) typeinfo.TypeInfo {
 		return typeinfo.DatetimeType
 	}
 
-	_, err = typeinfo.TimeType.ParseValue(context.Background(), nil, &strVal)
+	_, err = typeinfo.StringDefaultType.ConvertToType(context.Background(), nil, typeinfo.TimeType, types.String(strVal))
 	if err == nil {
 		return typeinfo.TimeType
 	}

--- a/go/libraries/doltcore/rowconv/row_converter.go
+++ b/go/libraries/doltcore/rowconv/row_converter.go
@@ -56,26 +56,12 @@ func NewRowConverter(ctx context.Context, vrw types.ValueReadWriter, mapping *Fi
 			return nil, fmt.Errorf("Could not find column being mapped. src tag: %d, dest tag: %d", srcTag, destTag)
 		}
 
-		if srcCol.TypeInfo.Equals(destCol.TypeInfo) {
-			convFuncs[srcTag] = func(v types.Value) (types.Value, error) {
-				return v, nil
-			}
+		tc, _, err := typeinfo.GetTypeConverter(ctx, srcCol.TypeInfo, destCol.TypeInfo)
+		if err != nil {
+			return nil, err
 		}
-		if typeinfo.IsStringType(destCol.TypeInfo) {
-			convFuncs[srcTag] = func(v types.Value) (types.Value, error) {
-				val, err := srcCol.TypeInfo.FormatValue(v)
-				if err != nil {
-					return nil, err
-				}
-				if val == nil {
-					return types.NullValue, nil
-				}
-				return types.String(*val), nil
-			}
-		} else {
-			convFuncs[srcTag] = func(v types.Value) (types.Value, error) {
-				return typeinfo.Convert(ctx, vrw, v, srcCol.TypeInfo, destCol.TypeInfo)
-			}
+		convFuncs[srcTag] = func(v types.Value) (types.Value, error) {
+			return tc(ctx, vrw, v)
 		}
 	}
 

--- a/go/libraries/doltcore/schema/typeinfo/bit.go
+++ b/go/libraries/doltcore/schema/typeinfo/bit.go
@@ -160,30 +160,6 @@ func (ti *bitType) NomsKind() types.NomsKind {
 	return types.UintKind
 }
 
-// ParseValue implements TypeInfo interface.
-func (ti *bitType) ParseValue(ctx context.Context, vrw types.ValueReadWriter, str *string) (types.Value, error) {
-	if str == nil || *str == "" {
-		return types.NullValue, nil
-	}
-	if val, err := strconv.ParseUint(*str, 10, 64); err == nil {
-		uintVal, err := ti.sqlBitType.Convert(val)
-		if err != nil {
-			return nil, err
-		}
-		if val, ok := uintVal.(uint64); ok {
-			return types.Uint(val), nil
-		}
-	}
-	strVal, err := ti.sqlBitType.Convert(*str)
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := strVal.(uint64); ok {
-		return types.Uint(val), nil
-	}
-	return nil, fmt.Errorf(`"%v" cannot convert the string "%v" to a value`, ti.String(), str)
-}
-
 // Promote implements TypeInfo interface.
 func (ti *bitType) Promote() TypeInfo {
 	return &bitType{ti.sqlBitType.Promote().(sql.BitType)}

--- a/go/libraries/doltcore/schema/typeinfo/bit_test.go
+++ b/go/libraries/doltcore/schema/typeinfo/bit_test.go
@@ -200,7 +200,8 @@ func TestBitParseValue(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf(`%v %v`, test.typ.String(), test.input), func(t *testing.T) {
-			output, err := test.typ.ParseValue(context.Background(), nil, &test.input)
+			vrw := types.NewMemoryValueStore()
+			output, err := StringDefaultType.ConvertToType(context.Background(), vrw, test.typ, types.String(test.input))
 			if !test.expectedErr {
 				require.NoError(t, err)
 				assert.Equal(t, test.output, output)

--- a/go/libraries/doltcore/schema/typeinfo/blobstring_test.go
+++ b/go/libraries/doltcore/schema/typeinfo/blobstring_test.go
@@ -184,7 +184,7 @@ func TestBlobStringParseValue(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf(`%v %v`, test.typ.String(), test.input), func(t *testing.T) {
 			vrw := types.NewMemoryValueStore()
-			output, err := test.typ.ParseValue(context.Background(), vrw, &test.input)
+			output, err := StringDefaultType.ConvertToType(context.Background(), vrw, test.typ, types.String(test.input))
 			if !test.expectedErr {
 				require.NoError(t, err)
 				assert.Equal(t, test.output, output)

--- a/go/libraries/doltcore/schema/typeinfo/bool.go
+++ b/go/libraries/doltcore/schema/typeinfo/bool.go
@@ -161,14 +161,6 @@ func (ti *boolType) NomsKind() types.NomsKind {
 	return types.BoolKind
 }
 
-// ParseValue implements TypeInfo interface.
-func (ti *boolType) ParseValue(ctx context.Context, vrw types.ValueReadWriter, str *string) (types.Value, error) {
-	if str == nil || *str == "" {
-		return types.NullValue, nil
-	}
-	return ti.ConvertValueToNomsValue(context.Background(), nil, *str)
-}
-
 // Promote implements TypeInfo interface.
 func (ti *boolType) Promote() TypeInfo {
 	return ti
@@ -200,7 +192,19 @@ func boolTypeConverter(ctx context.Context, src *boolType, destTi TypeInfo) (tc 
 			}
 		}, true, nil
 	case *blobStringType:
-		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+		return func(ctx context.Context, vrw types.ValueReadWriter, v types.Value) (types.Value, error) {
+			if v == nil || v == types.NullValue {
+				return types.NullValue, nil
+			}
+			val := v.(types.Bool)
+			var newVal int
+			if val {
+				newVal = 1
+			} else {
+				newVal = 0
+			}
+			return dest.ConvertValueToNomsValue(ctx, vrw, newVal)
+		}, true, nil
 	case *boolType:
 		return identityTypeConverter, false, nil
 	case *datetimeType:
@@ -212,7 +216,19 @@ func boolTypeConverter(ctx context.Context, src *boolType, destTi TypeInfo) (tc 
 	case *floatType:
 		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
 	case *inlineBlobType:
-		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+		return func(ctx context.Context, vrw types.ValueReadWriter, v types.Value) (types.Value, error) {
+			if v == nil || v == types.NullValue {
+				return types.NullValue, nil
+			}
+			val := v.(types.Bool)
+			var newVal int
+			if val {
+				newVal = 1
+			} else {
+				newVal = 0
+			}
+			return dest.ConvertValueToNomsValue(ctx, vrw, newVal)
+		}, true, nil
 	case *jsonType:
 		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
 	case *intType:
@@ -226,9 +242,33 @@ func boolTypeConverter(ctx context.Context, src *boolType, destTi TypeInfo) (tc 
 	case *uuidType:
 		return nil, false, IncompatibleTypeConversion.New(src.String(), destTi.String())
 	case *varBinaryType:
-		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+		return func(ctx context.Context, vrw types.ValueReadWriter, v types.Value) (types.Value, error) {
+			if v == nil || v == types.NullValue {
+				return types.NullValue, nil
+			}
+			val := v.(types.Bool)
+			var newVal int
+			if val {
+				newVal = 1
+			} else {
+				newVal = 0
+			}
+			return dest.ConvertValueToNomsValue(ctx, vrw, newVal)
+		}, true, nil
 	case *varStringType:
-		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
+		return func(ctx context.Context, vrw types.ValueReadWriter, v types.Value) (types.Value, error) {
+			if v == nil || v == types.NullValue {
+				return types.NullValue, nil
+			}
+			val := v.(types.Bool)
+			var newVal int
+			if val {
+				newVal = 1
+			} else {
+				newVal = 0
+			}
+			return dest.ConvertValueToNomsValue(ctx, vrw, newVal)
+		}, true, nil
 	case *yearType:
 		return wrapConvertValueToNomsValue(dest.ConvertValueToNomsValue)
 	default:

--- a/go/libraries/doltcore/schema/typeinfo/bool_test.go
+++ b/go/libraries/doltcore/schema/typeinfo/bool_test.go
@@ -170,7 +170,8 @@ func TestBoolParseValue(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf(`%v %v`, BoolType.String(), test.input), func(t *testing.T) {
-			output, err := BoolType.ParseValue(context.Background(), nil, &test.input)
+			vrw := types.NewMemoryValueStore()
+			output, err := StringDefaultType.ConvertToType(context.Background(), vrw, BoolType, types.String(test.input))
 			if !test.expectedErr {
 				require.NoError(t, err)
 				assert.Equal(t, test.output, output)

--- a/go/libraries/doltcore/schema/typeinfo/datetime.go
+++ b/go/libraries/doltcore/schema/typeinfo/datetime.go
@@ -187,21 +187,6 @@ func (ti *datetimeType) NomsKind() types.NomsKind {
 	return types.TimestampKind
 }
 
-// ParseValue implements TypeInfo interface.
-func (ti *datetimeType) ParseValue(ctx context.Context, vrw types.ValueReadWriter, str *string) (types.Value, error) {
-	if str == nil || *str == "" {
-		return types.NullValue, nil
-	}
-	strVal, err := ti.sqlDatetimeType.Convert(*str)
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := strVal.(time.Time); ok {
-		return types.Timestamp(val), nil
-	}
-	return nil, fmt.Errorf(`"%v" cannot convert the string "%v" to a value`, ti.String(), str)
-}
-
 // Promote implements TypeInfo interface.
 func (ti *datetimeType) Promote() TypeInfo {
 	return &datetimeType{ti.sqlDatetimeType.Promote().(sql.DatetimeType)}

--- a/go/libraries/doltcore/schema/typeinfo/datetime_test.go
+++ b/go/libraries/doltcore/schema/typeinfo/datetime_test.go
@@ -177,7 +177,7 @@ func TestDatetimeFormatValue(t *testing.T) {
 	}
 }
 
-func TestDatetimeParseValue(t *testing.T) {
+func TestDatetimeConversion(t *testing.T) {
 	tests := []struct {
 		typ         *datetimeType
 		input       string
@@ -238,7 +238,7 @@ func TestDatetimeParseValue(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf(`%v %v`, test.typ.String(), test.input), func(t *testing.T) {
 			vrw := types.NewMemoryValueStore()
-			output, err := test.typ.ParseValue(context.Background(), vrw, &test.input)
+			output, err := StringDefaultType.ConvertToType(context.Background(), vrw, test.typ, types.String(test.input))
 			if !test.expectedErr {
 				require.NoError(t, err)
 				assert.Equal(t, test.output, output)

--- a/go/libraries/doltcore/schema/typeinfo/decimal.go
+++ b/go/libraries/doltcore/schema/typeinfo/decimal.go
@@ -172,14 +172,6 @@ func (ti *decimalType) NomsKind() types.NomsKind {
 	return types.DecimalKind
 }
 
-// ParseValue implements TypeInfo interface.
-func (ti *decimalType) ParseValue(ctx context.Context, vrw types.ValueReadWriter, str *string) (types.Value, error) {
-	if str == nil || *str == "" {
-		return types.NullValue, nil
-	}
-	return ti.ConvertValueToNomsValue(context.Background(), nil, *str)
-}
-
 // Promote implements TypeInfo interface.
 func (ti *decimalType) Promote() TypeInfo {
 	return &decimalType{ti.sqlDecimalType.Promote().(sql.DecimalType)}

--- a/go/libraries/doltcore/schema/typeinfo/decimal_test.go
+++ b/go/libraries/doltcore/schema/typeinfo/decimal_test.go
@@ -264,7 +264,7 @@ func TestDecimalParseValue(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf(`%v %v`, test.typ.String(), test.input), func(t *testing.T) {
 			vrw := types.NewMemoryValueStore()
-			output, err := test.typ.ParseValue(context.Background(), vrw, &test.input)
+			output, err := StringDefaultType.ConvertToType(context.Background(), vrw, test.typ, types.String(test.input))
 			if !test.expectedErr {
 				require.NoError(t, err)
 				assert.True(t, test.output.Equals(output))
@@ -560,7 +560,7 @@ func TestDecimalRoundTrip(t *testing.T) {
 				output, err := test.typ.ConvertNomsValueToValue(parsed)
 				require.NoError(t, err)
 				assert.Equal(t, test.output, output)
-				parsed2, err := test.typ.ParseValue(context.Background(), vrw, &test.input)
+				parsed2, err := StringDefaultType.ConvertToType(context.Background(), vrw, test.typ, types.String(test.input))
 				require.NoError(t, err)
 				assert.Equal(t, parsed, parsed2)
 				output2, err := test.typ.FormatValue(parsed2)
@@ -568,7 +568,7 @@ func TestDecimalRoundTrip(t *testing.T) {
 				assert.Equal(t, test.output, *output2)
 			} else {
 				assert.Error(t, err)
-				_, err = test.typ.ParseValue(context.Background(), vrw, &test.input)
+				_, err = StringDefaultType.ConvertToType(context.Background(), vrw, test.typ, types.String(test.input))
 				assert.Error(t, err)
 			}
 		})

--- a/go/libraries/doltcore/schema/typeinfo/enum.go
+++ b/go/libraries/doltcore/schema/typeinfo/enum.go
@@ -192,18 +192,6 @@ func (ti *enumType) NomsKind() types.NomsKind {
 	return types.UintKind
 }
 
-// ParseValue implements TypeInfo interface.
-func (ti *enumType) ParseValue(ctx context.Context, vrw types.ValueReadWriter, str *string) (types.Value, error) {
-	if str == nil || *str == "" {
-		return types.NullValue, nil
-	}
-	val, err := ti.sqlEnumType.Marshal(*str)
-	if err != nil {
-		return nil, err
-	}
-	return types.Uint(val), nil
-}
-
 // Promote implements TypeInfo interface.
 func (ti *enumType) Promote() TypeInfo {
 	return &enumType{ti.sqlEnumType.Promote().(sql.EnumType)}

--- a/go/libraries/doltcore/schema/typeinfo/enum_test.go
+++ b/go/libraries/doltcore/schema/typeinfo/enum_test.go
@@ -249,7 +249,7 @@ func TestEnumParseValue(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf(`%v %v`, test.typ.String(), test.input), func(t *testing.T) {
 			vrw := types.NewMemoryValueStore()
-			output, err := test.typ.ParseValue(context.Background(), vrw, &test.input)
+			output, err := StringDefaultType.ConvertToType(context.Background(), vrw, test.typ, types.String(test.input))
 			if !test.expectedErr {
 				require.NoError(t, err)
 				assert.Equal(t, test.output, output)

--- a/go/libraries/doltcore/schema/typeinfo/float.go
+++ b/go/libraries/doltcore/schema/typeinfo/float.go
@@ -184,14 +184,6 @@ func (ti *floatType) NomsKind() types.NomsKind {
 	return types.FloatKind
 }
 
-// ParseValue implements TypeInfo interface.
-func (ti *floatType) ParseValue(ctx context.Context, vrw types.ValueReadWriter, str *string) (types.Value, error) {
-	if str == nil || *str == "" {
-		return types.NullValue, nil
-	}
-	return ti.ConvertValueToNomsValue(context.Background(), nil, *str)
-}
-
 // Promote implements TypeInfo interface.
 func (ti *floatType) Promote() TypeInfo {
 	return &floatType{ti.sqlFloatType.Promote().(sql.NumberType)}

--- a/go/libraries/doltcore/schema/typeinfo/float_test.go
+++ b/go/libraries/doltcore/schema/typeinfo/float_test.go
@@ -209,7 +209,7 @@ func TestFloatParseValue(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf(`%v %v`, test.typ.String(), test.input), func(t *testing.T) {
 			vrw := types.NewMemoryValueStore()
-			output, err := test.typ.ParseValue(context.Background(), vrw, &test.input)
+			output, err := StringDefaultType.ConvertToType(context.Background(), vrw, test.typ, types.String(test.input))
 			if !test.expectedErr {
 				require.NoError(t, err)
 				assert.Equal(t, test.output, output)

--- a/go/libraries/doltcore/schema/typeinfo/inlineblob_test.go
+++ b/go/libraries/doltcore/schema/typeinfo/inlineblob_test.go
@@ -161,7 +161,7 @@ func TestInlineBlobParseValue(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf(`%v %v`, DefaultInlineBlobType.String(), test.input), func(t *testing.T) {
 			vrw := types.NewMemoryValueStore()
-			output, err := DefaultInlineBlobType.ParseValue(context.Background(), vrw, &test.input)
+			output, err := StringDefaultType.ConvertToType(context.Background(), vrw, DefaultInlineBlobType, types.String(test.input))
 			require.NoError(t, err)
 			assert.Equal(t, test.output, output)
 		})

--- a/go/libraries/doltcore/schema/typeinfo/int.go
+++ b/go/libraries/doltcore/schema/typeinfo/int.go
@@ -220,14 +220,6 @@ func (ti *intType) NomsKind() types.NomsKind {
 	return types.IntKind
 }
 
-// ParseValue implements TypeInfo interface.
-func (ti *intType) ParseValue(ctx context.Context, vrw types.ValueReadWriter, str *string) (types.Value, error) {
-	if str == nil || *str == "" {
-		return types.NullValue, nil
-	}
-	return ti.ConvertValueToNomsValue(context.Background(), nil, *str)
-}
-
 // Promote implements TypeInfo interface.
 func (ti *intType) Promote() TypeInfo {
 	return &intType{ti.sqlIntType.Promote().(sql.NumberType)}

--- a/go/libraries/doltcore/schema/typeinfo/int_test.go
+++ b/go/libraries/doltcore/schema/typeinfo/int_test.go
@@ -244,7 +244,7 @@ func TestIntParseValue(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf(`%v %v`, test.typ.String(), test.input), func(t *testing.T) {
 			vrw := types.NewMemoryValueStore()
-			output, err := test.typ.ParseValue(context.Background(), vrw, &test.input)
+			output, err := StringDefaultType.ConvertToType(context.Background(), vrw, test.typ, types.String(test.input))
 			if !test.expectedErr {
 				require.NoError(t, err)
 				assert.Equal(t, test.output, output)

--- a/go/libraries/doltcore/schema/typeinfo/json.go
+++ b/go/libraries/doltcore/schema/typeinfo/json.go
@@ -135,14 +135,6 @@ func (ti *jsonType) NomsKind() types.NomsKind {
 	return types.JSONKind
 }
 
-// ParseValue implements TypeInfo interface.
-func (ti *jsonType) ParseValue(ctx context.Context, vrw types.ValueReadWriter, str *string) (types.Value, error) {
-	if str == nil {
-		return types.NullValue, nil
-	}
-	return ti.ConvertValueToNomsValue(ctx, vrw, *str)
-}
-
 // Promote implements TypeInfo interface.
 func (ti *jsonType) Promote() TypeInfo {
 	return &jsonType{ti.jsonType.Promote().(sql.JsonType)}

--- a/go/libraries/doltcore/schema/typeinfo/set.go
+++ b/go/libraries/doltcore/schema/typeinfo/set.go
@@ -185,18 +185,6 @@ func (ti *setType) NomsKind() types.NomsKind {
 	return types.UintKind
 }
 
-// ParseValue implements TypeInfo interface.
-func (ti *setType) ParseValue(ctx context.Context, vrw types.ValueReadWriter, str *string) (types.Value, error) {
-	if str == nil {
-		return types.NullValue, nil
-	}
-	val, err := ti.sqlSetType.Marshal(*str)
-	if err != nil {
-		return nil, err
-	}
-	return types.Uint(val), nil
-}
-
 // Promote implements TypeInfo interface.
 func (ti *setType) Promote() TypeInfo {
 	return &setType{ti.sqlSetType.Promote().(sql.SetType)}

--- a/go/libraries/doltcore/schema/typeinfo/set_test.go
+++ b/go/libraries/doltcore/schema/typeinfo/set_test.go
@@ -261,7 +261,7 @@ func TestSetParseValue(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf(`%v %v`, test.typ.String(), test.input), func(t *testing.T) {
 			vrw := types.NewMemoryValueStore()
-			output, err := test.typ.ParseValue(context.Background(), vrw, &test.input)
+			output, err := StringDefaultType.ConvertToType(context.Background(), vrw, test.typ, types.String(test.input))
 			if !test.expectedErr {
 				require.NoError(t, err)
 				assert.Equal(t, test.output, output)

--- a/go/libraries/doltcore/schema/typeinfo/time.go
+++ b/go/libraries/doltcore/schema/typeinfo/time.go
@@ -121,18 +121,6 @@ func (ti *timeType) NomsKind() types.NomsKind {
 	return types.IntKind
 }
 
-// ParseValue implements TypeInfo interface.
-func (ti *timeType) ParseValue(ctx context.Context, vrw types.ValueReadWriter, str *string) (types.Value, error) {
-	if str == nil || *str == "" {
-		return types.NullValue, nil
-	}
-	val, err := ti.sqlTimeType.Marshal(*str)
-	if err != nil {
-		return nil, err
-	}
-	return types.Int(val), nil
-}
-
 // Promote implements TypeInfo interface.
 func (ti *timeType) Promote() TypeInfo {
 	return &timeType{ti.sqlTimeType.Promote().(sql.TimeType)}

--- a/go/libraries/doltcore/schema/typeinfo/time_test.go
+++ b/go/libraries/doltcore/schema/typeinfo/time_test.go
@@ -226,7 +226,7 @@ func TestTimeParseValue(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf(`%v`, test.input), func(t *testing.T) {
 			vrw := types.NewMemoryValueStore()
-			output, err := TimeType.ParseValue(context.Background(), vrw, &test.input)
+			output, err := StringDefaultType.ConvertToType(context.Background(), vrw, TimeType, types.String(test.input))
 			if !test.expectedErr {
 				require.NoError(t, err)
 				assert.Equal(t, test.output, output)

--- a/go/libraries/doltcore/schema/typeinfo/tuple.go
+++ b/go/libraries/doltcore/schema/typeinfo/tuple.go
@@ -98,11 +98,6 @@ func (ti *tupleType) NomsKind() types.NomsKind {
 	return types.TupleKind
 }
 
-// ParseValue implements TypeInfo interface.
-func (ti *tupleType) ParseValue(ctx context.Context, vrw types.ValueReadWriter, str *string) (types.Value, error) {
-	return nil, fmt.Errorf(`"%v" cannot parse strings`, ti.String())
-}
-
 // Promote implements TypeInfo interface.
 func (ti *tupleType) Promote() TypeInfo {
 	return ti

--- a/go/libraries/doltcore/schema/typeinfo/typeconverter.go
+++ b/go/libraries/doltcore/schema/typeinfo/typeconverter.go
@@ -20,9 +20,11 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/shopspring/decimal"
 	"gopkg.in/src-d/go-errors.v1"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/json"
 	"github.com/dolthub/dolt/go/store/types"
 )
 
@@ -123,10 +125,16 @@ func wrapConvertValueToNomsValue(
 			vInt = *(*string)(unsafe.Pointer(&val))
 		case types.Int:
 			vInt = int64(val)
+		case types.JSON:
+			var err error
+			vInt, err = json.NomsJSON(val).ToString(sql.NewEmptyContext())
+			if err != nil {
+				return nil, err
+			}
 		case types.String:
 			vInt = string(val)
 		case types.Timestamp:
-			vInt = time.Time(val)
+			vInt = time.Time(val).UTC()
 		case types.UUID:
 			vInt = val.String()
 		case types.Uint:

--- a/go/libraries/doltcore/schema/typeinfo/typeinfo.go
+++ b/go/libraries/doltcore/schema/typeinfo/typeinfo.go
@@ -105,9 +105,6 @@ type TypeInfo interface {
 	// NomsKind returns the NomsKind that best matches this TypeInfo.
 	NomsKind() types.NomsKind
 
-	// ParseValue parses a string and returns a go value that represents it according to this type.
-	ParseValue(ctx context.Context, vrw types.ValueReadWriter, str *string) (types.Value, error)
-
 	// Promote will promote the current TypeInfo to the largest representing TypeInfo of the same kind, such as Int8 to Int64.
 	Promote() TypeInfo
 
@@ -305,20 +302,6 @@ func FromKind(kind types.NomsKind) TypeInfo {
 	default:
 		panic(fmt.Errorf(`no default type info for NomsKind "%v"`, kind.String()))
 	}
-}
-
-// Convert takes in a types.Value, as well as the source and destination TypeInfos, and
-// converts the TypeInfo into the applicable types.Value.
-func Convert(ctx context.Context, vrw types.ValueReadWriter, v types.Value, srcTi TypeInfo, destTi TypeInfo) (types.Value, error) {
-	str, err := srcTi.FormatValue(v)
-	if err != nil {
-		return nil, err
-	}
-	val, err := destTi.ParseValue(ctx, vrw, str)
-	if err != nil {
-		return nil, err
-	}
-	return val, nil
 }
 
 // IsStringType returns whether the given TypeInfo represents a CHAR, VARCHAR, or TEXT-derivative.

--- a/go/libraries/doltcore/schema/typeinfo/typeinfo_test.go
+++ b/go/libraries/doltcore/schema/typeinfo/typeinfo_test.go
@@ -43,9 +43,6 @@ func TestTypeInfoSuite(t *testing.T) {
 	t.Run("ForeignKindHandling", func(t *testing.T) {
 		testTypeInfoForeignKindHandling(t, typeInfoArrays, validTypeValues)
 	})
-	t.Run("FormatParseRoundTrip", func(t *testing.T) {
-		testTypeInfoFormatParseRoundTrip(t, typeInfoArrays, validTypeValues)
-	})
 	t.Run("GetTypeParams", func(t *testing.T) {
 		testTypeInfoGetTypeParams(t, typeInfoArrays)
 	})
@@ -57,6 +54,9 @@ func TestTypeInfoSuite(t *testing.T) {
 	})
 	t.Run("ToSqlType", func(t *testing.T) {
 		testTypeInfoToSqlType(t, typeInfoArrays)
+	})
+	t.Run("GetTypeConverter Inclusion", func(t *testing.T) {
+		testTypeInfoConversionsExist(t, typeInfoArrays)
 	})
 }
 
@@ -216,38 +216,6 @@ func testTypeInfoForeignKindHandling(t *testing.T, tiArrays [][]TypeInfo, vaArra
 	}
 }
 
-// assuming valid data, verifies that the To-From string functions can round trip
-func testTypeInfoFormatParseRoundTrip(t *testing.T, tiArrays [][]TypeInfo, vaArrays [][]types.Value) {
-	for rowIndex, tiArray := range tiArrays {
-		t.Run(tiArray[0].GetTypeIdentifier().String(), func(t *testing.T) {
-			for _, ti := range tiArray {
-				atLeastOneValid := false
-				t.Run(ti.String(), func(t *testing.T) {
-					for _, val := range vaArrays[rowIndex] {
-						t.Run(fmt.Sprintf(`types.%v(%v)`, val.Kind().String(), humanReadableString(val)), func(t *testing.T) {
-							str, err := ti.FormatValue(val)
-							if ti.IsValid(val) {
-								atLeastOneValid = true
-								require.NoError(t, err)
-								vrw := types.NewMemoryValueStore()
-								outVal, err := ti.ParseValue(context.Background(), vrw, str)
-								require.NoError(t, err)
-								if ti == DateType { // special case as DateType removes the hh:mm:ss
-									val = types.Timestamp(time.Time(val.(types.Timestamp)).Truncate(24 * time.Hour))
-									require.True(t, val.Equals(outVal), "\"%v\"\n\"%v\"", val, outVal)
-								} else if ti.GetTypeIdentifier() != DecimalTypeIdentifier { // Any Decimal's on-disk representation varies by precision/scale
-									require.True(t, val.Equals(outVal), "\"%v\"\n\"%v\"", val, outVal)
-								}
-							}
-						})
-					}
-				})
-				require.True(t, atLeastOneValid, `all values reported false for "%v"`, ti.String())
-			}
-		})
-	}
-}
-
 // verify that FromTypeParams can reconstruct the exact same TypeInfo from the params
 func testTypeInfoGetTypeParams(t *testing.T, tiArrays [][]TypeInfo) {
 	for _, tiArray := range tiArrays {
@@ -295,12 +263,6 @@ func testTypeInfoNullHandling(t *testing.T, tiArrays [][]TypeInfo) {
 						require.True(t, ti.IsValid(types.NullValue))
 						require.True(t, ti.IsValid(nil))
 					})
-					t.Run("ParseValue", func(t *testing.T) {
-						vrw := types.NewMemoryValueStore()
-						tVal, err := ti.ParseValue(context.Background(), vrw, nil)
-						require.NoError(t, err)
-						require.Equal(t, types.NullValue, tVal)
-					})
 				})
 			}
 		})
@@ -336,6 +298,21 @@ func testTypeInfoToSqlType(t *testing.T, tiArrays [][]TypeInfo) {
 				})
 			}
 		})
+	}
+}
+
+// ensures that all types at least have a branch to all other types, which is useful in case a developer forgets to add
+// a new type everywhere it needs to go
+func testTypeInfoConversionsExist(t *testing.T, tiArrays [][]TypeInfo) {
+	for _, tiArray1 := range tiArrays {
+		for _, tiArray2 := range tiArrays {
+			ti1 := tiArray1[0]
+			ti2 := tiArray2[0]
+			t.Run(fmt.Sprintf("%s -> %s", ti1.GetTypeIdentifier().String(), ti2.GetTypeIdentifier().String()), func(t *testing.T) {
+				_, _, err := GetTypeConverter(context.Background(), ti1, ti2)
+				require.False(t, UnhandledTypeConversion.Is(err))
+			})
+		}
 	}
 }
 

--- a/go/libraries/doltcore/schema/typeinfo/uint.go
+++ b/go/libraries/doltcore/schema/typeinfo/uint.go
@@ -220,14 +220,6 @@ func (ti *uintType) NomsKind() types.NomsKind {
 	return types.UintKind
 }
 
-// ParseValue implements TypeInfo interface.
-func (ti *uintType) ParseValue(ctx context.Context, vrw types.ValueReadWriter, str *string) (types.Value, error) {
-	if str == nil || *str == "" {
-		return types.NullValue, nil
-	}
-	return ti.ConvertValueToNomsValue(context.Background(), nil, *str)
-}
-
 // Promote implements TypeInfo interface.
 func (ti *uintType) Promote() TypeInfo {
 	return &uintType{ti.sqlUintType.Promote().(sql.NumberType)}

--- a/go/libraries/doltcore/schema/typeinfo/uint_test.go
+++ b/go/libraries/doltcore/schema/typeinfo/uint_test.go
@@ -238,7 +238,7 @@ func TestUintParseValue(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf(`%v %v`, test.typ.String(), test.input), func(t *testing.T) {
 			vrw := types.NewMemoryValueStore()
-			output, err := test.typ.ParseValue(context.Background(), vrw, &test.input)
+			output, err := StringDefaultType.ConvertToType(context.Background(), vrw, test.typ, types.String(test.input))
 			if !test.expectedErr {
 				require.NoError(t, err)
 				assert.Equal(t, test.output, output)

--- a/go/libraries/doltcore/schema/typeinfo/unknown.go
+++ b/go/libraries/doltcore/schema/typeinfo/unknown.go
@@ -74,11 +74,6 @@ func (ti *unknownType) NomsKind() types.NomsKind {
 	return types.UnknownKind
 }
 
-// ParseValue implements TypeInfo interface.
-func (ti *unknownType) ParseValue(context.Context, types.ValueReadWriter, *string) (types.Value, error) {
-	return nil, fmt.Errorf(`"Unknown" cannot convert any strings to a Noms value`)
-}
-
 // Promote implements TypeInfo interface.
 func (ti *unknownType) Promote() TypeInfo {
 	return ti

--- a/go/libraries/doltcore/schema/typeinfo/uuid.go
+++ b/go/libraries/doltcore/schema/typeinfo/uuid.go
@@ -123,18 +123,6 @@ func (ti *uuidType) NomsKind() types.NomsKind {
 	return types.UUIDKind
 }
 
-// ParseValue implements TypeInfo interface.
-func (ti *uuidType) ParseValue(ctx context.Context, vrw types.ValueReadWriter, str *string) (types.Value, error) {
-	if str == nil || *str == "" {
-		return types.NullValue, nil
-	}
-	uuidVal, err := uuid.Parse(*str)
-	if err != nil {
-		return nil, err
-	}
-	return types.UUID(uuidVal), nil
-}
-
 // Promote implements TypeInfo interface.
 func (ti *uuidType) Promote() TypeInfo {
 	return ti

--- a/go/libraries/doltcore/schema/typeinfo/uuid_test.go
+++ b/go/libraries/doltcore/schema/typeinfo/uuid_test.go
@@ -195,7 +195,7 @@ func TestUuidParseValue(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf(`%v %v`, UuidType.String(), test.input), func(t *testing.T) {
 			vrw := types.NewMemoryValueStore()
-			output, err := UuidType.ParseValue(context.Background(), vrw, &test.input)
+			output, err := StringDefaultType.ConvertToType(context.Background(), vrw, UuidType, types.String(test.input))
 			if !test.expectedErr {
 				require.NoError(t, err)
 				assert.Equal(t, test.output, output)

--- a/go/libraries/doltcore/schema/typeinfo/varstring_test.go
+++ b/go/libraries/doltcore/schema/typeinfo/varstring_test.go
@@ -232,7 +232,7 @@ func TestVarStringParseValue(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf(`%v %v`, test.typ.String(), test.input), func(t *testing.T) {
 			vrw := types.NewMemoryValueStore()
-			output, err := test.typ.ParseValue(context.Background(), vrw, &test.input)
+			output, err := StringDefaultType.ConvertToType(context.Background(), vrw, test.typ, types.String(test.input))
 			if !test.expectedErr {
 				require.NoError(t, err)
 				assert.Equal(t, test.output, output)

--- a/go/libraries/doltcore/schema/typeinfo/year.go
+++ b/go/libraries/doltcore/schema/typeinfo/year.go
@@ -134,21 +134,6 @@ func (ti *yearType) NomsKind() types.NomsKind {
 	return types.IntKind
 }
 
-// ParseValue implements TypeInfo interface.
-func (ti *yearType) ParseValue(ctx context.Context, vrw types.ValueReadWriter, str *string) (types.Value, error) {
-	if str == nil || *str == "" {
-		return types.NullValue, nil
-	}
-	intVal, err := ti.sqlYearType.Convert(*str)
-	if err != nil {
-		return nil, err
-	}
-	if val, ok := intVal.(int16); ok {
-		return types.Int(val), nil
-	}
-	return nil, fmt.Errorf(`"%v" cannot convert the string "%v" to a value`, ti.String(), str)
-}
-
 // Promote implements TypeInfo interface.
 func (ti *yearType) Promote() TypeInfo {
 	return &yearType{ti.sqlYearType.Promote().(sql.YearType)}

--- a/go/libraries/doltcore/schema/typeinfo/year_test.go
+++ b/go/libraries/doltcore/schema/typeinfo/year_test.go
@@ -191,7 +191,7 @@ func TestYearParseValue(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf(`%v %v`, YearType.String(), test.input), func(t *testing.T) {
 			vrw := types.NewMemoryValueStore()
-			output, err := YearType.ParseValue(context.Background(), vrw, &test.input)
+			output, err := StringDefaultType.ConvertToType(context.Background(), vrw, YearType, types.String(test.input))
 			if !test.expectedErr {
 				require.NoError(t, err)
 				assert.Equal(t, test.output, output)

--- a/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
@@ -275,7 +275,7 @@ func interfaceValueAsSqlString(ctx context.Context, ti typeinfo.TypeInfo, value 
 	case typeinfo.UuidTypeIdentifier, typeinfo.TimeTypeIdentifier, typeinfo.YearTypeIdentifier:
 		return singleQuote + str + singleQuote, nil
 	case typeinfo.DatetimeTypeIdentifier:
-		reparsed, err := ti.ParseValue(ctx, nil, &str)
+		reparsed, err := typeinfo.StringDefaultType.ConvertToType(ctx, nil, ti, types.String(str))
 		if err != nil {
 			return "", err
 		}
@@ -299,7 +299,6 @@ func interfaceValueAsSqlString(ctx context.Context, ti typeinfo.TypeInfo, value 
 	}
 }
 
-// todo: this is a hack, varstring should handle this
 func quoteAndEscapeString(s string) string {
 	buf := &bytes.Buffer{}
 	v, err := sqltypes.NewValue(sqltypes.VarChar, []byte(s))


### PR DESCRIPTION
Back when `GetTypeConverter` was added, `Parse` was deprecated. This PR now fully removes it. In addition, a few bugs regarding type conversions were fixed, a new test enforcing the inclusion of all types in `GetTypeConverter` was added, and a few more comments were added to clarify the different string type implementations.