### PR TITLE
[no-release-notes] Replace `tree.NodeBuilder` with `message.Serializer`

### DIFF
--- a/go/store/prolly/conflicts_map.go
+++ b/go/store/prolly/conflicts_map.go
@@ -17,6 +17,8 @@ package prolly
 import (
 	"context"
 
+	"github.com/dolthub/dolt/go/store/prolly/message"
+
 	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/prolly/tree"
 	"github.com/dolthub/dolt/go/store/types"
@@ -135,10 +137,10 @@ func (wr ConflictEditor) Delete(ctx context.Context, key val.Tuple) error {
 }
 
 func (wr ConflictEditor) Flush(ctx context.Context) (ConflictMap, error) {
-	factory := newMapBuilder
 	tr := wr.conflicts.tree
+	serializer := message.ProllyMapSerializer{Pool: tr.ns.Pool()}
 
-	root, err := tree.ApplyMutations(ctx, tr.ns, tr.root, factory, wr.conflicts.mutations(), tr.compareItems)
+	root, err := tree.ApplyMutations(ctx, tr.ns, tr.root, serializer, wr.conflicts.mutations(), tr.compareItems)
 	if err != nil {
 		return ConflictMap{}, err
 	}

--- a/go/store/prolly/map.go
+++ b/go/store/prolly/map.go
@@ -53,7 +53,8 @@ func NewMap(node tree.Node, ns tree.NodeStore, keyDesc, valDesc val.TupleDesc) M
 
 // NewMapFromTuples creates a prolly tree Map from slice of sorted Tuples.
 func NewMapFromTuples(ctx context.Context, ns tree.NodeStore, keyDesc, valDesc val.TupleDesc, tups ...val.Tuple) (Map, error) {
-	ch, err := tree.NewEmptyChunker(ctx, ns, newMapBuilder)
+	serializer := message.ProllyMapSerializer{Pool: ns.Pool()}
+	ch, err := tree.NewEmptyChunker(ctx, ns, serializer)
 	if err != nil {
 		return Map{}, err
 	}
@@ -81,7 +82,8 @@ func DiffMaps(ctx context.Context, from, to Map, cb DiffFn) error {
 }
 
 func MergeMaps(ctx context.Context, left, right, base Map, cb tree.CollisionFn) (Map, error) {
-	tuples, err := mergeOrderedTrees(ctx, left.tuples, right.tuples, base.tuples, cb)
+	serializer := message.ProllyMapSerializer{Pool: left.tuples.ns.Pool()}
+	tuples, err := mergeOrderedTrees(ctx, left.tuples, right.tuples, base.tuples, cb, serializer)
 	if err != nil {
 		return Map{}, err
 	}
@@ -245,56 +247,8 @@ func (p *pointLookup) Next(context.Context) (key, value val.Tuple, err error) {
 }
 
 func newEmptyMapNode(pool pool.BuffPool) tree.Node {
-	bld := &mapBuilder{}
-	return bld.Build(pool)
-}
-
-func newMapBuilder(level int) *mapBuilder {
-	return &mapBuilder{level: level}
-}
-
-var _ tree.NodeBuilderFactory[*mapBuilder] = newMapBuilder
-
-type mapBuilder struct {
-	keys, values [][]byte
-	size, level  int
-
-	subtrees tree.SubtreeCounts
-}
-
-var _ tree.NodeBuilder = &mapBuilder{}
-
-func (nb *mapBuilder) StartNode() {
-	nb.reset()
-}
-
-func (nb *mapBuilder) HasCapacity(key, value tree.Item) bool {
-	sum := nb.size + len(key) + len(value)
-	return sum <= int(message.MaxVectorOffset)
-}
-
-func (nb *mapBuilder) AddItems(key, value tree.Item, subtree uint64) {
-	nb.keys = append(nb.keys, key)
-	nb.values = append(nb.values, value)
-	nb.size += len(key) + len(value)
-	nb.subtrees = append(nb.subtrees, subtree)
-}
-
-func (nb *mapBuilder) Count() int {
-	return len(nb.keys)
-}
-
-func (nb *mapBuilder) reset() {
-	// buffers are copied, it's safe to re-use the memory.
-	nb.keys = nb.keys[:0]
-	nb.values = nb.values[:0]
-	nb.size = 0
-	nb.subtrees = nb.subtrees[:0]
-}
-
-func (nb *mapBuilder) Build(pool pool.BuffPool) (node tree.Node) {
-	msg := message.SerializeProllyMap(pool, nb.keys, nb.values, nb.level, nb.subtrees)
-	nb.reset()
+	serializer := message.ProllyMapSerializer{Pool: pool}
+	msg := serializer.Serialize(nil, nil, nil, 0)
 	return tree.NodeFromBytes(msg)
 }
 

--- a/go/store/prolly/map_test.go
+++ b/go/store/prolly/map_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/pool"
+	"github.com/dolthub/dolt/go/store/prolly/message"
 	"github.com/dolthub/dolt/go/store/prolly/tree"
 	"github.com/dolthub/dolt/go/store/val"
 )
@@ -131,7 +132,8 @@ func prollyMapFromTuples(t *testing.T, kd, vd val.TupleDesc, tuples [][2]val.Tup
 	ctx := context.Background()
 	ns := tree.NewTestNodeStore()
 
-	chunker, err := tree.NewEmptyChunker(ctx, ns, newMapBuilder)
+	serializer := message.ProllyMapSerializer{Pool: ns.Pool()}
+	chunker, err := tree.NewEmptyChunker(ctx, ns, serializer)
 	require.NoError(t, err)
 
 	for _, pair := range tuples {

--- a/go/store/prolly/message/address_map.go
+++ b/go/store/prolly/message/address_map.go
@@ -34,14 +34,20 @@ const (
 
 var addressMapFileID = []byte(serial.AddressMapFileID)
 
-func SerializeAddressMap(pool pool.BuffPool, keys, addrs [][]byte, level int, subtrees []uint64) Message {
+type AddressMapSerializer struct {
+	Pool pool.BuffPool
+}
+
+var _ Serializer = AddressMapSerializer{}
+
+func (s AddressMapSerializer) Serialize(keys, addrs [][]byte, subtrees []uint64, level int) Message {
 	var (
 		keyArr, keyOffs  fb.UOffsetT
 		addrArr, cardArr fb.UOffsetT
 	)
 
 	keySz, addrSz, totalSz := estimateAddressMapSize(keys, addrs, subtrees)
-	b := getFlatbufferBuilder(pool, totalSz)
+	b := getFlatbufferBuilder(s.Pool, totalSz)
 
 	// keys
 	keyArr = writeItemBytes(b, keys, keySz)

--- a/go/store/prolly/message/message.go
+++ b/go/store/prolly/message/message.go
@@ -25,6 +25,10 @@ import (
 
 type Message []byte
 
+type Serializer interface {
+	Serialize(keys, values [][]byte, subtrees []uint64, level int) Message
+}
+
 func GetKeys(msg Message) val.SlicedBuffer {
 	id := serial.GetFileID(msg)
 	switch id {

--- a/go/store/prolly/message/prolly_map.go
+++ b/go/store/prolly/message/prolly_map.go
@@ -37,7 +37,13 @@ const (
 
 var prollyMapFileID = []byte(serial.ProllyTreeNodeFileID)
 
-func SerializeProllyMap(pool pool.BuffPool, keys, values [][]byte, level int, subtrees []uint64) Message {
+type ProllyMapSerializer struct {
+	Pool pool.BuffPool
+}
+
+var _ Serializer = ProllyMapSerializer{}
+
+func (s ProllyMapSerializer) Serialize(keys, values [][]byte, subtrees []uint64, level int) Message {
 	var (
 		keyTups, keyOffs fb.UOffsetT
 		valTups, valOffs fb.UOffsetT
@@ -45,7 +51,7 @@ func SerializeProllyMap(pool pool.BuffPool, keys, values [][]byte, level int, su
 	)
 
 	keySz, valSz, bufSz := estimateProllyMapSize(keys, values, subtrees)
-	b := getFlatbufferBuilder(pool, bufSz)
+	b := getFlatbufferBuilder(s.Pool, bufSz)
 
 	// serialize keys and offsets
 	keyTups = writeItemBytes(b, keys, keySz)

--- a/go/store/prolly/message/prolly_map_test.go
+++ b/go/store/prolly/message/prolly_map_test.go
@@ -29,7 +29,8 @@ func TestGetKeyValueOffsetsVectors(t *testing.T) {
 	for trial := 0; trial < 100; trial++ {
 		keys, values := randomByteSlices(t, (testRand.Int()%101)+50)
 		require.True(t, sumSize(keys)+sumSize(values) < MaxVectorOffset)
-		msg := SerializeProllyMap(sharedPool, keys, values, 0, nil)
+		s := ProllyMapSerializer{Pool: sharedPool}
+		msg := s.Serialize(keys, values, nil, 0)
 
 		// uses getProllyMapKeyOffsetsVector with hard-coded vtable slot
 		keyBuf := getProllyMapKeys(msg)

--- a/go/store/prolly/mutable_map.go
+++ b/go/store/prolly/mutable_map.go
@@ -17,8 +17,8 @@ package prolly
 import (
 	"context"
 
+	"github.com/dolthub/dolt/go/store/prolly/message"
 	"github.com/dolthub/dolt/go/store/prolly/tree"
-
 	"github.com/dolthub/dolt/go/store/val"
 )
 
@@ -42,10 +42,10 @@ func newMutableMap(m Map) MutableMap {
 
 // Map materializes the pending mutations in the MutableMap.
 func (mut MutableMap) Map(ctx context.Context) (Map, error) {
-	factory := newMapBuilder
 	tr := mut.tuples.tree
+	serializer := message.ProllyMapSerializer{Pool: tr.ns.Pool()}
 
-	root, err := tree.ApplyMutations(ctx, tr.ns, tr.root, factory, mut.tuples.mutations(), tr.compareItems)
+	root, err := tree.ApplyMutations(ctx, tr.ns, tr.root, serializer, mut.tuples.mutations(), tr.compareItems)
 	if err != nil {
 		return Map{}, err
 	}

--- a/go/store/prolly/mutable_map_read_test.go
+++ b/go/store/prolly/mutable_map_read_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dolthub/dolt/go/store/prolly/message"
 	"github.com/dolthub/dolt/go/store/prolly/tree"
 	"github.com/dolthub/dolt/go/store/val"
 )
@@ -128,7 +129,8 @@ func makeMutableMap(t *testing.T, count int) (testMap, [][2]val.Tuple) {
 	tree.SortTuplePairs(mapTuples, kd)
 	tree.SortTuplePairs(memTuples, kd)
 
-	chunker, err := tree.NewEmptyChunker(ctx, ns, newMapBuilder)
+	serializer := message.ProllyMapSerializer{Pool: ns.Pool()}
+	chunker, err := tree.NewEmptyChunker(ctx, ns, serializer)
 	require.NoError(t, err)
 	for _, pair := range mapTuples {
 		err = chunker.AddPair(ctx, tree.Item(pair[0]), tree.Item(pair[1]))

--- a/go/store/prolly/mutable_map_write_test.go
+++ b/go/store/prolly/mutable_map_write_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dolthub/dolt/go/store/prolly/message"
 	"github.com/dolthub/dolt/go/store/prolly/tree"
 	"github.com/dolthub/dolt/go/store/val"
 )
@@ -438,7 +439,8 @@ func ascendingIntMapWithStep(t *testing.T, count, step int) Map {
 		tuples[i][0], tuples[i][1] = makePut(v, v)
 	}
 
-	chunker, err := tree.NewEmptyChunker(ctx, ns, newMapBuilder)
+	serializer := message.ProllyMapSerializer{Pool: ns.Pool()}
+	chunker, err := tree.NewEmptyChunker(ctx, ns, serializer)
 	require.NoError(t, err)
 
 	for _, pair := range tuples {

--- a/go/store/prolly/ordered_tree.go
+++ b/go/store/prolly/ordered_tree.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/dolthub/dolt/go/store/prolly/message"
+
 	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/prolly/tree"
 	"github.com/dolthub/dolt/go/store/skip"
@@ -64,13 +66,14 @@ func diffOrderedTrees[K, V ~[]byte, O ordering[K]](
 	return err
 }
 
-func mergeOrderedTrees[K, V ~[]byte, O ordering[K]](
+func mergeOrderedTrees[K, V ~[]byte, O ordering[K], S message.Serializer](
 	ctx context.Context,
 	l, r, base orderedTree[K, V, O],
 	cb tree.CollisionFn,
+	serializer S,
 ) (orderedTree[K, V, O], error) {
-	cfn, fact := base.compareItems, newMapBuilder
-	root, err := tree.ThreeWayMerge(ctx, base.ns, l.root, r.root, base.root, cfn, cb, fact)
+	cfn := base.compareItems
+	root, err := tree.ThreeWayMerge(ctx, base.ns, l.root, r.root, base.root, cfn, cb, serializer)
 	if err != nil {
 		return orderedTree[K, V, O]{}, err
 	}

--- a/go/store/prolly/tree/content_address_test.go
+++ b/go/store/prolly/tree/content_address_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/dolthub/dolt/go/store/prolly/message"
 	"github.com/dolthub/dolt/go/store/val"
 )
 
@@ -45,7 +46,9 @@ func makeTree(t *testing.T, tuples [][2]val.Tuple) Node {
 	ctx := context.Background()
 	ns := NewTestNodeStore()
 
-	chunker, err := newEmptyChunker(ctx, ns, newTestBuilder)
+	// todo(andy): move this test
+	serializer := message.ProllyMapSerializer{Pool: ns.Pool()}
+	chunker, err := newEmptyChunker(ctx, ns, serializer)
 	require.NoError(t, err)
 	for _, pair := range tuples {
 		err := chunker.AddPair(ctx, Item(pair[0]), Item(pair[1]))

--- a/go/store/prolly/tree/merge.go
+++ b/go/store/prolly/tree/merge.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"io"
 
+	"github.com/dolthub/dolt/go/store/prolly/message"
+
 	"golang.org/x/sync/errgroup"
 )
 
@@ -35,13 +37,13 @@ type CollisionFn func(left, right Diff) (Diff, bool)
 // |right| are applied directly to |left|. This reduces the amount of write work and improves performance.
 // In the case that a key-value pair was modified on both |left| and |right| with different resulting
 // values, the CollisionFn is called to perform a cell-wise merge, or to throw a conflict.
-func ThreeWayMerge[B NodeBuilder](
+func ThreeWayMerge[S message.Serializer](
 	ctx context.Context,
 	ns NodeStore,
 	left, right, base Node,
 	compare CompareFn,
 	collide CollisionFn,
-	factory NodeBuilderFactory[B],
+	serializer S,
 ) (final Node, err error) {
 
 	ld, err := DifferFromRoots(ctx, ns, base, left, compare)
@@ -70,7 +72,7 @@ func ThreeWayMerge[B NodeBuilder](
 
 	// consume |patches| and apply them to |left|
 	eg.Go(func() error {
-		final, err = ApplyMutations(ctx, ns, left, factory, patches, compare)
+		final, err = ApplyMutations(ctx, ns, left, serializer, patches, compare)
 		return err
 	})
 

--- a/go/store/prolly/tree/merge.go
+++ b/go/store/prolly/tree/merge.go
@@ -19,9 +19,9 @@ import (
 	"context"
 	"io"
 
-	"github.com/dolthub/dolt/go/store/prolly/message"
-
 	"golang.org/x/sync/errgroup"
+
+	"github.com/dolthub/dolt/go/store/prolly/message"
 )
 
 const patchBufferSize = 1024

--- a/go/store/prolly/tree/mutator.go
+++ b/go/store/prolly/tree/mutator.go
@@ -17,6 +17,8 @@ package tree
 import (
 	"bytes"
 	"context"
+
+	"github.com/dolthub/dolt/go/store/prolly/message"
 )
 
 type MutationIter interface {
@@ -24,11 +26,11 @@ type MutationIter interface {
 	Close() error
 }
 
-func ApplyMutations[B NodeBuilder](
+func ApplyMutations[S message.Serializer](
 	ctx context.Context,
 	ns NodeStore,
 	root Node,
-	factory NodeBuilderFactory[B],
+	serializer S,
 	edits MutationIter,
 	compare CompareFn,
 ) (Node, error) {
@@ -42,7 +44,7 @@ func ApplyMutations[B NodeBuilder](
 		return Node{}, err
 	}
 
-	chkr, err := newChunker(ctx, cur.Clone(), 0, ns, factory)
+	chkr, err := newChunker(ctx, cur.Clone(), 0, ns, serializer)
 	if err != nil {
 		return Node{}, err
 	}

--- a/go/store/prolly/tree/node_cursor.go
+++ b/go/store/prolly/tree/node_cursor.go
@@ -38,6 +38,15 @@ type Cursor struct {
 	nrw      NodeStore
 }
 
+type SubtreeCounts []uint64
+
+func (sc SubtreeCounts) Sum() (s uint64) {
+	for _, count := range sc {
+		s += count
+	}
+	return
+}
+
 type CompareFn func(left, right Item) int
 
 type SearchFn func(nd Node) (idx int)

--- a/go/store/prolly/tree/node_cursor_test.go
+++ b/go/store/prolly/tree/node_cursor_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dolthub/dolt/go/store/prolly/message"
 	"github.com/dolthub/dolt/go/store/val"
 )
 
@@ -53,7 +54,8 @@ func testNewCursorAtItem(t *testing.T, count int) {
 func randomTree(t *testing.T, count int) (Node, [][2]Item, NodeStore) {
 	ctx := context.Background()
 	ns := NewTestNodeStore()
-	chkr, err := newEmptyChunker(ctx, ns, newTestBuilder)
+	serializer := message.ProllyMapSerializer{Pool: ns.Pool()}
+	chkr, err := newEmptyChunker(ctx, ns, serializer)
 	require.NoError(t, err)
 
 	items := randomTupleItemPairs(count / 2)

--- a/go/store/prolly/tree/node_splitter_test.go
+++ b/go/store/prolly/tree/node_splitter_test.go
@@ -23,8 +23,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/store/prolly/message"
 )
 
 func init() {
@@ -100,7 +101,8 @@ func makeProllyTreeWithSizes(t *testing.T, fact splitterFactory, scale, keySz, v
 
 	ctx := context.Background()
 	ns = NewTestNodeStore()
-	chunker, err := newEmptyChunker(ctx, ns, newTestBuilder)
+	serializer := message.ProllyMapSerializer{Pool: ns.Pool()}
+	chunker, err := newEmptyChunker(ctx, ns, serializer)
 	require.NoError(t, err)
 
 	for i := 0; i < scale; i++ {

--- a/go/store/prolly/write_amplification_test.go
+++ b/go/store/prolly/write_amplification_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/dolthub/dolt/go/store/prolly/message"
 	"github.com/dolthub/dolt/go/store/prolly/tree"
 	"github.com/dolthub/dolt/go/store/val"
 )
@@ -197,7 +198,8 @@ func prollyMapFromKeysAndValues(t *testing.T, kd, vd val.TupleDesc, keys, values
 	ns := tree.NewTestNodeStore()
 	require.Equal(t, len(keys), len(values))
 
-	chunker, err := tree.NewEmptyChunker(ctx, ns, newMapBuilder)
+	serializer := message.ProllyMapSerializer{Pool: ns.Pool()}
+	chunker, err := tree.NewEmptyChunker(ctx, ns, serializer)
 	require.NoError(t, err)
 
 	for i := range keys {


### PR DESCRIPTION
Some degree of builder polymorphism is needed to support prolly trees nodes backed by multiple flatbuffers messages. This PR reduces the scope of that polymorphism, simplifying the write path throughout the `prolly` and `tree` packages.