### PR TITLE
Clone Dolthub Links

### DIFF
--- a/go/cmd/dolt/commands/clone.go
+++ b/go/cmd/dolt/commands/clone.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
@@ -232,7 +231,7 @@ func createRemote(ctx context.Context, remoteName, remoteUrl string, params map[
 }
 
 // validateAndParseDolthubUrl validates and returns a Dolthub repo link's repository name. For example, given this url: https://www.dolthub.com/repositories/user/test
-// the function would return 'user/test'. Note this function correctly does not handle remocing additional path extensions. The url: https://www.dolthub.com/repositories/user/test/pulls
+// the function would return 'user/test'. Note this function correctly does not handle removing additional path extensions. The url: https://www.dolthub.com/repositories/user/test/pulls
 // would return 'user/test/pulls' and eventually error later in the code base.
 func validateAndParseDolthubUrl(urlStr string) (string, bool) {
 	u, err := earl.Parse(urlStr)
@@ -247,7 +246,7 @@ func validateAndParseDolthubUrl(urlStr string) (string, bool) {
 
 		if len(split) > 2 {
 			// the path is of the form /repositories/user/repoName
-			return filepath.Join(split[2:]...), true
+			return strings.Join(split[2:], "/"), true
 		}
 	}
 

--- a/go/cmd/dolt/commands/clone.go
+++ b/go/cmd/dolt/commands/clone.go
@@ -232,7 +232,7 @@ func createRemote(ctx context.Context, remoteName, remoteUrl string, params map[
 }
 
 // validateAndParseDolthubUrl validates and returns a Dolthub repo link's repository name. For example, given this url: https://www.dolthub.com/repositories/user/test
-// the function would return 'user/test'. Note this function correctly does handle additional path extensions. The url: https://www.dolthub.com/repositories/user/test/pulls
+// the function would return 'user/test'. Note this function correctly does not handle remocing additional path extensions. The url: https://www.dolthub.com/repositories/user/test/pulls
 // would return 'user/test/pulls' and eventually error later in the code base.
 func validateAndParseDolthubUrl(urlStr string) (string, bool) {
 	u, err := earl.Parse(urlStr)

--- a/go/cmd/dolt/commands/clone.go
+++ b/go/cmd/dolt/commands/clone.go
@@ -114,7 +114,7 @@ func clone(ctx context.Context, apr *argparser.ArgParseResults, dEnv *env.DoltEn
 
 	userDirExists, _ := dEnv.FS.Exists(dir)
 
-	scheme, remoteUrl, err := env.GetAbsRemoteUrl(dEnv.FS, dEnv.Config, urlStr)
+	scheme, remoteUrl, err := env.GetAbsRemoteUrl(dEnv.FS, dEnv.Config, urlStr) // TODO: Probably should support here
 
 	if err != nil {
 		return errhand.BuildDError("error: '%s' is not valid.", urlStr).Build()
@@ -205,6 +205,8 @@ func parseArgs(apr *argparser.ArgParseResults) (string, string, errhand.VerboseE
 
 func createRemote(ctx context.Context, remoteName, remoteUrl string, params map[string]string, dEnv *env.DoltEnv) (env.Remote, *doltdb.DoltDB, errhand.VerboseError) {
 	cli.Printf("cloning %s\n", remoteUrl)
+
+	// TODO: Can do check for dolthub url here
 
 	r := env.NewRemote(remoteName, remoteUrl, params)
 	ddb, err := r.GetRemoteDB(ctx, types.Format_Default, dEnv)

--- a/go/cmd/dolt/commands/clone_test.go
+++ b/go/cmd/dolt/commands/clone_test.go
@@ -49,6 +49,10 @@ func TestParseDolthubRepos(t *testing.T) {
 			urlStr:   "http://www.dolthub.com/repositories",
 			expected: "",
 		},
+		{
+			urlStr:   "https://www.dolthub.com/repositories/dolthub/museum-collections",
+			expected: "dolthub/museum-collections",
+		},
 	}
 
 	for _, test := range tests {

--- a/go/cmd/dolt/commands/clone_test.go
+++ b/go/cmd/dolt/commands/clone_test.go
@@ -1,0 +1,63 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseDolthubRepos(t *testing.T) {
+	tests := []struct {
+		urlStr   string
+		expected string
+	}{
+		{
+			urlStr:   "https://www.dolthub.com/repositories/web3/bitcoin-fast",
+			expected: "web3/bitcoin-fast",
+		},
+		{
+			urlStr:   "https://www.dolthub.com/repositories/web3/bitcoin-fast/pulls",
+			expected: "web3/bitcoin-fast/pulls",
+		},
+		{
+			urlStr:   "https://www.dolthub.com/repositories",
+			expected: "",
+		},
+		{
+			urlStr:   "https://www.dolthub.com/repositories/test",
+			expected: "test",
+		},
+		{
+			urlStr:   "https://www.notdolthub.com/repositories/dads",
+			expected: "",
+		},
+		{
+			urlStr:   "http://www.dolthub.com/repositories",
+			expected: "",
+		},
+	}
+
+	for _, test := range tests {
+		received, ok := validateAndParseDolthubUrl(test.urlStr)
+		if test.expected == "" {
+			require.False(t, ok)
+		} else {
+			require.Equal(t, test.expected, received)
+		}
+	}
+
+}

--- a/go/libraries/doltcore/env/remotes.go
+++ b/go/libraries/doltcore/env/remotes.go
@@ -421,23 +421,6 @@ func GetAbsRemoteUrl(fs filesys2.Filesys, cfg config.ReadableConfig, urlArg stri
 			return u.Scheme, absUrl, err
 		}
 
-		// This is a dolthub link
-		if u.Scheme == dbfactory.HTTPSScheme && u.Host == "www.dolthub.com" {
-			split := strings.Split(u.Path, "/")
-
-			repoName := filepath.Join(split[2:]...)
-			hostName, err := cfg.GetString(RemotesApiHostKey)
-			if err != nil {
-				if err != config.ErrConfigParamNotFound {
-					return "", "", err
-				}
-
-				hostName = DefaultRemotesApiHost
-			}
-
-			return dbfactory.HTTPSScheme, "https://" + path.Join(hostName, repoName), nil
-		}
-
 		return u.Scheme, urlArg, nil
 	} else if u.Host != "" {
 		return dbfactory.HTTPSScheme, "https://" + urlArg, nil

--- a/go/libraries/doltcore/env/remotes.go
+++ b/go/libraries/doltcore/env/remotes.go
@@ -421,6 +421,23 @@ func GetAbsRemoteUrl(fs filesys2.Filesys, cfg config.ReadableConfig, urlArg stri
 			return u.Scheme, absUrl, err
 		}
 
+		// This is a dolthub link
+		if u.Scheme == dbfactory.HTTPSScheme && u.Host == "www.dolthub.com" {
+			split := strings.Split(u.Path, "/")
+
+			repoName := filepath.Join(split[2:]...)
+			hostName, err := cfg.GetString(RemotesApiHostKey)
+			if err != nil {
+				if err != config.ErrConfigParamNotFound {
+					return "", "", err
+				}
+
+				hostName = DefaultRemotesApiHost
+			}
+
+			return dbfactory.HTTPSScheme, "https://" + path.Join(hostName, repoName), nil
+		}
+
 		return u.Scheme, urlArg, nil
 	} else if u.Host != "" {
 		return dbfactory.HTTPSScheme, "https://" + urlArg, nil


### PR DESCRIPTION
This pr supports `dolt clone` for  `https://www.dolthub.com/repositories/..` databases