### PR TITLE
[no-release-notes] go/libraries/doltcore/dbfactory: file.go: Fix the default NBF Format used when constructing the old gen to match the new gen.

### DIFF
--- a/go/libraries/doltcore/dbfactory/file.go
+++ b/go/libraries/doltcore/dbfactory/file.go
@@ -77,7 +77,7 @@ func (fact FileFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, 
 		}
 	}
 
-	oldGenSt, err := nbs.NewLocalStore(ctx, nbf.VersionString(), oldgenPath, defaultMemTableSize)
+	oldGenSt, err := nbs.NewLocalStore(ctx, newGenSt.Version(), oldgenPath, defaultMemTableSize)
 
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
This fixes the panic when using very old repositories (7.18) or experimental formats in new ones.