### PR TITLE
Adding tests to validate as of support for describe table.

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -123,6 +123,7 @@ func TestSingleScript(t *testing.T) {
 }
 
 func TestVersionedQueries(t *testing.T) {
+	skipNewFormat(t)
 	enginetest.TestVersionedQueries(t, newDoltHarness(t))
 }
 

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -510,6 +510,16 @@ func TestDoltScripts(t *testing.T) {
 	}
 }
 
+func TestDescribeTableAsOf(t *testing.T) {
+	// These tests rely on altering schema, and the new storage format doesn't support that yet,
+	// so we need to skip them. Once the new storage format supports altering schema, we can move
+	// these ScriptTests back into the DoltScripts var so they get picked up by the TestDoltScripts
+	// method above and then remove this method.
+	skipNewFormat(t)
+
+	enginetest.TestScript(t, newDoltHarness(t), DescribeTableAsOfScriptTest)
+}
+
 func TestDoltMerge(t *testing.T) {
 	skipNewFormat(t)
 	harness := newDoltHarness(t)

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -28,6 +28,46 @@ import (
 // this slice into others with good names as it grows.
 var DoltScripts = []enginetest.ScriptTest{
 	{
+		Name: "Describe table as of",
+		SetUpScript: []string{
+			"set @Commit0 = dolt_commit('--allow-empty', '-m', 'before creating table a');",
+			"create table a (pk int primary key, c1 int);",
+			"set @Commit1 = dolt_commit('-am', 'creating table a');",
+			"alter table a add column c2 text;",
+			"set @Commit2 = dolt_commit('-am', 'adding column c2');",
+			"alter table a drop column c1;",
+			"set @Commit3 = dolt_commit('-am', 'dropping column c1');",
+		},
+		Assertions: []enginetest.ScriptTestAssertion{
+			{
+				Query:       "describe a as of @Commit0;",
+				ExpectedErr: sql.ErrTableNotFound,
+			},
+			{
+				Query: "describe a as of @Commit1;",
+				Expected: []sql.Row{
+					{"pk", "int", "NO", "PRI", "", ""},
+					{"c1", "int", "YES", "", "", ""},
+				},
+			},
+			{
+				Query: "describe a as of @Commit2;",
+				Expected: []sql.Row{
+					{"pk", "int", "NO", "PRI", "", ""},
+					{"c1", "int", "YES", "", "", ""},
+					{"c2", "text", "YES", "", "", ""},
+				},
+			},
+			{
+				Query: "describe a as of @Commit3;",
+				Expected: []sql.Row{
+					{"pk", "int", "NO", "PRI", "", ""},
+					{"c2", "text", "YES", "", "", ""},
+				},
+			},
+		},
+	},
+	{
 		Name: "test as of indexed join (https://github.com/dolthub/dolt/issues/2189)",
 		SetUpScript: []string{
 			"create table a (pk int primary key, c1 int)",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -69,46 +69,6 @@ var DescribeTableAsOfScriptTest = enginetest.ScriptTest{
 // this slice into others with good names as it grows.
 var DoltScripts = []enginetest.ScriptTest{
 	{
-		Name: "Describe table as of",
-		SetUpScript: []string{
-			"set @Commit0 = dolt_commit('--allow-empty', '-m', 'before creating table a');",
-			"create table a (pk int primary key, c1 int);",
-			"set @Commit1 = dolt_commit('-am', 'creating table a');",
-			"alter table a add column c2 text;",
-			"set @Commit2 = dolt_commit('-am', 'adding column c2');",
-			"alter table a drop column c1;",
-			"set @Commit3 = dolt_commit('-am', 'dropping column c1');",
-		},
-		Assertions: []enginetest.ScriptTestAssertion{
-			{
-				Query:       "describe a as of @Commit0;",
-				ExpectedErr: sql.ErrTableNotFound,
-			},
-			{
-				Query: "describe a as of @Commit1;",
-				Expected: []sql.Row{
-					{"pk", "int", "NO", "PRI", "", ""},
-					{"c1", "int", "YES", "", "", ""},
-				},
-			},
-			{
-				Query: "describe a as of @Commit2;",
-				Expected: []sql.Row{
-					{"pk", "int", "NO", "PRI", "", ""},
-					{"c1", "int", "YES", "", "", ""},
-					{"c2", "text", "YES", "", "", ""},
-				},
-			},
-			{
-				Query: "describe a as of @Commit3;",
-				Expected: []sql.Row{
-					{"pk", "int", "NO", "PRI", "", ""},
-					{"c2", "text", "YES", "", "", ""},
-				},
-			},
-		},
-	},
-	{
 		Name: "test as of indexed join (https://github.com/dolthub/dolt/issues/2189)",
 		SetUpScript: []string{
 			"create table a (pk int primary key, c1 int)",


### PR DESCRIPTION
Enables Dolt to support `describe table as of <commit>` or `show columns from table as of <commit>`.

Depends on:
* Vitess support: https://github.com/dolthub/vitess/pull/150
* Go-mysql-server support: https://github.com/dolthub/go-mysql-server/pull/923