### PR TITLE
Fixed foreign key parent referencing + keyless referencing

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -68,7 +68,7 @@ require (
 )
 
 require (
-	github.com/dolthub/go-mysql-server v0.11.1-0.20220602210210-560a7ba0d5ff
+	github.com/dolthub/go-mysql-server v0.11.1-0.20220603175623-00b27666e570
 	github.com/google/flatbuffers v2.0.6+incompatible
 	github.com/gosuri/uilive v0.0.4
 	github.com/kch42/buzhash v0.0.0-20160816060738-9bdec3dec7c6

--- a/go/go.sum
+++ b/go/go.sum
@@ -178,8 +178,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dolthub/fslock v0.0.3 h1:iLMpUIvJKMKm92+N1fmHVdxJP5NdyDK5bK7z7Ba2s2U=
 github.com/dolthub/fslock v0.0.3/go.mod h1:QWql+P17oAAMLnL4HGB5tiovtDuAjdDTPbuqx7bYfa0=
-github.com/dolthub/go-mysql-server v0.11.1-0.20220602210210-560a7ba0d5ff h1:wA5cLHgPPbQbN90YvcJSC1TsgIepqc/pzBBGKDWVx1M=
-github.com/dolthub/go-mysql-server v0.11.1-0.20220602210210-560a7ba0d5ff/go.mod h1:VY2z/8rjWxzGzHFIRpOBFC7qBTj1PXQvNaXd5KNP+8A=
+github.com/dolthub/go-mysql-server v0.11.1-0.20220603175623-00b27666e570 h1:0xgeJy7a4iOj++oWK1UEikArenERzvi3Vy8t3TGrXcM=
+github.com/dolthub/go-mysql-server v0.11.1-0.20220603175623-00b27666e570/go.mod h1:VY2z/8rjWxzGzHFIRpOBFC7qBTj1PXQvNaXd5KNP+8A=
 github.com/dolthub/ishell v0.0.0-20220112232610-14e753f0f371 h1:oyPHJlzumKta1vnOQqUnfdz+pk3EmnHS3Nd0cCT0I2g=
 github.com/dolthub/ishell v0.0.0-20220112232610-14e753f0f371/go.mod h1:dhGBqcCEfK5kuFmeO5+WOx3hqc1k3M29c1oS/R7N4ms=
 github.com/dolthub/jsonpath v0.0.0-20210609232853-d49537a30474 h1:xTrR+l5l+1Lfq0NvhiEsctylXinUMFhhsqaEcl414p8=

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -173,14 +173,6 @@ func TestAmbiguousColumnResolution(t *testing.T) {
 }
 
 func TestInsertInto(t *testing.T) {
-	if types.IsFormat_DOLT_1(types.Format_Default) {
-		for i := len(queries.InsertScripts) - 1; i >= 0; i-- {
-			//TODO: on duplicate key broken for foreign keys in new format
-			if queries.InsertScripts[i].Name == "Insert on duplicate key" {
-				queries.InsertScripts = append(queries.InsertScripts[:i], queries.InsertScripts[i+1:]...)
-			}
-		}
-	}
 	enginetest.TestInsertInto(t, newDoltHarness(t))
 }
 
@@ -931,14 +923,6 @@ func TestScriptsPrepared(t *testing.T) {
 
 func TestInsertScriptsPrepared(t *testing.T) {
 	skipPreparedTests(t)
-	if types.IsFormat_DOLT_1(types.Format_Default) {
-		for i := len(queries.InsertScripts) - 1; i >= 0; i-- {
-			//TODO: on duplicate key broken for foreign keys in new format
-			if queries.InsertScripts[i].Name == "Insert on duplicate key" {
-				queries.InsertScripts = append(queries.InsertScripts[:i], queries.InsertScripts[i+1:]...)
-			}
-		}
-	}
 	enginetest.TestInsertScriptsPrepared(t, newDoltHarness(t))
 }
 
@@ -989,8 +973,6 @@ func TestPrepared(t *testing.T) {
 }
 
 func TestPreparedInsert(t *testing.T) {
-	//TODO: on duplicate key broken for foreign keys in new format
-	skipNewFormat(t)
 	skipPreparedTests(t)
 	enginetest.TestPreparedInsert(t, newDoltHarness(t))
 }

--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -35,6 +35,7 @@ type DoltIndex interface {
 	Schema() schema.Schema
 	IndexSchema() schema.Schema
 	Format() *types.NomsBinFormat
+	IsPrimaryKey() bool
 	GetDurableIndexes(*sql.Context, *doltdb.Table) (durable.Index, durable.Index, error)
 }
 
@@ -80,6 +81,7 @@ func getPrimaryKeyIndex(ctx context.Context, db, tbl string, t *doltdb.Table, sc
 		indexSch: sch,
 		tableSch: sch,
 		unique:   true,
+		isPk:     true,
 		comment:  "",
 		vrw:      t.ValueReadWriter(),
 		keyBld:   keyBld,
@@ -106,6 +108,7 @@ func getSecondaryIndex(ctx context.Context, db, tbl string, t *doltdb.Table, sch
 		indexSch: idx.Schema(),
 		tableSch: sch,
 		unique:   idx.IsUnique(),
+		isPk:     false,
 		comment:  idx.Comment(),
 		vrw:      t.ValueReadWriter(),
 		keyBld:   keyBld,
@@ -122,6 +125,7 @@ type doltIndex struct {
 	indexSch schema.Schema
 	tableSch schema.Schema
 	unique   bool
+	isPk     bool
 	comment  string
 
 	vrw    types.ValueReadWriter
@@ -328,6 +332,11 @@ func (di doltIndex) ID() string {
 // IsUnique implements sql.Index
 func (di doltIndex) IsUnique() bool {
 	return di.unique
+}
+
+// IsPrimaryKey implements DoltIndex.
+func (di doltIndex) IsPrimaryKey() bool {
+	return di.isPk
 }
 
 // Comment implements sql.Index

--- a/go/libraries/doltcore/sqle/writer/prolly_fk_indexer.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_fk_indexer.go
@@ -56,11 +56,10 @@ func (n prollyFkIndexer) Partitions(ctx *sql.Context) (sql.PartitionIter, error)
 // PartitionRows implements the interface sql.Table.
 func (n prollyFkIndexer) PartitionRows(ctx *sql.Context, _ sql.Partition) (sql.RowIter, error) {
 	var idxWriter indexWriter
+	var ok bool
 	if n.index.IsPrimaryKey() {
 		idxWriter = n.writer.primary
-	} else if idxWriterPosition, ok := n.writer.secNames[n.index.ID()]; ok {
-		idxWriter = n.writer.secondary[idxWriterPosition]
-	} else {
+	} else if idxWriter, ok = n.writer.secondary[n.index.ID()]; !ok {
 		return nil, fmt.Errorf("unable to find writer for index `%s`", n.index.ID())
 	}
 

--- a/go/libraries/doltcore/sqle/writer/prolly_index_writer.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_index_writer.go
@@ -56,11 +56,12 @@ func getPrimaryKeylessProllyWriter(ctx context.Context, t *doltdb.Table, sqlSch 
 
 	m := durable.ProllyMapFromIndex(idx)
 
-	_, valDesc := m.Descriptors()
+	keyDesc, valDesc := m.Descriptors()
 	_, valMap := ordinalMappingsFromSchema(sqlSch, sch)
 
 	return prollyKeylessWriter{
 		mut:    m.Mutate(),
+		keyBld: val.NewTupleBuilder(keyDesc),
 		valBld: val.NewTupleBuilder(valDesc),
 		valMap: valMap,
 	}, nil
@@ -238,6 +239,7 @@ type prollyKeylessWriter struct {
 	name string
 	mut  prolly.MutableMap
 
+	keyBld *val.TupleBuilder
 	valBld *val.TupleBuilder
 	valMap val.OrdinalMapping
 }

--- a/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
@@ -39,6 +39,7 @@ type prollyTableWriter struct {
 
 	primary   indexWriter
 	secondary []indexWriter
+	secNames  map[string]int
 
 	tbl    *doltdb.Table
 	sch    schema.Schema
@@ -280,12 +281,17 @@ func (w *prollyTableWriter) Reset(ctx context.Context, sess *prollyWriteSession,
 			return err
 		}
 	}
+	secNames := make(map[string]int)
+	for i, secondaryWriter := range newSecondaries {
+		secNames[secondaryWriter.Name()] = i
+	}
 
 	w.tbl = tbl
 	w.sch = sch
 	w.sqlSch = sqlSch.Schema
 	w.primary = newPrimary
 	w.secondary = newSecondaries
+	w.secNames = secNames
 	w.aiCol = aiCol
 	w.flusher = sess
 

--- a/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
@@ -38,8 +38,7 @@ type prollyTableWriter struct {
 	dbName    string
 
 	primary   indexWriter
-	secondary []indexWriter
-	secNames  map[string]int
+	secondary map[string]indexWriter
 
 	tbl    *doltdb.Table
 	sch    schema.Schema
@@ -55,17 +54,18 @@ type prollyTableWriter struct {
 
 var _ TableWriter = &prollyTableWriter{}
 
-func getSecondaryProllyIndexWriters(ctx context.Context, t *doltdb.Table, sqlSch sql.Schema, sch schema.Schema) ([]indexWriter, error) {
+func getSecondaryProllyIndexWriters(ctx context.Context, t *doltdb.Table, sqlSch sql.Schema, sch schema.Schema) (map[string]indexWriter, error) {
 	s, err := t.GetIndexSet(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	definitions := sch.Indexes().AllIndexes()
-	writers := make([]indexWriter, len(definitions))
+	writers := make(map[string]indexWriter)
 
-	for i, def := range definitions {
-		idxRows, err := s.GetIndex(ctx, sch, def.Name())
+	for _, def := range definitions {
+		defName := def.Name()
+		idxRows, err := s.GetIndex(ctx, sch, defName)
 		if err != nil {
 			return nil, err
 		}
@@ -74,8 +74,8 @@ func getSecondaryProllyIndexWriters(ctx context.Context, t *doltdb.Table, sqlSch
 		keyMap, valMap := ordinalMappingsFromSchema(sqlSch, def.Schema())
 		keyDesc, valDesc := m.Descriptors()
 
-		writers[i] = prollyIndexWriter{
-			name:   def.Name(),
+		writers[defName] = prollyIndexWriter{
+			name:   defName,
 			mut:    m.Mutate(),
 			keyBld: val.NewTupleBuilder(keyDesc),
 			keyMap: keyMap,
@@ -87,17 +87,18 @@ func getSecondaryProllyIndexWriters(ctx context.Context, t *doltdb.Table, sqlSch
 	return writers, nil
 }
 
-func getSecondaryKeylessProllyWriters(ctx context.Context, t *doltdb.Table, sqlSch sql.Schema, sch schema.Schema, primary prollyKeylessWriter) ([]indexWriter, error) {
+func getSecondaryKeylessProllyWriters(ctx context.Context, t *doltdb.Table, sqlSch sql.Schema, sch schema.Schema, primary prollyKeylessWriter) (map[string]indexWriter, error) {
 	s, err := t.GetIndexSet(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	definitions := sch.Indexes().AllIndexes()
-	writers := make([]indexWriter, len(definitions))
+	writers := make(map[string]indexWriter)
 
-	for i, def := range definitions {
-		idxRows, err := s.GetIndex(ctx, sch, def.Name())
+	for _, def := range definitions {
+		defName := def.Name()
+		idxRows, err := s.GetIndex(ctx, sch, defName)
 		if err != nil {
 			return nil, err
 		}
@@ -107,8 +108,8 @@ func getSecondaryKeylessProllyWriters(ctx context.Context, t *doltdb.Table, sqlS
 		keyMap, valMap := ordinalMappingsFromSchema(sqlSch, def.Schema())
 		keyDesc, valDesc := m.Descriptors()
 
-		writers[i] = prollyKeylessSecondaryWriter{
-			name:    def.Name(),
+		writers[defName] = prollyKeylessSecondaryWriter{
+			name:    defName,
 			mut:     m.Mutate(),
 			primary: primary,
 			unique:  def.IsUnique(),
@@ -261,7 +262,7 @@ func (w *prollyTableWriter) Reset(ctx context.Context, sess *prollyWriteSession,
 	aiCol := autoIncrementColFromSchema(sch)
 	var newPrimary indexWriter
 
-	var newSecondaries []indexWriter
+	var newSecondaries map[string]indexWriter
 	if schema.IsKeyless(sch) {
 		newPrimary, err = getPrimaryKeylessProllyWriter(ctx, tbl, sqlSch.Schema, sch)
 		if err != nil {
@@ -281,17 +282,12 @@ func (w *prollyTableWriter) Reset(ctx context.Context, sess *prollyWriteSession,
 			return err
 		}
 	}
-	secNames := make(map[string]int)
-	for i, secondaryWriter := range newSecondaries {
-		secNames[secondaryWriter.Name()] = i
-	}
 
 	w.tbl = tbl
 	w.sch = sch
 	w.sqlSch = sqlSch.Schema
 	w.primary = newPrimary
 	w.secondary = newSecondaries
-	w.secNames = secNames
 	w.aiCol = aiCol
 	w.flusher = sess
 

--- a/go/libraries/doltcore/sqle/writer/prolly_write_session.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_write_session.go
@@ -66,7 +66,7 @@ func (s *prollyWriteSession) GetTableWriter(ctx context.Context, table, db strin
 	autoCol := autoIncrementColFromSchema(sch)
 
 	var pw indexWriter
-	var sws []indexWriter
+	var sws map[string]indexWriter
 	if schema.IsKeyless(sch) {
 		pw, err = getPrimaryKeylessProllyWriter(ctx, t, pkSch.Schema, sch)
 		if err != nil {
@@ -86,17 +86,12 @@ func (s *prollyWriteSession) GetTableWriter(ctx context.Context, table, db strin
 			return nil, err
 		}
 	}
-	secNames := make(map[string]int)
-	for i, secondaryWriter := range sws {
-		secNames[secondaryWriter.Name()] = i
-	}
 
 	twr := &prollyTableWriter{
 		tableName: table,
 		dbName:    db,
 		primary:   pw,
 		secondary: sws,
-		secNames:  secNames,
 		tbl:       t,
 		sch:       sch,
 		sqlSch:    pkSch.Schema,

--- a/go/libraries/doltcore/sqle/writer/prolly_write_session.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_write_session.go
@@ -86,12 +86,17 @@ func (s *prollyWriteSession) GetTableWriter(ctx context.Context, table, db strin
 			return nil, err
 		}
 	}
+	secNames := make(map[string]int)
+	for i, secondaryWriter := range sws {
+		secNames[secondaryWriter.Name()] = i
+	}
 
 	twr := &prollyTableWriter{
 		tableName: table,
 		dbName:    db,
 		primary:   pw,
 		secondary: sws,
+		secNames:  secNames,
 		tbl:       t,
 		sch:       sch,
 		sqlSch:    pkSch.Schema,


### PR DESCRIPTION
We, apparently, don't have any tests for referencing the primary key in a foreign key, so those have been failing in the new format. In addition, some changes ended up breaking new format keyless, which was also not caught due to lack of tests. Both of those issues have been fixed.

Tests have been added to GMS: https://github.com/dolthub/go-mysql-server/pull/1038