### PR TITLE
Add support for ancestor references in database revision specifiers

### DIFF
--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -828,6 +828,42 @@ func (ddb *DoltDB) VisitRefsOfType(ctx context.Context, refTypeFilter map[ref.Re
 	})
 }
 
+// GetRefByNameInsensitive searches this Dolt database's branch, tag, and head refs for a case-insensitive
+// match of the specified ref name. If a matching DoltRef is found, it is returned; otherwise an error is returned.
+func (ddb *DoltDB) GetRefByNameInsensitive(ctx context.Context, refName string) (ref.DoltRef, error) {
+	branchRefs, err := ddb.GetBranches(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, branchRef := range branchRefs {
+		if strings.ToLower(branchRef.GetPath()) == strings.ToLower(refName) {
+			return branchRef, nil
+		}
+	}
+
+	headRefs, err := ddb.GetHeadRefs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, headRef := range headRefs {
+		if strings.ToLower(headRef.GetPath()) == strings.ToLower(refName) {
+			return headRef, nil
+		}
+	}
+
+	tagRefs, err := ddb.GetTags(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, tagRef := range tagRefs {
+		if strings.ToLower(tagRef.GetPath()) == strings.ToLower(refName) {
+			return tagRef, nil
+		}
+	}
+
+	return nil, ref.ErrInvalidRefSpec
+}
+
 func (ddb *DoltDB) GetRefsOfType(ctx context.Context, refTypeFilter map[ref.RefType]struct{}) ([]ref.DoltRef, error) {
 	var refs []ref.DoltRef
 	err := ddb.VisitRefsOfType(ctx, refTypeFilter, func(r ref.DoltRef, _ hash.Hash) error {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -179,6 +179,81 @@ var DescribeTableAsOfScriptTest = queries.ScriptTest{
 
 var DoltRevisionDbScripts = []queries.ScriptTest{
 	{
+		Name: "database revision specs: Ancestor references",
+		SetUpScript: []string{
+			"create table t01 (pk int primary key, c1 int)",
+			"call dolt_commit('-am', 'creating table t01 on main');",
+			"call dolt_branch('branch1');",
+			"insert into t01 values (1, 1), (2, 2);",
+			"call dolt_commit('-am', 'adding rows to table t01 on main');",
+			"insert into t01 values (3, 3);",
+			"call dolt_commit('-am', 'adding another row to table t01 on main');",
+			"call dolt_tag('tag1');",
+			"call dolt_checkout('branch1');",
+			"insert into t01 values (100, 100), (200, 200);",
+			"call dolt_commit('-am', 'inserting rows in t01 on branch1');",
+			"insert into t01 values (1000, 1000);",
+			"call dolt_commit('-am', 'inserting another row in t01 on branch1');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "show databases;",
+				Expected: []sql.Row{{"mydb"}, {"information_schema"}, {"mysql"}},
+			},
+			{
+				Query:    "use `mydb/tag1~`;",
+				Expected: []sql.Row{},
+			},
+			{
+				// The database name should be the resolved commit, not the revision spec we started with.
+				// We can't easily match the exact commit in these tests, so match against a commit hash pattern.
+				Query:    "select database() regexp '^mydb/[0-9a-v]{32}$', database() = 'mydb/tag1~';",
+				Expected: []sql.Row{{true, false}},
+			},
+			{
+				Query:    "select * from t01;",
+				Expected: []sql.Row{{1, 1}, {2, 2}},
+			},
+			{
+				Query:    "select * from `mydb/tag1^`.t01;",
+				Expected: []sql.Row{{1, 1}, {2, 2}},
+			},
+			{
+				// Only merge commits are valid for ^2 ancestor spec
+				Query:          "select * from `mydb/tag1^2`.t01;",
+				ExpectedErrStr: "invalid ancestor spec",
+			},
+			{
+				Query:    "select * from `mydb/tag1~1`.t01;",
+				Expected: []sql.Row{{1, 1}, {2, 2}},
+			},
+			{
+				Query:    "select * from `mydb/tag1~2`.t01;",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:       "select * from `mydb/tag1~3`.t01;",
+				ExpectedErr: sql.ErrTableNotFound,
+			},
+			{
+				Query:    "select * from `mydb/branch1~`.t01;",
+				Expected: []sql.Row{{100, 100}, {200, 200}},
+			},
+			{
+				Query:    "select * from `mydb/branch1^`.t01;",
+				Expected: []sql.Row{{100, 100}, {200, 200}},
+			},
+			{
+				Query:    "select * from `mydb/branch1~2`.t01;",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:       "select * from `mydb/branch1~3`.t01;",
+				ExpectedErr: sql.ErrTableNotFound,
+			},
+		},
+	},
+	{
 		Name: "database revision specs: tag-qualified revision spec",
 		SetUpScript: []string{
 			"create table t01 (pk int primary key, c1 int)",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -182,6 +182,7 @@ var DoltRevisionDbScripts = []queries.ScriptTest{
 		Name: "database revision specs: Ancestor references",
 		SetUpScript: []string{
 			"create table t01 (pk int primary key, c1 int)",
+			"call dolt_add('t01');",
 			"call dolt_commit('-am', 'creating table t01 on main');",
 			"call dolt_branch('branch1');",
 			"insert into t01 values (1, 1), (2, 2);",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -236,6 +236,10 @@ var DoltRevisionDbScripts = []queries.ScriptTest{
 				ExpectedErr: sql.ErrTableNotFound,
 			},
 			{
+				Query:          "select * from `mydb/tag1~20`.t01;",
+				ExpectedErrStr: "invalid ancestor spec",
+			},
+			{
 				Query:    "select * from `mydb/branch1~`.t01;",
 				Expected: []sql.Row{{100, 100}, {200, 200}},
 			},


### PR DESCRIPTION
Enables use of `~` and `^` to reference ancestors in database revision specifiers. 

Fixes: https://github.com/dolthub/dolt/issues/2146