### PR TITLE
Fix cherry-pick flaky test

### DIFF
--- a/go/cmd/dolt/commands/cnfcmds/cat.go
+++ b/go/cmd/dolt/commands/cnfcmds/cat.go
@@ -137,8 +137,7 @@ func exitWithVerr(verr errhand.VerboseError) int {
 func printConflicts(ctx context.Context, root *doltdb.RootValue, tblNames []string) errhand.VerboseError {
 	if len(tblNames) == 1 && tblNames[0] == "." {
 		var err error
-		tblNames, err = doltdb.UnionTableNames(ctx, root)
-
+		tblNames, err = root.GetTableNames(ctx)
 		if err != nil {
 			return errhand.BuildDError("unable to read tables").AddCause(err).Build()
 		}

--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -1258,19 +1258,27 @@ func GetRootValueSuperSchema(ctx context.Context, root *RootValue) (*schema.Supe
 }
 
 // UnionTableNames returns an array of all table names in all roots passed as params.
+// The table names are in order of the RootValues passed in.
 func UnionTableNames(ctx context.Context, roots ...*RootValue) ([]string, error) {
-	allTblNames := make([]string, 0, 16)
+	if len(roots) < 1 {
+		return nil, nil
+	}
+	seenTblNamesMap := make(map[string]bool)
+	tblNames := []string{}
 	for _, root := range roots {
-		tblNames, err := root.GetTableNames(ctx)
-
+		rootTblNames, err := root.GetTableNames(ctx)
 		if err != nil {
 			return nil, err
 		}
-
-		allTblNames = append(allTblNames, tblNames...)
+		for _, tn := range rootTblNames {
+			if _, ok := seenTblNamesMap[tn]; !ok {
+				seenTblNamesMap[tn] = true
+				tblNames = append(tblNames, tn)
+			}
+		}
 	}
 
-	return set.Unique(allTblNames), nil
+	return tblNames, nil
 }
 
 // validateTagUniqueness checks for tag collisions between the given table and the set of tables in then given root.

--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -1260,9 +1260,6 @@ func GetRootValueSuperSchema(ctx context.Context, root *RootValue) (*schema.Supe
 // UnionTableNames returns an array of all table names in all roots passed as params.
 // The table names are in order of the RootValues passed in.
 func UnionTableNames(ctx context.Context, roots ...*RootValue) ([]string, error) {
-	if len(roots) < 1 {
-		return nil, nil
-	}
 	seenTblNamesMap := make(map[string]bool)
 	tblNames := []string{}
 	for _, root := range roots {

--- a/go/libraries/doltcore/merge/merge.go
+++ b/go/libraries/doltcore/merge/merge.go
@@ -969,6 +969,7 @@ func MergeRoots(ctx context.Context, theirRootIsh, ancRootIsh hash.Hash, ourRoot
 		}
 	}
 
+	// ourRoot table names need to be in front of the result array, so pass in as the first RootValue
 	tblNames, err := doltdb.UnionTableNames(ctx, ourRoot, theirRoot)
 
 	if err != nil {

--- a/go/libraries/doltcore/merge/merge.go
+++ b/go/libraries/doltcore/merge/merge.go
@@ -969,7 +969,12 @@ func MergeRoots(ctx context.Context, theirRootIsh, ancRootIsh hash.Hash, ourRoot
 		}
 	}
 
-	// ourRoot table names need to be in front of the result array, so pass in as the first RootValue
+	// Make sure to pass in ourRoot as the first RootValue so that ourRoot's table names will be merged first.
+	// This helps to avoid non-deterministic error result for table rename cases. Renaming a table creates two changes:
+	// 1. dropping the old name table
+	// 2. adding the new name table
+	// Dropping the old name table will trigger delete/modify conflict, which is the preferred error case over
+	// same column tag used error returned from creating the new name table.
 	tblNames, err := doltdb.UnionTableNames(ctx, ourRoot, theirRoot)
 
 	if err != nil {
@@ -983,7 +988,8 @@ func MergeRoots(ctx context.Context, theirRootIsh, ancRootIsh hash.Hash, ourRoot
 	optsWithFKChecks := opts
 	optsWithFKChecks.ForeignKeyChecksDisabled = true
 
-	// Merge tables one at a time. This is done based on name, so will work badly for things like table renames.
+	// Merge tables one at a time. This is done based on name. With table names from ourRoot being merged first,
+	// renaming a table will return delete/modify conflict error consistently.
 	// TODO: merge based on a more durable table identity that persists across renames
 	merger := NewMerger(ctx, theirRootIsh, ancRootIsh, ourRoot, theirRoot, ancRoot, ourRoot.VRW())
 	for _, tblName := range tblNames {


### PR DESCRIPTION
This PR fixes `cherry-pick: commit with ALTER TABLE rename table name` flaky bats test. 
`doltdb.UnionTableNames()` method returns inconsistent/randomized ordered array of table names. Renaming table is not tracked when merging, so that it becomes the old name table being dropping and the new table being added. If the tableNames array has old table name first, then the error case is caught, but if the tableNames array has the new table name first, then MergeRoots try to add the exact same table, which returns error of same column tags. 
To avoid this, `doltdb.UnionTableNames()` method now returns unique table names present in order of RootValues passed in.