### PR TITLE
Apply column defaults when merging in new columns

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
@@ -3921,6 +3921,84 @@ var ThreeWayMergeWithSchemaChangeTestScripts = []MergeScriptTest{
 		},
 	},
 	{
+		Name: "adding a column with a literal default value",
+		AncSetUpScript: []string{
+			"CREATE table t (pk int primary key);",
+			"INSERT into t values (1);",
+		},
+		RightSetUpScript: []string{
+			"alter table t add column c1 varchar(100) default ('hello');",
+			"insert into t values (2, 'hi');",
+			"alter table t add index idx1 (c1, pk);",
+		},
+		LeftSetUpScript: []string{
+			"insert into t values (3);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "call dolt_merge('right');",
+				Expected: []sql.Row{{0, 0x0}},
+			},
+			{
+				Query:    "select * from t;",
+				Expected: []sql.Row{{1, "hello"}, {2, "hi"}, {3, "hello"}},
+			},
+		},
+	},
+	{
+		Name: "altering a column to add a literal default value",
+		AncSetUpScript: []string{
+			"CREATE table t (pk int primary key, c1 varchar(100));",
+			"INSERT into t values (1, NULL);",
+			"alter table t add index idx1 (c1, pk);",
+		},
+		RightSetUpScript: []string{
+			"alter table t modify column c1 varchar(100) default ('hello');",
+			"insert into t values (2, DEFAULT);",
+		},
+		LeftSetUpScript: []string{
+			"insert into t values (3, NULL);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "call dolt_merge('right');",
+				Expected: []sql.Row{{0, 0x0}},
+			},
+			{
+				Query:    "select * from t;",
+				Expected: []sql.Row{{1, nil}, {2, "hello"}, {3, nil}},
+			},
+		},
+	},
+	{
+		// TODO: We can currently only support literal default values. Supporting column references and functions
+		//       requires getting the analyzer involved to resolve references.
+		Name: "adding a column with a non-literal default value",
+		AncSetUpScript: []string{
+			"CREATE table t (pk int primary key);",
+			"INSERT into t values (1);",
+		},
+		RightSetUpScript: []string{
+			"alter table t add column c1 varchar(100) default (CONCAT('h','e','l','l','o'));",
+			"insert into t values (2, 'hi');",
+			"alter table t add index idx1 (c1, pk);",
+		},
+		LeftSetUpScript: []string{
+			"insert into t values (3);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:       "call dolt_merge('right');",
+				ExpectedErr: merge.ErrUnableToMergeColumnDefaultValue,
+			},
+			{
+				Skip:     true,
+				Query:    "select * from t;",
+				Expected: []sql.Row{{1, "hello"}, {2, "hi"}, {3, "hello"}},
+			},
+		},
+	},
+	{
 		Name: "adding different columns to both sides",
 		AncSetUpScript: []string{
 			"create table t (pk int primary key);",


### PR DESCRIPTION
Currently, when merging in a new column and updating existing rows for the new column, any column default value for the new column is ignored. This can result in inconsistent data that customers do not expect (e.g. https://github.com/dolthub/dolt/issues/4456). 

This PR adds initial support for applying column defaults when merging in a new column. Only literal default values are supported in this PR. Supporting column references and function references will require more work to properly resolve those references through the analyzer's code. If an unsupported column default value is present, this change detects that we cannot apply it and errors out the merge, instead of dropping the default value and leaving the new column null. 

Fixes https://github.com/dolthub/dolt/issues/4456 (which specifically only needs support for literal default values)
