### PR TITLE
go/cmd/dolt: Add create new branch suggestion to dolt checkout {commit_hash}

### DIFF
--- a/integration-tests/bats/checkout.bats
+++ b/integration-tests/bats/checkout.bats
@@ -171,7 +171,7 @@ SQL
   sha=$(dolt log --oneline --decorate=no | head -n 1 | cut -d ' ' -f 1)
 
   # remove special characters (color)
-  sha=$(echo $sha | sed -r "s/[[:cntrl:]]\[[0-9]{1,3}m//g")
+  sha=$(echo $sha | sed -E "s/[[:cntrl:]]\[[0-9]{1,3}m//g")
 
   run dolt checkout "$sha"
   [ "$status" -ne 0 ]

--- a/integration-tests/bats/checkout.bats
+++ b/integration-tests/bats/checkout.bats
@@ -163,3 +163,18 @@ SQL
     [[ "$output" =~ "8" ]] || false
     [[ ! "$output" =~ "4" ]] || false
 }
+
+@test "checkout: attempting to checkout a detached head shows a suggestion instead" {
+  dolt sql -q "create table test (id int primary key);"
+  dolt add .
+  dolt commit -m "create test table."
+  sha=$(dolt log --oneline --decorate=no | head -n 1 | cut -d ' ' -f 1)
+
+  # remove special characters (color)
+  sha=$(echo $sha | sed -r "s/[[:cntrl:]]\[[0-9]{1,3}m//g")
+
+  run dolt checkout "$sha"
+  [ "$status" -ne 0 ]
+  cmd=$(echo "${lines[1]}" | cut -d ' ' -f 1,2,3)
+  [[ $cmd =~ "dolt checkout $sha" ]]
+}


### PR DESCRIPTION
Closes #3276 

Instead of showing the following when trying to checkout a specific commit:
```
dolt checkout 400435pip70vh165ggsq4etmggdh6h5i
error: could not find 400435pip70vh165ggsq4etmggdh6h5
```
We instead show:
```
dolt checkout 400435pip70vh165ggsq4etmggdh6h5i
dolt does not support a detached head state. To create a branch at this commit instead, run:

	dolt checkout 400435pip70vh165ggsq4etmggdh6h5i -b {new_branch_name}

```