### PR TITLE
Refactor SQLEngine instantiation into the Queryist interface

### DIFF
--- a/go/cmd/dolt/cli/cli_context.go
+++ b/go/cmd/dolt/cli/cli_context.go
@@ -14,10 +14,68 @@
 
 package cli
 
-import "github.com/dolthub/dolt/go/libraries/utils/argparser"
+import (
+	"context"
+	"fmt"
+	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
+	"github.com/dolthub/dolt/go/libraries/utils/argparser"
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+// Queryist is generic interface for executing queries.
+type Queryist interface {
+	Query(ctx *sql.Context, query string) (sql.Schema, sql.RowIter, error)
+}
+
+// LateBindQueryist is a function that will be called the first time Querist is needed for use. Input is a context which
+// is appropriate for the call to comence. Output is a Queryist, a sql.Context, a closer function, and an error.
+// The closer function is called when the Queryist is no longer needed, typically a defer right after getting it.
+type LateBindQueryist func(ctx context.Context) (Queryist, *sql.Context, func(), error)
 
 // CliContexct is used to pass top level command information down to subcommands.
 type CliContext interface {
 	// GlobalArgs returns the arguments passed before the subcommand.
 	GlobalArgs() *argparser.ArgParseResults
+	QueryEngine(ctx context.Context) (Queryist, *sql.Context, func(), error)
+}
+
+type LateBindCliContext struct {
+	globalArgs *argparser.ArgParseResults
+	queryist   Queryist
+	sqlCtx     *sql.Context
+
+	bind LateBindQueryist
+}
+
+// GlobalArgs returns the arguments passed before the subcommand.
+func (lbc LateBindCliContext) GlobalArgs() *argparser.ArgParseResults {
+	return lbc.globalArgs
+}
+
+// QueryEngine returns a Queryist, a sql.Context, a closer function, and an error. It ensures that only one call to the
+// LateBindQueryist is made, and caches the result.
+func (lbc LateBindCliContext) QueryEngine(ctx context.Context) (Queryist, *sql.Context, func(), error) {
+	if lbc.queryist != nil {
+		return lbc.queryist, lbc.sqlCtx, nil, nil
+	}
+
+	qryist, sqlCtx, closer, err := lbc.bind(ctx)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	lbc.queryist = qryist
+	lbc.sqlCtx = sqlCtx
+
+	return qryist, sqlCtx, closer, nil
+}
+
+var _ CliContext = LateBindCliContext{}
+
+func BuildCliContext(args *argparser.ArgParseResults, latebind LateBindQueryist) (CliContext, errhand.VerboseError) {
+	if args == nil || latebind == nil {
+		return nil, errhand.VerboseErrorFromError(fmt.Errorf("Invariants violated.  args and latebind must be non nil."))
+	}
+
+	return LateBindCliContext{globalArgs: args, bind: latebind}, nil
 }

--- a/go/cmd/dolt/cli/cli_context.go
+++ b/go/cmd/dolt/cli/cli_context.go
@@ -17,9 +17,11 @@ package cli
 import (
 	"context"
 	"fmt"
+
+	"github.com/dolthub/go-mysql-server/sql"
+
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
-	"github.com/dolthub/go-mysql-server/sql"
 )
 
 // LateBindQueryist is a function that will be called the first time Querist is needed for use. Input is a context which

--- a/go/cmd/dolt/cli/cli_context.go
+++ b/go/cmd/dolt/cli/cli_context.go
@@ -45,8 +45,8 @@ func NewCliContext(args *argparser.ArgParseResults, latebind LateBindQueryist) (
 	return LateBindCliContext{globalArgs: args, bind: latebind}, nil
 }
 
-// LateBindCliContext is a struct that implements CliContext. It's primary purpose is to wrap the global arguments and
-// provide an implementation of the QueryEngine function. This instance is stateful to ensure that the Queryist if only
+// LateBindCliContext is a struct that implements CliContext. Its primary purpose is to wrap the global arguments and
+// provide an implementation of the QueryEngine function. This instance is stateful to ensure that the Queryist is only
 // created once.
 type LateBindCliContext struct {
 	globalArgs *argparser.ArgParseResults

--- a/go/cmd/dolt/cli/command.go
+++ b/go/cmd/dolt/cli/command.go
@@ -17,6 +17,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"github.com/dolthub/go-mysql-server/sql"
 	"os"
 	"os/signal"
 	"strings"
@@ -78,6 +79,12 @@ type SignalCommand interface {
 
 	// InstallsSignalHandlers returns whether this command manages its own signal handlers for interruption / termination.
 	InstallsSignalHandlers() bool
+}
+
+// Queryist is generic interface for executing queries. Commands will be provided a Queryist to perform any work using
+// SQL. The Queryist can be obtained from the CliContext passed into the Exec method by calling the QueryEngine method.
+type Queryist interface {
+	Query(ctx *sql.Context, query string) (sql.Schema, sql.RowIter, error)
 }
 
 // This type is to store the content of a documented command, elsewhere we can transform this struct into

--- a/go/cmd/dolt/cli/command.go
+++ b/go/cmd/dolt/cli/command.go
@@ -17,12 +17,12 @@ package cli
 import (
 	"context"
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
 
+	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/fatih/color"
 
 	eventsapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"

--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -20,6 +20,14 @@ import (
 	"runtime"
 	"strings"
 
+	gms "github.com/dolthub/go-mysql-server"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/analyzer"
+	"github.com/dolthub/go-mysql-server/sql/binlogreplication"
+	"github.com/dolthub/go-mysql-server/sql/mysql_db"
+	"github.com/dolthub/go-mysql-server/sql/rowexec"
+	_ "github.com/dolthub/go-mysql-server/sql/variables"
+
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
@@ -30,13 +38,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/mysql_file_handler"
 	"github.com/dolthub/dolt/go/libraries/utils/config"
 	"github.com/dolthub/dolt/go/store/types"
-	gms "github.com/dolthub/go-mysql-server"
-	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/go-mysql-server/sql/analyzer"
-	"github.com/dolthub/go-mysql-server/sql/binlogreplication"
-	"github.com/dolthub/go-mysql-server/sql/mysql_db"
-	"github.com/dolthub/go-mysql-server/sql/rowexec"
-	_ "github.com/dolthub/go-mysql-server/sql/variables"
 )
 
 // SqlEngine packages up the context necessary to run sql queries against dsqle.

--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -16,19 +16,9 @@ package engine
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"runtime"
 	"strings"
-
-	gms "github.com/dolthub/go-mysql-server"
-	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/go-mysql-server/sql/analyzer"
-	"github.com/dolthub/go-mysql-server/sql/binlogreplication"
-	"github.com/dolthub/go-mysql-server/sql/mysql_db"
-	"github.com/dolthub/go-mysql-server/sql/rowexec"
-	_ "github.com/dolthub/go-mysql-server/sql/variables"
-	"github.com/dolthub/vitess/go/vt/sqlparser"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
@@ -40,6 +30,13 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/mysql_file_handler"
 	"github.com/dolthub/dolt/go/libraries/utils/config"
 	"github.com/dolthub/dolt/go/store/types"
+	gms "github.com/dolthub/go-mysql-server"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/analyzer"
+	"github.com/dolthub/go-mysql-server/sql/binlogreplication"
+	"github.com/dolthub/go-mysql-server/sql/mysql_db"
+	"github.com/dolthub/go-mysql-server/sql/rowexec"
+	_ "github.com/dolthub/go-mysql-server/sql/variables"
 )
 
 // SqlEngine packages up the context necessary to run sql queries against dsqle.
@@ -247,39 +244,6 @@ func (se *SqlEngine) Query(ctx *sql.Context, query string) (sql.Schema, sql.RowI
 // Analyze analyzes a node.
 func (se *SqlEngine) Analyze(ctx *sql.Context, n sql.Node) (sql.Node, error) {
 	return se.engine.Analyzer.Analyze(ctx, n, nil)
-}
-
-// TODO: All of this logic should be moved to the engine...
-func (se *SqlEngine) Dbddl(ctx *sql.Context, dbddl *sqlparser.DBDDL, query string) (sql.Schema, sql.RowIter, error) {
-	action := strings.ToLower(dbddl.Action)
-	var rowIter sql.RowIter = nil
-	var err error = nil
-
-	if action != sqlparser.CreateStr && action != sqlparser.DropStr {
-		return nil, nil, fmt.Errorf("Unhandled DBDDL action %v in Query %v", action, query)
-	}
-
-	if action == sqlparser.DropStr {
-		// Should not be allowed to delete repo name and information schema
-		if dbddl.DBName == sql.InformationSchemaDatabaseName {
-			return nil, nil, fmt.Errorf("DROP DATABASE isn't supported for database %s", sql.InformationSchemaDatabaseName)
-		}
-	}
-
-	sch, rowIter, err := se.Query(ctx, query)
-
-	if rowIter != nil {
-		err = rowIter.Close(ctx)
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return sch, nil, nil
 }
 
 func (se *SqlEngine) GetUnderlyingEngine() *gms.Engine {

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -205,7 +205,9 @@ func (cmd SqlCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
-	defer closeFunc()
+	if closeFunc != nil {
+		defer closeFunc()
+	}
 
 	if query, queryOK := apr.GetValue(QueryFlag); queryOK {
 		if apr.Contains(saveFlag) {

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -1017,7 +1017,7 @@ func processParsedQuery(ctx *sql.Context, query string, qryist cli.Queryist, sql
 		return nil, nil, nil
 	case *sqlparser.DBDDL:
 		if se, ok := qryist.(*engine.SqlEngine); ok {
-			// NM4 refactor this out
+			// NM4 TODO refactor this out. Dbddl is a special case which is no longer needed. Breaks tests if we naively drop it tho.
 			return se.Dbddl(ctx, s, query)
 		}
 		return nil, nil, fmt.Errorf("unsupported statement: %s", query)

--- a/go/cmd/dolt/commands/sql_test.go
+++ b/go/cmd/dolt/commands/sql_test.go
@@ -43,19 +43,22 @@ import (
 
 var tableName = "people"
 
-var stubCliCtx = BuildEmptyCliContext()
-
 // Smoke test: Console opens and exits
 func TestSqlConsole(t *testing.T) {
 	t.Run("SQL console opens and exits", func(t *testing.T) {
+		ctx := context.TODO()
+
 		dEnv, err := sqle.CreateEnvWithSeedData()
 		require.NoError(t, err)
 		defer dEnv.DoltDB.Close()
 
+		cliCtx, err := NewArgFreeCliContext(ctx, dEnv)
+		require.NoError(t, err)
+
 		args := []string{}
 		commandStr := "dolt sql"
 
-		result := SqlCmd{}.Exec(context.TODO(), commandStr, args, dEnv, stubCliCtx)
+		result := SqlCmd{}.Exec(ctx, commandStr, args, dEnv, cliCtx)
 		assert.Equal(t, 0, result)
 	})
 
@@ -76,14 +79,19 @@ func TestSqlBatchMode(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.query, func(t *testing.T) {
+			ctx := context.TODO()
+
 			dEnv, err := sqle.CreateEnvWithSeedData()
 			require.NoError(t, err)
 			defer dEnv.DoltDB.Close()
 
+			cliCtx, err := NewArgFreeCliContext(ctx, dEnv)
+			require.NoError(t, err)
+
 			args := []string{"-b", "-q", test.query}
 
 			commandStr := "dolt sql"
-			result := SqlCmd{}.Exec(context.TODO(), commandStr, args, dEnv, stubCliCtx)
+			result := SqlCmd{}.Exec(ctx, commandStr, args, dEnv, cliCtx)
 			assert.Equal(t, test.expectedRes, result)
 		})
 	}
@@ -115,14 +123,18 @@ func TestSqlSelect(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.query, func(t *testing.T) {
+			ctx := context.TODO()
 			dEnv, err := sqle.CreateEnvWithSeedData()
 			require.NoError(t, err)
 			defer dEnv.DoltDB.Close()
 
+			cliCtx, err := NewArgFreeCliContext(ctx, dEnv)
+			require.NoError(t, err)
+
 			args := []string{"-q", test.query}
 
 			commandStr := "dolt sql"
-			result := SqlCmd{}.Exec(context.TODO(), commandStr, args, dEnv, stubCliCtx)
+			result := SqlCmd{}.Exec(ctx, commandStr, args, dEnv, cliCtx)
 			assert.Equal(t, test.expectedRes, result)
 		})
 	}
@@ -141,14 +153,18 @@ func TestSqlShow(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.query, func(t *testing.T) {
+			ctx := context.TODO()
 			dEnv, err := sqle.CreateEnvWithSeedData()
 			require.NoError(t, err)
 			defer dEnv.DoltDB.Close()
 
+			cliCtx, err := NewArgFreeCliContext(ctx, dEnv)
+			require.NoError(t, err)
+
 			args := []string{"-q", test.query}
 
 			commandStr := "dolt sql"
-			result := SqlCmd{}.Exec(context.TODO(), commandStr, args, dEnv, stubCliCtx)
+			result := SqlCmd{}.Exec(ctx, commandStr, args, dEnv, cliCtx)
 			assert.Equal(t, test.expectedRes, result)
 		})
 	}
@@ -171,6 +187,8 @@ func TestCreateTable(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.query, func(t *testing.T) {
+			ctx := context.TODO()
+
 			dEnv := dtestutils.CreateTestEnv()
 			defer dEnv.DoltDB.Close()
 			working, err := dEnv.WorkingRoot(context.Background())
@@ -179,9 +197,12 @@ func TestCreateTable(t *testing.T) {
 			assert.NoError(t, err)
 			assert.False(t, has, "table exists before creating it")
 
+			cliCtx, err := NewArgFreeCliContext(ctx, dEnv)
+			require.NoError(t, err)
+
 			args := []string{"-q", test.query}
 			commandStr := "dolt sql"
-			result := SqlCmd{}.Exec(context.TODO(), commandStr, args, dEnv, stubCliCtx)
+			result := SqlCmd{}.Exec(ctx, commandStr, args, dEnv, cliCtx)
 			assert.Equal(t, test.expectedRes, result)
 
 			working, err = dEnv.WorkingRoot(context.Background())
@@ -215,13 +236,17 @@ func TestShowTables(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.query, func(t *testing.T) {
+			ctx := context.TODO()
 			dEnv, err := sqle.CreateEnvWithSeedData()
 			require.NoError(t, err)
 			defer dEnv.DoltDB.Close()
 
+			cliCtx, err := NewArgFreeCliContext(ctx, dEnv)
+			require.NoError(t, err)
+
 			args := []string{"-q", test.query}
 			commandStr := "dolt sql"
-			result := SqlCmd{}.Exec(context.TODO(), commandStr, args, dEnv, stubCliCtx)
+			result := SqlCmd{}.Exec(ctx, commandStr, args, dEnv, cliCtx)
 			assert.Equal(t, test.expectedRes, result)
 		})
 	}
@@ -246,13 +271,18 @@ func TestAlterTable(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.query, func(t *testing.T) {
+			ctx := context.TODO()
+
 			dEnv, err := sqle.CreateEnvWithSeedData()
 			require.NoError(t, err)
 			defer dEnv.DoltDB.Close()
 
+			cliCtx, err := NewArgFreeCliContext(ctx, dEnv)
+			require.NoError(t, err)
+
 			args := []string{"-q", test.query}
 			commandStr := "dolt sql"
-			result := SqlCmd{}.Exec(context.TODO(), commandStr, args, dEnv, stubCliCtx)
+			result := SqlCmd{}.Exec(ctx, commandStr, args, dEnv, cliCtx)
 			assert.Equal(t, test.expectedRes, result)
 		})
 	}
@@ -273,13 +303,17 @@ func TestDropTable(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.query, func(t *testing.T) {
+			ctx := context.TODO()
 			dEnv, err := sqle.CreateEnvWithSeedData()
 			require.NoError(t, err)
 			defer dEnv.DoltDB.Close()
 
+			cliCtx, err := NewArgFreeCliContext(ctx, dEnv)
+			require.NoError(t, err)
+
 			args := []string{"-q", test.query}
 			commandStr := "dolt sql"
-			result := SqlCmd{}.Exec(context.TODO(), commandStr, args, dEnv, stubCliCtx)
+			result := SqlCmd{}.Exec(ctx, commandStr, args, dEnv, cliCtx)
 			assert.Equal(t, test.expectedRes, result)
 		})
 	}
@@ -395,10 +429,13 @@ func TestInsert(t *testing.T) {
 			require.NoError(t, err)
 			defer dEnv.DoltDB.Close()
 
+			cliCtx, err := NewArgFreeCliContext(ctx, dEnv)
+			require.NoError(t, err)
+
 			args := []string{"-q", test.query}
 
 			commandStr := "dolt sql"
-			result := SqlCmd{}.Exec(ctx, commandStr, args, dEnv, stubCliCtx)
+			result := SqlCmd{}.Exec(ctx, commandStr, args, dEnv, cliCtx)
 			assert.Equal(t, test.expectedRes, result)
 
 			if result == 0 {
@@ -476,10 +513,13 @@ func TestUpdate(t *testing.T) {
 			require.NoError(t, err)
 			defer dEnv.DoltDB.Close()
 
+			cliCtx, err := NewArgFreeCliContext(ctx, dEnv)
+			require.NoError(t, err)
+
 			args := []string{"-q", test.query}
 
 			commandStr := "dolt sql"
-			result := SqlCmd{}.Exec(ctx, commandStr, args, dEnv, stubCliCtx)
+			result := SqlCmd{}.Exec(ctx, commandStr, args, dEnv, cliCtx)
 			assert.Equal(t, test.expectedRes, result)
 
 			if result == 0 {
@@ -546,15 +586,18 @@ func TestDelete(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.query, func(t *testing.T) {
+			ctx := context.Background()
 			dEnv, err := sqle.CreateEnvWithSeedData()
 			require.NoError(t, err)
 			defer dEnv.DoltDB.Close()
 
+			cliCtx, err := NewArgFreeCliContext(ctx, dEnv)
+			require.NoError(t, err)
+
 			args := []string{"-q", test.query}
 
-			ctx := context.Background()
 			commandStr := "dolt sql"
-			result := SqlCmd{}.Exec(ctx, commandStr, args, dEnv, stubCliCtx)
+			result := SqlCmd{}.Exec(ctx, commandStr, args, dEnv, cliCtx)
 			assert.Equal(t, test.expectedRes, result)
 
 			if result == 0 {

--- a/go/cmd/dolt/commands/utils.go
+++ b/go/cmd/dolt/commands/utils.go
@@ -17,17 +17,17 @@ package commands
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+
+	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
-	"github.com/dolthub/dolt/go/libraries/utils/argparser"
-	"github.com/dolthub/go-mysql-server/sql"
-	"path/filepath"
-
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
+	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 )
 
 var fwtStageName = "fwt"

--- a/go/cmd/dolt/commands/utils.go
+++ b/go/cmd/dolt/commands/utils.go
@@ -178,7 +178,7 @@ func newLateBindingEngine(
 		PrivFilePath:       privsFp,
 		BranchCtrlFilePath: branchControlFilePath,
 		ServerUser:         username,
-		ServerHost:         "localhost", // NM4 - was a const before. shrug?
+		ServerHost:         "localhost",
 		Autocommit:         true,
 	}
 

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -307,11 +307,19 @@ func runMain() int {
 				args = args[1:]
 
 			case featureVersionFlag:
-				if featureVersion, err := strconv.Atoi(args[1]); err == nil {
-					doltdb.DoltFeatureVersion = doltdb.FeatureVersion(featureVersion)
+				var err error
+				if len(args) == 0 {
+					err = fmt.Errorf("missing argument for the --feature-version flag")
 				} else {
-					panic(err)
+					if featureVersion, err := strconv.Atoi(args[1]); err == nil {
+						doltdb.DoltFeatureVersion = doltdb.FeatureVersion(featureVersion)
+					}
 				}
+				if err != nil {
+					cli.PrintErrln(err.Error())
+					return 1
+				}
+
 				args = args[2:]
 
 			default:

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -19,6 +19,7 @@ import (
 	crand "crypto/rand"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"math/rand"
 	"net/http"
 	_ "net/http/pprof"
@@ -431,7 +432,18 @@ func runMain() int {
 		_, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString("dolt", doc, globalArgParser))
 		apr := cli.ParseArgsOrDie(globalArgParser, globalArgs, usage)
 
-		cliCtx = tmpCliContext{globalArgs: apr}
+		lateBind, err := commands.BuildSqlEngineQueryist(ctx, dEnv, apr)
+		if err != nil {
+			cli.PrintErrln(color.RedString("Failure to Load SQL Engine: %v", err))
+			return 1
+		}
+
+		cliCtx, err = cli.BuildCliContext(apr, lateBind)
+		if err != nil {
+			cli.PrintErrln(color.RedString("Unexpected Error: %v", err))
+			return 1
+		}
+
 	}
 
 	res := doltCommand.Exec(ctx, "dolt", args, dEnv, cliCtx)
@@ -452,18 +464,6 @@ func runMain() int {
 
 	return res
 }
-
-// tmpCliContext is a temporary implementation of the CliContext interface. It is used to pass the global args to the
-// subcommands, will be replaced with implementations aware of query contexts shortly.
-type tmpCliContext struct {
-	globalArgs *argparser.ArgParseResults
-}
-
-func (t tmpCliContext) GlobalArgs() *argparser.ArgParseResults {
-	return t.globalArgs
-}
-
-var _ cli.CliContext = (*tmpCliContext)(nil)
 
 // splitArgsOnSubCommand splits the args into two slices, the first containing all args before the first subcommand,
 // and the second containing all args after the first subcommand. The second slice will start with the subcommand name.
@@ -552,7 +552,11 @@ func buildGlobalArgs() *argparser.ArgParser {
 	ap := argparser.NewArgParserWithVariableArgs("dolt")
 
 	// Pulling this argument forward first to pave the way. Others will follow.
+	ap.SupportsString(commands.UserFlag, "u", "user", fmt.Sprintf("Defines the local superuser (defaults to `%v`). If the specified user exists, will take on permissions of that user.", commands.DefaultUser))
 	ap.SupportsString(commands.DataDirFlag, "", "directory", "Defines a directory whose subdirectories should all be dolt data repositories accessible as independent databases within. Defaults to the current directory.")
+	ap.SupportsString(commands.CfgDirFlag, "", "directory", "Defines a directory that contains configuration files for dolt. Defaults to `$data-dir/.doltcfg`. Will only be created if there is a change that affect configuration settings.")
+	ap.SupportsString(commands.PrivsFilePathFlag, "", "privilege file", "Path to a file to load and store users and grants. Defaults to `$doltcfg-dir/privileges.db`. Will only be created if there is a change to privileges.")
+	ap.SupportsString(commands.BranchCtrlPathFlag, "", "branch control file", "Path to a file to load and store branch control permissions. Defaults to `$doltcfg-dir/branch_control.db`. Will only be created if there is a change to branch control permissions.")
 
 	return ap
 }

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -446,7 +446,7 @@ func runMain() int {
 			return 1
 		}
 
-		cliCtx, err = cli.BuildCliContext(apr, lateBind)
+		cliCtx, err = cli.NewCliContext(apr, lateBind)
 		if err != nil {
 			cli.PrintErrln(color.RedString("Unexpected Error: %v", err))
 			return 1

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -562,7 +562,7 @@ func buildGlobalArgs() *argparser.ArgParser {
 	// Pulling this argument forward first to pave the way. Others will follow.
 	ap.SupportsString(commands.UserFlag, "u", "user", fmt.Sprintf("Defines the local superuser (defaults to `%v`). If the specified user exists, will take on permissions of that user.", commands.DefaultUser))
 	ap.SupportsString(commands.DataDirFlag, "", "directory", "Defines a directory whose subdirectories should all be dolt data repositories accessible as independent databases within. Defaults to the current directory.")
-	ap.SupportsString(commands.CfgDirFlag, "", "directory", "Defines a directory that contains configuration files for dolt. Defaults to `$data-dir/.doltcfg`. Will only be created if there is a change that affect configuration settings.")
+	ap.SupportsString(commands.CfgDirFlag, "", "directory", "Defines a directory that contains configuration files for dolt. Defaults to `$data-dir/.doltcfg`. Will only be created if there is a change to configuration settings.")
 	ap.SupportsString(commands.PrivsFilePathFlag, "", "privilege file", "Path to a file to load and store users and grants. Defaults to `$doltcfg-dir/privileges.db`. Will only be created if there is a change to privileges.")
 	ap.SupportsString(commands.BranchCtrlPathFlag, "", "branch control file", "Path to a file to load and store branch control permissions. Defaults to `$doltcfg-dir/branch_control.db`. Will only be created if there is a change to branch control permissions.")
 

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -155,6 +155,8 @@ func main() {
 func runMain() int {
 	args := os.Args[1:]
 
+	start := time.Now()
+
 	if len(args) == 0 {
 		doltCommand.PrintUsage("dolt")
 		return 1
@@ -432,9 +434,6 @@ func runMain() int {
 		return 1
 	}
 
-	start := time.Now()
-	ctx, stop := context.WithCancel(ctx)
-
 	var cliCtx cli.CliContext = nil
 	if initCliContext {
 		_, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString("dolt", doc, globalArgParser))
@@ -454,6 +453,7 @@ func runMain() int {
 
 	}
 
+	ctx, stop := context.WithCancel(ctx)
 	res := doltCommand.Exec(ctx, "dolt", args, dEnv, cliCtx)
 	stop()
 

--- a/go/libraries/doltcore/doltdb/feature_version_test.go
+++ b/go/libraries/doltcore/doltdb/feature_version_test.go
@@ -58,7 +58,10 @@ func (cmd fvCommand) exec(ctx context.Context, dEnv *env.DoltEnv) int {
 	// execute the command using |cmd.user|'s Feature Version
 	doltdb.DoltFeatureVersion = cmd.user.vers
 	defer func() { doltdb.DoltFeatureVersion = DoltFeatureVersionCopy }()
-	return cmd.cmd.Exec(ctx, cmd.cmd.Name(), cmd.args, dEnv, commands.BuildEmptyCliContext())
+
+	cliCtx, _ := commands.NewArgFreeCliContext(ctx, dEnv)
+
+	return cmd.cmd.Exec(ctx, cmd.cmd.Name(), cmd.args, dEnv, cliCtx)
 }
 
 type fvUser struct {

--- a/go/libraries/doltcore/doltdb/foreign_key_test.go
+++ b/go/libraries/doltcore/doltdb/foreign_key_test.go
@@ -37,8 +37,6 @@ func TestForeignKeys(t *testing.T) {
 	}
 }
 
-var fkCliCtx = commands.BuildEmptyCliContext()
-
 func TestForeignKeyErrors(t *testing.T) {
 	skipNewFormat(t)
 	cmds := []testCommand{
@@ -49,15 +47,17 @@ func TestForeignKeyErrors(t *testing.T) {
 
 	ctx := context.Background()
 	dEnv := dtestutils.CreateTestEnv()
+	cliCtx, err := commands.NewArgFreeCliContext(ctx, dEnv)
+	require.NoError(t, err)
 
 	for _, c := range cmds {
-		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, fkCliCtx)
+		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)
 		require.Equal(t, 0, exitCode)
 	}
 
-	exitCode := commands.SqlCmd{}.Exec(ctx, commands.SqlCmd{}.Name(), []string{"-q", `ALTER TABLE test MODIFY v1 INT;`}, dEnv, fkCliCtx)
+	exitCode := commands.SqlCmd{}.Exec(ctx, commands.SqlCmd{}.Name(), []string{"-q", `ALTER TABLE test MODIFY v1 INT;`}, dEnv, cliCtx)
 	require.Equal(t, 1, exitCode)
-	exitCode = commands.SqlCmd{}.Exec(ctx, commands.SqlCmd{}.Name(), []string{"-q", `ALTER TABLE test2 MODIFY v1 INT;`}, dEnv, fkCliCtx)
+	exitCode = commands.SqlCmd{}.Exec(ctx, commands.SqlCmd{}.Name(), []string{"-q", `ALTER TABLE test2 MODIFY v1 INT;`}, dEnv, cliCtx)
 
 	require.Equal(t, 1, exitCode)
 }
@@ -98,12 +98,15 @@ func testForeignKeys(t *testing.T, test foreignKeyTest) {
 	ctx := context.Background()
 	dEnv := dtestutils.CreateTestEnv()
 
+	cliCtx, verr := commands.NewArgFreeCliContext(ctx, dEnv)
+	require.NoError(t, verr)
+
 	for _, c := range fkSetupCommon {
-		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, fkCliCtx)
+		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)
 		require.Equal(t, 0, exitCode)
 	}
 	for _, c := range test.setup {
-		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, fkCliCtx)
+		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)
 		require.Equal(t, 0, exitCode)
 	}
 

--- a/go/libraries/doltcore/doltdb/gc_test.go
+++ b/go/libraries/doltcore/doltdb/gc_test.go
@@ -55,8 +55,6 @@ type gcTest struct {
 	postGCFunc func(ctx context.Context, t *testing.T, ddb *doltdb.DoltDB, prevRes interface{})
 }
 
-var gcCliCtx = commands.BuildEmptyCliContext()
-
 var gcTests = []gcTest{
 	{
 		name: "gc test",
@@ -114,8 +112,11 @@ func testGarbageCollection(t *testing.T, test gcTest) {
 	dEnv := dtestutils.CreateTestEnv()
 	defer dEnv.DoltDB.Close()
 
+	cliCtx, verr := commands.NewArgFreeCliContext(ctx, dEnv)
+	require.NoError(t, verr)
+
 	for _, c := range gcSetupCommon {
-		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, gcCliCtx)
+		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)
 		require.Equal(t, 0, exitCode)
 	}
 
@@ -123,7 +124,7 @@ func testGarbageCollection(t *testing.T, test gcTest) {
 	for _, stage := range test.stages {
 		res = stage.preStageFunc(ctx, t, dEnv.DoltDB, res)
 		for _, c := range stage.commands {
-			exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, gcCliCtx)
+			exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)
 			require.Equal(t, 0, exitCode)
 		}
 	}

--- a/go/libraries/doltcore/merge/keyless_integration_test.go
+++ b/go/libraries/doltcore/merge/keyless_integration_test.go
@@ -114,9 +114,11 @@ func TestKeylessMerge(t *testing.T) {
 			require.NoError(t, err)
 			err = dEnv.UpdateWorkingRoot(ctx, root)
 			require.NoError(t, err)
+			cliCtx, err := cmd.NewArgFreeCliContext(ctx, dEnv)
+			require.NoError(t, err)
 
 			for _, c := range test.setup {
-				exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cmd.BuildEmptyCliContext())
+				exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)
 				require.Equal(t, 0, exitCode)
 			}
 
@@ -247,9 +249,11 @@ func TestKeylessMergeConflicts(t *testing.T) {
 		require.NoError(t, err)
 		err = dEnv.UpdateWorkingRoot(ctx, root)
 		require.NoError(t, err)
+		cliCtx, err := cmd.NewArgFreeCliContext(ctx, dEnv)
+		require.NoError(t, err)
 
 		for _, c := range cc {
-			exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cmd.BuildEmptyCliContext())
+			exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)
 			// allow merge to fail with conflicts
 			if _, ok := c.cmd.(cmd.MergeCmd); !ok {
 				require.Equal(t, 0, exitCode)

--- a/go/libraries/doltcore/merge/schema_integration_test.go
+++ b/go/libraries/doltcore/merge/schema_integration_test.go
@@ -40,7 +40,9 @@ type testCommand struct {
 }
 
 func (tc testCommand) exec(t *testing.T, ctx context.Context, dEnv *env.DoltEnv) int {
-	return tc.cmd.Exec(ctx, tc.cmd.Name(), tc.args, dEnv, commands.BuildEmptyCliContext())
+	cliCtx, err := commands.NewArgFreeCliContext(ctx, dEnv)
+	require.NoError(t, err)
+	return tc.cmd.Exec(ctx, tc.cmd.Name(), tc.args, dEnv, cliCtx)
 }
 
 type args []string

--- a/go/libraries/doltcore/migrate/integration_test.go
+++ b/go/libraries/doltcore/migrate/integration_test.go
@@ -170,10 +170,12 @@ func setupMigrationTest(t *testing.T, ctx context.Context, test migrationTest) *
 		dEnv, err = test.hook(ctx, dEnv)
 		require.NoError(t, err)
 	}
+	cliCtx, err := commands.NewArgFreeCliContext(ctx, dEnv)
+	require.NoError(t, err)
 
 	cmd := commands.SqlCmd{}
 	for _, query := range test.setup {
-		code := cmd.Exec(ctx, cmd.Name(), []string{"-q", query}, dEnv, commands.BuildEmptyCliContext())
+		code := cmd.Exec(ctx, cmd.Name(), []string{"-q", query}, dEnv, cliCtx)
 		require.Equal(t, 0, code)
 	}
 	return dEnv

--- a/go/libraries/doltcore/rebase/filter_branch_test.go
+++ b/go/libraries/doltcore/rebase/filter_branch_test.go
@@ -55,8 +55,6 @@ type testAssertion struct {
 	rows  []sql.Row
 }
 
-var cliCtx = cmd.BuildEmptyCliContext()
-
 var setupCommon = []testCommand{
 	{cmd.SqlCmd{}, args{"-q",
 		`create table test (
@@ -204,6 +202,9 @@ func filterBranchTests() []filterBranchTest {
 func setupFilterBranchTests(t *testing.T) *env.DoltEnv {
 	ctx := context.Background()
 	dEnv := dtestutils.CreateTestEnv()
+	cliCtx, err := cmd.NewArgFreeCliContext(ctx, dEnv)
+	require.NoError(t, err)
+
 	for _, c := range setupCommon {
 		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)
 		require.Equal(t, 0, exitCode)
@@ -216,6 +217,9 @@ func testFilterBranch(t *testing.T, test filterBranchTest) {
 	ctx := context.Background()
 	dEnv := setupFilterBranchTests(t)
 	defer dEnv.DoltDB.Close()
+	cliCtx, err := cmd.NewArgFreeCliContext(ctx, dEnv)
+	require.NoError(t, err)
+
 	for _, c := range test.setup {
 		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)
 		require.Equal(t, 0, exitCode)

--- a/go/libraries/doltcore/schema/integration_test.go
+++ b/go/libraries/doltcore/schema/integration_test.go
@@ -176,8 +176,11 @@ func TestGetKeyTags(t *testing.T) {
 func runTestSql(t *testing.T, ctx context.Context, setup []string) (*doltdb.DoltDB, *doltdb.RootValue) {
 	dEnv := dtestutils.CreateTestEnv()
 	cmd := commands.SqlCmd{}
+	cliCtx, verr := commands.NewArgFreeCliContext(ctx, dEnv)
+	require.NoError(t, verr)
+
 	for _, query := range setup {
-		code := cmd.Exec(ctx, cmd.Name(), []string{"-q", query}, dEnv, commands.BuildEmptyCliContext())
+		code := cmd.Exec(ctx, cmd.Name(), []string{"-q", query}, dEnv, cliCtx)
 		require.Equal(t, 0, code)
 	}
 	root, err := dEnv.WorkingRoot(ctx)

--- a/go/libraries/doltcore/sqle/integration_test/database_revision_test.go
+++ b/go/libraries/doltcore/sqle/integration_test/database_revision_test.go
@@ -152,9 +152,11 @@ func TestDbRevision(t *testing.T) {
 			dEnv := dtestutils.CreateTestEnv()
 			defer dEnv.DoltDB.Close()
 
+			cliCtx, _ := cmd.NewArgFreeCliContext(ctx, dEnv)
+
 			setup := append(setupCommon, test.setup...)
 			for _, c := range setup {
-				exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cmd.BuildEmptyCliContext())
+				exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)
 				require.Equal(t, 0, exitCode)
 			}
 

--- a/go/libraries/doltcore/sqle/integration_test/history_table_test.go
+++ b/go/libraries/doltcore/sqle/integration_test/history_table_test.go
@@ -212,8 +212,11 @@ var INIT = ""   // HEAD~4
 func setupHistoryTests(t *testing.T) *env.DoltEnv {
 	ctx := context.Background()
 	dEnv := dtestutils.CreateTestEnv()
+	cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv)
+	require.NoError(t, verr)
+
 	for _, c := range setupCommon {
-		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cmd.BuildEmptyCliContext())
+		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)
 		require.Equal(t, 0, exitCode)
 	}
 
@@ -236,8 +239,11 @@ func setupHistoryTests(t *testing.T) *env.DoltEnv {
 
 func testHistoryTable(t *testing.T, test historyTableTest, dEnv *env.DoltEnv) {
 	ctx := context.Background()
+	cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv)
+	require.NoError(t, verr)
+
 	for _, c := range test.setup {
-		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cmd.BuildEmptyCliContext())
+		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)
 		require.Equal(t, 0, exitCode)
 	}
 

--- a/go/libraries/doltcore/sqle/integration_test/json_value_test.go
+++ b/go/libraries/doltcore/sqle/integration_test/json_value_test.go
@@ -126,10 +126,12 @@ func TestJsonValues(t *testing.T) {
 func testJsonValue(t *testing.T, test jsonValueTest, setupCommon []testCommand) {
 	ctx := context.Background()
 	dEnv := dtestutils.CreateTestEnv()
+	cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv)
+	require.NoError(t, verr)
 
 	setup := append(setupCommon, test.setup...)
 	for _, c := range setup {
-		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cmd.BuildEmptyCliContext())
+		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)
 		require.Equal(t, 0, exitCode)
 	}
 

--- a/go/libraries/utils/argparser/results.go
+++ b/go/libraries/utils/argparser/results.go
@@ -50,6 +50,11 @@ func (res *ArgParseResults) Equals(other *ArgParseResults) bool {
 	return true
 }
 
+// NewEmptyResults creates a new ArgParseResults object with no arguments or options. Mostly useful for testing.
+func NewEmptyResults() *ArgParseResults {
+	return &ArgParseResults{options: make(map[string]string), Args: make([]string, 0)}
+}
+
 func (res *ArgParseResults) Contains(name string) bool {
 	_, ok := res.options[name]
 	return ok

--- a/go/performance/microsysbench/sysbench_test.go
+++ b/go/performance/microsysbench/sysbench_test.go
@@ -140,7 +140,12 @@ func populateRepo(dEnv *env.DoltEnv, insertData string) {
 	execSql := func(dEnv *env.DoltEnv, q string) int {
 		ctx := context.Background()
 		args := []string{"-r", "null", "-q", q}
-		return commands.SqlCmd{}.Exec(ctx, "sql", args, dEnv, commands.BuildEmptyCliContext())
+		cliCtx, err := commands.NewArgFreeCliContext(ctx, dEnv)
+		if err != nil {
+			panic(err)
+		}
+
+		return commands.SqlCmd{}.Exec(ctx, "sql", args, dEnv, cliCtx)
 	}
 	execSql(dEnv, createTable)
 	execSql(dEnv, insertData)

--- a/integration-tests/bats/replication-multidb.bats
+++ b/integration-tests/bats/replication-multidb.bats
@@ -61,25 +61,25 @@ teardown() {
     cd dbs1/repo1
     dolt config --local --add sqlserver.global.dolt_replicate_to_remote unknown
     cd ../..
-    run dolt sql --data-dir=dbs1 -b -q "select @@GLOBAL.dolt_replicate_to_remote"
+    run dolt --data-dir=dbs1 sql -b -q "select @@GLOBAL.dolt_replicate_to_remote"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "remote1" ]] || false
 }
 
 @test "replication-multidb: push on sqlengine commit" {
     dolt config --global --add sqlserver.global.dolt_replicate_to_remote remote1
-    dolt sql --data-dir=dbs1 -b -q "use repo1; create table t1 (a int primary key)"
-    dolt sql --data-dir=dbs1 -b -q "use repo1; call dolt_add('.')"
-    dolt sql --data-dir=dbs1 -b -q "use repo1; call dolt_commit('-am', 'cm')"
-    dolt sql --data-dir=dbs1 -b -q "use repo2; create table t2 (a int primary key)"
-    dolt sql --data-dir=dbs1 -b -q "use repo2; call dolt_add('.')"
-    dolt sql --data-dir=dbs1 -b -q "use repo2; call dolt_commit('-am', 'cm')"
-    dolt sql --data-dir=dbs1 -b -q "use repo3; create table t3 (a int primary key)"
-    dolt sql --data-dir=dbs1 -b -q "use repo3; call dolt_add('.')"
-    dolt sql --data-dir=dbs1 -b -q "use repo3; call dolt_commit('-am', 'cm')"
+    dolt --data-dir= dbs1 sql -b -q "use repo1; create table t1 (a int primary key)"
+    dolt --data-dir= dbs1 sql -b -q "use repo1; call dolt_add('.')"
+    dolt --data-dir= dbs1 sql -b -q "use repo1; call dolt_commit('-am', 'cm')"
+    dolt --data-dir= dbs1 sql -b -q "use repo2; create table t2 (a int primary key)"
+    dolt --data-dir= dbs1 sql -b -q "use repo2; call dolt_add('.')"
+    dolt --data-dir= dbs1 sql -b -q "use repo2; call dolt_commit('-am', 'cm')"
+    dolt --data-dir= dbs1 sql -b -q "use repo3; create table t3 (a int primary key)"
+    dolt --data-dir= dbs1 sql -b -q "use repo3; call dolt_add('.')"
+    dolt --data-dir= dbs1 sql -b -q "use repo3; call dolt_commit('-am', 'cm')"
     
     clone_helper $TMPDIRS
-    run dolt sql --data-dir=dbs2 -b -q "use repo1; show tables" -r csv
+    run dolt --data-dir=dbs2 sql -b -q "use repo1; show tables" -r csv
 
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" -eq 4 ]
@@ -87,14 +87,14 @@ teardown() {
     [[ ! "$output" =~ "t2" ]] || false
     [[ ! "$output" =~ "t3" ]] || false
 
-    run dolt sql --data-dir=dbs2 -b -q "use repo2; show tables" -r csv
+    run dolt --data-dir=dbs2 sql -b -q "use repo2; show tables" -r csv
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" -eq 4 ]
     [[ "$output" =~ "t2" ]] || false
     [[ ! n"$output" =~ "t1" ]] || false
     [[ ! "$output" =~ "t3" ]] || faalse
 
-    run dolt sql --data-dir=dbs2 -b -q "use repo3; show tables" -r csv
+    run dolt --data-dir=dbs2 sql -b -q "use repo3; show tables" -r csv
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" -eq 4 ]
     [[ "$output" =~ "t3" ]] || false
@@ -106,7 +106,7 @@ teardown() {
     dolt config --global --add sqlserver.global.dolt_replicate_to_remote remote1
     dolt sql -q "set @@persist.dolt_replication_remote_url_template = 'file://$TMPDIRS/rem1/{database}'"
 
-    dolt sql --data-dir=dbs1 <<SQL
+    dolt --data-dir=dbs1 sql <<SQL
 create database newdb;
 use newdb;
 create table new_table (b int primary key);
@@ -123,7 +123,7 @@ SQL
     # TODO: fix this mess
     dolt config --global --unset sqlserver.global.dolt_replicate_to_remote
     
-    run dolt sql --data-dir=dbs2 -q "use newdb; show tables" -r csv
+    run dolt --data-dir=dbs2 sql -q "use newdb; show tables" -r csv
     [ $status -eq 0 ]
     [ "${#lines[@]}" -eq 3 ]
     [[ "$output" =~ "new_table" ]] || false
@@ -147,7 +147,7 @@ SQL
     dolt sql -q "set @@persist.dolt_replication_remote_url_template = 'file://$TMPDIRS/rem2/{database}'"
 
     mkdir -p "${TMPDIRS}/dbs2"
-    dolt sql --data-dir=dbs2 <<SQL
+    dolt --data-dir=dbs2 sql <<SQL
 call dolt_clone('file://${TMPDIRS}/rem1/repo1', 'repo1');
 use repo1;
 create table new_table (b int primary key);
@@ -165,12 +165,12 @@ SQL
     # TODO: fix this mess
     dolt config --global --unset sqlserver.global.dolt_replicate_to_remote
     
-    run dolt sql --data-dir=dbs3 -q "use repo1; show tables" -r csv
+    run dolt --data-dir=dbs3 sql -q "use repo1; show tables" -r csv
     [ $status -eq 0 ]
     [ "${#lines[@]}" -eq 3 ]
     [[ "$output" =~ "new_table" ]] || false
 
-    run dolt sql --data-dir=dbs3 -q "use repo2; show tables" -r csv
+    run dolt --data-dir=dbs3 sql -q "use repo2; show tables" -r csv
     [ $status -eq 0 ]
     [ "${#lines[@]}" -eq 2 ]
     [[ ! "$output" =~ "new_table" ]] || false
@@ -180,7 +180,7 @@ SQL
     dolt config --global --add sqlserver.global.dolt_replicate_to_remote remote1
     dolt sql -q "set @@persist.dolt_replication_remote_url_template = 'file://$TMPDIRS/rem1/{database}'"
 
-    dolt sql --data-dir=dbs1 -q "create database newdb;"
+    dolt --data-dir=dbs1 sql -q "create database newdb;"
 
     mkdir -p "${TMPDIRS}/dbs2"
     cd $TMPDIRS
@@ -191,22 +191,22 @@ SQL
     # mess
     dolt config --global --unset sqlserver.global.dolt_replicate_to_remote
     
-    run dolt sql --data-dir=dbs2 -q "use newdb; show tables" -r csv
+    run dolt --data-dir=dbs2 sql -q "use newdb; show tables" -r csv
     [ $status -eq 0 ]
     [ "${#lines[@]}" -eq 2 ]
 }
 
 @test "replication-multidb: pull on read" {
     push_helper $TMPDIRS
-    dolt sql --data-dir=dbs1 -b -q "use repo1; create table t1 (a int primary key)"
-    dolt sql --data-dir=dbs1 -b -q "use repo1; call dolt_add('.')"
-    dolt sql --data-dir=dbs1 -b -q "use repo1; call dolt_commit('-am', 'cm')"
-    dolt sql --data-dir=dbs1 -b -q "use repo2; create table t2 (a int primary key)"
-    dolt sql --data-dir=dbs1 -b -q "use repo2; call dolt_add('.')"
-    dolt sql --data-dir=dbs1 -b -q "use repo2; call dolt_commit('-am', 'cm')"
-    dolt sql --data-dir=dbs1 -b -q "use repo3; create table t3 (a int primary key)"
-    dolt sql --data-dir=dbs1 -b -q "use repo3; call dolt_add('.')"
-    dolt sql --data-dir=dbs1 -b -q "use repo3; call dolt_commit('-am', 'cm')"
+    dolt --data-dir=dbs1 sql -b -q "use repo1; create table t1 (a int primary key)"
+    dolt --data-dir=dbs1 sql -b -q "use repo1; call dolt_add('.')"
+    dolt --data-dir=dbs1 sql -b -q "use repo1; call dolt_commit('-am', 'cm')"
+    dolt --data-dir=dbs1 sql -b -q "use repo2; create table t2 (a int primary key)"
+    dolt --data-dir=dbs1 sql -b -q "use repo2; call dolt_add('.')"
+    dolt --data-dir=dbs1 sql -b -q "use repo2; call dolt_commit('-am', 'cm')"
+    dolt --data-dir=dbs1 sql -b -q "use repo3; create table t3 (a int primary key)"
+    dolt --data-dir=dbs1 sql -b -q "use repo3; call dolt_add('.')"
+    dolt --data-dir=dbs1 sql -b -q "use repo3; call dolt_commit('-am', 'cm')"
 
     clone_helper $TMPDIRS
     push_helper $TMPDIRS
@@ -214,21 +214,21 @@ SQL
     dolt config --global --add sqlserver.global.dolt_read_replica_remote remote1
     dolt config --global --add sqlserver.global.dolt_replicate_heads main
 
-    run dolt sql --data-dir=dbs2 -b -q "use repo1; show tables" -r csv
+    run dolt --data-dir=dbs2 sql -b -q "use repo1; show tables" -r csv
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" -eq 4 ]
     [[ "$output" =~ "t1" ]] || false
     [[ ! "$output" =~ "t2" ]] || false
     [[ ! "$output" =~ "t3" ]] || false
 
-    run dolt sql --data-dir=dbs2 -b -q "use repo2; show tables" -r csv
+    run dolt --data-dir=dbs2 sql -b -q "use repo2; show tables" -r csv
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" -eq 4 ]
     [[ "$output" =~ "t2" ]] || false
     [[ ! n"$output" =~ "t1" ]] || false
     [[ ! "$output" =~ "t3" ]] || faalse
 
-    run dolt sql --data-dir=dbs2 -b -q "use repo3; show tables" -r csv
+    run dolt --data-dir=dbs2 sql -b -q "use repo3; show tables" -r csv
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" -eq 4 ]
     [[ "$output" =~ "t3" ]] || false
@@ -240,7 +240,7 @@ SQL
     dolt config --global --add sqlserver.global.dolt_replicate_to_remote remote1
     dolt sql -q "set @@persist.dolt_replication_remote_url_template = 'file://$TMPDIRS/rem1/{database}'"
 
-    dolt sql --data-dir=dbs1 <<SQL
+    dolt --data-dir=dbs1 sql <<SQL
 create database newdb;
 use newdb;
 create table new_table (b int primary key);
@@ -259,20 +259,20 @@ SQL
 
     [ ! -d "dbs2/newdb" ]
     
-    run dolt sql --data-dir=dbs2 -q "use newdb; show tables" -r csv
+    run dolt --data-dir=dbs2 sql -q "use newdb; show tables" -r csv
     [ $status -eq 0 ]
     [[ "$output" =~ "new_table" ]] || false
 
     [ -d "dbs2/newdb" ]
 
-    run dolt sql --data-dir=dbs2 -q "use not_exist; show tables" -r csv
+    run dolt --data-dir=dbs2 sql -q "use not_exist; show tables" -r csv
     [ $status -ne 0 ]
     [[ "$output" =~ "database not found" ]] || false
 }
 
 @test "replication-multidb: missing database config" {
     dolt config --global --add sqlserver.global.dolt_replicate_to_remote unknown
-    run dolt sql --data-dir=dbs1 -b -q "use repo1; create table t1 (a int primary key)"
+    run dolt --data-dir=dbs1 sql -b -q "use repo1; create table t1 (a int primary key)"
     [ "$status" -eq 1 ]
     [[ ! "$output" =~ "panic" ]] || false
     [[ "$output" =~ "remote not found: 'unknown'" ]] || false
@@ -281,7 +281,7 @@ SQL
 @test "replication-multidb: missing database config quiet warning" {
     dolt config --global --add sqlserver.global.dolt_replicate_to_remote unknown
     dolt config --global --add sqlserver.global.dolt_skip_replication_errors 1
-    dolt sql --data-dir=dbs1 -b -q "use repo1; create table t1 (a int primary key)"
+    dolt --data-dir=dbs1 sql -b -q "use repo1; create table t1 (a int primary key)"
 }
 
 @test "replication-multidb: sql-server push on commit" {
@@ -302,21 +302,21 @@ SQL
 
     clone_helper $TMPDIRS
 
-    run dolt sql --data-dir=dbs2 -b -q "use repo1; show tables" -r csv
+    run dolt --data-dir=dbs2 sql -b -q "use repo1; show tables" -r csv
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" -eq 4 ]
     [[ "$output" =~ "t1" ]] || false
     [[ ! "$output" =~ "t2" ]] || false
     [[ ! "$output" =~ "t3" ]] || false
 
-    run dolt sql --data-dir=dbs2 -b -q "use repo2; show tables" -r csv
+    run dolt --data-dir=dbs2 sql -b -q "use repo2; show tables" -r csv
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" -eq 4 ]
     [[ "$output" =~ "t2" ]] || false
     [[ ! n"$output" =~ "t1" ]] || false
     [[ ! "$output" =~ "t3" ]] || faalse
 
-    run dolt sql --data-dir=dbs2 -b -q "use repo3; show tables" -r csv
+    run dolt --data-dir=dbs2 sql -b -q "use repo3; show tables" -r csv
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" -eq 4 ]
     [[ "$output" =~ "t3" ]] || false
@@ -326,15 +326,15 @@ SQL
 
 @test "replication-multidb: sql-server pull on read" {
     push_helper $TMPDIRS
-    dolt sql --data-dir=dbs1 -b -q "use repo1; create table t1 (a int primary key)"
-    dolt sql --data-dir=dbs1 -b -q "use repo1; call dolt_add('.')"
-    dolt sql --data-dir=dbs1 -b -q "use repo1; call dolt_commit('-am', 'cm')"
-    dolt sql --data-dir=dbs1 -b -q "use repo2; create table t2 (a int primary key)"
-    dolt sql --data-dir=dbs1 -b -q "use repo2; call dolt_add('.')"
-    dolt sql --data-dir=dbs1 -b -q "use repo2; call dolt_commit('-am', 'cm')"
-    dolt sql --data-dir=dbs1 -b -q "use repo3; create table t3 (a int primary key)"
-    dolt sql --data-dir=dbs1 -b -q "use repo3; call dolt_add('.')"
-    dolt sql --data-dir=dbs1 -b -q "use repo3; call dolt_commit('-am', 'cm')"
+    dolt --data-dir=dbs1 sql -b -q "use repo1; create table t1 (a int primary key)"
+    dolt --data-dir=dbs1 sql -b -q "use repo1; call dolt_add('.')"
+    dolt --data-dir=dbs1 sql -b -q "use repo1; call dolt_commit('-am', 'cm')"
+    dolt --data-dir=dbs1 sql -b -q "use repo2; create table t2 (a int primary key)"
+    dolt --data-dir=dbs1 sql -b -q "use repo2; call dolt_add('.')"
+    dolt --data-dir=dbs1 sql -b -q "use repo2; call dolt_commit('-am', 'cm')"
+    dolt --data-dir=dbs1 sql -b -q "use repo3; create table t3 (a int primary key)"
+    dolt --data-dir=dbs1 sql -b -q "use repo3; call dolt_add('.')"
+    dolt --data-dir=dbs1 sql -b -q "use repo3; call dolt_commit('-am', 'cm')"
 
     clone_helper $TMPDIRS
     push_helper $TMPDIRS

--- a/integration-tests/bats/sql-create-database.bats
+++ b/integration-tests/bats/sql-create-database.bats
@@ -103,7 +103,7 @@ SQL
 
     mkdir db_dir
     
-    dolt sql --data-dir db_dir <<SQL
+    dolt --data-dir db_dir sql <<SQL
 create database mydb1;
 create database mydb2;
 use mydb1;
@@ -132,12 +132,12 @@ SQL
 
     cd ../../
     
-    dolt sql --data-dir db_dir -q "drop database mydb1"
+    dolt --data-dir db_dir sql -q "drop database mydb1"
     
     [ ! -d db_dir/mydb1 ]
     [ -d db_dir/mydb2 ]
 
-    run dolt sql --data-dir db_dir -q "show databases"
+    run dolt --data-dir db_dir sql -q "show databases"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "mydb2" ]] || false
     [[ ! "$output" =~ "mydb1" ]] || false
@@ -147,7 +147,7 @@ SQL
     absdir="/tmp/$$/db_dir"
     mkdir -p "$absdir"
 
-    dolt sql --data-dir "$absdir" <<SQL
+    dolt --data-dir "$absdir" sql <<SQL
 create database mydb1;
 create database mydb2;
 use mydb1;
@@ -164,7 +164,7 @@ SQL
     [ -d "$absdir/mydb1" ]
     [ -d "$absdir/mydb2" ]
 
-    dolt sql --data-dir "$absdir" -q "drop database mydb1"
+    dolt --data-dir "$absdir" sql -q "drop database mydb1"
 
     [ ! -d "$absdir/mydb1" ]
     [ -d "$absdir/mydb2" ]

--- a/integration-tests/bats/sql-create-tables.bats
+++ b/integration-tests/bats/sql-create-tables.bats
@@ -359,7 +359,7 @@ SQL
     cd workspace
     dolt init
     cd ..
-    dolt sql --data-dir ./ -b -q "USE workspace;CREATE TABLE mytable LIKE otherdb.othertable;"
+    dolt --data-dir ./ sql -b -q "USE workspace;CREATE TABLE mytable LIKE otherdb.othertable;"
     cd workspace
     run dolt schema show mytable
     [ "$status" -eq 0 ]
@@ -705,7 +705,7 @@ SQL
     cd repo2
     dolt init
     cd ..
-    run dolt sql --data-dir ./ -b -q "USE repo2;CREATE TEMPORARY TABLE temp2 LIKE repo1.tableone;"
+    run dolt --data-dir ./ sql -b -q "USE repo2;CREATE TEMPORARY TABLE temp2 LIKE repo1.tableone;"
     [ "$status" -eq 0 ]
     cd repo2
 

--- a/integration-tests/bats/sql-multi-db.bats
+++ b/integration-tests/bats/sql-multi-db.bats
@@ -20,7 +20,7 @@ teardown() {
 }
 
 seed_repos_with_tables_with_use_statements() {
-    dolt sql -r csv --data-dir ./ -b -q "
+    dolt --data-dir ./ sql -r csv -b -q "
             USE repo1;
             CREATE TABLE r1_t1 (pk BIGINT, PRIMARY KEY(pk));
             INSERT INTO r1_t1 (pk) values (0),(1),(2);
@@ -31,7 +31,7 @@ seed_repos_with_tables_with_use_statements() {
 
 @test "sql-multi-db: sql multi-db test show databases" {
     EXPECTED=$(echo -e "Database\ninformation_schema\nmysql\nrepo1\nrepo2")
-    run dolt sql -r csv --data-dir ./ -q "SHOW DATABASES"
+    run dolt --data-dir ./ sql -r csv -q "SHOW DATABASES"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "$EXPECTED" ]] || false
 }
@@ -40,26 +40,26 @@ seed_repos_with_tables_with_use_statements() {
     seed_repos_with_tables_with_use_statements
 
     EXPECTED_R1T1=$(echo -e "pk\n0\n1\n2")
-    run dolt sql -r csv --data-dir ./ -b -q "USE repo1; SELECT * FROM r1_t1;"
+    run dolt --data-dir ./ sql -r csv -b -q "USE repo1; SELECT * FROM r1_t1;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "$EXPECTED_R1T1" ]] || false
 
     EXPECTED_R2T1=$(echo -e "pk,c1\n2,200\n3,300\n4,400")
-    run dolt sql -r csv --data-dir ./ -b -q "USE repo2; SELECT * FROM r2_t1;"
+    run dolt --data-dir ./ sql -r csv -b -q "USE repo2; SELECT * FROM r2_t1;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "$EXPECTED_R2T1" ]] || false
 
     # test tables of other database inaccessible without database qualifier
-    run dolt sql -r csv --data-dir ./ -b -q "USE repo1; SELECT * FROM r2_t1;"
+    run dolt --data-dir ./ sql -r csv -b -q "USE repo1; SELECT * FROM r2_t1;"
     [ ! "$status" -eq 0 ]
-    run dolt sql -r csv --data-dir ./ -b -q "USE repo2; SELECT * FROM r1_t1;"
+    run dolt --data-dir ./ sql -r csv -b -q "USE repo2; SELECT * FROM r1_t1;"
     [ ! "$status" -eq 0 ]
 
     # test tables in other databases accessible when qualified
-    run dolt sql -r csv --data-dir ./ -b -q "USE repo1; SELECT * FROM repo2.r2_t1;"
+    run dolt --data-dir ./ sql -r csv -b -q "USE repo1; SELECT * FROM repo2.r2_t1;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "$EXPECTED_R2T1" ]] || false
-    run dolt sql -r csv --data-dir ./ -b -q "USE repo2; SELECT * FROM repo1.r1_t1;"
+    run dolt --data-dir ./ sql -r csv -b -q "USE repo2; SELECT * FROM repo1.r1_t1;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "$EXPECTED_R1T1" ]] || false
 }
@@ -67,7 +67,7 @@ seed_repos_with_tables_with_use_statements() {
 @test "sql-multi-db: sql test use invalid db name" {
     seed_repos_with_tables_with_use_statements
 
-    run dolt sql -r csv --data-dir ./ -q "USE invalid_db_name;"
+    run dolt --data-dir ./ sql -r csv -q "USE invalid_db_name;"
     [ ! "$status" -eq 0 ]
     echo $output
     [[ "$output" =~ "database not found: invalid_db_name" ]] || false
@@ -77,7 +77,7 @@ seed_repos_with_tables_with_use_statements() {
     seed_repos_with_tables_with_use_statements
 
     EXPECTED=$(echo -e "pk,c1\n2,200")
-    run dolt sql -r csv --data-dir ./ -b -q "
+    run dolt --data-dir ./ sql -r csv -b -q "
         USE repo1;
         SELECT r1_t1.pk as pk, repo2.r2_t1.c1 as c1 FROM r1_t1 JOIN repo2.r2_t1 ON r1_t1.pk=repo2.r2_t1.pk;"
     echo \"\"\"$output\"\"\"
@@ -87,11 +87,11 @@ seed_repos_with_tables_with_use_statements() {
 
 @test "sql-multi-db: join on multiple databases with same name" {
     seed_repos_with_tables_with_use_statements
-    dolt sql --data-dir ./ -b -q "
+    dolt --data-dir ./ sql -b -q "
             USE repo1;
             CREATE TABLE r2_t1 (pk BIGINT, c1 BIGINT, PRIMARY KEY(pk));
             INSERT INTO r2_t1 (pk, c1) values (2,200),(3,300),(4,400);"
-    run dolt sql --data-dir ./ -q "select * from repo1.r2_t1 join repo2.r2_t1 on repo1.r2_t1.pk=repo2.r2_t1.pk"
+    run dolt --data-dir ./ sql -q "select * from repo1.r2_t1 join repo2.r2_t1 on repo1.r2_t1.pk=repo2.r2_t1.pk"
     skip "Fails on Not unique table/alias"
     [ "$status" -eq 0 ]
     [[ ! $output =~ "Not unique table/alias" ]] || false
@@ -109,7 +109,7 @@ seed_repos_with_tables_with_use_statements() {
     dolt clone file://../remote1 repo2
 
     cd ..
-    run dolt sql --data-dir ./subremotes -b -q "
+    run dolt --data-dir ./subremotes sql -b -q "
         USE repo2;
         call dolt_fetch();" -r csv
     [ "$status" -eq 0 ]

--- a/integration-tests/bats/sql-server-remotesrv.bats
+++ b/integration-tests/bats/sql-server-remotesrv.bats
@@ -165,7 +165,7 @@ SQL
     mkdir remote
     cd remote
     dolt init
-    dolt sql --privilege-file=privs.json -q "CREATE USER user IDENTIFIED BY 'pass0'"
+    dolt --privilege-file=privs.json sql -q "CREATE USER user IDENTIFIED BY 'pass0'"
     dolt sql -q 'create table vals (i int);'
     dolt sql -q 'insert into vals (i) values (1), (2), (3), (4), (5);'
     dolt add vals
@@ -237,7 +237,7 @@ SQL
     mkdir remote
     cd remote
     dolt init
-    dolt sql --privilege-file=privs.json -q "CREATE USER user0 IDENTIFIED BY 'pass0'"
+    dolt --privilege-file=privs.json sql -q "CREATE USER user0 IDENTIFIED BY 'pass0'"
     dolt sql -q 'create table vals (i int);'
     dolt sql -q 'insert into vals (i) values (1), (2), (3), (4), (5);'
     dolt add vals
@@ -258,7 +258,7 @@ SQL
     mkdir remote
     cd remote
     dolt init
-    dolt sql --privilege-file=privs.json -q "CREATE USER user0 IDENTIFIED BY 'pass0'"
+    dolt --privilege-file=privs.json sql -q "CREATE USER user0 IDENTIFIED BY 'pass0'"
     dolt sql -q 'create table vals (i int);'
     dolt sql -q 'insert into vals (i) values (1), (2), (3), (4), (5);'
     dolt add vals

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -149,10 +149,10 @@ user_session_vars:
     aws_credentials_file: /Users/user1/.aws/config
     aws_credentials_profile: lddev" > server.yaml
 
-    dolt sql --privilege-file=privs.json -q "CREATE USER dolt@'127.0.0.1'"
-    dolt sql --privilege-file=privs.json -q "CREATE USER user0@'127.0.0.1' IDENTIFIED BY 'pass0'"
-    dolt sql --privilege-file=privs.json -q "CREATE USER user1@'127.0.0.1' IDENTIFIED BY 'pass1'"
-    dolt sql --privilege-file=privs.json -q "CREATE USER user2@'127.0.0.1' IDENTIFIED BY 'pass2'"
+    dolt --privilege-file=privs.json sql -q "CREATE USER dolt@'127.0.0.1'"
+    dolt --privilege-file=privs.json sql -q "CREATE USER user0@'127.0.0.1' IDENTIFIED BY 'pass0'"
+    dolt --privilege-file=privs.json sql -q "CREATE USER user1@'127.0.0.1' IDENTIFIED BY 'pass1'"
+    dolt --privilege-file=privs.json sql -q "CREATE USER user2@'127.0.0.1' IDENTIFIED BY 'pass2'"
 
     start_sql_server_with_config "" server.yaml
 
@@ -200,7 +200,7 @@ SQL
     [[ "$output" =~ "one_pk" ]] || false
 
     # Add rows on the command line
-    run dolt sql --user=dolt -q "insert into one_pk values (1,1,1)"
+    run dolt --user=dolt sql -q "insert into one_pk values (1,1,1)"
     [ "$status" -eq 1 ]
 
     run dolt sql-client -P $PORT -u dolt -q "SELECT * FROM one_pk"
@@ -307,7 +307,7 @@ SQL
     run dolt status
     [ "$status" -eq 0 ]
     [[ "$output" =~ "working tree clean" ]] || false
-    run dolt sql --user=dolt -q "SELECT sum(pk), sum(c0) FROM test;" -r csv
+    run dolt --user=dolt sql -q "SELECT sum(pk), sum(c0) FROM test;" -r csv
     [ "$status" -eq 0 ]
     [[ "$output" =~ "6,6" ]] || false
 
@@ -318,7 +318,7 @@ SQL
     run dolt status
     [ "$status" -eq 0 ]
     [[ "$output" =~ "working tree clean" ]] || false
-    run dolt sql --user=dolt -q "SELECT sum(pk), sum(c0) FROM test;" -r csv
+    run dolt --user=dolt sql -q "SELECT sum(pk), sum(c0) FROM test;" -r csv
     [ "$status" -eq 0 ]
     [[ "$output" =~ "6,6" ]] || false
 }
@@ -690,11 +690,11 @@ SQL
 
      # verify changes outside the session
      cd repo2
-     run dolt sql --user=dolt -q "show tables"
+     run dolt --user=dolt sql -q "show tables"
      [ "$status" -eq 0 ]
      [[ "$output" =~ "one_pk" ]] || false
 
-     run dolt sql --user=dolt -q "select * from one_pk"
+     run dolt --user=dolt sql -q "select * from one_pk"
      [ "$status" -eq 0 ]
      [[ "$output" =~ " 0 " ]] || false
      [[ "$output" =~ " 1 " ]] || false
@@ -712,7 +712,7 @@ SQL
 
      # verify changes outside the session
      cd newdb
-     run dolt sql --user=dolt -q "show tables"
+     run dolt --user=dolt sql -q "show tables"
      [ "$status" -eq 0 ]
      [[ "$output" =~ "test" ]] || false
 }
@@ -745,7 +745,7 @@ SQL
     [ "$status" -eq 0 ]
     [[ "$output" =~ "one_pk" ]] || false
 
-    run dolt sql --user=dolt -q "drop table one_pk"
+    run dolt --user=dolt sql -q "drop table one_pk"
     [ "$status" -eq 1 ]
 
     dolt sql-client -P $PORT -u dolt --use-db repo1 -q "drop table one_pk"
@@ -1094,7 +1094,7 @@ END""")
     [ "$status" -eq 0 ]
     [[ "$output" =~ "new table a" ]] || false
 
-    run dolt sql --user=dolt -q "show tables"
+    run dolt --user=dolt sql -q "show tables"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "a" ]] || false
 
@@ -1103,7 +1103,7 @@ END""")
     [ "$status" -eq 0 ]
     [[ "$output" =~ "new table b" ]] || false
 
-    run dolt sql --user=dolt -q "show tables"
+    run dolt --user=dolt sql -q "show tables"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "b" ]] || false
 
@@ -1340,7 +1340,7 @@ END""")
     [ "$status" -eq 0 ]
     [[ "$output" =~ "new table a" ]] || false
 
-    run dolt sql --user=dolt -q "show tables"
+    run dolt --user=dolt sql -q "show tables"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "a" ]] || false
 
@@ -1349,7 +1349,7 @@ END""")
     [ "$status" -eq 0 ]
     [[ "$output" =~ "new table b" ]] || false
 
-    run dolt sql --user=dolt -q "show tables"
+    run dolt --user=dolt sql -q "show tables"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "b" ]] || false
 

--- a/integration-tests/bats/sql-shell.bats
+++ b/integration-tests/bats/sql-shell.bats
@@ -33,7 +33,7 @@ teardown() {
     [[ "$output" =~ "localhost" ]] || false
 
     # make it dolt@localhost
-    run dolt sql --user=dolt <<< "select user, host from mysql.user"
+    run dolt --user=dolt sql <<< "select user, host from mysql.user"
     [ "$status" -eq 0 ]
     ! [[ "$output" =~ "root" ]] || false
     [[ "$output" =~ "dolt" ]] || false
@@ -195,14 +195,14 @@ teardown() {
     cd ..
 
     # show databases, expect all
-    run dolt sql --data-dir=db_dir <<< "show databases;"
+    run dolt --data-dir=db_dir sql <<< "show databases;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "db1" ]] || false
     [[ "$output" =~ "db2" ]] || false
     [[ "$output" =~ "db3" ]] || false
 
     # show users, expect just root user
-    run dolt sql --data-dir=db_dir <<< "select user from mysql.user;"
+    run dolt --data-dir=db_dir sql <<< "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     ! [[ "$output" =~ "new_user" ]] || false
@@ -214,11 +214,11 @@ teardown() {
     ! [[ "$output" =~ ".doltcfg" ]] || false
 
     # create new user
-    run dolt sql --data-dir=db_dir <<< "create user new_user"
+    run dolt --data-dir=db_dir sql <<< "create user new_user"
     [ "$status" -eq 0 ]
 
     # show users, expect root user and new_user
-    run dolt sql --data-dir=db_dir <<< "select user from mysql.user;"
+    run dolt --data-dir=db_dir sql <<< "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     [[ "$output" =~ "new_user" ]] || false
@@ -263,7 +263,7 @@ teardown() {
     rm -rf doltcfgdir
 
     # show users, expect just root user
-    run dolt sql --doltcfg-dir=doltcfgdir <<< "select user from mysql.user;"
+    run dolt --doltcfg-dir=doltcfgdir sql <<< "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     ! [[ "$output" =~ "new_user" ]] || false
@@ -273,11 +273,11 @@ teardown() {
     ! [[ "$output" =~ "doltcfgdir" ]] || false
 
     # create new_user
-    run dolt sql --doltcfg-dir=doltcfgdir <<< "create user new_user"
+    run dolt --doltcfg-dir=doltcfgdir sql <<< "create user new_user"
     [ "$status" -eq 0 ]
 
     # show users, expect root user and new_user
-    run dolt sql --doltcfg-dir=doltcfgdir <<< "select user from mysql.user;"
+    run dolt --doltcfg-dir=doltcfgdir sql <<< "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     [[ "$output" =~ "new_user" ]] || false
@@ -300,7 +300,7 @@ teardown() {
     rm -f privs.db
 
     # show users, expect just root user
-    run dolt sql --privilege-file=privs.db <<< "select user from mysql.user;"
+    run dolt --privilege-file=privs.db sql <<< "select user from mysql.user;"
     [[ "$output" =~ "root" ]] || false
     ! [[ "$output" =~ "new_user" ]] || false
 
@@ -309,11 +309,11 @@ teardown() {
     ! [[ "$output" =~ "privs.db" ]] || false
 
     # create new_user
-    run dolt sql --privilege-file=privs.db <<< "create user new_user"
+    run dolt --privilege-file=privs.db sql <<< "create user new_user"
     [ "$status" -eq 0 ]
 
     # show users, expect root user and new_user
-    run dolt sql --privilege-file=privs.db <<< "select user from mysql.user;"
+    run dolt --privilege-file=privs.db sql <<< "select user from mysql.user;"
     [[ "$output" =~ "root" ]] || false
     [[ "$output" =~ "new_user" ]] || false
 
@@ -360,14 +360,14 @@ teardown() {
     cd ..
 
     # show databases, expect all
-    run dolt sql --data-dir=db_dir --doltcfg-dir=doltcfgdir <<< "show databases;"
+    run dolt --data-dir=db_dir --doltcfg-dir=doltcfgdir sql <<< "show databases;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "db1" ]] || false
     [[ "$output" =~ "db2" ]] || false
     [[ "$output" =~ "db3" ]] || false
 
     # show users, expect just root user
-    run dolt sql --data-dir=db_dir --doltcfg-dir=doltcfgdir <<< "select user from mysql.user;"
+    run dolt --data-dir=db_dir --doltcfg-dir=doltcfgdir sql <<< "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     ! [[ "$output" =~ "new_user" ]] || false
@@ -380,11 +380,11 @@ teardown() {
     ! [[ "$output" =~ ".doltcfg" ]] || false
 
     # create new user
-    run dolt sql --data-dir=db_dir --doltcfg-dir=doltcfgdir <<< "create user new_user"
+    run dolt --data-dir=db_dir --doltcfg-dir=doltcfgdir sql <<< "create user new_user"
     [ "$status" -eq 0 ]
 
     # show users, expect root user and new_user
-    run dolt sql --data-dir=db_dir --doltcfg-dir=doltcfgdir <<< "select user from mysql.user;"
+    run dolt --data-dir=db_dir --doltcfg-dir=doltcfgdir sql <<< "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     [[ "$output" =~ "new_user" ]] || false
@@ -417,7 +417,7 @@ teardown() {
     ! [[ "$output" =~ "new_user" ]] || false
 
     # show users, expect root and new_user
-    run dolt sql --doltcfg-dir=../doltcfgdir <<< "select user from mysql.user"
+    run dolt --doltcfg-dir=../doltcfgdir sql <<< "select user from mysql.user"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     [[ "$output" =~ "new_user" ]] || false
@@ -459,14 +459,14 @@ teardown() {
     cd ..
 
     # show databases, expect all
-    run dolt sql --data-dir=db_dir --privilege-file=privs.db <<< "show databases;"
+    run dolt --data-dir=db_dir --privilege-file=privs.db sql <<< "show databases;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "db1" ]] || false
     [[ "$output" =~ "db2" ]] || false
     [[ "$output" =~ "db3" ]] || false
 
     # show users, expect just root user
-    run dolt sql --data-dir=db_dir --privilege-file=privs.db <<< "select user from mysql.user;"
+    run dolt --data-dir=db_dir --privilege-file=privs.db sql <<< "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     ! [[ "$output" =~ "new_user" ]] || false
@@ -478,11 +478,11 @@ teardown() {
     ! [[ "$output" =~ ".doltcfg" ]] || false
 
     # create new user
-    run dolt sql --data-dir=db_dir --privilege-file=privs.db <<< "create user new_user"
+    run dolt --data-dir=db_dir --privilege-file=privs.db sql <<< "create user new_user"
     [ "$status" -eq 0 ]
 
     # show users, expect root user and new_user
-    run dolt sql --data-dir=db_dir --privilege-file=privs.db <<< "select user from mysql.user;"
+    run dolt --data-dir=db_dir --privilege-file=privs.db sql <<< "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     [[ "$output" =~ "new_user" ]] || false
@@ -515,7 +515,7 @@ teardown() {
     ! [[ "$output" =~ "new_user" ]] || false
 
     # show users, expect root and new_user
-    run dolt sql --privilege-file=../privs.db <<< "select user from mysql.user"
+    run dolt --privilege-file=../privs.db sql <<< "select user from mysql.user"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     [[ "$output" =~ "new_user" ]] || false
@@ -535,7 +535,7 @@ teardown() {
     rm -rf privs.db
 
     # show users, expect just root user
-    run dolt sql --doltcfg-dir=doltcfgdir --privilege-file=privs.db <<< "select user from mysql.user;"
+    run dolt --doltcfg-dir=doltcfgdir --privilege-file=privs.db sql <<< "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     ! [[ "$output" =~ "new_user" ]] || false
@@ -545,11 +545,11 @@ teardown() {
     ! [[ "$output" =~ "doltcfgdir" ]] || false
 
     # create new_user
-    run dolt sql --doltcfg-dir=doltcfgdir --privilege-file=privs.db <<< "create user new_user"
+    run dolt --doltcfg-dir=doltcfgdir --privilege-file=privs.db sql <<< "create user new_user"
     [ "$status" -eq 0 ]
 
     # show users, expect root user and new_user
-    run dolt sql --doltcfg-dir=doltcfgdir --privilege-file=privs.db <<< "select user from mysql.user;"
+    run dolt --doltcfg-dir=doltcfgdir --privilege-file=privs.db sql <<< "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     [[ "$output" =~ "new_user" ]] || false
@@ -599,14 +599,14 @@ teardown() {
     cd ..
 
     # show databases, expect all
-    run dolt sql --data-dir=db_dir --doltcfg-dir=doltcfgdir --privilege-file=privs.db <<< "show databases;"
+    run dolt --data-dir=db_dir --doltcfg-dir=doltcfgdir --privilege-file=privs.db sql <<< "show databases;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "db1" ]] || false
     [[ "$output" =~ "db2" ]] || false
     [[ "$output" =~ "db3" ]] || false
 
     # show users, expect just root user
-    run dolt sql --data-dir=db_dir --doltcfg-dir=doltcfgdir --privilege-file=privs.db <<< "select user from mysql.user;"
+    run dolt --data-dir=db_dir --doltcfg-dir=doltcfgdir --privilege-file=privs.db sql <<< "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     ! [[ "$output" =~ "new_user" ]] || false
@@ -619,11 +619,11 @@ teardown() {
     ! [[ "$output" =~ ".doltcfg" ]] || false
 
     # create new user
-    run dolt sql --data-dir=db_dir --doltcfg-dir=doltcfgdir --privilege-file=privs.db <<< "create user new_user"
+    run dolt --data-dir=db_dir --doltcfg-dir=doltcfgdir --privilege-file=privs.db sql <<< "create user new_user"
     [ "$status" -eq 0 ]
 
     # show users, expect root user and new_user
-    run dolt sql --data-dir=db_dir --doltcfg-dir=doltcfgdir --privilege-file=privs.db <<< "select user from mysql.user;"
+    run dolt --data-dir=db_dir --doltcfg-dir=doltcfgdir --privilege-file=privs.db sql <<< "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     [[ "$output" =~ "new_user" ]] || false
@@ -659,13 +659,13 @@ teardown() {
     ! [[ "$output" =~ "new_user" ]] || false
 
     # show users, expect root and new_user
-    run dolt sql --doltcfg-dir=../doltcfgdir <<< "select user from mysql.user"
+    run dolt --doltcfg-dir=../doltcfgdir sql <<< "select user from mysql.user"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     ! [[ "$output" =~ "new_user" ]] || false
 
     # show users, expect root and new_user
-    run dolt sql --privilege-file=../privs.db <<< "select user from mysql.user"
+    run dolt --privilege-file=../privs.db sql <<< "select user from mysql.user"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     [[ "$output" =~ "new_user" ]] || false
@@ -695,7 +695,7 @@ teardown() {
     [[ "$output" =~ "multiple .doltcfg directories detected" ]] || false
 
     # specifying datadir, resolves issue
-    run dolt sql --data-dir=. <<< "show databases;"
+    run dolt --data-dir=. sql <<< "show databases;"
     [ "$status" -eq 0 ]
 
     # remove existing directories
@@ -769,24 +769,24 @@ teardown() {
     mkdir new_repo
     cd new_repo
 
-    run dolt sql --data-dir=$DATADIR <<< "show databases"
+    run dolt --data-dir=$DATADIR sql <<< "show databases"
     [ $status -eq 0 ]
     [[ $output =~ "db1" ]] || false
     [[ $output =~ "db2" ]] || false
     [[ $output =~ "db3" ]] || false
 
-    run dolt sql --data-dir=$DATADIR <<< "create user new_user"
+    run dolt --data-dir=$DATADIR sql <<< "create user new_user"
     [ $status -eq 0 ]
 
-    run dolt sql --data-dir=$DATADIR <<< "use db1; select user from mysql.user"
-    [ $status -eq 0 ]
-    [[ $output =~ "new_user" ]] || false
-
-    run dolt sql --data-dir=$DATADIR <<< "use db2; select user from mysql.user"
+    run dolt --data-dir=$DATADIR sql <<< "use db1; select user from mysql.user"
     [ $status -eq 0 ]
     [[ $output =~ "new_user" ]] || false
 
-    run dolt sql --data-dir=$DATADIR <<< "use db3; select user from mysql.user"
+    run dolt --data-dir=$DATADIR sql <<< "use db2; select user from mysql.user"
+    [ $status -eq 0 ]
+    [[ $output =~ "new_user" ]] || false
+
+    run dolt --data-dir=$DATADIR sql <<< "use db3; select user from mysql.user"
     [ $status -eq 0 ]
     [[ $output =~ "new_user" ]] || false
 

--- a/integration-tests/bats/sql-shell.bats
+++ b/integration-tests/bats/sql-shell.bats
@@ -49,15 +49,15 @@ teardown() {
     # default user is root
     run dolt sql <<< "select user from mysql.user"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "root" ]]
+    [[ "$output" =~ "root" ]] || false
 
     # create user
     run dolt sql <<< "create user new_user@'localhost'"
     [ "$status" -eq 0 ]
 
-    run dolt sql --user=new_user <<< "select user from mysql.user"
+    run dolt --user=new_user sql <<< "select user from mysql.user"
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "Access denied for user" ]]
+    [[ "$output" =~ "Access denied for user" ]] || false
 
     rm -rf .doltcfg
 }

--- a/integration-tests/bats/sql.bats
+++ b/integration-tests/bats/sql.bats
@@ -51,7 +51,7 @@ teardown() {
     [[ "$output" =~ "localhost" ]] || false
 
     # make it dolt@localhost
-    run dolt sql --user=dolt -q "select user, host from mysql.user"
+    run dolt --user=dolt sql -q "select user, host from mysql.user"
     [ "$status" -eq 0 ]
     ! [[ "$output" =~ "root" ]] || false
     [[ "$output" =~ "dolt" ]] || false
@@ -73,7 +73,7 @@ teardown() {
     run dolt sql -q "create user new_user@'localhost'"
     [ "$status" -eq 0 ]
 
-    run dolt sql --user=new_user -q "select user from mysql.user"
+    run dolt --user=new_user sql -q "select user from mysql.user"
     [ "$status" -eq 1 ]
     [[ "$output" =~ "Access denied for user" ]]
 
@@ -143,14 +143,14 @@ teardown() {
     cd ..
 
     # show databases, expect all
-    run dolt sql --data-dir=db_dir -q "show databases;"
+    run dolt --data-dir=db_dir sql -q "show databases;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "db1" ]] || false
     [[ "$output" =~ "db2" ]] || false
     [[ "$output" =~ "db3" ]] || false
 
     # show users, expect just root user
-    run dolt sql --data-dir=db_dir -q "select user from mysql.user;"
+    run dolt --data-dir=db_dir sql -q "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     ! [[ "$output" =~ "new_user" ]] || false
@@ -162,11 +162,11 @@ teardown() {
     ! [[ "$output" =~ ".doltcfg" ]] || false
 
     # create new user
-    run dolt sql --data-dir=db_dir -q "create user new_user"
+    run dolt --data-dir=db_dir sql -q "create user new_user"
     [ "$status" -eq 0 ]
 
     # show users, expect root user and new_user
-    run dolt sql --data-dir=db_dir -q "select user from mysql.user;"
+    run dolt --data-dir=db_dir sql -q "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     [[ "$output" =~ "new_user" ]] || false
@@ -204,45 +204,13 @@ teardown() {
     rm -rf db_dir
 }
 
-@test "sql: check --data-dir can be used as argument before subcommand" {
-    # remove config files
-    rm -rf .doltcfg
-    rm -rf db_dir
-
-    # create data dir
-    mkdir db_dir
-    cd db_dir
-    DATADIR=$(pwd)
-
-    # create databases
-    mkdir dba
-    cd dba
-    dolt init
-    cd ..
-
-    mkdir dbb
-    cd dbb
-    dolt init
-
-    # Ensure --data-dir flag is really used.
-    cd /tmp
-
-    # show databases, expect all
-    run dolt --data-dir="$DATADIR" sql -q "show databases;"
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ "dba" ]] || false
-    [[ "$output" =~ "dbb" ]] || false
-
-    dolt --data-dir="$DATADIR" sql -q "use dba; create table tablea (id int);"
-}
-
 @test "sql: check configurations specify doltcfg directory" {
     # remove any previous config directories
     rm -rf .doltcfg
     rm -rf doltcfgdir
 
     # show users, expect just root user
-    run dolt sql --doltcfg-dir=doltcfgdir -q "select user from mysql.user;"
+    run dolt --doltcfg-dir=doltcfgdir sql -q "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     ! [[ "$output" =~ "new_user" ]] || false
@@ -252,11 +220,11 @@ teardown() {
     ! [[ "$output" =~ "doltcfgdir" ]] || false
 
     # create new_user
-    run dolt sql --doltcfg-dir=doltcfgdir -q "create user new_user"
+    run dolt --doltcfg-dir=doltcfgdir sql -q "create user new_user"
     [ "$status" -eq 0 ]
 
     # show users, expect root user and new_user
-    run dolt sql --doltcfg-dir=doltcfgdir -q "select user from mysql.user;"
+    run dolt --doltcfg-dir=doltcfgdir sql -q "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     [[ "$output" =~ "new_user" ]] || false
@@ -279,7 +247,7 @@ teardown() {
     rm -f privs.db
 
     # show users, expect just root user
-    run dolt sql --privilege-file=privs.db -q "select user from mysql.user;"
+    run dolt --privilege-file=privs.db sql -q "select user from mysql.user;"
     [[ "$output" =~ "root" ]] || false
     ! [[ "$output" =~ "new_user" ]] || false
 
@@ -287,11 +255,11 @@ teardown() {
     ! [[ "$output" =~ ".doltcfg" ]] || false
 
     # create new_user
-    run dolt sql --privilege-file=privs.db -q "create user new_user"
+    run dolt --privilege-file=privs.db sql -q "create user new_user"
     [ "$status" -eq 0 ]
 
     # show users, expect root user and new_user
-    run dolt sql --privilege-file=privs.db -q "select user from mysql.user;"
+    run dolt --privilege-file=privs.db sql -q "select user from mysql.user;"
     [[ "$output" =~ "root" ]] || false
     [[ "$output" =~ "new_user" ]] || false
 
@@ -338,14 +306,14 @@ teardown() {
     cd ..
 
     # show databases, expect all
-    run dolt sql --data-dir=db_dir --doltcfg-dir=doltcfgdir -q "show databases;"
+    run dolt --data-dir=db_dir --doltcfg-dir=doltcfgdir sql -q "show databases;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "db1" ]] || false
     [[ "$output" =~ "db2" ]] || false
     [[ "$output" =~ "db3" ]] || false
 
     # show users, expect just root user
-    run dolt sql --data-dir=db_dir --doltcfg-dir=doltcfgdir -q "select user from mysql.user;"
+    run dolt --data-dir=db_dir --doltcfg-dir=doltcfgdir sql -q "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     ! [[ "$output" =~ "new_user" ]] || false
@@ -358,11 +326,11 @@ teardown() {
     ! [[ "$output" =~ ".doltcfg" ]] || false
 
     # create new user
-    run dolt sql --data-dir=db_dir --doltcfg-dir=doltcfgdir -q "create user new_user"
+    run dolt --data-dir=db_dir --doltcfg-dir=doltcfgdir sql -q "create user new_user"
     [ "$status" -eq 0 ]
 
     # show users, expect root user and new_user
-    run dolt sql --data-dir=db_dir --doltcfg-dir=doltcfgdir -q "select user from mysql.user;"
+    run dolt --data-dir=db_dir --doltcfg-dir=doltcfgdir sql -q "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     [[ "$output" =~ "new_user" ]] || false
@@ -396,7 +364,7 @@ teardown() {
     ! [[ "$output" =~ "new_user" ]] || false
 
     # show users, expect root and new_user
-    run dolt sql --doltcfg-dir=../doltcfgdir -q "select user from mysql.user"
+    run dolt --doltcfg-dir=../doltcfgdir sql -q "select user from mysql.user"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     [[ "$output" =~ "new_user" ]] || false
@@ -438,14 +406,14 @@ teardown() {
     cd ..
 
     # show databases, expect all
-    run dolt sql --data-dir=db_dir --privilege-file=privs.db -q "show databases;"
+    run dolt --data-dir=db_dir --privilege-file=privs.db sql -q "show databases;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "db1" ]] || false
     [[ "$output" =~ "db2" ]] || false
     [[ "$output" =~ "db3" ]] || false
 
     # show users, expect just root user
-    run dolt sql --data-dir=db_dir --privilege-file=privs.db -q "select user from mysql.user;"
+    run dolt --data-dir=db_dir --privilege-file=privs.db sql -q "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     ! [[ "$output" =~ "new_user" ]] || false
@@ -457,11 +425,11 @@ teardown() {
     ! [[ "$output" =~ ".doltcfg" ]] || false
 
     # create new user
-    run dolt sql --data-dir=db_dir --privilege-file=privs.db -q "create user new_user"
+    run dolt --data-dir=db_dir --privilege-file=privs.db sql -q "create user new_user"
     [ "$status" -eq 0 ]
 
     # show users, expect root user and new_user
-    run dolt sql --data-dir=db_dir --privilege-file=privs.db -q "select user from mysql.user;"
+    run dolt --data-dir=db_dir --privilege-file=privs.db sql -q "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     [[ "$output" =~ "new_user" ]] || false
@@ -494,7 +462,7 @@ teardown() {
     ! [[ "$output" =~ "new_user" ]] || false
 
     # show users, expect root and new_user
-    run dolt sql --privilege-file=../privs.db -q "select user from mysql.user"
+    run dolt --privilege-file=../privs.db sql -q "select user from mysql.user"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     [[ "$output" =~ "new_user" ]] || false
@@ -514,7 +482,7 @@ teardown() {
     rm -rf privs.db
 
     # show users, expect just root user
-    run dolt sql --doltcfg-dir=doltcfgdir --privilege-file=privs.db -q "select user from mysql.user;"
+    run dolt --doltcfg-dir=doltcfgdir --privilege-file=privs.db sql -q "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     ! [[ "$output" =~ "new_user" ]] || false
@@ -524,11 +492,11 @@ teardown() {
     ! [[ "$output" =~ "doltcfgdir" ]] || false
 
     # create new_user
-    run dolt sql --doltcfg-dir=doltcfgdir --privilege-file=privs.db -q "create user new_user"
+    run dolt --doltcfg-dir=doltcfgdir --privilege-file=privs.db sql -q "create user new_user"
     [ "$status" -eq 0 ]
 
     # show users, expect root user and new_user
-    run dolt sql --doltcfg-dir=doltcfgdir --privilege-file=privs.db -q "select user from mysql.user;"
+    run dolt --doltcfg-dir=doltcfgdir --privilege-file=privs.db sql -q "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     [[ "$output" =~ "new_user" ]] || false
@@ -580,14 +548,14 @@ teardown() {
     cd ..
 
     # show databases, expect all
-    run dolt sql --data-dir=db_dir --doltcfg-dir=doltcfgdir --privilege-file=privs.db -q "show databases;"
+    run dolt --data-dir=db_dir --doltcfg-dir=doltcfgdir --privilege-file=privs.db sql -q "show databases;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "db1" ]] || false
     [[ "$output" =~ "db2" ]] || false
     [[ "$output" =~ "db3" ]] || false
 
     # show users, expect just root user
-    run dolt sql --data-dir=db_dir --doltcfg-dir=doltcfgdir --privilege-file=privs.db -q "select user from mysql.user;"
+    run dolt --data-dir=db_dir --doltcfg-dir=doltcfgdir --privilege-file=privs.db sql -q "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     ! [[ "$output" =~ "new_user" ]] || false
@@ -601,11 +569,11 @@ teardown() {
     ! [[ "$output" =~ ".doltcfg" ]] || false
 
     # create new user
-    run dolt sql --data-dir=db_dir --doltcfg-dir=doltcfgdir --privilege-file=privs.db -q "create user new_user"
+    run dolt --data-dir=db_dir --doltcfg-dir=doltcfgdir --privilege-file=privs.db sql -q "create user new_user"
     [ "$status" -eq 0 ]
 
     # show users, expect root user and new_user
-    run dolt sql --data-dir=db_dir --doltcfg-dir=doltcfgdir --privilege-file=privs.db -q "select user from mysql.user;"
+    run dolt --data-dir=db_dir --doltcfg-dir=doltcfgdir --privilege-file=privs.db sql -q "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     [[ "$output" =~ "new_user" ]] || false
@@ -641,13 +609,13 @@ teardown() {
     ! [[ "$output" =~ "new_user" ]] || false
 
     # show users, expect root and new_user
-    run dolt sql --doltcfg-dir=../doltcfgdir -q "select user from mysql.user"
+    run dolt --doltcfg-dir=../doltcfgdir sql -q "select user from mysql.user"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     ! [[ "$output" =~ "new_user" ]] || false
 
     # show users, expect root and new_user
-    run dolt sql --privilege-file=../privs.db -q "select user from mysql.user"
+    run dolt --privilege-file=../privs.db sql -q "select user from mysql.user"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     [[ "$output" =~ "new_user" ]] || false
@@ -667,20 +635,20 @@ teardown() {
     rm -rf inner_db
     rm -f privs.db
 
-    run dolt sql --privilege-file=privs.db -q "create database inner_db;"
+    run dolt --privilege-file=privs.db sql -q "create database inner_db;"
     [ "$status" -eq 0 ]
 
-    run dolt sql --privilege-file=privs.db -q "create user new_user;"
+    run dolt --privilege-file=privs.db sql -q "create user new_user;"
     [ "$status" -eq 0 ]
 
-    run dolt sql --privilege-file=privs.db -q "select user from mysql.user;"
+    run dolt --privilege-file=privs.db sql -q "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     [[ "$output" =~ "new_user" ]] || false
 
     cd inner_db
 
-    run dolt sql --privilege-file=../privs.db -q "select user from mysql.user;"
+    run dolt --privilege-file=../privs.db sql -q "select user from mysql.user;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "root" ]] || false
     [[ "$output" =~ "new_user" ]] || false
@@ -708,7 +676,7 @@ teardown() {
     [[ "$output" =~ "multiple .doltcfg directories detected" ]] || false
 
     # specifying datadir, resolves issue
-    run dolt sql --data-dir=. -q "show databases;"
+    run dolt --data-dir=. sql -q "show databases;"
     [ "$status" -eq 0 ]
 
     # remove existing directories
@@ -782,24 +750,24 @@ teardown() {
     mkdir new_repo
     cd new_repo
 
-    run dolt sql --data-dir=$DATADIR -q "show databases"
+    run dolt --data-dir=$DATADIR sql -q "show databases"
     [ $status -eq 0 ]
     [[ $output =~ "db1" ]] || false
     [[ $output =~ "db2" ]] || false
     [[ $output =~ "db3" ]] || false
 
-    run dolt sql --data-dir=$DATADIR -q "create user new_user"
+    run dolt --data-dir=$DATADIR sql -q "create user new_user"
     [ $status -eq 0 ]
 
-    run dolt sql --data-dir=$DATADIR -q "use db1; select user from mysql.user"
-    [ $status -eq 0 ]
-    [[ $output =~ "new_user" ]] || false
-
-    run dolt sql --data-dir=$DATADIR -q "use db2; select user from mysql.user"
+    run dolt --data-dir=$DATADIR sql -q "use db1; select user from mysql.user"
     [ $status -eq 0 ]
     [[ $output =~ "new_user" ]] || false
 
-    run dolt sql --data-dir=$DATADIR -q "use db3; select user from mysql.user"
+    run dolt --data-dir=$DATADIR sql -q "use db2; select user from mysql.user"
+    [ $status -eq 0 ]
+    [[ $output =~ "new_user" ]] || false
+
+    run dolt --data-dir=$DATADIR sql -q "use db3; select user from mysql.user"
     [ $status -eq 0 ]
     [[ $output =~ "new_user" ]] || false
 


### PR DESCRIPTION
SQL Command arguments which pertain to instantiating a local SqlEngine instance are now global arguments which come before the sql subcommand. This is a breaking change for users of the `sql` command who pass in the following arguments:

- --data-dir
- --user
- --doltcfg-dir
- --privilege-file
- --branch-control-file

All of the test changes pertain to moving those arguments, and nothing else. This is by design to ensure we don't have broader impact to the interface.

With this abstraction in place, we can put a different Queryist implementation in place - specifically one which talks to a remotes server - which is the end goal.

Step on the path to: https://github.com/dolthub/dolt/issues/3922