### PR TITLE
go/utils/remotesrv: Make remotesrv implementation into a library which can be used from dolt proper.

### DIFF
--- a/go/libraries/doltcore/remotesrv/dbcache.go
+++ b/go/libraries/doltcore/remotesrv/dbcache.go
@@ -1,0 +1,36 @@
+// Copyright 2019 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remotesrv
+
+import (
+	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/dolthub/dolt/go/store/nbs"
+)
+
+type DBCache interface {
+	Get(org, repo, nbfVerStr string) (RemoteSrvStore, error)
+}
+
+type RemoteSrvStore interface {
+	chunks.ChunkStore
+	nbs.TableFileStore
+
+	Path() (string, bool)
+	GetChunkLocationsWithPaths(hashes hash.HashSet) (map[string]map[hash.Hash]nbs.Range, error)
+}
+
+var _ RemoteSrvStore = &nbs.NomsBlockStore{}
+var _ RemoteSrvStore = &nbs.GenerationalNBS{}

--- a/go/libraries/doltcore/remotesrv/grpc.go
+++ b/go/libraries/doltcore/remotesrv/grpc.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package remotesrv
 
 import (
 	"context"
@@ -90,7 +90,7 @@ func (rs *RemoteChunkStore) HasChunks(ctx context.Context, req *remotesapi.HasCh
 	return resp, nil
 }
 
-func (rs *RemoteChunkStore) getRelativeStorePath(cs store) (string, error) {
+func (rs *RemoteChunkStore) getRelativeStorePath(cs RemoteSrvStore) (string, error) {
 	cspath, ok := cs.Path()
 	if !ok {
 		return "", status.Error(codes.Internal, "chunkstore misconfigured; cannot generate HTTP paths")
@@ -158,7 +158,7 @@ func (rs *RemoteChunkStore) StreamDownloadLocations(stream remotesapi.ChunkStore
 	defer func() { logger("finished") }()
 
 	var repoID *remotesapi.RepoId
-	var cs store
+	var cs RemoteSrvStore
 	var prefix string
 	for {
 		req, err := stream.Recv()
@@ -423,7 +423,7 @@ func (rs *RemoteChunkStore) ListTableFiles(ctx context.Context, req *remotesapi.
 	return resp, nil
 }
 
-func getTableFileInfo(rs *RemoteChunkStore, logger func(string), tableList []nbs.TableFile, req *remotesapi.ListTableFilesRequest, cs store) ([]*remotesapi.TableFileInfo, error) {
+func getTableFileInfo(rs *RemoteChunkStore, logger func(string), tableList []nbs.TableFile, req *remotesapi.ListTableFilesRequest, cs RemoteSrvStore) ([]*remotesapi.TableFileInfo, error) {
 	prefix, err := rs.getRelativeStorePath(cs)
 	if err != nil {
 		return nil, err
@@ -473,11 +473,11 @@ func (rs *RemoteChunkStore) AddTableFiles(ctx context.Context, req *remotesapi.A
 	return &remotesapi.AddTableFilesResponse{Success: true}, nil
 }
 
-func (rs *RemoteChunkStore) getStore(repoId *remotesapi.RepoId, rpcName string) store {
+func (rs *RemoteChunkStore) getStore(repoId *remotesapi.RepoId, rpcName string) RemoteSrvStore {
 	return rs.getOrCreateStore(repoId, rpcName, types.Format_Default.VersionString())
 }
 
-func (rs *RemoteChunkStore) getOrCreateStore(repoId *remotesapi.RepoId, rpcName, nbfVerStr string) store {
+func (rs *RemoteChunkStore) getOrCreateStore(repoId *remotesapi.RepoId, rpcName, nbfVerStr string) RemoteSrvStore {
 	org := repoId.Org
 	repoName := repoId.RepoName
 

--- a/go/libraries/doltcore/remotesrv/http.go
+++ b/go/libraries/doltcore/remotesrv/http.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package remotesrv
 
 import (
 	"bytes"

--- a/go/libraries/doltcore/remotesrv/server.go
+++ b/go/libraries/doltcore/remotesrv/server.go
@@ -1,0 +1,107 @@
+// Copyright 2019 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remotesrv
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"sync"
+
+	"google.golang.org/grpc"
+
+	remotesapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/remotesapi/v1alpha1"
+	"github.com/dolthub/dolt/go/libraries/utils/filesys"
+)
+
+type Server struct {
+	wg       sync.WaitGroup
+	stopChan chan struct{}
+
+	grpcPort int
+	grpcSrv  *grpc.Server
+	httpPort int
+	httpSrv  http.Server
+}
+
+func (s *Server) GracefulStop() {
+	close(s.stopChan)
+	s.wg.Wait()
+}
+
+func NewServer(httpHost string, httpPort, grpcPort int, fs filesys.Filesys, dbCache DBCache, readOnly bool) *Server {
+	s := new(Server)
+	s.stopChan = make(chan struct{})
+	s.wg.Add(4)
+
+	expectedFiles := newFileDetails()
+
+	s.grpcPort = grpcPort
+	s.grpcSrv = grpc.NewServer(grpc.MaxRecvMsgSize(128 * 1024 * 1024))
+        var chnkSt remotesapi.ChunkStoreServiceServer = NewHttpFSBackedChunkStore(httpHost, dbCache, expectedFiles, fs)
+        if readOnly {
+                chnkSt = ReadOnlyChunkStore{chnkSt}
+        }
+	remotesapi.RegisterChunkStoreServiceServer(s.grpcSrv, chnkSt)
+
+	s.httpPort = httpPort
+	s.httpSrv = http.Server{
+		Addr:    fmt.Sprintf(":%d", httpPort),
+		Handler: newFileHandler(dbCache, expectedFiles, fs, readOnly),
+	}
+
+	return s
+}
+
+func (s *Server) Serve() error {
+	grpcListener, err := net.Listen("tcp", fmt.Sprintf(":%d", s.grpcPort))
+	if err != nil {
+		return err
+	}
+	httpListener, err := net.Listen("tcp", fmt.Sprintf(":%d", s.httpPort))
+	if err != nil {
+		grpcListener.Close()
+		return err
+	}
+
+	go func() {
+		defer s.wg.Done()
+		log.Println("Starting grpc server on port", s.grpcPort)
+		err = s.grpcSrv.Serve(grpcListener)
+		log.Println("grpc server exited. error:", err)
+	}()
+	go func() {
+		defer s.wg.Done()
+		<-s.stopChan
+		s.grpcSrv.GracefulStop()
+	}()
+
+	go func() {
+		defer s.wg.Done()
+		log.Println("Starting http server on port ", s.httpPort)
+		err := s.httpSrv.Serve(httpListener)
+		log.Println("http server exited. exit error:", err)
+	}()
+	go func() {
+		defer s.wg.Done()
+		<-s.stopChan
+		s.httpSrv.Shutdown(context.Background())
+	}()
+
+	s.wg.Wait()
+	return nil
+}

--- a/go/utils/remotesrv/main.go
+++ b/go/utils/remotesrv/main.go
@@ -29,14 +29,13 @@ import (
 	"github.com/dolthub/dolt/go/store/datas"
 )
 
-var readOnlyParam *bool = flag.Bool("read-only", false, "run a read-only server which does not allow writes")
-
 func main() {
-	repoModeParam := flag.Bool("repo-mode", false, "act as a remote for a dolt directory, instead of stand alone")
-	dirParam := flag.String("dir", "", "root directory that this command will run in.")
-	grpcPortParam := flag.Int("grpc-port", -1, "root directory that this command will run in.")
-	httpPortParam := flag.Int("http-port", -1, "root directory that this command will run in.")
-	httpHostParam := flag.String("http-host", "localhost", "host url that this command will assume.")
+	readOnlyParam := flag.Bool("read-only", false, "run a read-only server which does not allow writes")
+	repoModeParam := flag.Bool("repo-mode", false, "act as a remote for an existing dolt directory, instead of stand alone")
+	dirParam := flag.String("dir", "", "root directory that this command will run in; default cwd")
+	grpcPortParam := flag.Int("grpc-port", -1, "the port the grpc server will listen on; default 50051")
+	httpPortParam := flag.Int("http-port", -1, "the port the http server will listen on; default 80; if http-port is equal to grpc-port, both services will serve over the same port")
+	httpHostParam := flag.String("http-host", "", "hostname to use in the host component of the URLs that the server generates; default ''; if '', server will echo the :authority header")
 	flag.Parse()
 
 	if dirParam != nil && len(*dirParam) > 0 {

--- a/integration-tests/bats/remotesrv.bats
+++ b/integration-tests/bats/remotesrv.bats
@@ -94,3 +94,18 @@ teardown() {
     run dolt push origin main:main
     [[ "$status" != 0 ]] || false
 }
+
+@test "remotesrv: can run grpc and http on same port" {
+    mkdir remote
+    cd remote
+    dolt init
+    dolt sql -q 'create table vals (i int);'
+    dolt add vals
+    dolt commit -m 'create vals table.'
+
+    remotesrv --grpc-port 1234 --http-port 1234 --repo-mode &
+    remotesrv_pid=$!
+
+    cd ../
+    dolt clone http://localhost:1234/test-org/test-repo repo1
+}


### PR DESCRIPTION
Adds some functionality to remotesrv:

* `-http-port` and `-grpc-port` can be the same, in which case there is only one listener and both gRPC and file server traffic are served over the same port.
* the grpc server will echo the incoming request's `:authority` header, with the supplied `-http-port`, if no `-http-host` is supplied. Changes the default behavior of `remotesrv` to be that, rather than generating URLs with an authority component containing `localhost` as the hostname.