### PR TITLE
dolt pull without configs doesnt return error when up to date

### DIFF
--- a/go/cmd/dolt/commands/pull.go
+++ b/go/cmd/dolt/commands/pull.go
@@ -17,11 +17,11 @@ package commands
 import (
 	"context"
 	"fmt"
-	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	eventsapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/merge"

--- a/go/cmd/dolt/commands/pull.go
+++ b/go/cmd/dolt/commands/pull.go
@@ -17,6 +17,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
@@ -181,7 +182,7 @@ func pullHelper(ctx context.Context, dEnv *env.DoltEnv, pullSpec *env.PullSpec) 
 			// If configurations are not set and a ff merge are not possible throw an error.
 			if configErr != nil {
 				canFF, err := mergeSpec.HeadC.CanFastForwardTo(ctx, mergeSpec.MergeC)
-				if err != nil {
+				if err != nil && err != doltdb.ErrUpToDate {
 					return err
 				}
 

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -1295,6 +1295,10 @@ SQL
     [ "$status" -eq 0 ]
     [[ "$output" =~ "test commit" ]] || false
 
+    # test pull with workspace up to date
+    run dolt pull
+    [ "$status" -eq 0 ]
+
     # turn back on the configs and make a change in the remote
     dolt config --global --add user.name mysql-test-runner
     dolt config --global --add user.email mysql-test-runner@liquidata.co

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -1298,6 +1298,7 @@ SQL
     # test pull with workspace up to date
     run dolt pull
     [ "$status" -eq 0 ]
+    [[ "$output" =~ "Everything up-to-date." ]] || false
 
     # turn back on the configs and make a change in the remote
     dolt config --global --add user.name mysql-test-runner


### PR DESCRIPTION
`dolt pull` should not error out when there is no user name or email set. However, when `dolt pull` is run in a workspace that is already up to date with remote, the CLI returns an error `up to date` instead of printing `Everything up-to-date.`. This change fixes `dolt pull` to not return an error when the workspace is already up to date.

fixes: https://github.com/dolthub/dolt/issues/5079