### PR TITLE
Removed branch control database file size limitation

### DIFF
--- a/go/libraries/doltcore/branch_control/access.go
+++ b/go/libraries/doltcore/branch_control/access.go
@@ -364,10 +364,10 @@ func (tbl *Access) insert(database string, branch string, user string, host stri
 
 // Serialize returns the offset for the AccessValue written to the given builder.
 func (val *AccessValue) Serialize(b *flatbuffers.Builder) flatbuffers.UOffsetT {
-	database := b.CreateString(val.Database)
-	branch := b.CreateString(val.Branch)
-	user := b.CreateString(val.User)
-	host := b.CreateString(val.Host)
+	database := b.CreateSharedString(val.Database)
+	branch := b.CreateSharedString(val.Branch)
+	user := b.CreateSharedString(val.User)
+	host := b.CreateSharedString(val.Host)
 
 	serial.BranchControlAccessValueStart(b)
 	serial.BranchControlAccessValueAddDatabase(b, database)

--- a/go/libraries/doltcore/branch_control/binlog.go
+++ b/go/libraries/doltcore/branch_control/binlog.go
@@ -203,10 +203,10 @@ func (binlog *Binlog) Rows() []BinlogRow {
 
 // Serialize returns the offset for the BinlogRow written to the given builder.
 func (row *BinlogRow) Serialize(b *flatbuffers.Builder) flatbuffers.UOffsetT {
-	database := b.CreateString(row.Database)
-	branch := b.CreateString(row.Branch)
-	user := b.CreateString(row.User)
-	host := b.CreateString(row.Host)
+	database := b.CreateSharedString(row.Database)
+	branch := b.CreateSharedString(row.Branch)
+	user := b.CreateSharedString(row.User)
+	host := b.CreateSharedString(row.Host)
 
 	serial.BranchControlBinlogRowStart(b)
 	serial.BranchControlBinlogRowAddIsInsert(b, row.IsInsert)

--- a/go/libraries/doltcore/branch_control/namespace.go
+++ b/go/libraries/doltcore/branch_control/namespace.go
@@ -316,10 +316,10 @@ func (tbl *Namespace) filterHosts(filters []uint32) []MatchExpression {
 
 // Serialize returns the offset for the NamespaceValue written to the given builder.
 func (val *NamespaceValue) Serialize(b *flatbuffers.Builder) flatbuffers.UOffsetT {
-	database := b.CreateString(val.Database)
-	branch := b.CreateString(val.Branch)
-	user := b.CreateString(val.User)
-	host := b.CreateString(val.Host)
+	database := b.CreateSharedString(val.Database)
+	branch := b.CreateSharedString(val.Branch)
+	user := b.CreateSharedString(val.User)
+	host := b.CreateSharedString(val.Host)
 
 	serial.BranchControlNamespaceValueStart(b)
 	serial.BranchControlNamespaceValueAddDatabase(b, database)


### PR DESCRIPTION
The resulting database file is fully compatible with older dolt clients since the read path skips the size and noms prefix. Switching the strings to `CreateShared` also gave a decent space savings as well.

To see if there was a noticeable performance difference, I tried removing everything except for the binlog, and reconstructing the branch control tables from the binlog, and the differences were negligible. The resulting file was definitely smaller, but performance-wise there wasn't much difference when reading or writing from the file. We spend so much time in the engine that it doesn't really matter. So I decided to go this route since we still retain full compatibility.