### PR TITLE
found minor bug in validate.go

### DIFF
--- a/go/libraries/doltcore/migrate/validation.go
+++ b/go/libraries/doltcore/migrate/validation.go
@@ -164,7 +164,7 @@ func validateTableDataPartition(ctx context.Context, name string, old, new *dolt
 }
 
 func equalRows(old, new sql.Row, sch sql.Schema) (bool, error) {
-	if len(new) != len(new) || len(new) != len(sch) {
+	if len(new) != len(old) || len(new) != len(sch) {
 		return false, nil
 	}
 


### PR DESCRIPTION
In validate.go I found a small bug where there is a comparison on the same object (len(new) != len(new)). I assume this was meant to compare len(new) with len(old) so I fixed that here. 