### PR TITLE
Remove overzealous validation check.

### DIFF
--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -475,19 +475,6 @@ func newImportSqlEngineMover(ctx context.Context, dEnv *env.DoltEnv, rdSchema sc
 		return nil, dmce
 	}
 
-	// Validate that the schema from files has primary keys.
-	err := tableSchema.GetPKCols().Iter(func(tag uint64, col schema.Column) (stop bool, err error) {
-		preImage := imOpts.nameMapper.PreImage(col.Name)
-		_, found := rdSchema.GetAllCols().GetByName(preImage)
-		if !found {
-			err = fmt.Errorf("input primary keys do not match primary keys of existing table")
-		}
-		return err == nil, err
-	})
-	if err != nil {
-		return nil, &mvdata.DataMoverCreationError{ErrType: mvdata.SchemaErr, Cause: err}
-	}
-
 	// construct the schema of the set of column to be updated.
 	rowOperationColColl := schema.NewColCollection()
 	rdSchema.GetAllCols().Iter(func(tag uint64, col schema.Column) (stop bool, err error) {

--- a/integration-tests/bats/import-replace-tables.bats
+++ b/integration-tests/bats/import-replace-tables.bats
@@ -42,8 +42,7 @@ CREATE TABLE test (
 SQL
     run dolt table import -r test `batshelper 2pk5col-ints.csv`
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "Error determining the output schema." ]] || false
-    [[ "$output" =~ "cause: input primary keys do not match primary keys of existing table" ]] || false
+    [[ "$output" =~ "Field 'pk' doesn't have a default value" ]] || false
 }
 
 @test "import-replace-tables: replace table using psv" {
@@ -79,8 +78,7 @@ CREATE TABLE test (
 SQL
     run dolt table import -r test `batshelper 1pk5col-ints.psv`
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "Error determining the output schema." ]] || false
-    [[ "$output" =~ "cause: input primary keys do not match primary keys of existing table" ]] || false
+    [[ "$output" =~ "Field 'pk1' doesn't have a default value" ]] || false
 }
 
 @test "import-replace-tables: replace table using schema with csv" {
@@ -252,8 +250,7 @@ SQL
     [[ "$output" =~ "Import completed successfully." ]] || false
     run dolt table import -r test `batshelper 1pk5col-ints.csv`
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "Error determining the output schema." ]] || false
-    [[ "$output" =~ "cause: input primary keys do not match primary keys of existing table" ]] || false
+    [[ "$output" =~ "Field 'pk1' doesn't have a default value" ]] || false
 }
 
 @test "import-replace-tables: replace table with 2 primary keys with a csv with 2 primary keys" {

--- a/integration-tests/bats/import-update-tables.bats
+++ b/integration-tests/bats/import-update-tables.bats
@@ -668,7 +668,7 @@ DELIM
 
     run dolt table import -u test 1pk5col-ints-updt.csv
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "Error determining the output schema." ]] || false
+    [[ "$output" =~ "Field 'pk' doesn't have a default value" ]] || false
 }
 
 @test "import-update-tables: partial update on keyless table" {

--- a/integration-tests/bats/import-update-tables.bats
+++ b/integration-tests/bats/import-update-tables.bats
@@ -1296,3 +1296,23 @@ DELIM
     [ $status -eq 0 ]
     [[ "$output" =~ '1,0,0,0,0,0,0,0,0,0,0,0000-00-00,00:00:00,0000-00-00 00:00:00,0000-00-00 00:00:00,0,first,""' ]] || false
 }
+
+@test "import-update-tables: import table with absent auto-increment column" {
+    dolt sql <<SQL
+CREATE TABLE tbl (
+    id int PRIMARY KEY AUTO_INCREMENT,
+    v1 int,
+    v2 int,
+    INDEX v1 (v1),
+    INDEX v2 (v2)
+);
+SQL
+
+    cat <<DELIM > auto-increment.csv
+v1,v2
+4,2
+3,1
+DELIM
+
+    dolt table import -u tbl auto-increment.csv
+}


### PR DESCRIPTION
This check appears to be redundant, in order to fail early and return a more helpful error message. But it's not helpful if it's wrong... which it is. It errors fast on inputs that should be correct (such as auto-increment columns), and it not only fails on the example from https://github.com/dolthub/dolt/issues/5855, but it would prevent us from implementing a permanent fix.

Removing the check, all tests still pass, because invalid imports are still detected by the remaining checks.