### PR TITLE
go/libraries/doltcore/sqle: database_provider.go: Reuse ReadReplicaDatabase's upstream DoltDB instance in is{Branch,Tag} instead of creating a new one.

### DIFF
--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -1000,11 +1000,7 @@ func isBranch(ctx context.Context, db SqlDatabase, branchName string, dialer dbf
 	var ddbs []*doltdb.DoltDB
 
 	if rdb, ok := db.(ReadReplicaDatabase); ok {
-		remoteDB, err := rdb.remote.GetRemoteDB(ctx, rdb.ddb.Format(), dialer)
-		if err != nil {
-			return "", false, err
-		}
-		ddbs = append(ddbs, rdb.ddb, remoteDB)
+		ddbs = append(ddbs, rdb.ddb, rdb.srcDB)
 	} else if ddb, ok := db.(Database); ok {
 		ddbs = append(ddbs, ddb.ddb)
 	} else {
@@ -1030,11 +1026,7 @@ func isTag(ctx context.Context, db SqlDatabase, tagName string, dialer dbfactory
 	var ddbs []*doltdb.DoltDB
 
 	if rdb, ok := db.(ReadReplicaDatabase); ok {
-		remoteDB, err := rdb.remote.GetRemoteDB(ctx, rdb.ddb.Format(), dialer)
-		if err != nil {
-			return false, err
-		}
-		ddbs = append(ddbs, rdb.ddb, remoteDB)
+		ddbs = append(ddbs, rdb.ddb, rdb.srcDB)
 	} else if ddb, ok := db.(Database); ok {
 		ddbs = append(ddbs, ddb.ddb)
 	} else {


### PR DESCRIPTION
Calling remote.GetRemoteDB() creates a new gRPC connection pool, a new HTTP connection pool, a new chunk cache for the returned DoltDB, etc. There should only be one instance of the upstream DoltDB for the ReadReplicaDatabase, and we can just use the one we have to check for branch and tag existence.