### PR TITLE
[no-release-notes] /integration-tests/bats/sql-create-database.bats: add skip bats test for CHARACTER SET parsing bug

### DIFF
--- a/integration-tests/bats/sql-create-database.bats
+++ b/integration-tests/bats/sql-create-database.bats
@@ -298,3 +298,10 @@ SQL
     [ "$status" -eq 0 ]
     [[ "$output" =~ "$before" ]] || false
 }
+
+@test "sql-create-database: create database with character set should parse correctly and not error" {
+    skip "currently fails with Error parsing SQL"
+    run dolt sql -q 'CREATE DATABASE metabase CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ 'Query OK, 0 rows affected' ]] || false
+}


### PR DESCRIPTION
This PR adds skipped bats test that reproduces https://github.com/dolthub/dolt/issues/2971