### PR TITLE
dolt commit -a ignores new tables

### DIFF
--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -103,7 +103,7 @@ func performCommit(ctx context.Context, commandStr string, args []string, dEnv *
 	}
 
 	if allFlag {
-		roots, err = actions.StageAllTables(ctx, roots)
+		roots, err = actions.StageModifiedAndDeletedTables(ctx, roots)
 		if err != nil {
 			return handleCommitErr(ctx, dEnv, err, help)
 		}

--- a/go/libraries/doltcore/env/actions/staged.go
+++ b/go/libraries/doltcore/env/actions/staged.go
@@ -37,7 +37,7 @@ func StageAllTables(ctx context.Context, roots doltdb.Roots) (doltdb.Roots, erro
 func StageModifiedAndDeletedTables(ctx context.Context, roots doltdb.Roots) (doltdb.Roots, error) {
 	_, unstaged, err := diff.GetStagedUnstagedTableDeltas(ctx, roots)
 	if err != nil {
-		return nil, err
+		return doltdb.Roots{}, err
 	}
 
 	tbls := []string{}

--- a/go/libraries/doltcore/env/actions/staged.go
+++ b/go/libraries/doltcore/env/actions/staged.go
@@ -17,6 +17,7 @@ package actions
 import (
 	"context"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 )
 
@@ -28,6 +29,22 @@ func StageAllTables(ctx context.Context, roots doltdb.Roots) (doltdb.Roots, erro
 	tbls, err := doltdb.UnionTableNames(ctx, roots.Staged, roots.Working)
 	if err != nil {
 		return doltdb.Roots{}, err
+	}
+
+	return stageTables(ctx, roots, tbls)
+}
+
+func StageModifiedAndDeletedTables(ctx context.Context, roots doltdb.Roots) (doltdb.Roots, error) {
+	_, unstaged, err := diff.GetStagedUnstagedTableDeltas(ctx, roots)
+	if err != nil {
+		return nil, err
+	}
+
+	tbls := []string{}
+	for _, tableDelta := range unstaged {
+		if !tableDelta.IsAdd() {
+			tbls = append(tbls, tableDelta.FromName)
+		}
 	}
 
 	return stageTables(ctx, roots, tbls)

--- a/go/libraries/doltcore/merge/integration_test.go
+++ b/go/libraries/doltcore/merge/integration_test.go
@@ -96,9 +96,11 @@ func TestMerge(t *testing.T) {
 				{cmd.BranchCmd{}, args{"other"}},
 				{cmd.SqlCmd{}, args{"-q", "CREATE TABLE quiz (pk varchar(120) primary key);"}},
 				{cmd.SqlCmd{}, args{"-q", "INSERT INTO quiz VALUES ('a'),('b'),('c');"}},
+				{cmd.AddCmd{}, []string{"."}},
 				{cmd.CommitCmd{}, args{"-am", "added rows on main"}},
 				{cmd.CheckoutCmd{}, args{"other"}},
 				{cmd.SqlCmd{}, args{"-q", "CREATE TABLE quiz (pk varchar(120) primary key);"}},
+				{cmd.AddCmd{}, []string{"."}},
 				{cmd.SqlCmd{}, args{"-q", "INSERT INTO quiz VALUES ('x'),('y'),('z');"}},
 				{cmd.CommitCmd{}, args{"-am", "added rows on other"}},
 				{cmd.CheckoutCmd{}, args{env.DefaultInitBranch}},
@@ -145,6 +147,7 @@ func TestMergeConflicts(t *testing.T) {
 
 	setupCommon := []testCommand{
 		{cmd.SqlCmd{}, args{"-q", "CREATE TABLE test (pk int PRIMARY KEY, c0 int);"}},
+		{cmd.AddCmd{}, []string{"."}},
 		{cmd.CommitCmd{}, args{"-am", "created table test"}},
 	}
 
@@ -176,6 +179,7 @@ func TestMergeConflicts(t *testing.T) {
 			setup: []testCommand{
 				{cmd.CheckoutCmd{}, args{"-b", "other"}},
 				{cmd.SqlCmd{}, args{"-q", "INSERT INTO test VALUES (1,1),(2,2);"}},
+				{cmd.AddCmd{}, []string{"."}},
 				{cmd.CommitCmd{}, args{"-am", "added rows on other"}},
 				{cmd.CheckoutCmd{}, args{env.DefaultInitBranch}},
 				{cmd.SqlCmd{}, args{"-q", "INSERT INTO test VALUES (1,11),(2,22);"}},
@@ -195,10 +199,12 @@ func TestMergeConflicts(t *testing.T) {
 				{cmd.CheckoutCmd{}, args{"-b", "other"}},
 				{cmd.SqlCmd{}, args{"-q", "CREATE TABLE quiz (pk int PRIMARY KEY, c0 int);"}},
 				{cmd.SqlCmd{}, args{"-q", "INSERT INTO quiz VALUES (1,1),(2,2);"}},
+				{cmd.AddCmd{}, []string{"."}},
 				{cmd.CommitCmd{}, args{"-am", "added rows on other"}},
 				{cmd.CheckoutCmd{}, args{env.DefaultInitBranch}},
 				{cmd.SqlCmd{}, args{"-q", "CREATE TABLE quiz (pk int PRIMARY KEY, c0 int);"}},
 				{cmd.SqlCmd{}, args{"-q", "INSERT INTO quiz VALUES (1,11),(2,22);"}},
+				{cmd.AddCmd{}, []string{"."}},
 				{cmd.CommitCmd{}, args{"-am", "added the same rows on main"}},
 				{cmd.MergeCmd{}, args{"other"}},
 			},
@@ -213,10 +219,12 @@ func TestMergeConflicts(t *testing.T) {
 				{cmd.CheckoutCmd{}, args{"-b", "other"}},
 				{cmd.SqlCmd{}, args{"-q", "CREATE TABLE quiz (pk int PRIMARY KEY, c0 int);"}},
 				{cmd.SqlCmd{}, args{"-q", "INSERT INTO quiz VALUES (1,1),(2,2);"}},
+				{cmd.AddCmd{}, []string{"."}},
 				{cmd.CommitCmd{}, args{"-am", "added rows on other"}},
 				{cmd.CheckoutCmd{}, args{env.DefaultInitBranch}},
 				{cmd.SqlCmd{}, args{"-q", "CREATE TABLE quiz (pk int PRIMARY KEY, c0 int);"}},
 				{cmd.SqlCmd{}, args{"-q", "INSERT INTO quiz VALUES (1,11),(2,22);"}},
+				{cmd.AddCmd{}, []string{"."}},
 				{cmd.CommitCmd{}, args{"-am", "added the same rows on main"}},
 				{cmd.MergeCmd{}, args{"other"}},
 				{cnfcmds.ResolveCmd{}, args{"--theirs", "quiz"}},

--- a/go/libraries/doltcore/merge/keyless_integration_test.go
+++ b/go/libraries/doltcore/merge/keyless_integration_test.go
@@ -47,6 +47,7 @@ func TestKeylessMerge(t *testing.T) {
 			name: "fast-forward merge",
 			setup: []testCommand{
 				{cmd.SqlCmd{}, []string{"-q", "insert into noKey values (1,2),(1,2);"}},
+				{cmd.AddCmd{}, []string{"."}},
 				{cmd.CommitCmd{}, []string{"-am", "added rows"}},
 				{cmd.CheckoutCmd{}, []string{"-b", "other"}},
 				{cmd.SqlCmd{}, []string{"-q", "insert into noKey values (3,4);"}},
@@ -63,6 +64,7 @@ func TestKeylessMerge(t *testing.T) {
 			name: "3-way merge",
 			setup: []testCommand{
 				{cmd.SqlCmd{}, []string{"-q", "insert into noKey values (1,2),(1,2);"}},
+				{cmd.AddCmd{}, []string{"."}},
 				{cmd.CommitCmd{}, []string{"-am", "added rows"}},
 				{cmd.CheckoutCmd{}, []string{"-b", "other"}},
 				{cmd.SqlCmd{}, []string{"-q", "insert into noKey values (3,4);"}},
@@ -82,6 +84,7 @@ func TestKeylessMerge(t *testing.T) {
 			name: "3-way merge with duplicates",
 			setup: []testCommand{
 				{cmd.SqlCmd{}, []string{"-q", "insert into noKey values (1,2),(1,2);"}},
+				{cmd.AddCmd{}, []string{"."}},
 				{cmd.CommitCmd{}, []string{"-am", "added rows"}},
 				{cmd.CheckoutCmd{}, []string{"-b", "other"}},
 				{cmd.SqlCmd{}, []string{"-q", "insert into noKey values (3,4), (3,4);"}},
@@ -145,6 +148,7 @@ func TestKeylessMergeConflicts(t *testing.T) {
 			name: "identical parallel changes",
 			setup: []testCommand{
 				{cmd.SqlCmd{}, []string{"-q", "insert into noKey values (1,2),(1,2);"}},
+				{cmd.AddCmd{}, []string{"."}},
 				{cmd.CommitCmd{}, []string{"-am", "added rows"}},
 				{cmd.CheckoutCmd{}, []string{"-b", "other"}},
 				{cmd.SqlCmd{}, []string{"-q", "insert into noKey values (3,4);"}},
@@ -174,6 +178,7 @@ func TestKeylessMergeConflicts(t *testing.T) {
 			name: "asymmetric parallel deletes",
 			setup: []testCommand{
 				{cmd.SqlCmd{}, []string{"-q", "insert into noKey values (1,2),(1,2),(1,2),(1,2);"}},
+				{cmd.AddCmd{}, []string{"."}},
 				{cmd.CommitCmd{}, []string{"-am", "added rows"}},
 				{cmd.CheckoutCmd{}, []string{"-b", "other"}},
 				{cmd.SqlCmd{}, []string{"-q", "delete from noKey where (c1,c2) = (1,2) limit 1;"}},
@@ -201,6 +206,7 @@ func TestKeylessMergeConflicts(t *testing.T) {
 			name: "asymmetric parallel updates",
 			setup: []testCommand{
 				{cmd.SqlCmd{}, []string{"-q", "insert into noKey values (1,2),(1,2),(1,2),(1,2);"}},
+				{cmd.AddCmd{}, []string{"."}},
 				{cmd.CommitCmd{}, []string{"-am", "added rows"}},
 				{cmd.CheckoutCmd{}, []string{"-b", "other"}},
 				{cmd.SqlCmd{}, []string{"-q", "update noKey set c2 = 9 limit 1;"}},

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_commit.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_commit.go
@@ -66,7 +66,7 @@ func DoDoltCommit(ctx *sql.Context, args []string) (string, error) {
 	}
 
 	if apr.Contains(cli.AllFlag) {
-		roots, err = actions.StageAllTables(ctx, roots)
+		roots, err = actions.StageModifiedAndDeletedTables(ctx, roots)
 		if err != nil {
 			return "", fmt.Errorf(err.Error())
 		}

--- a/go/libraries/doltcore/sqle/enginetest/ddl_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/ddl_queries.go
@@ -678,6 +678,7 @@ var BrokenDDLScripts = []queries.ScriptTest{
 		Name: "table with commit column should maintain its data in diff",
 		SetUpScript: []string{
 			"CREATE TABLE t (pk int PRIMARY KEY, commit text);",
+			"CALL DOLT_ADD('.');",
 			"set @Commit1 = dolt_commit('-am', 'creating table t');",
 			"INSERT INTO t VALUES (1, 'hi');",
 			"set @Commit2 = dolt_commit('-am', 'insert data');",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -114,6 +114,7 @@ func TestSingleScript(t *testing.T) {
 			Name: "truncate table",
 			SetUpScript: []string{
 				"create table t (a int primary key auto_increment, b int)",
+				"call dolt_add('.')",
 				"call dolt_commit('-am', 'empty table')",
 				"call dolt_branch('branch1')",
 				"call dolt_branch('branch2')",
@@ -247,6 +248,7 @@ func TestSingleScriptPrepared(t *testing.T) {
 	s := []setup.SetupScript{
 		{
 			"create table test (pk int primary key, c1 int)",
+			"call dolt_add('.')",
 			"insert into test values (0,0), (1,1);",
 			"set @Commit1 = dolt_commit('-am', 'creating table');",
 			"call dolt_branch('-c', 'main', 'newb')",
@@ -773,6 +775,7 @@ func TestDoltRevisionDbScripts(t *testing.T) {
 
 	setupScripts := []setup.SetupScript{
 		{"create table t01 (pk int primary key, c1 int)"},
+		{"call dolt_add('.');"},
 		{"call dolt_commit('-am', 'creating table t01 on main');"},
 		{"insert into t01 values (1, 1), (2, 2);"},
 		{"call dolt_commit('-am', 'adding rows to table t01 on main');"},
@@ -1010,6 +1013,7 @@ func TestSingleTransactionScript(t *testing.T) {
 		Name: "allow commit conflicts on, conflict on dolt_merge",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key, val int)",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0, 0)",
 			"SELECT DOLT_COMMIT('-a', '-m', 'initial table');",
 		},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -76,6 +76,7 @@ func TestSingleQuery(t *testing.T) {
 	setupQueries := []string{
 		"create table t1 (pk int primary key, c int);",
 		"insert into t1 values (1,2), (3,4)",
+		"call dolt_add('.')",
 		"set @Commit1 = dolt_commit('-am', 'initial table');",
 		"insert into t1 values (5,6), (7,8)",
 		"set @Commit2 = dolt_commit('-am', 'two more rows');",
@@ -212,6 +213,7 @@ func TestSingleQueryPrepared(t *testing.T) {
 
 	setupQueries := []string{
 		"create table t1 (pk int primary key, c int);",
+		"call dolt_add('.')",
 		"insert into t1 values (1,2), (3,4)",
 		"set @Commit1 = dolt_commit('-am', 'initial table');",
 		"insert into t1 values (5,6), (7,8)",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
@@ -166,6 +166,7 @@ func commitScripts(dbs []string) []setup.SetupScript {
 	for i := range dbs {
 		db := dbs[i]
 		commitCmds = append(commitCmds, fmt.Sprintf("use %s", db))
+		commitCmds = append(commitCmds, "call dolt_add('.')")
 		commitCmds = append(commitCmds, fmt.Sprintf("call dolt_commit('--allow-empty', '-am', 'checkpoint enginetest database %s', '--date', '1970-01-01T12:00:00')", db))
 	}
 	commitCmds = append(commitCmds, "use mydb")
@@ -438,6 +439,8 @@ func (d *DoltHarness) SnapshotTable(db sql.VersionedDatabase, name string, asOf 
 
 	ctx := enginetest.NewContext(d)
 	_, iter, err := e.Query(ctx,
+		"CALL DOLT_ADD('.')")
+	_, iter, err = e.Query(ctx,
 		"SELECT COMMIT('-am', 'test commit');")
 	require.NoError(d.t, err)
 	_, err = sql.RowIterToRows(ctx, nil, iter)

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -36,16 +36,19 @@ var ViewsWithAsOfScriptTest = queries.ScriptTest{
 		"CALL dolt_commit('--allow-empty', '-m', 'cm0');",
 
 		"CREATE TABLE t1 (pk int PRIMARY KEY AUTO_INCREMENT, c0 int);",
+		"CALL dolt_add('.')",
 		"CALL dolt_commit('-am', 'cm1');",
 		"INSERT INTO t1 (c0) VALUES (1), (2);",
 		"CALL dolt_commit('-am', 'cm2');",
 
 		"CREATE TABLE t2 (pk int PRIMARY KEY AUTO_INCREMENT, vc varchar(100));",
+		"CALL dolt_add('.')",
 		"CALL dolt_commit('-am', 'cm3');",
 		"INSERT INTO t2 (vc) VALUES ('one'), ('two');",
 		"CALL dolt_commit('-am', 'cm4');",
 
 		"CREATE VIEW v1 as select * from t1 union select * from t2",
+		"call dolt_add('.');",
 		"CALL dolt_commit('-am', 'cm5');",
 	},
 	Assertions: []queries.ScriptTestAssertion{
@@ -86,6 +89,7 @@ var ShowCreateTableAsOfScriptTest = queries.ScriptTest{
 	SetUpScript: []string{
 		"set @Commit0 = hashof('main');",
 		"create table a (pk int primary key, c1 int);",
+		"call dolt_add('.');",
 		"set @Commit1 = dolt_commit('-am', 'creating table a');",
 		"alter table a add column c2 varchar(20);",
 		"set @Commit2 = dolt_commit('-am', 'adding column c2');",
@@ -141,6 +145,7 @@ var DescribeTableAsOfScriptTest = queries.ScriptTest{
 	SetUpScript: []string{
 		"set @Commit0 = dolt_commit('--allow-empty', '-m', 'before creating table a');",
 		"create table a (pk int primary key, c1 int);",
+		"call dolt_add('.');",
 		"set @Commit1 = dolt_commit('-am', 'creating table a');",
 		"alter table a add column c2 varchar(20);",
 		"set @Commit2 = dolt_commit('-am', 'adding column c2');",
@@ -182,6 +187,7 @@ var DoltRevisionDbScripts = []queries.ScriptTest{
 		Name: "database revision specs: tag-qualified revision spec",
 		SetUpScript: []string{
 			"create table t01 (pk int primary key, c1 int)",
+			"call dolt_add('.')",
 			"call dolt_commit('-am', 'creating table t01 on main');",
 			"insert into t01 values (1, 1), (2, 2);",
 			"call dolt_commit('-am', 'adding rows to table t01 on main');",
@@ -244,6 +250,7 @@ var DoltRevisionDbScripts = []queries.ScriptTest{
 		Name: "database revision specs: branch-qualified revision spec",
 		SetUpScript: []string{
 			"create table t01 (pk int primary key, c1 int)",
+			"call dolt_add('.')",
 			"call dolt_commit('-am', 'creating table t01 on main');",
 			"insert into t01 values (1, 1), (2, 2);",
 			"call dolt_commit('-am', 'adding rows to table t01 on main');",
@@ -354,6 +361,7 @@ var DoltScripts = []queries.ScriptTest{
 		Name: "test as of indexed join (https://github.com/dolthub/dolt/issues/2189)",
 		SetUpScript: []string{
 			"create table a (pk int primary key, c1 int)",
+			"call DOLT_ADD('.')",
 			"insert into a values (1,1), (2,2), (3,3)",
 			"select DOLT_COMMIT('-a', '-m', 'first commit')",
 			"insert into a values (4,4), (5,5), (6,6)",
@@ -462,6 +470,7 @@ var DoltScripts = []queries.ScriptTest{
 		Name: "Prepared ASOF",
 		SetUpScript: []string{
 			"create table test (pk int primary key, c1 int)",
+			"call dolt_add('.')",
 			"insert into test values (0,0), (1,1);",
 			"set @Commit1 = dolt_commit('-am', 'creating table');",
 			"call dolt_branch('-c', 'main', 'newb')",
@@ -545,6 +554,7 @@ var DoltUserPrivTests = []queries.UserPrivilegeTest{
 		SetUpScript: []string{
 			"CREATE TABLE mydb.test (pk BIGINT PRIMARY KEY);",
 			"CREATE TABLE mydb.test2 (pk BIGINT PRIMARY KEY);",
+			"CALL DOLT_ADD('.')",
 			"SELECT DOLT_COMMIT('-am', 'creating tables test and test2');",
 			"INSERT INTO mydb.test VALUES (1);",
 			"SELECT DOLT_COMMIT('-am', 'inserting into test');",
@@ -659,6 +669,7 @@ var HistorySystemTableScriptTests = []queries.ScriptTest{
 		Name: "empty table",
 		SetUpScript: []string{
 			"create table t (n int, c varchar(20));",
+			"call dolt_add('.')",
 			"set @Commit1 = dolt_commit('-am', 'creating table t');",
 		},
 		Assertions: []queries.ScriptTestAssertion{
@@ -673,6 +684,7 @@ var HistorySystemTableScriptTests = []queries.ScriptTest{
 		SetUpScript: []string{
 			"create table foo1 (n int, de varchar(20));",
 			"insert into foo1 values (1, 'Ein'), (2, 'Zwei'), (3, 'Drei');",
+			"call dolt_add('.')",
 			"set @Commit1 = dolt_commit('-am', 'inserting into foo1', '--date', '2022-08-06T12:00:00');",
 
 			"update foo1 set de='Eins' where n=1;",
@@ -704,6 +716,7 @@ var HistorySystemTableScriptTests = []queries.ScriptTest{
 		Name: "primary key table: basic cases",
 		SetUpScript: []string{
 			"create table t1 (n int primary key, de varchar(20));",
+			"call dolt_add('.')",
 			"insert into t1 values (1, 'Eins'), (2, 'Zwei'), (3, 'Drei');",
 			"set @Commit1 = dolt_commit('-am', 'inserting into t1', '--date', '2022-08-06T12:00:01');",
 
@@ -771,6 +784,7 @@ var HistorySystemTableScriptTests = []queries.ScriptTest{
 		Name: "index by primary key",
 		SetUpScript: []string{
 			"create table t1 (pk int primary key, c int);",
+			"call dolt_add('.')",
 			"insert into t1 values (1,2), (3,4)",
 			"set @Commit1 = dolt_commit('-am', 'initial table');",
 			"insert into t1 values (5,6), (7,8)",
@@ -829,6 +843,7 @@ var HistorySystemTableScriptTests = []queries.ScriptTest{
 		Name: "adding an index",
 		SetUpScript: []string{
 			"create table t1 (pk int primary key, c int);",
+			"call dolt_add('.')",
 			"insert into t1 values (1,2), (3,4)",
 			"set @Commit1 = dolt_commit('-am', 'initial table');",
 			"insert into t1 values (5,6), (7,8)",
@@ -875,6 +890,7 @@ var HistorySystemTableScriptTests = []queries.ScriptTest{
 		Name: "primary key table: non-pk column drops and adds",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c1 int, c2 varchar(20));",
+			"call dolt_add('.')",
 			"insert into t values (1, 2, '3'), (4, 5, '6');",
 			"set @Commit1 = DOLT_COMMIT('-am', 'creating table t');",
 
@@ -914,6 +930,7 @@ var HistorySystemTableScriptTests = []queries.ScriptTest{
 		Name: "primary key table: non-pk column type changes",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c1 int, c2 varchar(20));",
+			"call dolt_add('.')",
 			"insert into t values (1, 2, '3'), (4, 5, '6');",
 			"set @Commit1 = DOLT_COMMIT('-am', 'creating table t');",
 			"alter table t modify column c2 int;",
@@ -939,10 +956,12 @@ var HistorySystemTableScriptTests = []queries.ScriptTest{
 		Name: "primary key table: rename table",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c1 int, c2 varchar(20));",
+			"call dolt_add('.')",
 			"insert into t values (1, 2, '3'), (4, 5, '6');",
 			"set @Commit1 = DOLT_COMMIT('-am', 'creating table t');",
 
 			"alter table t rename to t2;",
+			"call dolt_add('.')",
 			"set @Commit2 = DOLT_COMMIT('-am', 'renaming table to t2');",
 		},
 		Assertions: []queries.ScriptTestAssertion{
@@ -964,6 +983,7 @@ var HistorySystemTableScriptTests = []queries.ScriptTest{
 		Name: "primary key table: delete and recreate table",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c1 int, c2 varchar(20));",
+			"call dolt_add('.')",
 			"insert into t values (1, 2, '3'), (4, 5, '6');",
 			"set @Commit1 = DOLT_COMMIT('-am', 'creating table t');",
 
@@ -971,6 +991,7 @@ var HistorySystemTableScriptTests = []queries.ScriptTest{
 			"set @Commit2 = DOLT_COMMIT('-am', 'dropping table t');",
 
 			"create table t (pk int primary key, c1 int);",
+			"call dolt_add('.')",
 			"set @Commit3 = DOLT_COMMIT('-am', 'recreating table t');",
 		},
 		Assertions: []queries.ScriptTestAssertion{
@@ -1226,6 +1247,7 @@ var MergeScripts = []queries.ScriptTest{
 		Name: "CALL DOLT_MERGE ff correctly works with autocommit off",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key)",
+			"call DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0),(1),(2);",
 			"SET autocommit = 0",
 			"SELECT DOLT_COMMIT('-a', '-m', 'Step 1');",
@@ -1259,6 +1281,7 @@ var MergeScripts = []queries.ScriptTest{
 		Name: "CALL DOLT_MERGE no-ff correctly works with autocommit off",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key)",
+			"call DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0),(1),(2);",
 			"SET autocommit = 0",
 			"SELECT DOLT_COMMIT('-a', '-m', 'Step 1', '--date', '2022-08-06T12:00:00');",
@@ -1296,6 +1319,7 @@ var MergeScripts = []queries.ScriptTest{
 		Name: "CALL DOLT_MERGE without conflicts correctly works with autocommit off with commit flag",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key)",
+			"call DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0),(1),(2);",
 			"SET autocommit = 0",
 			"SELECT DOLT_COMMIT('-a', '-m', 'Step 1', '--date', '2022-08-06T12:00:01');",
@@ -1369,6 +1393,7 @@ var MergeScripts = []queries.ScriptTest{
 		Name: "CALL DOLT_MERGE with conflicts can be correctly resolved when autocommit is off",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key, val int)",
+			"call DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0, 0)",
 			"SET autocommit = 0",
 			"SELECT DOLT_COMMIT('-a', '-m', 'Step 1', '--date', '2022-08-06T12:00:01');",
@@ -1423,6 +1448,7 @@ var MergeScripts = []queries.ScriptTest{
 		Name: "CALL DOLT_MERGE ff & squash correctly works with autocommit off",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key)",
+			"call DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0),(1),(2);",
 			"SET autocommit = 0",
 			"SELECT DOLT_COMMIT('-a', '-m', 'Step 1');",
@@ -1455,6 +1481,7 @@ var MergeScripts = []queries.ScriptTest{
 		Name: "CALL DOLT_MERGE ff & squash with a checkout in between",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key)",
+			"call DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0),(1),(2);",
 			"SET autocommit = 0",
 			"SELECT DOLT_COMMIT('-a', '-m', 'Step 1');",
@@ -1483,6 +1510,7 @@ var MergeScripts = []queries.ScriptTest{
 		Name: "CALL DOLT_MERGE ff",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key)",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0),(1),(2);",
 			"SELECT DOLT_COMMIT('-a', '-m', 'Step 1');",
 			"SELECT DOLT_CHECKOUT('-b', 'feature-branch')",
@@ -1515,6 +1543,7 @@ var MergeScripts = []queries.ScriptTest{
 		Name: "CALL DOLT_MERGE no-ff",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key)",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0),(1),(2);",
 			"SELECT DOLT_COMMIT('-a', '-m', 'Step 1');",
 			"SELECT DOLT_CHECKOUT('-b', 'feature-branch')",
@@ -1551,6 +1580,7 @@ var MergeScripts = []queries.ScriptTest{
 		Name: "CALL DOLT_MERGE with no conflicts works",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key)",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0),(1),(2);",
 			"SELECT DOLT_COMMIT('-a', '-m', 'Step 1', '--date', '2022-08-06T12:00:00');",
 			"SELECT DOLT_CHECKOUT('-b', 'feature-branch')",
@@ -1625,6 +1655,7 @@ var MergeScripts = []queries.ScriptTest{
 		Name: "CALL DOLT_MERGE with conflict is queryable and committable with dolt_allow_commit_conflicts on",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key, val int)",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0, 0)",
 			"SELECT DOLT_COMMIT('-a', '-m', 'Step 1');",
 			"SELECT DOLT_CHECKOUT('-b', 'feature-branch')",
@@ -1679,6 +1710,7 @@ var MergeScripts = []queries.ScriptTest{
 		Name: "CALL DOLT_MERGE with conflicts can be aborted when autocommit is off",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key, val int)",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0, 0)",
 			"SET autocommit = 0",
 			"SELECT DOLT_COMMIT('-a', '-m', 'Step 1');",
@@ -1729,6 +1761,7 @@ var MergeScripts = []queries.ScriptTest{
 		Name: "CALL DOLT_MERGE complains when a merge overrides local changes",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key, val int)",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0, 0)",
 			"SET autocommit = 0",
 			"SELECT DOLT_COMMIT('-a', '-m', 'Step 1');",
@@ -1750,6 +1783,7 @@ var MergeScripts = []queries.ScriptTest{
 		Name: "Drop and add primary key on two branches converges to same schema",
 		SetUpScript: []string{
 			"create table t1 (i int);",
+			"call dolt_add('.');",
 			"call dolt_commit('-am', 't1 table')",
 			"call dolt_checkout('-b', 'b1')",
 			"alter table t1 add primary key(i)",
@@ -1780,6 +1814,7 @@ var MergeScripts = []queries.ScriptTest{
 			"CREATE table parent (pk int PRIMARY KEY, col1 int);",
 			"CREATE table child (pk int PRIMARY KEY, parent_fk int, FOREIGN KEY (parent_fk) REFERENCES parent(pk));",
 			"CREATE table other (pk int);",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO parent VALUES (1, 1), (2, 2);",
 			"CALL DOLT_COMMIT('-am', 'setup');",
 			"CALL DOLT_BRANCH('branch1');",
@@ -1808,6 +1843,7 @@ var MergeScripts = []queries.ScriptTest{
 		SetUpScript: []string{
 			"CREATE TABLE parent (pk BIGINT PRIMARY KEY, v1 BIGINT, INDEX(v1));",
 			"CREATE TABLE child (pk BIGINT PRIMARY KEY, v1 BIGINT, CONSTRAINT fk_name FOREIGN KEY (v1) REFERENCES parent (v1));",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO parent VALUES (10, 1), (20, 2), (30, 2);",
 			"INSERT INTO child VALUES (1, 1);",
 			"CALL DOLT_COMMIT('-am', 'MC1');",
@@ -1850,6 +1886,7 @@ var MergeScripts = []queries.ScriptTest{
 		SetUpScript: []string{
 			"SET dolt_force_transaction_commit = on;",
 			"CREATE TABLE t (pk int PRIMARY KEY, col1 int UNIQUE);",
+			"CALL dolt_add('.')",
 			"CALL DOLT_COMMIT('-am', 'create table');",
 
 			"CALL DOLT_CHECKOUT('-b', 'right');",
@@ -1880,6 +1917,7 @@ var MergeScripts = []queries.ScriptTest{
 		SetUpScript: []string{
 			"SET dolt_force_transaction_commit = on;",
 			"CREATE TABLE t (pk int PRIMARY KEY, col1 int UNIQUE);",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO t VALUES (1, 1), (2, 2);",
 			"CALL DOLT_COMMIT('-am', 'create table');",
 
@@ -1911,6 +1949,7 @@ var MergeScripts = []queries.ScriptTest{
 		SetUpScript: []string{
 			"SET dolt_force_transaction_commit = on;",
 			"CREATE TABLE t (pk int PRIMARY KEY, col1 int UNIQUE);",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO t VALUES (1, 1), (2, 2);",
 			"CALL DOLT_COMMIT('-am', 'create table');",
 
@@ -1942,6 +1981,7 @@ var MergeScripts = []queries.ScriptTest{
 		SetUpScript: []string{
 			"SET dolt_force_transaction_commit = on;",
 			"CREATE TABLE t (pk int PRIMARY KEY, col1 int, col2 int, UNIQUE col1_col2_u (col1, col2));",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO T VALUES (1, 1, 1), (2, NULL, NULL);",
 			"CALL DOLT_COMMIT('-am', 'setup');",
 
@@ -1978,6 +2018,7 @@ var MergeScripts = []queries.ScriptTest{
 		SetUpScript: []string{
 			"SET dolt_force_transaction_commit = on;",
 			"CREATE TABLE t (pk int PRIMARY KEY, col1 int);",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO t VALUES (1, 1), (2, 1);",
 			"CALL DOLT_COMMIT('-am', 'table and data');",
 
@@ -2007,11 +2048,13 @@ var MergeScripts = []queries.ScriptTest{
 			"SET dolt_allow_commit_conflicts = on;",
 			"CALL DOLT_CHECKOUT('-b', 'other');",
 			"CREATE TABLE t (pk int PRIMARY key, col1 int, extracol int);",
+			"CALL DOLT_ADD('.')",
 			"INSERT into t VALUES (1, 1, 1);",
 			"CALL DOLT_COMMIT('-am', 'right');",
 
 			"CALL DOLT_CHECKOUT('main');",
 			"CREATE TABLE t (pk int PRIMARY key, col1 int);",
+			"CALL DOLT_ADD('.')",
 			"INSERT into t VALUES (2, 2);",
 			"CALL DOLT_COMMIT('-am', 'left');",
 		},
@@ -2028,11 +2071,13 @@ var MergeScripts = []queries.ScriptTest{
 			"SET dolt_allow_commit_conflicts = on;",
 			"CALL DOLT_CHECKOUT('-b', 'other');",
 			"CREATE TABLE t (pk int PRIMARY key, col1 int);",
+			"CALL DOLT_ADD('.')",
 			"INSERT into t VALUES (1, 1);",
 			"CALL DOLT_COMMIT('-am', 'right');",
 
 			"CALL DOLT_CHECKOUT('main');",
 			"CREATE TABLE t (pk int PRIMARY key, col1 int);",
+			"CALL DOLT_ADD('.')",
 			"INSERT into t VALUES (2, 2);",
 			"CALL DOLT_COMMIT('-am', 'left');",
 		},
@@ -2053,11 +2098,13 @@ var MergeScripts = []queries.ScriptTest{
 			"SET dolt_allow_commit_conflicts = on;",
 			"CALL DOLT_CHECKOUT('-b', 'other');",
 			"CREATE TABLE t (pk int PRIMARY key, col1 int);",
+			"CALL DOLT_ADD('.')",
 			"INSERT into t VALUES (1, -1);",
 			"CALL DOLT_COMMIT('-am', 'right');",
 
 			"CALL DOLT_CHECKOUT('main');",
 			"CREATE TABLE t (pk int PRIMARY key, col1 int);",
+			"CALL DOLT_ADD('.')",
 			"INSERT into t VALUES (1, 1);",
 			"CALL DOLT_COMMIT('-am', 'left');",
 		},
@@ -2113,6 +2160,7 @@ var MergeScripts = []queries.ScriptTest{
 		Name: "dolt_merge() works with no auto increment overlap",
 		SetUpScript: []string{
 			"CREATE TABLE t (pk int PRIMARY KEY AUTO_INCREMENT, c0 int);",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO t (c0) VALUES (1), (2);",
 			"CALL dolt_commit('-a', '-m', 'cm1');",
 			"CALL dolt_checkout('-b', 'test');",
@@ -2147,6 +2195,7 @@ var MergeScripts = []queries.ScriptTest{
 		Name: "dolt_merge() (3way) works with no auto increment overlap",
 		SetUpScript: []string{
 			"CREATE TABLE t (pk int PRIMARY KEY AUTO_INCREMENT, c0 int);",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO t (c0) VALUES (1);",
 			"CALL dolt_commit('-a', '-m', 'cm1');",
 			"CALL dolt_checkout('-b', 'test');",
@@ -2256,6 +2305,7 @@ var Dolt1MergeScripts = []queries.ScriptTest{
 		Name: "Merge errors if the primary key types have changed (even if the new type has the same NomsKind)",
 		SetUpScript: []string{
 			"CREATE TABLE t (pk1 bigint, pk2 bigint, PRIMARY KEY (pk1, pk2));",
+			"CALL DOLT_ADD('.')",
 			"CALL DOLT_COMMIT('-am', 'setup');",
 
 			"CALL DOLT_CHECKOUT('-b', 'right');",
@@ -2282,6 +2332,7 @@ var KeylessMergeCVsAndConflictsScripts = []queries.ScriptTest{
 		SetUpScript: []string{
 			"SET dolt_force_transaction_commit = on;",
 			"CREATE table t (col1 int, col2 int UNIQUE);",
+			"CALL DOLT_ADD('.')",
 			"CALL DOLT_COMMIT('-am', 'setup');",
 
 			"CALL DOLT_CHECKOUT('-b', 'right');",
@@ -2313,6 +2364,7 @@ var KeylessMergeCVsAndConflictsScripts = []queries.ScriptTest{
 			"SET dolt_force_transaction_commit = on;",
 			"CREATE table parent (pk int PRIMARY KEY);",
 			"CREATE table child (parent_fk int, FOREIGN KEY (parent_fk) REFERENCES parent (pk));",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO parent VALUES (1);",
 			"CALL DOLT_COMMIT('-am', 'setup');",
 
@@ -2348,6 +2400,7 @@ var KeylessMergeCVsAndConflictsScripts = []queries.ScriptTest{
 		SetUpScript: []string{
 			"SET dolt_allow_commit_conflicts = on;",
 			"CREATE table t (col1 int, col2 int);",
+			"CALL DOLT_ADD('.')",
 			"CALL DOLT_COMMIT('-am', 'setup');",
 
 			"CALL DOLT_CHECKOUT('-b', 'right');",
@@ -2377,6 +2430,7 @@ var DoltConflictTableNameTableTests = []queries.ScriptTest{
 		SetUpScript: []string{
 			"SET dolt_allow_commit_conflicts = on;",
 			"CREATE table t (pk int PRIMARY KEY, col1 int);",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO t VALUES (1, 1);",
 			"INSERT INTO t VALUES (2, 2);",
 			"INSERT INTO t VALUES (3, 3);",
@@ -2418,6 +2472,7 @@ var DoltConflictTableNameTableTests = []queries.ScriptTest{
 		SetUpScript: []string{
 			"SET dolt_allow_commit_conflicts = on;",
 			"CREATE table t (col1 int);",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO t VALUES (1), (2), (3), (4), (6);",
 			"CALL DOLT_COMMIT('-am', 'init');",
 
@@ -2468,6 +2523,7 @@ var MergeArtifactsScripts = []queries.ScriptTest{
 			"SET dolt_allow_commit_conflicts = on",
 			"CALL DOLT_CHECKOUT('-b', 'conflicts1');",
 			"CREATE table t (pk int PRIMARY KEY, col1 int);",
+			"CALL DOLT_ADD('.')",
 			"CALL DOLT_COMMIT('-am', 'create table');",
 			"CALL DOLT_BRANCH('conflicts2');",
 
@@ -2565,6 +2621,7 @@ var MergeArtifactsScripts = []queries.ScriptTest{
 		SetUpScript: []string{
 			"SET dolt_allow_commit_conflicts = on",
 			"CREATE table t (pk int PRIMARY KEY, col1 int);",
+			"CALL DOLT_ADD('.')",
 			"CALL DOLT_COMMIT('-am', 'create table');",
 			"INSERT INTO t VALUES (1, 1);",
 			"CALL DOLT_COMMIT('-am', 'insert pk 1');",
@@ -2611,6 +2668,7 @@ var MergeArtifactsScripts = []queries.ScriptTest{
 			"CALL DOLT_CHECKOUT('-b', 'viol1');",
 			"CREATE TABLE parent (pk int PRIMARY KEY);",
 			"CREATE TABLE child (pk int PRIMARY KEY, fk int, FOREIGN KEY (fk) REFERENCES parent (pk));",
+			"CALL DOLT_ADD('.')",
 			"CALL DOLT_COMMIT('-am', 'setup table');",
 			"CALL DOLT_BRANCH('viol2');",
 			"CALL DOLT_BRANCH('other3');",
@@ -2728,6 +2786,7 @@ var MergeArtifactsScripts = []queries.ScriptTest{
 		SetUpScript: []string{
 			"SET dolt_force_transaction_commit = on;",
 			"CREATE TABLE t (pk int PRIMARY KEY, col1 int UNIQUE);",
+			"CALL DOLT_ADD('.')",
 			"CALL DOLT_COMMIT('-am', 'create table t');",
 			"CALL DOLT_BRANCH('right');",
 			"CALL DOLT_BRANCH('left2');",
@@ -2812,6 +2871,7 @@ var MergeArtifactsScripts = []queries.ScriptTest{
 		SetUpScript: []string{
 			"SET dolt_force_transaction_commit = on;",
 			"CREATE TABLE t (pk int PRIMARY KEY, col1 int);",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO t VALUES (1, 1), (2, 1);",
 			"CALL DOLT_COMMIT('-am', 'table and data');",
 
@@ -2855,6 +2915,7 @@ var MergeArtifactsScripts = []queries.ScriptTest{
 			  FOREIGN KEY (col1) REFERENCES parent(col1),
 			  FOREIGN KEY (col2) REFERENCES parent(col2)
 			);`,
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO parent VALUES (1, 1, 1);",
 			"CALL DOLT_COMMIT('-am', 'initial');",
 
@@ -2886,6 +2947,7 @@ var MergeArtifactsScripts = []queries.ScriptTest{
 		SetUpScript: []string{
 			"SET dolt_force_transaction_commit = on;",
 			"CREATE table t (pk int PRIMARY KEY, col1 int UNIQUE, col2 int UNIQUE);",
+			"CALL DOLT_ADD('.')",
 			"CALL DOLT_COMMIT('-am', 'setup');",
 
 			"CALL DOLT_CHECKOUT('-b', 'right');",
@@ -2919,6 +2981,7 @@ var OldFormatMergeConflictsAndCVsScripts = []queries.ScriptTest{
 			"CREATE table parent (pk int PRIMARY KEY, col1 int);",
 			"CREATE table child (pk int PRIMARY KEY, parent_fk int, FOREIGN KEY (parent_fk) REFERENCES parent(pk));",
 			"CREATE table other (pk int);",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO parent VALUES (1, 1), (2, 2);",
 			"CALL DOLT_COMMIT('-am', 'setup');",
 			"CALL DOLT_BRANCH('branch1');",
@@ -3055,6 +3118,7 @@ var OldFormatMergeConflictsAndCVsScripts = []queries.ScriptTest{
 		SetUpScript: []string{
 			"CREATE table parent (pk int PRIMARY KEY, col1 int);",
 			"CREATE table child (pk int PRIMARY KEY, parent_fk int, FOREIGN KEY (parent_fk) REFERENCES parent(pk));",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO parent VALUES (1, 1), (2, 1);",
 			"CALL DOLT_COMMIT('-am', 'create table with data');",
 			"CALL DOLT_BRANCH('other');",
@@ -3128,6 +3192,7 @@ var OldFormatMergeConflictsAndCVsScripts = []queries.ScriptTest{
 		SetUpScript: []string{
 			"CREATE table parent (pk int PRIMARY KEY, col1 int);",
 			"CREATE table child (pk int PRIMARY KEY, parent_fk int, FOREIGN KEY (parent_fk) REFERENCES parent(pk));",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO parent VALUES (1, 1), (2, 1);",
 			"CALL DOLT_COMMIT('-am', 'create table with data');",
 			"CALL DOLT_BRANCH('other');",
@@ -3202,6 +3267,7 @@ var OldFormatMergeConflictsAndCVsScripts = []queries.ScriptTest{
 		SetUpScript: []string{
 			"SET dolt_force_transaction_commit = on;",
 			"CREATE TABLE t (pk int PRIMARY KEY, col1 int);",
+			"CALL DOLT_ADD('.')",
 			"CALL DOLT_COMMIT('-am', 'table');",
 			"CALL DOLT_BRANCH('right');",
 			"INSERT INTO t VALUES (1, 1), (2, 1);",
@@ -3239,6 +3305,7 @@ var OldFormatMergeConflictsAndCVsScripts = []queries.ScriptTest{
 		SetUpScript: []string{
 			"SET dolt_force_transaction_commit = on;",
 			"CREATE TABLE t (pk int PRIMARY KEY, col1 int);",
+			"CALL DOLT_ADD('.');",
 			"INSERT INTO t VALUES (1, 1), (2, 1);",
 			"CALL DOLT_COMMIT('-am', 'table and data');",
 
@@ -3400,6 +3467,7 @@ var DoltBranchScripts = []queries.ScriptTest{
 		Name: "Create branch from startpoint",
 		SetUpScript: []string{
 			"create table a (x int)",
+			"call dolt_add('.')",
 			"set @commit1 = (select DOLT_COMMIT('-am', 'add table a'));",
 		},
 		Assertions: []queries.ScriptTestAssertion{
@@ -3436,6 +3504,7 @@ var DoltReset = []queries.ScriptTest{
 		Name: "CALL DOLT_RESET('--hard') should reset the merge state after uncommitted merge",
 		SetUpScript: []string{
 			"CREATE TABLE test1 (pk int NOT NULL, c1 int, c2 int, PRIMARY KEY (pk));",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO test1 values (0,1,1);",
 			"CALL DOLT_COMMIT('-am', 'added table')",
 
@@ -3463,6 +3532,7 @@ var DoltReset = []queries.ScriptTest{
 		SetUpScript: []string{
 			"SET dolt_allow_commit_conflicts = on",
 			"CREATE TABLE test1 (pk int NOT NULL, c1 int, c2 int, PRIMARY KEY (pk));",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO test1 values (0,1,1);",
 			"CALL DOLT_COMMIT('-am', 'added table')",
 
@@ -3491,6 +3561,7 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 		Name: "base case: added rows",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c1 int, c2 int);",
+			"call dolt_add('.')",
 			"insert into t values (1, 2, 3), (4, 5, 6);",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'creating table t'));",
 		},
@@ -3512,6 +3583,7 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 		Name: "base case: modified rows",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c1 int, c2 int);",
+			"call dolt_add('.')",
 			"insert into t values (1, 2, 3), (4, 5, 6);",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'creating table t'));",
 
@@ -3535,6 +3607,7 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 		Name: "base case: deleted row",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c1 int, c2 int);",
+			"call dolt_add('.')",
 			"insert into t values (1, 2, 3), (4, 5, 6);",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'creating table t'));",
 
@@ -3559,6 +3632,7 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 		Name: "table drop and recreate with overlapping schema",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c int);",
+			"call dolt_add('.')",
 			"insert into t values (1, 2), (3, 4);",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'creating table t'));",
 
@@ -3566,6 +3640,7 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 			"set @Commit2 = (select DOLT_COMMIT('-am', 'dropping table t'));",
 
 			"create table t (pk int primary key, c int);",
+			"call dolt_add('.')",
 			"insert into t values (100, 200), (300, 400);",
 			"set @Commit3 = (select DOLT_COMMIT('-am', 'recreating table t'));",
 		},
@@ -3588,6 +3663,7 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 		Name: "column drop",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c1 int, c2 int);",
+			"call dolt_add('.')",
 			"insert into t values (1, 2, 3), (4, 5, 6);",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'creating table t'));",
 
@@ -3620,6 +3696,7 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 		Name: "column drop and recreate with same type",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c int);",
+			"call dolt_add('.')",
 			"insert into t values (1, 2), (3, 4);",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'creating table t'));",
 
@@ -3662,6 +3739,7 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 		Name: "column drop, then rename column with same type to same name",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c1 int, c2 int);",
+			"call dolt_add('.')",
 			"insert into t values (1, 2, 3), (4, 5, 6);",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'creating table t'));",
 
@@ -3749,6 +3827,7 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 		Name: "column drop and recreate with different type that can be coerced (int -> string)",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c int);",
+			"call dolt_add('.')",
 			"insert into t values (1, 2), (3, 4);",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'creating table t'));",
 
@@ -3790,6 +3869,7 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 		Name: "column drop and recreate with different type that can NOT be coerced (string -> int)",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c varchar(20));",
+			"call dolt_add('.')",
 			"insert into t values (1, 'two'), (3, 'four');",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'creating table t'));",
 
@@ -3838,6 +3918,7 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 		Name: "multiple column renames",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c1 int);",
+			"call dolt_add('.')",
 			"insert into t values (1, 2);",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'creating table t'));",
 
@@ -3888,6 +3969,7 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 		Name: "primary key change",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c1 int);",
+			"call dolt_add('.')",
 			"insert into t values (1, 2), (3, 4);",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'creating table t'));",
 
@@ -3923,6 +4005,7 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 		Name: "table with commit column should maintain its data in diff",
 		SetUpScript: []string{
 			"CREATE TABLE t (pk int PRIMARY KEY, commit varchar(20));",
+			"CALL DOLT_ADD('.')",
 			"CALL dolt_commit('-am', 'creating table t');",
 			"INSERT INTO t VALUES (1, 'hi');",
 			"CALL dolt_commit('-am', 'insert data');",
@@ -3938,6 +4021,7 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 		Name: "selecting to_pk columns",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c1 int, c2 int);",
+			"call dolt_add('.')",
 			"insert into t values (1, 2, 3), (4, 5, 6);",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'first commit'));",
 			"insert into t values (7, 8, 9);",
@@ -3970,6 +4054,7 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 		Name: "selecting to_pk1 and to_pk2 columns",
 		SetUpScript: []string{
 			"create table t (pk1 int, pk2 int, c1 int, primary key (pk1, pk2));",
+			"call dolt_add('.')",
 			"insert into t values (1, 2, 3), (4, 5, 6);",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'first commit'));",
 			"insert into t values (7, 8, 9);",
@@ -4036,6 +4121,7 @@ var Dolt1DiffSystemTableScripts = []queries.ScriptTest{
 		Name: "Diff table stops creating diff partitions when any primary key type has changed",
 		SetUpScript: []string{
 			"CREATE TABLE t (pk1 VARCHAR(100), pk2 VARCHAR(100), PRIMARY KEY (pk1, pk2));",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO t VALUES ('1', '1');",
 			"CALL DOLT_COMMIT('-am', 'setup');",
 
@@ -4059,6 +4145,7 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 		Name: "invalid arguments",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c1 varchar(20), c2 varchar(20));",
+			"call dolt_add('.')",
 			"set @Commit1 = dolt_commit('-am', 'creating table t');",
 
 			"insert into t values(1, 'one', 'two'), (2, 'two', 'three');",
@@ -4125,12 +4212,14 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 			"set @Commit0 = HashOf('HEAD');",
 
 			"create table t (pk int primary key, c1 varchar(20), c2 varchar(20));",
+			"call dolt_add('.')",
 			"set @Commit1 = dolt_commit('-am', 'creating table t');",
 
 			"insert into t values(1, 'one', 'two');",
 			"set @Commit2 = dolt_commit('-am', 'inserting into table t');",
 
 			"create table t2 (pk int primary key, c1 varchar(20), c2 varchar(20));",
+			"call dolt_add('.')",
 			"insert into t2 values(100, 'hundred', 'hundert');",
 			"set @Commit3 = dolt_commit('-am', 'inserting into table t2');",
 
@@ -4193,6 +4282,7 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 			"set @Commit0 = HashOf('HEAD');",
 
 			"create table t (pk int primary key, c1 text, c2 text);",
+			"call dolt_add('.')",
 			"insert into t values (1, 'one', 'two'), (2, 'three', 'four');",
 			"set @Commit1 = dolt_commit('-am', 'inserting two rows into table t');",
 
@@ -4255,6 +4345,7 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 		Name: "diff with branch refs",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c1 varchar(20), c2 varchar(20));",
+			"call dolt_add('.')",
 			"set @Commit1 = dolt_commit('-am', 'creating table t');",
 
 			"insert into t values(1, 'one', 'two');",
@@ -4302,6 +4393,7 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 		Name: "schema modification: drop and recreate column with same type",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c1 varchar(20), c2 varchar(20));",
+			"call dolt_add('.')",
 			"set @Commit1 = dolt_commit('-am', 'creating table t');",
 
 			"insert into t values(1, 'one', 'two'), (2, 'two', 'three');",
@@ -4361,6 +4453,7 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 		Name: "schema modification: rename columns",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c1 varchar(20), c2 int);",
+			"call dolt_add('.')",
 			"set @Commit1 = dolt_commit('-am', 'creating table t');",
 
 			"insert into t values(1, 'one', -1), (2, 'two', -2);",
@@ -4429,6 +4522,7 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 		Name: "schema modification: drop and rename columns with different types",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c1 varchar(20), c2 varchar(20));",
+			"call dolt_add('.')",
 			"set @Commit1 = dolt_commit('-am', 'creating table t');",
 
 			"insert into t values(1, 'one', 'asdf'), (2, 'two', '2');",
@@ -4509,6 +4603,7 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 		Name: "dropped table",
 		SetUpScript: []string{
 			"create table t1 (a int primary key, b int)",
+			"call dolt_add('.')",
 			"insert into t1 values (1,2)",
 			"call dolt_commit('-am', 'new table')",
 			"drop table t1",
@@ -4525,9 +4620,11 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 		Name: "renamed table",
 		SetUpScript: []string{
 			"create table t1 (a int primary key, b int)",
+			"call dolt_add('.')",
 			"insert into t1 values (1,2)",
 			"call dolt_commit('-am', 'new table')",
 			"alter table t1 rename to t2",
+			"call dolt_add('.')",
 			"insert into t2 values (3,4)",
 			"call dolt_commit('-am', 'renamed table')",
 		},
@@ -4606,6 +4703,7 @@ var UnscopedDiffSystemTableScriptTests = []queries.ScriptTest{
 			"create table regularTable (a int primary key, b int, c int);",
 			"create table droppedTable (a int primary key, b int, c int);",
 			"create table renamedEmptyTable (a int primary key, b int, c int);",
+			"call dolt_add('.')",
 			"insert into droppedTable values (1, 2, 3), (2, 3, 4);",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'Creating tables x and y'));",
 
@@ -4641,10 +4739,12 @@ var UnscopedDiffSystemTableScriptTests = []queries.ScriptTest{
 		SetUpScript: []string{
 			"create table x (a int primary key, b int, c int);",
 			"create table y (a int primary key, b int, c int);",
+			"call dolt_add('.')",
 			"insert into x values (1, 2, 3), (2, 3, 4);",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'Creating tables x and y'));",
 
 			"create table z (a int primary key, b int, c int);",
+			"call dolt_add('.')",
 			"insert into z values (100, 101, 102);",
 			"set @Commit2 = (select DOLT_COMMIT('-am', 'Creating tables z'));",
 
@@ -4679,18 +4779,22 @@ var UnscopedDiffSystemTableScriptTests = []queries.ScriptTest{
 		SetUpScript: []string{
 			"create table x (a int primary key, b int, c int)",
 			"create table y (a int primary key, b int, c int)",
+			"call dolt_add('.')",
 			"insert into x values (1, 2, 3), (2, 3, 4)",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'Creating tables x and y'))",
 
 			"create table z (a int primary key, b int, c int)",
+			"call dolt_add('.')",
 			"insert into z values (100, 101, 102)",
 			"set @Commit2 = (select DOLT_COMMIT('-am', 'Creating tables z'))",
 
 			"rename table x to x1",
+			"call dolt_add('.')",
 			"insert into x1 values (1000, 1001, 1002);",
 			"set @Commit3 = (select DOLT_COMMIT('-am', 'Renaming table x to x1 and inserting data'))",
 
 			"rename table x1 to x2",
+			"call dolt_add('.')",
 			"set @Commit4 = (select DOLT_COMMIT('-am', 'Renaming table x1 to x2'))",
 		},
 		Assertions: []queries.ScriptTestAssertion{
@@ -4721,6 +4825,7 @@ var UnscopedDiffSystemTableScriptTests = []queries.ScriptTest{
 		SetUpScript: []string{
 			"create table x (a int primary key, b int, c int)",
 			"create table y (a int primary key, b int, c int)",
+			"call dolt_add('.')",
 			"insert into x values (1, 2, 3), (2, 3, 4)",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'Creating tables x and y'))",
 
@@ -4754,6 +4859,7 @@ var UnscopedDiffSystemTableScriptTests = []queries.ScriptTest{
 		SetUpScript: []string{
 			"create table x (a int primary key, b int, c int)",
 			"create table y (a int primary key, b int, c int)",
+			"call dolt_add('.')",
 			"insert into x values (1, 2, 3), (2, 3, 4)",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'Creating tables x and y'))",
 
@@ -4787,11 +4893,13 @@ var UnscopedDiffSystemTableScriptTests = []queries.ScriptTest{
 			"select dolt_checkout('-b', 'branch1')",
 			"create table x (a int primary key, b int, c int)",
 			"create table y (a int primary key, b int, c int)",
+			"call dolt_add('.')",
 			"insert into x values (1, 2, 3), (2, 3, 4)",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'Creating tables x and y'))",
 
 			"select dolt_checkout('-b', 'branch2')",
 			"create table z (a int primary key, b int, c int)",
+			"call dolt_add('.')",
 			"insert into z values (100, 101, 102)",
 			"set @Commit2 = (select DOLT_COMMIT('-am', 'Creating tables z'))",
 
@@ -4827,11 +4935,13 @@ var UnscopedDiffSystemTableScriptTests = []queries.ScriptTest{
 			"select dolt_checkout('-b', 'branch1')",
 			"create table x (a int primary key, b int, c int)",
 			"create table y (a int primary key, b int, c int)",
+			"call dolt_add('.')",
 			"insert into x values (1, 2, 3), (2, 3, 4)",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'Creating tables x and y'))",
 
 			"select dolt_checkout('-b', 'branch2')",
 			"create table z (a int primary key, b int, c int)",
+			"call dolt_add('.')",
 			"insert into z values (100, 101, 102)",
 			"set @Commit2 = (select DOLT_COMMIT('-am', 'Creating tables z'))",
 
@@ -4864,6 +4974,7 @@ var CommitDiffSystemTableScriptTests = []queries.ScriptTest{
 		Name: "error handling",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c1 int, c2 int);",
+			"call dolt_add('.')",
 			"insert into t values (1, 2, 3), (4, 5, 6);",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'creating table t'));",
 		},
@@ -4887,6 +4998,7 @@ var CommitDiffSystemTableScriptTests = []queries.ScriptTest{
 		SetUpScript: []string{
 			"set @Commit0 = HASHOF('HEAD');",
 			"create table t (pk int primary key, c1 int, c2 int);",
+			"call dolt_add('.')",
 			"insert into t values (1, 2, 3), (4, 5, 6);",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'creating table t'));",
 
@@ -4942,6 +5054,7 @@ var CommitDiffSystemTableScriptTests = []queries.ScriptTest{
 		SetUpScript: []string{
 			"set @Commit0 = HASHOF('HEAD');",
 			"create table t (pk int primary key, c1 int, c2 int);",
+			"call dolt_add('.')",
 			"insert into t values (1, 2, 3), (4, 5, 6);",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'creating table t'));",
 
@@ -4971,6 +5084,7 @@ var CommitDiffSystemTableScriptTests = []queries.ScriptTest{
 		SetUpScript: []string{
 			"set @Commit0 = HASHOF('HEAD');",
 			"create table t (pk int primary key, c int);",
+			"call dolt_add('.')",
 			"insert into t values (1, 2), (3, 4);",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'creating table t'));",
 
@@ -5010,6 +5124,7 @@ var CommitDiffSystemTableScriptTests = []queries.ScriptTest{
 		SetUpScript: []string{
 			"set @Commit0 = HASHOF('HEAD');",
 			"create table t (pk int primary key, c1 int, c2 int);",
+			"call dolt_add('.')",
 			"insert into t values (1, 2, 3), (4, 5, 6);",
 			"set @Commit1 = DOLT_COMMIT('-am', 'creating table t');",
 
@@ -5052,6 +5167,7 @@ var CommitDiffSystemTableScriptTests = []queries.ScriptTest{
 		SetUpScript: []string{
 			"set @Commit0 = HASHOF('HEAD');",
 			"create table t (pk int primary key, c int);",
+			"call dolt_add('.')",
 			"insert into t values (1, 2), (3, 4);",
 			"set @Commit1 = DOLT_COMMIT('-am', 'creating table t');",
 
@@ -5090,6 +5206,7 @@ var CommitDiffSystemTableScriptTests = []queries.ScriptTest{
 		SetUpScript: []string{
 			"set @Commit0 = HASHOF('HEAD');",
 			"create table t (pk int primary key, c varchar(20));",
+			"call dolt_add('.')",
 			"insert into t values (1, 'two'), (3, 'four');",
 			"set @Commit1 = (select DOLT_COMMIT('-am', 'creating table t'));",
 
@@ -5134,6 +5251,7 @@ var CommitDiffSystemTableScriptTests = []queries.ScriptTest{
 		Name: "schema modification: primary key change",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c1 int);",
+			"call dolt_add('.')",
 			"insert into t values (1, 2), (3, 4);",
 			"set @Commit1 = DOLT_COMMIT('-am', 'creating table t');",
 
@@ -5168,6 +5286,7 @@ var verifyConstraintsSetupScript = []string{
 	"CREATE TABLE child3 (pk BIGINT PRIMARY KEY, v1 BIGINT, CONSTRAINT fk_name1 FOREIGN KEY (v1) REFERENCES parent3 (v1));",
 	"CREATE TABLE parent4 (pk BIGINT PRIMARY KEY, v1 BIGINT, INDEX (v1));",
 	"CREATE TABLE child4 (pk BIGINT PRIMARY KEY, v1 BIGINT, CONSTRAINT fk_name2 FOREIGN KEY (v1) REFERENCES parent4 (v1));",
+	"CALL DOLT_ADD('.')",
 	"INSERT INTO parent3 VALUES (1, 1);",
 	"INSERT INTO parent4 VALUES (2, 2);",
 	"SET foreign_key_checks=0;",
@@ -5535,6 +5654,7 @@ var DoltTagTestScripts = []queries.ScriptTest{
 		Name: "dolt-tag: SQL create tags",
 		SetUpScript: []string{
 			"CREATE TABLE test(pk int primary key);",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0),(1),(2);",
 			"CALL DOLT_COMMIT('-am','created table test')",
 		},
@@ -5561,6 +5681,7 @@ var DoltTagTestScripts = []queries.ScriptTest{
 		Name: "dolt-tag: SQL delete tags",
 		SetUpScript: []string{
 			"CREATE TABLE test(pk int primary key);",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0),(1),(2);",
 			"CALL DOLT_COMMIT('-am','created table test')",
 			"CALL DOLT_TAG('v1', '-m', 'create tag v1')",
@@ -5594,6 +5715,7 @@ var DoltTagTestScripts = []queries.ScriptTest{
 		Name: "dolt-tag: SQL use a tag as a ref for merge",
 		SetUpScript: []string{
 			"CREATE TABLE test(pk int primary key);",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0),(1),(2);",
 			"CALL DOLT_COMMIT('-am','created table test')",
 			"DELETE FROM test WHERE pk = 0",
@@ -5719,6 +5841,7 @@ var DoltAutoIncrementTests = []queries.ScriptTest{
 		Name: "insert on different branches",
 		SetUpScript: []string{
 			"create table t (a int primary key auto_increment, b int)",
+			"call dolt_add('.')",
 			"call dolt_commit('-am', 'empty table')",
 			"call dolt_branch('branch1')",
 			"call dolt_branch('branch2')",
@@ -5772,6 +5895,7 @@ var DoltAutoIncrementTests = []queries.ScriptTest{
 		Name: "drop table",
 		SetUpScript: []string{
 			"create table t (a int primary key auto_increment, b int)",
+			"call dolt_add('.')",
 			"call dolt_commit('-am', 'empty table')",
 			"call dolt_branch('branch1')",
 			"call dolt_branch('branch2')",
@@ -5861,6 +5985,7 @@ var BrokenAutoIncrementTests = []queries.ScriptTest{
 		Name: "truncate table",
 		SetUpScript: []string{
 			"create table t (a int primary key auto_increment, b int)",
+			"call dolt_add('.')",
 			"call dolt_commit('-am', 'empty table')",
 			"call dolt_branch('branch1')",
 			"call dolt_branch('branch2')",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -1045,6 +1045,7 @@ var HistorySystemTableScriptTests = []queries.ScriptTest{
 		Name:         "index by primary key",
 		SetUpScript: []string{
 			"create table t1 (pk int primary key, c int);",
+			"call dolt_add('.')",
 			"insert into t1 values (1,2), (3,4)",
 			"set @Commit1 = dolt_commit('-am', 'initial table');",
 			"insert into t1 values (5,6), (7,8)",
@@ -1081,6 +1082,7 @@ var HistorySystemTableScriptTests = []queries.ScriptTest{
 		Name:         "adding an index",
 		SetUpScript: []string{
 			"create table t1 (pk int primary key, c int);",
+			"call dolt_add('.')",
 			"insert into t1 values (1,2), (3,4)",
 			"set @Commit1 = dolt_commit('-am', 'initial table');",
 			"insert into t1 values (5,6), (7,8)",
@@ -1148,6 +1150,7 @@ var BrokenHistorySystemTableScriptTests = []queries.ScriptTest{
 		Name: "index by primary key",
 		SetUpScript: []string{
 			"create table t1 (pk int primary key, c int);",
+			"call dolt_add('.')",
 			"insert into t1 values (1,2), (3,4)",
 			"set @Commit1 = dolt_commit('-am', 'initial table');",
 			"insert into t1 values (5,6), (7,8)",
@@ -1183,6 +1186,7 @@ var BrokenHistorySystemTableScriptTests = []queries.ScriptTest{
 		Name: "adding an index",
 		SetUpScript: []string{
 			"create table t1 (pk int primary key, c int);",
+			"call dolt_add('.')",
 			"insert into t1 values (1,2), (3,4)",
 			"set @Commit1 = dolt_commit('-am', 'initial table');",
 			"insert into t1 values (5,6), (7,8)",
@@ -1254,6 +1258,7 @@ var MergeScripts = []queries.ScriptTest{
 			"SELECT DOLT_CHECKOUT('-b', 'feature-branch')",
 			"INSERT INTO test VALUES (3);",
 			"UPDATE test SET pk=1000 WHERE pk=0;",
+			"CALL DOLT_ADD('.');",
 			"SELECT DOLT_COMMIT('-a', '-m', 'this is a ff');",
 			"SELECT DOLT_CHECKOUT('main');",
 		},
@@ -1319,7 +1324,7 @@ var MergeScripts = []queries.ScriptTest{
 		Name: "CALL DOLT_MERGE without conflicts correctly works with autocommit off with commit flag",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key)",
-			"call DOLT_ADD('.')",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0),(1),(2);",
 			"SET autocommit = 0",
 			"SELECT DOLT_COMMIT('-a', '-m', 'Step 1', '--date', '2022-08-06T12:00:01');",
@@ -1354,6 +1359,7 @@ var MergeScripts = []queries.ScriptTest{
 		Name: "CALL DOLT_MERGE without conflicts correctly works with autocommit off and no commit flag",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key)",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0),(1),(2);",
 			"SET autocommit = 0",
 			"SELECT DOLT_COMMIT('-a', '-m', 'Step 1', '--date', '2022-08-06T12:00:01');",
@@ -1618,6 +1624,7 @@ var MergeScripts = []queries.ScriptTest{
 		Name: "CALL DOLT_MERGE with no conflicts works with no-commit flag",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key)",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0),(1),(2);",
 			"SELECT DOLT_COMMIT('-a', '-m', 'Step 1', '--date', '2022-08-06T12:00:00');",
 			"SELECT DOLT_CHECKOUT('-b', 'feature-branch')",
@@ -4095,6 +4102,7 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 			"CREATE TABLE t (pk1 int PRIMARY KEY);",
 			"INSERT INTO t values (1);",
 			"CREATE table t2 (pk1a int, pk1b int, PRIMARY KEY (pk1a, pk1b));",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO t2 values (2, 2);",
 			"CALL DOLT_COMMIT('-am', 'initial');",
 
@@ -4647,6 +4655,7 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 			"INSERT INTO t1 VALUES (1, 1);",
 			"CREATE TABLE t2 (pk1a int, pk1b int, col1 int, PRIMARY KEY (pk1a, pk1b));",
 			"INSERT INTO t2 VALUES (1, 1, 1);",
+			"CALL DOLT_ADD('.')",
 			"CALL DOLT_COMMIT('-am', 'initial');",
 
 			"ALTER TABLE t1 RENAME COLUMN pk to pk2;",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_transaction_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_transaction_queries.go
@@ -761,6 +761,7 @@ var DoltConflictHandlingTests = []queries.TransactionTest{
 		Name: "default behavior (rollback on commit conflict)",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key, val int)",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0, 0)",
 			"SELECT DOLT_COMMIT('-a', '-m', 'initial table');",
 		},
@@ -811,6 +812,7 @@ var DoltConflictHandlingTests = []queries.TransactionTest{
 		Name: "allow commit conflicts on, conflict on transaction commit",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key, val int)",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0, 0)",
 			"SELECT DOLT_COMMIT('-a', '-m', 'initial table');",
 		},
@@ -861,6 +863,7 @@ var DoltConflictHandlingTests = []queries.TransactionTest{
 		Name: "force commit on, conflict on transaction commit (same as dolt_allow_commit_conflicts)",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key, val int)",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0, 0)",
 			"SELECT DOLT_COMMIT('-a', '-m', 'initial table');",
 		},
@@ -911,6 +914,7 @@ var DoltConflictHandlingTests = []queries.TransactionTest{
 		Name: "allow commit conflicts on, conflict on dolt_merge",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key, val int)",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0, 0)",
 			"SELECT DOLT_COMMIT('-a', '-m', 'initial table');",
 		},
@@ -1001,6 +1005,7 @@ var DoltConflictHandlingTests = []queries.TransactionTest{
 		Name: "force commit on, conflict on dolt_merge (same as dolt_allow_commit_conflicts)",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key, val int)",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0, 0)",
 			"SELECT DOLT_COMMIT('-a', '-m', 'initial table');",
 		},
@@ -1089,6 +1094,7 @@ var DoltConflictHandlingTests = []queries.TransactionTest{
 		Name: "allow commit conflicts off, conflict on dolt_merge",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key, val int)",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0, 0)",
 			"SELECT DOLT_COMMIT('-a', '-m', 'initial table');",
 		},
@@ -1159,6 +1165,7 @@ var DoltConflictHandlingTests = []queries.TransactionTest{
 		Name: "conflicts from a DOLT_MERGE return an initially unhelpful error in a concurrent write scenario",
 		SetUpScript: []string{
 			"CREATE TABLE t (pk int PRIMARY KEY, col1 int);",
+			"CALL DOLT_ADD('.')",
 			"CALL DOLT_COMMIT('-am', 'create table');",
 
 			"CALL DOLT_CHECKOUT('-b', 'right');",
@@ -1341,6 +1348,7 @@ var DoltSqlFuncTransactionTests = []queries.TransactionTest{
 		Name: "committed conflicts are seen by other sessions",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key, val int)",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO test VALUES (0, 0)",
 			"SELECT DOLT_COMMIT('-a', '-m', 'Step 1');",
 			"SELECT DOLT_CHECKOUT('-b', 'feature-branch')",
@@ -1482,6 +1490,7 @@ var DoltConstraintViolationTransactionTests = []queries.TransactionTest{
 		Name: "Constraint violations created by DOLT_MERGE should cause a roll back",
 		SetUpScript: []string{
 			"CREATE TABLE t (pk int PRIMARY KEY, col1 int UNIQUE);",
+			"CALL DOLT_ADD('.')",
 			"CALL DOLT_COMMIT('-am', 'create table');",
 
 			"CALL DOLT_CHECKOUT('-b', 'right');",
@@ -1515,6 +1524,7 @@ var DoltConstraintViolationTransactionTests = []queries.TransactionTest{
 		SetUpScript: []string{
 			"CREATE TABLE parent (pk BIGINT PRIMARY KEY, v1 BIGINT, INDEX(v1));",
 			"CREATE TABLE child (pk BIGINT PRIMARY KEY, v1 BIGINT);",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO parent VALUES (10, 1), (20, 2);",
 			"INSERT INTO child VALUES (1, 1), (2, 2);",
 			"ALTER TABLE child ADD CONSTRAINT fk_name FOREIGN KEY (v1) REFERENCES parent (v1);",
@@ -1544,6 +1554,7 @@ var DoltConstraintViolationTransactionTests = []queries.TransactionTest{
 		SetUpScript: []string{
 			"CREATE TABLE parent (pk BIGINT PRIMARY KEY, v1 BIGINT, INDEX(v1));",
 			"CREATE TABLE child (pk BIGINT PRIMARY KEY, v1 BIGINT);",
+			"CALL DOLT_ADD('.')",
 			"INSERT INTO parent VALUES (10, 1), (20, 2);",
 			"INSERT INTO child VALUES (1, 1), (2, 2);",
 			"ALTER TABLE child ADD CONSTRAINT fk_name FOREIGN KEY (v1) REFERENCES parent (v1);",

--- a/integration-tests/bats/auto_increment.bats
+++ b/integration-tests/bats/auto_increment.bats
@@ -440,6 +440,7 @@ CREATE TABLE t (
     c0 int
 );
 
+CALL DOLT_ADD('.');
 INSERT INTO t (c0) VALUES (1), (2);
 SELECT DOLT_COMMIT('-a', '-m', 'cm1');
 SELECT DOLT_CHECKOUT('-b', 'test');
@@ -471,6 +472,7 @@ CREATE TABLE t (
     c0 int
 );
 
+CALL DOLT_ADD('.');
 INSERT INTO t (c0) VALUES (1), (2);
 SELECT DOLT_COMMIT('-a', '-m', 'cm1');
 SELECT DOLT_CHECKOUT('-b', 'test');
@@ -504,6 +506,7 @@ CREATE TABLE t (
     c0 int
 );
 
+CALL DOLT_ADD('.');
 INSERT INTO t (c0) VALUES (1), (2);
 SELECT DOLT_COMMIT('-a', '-m', 'cm1');
 SELECT DOLT_CHECKOUT('-b', 'test');
@@ -537,6 +540,7 @@ CREATE TABLE t (
     c0 int
 );
 
+CALL DOLT_ADD('.');
 INSERT INTO t VALUES (4, 4), (5, 5);
 SELECT DOLT_COMMIT('-a', '-m', 'cm1');
 SELECT DOLT_CHECKOUT('-b', 'test');
@@ -697,6 +701,7 @@ SQL
 
 @test "auto_increment: globally distinct auto increment values" {
     dolt sql  <<SQL
+call dolt_add('.');
 call dolt_commit('-am', 'empty table');
 call dolt_branch('branch1');
 call dolt_branch('branch2');
@@ -734,6 +739,7 @@ SQL
     dolt checkout main
     dolt sql  <<SQL
 create table t1 (ai bigint primary key auto_increment, c0 int);
+call dolt_add('.');
 call dolt_commit('-am', 'empty table');
 call dolt_branch('branch3');
 call dolt_branch('branch4');

--- a/integration-tests/bats/backup.bats
+++ b/integration-tests/bats/backup.bats
@@ -11,6 +11,7 @@ setup() {
     dolt init
     dolt tag v1
     dolt sql -q "create table t1 (a int)"
+    dolt add .
     dolt commit -am "cm"
     dolt branch feature
     dolt remote add origin file://../rem1
@@ -187,6 +188,7 @@ teardown() {
     cd .. && mkdir repo2 && cd repo2
     dolt init
     dolt sql -q "create table s1 (a int)"
+    dolt add .
     dolt commit -am "cm"
 
     dolt backup add bac1 file://../bac1

--- a/integration-tests/bats/checkout.bats
+++ b/integration-tests/bats/checkout.bats
@@ -15,6 +15,7 @@ teardown() {
 create table test(a int primary key);
 insert into test values (1);
 SQL
+    dolt add .
 
     dolt commit -am "Initial table with one row"
     dolt branch feature
@@ -59,6 +60,7 @@ create table test(a int primary key);
 insert into test values (1);
 SQL
 
+    dolt add .
     dolt commit -am "Initial table with one row"
     dolt branch feature
 

--- a/integration-tests/bats/cherry-pick.bats
+++ b/integration-tests/bats/cherry-pick.bats
@@ -5,6 +5,7 @@ setup() {
     setup_common
 
     dolt sql -q "CREATE TABLE test(pk BIGINT PRIMARY KEY, v varchar(10))"
+    dolt add .
     dolt commit -am "Created table"
     dolt checkout -b branch1
     dolt sql -q "INSERT INTO test VALUES (1, 'a')"
@@ -103,6 +104,7 @@ teardown() {
 
 @test "cherry-pick: insert, update, delete rows and schema changes on non existent table in working set" {
     dolt sql -q "CREATE TABLE branch1table (id int primary key, col1 int)"
+    dolt add .
     dolt sql -q "INSERT INTO branch1table VALUES (9,8),(7,6),(5,4)"
     dolt commit -am "create table with rows"
 
@@ -156,12 +158,14 @@ teardown() {
 
 @test "cherry-pick: row data conflict, leave working set clean" {
     dolt sql -q "CREATE TABLE other (pk int primary key, v int)"
+    dolt add .
     dolt sql -q "INSERT INTO other VALUES (1, 2)"
     dolt sql -q "INSERT INTO test VALUES (4,'f')"
     dolt commit -am "add other table"
 
     dolt checkout main
     dolt sql -q "CREATE TABLE other (pk int primary key, v int)"
+    dolt add .
     dolt sql -q "INSERT INTO other VALUES (1, 3)"
     dolt sql -q "INSERT INTO test VALUES (4,'k')"
     dolt commit -am "add other table with conflict and test with conflict"
@@ -176,6 +180,7 @@ teardown() {
 
 @test "cherry-pick: commit with CREATE TABLE" {
     dolt sql -q "CREATE TABLE table_a (pk BIGINT PRIMARY KEY, v varchar(10))"
+    dolt add .
     dolt sql -q "INSERT INTO table_a VALUES (11, 'aa'), (22, 'ab'), (33, 'ac')"
     dolt sql -q "DELETE FROM test WHERE pk = 2"
     dolt commit -am "Added table_a with rows and delete pk=2 from test"
@@ -220,6 +225,7 @@ teardown() {
 
 @test "cherry-pick: commit with ALTER TABLE rename table name" {
     dolt sql -q "ALTER TABLE test RENAME TO new_name"
+    dolt add .
     dolt commit -am "rename table name"
 
     dolt checkout main
@@ -274,6 +280,7 @@ teardown() {
     run dolt sql -q "SELECT * FROM test"
     [[ "$output" =~ "z inserted" ]] || false
 
+    dolt add .
     dolt commit -am "add trigger"
 
     dolt checkout main
@@ -305,6 +312,7 @@ teardown() {
     run dolt sql -q "CALL proc1(434)"
     [[ "$output" =~ "434" ]] || false
 
+    dolt add .
     dolt commit -am "add procedure"
 
     dolt checkout main
@@ -324,6 +332,7 @@ teardown() {
 @test "cherry-pick: keyless table" {
     dolt checkout main
     dolt sql -q "CREATE TABLE keyless (id int, name varchar(10))"
+    dolt add .
     dolt commit -am "add keyless table"
 
     dolt checkout -b branch2

--- a/integration-tests/bats/config.bats
+++ b/integration-tests/bats/config.bats
@@ -209,6 +209,7 @@ teardown() {
 
     dolt init
     dolt sql -q "CREATE TABLE test (pk int primary key)"
+    dolt add .
 
     dolt config --global --unset user.name
     dolt config --global --unset user.email
@@ -229,6 +230,7 @@ teardown() {
     CREATE TABLE test (
        pk int primary key
     )"
+    dolt add .
 
     dolt config --global --unset user.name
     dolt config --global --unset user.email
@@ -242,6 +244,7 @@ teardown() {
     [[ "$output" =~ "created table test" ]] || false
 
     dolt sql -q "create table test2 (pk int primary key)"
+    dolt add .
     
     dolt config --global --add user.name "bats tester"
 

--- a/integration-tests/bats/conflict-cat.bats
+++ b/integration-tests/bats/conflict-cat.bats
@@ -16,6 +16,7 @@ INSERT INTO t VALUES (1, 1);
 INSERT INTO t VALUES (2, 2);
 INSERT INTO t VALUES (3, 3);
 SQL
+    dolt add .
     dolt commit -am 'create table with rows'
 
     dolt checkout -b other
@@ -55,6 +56,7 @@ SQL
 
 @test "conflict-cat: conflicts should show using the union-schema (new schema on right)" {
     dolt sql -q "CREATE TABLE t (a INT PRIMARY KEY, b INT);"
+    dolt add .
     dolt commit -am "base"
 
     dolt checkout -b right
@@ -78,6 +80,7 @@ SQL
 
 @test "conflict-cat: conflicts should show using the union-schema (new schema on left)" {
     dolt sql -q "CREATE TABLE t (a INT PRIMARY KEY, b INT);"
+    dolt add .
     dolt commit -am "base"
 
     dolt checkout -b right

--- a/integration-tests/bats/constraint-violations.bats
+++ b/integration-tests/bats/constraint-violations.bats
@@ -2842,6 +2842,7 @@ CREATE TABLE t (
   pk int PRIMARY KEY,
   col1 int
 );
+CALL DOLT_ADD('.');
 
 CALL DOLT_COMMIT('-am', 'create table');
 CALL DOLT_BRANCH('right');

--- a/integration-tests/bats/create-views.bats
+++ b/integration-tests/bats/create-views.bats
@@ -239,6 +239,7 @@ SQL
 @test "create-views: AS OF" {
     dolt sql <<SQL
 create table t1 (a int primary key, b int);
+call dolt_add('.');
 insert into t1 values (1,1);
 select dolt_commit('-am', 'table with one row');
 select dolt_branch('onerow');
@@ -246,9 +247,11 @@ insert into t1 values (2,2);
 select dolt_commit('-am', 'table with two rows');
 select dolt_branch('tworows');
 create view v1 as select * from t1;
+call dolt_add('.');
 select dolt_commit('-am', 'view with select *');
 select dolt_branch('view');
 insert into t1 values (3,3);
+call dolt_add('.');
 select dolt_commit('-am', 'table with three rows');
 select dolt_branch('threerows');
 drop view v1;

--- a/integration-tests/bats/diff.bats
+++ b/integration-tests/bats/diff.bats
@@ -1007,6 +1007,7 @@ CREATE TABLE t1 (pk int PRIMARY KEY, col1 int);
 INSERT INTO t1 VALUES (1, 1);
 CREATE TABLE t2 (pk1a int, pk1b int, col1 int, PRIMARY KEY (pk1a, pk1b));
 INSERT INTO t2 VALUES (1, 1, 1);
+SELECT DOLT_ADD('.');
 SQL
     dolt commit -am "initial"
 
@@ -1016,6 +1017,7 @@ UPDATE t1 set col1 = 100;
 ALTER TABLE t2 RENAME COLUMN pk1a to pk2a;
 ALTER TABLE t2 RENAME COLUMN pk1b to pk2b;
 UPDATE t2 set col1 = 100;
+SELECT DOLT_ADD('.');
 SQL
     dolt commit -am 'rename primary key'
 

--- a/integration-tests/bats/diff.bats
+++ b/integration-tests/bats/diff.bats
@@ -77,6 +77,7 @@ create table test (pk int primary key, c1 int, c2 int);
 insert into test values (1,2,3);
 insert into test values (4,5,6);
 SQL
+    dolt add .
     dolt commit -am "First commit"
 
     dolt sql <<SQL
@@ -153,6 +154,7 @@ EOF
 }
 
 @test "diff: data diff only" {
+    dolt add .
     dolt commit -am "First commit"
 
     dolt sql -q "insert into test (pk) values (10);"
@@ -166,6 +168,7 @@ EOF
 }
 
 @test "diff: schema changes only" {
+    dolt add .
     dolt commit -am "First commit"
 
     dolt sql <<SQL
@@ -541,6 +544,7 @@ SQL
 
 @test "diff: diff summary incorrect primary key set change regression test" {
     dolt sql -q "create table testdrop (col1 varchar(20), id int primary key, col2 varchar(20))"
+    dolt add .
     dolt sql -q "insert into testdrop values ('test1', 1, 'test2')"
     dolt commit -am "Add testdrop table"
 
@@ -682,6 +686,7 @@ SQL
 
 @test "diff: sql update queries only show changed columns" {
     dolt sql -q "create table t(pk int primary key, val1 int, val2 int)"
+    dolt add .
     dolt sql -q "INSERT INTO t VALUES (1, 1, 1)"
 
     dolt commit -am "cm1"
@@ -718,6 +723,7 @@ SQL
 @test "diff: keyless sql diffs" {
     
     dolt sql -q "create table t(pk int, val int)"
+    dolt add .
     dolt commit -am "cm1"
 
     dolt sql -q "INSERT INTO t values (1, 1)"
@@ -780,6 +786,7 @@ SQL
 create table t(pk int, val int);
 insert into t values (1,1);
 SQL
+    dolt add .
     dolt commit -am "creating table"
 
     dolt sql -q "alter table t add primary key (pk)"
@@ -816,6 +823,7 @@ SQL
 
 @test "diff: created and dropped tables include schema and data changes in results" {
   dolt sql -q "create table a(pk int primary key)"
+  dolt add .
   dolt commit -am "creating table a"
   dolt sql -q "insert into a values (1), (2)"
   dolt commit -am "inserting data into table a"
@@ -840,6 +848,7 @@ SQL
 
 @test "diff: large diff does not drop rows" {
     dolt sql -q "create table t(pk int primary key, val int)"
+    dolt add .
 
     VALUES=""
     for i in {1..1000}

--- a/integration-tests/bats/doltpy.bats
+++ b/integration-tests/bats/doltpy.bats
@@ -10,6 +10,7 @@ CREATE TABLE foo (
   PRIMARY KEY (a)
 );
 INSERT INTO foo VALUES (0,0), (1,1);
+CALL DOLT_ADD('.');
 SELECT DOLT_COMMIT('-am', 'Initialize table');
 SQL
 }

--- a/integration-tests/bats/drop-create.bats
+++ b/integration-tests/bats/drop-create.bats
@@ -14,6 +14,7 @@ teardown() {
     dolt sql  <<SQL
 create table test(a int primary key, b int null);
 insert into test values (1,1), (2,2);
+call dolt_add('.');
 select dolt_commit("-am", "table with two rows");
 SQL
 
@@ -40,6 +41,7 @@ SQL
 @test "drop-create: same schema and data, commit after drop" {
     dolt sql  <<SQL
 create table test(a int primary key, b int null);
+call dolt_add('.');
 insert into test values (1,1), (2,2);
 select dolt_commit("-am", "table with two rows");
 SQL
@@ -77,6 +79,7 @@ SQL
 @test "drop-create: added column" {
     dolt sql  <<SQL
 create table test(a int primary key, b int null);
+call dolt_add('.');
 insert into test values (1,1), (2,2);
 select dolt_commit("-am", "table with two rows");
 SQL
@@ -131,6 +134,7 @@ EOF
 @test "drop-create: added column with data modifications" {
     dolt sql  <<SQL
 create table test(a int primary key, b int null);
+call dolt_add('.');
 insert into test values (1,1), (2,2);
 select dolt_commit("-am", "table with two rows");
 SQL
@@ -168,6 +172,7 @@ SQL
 @test "drop-create: dropped column" {
     dolt sql  <<SQL
 create table test(a int primary key, b int null, c int null);
+call dolt_add('.');
 insert into test values (1,2,3), (4,5,6);
 select dolt_commit("-am", "table with two rows");
 SQL
@@ -204,6 +209,7 @@ SQL
 @test "drop-create: dropped column with data modifications" {
     dolt sql  <<SQL
 create table test(a int primary key, b int null, c int null);
+call dolt_add('.');
 insert into test values (1,2,3), (4,5,6);
 select dolt_commit("-am", "table with two rows");
 SQL
@@ -241,6 +247,7 @@ SQL
 @test "drop-create: added column, modified column" {
     dolt sql  <<SQL
 create table test(a int primary key, b int null);
+call dolt_add('.');
 insert into test values (1,1), (2,2);
 select dolt_commit("-am", "table with two rows");
 SQL
@@ -290,6 +297,7 @@ EOF
 @test "drop-create: constraint changes" {
     dolt sql  <<SQL
 create table test(a int primary key, b int null);
+call dolt_add('.');
 insert into test values (1,1), (2,2);
 select dolt_commit("-am", "table with two rows");
 SQL
@@ -330,6 +338,7 @@ SQL
 @test "drop-create: default changes" {
     dolt sql  <<SQL
 create table test(a int primary key, b int null default 10);
+call dolt_add('.');
 insert into test values (1,1), (2,2);
 select dolt_commit("-am", "table with two rows");
 SQL

--- a/integration-tests/bats/export-tables.bats
+++ b/integration-tests/bats/export-tables.bats
@@ -111,6 +111,7 @@ if rows[2] != "9,8,7,6,5,4".split(","):
     # string columns
     dolt sql -q "create table strings (a varchar(10) primary key, b char(10))"
     dolt sql -q "insert into strings values ('abc', '123'), ('def', '456')"
+    dolt add .
     dolt commit -am "Checkpoint"
 
     dolt table export strings -f export.sql
@@ -122,6 +123,7 @@ if rows[2] != "9,8,7,6,5,4".split(","):
     # enum columns
     dolt sql -q "create table enums (a varchar(10) primary key, b enum('one','two','three'))"
     dolt sql -q "insert into enums values ('abc', 'one'), ('def', 'two')"
+    dolt add .
     dolt commit -am "Checkpoint"
 
     dolt table export enums -f export.sql
@@ -137,6 +139,7 @@ create table sets (a varchar(10) primary key, b set('one','two','three'));
 insert into sets values ('abc', 'one,two'), ('def', 'two,three');
 SQL
     
+    dolt add .
     dolt commit -am "Checkpoint"
 
     dolt table export sets -f export.sql
@@ -148,6 +151,7 @@ SQL
 
     # json columns
     dolt sql -q "create table json_vals (a varchar(10) primary key, b json)"
+    dolt add .
     dolt sql <<SQL
     insert into json_vals values ('abc', '{"key": "value"}'), ('def', '[{"a": "b"},{"conjuction": "it\'s"}]');
 SQL
@@ -192,6 +196,7 @@ alter table one add foreign key (b) references two (c);
 alter table two add foreign key (d) references one (a);
 SQL
 
+    dolt add .
     dolt commit -am "Added tables and data"
     
     dolt table export one one.sql

--- a/integration-tests/bats/foreign-keys-invert-pk.bats
+++ b/integration-tests/bats/foreign-keys-invert-pk.bats
@@ -10,6 +10,7 @@ create table b (x int, y int, primary key (y,x), foreign key (y) references a(y)
 insert into a values (4,0), (3,1), (2,2);
 insert into b values (2,1), (4,2), (3,0);
 SQL
+    dolt add .
 }
 
 teardown() {

--- a/integration-tests/bats/import-update-tables.bats
+++ b/integration-tests/bats/import-update-tables.bats
@@ -344,6 +344,7 @@ DELIM
 
     dolt sql < 1pk5col-ints-sch.sql
     dolt table import -u --continue test 1pk5col-rpt-ints.csv
+    dolt add .
     dolt commit -am "cm1"
 
     run dolt table import -u --continue test 1pk5col-rpt-ints.csv

--- a/integration-tests/bats/index.bats
+++ b/integration-tests/bats/index.bats
@@ -18,6 +18,7 @@ CREATE TABLE twopk (
   PRIMARY KEY(pk1, pk2)
 );
 SQL
+    dolt add .
 }
 
 teardown() {

--- a/integration-tests/bats/json-diff.bats
+++ b/integration-tests/bats/json-diff.bats
@@ -58,6 +58,7 @@ teardown() {
     dolt sql <<SQL
 drop table test;
 create table test (pk int primary key, c1 int, c2 int);
+call dolt_add('.');
 insert into test values (1,2,3);
 insert into test values (4,5,6);
 SQL
@@ -215,6 +216,7 @@ SQL
 
 @test "json-diff: keyless table" {
     dolt sql -q "create table t(pk int, val int)"
+    dolt add .
     dolt commit -am "cm1"
 
     dolt sql -q "INSERT INTO t values (1, 1)"
@@ -259,6 +261,7 @@ SQL
 create table t(pk int, val int);
 insert into t values (1,1);
 SQL
+    dolt add .
     dolt commit -am "creating table"
 
     dolt sql -q "alter table t add primary key (pk)"

--- a/integration-tests/bats/keyless.bats
+++ b/integration-tests/bats/keyless.bats
@@ -11,6 +11,7 @@ CREATE TABLE keyless (
 );
 INSERT INTO keyless VALUES (0,0),(2,2),(1,1),(1,1);
 SQL
+    dolt add .
     dolt commit -am "init"
 }
 
@@ -363,6 +364,7 @@ INSERT INTO dupe (c0,c1) VALUES
     (1,1),(1,1),(1,1),(1,1),(1,1),
     (1,1),(1,1),(1,1),(1,1),(1,1);
 SQL
+    dolt add .
     dolt commit -am "created table dupe"
 }
 

--- a/integration-tests/bats/log.bats
+++ b/integration-tests/bats/log.bats
@@ -123,6 +123,7 @@ teardown() {
 
 @test "log: Log on a table has basic functionality" {
     dolt sql -q "create table test (pk int PRIMARY KEY)"
+    dolt add .
     dolt commit -am "first commit"
 
     run dolt log test
@@ -140,6 +141,7 @@ teardown() {
     [[ ! "$output" =~ "Initialize data repository" ]] || false
 
     dolt sql -q "create table test2 (pk int PRIMARY KEY)"
+    dolt add .
     dolt commit -am "third commit"
 
     # Validate we only look at the right commits
@@ -153,6 +155,7 @@ teardown() {
 
 @test "log: Log on a table works with -n" {
     dolt sql -q "create table test (pk int PRIMARY KEY)"
+    dolt add .
     dolt commit -am "first commit"
 
     run dolt log -n 1 test
@@ -168,6 +171,7 @@ teardown() {
     [[ "$output" =~ "first commit" ]] || false
 
     dolt sql -q "create table test2 (pk int PRIMARY KEY)"
+    dolt add .
     dolt commit -am "third commit"
 
     dolt sql -q "insert into test2 values (4)"

--- a/integration-tests/bats/merge.bats
+++ b/integration-tests/bats/merge.bats
@@ -448,6 +448,7 @@ CREATE TABLE test (
 );
 INSERT INTO test VALUES (1, 0, 0);
 SQL
+    dolt add .
     dolt commit -am "initial data"
     dolt branch right
 
@@ -490,6 +491,7 @@ SQL
 create table test3 (a int primary key);
 INSERT INTO test3 VALUES (0), (1);
 SQL
+    dolt add .
     dolt commit -am "new table test3"
 
     dolt checkout main
@@ -656,6 +658,7 @@ CREATE table child (pk int PRIMARY KEY, parent_fk int, FOREIGN KEY (parent_fk) R
 CREATE table other (pk int);
 INSERT INTO parent VALUES (1, 1);
 SQL
+    dolt add .
     dolt commit -am "create table with data";
     dolt branch right
     dolt sql -q "DELETE FROM parent where pk = 1;"
@@ -686,6 +689,7 @@ CREATE table parent (pk int PRIMARY KEY, col1 int);
 CREATE table child (pk int PRIMARY KEY, parent_fk int, FOREIGN KEY (parent_fk) REFERENCES parent(pk));
 INSERT INTO parent VALUES (1, 1), (2, 1);
 SQL
+    dolt add .
     dolt commit -am "create table with data";
     dolt branch other
     dolt branch other2
@@ -745,6 +749,7 @@ CREATE table parent (pk int PRIMARY KEY, col1 int);
 CREATE table child (pk int PRIMARY KEY, parent_fk int, FOREIGN KEY (parent_fk) REFERENCES parent(pk));
 INSERT INTO parent VALUES (1, 1), (2, 1);
 SQL
+    dolt add .
     dolt commit -am "create table with data";
     dolt branch other
     dolt branch other2
@@ -832,6 +837,7 @@ SQL
 
     dolt checkout main
     dolt sql -q "ALTER TABLE test1 RENAME TO new_name"
+    dolt add .
     dolt commit -am "rename test1"
 
     run dolt merge merge_branch
@@ -842,6 +848,7 @@ SQL
 @test "merge: ourRoot modifies, theirRoot renames" {
     dolt checkout -b merge_branch
     dolt sql -q "ALTER TABLE test1 RENAME TO new_name"
+    dolt add .
     dolt commit -am "rename test1"
 
     dolt checkout main

--- a/integration-tests/bats/migrate.bats
+++ b/integration-tests/bats/migrate.bats
@@ -168,6 +168,7 @@ CALL dadd('-A');
 CALL dcommit('-am', 'added table test');
 SQL
     dolt docs read README.md README.md
+    dolt add .
     dolt commit -am "added a README"
 
     dolt migrate

--- a/integration-tests/bats/multidb.bats
+++ b/integration-tests/bats/multidb.bats
@@ -30,7 +30,7 @@ teardown() {
 @test "multidb: database default branches" {
     cd dbs1
     start_multi_db_server repo1
-    server_query repo1 1 dolt "" "create database new; use new; call dcheckout('-b', 'feat'); create table t (x int); call dcommit('-am', 'cm'); set @@global.new_default_branch='feat'"
+    server_query repo1 1 dolt "" "create database new; use new; call dcheckout('-b', 'feat'); create table t (x int); call dolt_add('.'); call dcommit('-am', 'cm'); set @@global.new_default_branch='feat'"
     server_query repo1 1 "use repo1"
 }
 

--- a/integration-tests/bats/multiple-tables.bats
+++ b/integration-tests/bats/multiple-tables.bats
@@ -100,6 +100,7 @@ teardown() {
 }
 
 @test "multiple-tables: dolt commit with -a flag adds all changes" {
+    dolt add .
     dolt sql -q "insert into test1 values (0, 1, 2, 3, 4, 5)"
     dolt sql -q "insert into test2 values (0, 1, 2, 3, 4, 5)"
     run dolt commit -a -m "Commit1"

--- a/integration-tests/bats/primary-key-changes.bats
+++ b/integration-tests/bats/primary-key-changes.bats
@@ -220,6 +220,7 @@ teardown() {
 
 @test "primary-key-changes: ff merge with primary key schema differences correctly works" {
     dolt sql -q "create table t(pk int PRIMARY KEY, val1 int, val2 int)"
+    dolt add .
     dolt sql -q "INSERT INTO t values (1,1,1)"
 
     dolt commit -am "cm1"
@@ -238,6 +239,7 @@ teardown() {
 
 @test "primary-key-changes: merge on branch with primary key dropped throws an error" {
     dolt sql -q "create table t(pk int PRIMARY KEY, val1 int, val2 int)"
+    dolt add .
     dolt sql -q "INSERT INTO t values (1,1,1)"
     dolt commit -am "cm1"
     dolt checkout -b test
@@ -264,6 +266,7 @@ teardown() {
 
 @test "primary-key-changes: merge on branch with primary key added throws an error" {
     dolt sql -q "create table t(pk int, val1 int, val2 int)"
+    dolt add .
     dolt sql -q "INSERT INTO t values (1,1,1)"
     dolt commit -am "cm1"
     dolt checkout -b test
@@ -290,6 +293,7 @@ teardown() {
 
 @test "primary-key-changes: diff on primary key schema change shows schema level diff but does not show row level diff" {
     dolt sql -q "CREATE TABLE t (pk int PRIMARY KEY, val int)"
+    dolt add .
     dolt sql -q "INSERT INTO t VALUES (1, 1)"
     dolt commit -am "cm1"
 
@@ -312,6 +316,7 @@ teardown() {
 
 @test "primary-key-changes: diff on composite schema" {
     dolt sql -q "CREATE TABLE t (pk int PRIMARY KEY, val int)"
+    dolt add .
     dolt sql -q "INSERT INTO t VALUES (1, 1)"
     dolt commit -am "cm1"
 
@@ -413,6 +418,7 @@ SQL
 
 @test "primary-key-changes: test whether dolt_commit_diff correctly returns a diff whether there is or isn't a schema change" {
     dolt sql -q "CREATE TABLE t (pk int PRIMARY KEY, val int)"
+    dolt add .
     dolt commit -am "cm0"
 
     dolt sql -q "INSERT INTO t VALUES (1, 1)"
@@ -455,6 +461,7 @@ SQL
 @test "primary-key-changes: dolt constraints verify works gracefully with schema violations" {
 
     dolt sql -q "CREATE table t (pk int primary key, val int)"
+    dolt add .
     dolt commit -am "cm1"
 
     dolt sql -q "alter table t drop primary key"
@@ -469,6 +476,7 @@ SQL
 
 @test "primary-key-changes: add/drop primary key in different order" {
     dolt sql -q "CREATE table t (pk int primary key, val int)"
+    dolt add .
     dolt commit -am "cm1"
 
     dolt sql -q "alter table t drop primary key"
@@ -494,6 +502,7 @@ SQL
 
 @test "primary-key-changes: same primary key set in different order is detected and blocked on merge" {
     dolt sql -q "CREATE table t (pk int, val int, primary key (pk, val))"
+    dolt add .
     dolt commit -am "cm1"
 
     dolt checkout -b test
@@ -553,6 +562,7 @@ SQL
 
 @test "primary-key-changes: column with duplicates throws an error when added as pk" {
     dolt sql -q "CREATE table t (pk int, val int)"
+    dolt add .
     dolt sql -q "INSERT INTO t VALUES (1,1),(2,1)"
     dolt commit -am "cm1"
 

--- a/integration-tests/bats/remotes-sql-server.bats
+++ b/integration-tests/bats/remotes-sql-server.bats
@@ -25,6 +25,7 @@ setup() {
     dolt remote add remote1 file://../rem1
     cd ../repo1
     dolt sql -q "create table test (pk int primary key)"
+    dolt add .
     dolt sql -q "insert into test values (0),(1),(2)"
 
     cd ..

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -186,6 +186,7 @@ teardown() {
     dolt init
     dolt remote add origin file://../remote
     dolt sql -q "CREATE TABLE a (pk int)"
+    dolt add .
     dolt commit -am "add table a"
     dolt push --set-upstream origin main
     dolt checkout -b other
@@ -226,6 +227,7 @@ teardown() {
     dolt init
     dolt remote add test-remote http://localhost:50051/test-org/test-repo
     dolt sql -q "CREATE TABLE test (pk INT)"
+    dolt add .
     dolt commit -am "main commit"
     dolt push test-remote main
     run dolt branch -a
@@ -276,6 +278,7 @@ SQL
     dolt init
     dolt remote add origin file://../remote
     dolt sql -q "CREATE TABLE a (pk int)"
+    dolt add .
     dolt commit -am "add table a"
     dolt push --set-upstream origin main
     dolt checkout -b other
@@ -365,6 +368,7 @@ SQL
     dolt remote add test-remote http://localhost:50051/test-org/test-repo
     dolt checkout -b test-branch
     dolt sql -q "create table t1(c0 varchar(100));"
+    dolt add .
     dolt commit -am "adding table t1"
     run dolt push test-remote test-branch
     [ "$status" -eq 0 ]
@@ -1829,6 +1833,7 @@ setup_ref_test() {
     cd repo2
     dolt checkout -b other
     dolt sql -q "create table t (i int)"
+    dolt add .
     dolt commit -am "adding table from other"
     dolt push origin other
 
@@ -1893,6 +1898,7 @@ SQL
 
     dolt checkout main
     dolt sql -q "CREATE TABLE a(pk int primary key)"
+    dolt add .
     dolt commit -am "add table a"
     dolt push
 
@@ -1917,6 +1923,7 @@ SQL
 
     cd repo2
     dolt sql -q "CREATE TABLE test (id int primary key)"
+    dolt add .
     dolt commit -am "create table"
     run dolt push
     [ "$status" -eq "0" ]
@@ -2021,6 +2028,7 @@ SQL
     dolt init
     dolt remote add origin file://../remote
     dolt sql -q "CREATE TABLE a (pk int)"
+    dolt add .
     dolt commit -am "add table a"
     dolt push --set-upstream origin main
     dolt checkout -b other
@@ -2135,6 +2143,7 @@ create table new_table(a int primary key);
 insert into new_table values (1), (2);
 SQL
     cd repo2
+    dolt add .
     dolt commit -am "a commit for main from repo2"
     dolt push origin main
     cd ..

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -397,6 +397,7 @@ SQL
     [[ "$output" =~ 'local changes to the following tables would be overwritten by merge' ]] || false
 
     # Commit changes and test that a merge conflict fails the pull
+    dolt add .
     dolt commit -am "adding new t1 table"
     run dolt pull test-remote test-branch
     [ "$status" -eq 1 ]
@@ -1939,6 +1940,7 @@ SQL
     [[ "$output" =~ "1 commit" ]] || false
 
     dolt sql -q "CREATE TABLE different (id int primary key)"
+    dolt add .
     dolt commit -am "create different table"
 
     run dolt status
@@ -2174,6 +2176,7 @@ SQL
     cd repo2
     dolt remote add test-remote http://localhost:50051/test-org/test-repo
     dolt sql -q "CREATE TABLE test_table (pk INT)"
+    dolt add .
     dolt commit -am "main commit"
     dolt push test-remote main
     cd ..

--- a/integration-tests/bats/replace.bats
+++ b/integration-tests/bats/replace.bats
@@ -5,6 +5,7 @@ setup() {
     setup_common
 
     dolt sql -q "create table t1 (a bigint primary key, b bigint)"
+    dolt add .
     dolt sql -q "insert into t1 values (0,0), (1,1)"
     dolt commit -am "Init"
     dolt sql -q "drop table t1"

--- a/integration-tests/bats/replication-multidb.bats
+++ b/integration-tests/bats/replication-multidb.bats
@@ -69,10 +69,13 @@ teardown() {
 @test "replication-multidb: push on sqlengine commit" {
     dolt config --global --add sqlserver.global.dolt_replicate_to_remote remote1
     dolt sql --data-dir=dbs1 -b -q "use repo1; create table t1 (a int primary key)"
+    dolt sql --data-dir=dbs1 -b -q "use repo1; call dolt_add('.')"
     dolt sql --data-dir=dbs1 -b -q "use repo1; select dolt_commit('-am', 'cm')"
     dolt sql --data-dir=dbs1 -b -q "use repo2; create table t2 (a int primary key)"
+    dolt sql --data-dir=dbs1 -b -q "use repo2; call dolt_add('.')"
     dolt sql --data-dir=dbs1 -b -q "use repo2; select dolt_commit('-am', 'cm')"
     dolt sql --data-dir=dbs1 -b -q "use repo3; create table t3 (a int primary key)"
+    dolt sql --data-dir=dbs1 -b -q "use repo3; call dolt_add('.')"
     dolt sql --data-dir=dbs1 -b -q "use repo3; select dolt_commit('-am', 'cm')"
     
     clone_helper $TMPDIRS
@@ -101,10 +104,13 @@ teardown() {
 @test "replication-multidb: pull on read" {
     push_helper $TMPDIRS
     dolt sql --data-dir=dbs1 -b -q "use repo1; create table t1 (a int primary key)"
+    dolt sql --data-dir=dbs1 -b -q "use repo1; call dolt_add('.')"
     dolt sql --data-dir=dbs1 -b -q "use repo1; select dolt_commit('-am', 'cm')"
     dolt sql --data-dir=dbs1 -b -q "use repo2; create table t2 (a int primary key)"
+    dolt sql --data-dir=dbs1 -b -q "use repo2; call dolt_add('.')"
     dolt sql --data-dir=dbs1 -b -q "use repo2; select dolt_commit('-am', 'cm')"
     dolt sql --data-dir=dbs1 -b -q "use repo3; create table t3 (a int primary key)"
+    dolt sql --data-dir=dbs1 -b -q "use repo3; call dolt_add('.')"
     dolt sql --data-dir=dbs1 -b -q "use repo3; select dolt_commit('-am', 'cm')"
 
     clone_helper $TMPDIRS
@@ -189,10 +195,13 @@ teardown() {
 @test "replication-multidb: sql-server pull on read" {
     push_helper $TMPDIRS
     dolt sql --data-dir=dbs1 -b -q "use repo1; create table t1 (a int primary key)"
+    dolt sql --data-dir=dbs1 -b -q "use repo1; call dolt_add('.')"
     dolt sql --data-dir=dbs1 -b -q "use repo1; select dolt_commit('-am', 'cm')"
     dolt sql --data-dir=dbs1 -b -q "use repo2; create table t2 (a int primary key)"
+    dolt sql --data-dir=dbs1 -b -q "use repo2; call dolt_add('.')"
     dolt sql --data-dir=dbs1 -b -q "use repo2; select dolt_commit('-am', 'cm')"
     dolt sql --data-dir=dbs1 -b -q "use repo3; create table t3 (a int primary key)"
+    dolt sql --data-dir=dbs1 -b -q "use repo3; call dolt_add('.')"
     dolt sql --data-dir=dbs1 -b -q "use repo3; select dolt_commit('-am', 'cm')"
 
     clone_helper $TMPDIRS

--- a/integration-tests/bats/replication-multidb.bats
+++ b/integration-tests/bats/replication-multidb.bats
@@ -162,10 +162,13 @@ teardown() {
     cd ..
 
     server_query repo1 1 dolt "" "create table t1 (a int primary key)"
+    server_query repo1 1 dolt "" "call dolt_add('.')"
     server_query repo1 1 dolt "" "call dolt_commit('-am', 'cm')"
     server_query repo2 1 dolt "" "create table t2 (a int primary key)"
+    server_query repo2 1 dolt "" "call dolt_add('.')"
     server_query repo2 1 dolt  "" "call dolt_commit('-am', 'cm')"
     server_query repo3 1 dolt "" "create table t3 (a int primary key)"
+    server_query repo3 1 dolt "" "call dolt_add('.')"
     server_query repo3 1 dolt "" "call dolt_commit('-am', 'cm')"
 
     clone_helper $TMPDIRS

--- a/integration-tests/bats/replication.bats
+++ b/integration-tests/bats/replication.bats
@@ -49,6 +49,7 @@ teardown() {
     cd repo1
     dolt config --local --add sqlserver.global.dolt_replicate_to_remote backup1
     dolt sql -q "create table t1 (a int primary key)"
+    dolt sql -q "call dolt_add('.')"
     dolt sql -q "select dolt_commit('-am', 'cm')"
 
     cd ..
@@ -180,6 +181,7 @@ teardown() {
     dolt config --local --add sqlserver.global.dolt_replicate_to_remote backup1
     dolt config --local --add sqlserver.global.dolt_replicate_heads main,new_branch
     dolt sql -q "create table t1 (a int primary key)"
+    dolt sql -q "call dolt_add('.')"
     dolt sql -q "call dolt_commit('-am', 'commit')"
     dolt sql -q "call dolt_branch('new_branch')"
 
@@ -198,6 +200,7 @@ teardown() {
     dolt config --local --add sqlserver.global.dolt_replicate_to_remote backup1
     dolt config --local --add sqlserver.global.dolt_replicate_heads main,new_branch
     dolt sql -q "create table t1 (a int primary key)"
+    dolt sql -q "call dolt_add('.')"
     dolt sql -q "call dolt_commit('-am', 'commit')"
     dolt sql -q "call dolt_checkout('-b', 'new_branch')"
 
@@ -216,9 +219,11 @@ teardown() {
     dolt config --local --add sqlserver.global.dolt_replicate_to_remote backup1
     dolt config --local --add sqlserver.global.dolt_replicate_heads main,new_branch
     dolt sql -q "create table t1 (a int primary key)"
+    dolt sql -q "call dolt_add('.')"
     dolt sql -q "call dolt_commit('-am', 'commit')"
     dolt sql -q "call dolt_checkout('-b', 'new_branch')"
     dolt sql -q "create table t2 (b int primary key)"
+    dolt sql -q "call dolt_add('.')"
     dolt sql -q "call dolt_commit('-am', 'commit')"
     dolt sql -q "call dolt_checkout('main')"
     dolt sql -q "call dolt_merge('new_branch')"
@@ -459,6 +464,7 @@ SQL
     dolt config --local --add sqlserver.global.dolt_replicate_to_remote remote1
     dolt checkout -b new_feature
     dolt sql -q "create table t1 (a int primary key)"
+    dolt sql -q "call dolt_add('.')"
     dolt sql -q "select dolt_commit('-am', 'cm')"
 
     cd ..
@@ -483,6 +489,8 @@ SQL
     run dolt sql -q "create table t1 (a int primary key)"
     [ "$status" -eq 0 ]
     [[ ! "$output" =~ "remote not found" ]] || false
+
+    dolt add .
 
     run dolt sql -q "select dolt_commit('-am', 'cm')"
     [ "$status" -eq 0 ]
@@ -572,6 +580,7 @@ SQL
     dolt config --local --add sqlserver.global.dolt_replicate_to_remote remote1
     dolt config --local --add sqlserver.global.dolt_async_replication 1
     dolt sql -q "create table t1 (a int primary key)"
+    dolt sql -q "call dolt_add('.')"
     dolt sql -q "select dolt_commit('-am', 'cm')"
     sleep 5
 

--- a/integration-tests/bats/replication.bats
+++ b/integration-tests/bats/replication.bats
@@ -26,6 +26,7 @@ teardown() {
 @test "replication: default no replication" {
     cd repo1
     dolt sql -q "create table t1 (a int primary key)"
+    dolt add .
     dolt commit -am "cm"
 
     [ ! -d "../bac1/.dolt" ] || false
@@ -36,6 +37,7 @@ teardown() {
     cd repo1
     dolt config --local --add sqlserver.global.dolt_replicate_to_remote backup1
     dolt sql -q "create table t1 (a int primary key)"
+    dolt add .
     dolt commit -am "cm"
 
     cd ..
@@ -139,6 +141,7 @@ teardown() {
     dolt clone file://./rem1 repo2
     cd repo2
     dolt sql -q "create table t1 (a int primary key)"
+    dolt add .
     dolt commit -am "new commit"
     dolt push origin main
 
@@ -235,6 +238,7 @@ teardown() {
     cd repo2
     dolt checkout -b new_feature
     dolt sql -q "create table t1 (a int)"
+    dolt add .
     dolt commit -am "cm"
     dolt push origin new_feature
 
@@ -253,6 +257,7 @@ teardown() {
     cd repo2
     dolt checkout -b new_feature
     dolt sql -q "create table t1 (a int)"
+    dolt add .
     dolt commit -am "cm"
     dolt push origin new_feature
 
@@ -271,10 +276,12 @@ teardown() {
     cd repo2
     dolt checkout -b new_feature
     dolt sql -q "create table t1 (a int)"
+    dolt add .
     dolt commit -am "cm"
     dolt push origin new_feature
     dolt checkout main
     dolt sql -q "create table t2 (a int)"
+    dolt add .
     dolt commit -am "cm"
     dolt push origin main
 
@@ -390,6 +397,7 @@ teardown() {
     dolt checkout feat
     dolt sql -q "create table t1 (a int)"
     dolt sql -q "create table t2 (a int)"
+    dolt add .
     dolt commit -am "cm"
     # remote1 has tables
     dolt push remote1 feat
@@ -414,6 +422,7 @@ SQL
     cd repo2
     dolt checkout -b new_feature
     dolt sql -q "create table t1 (a int)"
+    dolt add .
     dolt commit -am "cm"
     dolt push origin new_feature
 
@@ -520,6 +529,7 @@ SQL
     cd repo2
     dolt checkout -b feature-branch
     dolt sql -q "create table t1 (a int primary key)"
+    dolt add .
     dolt commit -am "new commit"
     dolt push origin feature-branch
 
@@ -547,6 +557,7 @@ SQL
     cd ../repo2
     dolt checkout feature-branch
     dolt sql -q "create table t1 (a int primary key)"
+    dolt add .
     dolt commit -am "new commit"
     dolt push origin feature-branch
 

--- a/integration-tests/bats/schema-changes.bats
+++ b/integration-tests/bats/schema-changes.bats
@@ -309,6 +309,7 @@ SQL
     # Commit is important here because we are testing column reuse on
     # drop / add, we want to be sure that we don't re-use any old
     # values from before the column was dropped
+    dolt add .
     dolt commit -am "Committing test table"
 
     dolt sql -q "alter table test2 drop column v1"
@@ -336,6 +337,7 @@ CREATE TABLE test2(
 insert into test2 values (1, 1, 1), (2, 2, 2);
 SQL
 
+    dolt add .
     # Commit is important here because we are testing column reuse on
     # drop / add, we want to be sure that we don't re-use any old
     # values from before the column was dropped

--- a/integration-tests/bats/sql-checkout.bats
+++ b/integration-tests/bats/sql-checkout.bats
@@ -489,6 +489,7 @@ CREATE TABLE one_pk (
   c2 BIGINT,
   PRIMARY KEY (pk1)
 );
+SELECT DOLT_ADD('.');
 SELECT DOLT_COMMIT('-a', '-m', 'add tables');
 SELECT DOLT_CHECKOUT('-b', 'feature-branch');
 SELECT DOLT_CHECKOUT('main');
@@ -522,6 +523,7 @@ CREATE TABLE one_pk (
   c2 BIGINT,
   PRIMARY KEY (pk1)
 );
+SELECT DOLT_ADD('.');
 CALL DOLT_COMMIT('-a', '-m', 'add tables');
 CALL DOLT_CHECKOUT('-b', 'feature-branch');
 CALL DOLT_CHECKOUT('main');

--- a/integration-tests/bats/sql-clean.bats
+++ b/integration-tests/bats/sql-clean.bats
@@ -10,6 +10,7 @@ CREATE TABLE test (
 );
 SQL
 
+    dolt add .
     dolt commit -a -m "Add a table"
 }
 

--- a/integration-tests/bats/sql-commit.bats
+++ b/integration-tests/bats/sql-commit.bats
@@ -10,6 +10,7 @@ CREATE TABLE test (
 );
 
 INSERT INTO test VALUES (0),(1),(2);
+CALL DOLT_ADD('.');
 SQL
 }
 

--- a/integration-tests/bats/sql-create-database.bats
+++ b/integration-tests/bats/sql-create-database.bats
@@ -80,6 +80,7 @@ SQL
 create database mydb;
 use mydb;
 create table test(a int primary key);
+call dolt_add('.');
 select dolt_commit("-am", "first commit");
 SQL
 

--- a/integration-tests/bats/sql-create-database.bats
+++ b/integration-tests/bats/sql-create-database.bats
@@ -107,10 +107,12 @@ create database mydb1;
 create database mydb2;
 use mydb1;
 create table test(a int primary key);
+call dolt_add('.');
 select dolt_commit("-am", "first commit mydb1");
 use mydb2;
 begin;
 create table test(a int primary key);
+call dolt_add('.');
 select dolt_commit("-am", "first commit mydb2");
 SQL
 
@@ -149,10 +151,12 @@ create database mydb1;
 create database mydb2;
 use mydb1;
 create table test(a int primary key);
+call dolt_add('.');
 select dolt_commit("-am", "first commit mydb1");
 use mydb2;
 begin;
 create table test(a int primary key);
+call dolt_add('.');
 select dolt_commit("-am", "first commit mydb2");
 SQL
 

--- a/integration-tests/bats/sql-fetch.bats
+++ b/integration-tests/bats/sql-fetch.bats
@@ -22,6 +22,7 @@ setup() {
     # table and comits only present on repo1, rem1 at start
     cd $TMPDIRS/repo1
     dolt sql -q "create table t1 (a int primary key, b int)"
+    dolt add .
     dolt commit -am "First commit"
     dolt sql -q "insert into t1 values (0,0)"
     dolt commit -am "Second commit"
@@ -360,6 +361,7 @@ teardown() {
     # reverse information flow for force fetch repo1->rem1->repo2
     cd repo2
     dolt sql -q "create table t2 (a int)"
+    dolt add .
     dolt commit -am "forced commit"
     dolt push --force origin main
 
@@ -385,6 +387,7 @@ teardown() {
     # reverse information flow for force fetch repo1->rem1->repo2
     cd repo2
     dolt sql -q "create table t2 (a int)"
+    dolt add .
     dolt commit -am "forced commit"
     dolt push --force origin main
 

--- a/integration-tests/bats/sql-merge.bats
+++ b/integration-tests/bats/sql-merge.bats
@@ -11,6 +11,7 @@ CREATE TABLE test (
 
 INSERT INTO test VALUES (0),(1),(2);
 SQL
+dolt add .
 }
 
 teardown() {
@@ -1375,6 +1376,7 @@ SQL
 @test "sql-merge: adding and dropping primary keys any number of times not produce schema merge conflicts" {
     dolt commit -am "commit all changes"
     dolt sql -q "create table test_null (i int)"
+    dolt add .
     dolt commit -am "initial"
 
     dolt checkout -b b1
@@ -1395,6 +1397,7 @@ SQL
 
 @test "sql-merge: identical schema changes with data changes merges correctly" {
     dolt sql -q "create table t (i int primary key)"
+    dolt add .
     dolt commit -am "initial commit"
     dolt branch b1
     dolt branch b2
@@ -1416,6 +1419,7 @@ SQL
 # TODO: what happens when the data conflicts with new check?
 @test "sql-merge: non-conflicting data and constraint changes are preserved" {
     dolt sql -q "create table t (i int)"
+    dolt add .
     dolt commit -am "initial commit"
 
     dolt checkout -b other
@@ -1445,6 +1449,7 @@ SQL
 
 @test "sql-merge: non-overlapping check constraints merge successfully" {
     dolt sql -q "create table t (i int, j int)"
+    dolt add .
     dolt commit -am "initial commit"
 
     dolt checkout -b other
@@ -1472,6 +1477,7 @@ SQL
 
 @test "sql-merge: different check constraints on same column throw conflict" {
     dolt sql -q "create table t (i int)"
+    dolt add .
     dolt commit -am "initial commit"
 
     dolt checkout -b other
@@ -1496,6 +1502,7 @@ SQL
 # TODO: what happens when the new data conflicts with modified check?
 @test "sql-merge: non-conflicting constraint modification is preserved" {
     dolt sql -q "create table t (i int)"
+    dolt add .
     dolt sql -q "alter table t add constraint c check (i > 0)"
     dolt commit -am "initial commit"
 
@@ -1531,6 +1538,7 @@ SQL
 # TODO: expected behavior for dropping constraints?
 @test "sql-merge: dropping constraint in one branch drops from both" {
     dolt sql -q "create table t (i int)"
+    dolt add .
     dolt sql -q "alter table t add constraint c check (i > 0)"
     dolt commit -am "initial commit"
 
@@ -1564,6 +1572,7 @@ SQL
 
 @test "sql-merge: dropping constraint on both branches merges successfully" {
     dolt sql -q "create table t (i int)"
+    dolt add .
     dolt sql -q "alter table t add constraint c check (i > 0)"
     dolt commit -am "initial commit"
 
@@ -1591,6 +1600,7 @@ SQL
 
 @test "sql-merge: dropping constraint in one branch and modifying same in other results in conflict" {
     dolt sql -q "create table t (i int)"
+    dolt add .
     dolt sql -q "alter table t add constraint c check (i > 0)"
     dolt commit -am "initial commit"
 
@@ -1616,6 +1626,7 @@ SQL
 
 @test "sql-merge: merging with not null and check constraints preserves both constraints" {
     dolt sql -q "create table t (i int)"
+    dolt add .
     dolt commit -am "initial commit"
 
     dolt branch b1
@@ -1649,6 +1660,7 @@ SQL
 
 @test "sql-merge: check constraint with name collision" {
     dolt sql -q "create table t (i int)"
+    dolt add .
     dolt commit -am "initial commit"
 
     dolt branch b1
@@ -1678,6 +1690,7 @@ SQL
 
 @test "sql-merge: check constraint for deleted column in another table" {
     dolt sql -q "create table t (i int primary key, j int)"
+    dolt add .
     dolt commit -am "initial commit"
 
     dolt branch b1

--- a/integration-tests/bats/sql-merge.bats
+++ b/integration-tests/bats/sql-merge.bats
@@ -281,6 +281,7 @@ SQL
 CREATE TABLE test2 (pk int primary key, val int);
 INSERT INTO test2 VALUES (0, 0);
 SET autocommit = 0;
+CALL DOLT_ADD('.');
 SELECT DOLT_COMMIT('-a', '-m', 'Step 1');
 SELECT DOLT_CHECKOUT('-b', 'feature-branch');
 INSERT INTO test2 VALUES (1, 1);
@@ -303,6 +304,7 @@ SQL
 @test "sql-merge: CALL End to End Conflict Resolution with autocommit off." {
     dolt sql << SQL
 CREATE TABLE test2 (pk int primary key, val int);
+CALL DOLT_ADD('.');
 INSERT INTO test2 VALUES (0, 0);
 SET autocommit = 0;
 CALL DOLT_COMMIT('-a', '-m', 'Step 1');
@@ -630,6 +632,7 @@ CREATE TABLE one_pk (
   c2 BIGINT,
   PRIMARY KEY (pk1)
 );
+CALL DOLT_ADD('.');
 SELECT DOLT_COMMIT('-a', '-m', 'add tables');
 SELECT DOLT_CHECKOUT('-b', 'feature-branch');
 SELECT DOLT_CHECKOUT('main');
@@ -681,6 +684,7 @@ CREATE TABLE one_pk (
   c2 BIGINT,
   PRIMARY KEY (pk1)
 );
+CALL DOLT_ADD('.');
 CALL DOLT_COMMIT('-a', '-m', 'add tables');
 CALL DOLT_CHECKOUT('-b', 'feature-branch');
 CALL DOLT_CHECKOUT('main');
@@ -731,6 +735,7 @@ CREATE TABLE one_pk (
   c2 BIGINT,
   PRIMARY KEY (pk1)
 );
+CALL DOLT_ADD('.');
 SELECT DOLT_COMMIT('-a', '-m', 'add tables');
 SELECT DOLT_CHECKOUT('-b', 'feature-branch');
 SELECT DOLT_CHECKOUT('main');
@@ -797,6 +802,7 @@ CREATE TABLE one_pk (
   c2 BIGINT,
   PRIMARY KEY (pk1)
 );
+CALL DOLT_ADD('.');
 SELECT DOLT_COMMIT('-a', '-m', 'add tables');
 SELECT DOLT_CHECKOUT('-b', 'feature-branch');
 SELECT DOLT_CHECKOUT('main');
@@ -837,6 +843,7 @@ CREATE TABLE one_pk (
   c2 BIGINT,
   PRIMARY KEY (pk1)
 );
+CALL DOLT_ADD('.');
 CALL DOLT_COMMIT('-a', '-m', 'add tables');
 CALL DOLT_CHECKOUT('-b', 'feature-branch');
 CALL DOLT_CHECKOUT('main');
@@ -876,6 +883,7 @@ CREATE TABLE one_pk (
   c2 BIGINT,
   PRIMARY KEY (pk1)
 );
+CALL DOLT_ADD('.');
 SELECT DOLT_COMMIT('-a', '-m', 'add tables');
 SELECT DOLT_CHECKOUT('-b', 'feature-branch');
 SELECT DOLT_CHECKOUT('main');
@@ -906,6 +914,7 @@ CREATE TABLE one_pk (
   c2 BIGINT,
   PRIMARY KEY (pk1)
 );
+CALL DOLT_ADD('.');
 CALL DOLT_COMMIT('-a', '-m', 'add tables');
 CALL DOLT_CHECKOUT('-b', 'feature-branch');
 CALL DOLT_CHECKOUT('main');
@@ -936,6 +945,7 @@ CREATE TABLE one_pk (
   c2 BIGINT,
   PRIMARY KEY (pk1)
 );
+CALL DOLT_ADD('.');
 SELECT DOLT_COMMIT('-a', '-m', 'add tables');
 SELECT DOLT_CHECKOUT('-b', 'feature-branch');
 SELECT DOLT_CHECKOUT('main');
@@ -965,6 +975,7 @@ CREATE TABLE one_pk (
   c2 BIGINT,
   PRIMARY KEY (pk1)
 );
+CALL DOLT_ADD('.');
 CALL DOLT_COMMIT('-a', '-m', 'add tables');
 CALL DOLT_CHECKOUT('-b', 'feature-branch');
 CALL DOLT_CHECKOUT('main');
@@ -1292,6 +1303,7 @@ CREATE TABLE one_pk (
   c2 BIGINT,
   PRIMARY KEY (pk1)
 );
+CALL DOLT_ADD('.');
 SELECT DOLT_COMMIT('-a', '-m', 'add tables');
 SELECT DOLT_CHECKOUT('-b', 'feature-branch');
 SELECT DOLT_CHECKOUT('main');

--- a/integration-tests/bats/sql-pull.bats
+++ b/integration-tests/bats/sql-pull.bats
@@ -237,6 +237,7 @@ teardown() {
     cd repo1
     dolt checkout -b feature2
     dolt sql -q "create table t2 (i int primary key);"
+    dolt sql -q "call dolt_add('.');"
     dolt sql -q "call dolt_commit('-am', 'create t2')"
     dolt push --set-upstream origin feature2
 

--- a/integration-tests/bats/sql-pull.bats
+++ b/integration-tests/bats/sql-pull.bats
@@ -25,6 +25,7 @@ setup() {
     # table and commits only present on repo1, rem1 at start
     cd $TMPDIRS/repo1
     dolt sql -q "create table t1 (a int primary key, b int)"
+    dolt add .
     dolt commit -am "First commit"
     dolt sql -q "insert into t1 values (0,0)"
     dolt commit -am "Second commit"
@@ -424,6 +425,7 @@ teardown() {
 
     dolt checkout feature
     dolt sql -q "create table t2 (a int)"
+    dolt add .
     dolt commit -am "feature commit"
     dolt tag v3
     dolt push origin v3
@@ -446,6 +448,7 @@ teardown() {
 
     dolt checkout feature
     dolt sql -q "create table t2 (a int)"
+    dolt add .
     dolt commit -am "feature commit"
     dolt tag v3
     dolt push origin v3

--- a/integration-tests/bats/sql-push.bats
+++ b/integration-tests/bats/sql-push.bats
@@ -23,6 +23,7 @@ setup() {
     # table and comits only present on repo1, rem1 at start
     cd $TMPDIRS/repo1
     dolt sql -q "create table t1 (a int primary key, b int)"
+    dolt add .
     dolt commit -am "First commit"
     dolt sql -q "insert into t1 values (0,0)"
     dolt commit -am "Second commit"
@@ -189,6 +190,7 @@ teardown() {
 @test "sql-push: dolt_push --force flag" {
     cd repo2
     dolt sql -q "create table t2 (a int)"
+    dolt add .
     dolt commit -am "commit to override"
     dolt push origin main
 
@@ -203,6 +205,7 @@ teardown() {
 @test "sql-push: CALL dolt_push --force flag" {
     cd repo2
     dolt sql -q "create table t2 (a int)"
+    dolt add .
     dolt commit -am "commit to override"
     dolt push origin main
 

--- a/integration-tests/bats/sql-reset.bats
+++ b/integration-tests/bats/sql-reset.bats
@@ -10,6 +10,7 @@ CREATE TABLE test (
 );
 SQL
 
+    dolt add .
     dolt commit -a -m "Add a table"
 }
 

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -340,8 +340,8 @@ SQL
     [ "$status" -eq 0 ]
     [[ "$output" =~ "one_pk" ]] || false
 
+    dolt sql --user=dolt -q "CALL DOLT_ADD('.')"
     # check that dolt_commit works properly when autocommit is on
-    dolt add .
     run dolt sql --user=dolt -q "SELECT DOLT_COMMIT('-a', '-m', 'Commit1')"
     [ "$status" -eq 0 ]
 
@@ -775,6 +775,7 @@ SQL
         PRIMARY KEY (pk)
     );
     INSERT INTO one_pk (pk,c1,c2) VALUES (2,2,2),(3,3,3);
+    CALL DOLT_ADD('.');
     SELECT commit('-am', 'test commit message', '--author', 'John Doe <john@example.com>');
     INSERT INTO dolt_branches (name,hash) VALUES ('main', @@repo1_head);"
 
@@ -1129,6 +1130,7 @@ END""")
     server_query repo1 1 dolt "" "INSERT INTO t1 (val) VALUES (2)"
     server_query repo1 1 dolt "" "SELECT * FROM t1" "pk,val\n1,1\n2,2"
 
+    run server_query repo1 1 dolt "" "call dolt_add('.')"
     run server_query repo1 1 dolt "" "call dolt_commit('-am', 'table with two values')"
     run server_query repo1 1 dolt "" "call dolt_branch('new_branch')"
 
@@ -1200,11 +1202,13 @@ END""")
     server_query "" 1 dolt "" "create database test1"
     server_query "" 1 dolt "" "show databases" "Database\ninformation_schema\nmysql\ntest1"
     server_query "test1" 1 dolt "" "create table a(x int)"
+    server_query "test1" 1 dolt "" "select dolt_add('.')"
     server_query "test1" 1 dolt "" "insert into a values (1), (2)"
     server_query "test1" 1 dolt "" "call dolt_commit('-a', '-m', 'new table a')"
 
     server_query "" 1 dolt "" "create database test2"
     server_query "test2" 1 dolt "" "create table b(x int)"
+    server_query "test2" 1 dolt "" "select dolt_add('.')"
     server_query "test2" 1 dolt "" "insert into b values (1), (2)"
     server_query "test2" 1 dolt "" "select dolt_commit('-a', '-m', 'new table b')"
 
@@ -1230,6 +1234,7 @@ END""")
 
     server_query "" 1 dolt "" "create database test3"
     server_query "test3" 1 dolt "" "create table c(x int)"
+    server_query "test3" 1 dolt "" "select dolt_add('.')"
     server_query "test3" 1 dolt "" "insert into c values (1), (2)"
     run server_query "test3" 1 dolt "" "select dolt_commit('-a', '-m', 'new table c')"
 
@@ -1257,14 +1262,17 @@ END""")
 
     server_query "" 1 dolt "" "show databases" "Database\ninformation_schema\nmysql\ntest1\ntest2\ntest3"
     server_query "test1" 1 dolt "" "create table a(x int)"
+    server_query "test1" 1 dolt "" "select dolt_add('.')"
     server_query "test1" 1 dolt "" "insert into a values (1), (2)"
     run server_query "test1" 1 dolt "" "call dolt_commit('-a', '-m', 'new table a')"
 
     server_query "test2" 1 dolt "" "create table a(x int)"
+    server_query "test2" 1 dolt "" "select dolt_add('.')"
     server_query "test2" 1 dolt "" "insert into a values (3), (4)"
     server_query "test2" 1 dolt "" "call dolt_commit('-a', '-m', 'new table a')"
 
     server_query "test3" 1 dolt "" "create table a(x int)"
+    server_query "test3" 1 dolt "" "select dolt_add('.')"
     server_query "test3" 1 dolt "" "insert into a values (5), (6)"
     server_query "test3" 1 dolt "" "call dolt_commit('-a', '-m', 'new table a')"
 
@@ -1303,7 +1311,7 @@ END""")
     server_query "" 1 dolt "" "show databases" "Database\nTest1\ninformation_schema\nmysql"
     server_query "" 1 dolt "" "use test1; create table a(x int);"
     server_query "" 1 dolt "" "use TEST1; insert into a values (1), (2);"
-    run server_query "" 1 dolt "" "use test1; select dolt_commit('-a', '-m', 'new table a');"
+    run server_query "" 1 dolt "" "use test1; select dolt_add('.'); select dolt_commit('-a', '-m', 'new table a');"
     server_query "" 1 dolt "" "use test1; call dolt_checkout('-b', 'newbranch');"
     server_query "" 1 dolt "" "use \`TEST1/newbranch\`; select * from a order by x" ";x\n1\n2"
     server_query "" 1 dolt "" "use \`test1/newbranch\`; select * from a order by x" ";x\n1\n2"
@@ -1323,6 +1331,7 @@ END""")
     server_query "" 1 dolt "" "create database test1"
     server_query "" 1 dolt "" "show databases" "Database\ninformation_schema\nmysql\ntest1"
     server_query "test1" 1 dolt "" "create table a(x int)"
+    server_query "test1" 1 dolt "" "select dolt_add('.')"
     server_query "test1" 1 dolt "" "insert into a values (1), (2)"
 
     server_query "test1" 1 dolt "" "call dolt_commit('-a', '-m', 'new table a')"
@@ -1338,6 +1347,7 @@ END""")
 
     server_query "" 1 dolt "" "create database test3"
     server_query "test3" 1 dolt "" "create table c(x int)"
+    server_query "test3" 1 dolt "" "select dolt_add('.')"
     server_query "test3" 1 dolt "" "insert into c values (1), (2)"
     server_query "test3" 1 dolt "" "call dolt_commit('-a', '-m', 'new table c')"
 
@@ -1379,12 +1389,15 @@ END""")
     server_query "" 1 dolt "" "create database test1"
     server_query "repo1" 1 dolt "" "show databases" "Database\ninformation_schema\nmysql\nrepo1\ntest1"
     server_query "test1" 1 dolt "" "create table a(x int)"
+    server_query "test1" 1 dolt "" "select dolt_add('.')"
     server_query "test1" 1 dolt "" "insert into a values (1), (2)"
+
     # not bothering to check the results of the commit here
     server_query "test1" 1 dolt "" "call dolt_commit('-a', '-m', 'new table a')"
 
     server_query "" 1 dolt "" "create database test2"
     server_query "test2" 1 dolt "" "create table b(x int)"
+    server_query "test2" 1 dolt "" "select dolt_add('.')"
     server_query "test2" 1 dolt "" "insert into b values (1), (2)"
     # not bothering to check the results of the commit here
     server_query "test2" 1 dolt "" "call dolt_commit('-a', '-m', 'new table b')"

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -341,6 +341,7 @@ SQL
     [[ "$output" =~ "one_pk" ]] || false
 
     # check that dolt_commit works properly when autocommit is on
+    dolt add .
     run dolt sql --user=dolt -q "SELECT DOLT_COMMIT('-a', '-m', 'Commit1')"
     [ "$status" -eq 0 ]
 

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -838,6 +838,7 @@ SQL
 
     cd repo1
     dolt sql -q "create table test (pk int primary key)"
+    dolt add .
     dolt commit -a -m "Created new table"
     dolt sql -q "insert into test values (1), (2), (3)"
     dolt commit -a -m "Inserted 3 values"
@@ -1428,6 +1429,7 @@ END""")
 
     cd ../repo2
     dolt sql -q "create table test (a int)"
+    dolt add .
     dolt commit -am "new commit"
     dolt push -u remote1 main
 
@@ -1456,6 +1458,7 @@ databases:
     dolt sql -q "create table r1t_one (id1 int primary key, col1 varchar(20));"
     dolt sql -q "insert into r1t_one values (1,'aaaa'), (2,'bbbb'), (3,'cccc');"
     dolt sql -q "create table r1t_two (id2 int primary key, col2 varchar(20));"
+    dolt add .
     dolt commit -am "create two tables"
 
     cd ../repo2
@@ -1463,6 +1466,7 @@ databases:
     dolt sql -q "create table r2t_two (id2 int primary key, col2 varchar(20));"
     dolt sql -q "create table r2t_three (id3 int primary key, col3 varchar(20));"
     dolt sql -q "insert into r2t_three values (4,'dddd'), (3,'gggg'), (2,'eeee'), (1,'ffff');"
+    dolt add .
     dolt commit -am "create three tables"
 
     cd ..

--- a/integration-tests/bats/sql.bats
+++ b/integration-tests/bats/sql.bats
@@ -2398,6 +2398,7 @@ SQL
 
 @test "sql: dolt diff table correctly works with IN" {
     dolt sql -q "CREATE TABLE mytable(pk int primary key);"
+    dolt add .
     dolt sql -q "INSERT INTO mytable VALUES (1), (2)"
     dolt commit -am "Commit 1"
 

--- a/integration-tests/bats/sql.bats
+++ b/integration-tests/bats/sql.bats
@@ -1290,6 +1290,7 @@ SQL
 USE \`dolt_repo_$$/feature-branch\`;
 CREATE TABLE table_a(x int primary key);
 CREATE TABLE table_b(x int primary key);
+CALL DOLT_ADD('.');
 SELECT DOLT_COMMIT('-a', '-m', 'two new tables');
 SQL
     
@@ -1314,6 +1315,7 @@ SQL
 CREATE DATABASE test1;
 USE test1;
 CREATE TABLE table_a(x int primary key);
+CALL DOLT_ADD('.');
 insert into table_a values (1), (2);
 SELECT DOLT_COMMIT('-a', '-m', 'created table_a');
 SQL
@@ -1376,6 +1378,7 @@ SQL
 CREATE DATABASE test1;
 USE test1;
 CREATE TABLE table_a(x int primary key);
+CALL DOLT_ADD('.');
 insert into table_a values (1), (2);
 SELECT DOLT_COMMIT('-a', '-m', 'created table_a');
 SQL
@@ -1470,6 +1473,7 @@ SQL
     dolt sql  <<SQL
 set @@dolt_repo_$$_head_ref = 'feature-branch';
 CREATE TABLE test (x int primary key);
+CALL DOLT_ADD('.');
 SELECT DOLT_COMMIT('-a', '-m', 'new table');
 SQL
     
@@ -1520,6 +1524,7 @@ SQL
     dolt sql  <<SQL
 USE \`dolt_repo_$$/feature-branch\`;
 CREATE TABLE a1(x int primary key);
+CALL DOLT_ADD('.');
 insert into a1 values (1), (2), (3);
 SELECT DOLT_COMMIT('-a', '-m', 'new table');
 SQL
@@ -1537,6 +1542,7 @@ SQL
     dolt sql  <<SQL
 USE \`dolt_repo_$$/feature-branch\`;
 CREATE TABLE a1(x int primary key);
+CALL DOLT_ADD('.');
 insert into a1 values (1), (2), (3);
 SELECT DOLT_COMMIT('-a', '-m', 'new table');
 SQL
@@ -1555,6 +1561,7 @@ SQL
     
     dolt sql  <<SQL
 CREATE TABLE a1(x int primary key);
+CALL DOLT_ADD('.');
 insert into a1 values (1), (2), (3);
 SELECT DOLT_COMMIT('-a', '-m', 'new table');
 insert into a1 values (4), (5), (6);
@@ -1586,6 +1593,7 @@ SQL
     
     dolt sql  <<SQL
 CREATE TABLE a1(x int primary key);
+CALL DOLT_ADD('.');
 insert into a1 values (1), (2), (3);
 SELECT DOLT_COMMIT('-a', '-m', 'new table');
 insert into a1 values (4), (5), (6);
@@ -1615,6 +1623,7 @@ SQL
     
     dolt sql  <<SQL
 CREATE TABLE a1(x int primary key);
+CALL DOLT_ADD('.');
 insert into a1 values (1), (2), (3);
 SELECT DOLT_COMMIT('-a', '-m', 'new table');
 insert into a1 values (4), (5), (6);
@@ -1645,6 +1654,7 @@ SQL
     dolt sql  <<SQL
 USE \`dolt_repo_$$/feature-branch\`;
 CREATE TABLE a1(x int primary key);
+CALL DOLT_ADD('.');
 insert into a1 values (1), (2), (3);
 SELECT DOLT_COMMIT('-a', '-m', 'new table');
 SQL
@@ -1680,6 +1690,7 @@ SQL
     
     dolt sql  <<SQL
 CREATE TABLE a1(x int primary key);
+CALL DOLT_ADD('.');
 insert into a1 values (1), (2), (3);
 SELECT DOLT_COMMIT('-a', '-m', 'new table');
 insert into a1 values (4), (5), (6);
@@ -1709,6 +1720,7 @@ SQL
     
     dolt sql  <<SQL
 CREATE TABLE a1(x int primary key);
+CALL DOLT_ADD('.');
 insert into a1 values (1), (2), (3);
 SELECT DOLT_COMMIT('-a', '-m', 'new table');
 insert into a1 values (4), (5), (6);

--- a/integration-tests/bats/status.bats
+++ b/integration-tests/bats/status.bats
@@ -218,6 +218,7 @@ SQL
 
 @test "status: dolt reset hard with ~ works" {
     dolt sql -q "CREATE TABLE test (pk int PRIMARY KEY);"
+    dolt add .
     dolt commit -am "cm1"
 
     dolt sql -q "INSERT INTO test values (1);"
@@ -261,6 +262,7 @@ SQL
 
 @test "status: dolt reset soft with ~ works" {
     dolt sql -q "CREATE TABLE test (pk int PRIMARY KEY);"
+    dolt add .
     dolt commit -am "cm1"
 
     dolt sql -q "INSERT INTO test values (1);"
@@ -306,6 +308,7 @@ CREATE TABLE one (
   v2 BIGINT
 );
 SQL
+    dolt add .
     dolt commit -am "added table"
     dolt sql -q "rename table one to one_super"
 
@@ -316,18 +319,21 @@ SQL
 @test "status: dolt reset works with commit hash ref" {
     dolt sql -q "CREATE TABLE tb1 (pk int PRIMARY KEY);"
     dolt sql -q "INSERT INTO tb1 values (1);"
+    dolt add .
     dolt commit -am "cm1"
 
     cm1=$(get_head_commit)
 
     dolt sql -q "CREATE TABLE tb2 (pk int PRIMARY KEY);"
     dolt sql -q "INSERT INTO tb2 values (11);"
+    dolt add .
     dolt commit -am "cm2"
 
     cm2=$(get_head_commit)
 
     dolt sql -q "CREATE TABLE tb3 (pk int PRIMARY KEY);"
     dolt sql -q "INSERT INTO tb3 values (11);"
+    dolt add .
     dolt commit -am "cm3"
 
     cm3=$(get_head_commit)
@@ -354,6 +360,7 @@ SQL
     run dolt sql -q "SELECT COUNT(*) FROM dolt_log"
     [[ "$output" =~ "3" ]] || false # includes init commit
 
+    dolt add .
     dolt commit -am "commit 3"
 
     # Do a soft reset to commit 1
@@ -372,6 +379,7 @@ SQL
 
 @test "status: dolt reset works with branch ref" {
     dolt sql -q "CREATE TABLE tbl(pk int);"
+    dolt add .
     dolt sql -q "INSERT into tbl VALUES (1)"
     dolt commit -am "cm1"
 
@@ -379,6 +387,7 @@ SQL
     dolt checkout -b test
     dolt sql -q "INSERT INTO tbl VALUES (2),(3)"
     dolt sql -q "CREATE TABLE tbl2(pk int);"
+    dolt add .
     dolt commit -am "test cm1"
 
     # go back to main and merge
@@ -401,6 +410,7 @@ SQL
 
 @test "status: dolt reset ref properly manages staged changes as well" {
     dolt sql -q "CREATE TABLE tbl(pk int);"
+    dolt add .
     dolt sql -q "INSERT into tbl VALUES (1)"
     dolt commit -am "cm1"
 

--- a/integration-tests/bats/system-tables.bats
+++ b/integration-tests/bats/system-tables.bats
@@ -536,6 +536,7 @@ SQL
 @test "system-tables: dolt diff includes changes from initial commit" {
     dolt sql -q "CREATE TABLE test(pk int primary key, val int)"
     dolt sql -q "INSERT INTO test VALUES (1,1)"
+    dolt add .
     dolt commit -am "cm1"
 
     dolt sql -q "INSERT INTO test VALUES (2,2)"
@@ -549,6 +550,7 @@ SQL
 
 @test "system-tables: query dolt_tags" {
     dolt sql -q "CREATE TABLE test(pk int primary key, val int)"
+    dolt add .
     dolt sql -q "INSERT INTO test VALUES (1,1)"
     dolt commit -am "cm1"
     dolt tag v1 head -m "tag v1 from main"


### PR DESCRIPTION
Fixes #4133.

This PR will fix the `-a` flag in `dolt commit` committing new tables. 

The bulk of this PR is fixing old integration tests, as many of them assumes the old behavior of `dolt commit -am`.