### PR TITLE
dolt reset --hard clears any merge state

### DIFF
--- a/go/libraries/doltcore/env/actions/reset.go
+++ b/go/libraries/doltcore/env/actions/reset.go
@@ -107,7 +107,7 @@ func ResetHard(ctx context.Context, dEnv *env.DoltEnv, cSpecStr string, roots do
 		return err
 	}
 
-	err = dEnv.UpdateWorkingSet(ctx, ws.WithWorkingRoot(roots.Working).WithStagedRoot(roots.Staged))
+	err = dEnv.UpdateWorkingSet(ctx, ws.WithWorkingRoot(roots.Working).WithStagedRoot(roots.Staged).ClearMerge())
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_reset.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_reset.go
@@ -97,7 +97,7 @@ func DoDoltReset(ctx *sql.Context, args []string) (int, error) {
 		if err != nil {
 			return 1, err
 		}
-		err = dSess.SetWorkingSet(ctx, dbName, ws.WithWorkingRoot(roots.Working).WithStagedRoot(roots.Staged))
+		err = dSess.SetWorkingSet(ctx, dbName, ws.WithWorkingRoot(roots.Working).WithStagedRoot(roots.Staged).ClearMerge())
 		if err != nil {
 			return 1, err
 		}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -606,6 +606,14 @@ func TestDoltMerge(t *testing.T) {
 	}
 }
 
+func TestDoltReset(t *testing.T) {
+	skipNewFormat(t)
+	harness := newDoltHarness(t)
+	for _, script := range DoltReset {
+		enginetest.TestScript(t, harness, script)
+	}
+}
+
 // TestSingleTransactionScript is a convenience method for debugging a single transaction test. Unskip and set to the
 // desired test.
 func TestSingleTransactionScript(t *testing.T) {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -970,6 +970,62 @@ var DoltMerge = []enginetest.ScriptTest{
 	},
 }
 
+var DoltReset = []enginetest.ScriptTest{
+	{
+		Name: "CALL DOLT_RESET('--hard') should reset the merge state after uncommitted merge",
+		SetUpScript: []string{
+			"CREATE TABLE test1 (pk int NOT NULL, c1 int, c2 int, PRIMARY KEY (pk));",
+			"INSERT INTO test1 values (0,1,1);",
+			"CALL DOLT_COMMIT('-am', 'added table')",
+
+			"CALL DOLT_CHECKOUT('-b', 'merge_branch');",
+			"UPDATE test1 set c1 = 2;",
+			"CALL DOLT_COMMIT('-am', 'update pk 0 = 2,1 to test1');",
+
+			"CALL DOLT_CHECKOUT('main');",
+			"UPDATE test1 set c2 = 2;",
+			"CALL DOLT_COMMIT('-am', 'update pk 0 = 1,2 to test1');",
+
+			"CALL DOLT_MERGE('merge_branch');",
+
+			"CALL DOLT_RESET('--hard');",
+		},
+		Assertions: []enginetest.ScriptTestAssertion{
+			{
+				Query:          "CALL DOLT_MERGE('--abort')",
+				ExpectedErrStr: "fatal: There is no merge to abort",
+			},
+		},
+	},
+	// TODO: The following test case doesn't work. We need the setup the conflicted state in SetUpScript, but
+	// unfortunately, DOLT_MERGE produces an error when a conflict occurs failing the test.
+	/*{
+		Name: "CALL DOLT_RESET('--hard') should reset the merge state after conflicting merge",
+		SetUpScript: []string{
+			"CREATE TABLE test1 (pk int NOT NULL, c1 int, c2 int, PRIMARY KEY (pk));",
+			"INSERT INTO test1 values (0,1,1);",
+			"CALL DOLT_COMMIT('-am', 'added table')",
+
+			"CALL DOLT_CHECKOUT('-b', 'merge_branch');",
+			"UPDATE test1 set c1 = 2, c2 = 2;",
+			"CALL DOLT_COMMIT('-am', 'update pk 0 = 2,2 to test1');",
+
+			"CALL DOLT_CHECKOUT('main');",
+			"UPDATE test1 set c1 = 3, c2 = 3;",
+			"CALL DOLT_COMMIT('-am', 'update pk 0 = 3,3 to test1');",
+
+			"CALL DOLT_MERGE('merge_branch');",
+			"CALL DOLT_RESET('--hard');",
+		},
+		Assertions: []enginetest.ScriptTestAssertion{
+			{
+				Query:          "CALL DOLT_MERGE('--abort')",
+				ExpectedErrStr: "fatal: There is no merge to abort",
+			},
+		},
+	}, */
+}
+
 var DiffSystemTableScriptTests = []enginetest.ScriptTest{
 	{
 		Name: "base case: added rows",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -997,11 +997,10 @@ var DoltReset = []enginetest.ScriptTest{
 			},
 		},
 	},
