### PR TITLE
[no-release-notes] In __DOLT_1__, throw error if schemas have different primary key types

### DIFF
--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -385,7 +385,7 @@ func diffUserTables(ctx context.Context, dEnv *env.DoltEnv, dArgs *diffArgs) (ve
 				fromSch = toSch
 			}
 
-			if !schema.ArePrimaryKeySetsDiffable(fromSch, toSch) {
+			if !schema.ArePrimaryKeySetsDiffable(td.Format(), fromSch, toSch) {
 				cli.PrintErrf("Primary key sets differ between revisions for table %s, skipping data diff\n", tblName)
 				continue
 			}

--- a/go/libraries/doltcore/diff/async_differ.go
+++ b/go/libraries/doltcore/diff/async_differ.go
@@ -28,11 +28,11 @@ import (
 	"github.com/dolthub/dolt/go/store/types"
 )
 
-func NewRowDiffer(ctx context.Context, fromSch, toSch schema.Schema, buf int) RowDiffer {
+func NewRowDiffer(ctx context.Context, format *types.NomsBinFormat, fromSch, toSch schema.Schema, buf int) RowDiffer {
 	ad := NewAsyncDiffer(buf)
 
 	// Returns an EmptyRowDiffer if the two schemas are not diffable.
-	if !schema.ArePrimaryKeySetsDiffable(fromSch, toSch) {
+	if !schema.ArePrimaryKeySetsDiffable(format, fromSch, toSch) {
 		return &EmptyRowDiffer{}
 	}
 

--- a/go/libraries/doltcore/diff/diff_summary.go
+++ b/go/libraries/doltcore/diff/diff_summary.go
@@ -66,7 +66,7 @@ func SummaryForTableDelta(ctx context.Context, ch chan DiffSummaryProgress, td T
 		return errhand.BuildDError("cannot retrieve schema for table %s", td.ToName).AddCause(err).Build()
 	}
 
-	if !schema.ArePrimaryKeySetsDiffable(fromSch, toSch) {
+	if !schema.ArePrimaryKeySetsDiffable(td.Format(), fromSch, toSch) {
 		return errhand.BuildDError("diff summary will not compute due to primary key set change with table %s", td.CurName()).Build()
 	}
 

--- a/go/libraries/doltcore/diff/table_deltas.go
+++ b/go/libraries/doltcore/diff/table_deltas.go
@@ -284,7 +284,7 @@ func (td TableDelta) HasSchemaChanged(ctx context.Context) (bool, error) {
 }
 
 func (td TableDelta) HasPrimaryKeySetChanged() bool {
-	return !schema.ArePrimaryKeySetsDiffable(td.FromSch, td.ToSch)
+	return !schema.ArePrimaryKeySetsDiffable(td.Format(), td.FromSch, td.ToSch)
 }
 
 func (td TableDelta) HasChanges() (bool, error) {

--- a/go/libraries/doltcore/merge/merge_rows.go
+++ b/go/libraries/doltcore/merge/merge_rows.go
@@ -120,7 +120,7 @@ func (rm *RootMerger) MergeTable(ctx context.Context, tblName string, opts edito
 		return nil, nil, errors.New(fmt.Sprintf("schema changes not supported: %s table schema does not match in current HEAD and cherry-pick commit.", tblName))
 	}
 
-	mergeSch, schConflicts, err := SchemaMerge(tm.leftSch, tm.rightSch, tm.ancSch, tblName)
+	mergeSch, schConflicts, err := SchemaMerge(tm.vrw.Format(), tm.leftSch, tm.rightSch, tm.ancSch, tblName)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/libraries/doltcore/merge/merge_schema.go
+++ b/go/libraries/doltcore/merge/merge_schema.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/dolthub/dolt/go/store/types"
 	sqle "github.com/dolthub/go-mysql-server"
 	"github.com/dolthub/go-mysql-server/sql"
 
@@ -120,7 +121,7 @@ func (c ChkConflict) String() string {
 var ErrMergeWithDifferentPkSets = errors.New("error: cannot merge two tables with different primary key sets")
 
 // SchemaMerge performs a three-way merge of ourSch, theirSch, and ancSch.
-func SchemaMerge(ourSch, theirSch, ancSch schema.Schema, tblName string) (sch schema.Schema, sc SchemaConflict, err error) {
+func SchemaMerge(format *types.NomsBinFormat, ourSch, theirSch, ancSch schema.Schema, tblName string) (sch schema.Schema, sc SchemaConflict, err error) {
 	// (sch - ancSch) ∪ (mergeSch - ancSch) ∪ (sch ∩ mergeSch)
 	sc = SchemaConflict{
 		TableName: tblName,
@@ -128,7 +129,7 @@ func SchemaMerge(ourSch, theirSch, ancSch schema.Schema, tblName string) (sch sc
 
 	// TODO: We'll remove this once it's possible to get diff and merge on different primary key sets
 	// TODO: decide how to merge different orders of PKS
-	if !schema.ArePrimaryKeySetsDiffable(ourSch, theirSch) {
+	if !schema.ArePrimaryKeySetsDiffable(format, ourSch, theirSch) {
 		return nil, SchemaConflict{}, ErrMergeWithDifferentPkSets
 	}
 

--- a/go/libraries/doltcore/merge/merge_schema.go
+++ b/go/libraries/doltcore/merge/merge_schema.go
@@ -20,12 +20,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dolthub/dolt/go/store/types"
 	sqle "github.com/dolthub/go-mysql-server"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/dolt/go/store/types"
 )
 
 type conflictKind byte

--- a/go/libraries/doltcore/merge/schema_integration_test.go
+++ b/go/libraries/doltcore/merge/schema_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/dolthub/dolt/go/store/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -611,7 +612,7 @@ func testMergeSchemasWithConflicts(t *testing.T, test mergeSchemaConflictTest) {
 
 	otherSch := getSchema(t, dEnv)
 
-	_, actConflicts, err := merge.SchemaMerge(mainSch, otherSch, ancSch, "test")
+	_, actConflicts, err := merge.SchemaMerge(types.Format_Default, mainSch, otherSch, ancSch, "test")
 	if test.expectedErr != nil {
 		assert.True(t, errors.Is(err, test.expectedErr))
 		return

--- a/go/libraries/doltcore/merge/schema_integration_test.go
+++ b/go/libraries/doltcore/merge/schema_integration_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/dolthub/dolt/go/store/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -32,6 +31,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
+	"github.com/dolthub/dolt/go/store/types"
 )
 
 type testCommand struct {

--- a/go/libraries/doltcore/merge/violations_fk.go
+++ b/go/libraries/doltcore/merge/violations_fk.go
@@ -212,7 +212,7 @@ func nomsParentFkConstraintViolations(
 		return nil, false, err
 	}
 
-	differ := diff.NewRowDiffer(ctx, preParentSch, postParent.Schema, 1024)
+	differ := diff.NewRowDiffer(ctx, preParentRowData.Format(), preParentSch, postParent.Schema, 1024)
 	defer differ.Close()
 	differ.Start(ctx, preParentRowData, durable.NomsMapFromIndex(postParent.RowData))
 	for {
@@ -379,7 +379,7 @@ func nomsChildFkConstraintViolations(
 		return nil, false, err
 	}
 
-	differ := diff.NewRowDiffer(ctx, preChildSch, postChild.Schema, 1024)
+	differ := diff.NewRowDiffer(ctx, preChildRowData.Format(), preChildSch, postChild.Schema, 1024)
 	defer differ.Close()
 	differ.Start(ctx, preChildRowData, durable.NomsMapFromIndex(postChild.RowData))
 	for {

--- a/go/libraries/doltcore/schema/schema.go
+++ b/go/libraries/doltcore/schema/schema.go
@@ -167,7 +167,7 @@ func GetSharedCols(schema Schema, cmpNames []string, cmpKinds []types.NomsKind) 
 
 // ArePrimaryKeySetsDiffable checks if two schemas are diffable. Assumes the
 // passed in schema are from the same table between commits. If __DOLT_1__, then
-// it also checks if the underlying types of the columns are equal.
+// it also checks if the underlying SQL types of the columns are equal.
 func ArePrimaryKeySetsDiffable(format *types.NomsBinFormat, fromSch, toSch Schema) bool {
 	if fromSch == nil && toSch == nil {
 		return false
@@ -195,7 +195,7 @@ func ArePrimaryKeySetsDiffable(format *types.NomsBinFormat, fromSch, toSch Schem
 		if (c1.Tag != c2.Tag) || (c1.IsPartOfPK != c2.IsPartOfPK) {
 			return false
 		}
-		if types.IsFormat_DOLT_1(format) && !c1.TypeInfo.Equals(c2.TypeInfo) {
+		if types.IsFormat_DOLT_1(format) && !c1.TypeInfo.ToSqlType().Equals(c2.TypeInfo.ToSqlType()) {
 			return false
 		}
 	}

--- a/go/libraries/doltcore/schema/schema.go
+++ b/go/libraries/doltcore/schema/schema.go
@@ -165,9 +165,10 @@ func GetSharedCols(schema Schema, cmpNames []string, cmpKinds []types.NomsKind) 
 	return shared
 }
 
-// ArePrimaryKeySetsDiffable checks if two schemas are diffable. Assumes the passed in schema are from the same table
-// between commits.
-func ArePrimaryKeySetsDiffable(fromSch, toSch Schema) bool {
+// ArePrimaryKeySetsDiffable checks if two schemas are diffable. Assumes the
+// passed in schema are from the same table between commits. If __DOLT_1__, then
+// it also checks if the underlying types of the columns are equal.
+func ArePrimaryKeySetsDiffable(format *types.NomsBinFormat, fromSch, toSch Schema) bool {
 	if fromSch == nil && toSch == nil {
 		return false
 		// Empty case
@@ -192,6 +193,9 @@ func ArePrimaryKeySetsDiffable(fromSch, toSch Schema) bool {
 		c1 := cc1.GetAtIndex(i)
 		c2 := cc2.GetAtIndex(i)
 		if (c1.Tag != c2.Tag) || (c1.IsPartOfPK != c2.IsPartOfPK) {
+			return false
+		}
+		if types.IsFormat_DOLT_1(format) && !c1.TypeInfo.Equals(c2.TypeInfo) {
 			return false
 		}
 	}

--- a/go/libraries/doltcore/sqle/dtables/diff_iter.go
+++ b/go/libraries/doltcore/sqle/dtables/diff_iter.go
@@ -87,7 +87,7 @@ func newNomsDiffIter(ctx *sql.Context, ddb *doltdb.DoltDB, joiner *rowconv.Joine
 	fromCmInfo := commitInfo{types.String(dp.fromName), dp.fromDate, fromCol.Tag, fromDateCol.Tag}
 	toCmInfo := commitInfo{types.String(dp.toName), dp.toDate, toCol.Tag, toDateCol.Tag}
 
-	rd := diff.NewRowDiffer(ctx, fromSch, toSch, 1024)
+	rd := diff.NewRowDiffer(ctx, ddb.Format(), fromSch, toSch, 1024)
 	// TODO (dhruv) don't cast to noms map
 	// Use index lookup if it exists
 	if lookup == nil {

--- a/go/libraries/doltcore/sqle/dtables/diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/diff_table.go
@@ -333,7 +333,7 @@ func (dp *DiffPartition) isDiffablePartition(ctx *sql.Context) (bool, error) {
 		return false, err
 	}
 
-	return schema.ArePrimaryKeySetsDiffable(fromSch, toSch), nil
+	return schema.ArePrimaryKeySetsDiffable(dp.from.Format(), fromSch, toSch), nil
 }
 
 type partitionSelectFunc func(*sql.Context, DiffPartition) (bool, error)

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -738,6 +738,12 @@ func TestDoltMerge(t *testing.T) {
 		// dolt versioning conflicts with reset harness -- use new harness every time
 		enginetest.TestScript(t, newDoltHarness(t), script)
 	}
+
+	if types.IsFormat_DOLT_1(types.Format_Default) {
+		for _, script := range Dolt1MergeScripts {
+			enginetest.TestScript(t, newDoltHarness(t), script)
+		}
+	}
 }
 
 func TestDoltConflictsTableNameTable(t *testing.T) {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -955,6 +955,12 @@ func TestDiffSystemTable(t *testing.T) {
 			enginetest.TestScript(t, harness, test)
 		})
 	}
+
+	if types.IsFormat_DOLT_1(types.Format_Default) {
+		for _, test := range Dolt1DiffSystemTableScripts {
+			enginetest.TestScript(t, newDoltHarness(t), test)
+		}
+	}
 }
 
 func TestTestReadOnlyDatabases(t *testing.T) {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -1799,6 +1799,31 @@ var MergeScripts = []queries.ScriptTest{
 	},
 }
 
+var Dolt1MergeScripts = []queries.ScriptTest{
+	{
+		Name: "Merge errors if the primary key types have changed (even if the new type has the same NomsKind)",
+		SetUpScript: []string{
+			"CREATE TABLE t (pk1 bigint, pk2 bigint, PRIMARY KEY (pk1, pk2));",
+			"CALL DOLT_COMMIT('-am', 'setup');",
+
+			"CALL DOLT_CHECKOUT('-b', 'right');",
+			"ALTER TABLE t MODIFY COLUMN pk2 tinyint",
+			"INSERT INTO t VALUES (2, 2);",
+			"CALL DOLT_COMMIT('-am', 'right commit');",
+
+			"CALL DOLT_CHECKOUT('main');",
+			"INSERT INTO t VALUES (1, 1);",
+			"CALL DOLT_COMMIT('-am', 'left commit');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:          "CALL DOLT_MERGE('right');",
+				ExpectedErrStr: "error: cannot merge two tables with different primary key sets",
+			},
+		},
+	},
+}
+
 var KeylessMergeCVsAndConflictsScripts = []queries.ScriptTest{
 	{
 		Name: "Keyless merge with unique indexes documents violations",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -3554,6 +3554,29 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 	},
 }
 
+var Dolt1DiffSystemTableScripts = []queries.ScriptTest{
+	{
+		Name: "Diff table stops creating diff partitions when any primary key type has changed",
+		SetUpScript: []string{
+			"CREATE TABLE t (pk1 VARCHAR(100), pk2 VARCHAR(100), PRIMARY KEY (pk1, pk2));",
+			"INSERT INTO t VALUES ('1', '1');",
+			"CALL DOLT_COMMIT('-am', 'setup');",
+
+			"ALTER TABLE t MODIFY COLUMN pk2 VARCHAR(101)",
+			"CALL DOLT_COMMIT('-am', 'modify column type');",
+
+			"INSERT INTO t VALUES ('2', '2');",
+			"CALL DOLT_COMMIT('-am', 'insert new row');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "SELECT to_pk1, to_pk2, from_pk1, from_pk2, diff_type from dolt_diff_t;",
+				Expected: []sql.Row{{"2", "2", nil, nil, "added"}},
+			},
+		},
+	},
+}
+
 var DiffTableFunctionScriptTests = []queries.ScriptTest{
 	{
 		Name: "invalid arguments",

--- a/integration-tests/bats/schema-changes.bats
+++ b/integration-tests/bats/schema-changes.bats
@@ -183,8 +183,6 @@ SQL
 }
 
 @test "schema-changes: changing column types in place works" {
-    skip_nbf_dolt_1 "hangs"
-    
     dolt sql <<SQL
 CREATE TABLE test2(
   pk1 BIGINT,
@@ -248,6 +246,7 @@ SQL
     dolt add .
     dolt commit -m "Created table with one row"
 
+    skip_nbf_dolt_1 "In __DOLT_1__ the following throws an error since the primary key types changed"
     dolt merge main
 
     run dolt sql -q 'show create table test2'


### PR DESCRIPTION
Unskips schema-changes.bats