### PR TITLE
Add remote tracking info to dolt status

### DIFF
--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -468,37 +468,6 @@ func getAddedNotStaged(notStagedTbls []diff.TableDelta, notStagedDocs *diff.DocD
 	return lines
 }
 
-// TODO: working docs in conflict param not used here
-func PrintStatus(ctx context.Context, dEnv *env.DoltEnv, stagedTbls, notStagedTbls []diff.TableDelta, workingTblsInConflict, workingTblsWithViolations []string, stagedDocs, notStagedDocs *diff.DocDiffs) error {
-	cli.Printf(branchHeader, dEnv.RepoStateReader().CWBHeadRef().GetPath())
-
-	mergeActive, err := dEnv.IsMergeActive(ctx)
-	if err != nil {
-		return err
-	}
-
-	if mergeActive {
-		if len(workingTblsInConflict) > 0 && len(workingTblsWithViolations) > 0 {
-			cli.Println(fmt.Sprintf(unmergedTablesHeader, "conflicts and constraint violations"))
-		} else if len(workingTblsInConflict) > 0 {
-			cli.Println(fmt.Sprintf(unmergedTablesHeader, "conflicts"))
-		} else if len(workingTblsWithViolations) > 0 {
-			cli.Println(fmt.Sprintf(unmergedTablesHeader, "constraint violations"))
-		} else {
-			cli.Println(allMergedHeader)
-		}
-	}
-
-	n := printStagedDiffs(cli.CliOut, stagedTbls, stagedDocs, true)
-	n = PrintDiffsNotStaged(ctx, dEnv, cli.CliOut, notStagedTbls, notStagedDocs, true, n, workingTblsInConflict, workingTblsWithViolations)
-
-	if !mergeActive && n == 0 {
-		cli.Println("nothing to commit, working tree clean")
-	}
-
-	return nil
-}
-
 const (
 	branchHeader     = "On branch %s\n"
 	stagedHeader     = `Changes to be committed:`

--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -17,10 +17,11 @@ package commands
 import (
 	"context"
 	"fmt"
+	"io"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions/commitwalk"
 	"github.com/dolthub/dolt/go/store/hash"
-	"io"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"

--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -235,18 +235,14 @@ func countCommitsInRange(ctx context.Context, ddb *doltdb.DoltDB, startCommitHas
 	}
 	count := 0
 	for {
-		_, commit, err := itr.Next(ctx)
+		hash, _, err := itr.Next(ctx)
 		if err == io.EOF {
 			return 0, errors.New("no match found to ancestor commit")
 		} else if err != nil {
 			return 0, err
 		}
 
-		h, err := commit.HashOf()
-		if err != nil {
-			return 0, err
-		}
-		if h == targetCommitHash {
+		if hash == targetCommitHash {
 			break
 		}
 		count += 1

--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -105,7 +105,7 @@ func (cmd StatusCmd) Exec(ctx context.Context, commandStr string, args []string,
 
 // TODO: working docs in conflict param not used here
 func PrintStatus(ctx context.Context, dEnv *env.DoltEnv, stagedTbls, notStagedTbls []diff.TableDelta, workingTblsInConflict, workingTblsWithViolations []string, stagedDocs, notStagedDocs *diff.DocDiffs) error {
-	cli.Printf(branchHeader, rsr.CWBHeadRef().GetPath())
+	cli.Printf(branchHeader, dEnv.RepoStateReader().CWBHeadRef().GetPath())
 
 	err := printRemoteRefTrackingInfo(ctx, dEnv)
 	if err != nil {


### PR DESCRIPTION
Added remote tracking information for dolt status. If the local branch has upstream remote branch, `dolt status` outputs whether the local branch is ahead of, behind, diverged from or up-to-date with the tracked remote branch.