### PR TITLE
[no-release-notes] Add `enginetest` validation stage for secondary index consistency

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/validation.go
+++ b/go/libraries/doltcore/sqle/enginetest/validation.go
@@ -189,19 +189,26 @@ func ordinalMappingsForSecondaryIndex(sch schema.Schema, def schema.Index) (ord 
 	}
 
 	secondary := def.Schema().GetPKCols()
-	primary := sch.GetAllCols().GetColumns()
-
 	ord = make(val.OrdinalMapping, secondary.Size())
+
 	for i := range ord {
+		name := secondary.GetAtIndex(i).Name
 		ord[i] = -1
-		n := secondary.GetAtIndex(i).Name
-		for j, col := range primary {
-			if col.Name == n {
+
+		pks := sch.GetPKCols().GetColumns()
+		for j, col := range pks {
+			if col.Name == name {
 				ord[i] = j
 			}
 		}
+		vals := sch.GetNonPKCols().GetColumns()
+		for j, col := range vals {
+			if col.Name == name {
+				ord[i] = j + len(pks)
+			}
+		}
 		if ord[i] < 0 {
-			panic("column " + n + " not found")
+			panic("column " + name + " not found")
 		}
 	}
 	return


### PR DESCRIPTION
This validation stage runs after every engine test and asserts consistency between primary and secondary indexes.

For context, this GMS PR added enginetest validation: https://github.com/dolthub/go-mysql-server/pull/1043