### PR TITLE
fixes timing for multi statement queries

### DIFF
--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/abiosoft/readline"
 	"github.com/dolthub/go-mysql-server/sql"
@@ -819,6 +820,8 @@ func runMultiStatementMode(ctx *sql.Context, se *engine.SqlEngine, input io.Read
 			}
 		}
 
+		// store start time for query
+		ctx.SetQueryTime(time.Now())
 		sqlSch, rowIter, err := processParsedQuery(ctx, query, se, sqlStatement)
 		if err != nil {
 			handleError(scanner.statementStartLine, query, err)


### PR DESCRIPTION
This change fixes timing for multi statement queries to print the time to execute the query instead of the time to print the results or the time since the first query started.