### PR TITLE
verify fk with secondary when available

### DIFF
--- a/go/libraries/doltcore/merge/violations_fk.go
+++ b/go/libraries/doltcore/merge/violations_fk.go
@@ -376,7 +376,7 @@ func childFkConstraintViolations(
 	if preChildRowData.Format() == types.Format_DOLT {
 		if empty, err := preChildRowData.Empty(); err != nil {
 			return err
-		} else if !empty && preChild.IndexData != nil {
+		} else if !empty && preChild.IndexData != nil && postChild.Schema.GetPKCols().Size() > 0 && preChild.Schema.GetPKCols().Size() > 0 {
 			m := durable.ProllyMapFromIndex(preChild.IndexData)
 			return prollyChildSecDiffFkConstraintViolations(ctx, foreignKey, postParent, postChild, m, receiver)
 		}

--- a/go/libraries/doltcore/merge/violations_fk_prolly.go
+++ b/go/libraries/doltcore/merge/violations_fk_prolly.go
@@ -96,10 +96,6 @@ func prollyParentFkConstraintViolations(
 	return nil
 }
 
-type cvKey struct {
-	k, v, partial val.Tuple
-}
-
 func prollyChildPriDiffFkConstraintViolations(
 	ctx context.Context,
 	foreignKey doltdb.ForeignKey,

--- a/go/store/prolly/tuple_map.go
+++ b/go/store/prolly/tuple_map.go
@@ -216,6 +216,10 @@ func (m Map) NodeStore() tree.NodeStore {
 	return m.tuples.NodeStore
 }
 
+func (m Map) Tuples() tree.StaticMap[val.Tuple, val.Tuple, val.TupleDesc] {
+	return m.tuples
+}
+
 // Mutate makes a MutableMap from a Map.
 func (m Map) Mutate() *MutableMap {
 	return newMutableMap(m)


### PR DESCRIPTION
We resolve foreign key conflicts by:
1) diffing a before/after index to generate keys
2) constructing a lookup key for the reference index
3) perform a lookup into the reference index
4) report a conflict if reference dependency is missing

For huge tables, we want the `from` keys to be ordered relative to the `to` index. When this is not the case, the `to` lookup will be random access and read a chunk from disk. Millions of random access lookups that all IO chunks from disk adds a ~1000x perf hit for validating a single FK relative to sorted lookups.

This PR does a secondary key diff -> secondary foreign key lookup. The diffs are ordered relative to one-another, and this usually makes big merges faster.

The main downside is that constraint violations still require a primary key lookup to backfill missing columns, which will usually be out-of-order relative to the secondary key iter order. Keyless fks are also excluded from the optimization for now.

