### PR TITLE
go/libraries/doltcore/sqle/dsess: Refactor Dolt Session update methods

### DIFF
--- a/go/libraries/doltcore/sqle/dfunctions/dolt_merge.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_merge.go
@@ -97,7 +97,7 @@ func doDoltMerge(ctx *sql.Context, row sql.Row, exprs []sql.Expression) (interfa
 			return noConflicts, err
 		}
 
-		err := sess.SetWorkingSet(ctx, dbName, ws, nil)
+		err := sess.SetWorkingSet(ctx, dbName, ws)
 		if err != nil {
 			return noConflicts, err
 		}
@@ -171,7 +171,7 @@ func mergeIntoWorkingSet(ctx *sql.Context, sess *dsess.DoltSession, roots doltdb
 			if err == doltdb.ErrUnresolvedConflicts {
 				// if there are unresolved conflicts, write the resulting working set back to the session and return an
 				// error message
-				wsErr := sess.SetWorkingSet(ctx, dbName, ws, nil)
+				wsErr := sess.SetWorkingSet(ctx, dbName, ws)
 				if wsErr != nil {
 					return ws, hasConflicts, wsErr
 				}
@@ -199,7 +199,7 @@ func mergeIntoWorkingSet(ctx *sql.Context, sess *dsess.DoltSession, roots doltdb
 	if err == doltdb.ErrUnresolvedConflicts || err == doltdb.ErrUnresolvedConstraintViolations {
 		// if there are unresolved conflicts, write the resulting working set back to the session and return an
 		// error message
-		wsErr := sess.SetWorkingSet(ctx, dbName, ws, nil)
+		wsErr := sess.SetWorkingSet(ctx, dbName, ws)
 		if wsErr != nil {
 			return ws, hasConflicts, wsErr
 		}
@@ -211,7 +211,7 @@ func mergeIntoWorkingSet(ctx *sql.Context, sess *dsess.DoltSession, roots doltdb
 		return ws, noConflicts, err
 	}
 
-	err = sess.SetWorkingSet(ctx, dbName, ws, nil)
+	err = sess.SetWorkingSet(ctx, dbName, ws)
 	if err != nil {
 		return ws, noConflicts, err
 	}
@@ -273,7 +273,7 @@ func executeFFMerge(ctx *sql.Context, dbName string, squash bool, ws *doltdb.Wor
 	// merges). Hence, we go ahead and commit the working set to the transaction.
 	sess := dsess.DSessFromSess(ctx.Session)
 
-	err = sess.SetWorkingSet(ctx, dbName, ws, nil)
+	err = sess.SetWorkingSet(ctx, dbName, ws)
 	if err != nil {
 		return ws, err
 	}
@@ -311,7 +311,7 @@ func executeNoFFMerge(
 
 	// Save our work so far in the session, as it will be referenced by the commit call below (badly in need of a
 	// refactoring)
-	err = dSess.SetWorkingSet(ctx, dbName, ws, nil)
+	err = dSess.SetWorkingSet(ctx, dbName, ws)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_pull.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_pull.go
@@ -138,7 +138,7 @@ func (d DoltPullFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 				return conflicts, err
 			}
 
-			err = sess.SetWorkingSet(ctx, dbName, ws, nil)
+			err = sess.SetWorkingSet(ctx, dbName, ws)
 			if err != nil {
 				return conflicts, err
 			}

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_reset.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_reset.go
@@ -95,7 +95,7 @@ func (d DoltResetFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) 
 		if err != nil {
 			return nil, err
 		}
-		err = dSess.SetWorkingSet(ctx, dbName, ws.WithWorkingRoot(roots.Working).WithStagedRoot(roots.Staged), nil)
+		err = dSess.SetWorkingSet(ctx, dbName, ws.WithWorkingRoot(roots.Working).WithStagedRoot(roots.Staged))
 		if err != nil {
 			return 1, err
 		}

--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -829,23 +829,24 @@ func (sess *Session) AddDB(ctx *sql.Context, dbState InitialDbState) error {
 	// TODO: figure out how to cast this to dsqle.SqlDatabase without creating import cycles
 	nbf := sessionState.dbData.Ddb.Format()
 	editOpts := db.(interface{ EditOptions() editor.Options }).EditOptions()
-	sessionState.WriteSession = writer.NewWriteSession(nbf, nil, editOpts)
 
 	// WorkingSet is nil in the case of a read only, detached head DB
 	if dbState.Err != nil {
 		sessionState.Err = dbState.Err
+
 	} else if dbState.WorkingSet != nil {
 		sessionState.WorkingSet = dbState.WorkingSet
+		sessionState.WriteSession = writer.NewWriteSession(nbf, sessionState.WorkingSet, editOpts)
 		err := sess.SetWorkingSet(ctx, db.Name(), dbState.WorkingSet)
 		if err != nil {
 			return err
 		}
+
 	} else {
 		headRoot, err := dbState.HeadCommit.GetRootValue()
 		if err != nil {
 			return err
 		}
-
 		sessionState.headRoot = headRoot
 	}
 

--- a/go/libraries/doltcore/sqle/writer/noms_write_session.go
+++ b/go/libraries/doltcore/sqle/writer/noms_write_session.go
@@ -54,11 +54,10 @@ type WriteSession interface {
 // nomsWriteSession handles all edit operations on a table that may also update other tables.
 // Serves as coordination for SessionedTableEditors.
 type nomsWriteSession struct {
-	opts editor.Options
-
 	workingSet *doltdb.WorkingSet
 	tables     map[string]*sessionedTableEditor
 	writeMutex *sync.RWMutex // This mutex is specifically for changes that affect the TES or all STEs
+	opts       editor.Options
 }
 
 var _ WriteSession = &nomsWriteSession{}
@@ -76,10 +75,10 @@ func NewWriteSession(nbf *types.NomsBinFormat, ws *doltdb.WorkingSet, opts edito
 	}
 
 	return &nomsWriteSession{
-		opts:       opts,
 		workingSet: ws,
 		tables:     make(map[string]*sessionedTableEditor),
 		writeMutex: &sync.RWMutex{},
+		opts:       opts,
 	}
 }
 

--- a/go/libraries/doltcore/sqle/writer/noms_write_session.go
+++ b/go/libraries/doltcore/sqle/writer/noms_write_session.go
@@ -34,11 +34,11 @@ type WriteSession interface {
 	// GetTableWriter creates a TableWriter and adds it to the WriteSession.
 	GetTableWriter(ctx context.Context, table, db string, ait globalstate.AutoIncrementTracker, setter SessionRootSetter, batched bool) (TableWriter, error)
 
-	// UpdateWorkingSet takes a callback to update this WriteSession's WorkingSet.
-	// WriteSession flushes the pending writes in the session before calling the callback.
+	// UpdateWorkingSet takes a callback to update this WriteSession's WorkingSet. The update method cannot change the
+	// WorkingSetRef of the WriteSession. WriteSession flushes the pending writes in the session before calling the update.
 	UpdateWorkingSet(ctx context.Context, cb func(ctx context.Context, current *doltdb.WorkingSet) (*doltdb.WorkingSet, error)) error
 
-	// SetWorkingSet sets the root for the WriteSession.
+	// SetWorkingSet modifies the state of the WriteSession. The WorkingSetRef of |ws| must match the existing Ref.
 	SetWorkingSet(ctx context.Context, ws *doltdb.WorkingSet) error
 
 	// Flush flushes the pending writes in the session.

--- a/go/libraries/doltcore/sqle/writer/noms_write_session.go
+++ b/go/libraries/doltcore/sqle/writer/noms_write_session.go
@@ -310,6 +310,9 @@ func (s *nomsWriteSession) setWorkingSet(ctx context.Context, ws *doltdb.Working
 	if ws == nil {
 		return fmt.Errorf("cannot set a nomsWriteSession's working set to nil once it has been created")
 	}
+	if s.workingSet != nil && s.workingSet.Ref() != ws.Ref() {
+		return fmt.Errorf("cannot change working set ref using SetWorkingSet")
+	}
 	s.workingSet = ws
 
 	root := ws.WorkingRoot()


### PR DESCRIPTION
This PR alters the life cycle of WriteSessions within a dolt session. WriteSessions now have a single working set ref throughout their existence, and assert that their working set ref is not changed by set or update calls. 
To switch branches/working set, the Session discards the existing (empty) WriteSession, and creates a new one