### PR TITLE
Remove unneeded serialization and hashing step.

### DIFF
--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -237,19 +237,20 @@ func getCommitValForRefStr(ctx context.Context, db datas.Database, vrw types.Val
 		return nil, ErrBranchNotFound
 	}
 
+	var commitaddr hash.Hash
 	if ds.IsTag() {
-		_, commitaddr, err := ds.HeadTag()
+		_, commitaddr, err = ds.HeadTag()
 		if err != nil {
 			return nil, err
 		}
-		return datas.LoadCommitAddr(ctx, vrw, commitaddr)
+	} else {
+		addr, ok := ds.MaybeHeadAddr()
+		if !ok {
+			return nil, fmt.Errorf("Unable to load head for %s", ref)
+		}
+		commitaddr = addr
 	}
-
-	r, _, err := ds.MaybeHeadRef()
-	if err != nil {
-		return nil, err
-	}
-	return datas.LoadCommitRef(ctx, vrw, r)
+	return datas.LoadCommitAddr(ctx, vrw, commitaddr)
 }
 
 func getCommitValForHash(ctx context.Context, vr types.ValueReader, c string) (*datas.Commit, error) {


### PR DESCRIPTION
A minor refactor. All go tests still pass with this change.

MaybeHeadRef serializes the commit content, and LoadCommitRef hashes the commit. Neither of these steps is necessary because the hash is already computed and available by calling MaybeHeadAddr.

The performance improvement is negligible, but simpler code is more maintainable code.