### PR TITLE
store/datas/pull: If the BPS is less than 1, report 0

### DIFF
--- a/go/store/datas/pull/puller.go
+++ b/go/store/datas/pull/puller.go
@@ -223,6 +223,13 @@ func emitStats(s *stats, ch chan Stats) (cancel func()) {
 					smoothedFetchBPS = curFetchedBPS + weight*(newFetchedBPS-curFetchedBPS)
 				}
 
+				if smoothedSendBPS < 1 {
+					smoothedSendBPS = 0
+				}
+				if smoothedFetchBPS < 1 {
+					smoothedFetchBPS = 0
+				}
+
 				atomic.StoreUint64(&s.sendBytesPerSec, math.Float64bits(smoothedSendBPS))
 				atomic.StoreUint64(&s.fetchedSourceBytesPerSec, math.Float64bits(smoothedFetchBPS))
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14025711/194154643-b634ac59-8ea1-4560-8fcf-6f3a059f5035.png)
 ^ prevents the push / pull progress reporter from reporting very small BP/s units.