### PR TITLE
Adds `dolt_merge_status` system table

### DIFF
--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -379,7 +379,7 @@ func PrintDiffsNotStaged(
 		if linesPrinted > 0 {
 			cli.Println()
 		}
-		iohelp.WriteLine(wr, mergedTableHeader)
+		iohelp.WriteLine(wr, unmergedPathsHeader)
 		if printHelp {
 			iohelp.WriteLine(wr, mergedTableHelp)
 		}
@@ -498,8 +498,8 @@ const (
 	allMergedHeader = `All conflicts and constraint violations fixed but you are still merging.
   (use "dolt commit" to conclude merge)`
 
-	mergedTableHeader = `Unmerged paths:`
-	mergedTableHelp   = `  (use "dolt add <file>..." to mark resolution)`
+	unmergedPathsHeader = `Unmerged paths:`
+	mergedTableHelp     = `  (use "dolt add <file>..." to mark resolution)`
 
 	workingHeader     = `Changes not staged for commit:`
 	workingHeaderHelp = `  (use "dolt add <table>" to update what will be committed)

--- a/go/gen/fb/serial/workingset.go
+++ b/go/gen/fb/serial/workingset.go
@@ -345,7 +345,15 @@ func (rcv *MergeState) MutateFromCommitAddr(j int, n byte) bool {
 	return false
 }
 
-const MergeStateNumFields = 2
+func (rcv *MergeState) FromCommitSpecStr() []byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
+	if o != 0 {
+		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+	}
+	return nil
+}
+
+const MergeStateNumFields = 3
 
 func MergeStateStart(builder *flatbuffers.Builder) {
 	builder.StartObject(MergeStateNumFields)
@@ -361,6 +369,9 @@ func MergeStateAddFromCommitAddr(builder *flatbuffers.Builder, fromCommitAddr fl
 }
 func MergeStateStartFromCommitAddrVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(1, numElems, 1)
+}
+func MergeStateAddFromCommitSpecStr(builder *flatbuffers.Builder, fromCommitSpecStr flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(2, flatbuffers.UOffsetT(fromCommitSpecStr), 0)
 }
 func MergeStateEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()

--- a/go/libraries/doltcore/doltdb/system_table.go
+++ b/go/libraries/doltcore/doltdb/system_table.go
@@ -265,6 +265,9 @@ const (
 	// StatusTableName is the status system table name.
 	StatusTableName = "dolt_status"
 
+	// MergeStatusTableName is the merge status system table name.
+	MergeStatusTableName = "dolt_merge_status"
+
 	// TagsTableName is the tags table name
 	TagsTableName = "dolt_tags"
 )

--- a/go/libraries/doltcore/dtestutils/testcommands/command.go
+++ b/go/libraries/doltcore/dtestutils/testcommands/command.go
@@ -302,7 +302,7 @@ func (m Merge) Exec(t *testing.T, dEnv *env.DoltEnv) error {
 			require.True(t, stats.Conflicts == 0)
 		}
 
-		err = dEnv.StartMerge(context.Background(), cm2)
+		err = dEnv.StartMerge(context.Background(), cm2, dref.String())
 		if err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -769,7 +769,11 @@ func (dEnv *DoltEnv) ClearMerge(ctx context.Context) error {
 	return dEnv.DoltDB.UpdateWorkingSet(ctx, ws.Ref(), ws.ClearMerge(), h, dEnv.workingSetMeta())
 }
 
-func (dEnv *DoltEnv) StartMerge(ctx context.Context, commit *doltdb.Commit) error {
+// StartMerge updates the WorkingSet with merge information. |commit| is the
+// source commit of the merge and |commitSpecStr| is how that |commit| was
+// specified. Typically, |commitSpecStr| is specified by the user, but it could
+// also be specified by a transaction merge.
+func (dEnv *DoltEnv) StartMerge(ctx context.Context, commit *doltdb.Commit, commitSpecStr string) error {
 	ws, err := dEnv.WorkingSet(ctx)
 	if err != nil {
 		return err
@@ -780,7 +784,7 @@ func (dEnv *DoltEnv) StartMerge(ctx context.Context, commit *doltdb.Commit) erro
 		return err
 	}
 
-	return dEnv.DoltDB.UpdateWorkingSet(ctx, ws.Ref(), ws.StartMerge(commit), h, dEnv.workingSetMeta())
+	return dEnv.DoltDB.UpdateWorkingSet(ctx, ws.Ref(), ws.StartMerge(commit, commitSpecStr), h, dEnv.workingSetMeta())
 }
 
 func (dEnv *DoltEnv) IsMergeActive(ctx context.Context) (bool, error) {

--- a/go/libraries/doltcore/env/environment_test.go
+++ b/go/libraries/doltcore/env/environment_test.go
@@ -179,7 +179,7 @@ func TestMigrateWorkingSet(t *testing.T) {
 	// persisted to the working set
 	commit, err := dEnv.DoltDB.ResolveCommitRef(context.Background(), dEnv.RepoState.CWBHeadRef())
 	require.NoError(t, err)
-	ws.StartMerge(commit)
+	ws.StartMerge(commit, "HEAD")
 
 	workingRoot := ws.WorkingRoot()
 	stagedRoot := ws.StagedRoot()

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -461,6 +461,8 @@ func (db Database) getTableInsensitive(ctx *sql.Context, head *doltdb.Commit, ds
 			map[string]env.BranchConfig{},
 			map[string]env.Remote{})
 		dt, found = dtables.NewStatusTable(ctx, db.name, db.ddb, adapter), true
+	case doltdb.MergeStatusTableName:
+		dt, found = dtables.NewMergeStatusTable(db.name), true
 	case doltdb.TagsTableName:
 		dt, found = dtables.NewTagsTable(ctx, db.ddb), true
 	}

--- a/go/libraries/doltcore/sqle/dtables/merge_status_table.go
+++ b/go/libraries/doltcore/sqle/dtables/merge_status_table.go
@@ -1,0 +1,163 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dtables
+
+import (
+	"context"
+	"io"
+	"strings"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/index"
+	"github.com/dolthub/dolt/go/libraries/utils/set"
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+// MergeStatusTable is a sql.Table implementation that implements a system table
+// which shows information about an active merge.
+type MergeStatusTable struct {
+	dbName string
+}
+
+func (s MergeStatusTable) Name() string {
+	return doltdb.MergeStatusTableName
+}
+
+func (s MergeStatusTable) String() string {
+	return doltdb.MergeStatusTableName
+}
+
+func (s MergeStatusTable) Schema() sql.Schema {
+	return []*sql.Column{
+		{Name: "is_merging", Type: sql.Boolean, Source: doltdb.MergeStatusTableName, PrimaryKey: false, Nullable: false},
+		{Name: "source", Type: sql.Text, Source: doltdb.MergeStatusTableName, PrimaryKey: false, Nullable: true},
+		{Name: "source_commit", Type: sql.Text, Source: doltdb.MergeStatusTableName, PrimaryKey: false, Nullable: true},
+		{Name: "target", Type: sql.Text, Source: doltdb.MergeStatusTableName, PrimaryKey: false, Nullable: true},
+		{Name: "unmerged_tables", Type: sql.Text, Source: doltdb.MergeStatusTableName, PrimaryKey: false, Nullable: true},
+	}
+}
+
+func (s MergeStatusTable) Collation() sql.CollationID {
+	return sql.Collation_Default
+}
+
+func (s MergeStatusTable) Partitions(*sql.Context) (sql.PartitionIter, error) {
+	return index.SinglePartitionIterFromNomsMap(nil), nil
+}
+
+func (s MergeStatusTable) PartitionRows(ctx *sql.Context, _ sql.Partition) (sql.RowIter, error) {
+	sesh := dsess.DSessFromSess(ctx.Session)
+	ws, err := sesh.WorkingSet(ctx, s.dbName)
+	if err != nil {
+		return nil, err
+	}
+
+	return newMergeStatusItr(ctx, ws)
+}
+
+// NewMergeStatusTable creates a StatusTable
+func NewMergeStatusTable(dbName string) sql.Table {
+	return &MergeStatusTable{dbName}
+}
+
+// MergeStatusIter is a sql.RowItr implementation which iterates over each commit as if it's a row in the table.
+type MergeStatusIter struct {
+	idx            int
+	isMerging      bool
+	sourceCommit   *string
+	source         *string
+	target         *string
+	unmergedTables *string
+}
+
+func newMergeStatusItr(ctx context.Context, ws *doltdb.WorkingSet) (*MergeStatusIter, error) {
+	wr := ws.WorkingRoot()
+
+	inConflict, err := wr.TablesInConflict(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	tblsWithViolations, err := wr.TablesWithConstraintViolations(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	unmergedTblNames := set.NewStrSet(inConflict)
+	unmergedTblNames.Add(tblsWithViolations...)
+
+	var sourceCommitSpecStr *string
+	var sourceCommitHash *string
+	var target *string
+	var unmergedTables *string
+	if ws.MergeActive() {
+		state := ws.MergeState()
+
+		s := state.CommitSpecStr()
+		sourceCommitSpecStr = &s
+
+		cmHash, err := state.Commit().HashOf()
+		if err != nil {
+			return nil, err
+		}
+		s2 := cmHash.String()
+		sourceCommitHash = &s2
+
+		curr, err := ws.Ref().ToHeadRef()
+		if err != nil {
+			return nil, err
+		}
+		s3 := curr.String()
+		target = &s3
+
+		s4 := strings.Join(unmergedTblNames.AsSlice(), ", ")
+		unmergedTables = &s4
+	}
+
+	return &MergeStatusIter{
+		idx:            0,
+		isMerging:      ws.MergeActive(),
+		source:         sourceCommitSpecStr,
+		sourceCommit:   sourceCommitHash,
+		target:         target,
+		unmergedTables: unmergedTables,
+	}, nil
+}
+
+// Next retrieves the next row.
+func (itr *MergeStatusIter) Next(*sql.Context) (sql.Row, error) {
+	if itr.idx >= 1 {
+		return nil, io.EOF
+	}
+
+	defer func() {
+		itr.idx++
+	}()
+
+	return sql.NewRow(itr.isMerging, unwrapString(itr.source), unwrapString(itr.sourceCommit), unwrapString(itr.target), unwrapString(itr.unmergedTables)), nil
+}
+
+func unwrapString(s *string) interface{} {
+	if s == nil {
+		return nil
+	}
+	return *s
+}
+
+// Close closes the iterator.
+func (itr *MergeStatusIter) Close(*sql.Context) error {
+	return nil
+}

--- a/go/libraries/doltcore/sqle/dtables/merge_status_table.go
+++ b/go/libraries/doltcore/sqle/dtables/merge_status_table.go
@@ -19,11 +19,12 @@ import (
 	"io"
 	"strings"
 
+	"github.com/dolthub/go-mysql-server/sql"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/index"
 	"github.com/dolthub/dolt/go/libraries/utils/set"
-	"github.com/dolthub/go-mysql-server/sql"
 )
 
 // MergeStatusTable is a sql.Table implementation that implements a system table

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -1329,6 +1329,10 @@ var MergeScripts = []queries.ScriptTest{
 				Expected: []sql.Row{{1, 0}},
 			},
 			{
+				Query:    "SELECT is_merging, source, target, unmerged_tables FROM DOLT_MERGE_STATUS;",
+				Expected: []sql.Row{{false, nil, nil, nil}},
+			},
+			{
 				Query:    "SELECT * from dolt_status",
 				Expected: []sql.Row{},
 			},
@@ -1361,6 +1365,10 @@ var MergeScripts = []queries.ScriptTest{
 				// No-FF-Merge
 				Query:    "CALL DOLT_MERGE('feature-branch', '-no-ff', '-m', 'this is a no-ff')",
 				Expected: []sql.Row{{1, 0}},
+			},
+			{
+				Query:    "SELECT is_merging, source, target, unmerged_tables FROM DOLT_MERGE_STATUS;",
+				Expected: []sql.Row{{false, nil, nil, nil}},
 			},
 			{
 				Query:    "SELECT * from dolt_status",
@@ -1402,6 +1410,10 @@ var MergeScripts = []queries.ScriptTest{
 				Expected: []sql.Row{{0, 0}},
 			},
 			{
+				Query:    "SELECT is_merging, source, target, unmerged_tables FROM DOLT_MERGE_STATUS;",
+				Expected: []sql.Row{{false, nil, nil, nil}},
+			},
+			{
 				Query:    "SELECT COUNT(*) from dolt_status",
 				Expected: []sql.Row{{0}},
 			},
@@ -1435,6 +1447,10 @@ var MergeScripts = []queries.ScriptTest{
 			{
 				Query:    "CALL DOLT_MERGE('feature-branch', '-m', 'this is a merge', '--no-commit')",
 				Expected: []sql.Row{{0, 0}},
+			},
+			{
+				Query:    "SELECT is_merging, source, target, unmerged_tables FROM DOLT_MERGE_STATUS;",
+				Expected: []sql.Row{{true, "feature-branch", "refs/heads/main", ""}},
 			},
 			{
 				Query:    "SELECT COUNT(*) from dolt_status",
@@ -1475,6 +1491,10 @@ var MergeScripts = []queries.ScriptTest{
 			{
 				Query:    "CALL DOLT_MERGE('feature-branch', '-m', 'this is a merge')",
 				Expected: []sql.Row{{0, 1}},
+			},
+			{
+				Query:    "SELECT is_merging, source, target, unmerged_tables FROM DOLT_MERGE_STATUS;",
+				Expected: []sql.Row{{true, "feature-branch", "refs/heads/main", "test"}},
 			},
 			{
 				Query:    "SELECT * from dolt_status",
@@ -1592,6 +1612,10 @@ var MergeScripts = []queries.ScriptTest{
 				Expected: []sql.Row{{1, 0}},
 			},
 			{
+				Query:    "SELECT is_merging, source, target, unmerged_tables FROM DOLT_MERGE_STATUS;",
+				Expected: []sql.Row{{false, nil, nil, nil}},
+			},
+			{
 				Query:    "SELECT * from dolt_status",
 				Expected: []sql.Row{},
 			},
@@ -1623,6 +1647,10 @@ var MergeScripts = []queries.ScriptTest{
 				// No-FF-Merge
 				Query:    "CALL DOLT_MERGE('feature-branch', '-no-ff', '-m', 'this is a no-ff')",
 				Expected: []sql.Row{{1, 0}},
+			},
+			{
+				Query:    "SELECT is_merging, source, target, unmerged_tables FROM DOLT_MERGE_STATUS;",
+				Expected: []sql.Row{{false, nil, nil, nil}},
 			},
 			{
 				Query:    "SELECT * from dolt_status",
@@ -1748,6 +1776,10 @@ var MergeScripts = []queries.ScriptTest{
 				Expected: []sql.Row{{0}},
 			},
 			{
+				Query:    "SELECT is_merging, source, target, unmerged_tables FROM DOLT_MERGE_STATUS;",
+				Expected: []sql.Row{{false, nil, nil, nil}},
+			},
+			{
 				Query:    "SELECT * FROM test",
 				Expected: []sql.Row{{0, 1001}},
 			},
@@ -1807,6 +1839,10 @@ var MergeScripts = []queries.ScriptTest{
 				Expected: []sql.Row{{0}},
 			},
 			{
+				Query:    "SELECT is_merging, source, target, unmerged_tables FROM DOLT_MERGE_STATUS;",
+				Expected: []sql.Row{{false, nil, nil, nil}},
+			},
+			{
 				Query:    "SELECT * from dolt_status",
 				Expected: []sql.Row{},
 			},
@@ -1843,6 +1879,10 @@ var MergeScripts = []queries.ScriptTest{
 			{
 				Query:       "CALL DOLT_MERGE('feature-branch', '-m', 'this is a merge')",
 				ExpectedErr: dfunctions.ErrUncommittedChanges,
+			},
+			{
+				Query:    "SELECT is_merging, source, target, unmerged_tables FROM DOLT_MERGE_STATUS;",
+				Expected: []sql.Row{{false, nil, nil, nil}},
 			},
 		},
 	},
@@ -1917,6 +1957,7 @@ var MergeScripts = []queries.ScriptTest{
 			"CALL DOLT_BRANCH('other');",
 			"DELETE from parent WHERE pk = 20;",
 			"CALL DOLT_COMMIT('-am', 'MC2');",
+
 			"CALL DOLT_CHECKOUT('other');",
 			"INSERT INTO child VALUES (2, 2);",
 			"CALL DOLT_COMMIT('-am', 'OC1');",
@@ -1976,6 +2017,10 @@ var MergeScripts = []queries.ScriptTest{
 			{
 				Query:    "SELECT violation_type, pk, col1 from dolt_constraint_violations_t;",
 				Expected: []sql.Row{{uint64(merge.CvType_UniqueIndex), 1, 1}, {uint64(merge.CvType_UniqueIndex), 2, 1}},
+			},
+			{
+				Query:    "SELECT is_merging, source, target, unmerged_tables FROM DOLT_MERGE_STATUS;",
+				Expected: []sql.Row{{true, "right", "refs/heads/main", "t"}},
 			},
 		},
 	},

--- a/go/serial/workingset.fbs
+++ b/go/serial/workingset.fbs
@@ -32,6 +32,10 @@ table MergeState {
 
   // The commit that we are merging.
   from_commit_addr:[ubyte] (required);
+
+  // The spec that was used to identify the commit that we are merging. Optional
+  // for backwards compatibility.
+  from_commit_spec_str:string;
 }
 
 // KEEP THIS IN SYNC WITH fileidentifiers.go

--- a/integration-tests/bats/reset.bats
+++ b/integration-tests/bats/reset.bats
@@ -60,6 +60,10 @@ merge_with_conflicts() {
 @test "reset: dolt reset --hard should clear an uncommitted merge state" {
     merge_without_conflicts
 
+    run dolt sql -q "SELECT * from dolt_merge_status;"
+    echo $output
+    [[ "$output" =~ "false" ]] || false
+
     run dolt reset --hard
     [ $status -eq 0 ]
 
@@ -68,11 +72,20 @@ merge_with_conflicts() {
 
     run dolt merge --abort
     [[ "$output" =~ "fatal: There is no merge to abort" ]]
+
+    run dolt sql -q "SELECT * from dolt_merge_status;"
+    [[ "$output" =~ "false" ]]
 }
 
 @test "reset: dolt reset --hard should clear a conflicted merge state" {
     merge_with_conflicts
 
+    run dolt sql -q "SELECT * from dolt_merge_status;"
+    [[ "$output" =~ "true" ]] || false
+    [[ "$output" =~ "merge_branch" ]] || false
+    [[ "$output" =~ "refs/heads/main" ]] || false
+    [[ "$output" =~ "test1" ]] || false
+
     run dolt reset --hard
     [ $status -eq 0 ]
 
@@ -81,4 +94,7 @@ merge_with_conflicts() {
 
     run dolt merge --abort
     [[ "$output" =~ "fatal: There is no merge to abort" ]]
+
+    run dolt sql -q "SELECT * from dolt_merge_status;"
+    [[ "$output" =~ "false" ]]
 }


### PR DESCRIPTION
Closes https://github.com/dolthub/dolt/issues/3504

The `dolt_merge_status` system table tells a user if a merge is active. It has the following schema:
```sql
CREATE TABLE `dolt_merge_status` (
-- Whether a merge is currently active or not
  `is_merging` tinyint NOT NULL, 
 -- The commit spec that was used to initiate the merge
  `source` text,
-- The commit that the commit spec resolved to at the time of merge
  `source_commit` text, 
-- The target destination working set
  `target` text, 
-- A list of tables that have conflicts or constraint violations
  `unmerged_tables` text 
)
```

For example, lets create a simple conflict:
```bash
dolt sql -q "CREATE TABLE t (a INT PRIMARY KEY, b INT);"
dolt add .
dolt commit -am "base"

dolt checkout -b right
dolt sql <<SQL
ALTER TABLE t ADD c INT;
INSERT INTO t VALUES (1, 2, 1);
SQL
dolt commit -am "right"

dolt checkout main
dolt sql -q "INSERT INTO t values (1, 3);"
dolt commit -am "left"

dolt merge right
```

Output of `SELECT * from dolt_merge_status;`:
```
+------------+--------+----------------------------------+-----------------+-----------------+
| is_merging | source | source_commit                    | target          | unmerged_tables |
+------------+--------+----------------------------------+-----------------+-----------------+
| true       | right  | fbghslue1k9cfgbi00ti4r8417frgbca | refs/heads/main | t               |
+------------+--------+----------------------------------+-----------------+-----------------+
```
