### PR TITLE
go/store/nbs: Make a chunkSource able to return a real io.Reader.

### DIFF
--- a/go/store/nbs/bs_persister.go
+++ b/go/store/nbs/bs_persister.go
@@ -233,6 +233,11 @@ type bsTableReaderAt struct {
 	bs  blobstore.Blobstore
 }
 
+func (bsTRA *bsTableReaderAt) Reader(ctx context.Context) (io.ReadCloser, error) {
+	rc, _, err := bsTRA.bs.Get(ctx, bsTRA.key, blobstore.AllRange)
+	return rc, err
+}
+
 // ReadAtWithStats is the bsTableReaderAt implementation of the tableReaderAt interface
 func (bsTRA *bsTableReaderAt) ReadAtWithStats(ctx context.Context, p []byte, off int64, stats *Stats) (int, error) {
 	br := blobstore.NewBlobRange(off, int64(len(p)))

--- a/go/store/nbs/dynamo_table_reader.go
+++ b/go/store/nbs/dynamo_table_reader.go
@@ -22,6 +22,7 @@
 package nbs
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -51,6 +52,14 @@ type tableNotInDynamoErr struct {
 
 func (t tableNotInDynamoErr) Error() string {
 	return fmt.Sprintf("NBS table %s not present in DynamoDB table %s", t.nbs, t.dynamo)
+}
+
+func (dtra *dynamoTableReaderAt) Reader(ctx context.Context) (io.ReadCloser, error) {
+	data, err := dtra.ddb.ReadTable(ctx, dtra.h, &Stats{})
+	if err != nil {
+		return nil, err
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
 }
 
 func (dtra *dynamoTableReaderAt) ReadAtWithStats(ctx context.Context, p []byte, off int64, stats *Stats) (n int, err error) {

--- a/go/store/nbs/empty_chunk_source.go
+++ b/go/store/nbs/empty_chunk_source.go
@@ -70,8 +70,8 @@ func (ecs emptyChunkSource) index() (tableIndex, error) {
 	return onHeapTableIndex{}, nil
 }
 
-func (ecs emptyChunkSource) reader(context.Context) (io.Reader, uint64, error) {
-	return &bytes.Buffer{}, 0, nil
+func (ecs emptyChunkSource) reader(context.Context) (io.ReadCloser, uint64, error) {
+	return io.NopCloser(&bytes.Buffer{}), 0, nil
 }
 
 func (ecs emptyChunkSource) getRecordRanges(lookups []getRecord) (map[hash.Hash]Range, error) {

--- a/go/store/nbs/journal_chunk_source.go
+++ b/go/store/nbs/journal_chunk_source.go
@@ -193,9 +193,9 @@ func (s journalChunkSource) hash() addr {
 }
 
 // reader implements chunkSource.
-func (s journalChunkSource) reader(context.Context) (io.Reader, uint64, error) {
+func (s journalChunkSource) reader(context.Context) (io.ReadCloser, uint64, error) {
 	rdr, sz, err := s.journal.Snapshot()
-	return rdr, uint64(sz), err
+	return io.NopCloser(rdr), uint64(sz), err
 }
 
 func (s journalChunkSource) getRecordRanges(requests []getRecord) (map[hash.Hash]Range, error) {

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -1292,7 +1292,7 @@ func newTableFile(cs chunkSource, info tableSpec) tableFile {
 			if err != nil {
 				return nil, 0, err
 			}
-			return io.NopCloser(r), s, nil
+			return r, s, nil
 		},
 	}
 }

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -260,7 +260,7 @@ type chunkSource interface {
 	hash() addr
 
 	// opens a Reader to the first byte of the chunkData segment of this table.
-	reader(context.Context) (io.Reader, uint64, error)
+	reader(context.Context) (io.ReadCloser, uint64, error)
 
 	// getRecordRanges sets getRecord.found to true, and returns a Range for each present getRecord query.
 	getRecordRanges(requests []getRecord) (map[hash.Hash]Range, error)


### PR DESCRIPTION
With TableFileStore.WriteTableFile() being used on the clone path, we want to turn chunk sources into an io.ReadCloser. In the past, store/nbs always did this by using the ReaderAt to emulate an io.Reader. For files this maybe has OK performance, but for AWS/Blobstore remotes it causes a serial sequence of lots of small reads against blob storage as the io.Copy() implementation copies a few dozen KBs at a time.

This change makes it so a chunkSource can return an actual Reader. file_table_reader leaves the reader at emulation in place for now. One reason to potentially get rid of even that layer is to enable something like .WriteTo() -> sendfile() translations. Those are not currently directly in place because we currently instrument the returned Reader with byte counting, for example, so we can report on Clone progress. One reason to leave the ReaderAt implementation in place, on the other hand, is interactions with file descriptors and the file descriptor cache. This is an investigation for later; it seemed most prudent to leave it for now since it's not currently causing pain.