### PR TITLE
Bug fix for an index out of bounds panic in DOLT_HISTORY_<TABLE>

### DIFF
--- a/go/libraries/doltcore/sqle/dtables/filtered_reader.go
+++ b/go/libraries/doltcore/sqle/dtables/filtered_reader.go
@@ -249,18 +249,20 @@ func CreateReaderFuncLimitedByExpressions(nbf *types.NomsBinFormat, tblSch schem
 	pkCols := tblSch.GetPKCols()
 	var keySet setalgebra.Set = setalgebra.UniversalSet{}
 	var err error
-	for _, filter := range filters {
-		var setForFilter setalgebra.Set
-		setForFilter, err = getSetForKeyColumn(nbf, pkCols.GetByIndex(0), filter)
 
-		if err != nil {
-			break
-		}
+	if len(pkCols.GetColumns()) > 0 {
+		for _, filter := range filters {
+			var setForFilter setalgebra.Set
 
-		keySet, err = keySet.Intersect(setForFilter)
+			setForFilter, err = getSetForKeyColumn(nbf, pkCols.GetByIndex(0), filter)
+			if err != nil {
+				break
+			}
 
-		if err != nil {
-			break
+			keySet, err = keySet.Intersect(setForFilter)
+			if err != nil {
+				break
+			}
 		}
 	}
 

--- a/go/libraries/doltcore/sqle/dtables/history_table.go
+++ b/go/libraries/doltcore/sqle/dtables/history_table.go
@@ -348,6 +348,9 @@ func newRowItrForTableAtCommit(
 		return nil, err
 	}
 
+	// TODO: ThreadSafeCRFuncCache is an older and suboptimal filtering approach that should be replaced
+	//       with the unified indexing path that all other tables use. This logic existed before there was a
+	//       reasonable way to apply multiple filter conditions to an indexed table scan.
 	createReaderFunc, err := readerCreateFuncCache.GetOrCreate(schHash, tbl.Format(), tblSch, filters)
 
 	if err != nil {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -381,6 +381,17 @@ func TestDoltMerge(t *testing.T) {
 	}
 }
 
+func TestScopedDoltHistorySystemTables(t *testing.T) {
+	harness := newDoltHarness(t)
+	for _, test := range ScopedDoltHistoryScriptTests {
+		databases := harness.NewDatabases("mydb")
+		engine := enginetest.NewEngineWithDbs(t, harness, databases)
+		t.Run(test.Name, func(t *testing.T) {
+			enginetest.TestScriptWithEngine(t, engine, harness, test)
+		})
+	}
+}
+
 // TestSingleTransactionScript is a convenience method for debugging a single transaction test. Unskip and set to the
 // desired test.
 func TestSingleTransactionScript(t *testing.T) {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -94,6 +94,23 @@ var DoltScripts = []enginetest.ScriptTest{
 	},
 }
 
+var ScopedDoltHistoryScriptTests = []enginetest.ScriptTest{
+	{
+		Name: "scoped-dolt-history-system-table: filtering results on non-pk tables",
+		SetUpScript: []string{
+			"create table foo1 (n int, abcd text);",
+			"insert into foo1 values (1, 'Eins'), (2, 'Zwei'), (3, 'Drei');",
+			"select dolt_commit('-am', 'inserting into foo1');",
+		},
+		Assertions: []enginetest.ScriptTestAssertion{
+			{
+				Query:    "select n, abcd FROM DOLT_HISTORY_foo1 where n=1;",
+				Expected: []sql.Row{{1, "Eins"}},
+			},
+		},
+	},
+}
+
 var DoltMerge = []enginetest.ScriptTest{
 	{
 		Name: "DOLT_MERGE ff correctly works with autocommit off",

--- a/integration-tests/bats/system-tables.bats
+++ b/integration-tests/bats/system-tables.bats
@@ -358,6 +358,19 @@ teardown() {
     echo ${#lines[@]}
     [ $status -eq 0 ]
     [ "${#lines[@]}" -eq 6 ]
+
+    # Test DOLT_HISTORY_ table works for tables with no primary keys
+    dolt sql -q "create table nopks (a int, b text);"
+    dolt sql -q "insert into nopks values (123, 'onetwothree'), (234, 'twothreefour');"
+    dolt add nopks
+    dolt commit -m "Adding table nopks"
+    run dolt sql -q "select * from dolt_history_nopks;"
+    [ $status -eq 0 ]
+    [ "${#lines[@]}" -eq 6 ]
+    run dolt sql -q "select * from dolt_history_nopks where a=123;"
+    [ $status -eq 0 ]
+    [ "${#lines[@]}" -eq 5 ]
+    [[ "$output" =~ "onetwothree" ]] || false
 }
 
 @test "system-tables: query dolt_commits" {


### PR DESCRIPTION
Panic occurs when selecting from `DOLT_HISTORY_<TABLE>` using a filter expression and the underlying table that doesn't have a primary key.