### PR TITLE
go/libraries/doltcore/remotestorage: chunk_store: Fix semantics of Rebase and Root. Root stays fixed until a Rebase call.

### DIFF
--- a/go/libraries/doltcore/remotesrv/grpc.go
+++ b/go/libraries/doltcore/remotesrv/grpc.go
@@ -383,15 +383,6 @@ func (rs *RemoteChunkStore) Rebase(ctx context.Context, req *remotesapi.RebaseRe
 		return nil, status.Error(codes.Internal, "Could not get chunkstore")
 	}
 
-	logger.Printf("found %s", repoPath)
-
-	err = cs.Rebase(ctx)
-
-	if err != nil {
-		logger.Printf("error occurred during processing of Rebase rpc of %s details: %v", repoPath, err)
-		return nil, status.Errorf(codes.Internal, "failed to rebase: %v", err)
-	}
-
 	return &remotesapi.RebaseResponse{}, nil
 }
 
@@ -474,11 +465,6 @@ func (rs *RemoteChunkStore) GetRepoMetadata(ctx context.Context, req *remotesapi
 	}
 	if cs == nil {
 		return nil, status.Error(codes.Internal, "Could not get chunkstore")
-	}
-
-	err = cs.Rebase(ctx)
-	if err != nil {
-		return nil, err
 	}
 
 	size, err := cs.Size(ctx)

--- a/go/libraries/doltcore/sqle/cluster/commithook.go
+++ b/go/libraries/doltcore/sqle/cluster/commithook.go
@@ -226,11 +226,13 @@ func (h *commithook) attemptReplicate(ctx context.Context) {
 		datasDB := doltdb.HackDatasDatabaseFromDoltDB(destDB)
 		cs := datas.ChunkStoreFromDatabase(datasDB)
 		var curRootHash hash.Hash
-		if curRootHash, err = cs.Root(ctx); err == nil {
-			var ok bool
-			ok, err = cs.Commit(ctx, toPush, curRootHash)
-			if err == nil && !ok {
-				err = errDestDBRootHashMoved
+		if err = cs.Rebase(ctx); err == nil {
+			if curRootHash, err = cs.Root(ctx); err == nil {
+				var ok bool
+				ok, err = cs.Commit(ctx, toPush, curRootHash)
+				if err == nil && !ok {
+					err = errDestDBRootHashMoved
+				}
 			}
 		}
 	}

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -1000,11 +1000,7 @@ func isBranch(ctx context.Context, db SqlDatabase, branchName string, dialer dbf
 	var ddbs []*doltdb.DoltDB
 
 	if rdb, ok := db.(ReadReplicaDatabase); ok {
-		remoteDB, err := rdb.remote.GetRemoteDB(ctx, rdb.ddb.Format(), dialer)
-		if err != nil {
-			return "", false, err
-		}
-		ddbs = append(ddbs, rdb.ddb, remoteDB)
+		ddbs = append(ddbs, rdb.ddb, rdb.srcDB)
 	} else if ddb, ok := db.(Database); ok {
 		ddbs = append(ddbs, ddb.ddb)
 	} else {
@@ -1030,11 +1026,7 @@ func isTag(ctx context.Context, db SqlDatabase, tagName string, dialer dbfactory
 	var ddbs []*doltdb.DoltDB
 
 	if rdb, ok := db.(ReadReplicaDatabase); ok {
-		remoteDB, err := rdb.remote.GetRemoteDB(ctx, rdb.ddb.Format(), dialer)
-		if err != nil {
-			return false, err
-		}
-		ddbs = append(ddbs, rdb.ddb, remoteDB)
+		ddbs = append(ddbs, rdb.ddb, rdb.srcDB)
 	} else if ddb, ok := db.(Database); ok {
 		ddbs = append(ddbs, ddb.ddb)
 	} else {

--- a/go/store/datas/pull/pull.go
+++ b/go/store/datas/pull/pull.go
@@ -136,18 +136,14 @@ func pull(ctx context.Context, srcCS, sinkCS chunks.ChunkStore, walkAddrs WalkAd
 }
 
 func persistChunks(ctx context.Context, cs chunks.ChunkStore) error {
-	// todo: there is no call to rebase on an unsuccessful Commit()
-	// will  this loop forever?
 	var success bool
 	for !success {
 		r, err := cs.Root(ctx)
-
 		if err != nil {
 			return err
 		}
 
 		success, err = cs.Commit(ctx, r, r)
-
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When remotestorage.DoltChunkStore was originally written, it forwarded all ChunkStore calls to the remotesapi. In reality, a client should expect a snapshot of the database on open, and the root should only change when Rebase() or Commit() is called. This fixes up that initial flaw. Rebase() becomes a refresh of the Root from the gRPC service, and Root() itself is just a read of the cached root hash.

This reduces unnecessary traffic to the remotestorage service and improves performance of things like sql-server read replicas.