### PR TITLE
`dolt diff` shouldn't print ignored tables.

### DIFF
--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -578,8 +578,8 @@ func diffUserTables(ctx context.Context, dEnv *env.DoltEnv, dArgs *diffArgs) err
 
 	doltSchemasChanged := false
 	for _, td := range tableDeltas {
-		// Don't print tables if one side of the diff is an ignored table in the working set.
-		if toRootHash == workingSetHash {
+		// Don't print tables if one side of the diff is an ignored table in the working set being added.
+		if toRootHash == workingSetHash && td.FromTable == nil {
 			ignoreResult, err := ignoredTablePatterns.IsTableNameIgnored(td.ToName)
 			if err != nil {
 				return errhand.VerboseErrorFromError(err)
@@ -589,7 +589,7 @@ func diffUserTables(ctx context.Context, dEnv *env.DoltEnv, dArgs *diffArgs) err
 			}
 		}
 
-		if fromRootHash == workingSetHash {
+		if fromRootHash == workingSetHash && td.ToTable == nil {
 			ignoreResult, err := ignoredTablePatterns.IsTableNameIgnored(td.FromName)
 			if err != nil {
 				return errhand.VerboseErrorFromError(err)

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -64,6 +64,7 @@ const (
 	SkinnyFlag  = "skinny"
 	MergeBase   = "merge-base"
 	DiffMode    = "diff-mode"
+	ReverseFlag = "reverse"
 )
 
 var diffDocs = cli.CommandDocumentationContent{
@@ -155,6 +156,7 @@ func (cmd DiffCmd) ArgParser() *argparser.ArgParser {
 	ap.SupportsFlag(SkinnyFlag, "sk", "Shows only primary key columns and any columns with data changes.")
 	ap.SupportsFlag(MergeBase, "", "Uses merge base of the first commit and second commit (or HEAD if not supplied) as the first commit")
 	ap.SupportsString(DiffMode, "", "diff mode", "Determines how to display modified rows with tabular output. Valid values are row, line, in-place, context. Defaults to context.")
+	ap.SupportsFlag(ReverseFlag, "R", "Reverses the direction of the diff.")
 	return ap
 }
 
@@ -245,6 +247,15 @@ func parseDiffArgs(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.ArgPar
 	tableNames, err := dArgs.applyDiffRoots(ctx, dEnv, apr.Args, apr.Contains(cli.CachedFlag), apr.Contains(MergeBase))
 	if err != nil {
 		return nil, err
+	}
+
+	if apr.Contains(ReverseFlag) {
+		dArgs.diffDatasets = &diffDatasets{
+			fromRoot: dArgs.toRoot,
+			fromRef:  dArgs.toRef,
+			toRoot:   dArgs.fromRoot,
+			toRef:    dArgs.fromRef,
+		}
 	}
 
 	tableSet, err := parseDiffTableSet(ctx, dEnv, dArgs.diffDatasets, tableNames)

--- a/integration-tests/bats/diff.bats
+++ b/integration-tests/bats/diff.bats
@@ -192,6 +192,79 @@ SQL
     [[ "$output" =~ "| > | modify2 | CREATE PROCEDURE modify2() SELECT 43 |" ]] || false
 }
 
+@test "diff: reverse diff" {
+    # We're not using the test table, so we might as well delete it
+    dolt sql <<SQL
+DROP TABLE test;
+CREATE TABLE tbl (PK BIGINT PRIMARY KEY);
+INSERT INTO tbl VALUES (1), (2), (3);
+DELIMITER //
+CREATE PROCEDURE modify1() BEGIN
+DECLARE a INT DEFAULT 1;
+SELECT a
+  AS RESULT;
+END//
+CREATE PROCEDURE modify2() SELECT 42;//
+CREATE PROCEDURE remove() BEGIN
+SELECT 8;
+END//
+SQL
+    dolt add -A
+    dolt commit -m "First commit"
+    dolt branch original
+
+    dolt sql <<SQL
+DELETE FROM tbl WHERE pk = 2;
+INSERT INTO tbl VALUES (4);
+DROP PROCEDURE modify1;
+DROP PROCEDURE modify2;
+DROP PROCEDURE remove;
+DELIMITER //
+CREATE PROCEDURE modify1() BEGIN
+SELECT 2
+  AS RESULTING
+  FROM DUAL;
+END//
+CREATE PROCEDURE modify2() SELECT 43;//
+CREATE PROCEDURE adding() BEGIN
+SELECT 9;
+END//
+SQL
+    dolt add -A
+    dolt commit -m "Second commit"
+
+    # Look at the context diff
+    run dolt diff original -R
+    [ "$status" -eq 0 ]
+    echo "$output"
+    # Verify that standard diffs are still working
+    [[ "$output" =~ "|   | PK |" ]] || false
+    [[ "$output" =~ "+---+----+" ]] || false
+    [[ "$output" =~ "| - | 4  |" ]] || false
+    [[ "$output" =~ "| + | 2  |" ]] || false
+    # Check the overall stored procedure diff (excluding dates since they're variable)
+    [[ "$output" =~ "+---+---------+--------------------------------------+" ]] || false
+    [[ "$output" =~ "|   | name    | create_stmt                          |" ]] || false
+    [[ "$output" =~ "+---+---------+--------------------------------------+" ]] || false
+    [[ "$output" =~ "| - | adding  | CREATE PROCEDURE adding() BEGIN      |" ]] || false
+    [[ "$output" =~ "|   |         | SELECT 9;                            |" ]] || false
+    [[ "$output" =~ "|   |         | END                                  |" ]] || false
+    [[ "$output" =~ "| * | modify1 |  CREATE PROCEDURE modify1() BEGIN    |" ]] || false
+    [[ "$output" =~ "|   |         | -SELECT 2                            |" ]] || false
+    [[ "$output" =~ "|   |         | -  AS RESULTING                      |" ]] || false
+    [[ "$output" =~ "|   |         | -  FROM DUAL;                        |" ]] || false
+    [[ "$output" =~ "|   |         | +DECLARE a INT DEFAULT 1;            |" ]] || false
+    [[ "$output" =~ "|   |         | +SELECT a                            |" ]] || false
+    [[ "$output" =~ "|   |         | +  AS RESULT;                        |" ]] || false
+    [[ "$output" =~ "|   |         |  END                                 |" ]] || false
+    [[ "$output" =~ "| < | modify2 | CREATE PROCEDURE modify2() SELECT 43 |" ]] || false
+    [[ "$output" =~ "| > | modify2 | CREATE PROCEDURE modify2() SELECT 42 |" ]] || false
+    [[ "$output" =~ "| + | remove  | CREATE PROCEDURE remove() BEGIN      |" ]] || false
+    [[ "$output" =~ "|   |         | SELECT 8;                            |" ]] || false
+    [[ "$output" =~ "|   |         | END                                  |" ]] || false
+    [[ "$output" =~ "+---+---------+--------------------------------------+" ]] || false
+}
+
 @test "diff: clean working set" {
     dolt add .
     dolt commit -m table

--- a/integration-tests/bats/ignore.bats
+++ b/integration-tests/bats/ignore.bats
@@ -277,3 +277,19 @@ SQL
     [[ "$output" =~ "ignoreme" ]] || false
 
 }
+
+@test "ignore: don't display ignored tables in dolt diff" {
+    skip_nbf_ld_1
+
+    dolt sql <<SQL
+CREATE TABLE ignoreme (pk int);
+CREATE TABLE nomatch (pk int);
+SQL
+
+    run dolt diff
+
+    [ "$status" -eq 0 ]
+
+    [[ "$output" =~ "nomatch" ]] || false
+    [[ ! ["$output" =~ "ignoreme"] ]] || false
+}

--- a/integration-tests/bats/ignore.bats
+++ b/integration-tests/bats/ignore.bats
@@ -238,7 +238,7 @@ SQL
 
     [ "$status" -eq 0 ]
 
-    [[ ! ["$output" =~ "diff --dolt a/ignoreme b/ignoreme"] ]] || false
+    ! [["$output" =~ "diff --dolt a/ignoreme b/ignoreme"]] || false
 
 }
 
@@ -255,8 +255,8 @@ SQL
     [ "$status" -eq 0 ]
 
     [[ "$output" =~ "nomatch" ]] || false
-    [[ ! ["$output" =~ "Ignored tables"] ]] || false
-    [[ ! ["$output" =~ "ignoreme"] ]] || false
+    ! [["$output" =~ "Ignored tables"]] || false
+    ! [["$output" =~ "ignoreme"]] || false
 
 }
 
@@ -291,5 +291,5 @@ SQL
     [ "$status" -eq 0 ]
 
     [[ "$output" =~ "nomatch" ]] || false
-    [[ ! ["$output" =~ "ignoreme"] ]] || false
+    ! [["$output" =~ "ignoreme"]] || false
 }

--- a/integration-tests/bats/ignore.bats
+++ b/integration-tests/bats/ignore.bats
@@ -278,7 +278,7 @@ SQL
 
 }
 
-@test "ignore: don't display add ignored tables in dolt diff" {
+@test "ignore: don't display new but ignored tables in dolt diff" {
     skip_nbf_ld_1
 
     dolt sql <<SQL
@@ -287,6 +287,22 @@ CREATE TABLE nomatch (pk int);
 SQL
 
     run dolt diff
+
+    [ "$status" -eq 0 ]
+
+    [[ "$output" =~ "nomatch" ]] || false
+    ! [["$output" =~ "ignoreme"]] || false
+}
+
+@test "ignore: don't display new but ignored tables in reverse diff" {
+    skip_nbf_ld_1
+
+    dolt sql <<SQL
+CREATE TABLE ignoreme (pk int);
+CREATE TABLE nomatch (pk int);
+SQL
+
+    run dolt diff -R
 
     [ "$status" -eq 0 ]
 
@@ -308,6 +324,28 @@ INSERT INTO ignoreme VALUES (1);
 SQL
 
     run dolt diff
+
+    [ "$status" -eq 0 ]
+
+    echo "$output"
+
+    [[ "$output" =~ "ignoreme" ]] || false
+}
+
+@test "ignore: DO display modified ignored tables in reverse diff after staging" {
+    skip_nbf_ld_1
+
+    dolt sql <<SQL
+CREATE TABLE ignoreme (pk int);
+SQL
+
+    dolt add --force ignoreme
+
+    dolt sql <<SQL
+INSERT INTO ignoreme VALUES (1);
+SQL
+
+    run dolt diff -R
 
     [ "$status" -eq 0 ]
 

--- a/integration-tests/bats/ignore.bats
+++ b/integration-tests/bats/ignore.bats
@@ -278,7 +278,7 @@ SQL
 
 }
 
-@test "ignore: don't display ignored tables in dolt diff" {
+@test "ignore: don't display add ignored tables in dolt diff" {
     skip_nbf_ld_1
 
     dolt sql <<SQL
@@ -292,4 +292,49 @@ SQL
 
     [[ "$output" =~ "nomatch" ]] || false
     ! [["$output" =~ "ignoreme"]] || false
+}
+
+@test "ignore: DO display modified ignored tables in dolt diff after staging" {
+    skip_nbf_ld_1
+
+    dolt sql <<SQL
+CREATE TABLE ignoreme (pk int);
+SQL
+
+    dolt add --force ignoreme
+
+    dolt sql <<SQL
+INSERT INTO ignoreme VALUES (1);
+SQL
+
+    run dolt diff
+
+    [ "$status" -eq 0 ]
+
+    echo "$output"
+
+    [[ "$output" =~ "ignoreme" ]] || false
+}
+
+@test "ignore: DO display modified ignored tables in dolt diff after committing" {
+    skip_nbf_ld_1
+
+    dolt sql <<SQL
+CREATE TABLE ignoreme (pk int);
+SQL
+
+    dolt add --force ignoreme
+    dolt commit -m "commit1"
+
+    dolt sql <<SQL
+INSERT INTO ignoreme VALUES (1);
+SQL
+
+    run dolt diff
+
+    [ "$status" -eq 0 ]
+
+    echo "$output"
+
+    [[ "$output" =~ "ignoreme" ]] || false
 }


### PR DESCRIPTION
Fixes #5841 