### PR TITLE
Display schema and data for created and dropped tables in `dolt diff` command 

### DIFF
--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -464,6 +464,9 @@ func printShowCreateTableDiff(ctx context.Context, td diff.TableDelta) errhand.V
 		sqlDb := sqle.NewSingleTableDatabase(td.FromName, fromSch, td.FromFks, td.FromFksParentSch)
 		sqlCtx, engine, _ := sqle.PrepareCreateTableStmt(ctx, sqlDb)
 		fromCreateStmt, err = sqle.GetCreateTableStmt(sqlCtx, engine, td.FromName)
+		if err != nil {
+			return errhand.VerboseErrorFromError(err)
+		}
 	}
 
 	var toCreateStmt = ""
@@ -471,6 +474,9 @@ func printShowCreateTableDiff(ctx context.Context, td diff.TableDelta) errhand.V
 		sqlDb := sqle.NewSingleTableDatabase(td.ToName, toSch, td.ToFks, td.ToFksParentSch)
 		sqlCtx, engine, _ := sqle.PrepareCreateTableStmt(ctx, sqlDb)
 		toCreateStmt, err = sqle.GetCreateTableStmt(sqlCtx, engine, td.ToName)
+		if err != nil {
+			return errhand.VerboseErrorFromError(err)
+		}
 	}
 
 	if fromCreateStmt != toCreateStmt {

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -403,12 +403,6 @@ func diffUserTables(ctx context.Context, fromRoot, toRoot *doltdb.RootValue, dAr
 
 		if dArgs.diffOutput == TabularDiffOutput {
 			printTableDiffSummary(td)
-
-			// if we're in standard output mode, follow Git convention
-			// and don't print data diffs for added/dropped tables
-			if td.IsDrop() || td.IsAdd() {
-				continue
-			}
 		}
 
 		if tblName == doltdb.DocTableName {
@@ -453,10 +447,6 @@ func diffSchemas(ctx context.Context, toRoot *doltdb.RootValue, td diff.TableDel
 	}
 
 	if dArgs.diffOutput == TabularDiffOutput {
-		if td.IsDrop() || td.IsAdd() {
-			panic("cannot perform tabular schema diff for added/dropped tables")
-		}
-
 		return printShowCreateTableDiff(ctx, td)
 	}
 
@@ -469,13 +459,19 @@ func printShowCreateTableDiff(ctx context.Context, td diff.TableDelta) errhand.V
 		return errhand.BuildDError("cannot retrieve schema for table %s", td.ToName).AddCause(err).Build()
 	}
 
-	sqlDb := sqle.NewSingleTableDatabase(td.ToName, fromSch, td.FromFks, td.FromFksParentSch)
-	sqlCtx, engine, _ := sqle.PrepareCreateTableStmt(ctx, sqlDb)
-	fromCreateStmt, err := sqle.GetCreateTableStmt(sqlCtx, engine, td.ToName)
+	var fromCreateStmt = ""
+	if td.FromTable != nil {
+		sqlDb := sqle.NewSingleTableDatabase(td.FromName, fromSch, td.FromFks, td.FromFksParentSch)
+		sqlCtx, engine, _ := sqle.PrepareCreateTableStmt(ctx, sqlDb)
+		fromCreateStmt, err = sqle.GetCreateTableStmt(sqlCtx, engine, td.FromName)
+	}
 
-	sqlDb = sqle.NewSingleTableDatabase(td.ToName, toSch, td.ToFks, td.ToFksParentSch)
-	sqlCtx, engine, _ = sqle.PrepareCreateTableStmt(ctx, sqlDb)
-	toCreateStmt, err := sqle.GetCreateTableStmt(sqlCtx, engine, td.ToName)
+	var toCreateStmt = ""
+	if td.ToTable != nil {
+		sqlDb := sqle.NewSingleTableDatabase(td.ToName, toSch, td.ToFks, td.ToFksParentSch)
+		sqlCtx, engine, _ := sqle.PrepareCreateTableStmt(ctx, sqlDb)
+		toCreateStmt, err = sqle.GetCreateTableStmt(sqlCtx, engine, td.ToName)
+	}
 
 	if fromCreateStmt != toCreateStmt {
 		cli.Println(textdiff.LineDiff(fromCreateStmt, toCreateStmt))
@@ -605,8 +601,11 @@ func diffRows(ctx context.Context, td diff.TableDelta, dArgs *diffArgs, vrw type
 	if err != nil {
 		return errhand.BuildDError("cannot retrieve schema for table %s", td.ToName).AddCause(err).Build()
 	}
+
 	if td.IsAdd() {
 		fromSch = toSch
+	} else if td.IsDrop() {
+		toSch = fromSch
 	}
 
 	fromRows, toRows, err := td.GetMaps(ctx)
@@ -809,7 +808,6 @@ func createSplitter(ctx context.Context, vrw types.ValueReadWriter, fromSch sche
 		if err != nil {
 			return nil, nil, errhand.BuildDError("Merge failed. Tables with different primary keys cannot be merged.").AddCause(err).Build()
 		}
-
 	} else {
 		unionSch = toSch
 	}

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -569,7 +569,7 @@ func (t *DoltTable) GetChecks(ctx *sql.Context) ([]sql.CheckDefinition, error) {
 
 func checksInSchema(sch schema.Schema) []sql.CheckDefinition {
 	if sch.Checks() == nil {
-		return []sql.CheckDefinition{}
+		return nil
 	}
 
 	checks := make([]sql.CheckDefinition, sch.Checks().Count())

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -568,6 +568,10 @@ func (t *DoltTable) GetChecks(ctx *sql.Context) ([]sql.CheckDefinition, error) {
 }
 
 func checksInSchema(sch schema.Schema) []sql.CheckDefinition {
+	if sch.Checks() == nil {
+		return []sql.CheckDefinition{}
+	}
+
 	checks := make([]sql.CheckDefinition, sch.Checks().Count())
 	for i, check := range sch.Checks().AllChecks() {
 		checks[i] = sql.CheckDefinition{

--- a/integration-tests/bats/diff.bats
+++ b/integration-tests/bats/diff.bats
@@ -627,6 +627,29 @@ SQL
     [ "${lines[0]}" = 'ALTER TABLE `t` RENAME COLUMN `pk` TO `pk`;' ]
 }
 
+@test "diff: created and dropped tables include schema and data changes in results" {
+  dolt sql -q "create table a(pk int primary key)"
+  dolt commit -am "creating table a"
+  dolt sql -q "insert into a values (1), (2)"
+  dolt commit -am "inserting data into table a"
+  dolt sql -q "drop table a"
+  dolt commit -am "dropping table a"
+
+  run dolt diff HEAD~3 HEAD~2
+  [[ $output =~ 'added table' ]] || false
+  [[ $output =~ '+CREATE TABLE `a` (' ]] || false
+
+  run dolt diff HEAD~3 HEAD~1
+  [[ $output =~ 'added table' ]] || false
+  [[ $output =~ '+CREATE TABLE `a` (' ]] || false
+  [[ $output =~ "+  | 1 " ]] || false
+
+  run dolt diff HEAD~1 HEAD
+  [[ $output =~ 'deleted table' ]] || false
+  [[ $output =~ '-CREATE TABLE `a` (' ]] || false
+  [[ $output =~ "-  | 1 " ]] || false
+}
+
 @test "diff: large diff does not drop rows" {
     dolt sql -q "create table t(pk int primary key, val int)"
 


### PR DESCRIPTION
Fixes: https://github.com/dolthub/dolt/issues/3300

The `dolt diff` command was previously omitting schema and data diffs if tables were created or dropped within the commit range, and only outputting diff summary information with tabular output. This change causes the schema changes and data changes to be included in tabular output. 

Old behavior: 
```
❯ dolt diff mhgva1kfcljign82ntcmr6ftmpbmemko j6n5727at9652tri8ncsa02v794h1fi4
diff --dolt a/a b/a
added table

❯ dolt diff mhgva1kfcljign82ntcmr6ftmpbmemko ccm9bfiv6jhft1tmeu1cqd0ghduhg4v7
diff --dolt a/a b/a
added table

❯ dolt diff qd507o2jjlckjgmn2polsmiifk62vo8n js1bb2cvdr7h4tdj2d3m33jhp9rc9ee9
diff --dolt a/a b/a
deleted table
```

New behavior:
```
❯ dolt diff mhgva1kfcljign82ntcmr6ftmpbmemko j6n5727at9652tri8ncsa02v794h1fi4
diff --dolt a/a b/a
added table
+CREATE TABLE `a` (
+  `n` int NOT NULL,
+  PRIMARY KEY (`n`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+-----+---+
|     | n |
+-----+---+
+-----+---+

❯ dolt diff mhgva1kfcljign82ntcmr6ftmpbmemko ccm9bfiv6jhft1tmeu1cqd0ghduhg4v7
diff --dolt a/a b/a
added table
+CREATE TABLE `a` (
+  `n` int NOT NULL,
+  PRIMARY KEY (`n`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+-----+---+
|     | n |
+-----+---+
|  +  | 1 |
|  +  | 2 |
+-----+---+

❯ dolt diff qd507o2jjlckjgmn2polsmiifk62vo8n js1bb2cvdr7h4tdj2d3m33jhp9rc9ee9
diff --dolt a/a b/a
deleted table
-CREATE TABLE `a` (
-  `n` int NOT NULL,
-  PRIMARY KEY (`n`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+-----+---+
|     | n |
+-----+---+
|  -  | 1 |
|  -  | 2 |
|  -  | 3 |
+-----+---+
```