### PR TITLE
Bug fix for Tuple.Compare to return consistent results when comparing against a null value

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -329,6 +329,24 @@ var DoltRevisionDbScripts = []queries.ScriptTest{
 // this slice into others with good names as it grows.
 var DoltScripts = []queries.ScriptTest{
 	{
+		Name: "test null filtering in secondary indexes (https://github.com/dolthub/dolt/issues/4199)",
+		SetUpScript: []string{
+			"create table t (a int primary key auto_increment, d datetime, index index1 (d));",
+			"insert into t (d) values (NOW()), (NOW());",
+			"insert into t (d) values (NULL), (NULL);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "select count(*) from t where d is not null",
+				Expected: []sql.Row{{2}},
+			},
+			{
+				Query:    "select count(*) from t where d is null",
+				Expected: []sql.Row{{2}},
+			},
+		},
+	},
+	{
 		Name: "test backticks in index name (https://github.com/dolthub/dolt/issues/3776)",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c1 int)",

--- a/go/libraries/doltcore/table/typed/noms/range_reader.go
+++ b/go/libraries/doltcore/table/typed/noms/range_reader.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/dolthub/go-mysql-server/sql"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/store/types"
@@ -251,6 +253,43 @@ func (nrr *NomsRangeReader) VerifySchema(outSch schema.Schema) (bool, error) {
 // Close should release resources being held
 func (nrr *NomsRangeReader) Close(ctx context.Context) error {
 	return nil
+}
+
+// SqlRowFromTuples constructs a go-mysql-server/sql.Row from Noms tuples.
+func SqlRowFromTuples(sch schema.Schema, key, val types.Tuple) (sql.Row, error) {
+	allCols := sch.GetAllCols()
+	colVals := make(sql.Row, allCols.Size())
+
+	keySl, err := key.AsSlice()
+	if err != nil {
+		return nil, err
+	}
+	valSl, err := val.AsSlice()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, sl := range []types.TupleValueSlice{keySl, valSl} {
+		var convErr error
+		err := row.IterPkTuple(sl, func(tag uint64, val types.Value) (stop bool, err error) {
+			if idx, ok := allCols.TagToIdx[tag]; ok {
+				col := allCols.GetByIndex(idx)
+				colVals[idx], convErr = col.TypeInfo.ConvertNomsValueToValue(val)
+
+				if convErr != nil {
+					return false, err
+				}
+			}
+
+			return false, nil
+		})
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return sql.NewRow(colVals...), nil
 }
 
 type CardinalityCounter struct {

--- a/go/store/types/tuple.go
+++ b/go/store/types/tuple.go
@@ -690,6 +690,15 @@ func (t Tuple) TupleCompare(nbf *NomsBinFormat, otherTuple Tuple) (int, error) {
 		otherKind := otherDec.ReadKind()
 
 		if kind != otherKind {
+			// If we are comparing any type to a null type, always evaluate
+			// the null value as greater than the non-null value. This is needed
+			// to keep null value ordering consistent in indexes.
+			if kind == NullKind {
+				return 1, nil
+			} else if otherKind == NullKind {
+				return -1, nil
+			}
+
 			return int(kind) - int(otherKind), nil
 		}
 

--- a/go/store/types/tuple_test.go
+++ b/go/store/types/tuple_test.go
@@ -186,6 +186,46 @@ func TestTupleLess(t *testing.T) {
 			[]Value{UUID(uuid.MustParse(OneUUID)), String("abc")},
 			true,
 		},
+		{
+			[]Value{UUID(uuid.MustParse(OneUUID)), String("abc")},
+			[]Value{UUID(uuid.MustParse(OneUUID)), NullValue},
+			true,
+		},
+		{
+			[]Value{UUID(uuid.MustParse(OneUUID)), NullValue},
+			[]Value{UUID(uuid.MustParse(OneUUID)), String("abc")},
+			false,
+		},
+		{
+			[]Value{UUID(uuid.MustParse(OneUUID)), Timestamp(time.Now())},
+			[]Value{UUID(uuid.MustParse(OneUUID)), NullValue},
+			true,
+		},
+		{
+			[]Value{UUID(uuid.MustParse(OneUUID)), NullValue},
+			[]Value{UUID(uuid.MustParse(OneUUID)), Timestamp(time.Now())},
+			false,
+		},
+		{
+			[]Value{UUID(uuid.MustParse(OneUUID)), Int(100)},
+			[]Value{UUID(uuid.MustParse(OneUUID)), NullValue},
+			true,
+		},
+		{
+			[]Value{UUID(uuid.MustParse(OneUUID)), NullValue},
+			[]Value{UUID(uuid.MustParse(OneUUID)), Int(100)},
+			false,
+		},
+		{
+			[]Value{UUID(uuid.MustParse(OneUUID)), Point{1, 1.0, 1.0}},
+			[]Value{UUID(uuid.MustParse(OneUUID)), NullValue},
+			true,
+		},
+		{
+			[]Value{UUID(uuid.MustParse(OneUUID)), NullValue},
+			[]Value{UUID(uuid.MustParse(OneUUID)), Point{1, 1.0, 1.0}},
+			false,
+		},
 	}
 
 	isLTZero := func(n int) bool {
@@ -194,23 +234,25 @@ func TestTupleLess(t *testing.T) {
 
 	nbf := Format_Default
 	for _, test := range tests {
-		tpl1, err := NewTuple(nbf, test.vals1...)
+		t.Run("", func(t *testing.T) {
+			tpl1, err := NewTuple(nbf, test.vals1...)
 
-		require.NoError(t, err)
+			require.NoError(t, err)
 
-		tpl2, err := NewTuple(nbf, test.vals2...)
-		require.NoError(t, err)
+			tpl2, err := NewTuple(nbf, test.vals2...)
+			require.NoError(t, err)
 
-		actual, err := tpl1.Less(nbf, tpl2)
-		require.NoError(t, err)
+			actual, err := tpl1.Less(nbf, tpl2)
+			require.NoError(t, err)
 
-		if actual != test.expected {
-			t.Error("tpl1:", mustString(EncodedValue(context.Background(), tpl1)), "tpl2:", mustString(EncodedValue(context.Background(), tpl2)), "expected", test.expected, "actual:", actual)
-		}
+			if actual != test.expected {
+				t.Error("tpl1:", mustString(EncodedValue(context.Background(), tpl1)), "tpl2:", mustString(EncodedValue(context.Background(), tpl2)), "expected", test.expected, "actual:", actual)
+			}
 
-		res, err := tpl1.Compare(nbf, tpl2)
-		require.NoError(t, err)
-		require.Equal(t, actual, isLTZero(res))
+			res, err := tpl1.Compare(nbf, tpl2)
+			require.NoError(t, err)
+			require.Equal(t, actual, isLTZero(res))
+		})
 	}
 }
 


### PR DESCRIPTION
`Tuple.Compare` / `Tuple.Less` returns inconsistent results when comparing different types against a null value. This caused non-null values for most types to be ordered before null values, but other types like time/date/datetime to have non-null values _after_ null values in the index. That resulted in incorrect query execution because the index range reader saw the null values and exited out before ever evaluating the non-null values. 

Fixes: https://github.com/dolthub/dolt/issues/4199