### PR TITLE
Fix bug in colDiffs

### DIFF
--- a/go/cmd/dolt/commands/diffsplitter.go
+++ b/go/cmd/dolt/commands/diffsplitter.go
@@ -118,9 +118,14 @@ func (ds diffSplitter) splitDiffResultRow(row sql.Row) (rowDiff, rowDiff, error)
 			oldRow.row[ds.queryToTarget[i]] = row[i]
 
 			if diffTypeStr == "modified" {
-				if n, err := cmp(row[i], row[ds.fromTo[i]]); err != nil {
-					return rowDiff{}, rowDiff{}, err
-				} else if n != 0 {
+				fromToIndex, ok := ds.fromTo[i]
+				if ok {
+					if n, err := cmp(row[i], row[fromToIndex]); err != nil {
+						return rowDiff{}, rowDiff{}, err
+					} else if n != 0 {
+						oldRow.colDiffs[ds.queryToTarget[i]] = diff.ModifiedOld
+					}
+				} else {
 					oldRow.colDiffs[ds.queryToTarget[i]] = diff.ModifiedOld
 				}
 			} else {

--- a/go/cmd/dolt/commands/diffsplitter_test.go
+++ b/go/cmd/dolt/commands/diffsplitter_test.go
@@ -127,7 +127,7 @@ func TestDiffSplitter(t *testing.T) {
 					old: rowDiff{
 						row:      sql.Row{5, 6, nil},
 						rowDiff:  diff.ModifiedOld,
-						colDiffs: []diff.ChangeType{diff.None, diff.None, diff.None},
+						colDiffs: []diff.ChangeType{diff.ModifiedOld, diff.None, diff.None},
 					},
 					new: rowDiff{
 						row:      sql.Row{nil, 6, 100},


### PR DESCRIPTION
Fixes #4326 

- Fix a bug in `splitDiffResultRow` where a key existence is not being checked in a map. Specifically, `ds.fromTo[i]]` defaulted to `0` (the zero value for `int`) in the case where `i` did not exist as a key in `ds.fromTo`.

![image](https://user-images.githubusercontent.com/35494233/190865161-31eec4d3-4460-4b88-af12-a6a18530098c.png)
