### PR TITLE
bugfix: using nils instead of "NULL" strings

### DIFF
--- a/go/libraries/doltcore/sqle/dtables/unscoped_diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/unscoped_diff_table.go
@@ -149,10 +149,10 @@ func (d *doltDiffWorkingSetRowItr) Next(ctx *sql.Context) (sql.Row, error) {
 	sqlRow := sql.NewRow(
 		changeSet,
 		change.tableName,
-		"NULL", // committer
-		"NULL", // email
-		"NULL", // date
-		"NULL", // message
+		nil, // committer
+		nil, // email
+		nil, // date
+		nil, // message
 		change.dataChange,
 		change.schemaChange,
 	)

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -3034,10 +3034,10 @@ var UnscopedDiffSystemTableScriptTests = []queries.ScriptTest{
 			{
 				Query: "SELECT * FROM DOLT_DIFF WHERE COMMIT_HASH in ('WORKING', 'STAGED') ORDER BY table_name;",
 				Expected: []sql.Row{
-					{"STAGED", "addedTable", "NULL", "NULL", "NULL", "NULL", false, true},
-					{"STAGED", "droppedTable", "NULL", "NULL", "NULL", "NULL", true, true},
-					{"WORKING", "newRenamedEmptyTable", "NULL", "NULL", "NULL", "NULL", false, true},
-					{"WORKING", "regularTable", "NULL", "NULL", "NULL", "NULL", true, false},
+					{"STAGED", "addedTable", nil, nil, nil, nil, false, true},
+					{"STAGED", "droppedTable", nil, nil, nil, nil, true, true},
+					{"WORKING", "newRenamedEmptyTable", nil, nil, nil, nil, false, true},
+					{"WORKING", "regularTable", nil, nil, nil, nil, true, false},
 				},
 			},
 		},

--- a/integration-tests/bats/system-tables.bats
+++ b/integration-tests/bats/system-tables.bats
@@ -224,6 +224,17 @@ teardown() {
     [[ "$output" =~ 0 ]] || false
 }
 
+@test "system-tables: query dolt_diff system table" {
+    dolt sql -q "CREATE TABLE testStaged (pk INT, c1 INT, PRIMARY KEY(pk))"
+    dolt add testStaged
+    dolt sql -q "CREATE TABLE testWorking (pk INT, c1 INT, PRIMARY KEY(pk))"
+
+    run dolt sql -r csv -q 'select * from dolt_diff'
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "STAGED,testStaged,,,,,false,true" ]] || false
+    [[ "$output" =~ "WORKING,testWorking,,,,,false,true" ]] || false
+}
+
 @test "system-tables: query dolt_diff_ system table" {
     dolt sql -q "CREATE TABLE test (pk INT, c1 INT, PRIMARY KEY(pk))"
     dolt add test


### PR DESCRIPTION
The `dolt_diff` system table was returning literal `"NULL"` strings instead of `nil` values. This worked in the enginetests, but when they get printed out in a shell they couldn't be converted into a datetime and produced an error. 