### PR TITLE
fix enum panics in history table

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -1277,6 +1277,24 @@ var HistorySystemTableScriptTests = []queries.ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "dolt_history table with enums",
+		SetUpScript: []string{
+			"create table t (pk int primary key, c1 enum('foo','bar'));",
+			"call dolt_add('-A');",
+			"call dolt_commit('-m', 'creating table t');",
+			"insert into t values (1, 'foo');",
+			"call dolt_commit('-am', 'added values');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "select c1 from dolt_history_t;",
+				Expected: []sql.Row{
+					{uint64(1)},
+				},
+			},
+		},
+	},
 }
 
 // BrokenHistorySystemTableScriptTests contains tests that work for non-prepared, but don't work

--- a/go/libraries/doltcore/sqle/history_table.go
+++ b/go/libraries/doltcore/sqle/history_table.go
@@ -473,18 +473,6 @@ func rowConverter(srcSchema, targetSchema sql.Schema, h hash.Hash, meta *datas.C
 		if srcIdx >= 0 {
 			// only add a conversion if the type is the same
 			// TODO: we could do a projection to convert between types in some cases
-			//sourceType :=
-			//targetType :=
-			//
-			//// enumtypes contain a map, which panics when == opeartor is used
-			//_, srcIsEnum := sourceType.(sql.EnumType)
-			//_, tarIsEnum := targetType.(sql.EnumType)
-			//if srcIsEnum && tarIsEnum {
-			//	srcToTarget[srcIdx] = i
-			//} else if sourceType == targetType {
-			//	srcToTarget[srcIdx] = i
-			//}
-			
 			if srcSchema[srcIdx].Type.Equals(targetSchema[i].Type) {
 				srcToTarget[srcIdx] = i
 			}

--- a/go/libraries/doltcore/sqle/history_table.go
+++ b/go/libraries/doltcore/sqle/history_table.go
@@ -473,15 +473,19 @@ func rowConverter(srcSchema, targetSchema sql.Schema, h hash.Hash, meta *datas.C
 		if srcIdx >= 0 {
 			// only add a conversion if the type is the same
 			// TODO: we could do a projection to convert between types in some cases
-			sourceType := srcSchema[srcIdx].Type
-			targetType := targetSchema[i].Type
-
-			// enumtypes contain a map, which panics when == opeartor is used
-			_, srcIsEnum := sourceType.(sql.EnumType)
-			_, tarIsEnum := targetType.(sql.EnumType)
-			if srcIsEnum && tarIsEnum {
-				srcToTarget[srcIdx] = i
-			} else if sourceType == targetType {
+			//sourceType :=
+			//targetType :=
+			//
+			//// enumtypes contain a map, which panics when == opeartor is used
+			//_, srcIsEnum := sourceType.(sql.EnumType)
+			//_, tarIsEnum := targetType.(sql.EnumType)
+			//if srcIsEnum && tarIsEnum {
+			//	srcToTarget[srcIdx] = i
+			//} else if sourceType == targetType {
+			//	srcToTarget[srcIdx] = i
+			//}
+			
+			if srcSchema[srcIdx].Type.Equals(targetSchema[i].Type) {
 				srcToTarget[srcIdx] = i
 			}
 		}

--- a/go/libraries/doltcore/sqle/history_table.go
+++ b/go/libraries/doltcore/sqle/history_table.go
@@ -473,7 +473,15 @@ func rowConverter(srcSchema, targetSchema sql.Schema, h hash.Hash, meta *datas.C
 		if srcIdx >= 0 {
 			// only add a conversion if the type is the same
 			// TODO: we could do a projection to convert between types in some cases
-			if srcSchema[srcIdx].Type == targetSchema[i].Type {
+			sourceType := srcSchema[srcIdx].Type
+			targetType := targetSchema[i].Type
+
+			// enumtypes contain a map, which panics when == opeartor is used
+			_, srcIsEnum := sourceType.(sql.EnumType)
+			_, tarIsEnum := targetType.(sql.EnumType)
+			if srcIsEnum && tarIsEnum {
+				srcToTarget[srcIdx] = i
+			} else if sourceType == targetType {
 				srcToTarget[srcIdx] = i
 			}
 		}


### PR DESCRIPTION
Closes: https://github.com/dolthub/dolt/issues/4279

`sql.enumtype` contains a map, which in golang cannot be used in `==` operator