### PR TITLE
Prevent `use [db]/[tag]` from creating duplicate revision db

### DIFF
--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -472,16 +472,6 @@ func (p DoltDatabaseProvider) databaseForRevision(ctx *sql.Context, revDB string
 			return nil, dsess.InitialDbState{}, false, nil
 		}
 
-		// tag, err := srcDb.(Database).DbData().Ddb.ResolveTag(ctx, ref.NewTagRef(revSpec))
-		// if err != nil {
-		// 	return nil, dsess.InitialDbState{}, false, err
-		// }
-
-		// commitHash, err := tag.Commit.HashOf()
-		// if err != nil {
-		// 	return nil, dsess.InitialDbState{}, false, err
-		// }
-
 		db, init, err := dbRevisionForTag(ctx, srcDb.(Database), revSpec)
 		if err != nil {
 			return nil, dsess.InitialDbState{}, false, err

--- a/integration-tests/bats/sql.bats
+++ b/integration-tests/bats/sql.bats
@@ -1626,15 +1626,9 @@ SQL
 }
 
 @test "sql: USE tag doesn't create duplicate commit DB name" {
+    skip "unrelated panic when dolt_checkout is called after using a read-only revision db https://github.com/dolthub/dolt/issues/4067"
     dolt add .; dolt commit -m 'commit tables'
     dolt checkout -b feature-branch
-    
-    dolt sql  <<SQL
-USE \`dolt_repo_$$/feature-branch\`;
-CREATE TABLE a1(x int primary key);
-insert into a1 values (1), (2), (3);
-SELECT DOLT_COMMIT('-a', '-m', 'new table');
-SQL
 
     # get the last commit hash
     hash=`dolt log | grep commit | cut -d" " -f2 | tail -n+1 | head -n1`


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/4030

Wrote a bats based on the repro in the issue, but there's an [unrelated panic](https://github.com/dolthub/dolt/issues/4067) causing the test to fail
```
taylor@MacBook-Pro-3 us-jails % dolt sql
# Welcome to the DoltSQL shell.
# Statements must be terminated with ';'.
# "exit" or "quit" (or Ctrl-D) to exit.
us_jails> select * from dolt_log limit 1;
+----------------------------------+---------------+---------------------+-------------------------+-----------+
| commit_hash                      | committer     | email               | date                    | message   |
+----------------------------------+---------------+---------------------+-------------------------+-----------+
| gmlgmb9vp91a0hjpk35v54t0j43dshlf | Taylor Bantle | taylor@liquidata.co | 2022-08-11 20:16:43.467 | new table |
+----------------------------------+---------------+---------------------+-------------------------+-----------+
us_jails> use `us_jails/gmlgmb9vp91a0hjpk35v54t0j43dshlf`;
Database changed
us_jails/gmlgmb9vp91a0hjpk35v54t0j43dshlf> use `us_jails/feature-branch`;
Database changed
us_jails/feature-branch> call dolt_tag("v2");
+--------+
| status |
+--------+
| 0      |
+--------+
us_jails/feature-branch> use `us_jails/v2`;
Database changed
us_jails/v2> show databases;
+-------------------------------------------+
| Database                                  |
+-------------------------------------------+
| information_schema                        |
| test                                      |
| us_jails                                  |
| us_jails/feature-branch                   |
| us_jails/gmlgmb9vp91a0hjpk35v54t0j43dshlf |
| us_jails/v2                               |
+-------------------------------------------+
```