### PR TITLE
Build and install for for Linux OS on Mac arm64/aarch64 hardware

### DIFF
--- a/go/utils/publishrelease/buildbinaries.sh
+++ b/go/utils/publishrelease/buildbinaries.sh
@@ -15,7 +15,7 @@ apt-get update && apt-get install -y zip
 cd /src
 
 BINS="dolt git-dolt git-dolt-smudge"
-OS_ARCH_TUPLES="windows-amd64 linux-amd64 darwin-amd64 darwin-arm64"
+OS_ARCH_TUPLES="windows-amd64 linux-amd64 linux-arm64 darwin-amd64 darwin-arm64"
 
 for tuple in $OS_ARCH_TUPLES; do
   os=`echo $tuple | sed 's/-.*//'`

--- a/go/utils/publishrelease/install.sh
+++ b/go/utils/publishrelease/install.sh
@@ -52,8 +52,13 @@ assert_linux_or_macos() {
     fail "E_UNSUPPORTED_OS" "dolt install.sh only supports macOS and Linux."
   fi
 
-  if [ "$ARCH-$OS" != "x86_64-Linux" -a "$ARCH-$OS" != "x86_64-Darwin" -a "$ARCH-$OS" != "arm64-Darwin" ]; then
-    fail "E_UNSUPPOSED_ARCH" "dolt install.sh only supports installing dolt on x86_64 or x86 or Darwin-arm64."
+  # Translate aarch64 to arm64, since that's what GOARCH calls it
+  if [ "$ARCH" == "aarch64" ]; then
+    ARCH="arm64"
+  fi
+
+  if [ "$ARCH-$OS" != "x86_64-Linux" -a "$ARCH-$OS" != "x86_64-Darwin" -a "$ARCH-$OS" != "arm64-Darwin" -a "$ARCH-$OS" != "arm64-Linux" ]; then
+    fail "E_UNSUPPOSED_ARCH" "dolt install.sh only supports installing dolt on x86_64, x86, Linux-aarch64, or Darwin-arm64."
   fi
 
   if [ "$OS" == Linux ]; then


### PR DESCRIPTION
I tested the build binaries script locally and confirmed it is producing the new `dolt-linux-arm64.tar.gz` artifact. I also ran the install script on an Ubuntu container and verified that it tries to download that same artifact from GitHub, then copied the new artifact over and verified that the dolt binary executes as expected. 

Anything else I need to do to get that new artifact to show up on GitHub in the next release? 

Resolves: https://github.com/dolthub/dolt/issues/3726