### PR TITLE
Expand DOLT_DIFF system table to indicate the type of change

### DIFF
--- a/go/libraries/doltcore/sqle/dtables/unscoped_diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/unscoped_diff_table.go
@@ -34,6 +34,14 @@ type UnscopedDiffTable struct {
 	head *doltdb.Commit
 }
 
+// tableChange is an internal data structure used to hold the results of processing
+// a diff.TableDelta structure into the output data for this system table.
+type tableChange struct {
+	tableName    string
+	dataChange   bool
+	schemaChange bool
+}
+
 // NewUnscopedDiffTable creates an UnscopedDiffTable
 func NewUnscopedDiffTable(_ *sql.Context, ddb *doltdb.DoltDB, head *doltdb.Commit) sql.Table {
 	return &UnscopedDiffTable{ddb: ddb, head: head}
@@ -169,12 +177,6 @@ func (itr *UnscopedDiffTableItr) loadTableChanges(commit *doltdb.Commit) error {
 	}
 
 	return nil
-}
-
-type tableChange struct {
-	tableName    string
-	dataChange   bool
-	schemaChange bool
 }
 
 // calculateTableChanges calculates the tables that changed in the specified commit, by comparing that

--- a/go/libraries/doltcore/sqle/dtables/unscoped_diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/unscoped_diff_table.go
@@ -52,6 +52,8 @@ func (dt *UnscopedDiffTable) String() string {
 
 // Schema is a sql.Table interface function that returns the sql.Schema for this system table.
 func (dt *UnscopedDiffTable) Schema() sql.Schema {
+	// TODO: Would be nice to fix this ordering, but make sure to fix tests, too
+	// TODO: Why do these say the source is LogTable ?
 	return []*sql.Column{
 		{Name: "commit_hash", Type: sql.Text, Source: doltdb.LogTableName, PrimaryKey: true},
 		{Name: "committer", Type: sql.Text, Source: doltdb.LogTableName, PrimaryKey: false},
@@ -59,6 +61,8 @@ func (dt *UnscopedDiffTable) Schema() sql.Schema {
 		{Name: "date", Type: sql.Datetime, Source: doltdb.LogTableName, PrimaryKey: false},
 		{Name: "message", Type: sql.Text, Source: doltdb.LogTableName, PrimaryKey: false},
 		{Name: "table_name", Type: sql.Text, Source: doltdb.LogTableName, PrimaryKey: true},
+		{Name: "data_change", Type: sql.Boolean, Source: doltdb.LogTableName, PrimaryKey: true},
+		{Name: "schema_change", Type: sql.Boolean, Source: doltdb.LogTableName, PrimaryKey: true},
 	}
 }
 

--- a/go/libraries/doltcore/sqle/dtables/unscoped_diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/unscoped_diff_table.go
@@ -52,17 +52,15 @@ func (dt *UnscopedDiffTable) String() string {
 
 // Schema is a sql.Table interface function that returns the sql.Schema for this system table.
 func (dt *UnscopedDiffTable) Schema() sql.Schema {
-	// TODO: Would be nice to fix this ordering, but make sure to fix tests, too
-	// TODO: Why do these say the source is LogTable ?
 	return []*sql.Column{
-		{Name: "commit_hash", Type: sql.Text, Source: doltdb.LogTableName, PrimaryKey: true},
-		{Name: "committer", Type: sql.Text, Source: doltdb.LogTableName, PrimaryKey: false},
-		{Name: "email", Type: sql.Text, Source: doltdb.LogTableName, PrimaryKey: false},
-		{Name: "date", Type: sql.Datetime, Source: doltdb.LogTableName, PrimaryKey: false},
-		{Name: "message", Type: sql.Text, Source: doltdb.LogTableName, PrimaryKey: false},
-		{Name: "table_name", Type: sql.Text, Source: doltdb.LogTableName, PrimaryKey: true},
-		{Name: "data_change", Type: sql.Boolean, Source: doltdb.LogTableName, PrimaryKey: true},
-		{Name: "schema_change", Type: sql.Boolean, Source: doltdb.LogTableName, PrimaryKey: true},
+		{Name: "commit_hash", Type: sql.Text, Source: doltdb.DiffTableName, PrimaryKey: true},
+		{Name: "table_name", Type: sql.Text, Source: doltdb.DiffTableName, PrimaryKey: true},
+		{Name: "committer", Type: sql.Text, Source: doltdb.DiffTableName, PrimaryKey: false},
+		{Name: "email", Type: sql.Text, Source: doltdb.DiffTableName, PrimaryKey: false},
+		{Name: "date", Type: sql.Datetime, Source: doltdb.DiffTableName, PrimaryKey: false},
+		{Name: "message", Type: sql.Text, Source: doltdb.DiffTableName, PrimaryKey: false},
+		{Name: "data_change", Type: sql.Boolean, Source: doltdb.DiffTableName, PrimaryKey: true},
+		{Name: "schema_change", Type: sql.Boolean, Source: doltdb.DiffTableName, PrimaryKey: true},
 	}
 }
 
@@ -143,8 +141,8 @@ func (itr *UnscopedDiffTableItr) Next(*sql.Context) (sql.Row, error) {
 		return nil, err
 	}
 
-	return sql.NewRow(hash.String(), meta.Name, meta.Email, meta.Time(),
-		meta.Description, itr.tableNames[itr.tableNameIdx]), nil
+	return sql.NewRow(hash.String(), itr.tableNames[itr.tableNameIdx], meta.Name, meta.Email, meta.Time(),
+		meta.Description), nil
 }
 
 // loadTableNames loads the set of changed tables for the current commit into this iterator, taking

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -517,8 +517,6 @@ func TestUnscopedDoltDiffSystemTable(t *testing.T) {
 	for _, test := range UnscopedDiffTableTests {
 		databases := harness.NewDatabases("mydb")
 		engine := enginetest.NewEngineWithDbs(t, harness, databases)
-		//engine.Analyzer.Debug = true
-		//engine.Analyzer.Verbose = true
 		t.Run(test.Name, func(t *testing.T) {
 			enginetest.TestScriptWithEngine(t, engine, harness, test)
 		})

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -517,8 +517,8 @@ func TestUnscopedDoltDiffSystemTable(t *testing.T) {
 	for _, test := range UnscopedDiffTableTests {
 		databases := harness.NewDatabases("mydb")
 		engine := enginetest.NewEngineWithDbs(t, harness, databases)
-		engine.Analyzer.Debug = true
-		engine.Analyzer.Verbose = true
+		//engine.Analyzer.Debug = true
+		//engine.Analyzer.Verbose = true
 		t.Run(test.Name, func(t *testing.T) {
 			enginetest.TestScriptWithEngine(t, engine, harness, test)
 		})

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -751,7 +751,6 @@ var UnscopedDiffTableTests = []enginetest.ScriptTest{
 			},
 		},
 	},
-	// TODO: Revisit this?
 	// The DOLT_DIFF system table doesn't currently show any diff data for a merge commit.
 	// When processing a merge commit, diff.GetTableDeltas isn't aware of branch context, so it
 	// doesn't detect that any tables have changed.

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -620,12 +620,16 @@ var UnscopedDiffTableTests = []enginetest.ScriptTest{
 			"set @Commit2 = (select DOLT_COMMIT('-am', 'Creating tables z'))",
 
 			"rename table x to x1",
-			"set @Commit3 = (select DOLT_COMMIT('-am', 'Renaming table x to x1'))",
+			"insert into x1 values (1000, 1001, 1002);",
+			"set @Commit3 = (select DOLT_COMMIT('-am', 'Renaming table x to x1 and inserting data'))",
+
+			"rename table x1 to x2",
+			"set @Commit4 = (select DOLT_COMMIT('-am', 'Renaming table x1 to x2'))",
 		},
 		Assertions: []enginetest.ScriptTestAssertion{
 			{
 				Query:    "SELECT COUNT(*) FROM DOLT_DIFF",
-				Expected: []sql.Row{{4}},
+				Expected: []sql.Row{{5}},
 			},
 			{
 				Query:    "select table_name, schema_change, data_change from DOLT_DIFF where commit_hash in (@Commit1)",
@@ -637,7 +641,11 @@ var UnscopedDiffTableTests = []enginetest.ScriptTest{
 			},
 			{
 				Query:    "select table_name, schema_change, data_change from DOLT_DIFF where commit_hash in (@Commit3)",
-				Expected: []sql.Row{{"x1", true, false}},
+				Expected: []sql.Row{{"x1", true, true}},
+			},
+			{
+				Query:    "select table_name, schema_change, data_change from DOLT_DIFF where commit_hash in (@Commit4)",
+				Expected: []sql.Row{{"x2", true, false}},
 			},
 		},
 	},
@@ -650,10 +658,10 @@ var UnscopedDiffTableTests = []enginetest.ScriptTest{
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'Creating tables x and y'))",
 
 			"drop table x",
-			"set @Commit2 = (select DOLT_COMMIT('-am', 'Dropping table x'))",
+			"set @Commit2 = (select DOLT_COMMIT('-am', 'Dropping non-empty table x'))",
 
 			"drop table y",
-			"set @Commit3 = (select DOLT_COMMIT('-am', 'Dropping table y'))",
+			"set @Commit3 = (select DOLT_COMMIT('-am', 'Dropping empty table y'))",
 		},
 		Assertions: []enginetest.ScriptTestAssertion{
 			{


### PR DESCRIPTION
This change adds two new boolean columns to the unscoped `DOLT_DIFF` system table to enable customers to determine if a change to a table was a schema change or a data change (or both). 

Example Usage: 
```
> create table x (a int primary key, b int, c int);
> create table y (a int primary key, b int, c int);
> insert into x values (1, 2, 3), (2, 3, 4);
> select DOLT_COMMIT('-am', 'Creating tables x and y');
> select * from dolt_diff;
+----------------------------------+------------+-----------+-------------------------+----------------------------------+-------------------------+-------------+---------------+
| commit_hash                      | table_name | committer | email                   | date                             | message                 | data_change | schema_change |
+----------------------------------+------------+-----------+-------------------------+----------------------------------+-------------------------+-------------+---------------+
| 1blnkur3m1hla2a4got9t513982a4ad1 | x          | jfulghum  | jason.fulghum@gmail.com | 2022-02-21 14:39:37.01 -0800 PST | Creating tables x and y | true        | true          |
| 1blnkur3m1hla2a4got9t513982a4ad1 | y          | jfulghum  | jason.fulghum@gmail.com | 2022-02-21 14:39:37.01 -0800 PST | Creating tables x and y | false       | true          |
+----------------------------------+------------+-----------+-------------------------+----------------------------------+-------------------------+-------------+---------------+
```

Resolves: https://github.com/dolthub/dolt/issues/2834