### PR TITLE
go/doltcore/sqle: Initialize remotes, backups, and branch config when constructing revision databases

### DIFF
--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -1025,6 +1025,21 @@ func dbRevisionForBranch(ctx context.Context, srcDb SqlDatabase, revSpec string)
 		}
 	}
 
+	remotes, err := static.GetRemotes()
+	if err != nil {
+		return nil, dsess.InitialDbState{}, err
+	}
+
+	branches, err := static.GetBranches()
+	if err != nil {
+		return nil, dsess.InitialDbState{}, err
+	}
+
+	backups, err := static.GetBackups()
+	if err != nil {
+		return nil, dsess.InitialDbState{}, err
+	}
+
 	init := dsess.InitialDbState{
 		Db:         db,
 		HeadCommit: cm,
@@ -1034,6 +1049,10 @@ func dbRevisionForBranch(ctx context.Context, srcDb SqlDatabase, revSpec string)
 			Rsw: static,
 			Rsr: static,
 		},
+		Remotes:  remotes,
+		Branches: branches,
+		Backups:  backups,
+		//ReadReplica: //todo
 	}
 
 	return db, init, nil
@@ -1065,6 +1084,11 @@ func dbRevisionForTag(ctx context.Context, srcDb Database, revSpec string) (Read
 			Rsw: srcDb.DbData().Rsw,
 			Rsr: srcDb.DbData().Rsr,
 		},
+		// todo: should we initialize
+		//  - Remotes
+		//  - Branches
+		//  - Backups
+		//  - ReadReplicas
 	}
 
 	return db, init, nil
@@ -1099,6 +1123,11 @@ func dbRevisionForCommit(ctx context.Context, srcDb Database, revSpec string) (R
 			Rsw: srcDb.DbData().Rsw,
 			Rsr: srcDb.DbData().Rsr,
 		},
+		// todo: should we initialize
+		//  - Remotes
+		//  - Branches
+		//  - Backups
+		//  - ReadReplicas
 	}
 
 	return db, init, nil

--- a/integration-tests/bats/system-tables.bats
+++ b/integration-tests/bats/system-tables.bats
@@ -230,6 +230,26 @@ teardown() {
     [[ "$output" =~ 0 ]] || false
 }
 
+@test "system-tables: revision databases can query dolt_remotes table" {
+    mkdir remote
+    dolt remote add origin file://remote/
+    dolt branch b1
+
+    run dolt sql <<SQL
+SELECT name FROM dolt_remotes;
+SQL
+    [ $status -eq 0 ]
+    [[ "$output" =~ "origin" ]] || false
+
+    DATABASE=$(echo $(basename $(pwd)) | tr '-' '_')
+    run dolt sql <<SQL
+USE $DATABASE/b1;
+SELECT name FROM dolt_remotes;
+SQL
+    [ $status -eq 0 ]
+    [[ "$output" =~ "origin" ]] || false
+}
+
 @test "system-tables: query dolt_diff system table" {
     dolt sql -q "CREATE TABLE testStaged (pk INT, c1 INT, PRIMARY KEY(pk))"
     dolt add testStaged


### PR DESCRIPTION
fix for #4518