### PR TITLE
add --schema-only flag for `dolt dump`

### DIFF
--- a/go/cmd/dolt/commands/dump.go
+++ b/go/cmd/dolt/commands/dump.go
@@ -17,7 +17,6 @@ package commands
 import (
 	"context"
 	"fmt"
-	"github.com/dolthub/dolt/go/libraries/doltcore/table/untyped/sqlexport"
 	"os"
 	"path/filepath"
 	"strings"
@@ -33,6 +32,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
+	"github.com/dolthub/dolt/go/libraries/doltcore/table/untyped/sqlexport"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/libraries/utils/iohelp"
@@ -215,9 +215,9 @@ func (cmd DumpCmd) Exec(ctx context.Context, commandStr string, args []string, d
 }
 
 type dumpOptions struct {
-	format string
+	format     string
 	schemaOnly bool
-	dest   mvdata.DataLocation
+	dest       mvdata.DataLocation
 }
 
 type tableOptions struct {
@@ -414,9 +414,9 @@ func getDumpOptions(fileName string, rf string, schemaOnly bool) *dumpOptions {
 	fileLoc := getDumpDestination(fileName)
 
 	return &dumpOptions{
-		format: rf,
+		format:     rf,
 		schemaOnly: schemaOnly,
-		dest:   fileLoc,
+		dest:       fileLoc,
 	}
 }
 

--- a/go/cmd/dolt/commands/dump.go
+++ b/go/cmd/dolt/commands/dump.go
@@ -17,6 +17,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/table/untyped/sqlexport"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,6 +45,7 @@ const (
 	batchFlag        = "batch"
 	noBatchFlag      = "no-batch"
 	noAutocommitFlag = "no-autocommit"
+	schemaOnlyFlag   = "schema-only"
 
 	sqlFileExt     = "sql"
 	csvFileExt     = "csv"
@@ -94,6 +96,7 @@ func (cmd DumpCmd) ArgParser() *argparser.ArgParser {
 	ap.SupportsFlag(batchFlag, "", "Return batch insert statements wherever possible, enabled by default.")
 	ap.SupportsFlag(noBatchFlag, "", "Always emit one row per statement, rather than batching multiple rows into each statement.")
 	ap.SupportsFlag(noAutocommitFlag, "na", "Turns off autocommit for each dumped table. Used to speed up loading of outputted sql file")
+	ap.SupportsFlag(schemaOnlyFlag, "", "Dumping a table schema with no data to sql file")
 	return ap
 }
 
@@ -127,16 +130,17 @@ func (cmd DumpCmd) Exec(ctx context.Context, commandStr string, args []string, d
 	}
 
 	force := apr.Contains(forceParam)
+	schemaOnly := apr.Contains(schemaOnlyFlag)
 	resFormat, _ := apr.GetValue(FormatFlag)
 	resFormat = strings.TrimPrefix(resFormat, ".")
 
-	name, vErr := validateArgs(apr)
+	outputFileOrDirName, vErr := validateArgs(apr)
 	if vErr != nil {
 		return HandleVErrAndExitCode(vErr, usage)
 	}
 
 	// Look for schemas and procedures table, and add to tblNames only for sql dumps
-	if resFormat == emptyFileExt || resFormat == sqlFileExt {
+	if !schemaOnly && (resFormat == emptyFileExt || resFormat == sqlFileExt) {
 		sysTblNames, err := doltdb.GetSystemTableNames(ctx, root)
 		if err != nil {
 			return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
@@ -153,16 +157,23 @@ func (cmd DumpCmd) Exec(ctx context.Context, commandStr string, args []string, d
 
 	switch resFormat {
 	case emptyFileExt, sqlFileExt:
-		if name == emptyStr {
-			name = fmt.Sprintf("doltdump.sql")
+		var defaultName string
+		if schemaOnly {
+			defaultName = fmt.Sprintf("doltdump_schema_only.sql")
 		} else {
-			if !strings.HasSuffix(name, ".sql") {
-				name = fmt.Sprintf("%s.sql", name)
+			defaultName = fmt.Sprintf("doltdump.sql")
+		}
+
+		if outputFileOrDirName == emptyStr {
+			outputFileOrDirName = defaultName
+		} else {
+			if !strings.HasSuffix(outputFileOrDirName, ".sql") {
+				outputFileOrDirName = fmt.Sprintf("%s.sql", outputFileOrDirName)
 			}
 		}
 
-		dumpOpts := getDumpOptions(name, resFormat)
-		fPath, err := checkAndCreateOpenDestFile(ctx, root, dEnv, force, dumpOpts, name)
+		dumpOpts := getDumpOptions(outputFileOrDirName, resFormat, schemaOnly)
+		fPath, err := checkAndCreateOpenDestFile(ctx, root, dEnv, force, dumpOpts, outputFileOrDirName)
 		if err != nil {
 			return HandleVErrAndExitCode(err, usage)
 		}
@@ -173,24 +184,24 @@ func (cmd DumpCmd) Exec(ctx context.Context, commandStr string, args []string, d
 		}
 
 		for _, tbl := range tblNames {
-			tblOpts := newTableArgs(tbl, dumpOpts.dest, !apr.Contains(noBatchFlag), apr.Contains(noAutocommitFlag))
+			tblOpts := newTableArgs(tbl, dumpOpts.dest, !apr.Contains(noBatchFlag), apr.Contains(noAutocommitFlag), schemaOnly)
 			err = dumpTable(ctx, dEnv, tblOpts, fPath)
 			if err != nil {
 				return HandleVErrAndExitCode(err, usage)
 			}
 		}
 	case csvFileExt:
-		err = dumpTables(ctx, root, dEnv, force, tblNames, csvFileExt, name, false)
+		err = dumpNonSqlTables(ctx, root, dEnv, force, tblNames, csvFileExt, outputFileOrDirName, false)
 		if err != nil {
 			return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 		}
 	case jsonFileExt:
-		err = dumpTables(ctx, root, dEnv, force, tblNames, jsonFileExt, name, false)
+		err = dumpNonSqlTables(ctx, root, dEnv, force, tblNames, jsonFileExt, outputFileOrDirName, false)
 		if err != nil {
 			return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 		}
 	case parquetFileExt:
-		err = dumpTables(ctx, root, dEnv, force, tblNames, parquetFileExt, name, false)
+		err = dumpNonSqlTables(ctx, root, dEnv, force, tblNames, parquetFileExt, outputFileOrDirName, false)
 		if err != nil {
 			return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 		}
@@ -205,11 +216,13 @@ func (cmd DumpCmd) Exec(ctx context.Context, commandStr string, args []string, d
 
 type dumpOptions struct {
 	format string
+	schemaOnly bool
 	dest   mvdata.DataLocation
 }
 
 type tableOptions struct {
 	tableName     string
+	schemaOnly    bool
 	dest          mvdata.DataLocation
 	batched       bool
 	autocommitOff bool
@@ -257,8 +270,17 @@ func dumpTable(ctx context.Context, dEnv *env.DoltEnv, tblOpts *tableOptions, fi
 		return errhand.BuildDError("Error creating writer for %s.", tblOpts.SrcName()).AddCause(err).Build()
 	}
 
-	pipeline := mvdata.NewDataMoverPipeline(ctx, rd, wr)
-	err = pipeline.Execute()
+	if tblOpts.schemaOnly {
+		// table schema can be exported to only sql file.
+		if sqlExpWr, ok := wr.(*sqlexport.SqlExportWriter); ok {
+			err = sqlExpWr.WriteDropCreateOnly(ctx)
+		} else {
+			err = errhand.BuildDError("Cannot export table schemas to non-sql output file").Build()
+		}
+	} else {
+		pipeline := mvdata.NewDataMoverPipeline(ctx, rd, wr)
+		err = pipeline.Execute()
+	}
 
 	if err != nil {
 		return errhand.BuildDError("Error with dumping %s.", tblOpts.SrcName()).AddCause(err).Build()
@@ -363,6 +385,7 @@ func validateArgs(apr *argparser.ArgParseResults) (string, errhand.VerboseError)
 	rf = strings.TrimPrefix(rf, ".")
 	fn, fnOk := apr.GetValue(filenameFlag)
 	dn, dnOk := apr.GetValue(directoryFlag)
+	snOk := apr.Contains(schemaOnlyFlag)
 
 	if fnOk && dnOk {
 		return emptyStr, errhand.BuildDError("cannot pass both directory and file names").SetPrintUsage().Build()
@@ -373,19 +396,12 @@ func validateArgs(apr *argparser.ArgParseResults) (string, errhand.VerboseError)
 			return emptyStr, errhand.BuildDError("%s is not supported for %s exports", directoryFlag, sqlFileExt).SetPrintUsage().Build()
 		}
 		return fn, nil
-	case csvFileExt:
+	case csvFileExt, jsonFileExt, parquetFileExt:
 		if fnOk {
-			return emptyStr, errhand.BuildDError("%s is not supported for %s exports", filenameFlag, csvFileExt).SetPrintUsage().Build()
+			return emptyStr, errhand.BuildDError("%s is not supported for %s exports", filenameFlag, rf).SetPrintUsage().Build()
 		}
-		return dn, nil
-	case jsonFileExt:
-		if fnOk {
-			return emptyStr, errhand.BuildDError("%s is not supported for %s exports", filenameFlag, jsonFileExt).SetPrintUsage().Build()
-		}
-		return dn, nil
-	case parquetFileExt:
-		if fnOk {
-			return emptyStr, errhand.BuildDError("%s is not supported for %s exports", filenameFlag, parquetFileExt).SetPrintUsage().Build()
+		if snOk {
+			return emptyStr, errhand.BuildDError("%s is not supported for %s exports", schemaOnlyFlag, rf).SetPrintUsage().Build()
 		}
 		return dn, nil
 	default:
@@ -394,29 +410,34 @@ func validateArgs(apr *argparser.ArgParseResults) (string, errhand.VerboseError)
 }
 
 // getDumpArgs returns dumpOptions of result format and dest file location corresponding to the input parameters
-func getDumpOptions(fileName string, rf string) *dumpOptions {
+func getDumpOptions(fileName string, rf string, schemaOnly bool) *dumpOptions {
 	fileLoc := getDumpDestination(fileName)
 
 	return &dumpOptions{
 		format: rf,
+		schemaOnly: schemaOnly,
 		dest:   fileLoc,
 	}
 }
 
 // newTableArgs returns tableOptions of table name and src table location and dest file location
 // corresponding to the input parameters
-func newTableArgs(tblName string, destination mvdata.DataLocation, batched bool, autocommitOff bool) *tableOptions {
+func newTableArgs(tblName string, destination mvdata.DataLocation, batched, autocommitOff, schemaOnly bool) *tableOptions {
+	if schemaOnly {
+		batched = false
+	}
 	return &tableOptions{
 		tableName:     tblName,
+		schemaOnly:    schemaOnly,
 		dest:          destination,
 		batched:       batched,
 		autocommitOff: autocommitOff,
 	}
 }
 
-// dumpTables returns nil if all tables is dumped successfully, and it returns err if there is one.
+// dumpNonSqlTables returns nil if all tables is dumped successfully, and it returns err if there is one.
 // It handles only csv and json file types(rf).
-func dumpTables(ctx context.Context, root *doltdb.RootValue, dEnv *env.DoltEnv, force bool, tblNames []string, rf string, dirName string, batched bool) errhand.VerboseError {
+func dumpNonSqlTables(ctx context.Context, root *doltdb.RootValue, dEnv *env.DoltEnv, force bool, tblNames []string, rf string, dirName string, batched bool) errhand.VerboseError {
 	var fName string
 	if dirName == emptyStr {
 		dirName = fmt.Sprintf("doltdump/")
@@ -428,14 +449,14 @@ func dumpTables(ctx context.Context, root *doltdb.RootValue, dEnv *env.DoltEnv, 
 
 	for _, tbl := range tblNames {
 		fName = fmt.Sprintf("%s%s.%s", dirName, tbl, rf)
-		dumpOpts := getDumpOptions(fName, rf)
+		dumpOpts := getDumpOptions(fName, rf, false)
 
 		fPath, err := checkAndCreateOpenDestFile(ctx, root, dEnv, force, dumpOpts, fName)
 		if err != nil {
 			return err
 		}
 
-		tblOpts := newTableArgs(tbl, dumpOpts.dest, batched, false)
+		tblOpts := newTableArgs(tbl, dumpOpts.dest, batched, false, false)
 
 		err = dumpTable(ctx, dEnv, tblOpts, fPath)
 		if err != nil {

--- a/go/cmd/dolt/commands/dump.go
+++ b/go/cmd/dolt/commands/dump.go
@@ -190,18 +190,8 @@ func (cmd DumpCmd) Exec(ctx context.Context, commandStr string, args []string, d
 				return HandleVErrAndExitCode(err, usage)
 			}
 		}
-	case csvFileExt:
-		err = dumpNonSqlTables(ctx, root, dEnv, force, tblNames, csvFileExt, outputFileOrDirName, false)
-		if err != nil {
-			return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-		}
-	case jsonFileExt:
-		err = dumpNonSqlTables(ctx, root, dEnv, force, tblNames, jsonFileExt, outputFileOrDirName, false)
-		if err != nil {
-			return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-		}
-	case parquetFileExt:
-		err = dumpNonSqlTables(ctx, root, dEnv, force, tblNames, parquetFileExt, outputFileOrDirName, false)
+	case csvFileExt, jsonFileExt, parquetFileExt:
+		err = dumpNonSqlTables(ctx, root, dEnv, force, tblNames, resFormat, outputFileOrDirName, false)
 		if err != nil {
 			return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 		}

--- a/go/cmd/dolt/commands/dump.go
+++ b/go/cmd/dolt/commands/dump.go
@@ -401,7 +401,7 @@ func validateArgs(apr *argparser.ArgParseResults) (string, errhand.VerboseError)
 			return emptyStr, errhand.BuildDError("%s is not supported for %s exports", filenameFlag, rf).SetPrintUsage().Build()
 		}
 		if snOk {
-			return emptyStr, errhand.BuildDError("%s is not supported for %s exports", schemaOnlyFlag, rf).SetPrintUsage().Build()
+			return emptyStr, errhand.BuildDError("%s dump is not supported for %s exports", schemaOnlyFlag, rf).SetPrintUsage().Build()
 		}
 		return dn, nil
 	default:

--- a/go/cmd/dolt/commands/dump.go
+++ b/go/cmd/dolt/commands/dump.go
@@ -94,9 +94,9 @@ func (cmd DumpCmd) ArgParser() *argparser.ArgParser {
 	ap.SupportsString(directoryFlag, "d", "directory_name", "Define directory name to dump the files in. Defaults to `doltdump/`.")
 	ap.SupportsFlag(forceParam, "f", "If data already exists in the destination, the force flag will allow the target to be overwritten.")
 	ap.SupportsFlag(batchFlag, "", "Return batch insert statements wherever possible, enabled by default.")
-	ap.SupportsFlag(noBatchFlag, "", "Always emit one row per statement, rather than batching multiple rows into each statement.")
-	ap.SupportsFlag(noAutocommitFlag, "na", "Turns off autocommit for each dumped table. Used to speed up loading of outputted sql file")
-	ap.SupportsFlag(schemaOnlyFlag, "", "Dumping a table schema with no data to sql file")
+	ap.SupportsFlag(noBatchFlag, "", "Emit one row per statement, instead of batching multiple rows into each statement.")
+	ap.SupportsFlag(noAutocommitFlag, "na", "Turn off autocommit for each dumped table. Useful for speeding up loading of output SQL file.")
+	ap.SupportsFlag(schemaOnlyFlag, "", "Dump a table's schema, without including any data, to the output SQL file.")
 	return ap
 }
 

--- a/go/libraries/doltcore/table/untyped/sqlexport/sqlwriter.go
+++ b/go/libraries/doltcore/table/untyped/sqlexport/sqlwriter.go
@@ -142,6 +142,10 @@ func (w *SqlExportWriter) maybeWriteDropCreate(ctx context.Context) error {
 	return nil
 }
 
+func (w *SqlExportWriter) WriteDropCreateOnly(ctx context.Context) error {
+	return w.maybeWriteDropCreate(ctx)
+}
+
 func (w *SqlExportWriter) maybeWriteAutocommitoff() error {
 	if w.writtenAutocommitOff || !w.autocommitOff {
 		return nil

--- a/integration-tests/bats/dump.bats
+++ b/integration-tests/bats/dump.bats
@@ -638,6 +638,30 @@ teardown() {
     [ ! -f dumps/warehouse.json ]
 }
 
+@test "dump: dump with schema-only flag" {
+    dolt sql -q "CREATE TABLE new_table(pk int primary key);"
+    dolt sql -q "INSERT INTO new_table VALUES (1), (2);"
+    run dolt dump --schema-only
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Successfully exported data." ]] || false
+    [ -f doltdump_schema_only.sql ]
+
+    run grep 'CREATE TABLE' doltdump_schema_only.sql
+    [ "${#lines[@]}" -eq 1 ]
+
+    run grep 'INSERT' doltdump_schema_only.sql
+    [ "${#lines[@]}" -eq 0 ]
+}
+
+@test "dump: dump with schema-only flag errors with non-sql output file" {
+    dolt sql -q "CREATE TABLE new_table(pk int primary key);"
+    dolt sql -q "INSERT INTO new_table VALUES (1), (2);"
+    run dolt dump --schema-only -r csv
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Cannot export table schemas to non-sql output file" ]] || false
+    [ ! -f doltdump_schema_only.csv ]
+}
+
 @test "dump: JSON type - export tables with types, longtext and blob" {
     skip "export table in json with these types not working"
     dolt sql -q "CREATE TABLE warehouse(warehouse_id int primary key, warehouse_name longtext);"

--- a/integration-tests/bats/dump.bats
+++ b/integration-tests/bats/dump.bats
@@ -658,7 +658,7 @@ teardown() {
     dolt sql -q "INSERT INTO new_table VALUES (1), (2);"
     run dolt dump --schema-only -r csv
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "Cannot export table schemas to non-sql output file" ]] || false
+    [[ "$output" =~ "schema-only dump is not supported for csv exports" ]] || false
     [ ! -f doltdump_schema_only.csv ]
 }
 


### PR DESCRIPTION
--schema-only is used for dump table schemas with no data into sql file.