### PR TITLE
add bats test for binary string encoded to utf8

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/cespare/xxhash v1.1.0
 	github.com/creasty/defaults v1.6.0
-	github.com/dolthub/go-mysql-server v0.14.1-0.20230202040457-507ba0a4421f
+	github.com/dolthub/go-mysql-server v0.14.1-0.20230202225722-10ae08e7a287
 	github.com/google/flatbuffers v2.0.6+incompatible
 	github.com/kch42/buzhash v0.0.0-20160816060738-9bdec3dec7c6
 	github.com/mitchellh/go-ps v1.0.0

--- a/go/go.mod
+++ b/go/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/cespare/xxhash v1.1.0
 	github.com/creasty/defaults v1.6.0
-	github.com/dolthub/go-mysql-server v0.14.1-0.20230202225722-10ae08e7a287
+	github.com/dolthub/go-mysql-server v0.14.1-0.20230207205123-33c0318f5d1a
 	github.com/google/flatbuffers v2.0.6+incompatible
 	github.com/kch42/buzhash v0.0.0-20160816060738-9bdec3dec7c6
 	github.com/mitchellh/go-ps v1.0.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -161,8 +161,8 @@ github.com/dolthub/flatbuffers v1.13.0-dh.1 h1:OWJdaPep22N52O/0xsUevxJ6Qfw1M2txC
 github.com/dolthub/flatbuffers v1.13.0-dh.1/go.mod h1:CorYGaDmXjHz1Z7i50PYXG1Ricn31GcA2wNOTFIQAKE=
 github.com/dolthub/fslock v0.0.3 h1:iLMpUIvJKMKm92+N1fmHVdxJP5NdyDK5bK7z7Ba2s2U=
 github.com/dolthub/fslock v0.0.3/go.mod h1:QWql+P17oAAMLnL4HGB5tiovtDuAjdDTPbuqx7bYfa0=
-github.com/dolthub/go-mysql-server v0.14.1-0.20230202225722-10ae08e7a287 h1:vMfwVvUJlD6x8yXr0uBp95vW4VEDYceTtTxsHLDxRP4=
-github.com/dolthub/go-mysql-server v0.14.1-0.20230202225722-10ae08e7a287/go.mod h1:aVtgxAf6Bfs0hCj+KzIH7Y1aAxg7/7FlslouCh94VVQ=
+github.com/dolthub/go-mysql-server v0.14.1-0.20230207205123-33c0318f5d1a h1:lahWiohhmaEgjMff/zCfXp9ig7o5NFImwjRSZEHhMbo=
+github.com/dolthub/go-mysql-server v0.14.1-0.20230207205123-33c0318f5d1a/go.mod h1:aVtgxAf6Bfs0hCj+KzIH7Y1aAxg7/7FlslouCh94VVQ=
 github.com/dolthub/ishell v0.0.0-20221214210346-d7db0b066488 h1:0HHu0GWJH0N6a6keStrHhUAK5/o9LVfkh44pvsV4514=
 github.com/dolthub/ishell v0.0.0-20221214210346-d7db0b066488/go.mod h1:ehexgi1mPxRTk0Mok/pADALuHbvATulTh6gzr7NzZto=
 github.com/dolthub/jsonpath v0.0.0-20210609232853-d49537a30474 h1:xTrR+l5l+1Lfq0NvhiEsctylXinUMFhhsqaEcl414p8=

--- a/go/go.sum
+++ b/go/go.sum
@@ -161,8 +161,8 @@ github.com/dolthub/flatbuffers v1.13.0-dh.1 h1:OWJdaPep22N52O/0xsUevxJ6Qfw1M2txC
 github.com/dolthub/flatbuffers v1.13.0-dh.1/go.mod h1:CorYGaDmXjHz1Z7i50PYXG1Ricn31GcA2wNOTFIQAKE=
 github.com/dolthub/fslock v0.0.3 h1:iLMpUIvJKMKm92+N1fmHVdxJP5NdyDK5bK7z7Ba2s2U=
 github.com/dolthub/fslock v0.0.3/go.mod h1:QWql+P17oAAMLnL4HGB5tiovtDuAjdDTPbuqx7bYfa0=
-github.com/dolthub/go-mysql-server v0.14.1-0.20230202040457-507ba0a4421f h1:bkJg9Lvj5vnyA/FFdJR1qcOkR5qYPKs287WtimU+etw=
-github.com/dolthub/go-mysql-server v0.14.1-0.20230202040457-507ba0a4421f/go.mod h1:aVtgxAf6Bfs0hCj+KzIH7Y1aAxg7/7FlslouCh94VVQ=
+github.com/dolthub/go-mysql-server v0.14.1-0.20230202225722-10ae08e7a287 h1:vMfwVvUJlD6x8yXr0uBp95vW4VEDYceTtTxsHLDxRP4=
+github.com/dolthub/go-mysql-server v0.14.1-0.20230202225722-10ae08e7a287/go.mod h1:aVtgxAf6Bfs0hCj+KzIH7Y1aAxg7/7FlslouCh94VVQ=
 github.com/dolthub/ishell v0.0.0-20221214210346-d7db0b066488 h1:0HHu0GWJH0N6a6keStrHhUAK5/o9LVfkh44pvsV4514=
 github.com/dolthub/ishell v0.0.0-20221214210346-d7db0b066488/go.mod h1:ehexgi1mPxRTk0Mok/pADALuHbvATulTh6gzr7NzZto=
 github.com/dolthub/jsonpath v0.0.0-20210609232853-d49537a30474 h1:xTrR+l5l+1Lfq0NvhiEsctylXinUMFhhsqaEcl414p8=

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -1873,3 +1873,13 @@ s.close()
     [ $status -eq 0 ]
     [[ "$output" =~ "$EXPECTED" ]] || false
 }
