### PR TITLE
create db with specific format depending on currentDB format

### DIFF
--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -249,7 +249,15 @@ func (p DoltDatabaseProvider) CreateDatabase(ctx *sql.Context, name string) erro
 	// TODO: fill in version appropriately
 	dsess := dsess.DSessFromSess(ctx.Session)
 	newEnv := env.Load(ctx, env.GetCurrentUserHomeDir, newFs, p.dbFactoryUrl, "TODO")
-	err = newEnv.InitRepo(ctx, types.Format_Default, dsess.Username(), dsess.Email(), p.defaultBranch)
+
+	// if currentDB is empty, it will create the database with the default format which is the old format
+	newDbStorageFormat := types.Format_Default
+	if curDB := dsess.GetCurrentDatabase(); curDB != "" {
+		if ddb, ok := dsess.GetDoltDB(ctx, curDB); ok {
+			newDbStorageFormat = ddb.ValueReadWriter().Format()
+		}
+	}
+	err = newEnv.InitRepo(ctx, newDbStorageFormat, dsess.Username(), dsess.Email(), p.defaultBranch)
 	if err != nil {
 		return err
 	}

--- a/integration-tests/bats/init.bats
+++ b/integration-tests/bats/init.bats
@@ -253,7 +253,14 @@ teardown() {
 @test "init: create a database when current working directory does not have a database yet" {
     # it creates old format even though there is new format db exists in the current directory.
     set_dolt_user "baz", "baz@bash.com"
-    orig_bin_format=$DOLT_DEFAULT_BIN_FORMAT
+
+    # Default format is OLD (__LD_1__) when DOLT_DEFAULT_BIN_FORMAT is undefined
+    if [ "$DOLT_DEFAULT_BIN_FORMAT" = "" ]
+    then
+        orig_bin_format="__LD_1__"
+    else
+        orig_bin_format=$DOLT_DEFAULT_BIN_FORMAT
+    fi
 
     mkdir new_format && cd new_format
     run dolt init --new-format

--- a/integration-tests/bats/init.bats
+++ b/integration-tests/bats/init.bats
@@ -253,6 +253,7 @@ teardown() {
 @test "init: create a database when current working directory does not have a database yet" {
     # it creates old format even though there is new format db exists in the current directory.
     set_dolt_user "baz", "baz@bash.com"
+    orig_bin_format=$DOLT_DEFAULT_BIN_FORMAT
 
     mkdir new_format && cd new_format
     run dolt init --new-format
@@ -264,6 +265,10 @@ teardown() {
     [[ $output =~ "NEW ( __DOLT__ )" ]] || false
 
     cd ..
+    run dolt version
+    [ "$status" -eq 0 ]
+    [[ $output =~ "no valid database in this directory" ]] || false
+
     dolt sql -q "create database test"
     run ls
     [[ $output =~ "test" ]] || false
@@ -271,8 +276,7 @@ teardown() {
     cd test
     run dolt version
     [ "$status" -eq 0 ]
-    [[ $output =~ "OLD ( __LD_1__ )" ]] || false
-    [[ ! $output =~ "NEW ( __DOLT__ )" ]] || false
+    [[ "$output" =~ "$orig_bin_format" ]] || false
 }
 
 assert_valid_repository () {


### PR DESCRIPTION
`CREATE DATABASE` on new-format DB should create DB with new-format(same format as the currentDB)