### PR TITLE
Fix dolt creds check with specified endpoint

### DIFF
--- a/go/cmd/dolt/commands/credcmds/check.go
+++ b/go/cmd/dolt/commands/credcmds/check.go
@@ -17,7 +17,7 @@ package credcmds
 import (
 	"context"
 	"fmt"
-	"net/url"
+	"net"
 
 	"google.golang.org/grpc"
 
@@ -107,11 +107,12 @@ func loadEndpoint(dEnv *env.DoltEnv, apr *argparser.ArgParseResults) (string, st
 }
 
 func getHostFromEndpoint(endpoint string) string {
-	u, err := url.Parse(endpoint)
+	host, _, err := net.SplitHostPort(endpoint)
 	if err != nil {
+		cli.Printf("error getting host name from provided endpoint '%s': %v\nUsing default host instead: %s\n", endpoint, err, env.DefaultRemotesApiHost)
 		return env.DefaultRemotesApiHost
 	}
-	return u.Hostname()
+	return host
 }
 
 func loadCred(dEnv *env.DoltEnv, apr *argparser.ArgParseResults) (creds.DoltCreds, errhand.VerboseError) {


### PR DESCRIPTION
Using `dolt creds check --endpoint <endpoint> --creds <creds>` was failing with an audience error because we were using the wrong parsing logic to get the host for the endpoint. This fixes that and adds a log if the endpoint cannot be parsed
```
% dolt creds check --endpoint doltremoteapi.awsdev.ld-corp.com:443 --creds b33diq4ht3t73hnp5bofekvsg9lk36ou2gto74f7ot02g38r70mg
Calling...
  Endpoint: doltremoteapi.awsdev.ld-corp.com:443
  Key: b33diq4ht3t73hnp5bofekvsg9lk36ou2gto74f7ot02g38r70mg
error: calling doltremoteapi with credentials.
cause: rpc error: code = Unauthenticated desc = jwt_token validation failed: square/go-jose/jwt: validation failed, invalid audience claim (aud)
```