+
+@test "sql-server: binary literal is printed as hex string for utf8 charset result set" {
+    cd repo1
+    start_sql_server
+    dolt sql-client -P $PORT -u dolt --use-db repo1 -q "SET character_set_results = utf8; CREATE TABLE mapping(branch_id binary(16) PRIMARY KEY, user_id binary(16) NOT NULL, company_id binary(16) NOT NULL);"
+
+    run dolt sql-client -P $PORT -u dolt --use-db repo1 -q "EXPLAIN SELECT m.* FROM mapping m WHERE user_id = uuid_to_bin('1c4c4e33-8ad7-4421-8450-9d5182816ac3');"
+    [ $status -eq 0 ]
+    [[ "$output" =~ "0x1C4C4E338AD7442184509D5182816AC3" ]] || false
+}

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -1873,13 +1873,3 @@ s.close()
     [ $status -eq 0 ]
     [[ "$output" =~ "$EXPECTED" ]] || false
 }
-
-@test "sql-server: binary literal is printed as hex string for utf8 charset result set" {
-    cd repo1
-    start_sql_server
-    dolt sql-client -P $PORT -u dolt --use-db repo1 -q "SET character_set_results = utf8; CREATE TABLE mapping(branch_id binary(16) PRIMARY KEY, user_id binary(16) NOT NULL, company_id binary(16) NOT NULL);"
-
-    run dolt sql-client -P $PORT -u dolt --use-db repo1 -q "EXPLAIN SELECT m.* FROM mapping m WHERE user_id = uuid_to_bin('1c4c4e33-8ad7-4421-8450-9d5182816ac3');"
-    [ $status -eq 0 ]
-    [[ "$output" =~ "0x1C4C4E338AD7442184509D5182816AC3" ]] || false
-}

--- a/integration-tests/bats/sql.bats
+++ b/integration-tests/bats/sql.bats
@@ -2780,7 +2780,7 @@ SQL
     [ "$status" -eq 0 ]
 }
 
-@test "sql-server: binary data is printed as hex string as default" {
+@test "sql: binary data is printed as hex string as default" {
     dolt sql -q "CREATE TABLE mapping(branch_id binary(16) PRIMARY KEY, user_id binary(16) NOT NULL, company_id binary(16) NOT NULL);"
     run dolt sql -q "EXPLAIN SELECT m.* FROM mapping m WHERE user_id = uuid_to_bin('1c4c4e33-8ad7-4421-8450-9d5182816ac3');"
     [ $status -eq 0 ]

--- a/integration-tests/bats/sql.bats
+++ b/integration-tests/bats/sql.bats
@@ -2779,3 +2779,10 @@ SQL
     run dolt sql -q 'INSERT INTO dts (`created_at`) VALUES ("0001-01-01 00:00:00");'
     [ "$status" -eq 0 ]
 }
+
+@test "sql-server: binary data is printed as hex string as default" {
+    dolt sql -q "CREATE TABLE mapping(branch_id binary(16) PRIMARY KEY, user_id binary(16) NOT NULL, company_id binary(16) NOT NULL);"
+    run dolt sql -q "EXPLAIN SELECT m.* FROM mapping m WHERE user_id = uuid_to_bin('1c4c4e33-8ad7-4421-8450-9d5182816ac3');"
+    [ $status -eq 0 ]
+    [[ "$output" =~ "0x1C4C4E338AD7442184509D5182816AC3" ]] || false
+}

--- a/integration-tests/bats/sql.bats
+++ b/integration-tests/bats/sql.bats
@@ -2779,10 +2779,3 @@ SQL
     run dolt sql -q 'INSERT INTO dts (`created_at`) VALUES ("0001-01-01 00:00:00");'
     [ "$status" -eq 0 ]
 }
-
-@test "sql: binary data is printed as hex string as default" {
-    dolt sql -q "CREATE TABLE mapping(branch_id binary(16) PRIMARY KEY, user_id binary(16) NOT NULL, company_id binary(16) NOT NULL);"
-    run dolt sql -q "EXPLAIN SELECT m.* FROM mapping m WHERE user_id = uuid_to_bin('1c4c4e33-8ad7-4421-8450-9d5182816ac3');"
-    [ $status -eq 0 ]
-    [[ "$output" =~ "0x1C4C4E338AD7442184509D5182816AC3" ]] || false
-}


### PR DESCRIPTION
Depends on https://github.com/dolthub/go-mysql-server/pull/1583
DataGrip sets the `character_set_results` system variable to `utf8`, which raw binary strings cannot be encoded into. MySQL returns binary type strings in hex format.