### PR TITLE
fix for datetime and time types for exporting parquet file

### DIFF
--- a/go/libraries/doltcore/table/typed/parquet/reader.go
+++ b/go/libraries/doltcore/table/typed/parquet/reader.go
@@ -104,7 +104,7 @@ func (pr *ParquetReader) ReadSqlRow(ctx context.Context) (sql.Row, error) {
 		if val != nil {
 			sqlType := col.TypeInfo.ToSqlType()
 			if _, ok := sqlType.(sql.DatetimeType); ok {
-				val = time.Unix(val.(int64), 0)
+				val = time.UnixMicro(val.(int64))
 			} else if _, ok := sqlType.(sql.TimeType); ok {
 				val = sql.Timespan(val.(int64))
 			}

--- a/go/libraries/doltcore/table/typed/parquet/reader.go
+++ b/go/libraries/doltcore/table/typed/parquet/reader.go
@@ -105,8 +105,6 @@ func (pr *ParquetReader) ReadSqlRow(ctx context.Context) (sql.Row, error) {
 			sqlType := col.TypeInfo.ToSqlType()
 			if _, ok := sqlType.(sql.DatetimeType); ok {
 				val = time.UnixMicro(val.(int64))
-			} else if _, ok := sqlType.(sql.TimeType); ok {
-				val = sql.Timespan(val.(int64))
 			}
 		}
 

--- a/go/libraries/doltcore/table/typed/parquet/writer.go
+++ b/go/libraries/doltcore/table/typed/parquet/writer.go
@@ -42,7 +42,7 @@ var typeMap = map[typeinfo.Identifier]string{
 	typeinfo.EnumTypeIdentifier:       "type=BYTE_ARRAY, convertedtype=UTF8",
 	typeinfo.InlineBlobTypeIdentifier: "type=BYTE_ARRAY, convertedtype=UTF8",
 	typeinfo.SetTypeIdentifier:        "type=BYTE_ARRAY, convertedtype=UTF8",
-	typeinfo.TimeTypeIdentifier:       "type=INT64, convertedtype=TIME_MICROS",
+	typeinfo.TimeTypeIdentifier:       "type=BYTE_ARRAY, convertedtype=UTF8",
 	typeinfo.TupleTypeIdentifier:      "type=BYTE_ARRAY, convertedtype=UTF8",
 	typeinfo.UuidTypeIdentifier:       "type=BYTE_ARRAY, convertedtype=UTF8",
 	typeinfo.VarBinaryTypeIdentifier:  "type=BYTE_ARRAY, convertedtype=UTF8",
@@ -116,12 +116,10 @@ func (pwr *ParquetWriter) WriteSqlRow(ctx context.Context, r sql.Row) error {
 			case typeinfo.DatetimeTypeIdentifier:
 				val = val.(time.Time).UnixMicro()
 				sqlType = sql.Int64
-			case typeinfo.TimeTypeIdentifier:
-				v := int64(val.(sql.Timespan))
-				// take abs(val) TODO : negative timespan goes out of range when imported into pandas
-				//shift := v >> 63
-				val = v //(v ^ shift) - shift
-				sqlType = sql.Int64
+			//case typeinfo.TimeTypeIdentifier:
+			//	v := int32(val.(sql.Timespan))
+			//	val = v
+			//	sqlType = sql.Int32
 			case typeinfo.BitTypeIdentifier:
 				sqlType = sql.Uint64
 			}

--- a/go/libraries/doltcore/table/typed/parquet/writer.go
+++ b/go/libraries/doltcore/table/typed/parquet/writer.go
@@ -46,7 +46,7 @@ var typeMap = map[typeinfo.Identifier]string{
 	typeinfo.TupleTypeIdentifier:      "type=BYTE_ARRAY, convertedtype=UTF8",
 	typeinfo.UuidTypeIdentifier:       "type=BYTE_ARRAY, convertedtype=UTF8",
 	typeinfo.VarBinaryTypeIdentifier:  "type=BYTE_ARRAY, convertedtype=UTF8",
-	typeinfo.YearTypeIdentifier:       "type=INT32, convertedtype=DATE",
+	typeinfo.YearTypeIdentifier:       "type=INT32, convertedtype=INT_32",
 	typeinfo.UnknownTypeIdentifier:    "type=BYTE_ARRAY, convertedtype=UTF8",
 	typeinfo.JSONTypeIdentifier:       "type=BYTE_ARRAY, convertedtype=UTF8",
 	typeinfo.BlobStringTypeIdentifier: "type=BYTE_ARRAY, convertedtype=UTF8",
@@ -119,8 +119,8 @@ func (pwr *ParquetWriter) WriteSqlRow(ctx context.Context, r sql.Row) error {
 			case typeinfo.TimeTypeIdentifier:
 				v := int64(val.(sql.Timespan))
 				// take abs(val) TODO : negative timespan goes out of range when imported into pandas
-				shift := v >> 63
-				val = (v ^ shift) - shift
+				//shift := v >> 63
+				val = v //(v ^ shift) - shift
 				sqlType = sql.Int64
 			case typeinfo.BitTypeIdentifier:
 				sqlType = sql.Uint64

--- a/go/libraries/doltcore/table/typed/parquet/writer.go
+++ b/go/libraries/doltcore/table/typed/parquet/writer.go
@@ -42,7 +42,7 @@ var typeMap = map[typeinfo.Identifier]string{
 	typeinfo.EnumTypeIdentifier:       "type=BYTE_ARRAY, convertedtype=UTF8",
 	typeinfo.InlineBlobTypeIdentifier: "type=BYTE_ARRAY, convertedtype=UTF8",
 	typeinfo.SetTypeIdentifier:        "type=BYTE_ARRAY, convertedtype=UTF8",
-	typeinfo.TimeTypeIdentifier:       "type=BYTE_ARRAY, convertedtype=UTF8",
+	typeinfo.TimeTypeIdentifier:       "type=INT64, convertedtype=TIMESPAN",
 	typeinfo.TupleTypeIdentifier:      "type=BYTE_ARRAY, convertedtype=UTF8",
 	typeinfo.UuidTypeIdentifier:       "type=BYTE_ARRAY, convertedtype=UTF8",
 	typeinfo.VarBinaryTypeIdentifier:  "type=BYTE_ARRAY, convertedtype=UTF8",
@@ -116,10 +116,9 @@ func (pwr *ParquetWriter) WriteSqlRow(ctx context.Context, r sql.Row) error {
 			case typeinfo.DatetimeTypeIdentifier:
 				val = val.(time.Time).UnixMicro()
 				sqlType = sql.Int64
-			//case typeinfo.TimeTypeIdentifier:
-			//	v := int32(val.(sql.Timespan))
-			//	val = v
-			//	sqlType = sql.Int32
+			case typeinfo.TimeTypeIdentifier:
+				val = int64(val.(sql.Timespan).AsTimeDuration())
+				sqlType = sql.Int64
 			case typeinfo.BitTypeIdentifier:
 				sqlType = sql.Uint64
 			}

--- a/integration-tests/bats/export-tables.bats
+++ b/integration-tests/bats/export-tables.bats
@@ -418,41 +418,6 @@ print(pd.to_timedelta(df.at[0, 'v2']))
     [[ "$output" =~ "-1 days +12:48:49" ]] || false
 }
 
-@test "export-tables: table export negative time type to parquet" {
-    skip "TODO : negative time type in parquet export fails for importing to pandas"
-    dolt sql <<SQL
-CREATE TABLE diffTypes (pk BIGINT PRIMARY KEY,v2 TIME);
-INSERT INTO diffTypes VALUES (1,'-11:11:11'), (2,NULL);
-SQL
-    run dolt table export diffTypes dt.parquet
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ "Successfully exported data." ]] || false
-    [ -f dt.parquet ]
-
-    run parquet-tools cat --json dt.parquet
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ '{"pk":1,"v2":-40271000000}' ]] || false
-    [[ "$output" =~ '{"pk":2}' ]] || false
-
-    echo "import pandas as pd
-df = pd.read_parquet('dt.parquet')
-print(df)
-" > pandas_test.py
-    python3 pandas_test.py > pandas.txt
-    [ -f pandas.txt ]
-
-    echo "import pyarrow.parquet as pq
-table = pq.read_table('dt.parquet')
-print(table.to_pandas())
-" > arrow_test.py
-    python3 arrow_test.py > pyarrow.txt
-    [ -f pyarrow.txt ]
-
-    run diff pandas.txt pyarrow.txt
-    [ "$status" -eq 0 ]
-    [ "$output" = "" ]
-}
-
 @test "export-tables: table export more types to parquet" {
     skiponwindows "Missing dependencies"
     dolt sql <<SQL

--- a/integration-tests/bats/export-tables.bats
+++ b/integration-tests/bats/export-tables.bats
@@ -374,7 +374,7 @@ CREATE TABLE diffTypes (
   v6 ENUM('one', 'two', 'three')
 );
 INSERT INTO diffTypes VALUES
-    (1,'2020-04-08','11:11:11','2020','2020-04-08 11:11:11',true,'one'),
+    (1,'2020-04-08','-11:11:11','2020','2020-04-08 11:11:11',true,'one'),
     (2,'2020-04-08','12:12:12','2020','2020-04-08 12:12:12',false,'three'),
     (3,'2021-10-09','04:12:34','2019','2019-10-09 04:12:34',true,NULL);
 SQL
@@ -385,9 +385,16 @@ SQL
 
     run parquet-tools cat --json dt.parquet
     [ "$status" -eq 0 ]
-    [[ "$output" =~ '{"pk":1,"v1":1586304000000000,"v2":40271000000,"v3":2020,"v4":1586344271000000,"v5":1,"v6":"one"}' ]] || false
-    [[ "$output" =~ '{"pk":2,"v1":1586304000000000,"v2":43932000000,"v3":2020,"v4":1586347932000000,"v5":0,"v6":"three"}' ]] || false
-    [[ "$output" =~ '{"pk":3,"v1":1633737600000000,"v2":15154000000,"v3":2019,"v4":1570594354000000,"v5":1}' ]] || false
+    [[ "$output" =~ '{"pk":1,"v1":1586304000000000,"v2":"-11:11:11","v3":2020,"v4":1586344271000000,"v5":1,"v6":"one"}' ]] || false
+    [[ "$output" =~ '{"pk":2,"v1":1586304000000000,"v2":"12:12:12","v3":2020,"v4":1586347932000000,"v5":0,"v6":"three"}' ]] || false
+    [[ "$output" =~ '{"pk":3,"v1":1633737600000000,"v2":"04:12:34","v3":2019,"v4":1570594354000000,"v5":1}' ]] || false
+
+    run dolt sql -q "SELECT * FROM diffTypes"
+    result=$output
+
+    dolt table import -r diffTypes dt.parquet
+    run dolt sql -q "SELECT * FROM diffTypes"
+    [ "$output" = "$result" ]
 
     echo "import pandas as pd
 df = pd.read_parquet('dt.parquet')


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/3517 

Issues for importing parquet file from Dolt export to pandas.
- Datetime type is exported as timestamp to avoid out of range issues.
- Time type is exported as timedelta to avoid being parsed as time and panics if val is negative 

