### PR TITLE
go/doltcore/migrate: modify migrated tuples sink to sort incoming tuples

### DIFF
--- a/go/libraries/doltcore/sqle/altertests/common_test.go
+++ b/go/libraries/doltcore/sqle/altertests/common_test.go
@@ -46,6 +46,7 @@ func RunModifyTypeTests(t *testing.T, tests []ModifyTypeTest) {
 		if len(name) > 200 {
 			name = name[:200]
 		}
+		test := test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()

--- a/integration-tests/bats/migration-integration.bats
+++ b/integration-tests/bats/migration-integration.bats
@@ -21,7 +21,7 @@ teardown() {
     run dolt tag -v
     [ "$status" -eq 0 ]
     [[ "$output" =~ "r9jv07tf9un3fm1fg72v7ad9er89oeo7" ]] || false
-    [[ ! "$output" =~ "euna1i8brh95lo9mcg05s3m8h781fr8a" ]] || false
+    [[ ! "$output" =~ "d0q6hb3vcq1oe178usc6rd28db1cnh26" ]] || false
 
     dolt migrate
     [[ $(cat ./.dolt/noms/manifest | cut -f 2 -d :) = "$TARGET_NBF" ]] || false
@@ -29,7 +29,7 @@ teardown() {
     dolt tag -v
     run dolt tag -v
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "euna1i8brh95lo9mcg05s3m8h781fr8a" ]] || false
+    [[ "$output" =~ "d0q6hb3vcq1oe178usc6rd28db1cnh26" ]] || false
     [[ ! "$output" =~ "r9jv07tf9un3fm1fg72v7ad9er89oeo7" ]] || false
 
     # validate TEXT migration
@@ -47,7 +47,7 @@ teardown() {
     run dolt tag -v
     [ "$status" -eq 0 ]
     [[ "$output" =~ "r9jv07tf9un3fm1fg72v7ad9er89oeo7" ]] || false
-    [[ ! "$output" =~ "euna1i8brh95lo9mcg05s3m8h781fr8a" ]] || false
+    [[ ! "$output" =~ "d0q6hb3vcq1oe178usc6rd28db1cnh26" ]] || false
 
     dolt migrate
     [[ $(cat ./.dolt/noms/manifest | cut -f 2 -d :) = "$TARGET_NBF" ]] || false
@@ -55,7 +55,7 @@ teardown() {
     dolt tag -v
     run dolt tag -v
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "euna1i8brh95lo9mcg05s3m8h781fr8a" ]] || false
+    [[ "$output" =~ "d0q6hb3vcq1oe178usc6rd28db1cnh26" ]] || false
     [[ ! "$output" =~ "r9jv07tf9un3fm1fg72v7ad9er89oeo7" ]] || false
 
     # validate TEXT migration


### PR DESCRIPTION
#4221 alters tuple ordering for NBF `__LD_1__` to sort `NULL` fields last. In NBF `__DOLT__`, `NULL` fields are ordered first. This change to `dolt migrate` sorts migrated tuples on-the-fly to compensate for this mismatch