### PR TITLE
Improve dolt_ignore pattern rules

### DIFF
--- a/go/libraries/doltcore/doltdb/ignore.go
+++ b/go/libraries/doltcore/doltdb/ignore.go
@@ -110,6 +110,7 @@ func compilePattern(pattern string) (*regexp.Regexp, error) {
 	pattern = "^" + regexp.QuoteMeta(pattern) + "$"
 	pattern = strings.Replace(pattern, "\\?", ".", -1)
 	pattern = strings.Replace(pattern, "\\*", ".*", -1)
+	pattern = strings.Replace(pattern, "\\%", ".*", -1)
 	return regexp.Compile(pattern)
 }
 
@@ -119,8 +120,10 @@ func compilePattern(pattern string) (*regexp.Regexp, error) {
 func getMoreSpecificPatterns(lessSpecific string) (*regexp.Regexp, error) {
 	pattern := "^" + regexp.QuoteMeta(lessSpecific) + "$"
 	// A ? can expand to any character except for a *, since that also has special meaning in patterns.
+
 	pattern = strings.Replace(pattern, "\\?", "[^\\*]", -1)
 	pattern = strings.Replace(pattern, "\\*", ".*", -1)
+	pattern = strings.Replace(pattern, "\\%", ".*", -1)
 	return regexp.Compile(pattern)
 }
 

--- a/go/libraries/doltcore/doltdb/ignore.go
+++ b/go/libraries/doltcore/doltdb/ignore.go
@@ -121,7 +121,7 @@ func getMoreSpecificPatterns(lessSpecific string) (*regexp.Regexp, error) {
 	pattern := "^" + regexp.QuoteMeta(lessSpecific) + "$"
 	// A ? can expand to any character except for a *, since that also has special meaning in patterns.
 
-	pattern = strings.Replace(pattern, "\\?", "[^\\*]", -1)
+	pattern = strings.Replace(pattern, "\\?", "[^\\*%]", -1)
 	pattern = strings.Replace(pattern, "\\*", ".*", -1)
 	pattern = strings.Replace(pattern, "\\%", ".*", -1)
 	return regexp.Compile(pattern)

--- a/go/libraries/doltcore/doltdb/ignore.go
+++ b/go/libraries/doltcore/doltdb/ignore.go
@@ -110,7 +110,7 @@ func compilePattern(pattern string) (*regexp.Regexp, error) {
 	pattern = "^" + regexp.QuoteMeta(pattern) + "$"
 	pattern = strings.Replace(pattern, "\\?", ".", -1)
 	pattern = strings.Replace(pattern, "\\*", ".*", -1)
-	pattern = strings.Replace(pattern, "\\%", ".*", -1)
+	pattern = strings.Replace(pattern, "%", ".*", -1)
 	return regexp.Compile(pattern)
 }
 
@@ -123,7 +123,7 @@ func getMoreSpecificPatterns(lessSpecific string) (*regexp.Regexp, error) {
 
 	pattern = strings.Replace(pattern, "\\?", "[^\\*%]", -1)
 	pattern = strings.Replace(pattern, "\\*", ".*", -1)
-	pattern = strings.Replace(pattern, "\\%", ".*", -1)
+	pattern = strings.Replace(pattern, "%", ".*", -1)
 	return regexp.Compile(pattern)
 }
 

--- a/integration-tests/bats/ignore.bats
+++ b/integration-tests/bats/ignore.bats
@@ -12,6 +12,8 @@ INSERT INTO dolt_ignore VALUES
   ("*_ignore", true),
   ("do_not_ignore", false),
 
+  ("%_also_ignore", true),
+
   ("commit_*", false),
   ("commit_me_not", true),
 
@@ -85,6 +87,7 @@ SQL
 
     dolt sql <<SQL
 CREATE TABLE please_ignore (pk int);
+CREATE TABLE please_also_ignore (pk int);
 CREATE TABLE do_not_ignore (pk int);
 CREATE TABLE commit_me (pk int);
 CREATE TABLE commit_me_not(pk int);
@@ -96,6 +99,7 @@ SQL
     staged=$(get_staged_tables)
 
     [[ ! -z $(echo "$ignored" | grep "please_ignore") ]] || false
+    [[ ! -z $(echo "$ignored" | grep "please_also_ignore") ]] || false
     [[ ! -z $(echo "$staged" | grep "do_not_ignore") ]] || false
     [[ ! -z $(echo "$staged" | grep "commit_me") ]] || false
     [[ ! -z $(echo "$ignored" | grep "commit_me_not") ]] || false

--- a/integration-tests/bats/ignore.bats
+++ b/integration-tests/bats/ignore.bats
@@ -380,3 +380,24 @@ SQL
 
     [[ "$output" =~ "ignoreme" ]] || false
 }
+
+@test "ignore: detect when equivalent patterns have different values" {
+    dolt sql <<SQL
+INSERT INTO dolt_ignore VALUES
+  ("**_test", true),
+  ("*_test", false),
+
+  ("*_foo", true),
+  ("%_foo", false);
+CREATE TABLE a_test (pk int);
+CREATE TABLE a_foo (pk int);
+SQL
+
+    conflict=$(get_conflict_tables)
+
+    echo "$conflict"
+
+    [[ ! -z $(echo "$conflict" | grep "a_test") ]] || false
+    [[ ! -z $(echo "$conflict" | grep "a_foo") ]] || false
+
+}

--- a/integration-tests/bats/ignore.bats
+++ b/integration-tests/bats/ignore.bats
@@ -382,6 +382,8 @@ SQL
 }
 
 @test "ignore: detect when equivalent patterns have different values" {
+    skip_nbf_ld_1
+
     dolt sql <<SQL
 INSERT INTO dolt_ignore VALUES
   ("**_test", true),

--- a/integration-tests/bats/ignore.bats
+++ b/integration-tests/bats/ignore.bats
@@ -12,7 +12,7 @@ INSERT INTO dolt_ignore VALUES
   ("*_ignore", true),
   ("do_not_ignore", false),
 
-  ("%_also_ignore", true),
+  ("%_ignore_too", true),
 
   ("commit_*", false),
   ("commit_me_not", true),
@@ -87,7 +87,7 @@ SQL
 
     dolt sql <<SQL
 CREATE TABLE please_ignore (pk int);
-CREATE TABLE please_also_ignore (pk int);
+CREATE TABLE please_ignore_too (pk int);
 CREATE TABLE do_not_ignore (pk int);
 CREATE TABLE commit_me (pk int);
 CREATE TABLE commit_me_not(pk int);
@@ -99,7 +99,7 @@ SQL
     staged=$(get_staged_tables)
 
     [[ ! -z $(echo "$ignored" | grep "please_ignore") ]] || false
-    [[ ! -z $(echo "$ignored" | grep "please_also_ignore") ]] || false
+    [[ ! -z $(echo "$ignored" | grep "please_ignore_too") ]] || false
     [[ ! -z $(echo "$staged" | grep "do_not_ignore") ]] || false
     [[ ! -z $(echo "$staged" | grep "commit_me") ]] || false
     [[ ! -z $(echo "$ignored" | grep "commit_me_not") ]] || false


### PR DESCRIPTION
This PR does two things:

- introduces % as an alias for *, since % is the SQL wildcard
- adds an additional check for dolt_ignore rules that are equivalent but have different `ignored` values.