### PR TITLE
reorder arguments of dolt_diff() table function

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,10 +584,10 @@ mysql> select * from employees as of 'modifications';
 5 rows in set (0.01 sec)
 ```
 
-If I'd like to see the diff between the two branches, I can use the `dolt_diff()` table function. It takes the table name and two branches as arguments.
+If I'd like to see the diff between the two branches, I can use the `dolt_diff()` table function. It takes two branches and the table name as arguments.
 
 ```
-mysql> select * from dolt_diff('employees', 'main','modifications');
+mysql> select * from dolt_diff('main', 'modifications', 'employees');
 +--------------+---------------+-------+---------------+-------------------------+----------------+-----------------+---------+-------------+-------------------------+-----------+
 | to_last_name | to_first_name | to_id | to_commit     | to_commit_date          | from_last_name | from_first_name | from_id | from_commit | from_commit_date        | diff_type |
 +--------------+---------------+-------+---------------+-------------------------+----------------+-----------------+---------+-------------+-------------------------+-----------+

--- a/go/Godeps/LICENSES
+++ b/go/Godeps/LICENSES
@@ -1180,6 +1180,26 @@ Creative Commons may be contacted at creativecommons.org.
 ================================================================================
 
 ================================================================================
+= github.com/aliyun/aliyun-oss-go-sdk licensed under: =
+
+Copyright (c) 2015 aliyun.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+= LICENSE e38acb655cae71b0deffe4354c611894b747c461da744bbb5f3bc54f =
+================================================================================
+
+================================================================================
 = github.com/andreyvit/diff licensed under: =
 
 MIT License
@@ -8526,6 +8546,40 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 = golang.org/x/text licensed under: =
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+= LICENSE ed6066ae50f153e2965216c6d4b9335900f1f8b2b526527f49a619d7 =
+================================================================================
+
+================================================================================
+= golang.org/x/time licensed under: =
 
 Copyright (c) 2009 The Go Authors. All rights reserved.
 

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -593,7 +593,7 @@ func diffRows(
 	}
 
 	columns := getColumnNamesString(td.FromSch, td.ToSch)
