### PR TITLE
Add `--track` flag to dolt checkout

### DIFF
--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -95,6 +95,7 @@ const (
 	DeleteFlag       = "delete"
 	DeleteForceFlag  = "D"
 	OutputOnlyFlag   = "output-only"
+	TrackFlag        = "track"
 )
 
 const (
@@ -163,6 +164,7 @@ func CreateCheckoutArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParser()
 	ap.SupportsString(CheckoutCoBranch, "", "branch", "Create a new branch named {{.LessThan}}new_branch{{.GreaterThan}} and start it at {{.LessThan}}start_point{{.GreaterThan}}.")
 	ap.SupportsFlag(ForceFlag, "f", "If there is any changes in working set, the force flag will wipe out the current changes and checkout the new branch.")
+	ap.SupportsString(TrackFlag, "t", "direct|inherit", "When creating a new branch, set up 'upstream' configuration. Defaults to 'direct'.")
 	return ap
 }
 

--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -164,7 +164,7 @@ func CreateCheckoutArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParser()
 	ap.SupportsString(CheckoutCoBranch, "", "branch", "Create a new branch named {{.LessThan}}new_branch{{.GreaterThan}} and start it at {{.LessThan}}start_point{{.GreaterThan}}.")
 	ap.SupportsFlag(ForceFlag, "f", "If there is any changes in working set, the force flag will wipe out the current changes and checkout the new branch.")
-	ap.SupportsString(TrackFlag, "t", "direct|inherit", "When creating a new branch, set up 'upstream' configuration. Defaults to 'direct'.")
+	ap.SupportsString(TrackFlag, "t", "", "When creating a new branch, set up 'upstream' configuration.")
 	return ap
 }
 

--- a/go/cmd/dolt/commands/checkout.go
+++ b/go/cmd/dolt/commands/checkout.go
@@ -166,7 +166,7 @@ func checkoutNewBranch(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.Ar
 		}
 		_, remoteOk := remotes[remoteName]
 		if !remoteOk {
-			return errhand.BuildDError(fmt.Errorf("'%s' is not a commit and a branch '%s' cannot be created from it", startPt, remoteBranchName).Error()).Build()
+			return errhand.BuildDError(fmt.Errorf("'%s' is not a valid remote ref and a branch '%s' cannot be created from it", startPt, remoteBranchName).Error()).Build()
 		}
 		newBranchName = remoteBranchName
 	}
