### PR TITLE
Added `dolt_show_branch_databases` system variable

### DIFF
--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -290,14 +290,14 @@ func (p DoltDatabaseProvider) AllDatabases(ctx *sql.Context) (all []sql.Database
 				continue
 			}
 			all = append(all, revisionDbs...)
-			
-			// if one of the revisions we just expanded matches the curr db, mark it so we don't double-include that 
+
+			// if one of the revisions we just expanded matches the curr db, mark it so we don't double-include that
 			// revision db
 			if !foundDatabase && currDb != "" {
 				for _, revisionDb := range revisionDbs {
 					if strings.ToLower(revisionDb.Name()) == currDb {
 						foundDatabase = true
-					} 
+					}
 				}
 			}
 		}

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -270,9 +270,9 @@ func (p DoltDatabaseProvider) HasDatabase(ctx *sql.Context, name string) bool {
 
 func (p DoltDatabaseProvider) AllDatabases(ctx *sql.Context) (all []sql.Database) {
 	p.mu.RLock()
-	
+
 	showBranches, _ := dsess.GetBooleanSystemVar(ctx, dsess.ShowBranchDatabase)
-	
+
 	all = make([]sql.Database, 0, len(p.databases))
 	var foundDatabase bool
 	currDb := strings.ToLower(ctx.GetCurrentDatabase())
@@ -281,14 +281,14 @@ func (p DoltDatabaseProvider) AllDatabases(ctx *sql.Context) (all []sql.Database
 			foundDatabase = true
 		}
 		all = append(all, db)
-		
+
 		if showBranches {
 			revisionDbs, err := p.allRevisionDbs(ctx, db)
 			if err != nil {
 				// TODO: this interface is wrong, needs to return errors
 				continue
 			}
-			all = append(all, revisionDbs...)	
+			all = append(all, revisionDbs...)
 		}
 	}
 	p.mu.RUnlock()
@@ -320,7 +320,7 @@ func (p DoltDatabaseProvider) allRevisionDbs(ctx *sql.Context, db SqlDatabase) (
 	if err != nil {
 		return nil, err
 	}
-	
+
 	revDbs := make([]sql.Database, len(branches))
 	for i, branch := range branches {
 		revDb, _, ok, err := p.databaseForRevision(ctx, fmt.Sprintf("%s/%s", db.Name(), branch.GetPath()))
@@ -332,7 +332,7 @@ func (p DoltDatabaseProvider) allRevisionDbs(ctx *sql.Context, db SqlDatabase) (
 		}
 		revDbs[i] = revDb
 	}
-	
+
 	return revDbs, nil
 }
 

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -271,7 +271,7 @@ func (p DoltDatabaseProvider) HasDatabase(ctx *sql.Context, name string) bool {
 func (p DoltDatabaseProvider) AllDatabases(ctx *sql.Context) (all []sql.Database) {
 	p.mu.RLock()
 
-	showBranches, _ := dsess.GetBooleanSystemVar(ctx, dsess.ShowBranchDatabase)
+	showBranches, _ := dsess.GetBooleanSystemVar(ctx, dsess.ShowBranchDatabases)
 
 	all = make([]sql.Database, 0, len(p.databases))
 	var foundDatabase bool

--- a/go/libraries/doltcore/sqle/dsess/variables.go
+++ b/go/libraries/doltcore/sqle/dsess/variables.go
@@ -49,6 +49,7 @@ const (
 	AwsCredsFile                  = "aws_credentials_file"
 	AwsCredsProfile               = "aws_credentials_profile"
 	AwsCredsRegion                = "aws_credentials_region"
+	ShowBranchDatabase            = "dolt_show_branch_databases"
 )
 
 const URLTemplateDatabasePlaceholder = "{database}"
@@ -166,7 +167,7 @@ func GetBooleanSystemVar(ctx *sql.Context, varName string) (bool, error) {
 		return false, fmt.Errorf("unexpected type for variable %s: %T", varName, val)
 	}
 
-	return i8 == 1, nil
+	return i8 == int8(1), nil
 }
 
 // IgnoreReplicationErrors returns true if the dolt_skip_replication_errors system variable is set to true, which means

--- a/go/libraries/doltcore/sqle/dsess/variables.go
+++ b/go/libraries/doltcore/sqle/dsess/variables.go
@@ -49,7 +49,7 @@ const (
 	AwsCredsFile                  = "aws_credentials_file"
 	AwsCredsProfile               = "aws_credentials_profile"
 	AwsCredsRegion                = "aws_credentials_region"
-	ShowBranchDatabase            = "dolt_show_branch_databases"
+	ShowBranchDatabases           = "dolt_show_branch_databases"
 )
 
 const URLTemplateDatabasePlaceholder = "{database}"

--- a/go/libraries/doltcore/sqle/system_variables.go
+++ b/go/libraries/doltcore/sqle/system_variables.go
@@ -159,11 +159,11 @@ func AddDoltSystemVariables() {
 			Default:           nil,
 		},
 		{
-			Name:              dsess.ShowBranchDatabase,
+			Name:              dsess.ShowBranchDatabases,
 			Scope:             sql.SystemVariableScope_Both,
 			Dynamic:           true,
 			SetVarHintApplies: false,
-			Type:              types.NewSystemBoolType(dsess.ShowBranchDatabase),
+			Type:              types.NewSystemBoolType(dsess.ShowBranchDatabases),
 			Default:           int8(0),
 		},
 	})

