### PR TITLE
go/cmd/dolt: Fix fetch printing newline for each progress update on Windows

### DIFF
--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -956,8 +956,7 @@ func diffSummary(ctx context.Context, td diff.TableDelta, colLen int) errhand.Ve
 	acc := diff.DiffSummaryProgress{}
 	var count int64
 	var pos int
-	eP := cli.StartEphemeralPrinter()
-	defer eP.Stop()
+	eP := cli.NewEphemeralPrinter()
 	for p := range ch {
 		if ae.IsSet() {
 			break

--- a/go/cmd/dolt/commands/login.go
+++ b/go/cmd/dolt/commands/login.go
@@ -170,8 +170,7 @@ func loginWithCreds(ctx context.Context, dEnv *env.DoltEnv, dc creds.DoltCreds, 
 		cli.Println("Checking remote server looking for key association.")
 	}
 
-	p := cli.StartEphemeralPrinter()
-	defer p.Stop()
+	p := cli.NewEphemeralPrinter()
 	linePrinter := func() func(line string) {
 		return func(line string) {
 			p.Printf(line + "\n")

--- a/go/cmd/dolt/commands/push.go
+++ b/go/cmd/dolt/commands/push.go
@@ -182,8 +182,7 @@ func pullerProgFunc(ctx context.Context, pullerEventCh chan pull.PullerEvent, la
 	var filesTransfered int
 	var ts TextSpinner
 
-	p := cli.StartEphemeralPrinter()
-	defer p.Stop()
+	p := cli.NewEphemeralPrinter()
 	uploadRate := ""
 
 	for evt := range pullerEventCh {
@@ -249,8 +248,7 @@ func progFunc(ctx context.Context, progChan chan pull.PullProgress) {
 	var latest pull.PullProgress
 	last := time.Now().UnixNano() - 1
 	done := false
-	p := cli.StartEphemeralPrinter()
-	defer p.Stop()
+	p := cli.NewEphemeralPrinter()
 	for !done {
 		if ctx.Err() != nil {
 			return

--- a/go/libraries/doltcore/env/actions/clone.go
+++ b/go/libraries/doltcore/env/actions/clone.go
@@ -103,8 +103,7 @@ func cloneProg(eventCh <-chan pull.TableFileEvent) {
 		tableFiles        = make(map[string]*nbs.TableFile)
 	)
 
-	p := cli.StartEphemeralPrinter()
-	defer p.Stop()
+	p := cli.NewEphemeralPrinter()
 
 	p.Printf("Retrieving remote information.\n")
 	p.Display()


### PR DESCRIPTION
Fixes: https://github.com/dolthub/dolt/issues/2941

The above reported bug is caused by `EphemeralPrinter`. It's related to how the underlying library of `uilive` clears terminal lines on Windows. `uilive` will only clear terminal lines successfully if it detects that the given `io.Writer` is a terminal. The package does this by checking if the io.Writer has a `Fd` function and using the returned file descriptor for its `istty` check.

When color.Output is used as the `io.Writer`, `uilive`'s terminal check fails since that does not declare `Fd`. The problem is that color.Output does use the initial `os.StdOut` which is in fact the terminal... 

This was fixed by wrapping color.Output with a struct that reports the correct file descriptor.

This PR also improves the display output of ephemeral printer by controlling when `uilive` flushes its output.