### PR TITLE
dolt backup sync-url

### DIFF
--- a/go/cmd/dolt/commands/backup.go
+++ b/go/cmd/dolt/commands/backup.go
@@ -61,13 +61,18 @@ Remove the backup named {{.LessThan}}name{{.GreaterThan}}. All configuration set
 Restore a Dolt database from a given {{.LessThan}}url{{.GreaterThan}} into a specified directory {{.LessThan}}url{{.GreaterThan}}.
 
 {{.EmphasisLeft}}sync{{.EmphasisRight}}
-Snapshot the database and upload to the backup {{.LessThan}}name{{.GreaterThan}}. This includes branches, tags, working sets, and remote tracking refs.`,
+Snapshot the database and upload to the backup {{.LessThan}}name{{.GreaterThan}}. This includes branches, tags, working sets, and remote tracking refs.
+	
+{{.EmphasisLeft}}sync{{.EmphasisRight}}
+Snapshot the database and upload the backup to {{.LessThan}}url{{.GreaterThan}}. Like sync, this includes branches, tags, working sets, and remote tracking refs, but it does not require you to create a named backup`,
+
 	Synopsis: []string{
 		"[-v | --verbose]",
 		"add [--aws-region {{.LessThan}}region{{.GreaterThan}}] [--aws-creds-type {{.LessThan}}creds-type{{.GreaterThan}}] [--aws-creds-file {{.LessThan}}file{{.GreaterThan}}] [--aws-creds-profile {{.LessThan}}profile{{.GreaterThan}}] {{.LessThan}}name{{.GreaterThan}} {{.LessThan}}url{{.GreaterThan}}",
 		"remove {{.LessThan}}name{{.GreaterThan}}",
 		"restore {{.LessThan}}url{{.GreaterThan}} {{.LessThan}}name{{.GreaterThan}}",
 		"sync {{.LessThan}}name{{.GreaterThan}}",
+		"sync-url [--aws-region {{.LessThan}}region{{.GreaterThan}}] [--aws-creds-type {{.LessThan}}creds-type{{.GreaterThan}}] [--aws-creds-file {{.LessThan}}file{{.GreaterThan}}] [--aws-creds-profile {{.LessThan}}profile{{.GreaterThan}}] {{.LessThan}}url{{.GreaterThan}}",
 	},
 }
 
@@ -125,6 +130,8 @@ func (cmd BackupCmd) Exec(ctx context.Context, commandStr string, args []string,
 		verr = removeBackup(ctx, dEnv, apr)
 	case apr.Arg(0) == cli.SyncBackupId:
 		verr = syncBackup(ctx, dEnv, apr)
+	case apr.Arg(0) == cli.SyncBackupUrlId:
+		verr = syncBackupUrl(ctx, dEnv, apr)
 	case apr.Arg(0) == cli.RestoreBackupId:
 		verr = restoreBackup(ctx, dEnv, apr)
 	default:
@@ -171,9 +178,9 @@ func addBackup(dEnv *env.DoltEnv, apr *argparser.ArgParseResults) errhand.Verbos
 		return errhand.BuildDError("error: '%s' is not valid.", backupUrl).AddCause(err).Build()
 	}
 
-	params, verr := parseBackupArgs(apr, scheme, absBackupUrl)
-	if verr != nil {
-		return verr
+	params, err := cli.ProcessBackupArgs(apr, scheme, absBackupUrl)
+	if err != nil {
+		return errhand.VerboseErrorFromError(err)
 	}
 
 	r := env.NewRemote(backupName, backupUrl, params, dEnv)
@@ -193,19 +200,6 @@ func addBackup(dEnv *env.DoltEnv, apr *argparser.ArgParseResults) errhand.Verbos
 	default:
 		return errhand.BuildDError("error: Unable to save changes.").AddCause(err).Build()
 	}
-}
-
-func parseBackupArgs(apr *argparser.ArgParseResults, scheme, backupUrl string) (map[string]string, errhand.VerboseError) {
-	params := map[string]string{}
-
-	var verr errhand.VerboseError
-	if scheme == dbfactory.AWSScheme {
-		verr = addAWSParams(backupUrl, apr, params)
-	} else {
-		verr = verifyNoAwsParams(apr)
-	}
-
-	return params, verr
 }
 
 func printBackups(dEnv *env.DoltEnv, apr *argparser.ArgParseResults) errhand.VerboseError {
@@ -230,6 +224,26 @@ func printBackups(dEnv *env.DoltEnv, apr *argparser.ArgParseResults) errhand.Ver
 	return nil
 }
 
