### PR TITLE
Fix binlog connection re-establishment when connection closes between messages

### DIFF
--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_reconnect_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_reconnect_test.go
@@ -54,7 +54,7 @@ func TestBinlogReplicationAutoReconnect(t *testing.T) {
 	// Remove the limit_data toxic so that a connection can be reestablished
 	err := mysqlProxy.RemoveToxic("limit_data")
 	require.NoError(t, err)
-	fmt.Printf("Toxiproxy proxy limit_data toxic removed")
+	t.Logf("Toxiproxy proxy limit_data toxic removed")
 
 	// Assert that all records get written to the table
 	waitForReplicaToCatchUp(t)
@@ -157,7 +157,7 @@ func configureToxiProxy(t *testing.T) {
 		toxiproxyServer.Listen("localhost", strconv.Itoa(toxiproxyPort))
 	}()
 	time.Sleep(500 * time.Millisecond)
-	fmt.Printf("Toxiproxy control plane running on port %d \n", toxiproxyPort)
+	t.Logf("Toxiproxy control plane running on port %d", toxiproxyPort)
 
 	toxiClient = toxiproxyclient.NewClient(fmt.Sprintf("localhost:%d", toxiproxyPort))
 
@@ -169,7 +169,7 @@ func configureToxiProxy(t *testing.T) {
 	if err != nil {
 		panic(fmt.Sprintf("unable to create toxiproxy: %v", err.Error()))
 	}
-	fmt.Printf("Toxiproxy proxy started on port %d \n", proxyPort)
+	t.Logf("Toxiproxy proxy started on port %d", proxyPort)
 }
 
 // turnOnLimitDataToxic adds a limit_data toxic to the active Toxiproxy, which prevents more than 1KB of data
@@ -181,7 +181,7 @@ func turnOnLimitDataToxic(t *testing.T) {
 		"bytes": 1_000,
 	})
 	require.NoError(t, err)
-	fmt.Printf("Toxiproxy proxy with limit_data toxic (1KB) started on port %d \n", proxyPort)
+	t.Logf("Toxiproxy proxy with limit_data toxic (1KB) started on port %d", proxyPort)
 }
 
 // convertByteArraysToStrings converts each []byte value in the specified map |m| into a string.

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_reconnect_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_reconnect_test.go
@@ -17,6 +17,7 @@ package binlogreplication
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -70,7 +71,7 @@ func TestBinlogReplicationAutoReconnect(t *testing.T) {
 	// Assert that show replica status show reconnection IO error
 	status := showReplicaStatus(t)
 	require.Equal(t, "1158", status["Last_IO_Errno"])
-	require.Equal(t, "unexpected EOF", status["Last_IO_Error"])
+	require.True(t, strings.Contains(status["Last_IO_Error"].(string), "EOF"))
 	requireRecentTimeString(t, status["Last_IO_Error_Timestamp"])
 }
 

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_test.go
@@ -476,7 +476,7 @@ func TestCharsetsAndCollations(t *testing.T) {
 // Test Helper Functions
 //
 
-// waitForReplicaToCatchUp waits (up to 20s) for the replica to catch up with the primary database. The
+// waitForReplicaToCatchUp waits (up to 60s) for the replica to catch up with the primary database. The
 // lag is measured by checking that gtid_executed is the same on the primary and replica.
 func waitForReplicaToCatchUp(t *testing.T) {
 	timeLimit := 60 * time.Second


### PR DESCRIPTION
This PR changes our handling of `io.EOF` to trigger our connection re-establishment logic. Previously, only `io.UnexpectedEOF` was triggering a connection re-establishment. 

We found this by digging into some flakiness in the `TestBinlogReplicationAutoReconnect` test:
- https://github.com/dolthub/dolt/actions/runs/4888594518/jobs/8726401205
- https://github.com/dolthub/dolt/actions/runs/4888594518/jobs/8726401205
- https://github.com/dolthub/dolt/actions/runs/4888566463/jobs/8726344999

This test is a little more complex than the other binlog replication tests – it uses Toxiproxy to simulate a dying connection to test the automatic reconnection feature. 

In each of the failures above, the test fails after timing out waiting for the replica to report it has processed the same GTID set that the primary reports. Each time, the primary reports GTIDS 1-1004, but the replica only has GTIDS 1-3. 

Comparing the failed test run log output to a successful test run... the successful run shows the log message `no binlog connection to source, attempting to establish one` many more times. While the Toxiproxy has a data_limit toxic in place, we keep re-establishing a connection and reading the data before Toxiproxy starts causing chaos. This is as intended, and when the data_limit toxic is removed, the binlog replica re-establishes a connection again, and this time is able to keep pulling off events. However, in the failed tests above, I'm only seeing this connection re-establishment happen once, and then the replica just keeps reporting `No more binlog messages; retrying in 1s...`, which indicates it has a connection, but isn't receiving anything. 

This seems to happen when Toxiproxy happens to close the connection cleanly between binlog messages. If the connection close happens while a binlog message is in-flight, we receive an `io.UnexpectedEOF` error and correctly re-establish a connection. If the timing is just right, then we will receive an `io.EOF`. I previously thought that we would receive an `EOF` if there was no binlog event to read over the connection after a period of time, but after looking at the vitess connection handling code more, this doesn't seem to be the case, and `EOF` should be treated the same as `UnexpectedEOF`. 

There are also a few other minor test tweaks in here, like ensuring we check for any returned error when managing the toxics loaded on Toxiproxy. 