### PR TITLE
Improved error message for multistatement query failing during exec

### DIFF
--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -735,6 +735,7 @@ func runMultiStatementMode(ctx *sql.Context, se *engine.SqlEngine, input io.Read
 			if rowIter != nil {
 				err = engine.PrettyPrintResults(ctx, se.GetReturnFormat(), sqlSch, rowIter, HasTopLevelOrderByClause(query))
 				if err != nil {
+					err = fmt.Errorf("error executing query on line %d: %v", scanner.statementStartLine, err)
 					return errhand.VerboseErrorFromError(err)
 				}
 			}

--- a/integration-tests/bats/sql-branch.bats
+++ b/integration-tests/bats/sql-branch.bats
@@ -74,12 +74,12 @@ teardown() {
     dolt branch existing_branch
     run dolt sql -q "SELECT DOLT_BRANCH('existing_branch')"
     [ $status -eq 1 ]
-    [ "$output" = "fatal: A branch named 'existing_branch' already exists." ]
+    [[ "$output" =~ "fatal: A branch named 'existing_branch' already exists." ]] || false
 
     # empty branch
     run dolt sql -q "SELECT DOLT_BRANCH('')"
     [ $status -eq 1 ]
-    [ "$output" = "error: cannot branch empty string" ]
+    [[ "$output" =~ "error: cannot branch empty string" ]] || false
 }
 
 @test "sql-branch: CALL DOLT_BRANCH throws error" {
@@ -164,12 +164,12 @@ SQL
     # branch copying from is empty
     run dolt sql -q "SELECT DOLT_BRANCH('-c','','copy')"
     [ $status -eq 1 ]
-    [ "$output" = "error: cannot branch empty string" ]
+    [[ "$output" =~ "error: cannot branch empty string" ]] || false
 
     # branch copying to is empty
     run dolt sql -q "SELECT DOLT_BRANCH('-c','main','')"
     [ $status -eq 1 ]
-    [ "$output" = "error: cannot branch empty string" ]
+    [[ "$output" =~ "error: cannot branch empty string" ]] || false
 
     dolt branch 'existing_branch'
     run dolt branch
@@ -180,12 +180,12 @@ SQL
     # branch copying from that don't exist
     run dolt sql -q "SELECT DOLT_BRANCH('-c', 'original', 'copy');"
     [ $status -eq 1 ]
-    [ "$output" = "fatal: A branch named 'original' not found" ]
+    [[ "$output" =~ "fatal: A branch named 'original' not found" ]] || false
 
     # branch copying to that exists
     run dolt sql -q "SELECT DOLT_BRANCH('-c', 'main', 'existing_branch');"
     [ $status -eq 1 ]
-    [ "$output" = "fatal: A branch named 'existing_branch' already exists." ]
+    [[ "$output" =~ "fatal: A branch named 'existing_branch' already exists." ]] || false
 }
 
 @test "sql-branch: CALL DOLT_BRANCH -c throws error on error cases" {

--- a/integration-tests/bats/sql-spatial-types.bats
+++ b/integration-tests/bats/sql-spatial-types.bats
@@ -268,5 +268,5 @@ INSERT INTO t1 values (0, point(1,2));
 INSERT INTO t1 VALUES (1,0x000000000104000000030000000101000000000000000000F03F000000000000F03F010100000000000000000000400000000000000040010100000000000000000008400000000000000840);
 SQL
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "error executing query on line 2: unsupported feature: MultiPoint geospatial type" ]] || false
+    [[ "$output" =~ "error executing query on line 2: unsupported geospatial type: MultiPoint from value: 0x0" ]] || false
 }

--- a/integration-tests/bats/sql-spatial-types.bats
+++ b/integration-tests/bats/sql-spatial-types.bats
@@ -74,7 +74,7 @@ teardown() {
     [[ "$output" =~ "POLYGON((0.123 0.456,1.22 1.33,1.11 0.99,0.123 0.456))" ]] || false
 }
 
-@test "sql-spatial-types: create geometry table and insert existing spetial types" {
+@test "sql-spatial-types: create geometry table and insert existing spatial types" {
     skip_nbf_dolt_1
 
     # create geometry table
@@ -104,7 +104,6 @@ teardown() {
     [[ "$output" =~ "LINESTRING(1 2,3 4)" ]] || false
     [[ "$output" =~ "POLYGON((1 2,3 4,5 6,1 2))" ]] || false
 }
-
 
 @test "sql-spatial-types: prevent point as primary key" {
     run dolt sql -q "create table point_tbl (p point primary key)"
@@ -213,7 +212,7 @@ teardown() {
 
     run dolt sql -q "INSERT INTO pt VALUES (2, ST_GEOMFROMTEXT(ST_ASWKT(POINT(1,2)), 4326))"
     [ "$status" -eq 1 ]
-    [ "$output" = "The SRID of the geometry does not match the SRID of the column 'p'. The SRID of the geometry is 4326, but the SRID of the column is 0. Consider changing the SRID of the geometry or the SRID property of the column." ]
+    [[ "$output" =~ "The SRID of the geometry does not match the SRID of the column 'p'. The SRID of the geometry is 4326, but the SRID of the column is 0. Consider changing the SRID of the geometry or the SRID property of the column." ]] || false
 
     run dolt sql -q "SELECT ST_ASWKT(p) FROM pt"
     [[ ! "$output" =~ "POINT(1 2)" ]] || false
@@ -259,4 +258,15 @@ SQL
     run dolt sql -q "ALTER TABLE table1 MODIFY COLUMN p POINT SRID 0"
     [ "$status" -eq 1 ]
     [[ "$output" =~ "The SRID of the geometry does not match the SRID of the column 'p'. The SRID of the geometry is 4326, but the SRID of the column is 0. Consider changing the SRID of the geometry or the SRID property of the column." ]] || false
+}
+
+@test "sql-spatial-types: multistatement exec with unsupported spatial types" {
+    dolt sql -q "CREATE TABLE t1 (i int primary key, g GEOMETRY NOT NULL);"
+
+    run dolt sql << SQL
+INSERT INTO t1 values (0, point(1,2));
+INSERT INTO t1 VALUES (1,0x000000000104000000030000000101000000000000000000F03F000000000000F03F010100000000000000000000400000000000000040010100000000000000000008400000000000000840);
+SQL
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "error executing query on line 2: unsupported feature: MultiPoint geospatial type" ]] || false
 }


### PR DESCRIPTION
While debugging https://github.com/dolthub/dolt/issues/3512 , realized that if a multistatement exec fails during query execution, Dolt doesn't tell you which line failed. Updated the error message to include the failing statement's line and added a bats test for the original customer issue. 

Depends on: https://github.com/dolthub/go-mysql-server/pull/1066