### PR TITLE
Read replica update working set fixes

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/server_test.go
+++ b/go/cmd/dolt/commands/sqlserver/server_test.go
@@ -35,6 +35,14 @@ import (
 	"github.com/dolthub/dolt/go/libraries/utils/config"
 )
 
+//TODO: server tests need to expose a higher granularity for server interactions:
+// - replication readers and writers that are connected through configs
+// - configs need to be dynamic
+// - interleave inter and intra-session queries
+// - simulate server/connection failures
+// - load balancing?
+// - multi-master?
+
 type testPerson struct {
 	Name       string
 	Age        int

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -233,6 +233,8 @@ func (p DoltDatabaseProvider) DropDatabase(ctx *sql.Context, name string) error 
 	return nil
 }
 
+//TODO: databaseForRevision should call checkout on the given branch/commit, returning a non-mutable session
+// only if a non-branch revspec was indicated.
 func (p DoltDatabaseProvider) databaseForRevision(ctx *sql.Context, revDB string) (sql.Database, dsess.InitialDbState, bool, error) {
 	revDB = strings.ToLower(revDB)
 	if !strings.Contains(revDB, dbRevisionDelimiter) {
@@ -452,10 +454,9 @@ func dbRevisionForBranch(ctx context.Context, srcDb SqlDatabase, revSpec string)
 				gs:       v.gs,
 				editOpts: v.editOpts,
 			},
-			remoteTrackRef: v.remoteTrackRef,
-			remote:         v.remote,
-			srcDB:          v.srcDB,
-			tmpDir:         v.tmpDir,
+			remote: v.remote,
+			srcDB:  v.srcDB,
+			tmpDir: v.tmpDir,
 		}
 	}
 

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -49,10 +49,10 @@ type DoltDatabaseProvider struct {
 	dbFactoryUrl string
 }
 
-var _ sql.DatabaseProvider = DoltDatabaseProvider{}
-var _ sql.FunctionProvider = DoltDatabaseProvider{}
-var _ sql.MutableDatabaseProvider = DoltDatabaseProvider{}
-var _ dsess.RevisionDatabaseProvider = DoltDatabaseProvider{}
+var _ sql.DatabaseProvider = (*DoltDatabaseProvider)(nil)
+var _ sql.FunctionProvider = (*DoltDatabaseProvider)(nil)
+var _ sql.MutableDatabaseProvider = (*DoltDatabaseProvider)(nil)
+var _ dsess.RevisionDatabaseProvider = (*DoltDatabaseProvider)(nil)
 
 // NewDoltDatabaseProvider returns a provider for the databases given
 func NewDoltDatabaseProvider(defaultBranch string, fs filesys.Filesys, databases ...sql.Database) DoltDatabaseProvider {
@@ -233,7 +233,7 @@ func (p DoltDatabaseProvider) DropDatabase(ctx *sql.Context, name string) error 
 	return nil
 }
 
