### PR TITLE
sql-server: `dolt_log_level` system variable allows reading the current log level for the server and setting a new one.

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -105,6 +105,13 @@ func Serve(
 				logrus.TraceLevel.String(),
 			),
 			Default:           logrus.GetLevel().String(),
+			NotifyChanged:     func(scope sql.SystemVariableScope, v sql.SystemVarValue) {
+				if level, err := logrus.ParseLevel(v.Val.(string)); err == nil {
+					logrus.SetLevel(level)
+				} else {
+					logrus.Warnf("could not parse requested log level %s as a log level. dolt_log_level variable value and logging behavior will diverge.", v.Val.(string))
+				}
+			},
 		},
 	})
 

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -40,8 +40,8 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/binlogreplication"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/cluster"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	_ "github.com/dolthub/dolt/go/libraries/doltcore/sqle/dfunctions"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqlserver"
 )
 
@@ -90,12 +90,12 @@ func Serve(
 	logrus.SetFormatter(LogFormat{})
 
 	sql.SystemVariables.AddSystemVariables([]sql.SystemVariable{
-                {
+		{
 			Name:              dsess.DoltLogLevel,
 			Scope:             sql.SystemVariableScope_Global,
 			Dynamic:           true,
 			SetVarHintApplies: false,
-			Type:              types.NewSystemEnumType(dsess.DoltLogLevel,
+			Type: types.NewSystemEnumType(dsess.DoltLogLevel,
 				logrus.PanicLevel.String(),
 				logrus.FatalLevel.String(),
 				logrus.ErrorLevel.String(),
@@ -104,8 +104,8 @@ func Serve(
 				logrus.DebugLevel.String(),
 				logrus.TraceLevel.String(),
 			),
-			Default:           logrus.GetLevel().String(),
-			NotifyChanged:     func(scope sql.SystemVariableScope, v sql.SystemVarValue) {
+			Default: logrus.GetLevel().String(),
+			NotifyChanged: func(scope sql.SystemVariableScope, v sql.SystemVarValue) {
 				if level, err := logrus.ParseLevel(v.Val.(string)); err == nil {
 					logrus.SetLevel(level)
 				} else {

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/dolthub/go-mysql-server/server"
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
 	"github.com/dolthub/vitess/go/mysql"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -39,6 +40,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/binlogreplication"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/cluster"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	_ "github.com/dolthub/dolt/go/libraries/doltcore/sqle/dfunctions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqlserver"
 )
@@ -86,6 +88,25 @@ func Serve(
 		logrus.SetLevel(level)
 	}
 	logrus.SetFormatter(LogFormat{})
+
+	sql.SystemVariables.AddSystemVariables([]sql.SystemVariable{
+                {
+			Name:              dsess.DoltLogLevel,
+			Scope:             sql.SystemVariableScope_Global,
+			Dynamic:           true,
+			SetVarHintApplies: false,
+			Type:              types.NewSystemEnumType(dsess.DoltLogLevel,
+				logrus.PanicLevel.String(),
+				logrus.FatalLevel.String(),
+				logrus.ErrorLevel.String(),
+				logrus.WarnLevel.String(),
+				logrus.InfoLevel.String(),
+				logrus.DebugLevel.String(),
+				logrus.TraceLevel.String(),
+			),
+			Default:           logrus.GetLevel().String(),
+		},
+	})
 
 	var mrEnv *env.MultiRepoEnv
 	var err error

--- a/go/libraries/doltcore/sqle/dsess/variables.go
+++ b/go/libraries/doltcore/sqle/dsess/variables.go
@@ -50,6 +50,7 @@ const (
 	AwsCredsProfile               = "aws_credentials_profile"
 	AwsCredsRegion                = "aws_credentials_region"
 	ShowBranchDatabases           = "dolt_show_branch_databases"
+	DoltLogLevel                  = "dolt_log_level"
 
 	DoltClusterRoleVariable      = "dolt_cluster_role"
 	DoltClusterRoleEpochVariable = "dolt_cluster_role_epoch"

--- a/integration-tests/go-sql-server-driver/tests/sql-server-config.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-config.yaml
@@ -275,23 +275,34 @@ tests:
       result:
         columns: ["@@GLOBAL.max_connections"]
         rows: [["555"]]
-- name: "@@global.dolt_log_level read behavior"
+- name: "@@global.dolt_log_level behavior"
   repos:
   - name: repo1
     server:
-      args: ["-l", "trace"]
+      args: ["-l", "warning"]
+      log_matches:
+      - "Starting query"
   connections:
   - on: repo1
     queries:
     - query: "select @@GLOBAL.dolt_log_level"
       result:
         columns: ["@@GLOBAL.dolt_log_level"]
+        rows: [["warning"]]
+    - exec: "set @@GLOBAL.dolt_log_level = 'trace'"
+    - query: "select 2+2 from dual"
+      result:
+        columns: ["2+2"]
+        rows: [["4"]]
+    - query: "select @@GLOBAL.dolt_log_level"
+      result:
+        columns: ["@@GLOBAL.dolt_log_level"]
         rows: [["trace"]]
     restart_server:
-      args: ["-l", "debug"]
+      args: ["-l", "info"]
   - on: repo1
     queries:
     - query: "select @@GLOBAL.dolt_log_level"
       result:
         columns: ["@@GLOBAL.dolt_log_level"]
-        rows: [["debug"]]
+        rows: [["info"]]

--- a/integration-tests/go-sql-server-driver/tests/sql-server-config.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-config.yaml
@@ -275,3 +275,23 @@ tests:
       result:
         columns: ["@@GLOBAL.max_connections"]
         rows: [["555"]]
+- name: "@@global.dolt_log_level read behavior"
+  repos:
+  - name: repo1
+    server:
+      args: ["-l", "trace"]
+  connections:
+  - on: repo1
+    queries:
+    - query: "select @@GLOBAL.dolt_log_level"
+      result:
+        columns: ["@@GLOBAL.dolt_log_level"]
+        rows: [["trace"]]
+    restart_server:
+      args: ["-l", "debug"]
+  - on: repo1
+    queries:
+    - query: "select @@GLOBAL.dolt_log_level"
+      result:
+        columns: ["@@GLOBAL.dolt_log_level"]
+        rows: [["debug"]]


### PR DESCRIPTION
Written values do not persist across server restarts.