--- a/go/libraries/doltcore/sqle/system_variables.go
+++ b/go/libraries/doltcore/sqle/system_variables.go
@@ -158,6 +158,14 @@ func AddDoltSystemVariables() {
 			Type:              types.NewSystemStringType(dsess.AwsCredsRegion),
 			Default:           nil,
 		},
+		{
+			Name:              dsess.ShowBranchDatabase,
+			Scope:             sql.SystemVariableScope_Both,
+			Dynamic:           true,
+			SetVarHintApplies: false,
+			Type:              types.NewSystemBoolType(dsess.ShowBranchDatabase),
+			Default:           int8(0),
+		},
 	})
 }
 

--- a/integration-tests/bats/sql.bats
+++ b/integration-tests/bats/sql.bats
@@ -1375,6 +1375,52 @@ SQL
     [[ "$output" =~ "exists" ]] || false
 }
 
+@test "sql: dolt_show_branch_databases" {
+    mkdir new && cd new
+
+    dolt sql <<SQL
+create database db1;
+create database db2;
+use db1;
+create table t1 (a int primary key);
+call dolt_commit('-Am', 'new table');
+call dolt_branch('b1');
+call dolt_branch('b2');
+use db2;
+create table t2 (b int primary key);
+call dolt_commit('-Am', 'new table');
+call dolt_branch('b3');
+call dolt_branch('b4');
+SQL
+
+    run dolt sql -r csv -q "show databases"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "db1" ]] || false
+    [[ "$output" =~ "db2" ]] || false
+    [[ ! "$output" =~ "/" ]] || false
+
+    run dolt sql -r csv -q "set dolt_show_branch_databases = 1; show databases"
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 11 ] # 2 base dbs, 3 branch dbs each, 2 mysql dbs, 1 header line
+    [[ "$output" =~ "db1/b1" ]] || false
+    [[ "$output" =~ "db1/b2" ]] || false
+    [[ "$output" =~ "db1/main" ]] || false
+    [[ "$output" =~ "db2/b3" ]] || false
+    [[ "$output" =~ "db2/b4" ]] || false
+    [[ "$output" =~ "db2/main" ]] || false
+
+    run dolt sql -q "show databases"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "db1" ]] || false
+    [[ "$output" =~ "db2" ]] || false
+    [[ ! "$output" =~ "/" ]] || false
+
+    dolt sql -q "set @@persist.dolt_show_branch_databases = 1"
+    run dolt sql -r csv -q "show databases"
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 11 ]
+}
+
 @test "sql: run outside a dolt directory" {
     mkdir new && cd new
 

--- a/integration-tests/bats/sql.bats
+++ b/integration-tests/bats/sql.bats
@@ -1419,6 +1419,12 @@ SQL
     run dolt sql -r csv -q "show databases"
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" -eq 11 ]
+
+    # make sure we aren't double-counting revision dbs
+    run dolt sql -r csv -q 'use `db1/main`; show databases'
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Database changed" ]] || false
+    [ "${#lines[@]}" -eq 12 ] # one line for above output, 11 dbs
 }
 
 @test "sql: run outside a dolt directory" {


### PR DESCRIPTION
When set to 1, will cause a revision database for each branch to appear in `show databases`, information schema tables, etc.