### PR TITLE
go/store/nbs: first pass at journaling chunk store

### DIFF
--- a/go/performance/scripts/local_sysbench.sh
+++ b/go/performance/scripts/local_sysbench.sh
@@ -35,6 +35,9 @@ do
         --row2) export ENABLE_ROW_ITER_2=true
             ;;
 
+        --journal) export DOLT_ENABLE_CHUNK_JOURNAL=true
+            ;;
+
         # specify sysbench benchmark
         *) SYSBENCH_TEST="$1"
             ;;
@@ -123,6 +126,7 @@ sysbench \
   --db-ps-mode=disable \
   "$SYSBENCH_TEST" run
 
+unset DOLT_ENABLE_CHUNK_JOURNAL
 unset DOLT_DEFAULT_BIN_FORMAT
 unset ENABLE_ROW_ITER_2
 unset SINGLE_THREAD_FEATURE_FLAG

--- a/go/store/nbs/aws_table_persister.go
+++ b/go/store/nbs/aws_table_persister.go
@@ -575,3 +575,7 @@ func (s3p awsTablePersister) uploadPart(ctx context.Context, data []byte, key, u
 func (s3p awsTablePersister) PruneTableFiles(ctx context.Context, contents manifestContents) error {
 	return chunks.ErrUnsupportedOperation
 }
+
+func (s3p awsTablePersister) Close() error {
+	return nil
+}

--- a/go/store/nbs/block_store_test.go
+++ b/go/store/nbs/block_store_test.go
@@ -46,21 +46,33 @@ import (
 const testMemTableSize = 1 << 8
 
 func TestBlockStoreSuite(t *testing.T) {
-	suite.Run(t, &BlockStoreSuite{})
+	fn := func(ctx context.Context, dir string) (*NomsBlockStore, error) {
+		nbf := constants.FormatDefaultString
+		qp := NewUnlimitedMemQuotaProvider()
+		return NewLocalStore(ctx, nbf, dir, testMemTableSize, qp)
+	}
+	suite.Run(t, &BlockStoreSuite{factory: fn})
 }
 
 type BlockStoreSuite struct {
 	suite.Suite
 	dir        string
 	store      *NomsBlockStore
+	factory    nbsFactory
 	putCountFn func() int
+
+	// if true, skip interloper tests
+	skipInterloper bool
 }
+
+type nbsFactory func(ctx context.Context, dir string) (*NomsBlockStore, error)
 
 func (suite *BlockStoreSuite) SetupTest() {
 	var err error
 	suite.dir, err = os.MkdirTemp("", "")
 	suite.NoError(err)
-	suite.store, err = NewLocalStore(context.Background(), constants.FormatDefaultString, suite.dir, testMemTableSize, NewUnlimitedMemQuotaProvider())
+	ctx := context.Background()
+	suite.store, err = suite.factory(ctx, suite.dir)
 	suite.NoError(err)
 	suite.putCountFn = func() int {
 		return int(suite.store.putCount)
@@ -271,6 +283,9 @@ func (suite *BlockStoreSuite) TestChunkStoreHasMany() {
 }
 
 func (suite *BlockStoreSuite) TestChunkStoreFlushOptimisticLockFail() {
+	if suite.skipInterloper {
+		suite.T().Skip()
+	}
 	input1, input2 := []byte("abc"), []byte("def")
 	c1, c2 := chunks.NewChunk(input1), chunks.NewChunk(input2)
 	root, err := suite.store.Root(context.Background())
@@ -319,6 +334,9 @@ func (suite *BlockStoreSuite) TestChunkStoreFlushOptimisticLockFail() {
 }
 
 func (suite *BlockStoreSuite) TestChunkStoreRebaseOnNoOpFlush() {
+	if suite.skipInterloper {
+		suite.T().Skip()
+	}
 	input1 := []byte("abc")
 	c1 := chunks.NewChunk(input1)
 
@@ -353,6 +371,9 @@ func (suite *BlockStoreSuite) TestChunkStoreRebaseOnNoOpFlush() {
 }
 
 func (suite *BlockStoreSuite) TestChunkStorePutWithRebase() {
+	if suite.skipInterloper {
+		suite.T().Skip()
+	}
 	input1, input2 := []byte("abc"), []byte("def")
 	c1, c2 := chunks.NewChunk(input1), chunks.NewChunk(input2)
 	root, err := suite.store.Root(context.Background())

--- a/go/store/nbs/bs_persister.go
+++ b/go/store/nbs/bs_persister.go
@@ -126,3 +126,7 @@ func newBSChunkSource(ctx context.Context, bs blobstore.Blobstore, name addr, ch
 func (bsp *blobstorePersister) PruneTableFiles(ctx context.Context, contents manifestContents) error {
 	return chunks.ErrUnsupportedOperation
 }
+
+func (bsp *blobstorePersister) Close() error {
+	return nil
+}

--- a/go/store/nbs/chunk_journal.go
+++ b/go/store/nbs/chunk_journal.go
@@ -11,13 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// This file incorporates work covered by the following copyright and
-// permission notice:
-//
-// Copyright 2016 Attic Labs, Inc. All rights reserved.
-// Licensed under the Apache License, version 2.0:
-// http://www.apache.org/licenses/LICENSE-2.0
 
 package nbs
 

--- a/go/store/nbs/chunk_journal.go
+++ b/go/store/nbs/chunk_journal.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/d"
 	"github.com/dolthub/dolt/go/store/hash"
 )
 
@@ -42,9 +43,10 @@ func init() {
 }
 
 const (
-	chunkJournalName = "nbs_chunk_journal"
-	chunkJournalAddr = "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv"
-	chunkJournalSize = 256 * 1024 * 1024
+	chunkJournalName      = "nbs_chunk_journal"
+	chunkJournalAddr      = "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv"
+	chunkJournalFileSize  = 256 * 1024 * 1024
+	journalWriterBuffSize = 1024 * 1024
 )
 
 var (
@@ -54,9 +56,7 @@ var (
 )
 
 type chunkJournal struct {
-	journal *os.File
-	offset  int64
-	dir     string
+	journal *journalWriter
 
 	// todo(andy): on graceful shutdown, we need to
 	//  flush |manifest| and |rootHash| to |backing|
@@ -92,25 +92,50 @@ func newChunkJournal(ctx context.Context, dir string, m manifest) (*chunkJournal
 		return journal, nil
 	}
 
-	file, err := openJournal(ctx, filepath.Join(dir, chunkJournalName))
+	file, err := openJournalFile(ctx, filepath.Join(dir, chunkJournalName))
 	if err != nil {
 		return nil, err
 	}
 
-	journal = &chunkJournal{
-		journal: file,
-		dir:     dir,
-		backing: m,
+	// bootstrap chunk journal from |file|
+	src := journalChunkSource{
+		journal: nil,
+		address: journalAddr,
+		lookups: make(map[addr]jrecordLookup),
 	}
 
-	if err = readJournal(ctx, journal); err != nil {
+	var last hash.Hash
+	off, err := processRecords(ctx, file, func(o int64, r jrecord) error {
+		switch r.kind {
+		case chunkKind:
+			src.lookups[r.address] = jrecordLookup{offset: o, length: r.length}
+			src.compressedSz += uint64(r.length)
+			// todo(andy): uncompressed size
+		case rootHashKind:
+			last = hash.Hash(r.address)
+		default:
+			return fmt.Errorf("unknown journal record kind (%d)", r.kind)
+		}
+		return nil
+	})
+	if err != nil {
 		return nil, err
 	}
 
+	wr := newJournalWriter(file, off, journalWriterBuffSize)
+	src.journal = wr
+	sources := map[addr]chunkSource{src.address: src}
+
+	journal = &chunkJournal{
+		journal:  wr,
+		backing:  m,
+		rootHash: last,
+		sources:  sources,
+	}
 	return journal, nil
 }
 
-func openJournal(ctx context.Context, path string) (*os.File, error) {
+func openJournalFile(ctx context.Context, path string) (*os.File, error) {
 	var create bool
 	info, err := os.Stat(path)
 	if errors.Is(err, os.ErrNotExist) {
@@ -133,7 +158,7 @@ func openJournal(ctx context.Context, path string) (*os.File, error) {
 	// zero file the file
 	k := 1024 * 1024
 	b := make([]byte, k)
-	for i := 0; i < chunkJournalSize; i += k {
+	for i := 0; i < chunkJournalFileSize; i += k {
 		if _, err = f.Write(b); err != nil {
 			return nil, err
 		}
@@ -146,40 +171,6 @@ func openJournal(ctx context.Context, path string) (*os.File, error) {
 	}
 
 	return f, nil
-}
-
-func readJournal(ctx context.Context, j *chunkJournal) error {
-	src := journalChunkSource{
-		journal: j.journal,
-		lookups: make(map[addr]jrecordLookup),
-	}
-
-	var last hash.Hash
-	off, err := processRecords(ctx, j.journal, func(off int64, rec jrecord) error {
-		switch rec.kind {
-		case chunkKind:
-			src.lookups[rec.address] = jrecordLookup{offset: off, length: rec.length}
-			src.compressedSz += uint64(rec.length)
-			// todo(andy): uncompressed size
-
-		case rootHashKind:
-			last = hash.Hash(rec.address)
-
-		default:
-			return fmt.Errorf("unknown journal record kind (%d)", rec.kind)
-		}
-		return nil
-	})
-	if err != nil {
-		return nil
-	}
-
-	src.address = journalAddr
-	j.sources = map[addr]chunkSource{src.address: src}
-	j.offset = off
-	j.rootHash = last
-
-	return nil
 }
 
 // Persist implements tablePersister.
@@ -196,29 +187,32 @@ func (j *chunkJournal) Persist(ctx context.Context, mt *memTable, haver chunkRea
 		journal: j.journal,
 		lookups: make(map[addr]jrecordLookup, len(mt.order)),
 	}
-	buf := make([]byte, maxTableSize(uint64(len(mt.order)), mt.totalData))
 
-	var off int64
 	for _, record := range mt.order {
 		if record.has {
 			continue
 		}
 		c := chunks.NewChunkWithHash(hash.Hash(*record.a), mt.chunks[*record.a])
 		cc := ChunkToCompressedChunk(c)
-		n := writeChunkRecord(buf[off:], cc)
-		rec := jrecordLookup{offset: j.offset + off, length: n}
-		off += int64(n)
-
+		rec := jrecordLookup{
+			offset: j.journal.Offset(),
+			length: chunkRecordSize(cc),
+		}
+		buf, err := j.journal.GetBytes(int(rec.length))
+		if err != nil {
+			return nil, err
+		}
+		_ = writeChunkRecord(buf, cc)
 		src.lookups[*record.a] = rec
 		src.compressedSz += uint64(cc.CompressedSize())
 	}
-	src.address = addr(hash.Of(buf[:off]))
 
-	if err := j.flushBuffer(buf[:off]); err != nil {
-		return nil, err
+	// pick an arbitrary name for |src|
+	for a := range src.lookups {
+		src.address = addr(hash.Of(a[:]))
+		break
 	}
 	j.sources[src.address] = src
-	j.offset += off
 
 	return src, nil
 }
@@ -309,20 +303,22 @@ func (j *chunkJournal) Update(ctx context.Context, lastLock addr, next manifestC
 	if j.manifest.gcGen != next.gcGen {
 		panic("chunkJournal cannot update GC generation")
 	}
-
 	if writeHook != nil {
 		if err := writeHook(); err != nil {
 			return manifestContents{}, err
 		}
 	}
-
 	if j.manifest.lock != lastLock {
 		return j.manifest, nil // |next| is stale
 	}
 
-	buf := make([]byte, rootHashRecordSize)
+	buf, err := j.journal.GetBytes(rootHashRecordSize)
+	if err != nil {
+		return manifestContents{}, err
+	}
 	writeRootHashRecord(buf, addr(next.root))
-	if err := j.flushBuffer(buf); err != nil {
+
+	if err := j.journal.Sync(); err != nil {
 		return manifestContents{}, err
 	}
 	j.manifest = next
@@ -353,14 +349,6 @@ func (j *chunkJournal) ParseIfExists(ctx context.Context, stats *Stats, readHook
 	}
 
 	return ok, j.manifest, nil
-}
-
-func (j *chunkJournal) flushBuffer(buf []byte) (err error) {
-	// todo(andy): pad to page boundary
-	if _, err = j.journal.WriteAt(buf, j.offset); err != nil {
-		return err
-	}
-	return j.journal.Sync()
 }
 
 func (s journalChunkSource) has(h addr) (bool, error) {
@@ -517,8 +505,12 @@ const (
 	rootHashRecordSize = recMinSz
 )
 
+func chunkRecordSize(c CompressedChunk) uint32 {
+	return uint32(len(c.FullCompressedChunk)) + recMinSz
+}
+
 func writeChunkRecord(buf []byte, c CompressedChunk) (n uint32) {
-	l := uint32(len(c.FullCompressedChunk)) + recMinSz
+	l := chunkRecordSize(c)
 	writeUint(buf[:recLenSz], l)
 	n += recLenSz
 	buf[n] = byte(chunkKind)
@@ -529,6 +521,7 @@ func writeChunkRecord(buf []byte, c CompressedChunk) (n uint32) {
 	n += uint32(len(c.FullCompressedChunk))
 	writeUint(buf[n:], crc(buf[:n]))
 	n += checksumSize
+	d.PanicIfFalse(l == n)
 	return
 }
 

--- a/go/store/nbs/chunk_journal.go
+++ b/go/store/nbs/chunk_journal.go
@@ -1,0 +1,445 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package nbs
+
+import (
+	"bufio"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"sync/atomic"
+
+	"github.com/golang/snappy"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/d"
+	"github.com/dolthub/dolt/go/store/hash"
+)
+
+var chunkJournalAddr = addr{
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+}
+
+const (
+	chunkJournalName = "nbs_chunk_journal"
+)
+
+func newChunkJournal(ctx context.Context, mc manifestContents) (chunkJournal, error) {
+	panic("unimplemented")
+}
+
+type chunkJournal struct {
+	manifest manifestContents
+
+	file   *os.File
+	offset int64
+	dir    string
+
+	mu             sync.RWMutex
+	lookups        map[addr]jrecordLookup
+	uncompressedSz uint64
+	compressedSz   uint64
+}
+
+var _ tablePersister = &chunkJournal{}
+var _ manifest = &chunkJournal{}
+
+type jrecordLookup struct {
+	offset int64
+	length uint32
+}
+
+// Persist implements tablePersister.
+func (j *chunkJournal) Persist(ctx context.Context, mt *memTable, haver chunkReader, stats *Stats) (chunkSource, error) {
+	// todo(andy): what does contention look like here?
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	if haver != nil {
+		sort.Sort(hasRecordByPrefix(mt.order)) // hasMany() requires addresses to be sorted.
+		if _, err := haver.hasMany(mt.order); err != nil {
+			return nil, err
+		}
+		sort.Sort(hasRecordByOrder(mt.order)) // restore "insertion" order for write
+	}
+
+	// todo: allocate based on absent novel chunks
+	buf := make([]byte, maxTableSize(uint64(len(mt.order)), mt.totalData))
+	for _, record := range mt.order {
+		if record.has {
+			continue
+		}
+		c := mt.chunks[*record.a]
+		n := writeJournalRecord(buf, chunkKind, *record.a, c)
+		j.lookups[*record.a] = jrecordLookup{offset: j.offset, length: n}
+		j.offset += int64(n)
+		j.compressedSz += uint64(n)
+		j.uncompressedSz += uint64(len(c))
+		buf = buf[n:]
+	}
+
+	n, err := j.file.Write(buf)
+	if err != nil {
+		return nil, err
+	} else if n < len(buf) {
+		return nil, fmt.Errorf("incomplete write (%d < %d)", n, len(buf))
+	}
+	return chunkJournalSource{journal: j}, nil
+}
+
+// ConjoinAll implements tablePersister.
+func (j *chunkJournal) ConjoinAll(ctx context.Context, sources chunkSources, stats *Stats) (chunkSource, error) {
+	for _, s := range sources {
+		if _, ok := s.(chunkJournalSource); !ok {
+			panic("expected chunkSource to be chunkJournalSource")
+		}
+	}
+	return chunkJournalSource{journal: j}, nil
+}
+
+// Open implements tablePersister.
+func (j *chunkJournal) Open(ctx context.Context, name addr, chunkCount uint32, stats *Stats) (chunkSource, error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	d.PanicIfFalse(name == chunkJournalAddr)
+	d.PanicIfFalse(j.file == nil && len(j.lookups) == 0)
+	d.PanicIfFalse(j.offset == 0)
+	d.PanicIfFalse(j.uncompressedSz == 0)
+	d.PanicIfFalse(j.compressedSz == 0)
+
+	var err error
+	j.file, err = os.Open(filepath.Join(j.dir, name.String()))
+	if err != nil {
+		return nil, err
+	}
+	j.lookups = make(map[addr]jrecordLookup, chunkCount)
+
+	j.offset, err = processRecords(ctx, j.file, func(off int64, rec jrecord) error {
+		j.lookups[rec.address] = jrecordLookup{offset: off, length: rec.length}
+		j.compressedSz += uint64(rec.length)
+		// todo(andy): uncompressed size
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return chunkJournalSource{journal: j}, nil
+}
+
+// PruneTableFiles implements tablePersister.
+func (j *chunkJournal) PruneTableFiles(ctx context.Context, contents manifestContents) error {
+	panic("unimplemented")
+}
+
+// Update implements manifest.
+func (j *chunkJournal) Update(ctx context.Context, lastLock addr, next manifestContents, stats *Stats, writeHook func() error) (manifestContents, error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if err := writeHook(); err != nil {
+		return manifestContents{}, err
+	}
+
+	curr := j.manifest
+	if curr.lock != lastLock {
+		return curr, nil // stale
+	}
+	if curr.manifestVers != next.manifestVers ||
+		curr.nbfVers != next.nbfVers ||
+		curr.gcGen != next.gcGen {
+		panic("manifest metadata does not match")
+	}
+	j.manifest = next
+	return j.manifest, nil
+}
+
+// Name implements manifest.
+func (j *chunkJournal) Name() string {
+	return chunkJournalName
+}
+
+// ParseIfExists implements manifest.
+func (j *chunkJournal) ParseIfExists(ctx context.Context, stats *Stats, readHook func() error) (bool, manifestContents, error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if err := readHook(); err != nil {
+		return false, manifestContents{}, err
+	}
+	return true, j.manifest, nil
+}
+
+func (j *chunkJournal) getLookup(h addr) (l jrecordLookup, ok bool) {
+	j.mu.RLock()
+	defer j.mu.RUnlock()
+	l, ok = j.lookups[h]
+	return
+}
+
+func (j *chunkJournal) readJournalRecord(l jrecordLookup) (jrecord, error) {
+	j.mu.RLock()
+	defer j.mu.RUnlock()
+	b := make([]byte, l.length)
+	if _, err := j.file.ReadAt(b, l.offset); err != nil {
+		return jrecord{}, err
+	}
+	return readJournalRecord(b), nil
+}
+
+func (j *chunkJournal) count() uint32 {
+	j.mu.RLock()
+	defer j.mu.RUnlock()
+	return uint32(len(j.lookups))
+}
+
+func (j *chunkJournal) uncompressedSize() uint64 {
+	return atomic.LoadUint64(&j.uncompressedSz)
+}
+
+type chunkJournalSource struct {
+	journal *chunkJournal
+}
+
+var _ chunkSource = chunkJournalSource{}
+
+func (s chunkJournalSource) has(h addr) (bool, error) {
+	_, ok := s.journal.getLookup(h)
+	return ok, nil
+}
+
+func (s chunkJournalSource) hasMany(addrs []hasRecord) (missing bool, err error) {
+	for i := range addrs {
+		a := addrs[i].a
+		if _, ok := s.journal.getLookup(*a); ok {
+			addrs[i].has = true
+		} else {
+			missing = true
+		}
+	}
+	return
+}
+
+func (s chunkJournalSource) getCompressed(ctx context.Context, h addr, stats *Stats) (CompressedChunk, error) {
+	e, ok := s.journal.getLookup(h)
+	if !ok {
+		return CompressedChunk{}, nil
+	}
+	rec, err := s.journal.readJournalRecord(e)
+	if err != nil {
+		return CompressedChunk{}, err
+	}
+	return NewCompressedChunk(hash.Hash(h), rec.cmpData)
+}
+
+func (s chunkJournalSource) get(ctx context.Context, h addr, stats *Stats) ([]byte, error) {
+	cc, err := s.getCompressed(ctx, h, stats)
+	if err != nil {
+		return nil, err
+	} else if cc.IsEmpty() {
+		return nil, nil
+	}
+	ch, err := cc.ToChunk()
+	if err != nil {
+		return nil, err
+	}
+	return ch.Data(), nil
+}
+
+func (s chunkJournalSource) getMany(ctx context.Context, _ *errgroup.Group, reqs []getRecord, found func(context.Context, *chunks.Chunk), stats *Stats) (bool, error) {
+	var remaining bool
+	// todo: read planning
+	for i := range reqs {
+		data, err := s.get(ctx, *reqs[i].a, stats)
+		if err != nil {
+			return false, err
+		} else if data != nil {
+			ch := chunks.NewChunkWithHash(hash.Hash(*reqs[i].a), data)
+			found(ctx, &ch)
+		} else {
+			remaining = true
+		}
+	}
+	return remaining, nil
+}
+
+func (s chunkJournalSource) getManyCompressed(ctx context.Context, _ *errgroup.Group, reqs []getRecord, found func(context.Context, CompressedChunk), stats *Stats) (bool, error) {
+	var remaining bool
+	// todo: read planning
+	for i := range reqs {
+		cc, err := s.getCompressed(ctx, *reqs[i].a, stats)
+		if err != nil {
+			return false, err
+		} else if cc.IsEmpty() {
+			remaining = true
+		} else {
+			found(ctx, cc)
+		}
+	}
+	return remaining, nil
+}
+
+func (s chunkJournalSource) count() (uint32, error) {
+	return s.journal.count(), nil
+}
+
+func (s chunkJournalSource) uncompressedLen() (uint64, error) {
+	return s.journal.uncompressedSize(), nil
+}
+
+func (s chunkJournalSource) hash() (addr, error) {
+	// todo(andy): |hash()| belongs to the chunkSource interface and exists
+	//  due to the duality between chunkSources & table files. chunkJournal
+	//  seeks to create many chunkSources that depend on a single file.
+	//  |hash()| in particular is relevant to the implementation of Rebase().
+	return chunkJournalAddr, nil
+}
+
+// reader implements chunkSource.
+func (s chunkJournalSource) reader(context.Context) (io.Reader, error) {
+	// todo(andy): |reader()| belongs to the chunkSource interface and exists
+	//  due to the duality between chunkSources & table files. chunkJournal
+	//  seeks to create many chunkSources that depend on a single file.
+	//  |reader()| in particular is relevant to conjoin implementations.
+	panic("unimplemented")
+}
+
+// size implements chunkSource.
+// size returns the total size of the chunkSource: chunks, index, and footer
+func (s chunkJournalSource) size() (uint64, error) {
+	panic("unimplemented")
+}
+
+// index implements chunkSource.
+func (s chunkJournalSource) index() (tableIndex, error) {
+	panic("unimplemented")
+}
+
+func (s chunkJournalSource) clone() (chunkSource, error) {
+	panic("unimplemented")
+}
+
+func (s chunkJournalSource) close() error {
+	return nil
+}
+
+type jrecordKind uint8
+
+const (
+	rootHashKind jrecordKind = 1
+	chunkKind    jrecordKind = 2
+
+	minRecordSize = uint32Size + addrSize + checksumSize
+	maxRecordSize = 128 * 1024 // todo(andy): less arbitrary
+)
+
+type jrecord struct {
+	length   uint32
+	kind     jrecordKind
+	address  addr
+	cmpData  []byte
+	checksum uint32
+}
+
+// todo(andy): manifest updates
+func readJournalRecord(buf []byte) (rec jrecord) {
+	rec.length = readUint(buf)
+	buf = buf[uint32Size:]
+	rec.kind = jrecordKind(buf[0])
+	buf = buf[1:]
+	copy(rec.address[:], buf)
+	buf = buf[addrSize:]
+	rec.cmpData = buf[:len(buf)-checksumSize]
+	tail := buf[len(buf)-checksumSize:]
+	rec.checksum = readUint(tail)
+	return
+}
+
+func writeJournalRecord(buf []byte, kind jrecordKind, a addr, data []byte) uint32 {
+	// |length| written last
+	var n uint32 = uint32Size
+	buf[n] = byte(kind)
+	n += 1
+	copy(buf[n:], a[:])
+	n += addrSize
+	compressed := snappy.Encode(buf[n:], data) // todo: zstd
+	n += uint32(len(compressed))
+	// todo(andy): checksum |compressed| or everything?
+	writeUint(buf[n:], crc(compressed))
+	n += checksumSize
+	writeUint(buf[:uint32Size], n)
+	return n
+}
+
+func processRecords(ctx context.Context, r io.Reader, cb func(o int64, r jrecord) error) (off int64, err error) {
+	var buf []byte
+	rdr := bufio.NewReaderSize(r, 1024*1024)
+
+	for {
+		// peek to read next record size
+		if buf, err = rdr.Peek(uint32Size); err != nil {
+			break
+		}
+
+		l := readUint(buf)
+		if l < minRecordSize || l > maxRecordSize {
+			break
+		}
+		if buf, err = rdr.Peek(int(l)); err != nil {
+			break
+		}
+
+		rec := readJournalRecord(buf)
+		if crc(rec.cmpData) != rec.checksum {
+			break // stop if we can't checksum |rec|
+		}
+
+		if err = cb(off, rec); err != nil {
+			break
+		}
+
+		// read from |rdr| into |buf| to advance |rdr| state
+		if _, err = io.ReadFull(rdr, buf); err != nil {
+			break
+		}
+		off += int64(len(buf))
+	}
+	if err == io.EOF {
+		err = nil
+	}
+	return
+}
+
+func readUint(buf []byte) uint32 {
+	return binary.BigEndian.Uint32(buf)
+}
+
+func writeUint(buf []byte, u uint32) {
+	binary.BigEndian.PutUint32(buf, u)
+}

--- a/go/store/nbs/chunk_journal_test.go
+++ b/go/store/nbs/chunk_journal_test.go
@@ -11,13 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// This file incorporates work covered by the following copyright and
-// permission notice:
-//
-// Copyright 2016 Attic Labs, Inc. All rights reserved.
-// Licensed under the Apache License, version 2.0:
-// http://www.apache.org/licenses/LICENSE-2.0
 
 package nbs
 

--- a/go/store/nbs/chunk_journal_test.go
+++ b/go/store/nbs/chunk_journal_test.go
@@ -1,0 +1,43 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package nbs
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChunkJournalAddr(t *testing.T) {
+	expAddr := addr{
+		255, 255, 255, 255, 255,
+		255, 255, 255, 255, 255,
+		255, 255, 255, 255, 255,
+		255, 255, 255, 255, 255,
+	}
+	expString := "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv"
+	assert.Equal(t, expAddr, chunkJournalAddr)
+	assert.Equal(t, expString, chunkJournalAddr.String())
+	assert.Equal(t, uint64(math.MaxUint64), chunkJournalAddr.Prefix())
+	assert.Equal(t, uint32(math.MaxUint32), chunkJournalAddr.Checksum())
+}

--- a/go/store/nbs/chunk_journal_test.go
+++ b/go/store/nbs/chunk_journal_test.go
@@ -22,10 +22,18 @@
 package nbs
 
 import (
+	"bytes"
+	"context"
 	"math"
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/d"
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 func TestChunkJournalAddr(t *testing.T) {
@@ -40,4 +48,138 @@ func TestChunkJournalAddr(t *testing.T) {
 	assert.Equal(t, expString, chunkJournalAddr.String())
 	assert.Equal(t, uint64(math.MaxUint64), chunkJournalAddr.Prefix())
 	assert.Equal(t, uint32(math.MaxUint32), chunkJournalAddr.Checksum())
+}
+
+func TestRoundTripRecords(t *testing.T) {
+	t.Run("chunk record", func(t *testing.T) {
+		for i := 0; i < 64; i++ {
+			rec, buf := makeChunkRecord()
+			assert.Equal(t, rec.length, uint32(len(buf)))
+			b := make([]byte, rec.length)
+			n := writeChunkRecord(b, mustCompressedChunk(rec))
+			assert.Equal(t, n, rec.length)
+			assert.Equal(t, buf, b)
+			r := readJournalRecord(buf)
+			assert.Equal(t, rec, r)
+		}
+	})
+	t.Run("root hash record", func(t *testing.T) {
+		for i := 0; i < 64; i++ {
+			rec, buf := makeRootHashRecord()
+			assert.Equal(t, rec.length, uint32(len(buf)))
+			b := make([]byte, rec.length)
+			n := writeRootHashRecord(b, rec.address)
+			assert.Equal(t, n, rec.length)
+			assert.Equal(t, buf, b)
+			r := readJournalRecord(buf)
+			assert.Equal(t, rec, r)
+		}
+	})
+}
+
+func TestProcessRecords(t *testing.T) {
+	const cnt = 1024
+	ctx := context.Background()
+	records := make([]jrecord, cnt)
+	buffers := make([][]byte, cnt)
+	journal := make([]byte, cnt*1024)
+
+	var off uint32
+	for i := range records {
+		var r jrecord
+		var b []byte
+		if i%8 == 0 {
+			r, b = makeRootHashRecord()
+			off += writeRootHashRecord(journal[off:], r.address)
+		} else {
+			r, b = makeChunkRecord()
+			off += writeChunkRecord(journal[off:], mustCompressedChunk(r))
+		}
+		records[i], buffers[i] = r, b
+	}
+
+	var i, sum int
+	check := func(o int64, r jrecord) (_ error) {
+		require.True(t, i < cnt)
+		assert.Equal(t, records[i], r)
+		assert.Equal(t, sum, int(o))
+		sum += len(buffers[i])
+		i++
+		return
+	}
+
+	n, c, err := processRecords(ctx, bytes.NewBuffer(journal), check)
+	assert.Equal(t, cnt, int(c))
+	assert.Equal(t, int(off), int(n))
+	require.NoError(t, err)
+
+	i, sum = 0, 0
+	// write a bogus record to the end and process again
+	writeCorruptRecord(journal[off:])
+	n, c, err = processRecords(ctx, bytes.NewBuffer(journal), check)
+	assert.Equal(t, cnt, int(c))
+	assert.Equal(t, int(off), int(n))
+	require.NoError(t, err)
+}
+
+func makeChunkRecord() (jrecord, []byte) {
+	ch := chunks.NewChunk(randBuf(100))
+	cc := ChunkToCompressedChunk(ch)
+	payload := cc.FullCompressedChunk
+
+	b := make([]byte, recMinSz+len(payload))
+	writeUint(b, uint32(len(b)))
+	b[recLenSz] = byte(chunkKind)
+	copy(b[recLenSz+recKindSz:], cc.H[:])
+	copy(b[recLenSz+recKindSz+addrSize:], payload)
+	c := crc(b[:len(b)-checksumSize])
+	writeUint(b[len(b)-checksumSize:], c)
+	r := jrecord{
+		length:   uint32(len(b)),
+		kind:     chunkKind,
+		address:  addr(cc.H),
+		payload:  payload,
+		checksum: c,
+	}
+	return r, b
+}
+
+func makeRootHashRecord() (jrecord, []byte) {
+	a := addr(hash.Of(randBuf(8)))
+	b := make([]byte, recMinSz)
+	writeUint(b, uint32(len(b)))
+	b[recLenSz] = byte(rootHashKind)
+	copy(b[recLenSz+recKindSz:], a[:])
+	c := crc(b[:len(b)-checksumSize])
+	writeUint(b[len(b)-checksumSize:], c)
+	r := jrecord{
+		length:   uint32(len(b)),
+		kind:     rootHashKind,
+		payload:  b[len(b):],
+		address:  a,
+		checksum: c,
+	}
+	return r, b
+}
+
+func writeCorruptRecord(buf []byte) (n uint32) {
+	// fill with random data
+	rand.Read(buf[:recMinSz])
+	// write a valid size, kind
+	writeUint(buf, recMinSz)
+	buf[recLenSz] = byte(rootHashKind)
+	return recMinSz
+}
+
+func mustCompressedChunk(rec jrecord) CompressedChunk {
+	d.PanicIfFalse(rec.kind == chunkKind)
+	cc, err := NewCompressedChunk(hash.Hash(rec.address), rec.payload)
+	d.PanicIfError(err)
+	return cc
+}
+
+func randBuf(n int) (b []byte) {
+	b = make([]byte, n)
+	rand.Read(b)
+	return
 }

--- a/go/store/nbs/chunk_journal_test.go
+++ b/go/store/nbs/chunk_journal_test.go
@@ -153,7 +153,7 @@ func TestProcessRecords(t *testing.T) {
 		return
 	}
 
-	n, err := processRecords(ctx, bytes.NewBuffer(journal), check)
+	n, err := processRecords(ctx, bytes.NewReader(journal), check)
 	assert.Equal(t, cnt, i)
 	assert.Equal(t, int(off), int(n))
 	require.NoError(t, err)
@@ -161,7 +161,7 @@ func TestProcessRecords(t *testing.T) {
 	i, sum = 0, 0
 	// write a bogus record to the end and process again
 	writeCorruptRecord(journal[off:])
-	n, err = processRecords(ctx, bytes.NewBuffer(journal), check)
+	n, err = processRecords(ctx, bytes.NewReader(journal), check)
 	assert.Equal(t, cnt, i)
 	assert.Equal(t, int(off), int(n))
 	require.NoError(t, err)

--- a/go/store/nbs/file_table_persister.go
+++ b/go/store/nbs/file_table_persister.go
@@ -241,3 +241,7 @@ func (ftp *fsTablePersister) PruneTableFiles(ctx context.Context, contents manif
 
 	return nil
 }
+
+func (ftp *fsTablePersister) Close() error {
+	return nil
+}

--- a/go/store/nbs/journal_writer.go
+++ b/go/store/nbs/journal_writer.go
@@ -1,0 +1,122 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nbs
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+func newJournalWriter(file *os.File, offset int64, size int) *journalWriter {
+	return &journalWriter{
+		buf:  make([]byte, 0, size),
+		file: file,
+		off:  offset,
+	}
+}
+
+type journalWriter struct {
+	buf  []byte
+	file *os.File
+	off  int64
+}
+
+var _ io.ReaderAt = &journalWriter{}
+var _ io.WriteCloser = &journalWriter{}
+
+func (j *journalWriter) Offset() int64 {
+	return j.off + int64(len(j.buf))
+}
+
+func (j *journalWriter) ReadAt(p []byte, off int64) (n int, err error) {
+	var bp []byte
+	if off < j.off {
+		// fill some or all of |p| from |j.file|
+		fread := int(j.off - off)
+		if len(p) > fread {
+			// straddled read
+			bp = p[fread:]
+			p = p[:fread]
+		}
+		if n, err = j.file.ReadAt(p, off); err != nil {
+			return 0, err
+		}
+		off = 0
+	} else {
+		// fill all of |p| from |j.buf|
+		bp = p
+		off -= j.off
+	}
+	n += copy(bp, j.buf[off:])
+	return
+}
+
+func (j *journalWriter) GetBytes(n int) (buf []byte, err error) {
+	c, l := cap(j.buf), len(j.buf)
+	if n > c {
+		err = fmt.Errorf("requested bytes (%d) exceeds capacity (%d)", n, c)
+		return
+	} else if n > c-l {
+		if err = j.Flush(); err != nil {
+			return
+		}
+	}
+	l = len(j.buf)
+	j.buf = j.buf[:l+n]
+	buf = j.buf[l : l+n]
+	return
+}
+
+func (j *journalWriter) Write(p []byte) (n int, err error) {
+	if len(p) > len(j.buf) {
+		// write directly to |j.file|
+		if err = j.Flush(); err != nil {
+			return 0, err
+		}
+		n, err = j.file.WriteAt(p, j.off)
+		j.off += int64(n)
+		return
+	}
+	var buf []byte
+	if buf, err = j.GetBytes(len(p)); err != nil {
+		return 0, err
+	}
+	n = copy(buf, p)
+	return
+}
+
+func (j *journalWriter) Flush() (err error) {
+	if _, err = j.file.WriteAt(j.buf, j.off); err != nil {
+		return err
+	}
+	j.off += int64(len(j.buf))
+	j.buf = j.buf[:0]
+	return
+}
+
+func (j *journalWriter) Sync() (err error) {
+	if err = j.Flush(); err != nil {
+		return err
+	}
+	return j.file.Sync()
+}
+
+func (j *journalWriter) Close() (err error) {
+	if err = j.Flush(); err != nil {
+		return err
+	}
+	return j.file.Close()
+}

--- a/go/store/nbs/journal_writer_test.go
+++ b/go/store/nbs/journal_writer_test.go
@@ -1,0 +1,217 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nbs
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type operation struct {
+	kind   opKind
+	buf    []byte
+	readAt int64
+}
+
+type opKind byte
+
+const (
+	readOp opKind = iota
+	writeOp
+	flushOp
+)
+
+func TestJournalWriter(t *testing.T) {
+	tests := []struct {
+		name string
+		size int
+		init []byte
+		ops  []operation
+	}{
+		{
+			name: "smoke test",
+			size: 16,
+		},
+		{
+			name: "write to empty file",
+			size: 16,
+			ops: []operation{
+				{kind: writeOp, buf: []byte("lorem")},
+				{kind: writeOp, buf: []byte("ipsum")},
+			},
+		},
+		{
+			name: "read from non-empty file",
+			size: 16,
+			init: []byte("loremipsum"),
+			ops: []operation{
+				{kind: readOp, buf: []byte("lorem"), readAt: 0},
+				{kind: readOp, buf: []byte("ipsum"), readAt: 5},
+				{kind: readOp, buf: []byte("loremipsum"), readAt: 0},
+			},
+		},
+		{
+			name: "read new writes",
+			size: 16,
+			ops: []operation{
+				{kind: writeOp, buf: []byte("lorem")},
+				{kind: readOp, buf: []byte("lorem"), readAt: 0},
+				{kind: writeOp, buf: []byte("ipsum")},
+				{kind: readOp, buf: []byte("lorem"), readAt: 0},
+				{kind: readOp, buf: []byte("ipsum"), readAt: 5},
+			},
+		},
+		{
+			name: "read flushed writes",
+			size: 16,
+			ops: []operation{
+				{kind: writeOp, buf: []byte("lorem")},
+				{kind: flushOp},
+				{kind: readOp, buf: []byte("lorem"), readAt: 0},
+				{kind: writeOp, buf: []byte("ipsum")},
+				{kind: readOp, buf: []byte("ipsum"), readAt: 5},
+				{kind: readOp, buf: []byte("lorem"), readAt: 0},
+				{kind: flushOp},
+			},
+		},
+		{
+			name: "read partially flushed writes",
+			size: 16,
+			ops: []operation{
+				{kind: writeOp, buf: []byte("lorem")},
+				{kind: flushOp},
+				{kind: writeOp, buf: []byte("ipsum")},
+				{kind: readOp, buf: []byte("loremipsum"), readAt: 0},
+			},
+		},
+		{
+			name: "successive writes trigger buffer flush ",
+			size: 16,
+			ops: []operation{
+				{kind: writeOp, buf: []byte("lorem")},
+				{kind: readOp, buf: []byte("lorem"), readAt: 0},
+				{kind: writeOp, buf: []byte("ipsum")},
+				{kind: readOp, buf: []byte("ipsum"), readAt: 5},
+				{kind: writeOp, buf: []byte("dolor")},
+				{kind: readOp, buf: []byte("dolor"), readAt: 10},
+				{kind: writeOp, buf: []byte("sit")}, // triggers a flush
+				{kind: readOp, buf: []byte("sit"), readAt: 15},
+				{kind: readOp, buf: []byte("loremipsumdolorsit"), readAt: 0},
+				{kind: writeOp, buf: []byte("amet")},
+				{kind: readOp, buf: []byte("amet"), readAt: 18},
+				{kind: readOp, buf: []byte("loremipsumdolorsitamet"), readAt: 0},
+			},
+		},
+		{
+			name: "write larger that buffer",
+			size: 8,
+			init: []byte("loremipsum"),
+			ops: []operation{
+				{kind: flushOp},
+				{kind: writeOp, buf: []byte("dolorsitamet")},
+				{kind: readOp, buf: []byte("dolorsitamet"), readAt: 10},
+				{kind: readOp, buf: []byte("loremipsumdolorsitamet"), readAt: 0},
+			},
+		},
+		{
+			name: "flush empty buffer",
+			size: 16,
+			init: []byte("loremipsum"),
+			ops: []operation{
+				{kind: flushOp},
+			},
+		},
+		{
+			name: "double flush write",
+			size: 16,
+			init: []byte("loremipsum"),
+			ops: []operation{
+				{kind: writeOp, buf: []byte("dolor")},
+				{kind: flushOp},
+				{kind: flushOp},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name+"journal.Write()", func(t *testing.T) {
+			f := newTestFile(t)
+			n, err := f.Write(test.init)
+			require.NoError(t, err)
+			j := newJournalWriter(f, int64(n), test.size)
+
+			var off = int64(n)
+			for i, op := range test.ops {
+				switch op.kind {
+				case readOp:
+					act := make([]byte, len(op.buf))
+					n, err = j.ReadAt(act, op.readAt)
+					assert.NoError(t, err, "operation %d errored", i)
+					assert.Equal(t, len(op.buf), n, "operation %d failed", i)
+					assert.Equal(t, op.buf, act, "operation %d failed", i)
+				case writeOp:
+					n, err = j.Write(op.buf)
+					assert.NoError(t, err, "operation %d errored", i)
+					assert.Equal(t, len(op.buf), n, "operation %d failed", i)
+					off += int64(n)
+				case flushOp:
+					err = j.Flush()
+					assert.NoError(t, err, "operation %d errored", i)
+				default:
+					t.Fatal("unknown opKind")
+				}
+				assert.Equal(t, off, j.Offset())
+			}
+			assert.NoError(t, j.Close())
+		})
+	}
+}
+
+func TestJournalWriterSyncClose(t *testing.T) {
+	f := newTestFile(t)
+	n, err := f.Write([]byte("loremipsum"))
+	require.NoError(t, err)
+	j := newJournalWriter(f, int64(n), 16)
+
+	// sync triggers flush
+	n, err = j.Write([]byte("dolor"))
+	require.NoError(t, err)
+	assert.Equal(t, 5, n)
+	err = j.Sync()
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(j.buf))
+	assert.Equal(t, 15, int(j.off))
+
+	// close triggers flush
+	n, err = j.Write([]byte("sit"))
+	require.NoError(t, err)
+	assert.Equal(t, 3, n)
+	err = j.Close()
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(j.buf))
+	assert.Equal(t, 18, int(j.off))
+}
+
+func newTestFile(t *testing.T) *os.File {
+	name := fmt.Sprintf("journal%d.log", rand.Intn(65536))
+	f, err := os.Create(path.Join(t.TempDir(), name))
+	require.NoError(t, err)
+	return f
+}

--- a/go/store/nbs/journal_writer_test.go
+++ b/go/store/nbs/journal_writer_test.go
@@ -204,6 +204,7 @@ func TestJournalWriterWriteChunk(t *testing.T) {
 	for a, l := range lookups {
 		validateLookup(t, j, l, data[a])
 	}
+	require.NoError(t, j.Close())
 }
 
 func TestJournalWriterBootstrap(t *testing.T) {
@@ -236,6 +237,7 @@ func TestJournalWriterBootstrap(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, ch.Data(), buf)
 	}
+	require.NoError(t, j.Close())
 }
 
 func validateLookup(t *testing.T, j *journalWriter, l jrecordLookup, cc CompressedChunk) {

--- a/go/store/nbs/root_tracker_test.go
+++ b/go/store/nbs/root_tracker_test.go
@@ -627,6 +627,10 @@ func (ftp fakeTablePersister) PruneTableFiles(_ context.Context, _ manifestConte
 	return chunks.ErrUnsupportedOperation
 }
 
+func (ftp fakeTablePersister) Close() error {
+	return nil
+}
+
 func extractAllChunks(ctx context.Context, src chunkSource, cb func(rec extractRecord)) (err error) {
 	var index tableIndex
 	if index, err = src.index(); err != nil {

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -1146,8 +1146,14 @@ func (nbs *NomsBlockStore) Version() string {
 	return nbs.upstream.nbfVers
 }
 
-func (nbs *NomsBlockStore) Close() error {
-	return nbs.tables.close()
+func (nbs *NomsBlockStore) Close() (err error) {
+	if cerr := nbs.p.Close(); cerr != nil {
+		err = cerr
+	}
+	if cerr := nbs.tables.close(); cerr != nil {
+		err = cerr
+	}
+	return
 }
 
 func (nbs *NomsBlockStore) Stats() interface{} {

--- a/go/store/nbs/store_test.go
+++ b/go/store/nbs/store_test.go
@@ -41,6 +41,10 @@ import (
 )
 
 func makeTestLocalStore(t *testing.T, maxTableFiles int) (st *NomsBlockStore, nomsDir string, q MemoryQuotaProvider) {
+	if chunkJournalFeatureFlag {
+		t.Skip()
+	}
+
 	ctx := context.Background()
 	nomsDir = filepath.Join(tempfiles.MovableTempFileProvider.GetTempDir(), "noms_"+uuid.New().String()[:8])
 	err := os.MkdirAll(nomsDir, os.ModePerm)

--- a/go/store/nbs/table_persister.go
+++ b/go/store/nbs/table_persister.go
@@ -27,6 +27,7 @@ import (
 	"crypto/sha512"
 	"encoding/binary"
 	"errors"
+	"io"
 	"sort"
 )
 
@@ -51,6 +52,8 @@ type tablePersister interface {
 
 	// PruneTableFiles deletes old table files that are no longer referenced in the manifest.
 	PruneTableFiles(ctx context.Context, contents manifestContents) error
+
+	io.Closer
 }
 
 type chunkSourcesByAscendingCount struct {

--- a/go/store/nbs/table_set.go
+++ b/go/store/nbs/table_set.go
@@ -229,11 +229,11 @@ func (ts tableSet) uncompressedLen() (uint64, error) {
 func (ts tableSet) physicalLen() (uint64, error) {
 	f := func(css chunkSources) (data uint64, err error) {
 		for _, haver := range css {
-			index, err := haver.index()
+			sz, err := haver.size()
 			if err != nil {
 				return 0, err
 			}
-			data += index.tableFileSize()
+			data += sz
 		}
 		return
 	}


### PR DESCRIPTION
Adds `chunkJournal` a log-based `ChunkStore` that integrates into current `NomsBlockStore` machinery. `chunkJournal` implements `tablePersister` and `manifest`. When `Memtable`s are passed to `Persist()`, their contents appended to the journal file at current offset and a  `journalChunkSource` (implementing `chunkSource`) is returned. `journalChunkSource` is an in-memory object containing offset metadata for reading back chunks from the journal file. The `chunkJournal` also persists root hash updates to the log via the `manifest` interface. 

This implementation is currently behind a feature flag. Lots of work remains to fully support current NBS functionality. 
- Push/Pull/Clone paths are largely unsupported. 
- `chunkJournal` is limited to a fixed size, doesn't have support for finalizing the current journal as a table file
- `chunkJournal` needs to flush current in-memory manifest contents to manifest file
- Entire journal file must be processed at startup (needs out-of-band index)
- Need to shore-up NBS instantiation. The implementation here uses a global singleton to handle multiple in-process instantiations, however this breaks multi-db support. 
- Current chunk record format is temporary and needs support for format extension