### PR TITLE
`dolt_diff` respects qualified database

### DIFF
--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -425,7 +425,7 @@ func (db Database) getTableInsensitive(ctx *sql.Context, head *doltdb.Commit, ds
 			}
 		}
 
-		dt, found = dtables.NewUnscopedDiffTable(ctx, db.ddb, db.name, head), true
+		dt, found = dtables.NewUnscopedDiffTable(ctx, db.name, db.ddb, head), true
 	case doltdb.TableOfTablesInConflictName:
 		dt, found = dtables.NewTableOfTablesInConflict(ctx, db.name, db.ddb), true
 	case doltdb.TableOfTablesWithViolationsName:

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -425,7 +425,7 @@ func (db Database) getTableInsensitive(ctx *sql.Context, head *doltdb.Commit, ds
 			}
 		}
 
-		dt, found = dtables.NewUnscopedDiffTable(ctx, db.ddb, head), true
+		dt, found = dtables.NewUnscopedDiffTable(ctx, db.ddb, db.name, head), true
 	case doltdb.TableOfTablesInConflictName:
 		dt, found = dtables.NewTableOfTablesInConflict(ctx, db.name, db.ddb), true
 	case doltdb.TableOfTablesWithViolationsName:

--- a/go/libraries/doltcore/sqle/dtables/unscoped_diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/unscoped_diff_table.go
@@ -45,8 +45,8 @@ var _ sql.FilteredTable = (*UnscopedDiffTable)(nil)
 // UnscopedDiffTable is a sql.Table implementation of a system table that shows which tables have
 // changed in each commit, across all branches.
 type UnscopedDiffTable struct {
-	ddb              *doltdb.DoltDB
 	dbName           string
+	ddb              *doltdb.DoltDB
 	head             *doltdb.Commit
 	partitionFilters []sql.Expression
 	commitCheck      doltdb.CommitFilter
@@ -61,8 +61,8 @@ type tableChange struct {
 }
 
 // NewUnscopedDiffTable creates an UnscopedDiffTable
-func NewUnscopedDiffTable(_ *sql.Context, ddb *doltdb.DoltDB, dbName string, head *doltdb.Commit) sql.Table {
-	return &UnscopedDiffTable{ddb: ddb, dbName: dbName, head: head}
+func NewUnscopedDiffTable(_ *sql.Context, dbName string, ddb *doltdb.DoltDB, head *doltdb.Commit) sql.Table {
+	return &UnscopedDiffTable{dbName: dbName, ddb: ddb, head: head}
 }
 
 // Filters returns the list of filters that are applied to this table.

--- a/integration-tests/bats/sql.bats
+++ b/integration-tests/bats/sql.bats
@@ -2581,6 +2581,22 @@ SQL
     [[ "$output" =~ "3" ]] || false
 }
 
+@test "sql: dolt diff table respects qualified database" {
+    dolt sql -q "CREATE DATABASE db01; CREATE DATABASE db02;"
+    dolt sql -q "USE db01; CREATE TABLE t01(pk int primary key);"
+    run dolt sql -q "USE db01; SELECT * FROM dolt_diff;"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "t01" ]] || false
+
+    run dolt sql -q "USE db02; SELECT * FROM dolt_diff;"
+    [ "$status" -eq 0 ]
+    ! [[ "$output" =~ "t01" ]] || false
+
+    run dolt sql -q "USE db02; SELECT * FROM db01.dolt_diff;"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "t01" ]] || false
+}
+
 @test "sql: sql print on order by returns the correct result" {
     dolt sql -q "CREATE TABLE mytable(pk int primary key);"
     dolt sql -q "INSERT INTO mytable VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16),(17),(18),(19),(20)"


### PR DESCRIPTION
This change corrects the `dolt_diff` system table to use the qualified database if provided instead of always defaulting to the session's current database.

fixes: https://github.com/dolthub/dolt/issues/5226