### PR TITLE
turn off opt-in feature for unix socket

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -403,11 +403,7 @@ func checkForUnixSocket(config ServerConfig) (string, bool, error) {
 		if runtime.GOOS == "windows" {
 			return "", false, fmt.Errorf("cannot define unix socket file on Windows")
 		}
-		s := config.Socket()
-		if s == "" {
-			s = defaultUnixSocketFilePath
-		}
-		return s, true, nil
+		return config.Socket(), true, nil
 	} else {
 		// if host is undefined or defined as "localhost" -> unix
 		if runtime.GOOS != "windows" && config.Host() == "localhost" {

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -384,21 +384,36 @@ func handleProtocolAndAddress(serverConfig ServerConfig) (server.Config, error) 
 	}
 	serverConf.Address = hostPort
 
-	// if socket is defined with or without value -> unix
-	if serverConfig.Socket() != "" {
-		if runtime.GOOS == "windows" {
-			return server.Config{}, fmt.Errorf("cannot define unix socket file on Windows")
-		}
-		serverConf.Socket = serverConfig.Socket()
+	sock, useSock, err := checkForUnixSocket(serverConfig)
+	if err != nil {
+		return server.Config{}, err
 	}
-	// TODO : making it an "opt in" feature (just to start) and requiring users to pass in the `--socket` flag
-	//  to turn them on instead of defaulting them on when host and port aren't set or host is set to `localhost`.
-	//} else {
-	//	// if host is undefined or defined as "localhost" -> unix
-	//	if shouldUseUnixSocket(serverConfig) {
-	//		serverConf.Socket = defaultUnixSocketFilePath
-	//	}
-	//}
+	if useSock {
+		serverConf.Socket = sock
+	}
 
 	return serverConf, nil
+}
+
+// checkForUnixSocket evaluates ServerConfig for whether the unix socket is to be used or not.
+// If user defined socket flag or host is 'localhost', it returns the unix socket file location
+// either user-defined or the default if it was not defined.
+func checkForUnixSocket(config ServerConfig) (string, bool, error) {
+	if config.Socket() != "" {
+		if runtime.GOOS == "windows" {
+			return "", false, fmt.Errorf("cannot define unix socket file on Windows")
+		}
+		s := config.Socket()
+		if s == "" {
+			s = defaultUnixSocketFilePath
+		}
+		return s, true, nil
+	} else {
+		// if host is undefined or defined as "localhost" -> unix
+		if runtime.GOOS != "windows" && config.Host() == "localhost" {
+			return defaultUnixSocketFilePath, true, nil
+		}
+	}
+
+	return "", false, nil
 }

--- a/go/cmd/dolt/commands/sqlserver/serverconfig.go
+++ b/go/cmd/dolt/commands/sqlserver/serverconfig.go
@@ -532,12 +532,12 @@ func ConnectionString(config ServerConfig, database string) string {
 // ConfigInfo returns a summary of some of the config which contains some of the more important information
 func ConfigInfo(config ServerConfig) string {
 	socket := ""
-	if config.Socket() != "" {
-		s := config.Socket()
-		if s == "" {
-			s = defaultUnixSocketFilePath
-		}
-		socket = fmt.Sprintf(`|S="%v"`, s)
+	sock, useSock, err := checkForUnixSocket(config)
+	if err != nil {
+		panic(err)
+	}
+	if useSock {
+		socket = fmt.Sprintf(`|S="%v"`, sock)
 	}
 	return fmt.Sprintf(`HP="%v:%v"|T="%v"|R="%v"|L="%v"%s`, config.Host(), config.Port(),
 		config.ReadTimeout(), config.ReadOnly(), config.LogLevel(), socket)

--- a/integration-tests/bats/sql-server-remotesrv.bats
+++ b/integration-tests/bats/sql-server-remotesrv.bats
@@ -127,7 +127,7 @@ SQL
     dolt add vals
     dolt commit -m 'create initial vals table'
 
-    dolt sql-server --remotesapi-port 50051 &
+    dolt sql-server --host 127.0.0.1 --remotesapi-port 50051 &
     srv_pid=$!
 
     cd ../../


### PR DESCRIPTION
Initial implementation of unix socket has opt-in feature for unix socket support. The default of mysql unix socket when socket flag is not defined is when host is defined as 'localhost' or undefined. 