### PR TITLE
deeper comparison for foregin key indexes

### DIFF
--- a/go/libraries/doltcore/doltdb/foreign_key_coll.go
+++ b/go/libraries/doltcore/doltdb/foreign_key_coll.go
@@ -131,7 +131,9 @@ func (fk ForeignKey) DeepEquals(other ForeignKey) bool {
 	}
 	return fk.Name == other.Name &&
 		fk.TableName == other.TableName &&
-		fk.ReferencedTableName == other.ReferencedTableName
+		fk.ReferencedTableName == other.ReferencedTableName &&
+		fk.TableIndex == other.TableIndex &&
+		fk.ReferencedTableIndex == other.ReferencedTableIndex
 }
 
 // HashOf returns the Noms hash of a ForeignKey.


### PR DESCRIPTION
If we have committed tables before [this](https://github.com/dolthub/dolt/pull/4583) change, where the tables have a foreign key that references an index that could've been replace with an existing primary key, apply those changes, and we drop and recreate the parent/child tables in exactly the same way, we stage the parent table, but not the child table, which causes our foreign keys to enter a bad state.

repro for clarity:
```shell
// SWITCH TO DOLT v0.50.8
rm -rf .dolt
dolt init
dolt sql -q "create table payment(payment_id int primary key);"
dolt sql -q "create table subscription(id int primary key, payment_id int);"
dolt sql -q "alter table subscription add constraint subscription_pm_fk foreign key (payment_id) references payment(payment_id);"
dolt add .
dolt commit -m "commit from the past"

// SWITCH TO MAIN
dolt sql -q "drop table subscription";
dolt sql -q "drop table payment";
dolt sql -q "create table payment(payment_id int primary key);"
dolt sql -q "create table subscription(id int primary key, payment_id int);" #A 
dolt sql -q "alter table subscription add constraint subscription_pm_fk foreign key (payment_id) references payment(payment_id);" #B 
dolt add .
dolt commit -m "commit from the future"
```

You can see this by running `dolt status` after line (A) and then line (B).

The fix was to have our DeepEquals comparison for foreign key definitions also check if the referencing table index names have changed, and hope that that doesn't break anything else.