### PR TITLE
dolt_conflicts_$tbl_name: updates to the our version persist

### DIFF
--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -405,7 +405,13 @@ func (db Database) getTableInsensitive(ctx *sql.Context, head *doltdb.Commit, ds
 
 	case strings.HasPrefix(lwrName, doltdb.DoltConfTablePrefix):
 		suffix := tblName[len(doltdb.DoltConfTablePrefix):]
-		dt, err := dtables.NewConflictsTable(ctx, suffix, root, dtables.RootSetter(db))
+		srcTable, ok, err := db.getTableInsensitive(ctx, head, ds, root, suffix)
+		if err != nil {
+			return nil, false, err
+		} else if !ok {
+			return nil, false, nil
+		}
+		dt, err := dtables.NewConflictsTable(ctx, suffix, srcTable, root, dtables.RootSetter(db))
 		if err != nil {
 			return nil, false, err
 		}

--- a/go/libraries/doltcore/sqle/dtables/conflicts_tables.go
+++ b/go/libraries/doltcore/sqle/dtables/conflicts_tables.go
@@ -16,6 +16,7 @@ package dtables
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/dolthub/go-mysql-server/sql"
 
@@ -27,7 +28,7 @@ import (
 )
 
 // NewConflictsTable returns a new ConflictsTable instance
-func NewConflictsTable(ctx *sql.Context, tblName string, root *doltdb.RootValue, rs RootSetter) (sql.Table, error) {
+func NewConflictsTable(ctx *sql.Context, tblName string, srcTbl sql.Table, root *doltdb.RootValue, rs RootSetter) (sql.Table, error) {
 	tbl, tblName, ok, err := root.GetTableInsensitive(ctx, tblName)
 	if err != nil {
 		return nil, err
@@ -36,7 +37,11 @@ func NewConflictsTable(ctx *sql.Context, tblName string, root *doltdb.RootValue,
 	}
 
 	if types.IsFormat_DOLT(tbl.Format()) {
-		return newProllyConflictsTable(ctx, tbl, tblName, root, rs)
+		upd, ok := srcTbl.(sql.UpdatableTable)
+		if !ok {
+			return nil, fmt.Errorf("%s can not have conflicts because it is not updateable", tblName)
+		}
+		return newProllyConflictsTable(ctx, tbl, upd, tblName, root, rs)
 	}
 
 	return newNomsConflictsTable(ctx, tbl, tblName, root, rs)

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -933,6 +933,12 @@ func TestDoltConflictsTableNameTable(t *testing.T) {
 	for _, script := range DoltConflictTableNameTableTests {
 		enginetest.TestScript(t, newDoltHarness(t), script)
 	}
+
+	if types.IsFormat_DOLT(types.Format_Default) {
+		for _, script := range Dolt1ConflictTableNameTableTests {
+			enginetest.TestScript(t, newDoltHarness(t), script)
+		}
+	}
 }
 
 // tests new format behavior for keyless merges that create CVs and conflicts


### PR DESCRIPTION
Any columns prefixed with `our_` can now be updated on the `dolt_conflicts_$tbl_name` tables. Updates on the our columns get translated to updates on the conflict source table.

First pass on implementing the suggestion in #4854. Handles keyless and keyed tables. Does not add the auto-incrementing id to the conflict table. Will get this out to the customer first and then come back.