### PR TITLE
Revert table_reader changes

### DIFF
--- a/go/store/nbs/table_reader.go
+++ b/go/store/nbs/table_reader.go
@@ -132,6 +132,7 @@ type tableReaderAt interface {
 // more chunks together into a single read request to backing storage.
 type tableReader struct {
 	tableIndex
+	prefixes              []uint64
 	chunkCount            uint32
 	totalUncompressedData uint64
 	r                     tableReaderAt
@@ -142,17 +143,18 @@ type tableReader struct {
 // and footer, though it may contain an unspecified number of bytes before that data. r should allow
 // retrieving any desired range of bytes from the table.
 func newTableReader(index tableIndex, r tableReaderAt, blockSize uint64) (tableReader, error) {
+	p, err := index.Prefixes()
+	if err != nil {
+		return tableReader{}, err
+	}
 	return tableReader{
 		index,
+		p,
 		index.ChunkCount(),
 		index.TotalUncompressedData(),
 		r,
 		blockSize,
 	}, nil
-}
-
-func (tr tableReader) prefixAt(idx uint32) uint64 {
-	return tr.tableIndex.PrefixAt(idx)
 }
 
 // Scan across (logically) two ordered slices of address prefixes.
@@ -168,7 +170,7 @@ func (tr tableReader) hasMany(addrs []hasRecord) (bool, error) {
 			continue
 		}
 
-		for filterIdx < filterLen && addr.prefix > tr.prefixAt(filterIdx) {
+		for filterIdx < filterLen && addr.prefix > tr.prefixes[filterIdx] {
 			filterIdx++
 		}
 
@@ -176,13 +178,13 @@ func (tr tableReader) hasMany(addrs []hasRecord) (bool, error) {
 			return true, nil
 		}
 
-		if addr.prefix != tr.prefixAt(filterIdx) {
+		if addr.prefix != tr.prefixes[filterIdx] {
 			remaining = true
 			continue
 		}
 
 		// prefixes are equal, so locate and compare against the corresponding suffix
-		for j := filterIdx; j < filterLen && addr.prefix == tr.prefixAt(j); j++ {
+		for j := filterIdx; j < filterLen && addr.prefix == tr.prefixes[j]; j++ {
 			m, err := tr.EntrySuffixMatches(j, addr.a)
 			if err != nil {
 				return false, err
@@ -481,7 +483,7 @@ func (tr tableReader) getManyAtOffsetsWithReadFunc(
 // order.
 func (tr tableReader) findOffsets(reqs []getRecord) (ors offsetRecSlice, remaining bool, err error) {
 	filterIdx := uint32(0)
-	filterLen := tr.chunkCount
+	filterLen := uint32(len(tr.prefixes))
 	ors = make(offsetRecSlice, 0, len(reqs))
 
 	// Iterate over |reqs| and |tr.prefixes| (both sorted by address) and build the set
@@ -492,7 +494,7 @@ func (tr tableReader) findOffsets(reqs []getRecord) (ors offsetRecSlice, remaini
 		}
 
 		// advance within the prefixes until we reach one which is >= req.prefix
-		for filterIdx < filterLen && tr.prefixAt(filterIdx) < req.prefix {
+		for filterIdx < filterLen && tr.prefixes[filterIdx] < req.prefix {
 			filterIdx++
 		}
 
@@ -501,13 +503,13 @@ func (tr tableReader) findOffsets(reqs []getRecord) (ors offsetRecSlice, remaini
 			break
 		}
 
-		if req.prefix != tr.prefixAt(filterIdx) {
+		if req.prefix != tr.prefixes[filterIdx] {
 			remaining = true
 			continue
 		}
 
 		// record all offsets within the table which contain the data required.
-		for j := filterIdx; j < filterLen && req.prefix == tr.prefixAt(j); j++ {
+		for j := filterIdx; j < filterLen && req.prefix == tr.prefixes[j]; j++ {
 			m, err := tr.EntrySuffixMatches(j, req.a)
 			if err != nil {
 				return nil, false, err
@@ -658,7 +660,7 @@ func (tr tableReader) Clone() (tableReader, error) {
 	if err != nil {
 		return tableReader{}, err
 	}
-	return tableReader{ti, tr.chunkCount, tr.totalUncompressedData, tr.r, tr.blockSize}, nil
+	return tableReader{ti, tr.prefixes, tr.chunkCount, tr.totalUncompressedData, tr.r, tr.blockSize}, nil
 }
 
 type readerAdapter struct {


### PR DESCRIPTION
This revert the changes made to table_reader.go in commit d3166e88710f9968c98a0613af5f9ab4a43d7d8e

This was done to chase a performance regression to `oltp_delete` that occurred in Dolt v0.39.1