### PR TITLE
found another minor bug in results.go

### DIFF
--- a/go/libraries/utils/argparser/results.go
+++ b/go/libraries/utils/argparser/results.go
@@ -28,8 +28,10 @@ type ArgParseResults struct {
 	parser  *ArgParser
 }
 
+// Equals res and other are only considered equal if the order and contents of their arguments
+// are the same.
 func (res *ArgParseResults) Equals(other *ArgParseResults) bool {
-	if len(res.Args) != len(other.Args) || len(res.options) != len(res.options) {
+	if len(res.Args) != len(other.Args) || len(res.options) != len(other.options) {
 		return false
 	}
 


### PR DESCRIPTION
Found the same kind of bug as before this time in results.go. I changed the comparison to be correct as before.

Question about line 36. We are requiring exact order and not just content, is that correct or should we sort the args before comparing them?