### PR TITLE
fixes dolt table export appending success message to csv when using redirect syntax

### DIFF
--- a/go/cmd/dolt/commands/tblcmds/export.go
+++ b/go/cmd/dolt/commands/tblcmds/export.go
@@ -216,7 +216,7 @@ func (cmd ExportCmd) Exec(ctx context.Context, commandStr string, args []string,
 		return commands.HandleVErrAndExitCode(errhand.BuildDError("Error opening writer for %s.", exOpts.DestName()).AddCause(err).Build(), usage)
 	}
 
-	cli.Println(color.CyanString("Successfully exported data."))
+	cli.PrintErrln(color.CyanString("Successfully exported data."))
 	return 0
 }
 

--- a/integration-tests/bats/export-tables.bats
+++ b/integration-tests/bats/export-tables.bats
@@ -68,7 +68,7 @@ for line in sys.stdin:
     if line != "":
         rows.append(line.strip().split(","))
 
-if len(rows) != 4: # extra line for success
+if len(rows) != 3: # extra line for success
     sys.exit(1)
 
 if rows[0] != "pk,c1,c2,c3,c4,c5".split(","):
@@ -98,6 +98,11 @@ if rows[2] != "9,8,7,6,5,4".split(","):
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Successfully exported data." ]] || false
     [ -f export.csv ]
+    # test export works with redirect syntax
+    dolt table export -f test_int > export.csv
+    run wc -l export.csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "2 export.csv" ]] || false
 }
 
 @test "export-tables: dolt table SQL export" {

--- a/integration-tests/bats/export-tables.bats
+++ b/integration-tests/bats/export-tables.bats
@@ -68,7 +68,7 @@ for line in sys.stdin:
     if line != "":
         rows.append(line.strip().split(","))
 
-if len(rows) != 3: # extra line for success
+if len(rows) != 3:
     sys.exit(1)
 
 if rows[0] != "pk,c1,c2,c3,c4,c5".split(","):


### PR DESCRIPTION
`dolt table export` was previously appending "Successfully exported data." to the end of the csv file when using the redirect syntax (e.g. `dolt table export hospitals > hospitals.csv`). The success message didn't get appended when redirect syntax wasn't used (e.g. `dolt table export hospitals hospitals.csv`). This fix makes it so that both formats work as expected.

issue: https://github.com/dolthub/dolt/issues/4889