### PR TITLE
Add `from_table_name` and `to_table_name` columns to `dolt_diff_summary` table function

### DIFF
--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -504,8 +504,12 @@ func printDiffSummary(ctx context.Context, tds []diff.TableDelta, dArgs *diffArg
 		if err != nil {
 			return errhand.BuildDError("could not get table delta summary").AddCause(err).Build()
 		}
+		tableName := summ.TableName
+		if summ.DiffType == "renamed" {
+			tableName = fmt.Sprintf("%s -> %s", summ.FromTableName, summ.ToTableName)
+		}
 
-		err = wr.WriteSqlRow(ctx, sql.Row{td.CurName(), summ.DiffType, summ.DataChange, summ.SchemaChange})
+		err = wr.WriteSqlRow(ctx, sql.Row{tableName, summ.DiffType, summ.DataChange, summ.SchemaChange})
 		if err != nil {
 			return errhand.BuildDError("could not write table delta summary").AddCause(err).Build()
 		}

--- a/go/libraries/doltcore/diff/table_deltas.go
+++ b/go/libraries/doltcore/diff/table_deltas.go
@@ -58,10 +58,12 @@ type TableDelta struct {
 }
 
 type TableDeltaSummary struct {
-	DiffType     string
-	DataChange   bool
-	SchemaChange bool
-	TableName    string
+	DiffType      string
+	DataChange    bool
+	SchemaChange  bool
+	TableName     string
+	FromTableName string
+	ToTableName   string
 }
 
 // GetStagedUnstagedTableDeltas represents staged and unstaged changes as TableDelta slices.
@@ -414,10 +416,11 @@ func (td TableDelta) GetSummary(ctx context.Context) (*TableDeltaSummary, error)
 		}
 
 		return &TableDeltaSummary{
-			TableName:    td.FromName,
-			DataChange:   !isEmpty,
-			SchemaChange: true,
-			DiffType:     "dropped",
+			TableName:     td.FromName,
+			FromTableName: td.FromName,
+			DataChange:    !isEmpty,
+			SchemaChange:  true,
+			DiffType:      "dropped",
 		}, nil
 	}
 
@@ -429,10 +432,12 @@ func (td TableDelta) GetSummary(ctx context.Context) (*TableDeltaSummary, error)
 		}
 
 		return &TableDeltaSummary{
-			TableName:    td.ToName,
-			DataChange:   dataChanged,
-			SchemaChange: true,
-			DiffType:     "renamed",
+			TableName:     td.ToName,
+			FromTableName: td.FromName,
+			ToTableName:   td.ToName,
+			DataChange:    dataChanged,
+			SchemaChange:  true,
+			DiffType:      "renamed",
 		}, nil
 	}
 
@@ -445,6 +450,7 @@ func (td TableDelta) GetSummary(ctx context.Context) (*TableDeltaSummary, error)
 
 		return &TableDeltaSummary{
 			TableName:    td.ToName,
+			ToTableName:  td.ToName,
 			DataChange:   !isEmpty,
 			SchemaChange: true,
 			DiffType:     "added",
@@ -464,10 +470,12 @@ func (td TableDelta) GetSummary(ctx context.Context) (*TableDeltaSummary, error)
 	}
 
 	return &TableDeltaSummary{
-		TableName:    td.ToName,
-		DataChange:   dataChanged,
-		SchemaChange: schemaChanged,
-		DiffType:     "modified",
+		TableName:     td.FromName,
+		FromTableName: td.FromName,
+		ToTableName:   td.ToName,
+		DataChange:    dataChanged,
+		SchemaChange:  schemaChanged,
+		DiffType:      "modified",
 	}, nil
 }
 