-func (p DoltDatabaseProvider) databaseForRevision(ctx context.Context, revDB string) (sql.Database, dsess.InitialDbState, bool, error) {
+func (p DoltDatabaseProvider) databaseForRevision(ctx *sql.Context, revDB string) (sql.Database, dsess.InitialDbState, bool, error) {
 	revDB = strings.ToLower(revDB)
 	if !strings.Contains(revDB, dbRevisionDelimiter) {
 		return nil, dsess.InitialDbState{}, false, nil
@@ -298,7 +298,7 @@ func (p DoltDatabaseProvider) databaseForRevision(ctx context.Context, revDB str
 	return nil, dsess.InitialDbState{}, false, nil
 }
 
-func (p DoltDatabaseProvider) RevisionDbState(ctx context.Context, revDB string) (dsess.InitialDbState, error) {
+func (p DoltDatabaseProvider) RevisionDbState(ctx *sql.Context, revDB string) (dsess.InitialDbState, error) {
 	_, init, ok, err := p.databaseForRevision(ctx, revDB)
 	if err != nil {
 		return dsess.InitialDbState{}, err
@@ -333,7 +333,7 @@ func (p DoltDatabaseProvider) TableFunction(ctx *sql.Context, name string) (sql.
 // switchAndFetchReplicaHead tries to pull the latest version of a branch. Will fail if the branch
 // does not exist on the ReadReplicaDatabase's remote. If the target branch is not a replication
 // head, the new branch will not be continuously fetched.
-func switchAndFetchReplicaHead(ctx context.Context, branch string, db ReadReplicaDatabase) error {
+func switchAndFetchReplicaHead(ctx *sql.Context, branch string, db ReadReplicaDatabase) error {
 	branchRef := ref.NewBranchRef(branch)
 
 	var branchExists bool
@@ -361,13 +361,6 @@ func switchAndFetchReplicaHead(ctx context.Context, branch string, db ReadReplic
 		if err != nil {
 			return err
 		}
-	}
-
-	// update ReadReplicaRemote with new HEAD
-	// dolt_replicate_heads configuration remains unchanged
-	db, err = db.SetHeadRef(branchRef)
-	if err != nil {
-		return err
 	}
 
 	// create workingSets/heads/branch and update the working set
@@ -459,7 +452,6 @@ func dbRevisionForBranch(ctx context.Context, srcDb SqlDatabase, revSpec string)
 				gs:       v.gs,
 				editOpts: v.editOpts,
 			},
-			headRef:        v.headRef,
 			remoteTrackRef: v.remoteTrackRef,
 			remote:         v.remote,
 			srcDB:          v.srcDB,

--- a/go/libraries/doltcore/sqle/dsess/revision_db_provider.go
+++ b/go/libraries/doltcore/sqle/dsess/revision_db_provider.go
@@ -15,8 +15,6 @@
 package dsess
 
 import (
-	"context"
-
 	"github.com/dolthub/go-mysql-server/sql"
 )
 
@@ -27,7 +25,7 @@ import (
 // databases. Revision databases for branches will be read/write.
 type RevisionDatabaseProvider interface {
 	// RevisionDbState provides the InitialDbState for a revision database.
-	RevisionDbState(ctx context.Context, revDB string) (InitialDbState, error)
+	RevisionDbState(ctx *sql.Context, revDB string) (InitialDbState, error)
 }
 
 func EmptyDatabaseProvider() RevisionDatabaseProvider {
@@ -36,6 +34,6 @@ func EmptyDatabaseProvider() RevisionDatabaseProvider {
 
 type emptyRevisionDatabaseProvider struct{}
 
-func (e emptyRevisionDatabaseProvider) RevisionDbState(_ context.Context, revDB string) (InitialDbState, error) {
+func (e emptyRevisionDatabaseProvider) RevisionDbState(_ *sql.Context, revDB string) (InitialDbState, error) {
 	return InitialDbState{}, sql.ErrDatabaseNotFound.New(revDB)
 }

--- a/go/libraries/doltcore/sqle/read_replica_database.go
+++ b/go/libraries/doltcore/sqle/read_replica_database.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -27,6 +26,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"github.com/dolthub/dolt/go/store/types"
 )
 

--- a/go/libraries/doltcore/sqle/read_replica_database.go
+++ b/go/libraries/doltcore/sqle/read_replica_database.go
@@ -32,10 +32,9 @@ import (
 
 type ReadReplicaDatabase struct {
 	Database
-	remoteTrackRef ref.DoltRef
-	remote         env.Remote
-	srcDB          *doltdb.DoltDB
-	tmpDir         string
+	remote env.Remote
+	srcDB  *doltdb.DoltDB
+	tmpDir string
 }
 
 var _ SqlDatabase = ReadReplicaDatabase{}

--- a/integration-tests/bats/replication.bats
+++ b/integration-tests/bats/replication.bats
@@ -255,7 +255,6 @@ teardown() {
     dolt config --local --add sqlserver.global.dolt_replicate_all_heads 1
     dolt config --local --add sqlserver.global.dolt_read_replica_remote origin
     # repo2 pulls on read
-    dolt branch
     run dolt sql -r csv -b <<SQL
 call dolt_checkout('feat');
 show tables;

--- a/integration-tests/bats/replication.bats
+++ b/integration-tests/bats/replication.bats
@@ -232,6 +232,41 @@ teardown() {
     [[ ! "$output" =~ "panic" ]] || false
 }
 
+@test "replication: pull all heads from feat" {
+    cd repo1
+    dolt branch -c main feat
+    dolt push remote1 feat
+    cd ..
+    # clone repo2 from repo1
+    dolt clone file://./rem1 repo2
+    cd repo2
+    dolt checkout feat
+    dolt checkout main
+    # add tables to repo1
+    cd ../repo1
+    dolt checkout feat
+    dolt sql -q "create table t1 (a int)"
+    dolt sql -q "create table t2 (a int)"
+    dolt commit -am "cm"
+    # remote1 has tables
+    dolt push remote1 feat
+    # repo2 replication config
+    cd ../repo2
+    dolt config --local --add sqlserver.global.dolt_replicate_all_heads 1
+    dolt config --local --add sqlserver.global.dolt_read_replica_remote origin
+    # repo2 pulls on read
+    dolt branch
+    run dolt sql -r csv -b <<SQL
+call dolt_checkout('feat');
+show tables;
+SQL
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 4 ]
+    [[ "${lines[0]}" =~ "Tables_in_repo2" ]] || false
+    [[ "${lines[1]}" =~ "t1" ]] || false
+    [[ "${lines[2]}" =~ "t2" ]] || false
+}
+
 @test "replication: pull all heads" {
     dolt clone file://./rem1 repo2
     cd repo2


### PR DESCRIPTION
Read replica pull updates the session working set after pulling a
filtered set of branches from the tracking database. The original
(buggy) implementation updates the working set to the branch specified
at server-start time. The identity of that branch was fixed for the
duration of the server, so dolt_checkout would (appear to) have no
effect on the new branch's working set. What actually happened was more
pernicious: the working set was updated to the value of the
incorrect branch.

The fix no longer statically sets the active branch for a read replica
database. The active branch is pulled from the `*sql.Context`, so the
correct working set will be updated.

Note:
- Changing the remote name or remote endpoint would have a similar static state issue. We could read remote name and remote target from the session vars, repo state reader at pull time.