### PR TITLE
[no-release-notes] Benchmarks for hash perf

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -99,7 +99,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/jstemmer/go-junit-report v0.9.1 // indirect
 	github.com/klauspost/compress v1.10.10 // indirect
-	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
+	github.com/klauspost/cpuid/v2 v2.0.12 // indirect
 	github.com/lestrrat-go/strftime v1.0.4 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/mattn/go-colorable v0.1.7 // indirect
@@ -117,6 +117,7 @@ require (
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/tklauser/numcpus v0.3.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
+	github.com/zeebo/blake3 v0.2.3 // indirect
 	go.opencensus.io v0.22.4 // indirect
 	go.uber.org/atomic v1.6.0 // indirect
 	go.uber.org/multierr v1.5.0 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -451,6 +451,8 @@ github.com/klauspost/compress v1.10.10 h1:a/y8CglcM7gLGYmlbP/stPE5sR3hbhFRUjCBfd
 github.com/klauspost/compress v1.10.10/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
+github.com/klauspost/cpuid/v2 v2.0.12 h1:p9dKCg8i4gmOxtv35DvrYoWqYzQrvEVdjQ762Y0OqZE=
+github.com/klauspost/cpuid/v2 v2.0.12/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
@@ -746,7 +748,11 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yusufpapurcu/wmi v1.2.2 h1:KBNDSne4vP5mbSWnJbO+51IMOXJB67QiYCSBrubbPRg=
 github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+github.com/zeebo/assert v1.1.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
+github.com/zeebo/blake3 v0.2.3 h1:TFoLXsjeXqRNFxSbk35Dk4YtszE/MQQGK10BH4ptoTg=
+github.com/zeebo/blake3 v0.2.3/go.mod h1:mjJjZpnsyIVtVgTOSpJ9vmRE4wgDeyt2HU3qXvvKCaQ=
+github.com/zeebo/pcg v1.0.1/go.mod h1:09F0S9iiKrwn9rlI5yjLkmrug154/YRW6KnnXVDM/l4=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/go/store/hash/hash_test.go
+++ b/go/store/hash/hash_test.go
@@ -22,9 +22,10 @@
 package hash
 
 import (
-	"golang.org/x/crypto/blake2b"
 	"math/rand"
 	"testing"
+
+	"golang.org/x/crypto/blake2b"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/zeebo/blake3"

--- a/go/store/hash/hash_test.go
+++ b/go/store/hash/hash_test.go
@@ -22,13 +22,13 @@
 package hash
 
 import (
+	"golang.org/x/crypto/blake2b"
 	"math/rand"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/zeebo/blake3"
 	"github.com/zeebo/xxh3"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestParseError(t *testing.T) {
@@ -164,6 +164,13 @@ func BenchmarkSha512(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		j := i % len(benchData)
 		_ = Of(benchData[j])
+	}
+}
+
+func BenchmarkBlake2(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		j := i % len(benchData)
+		_ = blake2b.Sum256(benchData[j])
 	}
 }
 

--- a/go/store/hash/hash_test.go
+++ b/go/store/hash/hash_test.go
@@ -22,7 +22,11 @@
 package hash
 
 import (
+	"math/rand"
 	"testing"
+
+	"github.com/zeebo/blake3"
+	"github.com/zeebo/xxh3"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -143,4 +147,36 @@ func TestCompareGreater(t *testing.T) {
 	assert.False(r0.Compare(r0) > 0)
 	assert.False(r0.Compare(r2) > 0)
 	assert.True(r2.Compare(r0) > 0)
+}
+
+func init() {
+	avg, std := 4096.0, 1024.0
+	for i := range benchData {
+		sz := int(rand.NormFloat64()*std + avg)
+		benchData[i] = make([]byte, sz)
+		rand.Read(benchData[i])
+	}
+}
+
+var benchData [512][]byte
+
+func BenchmarkSha512(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		j := i % len(benchData)
+		_ = Of(benchData[j])
+	}
+}
+
+func BenchmarkBlake3(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		j := i % len(benchData)
+		_ = blake3.Sum256(benchData[j])
+	}
+}
+
+func BenchmarkXXHash(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		j := i % len(benchData)
+		_ = xxh3.Hash128(benchData[j])
+	}
 }


### PR DESCRIPTION
```
 % go test -bench Benchmark
goos: darwin
goarch: amd64
pkg: github.com/dolthub/dolt/go/store/hash
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkSha512-12        172446              6149   ns/op
BenchmarkBlake2-12        313255              3648   ns/op
BenchmarkBlake3-12        467600              2421   ns/op
BenchmarkXXHash-12       9873788               124.2 ns/op
PASS
ok      github.com/dolthub/dolt/go/store/hash   4.943s

```