### PR TITLE
Improve merge failure messages

### DIFF
--- a/go/cmd/dolt/commands/merge.go
+++ b/go/cmd/dolt/commands/merge.go
@@ -206,7 +206,7 @@ func (cmd MergeCmd) Exec(ctx context.Context, commandStr string, args []string, 
 				return handleCommitErr(ctx, dEnv, err, usage)
 			}
 
-			tblToStats, err := merge.MergeCommitSpec(ctx, dEnv, spec)
+			tblToStats, mergeErr := merge.MergeCommitSpec(ctx, dEnv, spec)
 			hasConflicts, hasConstraintViolations := printSuccessStats(tblToStats)
 			wRoot, err := dEnv.WorkingRoot(ctx)
 			if err != nil {
@@ -231,13 +231,14 @@ func (cmd MergeCmd) Exec(ctx context.Context, commandStr string, args []string, 
 					"Constraint violations for the working set may be viewed using the 'dolt_constraint_violations' system table.\n"+
 					"They may be queried and removed per-table using the 'dolt_constraint_violations_TABLENAME' system table.\n", unmergedCnt)
 			}
-			if err != nil {
+
+			if mergeErr != nil {
 				var verr errhand.VerboseError
-				switch err {
+				switch mergeErr {
 				case doltdb.ErrIsAhead:
 					verr = nil
 				default:
-					verr = errhand.VerboseErrorFromError(err)
+					verr = errhand.VerboseErrorFromError(mergeErr)
 					cli.Println("Unable to stage changes: add and commit to finish merge")
 				}
 				return handleCommitErr(ctx, dEnv, verr, usage)

--- a/go/cmd/dolt/commands/merge.go
+++ b/go/cmd/dolt/commands/merge.go
@@ -146,14 +146,23 @@ func (cmd MergeCmd) Exec(ctx context.Context, commandStr string, args []string, 
 			if err != nil {
 				verr = errhand.BuildDError("error: failed to get constraint violations").AddCause(err).Build()
 			}
+
+			unmergedCnt, err := getUnmergedTableCount(ctx, root)
+			if err != nil {
+				cli.PrintErrln(err.Error())
+				return 1
+			}
+
 			if hasCnf || hasCV {
-				cli.Println("error: Merging is not possible because you have unmerged tables.")
+				cli.Printf("error: A merge is already in progress, %d table(s) are unmerged due to conflicts or constraint violations.\n", unmergedCnt)
 				cli.Println("hint: Fix them up in the working tree, and then use 'dolt add <table>'")
 				cli.Println("hint: as appropriate to mark resolution and make a commit.")
 				if hasCnf && hasCV {
-					cli.Println("fatal: Exiting because of an unresolved conflict and constraint violation.")
+					cli.Println("fatal: Exiting because of an unresolved conflict and constraint violation.\n" +
+						"fatal: Use 'dolt conflicts' to investigate and resolve conflicts.")
 				} else if hasCnf {
-					cli.Println("fatal: Exiting because of an unresolved conflict.")
+					cli.Println("fatal: Exiting because of an unresolved conflict.\n" +
+						"fatal: Use 'dolt conflicts' to investigate and resolve conflicts.")
 				} else {
 					cli.Println("fatal: Exiting because of an unresolved constraint violation.")
 				}
@@ -199,14 +208,28 @@ func (cmd MergeCmd) Exec(ctx context.Context, commandStr string, args []string, 
 
 			tblToStats, err := merge.MergeCommitSpec(ctx, dEnv, spec)
 			hasConflicts, hasConstraintViolations := printSuccessStats(tblToStats)
+			wRoot, err := dEnv.WorkingRoot(ctx)
+			if err != nil {
+				cli.PrintErrln(err.Error())
+				return 1
+			}
+			unmergedCnt, err = getUnmergedTableCount(ctx, wRoot)
+			if err != nil {
+				cli.PrintErrln(err.Error())
+				return 1
+			}
 			if hasConflicts && hasConstraintViolations {
-				cli.Println("Automatic merge failed; fix conflicts and constraint violations and then commit the result.")
+				cli.Printf("Automatic merge failed; %d table(s) are unmerged.\n"+
+					"Fix conflicts and constraint violations and then commit the result.\n"+
+					"Use 'dolt conflicts' to investigate and resolve conflicts.\n", unmergedCnt)
 			} else if hasConflicts {
-				cli.Println("Automatic merge failed; fix conflicts and then commit the result.")
+				cli.Printf("Automatic merge failed; %d table(s) are unmerged.\n"+
+					"Use 'dolt conflicts' to investigate and resolve conflicts.\n", unmergedCnt)
 			} else if hasConstraintViolations {
-				cli.Println("Automatic merge failed; fix constraint violations and then commit the result.\n" +
-					"Constraint violations for the working set may be viewed using the 'dolt_constraint_violations' system table.\n" +
-					"They may be queried and removed per-table using the 'dolt_constraint_violations_TABLENAME' system table.")
+				cli.Printf("Automatic merge failed; %d table(s) are unmerged.\n"+
+					"Fix constraint violations and then commit the result.\n"+
+					"Constraint violations for the working set may be viewed using the 'dolt_constraint_violations' system table.\n"+
+					"They may be queried and removed per-table using the 'dolt_constraint_violations_TABLENAME' system table.\n", unmergedCnt)
 			}
 			if err != nil {
 				var verr errhand.VerboseError
@@ -223,6 +246,30 @@ func (cmd MergeCmd) Exec(ctx context.Context, commandStr string, args []string, 
 	}
 
 	return handleCommitErr(ctx, dEnv, verr, usage)
+}
+
+func getUnmergedTableCount(ctx context.Context, root *doltdb.RootValue) (int, error) {
+	conflicted, err := root.TablesInConflict(ctx)
+	if err != nil {
+		return 0, err
+	}
+	cved, err := root.TablesWithConstraintViolations(ctx)
+	if err != nil {
+		return 0, err
+	}
+	uniqued := make(map[string]interface{})
+	for _, t := range conflicted {
+		uniqued[t] = struct{}{}
+	}
+	for _, t := range cved {
+		uniqued[t] = struct{}{}
+	}
+	var unmergedTableCount int
+	for range uniqued {
+		unmergedTableCount++
+	}
+
+	return unmergedTableCount, nil
 }
 
 func getCommitMessage(ctx context.Context, apr *argparser.ArgParseResults, dEnv *env.DoltEnv, spec *merge.MergeSpec) (string, errhand.VerboseError) {

--- a/integration-tests/bats/constraint-violations.bats
+++ b/integration-tests/bats/constraint-violations.bats
@@ -29,7 +29,7 @@ SQL
 
     run dolt merge other
     [ "$status" -eq "0" ]
-    [[ "$output" =~ "fix constraint violations" ]] || false
+    [[ "$output" =~ "Fix constraint violations" ]] || false
     run dolt sql -q "SELECT * FROM dolt_constraint_violations" -r=csv
     [ "$status" -eq "0" ]
     [[ "$output" =~ "table,num_violations" ]] || false


### PR DESCRIPTION
Fixes #3336 

Slightly improves the failure messages for merge. Basically adds a better hint that `dolt conflicts` should be used to investigate and resolve any conflicts.

Before:
```
-> dolt merge right
Updating j2pj08g8rkm8o348fr13vbo9fafv0ck8..rbdk7ovdugbnsnimrjjqq6rbq09idh7p
Auto-merging t
CONFLICT (content): Merge conflict in t
Automatic merge failed; fix conflicts and then commit the result.

-> dolt merge right
error: Merging is not possible because you have unmerged tables.
hint: Fix them up in the working tree, and then use 'dolt add <table>'
hint: as appropriate to mark resolution and make a commit.
fatal: Exiting because of an unresolved conflict.
```

After:
```
-> dolt merge right
Updating j2pj08g8rkm8o348fr13vbo9fafv0ck8..rbdk7ovdugbnsnimrjjqq6rbq09idh7p
Auto-merging t
CONFLICT (content): Merge conflict in t
Automatic merge failed; 1 table(s) are unmerged.
Use 'dolt conflicts' to investigate and resolve conflicts.

-> dolt merge right
error: A merge is already in progress, 1 table(s) are unmerged due to conflicts or constraint violations.
hint: Fix them up in the working tree, and then use 'dolt add <table>'
hint: as appropriate to mark resolution and make a commit.
fatal: Exiting because of an unresolved conflict.
fatal: Use 'dolt conflicts' to investigate and resolve conflicts.
```