### PR TITLE
get next port number if random port is in use

### DIFF
--- a/integration-tests/bats/helper/query-server-common.bash
+++ b/integration-tests/bats/helper/query-server-common.bash
@@ -249,11 +249,14 @@ server_query_with_port() {
 
 definePORT() {
   getPORT=""
-  let getPORT="$$ % (65536-1024) + 1024"
-  portinuse=$(lsof -i -P -n | grep LISTEN | grep $attemptedPORT | wc -l)
-  if [ $portinuse -gt 0 ]
-  then
-    let getPORT="($$ + 1) % (65536-1024) + 1024"
-  fi
-  echo "$getPORT"
+  for i in {0..9}
+  do
+    let getPORT="($$ + $i) % (65536-1024) + 1024"
+    portinuse=$(lsof -i -P -n | grep LISTEN | grep $attemptedPORT | wc -l)
+      if [ $portinuse -eq 0 ]
+      then
+        echo "$getPORT"
+        break
+      fi
+  done
 }

--- a/integration-tests/bats/helper/query-server-common.bash
+++ b/integration-tests/bats/helper/query-server-common.bash
@@ -113,7 +113,7 @@ wait_for_connection(port=int(port_str), timeout_ms=int(timeout_ms), database=dat
 
 start_sql_server() {
     DEFAULT_DB="$1"
-    let PORT="$$ % (65536-1024) + 1024"
+    PORT=$( definePORT )
     dolt sql-server --host 0.0.0.0 --port=$PORT --user dolt &
     SERVER_PID=$!
     wait_for_connection $PORT 5000
@@ -124,7 +124,7 @@ start_sql_server() {
 # this func)
 start_sql_server_with_args() {
     DEFAULT_DB=""
-    let PORT="$$ % (65536-1024) + 1024"
+    PORT=$( definePORT )
     dolt sql-server "$@" --port=$PORT &
     SERVER_PID=$!
     wait_for_connection $PORT 5000
@@ -132,7 +132,7 @@ start_sql_server_with_args() {
 
 start_sql_server_with_config() {
     DEFAULT_DB="$1"
-    let PORT="$$ % (65536-1024) + 1024"
+    PORT=$( definePORT )
     echo "
 log_level: debug
 
@@ -155,7 +155,7 @@ behavior:
 
 start_sql_multi_user_server() {
     DEFAULT_DB="$1"
-    let PORT="$$ % (65536-1024) + 1024"
+    PORT=$( definePORT )
     echo "
 log_level: debug
 
@@ -177,7 +177,7 @@ behavior:
 
 start_multi_db_server() {
     DEFAULT_DB="$1"
-    let PORT="$$ % (65536-1024) + 1024"
+    PORT=$( definePORT )
     dolt sql-server --host 0.0.0.0 --port=$PORT --user dolt --data-dir ./ &
     SERVER_PID=$!
     wait_for_connection $PORT 5000
@@ -233,7 +233,7 @@ stop_sql_server() {
 #  * param7: Expected exception value of 1. Mutually exclusive with param6.
 #
 server_query() {
-    let PORT="$$ % (65536-1024) + 1024"
+    PORT=$( definePORT )
     server_query_with_port "$PORT" "$@"
 }
 
@@ -245,4 +245,15 @@ server_query_with_port() {
     PYTEST_DIR="$BATS_TEST_DIRNAME/helper"
     echo Executing server_query
     python3 -u -c "$PYTHON_QUERY_SCRIPT" -- "$PYTEST_DIR" "$1" "$PORT" "$2" "$3" "$4" "$5" "$6" "$7"
+}
+
+definePORT() {
+  getPORT=""
+  let getPORT="$$ % (65536-1024) + 1024"
+  portinuse=$(lsof -i -P -n | grep LISTEN | grep $attemptedPORT | wc -l)
+  if [ $portinuse -gt 0 ]
+  then
+    let getPORT="($$ + 1) % (65536-1024) + 1024"
+  fi
+  echo "$getPORT"
 }

--- a/integration-tests/bats/sql-jwt-auth.bats
+++ b/integration-tests/bats/sql-jwt-auth.bats
@@ -29,7 +29,7 @@ teardown() {
     cp "$BATS_TEST_DIRNAME"/../../go/cmd/dolt/commands/sqlserver/testdata/chain_key.pem .
     cp "$BATS_TEST_DIRNAME"/../../go/cmd/dolt/commands/sqlserver/testdata/chain_cert.pem .
     cp "$BATS_TEST_DIRNAME"/../../go/libraries/utils/jwtauth/gen_keys/test_jwks.json .
-    let PORT="$$ % (65536-1024) + 1024"
+    PORT=$( definePORT )
     TOKEN="`cat $BATS_TEST_DIRNAME/../../go/libraries/utils/jwtauth/gen_keys/token.jwt`"
 
     cat >config.yml <<EOF

--- a/integration-tests/bats/sql-privs.bats
+++ b/integration-tests/bats/sql-privs.bats
@@ -55,7 +55,7 @@ teardown() {
 
 @test "sql-privs: default user is root. create new user destroys default user." {
     make_test_repo
-    let PORT="$$ % (65536-1024) + 1024"
+    PORT=$( definePORT )
     dolt sql-server --host 0.0.0.0 --port=$PORT &
     SERVER_PID=$! # will get killed by teardown_common
     sleep 5 # not using python wait so this works on windows
@@ -68,7 +68,7 @@ teardown() {
     rm -f .dolt/sql-server.lock
 
     # restarting server
-    let PORT="$$ % (65536-1024) + 1024"
+    PORT=$( definePORT )
     dolt sql-server --host 0.0.0.0 --port=$PORT &
     SERVER_PID=$! # will get killed by teardown_common
     sleep 5 # not using python wait so this works on windows
@@ -96,7 +96,7 @@ teardown() {
 @test "sql-privs: yaml with no user is replaced with command line user" {
     make_test_repo
     touch server.yaml
-    let PORT="$$ % (65536-1024) + 1024"
+    PORT=$( definePORT )
 
     echo "log_level: debug
 
@@ -118,7 +118,7 @@ behavior:
 @test "sql-privs: yaml with user is also replaced with command line user" {
     make_test_repo
     touch server.yaml
-    let PORT="$$ % (65536-1024) + 1024"
+    PORT=$( definePORT )
 
     echo "log_level: debug
 user:

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -53,7 +53,7 @@ teardown() {
     cd repo1
     dolt sql -q "create user dolt@'%' identified by '123'"
 
-    let PORT="$$ % (65536-1024) + 1024"
+    PORT=$( definePORT )
     dolt sql-server --port=$PORT --user dolt > log.txt 2>&1 &
     SERVER_PID=$!
     sleep 5
@@ -684,7 +684,7 @@ SQL
     skiponwindows "Missing dependencies"
     cd repo1
     dolt sql -q 'create table test (id int primary key)'
-    let PORT="$$ % (65536-1024) + 1024"
+    PORT=$( definePORT )
     cat >config.yml <<EOF
 log_level: debug
 behavior:
@@ -731,7 +731,7 @@ END""")
     skiponwindows "Missing dependencies"
     cd repo1
     dolt sql -q 'create table test (id int primary key)'
-    let PORT="$$ % (65536-1024) + 1024"
+    PORT=$( definePORT )
     cat >config.yml <<EOF
 log_level: debug
 user:
@@ -1156,7 +1156,7 @@ databases:
 @test "sql-server: sql-server locks database" {
     cd repo1
     start_sql_server
-    let PORT="$$ % (65536-1024) + 1024"
+    PORT=$( definePORT )
     run dolt sql-server -P $PORT
     [ "$status" -eq 1 ]
 }
@@ -1164,7 +1164,7 @@ databases:
 @test "sql-server: multi dir sql-server locks out childen" {
     start_sql_server
     cd repo2
-    let PORT="$$ % (65536-1024) + 1024"
+    PORT=$( definePORT )
     run dolt sql-server -P $PORT
     [ "$status" -eq 1 ]
 }
@@ -1173,7 +1173,7 @@ databases:
     cd repo2
     start_sql_server
     cd ..
-    let PORT="$$ % (65536-1024) + 1024"
+    PORT=$( definePORT )
     run dolt sql-server -P $PORT
     [ "$status" -eq 1 ]
 }
@@ -1183,7 +1183,7 @@ databases:
     start_sql_server
     server_query repo1 1 dolt "" "create database newdb" ""
     cd newdb
-    let PORT="$$ % (65536-1024) + 1024"
+    PORT=$( definePORT )
     run dolt sql-server -P $PORT
     [ "$status" -eq 1 ]
 }
@@ -1204,7 +1204,7 @@ databases:
     skiponwindows "unix socket is not available on Windows"
     cd repo2
     DEFAULT_DB="repo2"
-    let PORT="$$ % (65536-1024) + 1024"
+    PORT=$( definePORT )
 
     dolt sql-server --port $PORT --user dolt >> log.txt 2>&1 &
     SERVER_PID=$!
@@ -1228,7 +1228,7 @@ databases:
     skiponwindows "unix socket is not available on Windows"
     cd repo2
     DEFAULT_DB="repo2"
-    let PORT="$$ % (65536-1024) + 1024"
+    PORT=$( definePORT )
 
     dolt sql-server --port $PORT --user dolt --socket > log.txt 2>&1 &
     SERVER_PID=$!
@@ -1249,7 +1249,7 @@ databases:
     run pwd
     REPO_NAME=$output
 
-    let PORT="$$ % (65536-1024) + 1024"
+    PORT=$( definePORT )
     dolt sql-server --port=$PORT --socket="$REPO_NAME/mysql.sock" --user dolt > log.txt 2>&1 &
     SERVER_PID=$!
     run wait_for_connection $PORT 5000
@@ -1264,7 +1264,7 @@ databases:
     skiponwindows "unix socket is not available on Windows"
     cd repo2
     DEFAULT_DB="repo2"
-    let PORT="$$ % (65536-1024) + 1024"
+    PORT=$( definePORT )
 
     echo "
 log_level: debug
@@ -1382,7 +1382,7 @@ s.close()
     run dolt init --new-format
     [ $status -eq 0 ]
 
-    let PORT="$$ % (65536-1024) + 1024"
+    PORT=$( definePORT )
     dolt sql-server --host 0.0.0.0 --port=$PORT --user dolt &
     SERVER_PID=$! # will get killed by teardown_common
     sleep 5 # not using python wait so this works on windows

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -1420,6 +1420,11 @@ s.close()
 
     run grep "failed to access 'mydb2' database: can no longer find .dolt dir on disk" server_log.txt
     [ "${#lines[@]}" -eq 1 ]
+
+    # this tests fails sometimes as the server is stopped from the above error
+    # but stop_sql_server in teardown tries to kill process that is not running anymore,
+    # so start the server again, and it will be stopped in teardown
+    start_sql_server
 }
 
 @test "sql-server: dropping database that the server is running in should drop only the db itself not its nested dbs" {

--- a/integration-tests/mysql-client-tests/mysql-client-tests.bats
+++ b/integration-tests/mysql-client-tests/mysql-client-tests.bats
@@ -170,11 +170,14 @@ EOF" -m "postgres"
 
 definePORT() {
   getPORT=""
-  let getPORT="$$ % (65536-1024) + 1024"
-  portinuse=$(lsof -i -P -n | grep LISTEN | grep $attemptedPORT | wc -l)
-  if [ $portinuse -gt 0 ]
-  then
-    let getPORT="($$ + 1) % (65536-1024) + 1024"
-  fi
-  echo "$getPORT"
+  for i in {0..9}
+  do
+    let getPORT="($$ + $i) % (65536-1024) + 1024"
+    portinuse=$(lsof -i -P -n | grep LISTEN | grep $attemptedPORT | wc -l)
+      if [ $portinuse -eq 0 ]
+      then
+        echo "$getPORT"
+        break
+      fi
+  done
 }

--- a/integration-tests/mysql-client-tests/mysql-client-tests.bats
+++ b/integration-tests/mysql-client-tests/mysql-client-tests.bats
@@ -19,7 +19,7 @@ setup() {
     dolt sql -q "CREATE TABLE warehouse(warehouse_id int primary key, warehouse_name longtext)"
     dolt sql -q "INSERT into warehouse VALUES (1, 'UPS'), (2, 'TV'), (3, 'Table');"
 
-    let PORT="$$ % (65536-1024) + 1024"
+    PORT=$( definePORT )
     USER="dolt"
     dolt sql-server --host 0.0.0.0 --port=$PORT --user=$USER --loglevel=trace &
     SERVER_PID=$!

--- a/integration-tests/mysql-client-tests/mysql-client-tests.bats
+++ b/integration-tests/mysql-client-tests/mysql-client-tests.bats
@@ -167,3 +167,14 @@ EOF" -m "postgres"
 @test "R RMariaDB client" {
     Rscript $BATS_TEST_DIRNAME/r/rmariadb-test.r $USER $PORT $REPO_NAME
 }
+
+definePORT() {
+  getPORT=""
+  let getPORT="$$ % (65536-1024) + 1024"
+  portinuse=$(lsof -i -P -n | grep LISTEN | grep $attemptedPORT | wc -l)
+  if [ $portinuse -gt 0 ]
+  then
+    let getPORT="($$ + 1) % (65536-1024) + 1024"
+  fi
+  echo "$getPORT"
+}

--- a/integration-tests/orm-tests/orm-tests.bats
+++ b/integration-tests/orm-tests/orm-tests.bats
@@ -7,7 +7,7 @@ setup() {
 
   dolt init
 
-  let PORT="$$ % (65536-1024) + 1024"
+  PORT=$( definePORT )
   USER="dolt"
   dolt sql-server --host 0.0.0.0 --port=$PORT --user=$USER --loglevel=trace &
   SERVER_PID=$!


### PR DESCRIPTION
fixed in bats testing:
- if PORT in use, get the next unused PORT number when starting a sql-server
- kill a process only if it's still running when stopping a sql-server