### PR TITLE
go/store/nbs: reduce startup latency for chunk journal

### DIFF
--- a/go/store/nbs/journal_index_record.go
+++ b/go/store/nbs/journal_index_record.go
@@ -167,12 +167,16 @@ func readJournalIndexRecord(buf []byte) (rec indexRec, err error) {
 	return
 }
 
-func validateIndexRecord(buf []byte) (ok bool) {
-	if len(buf) > (indexRecLenSz + indexRecChecksumSz) {
-		off := len(buf) - indexRecChecksumSz
-		ok = crc(buf[:off]) == readUint32(buf[off:])
+func validateIndexRecord(buf []byte) bool {
+	if len(buf) < (indexRecLenSz + indexRecChecksumSz) {
+		return false
 	}
-	return
+	off := readUint32(buf)
+	if int(off) > len(buf) {
+		return false
+	}
+	off -= indexRecChecksumSz
+	return crc(buf[:off]) == readUint32(buf[off:])
 }
 
 // processIndexRecords reads a sequence of index records from |r| and passes them to the callback. While reading records

--- a/go/store/nbs/journal_record.go
+++ b/go/store/nbs/journal_record.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 
@@ -256,7 +257,10 @@ func processJournalRecords(ctx context.Context, r io.ReadSeeker, off int64, cb f
 
 func peekRootHashAt(journal io.ReaderAt, offset int64) (root hash.Hash, err error) {
 	buf := make([]byte, 1024) // assumes len(rec) < 1024
-	if _, err = journal.ReadAt(buf, offset); err != nil {
+	_, err = journal.ReadAt(buf, offset)
+	if errors.Is(err, io.EOF) {
+		err = nil // EOF is expected for last record
+	} else if err != nil {
 		return
 	}
 	sz := readUint32(buf)

--- a/go/store/nbs/journal_writer.go
+++ b/go/store/nbs/journal_writer.go
@@ -244,10 +244,8 @@ func (wr *journalWriter) bootstrapJournal(ctx context.Context) (last hash.Hash, 
 
 		err = eg.Wait()
 		if err != nil {
-			// todo: issue warning on corrupt index recovery
-			if err = wr.corruptIndexRecovery(ctx); err != nil {
-				return
-			}
+			_ = wr.corruptIndexRecovery(ctx)
+			return hash.Hash{}, err
 		}
 		wr.ranges = wr.ranges.flatten()
 	}
@@ -277,6 +275,7 @@ func (wr *journalWriter) bootstrapJournal(ctx context.Context) (last hash.Hash, 
 
 // corruptIndexRecovery handles a corrupted or malformed journal index by truncating
 // the index file and restarting the journal bootstrapping process without an index.
+// todo: make backup file?
 func (wr *journalWriter) corruptIndexRecovery(ctx context.Context) (err error) {
 	if _, err = wr.index.Seek(0, io.SeekStart); err != nil {
 		return

--- a/go/store/nbs/journal_writer.go
+++ b/go/store/nbs/journal_writer.go
@@ -189,6 +189,11 @@ func (wr *journalWriter) bootstrapJournal(ctx context.Context) (last hash.Hash, 
 			return hash.Hash{}, err
 		}
 
+		// initialize range index with enough capacity to
+		// avoid rehashing during bootstrapping
+		cnt := estimateRangeCount(info)
+		wr.ranges.cached = swiss.NewMap[addr16, Range](cnt)
+
 		eg, ectx := errgroup.WithContext(ctx)
 		ch := make(chan []lookup, 4)
 

--- a/go/store/nbs/journal_writer.go
+++ b/go/store/nbs/journal_writer.go
@@ -244,7 +244,10 @@ func (wr *journalWriter) bootstrapJournal(ctx context.Context) (last hash.Hash, 
 
 		err = eg.Wait()
 		if err != nil {
-			_ = wr.corruptIndexRecovery(ctx)
+			err = errors.Join(errors.New("error bootstrapping chunk journal: "), err)
+			if cerr := wr.corruptIndexRecovery(ctx); cerr != nil {
+				err = errors.Join(err, cerr)
+			}
 			return hash.Hash{}, err
 		}
 		wr.ranges = wr.ranges.flatten()

--- a/go/store/nbs/journal_writer.go
+++ b/go/store/nbs/journal_writer.go
@@ -244,9 +244,9 @@ func (wr *journalWriter) bootstrapJournal(ctx context.Context) (last hash.Hash, 
 
 		err = eg.Wait()
 		if err != nil {
-			err = errors.Join(errors.New("error bootstrapping chunk journal: "), err)
+			err = fmt.Errorf("error bootstrapping chunk journal: %s", err.Error())
 			if cerr := wr.corruptIndexRecovery(ctx); cerr != nil {
-				err = errors.Join(err, cerr)
+				err = fmt.Errorf("error recovering corrupted chunk journal index: %s", err.Error())
 			}
 			return hash.Hash{}, err
 		}

--- a/go/store/nbs/journal_writer_test.go
+++ b/go/store/nbs/journal_writer_test.go
@@ -365,6 +365,7 @@ func TestJournalIndexBootstrap(t *testing.T) {
 				}
 				assert.Equal(t, expected[len(expected)-1].last, last)
 			}
+
 			idxPath := filepath.Join(filepath.Dir(path), journalIndexFileName)
 
 			before, err := os.Stat(idxPath)
@@ -382,13 +383,14 @@ func TestJournalIndexBootstrap(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, before.Size(), info.Size())
 
-			// bootstrap journal without index
+			// bootstrap journal with corrupted index
 			corruptJournalIndex(t, idxPath)
-			validateJournal(path, epochs)
-			// assert corrupt index cleaned up
-			info, err = os.Stat(idxPath)
+			jnl, ok, err := openJournalWriter(ctx, idxPath)
 			require.NoError(t, err)
-			assert.Equal(t, int64(0), info.Size())
+			require.True(t, ok)
+			_, err = jnl.bootstrapJournal(ctx)
+			assert.Error(t, err)
+
 		})
 	}
 }

--- a/integration-tests/bats/chunk-journal.bats
+++ b/integration-tests/bats/chunk-journal.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+load $BATS_TEST_DIRNAME/helper/common.bash
+
+setup() {
+    setup_common
+}
+
+teardown() {
+    assert_feature_version
+    teardown_common
+}
+
+@test "chunk-journal: assert chunk journal index is correctly bootstrapped" {
+    dolt sql -q "create table t (pk int primary key, c0 text);"
+    dolt commit -Am "new table t"
+
+    # chunk journal index is only populated after a sufficient number of chunk
+    # records have been written to the journal, see go/store/nbs/journal_writer.go
+    echo "insert into t values" > import.sql
+    for i in {1..16384}
+    do
+        echo "  ($i,'$i')," >> import.sql
+    done
+    echo "  (16385,'16385');" >> import.sql
+
+    dolt sql < import.sql
+
+    # read the database
+    dolt status
+    [ -s ".dolt/noms/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv" ]
+    [ -s ".dolt/noms/journal.idx" ]
+
+    # write the database
+    dolt checkout -b newbranch
+    [ -s ".dolt/noms/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv" ]
+    [ -s ".dolt/noms/journal.idx" ]
+}


### PR DESCRIPTION
https://github.com/dolthub/dolt/pull/5393 added a "journal index" to accelerate chunk journal bootstrapping. Unfortunately it never worked! Bugs in the journal index bootstrapping process caused sanity checks to fail and the journal index was subsequently dropped. The chunk journal itself was still valid and the bugs had no effect on correctness. However, without a valid journal index we were forced to always take the slow-path on startup.