### PR TITLE
Add Server Runtime details to the sql-server.lock file

### DIFF
--- a/go/gen/proto/dolt/services/eventsapi/v1alpha1/client_event.pb.go
+++ b/go/gen/proto/dolt/services/eventsapi/v1alpha1/client_event.pb.go
@@ -23,12 +23,13 @@
 package eventsapi
 
 import (
+	reflect "reflect"
+	sync "sync"
+
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/go/gen/proto/dolt/services/eventsapi/v1alpha1/client_event_grpc.pb.go
+++ b/go/gen/proto/dolt/services/eventsapi/v1alpha1/client_event_grpc.pb.go
@@ -24,6 +24,7 @@ package eventsapi
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/go/gen/proto/dolt/services/eventsapi/v1alpha1/event_constants.pb.go
+++ b/go/gen/proto/dolt/services/eventsapi/v1alpha1/event_constants.pb.go
@@ -23,10 +23,11 @@
 package eventsapi
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/go/gen/proto/dolt/services/remotesapi/v1alpha1/chunkstore.pb.go
+++ b/go/gen/proto/dolt/services/remotesapi/v1alpha1/chunkstore.pb.go
@@ -21,11 +21,12 @@
 package remotesapi
 
 import (
+	reflect "reflect"
+	sync "sync"
+
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/go/gen/proto/dolt/services/remotesapi/v1alpha1/chunkstore_grpc.pb.go
+++ b/go/gen/proto/dolt/services/remotesapi/v1alpha1/chunkstore_grpc.pb.go
@@ -22,6 +22,7 @@ package remotesapi
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/go/gen/proto/dolt/services/remotesapi/v1alpha1/credentials.pb.go
+++ b/go/gen/proto/dolt/services/remotesapi/v1alpha1/credentials.pb.go
@@ -21,10 +21,11 @@
 package remotesapi
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/go/gen/proto/dolt/services/remotesapi/v1alpha1/credentials_grpc.pb.go
+++ b/go/gen/proto/dolt/services/remotesapi/v1alpha1/credentials_grpc.pb.go
@@ -22,6 +22,7 @@ package remotesapi
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -1282,16 +1282,18 @@ func WriteLockfile(fs filesys.Filesys, lock DBLock) error {
 		portStr = "-"
 	}
 
-	_, err := os.Create(lockFile)
-	if err != nil {
-		return err
-	}
-	err = os.Chmod(lockFile, 0600)
-	if err != nil {
-		return err
+	if filesys.LocalFS == fs {
+		_, err := os.Create(lockFile)
+		if err != nil {
+			return err
+		}
+		err = os.Chmod(lockFile, 0600)
+		if err != nil {
+			return err
+		}
 	}
 
-	err = fs.WriteFile(lockFile, []byte(fmt.Sprintf("%d:%s:%s", lock.Pid, portStr, lock.Secret)))
+	err := fs.WriteFile(lockFile, []byte(fmt.Sprintf("%d:%s:%s", lock.Pid, portStr, lock.Secret)))
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -18,13 +18,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/google/uuid"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	ps "github.com/mitchellh/go-ps"
 	goerrors "gopkg.in/src-d/go-errors.v1"
 

--- a/go/libraries/doltcore/env/multi_repo_env.go
+++ b/go/libraries/doltcore/env/multi_repo_env.go
@@ -282,9 +282,9 @@ func (mrEnv *MultiRepoEnv) IsLocked() (bool, string) {
 	return false, ""
 }
 
-// Lock locks all child envs. If an error is returned, all
+// Lock locks all child envs. The DBLock contains the details to write to the lock files. If an error is returned, all
 // child envs will be returned with their initial lock state.
-func (mrEnv *MultiRepoEnv) Lock() error {
+func (mrEnv *MultiRepoEnv) Lock(lck DBLock) (err error) {
 	if mrEnv.ignoreLockFile {
 		return nil
 	}
@@ -293,9 +293,8 @@ func (mrEnv *MultiRepoEnv) Lock() error {
 		return ErrActiveServerLock.New(f)
 	}
 
-	var err error
 	for _, e := range mrEnv.envs {
-		err = e.env.Lock()
+		err = e.env.Lock(lck)
 		if err != nil {
 			mrEnv.Unlock()
 			return err

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_metadata_persistence.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_metadata_persistence.go
@@ -26,7 +26,7 @@ import (
 // persistReplicationConfiguration saves the specified |replicaSourceInfo| to disk; if any problems are encountered
 // while saving to disk, an error is returned.
 func persistReplicationConfiguration(ctx *sql.Context, replicaSourceInfo *mysql_db.ReplicaSourceInfo) error {
-	server := sqlserver.GetRunningServer()
+	server, _ := sqlserver.GetRunningServer()
 	if server == nil {
 		return fmt.Errorf("no SQL server running; " +
 			"replication commands may only be used when running from dolt sql-server, and not from dolt sql")
@@ -43,7 +43,7 @@ func persistReplicationConfiguration(ctx *sql.Context, replicaSourceInfo *mysql_
 
 // loadReplicationConfiguration loads the replication configuration for default channel ("").
 func loadReplicationConfiguration(_ *sql.Context) (*mysql_db.ReplicaSourceInfo, error) {
-	server := sqlserver.GetRunningServer()
+	server, _ := sqlserver.GetRunningServer()
 	if server == nil {
 		return nil, fmt.Errorf("no SQL server running; " +
 			"replication commands may only be used when running from dolt sql-server, and not from dolt sql")
@@ -66,7 +66,7 @@ func loadReplicationConfiguration(_ *sql.Context) (*mysql_db.ReplicaSourceInfo, 
 
 // deleteReplicationConfiguration deletes all replication configuration for the default channel ("").
 func deleteReplicationConfiguration(ctx *sql.Context) error {
-	server := sqlserver.GetRunningServer()
+	server, _ := sqlserver.GetRunningServer()
 	if server == nil {
 		return fmt.Errorf("no SQL server running; " +
 			"replication commands may only be used when running from dolt sql-server, and not from dolt sql")

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_applier.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_applier.go
@@ -252,7 +252,7 @@ func (a *binlogReplicaApplier) startReplicationEventStream(ctx *sql.Context, con
 // replicaBinlogEventHandler runs a loop, processing binlog events until the applier's stop replication channel
 // receives a signal to stop.
 func (a *binlogReplicaApplier) replicaBinlogEventHandler(ctx *sql.Context) error {
-	server := sqlserver.GetRunningServer()
+	server, _ := sqlserver.GetRunningServer()
 	if server == nil {
 		return fmt.Errorf("unable to access a running SQL server")
 	}
@@ -877,7 +877,7 @@ func convertVitessJsonExpressionString(ctx *sql.Context, value sqltypes.Value) (
 		return nil, err
 	}
 
-	server := sqlserver.GetRunningServer()
+	server, _ := sqlserver.GetRunningServer()
 	if server == nil {
 		return nil, fmt.Errorf("unable to access running SQL server")
 	}

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_controller.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_controller.go
@@ -151,7 +151,7 @@ func (d *doltBinlogReplicaController) StartReplica(ctx *sql.Context) error {
 // created and locked to disable log ins, and if it does exist, but is missing super privs or is not
 // locked, it will be given super user privs and locked.
 func (d *doltBinlogReplicaController) configureReplicationUser(ctx *sql.Context) error {
-	server := sqlserver.GetRunningServer()
+	server, _ := sqlserver.GetRunningServer()
 	if server == nil {
 		return fmt.Errorf("unable to access a running SQL server")
 	}

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -410,8 +410,9 @@ func (p DoltDatabaseProvider) CreateCollatedDatabase(ctx *sql.Context, name stri
 	// If we're running in a sql-server context, ensure the new database is locked so that it can't
 	// be edited from the CLI. We can't rely on looking for an existing lock file, since this could
 	// be the first db creation if sql-server was started from a bare directory.
-	if sqlserver.GetRunningServer() != nil {
-		err = newEnv.Lock()
+	_, lckDeets := sqlserver.GetRunningServer()
+	if lckDeets != nil {
+		err = newEnv.Lock(*lckDeets)
 		if err != nil {
 			ctx.GetLogger().Warnf("Failed to lock newly created database: %s", err.Error())
 		}
@@ -687,7 +688,7 @@ func (p DoltDatabaseProvider) invalidateDbStateInAllSessions(ctx *sql.Context, n
 	}
 
 	// If we have a running server, remove it from other sessions as well
-	runningServer := sqlserver.GetRunningServer()
+	runningServer, _ := sqlserver.GetRunningServer()
 	if runningServer != nil {
 		sessionManager := runningServer.SessionManager()
 		err := sessionManager.Iter(func(session sql.Session) (bool, error) {

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_branch.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_branch.go
@@ -215,7 +215,7 @@ func validateBranchNotActiveInAnySession(ctx *sql.Context, branchName string) er
 		return nil
 	}
 
-	runningServer := sqlserver.GetRunningServer()
+	runningServer, _ := sqlserver.GetRunningServer()
 	if runningServer == nil {
 		return nil
 	}

--- a/go/libraries/doltcore/sqlserver/dolt_server.go
+++ b/go/libraries/doltcore/sqlserver/dolt_server.go
@@ -16,8 +16,9 @@ package sqlserver
 
 import (
 	"fmt"
-	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"sync"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 
 	"github.com/dolthub/go-mysql-server/server"
 )
@@ -25,7 +26,7 @@ import (
 var lockedDetails *serverAndLockfile
 var mutex sync.Mutex
 
-// serverAndLockfile holds a *server.Server and a *env.DBLock for a running server 
+// serverAndLockfile holds a *server.Server and a *env.DBLock for a running server
 type serverAndLockfile struct {
 	Server   *server.Server
 	Lockfile *env.DBLock

--- a/go/libraries/doltcore/sqlserver/dolt_server.go
+++ b/go/libraries/doltcore/sqlserver/dolt_server.go
@@ -25,7 +25,7 @@ import (
 var lockedDetails *serverAndLockfile
 var mutex sync.Mutex
 
-// Struct for holding a *server.Server and a *env.DBLock
+// serverAndLockfile holds a *server.Server and a *env.DBLock for a running server 
 type serverAndLockfile struct {
 	Server   *server.Server
 	Lockfile *env.DBLock

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -243,7 +243,7 @@ SQL
     # check that dolt_commit throws an error when there are no changes to commit
     run dolt sql-client -P $PORT -u dolt --no-auto-commit -q "CALL DOLT_COMMIT('-a', '-m', 'Commit1')"
     [ $status -ne 0 ]
-    [[ "$output" =~ "nothing to commit" ]] || false 
+    [[ "$output" =~ "nothing to commit" ]] || false
 
     run dolt ls
     [ "$status" -eq 0 ]
@@ -1076,6 +1076,7 @@ END""")
 
     # Make sure the sql-server lock file is set for a newly created database
     [[ -f "$PWD/test1/.dolt/sql-server.lock" ]] || false
+    [[ $(stat -f "%Lp" "$PWD/test1/.dolt/sql-server.lock") == "600" ]] || false
 
     dolt sql-client -P $PORT -u dolt --use-db 'test1' -q "create table a(x int)"
     dolt sql-client -P $PORT -u dolt --use-db 'test1' -q "call dolt_add('.')"
@@ -1446,6 +1447,14 @@ databases:
     [ "$status" -eq 1 ]
 }
 
+@test "sql-server: sql-server sets permissions on sql-server.lock" {
+    cd repo1
+    ! [[ -f "$PWD/.dolt/sql-server.lock" ]] || false
+    start_sql_server
+    [[ -f "$PWD/.dolt/sql-server.lock" ]] || false
+    [[ $(stat -f "%Lp" "$PWD/.dolt/sql-server.lock") == "600" ]] || false
+}
+
 @test "sql-server: multi dir sql-server locks out children" {
     start_sql_server
     cd repo2
@@ -1470,6 +1479,7 @@ databases:
 
     # Make sure the sql-server lock file is set for the new database
     [[ -f "$PWD/newdb/.dolt/sql-server.lock" ]] || false
+    [[ $(stat -f "%Lp" "$PWD/newdb/.dolt/sql-server.lock") == "600" ]] || false
 
     # Verify that we can't start a sql-server from the new database dir
     cd newdb

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -1076,7 +1076,6 @@ END""")
 
     # Make sure the sql-server lock file is set for a newly created database
     [[ -f "$PWD/test1/.dolt/sql-server.lock" ]] || false
-    [[ $(stat -f "%Lp" "$PWD/test1/.dolt/sql-server.lock") == "600" ]] || false
 
     dolt sql-client -P $PORT -u dolt --use-db 'test1' -q "create table a(x int)"
     dolt sql-client -P $PORT -u dolt --use-db 'test1' -q "call dolt_add('.')"
@@ -1452,7 +1451,15 @@ databases:
     ! [[ -f "$PWD/.dolt/sql-server.lock" ]] || false
     start_sql_server
     [[ -f "$PWD/.dolt/sql-server.lock" ]] || false
-    [[ $(stat -f "%Lp" "$PWD/.dolt/sql-server.lock") == "600" ]] || false
+
+
+    if [[ `uname` == 'Darwin' ]]; then
+      run stat -x "$PWD/.dolt/sql-server.lock"
+      [[ "$output" =~ "(0600/-rw-------)" ]] || false
+    else
+      run stat "$PWD/.dolt/sql-server.lock"
+      [[ "$output" =~ "(0600/-rw-------)" ]] || false
+    fi
 }
 
 @test "sql-server: multi dir sql-server locks out children" {
@@ -1479,7 +1486,6 @@ databases:
 
     # Make sure the sql-server lock file is set for the new database
     [[ -f "$PWD/newdb/.dolt/sql-server.lock" ]] || false
-    [[ $(stat -f "%Lp" "$PWD/newdb/.dolt/sql-server.lock") == "600" ]] || false
 
     # Verify that we can't start a sql-server from the new database dir
     cd newdb


### PR DESCRIPTION
Add runtime information for the server to the sql-server.lock file. We track three pieces of information:

1) The PID. As before.
2) The port of the server, if there is one. You can grab the lock as a cli process, which has no port.
3) A secret. Currently implemented as a UUID. This will be used to ensure that the connecting through the server is only performed by user's and processes which have read access to the server.

In addition, this change modifies the sql-server.lock file to be only readable by the owner.

Step (1) of:  https://github.com/dolthub/dolt/issues/3922.