### PR TITLE
makes -f default behavior for dolt fetch

### DIFF
--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -228,7 +228,6 @@ func CreateCherryPickArgParser() *argparser.ArgParser {
 
 func CreateFetchArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParser()
-	ap.SupportsFlag(ForceFlag, "f", "Update refs to remote branches with the current state of the remote, overwriting any conflicting history.")
 	return ap
 }
 

--- a/go/cmd/dolt/commands/fetch.go
+++ b/go/cmd/dolt/commands/fetch.go
@@ -77,22 +77,14 @@ func (cmd FetchCmd) Exec(ctx context.Context, commandStr string, args []string, 
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
-	updateMode := ref.UpdateMode{Force: apr.Contains(cli.ForceFlag)}
 
 	srcDB, err := r.GetRemoteDBWithoutCaching(ctx, dEnv.DbData().Ddb.ValueReadWriter().Format(), dEnv)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	err = actions.FetchRefSpecs(ctx, dEnv.DbData(), srcDB, refSpecs, r, updateMode, buildProgStarter(downloadLanguage), stopProgFuncs)
-	switch err {
-	case doltdb.ErrUpToDate:
-		return HandleVErrAndExitCode(nil, usage)
-	case actions.ErrCantFF:
-		verr := errhand.BuildDError("error: fetch failed, can't fast forward remote tracking ref").AddCause(err).Build()
-		return HandleVErrAndExitCode(verr, usage)
-	}
-	if err != nil {
+	err = actions.FetchRefSpecs(ctx, dEnv.DbData(), srcDB, refSpecs, r, ref.UpdateMode{Force: true}, buildProgStarter(downloadLanguage), stopProgFuncs)
+	if err != nil && err != doltdb.ErrUpToDate {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 	return HandleVErrAndExitCode(nil, usage)

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_fetch.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_fetch.go
@@ -62,14 +62,12 @@ func doDoltFetch(ctx *sql.Context, args []string) (int, error) {
 		return cmdFailure, err
 	}
 
-	updateMode := ref.UpdateMode{Force: apr.Contains(cli.ForceFlag)}
-
 	srcDB, err := sess.Provider().GetRemoteDB(ctx, dbData.Ddb.ValueReadWriter().Format(), remote, false)
 	if err != nil {
 		return 1, err
 	}
 
-	err = actions.FetchRefSpecs(ctx, dbData, srcDB, refSpecs, remote, updateMode, runProgFuncs, stopProgFuncs)
+	err = actions.FetchRefSpecs(ctx, dbData, srcDB, refSpecs, remote, ref.UpdateMode{Force: true}, runProgFuncs, stopProgFuncs)
 	if err != nil {
 		return cmdFailure, fmt.Errorf("fetch failed: %w", err)
 	}

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -1217,6 +1217,28 @@ SQL
     [ "$status" -eq 0 ]
 }
 
+@test "remotes: fetch after force push" {
+    mkdir remote clone1
+    cd clone1
+    dolt init
+    dolt sql -q "create table t (pk int primary key);"
+    dolt commit -Am "commit1"
+
+    dolt remote add origin file://../remote
+    dolt push origin main
+
+    cd ..
+    dolt clone file://./remote clone2
+
+    cd clone1
+    dolt commit --amend -m "commit1 edited"
+    dolt push origin main -f
+
+    cd ../clone2
+    run dolt fetch
+    [ "$status" -eq 0 ]
+}
+
 @test "remotes: force fetch from main" {
     dolt remote add test-remote http://localhost:50051/test-org/test-repo
     dolt push --set-upstream test-remote main
@@ -1256,11 +1278,9 @@ SQL
     dolt fetch
     dolt push -f origin main
     cd ../../
-    run dolt fetch test-remote
-    [ "$status" -ne 0 ]
     run dolt pull
     [ "$status" -ne 0 ]
-    run dolt fetch -f test-remote
+    run dolt fetch test-remote
     [ "$status" -eq 0 ]
     run dolt pull --no-edit
     [ "$status" -eq 0 ]

--- a/integration-tests/bats/sql-fetch.bats
+++ b/integration-tests/bats/sql-fetch.bats
@@ -357,46 +357,17 @@ teardown() {
     [[ "$output" =~ "t1" ]] || false
 }
 
-@test "sql-fetch: dolt_fetch --force" {
+@test "sql-fetch: dolt_fetch with forced commit" {
     # reverse information flow for force fetch repo1->rem1->repo2
     cd repo2
     dolt sql -q "create table t2 (a int)"
     dolt add .
     dolt commit -am "forced commit"
     dolt push --force origin main
-
     cd ../repo1
+
     run dolt sql -q "call dolt_fetch('origin', 'main')"
-    [ "$status" -eq 1 ]
-    [[ "$output" =~ "fetch failed: can't fast forward merge" ]] || false
-
-    dolt sql -q "call dolt_fetch('--force', 'origin', 'main')"
-    
-    dolt diff main origin/main
-    run dolt diff main origin/main
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "deleted table" ]] || false
-
-    run dolt sql -q "show tables as of hashof('origin/main')" -r csv
-    [ "${#lines[@]}" -eq 2 ]
-    [[ "$output" =~ "Table" ]] || false
-    [[ "$output" =~ "t2" ]] || false
-}
-
-@test "sql-fetch: CALL dolt_fetch --force" {
-    # reverse information flow for force fetch repo1->rem1->repo2
-    cd repo2
-    dolt sql -q "create table t2 (a int)"
-    dolt add .
-    dolt commit -am "forced commit"
-    dolt push --force origin main
-
-    cd ../repo1
-    run dolt sql -q "CALL dolt_fetch('origin', 'main')"
-    [ "$status" -eq 1 ]
-    [[ "$output" =~ "fetch failed: can't fast forward merge" ]] || false
-
-    dolt sql -q "CALL dolt_fetch('--force', 'origin', 'main')"
     
     run dolt diff main origin/main
     [ "$status" -eq 0 ]


### PR DESCRIPTION
This change makes force fetch the default behavior for `dolt fetch` and removes the `-f` force flag to prevent errors when fetching after a force push.

fixes: https://github.com/dolthub/dolt/issues/4943