### PR TITLE
Adding a mysql connector integ test for the Ruby mysql2 library

### DIFF
--- a/integration-tests/MySQLDockerfile
+++ b/integration-tests/MySQLDockerfile
@@ -36,7 +36,8 @@ RUN apt update -y && \
         g++ \
         libmysqlcppconn-dev \
         git \
-        ruby\
+        ruby \
+        ruby-dev \
         gem \
         libc6 \
         libgcc1 \

--- a/integration-tests/mysql-client-tests/mysql-client-tests.bats
+++ b/integration-tests/mysql-client-tests/mysql-client-tests.bats
@@ -100,6 +100,10 @@ cmake ..
     ruby $BATS_TEST_DIRNAME/ruby/ruby-mysql-test.rb $USER $PORT $REPO_NAME
 }
 
+@test "ruby mysql2 test" {
+    ruby $BATS_TEST_DIRNAME/ruby/mysql2-test.rb $USER $PORT $REPO_NAME
+}
+
 @test "elixir myxql test" {
     cd $BATS_TEST_DIRNAME/elixir/
     # install some mix dependencies

--- a/integration-tests/mysql-client-tests/ruby/Gemfile
+++ b/integration-tests/mysql-client-tests/ruby/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
 gem 'ruby-mysql', '~> 2.10'
+gem 'mysql2', '~> 0.5.5'

--- a/integration-tests/mysql-client-tests/ruby/Gemfile.lock
+++ b/integration-tests/mysql-client-tests/ruby/Gemfile.lock
@@ -1,12 +1,14 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    mysql2 (0.5.5)
     ruby-mysql (2.10.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  mysql2 (~> 0.5.5)
   ruby-mysql (~> 2.10)
 
 BUNDLED WITH

--- a/integration-tests/mysql-client-tests/ruby/mysql2-test.rb
+++ b/integration-tests/mysql-client-tests/ruby/mysql2-test.rb
@@ -1,8 +1,7 @@
 #!/usr/bin/ruby
 
-require 'mysql'
+require 'mysql2'
 require 'test/unit'
-require 'pp'
 
 extend Test::Unit::Assertions
 
@@ -28,22 +27,23 @@ queries = [
 ]
 
 # Smoke test the queries to make sure nothing blows up
-conn = Mysql::new("127.0.0.1", user, "", db, port)
+client = Mysql2::Client.new(:host => "127.0.0.1", :port => port, :username => user, :database => db)
 queries.each do |query|
-  res = conn.query(query)
+  res = client.query(query)
 end
 
+
 # Then make sure we can read some data back
-res = conn.query("SELECT * from test where pk = 1;")
+res = client.query("SELECT * from test where pk = 1;")
 rowCount = 0
 res.each do |row|
   rowCount += 1
-  assert_equal 1, row[0].to_i
-  assert_equal 1, row[1].to_i
-  assert_equal 123456.789, row[2].to_f
-  assert_equal 420.42, row[3].to_f
+  assert_equal 1, row["pk"]
+  assert_equal 1, row["value"]
+  assert_equal 123456.789, row["d1"]
+  assert_equal 420.42, row["f1"]
 end
 assert_equal 1, rowCount
 
-conn.close()
+client.close()
 exit(0)


### PR DESCRIPTION
Issue https://github.com/dolthub/dolt/issues/5834 uncovered that we weren't testing what seems to be the [recommended Ruby MySQL connector library (`mysql2`)](https://dev.mysql.com/doc/refman/8.0/en/apis-ruby.html), so this PR adds a connector integration test for it. 