### PR TITLE
Fixing variable name in `getPORT` helper function

### DIFF
--- a/integration-tests/bats/helper/query-server-common.bash
+++ b/integration-tests/bats/helper/query-server-common.bash
@@ -256,7 +256,7 @@ definePORT() {
   for i in {0..9}
   do
     let getPORT="($$ + $i) % (65536-1024) + 1024"
-    portinuse=$(lsof -i -P -n | grep LISTEN | grep $attemptedPORT | wc -l)
+    portinuse=$(lsof -i -P -n | grep LISTEN | grep $getPORT | wc -l)
     if [ $portinuse -eq 0 ]; then
       echo "$getPORT"
       break

--- a/integration-tests/bats/helper/query-server-common.bash
+++ b/integration-tests/bats/helper/query-server-common.bash
@@ -237,7 +237,6 @@ stop_sql_server() {
 #  * param7: Expected exception value of 1. Mutually exclusive with param6.
 #
 server_query() {
-    PORT=$( definePORT )
     server_query_with_port "$PORT" "$@"
 }
 

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -54,7 +54,7 @@ teardown() {
     dolt sql -q "create user dolt@'%' identified by '123'"
 
     PORT=$( definePORT )
-    dolt sql-server --port=$PORT --user dolt > log.txt 2>&1 &
+    dolt sql-server --port=$PORT --user dolt --socket "dolt.$PORT.sock" > log.txt 2>&1 &
     SERVER_PID=$!
     sleep 5
 
@@ -695,7 +695,7 @@ listener:
   host: "0.0.0.0"
   port: $PORT
 EOF
-    dolt sql-server --config ./config.yml &
+    dolt sql-server --config ./config.yml --socket "dolt.$PORT.sock" &
     SERVER_PID=$!
     # We do things manually here because we need to control CLIENT_MULTI_STATEMENTS.
     python3 -c '
@@ -740,7 +740,7 @@ listener:
   host: "0.0.0.0"
   port: $PORT
 EOF
-    dolt sql-server --config ./config.yml &
+    dolt sql-server --config ./config.yml --socket "dolt.$PORT.sock" &
     SERVER_PID=$!
     # We do things manually here because we need to control CLIENT_MULTI_STATEMENTS.
     python3 -c '
@@ -1157,15 +1157,15 @@ databases:
     cd repo1
     start_sql_server
     PORT=$( definePORT )
-    run dolt sql-server -P $PORT
+    run dolt sql-server -P $PORT --socket "dolt.$PORT.sock"
     [ "$status" -eq 1 ]
 }
 
-@test "sql-server: multi dir sql-server locks out childen" {
+@test "sql-server: multi dir sql-server locks out children" {
     start_sql_server
     cd repo2
     PORT=$( definePORT )
-    run dolt sql-server -P $PORT
+    run dolt sql-server -P $PORT --socket "dolt.$PORT.sock"
     [ "$status" -eq 1 ]
 }
 
@@ -1174,7 +1174,7 @@ databases:
     start_sql_server
     cd ..
     PORT=$( definePORT )
-    run dolt sql-server -P $PORT
+    run dolt sql-server -P $PORT --socket "dolt.$PORT.sock"
     [ "$status" -eq 1 ]
 }
 
@@ -1184,7 +1184,7 @@ databases:
     server_query repo1 1 dolt "" "create database newdb" ""
     cd newdb
     PORT=$( definePORT )
-    run dolt sql-server -P $PORT
+    run dolt sql-server -P $PORT --socket "dolt.$PORT.sock"
     [ "$status" -eq 1 ]
 }
 
@@ -1222,6 +1222,8 @@ databases:
     run dolt sql-client --host=0.0.0.0 --port=$PORT --user=dolt <<< "exit;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "# Welcome to the Dolt MySQL client." ]] || false
+
+    rm /tmp/mysql.sock
 }
 
 @test "sql-server: start server with socket option undefined should set default socket path" {
@@ -1239,6 +1241,8 @@ databases:
     run grep '\"/tmp/mysql.sock\"' log.txt
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" -eq 1 ]
+
+    rm /tmp/mysql.sock
 }
 
 @test "sql-server: server fails to start up if there is already a file in the socket file path" {
@@ -1276,7 +1280,7 @@ listener:
   host: localhost
   port: $PORT
   max_connections: 10
-  socket: /tmp/mysql.sock
+  socket: dolt.$PORT.sock
 
 behavior:
   autocommit: true" > server.yaml
@@ -1287,7 +1291,7 @@ behavior:
 
     server_query repo2 1 dolt "" "select 1 as col1" "col1\n1"
 
-    run grep '\"/tmp/mysql.sock\"' log.txt
+    run grep "dolt.$PORT.sock" log.txt
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" -eq 1 ]
 }
@@ -1329,7 +1333,7 @@ s.close()
 " > port_finder.py
 
     PORT=$(python3 port_finder.py)
-    run dolt sql-server --port=$PORT
+    run dolt sql-server --port=$PORT --socket "dolt.$PORT.sock"
     [ "$status" -eq 1 ]
     [[ "$output" =~ "database locked by another sql-server; either clone the database to run a second server" ]] || false
 
@@ -1383,7 +1387,7 @@ s.close()
     [ $status -eq 0 ]
 
     PORT=$( definePORT )
-    dolt sql-server --host 0.0.0.0 --port=$PORT --user dolt &
+    dolt sql-server --host 0.0.0.0 --port=$PORT --user dolt --socket "dolt.$PORT.sock" &
     SERVER_PID=$! # will get killed by teardown_common
     sleep 5 # not using python wait so this works on windows
 


### PR DESCRIPTION
I noticed some errors with grep syntax in a failed BATS test. Looks like we just had an empty env var so there wasn't anything passed to `grep`, which caused errors and prevented us from fully checking if a port is in use. 