### PR TITLE
Apply PK ordinals to secondary index pk tag ordering

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/dolthub/ishell v0.0.0-20220112232610-14e753f0f371
 	github.com/dolthub/mmap-go v1.0.4-0.20201107010347-f9f2a9588a66
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20220314213812-0ccb112f20e4
+	github.com/dolthub/vitess v0.0.0-20220315232032-19d17da876ea
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.9.0
 	github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568
@@ -68,7 +68,7 @@ require (
 )
 
 require (
-	github.com/dolthub/go-mysql-server v0.11.1-0.20220315171316-60cf12b6ed18
+	github.com/dolthub/go-mysql-server v0.11.1-0.20220316214200-9508becd56f1
 	github.com/google/flatbuffers v2.0.5+incompatible
 	github.com/gosuri/uilive v0.0.4
 	github.com/kch42/buzhash v0.0.0-20160816060738-9bdec3dec7c6

--- a/go/go.mod
+++ b/go/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/dolthub/ishell v0.0.0-20220112232610-14e753f0f371
 	github.com/dolthub/mmap-go v1.0.4-0.20201107010347-f9f2a9588a66
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20220315232032-19d17da876ea
+	github.com/dolthub/vitess v0.0.0-20220316210939-c9166dcd691d
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.9.0
 	github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568
@@ -68,7 +68,7 @@ require (
 )
 
 require (
-	github.com/dolthub/go-mysql-server v0.11.1-0.20220316214200-9508becd56f1
+	github.com/dolthub/go-mysql-server v0.11.1-0.20220316231244-f2f8808feb31
 	github.com/google/flatbuffers v2.0.5+incompatible
 	github.com/gosuri/uilive v0.0.4
 	github.com/kch42/buzhash v0.0.0-20160816060738-9bdec3dec7c6

--- a/go/go.sum
+++ b/go/go.sum
@@ -170,8 +170,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dolthub/fslock v0.0.3 h1:iLMpUIvJKMKm92+N1fmHVdxJP5NdyDK5bK7z7Ba2s2U=
 github.com/dolthub/fslock v0.0.3/go.mod h1:QWql+P17oAAMLnL4HGB5tiovtDuAjdDTPbuqx7bYfa0=
-github.com/dolthub/go-mysql-server v0.11.1-0.20220315171316-60cf12b6ed18 h1:8GGAzUhL3V/AEQWhLo+XX7uzKajIjn236xtoU7BZsFA=
-github.com/dolthub/go-mysql-server v0.11.1-0.20220315171316-60cf12b6ed18/go.mod h1:H3WxMk5sZmqOIrOJSZMYjhAw5WsJO3L9oKr92DO/P98=
+github.com/dolthub/go-mysql-server v0.11.1-0.20220316214200-9508becd56f1 h1:taTgymRgnzX711BkxcQI+YaUl1y94TObgrQANx1QKj8=
+github.com/dolthub/go-mysql-server v0.11.1-0.20220316214200-9508becd56f1/go.mod h1:3mKdRChdRH7SCQ5rM21sor1EctTUVOTadBDCrkmPQAo=
 github.com/dolthub/ishell v0.0.0-20220112232610-14e753f0f371 h1:oyPHJlzumKta1vnOQqUnfdz+pk3EmnHS3Nd0cCT0I2g=
 github.com/dolthub/ishell v0.0.0-20220112232610-14e753f0f371/go.mod h1:dhGBqcCEfK5kuFmeO5+WOx3hqc1k3M29c1oS/R7N4ms=
 github.com/dolthub/jsonpath v0.0.0-20210609232853-d49537a30474 h1:xTrR+l5l+1Lfq0NvhiEsctylXinUMFhhsqaEcl414p8=
@@ -180,8 +180,8 @@ github.com/dolthub/mmap-go v1.0.4-0.20201107010347-f9f2a9588a66 h1:WRPDbpJWEnPxP
 github.com/dolthub/mmap-go v1.0.4-0.20201107010347-f9f2a9588a66/go.mod h1:N5ZIbMGuDUpTpOFQ7HcsN6WSIpTGQjHP+Mz27AfmAgk=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20220314213812-0ccb112f20e4 h1:MB3IZHADmLWoxC+5t6U/cTCxS1t5bCfCQgEoHU2vHfs=
-github.com/dolthub/vitess v0.0.0-20220314213812-0ccb112f20e4/go.mod h1:qpZ4j0dval04OgZJ5fyKnlniSFUosTH280pdzUjUJig=
+github.com/dolthub/vitess v0.0.0-20220315232032-19d17da876ea h1:3mGkJYjzHqzuwSUSlvQxbMqkZg/gqP6U/tpSjIssyto=
+github.com/dolthub/vitess v0.0.0-20220315232032-19d17da876ea/go.mod h1:qpZ4j0dval04OgZJ5fyKnlniSFUosTH280pdzUjUJig=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/go/go.sum
+++ b/go/go.sum
@@ -170,8 +170,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dolthub/fslock v0.0.3 h1:iLMpUIvJKMKm92+N1fmHVdxJP5NdyDK5bK7z7Ba2s2U=
 github.com/dolthub/fslock v0.0.3/go.mod h1:QWql+P17oAAMLnL4HGB5tiovtDuAjdDTPbuqx7bYfa0=
-github.com/dolthub/go-mysql-server v0.11.1-0.20220316214200-9508becd56f1 h1:taTgymRgnzX711BkxcQI+YaUl1y94TObgrQANx1QKj8=
-github.com/dolthub/go-mysql-server v0.11.1-0.20220316214200-9508becd56f1/go.mod h1:3mKdRChdRH7SCQ5rM21sor1EctTUVOTadBDCrkmPQAo=
+github.com/dolthub/go-mysql-server v0.11.1-0.20220316231244-f2f8808feb31 h1:/hurSSKU1r4+gUyK8qk8TBNxrUnUSMDw0BmyCW1Weas=
+github.com/dolthub/go-mysql-server v0.11.1-0.20220316231244-f2f8808feb31/go.mod h1:isAT/2I7NVePTsMk6amxqMSuw0V1WWOg6lZipLgP73M=
 github.com/dolthub/ishell v0.0.0-20220112232610-14e753f0f371 h1:oyPHJlzumKta1vnOQqUnfdz+pk3EmnHS3Nd0cCT0I2g=
 github.com/dolthub/ishell v0.0.0-20220112232610-14e753f0f371/go.mod h1:dhGBqcCEfK5kuFmeO5+WOx3hqc1k3M29c1oS/R7N4ms=
 github.com/dolthub/jsonpath v0.0.0-20210609232853-d49537a30474 h1:xTrR+l5l+1Lfq0NvhiEsctylXinUMFhhsqaEcl414p8=
@@ -180,8 +180,8 @@ github.com/dolthub/mmap-go v1.0.4-0.20201107010347-f9f2a9588a66 h1:WRPDbpJWEnPxP
 github.com/dolthub/mmap-go v1.0.4-0.20201107010347-f9f2a9588a66/go.mod h1:N5ZIbMGuDUpTpOFQ7HcsN6WSIpTGQjHP+Mz27AfmAgk=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20220315232032-19d17da876ea h1:3mGkJYjzHqzuwSUSlvQxbMqkZg/gqP6U/tpSjIssyto=
-github.com/dolthub/vitess v0.0.0-20220315232032-19d17da876ea/go.mod h1:qpZ4j0dval04OgZJ5fyKnlniSFUosTH280pdzUjUJig=
+github.com/dolthub/vitess v0.0.0-20220316210939-c9166dcd691d h1:vt3vbDwaSeSXIEr8s9FmX+c+KjZ/DF6ScW33Xe2TF6I=
+github.com/dolthub/vitess v0.0.0-20220316210939-c9166dcd691d/go.mod h1:qpZ4j0dval04OgZJ5fyKnlniSFUosTH280pdzUjUJig=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/go/libraries/doltcore/schema/alterschema/addpk.go
+++ b/go/libraries/doltcore/schema/alterschema/addpk.go
@@ -110,11 +110,11 @@ func AddPrimaryKeyToTable(ctx context.Context, table *doltdb.Table, tableName st
 		}
 	}
 
-	newSchema.Indexes().AddIndex(sch.Indexes().AllIndexes()...)
 	err = newSchema.SetPkOrdinals(pkOrdinals)
 	if err != nil {
 		return nil, err
 	}
+	newSchema.Indexes().AddIndex(sch.Indexes().AllIndexes()...)
 
 	// Rebuild all of the indexes now that the primary key has been changed
 	return insertKeyedData(ctx, nbf, table, newSchema, tableName, opts)

--- a/go/libraries/doltcore/schema/index_coll.go
+++ b/go/libraries/doltcore/schema/index_coll.go
@@ -62,6 +62,8 @@ type IndexCollection interface {
 	RemoveIndex(indexName string) (Index, error)
 	// RenameIndex renames an index in the table metadata.
 	RenameIndex(oldName, newName string) (Index, error)
+	//SetPks changes the pks or pk ordinals
+	SetPks([]uint64) error
 }
 
 type IndexProperties struct {
@@ -403,6 +405,14 @@ func (ixc *indexCollectionImpl) tagsExist(tags ...uint64) bool {
 		}
 	}
 	return true
+}
+
+func (ixc *indexCollectionImpl) SetPks(tags []uint64) error {
+	if len(tags) != len(ixc.pks) {
+		return ErrInvalidPkOrdinals
+	}
+	ixc.pks = tags
+	return nil
 }
 
 func combineAllTags(tags []uint64, pks []uint64) []uint64 {

--- a/go/libraries/doltcore/schema/schema_impl.go
+++ b/go/libraries/doltcore/schema/schema_impl.go
@@ -225,12 +225,14 @@ func (si *schemaImpl) SetPkOrdinals(o []int) error {
 
 	si.pkOrdinals = o
 	newPks := make([]Column, si.pkCols.Size())
+	newPkTags := make([]uint64, si.pkCols.Size())
 	for i, j := range si.pkOrdinals {
-		newPks[i] = si.allCols.GetByIndex(j)
+		pkCol := si.allCols.GetByIndex(j)
+		newPks[i] = pkCol
+		newPkTags[i] = pkCol.Tag
 	}
 	si.pkCols = NewColCollection(newPks...)
-
-	return nil
+	return si.indexCollection.SetPks(newPkTags)
 }
 
 func (si *schemaImpl) String() string {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -224,8 +224,12 @@ func TestCreateTable(t *testing.T) {
 	enginetest.TestCreateTable(t, newDoltHarness(t))
 }
 
-func TestPkOrdinals(t *testing.T) {
-	enginetest.TestPkOrdinals(t, newDoltHarness(t))
+func TestPkOrdinalsDDL(t *testing.T) {
+	enginetest.TestPkOrdinalsDDL(t, newDoltHarness(t))
+}
+
+func TestPkOrdinalsDML(t *testing.T) {
+	enginetest.TestPkOrdinalsDML(t, newDoltHarness(t))
 }
 
 func TestDropTable(t *testing.T) {

--- a/go/libraries/doltcore/sqle/index/noms_index_iter.go
+++ b/go/libraries/doltcore/sqle/index/noms_index_iter.go
@@ -148,10 +148,14 @@ func (i *indexLookupRowIterAdapter) queueRows(ctx context.Context, epoch int) {
 		select {
 		case lookups.toLookupCh <- lookup:
 		case <-ctx.Done():
+			err := ctx.Err()
+			if err == nil {
+				err = io.EOF
+			}
 			i.resultBuf.Push(lookupResult{
 				idx: idx,
 				r:   nil,
-				err: ctx.Err(),
+				err: err,
 			}, epoch)
 
 			return

--- a/go/libraries/doltcore/sqle/sqlutil/sql_row.go
+++ b/go/libraries/doltcore/sqle/sqlutil/sql_row.go
@@ -164,6 +164,10 @@ func DoltKeyValueAndMappingFromSqlRow(ctx context.Context, vrw types.ValueReadWr
 // DoltKeyAndMappingFromSqlRow converts a sql.Row to key tuple and keeps a mapping from tag to value that
 // can be used to speed up index key generation for foreign key checks.
 func DoltKeyAndMappingFromSqlRow(ctx context.Context, vrw types.ValueReadWriter, r sql.Row, doltSchema schema.Schema) (types.Tuple, map[uint64]types.Value, error) {
+	if r == nil {
+		return types.EmptyTuple(vrw.Format()), nil, sql.ErrUnexpectedNilRow.New()
+	}
+
 	allCols := doltSchema.GetAllCols()
 	pkCols := doltSchema.GetPKCols()
 


### PR DESCRIPTION
The original bug was found by stabs: https://github.com/dolthub/dolt/issues/2991
Refer to the GMS PR with a script test for testing the condition that triggers the bug: https://github.com/dolthub/go-mysql-server/pull/881

A summary of the bug is: Secondary indexes were caching old pk orderings. Schema changes created an inconsistency between secondary indexes and the primary keys they referred to, causing errors in index lookups. This only impacts DDL statements involving a new pk ordering and preexisting secondary indexes.

There are several layers of indirection between pk source row and secondary index row. When creating an index row, a higher layer of code reads and formats keys in the correct index ordering (for example, reading schema order (x,y,z) -> (y,z,x)). However, we deconstruct and rebuild that row before inserting values into a secondary index. The second constructor drops the ordering in favor of a hashmap of tags, and uses an index embedded tag ordering `pks` to recreate the row.

This fix extends `schema.SetPkOrdinals` to override the preexisting ordering of `pks` with an `indexCollection.SetPks` method.