### PR TITLE
store/types: fix dropped error

### DIFF
--- a/go/store/types/map.go
+++ b/go/store/types/map.go
@@ -792,6 +792,9 @@ func indexForKeyWithinSubtree(ctx context.Context, key orderedKey, metaSeq metaS
 		}
 
 		isLess, err := key.Less(vrw.Format(), tupleKey)
+		if err != nil {
+			return 0, err
+		}
 		if !isLess {
 			eq := tupleKey.v.Equals(key.v)
 			if eq {


### PR DESCRIPTION
This fixes a dropped `err` variable in the `store/types` package.