### PR TITLE
Adding basic support for conflict validation in new schema merge test framework

### DIFF
--- a/go/gen/proto/dolt/services/eventsapi/v1alpha1/client_event.pb.go
+++ b/go/gen/proto/dolt/services/eventsapi/v1alpha1/client_event.pb.go
@@ -23,13 +23,12 @@
 package eventsapi
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (

--- a/go/gen/proto/dolt/services/eventsapi/v1alpha1/client_event_grpc.pb.go
+++ b/go/gen/proto/dolt/services/eventsapi/v1alpha1/client_event_grpc.pb.go
@@ -24,7 +24,6 @@ package eventsapi
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/go/gen/proto/dolt/services/eventsapi/v1alpha1/event_constants.pb.go
+++ b/go/gen/proto/dolt/services/eventsapi/v1alpha1/event_constants.pb.go
@@ -23,11 +23,10 @@
 package eventsapi
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (

--- a/go/gen/proto/dolt/services/remotesapi/v1alpha1/chunkstore.pb.go
+++ b/go/gen/proto/dolt/services/remotesapi/v1alpha1/chunkstore.pb.go
@@ -21,12 +21,11 @@
 package remotesapi
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (

--- a/go/gen/proto/dolt/services/remotesapi/v1alpha1/chunkstore_grpc.pb.go
+++ b/go/gen/proto/dolt/services/remotesapi/v1alpha1/chunkstore_grpc.pb.go
@@ -22,7 +22,6 @@ package remotesapi
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/go/gen/proto/dolt/services/remotesapi/v1alpha1/credentials.pb.go
+++ b/go/gen/proto/dolt/services/remotesapi/v1alpha1/credentials.pb.go
@@ -21,11 +21,10 @@
 package remotesapi
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (

--- a/go/gen/proto/dolt/services/remotesapi/v1alpha1/credentials_grpc.pb.go
+++ b/go/gen/proto/dolt/services/remotesapi/v1alpha1/credentials_grpc.pb.go
@@ -22,7 +22,6 @@ package remotesapi
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"


### PR DESCRIPTION
This also pointed out an issue in the framework where any secondary index and check constraint definitions are silently swallowed.