### PR TITLE
fix inconsistencies of dolt checkout and pull commands

### DIFF
--- a/go/cmd/dolt/commands/checkout.go
+++ b/go/cmd/dolt/commands/checkout.go
@@ -267,18 +267,18 @@ func setRemoteUpstreamForCheckout(dEnv *env.DoltEnv, branchRef ref.RemoteRef) er
 	src := refSpec.SrcRef(dEnv.RepoStateReader().CWBHeadRef())
 	dest := refSpec.DestRef(src)
 
-	uErr := dEnv.RepoStateWriter().UpdateBranch(src.GetPath(), env.BranchConfig{
+	err = dEnv.RepoStateWriter().UpdateBranch(src.GetPath(), env.BranchConfig{
 		Merge: ref.MarshalableRef{
 			Ref: dest,
 		},
 		Remote: branchRef.GetRemote(),
 	})
-	if uErr != nil {
-		return errhand.BuildDError(uErr.Error()).Build()
+	if err != nil {
+		return errhand.BuildDError(err.Error()).Build()
 	}
-	uErr = dEnv.RepoState.Save(dEnv.FS)
-	if uErr != nil {
-		uErr = errhand.BuildDError(actions.ErrFailedToSaveRepoState.Error()).AddCause(uErr).Build()
+	err = dEnv.RepoState.Save(dEnv.FS)
+	if err != nil {
+		return errhand.BuildDError(actions.ErrFailedToSaveRepoState.Error()).AddCause(err).Build()
 	}
 	cli.Printf("branch '%s' set up to track '%s'.\n", src.GetPath(), branchRef.GetPath())
 

--- a/go/cmd/dolt/commands/checkout.go
+++ b/go/cmd/dolt/commands/checkout.go
@@ -241,7 +241,7 @@ func checkoutBranch(ctx context.Context, dEnv *env.DoltEnv, name string, force b
 			return bdr.Build()
 		} else if err == doltdb.ErrAlreadyOnBranch {
 			// Being on the same branch shouldn't be an error
-			cli.Printf("Already on branch '%s'", name)
+			cli.Printf("Already on branch '%s'\n", name)
 			return nil
 		} else {
 			bdr := errhand.BuildDError("fatal: Unexpected error checking out branch '%s'", name)

--- a/go/cmd/dolt/commands/checkout.go
+++ b/go/cmd/dolt/commands/checkout.go
@@ -17,6 +17,7 @@ package commands
 import (
 	"context"
 	"fmt"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"

--- a/go/cmd/dolt/commands/pull.go
+++ b/go/cmd/dolt/commands/pull.go
@@ -130,6 +130,11 @@ func pullHelper(ctx context.Context, dEnv *env.DoltEnv, pullSpec *env.PullSpec) 
 				return fmt.Errorf("fetch failed; %w", err)
 			}
 
+			// Only merge iff branch is current branch and there is an upstream set (pullSpec.Branch is set to nil if there is no upstream)
+			if branchRef != pullSpec.Branch {
+				continue
+			}
+
 			t := datas.CommitNowFunc()
 
 			roots, err := dEnv.Roots(ctx)
@@ -145,11 +150,6 @@ func pullHelper(ctx context.Context, dEnv *env.DoltEnv, pullSpec *env.PullSpec) 
 					return configErr
 				}
 				name, email = "", ""
-			}
-
-			// Only merge iff branch is current branch
-			if branchRef != pullSpec.Branch {
-				continue
 			}
 
 			// Begin merge

--- a/go/cmd/dolt/commands/pull.go
+++ b/go/cmd/dolt/commands/pull.go
@@ -81,11 +81,13 @@ func (cmd PullCmd) Exec(ctx context.Context, commandStr string, args []string, d
 	}
 
 	var remoteName string
+	var remoteOnly = false
 	if apr.NArg() == 1 {
 		remoteName = apr.Arg(0)
+		remoteOnly = true
 	}
 
-	pullSpec, err := env.NewPullSpec(ctx, dEnv.RepoStateReader(), remoteName, apr.Contains(cli.SquashParam), apr.Contains(cli.NoFFParam), apr.Contains(cli.ForceFlag))
+	pullSpec, err := env.NewPullSpec(ctx, dEnv.RepoStateReader(), remoteName, apr.Contains(cli.SquashParam), apr.Contains(cli.NoFFParam), apr.Contains(cli.ForceFlag), remoteOnly)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}

--- a/go/cmd/dolt/commands/pull.go
+++ b/go/cmd/dolt/commands/pull.go
@@ -81,13 +81,11 @@ func (cmd PullCmd) Exec(ctx context.Context, commandStr string, args []string, d
 	}
 
 	var remoteName string
-	var remoteOnly = false
 	if apr.NArg() == 1 {
 		remoteName = apr.Arg(0)
-		remoteOnly = true
 	}
 
-	pullSpec, err := env.NewPullSpec(ctx, dEnv.RepoStateReader(), remoteName, apr.Contains(cli.SquashParam), apr.Contains(cli.NoFFParam), apr.Contains(cli.ForceFlag), remoteOnly)
+	pullSpec, err := env.NewPullSpec(ctx, dEnv.RepoStateReader(), remoteName, apr.Contains(cli.SquashParam), apr.Contains(cli.NoFFParam), apr.Contains(cli.ForceFlag), apr.NArg() == 1)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}

--- a/go/libraries/doltcore/env/actions/remotes.go
+++ b/go/libraries/doltcore/env/actions/remotes.go
@@ -132,7 +132,6 @@ func DoPush(ctx context.Context, rsr env.RepoStateReader, rsw env.RepoStateWrite
 			if err != nil {
 				return err
 			}
-			// TODO : set upstream should be persisted outside of session
 		}
 	}
 

