### PR TITLE
allow drop current database directory and fix drop db with '-'

### DIFF
--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -540,7 +540,11 @@ func (p DoltDatabaseProvider) DropDatabase(ctx *sql.Context, name string) error 
 	db := p.databases[dbKey]
 
 	// get location of database that's being dropped
-	dropDbLoc, err := p.dbLocations[db.Name()].Abs("")
+	dbLoc := p.dbLocations[dbKey]
+	if dbLoc == nil {
+		return sql.ErrDatabaseNotFound.New(db.Name())
+	}
+	dropDbLoc, err := dbLoc.Abs("")
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -548,14 +548,14 @@ func (p DoltDatabaseProvider) DropDatabase(ctx *sql.Context, name string) error 
 	if err != nil {
 		return err
 	}
-	currentDbLoc, err := p.fs.Abs("")
+	rootDbLoc, err := p.fs.Abs("")
 	if err != nil {
 		return err
 	}
 	dirToDelete := ""
 	// if the database is in the directory itself, we remove '.dolt' directory rather than
 	// the whole directory itself because it can have other databases that are nested.
-	if currentDbLoc == dropDbLoc {
+	if rootDbLoc == dropDbLoc {
 		doltDirExists, _ := p.fs.Exists(dbfactory.DoltDir)
 		if !doltDirExists {
 			return sql.ErrDatabaseNotFound.New(db.Name())

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -1739,3 +1739,36 @@ s.close()
     run grep "failed to access 'mydb2' database: can no longer find .dolt dir on disk" server_log.txt
     [ "${#lines[@]}" -eq 1 ]
 }
+
+@test "sql-server: dropping database that the server is running in" {
+    skiponwindows "Missing dependencies"
+
+    mkdir mydb
+    cd mydb
+    dolt init
+
+    start_sql_server >> server_log.txt 2>&1
+
+    server_query "" 1 dolt "" "DROP DATABASE mydb"
+
+    run grep "database not found: mydb" server_log.txt
+    [ "${#lines[@]}" -eq 0 ]
+
+    [ ! -d .dolt ]
+}
+
+@test "sql-server: dropping database currently selected and that the server is running in" {
+    skiponwindows "Missing dependencies"
+
+    mkdir mydb
+    cd mydb
+    dolt init
+
+    start_sql_server >> server_log.txt 2>&1
+    server_query "mydb" 1 dolt "" "DROP DATABASE mydb;"
+
+    run grep "database not found: mydb" server_log.txt
+    [ "${#lines[@]}" -eq 0 ]
+
+    [ ! -d .dolt ]
+}

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -1772,3 +1772,20 @@ s.close()
 
     [ ! -d .dolt ]
 }
+
+@test "sql-server: dropping database with '-' in it" {
+    skiponwindows "Missing dependencies"
+
+    mkdir my-db
+    cd my-db
+    dolt init
+    cd ..
+
+    start_sql_server >> server_log.txt 2>&1
+    server_query "" 1 dolt "" "DROP DATABASE my_db;"
+
+    run grep "database not found: my_db" server_log.txt
+    [ "${#lines[@]}" -eq 0 ]
+
+    [ ! -d my-db ]
+}


### PR DESCRIPTION
This PR fixes two issues:
- if the server is running in the database itself, the database can be dropped regardless of being selected database.
- drop database with '-' in dir name and '_' in database name.
