### PR TITLE
Fixed panic in dolt_commit_diff tables when referring to commits where the table doesn't exist

### DIFF
--- a/go/libraries/doltcore/sqle/dtables/diff_iter.go
+++ b/go/libraries/doltcore/sqle/dtables/diff_iter.go
@@ -233,7 +233,7 @@ var _ sql.RowIter = prollyDiffIter{}
 // than |targetFromSchema| or |targetToSchema|. We convert the rows from the
 // schema of |from| to |targetFromSchema| and the schema of |to| to
 // |targetToSchema|. See the tablediff_prolly package.
-func newProllyDiffIter(ctx *sql.Context, dp DiffPartition, ddb *doltdb.DoltDB, targetFromSchema, targetToSchema schema.Schema) (prollyDiffIter, error) {
+func newProllyDiffIter(ctx *sql.Context, dp DiffPartition, targetFromSchema, targetToSchema schema.Schema) (prollyDiffIter, error) {
 	fromCm := commitInfo2{
 		name: dp.fromName,
 		ts:   (*time.Time)(dp.fromDate),

--- a/go/libraries/doltcore/sqle/dtables/diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/diff_table.go
@@ -663,7 +663,7 @@ func (dp *DiffPartition) isDiffablePartition(ctx *sql.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	
+
 	toSch, err := dp.to.GetSchema(ctx)
 	if err != nil {
 		return false, err

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -4777,7 +4777,7 @@ var CommitDiffSystemTableScriptTests = []queries.ScriptTest{
 			"insert into t values (1, 2), (3, 4);",
 			"set @Commit1 = '';",
 			"CALL DOLT_COMMIT_HASH_OUT(@Commit1, '-am', 'creating table t');",
-			
+
 			"drop table t",
 			"set @Commit2 = '';",
 			"CALL DOLT_COMMIT_HASH_OUT(@Commit2, '-am', 'dropping table');",
@@ -4798,14 +4798,14 @@ var CommitDiffSystemTableScriptTests = []queries.ScriptTest{
 				ExpectedWarning:                 1105,
 				ExpectedWarningsCount:           1,
 				ExpectedWarningMessageSubstring: "cannot render full diff between commits",
-				Expected: []sql.Row{},
+				Expected:                        []sql.Row{},
 			},
 			{
 				Query:                           "select * from dolt_commit_diff_t where from_commit=@Commit3 and to_commit=@Commit3;",
 				ExpectedWarning:                 1105,
 				ExpectedWarningsCount:           1,
 				ExpectedWarningMessageSubstring: "cannot render full diff between commits",
-				Expected: []sql.Row{},
+				Expected:                        []sql.Row{},
 			},
 			{
 				Query:    "SELECT to_pk, to_c1, from_pk, from_c1, diff_type FROM DOLT_commit_DIFF_t where from_commit=@Commit3 and to_commit=@Commit4;",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -4769,6 +4769,54 @@ var CommitDiffSystemTableScriptTests = []queries.ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "added and dropped table",
+		SetUpScript: []string{
+			"create table t (pk int primary key, c1 int);",
+			"call dolt_add('.')",
+			"insert into t values (1, 2), (3, 4);",
+			"set @Commit1 = '';",
+			"CALL DOLT_COMMIT_HASH_OUT(@Commit1, '-am', 'creating table t');",
+			
+			"drop table t",
+			"set @Commit2 = '';",
+			"CALL DOLT_COMMIT_HASH_OUT(@Commit2, '-am', 'dropping table');",
+
+			"create table unrelated (a int primary key);",
+			"set @Commit3 = '';",
+			"CALL DOLT_COMMIT_HASH_OUT(@Commit3, '-Am', 'created unrelated table');",
+
+			"create table t (pk int primary key, c1 int);",
+			"call dolt_add('.')",
+			"insert into t values (1, 2);",
+			"set @Commit4 = '';",
+			"CALL DOLT_COMMIT_HASH_OUT(@Commit4, '-Am', 'recreating table t');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:                           "select * from dolt_commit_diff_t where from_commit=@Commit2 and to_commit=@Commit3;",
+				ExpectedWarning:                 1105,
+				ExpectedWarningsCount:           1,
+				ExpectedWarningMessageSubstring: "cannot render full diff between commits",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:                           "select * from dolt_commit_diff_t where from_commit=@Commit3 and to_commit=@Commit3;",
+				ExpectedWarning:                 1105,
+				ExpectedWarningsCount:           1,
+				ExpectedWarningMessageSubstring: "cannot render full diff between commits",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "SELECT to_pk, to_c1, from_pk, from_c1, diff_type FROM DOLT_commit_DIFF_t where from_commit=@Commit3 and to_commit=@Commit4;",
+				Expected: []sql.Row{{1, 2, nil, nil, "added"}},
+			},
+			{
+				Query:    "SELECT to_pk, to_c1, from_pk, from_c1, diff_type FROM DOLT_commit_DIFF_t where from_commit=@Commit1 and to_commit=@Commit4;",
+				Expected: []sql.Row{{nil, nil, 3, 4, "removed"}},
+			},
+		},
+	},
 }
 
 type systabScript struct {


### PR DESCRIPTION
Fixes #5730