### PR TITLE
Add dolt_conflict_id to dolt_conflicts_$table_name

### DIFF
--- a/go/store/prolly/artifact_map.go
+++ b/go/store/prolly/artifact_map.go
@@ -582,7 +582,7 @@ func mergeArtifactsDescriptorsFromSource(srcKd val.TupleDesc) (kd, vd val.TupleD
 	// commit hash, and artifact type.
 	keyTypes := srcKd.Types
 
-	// target branch commit hash
+	// source branch commit hash
 	keyTypes = append(keyTypes, val.Type{Enc: val.CommitAddrEnc, Nullable: false})
 
 	// artifact type

--- a/go/store/val/keyless_tuple.go
+++ b/go/store/val/keyless_tuple.go
@@ -45,6 +45,10 @@ func HashTupleFromValue(pool pool.BuffPool, value Tuple) (key Tuple) {
 	return
 }
 
+func ReadHashFromTuple(keylessKey Tuple) []byte {
+	return keylessKey[keylessHashSz:]
+}
+
 func ReadKeylessCardinality(value Tuple) uint64 {
 	return readUint64(value[:keylessCardSz])
 }


### PR DESCRIPTION
This PR makes manipulating the dolt_conflicts_$table_name tables easier. It adds a new `dolt_conflict_id` column. The column is a hash of the primary keys for a keyed table (or the value hash of the row for a keyless table) and the `from_root_ish` column. The `dolt_conflict_id` column uniquely identifies a conflict.

A sample:
```
dolt sql -q "select * from dolt_conflicts_t;"
+----------------------------------+---------+-----------+--------+----------+---------------+----------+------------+-----------------+------------------------+
| from_root_ish                    | base_pk | base_col1 | our_pk | our_col1 | our_diff_type | their_pk | their_col1 | their_diff_type | dolt_conflict_id       |
+----------------------------------+---------+-----------+--------+----------+---------------+----------+------------+-----------------+------------------------+
| b6qeivhltgrm2la9057uis84eav5n2rl | 1       | NULL      | 1      | -100     | modified      | 1        | 100        | modified        | +Z9y2YEvo0d1ZupbzGiyrQ |
+----------------------------------+---------+-----------+--------+----------+---------------+----------+------------+-----------------+------------------------+
```