### PR TITLE
go/libraries/doltcore/env/actions: fix dropped error

### DIFF
--- a/go/libraries/doltcore/env/actions/clone.go
+++ b/go/libraries/doltcore/env/actions/clone.go
@@ -250,6 +250,9 @@ func CloneRemote(ctx context.Context, srcDB *doltdb.DoltDB, remoteName, branch s
 
 	// Retrieve existing working set, delete if it exists
 	ws, err := dEnv.DoltDB.ResolveWorkingSet(ctx, wsRef)
+	if err != nil {
+		return err
+	}
 	if ws != nil {
 		dEnv.DoltDB.DeleteWorkingSet(ctx, wsRef)
 	}


### PR DESCRIPTION
This fixes a dropped `err` variable in `go/libraries/doltcore/env/actions`.