### PR TITLE
Quick fix for unnecessary error being logged

### DIFF
--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -262,7 +262,7 @@ func (p DoltDatabaseProvider) attemptCloneReplica(ctx *sql.Context, dbName strin
 
 func (p DoltDatabaseProvider) HasDatabase(ctx *sql.Context, name string) bool {
 	_, err := p.Database(ctx, name)
-	if err != nil {
+	if err != nil && !sql.ErrDatabaseNotFound.Is(err) {
 		ctx.GetLogger().Errorf(err.Error())
 	}
 	return err == nil


### PR DESCRIPTION
We started logging an error instead of swallowing it, which is good, but we need to check if it's the `ErrDatabaseNotFound` error we know we might see, and not log an error if it's that expected case. 