### PR TITLE
[no-release-notes] go/store/prolly/tree: stripe-locked node store cache

### DIFF
--- a/go/store/prolly/benchmark/benchmark_read_test.go
+++ b/go/store/prolly/benchmark/benchmark_read_test.go
@@ -38,7 +38,19 @@ func BenchmarkMapGet(b *testing.B) {
 	})
 }
 
-func BenchmarkMapGetParallel(b *testing.B) {
+func BenchmarkStepMapGet(b *testing.B) {
+	b.Skip()
+	step := uint64(100_000)
+	for sz := step; sz < step*20; sz += step {
+		nm := fmt.Sprintf("benchmark maps %d", sz)
+		b.Run(nm, func(b *testing.B) {
+			benchmarkProllyMapGet(b, sz)
+			benchmarkTypesMapGet(b, sz)
+		})
+	}
+}
+
+func BenchmarkParallelMapGet(b *testing.B) {
 	b.Run("benchmark maps 10k", func(b *testing.B) {
 		benchmarkProllyMapGetParallel(b, 10_000)
 		benchmarkTypesMapGetParallel(b, 10_000)
@@ -61,11 +73,11 @@ func BenchmarkNomsGetLarge(b *testing.B) {
 	benchmarkTypesMapGet(b, 1_000_000)
 }
 
-func BenchmarkProllyGetLargeParallel(b *testing.B) {
+func BenchmarkProllyParallelGetLarge(b *testing.B) {
 	benchmarkProllyMapGetParallel(b, 1_000_000)
 }
 
-func BenchmarkNomsGetLargeParallel(b *testing.B) {
+func BenchmarkNomsParallelGetLarge(b *testing.B) {
 	benchmarkTypesMapGetParallel(b, 1_000_000)
 }
 

--- a/go/store/prolly/benchmark/benchmark_read_test.go
+++ b/go/store/prolly/benchmark/benchmark_read_test.go
@@ -65,6 +65,18 @@ func BenchmarkParallelMapGet(b *testing.B) {
 	})
 }
 
+func BenchmarkStepParallelMapGet(b *testing.B) {
+	b.Skip()
+	step := uint64(100_000)
+	for sz := step; sz < step*20; sz += step {
+		nm := fmt.Sprintf("benchmark maps parallel %d", sz)
+		b.Run(nm, func(b *testing.B) {
+			benchmarkProllyMapGetParallel(b, sz)
+			benchmarkTypesMapGetParallel(b, sz)
+		})
+	}
+}
+
 func BenchmarkProllyGetLarge(b *testing.B) {
 	benchmarkProllyMapGet(b, 1_000_000)
 }

--- a/go/store/prolly/benchmark/benchmark_read_test.go
+++ b/go/store/prolly/benchmark/benchmark_read_test.go
@@ -61,6 +61,14 @@ func BenchmarkNomsGetLarge(b *testing.B) {
 	benchmarkTypesMapGet(b, 1_000_000)
 }
 
+func BenchmarkProllyGetLargeParallel(b *testing.B) {
+	benchmarkProllyMapGetParallel(b, 1_000_000)
+}
+
+func BenchmarkNomsGetLargeParallel(b *testing.B) {
+	benchmarkTypesMapGetParallel(b, 1_000_000)
+}
+
 func benchmarkProllyMapGet(b *testing.B, size uint64) {
 	bench := generateProllyBench(b, size)
 	b.Run(fmt.Sprintf("benchmark prolly map %d", size), func(b *testing.B) {
@@ -94,8 +102,9 @@ func benchmarkProllyMapGetParallel(b *testing.B, size uint64) {
 	b.Run(fmt.Sprintf("benchmark prolly map %d", size), func(b *testing.B) {
 		b.RunParallel(func(b *testing.PB) {
 			ctx := context.Background()
+			rnd := rand.NewSource(0)
 			for b.Next() {
-				idx := rand.Uint64() % uint64(len(bench.tups))
+				idx := int(rnd.Int63()) % len(bench.tups)
 				key := bench.tups[idx][0]
 				_ = bench.m.Get(ctx, key, func(_, _ val.Tuple) (e error) {
 					return
@@ -111,8 +120,9 @@ func benchmarkTypesMapGetParallel(b *testing.B, size uint64) {
 	b.Run(fmt.Sprintf("benchmark types map %d", size), func(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			ctx := context.Background()
+			rnd := rand.NewSource(0)
 			for pb.Next() {
-				idx := rand.Uint64() % uint64(len(bench.tups))
+				idx := int(rnd.Int63()) % len(bench.tups)
 				_, _, _ = bench.m.MaybeGet(ctx, bench.tups[idx][0])
 			}
 		})

--- a/go/store/prolly/benchmark/benchmark_write_test.go
+++ b/go/store/prolly/benchmark/benchmark_write_test.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"math/rand"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkMapUpdate(b *testing.B) {
@@ -38,11 +36,11 @@ func BenchmarkMapUpdate(b *testing.B) {
 }
 
 func BenchmarkProllySmallWrites(b *testing.B) {
-	benchmarkProllyMapUpdate(b, 10_000, 10)
+	benchmarkProllyMapUpdate(b, 10_000, 1)
 }
 
 func BenchmarkTypesSmallWrites(b *testing.B) {
-	benchmarkTypesMapUpdate(b, 10_000, 10)
+	benchmarkTypesMapUpdate(b, 10_000, 1)
 }
 
 func BenchmarkProllyMediumWrites(b *testing.B) {
@@ -72,8 +70,7 @@ func benchmarkProllyMapUpdate(b *testing.B, size, k uint64) {
 				idx = rand.Uint64() % uint64(len(bench.tups))
 				value := bench.tups[idx][0]
 
-				err := mut.Put(ctx, key, value)
-				require.NoError(b, err)
+				_ = mut.Put(ctx, key, value)
 			}
 			_, _ = mut.Map(ctx)
 		}

--- a/go/store/prolly/message/prolly_map.go
+++ b/go/store/prolly/message/prolly_map.go
@@ -203,7 +203,7 @@ func estimateProllyMapSize(keys, values [][]byte, subtrees []uint64) (keySz, val
 	bufSz += len(keys)*2 + len(values)*2 // offsets
 	bufSz += 8 + 1 + 1 + 1               // metadata
 	bufSz += 72                          // vtable (approx)
-	bufSz += 100						 // padding?
+	bufSz += 100                         // padding?
 
 	return
 }

--- a/go/store/prolly/message/prolly_map.go
+++ b/go/store/prolly/message/prolly_map.go
@@ -197,11 +197,13 @@ func estimateProllyMapSize(keys, values [][]byte, subtrees []uint64) (keySz, val
 		panic(fmt.Sprintf("value vector exceeds Size limit ( %d > %d )", valSz, MaxVectorOffset))
 	}
 
+	// todo(andy): better estimates
 	bufSz += keySz + valSz               // tuples
 	bufSz += refCntSz                    // subtree counts
 	bufSz += len(keys)*2 + len(values)*2 // offsets
 	bufSz += 8 + 1 + 1 + 1               // metadata
 	bufSz += 72                          // vtable (approx)
+	bufSz += 100						 // padding?
 
 	return
 }

--- a/go/store/prolly/message/serialize.go
+++ b/go/store/prolly/message/serialize.go
@@ -28,8 +28,8 @@ const (
 
 func getFlatbufferBuilder(pool pool.BuffPool, sz int) (b *fb.Builder) {
 	b = fb.NewBuilder(0)
-	buf := pool.Get(uint64(sz))
-	b.Bytes = buf[:0]
+	b.Bytes = pool.Get(uint64(sz))
+	b.Reset()
 	return
 }
 

--- a/go/store/prolly/mutable_map.go
+++ b/go/store/prolly/mutable_map.go
@@ -58,9 +58,6 @@ func (mut MutableMap) Map(ctx context.Context) (Map, error) {
 		return Map{}, err
 	}
 
-	// release buffer
-	mut.tuples.edits.Close()
-
 	return Map{
 		tuples: orderedTree[val.Tuple, val.Tuple, val.TupleDesc]{
 			root:  root,

--- a/go/store/prolly/mutable_map.go
+++ b/go/store/prolly/mutable_map.go
@@ -58,6 +58,9 @@ func (mut MutableMap) Map(ctx context.Context) (Map, error) {
 		return Map{}, err
 	}
 
+	// release buffer
+	mut.tuples.edits.Close()
+
 	return Map{
 		tuples: orderedTree[val.Tuple, val.Tuple, val.TupleDesc]{
 			root:  root,

--- a/go/store/prolly/tree/chunker.go
+++ b/go/store/prolly/tree/chunker.go
@@ -61,7 +61,6 @@ func newChunker[S message.Serializer](ctx context.Context, cur *Cursor, level in
 
 	splitter := defaultSplitterFactory(uint8(level % 256))
 	builder := newNodeBuilder(serializer, level)
-	builder.startNode()
 
 	sc := &chunker[S]{
 		cur:        cur,
@@ -324,7 +323,6 @@ func (tc *chunker[S]) handleChunkBoundary(ctx context.Context) error {
 	}
 
 	tc.splitter.Reset()
-	tc.builder.startNode()
 
 	return nil
 }

--- a/go/store/prolly/tree/chunker_test.go
+++ b/go/store/prolly/tree/chunker_test.go
@@ -71,9 +71,7 @@ func validateTreeItems(t *testing.T, ns NodeStore, nd Node, expected [][2]Item) 
 	i := 0
 	ctx := context.Background()
 	err := iterTree(ctx, ns, nd, func(actual Item) (err error) {
-		if !assert.Equal(t, expected[i/2][i%2], actual) {
-			panic("here")
-		}
+		assert.Equal(t, expected[i/2][i%2], actual)
 		i++
 		return
 	})

--- a/go/store/prolly/tree/node_cache.go
+++ b/go/store/prolly/tree/node_cache.go
@@ -1,0 +1,189 @@
+// Copyright 2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tree
+
+import (
+	"encoding/binary"
+	"fmt"
+	"sync"
+
+	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/hash"
+)
+
+const (
+	numStripes = 256
+)
+
+func newChunkCache(maxSize int) (c chunkCache) {
+	sz := maxSize / numStripes
+	for i := range c.stripes {
+		c.stripes[i] = newStripe(sz)
+	}
+	return
+}
+
+type chunkCache struct {
+	stripes [numStripes]*stripe
+}
+
+func (c chunkCache) get(addr hash.Hash) (chunks.Chunk, bool) {
+	return c.pickStripe(addr).get(addr)
+}
+
+func (c chunkCache) insert(ch chunks.Chunk) {
+	c.pickStripe(ch.Hash()).insert(ch)
+}
+
+func (c chunkCache) pickStripe(addr hash.Hash) *stripe {
+	i := binary.LittleEndian.Uint32(addr[:4]) % numStripes
+	return c.stripes[i]
+}
+
+type centry struct {
+	c    chunks.Chunk
+	i    int
+	prev *centry
+	next *centry
+}
+
+type stripe struct {
+	mu     *sync.Mutex
+	chunks map[hash.Hash]*centry
+	head   *centry
+	sz     int
+	maxSz  int
+	rev    int
+}
+
+func newStripe(maxSize int) *stripe {
+	return &stripe{
+		&sync.Mutex{},
+		make(map[hash.Hash]*centry),
+		nil,
+		0,
+		maxSize,
+		0,
+	}
+}
+
+func removeFromList(e *centry) {
+	e.prev.next = e.next
+	e.next.prev = e.prev
+	e.prev = e
+	e.next = e
+}
+
+func (s *stripe) moveToFront(e *centry) {
+	e.i = s.rev
+	s.rev++
+	if s.head == e {
+		return
+	}
+	if s.head != nil {
+		removeFromList(e)
+		e.next = s.head
+		e.prev = s.head.prev
+		s.head.prev = e
+		e.prev.next = e
+	}
+	s.head = e
+}
+
+func (s *stripe) get(h hash.Hash) (chunks.Chunk, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if e, ok := s.chunks[h]; ok {
+		s.moveToFront(e)
+		return e.c, true
+	} else {
+		return chunks.EmptyChunk, false
+	}
+}
+
+func (s *stripe) insert(c chunks.Chunk) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.addIfAbsent(c)
+}
+
+func (s *stripe) addIfAbsent(c chunks.Chunk) {
+	if e, ok := s.chunks[c.Hash()]; !ok {
+		e = &centry{c, 0, nil, nil}
+		e.next = e
+		e.prev = e
+		s.moveToFront(e)
+		s.chunks[c.Hash()] = e
+		s.sz += c.Size()
+		s.shrinkToMaxSz()
+	} else {
+		s.moveToFront(e)
+	}
+}
+
+func (s *stripe) shrinkToMaxSz() {
+	for s.sz > s.maxSz {
+		if s.head != nil {
+			t := s.head.prev
+			removeFromList(t)
+			if t == s.head {
+				s.head = nil
+			}
+			delete(s.chunks, t.c.Hash())
+			s.sz -= t.c.Size()
+		} else {
+			panic("cache is empty but cache Size is > than max Size")
+		}
+	}
+}
+
+func (s *stripe) sanityCheck() {
+	if s.head != nil {
+		p := s.head.next
+		i := 1
+		sz := s.head.c.Size()
+		lasti := s.head.i
+		for p != s.head {
+			i++
+			sz += p.c.Size()
+			if p.i >= lasti {
+				panic("encountered lru list entry with higher rev later in the list.")
+			}
+			p = p.next
+		}
+		if i != len(s.chunks) {
+			panic(fmt.Sprintf("cache lru list has different Size than cache.chunks. %d vs %d", i, len(s.chunks)))
+		}
+		if sz != s.sz {
+			panic("entries reachable from lru list have different Size than cache.sz.")
+		}
+		j := 1
+		p = s.head.prev
+		for p != s.head {
+			j++
+			p = p.prev
+		}
+		if j != i {
+			panic("length of list backwards is not equal to length of list forward")
+		}
+	} else {
+		if len(s.chunks) != 0 {
+			panic("lru list is empty but s.chunks is not")
+		}
+		if s.sz != 0 {
+			panic("lru list is empty but s.sz is not 0")
+		}
+	}
+}

--- a/go/store/skip/list.go
+++ b/go/store/skip/list.go
@@ -15,10 +15,11 @@
 package skip
 
 import (
-	"github.com/zeebo/xxh3"
 	"math"
 	"math/rand"
 	"sync"
+
+	"github.com/zeebo/xxh3"
 )
 
 const (

--- a/go/store/skip/list.go
+++ b/go/store/skip/list.go
@@ -17,7 +17,6 @@ package skip
 import (
 	"math"
 	"math/rand"
-	"sync"
 
 	"github.com/zeebo/xxh3"
 )
@@ -58,7 +57,7 @@ type skipNode struct {
 }
 
 func NewSkipList(cmp ValueCmp) *List {
-	nodes := getNodes()
+	nodes := make([]skipNode, 0, 8)
 
 	// initialize sentinel node
 	nodes = append(nodes, skipNode{
@@ -100,11 +99,6 @@ func (l *List) Truncate() {
 	s.prev = sentinelId
 	l.updateNode(s)
 	l.count = 0
-}
-
-func (l *List) Close() {
-	putNodes(l.nodes)
-	l.nodes = nil
 }
 
 func (l *List) Count() int {
@@ -381,20 +375,4 @@ func rollHeight(key []byte, salt uint64) (h uint8) {
 	}
 
 	return
-}
-
-var skipNodePool = sync.Pool{
-	New: func() any {
-		return make([]skipNode, 0, 128)
-	},
-}
-
-func getNodes() []skipNode {
-	return skipNodePool.Get().([]skipNode)
-}
-
-func putNodes(nodes []skipNode) {
-	if cap(nodes) == 128 {
-		skipNodePool.Put(nodes[:0])
-	}
 }


### PR DESCRIPTION
- Adds parallel benchmarks for `prolly.Map.Get()`
- Adds stripe-locked chunk cache to reduce lock-contention on `tree.NodeStore`
- Adds `sync.Pool` for `tree.nodeBuilder`
- Cleans up unneeded allocations on the write path