### PR TITLE
[no-release-notes] Changing Dolt Harness to track a MultiRepoEnv 

### DIFF
--- a/go/libraries/doltcore/dtestutils/environment.go
+++ b/go/libraries/doltcore/dtestutils/environment.go
@@ -28,20 +28,28 @@ import (
 )
 
 const (
-	TestHomeDir = "/user/bheni"
-	WorkingDir  = "/user/bheni/datasets/states"
+	TestHomeDirPrefix = "/user/dolt/"
+	WorkingDirPrefix  = "/user/dolt/datasets/"
 )
 
-func testHomeDirFunc() (string, error) {
-	return TestHomeDir, nil
+// CreateTestEnv creates a new DoltEnv suitable for testing. The CreateTestEnvWithName
+// function should generally be preferred over this method, especially when working
+// with tests using multiple databases within a MultiRepoEnv.
+func CreateTestEnv() *env.DoltEnv {
+	return CreateTestEnvWithName("test")
 }
 
-func CreateTestEnv() *env.DoltEnv {
+// CreateTestEnvWithName creates a new DoltEnv suitable for testing and uses
+// the specified name to distinguish it from other test envs. This function
+// should generally be preferred over CreateTestEnv, especially when working with
+// tests using multiple databases within a MultiRepoEnv.
+func CreateTestEnvWithName(envName string) *env.DoltEnv {
 	const name = "billy bob"
 	const email = "bigbillieb@fake.horse"
-	initialDirs := []string{TestHomeDir, WorkingDir}
-	fs := filesys.NewInMemFS(initialDirs, nil, WorkingDir)
-	dEnv := env.Load(context.Background(), testHomeDirFunc, fs, doltdb.InMemDoltDB, "test")
+	initialDirs := []string{TestHomeDirPrefix + envName, WorkingDirPrefix + envName}
+	homeDirFunc := func() (string, error) { return TestHomeDirPrefix + envName, nil }
+	fs := filesys.NewInMemFS(initialDirs, nil, WorkingDirPrefix+envName)
+	dEnv := env.Load(context.Background(), homeDirFunc, fs, doltdb.InMemDoltDB+envName, "test")
 	cfg, _ := dEnv.Config.GetConfig(env.GlobalConfig)
 	cfg.SetStrings(map[string]string{
 		env.UserNameKey:  name,

--- a/go/libraries/doltcore/env/multi_repo_env.go
+++ b/go/libraries/doltcore/env/multi_repo_env.go
@@ -69,6 +69,21 @@ func (mrEnv *MultiRepoEnv) AddEnv(name string, dEnv *DoltEnv) {
 	})
 }
 
+// AddOrReplaceEnvs adds the specified DoltEnv to this MultiRepoEnv, replacing
+// any existing environment in the MultiRepoEnv with the same name.
+func (mrEnv *MultiRepoEnv) AddOrReplaceEnv(name string, dEnv *DoltEnv) {
+	// TODO: Modeling NamedEnvs as a map could probably simplify this file
+	newNamedEnvs := make([]NamedEnv, 0, len(mrEnv.envs))
+	for _, namedEnv := range mrEnv.envs {
+		if namedEnv.name != name {
+			newNamedEnvs = append(newNamedEnvs, namedEnv)
+		}
+	}
+	newNamedEnvs = append(newNamedEnvs, NamedEnv{name: name, env: dEnv})
+
+	mrEnv.envs = newNamedEnvs
+}
+
 // GetEnv returns the env with the name given, or nil if no such env exists
 func (mrEnv *MultiRepoEnv) GetEnv(name string) *DoltEnv {
 	var found *DoltEnv

--- a/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
@@ -200,7 +200,7 @@ func (d *DoltHarness) NewDatabases(names ...string) []sql.Database {
 	d.databases = nil
 	d.databaseGlobalStates = nil
 	for _, name := range names {
-		dEnv := dtestutils.CreateTestEnv()
+		dEnv := dtestutils.CreateTestEnvWithName(name)
 
 		opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 		db := sqle.NewDatabase(name, dEnv.DbData(), opts)


### PR DESCRIPTION
DoltHarness was tracking a single DoltEnv for all databases, meaning the DoltDB, working set, etc were shared. After fixing a transaction initialization bug, that fix triggered the tests to start failing because of the DoltDB sharing. 

This change moves DoltHarness to use a MultiRepoEnv for tracking test databases, instead of a single DoltEnv.