--- a/go/libraries/doltcore/env/actions/remotes.go
+++ b/go/libraries/doltcore/env/actions/remotes.go
@@ -132,6 +132,7 @@ func DoPush(ctx context.Context, rsr env.RepoStateReader, rsw env.RepoStateWrite
 			if err != nil {
 				return err
 			}
+			// TODO : set upstream should be persisted outside of session
 		}
 	}
 

--- a/go/libraries/doltcore/env/actions/table.go
+++ b/go/libraries/doltcore/env/actions/table.go
@@ -131,28 +131,20 @@ func RemoveDocsTable(tbls []string) []string {
 	return result
 }
 
-// GetRemoteBranchRef returns the ref of a branch and ensures it matched with name. It will also return boolean value
-// representing whether there is not match or not and an error if there is one.
-func GetRemoteBranchRef(ctx context.Context, ddb *doltdb.DoltDB, name string) (ref.RemoteRef, bool, error) {
+// GetRemoteBranchRef returns a remote ref with matching name for a branch for each remotes.
+func GetRemoteBranchRef(ctx context.Context, ddb *doltdb.DoltDB, name string) ([]ref.RemoteRef, error) {
 	remoteRefFilter := map[ref.RefType]struct{}{ref.RemoteRefType: {}}
 	refs, err := ddb.GetRefsOfType(ctx, remoteRefFilter)
-
 	if err != nil {
-		return ref.RemoteRef{}, false, err
+		return nil, err
 	}
 
-	// This will only do this behavior of guessing the remote branch if there is exactly one remote tracking branch with the matching branch name.
-	var found = false
-	var remoteRef ref.RemoteRef
+	var remoteRef []ref.RemoteRef
 	for _, rf := range refs {
 		if remRef, ok := rf.(ref.RemoteRef); ok && remRef.GetBranch() == name {
-			if found {
-				return ref.RemoteRef{}, false, nil
-			}
-			found = true
-			remoteRef = remRef
+			remoteRef = append(remoteRef, remRef)
 		}
 	}
 
-	return remoteRef, found, nil
+	return remoteRef, nil
 }

--- a/go/libraries/doltcore/env/actions/table.go
+++ b/go/libraries/doltcore/env/actions/table.go
@@ -141,11 +141,18 @@ func GetRemoteBranchRef(ctx context.Context, ddb *doltdb.DoltDB, name string) (r
 		return ref.RemoteRef{}, false, err
 	}
 
+	// This will only do this behavior of guessing the remote branch if there is exactly one remote tracking branch with the matching branch name.
+	var found = false
+	var remoteRef ref.RemoteRef
 	for _, rf := range refs {
 		if remRef, ok := rf.(ref.RemoteRef); ok && remRef.GetBranch() == name {
-			return remRef, true, nil
+			if found {
+				return ref.RemoteRef{}, false, nil
+			}
+			found = true
+			remoteRef = remRef
 		}
 	}
 
-	return ref.RemoteRef{}, false, nil
+	return remoteRef, found, nil
 }

