### PR TITLE
Updating release workflow to include new Linux-ARM64 build

### DIFF
--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -59,8 +59,8 @@ jobs:
           draft: false
           prerelease: false
           commitish: ${{ steps.build_binaries.outputs.commitish }}
-      - name: Upload Linux Distro
-        id: upload-linux-distro
+      - name: Upload Linux AMD64 Distro
+        id: upload-linux-amd64-distro
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -69,6 +69,15 @@ jobs:
           asset_path: go/out/dolt-linux-amd64.tar.gz
           asset_name: dolt-linux-amd64.tar.gz
           asset_content_type: application/zip
+      - name: Upload Linux ARM64 Distro
+        id: upload-linux-arm64-distro
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: go/out/dolt-linux-arm64.tar.gz
+          asset_name: dolt-linux-arm64.tar.gz
       - name: Upload OSX AMD64 Distro
         id: upload-osx-amd64-distro
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
I previously updated the build and install scripts to support Linux OS running on Mac hardware (https://github.com/dolthub/dolt/pull/3727), but I missed this update to the GitHub workflow to copy the new artifact over and make it available on the GitHub release page. 