### PR TITLE
Fixing bad error message for `ErrBranchNotFound`

### DIFF
--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -295,6 +295,10 @@ func (ddb *DoltDB) Resolve(ctx context.Context, cs *CommitSpec, cwb ref.DoltRef)
 			if err != ErrBranchNotFound {
 				return nil, err
 			}
+			// Wrap ErrBranchNotFound to include branch name
+			if err == ErrBranchNotFound {
+				err = errors.New("branch not found: " + candidate)
+			}
 		}
 	case headCommitSpec:
 		if cwb == nil {

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -297,7 +297,7 @@ func (ddb *DoltDB) Resolve(ctx context.Context, cs *CommitSpec, cwb ref.DoltRef)
 			}
 			// Wrap ErrBranchNotFound to include branch name
 			if err == ErrBranchNotFound {
-				err = errors.New("branch not found: " + candidate)
+				err = errors.New(fmt.Sprintf("branch not found: %v", candidate))
 			}
 		}
 	case headCommitSpec:

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -292,12 +292,10 @@ func (ddb *DoltDB) Resolve(ctx context.Context, cs *CommitSpec, cwb ref.DoltRef)
 			if err == nil {
 				break
 			}
-			if err != ErrBranchNotFound {
-				return nil, err
-			}
-			// Wrap ErrBranchNotFound to include branch name
 			if err == ErrBranchNotFound {
-				err = errors.New(fmt.Sprintf("branch not found: %v", candidate))
+				err = ErrBranchNotFoundInfo.New(cs.baseSpec)
+			} else {
+				return nil, err
 			}
 		}
 	case headCommitSpec:

--- a/go/libraries/doltcore/doltdb/errors.go
+++ b/go/libraries/doltcore/doltdb/errors.go
@@ -17,6 +17,7 @@ package doltdb
 import (
 	"errors"
 	"fmt"
+
 	errors2 "gopkg.in/src-d/go-errors.v1"
 )
 

--- a/go/libraries/doltcore/doltdb/errors.go
+++ b/go/libraries/doltcore/doltdb/errors.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"fmt"
 
-	errors2 "gopkg.in/src-d/go-errors.v1"
+	goerrors "gopkg.in/src-d/go-errors.v1"
 )
 
 var ErrInvBranchName = errors.New("not a valid user branch name")
@@ -34,7 +34,7 @@ var ErrFoundHashNotACommit = errors.New("the value retrieved for this hash is no
 
 var ErrHashNotFound = errors.New("could not find a value for this hash")
 var ErrBranchNotFound = errors.New("branch not found")
-var ErrBranchNotFoundInfo = errors2.NewKind("branch not found: %v")
+var ErrBranchNotFoundInfo = goerrors.NewKind("branch not found: %v")
 var ErrTagNotFound = errors.New("tag not found")
 var ErrWorkingSetNotFound = errors.New("working set not found")
 var ErrWorkspaceNotFound = errors.New("workspace not found")

--- a/go/libraries/doltcore/doltdb/errors.go
+++ b/go/libraries/doltcore/doltdb/errors.go
@@ -17,6 +17,7 @@ package doltdb
 import (
 	"errors"
 	"fmt"
+	errors2 "gopkg.in/src-d/go-errors.v1"
 )
 
 var ErrInvBranchName = errors.New("not a valid user branch name")
@@ -32,6 +33,7 @@ var ErrFoundHashNotACommit = errors.New("the value retrieved for this hash is no
 
 var ErrHashNotFound = errors.New("could not find a value for this hash")
 var ErrBranchNotFound = errors.New("branch not found")
+var ErrBranchNotFoundInfo = errors2.NewKind("branch not found: %v")
 var ErrTagNotFound = errors.New("tag not found")
 var ErrWorkingSetNotFound = errors.New("working set not found")
 var ErrWorkspaceNotFound = errors.New("workspace not found")

--- a/go/libraries/doltcore/env/actions/branch.go
+++ b/go/libraries/doltcore/env/actions/branch.go
@@ -475,6 +475,10 @@ func MaybeGetCommit(ctx context.Context, dEnv *env.DoltEnv, str string) (*doltdb
 	if err == nil {
 		cm, err := dEnv.DoltDB.Resolve(ctx, cs, dEnv.RepoStateReader().CWBHeadRef())
 
+		if doltdb.ErrBranchNotFoundInfo.Is(err) {
+			return nil, nil
+		}
+
 		switch err {
 		case nil:
 			return cm, nil

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -1409,7 +1409,7 @@ var DiffTableFunctionScriptTests = []enginetest.ScriptTest{
 			},
 			{
 				Query:          "SELECT * from dolt_diff('t', @Commit1, 'fake-branch');",
-				ExpectedErrStr: "branch not found: fake-branch",
+				ExpectedErrStr: "branch not found: refs/remotes/fake-branch",
 			},
 			{
 				Query:       "SELECT * from dolt_diff('t', @Commit1, concat('fake', '-', 'branch'));",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -1409,7 +1409,7 @@ var DiffTableFunctionScriptTests = []enginetest.ScriptTest{
 			},
 			{
 				Query:          "SELECT * from dolt_diff('t', @Commit1, 'fake-branch');",
-				ExpectedErrStr: "branch not found: refs/remotes/fake-branch",
+				ExpectedErrStr: "branch not found: fake-branch",
 			},
 			{
 				Query:       "SELECT * from dolt_diff('t', @Commit1, concat('fake', '-', 'branch'));",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -1409,7 +1409,7 @@ var DiffTableFunctionScriptTests = []enginetest.ScriptTest{
 			},
 			{
 				Query:          "SELECT * from dolt_diff('t', @Commit1, 'fake-branch');",
-				ExpectedErrStr: "branch not found",
+				ExpectedErrStr: "branch not found: fake-branch",
 			},
 			{
 				Query:       "SELECT * from dolt_diff('t', @Commit1, concat('fake', '-', 'branch'));",


### PR DESCRIPTION
Fix error message for ErrBranchNotFound to include the branch that wasn't found.

helps for: https://github.com/dolthub/dolt/issues/3270