### PR TITLE
Fix Pk ordinal delete bug

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -68,7 +68,7 @@ require (
 )
 
 require (
-	github.com/dolthub/go-mysql-server v0.11.1-0.20220304213711-4d7d9a2c6f81
+	github.com/dolthub/go-mysql-server v0.11.1-0.20220308193105-45dd4ffcd4af
 	github.com/google/flatbuffers v2.0.5+incompatible
 	github.com/gosuri/uilive v0.0.4
 	github.com/kch42/buzhash v0.0.0-20160816060738-9bdec3dec7c6

--- a/go/go.sum
+++ b/go/go.sum
@@ -170,8 +170,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dolthub/fslock v0.0.3 h1:iLMpUIvJKMKm92+N1fmHVdxJP5NdyDK5bK7z7Ba2s2U=
 github.com/dolthub/fslock v0.0.3/go.mod h1:QWql+P17oAAMLnL4HGB5tiovtDuAjdDTPbuqx7bYfa0=
-github.com/dolthub/go-mysql-server v0.11.1-0.20220304213711-4d7d9a2c6f81 h1:uk9aHMW7ji1rbSBhAq0h/Ncy4/mIN+7cFqk/zQES3Zo=
-github.com/dolthub/go-mysql-server v0.11.1-0.20220304213711-4d7d9a2c6f81/go.mod h1:5WoXPdkIrkNBjKH+Y1XMfwREEtPXOW/yN8QfulFpZ1s=
+github.com/dolthub/go-mysql-server v0.11.1-0.20220308193105-45dd4ffcd4af h1:x3n5kCSlCeKAxyNhr6WBkLbaActYdkt48K6yMlG1Mxo=
+github.com/dolthub/go-mysql-server v0.11.1-0.20220308193105-45dd4ffcd4af/go.mod h1:5WoXPdkIrkNBjKH+Y1XMfwREEtPXOW/yN8QfulFpZ1s=
 github.com/dolthub/ishell v0.0.0-20220112232610-14e753f0f371 h1:oyPHJlzumKta1vnOQqUnfdz+pk3EmnHS3Nd0cCT0I2g=
 github.com/dolthub/ishell v0.0.0-20220112232610-14e753f0f371/go.mod h1:dhGBqcCEfK5kuFmeO5+WOx3hqc1k3M29c1oS/R7N4ms=
 github.com/dolthub/jsonpath v0.0.0-20210609232853-d49537a30474 h1:xTrR+l5l+1Lfq0NvhiEsctylXinUMFhhsqaEcl414p8=

--- a/go/libraries/doltcore/sqle/sqlutil/sql_row.go
+++ b/go/libraries/doltcore/sqle/sqlutil/sql_row.go
@@ -194,7 +194,6 @@ func DoltKeyAndMappingFromSqlRow(ctx context.Context, vrw types.ValueReadWriter,
 	}
 
 	pkOrds := doltSchema.GetPkOrdinals()
-
 	for i, pkCol := range pkCols.GetColumns() {
 		ord := pkOrds[i]
 		val := r[ord]
@@ -202,11 +201,7 @@ func DoltKeyAndMappingFromSqlRow(ctx context.Context, vrw types.ValueReadWriter,
 			return types.Tuple{}, nil, errors.New("not all pk columns have a value")
 		}
 		pkVals[i*2] = types.Uint(pkCol.Tag)
-		nomsVal, err := pkCol.TypeInfo.ConvertValueToNomsValue(ctx, vrw, val)
-		if err != nil {
-			return types.Tuple{}, nil, err
-		}
-		pkVals[i*2+1] = nomsVal
+		pkVals[i*2+1] = tagToVal[pkCol.Tag]
 	}
 
 	nbf := vrw.Format()


### PR DESCRIPTION
Consider a table with a primary key defined in a different order than the schema:

```SQL
> create table a (x int, y int, primary key (y,x);
> insert into a values (0,1), (2,3);
Query OK, 1 row affected
```

Deletes were matching rows in the index and correctly tracking the affected row count, but generating intermediate schema-order key tuples incompatible with the table PK order. The incompatible keys failed to match the source keys in the roundtrip as the edits were applied to the table:

```SQL
> delete from a where x = 0;
Query OK, 1 row affected
> delete from a where x = 0;
Query OK, 1 row affected
> select * from a where x = 0:
+---+---+
| x | y |
+---+---+
| 0 | 1 |
| 2 | 3 |
+---+---+
```

i.e. we were matching `(1,0)` and then trying to delete `(0,1)`.

This fixes the intermediate row key tuple to match the pk order. Test in https://github.com/dolthub/go-mysql-server/pull/854.