+func syncBackupUrl(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.ArgParseResults) errhand.VerboseError {
+	if apr.NArg() != 2 {
+		return errhand.BuildDError("").SetPrintUsage().Build()
+	}
+
+	backupUrl := apr.Arg(1)
+	scheme, absBackupUrl, err := env.GetAbsRemoteUrl(dEnv.FS, dEnv.Config, backupUrl)
+	if err != nil {
+		return errhand.BuildDError("error: '%s' is not valid.", backupUrl).AddCause(err).Build()
+	}
+
+	params, err := cli.ProcessBackupArgs(apr, scheme, absBackupUrl)
+	if err != nil {
+		return errhand.VerboseErrorFromError(err)
+	}
+
+	b := env.NewRemote("__temp__", backupUrl, params, dEnv)
+	return backup(ctx, dEnv, b)
+}
+
 func syncBackup(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.ArgParseResults) errhand.VerboseError {
 	if apr.NArg() != 2 {
 		return errhand.BuildDError("").SetPrintUsage().Build()
@@ -241,15 +255,21 @@ func syncBackup(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.ArgParseR
 	if err != nil {
 		return errhand.BuildDError("Unable to get backups from the local directory").AddCause(err).Build()
 	}
+
 	b, ok := backups[backupName]
 	if !ok {
 		return errhand.BuildDError("error: unknown backup: '%s' ", backupName).Build()
 	}
 
+	return backup(ctx, dEnv, b)
+}
+
+func backup(ctx context.Context, dEnv *env.DoltEnv, b env.Remote) errhand.VerboseError {
 	destDb, err := b.GetRemoteDB(ctx, dEnv.DoltDB.ValueReadWriter().Format())
 	if err != nil {
 		return errhand.BuildDError("error: unable to open destination.").AddCause(err).Build()
 	}
+
 	err = actions.SyncRoots(ctx, dEnv.DoltDB, destDb, dEnv.TempTableFilesDir(), buildProgStarter(defaultLanguage), stopProgFuncs)
 
 	switch err {

--- a/go/cmd/dolt/commands/backup.go
+++ b/go/cmd/dolt/commands/backup.go
@@ -63,7 +63,7 @@ Restore a Dolt database from a given {{.LessThan}}url{{.GreaterThan}} into a spe
 {{.EmphasisLeft}}sync{{.EmphasisRight}}
 Snapshot the database and upload to the backup {{.LessThan}}name{{.GreaterThan}}. This includes branches, tags, working sets, and remote tracking refs.
 	
-{{.EmphasisLeft}}sync{{.EmphasisRight}}
+{{.EmphasisLeft}}sync-url{{.EmphasisRight}}
 Snapshot the database and upload the backup to {{.LessThan}}url{{.GreaterThan}}. Like sync, this includes branches, tags, working sets, and remote tracking refs, but it does not require you to create a named backup`,
 
 	Synopsis: []string{

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_backup.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_backup.go
@@ -16,17 +16,17 @@ package dfunctions
 
 import (
 	"fmt"
-	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
-	"github.com/dolthub/dolt/go/libraries/doltcore/env"
-	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
+	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
+	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/store/datas/pull"
 )
 

--- a/integration-tests/bats/backup.bats
+++ b/integration-tests/bats/backup.bats
@@ -255,3 +255,17 @@ teardown() {
     [[ ! "$output" =~ "panic" ]] || false
     [[ "$output" =~ "address conflict with a remote: 'bac1'" ]] || false
 }
+
+@test "backup: sync-url" {
+    skip_nbf_dolt_1
+    cd repo1
+    dolt backup sync-url file://../bac1
+
+    cd ..
+    run dolt backup restore file://./bac1 repo2
+    cd repo2
+    run dolt ls
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 2 ]
+    [[ "$output" =~ "t1" ]] || false
+}

--- a/integration-tests/bats/sql-backup.bats
+++ b/integration-tests/bats/sql-backup.bats
@@ -90,3 +90,25 @@ teardown() {
     (cd the_restore && dolt status)
     dolt sql -q "CALL dolt_backup('sync', 'hostedapidb-0')"
 }
+
+@test "sql-backup: dolt_backup sync-url" {
+    mkdir the_backup
+    dolt sql -q "select dolt_backup('sync-url', 'file://./the_backup')"
+    # Initial backup works.
+    dolt backup restore file://./the_backup the_restore
+    (cd the_restore && dolt status)
+
+    rm -rf the_backup the_restore
+
+    mkdir the_backup
+    dolt sql -q "CALL dolt_backup('sync-url', 'file://./the_backup')"
+    dolt backup restore file://./the_backup the_restore
+    (cd the_restore && dolt status)
+}
+
+@test "sql-backup: dolt_backup sync-url fails for http remotes" {
+    run dolt sql -q "select dolt_backup('sync-url', 'http://dolthub.com/dolthub/backup')"
+    [ "$status" -ne 0 ]
+    run dolt sql -q "CALL dolt_backup('sync-url', 'https://dolthub.com/dolthub/backup')"
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Adds `sync-url` to the backup command as a way to backup a database without having to add a backup.  This is useful in sql-server mode where you cannot add named backups.