### PR TITLE
Add errors to tableIndex interface funcs

### DIFF
--- a/go/store/nbs/aws_chunk_source.go
+++ b/go/store/nbs/aws_chunk_source.go
@@ -43,7 +43,11 @@ func newAWSChunkSource(ctx context.Context, ddb *ddbTableStore, s3 *s3ObjectRead
 
 		if index, found := indexCache.get(name); found {
 			tra := &awsTableReaderAt{al: al, ddb: ddb, s3: s3, name: name, chunkCount: chunkCount}
-			return &chunkSourceAdapter{newTableReader(index, tra, s3BlockSize), name}, nil
+			tr, err := newTableReader(index, tra, s3BlockSize)
+			if err != nil {
+				return &chunkSourceAdapter{}, err
+			}
+			return &chunkSourceAdapter{tr, name}, nil
 		}
 	}
 
@@ -98,7 +102,11 @@ func newAWSChunkSource(ctx context.Context, ddb *ddbTableStore, s3 *s3ObjectRead
 		indexCache.put(name, ohi)
 	}
 
-	return &chunkSourceAdapter{newTableReader(index, tra, s3BlockSize), name}, nil
+	tr, err := newTableReader(index, tra, s3BlockSize)
+	if err != nil {
+		return &chunkSourceAdapter{}, err
+	}
+	return &chunkSourceAdapter{tr, name}, nil
 }
 
 type awsTableReaderAt struct {

--- a/go/store/nbs/aws_table_persister_test.go
+++ b/go/store/nbs/aws_table_persister_test.go
@@ -548,6 +548,7 @@ func bytesToChunkSource(t *testing.T, bs ...[]byte) chunkSource {
 	data := buff[:tableSize]
 	ti, err := parseTableIndex(data)
 	require.NoError(t, err)
-	rdr := newTableReader(ti, tableReaderAtFromBytes(data), fileBlockSize)
+	rdr, err := newTableReader(ti, tableReaderAtFromBytes(data), fileBlockSize)
+	require.NoError(t, err)
 	return chunkSourceAdapter{rdr, name}
 }

--- a/go/store/nbs/block_store_test.go
+++ b/go/store/nbs/block_store_test.go
@@ -418,7 +418,9 @@ func TestBlockStoreConjoinOnCommit(t *testing.T) {
 	assertContainAll := func(t *testing.T, store chunks.ChunkStore, srcs ...chunkSource) {
 		rdrs := make(chunkReaderGroup, len(srcs))
 		for i, src := range srcs {
-			rdrs[i] = src.Clone()
+			c, err := src.Clone()
+			require.NoError(t, err)
+			rdrs[i] = c
 		}
 		chunkChan := make(chan extractRecord, mustUint32(rdrs.count()))
 		err := rdrs.extract(context.Background(), chunkChan)

--- a/go/store/nbs/bs_persister.go
+++ b/go/store/nbs/bs_persister.go
@@ -110,7 +110,11 @@ func newBSChunkSource(ctx context.Context, bs blobstore.Blobstore, name addr, ch
 
 		if index, found := indexCache.get(name); found {
 			bsTRA := &bsTableReaderAt{name.String(), bs}
-			return &chunkSourceAdapter{newTableReader(index, bsTRA, blockSize), name}, nil
+			tr, err := newTableReader(index, bsTRA, blockSize)
+			if err != nil {
+				return nil, err
+			}
+			return &chunkSourceAdapter{tr, name}, nil
 		}
 	}
 
@@ -148,7 +152,11 @@ func newBSChunkSource(ctx context.Context, bs blobstore.Blobstore, name addr, ch
 		indexCache.put(name, index)
 	}
 
-	return &chunkSourceAdapter{newTableReader(index, tra, s3BlockSize), name}, nil
+	tr, err := newTableReader(index, tra, s3BlockSize)
+	if err != nil {
+		return nil, err
+	}
+	return &chunkSourceAdapter{tr, name}, nil
 }
 
 func (bsp *blobstorePersister) PruneTableFiles(ctx context.Context, contents manifestContents) error {

--- a/go/store/nbs/chunk_source_adapter.go
+++ b/go/store/nbs/chunk_source_adapter.go
@@ -42,7 +42,11 @@ func newReaderFromIndexData(indexCache *indexCache, idxData []byte, name addr, t
 		indexCache.put(name, index)
 	}
 
-	return &chunkSourceAdapter{newTableReader(index, tra, blockSize), name}, nil
+	tr, err := newTableReader(index, tra, blockSize)
+	if err != nil {
+		return nil, err
+	}
+	return &chunkSourceAdapter{tr, name}, nil
 }
 
 func (csa chunkSourceAdapter) Close() error {

--- a/go/store/nbs/chunk_source_adapter.go
+++ b/go/store/nbs/chunk_source_adapter.go
@@ -49,6 +49,10 @@ func (csa chunkSourceAdapter) Close() error {
 	return csa.tableReader.Close()
 }
 
-func (csa chunkSourceAdapter) Clone() chunkSource {
-	return &chunkSourceAdapter{csa.tableReader.Clone(), csa.h}
+func (csa chunkSourceAdapter) Clone() (chunkSource, error) {
+	tr, err := csa.tableReader.Clone()
+	if err != nil {
+		return &chunkSourceAdapter{}, err
+	}
+	return &chunkSourceAdapter{tr, csa.h}, nil
 }

--- a/go/store/nbs/cmp_chunk_table_writer_test.go
+++ b/go/store/nbs/cmp_chunk_table_writer_test.go
@@ -37,7 +37,8 @@ func TestCmpChunkTableWriter(t *testing.T) {
 	// Setup a TableReader to read compressed chunks out of
 	ti, err := parseTableIndex(buff)
 	require.NoError(t, err)
-	tr := newTableReader(ti, tableReaderAtFromBytes(buff), fileBlockSize)
+	tr, err := newTableReader(ti, tableReaderAtFromBytes(buff), fileBlockSize)
+	require.NoError(t, err)
 
 	hashes := make(hash.HashSet)
 	for _, chnk := range testMDChunks {
@@ -74,7 +75,8 @@ func TestCmpChunkTableWriter(t *testing.T) {
 	outputBuff := output.Bytes()
 	outputTI, err := parseTableIndex(outputBuff)
 	require.NoError(t, err)
-	outputTR := newTableReader(outputTI, tableReaderAtFromBytes(buff), fileBlockSize)
+	outputTR, err := newTableReader(outputTI, tableReaderAtFromBytes(buff), fileBlockSize)
+	require.NoError(t, err)
 
 	compareContentsOfTables(t, ctx, hashes, tr, outputTR)
 }

--- a/go/store/nbs/conjoiner_test.go
+++ b/go/store/nbs/conjoiner_test.go
@@ -64,7 +64,9 @@ func makeTestSrcs(t *testing.T, tableSizes []uint32, p tablePersister) (srcs chu
 		}
 		cs, err := p.Persist(context.Background(), mt, nil, &Stats{})
 		require.NoError(t, err)
-		srcs = append(srcs, cs.Clone())
+		c, err := cs.Clone()
+		require.NoError(t, err)
+		srcs = append(srcs, c)
 	}
 	return
 }

--- a/go/store/nbs/dynamo_fake_test.go
+++ b/go/store/nbs/dynamo_fake_test.go
@@ -62,7 +62,12 @@ func (m *fakeDDB) readerForTable(name addr) (chunkReader, error) {
 			return nil, err
 		}
 
-		return newTableReader(ti, tableReaderAtFromBytes(buff), fileBlockSize), nil
+		tr, err := newTableReader(ti, tableReaderAtFromBytes(buff), fileBlockSize)
+		if err != nil {
+			return nil, err
+		}
+
+		return tr, nil
 	}
 	return nil, nil
 }

--- a/go/store/nbs/file_table_persister_test.go
+++ b/go/store/nbs/file_table_persister_test.go
@@ -129,7 +129,8 @@ func TestFSTablePersisterPersist(t *testing.T) {
 		require.NoError(t, err)
 		ti, err := parseTableIndex(buff)
 		require.NoError(t, err)
-		tr := newTableReader(ti, tableReaderAtFromBytes(buff), fileBlockSize)
+		tr, err := newTableReader(ti, tableReaderAtFromBytes(buff), fileBlockSize)
+		require.NoError(t, err)
 		assertChunksInReader(testChunks, tr, assert)
 	}
 }
@@ -229,7 +230,8 @@ func TestFSTablePersisterConjoinAll(t *testing.T) {
 		require.NoError(t, err)
 		ti, err := parseTableIndex(buff)
 		require.NoError(t, err)
-		tr := newTableReader(ti, tableReaderAtFromBytes(buff), fileBlockSize)
+		tr, err := newTableReader(ti, tableReaderAtFromBytes(buff), fileBlockSize)
+		require.NoError(t, err)
 		assertChunksInReader(testChunks, tr, assert)
 	}
 
@@ -267,7 +269,8 @@ func TestFSTablePersisterConjoinAllDups(t *testing.T) {
 		require.NoError(t, err)
 		ti, err := parseTableIndex(buff)
 		require.NoError(t, err)
-		tr := newTableReader(ti, tableReaderAtFromBytes(buff), fileBlockSize)
+		tr, err := newTableReader(ti, tableReaderAtFromBytes(buff), fileBlockSize)
+		require.NoError(t, err)
 		assertChunksInReader(testChunks, tr, assert)
 		assert.EqualValues(reps*len(testChunks), mustUint32(tr.count()))
 	}

--- a/go/store/nbs/mem_table_test.go
+++ b/go/store/nbs/mem_table_test.go
@@ -152,14 +152,16 @@ func TestMemTableWrite(t *testing.T) {
 	require.NoError(t, err)
 	ti1, err := parseTableIndex(td1)
 	require.NoError(t, err)
-	tr1 := newTableReader(ti1, tableReaderAtFromBytes(td1), fileBlockSize)
+	tr1, err := newTableReader(ti1, tableReaderAtFromBytes(td1), fileBlockSize)
+	require.NoError(t, err)
 	assert.True(tr1.has(computeAddr(chunks[1])))
 
 	td2, _, err := buildTable(chunks[2:])
 	require.NoError(t, err)
 	ti2, err := parseTableIndex(td2)
 	require.NoError(t, err)
-	tr2 := newTableReader(ti2, tableReaderAtFromBytes(td2), fileBlockSize)
+	tr2, err := newTableReader(ti2, tableReaderAtFromBytes(td2), fileBlockSize)
+	require.NoError(t, err)
 	assert.True(tr2.has(computeAddr(chunks[2])))
 
 	_, data, count, err := mt.write(chunkReaderGroup{tr1, tr2}, &Stats{})
@@ -168,7 +170,8 @@ func TestMemTableWrite(t *testing.T) {
 
 	ti, err := parseTableIndex(data)
 	require.NoError(t, err)
-	outReader := newTableReader(ti, tableReaderAtFromBytes(data), fileBlockSize)
+	outReader, err := newTableReader(ti, tableReaderAtFromBytes(data), fileBlockSize)
+	require.NoError(t, err)
 	assert.True(outReader.has(computeAddr(chunks[0])))
 	assert.False(outReader.has(computeAddr(chunks[1])))
 	assert.False(outReader.has(computeAddr(chunks[2])))

--- a/go/store/nbs/mmap_table_reader.go
+++ b/go/store/nbs/mmap_table_reader.go
@@ -167,8 +167,12 @@ func (mmtr *mmapTableReader) Close() error {
 	return mmtr.tableReader.Close()
 }
 
-func (mmtr *mmapTableReader) Clone() chunkSource {
-	return &mmapTableReader{mmtr.tableReader.Clone(), mmtr.fc, mmtr.h}
+func (mmtr *mmapTableReader) Clone() (chunkSource, error) {
+	tr, err := mmtr.tableReader.Clone()
+	if err != nil {
+		return &mmapTableReader{}, err
+	}
+	return &mmapTableReader{tr, mmtr.fc, mmtr.h}, nil
 }
 
 type cacheReaderAt struct {

--- a/go/store/nbs/mmap_table_reader.go
+++ b/go/store/nbs/mmap_table_reader.go
@@ -152,8 +152,12 @@ func newMmapTableReader(dir string, h addr, chunkCount uint32, indexCache *index
 		return nil, errors.New("unexpected chunk count")
 	}
 
+	tr, err := newTableReader(index, &cacheReaderAt{path, fc}, fileBlockSize)
+	if err != nil {
+		return nil, err
+	}
 	return &mmapTableReader{
-		newTableReader(index, &cacheReaderAt{path, fc}, fileBlockSize),
+		tr,
 		fc,
 		h,
 	}, nil

--- a/go/store/nbs/persisting_chunk_source.go
+++ b/go/store/nbs/persisting_chunk_source.go
@@ -100,9 +100,9 @@ func (ccs *persistingChunkSource) Close() error {
 	return nil
 }
 
-func (ccs *persistingChunkSource) Clone() chunkSource {
+func (ccs *persistingChunkSource) Clone() (chunkSource, error) {
 	// persistingChunkSource does not own |cs| or |mt|. No need to Clone.
-	return ccs
+	return ccs, nil
 }
 
 func (ccs *persistingChunkSource) has(h addr) (bool, error) {
@@ -308,6 +308,6 @@ func (ecs emptyChunkSource) Close() error {
 	return nil
 }
 
-func (ecs emptyChunkSource) Clone() chunkSource {
-	return ecs
+func (ecs emptyChunkSource) Clone() (chunkSource, error) {
+	return ecs, nil
 }

--- a/go/store/nbs/root_tracker_test.go
+++ b/go/store/nbs/root_tracker_test.go
@@ -467,7 +467,11 @@ func (ftp fakeTablePersister) Persist(ctx context.Context, mt *memTable, haver c
 				return nil, err
 			}
 
-			ftp.sources[name] = newTableReader(ti, tableReaderAtFromBytes(data), fileBlockSize)
+			s, err := newTableReader(ti, tableReaderAtFromBytes(data), fileBlockSize)
+			if err != nil {
+				return emptyChunkSource{}, err
+			}
+			ftp.sources[name] = s
 			return chunkSourceAdapter{ftp.sources[name], name}, nil
 		}
 	}
@@ -490,7 +494,11 @@ func (ftp fakeTablePersister) ConjoinAll(ctx context.Context, sources chunkSourc
 			return nil, err
 		}
 
-		ftp.sources[name] = newTableReader(ti, tableReaderAtFromBytes(data), fileBlockSize)
+		s, err := newTableReader(ti, tableReaderAtFromBytes(data), fileBlockSize)
+		if err != nil {
+			return nil, err
+		}
+		ftp.sources[name] = s
 		return chunkSourceAdapter{ftp.sources[name], name}, nil
 	}
 	return emptyChunkSource{}, nil

--- a/go/store/nbs/s3_fake_test.go
+++ b/go/store/nbs/s3_fake_test.go
@@ -81,7 +81,11 @@ func (m *fakeS3) readerForTable(name addr) (chunkReader, error) {
 		if err != nil {
 			return nil, err
 		}
-		return newTableReader(ti, tableReaderAtFromBytes(buff), s3BlockSize), nil
+		tr, err := newTableReader(ti, tableReaderAtFromBytes(buff), s3BlockSize)
+		if err != nil {
+			return nil, err
+		}
+		return tr, nil
 	}
 	return nil, nil
 }
@@ -100,7 +104,11 @@ func (m *fakeS3) readerForTableWithNamespace(ns string, name addr) (chunkReader,
 			return nil, err
 		}
 
-		return newTableReader(ti, tableReaderAtFromBytes(buff), s3BlockSize), nil
+		tr, err := newTableReader(ti, tableReaderAtFromBytes(buff), s3BlockSize)
+		if err != nil {
+			return nil, err
+		}
+		return tr, nil
 	}
 	return nil, nil
 }

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -117,7 +117,10 @@ func (nbs *NomsBlockStore) GetChunkLocations(hashes hash.HashSet) (map[hash.Hash
 		for _, cs := range css {
 			switch tr := cs.(type) {
 			case *mmapTableReader:
-				offsetRecSlice, _ := tr.findOffsets(gr)
+				offsetRecSlice, _, err := tr.findOffsets(gr)
+				if err != nil {
+					return err
+				}
 				if len(offsetRecSlice) > 0 {
 					y, ok := ranges[hash.Hash(tr.h)]
 
@@ -154,7 +157,10 @@ func (nbs *NomsBlockStore) GetChunkLocations(hashes hash.HashSet) (map[hash.Hash
 				var foundHashes []hash.Hash
 				for h := range hashes {
 					a := addr(h)
-					e, ok := tableIndex.Lookup(&a)
+					e, ok, err := tableIndex.Lookup(&a)
+					if err != nil {
+						return err
+					}
 					if ok {
 						foundHashes = append(foundHashes, h)
 						y[h] = Range{Offset: e.Offset(), Length: e.Length()}

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -238,7 +238,7 @@ type chunkReader interface {
 }
 
 type chunkReadPlanner interface {
-	findOffsets(reqs []getRecord) (ors offsetRecSlice, remaining bool)
+	findOffsets(reqs []getRecord) (ors offsetRecSlice, remaining bool, err error)
 	getManyAtOffsets(
 		ctx context.Context,
 		eg *errgroup.Group,
@@ -269,7 +269,7 @@ type chunkSource interface {
 	// cannot be |Close|d more than once, so if a |chunkSource| is being
 	// retained in two objects with independent life-cycle, it should be
 	// |Clone|d first.
-	Clone() chunkSource
+	Clone() (chunkSource, error)
 }
 
 type chunkSources []chunkSource

--- a/go/store/nbs/table_persister.go
+++ b/go/store/nbs/table_persister.go
@@ -256,8 +256,14 @@ func planConjoin(sources chunkSources, stats *Stats) (plan compactionPlan, err e
 			return compactionPlan{}, err
 		}
 
-		ordinals := index.Ordinals()
-		prefixes := index.Prefixes()
+		ordinals, err := index.Ordinals()
+		if err != nil {
+			return compactionPlan{}, err
+		}
+		prefixes, err := index.Prefixes()
+		if err != nil {
+			return compactionPlan{}, err
+		}
 
 		// Add all the prefix tuples from this index to the list of all prefixIndexRecs, modifying the ordinals such that all entries from the 1st item in sources come after those in the 0th and so on.
 		for j, prefix := range prefixes {

--- a/go/store/nbs/table_persister.go
+++ b/go/store/nbs/table_persister.go
@@ -294,7 +294,10 @@ func planConjoin(sources chunkSources, stats *Stats) (plan compactionPlan, err e
 			// Build up the index one entry at a time.
 			var a addr
 			for i := 0; i < len(ordinals); i++ {
-				e := index.IndexEntry(uint32(i), &a)
+				e, err := index.IndexEntry(uint32(i), &a)
+				if err != nil {
+					return compactionPlan{}, err
+				}
 				li := lengthsPos + lengthSize*uint64(ordinals[i])
 				si := suffixesPos + addrSuffixSize*uint64(ordinals[i])
 				binary.BigEndian.PutUint32(plan.mergedIndex[li:], e.Length())

--- a/go/store/nbs/table_persister_test.go
+++ b/go/store/nbs/table_persister_test.go
@@ -47,7 +47,9 @@ func TestPlanCompaction(t *testing.T) {
 		require.NoError(t, err)
 		ti, err := parseTableIndex(data)
 		require.NoError(t, err)
-		src := chunkSourceAdapter{newTableReader(ti, tableReaderAtFromBytes(data), fileBlockSize), name}
+		tr, err := newTableReader(ti, tableReaderAtFromBytes(data), fileBlockSize)
+		require.NoError(t, err)
+		src := chunkSourceAdapter{tr, name}
 		dataLens = append(dataLens, uint64(len(data))-indexSize(mustUint32(src.count()))-footerSize)
 		sources = append(sources, src)
 	}
@@ -67,7 +69,8 @@ func TestPlanCompaction(t *testing.T) {
 	assert.Equal(totalChunks, idx.chunkCount)
 	assert.Equal(totalUnc, idx.totalUncompressedData)
 
-	tr := newTableReader(idx, tableReaderAtFromBytes(nil), fileBlockSize)
+	tr, err := newTableReader(idx, tableReaderAtFromBytes(nil), fileBlockSize)
+	require.NoError(t, err)
 	for _, content := range tableContents {
 		assertChunksInReader(content, tr, assert)
 	}

--- a/go/store/nbs/table_reader.go
+++ b/go/store/nbs/table_reader.go
@@ -199,12 +199,12 @@ func (i mmapTableIndex) Close() error {
 	return nil
 }
 
-func (i mmapTableIndex) Clone() tableIndex {
+func (i mmapTableIndex) Clone() (tableIndex, error) {
 	cnt := atomic.AddInt32(i.refCnt, 1)
 	if cnt == 1 {
 		panic("Clone() called after last Close(). This index is no longer valid.")
 	}
-	return i
+	return i, nil
 }
 
 func (i mmapTableIndex) prefixIdx(prefix uint64) (idx uint32) {
@@ -223,32 +223,32 @@ func (i mmapTableIndex) prefixIdx(prefix uint64) (idx uint32) {
 	return
 }
 
-func (i mmapTableIndex) Lookup(h *addr) (indexEntry, bool) {
+func (i mmapTableIndex) Lookup(h *addr) (indexEntry, bool, error) {
 	prefix := binary.BigEndian.Uint64(h[:])
 	for idx := i.prefixIdx(prefix); idx < i.chunkCount && i.prefixes[idx] == prefix; idx++ {
 		mi := idx * mmapIndexEntrySize
 		e := mmapIndexEntry(i.data[mi : mi+mmapIndexEntrySize])
 		if bytes.Equal(e.suffix(), h[addrPrefixSize:]) {
-			return e, true
+			return e, true, nil
 		}
 	}
-	return mmapIndexEntry{}, false
+	return mmapIndexEntry{}, false, nil
 }
 
-func (i mmapTableIndex) EntrySuffixMatches(idx uint32, h *addr) bool {
+func (i mmapTableIndex) EntrySuffixMatches(idx uint32, h *addr) (bool, error) {
 	mi := idx * mmapIndexEntrySize
 	e := mmapIndexEntry(i.data[mi : mi+mmapIndexEntrySize])
-	return bytes.Equal(e.suffix(), h[addrPrefixSize:])
+	return bytes.Equal(e.suffix(), h[addrPrefixSize:]), nil
 }
 
-func (i mmapTableIndex) IndexEntry(idx uint32, a *addr) indexEntry {
+func (i mmapTableIndex) IndexEntry(idx uint32, a *addr) (indexEntry, error) {
 	mi := idx * mmapIndexEntrySize
 	e := mmapIndexEntry(i.data[mi : mi+mmapIndexEntrySize])
 	if a != nil {
 		binary.BigEndian.PutUint64(a[:], i.prefixes[idx])
 		copy(a[addrPrefixSize:], e.suffix())
 	}
-	return e
+	return e, nil
 }
 
 type mmapIndexEntry []byte
@@ -332,14 +332,14 @@ type tableIndex interface {
 	// EntrySuffixMatches returns true if the entry at index |idx| matches
 	// the suffix of the address |h|. Used by |Lookup| after finding
 	// matching indexes based on |Prefixes|.
-	EntrySuffixMatches(idx uint32, h *addr) bool
+	EntrySuffixMatches(idx uint32, h *addr) (bool, error)
 	// IndexEntry returns the |indexEntry| at |idx|. Optionally puts the
 	// full address of that entry in |a| if |a| is not |nil|.
-	IndexEntry(idx uint32, a *addr) indexEntry
+	IndexEntry(idx uint32, a *addr) (indexEntry, error)
 	// Lookup returns an |indexEntry| for the chunk corresponding to the
 	// provided address |h|. Second returns is |true| if an entry exists
 	// and |false| otherwise.
-	Lookup(h *addr) (indexEntry, bool)
+	Lookup(h *addr) (indexEntry, bool, error)
 	// Ordinals returns a slice of indexes which maps the |i|th chunk in
 	// the indexed file to its corresponding entry in index. The |i|th
 	// entry in the result is the |i|th chunk in the indexed file, and its
@@ -359,7 +359,7 @@ type tableIndex interface {
 
 	// Clone returns a |tableIndex| with the same contents which can be
 	// |Close|d independently.
-	Clone() tableIndex
+	Clone() (tableIndex, error)
 }
 
 var _ tableIndex = mmapTableIndex{}
@@ -371,28 +371,37 @@ func parseTableIndex(buff []byte) (onHeapTableIndex, error) {
 	return ReadTableIndex(bytes.NewReader(buff))
 }
 
-func ReadTableIndex(rd io.ReadSeeker) (onHeapTableIndex, error) {
+func ReadTableFooter(rd io.ReadSeeker) (chunkCount uint32, totalUncompressedData uint64, err error) {
 	footerSize := int64(magicNumberSize + uint64Size + uint32Size)
-	_, err := rd.Seek(-footerSize, io.SeekEnd)
+	_, err = rd.Seek(-footerSize, io.SeekEnd)
 
 	if err != nil {
-		return onHeapTableIndex{}, err
+		return 0, 0, err
 	}
 
 	footer, err := iohelp.ReadNBytes(rd, int(footerSize))
 
 	if err != nil {
-		return onHeapTableIndex{}, err
+		return 0, 0, err
 	}
 
 	if string(footer[uint32Size+uint64Size:]) != magicNumber {
-		return onHeapTableIndex{}, ErrInvalidTableFile
+		return 0, 0, ErrInvalidTableFile
 	}
 
-	chunkCount := binary.BigEndian.Uint32(footer)
-	totalUncompressedData := binary.BigEndian.Uint64(footer[uint32Size:])
+	chunkCount = binary.BigEndian.Uint32(footer)
+	totalUncompressedData = binary.BigEndian.Uint64(footer[uint32Size:])
 
-	// index
+	return
+}
+
+func ReadTableIndex(rd io.ReadSeeker) (onHeapTableIndex, error) {
+	footerSize := int64(magicNumberSize + uint64Size + uint32Size)
+	chunkCount, totalUncompressedData, err := ReadTableFooter(rd)
+	if err != nil {
+		return onHeapTableIndex{}, err
+	}
+
 	suffixesSize := int64(chunkCount) * addrSuffixSize
 	lengthsSize := int64(chunkCount) * lengthSize
 	tuplesSize := int64(chunkCount) * prefixTupleSize
@@ -456,7 +465,7 @@ func (ti onHeapTableIndex) TableFileSize() uint64 {
 	if ti.chunkCount == 0 {
 		return footerSize
 	}
-	len, offset := ti.offsets[ti.chunkCount-1], uint64(ti.lengths[ti.chunkCount-1])
+	offset, len := ti.offsets[ti.chunkCount-1], uint64(ti.lengths[ti.chunkCount-1])
 	return offset + len + indexSize(ti.chunkCount) + footerSize
 }
 
@@ -481,9 +490,9 @@ func (ti onHeapTableIndex) prefixIdx(prefix uint64) (idx uint32) {
 
 // EntrySuffixMatches returns true IFF the suffix for prefix entry |idx|
 // matches the address |a|.
-func (ti onHeapTableIndex) EntrySuffixMatches(idx uint32, h *addr) bool {
+func (ti onHeapTableIndex) EntrySuffixMatches(idx uint32, h *addr) (bool, error) {
 	li := uint64(ti.ordinals[idx]) * addrSuffixSize
-	return bytes.Equal(h[addrPrefixSize:], ti.suffixes[li:li+addrSuffixSize])
+	return bytes.Equal(h[addrPrefixSize:], ti.suffixes[li:li+addrSuffixSize]), nil
 }
 
 // lookupOrdinal returns the ordinal of |h| if present. Returns |ti.chunkCount|
@@ -492,7 +501,7 @@ func (ti onHeapTableIndex) lookupOrdinal(h *addr) uint32 {
 	prefix := h.Prefix()
 
 	for idx := ti.prefixIdx(prefix); idx < ti.chunkCount && ti.prefixes[idx] == prefix; idx++ {
-		if ti.EntrySuffixMatches(idx, h) {
+		if b, _ := ti.EntrySuffixMatches(idx, h); b {
 			return ti.ordinals[idx]
 		}
 	}
@@ -500,22 +509,22 @@ func (ti onHeapTableIndex) lookupOrdinal(h *addr) uint32 {
 	return ti.chunkCount
 }
 
-func (ti onHeapTableIndex) IndexEntry(idx uint32, a *addr) indexEntry {
+func (ti onHeapTableIndex) IndexEntry(idx uint32, a *addr) (indexEntry, error) {
 	ord := ti.ordinals[idx]
 	if a != nil {
 		binary.BigEndian.PutUint64(a[:], ti.prefixes[idx])
 		li := uint64(ord) * addrSuffixSize
 		copy(a[addrPrefixSize:], ti.suffixes[li:li+addrSuffixSize])
 	}
-	return indexResult{ti.offsets[ord], ti.lengths[ord]}
+	return indexResult{ti.offsets[ord], ti.lengths[ord]}, nil
 }
 
-func (ti onHeapTableIndex) Lookup(h *addr) (indexEntry, bool) {
+func (ti onHeapTableIndex) Lookup(h *addr) (indexEntry, bool, error) {
 	ord := ti.lookupOrdinal(h)
 	if ord == ti.chunkCount {
-		return indexResult{}, false
+		return indexResult{}, false, nil
 	}
-	return indexResult{ti.offsets[ord], ti.lengths[ord]}, true
+	return indexResult{ti.offsets[ord], ti.lengths[ord]}, true, nil
 }
 
 func (ti onHeapTableIndex) Prefixes() []uint64 {
@@ -526,20 +535,20 @@ func (ti onHeapTableIndex) Ordinals() []uint32 {
 	return ti.ordinals
 }
 
-func (i onHeapTableIndex) ChunkCount() uint32 {
-	return i.chunkCount
+func (ti onHeapTableIndex) ChunkCount() uint32 {
+	return ti.chunkCount
 }
 
-func (i onHeapTableIndex) TotalUncompressedData() uint64 {
-	return i.totalUncompressedData
+func (ti onHeapTableIndex) TotalUncompressedData() uint64 {
+	return ti.totalUncompressedData
 }
 
-func (i onHeapTableIndex) Close() error {
+func (ti onHeapTableIndex) Close() error {
 	return nil
 }
 
-func (i onHeapTableIndex) Clone() tableIndex {
-	return i
+func (ti onHeapTableIndex) Clone() (tableIndex, error) {
+	return ti, nil
 }
 
 // newTableReader parses a valid nbs table byte stream and returns a reader. buff must end with an NBS index
@@ -584,7 +593,11 @@ func (tr tableReader) hasMany(addrs []hasRecord) (bool, error) {
 
 		// prefixes are equal, so locate and compare against the corresponding suffix
 		for j := filterIdx; j < filterLen && addr.prefix == tr.prefixes[j]; j++ {
-			if tr.EntrySuffixMatches(j, addr.a) {
+			m, err := tr.EntrySuffixMatches(j, addr.a)
+			if err != nil {
+				return false, err
+			}
+			if m {
 				addrs[i].has = true
 				break
 			}
@@ -612,14 +625,17 @@ func (tr tableReader) index() (tableIndex, error) {
 
 // returns true iff |h| can be found in this table.
 func (tr tableReader) has(h addr) (bool, error) {
-	_, ok := tr.Lookup(&h)
-	return ok, nil
+	_, ok, err := tr.Lookup(&h)
+	return ok, err
 }
 
 // returns the storage associated with |h|, iff present. Returns nil if absent. On success,
 // the returned byte slice directly references the underlying storage.
 func (tr tableReader) get(ctx context.Context, h addr, stats *Stats) ([]byte, error) {
-	e, found := tr.Lookup(&h)
+	e, found, err := tr.Lookup(&h)
+	if err != nil {
+		return nil, err
+	}
 	if !found {
 		return nil, nil
 	}
@@ -746,15 +762,21 @@ func (tr tableReader) getMany(
 
 	// Pass #1: Iterate over |reqs| and |tr.prefixes| (both sorted by address) and build the set
 	// of table locations which must be read in order to satisfy the getMany operation.
-	offsetRecords, remaining := tr.findOffsets(reqs)
-	err := tr.getManyAtOffsets(ctx, eg, offsetRecords, found, stats)
+	offsetRecords, remaining, err := tr.findOffsets(reqs)
+	if err != nil {
+		return false, err
+	}
+	err = tr.getManyAtOffsets(ctx, eg, offsetRecords, found, stats)
 	return remaining, err
 }
 func (tr tableReader) getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, CompressedChunk), stats *Stats) (bool, error) {
 	// Pass #1: Iterate over |reqs| and |tr.prefixes| (both sorted by address) and build the set
 	// of table locations which must be read in order to satisfy the getMany operation.
-	offsetRecords, remaining := tr.findOffsets(reqs)
-	err := tr.getManyCompressedAtOffsets(ctx, eg, offsetRecords, found, stats)
+	offsetRecords, remaining, err := tr.findOffsets(reqs)
+	if err != nil {
+		return false, err
+	}
+	err = tr.getManyCompressedAtOffsets(ctx, eg, offsetRecords, found, stats)
 	return remaining, err
 }
 
@@ -867,7 +889,7 @@ func (tr tableReader) getManyAtOffsetsWithReadFunc(
 // chunks remaining will be set to false upon return. If some are not here,
 // then remaining will be true. The result offsetRecSlice is sorted in offset
 // order.
-func (tr tableReader) findOffsets(reqs []getRecord) (ors offsetRecSlice, remaining bool) {
+func (tr tableReader) findOffsets(reqs []getRecord) (ors offsetRecSlice, remaining bool, err error) {
 	filterIdx := uint32(0)
 	filterLen := uint32(len(tr.prefixes))
 	ors = make(offsetRecSlice, 0, len(reqs))
@@ -896,9 +918,16 @@ func (tr tableReader) findOffsets(reqs []getRecord) (ors offsetRecSlice, remaini
 
 		// record all offsets within the table which contain the data required.
 		for j := filterIdx; j < filterLen && req.prefix == tr.prefixes[j]; j++ {
-			if tr.EntrySuffixMatches(j, req.a) {
+			m, err := tr.EntrySuffixMatches(j, req.a)
+			if err != nil {
+				return nil, false, err
+			}
+			if m {
 				reqs[i].found = true
-				entry := tr.IndexEntry(j, nil)
+				entry, err := tr.IndexEntry(j, nil)
+				if err != nil {
+					return nil, false, err
+				}
 				ors = append(ors, offsetRec{req.a, entry.Offset(), entry.Length()})
 				break
 			}
@@ -906,7 +935,7 @@ func (tr tableReader) findOffsets(reqs []getRecord) (ors offsetRecSlice, remaini
 	}
 
 	sort.Sort(ors)
-	return ors, remaining
+	return ors, remaining, nil
 }
 
 func canReadAhead(fRec offsetRec, curStart, curEnd, blockSize uint64) (newEnd uint64, canRead bool) {
@@ -933,7 +962,10 @@ func canReadAhead(fRec offsetRec, curStart, curEnd, blockSize uint64) (newEnd ui
 func (tr tableReader) calcReads(reqs []getRecord, blockSize uint64) (reads int, remaining bool, err error) {
 	var offsetRecords offsetRecSlice
 	// Pass #1: Build the set of table locations which must be read in order to find all the elements of |reqs| which are present in this table.
-	offsetRecords, remaining = tr.findOffsets(reqs)
+	offsetRecords, remaining, err = tr.findOffsets(reqs)
+	if err != nil {
+		return 0, false, err
+	}
 
 	// Now |offsetRecords| contains all locations within the table which must
 	// be searched (note that there may be duplicates of a particular
@@ -997,7 +1029,10 @@ func (tr tableReader) extract(ctx context.Context, chunks chan<- extractRecord) 
 	var ors offsetRecSlice
 	for i := uint32(0); i < tr.chunkCount; i++ {
 		a := new(addr)
-		e := tr.IndexEntry(i, a)
+		e, err := tr.IndexEntry(i, a)
+		if err != nil {
+			return err
+		}
 		ors = append(ors, offsetRec{a, e.Offset(), e.Length()})
 	}
 	sort.Sort(ors)
@@ -1020,8 +1055,12 @@ func (tr tableReader) Close() error {
 	return tr.tableIndex.Close()
 }
 
-func (tr tableReader) Clone() tableReader {
-	return tableReader{tr.tableIndex.Clone(), tr.prefixes, tr.chunkCount, tr.totalUncompressedData, tr.r, tr.blockSize}
+func (tr tableReader) Clone() (tableReader, error) {
+	ti, err := tr.tableIndex.Clone()
+	if err != nil {
+		return tableReader{}, err
+	}
+	return tableReader{ti, tr.prefixes, tr.chunkCount, tr.totalUncompressedData, tr.r, tr.blockSize}, nil
 }
 
 type readerAdapter struct {

--- a/go/store/nbs/table_test.go
+++ b/go/store/nbs/table_test.go
@@ -79,7 +79,8 @@ func TestSimple(t *testing.T) {
 	require.NoError(t, err)
 	ti, err := parseTableIndex(tableData)
 	require.NoError(t, err)
-	tr := newTableReader(ti, tableReaderAtFromBytes(tableData), fileBlockSize)
+	tr, err := newTableReader(ti, tableReaderAtFromBytes(tableData), fileBlockSize)
+	require.NoError(t, err)
 
 	assertChunksInReader(chunks, tr, assert)
 
@@ -125,7 +126,8 @@ func TestHasMany(t *testing.T) {
 	require.NoError(t, err)
 	ti, err := parseTableIndex(tableData)
 	require.NoError(t, err)
-	tr := newTableReader(ti, tableReaderAtFromBytes(tableData), fileBlockSize)
+	tr, err := newTableReader(ti, tableReaderAtFromBytes(tableData), fileBlockSize)
+	require.NoError(t, err)
 
 	addrs := addrSlice{computeAddr(chunks[0]), computeAddr(chunks[1]), computeAddr(chunks[2])}
 	hasAddrs := []hasRecord{
@@ -175,7 +177,8 @@ func TestHasManySequentialPrefix(t *testing.T) {
 
 	ti, err := parseTableIndex(buff)
 	require.NoError(t, err)
-	tr := newTableReader(ti, tableReaderAtFromBytes(buff), fileBlockSize)
+	tr, err := newTableReader(ti, tableReaderAtFromBytes(buff), fileBlockSize)
+	require.NoError(t, err)
 
 	hasAddrs := make([]hasRecord, 2)
 	// Leave out the first address
@@ -203,7 +206,8 @@ func TestGetMany(t *testing.T) {
 	require.NoError(t, err)
 	ti, err := parseTableIndex(tableData)
 	require.NoError(t, err)
-	tr := newTableReader(ti, tableReaderAtFromBytes(tableData), fileBlockSize)
+	tr, err := newTableReader(ti, tableReaderAtFromBytes(tableData), fileBlockSize)
+	require.NoError(t, err)
 
 	addrs := addrSlice{computeAddr(data[0]), computeAddr(data[1]), computeAddr(data[2])}
 	getBatch := []getRecord{
@@ -236,7 +240,8 @@ func TestCalcReads(t *testing.T) {
 	require.NoError(t, err)
 	ti, err := parseTableIndex(tableData)
 	require.NoError(t, err)
-	tr := newTableReader(ti, tableReaderAtFromBytes(tableData), 0)
+	tr, err := newTableReader(ti, tableReaderAtFromBytes(tableData), 0)
+	require.NoError(t, err)
 	addrs := addrSlice{computeAddr(chunks[0]), computeAddr(chunks[1]), computeAddr(chunks[2])}
 	getBatch := []getRecord{
 		{&addrs[0], binary.BigEndian.Uint64(addrs[0][:addrPrefixSize]), false},
@@ -272,7 +277,8 @@ func TestExtract(t *testing.T) {
 	require.NoError(t, err)
 	ti, err := parseTableIndex(tableData)
 	require.NoError(t, err)
-	tr := newTableReader(ti, tableReaderAtFromBytes(tableData), fileBlockSize)
+	tr, err := newTableReader(ti, tableReaderAtFromBytes(tableData), fileBlockSize)
+	require.NoError(t, err)
 
 	addrs := addrSlice{computeAddr(chunks[0]), computeAddr(chunks[1]), computeAddr(chunks[2])}
 
@@ -310,7 +316,8 @@ func Test65k(t *testing.T) {
 	require.NoError(t, err)
 	ti, err := parseTableIndex(tableData)
 	require.NoError(t, err)
-	tr := newTableReader(ti, tableReaderAtFromBytes(tableData), fileBlockSize)
+	tr, err := newTableReader(ti, tableReaderAtFromBytes(tableData), fileBlockSize)
+	require.NoError(t, err)
 
 	for i := 0; i < count; i++ {
 		data := dataFn(i)
@@ -362,7 +369,8 @@ func doTestNGetMany(t *testing.T, count int) {
 	require.NoError(t, err)
 	ti, err := parseTableIndex(tableData)
 	require.NoError(t, err)
-	tr := newTableReader(ti, tableReaderAtFromBytes(tableData), fileBlockSize)
+	tr, err := newTableReader(ti, tableReaderAtFromBytes(tableData), fileBlockSize)
+	require.NoError(t, err)
 
 	getBatch := make([]getRecord, len(data))
 	for i := 0; i < count; i++ {

--- a/go/store/nbs/util.go
+++ b/go/store/nbs/util.go
@@ -35,7 +35,10 @@ func IterChunks(rd io.ReadSeeker, cb func(chunk chunks.Chunk) (stop bool, err er
 	seen := make(map[addr]bool)
 	for i := uint32(0); i < idx.ChunkCount(); i++ {
 		var a addr
-		ie := idx.IndexEntry(i, &a)
+		ie, err := idx.IndexEntry(i, &a)
+		if err != nil {
+			return err
+		}
 		if _, ok := seen[a]; !ok {
 			seen[a] = true
 			chunkBytes, err := readNFrom(rd, ie.Offset(), ie.Length())


### PR DESCRIPTION
In preparation for a disk `tableIndex`, I altered the tableIndex functions to return errors and fixed any code that needs to return errors. 

The Ordinals() and Prefixes() functions have also been changed to return errors, but for TOW I'm not sure we can return an entire slice of all ordinals or prefixes without blowing up.