### PR TITLE
Follow-up to validating extra command line arguments.

### DIFF
--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -157,7 +157,7 @@ func CreateConflictsResolveArgParser() *argparser.ArgParser {
 
 func CreateMergeArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParserWithMaxArgs("merge", 1)
-	ap.TooManyArgsError = func(receivedArgs []string) error {
+	ap.TooManyArgsErrorFunc = func(receivedArgs []string) error {
 		return fmt.Errorf("Error: Dolt does not support merging from multiple commits. You probably meant to checkout one and then merge from the other.")
 	}
 	ap.SupportsFlag(NoFFParam, "", "Create a merge commit even when the merge resolves as a fast-forward.")
@@ -232,7 +232,7 @@ func CreateCheckoutArgParser() *argparser.ArgParser {
 
 func CreateCherryPickArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParserWithMaxArgs("cherrypick", 1)
-	ap.TooManyArgsError = func(receivedArgs []string) error {
+	ap.TooManyArgsErrorFunc = func(receivedArgs []string) error {
 		return fmt.Errorf("cherry-picking multiple commits is not supported yet.")
 	}
 	return ap

--- a/go/cmd/dolt/commands/indexcmds/ls.go
+++ b/go/cmd/dolt/commands/indexcmds/ls.go
@@ -57,7 +57,7 @@ func (cmd LsCmd) ArgParser() *argparser.ArgParser {
 
 func (cmd LsCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.ArgParser()
-	ap.TooManyArgsError = func(receivedArgs []string) error {
+	ap.TooManyArgsErrorFunc = func(receivedArgs []string) error {
 		args := strings.Join(receivedArgs, ", ")
 		return fmt.Errorf("Only one table may be provided at a time. Received %d: %s", len(receivedArgs), args)
 	}

--- a/go/libraries/utils/argparser/parser.go
+++ b/go/libraries/utils/argparser/parser.go
@@ -71,10 +71,11 @@ func NewArgParserWithMaxArgs(name string, maxArgs int) *ArgParser {
 	var supported []*Option
 	nameOrAbbrevToOpt := make(map[string]*Option)
 	return &ArgParser{
-		MaxArgs:           maxArgs,
-		TooManyArgsError:  tooManyArgsErrorGenerator,
-		Supported:         supported,
-		nameOrAbbrevToOpt: nameOrAbbrevToOpt,
+		Name:                 name,
+		MaxArgs:              maxArgs,
+		TooManyArgsErrorFunc: tooManyArgsErrorGenerator,
+		Supported:            supported,
+		nameOrAbbrevToOpt:    nameOrAbbrevToOpt,
 	}
 }
 
@@ -360,7 +361,7 @@ func (ap *ArgParser) Parse(args []string) (*ArgParseResults, error) {
 	}
 
 	if ap.MaxArgs != -1 && len(list) > ap.MaxArgs {
-		return nil, ap.TooManyArgsError(list)
+		return nil, ap.TooManyArgsErrorFunc(list)
 	}
 
 	return &ArgParseResults{results, list, ap}, nil

--- a/go/libraries/utils/argparser/parser.go
+++ b/go/libraries/utils/argparser/parser.go
@@ -49,12 +49,12 @@ func ValidatorFromStrList(paramName string, validStrList []string) ValidationFun
 }
 
 type ArgParser struct {
-	Name              string
-	MaxArgs           int
-	TooManyArgsError  func(receivedArgs []string) error
-	Supported         []*Option
-	nameOrAbbrevToOpt map[string]*Option
-	ArgListHelp       [][2]string
+	Name                 string
+	MaxArgs              int
+	TooManyArgsErrorFunc func(receivedArgs []string) error
+	Supported            []*Option
+	nameOrAbbrevToOpt    map[string]*Option
+	ArgListHelp          [][2]string
 }
 
 func NewArgParserWithVariableArgs(name string) *ArgParser {

--- a/go/libraries/utils/argparser/parser.go
+++ b/go/libraries/utils/argparser/parser.go
@@ -57,10 +57,9 @@ type ArgParser struct {
 	ArgListHelp          [][2]string
 }
 
-func NewArgParserWithVariableArgs(name string) *ArgParser {
-	return NewArgParserWithMaxArgs(name, -1)
-}
-
+// NewArgParserWithMaxArgs creates a new ArgParser for a named command that limits how many positional arguments it
+// will accept. If additional arguments are provided, parsing will return an error with a detailed error message,
+// using the provided command name.
 func NewArgParserWithMaxArgs(name string, maxArgs int) *ArgParser {
 	tooManyArgsErrorGenerator := func(receivedArgs []string) error {
 		args := strings.Join(receivedArgs, ", ")
@@ -77,6 +76,12 @@ func NewArgParserWithMaxArgs(name string, maxArgs int) *ArgParser {
 		Supported:         supported,
 		nameOrAbbrevToOpt: nameOrAbbrevToOpt,
 	}
+}
+
+// NewArgParserWithVariableArgs creates a new ArgParser for a named command
+// that accepts any number of positional arguments.
+func NewArgParserWithVariableArgs(name string) *ArgParser {
+	return NewArgParserWithMaxArgs(name, -1)
 }
 
 // SupportOption adds support for a new argument with the option given. Options must have a unique name and abbreviated name.

--- a/go/libraries/utils/argparser/parser_test.go
+++ b/go/libraries/utils/argparser/parser_test.go
@@ -15,6 +15,7 @@
 package argparser
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -89,6 +90,13 @@ func TestArgParser(t *testing.T) {
 			NewArgParserWithVariableArgs("test").SupportsString("param", "p", "", ""),
 			[]string{"--paramvalue"},
 			UnknownArgumentParam{"paramvalue"},
+			map[string]string{},
+			[]string{},
+		},
+		{
+			NewArgParserWithMaxArgs("test", 1),
+			[]string{"foo", "bar"},
+			errors.New("error: test has too many positional arguments. Expected at most 1, found 2: foo, bar"),
 			map[string]string{},
 			[]string{},
 		},


### PR DESCRIPTION
A follow-up to https://github.com/dolthub/dolt/pull/5762 addressing comments in the original PR.