### PR TITLE
Fix broken link for hosted dolt in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ baby.
 
 We also built [DoltHub](https://www.dolthub.com), a place to share
 Dolt databases. We host public data for free. If you want to host
-your own version of DoltHub, we have [DoltLab](https://www.doltlab.com). If you want us to run a Dolt server for you, we have [Hosted Dolt](hosted.doltdb.com).
+your own version of DoltHub, we have [DoltLab](https://www.doltlab.com). If you want us to run a Dolt server for you, we have [Hosted Dolt](https://hosted.doltdb.com).
 
 [Join us on Discord](https://discord.com/invite/RFwfYpu) to say hi and
 ask questions.


### PR DESCRIPTION
Without the HTTPS prefix, the link went to https://github.com/dolthub/dolt/blob/main/hosted.doltdb.com