### PR TITLE
fix `insert ... on duplicate key update ...` for unique keys

### DIFF
--- a/go/libraries/doltcore/sqle/writer/prolly_index_writer_keyless.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_index_writer_keyless.go
@@ -45,6 +45,10 @@ func (k prollyKeylessWriter) Map(ctx context.Context) (prolly.Map, error) {
 	return k.mut.Map(ctx)
 }
 
+func (k prollyKeylessWriter) ValidateKeyViolations(ctx context.Context, sqlRow sql.Row) error {
+	return nil
+}
+
 func (k prollyKeylessWriter) Insert(ctx context.Context, sqlRow sql.Row) error {
 	hashId, value, err := k.tuplesFromRow(ctx, sqlRow)
 	if err != nil {
@@ -196,6 +200,11 @@ func (writer prollyKeylessSecondaryWriter) Name() string {
 // Map implements the interface indexWriter.
 func (writer prollyKeylessSecondaryWriter) Map(ctx context.Context) (prolly.Map, error) {
 	return writer.mut.Map(ctx)
+}
+
+// ValidateKeyViolations implements the interface indexWriter.
+func (writer prollyKeylessSecondaryWriter) ValidateKeyViolations(ctx context.Context, sqlRow sql.Row) error {
+	return nil
 }
 
 // Insert implements the interface indexWriter.

--- a/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
@@ -130,15 +130,23 @@ func getSecondaryKeylessProllyWriters(ctx context.Context, t *doltdb.Table, sqlS
 }
 
 // Insert implements TableWriter.
+// TODO: do validation before insertion
 func (w *prollyTableWriter) Insert(ctx *sql.Context, sqlRow sql.Row) (err error) {
+	if err := w.primary.ValidateKeyViolations(ctx, sqlRow); err != nil {
+		return err
+	}
+	for _, wr := range w.secondary {
+		if err := wr.ValidateKeyViolations(ctx, sqlRow); err != nil {
+			if uke, ok := err.(secondaryUniqueKeyError); ok {
+				return w.primary.(primaryIndexErrBuilder).errForSecondaryUniqueKeyError(ctx, uke)
+			}
+		}
+	}
 	if err := w.primary.Insert(ctx, sqlRow); err != nil {
 		return err
 	}
 	for _, wr := range w.secondary {
 		if err := wr.Insert(ctx, sqlRow); err != nil {
-			if uke, ok := err.(secondaryUniqueKeyError); ok {
-				return w.primary.(primaryIndexErrBuilder).errForSecondaryUniqueKeyError(ctx, uke)
-			}
 			return err
 		}
 	}

--- a/integration-tests/bats/sql.bats
+++ b/integration-tests/bats/sql.bats
@@ -2194,6 +2194,19 @@ SQL
     [[ "$output" =~ "d,1,1" ]] || false
 }
 
+@test "sql: duplicate key inserts on table with primary and secondary indexes" {
+    dolt sql -q "CREATE TABLE test (pk int primary key, uk int unique key, i int);"
+    dolt sql -q "INSERT INTO test VALUES(0,0,0);"
+    run dolt sql -r csv -q "SELECT * from test"
+    [ $status -eq 0 ]
+    [[ "$output" =~ "0,0,0" ]] || false
+    run dolt sql -q "INSERT INTO test (pk,uk) VALUES(1,0) on duplicate key update i = 99;"
+    [ $status -eq 0 ]
+    run dolt sql -r csv -q "SELECT * from test"
+    [ $status -eq 0 ]
+    [[ "$output" =~ "0,0,99" ]] || false
+}
+
 @test "sql: at commit" {
   skip "zachmu broke this, needs to fix"
     


### PR DESCRIPTION
fix for: https://github.com/dolthub/dolt/issues/4475

only happens in new format, solution was just to validate any key violations before inserting anything.