### PR TITLE
[no-release-notes] go/store/nbs/table_reader.go: Fix a bug in findOffsets where we returning remaining == false sometimes.

### DIFF
--- a/go/store/nbs/table_reader.go
+++ b/go/store/nbs/table_reader.go
@@ -522,6 +522,10 @@ func (tr tableReader) findOffsets(reqs []getRecord) (ors offsetRecSlice, remaini
 				break
 			}
 		}
+
+		if !reqs[i].found {
+			remaining = true
+		}
 	}
 
 	sort.Sort(ors)


### PR DESCRIPTION
In the case where we find a matching prefix but no matching suffixes, we were
failing to appropriately set remaining = true.