### PR TITLE
Add -A (--ALL) to `dolt commit` and `CALL DOLT_COMMIT`

### DIFF
--- a/go/Godeps/LICENSES
+++ b/go/Godeps/LICENSES
@@ -4941,35 +4941,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ================================================================================
 
 ================================================================================
-= github.com/klauspost/cpuid/v2 licensed under: =
-
-The MIT License (MIT)
-
-Copyright (c) 2015 Klaus Post
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
-= LICENSE 24dd21670b04d159a0d6c283884da9d23f8761460c300d4702ccffa5 =
-================================================================================
-
-================================================================================
 = github.com/lestrrat-go/strftime licensed under: =
 
 MIT License

--- a/go/Godeps/LICENSES
+++ b/go/Godeps/LICENSES
@@ -4941,6 +4941,35 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ================================================================================
 
 ================================================================================
+= github.com/klauspost/cpuid/v2 licensed under: =
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Klaus Post
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+= LICENSE 24dd21670b04d159a0d6c283884da9d23f8761460c300d4702ccffa5 =
+================================================================================
+
+================================================================================
 = github.com/lestrrat-go/strftime licensed under: =
 
 MIT License

--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -84,6 +84,7 @@ const (
 	DryRunFlag       = "dry-run"
 	SetUpstreamFlag  = "set-upstream"
 	AllFlag          = "all"
+	UpperCaseAllFlag = "ALL"
 	HardResetParam   = "hard"
 	SoftResetParam   = "soft"
 	CheckoutCoBranch = "b"
@@ -128,6 +129,7 @@ func CreateCommitArgParser() *argparser.ArgParser {
 	ap.SupportsFlag(ForceFlag, "f", "Ignores any foreign key warnings and proceeds with the commit.")
 	ap.SupportsString(AuthorParam, "", "author", "Specify an explicit author using the standard A U Thor {{.LessThan}}author@example.com{{.GreaterThan}} format.")
 	ap.SupportsFlag(AllFlag, "a", "Adds all existing, changed tables (but not new tables) in the working set to the staged set.")
+	ap.SupportsFlag(UpperCaseAllFlag, "A", "Adds all tables (including new tables) in the working set to the staged set.")
 	ap.SupportsFlag(AmendFlag, "", "Amend previous commit")
 	return ap
 }

--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -92,6 +92,7 @@ func performCommit(ctx context.Context, commandStr string, args []string, dEnv *
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
 	allFlag := apr.Contains(cli.AllFlag)
+	upperCaseAllFlag := apr.Contains(cli.UpperCaseAllFlag)
 
 	if dEnv.IsLocked() {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(env.ErrActiveServerLock.New(dEnv.LockFile())), help)
@@ -102,7 +103,12 @@ func performCommit(ctx context.Context, commandStr string, args []string, dEnv *
 		return HandleVErrAndExitCode(errhand.BuildDError("Couldn't get working root").AddCause(err).Build(), usage)
 	}
 
-	if allFlag {
+	if upperCaseAllFlag {
+		roots, err = actions.StageAllTables(ctx, roots)
+		if err != nil {
+			return handleCommitErr(ctx, dEnv, err, help)
+		}
+	} else if allFlag {
 		roots, err = actions.StageModifiedAndDeletedTables(ctx, roots)
 		if err != nil {
 			return handleCommitErr(ctx, dEnv, err, help)

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_commit.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_commit.go
@@ -65,7 +65,12 @@ func DoDoltCommit(ctx *sql.Context, args []string) (string, error) {
 		return "", fmt.Errorf("Could not load database %s", dbName)
 	}
 
-	if apr.Contains(cli.AllFlag) {
+	if apr.Contains(cli.UpperCaseAllFlag) {
+		roots, err = actions.StageAllTables(ctx, roots)
+		if err != nil {
+			return "", fmt.Errorf(err.Error())
+		}
+	} else if apr.Contains(cli.AllFlag) {
 		roots, err = actions.StageModifiedAndDeletedTables(ctx, roots)
 		if err != nil {
 			return "", fmt.Errorf(err.Error())

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -46,7 +46,7 @@ var skipPrepared bool
 // SkipPreparedsCount is used by the "ci-check-repo CI workflow
 // as a reminder to consider prepareds when adding a new
 // enginetest suite.
-const SkipPreparedsCount = 77
+const SkipPreparedsCount = 78
 
 const skipPreparedFlag = "DOLT_SKIP_PREPARED_ENGINETESTS"
 

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -1239,6 +1239,13 @@ func TestTypesOverWire(t *testing.T) {
 	enginetest.TestTypesOverWire(t, harness, newSessionBuilder(harness))
 }
 
+func TestDoltCommit(t *testing.T) {
+	harness := newDoltHarness(t)
+	for _, script := range DoltCommitTests {
+		enginetest.TestScript(t, harness, script)
+	}
+}
+
 func TestQueriesPrepared(t *testing.T) {
 	enginetest.TestQueriesPrepared(t, newDoltHarness(t))
 }

--- a/integration-tests/bats/commit.bats
+++ b/integration-tests/bats/commit.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+load $BATS_TEST_DIRNAME/helper/common.bash
+
+setup() {
+    setup_common
+}
+
+teardown() {
+    assert_feature_version
+    teardown_common
+}
+
+@test "commit: -ALL (-a) adds all tables including new ones to the staged set." {
+    dolt sql -q "CREATE table t (pk int primary key);"
+    dolt sql -q "INSERT INTO t VALUES (1);"
+    dolt add t
+    dolt commit -m "add table t"
+    dolt reset --hard
+    run dolt sql -q "SELECT * from t;"
+    [ $status -eq 0 ]
+    [[ "$output" =~ "| 1" ]] || false
+
+    dolt sql -q "DELETE from t where pk = 1;"
+    dolt commit -ALL -m "update table t"
+    dolt reset --hard
+    run dolt sql -q "SELECT * from t;"
+    [ $status -eq 0 ]
+    [[ ! "$output" =~ "| 1" ]] || false
+
+    dolt sql -q "DROP TABLE t;"
+    dolt commit -Am "drop table t;"
+    dolt reset --hard
+    run dolt ls
+    [ $status -eq 0 ]
+    [[ "$output" =~ "No tables in working set" ]] || false
+
+    dolt sql -q "CREATE table t2 (pk int primary key);"
+    dolt commit -Am "add table t2"
+    dolt reset --hard
+    run dolt ls
+    [ $status -eq 0 ]
+    [[ "$output" =~ "t2" ]] || false
+}

--- a/integration-tests/bats/commit.bats
+++ b/integration-tests/bats/commit.bats
@@ -10,7 +10,7 @@ teardown() {
     teardown_common
 }
 
-@test "commit: -ALL (-a) adds all tables including new ones to the staged set." {
+@test "commit: -ALL (-A) adds all tables including new ones to the staged set." {
     dolt sql -q "CREATE table t (pk int primary key);"
     dolt sql -q "INSERT INTO t VALUES (1);"
     dolt add t


### PR DESCRIPTION
`-A` adds all tables (including new tables) to the staged set before committing.

Closes #4309 