### PR TITLE
Fix dolt_gc for repositories newly using chunk journal.

### DIFF
--- a/go/libraries/doltcore/dtestutils/sql_server_driver/cmd.go
+++ b/go/libraries/doltcore/dtestutils/sql_server_driver/cmd.go
@@ -178,6 +178,12 @@ func WithArgs(args ...string) SqlServerOpt {
 	}
 }
 
+func WithEnvs(envs ...string) SqlServerOpt {
+	return func(s *SqlServer) {
+		s.Cmd.Env = append(s.Cmd.Env, envs...)
+	}
+}
+
 func WithPort(port int) SqlServerOpt {
 	return func(s *SqlServer) {
 		s.Port = port
@@ -235,7 +241,7 @@ func (s *SqlServer) ErrorStop() error {
 	return s.Cmd.Wait()
 }
 
-func (s *SqlServer) Restart(newargs *[]string) error {
+func (s *SqlServer) Restart(newargs *[]string, newenvs *[]string) error {
 	err := s.GracefulStop()
 	if err != nil {
 		return err
@@ -245,6 +251,9 @@ func (s *SqlServer) Restart(newargs *[]string) error {
 		args = append([]string{"sql-server"}, (*newargs)...)
 	}
 	s.Cmd = s.RecreateCmd(args...)
+	if newenvs != nil {
+		s.Cmd.Env = append(s.Cmd.Env, (*newenvs)...)
+	}
 	stdout, err := s.Cmd.StdoutPipe()
 	if err != nil {
 		return err

--- a/go/libraries/doltcore/dtestutils/sql_server_driver/server.go
+++ b/go/libraries/doltcore/dtestutils/sql_server_driver/server.go
@@ -75,6 +75,7 @@ func (c Connection) Password() (string, error) {
 // example, to change server config on a restart.
 type RestartArgs struct {
 	Args *[]string `yaml:"args"`
+	Envs *[]string `yaml:"envs"`
 }
 
 // |TestRepo| represents an init'd dolt repository that is available to a
@@ -155,6 +156,7 @@ func (f WithFile) WriteAtDir(dir string) error {
 type Server struct {
 	Name string   `yaml:"name"`
 	Args []string `yaml:"args"`
+	Envs []string `yaml:"envs"`
 
 	// The |Port| which the server will be running on. For now, it is up to
 	// the |Args| to make sure this is true. Defaults to 3308.

--- a/go/store/nbs/journal.go
+++ b/go/store/nbs/journal.go
@@ -277,7 +277,14 @@ func (j *chunkJournal) UpdateGCGen(ctx context.Context, lastLock addr, next mani
 	updater, ok := j.backing.(manifestGCGenUpdater)
 	if !ok {
 		return manifestContents{}, fmt.Errorf("manifest (%s) does not support garbage collection", j.backing.Name())
-	} else if j.contents.lock != lastLock {
+	}
+
+	if j.wr == nil {
+		// pass the update to |j.backing| if the journal is not initialized
+		return updater.UpdateGCGen(ctx, lastLock, next, stats, writeHook)
+	}
+
+	if j.contents.lock != lastLock {
 		return j.contents, nil // |next| is stale
 	}
 

--- a/integration-tests/go-sql-server-driver/concurrent_gc_test.go
+++ b/integration-tests/go-sql-server-driver/concurrent_gc_test.go
@@ -223,5 +223,11 @@ func (gct gcTest) run(t *testing.T) {
 
 	require.NoError(t, eg.Wait())
 
+	// Recreate the connection pool here, since idle connections in the
+	// connection pool may be stale.
+	db.Close()
+	db, err = server.DB(driver.Connection{User: "root"})
+	require.NoError(t, err)
+
 	gct.finalize(t, context.Background(), db)
 }

--- a/integration-tests/go-sql-server-driver/testdef.go
+++ b/integration-tests/go-sql-server-driver/testdef.go
@@ -37,10 +37,10 @@ type TestDef struct {
 // any Servers defined within them will be started. The interactions and
 // assertions defined in Conns will be run.
 type Test struct {
-	Name       string              `yaml:"name"`
-	Repos      []driver.TestRepo   `yaml:"repos"`
-	MultiRepos []driver.MultiRepo  `yaml:"multi_repos"`
-	Conns      []driver.Connection `yaml:"connections"`
+	Name        string              `yaml:"name"`
+	Repos       []driver.TestRepo   `yaml:"repos"`
+	MultiRepos  []driver.MultiRepo  `yaml:"multi_repos"`
+	Conns       []driver.Connection `yaml:"connections"`
 
 	// Skip the entire test with this reason.
 	Skip string `yaml:"skip"`
@@ -74,7 +74,7 @@ func MakeServer(t *testing.T, dc driver.DoltCmdable, s *driver.Server) *driver.S
 	if s == nil {
 		return nil
 	}
-	opts := []driver.SqlServerOpt{driver.WithArgs(s.Args...)}
+	opts := []driver.SqlServerOpt{driver.WithArgs(s.Args...), driver.WithEnvs(s.Envs...)}
 	if s.Port != 0 {
 		opts = append(opts, driver.WithPort(s.Port))
 	}
@@ -184,7 +184,7 @@ func (test Test) Run(t *testing.T) {
 			}()
 		}
 		if c.RestartServer != nil {
-			err := server.Restart(c.RestartServer.Args)
+			err := server.Restart(c.RestartServer.Args, c.RestartServer.Envs)
 			require.NoError(t, err)
 		}
 	}

--- a/integration-tests/go-sql-server-driver/tests/sql-server-orig.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-orig.yaml
@@ -330,3 +330,21 @@ tests:
     queries:
     - exec: "INSERT INTO t1 VALUES (1, 1),(2, 2)"
       error_match: "table not found"
+- name: dolt_gc succeeds as first write on existing database without a journal after chunk journal is enabled
+  multi_repos:
+  - name: server1
+    server:
+      envs: ["DOLT_DISABLE_CHUNK_JOURNAL=true"]
+  connections:
+  - on: server1
+    queries:
+    - exec: "CREATE DATABASE mydb"
+    - exec: "USE mydb"
+    - exec: "CREATE TABLE vals (id int primary key, val int)"
+    - exec: "INSERT INTO vals VALUES (1, 1),(2, 2)"
+    restart_server:
+      envs: []
+  - on: server1
+    queries:
+    - exec: "USE mydb"
+    - exec: "CALL dolt_gc()"


### PR DESCRIPTION
When a repository was created with < 0.75.0, or if it was created and used with `DOLT_DISABLE_CHUNK_JOURNAL=true`, it does not have a chunk journal. If it then runs dolt in a mode where it uses the chunk journal, the journal will not be bootstrapped until a write is done against the database. In the state where `dolt` is using the chunk journal but the chunk journal is not bootstrapped, `dolt gc` and `call dolt_gc()` were broken. They would fail with the message: `concurrent manifest edit during GC, before swapTables. GC failed.`.

This fixes that by making the chunk journal forward UpdateGCGen manifest update calls in its non-bootstrapped state, the same way it forwards Update manifest calls.