### PR TITLE
[interactive-pr] Branch Control Demo

### DIFF
--- a/go/libraries/doltcore/sqle/dtables/branch_control.go
+++ b/go/libraries/doltcore/sqle/dtables/branch_control.go
@@ -1,0 +1,407 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dtables
+
+import (
+	"fmt"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/vitess/go/sqltypes"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/index"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/temp_branch_control"
+)
+
+type BranchControl struct{}
+
+var _ sql.Table = (*BranchControl)(nil)
+var _ sql.InsertableTable = (*BranchControl)(nil)
+var _ sql.ReplaceableTable = (*BranchControl)(nil)
+var _ sql.UpdatableTable = (*BranchControl)(nil)
+var _ sql.DeletableTable = (*BranchControl)(nil)
+var _ sql.RowInserter = (*BranchControl)(nil)
+var _ sql.RowReplacer = (*BranchControl)(nil)
+var _ sql.RowUpdater = (*BranchControl)(nil)
+var _ sql.RowDeleter = (*BranchControl)(nil)
+
+// Name implements the interface sql.Table.
+func (b *BranchControl) Name() string {
+	return "dolt_branch_control"
+}
+
+// String implements the interface sql.Table.
+func (b *BranchControl) String() string {
+	return "dolt_branch_control"
+}
+
+// Schema implements the interface sql.Table.
+func (b *BranchControl) Schema() sql.Schema {
+	return sql.Schema{
+		&sql.Column{
+			Name:       "branch",
+			Type:       sql.MustCreateString(sqltypes.VarChar, 16383, sql.Collation_utf8mb4_0900_bin),
+			Source:     "dolt_branch_control",
+			PrimaryKey: true,
+		},
+		&sql.Column{
+			Name:       "user",
+			Type:       sql.MustCreateString(sqltypes.VarChar, 16383, sql.Collation_utf8mb4_0900_bin),
+			Source:     "dolt_branch_control",
+			PrimaryKey: true,
+		},
+		&sql.Column{
+			Name:       "host",
+			Type:       sql.MustCreateString(sqltypes.VarChar, 16383, sql.Collation_utf8mb4_0900_ai_ci),
+			Source:     "dolt_branch_control",
+			PrimaryKey: true,
+		},
+		&sql.Column{
+			Name:       "permissions",
+			Type:       sql.MustCreateSetType([]string{"admin", "write", "destroy", "merge", "branch"}, sql.Collation_utf8mb4_0900_ai_ci),
+			Source:     "dolt_branch_control",
+			PrimaryKey: false,
+		},
+	}
+}
+
+// Collation implements the interface sql.Table.
+func (b *BranchControl) Collation() sql.CollationID {
+	return sql.Collation_Default
+}
+
+// Partitions implements the interface sql.Table.
+func (b *BranchControl) Partitions(context *sql.Context) (sql.PartitionIter, error) {
+	return index.SinglePartitionIterFromNomsMap(nil), nil
+}
+
+// PartitionRows implements the interface sql.Table.
+func (b *BranchControl) PartitionRows(context *sql.Context, partition sql.Partition) (sql.RowIter, error) {
+	var rows []sql.Row
+	for _, node := range temp_branch_control.StaticAccess.Nodes {
+		rows = append(rows, sql.Row{
+			node.Branch.String(),
+			node.User.String(),
+			node.Host.String(),
+			uint64(node.Permissions),
+		})
+	}
+	return sql.RowsToRowIter(rows...), nil
+}
+
+// Inserter implements the interface sql.InsertableTable.
+func (b *BranchControl) Inserter(context *sql.Context) sql.RowInserter {
+	return b
+}
+
+// Replacer implements the interface sql.ReplaceableTable.
+func (b *BranchControl) Replacer(ctx *sql.Context) sql.RowReplacer {
+	return b
+}
+
+// Updater implements the interface sql.UpdatableTable.
+func (b *BranchControl) Updater(ctx *sql.Context) sql.RowUpdater {
+	return b
+}
+
+// Deleter implements the interface sql.DeletableTable.
+func (b *BranchControl) Deleter(context *sql.Context) sql.RowDeleter {
+	return b
+}
+
+// StatementBegin implements the interface sql.TableEditor.
+func (b *BranchControl) StatementBegin(ctx *sql.Context) {}
+
+// DiscardChanges implements the interface sql.TableEditor.
+func (b *BranchControl) DiscardChanges(ctx *sql.Context, errorEncountered error) error {
+	return nil
+}
+
+// StatementComplete implements the interface sql.TableEditor.
+func (b *BranchControl) StatementComplete(ctx *sql.Context) error {
+	return nil
+}
+
+// Insert implements the interface sql.RowInserter.
+func (b *BranchControl) Insert(ctx *sql.Context, row sql.Row) error {
+	temp_branch_control.StaticAccess.RWMutex.Lock()
+	defer temp_branch_control.StaticAccess.RWMutex.Unlock()
+
+	branchLm, err := expression.ConstructLikeMatcher(sql.Collation_utf8mb4_0900_bin, row[0].(string), '\\')
+	if err != nil {
+		return err
+	}
+	userLm, err := expression.ConstructLikeMatcher(sql.Collation_utf8mb4_0900_bin, row[1].(string), '\\')
+	if err != nil {
+		return err
+	}
+	hostLm, err := expression.ConstructLikeMatcher(sql.Collation_utf8mb4_0900_ai_ci, row[2].(string), '\\')
+	if err != nil {
+		return err
+	}
+	perms := temp_branch_control.Permissions(row[3].(uint64))
+	temp_branch_control.StaticAccess.Nodes = append(temp_branch_control.StaticAccess.Nodes, temp_branch_control.AccessNode{
+		Branch:      branchLm,
+		User:        userLm,
+		Host:        hostLm,
+		Permissions: perms,
+	})
+	return nil
+}
+
+// Update implements the interface sql.RowUpdater.
+func (b *BranchControl) Update(ctx *sql.Context, old sql.Row, new sql.Row) error {
+	temp_branch_control.StaticAccess.RWMutex.Lock()
+	defer temp_branch_control.StaticAccess.RWMutex.Unlock()
+
+	oldBranch := old[0].(string)
+	oldUser := old[1].(string)
+	oldHost := old[2].(string)
+	for i, node := range temp_branch_control.StaticAccess.Nodes {
+		if node.Branch.String() == oldBranch && node.User.String() == oldUser && node.Host.String() == oldHost {
+			branchLm, err := expression.ConstructLikeMatcher(sql.Collation_utf8mb4_0900_bin, new[0].(string), '\\')
+			if err != nil {
+				return err
+			}
+			userLm, err := expression.ConstructLikeMatcher(sql.Collation_utf8mb4_0900_bin, new[1].(string), '\\')
+			if err != nil {
+				return err
+			}
+			hostLm, err := expression.ConstructLikeMatcher(sql.Collation_utf8mb4_0900_ai_ci, new[2].(string), '\\')
+			if err != nil {
+				return err
+			}
+			perms := temp_branch_control.Permissions(new[3].(uint64))
+			temp_branch_control.StaticAccess.Nodes[i] = temp_branch_control.AccessNode{
+				Branch:      branchLm,
+				User:        userLm,
+				Host:        hostLm,
+				Permissions: perms,
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("could not find row with pk [`%s`, `%s`, `%s`]", oldBranch, oldUser, oldHost)
+}
+
+// Delete implements the interface sql.RowDeleter.
+func (b *BranchControl) Delete(ctx *sql.Context, row sql.Row) error {
+	temp_branch_control.StaticAccess.RWMutex.Lock()
+	defer temp_branch_control.StaticAccess.RWMutex.Unlock()
+
+	staticAccess := temp_branch_control.StaticAccess
+	branch := row[0].(string)
+	user := row[1].(string)
+	host := row[2].(string)
+	for i, node := range staticAccess.Nodes {
+		if node.Branch.String() == branch && node.User.String() == user && node.Host.String() == host {
+			lastNode := len(staticAccess.Nodes) - 1
+			staticAccess.Nodes[i], staticAccess.Nodes[lastNode] = staticAccess.Nodes[lastNode], staticAccess.Nodes[i]
+			staticAccess.Nodes = staticAccess.Nodes[:lastNode]
+			return nil
+		}
+	}
+	return fmt.Errorf("could not find row with pk [`%s`, `%s`, `%s`]", branch, user, host)
+}
+
+// Close implements the interface sql.Closer.
+func (b *BranchControl) Close(context *sql.Context) error {
+	return nil
+}
+
+type BranchControlProtected struct{}
+
+var _ sql.Table = (*BranchControlProtected)(nil)
+var _ sql.InsertableTable = (*BranchControlProtected)(nil)
+var _ sql.ReplaceableTable = (*BranchControlProtected)(nil)
+var _ sql.UpdatableTable = (*BranchControlProtected)(nil)
+var _ sql.DeletableTable = (*BranchControlProtected)(nil)
+var _ sql.RowInserter = (*BranchControlProtected)(nil)
+var _ sql.RowReplacer = (*BranchControlProtected)(nil)
+var _ sql.RowUpdater = (*BranchControlProtected)(nil)
+var _ sql.RowDeleter = (*BranchControlProtected)(nil)
+
+// Name implements the interface sql.Table.
+func (b *BranchControlProtected) Name() string {
+	return "dolt_branch_control_protected"
+}
+
+// String implements the interface sql.Table.
+func (b *BranchControlProtected) String() string {
+	return "dolt_branch_control_protected"
+}
+
+// Schema implements the interface sql.Table.
+func (b *BranchControlProtected) Schema() sql.Schema {
+	return sql.Schema{
+		&sql.Column{
+			Name:       "branch",
+			Type:       sql.MustCreateString(sqltypes.VarChar, 16383, sql.Collation_utf8mb4_0900_bin),
+			Source:     "dolt_branch_control_protected",
+			PrimaryKey: true,
+		},
+		&sql.Column{
+			Name:       "user",
+			Type:       sql.MustCreateString(sqltypes.VarChar, 16383, sql.Collation_utf8mb4_0900_bin),
+			Source:     "dolt_branch_control_protected",
+			PrimaryKey: true,
+		},
+		&sql.Column{
+			Name:       "host",
+			Type:       sql.MustCreateString(sqltypes.VarChar, 16383, sql.Collation_utf8mb4_0900_ai_ci),
+			Source:     "dolt_branch_control_protected",
+			PrimaryKey: true,
+		},
+	}
+}
+
+// Collation implements the interface sql.Table.
+func (b *BranchControlProtected) Collation() sql.CollationID {
+	return sql.Collation_Default
+}
+
+// Partitions implements the interface sql.Table.
+func (b *BranchControlProtected) Partitions(context *sql.Context) (sql.PartitionIter, error) {
+	return index.SinglePartitionIterFromNomsMap(nil), nil
+}
+
+// PartitionRows implements the interface sql.Table.
+func (b *BranchControlProtected) PartitionRows(context *sql.Context, partition sql.Partition) (sql.RowIter, error) {
+	var rows []sql.Row
+	for _, node := range temp_branch_control.StaticCreation.Nodes {
+		rows = append(rows, sql.Row{
+			node.Branch.String(),
+			node.User.String(),
+			node.Host.String(),
+		})
+	}
+	return sql.RowsToRowIter(rows...), nil
+}
+
+// Inserter implements the interface sql.InsertableTable.
+func (b *BranchControlProtected) Inserter(context *sql.Context) sql.RowInserter {
+	return b
+}
+
+// Replacer implements the interface sql.ReplaceableTable.
+func (b *BranchControlProtected) Replacer(ctx *sql.Context) sql.RowReplacer {
+	return b
+}
+
+// Updater implements the interface sql.UpdatableTable.
+func (b *BranchControlProtected) Updater(ctx *sql.Context) sql.RowUpdater {
+	return b
+}
+
+// Deleter implements the interface sql.DeletableTable.
+func (b *BranchControlProtected) Deleter(context *sql.Context) sql.RowDeleter {
+	return b
+}
+
+// StatementBegin implements the interface sql.TableEditor.
+func (b *BranchControlProtected) StatementBegin(ctx *sql.Context) {}
+
+// DiscardChanges implements the interface sql.TableEditor.
+func (b *BranchControlProtected) DiscardChanges(ctx *sql.Context, errorEncountered error) error {
+	return nil
+}
+
+// StatementComplete implements the interface sql.TableEditor.
+func (b *BranchControlProtected) StatementComplete(ctx *sql.Context) error {
+	return nil
+}
+
+// Insert implements the interface sql.RowInserter.
+func (b *BranchControlProtected) Insert(ctx *sql.Context, row sql.Row) error {
+	temp_branch_control.StaticCreation.RWMutex.Lock()
+	defer temp_branch_control.StaticCreation.RWMutex.Unlock()
+
+	branchLm, err := expression.ConstructLikeMatcher(sql.Collation_utf8mb4_0900_bin, row[0].(string), '\\')
+	if err != nil {
+		return err
+	}
+	userLm, err := expression.ConstructLikeMatcher(sql.Collation_utf8mb4_0900_bin, row[1].(string), '\\')
+	if err != nil {
+		return err
+	}
+	hostLm, err := expression.ConstructLikeMatcher(sql.Collation_utf8mb4_0900_ai_ci, row[2].(string), '\\')
+	if err != nil {
+		return err
+	}
+	temp_branch_control.StaticCreation.Nodes = append(temp_branch_control.StaticCreation.Nodes, temp_branch_control.CreationNode{
+		Branch: branchLm,
+		User:   userLm,
+		Host:   hostLm,
+	})
+	return nil
+}
+
+// Update implements the interface sql.RowUpdater.
+func (b *BranchControlProtected) Update(ctx *sql.Context, old sql.Row, new sql.Row) error {
+	temp_branch_control.StaticCreation.RWMutex.Lock()
+	defer temp_branch_control.StaticCreation.RWMutex.Unlock()
+
+	oldBranch := old[0].(string)
+	oldUser := old[1].(string)
+	oldHost := old[2].(string)
+	for i, node := range temp_branch_control.StaticCreation.Nodes {
+		if node.Branch.String() == oldBranch && node.User.String() == oldUser && node.Host.String() == oldHost {
+			branchLm, err := expression.ConstructLikeMatcher(sql.Collation_utf8mb4_0900_bin, new[0].(string), '\\')
+			if err != nil {
+				return err
+			}
+			userLm, err := expression.ConstructLikeMatcher(sql.Collation_utf8mb4_0900_bin, new[1].(string), '\\')
+			if err != nil {
+				return err
+			}
+			hostLm, err := expression.ConstructLikeMatcher(sql.Collation_utf8mb4_0900_ai_ci, new[2].(string), '\\')
+			if err != nil {
+				return err
+			}
+			temp_branch_control.StaticCreation.Nodes[i] = temp_branch_control.CreationNode{
+				Branch: branchLm,
+				User:   userLm,
+				Host:   hostLm,
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("could not find row with pk [`%s`, `%s`, `%s`]", oldBranch, oldUser, oldHost)
+}
+
+// Delete implements the interface sql.RowDeleter.
+func (b *BranchControlProtected) Delete(ctx *sql.Context, row sql.Row) error {
+	temp_branch_control.StaticCreation.RWMutex.Lock()
+	defer temp_branch_control.StaticCreation.RWMutex.Unlock()
+
+	staticCreation := temp_branch_control.StaticCreation
+	branch := row[0].(string)
+	user := row[1].(string)
+	host := row[2].(string)
+	for i, node := range staticCreation.Nodes {
+		if node.Branch.String() == branch && node.User.String() == user && node.Host.String() == host {
+			lastNode := len(staticCreation.Nodes) - 1
+			staticCreation.Nodes[i], staticCreation.Nodes[lastNode] = staticCreation.Nodes[lastNode], staticCreation.Nodes[i]
+			staticCreation.Nodes = staticCreation.Nodes[:lastNode]
+			return nil
+		}
+	}
+	return fmt.Errorf("could not find row with pk [`%s`, `%s`, `%s`]", branch, user, host)
+}
+
+// Close implements the interface sql.Closer.
+func (b *BranchControlProtected) Close(context *sql.Context) error {
+	return nil
+}

--- a/go/libraries/doltcore/sqle/temp_branch_control/branch_control.go
+++ b/go/libraries/doltcore/sqle/temp_branch_control/branch_control.go
@@ -1,0 +1,183 @@
+//TODO: DELETE ME LATER, FOR TESTING PURPOSES ONLY
+
+package temp_branch_control
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+)
+
+// Permissions are a set of flags that denote a user's allowed functionality on a branch.
+type Permissions uint64
+
+const ( // Make these explicit after settling on which permissions to actually use
+	Permissions_Admin Permissions = 1 << iota
+	Permissions_Write
+	Permissions_Destroy
+	Permissions_Merge
+	Permissions_Branch
+	Permissions_All Permissions = (Permissions_Branch << 1) - 1 // Update when new permissions are added
+)
+
+// To prevent import cycles, try and rely on as few Dolt packages as possible so that this may be called from as many
+// places as possible
+type BranchAwareSession interface {
+	sql.Session
+	GetBranch() string
+	GetUser() string
+	GetHost() string
+}
+
+// Slice to hold nodes is temporary, will decide a better format later
+type Access struct {
+	Nodes   []AccessNode
+	RWMutex *sync.RWMutex
+}
+
+type Creation struct {
+	Nodes   []CreationNode
+	RWMutex *sync.RWMutex
+}
+
+// Temporary global variables to aid with development
+var StaticAccess = &Access{nil, &sync.RWMutex{}}
+var StaticCreation = &Creation{nil, &sync.RWMutex{}}
+
+// I'm using the `LikeMatcher` here as it allows for the "username%" semantics that we like, but it doesn't support
+// any kind of longest-match semantics, so I'll either extend this or come up with something better
+type AccessNode struct {
+	Branch      expression.LikeMatcher
+	User        expression.LikeMatcher
+	Host        expression.LikeMatcher
+	Permissions Permissions
+}
+
+type CreationNode struct {
+	Branch expression.LikeMatcher
+	User   expression.LikeMatcher
+	Host   expression.LikeMatcher
+}
+
+func mustConstructLikeMatcher(collation sql.CollationID, pattern string) expression.LikeMatcher {
+	lm, err := expression.ConstructLikeMatcher(collation, pattern, '\\')
+	if err != nil {
+		panic(err)
+	}
+	return lm
+}
+
+// Temporary init to aid development
+func init() {
+	StaticAccess.Nodes = append(StaticAccess.Nodes, AccessNode{
+		Branch:      mustConstructLikeMatcher(sql.Collation_utf8mb4_0900_bin, `%`),
+		User:        mustConstructLikeMatcher(sql.Collation_utf8mb4_0900_bin, "root"),
+		Host:        mustConstructLikeMatcher(sql.Collation_utf8mb4_0900_ai_ci, "%"),
+		Permissions: Permissions_All,
+	})
+	StaticCreation.Nodes = append(StaticCreation.Nodes, CreationNode{
+		Branch: mustConstructLikeMatcher(sql.Collation_utf8mb4_0900_bin, `%`),
+		User:   mustConstructLikeMatcher(sql.Collation_utf8mb4_0900_bin, "root"),
+		Host:   mustConstructLikeMatcher(sql.Collation_utf8mb4_0900_ai_ci, "%"),
+	})
+}
+
+// CheckAccess returns whether the given context has the correct permissions on its selected branch. In general, SQL
+// statements will almost always return a *sql.Context, so any checks from the SQL path will correctly check for branch
+// permissions. However, not all CLI commands use *sql.Context, and therefore will not have any user associated with
+// the context. In these cases, CheckAccess will pass as we want to allow all local commands to ignore branch
+// permissions.
+func CheckAccess(ctx context.Context, flags Permissions) error {
+	branchAwareSession := getBranchAwareSession(ctx)
+	if branchAwareSession == nil {
+		return nil
+	}
+	StaticAccess.RWMutex.RLock()
+	defer StaticAccess.RWMutex.RUnlock()
+
+	branch := branchAwareSession.GetBranch()
+	user := branchAwareSession.GetUser()
+	host := branchAwareSession.GetHost()
+	// Won't actually loop over everything, not performant at all
+	for _, node := range StaticAccess.Nodes {
+		// This doesn't apply the "longest match" rule
+		if node.Branch.Match(branch) && node.User.Match(user) && node.Host.Match(host) {
+			if (node.Permissions&flags == flags) || (node.Permissions&Permissions_Admin > 0) {
+				return nil
+			}
+			return fmt.Errorf("`%s`@`%s` does not have the correct permissions on branch `%s`", user, host, branch)
+		}
+	}
+	return fmt.Errorf("`%s`@`%s` does not have the correct permissions on branch `%s`", user, host, branch)
+}
+
+// CanCreateBranch returns whether the given context can create a branch with the given name. In general, SQL statements
+// will almost always return a *sql.Context, so any checks from the SQL path will be able to validate a branch's name.
+// However, not all CLI commands use *sql.Context, and therefore will not have any user associated with the context. In
+// these cases, CanCreateBranch will pass as we want to allow all local commands to freely create branches.
+func CanCreateBranch(ctx context.Context, branchName string) error {
+	branchAwareSession := getBranchAwareSession(ctx)
+	if branchAwareSession == nil {
+		return nil
+	}
+	StaticCreation.RWMutex.RLock()
+	defer StaticCreation.RWMutex.RUnlock()
+
+	user := branchAwareSession.GetUser()
+	host := branchAwareSession.GetHost()
+	// As this doesn't handle the "longest match" rule, we just iterate over all matches and see if any of them work
+	matchFound := false
+	for _, node := range StaticCreation.Nodes {
+		if node.Branch.Match(branchName) {
+			matchFound = true
+			if node.User.Match(user) && node.Host.Match(host) {
+				return nil
+			}
+		}
+	}
+	if matchFound {
+		return fmt.Errorf("`%s`@`%s` cannot create a branch named `%s`", user, host, branchName)
+	}
+	return nil
+}
+
+// CanDeleteBranch returns whether the given context can delete a branch with the given name. In general, SQL statements
+// will almost always return a *sql.Context, so any checks from the SQL path will be able to validate a branch's name.
+// However, not all CLI commands use *sql.Context, and therefore will not have any user associated with the context. In
+// these cases, CanDeleteBranch will pass as we want to allow all local commands to freely delete branches.
+func CanDeleteBranch(ctx context.Context, branchName string) error {
+	branchAwareSession := getBranchAwareSession(ctx)
+	if branchAwareSession == nil {
+		return nil
+	}
+	StaticAccess.RWMutex.RLock()
+	defer StaticAccess.RWMutex.RUnlock()
+
+	user := branchAwareSession.GetUser()
+	host := branchAwareSession.GetHost()
+	for _, node := range StaticAccess.Nodes {
+		if node.Branch.Match(branchName) && node.User.Match(user) && node.Host.Match(host) {
+			if (node.Permissions&Permissions_Destroy > 0) || (node.Permissions&Permissions_Admin > 0) {
+				return nil
+			}
+			return fmt.Errorf("`%s`@`%s` cannot delete the branch `%s`", user, host, branchName)
+		}
+	}
+	return fmt.Errorf("`%s`@`%s` cannot delete the branch `%s`", user, host, branchName)
+}
+
+// getBranchAwareSession returns the session contained within the context. If the context does NOT contain a session,
+// then nil is returned.
+func getBranchAwareSession(ctx context.Context) BranchAwareSession {
+	if sqlCtx, ok := ctx.(*sql.Context); ok {
+		if bas, ok := sqlCtx.Session.(BranchAwareSession); ok {
+			return bas
+		}
+	} else if bas, ok := ctx.(BranchAwareSession); ok {
+		return bas
+	}
+	return nil
+}

--- a/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/globalstate"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/index"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlutil"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/temp_branch_control"
 	"github.com/dolthub/dolt/go/store/pool"
 	"github.com/dolthub/dolt/go/store/prolly"
 	"github.com/dolthub/dolt/go/store/val"
@@ -131,6 +132,9 @@ func getSecondaryKeylessProllyWriters(ctx context.Context, t *doltdb.Table, sqlS
 
 // Insert implements TableWriter.
 func (w *prollyTableWriter) Insert(ctx *sql.Context, sqlRow sql.Row) (err error) {
+	if err := temp_branch_control.CheckAccess(ctx, temp_branch_control.Permissions_Write); err != nil {
+		return err
+	}
 	if err := w.primary.Insert(ctx, sqlRow); err != nil {
 		return err
 	}
@@ -147,6 +151,9 @@ func (w *prollyTableWriter) Insert(ctx *sql.Context, sqlRow sql.Row) (err error)
 
 // Delete implements TableWriter.
 func (w *prollyTableWriter) Delete(ctx *sql.Context, sqlRow sql.Row) (err error) {
+	if err := temp_branch_control.CheckAccess(ctx, temp_branch_control.Permissions_Write); err != nil {
+		return err
+	}
 	for _, wr := range w.secondary {
 		if err := wr.Delete(ctx, sqlRow); err != nil {
 			return err
@@ -160,6 +167,9 @@ func (w *prollyTableWriter) Delete(ctx *sql.Context, sqlRow sql.Row) (err error)
 
 // Update implements TableWriter.
 func (w *prollyTableWriter) Update(ctx *sql.Context, oldRow sql.Row, newRow sql.Row) (err error) {
+	if err := temp_branch_control.CheckAccess(ctx, temp_branch_control.Permissions_Write); err != nil {
+		return err
+	}
 	for _, wr := range w.secondary {
 		if err := wr.Update(ctx, oldRow, newRow); err != nil {
 			if uke, ok := err.(secondaryUniqueKeyError); ok {


### PR DESCRIPTION
Take a look over this for now, and I'll walk through it with you @zachmu later today (along with a live demo showing its use). This is only the _core_ Dolt changes so far.

As a big warning, this is all temporary code, and I expect very little of it to make it into the final PR. However, I will be building upon many of the ideas here, so if any of these are fundamentally wrong in some way, this is a great time to catch it. I've also littered comments throughout, going over how I plan to actually implement much of the functionality.

As a refresher, we have two tables `dolt_branch_control` (`dbc`) and `dolt_branch_control_protected` (`dbcp`). The first, `dbc`, handles the permissions that each branch and user combination has. These are implemented using the `LIKE` expression syntax, which will (eventually) match using the "longest match wins" rule. The second, `dbcp`, is a sort of blacklist that restricts branch creation. If a branch matches, then we return the result of the user and host fields matching. If no expressions match the branch name, then it is allowed. This means it **only** fails when we've matched a branch name, but the user and host do not match.

Included are three files: the core `temp_branch_control/branch_control.go` file, which is the hub for the test implementation. `dtables/branch_control.go`, which is mainly to show the schema. And `prolly_table_writer.go`, which represents how the checks are added throughout the codebase, and also shows the level at which they're implemented (i.e. above the `types` package, but not in GMS). This does present a problem regarding other engineers adding new functionality, but I have some ideas on the implementation of a PR check that may catch some of it.