### PR TITLE
Changes to schema instantiation

### DIFF
--- a/go/libraries/doltcore/migrate/integration_test.go
+++ b/go/libraries/doltcore/migrate/integration_test.go
@@ -104,7 +104,7 @@ func TestMigration(t *testing.T) {
 					expected: []sql.Row{
 						{"pk", "varchar(16383)", "NO", "PRI", "NULL", ""},
 						{"c0", "int", "YES", "", "NULL", ""},
-						{"c1", "varbinary(16383)", "YES", "", "NULL", ""},
+						{"c1", "varbinary(16383)", "YES", "MUL", "NULL", ""},
 					},
 				},
 			},

--- a/go/libraries/doltcore/migrate/transform.go
+++ b/go/libraries/doltcore/migrate/transform.go
@@ -451,7 +451,15 @@ func migrateSchema(ctx context.Context, tableName string, existing schema.Schema
 			}
 		}
 		if patched {
-			return schema.SchemaFromCols(schema.NewColCollection(cols...))
+			allCols := schema.NewColCollection(cols...)
+			schema.NewIndexCollection(allCols, existing.GetPKCols())
+			return schema.NewSchema(
+				allCols,
+				existing.GetPkOrdinals(),
+				existing.GetCollation(),
+				existing.Indexes(),
+				existing.Checks(),
+			)
 		}
 		return existing, nil
 	}
@@ -522,14 +530,17 @@ func migrateSchema(ctx context.Context, tableName string, existing schema.Schema
 		return existing, nil
 	}
 
-	sch, err := schema.SchemaFromCols(schema.NewColCollection(cols...))
+	sch, err := schema.NewSchema(
+		schema.NewColCollection(cols...),
+		existing.GetPkOrdinals(),
+		existing.GetCollation(),
+		existing.Indexes(),
+		existing.Checks(),
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	if err = sch.SetPkOrdinals(existing.GetPkOrdinals()); err != nil {
-		return nil, err
-	}
 	return sch, nil
 }
 

--- a/go/libraries/doltcore/schema/check_coll.go
+++ b/go/libraries/doltcore/schema/check_coll.go
@@ -33,6 +33,8 @@ type CheckCollection interface {
 	DropCheck(name string) error
 	// AllChecks returns all the checks in the collection
 	AllChecks() []Check
+	// Equals returns whether the provided check collection is equal or not.
+	Equals(other CheckCollection) bool
 	// Count returns the size of the collection
 	Count() int
 }
@@ -93,6 +95,26 @@ func (c *checkCollection) AllChecks() []Check {
 		checks[i] = check
 	}
 	return checks
+}
+
+func (c *checkCollection) Equals(other CheckCollection) bool {
+
+	o := other.(*checkCollection)
+	if len(c.checks) != len(o.checks) {
+		return false
+	}
+
+	for i := range c.checks {
+		a := c.checks[i]
+		b := o.checks[i]
+		if a.name != b.name ||
+			a.expression != b.expression ||
+			a.enforced != b.enforced {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (c *checkCollection) Count() int {

--- a/go/libraries/doltcore/schema/col_coll_test.go
+++ b/go/libraries/doltcore/schema/col_coll_test.go
@@ -19,9 +19,10 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
 	"github.com/dolthub/dolt/go/store/types"
-	"github.com/stretchr/testify/assert"
 )
 
 var firstNameCol = Column{"first", 0, types.StringKind, false, typeinfo.StringDefaultType, "", false, "", nil}

--- a/go/libraries/doltcore/schema/col_coll_test.go
+++ b/go/libraries/doltcore/schema/col_coll_test.go
@@ -19,10 +19,9 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
 	"github.com/dolthub/dolt/go/store/types"
+	"github.com/stretchr/testify/assert"
 )
 
 var firstNameCol = Column{"first", 0, types.StringKind, false, typeinfo.StringDefaultType, "", false, "", nil}

--- a/go/libraries/doltcore/schema/schema.go
+++ b/go/libraries/doltcore/schema/schema.go
@@ -158,6 +158,19 @@ func SchemasAreEqual(sch1, sch2 Schema) bool {
 		return false
 	}
 
+	if sch1.GetCollation() != sch2.GetCollation() {
+		return false
+	}
+
+	if (sch1.Checks() == nil) != (sch2.Checks() == nil) {
+		return false
+	}
+
+	if sch1.Checks() != nil && sch2.Checks() != nil &&
+		!sch1.Checks().Equals(sch2.Checks()) {
+		return false
+	}
+
 	return sch1.Indexes().Equals(sch2.Indexes())
 }
 

--- a/go/libraries/doltcore/sqle/sqlutil/convert.go
+++ b/go/libraries/doltcore/sqle/sqlutil/convert.go
@@ -109,16 +109,15 @@ func ToDoltSchema(
 		return nil, err
 	}
 
-	sch, err := schema.SchemaFromCols(colColl)
+	sch, err := schema.NewSchema(colColl,
+		sqlSchema.PkOrdinals,
+		schema.Collation(collation),
+		nil,
+		nil,
+	)
 	if err != nil {
 		return nil, err
 	}
-
-	err = sch.SetPkOrdinals(sqlSchema.PkOrdinals)
-	if err != nil {
-		return nil, err
-	}
-	sch.SetCollation(schema.Collation(collation))
 
 	return sch, nil
 }

