### PR TITLE
Changing `loglevel` param to be case insensitive. 

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -402,7 +402,7 @@ func getCommandLineServerConfig(dEnv *env.DoltEnv, apr *argparser.ArgParseResult
 	}
 
 	if logLevel, ok := apr.GetValue(logLevelFlag); ok {
-		serverConfig.withLogLevel(LogLevel(logLevel))
+		serverConfig.withLogLevel(LogLevel(strings.ToLower(logLevel)))
 	}
 
 	if dataDir, ok := apr.GetValue(commands.MultiDBDirFlag); ok {

--- a/go/cmd/dolt/commands/sqlserver/yaml_config.go
+++ b/go/cmd/dolt/commands/sqlserver/yaml_config.go
@@ -153,6 +153,8 @@ var _ validatingServerConfig = YAMLConfig{}
 func NewYamlConfig(configFileData []byte) (YAMLConfig, error) {
 	var cfg YAMLConfig
 	err := yaml.UnmarshalStrict(configFileData, &cfg)
+	loglevel := strings.ToLower(*cfg.LogLevelStr)
+	cfg.LogLevelStr = &loglevel
 	return cfg, err
 }
 

--- a/go/cmd/dolt/commands/sqlserver/yaml_config.go
+++ b/go/cmd/dolt/commands/sqlserver/yaml_config.go
@@ -153,8 +153,10 @@ var _ validatingServerConfig = YAMLConfig{}
 func NewYamlConfig(configFileData []byte) (YAMLConfig, error) {
 	var cfg YAMLConfig
 	err := yaml.UnmarshalStrict(configFileData, &cfg)
-	loglevel := strings.ToLower(*cfg.LogLevelStr)
-	cfg.LogLevelStr = &loglevel
+	if cfg.LogLevelStr != nil {
+		loglevel := strings.ToLower(*cfg.LogLevelStr)
+		cfg.LogLevelStr = &loglevel
+	}
 	return cfg, err
 }
 

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -54,6 +54,17 @@ teardown() {
     dolt sql-client -P $PORT -u dolt --use-db 'test01' -q"call dolt_clone('file:///$tempDir/remote')" 
 }
 
+@test "sql-server: loglevels are case insensitive" {
+    cd repo1
+    PORT=$( definePORT )
+    dolt sql-server --loglevel TrAcE --port=$PORT --user dolt --socket "dolt.$PORT.sock" > log.txt 2>&1 &
+    SERVER_PID=$!
+    sleep 5
+
+    # Run a simple query to make sure the sql-server is up
+    dolt sql-client --host=0.0.0.0 -P $PORT -u dolt --use-db '' -q "show databases;"
+}
+
 @test "sql-server: server assumes existing user" {
     cd repo1
     dolt sql -q "create user dolt@'%' identified by '123'"

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -55,14 +55,31 @@ teardown() {
 }
 
 @test "sql-server: loglevels are case insensitive" {
+    # assert that loglevel on command line is not case sensitive
     cd repo1
     PORT=$( definePORT )
     dolt sql-server --loglevel TrAcE --port=$PORT --user dolt --socket "dolt.$PORT.sock" > log.txt 2>&1 &
     SERVER_PID=$!
-    sleep 5
-
-    # Run a simple query to make sure the sql-server is up
+    wait_for_connection $PORT 5000
     dolt sql-client --host=0.0.0.0 -P $PORT -u dolt --use-db '' -q "show databases;"
+    stop_sql_server
+
+    # assert that loglevel in yaml config is not case sensitive
+    cat >config.yml <<EOF
+log_level: dEBuG
+behavior:
+  disable_client_multi_statements: true
+user:
+  name: dolt
+listener:
+  host: "0.0.0.0"
+  port: $PORT
+EOF
+    dolt sql-server --config ./config.yml --socket "dolt.$PORT.sock" &
+    SERVER_PID=$!
+    wait_for_connection $PORT 5000
+    dolt sql-client --host=0.0.0.0 -P $PORT -u dolt --use-db '' -q "show databases;"
+    stop_sql_server
 }
 
 @test "sql-server: server assumes existing user" {


### PR DESCRIPTION
This allows the `loglevel` CLI param and `log_level` YAML config key to be case insensitive.

Fixes: https://github.com/dolthub/dolt/issues/4864