### PR TITLE
fix merge --no-ff --no-commit

### DIFF
--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -321,9 +321,8 @@ func getCommitMessageFromEditor(ctx context.Context, dEnv *env.DoltEnv, suggeste
 		finalMsg = parseCommitMessage(commitMsg)
 	})
 
-	// if editor could not be opened or the message received is empty, use auto-generated/suggested msg.
-	if err != nil || finalMsg == "" {
-		return suggestedMsg, nil
+	if err != nil {
+		return "", err
 	}
 
 	return finalMsg, nil

--- a/go/cmd/dolt/commands/merge.go
+++ b/go/cmd/dolt/commands/merge.go
@@ -222,6 +222,7 @@ func validateMergeSpec(ctx context.Context, spec *merge.MergeSpec) errhand.Verbo
 		return nil
 
 	}
+	cli.Println("Updating", spec.HeadH.String()+".."+spec.MergeH.String())
 
 	if spec.Squash {
 		cli.Println("Squash commit -- not updating HEAD")
@@ -470,8 +471,6 @@ func performMerge(ctx context.Context, dEnv *env.DoltEnv, spec *merge.MergeSpec,
 		if spec.Noff {
 			return executeNoFFMergeAndCommit(ctx, dEnv, spec, suggestedMsg)
 		}
-
-		cli.Println("Updating", spec.HeadH.String()+".."+spec.MergeH.String())
 		return nil, merge.ExecuteFFMerge(ctx, dEnv, spec)
 	}
 	return executeMergeAndCommit(ctx, dEnv, spec, suggestedMsg)

--- a/go/cmd/dolt/commands/merge.go
+++ b/go/cmd/dolt/commands/merge.go
@@ -159,9 +159,9 @@ func (cmd MergeCmd) Exec(ctx context.Context, commandStr string, args []string, 
 			}
 
 			suggestedMsg := fmt.Sprintf("Merge branch '%s' into %s", commitSpecStr, dEnv.RepoStateReader().CWBHeadRef().GetPath())
-			msg, err := getCommitMessage(ctx, apr, dEnv, suggestedMsg)
-			if err != nil {
-				return handleCommitErr(ctx, dEnv, err, usage)
+			msg := ""
+			if m, ok := apr.GetValue(cli.MessageArg); ok {
+				msg = m
 			}
 
 			if apr.Contains(cli.NoCommitFlag) && apr.Contains(cli.CommitFlag) {
@@ -214,25 +214,6 @@ func getUnmergedTableCount(ctx context.Context, root *doltdb.RootValue) (int, er
 	return unmergedTableCount, nil
 }
 
-// getCommitMessage returns commit message depending on whether user defined commit message and/or no-ff flag.
-// If user defined message, it will use that. If not, and no-ff flag is defined, it will ask user for commit message from editor.
-// If none of commit message or no-ff flag is defined, it will return suggested message.
-func getCommitMessage(ctx context.Context, apr *argparser.ArgParseResults, dEnv *env.DoltEnv, suggestedMsg string) (string, errhand.VerboseError) {
-	if m, ok := apr.GetValue(cli.MessageArg); ok {
-		return m, nil
-	}
-
-	if apr.Contains(cli.NoFFParam) {
-		msg, err := getCommitMessageFromEditor(ctx, dEnv, suggestedMsg, "", apr.Contains(cli.NoEditFlag))
-		if err != nil {
-			return "", errhand.VerboseErrorFromError(err)
-		}
-		return msg, nil
-	}
-
-	return "", nil
-}
-
 func validateMergeSpec(ctx context.Context, spec *merge.MergeSpec) errhand.VerboseError {
 	if spec.HeadH == spec.MergeH {
 		//TODO - why is this different for merge/pull?
@@ -241,7 +222,6 @@ func validateMergeSpec(ctx context.Context, spec *merge.MergeSpec) errhand.Verbo
 		return nil
 
 	}
-	cli.Println("Updating", spec.HeadH.String()+".."+spec.MergeH.String())
 
 	if spec.Squash {
 		cli.Println("Squash commit -- not updating HEAD")
@@ -484,38 +464,119 @@ func handleMergeErr(ctx context.Context, dEnv *env.DoltEnv, mergeErr error, hasC
 // FF merges will not surface constraint violations on their own; constraint verify --all
 // is required to reify violations.
 func performMerge(ctx context.Context, dEnv *env.DoltEnv, spec *merge.MergeSpec, suggestedMsg string) (map[string]*merge.MergeStats, error) {
-	var tblStats map[string]*merge.MergeStats
 	if ok, err := spec.HeadC.CanFastForwardTo(ctx, spec.MergeC); err != nil && !errors.Is(err, doltdb.ErrUpToDate) {
 		return nil, err
 	} else if ok {
 		if spec.Noff {
-			tblStats, err = merge.ExecNoFFMerge(ctx, dEnv, spec)
-			return tblStats, err
+			return executeNoFFMergeAndCommit(ctx, dEnv, spec, suggestedMsg)
 		}
+
+		cli.Println("Updating", spec.HeadH.String()+".."+spec.MergeH.String())
 		return nil, merge.ExecuteFFMerge(ctx, dEnv, spec)
 	}
-	tblStats, err := merge.ExecuteMerge(ctx, dEnv, spec)
+	return executeMergeAndCommit(ctx, dEnv, spec, suggestedMsg)
+}
+
+func executeNoFFMergeAndCommit(ctx context.Context, dEnv *env.DoltEnv, spec *merge.MergeSpec, suggestedMsg string) (map[string]*merge.MergeStats, error) {
+	tblToStats, err := merge.ExecNoFFMerge(ctx, dEnv, spec)
 	if err != nil {
-		return tblStats, err
+		return tblToStats, err
 	}
 
-	if !spec.NoCommit && !hasConflictOrViolations(tblStats) {
-		msg := spec.Msg
-		if spec.Msg == "" {
-			msg, err = getCommitMessageFromEditor(ctx, dEnv, suggestedMsg, "", spec.NoEdit)
-			if err != nil {
-				return nil, err
-			}
-		}
-		author := fmt.Sprintf("%s <%s>", spec.Name, spec.Email)
-
-		res := performCommit(ctx, "commit", []string{"-m", msg, "--author", author}, dEnv)
-		if res != 0 {
-			return nil, fmt.Errorf("dolt commit failed after merging")
-		}
+	if spec.NoCommit {
+		cli.Println("Automatic merge went well; stopped before committing as requested")
+		return tblToStats, nil
 	}
 
-	return tblStats, nil
+	// Reload roots since the above method writes new values to the working set
+	roots, err := dEnv.Roots(ctx)
+	if err != nil {
+		return tblToStats, err
+	}
+
+	ws, err := dEnv.WorkingSet(ctx)
+	if err != nil {
+		return tblToStats, err
+	}
+
+	var mergeParentCommits []*doltdb.Commit
+	if ws.MergeActive() {
+		mergeParentCommits = []*doltdb.Commit{ws.MergeState().Commit()}
+	}
+
+	msg, err := getCommitMsgForMerge(ctx, dEnv, spec.Msg, suggestedMsg, spec.NoEdit)
+	if err != nil {
+		return tblToStats, err
+	}
+
+	_, err = actions.CommitStaged(ctx, roots, ws.MergeActive(), mergeParentCommits, dEnv.DbData(), actions.CommitStagedProps{
+		Message:    msg,
+		Date:       spec.Date,
+		AllowEmpty: spec.AllowEmpty,
+		Force:      spec.Force,
+		Name:       spec.Name,
+		Email:      spec.Email,
+	})
+
+	if err != nil {
+		return tblToStats, fmt.Errorf("%w; failed to commit", err)
+	}
+
+	err = dEnv.ClearMerge(ctx)
+	if err != nil {
+		return tblToStats, err
+	}
+
+	return tblToStats, err
+}
+
+func executeMergeAndCommit(ctx context.Context, dEnv *env.DoltEnv, spec *merge.MergeSpec, suggestedMsg string) (map[string]*merge.MergeStats, error) {
+	tblToStats, err := merge.ExecuteMerge(ctx, dEnv, spec)
+	if err != nil {
+		return tblToStats, err
+	}
+
+	if hasConflictOrViolations(tblToStats) {
+		return tblToStats, nil
+	}
+
+	if spec.NoCommit {
+		cli.Println("Automatic merge went well; stopped before committing as requested")
+		return tblToStats, nil
+	}
+
+	msg, err := getCommitMsgForMerge(ctx, dEnv, spec.Msg, suggestedMsg, spec.NoEdit)
+	if err != nil {
+		return tblToStats, err
+	}
+
+	author := fmt.Sprintf("%s <%s>", spec.Name, spec.Email)
+
+	res := performCommit(ctx, "commit", []string{"-m", msg, "--author", author}, dEnv)
+	if res != 0 {
+		return nil, fmt.Errorf("dolt commit failed after merging")
+	}
+
+	return tblToStats, nil
+}
+
+// getCommitMsgForMerge returns user defined message if exists; otherwise, get the commit message from editor.
+func getCommitMsgForMerge(ctx context.Context, dEnv *env.DoltEnv, userDefinedMsg, suggestedMsg string, noEdit bool) (string, error) {
+	if userDefinedMsg != "" {
+		return userDefinedMsg, nil
+	}
+
+	msg, err := getCommitMessageFromEditor(ctx, dEnv, suggestedMsg, "", noEdit)
+	if err != nil {
+		return msg, err
+	}
+
+	if msg == "" {
+		return msg, fmt.Errorf("error: Empty commit message.\n" +
+			"Not committing merge; use 'dolt commit' to complete the merge.")
+	}
+
+	return msg, nil
 }
 
 // hasConflictOrViolations checks for conflicts or constraint violation regardless of a table being modified

--- a/go/libraries/doltcore/merge/action.go
+++ b/go/libraries/doltcore/merge/action.go
@@ -124,44 +124,6 @@ func ExecNoFFMerge(ctx context.Context, dEnv *env.DoltEnv, spec *MergeSpec) (map
 	tblToStats := make(map[string]*MergeStats)
 	err = mergedRootToWorking(ctx, false, dEnv, mergedRoot, spec.WorkingDiffs, spec.MergeC, spec.MergeCSpecStr, tblToStats)
 
-	if err != nil {
-		return tblToStats, err
-	}
-
-	// Reload roots since the above method writes new values to the working set
-	roots, err := dEnv.Roots(ctx)
-	if err != nil {
-		return tblToStats, err
-	}
-
-	ws, err := dEnv.WorkingSet(ctx)
-	if err != nil {
-		return tblToStats, err
-	}
-
-	var mergeParentCommits []*doltdb.Commit
-	if ws.MergeActive() {
-		mergeParentCommits = []*doltdb.Commit{ws.MergeState().Commit()}
-	}
-
-	_, err = actions.CommitStaged(ctx, roots, ws.MergeActive(), mergeParentCommits, dEnv.DbData(), actions.CommitStagedProps{
-		Message:    spec.Msg,
-		Date:       spec.Date,
-		AllowEmpty: spec.AllowEmpty,
-		Force:      spec.Force,
-		Name:       spec.Name,
-		Email:      spec.Email,
-	})
-
-	if err != nil {
-		return tblToStats, fmt.Errorf("%w; failed to commit", err)
-	}
-
-	err = dEnv.ClearMerge(ctx)
-	if err != nil {
-		return tblToStats, err
-	}
-
 	return tblToStats, err
 }
 


### PR DESCRIPTION
If the editor process is killed or the editor was saved with empty message, it gives error.
Fixes `dolt merge --no-ff --no-commit`, now it does not fast-forward and commit. It leaves the working set with changes.