### PR TITLE
Simplify RebuildIndex

### DIFF
--- a/go/cmd/dolt/commands/dump.go
+++ b/go/cmd/dolt/commands/dump.go
@@ -239,7 +239,7 @@ func dumpTable(ctx context.Context, dEnv *env.DoltEnv, tblOpts *tableOptions, fi
 }
 
 func getTableWriter(ctx context.Context, dEnv *env.DoltEnv, tblOpts *tableOptions, outSch schema.Schema, filePath string) (table.SqlTableWriter, errhand.VerboseError) {
-	opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+	opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 
 	writer, err := dEnv.FS.OpenForWriteAppend(filePath, os.ModePerm)
 	if err != nil {

--- a/go/cmd/dolt/commands/engine/utils.go
+++ b/go/cmd/dolt/commands/engine/utils.go
@@ -86,7 +86,8 @@ func GetCommitHooks(ctx context.Context, dEnv *env.DoltEnv) ([]doltdb.CommitHook
 
 func newDatabase(name string, dEnv *env.DoltEnv) sqle.Database {
 	opts := editor.Options{
-		Deaf: dEnv.DbEaFactory(),
+		Deaf:    dEnv.DbEaFactory(),
+		Tempdir: dEnv.TempTableFilesDir(),
 	}
 	return sqle.NewDatabase(name, dEnv.DbData(), opts)
 }
@@ -96,7 +97,8 @@ func newDatabase(name string, dEnv *env.DoltEnv) sqle.Database {
 // that will log warnings when attempting to perform replica commands.
 func newReplicaDatabase(ctx context.Context, name string, remoteName string, dEnv *env.DoltEnv) (sqle.ReadReplicaDatabase, error) {
 	opts := editor.Options{
-		Deaf: dEnv.DbEaFactory(),
+		Deaf:    dEnv.DbEaFactory(),
+		Tempdir: dEnv.TempTableFilesDir(),
 	}
 
 	db := sqle.NewDatabase(name, dEnv.DbData(), opts)

--- a/go/cmd/dolt/commands/filter-branch.go
+++ b/go/cmd/dolt/commands/filter-branch.go
@@ -239,7 +239,7 @@ func rebaseSqlEngine(ctx context.Context, dEnv *env.DoltEnv, cm *doltdb.Commit) 
 		return nil, nil, err
 	}
 
-	opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+	opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 	db := dsqle.NewDatabase(dbName, dEnv.DbData(), opts)
 
 	mrEnv, err := env.DoltEnvAsMultiEnv(ctx, dEnv)

--- a/go/cmd/dolt/commands/indexcmds/rebuild.go
+++ b/go/cmd/dolt/commands/indexcmds/rebuild.go
@@ -84,7 +84,7 @@ func (cmd RebuildCmd) Exec(ctx context.Context, commandStr string, args []string
 	if !ok {
 		return HandleErr(errhand.BuildDError("The table `%s` does not exist.", tableName).Build(), nil)
 	}
-	opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+	opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 	indexRowData, err := editor.RebuildIndex(ctx, table, indexName, opts)
 	if err != nil {
 		return HandleErr(errhand.BuildDError("Unable to rebuild index `%s` on table `%s`.", indexName, tableName).AddCause(err).Build(), nil)

--- a/go/cmd/dolt/commands/revert.go
+++ b/go/cmd/dolt/commands/revert.go
@@ -115,7 +115,7 @@ func (cmd RevertCmd) Exec(ctx context.Context, commandStr string, args []string,
 		commits[i] = commit
 	}
 
-	opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+	opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 	workingRoot, revertMessage, err := merge.Revert(ctx, dEnv.DoltDB, workingRoot, commits, opts)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)

--- a/go/cmd/dolt/commands/schcmds/export.go
+++ b/go/cmd/dolt/commands/schcmds/export.go
@@ -134,7 +134,7 @@ func exportSchemas(ctx context.Context, apr *argparser.ArgParseResults, root *do
 	}
 
 	for _, tn := range tablesToExport {
-		opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+		opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 		verr := exportTblSchema(ctx, tn, root, wr, opts)
 		if verr != nil {
 			return verr

--- a/go/cmd/dolt/commands/schcmds/show.go
+++ b/go/cmd/dolt/commands/schcmds/show.go
@@ -135,7 +135,7 @@ func printSchemas(ctx context.Context, apr *argparser.ArgParseResults, dEnv *env
 			}
 		}
 
-		opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+		opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 		sqlCtx, engine, _ := dsqle.PrepareCreateTableStmt(ctx, dsqle.NewUserSpaceDatabase(root, opts))
 
 		var notFound []string

--- a/go/libraries/doltcore/dtestutils/testcommands/command.go
+++ b/go/libraries/doltcore/dtestutils/testcommands/command.go
@@ -187,7 +187,7 @@ func (q Query) CommandString() string { return fmt.Sprintf("query %s", q.Query) 
 func (q Query) Exec(t *testing.T, dEnv *env.DoltEnv) error {
 	root, err := dEnv.WorkingRoot(context.Background())
 	require.NoError(t, err)
-	opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+	opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 	sqlDb := dsqle.NewDatabase("dolt", dEnv.DbData(), opts)
 	engine, sqlCtx, err := dsqle.NewTestEngine(t, dEnv, context.Background(), sqlDb, root)
 	require.NoError(t, err)
@@ -303,7 +303,7 @@ func (m Merge) Exec(t *testing.T, dEnv *env.DoltEnv) error {
 		assert.NoError(t, err)
 
 	} else {
-		opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+		opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 		mergedRoot, tblToStats, err := merge.MergeCommits(context.Background(), cm1, cm2, opts)
 		require.NoError(t, err)
 		for _, stats := range tblToStats {

--- a/go/libraries/doltcore/merge/action.go
+++ b/go/libraries/doltcore/merge/action.go
@@ -236,7 +236,7 @@ func ExecuteFFMerge(
 }
 
 func ExecuteMerge(ctx context.Context, dEnv *env.DoltEnv, spec *MergeSpec) (map[string]*MergeStats, error) {
-	opts := editor.Options{Deaf: dEnv.BulkDbEaFactory()}
+	opts := editor.Options{Deaf: dEnv.BulkDbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 	mergedRoot, tblToStats, err := MergeCommits(ctx, spec.HeadC, spec.MergeC, opts)
 	if err != nil {
 		switch err {

--- a/go/libraries/doltcore/merge/resolve.go
+++ b/go/libraries/doltcore/merge/resolve.go
@@ -275,7 +275,7 @@ func AutoResolveTables(ctx context.Context, dEnv *env.DoltEnv, autoResolver Auto
 
 func autoResolve(ctx context.Context, dEnv *env.DoltEnv, root *doltdb.RootValue, autoResolver AutoResolver, tbls []string) error {
 	var err error
-	opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+	opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 	for _, tblName := range tbls {
 		root, err = ResolveTable(ctx, root.VRW(), tblName, root, autoResolver, opts)
 		if err != nil {

--- a/go/libraries/doltcore/mvdata/data_loc_test.go
+++ b/go/libraries/doltcore/mvdata/data_loc_test.go
@@ -200,7 +200,7 @@ func TestCreateRdWr(t *testing.T) {
 
 		loc := test.dl
 
-		opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+		opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 
 		filePath, fpErr := dEnv.FS.Abs(strings.Split(loc.String(), ":")[1])
 		if fpErr != nil {

--- a/go/libraries/doltcore/schema/alterschema/droppk_test.go
+++ b/go/libraries/doltcore/schema/alterschema/droppk_test.go
@@ -270,7 +270,7 @@ func TestDropPks(t *testing.T) {
 			dEnv := dtestutils.CreateTestEnv()
 			ctx := context.Background()
 
-			opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+			opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 			db := sqle.NewDatabase("dolt", dEnv.DbData(), opts)
 			root, _ := dEnv.WorkingRoot(ctx)
 			engine, sqlCtx, err := sqle.NewTestEngine(t, dEnv, ctx, db, root)

--- a/go/libraries/doltcore/schema/alterschema/modifycolumn_test.go
+++ b/go/libraries/doltcore/schema/alterschema/modifycolumn_test.go
@@ -177,7 +177,7 @@ func TestModifyColumn(t *testing.T) {
 			tbl, _, err := root.GetTable(ctx, tableName)
 			assert.NoError(t, err)
 
-			opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+			opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 			updatedTable, err := ModifyColumn(ctx, tbl, tt.existingColumn, tt.newColumn, tt.order, opts)
 			if len(tt.expectedErr) > 0 {
 				require.Error(t, err)

--- a/go/libraries/doltcore/sqle/altertests/common_test.go
+++ b/go/libraries/doltcore/sqle/altertests/common_test.go
@@ -117,7 +117,7 @@ func parseTime(timestampLayout bool, value string) time.Time {
 
 func executeSelect(t *testing.T, ctx context.Context, dEnv *env.DoltEnv, root *doltdb.RootValue, query string) ([]interface{}, error) {
 	var err error
-	opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+	opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 	db := sqle.NewDatabase("dolt", dEnv.DbData(), opts)
 	engine, sqlCtx, err := sqle.NewTestEngine(t, dEnv, ctx, db, root)
 	if err != nil {
@@ -146,7 +146,7 @@ func executeSelect(t *testing.T, ctx context.Context, dEnv *env.DoltEnv, root *d
 }
 
 func executeModify(t *testing.T, ctx context.Context, dEnv *env.DoltEnv, root *doltdb.RootValue, query string) (*doltdb.RootValue, error) {
-	opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+	opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 	db := sqle.NewDatabase("dolt", dEnv.DbData(), opts)
 	engine, sqlCtx, err := sqle.NewTestEngine(t, dEnv, ctx, db, root)
 	if err != nil {

--- a/go/libraries/doltcore/sqle/common_test.go
+++ b/go/libraries/doltcore/sqle/common_test.go
@@ -41,7 +41,7 @@ type SetupFn func(t *testing.T, dEnv *env.DoltEnv)
 // the targetSchema given is used to prepare all rows.
 func executeSelect(t *testing.T, ctx context.Context, dEnv *env.DoltEnv, root *doltdb.RootValue, query string) ([]sql.Row, sql.Schema, error) {
 	var err error
-	opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+	opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 	db := NewDatabase("dolt", dEnv.DbData(), opts)
 	engine, sqlCtx, err := NewTestEngine(t, dEnv, ctx, db, root)
 	if err != nil {
@@ -68,7 +68,7 @@ func executeSelect(t *testing.T, ctx context.Context, dEnv *env.DoltEnv, root *d
 
 // Runs the query given and returns the error (if any).
 func executeModify(t *testing.T, ctx context.Context, dEnv *env.DoltEnv, root *doltdb.RootValue, query string) (*doltdb.RootValue, error) {
-	opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+	opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 	db := NewDatabase("dolt", dEnv.DbData(), opts)
 	engine, sqlCtx, err := NewTestEngine(t, dEnv, ctx, db, root)
 

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -91,8 +91,7 @@ type Database struct {
 	// todo: needs a major refactor to
 	//   correctly handle persisted sequences
 	//   that must be coordinated across txs
-	gs globalstate.GlobalState
-
+	gs       globalstate.GlobalState
 	editOpts editor.Options
 }
 

--- a/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
@@ -205,7 +205,7 @@ func (d *DoltHarness) NewDatabases(names ...string) []sql.Database {
 	d.databases = nil
 	d.databaseGlobalStates = nil
 	for _, name := range names {
-		opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+		opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 		db := sqle.NewDatabase(name, dEnv.DbData(), opts)
 		d.databases = append(d.databases, db)
 

--- a/go/libraries/doltcore/sqle/index/mergeable_indexes_setup_test.go
+++ b/go/libraries/doltcore/sqle/index/mergeable_indexes_setup_test.go
@@ -39,7 +39,7 @@ func setupIndexes(t *testing.T, tableName, insertQuery string) (*sqle.Engine, *e
 	dEnv := dtestutils.CreateTestEnv()
 	root, err := dEnv.WorkingRoot(context.Background())
 	require.NoError(t, err)
-	opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+	opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 	db := dsqle.NewDatabase("dolt", dEnv.DbData(), opts)
 	engine, sqlCtx, err := dsqle.NewTestEngine(t, dEnv, context.Background(), db, root)
 	require.NoError(t, err)

--- a/go/libraries/doltcore/sqle/logictest/dolt/doltharness.go
+++ b/go/libraries/doltcore/sqle/logictest/dolt/doltharness.go
@@ -306,7 +306,7 @@ func schemaToSchemaString(sch sql.Schema) (string, error) {
 }
 
 func sqlNewEngine(dEnv *env.DoltEnv) (*sqle.Engine, error) {
-	opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+	opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 	db := dsql.NewDatabase("dolt", dEnv.DbData(), opts)
 	mrEnv, err := env.DoltEnvAsMultiEnv(context.Background(), dEnv)
 	if err != nil {

--- a/go/libraries/doltcore/sqle/schema_table_test.go
+++ b/go/libraries/doltcore/sqle/schema_table_test.go
@@ -34,7 +34,7 @@ import (
 func TestSchemaTableRecreation(t *testing.T) {
 	ctx := NewTestSQLCtx(context.Background())
 	dEnv := dtestutils.CreateTestEnv()
-	opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+	opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 	db := NewDatabase("dolt", dEnv.DbData(), opts)
 	dbState := getDbState(t, db, dEnv)
 	err := dsess.DSessFromSess(ctx.Session).AddDB(ctx, dbState)

--- a/go/libraries/doltcore/sqle/sqlbatch_test.go
+++ b/go/libraries/doltcore/sqle/sqlbatch_test.go
@@ -64,7 +64,7 @@ func TestSqlBatchInserts(t *testing.T) {
 	CreateTestDatabase(dEnv, t)
 	root, _ := dEnv.WorkingRoot(ctx)
 
-	opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+	opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 	db := NewDatabase("dolt", dEnv.DbData(), opts)
 	engine, sqlCtx, err := NewTestEngine(t, dEnv, ctx, db, root)
 	require.NoError(t, err)
@@ -154,7 +154,7 @@ func TestSqlBatchInsertIgnoreReplace(t *testing.T) {
 	CreateTestDatabase(dEnv, t)
 	root, _ := dEnv.WorkingRoot(ctx)
 
-	opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+	opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 	db := NewDatabase("dolt", dEnv.DbData(), opts)
 	engine, sqlCtx, err := NewTestEngine(t, dEnv, ctx, db, root)
 	require.NoError(t, err)
@@ -194,7 +194,7 @@ func TestSqlBatchInsertErrors(t *testing.T) {
 	CreateTestDatabase(dEnv, t)
 	root, _ := dEnv.WorkingRoot(ctx)
 
-	opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+	opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 	db := NewDatabase("dolt", dEnv.DbData(), opts)
 	engine, sqlCtx, err := NewTestEngine(t, dEnv, ctx, db, root)
 	require.NoError(t, err)

--- a/go/libraries/doltcore/sqle/testutil.go
+++ b/go/libraries/doltcore/sqle/testutil.go
@@ -41,7 +41,7 @@ import (
 // ExecuteSql executes all the SQL non-select statements given in the string against the root value given and returns
 // the updated root, or an error. Statements in the input string are split by `;\n`
 func ExecuteSql(t *testing.T, dEnv *env.DoltEnv, root *doltdb.RootValue, statements string) (*doltdb.RootValue, error) {
-	opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+	opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 	db := NewDatabase("dolt", dEnv.DbData(), opts)
 
 	engine, ctx, err := NewTestEngine(t, dEnv, context.Background(), db, root)
@@ -171,7 +171,7 @@ func ExecuteSelect(t *testing.T, dEnv *env.DoltEnv, ddb *doltdb.DoltDB, root *do
 		Drw: dEnv.DocsReadWriter(),
 	}
 
-	opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+	opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 	db := NewDatabase("dolt", dbData, opts)
 	engine, ctx, err := NewTestEngine(t, dEnv, context.Background(), db, root)
 	if err != nil {

--- a/go/libraries/doltcore/sqle/writer/noms_table_writer_test.go
+++ b/go/libraries/doltcore/sqle/writer/noms_table_writer_test.go
@@ -162,7 +162,7 @@ func TestTableEditor(t *testing.T) {
 
 			ctx := sqle.NewTestSQLCtx(context.Background())
 			root, _ := dEnv.WorkingRoot(context.Background())
-			opts := editor.Options{Deaf: dEnv.DbEaFactory()}
+			opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 			db := sqle.NewDatabase("dolt", dEnv.DbData(), opts)
 			err := dsess.DSessFromSess(ctx.Session).AddDB(ctx, getDbState(t, db, dEnv))
 			require.NoError(t, err)

--- a/go/libraries/doltcore/table/editor/index_editor.go
+++ b/go/libraries/doltcore/table/editor/index_editor.go
@@ -17,6 +17,7 @@ package editor
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"sync"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
@@ -287,7 +288,14 @@ func RebuildIndex(ctx context.Context, tbl *doltdb.Table, indexName string, opts
 		return types.EmptyMap, fmt.Errorf("index `%s` does not exist", indexName)
 	}
 
-	rebuiltIndexData, err := rebuildIndexRowData(ctx, tbl.ValueReadWriter(), sch, tableRowData, index, opts)
+	tf := tupleFactories.Get().(*types.TupleFactory)
+
+	tmpDir, err := ioutil.TempDir("", "tempif-*")
+	if err != nil {
+		return types.EmptyMap, err
+	}
+	opts.Deaf = NewBulkImportTEAFactory(tbl.Format(), tbl.ValueReadWriter(), tmpDir)
+	rebuiltIndexData, err := rebuildIndexRowData(ctx, tbl.ValueReadWriter(), sch, tableRowData, index, opts, tf)
 	if err != nil {
 		return types.EmptyMap, err
 	}
@@ -314,8 +322,15 @@ func RebuildAllIndexes(ctx context.Context, t *doltdb.Table, opts Options) (*dol
 		return nil, err
 	}
 
+	tf := tupleFactories.Get().(*types.TupleFactory)
+
+	tmpDir, err := ioutil.TempDir("", "tempif-*")
+	if err != nil {
+		return nil, err
+	}
+	opts.Deaf = NewBulkImportTEAFactory(t.Format(), t.ValueReadWriter(), tmpDir)
 	for _, index := range sch.Indexes().AllIndexes() {
-		rebuiltIndexRowData, err := rebuildIndexRowData(ctx, t.ValueReadWriter(), sch, tableRowData, index, opts)
+		rebuiltIndexRowData, err := rebuildIndexRowData(ctx, t.ValueReadWriter(), sch, tableRowData, index, opts, tf)
 		if err != nil {
 			return nil, err
 		}
@@ -329,20 +344,19 @@ func RebuildAllIndexes(ctx context.Context, t *doltdb.Table, opts Options) (*dol
 	return t.SetIndexSet(ctx, indexes)
 }
 
-func rebuildIndexRowData(ctx context.Context, vrw types.ValueReadWriter, sch schema.Schema, tblRowData types.Map, index schema.Index, opts Options) (types.Map, error) {
+func rebuildIndexRowData(ctx context.Context, vrw types.ValueReadWriter, sch schema.Schema, tblRowData types.Map, index schema.Index, opts Options, tf *types.TupleFactory) (types.Map, error) {
 	emptyIndexMap, err := types.NewMap(ctx, vrw)
 	if err != nil {
 		return types.EmptyMap, err
 	}
 	indexEditor := NewIndexEditor(ctx, index, emptyIndexMap, sch, opts)
-
 	err = tblRowData.IterAll(ctx, func(key, value types.Value) error {
 		dRow, err := row.FromNoms(sch, key.(types.Tuple), value.(types.Tuple))
 		if err != nil {
 			return err
 		}
 
-		fullKey, partialKey, keyVal, err := dRow.ReduceToIndexKeys(index, nil)
+		fullKey, partialKey, keyVal, err := dRow.ReduceToIndexKeys(index, tf)
 		if err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/table/editor/pk_table_editor.go
+++ b/go/libraries/doltcore/table/editor/pk_table_editor.go
@@ -91,6 +91,13 @@ func NewTableEditor(ctx context.Context, t *doltdb.Table, tableSch schema.Schema
 type Options struct {
 	ForeignKeyChecksDisabled bool // If true, then ALL foreign key checks AND updates (through CASCADE, etc.) are skipped
 	Deaf                     DbEaFactory
+	Tempdir                  string
+}
+
+// WithDeaf returns a new Options with the given  edit accumulator factory class
+func (o Options) WithDeaf(deaf DbEaFactory) Options {
+	o.Deaf = deaf
+	return o
 }
 
 func TestEditorOptions(vrw types.ValueReadWriter) Options {


### PR DESCRIPTION
Two improvements with index rewriting:

1) Brian's `TupleFactory` optimizations were being skipped, and 70% of
the runtime was spent building `newBinaryNomsWriter` instances for tuple
construction. Removing this restores index inserts as the only memory
pressure.

2) Brian's `BulkEditAccumulator` lets the final Map sort skip
work materializing intermediate prolly trees.

On a 2000 row table, fix (1) reduces the runtime by 50% (80ms -> 40ms),
and fix (2) reduces the runtime by another 40% (40ms -> 10ms)%, for a
cumulative ~90% improvement.