### PR TITLE
Change dolt_diff_summary table function to return empty diffs for tab…

### DIFF
--- a/go/libraries/doltcore/diff/diff_summary.go
+++ b/go/libraries/doltcore/diff/diff_summary.go
@@ -32,6 +32,8 @@ import (
 	"github.com/dolthub/dolt/go/store/val"
 )
 
+var ErrPrimaryKeySetChanged = errors.New("primary key set changed")
+
 type DiffSummaryProgress struct {
 	Adds, Removes, Changes, CellChanges, NewRowSize, OldRowSize, NewCellSize, OldCellSize uint64
 }
@@ -75,7 +77,7 @@ func SummaryForTableDelta(ctx context.Context, ch chan DiffSummaryProgress, td T
 	}
 
 	if !schema.ArePrimaryKeySetsDiffable(td.Format(), fromSch, toSch) {
-		return errhand.BuildDError("diff summary will not compute due to primary key set change with table %s", td.CurName()).Build()
+		return fmt.Errorf("failed to compute diff summary for table %s: %w", td.CurName(), ErrPrimaryKeySetChanged)
 	}
 
 	keyless, err := td.IsKeyless(ctx)

--- a/go/libraries/doltcore/sqle/dolt_diff_summary_table_function.go
+++ b/go/libraries/doltcore/sqle/dolt_diff_summary_table_function.go
@@ -21,13 +21,13 @@ import (
 	"math"
 	"strings"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dtables"
 	"github.com/dolthub/go-mysql-server/sql"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dtables"
 )
 
 var _ sql.TableFunction = (*DiffSummaryTableFunction)(nil)

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dtables"
 	"github.com/dolthub/go-mysql-server/enginetest/queries"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
@@ -28,6 +27,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dfunctions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dtables"
 )
 
 var ViewsWithAsOfScriptTest = queries.ScriptTest{

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dtables"
 	"github.com/dolthub/go-mysql-server/enginetest/queries"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
@@ -6316,6 +6317,50 @@ inner join t as of @Commit3 on rows_unmodified = t.pk;`,
 			{
 				Query:    "SELECT * from dolt_diff_summary('HEAD~', 'HEAD');",
 				Expected: []sql.Row{},
+			},
+		},
+	},
+	{
+		Name: "pk set change should throw an error for 3 argument dolt_diff_summary",
+		SetUpScript: []string{
+			"CREATE table t (pk int primary key);",
+			"INSERT INTO t values (1);",
+			"CALL DOLT_COMMIT('-Am', 'table with row');",
+			"ALTER TABLE t ADD col1 int not null default 0;",
+			"ALTER TABLE t drop primary key;",
+			"ALTER TABLE t add primary key (pk, col1);",
+			"CALL DOLT_COMMIT('-am', 'add secondary column with primary key');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:          "SELECT * from dolt_diff_summary('HEAD~', 'HEAD', 't');",
+				ExpectedErrStr: "failed to compute diff summary for table t: primary key set changed",
+			},
+		},
+	},
+	{
+		Name: "pk set change should report warning for 2 argument dolt_diff_summary",
+		SetUpScript: []string{
+			"CREATE table t (pk int primary key);",
+			"INSERT INTO t values (1);",
+			"CREATE table t2 (pk int primary key);",
+			"INSERT INTO t2 values (2);",
+			"CALL DOLT_COMMIT('-Am', 'multiple tables');",
+			"ALTER TABLE t ADD col1 int not null default 0;",
+			"ALTER TABLE t drop primary key;",
+			"ALTER TABLE t add primary key (pk, col1);",
+			"INSERT INTO t2 values (3), (4), (5);",
+			"CALL DOLT_COMMIT('-am', 'add secondary column with primary key to t');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "SELECT * from dolt_diff_summary('HEAD~', 'HEAD')",
+				Expected: []sql.Row{
+					{"t", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+					{"t2", 1, 3, 0, 0, 3, 0, 0, 1, 4, 1, 4},
+				},
+				ExpectedWarning:       dtables.PrimaryKeyChangeWarningCode,
+				ExpectedWarningsCount: 1,
 			},
 		},
 	},

--- a/integration-tests/bats/primary-key-changes.bats
+++ b/integration-tests/bats/primary-key-changes.bats
@@ -342,7 +342,7 @@ teardown() {
 
     run dolt diff --summary
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "diff summary will not compute due to primary key set change with table t" ]] || false
+    [[ "$output" =~ "failed to compute diff summary for table t: primary key set changed" ]] || false
 
     dolt add .
 


### PR DESCRIPTION
…les with pk set changes.

- The 3 argument version returns an error if the table specified has a pk set change.
- The 2 argument verison returns empty diffs and returns a warning.

I considered approximating the diff for the pk set change, but it feels like an overreach for the customers need.

Fixes: #4818 