### PR TITLE
Allow the pprof server to handle connections from non-localhost

### DIFF
--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -186,7 +186,7 @@ func runMain() int {
 					cli.Println(cyanStar, "  /trace: A trace of execution of the current program. You can specify the duration in the seconds GET parameter. After you get the trace file, use the go tool trace command to investigate the trace.")
 					cli.Println()
 
-					err := http.ListenAndServe("localhost:6060", nil)
+					err := http.ListenAndServe("0.0.0.0:6060", nil)
 
 					if err != nil {
 						cli.Println(color.YellowString("pprof server exited with error: %v", err))


### PR DESCRIPTION
Allow the pprof server to handle connections from non-localhost machines.

This change is necessary to reach a Docker pprof server from host machine.