### PR TITLE
fix minor log.Fatalln output

### DIFF
--- a/go/utils/remotesrv/main.go
+++ b/go/utils/remotesrv/main.go
@@ -42,9 +42,7 @@ func main() {
 		err := os.Chdir(*dirParam)
 
 		if err != nil {
-			log.Fatalln("failed to chdir to:", *dirParam)
-			log.Fatalln("error:", err.Error())
-			os.Exit(1)
+			log.Fatalln("failed to chdir to:", *dirParam, "error:", err.Error())
 		} else {
 			log.Println("cwd set to " + *dirParam)
 		}


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

log.Fatalln is equivalent to Println() followed by a call to os.Exit(1).

see example:

https://go.dev/play/p/VcdbrSNK6wH
```go
package main

import (
	"log"
	"os"
)

func main() {
	log.Fatalln("A")
	log.Fatalln("B") // unreachable code
	os.Exit(2)
}

/* output:
2009/11/10 23:00:00 A

Program exited.
*/

```