### PR TITLE
go/doltcore/migrate: Patch schemas to use `utf8mb4_0900_bin` to match e…

### DIFF
--- a/go/libraries/doltcore/migrate/transform.go
+++ b/go/libraries/doltcore/migrate/transform.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/vitess/go/vt/proto/query"
 	"golang.org/x/sync/errgroup"
 
@@ -446,6 +447,35 @@ func migrateSchema(ctx context.Context, tableName string, existing schema.Schema
 			}
 		}
 	}
+
+	// String types are sorted using a binary collation in __LD_1__
+	// force-set collation to utf8mb4_0900_bin to match the order
+	for i, c := range cols {
+		st, ok := c.TypeInfo.ToSqlType().(sql.StringType)
+		if !ok {
+			continue
+		}
+		patched = true
+
+		var err error
+		st, err = sql.CreateString(st.Type(), st.Length(), sql.Collation_utf8mb4_0900_bin)
+		if err != nil {
+			return nil, err
+		}
+
+		info, err := typeinfo.FromSqlType(st)
+		if err != nil {
+			return nil, err
+		}
+
+		cols[i], err = schema.NewColumnWithTypeInfo(
+			c.Name, c.Tag, info, c.IsPartOfPK, c.Default,
+			c.AutoIncrement, c.Comment, c.Constraints...)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if patched {
 		return schema.SchemaFromCols(schema.NewColCollection(cols...))
 	}

--- a/integration-tests/bats/migrate.bats
+++ b/integration-tests/bats/migrate.bats
@@ -203,3 +203,29 @@ SQL
     run checksum_table keyless head~1
     [[ "$output" =~ "$PREV" ]] || false
 }
+
+@test "migrate: fixup key collations to match index order" {
+    dolt sql <<SQL
+CREATE TABLE t (
+    a varchar(20) primary key COLLATE utf8mb4_0900_ai_ci NOT NULL,
+    b varchar(20) COLLATE utf8mb4_0900_ai_ci NOT NULL,
+    INDEX(b));
+INSERT INTO t VALUES ('h/a', 'a'), ('h&a', 'B');
+SQL
+
+    run dolt schema show t
+    [[ "$output" =~ "utf8mb4_0900_ai_ci" ]] || false
+    [[ ! "$output" =~ "utf8mb4_0900_bin," ]] || false
+
+    dolt migrate
+    [[ $(cat ./.dolt/noms/manifest | cut -f 2 -d :) = "$TARGET_NBF" ]] || false
+
+    # utf8mb4_0900_ai_ci is converted to utf8mb4_0900_bin to match index order
+    dolt schema show t
+    run dolt schema show t
+    [[ "$output" =~ "utf8mb4_0900_bin" ]] || false
+    [[ ! "$output" =~ "utf8mb4_0900_ai_ci" ]] || false
+
+    run dolt sql -q "SELECT * FROM t ORDER BY a LIMIT 1" -r csv
+    [[ "$output" =~ "h&a,B" ]] || false
+}


### PR DESCRIPTION
…xisting index order