### PR TITLE
go/cmd/dolt: Add download statistics to dolt clone

### DIFF
--- a/go/Godeps/LICENSES
+++ b/go/Godeps/LICENSES
@@ -4349,6 +4349,23 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ================================================================================
 
 ================================================================================
+= github.com/gosuri/uilive licensed under: =
+
+MIT License
+===========
+
+Copyright (c) 2015, Greg Osuri
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+= LICENSE cde7aa271cbea2eab88298ec101c4d0acf5d175e056bdba8f573ca79 =
+================================================================================
+
+================================================================================
 = github.com/hashicorp/golang-lru licensed under: =
 
 Mozilla Public License, version 2.0

--- a/go/go.mod
+++ b/go/go.mod
@@ -70,6 +70,7 @@ require (
 require (
 	github.com/dolthub/go-mysql-server v0.11.1-0.20220215191257-1f49bce27f46
 	github.com/google/flatbuffers v2.0.5+incompatible
+	github.com/gosuri/uilive v0.0.4
 	github.com/kch42/buzhash v0.0.0-20160816060738-9bdec3dec7c6
 	github.com/prometheus/client_golang v1.11.0
 	github.com/shirou/gopsutil/v3 v3.22.1

--- a/go/go.sum
+++ b/go/go.sum
@@ -381,6 +381,8 @@ github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoA
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gostaticanalysis/analysisutil v0.0.0-20190318220348-4088753ea4d3/go.mod h1:eEOZF4jCKGi+aprrirO9e7WKB3beBRtWgqGunKl6pKE=
 github.com/gostaticanalysis/analysisutil v0.0.3/go.mod h1:eEOZF4jCKGi+aprrirO9e7WKB3beBRtWgqGunKl6pKE=
+github.com/gosuri/uilive v0.0.4 h1:hUEBpQDj8D8jXgtCdBu7sWsy5sbW/5GhuO8KBwJ2jyY=
+github.com/gosuri/uilive v0.0.4/go.mod h1:V/epo5LjjlDE5RJUcqx8dbw+zc93y5Ya3yg8tfZ74VI=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=

--- a/go/libraries/doltcore/env/actions/clone.go
+++ b/go/libraries/doltcore/env/actions/clone.go
@@ -145,7 +145,7 @@ func cloneProg(eventCh <-chan pull.TableFileEvent) {
 			s := currStats[fileId]
 			bps := float64(s.Read) / s.Elapsed.Seconds()
 			rate := humanize.Bytes(uint64(bps)) + "/s"
-			fmt.Fprintf(writer.Newline(), "File: %s (%s chunks) - %.2f%% downloaded, %s\n",
+			fmt.Fprintf(writer.Newline(), "Downloading file: %s (%s chunks) - %.2f%% downloaded, %s, \n",
 				fileId, strhelp.CommaIfy(int64((*tableFiles[fileId]).NumChunks())), s.Percent*100, rate)
 		}
 		writer.Stop()

--- a/go/libraries/doltcore/env/actions/clone.go
+++ b/go/libraries/doltcore/env/actions/clone.go
@@ -100,7 +100,6 @@ func cloneProg(eventCh <-chan pull.TableFileEvent) {
 		chunksDownloaded  int64
 		currStats         = make(map[string]iohelp.ReadStats)
 		tableFiles        = make(map[string]*nbs.TableFile)
-		//cliPos            int
 	)
 
 	writer := uilive.New()
@@ -140,7 +139,8 @@ func cloneProg(eventCh <-chan pull.TableFileEvent) {
 
 		// Starting and stopping for each event seems to be less jumpy
 		writer.Start()
-		fmt.Fprintf(writer, "%s of %s chunks complete. %s chunks being downloaded currently.\n", strhelp.CommaIfy(chunksDownloaded), strhelp.CommaIfy(chunks), strhelp.CommaIfy(chunksDownloading))
+		fmt.Fprintf(writer, "%s of %s chunks complete. %s chunks being downloaded currently.\n",
+			strhelp.CommaIfy(chunksDownloaded), strhelp.CommaIfy(chunks), strhelp.CommaIfy(chunksDownloading))
 		for _, fileId := range sortedKeys(currStats) {
 			s := currStats[fileId]
 			bps := float64(s.Read) / s.Elapsed.Seconds()

--- a/go/libraries/doltcore/env/actions/clone.go
+++ b/go/libraries/doltcore/env/actions/clone.go
@@ -23,6 +23,9 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/dustin/go-humanize"
+	"github.com/gosuri/uilive"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
@@ -33,8 +36,6 @@ import (
 	"github.com/dolthub/dolt/go/store/datas/pull"
 	"github.com/dolthub/dolt/go/store/nbs"
 	"github.com/dolthub/dolt/go/store/types"
-	"github.com/dustin/go-humanize"
-	"github.com/gosuri/uilive"
 )
 
 var ErrRepositoryExists = errors.New("data repository already exists")

--- a/go/libraries/utils/iohelp/read_with_stats.go
+++ b/go/libraries/utils/iohelp/read_with_stats.go
@@ -66,11 +66,9 @@ func (rws *ReaderWithStats) Start(updateFunc func(ReadStats)) {
 	}()
 }
 
-// Close is equivalent to Stop
-func (rws *ReaderWithStats) Close() error {
-	return rws.Stop()
-}
-
+// Stop "closes" ReaderWithStats. Occasionally, we might pass this ReaderWithStats as the body of
+// a http.Request. Since http.Request will close the body if it is an io.Closer, we can't have ReaderWithStats conform
+// to io.Closer. We want full control over the Start and Stop of ReaderWithStats.
 func (rws *ReaderWithStats) Stop() error {
 	close(rws.closeCh)
 

--- a/go/libraries/utils/iohelp/read_with_stats.go
+++ b/go/libraries/utils/iohelp/read_with_stats.go
@@ -63,6 +63,17 @@ func (rws *ReaderWithStats) Start(updateFunc func(ReadStats)) {
 	}()
 }
 
+// Close closes this reader. Only one of Close or Stop should be called
+func (rws *ReaderWithStats) Close() error {
+	close(rws.closeCh)
+
+	if closer, ok := rws.rd.(io.Closer); ok {
+		return closer.Close()
+	}
+
+	return nil
+}
+
 func (rws *ReaderWithStats) Stop() {
 	close(rws.closeCh)
 

--- a/go/store/datas/pull/clone.go
+++ b/go/store/datas/pull/clone.go
@@ -155,7 +155,7 @@ func clone(ctx context.Context, srcTS, sinkTS nbs.TableFileStore, eventCh chan<-
 				})
 
 				report(TableFileEvent{EventType: DownloadStart, TableFiles: []nbs.TableFile{tblFile}})
-				err = sinkTS.WriteTableFile(ctx, tblFile.FileID(), tblFile.NumChunks(), rd, 0, nil)
+				err = sinkTS.WriteTableFile(ctx, tblFile.FileID(), tblFile.NumChunks(), rdStats, contentLength, nil)
 				if err != nil {
 					report(TableFileEvent{EventType: DownloadFailed, TableFiles: []nbs.TableFile{tblFile}})
 					return err

--- a/go/store/datas/pull/clone.go
+++ b/go/store/datas/pull/clone.go
@@ -20,10 +20,10 @@ import (
 	"io"
 
 	"github.com/cenkalti/backoff"
-	"github.com/dolthub/dolt/go/libraries/utils/iohelp"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 
+	"github.com/dolthub/dolt/go/libraries/utils/iohelp"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/nbs"

--- a/go/store/datas/pull/pull_test.go
+++ b/go/store/datas/pull/pull_test.go
@@ -385,8 +385,8 @@ func (ttf *TestFailingTableFile) NumChunks() int {
 	return ttf.numChunks
 }
 
-func (ttf *TestFailingTableFile) Open(ctx context.Context) (io.ReadCloser, error) {
-	return io.NopCloser(bytes.NewReader([]byte{0x00})), errors.New("this is a test error")
+func (ttf *TestFailingTableFile) Open(ctx context.Context) (io.ReadCloser, uint64, error) {
+	return io.NopCloser(bytes.NewReader([]byte{0x00})), 1, errors.New("this is a test error")
 }
 
 type TestTableFile struct {
@@ -403,8 +403,8 @@ func (ttf *TestTableFile) NumChunks() int {
 	return ttf.numChunks
 }
 
-func (ttf *TestTableFile) Open(ctx context.Context) (io.ReadCloser, error) {
-	return io.NopCloser(bytes.NewReader(ttf.data)), nil
+func (ttf *TestTableFile) Open(ctx context.Context) (io.ReadCloser, uint64, error) {
+	return io.NopCloser(bytes.NewReader(ttf.data)), uint64(len(ttf.data)), nil
 }
 
 type TestTableFileWriter struct {

--- a/go/store/datas/pull/puller.go
+++ b/go/store/datas/pull/puller.go
@@ -223,7 +223,7 @@ func (p *Puller) uploadTempTableFile(ctx context.Context, ae *atomicerr.AtomicEr
 		}))
 	})
 	defer func() {
-		fWithStats.Stop()
+		_ = fWithStats.Stop()
 
 		go func() {
 			_ = file.Remove(tmpTblFile.path)

--- a/go/store/nbs/file_table_persister.go
+++ b/go/store/nbs/file_table_persister.go
@@ -133,9 +133,6 @@ func (ftp *fsTablePersister) persistTable(ctx context.Context, name addr, data [
 
 func (ftp *fsTablePersister) ConjoinAll(ctx context.Context, sources chunkSources, stats *Stats) (chunkSource, error) {
 	plan, err := planConjoin(sources, stats)
-	for _, source := range sources {
-		source.Close()
-	}
 
 	if err != nil {
 		return emptyChunkSource{}, err

--- a/go/store/nbs/file_table_persister.go
+++ b/go/store/nbs/file_table_persister.go
@@ -133,6 +133,9 @@ func (ftp *fsTablePersister) persistTable(ctx context.Context, name addr, data [
 
 func (ftp *fsTablePersister) ConjoinAll(ctx context.Context, sources chunkSources, stats *Stats) (chunkSource, error) {
 	plan, err := planConjoin(sources, stats)
+	for _, source := range sources {
+		source.Close()
+	}
 
 	if err != nil {
 		return emptyChunkSource{}, err

--- a/go/store/nbs/persisting_chunk_source.go
+++ b/go/store/nbs/persisting_chunk_source.go
@@ -226,6 +226,20 @@ func (ccs *persistingChunkSource) reader(ctx context.Context) (io.Reader, error)
 	return ccs.cs.reader(ctx)
 }
 
+func (ccs *persistingChunkSource) size() (uint64, error) {
+	err := ccs.wait()
+
+	if err != nil {
+		return 0, err
+	}
+
+	if ccs.cs == nil {
+		return 0, ErrNoChunkSource
+	}
+
+	return ccs.cs.size()
+}
+
 func (ccs *persistingChunkSource) calcReads(reqs []getRecord, blockSize uint64) (reads int, remaining bool, err error) {
 	err = ccs.wait()
 
@@ -294,6 +308,10 @@ func (ecs emptyChunkSource) index() (tableIndex, error) {
 
 func (ecs emptyChunkSource) reader(context.Context) (io.Reader, error) {
 	return &bytes.Buffer{}, nil
+}
+
+func (ecs emptyChunkSource) size() (uint64, error) {
+	return 0, nil
 }
 
 func (ecs emptyChunkSource) calcReads(reqs []getRecord, blockSize uint64) (reads int, remaining bool, err error) {

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -1216,7 +1216,12 @@ func newTableFile(cs chunkSource, info tableSpec) tableFile {
 				return nil, 0, err
 			}
 
-			return io.NopCloser(r), 0, nil
+			s, err := cs.size()
+			if err != nil {
+				return nil, 0, err
+			}
+
+			return io.NopCloser(r), s, nil
 		},
 	}
 }

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -1216,12 +1216,7 @@ func newTableFile(cs chunkSource, info tableSpec) tableFile {
 				return nil, 0, err
 			}
 
-			len, err := cs.uncompressedLen()
-			if err != nil {
-				return nil, 0, err
-			}
-
-			return io.NopCloser(r), len, nil
+			return io.NopCloser(r), 0, nil
 		},
 	}
 }

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -1135,7 +1135,7 @@ func (nbs *NomsBlockStore) StatsSummary() string {
 // tableFile is our implementation of TableFile.
 type tableFile struct {
 	info TableSpecInfo
-	open func(ctx context.Context) (io.ReadCloser, error)
+	open func(ctx context.Context) (io.ReadCloser, uint64, error)
 }
 
 // FileID gets the id of the file
@@ -1148,8 +1148,8 @@ func (tf tableFile) NumChunks() int {
 	return int(tf.info.GetChunkCount())
 }
 
-// Open returns an io.ReadCloser which can be used to read the bytes of a table file.
-func (tf tableFile) Open(ctx context.Context) (io.ReadCloser, error) {
+// Open returns an io.ReadCloser which can be used to read the bytes of a table file and the content length in bytes.
+func (tf tableFile) Open(ctx context.Context) (io.ReadCloser, uint64, error) {
 	return tf.open(ctx)
 }
 
@@ -1210,13 +1210,18 @@ func getTableFiles(css map[addr]chunkSource, contents manifestContents, numSpecs
 func newTableFile(cs chunkSource, info tableSpec) tableFile {
 	return tableFile{
 		info: info,
-		open: func(ctx context.Context) (io.ReadCloser, error) {
+		open: func(ctx context.Context) (io.ReadCloser, uint64, error) {
 			r, err := cs.reader(ctx)
 			if err != nil {
-				return nil, err
+				return nil, 0, err
 			}
 
-			return io.NopCloser(r), nil
+			len, err := cs.uncompressedLen()
+			if err != nil {
+				return nil, 0, err
+			}
+
+			return io.NopCloser(r), len, nil
 		},
 	}
 }

--- a/go/store/nbs/store_test.go
+++ b/go/store/nbs/store_test.go
@@ -94,8 +94,9 @@ func TestNBSAsTableFileStore(t *testing.T) {
 		expected, ok := fileToData[fileID]
 		require.True(t, ok)
 
-		rd, _, err := src.Open(context.Background())
+		rd, contentLength, err := src.Open(context.Background())
 		require.NoError(t, err)
+		require.Equal(t, len(expected), int(contentLength))
 
 		data, err := io.ReadAll(rd)
 		require.NoError(t, err)

--- a/go/store/nbs/store_test.go
+++ b/go/store/nbs/store_test.go
@@ -94,7 +94,7 @@ func TestNBSAsTableFileStore(t *testing.T) {
 		expected, ok := fileToData[fileID]
 		require.True(t, ok)
 
-		rd, err := src.Open(context.Background())
+		rd, _, err := src.Open(context.Background())
 		require.NoError(t, err)
 
 		data, err := io.ReadAll(rd)

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -283,8 +283,8 @@ type TableFile interface {
 	// NumChunks returns the number of chunks in a table file
 	NumChunks() int
 
-	// Open returns an io.ReadCloser which can be used to read the bytes of a table file.
-	Open(ctx context.Context) (io.ReadCloser, error)
+	// Open returns an io.ReadCloser which can be used to read the bytes of a table file and the content length in bytes.
+	Open(ctx context.Context) (io.ReadCloser, uint64, error)
 }
 
 // Describes what is possible to do with TableFiles in a TableFileStore.

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -263,6 +263,8 @@ type chunkSource interface {
 
 	// opens a Reader to the first byte of the chunkData segment of this table.
 	reader(context.Context) (io.Reader, error)
+	// size returns the total size of the chunkSource: chunks, index, and footer
+	size() (uint64, error)
 	index() (tableIndex, error)
 
 	// Clone returns a |chunkSource| with the same contents as the

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -283,7 +283,8 @@ type TableFile interface {
 	// NumChunks returns the number of chunks in a table file
 	NumChunks() int
 
-	// Open returns an io.ReadCloser which can be used to read the bytes of a table file and the content length in bytes.
+	// Open returns an io.ReadCloser which can be used to read the bytes of a table file. The total length of the
+	// table file in bytes can be optionally returned.
 	Open(ctx context.Context) (io.ReadCloser, uint64, error)
 }
 

--- a/go/store/nbs/table_reader.go
+++ b/go/store/nbs/table_reader.go
@@ -643,6 +643,11 @@ func (tr tableReader) reader(ctx context.Context) (io.Reader, error) {
 	return io.LimitReader(&readerAdapter{tr.r, 0, ctx}, int64(i.TableFileSize())), nil
 }
 
+func (tr tableReader) size() (uint64, error) {
+	i, _ := tr.index()
+	return i.TableFileSize(), nil
+}
+
 func (tr tableReader) Close() error {
 	return tr.tableIndex.Close()
 }


### PR DESCRIPTION
Previously, it was difficult to understand the progress of `dolt clone`, especially when you are cloning a db with a small number of large table files. `dolt clone` now lists which table files are being concurrently downloaded and shows the progress and download rate for each. 

An example:
![Screen Shot 2022-02-16 at 4 45 29 PM](https://user-images.githubusercontent.com/14025711/154382327-c38a861b-1cad-40a6-a18a-dea14dab5f6f.png)

@reltuk Brought up the concern for compatibility between the new `uilive` dep and `github.com/faith/color`. In my testing there doesn't seem to be any issues:

![Screen_Shot_2022-02-16_at_3 51 45_PM](https://user-images.githubusercontent.com/14025711/154380907-8345a13d-8c4d-450c-be9a-3438f71dc172.png)


