### PR TITLE
add bats test for different db stmts

### DIFF
--- a/integration-tests/bats/auto_increment.bats
+++ b/integration-tests/bats/auto_increment.bats
@@ -682,3 +682,16 @@ SQL
     [[ "${lines[2]}" =~ "2" ]] || false    
 }
 
+@test "auto_increment: alter table add constraint for different database" {
+    skip "add constraint for different database fix in progress"
+    dolt sql  <<SQL
+CREATE DATABASE public;
+CREATE TABLE public.test (pk integer NOT NULL, c1 integer, c2 integer);
+ALTER TABLE public.test ADD CONSTRAINT serial_pk_pkey PRIMARY KEY (pk);
+ALTER TABLE public.test MODIFY pk integer auto_increment;
+SQL
+
+    run dolt sql -q "SHOW CREATE TABLE public.test"
+    [ $status -eq 0 ]
+    [[ "$output" =~ "NOT NULL AUTO_INCREMENT" ]] || false
+}

--- a/integration-tests/bats/index.bats
+++ b/integration-tests/bats/index.bats
@@ -2599,3 +2599,17 @@ SQL
     [[ "$output" =~ "Bbbb" ]] || false
     [[ "$output" =~ "bBbb" ]] || false
 }
+
+@test "index: alter table create index for different database" {
+    skip "create index for different database fix in progress"
+    dolt sql  <<SQL
+CREATE DATABASE public;
+CREATE TABLE public.test (pk integer NOT NULL, c1 integer);
+ALTER TABLE public.test ADD CONSTRAINT index_test_pkey PRIMARY KEY (pk);
+CREATE INDEX index_test_c1_idx ON public.test (c1);
+SQL
+
+    run dolt sql -q "show create table public.test"
+    [ $status -eq 0 ]
+    [[ "$output" =~ "KEY \`index_test_c1_idx\`" ]] || false
+}


### PR DESCRIPTION
Added tests for using different database than current for ALTER TABLE - CREATE INDEX and ADD CONSTRAINT. 
Added tests for ADD CONSTRAINT FOREIGN KEY query should be failing, but currently does not.