### PR TITLE
change dolt_diff system table to coerce schema by name only

### DIFF
--- a/go/libraries/doltcore/rowconv/row_converter.go
+++ b/go/libraries/doltcore/rowconv/row_converter.go
@@ -30,7 +30,7 @@ var IdentityConverter = &RowConverter{nil, true, nil}
 
 // WarnFunction is a callback function that callers can optionally provide during row conversion
 // to take an extra action when a value cannot be automatically converted to the output data type.
-type WarnFunction func(int, string, ...string)
+type WarnFunction func(int, string, ...interface{})
 
 var DatatypeCoercionFailureWarning = "unable to coerce value from field '%s' into latest column schema"
 

--- a/go/libraries/doltcore/sqle/dtables/diff_iter.go
+++ b/go/libraries/doltcore/sqle/dtables/diff_iter.go
@@ -90,11 +90,7 @@ func newNomsDiffIter(ctx *sql.Context, ddb *doltdb.DoltDB, joiner *rowconv.Joine
 	// TODO (dhruv) don't cast to noms map
 	rd.Start(ctx, durable.NomsMapFromIndex(fromData), durable.NomsMapFromIndex(toData))
 
-	warnFn := func(code int, message string, args ...string) {
-		ctx.Warn(code, message, args)
-	}
-
-	src := diff.NewRowDiffSource(rd, joiner, warnFn)
+	src := diff.NewRowDiffSource(rd, joiner, ctx.Warn)
 	src.AddInputRowConversion(fromConv, toConv)
 
 	return &diffRowItr{
@@ -245,12 +241,12 @@ func newProllyDiffIter(ctx *sql.Context, dp DiffPartition, ddb *doltdb.DoltDB, t
 	}
 	to := durable.ProllyMapFromIndex(t)
 
-	fromConverter, err := NewProllyRowConverter(fSch, targetFromSchema)
+	fromConverter, err := NewProllyRowConverter(fSch, targetFromSchema, ctx.Warn)
 	if err != nil {
 		return prollyDiffIter{}, err
 	}
 
-	toConverter, err := NewProllyRowConverter(tSch, targetToSchema)
+	toConverter, err := NewProllyRowConverter(tSch, targetToSchema, ctx.Warn)
 	if err != nil {
 		return prollyDiffIter{}, err
 	}

--- a/go/libraries/doltcore/sqle/dtables/diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/diff_table.go
@@ -488,7 +488,7 @@ func (dp DiffPartition) rowConvForSchema(ctx context.Context, vrw types.ValueRea
 		return rowconv.IdentityConverter, nil
 	}
 
-	fm, err := rowconv.TagMappingWithNameFallback(srcSch, targetSch)
+	fm, err := rowconv.TagMappingByName(srcSch, targetSch)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/dtables/history_table.go
+++ b/go/libraries/doltcore/sqle/dtables/history_table.go
@@ -424,6 +424,7 @@ func rowConvForSchema(ctx context.Context, vrw types.ValueReadWriter, targetSch 
 		return rowconv.IdentityConverter, nil
 	}
 
+	// TODO: Update history table to also match by name only
 	fm, err := rowconv.TagMappingWithNameFallback(sch, targetSch)
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/sqle/dtables/prolly_row_conv.go
+++ b/go/libraries/doltcore/sqle/dtables/prolly_row_conv.go
@@ -15,6 +15,7 @@
 package dtables
 
 import (
+	"github.com/dolthub/dolt/go/libraries/doltcore/rowconv"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
@@ -36,9 +37,10 @@ type ProllyRowConverter struct {
 	valDesc          val.TupleDesc
 	pkTargetTypes    []sql.Type
 	nonPkTargetTypes []sql.Type
+	warnFn           rowconv.WarnFunction
 }
 
-func NewProllyRowConverter(inSch, outSch schema.Schema) (ProllyRowConverter, error) {
+func NewProllyRowConverter(inSch, outSch schema.Schema, warnFn rowconv.WarnFunction) (ProllyRowConverter, error) {
 	keyProj, valProj, err := diff.MapSchemaBasedOnName(inSch, outSch)
 	if err != nil {
 		return ProllyRowConverter{}, err
@@ -80,22 +82,43 @@ func NewProllyRowConverter(inSch, outSch schema.Schema) (ProllyRowConverter, err
 		valDesc:          vd,
 		pkTargetTypes:    pkTargetTypes,
 		nonPkTargetTypes: nonPkTargetTypes,
+		warnFn:           warnFn,
 	}, nil
 }
 
 // PutConverted converts the |key| and |value| val.Tuple from |inSchema| to |outSchema|
 // and places the converted row in |dstRow|.
 func (c ProllyRowConverter) PutConverted(key, value val.Tuple, dstRow []interface{}) error {
-	for i, j := range c.keyProj {
+	err := c.putFields(key, c.keyProj, c.keyDesc, c.pkTargetTypes, dstRow)
+	if err != nil {
+		return err
+	}
+
+	err = c.putFields(value, c.valProj, c.valDesc, c.nonPkTargetTypes, dstRow)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c ProllyRowConverter) putFields(tup val.Tuple, proj val.OrdinalMapping, desc val.TupleDesc, targetTypes []sql.Type, dstRow []interface{}) error {
+	for i, j := range proj {
 		if j == -1 {
 			continue
 		}
-		f, err := index.GetField(c.keyDesc, i, key)
+		f, err := index.GetField(desc, i, tup)
 		if err != nil {
 			return err
 		}
-		if t := c.pkTargetTypes[i]; t != nil {
+		if t := targetTypes[i]; t != nil {
 			dstRow[j], err = t.Convert(f)
+			if sql.ErrInvalidValue.Is(err) && c.warnFn != nil {
+				col := c.inSchema.GetAllCols().GetByIndex(i)
+				c.warnFn(rowconv.DatatypeCoercionFailureWarningCode, rowconv.DatatypeCoercionFailureWarning, col.Name)
+				dstRow[j] = nil
+				err = nil
+			}
 			if err != nil {
 				return err
 			}
@@ -103,24 +126,5 @@ func (c ProllyRowConverter) PutConverted(key, value val.Tuple, dstRow []interfac
 			dstRow[j] = f
 		}
 	}
-
-	for i, j := range c.valProj {
-		if j == -1 {
-			continue
-		}
-		f, err := index.GetField(c.valDesc, i, value)
-		if err != nil {
-			return err
-		}
-		if t := c.nonPkTargetTypes[i]; t != nil {
-			dstRow[j], err = t.Convert(f)
-			if err != nil {
-				return err
-			}
-		} else {
-			dstRow[j] = f
-		}
-	}
-
 	return nil
 }

--- a/go/libraries/doltcore/sqle/dtables/prolly_row_conv.go
+++ b/go/libraries/doltcore/sqle/dtables/prolly_row_conv.go
@@ -15,11 +15,10 @@
 package dtables
 
 import (
-	"github.com/dolthub/dolt/go/libraries/doltcore/rowconv"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
-
+	"github.com/dolthub/dolt/go/libraries/doltcore/rowconv"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/index"
 	"github.com/dolthub/dolt/go/store/prolly"

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -770,7 +770,6 @@ func TestDiffTableFunction(t *testing.T) {
 }
 
 func TestCommitDiffSystemTable(t *testing.T) {
-	skipNewFormat(t)
 	harness := newDoltHarness(t)
 	harness.Setup(setup.MydbData)
 	for _, test := range CommitDiffSystemTableScriptTests {
@@ -782,7 +781,6 @@ func TestCommitDiffSystemTable(t *testing.T) {
 }
 
 func TestDiffSystemTable(t *testing.T) {
-	skipNewFormat(t)
 	harness := newDoltHarness(t)
 	harness.Setup(setup.MydbData)
 	for _, test := range DiffSystemTableScriptTests {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -1684,21 +1684,65 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 			{
 				Query: "SELECT to_pk, to_c1, from_pk, from_c1, diff_type FROM DOLT_DIFF_t WHERE TO_COMMIT=@Commit1 ORDER BY to_pk;",
 				Expected: []sql.Row{
-					{1, 3, nil, nil, "added"},
-					{4, 6, nil, nil, "added"},
+					{1, 2, nil, nil, "added"},
+					{4, 5, nil, nil, "added"},
 				},
 			},
 			{
 				Query: "SELECT to_pk, to_c1, from_pk, from_c1, diff_type FROM DOLT_DIFF_t WHERE TO_COMMIT=@Commit2 ORDER BY to_pk;",
 				Expected: []sql.Row{
-					{1, 3, 1, 3, "modified"},
-					{4, 6, 4, 6, "modified"},
+					{1, nil, 1, 2, "modified"},
+					{4, nil, 4, 5, "modified"},
 				},
 			},
 			{
 				Query: "SELECT to_pk, to_c1, from_pk, from_c1, diff_type FROM DOLT_DIFF_t WHERE TO_COMMIT=@Commit3 ORDER BY to_pk;",
 				Expected: []sql.Row{
 					{100, 101, nil, nil, "added"},
+					// TODO: It's more correct to also return the following rows.
+					//{1, 3, 1, nil, "modified"},
+					//{4, 6, 4, nil, "modified"}
+
+					// To explain why, let's inspect table t at each of the commits:
+					//
+					//     @Commit1          @Commit2         @Commit3
+					// +----+----+----+     +----+----+     +-----+-----+
+					// | pk | c1 | c2 |     | pk | c2 |     | pk  | c1  |
+					// +----+----+----+     +----+----+     +-----+-----+
+					// | 1  | 2  | 3  |     | 1  | 3  |     | 1   | 3   |
+					// | 4  | 5  | 6  |     | 4  | 6  |     | 4   | 6   |
+					// +----+----+----+     +----+----+     | 100 | 101 |
+					//                                      +-----+-----+
+					//
+					// If you were to interpret each table using the schema at
+					// @Commit3, (pk, c1), you would see the following:
+					//
+					//   @Commit1            @Commit2         @Commit3
+					// +----+----+         +----+------+     +-----+-----+
+					// | pk | c1 |         | pk | c1   |     | pk  | c1  |
+					// +----+----+         +----+------+     +-----+-----+
+					// | 1  | 2  |         | 1  | NULL |     | 1   | 3   |
+					// | 4  | 5  |         | 4  | NULL |     | 4   | 6   |
+					// +----+----+         +----+------+     | 100 | 101 |
+					//                                       +-----+-----+
+					//
+					// The corresponding diffs for the interpreted tables:
+					//
+					// Diff between init and @Commit1:
+					// + (1, 2)
+					// + (4, 5)
+					//
+					// Diff between @Commit1 and @Commit2:
+					// ~ (1, NULL)
+					// ~ (4, NULL)
+					//
+					// Diff between @Commit2 and @Commit3:
+					// ~ (1, 3) <- currently not outputted
+					// ~ (4, 6) <- currently not outputted
+					// + (100, 101)
+					//
+					// The missing rows are not produced by diff since the
+					// underlying value of the prolly trees are not modified during a column rename.
 				},
 			},
 		},
@@ -2660,20 +2704,21 @@ var CommitDiffSystemTableScriptTests = []queries.ScriptTest{
 			{
 				Query: "SELECT to_pk, to_c1, from_pk, from_c1, diff_type FROM DOLT_COMMIT_DIFF_t WHERE TO_COMMIT=@Commit1 and FROM_COMMIT=@Commit0 ORDER BY to_pk;",
 				Expected: []sql.Row{
-					{1, 3, nil, nil, "added"},
-					{4, 6, nil, nil, "added"},
+					{1, 2, nil, nil, "added"},
+					{4, 5, nil, nil, "added"},
 				},
 			},
 			{
 				Query: "SELECT to_pk, to_c1, from_pk, from_c1, diff_type FROM DOLT_COMMIT_DIFF_t WHERE TO_COMMIT=@Commit2 and FROM_COMMIT=@Commit1 ORDER BY to_pk;",
 				Expected: []sql.Row{
-					{1, 3, 1, 3, "modified"},
-					{4, 6, 4, 6, "modified"},
+					{1, nil, 1, 2, "modified"},
+					{4, nil, 4, 5, "modified"},
 				},
 			},
 			{
 				Query: "SELECT to_pk, to_c1, from_pk, from_c1, diff_type FROM DOLT_COMMIT_DIFF_t WHERE TO_COMMIT=@Commit3 and FROM_COMMIT=@Commit2 ORDER BY to_pk;",
 				Expected: []sql.Row{
+					// TODO: Missing rows here see TestDiffSystemTable tests
 					{100, 101, nil, nil, "added"},
 				},
 			},


### PR DESCRIPTION
The dolt_diff_{table_name} system table now coerces schema by name only. The dolt_diff table uses the schema at head to interpret the tables at every prior commit. Previously the schema of the table at each prior commit was matched to the head schema using tags with a name fallback. Now it is matched by name only.

Let's consider an example between the new and old behaviors. Define table `t` with the following schema:
```sql
CREATE TABLE t (
    pk int PRIMARY KEY,
    a text
);
```

In commit1 we insert the following row:
```
INSERT INTO T VALUES (1, 'one');
```

In commit2 we rename col1 to col2:
```
ALTER TABLE T RENAME col1 TO col2
```

In the old behavior, we would see the following diffs. 

Between init and commit1:
```
+ (1, 'one')
```

No diff between commit1 and commit2.

In the new behavior, we would see the following diffs.

Between init and commit1:
```
+ (1, NULL)
```

No diff between commit1 and commit2. (We actually do expect to see `~ (1, 'one')` here but this is a TODO and known issue.)

Also adds warnings to new storage format when a column value coercion fails.