### PR TITLE
Test for inserting ampersands into jsons

### DIFF
--- a/integration-tests/bats/json.bats
+++ b/integration-tests/bats/json.bats
@@ -10,6 +10,34 @@ teardown() {
     teardown_common
 }
 
+
+@test "json: insert value with ampersand" {
+    dolt sql <<SQL
+    CREATE TABLE js (
+        pk int PRIMARY KEY,
+        js json
+    );
+    INSERT INTO js VALUES (1, '{"a":"A&B"}');
+SQL
+    run dolt sql -q "SELECT * FROM js;" -r csv
+    [ "$status" -eq 0 ]
+    [ "${lines[1]}" = '1,"{""a"": ""A&B""}"' ]
+}
+
+
+@test "json: insert array with ampersand" {
+    dolt sql <<SQL
+    CREATE TABLE js (
+        pk int PRIMARY KEY,
+        js json
+    );
+    INSERT INTO js VALUES (1, '[{"a":"A&B"}]');
+SQL
+    run dolt sql -q "SELECT * FROM js;" -r csv
+    [ "$status" -eq 0 ]
+    [ "${lines[1]}" = '1,"[{""a"": ""A&B""}]"' ]
+}
+
 @test "json: Create table with JSON column" {
     run dolt sql <<SQL
     CREATE TABLE js (
@@ -219,3 +247,5 @@ SQL
     [ "${lines[1]}" = '1,"{""a"": 1}"' ]
     [ "${lines[2]}" = '2,"{""b"": 99}"' ]
 }
+
+


### PR DESCRIPTION
Currently it gives following: 

```
 ✗ json: insert value with ampersand
   (in test file json.bats, line 24)
     `[ "${lines[1]}" = '1,"{""a"": ""A&B""}"' ]' failed
   Successfully initialized dolt data repository.
   Query OK, 1 row affected (0.00 sec)
   pk,js
   1,"{""a"":""A\u0026B""}"
 ✗ json: insert array with ampersand
   (in test file json.bats, line 38)
     `[ "${lines[1]}" = '1,"[{""a"": ""A&B""}]"' ]' failed
   Successfully initialized dolt data repository.
   Query OK, 1 row affected (0.00 sec)
   pk,js
   1,"[{""a"":""A\u0026B""}]"
```