### PR TITLE
Fix for persisted database specific system variables failing to load

### DIFF
--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -355,6 +355,33 @@ func runMain() int {
 
 	defer tempfiles.MovableTempFileProvider.Clean()
 
+	// Find all database names and add global variables for them. This needs to
+	// occur before a call to dsess.InitPersistedSystemVars. Otherwise, database
+	// specific persisted system vars will fail to load.
+	//
+	// In general, there is a lot of work TODO in this area. System global
+	// variables are persisted to the Dolt local config if found and if not
+	// found the Dolt global config (typically ~/.dolt/config_global.json).
+
+	// Depending on what directory a dolt sql-server is started in, users may
+	// see different variables values. For example, start a dolt sql-server in
+	// the dolt database folder and persist some system variable.
+
+	// If dolt sql-server is started outside that folder, those system variables
+	// will be lost. This is particularly confusing for database specific system
+	// variables like `${db_name}_default_branch` (maybe these should not be
+	// part of Dolt config in the first place!).
+
+	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
+	if err != nil {
+		cli.PrintErrln("failed to load database names")
+		return 1
+	}
+	_ = mrEnv.Iter(func(dbName string, dEnv *env.DoltEnv) (stop bool, err error) {
+		dsess.DefineSystemVariablesForDB(dbName)
+		return false, nil
+	})
+
 	err = dsess.InitPersistedSystemVars(dEnv)
 	if err != nil {
 		cli.Printf("error: failed to load persisted global variables: %s\n", err.Error())

--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -909,6 +909,7 @@ func (d *DoltSession) HasDB(ctx *sql.Context, dbName string) bool {
 // other state tracking metadata.
 func (d *DoltSession) AddDB(ctx *sql.Context, dbState InitialDbState) error {
 	db := dbState.Db
+	DefineSystemVariablesForDB(db.Name())
 
 	sessionState := NewEmptyDatabaseSessionState()
 	d.dbStates[db.Name()] = sessionState

--- a/go/libraries/doltcore/sqle/dsess/variables.go
+++ b/go/libraries/doltcore/sqle/dsess/variables.go
@@ -105,8 +105,8 @@ func init() {
 	})
 }
 
-// defineSystemVariablesForDB defines per database dolt-session variables in the engine as necessary
-func defineSystemVariablesForDB(name string) {
+// DefineSystemVariablesForDB defines per database dolt-session variables in the engine as necessary
+func DefineSystemVariablesForDB(name string) {
 	if _, _, ok := sql.SystemVariables.GetGlobal(name + HeadKeySuffix); !ok {
 		sql.SystemVariables.AddSystemVariables([]sql.SystemVariable{
 			{

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -21,7 +21,25 @@ teardown() {
     teardown_common
 }
 
+@test "sql-server: Database specific system variables should be loaded" {
+    cd repo1
+    dolt branch dev
 
+    start_sql_server
+    server_query repo1 1 "SET PERSIST repo1_default_branch = 'dev';" ""
+    stop_sql_server
+    start_sql_server
+    server_query repo1 1 "SELECT @@repo1_default_branch;" "@@SESSION.repo1_default_branch\ndev"
+    stop_sql_server
+
+    # system variable is lost when starting sql-server outside of the folder
+    cd ..
+    start_sql_server
+    server_query repo1 1 "SELECT LENGTH(@@repo1_default_branch);" "LENGTH(@@repo1_default_branch)\n0"
+
+    # Ideally we would test the global config, but altering the DOLT_ROOT_PATH environment var here is a
+    # code smell.
+}
 
 @test "sql-server: user session variables from config" {
   cd repo1

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -12,6 +12,10 @@ make_repo() {
 setup() {
     skiponwindows "tests are flaky on Windows"
     setup_no_dolt_init
+    mkdir $BATS_TMPDIR/sql-server-test$$
+    nativevar DOLT_ROOT_PATH $BATS_TMPDIR/sql-server-test$$ /p
+    dolt config --global --add user.email "test@test.com"
+    dolt config --global --add user.name "test"
     make_repo repo1
     make_repo repo2
 }
@@ -22,8 +26,6 @@ teardown() {
 }
 
 @test "sql-server: Database specific system variables should be loaded" {
-    dir=$(pwd)
-    nativevar DOLT_ROOT_PATH $dir
     cd repo1
     dolt branch dev
     dolt branch other
@@ -48,7 +50,7 @@ teardown() {
 
     # ensure we didn't blow away local setting
     cd repo1
-    start_sql_server
+    start_sql_server_with_args --user dolt --doltcfg-dir './'
     server_query repo1 1 "SELECT @@repo1_default_branch;" "@@SESSION.repo1_default_branch\ndev"
 }
 


### PR DESCRIPTION
Fix for https://github.com/dolthub/dolt/issues/3887

Persisting and loading `${branch_name}_default_branch` from config now works.