### PR TITLE
[no-release-notes] moving tests to gms

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/cespare/xxhash v1.1.0
 	github.com/creasty/defaults v1.6.0
-	github.com/dolthub/go-mysql-server v0.14.1-0.20221115164917-f8c6c16520ab
+	github.com/dolthub/go-mysql-server v0.14.1-0.20221116004305-6af2406c5bd0
 	github.com/google/flatbuffers v2.0.6+incompatible
 	github.com/kch42/buzhash v0.0.0-20160816060738-9bdec3dec7c6
 	github.com/mitchellh/go-ps v1.0.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -180,8 +180,8 @@ github.com/dolthub/flatbuffers v1.13.0-dh.1 h1:OWJdaPep22N52O/0xsUevxJ6Qfw1M2txC
 github.com/dolthub/flatbuffers v1.13.0-dh.1/go.mod h1:CorYGaDmXjHz1Z7i50PYXG1Ricn31GcA2wNOTFIQAKE=
 github.com/dolthub/fslock v0.0.3 h1:iLMpUIvJKMKm92+N1fmHVdxJP5NdyDK5bK7z7Ba2s2U=
 github.com/dolthub/fslock v0.0.3/go.mod h1:QWql+P17oAAMLnL4HGB5tiovtDuAjdDTPbuqx7bYfa0=
-github.com/dolthub/go-mysql-server v0.14.1-0.20221115164917-f8c6c16520ab h1:xBvGPqRiDoi+jLAuCmLGN1qj7DeC9fJ7/ATz8bKq/J4=
-github.com/dolthub/go-mysql-server v0.14.1-0.20221115164917-f8c6c16520ab/go.mod h1:KtpU4Sf7J+SIat/nxoA733QTn3tdL34NtoGxEBFcTsA=
+github.com/dolthub/go-mysql-server v0.14.1-0.20221116004305-6af2406c5bd0 h1:BSTAs705aUez54ENrjZCQ3px0s/17nPi58XvDlpA0sI=
+github.com/dolthub/go-mysql-server v0.14.1-0.20221116004305-6af2406c5bd0/go.mod h1:KtpU4Sf7J+SIat/nxoA733QTn3tdL34NtoGxEBFcTsA=
 github.com/dolthub/ishell v0.0.0-20220112232610-14e753f0f371 h1:oyPHJlzumKta1vnOQqUnfdz+pk3EmnHS3Nd0cCT0I2g=
 github.com/dolthub/ishell v0.0.0-20220112232610-14e753f0f371/go.mod h1:dhGBqcCEfK5kuFmeO5+WOx3hqc1k3M29c1oS/R7N4ms=
 github.com/dolthub/jsonpath v0.0.0-20210609232853-d49537a30474 h1:xTrR+l5l+1Lfq0NvhiEsctylXinUMFhhsqaEcl414p8=

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -46,7 +46,7 @@ var skipPrepared bool
 // SkipPreparedsCount is used by the "ci-check-repo CI workflow
 // as a reminder to consider prepareds when adding a new
 // enginetest suite.
-const SkipPreparedsCount = 85
+const SkipPreparedsCount = 84
 
 const skipPreparedFlag = "DOLT_SKIP_PREPARED_ENGINETESTS"
 

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -46,7 +46,7 @@ var skipPrepared bool
 // SkipPreparedsCount is used by the "ci-check-repo CI workflow
 // as a reminder to consider prepareds when adding a new
 // enginetest suite.
-const SkipPreparedsCount = 83
+const SkipPreparedsCount = 85
 
 const skipPreparedFlag = "DOLT_SKIP_PREPARED_ENGINETESTS"
 
@@ -503,6 +503,11 @@ func TestCreateDatabase(t *testing.T) {
 func TestBlobs(t *testing.T) {
 	skipOldFormat(t)
 	enginetest.TestBlobs(t, newDoltHarness(t))
+}
+
+func TestIndexes(t *testing.T) {
+	harness := newDoltHarness(t)
+	enginetest.TestIndexes(t, harness)
 }
 
 func TestIndexPrefix(t *testing.T) {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -718,22 +718,6 @@ var DoltScripts = []queries.ScriptTest{
 			},
 		},
 	},
-	{
-		Name: "unique key violation prevents insert",
-		SetUpScript: []string{
-			"CREATE TABLE auniquetable (pk int primary key, uk int unique key, i int);",
-			"INSERT INTO auniquetable VALUES(0,0,0);",
-			"INSERT INTO auniquetable (pk,uk) VALUES(1,0) on duplicate key update i = 99;",
-		},
-		Assertions: []queries.ScriptTestAssertion{
-			{
-				Query: "SELECT pk, uk, i from auniquetable",
-				Expected: []sql.Row{
-					{0, 0, 99},
-				},
-			},
-		},
-	},
 }
 
 func makeLargeInsert(sz int) string {


### PR DESCRIPTION
tests that used to just work for dolt, now work for in-memory tables, so moving the tests there.
companion PR: https://github.com/dolthub/go-mysql-server/pull/1407