-	query := fmt.Sprintf("select %s, %s from dolt_diff('%s', '%s', '%s')", columns, "diff_type", tableName, from, to)
+	query := fmt.Sprintf("select %s, %s from dolt_diff('%s', '%s', '%s')", columns, "diff_type", from, to, tableName)
 
 	if len(dArgs.where) > 0 {
 		query += " where " + dArgs.where

--- a/go/libraries/doltcore/dbfactory/oss.go
+++ b/go/libraries/doltcore/dbfactory/oss.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
+
 	"github.com/dolthub/dolt/go/store/blobstore"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/datas"

--- a/go/libraries/doltcore/sqle/dolt_diff_table_function.go
+++ b/go/libraries/doltcore/sqle/dolt_diff_table_function.go
@@ -38,9 +38,9 @@ var _ sql.TableFunction = (*DiffTableFunction)(nil)
 
 type DiffTableFunction struct {
 	ctx            *sql.Context
-	tableNameExpr  sql.Expression
 	fromCommitExpr sql.Expression
 	toCommitExpr   sql.Expression
+	tableNameExpr  sql.Expression
 	database       sql.Database
 	sqlSch         sql.Schema
 	joiner         *rowconv.Joiner
@@ -80,7 +80,7 @@ func (dtf *DiffTableFunction) WithDatabase(database sql.Database) (sql.Node, err
 // Expressions implements the sql.Expressioner interface
 func (dtf *DiffTableFunction) Expressions() []sql.Expression {
 	return []sql.Expression{
-		dtf.tableNameExpr, dtf.fromCommitExpr, dtf.toCommitExpr,
+		dtf.fromCommitExpr, dtf.toCommitExpr, dtf.tableNameExpr,
 	}
 }
 
@@ -99,16 +99,16 @@ func (dtf *DiffTableFunction) WithExpressions(expression ...sql.Expression) (sql
 		}
 	}
 
-	dtf.tableNameExpr = expression[0]
-	dtf.fromCommitExpr = expression[1]
-	dtf.toCommitExpr = expression[2]
+	dtf.fromCommitExpr = expression[0]
+	dtf.toCommitExpr = expression[1]
+	dtf.tableNameExpr = expression[2]
 
-	tableName, fromCommitVal, toCommitVal, err := dtf.evaluateArguments()
+	fromCommitVal, toCommitVal, tableName, err := dtf.evaluateArguments()
 	if err != nil {
 		return nil, err
 	}
 
-	err = dtf.generateSchema(dtf.ctx, tableName, fromCommitVal, toCommitVal)
+	err = dtf.generateSchema(dtf.ctx, fromCommitVal, toCommitVal, tableName)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (dtf *DiffTableFunction) RowIter(ctx *sql.Context, _ sql.Row) (sql.RowIter,
 	// TODO: When we add support for joining on table functions, we'll need to evaluate this against the
 	//       specified row. That row is what has the left_table context in a join query.
 	//       This will expand the test cases we need to cover significantly.
-	_, fromCommit, toCommit, err := dtf.evaluateArguments()
+	fromCommit, toCommit, _, err := dtf.evaluateArguments()
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +199,7 @@ func (dtf *DiffTableFunction) WithChildren(node ...sql.Node) (sql.Node, error) {
 
 // CheckPrivileges implements the sql.Node interface
 func (dtf *DiffTableFunction) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
-	tableName, _, _, err := dtf.evaluateArguments()
+	_, _, tableName, err := dtf.evaluateArguments()
 	if err != nil {
 		return false
 	}
@@ -211,46 +211,46 @@ func (dtf *DiffTableFunction) CheckPrivileges(ctx *sql.Context, opChecker sql.Pr
 
 // evaluateArguments evaluates the argument expressions to turn them into values this DiffTableFunction
 // can use. Note that this method only evals the expressions, and doesn't validate the values.
-func (dtf *DiffTableFunction) evaluateArguments() (string, interface{}, interface{}, error) {
+func (dtf *DiffTableFunction) evaluateArguments() (interface{}, interface{}, string, error) {
 	if !dtf.Resolved() {
-		return "", nil, nil, nil
+		return nil, nil, "", nil
 	}
 
 	if !sql.IsText(dtf.tableNameExpr.Type()) {
-		return "", nil, nil, sql.ErrInvalidArgumentDetails.New(dtf.FunctionName(), dtf.tableNameExpr.String())
+		return nil, nil, "", sql.ErrInvalidArgumentDetails.New(dtf.FunctionName(), dtf.tableNameExpr.String())
 	}
 
 	if !sql.IsText(dtf.fromCommitExpr.Type()) {
-		return "", nil, nil, sql.ErrInvalidArgumentDetails.New(dtf.FunctionName(), dtf.fromCommitExpr.String())
+		return nil, nil, "", sql.ErrInvalidArgumentDetails.New(dtf.FunctionName(), dtf.fromCommitExpr.String())
 	}
 
 	if !sql.IsText(dtf.toCommitExpr.Type()) {
-		return "", nil, nil, sql.ErrInvalidArgumentDetails.New(dtf.FunctionName(), dtf.toCommitExpr.String())
+		return nil, nil, "", sql.ErrInvalidArgumentDetails.New(dtf.FunctionName(), dtf.toCommitExpr.String())
 	}
 
 	tableNameVal, err := dtf.tableNameExpr.Eval(dtf.ctx, nil)
 	if err != nil {
-		return "", nil, nil, err
+		return nil, nil, "", err
 	}
 	tableName, ok := tableNameVal.(string)
 	if !ok {
-		return "", nil, nil, ErrInvalidTableName.New(dtf.tableNameExpr.String())
+		return nil, nil, "", ErrInvalidTableName.New(dtf.tableNameExpr.String())
 	}
 
 	fromCommitVal, err := dtf.fromCommitExpr.Eval(dtf.ctx, nil)
 	if err != nil {
-		return "", nil, nil, err
+		return nil, nil, "", err
 	}
 
 	toCommitVal, err := dtf.toCommitExpr.Eval(dtf.ctx, nil)
 	if err != nil {
-		return "", nil, nil, err
+		return nil, nil, "", err
 	}
 
-	return tableName, fromCommitVal, toCommitVal, nil
+	return fromCommitVal, toCommitVal, tableName, nil
 }
 
-func (dtf *DiffTableFunction) generateSchema(ctx *sql.Context, tableName string, fromCommitVal, toCommitVal interface{}) error {
+func (dtf *DiffTableFunction) generateSchema(ctx *sql.Context, fromCommitVal, toCommitVal interface{}, tableName string) error {
 	if !dtf.Resolved() {
 		return nil
 	}
@@ -260,7 +260,7 @@ func (dtf *DiffTableFunction) generateSchema(ctx *sql.Context, tableName string,
 		return fmt.Errorf("unexpected database type: %T", dtf.database)
 	}
 
-	delta, err := dtf.cacheTableDelta(ctx, tableName, fromCommitVal, toCommitVal, sqledb)
+	delta, err := dtf.cacheTableDelta(ctx, fromCommitVal, toCommitVal, tableName, sqledb)
 	if err != nil {
 		return err
 	}
@@ -308,7 +308,7 @@ func (dtf *DiffTableFunction) generateSchema(ctx *sql.Context, tableName string,
 
 // cacheTableDelta caches and returns an appropriate table delta for the table name given, taking renames into
 // consideration. Returns a sql.ErrTableNotFound if the given table name cannot be found in either revision.
-func (dtf *DiffTableFunction) cacheTableDelta(ctx *sql.Context, tableName string, fromCommitVal interface{}, toCommitVal interface{}, db Database) (diff.TableDelta, error) {
+func (dtf *DiffTableFunction) cacheTableDelta(ctx *sql.Context, fromCommitVal interface{}, toCommitVal interface{}, tableName string, db Database) (diff.TableDelta, error) {
 	fromRoot, _, fromDate, err := loadDetailsForRef(ctx, fromCommitVal, db)
 	if err != nil {
 		return diff.TableDelta{}, err
@@ -395,9 +395,9 @@ func (dtf *DiffTableFunction) Resolved() bool {
 // String implements the Stringer interface
 func (dtf *DiffTableFunction) String() string {
 	return fmt.Sprintf("DOLT_DIFF(%s, %s, %s)",
-		dtf.tableNameExpr.String(),
 		dtf.fromCommitExpr.String(),
-		dtf.toCommitExpr.String())
+		dtf.toCommitExpr.String(),
+		dtf.tableNameExpr.String())
 }
 
 // FunctionName implements the sql.TableFunction interface

--- a/go/libraries/doltcore/sqle/enginetest/ddl_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/ddl_queries.go
@@ -685,7 +685,7 @@ var BrokenDDLScripts = []queries.ScriptTest{
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
-				Query:    "SELECT to_pk, to_commit, from_pk, from_commit, diff_type from dolt_diff('t', @Commit1, @Commit2);",
+				Query:    "SELECT to_pk, to_commit, from_pk, from_commit, diff_type from dolt_diff(@Commit1, @Commit2, 't');",
 				Expected: []sql.Row{{1, "hi", nil, nil, "added"}},
 			},
 		},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -731,7 +731,7 @@ var DoltUserPrivTests = []queries.UserPrivilegeTest{
 				// Without access to the database, dolt_diff should fail with a database access error
 				User:        "tester",
 				Host:        "localhost",
-				Query:       "SELECT * FROM dolt_diff('test', 'main~', 'main');",
+				Query:       "SELECT * FROM dolt_diff('main~', 'main', 'test');",
 				ExpectedErr: sql.ErrDatabaseAccessDeniedForUser,
 			},
 			{
@@ -752,14 +752,14 @@ var DoltUserPrivTests = []queries.UserPrivilegeTest{
 				// After granting access to mydb.test, dolt_diff should work
 				User:     "tester",
 				Host:     "localhost",
-				Query:    "SELECT COUNT(*) FROM dolt_diff('test', 'main~', 'main');",
+				Query:    "SELECT COUNT(*) FROM dolt_diff('main~', 'main0, 'test');",
 				Expected: []sql.Row{{1}},
 			},
 			{
 				// With access to the db, but not the table, dolt_diff should fail
 				User:        "tester",
 				Host:        "localhost",
-				Query:       "SELECT * FROM dolt_diff('test2', 'main~', 'main');",
+				Query:       "SELECT * FROM dolt_diff('main~', 'main', 'test2');",
 				ExpectedErr: sql.ErrPrivilegeCheckFailed,
 			},
 			{
@@ -787,7 +787,7 @@ var DoltUserPrivTests = []queries.UserPrivilegeTest{
 				// After revoking access, dolt_diff should fail
 				User:        "tester",
 				Host:        "localhost",
-				Query:       "SELECT * FROM dolt_diff('test', 'main~', 'main');",
+				Query:       "SELECT * FROM dolt_diff('main~', 'main', 'test');",
 				ExpectedErr: sql.ErrDatabaseAccessDeniedForUser,
 			},
 			{
@@ -801,7 +801,7 @@ var DoltUserPrivTests = []queries.UserPrivilegeTest{
 				// After granting access to the entire db, dolt_diff should work
 				User:     "tester",
 				Host:     "localhost",
-				Query:    "SELECT COUNT(*) FROM dolt_diff('test', 'main~', 'main');",
+				Query:    "SELECT COUNT(*) FROM dolt_diff('main~', 'main', 'test');",
 				Expected: []sql.Row{{1}},
 			},
 			{
@@ -822,7 +822,7 @@ var DoltUserPrivTests = []queries.UserPrivilegeTest{
 				// After revoking access, dolt_diff should fail
 				User:        "tester",
 				Host:        "localhost",
-				Query:       "SELECT * FROM dolt_diff('test', 'main~', 'main');",
+				Query:       "SELECT * FROM dolt_diff('main~', 'main', 'test');",
 				ExpectedErr: sql.ErrDatabaseAccessDeniedForUser,
 			},
 			{
@@ -843,7 +843,7 @@ var DoltUserPrivTests = []queries.UserPrivilegeTest{
 				// After granting global access to *.*, dolt_diff should work
 				User:     "tester",
 				Host:     "localhost",
-				Query:    "SELECT COUNT(*) FROM dolt_diff('test', 'main~', 'main');",
+				Query:    "SELECT COUNT(*) FROM dolt_diff('main~', 'main', 'test');",
 				Expected: []sql.Row{{1}},
 			},
 			{
@@ -857,7 +857,7 @@ var DoltUserPrivTests = []queries.UserPrivilegeTest{
 				// After revoking global access, dolt_diff should fail
 				User:        "tester",
 				Host:        "localhost",
-				Query:       "SELECT * FROM dolt_diff('test', 'main~', 'main');",
+				Query:       "SELECT * FROM dolt_diff('main~', 'main', 'test');",
 				ExpectedErr: sql.ErrDatabaseAccessDeniedForUser,
 			},
 		},
@@ -4310,6 +4310,26 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "add multiple columns, then set and unset a value. Should not show a diff",
+		SetUpScript: []string{
+			"CREATE table t (pk int primary key);",
+			"Insert into t values (1);",
+			"alter table t add column col1 int;",
+			"alter table t add column col2 int;",
+			"CALL DOLT_ADD('.');",
+			"CALL DOLT_COMMIT('-am', 'setup');",
+			"UPDATE t set col1 = 1 where pk = 1;",
+			"UPDATE t set col1 = null where pk = 1;",
+			"CALL DOLT_COMMIT('--allow-empty', '-am', 'fix short tuple');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "SELECT to_pk, to_col1, from_pk, from_col1, diff_type from dolt_diff_t;",
+				Expected: []sql.Row{{1, nil, nil, nil, "added"}},
+			},
+		},
+	},
 }
 
 var Dolt1DiffSystemTableScripts = []queries.ScriptTest{
@@ -4353,11 +4373,11 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 				ExpectedErr: sql.ErrInvalidArgumentNumber,
 			},
 			{
-				Query:       "SELECT * from dolt_diff('t', @Commit1);",
+				Query:       "SELECT * from dolt_diff(@Commit1, 't');",
 				ExpectedErr: sql.ErrInvalidArgumentNumber,
 			},
 			{
-				Query:       "SELECT * from dolt_diff('t', @Commit1, @Commit2, 'extra');",
+				Query:       "SELECT * from dolt_diff(@Commit1, @Commit2, 'extra', 't');",
 				ExpectedErr: sql.ErrInvalidArgumentNumber,
 			},
 			{
@@ -4365,39 +4385,39 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 				ExpectedErr: sql.ErrInvalidArgumentDetails,
 			},
 			{
-				Query:       "SELECT * from dolt_diff(123, @Commit1, @Commit2);",
+				Query:       "SELECT * from dolt_diff(@Commit1, @Commit2, 123);",
 				ExpectedErr: sql.ErrInvalidArgumentDetails,
 			},
 			{
-				Query:       "SELECT * from dolt_diff('t', 123, @Commit2);",
+				Query:       "SELECT * from dolt_diff(123, @Commit2, 't');",
 				ExpectedErr: sql.ErrInvalidArgumentDetails,
 			},
 			{
-				Query:       "SELECT * from dolt_diff('t', @Commit1, 123);",
+				Query:       "SELECT * from dolt_diff(@Commit1, 123, 't');",
 				ExpectedErr: sql.ErrInvalidArgumentDetails,
 			},
 			{
-				Query:       "SELECT * from dolt_diff('doesnotexist', @Commit1, @Commit2);",
+				Query:       "SELECT * from dolt_diff(@Commit1, @Commit2, 'doesnotexist');",
 				ExpectedErr: sql.ErrTableNotFound,
 			},
 			{
-				Query:          "SELECT * from dolt_diff('t', 'fakefakefakefakefakefakefakefake', @Commit2);",
+				Query:          "SELECT * from dolt_diff('fakefakefakefakefakefakefakefake', @Commit2, 't');",
 				ExpectedErrStr: "target commit not found",
 			},
 			{
-				Query:          "SELECT * from dolt_diff('t', @Commit1, 'fake-branch');",
+				Query:          "SELECT * from dolt_diff(@Commit1, 'fake-branch', 't');",
 				ExpectedErrStr: "branch not found: fake-branch",
 			},
 			{
-				Query:       "SELECT * from dolt_diff('t', @Commit1, concat('fake', '-', 'branch'));",
+				Query:       "SELECT * from dolt_diff(@Commit1, concat('fake', '-', 'branch'), 't');",
 				ExpectedErr: sqle.ErrInvalidNonLiteralArgument,
 			},
 			{
-				Query:       "SELECT * from dolt_diff('t', hashof('main'), @Commit2);",
+				Query:       "SELECT * from dolt_diff(hashof('main'), @Commit2, 't');",
 				ExpectedErr: sqle.ErrInvalidNonLiteralArgument,
 			},
 			{
-				Query:       "SELECT * from dolt_diff(LOWER('T'), hashof('main'), @Commit2);",
+				Query:       "SELECT * from dolt_diff(hashof('main'), @Commit2, LOWER('T'));",
 				ExpectedErr: sqle.ErrInvalidNonLiteralArgument,
 			},
 		},
@@ -4425,15 +4445,15 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
-				Query:    "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type from dolt_diff('t', @Commit1, @Commit2);",
+				Query:    "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type from dolt_diff(@Commit1, @Commit2, 't');",
 				Expected: []sql.Row{{1, "one", "two", nil, nil, nil, "added"}},
 			},
 			{
-				Query:    "SELECT COUNT(*) from dolt_diff('t', @Commit2, @Commit3);",
+				Query:    "SELECT COUNT(*) from dolt_diff(@Commit2, @Commit3, 't');",
 				Expected: []sql.Row{{0}},
 			},
 			{
-				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type from dolt_diff('t', @Commit3, @Commit4);",
+				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type from dolt_diff(@Commit3, @Commit4, 't');",
 				Expected: []sql.Row{
 					{1, "uno", "dos", 1, "one", "two", "modified"},
 					{2, "two", "three", nil, nil, nil, "added"},
@@ -4441,7 +4461,7 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 				},
 			},
 			{
-				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type from dolt_diff('t', @Commit4, @Commit3);",
+				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type from dolt_diff(@Commit4, @Commit3, 't');",
 				Expected: []sql.Row{
 					{1, "one", "two", 1, "uno", "dos", "modified"},
 					{nil, nil, nil, 2, "two", "three", "removed"},
@@ -4450,11 +4470,11 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 			},
 			{
 				// Table t2 had no changes between Commit3 and Commit4, so results should be empty
-				Query:    "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type  from dolt_diff('T2', @Commit3, @Commit4);",
+				Query:    "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type  from dolt_diff(@Commit3, @Commit4, 'T2');",
 				Expected: []sql.Row{},
 			},
 			{
-				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type  from dolt_diff('t', @Commit1, @Commit4);",
+				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type  from dolt_diff(@Commit1, @Commit4, 't');",
 				Expected: []sql.Row{
 					{1, "uno", "dos", nil, nil, nil, "added"},
 					{2, "two", "three", nil, nil, nil, "added"},
@@ -4463,7 +4483,7 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 			},
 			{
 				// Reverse the to/from commits to see the diff from the other direction
-				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type  from dolt_diff('T', @Commit4, @Commit1);",
+				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type  from dolt_diff(@Commit4, @Commit1, 'T');",
 				Expected: []sql.Row{
 					{nil, nil, nil, 1, "uno", "dos", "removed"},
 					{nil, nil, nil, 2, "two", "three", "removed"},
@@ -4488,7 +4508,7 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
-				Query: "SELECT from_pk, from_c1, from_c2, to_pk, to_c1, to_c2, diff_type from dolt_diff('t', @Commit1, 'WORKING') order by coalesce(from_pk, to_pk)",
+				Query: "SELECT from_pk, from_c1, from_c2, to_pk, to_c1, to_c2, diff_type from dolt_diff(@Commit1, 'WORKING', 't') order by coalesce(from_pk, to_pk)",
 				Expected: []sql.Row{
 					{1, "one", "two", 1, "one", "100", "modified"},
 					{2, "three", "four", nil, nil, nil, "removed"},
@@ -4496,7 +4516,7 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 				},
 			},
 			{
-				Query: "SELECT from_pk, from_c1, from_c2, to_pk, to_c1, to_c2, diff_type from dolt_diff('t', 'STAGED', 'WORKING') order by coalesce(from_pk, to_pk);",
+				Query: "SELECT from_pk, from_c1, from_c2, to_pk, to_c1, to_c2, diff_type from dolt_diff('STAGED', 'WORKING', 't') order by coalesce(from_pk, to_pk);",
 				Expected: []sql.Row{
 					{1, "one", "two", 1, "one", "100", "modified"},
 					{2, "three", "four", nil, nil, nil, "removed"},
@@ -4504,7 +4524,7 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 				},
 			},
 			{
-				Query: "SELECT from_pk, from_c1, from_c2, to_pk, to_c1, to_c2, diff_type from dolt_diff('t', 'WORKING', 'STAGED') order by coalesce(from_pk, to_pk);",
+				Query: "SELECT from_pk, from_c1, from_c2, to_pk, to_c1, to_c2, diff_type from dolt_diff('WORKING', 'STAGED', 't') order by coalesce(from_pk, to_pk);",
 				Expected: []sql.Row{
 					{1, "one", "100", 1, "one", "two", "modified"},
 					{nil, nil, nil, 2, "three", "four", "added"},
@@ -4512,11 +4532,11 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 				},
 			},
 			{
-				Query:    "SELECT from_pk, from_c1, from_c2, to_pk, to_c1, to_c2, diff_type from dolt_diff('t', 'WORKING', 'WORKING') order by coalesce(from_pk, to_pk);",
+				Query:    "SELECT from_pk, from_c1, from_c2, to_pk, to_c1, to_c2, diff_type from dolt_diff('WORKING', 'WORKING', 't') order by coalesce(from_pk, to_pk);",
 				Expected: []sql.Row{},
 			},
 			{
-				Query:    "SELECT from_pk, from_c1, from_c2, to_pk, to_c1, to_c2, diff_type from dolt_diff('t', 'STAGED', 'STAGED') order by coalesce(from_pk, to_pk);",
+				Query:    "SELECT from_pk, from_c1, from_c2, to_pk, to_c1, to_c2, diff_type from dolt_diff('STAGED', 'STAGED', 't') order by coalesce(from_pk, to_pk);",
 				Expected: []sql.Row{},
 			},
 			{
@@ -4524,11 +4544,11 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 				SkipResultsCheck: true,
 			},
 			{
-				Query:    "SELECT from_pk, from_c1, from_c2, to_pk, to_c1, to_c2, diff_type from dolt_diff('t', 'WORKING', 'STAGED') order by coalesce(from_pk, to_pk);",
+				Query:    "SELECT from_pk, from_c1, from_c2, to_pk, to_c1, to_c2, diff_type from dolt_diff('WORKING', 'STAGED', 't') order by coalesce(from_pk, to_pk);",
 				Expected: []sql.Row{},
 			},
 			{
-				Query: "SELECT from_pk, from_c1, from_c2, to_pk, to_c1, to_c2, diff_type from dolt_diff('t', 'HEAD', 'STAGED') order by coalesce(from_pk, to_pk);",
+				Query: "SELECT from_pk, from_c1, from_c2, to_pk, to_c1, to_c2, diff_type from dolt_diff('HEAD', 'STAGED', 't') order by coalesce(from_pk, to_pk);",
 				Expected: []sql.Row{
 					{1, "one", "two", 1, "one", "100", "modified"},
 					{2, "three", "four", nil, nil, nil, "removed"},
@@ -4563,21 +4583,21 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
-				Query: "SELECT to_pk, to_c1, from_pk, from_c1, from_c2, diff_type from dolt_diff('t', 'main', 'branch1');",
+				Query: "SELECT to_pk, to_c1, from_pk, from_c1, from_c2, diff_type from dolt_diff('main', 'branch1', 't');",
 				Expected: []sql.Row{
 					{nil, nil, 1, "one", "two", "removed"},
 					{2, "two", 2, "two", "three", "modified"},
 				},
 			},
 			{
-				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, diff_type from dolt_diff('t', 'branch1', 'main');",
+				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, diff_type from dolt_diff('branch1', 'main', 't');",
 				Expected: []sql.Row{
 					{1, "one", "two", nil, nil, "added"},
 					{2, "two", "three", 2, "two", "modified"},
 				},
 			},
 			{
-				Query: "SELECT to_pk, to_c1, from_pk, from_c1, from_c2, diff_type from dolt_diff('t', 'main~', 'branch1');",
+				Query: "SELECT to_pk, to_c1, from_pk, from_c1, from_c2, diff_type from dolt_diff('main~', 'branch1', 't');",
 				Expected: []sql.Row{
 					{nil, nil, 1, "one", "two", "removed"},
 					{2, "two", nil, nil, nil, "added"},
@@ -4605,25 +4625,25 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
-				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type from dolt_diff('t', @Commit1, @Commit2);",
+				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type from dolt_diff(@Commit1, @Commit2, 't');",
 				Expected: []sql.Row{
 					{1, "one", "two", nil, nil, nil, "added"},
 					{2, "two", "three", nil, nil, nil, "added"},
 				},
 			},
 			{
-				Query: "SELECT to_pk, to_c1, from_pk, from_c1, from_c2, diff_type from dolt_diff('t', @Commit2, @Commit3);",
+				Query: "SELECT to_pk, to_c1, from_pk, from_c1, from_c2, diff_type from dolt_diff(@Commit2, @Commit3, 't');",
 				Expected: []sql.Row{
 					{1, "one", 1, "one", "two", "modified"},
 					{2, "two", 2, "two", "three", "modified"},
 				},
 			},
 			{
-				Query:       "SELECT to_c2 from dolt_diff('t', @Commit2, @Commit3);",
+				Query:       "SELECT to_c2 from dolt_diff(@Commit2, @Commit3, 't');",
 				ExpectedErr: sql.ErrColumnNotFound,
 			},
 			{
-				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, diff_type from dolt_diff('t', @Commit3, @Commit4);",
+				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, diff_type from dolt_diff(@Commit3, @Commit4, 't');",
 				Expected: []sql.Row{
 					{1, "one", "foo", 1, "one", "modified"},
 					// This row doesn't show up as changed because adding a column doesn't touch the row data.
@@ -4632,11 +4652,11 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 				},
 			},
 			{
-				Query:       "SELECT from_c2 from dolt_diff('t', @Commit3, @Commit4);",
+				Query:       "SELECT from_c2 from dolt_diff(@Commit3, @Commit4, 't');",
 				ExpectedErr: sql.ErrColumnNotFound,
 			},
 			{
-				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type from dolt_diff('t', @Commit1, @Commit4);",
+				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type from dolt_diff(@Commit1, @Commit4, 't');",
 				Expected: []sql.Row{
 					{1, "one", "foo", nil, nil, nil, "added"},
 					{2, "two", nil, nil, nil, nil, "added"},
@@ -4668,43 +4688,43 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
-				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type from dolt_diff('t', @Commit1, @Commit2);",
+				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type from dolt_diff(@Commit1, @Commit2, 't');",
 				Expected: []sql.Row{
 					{1, "one", -1, nil, nil, nil, "added"},
 					{2, "two", -2, nil, nil, nil, "added"},
 				},
 			},
 			{
-				Query:       "SELECT to_c2 from dolt_diff('t', @Commit2, @Commit3);",
+				Query:       "SELECT to_c2 from dolt_diff(@Commit2, @Commit3, 't');",
 				ExpectedErr: sql.ErrColumnNotFound,
 			},
 			{
-				Query:    "SELECT to_pk, to_c1, to_c3, from_pk, from_c1, from_c2, diff_type from dolt_diff('t', @Commit2, @Commit3);",
+				Query:    "SELECT to_pk, to_c1, to_c3, from_pk, from_c1, from_c2, diff_type from dolt_diff(@Commit2, @Commit3, 't');",
 				Expected: []sql.Row{},
 			},
 			{
-				Query: "SELECT to_pk, to_c1, to_c3, from_pk, from_c1, from_c3, diff_type from dolt_diff('t', @Commit3, @Commit4);",
+				Query: "SELECT to_pk, to_c1, to_c3, from_pk, from_c1, from_c3, diff_type from dolt_diff(@Commit3, @Commit4, 't');",
 				Expected: []sql.Row{
 					{3, "three", -3, nil, nil, nil, "added"},
 					{1, "one", 1, 1, "one", -1, "modified"},
 				},
 			},
 			{
-				Query:       "SELECT from_c2 from dolt_diff('t', @Commit4, @Commit5);",
+				Query:       "SELECT from_c2 from dolt_diff(@Commit4, @Commit5, 't');",
 				ExpectedErr: sql.ErrColumnNotFound,
 			},
 			{
-				Query:       "SELECT to_c3 from dolt_diff('t', @Commit4, @Commit5);",
+				Query:       "SELECT to_c3 from dolt_diff(@Commit4, @Commit5, 't');",
 				ExpectedErr: sql.ErrColumnNotFound,
 			},
 			{
-				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c3, diff_type from dolt_diff('t', @Commit4, @Commit5);",
+				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c3, diff_type from dolt_diff(@Commit4, @Commit5, 't');",
 				Expected: []sql.Row{
 					{4, "four", -4, nil, nil, nil, "added"},
 				},
 			},
 			{
-				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type from dolt_diff('t', @Commit1, @Commit5);",
+				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type from dolt_diff(@Commit1, @Commit5, 't');",
 				Expected: []sql.Row{
 					{1, "one", 1, nil, nil, nil, "added"},
 					{2, "two", -2, nil, nil, nil, "added"},
@@ -4737,34 +4757,34 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
-				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type from dolt_diff('t', @Commit1, @Commit2);",
+				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type from dolt_diff(@Commit1, @Commit2, 't');",
 				Expected: []sql.Row{
 					{1, "one", "asdf", nil, nil, nil, "added"},
 					{2, "two", "2", nil, nil, nil, "added"},
 				},
 			},
 			{
-				Query: "SELECT to_pk, to_c1, from_pk, from_c1, from_c2, diff_type from dolt_diff('t', @Commit2, @Commit3);",
+				Query: "SELECT to_pk, to_c1, from_pk, from_c1, from_c2, diff_type from dolt_diff(@Commit2, @Commit3, 't');",
 				Expected: []sql.Row{
 					{1, "one", 1, "one", "asdf", "modified"},
 					{2, "two", 2, "two", "2", "modified"},
 				},
 			},
 			{
-				Query: "SELECT to_pk, to_c1, from_pk, from_c1, diff_type from dolt_diff('t', @Commit3, @Commit4);",
+				Query: "SELECT to_pk, to_c1, from_pk, from_c1, diff_type from dolt_diff(@Commit3, @Commit4, 't');",
 				Expected: []sql.Row{
 					{3, "three", nil, nil, "added"},
 					{1, "fdsa", 1, "one", "modified"},
 				},
 			},
 			{
-				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, diff_type from dolt_diff('t', @Commit4, @Commit5);",
+				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, diff_type from dolt_diff(@Commit4, @Commit5, 't');",
 				Expected: []sql.Row{
 					{4, "four", -4, nil, nil, "added"},
 				},
 			},
 			{
-				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type from dolt_diff('t', @Commit1, @Commit5);",
+				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type from dolt_diff(@Commit1, @Commit5, 't');",
 				Expected: []sql.Row{
 					{1, "fdsa", nil, nil, nil, nil, "added"},
 					{2, "two", nil, nil, nil, nil, "added"},
@@ -4782,15 +4802,15 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
-				Query:    "select to_a, to_b, from_commit, to_commit, diff_type from dolt_diff('t1', 'HEAD', 'WORKING')",
+				Query:    "select to_a, to_b, from_commit, to_commit, diff_type from dolt_diff('HEAD', 'WORKING', 't1')",
 				Expected: []sql.Row{{1, 2, "HEAD", "WORKING", "added"}},
 			},
 			{
-				Query:       "select to_a, from_b, from_commit, to_commit, diff_type from dolt_diff('t1', 'HEAD', 'WORKING')",
+				Query:       "select to_a, from_b, from_commit, to_commit, diff_type from dolt_diff('HEAD', 'WORKING', 't1')",
 				ExpectedErr: sql.ErrColumnNotFound,
 			},
 			{
-				Query:    "select from_a, from_b, from_commit, to_commit, diff_type from dolt_diff('t1', 'WORKING', 'HEAD')",
+				Query:    "select from_a, from_b, from_commit, to_commit, diff_type from dolt_diff('WORKING', 'HEAD', 't1')",
 				Expected: []sql.Row{{1, 2, "WORKING", "HEAD", "removed"}},
 			},
 		},
@@ -4807,7 +4827,7 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
-				Query:    "select from_a, from_b, from_commit, to_commit, diff_type from dolt_diff('t1', 'HEAD~', 'HEAD')",
+				Query:    "select from_a, from_b, from_commit, to_commit, diff_type from dolt_diff('HEAD~', 'HEAD', 't1')",
 				Expected: []sql.Row{{1, 2, "HEAD~", "HEAD", "removed"}},
 			},
 		},
@@ -4826,12 +4846,12 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
-				Query:    "select to_a, to_b, from_commit, to_commit, diff_type from dolt_diff('t2', 'HEAD~', 'HEAD')",
+				Query:    "select to_a, to_b, from_commit, to_commit, diff_type from dolt_diff('HEAD~', 'HEAD', 't2')",
 				Expected: []sql.Row{{3, 4, "HEAD~", "HEAD", "added"}},
 			},
 			{
 				// Maybe confusing? We match the old table name as well
-				Query:    "select to_a, to_b, from_commit, to_commit, diff_type from dolt_diff('t1', 'HEAD~', 'HEAD')",
+				Query:    "select to_a, to_b, from_commit, to_commit, diff_type from dolt_diff('HEAD~', 'HEAD', 't1')",
 				Expected: []sql.Row{{3, 4, "HEAD~", "HEAD", "added"}},
 			},
 		},
@@ -4855,32 +4875,12 @@ var DiffTableFunctionScriptTests = []queries.ScriptTest{
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
-				Query:    "select to_pk2, to_col1, from_pk, from_col1, diff_type from dolt_diff('t1', 'HEAD~', 'HEAD')",
+				Query:    "select to_pk2, to_col1, from_pk, from_col1, diff_type from dolt_diff('HEAD~', 'HEAD', 't1')",
 				Expected: []sql.Row{{1, 100, 1, 1, "modified"}},
 			},
 			{
-				Query:    "select to_pk2a, to_pk2b, to_col1, from_pk1a, from_pk1b, from_col1, diff_type from dolt_diff('t2', 'HEAD~', 'HEAD');",
+				Query:    "select to_pk2a, to_pk2b, to_col1, from_pk1a, from_pk1b, from_col1, diff_type from dolt_diff('HEAD~', 'HEAD', 't2');",
 				Expected: []sql.Row{{1, 1, 100, 1, 1, 1, "modified"}},
-			},
-		},
-	},
-	{
-		Name: "add multiple columns, then set and unset a value. Should not show a diff",
-		SetUpScript: []string{
-			"CREATE table t (pk int primary key);",
-			"Insert into t values (1);",
-			"alter table t add column col1 int;",
-			"alter table t add column col2 int;",
-			"CALL DOLT_ADD('.');",
-			"CALL DOLT_COMMIT('-am', 'setup');",
-			"UPDATE t set col1 = 1 where pk = 1;",
-			"UPDATE t set col1 = null where pk = 1;",
-			"CALL DOLT_COMMIT('--allow-empty', '-am', 'fix short tuple');",
-		},
-		Assertions: []queries.ScriptTestAssertion{
-			{
-				Query:    "SELECT to_pk, to_col1, from_pk, from_col1, diff_type from dolt_diff_t;",
-				Expected: []sql.Row{{1, nil, nil, nil, "added"}},
 			},
 		},
 	},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -752,7 +752,7 @@ var DoltUserPrivTests = []queries.UserPrivilegeTest{
 				// After granting access to mydb.test, dolt_diff should work
 				User:     "tester",
 				Host:     "localhost",
-				Query:    "SELECT COUNT(*) FROM dolt_diff('main~', 'main0, 'test');",
+				Query:    "SELECT COUNT(*) FROM dolt_diff('main~', 'main', 'test');",
 				Expected: []sql.Row{{1}},
 			},
 			{


### PR DESCRIPTION
This PR updates argument ordering of `dolt_diff()` table function to match `dolt_diff_summary()` table function, which matches CLI command argument order.