### PR TITLE
Fix int overflow on 32-bit architectures

### DIFF
--- a/go/store/prolly/tree/testutils.go
+++ b/go/store/prolly/tree/testutils.go
@@ -213,16 +213,16 @@ func randomField(tb *val.TupleBuilder, idx int, typ val.Type, ns NodeStore) {
 		v := uint16(testRand.Intn(math.MaxUint16))
 		tb.PutUint16(idx, v)
 	case val.Int32Enc:
-		v := int32(testRand.Intn(math.MaxInt32) * neg)
+		v := testRand.Int31() * int32(neg)
 		tb.PutInt32(idx, v)
 	case val.Uint32Enc:
-		v := uint32(testRand.Intn(math.MaxUint32))
+		v := testRand.Uint32()
 		tb.PutUint32(idx, v)
 	case val.Int64Enc:
-		v := int64(testRand.Intn(math.MaxInt64) * neg)
+		v := testRand.Int63() * int64(neg)
 		tb.PutInt64(idx, v)
 	case val.Uint64Enc:
-		v := uint64(testRand.Uint64())
+		v := testRand.Uint64()
 		tb.PutUint64(idx, v)
 	case val.Float32Enc:
 		tb.PutFloat32(idx, testRand.Float32())

--- a/go/store/skip/list.go
+++ b/go/store/skip/list.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	maxHeight  = 9
-	maxCount   = math.MaxUint32 - 1
+	maxCount   = math.MaxInt - 1
 	sentinelId = nodeId(0)
 	initSize   = 8
 )


### PR DESCRIPTION
```py
$  GOARCH=386 GOOS=linux go build ./...
# github.com/dolthub/dolt/go/store/skip
store/skip/list.go:152:21: maxCount (untyped int constant 4294967294) overflows int
```
See also https://github.com/dolthub/vitess/pull/216