### PR TITLE
Branch Control Pt. 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ venv
 
 .DS_Store
 .sqlhistory
+.doltcfg
 test.sh
 
 # ignore cp'd sysbench runner testing files

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -138,16 +138,17 @@ func Serve(
 
 	// Create SQL Engine with users
 	config := &engine.SqlEngineConfig{
-		InitialDb:         "",
-		IsReadOnly:        serverConfig.ReadOnly(),
-		PrivFilePath:      serverConfig.PrivilegeFilePath(),
-		DoltCfgDirPath:    serverConfig.CfgDir(),
-		ServerUser:        serverConfig.User(),
-		ServerPass:        serverConfig.Password(),
-		ServerHost:        serverConfig.Host(),
-		Autocommit:        serverConfig.AutoCommit(),
-		JwksConfig:        serverConfig.JwksConfig(),
-		ClusterController: clusterController,
+		InitialDb:          "",
+		IsReadOnly:         serverConfig.ReadOnly(),
+		PrivFilePath:       serverConfig.PrivilegeFilePath(),
+		BranchCtrlFilePath: serverConfig.BranchControlFilePath(),
+		DoltCfgDirPath:     serverConfig.CfgDir(),
+		ServerUser:         serverConfig.User(),
+		ServerPass:         serverConfig.Password(),
+		ServerHost:         serverConfig.Host(),
+		Autocommit:         serverConfig.AutoCommit(),
+		JwksConfig:         serverConfig.JwksConfig(),
+		ClusterController:  clusterController,
 	}
 	sqlEngine, err := engine.NewSqlEngine(
 		ctx,

--- a/go/cmd/dolt/commands/sqlserver/sqlclient.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlclient.go
@@ -19,6 +19,7 @@ import (
 	mysql "database/sql"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -39,7 +40,10 @@ import (
 )
 
 const (
-	sqlClientDualFlag = "dual"
+	sqlClientDualFlag     = "dual"
+	sqlClientQueryFlag    = "query"
+	sqlClientUseDbFlag    = "use-db"
+	sqlClientResultFormat = "result-format"
 )
 
 var sqlClientDocs = cli.CommandDocumentationContent{
@@ -52,6 +56,7 @@ Similar to {{.EmphasisLeft}}dolt sql-server{{.EmphasisRight}}, this command may 
 	Synopsis: []string{
 		"[-d] --config {{.LessThan}}file{{.GreaterThan}}",
 		"[-d] [-H {{.LessThan}}host{{.GreaterThan}}] [-P {{.LessThan}}port{{.GreaterThan}}] [-u {{.LessThan}}user{{.GreaterThan}}] [-p {{.LessThan}}password{{.GreaterThan}}] [-t {{.LessThan}}timeout{{.GreaterThan}}] [-l {{.LessThan}}loglevel{{.GreaterThan}}] [--data-dir {{.LessThan}}directory{{.GreaterThan}}] [--query-parallelism {{.LessThan}}num-go-routines{{.GreaterThan}}] [-r]",
+		"-q {{.LessThan}}string{{.GreaterThan}} [--use-db {{.LessThan}}db_name{{.GreaterThan}}] [--result-format {{.LessThan}}format{{.GreaterThan}}] [-H {{.LessThan}}host{{.GreaterThan}}] [-P {{.LessThan}}port{{.GreaterThan}}] [-u {{.LessThan}}user{{.GreaterThan}}] [-p {{.LessThan}}password{{.GreaterThan}}]",
 	},
 }
 
@@ -77,6 +82,10 @@ func (cmd SqlClientCmd) Docs() *cli.CommandDocumentation {
 func (cmd SqlClientCmd) ArgParser() *argparser.ArgParser {
 	ap := SqlServerCmd{}.ArgParser()
 	ap.SupportsFlag(sqlClientDualFlag, "d", "Causes this command to spawn a dolt server that is automatically connected to.")
+	ap.SupportsString(sqlClientQueryFlag, "q", "string", "Sends the given query to the server and immediately exits.")
+	ap.SupportsString(sqlClientUseDbFlag, "", "db_name", fmt.Sprintf("Selects the given database before executing a query. "+
+		"By default, uses the current folder's name. Must be used with the --%s flag.", sqlClientQueryFlag))
+	ap.SupportsString(sqlClientResultFormat, "", "format", fmt.Sprintf("Returns the results in the given format. Must be used with the --%s flag.", sqlClientQueryFlag))
 	return ap
 }
 
@@ -112,6 +121,18 @@ func (cmd SqlClientCmd) Exec(ctx context.Context, commandStr string, args []stri
 			cli.PrintErrln(err.Error())
 			return 1
 		}
+		if apr.Contains(sqlClientQueryFlag) {
+			cli.PrintErrln(color.RedString(fmt.Sprintf("--%s flag may not be used with --%s", sqlClientDualFlag, sqlClientQueryFlag)))
+			return 1
+		}
+		if apr.Contains(sqlClientUseDbFlag) {
+			cli.PrintErrln(color.RedString(fmt.Sprintf("--%s flag may not be used with --%s", sqlClientDualFlag, sqlClientUseDbFlag)))
+			return 1
+		}
+		if apr.Contains(sqlClientResultFormat) {
+			cli.PrintErrln(color.RedString(fmt.Sprintf("--%s flag may not be used with --%s", sqlClientDualFlag, sqlClientResultFormat)))
+			return 1
+		}
 
 		serverConfig, err = GetServerConfig(dEnv, apr)
 		if err != nil {
@@ -144,7 +165,44 @@ func (cmd SqlClientCmd) Exec(ctx context.Context, commandStr string, args []stri
 		}
 	}
 
-	conn, err := dbr.Open("mysql", ConnectionString(serverConfig, ""), nil)
+	query, hasQuery := apr.GetValue(sqlClientQueryFlag)
+	dbToUse, hasUseDb := apr.GetValue(sqlClientUseDbFlag)
+	resultFormat, hasResultFormat := apr.GetValue(sqlClientResultFormat)
+	if !hasQuery && hasUseDb {
+		cli.PrintErrln(color.RedString(fmt.Sprintf("--%s may only be used with --%s", sqlClientUseDbFlag, sqlClientQueryFlag)))
+		return 1
+	} else if !hasQuery && hasResultFormat {
+		cli.PrintErrln(color.RedString(fmt.Sprintf("--%s may only be used with --%s", sqlClientUseDbFlag, sqlClientResultFormat)))
+		return 1
+	}
+	if !hasUseDb && hasQuery {
+		directory, err := os.Getwd()
+		if err != nil {
+			cli.PrintErrln(color.RedString(err.Error()))
+			return 1
+		}
+		dbToUse = filepath.Base(directory)
+	}
+	format := engine.FormatTabular
+	if hasResultFormat {
+		switch strings.ToLower(resultFormat) {
+		case "tabular":
+			format = engine.FormatTabular
+		case "csv":
+			format = engine.FormatCsv
+		case "json":
+			format = engine.FormatJson
+		case "null":
+			format = engine.FormatNull
+		case "vertical":
+			format = engine.FormatVertical
+		default:
+			cli.PrintErrln(color.RedString(fmt.Sprintf("unknown --%s value: %s", sqlClientResultFormat, resultFormat)))
+			return 1
+		}
+	}
+
+	conn, err := dbr.Open("mysql", ConnectionString(serverConfig, dbToUse), nil)
 	if err != nil {
 		cli.PrintErrln(err.Error())
 		serverController.StopServer()
@@ -155,6 +213,34 @@ func (cmd SqlClientCmd) Exec(ctx context.Context, commandStr string, args []stri
 		return 1
 	}
 	_ = conn.Ping()
+
+	if hasQuery {
+		defer conn.Close()
+		rows, err := conn.Query(query)
+		if err != nil {
+			cli.PrintErrln(err.Error())
+			return 1
+		}
+		if rows != nil {
+			sqlCtx := sql.NewContext(ctx)
+			wrapper, err := NewMysqlRowWrapper(rows)
+			if err != nil {
+				cli.PrintErrln(err.Error())
+				return 1
+			}
+			defer wrapper.Close(sqlCtx)
+			if wrapper.HasMoreRows() {
+				err = engine.PrettyPrintResults(sqlCtx, format, wrapper.Schema(), wrapper)
+				if err != nil {
+					cli.PrintErrln(err.Error())
+					return 1
+				}
+			}
+		}
+
+		return 0
+	}
+
 	ticker := time.NewTicker(time.Second * 10)
 	go func() {
 		for range ticker.C {

--- a/go/libraries/doltcore/branch_control/branch_control.go
+++ b/go/libraries/doltcore/branch_control/branch_control.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	goerrors "errors"
 	"fmt"
+	"net"
 	"os"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -36,6 +37,7 @@ var (
 	ErrUpdatingRow          = errors.NewKind("`%s`@`%s` cannot update the row [%q, %q, %q]")
 	ErrUpdatingToRow        = errors.NewKind("`%s`@`%s` cannot update the row [%q, %q, %q] to the new branch expression %q")
 	ErrDeletingRow          = errors.NewKind("`%s`@`%s` cannot delete the row [%q, %q, %q]")
+	ErrMissingController    = errors.NewKind("a context has a non-nil session but is missing its branch controller")
 )
 
 // Context represents the interface that must be inherited from the context.
@@ -55,95 +57,141 @@ type Controller struct {
 	doltConfigDirPath     string
 }
 
-// TODO: delete me
-var StaticController = &Controller{}
+var (
+	// superUser is the server-wide user that has full, irrevocable permission to do whatever they want to any branch and table
+	superUser string
+	// superHost is the host counterpart of the superUser
+	superHost string
+	// superHostIsLoopback states whether the superHost is a loopback address
+	superHostIsLoopback bool
+)
+
 var enabled = false
 
 func init() {
 	if os.Getenv("DOLT_ENABLE_BRANCH_CONTROL") != "" {
 		enabled = true
 	}
-	StaticController = CreateControllerWithSuperUser(context.Background(), "root", "localhost")
 }
 
-// CreateController returns an empty *Controller.
-func CreateController(ctx context.Context) *Controller {
-	return CreateControllerWithSuperUser(ctx, "", "")
+// SetEnabled is a TEMPORARY function just used for testing (so that we don't have to set the env variable)
+func SetEnabled(value bool) {
+	enabled = value
 }
 
-// CreateControllerWithSuperUser returns a controller with the given user and host set as an immutable super user.
-func CreateControllerWithSuperUser(ctx context.Context, superUser string, superHost string) *Controller {
-	//TODO: put in the context
-	accessTbl := newAccess(superUser, superHost)
-	return &Controller{
-		Access:    accessTbl,
-		Namespace: newNamespace(accessTbl, superUser, superHost),
+// SetSuperUser sets the server-wide super user to the given user and host combination. The super user has full,
+// irrevocable permission to do whatever they want to any branch and table.
+func SetSuperUser(user string, host string) {
+	superUser = user
+	// Check if superHost is a loopback
+	if host == "localhost" || net.ParseIP(host).IsLoopback() {
+		superHost = "localhost"
+		superHostIsLoopback = true
+	} else {
+		superHost = host
+		superHostIsLoopback = false
 	}
 }
 
-// LoadData loads the data from the given location into the controller.
-func LoadData(ctx context.Context, branchControlFilePath string, doltConfigDirPath string) error {
-	//TODO: load into the context's controller
+// IsSuperUser returns whether the given user and host combination is the super user.
+func IsSuperUser(user string, host string) bool {
+	if user == superUser && ((host == superHost) || (superHostIsLoopback && net.ParseIP(host).IsLoopback())) {
+		return true
+	}
+	return false
+}
+
+// CreateDefaultController returns a default controller, which only has a single entry allowing all users to have write
+// permissions on all branches (only the super user has admin, if a super user has been set). This is equivalent to
+// passing empty strings to LoadData.
+func CreateDefaultController() *Controller {
+	controller, err := LoadData("", "")
+	if err != nil {
+		panic(err) // should never happen
+	}
+	return controller
+}
+
+// LoadData loads the data from the given location and returns a controller. Returns the default controller if the
+// `branchControlFilePath` is empty.
+func LoadData(branchControlFilePath string, doltConfigDirPath string) (*Controller, error) {
 	if !enabled {
-		return nil
+		return nil, nil
+	}
+	accessTbl := newAccess()
+	controller := &Controller{
+		Access:                accessTbl,
+		Namespace:             newNamespace(accessTbl),
+		branchControlFilePath: branchControlFilePath,
+		doltConfigDirPath:     doltConfigDirPath,
 	}
 
 	// Do not attempt to load from an empty file path
 	if len(branchControlFilePath) == 0 {
-		return nil
+		// If the path is empty, then we should populate the controller with the default row to ensure normal (expected) operation
+		controller.Access.insertDefaultRow()
+		return controller, nil
 	}
 
-	StaticController.branchControlFilePath = branchControlFilePath
-	StaticController.doltConfigDirPath = doltConfigDirPath
 	data, err := os.ReadFile(branchControlFilePath)
 	if err != nil && !goerrors.Is(err, os.ErrNotExist) {
-		return err
+		return nil, err
 	}
 	// Nothing to load so we can return
 	if len(data) == 0 {
-		return nil
+		// As there is nothing to load, we should populate the controller with the default row to ensure normal (expected) operation
+		controller.Access.insertDefaultRow()
+		return controller, nil
 	}
 	// Load the tables
 	if serial.GetFileID(data) != serial.BranchControlFileID {
-		return fmt.Errorf("unable to deserialize branch controller, unknown file ID `%s`", serial.GetFileID(data))
+		return nil, fmt.Errorf("unable to deserialize branch controller, unknown file ID `%s`", serial.GetFileID(data))
 	}
 	bc, err := serial.TryGetRootAsBranchControl(data, serial.MessagePrefixSz)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	access, err := bc.TryAccessTbl(nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	namespace, err := bc.TryNamespaceTbl(nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	// The Deserialize functions acquire write locks, so we don't acquire them here
-	if err = StaticController.Access.Deserialize(access); err != nil {
-		return err
+	if err = controller.Access.Deserialize(access); err != nil {
+		return nil, err
 	}
-	if err = StaticController.Namespace.Deserialize(namespace); err != nil {
-		return err
+	if err = controller.Namespace.Deserialize(namespace); err != nil {
+		return nil, err
 	}
-	return nil
+	return controller, nil
 }
 
 // SaveData saves the data from the context's controller to the location pointed by it.
 func SaveData(ctx context.Context) error {
-	//TODO: load from the context's controller
 	if !enabled {
 		return nil
 	}
-
+	branchAwareSession := GetBranchAwareSession(ctx)
+	// A nil session means we're not in the SQL context, so we've got nothing to serialize
+	if branchAwareSession == nil {
+		return nil
+	}
+	controller := branchAwareSession.GetController()
+	// If there is no controller in the context, then we have nothing to serialize
+	if controller == nil {
+		return nil
+	}
 	// If we never set a save location then we just return
-	if len(StaticController.branchControlFilePath) == 0 {
+	if len(controller.branchControlFilePath) == 0 {
 		return nil
 	}
 	// Create the doltcfg directory if it doesn't exist
-	if len(StaticController.doltConfigDirPath) != 0 {
-		if _, err := os.Stat(StaticController.doltConfigDirPath); os.IsNotExist(err) {
-			if mkErr := os.Mkdir(StaticController.doltConfigDirPath, 0777); mkErr != nil {
+	if len(controller.doltConfigDirPath) != 0 {
+		if _, err := os.Stat(controller.doltConfigDirPath); os.IsNotExist(err) {
+			if mkErr := os.Mkdir(controller.doltConfigDirPath, 0777); mkErr != nil {
 				return mkErr
 			}
 		} else if err != nil {
@@ -152,20 +200,14 @@ func SaveData(ctx context.Context) error {
 	}
 	b := flatbuffers.NewBuilder(1024)
 	// The Serialize functions acquire read locks, so we don't acquire them here
-	accessOffset := StaticController.Access.Serialize(b)
-	namespaceOffset := StaticController.Namespace.Serialize(b)
+	accessOffset := controller.Access.Serialize(b)
+	namespaceOffset := controller.Namespace.Serialize(b)
 	serial.BranchControlStart(b)
 	serial.BranchControlAddAccessTbl(b, accessOffset)
 	serial.BranchControlAddNamespaceTbl(b, namespaceOffset)
 	root := serial.BranchControlEnd(b)
 	data := serial.FinishMessage(b, root, []byte(serial.BranchControlFileID))
-	return os.WriteFile(StaticController.branchControlFilePath, data, 0777)
-}
-
-// Reset is a temporary function just for testing. Once the controller is in the context, this will be unnecessary.
-func Reset() {
-	//TODO: remove this once the controller is in the context
-	StaticController = CreateControllerWithSuperUser(context.Background(), StaticController.Access.SuperUser, StaticController.Access.SuperHost)
+	return os.WriteFile(controller.branchControlFilePath, data, 0777)
 }
 
 // CheckAccess returns whether the given context has the correct permissions on its selected branch. In general, SQL
@@ -182,8 +224,13 @@ func CheckAccess(ctx context.Context, flags Permissions) error {
 	if branchAwareSession == nil {
 		return nil
 	}
-	StaticController.Access.RWMutex.RLock()
-	defer StaticController.Access.RWMutex.RUnlock()
+	controller := branchAwareSession.GetController()
+	// Any context that has a non-nil session should always have a non-nil controller, so this is an error
+	if controller == nil {
+		return ErrMissingController.New()
+	}
+	controller.Access.RWMutex.RLock()
+	defer controller.Access.RWMutex.RUnlock()
 
 	user := branchAwareSession.GetUser()
 	host := branchAwareSession.GetHost()
@@ -192,7 +239,7 @@ func CheckAccess(ctx context.Context, flags Permissions) error {
 		return err
 	}
 	// Get the permissions for the branch, user, and host combination
-	_, perms := StaticController.Access.Match(branch, user, host)
+	_, perms := controller.Access.Match(branch, user, host)
 	// If either the flags match or the user is an admin for this branch, then we allow access
 	if (perms&flags == flags) || (perms&Permissions_Admin == Permissions_Admin) {
 		return nil
@@ -209,15 +256,21 @@ func CanCreateBranch(ctx context.Context, branchName string) error {
 		return nil
 	}
 	branchAwareSession := GetBranchAwareSession(ctx)
+	// A nil session means we're not in the SQL context, so we allow the create operation
 	if branchAwareSession == nil {
 		return nil
 	}
-	StaticController.Namespace.RWMutex.RLock()
-	defer StaticController.Namespace.RWMutex.RUnlock()
+	controller := branchAwareSession.GetController()
+	// Any context that has a non-nil session should always have a non-nil controller, so this is an error
+	if controller == nil {
+		return ErrMissingController.New()
+	}
+	controller.Namespace.RWMutex.RLock()
+	defer controller.Namespace.RWMutex.RUnlock()
 
 	user := branchAwareSession.GetUser()
 	host := branchAwareSession.GetHost()
-	if StaticController.Namespace.CanCreate(branchName, user, host) {
+	if controller.Namespace.CanCreate(branchName, user, host) {
 		return nil
 	}
 	return ErrCannotCreateBranch.New(user, host, branchName)
@@ -236,18 +289,54 @@ func CanDeleteBranch(ctx context.Context, branchName string) error {
 	if branchAwareSession == nil {
 		return nil
 	}
-	StaticController.Access.RWMutex.RLock()
-	defer StaticController.Access.RWMutex.RUnlock()
+	controller := branchAwareSession.GetController()
+	// Any context that has a non-nil session should always have a non-nil controller, so this is an error
+	if controller == nil {
+		return ErrMissingController.New()
+	}
+	controller.Access.RWMutex.RLock()
+	defer controller.Access.RWMutex.RUnlock()
 
 	user := branchAwareSession.GetUser()
 	host := branchAwareSession.GetHost()
 	// Get the permissions for the branch, user, and host combination
-	_, perms := StaticController.Access.Match(branchName, user, host)
+	_, perms := controller.Access.Match(branchName, user, host)
 	// If the user has the write or admin flags, then we allow access
 	if (perms&Permissions_Write == Permissions_Write) || (perms&Permissions_Admin == Permissions_Admin) {
 		return nil
 	}
 	return ErrCannotDeleteBranch.New(user, host, branchName)
+}
+
+// AddAdminForContext adds an entry in the access table for the user represented by the given context. If the
+// context is missing some functionality that is needed to perform the addition, such as a user or the Controller, then
+// this simply returns.
+func AddAdminForContext(ctx context.Context, branchName string) error {
+	if !enabled {
+		return nil
+	}
+	branchAwareSession := GetBranchAwareSession(ctx)
+	if branchAwareSession == nil {
+		return nil
+	}
+	controller := branchAwareSession.GetController()
+	if controller == nil {
+		return nil
+	}
+
+	user := branchAwareSession.GetUser()
+	host := branchAwareSession.GetHost()
+	// Check if we already have admin permissions for the given branch, as there's no need to do another insertion if so
+	controller.Access.RWMutex.RLock()
+	_, modPerms := controller.Access.Match(branchName, user, host)
+	controller.Access.RWMutex.RUnlock()
+	if modPerms&Permissions_Admin == Permissions_Admin {
+		return nil
+	}
+	controller.Access.RWMutex.Lock()
+	controller.Access.insert(branchName, user, host, Permissions_Admin)
+	controller.Access.RWMutex.Unlock()
+	return SaveData(ctx)
 }
 
 // GetBranchAwareSession returns the session contained within the context. If the context does NOT contain a session,

--- a/go/libraries/doltcore/branch_control/expr_parser.go
+++ b/go/libraries/doltcore/branch_control/expr_parser.go
@@ -156,10 +156,6 @@ func ParseExpression(str string, collation sql.CollationID) []int32 {
 // This is true even when the match expressions are pooled. The reason is unknown, but as we only need the collection
 // indexes anyway, we discard the match expressions and return only their indexes.
 func Match(matchExprCollection []MatchExpression, str string, collation sql.CollationID) []uint32 {
-	if len(str) == 0 {
-		return nil
-	}
-
 	sortFunc := collation.Sorter()
 	// Grab the first rune and also remove it from the string
 	r, rSize := utf8.DecodeRuneInString(str)

--- a/go/libraries/doltcore/branch_control/namespace.go
+++ b/go/libraries/doltcore/branch_control/namespace.go
@@ -31,13 +31,11 @@ type Namespace struct {
 	access *Access
 	binlog *Binlog
 
-	Branches  []MatchExpression
-	Users     []MatchExpression
-	Hosts     []MatchExpression
-	Values    []NamespaceValue
-	SuperUser string
-	SuperHost string
-	RWMutex   *sync.RWMutex
+	Branches []MatchExpression
+	Users    []MatchExpression
+	Hosts    []MatchExpression
+	Values   []NamespaceValue
+	RWMutex  *sync.RWMutex
 }
 
 // NamespaceValue contains the user-facing values of a particular row.
@@ -48,17 +46,15 @@ type NamespaceValue struct {
 }
 
 // newNamespace returns a new Namespace.
-func newNamespace(accessTbl *Access, superUser string, superHost string) *Namespace {
+func newNamespace(accessTbl *Access) *Namespace {
 	return &Namespace{
-		binlog:    NewNamespaceBinlog(nil),
-		access:    accessTbl,
-		Branches:  nil,
-		Users:     nil,
-		Hosts:     nil,
-		Values:    nil,
-		SuperUser: superUser,
-		SuperHost: superHost,
-		RWMutex:   &sync.RWMutex{},
+		binlog:   NewNamespaceBinlog(nil),
+		access:   accessTbl,
+		Branches: nil,
+		Users:    nil,
+		Hosts:    nil,
+		Values:   nil,
+		RWMutex:  &sync.RWMutex{},
 	}
 }
 
@@ -66,7 +62,7 @@ func newNamespace(accessTbl *Access, superUser string, superHost string) *Namesp
 // branch. Handles the super user case.
 func (tbl *Namespace) CanCreate(branch string, user string, host string) bool {
 	// Super user can always create branches
-	if user == tbl.SuperUser && host == tbl.SuperHost {
+	if IsSuperUser(user, host) {
 		return true
 	}
 	matchedSet := Match(tbl.Branches, branch, sql.Collation_utf8mb4_0900_ai_ci)
@@ -115,6 +111,11 @@ func (tbl *Namespace) GetIndex(branchExpr string, userExpr string, hostExpr stri
 		}
 	}
 	return -1
+}
+
+// GetBinlog returns the table's binlog.
+func (tbl *Namespace) GetBinlog() *Binlog {
+	return tbl.binlog
 }
 
 // Access returns the Access table.

--- a/go/libraries/doltcore/env/actions/branch.go
+++ b/go/libraries/doltcore/env/actions/branch.go
@@ -19,6 +19,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
@@ -197,6 +199,10 @@ func CreateBranchWithStartPt(ctx context.Context, dbData env.DbData, newBranch, 
 		} else {
 			return fmt.Errorf("fatal: Unexpected error creating branch '%s' : %v", newBranch, err)
 		}
+	}
+	err = branch_control.AddAdminForContext(ctx, newBranch)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -468,9 +468,19 @@ func (db Database) getTableInsensitive(ctx *sql.Context, head *doltdb.Commit, ds
 	case doltdb.TagsTableName:
 		dt, found = dtables.NewTagsTable(ctx, db.ddb), true
 	case dtables.AccessTableName:
-		dt, found = dtables.NewBranchControlTable(branch_control.StaticController.Access), true
+		basCtx := branch_control.GetBranchAwareSession(ctx)
+		if basCtx != nil {
+			if controller := basCtx.GetController(); controller != nil {
+				dt, found = dtables.NewBranchControlTable(controller.Access), true
+			}
+		}
 	case dtables.NamespaceTableName:
-		dt, found = dtables.NewBranchNamespaceControlTable(branch_control.StaticController.Namespace), true
+		basCtx := branch_control.GetBranchAwareSession(ctx)
+		if basCtx != nil {
+			if controller := basCtx.GetController(); controller != nil {
+				dt, found = dtables.NewBranchNamespaceControlTable(controller.Namespace), true
+			}
+		}
 	}
 	if found {
 		return dt, found, nil

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_add.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_add.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 )
@@ -45,6 +46,9 @@ func DoDoltAdd(ctx *sql.Context, args []string) (int, error) {
 
 	if len(dbName) == 0 {
 		return 1, fmt.Errorf("Empty database name.")
+	}
+	if err := branch_control.CheckAccess(ctx, branch_control.Permissions_Write); err != nil {
+		return 1, err
 	}
 
 	apr, err := cli.CreateAddArgParser().Parse(args)

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_backup.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_backup.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/expression"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
@@ -77,6 +78,9 @@ func DoDoltBackup(ctx *sql.Context, args []string) (int, error) {
 	dbName := ctx.GetCurrentDatabase()
 	if len(dbName) == 0 {
 		return statusErr, fmt.Errorf("Empty database name.")
+	}
+	if err := branch_control.CheckAccess(ctx, branch_control.Permissions_Write); err != nil {
+		return statusErr, err
 	}
 
 	apr, err := cli.CreateBackupArgParser().Parse(args)

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_clean.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_clean.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 )
@@ -45,6 +46,9 @@ func DoDoltClean(ctx *sql.Context, args []string) (int, error) {
 
 	if len(dbName) == 0 {
 		return 1, fmt.Errorf("Empty database name.")
+	}
+	if err := branch_control.CheckAccess(ctx, branch_control.Permissions_Write); err != nil {
+		return statusErr, err
 	}
 
 	dSess := dsess.DSessFromSess(ctx.Session)

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_commit.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_commit.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dolthub/vitess/go/vt/proto/query"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 )
@@ -51,6 +52,9 @@ func (d DoltCommitFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error)
 }
 
 func DoDoltCommit(ctx *sql.Context, args []string) (string, error) {
+	if err := branch_control.CheckAccess(ctx, branch_control.Permissions_Write); err != nil {
+		return "", err
+	}
 	// Get the information for the sql context.
 	dbName := ctx.GetCurrentDatabase()
 

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_fetch.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_fetch.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/expression"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
@@ -77,6 +78,9 @@ func DoDoltFetch(ctx *sql.Context, args []string) (int, error) {
 
 	if len(dbName) == 0 {
 		return cmdFailure, fmt.Errorf("empty database name")
+	}
+	if err := branch_control.CheckAccess(ctx, branch_control.Permissions_Write); err != nil {
+		return cmdFailure, err
 	}
 
 	sess := dsess.DSessFromSess(ctx.Session)

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_merge.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_merge.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/expression"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
@@ -71,6 +72,9 @@ func DoDoltMerge(ctx *sql.Context, args []string) (int, int, error) {
 
 	if len(dbName) == 0 {
 		return noConflictsOrViolations, threeWayMerge, fmt.Errorf("Empty database name.")
+	}
+	if err := branch_control.CheckAccess(ctx, branch_control.Permissions_Write); err != nil {
+		return noConflictsOrViolations, threeWayMerge, err
 	}
 
 	sess := dsess.DSessFromSess(ctx.Session)

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_pull.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_pull.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/expression"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
@@ -79,6 +80,9 @@ func DoDoltPull(ctx *sql.Context, args []string) (int, int, error) {
 
 	if len(dbName) == 0 {
 		return noConflictsOrViolations, threeWayMerge, fmt.Errorf("empty database name.")
+	}
+	if err := branch_control.CheckAccess(ctx, branch_control.Permissions_Write); err != nil {
+		return noConflictsOrViolations, threeWayMerge, err
 	}
 
 	sess := dsess.DSessFromSess(ctx.Session)

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_push.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_push.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/expression"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
@@ -73,6 +74,9 @@ func DoDoltPush(ctx *sql.Context, args []string) (int, error) {
 
 	if len(dbName) == 0 {
 		return cmdFailure, fmt.Errorf("empty database name")
+	}
+	if err := branch_control.CheckAccess(ctx, branch_control.Permissions_Write); err != nil {
+		return cmdFailure, err
 	}
 
 	sess := dsess.DSessFromSess(ctx.Session)

--- a/go/libraries/doltcore/sqle/dfunctions/dolt_reset.go
+++ b/go/libraries/doltcore/sqle/dfunctions/dolt_reset.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
@@ -46,6 +47,9 @@ func DoDoltReset(ctx *sql.Context, args []string) (int, error) {
 
 	if len(dbName) == 0 {
 		return 1, fmt.Errorf("Empty database name.")
+	}
+	if err := branch_control.CheckAccess(ctx, branch_control.Permissions_Write); err != nil {
+		return 1, err
 	}
 
 	dSess := dsess.DSessFromSess(ctx.Session)

--- a/go/libraries/doltcore/sqle/dfunctions/revert.go
+++ b/go/libraries/doltcore/sqle/dfunctions/revert.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/expression"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/merge"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
@@ -60,6 +61,9 @@ func DoDoltRevert(ctx *sql.Context, row sql.Row, args []string) (int, error) {
 	ddb, ok := dSess.GetDoltDB(ctx, dbName)
 	if !ok {
 		return 1, fmt.Errorf("dolt database could not be found")
+	}
+	if err := branch_control.CheckAccess(ctx, branch_control.Permissions_Write); err != nil {
+		return 1, err
 	}
 	workingSet, err := dSess.WorkingSet(ctx, dbName)
 	if err != nil {

--- a/go/libraries/doltcore/sqle/dfunctions/verify_constraints.go
+++ b/go/libraries/doltcore/sqle/dfunctions/verify_constraints.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/expression"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/merge"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
@@ -55,6 +56,9 @@ func (vc *ConstraintsVerifyFunc) Eval(ctx *sql.Context, row sql.Row) (interface{
 }
 
 func DoDoltConstraintsVerify(ctx *sql.Context, args []string) (int, error) {
+	if err := branch_control.CheckAccess(ctx, branch_control.Permissions_Write); err != nil {
+		return 1, err
+	}
 	dbName := ctx.GetCurrentDatabase()
 	dSess := dsess.DSessFromSess(ctx.Session)
 	workingSet, err := dSess.WorkingSet(ctx, dbName)

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_conflicts_resolve.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_conflicts_resolve.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/conflict"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
@@ -402,6 +403,9 @@ func ResolveConflicts(ctx *sql.Context, dSess *dsess.DoltSession, root *doltdb.R
 }
 
 func DoDoltConflictsResolve(ctx *sql.Context, args []string) (int, error) {
+	if err := branch_control.CheckAccess(ctx, branch_control.Permissions_Write); err != nil {
+		return 1, err
+	}
 	dbName := ctx.GetCurrentDatabase()
 	fmt.Printf("database name: %s", dbName)
 

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_remote.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_remote.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
+	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
@@ -45,6 +46,9 @@ func doDoltRemote(ctx *sql.Context, args []string) (int, error) {
 	dbName := ctx.GetCurrentDatabase()
 	if len(dbName) == 0 {
 		return 1, fmt.Errorf("Empty database name.")
+	}
+	if err := branch_control.CheckAccess(ctx, branch_control.Permissions_Write); err != nil {
+		return 1, err
 	}
 	dSess := dsess.DSessFromSess(ctx.Session)
 	dbData, ok := dSess.GetDbData(ctx, dbName)

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_tag.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_tag.go
@@ -17,11 +17,11 @@ package dprocedures
 import (
 	"fmt"
 
+	"github.com/dolthub/go-mysql-server/sql"
+
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
-
-	"github.com/dolthub/go-mysql-server/sql"
 )
 
 // doltTag is the stored procedure version of the CLI `dolt tag` command

--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -54,14 +54,15 @@ var ErrCurrentBranchDeleted = errors.New("current branch has been force deleted.
 // DoltSession is the sql.Session implementation used by dolt. It is accessible through a *sql.Context instance
 type DoltSession struct {
 	sql.Session
-	batchMode   batchMode
-	username    string
-	email       string
-	dbStates    map[string]*DatabaseSessionState
-	provider    DoltDatabaseProvider
-	tempTables  map[string][]sql.Table
-	globalsConf config.ReadWriteConfig
-	mu          *sync.Mutex
+	batchMode        batchMode
+	username         string
+	email            string
+	dbStates         map[string]*DatabaseSessionState
+	provider         DoltDatabaseProvider
+	tempTables       map[string][]sql.Table
+	globalsConf      config.ReadWriteConfig
+	branchController *branch_control.Controller
+	mu               *sync.Mutex
 
 	// If non-nil, this will be returned from ValidateSession.
 	// Used by sqle/cluster to put a session into a terminal err state.
@@ -75,32 +76,40 @@ var _ branch_control.Context = (*DoltSession)(nil)
 // DefaultSession creates a DoltSession with default values
 func DefaultSession(pro DoltDatabaseProvider) *DoltSession {
 	return &DoltSession{
-		Session:     sql.NewBaseSession(),
-		username:    "",
-		email:       "",
-		dbStates:    make(map[string]*DatabaseSessionState),
-		provider:    pro,
-		tempTables:  make(map[string][]sql.Table),
-		globalsConf: config.NewMapConfig(make(map[string]string)),
-		mu:          &sync.Mutex{},
+		Session:          sql.NewBaseSession(),
+		username:         "",
+		email:            "",
+		dbStates:         make(map[string]*DatabaseSessionState),
+		provider:         pro,
+		tempTables:       make(map[string][]sql.Table),
+		globalsConf:      config.NewMapConfig(make(map[string]string)),
+		branchController: branch_control.CreateDefaultController(), // Default sessions are fine with the default controller
+		mu:               &sync.Mutex{},
 	}
 }
 
 // NewDoltSession creates a DoltSession object from a standard sql.Session and 0 or more Database objects.
-func NewDoltSession(ctx *sql.Context, sqlSess *sql.BaseSession, pro DoltDatabaseProvider, conf config.ReadWriteConfig, dbs ...InitialDbState) (*DoltSession, error) {
+func NewDoltSession(
+	ctx *sql.Context,
+	sqlSess *sql.BaseSession,
+	pro DoltDatabaseProvider,
+	conf config.ReadWriteConfig,
+	branchController *branch_control.Controller,
+	dbs ...InitialDbState) (*DoltSession, error) {
 	username := conf.GetStringOrDefault(env.UserNameKey, "")
 	email := conf.GetStringOrDefault(env.UserEmailKey, "")
 	globals := config.NewPrefixConfig(conf, env.SqlServerGlobalsPrefix)
 
 	sess := &DoltSession{
-		Session:     sqlSess,
-		username:    username,
-		email:       email,
-		dbStates:    make(map[string]*DatabaseSessionState),
-		provider:    pro,
-		tempTables:  make(map[string][]sql.Table),
-		globalsConf: globals,
-		mu:          &sync.Mutex{},
+		Session:          sqlSess,
+		username:         username,
+		email:            email,
+		dbStates:         make(map[string]*DatabaseSessionState),
+		provider:         pro,
+		tempTables:       make(map[string][]sql.Table),
+		globalsConf:      globals,
+		branchController: branchController,
+		mu:               &sync.Mutex{},
 	}
 
 	for _, db := range dbs {
@@ -1197,11 +1206,25 @@ func (d *DoltSession) SystemVariablesInConfig() ([]sql.SystemVariable, error) {
 
 // GetBranch implements the interface branch_control.Context.
 func (d *DoltSession) GetBranch() (string, error) {
-	branchRef, err := d.CWBHeadRef(sql.NewContext(context.Background(), sql.WithSession(d)), d.Session.GetCurrentDatabase())
+	ctx := sql.NewContext(context.Background(), sql.WithSession(d))
+	currentDb := d.Session.GetCurrentDatabase()
+	dbState, _, err := d.LookupDbState(ctx, currentDb)
 	if err != nil {
+		if len(currentDb) == 0 && sql.ErrDatabaseNotFound.Is(err) {
+			// Some operations return an empty database (namely tests), so we return an empty branch in such cases
+			return "", nil
+		}
 		return "", err
 	}
-	return branchRef.GetPath(), nil
+	if dbState.WorkingSet != nil {
+		branchRef, err := dbState.WorkingSet.Ref().ToHeadRef()
+		if err != nil {
+			return "", err
+		}
+		return branchRef.GetPath(), nil
+	}
+	// A nil working set probably means that we're not on a branch (like we may be on a commit), so we return an empty string
+	return "", nil
 }
 
 // GetUser implements the interface branch_control.Context.
@@ -1216,8 +1239,7 @@ func (d *DoltSession) GetHost() string {
 
 // GetController implements the interface branch_control.Context.
 func (d *DoltSession) GetController() *branch_control.Controller {
-	//TODO implement me
-	panic("implement me")
+	return d.branchController
 }
 
 // validatePersistedSysVar checks whether a system variable exists and is dynamic

--- a/go/libraries/doltcore/sqle/index/mergeable_indexes_setup_test.go
+++ b/go/libraries/doltcore/sqle/index/mergeable_indexes_setup_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/dtestutils"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
@@ -111,7 +112,9 @@ func setupIndexes(t *testing.T, tableName, insertQuery string) (*sqle.Engine, *e
 
 	// Get an updated root to use for the rest of the test
 	ctx := sql.NewEmptyContext()
-	sess, err := dsess.NewDoltSession(ctx, ctx.Session.(*sql.BaseSession), pro, config.NewEmptyMapConfig(), getDbState(t, db, dEnv))
+	controller := branch_control.CreateDefaultController()
+	sess, err := dsess.NewDoltSession(ctx, ctx.Session.(*sql.BaseSession), pro, config.NewEmptyMapConfig(),
+		controller, getDbState(t, db, dEnv))
 	require.NoError(t, err)
 	roots, ok := sess.GetRoots(ctx, db.Name())
 	require.True(t, ok)

--- a/go/libraries/doltcore/sqle/testutil.go
+++ b/go/libraries/doltcore/sqle/testutil.go
@@ -28,6 +28,7 @@ import (
 	"github.com/dolthub/vitess/go/vt/sqlparser"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
 	"github.com/dolthub/dolt/go/libraries/doltcore/dtestutils"
@@ -118,6 +119,7 @@ func NewTestSQLCtxWithProvider(ctx context.Context, pro dsess.DoltDatabaseProvid
 		sql.NewBaseSession(),
 		pro,
 		config2.NewMapConfig(make(map[string]string)),
+		branch_control.CreateDefaultController(),
 	)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
This PR:
* Moves the branch controller into the context
* Adds the remaining stored procedures
* Handles declaring the super user via CLI arguments or YAML
* Fixes bugs found through additional testing
* Enables branch control globally

Things still missing:
* Bats tests (will mainly copy the engine tests, but makes use of saving/loading from disk)
* Ways to interact with the binlog
* Support for roles

Role support is actually a bit more involved than originally anticipated. It involves coordination with the privilege tables, which were not built to be interacted with outside of their specific GMS context. I'm thinking it should get pushed back to a v2 implementation, unless it's high priority.