--- a/go/libraries/doltcore/env/actions/table.go
+++ b/go/libraries/doltcore/env/actions/table.go
@@ -133,19 +133,19 @@ func RemoveDocsTable(tbls []string) []string {
 
 // GetRemoteBranchRef returns the ref of a branch and ensures it matched with name. It will also return boolean value
 // representing whether there is not match or not and an error if there is one.
-func GetRemoteBranchRef(ctx context.Context, ddb *doltdb.DoltDB, name string) (ref.DoltRef, bool, error) {
+func GetRemoteBranchRef(ctx context.Context, ddb *doltdb.DoltDB, name string) (ref.RemoteRef, bool, error) {
 	remoteRefFilter := map[ref.RefType]struct{}{ref.RemoteRefType: {}}
 	refs, err := ddb.GetRefsOfType(ctx, remoteRefFilter)
 
 	if err != nil {
-		return nil, false, err
+		return ref.RemoteRef{}, false, err
 	}
 
 	for _, rf := range refs {
 		if remRef, ok := rf.(ref.RemoteRef); ok && remRef.GetBranch() == name {
-			return rf, true, nil
+			return remRef, true, nil
 		}
 	}
 
-	return nil, false, nil
+	return ref.RemoteRef{}, false, nil
 }

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_checkout.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_checkout.go
@@ -124,7 +124,11 @@ func checkoutRemoteBranch(ctx *sql.Context, dbName string, dbData env.DbData, ro
 	if ref, refExists, err := actions.GetRemoteBranchRef(ctx, dbData.Ddb, branchName); err != nil {
 		return errors.New("fatal: unable to read from data repository")
 	} else if refExists {
-		return checkoutNewBranch(ctx, dbName, dbData, roots, branchName, ref.String())
+		err = checkoutNewBranch(ctx, dbName, dbData, roots, branchName, ref.String())
+		if err == nil {
+			// TODO : set upstream tracking
+		}
+		return err
 	} else {
 		return fmt.Errorf("error: could not find %s", branchName)
 	}

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_checkout.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_checkout.go
@@ -17,13 +17,13 @@ package dfunctions
 import (
 	"errors"
 	"fmt"
-	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_pull.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_pull.go
@@ -97,13 +97,11 @@ func DoDoltPull(ctx *sql.Context, args []string) (int, int, error) {
 	}
 
 	var remoteName string
-	var remoteOnly = false
 	if apr.NArg() == 1 {
 		remoteName = apr.Arg(0)
-		remoteOnly = true
 	}
 
-	pullSpec, err := env.NewPullSpec(ctx, dbData.Rsr, remoteName, apr.Contains(cli.SquashParam), apr.Contains(cli.NoFFParam), apr.Contains(cli.ForceFlag), remoteOnly)
+	pullSpec, err := env.NewPullSpec(ctx, dbData.Rsr, remoteName, apr.Contains(cli.SquashParam), apr.Contains(cli.NoFFParam), apr.Contains(cli.ForceFlag), apr.NArg() == 1)
 	if err != nil {
 		return noConflictsOrViolations, threeWayMerge, err
 	}

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_pull.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_pull.go
@@ -97,11 +97,13 @@ func DoDoltPull(ctx *sql.Context, args []string) (int, int, error) {
 	}
 
 	var remoteName string
+	var remoteOnly = false
 	if apr.NArg() == 1 {
 		remoteName = apr.Arg(0)
+		remoteOnly = true
 	}
 
-	pullSpec, err := env.NewPullSpec(ctx, dbData.Rsr, remoteName, apr.Contains(cli.SquashParam), apr.Contains(cli.NoFFParam), apr.Contains(cli.ForceFlag))
+	pullSpec, err := env.NewPullSpec(ctx, dbData.Rsr, remoteName, apr.Contains(cli.SquashParam), apr.Contains(cli.NoFFParam), apr.Contains(cli.ForceFlag), remoteOnly)
 	if err != nil {
 		return noConflictsOrViolations, threeWayMerge, err
 	}
@@ -135,7 +137,7 @@ func DoDoltPull(ctx *sql.Context, args []string) (int, int, error) {
 
 			rsSeen = true
 			// todo: can we pass nil for either of the channels?
-			srcDBCommit, err := actions.FetchRemoteBranch(ctx, dbData.Rsw.TempTableFilesDir(), pullSpec.Remote, srcDB, dbData.Ddb, pullSpec.Branch, runProgFuncs, stopProgFuncs)
+			srcDBCommit, err := actions.FetchRemoteBranch(ctx, dbData.Rsw.TempTableFilesDir(), pullSpec.Remote, srcDB, dbData.Ddb, branchRef, runProgFuncs, stopProgFuncs)
 			if err != nil {
 				return noConflictsOrViolations, threeWayMerge, err
 			}

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_pull.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_pull.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"strings"
 	"sync"
 
@@ -29,6 +28,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
+	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"github.com/dolthub/dolt/go/store/datas/pull"
 )

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_push.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_push.go
@@ -102,5 +102,6 @@ func DoDoltPush(ctx *sql.Context, args []string) (int, error) {
 			return cmdFailure, err
 		}
 	}
+	// TODO : set upstream should be persisted outside of session
 	return cmdSuccess, nil
 }

--- a/integration-tests/bats/remotes-file-system.bats
+++ b/integration-tests/bats/remotes-file-system.bats
@@ -48,7 +48,7 @@ SQL
     # push to a file based remote
     mkdir remotedir
     dolt remote add origin file://remotedir
-    dolt push origin main
+    dolt push --set-upstream origin main
 
     # clone from a directory
     cd dolt-repo-clones

--- a/integration-tests/bats/remotes-localbs.bats
+++ b/integration-tests/bats/remotes-localbs.bats
@@ -36,7 +36,7 @@ SQL
     # push to a localbs based remote
     mkdir remotedir
     dolt remote add origin localbs://remotedir
-    dolt push origin main
+    dolt push --set-upstream origin main
 
     # clone from a directory
     cd dolt-repo-clones

--- a/integration-tests/bats/remotes-sql-server.bats
+++ b/integration-tests/bats/remotes-sql-server.bats
@@ -41,14 +41,15 @@ teardown() {
 
     cd repo1
     dolt remote add origin file://../rem1
+    dolt commit -am "add test"
+    dolt checkout -b other
     start_sql_server repo1
 
-    dolt push origin main
     run server_query repo1 1 "select dolt_push() as p" "p\n0"
     [ "$status" -eq 1 ]
     [[ "$output" =~ "the current branch has no upstream branch" ]] || false
 
-    server_query repo1 1 "select dolt_push('--set-upstream', 'origin', 'main') as p" "p\n1"
+    server_query repo1 1 "select dolt_push('--set-upstream', 'origin', 'other') as p" "p\n1"
 
     skip "In-memory branch doesn't track upstream"
     server_query repo1 1 "select dolt_push() as p" "p\n1"

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -174,10 +174,9 @@ teardown() {
     run dolt branch
     [[ ! "$output" =~ "other" ]] || false
 
-    # guessing the remote branch fails since there are two remotes with branch 'other'
     run dolt checkout other
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "error: could not find other" ]] || false
+    [[ "$output" =~ "'other' matched multiple (2) remote tracking branches" ]] || false
 }
 
 @test "remotes: cli 'dolt checkout -b new_branch' should not set upstream if there is a remote branch with matching name" {

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -189,12 +189,9 @@ teardown() {
 
     cd ../repo2
     dolt checkout other
-    dolt sql -q "DROP TABLE a"
-    dolt commit -am "drop table"
-
     run dolt pull
-    [ "$status" -eq 0 ]
-    [[ ! "$output" =~ "conflict: table with same name deleted and modified" ]] || false
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "There is no tracking information for the current branch." ]] || false
 }
 
 @test "remotes: add a remote using dolt remote" {

--- a/integration-tests/bats/sql-pull.bats
+++ b/integration-tests/bats/sql-pull.bats
@@ -23,7 +23,7 @@ setup() {
     dolt branch feature
     dolt remote add test-remote file://../rem1
 
-    # table and comits only present on repo1, rem1 at start
+    # table and commits only present on repo1, rem1 at start
     cd $TMPDIRS/repo1
     dolt sql -q "create table t1 (a int primary key, b int)"
     dolt commit -am "First commit"
@@ -176,7 +176,7 @@ teardown() {
     dolt checkout feature
     run dolt sql -q "select dolt_pull('origin')"
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "branch not found" ]] || false
+    [[ "$output" =~ "You asked to pull from the remote 'origin', but did not specify a branch" ]] || false
     [[ ! "$output" =~ "panic" ]] || false
 }
 
