### PR TITLE
Add Ephemeral Printer

### DIFF
--- a/go/cmd/dolt/cli/stdio.go
+++ b/go/cmd/dolt/cli/stdio.go
@@ -22,11 +22,11 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"github.com/dolthub/dolt/go/libraries/utils/iohelp"
-	"github.com/gosuri/uilive"
-
 	"github.com/fatih/color"
 	"github.com/google/uuid"
+	"github.com/gosuri/uilive"
+
+	"github.com/dolthub/dolt/go/libraries/utils/iohelp"
 )
 
 var outputClosed uint64

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -971,7 +971,7 @@ func diffSummary(ctx context.Context, td diff.TableDelta, colLen int) errhand.Ve
 		acc.OldSize += p.OldSize
 
 		if count%10000 == 0 {
-			eP.Printf("prev size: %d, new size: %d, adds: %d, deletes: %d, modifications: %d", acc.OldSize, acc.NewSize, acc.Adds, acc.Removes, acc.Changes)
+			eP.Printf("prev size: %d, new size: %d, adds: %d, deletes: %d, modifications: %d\n", acc.OldSize, acc.NewSize, acc.Adds, acc.Removes, acc.Changes)
 			eP.Display()
 		}
 

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -956,6 +956,8 @@ func diffSummary(ctx context.Context, td diff.TableDelta, colLen int) errhand.Ve
 	acc := diff.DiffSummaryProgress{}
 	var count int64
 	var pos int
