### PR TITLE
go/store/nbs: Fix some quota leaks in conjoin, GC.

### DIFF
--- a/go/libraries/doltcore/dtestutils/testcommands/multienv.go
+++ b/go/libraries/doltcore/dtestutils/testcommands/multienv.go
@@ -84,6 +84,15 @@ func (mr *MultiRepoTestSetup) homeProv() (string, error) {
 	return mr.Home, nil
 }
 
+func (mr *MultiRepoTestSetup) Close() {
+	for _, db := range mr.DoltDBs {
+		err := db.Close()
+		if err != nil {
+			mr.Errhand(err)
+		}
+	}
+}
+
 func (mr *MultiRepoTestSetup) Cleanup(dbName string) {
 	os.RemoveAll(mr.Root)
 }

--- a/go/store/cmd/noms/noms_root.go
+++ b/go/store/cmd/noms/noms_root.go
@@ -62,6 +62,7 @@ func runRoot(ctx context.Context, args []string) int {
 	cfg := config.NewResolver()
 	cs, err := cfg.GetChunkStore(ctx, args[0])
 	util.CheckErrorNoUsage(err)
+	defer cs.Close()
 
 	currRoot, err := cs.Root(ctx)
 

--- a/go/store/datas/pull/puller_test.go
+++ b/go/store/datas/pull/puller_test.go
@@ -164,6 +164,7 @@ type datasFactory func(context.Context) (types.ValueReadWriter, datas.Database)
 func testPuller(t *testing.T, makeDB datasFactory) {
 	ctx := context.Background()
 	vs, db := makeDB(ctx)
+	defer db.Close()
 
 	deltas := []struct {
 		name       string
@@ -325,6 +326,7 @@ func testPuller(t *testing.T, makeDB datasFactory) {
 			}()
 
 			sinkvs, sinkdb := makeDB(ctx)
+			defer sinkdb.Close()
 
 			tmpDir := filepath.Join(os.TempDir(), uuid.New().String())
 			err = os.MkdirAll(tmpDir, os.ModePerm)
@@ -351,7 +353,6 @@ func testPuller(t *testing.T, makeDB datasFactory) {
 			eq, err := pullerAddrEquality(ctx, rootAddr, sinkRootAddr, vs, sinkvs)
 			require.NoError(t, err)
 			assert.True(t, eq)
-
 		})
 	}
 }

--- a/go/store/nbs/aws_chunk_source_test.go
+++ b/go/store/nbs/aws_chunk_source_test.go
@@ -67,6 +67,7 @@ func TestAWSChunkSource(t *testing.T) {
 		t.Run("Has Chunks", func(t *testing.T) {
 			src := makeSrc(len(chunks) + 1)
 			assertChunksInReader(chunks, src, assert.New(t))
+			src.close()
 		})
 	})
 
@@ -76,6 +77,7 @@ func TestAWSChunkSource(t *testing.T) {
 		t.Run("Has Chunks", func(t *testing.T) {
 			src := makeSrc(len(chunks) - 1)
 			assertChunksInReader(chunks, src, assert.New(t))
+			src.close()
 		})
 	})
 }

