### PR TITLE
libraries/doltcore/table/editor: fix dropped test errors

### DIFF
--- a/go/libraries/doltcore/table/editor/table_edit_accumulator_test.go
+++ b/go/libraries/doltcore/table/editor/table_edit_accumulator_test.go
@@ -233,6 +233,7 @@ func TestGet(t *testing.T) {
 
 	// edits in materialized data
 	_, err = tea.MaterializeEdits(ctx, nbf)
+	require.NoError(t, err)
 	requireGet(ctx, t, tea, key1, true)
 	requireGet(ctx, t, tea, key2, true)
 	requireGet(ctx, t, tea, key3, true)
@@ -258,6 +259,7 @@ func TestGet(t *testing.T) {
 	requireGet(ctx, t, tea, key6, true)
 
 	_, err = tea.MaterializeEdits(ctx, nbf)
+	require.NoError(t, err)
 	requireGet(ctx, t, tea, key1, false)
 	requireGet(ctx, t, tea, key2, false)
 	requireGet(ctx, t, tea, key3, true)


### PR DESCRIPTION
This fixes two dropped test `err` variables in `libraries/doltcore/table/editor`.