### PR TITLE
performance/utils/sysbench_runner: fix dropped errors

### DIFF
--- a/go/performance/utils/sysbench_runner/csv_test.go
+++ b/go/performance/utils/sysbench_runner/csv_test.go
@@ -27,6 +27,7 @@ import (
 
 func TestWriteReadResultsCsv(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "TestWriteResultsCsv")
+	require.NoError(t, err)
 	err = os.MkdirAll(tmpDir, os.ModePerm)
 	require.NoError(t, err)
 

--- a/go/performance/utils/sysbench_runner/results.go
+++ b/go/performance/utils/sysbench_runner/results.go
@@ -289,6 +289,9 @@ func updateResult(result *Result, key, val string) error {
 		result.SqlTotalQueriesPerSecond = p
 	case ignoredErrors:
 		total, perSecond, err := FromValWithParens(val)
+		if err != nil {
+			return err
+		}
 		t, err := fromStringInt64(total)
 		if err != nil {
 			return err
@@ -301,6 +304,9 @@ func updateResult(result *Result, key, val string) error {
 		result.IgnoredErrorsPerSecond = p
 	case reconnects:
 		total, perSecond, err := FromValWithParens(val)
+		if err != nil {
+			return err
+		}
 		t, err := fromStringInt64(total)
 		if err != nil {
 			return err


### PR DESCRIPTION
This fixes three dropped `err` variables in `performance/utils/sysbench_runner`.