### PR TITLE
print spatial types as hex in shells only

### DIFF
--- a/go/libraries/doltcore/sqle/sqlutil/sql_row.go
+++ b/go/libraries/doltcore/sqle/sqlutil/sql_row.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"math"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -320,6 +321,13 @@ func SqlColToStr(sqlType sql.Type, col interface{}) (string, error) {
 			} else {
 				return "false", nil
 			}
+		case sql.Point, sql.LineString, sql.Polygon, sql.GeometryType:
+			res, err := sqlType.SQL(sqlColToStrContext, nil, col)
+			hexRes := fmt.Sprintf("0x%X", res.Raw())
+			if err != nil {
+				return "", err
+			}
+			return hexRes, nil
 		default:
 			res, err := sqlType.SQL(sqlColToStrContext, nil, col)
 			if err != nil {

--- a/go/libraries/doltcore/sqle/sqlutil/sql_row.go
+++ b/go/libraries/doltcore/sqle/sqlutil/sql_row.go
@@ -321,7 +321,7 @@ func SqlColToStr(sqlType sql.Type, col interface{}) (string, error) {
 			} else {
 				return "false", nil
 			}
-		case sql.Point, sql.LineString, sql.Polygon, sql.GeometryType:
+		case sql.SpatialColumnType:
 			res, err := sqlType.SQL(sqlColToStrContext, nil, col)
 			hexRes := fmt.Sprintf("0x%X", res.Raw())
 			if err != nil {


### PR DESCRIPTION
Related PR: https://github.com/dolthub/go-mysql-server/pull/1278

Since the `SQL` methods for `Point`, `LineString`, `Polygon`, and `Geometry` no longer return the hex formatted string, need to do a little extra work for prettier shell output.