### PR TITLE
[no-release-notes] old harness refactors

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -68,7 +68,7 @@ require (
 )
 
 require (
-	github.com/dolthub/go-mysql-server v0.11.1-0.20220519235058-86955e343071
+	github.com/dolthub/go-mysql-server v0.11.1-0.20220523211852-62d241042761
 	github.com/google/flatbuffers v2.0.5+incompatible
 	github.com/gosuri/uilive v0.0.4
 	github.com/kch42/buzhash v0.0.0-20160816060738-9bdec3dec7c6
@@ -144,3 +144,5 @@ replace (
 )
 
 go 1.18
+
+replace github.com/dolthub/go-mysql-server => /Users/max-hoffman/go/src/github.com/dolthub/go-mysql-server/

--- a/go/go.mod
+++ b/go/go.mod
@@ -144,5 +144,3 @@ replace (
 )
 
 go 1.18
-
-replace github.com/dolthub/go-mysql-server => /Users/max-hoffman/go/src/github.com/dolthub/go-mysql-server/

--- a/go/go.sum
+++ b/go/go.sum
@@ -178,8 +178,6 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dolthub/fslock v0.0.3 h1:iLMpUIvJKMKm92+N1fmHVdxJP5NdyDK5bK7z7Ba2s2U=
 github.com/dolthub/fslock v0.0.3/go.mod h1:QWql+P17oAAMLnL4HGB5tiovtDuAjdDTPbuqx7bYfa0=
-github.com/dolthub/go-mysql-server v0.11.1-0.20220519235058-86955e343071 h1:dxrZSTEaCY6fXlTX6gEF7HC30rQjNwLr0ZJxzus2YnA=
-github.com/dolthub/go-mysql-server v0.11.1-0.20220519235058-86955e343071/go.mod h1:h0gpkn07YqshhXbeNkOfII0uV+I37SJYyvccH77+FOk=
 github.com/dolthub/ishell v0.0.0-20220112232610-14e753f0f371 h1:oyPHJlzumKta1vnOQqUnfdz+pk3EmnHS3Nd0cCT0I2g=
 github.com/dolthub/ishell v0.0.0-20220112232610-14e753f0f371/go.mod h1:dhGBqcCEfK5kuFmeO5+WOx3hqc1k3M29c1oS/R7N4ms=
 github.com/dolthub/jsonpath v0.0.0-20210609232853-d49537a30474 h1:xTrR+l5l+1Lfq0NvhiEsctylXinUMFhhsqaEcl414p8=

--- a/go/go.sum
+++ b/go/go.sum
@@ -178,6 +178,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dolthub/fslock v0.0.3 h1:iLMpUIvJKMKm92+N1fmHVdxJP5NdyDK5bK7z7Ba2s2U=
 github.com/dolthub/fslock v0.0.3/go.mod h1:QWql+P17oAAMLnL4HGB5tiovtDuAjdDTPbuqx7bYfa0=
+github.com/dolthub/go-mysql-server v0.11.1-0.20220523211852-62d241042761 h1:wisep2IbO6IB7YAtl2H+445YbJN7wpjmpPk5WX0jS+4=
+github.com/dolthub/go-mysql-server v0.11.1-0.20220523211852-62d241042761/go.mod h1:h0gpkn07YqshhXbeNkOfII0uV+I37SJYyvccH77+FOk=
 github.com/dolthub/ishell v0.0.0-20220112232610-14e753f0f371 h1:oyPHJlzumKta1vnOQqUnfdz+pk3EmnHS3Nd0cCT0I2g=
 github.com/dolthub/ishell v0.0.0-20220112232610-14e753f0f371/go.mod h1:dhGBqcCEfK5kuFmeO5+WOx3hqc1k3M29c1oS/R7N4ms=
 github.com/dolthub/jsonpath v0.0.0-20210609232853-d49537a30474 h1:xTrR+l5l+1Lfq0NvhiEsctylXinUMFhhsqaEcl414p8=

--- a/go/libraries/doltcore/env/actions/commit.go
+++ b/go/libraries/doltcore/env/actions/commit.go
@@ -247,6 +247,9 @@ func TimeSortedCommits(ctx context.Context, ddb *doltdb.DoltDB, commit *doltdb.C
 		idx++
 	}
 
+	//todo(max): toposort this, two commits can have the same timestamp,
+	// and if the founding commit has the same timestamp as its ancestors
+	// this can cause diff errors.
 	var sortErr error
 	var metaI, metaJ *datas.CommitMeta
 	sort.Slice(uniqueCommits, func(i, j int) bool {

--- a/go/libraries/doltcore/sqle/dtables/unscoped_diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/unscoped_diff_table.go
@@ -182,6 +182,10 @@ func (itr *UnscopedDiffTableItr) loadTableChanges(ctx context.Context, commit *d
 // calculateTableChanges calculates the tables that changed in the specified commit, by comparing that
 // commit with its immediate ancestor commit.
 func (itr *UnscopedDiffTableItr) calculateTableChanges(ctx context.Context, commit *doltdb.Commit) ([]tableChange, error) {
+	if len(commit.DatasParents()) == 0 {
+		return nil, nil
+	}
+
 	toRootValue, err := commit.GetRootValue(ctx)
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -768,12 +768,9 @@ func TestHistorySystemTable(t *testing.T) {
 }
 
 func TestUnscopedDiffSystemTable(t *testing.T) {
-	harness := newDoltHarness(t)
-	harness.Setup(setup.MydbData)
 	for _, test := range UnscopedDiffSystemTableScriptTests {
-		harness.engine = nil
 		t.Run(test.Name, func(t *testing.T) {
-			enginetest.TestScript(t, harness, test)
+			enginetest.TestScript(t, newDoltHarness(t), test)
 		})
 	}
 }

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -114,13 +114,9 @@ func TestSingleScript(t *testing.T) {
 	}
 
 	harness := newDoltHarness(t)
+	harness.Setup(setup.MydbData)
 	for _, test := range scripts {
-		myDb := harness.NewDatabase("mydb")
-		databases := []sql.Database{myDb}
-		engine := enginetest.NewEngineWithDbs(t, harness, databases)
-		//engine.Analyzer.Debug = true
-		//engine.Analyzer.Verbose = true
-		enginetest.TestScriptWithEngine(t, engine, harness, test)
+		enginetest.TestScript(t, harness, test)
 	}
 }
 
@@ -302,9 +298,9 @@ func TestDoltUserPrivileges(t *testing.T) {
 	harness := newDoltHarness(t)
 	for _, script := range DoltUserPrivTests {
 		t.Run(script.Name, func(t *testing.T) {
-			myDb := harness.NewDatabase("mydb")
-			databases := []sql.Database{myDb}
-			engine := enginetest.NewEngineWithDbs(t, harness, databases)
+			harness.Setup(setup.MydbData)
+			engine, err := harness.NewEngine(t)
+			require.NoError(t, err)
 			defer engine.Close()
 
 			ctx := enginetest.NewContextWithClient(harness, sql.Client{
@@ -566,7 +562,9 @@ func TestStoredProcedures(t *testing.T) {
 
 func TestTransactions(t *testing.T) {
 	skipNewFormat(t)
-	enginetest.TestTransactionScripts(t, newDoltHarness(t))
+	for _, script := range queries.TransactionTests {
+		enginetest.TestTransactionScript(t, newDoltHarness(t), script)
+	}
 
 	for _, script := range DoltTransactionTests {
 		enginetest.TestTransactionScript(t, newDoltHarness(t), script)
@@ -619,20 +617,17 @@ func TestShowCreateTableAsOf(t *testing.T) {
 
 func TestDoltMerge(t *testing.T) {
 	skipNewFormat(t)
-	harness := newDoltHarness(t)
-	harness.Setup(setup.MydbData)
 	for _, script := range MergeScripts {
-		harness.engine = nil
-		enginetest.TestScript(t, harness, script)
+		// dolt versioning conflicts with reset harness -- use new harness every time
+		enginetest.TestScript(t, newDoltHarness(t), script)
 	}
 }
 
 func TestDoltReset(t *testing.T) {
 	skipNewFormat(t)
-	harness := newDoltHarness(t)
 	for _, script := range DoltReset {
-		harness.engine = nil
-		enginetest.TestScript(t, harness, script)
+		// dolt versioning conflicts with reset harness -- use new harness every time
+		enginetest.TestScript(t, newDoltHarness(t), script)
 	}
 }
 
@@ -742,22 +737,22 @@ func TestBrokenSystemTableQueries(t *testing.T) {
 func TestHistorySystemTable(t *testing.T) {
 	skipNewFormat(t)
 	harness := newDoltHarness(t)
+	harness.Setup(setup.MydbData)
 	for _, test := range HistorySystemTableScriptTests {
-		databases := harness.NewDatabases("mydb")
-		engine := enginetest.NewEngineWithDbs(t, harness, databases)
+		harness.engine = nil
 		t.Run(test.Name, func(t *testing.T) {
-			enginetest.TestScriptWithEngine(t, engine, harness, test)
+			enginetest.TestScript(t, harness, test)
 		})
 	}
 }
 
 func TestUnscopedDiffSystemTable(t *testing.T) {
 	harness := newDoltHarness(t)
+	harness.Setup(setup.MydbData)
 	for _, test := range UnscopedDiffSystemTableScriptTests {
-		databases := harness.NewDatabases("mydb")
-		engine := enginetest.NewEngineWithDbs(t, harness, databases)
+		harness.engine = nil
 		t.Run(test.Name, func(t *testing.T) {
-			enginetest.TestScriptWithEngine(t, engine, harness, test)
+			enginetest.TestScript(t, harness, test)
 		})
 	}
 }
@@ -765,12 +760,11 @@ func TestUnscopedDiffSystemTable(t *testing.T) {
 func TestDiffTableFunction(t *testing.T) {
 	skipNewFormat(t)
 	harness := newDoltHarness(t)
-
+	harness.Setup(setup.MydbData)
 	for _, test := range DiffTableFunctionScriptTests {
-		databases := harness.NewDatabases("mydb")
-		engine := enginetest.NewEngineWithDbs(t, harness, databases)
+		harness.engine = nil
 		t.Run(test.Name, func(t *testing.T) {
-			enginetest.TestScriptWithEngine(t, engine, harness, test)
+			enginetest.TestScript(t, harness, test)
 		})
 	}
 }
@@ -778,11 +772,11 @@ func TestDiffTableFunction(t *testing.T) {
 func TestCommitDiffSystemTable(t *testing.T) {
 	skipNewFormat(t)
 	harness := newDoltHarness(t)
+	harness.Setup(setup.MydbData)
 	for _, test := range CommitDiffSystemTableScriptTests {
-		databases := harness.NewDatabases("mydb")
-		engine := enginetest.NewEngineWithDbs(t, harness, databases)
+		harness.engine = nil
 		t.Run(test.Name, func(t *testing.T) {
-			enginetest.TestScriptWithEngine(t, engine, harness, test)
+			enginetest.TestScript(t, harness, test)
 		})
 	}
 }
@@ -790,11 +784,11 @@ func TestCommitDiffSystemTable(t *testing.T) {
 func TestDiffSystemTable(t *testing.T) {
 	skipNewFormat(t)
 	harness := newDoltHarness(t)
+	harness.Setup(setup.MydbData)
 	for _, test := range DiffSystemTableScriptTests {
-		databases := harness.NewDatabases("mydb")
-		engine := enginetest.NewEngineWithDbs(t, harness, databases)
+		harness.engine = nil
 		t.Run(test.Name, func(t *testing.T) {
-			enginetest.TestScriptWithEngine(t, engine, harness, test)
+			enginetest.TestScript(t, harness, test)
 		})
 	}
 }


### PR DESCRIPTION
Every engine test except `TestReadOnlyDatabase` and `TestVersioned` updated to new harness. Remove every use of `harness.NewDatabase`.