### PR TITLE
[no-release-notes] Ensure all dolt sql-server child processes get cleaned up

### DIFF
--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_test.go
@@ -51,7 +51,7 @@ func teardown(t *testing.T) {
 		mySqlProcess.Kill()
 	}
 	if doltProcess != nil {
-		doltProcess.Kill()
+		stopDoltSqlServer(t)
 	}
 	if mysqlLogFile != nil {
 		mysqlLogFile.Close()


### PR DESCRIPTION
`dolt sql-server` processes were not getting properly cleaned up by simply killing the top level process. This change switches to kill all the child processes in the process group. I'm unable to repro the lingering `dolt sql-server` processes with this change. 