@@ -185,18 +185,24 @@ teardown() {
     dolt checkout feature
     run dolt sql -q "CALL dolt_pull('origin')"
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "branch not found" ]] || false
+    [[ "$output" =~ "You asked to pull from the remote 'origin', but did not specify a branch" ]] || false
     [[ ! "$output" =~ "panic" ]] || false
 }
 
 @test "sql-pull: dolt_pull feature branch" {
     cd repo1
     dolt checkout feature
-    dolt merge main
     dolt push origin feature
 
     cd ../repo2
     dolt checkout feature
+    dolt push --set-upstream origin feature
+
+    cd ../repo1
+    dolt merge main
+    dolt push
+
+    cd ../repo2
     dolt sql -q "select dolt_pull('origin')"
     run dolt sql -q "show tables" -r csv
     [ "$status" -eq 0 ]
@@ -208,11 +214,17 @@ teardown() {
 @test "sql-pull: CALL dolt_pull feature branch" {
     cd repo1
     dolt checkout feature
-    dolt merge main
     dolt push origin feature
 
     cd ../repo2
     dolt checkout feature
+    dolt push --set-upstream origin feature
+
+    cd ../repo1
+    dolt merge main
+    dolt push
+
+    cd ../repo2
     dolt sql -q "CALL dolt_pull('origin')"
     run dolt sql -q "show tables" -r csv
     [ "$status" -eq 0 ]
@@ -429,4 +441,44 @@ teardown() {
     [[ "$output" =~ "v1" ]] || false
     [[ "$output" =~ "v2" ]] || false
     [[ ! "$output" =~ "v3" ]] || false
+}
+
+@test "sql-pull: dolt_pull also fetches, but does not merge other branches" {
+    cd repo1
+    dolt checkout -b other
+    dolt push --set-upstream origin other
+    dolt checkout feature
+    dolt push origin feature
+
+    cd ../repo2
+    dolt fetch
+    # this checkout will set upstream because 'other' branch is a new branch that matches one of remote tracking branch
+    dolt checkout other
+    # this checkout will not set upstream because this 'feature' branch existed before matching remote tracking branch was created
+    dolt checkout feature
+    dolt push --set-upstream origin feature
+
+    cd ../repo1
+    dolt merge main
+    dolt push
+    dolt checkout other
+    dolt commit --allow-empty -m "new commit on other"
+    dolt push
+
+    cd ../repo2
+    dolt sql -q "select dolt_pull()"
+    run dolt sql -q "show tables" -r csv
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 2 ]
+    [[ "$output" =~ "Table" ]] || false
+    [[ "$output" =~ "t1" ]] || false
+
+    dolt checkout other
+    run dolt log --oneline -n 1
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "new commit on other" ]] || false
+
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "behind 'origin/other' by 1 commit" ]] || false
 }

