### PR TITLE
Add Docker Image support for `linux/arm64`

### DIFF
--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -38,14 +38,15 @@ jobs:
           FILE: ${{ format('{0}/go/cmd/dolt/dolt.go', github.workspace) }}
           NEW_VERSION: ${{ needs.format-version.outputs.version }}
       - name: Update Dockerfile
-        run: sed -i -e 's/ARG DOLT_VERSION=.*/ARG DOLT_VERSION='"$NEW_VERSION"'/' "$FILE"
+        run: sed -i -e 's/ARG DOLT_VERSION=.*/ARG DOLT_VERSION='"$NEW_VERSION"'/' "$AMD64" "$ARM64"
         env:
-          FILE: ${{ format('{0}/docker/Dockerfile', github.workspace) }}
+          AMD64: ${{ format('{0}/docker/Dockerfile', github.workspace) }}
+          ARM64: ${{ format('{0}/docker/Dockerfile.arm64', github.workspace) }}
           NEW_VERSION: ${{ needs.format-version.outputs.version }}
       - uses: EndBug/add-and-commit@v7
         with:
           message: ${{ format('[ga-bump-release] Update Dolt version to {0} and release v{0}', needs.format-version.outputs.version) }}
-          add: ${{ format('[{0}/go/cmd/dolt/dolt.go, {0}/docker/Dockerfile]', github.workspace) }}
+          add: ${{ format('[{0}/go/cmd/dolt/dolt.go,{0}/docker/Dockerfile,{0}/docker/Dockerfile.arm64]', github.workspace) }}
           cwd: "."
       - name: Build Binaries
         id: build_binaries

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,4 +8,4 @@ RUN tar zxvf dolt-linux-amd64.tar.gz && \
     cp dolt-linux-amd64/bin/dolt /usr/local/bin && \
     rm -rf dolt-linux-amd64 dolt-linux-amd64.tar.gz
 
-CMD ["/usr/local/bin/dolt"]
+ENTRYPOINT ["/usr/local/bin/dolt"]

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -9,4 +9,4 @@ RUN tar zxvf dolt-linux-arm64.tar.gz && \
     cp dolt-linux-arm64/bin/dolt /usr/local/bin && \
     rm -rf dolt-linux-arm64 dolt-linux-arm64.tar.gz
 
-CMD ["/usr/local/bin/dolt"]
+ENTRYPOINT ["/usr/local/bin/dolt"]

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -1,0 +1,12 @@
+# syntax=docker/dockerfile:1.3-labs
+FROM --platform=linux/arm64 ubuntu:22.04
+COPY docker/qemu-aarch64-static /usr/bin/
+
+ARG DOLT_VERSION=0.50.5
+
+ADD https://github.com/dolthub/dolt/releases/download/v${DOLT_VERSION}/dolt-linux-arm64.tar.gz dolt-linux-arm64.tar.gz
+RUN tar zxvf dolt-linux-arm64.tar.gz && \
+    cp dolt-linux-arm64/bin/dolt /usr/local/bin && \
+    rm -rf dolt-linux-arm64 dolt-linux-arm64.tar.gz
+
+CMD ["/usr/local/bin/dolt"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,36 @@
+## Docker
+The method to create multiple architecture images for a single tag pushed to DockerHub is
+taken from `https://github.com/cgiraldo/docker-hello-multiarch`.
+
+We created multiple Dockerfiles for creating Docker Image of Dolt for different architectures.
+- `Dockerfile` without extension is for 'linux/amd64'
+- `Dockerfile.arm64` is for 'linux/arm64'
+- No Windows architecture is supported yet.
+
+If new Dockerfile is added to support different OS/architecture, make sure to add appropriate jobs
+in `.github/workflows/cd-release.yaml` that updates DOLT_VERSION for the Dockerfile.
+
+The directory `hooks` here include script file that help us create images for different architectures on x86_64 machine.
+The Docker documentation on hooks, `https://docs.docker.com/docker-hub/builds/advanced/#custom-build-phase-hooks`
+
+`hooks/post_checkout` installs appropriate version of QEMU tool, `multiarch/qemu-user-static`, which is used
+to enable an execution of different multi-architecture containers
+
+`hooks/pre_build` prepares the binary for running shell scripts on specific architecture. It's required for any
+OS/architecture except for x86_64.
+
+`hooks/post_push` uses two separate Docker Images for `linux/amd64` and `linux/arm64` to combine them in a single tag
+using `docker manifest` command which is 'experimental'. This requires 'experimental' config variable to be set
+to 'enabled'.
+
+IMPORTANT:
+Currently, we need to set up automated build for each of Dockerfiles for both `latest` and `<release_version>` tags.
+For example, we support `linux/amd64` and `linux/arm64`, so we need build for tags,
+`latest-amd64`,
+`latest-arm64`,
+`0.50.4-amd64`,
+`0.50.4-arm64`,
+if the current release version is '0.50.4'.
+
+-- `COPY docker/qemu-aarch64-static /usr/bin/` is required for building (non x86 architecture image) in x86 host 
+before any RUN commands.

--- a/docker/hooks/post_checkout
+++ b/docker/hooks/post_checkout
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Get architecture from Dockerfile.arch filename
+BUILD_ARCH=$(echo "${DOCKERFILE_PATH}" | cut -d '.' -f 2)
+
+echo "BUILD ARCH IS : ${BUILD_ARCH}"
+# For amd64 filename is Dockerfile (DOCKERFILE_PATH)
+[ "${BUILD_ARCH}" == "docker/Dockerfile" ] && \
+    { echo 'qemu-user-static: Download not required for current arch'; exit 0; }
+
+case ${BUILD_ARCH} in
+    amd64 ) QEMU_ARCH="x86_64" ;;
+    arm64 ) QEMU_ARCH="aarch64" ;
+ esac
+
+echo "QEMU ARCH IS : ${QEMU_ARCH}"
+
+QEMU_USER_STATIC_DOWNLOAD_URL="https://github.com/multiarch/qemu-user-static/releases/download"
+QEMU_USER_STATIC_LATEST_TAG=$(curl -s https://api.github.com/repos/multiarch/qemu-user-static/tags \
+    | grep 'name.*v[0-9]' \
+    | head -n 1 \
+    | cut -d '"' -f 4)
+
+curl -SL "${QEMU_USER_STATIC_DOWNLOAD_URL}/${QEMU_USER_STATIC_LATEST_TAG}/x86_64_qemu-${QEMU_ARCH}-static.tar.gz" \
+    | tar xzv

