### PR TITLE
Correct busted interface change for CliContext

### DIFF
--- a/go/cmd/dolt/cli/command.go
+++ b/go/cmd/dolt/cli/command.go
@@ -64,7 +64,7 @@ type Command interface {
 	// Description returns a description of the command
 	Description() string
 	// Exec executes the command
-	Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *CliContext) int
+	Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx CliContext) int
 	// Docs returns the documentation for this command, or nil if it's undocumented
 	Docs() *CommandDocumentation
 	// ArgParser returns the arg parser for this command
@@ -169,7 +169,7 @@ func (hc SubCommandHandler) Hidden() bool {
 	return hc.hidden
 }
 
-func (hc SubCommandHandler) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *CliContext) int {
+func (hc SubCommandHandler) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx CliContext) int {
 	if len(args) < 1 && hc.Unspecified == nil {
 		hc.printUsage(commandStr)
 		return 1

--- a/go/cmd/dolt/cli/command.go
+++ b/go/cmd/dolt/cli/command.go
@@ -183,11 +183,11 @@ func (hc SubCommandHandler) Exec(ctx context.Context, commandStr string, args []
 	for _, cmd := range hc.Subcommands {
 		lwrName := strings.ToLower(cmd.Name())
 		if lwrName == subCommandStr {
-			return hc.handleCommand(ctx, commandStr+" "+subCommandStr, cmd, args[1:], dEnv)
+			return hc.handleCommand(ctx, commandStr+" "+subCommandStr, cmd, args[1:], dEnv, cliCtx)
 		}
 	}
 	if hc.Unspecified != nil {
-		return hc.handleCommand(ctx, commandStr, hc.Unspecified, args, dEnv)
+		return hc.handleCommand(ctx, commandStr, hc.Unspecified, args, dEnv, cliCtx)
 	}
 
 	if !isHelp(subCommandStr) {
@@ -199,7 +199,7 @@ func (hc SubCommandHandler) Exec(ctx context.Context, commandStr string, args []
 	return 0
 }
 
-func (hc SubCommandHandler) handleCommand(ctx context.Context, commandStr string, cmd Command, args []string, dEnv *env.DoltEnv) int {
+func (hc SubCommandHandler) handleCommand(ctx context.Context, commandStr string, cmd Command, args []string, dEnv *env.DoltEnv, cliCtx CliContext) int {
 	cmdRequiresRepo := true
 	if rnrCmd, ok := cmd.(RepoNotRequiredCommand); ok {
 		cmdRequiresRepo = rnrCmd.RequiresRepo()
@@ -234,7 +234,7 @@ func (hc SubCommandHandler) handleCommand(ctx context.Context, commandStr string
 		return 1
 	}
 
-	ret := cmd.Exec(ctx, commandStr, args, dEnv, nil)
+	ret := cmd.Exec(ctx, commandStr, args, dEnv, cliCtx)
 
 	if evt != nil {
 		events.GlobalCollector.CloseEventAndAdd(evt)

--- a/go/cmd/dolt/cli/command_test.go
+++ b/go/cmd/dolt/cli/command_test.go
@@ -68,7 +68,7 @@ func (cmd *trackedCommand) RequiresRepo() bool {
 	return false
 }
 
-func (cmd *trackedCommand) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *CliContext) int {
+func (cmd *trackedCommand) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx CliContext) int {
 	cmd.called = true
 	cmd.cmdStr = commandStr
 	cmd.args = args

--- a/go/cmd/dolt/commands/add.go
+++ b/go/cmd/dolt/commands/add.go
@@ -60,7 +60,7 @@ func (cmd AddCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec executes the command
-func (cmd AddCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd AddCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cli.CreateAddArgParser()
 	helpPr, _ := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, addDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, helpPr)

--- a/go/cmd/dolt/commands/admin/setref.go
+++ b/go/cmd/dolt/commands/admin/setref.go
@@ -64,7 +64,7 @@ func (cmd SetRefCmd) Hidden() bool {
 
 // Version displays the version of the running dolt client
 // Exec executes the command
-func (cmd SetRefCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd SetRefCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	usage, _ := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, cli.CommandDocumentationContent{}, ap))
 

--- a/go/cmd/dolt/commands/admin/showroot.go
+++ b/go/cmd/dolt/commands/admin/showroot.go
@@ -60,7 +60,7 @@ func (cmd ShowRootCmd) Hidden() bool {
 
 // Version displays the version of the running dolt client
 // Exec executes the command
-func (cmd ShowRootCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd ShowRootCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	usage, _ := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, cli.CommandDocumentationContent{}, ap))
 

--- a/go/cmd/dolt/commands/assist.go
+++ b/go/cmd/dolt/commands/assist.go
@@ -66,7 +66,7 @@ func (a Assist) Hidden() bool {
 	return true
 }
 
-func (a *Assist) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (a *Assist) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	a.messages = make([]string, 0)
 
 	apiKey, ok := os.LookupEnv("OPENAI_API_KEY")

--- a/go/cmd/dolt/commands/backup.go
+++ b/go/cmd/dolt/commands/backup.go
@@ -105,7 +105,7 @@ func (cmd BackupCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd BackupCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd BackupCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, backupDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/blame.go
+++ b/go/cmd/dolt/commands/blame.go
@@ -79,7 +79,7 @@ func (cmd BlameCmd) EventType() eventsapi.ClientEventType {
 //
 // When all nodes have blame information, stop iterating through commits and print the blame graph.
 // Exec executes the command
-func (cmd BlameCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd BlameCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, blameDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/branch.go
+++ b/go/cmd/dolt/commands/branch.go
@@ -98,7 +98,7 @@ func (cmd BranchCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd BranchCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd BranchCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, branchDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/checkout.go
+++ b/go/cmd/dolt/commands/checkout.go
@@ -78,7 +78,7 @@ func (cmd CheckoutCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd CheckoutCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd CheckoutCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cli.CreateCheckoutArgParser()
 	helpPrt, usagePrt := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, checkoutDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, helpPrt)

--- a/go/cmd/dolt/commands/cherry-pick.go
+++ b/go/cmd/dolt/commands/cherry-pick.go
@@ -71,7 +71,7 @@ func (cmd CherryPickCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command.
-func (cmd CherryPickCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd CherryPickCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cli.CreateCherryPickArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, cherryPickDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/clean.go
+++ b/go/cmd/dolt/commands/clean.go
@@ -65,7 +65,7 @@ func (cmd CleanCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec executes the command
-func (cmd CleanCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd CleanCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cli.CreateCleanArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, cleanDocContent, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/clone.go
+++ b/go/cmd/dolt/commands/clone.go
@@ -81,7 +81,7 @@ func (cmd CloneCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd CloneCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd CloneCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, cloneDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/cnfcmds/cat.go
+++ b/go/cmd/dolt/commands/cnfcmds/cat.go
@@ -75,7 +75,7 @@ func (cmd CatCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec executes the command
-func (cmd CatCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd CatCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, catDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/cnfcmds/resolve.go
+++ b/go/cmd/dolt/commands/cnfcmds/resolve.go
@@ -88,7 +88,7 @@ func (cmd ResolveCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec executes the command
-func (cmd ResolveCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd ResolveCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, resDocumentation, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -76,7 +76,7 @@ func (cmd CommitCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec executes the command
-func (cmd CommitCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd CommitCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	res := performCommit(ctx, commandStr, args, dEnv)
 	if res == 1 {
 		return res

--- a/go/cmd/dolt/commands/config.go
+++ b/go/cmd/dolt/commands/config.go
@@ -116,7 +116,7 @@ func (cmd ConfigCmd) ArgParser() *argparser.ArgParser {
 
 // Exec is used by the config command to allow users to view / edit their global and repository local configurations.
 // Exec executes the command
-func (cmd ConfigCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd ConfigCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, cfgDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/credcmds/check.go
+++ b/go/cmd/dolt/commands/credcmds/check.go
@@ -78,7 +78,7 @@ func (cmd CheckCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec executes the command
-func (cmd CheckCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd CheckCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, checkDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/credcmds/import.go
+++ b/go/cmd/dolt/commands/credcmds/import.go
@@ -89,7 +89,7 @@ func (cmd ImportCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec executes the command
-func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, importDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/credcmds/ls.go
+++ b/go/cmd/dolt/commands/credcmds/ls.go
@@ -74,7 +74,7 @@ func (cmd LsCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec executes the command
-func (cmd LsCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd LsCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, lsDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/credcmds/new.go
+++ b/go/cmd/dolt/commands/credcmds/new.go
@@ -70,7 +70,7 @@ func (cmd NewCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec executes the command
-func (cmd NewCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd NewCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, newDocs, ap))
 	cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/credcmds/rm.go
+++ b/go/cmd/dolt/commands/credcmds/rm.go
@@ -67,7 +67,7 @@ func (cmd RmCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd RmCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd RmCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, rmDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/credcmds/use.go
+++ b/go/cmd/dolt/commands/credcmds/use.go
@@ -73,7 +73,7 @@ func (cmd UseCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec executes the command
-func (cmd UseCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd UseCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, useDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/cvcmds/verify_constraints.go
+++ b/go/cmd/dolt/commands/cvcmds/verify_constraints.go
@@ -67,7 +67,7 @@ func (cmd VerifyConstraintsCmd) ArgParser() *argparser.ArgParser {
 	return cli.CreateVerifyConstraintsArgParser(cmd.Name())
 }
 
-func (cmd VerifyConstraintsCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd VerifyConstraintsCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, _ := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, verifyConstraintsDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -159,7 +159,7 @@ func (cmd DiffCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec executes the command
-func (cmd DiffCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd DiffCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, diffDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/docscmds/diff.go
+++ b/go/cmd/dolt/commands/docscmds/diff.go
@@ -66,7 +66,7 @@ func (cmd DiffCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec implements cli.Command.
-func (cmd DiffCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd DiffCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, diffDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/docscmds/read.go
+++ b/go/cmd/dolt/commands/docscmds/read.go
@@ -71,7 +71,7 @@ func (cmd UploadCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec implements cli.Command.
-func (cmd UploadCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd UploadCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, uploadDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/docscmds/write.go
+++ b/go/cmd/dolt/commands/docscmds/write.go
@@ -69,7 +69,7 @@ func (cmd PrintCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec implements cli.Command.
-func (cmd PrintCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd PrintCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, printDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/dump.go
+++ b/go/cmd/dolt/commands/dump.go
@@ -113,7 +113,7 @@ func (cmd DumpCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd DumpCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd DumpCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, dumpDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/dump_docs.go
+++ b/go/cmd/dolt/commands/dump_docs.go
@@ -72,7 +72,7 @@ func (cmd *DumpDocsCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec executes the command
-func (cmd *DumpDocsCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd *DumpDocsCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, cli.CommandDocumentationContent{}, ap))

--- a/go/cmd/dolt/commands/fetch.go
+++ b/go/cmd/dolt/commands/fetch.go
@@ -68,7 +68,7 @@ func (cmd FetchCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec executes the command
-func (cmd FetchCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd FetchCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cli.CreateFetchArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, fetchDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/filter-branch.go
+++ b/go/cmd/dolt/commands/filter-branch.go
@@ -96,7 +96,7 @@ func (cmd FilterBranchCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd FilterBranchCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd FilterBranchCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, filterBranchDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/gc.go
+++ b/go/cmd/dolt/commands/gc.go
@@ -81,7 +81,7 @@ func (cmd GarbageCollectionCmd) EventType() eventsapi.ClientEventType {
 
 // Version displays the version of the running dolt client
 // Exec executes the command
-func (cmd GarbageCollectionCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd GarbageCollectionCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	var verr errhand.VerboseError
 
 	ap := cmd.ArgParser()

--- a/go/cmd/dolt/commands/gen_zsh_comp.go
+++ b/go/cmd/dolt/commands/gen_zsh_comp.go
@@ -47,7 +47,7 @@ func (z GenZshCompCmd) Description() string {
 	return "Creates a zsh autocomp file for all dolt commands"
 }
 
-func (z GenZshCompCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (z GenZshCompCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := z.ArgParser()
 
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, cli.CommandDocumentationContent{}, ap))

--- a/go/cmd/dolt/commands/indexcmds/cat.go
+++ b/go/cmd/dolt/commands/indexcmds/cat.go
@@ -79,7 +79,7 @@ func (cmd CatCmd) ArgParser() *argparser.ArgParser {
 	return ap
 }
 
-func (cmd CatCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd CatCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, catDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/indexcmds/ls.go
+++ b/go/cmd/dolt/commands/indexcmds/ls.go
@@ -55,7 +55,7 @@ func (cmd LsCmd) ArgParser() *argparser.ArgParser {
 	return ap
 }
 
-func (cmd LsCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd LsCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	ap.TooManyArgsErrorFunc = func(receivedArgs []string) error {
 		args := strings.Join(receivedArgs, ", ")

--- a/go/cmd/dolt/commands/indexcmds/rebuild.go
+++ b/go/cmd/dolt/commands/indexcmds/rebuild.go
@@ -58,7 +58,7 @@ func (cmd RebuildCmd) ArgParser() *argparser.ArgParser {
 	return ap
 }
 
-func (cmd RebuildCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd RebuildCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, rebuildDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/init.go
+++ b/go/cmd/dolt/commands/init.go
@@ -86,7 +86,7 @@ func (cmd InitCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec executes the command
-func (cmd InitCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd InitCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, initDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/inspect.go
+++ b/go/cmd/dolt/commands/inspect.go
@@ -73,7 +73,7 @@ func (cmd InspectCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec executes the command
-func (cmd InspectCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd InspectCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, cli.CommandDocumentationContent{}, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/log.go
+++ b/go/cmd/dolt/commands/log.go
@@ -109,7 +109,7 @@ func (cmd LogCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec executes the command
-func (cmd LogCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd LogCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	return cmd.logWithLoggerFunc(ctx, commandStr, args, dEnv)
 }
 

--- a/go/cmd/dolt/commands/login.go
+++ b/go/cmd/dolt/commands/login.go
@@ -94,7 +94,7 @@ func (cmd LoginCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd LoginCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd LoginCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, loginDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/ls.go
+++ b/go/cmd/dolt/commands/ls.go
@@ -78,7 +78,7 @@ func (cmd LsCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd LsCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd LsCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, lsDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/merge.go
+++ b/go/cmd/dolt/commands/merge.go
@@ -77,7 +77,7 @@ func (cmd MergeCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd MergeCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd MergeCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cli.CreateMergeArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, mergeDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/merge_base.go
+++ b/go/cmd/dolt/commands/merge_base.go
@@ -65,7 +65,7 @@ func (cmd MergeBaseCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd MergeBaseCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd MergeBaseCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, mergeBaseDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/migrate.go
+++ b/go/cmd/dolt/commands/migrate.go
@@ -75,7 +75,7 @@ func (cmd MigrateCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd MigrateCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd MigrateCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, migrateDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/pull.go
+++ b/go/cmd/dolt/commands/pull.go
@@ -68,7 +68,7 @@ func (cmd PullCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd PullCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd PullCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cli.CreatePullArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, pullDocs, ap))
 

--- a/go/cmd/dolt/commands/push.go
+++ b/go/cmd/dolt/commands/push.go
@@ -80,7 +80,7 @@ func (cmd PushCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd PushCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd PushCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, pushDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/read_tables.go
+++ b/go/cmd/dolt/commands/read_tables.go
@@ -84,7 +84,7 @@ func (cmd ReadTablesCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec executes the command
-func (cmd ReadTablesCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd ReadTablesCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, readTablesDocs, ap))

--- a/go/cmd/dolt/commands/remote.go
+++ b/go/cmd/dolt/commands/remote.go
@@ -101,7 +101,7 @@ func (cmd RemoteCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd RemoteCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd RemoteCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, remoteDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/reset.go
+++ b/go/cmd/dolt/commands/reset.go
@@ -81,7 +81,7 @@ func (cmd ResetCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec executes the command
-func (cmd ResetCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd ResetCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cli.CreateResetArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, resetDocContent, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/revert.go
+++ b/go/cmd/dolt/commands/revert.go
@@ -64,7 +64,7 @@ func (cmd RevertCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec implements the interface cli.Command.
-func (cmd RevertCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd RevertCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cli.CreateRevertArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, revertDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/roots.go
+++ b/go/cmd/dolt/commands/roots.go
@@ -80,7 +80,7 @@ func (cmd RootsCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec executes the command
-func (cmd RootsCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd RootsCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, _ := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, cli.CommandDocumentationContent{}, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/schcmds/export.go
+++ b/go/cmd/dolt/commands/schcmds/export.go
@@ -74,7 +74,7 @@ func (cmd ExportCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd ExportCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd ExportCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, schExportDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/schcmds/import.go
+++ b/go/cmd/dolt/commands/schcmds/import.go
@@ -160,7 +160,7 @@ func (cmd ImportCmd) ArgParser() *argparser.ArgParser {
 
 // Exec implements the import schema command that will take a file and infer it's schema, and then create a table matching that schema.
 // Exec executes the command
-func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, schImportDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/schcmds/show.go
+++ b/go/cmd/dolt/commands/schcmds/show.go
@@ -73,7 +73,7 @@ func (cmd ShowCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd ShowCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd ShowCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, tblSchemaDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/schcmds/tags.go
+++ b/go/cmd/dolt/commands/schcmds/tags.go
@@ -64,7 +64,7 @@ func (cmd TagsCmd) ArgParser() *argparser.ArgParser {
 	return ap
 }
 
-func (cmd TagsCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd TagsCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, tblTagsDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/schcmds/update-tag.go
+++ b/go/cmd/dolt/commands/schcmds/update-tag.go
@@ -65,7 +65,7 @@ func (cmd UpdateTagCmd) ArgParser() *argparser.ArgParser {
 	return ap
 }
 
-func (cmd UpdateTagCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd UpdateTagCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, updateTagDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/send_metrics.go
+++ b/go/cmd/dolt/commands/send_metrics.go
@@ -74,7 +74,7 @@ func (cmd SendMetricsCmd) ArgParser() *argparser.ArgParser {
 
 // Exec is the implementation of the command that flushes the events to the grpc service
 // Exec executes the command
-func (cmd SendMetricsCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd SendMetricsCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	if dEnv.DoltDB != nil { // see go/cmd/dolt/dolt.go:interceptSendMetrics()
 		cli.PrintErrln("expected DoltEnv without DoltDB")
 		return 1

--- a/go/cmd/dolt/commands/show.go
+++ b/go/cmd/dolt/commands/show.go
@@ -90,7 +90,7 @@ func (cmd ShowCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec executes the command
-func (cmd ShowCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd ShowCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, showDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -179,7 +179,7 @@ func (cmd SqlCmd) RequiresRepo() bool {
 // Exec executes the command
 // Unlike other commands, sql doesn't set a new working root directly, as the SQL layer updates the working set as
 // necessary when committing work.
-func (cmd SqlCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd SqlCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, sqlDocs, ap))
 

--- a/go/cmd/dolt/commands/sqlserver/sqlclient.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlclient.go
@@ -99,7 +99,7 @@ func (cmd SqlClientCmd) Hidden() bool {
 	return false
 }
 
-func (cmd SqlClientCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd SqlClientCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, _ := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, sqlClientDocs, ap))
 

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -173,7 +173,7 @@ func (cmd SqlServerCmd) RequiresRepo() bool {
 }
 
 // Exec executes the command
-func (cmd SqlServerCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd SqlServerCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	controller := NewServerController()
 	newCtx, cancelF := context.WithCancel(context.Background())
 	go func() {

--- a/go/cmd/dolt/commands/stashcmds/clear.go
+++ b/go/cmd/dolt/commands/stashcmds/clear.go
@@ -63,7 +63,7 @@ func (cmd StashClearCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd StashClearCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd StashClearCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	if !dEnv.DoltDB.Format().UsesFlatbuffers() {
 		cli.PrintErrln(ErrStashNotSupportedForOldFormat.Error())
 		return 1

--- a/go/cmd/dolt/commands/stashcmds/drop.go
+++ b/go/cmd/dolt/commands/stashcmds/drop.go
@@ -66,7 +66,7 @@ func (cmd StashDropCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd StashDropCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd StashDropCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	if !dEnv.DoltDB.Format().UsesFlatbuffers() {
 		cli.PrintErrln(ErrStashNotSupportedForOldFormat.Error())
 		return 1

--- a/go/cmd/dolt/commands/stashcmds/list.go
+++ b/go/cmd/dolt/commands/stashcmds/list.go
@@ -63,7 +63,7 @@ func (cmd StashListCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd StashListCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd StashListCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	if !dEnv.DoltDB.Format().UsesFlatbuffers() {
 		cli.PrintErrln(ErrStashNotSupportedForOldFormat.Error())
 		return 1

--- a/go/cmd/dolt/commands/stashcmds/pop.go
+++ b/go/cmd/dolt/commands/stashcmds/pop.go
@@ -70,7 +70,7 @@ func (cmd StashPopCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd StashPopCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd StashPopCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	if !dEnv.DoltDB.Format().UsesFlatbuffers() {
 		cli.PrintErrln(ErrStashNotSupportedForOldFormat.Error())
 		return 1

--- a/go/cmd/dolt/commands/stashcmds/stash.go
+++ b/go/cmd/dolt/commands/stashcmds/stash.go
@@ -88,7 +88,7 @@ func (cmd StashCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd StashCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd StashCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	if !dEnv.DoltDB.Format().UsesFlatbuffers() {
 		cli.PrintErrln(ErrStashNotSupportedForOldFormat.Error())
 		return 1

--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -61,7 +61,7 @@ func (cmd StatusCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec executes the command
-func (cmd StatusCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd StatusCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, _ := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, statusDocs, ap))
 	cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/tag.go
+++ b/go/cmd/dolt/commands/tag.go
@@ -71,7 +71,7 @@ func (cmd TagCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd TagCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd TagCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cli.CreateTagArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, tagDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/tblcmds/cp.go
+++ b/go/cmd/dolt/commands/tblcmds/cp.go
@@ -70,7 +70,7 @@ func (cmd CpCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd CpCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd CpCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, tblCpDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/tblcmds/export.go
+++ b/go/cmd/dolt/commands/tblcmds/export.go
@@ -185,7 +185,7 @@ func (cmd ExportCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd ExportCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd ExportCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	_, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, exportDocs, ap))
 

--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -372,7 +372,7 @@ func (cmd ImportCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, importDocs, ap))

--- a/go/cmd/dolt/commands/tblcmds/mv.go
+++ b/go/cmd/dolt/commands/tblcmds/mv.go
@@ -72,7 +72,7 @@ func (cmd MvCmd) EventType() eventsapi.ClientEventType {
 }
 
 // Exec executes the command
-func (cmd MvCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd MvCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, tblMvDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/tblcmds/rm.go
+++ b/go/cmd/dolt/commands/tblcmds/rm.go
@@ -66,7 +66,7 @@ func (cmd RmCmd) ArgParser() *argparser.ArgParser {
 }
 
 // Exec executes the command
-func (cmd RmCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd RmCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, tblRmDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)

--- a/go/cmd/dolt/commands/version.go
+++ b/go/cmd/dolt/commands/version.go
@@ -60,7 +60,7 @@ func (cmd VersionCmd) ArgParser() *argparser.ArgParser {
 
 // Version displays the version of the running dolt client
 // Exec executes the command
-func (cmd VersionCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx *cli.CliContext) int {
+func (cmd VersionCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	cli.Println("dolt version", cmd.VersionStr)
 
 	if dEnv.HasDoltDir() && dEnv.RSLoadErr == nil && !cli.CheckEnvIsValid(dEnv) {


### PR DESCRIPTION

TIL that interface pointers in golang are not useful. This changes that, and add in a couple calls in command.go which were neglected in the first refactor.

Step 3 of N: https://github.com/dolthub/dolt/issues/3922
