### PR TITLE
Add dolt diff --skinny flag

### DIFF
--- a/integration-tests/bats/diff.bats
+++ b/integration-tests/bats/diff.bats
@@ -793,7 +793,6 @@ SQL
     [[ "$output" =~ 'pk' ]] || false
     [[ "$output" =~ 'val1' ]] || false
     [[ "$output" =~ 's' ]] || false
-    [[ ! "$output" =~ 'val3' ]] || false
 }
 
 @test "diff: skinny flag only shows row changed when data is changed (row deleted)" {

--- a/integration-tests/bats/diff.bats
+++ b/integration-tests/bats/diff.bats
@@ -720,6 +720,24 @@ SQL
     [[ "$output" = 'UPDATE `t` SET `val1`=30,`val3`=4 WHERE `pk`=1;' ]] || false
 }
 
+@test "diff: skinny flag only shows row changed" {
+    dolt sql -q "create table t(pk int primary key, val1 int, val2 int)"
+    dolt add .
+    dolt sql -q "INSERT INTO t VALUES (1, 1, 1)"
+    dolt commit -am "cm1"
+
+    dolt sql -q "UPDATE t SET val1=2 where pk=1"
+    dolt commit -am "cm2"
+
+    dolt sql -q "UPDATE t SET val1=3 where pk=1"
+    dolt commit -am "cm3"
+
+    run dolt diff --skinny HEAD~1
+    [ $status -eq 0 ]
+    [[ ! "$output" =~ 'val2' ]] || false
+    [[ "$output" =~ 'val1' ]] || false
+}
+
 @test "diff: keyless sql diffs" {
     
     dolt sql -q "create table t(pk int, val int)"

--- a/integration-tests/bats/diff.bats
+++ b/integration-tests/bats/diff.bats
@@ -788,8 +788,6 @@ SQL
     dolt sql -q "UPDATE t SET val1=4 WHERE pk=2"
     dolt commit -am "cm2"
 
-    test=$(dolt diff --skinny --data HEAD~1)
-    echo $test
     run dolt diff --skinny --data HEAD~1
     [ $status -eq 0 ]
     [[ "$output" =~ 'pk' ]] || false

--- a/integration-tests/bats/diff.bats
+++ b/integration-tests/bats/diff.bats
@@ -741,6 +741,7 @@ SQL
     run dolt diff --skinny HEAD~1
     [ $status -eq 0 ]
     [[ ! "$output" =~ 'val2' ]] || false
+    [[ "$output" =~ 'pk' ]] || false
     [[ "$output" =~ 'val1' ]] || false
 }
 


### PR DESCRIPTION
Closes #790 

Adds a `--skinny` flag to `dolt diff`, which only shows primary keys and columns with changes.

 Note that `writeDiffResults` has been split into 2 functions - `writeFilteredRows` and `getDiffRows`. The former is responsible for printing the rows, while the latter function collects the relevant columns, depending on if the `--skinny` flag is active.

Also note that in the event of row addition/deletions, all columns will be included when the `--skinny` flag is active.