--- a/integration-tests/bats/migrate.bats
+++ b/integration-tests/bats/migrate.bats
@@ -324,3 +324,21 @@ SQL
     [[ $output =~ "3,4,a" ]]
     [[ $output =~ "5,6,b" ]]
 }
+
+@test "migrate: indexes, collation, and checks should be preserved" {
+   dolt sql -q "create table t (i int primary key, j int, v varchar(100), index (j), constraint j_chk check (j = 0)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;"
+   run dolt sql -q "show create table t"
+   [ $status -eq 0 ]
+   [[ $output =~ "KEY \`j\` (\`j\`)" ]] || false
+   [[ $output =~ "CONSTRAINT \`j_chk\` CHECK ((\`j\` = 0))" ]] || false
+   [[ $output =~ ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci" ]] || false
+
+   dolt commit -Am "create table"
+
+   dolt migrate
+   run dolt sql -q "show create table t"
+   [ $status -eq 0 ]
+   [[ $output =~ "KEY \`j\` (\`j\`)" ]] || false
+   [[ $output =~ "CONSTRAINT \`j_chk\` CHECK ((\`j\` = 0))" ]] || false
+   [[ $output =~ ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci" ]] || false
+}

--- a/integration-tests/bats/migration-integration.bats
+++ b/integration-tests/bats/migration-integration.bats
@@ -21,7 +21,7 @@ teardown() {
     run dolt tag -v
     [ "$status" -eq 0 ]
     [[ "$output" =~ "r9jv07tf9un3fm1fg72v7ad9er89oeo7" ]] || false
-    [[ ! "$output" =~ "tdkt7s7805k1ml4hu37pm688g5i0b8ie" ]] || false
+    [[ ! "$output" =~ "euna1i8brh95lo9mcg05s3m8h781fr8a" ]] || false
 
     dolt migrate
     [[ $(cat ./.dolt/noms/manifest | cut -f 2 -d :) = "$TARGET_NBF" ]] || false
@@ -29,7 +29,7 @@ teardown() {
     dolt tag -v
     run dolt tag -v
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "7jrvg1ajcdq6t9sevcejv4e9o0fgrmle" ]] || false
+    [[ "$output" =~ "euna1i8brh95lo9mcg05s3m8h781fr8a" ]] || false
     [[ ! "$output" =~ "r9jv07tf9un3fm1fg72v7ad9er89oeo7" ]] || false
 
     # validate TEXT migration
@@ -47,7 +47,7 @@ teardown() {
     run dolt tag -v
     [ "$status" -eq 0 ]
     [[ "$output" =~ "r9jv07tf9un3fm1fg72v7ad9er89oeo7" ]] || false
-    [[ ! "$output" =~ "tdkt7s7805k1ml4hu37pm688g5i0b8ie" ]] || false
+    [[ ! "$output" =~ "euna1i8brh95lo9mcg05s3m8h781fr8a" ]] || false
 
     dolt migrate
     [[ $(cat ./.dolt/noms/manifest | cut -f 2 -d :) = "$TARGET_NBF" ]] || false
@@ -55,7 +55,7 @@ teardown() {
     dolt tag -v
     run dolt tag -v
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "7jrvg1ajcdq6t9sevcejv4e9o0fgrmle" ]] || false
+    [[ "$output" =~ "euna1i8brh95lo9mcg05s3m8h781fr8a" ]] || false
     [[ ! "$output" =~ "r9jv07tf9un3fm1fg72v7ad9er89oeo7" ]] || false
 
     # validate TEXT migration
@@ -72,7 +72,7 @@ teardown() {
     run dolt tag -v
     [ "$status" -eq 0 ]
     [[ "$output" =~ "u8s83gapv7ghnbmrtpm8q5es0dbl7lpd" ]] || false
-    [[ ! "$output" =~ "apdp3stea20mmm80oiu2ipo07a7v1hvb" ]] || false
+    [[ ! "$output" =~ "nm1ubfu85p4c082bhertltrhkkeffaqg" ]] || false
 
     dolt migrate
     [[ $(cat ./.dolt/noms/manifest | cut -f 2 -d :) = "$TARGET_NBF" ]] || false
@@ -80,6 +80,6 @@ teardown() {
     dolt tag -v
     run dolt tag -v
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "apdp3stea20mmm80oiu2ipo07a7v1hvb" ]] || false
+    [[ "$output" =~ "nm1ubfu85p4c082bhertltrhkkeffaqg" ]] || false
     [[ ! "$output" =~ "u8s83gapv7ghnbmrtpm8q5es0dbl7lpd" ]] || false
 }


### PR DESCRIPTION
Fix for #4862 

Changes the way we instantiate schema.Schema in Dolt. In the past, we've had a couple bugs that have been caused by codepaths that build new schema objects. We've accidentally dropped primary key ordinals twice before and in #4862 we dropped indexes, checks, and collations.