### PR TITLE
Fix log table RowCount panic

### DIFF
--- a/go/libraries/doltcore/sqle/dtables/diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/diff_table.go
@@ -326,15 +326,6 @@ func (dt *DiffTable) GetIndexes(ctx *sql.Context) ([]sql.Index, error) {
 
 // IndexedAccess implements sql.IndexAddressable
 func (dt *DiffTable) IndexedAccess(lookup sql.IndexLookup) sql.IndexedTable {
-	//if !types.IsFormat_DOLT(dt.ddb.Format()) {
-	//	return nil
-	//}
-	//if lookup.Index.ID() == index.CommitHashIndexId {
-	//	_, ok := index.LookupToPointSelectStr(lookup)
-	//	if !ok {
-	//		return nil
-	//	}
-	//}
 	nt := *dt
 	return &nt
 }

--- a/go/libraries/doltcore/sqle/dtables/log_table.go
+++ b/go/libraries/doltcore/sqle/dtables/log_table.go
@@ -57,6 +57,9 @@ func (dt *LogTable) RowCount(ctx *sql.Context) (uint64, error) {
 		// TODO: remove this when we deprecate LD
 		return 1000, nil
 	}
+	if cc.IsEmpty() {
+		return 1, nil
+	}
 	cnt, err := cc.Count()
 	return uint64(cnt + 1), err
 }

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -2893,4 +2893,16 @@ var SystemTableIndexTests = []systabScript{
 			},
 		},
 	},
+	{
+		name: "empty log table",
+		setup: []string{
+			"create table xy (x int primary key, y int)",
+		},
+		queries: []systabQuery{
+			{
+				query: "select count(*) from dolt_log as dc join dolt_commit_ancestors as dca on dc.commit_hash = dca.commit_hash;",
+				exp:   []sql.Row{{1}},
+			},
+		},
+	},
 }


### PR DESCRIPTION
`CommitClosure` methods are not nil-safe, check before calling `CommitClosure.Count()`.