### PR TITLE
Only skip engine, not inverse

### DIFF
--- a/.github/workflows/ci-go-tests.yaml
+++ b/.github/workflows/ci-go-tests.yaml
@@ -43,7 +43,7 @@ jobs:
           echo "Testing Package: ${file_arr[$i]}"
           if [ "$MATRIX_OS" == 'ubuntu-18.04' ]
           then
-            if [[ "${file_arr[$i]}" == *enginetest* ]]; then
+            if [[ "${file_arr[$i]}" != *enginetest* ]]; then
               go test -timeout 45m -race "${file_arr[$i]}"
             else
               echo "skipping enginetests for -race"


### PR DESCRIPTION
Enginetest -race has it's own CI job that is only run on merge main. As part of that PR, I tried to skip enginetest -race during routine PR tests. I mistakenly did the opposite, running only enginetest -race on ubuntu.