### PR TITLE
Fix `call DOLT_VERIFY_CONSTRAINTS()` false-positive

### DIFF
--- a/go/libraries/doltcore/merge/violations_fk.go
+++ b/go/libraries/doltcore/merge/violations_fk.go
@@ -661,7 +661,7 @@ func newConstraintViolationsLoadedTable(ctx context.Context, tblName, idxName st
 			IsUserDefined: false,
 			Comment:       "",
 		}
-		pkIdx := schema.NewIndex("", pkCols.SortedTags, pkCols.SortedTags, pkIdxColl, pkIdxProps)
+		pkIdx := schema.NewIndex("", pkCols.Tags, pkCols.Tags, pkIdxColl, pkIdxProps)
 		return &constraintViolationsLoadedTable{
 			TableName:   trueTblName,
 			Table:       tbl,

--- a/go/libraries/doltcore/merge/violations_fk_prolly.go
+++ b/go/libraries/doltcore/merge/violations_fk_prolly.go
@@ -42,7 +42,7 @@ func prollyParentFkConstraintViolations(
 	postParentRowData := durable.ProllyMapFromIndex(postParent.RowData)
 	postParentIndexData := durable.ProllyMapFromIndex(postParent.IndexData)
 
-	idxDesc := postParent.Index.Schema().GetKeyDescriptor()
+	idxDesc, _ := postParentIndexData.Descriptors()
 	partialDesc := idxDesc.PrefixDesc(len(foreignKey.TableColumns))
 	partialKB := val.NewTupleBuilder(partialDesc)
 
@@ -102,12 +102,11 @@ func prollyChildFkConstraintViolations(
 	preChildRowData prolly.Map,
 	receiver FKViolationReceiver) error {
 	postChildRowData := durable.ProllyMapFromIndex(postChild.RowData)
+	parentScndryIdx := durable.ProllyMapFromIndex(postParent.IndexData)
 
-	idxDesc := postChild.Index.Schema().GetKeyDescriptor()
+	idxDesc, _ := parentScndryIdx.Descriptors()
 	partialDesc := idxDesc.PrefixDesc(len(foreignKey.TableColumns))
 	partialKB := val.NewTupleBuilder(partialDesc)
-
-	parentScndryIdx := durable.ProllyMapFromIndex(postParent.IndexData)
 
 	err := prolly.DiffMaps(ctx, preChildRowData, postChildRowData, func(ctx context.Context, diff tree.Diff) error {
 		switch diff.Type {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
@@ -3049,6 +3049,49 @@ var DoltVerifyConstraintsTestScripts = []queries.ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "verify-constraints: Regression test for bad compound primary key reuse as foreign key index - no error",
+		SetUpScript: []string{
+			"create table parent (col1 int not null, col2 float not null, primary key (col1, col2));",
+			"create table child (col1 int not null, col2 float not null, col3 int not null, col4 float not null, col5 int not null, col6 float not null, primary key (col1, col2, col3, col4, col5, col6), foreign key (col1, col2) references parent (col1, col2));",
+			"set foreign_key_checks = 0;",
+			"insert into parent values (1, 2.5), (7, 8.5);",
+			"insert into child values (1, 2.5, 3, 4.5, 5, 6.5), (7, 8.5, 9, 10.5, 11, 12.5);",
+			"set foreign_key_checks = 1;",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "call DOLT_VERIFY_CONSTRAINTS('--all');",
+				Expected: []sql.Row{{0}},
+			},
+			{
+				Query:    "select * from dolt_constraint_violations;",
+				Expected: []sql.Row{},
+			},
+		},
+	},
+	{
+		Name: "verify-constraints: Regression test for bad compound primary key reuse as foreign key index - error",
+		SetUpScript: []string{
+			"create table parent (col1 int not null, col2 float not null, primary key (col1, col2));",
+			"create table child (col1 int not null, col2 float not null, col3 int not null, col4 float not null, col5 int not null, col6 float not null, primary key (col1, col2, col3, col4, col5, col6), foreign key (col1, col2) references parent (col1, col2));",
+			"set foreign_key_checks = 0;",
+			"insert into parent values (1, 2.5);",
+			"insert into child values (1, 2.5, 3, 4.5, 5, 6.5), (7, 8.5, 9, 10.5, 11, 12.5);",
+			"set foreign_key_checks = 1;",
+			"set dolt_force_transaction_commit = 1;",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "call DOLT_VERIFY_CONSTRAINTS('--all');",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				Query:    "select * from dolt_constraint_violations;",
+				Expected: []sql.Row{{"child", uint64(1)}},
+			},
+		},
+	},
 }
 
 var errTmplNoAutomaticMerge = "table %s can't be automatically merged.\nTo merge this table, make the schema on the source and target branch equal."


### PR DESCRIPTION
Fix for bug reported by Fritter in Discord.

Here's what happened:
- Parent table has a simple pk
- Child table has a compound pk of length 3
- The foreign key is a single int column. It is the first column in the child table's pk, and the only column of parent's pk.
- No additional indexes are defined because we can reuse the pk index.

If we reuse the pk index, we have some special case code that builds a fake index definition. The issue is that we happened to pass sorted tags of the pks, instead the column-order tags. We then use the index definition to prefix iter secondary indexes.

This issue would not appear if you got lucky with the tags of your columns. Specifically, the sorted tag order had to match the tag order. For tables with one pk, this is always the case, and for the test we have for two pks, we also happen to get lucky. Unfortunately, Fritter has three column compound pk and he did not get lucky.