### PR TITLE
Branch Control fixes and improvements

### DIFF
--- a/go/libraries/doltcore/sqle/dtables/branch_control_table.go
+++ b/go/libraries/doltcore/sqle/dtables/branch_control_table.go
@@ -33,7 +33,7 @@ const (
 
 // PermissionsStrings is a slice of strings representing the available branch_control.branch_control.Permissions. The order of the
 // strings should exactly match the order of the branch_control.Permissions according to their flag value.
-var PermissionsStrings = []string{"admin", "write"}
+var PermissionsStrings = []string{"admin", "write", "read"}
 
 // accessSchema is the schema for the "dolt_branch_control" table.
 var accessSchema = sql.Schema{


### PR DESCRIPTION
There was a bug where, under very specific conditions, we could get the branch control table to have a nil map when there shouldn't be one, which would throw a panic. This situation also seemed to cause a bug where you could "infinitely" delete branches without them actually being removed, and our duplicate key detection failed to work in these cases. The root cause of both of those issues have been fixed.

In addition, if a customer wanted to reject a user from using a particular branch, but allow others, then it was very, very verbose to implement this functionality. I've instead modified our branch control system to take the longest match (which will be the most specific one due to our folding of expressions), and also added an explicit `"read"` permission, to force some (or all) users to only have `read` permissions even if there is a global allowance. This also matches the namespace table, which already operated on a longest-match principle.