### PR TITLE
[no-release-notes] go/libraries/utils/pipeline: Fix racey finalization of a pipeline.

### DIFF
--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -666,14 +666,6 @@ func runMultiStatementMode(ctx *sql.Context, se *engine.SqlEngine, input io.Read
 				if err != nil {
 					return errhand.VerboseErrorFromError(err)
 				}
-				if err != nil {
-					verr := formatQueryError(fmt.Sprintf("error on line %d for query %s", scanner.statementStartLine, query), err)
-					cli.PrintErrln(verr.Verbose())
-					// If continueOnErr is set keep executing the remaining queries but print the error out anyway.
-					if !continueOnErr {
-						return err
-					}
-				}
 			}
 		}
 		query = ""


### PR DESCRIPTION
Before this change, when an initial stage function returned a non-nil err, it
would return non-nil, resulting in closing its output channel and leaving the
errgroup responsible for canceling the egCtx.

The next transform stage would read `nil, false` on its inCh. That stage would
forward the `nil` down the transform pipeline. If the inCh selects all resolved
down the transform pipeline before any of the `<- ctx.Done()` selects, then the
pipeline would see the exact same behavior for the error case as it would see
for an `io.EOF` being reached in the first stage.

Instead, transform stages in the pipeline should abort without forwarding data
if they see a closed input channel. In turn, input stages should forward one
last `nil` sentinel value to their output channel when the see an `io.EOF`
before they close the channel.