--- a/docker/hooks/post_checkout
+++ b/docker/hooks/post_checkout
@@ -3,8 +3,7 @@
 # Get architecture from Dockerfile.arch filename
 BUILD_ARCH=$(echo "${DOCKERFILE_PATH}" | cut -d '.' -f 2)
 
-echo "BUILD ARCH IS : ${BUILD_ARCH}"
-# For amd64 filename is Dockerfile (DOCKERFILE_PATH)
+# For amd64 filename is Dockerfile (DOCKERFILE_PATH is 'docker/Dockerfile')
 [ "${BUILD_ARCH}" == "docker/Dockerfile" ] && \
     { echo 'qemu-user-static: Download not required for current arch'; exit 0; }
 
@@ -13,8 +12,7 @@ case ${BUILD_ARCH} in
     arm64 ) QEMU_ARCH="aarch64" ;
  esac
 
-echo "QEMU ARCH IS : ${QEMU_ARCH}"
-
+echo "QEMU architecture for '${BUILD_ARCH}' architecture is '${QEMU_ARCH}'"
 QEMU_USER_STATIC_DOWNLOAD_URL="https://github.com/multiarch/qemu-user-static/releases/download"
 QEMU_USER_STATIC_LATEST_TAG=$(curl -s https://api.github.com/repos/multiarch/qemu-user-static/tags \
     | grep 'name.*v[0-9]' \

--- a/docker/hooks/post_push
+++ b/docker/hooks/post_push
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Use docker cli v20.10.9 to use experimental manifest feature
+curl -SL "https://download.docker.com/linux/static/stable/x86_64/docker-20.10.9.tgz" | tar xzv docker/docker --transform='s/.*/docker-cli/'
+mkdir ~/.docker
+# Add auths and experimental to docker-cli config
+echo '{"auths": '$DOCKERCFG',"experimental":"enabled"}' > ~/.docker/config.json
+# Check if all arch images are in dockerhub
+VIRTUAL_IMAGE=$(echo "${IMAGE_NAME}" | rev | cut -d- -f2- | rev )
+
+AMD64_IMAGE="$VIRTUAL_IMAGE-amd64"
+ARM64_IMAGE="$VIRTUAL_IMAGE-arm64"
+
+echo "checking if ${AMD64_IMAGE} Manifest exists"
+if ! ./docker-cli manifest inspect ${AMD64_IMAGE}; then AMD64_IMAGE='' ; fi
+echo "checking if ${ARM64_IMAGE} Manifest exists"
+if ! ./docker-cli manifest inspect ${ARM64_IMAGE}; then ARM64_IMAGE='' ; fi
+
+echo "Creating multiarch manifest"
+./docker-cli manifest create $VIRTUAL_IMAGE $AMD64_IMAGE $ARM64_IMAGE
+if [ -n "${ARM64_IMAGE}" ]; then
+./docker-cli manifest annotate $VIRTUAL_IMAGE $ARM64_IMAGE --os linux --arch arm64
+fi
+./docker-cli manifest push $VIRTUAL_IMAGE
+
+rm -r docker-cli ~/.docker

--- a/docker/hooks/pre_build
+++ b/docker/hooks/pre_build
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+BUILD_ARCH=$(echo "${DOCKERFILE_PATH}" | cut -d '.' -f 2)
+
+[ "${BUILD_ARCH}" == "docker/Dockerfile" ] && \
+    { echo 'qemu-user-static: Registration not required for current arch'; exit 0; }
+
+docker run --rm --privileged multiarch/qemu-user-static:register --reset

--- a/docker/hooks/pre_build
+++ b/docker/hooks/pre_build
@@ -2,6 +2,7 @@
 
 BUILD_ARCH=$(echo "${DOCKERFILE_PATH}" | cut -d '.' -f 2)
 
+# For amd64 filename is Dockerfile (DOCKERFILE_PATH is 'docker/Dockerfile')
 [ "${BUILD_ARCH}" == "docker/Dockerfile" ] && \
     { echo 'qemu-user-static: Registration not required for current arch'; exit 0; }
 


### PR DESCRIPTION
Added Docker Image for `linux/arm64` addition to `linux/amd64` architecture. Each will be pushed to DockerHub as separate tags, but both image will be available for `latest` or `<release_version>` tags.