### PR TITLE
cmd user/password arguments always override yaml config

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -246,20 +246,12 @@ func GetServerConfig(dEnv *env.DoltEnv, apr *argparser.ArgParseResults) (ServerC
 		return getCommandLineServerConfig(dEnv, apr)
 	}
 
-	// a user/pass word was specified in yamlCfg
-	if yamlCfg.UserConfig.Name != nil || yamlCfg.UserConfig.Password != nil {
-		return yamlCfg, nil
+	// if command line user argument was given, replace yaml's user and password
+	if user, hasUser := apr.GetValue(commands.UserFlag); hasUser {
+		pass, _ := apr.GetValue(passwordFlag)
+		yamlCfg.UserConfig.Name = &user
+		yamlCfg.UserConfig.Password = &pass
 	}
-
-	// take user/password from commandline
-	cmdCfg, err := getCommandLineServerConfig(dEnv, apr)
-	if err != nil {
-		return nil, err
-	}
-	user := cmdCfg.User()
-	pass := cmdCfg.Password()
-	yamlCfg.UserConfig.Name = &user
-	yamlCfg.UserConfig.Password = &pass
 
 	return yamlCfg, nil
 }

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -235,10 +235,33 @@ func startServer(ctx context.Context, versionStr, commandStr string, args []stri
 // GetServerConfig returns ServerConfig that is set either from yaml file if given, if not it is set with values defined
 // on command line. Server config variables not defined are set to default values.
 func GetServerConfig(dEnv *env.DoltEnv, apr *argparser.ArgParseResults) (ServerConfig, error) {
+	var yamlCfg YAMLConfig
 	if cfgFile, ok := apr.GetValue(configFileFlag); ok {
-		return getYAMLServerConfig(dEnv.FS, cfgFile)
+		cfg, err := getYAMLServerConfig(dEnv.FS, cfgFile)
+		if err != nil {
+			return nil, err
+		}
+		yamlCfg = cfg.(YAMLConfig)
+	} else {
+		return getCommandLineServerConfig(dEnv, apr)
 	}
-	return getCommandLineServerConfig(dEnv, apr)
+
+	// a user/pass word was specified in yamlCfg
+	if yamlCfg.UserConfig.Name != nil || yamlCfg.UserConfig.Password != nil {
+		return yamlCfg, nil
+	}
+
+	// take user/password from commandline
+	cmdCfg, err := getCommandLineServerConfig(dEnv, apr)
+	if err != nil {
+		return nil, err
+	}
+	user := cmdCfg.User()
+	pass := cmdCfg.Password()
+	yamlCfg.UserConfig.Name = &user
+	yamlCfg.UserConfig.Password = &pass
+
+	return yamlCfg, nil
 }
 
 // SetupDoltConfig updates the given server config with where to create .doltcfg directory

--- a/integration-tests/bats/sql-privs.bats
+++ b/integration-tests/bats/sql-privs.bats
@@ -115,7 +115,7 @@ behavior:
     server_query test_db 1 cmddolt "" "select user from mysql.user order by user" "User\ncmddolt"
 }
 
-@test "sql-privs: yaml with user is not replaced with command line user" {
+@test "sql-privs: yaml with user is also replaced with command line user" {
     make_test_repo
     touch server.yaml
     let PORT="$$ % (65536-1024) + 1024"
@@ -136,7 +136,7 @@ behavior:
     dolt sql-server --port=$PORT --config server.yaml --user cmddolt &
     SERVER_PID=$!
 
-    server_query test_db 1 yamldolt "" "select user from mysql.user order by user" "User\nyamldolt"
+    server_query test_db 1 cmddolt "" "select user from mysql.user order by user" "User\ncmddolt"
 }
 
 @test "sql-privs: yaml specifies doltcfg dir" {


### PR DESCRIPTION
Closes: https://github.com/dolthub/dolt/issues/4333