### PR TITLE
[no-release-notes] `__DOLT_DEV__` Migration

### DIFF
--- a/go/cmd/dolt/commands/log.go
+++ b/go/cmd/dolt/commands/log.go
@@ -224,13 +224,7 @@ func logCommits(ctx context.Context, dEnv *env.DoltEnv, cs *doltdb.CommitSpec, o
 	}
 
 	matchFunc := func(commit *doltdb.Commit) (bool, error) {
-		numParents, err := commit.NumParents()
-
-		if err != nil {
-			return false, err
-		}
-
-		return numParents >= opts.minParents, nil
+		return commit.NumParents() >= opts.minParents, nil
 	}
 	commits, err := commitwalk.GetTopNTopoOrderedCommitsMatching(ctx, dEnv.DoltDB, h, opts.numLines, matchFunc)
 

--- a/go/cmd/dolt/commands/migrate.go
+++ b/go/cmd/dolt/commands/migrate.go
@@ -20,8 +20,10 @@ import (
 	"github.com/fatih/color"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	eventsapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
+	"github.com/dolthub/dolt/go/libraries/doltcore/migrate"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 )
 
@@ -36,7 +38,7 @@ const (
 var migrateDocs = cli.CommandDocumentationContent{
 	ShortDesc: "Executes a database migration to use the latest Dolt data format.",
 	LongDesc: `Migrate is a multi-purpose command to update the data format of a Dolt database. Over time, development 
-on Dolt requires changes to the on-disk data format. These changes are necessary to improve Database performance amd 
+on Dolt requires changes to the on-disk data format. These changes are necessary to improve Database performance and 
 correctness. Migrating to the latest format is therefore necessary for compatibility with the latest Dolt clients, and
 to take advantage of the newly released Dolt features.`,
 
@@ -76,7 +78,7 @@ func (cmd MigrateCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd MigrateCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.ArgParser()
-	help, _ := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, migrateDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, migrateDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
 	if apr.Contains(migratePushFlag) && apr.Contains(migratePullFlag) {
@@ -84,5 +86,23 @@ func (cmd MigrateCmd) Exec(ctx context.Context, commandStr string, args []string
 		return 1
 	}
 
+	if err := MigrateDatabase(ctx, dEnv); err != nil {
+		verr := errhand.BuildDError("migration failed").AddCause(err).Build()
+		return HandleVErrAndExitCode(verr, usage)
+	}
 	return 0
+}
+
+func MigrateDatabase(ctx context.Context, dEnv *env.DoltEnv) error {
+	menv, err := migrate.NewEnvironment(ctx, dEnv)
+	if err != nil {
+		return err
+	}
+
+	err = migrate.TraverseDAG(ctx, menv.Migration.DoltDB, menv.Existing.DoltDB)
+	if err != nil {
+		return err
+	}
+
+	return migrate.SwapChunkstores(ctx, menv.Migration, "")
 }

--- a/go/cmd/dolt/commands/migrate.go
+++ b/go/cmd/dolt/commands/migrate.go
@@ -109,5 +109,5 @@ func MigrateDatabase(ctx context.Context, dEnv *env.DoltEnv) error {
 		return err
 	}
 
-	return migrate.SwapChunkstores(ctx, menv.Migration, "")
+	return migrate.SwapChunkStores(ctx, menv)
 }

--- a/go/cmd/dolt/commands/migrate.go
+++ b/go/cmd/dolt/commands/migrate.go
@@ -98,8 +98,13 @@ func MigrateDatabase(ctx context.Context, dEnv *env.DoltEnv) error {
 	if err != nil {
 		return err
 	}
+	p, err := menv.Migration.FS.Abs(".")
+	if err != nil {
+		return err
+	}
+	cli.Println("migrating database at tmp dir: ", p)
 
-	err = migrate.TraverseDAG(ctx, menv.Migration.DoltDB, menv.Existing.DoltDB)
+	err = migrate.TraverseDAG(ctx, menv.Existing.DoltDB, menv.Migration.DoltDB)
 	if err != nil {
 		return err
 	}

--- a/go/cmd/dolt/commands/migrate.go
+++ b/go/cmd/dolt/commands/migrate.go
@@ -93,6 +93,7 @@ func (cmd MigrateCmd) Exec(ctx context.Context, commandStr string, args []string
 	return 0
 }
 
+// MigrateDatabase migrates the NomsBinFormat of |dEnv.DoltDB|.
 func MigrateDatabase(ctx context.Context, dEnv *env.DoltEnv) error {
 	menv, err := migrate.NewEnvironment(ctx, dEnv)
 	if err != nil {

--- a/go/libraries/doltcore/doltdb/commit.go
+++ b/go/libraries/doltcore/doltdb/commit.go
@@ -80,8 +80,8 @@ func (c *Commit) ParentHashes(ctx context.Context) ([]hash.Hash, error) {
 }
 
 // NumParents gets the number of parents a commit has.
-func (c *Commit) NumParents() (int, error) {
-	return len(c.parents), nil
+func (c *Commit) NumParents() int {
+	return len(c.parents)
 }
 
 func (c *Commit) Height() (uint64, error) {
@@ -180,14 +180,11 @@ func (c *Commit) GetAncestor(ctx context.Context, as *AncestorSpec) (*Commit, er
 
 	instructions := as.Instructions
 	for _, inst := range instructions {
-		n, err := cur.NumParents()
-		if err != nil {
-			return nil, err
-		}
-		if inst >= n {
+		if inst >= cur.NumParents() {
 			return nil, ErrInvalidAncestorSpec
 		}
 
+		var err error
 		cur, err = cur.GetParent(ctx, inst)
 		if err != nil {
 			return nil, err

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -633,10 +633,7 @@ func (ddb *DoltDB) ResolveParent(ctx context.Context, commit *Commit, parentIdx 
 }
 
 func (ddb *DoltDB) ResolveAllParents(ctx context.Context, commit *Commit) ([]*Commit, error) {
-	num, err := commit.NumParents()
-	if err != nil {
-		return nil, err
-	}
+	num := commit.NumParents()
 	resolved := make([]*Commit, num)
 	for i := 0; i < num; i++ {
 		parent, err := ddb.ResolveParent(ctx, commit, i)

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -79,6 +79,8 @@ func DoltDBFromCS(cs chunks.ChunkStore) *DoltDB {
 	return &DoltDB{hooksDatabase{Database: db}, vrw, ns}
 }
 
+// HackDatasDatabaseFromDoltDB unwraps a DoltDB to a datas.Database.
+// Deprecated: only for use in dolt migrate.
 func HackDatasDatabaseFromDoltDB(ddb *DoltDB) datas.Database {
 	return ddb.db
 }

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -596,6 +596,7 @@ func (ddb *DoltDB) CommitDanglingWithParentCommits(ctx context.Context, valHash 
 	return ddb.CommitDangling(ctx, val, commitOpts)
 }
 
+// CommitDangling creates a new Commit for |val| that is not referenced by any DoltRef.
 func (ddb *DoltDB) CommitDangling(ctx context.Context, val types.Value, opts datas.CommitOptions) (*Commit, error) {
 	cs := datas.ChunkStoreFromDatabase(ddb.db)
 

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -79,6 +79,10 @@ func DoltDBFromCS(cs chunks.ChunkStore) *DoltDB {
 	return &DoltDB{hooksDatabase{Database: db}, vrw, ns}
 }
 
+func HackDatasDatabaseFromDoltDB(ddb *DoltDB) datas.Database {
+	return ddb.db
+}
+
 // LoadDoltDB will acquire a reference to the underlying noms db.  If the Location is InMemDoltDB then a reference
 // to a newly created in memory database will be used. If the location is LocalDirDoltDB, the directory must exist or
 // this returns nil.

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -417,6 +417,15 @@ func (ddb *DoltDB) ReadRootValue(ctx context.Context, h hash.Hash) (*RootValue, 
 	return decodeRootNomsValue(ddb.vrw, ddb.ns, val)
 }
 
+// ReadCommit reads the Commit whose hash is |h|, if one exists.
+func (ddb *DoltDB) ReadCommit(ctx context.Context, h hash.Hash) (*Commit, error) {
+	c, err := datas.LoadCommitAddr(ctx, ddb.vrw, h)
+	if err != nil {
+		return nil, err
+	}
+	return NewCommit(ctx, ddb.vrw, ddb.ns, c)
+}
+
 // Commit will update a branch's head value to be that of a previously committed root value hash
 func (ddb *DoltDB) Commit(ctx context.Context, valHash hash.Hash, dref ref.DoltRef, cm *datas.CommitMeta) (*Commit, error) {
 	if dref.GetType() != ref.BranchRefType {

--- a/go/libraries/doltcore/doltdb/doltdb_test.go
+++ b/go/libraries/doltcore/doltdb/doltdb_test.go
@@ -325,7 +325,7 @@ func TestLDNoms(t *testing.T) {
 		assert.Equal(t, len(branches), 1)
 		assert.Equal(t, branches[0].Ref.GetPath(), "master")
 
-		numParents, err := commit.NumParents()
+		numParents := commit.NumParents()
 		assert.NoError(t, err)
 
 		if numParents != 1 {

--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -768,6 +768,10 @@ func (root *RootValue) withStorage(st rvStorage) *RootValue {
 	return &RootValue{root.vrw, root.ns, st, nil}
 }
 
+func HackNomsValuesFromRootValues(root *RootValue) types.Value {
+	return root.nomsValue()
+}
+
 func (root *RootValue) nomsValue() types.Value {
 	return root.st.nomsValue()
 }

--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -1325,6 +1325,8 @@ func NewDataCacheKey(rv *RootValue) (DataCacheKey, error) {
 	return DataCacheKey{hash}, nil
 }
 
+// HackNomsValuesFromRootValues unwraps a RootVal to a noms Value.
+// Deprecated: only for use in dolt migrate.
 func HackNomsValuesFromRootValues(root *RootValue) types.Value {
 	return root.nomsValue()
 }

--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -768,10 +768,6 @@ func (root *RootValue) withStorage(st rvStorage) *RootValue {
 	return &RootValue{root.vrw, root.ns, st, nil}
 }
 
-func HackNomsValuesFromRootValues(root *RootValue) types.Value {
-	return root.nomsValue()
-}
-
 func (root *RootValue) nomsValue() types.Value {
 	return root.st.nomsValue()
 }
@@ -1327,4 +1323,8 @@ func NewDataCacheKey(rv *RootValue) (DataCacheKey, error) {
 	}
 
 	return DataCacheKey{hash}, nil
+}
+
+func HackNomsValuesFromRootValues(root *RootValue) types.Value {
+	return root.nomsValue()
 }

--- a/go/libraries/doltcore/migrate/environment.go
+++ b/go/libraries/doltcore/migrate/environment.go
@@ -1,0 +1,153 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/utils/earl"
+	"github.com/dolthub/dolt/go/libraries/utils/filesys"
+	"github.com/dolthub/dolt/go/store/types"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/env"
+)
+
+const (
+	doltDir = dbfactory.DoltDir
+	nomsDir = dbfactory.DataDir
+)
+
+var targetFormat = types.Format_DOLT_DEV
+
+type Environment struct {
+	Migration *env.DoltEnv
+	Existing  *env.DoltEnv
+}
+
+func NewEnvironment(ctx context.Context, existing *env.DoltEnv) (Environment, error) {
+	mfs, err := getMigrateFS(existing.FS)
+	if err != nil {
+		return Environment{}, err
+	}
+
+	if err = InitMigrationDB(ctx, existing.FS, mfs); err != nil {
+		return Environment{}, err
+	}
+
+	mdb, err := doltdb.LoadDoltDB(ctx, targetFormat, doltdb.LocalDirDoltDB, mfs)
+	if err != nil {
+		return Environment{}, err
+	}
+
+	config, err := env.LoadDoltCliConfig(env.GetCurrentUserHomeDir, mfs)
+	if err != nil {
+		return Environment{}, err
+	}
+
+	migration := &env.DoltEnv{
+		Version:   existing.Version,
+		Config:    config,
+		RepoState: existing.RepoState,
+		DoltDB:    mdb,
+		FS:        mfs,
+		//urlStr:      urlStr,
+		//hdp:         hdp,
+	}
+
+	return Environment{
+		Migration: migration,
+		Existing:  existing,
+	}, nil
+}
+
+func SwapChunkstores(ctx context.Context, migration *env.DoltEnv, dest string) error {
+	return nil
+}
+
+func InitMigrationDB(ctx context.Context, src, dest filesys.Filesys) (err error) {
+	base, err := src.Abs(".")
+	if err != nil {
+		return err
+	}
+
+	ierr := src.Iter(doltDir, true, func(path string, size int64, isDir bool) (stop bool) {
+		if isDir {
+			err = dest.MkDirs(path)
+			stop = err != nil
+			return
+		}
+		if strings.Contains(path, nomsDir) {
+			return
+		}
+
+		path, err = filepath.Rel(base, path)
+		if err != nil {
+			stop = true
+			return
+		}
+
+		if err = filesys.CopyFile(path, path, src, dest); err != nil {
+			stop = true
+			return
+		}
+		return
+	})
+	if ierr != nil {
+		return ierr
+	}
+	if err != nil {
+		return err
+	}
+
+	dd, err := dest.Abs(filepath.Join(doltDir, nomsDir))
+	if err != nil {
+		return err
+	}
+	if err = dest.MkDirs(dd); err != nil {
+		return err
+	}
+
+	u, err := earl.Parse(dd)
+	if err != nil {
+		return err
+	}
+
+	_, _, _, err = dbfactory.FileFactory{}.CreateDB(ctx, targetFormat, u, nil)
+	return
+}
+
+func getMigrateFS(existing filesys.Filesys) (filesys.Filesys, error) {
+	uniq := fmt.Sprintf("dolt_migration_%d", time.Now().Unix())
+	tmpPath := filepath.Join(existing.TempDir(), uniq)
+	if err := existing.MkDirs(tmpPath); err != nil {
+		return nil, err
+	}
+
+	mfs, err := filesys.LocalFilesysWithWorkingDir(tmpPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = mfs.MkDirs(doltDir); err != nil {
+		return nil, err
+	}
+	return mfs, nil
+}

--- a/go/libraries/doltcore/migrate/environment.go
+++ b/go/libraries/doltcore/migrate/environment.go
@@ -226,7 +226,7 @@ func SwapManifests(ctx context.Context, src, dest filesys.Filesys) (err error) {
 }
 
 func getMigrateFS(existing filesys.Filesys) (filesys.Filesys, error) {
-	uniq := fmt.Sprintf("dolt_migration_%d", time.Now().Unix())
+	uniq := fmt.Sprintf("dolt_migration_%d", time.Now().UnixNano())
 	tmpPath := filepath.Join(existing.TempDir(), uniq)
 	if err := existing.MkDirs(tmpPath); err != nil {
 		return nil, err

--- a/go/libraries/doltcore/migrate/environment.go
+++ b/go/libraries/doltcore/migrate/environment.go
@@ -43,18 +43,20 @@ var (
 	migrationMsg = fmt.Sprintf("migrating database to Noms Binary Format %s", targetFormat.VersionString())
 )
 
+// Environment is a migration environment.
 type Environment struct {
 	Migration *env.DoltEnv
 	Existing  *env.DoltEnv
 }
 
+// NewEnvironment creates a migration Environment for |existing|.
 func NewEnvironment(ctx context.Context, existing *env.DoltEnv) (Environment, error) {
 	mfs, err := getMigrateFS(existing.FS)
 	if err != nil {
 		return Environment{}, err
 	}
 
-	if err = InitMigrationDB(ctx, existing, existing.FS, mfs); err != nil {
+	if err = initMigrationDB(ctx, existing, existing.FS, mfs); err != nil {
 		return Environment{}, err
 	}
 
@@ -84,7 +86,7 @@ func NewEnvironment(ctx context.Context, existing *env.DoltEnv) (Environment, er
 	}, nil
 }
 
-func InitMigrationDB(ctx context.Context, existing *env.DoltEnv, src, dest filesys.Filesys) (err error) {
+func initMigrationDB(ctx context.Context, existing *env.DoltEnv, src, dest filesys.Filesys) (err error) {
 	base, err := src.Abs(".")
 	if err != nil {
 		return err
@@ -163,6 +165,7 @@ func InitMigrationDB(ctx context.Context, existing *env.DoltEnv, src, dest files
 	return nil
 }
 
+// SwapChunkStores atomically swaps the ChunkStores of |menv.Migration| and |menv.Existing|.
 func SwapChunkStores(ctx context.Context, menv Environment) error {
 	src, dest := menv.Migration.FS, menv.Existing.FS
 
@@ -203,10 +206,10 @@ func SwapChunkStores(ctx context.Context, menv Environment) error {
 		return cpErr
 	}
 
-	return SwapManifests(ctx, src, dest)
+	return swapManifests(ctx, src, dest)
 }
 
-func SwapManifests(ctx context.Context, src, dest filesys.Filesys) (err error) {
+func swapManifests(ctx context.Context, src, dest filesys.Filesys) (err error) {
 	// backup the current manifest
 	manifest := filepath.Join(doltDir, nomsDir, manifestFile)
 	bak := filepath.Join(doltDir, nomsDir, manifestFile+".bak")

--- a/go/libraries/doltcore/migrate/migrate.go
+++ b/go/libraries/doltcore/migrate/migrate.go
@@ -1,0 +1,102 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+import (
+	"context"
+
+	"github.com/dolthub/dolt/go/store/hash"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
+)
+
+func TraverseDAG(ctx context.Context, ddb *doltdb.DoltDB) (Progress, error) {
+	heads, err := ddb.GetHeadRefs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	prog := newProgress()
+	for i := range heads {
+		if err = TraverseHistory(ctx, heads[i], prog); err != nil {
+			return nil, err
+		}
+	}
+	return prog, nil
+}
+
+func TraverseHistory(ctx context.Context, r ref.DoltRef, prog Progress) error {
+	return nil
+}
+
+func TraverseTagHistory(ctx context.Context, tag *doltdb.Tag, prog Progress) error {
+	return nil
+}
+
+func TraverseWorkingSetHistory(ctx context.Context, ws doltdb.WorkingSet, prog Progress) error {
+	return nil
+}
+
+func TraverseCommitHistory(ctx context.Context, cm *doltdb.Commit, prog Progress) error {
+	for {
+		ph, err := cm.ParentHashes(ctx)
+		if err != nil {
+			return err
+		}
+
+		idx, err := firstAbsent(ctx, prog, ph)
+		if err != nil {
+			return err
+		}
+		if idx < 0 {
+			// parents for |cm| are done, migrate |cm|
+			if err = MigrateCommit(ctx, cm, prog); err != nil {
+				return err
+			}
+			// pop the stack, traverse upwards
+			cm, err = prog.Pop(ctx)
+			if err != nil {
+				return err
+			}
+			if cm == nil {
+				return nil // done
+			}
+			continue
+		}
+
+		// push the stack, traverse downwards
+		if err = prog.Push(ctx, cm); err != nil {
+			return err
+		}
+		cm, err = cm.GetParent(ctx, idx)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func firstAbsent(ctx context.Context, p Progress, addrs []hash.Hash) (int, error) {
+	for i := range addrs {
+		ok, err := p.Has(ctx, addrs[i])
+		if err != nil {
+			return -1, err
+		}
+		if !ok {
+			return i, nil
+		}
+	}
+	return -1, nil
+}

--- a/go/libraries/doltcore/migrate/progress.go
+++ b/go/libraries/doltcore/migrate/progress.go
@@ -1,0 +1,80 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+import (
+	"context"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/store/hash"
+)
+
+type ChunkMapping interface {
+	Has(ctx context.Context, addr hash.Hash) (bool, error)
+	Get(ctx context.Context, addr hash.Hash) (hash.Hash, error)
+	Put(ctx context.Context, old, new hash.Hash) error
+}
+
+type CommitStack interface {
+	Push(ctx context.Context, cm *doltdb.Commit) error
+	Pop(ctx context.Context) (*doltdb.Commit, error)
+}
+
+type Progress interface {
+	ChunkMapping
+	CommitStack
+}
+
+type memoryProgress struct {
+	stack   []*doltdb.Commit
+	mapping map[hash.Hash]hash.Hash
+}
+
+func newProgress() Progress {
+	return memoryProgress{
+		stack:   make([]*doltdb.Commit, 0, 128),
+		mapping: make(map[hash.Hash]hash.Hash, 128),
+	}
+}
+
+func (mem memoryProgress) Has(ctx context.Context, addr hash.Hash) (ok bool, err error) {
+	_, ok = mem.mapping[addr]
+	return
+}
+
+func (mem memoryProgress) Get(ctx context.Context, old hash.Hash) (new hash.Hash, err error) {
+	new = mem.mapping[old]
+	return
+}
+
+func (mem memoryProgress) Put(ctx context.Context, old, new hash.Hash) (err error) {
+	mem.mapping[old] = new
+	return
+}
+
+func (mem memoryProgress) Push(ctx context.Context, cm *doltdb.Commit) (err error) {
+	mem.stack = append(mem.stack, cm)
+	return
+}
+
+func (mem memoryProgress) Pop(ctx context.Context) (cm *doltdb.Commit, err error) {
+	if len(mem.stack) == 0 {
+		return nil, nil
+	}
+	top := len(mem.stack) - 1
+	cm = mem.stack[top]
+	mem.stack = mem.stack[:top]
+	return
+}

--- a/go/libraries/doltcore/migrate/transform.go
+++ b/go/libraries/doltcore/migrate/transform.go
@@ -20,10 +20,10 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 )
 
-func MigrateCommit(ctx context.Context, old *doltdb.Commit, prog Progress) error {
+func MigrateCommit(ctx context.Context, old *doltdb.Commit, new *doltdb.DoltDB, prog Progress) error {
 	return nil
 }
 
-func MigrateRoot(ctx context.Context, old *doltdb.RootValue) (*doltdb.RootValue, error) {
+func MigrateRoot(ctx context.Context, old *doltdb.RootValue, new *doltdb.DoltDB) (*doltdb.RootValue, error) {
 	return old, nil
 }

--- a/go/libraries/doltcore/migrate/transform.go
+++ b/go/libraries/doltcore/migrate/transform.go
@@ -1,0 +1,29 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+import (
+	"context"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+)
+
+func MigrateCommit(ctx context.Context, old *doltdb.Commit, prog Progress) error {
+	return nil
+}
+
+func MigrateRoot(ctx context.Context, old *doltdb.RootValue) (*doltdb.RootValue, error) {
+	return old, nil
+}

--- a/go/libraries/doltcore/migrate/transform.go
+++ b/go/libraries/doltcore/migrate/transform.go
@@ -18,12 +18,179 @@ import (
 	"context"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
+	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/dolt/go/store/datas"
+	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/dolthub/dolt/go/store/types"
 )
 
-func MigrateCommit(ctx context.Context, old *doltdb.Commit, new *doltdb.DoltDB, prog Progress) error {
-	return nil
+func MigrateCommit(ctx context.Context, r ref.DoltRef, cm *doltdb.Commit, new *doltdb.DoltDB, prog Progress) error {
+	root, err := cm.GetRootValue(ctx)
+	if err != nil {
+		return err
+	}
+
+	mRoot, err := MigrateRoot(ctx, root, new)
+	if err != nil {
+		return err
+	}
+	_, addr, err := new.WriteRootValue(ctx, mRoot)
+	if err != nil {
+		return err
+	}
+	value, err := new.ValueReadWriter().ReadValue(ctx, addr)
+	if err != nil {
+		return err
+	}
+
+	opts, err := MigrateCommitOptions(ctx, cm, prog)
+	if err != nil {
+		return err
+	}
+
+	migratedCm, err := new.CommitValue(ctx, r, value, opts)
+	if err != nil {
+		return err
+	}
+
+	// update progress
+	oldHash, err := cm.HashOf()
+	if err != nil {
+		return err
+	}
+	newHash, err := migratedCm.HashOf()
+	if err != nil {
+		return err
+	}
+
+	return prog.Put(ctx, oldHash, newHash)
 }
 
-func MigrateRoot(ctx context.Context, old *doltdb.RootValue, new *doltdb.DoltDB) (*doltdb.RootValue, error) {
-	return old, nil
+func MigrateCommitOptions(ctx context.Context, oldCm *doltdb.Commit, prog Progress) (datas.CommitOptions, error) {
+	parents, err := oldCm.ParentHashes(ctx)
+	if err != nil {
+		return datas.CommitOptions{}, err
+	}
+
+	for i := range parents {
+		migrated, err := prog.Get(ctx, parents[i])
+		if err != nil {
+			return datas.CommitOptions{}, err
+		}
+		parents[i] = migrated
+	}
+
+	meta, err := oldCm.GetCommitMeta(ctx)
+	if err != nil {
+		return datas.CommitOptions{}, err
+	}
+
+	return datas.CommitOptions{
+		Parents: parents,
+		Meta:    meta,
+	}, nil
+}
+
+func MigrateRoot(ctx context.Context, root *doltdb.RootValue, new *doltdb.DoltDB) (*doltdb.RootValue, error) {
+	migrated, err := doltdb.EmptyRootValue(ctx, new.ValueReadWriter(), new.NodeStore())
+	if err != nil {
+		return nil, err
+	}
+
+	fkc, err := root.GetForeignKeyCollection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	migrated, err = migrated.PutForeignKeyCollection(ctx, fkc)
+	if err != nil {
+		return nil, err
+	}
+
+	err = root.IterTables(ctx, func(name string, tbl *doltdb.Table, _ schema.Schema) (bool, error) {
+		mtbl, err := MigrateTable(ctx, tbl, new)
+		if err != nil {
+			return true, err
+		}
+
+		migrated, err = migrated.PutTable(ctx, name, mtbl)
+		if err != nil {
+			return true, err
+		}
+		return false, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return migrated, nil
+}
+
+func MigrateTable(ctx context.Context, table *doltdb.Table, new *doltdb.DoltDB) (*doltdb.Table, error) {
+	rows, err := table.GetRowData(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	err = MigrateNomsMap(ctx, rows, table.ValueReadWriter(), new.ValueReadWriter())
+	if err != nil {
+		return nil, err
+	}
+
+	ai, err := table.GetAutoIncrementValue(ctx)
+	if err != nil {
+		return nil, err
+	}
+	autoInc := types.Uint(ai)
+
+	sch, err := table.GetSchema(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	oldSet, err := table.GetIndexSet(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	newSet, err := MigrateIndexSet(ctx, sch, oldSet, table.ValueReadWriter(), new)
+	if err != nil {
+		return nil, err
+	}
+
+	return doltdb.NewTable(ctx, new.ValueReadWriter(), new.NodeStore(), sch, rows, newSet, autoInc)
+}
+
+func MigrateIndexSet(ctx context.Context, sch schema.Schema, oldSet durable.IndexSet, old types.ValueReadWriter, new *doltdb.DoltDB) (durable.IndexSet, error) {
+	newSet := durable.NewIndexSet(ctx, new.ValueReadWriter(), new.NodeStore())
+	for _, def := range sch.Indexes().AllIndexes() {
+		idx, err := oldSet.GetIndex(ctx, sch, def.Name())
+		if err != nil {
+			return nil, err
+		}
+		if err = MigrateNomsMap(ctx, idx, old, new.ValueReadWriter()); err != nil {
+			return nil, err
+		}
+
+		newSet, err = newSet.PutIndex(ctx, def.Name(), idx)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return newSet, nil
+}
+
+func MigrateNomsMap(ctx context.Context, idx durable.Index, old, new types.ValueReadWriter) error {
+	m := durable.NomsMapFromIndex(idx)
+	_, _, err := types.VisitMapLevelOrder(m, func(h hash.Hash) (int64, error) {
+		v, err := old.ReadValue(ctx, h)
+		if err != nil {
+			return 0, err
+		}
+		_, err = new.WriteValue(ctx, v)
+		return 0, err
+	})
+	return err
 }

--- a/go/libraries/doltcore/migrate/transform.go
+++ b/go/libraries/doltcore/migrate/transform.go
@@ -27,6 +27,12 @@ import (
 )
 
 func MigrateCommit(ctx context.Context, r ref.DoltRef, cm *doltdb.Commit, new *doltdb.DoltDB, prog Progress) error {
+	oldHash, err := cm.HashOf()
+	if err != nil {
+		return err
+	}
+	prog.Log(ctx, "migrating commit %s", oldHash.String())
+
 	root, err := cm.GetRootValue(ctx)
 	if err != nil {
 		return err
@@ -56,10 +62,6 @@ func MigrateCommit(ctx context.Context, r ref.DoltRef, cm *doltdb.Commit, new *d
 	}
 
 	// update progress
-	oldHash, err := cm.HashOf()
-	if err != nil {
-		return err
-	}
 	newHash, err := migratedCm.HashOf()
 	if err != nil {
 		return err

--- a/go/libraries/doltcore/migrate/traverse.go
+++ b/go/libraries/doltcore/migrate/traverse.go
@@ -23,34 +23,34 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 )
 
-func TraverseDAG(ctx context.Context, ddb *doltdb.DoltDB) (Progress, error) {
-	heads, err := ddb.GetHeadRefs(ctx)
+func TraverseDAG(ctx context.Context, old, new *doltdb.DoltDB) error {
+	heads, err := old.GetHeadRefs(ctx)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	prog := newProgress()
 	for i := range heads {
-		if err = TraverseHistory(ctx, heads[i], prog); err != nil {
-			return nil, err
+		if err = TraverseRefHistory(ctx, heads[i], new, prog); err != nil {
+			return err
 		}
 	}
-	return prog, nil
-}
-
-func TraverseHistory(ctx context.Context, r ref.DoltRef, prog Progress) error {
 	return nil
 }
 
-func TraverseTagHistory(ctx context.Context, tag *doltdb.Tag, prog Progress) error {
+func TraverseRefHistory(ctx context.Context, r ref.DoltRef, new *doltdb.DoltDB, prog Progress) error {
 	return nil
 }
 
-func TraverseWorkingSetHistory(ctx context.Context, ws doltdb.WorkingSet, prog Progress) error {
+func TraverseTagHistory(ctx context.Context, tag *doltdb.Tag, new *doltdb.DoltDB, prog Progress) error {
 	return nil
 }
 
-func TraverseCommitHistory(ctx context.Context, cm *doltdb.Commit, prog Progress) error {
+func TraverseWorkingSetHistory(ctx context.Context, ws doltdb.WorkingSet, new *doltdb.DoltDB, prog Progress) error {
+	return nil
+}
+
+func TraverseCommitHistory(ctx context.Context, cm *doltdb.Commit, new *doltdb.DoltDB, prog Progress) error {
 	for {
 		ph, err := cm.ParentHashes(ctx)
 		if err != nil {
@@ -63,7 +63,7 @@ func TraverseCommitHistory(ctx context.Context, cm *doltdb.Commit, prog Progress
 		}
 		if idx < 0 {
 			// parents for |cm| are done, migrate |cm|
-			if err = MigrateCommit(ctx, cm, prog); err != nil {
+			if err = MigrateCommit(ctx, cm, new, prog); err != nil {
 				return err
 			}
 			// pop the stack, traverse upwards

--- a/go/libraries/doltcore/migrate/traverse.go
+++ b/go/libraries/doltcore/migrate/traverse.go
@@ -16,6 +16,7 @@ package migrate
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/dolthub/dolt/go/store/hash"
 
@@ -31,26 +32,112 @@ func TraverseDAG(ctx context.Context, old, new *doltdb.DoltDB) error {
 
 	prog := newProgress()
 	for i := range heads {
-		if err = TraverseRefHistory(ctx, heads[i], new, prog); err != nil {
+		if err = TraverseRefHistory(ctx, heads[i], old, new, prog); err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 
-func TraverseRefHistory(ctx context.Context, r ref.DoltRef, new *doltdb.DoltDB, prog Progress) error {
+func TraverseRefHistory(ctx context.Context, r ref.DoltRef, old, new *doltdb.DoltDB, prog Progress) error {
+	// map init commits
+	o, err := old.ResolveCommitRef(ctx, ref.NewInternalRef(doltdb.CreationBranch))
+	if err != nil {
+		return err
+	}
+	oh, err := o.HashOf()
+	if err != nil {
+		return err
+	}
+	n, err := new.ResolveCommitRef(ctx, ref.NewInternalRef(doltdb.CreationBranch))
+	if err != nil {
+		return err
+	}
+	nh, err := n.HashOf()
+	if err != nil {
+		return err
+	}
+	if err = prog.Put(ctx, oh, nh); err != nil {
+		return err
+	}
+
+	switch r.GetType() {
+	case ref.BranchRefType:
+		return TraverseBranchHistory(ctx, r.(ref.BranchRef), old, new, prog)
+
+	case ref.TagRefType:
+		t, err := old.ResolveTag(ctx, r.(ref.TagRef))
+		if err != nil {
+			return err
+		}
+		return TraverseTagHistory(ctx, t, old, new, prog)
+
+	case ref.RemoteRefType:
+		return nil // todo(andy)
+
+	case ref.WorkspaceRefType:
+		return nil // todo(andy)
+
+	case ref.InternalRefType:
+		return nil // todo(andy)?
+
+	default:
+		panic(fmt.Sprintf("unknown ref type %s", r.String()))
+	}
+}
+
+func TraverseBranchHistory(ctx context.Context, r ref.BranchRef, old, new *doltdb.DoltDB, prog Progress) error {
+	cm, err := old.ResolveCommitRef(ctx, r)
+	if err != nil {
+		return err
+	}
+	if err = TraverseCommitHistory(ctx, r, cm, new, prog); err != nil {
+		return err
+	}
+
+	oldHash, err := cm.HashOf()
+	if err != nil {
+		return err
+	}
+	newHash, err := prog.Get(ctx, oldHash)
+	if err != nil {
+		return err
+	}
+	if err = new.SetHead(ctx, r, newHash); err != nil {
+		return err
+	}
+
+	wsRef, err := ref.WorkingSetRefForHead(r)
+	if err != nil {
+		return err
+	}
+
+	ws, err := old.ResolveWorkingSet(ctx, wsRef)
+	if err != nil {
+		return err
+	}
+	return TraverseWorkingSetHistory(ctx, ws, old, new, prog)
+}
+
+func TraverseTagHistory(ctx context.Context, tag *doltdb.Tag, old, new *doltdb.DoltDB, prog Progress) error {
 	return nil
 }
 
-func TraverseTagHistory(ctx context.Context, tag *doltdb.Tag, new *doltdb.DoltDB, prog Progress) error {
+func TraverseWorkingSetHistory(ctx context.Context, ws *doltdb.WorkingSet, old, new *doltdb.DoltDB, prog Progress) error {
 	return nil
 }
 
-func TraverseWorkingSetHistory(ctx context.Context, ws doltdb.WorkingSet, new *doltdb.DoltDB, prog Progress) error {
-	return nil
-}
+func TraverseCommitHistory(ctx context.Context, r ref.DoltRef, cm *doltdb.Commit, new *doltdb.DoltDB, prog Progress) error {
+	ch, err := cm.HashOf()
+	if err != nil {
+		return err
+	}
+	ok, err := prog.Has(ctx, ch)
+	if err != nil || ok {
+		return err
+	}
 
-func TraverseCommitHistory(ctx context.Context, cm *doltdb.Commit, new *doltdb.DoltDB, prog Progress) error {
 	for {
 		ph, err := cm.ParentHashes(ctx)
 		if err != nil {
@@ -63,7 +150,7 @@ func TraverseCommitHistory(ctx context.Context, cm *doltdb.Commit, new *doltdb.D
 		}
 		if idx < 0 {
 			// parents for |cm| are done, migrate |cm|
-			if err = MigrateCommit(ctx, cm, new, prog); err != nil {
+			if err = MigrateCommit(ctx, r, cm, new, prog); err != nil {
 				return err
 			}
 			// pop the stack, traverse upwards

--- a/go/libraries/doltcore/migrate/traverse.go
+++ b/go/libraries/doltcore/migrate/traverse.go
@@ -100,7 +100,19 @@ func TraverseTagHistory(ctx context.Context, r ref.TagRef, old, new *doltdb.Dolt
 		return err
 	}
 
-	return new.NewTagAtCommit(ctx, r, t.Commit, t.Meta)
+	oldHash, err := t.Commit.HashOf()
+	if err != nil {
+		return err
+	}
+	newHash, err := prog.Get(ctx, oldHash)
+	if err != nil {
+		return err
+	}
+	cm, err := new.ReadCommit(ctx, newHash)
+	if err != nil {
+		return err
+	}
+	return new.NewTagAtCommit(ctx, r, cm, t.Meta)
 }
 
 func TraverseCommitHistory(ctx context.Context, cm *doltdb.Commit, new *doltdb.DoltDB, prog Progress) error {

--- a/go/libraries/doltcore/migrate/validation.go
+++ b/go/libraries/doltcore/migrate/validation.go
@@ -1,0 +1,48 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+)
+
+func ValidateMigration(ctx context.Context, old, new *doltdb.DoltDB) error {
+	if err := validateBranchMapping(ctx, old, new); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateBranchMapping(ctx context.Context, old, new *doltdb.DoltDB) error {
+	branches, err := old.GetBranches(ctx)
+	if err != nil {
+		return err
+	}
+
+	var ok bool
+	for _, bref := range branches {
+		ok, err = new.HasBranch(ctx, bref.GetPath())
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("failed to map branch %s", bref.GetPath())
+		}
+	}
+	return nil
+}

--- a/go/libraries/doltcore/migrate/validation.go
+++ b/go/libraries/doltcore/migrate/validation.go
@@ -21,7 +21,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 )
 
-func ValidateMigration(ctx context.Context, old, new *doltdb.DoltDB) error {
+func validateMigration(ctx context.Context, old, new *doltdb.DoltDB) error {
 	if err := validateBranchMapping(ctx, old, new); err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/rebase/rebase.go
+++ b/go/libraries/doltcore/rebase/rebase.go
@@ -31,8 +31,7 @@ type NeedsRebaseFn func(ctx context.Context, cm *doltdb.Commit) (bool, error)
 // EntireHistory returns a |NeedsRebaseFn| that rebases the entire commit history.
 func EntireHistory() NeedsRebaseFn {
 	return func(_ context.Context, cm *doltdb.Commit) (bool, error) {
-		n, err := cm.NumParents()
-		return n != 0, err
+		return cm.NumParents() != 0, nil
 	}
 }
 
@@ -54,11 +53,7 @@ func StopAtCommit(stopCommit *doltdb.Commit) NeedsRebaseFn {
 			return false, nil
 		}
 
-		n, err := cm.NumParents()
-		if err != nil {
-			return false, err
-		}
-		if n == 0 {
+		if cm.NumParents() == 0 {
 			return false, fmt.Errorf("commit %s is missing from the commit history of at least one rebase head", sh)
 		}
 

--- a/go/libraries/doltcore/sqle/json/noms_json_value_test.go
+++ b/go/libraries/doltcore/sqle/json/noms_json_value_test.go
@@ -193,10 +193,11 @@ func TestJSONStructuralSharing(t *testing.T) {
 		tup, err := types.NewTuple(types.Format_Default, types.Int(12), types.JSON(val))
 		require.NoError(t, err)
 		tuple_refs := make(hash.HashSet)
-		types.WalkAddrs(tup, vrw.Format(), func(h hash.Hash, _ bool) error {
+		err = types.WalkAddrs(tup, vrw.Format(), func(h hash.Hash, _ bool) error {
 			tuple_refs.Insert(h)
 			return nil
 		})
+		assert.NoError(t, err)
 
 		assert.Greater(t, len(json_refs), 0)
 		assert.Equal(t, len(json_refs), len(tuple_refs))

--- a/go/libraries/doltcore/sqle/json/noms_json_value_test.go
+++ b/go/libraries/doltcore/sqle/json/noms_json_value_test.go
@@ -184,16 +184,18 @@ func TestJSONStructuralSharing(t *testing.T) {
 		val := MustNomsJSONWithVRW(vrw, sb.String())
 
 		json_refs := make(hash.HashSet)
-		err := types.WalkAddrs(types.JSON(val), vrw.Format(), func(h hash.Hash, _ bool) {
+		err := types.WalkAddrs(types.JSON(val), vrw.Format(), func(h hash.Hash, _ bool) error {
 			json_refs.Insert(h)
+			return nil
 		})
 		require.NoError(t, err)
 
 		tup, err := types.NewTuple(types.Format_Default, types.Int(12), types.JSON(val))
 		require.NoError(t, err)
 		tuple_refs := make(hash.HashSet)
-		types.WalkAddrs(tup, vrw.Format(), func(h hash.Hash, _ bool) {
+		types.WalkAddrs(tup, vrw.Format(), func(h hash.Hash, _ bool) error {
 			tuple_refs.Insert(h)
+			return nil
 		})
 
 		assert.Greater(t, len(json_refs), 0)

--- a/go/libraries/utils/filesys/fs.go
+++ b/go/libraries/utils/filesys/fs.go
@@ -71,6 +71,9 @@ type WritableFS interface {
 
 	// MoveFile will move a file from the srcPath in the filesystem to the destPath
 	MoveFile(srcPath, destPath string) error
+
+	// TempDir returns the path of a new temporary directory.
+	TempDir() string
 }
 
 // FSIterCB specifies the signature of the function that will be called for every item found while iterating.

--- a/go/libraries/utils/filesys/fs.go
+++ b/go/libraries/utils/filesys/fs.go
@@ -114,3 +114,18 @@ func UnmarshalJSONFile(fs ReadableFS, path string, dest interface{}) error {
 
 	return json.Unmarshal(data, dest)
 }
+
+func CopyFile(srcPath, destPath string, srcFS, destFS Filesys) (err error) {
+	rd, err := srcFS.OpenForRead(srcPath)
+	if err != nil {
+		return err
+	}
+
+	wr, err := destFS.OpenForWrite(destPath, os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(wr, rd)
+	return
+}

--- a/go/libraries/utils/filesys/fs_test.go
+++ b/go/libraries/utils/filesys/fs_test.go
@@ -103,6 +103,20 @@ func TestFilesystems(t *testing.T) {
 			dataRead, err = fs.ReadFile(movedFilePath)
 			require.NoError(t, err)
 			require.Equal(t, dataRead, data)
+
+			tmp := fs.TempDir()
+			require.NotEmpty(t, tmp)
+			fp2 := filepath.Join(tmp, "data.txt")
+			wrc, err := fs.OpenForWrite(fp2, os.ModePerm)
+			require.NoError(t, err)
+			require.NoError(t, wrc.Close())
+
+			// Test writing/reading random data to tmp file
+			err = fs.WriteFile(fp2, data)
+			require.NoError(t, err)
+			dataRead, err = fs.ReadFile(fp2)
+			require.NoError(t, err)
+			require.Equal(t, dataRead, data)
 		})
 	}
 }

--- a/go/libraries/utils/filesys/inmemfs.go
+++ b/go/libraries/utils/filesys/inmemfs.go
@@ -16,8 +16,10 @@ package filesys
 
 import (
 	"bytes"
+	"encoding/base32"
 	"errors"
 	"io"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
@@ -557,6 +559,13 @@ func (fs *InMemFS) LastModified(path string) (t time.Time, exists bool) {
 	}
 
 	return time.Time{}, false
+}
+
+func (fs *InMemFS) TempDir() string {
+	buf := make([]byte, 16)
+	rand.Read(buf)
+	s := base32.HexEncoding.EncodeToString(buf)
+	return "/var/folders/gc/" + s + "/T/"
 }
 
 func (fs *InMemFS) pathToNative(path string) string {

--- a/go/libraries/utils/filesys/inmemfs.go
+++ b/go/libraries/utils/filesys/inmemfs.go
@@ -537,6 +537,44 @@ func (fs *InMemFS) MoveFile(srcPath, destPath string) error {
 	return os.ErrNotExist
 }
 
+func (fs *InMemFS) CopyFile(srcPath, destPath string) error {
+	fs.rwLock.Lock()
+	defer fs.rwLock.Unlock()
+
+	srcPath = fs.getAbsPath(srcPath)
+	destPath = fs.getAbsPath(destPath)
+
+	if exists, destIsDir := fs.exists(destPath); exists && destIsDir {
+		return ErrIsDir
+	}
+
+	if obj, ok := fs.objs[srcPath]; ok {
+		if obj.isDir() {
+			return ErrIsDir
+		}
+
+		destDir := filepath.Dir(destPath)
+		destParentDir, err := fs.mkDirs(destDir)
+		if err != nil {
+			return err
+		}
+
+		destData := make([]byte, len(obj.(*memFile).data))
+		copy(destData, obj.(*memFile).data)
+
+		now := InMemNowFunc()
+		destObj := &memFile{destPath, destData, destParentDir, now}
+
+		fs.objs[destPath] = destObj
+		destParentDir.objs[destPath] = destObj
+		destParentDir.time = now
+
+		return nil
+	}
+
+	return os.ErrNotExist
+}
+
 // converts a path to an absolute path.  If it's already an absolute path the input path will be returned unaltered
 func (fs *InMemFS) Abs(path string) (string, error) {
 	path = fs.pathToNative(path)

--- a/go/libraries/utils/filesys/localfs.go
+++ b/go/libraries/utils/filesys/localfs.go
@@ -318,3 +318,7 @@ func (fs *localFS) LastModified(path string) (t time.Time, exists bool) {
 
 	return stat.ModTime(), true
 }
+
+func (fs *localFS) TempDir() string {
+	return os.TempDir()
+}

--- a/go/store/cmd/noms/noms_show_test.go
+++ b/go/store/cmd/noms/noms_show_test.go
@@ -152,8 +152,9 @@ func (s *nomsShowTestSuite) TestNomsShowRaw() {
 	s.NoError(err)
 
 	numChildChunks := 0
-	err = types.WalkAddrs(l, vrw.Format(), func(_ hash.Hash, _ bool) {
+	err = types.WalkAddrs(l, vrw.Format(), func(_ hash.Hash, _ bool) error {
 		numChildChunks++
+		return nil
 	})
 	s.NoError(err)
 	s.True(numChildChunks > 0)

--- a/go/store/hash/hash.go
+++ b/go/store/hash/hash.go
@@ -51,6 +51,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/dolthub/dolt/go/store/d"
 )
@@ -190,4 +191,18 @@ func (hs HashSet) Empty() {
 	for h := range hs {
 		delete(hs, h)
 	}
+}
+
+func (hs HashSet) String() string {
+	var sb strings.Builder
+	sb.Grow(len(hs)*34 + 100)
+
+	sb.WriteString("HashSet {\n")
+	for h := range hs {
+		sb.WriteString("\t")
+		sb.WriteString(h.String())
+		sb.WriteString("\n")
+	}
+	sb.WriteString("}\n")
+	return sb.String()
 }

--- a/go/store/nbs/frag/main.go
+++ b/go/store/nbs/frag/main.go
@@ -130,11 +130,12 @@ func main() {
 		orderedChildren := hash.HashSlice{}
 		nextLevel := hash.HashSlice{}
 		for _, h := range current {
-			_ = types.WalkAddrs(currentValues[h], types.Format_Default, func(h hash.Hash, isleaf bool) {
+			_ = types.WalkAddrs(currentValues[h], types.Format_Default, func(h hash.Hash, isleaf bool) error {
 				orderedChildren = append(orderedChildren, h)
 				if !visited[h] && !isleaf {
 					nextLevel = append(nextLevel, h)
 				}
+				return nil
 			})
 		}
 

--- a/go/store/types/map.go
+++ b/go/store/types/map.go
@@ -627,7 +627,7 @@ func (m Map) HumanReadableString() string {
 }
 
 // VisitMapLevelOrder writes hashes of internal node chunks to a writer
-// delimited with a newline character and returns the number or chunks written and the total number of
+// delimited with a newline character and returns the number of chunks written and the total number of
 // bytes written or an error if encountered
 func VisitMapLevelOrder(m Map, cb func(h hash.Hash) (int64, error)) (int64, int64, error) {
 	chunkCount := int64(0)

--- a/go/store/types/ref.go
+++ b/go/store/types/ref.go
@@ -242,9 +242,8 @@ func WalkAddrsForNBF(nbf *NomsBinFormat) func(chunks.Chunk, func(h hash.Hash, is
 	}
 }
 
-func WalkAddrs(v Value, nbf *NomsBinFormat, cb func(h hash.Hash, isleaf bool)) error {
+func WalkAddrs(v Value, nbf *NomsBinFormat, cb func(h hash.Hash, isleaf bool) error) error {
 	return v.walkRefs(nbf, func(r Ref) error {
-		cb(r.TargetHash(), r.Height() == 1)
-		return nil
+		return cb(r.TargetHash(), r.Height() == 1)
 	})
 }

--- a/go/store/types/value_store.go
+++ b/go/store/types/value_store.go
@@ -95,7 +95,8 @@ func PanicIfDangling(ctx context.Context, unresolved hash.HashSet, cs chunks.Chu
 	d.PanicIfError(err)
 
 	if len(absent) != 0 {
-		d.Panic("Found dangling references to %v", absent)
+		s := absent.String()
+		d.Panic("Found dangling references to %s", s)
 	}
 }
 

--- a/integration-tests/bats/helper/common.bash
+++ b/integration-tests/bats/helper/common.bash
@@ -69,6 +69,12 @@ skip_nbf_dolt_1() {
   fi
 }
 
+skip_nbf_dolt_dev() {
+  if [ "$DOLT_DEFAULT_BIN_FORMAT" = "__DOLT_DEV__" ]; then
+    skip "skipping test for nomsBinFormat __DOLT_DEV__"
+  fi
+}
+
 setup_common() {
     setup_no_dolt_init
     dolt init

--- a/integration-tests/bats/migrate.bats
+++ b/integration-tests/bats/migrate.bats
@@ -3,6 +3,7 @@ load $BATS_TEST_DIRNAME/helper/common.bash
 
 setup() {
     skip_nbf_dolt_1
+    skip_nbf_dolt_dev
 
     TARGET_NBF="__DOLT_DEV__"
     setup_common

--- a/integration-tests/bats/migrate.bats
+++ b/integration-tests/bats/migrate.bats
@@ -2,6 +2,8 @@
 load $BATS_TEST_DIRNAME/helper/common.bash
 
 setup() {
+    skip_nbf_dolt_1
+
     TARGET_NBF="__DOLT_DEV__"
     setup_common
 }

--- a/integration-tests/bats/migrate.bats
+++ b/integration-tests/bats/migrate.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+load $BATS_TEST_DIRNAME/helper/common.bash
+
+setup() {
+    setup_common
+}
+
+teardown() {
+    teardown_common
+}
+
+function checksum_table {
+    QUERY="SELECT GROUP_CONCAT(column_name) FROM information_schema.columns WHERE table_name = '$1'"
+    COLUMNS=$( dolt sql -q "$QUERY" -r csv | tail -n1 | sed 's/"//g' )
+    dolt sql -q "SELECT CAST(SUM(CRC32(CONCAT($COLUMNS))) AS UNSIGNED) FROM $1" -r csv | tail -n1
+}
+
+@test "migrate: smoke test" {
+    dolt sql <<SQL
+CREATE TABLE test (pk int primary key, c0 int, c1 int);
+INSERT INTO test VALUES (1,1,1),(2,2,2),(3,3,3);
+CALL dcommit('-am', 'added table test');
+SQL
+
+    CHECKSUM=$(checksum_table test)
+    run dolt migrate
+    [ $status -eq 0 ]
+
+    run checksum_table test
+    [ $status -eq 0 ]
+    [[ "$output" =~ "$CHECKSUM" ]] || false
+}

--- a/integration-tests/bats/migrate.bats
+++ b/integration-tests/bats/migrate.bats
@@ -2,6 +2,7 @@
 load $BATS_TEST_DIRNAME/helper/common.bash
 
 setup() {
+    TARGET_NBF="__DOLT_DEV__"
     setup_common
 }
 
@@ -12,21 +13,118 @@ teardown() {
 function checksum_table {
     QUERY="SELECT GROUP_CONCAT(column_name) FROM information_schema.columns WHERE table_name = '$1'"
     COLUMNS=$( dolt sql -q "$QUERY" -r csv | tail -n1 | sed 's/"//g' )
-    dolt sql -q "SELECT CAST(SUM(CRC32(CONCAT($COLUMNS))) AS UNSIGNED) FROM $1" -r csv | tail -n1
+    dolt sql -q "SELECT CAST(SUM(CRC32(CONCAT($COLUMNS))) AS UNSIGNED) FROM $1 AS OF '$2';" -r csv | tail -n1
 }
 
 @test "migrate: smoke test" {
     dolt sql <<SQL
 CREATE TABLE test (pk int primary key, c0 int, c1 int);
-INSERT INTO test VALUES (1,1,1),(2,2,2),(3,3,3);
+INSERT INTO test VALUES (0,0,0);
+CALL dadd('-A');
+CALL dcommit('-am', 'added table test');
+SQL
+    CHECKSUM=$(checksum_table test head)
+
+    run cat ./.dolt/noms/manifest
+    [[ "$output" =~ "__LD_1__" ]] || false
+    [[ ! "$output" =~ "$TARGET_NBF" ]] || false
+
+    dolt migrate
+
+    run cat ./.dolt/noms/manifest
+    [[ "$output" =~ "$TARGET_NBF" ]] || false
+    [[ ! "$output" =~ "__LD_1__" ]] || false
+
+    run checksum_table test head
+    [[ "$output" =~ "$CHECKSUM" ]] || false
+
+    run dolt sql -q "SELECT count(*) FROM dolt_commits" -r csv
+    [ $status -eq 0 ]
+    [[ "$output" =~ "2" ]] || false
+}
+
+@test "migrate: manifest backup" {
+    dolt sql <<SQL
+CREATE TABLE test (pk int primary key, c0 int, c1 int);
+INSERT INTO test VALUES (0,0,0);
+CALL dadd('-A');
 CALL dcommit('-am', 'added table test');
 SQL
 
-    CHECKSUM=$(checksum_table test)
-    run dolt migrate
-    [ $status -eq 0 ]
+    dolt migrate
 
-    run checksum_table test
+    run cat ./.dolt/noms/manifest.bak
+    [[ "$output" =~ "__LD_1__" ]] || false
+    [[ ! "$output" =~ "$TARGET_NBF" ]] || false
+}
+
+@test "migrate: multiple branches" {
+    dolt sql <<SQL
+CREATE TABLE test (pk int primary key, c0 int, c1 int);
+INSERT INTO test VALUES (0,0,0);
+CALL dadd('-A');
+CALL dcommit('-am', 'added table test');
+SQL
+    dolt branch one
+    dolt branch two
+
+    dolt sql <<SQL
+CALL dcheckout('one');
+INSERT INTO test VALUES (1,1,1);
+CALL dcommit('-am', 'row (1,1,1)');
+CALL dcheckout('two');
+INSERT INTO test VALUES (2,2,2);
+CALL dcommit('-am', 'row (2,2,2)');
+CALL dmerge('one');
+SQL
+
+    MAIN=$(checksum_table test main)
+    ONE=$(checksum_table test one)
+    TWO=$(checksum_table test two)
+
+    dolt migrate
+
+    run cat ./.dolt/noms/manifest
+    [[ "$output" =~ "$TARGET_NBF" ]] || false
+
+    run checksum_table test main
+    [[ "$output" =~ "$MAIN" ]] || false
+    run checksum_table test one
+    [[ "$output" =~ "$ONE" ]] || false
+    run checksum_table test two
+    [[ "$output" =~ "$TWO" ]] || false
+
+    run dolt sql -q "SELECT count(*) FROM dolt_commits" -r csv
     [ $status -eq 0 ]
-    [[ "$output" =~ "$CHECKSUM" ]] || false
+    [[ "$output" =~ "4" ]] || false
+}
+
+@test "migrate: tag and working set" {
+    dolt sql <<SQL
+CREATE TABLE test (pk int primary key, c0 int, c1 int);
+INSERT INTO test VALUES (0,0,0);
+CALL dadd('-A');
+CALL dcommit('-am', 'added table test');
+CALL dtag('tag1', 'head');
+INSERT INTO test VALUES (1,1,1);
+CALL dcommit('-am', 'added rows');
+INSERT INTO test VALUES (2,2,2);
+SQL
+
+    HEAD=$(checksum_table test head)
+    PREV=$(checksum_table test head~1)
+    TAG=$(checksum_table test tag1)
+    [ $TAG -eq $PREV ]
+
+    dolt migrate
+
+    run cat ./.dolt/noms/manifest
+    [[ "$output" =~ "$TARGET_NBF" ]] || false
+
+    run checksum_table test head
+    [[ "$output" =~ "$HEAD" ]] || false
+    run checksum_table test head~1
+    [[ "$output" =~ "$PREV" ]] || false
+    run checksum_table test tag1
+    [[ "$output" =~ "$TAG" ]] || false
 }


### PR DESCRIPTION
implements a format migration for top-of-DAG objects from `__LD_1__` to `__DOLT_DEV__`