-	// TODO: The following test case doesn't work. We need the setup the conflicted state in SetUpScript, but
-	// unfortunately, DOLT_MERGE produces an error when a conflict occurs failing the test.
-	/*{
+	{
 		Name: "CALL DOLT_RESET('--hard') should reset the merge state after conflicting merge",
 		SetUpScript: []string{
+			"SET dolt_allow_commit_conflicts = on",
 			"CREATE TABLE test1 (pk int NOT NULL, c1 int, c2 int, PRIMARY KEY (pk));",
 			"INSERT INTO test1 values (0,1,1);",
 			"CALL DOLT_COMMIT('-am', 'added table')",
@@ -1023,7 +1022,7 @@ var DoltReset = []enginetest.ScriptTest{
 				ExpectedErrStr: "fatal: There is no merge to abort",
 			},
 		},
-	}, */
+	},
 }
 
 var DiffSystemTableScriptTests = []enginetest.ScriptTest{

--- a/integration-tests/bats/reset.bats
+++ b/integration-tests/bats/reset.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+load $BATS_TEST_DIRNAME/helper/common.bash
+
+setup() {
+    setup_common
+}
+
+teardown() {
+    assert_feature_version
+    teardown_common
+}
+
+setup_ancestor() {
+    dolt sql <<SQL
+CREATE TABLE test1 (
+  pk int NOT NULL,
+  c1 int,
+  c2 int,
+  PRIMARY KEY (pk)
+);
+INSERT INTO test1 values (0,1,1);
+SQL
+
+    dolt add test1
+
+    dolt add .
+    dolt commit -m "added tables"
+}
+
+merge_without_conflicts() {
+    setup_ancestor
+
+    dolt checkout -b merge_branch
+    dolt SQL -q "UPDATE test1 set c1 = 2;"
+    dolt add test1
+    dolt commit -m "update pk 0 = 2,1 to test1"
+
+    dolt checkout main
+    dolt SQL -q "UPDATE test1 set c2 = 2;"
+    dolt add test1
+    dolt commit -m "update pk 0 = 1,2 to test1"
+
+    run dolt merge merge_branch
+}
+
+merge_with_conflicts() {
+    setup_ancestor
+
+    dolt checkout -b merge_branch
+    dolt SQL -q "UPDATE test1 set c1 = 2, c2 = 2;"
+    dolt add test1
+    dolt commit -m "update pk 0 = 2,2 to test1"
+
+    dolt checkout main
+    dolt SQL -q "UPDATE test1 set c2 = 3, c2 = 3;"
+    dolt add test1
+    dolt commit -m "update pk 0 = 3,3 to test1"
+
+    run dolt merge merge_branch
+}
+
+@test "reset: git reset --hard should clear an uncommitted merge state" {
+    merge_without_conflicts
+
+    run dolt reset --hard
+    [ $status -eq 0 ]
+
+    run dolt status
+    [[ "$output" =~ "nothing to commit, working tree clean" ]]
+
+    run dolt merge --abort
+    [[ "$output" =~ "fatal: There is no merge to abort" ]]
+}
+
+@test "reset: git reset --hard should clear a conflicted merge state" {
+    merge_with_conflicts
+
+    run dolt reset --hard
+    [ $status -eq 0 ]
+
+    run dolt status
+    [[ "$output" =~ "nothing to commit, working tree clean" ]]
+
+    run dolt merge --abort
+    [[ "$output" =~ "fatal: There is no merge to abort" ]]
+}

--- a/integration-tests/bats/reset.bats
+++ b/integration-tests/bats/reset.bats
@@ -21,8 +21,6 @@ CREATE TABLE test1 (
 INSERT INTO test1 values (0,1,1);
 SQL
 
-    dolt add test1
-
     dolt add .
     dolt commit -m "added tables"
 }
@@ -59,7 +57,7 @@ merge_with_conflicts() {
     run dolt merge merge_branch
 }
 
-@test "reset: git reset --hard should clear an uncommitted merge state" {
+@test "reset: dolt reset --hard should clear an uncommitted merge state" {
     merge_without_conflicts
 
     run dolt reset --hard
@@ -72,7 +70,7 @@ merge_with_conflicts() {
     [[ "$output" =~ "fatal: There is no merge to abort" ]]
 }
 
-@test "reset: git reset --hard should clear a conflicted merge state" {
+@test "reset: dolt reset --hard should clear a conflicted merge state" {
     merge_with_conflicts
 
     run dolt reset --hard


### PR DESCRIPTION
Closes #3371 

When `dolt reset --hard` is called, it now clears the merge state if set. 