### PR TITLE
[no-release-notes] Unskip foreign-keys-invert-pk.bats for new format

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -58,7 +58,7 @@ require (
 )
 
 require (
-	github.com/dolthub/go-mysql-server v0.12.1-0.20220715194040-c44bba3ee53c
+	github.com/dolthub/go-mysql-server v0.12.1-0.20220715214341-16bf24de3162
 	github.com/google/flatbuffers v2.0.6+incompatible
 	github.com/gosuri/uilive v0.0.4
 	github.com/kch42/buzhash v0.0.0-20160816060738-9bdec3dec7c6

--- a/go/go.sum
+++ b/go/go.sum
@@ -173,8 +173,12 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dolthub/fslock v0.0.3 h1:iLMpUIvJKMKm92+N1fmHVdxJP5NdyDK5bK7z7Ba2s2U=
 github.com/dolthub/fslock v0.0.3/go.mod h1:QWql+P17oAAMLnL4HGB5tiovtDuAjdDTPbuqx7bYfa0=
-github.com/dolthub/go-mysql-server v0.12.1-0.20220715194040-c44bba3ee53c h1:y2NEkK5EZCrcWWBwuLEub5vZOXTPjAkM6S942WZgrb4=
-github.com/dolthub/go-mysql-server v0.12.1-0.20220715194040-c44bba3ee53c/go.mod h1:fhyVDvV0K59cdk9N7TQsPjr2Hp/Qseej8+R9tVqPDCg=
+github.com/dolthub/go-mysql-server v0.12.1-0.20220713232319-7ff7cdf2c557 h1:1nkWy/hLg1MecgiI7N6Y61I/mbw2Yer1hEDGvPIeyvU=
+github.com/dolthub/go-mysql-server v0.12.1-0.20220713232319-7ff7cdf2c557/go.mod h1:fhyVDvV0K59cdk9N7TQsPjr2Hp/Qseej8+R9tVqPDCg=
+github.com/dolthub/go-mysql-server v0.12.1-0.20220715213046-5462e2d88d3b h1:N+14RTQD3a4UbQRvgHhLL9rV+ii4yGr5juw+oxuf/Xc=
+github.com/dolthub/go-mysql-server v0.12.1-0.20220715213046-5462e2d88d3b/go.mod h1:fhyVDvV0K59cdk9N7TQsPjr2Hp/Qseej8+R9tVqPDCg=
+github.com/dolthub/go-mysql-server v0.12.1-0.20220715214341-16bf24de3162 h1:CifxeBAQHbvNd3UmXiN3rQ+RvYalDurIgVlXtr7rRIA=
+github.com/dolthub/go-mysql-server v0.12.1-0.20220715214341-16bf24de3162/go.mod h1:fhyVDvV0K59cdk9N7TQsPjr2Hp/Qseej8+R9tVqPDCg=
 github.com/dolthub/ishell v0.0.0-20220112232610-14e753f0f371 h1:oyPHJlzumKta1vnOQqUnfdz+pk3EmnHS3Nd0cCT0I2g=
 github.com/dolthub/ishell v0.0.0-20220112232610-14e753f0f371/go.mod h1:dhGBqcCEfK5kuFmeO5+WOx3hqc1k3M29c1oS/R7N4ms=
 github.com/dolthub/jsonpath v0.0.0-20210609232853-d49537a30474 h1:xTrR+l5l+1Lfq0NvhiEsctylXinUMFhhsqaEcl414p8=

--- a/go/go.sum
+++ b/go/go.sum
@@ -173,10 +173,6 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dolthub/fslock v0.0.3 h1:iLMpUIvJKMKm92+N1fmHVdxJP5NdyDK5bK7z7Ba2s2U=
 github.com/dolthub/fslock v0.0.3/go.mod h1:QWql+P17oAAMLnL4HGB5tiovtDuAjdDTPbuqx7bYfa0=
-github.com/dolthub/go-mysql-server v0.12.1-0.20220713232319-7ff7cdf2c557 h1:1nkWy/hLg1MecgiI7N6Y61I/mbw2Yer1hEDGvPIeyvU=
-github.com/dolthub/go-mysql-server v0.12.1-0.20220713232319-7ff7cdf2c557/go.mod h1:fhyVDvV0K59cdk9N7TQsPjr2Hp/Qseej8+R9tVqPDCg=
-github.com/dolthub/go-mysql-server v0.12.1-0.20220715213046-5462e2d88d3b h1:N+14RTQD3a4UbQRvgHhLL9rV+ii4yGr5juw+oxuf/Xc=
-github.com/dolthub/go-mysql-server v0.12.1-0.20220715213046-5462e2d88d3b/go.mod h1:fhyVDvV0K59cdk9N7TQsPjr2Hp/Qseej8+R9tVqPDCg=
 github.com/dolthub/go-mysql-server v0.12.1-0.20220715214341-16bf24de3162 h1:CifxeBAQHbvNd3UmXiN3rQ+RvYalDurIgVlXtr7rRIA=
 github.com/dolthub/go-mysql-server v0.12.1-0.20220715214341-16bf24de3162/go.mod h1:fhyVDvV0K59cdk9N7TQsPjr2Hp/Qseej8+R9tVqPDCg=
 github.com/dolthub/ishell v0.0.0-20220112232610-14e753f0f371 h1:oyPHJlzumKta1vnOQqUnfdz+pk3EmnHS3Nd0cCT0I2g=

--- a/go/libraries/doltcore/schema/schema.go
+++ b/go/libraries/doltcore/schema/schema.go
@@ -25,7 +25,8 @@ import (
 
 // Schema is an interface for retrieving the columns that make up a schema
 type Schema interface {
-	// GetPKCols gets the collection of columns which make the primary key.
+	// GetPKCols gets the collection of columns which make the primary key. They
+	// are always returned in ordinal order.
 	GetPKCols() *ColCollection
 
 	// GetNonPKCols gets the collection of columns which are not part of the primary key.

--- a/go/libraries/doltcore/schema/schema_test.go
+++ b/go/libraries/doltcore/schema/schema_test.go
@@ -103,6 +103,47 @@ func TestGetSharedCols(t *testing.T) {
 	assert.Equal(t, expected, res)
 }
 
+func TestSetPkOrder(t *testing.T) {
+
+	// GetPkCols() should always return columns in ordinal order
+	// GetAllCols() should always return columns in the defined schema's order
+	t.Run("returns the correct GetPkCols() order", func(t *testing.T) {
+		allColColl := NewColCollection(allCols...)
+		pkColColl := NewColCollection(pkCols...)
+		sch, err := SchemaFromCols(allColColl)
+		require.NoError(t, err)
+
+		require.Equal(t, allColColl, sch.GetAllCols())
+		require.Equal(t, pkColColl, sch.GetPKCols())
+
+		err = sch.SetPkOrdinals([]int{1, 0})
+		require.NoError(t, err)
+
+		expectedPkColColl := NewColCollection(pkCols[1], pkCols[0])
+		require.Equal(t, expectedPkColColl, sch.GetPKCols())
+		require.Equal(t, allColColl, sch.GetAllCols())
+	})
+
+	t.Run("Can round-trip", func(t *testing.T) {
+		allColColl := NewColCollection(allCols...)
+		pkColColl := NewColCollection(pkCols...)
+		sch, err := SchemaFromCols(allColColl)
+		require.NoError(t, err)
+
+		require.Equal(t, allColColl, sch.GetAllCols())
+		require.Equal(t, pkColColl, sch.GetPKCols())
+
+		err = sch.SetPkOrdinals([]int{1, 0})
+		require.NoError(t, err)
+
+		err = sch.SetPkOrdinals([]int{0, 1})
+		require.NoError(t, err)
+
+		require.Equal(t, allColColl, sch.GetAllCols())
+		require.Equal(t, pkColColl, sch.GetPKCols())
+	})
+}
+
 func mustGetCol(collection *ColCollection, name string) Column {
 	col, ok := collection.GetByName(name)
 	if !ok {

--- a/integration-tests/bats/foreign-keys-invert-pk.bats
+++ b/integration-tests/bats/foreign-keys-invert-pk.bats
@@ -3,7 +3,6 @@ load $BATS_TEST_DIRNAME/helper/common.bash
 
 setup() {
     setup_common
-    skip_nbf_dolt_1
 
     dolt sql <<SQL
 create table a (x int, y int, primary key (y,x));


### PR DESCRIPTION
`schema.Schema.GetPKCols()` returns columns in primary key ordinal ordering. In `prollyFkIndexer`, it was assumed that it returned in the defined schema's ordering.

Added some comments and associated test cases for `schema.Schema.SetPKOrdinals()`.

Coordinated GMS PR:
https://github.com/dolthub/go-mysql-server/pull/1117