### PR TITLE
[no-release-notes] Generate random key data with uniform distribution when running sysbe…

### DIFF
--- a/go/performance/utils/sysbench_runner/config.go
+++ b/go/performance/utils/sysbench_runner/config.go
@@ -59,6 +59,7 @@ var (
 var defaultSysbenchParams = []string{
 	"--db-driver=mysql",
 	"--db-ps-mode=disable",
+	"--rand-type=uniform",
 	fmt.Sprintf("--mysql-db=%s", dbName),
 }
 


### PR DESCRIPTION
…nch benchmarks

The default distribution for Sysbench is "Special" ([reference](https://www.percona.com/blog/2020/03/26/sysbench-and-the-random-distribution-effect/)), here we switch to "Uniform":

<img width="855" alt="image" src="https://user-images.githubusercontent.com/8837413/176321562-96453e1d-c539-4e8e-a03d-09360dca1612.png">
