### PR TITLE
[no-release-notes] Document and refactor `skip.List`

### DIFF
--- a/go/store/prolly/range_iter.go
+++ b/go/store/prolly/range_iter.go
@@ -133,11 +133,11 @@ func memIterFromRange(list *skip.List, rng Range) *memRangeIter {
 	}
 }
 
-// skipSearchFromRange is a skip.SearchFn used to initialize
-// a skip.List iterator for a given Range. The skip.SearchFn
+// skipSearchFromRange is a skip.SeekFn used to initialize
+// a skip.List iterator for a given Range. The skip.SeekFn
 // returns true if the iter being initialized is not yet
 // within the bounds of Range |rng|.
-func skipSearchFromRange(rng Range) skip.SearchFn {
+func skipSearchFromRange(rng Range) skip.SeekFn {
 	return func(nodeKey []byte) bool {
 		if nodeKey == nil {
 			return false

--- a/go/store/skip/list.go
+++ b/go/store/skip/list.go
@@ -92,11 +92,13 @@ func (l *List) Checkpoint() {
 
 // Revert reverts to the last recorded checkpoint.
 func (l *List) Revert() {
-	keepers := l.nodes[1:l.checkpoint]
+	cp := l.checkpoint
+	keepers := l.nodes[1:cp]
 	l.Truncate()
 	for _, nd := range keepers {
 		l.Put(nd.key, nd.val)
 	}
+	l.checkpoint = cp
 }
 
 // Truncate deletes all entries from the list.

--- a/go/store/skip/list_test.go
+++ b/go/store/skip/list_test.go
@@ -86,6 +86,125 @@ func TestMemoryFootprint(t *testing.T) {
 	assert.Equal(t, 20, sz)
 }
 
+func BenchmarkList(b *testing.B) {
+	b.Run("benchmark Get", func(b *testing.B) {
+		b.Run("n=64", func(b *testing.B) {
+			vals := randomInts(64)
+			l := NewSkipList(bytes.Compare)
+			for i := range vals {
+				l.Put(vals[i], vals[i])
+			}
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				_, ok := l.Get(vals[i%64])
+				if !ok {
+					b.Fail()
+				}
+			}
+			b.ReportAllocs()
+		})
+		b.Run("n=512", func(b *testing.B) {
+			vals := randomInts(512)
+			l := NewSkipList(bytes.Compare)
+			for i := range vals {
+				l.Put(vals[i], vals[i])
+			}
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				_, ok := l.Get(vals[i%512])
+				if !ok {
+					b.Fail()
+				}
+			}
+			b.ReportAllocs()
+		})
+		b.Run("n=4096", func(b *testing.B) {
+			vals := randomInts(4096)
+			l := NewSkipList(bytes.Compare)
+			for i := range vals {
+				l.Put(vals[i], vals[i])
+			}
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				_, ok := l.Get(vals[i%4096])
+				if !ok {
+					b.Fail()
+				}
+			}
+			b.ReportAllocs()
+		})
+		b.Run("n=32768", func(b *testing.B) {
+			vals := randomInts(32768)
+			l := NewSkipList(bytes.Compare)
+			for i := range vals {
+				l.Put(vals[i], vals[i])
+			}
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				_, ok := l.Get(vals[i%32768])
+				if !ok {
+					b.Fail()
+				}
+			}
+			b.ReportAllocs()
+		})
+	})
+	b.Run("benchmark Put", func(b *testing.B) {
+		b.Run("n=64", func(b *testing.B) {
+			vals := randomInts(64)
+			l := NewSkipList(bytes.Compare)
+			for i := 0; i < b.N; i++ {
+				j := i % 64
+				if j == 0 {
+					l.Truncate()
+				}
+				l.Put(vals[j], vals[j])
+			}
+			b.ReportAllocs()
+		})
+		b.Run("n=512", func(b *testing.B) {
+			vals := randomInts(512)
+			l := NewSkipList(bytes.Compare)
+			for i := 0; i < b.N; i++ {
+				j := i % 512
+				if j == 0 {
+					l.Truncate()
+				}
+				l.Put(vals[j], vals[j])
+			}
+			b.ReportAllocs()
+		})
+		b.Run("n=4096", func(b *testing.B) {
+			vals := randomInts(4096)
+			l := NewSkipList(bytes.Compare)
+			for i := 0; i < b.N; i++ {
+				j := i % 4096
+				if j == 0 {
+					l.Truncate()
+				}
+				l.Put(vals[j], vals[j])
+			}
+			b.ReportAllocs()
+		})
+		b.Run("n=32768", func(b *testing.B) {
+			vals := randomInts(32768)
+			l := NewSkipList(bytes.Compare)
+			for i := 0; i < b.N; i++ {
+				j := i % 32768
+				if j == 0 {
+					l.Truncate()
+				}
+				l.Put(vals[j], vals[j])
+			}
+			b.ReportAllocs()
+		})
+	})
+}
+
 func testSkipList(t *testing.T, compare ValueCmp, vals ...[]byte) {
 	src.Shuffle(len(vals), func(i, j int) {
 		vals[i], vals[j] = vals[j], vals[i]

--- a/go/store/skip/list_test.go
+++ b/go/store/skip/list_test.go
@@ -25,10 +25,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// var src = rand.New(rand.NewSource(time.Now().Unix()))
-var src = rand.New(rand.NewSource(0))
-
 func TestSkipList(t *testing.T) {
+	// set constant seed to improve debugging
+	randSrc = rand.New(rand.NewSource(0))
+
 	t.Run("test skip list", func(t *testing.T) {
 		vals := [][]byte{
 			b("a"), b("b"), b("c"), b("d"), b("e"),
@@ -39,7 +39,7 @@ func TestSkipList(t *testing.T) {
 	})
 
 	t.Run("test skip list of random bytes", func(t *testing.T) {
-		vals := randomVals((src.Int63() % 10_000) + 100)
+		vals := randomVals((randSrc.Int63() % 10_000) + 100)
 		testSkipList(t, bytes.Compare, vals...)
 	})
 	t.Run("test with custom compare function", func(t *testing.T) {
@@ -48,7 +48,7 @@ func TestSkipList(t *testing.T) {
 			r := int64(binary.LittleEndian.Uint64(right))
 			return int(l - r)
 		}
-		vals := randomInts((src.Int63() % 10_000) + 100)
+		vals := randomInts((randSrc.Int63() % 10_000) + 100)
 		testSkipList(t, compare, vals...)
 	})
 }
@@ -64,7 +64,7 @@ func TestSkipListCheckpoints(t *testing.T) {
 	})
 
 	t.Run("test skip list of random bytes", func(t *testing.T) {
-		vals := randomVals((src.Int63() % 10_000) + 100)
+		vals := randomVals((randSrc.Int63() % 10_000) + 100)
 		testSkipListCheckpoints(t, bytes.Compare, vals...)
 	})
 	t.Run("test with custom compare function", func(t *testing.T) {
@@ -73,7 +73,7 @@ func TestSkipListCheckpoints(t *testing.T) {
 			r := int64(binary.LittleEndian.Uint64(right))
 			return int(l - r)
 		}
-		vals := randomInts((src.Int63() % 10_000) + 100)
+		vals := randomInts((randSrc.Int63() % 10_000) + 100)
 		testSkipListCheckpoints(t, compare, vals...)
 	})
 }
@@ -81,9 +81,9 @@ func TestSkipListCheckpoints(t *testing.T) {
 func TestMemoryFootprint(t *testing.T) {
 	var sz int
 	sz = int(unsafe.Sizeof(skipNode{}))
-	assert.Equal(t, 80, sz)
+	assert.Equal(t, 104, sz)
 	sz = int(unsafe.Sizeof(skipPointer{}))
-	assert.Equal(t, 20, sz)
+	assert.Equal(t, 40, sz)
 }
 
 func BenchmarkList(b *testing.B) {
@@ -205,8 +205,8 @@ func BenchmarkList(b *testing.B) {
 	})
 }
 
-func testSkipList(t *testing.T, compare ValueCmp, vals ...[]byte) {
-	src.Shuffle(len(vals), func(i, j int) {
+func testSkipList(t *testing.T, compare KeyOrder, vals ...[]byte) {
+	randSrc.Shuffle(len(vals), func(i, j int) {
 		vals[i], vals[j] = vals[j], vals[i]
 	})
 
@@ -244,8 +244,8 @@ func testSkipListPuts(t *testing.T, list *List, vals ...[]byte) {
 }
 
 func testSkipListGets(t *testing.T, list *List, vals ...[]byte) {
-	// get in different order
-	src.Shuffle(len(vals), func(i, j int) {
+	// get in different keyOrder
+	randSrc.Shuffle(len(vals), func(i, j int) {
 		vals[i], vals[j] = vals[j], vals[i]
 	})
 
@@ -268,7 +268,7 @@ func testSkipListUpdates(t *testing.T, list *List, vals ...[]byte) {
 	}
 	assert.Equal(t, len(vals), list.Count())
 
-	src.Shuffle(len(vals), func(i, j int) {
+	randSrc.Shuffle(len(vals), func(i, j int) {
 		vals[i], vals[j] = vals[j], vals[i]
 	})
 	for _, exp := range vals {
@@ -282,7 +282,7 @@ func testSkipListUpdates(t *testing.T, list *List, vals ...[]byte) {
 }
 
 func testSkipListIterForward(t *testing.T, list *List, vals ...[]byte) {
-	// put |vals| back in order
+	// put |vals| back in keyOrder
 	sort.Slice(vals, func(i, j int) bool {
 		return list.compareKeys(vals[i], vals[j]) < 0
 	})
@@ -297,7 +297,7 @@ func testSkipListIterForward(t *testing.T, list *List, vals ...[]byte) {
 
 	// test iter at
 	for k := 0; k < 10; k++ {
-		idx = src.Int() % len(vals)
+		idx = randSrc.Int() % len(vals)
 		key := vals[idx]
 		act := validateIterForwardFrom(t, list, key)
 		exp := len(vals) - idx
@@ -311,14 +311,14 @@ func testSkipListIterForward(t *testing.T, list *List, vals ...[]byte) {
 }
 
 func testSkipListIterBackward(t *testing.T, list *List, vals ...[]byte) {
-	// put |vals| back in order
+	// put |vals| back in keyOrder
 	sort.Slice(vals, func(i, j int) bool {
 		return list.compareKeys(vals[i], vals[j]) < 0
 	})
 
 	// test iter at
 	for k := 0; k < 10; k++ {
-		idx := src.Int() % len(vals)
+		idx := randSrc.Int() % len(vals)
 		key := vals[idx]
 		act := validateIterBackwardFrom(t, list, key)
 		assert.Equal(t, idx+1, act)
@@ -395,8 +395,8 @@ func validateIterBackwardFrom(t *testing.T, l *List, key []byte) (count int) {
 func randomVals(cnt int64) (vals [][]byte) {
 	vals = make([][]byte, cnt)
 	for i := range vals {
-		bb := make([]byte, (src.Int63()%91)+10)
-		src.Read(bb)
+		bb := make([]byte, (randSrc.Int63()%91)+10)
+		randSrc.Read(bb)
 		vals[i] = bb
 	}
 	return
@@ -406,7 +406,7 @@ func randomInts(cnt int64) (vals [][]byte) {
 	vals = make([][]byte, cnt)
 	for i := range vals {
 		vals[i] = make([]byte, 8)
-		v := uint64(src.Int63())
+		v := uint64(randSrc.Int63())
 		binary.LittleEndian.PutUint64(vals[i], v)
 	}
 	return
@@ -436,8 +436,8 @@ func iterAllBackwards(l *List, cb func([]byte, []byte)) {
 	}
 }
 
-func testSkipListCheckpoints(t *testing.T, compare ValueCmp, data ...[]byte) {
-	src.Shuffle(len(data), func(i, j int) {
+func testSkipListCheckpoints(t *testing.T, compare KeyOrder, data ...[]byte) {
+	randSrc.Shuffle(len(data), func(i, j int) {
 		data[i], data[j] = data[j], data[i]
 	})
 

--- a/go/store/skip/list_test.go
+++ b/go/store/skip/list_test.go
@@ -82,7 +82,7 @@ func TestMemoryFootprint(t *testing.T) {
 	var sz int
 	sz = int(unsafe.Sizeof(skipNode{}))
 	assert.Equal(t, 104, sz)
-	sz = int(unsafe.Sizeof(skipPointer{}))
+	sz = int(unsafe.Sizeof(tower{}))
 	assert.Equal(t, 40, sz)
 }
 

--- a/go/store/skip/list_test.go
+++ b/go/store/skip/list_test.go
@@ -25,10 +25,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSkipList(t *testing.T) {
-	// set constant seed to improve debugging
-	randSrc = rand.New(rand.NewSource(0))
+var randSrc = rand.New(rand.NewSource(0))
 
+func TestSkipList(t *testing.T) {
 	t.Run("test skip list", func(t *testing.T) {
 		vals := [][]byte{
 			b("a"), b("b"), b("c"), b("d"), b("e"),


### PR DESCRIPTION
Improves `skip.List` performance for large lists by increasing max tower height from 5 to 10, and decreasing height-promotion probabilities.

before:
```
BenchmarkList
BenchmarkList/benchmark_Get
BenchmarkList/benchmark_Get/n=64
BenchmarkList/benchmark_Get/n=64-12    	 6292303	       217.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkList/benchmark_Get/n=512
BenchmarkList/benchmark_Get/n=512-12   	 4007974	       311.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkList/benchmark_Get/n=4096
BenchmarkList/benchmark_Get/n=4096-12  	 2511993	       513.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkList/benchmark_Get/n=32768
BenchmarkList/benchmark_Get/n=32768-12 	 1265131	       869.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkList/benchmark_Put
BenchmarkList/benchmark_Put/n=64
BenchmarkList/benchmark_Put/n=64-12    	 5640423	       213.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkList/benchmark_Put/n=512
BenchmarkList/benchmark_Put/n=512-12   	 4248255	       271.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkList/benchmark_Put/n=4096
BenchmarkList/benchmark_Put/n=4096-12  	 2934957	       447.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkList/benchmark_Put/n=32768
BenchmarkList/benchmark_Put/n=32768-12 	 1643672	       750.1 ns/op	       8 B/op	       0 allocs/op
PASS
```

after
```
BenchmarkList
BenchmarkList/benchmark_Get
BenchmarkList/benchmark_Get/n=64
BenchmarkList/benchmark_Get/n=64-12    	 5316765	       216.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkList/benchmark_Get/n=512
BenchmarkList/benchmark_Get/n=512-12   	 4198186	       288.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkList/benchmark_Get/n=4096
BenchmarkList/benchmark_Get/n=4096-12  	 2714745	       466.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkList/benchmark_Get/n=32768
BenchmarkList/benchmark_Get/n=32768-12 	 1846780	       594.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkList/benchmark_Put
BenchmarkList/benchmark_Put/n=64
BenchmarkList/benchmark_Put/n=64-12    	 4557384	       281.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkList/benchmark_Put/n=512
BenchmarkList/benchmark_Put/n=512-12   	 3194649	       376.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkList/benchmark_Put/n=4096
BenchmarkList/benchmark_Put/n=4096-12  	 2577404	       472.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkList/benchmark_Put/n=32768
BenchmarkList/benchmark_Put/n=32768-12 	 1731177	       652.3 ns/op	      10 B/op	       0 allocs/op
PASS

```