### PR TITLE
go/libraries/doltcore/dbfactory: aws.go: Support / as a character in database names for AWS remotes.

### DIFF
--- a/go/libraries/doltcore/dbfactory/aws.go
+++ b/go/libraries/doltcore/dbfactory/aws.go
@@ -152,9 +152,7 @@ func validatePath(path string) (string, error) {
 		pathLen--
 	}
 
-	// Should probably have regex validation of a valid database name here once we decide what valid database names look
-	// like.
-	if len(path) == 0 || strings.Index(path, "/") != -1 {
+	if len(path) == 0 {
 		return "", errors.New("invalid database name")
 	}
 

--- a/go/libraries/doltcore/dbfactory/aws_test.go
+++ b/go/libraries/doltcore/dbfactory/aws_test.go
@@ -60,8 +60,8 @@ func TestAWSPathValidation(t *testing.T) {
 		{
 			"slash in the middle",
 			"/data/base/",
-			"",
-			true,
+			"data/base",
+			false,
 		},
 	}
 

--- a/integration-tests/bats/aws-remotes.bats
+++ b/integration-tests/bats/aws-remotes.bats
@@ -73,3 +73,18 @@ skip_if_no_aws_tests() {
     dolt fetch origin
     dolt push origin :another-branch
 }
+
+@test "aws-remotes: can push to new remote which is a subdirectory" {
+    skip_if_no_aws_tests
+    random_repo=`openssl rand -hex 32`
+    dolt remote add origin 'aws://['"$DOLT_BATS_AWS_TABLE"':'"$DOLT_BATS_AWS_BUCKET"']/subdirectory_syntax_works/'"$random_repo"
+    dolt sql -q 'create table a_test_table (id int primary key)'
+    dolt sql -q 'insert into a_test_table values (1), (2), (47)'
+    dolt add .
+    dolt commit -m 'creating a test table'
+    dolt push origin main:main
+    dolt fetch origin
+    dolt push origin main:another-branch
+    dolt fetch origin
+    dolt push origin :another-branch
+}


### PR DESCRIPTION
This was previously forbidden because of how table files were stored in the
destination bucket, but that was changed long ago and this is now well
supported. Our internal remotes serving infrastructure uses chunk stores
constructed in the same way.