### PR TITLE
Fix 3 merge bugs related to secondary indexes

### DIFF
--- a/go/libraries/doltcore/doltdb/table.go
+++ b/go/libraries/doltcore/doltdb/table.go
@@ -373,11 +373,16 @@ func (t *Table) GetConstraintViolationsSchema(ctx context.Context) (schema.Schem
 	if t.Format() == types.Format_DOLT {
 		// the commit hash or working set hash of the right side during merge
 		colColl = colColl.Append(schema.NewColumn("from_root_ish", 0, types.StringKind, false))
+		colColl = colColl.Append(typeCol)
+		colColl = colColl.Append(sch.GetPKCols().GetColumns()...)
+		colColl = colColl.Append(sch.GetNonPKCols().GetColumns()...)
+		colColl = colColl.Append(infoCol)
+	} else {
+		colColl = colColl.Append(typeCol)
+		colColl = colColl.Append(sch.GetAllCols().GetColumns()...)
+		colColl = colColl.Append(infoCol)
 	}
 
-	colColl = colColl.Append(typeCol)
-	colColl = colColl.Append(sch.GetAllCols().GetColumns()...)
-	colColl = colColl.Append(infoCol)
 	return schema.SchemaFromCols(colColl)
 }
 

--- a/go/libraries/doltcore/merge/merge_prolly_indexes.go
+++ b/go/libraries/doltcore/merge/merge_prolly_indexes.go
@@ -211,6 +211,8 @@ func buildIndex(ctx context.Context, vrw types.ValueReadWriter, ns tree.NodeStor
 		kb := val.NewTupleBuilder(kd)
 		p := m.Pool()
 
+		pkMapping := ordinalMappingFromIndex(index)
+
 		mergedMap, err := creation.BuildUniqueProllyIndex(
 			ctx,
 			vrw,
@@ -219,8 +221,8 @@ func buildIndex(ctx context.Context, vrw types.ValueReadWriter, ns tree.NodeStor
 			index,
 			m,
 			func(ctx context.Context, existingKey, newKey val.Tuple) (err error) {
-				eK := getSuffix(kb, p, existingKey)
-				nK := getSuffix(kb, p, newKey)
+				eK := getPKFromSecondaryKey(kb, p, pkMapping, existingKey)
+				nK := getPKFromSecondaryKey(kb, p, pkMapping, newKey)
 				err = replaceUniqueKeyViolation(ctx, artEditor, m, eK, kd, theirRootIsh, vInfo, tblName)
 				if err != nil {
 					return err


### PR DESCRIPTION
- The schema of the dolt_constraint_violations table was incorrect.
- Unique key violations were being thrown by merge even if the index key included a null value.
- The primary key was being built incorrectly for the unique key violations generated by merge. Previously it was assumed that the primary index's key was a suffix of the secondary index's key. This is not the case when the index key includes a column in the primary key.