### PR TITLE
Refactoring MultiRepoEnv to use a map to store envs by name

### DIFF
--- a/go/libraries/doltcore/dtestutils/testcommands/multienv.go
+++ b/go/libraries/doltcore/dtestutils/testcommands/multienv.go
@@ -72,7 +72,7 @@ func NewMultiRepoTestSetup(errhand func(args ...interface{})) *MultiRepoTestSetu
 	}
 
 	return &MultiRepoTestSetup{
-		MrEnv:   env.MultiRepoEnv{},
+		MrEnv:   env.NewMultiRepoEnv(),
 		Remotes: make(map[string]env.Remote),
 		DoltDBs: make(map[string]*doltdb.DoltDB, 0),
 		DbNames: make([]string, 0),

--- a/go/libraries/doltcore/env/multi_repo_env.go
+++ b/go/libraries/doltcore/env/multi_repo_env.go
@@ -47,6 +47,13 @@ type MultiRepoEnv struct {
 	cfg  config.ReadWriteConfig
 }
 
+// NewMultiRepoEnv returns a new MultiRepoEnv initialized and ready for use.
+func NewMultiRepoEnv() MultiRepoEnv {
+	return MultiRepoEnv{
+		envs: make(map[string]*DoltEnv),
+	}
+}
+
 func (mrEnv *MultiRepoEnv) FileSystem() filesys.Filesys {
 	return mrEnv.fs
 }

--- a/go/libraries/doltcore/env/multi_repo_env_test.go
+++ b/go/libraries/doltcore/env/multi_repo_env_test.go
@@ -107,11 +107,7 @@ func TestDoltEnvAsMultiEnv(t *testing.T) {
 	mrEnv, err := DoltEnvAsMultiEnv(context.Background(), dEnv)
 	require.NoError(t, err)
 	assert.Len(t, mrEnv.envs, 1)
-
-	for _, e := range mrEnv.envs {
-		assert.Equal(t, "test_name_123", e.name)
-		assert.Equal(t, dEnv, e.env)
-	}
+	assert.Equal(t, dEnv, mrEnv.envs["test_name_123"])
 }
 
 func TestDoltEnvAsMultiEnvWithMultipleRepos(t *testing.T) {
@@ -127,36 +123,9 @@ func TestDoltEnvAsMultiEnvWithMultipleRepos(t *testing.T) {
 	mrEnv, err := DoltEnvAsMultiEnv(context.Background(), dEnv)
 	require.NoError(t, err)
 	assert.Len(t, mrEnv.envs, 3)
-
-	type envCmp struct {
-		name    string
-		doltDir string
-	}
-
-	expected := []envCmp{
-		{
-			name:    "test_name_123",
-			doltDir: dEnv.GetDoltDir(),
-		},
-		{
-			name:    "abc",
-			doltDir: subEnv1.GetDoltDir(),
-		},
-		{
-			name:    "def",
-			doltDir: subEnv2.GetDoltDir(),
-		},
-	}
-
-	var actual []envCmp
-	for _, env := range mrEnv.envs {
-		actual = append(actual, envCmp{
-			name:    env.name,
-			doltDir: env.env.GetDoltDir(),
-		})
-	}
-
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, dEnv.GetDoltDir(), mrEnv.envs["test_name_123"].GetDoltDir())
+	assert.Equal(t, subEnv2.GetDoltDir(), mrEnv.envs["def"].GetDoltDir())
+	assert.Equal(t, subEnv1.GetDoltDir(), mrEnv.envs["abc"].GetDoltDir())
 }
 
 func initMultiEnv(t *testing.T, testName string, names []string) (string, HomeDirProvider, map[string]*DoltEnv) {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
@@ -284,7 +284,7 @@ func (d *DoltHarness) NewDatabases(names ...string) []sql.Database {
 		globalState := globalstate.NewGlobalStateStore()
 		d.databaseGlobalStates = append(d.databaseGlobalStates, globalState)
 
-		d.multiRepoEnv.AddOrReplaceEnv(name, dEnv)
+		d.multiRepoEnv.AddEnv(name, dEnv)
 		d.createdEnvs[db.Name()] = dEnv
 	}
 


### PR DESCRIPTION
As discussed in https://github.com/dolthub/dolt/pull/3444, this is a follow up to simplify MultiRepoEnv by moving to track envs in a map. 