### PR TITLE
Fix a panic that occurs when grpc stream Recv() method returns an err…

### DIFF
--- a/go/libraries/doltcore/remotestorage/chunk_store.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store.go
@@ -600,7 +600,11 @@ func (dcs *DoltChunkStore) getDLLocs(ctx context.Context, hashes []hash.Hash) (d
 						if err == io.EOF {
 							return nil
 						}
-						return NewRpcError(err, "StreamDownloadLocations", dcs.host, reqs[completedReqs])
+						var r *remotesapi.GetDownloadLocsRequest
+						if completedReqs < len(reqs) {
+							r = reqs[completedReqs]
+						}
+						return NewRpcError(err, "StreamDownloadLocations", dcs.host, r)
 					}
 					if resp.RepoToken != "" {
 						dcs.repoToken.Store(resp.RepoToken)


### PR DESCRIPTION
…or before stream is closed

Stack trace from dolthubapi-asyncworker:
```
...
2022-11-11T20:01:12.919Z	ERROR	process/process.go:273	finished unary call with code Unknown	{"grpc.start_time": "2022-11-11T20:01:12Z", "grpc.request.deadline": "2022-11-11T20:11:12Z", "system": "grpc", "span.kind": "server", "grpc.service": "ld.services.dolthubapi.internal.v1alpha1.BountyService", "grpc.method": "ProcessMergeCommit", "request_id": "b947de69-f3d8-4b05-8d09-38cb2c11c326", "invocation_id": "01d9a1a2-0cc3-4619-b919-42a666a257d0", "error": "pq: duplicate key value violates unique constraint \"scoreboard_build_shards_pkey\"", "grpc.code": "Unknown", "grpc.time_ms": 102.431}
2022-11-11T20:01:12.920Z	INFO	request_logging/request_logging.go:21	beginning unary call	{"grpc.start_time": "2022-11-11T20:01:12Z", "grpc.request.deadline": "2022-11-11T20:01:13Z", "system": "grpc", "span.kind": "server", "grpc.service": "grpc.health.v1.Health", "grpc.method": "Check", "invocation_id": "a149d64f-e063-4f7b-ae40-a304bf86f50e"}
2022-11-11T20:01:12.920Z	INFO	process/process.go:273	finished unary call with code OK	{"grpc.start_time": "2022-11-11T20:01:12Z", "grpc.request.deadline": "2022-11-11T20:01:13Z", "system": "grpc", "span.kind": "server", "grpc.service": "grpc.health.v1.Health", "grpc.method": "Check", "invocation_id": "a149d64f-e063-4f7b-ae40-a304bf86f50e", "grpc.code": "OK", "grpc.time_ms": 0.124}
2022-11-11T20:01:12.922Z	INFO	zap/grpclogger.go:73	[transport]transport: loopyWriter.run returning. connection error: desc = "transport is closing"	{"system": "grpc", "grpc_log": true}
panic: runtime error: index out of range [1] with length 1

goroutine 2252120 [running]:
github.com/dolthub/dolt/go/libraries/doltcore/remotestorage.(*DoltChunkStore).getDLLocs.func2.2.2()
	external/com_github_dolthub_dolt_go/libraries/doltcore/remotestorage/chunk_store.go:603 +0x269
golang.org/x/sync/errgroup.(*Group).Go.func1()
	external/org_golang_x_sync/errgroup/errgroup.go:75 +0x64
created by golang.org/x/sync/errgroup.(*Group).Go
	external/org_golang_x_sync/errgroup/errgroup.go:72 +0xa5
```