### PR TITLE
Two code clean ups

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -156,7 +156,6 @@ func Serve(
 	sqlEngine, err := engine.NewSqlEngine(
 		ctx,
 		mrEnv,
-		engine.FormatTabular,
 		config,
 	)
 	if err != nil {

--- a/go/libraries/doltcore/mvdata/engine_table_reader.go
+++ b/go/libraries/doltcore/mvdata/engine_table_reader.go
@@ -52,7 +52,6 @@ func NewSqlEngineReader(ctx context.Context, dEnv *env.DoltEnv, tableName string
 	se, err := engine.NewSqlEngine(
 		ctx,
 		mrEnv,
-		engine.FormatCsv,
 		config,
 	)
 	if err != nil {

--- a/go/libraries/doltcore/mvdata/engine_table_writer.go
+++ b/go/libraries/doltcore/mvdata/engine_table_writer.go
@@ -84,7 +84,6 @@ func NewSqlEngineTableWriter(ctx context.Context, dEnv *env.DoltEnv, createTable
 	se, err := engine.NewSqlEngine(
 		ctx,
 		mrEnv,
-		engine.FormatCsv,
 		config,
 	)
 	if err != nil {


### PR DESCRIPTION
- More the format flag out of the sql engine. It's only used by the sql command, and causes confusion
- Drop the Dbddl code path. It's not longer required.