### PR TITLE
go: env/actions: remotes.go: In SyncRoots, if we are syncing to an empty destination repository, use pull.Clone instead of pull.Pull.

### DIFF
--- a/go/libraries/doltcore/env/actions/remotes.go
+++ b/go/libraries/doltcore/env/actions/remotes.go
@@ -501,31 +501,31 @@ func SyncRoots(ctx context.Context, srcDb, destDb *doltdb.DoltDB, tempTableDir s
 					if tfe.EventType == pull.DownloadStats {
 						stats[tfe.TableFiles[0]] = tfe.Stats[0]
 
-						totalsentbytes := uint64(0)
-						totalbytes := uint64(0)
+						totalSentBytes := uint64(0)
+						totalBytes := uint64(0)
 
 						for _, v := range stats {
 							if v.Percent > 0.001 {
-								totalsentbytes += v.Read
-								totalbytes += uint64(float64(v.Read) / v.Percent)
+								totalSentBytes += v.Read
+								totalBytes += uint64(float64(v.Read) / v.Percent)
 							}
 						}
 
 						// We fake some of these values.
-						toemit := pull.Stats{
-							FinishedSendBytes: totalsentbytes,
-							BufferedSendBytes: totalsentbytes,
-							SendBytesPerSec:   float64(totalsentbytes) / (time.Since(start).Seconds()),
+						toEmit := pull.Stats{
+							FinishedSendBytes: totalSentBytes,
+							BufferedSendBytes: totalSentBytes,
+							SendBytesPerSec:   float64(totalSentBytes) / (time.Since(start).Seconds()),
 
 							// estimate the number of chunks based on an average chunk size of 4096.
-							TotalSourceChunks:   totalbytes / 4096,
-							FetchedSourceChunks: totalsentbytes / 4096,
+							TotalSourceChunks:   totalBytes / 4096,
+							FetchedSourceChunks: totalSentBytes / 4096,
 
-							FetchedSourceBytes:       totalsentbytes,
-							FetchedSourceBytesPerSec: float64(totalsentbytes) / (time.Since(start).Seconds()),
+							FetchedSourceBytes:       totalSentBytes,
+							FetchedSourceBytesPerSec: float64(totalSentBytes) / (time.Since(start).Seconds()),
 						}
 						select {
-						case statsCh <- toemit:
+						case statsCh <- toEmit:
 
 							// TODO: This looks wrong without a ctx.Done() select, but Puller does not conditionally send here...
 

--- a/go/store/chunks/tablefilestore.go
+++ b/go/store/chunks/tablefilestore.go
@@ -21,6 +21,8 @@ import (
 	"github.com/dolthub/dolt/go/store/hash"
 )
 
+const JournalFileID = "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv"
+
 // TableFile is an interface for working with an existing table file
 type TableFile interface {
 	// FileID gets the id of the file

--- a/go/store/datas/pull/clone.go
+++ b/go/store/datas/pull/clone.go
@@ -17,6 +17,7 @@ package pull
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/cenkalti/backoff/v4"
@@ -29,12 +30,13 @@ import (
 )
 
 var ErrNoData = errors.New("no data")
+var ErrCloneUnsupported = errors.New("clone unsupported")
 
 func Clone(ctx context.Context, srcCS, sinkCS chunks.ChunkStore, eventCh chan<- TableFileEvent) error {
 	srcTS, srcOK := srcCS.(chunks.TableFileStore)
 
 	if !srcOK {
-		return errors.New("src db is not a Table File Store")
+		return fmt.Errorf("%w: src db is not a Table File Store", ErrCloneUnsupported)
 	}
 
 	size, err := srcTS.Size(ctx)
@@ -50,7 +52,7 @@ func Clone(ctx context.Context, srcCS, sinkCS chunks.ChunkStore, eventCh chan<- 
 	sinkTS, sinkOK := sinkCS.(chunks.TableFileStore)
 
 	if !sinkOK {
-		return errors.New("sink db is not a Table File Store")
+		return fmt.Errorf("%w: sink db is not a Table File Store", ErrCloneUnsupported)
 	}
 
 	return clone(ctx, srcTS, sinkTS, eventCh)

--- a/go/store/nbs/journal_writer.go
+++ b/go/store/nbs/journal_writer.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dolthub/swiss"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
 )
 
@@ -36,7 +37,7 @@ const (
 	//   but we don't have a hard limit on record size right now
 	journalWriterBuffSize = 1024 * 1024
 
-	chunkJournalAddr = "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv"
+	chunkJournalAddr = chunks.JournalFileID
 
 	journalIndexFileName = "journal.idx"
 


### PR DESCRIPTION
pull.Clone uses the TableFileStore interface to transit whole table files without needing to follow chunk references or do any reconciliation with the destination database regarding what it already has. It is much faster against every time of remote.