### PR TITLE
Fix panic when merging tables that have a check constraint with some string literal

### DIFF
--- a/go/libraries/doltcore/merge/merge_rows.go
+++ b/go/libraries/doltcore/merge/merge_rows.go
@@ -120,7 +120,7 @@ func (rm *RootMerger) MergeTable(ctx context.Context, tblName string, opts edito
 		return nil, nil, errors.New(fmt.Sprintf("schema changes not supported: %s table schema does not match in current HEAD and cherry-pick commit.", tblName))
 	}
 
-	mergeSch, schConflicts, err := SchemaMerge(tm.vrw.Format(), tm.leftSch, tm.rightSch, tm.ancSch, tblName)
+	mergeSch, schConflicts, err := SchemaMerge(ctx, tm.vrw.Format(), tm.leftSch, tm.rightSch, tm.ancSch, tblName)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/libraries/doltcore/merge/merge_schema.go
+++ b/go/libraries/doltcore/merge/merge_schema.go
@@ -121,7 +121,7 @@ func (c ChkConflict) String() string {
 var ErrMergeWithDifferentPkSets = errors.New("error: cannot merge two tables with different primary key sets")
 
 // SchemaMerge performs a three-way merge of ourSch, theirSch, and ancSch.
-func SchemaMerge(format *types.NomsBinFormat, ourSch, theirSch, ancSch schema.Schema, tblName string) (sch schema.Schema, sc SchemaConflict, err error) {
+func SchemaMerge(ctx context.Context, format *types.NomsBinFormat, ourSch, theirSch, ancSch schema.Schema, tblName string) (sch schema.Schema, sc SchemaConflict, err error) {
 	// (sch - ancSch) ∪ (mergeSch - ancSch) ∪ (sch ∩ mergeSch)
 	sc = SchemaConflict{
 		TableName: tblName,
@@ -166,7 +166,7 @@ func SchemaMerge(format *types.NomsBinFormat, ourSch, theirSch, ancSch schema.Sc
 
 	// Merge checks
 	var mergedChks []schema.Check
-	mergedChks, sc.ChkConflicts, err = mergeChecks(ourSch.Checks(), theirSch.Checks(), ancSch.Checks())
+	mergedChks, sc.ChkConflicts, err = mergeChecks(ctx, ourSch.Checks(), theirSch.Checks(), ancSch.Checks())
 	if err != nil {
 		return nil, EmptySchConflicts, err
 	}
@@ -763,7 +763,7 @@ func chkCollectionModified(anc, child []schema.Check) []schema.Check {
 }
 
 // mergeChecks attempts to combine ourChks, theirChks, and ancChks into a single collection, or gathers the conflicts
-func mergeChecks(ourChks, theirChks, ancChks schema.CheckCollection) ([]schema.Check, []ChkConflict, error) {
+func mergeChecks(ctx context.Context, ourChks, theirChks, ancChks schema.CheckCollection) ([]schema.Check, []ChkConflict, error) {
 	// Handles modifications
 	common, conflicts := checksInCommon(ourChks.AllChecks(), theirChks.AllChecks(), ancChks.AllChecks())
 
@@ -804,7 +804,7 @@ func mergeChecks(ourChks, theirChks, ancChks schema.CheckCollection) ([]schema.C
 			CheckExpression: chk.Expression(),
 			Enforced:        chk.Enforced(),
 		}
-		colNames, err := sqle.ColumnsFromCheckDefinition(sql.NewEmptyContext(), &chkDef)
+		colNames, err := sqle.ColumnsFromCheckDefinition(sql.NewContext(ctx), &chkDef)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -826,7 +826,7 @@ func mergeChecks(ourChks, theirChks, ancChks schema.CheckCollection) ([]schema.C
 			CheckExpression: ourChk.Expression(),
 			Enforced:        ourChk.Enforced(),
 		}
-		colNames, err := sqle.ColumnsFromCheckDefinition(sql.NewEmptyContext(), &chkDef)
+		colNames, err := sqle.ColumnsFromCheckDefinition(sql.NewContext(ctx), &chkDef)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/go/libraries/doltcore/merge/merge_schema.go
+++ b/go/libraries/doltcore/merge/merge_schema.go
@@ -804,7 +804,7 @@ func mergeChecks(ourChks, theirChks, ancChks schema.CheckCollection) ([]schema.C
 			CheckExpression: chk.Expression(),
 			Enforced:        chk.Enforced(),
 		}
-		colNames, err := sqle.ColumnsFromCheckDefinition(nil, &chkDef)
+		colNames, err := sqle.ColumnsFromCheckDefinition(sql.NewEmptyContext(), &chkDef)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -826,7 +826,7 @@ func mergeChecks(ourChks, theirChks, ancChks schema.CheckCollection) ([]schema.C
 			CheckExpression: ourChk.Expression(),
 			Enforced:        ourChk.Enforced(),
 		}
-		colNames, err := sqle.ColumnsFromCheckDefinition(nil, &chkDef)
+		colNames, err := sqle.ColumnsFromCheckDefinition(sql.NewEmptyContext(), &chkDef)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/go/libraries/doltcore/merge/schema_integration_test.go
+++ b/go/libraries/doltcore/merge/schema_integration_test.go
@@ -612,7 +612,7 @@ func testMergeSchemasWithConflicts(t *testing.T, test mergeSchemaConflictTest) {
 
 	otherSch := getSchema(t, dEnv)
 
-	_, actConflicts, err := merge.SchemaMerge(types.Format_Default, mainSch, otherSch, ancSch, "test")
+	_, actConflicts, err := merge.SchemaMerge(context.Background(), types.Format_Default, mainSch, otherSch, ancSch, "test")
 	if test.expectedErr != nil {
 		assert.True(t, errors.Is(err, test.expectedErr))
 		return

--- a/integration-tests/bats/schema-changes.bats
+++ b/integration-tests/bats/schema-changes.bats
@@ -374,3 +374,24 @@ EOF
     
     [[ "$output" =~ "$EXPECTED" ]] || false
 }
+
+# We passed nil where a sql ctx was expected in merge. When we added collations,
+# the sql ctx became required and merge started to panic.
+@test "schema-changes: regression test for merging check constraints with TEXT type panicking due to a nil sql ctx" {
+    dolt sql -q "create table t (pk int primary key, col1 text);"
+    dolt commit -Am "initial"
+    dolt branch right
+    dolt sql -q "insert into t values (1, 'valid');"
+    dolt commit -am "row"
+
+    dolt checkout right
+    dolt sql -q "alter table t add constraint col1_check CHECK (col1 = 'valid');"
+    dolt commit -am "add check"
+
+    dolt checkout main
+    dolt merge -m "merge" right
+
+    run dolt sql -q "show create table t;"
+    [ $status -eq 0 ]
+    [[ $output =~ "CHECK (col1 = 'valid')" ]]
+}

--- a/integration-tests/bats/schema-changes.bats
+++ b/integration-tests/bats/schema-changes.bats
@@ -393,5 +393,5 @@ EOF
 
     run dolt sql -q "show create table t;"
     [ $status -eq 0 ]
-    [[ $output =~ "CHECK (col1 = 'valid')" ]]
+    [[ $output =~ "CHECK ((\`col1\` = 'valid'))" ]] || false
 }


### PR DESCRIPTION
This PR fixes a panic that occurs when merging tables that define a check constraint using some string literal. The panic's stacktrace is:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x10 pc=0x10193c7f8]

goroutine 1 [running]:
github.com/dolthub/go-mysql-server/sql/parse.convertVal(0x0?, 0x14000e80520)
	/Users/dhruv/go/pkg/mod/github.com/dolthub/go-mysql-server@v0.12.1-0.20221018190947-3e6ea0fb9c2b/sql/parse/parse.go:3392 +0x658
github.com/dolthub/go-mysql-server/sql/parse.ExprToExpression(0x0, {0x10282ae00?, 0x14000e80520?})
	/Users/dhruv/go/pkg/mod/github.com/dolthub/go-mysql-server@v0.12.1-0.20221018190947-3e6ea0fb9c2b/sql/parse/parse.go:3100 +0x1ee4
github.com/dolthub/go-mysql-server/sql/parse.comparisonExprToExpression(0x10281e901?, 0x14000e86c80)
	/Users/dhruv/go/pkg/mod/github.com/dolthub/go-mysql-server@v0.12.1-0.20221018190947-3e6ea0fb9c2b/sql/parse/parse.go:3491 +0x54
github.com/dolthub/go-mysql-server/sql/parse.ExprToExpression(0x0, {0x10282ab00?, 0x14000e86c80?})
	/Users/dhruv/go/pkg/mod/github.com/dolthub/go-mysql-server@v0.12.1-0.20221018190947-3e6ea0fb9c2b/sql/parse/parse.go:3089 +0x1cb8
github.com/dolthub/go-mysql-server/sql/parse.ExprToExpression(0x0, {0x10282ada0?, 0x14000200e70?})
	/Users/dhruv/go/pkg/mod/github.com/dolthub/go-mysql-server@v0.12.1-0.20221018190947-3e6ea0fb9c2b/sql/parse/parse.go:3164 +0x1594
github.com/dolthub/go-mysql-server/sql/analyzer.ConvertCheckDefToConstraint(0x14000cbdf88?, 0x14000cbe288)
	/Users/dhruv/go/pkg/mod/github.com/dolthub/go-mysql-server@v0.12.1-0.20221018190947-3e6ea0fb9c2b/sql/analyzer/check_constraints.go:317 +0xc4
github.com/dolthub/go-mysql-server.ColumnsFromCheckDefinition(0x10250f760?, 0x14000cbe3d0?)
	/Users/dhruv/go/pkg/mod/github.com/dolthub/go-mysql-server@v0.12.1-0.20221018190947-3e6ea0fb9c2b/engine.go:583 +0x1c
github.com/dolthub/dolt/go/libraries/doltcore/merge.mergeChecks({0x102833588, 0x14000666e70}, {0x102833588, 0x14000667020}, {0x102833588, 0x14000667080})
	/Users/dhruv/dolt/go/libraries/doltcore/merge/merge_schema.go:807 +0x31c
github.com/dolthub/dolt/go/libraries/doltcore/merge.SchemaMerge(0x1036fac40?, {0x10284f700, 0x1400065d920}, {0x10284f700, 0x1400065dc20}, {0x10284f700, 0x1400065dd40}, {0x1036fac40, 0x1})
	/Users/dhruv/dolt/go/libraries/doltcore/merge/merge_schema.go:169 +0x5e0
github.com/dolthub/dolt/go/libraries/doltcore/merge.(*RootMerger).MergeTable(0x14000cbf0e0, {0x1028344d8, 0x14000e863c0}, {0x1036fac40, 0x1}, {0x0, {0x102824888, 0x140006611a0}, {0x1400066c6c0, 0x2c}}, ...)
	/Users/dhruv/dolt/go/libraries/doltcore/merge/merge_rows.go:123 +0x1ec
github.com/dolthub/dolt/go/libraries/doltcore/merge.MergeRoots({0x1028344d8, 0x14000e863c0}, 0x1400067f1d0, 0x1400067f220, 0x1400067f3b0, {0x102824130, 0x14000e86500}, {0x102824130, 0x14000e86980}, {0x0, ...}, ...)
	/Users/dhruv/dolt/go/libraries/doltcore/merge/merge.go:131 +0x62c
github.com/dolthub/dolt/go/libraries/doltcore/merge.MergeCommits({0x1028344d8, 0x14000e863c0}, 0x14000cbf3a8?, 0xb9ce7a80f36fd6ca?, {0x0, {0x102824888, 0x140006611a0}, {0x1400066c6c0, 0x2c}})
	/Users/dhruv/dolt/go/libraries/doltcore/merge/merge.go:66 +0xf0
github.com/dolthub/dolt/go/libraries/doltcore/merge.ExecuteMerge({0x1028344d8, 0x14000e863c0}, 0x14000e863c0?, 0x14000eb6000)
	/Users/dhruv/dolt/go/libraries/doltcore/merge/action.go:223 +0x9c
github.com/dolthub/dolt/go/cmd/dolt/commands.performMerge({0x1028344d8, 0x14000e863c0}, 0x14000eb6000?, 0x14000eb6000, {0x14000656280, 0x1e})
	/Users/dhruv/dolt/go/cmd/dolt/commands/merge.go:497 +0xfc
github.com/dolthub/dolt/go/cmd/dolt/commands.MergeCmd.Exec({}, {0x1028344d8, 0x14000e863c0}, {0x14000668210, 0xa}, {0x1400004e1d0, 0x1, 0x1}, 0x1400066a090)
	/Users/dhruv/dolt/go/cmd/dolt/commands/merge.go:184 +0x998
github.com/dolthub/dolt/go/cmd/dolt/cli.SubCommandHandler.handleCommand({{0x101e529aa, 0x4}, {0x101e6f2be, 0x11}, {0x0, 0x0}, {0x14000db6000, 0x2f, 0x2f}, 0x0}, ...)
	/Users/dhruv/dolt/go/cmd/dolt/cli/command.go:237 +0x450
github.com/dolthub/dolt/go/cmd/dolt/cli.SubCommandHandler.Exec({{0x101e529aa, 0x4}, {0x101e6f2be, 0x11}, {0x0, 0x0}, {0x14000db6000, 0x2f, 0x2f}, 0x0}, ...)
	/Users/dhruv/dolt/go/cmd/dolt/cli/command.go:186 +0x390
main.runMain()
	/Users/dhruv/dolt/go/cmd/dolt/dolt.go:395 +0x6ec
main.main()
	/Users/dhruv/dolt/go/cmd/dolt/dolt.go:140 +0x1c
```