### PR TITLE
Use absolute paths for data-dir and related options

### DIFF
--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -105,6 +105,7 @@ const (
 	UserFlag              = "user"
 	DefaultUser           = "root"
 	DefaultHost           = "localhost"
+	UseDbFlag             = "use-db"
 
 	welcomeMsg = `# Welcome to the DoltSQL shell.
 # Statements must be terminated with ';'.
@@ -436,29 +437,6 @@ func execSaveQuery(ctx *sql.Context, dEnv *env.DoltEnv, qryist cli.Queryist, apr
 	}
 
 	return 0
-}
-
-// getMultiRepoEnv returns an appropriate MultiRepoEnv for this invocation of the command
-func getMultiRepoEnv(ctx context.Context, workingDir string, dEnv *env.DoltEnv) (mrEnv *env.MultiRepoEnv, resolvedDir string, verr errhand.VerboseError) {
-	var err error
-	fs := dEnv.FS
-	if len(workingDir) > 0 {
-		fs, err = fs.WithWorkingDir(workingDir)
-	}
-	if err != nil {
-		return nil, "", errhand.VerboseErrorFromError(err)
-	}
-	resolvedDir, err = fs.Abs("")
-	if err != nil {
-		return nil, "", errhand.VerboseErrorFromError(err)
-	}
-
-	mrEnv, err = env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), fs, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
-	if err != nil {
-		return nil, "", errhand.VerboseErrorFromError(err)
-	}
-
-	return mrEnv, resolvedDir, nil
 }
 
 func execBatch(

--- a/go/cmd/dolt/commands/sqlserver/sqlclient.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlclient.go
@@ -44,7 +44,6 @@ import (
 const (
 	sqlClientDualFlag     = "dual"
 	SqlClientQueryFlag    = "query"
-	SqlClientUseDbFlag    = "use-db"
 	sqlClientResultFormat = "result-format"
 )
 
@@ -85,7 +84,7 @@ func (cmd SqlClientCmd) ArgParser() *argparser.ArgParser {
 	ap := SqlServerCmd{}.ArgParserWithName(cmd.Name())
 	ap.SupportsFlag(sqlClientDualFlag, "d", "Causes this command to spawn a dolt server that is automatically connected to.")
 	ap.SupportsString(SqlClientQueryFlag, "q", "string", "Sends the given query to the server and immediately exits.")
-	ap.SupportsString(SqlClientUseDbFlag, "", "db_name", fmt.Sprintf("Selects the given database before executing a query. "+
+	ap.SupportsString(commands.UseDbFlag, "", "db_name", fmt.Sprintf("Selects the given database before executing a query. "+
 		"By default, uses the current folder's name. Must be used with the --%s flag.", SqlClientQueryFlag))
 	ap.SupportsString(sqlClientResultFormat, "", "format", fmt.Sprintf("Returns the results in the given format. Must be used with the --%s flag.", SqlClientQueryFlag))
 	return ap
@@ -127,8 +126,8 @@ func (cmd SqlClientCmd) Exec(ctx context.Context, commandStr string, args []stri
 			cli.PrintErrln(color.RedString(fmt.Sprintf("--%s flag may not be used with --%s", sqlClientDualFlag, SqlClientQueryFlag)))
 			return 1
 		}
-		if apr.Contains(SqlClientUseDbFlag) {
-			cli.PrintErrln(color.RedString(fmt.Sprintf("--%s flag may not be used with --%s", sqlClientDualFlag, SqlClientUseDbFlag)))
+		if apr.Contains(commands.UseDbFlag) {
+			cli.PrintErrln(color.RedString(fmt.Sprintf("--%s flag may not be used with --%s", sqlClientDualFlag, commands.UseDbFlag)))
 			return 1
 		}
 		if apr.Contains(sqlClientResultFormat) {
@@ -168,13 +167,13 @@ func (cmd SqlClientCmd) Exec(ctx context.Context, commandStr string, args []stri
 	}
 
 	query, hasQuery := apr.GetValue(SqlClientQueryFlag)
-	dbToUse, hasUseDb := apr.GetValue(SqlClientUseDbFlag)
+	dbToUse, hasUseDb := apr.GetValue(commands.UseDbFlag)
 	resultFormat, hasResultFormat := apr.GetValue(sqlClientResultFormat)
 	if !hasQuery && hasUseDb {
-		cli.PrintErrln(color.RedString(fmt.Sprintf("--%s may only be used with --%s", SqlClientUseDbFlag, SqlClientQueryFlag)))
+		cli.PrintErrln(color.RedString(fmt.Sprintf("--%s may only be used with --%s", commands.UseDbFlag, SqlClientQueryFlag)))
 		return 1
 	} else if !hasQuery && hasResultFormat {
-		cli.PrintErrln(color.RedString(fmt.Sprintf("--%s may only be used with --%s", SqlClientUseDbFlag, sqlClientResultFormat)))
+		cli.PrintErrln(color.RedString(fmt.Sprintf("--%s may only be used with --%s", commands.UseDbFlag, sqlClientResultFormat)))
 		return 1
 	}
 	if !hasUseDb && hasQuery {

--- a/go/libraries/doltcore/env/multi_repo_env.go
+++ b/go/libraries/doltcore/env/multi_repo_env.go
@@ -58,6 +58,11 @@ type MultiRepoEnv struct {
 	ignoreLockFile bool
 }
 
+// NewMultiEnv returns a new MultiRepoEnv instance dirived from a root DoltEnv instance.
+func MultiEnvForSingleEnv(ctx context.Context, env *DoltEnv) (*MultiRepoEnv, error) {
+	return MultiEnvForDirectory(ctx, env.Config.WriteableConfig(), env.FS, env.Version, env.IgnoreLockFile, env)
+}
+
 // MultiEnvForDirectory returns a MultiRepoEnv for the directory rooted at the file system given. The doltEnv from the
 // invoking context is included. If it's non-nil and valid, it will be included in the returned MultiRepoEnv, and will
 // be the first database in all iterations.

--- a/integration-tests/bats/replication-multidb.bats
+++ b/integration-tests/bats/replication-multidb.bats
@@ -249,6 +249,7 @@ call dolt_commit('-am', 'new table');
 SQL
 
     cd $TMPDIRS
+    mkdir -p "dbs2"
 
     # this is a hack: we have to change our persisted global server
     # vars for the sql command to work on the replica TODO: fix this

--- a/integration-tests/bats/sql.bats
+++ b/integration-tests/bats/sql.bats
@@ -1031,7 +1031,7 @@ SQL
     run dolt sql -r csv -q "select @@character_set_client"
     [ $status -eq 0 ]
     [[ "$output" =~ "utf8mb4" ]] || false
-    
+
     run dolt sql -r json -q "select * from test order by a"
     [ $status -eq 0 ]
     [ "$output" == '{"rows": [{"a":1,"b":1.5,"c":"1","d":"2020-01-01 00:00:00"},{"a":2,"b":2.5,"c":"2","d":"2020-02-02 00:00:00"},{"a":3,"c":"3","d":"2020-03-03 00:00:00"},{"a":4,"b":4.5,"d":"2020-04-04 00:00:00"},{"a":5,"b":5.5,"c":"5"}]}' ]
@@ -2775,4 +2775,58 @@ SQL
 [[ "$output" =~ "Query OK, 1 row affected (1".*" sec)" ]] || false
 [[ "$output" =~ "Query OK, 1 row affected (2".*" sec)" ]] || false
 [[ "$output" =~ "Query OK, 1 row affected (3".*" sec)" ]] || false
+}
+
+
+@test "sql: check --data-dir used from a completely different location and still resolve DB names" {
+    # remove config files
+    rm -rf .doltcfg
+    rm -rf db_dir
+
+    mkdir db_dir
+    cd db_dir
+    ROOT_DIR=$(pwd)
+
+    # create an alternate database, without the table
+    mkdir dba
+    cd dba
+    dolt init
+    cd ..
+    dolt sql -q "create table dba_tbl (id int)"
+
+    mkdir dbb
+    cd dbb
+    dolt init
+    dolt sql -q "create table dbb_tbl (id int)"
+
+    # Ensure --data-dir flag is really used by changing the cwd.
+    cd /tmp
+
+    run dolt --data-dir="$ROOT_DIR/dbb" sql -q "show tables"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "dbb_tbl" ]] || false
+
+    run dolt --data-dir="$ROOT_DIR/dba" sql -q "show tables"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "dba_tbl" ]] || false
+
+    # Default to first DB alphabetically.
+    run dolt --data-dir="$ROOT_DIR" sql -q "show tables"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "dba_tbl" ]] || false
+
+    # --use-db arg can be used to be specific.
+    run dolt --data-dir="$ROOT_DIR" --use-db=dbb sql -q "show tables"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "dbb_tbl" ]] || false
+
+    # Redundant use of the flag is OK.
+    run dolt --data-dir="$ROOT_DIR/dbb" --use-db=dbb sql -q "show tables"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "dbb_tbl" ]] || false
+
+    # Use of the use-db flag when we have a different DB specified by data-dir should error.
+    run dolt --data-dir="$ROOT_DIR/dbb" --use-db=dba sql -q "show tables"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "database not found" ]] || false
 }


### PR DESCRIPTION
Collection of small changes related to global configuration arguments.
 * Provide the --use-db flag to indicate which database to use if its unclear.
 * Don't create a new multi repo environment in the late bind context. Create the first one correctly and reuse it.
 * Enforce that the --data-dir directory exists.
 * Convert relative paths from user to absolute paths
 * Removed some dead code.

One more step in the journey: https://github.com/dolthub/dolt/issues/3922