### PR TITLE
bug fix: binlog multi-db support

### DIFF
--- a/go/libraries/doltcore/sqle/altertests/common_test.go
+++ b/go/libraries/doltcore/sqle/altertests/common_test.go
@@ -46,6 +46,7 @@ func RunModifyTypeTests(t *testing.T, tests []ModifyTypeTest) {
 		if len(name) > 200 {
 			name = name[:200]
 		}
+		test := test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_applier.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_applier.go
@@ -395,6 +395,7 @@ func (a *binlogReplicaApplier) processBinlogEvent(ctx *sql.Context, engine *gms.
 			ctx.SetSessionVariable(ctx, "unique_checks", 1)
 		}
 
+		ctx.SetCurrentDatabase(query.Database)
 		executeQueryWithEngine(ctx, engine, query.SQL)
 		createCommit = strings.ToLower(query.SQL) != "begin"
 
@@ -908,15 +909,20 @@ func loadReplicaServerId() (uint32, error) {
 
 func executeQueryWithEngine(ctx *sql.Context, engine *gms.Engine, query string) {
 	if ctx.GetCurrentDatabase() == "" {
-		ctx.GetLogger().Warn("No current database selected")
+		ctx.GetLogger().WithFields(logrus.Fields{
+			"query": query,
+		}).Warn("No current database selected")
 	}
 
 	_, iter, err := engine.Query(ctx, query)
 	if err != nil {
 		// Log any errors, except for commits with "nothing to commit"
 		if err.Error() != "nothing to commit" {
-			msg := fmt.Sprintf("ERROR executing query: %v ", err.Error())
-			ctx.GetLogger().Errorf(msg)
+			msg := fmt.Sprintf("Error executing query")
+			ctx.GetLogger().WithFields(logrus.Fields{
+				"error": err.Error(),
+				"query": query,
+			}).Errorf(msg)
 			DoltBinlogReplicaController.setSqlError(mysql.ERUnknownError, msg)
 		}
 		return

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_applier.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_applier.go
@@ -918,11 +918,11 @@ func executeQueryWithEngine(ctx *sql.Context, engine *gms.Engine, query string) 
 	if err != nil {
 		// Log any errors, except for commits with "nothing to commit"
 		if err.Error() != "nothing to commit" {
-			msg := fmt.Sprintf("Error executing query")
 			ctx.GetLogger().WithFields(logrus.Fields{
 				"error": err.Error(),
 				"query": query,
-			}).Errorf(msg)
+			}).Errorf("Error executing query")
+			msg := fmt.Sprintf("Error executing query: %v", err.Error())
 			DoltBinlogReplicaController.setSqlError(mysql.ERUnknownError, msg)
 		}
 		return

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_multidb_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_multidb_test.go
@@ -29,14 +29,20 @@ func TestBinlogReplicationMultiDb(t *testing.T) {
 
 	// Make changes on the primary to db01 and db02
 	primaryDatabase.MustExec("create database db02;")
-	primaryDatabase.MustExec("create table db01.t01 (pk int primary key, c1 int default (0))")
-	primaryDatabase.MustExec("create table db02.t02 (pk int primary key, c1 int default (0))")
-	primaryDatabase.MustExec("insert into db01.t01 (pk) values (1), (3), (5), (8), (9);")
-	primaryDatabase.MustExec("insert into db02.t02 (pk) values (2), (4), (6), (7), (10);")
-	primaryDatabase.MustExec("delete from db01.t01 where pk=9;")
+	primaryDatabase.MustExec("use db01;")
+	primaryDatabase.MustExec("create table t01 (pk int primary key, c1 int default (0))")
+	primaryDatabase.MustExec("use db02;")
+	primaryDatabase.MustExec("create table t02 (pk int primary key, c1 int default (0))")
+	primaryDatabase.MustExec("use db01;")
+	primaryDatabase.MustExec("insert into t01 (pk) values (1), (3), (5), (8), (9);")
+	primaryDatabase.MustExec("use db02;")
+	primaryDatabase.MustExec("insert into t02 (pk) values (2), (4), (6), (7), (10);")
+	primaryDatabase.MustExec("use db01;")
+	primaryDatabase.MustExec("delete from t01 where pk=9;")
 	primaryDatabase.MustExec("delete from db02.t02 where pk=10;")
+	primaryDatabase.MustExec("use db02;")
 	primaryDatabase.MustExec("update db01.t01 set pk=7 where pk=8;")
-	primaryDatabase.MustExec("update db02.t02 set pk=8 where pk=7;")
+	primaryDatabase.MustExec("update t02 set pk=8 where pk=7;")
 
 	// Verify the changes in db01 on the replica
 	waitForReplicaToCatchUp(t)


### PR DESCRIPTION
We were missing the call to set the session's current database for binlog `Query` events. This was causing queries to execute against the wrong database when using binlog replication with multiple databases. Our binlog tests didn't catch this because the multi-db tests used fully qualified table names, so it didn't matter what database was currently selected. 

This change adds the call to set the current database and updates the multi-db tests to use a mix of `use` statements and fully qualified table names (and also cleans up some of our query error logging to make log output more helpful for debugging).