### PR TITLE
[no-release-notes] GMS bump

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/cespare/xxhash v1.1.0
 	github.com/creasty/defaults v1.6.0
-	github.com/dolthub/go-mysql-server v0.14.1-0.20221213222912-efbb4e505a0c
+	github.com/dolthub/go-mysql-server v0.14.1-0.20221214023744-98f3a2ec0bb9
 	github.com/google/flatbuffers v2.0.6+incompatible
 	github.com/kch42/buzhash v0.0.0-20160816060738-9bdec3dec7c6
 	github.com/mitchellh/go-ps v1.0.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -162,8 +162,8 @@ github.com/dolthub/flatbuffers v1.13.0-dh.1 h1:OWJdaPep22N52O/0xsUevxJ6Qfw1M2txC
 github.com/dolthub/flatbuffers v1.13.0-dh.1/go.mod h1:CorYGaDmXjHz1Z7i50PYXG1Ricn31GcA2wNOTFIQAKE=
 github.com/dolthub/fslock v0.0.3 h1:iLMpUIvJKMKm92+N1fmHVdxJP5NdyDK5bK7z7Ba2s2U=
 github.com/dolthub/fslock v0.0.3/go.mod h1:QWql+P17oAAMLnL4HGB5tiovtDuAjdDTPbuqx7bYfa0=
-github.com/dolthub/go-mysql-server v0.14.1-0.20221213222912-efbb4e505a0c h1:jTuH3b+hdI2+zJLt7SnHF48ZozTUsK1a8bYEYAKrGdM=
-github.com/dolthub/go-mysql-server v0.14.1-0.20221213222912-efbb4e505a0c/go.mod h1:Ei6QAcqEwiAsCFUpppEr955L5xFPo2du2fEsUvOIcZA=
+github.com/dolthub/go-mysql-server v0.14.1-0.20221214023744-98f3a2ec0bb9 h1:AmoinNZGy47j0mvKtti+Get9sDT5DUBwU+DrieyuF/s=
+github.com/dolthub/go-mysql-server v0.14.1-0.20221214023744-98f3a2ec0bb9/go.mod h1:Ei6QAcqEwiAsCFUpppEr955L5xFPo2du2fEsUvOIcZA=
 github.com/dolthub/ishell v0.0.0-20220112232610-14e753f0f371 h1:oyPHJlzumKta1vnOQqUnfdz+pk3EmnHS3Nd0cCT0I2g=
 github.com/dolthub/ishell v0.0.0-20220112232610-14e753f0f371/go.mod h1:dhGBqcCEfK5kuFmeO5+WOx3hqc1k3M29c1oS/R7N4ms=
 github.com/dolthub/jsonpath v0.0.0-20210609232853-d49537a30474 h1:xTrR+l5l+1Lfq0NvhiEsctylXinUMFhhsqaEcl414p8=


### PR DESCRIPTION
companion PR: https://github.com/dolthub/go-mysql-server/pull/1470