### PR TITLE
libraries/utils/editor: fix dropped error

### DIFF
--- a/go/libraries/utils/editor/edit.go
+++ b/go/libraries/utils/editor/edit.go
@@ -51,6 +51,9 @@ func OpenCommitEditor(ed string, initialContents string) (string, error) {
 	}
 	fmt.Printf("Waiting for command to finish.\n")
 	err = cmd.Wait()
+	if err != nil {
+		return "", err
+	}
 
 	data, err := os.ReadFile(filename)
 


### PR DESCRIPTION
This fixes a dropped `err` variable in `libraries/utils/editor`.