### PR TITLE
libraries/doltcore/doltdb: fix dropped errors

### DIFF
--- a/go/libraries/doltcore/doltdb/doltdb_test.go
+++ b/go/libraries/doltcore/doltdb/doltdb_test.go
@@ -293,8 +293,11 @@ func TestLDNoms(t *testing.T) {
 		ctx := context.Background()
 		tSchema := createTestSchema(t)
 		rowData, err := durable.NewEmptyIndex(ctx, ddb.vrw, ddb.ns, tSchema)
-		tbl, err = CreateTestTable(ddb.vrw, ddb.ns, tSchema, rowData)
+		if err != nil {
+			t.Fatal("Failed to create new empty index")
+		}
 
+		tbl, err = CreateTestTable(ddb.vrw, ddb.ns, tSchema, rowData)
 		if err != nil {
 			t.Fatal("Failed to create test table with data")
 		}

--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -1096,6 +1096,9 @@ func validateTagUniqueness(ctx context.Context, root *RootValue, tableName strin
 		}
 		return false, nil
 	})
+	if err != nil {
+		return err
+	}
 	if len(ee) > 0 {
 		return fmt.Errorf(strings.Join(ee, "\n"))
 	}


### PR DESCRIPTION
This fixes two dropped `err` variables in the `libraries/doltcore/doltdb`.