### PR TITLE
Prevent merges when either side has multiple indexes covering the same set of columns

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
@@ -3724,38 +3724,6 @@ var ThreeWayMergeWithSchemaChangeTestScripts = []MergeScriptTest{
 
 	// Data conflicts during a merge with schema changes
 	{
-		// Dolt indexes currently use the set of columns covered by the index, as a unique identifier for matching
-		// indexes on either side of a merge. As Dolt's index support has grown, this isn't guaranteed to be a unique
-		// id anymore, so instead of allowing a race condition in the merge logic, if we detect that multiple indexes
-		// cover the same set of columns, we return a schema conflict and let the user decide how to resolve it.
-		Name: "duplicate index tag set",
-		AncSetUpScript: []string{
-			"CREATE table t (pk int primary key, col1 varchar(100));",
-			"INSERT into t values (1, '100'), (2, '200');",
-			"alter table t add unique index idx1 (col1);",
-		},
-		RightSetUpScript: []string{
-			"alter table t add index idx2 (col1(10));",
-		},
-		LeftSetUpScript: []string{
-			"INSERT into t values (3, '300');",
-		},
-		Assertions: []queries.ScriptTestAssertion{
-			{
-				Query:    "call dolt_merge('right');",
-				Expected: []sql.Row{{0, 0x1}},
-			},
-			{
-				Query: "select table_name, our_schema, their_schema, base_schema, description from dolt_schema_conflicts;",
-				Expected: []sql.Row{{"t",
-					"CREATE TABLE `t` (\n  `pk` int NOT NULL,\n  `col1` varchar(100),\n  PRIMARY KEY (`pk`),\n  UNIQUE KEY `idx1` (`col1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
-					"CREATE TABLE `t` (\n  `pk` int NOT NULL,\n  `col1` varchar(100),\n  PRIMARY KEY (`pk`),\n  UNIQUE KEY `idx1` (`col1`),\n  KEY `idx2` (`col1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
-					"CREATE TABLE `t` (\n  `pk` int NOT NULL,\n  `col1` varchar(100),\n  PRIMARY KEY (`pk`),\n  UNIQUE KEY `idx1` (`col1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
-					"multiple indexes covering the same column set cannot be merged: 'idx1' and 'idx2'"}},
-			},
-		},
-	},
-	{
 		Name: "data conflict",
 		AncSetUpScript: []string{
 			"set autocommit = 0;",
@@ -4299,6 +4267,38 @@ var ThreeWayMergeWithSchemaChangeTestScripts = []MergeScriptTest{
 					"CREATE TABLE `t` (\n  `pk` int NOT NULL,\n  `col1` enum('blue','green','red'),\n  `col2` double,\n  `col3` bigint,\n  `col4` decimal(8,4),\n  `col5` varchar(20),\n  `col6` set('a','b','c'),\n  `col7` bit(2),\n  PRIMARY KEY (`pk`),\n  KEY `idx1` (`col1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 					"CREATE TABLE `t` (\n  `pk` int NOT NULL,\n  `col1` enum('blue','green'),\n  `col2` float,\n  `col3` smallint,\n  `col4` decimal(4,2),\n  `col5` varchar(10),\n  `col6` set('a','b'),\n  `col7` bit(1),\n  PRIMARY KEY (`pk`),\n  KEY `idx1` (`col1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 					"CREATE TABLE `t` (\n  `pk` int NOT NULL,\n  `col1` enum('blue','green','red'),\n  `col2` double,\n  `col3` bigint,\n  `col4` decimal(8,4),\n  `col5` varchar(20),\n  `col6` set('a','b','c'),\n  `col7` bit(2),\n  PRIMARY KEY (`pk`),\n  KEY `idx1` (`col1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;"}},
+			},
+		},
+	},
+	{
+		// Dolt indexes currently use the set of columns covered by the index, as a unique identifier for matching
+		// indexes on either side of a merge. As Dolt's index support has grown, this isn't guaranteed to be a unique
+		// id anymore, so instead of allowing a race condition in the merge logic, if we detect that multiple indexes
+		// cover the same set of columns, we return a schema conflict and let the user decide how to resolve it.
+		Name: "duplicate index tag set",
+		AncSetUpScript: []string{
+			"CREATE table t (pk int primary key, col1 varchar(100));",
+			"INSERT into t values (1, '100'), (2, '200');",
+			"alter table t add unique index idx1 (col1);",
+		},
+		RightSetUpScript: []string{
+			"alter table t add index idx2 (col1(10));",
+		},
+		LeftSetUpScript: []string{
+			"INSERT into t values (3, '300');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "call dolt_merge('right');",
+				Expected: []sql.Row{{0, 0x1}},
+			},
+			{
+				Query: "select table_name, our_schema, their_schema, base_schema, description from dolt_schema_conflicts;",
+				Expected: []sql.Row{{"t",
+					"CREATE TABLE `t` (\n  `pk` int NOT NULL,\n  `col1` varchar(100),\n  PRIMARY KEY (`pk`),\n  UNIQUE KEY `idx1` (`col1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+					"CREATE TABLE `t` (\n  `pk` int NOT NULL,\n  `col1` varchar(100),\n  PRIMARY KEY (`pk`),\n  UNIQUE KEY `idx1` (`col1`),\n  KEY `idx2` (`col1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+					"CREATE TABLE `t` (\n  `pk` int NOT NULL,\n  `col1` varchar(100),\n  PRIMARY KEY (`pk`),\n  UNIQUE KEY `idx1` (`col1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+					"multiple indexes covering the same column set cannot be merged: 'idx1' and 'idx2'"}},
 			},
 		},
 	},


### PR DESCRIPTION
When merging multiple indexes that cover the same set of columns (even if they are different types, such as a unique index and a prefix index), there is a race condition because of how our index support assumes the column tag set will be unique for every index. This can cause the wrong index to be matched and the wrong merge decisions to be made. 

I tried to come up with another way to opportunistically match indexes across the sides of a merge in PR https://github.com/dolthub/dolt/pull/5797, but I still found more edge cases and the extra complexity didn't seem worth it. It seemed better to have Dolt be vocal about the issue and let users resolve it, instead of trying to be clever when we can't merge that situation correctly every time. 