### PR TITLE
binlog bug fixes – stripping checksums and applying `Query` flags

### DIFF
--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_applier.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_applier.go
@@ -386,6 +386,7 @@ func (a *binlogReplicaApplier) processBinlogEvent(ctx *sql.Context, engine *gms.
 			ctx.SetSessionVariable(ctx, "foreign_key_checks", 1)
 		}
 
+		// NOTE: unique_checks is not currently honored by Dolt
 		if query.Options&mysql.QFlagOptionRelaxedUniqueChecks > 0 {
 			ctx.GetLogger().Tracef("Setting unique_checks=0")
 			ctx.SetSessionVariable(ctx, "unique_checks", 0)

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_test.go
@@ -629,6 +629,9 @@ func startMySqlServer(dir string) (int, *os.Process, error) {
 	os.Chdir(originalCwd)
 	fmt.Printf("MySQL server started on port %v \n", mySqlPort)
 
+	primaryDatabase.MustExec("CREATE USER 'replicator'@'%' IDENTIFIED BY 'password';")
+	primaryDatabase.MustExec("GRANT ALL PRIVILEGES ON *.* TO 'replicator'@'%';")
+
 	return mySqlPort, cmd.Process, nil
 }
 

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_test.go
@@ -592,7 +592,6 @@ func startMySqlServer(dir string) (int, *os.Process, error) {
 		fmt.Sprintf("--port=%v", mySqlPort),
 		"--server-id=11223344",
 		fmt.Sprintf("--socket=mysql-%v.sock", mySqlPort),
-		"--binlog-checksum=NONE",
 		"--general_log_file="+dir+"general_log",
 		"--log-bin="+dir+"log_bin",
 		"--slow_query_log_file="+dir+"slow_query_log",

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_test.go
@@ -491,7 +491,7 @@ func startReplication(_ *testing.T, port int) {
 	replicaDatabase.MustExec("SET @@GLOBAL.server_id=123;")
 	replicaDatabase.MustExec(
 		fmt.Sprintf("change replication source to SOURCE_HOST='localhost', SOURCE_USER='replicator', "+
-			"SOURCE_PASSWORD='password', SOURCE_PORT=%v;", port))
+			"SOURCE_PASSWORD='Zqr8_blrGm1!', SOURCE_PORT=%v;", port))
 
 	replicaDatabase.MustExec("start replica;")
 }
@@ -628,8 +628,8 @@ func startMySqlServer(dir string) (int, *os.Process, error) {
 	os.Chdir(originalCwd)
 	fmt.Printf("MySQL server started on port %v \n", mySqlPort)
 
-	primaryDatabase.MustExec("CREATE USER 'replicator'@'%' IDENTIFIED BY 'password';")
-	primaryDatabase.MustExec("GRANT ALL PRIVILEGES ON *.* TO 'replicator'@'%';")
+	primaryDatabase.MustExec("CREATE USER 'replicator'@'%' IDENTIFIED BY 'Zqr8_blrGm1!';")
+	primaryDatabase.MustExec("GRANT REPLICATION SLAVE ON *.* TO 'replicator'@'%';")
 
 	return mySqlPort, cmd.Process, nil
 }


### PR DESCRIPTION
This PR fixes a couple of issues from binlog testing:

### `Query` flags
Now that we have visibility to the additional flags in the `Query` binlog event (https://github.com/dolthub/vitess/pull/220), this PR adds handling for those flags. 

### Checksum support
To receive messages from the primary when `binlog_checksums` are enabled, the replica now sends a handshake signal to the primary and strips off any received checksum on binlog events. This lets us remove the requirement to disable checksums on the primary in order to use Dolt's binlog replication. 

### Password auth for tests
This PR also includes a change in the test code for the replica connect to the primary with a password, to ensure we're testing password auth. 