### PR TITLE
Mention official Arch Linux packaging in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ privileges or aren't comfortable running a script with them, you can download th
 for your platform from [the latest release](https://github.com/dolthub/dolt/releases), unzip it,
 and put the binary somewhere on your `$PATH`.
 
+### Linux
+
+#### Arch Linux
+
+Dolt is packaged in the official repositories for Arch Linux.
+
+```
+pacman -S dolt
+```
+
 ### Mac
 
 #### Homebrew


### PR DESCRIPTION
I've been maintaining the AUR recipe for dolt since 2021 and [updated it for almost all the releases since 0.28.4](https://aur.archlinux.org/cgit/aur.git/log/?h=dolt). I've now migrated the packaging from the AUR to prebuilt packages in the official Arch Linux repos.