### PR TITLE
go/libraries/doltcore/sqle/index: Cache durable.Index values for primary and secondary data.

### DIFF
--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -1566,3 +1566,11 @@ func (r fbRvStorage) DebugString(ctx context.Context) string {
 func (r fbRvStorage) nomsValue() types.Value {
 	return types.SerialMessage(r.srv.Table().Bytes)
 }
+
+type DataCacheKey struct {
+	rv *RootValue
+}
+
+func NewDataCacheKey(rv *RootValue) DataCacheKey {
+	return DataCacheKey{rv}
+}

--- a/go/libraries/doltcore/sqle/history_table.go
+++ b/go/libraries/doltcore/sqle/history_table.go
@@ -70,7 +70,7 @@ func (ht *HistoryTable) ShouldParallelizeAccess() bool {
 }
 
 func (ht *HistoryTable) GetIndexes(ctx *sql.Context) ([]sql.Index, error) {
-	tbl, err := ht.doltTable.doltTable(ctx)
+	tbl, err := ht.doltTable.DoltTable(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -275,9 +275,9 @@ type doltIndex struct {
 	vrw    types.ValueReadWriter
 	keyBld *val.TupleBuilder
 
-	cache            cachedDurableIndexes
-	coversAllCols    *bool
-	cachedLookupTags map[uint64]int
+	cache                 cachedDurableIndexes
+	coversAllCols         *bool
+	cachedLookupTags      map[uint64]int
 	cachedSqlRowConverter *KVToSqlRowConverter
 }
 

--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -30,6 +30,11 @@ import (
 	"github.com/dolthub/dolt/go/store/val"
 )
 
+type DoltTableable interface {
+	DoltTable(*sql.Context) (*doltdb.Table, error)
+	DataCacheKey(*sql.Context) (doltdb.DataCacheKey, bool, error)
+}
+
 type DoltIndex interface {
 	sql.FilteredIndex
 	sql.OrderedIndex
@@ -37,7 +42,7 @@ type DoltIndex interface {
 	IndexSchema() schema.Schema
 	Format() *types.NomsBinFormat
 	IsPrimaryKey() bool
-	GetDurableIndexes(*sql.Context, *doltdb.Table) (durable.Index, durable.Index, error)
+	GetDurableIndexes(*sql.Context, DoltTableable) (durable.Index, durable.Index, error)
 }
 
 func DoltDiffIndexesFromTable(ctx context.Context, db, tbl string, t *doltdb.Table) (indexes []sql.Index, err error) {
@@ -86,7 +91,7 @@ func DoltDiffIndexesFromTable(ctx context.Context, db, tbl string, t *doltdb.Tab
 
 	// TODO: need to add from_ columns
 
-	return append(indexes, toIndex), nil
+	return append(indexes, &toIndex), nil
 }
 
 func DoltIndexesFromTable(ctx context.Context, db, tbl string, t *doltdb.Table) (indexes []sql.Index, err error) {
@@ -146,7 +151,7 @@ func TableHasIndex(ctx context.Context, db, tbl string, t *doltdb.Table, i sql.I
 // indexesMatch returns whether the two index objects should be considered the same index for the purpose of a lookup,
 // i.e. whether they have the same name and index the same table columns.
 func indexesMatch(a sql.Index, b sql.Index) bool {
-	dia, dib := a.(doltIndex), b.(doltIndex)
+	dia, dib := a.(*doltIndex), b.(*doltIndex)
 	if dia.isPk != dib.isPk || dia.id != dib.id {
 		return false
 	}
@@ -171,7 +176,7 @@ func DoltHistoryIndexesFromTable(ctx context.Context, db, tbl string, t *doltdb.
 
 	unorderedIndexes := make([]sql.Index, len(indexes))
 	for i := range indexes {
-		di := indexes[i].(doltIndex)
+		di := indexes[i].(*doltIndex)
 		// History table indexed reads don't come back in order (iterated by commit graph first), and can include rows that
 		// weren't asked for (because the index needed may not exist at all revisions)
 		di.order = sql.IndexOrderNone
@@ -191,7 +196,7 @@ func getPrimaryKeyIndex(ctx context.Context, db, tbl string, t *doltdb.Table, sc
 
 	cols := sch.GetPKCols().GetColumns()
 
-	return doltIndex{
+	return &doltIndex{
 		id:                            "PRIMARY",
 		tblName:                       tbl,
 		dbName:                        db,
@@ -220,7 +225,7 @@ func getSecondaryIndex(ctx context.Context, db, tbl string, t *doltdb.Table, sch
 		cols[i], _ = idx.GetColumn(tag)
 	}
 
-	return doltIndex{
+	return &doltIndex{
 		id:                            idx.Name(),
 		tblName:                       tbl,
 		dbName:                        db,
@@ -235,6 +240,16 @@ func getSecondaryIndex(ctx context.Context, db, tbl string, t *doltdb.Table, sch
 		order:                         sql.IndexOrderAsc,
 		constrainedToLookupExpression: true,
 	}, nil
+}
+
+type DurableIndexes struct {
+	Primary durable.Index
+	Secondary durable.Index
+}
+
+type cachedDurableIndexes struct {
+	key doltdb.DataCacheKey
+	indexes DurableIndexes
 }
 
 type doltIndex struct {
@@ -255,12 +270,14 @@ type doltIndex struct {
 
 	vrw    types.ValueReadWriter
 	keyBld *val.TupleBuilder
+
+	cache cachedDurableIndexes
 }
 
 var _ DoltIndex = (*doltIndex)(nil)
 
 // ColumnExpressionTypes implements the interface sql.Index.
-func (di doltIndex) ColumnExpressionTypes(ctx *sql.Context) []sql.ColumnExpressionType {
+func (di *doltIndex) ColumnExpressionTypes(ctx *sql.Context) []sql.ColumnExpressionType {
 	cets := make([]sql.ColumnExpressionType, len(di.columns))
 	for i, col := range di.columns {
 		cets[i] = sql.ColumnExpressionType{
@@ -272,7 +289,7 @@ func (di doltIndex) ColumnExpressionTypes(ctx *sql.Context) []sql.ColumnExpressi
 }
 
 // NewLookup implements the interface sql.Index.
-func (di doltIndex) NewLookup(ctx *sql.Context, ranges ...sql.Range) (sql.IndexLookup, error) {
+func (di *doltIndex) NewLookup(ctx *sql.Context, ranges ...sql.Range) (sql.IndexLookup, error) {
 	if len(ranges) == 0 {
 		return nil, nil
 	}
@@ -284,7 +301,24 @@ func (di doltIndex) NewLookup(ctx *sql.Context, ranges ...sql.Range) (sql.IndexL
 	return di.newNomsLookup(ctx, ranges...)
 }
 
-func (di doltIndex) GetDurableIndexes(ctx *sql.Context, t *doltdb.Table) (primary, secondary durable.Index, err error) {
+func (di *doltIndex) GetDurableIndexes(ctx *sql.Context, ti DoltTableable) (primary, secondary durable.Index, err error) {
+	var newkey doltdb.DataCacheKey
+	var cancache bool
+	newkey, cancache, err = ti.DataCacheKey(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if cancache && di.cache.key == newkey {
+		return di.cache.indexes.Primary, di.cache.indexes.Secondary, nil
+	}
+
+	var t *doltdb.Table
+	t, err = ti.DoltTable(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	primary, err = t.GetRowData(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -297,10 +331,17 @@ func (di doltIndex) GetDurableIndexes(ctx *sql.Context, t *doltdb.Table) (primar
 			return nil, nil, err
 		}
 	}
+
+	if cancache {
+		di.cache.key = newkey
+		di.cache.indexes.Primary = primary
+		di.cache.indexes.Secondary = secondary
+	}
+
 	return
 }
 
-func (di doltIndex) newProllyLookup(ctx *sql.Context, ranges ...sql.Range) (sql.IndexLookup, error) {
+func (di *doltIndex) newProllyLookup(ctx *sql.Context, ranges ...sql.Range) (sql.IndexLookup, error) {
 	var err error
 	sqlRanges, err := pruneEmptyRanges(ranges)
 	if err != nil {
@@ -327,7 +368,7 @@ func (di doltIndex) newProllyLookup(ctx *sql.Context, ranges ...sql.Range) (sql.
 	}, nil
 }
 
-func (di doltIndex) newNomsLookup(ctx *sql.Context, ranges ...sql.Range) (sql.IndexLookup, error) {
+func (di *doltIndex) newNomsLookup(ctx *sql.Context, ranges ...sql.Range) (sql.IndexLookup, error) {
 	// This might remain nil if the given nomsRanges each contain an EmptyRange for one of the columns. This will just
 	// cause the lookup to return no rows, which is the desired behavior.
 	var readRanges []*noms.ReadRange
@@ -426,7 +467,7 @@ RangeLoop:
 	}, nil
 }
 
-func (di doltIndex) HandledFilters(filters []sql.Expression) []sql.Expression {
+func (di *doltIndex) HandledFilters(filters []sql.Expression) []sql.Expression {
 	if types.IsFormat_DOLT_1(di.vrw.Format()) {
 		// todo(andy): handle first column filters
 		return nil
@@ -438,17 +479,17 @@ func (di doltIndex) HandledFilters(filters []sql.Expression) []sql.Expression {
 	}
 }
 
-func (di doltIndex) Order() sql.IndexOrder {
+func (di *doltIndex) Order() sql.IndexOrder {
 	return di.order
 }
 
 // Database implement sql.Index
-func (di doltIndex) Database() string {
+func (di *doltIndex) Database() string {
 	return di.dbName
 }
 
 // Expressions implements sql.Index
-func (di doltIndex) Expressions() []string {
+func (di *doltIndex) Expressions() []string {
 	strs := make([]string, len(di.columns))
 	for i, col := range di.columns {
 		strs[i] = di.tblName + "." + col.Name
@@ -457,57 +498,57 @@ func (di doltIndex) Expressions() []string {
 }
 
 // ID implements sql.Index
-func (di doltIndex) ID() string {
+func (di *doltIndex) ID() string {
 	return di.id
 }
 
 // IsUnique implements sql.Index
-func (di doltIndex) IsUnique() bool {
+func (di *doltIndex) IsUnique() bool {
 	return di.unique
 }
 
 // IsPrimaryKey implements DoltIndex.
-func (di doltIndex) IsPrimaryKey() bool {
+func (di *doltIndex) IsPrimaryKey() bool {
 	return di.isPk
 }
 
 // Comment implements sql.Index
-func (di doltIndex) Comment() string {
+func (di *doltIndex) Comment() string {
 	return di.comment
 }
 
 // IndexType implements sql.Index
-func (di doltIndex) IndexType() string {
+func (di *doltIndex) IndexType() string {
 	return "BTREE"
 }
 
 // IsGenerated implements sql.Index
-func (di doltIndex) IsGenerated() bool {
+func (di *doltIndex) IsGenerated() bool {
 	return false
 }
 
 // Schema returns the dolt Table schema of this index.
-func (di doltIndex) Schema() schema.Schema {
+func (di *doltIndex) Schema() schema.Schema {
 	return di.tableSch
 }
 
 // IndexSchema returns the dolt index schema.
-func (di doltIndex) IndexSchema() schema.Schema {
+func (di *doltIndex) IndexSchema() schema.Schema {
 	return di.indexSch
 }
 
 // Table implements sql.Index
-func (di doltIndex) Table() string {
+func (di *doltIndex) Table() string {
 	return di.tblName
 }
 
-func (di doltIndex) Format() *types.NomsBinFormat {
+func (di *doltIndex) Format() *types.NomsBinFormat {
 	return di.vrw.Format()
 }
 
 // keysToTuple returns a tuple that indicates the starting point for an index. The empty tuple will cause the index to
 // start at the very beginning.
-func (di doltIndex) keysToTuple(ctx *sql.Context, keys []interface{}) (types.Tuple, error) {
+func (di *doltIndex) keysToTuple(ctx *sql.Context, keys []interface{}) (types.Tuple, error) {
 	nbf := di.vrw.Format()
 	if len(keys) > len(di.columns) {
 		return types.EmptyTuple(nbf), errors.New("too many keys for the column count")

--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -243,12 +243,12 @@ func getSecondaryIndex(ctx context.Context, db, tbl string, t *doltdb.Table, sch
 }
 
 type DurableIndexes struct {
-	Primary durable.Index
+	Primary   durable.Index
 	Secondary durable.Index
 }
 
 type cachedDurableIndexes struct {
-	key doltdb.DataCacheKey
+	key     doltdb.DataCacheKey
 	indexes DurableIndexes
 }
 

--- a/go/libraries/doltcore/sqle/index/dolt_index_test.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index_test.go
@@ -1064,7 +1064,7 @@ func TestDoltIndexBetween(t *testing.T) {
 			require.NoError(t, err)
 			require.True(t, ok)
 
-			indexIter, err := index.RowIterForIndexLookup(ctx, dt, indexLookup, pkSch, nil)
+			indexIter, err := index.RowIterForIndexLookup(ctx, NoCacheTableable{dt}, indexLookup, pkSch, nil)
 			require.NoError(t, err)
 
 			// If this is a primary index assert that a covering index was used
@@ -1083,6 +1083,18 @@ func TestDoltIndexBetween(t *testing.T) {
 			requireUnorderedRowsEqual(t, expectedRows, readRows)
 		})
 	}
+}
+
+type NoCacheTableable struct {
+	dt *doltdb.Table
+}
+
+func (t NoCacheTableable) DoltTable(ctx *sql.Context) (*doltdb.Table, error) {
+	return t.dt, nil
+}
+
+func (t NoCacheTableable) DataCacheKey(ctx *sql.Context) (doltdb.DataCacheKey, bool, error) {
+	return doltdb.DataCacheKey{}, false, nil
 }
 
 type rowSlice struct {
@@ -1295,7 +1307,7 @@ func testDoltIndex(t *testing.T, ctx *sql.Context, root *doltdb.RootValue, keys 
 	pkSch, err := sqlutil.FromDoltSchema("fake_table", idx.Schema())
 	require.NoError(t, err)
 
-	indexIter, err := index.RowIterForIndexLookup(ctx, dt, indexLookup, pkSch, nil)
+	indexIter, err := index.RowIterForIndexLookup(ctx, NoCacheTableable{dt}, indexLookup, pkSch, nil)
 	require.NoError(t, err)
 
 	var readRows []sql.Row

--- a/go/libraries/doltcore/sqle/index/index_lookup.go
+++ b/go/libraries/doltcore/sqle/index/index_lookup.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/dolthub/go-mysql-server/sql"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
@@ -44,7 +43,7 @@ func PartitionIndexedTableRows(ctx *sql.Context, idx sql.Index, part sql.Partiti
 	return RowIterForNomsRanges(ctx, doltIdx, ranges, columns, rp.primary, rp.secondary)
 }
 
-func RowIterForIndexLookup(ctx *sql.Context, t *doltdb.Table, ilu sql.IndexLookup, pkSch sql.PrimaryKeySchema, columns []string) (sql.RowIter, error) {
+func RowIterForIndexLookup(ctx *sql.Context, t DoltTableable, ilu sql.IndexLookup, pkSch sql.PrimaryKeySchema, columns []string) (sql.RowIter, error) {
 	lookup := ilu.(*doltIndexLookup)
 	idx := lookup.idx
 
@@ -126,7 +125,7 @@ func DoltIndexFromLookup(lookup sql.IndexLookup) DoltIndex {
 	return lookup.(*doltIndexLookup).idx
 }
 
-func NewRangePartitionIter(ctx *sql.Context, t *doltdb.Table, lookup sql.IndexLookup) (sql.PartitionIter, error) {
+func NewRangePartitionIter(ctx *sql.Context, t DoltTableable, lookup sql.IndexLookup) (sql.PartitionIter, error) {
 	dlu := lookup.(*doltIndexLookup)
 	primary, secondary, err := dlu.idx.GetDurableIndexes(ctx, t)
 	if err != nil {

--- a/go/libraries/doltcore/sqle/index/index_lookup.go
+++ b/go/libraries/doltcore/sqle/index/index_lookup.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/typed/noms"
 	"github.com/dolthub/dolt/go/store/prolly"
 	"github.com/dolthub/dolt/go/store/types"
@@ -67,7 +66,7 @@ func RowIterForProllyRange(ctx *sql.Context, idx DoltIndex, r prolly.Range, pkSc
 		return newProllyKeylessIndexIter(ctx, idx, r, pkSch, primary, secondary)
 	}
 
-	covers := indexCoversCols(idx, columns)
+	covers := idx.CoversColumns(columns)
 	if covers {
 		return newProllyCoveringIndexIter(ctx, idx, r, pkSch, secondary)
 	} else {
@@ -79,41 +78,12 @@ func RowIterForNomsRanges(ctx *sql.Context, idx DoltIndex, ranges []*noms.ReadRa
 	m := durable.NomsMapFromIndex(secondary)
 	nrr := noms.NewNomsRangeReader(idx.IndexSchema(), m, ranges)
 
-	covers := indexCoversCols(idx, columns)
+	covers := idx.CoversColumns(columns)
 	if covers || idx.ID() == "PRIMARY" {
 		return NewCoveringIndexRowIterAdapter(ctx, idx, nrr, columns), nil
 	} else {
 		return NewIndexLookupRowIterAdapter(ctx, idx, primary, nrr)
 	}
-}
-
-func indexCoversCols(idx DoltIndex, cols []string) bool {
-	if cols == nil {
-		cols = idx.Schema().GetAllCols().GetColumnNames()
-	}
-
-	var idxCols *schema.ColCollection
-	if types.IsFormat_DOLT_1(idx.Format()) {
-		// prolly indexes can cover an index lookup using
-		// both the key and value fields of the index,
-		// this allows using covering index machinery for
-		// primary key index lookups.
-		idxCols = idx.IndexSchema().GetAllCols()
-	} else {
-		// to cover an index lookup, noms indexes must
-		// contain all fields in the index's key.
-		idxCols = idx.IndexSchema().GetPKCols()
-	}
-
-	covers := true
-	for _, colName := range cols {
-		if _, ok := idxCols.GetByNameCaseInsensitive(colName); !ok {
-			covers = false
-			break
-		}
-	}
-
-	return covers
 }
 
 type IndexLookupKeyIterator interface {

--- a/go/libraries/doltcore/sqle/index/index_lookup.go
+++ b/go/libraries/doltcore/sqle/index/index_lookup.go
@@ -66,7 +66,7 @@ func RowIterForProllyRange(ctx *sql.Context, idx DoltIndex, r prolly.Range, pkSc
 		return newProllyKeylessIndexIter(ctx, idx, r, pkSch, primary, secondary)
 	}
 
-	covers := idx.CoversColumns(columns)
+	covers := idx.coversColumns(columns)
 	if covers {
 		return newProllyCoveringIndexIter(ctx, idx, r, pkSch, secondary)
 	} else {
@@ -78,7 +78,7 @@ func RowIterForNomsRanges(ctx *sql.Context, idx DoltIndex, ranges []*noms.ReadRa
 	m := durable.NomsMapFromIndex(secondary)
 	nrr := noms.NewNomsRangeReader(idx.IndexSchema(), m, ranges)
 
-	covers := idx.CoversColumns(columns)
+	covers := idx.coversColumns(columns)
 	if covers || idx.ID() == "PRIMARY" {
 		return NewCoveringIndexRowIterAdapter(ctx, idx, nrr, columns), nil
 	} else {

--- a/go/libraries/doltcore/sqle/index/noms_index_iter.go
+++ b/go/libraries/doltcore/sqle/index/noms_index_iter.go
@@ -56,16 +56,6 @@ type indexLookupRowIterAdapter struct {
 
 // NewIndexLookupRowIterAdapter returns a new indexLookupRowIterAdapter.
 func NewIndexLookupRowIterAdapter(ctx *sql.Context, idx DoltIndex, tableData durable.Index, keyIter nomsKeyIter) (*indexLookupRowIterAdapter, error) {
-	lookupTags := make(map[uint64]int)
-	for i, tag := range idx.Schema().GetPKCols().Tags {
-		lookupTags[tag] = i
-	}
-
-	// handle keyless case, where no columns are pk's and rowIdTag is the only lookup tag
-	if len(lookupTags) == 0 {
-		lookupTags[schema.KeylessRowIdTag] = 0
-	}
-
 	rows := durable.NomsMapFromIndex(tableData)
 
 	conv := NewKVToSqlRowConverterForCols(idx.Format(), idx.Schema())
@@ -79,7 +69,7 @@ func NewIndexLookupRowIterAdapter(ctx *sql.Context, idx DoltIndex, tableData dur
 		keyIter:    keyIter,
 		tableRows:  rows,
 		conv:       conv,
-		lookupTags: lookupTags,
+		lookupTags: idx.lookupTags(),
 		cancelF:    cancelF,
 		resultBuf:  resBuf,
 	}

--- a/go/libraries/doltcore/sqle/index/noms_index_iter.go
+++ b/go/libraries/doltcore/sqle/index/noms_index_iter.go
@@ -58,7 +58,6 @@ type indexLookupRowIterAdapter struct {
 func NewIndexLookupRowIterAdapter(ctx *sql.Context, idx DoltIndex, tableData durable.Index, keyIter nomsKeyIter) (*indexLookupRowIterAdapter, error) {
 	rows := durable.NomsMapFromIndex(tableData)
 
-	conv := NewKVToSqlRowConverterForCols(idx.Format(), idx.Schema())
 	resBuf := resultBufferPool.Get().(*async.RingBuffer)
 	epoch := resBuf.Reset()
 
@@ -68,7 +67,7 @@ func NewIndexLookupRowIterAdapter(ctx *sql.Context, idx DoltIndex, tableData dur
 		idx:        idx,
 		keyIter:    keyIter,
 		tableRows:  rows,
-		conv:       conv,
+		conv:       idx.sqlRowConverter(),
 		lookupTags: idx.lookupTags(),
 		cancelF:    cancelF,
 		resultBuf:  resBuf,

--- a/go/libraries/doltcore/sqle/indexed_dolt_table.go
+++ b/go/libraries/doltcore/sqle/indexed_dolt_table.go
@@ -52,28 +52,15 @@ func (idt *IndexedDoltTable) Schema() sql.Schema {
 }
 
 func (idt *IndexedDoltTable) Partitions(ctx *sql.Context) (sql.PartitionIter, error) {
-	dt, err := idt.table.doltTable(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return index.NewRangePartitionIter(ctx, dt, idt.indexLookup)
+	return index.NewRangePartitionIter(ctx, idt.table, idt.indexLookup)
 }
 
 func (idt *IndexedDoltTable) PartitionRows(ctx *sql.Context, part sql.Partition) (sql.RowIter, error) {
-	// todo(andy): only used by 'AS OF` queries
-	dt, err := idt.table.doltTable(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return index.RowIterForIndexLookup(ctx, dt, idt.indexLookup, idt.table.sqlSch, nil)
+	return index.RowIterForIndexLookup(ctx, idt.table, idt.indexLookup, idt.table.sqlSch, nil)
 }
 
 func (idt *IndexedDoltTable) PartitionRows2(ctx *sql.Context, part sql.Partition) (sql.RowIter, error) {
-	dt, err := idt.table.doltTable(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return index.RowIterForIndexLookup(ctx, dt, idt.indexLookup, idt.table.sqlSch, nil)
+	return index.RowIterForIndexLookup(ctx, idt.table, idt.indexLookup, idt.table.sqlSch, nil)
 }
 
 func (idt *IndexedDoltTable) IsTemporary() bool {
@@ -95,11 +82,7 @@ type WritableIndexedDoltTable struct {
 var _ sql.Table2 = (*WritableIndexedDoltTable)(nil)
 
 func (t *WritableIndexedDoltTable) Partitions(ctx *sql.Context) (sql.PartitionIter, error) {
-	dt, err := t.doltTable(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return index.NewRangePartitionIter(ctx, dt, t.indexLookup)
+	return index.NewRangePartitionIter(ctx, t.DoltTable, t.indexLookup)
 }
 
 func (t *WritableIndexedDoltTable) PartitionRows(ctx *sql.Context, part sql.Partition) (sql.RowIter, error) {

--- a/go/libraries/doltcore/sqle/procedures_table.go
+++ b/go/libraries/doltcore/sqle/procedures_table.go
@@ -141,12 +141,7 @@ func DoltProceduresGetAll(ctx *sql.Context, db Database) ([]sql.StoredProcedureD
 		return nil, err
 	}
 
-	dt, err := tbl.doltTable(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	iter, err := index.RowIterForIndexLookup(ctx, dt, lookup, tbl.sqlSch, nil)
+	iter, err := index.RowIterForIndexLookup(ctx, tbl.DoltTable, lookup, tbl.sqlSch, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -270,12 +265,7 @@ func DoltProceduresGetDetails(ctx *sql.Context, tbl *WritableDoltTable, name str
 		return sql.StoredProcedureDetails{}, false, err
 	}
 
-	dt, err := tbl.doltTable(ctx)
-	if err != nil {
-		return sql.StoredProcedureDetails{}, false, err
-	}
-
-	rowIter, err := index.RowIterForIndexLookup(ctx, dt, indexLookup, tbl.sqlSch, nil)
+	rowIter, err := index.RowIterForIndexLookup(ctx, tbl.DoltTable, indexLookup, tbl.sqlSch, nil)
 	if err != nil {
 		return sql.StoredProcedureDetails{}, false, err
 	}

--- a/go/libraries/doltcore/sqle/rows.go
+++ b/go/libraries/doltcore/sqle/rows.go
@@ -200,7 +200,7 @@ func ProllyRowIterFromPartition(
 // of |columns|.  Providing a column name which does not appear in the schema
 // is not an error, but no corresponding column will appear in the results.
 func TableToRowIter(ctx *sql.Context, table *WritableDoltTable, columns []string) (sql.RowIter, error) {
-	t, err := table.doltTable(ctx)
+	t, err := table.DoltTable.DoltTable(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/schema_table.go
+++ b/go/libraries/doltcore/sqle/schema_table.go
@@ -170,7 +170,7 @@ func migrateOldSchemasTableToNew(
 ) {
 	// Copy all of the old data over and add an index column and an extra column
 	var rowsToAdd []sql.Row
-	table, err := schemasTable.doltTable(ctx)
+	table, err := schemasTable.DoltTable.DoltTable(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -279,12 +279,7 @@ func fragFromSchemasTable(ctx *sql.Context, tbl *WritableDoltTable, fragType str
 		return nil, false, err
 	}
 
-	dt, err := tbl.doltTable(ctx)
-	if err != nil {
-		return nil, false, err
-	}
-
-	iter, err := index.RowIterForIndexLookup(ctx, dt, lookup, tbl.sqlSch, nil)
+	iter, err := index.RowIterForIndexLookup(ctx, tbl.DoltTable, lookup, tbl.sqlSch, nil)
 	if err != nil {
 		return nil, false, err
 	}

--- a/go/libraries/doltcore/sqle/schema_table_test.go
+++ b/go/libraries/doltcore/sqle/schema_table_test.go
@@ -58,7 +58,7 @@ func TestSchemaTableRecreationOlder(t *testing.T) {
 	err = inserter.Close(ctx)
 	require.NoError(t, err)
 
-	table, err := sqlTbl.(*WritableDoltTable).doltTable(ctx)
+	table, err := sqlTbl.(*WritableDoltTable).DoltTable.DoltTable(ctx)
 	require.NoError(t, err)
 
 	rowData, err := table.GetNomsRowData(ctx)
@@ -81,7 +81,7 @@ func TestSchemaTableRecreationOlder(t *testing.T) {
 	tbl, err := GetOrCreateDoltSchemasTable(ctx, db) // removes the old table and recreates it with the new schema
 	require.NoError(t, err)
 
-	table, err = tbl.doltTable(ctx)
+	table, err = tbl.DoltTable.DoltTable(ctx)
 	require.NoError(t, err)
 
 	rowData, err = table.GetNomsRowData(ctx)
@@ -136,7 +136,7 @@ func TestSchemaTableRecreation(t *testing.T) {
 	err = inserter.Close(ctx)
 	require.NoError(t, err)
 
-	table, err := sqlTbl.(*WritableDoltTable).doltTable(ctx)
+	table, err := sqlTbl.(*WritableDoltTable).DoltTable.DoltTable(ctx)
 	require.NoError(t, err)
 
 	rowData, err := table.GetNomsRowData(ctx)
@@ -159,7 +159,7 @@ func TestSchemaTableRecreation(t *testing.T) {
 	tbl, err := GetOrCreateDoltSchemasTable(ctx, db) // removes the old table and recreates it with the new schema
 	require.NoError(t, err)
 
-	table, err = tbl.doltTable(ctx)
+	table, err = tbl.DoltTable.DoltTable(ctx)
 	require.NoError(t, err)
 
 	rowData, err = table.GetNomsRowData(ctx)

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -187,14 +187,10 @@ func (t *DoltTable) WithIndexLookup(lookup sql.IndexLookup) sql.Table {
 }
 
 // doltTable returns the underlying doltTable from the current session
-func (t *DoltTable) doltTable(ctx *sql.Context) (*doltdb.Table, error) {
-	root := t.lockedToRoot
-	var err error
-	if root == nil {
-		root, err = t.getRoot(ctx)
-		if err != nil {
-			return nil, err
-		}
+func (t *DoltTable) DoltTable(ctx *sql.Context) (*doltdb.Table, error) {
+	root, err := t.workingRoot(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	table, ok, err := root.GetTable(ctx, t.tableName)
@@ -208,6 +204,27 @@ func (t *DoltTable) doltTable(ctx *sql.Context) (*doltdb.Table, error) {
 	return table, nil
 }
 
+// Return an opaque key that can be compared for equality to see if this
+// table's data still matches a previous view of the data that was retrieved
+// through DoltTable() or NumRows(), for example.
+//
+// Returns |false| for |ok| if this table's data is not cacheable.
+func (t *DoltTable) DataCacheKey(ctx *sql.Context) (doltdb.DataCacheKey, bool, error) {
+	r, err := t.workingRoot(ctx)
+	if err != nil {
+		return doltdb.DataCacheKey{}, false, err
+	}
+	return doltdb.NewDataCacheKey(r), true, nil
+}
+
+func (t *DoltTable) workingRoot(ctx *sql.Context) (*doltdb.RootValue, error) {
+	root := t.lockedToRoot
+	if root == nil {
+		return t.getRoot(ctx)
+	}
+	return root, nil
+}
+
 // getRoot returns the appropriate root value for this session. The only controlling factor
 // is whether this is a temporary table or not.
 func (t *DoltTable) getRoot(ctx *sql.Context) (*doltdb.RootValue, error) {
@@ -216,7 +233,7 @@ func (t *DoltTable) getRoot(ctx *sql.Context) (*doltdb.RootValue, error) {
 
 // GetIndexes implements sql.IndexedTable
 func (t *DoltTable) GetIndexes(ctx *sql.Context) ([]sql.Index, error) {
-	tbl, err := t.doltTable(ctx)
+	tbl, err := t.DoltTable(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +243,7 @@ func (t *DoltTable) GetIndexes(ctx *sql.Context) ([]sql.Index, error) {
 
 // HasIndex returns whether the given index is present in the table
 func (t *DoltTable) HasIndex(ctx *sql.Context, idx sql.Index) (bool, error) {
-	tbl, err := t.doltTable(ctx)
+	tbl, err := t.DoltTable(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -236,7 +253,7 @@ func (t *DoltTable) HasIndex(ctx *sql.Context, idx sql.Index) (bool, error) {
 
 // GetAutoIncrementValue gets the last AUTO_INCREMENT value
 func (t *DoltTable) GetAutoIncrementValue(ctx *sql.Context) (interface{}, error) {
-	table, err := t.doltTable(ctx)
+	table, err := t.DoltTable(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -255,7 +272,7 @@ func (t *DoltTable) String() string {
 
 // NumRows returns the unfiltered count of rows contained in the table
 func (t *DoltTable) NumRows(ctx *sql.Context) (uint64, error) {
-	table, err := t.doltTable(ctx)
+	table, err := t.DoltTable(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -295,7 +312,7 @@ func (t *DoltTable) sqlSchema() sql.PrimaryKeySchema {
 
 // Partitions returns the partitions for this table.
 func (t *DoltTable) Partitions(ctx *sql.Context) (sql.PartitionIter, error) {
-	table, err := t.doltTable(ctx)
+	table, err := t.DoltTable(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -365,7 +382,7 @@ func (itr emptyRowIterator) Close(*sql.Context) error {
 
 // PartitionRows returns the table rows for the partition given
 func (t *DoltTable) PartitionRows(ctx *sql.Context, partition sql.Partition) (sql.RowIter, error) {
-	table, err := t.doltTable(ctx)
+	table, err := t.DoltTable(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +391,7 @@ func (t *DoltTable) PartitionRows(ctx *sql.Context, partition sql.Partition) (sq
 }
 
 func (t DoltTable) PartitionRows2(ctx *sql.Context, part sql.Partition) (sql.RowIter2, error) {
-	table, err := t.doltTable(ctx)
+	table, err := t.DoltTable(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -498,7 +515,7 @@ func (t *WritableDoltTable) Replacer(ctx *sql.Context) sql.RowReplacer {
 
 // Truncate implements sql.TruncateableTable
 func (t *WritableDoltTable) Truncate(ctx *sql.Context) (int, error) {
-	table, err := t.doltTable(ctx)
+	table, err := t.DoltTable.DoltTable(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -606,7 +623,7 @@ func (t *WritableDoltTable) getTableAutoIncrementValue(ctx *sql.Context) (interf
 }
 
 func (t *DoltTable) GetChecks(ctx *sql.Context) ([]sql.CheckDefinition, error) {
-	table, err := t.doltTable(ctx)
+	table, err := t.DoltTable(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1102,7 +1119,7 @@ func (t *AlterableDoltTable) RewriteInserter(
 		return nil, err
 	}
 
-	dt, err := t.doltTable(ctx)
+	dt, err := t.DoltTable.DoltTable(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1537,7 +1554,7 @@ func (t *AlterableDoltTable) CreateIndex(
 		columns[i] = indexCol.Name
 	}
 
-	table, err := t.doltTable(ctx)
+	table, err := t.DoltTable.DoltTable(ctx)
 	if err != nil {
 		return err
 	}
@@ -1630,7 +1647,7 @@ func (t *AlterableDoltTable) RenameIndex(ctx *sql.Context, fromIndexName string,
 		return err
 	}
 
-	table, err := t.doltTable(ctx)
+	table, err := t.DoltTable.DoltTable(ctx)
 	if err != nil {
 		return err
 	}
@@ -2037,7 +2054,7 @@ func (t *AlterableDoltTable) CreateIndexForForeignKey(ctx *sql.Context, indexNam
 		columns[i] = indexCol.Name
 	}
 
-	table, err := t.doltTable(ctx)
+	table, err := t.DoltTable.DoltTable(ctx)
 	if err != nil {
 		return err
 	}
@@ -2163,7 +2180,7 @@ func (t *AlterableDoltTable) dropIndex(ctx *sql.Context, indexName string) (*dol
 		return nil, nil, err
 	}
 
-	table, err := t.doltTable(ctx)
+	table, err := t.DoltTable.DoltTable(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2231,7 +2248,7 @@ func (t *AlterableDoltTable) CreateCheck(ctx *sql.Context, check *sql.CheckDefin
 		return err
 	}
 
-	table, err := t.doltTable(ctx)
+	table, err := t.DoltTable.DoltTable(ctx)
 	if err != nil {
 		return err
 	}
@@ -2275,7 +2292,7 @@ func (t *AlterableDoltTable) DropCheck(ctx *sql.Context, chName string) error {
 		return err
 	}
 
-	table, err := t.doltTable(ctx)
+	table, err := t.DoltTable.DoltTable(ctx)
 	if err != nil {
 		return err
 	}
@@ -2354,7 +2371,7 @@ func (t *AlterableDoltTable) CreatePrimaryKey(ctx *sql.Context, columns []sql.In
 		return nil
 	}
 
-	table, err := t.doltTable(ctx)
+	table, err := t.DoltTable.DoltTable(ctx)
 	if err != nil {
 		return err
 	}
@@ -2418,7 +2435,7 @@ func (t *AlterableDoltTable) DropPrimaryKey(ctx *sql.Context) error {
 		return err
 	}
 
-	table, err := t.doltTable(ctx)
+	table, err := t.DoltTable.DoltTable(ctx)
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/sqle/temp_table.go
+++ b/go/libraries/doltcore/sqle/temp_table.go
@@ -219,9 +219,17 @@ func (t *TempTable) DataLength(ctx *sql.Context) (uint64, error) {
 	return idx.Count(), nil
 }
 
+func (t *TempTable) DoltTable(ctx *sql.Context) (*doltdb.Table, error) {
+	return t.table, nil
+}
+
+func (t *TempTable) DataCacheKey(ctx *sql.Context) (doltdb.DataCacheKey, bool, error) {
+	return doltdb.DataCacheKey{}, false, nil
+}
+
 func (t *TempTable) PartitionRows(ctx *sql.Context, partition sql.Partition) (sql.RowIter, error) {
 	if t.lookup != nil {
-		return index.RowIterForIndexLookup(ctx, t.table, t.lookup, t.pkSch, nil)
+		return index.RowIterForIndexLookup(ctx, t, t.lookup, t.pkSch, nil)
 	} else {
 		return partitionRows(ctx, t.table, t.sqlSchema().Schema, nil, partition)
 	}

--- a/go/libraries/doltcore/sqle/testutil.go
+++ b/go/libraries/doltcore/sqle/testutil.go
@@ -321,7 +321,7 @@ func DoltSchemaFromAlterableTable(t *AlterableDoltTable) schema.Schema {
 
 // DoltTableFromAlterableTable is a utility for integration tests
 func DoltTableFromAlterableTable(ctx *sql.Context, t *AlterableDoltTable) *doltdb.Table {
-	dt, err := t.doltTable(ctx)
+	dt, err := t.DoltTable.DoltTable(ctx)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Introduce an instance-local cache which can refresh its value when
the working root of the underlying table changes.

In 4300e8460eccfc999059eca503748766b7327869 we changed DoltIndex
implementations to not store row data. Index implementations are retrieved at
analysis time and used at query time, and storing row data in them breaks
things like static lookups and index joins in things like prepared statements
and stored procedures.

Retrieving the row data from the doltdb.Table instance for every lookup turns
out to have a sizeable performance impact, especially on something like a large
join.