--- a/go/libraries/doltcore/sqle/dolt_diff_summary_table_function.go
+++ b/go/libraries/doltcore/sqle/dolt_diff_summary_table_function.go
@@ -41,7 +41,8 @@ type DiffSummaryTableFunction struct {
 }
 
 var diffSummaryTableSchema = sql.Schema{
-	&sql.Column{Name: "table_name", Type: types.LongText, Nullable: false},
+	&sql.Column{Name: "from_table_name", Type: types.LongText, Nullable: false},
+	&sql.Column{Name: "to_table_name", Type: types.LongText, Nullable: false},
 	&sql.Column{Name: "diff_type", Type: types.Text, Nullable: false},
 	&sql.Column{Name: "data_change", Type: types.Boolean, Nullable: false},
 	&sql.Column{Name: "schema_change", Type: types.Boolean, Nullable: false},
@@ -268,8 +269,6 @@ func (ds *DiffSummaryTableFunction) RowIter(ctx *sql.Context, row sql.Row) (sql.
 
 		summs := []*diff.TableDeltaSummary{}
 		if summ != nil {
-			// Old name of renamed table can be matched, use provided name in result
-			summ.TableName = tableName
 			summs = []*diff.TableDeltaSummary{summ}
 		}
 
@@ -396,9 +395,10 @@ func (d *diffSummaryTableFunctionRowIter) Close(context *sql.Context) error {
 
 func getRowFromSummary(ds *diff.TableDeltaSummary) sql.Row {
 	return sql.Row{
-		ds.TableName,    // table_name
-		ds.DiffType,     // diff_type
-		ds.DataChange,   // data_change
-		ds.SchemaChange, // schema_change
+		ds.FromTableName, // from_table_name
+		ds.ToTableName,   // to_table_name
+		ds.DiffType,      // diff_type
+		ds.DataChange,    // data_change
+		ds.SchemaChange,  // schema_change
 	}
 }

--- a/go/libraries/doltcore/sqle/dtables/status_table.go
+++ b/go/libraries/doltcore/sqle/dtables/status_table.go
@@ -130,7 +130,7 @@ func handleStagedUnstagedTables(staged, unstaged []diff.TableDelta, itr *StatusI
 			itr.statuses[idx] = tblDiffTypeToLabel[diff.RemovedTable]
 		} else if td.IsRename() {
 			itr.tables[idx] = fmt.Sprintf("%s -> %s", td.FromName, td.ToName)
-			itr.statuses[idx] = tblDiffTypeToLabel[diff.RemovedTable]
+			itr.statuses[idx] = tblDiffTypeToLabel[diff.RenamedTable]
 		} else {
 			itr.tables[idx] = td.CurName()
 			itr.statuses[idx] = tblDiffTypeToLabel[diff.ModifiedTable]

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -2157,29 +2157,29 @@ var DiffSummaryTableFunctionScriptTests = []queries.ScriptTest{
 			{
 				// table is added, no data changes
 				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit2, 't');",
-				Expected: []sql.Row{{"t", "added", false, true}},
+				Expected: []sql.Row{{"", "t", "added", false, true}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit2, @Commit3, 't');",
-				Expected: []sql.Row{{"t", "modified", true, false}},
+				Expected: []sql.Row{{"t", "t", "modified", true, false}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit3, @Commit4, 't');",
-				Expected: []sql.Row{{"t", "modified", true, false}},
+				Expected: []sql.Row{{"t", "t", "modified", true, false}},
 			},
 			{
 				// change from and to commits
 				Query:    "SELECT * from dolt_diff_summary(@Commit4, @Commit3, 't');",
-				Expected: []sql.Row{{"t", "modified", true, false}},
+				Expected: []sql.Row{{"t", "t", "modified", true, false}},
 			},
 			{
 				// table is dropped
 				Query:    "SELECT * from dolt_diff_summary(@Commit4, @Commit5, 't');",
-				Expected: []sql.Row{{"t", "dropped", true, true}},
+				Expected: []sql.Row{{"t", "", "dropped", true, true}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit4, 't');",
-				Expected: []sql.Row{{"t", "added", true, true}},
+				Expected: []sql.Row{{"", "t", "added", true, true}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit5, 't');",
@@ -2220,28 +2220,28 @@ var DiffSummaryTableFunctionScriptTests = []queries.ScriptTest{
 			{
 				// table is added, no data diff, result is empty
 				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit2, 't');",
-				Expected: []sql.Row{{"t", "added", false, true}},
+				Expected: []sql.Row{{"", "t", "added", false, true}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit2, @Commit3, 't');",
-				Expected: []sql.Row{{"t", "modified", true, false}},
+				Expected: []sql.Row{{"t", "t", "modified", true, false}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit3, @Commit4, 't');",
-				Expected: []sql.Row{{"t", "modified", true, false}},
+				Expected: []sql.Row{{"t", "t", "modified", true, false}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit4, @Commit3, 't');",
-				Expected: []sql.Row{{"t", "modified", true, false}},
+				Expected: []sql.Row{{"t", "t", "modified", true, false}},
 			},
 			{
 				// table is dropped
 				Query:    "SELECT * from dolt_diff_summary(@Commit4, @Commit5, 't');",
-				Expected: []sql.Row{{"t", "dropped", true, true}},
+				Expected: []sql.Row{{"t", "", "dropped", true, true}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit4, 't');",
-				Expected: []sql.Row{{"t", "added", true, true}},
+				Expected: []sql.Row{{"", "t", "added", true, true}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit5, 't');",
@@ -2287,32 +2287,47 @@ var DiffSummaryTableFunctionScriptTests = []queries.ScriptTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit0, @Commit1);",
-				Expected: []sql.Row{{"t", "added", true, true}},
+				Expected: []sql.Row{{"", "t", "added", true, true}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit2);",
-				Expected: []sql.Row{{"t2", "added", true, true}},
+				Expected: []sql.Row{{"", "t2", "added", true, true}},
 			},
 			{
-				Query:    "SELECT * from dolt_diff_summary(@Commit2, @Commit3);",
-				Expected: []sql.Row{{"t", "modified", true, false}, {"t2", "modified", true, false}},
+				Query: "SELECT * from dolt_diff_summary(@Commit2, @Commit3);",
+				Expected: []sql.Row{
+					{"t", "t", "modified", true, false},
+					{"t2", "t2", "modified", true, false},
+				},
 			},
 			{
-				Query:    "SELECT * from dolt_diff_summary(@Commit3, @Commit4);",
-				Expected: []sql.Row{{"t", "modified", true, false}, {"t2", "modified", true, false}},
+				Query: "SELECT * from dolt_diff_summary(@Commit3, @Commit4);",
+				Expected: []sql.Row{
+					{"t", "t", "modified", true, false},
+					{"t2", "t2", "modified", true, false},
+				},
 			},
 			{
-				Query:    "SELECT * from dolt_diff_summary(@Commit0, @Commit4);",
-				Expected: []sql.Row{{"t", "added", true, true}, {"t2", "added", true, true}},
+				Query: "SELECT * from dolt_diff_summary(@Commit0, @Commit4);",
+				Expected: []sql.Row{
+					{"", "t", "added", true, true},
+					{"", "t2", "added", true, true},
+				},
 			},
 			{
 				Query: "SELECT * from dolt_diff_summary(@Commit4, @Commit2);",
 
-				Expected: []sql.Row{{"t", "modified", true, false}, {"t2", "modified", true, false}},
+				Expected: []sql.Row{
+					{"t", "t", "modified", true, false},
+					{"t2", "t2", "modified", true, false},
+				},
 			},
 			{
-				Query:    "SELECT * from dolt_diff_summary(@Commit3, 'WORKING');",
-				Expected: []sql.Row{{"t", "modified", true, false}, {"t2", "modified", true, false}, {"keyless", "added", false, true}},
+				Query: "SELECT * from dolt_diff_summary(@Commit3, 'WORKING');",
+				Expected: []sql.Row{
+					{"t", "t", "modified", true, false},
+					{"t2", "t2", "modified", true, false},
+					{"", "keyless", "added", false, true}},
 			},
 		},
 	},
@@ -2334,19 +2349,19 @@ var DiffSummaryTableFunctionScriptTests = []queries.ScriptTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit1, 'WORKING', 't')",
-				Expected: []sql.Row{{"t", "modified", true, false}},
+				Expected: []sql.Row{{"t", "t", "modified", true, false}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary('STAGED', 'WORKING', 't')",
-				Expected: []sql.Row{{"t", "modified", true, false}},
+				Expected: []sql.Row{{"t", "t", "modified", true, false}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary('STAGED..WORKING', 't')",
-				Expected: []sql.Row{{"t", "modified", true, false}},
+				Expected: []sql.Row{{"t", "t", "modified", true, false}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary('WORKING', 'STAGED', 't')",
-				Expected: []sql.Row{{"t", "modified", true, false}},
+				Expected: []sql.Row{{"t", "t", "modified", true, false}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary('WORKING', 'WORKING', 't')",
@@ -2370,7 +2385,7 @@ var DiffSummaryTableFunctionScriptTests = []queries.ScriptTest{
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary('HEAD', 'STAGED', 't')",
-				Expected: []sql.Row{{"t", "modified", true, false}},
+				Expected: []sql.Row{{"t", "t", "modified", true, false}},
 			},
 		},
 	},
@@ -2412,70 +2427,70 @@ var DiffSummaryTableFunctionScriptTests = []queries.ScriptTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "SELECT * from dolt_diff_summary('main', 'branch1', 't');",
-				Expected: []sql.Row{{"t", "modified", true, true}},
+				Expected: []sql.Row{{"t", "t", "modified", true, true}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary('main..branch1', 't');",
-				Expected: []sql.Row{{"t", "modified", true, true}},
+				Expected: []sql.Row{{"t", "t", "modified", true, true}},
 			},
 			{
 				Query: "SELECT * from dolt_diff_summary('main', 'branch1');",
 				Expected: []sql.Row{
-					{"t", "modified", true, true},
-					{"newtable", "dropped", true, true},
+					{"t", "t", "modified", true, true},
+					{"newtable", "", "dropped", true, true},
 				},
 			},
 			{
 				Query: "SELECT * from dolt_diff_summary('main..branch1');",
 				Expected: []sql.Row{
-					{"t", "modified", true, true},
-					{"newtable", "dropped", true, true},
+					{"t", "t", "modified", true, true},
+					{"newtable", "", "dropped", true, true},
 				},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary('branch1', 'main', 't');",
-				Expected: []sql.Row{{"t", "modified", true, true}},
+				Expected: []sql.Row{{"t", "t", "modified", true, true}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary('branch1..main', 't');",
-				Expected: []sql.Row{{"t", "modified", true, true}},
+				Expected: []sql.Row{{"t", "t", "modified", true, true}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary('main~2', 'branch1', 't');",
-				Expected: []sql.Row{{"t", "modified", true, true}},
+				Expected: []sql.Row{{"t", "t", "modified", true, true}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary('main~2..branch1', 't');",
-				Expected: []sql.Row{{"t", "modified", true, true}},
+				Expected: []sql.Row{{"t", "t", "modified", true, true}},
 			},
 
 			// Three dot
 			{
 				Query:    "SELECT * from dolt_diff_summary('main...branch1', 't');",
-				Expected: []sql.Row{{"t", "modified", true, true}},
+				Expected: []sql.Row{{"t", "t", "modified", true, true}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary('main...branch1');",
-				Expected: []sql.Row{{"t", "modified", true, true}},
+				Expected: []sql.Row{{"t", "t", "modified", true, true}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary('branch1...main', 't');",
-				Expected: []sql.Row{{"t", "modified", true, false}},
+				Expected: []sql.Row{{"t", "t", "modified", true, false}},
 			},
 			{
 				Query: "SELECT * from dolt_diff_summary('branch1...main');",
 				Expected: []sql.Row{
-					{"t", "modified", true, false},
-					{"newtable", "added", true, true},
+					{"t", "t", "modified", true, false},
+					{"", "newtable", "added", true, true},
 				},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary('branch1...main^');",
-				Expected: []sql.Row{{"t", "modified", true, false}},
+				Expected: []sql.Row{{"t", "t", "modified", true, false}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary('branch1...main', 'newtable');",
-				Expected: []sql.Row{{"newtable", "added", true, true}},
+				Expected: []sql.Row{{"", "newtable", "added", true, true}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary('main...main', 'newtable');",
@@ -2516,27 +2531,27 @@ var DiffSummaryTableFunctionScriptTests = []queries.ScriptTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit2, 't');",
-				Expected: []sql.Row{{"t", "modified", true, true}},
+				Expected: []sql.Row{{"t", "t", "modified", true, true}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit2, @Commit3, 't');",
-				Expected: []sql.Row{{"t", "modified", true, false}},
+				Expected: []sql.Row{{"t", "t", "modified", true, false}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit3, 't');",
-				Expected: []sql.Row{{"t", "modified", true, true}},
+				Expected: []sql.Row{{"t", "t", "modified", true, true}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit3, @Commit4, 't');",
-				Expected: []sql.Row{{"t", "modified", true, true}},
+				Expected: []sql.Row{{"t", "t", "modified", true, true}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit3, @Commit5, 't');",
-				Expected: []sql.Row{{"t", "modified", true, true}},
+				Expected: []sql.Row{{"t", "t", "modified", true, true}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit5, 't');",
-				Expected: []sql.Row{{"t", "modified", true, false}},
+				Expected: []sql.Row{{"t", "t", "modified", true, false}},
 			},
 		},
 	},
@@ -2573,26 +2588,27 @@ var DiffSummaryTableFunctionScriptTests = []queries.ScriptTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit2, 't');",
-				Expected: []sql.Row{{"t", "modified", true, false}},
+				Expected: []sql.Row{{"t", "t", "modified", true, false}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit2, @Commit3, 't');",
-				Expected: []sql.Row{{"t", "modified", true, true}}, // TODO: Data change should be false for renamed column
+				Expected: []sql.Row{{"t", "t", "modified", true, true}}, // TODO: Data change should be false for renamed column
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit3, @Commit4, 't');",
-				Expected: []sql.Row{{"t", "modified", true, false}},
+				Expected: []sql.Row{{"t", "t", "modified", true, false}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit4, @Commit5, 't');",
-				Expected: []sql.Row{{"t", "modified", true, true}},
+				Expected: []sql.Row{{"t", "t", "modified", true, true}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary(@Commit1, @Commit5, 't');",
-				Expected: []sql.Row{{"t", "modified", true, false}},
+				Expected: []sql.Row{{"t", "t", "modified", true, false}},
 			},
 		},
 	},
+
 	{
 		Name: "new table",
 		SetUpScript: []string{
@@ -2601,11 +2617,11 @@ var DiffSummaryTableFunctionScriptTests = []queries.ScriptTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "select * from dolt_diff_summary('HEAD', 'WORKING')",
-				Expected: []sql.Row{{"t1", "added", false, true}},
+				Expected: []sql.Row{{"", "t1", "added", false, true}},
 			},
 			{
 				Query:    "select * from dolt_diff_summary('WORKING', 'HEAD')",
-				Expected: []sql.Row{{"t1", "dropped", false, true}},
+				Expected: []sql.Row{{"t1", "", "dropped", false, true}},
 			},
 			{
 				Query:            "insert into t1 values (1,2)",
@@ -2613,14 +2629,15 @@ var DiffSummaryTableFunctionScriptTests = []queries.ScriptTest{
 			},
 			{
 				Query:    "select * from dolt_diff_summary('HEAD', 'WORKING', 't1')",
-				Expected: []sql.Row{{"t1", "added", true, true}},
+				Expected: []sql.Row{{"", "t1", "added", true, true}},
 			},
 			{
 				Query:    "select * from dolt_diff_summary('WORKING', 'HEAD', 't1')",
-				Expected: []sql.Row{{"t1", "dropped", true, true}},
+				Expected: []sql.Row{{"t1", "", "dropped", true, true}},
 			},
 		},
 	},
+
 	{
 		Name: "dropped table",
 		SetUpScript: []string{
@@ -2634,14 +2651,15 @@ var DiffSummaryTableFunctionScriptTests = []queries.ScriptTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "select * from dolt_diff_summary('HEAD~', 'HEAD', 't1')",
-				Expected: []sql.Row{{"t1", "dropped", true, true}},
+				Expected: []sql.Row{{"t1", "", "dropped", true, true}},
 			},
 			{
 				Query:    "select * from dolt_diff_summary('HEAD', 'HEAD~', 't1')",
-				Expected: []sql.Row{{"t1", "added", true, true}},
+				Expected: []sql.Row{{"", "t1", "added", true, true}},
 			},
 		},
 	},
+
 	{
 		Name: "renamed table",
 		SetUpScript: []string{
@@ -2657,32 +2675,33 @@ var DiffSummaryTableFunctionScriptTests = []queries.ScriptTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "select * from dolt_diff_summary('HEAD~', 'HEAD', 't2')",
-				Expected: []sql.Row{{"t2", "renamed", true, true}},
+				Expected: []sql.Row{{"t1", "t2", "renamed", true, true}},
 			},
 			{
 				Query:    "select * from dolt_diff_summary('HEAD~..HEAD', 't2')",
-				Expected: []sql.Row{{"t2", "renamed", true, true}},
+				Expected: []sql.Row{{"t1", "t2", "renamed", true, true}},
 			},
 			{
 				Query:    "select * from dolt_diff_summary('HEAD~', 'HEAD')",
-				Expected: []sql.Row{{"t2", "renamed", true, true}},
+				Expected: []sql.Row{{"t1", "t2", "renamed", true, true}},
 			},
 			{
 				Query:    "select * from dolt_diff_summary('HEAD~..HEAD')",
-				Expected: []sql.Row{{"t2", "renamed", true, true}},
+				Expected: []sql.Row{{"t1", "t2", "renamed", true, true}},
 			},
 			{
 				// Old table name can be matched as well
 				Query:    "select * from dolt_diff_summary('HEAD~', 'HEAD', 't1')",
-				Expected: []sql.Row{{"t1", "renamed", true, true}},
+				Expected: []sql.Row{{"t1", "t2", "renamed", true, true}},
 			},
 			{
 				// Old table name can be matched as well
 				Query:    "select * from dolt_diff_summary('HEAD~..HEAD', 't1')",
-				Expected: []sql.Row{{"t1", "renamed", true, true}},
+				Expected: []sql.Row{{"t1", "t2", "renamed", true, true}},
 			},
 		},
 	},
+
 	{
 		Name: "add multiple columns, then set and unset a value. Should not show a diff",
 		SetUpScript: []string{
@@ -2701,7 +2720,7 @@ var DiffSummaryTableFunctionScriptTests = []queries.ScriptTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "SELECT * from dolt_diff_summary('HEAD~2', 'HEAD');",
-				Expected: []sql.Row{{"t", "modified", true, true}},
+				Expected: []sql.Row{{"t", "t", "modified", true, true}},
 			},
 			{
 				Query:    "SELECT * from dolt_diff_summary('HEAD~', 'HEAD');",
@@ -2745,7 +2764,7 @@ var DiffSummaryTableFunctionScriptTests = []queries.ScriptTest{
 			{
 				Query: "SELECT * from dolt_diff_summary('HEAD~', 'HEAD')",
 				Expected: []sql.Row{
-					{"t2", "modified", true, false},
+					{"t2", "t2", "modified", true, false},
 				},
 				ExpectedWarning:       dtables.PrimaryKeyChangeWarningCode,
 				ExpectedWarningsCount: 1,

--- a/integration-tests/bats/sql-status.bats
+++ b/integration-tests/bats/sql-status.bats
@@ -34,6 +34,30 @@ teardown() {
     [[ "$output" =~ 'test,true,new table' ]] || false
 }
 
+@test "sql-status: status properly works with table rename" {
+    # Test is staged
+    dolt add test
+    run dolt sql -r csv -q "select * from dolt_status"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ 'test,true,new table' ]] || false
+
+    # Rename test to test2
+    run dolt sql -r csv -q "alter table test rename to test2"
+    [ "$status" -eq 0 ]
+
+    # Confirm table is now marked as renamed, test still staged
+    run dolt sql -r csv -q "select * from dolt_status"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ 'test,true,new table' ]] || false
+    [[ "$output" =~ 'test -> test2,false,renamed' ]] || false
+
+    # Confirm table is now marked as staged
+    dolt add test2
+    run dolt sql -r csv -q "select * from dolt_status"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ 'test2,true,new table' ]] || false
+}
+
 @test "sql-status: table that has staged and unstaged changes shows up twice" {
     # Stage one set of changes.
     dolt add test


### PR DESCRIPTION
- Also fixes `dolt_status` system table output for renamed tables
- Table name in `dolt diff --summary` CLI command for renamed table uses arrow syntax (i.e. `from_table -> to_table`)