### PR TITLE
Fix issues with docker entrypoint

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -29,12 +29,6 @@ DOLT_CONFIG_DIR="/etc/dolt/doltcfg.d"
 SERVER_CONFIG_DIR="/etc/dolt/servercfg.d"
 DOLT_ROOT_PATH="/.dolt"
 
-# create all dirs in path
-_create_dir() {
-    local path="$1"
-    mkdir -p "$path"
-}
-
 check_for_dolt() {
     local dolt_bin=$(which dolt)
     if [ ! -x "$dolt_bin" ]; then
@@ -129,10 +123,6 @@ _main() {
         # why we use fixed host=0.0.0.0 and port=3306 in README
         set -- dolt sql-server --host=0.0.0.0 --port=3306 "$@"
     fi
-
-    _create_dir $CONTAINER_DATA_DIR
-
-    cd $CONTAINER_DATA_DIR
 
     if [ "$1" = 'dolt' ] && [ "$2" = 'sql-server' ] && ! _mysql_want_help "$@"; then
         local dolt_version=$(dolt version | grep 'dolt version' | cut -f3 -d " ")

--- a/docker/serverDockerfile
+++ b/docker/serverDockerfile
@@ -20,4 +20,5 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 3306 33060
+WORKDIR /var/lib/dolt
 CMD [ "dolt", "sql-server", "--host=0.0.0.0" , "--port=3306" ]


### PR DESCRIPTION
1. Fix unability to process .sql in initdb
If user has some .sql files in `/docker-entrypoint-initdb.d` they will have an error:
```
2022-11-21 11:02:13+00:00 [Note] [Entrypoint]: /usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/init.sql
/usr/local/bin/docker-entrypoint.sh: line 98: docker_process_sql: command not found
```

This PR fixes it