### PR TITLE
Block branch switches when both branches have working set changes

### DIFF
--- a/go/cmd/dolt/commands/checkout.go
+++ b/go/cmd/dolt/commands/checkout.go
@@ -292,6 +292,15 @@ func checkoutBranch(ctx context.Context, dEnv *env.DoltEnv, name string, force b
 			// Being on the same branch shouldn't be an error
 			cli.Printf("Already on branch '%s'\n", name)
 			return nil
+		} else if err == actions.ErrWorkingSetsOnBothBranches {
+			str := fmt.Sprintf("error: There are uncommitted changes already on branch '%s'.", name) +
+				"This can happen when someone modifies that branch in a SQL session." +
+				fmt.Sprintf("You have uncommitted changes on this branch, and they would overwrite the uncommitted changes on branch %s on checkout.", name) +
+				"To solve this problem, you can " +
+				"1) commit or reset your changes on this branch, using `dolt commit` or `dolt reset`, before checking out the other branch, " +
+				"2) use the `-f` flag with `dolt checkout` to force an overwrite, or " +
+				"3) connect to branch '%s' with the SQL server and revert or commit changes there before proceeding."
+			return errhand.BuildDError(str).AddCause(err).Build()
 		} else {
 			bdr := errhand.BuildDError("fatal: Unexpected error checking out branch '%s'", name)
 			bdr.AddCause(err)

--- a/go/libraries/doltcore/env/actions/branch.go
+++ b/go/libraries/doltcore/env/actions/branch.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"

--- a/go/libraries/doltcore/env/actions/branch.go
+++ b/go/libraries/doltcore/env/actions/branch.go
@@ -18,9 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
 	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
-
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
@@ -31,7 +29,7 @@ import (
 var ErrAlreadyExists = errors.New("already exists")
 var ErrCOBranchDelete = errors.New("attempted to delete checked out branch")
 var ErrUnmergedBranchDelete = errors.New("attempted to delete a branch that is not fully merged into its parent; use `-f` to force")
-var ErrWorkingSetsOnBothBranches = errors.New("working sets exist on both branches")
+var ErrWorkingSetsOnBothBranches = errors.New("checkout would overwrite uncommitted changes on target branch")
 
 func RenameBranch(ctx context.Context, dbData env.DbData, config *env.DoltCliConfig, oldBranch, newBranch string, force bool) error {
 	oldRef := ref.NewBranchRef(oldBranch)
@@ -327,60 +325,7 @@ func CheckoutBranch(ctx context.Context, dEnv *env.DoltEnv, brName string, force
 	}
 
 	if !force {
-		// checkWorkingSetCompatibility checks that the current working set is "compatible" with the dest working set.
-		// This means that if both working sets are present (ie there are changes on both source and dest branches),
-		// we check if the changes are identical before allowing a clobbering checkout.
-		// Working set errors are ignored by this function, because they are properly handled elsewhere.
-		checkWorkingSetCompatibility := func() error {
-			currentWs, err := dEnv.WorkingSet(ctx)
-			if err != nil {
-				// working set does not exist, skip check
-				return nil
-			}
-
-			destWsRef, err := ref.WorkingSetRefForHead(branchRef)
-			if err != nil {
-				// dest working set does not exist, skip check
-				return nil
-			}
-			destWs, err := db.ResolveWorkingSet(ctx, destWsRef)
-			if err != nil {
-				// dest working set does not resolve, skip check
-				return nil
-			}
-
-			detectWorkingSetChanges := func(ws *doltdb.WorkingSet) (hasChanges bool, wrHash hash.Hash, err error) {
-				wrHash, err = ws.WorkingRoot().HashOf()
-				if err != nil {
-					return false, hash.Hash{}, err
-				}
-				srHash, err := ws.StagedRoot().HashOf()
-				if err != nil {
-					return false, hash.Hash{}, err
-				}
-				hasChanges = !wrHash.Equal(srHash)
-				return hasChanges, wrHash, nil
-			}
-
-			sourceHasChanges, sourceHash, err := detectWorkingSetChanges(currentWs)
-			if err != nil {
-				// error detecting source changes, skip check
-				return nil
-			}
-			destHasChanges, destHash, err := detectWorkingSetChanges(destWs)
-			if err != nil {
-				// error detecting dest changes, skip check
-				return nil
-			}
-			areHashesEqual := sourceHash.Equal(destHash)
-
-			if sourceHasChanges && destHasChanges && !areHashesEqual {
-				return ErrWorkingSetsOnBothBranches
-			}
-			return nil
-		}
-
-		err = checkWorkingSetCompatibility()
+		err = checkWorkingSetCompatibility(ctx, dEnv, branchRef)
 		if err != nil {
 			return err
 		}
@@ -521,6 +466,61 @@ func overwriteRoot(ctx context.Context, head *doltdb.RootValue, tblHashes map[st
 	}
 
 	return head, nil
+}
+
+// checkWorkingSetCompatibility checks that the current working set is "compatible" with the dest working set.
+// This means that if both working sets are present (ie there are changes on both source and dest branches),
+// we check if the changes are identical before allowing a clobbering checkout.
+// Working set errors are ignored by this function, because they are properly handled elsewhere.
+func checkWorkingSetCompatibility(ctx context.Context, dEnv *env.DoltEnv, branchRef ref.BranchRef) error {
+	currentWs, err := dEnv.WorkingSet(ctx)
+	if err != nil {
+		// working set does not exist, skip check
+		return nil
+	}
+
+	db := dEnv.DoltDB
+	destWsRef, err := ref.WorkingSetRefForHead(branchRef)
+	if err != nil {
+		// dest working set does not exist, skip check
+		return nil
+	}
+	destWs, err := db.ResolveWorkingSet(ctx, destWsRef)
+	if err != nil {
+		// dest working set does not resolve, skip check
+		return nil
+	}
+
+	sourceHasChanges, sourceHash, err := detectWorkingSetChanges(currentWs)
+	if err != nil {
+		// error detecting source changes, skip check
+		return nil
+	}
+	destHasChanges, destHash, err := detectWorkingSetChanges(destWs)
+	if err != nil {
+		// error detecting dest changes, skip check
+		return nil
+	}
+	areHashesEqual := sourceHash.Equal(destHash)
+
+	if sourceHasChanges && destHasChanges && !areHashesEqual {
+		return ErrWorkingSetsOnBothBranches
+	}
+	return nil
+}
+
+// detectWorkingSetChanges returns a boolean indicating whether the working set has changes, and a hash of the changes
+func detectWorkingSetChanges(ws *doltdb.WorkingSet) (hasChanges bool, wrHash hash.Hash, err error) {
+	wrHash, err = ws.WorkingRoot().HashOf()
+	if err != nil {
+		return false, hash.Hash{}, err
+	}
+	srHash, err := ws.StagedRoot().HashOf()
+	if err != nil {
+		return false, hash.Hash{}, err
+	}
+	hasChanges = !wrHash.Equal(srHash)
+	return hasChanges, wrHash, nil
 }
 
 func IsBranch(ctx context.Context, ddb *doltdb.DoltDB, str string) (bool, error) {

--- a/go/libraries/doltcore/env/actions/branch.go
+++ b/go/libraries/doltcore/env/actions/branch.go
@@ -332,21 +332,22 @@ func CheckoutBranch(ctx context.Context, dEnv *env.DoltEnv, brName string, force
 		}
 	}
 
+	shouldResetWorkingSet := true
 	roots, err := dEnv.Roots(ctx)
 	// roots will be empty/nil if the working set is not set (working set is not set if the current branch was deleted)
 	if errors.Is(err, doltdb.ErrBranchNotFound) || errors.Is(err, doltdb.ErrWorkingSetNotFound) {
-		roots, err = dEnv.RecoveryRoots(ctx)
-		if err != nil {
-			return err
-		}
+		roots, _ = dEnv.RecoveryRoots(ctx)
+		shouldResetWorkingSet = false
 	} else if err != nil {
 		return err
 	}
 
-	// reset the working set to the branch head, leaving the branch unchanged
-	err = ResetHard(ctx, dEnv, "", roots)
-	if err != nil {
-		return err
+	if shouldResetWorkingSet {
+		// reset the working set to the branch head, leaving the branch unchanged
+		err = ResetHard(ctx, dEnv, "", roots)
+		if err != nil {
+			return err
+		}
 	}
 
 	return checkoutBranchNoDocs(ctx, roots, branchRoot, dEnv.RepoStateWriter(), branchRef, force)

--- a/go/libraries/doltcore/env/actions/branch.go
+++ b/go/libraries/doltcore/env/actions/branch.go
@@ -335,7 +335,16 @@ func CheckoutBranch(ctx context.Context, dEnv *env.DoltEnv, brName string, force
 	// roots will be empty/nil if the working set is not set (working set is not set if the current branch was deleted)
 	if errors.Is(err, doltdb.ErrBranchNotFound) || errors.Is(err, doltdb.ErrWorkingSetNotFound) {
 		roots, err = dEnv.RecoveryRoots(ctx)
+		if err != nil {
+			return err
+		}
 	} else if err != nil {
+		return err
+	}
+
+	// reset the working set to the branch head, leaving the branch unchanged
+	err = ResetHard(ctx, dEnv, "", roots)
+	if err != nil {
 		return err
 	}
 

--- a/integration-tests/bats/checkout.bats
+++ b/integration-tests/bats/checkout.bats
@@ -41,9 +41,11 @@ SQL
     [ "$status" -eq 0 ]
     [[ "$output" =~ "modified" ]] || false
 
-    # Making additional changes to main, should carry them to feature without any problem
+    # Making additional changes to main, should error out because the changes are different from the feature branch
     dolt sql -q "insert into test values (3)"
-    dolt checkout feature
+    run dolt checkout feature
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "working sets exist on both branches" ]] || false
 
     run dolt sql -q "select count(*) from test"
     [ "$status" -eq 0 ]
@@ -51,7 +53,7 @@ SQL
 
     run dolt status
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "modified" ]] || false
+    [[ "$output" =~ "On branch main" ]] || false
 }
 
 @test "checkout: dolt checkout doesn't stomp working set changes on other branch" {
@@ -284,4 +286,69 @@ SQL
   commitmeta=$(dolt log --oneline --parents | head -n 1)
   [[ "$commitmeta" =~ "$shaparent1" ]] || false
   [[ "$commitmeta" =~ "$shaparent2" ]] || false
+}
+
+
+@test "checkout: block checkout when current and target branches have working set changes" {
+  dolt sql -q "create table users (id int primary key, name varchar(32));"
+  dolt add .
+  dolt commit -m "original users table"
+  dolt branch -c main feature
+
+  # make changes on main
+  dolt sql -q 'insert into users (id, name) values (1, "main-change");'
+  # make sure changes are present
+  run dolt sql -q "select count(*) from users"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "1" ]] || false
+
+  # checkout feature
+  dolt checkout feature
+  # make sure changes are pulled in from main
+  run dolt sql -q "select count(*) from users"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "1" ]] || false
+
+  # make changes on feature
+  dolt sql -q 'insert into users (id, name) values (2, "feature-change");'
+  # make sure new changes are present
+  run dolt sql -q "select count(*) from users"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "2" ]] || false
+
+  # try to checkout main, but fail due to working set changes
+  run dolt checkout main
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "working sets exist on both branches" ]] || false
+
+  # try to checkout main, but succeed due to force flag
+  dolt checkout -f main
+
+  # make sure changes on both branches were applied
+  run dolt sql -q "select count(*) from users"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "2" ]] || false
+}
+
+@test "checkout: allow checkout when current and target branches have identical working set changes" {
+  dolt sql -q "create table users (id int primary key, name varchar(32));"
+  dolt add .
+  dolt commit -m "original users table"
+
+  dolt branch -c main feature
+  dolt sql -q 'insert into users (id, name) values (1, "main-change");'
+
+  run dolt sql -q "select count(*) from users"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "1" ]] || false
+
+  dolt checkout feature
+  run dolt sql -q "select count(*) from users"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "1" ]] || false
+
+  dolt checkout main
+  run dolt sql -q "select count(*) from users"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "1" ]] || false
 }


### PR DESCRIPTION
Block branch switches when both current and target branches have working set changes.
Allow this behavior to be skipped using the `-f` flag, in which case the two working sets are combined (as is the current behavior).

This fixes https://github.com/dolthub/dolt/issues/4863