### PR TITLE
ArtifactEditor now resets after flushing

### DIFF
--- a/go/libraries/doltcore/merge/merge_prolly_indexes.go
+++ b/go/libraries/doltcore/merge/merge_prolly_indexes.go
@@ -107,7 +107,7 @@ func mergeProllySecondaryIndexes(
 	leftSet, rightSet durable.IndexSet,
 	finalSch schema.Schema,
 	finalRows durable.Index,
-	artifacts prolly.ArtifactsEditor,
+	artifacts *prolly.ArtifactsEditor,
 ) (durable.IndexSet, error) {
 
 	ancSet, err := tm.ancTbl.GetIndexSet(ctx)
@@ -197,7 +197,7 @@ func mergeProllySecondaryIndexes(
 	return mergedIndexSet, nil
 }
 
-func buildIndex(ctx context.Context, vrw types.ValueReadWriter, ns tree.NodeStore, postMergeSchema schema.Schema, index schema.Index, m prolly.Map, artEditor prolly.ArtifactsEditor, theirRootIsh doltdb.Rootish, tblName string) (durable.Index, error) {
+func buildIndex(ctx context.Context, vrw types.ValueReadWriter, ns tree.NodeStore, postMergeSchema schema.Schema, index schema.Index, m prolly.Map, artEditor *prolly.ArtifactsEditor, theirRootIsh doltdb.Rootish, tblName string) (durable.Index, error) {
 	if index.IsUnique() {
 		meta, err := makeUniqViolMeta(postMergeSchema, index)
 		if err != nil {

--- a/go/libraries/doltcore/merge/merge_prolly_rows.go
+++ b/go/libraries/doltcore/merge/merge_prolly_rows.go
@@ -377,7 +377,7 @@ func (m *valueMerger) processColumn(i int, left, right, base val.Tuple) ([]byte,
 }
 
 type conflictProcessor interface {
-	process(ctx context.Context, conflictChan chan confVals, artEditor prolly.ArtifactsEditor) error
+	process(ctx context.Context, conflictChan chan confVals, artEditor *prolly.ArtifactsEditor) error
 }
 
 func makeConflictProcessor(ctx context.Context, tm TableMerger) (conflictProcessor, error) {
@@ -434,7 +434,7 @@ func newInsertingProcessor(theirRootIsh, baseRootIsh doltdb.Rootish) (*inserting
 	return &p, nil
 }
 
-func (p *insertingProcessor) process(ctx context.Context, conflictChan chan confVals, artEditor prolly.ArtifactsEditor) error {
+func (p *insertingProcessor) process(ctx context.Context, conflictChan chan confVals, artEditor *prolly.ArtifactsEditor) error {
 	for {
 		select {
 		case conflict, ok := <-conflictChan:
@@ -453,7 +453,7 @@ func (p *insertingProcessor) process(ctx context.Context, conflictChan chan conf
 
 type abortingProcessor struct{}
 
-func (p abortingProcessor) process(ctx context.Context, conflictChan chan confVals, artEditor prolly.ArtifactsEditor) error {
+func (p abortingProcessor) process(ctx context.Context, conflictChan chan confVals, _ *prolly.ArtifactsEditor) error {
 	select {
 	case _, ok := <-conflictChan:
 		if !ok {

--- a/go/libraries/doltcore/merge/violations_fk.go
+++ b/go/libraries/doltcore/merge/violations_fk.go
@@ -212,7 +212,7 @@ type foreignKeyViolationWriter struct {
 	currTbl *doltdb.Table
 
 	// prolly
-	artEditor     prolly.ArtifactsEditor
+	artEditor     *prolly.ArtifactsEditor
 	kd            val.TupleDesc
 	cInfoJsonData []byte
 

--- a/go/libraries/doltcore/merge/violations_unique_prolly.go
+++ b/go/libraries/doltcore/merge/violations_unique_prolly.go
@@ -39,7 +39,7 @@ func addUniqIdxViols(
 	index schema.Index,
 	left, right, base prolly.Map,
 	m prolly.Map,
-	artEditor prolly.ArtifactsEditor,
+	artEditor *prolly.ArtifactsEditor,
 	theirRootIsh doltdb.Rootish,
 	tblName string) error {
 
@@ -153,7 +153,7 @@ func (m UniqCVMeta) PrettyPrint() string {
 	return jsonStr
 }
 
-func replaceUniqueKeyViolation(ctx context.Context, edt prolly.ArtifactsEditor, m prolly.Map, k val.Tuple, kd val.TupleDesc, theirRootIsh doltdb.Rootish, vInfo []byte, tblName string) error {
+func replaceUniqueKeyViolation(ctx context.Context, edt *prolly.ArtifactsEditor, m prolly.Map, k val.Tuple, kd val.TupleDesc, theirRootIsh doltdb.Rootish, vInfo []byte, tblName string) error {
 	var value val.Tuple
 	err := m.Get(ctx, k, func(_, v val.Tuple) error {
 		value = v

--- a/go/libraries/doltcore/sqle/dtables/conflicts_tables_prolly.go
+++ b/go/libraries/doltcore/sqle/dtables/conflicts_tables_prolly.go
@@ -539,7 +539,7 @@ type prollyConflictDeleter struct {
 	kd, vd         val.TupleDesc
 	kB, vB         *val.TupleBuilder
 	pool           pool.BuffPool
-	ed             prolly.ArtifactsEditor
+	ed             *prolly.ArtifactsEditor
 	ct             ProllyConflictsTable
 	rs             RootSetter
 	ourDiffTypeIdx int

--- a/go/libraries/doltcore/sqle/dtables/constraint_violations_prolly.go
+++ b/go/libraries/doltcore/sqle/dtables/constraint_violations_prolly.go
@@ -217,7 +217,7 @@ type prollyCVDeleter struct {
 	kd   val.TupleDesc
 	kb   *val.TupleBuilder
 	pool pool.BuffPool
-	ed   prolly.ArtifactsEditor
+	ed   *prolly.ArtifactsEditor
 	cvt  *prollyConstraintViolationsTable
 }
 

--- a/go/store/prolly/artifact_map.go
+++ b/go/store/prolly/artifact_map.go
@@ -155,9 +155,9 @@ func (m ArtifactMap) Pool() pool.BuffPool {
 	return m.tuples.NodeStore.Pool()
 }
 
-func (m ArtifactMap) Editor() ArtifactsEditor {
+func (m ArtifactMap) Editor() *ArtifactsEditor {
 	artKD, artVD := m.Descriptors()
-	return ArtifactsEditor{
+	return &ArtifactsEditor{
 		srcKeyDesc: m.srcKeyDesc,
 		mut: MutableMap{
 			tuples:  m.tuples.Mutate(),
@@ -316,7 +316,7 @@ type ArtifactsEditor struct {
 	pool         pool.BuffPool
 }
 
-func (wr ArtifactsEditor) Add(ctx context.Context, srcKey val.Tuple, theirRootIsh hash.Hash, artType ArtifactType, meta []byte) error {
+func (wr *ArtifactsEditor) Add(ctx context.Context, srcKey val.Tuple, theirRootIsh hash.Hash, artType ArtifactType, meta []byte) error {
 	for i := 0; i < srcKey.Count(); i++ {
 		wr.artKB.PutRaw(i, srcKey.GetField(i))
 	}
@@ -344,7 +344,7 @@ func (e *ErrMergeArtifactCollision) Error() string {
 // the given will be inserted. Returns true if a violation was replaced. If an
 // existing violation exists but has a different |meta.VInfo| value then
 // ErrMergeArtifactCollision is a returned.
-func (wr ArtifactsEditor) ReplaceConstraintViolation(ctx context.Context, srcKey val.Tuple, theirRootIsh hash.Hash, artType ArtifactType, meta ConstraintViolationMeta) error {
+func (wr *ArtifactsEditor) ReplaceConstraintViolation(ctx context.Context, srcKey val.Tuple, theirRootIsh hash.Hash, artType ArtifactType, meta ConstraintViolationMeta) error {
 	itr, err := wr.mut.IterRange(ctx, PrefixRange(srcKey, wr.srcKeyDesc))
 	if err != nil {
 		return err
@@ -406,11 +406,11 @@ func (wr ArtifactsEditor) ReplaceConstraintViolation(ctx context.Context, srcKey
 	return nil
 }
 
-func (wr ArtifactsEditor) Delete(ctx context.Context, key val.Tuple) error {
+func (wr *ArtifactsEditor) Delete(ctx context.Context, key val.Tuple) error {
 	return wr.mut.Delete(ctx, key)
 }
 
-func (wr ArtifactsEditor) Flush(ctx context.Context) (ArtifactMap, error) {
+func (wr *ArtifactsEditor) Flush(ctx context.Context) (ArtifactMap, error) {
 	s := message.NewMergeArtifactSerializer(wr.artKB.Desc, wr.NodeStore().Pool())
 
 	m, err := wr.mut.flushWithSerializer(ctx, s)
@@ -426,7 +426,7 @@ func (wr ArtifactsEditor) Flush(ctx context.Context) (ArtifactMap, error) {
 	}, nil
 }
 
-func (wr ArtifactsEditor) NodeStore() tree.NodeStore {
+func (wr *ArtifactsEditor) NodeStore() tree.NodeStore {
 	return wr.mut.NodeStore()
 }
 

--- a/go/store/prolly/tuple_mutable_map.go
+++ b/go/store/prolly/tuple_mutable_map.go
@@ -63,10 +63,6 @@ func (mut *MutableMap) Map(ctx context.Context) (Map, error) {
 }
 
 func (mut *MutableMap) flushWithSerializer(ctx context.Context, s message.Serializer) (Map, error) {
-	if err := mut.Checkpoint(ctx); err != nil {
-		return Map{}, err
-	}
-
 	sm := mut.tuples.StaticMap
 	fn := tree.ApplyMutations[val.Tuple, val.TupleDesc, message.Serializer]
 


### PR DESCRIPTION
ArtifactEditor held on to keys after flushing because it was a value receiver. Under the capacity threshold, constraint violations only flush once and we bypass this bug. For >50k constraint violations, every incremental CV will write the previous duplicate 40k CV's.