### PR TITLE
fix null value being exported for any types into .sql file

### DIFF
--- a/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
@@ -122,9 +122,12 @@ func SqlRowAsInsertStmt(ctx context.Context, r sql.Row, tableName string, tableS
 			b.WriteRune(',')
 		}
 		col := tableSch.GetAllCols().GetAtIndex(i)
-		str, err := interfaceValueAsSqlString(ctx, col.TypeInfo, val)
-		if err != nil {
-			return "", err
+		str := "NULL"
+		if val != nil {
+			str, err = interfaceValueAsSqlString(ctx, col.TypeInfo, val)
+			if err != nil {
+				return "", err
+			}
 		}
 
 		b.WriteString(str)

--- a/go/libraries/doltcore/sqle/sqlfmt/row_fmt_test.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/row_fmt_test.go
@@ -256,6 +256,19 @@ func TestValueAsSqlString(t *testing.T) {
 			ti:   typeinfo.StringDefaultType,
 			exp:  "'\\0\\'\\\"\\b\\n\\r\\t\\Z\\\\'",
 		},
+		// using only string and int types as an example, but includes all types
+		{
+			name: "NULL value for typeinfo.string types",
+			val:  nil,
+			ti:   typeinfo.StringDefaultType,
+			exp:  "NULL",
+		},
+		{
+			name: "NULL value for typeinfo.int types",
+			val:  nil,
+			ti:   typeinfo.Int64Type,
+			exp:  "NULL",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
the issue covered all typeInfo types where null values were not getting exported correctly. 
the fix is to add `NULL` whenever the value is nil and cannot be converted into sql types.