### PR TITLE
Reset source branch after checkout

### DIFF
--- a/go/cmd/dolt/commands/checkout.go
+++ b/go/cmd/dolt/commands/checkout.go
@@ -120,7 +120,12 @@ func (cmd CheckoutCmd) Exec(ctx context.Context, commandStr string, args []strin
 		if err != nil {
 			return HandleVErrAndExitCode(errhand.BuildDError(err.Error()).Build(), usagePrt)
 		}
-		verr := actions.ResetHard(ctx, dEnv, "HEAD", roots)
+		headRef := dEnv.RepoStateReader().CWBHeadRef()
+		ws, err := dEnv.WorkingSet(ctx)
+		if err != nil {
+			HandleVErrAndExitCode(errhand.BuildDError(err.Error()).Build(), usagePrt)
+		}
+		verr := actions.ResetHard(ctx, dEnv, "HEAD", roots, &headRef, ws)
 		return handleResetError(verr, usagePrt)
 	}
 

--- a/go/cmd/dolt/commands/checkout.go
+++ b/go/cmd/dolt/commands/checkout.go
@@ -125,7 +125,7 @@ func (cmd CheckoutCmd) Exec(ctx context.Context, commandStr string, args []strin
 		if err != nil {
 			HandleVErrAndExitCode(errhand.BuildDError(err.Error()).Build(), usagePrt)
 		}
-		verr := actions.ResetHard(ctx, dEnv, "HEAD", roots, &headRef, ws)
+		verr := actions.ResetHard(ctx, dEnv, "HEAD", roots, headRef, ws)
 		return handleResetError(verr, usagePrt)
 	}
 

--- a/go/cmd/dolt/commands/reset.go
+++ b/go/cmd/dolt/commands/reset.go
@@ -106,7 +106,13 @@ func (cmd ResetCmd) Exec(ctx context.Context, commandStr string, args []string, 
 			arg = apr.Arg(0)
 		}
 
