### PR TITLE
fixing panic when creating a polygon with more than one linestring

### DIFF
--- a/go/store/types/polygon.go
+++ b/go/store/types/polygon.go
@@ -160,7 +160,7 @@ func ParseEWKBPoly(buf []byte, srid uint32) Polygon {
 	lines := make([]LineString, numLines)
 	for i := uint32(0); i < numLines; i++ {
 		lines[i] = ParseEWKBLine(buf[s:], srid)
-		s += LengthSize * geometry.PointSize * len(lines[i].Points)
+		s += LengthSize + geometry.PointSize*len(lines[i].Points)
 	}
 
 	return Polygon{SRID: srid, Lines: lines}


### PR DESCRIPTION
```
geom_db> create table t (p polygon);
geom_db> insert into t values (polygon(linestring(point(1,1),point(2,2),point(3,3),point(1,1)),linestring(point(1,1),point(2,2),point(3,3),point(1,1)));
Query OK, 1 row affected
geom_db> select * from t;
panic in ExchangeIterPartitionRows: runtime error: slice bounds out of range [260:140]
```

fix was just a typo multiplying the index to be way out of range

enginetests for this case in GMS PR
