### PR TITLE
Dropping a non-pk column that is before a primary key column should be diffable.

### DIFF
--- a/go/libraries/doltcore/schema/schema.go
+++ b/go/libraries/doltcore/schema/schema.go
@@ -201,17 +201,6 @@ func ArePrimaryKeySetsDiffable(format *types.NomsBinFormat, fromSch, toSch Schem
 		}
 	}
 
-	ords1 := fromSch.GetPkOrdinals()
-	ords2 := toSch.GetPkOrdinals()
-	if ords1 == nil || ords2 == nil || len(ords1) != len(ords2) {
-		return false
-	}
-	for i := 0; i < len(ords1); i++ {
-		if ords1[i] != ords2[i] {
-			return false
-		}
-	}
-
 	return true
 }
 

--- a/go/libraries/doltcore/schema/schema_test.go
+++ b/go/libraries/doltcore/schema/schema_test.go
@@ -203,6 +203,123 @@ func TestValidateForInsert(t *testing.T) {
 	})
 }
 
+func TestArePrimaryKeySetsDiffable(t *testing.T) {
+	tests := []struct {
+		Name     string
+		From     Schema
+		To       Schema
+		Diffable bool
+	}{
+		{
+			Name: "Basic",
+			From: MustSchemaFromCols(NewColCollection(
+				NewColumn("pk", 0, types.IntKind, true))),
+			To: MustSchemaFromCols(NewColCollection(
+				NewColumn("pk", 0, types.IntKind, true))),
+			Diffable: true,
+		},
+		{
+			Name: "Column renames",
+			From: MustSchemaFromCols(NewColCollection(
+				NewColumn("pk", 1, types.IntKind, true))),
+			To: MustSchemaFromCols(NewColCollection(
+				NewColumn("pk2", 1, types.IntKind, true))),
+			Diffable: true,
+		},
+		{
+			Name: "Only pk ordering should matter for diffability",
+			From: MustSchemaFromCols(NewColCollection(
+				NewColumn("col1", 0, types.IntKind, false),
+				NewColumn("pk", 1, types.IntKind, true))),
+			To: MustSchemaFromCols(NewColCollection(
+				NewColumn("pk", 1, types.IntKind, true))),
+			Diffable: true,
+		},
+		{
+			Name: "Only pk ordering should matter for diffability - inverse",
+			From: MustSchemaFromCols(NewColCollection(
+				NewColumn("pk", 1, types.IntKind, true))),
+			To: MustSchemaFromCols(NewColCollection(
+				NewColumn("col1", 2, types.IntKind, false),
+				NewColumn("pk", 1, types.IntKind, true))),
+			Diffable: true,
+		},
+		{
+			Name: "Only pk ordering should matter for diffability - compound",
+			From: MustSchemaFromCols(NewColCollection(
+				NewColumn("pk1", 0, types.IntKind, true),
+				NewColumn("col1", 1, types.IntKind, false),
+				NewColumn("pk2", 2, types.IntKind, true))),
+			To: MustSchemaFromCols(NewColCollection(
+				NewColumn("pk1", 0, types.IntKind, true),
+				NewColumn("pk2", 2, types.IntKind, true))),
+			Diffable: true,
+		},
+		{
+			Name: "Tag mismatches",
+			From: MustSchemaFromCols(NewColCollection(
+				NewColumn("pk", 0, types.IntKind, true))),
+			To: MustSchemaFromCols(NewColCollection(
+				NewColumn("pk", 1, types.IntKind, true))),
+			Diffable: false,
+		},
+		{
+			Name: "PK Ordinal mismatches",
+			From: MustSchemaFromCols(NewColCollection(
+				NewColumn("pk1", 0, types.IntKind, true),
+				NewColumn("pk2", 1, types.IntKind, true))),
+			To: MustSchemaFromCols(NewColCollection(
+				NewColumn("pk2", 1, types.IntKind, true),
+				NewColumn("pk1", 0, types.IntKind, true))),
+			Diffable: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			d := ArePrimaryKeySetsDiffable(types.Format_Default, test.From, test.To)
+			require.Equal(t, test.Diffable, d)
+		})
+	}
+}
+
+func TestArePrimaryKeySetsDiffableTypeChanges(t *testing.T) {
+	// New format compares underlying SQL types
+	tests := []struct {
+		Name     string
+		From     Schema
+		To       Schema
+		Diffable bool
+		Format   *types.NomsBinFormat
+	}{
+		{
+			Name: "Int -> String (New Format)",
+			From: MustSchemaFromCols(NewColCollection(
+				NewColumn("pk", 0, types.IntKind, true))),
+			To: MustSchemaFromCols(NewColCollection(
+				NewColumn("pk", 0, types.StringKind, true))),
+			Diffable: false,
+			Format:   types.Format_DOLT_1,
+		},
+		{
+			Name: "Int -> String (Old Format)",
+			From: MustSchemaFromCols(NewColCollection(
+				NewColumn("pk", 0, types.IntKind, true))),
+			To: MustSchemaFromCols(NewColCollection(
+				NewColumn("pk", 0, types.StringKind, true))),
+			Diffable: true,
+			Format:   types.Format_LD_1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			d := ArePrimaryKeySetsDiffable(test.Format, test.From, test.To)
+			require.Equal(t, test.Diffable, d)
+		})
+	}
+}
+
 func testSchema(method string, sch Schema, t *testing.T) {
 	validateCols(t, allCols, sch.GetAllCols(), method+"GetAllCols")
 	validateCols(t, pkCols, sch.GetPKCols(), method+"GetPKCols")

--- a/integration-tests/bats/diff.bats
+++ b/integration-tests/bats/diff.bats
@@ -539,6 +539,17 @@ SQL
     [[ "$output" =~ "where pk=4" ]] || false
 }
 
+@test "diff: diff summary incorrect primary key set change regression test" {
+    dolt sql -q "create table testdrop (col1 varchar(20), id int primary key, col2 varchar(20))"
+    dolt sql -q "insert into testdrop values ('test1', 1, 'test2')"
+    dolt commit -am "Add testdrop table"
+
+    dolt sql -q "alter table testdrop drop column col1"
+    run dolt diff --summary
+    [ $status -eq 0 ]
+    [[ $output =~ "1 Row Modified (100.00%)" ]]
+}
+
 @test "diff: with where clause errors" {
     dolt sql -q "insert into test values (0, 0, 0, 0, 0, 0)"
     dolt sql -q "insert into test values (1, 1, 1, 1, 1, 1)"


### PR DESCRIPTION
Fixes #4037

The ordering of the primary key columns in returned by Schema.GetAllCols() should not determine diffability.

If and only if the primary key tags, their ordinal ordering, and their types (in the new format) are equal, two schemas are diffable.

Schema.GetPkCols() always returns the columns in ordinal order:
https://github.com/dolthub/dolt/blob/ad471682829fc379c95a41eb23f26c00cad0e099/go/libraries/doltcore/schema/schema_test.go#L106-L145