### PR TITLE
[no-release-notes]Blob internal chunksize different than leaf chunksize

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -595,11 +595,6 @@ func TestLoadDataErrors(t *testing.T) {
 }
 
 func TestJsonScripts(t *testing.T) {
-	if types.IsFormat_DOLT_1(types.Format_Default) {
-		// The new storage engine fails when trying to save data larger than 65kb
-		t.Skip()
-	}
-
 	enginetest.TestJsonScripts(t, newDoltHarness(t))
 }
 

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -1007,10 +1007,6 @@ func TestComplexIndexQueriesPrepared(t *testing.T) {
 }
 
 func TestJsonScriptsPrepared(t *testing.T) {
-	if types.IsFormat_DOLT_1(types.Format_Default) {
-		// The new storage engine fails when trying to save data larger than 65kb
-		t.Skip()
-	}
 	skipPreparedTests(t)
 	enginetest.TestJsonScriptsPrepared(t, newDoltHarness(t))
 }

--- a/go/store/prolly/tree/immutable_tree_test.go
+++ b/go/store/prolly/tree/immutable_tree_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/prolly/message"
 	"github.com/dolthub/dolt/go/store/val"
 )
@@ -33,10 +34,11 @@ func TestWriteImmutableTree(t *testing.T) {
 		inputSize int
 		chunkSize int
 		err       error
+		checkSum  bool
 	}{
 		{
 			inputSize: 100,
-			chunkSize: 5,
+			chunkSize: 40,
 		},
 		{
 			inputSize: 100,
@@ -48,19 +50,19 @@ func TestWriteImmutableTree(t *testing.T) {
 		},
 		{
 			inputSize: 255,
-			chunkSize: 5,
+			chunkSize: 40,
 		},
 		{
 			inputSize: 243,
-			chunkSize: 5,
+			chunkSize: 40,
 		},
 		{
 			inputSize: 47,
-			chunkSize: 3,
+			chunkSize: 40,
 		},
 		{
 			inputSize: 200,
-			chunkSize: 7,
+			chunkSize: 40,
 		},
 		{
 			inputSize: 200,
@@ -68,11 +70,36 @@ func TestWriteImmutableTree(t *testing.T) {
 		},
 		{
 			inputSize: 1,
-			chunkSize: 5,
+			chunkSize: 40,
 		},
 		{
 			inputSize: 20,
 			chunkSize: 500,
+		},
+		{
+			inputSize: 50_000_000,
+			chunkSize: 47,
+			checkSum:  false,
+		},
+		{
+			inputSize: 50_000_000,
+			chunkSize: 67,
+			checkSum:  false,
+		},
+		{
+			inputSize: 50_000_000,
+			chunkSize: 4000,
+			checkSum:  false,
+		},
+		{
+			inputSize: 50_000_000,
+			chunkSize: 32_000,
+			checkSum:  false,
+		},
+		{
+			inputSize: 50_000_000,
+			chunkSize: 33_000,
+			err:       ErrInvalidChunkSize,
 		},
 		{
 			inputSize: 10,
@@ -82,6 +109,11 @@ func TestWriteImmutableTree(t *testing.T) {
 		{
 			inputSize: 10,
 			chunkSize: -1,
+			err:       ErrInvalidChunkSize,
+		},
+		{
+			inputSize: 10,
+			chunkSize: 39,
 			err:       ErrInvalidChunkSize,
 		},
 	}
@@ -119,17 +151,22 @@ func TestWriteImmutableTree(t *testing.T) {
 						sum += int(i)
 					}
 					keyCnt = len(n.values.Buf)
+					if keyCnt != tt.chunkSize {
+						unfilledCnt += 1
+					}
 				} else {
 					keyCnt = n.Count()
-				}
-				if keyCnt != tt.chunkSize {
-					unfilledCnt += 1
+					if keyCnt < (tt.chunkSize / hash.ByteLen) {
+						unfilledCnt += 1
+					}
 				}
 				return nil
 			})
 
 			require.Equal(t, expLevel, root.Level())
-			require.Equal(t, expSum, sum)
+			if tt.checkSum {
+				require.Equal(t, expSum, sum)
+			}
 			require.Equal(t, tt.inputSize, byteCnt)
 			require.Equal(t, expUnfilled, unfilledCnt)
 			require.Equal(t, expSubtrees, root.getSubtreeCounts())
@@ -138,9 +175,14 @@ func TestWriteImmutableTree(t *testing.T) {
 }
 
 func expectedLevel(size, chunk int) int {
-	l := 0
-	for size > chunk {
-		size = size / chunk
+	if size <= chunk {
+		return 0
+	}
+	size = int(math.Ceil(float64(size) / float64(chunk)))
+	l := 1
+	intChunk := chunk / hash.ByteLen
+	for size > intChunk {
+		size = int(math.Ceil(float64(size) / float64(intChunk)))
 		l += 1
 	}
 	return l
@@ -150,21 +192,25 @@ func expectedSubtrees(size, chunk int) SubtreeCounts {
 	if size <= chunk {
 		return SubtreeCounts{0}
 	}
+	l := expectedLevel(size, chunk)
+
 	size = int(math.Ceil(float64(size) / float64(chunk)))
-	l := chunk
-	for l < size {
-		l *= chunk
-	}
-	l /= chunk
+	intChunk := chunk / hash.ByteLen
 
-	res := make(SubtreeCounts, 0)
-	for size > l {
-		res = append(res, uint64(l))
-		size -= l
-	}
-	res = append(res, uint64(size))
+	filledSubtree := int(math.Pow(float64(intChunk), float64(l-1)))
 
-	return res
+	subtrees := make(SubtreeCounts, 0)
+	for size > filledSubtree {
+		subtrees = append(subtrees, uint64(filledSubtree))
+		size -= filledSubtree
+	}
+	if size > 0 {
+		subtrees = append(subtrees, uint64(size))
+	}
+	if len(subtrees) > intChunk {
+		panic("unreachable")
+	}
+	return subtrees
 }
 
 func expectedSum(size int) int {
@@ -172,30 +218,30 @@ func expectedSum(size int) int {
 }
 
 func expectedUnfilled(size, chunk int) int {
-	l := chunk
-	for l < size {
-		l *= chunk
+	if size == chunk {
+		return 0
+	} else if size < chunk {
+		return 1
 	}
-	l /= chunk
-	size -= l
-	cnt := 0
-	i := 1
-	for size > 0 {
-		if l > size {
-			if i < chunk-1 {
-				cnt += 1
-			}
-			l /= chunk
-			i = 0
-		} else {
-			size -= l
-			i++
+
+	var unfilled int
+	// level 0 is special case
+	if size%chunk != 0 {
+		unfilled += 1
+	}
+	size = int(math.Ceil(float64(size) / float64(chunk)))
+
+	intChunk := chunk / hash.ByteLen
+	for size > intChunk {
+		if size%intChunk != 0 {
+			unfilled += 1
 		}
+		size = int(math.Ceil(float64(size) / float64(intChunk)))
 	}
-	if i < chunk {
-		cnt += 1
+	if size < intChunk {
+		unfilled += 1
 	}
-	return cnt
+	return unfilled
 }
 
 func TestImmutableTreeWalk(t *testing.T) {


### PR DESCRIPTION
Blob chunker panic fix. If we want to split at a chunk size of ex: 4000 bytes, then we can only fit 4000/20 hashes into internal nodes.