### PR TITLE
 Branch Control Pt. 6

### DIFF
--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -85,24 +85,26 @@ By default this command uses the dolt database in the current working directory,
 var ErrMultipleDoltCfgDirs = errors.NewKind("multiple .doltcfg directories detected: '%s' and '%s'; pass one of the directories using option --doltcfg-dir")
 
 const (
-	QueryFlag         = "query"
-	FormatFlag        = "result-format"
-	saveFlag          = "save"
-	executeFlag       = "execute"
-	listSavedFlag     = "list-saved"
-	messageFlag       = "message"
-	BatchFlag         = "batch"
-	DataDirFlag       = "data-dir"
-	MultiDBDirFlag    = "multi-db-dir"
-	CfgDirFlag        = "doltcfg-dir"
-	DefaultCfgDirName = ".doltcfg"
-	PrivsFilePathFlag = "privilege-file"
-	DefaultPrivsName  = "privileges.db"
-	continueFlag      = "continue"
-	fileInputFlag     = "file"
-	UserFlag          = "user"
-	DefaultUser       = "root"
-	DefaultHost       = "localhost"
+	QueryFlag             = "query"
+	FormatFlag            = "result-format"
+	saveFlag              = "save"
+	executeFlag           = "execute"
+	listSavedFlag         = "list-saved"
+	messageFlag           = "message"
+	BatchFlag             = "batch"
+	DataDirFlag           = "data-dir"
+	MultiDBDirFlag        = "multi-db-dir"
+	CfgDirFlag            = "doltcfg-dir"
+	DefaultCfgDirName     = ".doltcfg"
+	PrivsFilePathFlag     = "privilege-file"
+	BranchCtrlPathFlag    = "branch-control-file"
+	DefaultPrivsName      = "privileges.db"
+	DefaultBranchCtrlName = "branch_control.db"
+	continueFlag          = "continue"
+	fileInputFlag         = "file"
+	UserFlag              = "user"
+	DefaultUser           = "root"
+	DefaultHost           = "localhost"
 
 	welcomeMsg = `# Welcome to the DoltSQL shell.
 # Statements must be terminated with ';'.
@@ -157,6 +159,7 @@ func (cmd SqlCmd) ArgParser() *argparser.ArgParser {
 	ap.SupportsFlag(continueFlag, "c", "Continue running queries on an error. Used for batch mode only.")
 	ap.SupportsString(fileInputFlag, "f", "input file", "Execute statements from the file given.")
 	ap.SupportsString(PrivsFilePathFlag, "", "privilege file", "Path to a file to load and store users and grants. Defaults to `$doltcfg-dir/privileges.db`. Will only be created if there is a change to privileges.")
+	ap.SupportsString(BranchCtrlPathFlag, "", "branch control file", "Path to a file to load and store branch control permissions. Defaults to `$doltcfg-dir/branch_control.db`. Will only be created if there is a change to branch control permissions.")
 	ap.SupportsString(UserFlag, "u", "user", fmt.Sprintf("Defines the local superuser (defaults to `%v`). If the specified user exists, will take on permissions of that user.", DefaultUser))
 	return ap
 }
@@ -256,6 +259,15 @@ func (cmd SqlCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 		}
 	}
 
+	// If no privilege filepath specified, default to doltcfg directory
+	branchControlFilePath, hasBCFilePath := apr.GetValue(BranchCtrlPathFlag)
+	if !hasBCFilePath {
+		branchControlFilePath, err = dEnv.FS.Abs(filepath.Join(cfgDirPath, DefaultBranchCtrlName))
+		if err != nil {
+			return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+		}
+	}
+
 	initialRoots, err := mrEnv.GetWorkingRoots(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
@@ -278,13 +290,14 @@ func (cmd SqlCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 	}
 
 	config := &engine.SqlEngineConfig{
-		InitialDb:      currentDb,
-		IsReadOnly:     false,
-		DoltCfgDirPath: cfgDirPath,
-		PrivFilePath:   privsFp,
-		ServerUser:     username,
-		ServerHost:     DefaultHost,
-		Autocommit:     true,
+		InitialDb:          currentDb,
+		IsReadOnly:         false,
+		DoltCfgDirPath:     cfgDirPath,
+		PrivFilePath:       privsFp,
+		BranchCtrlFilePath: branchControlFilePath,
+		ServerUser:         username,
+		ServerHost:         DefaultHost,
+		Autocommit:         true,
 	}
 
 	if query, queryOK := apr.GetValue(QueryFlag); queryOK {

--- a/go/cmd/dolt/commands/sqlserver/serverconfig.go
+++ b/go/cmd/dolt/commands/sqlserver/serverconfig.go
@@ -54,6 +54,7 @@ const (
 	defaultDataDir                 = "."
 	defaultCfgDir                  = ".doltcfg"
 	defaultPrivilegeFilePath       = "privileges.db"
+	defaultBranchControlFilePath   = "branch_control.db"
 	defaultMetricsHost             = ""
 	defaultMetricsPort             = -1
 	defaultAllowCleartextPasswords = false
@@ -136,6 +137,8 @@ type ServerConfig interface {
 	// PrivilegeFilePath returns the path to the file which contains all needed privilege information in the form of a
 	// JSON string.
 	PrivilegeFilePath() string
+	// BranchControlFilePath returns the path to the file which contains the branch control permissions.
+	BranchControlFilePath() string
 	// UserVars is an array containing user specific session variables
 	UserVars() []UserSessionVars
 	// JwksConfig is an array containing jwks config
@@ -179,6 +182,7 @@ type commandLineServerConfig struct {
 	requireSecureTransport  bool
 	persistenceBehavior     string
 	privilegeFilePath       string
+	branchControlFilePath   string
 	allowCleartextPasswords bool
 	socket                  string
 	remotesapiPort          *int
@@ -294,6 +298,11 @@ func (cfg *commandLineServerConfig) ClusterConfig() cluster.Config {
 // JSON string.
 func (cfg *commandLineServerConfig) PrivilegeFilePath() string {
 	return cfg.privilegeFilePath
+}
+
+// BranchControlFilePath returns the path to the file which contains the branch control permissions.
+func (cfg *commandLineServerConfig) BranchControlFilePath() string {
+	return cfg.branchControlFilePath
 }
 
 // UserVars is an array containing user specific session variables.
@@ -416,6 +425,12 @@ func (cfg *commandLineServerConfig) withPrivilegeFilePath(privFilePath string) *
 	return cfg
 }
 
+// withBranchControlFilePath updates the path to the file which contains the branch control permissions
+func (cfg *commandLineServerConfig) withBranchControlFilePath(branchControlFilePath string) *commandLineServerConfig {
+	cfg.branchControlFilePath = branchControlFilePath
+	return cfg
+}
+
 func (cfg *commandLineServerConfig) withAllowCleartextPasswords(allow bool) *commandLineServerConfig {
 	cfg.allowCleartextPasswords = allow
 	return cfg
@@ -458,6 +473,7 @@ func DefaultServerConfig() *commandLineServerConfig {
 		dataDir:                 defaultDataDir,
 		cfgDir:                  filepath.Join(defaultDataDir, defaultCfgDir),
 		privilegeFilePath:       filepath.Join(defaultDataDir, defaultCfgDir, defaultPrivilegeFilePath),
+		branchControlFilePath:   filepath.Join(defaultDataDir, defaultCfgDir, defaultBranchControlFilePath),
 		allowCleartextPasswords: defaultAllowCleartextPasswords,
 	}
 }

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -148,6 +148,7 @@ func (cmd SqlServerCmd) ArgParser() *argparser.ArgParser {
 	ap.SupportsInt(maxConnectionsFlag, "", "max-connections", fmt.Sprintf("Set the number of connections handled by the server. Defaults to `%d`.", serverConfig.MaxConnections()))
 	ap.SupportsString(persistenceBehaviorFlag, "", "persistence-behavior", fmt.Sprintf("Indicate whether to `load` or `ignore` persisted global variables. Defaults to `%s`.", serverConfig.PersistenceBehavior()))
 	ap.SupportsString(commands.PrivsFilePathFlag, "", "privilege file", "Path to a file to load and store users and grants. Defaults to `$doltcfg-dir/privileges.db`. Will only be created if there is a change to privileges.")
+	ap.SupportsString(commands.BranchCtrlPathFlag, "", "branch control file", "Path to a file to load and store branch control permissions. Defaults to `$doltcfg-dir/branch_control.db`. Will only be created if there is a change to branch control permissions.")
 	ap.SupportsString(allowCleartextPasswordsFlag, "", "allow-cleartext-passwords", "Allows use of cleartext passwords. Defaults to false.")
 	ap.SupportsOptionalString(socketFlag, "", "socket file", "Path for the unix socket file. Defaults to '/tmp/mysql.sock'.")
 	ap.SupportsUint(remotesapiPortFlag, "", "remotesapi port", "Sets the port for a server which can expose the databases in this sql-server over remotesapi.")
@@ -325,6 +326,16 @@ func SetupDoltConfig(dEnv *env.DoltEnv, apr *argparser.ArgParseResults, config S
 			return err
 		}
 		serverConfig.withPrivilegeFilePath(path)
+	}
+
+	if branchControlFilePath, ok := apr.GetValue(commands.BranchCtrlPathFlag); ok {
+		serverConfig.withBranchControlFilePath(branchControlFilePath)
+	} else {
+		path, err := dEnv.FS.Abs(filepath.Join(cfgDirPath, commands.DefaultBranchCtrlName))
+		if err != nil {
+			return err
+		}
+		serverConfig.withBranchControlFilePath(path)
 	}
 
 	return nil

--- a/go/cmd/dolt/commands/sqlserver/yaml_config.go
+++ b/go/cmd/dolt/commands/sqlserver/yaml_config.go
@@ -178,7 +178,7 @@ func serverConfigAsYAMLConfig(cfg ServerConfig) YAMLConfig {
 			nillableBoolPtr(cfg.AllowCleartextPasswords()),
 			nillableStrPtr(cfg.Socket()),
 		},
-		DatabaseConfig:    nil,
+		DatabaseConfig: nil,
 	}
 }
 

--- a/go/cmd/dolt/commands/sqlserver/yaml_config.go
+++ b/go/cmd/dolt/commands/sqlserver/yaml_config.go
@@ -141,6 +141,7 @@ type YAMLConfig struct {
 	RemotesapiConfig  RemotesapiYAMLConfig  `yaml:"remotesapi"`
 	ClusterCfg        *ClusterYAMLConfig    `yaml:"cluster"`
 	PrivilegeFile     *string               `yaml:"privilege_file"`
+	BranchControlFile *string               `yaml:"branch_control_file"`
 	Vars              []UserSessionVars     `yaml:"user_session_vars"`
 	Jwks              []engine.JwksConfig   `yaml:"jwks"`
 	GoldenMysqlConn   *string               `yaml:"golden_mysql_conn"`
@@ -177,7 +178,7 @@ func serverConfigAsYAMLConfig(cfg ServerConfig) YAMLConfig {
 			nillableBoolPtr(cfg.AllowCleartextPasswords()),
 			nillableStrPtr(cfg.Socket()),
 		},
-		DatabaseConfig: nil,
+		DatabaseConfig:    nil,
 	}
 }
 
@@ -358,6 +359,14 @@ func (cfg YAMLConfig) PrivilegeFilePath() string {
 		return *cfg.PrivilegeFile
 	}
 	return filepath.Join(cfg.CfgDir(), defaultPrivilegeFilePath)
+}
+
+// BranchControlFilePath returns the path to the file which contains the branch control permissions.
+func (cfg YAMLConfig) BranchControlFilePath() string {
+	if cfg.BranchControlFile != nil {
+		return *cfg.BranchControlFile
+	}
+	return filepath.Join(cfg.CfgDir(), defaultBranchControlFilePath)
 }
 
 // UserVars is an array containing user specific session variables

--- a/go/libraries/doltcore/branch_control/access.go
+++ b/go/libraries/doltcore/branch_control/access.go
@@ -15,6 +15,9 @@
 package branch_control
 
 import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
 	"sync"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -26,6 +29,10 @@ type Permissions uint64
 const (
 	Permissions_Admin Permissions = 1 << iota // Permissions_Admin grants unrestricted control over a branch, including modification of table entries
 	Permissions_Write                         // Permissions_Write allows for all modifying operations on a branch, but does not allow modification of table entries
+)
+
+const (
+	currentAccessVersion = uint16(1)
 )
 
 // Access contains all of the expressions that comprise the "dolt_branch_control" table, which handles write Access to
@@ -53,6 +60,7 @@ type AccessValue struct {
 // newAccess returns a new Access.
 func newAccess(superUser string, superHost string) *Access {
 	return &Access{
+		binlog:    NewAccessBinlog(nil),
 		Branches:  nil,
 		Users:     nil,
 		Hosts:     nil,
@@ -66,6 +74,10 @@ func newAccess(superUser string, superHost string) *Access {
 // Match returns whether any entries match the given branch, user, and host, along with their permissions. Requires
 // external synchronization handling, therefore manually manage the RWMutex.
 func (tbl *Access) Match(branch string, user string, host string) (bool, Permissions) {
+	if tbl.SuperUser == user && tbl.SuperHost == host {
+		return true, Permissions_Admin
+	}
+
 	filteredIndexes := Match(tbl.Users, user, sql.Collation_utf8mb4_0900_bin)
 
 	filteredHosts := tbl.filterHosts(filteredIndexes)
@@ -93,6 +105,64 @@ func (tbl *Access) GetIndex(branchExpr string, userExpr string, hostExpr string)
 		}
 	}
 	return -1
+}
+
+// Serialize writes the table to the given buffer. All encoded integers are big-endian.
+func (tbl *Access) Serialize(buffer *bytes.Buffer) {
+	tbl.RWMutex.RLock()
+	defer tbl.RWMutex.RUnlock()
+
+	// Write the version bytes
+	writeUint16(buffer, currentAccessVersion)
+	// Write the number of entries
+	numOfEntries := uint32(len(tbl.Values))
+	writeUint32(buffer, numOfEntries)
+
+	// Write the rows
+	for _, matchExpr := range tbl.Branches {
+		matchExpr.Serialize(buffer)
+	}
+	for _, matchExpr := range tbl.Users {
+		matchExpr.Serialize(buffer)
+	}
+	for _, matchExpr := range tbl.Hosts {
+		matchExpr.Serialize(buffer)
+	}
+	for _, val := range tbl.Values {
+		val.Serialize(buffer)
+	}
+	// Write the binlog
+	_ = tbl.binlog.Serialize(buffer)
+}
+
+// Deserialize populates the table with the given data. Returns an error if the data cannot be deserialized, or if the
+// table has already been written to. Deserialize must be called on an empty table.
+func (tbl *Access) Deserialize(data []byte, position *uint64) error {
+	tbl.RWMutex.Lock()
+	defer tbl.RWMutex.Unlock()
+
+	if len(tbl.Values) != 0 {
+		return fmt.Errorf("cannot deserialize to a non-empty access table")
+	}
+	// Read the version
+	version := binary.BigEndian.Uint16(data[*position:])
+	*position += 2
+	if version != currentAccessVersion {
+		// If we ever increment the access version, this will instead handle the conversion from previous versions
+		return fmt.Errorf(`cannot deserialize an access table with version "%d"`, version)
+	}
+	// Read the number of entries
+	numOfEntries := binary.BigEndian.Uint32(data[*position:])
+	*position += 4
+	// Read the rows
+	tbl.Branches = deserializeMatchExpressions(numOfEntries, data, position)
+	tbl.Users = deserializeMatchExpressions(numOfEntries, data, position)
+	tbl.Hosts = deserializeMatchExpressions(numOfEntries, data, position)
+	tbl.Values = make([]AccessValue, numOfEntries)
+	for i := uint32(0); i < numOfEntries; i++ {
+		tbl.Values[i] = deserializeAccessValue(data, position)
+	}
+	return tbl.binlog.Deserialize(data, position)
 }
 
 // filterBranches returns all branches that match the given collection indexes.
@@ -138,4 +208,47 @@ func (tbl *Access) gatherPermissions(collectionIndexes []uint32) Permissions {
 		perms |= tbl.Values[collectionIndex].Permissions
 	}
 	return perms
+}
+
+// Serialize writes the value to the given buffer. All encoded integers are big-endian.
+func (val *AccessValue) Serialize(buffer *bytes.Buffer) {
+	// Write the branch
+	branchLen := uint16(len(val.Branch))
+	writeUint16(buffer, branchLen)
+	buffer.WriteString(val.Branch)
+	// Write the user
+	userLen := uint16(len(val.User))
+	writeUint16(buffer, userLen)
+	buffer.WriteString(val.User)
+	// Write the host
+	hostLen := uint16(len(val.Host))
+	writeUint16(buffer, hostLen)
+	buffer.WriteString(val.Host)
+	// Write the permissions
+	writeUint64(buffer, uint64(val.Permissions))
+}
+
+// deserializeAccessValue returns a AccessValue from the data at the given position. Assumes that the given data's
+// encoded integers are big-endian.
+func deserializeAccessValue(data []byte, position *uint64) AccessValue {
+	val := AccessValue{}
+	// Read the branch
+	branchLen := uint64(binary.BigEndian.Uint16(data[*position:]))
+	*position += 2
+	val.Branch = string(data[*position : *position+branchLen])
+	*position += branchLen
+	// Read the user
+	userLen := uint64(binary.BigEndian.Uint16(data[*position:]))
+	*position += 2
+	val.User = string(data[*position : *position+userLen])
+	*position += userLen
+	// Read the host
+	hostLen := uint64(binary.BigEndian.Uint16(data[*position:]))
+	*position += 2
+	val.Host = string(data[*position : *position+hostLen])
+	*position += hostLen
+	// Read the permissions
+	val.Permissions = Permissions(binary.BigEndian.Uint64(data[*position:]))
+	*position += 8
+	return val
 }

--- a/go/libraries/doltcore/sqle/dtables/binlog_table.go
+++ b/go/libraries/doltcore/sqle/dtables/binlog_table.go
@@ -1,0 +1,184 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dtables
+
+import (
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/vitess/go/sqltypes"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/index"
+)
+
+const (
+	AccessBinlogTableName    = AccessTableName + "_binlog"
+	NamespaceBinlogTableName = NamespaceTableName + "_binlog"
+)
+
+// accessBinlogSchema is the schema for the "dolt_branch_control_binlog" table.
+var accessBinlogSchema = sql.Schema{
+	&sql.Column{
+		Name:       "index",
+		Type:       sql.Int64,
+		Source:     AccessBinlogTableName,
+		PrimaryKey: true,
+	},
+	&sql.Column{
+		Name:       "operation",
+		Type:       sql.MustCreateEnumType([]string{"insert", "delete"}, sql.Collation_utf8mb4_0900_bin),
+		Source:     AccessBinlogTableName,
+		PrimaryKey: false,
+	},
+	&sql.Column{
+		Name:       "branch",
+		Type:       sql.MustCreateString(sqltypes.VarChar, 16383, sql.Collation_utf8mb4_0900_ai_ci),
+		Source:     AccessBinlogTableName,
+		PrimaryKey: false,
+	},
+	&sql.Column{
+		Name:       "user",
+		Type:       sql.MustCreateString(sqltypes.VarChar, 16383, sql.Collation_utf8mb4_0900_bin),
+		Source:     AccessBinlogTableName,
+		PrimaryKey: false,
+	},
+	&sql.Column{
+		Name:       "host",
+		Type:       sql.MustCreateString(sqltypes.VarChar, 16383, sql.Collation_utf8mb4_0900_ai_ci),
+		Source:     AccessBinlogTableName,
+		PrimaryKey: false,
+	},
+	&sql.Column{
+		Name:       "permissions",
+		Type:       sql.MustCreateSetType(PermissionsStrings, sql.Collation_utf8mb4_0900_ai_ci),
+		Source:     AccessBinlogTableName,
+		PrimaryKey: false,
+	},
+}
+
+// namespaceBinlogSchema is the schema for the "dolt_branch_namespace_control_binlog" table.
+var namespaceBinlogSchema = sql.Schema{
+	&sql.Column{
+		Name:       "index",
+		Type:       sql.Int64,
+		Source:     NamespaceBinlogTableName,
+		PrimaryKey: true,
+	},
+	&sql.Column{
+		Name:       "operation",
+		Type:       sql.MustCreateEnumType([]string{"insert", "delete"}, sql.Collation_utf8mb4_0900_bin),
+		Source:     NamespaceBinlogTableName,
+		PrimaryKey: false,
+	},
+	&sql.Column{
+		Name:       "branch",
+		Type:       sql.MustCreateString(sqltypes.VarChar, 16383, sql.Collation_utf8mb4_0900_ai_ci),
+		Source:     NamespaceBinlogTableName,
+		PrimaryKey: false,
+	},
+	&sql.Column{
+		Name:       "user",
+		Type:       sql.MustCreateString(sqltypes.VarChar, 16383, sql.Collation_utf8mb4_0900_bin),
+		Source:     NamespaceBinlogTableName,
+		PrimaryKey: false,
+	},
+	&sql.Column{
+		Name:       "host",
+		Type:       sql.MustCreateString(sqltypes.VarChar, 16383, sql.Collation_utf8mb4_0900_ai_ci),
+		Source:     NamespaceBinlogTableName,
+		PrimaryKey: false,
+	},
+}
+
+// BinlogTable provides a queryable view over the Binlog.
+type BinlogTable struct {
+	Log      *branch_control.Binlog
+	IsAccess bool
+}
+
+var _ sql.Table = BinlogTable{}
+
+// Name implements the interface sql.Table.
+func (b BinlogTable) Name() string {
+	if b.IsAccess {
+		return AccessBinlogTableName
+	} else {
+		return NamespaceBinlogTableName
+	}
+}
+
+// String implements the interface sql.Table.
+func (b BinlogTable) String() string {
+	if b.IsAccess {
+		return AccessBinlogTableName
+	} else {
+		return NamespaceBinlogTableName
+	}
+}
+
+// Schema implements the interface sql.Table.
+func (b BinlogTable) Schema() sql.Schema {
+	if b.IsAccess {
+		return accessBinlogSchema
+	} else {
+		return namespaceBinlogSchema
+	}
+}
+
+// Collation implements the interface sql.Table.
+func (b BinlogTable) Collation() sql.CollationID {
+	return sql.Collation_Default
+}
+
+// Partitions implements the interface sql.Table.
+func (b BinlogTable) Partitions(context *sql.Context) (sql.PartitionIter, error) {
+	return index.SinglePartitionIterFromNomsMap(nil), nil
+}
+
+// PartitionRows implements the interface sql.Table.
+func (b BinlogTable) PartitionRows(context *sql.Context, partition sql.Partition) (sql.RowIter, error) {
+	b.Log.RWMutex.RLock()
+	defer b.Log.RWMutex.RUnlock()
+
+	binlogRows := b.Log.Rows()
+	rows := make([]sql.Row, len(binlogRows))
+	for i := 0; i < len(binlogRows); i++ {
+		logRow := binlogRows[i]
+		operation := uint16(1)
+		if !logRow.IsInsert {
+			operation = 2
+		}
+
+		if b.IsAccess {
+			rows[i] = sql.Row{
+				int64(i),
+				operation,
+				logRow.Branch,
+				logRow.User,
+				logRow.Host,
+				logRow.Permissions,
+			}
+		} else {
+			rows[i] = sql.Row{
+				int64(i),
+				operation,
+				logRow.Branch,
+				logRow.User,
+				logRow.Host,
+			}
+		}
+	}
+	return sql.RowsToRowIter(rows...), nil
+}

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -778,6 +778,9 @@ func (t *WritableDoltTable) Updater(ctx *sql.Context) sql.RowUpdater {
 
 // AutoIncrementSetter implements sql.AutoIncrementTable
 func (t *WritableDoltTable) AutoIncrementSetter(ctx *sql.Context) sql.AutoIncrementSetter {
+	if err := branch_control.CheckAccess(ctx, branch_control.Permissions_Write); err != nil {
+		return sqlutil.NewStaticErrorEditor(err)
+	}
 	te, err := t.getTableEditor(ctx)
 	if err != nil {
 		return sqlutil.NewStaticErrorEditor(err)


### PR DESCRIPTION
This fixes a few issues found through testing, and also adds persistence for the tables. Also re-added the `binlog_table.go` file. I originally removed it, but misread the feedback that said to not expose it rather than to remove it.