### PR TITLE
[no-release-notes] New GitHub Action to label issues and PRs from customers

### DIFF
--- a/.github/workflows/label-customer-issues.yaml
+++ b/.github/workflows/label-customer-issues.yaml
@@ -1,0 +1,19 @@
+name: Label Customer Issues
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    branches: [main]
+    types: [opened]
+
+jobs:
+  label_customer_issues:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dolthub/label-customer-issues@main
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-label: customer-issue
+          pr-label: contribution
+          exclude: dependabot


### PR DESCRIPTION
Turning on a new GitHub action for the `dolt` repo. This action will label issues from non-team-members with the `customer-issue` label, and will label PRs from non-team-members (excluding dependabot) with the `contribution` label. The intent is to give us a visual indicator to help make customer issues and PRs a little more obvious and make sure they get attention. Over time, we could also get some nice metrics on incoming customer issues and contributions. 