### PR TITLE
Bug fix and test for index merge bug that didn't detect incompatible index types

### DIFF
--- a/go/libraries/doltcore/merge/merge_prolly_indexes.go
+++ b/go/libraries/doltcore/merge/merge_prolly_indexes.go
@@ -28,13 +28,6 @@ import (
 	"github.com/dolthub/dolt/go/store/val"
 )
 
-type confVals struct {
-	key      val.Tuple
-	ourVal   val.Tuple
-	theirVal val.Tuple
-	baseVal  val.Tuple
-}
-
 // mergeProllySecondaryIndexes merges the secondary indexes of the given |tbl|,
 // |mergeTbl|, and |ancTbl|. It stores the merged indexes into |tableToUpdate|
 // and returns its updated value.
@@ -46,7 +39,6 @@ func mergeProllySecondaryIndexes(
 	finalRows durable.Index,
 	artifacts *prolly.ArtifactsEditor,
 ) (durable.IndexSet, error) {
-
 	ancSet, err := tm.ancTbl.GetIndexSet(ctx)
 	if err != nil {
 		return nil, err
@@ -178,8 +170,4 @@ func applyEdit(ctx context.Context, idx MutableSecondaryIdx, key, from, to val.T
 		}
 	}
 	return nil
-}
-
-func emptyDiff(d tree.Diff) bool {
-	return d.Key == nil
 }

--- a/go/libraries/doltcore/schema/index.go
+++ b/go/libraries/doltcore/schema/index.go
@@ -132,6 +132,8 @@ func (ix *indexImpl) Equals(other Index) bool {
 	}
 
 	return ix.IsUnique() == other.IsUnique() &&
+		ix.IsSpatial() == other.IsSpatial() &&
+		compareUint16Slices(ix.PrefixLengths(), other.PrefixLengths()) &&
 		ix.Comment() == other.Comment() &&
 		ix.Name() == other.Name()
 }
@@ -142,7 +144,7 @@ func (ix *indexImpl) DeepEquals(other Index) bool {
 		return false
 	}
 
-	// we're only interested in columns the index is defined over, not the table's primary keys
+	// DeepEquals compares all tags used in this index, as well as the tags from the table's primary key
 	tt := ix.AllTags()
 	ot := other.AllTags()
 	for i := range tt {
@@ -152,8 +154,26 @@ func (ix *indexImpl) DeepEquals(other Index) bool {
 	}
 
 	return ix.IsUnique() == other.IsUnique() &&
+		ix.IsSpatial() == other.IsSpatial() &&
+		compareUint16Slices(ix.PrefixLengths(), other.PrefixLengths()) &&
 		ix.Comment() == other.Comment() &&
 		ix.Name() == other.Name()
+}
+
+// compareUint16Slices returns true if |a| and |b| contain the exact same uint16 values, in the same order; otherwise
+// it returns false.
+func compareUint16Slices(a, b []uint16) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
 }
 
 // GetColumn implements Index.

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
@@ -4151,6 +4151,28 @@ var ThreeWayMergeWithSchemaChangeTestScripts = []MergeScriptTest{
 
 	// Schema conflict test cases
 	{
+		Name: "index conflicts: both sides add an index with the same name, same columns, but different type",
+		AncSetUpScript: []string{
+			"CREATE table t (pk int primary key, col1 int, col2 varchar(100));",
+		},
+		RightSetUpScript: []string{
+			"alter table t add index idx1 (col2(2));",
+			"INSERT into t values (1, 10, '100');",
+		},
+		LeftSetUpScript: []string{
+			"alter table t add index idx1 (col2);",
+			"INSERT into t values (2, 20, '200');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:       "call dolt_merge('right');",
+				ExpectedErr: merge.ErrSchemaConflict,
+			},
+			// TODO: Check dolt_schema_conflicts table for the conflict metadata once that sys table exists
+		},
+	},
+
+	{
 		// https://github.com/dolthub/dolt/issues/2973
 		Name: "modifying a column on one side of a merge, and deleting it on the other",
 		AncSetUpScript: []string{

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
@@ -4203,10 +4203,17 @@ var ThreeWayMergeWithSchemaChangeTestScripts = []MergeScriptTest{
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
-				Query:       "call dolt_merge('right');",
-				ExpectedErr: merge.ErrSchemaConflict,
+				Query:    "call dolt_merge('right');",
+				Expected: []sql.Row{{0, 1}},
 			},
-			// TODO: Check dolt_schema_conflicts table for the conflict metadata once that sys table exists
+			{
+				Query: "select table_name, base_schema, our_schema, their_schema from dolt_schema_conflicts;",
+				Expected: []sql.Row{{"t",
+					"CREATE TABLE `t` (\n  `pk` int NOT NULL,\n  `col1` int,\n  `col2` varchar(100),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+					"CREATE TABLE `t` (\n  `pk` int NOT NULL,\n  `col1` int,\n  `col2` varchar(100),\n  PRIMARY KEY (`pk`),\n  KEY `idx1` (`col2`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+					"CREATE TABLE `t` (\n  `pk` int NOT NULL,\n  `col1` int,\n  `col2` varchar(100),\n  PRIMARY KEY (`pk`),\n  KEY `idx1` (`col2`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+				}},
+			},
 		},
 	},
 


### PR DESCRIPTION
The equality functions on `Index` weren't considering `prefixLengths` or `isSpatial`, which resulted in a merge bug where dolt would get confused and match two indexes as identical when they really weren't. 