--- a/go/store/nbs/block_store_test.go
+++ b/go/store/nbs/block_store_test.go
@@ -320,6 +320,7 @@ func (suite *BlockStoreSuite) TestChunkStoreFlushOptimisticLockFail() {
 
 	interloper, err := suite.factory(context.Background(), suite.dir)
 	suite.NoError(err)
+	defer interloper.Close()
 	err = interloper.Put(context.Background(), c1, noopGetAddrs)
 	suite.NoError(err)
 	h, err := interloper.Root(context.Background())
@@ -369,6 +370,7 @@ func (suite *BlockStoreSuite) TestChunkStoreRebaseOnNoOpFlush() {
 
 	interloper, err := suite.factory(context.Background(), suite.dir)
 	suite.NoError(err)
+	defer interloper.Close()
 	err = interloper.Put(context.Background(), c1, noopGetAddrs)
 	suite.NoError(err)
 	root, err := interloper.Root(context.Background())
@@ -408,6 +410,7 @@ func (suite *BlockStoreSuite) TestChunkStorePutWithRebase() {
 
 	interloper, err := suite.factory(context.Background(), suite.dir)
 	suite.NoError(err)
+	defer interloper.Close()
 	err = interloper.Put(context.Background(), c1, noopGetAddrs)
 	suite.NoError(err)
 	h, err := interloper.Root(context.Background())

--- a/go/store/nbs/cmp_chunk_table_writer_test.go
+++ b/go/store/nbs/cmp_chunk_table_writer_test.go
@@ -40,6 +40,7 @@ func TestCmpChunkTableWriter(t *testing.T) {
 	require.NoError(t, err)
 	tr, err := newTableReader(ti, tableReaderAtFromBytes(buff), fileBlockSize)
 	require.NoError(t, err)
+	defer tr.close()
 
 	hashes := make(hash.HashSet)
 	for _, chnk := range testMDChunks {
@@ -89,6 +90,7 @@ func TestCmpChunkTableWriter(t *testing.T) {
 	require.NoError(t, err)
 	outputTR, err := newTableReader(outputTI, tableReaderAtFromBytes(buff), fileBlockSize)
 	require.NoError(t, err)
+	defer outputTR.close()
 
 	compareContentsOfTables(t, ctx, hashes, tr, outputTR)
 }

--- a/go/store/nbs/conjoiner.go
+++ b/go/store/nbs/conjoiner.go
@@ -197,6 +197,13 @@ func conjoinTables(ctx context.Context, conjoinees []tableSpec, p tablePersister
 			return
 		})
 	}
+	defer func() {
+		for _, cs := range toConjoin {
+			if cs != nil {
+				cs.close()
+			}
+		}
+	}()
 	if err = eg.Wait(); err != nil {
 		return tableSpec{}, err
 	}
@@ -207,6 +214,7 @@ func conjoinTables(ctx context.Context, conjoinees []tableSpec, p tablePersister
 	if err != nil {
 		return tableSpec{}, err
 	}
+	defer conjoinedSrc.close()
 
 	stats.ConjoinLatency.SampleTimeSince(t1)
 	stats.TablesPerConjoin.SampleLen(len(toConjoin))

--- a/go/store/nbs/file_table_reader_test.go
+++ b/go/store/nbs/file_table_reader_test.go
@@ -56,5 +56,6 @@ func TestMmapTableReader(t *testing.T) {
 
 	trc, err := newFileTableReader(ctx, dir, h, uint32(len(chunks)), &UnlimitedQuotaProvider{}, fc)
 	require.NoError(t, err)
+	defer trc.close()
 	assertChunksInReader(chunks, trc, assert)
 }

--- a/go/store/nbs/mem_table_test.go
+++ b/go/store/nbs/mem_table_test.go
@@ -156,6 +156,7 @@ func TestMemTableWrite(t *testing.T) {
 	require.NoError(t, err)
 	tr1, err := newTableReader(ti1, tableReaderAtFromBytes(td1), fileBlockSize)
 	require.NoError(t, err)
+	defer tr1.close()
 	assert.True(tr1.has(computeAddr(chunks[1])))
 
 	td2, _, err := buildTable(chunks[2:])
@@ -164,6 +165,7 @@ func TestMemTableWrite(t *testing.T) {
 	require.NoError(t, err)
 	tr2, err := newTableReader(ti2, tableReaderAtFromBytes(td2), fileBlockSize)
 	require.NoError(t, err)
+	defer tr2.close()
 	assert.True(tr2.has(computeAddr(chunks[2])))
 
 	_, data, count, err := mt.write(chunkReaderGroup{tr1, tr2}, &Stats{})
@@ -174,6 +176,7 @@ func TestMemTableWrite(t *testing.T) {
 	require.NoError(t, err)
 	outReader, err := newTableReader(ti, tableReaderAtFromBytes(data), fileBlockSize)
 	require.NoError(t, err)
+	defer outReader.close()
 	assert.True(outReader.has(computeAddr(chunks[0])))
 	assert.False(outReader.has(computeAddr(chunks[1])))
 	assert.False(outReader.has(computeAddr(chunks[2])))

--- a/go/store/nbs/s3_fake_test.go
+++ b/go/store/nbs/s3_fake_test.go
@@ -78,12 +78,12 @@ func (m *fakeS3) readerForTable(ctx context.Context, name addr) (chunkReader, er
 	defer m.mu.Unlock()
 	if buff, present := m.data[name.String()]; present {
 		ti, err := parseTableIndexByCopy(ctx, buff, &UnlimitedQuotaProvider{})
-
 		if err != nil {
 			return nil, err
 		}
 		tr, err := newTableReader(ti, tableReaderAtFromBytes(buff), s3BlockSize)
 		if err != nil {
+			ti.Close()
 			return nil, err
 		}
 		return tr, nil

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -1625,9 +1625,9 @@ func (nbs *NomsBlockStore) swapTables(ctx context.Context, specs []tableSpec) (e
 	if err != nil {
 		return err
 	}
+	oldTables := nbs.tables
 	nbs.tables, nbs.upstream = ts, upstream
-
-	return nil
+	return oldTables.close()
 }
 
 // SetRootChunk changes the root chunk hash from the previous value to the new root.

--- a/go/store/nbs/store_test.go
+++ b/go/store/nbs/store_test.go
@@ -124,6 +124,7 @@ func TestNBSAsTableFileStore(t *testing.T) {
 
 func TestConcurrentPuts(t *testing.T) {
 	st, _, _ := makeTestLocalStore(t, 100)
+	defer st.Close()
 
 	errgrp, ctx := errgroup.WithContext(context.Background())
 
@@ -190,6 +191,7 @@ func TestNBSPruneTableFiles(t *testing.T) {
 	maxTableFiles := 16
 	st, nomsDir, _ := makeTestLocalStore(t, maxTableFiles)
 	fileToData := populateLocalStore(t, st, numTableFiles)
+	defer st.Close()
 
 	// add a chunk and flush to trigger a conjoin
 	c := chunks.NewChunk([]byte("it's a boy!"))
@@ -272,6 +274,7 @@ func makeChunkSet(N, size int) (s map[hash.Hash]chunks.Chunk) {
 func TestNBSCopyGC(t *testing.T) {
 	ctx := context.Background()
 	st, _, _ := makeTestLocalStore(t, 8)
+	defer st.Close()
 
 	keepers := makeChunkSet(64, 64)
 	tossers := makeChunkSet(64, 64)

--- a/go/store/nbs/table_index_test.go
+++ b/go/store/nbs/table_index_test.go
@@ -129,6 +129,7 @@ func TestResolveOneHash(t *testing.T) {
 	td, _, err := buildTable(chunks)
 	tIdx, err := parseTableIndexByCopy(ctx, td, &UnlimitedQuotaProvider{})
 	require.NoError(t, err)
+	defer tIdx.Close()
 
 	// get hashes out
 	hashes := make([]string, len(chunks))
@@ -161,6 +162,7 @@ func TestResolveFewHash(t *testing.T) {
 	td, _, err := buildTable(chunks)
 	tIdx, err := parseTableIndexByCopy(ctx, td, &UnlimitedQuotaProvider{})
 	require.NoError(t, err)
+	defer tIdx.Close()
 
 	// get hashes out
 	hashes := make([]string, len(chunks))
@@ -194,6 +196,7 @@ func TestAmbiguousShortHash(t *testing.T) {
 	td, _, err := buildFakeChunkTable(chunks)
 	idx, err := parseTableIndexByCopy(ctx, td, &UnlimitedQuotaProvider{})
 	require.NoError(t, err)
+	defer idx.Close()
 
 	tests := []struct {
 		pre string

--- a/go/store/nbs/table_set_test.go
+++ b/go/store/nbs/table_set_test.go
@@ -49,6 +49,9 @@ func TestTableSetPrepend(t *testing.T) {
 	assert := assert.New(t)
 	ts := newFakeTableSet(&UnlimitedQuotaProvider{})
 	specs, err := ts.toSpecs()
+	defer func() {
+		ts.close()
+	}()
 	require.NoError(t, err)
 	assert.Empty(specs)
 	mt := newMemTable(testMemTableSize)
@@ -75,6 +78,9 @@ func TestTableSetPrepend(t *testing.T) {
 func TestTableSetToSpecsExcludesEmptyTable(t *testing.T) {
 	assert := assert.New(t)
 	ts := newFakeTableSet(&UnlimitedQuotaProvider{})
+	defer func() {
+		ts.close()
+	}()
 	specs, err := ts.toSpecs()
 	require.NoError(t, err)
 	assert.Empty(specs)
@@ -101,6 +107,9 @@ func TestTableSetToSpecsExcludesEmptyTable(t *testing.T) {
 func TestTableSetFlattenExcludesEmptyTable(t *testing.T) {
 	assert := assert.New(t)
 	ts := newFakeTableSet(&UnlimitedQuotaProvider{})
+	defer func() {
+		ts.close()
+	}()
 	specs, err := ts.toSpecs()
 	require.NoError(t, err)
 	assert.Empty(specs)
@@ -183,6 +192,9 @@ func TestTableSetRebase(t *testing.T) {
 func TestTableSetPhysicalLen(t *testing.T) {
 	assert := assert.New(t)
 	ts := newFakeTableSet(&UnlimitedQuotaProvider{})
+	defer func() {
+		ts.close()
+	}()
 	specs, err := ts.toSpecs()
 	require.NoError(t, err)
 	assert.Empty(specs)

--- a/go/store/nbs/table_test.go
+++ b/go/store/nbs/table_test.go
@@ -83,6 +83,7 @@ func TestSimple(t *testing.T) {
 	require.NoError(t, err)
 	tr, err := newTableReader(ti, tableReaderAtFromBytes(tableData), fileBlockSize)
 	require.NoError(t, err)
+	defer tr.close()
 
 	assertChunksInReader(chunks, tr, assert)
 
@@ -131,6 +132,7 @@ func TestHasMany(t *testing.T) {
 	require.NoError(t, err)
 	tr, err := newTableReader(ti, tableReaderAtFromBytes(tableData), fileBlockSize)
 	require.NoError(t, err)
+	defer tr.close()
 
 	addrs := addrSlice{computeAddr(chunks[0]), computeAddr(chunks[1]), computeAddr(chunks[2])}
 	hasAddrs := []hasRecord{
@@ -183,6 +185,7 @@ func TestHasManySequentialPrefix(t *testing.T) {
 	require.NoError(t, err)
 	tr, err := newTableReader(ti, tableReaderAtFromBytes(buff), fileBlockSize)
 	require.NoError(t, err)
+	defer tr.close()
 
 	hasAddrs := make([]hasRecord, 2)
 	// Leave out the first address
@@ -237,6 +240,7 @@ func BenchmarkHasMany(b *testing.B) {
 	require.NoError(b, err)
 	tr, err := newTableReader(ti, tableReaderAtFromBytes(tableData), fileBlockSize)
 	require.NoError(b, err)
+	defer tr.close()
 
 	b.ResetTimer()
 	b.Run("dense has many", func(b *testing.B) {
@@ -277,6 +281,7 @@ func TestGetMany(t *testing.T) {
 	require.NoError(t, err)
 	tr, err := newTableReader(ti, tableReaderAtFromBytes(tableData), fileBlockSize)
 	require.NoError(t, err)
+	defer tr.close()
 
 	addrs := addrSlice{computeAddr(data[0]), computeAddr(data[1]), computeAddr(data[2])}
 	getBatch := []getRecord{
@@ -312,6 +317,7 @@ func TestCalcReads(t *testing.T) {
 	require.NoError(t, err)
 	tr, err := newTableReader(ti, tableReaderAtFromBytes(tableData), 0)
 	require.NoError(t, err)
+	defer tr.close()
 	addrs := addrSlice{computeAddr(chunks[0]), computeAddr(chunks[1]), computeAddr(chunks[2])}
 	getBatch := []getRecord{
 		{&addrs[0], binary.BigEndian.Uint64(addrs[0][:addrPrefixSize]), false},
@@ -350,6 +356,7 @@ func TestExtract(t *testing.T) {
 	require.NoError(t, err)
 	tr, err := newTableReader(ti, tableReaderAtFromBytes(tableData), fileBlockSize)
 	require.NoError(t, err)
+	defer tr.close()
 
 	addrs := addrSlice{computeAddr(chunks[0]), computeAddr(chunks[1]), computeAddr(chunks[2])}
 
@@ -390,6 +397,7 @@ func Test65k(t *testing.T) {
 	require.NoError(t, err)
 	tr, err := newTableReader(ti, tableReaderAtFromBytes(tableData), fileBlockSize)
 	require.NoError(t, err)
+	defer tr.close()
 
 	for i := 0; i < count; i++ {
 		data := dataFn(i)
@@ -444,6 +452,7 @@ func doTestNGetMany(t *testing.T, count int) {
 	require.NoError(t, err)
 	tr, err := newTableReader(ti, tableReaderAtFromBytes(tableData), fileBlockSize)
 	require.NoError(t, err)
+	defer tr.close()
 
 	getBatch := make([]getRecord, len(data))
 	for i := 0; i < count; i++ {

--- a/go/store/spec/spec_test.go
+++ b/go/store/spec/spec_test.go
@@ -239,14 +239,18 @@ func TestHref(t *testing.T) {
 
 	sp, _ := ForDatabase("aws://table/foo/bar/baz")
 	assert.Equal("aws://table/foo/bar/baz", sp.Href())
+	sp.Close()
 	sp, _ = ForDataset("aws://[table:bucket]/foo/bar/baz::myds")
 	assert.Equal("aws://[table:bucket]/foo/bar/baz", sp.Href())
+	sp.Close()
 	sp, _ = ForPath("aws://[table:bucket]/foo/bar/baz::myds.my.path")
 	assert.Equal("aws://[table:bucket]/foo/bar/baz", sp.Href())
+	sp.Close()
 
 	sp, err := ForPath("mem::myds.my.path")
 	assert.NoError(err)
 	assert.Equal("", sp.Href())
+	sp.Close()
 }
 
 func TestForDatabase(t *testing.T) {
@@ -323,8 +327,9 @@ func TestForDataset(t *testing.T) {
 
 	validDatasetNames := []string{"a", "Z", "0", "/", "-", "_"}
 	for _, s := range validDatasetNames {
-		_, err := ForDataset("mem::" + s)
+		spec, err := ForDataset("mem::" + s)
 		assert.NoError(t, err)
+		spec.Close()
 	}
 
 	tmpDir, err := os.MkdirTemp("", "spec_test")
@@ -416,6 +421,8 @@ func TestMultipleSpecsSameNBS(t *testing.T) {
 
 	assert.NoError(err1)
 	assert.NoError(err2)
+	defer spec1.Close()
+	defer spec2.Close()
 
 	s := types.String("hello")
 	db := spec1.GetDatabase(context.Background())
@@ -479,6 +486,7 @@ func TestExternalProtocol(t *testing.T) {
 
 	sp, err := ForDataset("test:foo::bar")
 	assert.NoError(err)
+	defer sp.Close()
 	assert.Equal("test", sp.Protocol)
 	assert.Equal("foo", sp.DatabaseName)
 


### PR DESCRIPTION
Adds a paranoid mode where we noisely detect unclosed table files. The mode can be enabled by setting an environment variable.

Fixes some unit tests, including all of go/store/... to run cleanly under the paranoid mode.

Changes the quota interface to:
* Release |sz int| bytes instead of requiring a []byte with the correct length to show up.
* Work with |int| instead of |uint64|, since MaxUint64 is never allocatable and MaxInt32+z is only allocatable on 64-bit platforms.
* Not return an error on Release(). Implementations should not fail to release quota.