### PR TITLE
go/libraries/doltcore/sqle/cluster: commithook.go: Fix initialization of commithook so it does not report isCaughtUp right after construction.

### DIFF
--- a/go/libraries/doltcore/sqle/cluster/commithook.go
+++ b/go/libraries/doltcore/sqle/cluster/commithook.go
@@ -164,6 +164,9 @@ func (h *commithook) isCaughtUp() bool {
 	if h.role != RolePrimary {
 		return true
 	}
+	if h.nextHead == (hash.Hash{}) {
+		return false
+	}
 	return h.nextHead == h.lastPushedHead
 }
 

--- a/go/libraries/doltcore/sqle/cluster/commithook_test.go
+++ b/go/libraries/doltcore/sqle/cluster/commithook_test.go
@@ -1,0 +1,43 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/dtestutils"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+)
+
+func TestCommitHookStartsNotCaughtUp(t *testing.T) {
+	srcEnv := dtestutils.CreateTestEnv()
+	t.Cleanup(func() {
+		srcEnv.DoltDB.Close()
+	})
+	destEnv := dtestutils.CreateTestEnv()
+	t.Cleanup(func() {
+		destEnv.DoltDB.Close()
+	})
+
+	hook := newCommitHook(logrus.StandardLogger(), "origin", "mydb", RolePrimary, func(context.Context) (*doltdb.DoltDB, error) {
+		return destEnv.DoltDB, nil
+	}, srcEnv.DoltDB, t.TempDir())
+
+	require.False(t, hook.isCaughtUp())
+}

--- a/go/libraries/doltcore/sqle/cluster/commithook_test.go
+++ b/go/libraries/doltcore/sqle/cluster/commithook_test.go
@@ -21,8 +21,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/dtestutils"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/dtestutils"
 )
 
 func TestCommitHookStartsNotCaughtUp(t *testing.T) {


### PR DESCRIPTION
Misreporting isCaughtUp would race to allow a primary to gracefully transition to standby without true-ing up the replicas immediately after creating a new database, for example.