### PR TITLE
Index Transformer

### DIFF
--- a/go/store/nbs/index_transformer.go
+++ b/go/store/nbs/index_transformer.go
@@ -13,24 +13,24 @@ var (
 // IndexTransformer transforms a table file index byte stream with lengths
 // to a table file index byte stream with offsets
 type IndexTransformer struct {
-	src         io.Reader
+	src io.Reader
+
 	lengthsIdx  int64 // Start index of lengths in table file byte stream
 	suffixesIdx int64 // Start index of suffixes in table file byte stream
-
-	buff   []byte
-	idx    int64
-	offset uint64
+	buff        []byte
+	idx         int64
+	offset      uint64
 }
 
 // Create an IndexTransform given a src reader, chunkCount, and maximum size of read
-func NewIndexTransformer(src io.Reader, chunkCount int, maxReadSize int) IndexTransformer {
+func NewIndexTransformer(src io.Reader, chunkCount int, maxReadSize int) *IndexTransformer {
 	tuplesSize := int64(chunkCount) * prefixTupleSize
 	lengthsSize := int64(chunkCount) * lengthSize
 
 	maxNumOffsetsToRead := maxReadSize / offsetSize
 	buffSize := maxNumOffsetsToRead * lengthSize
 
-	return IndexTransformer{
+	return &IndexTransformer{
 		src:         src,
 		buff:        make([]byte, buffSize),
 		lengthsIdx:  tuplesSize,

--- a/go/store/nbs/index_transformer.go
+++ b/go/store/nbs/index_transformer.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Dolthub, Inc.
+// Copyright 2022 Dolthub, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/go/store/nbs/index_transformer.go
+++ b/go/store/nbs/index_transformer.go
@@ -1,0 +1,97 @@
+package nbs
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+)
+
+var (
+	ErrNotEnoughBytesForLength = errors.New("could not read enough bytes to decode length")
+)
+
+// Transforms a byte stream of table file index and instead of writing
+// lengths in ordinal order, it writes offsets in ordinal order.
+type IndexTransformer struct {
+	src         io.Reader
+	lengthsIdx  int64 // Start index of lengths in table file byte stream
+	suffixesIdx int64 // Start index of suffixes in table file byte stream
+
+	buff   []byte
+	idx    int64
+	offset uint64
+}
+
+// Create an IndexTransform given a src reader, chunkCount, and maximum size of read
+func NewIndexTransformer(src io.Reader, chunkCount int, maxReadSize int) IndexTransformer {
+	tuplesSize := int64(chunkCount) * prefixTupleSize
+	lengthsSize := int64(chunkCount) * lengthSize
+
+	maxNumOffsetsToRead := maxReadSize / offsetSize
+	buffSize := maxNumOffsetsToRead * lengthSize
+
+	return IndexTransformer{
+		src:         src,
+		buff:        make([]byte, buffSize),
+		lengthsIdx:  tuplesSize,
+		suffixesIdx: tuplesSize + lengthsSize,
+	}
+}
+
+func (itr IndexTransformer) Read(p []byte) (n int, err error) {
+	// If we will read outside of lengths, just read.
+	if itr.idx+int64(len(p)) < itr.lengthsIdx || itr.idx >= itr.suffixesIdx {
+		n, err = itr.src.Read(p)
+		itr.idx += int64(n)
+		return n, err
+	}
+
+	// If we will read on the boundary between tuples and lengths,
+	// read up to the start of the lengths.
+	if itr.idx < itr.lengthsIdx {
+		b := p[:itr.lengthsIdx-itr.idx]
+		n, err := itr.src.Read(b)
+		itr.idx += int64(n)
+		return n, err
+	}
+
+	if len(p) < offsetSize {
+		// ASK: Should this be a panic?
+		// If this case is true, 0 bytes will be read and no error will be
+		// returned which is undesirable behavior for io.Reader
+
+		// We could return an error instead, but this feels like developer error
+		panic("len(p) must be at-least offsetSize")
+	}
+
+	// Now we can assume we are on a length boundary.
+
+	// Alter size of p so we don't read any suffix bytes
+	if int64(len(p)) > itr.idx-itr.suffixesIdx {
+		p = p[itr.idx-itr.suffixesIdx:]
+	}
+
+	// Read as many lengths, as offsets we can fit into p. (Assuming lengthsSize < offsetSize)
+
+	num := n / offsetSize
+	readSize := num * lengthSize
+
+	b := p[readSize:]
+	n, err = itr.src.Read(b)
+	if err != nil {
+		return n, err
+	}
+
+	// Copy lengths
+	copy(itr.buff, b)
+
+	// Calculate offsets
+	for lStart, oStart := 0, 0; lStart < readSize; lStart, oStart = lStart+lengthSize, oStart+offsetSize {
+		lengthBytes := itr.buff[lStart : lStart+lengthSize]
+		length := binary.BigEndian.Uint32(lengthBytes)
+		itr.offset += uint64(length)
+		binary.BigEndian.PutUint64(p[oStart:oStart+offsetSize], itr.offset)
+	}
+
+	return n, nil
+}

--- a/go/store/nbs/index_transformer.go
+++ b/go/store/nbs/index_transformer.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package nbs
 
 import (

--- a/go/store/nbs/index_transformer.go
+++ b/go/store/nbs/index_transformer.go
@@ -54,14 +54,6 @@ func NewOffsetsReader(lengthsReader io.Reader) *OffsetsReader {
 }
 
 func (tra *OffsetsReader) Read(p []byte) (n int, err error) {
-	// if len(p) < offsetSize {
-	// 	// ASK: Should this be a panic?
-	// 	// If this case is true, 0 bytes will be read and no error will be
-	// 	// returned which is undesirable behavior for io.Reader
-
-	// 	// We could return an error instead, but this feels like developer error
-	// 	panic("len(p) must be at-least offsetSize")
-	// }
 
 	// Read as many lengths, as offsets we can fit into p. Which is half.
 	// Below assumes that lengthSize * 2 = offsetSize

--- a/go/store/nbs/index_transformer_test.go
+++ b/go/store/nbs/index_transformer_test.go
@@ -56,7 +56,7 @@ func (r *minByteReader) Read(p []byte) (int, error) {
 	return n, err
 }
 
-// Altered from testing/iotest.TestReader to use alignedByteReader
+// Altered from testing/iotest.TestReader to use minByteReader
 func testReader(r io.Reader, content []byte) error {
 	if len(content) > 0 {
 		n, err := r.Read(nil)

--- a/go/store/nbs/index_transformer_test.go
+++ b/go/store/nbs/index_transformer_test.go
@@ -1,0 +1,145 @@
+package nbs
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math/rand"
+	"testing"
+
+	"github.com/dolthub/dolt/go/libraries/utils/test"
+	"github.com/stretchr/testify/require"
+)
+
+// minByteReader is a copy of smallerByteReader from testing/iotest
+// but with a minimum read size of min bytes.
+
+type minByteReader struct {
+	r   io.Reader
+	min int
+
+	n   int
+	off int
+}
+
+func (r *minByteReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	r.n = r.min + rand.Intn(r.min*100)
+
+	n := r.n
+	if n > len(p) {
+		n = len(p)
+	}
+	n, err := r.r.Read(p[0:n])
+	if err != nil && err != io.EOF {
+		err = fmt.Errorf("Read(%d bytes at offset %d): %v", n, r.off, err)
+	}
+	r.off += n
+	return n, err
+}
+
+// Altered from testing/iotest.TestReader to use alignedByteReader
+func testReader(r io.Reader, content []byte) error {
+	if len(content) > 0 {
+		n, err := r.Read(nil)
+		if n != 0 || err != nil {
+			return fmt.Errorf("Read(0) = %d, %v, want 0, nil", n, err)
+		}
+	}
+
+	data, err := io.ReadAll(&minByteReader{r: r, min: offsetSize})
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(data, content) {
+		return fmt.Errorf("ReadAll(varied amounts) = %q\n\twant %q", data, content)
+	}
+
+	n, err := r.Read(make([]byte, offsetSize))
+	if n != 0 || err != io.EOF {
+		return fmt.Errorf("Read(offsetSize) at EOF = %v, %v, want 0, EOF", n, err)
+	}
+
+	return nil
+}
+
+func get32Bytes(src []uint32) []byte {
+	dst := make([]byte, len(src)*uint32Size)
+	for i, start, end := 0, 0, lengthSize; i < len(src); i, start, end = i+1, end, end+lengthSize {
+		p := dst[start:end]
+		binary.BigEndian.PutUint32(p, src[i])
+	}
+	return dst
+}
+
+func get64Bytes(src []uint64) []byte {
+	dst := make([]byte, len(src)*uint64Size)
+	for i, start, end := 0, 0, offsetSize; i < len(src); i, start, end = i+1, end, end+offsetSize {
+		p := dst[start:end]
+		binary.BigEndian.PutUint64(p, src[i])
+	}
+	return dst
+}
+
+func randomUInt32s(n int) []uint32 {
+	out := make([]uint32, n)
+	for i := 0; i < n; i++ {
+		out[i] = uint32(rand.Intn(1000))
+	}
+	return out
+}
+
+func calcOffsets(arr []uint32) []uint64 {
+	out := make([]uint64, len(arr))
+	out[0] = uint64(arr[0])
+	for i := 1; i < len(arr); i++ {
+		out[i] = out[i-1] + uint64(arr[i])
+	}
+	return out
+}
+
+func TestLengthsTransformer(t *testing.T) {
+	testSize := rand.Intn(100) + 1
+	lengths := randomUInt32s(testSize)
+	offsets := calcOffsets(lengths)
+
+	lengthBytes := get32Bytes(lengths)
+	offsetBytes := get64Bytes(offsets)
+
+	lengthsReader := bytes.NewReader(lengthBytes)
+	offsetReader := NewOffsetsReader(lengthsReader)
+
+	err := testReader(offsetReader, offsetBytes)
+	require.NoError(t, err)
+}
+
+func TestIndexTransformer(t *testing.T) {
+	chunkCount := rand.Intn(1000) + 1
+	lengths := randomUInt32s(chunkCount)
+	offsets := calcOffsets(lengths)
+	lengthBytes := get32Bytes(lengths)
+	offsetBytes := get64Bytes(offsets)
+
+	tupleBytes := test.RandomData(chunkCount * prefixTupleSize)
+	suffixBytes := test.RandomData(chunkCount * addrSuffixSize)
+
+	var inBytes []byte
+	inBytes = append(inBytes, tupleBytes...)
+	inBytes = append(inBytes, lengthBytes...)
+	inBytes = append(inBytes, suffixBytes...)
+
+	var outBytes []byte
+	outBytes = append(outBytes, tupleBytes...)
+	outBytes = append(outBytes, offsetBytes...)
+	outBytes = append(outBytes, suffixBytes...)
+
+	inReader := bytes.NewBuffer(inBytes)
+	outReader := NewIndexTransformer(inReader, chunkCount)
+
+	err := testReader(outReader, outBytes)
+	require.NoError(t, err)
+}

--- a/go/store/nbs/index_transformer_test.go
+++ b/go/store/nbs/index_transformer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Dolthub, Inc.
+// Copyright 2022 Dolthub, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/go/store/nbs/index_transformer_test.go
+++ b/go/store/nbs/index_transformer_test.go
@@ -110,11 +110,13 @@ func TestLengthsTransformer(t *testing.T) {
 	lengthBytes := get32Bytes(lengths)
 	offsetBytes := get64Bytes(offsets)
 
-	lengthsReader := bytes.NewReader(lengthBytes)
-	offsetReader := NewOffsetsReader(lengthsReader)
+	t.Run("converts lengths into offsets", func(t *testing.T) {
+		lengthsReader := bytes.NewReader(lengthBytes)
+		offsetReader := NewOffsetsReader(lengthsReader)
 
-	err := testReader(offsetReader, offsetBytes)
-	require.NoError(t, err)
+		err := testReader(offsetReader, offsetBytes)
+		require.NoError(t, err)
+	})
 }
 
 func TestIndexTransformer(t *testing.T) {
@@ -137,9 +139,12 @@ func TestIndexTransformer(t *testing.T) {
 	outBytes = append(outBytes, offsetBytes...)
 	outBytes = append(outBytes, suffixBytes...)
 
-	inReader := bytes.NewBuffer(inBytes)
-	outReader := NewIndexTransformer(inReader, chunkCount)
+	t.Run("only converts lengths into offsets", func(t *testing.T) {
+		inReader := bytes.NewBuffer(inBytes)
+		outReader := NewIndexTransformer(inReader, chunkCount)
 
-	err := testReader(outReader, outBytes)
-	require.NoError(t, err)
+		err := testReader(outReader, outBytes)
+		require.NoError(t, err)
+	})
+
 }

--- a/go/store/nbs/index_transformer_test.go
+++ b/go/store/nbs/index_transformer_test.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package nbs
 
 import (

--- a/go/store/nbs/index_transformer_test.go
+++ b/go/store/nbs/index_transformer_test.go
@@ -22,8 +22,9 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/dolthub/dolt/go/libraries/utils/test"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/libraries/utils/test"
 )
 
 // minByteReader is a copy of smallerByteReader from testing/iotest

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -130,6 +130,7 @@ const (
 	uint32Size      = 4
 	ordinalSize     = uint32Size
 	lengthSize      = uint32Size
+	offsetSize      = uint64Size
 	magicNumber     = "\xff\xb5\xd8\xc2\x24\x63\xee\x50"
 	magicNumberSize = 8 //len(magicNumber)
 	footerSize      = uint32Size + uint64Size + magicNumberSize


### PR DESCRIPTION
IndexTransformer is an io.Reader that takes an io.Reader of the table file index. It specifically transforms the lengths into offsets.