### PR TITLE
Changing schema equality to not consider tag when comparing columns

### DIFF
--- a/go/libraries/doltcore/schema/col_coll.go
+++ b/go/libraries/doltcore/schema/col_coll.go
@@ -245,7 +245,9 @@ func ColCollsAreEqual(cc1, cc2 *ColCollection) bool {
 	}
 	// Pks Cols need to be in the same order and equivalent.
 	for i := 0; i < cc1.Size(); i++ {
-		if !cc1.cols[i].Equals(cc2.cols[i]) {
+		// Test that the columns are identical, but don't worry about tags matching, since
+		// different tags could be generated depending on how the schemas were created.
+		if !cc1.cols[i].EqualsWithoutTag(cc2.cols[i]) {
 			return false
 		}
 	}

--- a/go/libraries/doltcore/schema/column.go
+++ b/go/libraries/doltcore/schema/column.go
@@ -145,6 +145,16 @@ func (c Column) Equals(other Column) bool {
 		ColConstraintsAreEqual(c.Constraints, other.Constraints)
 }
 
+// EqualsWithoutTag tests equality between two columns, but does not check the columns' tags.
+func (c Column) EqualsWithoutTag(other Column) bool {
+	return c.Name == other.Name &&
+		c.Kind == other.Kind &&
+		c.IsPartOfPK == other.IsPartOfPK &&
+		c.TypeInfo.Equals(other.TypeInfo) &&
+		c.Default == other.Default &&
+		ColConstraintsAreEqual(c.Constraints, other.Constraints)
+}
+
 // Compatible tests compatibility between two columns. Compatible columns have the same tag and can store the same
 // kinds of values at the storage layer, but may have different constraints or type parameters.
 func (c Column) Compatible(other Column) bool {

--- a/integration-tests/bats/column_tags.bats
+++ b/integration-tests/bats/column_tags.bats
@@ -344,15 +344,7 @@ DELIM
     dolt sql -q "ALTER TABLE target DROP COLUMN badCol;"
     dolt commit -Am "fixup"
 
-    run dolt schema tags
-    [[ $output =~ "| target | col1   | 14690 |" ]] || false
-
     dolt checkout main
-
-    run dolt schema tags
-    [ $status -eq 0 ]
-    [[ $output =~ "| target | col1   | 14649 |" ]] || false
-
     run dolt merge other -m "merge other into main"
     [ $status -eq 0 ]
     [[ $output =~ "1 tables changed, 1 rows added(+)" ]] || false

--- a/integration-tests/bats/column_tags.bats
+++ b/integration-tests/bats/column_tags.bats
@@ -325,7 +325,7 @@ DELIM
     [[ $output =~ "col1   | 6" ]] || false
 }
 
-@test "column_tags: create table on two separate branches, merge them together by updating tags" {
+@test "column_tags: create table on two separate branches, merge them together even though they have different tags" {
     skip_nbf_not_dolt
 
     dolt branch other
@@ -352,14 +352,6 @@ DELIM
     run dolt schema tags
     [ $status -eq 0 ]
     [[ $output =~ "| target | col1   | 14649 |" ]] || false
-
-    run dolt merge other
-    [ $status -ne 0 ]
-    [[ $output =~ "table with same name 'target' added in 2 commits can't be merged" ]] || false
-    dolt reset --hard
-
-    dolt schema update-tag target col1 14690
-    dolt commit -am "update tag of col1 of target"
 
     run dolt merge other -m "merge other into main"
     [ $status -eq 0 ]


### PR DESCRIPTION
Two tables can have identical schemas, but different column tags if the columns were created in different orders (e.g. a different sequence of alters to get to the same schema). When we try to merge those two tables, we see that there is not a common ancestor, so we require the schemas to be exactly identical in order to merge the data. This results in a confusing merge error for customers because we tell them the schemas are different, but they look exactly the same (except for the different column tags). 

This change removes column tags from equality checks when testing equality of two schemas and enables the case above to merge cleanly. 