### PR TITLE
docs(README): add info about sql command

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Dolt needs a place to store your databases. I'm going to put my databases in `~/
 % cd dolt
 ```
 
-Any databases you create will be stored in this directory. So, for this example, a directory named `getting_started` will be created here once you run `create database getting_started`. Navigating to `~/dolt/getting_started` will allow you to access this database using the Dolt command line.
+Any databases you create will be stored in this directory. So, for this example, a directory named `getting_started` will be created here once you run later the sql command `create database getting_started;` (see section [Create a schema](#create-a-schema). Navigating to `~/dolt/getting_started` will then allow you to access this database using the Dolt command line.
 
 ## Start a MySQL-compatible database server
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Dolt needs a place to store your databases. I'm going to put my databases in `~/
 % cd dolt
 ```
 
-Any databases you create will be stored in this directory. So, for this example, a directory named `getting_started` will be created here once you run later the sql command `create database getting_started;` in a SQL shell (see section [Create a schema](#create-a-schema)). Navigating to `~/dolt/getting_started` will then allow you to access this database using the Dolt command line.
+Any databases you create will be stored in this directory. So, for this example, a directory named `getting_started` will be created here later in this walkthrough, after you run `create database getting_started;` in a SQL shell (see section [Create a schema](#create-a-schema)). Navigating to `~/dolt/getting_started` will then allow you to access this database using the Dolt command line.
 
 ## Start a MySQL-compatible database server
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Dolt needs a place to store your databases. I'm going to put my databases in `~/
 % cd dolt
 ```
 
-Any databases you create will be stored in this directory. So, for this example, a directory named `getting_started` will be created here once you run later the sql command `create database getting_started;` (see section [Create a schema](#create-a-schema). Navigating to `~/dolt/getting_started` will then allow you to access this database using the Dolt command line.
+Any databases you create will be stored in this directory. So, for this example, a directory named `getting_started` will be created here once you run later the sql command `create database getting_started;` in a SQL shell (see section [Create a schema](#create-a-schema)). Navigating to `~/dolt/getting_started` will then allow you to access this database using the Dolt command line.
 
 ## Start a MySQL-compatible database server
 


### PR DESCRIPTION
# changes:

- make an sql
- note that this is an sql command
- note that the exactly steps done later


# why:

- i was typing `dolt create database` and got error ... and searched what is the right syntax for `dolt` command to make the step "create an database" at this point - but this was not nessesary at this point, because its explained later

# suggestion:
- remove this lines or do a better rewording, so that an user not think he need to do here something.

# Note:
added also this PR for the docs: https://github.com/dolthub/docs/pull/1095