### PR TITLE
Fix `dolt conflicts cat` failing to show conflicted rows in the union-ed schema between left, right, and base.

### DIFF
--- a/go/libraries/doltcore/merge/conflict_splitter.go
+++ b/go/libraries/doltcore/merge/conflict_splitter.go
@@ -55,7 +55,7 @@ type ConflictSplitter struct {
 // NewConflictSplitter creates a new ConflictSplitter
 func NewConflictSplitter(ctx context.Context, vrw types.ValueReadWriter, joiner *rowconv.Joiner) (ConflictSplitter, error) {
 	baseSch := joiner.SchemaForName(baseStr)
-	ourSch := joiner.SchemaForName(baseStr)
+	ourSch := joiner.SchemaForName(oursStr)
 	theirSch := joiner.SchemaForName(theirsStr)
 
 	sch, err := untyped.UntypedSchemaUnion(baseSch, ourSch, theirSch)

--- a/go/libraries/doltcore/merge/merge.go
+++ b/go/libraries/doltcore/merge/merge.go
@@ -763,21 +763,25 @@ func nomsPkRowMerge(ctx context.Context, nbf *types.NomsBinFormat, sch schema.Sc
 
 		if valutil.NilSafeEqCheck(val, mergeVal) {
 			return val, false
-		} else {
-			modified := !valutil.NilSafeEqCheck(val, baseVal)
-			mergeModified := !valutil.NilSafeEqCheck(mergeVal, baseVal)
-			switch {
-			case modified && mergeModified:
-				return nil, true
-			case modified:
-				didMerge = true
-				return val, false
-			default:
-				didMerge = true
-				return mergeVal, false
-			}
 		}
 
+		if baseRow == nil {
+			// Conflicting insert
+			return nil, true
+		}
+
+		modified := !valutil.NilSafeEqCheck(val, baseVal)
+		mergeModified := !valutil.NilSafeEqCheck(mergeVal, baseVal)
+		switch {
+		case modified && mergeModified:
+			return nil, true
+		case modified:
+			didMerge = true
+			return val, false
+		default:
+			didMerge = true
+			return mergeVal, false
+		}
 	}
 
 	resultVals := make(row.TaggedValues)

--- a/go/libraries/doltcore/merge/merge.go
+++ b/go/libraries/doltcore/merge/merge.go
@@ -763,25 +763,21 @@ func nomsPkRowMerge(ctx context.Context, nbf *types.NomsBinFormat, sch schema.Sc
 
 		if valutil.NilSafeEqCheck(val, mergeVal) {
 			return val, false
+		} else {
+			modified := !valutil.NilSafeEqCheck(val, baseVal)
+			mergeModified := !valutil.NilSafeEqCheck(mergeVal, baseVal)
+			switch {
+			case modified && mergeModified:
+				return nil, true
+			case modified:
+				didMerge = true
+				return val, false
+			default:
+				didMerge = true
+				return mergeVal, false
+			}
 		}
 
-		if baseRow == nil {
-			// Conflicting insert
-			return nil, true
-		}
-
-		modified := !valutil.NilSafeEqCheck(val, baseVal)
-		mergeModified := !valutil.NilSafeEqCheck(mergeVal, baseVal)
-		switch {
-		case modified && mergeModified:
-			return nil, true
-		case modified:
-			didMerge = true
-			return val, false
-		default:
-			didMerge = true
-			return mergeVal, false
-		}
 	}
 
 	resultVals := make(row.TaggedValues)

--- a/go/libraries/doltcore/merge/row_merge_test.go
+++ b/go/libraries/doltcore/merge/row_merge_test.go
@@ -184,17 +184,16 @@ var testCases = []testCase{
 		true,
 		false,
 	},
-	// TODO (dhruv): Fix this bug in the old storage format
-	//{
-	//	"add rows but one holds a new column",
-	//	build(1, 1),
-	//	build(1, 1, 1),
-	//	nil,
-	//	2, 3, 2,
-	//	nil,
-	//	false,
-	//	true,
-	//},
+	{
+		"add rows but one holds a new column",
+		build(1, 1),
+		build(1, 1, 1),
+		nil,
+		2, 3, 2,
+		nil,
+		false,
+		true,
+	},
 	{
 		"Delete a row in one, set all null in the other",
 		build(0, 0, 0), // build translates zeros into NULL values

--- a/go/libraries/doltcore/merge/row_merge_test.go
+++ b/go/libraries/doltcore/merge/row_merge_test.go
@@ -184,16 +184,17 @@ var testCases = []testCase{
 		true,
 		false,
 	},
-	{
-		"add rows but one holds a new column",
-		build(1, 1),
-		build(1, 1, 1),
-		nil,
-		2, 3, 2,
-		nil,
-		false,
-		true,
-	},
+	// TODO (dhruv): need to fix this test case for new storage format
+	//{
+	//	"add rows but one holds a new column",
+	//	build(1, 1),
+	//	build(1, 1, 1),
+	//	nil,
+	//	2, 3, 2,
+	//	build(1, 1, 1),
+	//	true,
+	//	false,
+	//},
 	{
 		"Delete a row in one, set all null in the other",
 		build(0, 0, 0), // build translates zeros into NULL values

--- a/integration-tests/bats/conflict-cat.bats
+++ b/integration-tests/bats/conflict-cat.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+load $BATS_TEST_DIRNAME/helper/common.bash
+
+setup() {
+    setup_common
+}
+
+teardown() {
+    teardown_common
+}
+
+@test "conflicts should show using the union-schema (new schema on right)" {
+    dolt sql -q "CREATE TABLE t (a INT PRIMARY KEY, b INT);"
+    dolt commit -am "base"
+
+    dolt checkout -b right
+    dolt sql <<SQL
+ALTER TABLE t ADD c INT;
+INSERT INTO t VALUES (1, 1, 1);
+SQL
+    dolt commit -am "right"
+
+    dolt checkout main
+    dolt sql -q "INSERT INTO t values (1, 1);"
+    dolt commit -am "left"
+
+    dolt merge right
+
+    run dolt conflicts cat .
+    [[ "$output" =~ "| a" ]]
+    [[ "$output" =~ "| b" ]]
+    [[ "$output" =~ "| c" ]]
+}
+
+@test "conflicts should show using the union-schema (new schema on left)" {
+    dolt sql -q "CREATE TABLE t (a INT PRIMARY KEY, b INT);"
+    dolt commit -am "base"
+
+    dolt checkout -b right
+    dolt sql -q "INSERT INTO t values (1, 1);"
+    dolt commit -am "right"
+
+    dolt checkout main
+    dolt sql <<SQL
+ALTER TABLE t ADD c INT;
+INSERT INTO t VALUES (1, 1, 1);
+SQL
+    dolt commit -am "left"
+    dolt merge right
+
+    run dolt conflicts cat .
+    [[ "$output" =~ "| a" ]]
+    [[ "$output" =~ "| b" ]]
+    [[ "$output" =~ "| c" ]]
+}

--- a/integration-tests/bats/conflict-cat.bats
+++ b/integration-tests/bats/conflict-cat.bats
@@ -9,7 +9,7 @@ teardown() {
     teardown_common
 }
 
-@test "conflicts should show using the union-schema (new schema on right)" {
+@test "conflict-cat: conflicts should show using the union-schema (new schema on right)" {
     dolt sql -q "CREATE TABLE t (a INT PRIMARY KEY, b INT);"
     dolt commit -am "base"
 
@@ -32,7 +32,7 @@ SQL
     [[ "$output" =~ "| c" ]]
 }
 
-@test "conflicts should show using the union-schema (new schema on left)" {
+@test "conflict-cat: conflicts should show using the union-schema (new schema on left)" {
     dolt sql -q "CREATE TABLE t (a INT PRIMARY KEY, b INT);"
     dolt commit -am "base"
 

--- a/integration-tests/bats/conflict-cat.bats
+++ b/integration-tests/bats/conflict-cat.bats
@@ -16,12 +16,12 @@ teardown() {
     dolt checkout -b right
     dolt sql <<SQL
 ALTER TABLE t ADD c INT;
-INSERT INTO t VALUES (1, 1, 1);
+INSERT INTO t VALUES (1, 2, 1);
 SQL
     dolt commit -am "right"
 
     dolt checkout main
-    dolt sql -q "INSERT INTO t values (1, 1);"
+    dolt sql -q "INSERT INTO t values (1, 3);"
     dolt commit -am "left"
 
     dolt merge right
@@ -37,13 +37,13 @@ SQL
     dolt commit -am "base"
 
     dolt checkout -b right
-    dolt sql -q "INSERT INTO t values (1, 1);"
+    dolt sql -q "INSERT INTO t values (1, 2);"
     dolt commit -am "right"
 
     dolt checkout main
     dolt sql <<SQL
 ALTER TABLE t ADD c INT;
-INSERT INTO t VALUES (1, 1, 1);
+INSERT INTO t VALUES (1, 3, 1);
 SQL
     dolt commit -am "left"
     dolt merge right


### PR DESCRIPTION
Fixes a one-liner bug where the conflicted rows wouldn't show with the union schema between left, right, and base. Added a bats test as well.