### PR TITLE
go/libraries/doltcore/sqle/dsess: When commiting a transaction with a  DOLT_COMMIT, merge against the current HEAD if necessary.

### DIFF
--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -170,7 +170,7 @@ func performCommit(ctx context.Context, commandStr string, args []string, dEnv *
 			}
 		}
 
-		err = actions.ResetSoftToRef(ctx, dEnv.DbData(), "HEAD~1")
+		_, err = actions.ResetSoftToRef(ctx, dEnv.DbData(), "HEAD~1")
 		if err != nil {
 			return handleResetError(err, usage)
 		}
@@ -203,7 +203,7 @@ func performCommit(ctx context.Context, commandStr string, args []string, dEnv *
 	})
 	if err != nil {
 		if apr.Contains(cli.AmendFlag) {
-			errRes := actions.ResetSoftToRef(ctx, dEnv.DbData(), headHash.String())
+			_, errRes := actions.ResetSoftToRef(ctx, dEnv.DbData(), headHash.String())
 			if errRes != nil {
 				return handleResetError(errRes, usage)
 			}
@@ -222,7 +222,7 @@ func performCommit(ctx context.Context, commandStr string, args []string, dEnv *
 	)
 	if err != nil {
 		if apr.Contains(cli.AmendFlag) {
-			errRes := actions.ResetSoftToRef(ctx, dEnv.DbData(), headHash.String())
+			_, errRes := actions.ResetSoftToRef(ctx, dEnv.DbData(), headHash.String())
 			if errRes != nil {
 				return handleResetError(errRes, usage)
 			}

--- a/go/cmd/dolt/commands/reset.go
+++ b/go/cmd/dolt/commands/reset.go
@@ -122,7 +122,7 @@ func (cmd ResetCmd) Exec(ctx context.Context, commandStr string, args []string, 
 
 			// This is a valid ref
 			if ok {
-				err = actions.ResetSoftToRef(ctx, dEnv.DbData(), apr.Arg(0))
+				_, err = actions.ResetSoftToRef(ctx, dEnv.DbData(), apr.Arg(0))
 				return handleResetError(err, usage)
 			}
 		}

--- a/go/libraries/doltcore/env/actions/reset.go
+++ b/go/libraries/doltcore/env/actions/reset.go
@@ -204,34 +204,34 @@ func ResetSoft(ctx context.Context, dbData env.DbData, tables []string, roots do
 
 // ResetSoftToRef matches the `git reset --soft <REF>` pattern. It resets both staged and head to the previous ref
 // and leaves the working unset. The user can then choose to create a commit that contains all changes since the ref.
-func ResetSoftToRef(ctx context.Context, dbData env.DbData, cSpecStr string) error {
+func ResetSoftToRef(ctx context.Context, dbData env.DbData, cSpecStr string) (*doltdb.RootValue, error) {
 	cs, err := doltdb.NewCommitSpec(cSpecStr)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	newHead, err := dbData.Ddb.Resolve(ctx, cs, dbData.Rsr.CWBHeadRef())
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	foundRoot, err := newHead.GetRootValue(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Changed the staged to the old root. Leave the working as is.
 	err = dbData.Rsw.UpdateStagedRoot(ctx, foundRoot)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Update the head to this commit
 	if err = dbData.Ddb.SetHeadToCommit(ctx, dbData.Rsr.CWBHeadRef(), newHead); err != nil {
-		return err
+		return nil, err
 	}
 
-	return err
+	return foundRoot, err
 }
 
 func getUnionedTables(ctx context.Context, tables []string, stagedRoot, headRoot *doltdb.RootValue) ([]string, error) {

--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -570,16 +570,17 @@ func (d *DoltSession) NewPendingCommit(ctx *sql.Context, dbName string, roots do
 			mergeParentCommits = append(mergeParentCommits, parentCommit)
 		}
 
-		err = actions.ResetSoftToRef(ctx, sessionState.dbData, "HEAD~1")
+		root, err := actions.ResetSoftToRef(ctx, sessionState.dbData, "HEAD~1")
 		if err != nil {
 			return nil, err
 		}
+		roots.Head = root
 	}
 
 	pendingCommit, err := actions.GetCommitStaged(ctx, roots, sessionState.WorkingSet.MergeActive(), mergeParentCommits, sessionState.dbData.Ddb, props)
 	if err != nil {
 		if props.Amend {
-			err = actions.ResetSoftToRef(ctx, sessionState.dbData, headHash.String())
+			_, err = actions.ResetSoftToRef(ctx, sessionState.dbData, headHash.String())
 			if err != nil {
 				return nil, err
 			}

--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -570,6 +570,8 @@ func (d *DoltSession) NewPendingCommit(ctx *sql.Context, dbName string, roots do
 			mergeParentCommits = append(mergeParentCommits, parentCommit)
 		}
 
+		// TODO: This is not the correct way to write this commit as an amend. While this commit is running
+		// the branch head moves backwards and concurrency control here is not principled.
 		root, err := actions.ResetSoftToRef(ctx, sessionState.dbData, "HEAD~1")
 		if err != nil {
 			return nil, err

--- a/go/libraries/doltcore/sqle/dsess/transactions.go
+++ b/go/libraries/doltcore/sqle/dsess/transactions.go
@@ -183,7 +183,7 @@ func doltCommit(ctx *sql.Context,
 				tx.mergeEditOpts,
 				mo)
 			if err != nil {
-			        return nil, nil, err
+				return nil, nil, err
 			}
 			logrus.Tracef("staged and HEAD merge took %s", time.Since(start))
 		}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_transaction_commit_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_transaction_commit_test.go
@@ -200,6 +200,22 @@ func TestDoltTransactionCommitTwoClients(t *testing.T) {
 				Query:    "/* client b */ START TRANSACTION;",
 				Expected: []sql.Row{},
 			},
+			// Concurrent with the two transactions which are going to (dolt_)commit changes, we
+			// have a transaction which only modifies the working set. At the end of this
+			// sequence, the changes to the working set should not be committed.
+			{
+				Query:    "/* client c */ START TRANSACTION;",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "/* client c */ INSERT INTO x values (4, 4)",
+				Expected: []sql.Row{{types.NewOkResult(1)}},
+			},
+			{
+				Query:    "/* client c */ COMMIT",
+				Expected: []sql.Row{},
+			},
+			// Now we have the two concurrent transactions commit their changes.
 			{
 				Query:    "/* client a */ SET @@dolt_transaction_commit=1;",
 				Expected: []sql.Row{{}},
@@ -262,14 +278,18 @@ func TestDoltTransactionCommitTwoClients(t *testing.T) {
 			},
 			{
 				Query:    "/* client a */ SELECT * FROM x ORDER BY y;",
-				Expected: []sql.Row{{1, 1}, {2, 2}, {3, 3}},
+				Expected: []sql.Row{{1, 1}, {2, 2}, {3, 3}, {4, 4}},
 			},
 			{
 				Query:    "/* client b */ SELECT * FROM x ORDER BY y;",
-				Expected: []sql.Row{{1, 1}, {2, 2}, {3, 3}},
+				Expected: []sql.Row{{1, 1}, {2, 2}, {3, 3}, {4, 4}},
 			},
 			{
 				Query:    "/* client c */ SELECT * FROM x ORDER BY y;",
+				Expected: []sql.Row{{1, 1}, {2, 2}, {3, 3}, {4, 4}},
+			},
+			{
+				Query:    "/* client c */ SELECT * FROM x AS OF 'HEAD' ORDER BY y;",
 				Expected: []sql.Row{{1, 1}, {2, 2}, {3, 3}},
 			},
 			// After we commit both of these transactions, our working set should not have any pending changes.
@@ -277,7 +297,7 @@ func TestDoltTransactionCommitTwoClients(t *testing.T) {
 			// commit itself.
 			{
 				Query:    "/* client c */ SELECT COUNT(*) FROM DOLT_DIFF('HEAD', 'WORKING', 'x');",
-				Expected: []sql.Row{{0}},
+				Expected: []sql.Row{{1}},
 			},
 		},
 	})

--- a/go/libraries/doltcore/sqle/enginetest/dolt_transaction_commit_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_transaction_commit_test.go
@@ -292,9 +292,8 @@ func TestDoltTransactionCommitTwoClients(t *testing.T) {
 				Query:    "/* client c */ SELECT * FROM x AS OF 'HEAD' ORDER BY y;",
 				Expected: []sql.Row{{1, 1}, {2, 2}, {3, 3}},
 			},
-			// After we commit both of these transactions, our working set should not have any pending changes.
-			// In the past, we have merged the working set but failed to land the merged root value in the
-			// commit itself.
+			// After we commit both transactions, our working set should still have the change which
+			// was never dolt_committed.
 			{
 				Query:    "/* client c */ SELECT COUNT(*) FROM DOLT_DIFF('HEAD', 'WORKING', 'x');",
 				Expected: []sql.Row{{1}},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_transaction_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_transaction_queries.go
@@ -773,7 +773,7 @@ var DoltTransactionTests = []queries.TransactionTest{
 				Expected: []sql.Row{{0}},
 			},
 			{
-				Query:    "/* client a */ call dolt_commit('-m', 'initial commit of t1')",
+				Query:            "/* client a */ call dolt_commit('-m', 'initial commit of t1')",
 				SkipResultsCheck: true,
 			},
 			{
@@ -825,7 +825,7 @@ var DoltTransactionTests = []queries.TransactionTest{
 				Expected: []sql.Row{{types.NewOkResult(1)}},
 			},
 			{
-				Query:    "/* client a */ call dolt_commit('-m', 'add 3 to t1')",
+				Query:            "/* client a */ call dolt_commit('-m', 'add 3 to t1')",
 				SkipResultsCheck: true,
 			},
 			{
@@ -841,7 +841,7 @@ var DoltTransactionTests = []queries.TransactionTest{
 				Expected: []sql.Row{{1, 1}, {2, 2}, {3, 3}},
 			},
 			{
-				Query:    "/* client b */ call dolt_commit('-m', 'add 4 to t1')",
+				Query:            "/* client b */ call dolt_commit('-m', 'add 4 to t1')",
 				SkipResultsCheck: true,
 			},
 			{

--- a/go/libraries/doltcore/sqle/enginetest/dolt_transaction_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_transaction_queries.go
@@ -755,6 +755,109 @@ var DoltTransactionTests = []queries.TransactionTest{
 			},
 		},
 	},
+	{
+		Name: "call dolt_commit commits staged stuff, merges with working set and branch head",
+		SetUpScript: []string{
+			"create table t1 (id int primary key, val int)",
+			"create table t2 (id int primary key, val int)",
+			"insert into t1 values (1, 1), (2, 2)",
+			"insert into t2 values (1, 1), (2, 2)",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "/* client a */ set autocommit = off",
+				Expected: []sql.Row{{}},
+			},
+			{
+				Query:    "/* client a */ call dolt_add('t1')",
+				Expected: []sql.Row{{0}},
+			},
+			{
+				Query:    "/* client a */ call dolt_commit('-m', 'initial commit of t1')",
+				SkipResultsCheck: true,
+			},
+			{
+				Query:    "/* client b */ set autocommit = off",
+				Expected: []sql.Row{{}},
+			},
+			{
+				Query:    "/* client a */ start transaction",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "/* client b */ start transaction",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "/* client a */ insert into t1 values (3, 3)",
+				Expected: []sql.Row{{types.NewOkResult(1)}},
+			},
+			{
+				Query:    "/* client b */ insert into t1 values (4, 4)",
+				Expected: []sql.Row{{types.NewOkResult(1)}},
+			},
+			{
+				Query:    "/* client a */ insert into t2 values (3, 3)",
+				Expected: []sql.Row{{types.NewOkResult(1)}},
+			},
+			{
+				Query:    "/* client b */ insert into t2 values (4, 4)",
+				Expected: []sql.Row{{types.NewOkResult(1)}},
+			},
+			{
+				Query:    "/* client a */ call dolt_add('t1')",
+				Expected: []sql.Row{{0}},
+			},
+			{
+				Query:    "/* client b */ call dolt_add('t1')",
+				Expected: []sql.Row{{0}},
+			},
+			{
+				Query:    "/* client a */ insert into t1 values (5, 5)",
+				Expected: []sql.Row{{types.NewOkResult(1)}},
+			},
+			{
+				Query:    "/* client b */ insert into t1 values (6, 6)",
+				Expected: []sql.Row{{types.NewOkResult(1)}},
+			},
+			{
+				Query:    "/* client c */ insert into t2 values (6, 6)",
+				Expected: []sql.Row{{types.NewOkResult(1)}},
+			},
+			{
+				Query:    "/* client a */ call dolt_commit('-m', 'add 3 to t1')",
+				SkipResultsCheck: true,
+			},
+			{
+				Query:    "/* client a */ select * from t2 order by id asc",
+				Expected: []sql.Row{{1, 1}, {2, 2}, {3, 3}, {6, 6}},
+			},
+			{
+				Query:    "/* client a */ select * from t1 order by id asc",
+				Expected: []sql.Row{{1, 1}, {2, 2}, {3, 3}, {5, 5}},
+			},
+			{
+				Query:    "/* client a */ select * from t1 as of 'HEAD' order by id asc",
+				Expected: []sql.Row{{1, 1}, {2, 2}, {3, 3}},
+			},
+			{
+				Query:    "/* client b */ call dolt_commit('-m', 'add 4 to t1')",
+				SkipResultsCheck: true,
+			},
+			{
+				Query:    "/* client b */ select * from t2 order by id asc",
+				Expected: []sql.Row{{1, 1}, {2, 2}, {3, 3}, {4, 4}, {6, 6}},
+			},
+			{
+				Query:    "/* client b */ select * from t1 order by id asc",
+				Expected: []sql.Row{{1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {6, 6}},
+			},
+			{
+				Query:    "/* client b */ select * from t1 as of 'HEAD' order by id asc",
+				Expected: []sql.Row{{1, 1}, {2, 2}, {3, 3}, {4, 4}},
+			},
+		},
+	},
 }
 
 var DoltConflictHandlingTests = []queries.TransactionTest{


### PR DESCRIPTION
Update the transaction logic to land a merge of current HEAD and the staged root value when we are creating a commit and the current HEAD has moved since the start of the transaction.

Dolt allows two concurrent transactions to both land commits on a branch HEAD. In the past, Dolt would simply commit the staged value on each transaction as the value of the database for the commit, and would merge the working sets so that the branch working set was updated with the latest data. This would result in histories with commits which seemed to delete previously committed data, only for it to still be present in the working set and to reappear in later commits. This was particularly problematic under remote replication, where the dolt commits themselves are replicated.

A change landed recently attempted to fix this by writing the merged working set value as the committed value. That works in the case of @@dolt_transaction_commit, assuming there are no manual calls to DOLT_COMMIT with manually staged changes, for example, but it has the wrong semantics when a user is manually staging and commiting changes.