@@ -316,10 +316,10 @@ func checkoutBranch(ctx context.Context, dEnv *env.DoltEnv, name string, force b
 
 // setRemoteUpstreamForCheckout sets upstream for checked out branch. This applies `dolt checkout <bn>`,
 // if <bn> matches any remote branch name. This should not happen for `dolt checkout -b <bn>` case.
-func setRemoteUpstreamForCheckout(dEnv *env.DoltEnv, remName, remBranchName string) errhand.VerboseError {
-	refSpec, err := ref.ParseRefSpecForRemote(remName, remBranchName)
+func setRemoteUpstreamForCheckout(dEnv *env.DoltEnv, remote, remoteBranch string) errhand.VerboseError {
+	refSpec, err := ref.ParseRefSpecForRemote(remote, remoteBranch)
 	if err != nil {
-		return errhand.BuildDError(fmt.Errorf("%w: '%s'", err, remName).Error()).Build()
+		return errhand.BuildDError(fmt.Errorf("%w: '%s'", err, remote).Error()).Build()
 	}
 
 	currentBranch := dEnv.RepoStateReader().CWBHeadRef()
@@ -330,7 +330,7 @@ func setRemoteUpstreamForCheckout(dEnv *env.DoltEnv, remName, remBranchName stri
 		Merge: ref.MarshalableRef{
 			Ref: dest,
 		},
-		Remote: remName,
+		Remote: remote,
 	})
 	if err != nil {
 		return errhand.BuildDError(err.Error()).Build()
@@ -339,7 +339,7 @@ func setRemoteUpstreamForCheckout(dEnv *env.DoltEnv, remName, remBranchName stri
 	if err != nil {
 		return errhand.BuildDError(actions.ErrFailedToSaveRepoState.Error()).AddCause(err).Build()
 	}
-	cli.Printf("branch '%s' set up to track '%s/%s'.\n", currentBranch.GetPath(), remName, remBranchName)
+	cli.Printf("branch '%s' set up to track '%s/%s'.\n", currentBranch.GetPath(), remote, remoteBranch)
 
 	return nil
 }

--- a/go/libraries/doltcore/env/remotes.go
+++ b/go/libraries/doltcore/env/remotes.go
@@ -379,7 +379,8 @@ func NewPullSpec(ctx context.Context, rsr RepoStateReader, remoteName string, sq
 		return nil, err
 	}
 
-	if _, hasUpstream := trackedBranches[branch.GetPath()]; !hasUpstream {
+	trackedBranch, hasUpstream := trackedBranches[branch.GetPath()]
+	if !hasUpstream {
 		if remoteOnly {
 			return nil, fmt.Errorf(ErrPullWithRemoteNoUpstream.Error(), remoteName)
 		} else {
@@ -399,7 +400,7 @@ func NewPullSpec(ctx context.Context, rsr RepoStateReader, remoteName string, sq
 		RemoteName: remoteName,
 		Remote:     remote,
 		RefSpecs:   refSpecs,
-		Branch:     branch,
+		Branch:     trackedBranch.Merge.Ref,
 		Force:      force,
 	}, nil
 }

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -1879,4 +1879,17 @@ setup_ref_test() {
     run dolt pull
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Everything up-to-date." ]] || false
+
+    dolt checkout main
+    dolt branch -D newbranch
+
+    # branch.autosetupmerge configuration defaults to --track, so the upstream is set
+    run dolt checkout -b newbranch origin/feature
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Switched to branch 'newbranch'" ]] || false
+    [[ "$output" =~ "branch 'newbranch' set up to track 'origin/feature'." ]] || false
+
+    run dolt pull
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Everything up-to-date." ]] || false
 }

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -1824,3 +1824,59 @@ setup_ref_test() {
     [[ "$output" =~ "ahead" ]] || false
     [[ "$output" =~ "2 commit" ]] || false
 }
+
+@test "remotes: dolt checkout --track origin/feature checks out new local branch 'feature' with upstream set" {
+    mkdir remote
+    mkdir repo1
+
+    cd repo1
+    dolt init
+    dolt remote add origin file://../remote
+    dolt push --set-upstream origin main
+    dolt checkout -b feature
+    dolt push --set-upstream origin feature
+
+    cd ..
+    dolt clone file://./remote repo2
+
+    cd repo2
+    run dolt branch
+    [[ ! "$output" =~ "feature" ]] || false
+
+    run dolt checkout --track origin/feature
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Switched to branch 'feature'" ]] || false
+    [[ "$output" =~ "branch 'feature' set up to track 'origin/feature'." ]] || false
+
+    run dolt pull
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Everything up-to-date." ]] || false
+}
+
+@test "remotes: dolt checkout -b newbranch --track origin/feature checks out new local branch 'newbranch' with upstream set" {
+    mkdir remote
+    mkdir repo1
+
+    cd repo1
+    dolt init
+    dolt remote add origin file://../remote
+    dolt push --set-upstream origin main
+    dolt checkout -b feature
+    dolt push --set-upstream origin feature
+
+    cd ..
+    dolt clone file://./remote repo2
+
+    cd repo2
+    run dolt branch
+    [[ ! "$output" =~ "feature" ]] || false
+
+    run dolt checkout -b newbranch --track origin/feature
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Switched to branch 'newbranch'" ]] || false
+    [[ "$output" =~ "branch 'newbranch' set up to track 'origin/feature'." ]] || false
+
+    run dolt pull
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Everything up-to-date." ]] || false
+}


### PR DESCRIPTION
Adds `--track` flag for dolt checkout.
Fixes local branch tracking remote tracking branch with different names
- `dolt checkout --track origin/feature` will create new branch named `feature` and set its upstream to `origin/feature` remote branch
- `dolt checkout -b branch1 --track origin/feature` will create new branch named `branch1` and set its upstream to `origin/feature` remote branch
- `dolt checkout -b branch1 origin/feature` will guess remote branch. If remote branch `origin/feature` exists, it will set upstream to it.