### PR TITLE
Fix `dolt_remote` stored procedure to write to the correct database directory

### DIFF
--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -95,7 +95,7 @@ func NewSqlEngine(
 	if err != nil {
 		return nil, err
 	}
-	pro.WithRemoteDialer(mrEnv.RemoteDialProvider())
+	pro = pro.WithRemoteDialer(mrEnv.RemoteDialProvider())
 
 	// Load in privileges from file, if it exists
 	persister := mysql_file_handler.NewPersister(config.PrivFilePath, config.DoltCfgDirPath)

--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -75,7 +75,7 @@ func NewSqlEngine(
 
 	parallelism := runtime.GOMAXPROCS(0)
 
-	dbs, err := CollectDBs(ctx, mrEnv, config.Bulk)
+	dbs, locations, err := CollectDBs(ctx, mrEnv, config.Bulk)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func NewSqlEngine(
 	all := append(dsqleDBsAsSqlDBs(dbs), infoDB)
 
 	b := env.GetDefaultInitBranch(mrEnv.Config())
-	pro := dsqle.NewDoltDatabaseProvider(b, mrEnv.FileSystem(), all...).WithRemoteDialer(mrEnv.RemoteDialProvider())
+	pro := dsqle.NewDoltDatabaseProviderWithDatabases(b, mrEnv.FileSystem(), all, locations).WithRemoteDialer(mrEnv.RemoteDialProvider())
 
 	// Load in privileges from file, if it exists
 	persister := mysql_file_handler.NewPersister(config.PrivFilePath, config.DoltCfgDirPath)

--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -88,9 +88,14 @@ func NewSqlEngine(
 
 	infoDB := information_schema.NewInformationSchemaDatabase()
 	all := append(dsqleDBsAsSqlDBs(dbs), infoDB)
+	locations = append(locations, nil)
 
 	b := env.GetDefaultInitBranch(mrEnv.Config())
-	pro := dsqle.NewDoltDatabaseProviderWithDatabases(b, mrEnv.FileSystem(), all, locations).WithRemoteDialer(mrEnv.RemoteDialProvider())
+	pro, err := dsqle.NewDoltDatabaseProviderWithDatabases(b, mrEnv.FileSystem(), all, locations)
+	if err != nil {
+		return nil, err
+	}
+	pro.WithRemoteDialer(mrEnv.RemoteDialProvider())
 
 	// Load in privileges from file, if it exists
 	persister := mysql_file_handler.NewPersister(config.PrivFilePath, config.DoltCfgDirPath)

--- a/go/cmd/dolt/commands/engine/utils.go
+++ b/go/cmd/dolt/commands/engine/utils.go
@@ -17,7 +17,6 @@ package engine
 import (
 	"context"
 	"fmt"
-	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 
 	"github.com/dolthub/go-mysql-server/sql"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
+	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/store/types"
 )
 

--- a/go/cmd/dolt/commands/engine/utils.go
+++ b/go/cmd/dolt/commands/engine/utils.go
@@ -17,6 +17,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 
 	"github.com/dolthub/go-mysql-server/sql"
 
@@ -31,8 +32,9 @@ import (
 
 // CollectDBs takes a MultiRepoEnv and creates Database objects from each environment and returns a slice of these
 // objects.
-func CollectDBs(ctx context.Context, mrEnv *env.MultiRepoEnv, useBulkEditor bool) ([]sqle.SqlDatabase, error) {
+func CollectDBs(ctx context.Context, mrEnv *env.MultiRepoEnv, useBulkEditor bool) ([]sqle.SqlDatabase, []filesys.Filesys, error) {
 	var dbs []sqle.SqlDatabase
+	var locations []filesys.Filesys
 	var db sqle.SqlDatabase
 
 	err := mrEnv.Iter(func(name string, dEnv *env.DoltEnv) (stop bool, err error) {
@@ -56,14 +58,16 @@ func CollectDBs(ctx context.Context, mrEnv *env.MultiRepoEnv, useBulkEditor bool
 		}
 
 		dbs = append(dbs, db)
+		locations = append(locations, dEnv.FS)
+
 		return false, nil
 	})
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return dbs, nil
+	return dbs, locations, nil
 }
 
 // GetCommitHooks creates a list of hooks to execute on database commit. If doltdb.SkipReplicationErrorsKey is set,

--- a/go/cmd/dolt/commands/filter-branch.go
+++ b/go/cmd/dolt/commands/filter-branch.go
@@ -234,7 +234,10 @@ func rebaseSqlEngine(ctx context.Context, dEnv *env.DoltEnv, cm *doltdb.Commit) 
 	}
 
 	b := env.GetDefaultInitBranch(dEnv.Config)
-	pro := dsqle.NewDoltDatabaseProviderWithDatabase(b, mrEnv.FileSystem(), db, dEnv.FS)
+	pro, err := dsqle.NewDoltDatabaseProviderWithDatabase(b, mrEnv.FileSystem(), db, dEnv.FS)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	sess := dsess.DefaultSession(pro)
 

--- a/go/cmd/dolt/commands/filter-branch.go
+++ b/go/cmd/dolt/commands/filter-branch.go
@@ -234,7 +234,7 @@ func rebaseSqlEngine(ctx context.Context, dEnv *env.DoltEnv, cm *doltdb.Commit) 
 	}
 
 	b := env.GetDefaultInitBranch(dEnv.Config)
-	pro := dsqle.NewDoltDatabaseProvider(b, mrEnv.FileSystem(), db)
+	pro := dsqle.NewDoltDatabaseProviderWithDatabase(b, mrEnv.FileSystem(), db, dEnv.FS)
 
 	sess := dsess.DefaultSession(pro)
 

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -143,7 +143,7 @@ func (p DoltDatabaseProvider) HasDatabase(ctx *sql.Context, name string) bool {
 	return err == nil
 }
 
-func (p DoltDatabaseProvider) AllDatabases(ctx *sql.Context) (all []sql.Database) {
+func (p DoltDatabaseProvider) AllDatabases(_ *sql.Context) (all []sql.Database) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -47,7 +47,6 @@ type DoltDatabaseProvider struct {
 	mu        *sync.RWMutex
 
 	defaultBranch string
-	dataRootDir   string
 	fs            filesys.Filesys
 	remoteDialer  dbfactory.GRPCDialProvider
 

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_remote.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_remote.go
@@ -63,7 +63,7 @@ func doDoltRemote(ctx *sql.Context, args []string) (int, error) {
 
 	switch apr.Arg(0) {
 	case "add":
-		err = addRemote(ctx, dbData, apr, dSess)
+		err = addRemote(ctx, dbName, dbData, apr, dSess)
 	case "remove", "rm":
 		err = removeRemote(ctx, dbData, apr)
 	default:
@@ -76,7 +76,7 @@ func doDoltRemote(ctx *sql.Context, args []string) (int, error) {
 	return 0, nil
 }
 
-func addRemote(ctx *sql.Context, dbd env.DbData, apr *argparser.ArgParseResults, sess *dsess.DoltSession) error {
+func addRemote(_ *sql.Context, dbName string, dbd env.DbData, apr *argparser.ArgParseResults, sess *dsess.DoltSession) error {
 	if apr.NArg() != 3 {
 		return fmt.Errorf("error: invalid argument")
 	}
@@ -84,7 +84,12 @@ func addRemote(ctx *sql.Context, dbd env.DbData, apr *argparser.ArgParseResults,
 	remoteName := strings.TrimSpace(apr.Arg(1))
 	remoteUrl := apr.Arg(2)
 
-	scheme, absRemoteUrl, err := env.GetAbsRemoteUrl(sess.Provider().FileSystem(), &config.MapConfig{}, remoteUrl)
+	dbFs, err := sess.Provider().FileSystemForDatabase(dbName)
+	if err != nil {
+		return err
+	}
+
+	scheme, absRemoteUrl, err := env.GetAbsRemoteUrl(dbFs, &config.MapConfig{}, remoteUrl)
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/sqle/dsess/revision_db_provider.go
+++ b/go/libraries/doltcore/sqle/dsess/revision_db_provider.go
@@ -39,8 +39,13 @@ type RevisionDatabaseProvider interface {
 }
 type DoltDatabaseProvider interface {
 	RevisionDatabaseProvider
-	// FileSystem returns the filesystem used by this provider, rooted at the data directory for all databases
+
+	// FileSystem returns the filesystem used by this provider, rooted at the data directory for all databases.
 	FileSystem() filesys.Filesys
+	// FileSystemForDatabase returns a filesystem, with the working directory set to the root directory
+	// of the requested database. If the requested database isn't found, a database not found error
+	// is returned.
+	FileSystemForDatabase(dbname string) (filesys.Filesys, error)
 	// GetRemoteDB returns the remote database for given env.Remote object using the local database's vrw, and
 	// withCaching defines whether the remoteDB gets cached or not.
 	// This function replaces env.Remote's GetRemoteDB method during SQL session to access dialer in order
@@ -65,6 +70,10 @@ func (e emptyRevisionDatabaseProvider) GetRemoteDB(ctx *sql.Context, srcDB *dolt
 
 func (e emptyRevisionDatabaseProvider) FileSystem() filesys.Filesys {
 	return nil
+}
+
+func (e emptyRevisionDatabaseProvider) FileSystemForDatabase(dbname string) (filesys.Filesys, error) {
+	return nil, nil
 }
 
 func (e emptyRevisionDatabaseProvider) CloneDatabaseFromRemote(ctx *sql.Context, dbName, branch, remoteName, remoteUrl string, remoteParams map[string]string) error {

--- a/go/libraries/doltcore/sqle/dsess/session_state_adapter.go
+++ b/go/libraries/doltcore/sqle/dsess/session_state_adapter.go
@@ -55,19 +55,19 @@ func (s SessionStateAdapter) UpdateWorkingRoot(ctx context.Context, newRoot *dol
 	return s.session.SetRoots(ctx.(*sql.Context), s.dbName, roots)
 }
 
-func (s SessionStateAdapter) SetCWBHeadRef(ctx context.Context, marshalableRef ref.MarshalableRef) error {
+func (s SessionStateAdapter) SetCWBHeadRef(_ context.Context, _ ref.MarshalableRef) error {
 	return fmt.Errorf("Cannot set cwb head ref with a SessionStateAdapter")
 }
 
-func (s SessionStateAdapter) AbortMerge(ctx context.Context) error {
+func (s SessionStateAdapter) AbortMerge(_ context.Context) error {
 	return fmt.Errorf("Cannot abort merge with a SessionStateAdapter")
 }
 
-func (s SessionStateAdapter) ClearMerge(ctx context.Context) error {
+func (s SessionStateAdapter) ClearMerge(_ context.Context) error {
 	return nil
 }
 
-func (s SessionStateAdapter) StartMerge(ctx context.Context, commit *doltdb.Commit) error {
+func (s SessionStateAdapter) StartMerge(_ context.Context, _ *doltdb.Commit) error {
 	return fmt.Errorf("Cannot start merge with a SessionStateAdapter")
 }
 
@@ -82,7 +82,7 @@ func NewSessionStateAdapter(session *DoltSession, dbName string, remotes map[str
 	return SessionStateAdapter{session: session, dbName: dbName, remotes: remotes, branches: branches, backups: backups}
 }
 
-func (s SessionStateAdapter) GetRoots(ctx context.Context) (doltdb.Roots, error) {
+func (s SessionStateAdapter) GetRoots(_ context.Context) (doltdb.Roots, error) {
 	return s.session.GetDbStates()[s.dbName].GetRoots(), nil
 }
 
@@ -106,15 +106,15 @@ func (s SessionStateAdapter) CWBHeadSpec() *doltdb.CommitSpec {
 	return spec
 }
 
-func (s SessionStateAdapter) IsMergeActive(ctx context.Context) (bool, error) {
+func (s SessionStateAdapter) IsMergeActive(_ context.Context) (bool, error) {
 	return s.session.GetDbStates()[s.dbName].WorkingSet.MergeActive(), nil
 }
 
-func (s SessionStateAdapter) GetMergeCommit(ctx context.Context) (*doltdb.Commit, error) {
+func (s SessionStateAdapter) GetMergeCommit(_ context.Context) (*doltdb.Commit, error) {
 	return s.session.GetDbStates()[s.dbName].WorkingSet.MergeState().Commit(), nil
 }
 
-func (s SessionStateAdapter) GetPreMergeWorking(ctx context.Context) (*doltdb.RootValue, error) {
+func (s SessionStateAdapter) GetPreMergeWorking(_ context.Context) (*doltdb.RootValue, error) {
 	return s.session.GetDbStates()[s.dbName].WorkingSet.MergeState().PreMergeWorkingRoot(), nil
 }
 
@@ -147,11 +147,11 @@ func (s SessionStateAdapter) AddRemote(remote env.Remote) error {
 	return repoState.Save(fs)
 }
 
-func (s SessionStateAdapter) AddBackup(remote env.Remote) error {
+func (s SessionStateAdapter) AddBackup(_ env.Remote) error {
 	return fmt.Errorf("cannot insert remote in an SQL session")
 }
 
-func (s SessionStateAdapter) RemoveRemote(ctx context.Context, name string) error {
+func (s SessionStateAdapter) RemoveRemote(_ context.Context, name string) error {
 	delete(s.remotes, name)
 
 	fs := s.session.Provider().FileSystem()
@@ -163,7 +163,7 @@ func (s SessionStateAdapter) RemoveRemote(ctx context.Context, name string) erro
 	return repoState.Save(fs)
 }
 
-func (s SessionStateAdapter) RemoveBackup(ctx context.Context, name string) error {
+func (s SessionStateAdapter) RemoveBackup(_ context.Context, _ string) error {
 	return fmt.Errorf("cannot delete remote in an SQL session")
 }
 

--- a/go/libraries/doltcore/sqle/dsess/session_state_adapter.go
+++ b/go/libraries/doltcore/sqle/dsess/session_state_adapter.go
@@ -138,7 +138,11 @@ func (s SessionStateAdapter) UpdateBranch(name string, new env.BranchConfig) err
 func (s SessionStateAdapter) AddRemote(remote env.Remote) error {
 	s.remotes[remote.Name] = remote
 
-	fs := s.session.Provider().FileSystem()
+	fs, err := s.session.Provider().FileSystemForDatabase(s.dbName)
+	if err != nil {
+		return err
+	}
+
 	repoState, err := env.LoadRepoState(fs)
 	if err != nil {
 		return err
@@ -154,7 +158,11 @@ func (s SessionStateAdapter) AddBackup(_ env.Remote) error {
 func (s SessionStateAdapter) RemoveRemote(_ context.Context, name string) error {
 	delete(s.remotes, name)
 
-	fs := s.session.Provider().FileSystem()
+	fs, err := s.session.Provider().FileSystemForDatabase(s.dbName)
+	if err != nil {
+		return err
+	}
+
 	repoState, err := env.LoadRepoState(fs)
 	if err != nil {
 		return err

--- a/go/libraries/doltcore/sqle/dtables/remotes_table.go
+++ b/go/libraries/doltcore/sqle/dtables/remotes_table.go
@@ -15,7 +15,6 @@
 package dtables
 
 import (
-	"errors"
 	"fmt"
 	"io"
 
@@ -25,7 +24,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/index"
-	"github.com/dolthub/dolt/go/libraries/utils/config"
 )
 
 var _ sql.Table = (*RemotesTable)(nil)

--- a/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
@@ -77,7 +77,8 @@ func newDoltHarness(t *testing.T) *DoltHarness {
 	mrEnv, err := env.MultiEnvForDirectory(context.Background(), dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
 	require.NoError(t, err)
 	b := env.GetDefaultInitBranch(dEnv.Config)
-	pro := sqle.NewDoltDatabaseProvider(b, mrEnv.FileSystem())
+	pro, err := sqle.NewDoltDatabaseProvider(b, mrEnv.FileSystem())
+	require.NoError(t, err)
 	pro = pro.WithDbFactoryUrl(doltdb.InMemDoltDB)
 
 	localConfig := dEnv.Config.WriteableConfig()
@@ -341,7 +342,9 @@ func (d *DoltHarness) NewDatabaseProvider(dbs ...sql.Database) sql.MutableDataba
 	}
 
 	b := env.GetDefaultInitBranch(d.multiRepoEnv.Config())
-	pro := sqle.NewDoltDatabaseProviderWithDatabases(b, d.multiRepoEnv.FileSystem(), dbs, locations)
+	pro, err := sqle.NewDoltDatabaseProviderWithDatabases(b, d.multiRepoEnv.FileSystem(), dbs, locations)
+	require.NoError(d.t, err)
+
 	return pro.WithDbFactoryUrl(doltdb.InMemDoltDB)
 }
 

--- a/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
@@ -81,7 +81,6 @@ func newDoltHarness(t *testing.T) *DoltHarness {
 	pro = pro.WithDbFactoryUrl(doltdb.InMemDoltDB)
 
 	localConfig := dEnv.Config.WriteableConfig()
-
 	session, err := dsess.NewDoltSession(sql.NewEmptyContext(), enginetest.NewBaseSession(), pro, localConfig)
 	require.NoError(t, err)
 	dh := &DoltHarness{
@@ -147,6 +146,13 @@ func commitScripts(dbs []string) []setup.SetupScript {
 func (d *DoltHarness) NewEngine(t *testing.T) (*gms.Engine, error) {
 	if d.engine == nil {
 		pro := d.NewDatabaseProvider(information_schema.NewInformationSchemaDatabase())
+		doltProvider, ok := pro.(sqle.DoltDatabaseProvider)
+		require.True(t, ok)
+
+		var err error
+		d.session, err = dsess.NewDoltSession(sql.NewEmptyContext(), enginetest.NewBaseSession(), doltProvider, d.multiRepoEnv.Config())
+		require.NoError(t, err)
+
 		e, err := enginetest.NewEngineWithProviderSetup(t, d, pro, d.setupData)
 		if err != nil {
 			return nil, err

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -5204,4 +5204,32 @@ var DoltRemoteTestScripts = []queries.ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "dolt-remote: multi-repo test",
+		SetUpScript: []string{
+			"create database one",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "use one;",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "CALL DOLT_REMOTE('add','test01','file:///foo');",
+				Expected: []sql.Row{{0}},
+			},
+			{
+				Query:    "select count(*) from dolt_remotes where name='test01';",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				Query:    "use mydb;",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "select count(*) from dolt_remotes where name='test01';",
+				Expected: []sql.Row{{0}},
+			},
+		},
+	},
 }

--- a/go/libraries/doltcore/sqle/index/mergeable_indexes_setup_test.go
+++ b/go/libraries/doltcore/sqle/index/mergeable_indexes_setup_test.go
@@ -97,9 +97,12 @@ func setupIndexes(t *testing.T, tableName, insertQuery string) (*sqle.Engine, *e
 	mrEnv, err := env.MultiEnvForDirectory(context.Background(), dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
 	require.NoError(t, err)
 	b := env.GetDefaultInitBranch(dEnv.Config)
-	pro := dsqle.NewDoltDatabaseProviderWithDatabase(b, mrEnv.FileSystem(), db, dEnv.FS)
-	pro = pro.WithDbFactoryUrl(doltdb.InMemDoltDB)
+	pro, err := dsqle.NewDoltDatabaseProviderWithDatabase(b, mrEnv.FileSystem(), db, dEnv.FS)
+	if err != nil {
+		return nil, nil, nil, dsqle.Database{}, nil
+	}
 
+	pro = pro.WithDbFactoryUrl(doltdb.InMemDoltDB)
 	engine = sqle.NewDefault(pro)
 
 	// Get an updated root to use for the rest of the test

--- a/go/libraries/doltcore/sqle/index/mergeable_indexes_setup_test.go
+++ b/go/libraries/doltcore/sqle/index/mergeable_indexes_setup_test.go
@@ -97,7 +97,7 @@ func setupIndexes(t *testing.T, tableName, insertQuery string) (*sqle.Engine, *e
 	mrEnv, err := env.MultiEnvForDirectory(context.Background(), dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
 	require.NoError(t, err)
 	b := env.GetDefaultInitBranch(dEnv.Config)
-	pro := dsqle.NewDoltDatabaseProvider(b, mrEnv.FileSystem(), db)
+	pro := dsqle.NewDoltDatabaseProviderWithDatabase(b, mrEnv.FileSystem(), db, dEnv.FS)
 	pro = pro.WithDbFactoryUrl(doltdb.InMemDoltDB)
 
 	engine = sqle.NewDefault(pro)

--- a/go/libraries/doltcore/sqle/logictest/dolt/doltharness.go
+++ b/go/libraries/doltcore/sqle/logictest/dolt/doltharness.go
@@ -314,7 +314,7 @@ func sqlNewEngine(dEnv *env.DoltEnv) (*sqle.Engine, error) {
 	}
 
 	b := env.GetDefaultInitBranch(dEnv.Config)
-	pro := dsql.NewDoltDatabaseProvider(b, mrEnv.FileSystem(), db)
+	pro := dsql.NewDoltDatabaseProviderWithDatabase(b, mrEnv.FileSystem(), db, dEnv.FS)
 	pro = pro.WithDbFactoryUrl(doltdb.InMemDoltDB)
 
 	engine := sqle.NewDefault(pro)

--- a/go/libraries/doltcore/sqle/logictest/dolt/doltharness.go
+++ b/go/libraries/doltcore/sqle/logictest/dolt/doltharness.go
@@ -314,9 +314,12 @@ func sqlNewEngine(dEnv *env.DoltEnv) (*sqle.Engine, error) {
 	}
 
 	b := env.GetDefaultInitBranch(dEnv.Config)
-	pro := dsql.NewDoltDatabaseProviderWithDatabase(b, mrEnv.FileSystem(), db, dEnv.FS)
-	pro = pro.WithDbFactoryUrl(doltdb.InMemDoltDB)
+	pro, err := dsql.NewDoltDatabaseProviderWithDatabase(b, mrEnv.FileSystem(), db, dEnv.FS)
+	if err != nil {
+		return nil, err
+	}
 
+	pro = pro.WithDbFactoryUrl(doltdb.InMemDoltDB)
 	engine := sqle.NewDefault(pro)
 
 	return engine, nil

--- a/go/libraries/doltcore/sqle/show_create_table.go
+++ b/go/libraries/doltcore/sqle/show_create_table.go
@@ -28,7 +28,10 @@ import (
 // These functions cannot be in the sqlfmt package as the reliance on the sqle package creates a circular reference.
 
 func PrepareCreateTableStmt(ctx context.Context, sqlDb SqlDatabase) (*sql.Context, *sqle.Engine, *dsess.DoltSession) {
-	pro := NewDoltDatabaseProviderWithDatabase(env.DefaultInitBranch, nil, sqlDb, nil)
+	pro, err := NewDoltDatabaseProviderWithDatabase(env.DefaultInitBranch, nil, sqlDb, nil)
+	if err != nil {
+		return nil, nil, nil
+	}
 	engine := sqle.NewDefault(pro)
 
 	sess := dsess.DefaultSession(pro)

--- a/go/libraries/doltcore/sqle/show_create_table.go
+++ b/go/libraries/doltcore/sqle/show_create_table.go
@@ -28,7 +28,7 @@ import (
 // These functions cannot be in the sqlfmt package as the reliance on the sqle package creates a circular reference.
 
 func PrepareCreateTableStmt(ctx context.Context, sqlDb SqlDatabase) (*sql.Context, *sqle.Engine, *dsess.DoltSession) {
-	pro := NewDoltDatabaseProvider(env.DefaultInitBranch, nil, sqlDb)
+	pro := NewDoltDatabaseProviderWithDatabase(env.DefaultInitBranch, nil, sqlDb, nil)
 	engine := sqle.NewDefault(pro)
 
 	sess := dsess.DefaultSession(pro)

--- a/go/libraries/doltcore/sqle/testutil.go
+++ b/go/libraries/doltcore/sqle/testutil.go
@@ -125,7 +125,7 @@ func NewTestSQLCtxWithProvider(ctx context.Context, pro dsess.DoltDatabaseProvid
 // NewTestEngine creates a new default engine, and a *sql.Context and initializes indexes and schema fragments.
 func NewTestEngine(t *testing.T, dEnv *env.DoltEnv, ctx context.Context, db Database, root *doltdb.RootValue) (*sqle.Engine, *sql.Context, error) {
 	b := env.GetDefaultInitBranch(dEnv.Config)
-	pro := NewDoltDatabaseProvider(b, dEnv.FS, db)
+	pro := NewDoltDatabaseProviderWithDatabase(b, dEnv.FS, db, dEnv.FS)
 	engine := sqle.NewDefault(pro)
 	sqlCtx := NewTestSQLCtxWithProvider(ctx, pro)
 

--- a/go/libraries/doltcore/sqle/testutil.go
+++ b/go/libraries/doltcore/sqle/testutil.go
@@ -125,11 +125,12 @@ func NewTestSQLCtxWithProvider(ctx context.Context, pro dsess.DoltDatabaseProvid
 // NewTestEngine creates a new default engine, and a *sql.Context and initializes indexes and schema fragments.
 func NewTestEngine(t *testing.T, dEnv *env.DoltEnv, ctx context.Context, db Database, root *doltdb.RootValue) (*sqle.Engine, *sql.Context, error) {
 	b := env.GetDefaultInitBranch(dEnv.Config)
-	pro := NewDoltDatabaseProviderWithDatabase(b, dEnv.FS, db, dEnv.FS)
+	pro, err := NewDoltDatabaseProviderWithDatabase(b, dEnv.FS, db, dEnv.FS)
+	require.NoError(t, err)
 	engine := sqle.NewDefault(pro)
 	sqlCtx := NewTestSQLCtxWithProvider(ctx, pro)
 
-	err := dsess.DSessFromSess(sqlCtx.Session).AddDB(sqlCtx, getDbState(t, db, dEnv))
+	err = dsess.DSessFromSess(sqlCtx.Session).AddDB(sqlCtx, getDbState(t, db, dEnv))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -1825,6 +1825,28 @@ setup_ref_test() {
     [[ "$output" =~ "adding table from other" ]]
 }
 
+@test "remotes: dolt_remote uses the right db directory in a multidb env" {
+    tempDir=$(mktemp -d)
+
+    cd $tempDir
+    mkdir db1
+    cd db1
+    dolt init
+    cd ..
+
+    run dolt sql -q "use db1; call dolt_remote('add', 'test1', 'foo/bar');"
+    [ "$status" -eq 0 ]
+
+    run grep "test1" db1/.dolt/repo_state.json
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ '"name": "test1"' ]] || false
+    [ ! -d ".dolt" ]
+
+    run dolt sql -q "use db1; call dolt_remote('remove', 'test1');"
+    [ "$status" -eq 0 ]
+    [ ! -d ".dolt" ]
+}
+
 @test "remotes: dolt_remote add and remove works with other commands" {
     mkdir remote
     mkdir repo1


### PR DESCRIPTION
Changes DoltDatabaseProvider to track a Filesystem location for each database it manages. This allows callers, like the `dolt_remote` stored procedure to find the correct root directory for a database and update repo state correctly. 

Fixes #3936 