### PR TITLE
Add command line and SQL support for `dolt pull <remote> <remoteBranch>`

### DIFF
--- a/go/cmd/dolt/commands/pull.go
+++ b/go/cmd/dolt/commands/pull.go
@@ -36,7 +36,7 @@ var pullDocs = cli.CommandDocumentationContent{
 More precisely, dolt pull runs {{.EmphasisLeft}}dolt fetch{{.EmphasisRight}} with the given parameters and calls {{.EmphasisLeft}}dolt merge{{.EmphasisRight}} to merge the retrieved branch {{.EmphasisLeft}}HEAD{{.EmphasisRight}} into the current branch.
 `,
 	Synopsis: []string{
-		"{{.LessThan}}remote{{.GreaterThan}}",
+		`[{{.LessThan}}remote{{.GreaterThan}}, [{{.LessThan}}remoteBranch{{.GreaterThan}}]]`,
 	},
 }
 
@@ -59,6 +59,8 @@ func (cmd PullCmd) Docs() *cli.CommandDocumentation {
 
 func (cmd PullCmd) ArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParser()
+	ap.ArgListHelp = append(ap.ArgListHelp, [2]string{"remote", "The name of the remote to pull from."})
+	ap.ArgListHelp = append(ap.ArgListHelp, [2]string{"remoteBranch", "The name of a branch on the specified remote to be merged into the current working set."})
 	ap.SupportsFlag(cli.SquashParam, "", "Merges changes to the working set without updating the commit history")
 	return ap
 }

--- a/go/libraries/doltcore/env/actions/remotes.go
+++ b/go/libraries/doltcore/env/actions/remotes.go
@@ -32,7 +32,7 @@ import (
 )
 
 var ErrCantFF = errors.New("can't fast forward merge")
-var ErrInvalidPullArgs = errors.New("dolt pull takes at most one arg")
+var ErrInvalidPullArgs = errors.New("dolt pull takes at most two args")
 var ErrCannotPushRef = errors.New("cannot push ref")
 var ErrFailedToSaveRepoState = errors.New("failed to save repo state")
 var ErrFailedToDeleteRemote = errors.New("failed to delete remote")

--- a/go/libraries/doltcore/env/remotes.go
+++ b/go/libraries/doltcore/env/remotes.go
@@ -361,6 +361,20 @@ type PullSpec struct {
 }
 
 func NewPullSpec(_ context.Context, rsr RepoStateReader, remoteName, remoteRefName string, squash, noff, force, remoteOnly bool) (*PullSpec, error) {
+	refSpecs, err := GetRefSpecs(rsr, remoteName)
+	if err != nil {
+		return nil, err
+	}
+	if len(refSpecs) == 0 {
+		return nil, ErrNoRefSpecForRemote
+	}
+
+	remotes, err := rsr.GetRemotes()
+	if err != nil {
+		return nil, err
+	}
+	remote := remotes[refSpecs[0].GetRemote()]
+
 	var remoteRef ref.DoltRef
 	if remoteRefName == "" {
 		branch := rsr.CWBHeadRef()
@@ -382,20 +396,6 @@ func NewPullSpec(_ context.Context, rsr RepoStateReader, remoteName, remoteRefNa
 	} else {
 		remoteRef = ref.NewBranchRef(remoteRefName)
 	}
-
-	refSpecs, err := GetRefSpecs(rsr, remoteName)
-	if err != nil {
-		return nil, err
-	}
-	if len(refSpecs) == 0 {
-		return nil, ErrNoRefSpecForRemote
-	}
-
-	remotes, err := rsr.GetRemotes()
-	if err != nil {
-		return nil, err
-	}
-	remote := remotes[refSpecs[0].GetRemote()]
 
 	return &PullSpec{
 		Squash:     squash,

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_pull.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_pull.go
@@ -92,16 +92,19 @@ func DoDoltPull(ctx *sql.Context, args []string) (int, int, error) {
 		return noConflictsOrViolations, threeWayMerge, err
 	}
 
-	if apr.NArg() > 1 {
+	if apr.NArg() > 2 {
 		return noConflictsOrViolations, threeWayMerge, actions.ErrInvalidPullArgs
 	}
 
-	var remoteName string
+	var remoteName, remoteRefName string
 	if apr.NArg() == 1 {
 		remoteName = apr.Arg(0)
+	} else if apr.NArg() == 2 {
+		remoteName = apr.Arg(0)
+		remoteRefName = apr.Arg(1)
 	}
 
-	pullSpec, err := env.NewPullSpec(ctx, dbData.Rsr, remoteName, apr.Contains(cli.SquashParam), apr.Contains(cli.NoFFParam), apr.Contains(cli.ForceFlag), apr.NArg() == 1)
+	pullSpec, err := env.NewPullSpec(ctx, dbData.Rsr, remoteName, remoteRefName, apr.Contains(cli.SquashParam), apr.Contains(cli.NoFFParam), apr.Contains(cli.ForceFlag), apr.NArg() == 1)
 	if err != nil {
 		return noConflictsOrViolations, threeWayMerge, err
 	}
@@ -120,6 +123,15 @@ func DoDoltPull(ctx *sql.Context, args []string) (int, int, error) {
 	branchRefs, err := srcDB.GetHeadRefs(ctx)
 	if err != nil {
 		return noConflictsOrViolations, threeWayMerge, env.ErrFailedToReadDb
+	}
+
+	hasBranch, err := srcDB.HasBranch(ctx, pullSpec.Branch.GetPath())
+	if err != nil {
+		return noConflictsOrViolations, threeWayMerge, err
+	}
+	if !hasBranch {
+		return noConflictsOrViolations, threeWayMerge,
+			fmt.Errorf("branch %q not found on remote", pullSpec.Branch.GetPath())
 	}
 
 	var conflicts int

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -357,6 +357,14 @@ SQL
     dolt checkout -b test-branch
     run dolt push test-remote test-branch
     [ "$status" -eq 0 ]
+    dolt checkout main
+
+    # Specifying a non-existent branch returns an error
+    run dolt pull test-remote doesnotexist
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ 'branch "doesnotexist" not found on remote' ]] || false
+
+    # Specifying a valid branch merges it in
     run dolt pull test-remote test-branch
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Everything up-to-date" ]] || false

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -352,6 +352,16 @@ SQL
     [[ "$output" =~ "Everything up-to-date" ]] || false
 }
 
+@test "remotes: pull with explicit remote and branch" {
+    dolt remote add test-remote http://localhost:50051/test-org/test-repo
+    dolt checkout -b test-branch
+    run dolt push test-remote test-branch
+    [ "$status" -eq 0 ]
+    run dolt pull test-remote test-branch
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Everything up-to-date" ]] || false
+}
+
 @test "remotes: push and pull from non-main branch and use --set-upstream" {
     dolt remote add test-remote http://localhost:50051/test-org/test-repo
     dolt checkout -b test-branch

--- a/integration-tests/bats/sql-pull.bats
+++ b/integration-tests/bats/sql-pull.bats
@@ -459,6 +459,21 @@ teardown() {
     [[ ! "$output" =~ "v3" ]] || false
 }
 
+@test "sql-pull: dolt_pull with remote and remote ref" {
+    cd repo1
+    dolt checkout feature
+    dolt checkout -b newbranch
+    run dolt sql -q "show tables"
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "t1" ]] || false
+
+    run dolt sql -q "call dolt_pull('origin', 'main');"
+    [ "$status" -eq 0 ]
+    run dolt sql -q "show tables"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "t1" ]] || false
+}
+
 @test "sql-pull: dolt_pull also fetches, but does not merge other branches" {
     cd repo1
     dolt checkout -b other

--- a/integration-tests/bats/sql-pull.bats
+++ b/integration-tests/bats/sql-pull.bats
@@ -467,17 +467,34 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ ! "$output" =~ "t1" ]] || false
 
-    # Explicitly specifying the remote and remote ref will merge in that branch
+    # Specifying a non-existent remote branch returns an error
+    run dolt sql -q "call dolt_pull('origin', 'doesnotexist');"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ 'branch "doesnotexist" not found on remote' ]] || false
+
+    # Explicitly specifying the remote and branch will merge in that branch
     run dolt sql -q "call dolt_pull('origin', 'main');"
     [ "$status" -eq 0 ]
     run dolt sql -q "show tables"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "t1" ]] || false
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "working tree clean" ]] || false
 
-    # Specifying a non-existent remote ref gives an error
-    run dolt sql -q "call dolt_pull('origin', 'doesnotexist');"
+    # Make a conflicting working set change and test that pull complains
+    dolt reset --hard HEAD^1
+    dolt sql -q "insert into t1 values (0, 100);"
+    run dolt sql -q "call dolt_pull('origin', 'main');"
     [ "$status" -eq 1 ]
-    [[ "$output" =~ 'branch "doesnotexist" not found on remote' ]] || false
+    [[ "$output" =~ 'cannot merge with uncommitted changes' ]] || false
+
+    # Commit changes and test that a merge conflict fails the pull
+    dolt commit -am "adding new t1 table"
+    run dolt sql -q "call dolt_pull('origin', 'main');"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "| fast_forward | conflicts |" ]] || false
+    [[ "$output" =~ "| 0            | 1         |" ]] || false
 }
 
 @test "sql-pull: dolt_pull also fetches, but does not merge other branches" {

--- a/integration-tests/bats/sql-pull.bats
+++ b/integration-tests/bats/sql-pull.bats
@@ -467,11 +467,17 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ ! "$output" =~ "t1" ]] || false
 
+    # Explicitly specifying the remote and remote ref will merge in that branch
     run dolt sql -q "call dolt_pull('origin', 'main');"
     [ "$status" -eq 0 ]
     run dolt sql -q "show tables"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "t1" ]] || false
+
+    # Specifying a non-existent remote ref gives an error
+    run dolt sql -q "call dolt_pull('origin', 'doesnotexist');"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ 'branch "doesnotexist" not found on remote' ]] || false
 }
 
 @test "sql-pull: dolt_pull also fetches, but does not merge other branches" {


### PR DESCRIPTION
Adds support for explicitly specifying the remote branch to merge into the current working head. 

I was tempted to work on combining these two duplicated code paths, but wanted to keep scope small and get several bugs fixed before taking that on. 

Fixes: https://github.com/dolthub/dolt/issues/3937

Documentation updates: https://github.com/dolthub/docs/pull/811