### PR TITLE
Change HedgeStrategy  interface to control nextTry durations directly

### DIFF
--- a/go/libraries/doltcore/remotestorage/chunk_store.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store.go
@@ -50,13 +50,10 @@ var DownloadHedger *Hedger
 func init() {
 	// TODO: This does not necessarily respond well to changes in network
 	// conditions during the program's runtime.
-	DownloadHedger = NewHedger(
-		8,
-		NewMinStrategy(
-			1*time.Second,
-			NewPercentileStrategy(0, 1*time.Hour, 95.0),
-		),
-	)
+	e := NewPercentileEstimator(0, 1*time.Hour, 95.0)
+	s := NewMinHedgeStrategy(1*time.Second,
+		NewExponentialHedgeStrategy(NewEstimateStrategy(e)))
+	DownloadHedger = NewHedger(8, s, e)
 }
 
 var ErrUploadFailed = errors.New("upload failed")
@@ -1077,10 +1074,10 @@ type urlFactoryFunc func(error) (string, error)
 
 func hedgedRangeDownloadWithRetries(ctx context.Context, stats StatsRecorder, fetcher HTTPFetcher, offset, length uint64, urlStrF urlFactoryFunc) ([]byte, error) {
 	res, err := DownloadHedger.Do(ctx, Work{
-		Work: func(ctx context.Context, n int) (interface{}, error) {
+		Run: func(ctx context.Context, n int) (interface{}, error) {
 			return rangeDownloadWithRetries(ctx, stats, fetcher, offset, length, n, urlStrF)
 		},
-		Size: int64(length),
+		Size: length,
 	})
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/remotestorage/chunk_store.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store.go
@@ -1080,7 +1080,7 @@ func hedgedRangeDownloadWithRetries(ctx context.Context, stats StatsRecorder, fe
 		Work: func(ctx context.Context, n int) (interface{}, error) {
 			return rangeDownloadWithRetries(ctx, stats, fetcher, offset, length, n, urlStrF)
 		},
-		Size: int(length),
+		Size: int64(length),
 	})
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/remotestorage/hedge.go
+++ b/go/libraries/doltcore/remotestorage/hedge.go
@@ -24,159 +24,37 @@ import (
 	"github.com/HdrHistogram/hdrhistogram-go"
 )
 
-// Work is a description of work that can be hedged. The supplied Work function
-// should expect to potentially be called multiple times concurrently, and it
-// should respect |ctx| cancellation. |Size| will be passed to the |Strategy|
-// as a parameter to compute the potential hedge retry timeout for this Work.
-type Work struct {
-	// Work is the function that will be called by |Hedger.Do|. It will be
-	// called at least once, and possibly multiple times depending on how
-	// long it takes and the |Hedger|'s |Strategy|.
-	Work func(ctx context.Context, n int) (interface{}, error)
-
-	// Size is an integer representation of the size of the work.
-	// Potentially used by |Strategy|, not used by |Hedger|.
-	Size int64
+// Hedger can |Do| Work, potentially invoking Work |Run|'s more than once
+// concurrently if it is taking longer than |strat|'s |NextTry| duration.
+// Completed Work gets reported to the DurationObserver.
+type Hedger struct {
+	sema     *semaphore.Weighted
+	strat    HedgeStrategy
+	observer DurationObserver
+	after    afterFunc
 }
 
-// Hedger can |Do| |Work|, potentially invoking |Work| more than once
-// concurrently if it is taking longer than |Strategy| estimated it would. If
-// given a |fixedNextTryDuration|, Hedger will always invoke |Work| if not
-// completed after |fixedNextTryDuration| time.
-type Hedger struct {
-	sema                 *semaphore.Weighted
-	strat                Strategy
-	fixedNextTryDuration *time.Duration
-	after                afterFunc
+// NewHedger returns a new Hedger. |maxOutstanding| is the most hedged |Run|'s
+// that can be outstanding. If a |Run| would be hedged, but there are already
+// maxOutstanding hedged |Run|'s, nothing happens instead. |strat| is the
+// HedgeStrategy to use for this hedger. |observer| is a DurationObserver that
+// will receive |Observe|'s when a Work completes.
+func NewHedger(maxOutstanding int64, strat HedgeStrategy, observer DurationObserver) *Hedger {
+	return &Hedger{
+		semaphore.NewWeighted(maxOutstanding),
+		strat,
+		observer,
+		time.After,
+	}
 }
 
 type afterFunc func(time.Duration) <-chan time.Time
 
-// NewHedger returns a new Hedger. |maxOutstanding| is the most hedged requests
-// that can be outstanding. If a request would be hedged, but there are already
-// maxOutstanding hedged requests, nothing happens instead.
-func NewHedger(maxOutstanding int64, strat Strategy) *Hedger {
-	return &Hedger{
-		semaphore.NewWeighted(maxOutstanding),
-		strat,
-		nil,
-		time.After,
-	}
-}
-
-// NewFixedHedger returns a new Hedger. It will hedge a request if it fails to
-// complete in |nextTryDuration| time. |maxOutstanding| behaves in the same way
-// as NewHedger.
-func NewFixedHedger(maxOutstanding int64, nextTryDuration time.Duration) *Hedger {
-	return &Hedger{
-		semaphore.NewWeighted(maxOutstanding),
-		&noopStrategy{},
-		&nextTryDuration,
-		time.After,
-	}
-}
-
-// Stategy provides a way estimate the hedge timeout for |Work| given to a
-// |Hedger|.
-type Strategy interface {
-	// Duration returns the expected |time.Duration| of a piece of Work
-	// with |Size| |sz|.
-	Duration(sz int64) time.Duration
-	// Observe is called by |Hedger| when work is completed. |sz| is the
-	// |Size| of the work. |n| is the nth hedge which completed first, with
-	// 1 being the unhedged request. |d| is the duration the |Work|
-	// function took for the request that completed. |err| is any |error|
-	// returned from |Work|.
-	Observe(sz int64, n int, d time.Duration, err error)
-}
-
-// NewPercentileStrategy returns an initialized |PercentileStrategy| |Hedger|.
-func NewPercentileStrategy(low, high time.Duration, perc float64) *PercentileStrategy {
-	lowi := int64(low / time.Millisecond)
-	highi := int64(high / time.Millisecond)
-	return &PercentileStrategy{
-		perc,
-		hdrhistogram.New(lowi, highi, 3),
-		new(sync.Mutex),
-	}
-}
-
-// PercentileStrategy is a hedge timeout streategy which puts all |Observe|
-// durations into a histogram and returns the current value of the provided
-// |Percentile| in that histogram for the estimated |Duration|. |Size| is
-// ignored.
-type PercentileStrategy struct {
-	Percentile float64
-	histogram  *hdrhistogram.Histogram
-	mu         *sync.Mutex
-}
-
-// Duration implements |Strategy|.
-func (ps *PercentileStrategy) Duration(sz int64) time.Duration {
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
-	return time.Duration(ps.histogram.ValueAtQuantile(ps.Percentile)) * time.Millisecond
-}
-
-// Observe implements |Strategy|.
-func (ps *PercentileStrategy) Observe(sz int64, n int, d time.Duration, err error) {
-	if err == nil {
-		ps.mu.Lock()
-		defer ps.mu.Unlock()
-		ps.histogram.RecordValue(int64(d / time.Millisecond))
-	}
-}
-
-// MinStrategy is a hedge timeout strategy that optionally delegates to
-// |delegate| and replaces the estimated timeout with |min| if it would be less
-// than |min|. If |delegate| is |nil|, it is treated as if it always returned
-// 0.
-func NewMinStrategy(min time.Duration, delegate Strategy) *MinStrategy {
-	return &MinStrategy{
-		min,
-		delegate,
-	}
-}
-
-// MinStrategy optionally delegates to another |Strategy| and clamps its
-// |Duration| results to a minimum of |Min|.
-type MinStrategy struct {
-	// Min is the minimum |time.Duration| that |Duration| should return.
-	Min        time.Duration
-	underlying Strategy
-}
-
-// Duration implements |Strategy|.
-func (ms *MinStrategy) Duration(sz int64) time.Duration {
-	if ms.underlying == nil {
-		return ms.Min
-	}
-	u := ms.underlying.Duration(sz)
-	if u < ms.Min {
-		return ms.Min
-	}
-	return u
-}
-
-// Observe implements |Strategy|.
-func (ms *MinStrategy) Observe(sz int64, n int, d time.Duration, err error) {
-	if ms.underlying != nil {
-		ms.underlying.Observe(sz, n, d, err)
-	}
-}
-
-type noopStrategy struct{}
-
-func (no *noopStrategy) Duration(sz int64) time.Duration {
-	panic("unimplemented")
-}
-func (no *noopStrategy) Observe(sz int64, n int, d time.Duration, err error) {}
-
 var MaxHedgesPerRequest = 1
 
-// Do runs |w| to completion, potentially spawning concurrent hedge runs of it.
-// Returns the results from the first invocation that completes, and cancels
-// the contexts of all invocations.
+// Do runs |w| to completion, potentially spawning concurrent |Run|'s. Returns
+// the results from the first invocation that completes, and cancels the
+// contexts of all invocations.
 func (h *Hedger) Do(ctx context.Context, w Work) (interface{}, error) {
 	var cancels []func()
 	type res struct {
@@ -206,27 +84,23 @@ func (h *Hedger) Do(ctx context.Context, w Work) (interface{}, error) {
 		start := time.Now()
 		go func() {
 			defer finalize()
-			v, e := w.Work(ctx, n)
+			v, e := w.Run(ctx, n)
 			select {
 			case ch <- res{v, e, n, time.Since(start)}:
 			case <-ctx.Done():
 			}
 		}()
 	}
+	start := time.Now()
 	try()
 	for {
-		var nextTry time.Duration
-		if d := h.fixedNextTryDuration; d != nil {
-			nextTry = *d
-		} else {
-			nextTry = h.strat.Duration(w.Size) * (1 << len(cancels))
-		}
+		nextTry := h.strat.NextTry(w.Size, time.Since(start), len(cancels)+1)
 		select {
 		case r := <-ch:
 			for _, c := range cancels {
 				c()
 			}
-			h.strat.Observe(w.Size, r.n, r.d, r.e)
+			h.observer.Observe(w.Size, r.n, r.d, r.e)
 			return r.v, r.e
 		case <-h.after(nextTry):
 			try()
@@ -235,3 +109,188 @@ func (h *Hedger) Do(ctx context.Context, w Work) (interface{}, error) {
 		}
 	}
 }
+
+// Work is a description of work that can be hedged. The supplied Run function
+// should expect to potentially be called multiple times concurrently, and it
+// should respect |ctx| cancellation. |Size| will be used to estimate Run's
+// duration. This estimate is also used to determine when a Work's Run should be
+// hedged with concurrent Run call(s).
+type Work struct {
+	// Run is the function that will be called by |Hedger.Do|. It will be
+	// called at least once, and possibly multiple times depending on how
+	// long it takes and the |Hedger|'s |Strategy|.
+	Run func(ctx context.Context, n int) (interface{}, error)
+
+	// Size is an integer representation of the size of the work.
+	// Potentially used by |Strategy|, not used by |Hedger|.
+	Size uint64
+}
+
+// DynamicEstimator returns an estimated |Duration| for Work that is dynamically
+// updated by observations from |Observe|.
+type DynamicEstimator interface {
+	DurationEstimator
+	DurationObserver
+}
+
+// DurationEstimator returns an estimated duration given the size of a Work
+type DurationEstimator interface {
+	// Duration returns the expected |time.Duration| of a Work with |Size| |sz|.
+	Duration(sz uint64) time.Duration
+}
+
+// DurationObserver observes Work completions
+type DurationObserver interface {
+	// Observe is called by |Hedger| when work is completed. |sz| is the |Size|
+	// of the work. |n| specifies which |Run| called by the Hedger completed,
+	// with 1 being the first |Run|. |d| is the duration the |Run| function
+	// took for the |Run| that completed. |err| is any |error| returned from
+	// |Run|.
+	Observe(sz uint64, n int, d time.Duration, err error)
+}
+
+// NoopObserver is a DurationObserver has a noop |Observe|
+type NoopObserver struct {
+}
+
+// NewNoopObserver returns a new NoopObserver
+func NewNoopObserver() *NoopObserver {
+	return &NoopObserver{}
+}
+
+// Observe implements DurationObserver
+func (*NoopObserver) Observe(sz uint64, n int, d time.Duration, err error) {
+}
+
+// PercentileEstimator is an DynamicEstimator which puts all |Observe| durations
+// into a histogram and returns the current value of the provided |Percentile|
+// in that histogram for the estimated |Duration|. |sz| is ignored.
+type PercentileEstimator struct {
+	Percentile float64
+	histogram  *hdrhistogram.Histogram
+	mu         *sync.Mutex
+}
+
+// NewPercentileEstimator returns an initialized |PercentileEstimator|.
+func NewPercentileEstimator(low, high time.Duration, perc float64) *PercentileEstimator {
+	lowi := int64(low / time.Millisecond)
+	highi := int64(high / time.Millisecond)
+	return &PercentileEstimator{
+		perc,
+		hdrhistogram.New(lowi, highi, 3),
+		new(sync.Mutex),
+	}
+}
+
+// Duration implements DurationEstimator.
+func (ps *PercentileEstimator) Duration(sz uint64) time.Duration {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	return time.Duration(ps.histogram.ValueAtQuantile(ps.Percentile)) * time.Millisecond
+}
+
+// Observe implements DurationObserver.
+func (ps *PercentileEstimator) Observe(sz uint64, n int, d time.Duration, err error) {
+	if err == nil {
+		ps.mu.Lock()
+		defer ps.mu.Unlock()
+		_ = ps.histogram.RecordValue(int64(d / time.Millisecond))
+	}
+}
+
+// HedgeStrategy is used by Hedger to decide when to launch concurrent |Run|
+// calls.
+type HedgeStrategy interface {
+	// NextTry determines how long to wait before hedging a Work's |Run|
+	// function. |sz| is the |Size| of the Work, |elapsed| is the time since the
+	// first |Run| was called, and |n| is the hedge number starting from 1.
+	NextTry(sz uint64, elapsed time.Duration, n int) time.Duration
+}
+
+// FixedHedgeStrategy always returns |FixedNextTry| from |NextTry|
+type FixedHedgeStrategy struct {
+	FixedNextTry time.Duration
+}
+
+// NewFixedHedgeStrategy returns a new FixedHedgeStrategy
+func NewFixedHedgeStrategy(fixedNextTry time.Duration) *FixedHedgeStrategy {
+	return &FixedHedgeStrategy{fixedNextTry}
+}
+
+// NextTry implements HedgeStrategy
+func (s *FixedHedgeStrategy) NextTry(sz uint64, elapsed time.Duration, n int) time.Duration {
+	return s.FixedNextTry
+}
+
+// EstimateStrategy wraps a DurationEstimator. It wants to hedge Work |Run|'s
+// when it takes longer than the Work estimate.
+type EstimateStrategy struct {
+	e DurationEstimator
+}
+
+// NewEstimateStrategy returns a new EstimateStrategy
+func NewEstimateStrategy(e DurationEstimator) *EstimateStrategy {
+	return &EstimateStrategy{e}
+}
+
+// NextTry implements HedgeStrategy
+func (s *EstimateStrategy) NextTry(sz uint64, elapsed time.Duration, n int) time.Duration {
+	return s.e.Duration(sz)
+}
+
+// ExponentialHedgeStrategy increases the |underlying|'s nextTry by a factor of
+// two for every hedge attempt, including the first attempt.
+type ExponentialHedgeStrategy struct {
+	underlying HedgeStrategy
+}
+
+// NewExponentialHedgeStrategy returns a new ExponentialHedgeStrategy
+func NewExponentialHedgeStrategy(u HedgeStrategy) *ExponentialHedgeStrategy {
+	return &ExponentialHedgeStrategy{u}
+}
+
+// NextTry implements HedgeStrategy
+func (e *ExponentialHedgeStrategy) NextTry(sz uint64, elapsed time.Duration, n int) time.Duration {
+	estimate := e.underlying.NextTry(sz, elapsed, n)
+	return estimate * (1 << n)
+}
+
+// MinHedgeStrategy bounds an underlying strategy's NextTry duration to be
+// above |min|.
+type MinHedgeStrategy struct {
+	min        time.Duration
+	underlying HedgeStrategy
+}
+
+// NewMinHedgeStrategy returns a new MinHedgeStrategy
+func NewMinHedgeStrategy(min time.Duration, underlying HedgeStrategy) *MinHedgeStrategy {
+	return &MinHedgeStrategy{min, underlying}
+}
+
+// NextTry implements HedgeStrategy
+func (s *MinHedgeStrategy) NextTry(sz uint64, elapsed time.Duration, n int) time.Duration {
+	estimate := s.underlying.NextTry(sz, elapsed, n)
+	if estimate < s.min {
+		return s.min
+	}
+	return estimate
+}
+
+/*
+// MaxStrategy is an example of how multiple strategies can be composed.
+
+type MaxStrategy struct {
+	first  HedgeStrategy
+	second HedgeStrategy
+}
+
+func (s *MaxStrategy) NextTry(sz uint64, elapsed time.Duration, n int) time.Duration {
+	e1 := s.first.NextTry(sz, elapsed, n)
+	e2 := s.second.NextTry(sz, elapsed, n)
+	if e1 > e2 {
+		return e1
+	} else {
+		return e2
+	}
+}
+*/

--- a/go/libraries/doltcore/remotestorage/hedge_test.go
+++ b/go/libraries/doltcore/remotestorage/hedge_test.go
@@ -27,35 +27,63 @@ func init() {
 	MaxHedgesPerRequest = 1024
 }
 
-func TestPercentileStrategy(t *testing.T) {
-	s := NewPercentileStrategy(0, 1*time.Hour, 95.0)
+func TestPercentileEstimator(t *testing.T) {
+	e := NewPercentileEstimator(0, 1*time.Hour, 95.0)
 	for i := 0; i < 90; i++ {
-		s.Observe(1, 1, 1*time.Millisecond, nil)
+		e.Observe(1, 1, 1*time.Millisecond, nil)
 	}
 	for i := 0; i < 10; i++ {
-		s.Observe(10, 1, 100*time.Millisecond, nil)
+		e.Observe(10, 1, 100*time.Millisecond, nil)
 	}
-	d := s.Duration(10)
+	d := e.Duration(10)
 	assert.True(t, d > 90*time.Millisecond, "p95 is greater than 90 milliseconds, is %d", d)
 }
 
+// testEstimator is a DynamicEstimator for testing
+type testEstimator struct {
+	d            time.Duration
+	observations int
+}
+
+// Duration implements DurationEstimator.
+func (e *testEstimator) Duration(sz uint64) time.Duration {
+	return e.d
+}
+
+// Observe implements DurationObserver.
+func (e *testEstimator) Observe(sz uint64, n int, d time.Duration, err error) {
+	e.observations++
+}
+
+func TestEstimateStrategy(t *testing.T) {
+	e := &testEstimator{1 * time.Second, 0}
+	s := NewEstimateStrategy(e)
+	d := s.NextTry(0, 0, 0)
+	assert.Equal(t, 1*time.Second, d)
+}
+
 func TestMinStrategy(t *testing.T) {
-	u := NewPercentileStrategy(0, 1*time.Hour, 95.0)
-	s := NewMinStrategy(1*time.Second, u)
-	d := s.Duration(10)
-	assert.Equal(t, d, 1*time.Second)
-	for i := 0; i < 100; i++ {
-		s.Observe(10, 1, 15*time.Second, nil)
-	}
-	d = s.Duration(10)
-	assert.NotEqual(t, d, 1*time.Second)
+	fS := NewFixedHedgeStrategy(1 * time.Second)
+	s := NewMinHedgeStrategy(2*time.Second, fS)
+	assert.Equal(t, 2*time.Second, s.NextTry(0, 0, 1))
+	fS.FixedNextTry = 3 * time.Second
+	assert.Equal(t, 3*time.Second, s.NextTry(0, 0, 1))
+}
+
+func TestExponentialStrategy(t *testing.T) {
+	fS := NewFixedHedgeStrategy(1 * time.Second)
+	s := NewExponentialHedgeStrategy(fS)
+	d := s.NextTry(0, 0, 1)
+	assert.Equal(t, 2*time.Second, d)
+	d = s.NextTry(0, 0, 2)
+	assert.Equal(t, 4*time.Second, d)
 }
 
 func TestHedgerRunsWork(t *testing.T) {
-	h := NewHedger(1, NewMinStrategy(1*time.Second, nil))
+	h := NewHedger(1, NewFixedHedgeStrategy(1*time.Second), NewNoopObserver())
 	ran := false
 	i, err := h.Do(context.Background(), Work{
-		Work: func(ctx context.Context, n int) (interface{}, error) {
+		Run: func(ctx context.Context, n int) (interface{}, error) {
 			ran = true
 			return true, nil
 		},
@@ -65,13 +93,13 @@ func TestHedgerRunsWork(t *testing.T) {
 	assert.True(t, i.(bool))
 }
 
-func TestHedgerHedgesWork(t *testing.T) {
-	h := NewHedger(1, NewMinStrategy(10*time.Millisecond, nil))
+func TestHedgerHedgesWorkRuns(t *testing.T) {
+	h := NewHedger(1, NewFixedHedgeStrategy(10*time.Millisecond), NewNoopObserver())
 	ch := make(chan int, 2)
 	ch <- 1
 	ch <- 2
 	i, err := h.Do(context.Background(), Work{
-		Work: func(ctx context.Context, n int) (interface{}, error) {
+		Run: func(ctx context.Context, n int) (interface{}, error) {
 			i := <-ch
 			if i == 1 {
 				<-ctx.Done()
@@ -86,6 +114,31 @@ func TestHedgerHedgesWork(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 2, i.(int))
 	assert.Equal(t, 0, <-ch)
+}
+
+func TestHedgerObservesWork(t *testing.T) {
+	e := &testEstimator{}
+	h := NewHedger(1, NewFixedHedgeStrategy(10*time.Millisecond), e)
+	ch := make(chan int, 2)
+	ch <- 1
+	ch <- 2
+	i, err := h.Do(context.Background(), Work{
+		Run: func(ctx context.Context, n int) (interface{}, error) {
+			i := <-ch
+			if i == 1 {
+				<-ctx.Done()
+				close(ch)
+				return 1, nil
+			} else if i == 2 {
+				return 2, nil
+			}
+			panic("unexpected value in ch")
+		},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, i.(int))
+	assert.Equal(t, 0, <-ch)
+	assert.Equal(t, e.observations, 1)
 }
 
 // Behaves a bit like a WaitGroup but allows Done() to be called more than its
@@ -112,7 +165,7 @@ func (w *sloppyWG) Wait() {
 
 func TestHedgerObeysMaxHedges(t *testing.T) {
 	try := func(max int) {
-		h := NewHedger(int64(max), NewMinStrategy(1*time.Millisecond, nil))
+		h := NewHedger(int64(max), NewFixedHedgeStrategy(1*time.Millisecond), NewNoopObserver())
 		cnt := int32(0)
 		wg := newSloppyWG(int32(max + 4))
 		h.after = func(d time.Duration) <-chan time.Time {
@@ -120,7 +173,7 @@ func TestHedgerObeysMaxHedges(t *testing.T) {
 			return time.After(d)
 		}
 		i, err := h.Do(context.Background(), Work{
-			Work: func(ctx context.Context, n int) (interface{}, error) {
+			Run: func(ctx context.Context, n int) (interface{}, error) {
 				cur := atomic.AddInt32(&cnt, 1)
 				if cur == int32(max)+1 {
 					wg.Wait()
@@ -149,7 +202,7 @@ func TestMaxHedgesPerRequestObeyed(t *testing.T) {
 	}()
 
 	MaxHedgesPerRequest = 0
-	h := NewHedger(int64(32), NewMinStrategy(1*time.Millisecond, nil))
+	h := NewHedger(int64(32), NewFixedHedgeStrategy(1*time.Millisecond), NewNoopObserver())
 	cnt := int32(0)
 	wg := newSloppyWG(4)
 	h.after = func(d time.Duration) <-chan time.Time {
@@ -157,7 +210,7 @@ func TestMaxHedgesPerRequestObeyed(t *testing.T) {
 		return time.After(d)
 	}
 	i, err := h.Do(context.Background(), Work{
-		Work: func(ctx context.Context, n int) (interface{}, error) {
+		Run: func(ctx context.Context, n int) (interface{}, error) {
 			cur := atomic.AddInt32(&cnt, 1)
 			if cur == int32(1) {
 				wg.Wait()
@@ -178,7 +231,7 @@ func TestMaxHedgesPerRequestObeyed(t *testing.T) {
 		return time.After(d)
 	}
 	i, err = h.Do(context.Background(), Work{
-		Work: func(ctx context.Context, n int) (interface{}, error) {
+		Run: func(ctx context.Context, n int) (interface{}, error) {
 			cur := atomic.AddInt32(&cnt, 1)
 			if cur == int32(1) {
 				<-ctx.Done()
@@ -196,7 +249,7 @@ func TestMaxHedgesPerRequestObeyed(t *testing.T) {
 }
 
 func TestHedgerContextCancelObeyed(t *testing.T) {
-	h := NewHedger(int64(3), NewMinStrategy(1*time.Millisecond, nil))
+	h := NewHedger(int64(3), NewFixedHedgeStrategy(1*time.Millisecond), NewNoopObserver())
 	resCh := make(chan struct{})
 	canCh := make(chan struct{})
 	ctx, cancel := context.WithCancel(context.Background())
@@ -208,7 +261,7 @@ func TestHedgerContextCancelObeyed(t *testing.T) {
 		cancel()
 	}()
 	_, err := h.Do(ctx, Work{
-		Work: func(ctx context.Context, n int) (interface{}, error) {
+		Run: func(ctx context.Context, n int) (interface{}, error) {
 			canCh <- struct{}{}
 			<-ctx.Done()
 			resCh <- struct{}{}
@@ -229,7 +282,7 @@ func TestFixedHedgerHedgesAtFixedInterval(t *testing.T) {
 	}()
 
 	fixedInterval := 10 * time.Millisecond
-	h := NewFixedHedger(1, fixedInterval)
+	h := NewHedger(1, NewFixedHedgeStrategy(fixedInterval), NewNoopObserver())
 
 	MaxHedgesPerRequest = 1
 	cnt := int32(0)
@@ -242,7 +295,7 @@ func TestFixedHedgerHedgesAtFixedInterval(t *testing.T) {
 	}
 
 	_, err := h.Do(context.Background(), Work{
-		Work: func(ctx context.Context, n int) (interface{}, error) {
+		Run: func(ctx context.Context, n int) (interface{}, error) {
 			cur := atomic.AddInt32(&cnt, 1)
 			if cur == 1 {
 				<-ctx.Done()

--- a/go/libraries/doltcore/remotestorage/hedge_test.go
+++ b/go/libraries/doltcore/remotestorage/hedge_test.go
@@ -275,7 +275,7 @@ func TestHedgerContextCancelObeyed(t *testing.T) {
 	<-resCh
 }
 
-func TestFixedHedgerHedgesAtFixedInterval(t *testing.T) {
+func TestHedgerObeysStrategy(t *testing.T) {
 	before := MaxHedgesPerRequest
 	defer func() {
 		MaxHedgesPerRequest = before


### PR DESCRIPTION
`Strategy` has been renamed to `HedgeStrategy`. `HedgeStrategy`'s now control the nextTry durations directly and an `ExponentialHedgeStrategy` has been added that can be composed with other strategies to get the previous behavior.