### PR TITLE
Fix missing projection on indexed table

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -1465,6 +1465,28 @@ var HistorySystemTableScriptTests = []queries.ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "dolt_history table index lookup",
+		SetUpScript: []string{
+			"create table yx (y int, x int primary key);",
+			"call dolt_add('.');",
+			"call dolt_commit('-m', 'creating table');",
+			"insert into yx values (0, 1);",
+			"call dolt_commit('-am', 'add data');",
+			"insert into yx values (2, 3);",
+			"call dolt_commit('-am', 'add data');",
+			"insert into yx values (4, 5);",
+			"call dolt_commit('-am', 'add data');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "select count(x) from dolt_history_yx where x = 1;",
+				Expected: []sql.Row{
+					{3},
+				},
+			},
+		},
+	},
 }
 
 // BrokenHistorySystemTableScriptTests contains tests that work for non-prepared, but don't work

--- a/go/libraries/doltcore/sqle/indexed_dolt_table.go
+++ b/go/libraries/doltcore/sqle/indexed_dolt_table.go
@@ -81,7 +81,7 @@ func (idt *IndexedDoltTable) PartitionRows(ctx *sql.Context, part sql.Partition)
 		return nil, err
 	}
 	if idt.lb == nil || !canCache || idt.lb.Key() != key {
-		idt.lb, err = index.NewLookupBuilder(ctx, idt.table, idt.idx, key, nil, idt.table.sqlSch, idt.isDoltFormat)
+		idt.lb, err = index.NewLookupBuilder(ctx, idt.table, idt.idx, key, idt.table.projectedCols, idt.table.sqlSch, idt.isDoltFormat)
 		if err != nil {
 			return nil, err
 		}
@@ -98,7 +98,7 @@ func (idt *IndexedDoltTable) PartitionRows2(ctx *sql.Context, part sql.Partition
 		return nil, err
 	}
 	if idt.lb == nil || !canCache || idt.lb.Key() != key {
-		idt.lb, err = index.NewLookupBuilder(ctx, idt.table, idt.idx, key, nil, idt.table.sqlSch, idt.isDoltFormat)
+		idt.lb, err = index.NewLookupBuilder(ctx, idt.table, idt.idx, key, idt.table.projectedCols, idt.table.sqlSch, idt.isDoltFormat)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This error only applies to `DoltIndexedTable`, which as far as I can tell is limited to the history tables.