### PR TITLE
[no-release-notes] adds merge conflicts for the new storage format.

### DIFF
--- a/go/libraries/doltcore/doltdb/durable/conflict_index.go
+++ b/go/libraries/doltcore/doltdb/durable/conflict_index.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package durable
 
 import (

--- a/go/libraries/doltcore/doltdb/durable/conflict_index.go
+++ b/go/libraries/doltcore/doltdb/durable/conflict_index.go
@@ -1,0 +1,134 @@
+package durable
+
+import (
+	"context"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/dolthub/dolt/go/store/prolly"
+	"github.com/dolthub/dolt/go/store/prolly/tree"
+	"github.com/dolthub/dolt/go/store/types"
+)
+
+type ConflictIndex interface {
+	HashOf() (hash.Hash, error)
+	Count() uint64
+	Format() *types.NomsBinFormat
+}
+
+// RefFromConflictIndex persists |idx| and returns the types.Ref targeting it.
+func RefFromConflictIndex(ctx context.Context, vrw types.ValueReadWriter, idx ConflictIndex) (types.Ref, error) {
+	switch idx.Format() {
+	case types.Format_LD_1, types.Format_7_18, types.Format_DOLT_DEV:
+		return refFromNomsValue(ctx, vrw, idx.(nomsConflictIndex).index)
+
+	case types.Format_DOLT_1:
+		b := prolly.ValueFromConflictMap(idx.(prollyConflictIndex).index)
+		return refFromNomsValue(ctx, vrw, b)
+
+	default:
+		return types.Ref{}, errNbfUnkown
+	}
+}
+
+// NewEmptyConflictIndex returns an ConflictIndex with no rows.
+func NewEmptyConflictIndex(ctx context.Context, vrw types.ValueReadWriter, oursSch, theirsSch, baseSch schema.Schema) (ConflictIndex, error) {
+	switch vrw.Format() {
+	case types.Format_LD_1, types.Format_7_18, types.Format_DOLT_DEV:
+		m, err := types.NewMap(ctx, vrw)
+		if err != nil {
+			return nil, err
+		}
+		return ConflictIndexFromNomsMap(m, vrw), nil
+
+	case types.Format_DOLT_1:
+		kd, oursVD := prolly.MapDescriptorsFromScheam(oursSch)
+		theirsVD := prolly.ValueDescriptorFromSchema(theirsSch)
+		baseVD := prolly.ValueDescriptorFromSchema(baseSch)
+		ns := tree.NewNodeStore(prolly.ChunkStoreFromVRW(vrw))
+
+		m := prolly.NewEmptyConflictMap(ns, kd, oursVD, theirsVD, baseVD)
+
+		return ConflictIndexFromProllyMap(m), nil
+
+	default:
+		return nil, errNbfUnkown
+	}
+}
+
+func ConflictIndexFromNomsMap(m types.Map, vrw types.ValueReadWriter) ConflictIndex {
+	return nomsConflictIndex{
+		index: m,
+		vrw:   vrw,
+	}
+}
+
+func NomsMapFromConflictIndex(i ConflictIndex) types.Map {
+	return i.(nomsConflictIndex).index
+}
+
+func ConflictIndexFromProllyMap(m prolly.ConflictMap) ConflictIndex {
+	return prollyConflictIndex{
+		index: m,
+	}
+}
+
+func ProllyMapFromConflictIndex(i ConflictIndex) prolly.ConflictMap {
+	return i.(prollyConflictIndex).index
+}
+
+func conflictIndexFromRef(ctx context.Context, vrw types.ValueReadWriter, ourSch, theirSch, baseSch schema.Schema, r types.Ref) (ConflictIndex, error) {
+	return conflictIndexFromAddr(ctx, vrw, ourSch, theirSch, baseSch, r.TargetHash())
+}
+
+func conflictIndexFromAddr(ctx context.Context, vrw types.ValueReadWriter, ourSch, theirSch, baseSch schema.Schema, addr hash.Hash) (ConflictIndex, error) {
+	v, err := vrw.ReadValue(ctx, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	switch vrw.Format() {
+	case types.Format_LD_1, types.Format_7_18, types.Format_DOLT_DEV:
+		return ConflictIndexFromNomsMap(v.(types.Map), vrw), nil
+
+	case types.Format_DOLT_1:
+		m := prolly.ConflictMapFromValue(v, ourSch, theirSch, baseSch, vrw)
+		return ConflictIndexFromProllyMap(m), nil
+
+	default:
+		return nil, errNbfUnkown
+	}
+}
+
+type nomsConflictIndex struct {
+	index types.Map
+	vrw   types.ValueReadWriter
+}
+
+func (i nomsConflictIndex) HashOf() (hash.Hash, error) {
+	return i.index.Hash(i.vrw.Format())
+}
+
+func (i nomsConflictIndex) Count() uint64 {
+	return i.index.Len()
+}
+
+func (i nomsConflictIndex) Format() *types.NomsBinFormat {
+	return i.vrw.Format()
+}
+
+type prollyConflictIndex struct {
+	index prolly.ConflictMap
+}
+
+func (i prollyConflictIndex) HashOf() (hash.Hash, error) {
+	return i.index.HashOf(), nil
+}
+
+func (i prollyConflictIndex) Count() uint64 {
+	return uint64(i.index.Count())
+}
+
+func (i prollyConflictIndex) Format() *types.NomsBinFormat {
+	return i.index.Format()
+}

--- a/go/libraries/doltcore/doltdb/durable/index.go
+++ b/go/libraries/doltcore/doltdb/durable/index.go
@@ -300,6 +300,21 @@ func NewIndexSet(ctx context.Context, vrw types.ValueReadWriter) IndexSet {
 	}
 }
 
+func NewIndexSetWithEmptyIndexes(ctx context.Context, vrw types.ValueReadWriter, sch schema.Schema) (IndexSet, error) {
+	s := NewIndexSet(ctx, vrw)
+	for _, index := range sch.Indexes().AllIndexes() {
+		empty, err := NewEmptyIndex(ctx, vrw, index.Schema())
+		if err != nil {
+			return nil, err
+		}
+		s, err = s.PutIndex(ctx, index.Name(), empty)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return s, nil
+}
+
 type nomsIndexSet struct {
 	indexes types.Map
 	vrw     types.ValueReadWriter

--- a/go/libraries/doltcore/doltdb/durable/table.go
+++ b/go/libraries/doltcore/doltdb/durable/table.go
@@ -80,11 +80,11 @@ type Table interface {
 	SetIndexes(ctx context.Context, indexes IndexSet) (Table, error)
 
 	// GetConflicts returns the merge conflicts for this table.
-	GetConflicts(ctx context.Context) (conflict.ConflictSchema, types.Map, error)
+	GetConflicts(ctx context.Context) (conflict.ConflictSchema, ConflictIndex, error)
 	// HasConflicts returns true if this table has conflicts.
 	HasConflicts(ctx context.Context) (bool, error)
 	// SetConflicts sets the merge conflicts for this table.
-	SetConflicts(ctx context.Context, sch conflict.ConflictSchema, conflicts types.Map) (Table, error)
+	SetConflicts(ctx context.Context, sch conflict.ConflictSchema, conflicts ConflictIndex) (Table, error)
 	// ClearConflicts removes all merge conflicts for this table.
 	ClearConflicts(ctx context.Context) (Table, error)
 
@@ -368,44 +368,52 @@ func (t nomsTable) HasConflicts(ctx context.Context) (bool, error) {
 }
 
 // GetConflicts implements Table.
-func (t nomsTable) GetConflicts(ctx context.Context) (conflict.ConflictSchema, types.Map, error) {
+func (t nomsTable) GetConflicts(ctx context.Context) (conflict.ConflictSchema, ConflictIndex, error) {
 	schemasVal, ok, err := t.tableStruct.MaybeGet(conflictSchemasKey)
 	if err != nil {
-		return conflict.ConflictSchema{}, types.EmptyMap, err
+		return conflict.ConflictSchema{}, nil, err
 	}
 	if !ok {
-		confMap, _ := types.NewMap(ctx, t.valueReadWriter())
-		return conflict.ConflictSchema{}, confMap, nil
+		sch, err := t.GetSchema(ctx)
+		if err != nil {
+			return conflict.ConflictSchema{}, nil, err
+		}
+		empty, err := NewEmptyConflictIndex(ctx, t.vrw, sch, sch, sch)
+		if err != nil {
+			return conflict.ConflictSchema{}, nil, err
+		}
+		return conflict.ConflictSchema{}, empty, nil
 	}
 
 	schemas, err := conflict.ConflictSchemaFromValue(ctx, t.vrw, schemasVal)
 	if err != nil {
-		return conflict.ConflictSchema{}, types.EmptyMap, err
+		return conflict.ConflictSchema{}, nil, err
 	}
 
 	conflictsVal, _, err := t.tableStruct.MaybeGet(conflictsKey)
 	if err != nil {
-		return conflict.ConflictSchema{}, types.EmptyMap, err
+		return conflict.ConflictSchema{}, nil, err
 	}
 
-	confMap := types.EmptyMap
-	if conflictsVal != nil {
-		confMapRef := conflictsVal.(types.Ref)
-		v, err := confMapRef.TargetValue(ctx, t.vrw)
-
+	if conflictsVal == nil {
+		confIndex, err := NewEmptyConflictIndex(ctx, t.vrw, schemas.Schema, schemas.MergeSchema, schemas.Base)
 		if err != nil {
-			return conflict.ConflictSchema{}, types.EmptyMap, err
+			return conflict.ConflictSchema{}, nil, err
 		}
-
-		confMap = v.(types.Map)
+		return conflict.ConflictSchema{}, confIndex, nil
 	}
 
-	return schemas, confMap, nil
+	i, err := conflictIndexFromRef(ctx, t.vrw, schemas.Schema, schemas.MergeSchema, schemas.Base, conflictsVal.(types.Ref))
+	if err != nil {
+		return conflict.ConflictSchema{}, nil, err
+	}
+
+	return schemas, i, nil
 }
 
 // SetConflicts implements Table.
-func (t nomsTable) SetConflicts(ctx context.Context, schemas conflict.ConflictSchema, conflictData types.Map) (Table, error) {
-	conflictsRef, err := refFromNomsValue(ctx, t.vrw, conflictData)
+func (t nomsTable) SetConflicts(ctx context.Context, schemas conflict.ConflictSchema, conflictData ConflictIndex) (Table, error) {
+	conflictsRef, err := RefFromConflictIndex(ctx, t.vrw, conflictData)
 	if err != nil {
 		return nil, err
 	}
@@ -762,7 +770,7 @@ func (t doltDevTable) SetIndexes(ctx context.Context, indexes IndexSet) (Table, 
 	return doltDevTable{t.vrw, msg}, nil
 }
 
-func (t doltDevTable) GetConflicts(ctx context.Context) (conflict.ConflictSchema, types.Map, error) {
+func (t doltDevTable) GetConflicts(ctx context.Context) (conflict.ConflictSchema, ConflictIndex, error) {
 	conflicts := t.msg.Conflicts(nil)
 
 	ouraddr := hash.New(conflicts.OurSchemaBytes())
@@ -770,21 +778,28 @@ func (t doltDevTable) GetConflicts(ctx context.Context) (conflict.ConflictSchema
 	baseaddr := hash.New(conflicts.AncestorSchemaBytes())
 
 	if ouraddr.IsEmpty() {
-		m, err := types.NewMap(ctx, t.vrw)
-		return conflict.ConflictSchema{}, m, err
+		sch, err := t.GetSchema(ctx)
+		if err != nil {
+			return conflict.ConflictSchema{}, nil, err
+		}
+		empty, err := NewEmptyConflictIndex(ctx, t.vrw, sch, sch, sch)
+		if err != nil {
+			return conflict.ConflictSchema{}, nil, err
+		}
+		return conflict.ConflictSchema{}, empty, nil
 	}
 
 	ourschema, err := getSchemaAtAddr(ctx, t.vrw, ouraddr)
 	if err != nil {
-		return conflict.ConflictSchema{}, types.Map{}, err
+		return conflict.ConflictSchema{}, nil, err
 	}
 	theirschema, err := getSchemaAtAddr(ctx, t.vrw, theiraddr)
 	if err != nil {
-		return conflict.ConflictSchema{}, types.Map{}, err
+		return conflict.ConflictSchema{}, nil, err
 	}
 	baseschema, err := getSchemaAtAddr(ctx, t.vrw, baseaddr)
 	if err != nil {
-		return conflict.ConflictSchema{}, types.Map{}, err
+		return conflict.ConflictSchema{}, nil, err
 	}
 
 	conflictschema := conflict.ConflictSchema{
@@ -794,21 +809,20 @@ func (t doltDevTable) GetConflicts(ctx context.Context) (conflict.ConflictSchema
 	}
 
 	mapaddr := hash.New(conflicts.DataBytes())
-	var datamap types.Map
+	var conflictIdx ConflictIndex
 	if mapaddr.IsEmpty() {
-		datamap, err = types.NewMap(ctx, t.vrw)
+		conflictIdx, err = NewEmptyConflictIndex(ctx, t.vrw, ourschema, theirschema, baseschema)
 		if err != nil {
-			return conflict.ConflictSchema{}, types.Map{}, err
+			return conflict.ConflictSchema{}, nil, err
 		}
 	} else {
-		mapval, err := t.vrw.ReadValue(ctx, mapaddr)
+		conflictIdx, err = conflictIndexFromAddr(ctx, t.vrw, ourschema, theirschema, baseschema, mapaddr)
 		if err != nil {
-			return conflict.ConflictSchema{}, types.Map{}, err
+			return conflict.ConflictSchema{}, nil, err
 		}
-		datamap = mapval.(types.Map)
 	}
 
-	return conflictschema, datamap, nil
+	return conflictschema, conflictIdx, nil
 }
 
 func (t doltDevTable) HasConflicts(ctx context.Context) (bool, error) {
@@ -817,8 +831,8 @@ func (t doltDevTable) HasConflicts(ctx context.Context) (bool, error) {
 	return !addr.IsEmpty(), nil
 }
 
-func (t doltDevTable) SetConflicts(ctx context.Context, sch conflict.ConflictSchema, conflicts types.Map) (Table, error) {
-	conflictsRef, err := refFromNomsValue(ctx, t.vrw, conflicts)
+func (t doltDevTable) SetConflicts(ctx context.Context, sch conflict.ConflictSchema, conflicts ConflictIndex) (Table, error) {
+	conflictsRef, err := RefFromConflictIndex(ctx, t.vrw, conflicts)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/merge/conflict_source.go
+++ b/go/libraries/doltcore/merge/conflict_source.go
@@ -20,6 +20,7 @@ import (
 	"io"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/conflict"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
@@ -75,11 +76,16 @@ func NewConflictReader(ctx context.Context, tbl *doltdb.Table) (*ConflictReader,
 		return nil, err
 	}
 
-	_, confData, err := tbl.GetConflicts(ctx)
+	_, confIdx, err := tbl.GetConflicts(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	if confIdx.Format() == types.Format_DOLT_1 {
+		panic("conflict reader not implemented for new storage format")
+	}
+
+	confData := durable.NomsMapFromConflictIndex(confIdx)
 	confItr, err := confData.Iterator(ctx)
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/merge/keyless_integration_test.go
+++ b/go/libraries/doltcore/merge/keyless_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -262,8 +263,9 @@ func TestKeylessMergeConflicts(t *testing.T) {
 			require.NoError(t, err)
 			tbl, _, err := root.GetTable(ctx, tblName)
 			require.NoError(t, err)
-			_, conflicts, err := tbl.GetConflicts(ctx)
+			_, confIdx, err := tbl.GetConflicts(ctx)
 			require.NoError(t, err)
+			conflicts := durable.NomsMapFromConflictIndex(confIdx)
 
 			assert.True(t, conflicts.Len() > 0)
 			assert.Equal(t, int(conflicts.Len()), len(test.conflicts))

--- a/go/libraries/doltcore/merge/keyless_integration_test.go
+++ b/go/libraries/doltcore/merge/keyless_integration_test.go
@@ -18,13 +18,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	cmd "github.com/dolthub/dolt/go/cmd/dolt/commands"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands/cnfcmds"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
 	dtu "github.com/dolthub/dolt/go/libraries/doltcore/dtestutils"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"

--- a/go/libraries/doltcore/merge/merge_prolly.go
+++ b/go/libraries/doltcore/merge/merge_prolly.go
@@ -16,14 +16,12 @@ package merge
 
 import (
 	"context"
-	"errors"
 
 	"golang.org/x/sync/errgroup"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
-	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor/creation"
 	"github.com/dolthub/dolt/go/store/pool"
 	"github.com/dolthub/dolt/go/store/prolly"
 	"github.com/dolthub/dolt/go/store/prolly/tree"
@@ -31,10 +29,10 @@ import (
 	"github.com/dolthub/dolt/go/store/val"
 )
 
-type cellWiseMerge struct {
-	leftDiff  tree.Diff
-	rightDiff tree.Diff
-	merged    tree.Diff
+type mergeResult struct {
+	tbl   *doltdb.Table
+	cons  durable.ConflictIndex
+	stats *MergeStats
 }
 
 // mergeTableData three-way merges rows and indexes for a given table. First,
@@ -49,67 +47,88 @@ type cellWiseMerge struct {
 // entries are set to values consistent the cell-wise merge result. When the
 // root and merge secondary indexes are merged, they will produce entries
 // consistent with the primary row data.
-func mergeTableData(ctx context.Context, vrw types.ValueReadWriter, postMergeSchema, rootSchema, mergeSchema, ancSchema schema.Schema, tbl, mergeTbl, ancTbl, tableToUpdate *doltdb.Table) (*doltdb.Table, *MergeStats, error) {
+func mergeTableData(ctx context.Context, vrw types.ValueReadWriter, postMergeSchema, rootSchema, mergeSchema, ancSchema schema.Schema, tbl, mergeTbl, ancTbl, tableToUpdate *doltdb.Table) (mergeResult, error) {
 	group, gCtx := errgroup.WithContext(ctx)
 
-	cellWiseMerges := make(chan cellWiseMerge, 128)
+	indexEdits := make(chan indexEdit, 128)
+	conflicts := make(chan confVals, 128)
 	var updatedTable *doltdb.Table
 	var mergedData durable.Index
 
 	group.Go(func() error {
 		var err error
 		// TODO (dhruv): update this function definition to return any conflicts
-		updatedTable, mergedData, err = mergeProllyRowData(gCtx, postMergeSchema, rootSchema, mergeSchema, ancSchema, tbl, mergeTbl, ancTbl, tableToUpdate, cellWiseMerges)
+		updatedTable, mergedData, err = mergeProllyRowData(gCtx, postMergeSchema, rootSchema, mergeSchema, ancSchema, tbl, mergeTbl, ancTbl, tableToUpdate, indexEdits, conflicts)
 		if err != nil {
 			return err
 		}
-		defer close(cellWiseMerges)
+		defer close(indexEdits)
+		defer close(conflicts)
 		return nil
 	})
 
 	rootIndexSet, err := tbl.GetIndexSet(ctx)
 	if err != nil {
-		return nil, nil, err
+		return mergeResult{}, err
 	}
 	mergeIndexSet, err := mergeTbl.GetIndexSet(ctx)
 	if err != nil {
-		return nil, nil, err
+		return mergeResult{}, err
 	}
 
 	var updatedRootIndexSet durable.IndexSet
 	var updatedMergeIndexSet durable.IndexSet
 	group.Go(func() error {
 		var err error
-		updatedRootIndexSet, updatedMergeIndexSet, err = updateProllySecondaryIndexes(gCtx, cellWiseMerges, rootSchema, mergeSchema, tbl, mergeTbl, rootIndexSet, mergeIndexSet)
+		updatedRootIndexSet, updatedMergeIndexSet, err = updateProllySecondaryIndexes(gCtx, indexEdits, rootSchema, mergeSchema, tbl, mergeTbl, rootIndexSet, mergeIndexSet)
 		return err
+	})
+
+	confIdx, err := durable.NewEmptyConflictIndex(ctx, vrw, rootSchema, mergeSchema, ancSchema)
+	if err != nil {
+		return mergeResult{}, err
+	}
+	confEditor := durable.ProllyMapFromConflictIndex(confIdx).Editor()
+	group.Go(func() error {
+		return processConflicts(ctx, conflicts, confEditor)
 	})
 
 	err = group.Wait()
 	if err != nil {
-		return nil, nil, err
+		return mergeResult{}, err
 	}
 
 	tbl, err = tbl.SetIndexSet(ctx, updatedRootIndexSet)
 	if err != nil {
-		return nil, nil, err
+		return mergeResult{}, err
 	}
 	mergeTbl, err = mergeTbl.SetIndexSet(ctx, updatedMergeIndexSet)
 	if err != nil {
-		return nil, nil, err
+		return mergeResult{}, err
 	}
+
+	confMap, err := confEditor.Flush(ctx)
+	if err != nil {
+		return mergeResult{}, err
+	}
+	confIdx = durable.ConflictIndexFromProllyMap(confMap)
 
 	updatedTable, err = mergeProllySecondaryIndexes(ctx, vrw, postMergeSchema, rootSchema, mergeSchema, ancSchema, mergedData, tbl, mergeTbl, ancTbl, updatedTable)
 	if err != nil {
-		return nil, nil, err
+		return mergeResult{}, err
 	}
 
 	// TODO (dhruv): populate merge stats
-	return updatedTable, &MergeStats{Operation: TableModified}, nil
+	return mergeResult{
+		tbl:   updatedTable,
+		cons:  confIdx,
+		stats: &MergeStats{Operation: TableModified},
+	}, nil
 }
 
 // mergeProllyRowData merges the primary row table indexes of |tbl|, |mergeTbl|,
 // and |ancTbl|. It stores the merged row data into |tableToUpdate| and returns the new value along with the row data.
-func mergeProllyRowData(ctx context.Context, postMergeSchema, rootSch, mergeSch, ancSch schema.Schema, tbl, mergeTbl, ancTbl, tableToUpdate *doltdb.Table, cellWiseMerges chan cellWiseMerge) (*doltdb.Table, durable.Index, error) {
+func mergeProllyRowData(ctx context.Context, postMergeSchema, rootSch, mergeSch, ancSch schema.Schema, tbl, mergeTbl, ancTbl, tableToUpdate *doltdb.Table, indexEdits chan indexEdit, conflicts chan confVals) (*doltdb.Table, durable.Index, error) {
 	rootR, err := tbl.GetRowData(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -129,11 +148,29 @@ func mergeProllyRowData(ctx context.Context, postMergeSchema, rootSch, mergeSch,
 	m := durable.ProllyMapFromIndex(rootR)
 	vMerger := newValueMerger(postMergeSchema, rootSch, mergeSch, ancSch, m.Pool())
 
-	conflicted := false
 	mergedRP, err := prolly.MergeMaps(ctx, rootRP, mergeRP, ancRP, func(left, right tree.Diff) (tree.Diff, bool) {
 		merged, isConflict := vMerger.tryMerge(val.Tuple(left.To), val.Tuple(right.To), val.Tuple(left.From))
 		if isConflict {
-			conflicted = true
+			c := confVals{
+				key:      val.Tuple(left.Key),
+				ourVal:   val.Tuple(left.To),
+				theirVal: val.Tuple(right.To),
+				baseVal:  val.Tuple(left.From),
+			}
+			select {
+			case conflicts <- c:
+			case <-ctx.Done():
+				return tree.Diff{}, false
+			}
+			// Reset the change on the right
+			e := conflictEdit{
+				right: right,
+			}
+			select {
+			case indexEdits <- e:
+			case <-ctx.Done():
+				return tree.Diff{}, false
+			}
 			return tree.Diff{}, false
 		}
 
@@ -145,7 +182,7 @@ func mergeProllyRowData(ctx context.Context, postMergeSchema, rootSch, mergeSch,
 		}
 
 		select {
-		case cellWiseMerges <- cellWiseMerge{left, right, d}:
+		case indexEdits <- cellWiseMergeEdit{left, right, d}:
 			break
 		case <-ctx.Done():
 			return tree.Diff{}, false
@@ -155,9 +192,6 @@ func mergeProllyRowData(ctx context.Context, postMergeSchema, rootSch, mergeSch,
 	})
 	if err != nil {
 		return nil, nil, err
-	}
-	if conflicted {
-		return nil, nil, errors.New("row conflicts not supported yet")
 	}
 
 	updatedTbl, err := tableToUpdate.UpdateRows(ctx, durable.IndexFromProllyMap(mergedRP))
@@ -278,198 +312,22 @@ func (m *valueMerger) processColumn(i int, left, right, base val.Tuple) ([]byte,
 	}
 }
 
-// Given cellWiseMerge's sent on |cellWiseChan|, update the secondary indexes in
-// |rootIndexSet| and |mergeIndexSet| such that when the index sets are merged,
-// they produce entries consistent with the cell-wise merges. The updated
-// |rootIndexSet| and |mergeIndexSet| are returned.
-func updateProllySecondaryIndexes(
-	ctx context.Context,
-	cellWiseChan chan cellWiseMerge,
-	rootSchema, mergeSchema schema.Schema,
-	tbl, mergeTbl *doltdb.Table,
-	rootIndexSet, mergeIndexSet durable.IndexSet) (durable.IndexSet, durable.IndexSet, error) {
-
-	rootIdxs, err := getMutableSecondaryIdxs(ctx, rootSchema, tbl)
-	if err != nil {
-		return nil, nil, err
-	}
-	mergeIdxs, err := getMutableSecondaryIdxs(ctx, mergeSchema, mergeTbl)
-	if err != nil {
-		return nil, nil, err
-	}
-
+func processConflicts(ctx context.Context, conflictChan chan confVals, editor prolly.ConflictEditor) error {
 OUTER:
 	for {
 		select {
-		case m, ok := <-cellWiseChan:
+		case conflict, ok := <-conflictChan:
 			if !ok {
 				break OUTER
 			}
-			for _, idx := range rootIdxs {
-				// Revert corresponding idx entry in left
-				err = idx.UpdateEntry(ctx, val.Tuple(m.leftDiff.Key), val.Tuple(m.leftDiff.To), val.Tuple(m.leftDiff.From))
-				if err != nil {
-					return nil, nil, err
-				}
-			}
-			for _, idx := range mergeIdxs {
-				// Update corresponding idx entry to merged value in right
-				err = idx.UpdateEntry(ctx, val.Tuple(m.rightDiff.Key), val.Tuple(m.rightDiff.To), val.Tuple(m.merged.To))
-				if err != nil {
-					return nil, nil, err
-				}
+			err := editor.Add(ctx, conflict.key, conflict.ourVal, conflict.theirVal, conflict.baseVal)
+			if err != nil {
+				return err
 			}
 		case <-ctx.Done():
-			return nil, nil, ctx.Err()
+			return ctx.Err()
 		}
 	}
 
-	persistIndexMuts := func(indexSet durable.IndexSet, idxs []MutableSecondaryIdx) (durable.IndexSet, error) {
-		for _, idx := range idxs {
-			m, err := idx.Map(ctx)
-			if err != nil {
-				return nil, err
-			}
-			indexSet, err = indexSet.PutIndex(ctx, idx.Name, durable.IndexFromProllyMap(m))
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		return indexSet, nil
-	}
-
-	updatedRootIndexSet, err := persistIndexMuts(rootIndexSet, rootIdxs)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	updatedMergeIndexSet, err := persistIndexMuts(mergeIndexSet, mergeIdxs)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return updatedRootIndexSet, updatedMergeIndexSet, nil
-}
-
-// getMutableSecondaryIdxs returns a MutableSecondaryIdx for each secondary index
-// defined in |schema| and |tbl|.
-func getMutableSecondaryIdxs(ctx context.Context, schema schema.Schema, tbl *doltdb.Table) ([]MutableSecondaryIdx, error) {
-	indexSet, err := tbl.GetIndexSet(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	mods := make([]MutableSecondaryIdx, schema.Indexes().Count())
-	for i, index := range schema.Indexes().AllIndexes() {
-		idx, err := indexSet.GetIndex(ctx, schema, index.Name())
-		if err != nil {
-			return nil, err
-		}
-		m := durable.ProllyMapFromIndex(idx)
-
-		mods[i] = NewMutableSecondaryIdx(m, schema, index, m.Pool())
-	}
-
-	return mods, nil
-}
-
-// mergeProllySecondaryIndexes merges the secondary indexes of the given |tbl|,
-// |mergeTbl|, and |ancTbl|. It stores the merged indexes into |tableToUpdate|
-// and returns its updated value.
-func mergeProllySecondaryIndexes(ctx context.Context, vrw types.ValueReadWriter, postMergeSchema, rootSch, mergeSch, ancSch schema.Schema, mergedData durable.Index, tbl, mergeTbl, ancTbl, tableToUpdate *doltdb.Table) (*doltdb.Table, error) {
-	rootSet, err := tbl.GetIndexSet(ctx)
-	if err != nil {
-		return nil, err
-	}
-	mergeSet, err := mergeTbl.GetIndexSet(ctx)
-	if err != nil {
-		return nil, err
-	}
-	ancSet, err := ancTbl.GetIndexSet(ctx)
-	if err != nil {
-		return nil, err
-	}
-	mergedSet, err := mergeProllyIndexSets(ctx, vrw, postMergeSchema, rootSch, mergeSch, ancSch, mergedData, rootSet, mergeSet, ancSet)
-	if err != nil {
-		return nil, err
-	}
-	updatedTbl, err := tableToUpdate.SetIndexSet(ctx, mergedSet)
-	if err != nil {
-		return nil, err
-	}
-	return updatedTbl, nil
-}
-
-// mergeProllyIndexSets merges the |root|, |merge|, and |anc| index sets based
-// on the provided |postMergeSchema|. It returns the merged index set.
-func mergeProllyIndexSets(ctx context.Context, vrw types.ValueReadWriter, postMergeSchema, rootSch, mergeSch, ancSch schema.Schema, mergedData durable.Index, root, merge, anc durable.IndexSet) (durable.IndexSet, error) {
-	mergedIndexSet := durable.NewIndexSet(ctx, vrw)
-
-	tryGetIdx := func(sch schema.Schema, iS durable.IndexSet, indexName string) (idx durable.Index, ok bool, err error) {
-		ok = sch.Indexes().Contains(indexName)
-		if ok {
-			idx, err = iS.GetIndex(ctx, sch, indexName)
-			if err != nil {
-				return nil, false, err
-			}
-			return idx, true, nil
-		}
-		return nil, false, nil
-	}
-
-	// Based on the indexes in the post merge schema, merge the root, merge,
-	// and ancestor indexes.
-	for _, index := range postMergeSchema.Indexes().AllIndexes() {
-
-		rootI, rootOK, err := tryGetIdx(rootSch, root, index.Name())
-		if err != nil {
-			return nil, err
-		}
-		mergeI, mergeOK, err := tryGetIdx(mergeSch, merge, index.Name())
-		if err != nil {
-			return nil, err
-		}
-		ancI, ancOK, err := tryGetIdx(ancSch, anc, index.Name())
-		if err != nil {
-			return nil, err
-		}
-
-		mergedIndex, err := func() (durable.Index, error) {
-			if !rootOK || !mergeOK || !ancOK {
-				mergedIndex, err := creation.BuildSecondaryProllyIndex(ctx, vrw, postMergeSchema, index, durable.ProllyMapFromIndex(mergedData))
-				if err != nil {
-					return nil, err
-				}
-				return mergedIndex, nil
-			}
-
-			left := durable.ProllyMapFromIndex(rootI)
-			right := durable.ProllyMapFromIndex(mergeI)
-			base := durable.ProllyMapFromIndex(ancI)
-
-			var collision = false
-			merged, err := prolly.MergeMaps(ctx, left, right, base, func(left, right tree.Diff) (tree.Diff, bool) {
-				collision = true
-				return tree.Diff{}, true
-			})
-			if err != nil {
-				return nil, err
-			}
-			if collision {
-				return nil, errors.New("collisions not implemented")
-			}
-			return durable.IndexFromProllyMap(merged), nil
-		}()
-		if err != nil {
-			return nil, err
-		}
-
-		mergedIndexSet, err = mergedIndexSet.PutIndex(ctx, index.Name(), mergedIndex)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return mergedIndexSet, nil
+	return nil
 }

--- a/go/libraries/doltcore/merge/merge_prolly_indexes.go
+++ b/go/libraries/doltcore/merge/merge_prolly_indexes.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package merge
 
 import (

--- a/go/libraries/doltcore/merge/merge_prolly_indexes.go
+++ b/go/libraries/doltcore/merge/merge_prolly_indexes.go
@@ -85,16 +85,12 @@ type confVals struct {
 // mergeProllySecondaryIndexes merges the secondary indexes of the given |tbl|,
 // |mergeTbl|, and |ancTbl|. It stores the merged indexes into |tableToUpdate|
 // and returns its updated value.
-func mergeProllySecondaryIndexes(ctx context.Context, vrw types.ValueReadWriter, postMergeSchema, rootSch, mergeSch, ancSch schema.Schema, mergedData durable.Index, tbl, mergeTbl, ancTbl, tableToUpdate *doltdb.Table) (*doltdb.Table, error) {
+func mergeProllySecondaryIndexes(ctx context.Context, vrw types.ValueReadWriter, postMergeSchema, rootSch, mergeSch, ancSch schema.Schema, mergedData durable.Index, tbl, mergeTbl, tableToUpdate *doltdb.Table, ancSet durable.IndexSet) (*doltdb.Table, error) {
 	rootSet, err := tbl.GetIndexSet(ctx)
 	if err != nil {
 		return nil, err
 	}
 	mergeSet, err := mergeTbl.GetIndexSet(ctx)
-	if err != nil {
-		return nil, err
-	}
-	ancSet, err := ancTbl.GetIndexSet(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/merge/merge_prolly_indexes.go
+++ b/go/libraries/doltcore/merge/merge_prolly_indexes.go
@@ -1,0 +1,305 @@
+package merge
+
+import (
+	"context"
+	"errors"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor/creation"
+	"github.com/dolthub/dolt/go/store/prolly"
+	"github.com/dolthub/dolt/go/store/prolly/tree"
+	"github.com/dolthub/dolt/go/store/types"
+	"github.com/dolthub/dolt/go/store/val"
+)
+
+// indexEdit is an edit to a secondary index based on the primary row's key and value.
+// The members of tree.Diff have the following meanings:
+// - |Key| = the key to apply this edit on
+// - |From| = the previous value of this key (If nil, an insert is performed.)
+// - |To| = the new value of this key (If nil, a delete is performed.)
+//
+// It is invalid for |From| and |To| to be both be nil.
+type indexEdit interface {
+	leftEdit() *tree.Diff
+	rightEdit() *tree.Diff
+}
+
+// cellWiseMergeEdit implements indexEdit. It resets the left and updates the
+// right to the merged value.
+type cellWiseMergeEdit struct {
+	left   tree.Diff
+	right  tree.Diff
+	merged tree.Diff
+}
+
+var _ indexEdit = cellWiseMergeEdit{}
+
+func (m cellWiseMergeEdit) leftEdit() *tree.Diff {
+	// Reset left
+	return &tree.Diff{
+		Key:  m.left.Key,
+		From: m.left.To,
+		To:   m.left.From,
+	}
+}
+
+func (m cellWiseMergeEdit) rightEdit() *tree.Diff {
+	// Update right to merged val
+	return &tree.Diff{
+		Key:  m.merged.Key,
+		From: m.right.To,
+		To:   m.merged.To,
+	}
+}
+
+// conflictEdit implements indexEdit and it resets the right value.
+type conflictEdit struct {
+	right tree.Diff
+}
+
+var _ indexEdit = conflictEdit{}
+
+func (c conflictEdit) leftEdit() *tree.Diff {
+	// Noop left
+	return nil
+}
+
+func (c conflictEdit) rightEdit() *tree.Diff {
+	// Reset right
+	return &tree.Diff{
+		Key:  c.right.Key,
+		From: c.right.To,
+		To:   c.right.From,
+	}
+}
+
+type confVals struct {
+	key      val.Tuple
+	ourVal   val.Tuple
+	theirVal val.Tuple
+	baseVal  val.Tuple
+}
+
+// mergeProllySecondaryIndexes merges the secondary indexes of the given |tbl|,
+// |mergeTbl|, and |ancTbl|. It stores the merged indexes into |tableToUpdate|
+// and returns its updated value.
+func mergeProllySecondaryIndexes(ctx context.Context, vrw types.ValueReadWriter, postMergeSchema, rootSch, mergeSch, ancSch schema.Schema, mergedData durable.Index, tbl, mergeTbl, ancTbl, tableToUpdate *doltdb.Table) (*doltdb.Table, error) {
+	rootSet, err := tbl.GetIndexSet(ctx)
+	if err != nil {
+		return nil, err
+	}
+	mergeSet, err := mergeTbl.GetIndexSet(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ancSet, err := ancTbl.GetIndexSet(ctx)
+	if err != nil {
+		return nil, err
+	}
+	mergedSet, err := mergeProllyIndexSets(ctx, vrw, postMergeSchema, rootSch, mergeSch, ancSch, mergedData, rootSet, mergeSet, ancSet)
+	if err != nil {
+		return nil, err
+	}
+	updatedTbl, err := tableToUpdate.SetIndexSet(ctx, mergedSet)
+	if err != nil {
+		return nil, err
+	}
+	return updatedTbl, nil
+}
+
+// mergeProllyIndexSets merges the |root|, |merge|, and |anc| index sets based
+// on the provided |postMergeSchema|. It returns the merged index set.
+func mergeProllyIndexSets(ctx context.Context, vrw types.ValueReadWriter, postMergeSchema, rootSch, mergeSch, ancSch schema.Schema, mergedData durable.Index, root, merge, anc durable.IndexSet) (durable.IndexSet, error) {
+	mergedIndexSet := durable.NewIndexSet(ctx, vrw)
+
+	tryGetIdx := func(sch schema.Schema, iS durable.IndexSet, indexName string) (idx durable.Index, ok bool, err error) {
+		ok = sch.Indexes().Contains(indexName)
+		if ok {
+			idx, err = iS.GetIndex(ctx, sch, indexName)
+			if err != nil {
+				return nil, false, err
+			}
+			return idx, true, nil
+		}
+		return nil, false, nil
+	}
+
+	// Based on the indexes in the post merge schema, merge the root, merge,
+	// and ancestor indexes.
+	for _, index := range postMergeSchema.Indexes().AllIndexes() {
+
+		rootI, rootOK, err := tryGetIdx(rootSch, root, index.Name())
+		if err != nil {
+			return nil, err
+		}
+		mergeI, mergeOK, err := tryGetIdx(mergeSch, merge, index.Name())
+		if err != nil {
+			return nil, err
+		}
+		ancI, ancOK, err := tryGetIdx(ancSch, anc, index.Name())
+		if err != nil {
+			return nil, err
+		}
+
+		mergedIndex, err := func() (durable.Index, error) {
+			if !rootOK || !mergeOK || !ancOK {
+				mergedIndex, err := creation.BuildSecondaryProllyIndex(ctx, vrw, postMergeSchema, index, durable.ProllyMapFromIndex(mergedData))
+				if err != nil {
+					return nil, err
+				}
+				return mergedIndex, nil
+			}
+
+			left := durable.ProllyMapFromIndex(rootI)
+			right := durable.ProllyMapFromIndex(mergeI)
+			base := durable.ProllyMapFromIndex(ancI)
+
+			var collision = false
+			merged, err := prolly.MergeMaps(ctx, left, right, base, func(left, right tree.Diff) (tree.Diff, bool) {
+				collision = true
+				return tree.Diff{}, true
+			})
+			if err != nil {
+				return nil, err
+			}
+			if collision {
+				return nil, errors.New("collisions not implemented")
+			}
+			return durable.IndexFromProllyMap(merged), nil
+		}()
+		if err != nil {
+			return nil, err
+		}
+
+		mergedIndexSet, err = mergedIndexSet.PutIndex(ctx, index.Name(), mergedIndex)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return mergedIndexSet, nil
+}
+
+// Given cellWiseMergeEdit's sent on |cellWiseChan|, update the secondary indexes in
+// |rootIndexSet| and |mergeIndexSet| such that when the index sets are merged,
+// they produce entries consistent with the cell-wise merges. The updated
+// |rootIndexSet| and |mergeIndexSet| are returned.
+func updateProllySecondaryIndexes(
+	ctx context.Context,
+	cellWiseChan chan indexEdit,
+	rootSchema, mergeSchema schema.Schema,
+	tbl, mergeTbl *doltdb.Table,
+	rootIndexSet, mergeIndexSet durable.IndexSet) (durable.IndexSet, durable.IndexSet, error) {
+
+	rootIdxs, err := getMutableSecondaryIdxs(ctx, rootSchema, tbl)
+	if err != nil {
+		return nil, nil, err
+	}
+	mergeIdxs, err := getMutableSecondaryIdxs(ctx, mergeSchema, mergeTbl)
+	if err != nil {
+		return nil, nil, err
+	}
+
+OUTER:
+	for {
+		select {
+		case e, ok := <-cellWiseChan:
+			if !ok {
+				break OUTER
+			}
+			// See cellWiseMergeEdit and conflictEdit for implementations of leftEdit and rightEdit
+			if edit := e.leftEdit(); edit != nil {
+				for _, idx := range rootIdxs {
+					err := applyEdit(ctx, idx, edit)
+					if err != nil {
+						return nil, nil, err
+					}
+				}
+			}
+			if edit := e.rightEdit(); edit != nil {
+				for _, idx := range mergeIdxs {
+					err := applyEdit(ctx, idx, edit)
+					if err != nil {
+						return nil, nil, err
+					}
+				}
+			}
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		}
+	}
+
+	persistIndexMuts := func(indexSet durable.IndexSet, idxs []MutableSecondaryIdx) (durable.IndexSet, error) {
+		for _, idx := range idxs {
+			m, err := idx.Map(ctx)
+			if err != nil {
+				return nil, err
+			}
+			indexSet, err = indexSet.PutIndex(ctx, idx.Name, durable.IndexFromProllyMap(m))
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		return indexSet, nil
+	}
+
+	updatedRootIndexSet, err := persistIndexMuts(rootIndexSet, rootIdxs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	updatedMergeIndexSet, err := persistIndexMuts(mergeIndexSet, mergeIdxs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return updatedRootIndexSet, updatedMergeIndexSet, nil
+}
+
+// getMutableSecondaryIdxs returns a MutableSecondaryIdx for each secondary index
+// defined in |schema| and |tbl|.
+func getMutableSecondaryIdxs(ctx context.Context, schema schema.Schema, tbl *doltdb.Table) ([]MutableSecondaryIdx, error) {
+	indexSet, err := tbl.GetIndexSet(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	mods := make([]MutableSecondaryIdx, schema.Indexes().Count())
+	for i, index := range schema.Indexes().AllIndexes() {
+		idx, err := indexSet.GetIndex(ctx, schema, index.Name())
+		if err != nil {
+			return nil, err
+		}
+		m := durable.ProllyMapFromIndex(idx)
+
+		mods[i] = NewMutableSecondaryIdx(m, schema, index, m.Pool())
+	}
+
+	return mods, nil
+}
+
+// applyEdit applies |edit| to |idx|. If |len(edit.To)| == 0, then action is
+// a delete, if |len(edit.From)| == 0 then it is an insert, otherwise it is an
+// update.
+func applyEdit(ctx context.Context, idx MutableSecondaryIdx, edit *tree.Diff) error {
+	if len(edit.From) == 0 {
+		err := idx.InsertEntry(ctx, val.Tuple(edit.Key), val.Tuple(edit.To))
+		if err != nil {
+			return err
+		}
+	} else if len(edit.To) == 0 {
+		err := idx.DeleteEntry(ctx, val.Tuple(edit.Key), val.Tuple(edit.From))
+		if err != nil {
+			return err
+		}
+	} else {
+		err := idx.UpdateEntry(ctx, val.Tuple(edit.Key), val.Tuple(edit.From), val.Tuple(edit.To))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/go/libraries/doltcore/merge/merge_test.go
+++ b/go/libraries/doltcore/merge/merge_test.go
@@ -575,7 +575,12 @@ func setupNomsMergeTest(t *testing.T) (types.ValueReadWriter, *doltdb.RootValue,
 	mergeTbl, err = editor.RebuildAllIndexes(context.Background(), mergeTbl, editor.TestEditorOptions(vrw))
 	require.NoError(t, err)
 
-	root, mergeRoot, ancRoot := buildLeftRightAncCommitsAndBranches(t, ddb, tbl, updatedTbl, mergeTbl)
+	ancTable, err := doltdb.NewNomsTable(context.Background(), vrw, sch, initialRows, nil, nil)
+	require.NoError(t, err)
+	ancTable, err = editor.RebuildAllIndexes(context.Background(), ancTable, editor.TestEditorOptions(vrw))
+	require.NoError(t, err)
+
+	root, mergeRoot, ancRoot := buildLeftRightAncCommitsAndBranches(t, ddb, updatedTbl, mergeTbl, ancTable)
 
 	return vrw, root, mergeRoot, ancRoot, expectedRows, expectedConflicts, calcExpectedStats(t)
 }

--- a/go/libraries/doltcore/merge/mutable_secondary_index.go
+++ b/go/libraries/doltcore/merge/mutable_secondary_index.go
@@ -25,8 +25,8 @@ import (
 )
 
 // MutableSecondaryIdx wraps a prolly.MutableMap of a secondary table index. It
-// provides an UpdateEntry function which can be used to update an entry in the
-// secondary index given a modification to a row.
+// provides the InsertEntry, UpdateEntry, and DeleteEntry functions which can be
+// used to modify the index based on a modification to corresponding primary row.
 type MutableSecondaryIdx struct {
 	Name     string
 	mut      prolly.MutableMap
@@ -49,6 +49,17 @@ func NewMutableSecondaryIdx(m prolly.Map, sch schema.Schema, index schema.Index,
 	}
 }
 
+// InsertEntry inserts a secondary index entry given the key and new value
+// of the primary row.
+func (m MutableSecondaryIdx) InsertEntry(ctx context.Context, key, newValue val.Tuple) error {
+	newKey := m.mapKeyValue(key, newValue)
+	err := m.mut.Put(ctx, newKey, val.EmptyTuple)
+	if err != nil {
+		return nil
+	}
+	return nil
+}
+
 // UpdateEntry modifies the corresponding secondary index entry given the key
 // and curr/new values of the primary row.
 func (m MutableSecondaryIdx) UpdateEntry(ctx context.Context, key, currValue, newValue val.Tuple) error {
@@ -64,6 +75,16 @@ func (m MutableSecondaryIdx) UpdateEntry(ctx context.Context, key, currValue, ne
 		return nil
 	}
 
+	return nil
+}
+
+// DeleteEntry deletes a secondary index entry given they key and value of the primary row.
+func (m MutableSecondaryIdx) DeleteEntry(ctx context.Context, key val.Tuple, value val.Tuple) error {
+	currKey := m.mapKeyValue(key, value)
+	err := m.mut.Delete(ctx, currKey)
+	if err != nil {
+		return nil
+	}
 	return nil
 }
 

--- a/go/libraries/doltcore/sqle/dtables/table_of_tables_in_conflict.go
+++ b/go/libraries/doltcore/sqle/dtables/table_of_tables_in_conflict.go
@@ -136,7 +136,7 @@ func (dt *TableOfTablesInConflict) Partitions(ctx *sql.Context) (sql.PartitionIt
 				return nil, err
 			}
 
-			partitions = append(partitions, &tableInConflict{tblName, m.Len(), false, schemas})
+			partitions = append(partitions, &tableInConflict{tblName, m.Count(), false, schemas})
 		}
 	}
 

--- a/go/store/prolly/conflicts_map.go
+++ b/go/store/prolly/conflicts_map.go
@@ -16,6 +16,9 @@ package prolly
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"strings"
 
 	"github.com/dolthub/dolt/go/store/prolly/message"
 
@@ -49,9 +52,9 @@ type ConflictMap struct {
 	baseDesc  val.TupleDesc
 }
 
-func NewConflictMap(ns tree.NodeStore, key, ours, theirs, base val.TupleDesc) ConflictMap {
+func NewConflictMap(root tree.Node, ns tree.NodeStore, key, ours, theirs, base val.TupleDesc) ConflictMap {
 	conflicts := orderedTree[val.Tuple, Conflict, val.TupleDesc]{
-		root:  newEmptyMapNode(ns.Pool()),
+		root:  root,
 		ns:    ns,
 		order: key,
 	}
@@ -62,6 +65,10 @@ func NewConflictMap(ns tree.NodeStore, key, ours, theirs, base val.TupleDesc) Co
 		theirDesc: theirs,
 		baseDesc:  base,
 	}
+}
+
+func NewEmptyConflictMap(ns tree.NodeStore, key, ours, theirs, base val.TupleDesc) ConflictMap {
+	return NewConflictMap(newEmptyMapNode(ns.Pool()), ns, key, ours, theirs, base)
 }
 
 func (c ConflictMap) Count() int {
@@ -156,4 +163,50 @@ func (wr ConflictEditor) Flush(ctx context.Context) (ConflictMap, error) {
 		theirDesc: wr.theirDesc,
 		baseDesc:  wr.baseDesc,
 	}, nil
+}
+
+// ConflictDebugFormat formats a ConflictMap.
+func ConflictDebugFormat(ctx context.Context, m ConflictMap) (string, error) {
+	kd, ourVD, theirVD, baseVD := m.Descriptors()
+	iter, err := m.IterAll(ctx)
+	if err != nil {
+		return "", err
+	}
+	c := m.Count()
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Prolly Map (count: %d) {\n", c))
+	for {
+		k, v, err := iter.Next(ctx)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", err
+		}
+
+		sb.WriteString("\t")
+		sb.WriteString(kd.Format(k))
+		sb.WriteString(": ")
+		if len(v.OurValue()) == 0 {
+			sb.WriteString("NULL")
+		} else {
+			sb.WriteString(ourVD.Format(v.OurValue()))
+		}
+		sb.WriteString(", ")
+		if len(v.TheirValue()) == 0 {
+			sb.WriteString("NULL")
+		} else {
+			sb.WriteString(theirVD.Format(v.TheirValue()))
+		}
+		sb.WriteString(", ")
+		if len(v.BaseValue()) == 0 {
+			sb.WriteString("NULL")
+		} else {
+			sb.WriteString(baseVD.Format(v.BaseValue()))
+		}
+		sb.WriteString(",\n")
+	}
+	sb.WriteString("}")
+	return sb.String(), nil
 }

--- a/go/store/prolly/shim.go
+++ b/go/store/prolly/shim.go
@@ -35,12 +35,25 @@ func ValueFromMap(m Map) types.Value {
 	return tree.ValueFromNode(m.tuples.root)
 }
 
+func ValueFromConflictMap(m ConflictMap) types.Value {
+	return tree.ValueFromNode(m.conflicts.root)
+}
+
 func MapFromValue(v types.Value, sch schema.Schema, vrw types.ValueReadWriter) Map {
 	root := NodeFromValue(v)
 	kd := KeyDescriptorFromSchema(sch)
 	vd := ValueDescriptorFromSchema(sch)
 	ns := tree.NewNodeStore(ChunkStoreFromVRW(vrw))
 	return NewMap(root, ns, kd, vd)
+}
+
+func ConflictMapFromValue(v types.Value, ourSchema, theirSchema, baseSchema schema.Schema, vrw types.ValueReadWriter) ConflictMap {
+	root := NodeFromValue(v)
+	kd, ourVD := MapDescriptorsFromScheam(ourSchema)
+	theirVD := ValueDescriptorFromSchema(theirSchema)
+	baseVD := ValueDescriptorFromSchema(baseSchema)
+	ns := tree.NewNodeStore(ChunkStoreFromVRW(vrw))
+	return NewConflictMap(root, ns, kd, ourVD, theirVD, baseVD)
 }
 
 func ChunkStoreFromVRW(vrw types.ValueReadWriter) chunks.ChunkStore {


### PR DESCRIPTION
## Summary
- New storage format passes `merge.bats` after this PR except on one test which relies on `MergeStats`. MergeStats is a TODO.

- Adds and implements `durable.ConflictIndex`. 
- Adds conflict handling logic to `mergeTableData`. 
- Fixes a new storage format bug that occurs when the same two tables are added in left and right.
- Moves secondary index merges into its own file for clarity.

## Updating secondary indexes when a conflict occurs
When a conflict occurs, we also need to update the secondary indexes so that the left value's index entires are kept post-merge. The edit simply resets the right value.

Resetting values is the inverse of the original operation (Update -> Update, Insert -> Delete, Delete -> Insert). Previously, MutableSecondaryIndex only supported the Update operation, but with conflicts we needed to add all three. In order to send these edits over a single channel to the goroutine that processes these index updates, we added the interface `indexEdit`.

There are two implementations of `indexEdit`: a `conflictEdit` and a `cellWiseMergeEdit`. `conflictEdit` simply resets the right value. `cellWiseMergeEdit` resets the left value and updates the right value to the cell-wise merge result.