### PR TITLE
Root value cache key

### DIFF
--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -1250,16 +1250,16 @@ func (r fbRvStorage) nomsValue() types.Value {
 }
 
 type DataCacheKey struct {
-	hash.Hash
+	*RootValue
 }
 
 func NewDataCacheKey(rv *RootValue) (DataCacheKey, error) {
-	hash, err := rv.HashOf()
-	if err != nil {
-		return DataCacheKey{}, err
-	}
+	//hash, err := rv.HashOf()
+	//if err != nil {
+	//	return DataCacheKey{}, err
+	//}
 
-	return DataCacheKey{hash}, nil
+	return DataCacheKey{rv}, nil
 }
 
 // HackNomsValuesFromRootValues unwraps a RootVal to a noms Value.

--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -1253,8 +1253,8 @@ type DataCacheKey struct {
 	*RootValue
 }
 
-func NewDataCacheKey(rv *RootValue) (DataCacheKey, error) {
-	return DataCacheKey{rv}, nil
+func NewDataCacheKey(rv *RootValue) DataCacheKey {
+	return DataCacheKey{rv}
 }
 
 // HackNomsValuesFromRootValues unwraps a RootVal to a noms Value.

--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -1254,11 +1254,6 @@ type DataCacheKey struct {
 }
 
 func NewDataCacheKey(rv *RootValue) (DataCacheKey, error) {
-	//hash, err := rv.HashOf()
-	//if err != nil {
-	//	return DataCacheKey{}, err
-	//}
-
 	return DataCacheKey{rv}, nil
 }
 

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -580,7 +580,7 @@ func (db Database) getTable(ctx *sql.Context, root *doltdb.RootValue, tableName 
 		return nil, false, fmt.Errorf("no state for database %s", db.name)
 	}
 
-	key, err := doltdb.NewDataCacheKey(root)
+	key := doltdb.NewDataCacheKey(root)
 	if err != nil {
 		return nil, false, err
 	}
@@ -933,7 +933,7 @@ func (db Database) GetView(ctx *sql.Context, viewName string) (string, bool, err
 		return view, true, nil
 	}
 
-	key, err := doltdb.NewDataCacheKey(root)
+	key := doltdb.NewDataCacheKey(root)
 	if err != nil {
 		return "", false, err
 	}


### PR DESCRIPTION
from `index_join_scan`:
```
Latency (ms):
         min:                                    3.80
         avg:                                    4.35
         max:                                   10.85
         95th percentile:                        4.91
         sum:                                10000.42
```

to `index_join_scan`:
```
Latency (ms):
         min:                                    3.54
         avg:                                    3.92
         max:                                    8.84
         95th percentile:                        5.18
         sum:                                 9999.99
```