+	eP := cli.StartEphemeralPrinter()
+	defer eP.Stop()
 	for p := range ch {
 		if ae.IsSet() {
 			break
@@ -969,8 +971,8 @@ func diffSummary(ctx context.Context, td diff.TableDelta, colLen int) errhand.Ve
 		acc.OldSize += p.OldSize
 
 		if count%10000 == 0 {
-			statusStr := fmt.Sprintf("prev size: %d, new size: %d, adds: %d, deletes: %d, modifications: %d", acc.OldSize, acc.NewSize, acc.Adds, acc.Removes, acc.Changes)
-			pos = cli.DeleteAndPrint(pos, statusStr)
+			eP.Printf("prev size: %d, new size: %d, adds: %d, deletes: %d, modifications: %d", acc.OldSize, acc.NewSize, acc.Adds, acc.Removes, acc.Changes)
+			eP.Display()
 		}
 
 		count++

--- a/go/cmd/dolt/commands/login.go
+++ b/go/cmd/dolt/commands/login.go
@@ -174,7 +174,7 @@ func loginWithCreds(ctx context.Context, dEnv *env.DoltEnv, dc creds.DoltCreds, 
 	defer p.Stop()
 	linePrinter := func() func(line string) {
 		return func(line string) {
-			p.Printf(line)
+			p.Printf(line + "\n")
 			p.Display()
 		}
 	}()

--- a/go/cmd/dolt/commands/login.go
+++ b/go/cmd/dolt/commands/login.go
@@ -170,10 +170,12 @@ func loginWithCreds(ctx context.Context, dEnv *env.DoltEnv, dc creds.DoltCreds, 
 		cli.Println("Checking remote server looking for key association.")
 	}
 
+	p := cli.StartEphemeralPrinter()
+	defer p.Stop()
 	linePrinter := func() func(line string) {
-		prevMsgLen := 0
 		return func(line string) {
-			prevMsgLen = cli.DeleteAndPrint(prevMsgLen, line)
+			p.Printf(line)
+			p.Display()
 		}
 	}()
 

--- a/go/cmd/dolt/commands/push.go
+++ b/go/cmd/dolt/commands/push.go
@@ -235,9 +235,9 @@ func pullerProgFunc(ctx context.Context, pullerEventCh chan pull.PullerEvent, la
 			p.Printf("Files Written: %d", filesTransfered)
 		} else {
 			if len(uploadRate) > 0 {
-				p.Printf("Files Created: %d, Files Uploaded: %d, Current Upload Speed: %s", tableFilesClosed, filesTransfered, uploadRate)
+				p.Printf("Files Created: %d, Files Uploaded: %d, Current Upload Speed: %s\n", tableFilesClosed, filesTransfered, uploadRate)
 			} else {
-				p.Printf("Files Created: %d, Files Uploaded: %d", tableFilesClosed, filesTransfered)
+				p.Printf("Files Created: %d, Files Uploaded: %d\n", tableFilesClosed, filesTransfered)
 			}
 		}
 		p.Display()
@@ -272,11 +272,12 @@ func progFunc(ctx context.Context, progChan chan pull.PullProgress) {
 		if done || deltaTime > halfSec {
 			last = nowUnix
 			if latest.KnownCount > 0 {
-				p.Printf("Counted chunks: %d, Buffered chunks: %d)", latest.KnownCount, latest.DoneCount)
+				p.Printf("Counted chunks: %d, Buffered chunks: %d)\n", latest.KnownCount, latest.DoneCount)
 				p.Display()
 			}
 		}
 	}
+	p.Display()
 }
 
 // progLanguage is the language to use when displaying progress for a pull from a src db to a sink db.

--- a/go/cmd/dolt/commands/push.go
+++ b/go/cmd/dolt/commands/push.go
@@ -176,13 +176,14 @@ func (ts *TextSpinner) next() string {
 }
 
 func pullerProgFunc(ctx context.Context, pullerEventCh chan pull.PullerEvent, language progLanguage) {
-	var pos int
 	var currentTreeLevel int
 	var percentBuffered float64
 	var tableFilesClosed int
 	var filesTransfered int
 	var ts TextSpinner
 
+	p := cli.StartEphemeralPrinter()
+	defer p.Stop()
 	uploadRate := ""
 
 	for evt := range pullerEventCh {
@@ -229,28 +230,26 @@ func pullerProgFunc(ctx context.Context, pullerEventCh chan pull.PullerEvent, la
 			continue
 		}
 
-		var msg string
-		msg = fmt.Sprintf("%s Tree Level: %d, Percent Buffered: %.2f%%,", ts.next(), currentTreeLevel, percentBuffered)
-
+		p.Printf("%s Tree Level: %d, Percent Buffered: %.2f%%, ", ts.next(), currentTreeLevel, percentBuffered)
 		if language == downloadLanguage {
-			msg = fmt.Sprintf("%s Files Written: %d", msg, filesTransfered)
+			p.Printf("Files Written: %d", filesTransfered)
 		} else {
 			if len(uploadRate) > 0 {
-				msg = fmt.Sprintf("%s Files Created: %d, Files Uploaded: %d, Current Upload Speed: %s", msg, tableFilesClosed, filesTransfered, uploadRate)
+				p.Printf("Files Created: %d, Files Uploaded: %d, Current Upload Speed: %s\n", tableFilesClosed, filesTransfered, uploadRate)
 			} else {
-				msg = fmt.Sprintf("%s Files Created: %d, Files Uploaded: %d", msg, tableFilesClosed, filesTransfered)
+				p.Printf("Files Created: %d, Files Uploaded: %d\n", tableFilesClosed, filesTransfered)
 			}
 		}
-
-		pos = cli.DeleteAndPrint(pos, msg)
+		p.Display()
 	}
 }
 
 func progFunc(ctx context.Context, progChan chan pull.PullProgress) {
 	var latest pull.PullProgress
 	last := time.Now().UnixNano() - 1
-	lenPrinted := 0
 	done := false
+	p := cli.StartEphemeralPrinter()
+	defer p.Stop()
 	for !done {
 		if ctx.Err() != nil {
 			return
@@ -273,14 +272,10 @@ func progFunc(ctx context.Context, progChan chan pull.PullProgress) {
 		if done || deltaTime > halfSec {
 			last = nowUnix
 			if latest.KnownCount > 0 {
-				progMsg := fmt.Sprintf("Counted chunks: %d, Buffered chunks: %d)", latest.KnownCount, latest.DoneCount)
-				lenPrinted = cli.DeleteAndPrint(lenPrinted, progMsg)
+				p.Printf("Counted chunks: %d, Buffered chunks: %d)", latest.KnownCount, latest.DoneCount)
+				p.Display()
 			}
 		}
-	}
-
-	if lenPrinted > 0 {
-		cli.Println()
 	}
 }
 

--- a/go/cmd/dolt/commands/push.go
+++ b/go/cmd/dolt/commands/push.go
@@ -242,6 +242,7 @@ func pullerProgFunc(ctx context.Context, pullerEventCh chan pull.PullerEvent, la
 		}
 		p.Display()
 	}
+	p.Display()
 }
 
 func progFunc(ctx context.Context, progChan chan pull.PullProgress) {

--- a/go/cmd/dolt/commands/push.go
+++ b/go/cmd/dolt/commands/push.go
@@ -235,9 +235,9 @@ func pullerProgFunc(ctx context.Context, pullerEventCh chan pull.PullerEvent, la
 			p.Printf("Files Written: %d", filesTransfered)
 		} else {
 			if len(uploadRate) > 0 {
-				p.Printf("Files Created: %d, Files Uploaded: %d, Current Upload Speed: %s\n", tableFilesClosed, filesTransfered, uploadRate)
+				p.Printf("Files Created: %d, Files Uploaded: %d, Current Upload Speed: %s", tableFilesClosed, filesTransfered, uploadRate)
 			} else {
-				p.Printf("Files Created: %d, Files Uploaded: %d\n", tableFilesClosed, filesTransfered)
+				p.Printf("Files Created: %d, Files Uploaded: %d", tableFilesClosed, filesTransfered)
 			}
 		}
 		p.Display()

--- a/go/libraries/doltcore/env/actions/clone.go
+++ b/go/libraries/doltcore/env/actions/clone.go
@@ -105,7 +105,7 @@ func cloneProg(eventCh <-chan pull.TableFileEvent) {
 	p := cli.StartEphemeralPrinter()
 	defer p.Stop()
 
-	p.Printf("Retrieving remote information.")
+	p.Printf("Retrieving remote information.\n")
 	p.Display()
 
 	for tblFEvt := range eventCh {
@@ -138,18 +138,18 @@ func cloneProg(eventCh <-chan pull.TableFileEvent) {
 			}
 		}
 
-		p.Printf("%s of %s chunks complete. %s chunks being downloaded currently.",
+		p.Printf("%s of %s chunks complete. %s chunks being downloaded currently.\n",
 			strhelp.CommaIfy(chunksDownloaded), strhelp.CommaIfy(chunks), strhelp.CommaIfy(chunksDownloading))
 		for _, fileId := range sortedKeys(currStats) {
 			s := currStats[fileId]
 			bps := float64(s.Read) / s.Elapsed.Seconds()
 			rate := humanize.Bytes(uint64(bps)) + "/s"
-			p.Newline()
-			p.Printf("Downloading file: %s (%s chunks) - %.2f%% downloaded, %s",
+			p.Printf("Downloading file: %s (%s chunks) - %.2f%% downloaded, %s\n",
 				fileId, strhelp.CommaIfy(int64((*tableFiles[fileId]).NumChunks())), s.Percent*100, rate)
 		}
 		p.Display()
 	}
+	p.Display()
 }
 
 func sortedKeys(m map[string]iohelp.ReadStats) []string {

--- a/go/libraries/doltcore/env/actions/clone.go
+++ b/go/libraries/doltcore/env/actions/clone.go
@@ -23,6 +23,8 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/dustin/go-humanize"
+
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
@@ -34,7 +36,6 @@ import (
 	"github.com/dolthub/dolt/go/store/datas/pull"
 	"github.com/dolthub/dolt/go/store/nbs"
 	"github.com/dolthub/dolt/go/store/types"
-	"github.com/dustin/go-humanize"
 )
 
 var ErrRepositoryExists = errors.New("data repository already exists")

--- a/go/libraries/doltcore/env/actions/remotes.go
+++ b/go/libraries/doltcore/env/actions/remotes.go
@@ -360,9 +360,7 @@ func FetchRemoteBranch(ctx context.Context, tempTablesDir string, rem env.Remote
 	wg, progChan, pullerEventCh := progStarter(newCtx)
 	err = FetchCommit(ctx, tempTablesDir, srcDB, destDB, srcDBCommit, progChan, pullerEventCh)
 	progStopper(cancelFunc, wg, progChan, pullerEventCh)
-	if err == nil {
-		cli.Println()
-	} else if err == pull.ErrDBUpToDate {
+	if err == pull.ErrDBUpToDate {
 		err = nil
 	}
 

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -517,11 +517,9 @@ SQL
     cd test-repo
     run dolt fetch
     [ "$status" -eq 0 ]
-    [ "${#lines[@]}" -eq 4 ]
-    [ "${lines[0]}" != "" ]
-    [ "${lines[1]}" != "" ]
-    [ "${lines[2]}" != "" ]
-    [ "${lines[3]}" != "" ]
+    # The number of $lines and $output printed is non-deterministic
+    # due to EphemeralPrinter. We can't test for their length here.
+    [ "$output" != "" ]
 
     run dolt fetch
     [ "$status" -eq 0 ]


### PR DESCRIPTION
`EphemeralPrinter` is tool that you can use to print temporary line(s) to the console. Every time `Display` is called, the previously written lines are cleared, and the new lines are flushed to the output.

Fixes #2964