### PR TITLE
go/store/{nbs,datas/pull}: Fix race condition in concurrent pulls which can truncate a table file.

### DIFF
--- a/go/store/nbs/byte_sink.go
+++ b/go/store/nbs/byte_sink.go
@@ -15,6 +15,7 @@
 package nbs
 
 import (
+	"bytes"
 	"crypto/md5"
 	"errors"
 	"hash"
@@ -57,6 +58,8 @@ type ByteSink interface {
 
 	// FlushToFile writes all the data that was written to the ByteSink to a file at the given path
 	FlushToFile(path string) error
+
+	Reader() (io.ReadCloser, error)
 }
 
 // ErrBuffFull used by the FixedBufferSink when the data written is larger than the buffer allocated.
@@ -102,6 +105,10 @@ func (sink *FixedBufferByteSink) Flush(wr io.Writer) error {
 // FlushToFile writes all the data that was written to the ByteSink to a file at the given path
 func (sink *FixedBufferByteSink) FlushToFile(path string) (err error) {
 	return flushSinkToFile(sink, path)
+}
+
+func (sink *FixedBufferByteSink) Reader() (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader(sink.buff)), nil
 }
 
 // BlockBufferByteSink allocates blocks of data with a given block size to store the bytes written to the sink. New
@@ -151,6 +158,14 @@ func (sink *BlockBufferByteSink) Flush(wr io.Writer) (err error) {
 // FlushToFile writes all the data that was written to the ByteSink to a file at the given path
 func (sink *BlockBufferByteSink) FlushToFile(path string) (err error) {
 	return flushSinkToFile(sink, path)
+}
+
+func (sink *BlockBufferByteSink) Reader() (io.ReadCloser, error) {
+	rs := make([]io.Reader, len(sink.blocks))
+	for i := range sink.blocks {
+		rs[i] = bytes.NewReader(sink.blocks[i])
+	}
+	return io.NopCloser(io.MultiReader(rs...)), nil
 }
 
 // BufferedFileByteSink is a ByteSink implementation that buffers some amount of data before it passes it
@@ -237,8 +252,7 @@ func (sink *BufferedFileByteSink) backgroundWrite() {
 	sink.ae.SetIfError(err)
 }
 
-// Flush writes all the data that was written to the ByteSink to the supplied writer
-func (sink *BufferedFileByteSink) Flush(wr io.Writer) (err error) {
+func (sink *BufferedFileByteSink) finish() error {
 	toWrite := len(sink.currentBlock)
 	if toWrite > 0 {
 		sink.writeCh <- sink.currentBlock[:toWrite]
@@ -247,7 +261,13 @@ func (sink *BufferedFileByteSink) Flush(wr io.Writer) (err error) {
 	close(sink.writeCh)
 	sink.wg.Wait()
 
-	if err := sink.ae.Get(); err != nil {
+	return sink.ae.Get()
+}
+
+// Flush writes all the data that was written to the ByteSink to the supplied writer
+func (sink *BufferedFileByteSink) Flush(wr io.Writer) (err error) {
+	err = sink.finish()
+	if err != nil {
 		return err
 	}
 
@@ -273,19 +293,20 @@ func (sink *BufferedFileByteSink) Flush(wr io.Writer) (err error) {
 
 // FlushToFile writes all the data that was written to the ByteSink to a file at the given path
 func (sink *BufferedFileByteSink) FlushToFile(path string) (err error) {
-	toWrite := len(sink.currentBlock)
-	if toWrite > 0 {
-		sink.writeCh <- sink.currentBlock[:toWrite]
-	}
-
-	close(sink.writeCh)
-	sink.wg.Wait()
-
-	if err := sink.ae.Get(); err != nil {
+	err = sink.finish()
+	if err != nil {
 		return err
 	}
 
 	return file.Rename(sink.path, path)
+}
+
+func (sink *BufferedFileByteSink) Reader() (io.ReadCloser, error) {
+	err := sink.finish()
+	if err != nil {
+		return nil, err
+	}
+	return os.Open(sink.path)
 }
 
 // HashingByteSink is a ByteSink that keeps an md5 hash of all the data written to it.
@@ -328,6 +349,10 @@ func (sink *HashingByteSink) Flush(wr io.Writer) error {
 // FlushToFile writes all the data that was written to the ByteSink to a file at the given path
 func (sink *HashingByteSink) FlushToFile(path string) error {
 	return sink.backingSink.FlushToFile(path)
+}
+
+func (sink *HashingByteSink) Reader() (io.ReadCloser, error) {
+	return sink.backingSink.Reader()
 }
 
 // GetMD5 gets the MD5 hash of all the bytes written to the sink

--- a/go/store/nbs/gc_copier.go
+++ b/go/store/nbs/gc_copier.go
@@ -67,7 +67,7 @@ func (gcc *gcCopier) copyTablesToDir(ctx context.Context, destDir string) ([]tab
 
 	filepath := path.Join(destDir, filename)
 
-	if gcc.writer.Size() == 0 {
+	if gcc.writer.ChunkCount() == 0 {
 		return []tableSpec{}, nil
 	}
 
@@ -92,7 +92,7 @@ func (gcc *gcCopier) copyTablesToDir(ctx context.Context, destDir string) ([]tab
 	return []tableSpec{
 		{
 			name:       addr,
-			chunkCount: gcc.writer.ChunkCount(),
+			chunkCount: uint32(gcc.writer.ChunkCount()),
 		},
 	}, nil
 }

--- a/go/store/nbs/gc_copier.go
+++ b/go/store/nbs/gc_copier.go
@@ -63,7 +63,7 @@ func (gcc *gcCopier) addChunk(ctx context.Context, c CompressedChunk) error {
 	return gcc.writer.AddCmpChunk(c)
 }
 
-func (gcc *gcCopier) copyTablesToDir(ctx context.Context, destDir string) (ts []tableSpec,  err error) {
+func (gcc *gcCopier) copyTablesToDir(ctx context.Context, destDir string) (ts []tableSpec, err error) {
 	var filename string
 	filename, err = gcc.writer.Finish()
 	if err != nil {

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -1339,7 +1339,6 @@ func (nbs *NomsBlockStore) WriteTableFile(ctx context.Context, fileId string, nu
 		return errors.New("Not implemented")
 	}
 
-
 	tn, err := func() (n string, err error) {
 		var r io.ReadCloser
 		r, _, err = getRd()
@@ -1366,12 +1365,12 @@ func (nbs *NomsBlockStore) WriteTableFile(ctx context.Context, fileId string, nu
 			}
 		}()
 
-                _, err = io.Copy(temp, r)
-                if err != nil {
-                        return "", err
-                }
+		_, err = io.Copy(temp, r)
+		if err != nil {
+			return "", err
+		}
 
-                return temp.Name(), nil
+		return temp.Name(), nil
 	}()
 	if err != nil {
 		return err

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -41,9 +41,11 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/dolthub/dolt/go/libraries/utils/file"
 	"github.com/dolthub/dolt/go/store/blobstore"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/dolthub/dolt/go/store/util/tempfiles"
 )
 
 var (
@@ -1333,39 +1335,50 @@ func (nbs *NomsBlockStore) SupportedOperations() TableFileStoreOps {
 // WriteTableFile will read a table file from the provided reader and write it to the TableFileStore
 func (nbs *NomsBlockStore) WriteTableFile(ctx context.Context, fileId string, numChunks int, contentHash []byte, getRd func() (io.ReadCloser, uint64, error)) error {
 	fsPersister, ok := nbs.p.(*fsTablePersister)
-
 	if !ok {
 		return errors.New("Not implemented")
 	}
 
+
+	tn, err := func() (n string, err error) {
+		var r io.ReadCloser
+		r, _, err = getRd()
+		if err != nil {
+			return "", err
+		}
+		defer func() {
+			cerr := r.Close()
+			if err == nil {
+				err = cerr
+			}
+		}()
+
+		var temp *os.File
+		temp, err = tempfiles.MovableTempFileProvider.NewFile(fsPersister.dir, tempTablePrefix)
+		if err != nil {
+			return "", err
+		}
+
+		defer func() {
+			cerr := temp.Close()
+			if err == nil {
+				err = cerr
+			}
+		}()
+
+                _, err = io.Copy(temp, r)
+                if err != nil {
+                        return "", err
+                }
+
+                return temp.Name(), nil
+	}()
+	if err != nil {
+		return err
+	}
+
 	path := filepath.Join(fsPersister.dir, fileId)
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.ModePerm)
-
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		closeErr := f.Close()
-
-		if err == nil {
-			err = closeErr
-		}
-	}()
-
-	r, _, err := getRd()
-	if err != nil {
-		return err
-	}
-	defer func() {
-		closeErr := r.Close()
-
-		if err == nil {
-			err = closeErr
-		}
-	}()
-
-	return writeTo(f, r, copyTableFileBufferSize)
+	return file.Rename(tn, path)
 }
 
 // AddTableFilesToManifest adds table files to the manifest
@@ -1389,36 +1402,6 @@ func (nbs *NomsBlockStore) AddTableFilesToManifest(ctx context.Context, fileIdTo
 
 	_, err := nbs.UpdateManifest(ctx, fileIdHashToNumChunks)
 	return err
-}
-
-func writeTo(wr io.Writer, rd io.Reader, bufferSize uint32) error {
-	buf := make([]byte, bufferSize)
-
-	for {
-		// can return bytes and an io.EOF
-		n, err := rd.Read(buf)
-
-		if err != nil && err != io.EOF {
-			return err
-		}
-
-		pos := 0
-		for pos < n {
-			n, wrErr := wr.Write(buf[pos:n])
-
-			if wrErr != nil {
-				return wrErr
-			}
-
-			pos += n
-		}
-
-		if err == io.EOF {
-			break
-		}
-	}
-
-	return nil
 }
 
 // PruneTableFiles deletes old table files that are no longer referenced in the manifest.


### PR DESCRIPTION
In `NBSStore.WriteTableFile`, the code used to open the destination path with `O_TRUNC`, without checking in the file already exists or performing any synchronization with concurrent processes. It did this even before even calling `getRd()` to see if it would return an error.

As a result, a race condition exists, where a file gets written to the table file store and added to the manifest and then a later process calls `WriteTableFile` with that same filename and the file gets truncated. This is most likely to happen if there are two concurrent pulls for the same content, which will result in building up the same table files. One of the writes will win, and the later write will lose, but will still truncate the table file. In turn, this pull behavior is most likely to happen if you are a running a read replica sql-server, which might kick off two concurrent pulls for the same remote ref if two connections come in against that branch at the same time.

This PR changes the Puller path and some related paths to be less racey. In particular:

1) Change our use of `CmpChunkTableWriter` so that we don't flush to conflicting temporary file names. We can get a Reader without needing to generate a new temporary file name.
2) Change the write paths for NBSStore.WriteTableFile and gcCopier.copyTablesToDir to use the `tempfiles.MovableTempFileProvider` write-and-rename pattern. This is the same pattern that is used in file_table_persister, and it is safer than writing non-temp-tablefiles directly into the table file store.