### PR TITLE
[no-release-notes] dolt constraints verify for new format

### DIFF
--- a/go/cmd/dolt/commands/cvcmds/verify_constraints.go
+++ b/go/cmd/dolt/commands/cvcmds/verify_constraints.go
@@ -179,7 +179,7 @@ func printViolationsForTable(ctx context.Context, tblName string, tbl *doltdb.Ta
 	}
 
 	if limitItr.hitLimit {
-		cli.Println("Over 50 constraint violations were found. Please query '%s' to see them all.\\n", doltdb.DoltConstViolTablePrefix+tblName)
+		cli.Printf("Over 50 constraint violations were found. Please query '%s' to see them all.\n", doltdb.DoltConstViolTablePrefix+tblName)
 	}
 
 	return nil

--- a/go/cmd/dolt/commands/cvcmds/verify_constraints.go
+++ b/go/cmd/dolt/commands/cvcmds/verify_constraints.go
@@ -16,8 +16,9 @@ package cvcmds
 
 import (
 	"context"
-
-	"github.com/dolthub/go-mysql-server/sql"
+	"fmt"
+	"io"
+	"strings"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands"
@@ -26,10 +27,10 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/merge"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlutil"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 	"github.com/dolthub/dolt/go/libraries/utils/set"
 	"github.com/dolthub/dolt/go/store/types"
+	"github.com/dolthub/go-mysql-server/sql"
 )
 
 var verifyConstraintsDocs = cli.CommandDocumentationContent{
@@ -53,7 +54,7 @@ func (cmd VerifyConstraintsCmd) Description() string {
 }
 
 func (cmd VerifyConstraintsCmd) GatedForNBF(nbf *types.NomsBinFormat) bool {
-	return types.IsFormat_DOLT_1(nbf)
+	return false
 }
 
 func (cmd VerifyConstraintsCmd) Docs() *cli.CommandDocumentation {
@@ -109,51 +110,103 @@ func (cmd VerifyConstraintsCmd) Exec(ctx context.Context, commandStr string, arg
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.BuildDError("Unable to process constraint violations.").AddCause(err).Build(), nil)
 	}
-	if !outputOnly {
-		err = dEnv.UpdateWorkingRoot(ctx, endRoot)
-		if err != nil {
-			return commands.HandleVErrAndExitCode(errhand.BuildDError("Unable to update working root.").AddCause(err).Build(), nil)
-		}
+
+	err = dEnv.UpdateWorkingRoot(ctx, endRoot)
+	if err != nil {
+		return commands.HandleVErrAndExitCode(errhand.BuildDError("Unable to update working root.").AddCause(err).Build(), nil)
 	}
 
 	if tablesWithViolations.Size() > 0 {
 		cli.PrintErrln("All constraints are not satisfied.")
+		eng, err := engine.NewSqlEngineForEnv(ctx, dEnv)
+		if err != nil {
+			return commands.HandleVErrAndExitCode(errhand.BuildDError("Failed to build sql engine.").AddCause(err).Build(), nil)
+		}
+
 		for _, tableName := range tablesWithViolations.AsSortedSlice() {
-			table, ok, err := endRoot.GetTable(ctx, tableName)
+			tbl, ok, err := endRoot.GetTable(ctx, tableName)
 			if err != nil {
 				return commands.HandleVErrAndExitCode(errhand.BuildDError("Error loading table.").AddCause(err).Build(), nil)
 			}
 			if !ok {
 				return commands.HandleVErrAndExitCode(errhand.BuildDError("Unable to load table '%s'.", tableName).Build(), nil)
 			}
-			cvSch, err := table.GetConstraintViolationsSchema(ctx)
-			if err != nil {
-				return commands.HandleVErrAndExitCode(errhand.BuildDError("Error loading constraint violations schema.").AddCause(err).Build(), nil)
-			}
-			cvMap, err := table.GetConstraintViolations(ctx)
-			if err != nil {
-				return commands.HandleVErrAndExitCode(errhand.BuildDError("Error loading constraint violations data.").AddCause(err).Build(), nil)
-			}
-			sqlSchema, err := sqlutil.FromDoltSchema(tableName, cvSch)
-			if err != nil {
-				return commands.HandleVErrAndExitCode(errhand.BuildDError("Error attempting to convert schema").AddCause(err).Build(), nil)
-			}
-			rowIter, err := sqlutil.MapToSqlIter(ctx, cvSch, cvMap)
-			if err != nil {
-				return commands.HandleVErrAndExitCode(errhand.BuildDError("Error attempting to create row iterator").AddCause(err).Build(), nil)
-			}
 			cli.Println("")
 			cli.Println(doltdb.DoltConstViolTablePrefix + tableName)
-			if cvMap.Len() > 50 {
-				cli.Printf("Over 50 constraint violations were found. Please query '%s' to see them all.\n", doltdb.DoltConstViolTablePrefix+tableName)
-			} else {
-				err = engine.PrettyPrintResults(sql.NewEmptyContext(), engine.FormatTabular, sqlSchema.Schema, rowIter, false)
-				if err != nil {
-					return commands.HandleVErrAndExitCode(errhand.BuildDError("Error outputting rows").AddCause(err).Build(), nil)
-				}
+			dErr := printViolationsForTable(ctx, tableName, tbl, eng)
+			if dErr != nil {
+				return commands.HandleVErrAndExitCode(dErr, nil)
 			}
 		}
+
+		if outputOnly {
+			err = dEnv.UpdateWorkingRoot(ctx, working)
+			if err != nil {
+				return commands.HandleVErrAndExitCode(errhand.BuildDError("Unable to undo written constraint violations").AddCause(err).Build(), nil)
+			}
+		}
+
 		return 1
 	}
+
 	return 0
+}
+
+func printViolationsForTable(ctx context.Context, tblName string, tbl *doltdb.Table, eng *engine.SqlEngine) errhand.VerboseError {
+	sch, err := tbl.GetSchema(ctx)
+	if err != nil {
+		return errhand.BuildDError("Error loading table schema").AddCause(err).Build()
+	}
+
+	colNames := strings.Join(sch.GetAllCols().GetColumnNames(), ", ")
+	query := fmt.Sprintf("SELECT violation_type, %s, violation_info from dolt_constraint_violations_%s", colNames, tblName)
+
+	sCtx, err := engine.NewLocalSqlContext(ctx, eng)
+	if err != nil {
+		return errhand.BuildDError("Error making sql context").AddCause(err).Build()
+	}
+	sqlSch, sqlItr, err := eng.Query(sCtx, query)
+	if err != nil {
+		return errhand.BuildDError("Error querying constraint violations").AddCause(err).Build()
+	}
+
+	limitItr := &sqlLimitIter{itr: sqlItr, limit: 50}
+
+	err = engine.PrettyPrintResults(sCtx, engine.FormatTabular, sqlSch, limitItr, false)
+	if err != nil {
+		return errhand.BuildDError("Error outputting rows").AddCause(err).Build()
+	}
+
+	if limitItr.hitLimit {
+		cli.Println("Over 50 constraint violations were found. Please query '%s' to see them all.\\n", doltdb.DoltConstViolTablePrefix+tblName)
+	}
+
+	return nil
+}
+
+// returns io.EOF and sets hitLimit when |limit|+1 rows have been iterated from |itr|.
+type sqlLimitIter struct {
+	itr      sql.RowIter
+	limit    uint64
+	count    uint64
+	hitLimit bool
+}
+
+var _ sql.RowIter = &sqlLimitIter{}
+
+func (itr *sqlLimitIter) Next(ctx *sql.Context) (sql.Row, error) {
+	r, err := itr.itr.Next(ctx)
+	if err != nil {
+		return nil, err
+	}
+	itr.count++
+	if itr.count > itr.limit {
+		itr.hitLimit = true
+		return nil, io.EOF
+	}
+	return r, nil
+}
+
+func (itr *sqlLimitIter) Close(ctx *sql.Context) error {
+	return itr.itr.Close(ctx)
 }

--- a/go/cmd/dolt/commands/cvcmds/verify_constraints.go
+++ b/go/cmd/dolt/commands/cvcmds/verify_constraints.go
@@ -20,6 +20,8 @@ import (
 	"io"
 	"strings"
 
+	"github.com/dolthub/go-mysql-server/sql"
+
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
@@ -30,7 +32,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 	"github.com/dolthub/dolt/go/libraries/utils/set"
 	"github.com/dolthub/dolt/go/store/types"
-	"github.com/dolthub/go-mysql-server/sql"
 )
 
 var verifyConstraintsDocs = cli.CommandDocumentationContent{

--- a/integration-tests/bats/constraint-violations.bats
+++ b/integration-tests/bats/constraint-violations.bats
@@ -2662,7 +2662,6 @@ SQL
 }
 
 @test "constraint-violations: cyclic foreign keys, illegal deletion" {
-    skip_nbf_dolt_1 "uses dolt constraints verify"
 
     # We're deleting a reference in a cycle from each table to make sure it properly applies a violation in both instances
     dolt sql <<"SQL"

--- a/integration-tests/bats/verify-constraints.bats
+++ b/integration-tests/bats/verify-constraints.bats
@@ -57,12 +57,10 @@ teardown() {
 }
 
 @test "verify-constraints: Constraints verified" {
-    skip_nbf_dolt_1
     dolt constraints verify child1 child2
 }
 
 @test "verify-constraints: One table fails" {
-    skip_nbf_dolt_1
     dolt sql <<SQL
 SET foreign_key_checks=0;
 DELETE FROM parent1 WHERE pk = 1;
@@ -80,7 +78,6 @@ SQL
 }
 
 @test "verify-constraints: Two tables fail" {
-    skip_nbf_dolt_1
     dolt sql <<SQL
 SET foreign_key_checks=0;
 DELETE FROM parent2 WHERE pk = 2;
@@ -101,7 +98,6 @@ SQL
 }
 
 @test "verify-constraints: Ignores NULLs" {
-    skip_nbf_dolt_1
     dolt sql <<SQL
 CREATE TABLE parent (
     id BIGINT PRIMARY KEY,
@@ -131,7 +127,6 @@ SQL
 }
 
 @test "verify-constraints: CLI missing --all and --output-only, no named tables" {
-    skip_nbf_dolt_1
     run dolt constraints verify
     [ "$status" -eq "1" ]
     [[ "$output" =~ "fk_name1" ]] || false
@@ -142,7 +137,6 @@ SQL
 }
 
 @test "verify-constraints: CLI missing --all and --output-only, named tables" {
-    skip_nbf_dolt_1
     run dolt constraints verify child3
     [ "$status" -eq "1" ]
     [[ "$output" =~ "fk_name1" ]] || false
@@ -153,7 +147,6 @@ SQL
 }
 
 @test "verify-constraints: CLI --all" {
-    skip_nbf_dolt_1
     run dolt constraints verify --all child3 child4
     [ "$status" -eq "1" ]
     [[ "$output" =~ "fk_name1" ]] || false
@@ -165,7 +158,6 @@ SQL
 }
 
 @test "verify-constraints: CLI --output-only" {
-    skip_nbf_dolt_1
     run dolt constraints verify --output-only child3 child4
     [ "$status" -eq "1" ]
     [[ "$output" =~ "fk_name1" ]] || false
@@ -177,7 +169,6 @@ SQL
 }
 
 @test "verify-constraints: CLI --all and --output-only" {
-    skip_nbf_dolt_1
     run dolt constraints verify --all --output-only child3 child4
     [ "$status" -eq "1" ]
     [[ "$output" =~ "fk_name1" ]] || false


### PR DESCRIPTION
Reimplements dolt constraints verify to use the sql path when outputting rows.