### PR TITLE
fix DOLT_ROOT_PATH bug

### DIFF
--- a/go/libraries/doltcore/env/actions/clone.go
+++ b/go/libraries/doltcore/env/actions/clone.go
@@ -39,7 +39,6 @@ import (
 )
 
 var ErrRepositoryExists = errors.New("data repository already exists")
-var ErrFailedToInitRepo = errors.New("")
 var ErrFailedToCreateDirectory = errors.New("unable to create directories")
 var ErrFailedToAccessDir = errors.New("unable to access directories")
 var ErrFailedToCreateRepoStateWithRemote = errors.New("unable to create repo state with remote")
@@ -76,7 +75,7 @@ func EnvForClone(ctx context.Context, nbf *types.NomsBinFormat, r env.Remote, di
 	dEnv := env.Load(ctx, homeProvider, newFs, doltdb.LocalDirDoltDB, version)
 	err = dEnv.InitRepoWithNoData(ctx, nbf)
 	if err != nil {
-		return nil, fmt.Errorf("%w; %s", ErrFailedToInitRepo, err.Error())
+		return nil, fmt.Errorf("failed to init repo: %w", err)
 	}
 
 	dEnv.RSLoadErr = nil
@@ -280,7 +279,7 @@ func InitEmptyClonedRepo(ctx context.Context, dEnv *env.DoltEnv) error {
 
 	err := dEnv.InitDBWithTime(ctx, types.Format_Default, name, email, initBranch, datas.CommitNowFunc())
 	if err != nil {
-		return ErrFailedToInitRepo
+		return fmt.Errorf("failed to init repo: %w", err)
 	}
 
 	return nil

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -59,7 +59,6 @@ const (
 
 var zeroHashStr = (hash.Hash{}).String()
 
-var ErrPreexistingDoltDir = errors.New(".dolt dir already exists")
 var ErrStateUpdate = errors.New("error updating local data repo state")
 var ErrMarshallingSchema = errors.New("error marshalling schema")
 var ErrInvalidCredsFile = errors.New("invalid creds file")
@@ -389,7 +388,7 @@ func (dEnv *DoltEnv) createDirectories(dir string) (string, error) {
 	}
 
 	if dEnv.hasDoltDir(dir) {
-		return "", ErrPreexistingDoltDir
+		return "", fmt.Errorf(".dolt directory already exists at '%s'", dir)
 	}
 
 	absDataDir := filepath.Join(absPath, dbfactory.DoltDataDir)

--- a/go/libraries/doltcore/env/paths.go
+++ b/go/libraries/doltcore/env/paths.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
+	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 )
 
 const (
@@ -42,7 +43,7 @@ type HomeDirProvider func() (string, error)
 // provide a different directory where the root .dolt directory should be located and global state will be stored there.
 func GetCurrentUserHomeDir() (string, error) {
 	if doltRootPath, ok := os.LookupEnv(doltRootPathEnvVar); ok && doltRootPath != "" {
-		return doltRootPath, nil
+		return filesys.LocalFS.Abs(doltRootPath)
 	}
 
 	var home string


### PR DESCRIPTION
Currently there is an issue where if you run something like:

```DOLT_ROOT_PATH=. dolt backup restore <remote> subfolder/reponame```

This fixes that by returning the absolute path.