### PR TITLE
libraries/doltcore/merge: fix dropped error

### DIFF
--- a/go/libraries/doltcore/merge/constraint_violations.go
+++ b/go/libraries/doltcore/merge/constraint_violations.go
@@ -212,6 +212,9 @@ func parentFkConstraintViolations(
 				}
 				return false, nil
 			}()
+			if err != nil {
+				return nil, false, err
+			}
 			if shouldContinue {
 				continue
 			}


### PR DESCRIPTION
This fixes a dropped error in `libraries/doltcore/merge`.