### PR TITLE
[no-release-notes] Skip windows bats test

### DIFF
--- a/go/libraries/utils/filesys/localfs.go
+++ b/go/libraries/utils/filesys/localfs.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"time"
@@ -224,6 +225,7 @@ func (fs *localFS) MkDirs(path string) error {
 		return err
 	}
 
+	log.Println(path)
 	_, err = os.Stat(path)
 
 	if err != nil {

--- a/go/libraries/utils/filesys/localfs.go
+++ b/go/libraries/utils/filesys/localfs.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	"github.com/dolthub/dolt/go/libraries/utils/file"
@@ -223,11 +222,6 @@ func (fs *localFS) MkDirs(path string) error {
 
 	if err != nil {
 		return err
-	}
-
-	p, err := os.Stat(path)
-	if runtime.GOOS == "windows" && err == nil {
-		panic(p)
 	}
 
 	if err != nil {

--- a/go/libraries/utils/filesys/localfs.go
+++ b/go/libraries/utils/filesys/localfs.go
@@ -224,6 +224,8 @@ func (fs *localFS) MkDirs(path string) error {
 		return err
 	}
 
+	_, err = os.Stat(path)
+
 	if err != nil {
 		return os.MkdirAll(path, os.ModePerm)
 	}

--- a/go/libraries/utils/filesys/localfs.go
+++ b/go/libraries/utils/filesys/localfs.go
@@ -18,9 +18,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/dolthub/dolt/go/libraries/utils/file"
@@ -225,8 +225,10 @@ func (fs *localFS) MkDirs(path string) error {
 		return err
 	}
 
-	log.Println(path)
-	_, err = os.Stat(path)
+	p, err := os.Stat(path)
+	if runtime.GOOS == "windows" && err == nil {
+		panic(p)
+	}
 
 	if err != nil {
 		return os.MkdirAll(path, os.ModePerm)

--- a/integration-tests/bats/remotes-file-system.bats
+++ b/integration-tests/bats/remotes-file-system.bats
@@ -23,6 +23,7 @@ teardown() {
 }
 
 @test "remotes-file-system: Add a file system remote with a bad path" {
+    skiponwindows "this is being interpreted as valid"
     run dolt remote add origin file:///poop/
     [ $status -ne 0 ]
     [[ "$output" =~ "'file:///poop/' is not valid" ]] || false


### PR DESCRIPTION
The problem with this is code is that the path gets interpreted as `C:/poop` which is valid to create directory on. In a unix system creating a`/poop` would be blocked without sudo permissions. It's likely that our ci system is using some administrator setting giving easier access. I'm not really sure if this is a valid testcase anymore cc: @bheni 