--- a/integration-tests/bats/sql-pull.bats
+++ b/integration-tests/bats/sql-pull.bats
@@ -192,7 +192,7 @@ teardown() {
 @test "sql-pull: dolt_pull feature branch" {
     cd repo1
     dolt checkout feature
-    dolt push origin feature
+    dolt push --set-upstream origin feature
 
     cd ../repo2
     dolt checkout feature
@@ -214,7 +214,7 @@ teardown() {
 @test "sql-pull: CALL dolt_pull feature branch" {
     cd repo1
     dolt checkout feature
-    dolt push origin feature
+    dolt push --set-upstream origin feature
 
     cd ../repo2
     dolt checkout feature
@@ -460,7 +460,7 @@ teardown() {
 
     cd ../repo1
     dolt merge main
-    dolt push
+    dolt push origin feature
     dolt checkout other
     dolt commit --allow-empty -m "new commit on other"
     dolt push

--- a/integration-tests/bats/sql-push.bats
+++ b/integration-tests/bats/sql-push.bats
@@ -158,42 +158,28 @@ teardown() {
     [[ "$output" =~ "t1" ]] || false
 }
 
-@test "sql-push: dolt_push --set-upstream transient outside of session" {
+@test "sql-push: dolt_push --set-upstream persists outside of session" {
+    skip # setting upstream run in a session should persist outside of session
     cd repo1
-    dolt sql -q "select dolt_push('-u', 'origin', 'main')"
+    dolt push
+    dolt checkout -b other
+    dolt sql -q "select dolt_push('-u', 'origin', 'other')"
 
-    cd ../repo2
-    dolt pull origin
-    run dolt sql -q "show tables" -r csv
-    [ "$status" -eq 0 ]
-    [ "${#lines[@]}" -eq 2 ]
-    [[ "$output" =~ "Table" ]] || false
-    [[ "$output" =~ "t1" ]] || false
-
-    cd ../repo1
-    # TODO persist branch config?
+    # upstream should be set still
     run dolt sql -q "select dolt_push()"
-    [ "$status" -eq 1 ]
-    [[ "$output" =~ "the current branch has no upstream branch" ]] || false
+    [ "$status" -eq 0 ]
 }
 
-@test "sql-push: CALL dolt_push --set-upstream transient outside of session" {
+@test "sql-push: CALL dolt_push --set-upstream persists outside of session" {
+    skip # setting upstream run in a session should persist outside of session
     cd repo1
-    dolt sql -q "CALL dolt_push('-u', 'origin', 'main')"
+    dolt push
+    dolt checkout -b other
+    dolt sql -q "CALL dolt_push('-u', 'origin', 'other')"
 
-    cd ../repo2
-    dolt pull origin
-    run dolt sql -q "show tables" -r csv
-    [ "$status" -eq 0 ]
-    [ "${#lines[@]}" -eq 2 ]
-    [[ "$output" =~ "Table" ]] || false
-    [[ "$output" =~ "t1" ]] || false
-
-    cd ../repo1
-    # TODO persist branch config?
+    # upstream should be set still
     run dolt sql -q "CALL dolt_push()"
-    [ "$status" -eq 1 ]
-    [[ "$output" =~ "the current branch has no upstream branch" ]] || false
+    [ "$status" -eq 0 ]
 }
 
 @test "sql-push: dolt_push --force flag" {


### PR DESCRIPTION
This PR fixes inconsistent behaviors of Dolt CLI against Git commands AND of Dolt SQL against Dolt CLI commands.

Inconsistencies between Dolt CLI and Git:
- `dolt checkout new_branch`: checking out a new branch without `-b` flag. If there is a remote branch with matching name, sets upstream.
- `dolt checkout -b new_branch`: if there is a remote branch with matching name, it does not set upstream.
- `dolt pull` and `dolt pull remote_name`: each gives separate errors when run on a branch that does not have upstream

Inconsistencies between Dolt CLI and Dolt SQL:
- `dolt pull` should match `dolt_pull()`
- `dolt_checkout()` and `dolt_push()` should set upstream that persists outside of sql session (added skipped tests)
