### PR TITLE
[no-release-notes] Fix chunk corruption for keyless tables

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
@@ -277,6 +277,9 @@ func (d *DoltHarness) NewDatabases(names ...string) []sql.Database {
 	for _, name := range names {
 		dEnv := dtestutils.CreateTestEnvWithName(name)
 
+		store := dEnv.DoltDB.ValueReadWriter().(*types.ValueStore)
+		store.SetValidateContentAddresses(true)
+
 		opts := editor.Options{Deaf: dEnv.DbEaFactory(), Tempdir: dEnv.TempTableFilesDir()}
 		db := sqle.NewDatabase(name, dEnv.DbData(), opts)
 		d.databases = append(d.databases, db)

--- a/go/libraries/doltcore/sqle/writer/prolly_index_writer.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_index_writer.go
@@ -269,9 +269,9 @@ func (k prollyKeylessWriter) Insert(ctx context.Context, sqlRow sql.Row) error {
 	}
 
 	// increment cardinality
-	val.ModifyKeylessCardinality(value, int64(1))
+	updated, _ := val.ModifyKeylessCardinality(sharePool, value, int64(1))
 
-	return k.mut.Put(ctx, hashId, value)
+	return k.mut.Put(ctx, hashId, updated)
 }
 
 func (k prollyKeylessWriter) Delete(ctx context.Context, sqlRow sql.Row) error {
@@ -296,9 +296,9 @@ func (k prollyKeylessWriter) Delete(ctx context.Context, sqlRow sql.Row) error {
 	}
 
 	// decrement cardinality
-	after := val.ModifyKeylessCardinality(value, int64(-1))
+	updated, after := val.ModifyKeylessCardinality(sharePool, value, int64(-1))
 	if after > 0 {
-		return k.mut.Put(ctx, hashId, value)
+		return k.mut.Put(ctx, hashId, updated)
 	} else {
 		return k.mut.Delete(ctx, hashId)
 	}

--- a/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
@@ -30,6 +30,7 @@ import (
 	"github.com/dolthub/dolt/go/store/val"
 )
 
+// todo(andy): get from NodeStore
 var sharePool = pool.NewBuffPool()
 
 type prollyTableWriter struct {

--- a/go/store/prolly/tree/testutils.go
+++ b/go/store/prolly/tree/testutils.go
@@ -15,22 +15,21 @@
 package tree
 
 import (
+	"context"
+	"fmt"
 	"math"
 	"math/rand"
 	"sort"
 
-	"github.com/dolthub/dolt/go/store/prolly/message"
-
 	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/dolthub/dolt/go/store/pool"
+	"github.com/dolthub/dolt/go/store/prolly/message"
+	"github.com/dolthub/dolt/go/store/types"
 	"github.com/dolthub/dolt/go/store/val"
 )
 
 var testRand = rand.New(rand.NewSource(1))
-
-func NewTestNodeStore() NodeStore {
-	ts := &chunks.TestStorage{}
-	return NewNodeStore(ts.NewView())
-}
 
 func NewTupleLeafNode(keys, values []val.Tuple) Node {
 	ks := make([]Item, len(keys))
@@ -234,4 +233,50 @@ func randomField(tb *val.TupleBuilder, idx int, typ val.Type) {
 	default:
 		panic("unknown encoding")
 	}
+}
+
+func NewTestNodeStore() NodeStore {
+	ts := &chunks.TestStorage{}
+	ns := NewNodeStore(ts.NewView())
+	return nodeStoreValidator{ns: ns}
+}
+
+type nodeStoreValidator struct {
+	ns NodeStore
+}
+
+func (v nodeStoreValidator) Read(ctx context.Context, ref hash.Hash) (Node, error) {
+	nd, err := v.ns.Read(ctx, ref)
+	if err != nil {
+		return Node{}, err
+	}
+
+	actual := hash.Of(nd.msg)
+	if ref != actual {
+		err = fmt.Errorf("incorrect node hash (%s != %s)", ref, actual)
+		return Node{}, err
+	}
+	return nd, nil
+}
+
+func (v nodeStoreValidator) Write(ctx context.Context, nd Node) (hash.Hash, error) {
+	h, err := v.ns.Write(ctx, nd)
+	if err != nil {
+		return hash.Hash{}, err
+	}
+
+	actual := hash.Of(nd.msg)
+	if h != actual {
+		err = fmt.Errorf("incorrect node hash (%s != %s)", h, actual)
+		return hash.Hash{}, err
+	}
+	return h, nil
+}
+
+func (v nodeStoreValidator) Pool() pool.BuffPool {
+	return v.ns.Pool()
+}
+
+func (v nodeStoreValidator) Format() *types.NomsBinFormat {
+	return v.ns.Format()
 }

--- a/go/store/types/value_store.go
+++ b/go/store/types/value_store.go
@@ -160,7 +160,7 @@ func (lvs *ValueStore) SetEnforceCompleteness(enforce bool) {
 	lvs.enforceCompleteness = enforce
 }
 
-func (lvs *ValueStore) SetCheckContentAddress(validate bool) {
+func (lvs *ValueStore) SetValidateContentAddresses(validate bool) {
 	lvs.validateContentAddr = validate
 }
 

--- a/go/store/types/value_store.go
+++ b/go/store/types/value_store.go
@@ -24,6 +24,7 @@ package types
 import (
 	"context"
 	"errors"
+	"fmt"
 	"runtime"
 	"sync"
 
@@ -80,6 +81,7 @@ type ValueStore struct {
 	withBufferedChildren map[hash.Hash]uint64 // chunk Hash -> ref height
 	unresolvedRefs       hash.HashSet
 	enforceCompleteness  bool
+	validateContentAddr  bool
 	decodedChunks        *sizecache.SizeCache
 	nbf                  *NomsBinFormat
 
@@ -158,6 +160,10 @@ func (lvs *ValueStore) SetEnforceCompleteness(enforce bool) {
 	lvs.enforceCompleteness = enforce
 }
 
+func (lvs *ValueStore) SetCheckContentAddress(validate bool) {
+	lvs.validateContentAddr = validate
+}
+
 func (lvs *ValueStore) ChunkStore() chunks.ChunkStore {
 	return lvs.cs
 }
@@ -177,7 +183,13 @@ func (lvs *ValueStore) ReadValue(ctx context.Context, h hash.Hash) (Value, error
 			return nil, errors.New("value present but empty")
 		}
 
-		return v.(Value), nil
+		nv := v.(Value)
+		if lvs.validateContentAddr {
+			if err := validateContentAddress(lvs.nbf, h, nv); err != nil {
+				return nil, err
+			}
+		}
+		return nv, nil
 	}
 
 	chunk := func() chunks.Chunk {
@@ -211,6 +223,12 @@ func (lvs *ValueStore) ReadValue(ctx context.Context, h hash.Hash) (Value, error
 		return nil, errors.New("decoded value is empty")
 	}
 
+	if lvs.validateContentAddr {
+		if err = validateContentAddress(lvs.nbf, h, v); err != nil {
+			return nil, err
+		}
+	}
+
 	lvs.decodedChunks.Add(h, uint64(len(chunk.Data())), v)
 	return v, nil
 }
@@ -230,6 +248,11 @@ func (lvs *ValueStore) ReadManyValues(ctx context.Context, hashes hash.HashSlice
 		if v == nil {
 			return nil, errors.New("decoded value is empty")
 		}
+		if lvs.validateContentAddr {
+			if err := validateContentAddress(lvs.nbf, h, v); err != nil {
+				return nil, err
+			}
+		}
 
 		lvs.decodedChunks.Add(h, uint64(len(chunk.Data())), v)
 		return v, nil
@@ -243,7 +266,14 @@ func (lvs *ValueStore) ReadManyValues(ctx context.Context, hashes hash.HashSlice
 	for _, h := range hashes {
 		if v, ok := lvs.decodedChunks.Get(h); ok {
 			d.PanicIfTrue(v == nil)
-			foundValues[h] = v.(Value)
+
+			nv := v.(Value)
+			if lvs.validateContentAddr {
+				if err := validateContentAddress(lvs.nbf, h, nv); err != nil {
+					return nil, err
+				}
+			}
+			foundValues[h] = nv
 			continue
 		}
 
@@ -804,4 +834,16 @@ func (lvs *ValueStore) gcProcessRefs(ctx context.Context, visited hash.HashSet, 
 // Close closes the underlying ChunkStore
 func (lvs *ValueStore) Close() error {
 	return lvs.cs.Close()
+}
+
+func validateContentAddress(nbf *NomsBinFormat, h hash.Hash, v Value) (err error) {
+	var actual hash.Hash
+	actual, err = v.Hash(nbf)
+	if err != nil {
+		return
+	} else if actual != h {
+		err = fmt.Errorf("incorrect hash for value %s (%s != %s)",
+			v.HumanReadableString(), actual.String(), h.String())
+	}
+	return
 }

--- a/go/store/val/keyless_tuple.go
+++ b/go/store/val/keyless_tuple.go
@@ -49,8 +49,9 @@ func ReadKeylessCardinality(value Tuple) uint64 {
 	return readUint64(value[:keylessCardSz])
 }
 
-func ModifyKeylessCardinality(value Tuple, delta int64) (after uint64) {
-	buf := value[:keylessCardSz]
+func ModifyKeylessCardinality(pool pool.BuffPool, value Tuple, delta int64) (updated Tuple, after uint64) {
+	updated = cloneTuple(pool, value)
+	buf := updated[:keylessCardSz]
 	after = uint64(int64(readUint64(buf)) + delta)
 	writeUint64(buf, after)
 	return

--- a/go/store/val/tuple.go
+++ b/go/store/val/tuple.go
@@ -111,7 +111,7 @@ func NewTuple(pool pool.BuffPool, values ...[]byte) Tuple {
 	return tup
 }
 
-func CloneTuple(pool pool.BuffPool, tup Tuple) Tuple {
+func cloneTuple(pool pool.BuffPool, tup Tuple) Tuple {
 	buf := pool.Get(uint64(len(tup)))
 	copy(buf, tup)
 	return buf


### PR DESCRIPTION
Fixes a bug in `prollyKeylessWriter` where a cached chunk was being corrupted by an in-place edit to its buffer.