### PR TITLE
go/libraries/doltcore/sqle: ReadReplicaDatabase: Add variable for force pulling remote branches.

### DIFF
--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -860,7 +860,7 @@ func switchAndFetchReplicaHead(ctx *sql.Context, branch string, db ReadReplicaDa
 	}
 
 	// create workingSets/heads/branch and update the working set
-	err = pullBranches(ctx, db, []string{branch}, currentBranchRef)
+	err = pullBranches(ctx, db, []string{branch}, currentBranchRef, pullBehavior_fastForward)
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/sqle/dsess/variables.go
+++ b/go/libraries/doltcore/sqle/dsess/variables.go
@@ -39,6 +39,7 @@ const (
 	AllowCommitConflicts          = "dolt_allow_commit_conflicts"
 	ReplicateToRemote             = "dolt_replicate_to_remote"
 	ReadReplicaRemote             = "dolt_read_replica_remote"
+	ReadReplicaForcePull          = "dolt_read_replica_force_pull"
 	ReplicationRemoteURLTemplate  = "dolt_replication_remote_url_template"
 	SkipReplicationErrors         = "dolt_skip_replication_errors"
 	ReplicateHeads                = "dolt_replicate_heads"

--- a/go/libraries/doltcore/sqle/read_replica_database.go
+++ b/go/libraries/doltcore/sqle/read_replica_database.go
@@ -161,6 +161,7 @@ func (rrd ReadReplicaDatabase) PullFromRemote(ctx *sql.Context) error {
 }
 
 type pullBehavior bool
+
 const pullBehavior_fastForward pullBehavior = false
 const pullBehavior_forcePull pullBehavior = true
 

--- a/go/libraries/doltcore/sqle/read_replica_database.go
+++ b/go/libraries/doltcore/sqle/read_replica_database.go
@@ -113,6 +113,11 @@ func (rrd ReadReplicaDatabase) PullFromRemote(ctx *sql.Context) error {
 		return sql.ErrUnknownSystemVariable.New(dsess.ReplicateAllHeads)
 	}
 
+	behavior := pullBehavior_fastForward
+	if ReadReplicaForcePull() {
+		behavior = pullBehavior_forcePull
+	}
+
 	dSess := dsess.DSessFromSess(ctx.Session)
 	currentBranchRef, err := dSess.CWBHeadRef(ctx, rrd.name)
 	if err != nil {
@@ -131,7 +136,7 @@ func (rrd ReadReplicaDatabase) PullFromRemote(ctx *sql.Context) error {
 		if err != nil {
 			return err
 		}
-		err = pullBranches(ctx, rrd, branches, currentBranchRef)
+		err = pullBranches(ctx, rrd, branches, currentBranchRef, behavior)
 		if err != nil {
 			return err
 		}
@@ -141,7 +146,7 @@ func (rrd ReadReplicaDatabase) PullFromRemote(ctx *sql.Context) error {
 			return err
 		}
 		toPull, toDelete, err := getReplicationBranches(ctx, rrd)
-		err = pullBranches(ctx, rrd, toPull, currentBranchRef)
+		err = pullBranches(ctx, rrd, toPull, currentBranchRef, behavior)
 		if err != nil {
 			return err
 		}
@@ -155,7 +160,11 @@ func (rrd ReadReplicaDatabase) PullFromRemote(ctx *sql.Context) error {
 	return nil
 }
 
-func pullBranches(ctx *sql.Context, rrd ReadReplicaDatabase, branches []string, currentBranchRef ref.DoltRef) error {
+type pullBehavior bool
+const pullBehavior_fastForward pullBehavior = false
+const pullBehavior_forcePull pullBehavior = true
+
+func pullBranches(ctx *sql.Context, rrd ReadReplicaDatabase, branches []string, currentBranchRef ref.DoltRef, behavior pullBehavior) error {
 	refSpecs, err := env.ParseRSFromArgs(rrd.remote.Name, branches)
 	if err != nil {
 		return err
@@ -176,7 +185,15 @@ func pullBranches(ctx *sql.Context, rrd ReadReplicaDatabase, branches []string, 
 					return nil, err
 				}
 
-				err = rrd.ddb.FastForward(fetchCtx, rtRef, srcDBCommit)
+				if behavior == pullBehavior_forcePull {
+					commitHash, herr := srcDBCommit.HashOf()
+					if herr != nil {
+						return nil, err
+					}
+					err = rrd.ddb.SetHead(fetchCtx, rtRef, commitHash)
+				} else {
+					err = rrd.ddb.FastForward(fetchCtx, rtRef, srcDBCommit)
+				}
 				if err != nil {
 					return nil, err
 				}
@@ -188,7 +205,15 @@ func pullBranches(ctx *sql.Context, rrd ReadReplicaDatabase, branches []string, 
 				switch {
 				case err != nil:
 				case branchExists:
-					err = rrd.ddb.FastForward(fetchCtx, branch, srcDBCommit)
+					if behavior == pullBehavior_forcePull {
+						commitHash, herr := srcDBCommit.HashOf()
+						if herr != nil {
+							return nil, err
+						}
+						err = rrd.ddb.SetHead(fetchCtx, branch, commitHash)
+					} else {
+						err = rrd.ddb.FastForward(fetchCtx, branch, srcDBCommit)
+					}
 				default:
 					err = rrd.ddb.NewBranchAtCommit(fetchCtx, branch, srcDBCommit)
 				}

--- a/go/libraries/doltcore/sqle/system_variables.go
+++ b/go/libraries/doltcore/sqle/system_variables.go
@@ -56,6 +56,14 @@ func AddDoltSystemVariables() {
 			Default:           "",
 		},
 		{
+			Name:              dsess.ReadReplicaForcePull,
+			Scope:             sql.SystemVariableScope_Global,
+			Dynamic:           true,
+			SetVarHintApplies: false,
+			Type:              sql.NewSystemStringType(dsess.ReadReplicaForcePull),
+			Default:           int8(0),
+		},
+		{
 			Name:              dsess.SkipReplicationErrors,
 			Scope:             sql.SystemVariableScope_Global,
 			Dynamic:           true,
@@ -160,4 +168,12 @@ func SkipReplicationWarnings() bool {
 		panic("dolt system variables not loaded")
 	}
 	return skip == SysVarTrue
+}
+
+func ReadReplicaForcePull() bool {
+	_, forcePull, ok := sql.SystemVariables.GetGlobal(dsess.ReadReplicaForcePull)
+	if !ok {
+		panic("dolt system variables not loaded")
+	}
+	return forcePull == SysVarTrue
 }


### PR DESCRIPTION
This adds `@@global.dolt_read_replica_force_pull`, which will turn read replica fetches into force pulls, allowing a read replica to true-up with a remote which has experienced a force push.