### PR TITLE
add "create database" header to dolt dump sql files

### DIFF
--- a/integration-tests/bats/dump.bats
+++ b/integration-tests/bats/dump.bats
@@ -35,7 +35,11 @@ teardown() {
 
     run grep CREATE doltdump.sql
     [ "$status" -eq 0 ]
-    [ "${#lines[@]}" -eq 3 ]
+    [ "${#lines[@]}" -eq 4 ]
+
+    run grep "DATABASE IF NOT EXISTS" doltdump.sql
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 1 ]
 
     run grep FOREIGN_KEY_CHECKS=0 doltdump.sql
     [ "$status" -eq 0 ]
@@ -314,7 +318,7 @@ teardown() {
 
     run grep CREATE doltdump.sql
     [ "$status" -eq 0 ]
-    [ "${#lines[@]}" -eq 2 ]
+    [ "${#lines[@]}" -eq 3 ]
 
     run grep INSERT doltdump.sql
     [ "$status" -eq 1 ]
@@ -340,7 +344,7 @@ teardown() {
 
     run grep CREATE dumpfile.sql
     [ "$status" -eq 0 ]
-    [ "${#lines[@]}" -eq 3 ]
+    [ "${#lines[@]}" -eq 4 ]
 }
 
 @test "dump: SQL type - with directory name given" {

--- a/integration-tests/bats/dump.bats
+++ b/integration-tests/bats/dump.bats
@@ -66,6 +66,23 @@ teardown() {
     [[ "$output" =~ "Rows inserted: 6 Rows updated: 0 Rows deleted: 0" ]] || false
 }
 
+@test "dump: SQL type - no-create-db flag" {
+    dolt sql -q "CREATE TABLE new_table(pk int primary key);"
+    dolt sql -q "INSERT INTO new_table VALUES (1);"
+    dolt sql -q "CREATE TABLE warehouse(warehouse_id int primary key, warehouse_name longtext);"
+    dolt sql -q "INSERT into warehouse VALUES (1, 'UPS'), (2, 'TV'), (3, 'Table');"
+    dolt sql -q "create table enums (a varchar(10) primary key, b enum('one','two','three'))"
+    dolt sql -q "insert into enums values ('abc', 'one'), ('def', 'two')"
+
+    run dolt dump --no-create-db
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Successfully exported data." ]] || false
+    [ -f doltdump.sql ]
+
+    run grep "CREATE DATABASE" doltdump.sql
+    [ "$status" -eq 1 ]
+}
+
 @test "dump: SQL type - database name is reserved word/keyword" {
     dolt sql -q "CREATE DATABASE \`interval\`;"
     cd interval

--- a/integration-tests/data-dump-loading-tests/README.md
+++ b/integration-tests/data-dump-loading-tests/README.md
@@ -2,8 +2,11 @@
 We created tests for loading data dumps from mysqldump, and we run these tests through Github Actions
 on pull requests.
 
-These tests can be run locally using Docker. From the root directory of this repo, run:
+These tests can be run locally using Docker. Before you can build the image, you also need to copy the go folder
+into the integration-tests folder; unfortunately just symlinking doesn't seem to work. From the
+integration-tests directory of the dolt repo, run:
 ```bash
+$ cp -r ../go . 
 $ docker build -t data-dump-loading-tests -f DataDumpLoadDockerfile .
 $ docker run data-dump-loading-tests:latest
 ```

--- a/integration-tests/data-dump-loading-tests/import-mysqldump.bats
+++ b/integration-tests/data-dump-loading-tests/import-mysqldump.bats
@@ -339,7 +339,7 @@ SQL
 
     run dolt sql -q "show create table geometry_type;" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "\`g\` geometry DEFAULT (POINT(1, 2))," ]] || false
+    [[ "$output" =~ "\`g\` geometry DEFAULT (point(1,2))," ]] || false
 
     run dolt sql <<SQL
 CREATE TABLE polygon_type (
@@ -352,19 +352,19 @@ SQL
 
     run dolt sql -q "show create table polygon_type;" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "\`p\` polygon DEFAULT (POLYGON(LINESTRING(POINT(0, 0),POINT(8, 0),POINT(12, 9),POINT(0, 9),POINT(0, 0))))," ]] || false
+    [[ "$output" =~ "\`p\` polygon DEFAULT (polygon(linestring(point(0,0),point(8,0),point(12,9),point(0,9),point(0,0))))," ]] || false
 }
 
 @test "import mysqldump: select into syntax in procedure" {
     run dolt sql <<SQL
 CREATE TABLE inventory (item_id int primary key, shelf_id int, item varchar(10));
 INSERT INTO inventory VALUES (1, 1, 'a'), (2, 1, 'b'), (3, 2, 'c'), (4, 1, 'd'), (5, 4, 'e');
-DELIMITER $$ ;
+DELIMITER $$
 CREATE PROCEDURE count_and_print(IN p_shelf_id INT, OUT p_count INT) BEGIN
   SELECT item FROM inventory WHERE shelf_id = p_shelf_id ORDER BY item ASC;
   SELECT COUNT(*) INTO p_count FROM inventory WHERE shelf_id = p_shelf_id;
 END$$
-DELIMITER ; $$
+DELIMITER ;
 SQL
     [ "$status" -eq 0 ]
 
@@ -389,11 +389,11 @@ CREATE TABLE film (
   description text,
   PRIMARY KEY (film_id)
 );
-DELIMITER $$ ;
+DELIMITER $$
 CREATE TRIGGER ins_film AFTER INSERT ON film FOR EACH ROW BEGIN
   INSERT INTO film_text (film_id, title, description) VALUES (new.film_id, new.title, new.description);
 END$$
-DELIMITER ; $$
+DELIMITER ;
 SQL
     [ "$status" -eq 0 ]
 
@@ -422,7 +422,7 @@ SQL
 CREATE TABLE t0 (id INT PRIMARY KEY AUTO_INCREMENT, v1 INT, v2 TEXT);
 CREATE TABLE t1 (id INT PRIMARY KEY AUTO_INCREMENT, v1 INT, v2 TEXT);
 INSERT INTO t0 VALUES (1, 2, 'abc'), (2, 3, 'def');
-DELIMITER $$ ;
+DELIMITER $$
 CREATE PROCEDURE add_entry(i INT, s TEXT) BEGIN
   IF i > 50 THEN
     SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'too big number';
@@ -432,7 +432,7 @@ END$$
 CREATE TRIGGER trig AFTER INSERT ON t0 FOR EACH ROW BEGIN
   CALL back_up(NEW.v1, NEW.v2);
 END$$
-DELIMITER ; $$
+DELIMITER ;
 SQL
     [ "$status" -eq 0 ]
 
@@ -492,7 +492,7 @@ SQL
 CREATE DATABASE IF NOT EXISTS testdb;
 SQL
 
-    run dolt dump --no-autocommit
+    run dolt dump --no-autocommit --no-create-db
     [ -f doltdump.sql ]
 
     # remove the utf8mb4_0900_bin collation which is not supported in this installation of mysql


### PR DESCRIPTION
automatically adds `CREATE DATABASE IF NOT EXISTS ...; USE db;` to all dolt dump sql files, preventing errors from importing to dolt in non database directories

fixes: https://github.com/dolthub/dolt/issues/4837