### PR TITLE
use tini init system in docker container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,9 +4,13 @@ FROM --platform=$BUILDPLATFORM ubuntu:22.04
 ARG DOLT_VERSION
 ARG BUILDARCH
 
+RUN apt update -y && \
+    apt install -y \
+        tini
+
 ADD https://github.com/dolthub/dolt/releases/download/v${DOLT_VERSION}/dolt-linux-${BUILDARCH}.tar.gz dolt-linux-${BUILDARCH}.tar.gz
 RUN tar zxvf dolt-linux-${BUILDARCH}.tar.gz && \
     cp dolt-linux-${BUILDARCH}/bin/dolt /usr/local/bin && \
     rm -rf dolt-linux-${BUILDARCH} dolt-linux-${BUILDARCH}.tar.gz
 
-ENTRYPOINT ["/usr/local/bin/dolt"]
+ENTRYPOINT ["tini", "--", "/usr/local/bin/dolt"]

--- a/docker/serverDockerfile
+++ b/docker/serverDockerfile
@@ -1,23 +1,24 @@
 # syntax=docker/dockerfile:1.3-labs
-FROM --platform=$BUILDPLATFORM ubuntu:22.04 as builder
+FROM --platform=$BUILDPLATFORM ubuntu:22.04
 
 ARG DOLT_VERSION
 ARG BUILDARCH
+
+RUN apt update -y && \
+    apt install -y \
+        tini
 
 ADD https://github.com/dolthub/dolt/releases/download/v${DOLT_VERSION}/dolt-linux-${BUILDARCH}.tar.gz dolt-linux-${BUILDARCH}.tar.gz
 RUN tar zxvf dolt-linux-${BUILDARCH}.tar.gz && \
     cp dolt-linux-${BUILDARCH}/bin/dolt /usr/local/bin && \
     rm -rf dolt-linux-${BUILDARCH} dolt-linux-${BUILDARCH}.tar.gz
 
-
-FROM --platform=$BUILDPLATFORM builder
-
 RUN mkdir /docker-entrypoint-initdb.d
 VOLUME /var/lib/dolt
 
 COPY docker/docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "--", "docker-entrypoint.sh"]
 
 EXPOSE 3306 33060
 WORKDIR /var/lib/dolt


### PR DESCRIPTION
It's helpful for avoiding zombie processes and provides signal handling such as `SIGTERM` from `docker stop`
