### PR TITLE
Add new version of `dolt_diff_summary` table function 

### DIFF
--- a/go/libraries/doltcore/diff/table_deltas.go
+++ b/go/libraries/doltcore/diff/table_deltas.go
@@ -464,8 +464,8 @@ func (td TableDelta) GetSummary(ctx context.Context) (*TableDeltaSummary, error)
 		}, nil
 	}
 
-	// TODO: Modified columns (rename, add) without a data change are not
-	// accounted for here, `dataChanged` is true when it should be false
+	// TODO: Renamed columns without a data change are not accounted for here,
+	// `dataChanged` is true when it should be false
 	dataChanged, err := td.HasHashChanged()
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/diff/table_deltas.go
+++ b/go/libraries/doltcore/diff/table_deltas.go
@@ -464,6 +464,8 @@ func (td TableDelta) GetSummary(ctx context.Context) (*TableDeltaSummary, error)
 		}, nil
 	}
 
+	// TODO: Modified columns (rename, add) without a data change are not
+	// accounted for here, `dataChanged` is true when it should be false
 	dataChanged, err := td.HasHashChanged()
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -937,14 +937,16 @@ func (p DoltDatabaseProvider) ExternalStoredProcedures(_ *sql.Context, name stri
 
 // TableFunction implements the sql.TableFunctionProvider interface
 func (p DoltDatabaseProvider) TableFunction(_ *sql.Context, name string) (sql.TableFunction, error) {
-	// currently, only one table function is supported, if we extend this, we should clean this up
-	// and store table functions in a map, similar to regular functions.
+	// TODO: Clean this up and store table functions in a map, similar to regular functions.
 	switch strings.ToLower(name) {
 	case "dolt_diff":
 		dtf := &DiffTableFunction{}
 		return dtf, nil
 	case "dolt_diff_stat":
 		dtf := &DiffStatTableFunction{}
+		return dtf, nil
+	case "dolt_diff_summary":
+		dtf := &DiffSummaryTableFunction{}
 		return dtf, nil
 	case "dolt_log":
 		dtf := &LogTableFunction{}

--- a/go/libraries/doltcore/sqle/dolt_diff_summary_table_function.go
+++ b/go/libraries/doltcore/sqle/dolt_diff_summary_table_function.go
@@ -1,0 +1,414 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqle
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dtables"
+)
+
+var _ sql.TableFunction = (*DiffSummaryTableFunction)(nil)
+
+type DiffSummaryTableFunction struct {
+	ctx *sql.Context
+
+	fromCommitExpr sql.Expression
+	toCommitExpr   sql.Expression
+	dotCommitExpr  sql.Expression
+	tableNameExpr  sql.Expression
+	database       sql.Database
+}
+
+var diffSummaryTableSchema = sql.Schema{
+	&sql.Column{Name: "table_name", Type: types.LongText, Nullable: false},
+	&sql.Column{Name: "diff_type", Type: types.Text, Nullable: false},
+	&sql.Column{Name: "has_data_changes", Type: types.Boolean, Nullable: false},
+	&sql.Column{Name: "has_schema_changes", Type: types.Boolean, Nullable: false},
+}
+
+// NewInstance creates a new instance of TableFunction interface
+func (ds *DiffSummaryTableFunction) NewInstance(ctx *sql.Context, db sql.Database, expressions []sql.Expression) (sql.Node, error) {
+	newInstance := &DiffSummaryTableFunction{
+		ctx:      ctx,
+		database: db,
+	}
+
+	node, err := newInstance.WithExpressions(expressions...)
+	if err != nil {
+		return nil, err
+	}
+
+	return node, nil
+}
+
+// Database implements the sql.Databaser interface
+func (ds *DiffSummaryTableFunction) Database() sql.Database {
+	return ds.database
+}
+
+// WithDatabase implements the sql.Databaser interface
+func (ds *DiffSummaryTableFunction) WithDatabase(database sql.Database) (sql.Node, error) {
+	ds.database = database
+	return ds, nil
+}
+
+// Name implements the sql.TableFunction interface
+func (ds *DiffSummaryTableFunction) Name() string {
+	return "dolt_diff_summary"
+}
+
+func (ds *DiffSummaryTableFunction) commitsResolved() bool {
+	if ds.dotCommitExpr != nil {
+		return ds.dotCommitExpr.Resolved()
+	}
+	return ds.fromCommitExpr.Resolved() && ds.toCommitExpr.Resolved()
+}
+
+// Resolved implements the sql.Resolvable interface
+func (ds *DiffSummaryTableFunction) Resolved() bool {
+	if ds.tableNameExpr != nil {
+		return ds.commitsResolved() && ds.tableNameExpr.Resolved()
+	}
+	return ds.commitsResolved()
+}
+
+// String implements the Stringer interface
+func (ds *DiffSummaryTableFunction) String() string {
+	if ds.dotCommitExpr != nil {
+		if ds.tableNameExpr != nil {
+			return fmt.Sprintf("DOLT_DIFF_SUMMARY(%s, %s)", ds.dotCommitExpr.String(), ds.tableNameExpr.String())
+		}
+		return fmt.Sprintf("DOLT_DIFF_SUMMARY(%s)", ds.dotCommitExpr.String())
+	}
+	if ds.tableNameExpr != nil {
+		return fmt.Sprintf("DOLT_DIFF_SUMMARY(%s, %s, %s)", ds.fromCommitExpr.String(), ds.toCommitExpr.String(), ds.tableNameExpr.String())
+	}
+	return fmt.Sprintf("DOLT_DIFF_SUMMARY(%s, %s)", ds.fromCommitExpr.String(), ds.toCommitExpr.String())
+}
+
+// Schema implements the sql.Node interface.
+func (ds *DiffSummaryTableFunction) Schema() sql.Schema {
+	return diffSummaryTableSchema
+}
+
+// Children implements the sql.Node interface.
+func (ds *DiffSummaryTableFunction) Children() []sql.Node {
+	return nil
+}
+
+// WithChildren implements the sql.Node interface.
+func (ds *DiffSummaryTableFunction) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, fmt.Errorf("unexpected children")
+	}
+	return ds, nil
+}
+
+// CheckPrivileges implements the interface sql.Node.
+func (ds *DiffSummaryTableFunction) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
+	if ds.tableNameExpr != nil {
+		if !types.IsText(ds.tableNameExpr.Type()) {
+			return false
+		}
+
+		tableNameVal, err := ds.tableNameExpr.Eval(ds.ctx, nil)
+		if err != nil {
+			return false
+		}
+		tableName, ok := tableNameVal.(string)
+		if !ok {
+			return false
+		}
+
+		// TODO: Add tests for privilege checking
+		return opChecker.UserHasPrivileges(ctx,
+			sql.NewPrivilegedOperation(ds.database.Name(), tableName, "", sql.PrivilegeType_Select))
+	}
+
+	tblNames, err := ds.database.GetTableNames(ctx)
+	if err != nil {
+		return false
+	}
+
+	var operations []sql.PrivilegedOperation
+	for _, tblName := range tblNames {
+		operations = append(operations, sql.NewPrivilegedOperation(ds.database.Name(), tblName, "", sql.PrivilegeType_Select))
+	}
+
+	return opChecker.UserHasPrivileges(ctx, operations...)
+}
+
+// Expressions implements the sql.Expressioner interface.
+func (ds *DiffSummaryTableFunction) Expressions() []sql.Expression {
+	exprs := []sql.Expression{}
+	if ds.dotCommitExpr != nil {
+		exprs = append(exprs, ds.dotCommitExpr)
+	} else {
+		exprs = append(exprs, ds.fromCommitExpr, ds.toCommitExpr)
+	}
+	if ds.tableNameExpr != nil {
+		exprs = append(exprs, ds.tableNameExpr)
+	}
+	return exprs
+}
+
+// WithExpressions implements the sql.Expressioner interface.
+func (ds *DiffSummaryTableFunction) WithExpressions(expression ...sql.Expression) (sql.Node, error) {
+	if len(expression) < 1 {
+		return nil, sql.ErrInvalidArgumentNumber.New(ds.Name(), "1 to 3", len(expression))
+	}
+
+	for _, expr := range expression {
+		if !expr.Resolved() {
+			return nil, ErrInvalidNonLiteralArgument.New(ds.Name(), expr.String())
+		}
+		// prepared statements resolve functions beforehand, so above check fails
+		if _, ok := expr.(sql.FunctionExpression); ok {
+			return nil, ErrInvalidNonLiteralArgument.New(ds.Name(), expr.String())
+		}
+	}
+
+	if strings.Contains(expression[0].String(), "..") {
+		if len(expression) < 1 || len(expression) > 2 {
+			return nil, sql.ErrInvalidArgumentNumber.New(ds.Name(), "1 or 2", len(expression))
+		}
+		ds.dotCommitExpr = expression[0]
+		if len(expression) == 2 {
+			ds.tableNameExpr = expression[1]
+		}
+	} else {
+		if len(expression) < 2 || len(expression) > 3 {
+			return nil, sql.ErrInvalidArgumentNumber.New(ds.Name(), "2 or 3", len(expression))
+		}
+		ds.fromCommitExpr = expression[0]
+		ds.toCommitExpr = expression[1]
+		if len(expression) == 3 {
+			ds.tableNameExpr = expression[2]
+		}
+	}
+
+	// validate the expressions
+	if ds.dotCommitExpr != nil {
+		if !types.IsText(ds.dotCommitExpr.Type()) {
+			return nil, sql.ErrInvalidArgumentDetails.New(ds.Name(), ds.dotCommitExpr.String())
+		}
+	} else {
+		if !types.IsText(ds.fromCommitExpr.Type()) {
+			return nil, sql.ErrInvalidArgumentDetails.New(ds.Name(), ds.fromCommitExpr.String())
+		}
+		if !types.IsText(ds.toCommitExpr.Type()) {
+			return nil, sql.ErrInvalidArgumentDetails.New(ds.Name(), ds.toCommitExpr.String())
+		}
+	}
+
+	if ds.tableNameExpr != nil {
+		if !types.IsText(ds.tableNameExpr.Type()) {
+			return nil, sql.ErrInvalidArgumentDetails.New(ds.Name(), ds.tableNameExpr.String())
+		}
+	}
+
+	return ds, nil
+}
+
+// RowIter implements the sql.Node interface
+func (ds *DiffSummaryTableFunction) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
+	fromCommitVal, toCommitVal, dotCommitVal, tableName, err := ds.evaluateArguments()
+	if err != nil {
+		return nil, err
+	}
+
+	sqledb, ok := ds.database.(SqlDatabase)
+	if !ok {
+		return nil, fmt.Errorf("unexpected database type: %T", ds.database)
+	}
+
+	fromDetails, toDetails, err := loadDetailsForRefs(ctx, fromCommitVal, toCommitVal, dotCommitVal, sqledb)
+	if err != nil {
+		return nil, err
+	}
+
+	deltas, err := diff.GetTableDeltas(ctx, fromDetails.root, toDetails.root)
+	if err != nil {
+		return nil, err
+	}
+
+	// If tableNameExpr defined, return a single table diff stat result
+	if ds.tableNameExpr != nil {
+		delta := findMatchingDelta(deltas, tableName)
+
+		summ, err := getSummaryForDelta(ctx, delta, sqledb, fromDetails, toDetails)
+		if err != nil {
+			return nil, err
+		}
+		summs := []*diff.TableDeltaSummary{}
+		if summ != nil {
+			summs = []*diff.TableDeltaSummary{summ}
+		}
+		return NewDiffSummaryTableFunctionRowIter(summs), nil
+	}
+
+	var diffSummaries []*diff.TableDeltaSummary
+	for _, delta := range deltas {
+		summ, err := getSummaryForDelta(ctx, delta, sqledb, fromDetails, toDetails)
+		if err != nil {
+			return nil, err
+		}
+		if summ != nil {
+			diffSummaries = append(diffSummaries, summ)
+		}
+	}
+
+	return NewDiffSummaryTableFunctionRowIter(diffSummaries), nil
+}
+
+func getSummaryForDelta(ctx *sql.Context, delta diff.TableDelta, sqledb SqlDatabase, fromDetails, toDetails *refDetails) (*diff.TableDeltaSummary, error) {
+	if delta.FromTable == nil && delta.ToTable == nil {
+		return nil, nil
+	}
+
+	hasDataChanges, err := deltaHasDataChanges(ctx, delta, sqledb, fromDetails, toDetails)
+	if err != nil {
+		return nil, err
+	}
+
+	summ, err := delta.GetSummary(ctx, hasDataChanges)
+	if err != nil {
+		return nil, err
+	}
+
+	return summ, nil
+}
+
+func deltaHasDataChanges(ctx *sql.Context, delta diff.TableDelta, sqledb SqlDatabase, fromDetails, toDetails *refDetails) (bool, error) {
+	ddb := sqledb.DbData().Ddb
+	dp := dtables.NewDiffPartition(delta.ToTable, delta.FromTable, toDetails.hashStr, fromDetails.hashStr, toDetails.commitTime, fromDetails.commitTime, delta.ToSch, delta.FromSch)
+
+	_, j, err := dtables.GetDiffTableSchemaAndJoiner(delta.Format(), delta.FromSch, delta.ToSch)
+	if err != nil {
+		return false, err
+	}
+
+	rowIter, err := dp.GetRowIter(ctx, ddb, j, sql.IndexLookup{})
+	if err != nil {
+		return false, err
+	}
+
+	_, err = rowIter.Next(ctx)
+	if err == io.EOF {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// evaluateArguments returns fromCommitVal, toCommitVal, dotCommitVal, and tableName.
+// It evaluates the argument expressions to turn them into values this DiffSummaryTableFunction
+// can use. Note that this method only evals the expressions, and doesn't validate the values.
+func (ds *DiffSummaryTableFunction) evaluateArguments() (interface{}, interface{}, interface{}, string, error) {
+	var tableName string
+	if ds.tableNameExpr != nil {
+		tableNameVal, err := ds.tableNameExpr.Eval(ds.ctx, nil)
+		if err != nil {
+			return nil, nil, nil, "", err
+		}
+		tn, ok := tableNameVal.(string)
+		if !ok {
+			return nil, nil, nil, "", ErrInvalidTableName.New(ds.tableNameExpr.String())
+		}
+		tableName = tn
+	}
+
+	if ds.dotCommitExpr != nil {
+		dotCommitVal, err := ds.dotCommitExpr.Eval(ds.ctx, nil)
+		if err != nil {
+			return nil, nil, nil, "", err
+		}
+
+		return nil, nil, dotCommitVal, tableName, nil
+	}
+
+	fromCommitVal, err := ds.fromCommitExpr.Eval(ds.ctx, nil)
+	if err != nil {
+		return nil, nil, nil, "", err
+	}
+
+	toCommitVal, err := ds.toCommitExpr.Eval(ds.ctx, nil)
+	if err != nil {
+		return nil, nil, nil, "", err
+	}
+
+	return fromCommitVal, toCommitVal, nil, tableName, nil
+}
+
+//------------------------------------
+// diffSummaryTableFunctionRowIter
+//------------------------------------
+
+var _ sql.RowIter = &diffSummaryTableFunctionRowIter{}
+
+type diffSummaryTableFunctionRowIter struct {
+	summaries []*diff.TableDeltaSummary
+	diffIdx   int
+}
+
+func (d *diffSummaryTableFunctionRowIter) incrementIndexes() {
+	d.diffIdx++
+	if d.diffIdx >= len(d.summaries) {
+		d.diffIdx = 0
+		d.summaries = nil
+	}
+}
+
+func NewDiffSummaryTableFunctionRowIter(ds []*diff.TableDeltaSummary) sql.RowIter {
+	return &diffSummaryTableFunctionRowIter{
+		summaries: ds,
+	}
+}
+
+func (d *diffSummaryTableFunctionRowIter) Next(ctx *sql.Context) (sql.Row, error) {
+	defer d.incrementIndexes()
+	if d.diffIdx >= len(d.summaries) {
+		return nil, io.EOF
+	}
+
+	if d.summaries == nil {
+		return nil, io.EOF
+	}
+
+	ds := d.summaries[d.diffIdx]
+	return getRowFromSummary(ds), nil
+}
+
+func (d *diffSummaryTableFunctionRowIter) Close(context *sql.Context) error {
+	return nil
+}
+
+func getRowFromSummary(ds *diff.TableDeltaSummary) sql.Row {
+	return sql.Row{
+		ds.TableName,        // table_name
+		ds.DiffType,         // diff_type
+		ds.HasDataChanges,   // has_data_changes
+		ds.HasSchemaChanges, // has_schema_changes
+	}
+}

--- a/go/libraries/doltcore/sqle/dtables/unscoped_diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/unscoped_diff_table.go
@@ -52,14 +52,6 @@ type UnscopedDiffTable struct {
 	commitCheck      doltdb.CommitFilter
 }
 
-// tableChange is an internal data structure used to hold the results of processing
-// a diff.TableDelta structure into the output data for this system table.
-type tableChange struct {
-	tableName    string
-	dataChange   bool
-	schemaChange bool
-}
-
 // NewUnscopedDiffTable creates an UnscopedDiffTable
 func NewUnscopedDiffTable(_ *sql.Context, dbName string, ddb *doltdb.DoltDB, head *doltdb.Commit) sql.Table {
 	return &UnscopedDiffTable{dbName: dbName, ddb: ddb, head: head}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -1258,6 +1258,28 @@ func TestDiffStatTableFunctionPrepared(t *testing.T) {
 	}
 }
 
+func TestDiffSummaryTableFunction(t *testing.T) {
+	harness := newDoltHarness(t)
+	harness.Setup(setup.MydbData)
+	for _, test := range DiffSummaryTableFunctionScriptTests {
+		harness.engine = nil
+		t.Run(test.Name, func(t *testing.T) {
+			enginetest.TestScript(t, harness, test)
+		})
+	}
+}
+
+func TestDiffSummaryTableFunctionPrepared(t *testing.T) {
+	harness := newDoltHarness(t)
+	harness.Setup(setup.MydbData)
+	for _, test := range DiffSummaryTableFunctionScriptTests {
+		harness.engine = nil
+		t.Run(test.Name, func(t *testing.T) {
+			enginetest.TestScriptPrepared(t, harness, test)
+		})
+	}
+}
+
 func TestLogTableFunction(t *testing.T) {
 	harness := newDoltHarness(t)
 	harness.Setup(setup.MydbData)

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -832,6 +832,20 @@ var DoltUserPrivTests = []queries.UserPrivilegeTest{
 				ExpectedErr: sql.ErrDatabaseAccessDeniedForUser,
 			},
 			{
+				// Without access to the database, dolt_diff_summary should fail with a database access error
+				User:        "tester",
+				Host:        "localhost",
+				Query:       "SELECT * FROM dolt_diff_summary('main~', 'main', 'test');",
+				ExpectedErr: sql.ErrDatabaseAccessDeniedForUser,
+			},
+			{
+				// Without access to the database, dolt_diff_summary with dots should fail with a database access error
+				User:        "tester",
+				Host:        "localhost",
+				Query:       "SELECT * FROM dolt_diff_summary('main~..main', 'test');",
+				ExpectedErr: sql.ErrDatabaseAccessDeniedForUser,
+			},
+			{
 				// Without access to the database, dolt_log should fail with a database access error
 				User:        "tester",
 				Host:        "localhost",
@@ -902,6 +916,34 @@ var DoltUserPrivTests = []queries.UserPrivilegeTest{
 				ExpectedErr: sql.ErrPrivilegeCheckFailed,
 			},
 			{
+				// With access to the db, but not the table, dolt_diff_summary should fail
+				User:        "tester",
+				Host:        "localhost",
+				Query:       "SELECT * FROM dolt_diff_summary('main~', 'main', 'test2');",
+				ExpectedErr: sql.ErrPrivilegeCheckFailed,
+			},
+			{
+				// With access to the db, but not the table, dolt_diff_summary with dots should fail
+				User:        "tester",
+				Host:        "localhost",
+				Query:       "SELECT * FROM dolt_diff_summary('main~...main', 'test2');",
+				ExpectedErr: sql.ErrPrivilegeCheckFailed,
+			},
+			{
+				// With access to the db, dolt_diff_summary should fail for all tables if no access any of tables
+				User:        "tester",
+				Host:        "localhost",
+				Query:       "SELECT * FROM dolt_diff_summary('main~', 'main');",
+				ExpectedErr: sql.ErrPrivilegeCheckFailed,
+			},
+			{
+				// With access to the db, dolt_diff_summary with dots should fail for all tables if no access any of tables
+				User:        "tester",
+				Host:        "localhost",
+				Query:       "SELECT * FROM dolt_diff_summary('main~...main');",
+				ExpectedErr: sql.ErrPrivilegeCheckFailed,
+			},
+			{
 				// Revoke select on mydb.test
 				User:     "root",
 				Host:     "localhost",
@@ -958,6 +1000,20 @@ var DoltUserPrivTests = []queries.UserPrivilegeTest{
 				Expected: []sql.Row{{1}},
 			},
 			{
+				// After granting access to the entire db, dolt_diff_summary should work
+				User:     "tester",
+				Host:     "localhost",
+				Query:    "SELECT COUNT(*) FROM dolt_diff_summary('main~', 'main');",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				// After granting access to the entire db, dolt_diff_summary with dots should work
+				User:     "tester",
+				Host:     "localhost",
+				Query:    "SELECT COUNT(*) FROM dolt_diff_summary('main~...main');",
+				Expected: []sql.Row{{1}},
+			},
+			{
 				// After granting access to the entire db, dolt_log should work
 				User:     "tester",
 				Host:     "localhost",
@@ -990,6 +1046,13 @@ var DoltUserPrivTests = []queries.UserPrivilegeTest{
 				User:        "tester",
 				Host:        "localhost",
 				Query:       "SELECT * FROM dolt_diff_stat('main~', 'main', 'test');",
+				ExpectedErr: sql.ErrDatabaseAccessDeniedForUser,
+			},
+			{
+				// After revoking access, dolt_diff_summary should fail
+				User:        "tester",
+				Host:        "localhost",
+				Query:       "SELECT * FROM dolt_diff_summary('main~', 'main', 'test');",
 				ExpectedErr: sql.ErrDatabaseAccessDeniedForUser,
 			},
 			{

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -2528,7 +2528,7 @@ var DiffSummaryTableFunctionScriptTests = []queries.ScriptTest{
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit3, @Commit4, 't');",
-				Expected: []sql.Row{{"t", "modified", true, true}}, // TODO: data change should be false for added column
+				Expected: []sql.Row{{"t", "modified", true, true}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit3, @Commit5, 't');",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -2047,6 +2047,705 @@ inner join t as of @Commit3 on rows_unmodified = t.pk;`,
 	},
 }
 
+var DiffSummaryTableFunctionScriptTests = []queries.ScriptTest{
+	{
+		Name: "invalid arguments",
+		SetUpScript: []string{
+			"create table t (pk int primary key, c1 varchar(20), c2 varchar(20));",
+			"call dolt_add('.')",
+			"set @Commit1 = '';",
+			"call dolt_commit_hash_out(@Commit1, '-am', 'creating table t');",
+
+			"insert into t values(1, 'one', 'two'), (2, 'two', 'three');",
+			"set @Commit2 = '';",
+			"call dolt_commit_hash_out(@Commit2, '-am', 'inserting into t');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:       "SELECT * from dolt_diff_summary();",
+				ExpectedErr: sql.ErrInvalidArgumentNumber,
+			},
+			{
+				Query:       "SELECT * from dolt_diff_summary('t');",
+				ExpectedErr: sql.ErrInvalidArgumentNumber,
+			},
+			{
+				Query:       "SELECT * from dolt_diff_summary('t', @Commit1, @Commit2, 'extra');",
+				ExpectedErr: sql.ErrInvalidArgumentNumber,
+			},
+			{
+				Query:       "SELECT * from dolt_diff_summary(null, null, null);",
+				ExpectedErr: sql.ErrInvalidArgumentDetails,
+			},
+			{
+				Query:       "SELECT * from dolt_diff_summary(123, @Commit1, @Commit2);",
+				ExpectedErr: sql.ErrInvalidArgumentDetails,
+			},
+			{
+				Query:       "SELECT * from dolt_diff_summary('t', 123, @Commit2);",
+				ExpectedErr: sql.ErrInvalidArgumentDetails,
+			},
+			{
+				Query:       "SELECT * from dolt_diff_summary('t', @Commit1, 123);",
+				ExpectedErr: sql.ErrInvalidArgumentDetails,
+			},
+			{
+				Query:          "SELECT * from dolt_diff_summary('fake-branch', @Commit2, 't');",
+				ExpectedErrStr: "branch not found: fake-branch",
+			},
+			{
+				Query:          "SELECT * from dolt_diff_summary('fake-branch..main', 't');",
+				ExpectedErrStr: "branch not found: fake-branch",
+			},
+			{
+				Query:          "SELECT * from dolt_diff_summary(@Commit1, 'fake-branch', 't');",
+				ExpectedErrStr: "branch not found: fake-branch",
+			},
+			{
+				Query:          "SELECT * from dolt_diff_summary('main..fake-branch', 't');",
+				ExpectedErrStr: "branch not found: fake-branch",
+			},
+			{
+				Query:       "SELECT * from dolt_diff_summary(@Commit1, concat('fake', '-', 'branch'), 't');",
+				ExpectedErr: sqle.ErrInvalidNonLiteralArgument,
+			},
+			{
+				Query:       "SELECT * from dolt_diff_summary(hashof('main'), @Commit2, 't');",
+				ExpectedErr: sqle.ErrInvalidNonLiteralArgument,
+			},
+			{
+				Query:       "SELECT * from dolt_diff_summary(@Commit1, @Commit2, LOWER('T'));",
+				ExpectedErr: sqle.ErrInvalidNonLiteralArgument,
+			},
+		},
+	},
+	{
+		Name: "basic case with single table",
+		SetUpScript: []string{
+			"set @Commit0 = HashOf('HEAD');",
+			"set @Commit1 = '';",
+			"call dolt_commit_hash_out(@Commit1, '--allow-empty', '-m', 'creating table t');",
+
+			// create table t only
+			"create table t (pk int primary key, c1 varchar(20), c2 varchar(20));",
+			"call dolt_add('.')",
+			"set @Commit2 = '';",
+			"call dolt_commit_hash_out(@Commit2, '-am', 'creating table t');",
+
+			// insert 1 row into t
+			"insert into t values(1, 'one', 'two');",
+			"set @Commit3 = '';",
+			"call dolt_commit_hash_out(@Commit3, '-am', 'inserting 1 into table t');",
+
+			// insert 2 rows into t and update two cells
+			"insert into t values(2, 'two', 'three'), (3, 'three', 'four');",
+			"update t set c1='uno', c2='dos' where pk=1;",
+			"set @Commit4 = '';",
+			"call dolt_commit_hash_out(@Commit4, '-am', 'inserting 2 into table t');",
+
+			// drop table t only
+			"drop table t;",
+			"set @Commit5 = '';",
+			"call dolt_commit_hash_out(@Commit5, '-am', 'drop table t');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				// table does not exist, empty result
+				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit2, 'doesnotexist');",
+				Expected: []sql.Row{},
+			},
+			{
+				// table is added, no data changes
+				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit2, 't');",
+				Expected: []sql.Row{{"t", "added", false, true}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit2, @Commit3, 't');",
+				Expected: []sql.Row{{"t", "modified", true, false}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit3, @Commit4, 't');",
+				Expected: []sql.Row{{"t", "modified", true, false}},
+			},
+			{
+				// change from and to commits
+				Query:    "SELECT * from dolt_diff_summary(@Commit4, @Commit3, 't');",
+				Expected: []sql.Row{{"t", "modified", true, false}},
+			},
+			{
+				// table is dropped
+				Query:    "SELECT * from dolt_diff_summary(@Commit4, @Commit5, 't');",
+				Expected: []sql.Row{{"t", "dropped", true, true}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit4, 't');",
+				Expected: []sql.Row{{"t", "added", true, true}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit5, 't');",
+				Expected: []sql.Row{},
+			},
+		},
+	},
+	{
+		Name: "basic case with single keyless table",
+		SetUpScript: []string{
+			"set @Commit0 = HashOf('HEAD');",
+			"set @Commit1 = '';",
+			"call dolt_commit_hash_out(@Commit1, '--allow-empty', '-m', 'creating table t');",
+
+			// create table t only
+			"create table t (id int, c1 varchar(20), c2 varchar(20));",
+			"call dolt_add('.')",
+			"set @Commit2 = '';",
+			"call dolt_commit_hash_out(@Commit2, '-am', 'creating table t');",
+
+			// insert 1 row into t
+			"insert into t values(1, 'one', 'two');",
+			"set @Commit3 = '';",
+			"call dolt_commit_hash_out(@Commit3, '-am', 'inserting 1 into table t');",
+
+			// insert 2 rows into t and update two cells
+			"insert into t values(2, 'two', 'three'), (3, 'three', 'four');",
+			"update t set c1='uno', c2='dos' where id=1;",
+			"set @Commit4 = '';",
+			"call dolt_commit_hash_out(@Commit4, '-am', 'inserting 2 into table t');",
+
+			// drop table t only
+			"drop table t;",
+			"set @Commit5 = '';",
+			"call dolt_commit_hash_out(@Commit5, '-am', 'drop table t');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				// table is added, no data diff, result is empty
+				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit2, 't');",
+				Expected: []sql.Row{{"t", "added", false, true}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit2, @Commit3, 't');",
+				Expected: []sql.Row{{"t", "modified", true, false}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit3, @Commit4, 't');",
+				Expected: []sql.Row{{"t", "modified", true, false}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit4, @Commit3, 't');",
+				Expected: []sql.Row{{"t", "modified", true, false}},
+			},
+			{
+				// table is dropped
+				Query:    "SELECT * from dolt_diff_summary(@Commit4, @Commit5, 't');",
+				Expected: []sql.Row{{"t", "dropped", true, true}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit4, 't');",
+				Expected: []sql.Row{{"t", "added", true, true}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit5, 't');",
+				Expected: []sql.Row{},
+			},
+		},
+	},
+	{
+		Name: "basic case with multiple tables",
+		SetUpScript: []string{
+			"set @Commit0 = HashOf('HEAD');",
+
+			// add table t with 1 row
+			"create table t (pk int primary key, c1 varchar(20), c2 varchar(20));",
+			"insert into t values(1, 'one', 'two');",
+			"call dolt_add('.')",
+			"set @Commit1 = '';",
+			"call dolt_commit_hash_out(@Commit1, '-am', 'inserting into table t');",
+
+			// add table t2 with 1 row
+			"create table t2 (pk int primary key, c1 varchar(20), c2 varchar(20));",
+			"insert into t2 values(100, 'hundred', 'hundert');",
+			"call dolt_add('.')",
+			"set @Commit2 = '';",
+			"call dolt_commit_hash_out(@Commit2, '-am', 'inserting into table t2');",
+
+			// changes on both tables
+			"insert into t values(2, 'two', 'three'), (3, 'three', 'four'), (4, 'four', 'five');",
+			"update t set c1='uno', c2='dos' where pk=1;",
+			"insert into t2 values(101, 'hundred one', 'one');",
+			"set @Commit3 = '';",
+			"call dolt_commit_hash_out(@Commit3, '-am', 'inserting into table t');",
+
+			// changes on both tables
+			"delete from t where c2 = 'four';",
+			"update t2 set c2='zero' where pk=100;",
+			"set @Commit4 = '';",
+			"call dolt_commit_hash_out(@Commit4, '-am', 'inserting into table t');",
+
+			// create keyless table
+			"create table keyless (id int);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit0, @Commit1);",
+				Expected: []sql.Row{{"t", "added", true, true}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit2);",
+				Expected: []sql.Row{{"t2", "added", true, true}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit2, @Commit3);",
+				Expected: []sql.Row{{"t", "modified", true, false}, {"t2", "modified", true, false}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit3, @Commit4);",
+				Expected: []sql.Row{{"t", "modified", true, false}, {"t2", "modified", true, false}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit0, @Commit4);",
+				Expected: []sql.Row{{"t", "added", true, true}, {"t2", "added", true, true}},
+			},
+			{
+				Query: "SELECT * from dolt_diff_summary(@Commit4, @Commit2);",
+
+				Expected: []sql.Row{{"t", "modified", true, false}, {"t2", "modified", true, false}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit3, 'WORKING');",
+				Expected: []sql.Row{{"t", "modified", true, false}, {"t2", "modified", true, false}, {"keyless", "added", false, true}},
+			},
+		},
+	},
+	{
+		Name: "WORKING and STAGED",
+		SetUpScript: []string{
+			"set @Commit0 = HashOf('HEAD');",
+
+			"create table t (pk int primary key, c1 text, c2 text);",
+			"call dolt_add('.')",
+			"insert into t values (1, 'one', 'two'), (2, 'three', 'four');",
+			"set @Commit1 = '';",
+			"call dolt_commit_hash_out(@Commit1, '-am', 'inserting two rows into table t');",
+
+			"insert into t values (3, 'five', 'six');",
+			"delete from t where pk = 2",
+			"update t set c2 = '100' where pk = 1",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit1, 'WORKING', 't')",
+				Expected: []sql.Row{{"t", "modified", true, false}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary('STAGED', 'WORKING', 't')",
+				Expected: []sql.Row{{"t", "modified", true, false}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary('STAGED..WORKING', 't')",
+				Expected: []sql.Row{{"t", "modified", true, false}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary('WORKING', 'STAGED', 't')",
+				Expected: []sql.Row{{"t", "modified", true, false}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary('WORKING', 'WORKING', 't')",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary('WORKING..WORKING', 't')",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary('STAGED', 'STAGED', 't')",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:            "call dolt_add('.')",
+				SkipResultsCheck: true,
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary('WORKING', 'STAGED', 't')",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary('HEAD', 'STAGED', 't')",
+				Expected: []sql.Row{{"t", "modified", true, false}},
+			},
+		},
+	},
+	{
+		Name: "diff with branch refs",
+		SetUpScript: []string{
+			"create table t (pk int primary key, c1 varchar(20), c2 varchar(20));",
+			"call dolt_add('.')",
+			"set @Commit1 = '';",
+			"call dolt_commit_hash_out(@Commit1, '-am', 'creating table t');",
+
+			"insert into t values(1, 'one', 'two');",
+			"set @Commit2 = '';",
+			"call dolt_commit_hash_out(@Commit2, '-am', 'inserting row 1 into t in main');",
+
+			"CALL DOLT_checkout('-b', 'branch1');",
+			"alter table t drop column c2;",
+			"set @Commit3 = '';",
+			"call dolt_commit_hash_out(@Commit3, '-am', 'dropping column c2 in branch1');",
+
+			"delete from t where pk=1;",
+			"set @Commit4 = '';",
+			"call dolt_commit_hash_out(@Commit4, '-am', 'deleting row 1 in branch1');",
+
+			"insert into t values (2, 'two');",
+			"set @Commit5 = '';",
+			"call dolt_commit_hash_out(@Commit5, '-am', 'inserting row 2 in branch1');",
+
+			"CALL DOLT_checkout('main');",
+			"insert into t values (2, 'two', 'three');",
+			"set @Commit6 = '';",
+			"call dolt_commit_hash_out(@Commit6, '-am', 'inserting row 2 in main');",
+
+			"create table newtable (pk int primary key);",
+			"insert into newtable values (1), (2);",
+			"set @Commit7 = '';",
+			"call dolt_commit_hash_out(@Commit7, '-Am', 'new table newtable');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "SELECT * from dolt_diff_summary('main', 'branch1', 't');",
+				Expected: []sql.Row{{"t", "modified", true, true}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary('main..branch1', 't');",
+				Expected: []sql.Row{{"t", "modified", true, true}},
+			},
+			{
+				Query: "SELECT * from dolt_diff_summary('main', 'branch1');",
+				Expected: []sql.Row{
+					{"t", "modified", true, true},
+					{"newtable", "dropped", true, true},
+				},
+			},
+			{
+				Query: "SELECT * from dolt_diff_summary('main..branch1');",
+				Expected: []sql.Row{
+					{"t", "modified", true, true},
+					{"newtable", "dropped", true, true},
+				},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary('branch1', 'main', 't');",
+				Expected: []sql.Row{{"t", "modified", true, true}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary('branch1..main', 't');",
+				Expected: []sql.Row{{"t", "modified", true, true}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary('main~2', 'branch1', 't');",
+				Expected: []sql.Row{{"t", "modified", true, true}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary('main~2..branch1', 't');",
+				Expected: []sql.Row{{"t", "modified", true, true}},
+			},
+
+			// Three dot
+			{
+				Query:    "SELECT * from dolt_diff_summary('main...branch1', 't');",
+				Expected: []sql.Row{{"t", "modified", true, true}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary('main...branch1');",
+				Expected: []sql.Row{{"t", "modified", true, true}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary('branch1...main', 't');",
+				Expected: []sql.Row{{"t", "modified", true, false}},
+			},
+			{
+				Query: "SELECT * from dolt_diff_summary('branch1...main');",
+				Expected: []sql.Row{
+					{"t", "modified", true, false},
+					{"newtable", "added", true, true},
+				},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary('branch1...main^');",
+				Expected: []sql.Row{{"t", "modified", true, false}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary('branch1...main', 'newtable');",
+				Expected: []sql.Row{{"newtable", "added", true, true}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary('main...main', 'newtable');",
+				Expected: []sql.Row{},
+			},
+		},
+	},
+	{
+		Name: "schema modification: drop and add column",
+		SetUpScript: []string{
+			"create table t (pk int primary key, c1 varchar(20), c2 varchar(20));",
+			"call dolt_add('.');",
+			"insert into t values (1, 'one', 'two'), (2, 'two', 'three');",
+			"set @Commit1 = '';",
+			"call dolt_commit_hash_out(@Commit1, '-am', 'inserting row 1, 2 into t');",
+
+			// drop 1 column
+			"alter table t drop column c2;",
+			"set @Commit2 = '';",
+			"call dolt_commit_hash_out(@Commit2, '-am', 'dropping column c2');",
+
+			// add 1 row
+			"insert into t values (3, 'three');",
+			"set @Commit3 = '';",
+			"call dolt_commit_hash_out(@Commit3, '-am', 'inserting row 3');",
+
+			// add 1 column and 1 row and update
+			"alter table t add column c2 varchar(20);",
+			"insert into t values (4, 'four', 'five');",
+			"update t set c2='foo' where pk=1;",
+			"set @Commit4 = '';",
+			"call dolt_commit_hash_out(@Commit4, '-am', 'adding column c2, inserting, and updating data');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit2, 't');",
+				Expected: []sql.Row{{"t", "modified", true, true}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit2, @Commit3, 't');",
+				Expected: []sql.Row{{"t", "modified", true, false}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit3, 't');",
+				Expected: []sql.Row{{"t", "modified", true, true}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit3, @Commit4, 't');",
+				Expected: []sql.Row{{"t", "modified", true, true}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit4, 't');",
+				Expected: []sql.Row{{"t", "modified", true, false}},
+			},
+		},
+	},
+	{
+		Name: "schema modification: rename columns",
+		SetUpScript: []string{
+			"create table t (pk int primary key, c1 varchar(20), c2 int);",
+			"call dolt_add('.')",
+			"set @Commit1 = '';",
+			"call dolt_commit_hash_out(@Commit1, '-am', 'creating table t');",
+
+			// add rows
+			"insert into t values(1, 'one', -1), (2, 'two', -2);",
+			"set @Commit2 = '';",
+			"call dolt_commit_hash_out(@Commit2, '-am', 'inserting into t');",
+
+			// rename column
+			"alter table t rename column c2 to c3;",
+			"set @Commit3 = '';",
+			"call dolt_commit_hash_out(@Commit3, '-am', 'renaming column c2 to c3');",
+
+			// add row and update
+			"insert into t values (3, 'three', -3);",
+			"update t set c3=1 where pk=1;",
+			"set @Commit4 = '';",
+			"call dolt_commit_hash_out(@Commit4, '-am', 'inserting and updating data');",
+
+			// rename column and add row
+			"alter table t rename column c3 to c2;",
+			"insert into t values (4, 'four', -4);",
+			"set @Commit5 = '';",
+			"call dolt_commit_hash_out(@Commit5, '-am', 'renaming column c3 to c2, and inserting data');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit2, 't');",
+				Expected: []sql.Row{{"t", "modified", true, false}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit2, @Commit3, 't');",
+				Expected: []sql.Row{{"t", "modified", false, true}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit3, @Commit4, 't');",
+				Expected: []sql.Row{{"t", "modified", true, false}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit4, @Commit5, 't');",
+				Expected: []sql.Row{{"t", "modified", true, true}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit5, 't');",
+				Expected: []sql.Row{{"t", "modified", true, false}},
+			},
+		},
+	},
+	{
+		Name: "new table",
+		SetUpScript: []string{
+			"create table t1 (a int primary key, b int)",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "select * from dolt_diff_summary('HEAD', 'WORKING')",
+				Expected: []sql.Row{{"t1", "added", false, true}},
+			},
+			{
+				Query:    "select * from dolt_diff_summary('WORKING', 'HEAD')",
+				Expected: []sql.Row{{"t1", "dropped", false, true}},
+			},
+			{
+				Query:            "insert into t1 values (1,2)",
+				SkipResultsCheck: true,
+			},
+			{
+				Query:    "select * from dolt_diff_summary('HEAD', 'WORKING', 't1')",
+				Expected: []sql.Row{{"t1", "added", true, true}},
+			},
+			{
+				Query:    "select * from dolt_diff_summary('WORKING', 'HEAD', 't1')",
+				Expected: []sql.Row{{"t1", "dropped", true, true}},
+			},
+		},
+	},
+	{
+		Name: "dropped table",
+		SetUpScript: []string{
+			"create table t1 (a int primary key, b int)",
+			"call dolt_add('.')",
+			"insert into t1 values (1,2)",
+			"call dolt_commit('-am', 'new table')",
+			"drop table t1",
+			"call dolt_commit('-am', 'dropped table')",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "select * from dolt_diff_summary('HEAD~', 'HEAD', 't1')",
+				Expected: []sql.Row{{"t1", "dropped", true, true}},
+			},
+			{
+				Query:    "select * from dolt_diff_summary('HEAD', 'HEAD~', 't1')",
+				Expected: []sql.Row{{"t1", "added", true, true}},
+			},
+		},
+	},
+	{
+		Name: "renamed table",
+		SetUpScript: []string{
+			"create table t1 (a int primary key, b int)",
+			"call dolt_add('.')",
+			"insert into t1 values (1,2)",
+			"call dolt_commit('-am', 'new table')",
+			"alter table t1 rename to t2",
+			"call dolt_add('.')",
+			"insert into t2 values (3,4)",
+			"call dolt_commit('-am', 'renamed table')",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "select * from dolt_diff_summary('HEAD~', 'HEAD', 't2')",
+				Expected: []sql.Row{{"t2", "modified", true, false}},
+			},
+			{
+				Query:    "select * from dolt_diff_summary('HEAD~..HEAD', 't2')",
+				Expected: []sql.Row{{"t2", "modified", true, false}},
+			},
+			{
+				Query:    "select * from dolt_diff_summary('HEAD~', 'HEAD')",
+				Expected: []sql.Row{{"t2", "modified", true, false}},
+			},
+			{
+				Query:    "select * from dolt_diff_summary('HEAD~..HEAD')",
+				Expected: []sql.Row{{"t2", "modified", true, false}},
+			},
+			{
+				// Old table name can be matched as well
+				Query:    "select * from dolt_diff_summary('HEAD~', 'HEAD', 't1')",
+				Expected: []sql.Row{{"t1", "modified", true, false}},
+			},
+			{
+				// Old table name can be matched as well
+				Query:    "select * from dolt_diff_summary('HEAD~..HEAD', 't1')",
+				Expected: []sql.Row{{"t1", "modified", true, false}},
+			},
+		},
+	},
+	{
+		Name: "add multiple columns, then set and unset a value. Should not show a diff",
+		SetUpScript: []string{
+			"CREATE table t (pk int primary key);",
+			"Insert into t values (1);",
+			"CALL DOLT_ADD('.');",
+			"CALL DOLT_COMMIT('-am', 'setup');",
+			"alter table t add column col1 int;",
+			"alter table t add column col2 int;",
+			"CALL DOLT_ADD('.');",
+			"CALL DOLT_COMMIT('-am', 'add columns');",
+			"UPDATE t set col1 = 1 where pk = 1;",
+			"UPDATE t set col1 = null where pk = 1;",
+			"CALL DOLT_COMMIT('--allow-empty', '-am', 'fix short tuple');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "SELECT * from dolt_diff_summary('HEAD~2', 'HEAD');",
+				Expected: []sql.Row{{"t", "modified", false, true}},
+			},
+			{
+				Query:    "SELECT * from dolt_diff_summary('HEAD~', 'HEAD');",
+				Expected: []sql.Row{},
+			},
+		},
+	},
+	{
+		Name: "pk set change should throw an error for 3 argument dolt_diff_summary",
+		SetUpScript: []string{
+			"CREATE table t (pk int primary key);",
+			"INSERT INTO t values (1);",
+			"CALL DOLT_COMMIT('-Am', 'table with row');",
+			"ALTER TABLE t ADD col1 int not null default 0;",
+			"ALTER TABLE t drop primary key;",
+			"ALTER TABLE t add primary key (pk, col1);",
+			"CALL DOLT_COMMIT('-am', 'add secondary column with primary key');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:          "SELECT * from dolt_diff_summary('HEAD~', 'HEAD', 't');",
+				ExpectedErrStr: "failed to compute diff summary for table t: primary key set changed",
+			},
+		},
+	},
+	{
+		Name: "pk set change should report warning for 2 argument dolt_diff_summary",
+		SetUpScript: []string{
+			"CREATE table t (pk int primary key);",
+			"INSERT INTO t values (1);",
+			"CREATE table t2 (pk int primary key);",
+			"INSERT INTO t2 values (2);",
+			"CALL DOLT_COMMIT('-Am', 'multiple tables');",
+			"ALTER TABLE t ADD col1 int not null default 0;",
+			"ALTER TABLE t drop primary key;",
+			"ALTER TABLE t add primary key (pk, col1);",
+			"INSERT INTO t2 values (3), (4), (5);",
+			"CALL DOLT_COMMIT('-am', 'add secondary column with primary key to t');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "SELECT * from dolt_diff_summary('HEAD~', 'HEAD')",
+				Expected: []sql.Row{
+					{"t2", "modified", true, false},
+				},
+				ExpectedWarning:       dtables.PrimaryKeyChangeWarningCode,
+				ExpectedWarningsCount: 1,
+			},
+		},
+	},
+}
+
 var UnscopedDiffSystemTableScriptTests = []queries.ScriptTest{
 	{
 		Name: "working set changes",


### PR DESCRIPTION
The old version of the `dolt_diff_summary` table function was renamed to `dolt_diff_stat`
This new version of `dolt_diff_summary` returns a summary of changed tables between two refs
```sql
us_jails> select * from dolt_diff_summary("WORKING", "taylor/test");
+-----------------------------+-----------+-------------+---------------+
| table_name                  | diff_type | data_change | schema_change |
+-----------------------------+-----------+-------------+---------------+
| jails                       | modified  | true        | false         |
| test                        | dropped   | false       | true          |
| inmate_population_snapshots | added     | true        | true          |
+-----------------------------+-----------+-------------+---------------+
3 rows in set (0.01 sec)
```
