### PR TITLE
Print global arguments for 'dolt --help' but not 'dolt'

### DIFF
--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -427,6 +427,12 @@ func runMain() int {
 	globalArgs, args, initCliContext, printUsage, err := splitArgsOnSubCommand(args)
 	if printUsage {
 		doltCommand.PrintUsage("dolt")
+		_, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString("dolt", doc, globalArgParser))
+
+		cli.Println("\n\nDolt subcommands are in transition to using the flags listed below as global flags.  ")
+		cli.Println("The sql subcommand is currently the only command that uses these flags.  All other commands will ignore them.\n")
+		usage()
+
 		return 0
 	}
 	if err != nil {

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -429,8 +429,11 @@ func runMain() int {
 		doltCommand.PrintUsage("dolt")
 		_, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString("dolt", doc, globalArgParser))
 
-		cli.Println("\n\nDolt subcommands are in transition to using the flags listed below as global flags.  ")
-		cli.Println("The sql subcommand is currently the only command that uses these flags.  All other commands will ignore them.\n")
+		specialMsg := `
+Dolt subcommands are in transition to using the flags listed below as global flags.
+The sql subcommand is currently the only command that uses these flags. All other commands will ignore them.
+`
+		cli.Println(specialMsg)
 		usage()
 
 		return 0


### PR DESCRIPTION
Update the Dolt CLI To print the global flags when the --help flag is provided. New look:

```
$ dolt --help
Valid commands for dolt are
                init - Create an empty Dolt data repository.
              status - Show the working tree status.
                 add - Add table changes to the list of staged table changes.
                diff - Diff a table.
               reset - Remove table changes from the list of staged table changes.
               clean - Remove untracked tables from working set.
              commit - Record changes to the repository.
                 sql - Run a SQL query against tables in repository.
          sql-server - Start a MySQL-compatible server.
          sql-client - Starts a built-in MySQL client.
                 log - Show commit logs.
                show - Show information about a specific commit.
              branch - Create, list, edit, delete branches.
            checkout - Checkout a branch or overwrite a table from HEAD.
               merge - Merge a branch.
           conflicts - Commands for viewing and resolving merge conflicts.
         cherry-pick - Apply the changes introduced by an existing commit.
              revert - Undo the changes introduced in a commit.
               clone - Clone from a remote data repository.
               fetch - Update the database from a remote data repository.
                pull - Fetch from a dolt remote data repository and merge.
                push - Push to a dolt remote.
              config - Dolt configuration.
              remote - Manage set of tracked repositories.
              backup - Manage a set of server backups.
               login - Login to a dolt remote host.
               creds - Commands for managing credentials.
                  ls - List tables in the working set.
              schema - Commands for showing and importing table schemas.
               table - Commands for copying, renaming, deleting, and exporting tables.
                 tag - Create, list, delete tags.
               blame - Show what revision and author last modified each row of a table.
         constraints - Commands for handling constraints.
             migrate - Executes a database migration to use the latest Dolt data format.
         read-tables - Fetch table(s) at a specific commit into a new dolt repo
                  gc - Cleans up unreferenced data from the repository.
       filter-branch - Edits the commit history using the provided query.
          merge-base - Find the common ancestor of two commits.
             version - Displays the current Dolt cli version.
                dump - Export all tables in the working set into a file.
                docs - Commands for working with Dolt documents.
               stash - Stash the changes in a dirty working directory away.


Dolt subcommands are in transition to using the flags listed below as global flags.
The sql subcommand is currently the only command that uses these flags.  All other commands will ignore them.

usage: dolt <--data-dir=<path>> subcommand <subcommand arguments>

Specific dolt options
    -u <user>, --user=<user>
      Defines the local superuser (defaults to `root`). If the specified user exists, will take on permissions of that user.

    --data-dir=<directory>
      Defines a directory whose subdirectories should all be dolt data repositories accessible as independent databases within. Defaults to the current directory.

    --doltcfg-dir=<directory>
      Defines a directory that contains configuration files for dolt. Defaults to `$data-dir/.doltcfg`. Will only be created if there is a change to configuration settings.

    --privilege-file=<privilege file>
      Path to a file to load and store users and grants. Defaults to `$doltcfg-dir/privileges.db`. Will only be created if there is a change to privileges.

    --branch-control-file=<branch control file>
      Path to a file to load and store branch control permissions. Defaults to `$doltcfg-dir/branch_control.db`. Will only be created if there is a change to branch control permissions.
```