### PR TITLE
go/dolt/cmd: Use download language when dolt pulls from a remote

### DIFF
--- a/go/cmd/dolt/commands/backup.go
+++ b/go/cmd/dolt/commands/backup.go
@@ -257,7 +257,7 @@ func syncBackup(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.ArgParseR
 	}
 
 	destDb, err := b.GetRemoteDB(ctx, dEnv.DoltDB.ValueReadWriter().Format())
-	err = actions.SyncRoots(ctx, dEnv.DoltDB, destDb, dEnv.TempTableFilesDir(), runProgFuncs, stopProgFuncs)
+	err = actions.SyncRoots(ctx, dEnv.DoltDB, destDb, dEnv.TempTableFilesDir(), buildProgStarter(defaultLanguage), stopProgFuncs)
 
 	switch err {
 	case nil:
@@ -319,7 +319,7 @@ func restoreBackup(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.ArgPar
 		return errhand.VerboseErrorFromError(err)
 	}
 
-	err = actions.SyncRoots(ctx, srcDb, dEnv.DoltDB, dEnv.TempTableFilesDir(), runProgFuncs, stopProgFuncs)
+	err = actions.SyncRoots(ctx, srcDb, dEnv.DoltDB, dEnv.TempTableFilesDir(), buildProgStarter(downloadLanguage), stopProgFuncs)
 	if err != nil {
 		// If we're cloning into a directory that already exists do not erase it. Otherwise
 		// make best effort to delete the directory we created.

--- a/go/cmd/dolt/commands/fetch.go
+++ b/go/cmd/dolt/commands/fetch.go
@@ -81,7 +81,7 @@ func (cmd FetchCmd) Exec(ctx context.Context, commandStr string, args []string, 
 	}
 	updateMode := ref.UpdateMode{Force: apr.Contains(cli.ForceFlag)}
 
-	err = actions.FetchRefSpecs(ctx, dEnv.DbData(), refSpecs, r, updateMode, runProgFuncs, stopProgFuncs)
+	err = actions.FetchRefSpecs(ctx, dEnv.DbData(), refSpecs, r, updateMode, buildProgStarter(downloadLanguage), stopProgFuncs)
 	switch err {
 	case doltdb.ErrUpToDate:
 		return HandleVErrAndExitCode(nil, usage)

--- a/go/cmd/dolt/commands/pull.go
+++ b/go/cmd/dolt/commands/pull.go
@@ -111,7 +111,7 @@ func pullHelper(ctx context.Context, dEnv *env.DoltEnv, pullSpec *env.PullSpec) 
 
 		if remoteTrackRef != nil {
 
-			srcDBCommit, err := actions.FetchRemoteBranch(ctx, dEnv.TempTableFilesDir(), pullSpec.Remote, srcDB, dEnv.DoltDB, pullSpec.Branch, remoteTrackRef, runProgFuncs, stopProgFuncs)
+			srcDBCommit, err := actions.FetchRemoteBranch(ctx, dEnv.TempTableFilesDir(), pullSpec.Remote, srcDB, dEnv.DoltDB, pullSpec.Branch, remoteTrackRef, buildProgStarter(downloadLanguage), stopProgFuncs)
 			if err != nil {
 				return err
 			}
@@ -177,7 +177,7 @@ func pullHelper(ctx context.Context, dEnv *env.DoltEnv, pullSpec *env.PullSpec) 
 	if err != nil {
 		return err
 	}
-	err = actions.FetchFollowTags(ctx, dEnv.TempTableFilesDir(), srcDB, dEnv.DoltDB, runProgFuncs, stopProgFuncs)
+	err = actions.FetchFollowTags(ctx, dEnv.TempTableFilesDir(), srcDB, dEnv.DoltDB, buildProgStarter(downloadLanguage), stopProgFuncs)
 
 	if err != nil {
 		return err

--- a/go/cmd/dolt/commands/push.go
+++ b/go/cmd/dolt/commands/push.go
@@ -112,7 +112,7 @@ func (cmd PushCmd) Exec(ctx context.Context, commandStr string, args []string, d
 	}
 
 	var verr errhand.VerboseError
-	err = actions.DoPush(ctx, dEnv.RepoStateReader(), dEnv.RepoStateWriter(), dEnv.DoltDB, dEnv.TempTableFilesDir(), opts, runProgFuncs, stopProgFuncs)
+	err = actions.DoPush(ctx, dEnv.RepoStateReader(), dEnv.RepoStateWriter(), dEnv.DoltDB, dEnv.TempTableFilesDir(), opts, buildProgStarter(defaultLanguage), stopProgFuncs)
 	if err != nil {
 		verr = printInfoForPushError(err, opts.Remote, opts.DestRef, opts.RemoteRef)
 	}
@@ -175,11 +175,11 @@ func (ts *TextSpinner) next() string {
 	return string([]rune{spinnerSeq[ts.seqPos]})
 }
 
-func pullerProgFunc(ctx context.Context, pullerEventCh chan pull.PullerEvent) {
+func pullerProgFunc(ctx context.Context, pullerEventCh chan pull.PullerEvent, language progLanguage) {
 	var pos int
 	var currentTreeLevel int
 	var percentBuffered float64
-	var tableFilesBuffered int
+	var tableFilesClosed int
 	var filesUploaded int
 	var ts TextSpinner
 
@@ -213,7 +213,7 @@ func pullerProgFunc(ctx context.Context, pullerEventCh chan pull.PullerEvent) {
 		case pull.LevelDoneTWEvent:
 
 		case pull.TableFileClosedEvent:
-			tableFilesBuffered += 1
+			tableFilesClosed += 1
 
 		case pull.StartUploadTableFileEvent:
 
@@ -230,10 +230,16 @@ func pullerProgFunc(ctx context.Context, pullerEventCh chan pull.PullerEvent) {
 		}
 
 		var msg string
-		if len(uploadRate) > 0 {
-			msg = fmt.Sprintf("%s Tree Level: %d, Percent Buffered: %.2f%%, Files Written: %d, Files Uploaded: %d, Current Upload Speed: %s", ts.next(), currentTreeLevel, percentBuffered, tableFilesBuffered, filesUploaded, uploadRate)
+		msg = fmt.Sprintf("%s Tree Level: %d, Percent Buffered: %.2f%%,", ts.next(), currentTreeLevel, percentBuffered)
+
+		if language == downloadLanguage {
+			msg = fmt.Sprintf("%s Files Written: %d", msg, filesUploaded)
 		} else {
-			msg = fmt.Sprintf("%s Tree Level: %d, Percent Buffered: %.2f%% Files Written: %d, Files Uploaded: %d", ts.next(), currentTreeLevel, percentBuffered, tableFilesBuffered, filesUploaded)
+			if len(uploadRate) > 0 {
+				msg = fmt.Sprintf("%s Files Created: %d, Files Uploaded: %d, Current Upload Speed: %s", msg, tableFilesClosed, filesUploaded, uploadRate)
+			} else {
+				msg = fmt.Sprintf("%s Files Created: %d, Files Uploaded: %d", msg, tableFilesClosed, filesUploaded)
+			}
 		}
 
 		pos = cli.DeleteAndPrint(pos, msg)
@@ -278,24 +284,34 @@ func progFunc(ctx context.Context, progChan chan pull.PullProgress) {
 	}
 }
 
-func runProgFuncs(ctx context.Context) (*sync.WaitGroup, chan pull.PullProgress, chan pull.PullerEvent) {
-	pullerEventCh := make(chan pull.PullerEvent, 128)
-	progChan := make(chan pull.PullProgress, 128)
-	wg := &sync.WaitGroup{}
+// progLanguage is the language to use when displaying progress for a pull from a src db to a sink db.
+type progLanguage int
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		progFunc(ctx, progChan)
-	}()
+const (
+	defaultLanguage progLanguage = iota
+	downloadLanguage
+)
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		pullerProgFunc(ctx, pullerEventCh)
-	}()
+func buildProgStarter(language progLanguage) actions.ProgStarter {
+	return func(ctx context.Context) (*sync.WaitGroup, chan pull.PullProgress, chan pull.PullerEvent) {
+		pullerEventCh := make(chan pull.PullerEvent, 128)
+		progChan := make(chan pull.PullProgress, 128)
+		wg := &sync.WaitGroup{}
 
-	return wg, progChan, pullerEventCh
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			progFunc(ctx, progChan)
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			pullerProgFunc(ctx, pullerEventCh, language)
+		}()
+
+		return wg, progChan, pullerEventCh
+	}
 }
 
 func stopProgFuncs(cancel context.CancelFunc, wg *sync.WaitGroup, progChan chan pull.PullProgress, pullerEventCh chan pull.PullerEvent) {
@@ -303,7 +319,6 @@ func stopProgFuncs(cancel context.CancelFunc, wg *sync.WaitGroup, progChan chan 
 	close(progChan)
 	close(pullerEventCh)
 	wg.Wait()
-
 }
 
 func bytesPerSec(bytes uint64, start time.Time) string {

--- a/go/cmd/dolt/commands/push.go
+++ b/go/cmd/dolt/commands/push.go
@@ -180,7 +180,7 @@ func pullerProgFunc(ctx context.Context, pullerEventCh chan pull.PullerEvent, la
 	var currentTreeLevel int
 	var percentBuffered float64
 	var tableFilesClosed int
-	var filesUploaded int
+	var filesTransfered int
 	var ts TextSpinner
 
 	uploadRate := ""
@@ -222,7 +222,7 @@ func pullerProgFunc(ctx context.Context, pullerEventCh chan pull.PullerEvent, la
 			uploadRate = humanize.Bytes(uint64(bps)) + "/s"
 
 		case pull.EndUploadTableFileEvent:
-			filesUploaded += 1
+			filesTransfered += 1
 		}
 
 		if currentTreeLevel == -1 {
@@ -233,12 +233,12 @@ func pullerProgFunc(ctx context.Context, pullerEventCh chan pull.PullerEvent, la
 		msg = fmt.Sprintf("%s Tree Level: %d, Percent Buffered: %.2f%%,", ts.next(), currentTreeLevel, percentBuffered)
 
 		if language == downloadLanguage {
-			msg = fmt.Sprintf("%s Files Written: %d", msg, filesUploaded)
+			msg = fmt.Sprintf("%s Files Written: %d", msg, filesTransfered)
 		} else {
 			if len(uploadRate) > 0 {
-				msg = fmt.Sprintf("%s Files Created: %d, Files Uploaded: %d, Current Upload Speed: %s", msg, tableFilesClosed, filesUploaded, uploadRate)
+				msg = fmt.Sprintf("%s Files Created: %d, Files Uploaded: %d, Current Upload Speed: %s", msg, tableFilesClosed, filesTransfered, uploadRate)
 			} else {
-				msg = fmt.Sprintf("%s Files Created: %d, Files Uploaded: %d", msg, tableFilesClosed, filesUploaded)
+				msg = fmt.Sprintf("%s Files Created: %d, Files Uploaded: %d", msg, tableFilesClosed, filesTransfered)
 			}
 		}
 

--- a/go/libraries/doltcore/env/actions/remotes.go
+++ b/go/libraries/doltcore/env/actions/remotes.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
-
 	eventsapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"

--- a/go/store/datas/pull/puller.go
+++ b/go/store/datas/pull/puller.go
@@ -337,6 +337,11 @@ func (p *Puller) Pull(ctx context.Context) error {
 
 	if !ae.IsSet() && p.wr.Size() > 0 {
 		// p.wr may be nil in the error case
+		if p.wr != nil {
+			p.addEvent(NewTFPullerEvent(TableFileClosedEvent, &TableFileEventDetails{
+				CurrentFileSize: int64(p.wr.ContentLength()),
+			}))
+		}
 		completedTables <- FilledWriters{p.wr}
 	}
 


### PR DESCRIPTION
Fixes #2798

For downloads (pulling chunks from a remote db to a local db), dolt will now report the number of tables files written to disk as `Files Written`. It will no longer report an `Upload Rate` for a download as that is the speed at which the file is copied from a temp directory.

For uploads (pulling chunks from a local db to a remote db), dolt will now report the number of table files created during the pull process as `Files Created` and the number of these tables files that have been uploaded as `Files Uploaded`.