### PR TITLE
go/utils/remotesrv: use io.Copy in the http file server to write table file data to http.ResponseWriter

### DIFF
--- a/go/utils/remotesrv/http.go
+++ b/go/utils/remotesrv/http.go
@@ -90,14 +90,6 @@ func readTableFile(logger func(string), org, repo, fileId string, respWr http.Re
 			r, fileErr = getFileReaderAt(path, offset, length)
 		}
 	}
-	defer func() {
-		err := r.Close()
-		if err != nil {
-			err = fmt.Errorf("failed to close file at path %s: %w", path, err)
-			logger(err.Error())
-		}
-	}()
-
 	if fileErr != nil {
 		logger(fileErr.Error())
 		if errors.Is(fileErr, os.ErrNotExist) {
@@ -107,6 +99,13 @@ func readTableFile(logger func(string), org, repo, fileId string, respWr http.Re
 		}
 		return http.StatusInternalServerError
 	}
+	defer func() {
+		err := r.Close()
+		if err != nil {
+			err = fmt.Errorf("failed to close file at path %s: %w", path, err)
+			logger(err.Error())
+		}
+	}()
 
 	logger(fmt.Sprintf("opened file at path %s, going to read %d bytes", path, readSize))
 

--- a/go/utils/remotesrv/http.go
+++ b/go/utils/remotesrv/http.go
@@ -227,6 +227,11 @@ func openFile(path string) (*os.File, int64, error) {
 	return f, info.Size(), nil
 }
 
+type closerReaderWrapper struct {
+	io.Reader
+	io.Closer
+}
+
 func getFileReaderAt(path string, offset int64, length int64) (io.ReadCloser, error) {
 	f, fSize, err := openFile(path)
 	if err != nil {
@@ -242,5 +247,6 @@ func getFileReaderAt(path string, offset int64, length int64) (io.ReadCloser, er
 		return nil, fmt.Errorf("failed to seek file at path %s to offset %d: %w", path, offset, err)
 	}
 
-	return io.LimitReader(f, length).(io.ReadCloser), nil
+	r := closerReaderWrapper{io.LimitReader(f, length), f}
+	return r, nil
 }

--- a/go/utils/remotesrv/http.go
+++ b/go/utils/remotesrv/http.go
@@ -122,7 +122,7 @@ func readTableFile(logger func(string), org, repo, fileId string, respWr http.Re
 
 	logger(fmt.Sprintf("wrote %d bytes", n))
 
-	return -1
+	return http.StatusOK
 }
 
 func writeTableFile(logger func(string), org, repo, fileId string, request *http.Request) int {

--- a/go/utils/remotesrv/http.go
+++ b/go/utils/remotesrv/http.go
@@ -77,7 +77,7 @@ func readTableFile(logger func(string), org, repo, fileId string, respWr http.Re
 	var fileErr error
 	{
 		if rangeStr == "" {
-			logger("going to write entire file")
+			logger("going to read entire file")
 			r, readSize, fileErr = getFileReader(path)
 		} else {
 			offset, length, err := offsetAndLenFromRange(rangeStr)
@@ -85,7 +85,7 @@ func readTableFile(logger func(string), org, repo, fileId string, respWr http.Re
 				logger(err.Error())
 				return http.StatusBadRequest
 			}
-			logger(fmt.Sprintf("going to write bytes at offset %d, length %d", offset, length))
+			logger(fmt.Sprintf("going to read file at offset %d, length %d", offset, length))
 			readSize = length
 			r, fileErr = getFileReaderAt(path, offset, length)
 		}
@@ -108,7 +108,7 @@ func readTableFile(logger func(string), org, repo, fileId string, respWr http.Re
 		return http.StatusInternalServerError
 	}
 
-	logger(fmt.Sprintf("opened file at path %s, going to write %d bytes", path, readSize))
+	logger(fmt.Sprintf("opened file at path %s, going to read %d bytes", path, readSize))
 
 	n, err := io.Copy(respWr, r)
 	if err != nil {

--- a/go/utils/remotesrv/http.go
+++ b/go/utils/remotesrv/http.go
@@ -28,8 +28,12 @@ import (
 
 	remotesapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/remotesapi/v1alpha1"
 
-	"github.com/dolthub/dolt/go/libraries/utils/iohelp"
 	"github.com/dolthub/dolt/go/store/hash"
+)
+
+var (
+	ErrReadOutOfBounds = errors.New("cannot read file for given length and " +
+		"offset since the read would exceed the size of the file")
 )
 
 var expectedFiles = make(map[string]*remotesapi.TableFileDetails)
@@ -53,13 +57,7 @@ func ServeHTTP(respWr http.ResponseWriter, req *http.Request) {
 	statusCode := http.StatusMethodNotAllowed
 	switch req.Method {
 	case http.MethodGet:
-		rangeStr := req.Header.Get("Range")
-
-		if rangeStr == "" {
-			statusCode = readFile(logger, org, repo, hashStr, respWr)
-		} else {
-			statusCode = readChunk(logger, org, repo, hashStr, rangeStr, respWr)
-		}
+		statusCode = readTableFile(logger, org, repo, hashStr, respWr, req)
 
 	case http.MethodPost, http.MethodPut:
 		statusCode = writeTableFile(logger, org, repo, hashStr, req)
@@ -68,6 +66,58 @@ func ServeHTTP(respWr http.ResponseWriter, req *http.Request) {
 	if statusCode != -1 {
 		respWr.WriteHeader(statusCode)
 	}
+}
+
+func readTableFile(logger func(string), org, repo, fileId string, respWr http.ResponseWriter, req *http.Request) int {
+	rangeStr := req.Header.Get("Range")
+	path := filepath.Join(org, repo, fileId)
+
+	var r io.ReadCloser
+	var readSize int64
+	var fileErr error
+	{
+		if rangeStr == "" {
+			r, readSize, fileErr = getFileReader(path)
+		} else {
+			offset, length, err := offsetAndLenFromRange(rangeStr)
+			if err != nil {
+				logger(err.Error())
+				return http.StatusBadRequest
+			}
+			readSize = length
+			r, fileErr = getFileReaderAt(path, offset, length)
+		}
+	}
+	defer func() {
+		err := r.Close()
+		if err != nil {
+			err = fmt.Errorf("failed to close file at path %s: %w", path, err)
+			logger(err.Error())
+		}
+	}()
+
+	if fileErr != nil {
+		logger(fileErr.Error())
+		if errors.Is(fileErr, os.ErrNotExist) {
+			return http.StatusNotFound
+		} else if errors.Is(fileErr, ErrReadOutOfBounds) {
+			return http.StatusBadRequest
+		}
+		return http.StatusInternalServerError
+	}
+
+	n, err := io.Copy(respWr, r)
+	if err != nil {
+		err = fmt.Errorf("failed to write data to response writer: %w", err)
+		logger(err.Error())
+		return http.StatusInternalServerError
+	}
+	if n != readSize {
+		logger(fmt.Sprintf("wanted to write %d bytes from file (%s) but only wrote %d", readSize, path, n))
+		return http.StatusInternalServerError
+	}
+
+	return -1
 }
 
 func writeTableFile(logger func(string), org, repo, fileId string, request *http.Request) int {
@@ -157,127 +207,40 @@ func offsetAndLenFromRange(rngStr string) (int64, int64, error) {
 	return int64(start), int64(end-start) + 1, nil
 }
 
-func readFile(logger func(string), org, repo, fileId string, writer io.Writer) int {
-	path := filepath.Join(org, repo, fileId)
+// getFileReader opens a file at the given path and returns an io.ReadCloser,
+// the corresponding file's filesize, and a http status.
+func getFileReader(path string) (io.ReadCloser, int64, error) {
+	return openFile(path)
+}
 
+func openFile(path string) (*os.File, int64, error) {
 	info, err := os.Stat(path)
-
 	if err != nil {
-		logger("file not found. path: " + path)
-		return http.StatusNotFound
+		return nil, 0, fmt.Errorf("failed to get stats for file at path %s: %w", path, err)
 	}
 
 	f, err := os.Open(path)
-
 	if err != nil {
-		logger("failed to open file. file: " + path + " err: " + err.Error())
-		return http.StatusInternalServerError
+		return nil, 0, fmt.Errorf("failed to open file at path %s: %w", path, err)
 	}
 
-	defer func() {
-		err := f.Close()
-
-		if err != nil {
-			logger(fmt.Sprintf("Close failed. file: %s, err: %v", path, err))
-		} else {
-			logger("Close Successful")
-		}
-	}()
-
-	n, err := io.Copy(writer, f)
-
-	if err != nil {
-		logger("failed to write data to response. err : " + err.Error())
-		return -1
-	}
-
-	if n != info.Size() {
-		logger(fmt.Sprintf("failed to write entire file to response. Copied %d of %d err: %v", n, info.Size(), err))
-		return -1
-	}
-
-	return -1
+	return f, info.Size(), nil
 }
 
-func readChunk(logger func(string), org, repo, fileId, rngStr string, writer io.Writer) int {
-	offset, length, err := offsetAndLenFromRange(rngStr)
-
+func getFileReaderAt(path string, offset int64, length int64) (io.ReadCloser, error) {
+	f, fSize, err := openFile(path)
 	if err != nil {
-		logger(fmt.Sprintln(rngStr, "is not a valid range"))
-		return http.StatusBadRequest
+		return nil, err
 	}
 
-	data, retVal := readLocalRange(logger, org, repo, fileId, int64(offset), int64(length))
-
-	if retVal != -1 {
-		return retVal
+	if fSize < int64(offset+length) {
+		return nil, fmt.Errorf("failed to read file %s at offset %d, length %d: %w", path, offset, length, ErrReadOutOfBounds)
 	}
 
-	logger(fmt.Sprintf("writing %d bytes", len(data)))
-	err = iohelp.WriteAll(writer, data)
-
+	_, err = f.Seek(int64(offset), 0)
 	if err != nil {
-		logger("failed to write data to response " + err.Error())
-		return -1
+		return nil, fmt.Errorf("failed to seek file at path %s to offset %d: %w", path, offset, err)
 	}
 
-	logger("Successfully wrote data")
-	return -1
-}
-
-func readLocalRange(logger func(string), org, repo, fileId string, offset, length int64) ([]byte, int) {
-	path := filepath.Join(org, repo, fileId)
-
-	logger(fmt.Sprintf("Attempting to read bytes %d to %d from %s", offset, offset+length, path))
-	info, err := os.Stat(path)
-
-	if err != nil {
-		logger(fmt.Sprintf("file %s not found", path))
-		return nil, http.StatusNotFound
-	}
-
-	logger(fmt.Sprintf("Verified file %s exists", path))
-
-	if info.Size() < int64(offset+length) {
-		logger(fmt.Sprintf("Attempted to read bytes %d to %d, but the file is only %d bytes in size", offset, offset+length, info.Size()))
-		return nil, http.StatusBadRequest
-	}
-
-	logger(fmt.Sprintf("Verified the file is large enough to contain the range"))
-	f, err := os.Open(path)
-
-	if err != nil {
-		logger(fmt.Sprintf("Failed to open %s: %v", path, err))
-		return nil, http.StatusInternalServerError
-	}
-
-	defer func() {
-		err := f.Close()
-
-		if err != nil {
-			logger(fmt.Sprintf("Close failed. file: %s, err: %v", path, err))
-		} else {
-			logger("Close Successful")
-		}
-	}()
-
-	logger(fmt.Sprintf("Successfully opened file"))
-	pos, err := f.Seek(int64(offset), 0)
-
-	if err != nil {
-		logger(fmt.Sprintf("Failed to seek to %d: %v", offset, err))
-		return nil, http.StatusInternalServerError
-	}
-
-	logger(fmt.Sprintf("Seek succeeded.  Current position is %d", pos))
-	diff := offset - pos
-	data, err := iohelp.ReadNBytes(f, int(diff+int64(length)))
-
-	if err != nil {
-		logger(fmt.Sprintf("Failed to read %d bytes: %v", diff+length, err))
-		return nil, http.StatusInternalServerError
-	}
-
-	logger(fmt.Sprintf("Successfully read %d bytes", len(data)))
-	return data[diff:], -1
+	return io.LimitReader(f, length).(io.ReadCloser), nil
 }

--- a/go/utils/remotesrv/http.go
+++ b/go/utils/remotesrv/http.go
@@ -77,6 +77,7 @@ func readTableFile(logger func(string), org, repo, fileId string, respWr http.Re
 	var fileErr error
 	{
 		if rangeStr == "" {
+			logger("going to write entire file")
 			r, readSize, fileErr = getFileReader(path)
 		} else {
 			offset, length, err := offsetAndLenFromRange(rangeStr)
@@ -84,6 +85,7 @@ func readTableFile(logger func(string), org, repo, fileId string, respWr http.Re
 				logger(err.Error())
 				return http.StatusBadRequest
 			}
+			logger(fmt.Sprintf("going to write bytes at offset %d, length %d", offset, length))
 			readSize = length
 			r, fileErr = getFileReaderAt(path, offset, length)
 		}
@@ -106,6 +108,8 @@ func readTableFile(logger func(string), org, repo, fileId string, respWr http.Re
 		return http.StatusInternalServerError
 	}
 
+	logger(fmt.Sprintf("opened file at path %s, going to write %d bytes", path, readSize))
+
 	n, err := io.Copy(respWr, r)
 	if err != nil {
 		err = fmt.Errorf("failed to write data to response writer: %w", err)
@@ -116,6 +120,8 @@ func readTableFile(logger func(string), org, repo, fileId string, respWr http.Re
 		logger(fmt.Sprintf("wanted to write %d bytes from file (%s) but only wrote %d", readSize, path, n))
 		return http.StatusInternalServerError
 	}
+
+	logger(fmt.Sprintf("wrote %d bytes", n))
 
 	return -1
 }

--- a/go/utils/remotesrv/main.go
+++ b/go/utils/remotesrv/main.go
@@ -38,6 +38,8 @@ func main() {
 	httpHostParam := flag.String("http-host", "localhost", "host url that this command will assume.")
 	flag.Parse()
 
+	log.SetOutput(os.Stdout)
+
 	if dirParam != nil && len(*dirParam) > 0 {
 		err := os.Chdir(*dirParam)
 

--- a/go/utils/remotesrv/main.go
+++ b/go/utils/remotesrv/main.go
@@ -38,8 +38,6 @@ func main() {
 	httpHostParam := flag.String("http-host", "localhost", "host url that this command will assume.")
 	flag.Parse()
 
-	log.SetOutput(os.Stdout)
-
 	if dirParam != nil && len(*dirParam) > 0 {
 		err := os.Chdir(*dirParam)
 


### PR DESCRIPTION
## Problem

This PR fixes an issue when pulling chunks from Dolt `remotesrv`. The symptom is a `throughput below minimum allowable` error. The problem is that the dolt client can't handle large http chunks without failing to meet its minimum required download throughput. 

Dolt `remotesrv` hosts a simple http file server that can be used to write new table files and read existing table files. When `remotesrv` receives a request to read a file it will currently read all of the requested range into memory. It then, writes the 
entire range to `http.ResponseWriter` in a single `Write` call. 

This causes a very large http chunk ([see chunked transfer encoding](https://en.wikipedia.org/wiki/Chunked_transfer_encoding)) to be sent over the wire. When the Dolt client tries to read the http response using `Read`, it takes a long time to return. Due to the way the Dolt client measures `Read` throughput, if a single `Read` takes long enough, the minimum required throughput will not be met.

## Solution
We fixed this issue by using `io.Copy` to read from the file and simultaneously write to the `http.ResponseWriter`. `io.Copy` produces small enough writes to the response writer. This reduces the number of bytes read during a singular `Read` call on the Dolt client and allows the throughput measurement to be accurate.

We could have fixed this problem by changing the way the minimum required throughput was measured, but the above change reduces the memory overhead of `remotesrv` and uses an idiomatic Golang pattern. 

## Why doesn't this issue appear when pulling chunks from S3?
In Golang, `http.Response.Body` maximum `Read` sizes are determined by the `Content-Length` and whether chunked transfer encoding is being used. The exact semantics can be investigated by reading the sources here:
- [net/http parseTransferEncoding](https://cs.opensource.google/go/go/+/master:src/net/http/transfer.go;drc=master;bpv=1;bpt=1;l=624?gsn=parseTransferEncoding&gs=kythe%3A%2F%2Fgolang.org%3Flang%3Dgo%3Fpath%3Dnet%2Fhttp%23method%2520transferReader.parseTransferEncoding)
- [net/http chunkedReader](https://github.com/golang/go/blob/master/src/net/http/internal/chunked.go#L70)
- [net/http chunkedWriter](https://github.com/golang/go/blob/master/src/net/http/server.go#L368)

Since S3 returns a Content-Length and does not use chunked transfer encoding each `Read` call returns in a small enough size. 