### PR TITLE
actually use prefix index

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -111,12 +111,12 @@ func TestSingleScript(t *testing.T) {
 	script := queries.ScriptTest{
 		Name: "DELETE ME",
 		SetUpScript: []string{
-			"create table t (i int primary key auto_increment, j int, v1 varchar(10), v2 varchar(20), v3 varchar(30), index(v(1)))",
-			"insert into t(v) values ('aa'), ('bb'), ('cc')",
+			"create table t (i int primary key auto_increment, v1 varchar(10), v2 varchar(20), v3 varchar(30), index(v1(1), v2(2), v3(3)))",
+			"insert into t values (0, 'a1', 'a2', 'a3')",
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
-				Query:    "select * from t where v = 'a'",
+				Query:    "select * from t where v1 = 'a1'",
 				Expected: []sql.Row{},
 			},
 		},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -108,55 +108,39 @@ func TestSingleQuery(t *testing.T) {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	script := queries.ScriptTest{
-		Name: "DELETE ME",
-		SetUpScript: []string{
-			"create table t (i int primary key auto_increment, v1 varchar(10), v2 varchar(20), v3 varchar(30), index(v1(1), v2(2), v3(3)))",
-			"insert into t values (0, 'a1', 'a2', 'a3')",
-		},
-		Assertions: []queries.ScriptTestAssertion{
-			{
-				Query:    "select * from t where v1 = 'a1'",
-				Expected: []sql.Row{},
+	t.Skip()
+	var scripts = []queries.ScriptTest{
+		{
+			Name: "trigger before update, with indexed update",
+			SetUpScript: []string{
+				"create table a (x int primary key, y int, unique key (y))",
+				"create table b (z int primary key)",
+				"insert into a values (1,3), (10,20)",
+				"create trigger insert_b before update on a for each row insert into b values (old.x * 10)",
+				"update a set x = x + 1 where y = 20",
+			},
+			Assertions: []queries.ScriptTestAssertion{
+				{
+					Query: "select x, y from a order by 1",
+					Expected: []sql.Row{
+						{1, 3},
+						{11, 20},
+					},
+				},
+				{
+					Query: "select z from b",
+					Expected: []sql.Row{
+						{100},
+					},
+				},
 			},
 		},
 	}
-	harness := newDoltHarness(t)
-	enginetest.TestScript(t, harness, script)
 
-	//t.Skip()
-	//var scripts = []queries.ScriptTest{
-	//	{
-	//		Name: "trigger before update, with indexed update",
-	//		SetUpScript: []string{
-	//			"create table a (x int primary key, y int, unique key (y))",
-	//			"create table b (z int primary key)",
-	//			"insert into a values (1,3), (10,20)",
-	//			"create trigger insert_b before update on a for each row insert into b values (old.x * 10)",
-	//			"update a set x = x + 1 where y = 20",
-	//		},
-	//		Assertions: []queries.ScriptTestAssertion{
-	//			{
-	//				Query: "select x, y from a order by 1",
-	//				Expected: []sql.Row{
-	//					{1, 3},
-	//					{11, 20},
-	//				},
-	//			},
-	//			{
-	//				Query: "select z from b",
-	//				Expected: []sql.Row{
-	//					{100},
-	//				},
-	//			},
-	//		},
-	//	},
-	//}
-	//
-	//harness := newDoltHarness(t)
-	//for _, test := range scripts {
-	//	enginetest.TestScript(t, harness, test)
-	//}
+	harness := newDoltHarness(t)
+	for _, test := range scripts {
+		enginetest.TestScript(t, harness, test)
+	}
 }
 
 func TestSingleQueryPrepared(t *testing.T) {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -108,39 +108,57 @@ func TestSingleQuery(t *testing.T) {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	t.Skip()
-	var scripts = []queries.ScriptTest{
-		{
-			Name: "trigger before update, with indexed update",
-			SetUpScript: []string{
-				"create table a (x int primary key, y int, unique key (y))",
-				"create table b (z int primary key)",
-				"insert into a values (1,3), (10,20)",
-				"create trigger insert_b before update on a for each row insert into b values (old.x * 10)",
-				"update a set x = x + 1 where y = 20",
-			},
-			Assertions: []queries.ScriptTestAssertion{
-				{
-					Query: "select x, y from a order by 1",
-					Expected: []sql.Row{
-						{1, 3},
-						{11, 20},
-					},
-				},
-				{
-					Query: "select z from b",
-					Expected: []sql.Row{
-						{100},
-					},
+	script := queries.ScriptTest{
+		Name: "DELETE ME",
+		SetUpScript: []string{
+			"create table t (i int primary key, v1 text, v2 text, unique index (v1(3),v2(5)))",
+			"insert into t values (0, 'a', 'a'), (1, 'ab','ab'), (2, 'abc', 'abc'), (3, 'abcde', 'abcde')",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "select * from t where v1 = 'a'",
+				Expected: []sql.Row{
+					{1, "ab", "ab"},
 				},
 			},
 		},
 	}
-
 	harness := newDoltHarness(t)
-	for _, test := range scripts {
-		enginetest.TestScript(t, harness, test)
-	}
+	enginetest.TestScript(t, harness, script)
+
+	//t.Skip()
+	//var scripts = []queries.ScriptTest{
+	//	{
+	//		Name: "trigger before update, with indexed update",
+	//		SetUpScript: []string{
+	//			"create table a (x int primary key, y int, unique key (y))",
+	//			"create table b (z int primary key)",
+	//			"insert into a values (1,3), (10,20)",
+	//			"create trigger insert_b before update on a for each row insert into b values (old.x * 10)",
+	//			"update a set x = x + 1 where y = 20",
+	//		},
+	//		Assertions: []queries.ScriptTestAssertion{
+	//			{
+	//				Query: "select x, y from a order by 1",
+	//				Expected: []sql.Row{
+	//					{1, 3},
+	//					{11, 20},
+	//				},
+	//			},
+	//			{
+	//				Query: "select z from b",
+	//				Expected: []sql.Row{
+	//					{100},
+	//				},
+	//			},
+	//		},
+	//	},
+	//}
+	//
+	//harness := newDoltHarness(t)
+	//for _, test := range scripts {
+	//	enginetest.TestScript(t, harness, test)
+	//}
 }
 
 func TestSingleQueryPrepared(t *testing.T) {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -108,39 +108,55 @@ func TestSingleQuery(t *testing.T) {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	t.Skip()
-	var scripts = []queries.ScriptTest{
-		{
-			Name: "trigger before update, with indexed update",
-			SetUpScript: []string{
-				"create table a (x int primary key, y int, unique key (y))",
-				"create table b (z int primary key)",
-				"insert into a values (1,3), (10,20)",
-				"create trigger insert_b before update on a for each row insert into b values (old.x * 10)",
-				"update a set x = x + 1 where y = 20",
-			},
-			Assertions: []queries.ScriptTestAssertion{
-				{
-					Query: "select x, y from a order by 1",
-					Expected: []sql.Row{
-						{1, 3},
-						{11, 20},
-					},
-				},
-				{
-					Query: "select z from b",
-					Expected: []sql.Row{
-						{100},
-					},
-				},
+	script := queries.ScriptTest{
+		Name: "DELETE ME",
+		SetUpScript: []string{
+			"create table t (i int primary key auto_increment, j int, v1 varchar(10), v2 varchar(20), v3 varchar(30), index(v(1)))",
+			"insert into t(v) values ('aa'), ('bb'), ('cc')",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "select * from t where v = 'a'",
+				Expected: []sql.Row{},
 			},
 		},
 	}
-
 	harness := newDoltHarness(t)
-	for _, test := range scripts {
-		enginetest.TestScript(t, harness, test)
-	}
+	enginetest.TestScript(t, harness, script)
+
+	//t.Skip()
+	//var scripts = []queries.ScriptTest{
+	//	{
+	//		Name: "trigger before update, with indexed update",
+	//		SetUpScript: []string{
+	//			"create table a (x int primary key, y int, unique key (y))",
+	//			"create table b (z int primary key)",
+	//			"insert into a values (1,3), (10,20)",
+	//			"create trigger insert_b before update on a for each row insert into b values (old.x * 10)",
+	//			"update a set x = x + 1 where y = 20",
+	//		},
+	//		Assertions: []queries.ScriptTestAssertion{
+	//			{
+	//				Query: "select x, y from a order by 1",
+	//				Expected: []sql.Row{
+	//					{1, 3},
+	//					{11, 20},
+	//				},
+	//			},
+	//			{
+	//				Query: "select z from b",
+	//				Expected: []sql.Row{
+	//					{100},
+	//				},
+	//			},
+	//		},
+	//	},
+	//}
+	//
+	//harness := newDoltHarness(t)
+	//for _, test := range scripts {
+	//	enginetest.TestScript(t, harness, test)
+	//}
 }
 
 func TestSingleQueryPrepared(t *testing.T) {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -8571,4 +8571,60 @@ var DoltIndexPrefixScripts = []queries.ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "inline secondary indexes",
+		SetUpScript: []string{
+			"create table t (i int primary key, v1 varchar(10), v2 varchar(10), unique index (v1(3),v2(5)))",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "show create table t",
+				Expected: []sql.Row{{"t", "CREATE TABLE `t` (\n  `i` int NOT NULL,\n  `v1` varchar(10),\n  `v2` varchar(10),\n  PRIMARY KEY (`i`),\n  UNIQUE KEY `v1v2` (`v1`(3),`v2`(5))\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+			},
+			{
+				Query:    "insert into t values (0, 'a', 'a'), (1, 'ab','ab'), (2, 'abc', 'abc'), (3, 'abcde', 'abcde')",
+				Expected: []sql.Row{{sql.NewOkResult(4)}},
+			},
+			{
+				Query:       "insert into t values (99, 'abc', 'abcde')",
+				ExpectedErr: sql.ErrUniqueKeyViolation,
+			},
+			{
+				Query:       "insert into t values (99, 'abc123', 'abcde123')",
+				ExpectedErr: sql.ErrUniqueKeyViolation,
+			},
+			{
+				Query: "select * from t where v1 = 'a'",
+				Expected: []sql.Row{
+					{0, "a", "a"},
+				},
+			},
+			{
+				Query: "explain select * from t where v1 = 'a'",
+				Expected: []sql.Row{
+					{"Filter(t.v1 = 'a')"},
+					{" └─ IndexedTableAccess(t)"},
+					{"     ├─ index: [t.v1,t.v2]"},
+					{"     ├─ filters: [{[a, a], [NULL, ∞)}]"},
+					{"     └─ columns: [i v1 v2]"},
+				},
+			},
+			{
+				Query: "select * from t where v1 = 'abc'",
+				Expected: []sql.Row{
+					{2, "abc", "abc"},
+				},
+			},
+			{
+				Query: "explain select * from t where v1 = 'abc'",
+				Expected: []sql.Row{
+					{"Filter(t.v1 = 'abc')"},
+					{" └─ IndexedTableAccess(t)"},
+					{"     ├─ index: [t.v1,t.v2]"},
+					{"     ├─ filters: [{[abc, abc], [NULL, ∞)}]"},
+					{"     └─ columns: [i v1 v2]"},
+				},
+			},
+		},
+	},
 }

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -8715,39 +8715,39 @@ var DoltIndexPrefixScripts = []queries.ScriptTest{
 				},
 			},
 			// TODO: these are broken, figure out why
-			//{
-			//	Query: "select * from t where v1 > 'a' and v1 < 'abcde'",
-			//	Expected: []sql.Row{
-			//		{1, "ab", "ab"},
-			//	},
-			//},
-			//{
-			//	Query: "explain select * from t where v1 > 'a' and v1 < 'abcde'",
-			//	Expected: []sql.Row{
-			//		{"Filter((t.v1 > 'a') AND (t.v1 < 'abcde'))"},
-			//		{" └─ IndexedTableAccess(t)"},
-			//		{"     ├─ index: [t.v1,t.v2]"},
-			//		{"     ├─ filters: [{(a, abcde), [NULL, ∞)}]"},
-			//		{"     └─ columns: [i v1 v2]"},
-			//	},
-			//},
-			//{
-			//	Query: "select * from t where v1 > 'a' and v2 < 'abcde'",
-			//	Expected: []sql.Row{
-			//		{1, "ab", "ab"},
-			//		{2, "abc", "abc"},
-			//	},
-			//},
-			//{
-			//	Query: "explain select * from t where v1 > 'a' and v2 < 'abcde'",
-			//	Expected: []sql.Row{
-			//		{"Filter((t.v1 > 'a') AND (t.v2 < 'abcde'))"},
-			//		{" └─ IndexedTableAccess(t)"},
-			//		{"     ├─ index: [t.v1,t.v2]"},
-			//		{"     ├─ filters: [{(a, ∞), (NULL, abcde)}]"},
-			//		{"     └─ columns: [i v1 v2]"},
-			//	},
-			//},
+			{
+				Query: "select * from t where v1 > 'a' and v1 < 'abcde'",
+				Expected: []sql.Row{
+					{1, "ab", "ab"},
+				},
+			},
+			{
+				Query: "explain select * from t where v1 > 'a' and v1 < 'abcde'",
+				Expected: []sql.Row{
+					{"Filter((t.v1 > 'a') AND (t.v1 < 'abcde'))"},
+					{" └─ IndexedTableAccess(t)"},
+					{"     ├─ index: [t.v1,t.v2]"},
+					{"     ├─ filters: [{(a, abcde), [NULL, ∞)}]"},
+					{"     └─ columns: [i v1 v2]"},
+				},
+			},
+			{
+				Query: "select * from t where v1 > 'a' and v2 < 'abcde'",
+				Expected: []sql.Row{
+					{1, "ab", "ab"},
+					{2, "abc", "abc"},
+				},
+			},
+			{
+				Query: "explain select * from t where v1 > 'a' and v2 < 'abcde'",
+				Expected: []sql.Row{
+					{"Filter((t.v1 > 'a') AND (t.v2 < 'abcde'))"},
+					{" └─ IndexedTableAccess(t)"},
+					{"     ├─ index: [t.v1,t.v2]"},
+					{"     ├─ filters: [{(a, ∞), (NULL, abcde)}]"},
+					{"     └─ columns: [i v1 v2]"},
+				},
+			},
 		},
 	},
 }

--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -395,9 +395,6 @@ var _ DoltIndex = (*doltIndex)(nil)
 
 // CanSupport implements sql.Index
 func (di *doltIndex) CanSupport(...sql.Range) bool {
-	if len(di.prefixLengths) > 0 {
-		return false
-	}
 	return true
 }
 
@@ -798,6 +795,10 @@ func (di *doltIndex) prollyRangesFromSqlRanges(ctx context.Context, ns tree.Node
 				if err != nil {
 					return nil, err
 				}
+				// TODO (james): something with prefixLengths here!!!
+				// TODO (james): how do I know that this column is using this prefixLength? is it in order?
+				// TODO (james): just trim here I guess
+
 				if err = PutField(ctx, ns, tb, j, v); err != nil {
 					return nil, err
 				}

--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -866,6 +866,7 @@ func (di *doltIndex) prollyRangesFromSqlRanges(ctx context.Context, ns tree.Node
 				fields[i].Exact = false
 				continue
 			}
+			// TODO: text and blob just compare hashes, need to dereference and compare prefixes?
 			typ := di.keyBld.Desc.Types[i]
 			cmp := order.CompareValues(i, field.Hi.Value, field.Lo.Value, typ)
 			fields[i].Exact = cmp == 0

--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -773,6 +773,30 @@ func pruneEmptyRanges(sqlRanges []sql.Range) (pruned []sql.Range, err error) {
 	return pruned, nil
 }
 
+// trimRangeCutValue will trim the key value retrieved, depending on its type and prefix length
+// TODO: this is just the trimKeyPart in the SecondaryIndexWriters, maybe find a different place
+func (di *doltIndex) trimRangeCutValue(to int, keyPart interface{}) interface{} {
+	var prefixLength uint16
+	if len(di.prefixLengths) > to {
+		prefixLength = di.prefixLengths[to]
+	}
+	if prefixLength != 0 {
+		switch kp := keyPart.(type) {
+		case string:
+			if prefixLength > uint16(len(kp)) {
+				prefixLength = uint16(len(kp))
+			}
+			keyPart = kp[:prefixLength]
+		case []uint8:
+			if prefixLength > uint16(len(kp)) {
+				prefixLength = uint16(len(kp))
+			}
+			keyPart = kp[:prefixLength]
+		}
+	}
+	return keyPart
+}
+
 func (di *doltIndex) prollyRangesFromSqlRanges(ctx context.Context, ns tree.NodeStore, ranges []sql.Range, tb *val.TupleBuilder) ([]prolly.Range, error) {
 	ranges, err := pruneEmptyRanges(ranges)
 	if err != nil {
@@ -795,24 +819,8 @@ func (di *doltIndex) prollyRangesFromSqlRanges(ctx context.Context, ns tree.Node
 				if err != nil {
 					return nil, err
 				}
-				// TODO (james): how do I know which range corresponds to the right one that uses prefix lengths?
-				// TODO (james): just trim here I guess
-				prefixLength := di.prefixLengths[j] // TODO: j? k?
-				if prefixLength != 0 {
-					switch vp := v.(type) {
-					case string:
-						if prefixLength > uint16(len(vp)) {
-							prefixLength = uint16(len(vp))
-						}
-						v = vp[:prefixLength]
-					case []uint8:
-						if prefixLength > uint16(len(vp)) {
-							prefixLength = uint16(len(vp))
-						}
-						v = vp[:prefixLength]
-					}
-				}
-
+				// TODO (james): how do I know which range corresponds to the right one that uses prefix lengths? just guess for now
+				v = di.trimRangeCutValue(j, v) // TODO: j? k?
 				if err = PutField(ctx, ns, tb, j, v); err != nil {
 					return nil, err
 				}

--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -868,6 +868,14 @@ func (di *doltIndex) prollyRangesFromSqlRanges(ctx context.Context, ns tree.Node
 			}
 			// TODO: text and blob just compare hashes, need to dereference and compare prefixes?
 			typ := di.keyBld.Desc.Types[i]
+			if di.prefixLengths[i] > 0 && typ.Enc == val.StringAddrEnc {
+				v, err := GetField(ctx, di.keyBld.Desc, i, tup, ns)
+				if err != nil {
+					panic(err)
+				}
+				v = v
+			}
+
 			cmp := order.CompareValues(i, field.Hi.Value, field.Lo.Value, typ)
 			fields[i].Exact = cmp == 0
 		}

--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -846,6 +846,7 @@ func (di *doltIndex) prollyRangesFromSqlRanges(ctx context.Context, ns tree.Node
 				if err != nil {
 					return nil, err
 				}
+				v = di.trimRangeCutValue(i, v) // TODO: i? k?
 				if err = PutField(ctx, ns, tb, i, v); err != nil {
 					return nil, err
 				}

--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -795,9 +795,23 @@ func (di *doltIndex) prollyRangesFromSqlRanges(ctx context.Context, ns tree.Node
 				if err != nil {
 					return nil, err
 				}
-				// TODO (james): something with prefixLengths here!!!
-				// TODO (james): how do I know that this column is using this prefixLength? is it in order?
+				// TODO (james): how do I know which range corresponds to the right one that uses prefix lengths?
 				// TODO (james): just trim here I guess
+				prefixLength := di.prefixLengths[j] // TODO: j? k?
+				if prefixLength != 0 {
+					switch vp := v.(type) {
+					case string:
+						if prefixLength > uint16(len(vp)) {
+							prefixLength = uint16(len(vp))
+						}
+						v = vp[:prefixLength]
+					case []uint8:
+						if prefixLength > uint16(len(vp)) {
+							prefixLength = uint16(len(vp))
+						}
+						v = vp[:prefixLength]
+					}
+				}
 
 				if err = PutField(ctx, ns, tb, j, v); err != nil {
 					return nil, err

--- a/go/libraries/doltcore/sqle/writer/prolly_index_writer.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_index_writer.go
@@ -293,8 +293,14 @@ func (m prollySecondaryIndexWriter) trimKeyPart(to int, keyPart interface{}) int
 	if prefixLength != 0 {
 		switch kp := keyPart.(type) {
 		case string:
+			if prefixLength > uint16(len(kp)) {
+				prefixLength = uint16(len(kp))
+			}
 			keyPart = kp[:prefixLength]
 		case []uint8:
+			if prefixLength > uint16(len(kp)) {
+				prefixLength = uint16(len(kp))
+			}
 			keyPart = kp[:prefixLength]
 		}
 	}

--- a/go/store/val/tuple_compare.go
+++ b/go/store/val/tuple_compare.go
@@ -142,6 +142,7 @@ func compare(typ Type, left, right []byte) int {
 	case JSONAddrEnc:
 		return compareAddr(readAddr(left), readAddr(right))
 	case StringAddrEnc:
+		// TODO (james): dereference here?
 		return compareAddr(readAddr(left), readAddr(right))
 	default:
 		panic("unknown encoding")


### PR DESCRIPTION
This PR makes it so prefix indexes can be taken advantage of in queries where the filter is pusheddown.
I don't think I needed to add any special code to split the filter into two (one for range over prefix, another for actual equality), as the way look ups work in dolt it already kinda does that.


Also, fixes a panic for strings that are shorter than prefix length (maybe worth moving that into a different PR).

TODO:
 - range for referenced strings not working correctly, need to dereference the text/blob and compare the actual values instead of their hash

fix for: https://github.com/dolthub/dolt/issues/3974