-		err = actions.ResetHard(ctx, dEnv, arg, roots)
+		headRef := dEnv.RepoStateReader().CWBHeadRef()
+		ws, err := dEnv.WorkingSet(ctx)
+		if err != nil {
+			return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+		}
+
+		err = actions.ResetHard(ctx, dEnv, arg, roots, &headRef, ws)
 	} else {
 		// Check whether the input argument is a ref.
 		if apr.NArg() == 1 {

--- a/go/cmd/dolt/commands/reset.go
+++ b/go/cmd/dolt/commands/reset.go
@@ -112,7 +112,7 @@ func (cmd ResetCmd) Exec(ctx context.Context, commandStr string, args []string, 
 			return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 		}
 
-		err = actions.ResetHard(ctx, dEnv, arg, roots, &headRef, ws)
+		err = actions.ResetHard(ctx, dEnv, arg, roots, headRef, ws)
 	} else {
 		// Check whether the input argument is a ref.
 		if apr.NArg() == 1 {

--- a/go/libraries/doltcore/env/actions/branch.go
+++ b/go/libraries/doltcore/env/actions/branch.go
@@ -356,7 +356,7 @@ func CheckoutBranch(ctx context.Context, dEnv *env.DoltEnv, brName string, force
 
 	if shouldResetWorkingSet {
 		// reset the source branch's working set to the branch head, leaving the source branch unchanged
-		err = ResetHard(ctx, dEnv, "", roots, &branchHeadRef, currentWs)
+		err = ResetHard(ctx, dEnv, "", roots, branchHeadRef, currentWs)
 		if err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/env/actions/reset.go
+++ b/go/libraries/doltcore/env/actions/reset.go
@@ -136,7 +136,17 @@ func ResetHardTables(ctx context.Context, dbData env.DbData, cSpecStr string, ro
 	return resetHardTables(ctx, dbData, cSpecStr, roots)
 }
 
-func ResetHard(ctx context.Context, dEnv *env.DoltEnv, cSpecStr string, roots doltdb.Roots, headRef *ref.DoltRef, ws *doltdb.WorkingSet) error {
+// ResetHard resets the working, staged, and head based on the given parameters.
+// The reset can be performed on a non-current branch and working set.
+// Returns an error if the reset fails.
+func ResetHard(
+	ctx context.Context,
+	dEnv *env.DoltEnv,
+	cSpecStr string,
+	roots doltdb.Roots,
+	headRef *ref.DoltRef,
+	ws *doltdb.WorkingSet,
+) error {
 	dbData := dEnv.DbData()
 
 	newHead, roots, err := resetHardTables(ctx, dbData, cSpecStr, roots)

--- a/go/libraries/doltcore/env/actions/reset.go
+++ b/go/libraries/doltcore/env/actions/reset.go
@@ -17,6 +17,7 @@ package actions
 import (
 	"context"
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 
@@ -136,15 +137,10 @@ func ResetHardTables(ctx context.Context, dbData env.DbData, cSpecStr string, ro
 	return resetHardTables(ctx, dbData, cSpecStr, roots)
 }
 
-func ResetHard(ctx context.Context, dEnv *env.DoltEnv, cSpecStr string, roots doltdb.Roots) error {
+func ResetHard(ctx context.Context, dEnv *env.DoltEnv, cSpecStr string, roots doltdb.Roots, headRef *ref.DoltRef, ws *doltdb.WorkingSet) error {
 	dbData := dEnv.DbData()
 
 	newHead, roots, err := resetHardTables(ctx, dbData, cSpecStr, roots)
-	if err != nil {
-		return err
-	}
-
-	ws, err := dEnv.WorkingSet(ctx)
 	if err != nil {
 		return err
 	}
@@ -155,7 +151,7 @@ func ResetHard(ctx context.Context, dEnv *env.DoltEnv, cSpecStr string, roots do
 	}
 
 	if newHead != nil {
-		err = dEnv.DoltDB.SetHeadToCommit(ctx, dEnv.RepoStateReader().CWBHeadRef(), newHead)
+		err = dEnv.DoltDB.SetHeadToCommit(ctx, *headRef, newHead)
 		if err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/env/actions/reset.go
+++ b/go/libraries/doltcore/env/actions/reset.go
@@ -144,7 +144,7 @@ func ResetHard(
 	dEnv *env.DoltEnv,
 	cSpecStr string,
 	roots doltdb.Roots,
-	headRef *ref.DoltRef,
+	headRef ref.DoltRef,
 	ws *doltdb.WorkingSet,
 ) error {
 	dbData := dEnv.DbData()
@@ -160,7 +160,7 @@ func ResetHard(
 	}
 
 	if newHead != nil {
-		err = dEnv.DoltDB.SetHeadToCommit(ctx, *headRef, newHead)
+		err = dEnv.DoltDB.SetHeadToCommit(ctx, headRef, newHead)
 		if err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/env/actions/reset.go
+++ b/go/libraries/doltcore/env/actions/reset.go
@@ -136,7 +136,7 @@ func ResetHardTables(ctx context.Context, dbData env.DbData, cSpecStr string, ro
 	return resetHardTables(ctx, dbData, cSpecStr, roots)
 }
 
-// ResetHard resets the working, staged, and head based on the given parameters.
+// ResetHard resets the working, staged, and head to the ones in the provided roots and head ref.
 // The reset can be performed on a non-current branch and working set.
 // Returns an error if the reset fails.
 func ResetHard(

--- a/go/libraries/doltcore/env/actions/reset.go
+++ b/go/libraries/doltcore/env/actions/reset.go
@@ -17,12 +17,11 @@ package actions
 import (
 	"context"
 	"fmt"
-	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
-
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
+	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 )
 


### PR DESCRIPTION
When checking out a branch, clear the source branch's working set only after the destination checkout succeeds without errors.
