### PR TITLE
Fix --set-upstream bug when feature branch already exists on remote

### DIFF
--- a/go/libraries/doltcore/env/actions/remotes.go
+++ b/go/libraries/doltcore/env/actions/remotes.go
@@ -123,10 +123,6 @@ func DoPush(ctx context.Context, rsr env.RepoStateReader, rsw env.RepoStateWrite
 		err = fmt.Errorf("%w: %s of type %s", ErrCannotPushRef, opts.SrcRef.String(), opts.SrcRef.GetType())
 	}
 
-	if err != nil {
-		return err
-	}
-
 	if opts.SetUpstream {
 		return rsw.UpdateBranch(opts.SrcRef.GetPath(), env.BranchConfig{
 			Merge: ref.MarshalableRef{
@@ -136,7 +132,7 @@ func DoPush(ctx context.Context, rsr env.RepoStateReader, rsw env.RepoStateWrite
 		})
 	}
 
-	return nil
+	return err
 }
 
 // PushTag pushes a commit tag and all underlying data from a local source database to a remote destination database.

--- a/go/libraries/doltcore/env/actions/remotes.go
+++ b/go/libraries/doltcore/env/actions/remotes.go
@@ -123,20 +123,21 @@ func DoPush(ctx context.Context, rsr env.RepoStateReader, rsw env.RepoStateWrite
 		err = fmt.Errorf("%w: %s of type %s", ErrCannotPushRef, opts.SrcRef.String(), opts.SrcRef.GetType())
 	}
 
-	if !errors.Is(err, doltdb.ErrUpToDate) {
-		return err
+	if err == nil || errors.Is(err, doltdb.ErrUpToDate) || errors.Is(err, pull.ErrDBUpToDate) {
+		if opts.SetUpstream {
+			err := rsw.UpdateBranch(opts.SrcRef.GetPath(), env.BranchConfig{
+				Merge: ref.MarshalableRef{
+					Ref: opts.DestRef,
+				},
+				Remote: opts.Remote.Name,
+			})
+			if err != nil {
+				return err
+			}
+		}
 	}
 
-	if opts.SetUpstream {
-		return rsw.UpdateBranch(opts.SrcRef.GetPath(), env.BranchConfig{
-			Merge: ref.MarshalableRef{
-				Ref: opts.DestRef,
-			},
-			Remote: opts.Remote.Name,
-		})
-	}
-
-	return nil
+	return err
 }
 
 // PushTag pushes a commit tag and all underlying data from a local source database to a remote destination database.

--- a/go/libraries/doltcore/env/actions/remotes.go
+++ b/go/libraries/doltcore/env/actions/remotes.go
@@ -123,6 +123,10 @@ func DoPush(ctx context.Context, rsr env.RepoStateReader, rsw env.RepoStateWrite
 		err = fmt.Errorf("%w: %s of type %s", ErrCannotPushRef, opts.SrcRef.String(), opts.SrcRef.GetType())
 	}
 
+	if !errors.Is(err, doltdb.ErrUpToDate) {
+		return err
+	}
+
 	if opts.SetUpstream {
 		return rsw.UpdateBranch(opts.SrcRef.GetPath(), env.BranchConfig{
 			Merge: ref.MarshalableRef{
@@ -132,7 +136,7 @@ func DoPush(ctx context.Context, rsr env.RepoStateReader, rsw env.RepoStateWrite
 		})
 	}
 
-	return err
+	return nil
 }
 
 // PushTag pushes a commit tag and all underlying data from a local source database to a remote destination database.

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -1448,3 +1448,19 @@ setup_ref_test() {
     cd test-repo
     dolt push
 }
+
+@test "remotes: set upstream succeeds even if up to date" {
+    dolt remote add origin http://localhost:50051/test-org/test-repo
+    dolt push origin main
+    dolt checkout -b feature
+    dolt push --set-upstream origin feature
+
+    cd dolt-repo-clones
+    dolt clone http://localhost:50051/test-org/test-repo
+    cd test-repo
+    dolt checkout -b feature
+    run dolt push
+    [ "$status" -eq 1 ]
+    dolt push --set-upstream origin feature
+    dolt push
+}


### PR DESCRIPTION
We were missing a test for push --set-upstream where
the feature branch had already been pushed from another
clone.