### PR TITLE
Add support for `dolt table import -a`

### DIFF
--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -285,11 +285,11 @@ func validateImportArgs(apr *argparser.ArgParseResults) errhand.VerboseError {
 	}
 
 	if !apr.ContainsAny(createParam, updateParam, replaceParam, appendParam) {
-		return errhand.BuildDError("Must specify exactly one of -c, -u, -a, or -r.").Build()
+		return errhand.BuildDError("Must specify exactly one of -c, -u, -a, or -r.").SetPrintUsage().Build()
 	}
 
 	if len(apr.ContainsMany(createParam, updateParam, replaceParam, appendParam)) > 1 {
-		return errhand.BuildDError("Must specify exactly one of -c, -u, -a, or -r.").Build()
+		return errhand.BuildDError("Must specify exactly one of -c, -u, -a, or -r.").SetPrintUsage().Build()
 	}
 
 	if apr.Contains(schemaParam) && !apr.Contains(createParam) {

--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -92,13 +92,15 @@ The schema for the new table can be specified explicitly by providing a SQL sche
 
 If {{.EmphasisLeft}}--update-table | -u{{.EmphasisRight}} is given the operation will update {{.LessThan}}table{{.GreaterThan}} with the contents of file. The table's existing schema will be used, and field names will be used to match file fields with table fields unless a mapping file is specified.
 
-During import, if there is an error importing any row, the import will be aborted by default. Use the {{.EmphasisLeft}}--continue{{.EmphasisRight}} flag to continue importing when an error is encountered. You can add the {{.EmphasisLeft}}--quiet{{.EmphasisRight}} flag to prevent the import utility from printing all the skipped rows. 
+If {{.EmphasisLeft}}--append-table | -a{{.EmphasisRight}} is given the operation will add the contents of the file to {{.LessThan}}table{{.GreaterThan}}, without modifying any of the rows of {{.LessThan}}table{{.GreaterThan}}. If the file contains a row that matches the primary key of a row already in the table, the import will be aborted unless the --continue flag is used (in which case that row will not be imported.) The table's existing schema will be used, and field names will be used to match file fields with table fields unless a mapping file is specified.
 
 If {{.EmphasisLeft}}--replace-table | -r{{.EmphasisRight}} is given the operation will replace {{.LessThan}}table{{.GreaterThan}} with the contents of the file. The table's existing schema will be used, and field names will be used to match file fields with table fields unless a mapping file is specified.
 
 If the schema for the existing table does not match the schema for the new file, the import will be aborted by default. To overwrite both the table and the schema, use {{.EmphasisLeft}}-c -f{{.EmphasisRight}}.
 
 A mapping file can be used to map fields between the file being imported and the table being written to. This can be used when creating a new table, or updating or replacing an existing table.
+
+During import, if there is an error importing any row, the import will be aborted by default. Use the {{.EmphasisLeft}}--continue{{.EmphasisRight}} flag to continue importing when an error is encountered. You can add the {{.EmphasisLeft}}--quiet{{.EmphasisRight}} flag to prevent the import utility from printing all the skipped rows. 
 
 ` + schcmds.MappingFileHelp +
 		`
@@ -109,6 +111,7 @@ In create, update, and replace scenarios the file's extension is used to infer t
 	Synopsis: []string{
 		"-c [-f] [--pk {{.LessThan}}field{{.GreaterThan}}] [--schema {{.LessThan}}file{{.GreaterThan}}] [--map {{.LessThan}}file{{.GreaterThan}}] [--continue]  [--quiet] [--disable-fk-checks] [--file-type {{.LessThan}}type{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
 		"-u [--map {{.LessThan}}file{{.GreaterThan}}] [--continue] [--quiet] [--file-type {{.LessThan}}type{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
+		"-a [--map {{.LessThan}}file{{.GreaterThan}}] [--continue] [--quiet] [--file-type {{.LessThan}}type{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
 		"-r [--map {{.LessThan}}file{{.GreaterThan}}] [--file-type {{.LessThan}}type{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
 	},
 }

--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -283,8 +283,12 @@ func validateImportArgs(apr *argparser.ArgParseResults) errhand.VerboseError {
 		return errhand.BuildDError("parameters %s and %s are mutually exclusive", schemaParam, primaryKeyParam).Build()
 	}
 
-	if !apr.Contains(createParam) && !apr.Contains(updateParam) && !apr.Contains(replaceParam) {
-		return errhand.BuildDError("Must include '-c' for initial table import or -u to update existing table or -r to replace existing table.").Build()
+	if !apr.ContainsAny(createParam, updateParam, replaceParam, appendParam) {
+		return errhand.BuildDError("Must include '-c' for initial table import or -u to update existing table or -a to append to existing table or -r to replace existing table.").Build()
+	}
+
+	if len(apr.ContainsMany(createParam, updateParam, replaceParam, appendParam)) > 1 {
+		return errhand.BuildDError("Must not include multiple of '-c' for initial table import or -u to update existing table or -a to append to existing table or -r to replace existing table.").Build()
 	}
 
 	if apr.Contains(schemaParam) && !apr.Contains(createParam) {

--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -54,6 +54,7 @@ const (
 	createParam       = "create-table"
 	updateParam       = "update-table"
 	replaceParam      = "replace-table"
+	appendParam       = "append-table"
 	tableParam        = "table"
 	fileParam         = "file"
 	schemaParam       = "schema"
@@ -237,6 +238,8 @@ func getImportMoveOptions(ctx context.Context, apr *argparser.ArgParseResults, d
 		moveOp = mvdata.CreateOp
 	case apr.Contains(replaceParam):
 		moveOp = mvdata.ReplaceOp
+	case apr.Contains(appendParam):
+		moveOp = mvdata.AppendOp
 	default:
 		moveOp = mvdata.UpdateOp
 	}
@@ -352,6 +355,7 @@ func (cmd ImportCmd) ArgParser() *argparser.ArgParser {
 	ap.ArgListHelp = append(ap.ArgListHelp, [2]string{fileParam, "The file being imported. Supported file types are csv, psv, and nbf."})
 	ap.SupportsFlag(createParam, "c", "Create a new table, or overwrite an existing table (with the -f flag) from the imported data.")
 	ap.SupportsFlag(updateParam, "u", "Update an existing table with the imported data.")
+	ap.SupportsFlag(appendParam, "a", "Require that the operation will not modify any rows in the table.")
 	ap.SupportsFlag(forceParam, "f", "If a create operation is being executed, data already exists in the destination, the force flag will allow the target to be overwritten.")
 	ap.SupportsFlag(replaceParam, "r", "Replace existing table with imported data while preserving the original schema.")
 	ap.SupportsFlag(contOnErrParam, "", "Continue importing when row import errors are encountered.")

--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -17,7 +17,6 @@ package tblcmds
 import (
 	"context"
 	"fmt"
-	"gopkg.in/src-d/go-errors.v1"
 	"io"
 	"os"
 	"regexp"
@@ -31,6 +30,7 @@ import (
 	"github.com/fatih/color"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/text/message"
+	"gopkg.in/src-d/go-errors.v1"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands"

--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -285,11 +285,11 @@ func validateImportArgs(apr *argparser.ArgParseResults) errhand.VerboseError {
 	}
 
 	if !apr.ContainsAny(createParam, updateParam, replaceParam, appendParam) {
-		return errhand.BuildDError("Must include '-c' for initial table import or -u to update existing table or -a to append to existing table or -r to replace existing table.").Build()
+		return errhand.BuildDError("Must specify exactly one of -c, -u, -a, or -r.").Build()
 	}
 
 	if len(apr.ContainsMany(createParam, updateParam, replaceParam, appendParam)) > 1 {
-		return errhand.BuildDError("Must not include multiple of '-c' for initial table import or -u to update existing table or -a to append to existing table or -r to replace existing table.").Build()
+		return errhand.BuildDError("Must specify exactly one of -c, -u, -a, or -r.").Build()
 	}
 
 	if apr.Contains(schemaParam) && !apr.Contains(createParam) {

--- a/go/libraries/doltcore/mvdata/data_mover.go
+++ b/go/libraries/doltcore/mvdata/data_mover.go
@@ -161,4 +161,5 @@ const (
 	CreateOp  TableImportOp = "overwrite"
 	ReplaceOp TableImportOp = "replace"
 	UpdateOp  TableImportOp = "update"
+	AppendOp  TableImportOp = "append"
 )

--- a/go/libraries/doltcore/mvdata/engine_table_writer.go
+++ b/go/libraries/doltcore/mvdata/engine_table_writer.go
@@ -334,7 +334,7 @@ func (s *SqlEngineTableWriter) createTable() error {
 // getInsertNode returns the sql.Node to be iterated on given the import option.
 func (s *SqlEngineTableWriter) getInsertNode(inputChannel chan sql.Row) (sql.Node, error) {
 	switch s.importOption {
-	case CreateOp, ReplaceOp:
+	case CreateOp, ReplaceOp, AppendOp:
 		return s.createInsertImportNode(inputChannel, s.contOnErr, false, nil) // contonerr translates to ignore
 	case UpdateOp:
 		return s.createInsertImportNode(inputChannel, s.contOnErr, false, generateOnDuplicateKeyExpressions(s.rowOperationSchema.Schema)) // contonerr translates to ignore

--- a/integration-tests/bats/import-append-tables.bats
+++ b/integration-tests/bats/import-append-tables.bats
@@ -48,10 +48,14 @@ CSV
     run dolt table import -a t --continue <<CSV
 pk, col1
 1, 1
+2, 3
 CSV
 
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "Rows Processed: 1, Modifications: 0, Had No Effect: 1" ]] || false
+    [[ "$output" =~ "The following rows were skipped:" ]] || false
+    [[ "$output" =~ "[1,1]" ]] || false
+    [[ "$output" =~ "Rows Processed: 1, Additions: 1, Modifications: 0, Had No Effect: 0" ]] || false
+    [[ "$output" =~ "Lines skipped: 1" ]] || false
 }
 
 @test "import-append-tables: reject rows in source that would modify rows in destination, but continue if --continue is supplied" {

--- a/integration-tests/bats/import-append-tables.bats
+++ b/integration-tests/bats/import-append-tables.bats
@@ -24,6 +24,11 @@ CSV
     [ "$status" -eq 1 ]
     [[ "$output" =~ "An error occurred while moving data" ]] || false
     [[ "$output" =~ "row [1,1] would be overwritten by [1,2]" ]] || false
+
+    run dolt sql -q "select * from t"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "| 1 | 1 |" ]] || false
+    [ ! [["$output" =~ "| 1 | 2 |" ]] ] || false
 }
 
 @test "import-append-tables: disallow multiple keys with different values during append" {
@@ -37,6 +42,11 @@ CSV
     [ "$status" -eq 1 ]
     [[ "$output" =~ "An error occurred while moving data" ]] || false
     [[ "$output" =~ "row [1,1] would be overwritten by [1,2]" ]] || false
+
+    run dolt sql -q "select * from t"
+    [ "$status" -eq 0 ]
+    [ ! [[ "$output" =~ "| 1 | 1 |" ]] ] || false
+    [ ! [[ "$output" =~ "| 1 | 2 |" ]] ] || false
 }
 
 @test "import-append-tables: ignore rows that would have no effect on import" {
@@ -56,6 +66,11 @@ CSV
     [[ "$output" =~ "[1,1]" ]] || false
     [[ "$output" =~ "Rows Processed: 1, Additions: 1, Modifications: 0, Had No Effect: 0" ]] || false
     [[ "$output" =~ "Lines skipped: 1" ]] || false
+
+    run dolt sql -q "select * from t"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "| 1 | 1 |" ]] || false
+    [[ "$output" =~ "| 2 | 3 |" ]] || false
 }
 
 @test "import-append-tables: reject rows in source that would modify rows in destination, but continue if --continue is supplied" {
@@ -75,4 +90,10 @@ CSV
     [[ "$output" =~ "[1,2]" ]] || false
     [[ "$output" =~ "Rows Processed: 1, Additions: 1, Modifications: 0, Had No Effect: 0" ]] || false
     [[ "$output" =~ "Lines skipped: 1" ]] || false
+
+    run dolt sql -q "select * from t"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "| 1 | 1 |" ]] || false
+    [[ "$output" =~ "| 2 | 3 |" ]] || false
+    [ ! [[ "$output" =~ "| 1 | 2 |" ]] ] || false
 }

--- a/integration-tests/bats/import-append-tables.bats
+++ b/integration-tests/bats/import-append-tables.bats
@@ -21,6 +21,7 @@ pk, col1
 1, 2
 CSV
 
+    echo "$output"
     [ "$status" -eq 1 ]
     [[ "$output" =~ "An error occurred while moving data" ]] || false
     [[ "$output" =~ "row [1,1] would be overwritten by [1,2]" ]] || false
@@ -41,6 +42,7 @@ pk, col1
 1, 2
 CSV
 
+    echo "$output"
     [ "$status" -eq 1 ]
     [[ "$output" =~ "An error occurred while moving data" ]] || false
     [[ "$output" =~ "row [1,1] would be overwritten by [1,2]" ]] || false

--- a/integration-tests/bats/import-append-tables.bats
+++ b/integration-tests/bats/import-append-tables.bats
@@ -30,6 +30,7 @@ CSV
     [ "$status" -eq 0 ]
     [[   "$output" =~ "| 1  | 1    |" ]] || false
     [[ ! "$output" =~ "| 1  | 2    |" ]] || false
+    [ "${#lines[@]}" -eq 5 ]
 }
 
 @test "import-append-tables: disallow multiple keys with different values during append" {
@@ -48,6 +49,7 @@ CSV
     [ "$status" -eq 0 ]
     [[ ! "$output" =~ "| 1  | 1    |" ]] || false
     [[ ! "$output" =~ "| 1  | 2    |" ]] || false
+    [ "${#lines[@]}" -eq 0 ]
 }
 
 @test "import-append-tables: ignore rows that would have no effect on import" {
@@ -72,6 +74,7 @@ CSV
     [ "$status" -eq 0 ]
     [[ "$output" =~ "| 1  | 1    |" ]] || false
     [[ "$output" =~ "| 2  | 3    |" ]] || false
+    [ "${#lines[@]}" -eq 6 ]
 }
 
 @test "import-append-tables: reject rows in source that would modify rows in destination, but continue if --continue is supplied" {
@@ -97,4 +100,5 @@ CSV
     [[   "$output" =~ "| 1  | 1    |" ]] || false
     [[   "$output" =~ "| 2  | 3    |" ]] || false
     [[ ! "$output" =~ "| 1  | 2    |" ]] || false
+    [ "${#lines[@]}" -eq 6 ]
 }

--- a/integration-tests/bats/import-append-tables.bats
+++ b/integration-tests/bats/import-append-tables.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+load $BATS_TEST_DIRNAME/helper/common.bash
+
+setup() {
+    setup_common
+}
+
+teardown() {
+    assert_feature_version
+    teardown_common
+}
+
+@test "import-append-tables: " {
+    dolt sql -q "CREATE TABLE t (pk int primary key, col1 int);"
+    dolt import -a <<CSV
+pk, col1
+1, 1
+CSV
+    run dolt import -a <<CSV
+pk, col1
+1, 2
+CSV
+
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "An error occurred while moving data" ]] || false
+    # [[ "$output" =~ "cause: error: row [1,1] would be overwritten by [1,2]" ]] || false
+}

--- a/integration-tests/bats/import-append-tables.bats
+++ b/integration-tests/bats/import-append-tables.bats
@@ -28,7 +28,7 @@ CSV
     run dolt sql -q "select * from t"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "| 1 | 1 |" ]] || false
-    [ ! [["$output" =~ "| 1 | 2 |" ]] ] || false
+    [[ ! "$output" =~ "| 1 | 2 |" ]] || false
 }
 
 @test "import-append-tables: disallow multiple keys with different values during append" {
@@ -45,8 +45,8 @@ CSV
 
     run dolt sql -q "select * from t"
     [ "$status" -eq 0 ]
-    [ ! [[ "$output" =~ "| 1 | 1 |" ]] ] || false
-    [ ! [[ "$output" =~ "| 1 | 2 |" ]] ] || false
+    [[ ! "$output" =~ "| 1 | 1 |" ]] || false
+    [[ ! "$output" =~ "| 1 | 2 |" ]] || false
 }
 
 @test "import-append-tables: ignore rows that would have no effect on import" {
@@ -95,5 +95,5 @@ CSV
     [ "$status" -eq 0 ]
     [[ "$output" =~ "| 1 | 1 |" ]] || false
     [[ "$output" =~ "| 2 | 3 |" ]] || false
-    [ ! [[ "$output" =~ "| 1 | 2 |" ]] ] || false
+    [[ ! "$output" =~ "| 1 | 2 |" ]] || false
 }

--- a/integration-tests/bats/import-append-tables.bats
+++ b/integration-tests/bats/import-append-tables.bats
@@ -35,6 +35,7 @@ CSV
 }
 
 @test "import-append-tables: disallow multiple keys with different values during append" {
+    skip_nbf_not_dolt
     dolt sql -q "CREATE TABLE t (pk int primary key, col1 int);"
     run dolt table import -a t <<CSV
 pk, col1
@@ -55,6 +56,7 @@ CSV
 }
 
 @test "import-append-tables: ignore rows that would have no effect on import" {
+    skip_nbf_not_dolt
     dolt sql -q "CREATE TABLE t (pk int primary key, col1 int);"
     dolt table import -a t <<CSV
 pk, col1
@@ -80,6 +82,7 @@ CSV
 }
 
 @test "import-append-tables: reject rows in source that would modify rows in destination, but continue if --continue is supplied" {
+    skip_nbf_not_dolt
     dolt sql -q "CREATE TABLE t (pk int primary key, col1 int);"
     dolt table import -a t <<CSV
 pk, col1

--- a/integration-tests/bats/import-append-tables.bats
+++ b/integration-tests/bats/import-append-tables.bats
@@ -26,9 +26,10 @@ CSV
     [[ "$output" =~ "row [1,1] would be overwritten by [1,2]" ]] || false
 
     run dolt sql -q "select * from t"
+    echo "$output"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "| 1 | 1 |" ]] || false
-    [[ ! "$output" =~ "| 1 | 2 |" ]] || false
+    [[   "$output" =~ "| 1  | 1    |" ]] || false
+    [[ ! "$output" =~ "| 1  | 2    |" ]] || false
 }
 
 @test "import-append-tables: disallow multiple keys with different values during append" {
@@ -45,8 +46,8 @@ CSV
 
     run dolt sql -q "select * from t"
     [ "$status" -eq 0 ]
-    [[ ! "$output" =~ "| 1 | 1 |" ]] || false
-    [[ ! "$output" =~ "| 1 | 2 |" ]] || false
+    [[ ! "$output" =~ "| 1  | 1    |" ]] || false
+    [[ ! "$output" =~ "| 1  | 2    |" ]] || false
 }
 
 @test "import-append-tables: ignore rows that would have no effect on import" {
@@ -69,8 +70,8 @@ CSV
 
     run dolt sql -q "select * from t"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "| 1 | 1 |" ]] || false
-    [[ "$output" =~ "| 2 | 3 |" ]] || false
+    [[ "$output" =~ "| 1  | 1    |" ]] || false
+    [[ "$output" =~ "| 2  | 3    |" ]] || false
 }
 
 @test "import-append-tables: reject rows in source that would modify rows in destination, but continue if --continue is supplied" {
@@ -93,7 +94,7 @@ CSV
 
     run dolt sql -q "select * from t"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "| 1 | 1 |" ]] || false
-    [[ "$output" =~ "| 2 | 3 |" ]] || false
-    [[ ! "$output" =~ "| 1 | 2 |" ]] || false
+    [[   "$output" =~ "| 1  | 1    |" ]] || false
+    [[   "$output" =~ "| 2  | 3    |" ]] || false
+    [[ ! "$output" =~ "| 1  | 2    |" ]] || false
 }

--- a/integration-tests/bats/import-append-tables.bats
+++ b/integration-tests/bats/import-append-tables.bats
@@ -11,6 +11,7 @@ teardown() {
 }
 
 @test "import-append-tables: disallow overwriting row during append" {
+    skip_nbf_not_dolt
     dolt sql -q "CREATE TABLE t (pk int primary key, col1 int);"
     dolt table import -a t <<CSV
 pk, col1
@@ -21,7 +22,6 @@ pk, col1
 1, 2
 CSV
 
-    echo "$output"
     [ "$status" -eq 1 ]
     [[ "$output" =~ "An error occurred while moving data" ]] || false
     [[ "$output" =~ "row [1,1] would be overwritten by [1,2]" ]] || false

--- a/integration-tests/bats/import-tables.bats
+++ b/integration-tests/bats/import-tables.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+load $BATS_TEST_DIRNAME/helper/common.bash
+
+setup() {
+    setup_common
+}
+
+teardown() {
+    assert_feature_version
+    teardown_common
+}
+
+@test "import-tables: error if no operation is provided" {
+    run dolt table import t test.csv
+
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Must include '-c' for initial table import or -u to update existing table or -a to append to existing table or -r to replace existing table." ]] || false
+}
+
+@test "import-tables: error if multiple operations are provided" {
+    run dolt table import -c -u -r t test.csv
+
+    echo "$output"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Must not include multiple of '-c' for initial table import or -u to update existing table or -a to append to existing table or -r to replace existing table." ]] || false
+}

--- a/integration-tests/bats/import-tables.bats
+++ b/integration-tests/bats/import-tables.bats
@@ -14,7 +14,7 @@ teardown() {
     run dolt table import t test.csv
 
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "Must include '-c' for initial table import or -u to update existing table or -a to append to existing table or -r to replace existing table." ]] || false
+    [[ "$output" =~ "Must specify exactly one of -c, -u, -a, or -r." ]] || false
 }
 
 @test "import-tables: error if multiple operations are provided" {
@@ -23,5 +23,5 @@ teardown() {
     echo "$output"
 
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "Must not include multiple of '-c' for initial table import or -u to update existing table or -a to append to existing table or -r to replace existing table." ]] || false
+    [[ "$output" =~ "Must specify exactly one of -c, -u, -a, or -r." ]] || false
 }


### PR DESCRIPTION
I ended up going with @zachmu's suggestion of making this a new operation type like `-u`, `-c`, and `-r` instead of a separate flag after I realized that `-c` and `-r` already disallow overwriting fields and it didn't really make sense to add a flag that could only be used with `-u`.

This is less ambitious than what was outlined in https://github.com/dolthub/dolt/issues/5936. Notably, I made a big deal in the issue about how you can import the same file multiple times or files that contain previously imported rows without issue. This was a mostly a pet feature that I erroneously assumed would be simple to implement. Given that it wasn't a requirement, after some exploration I ultimately decided to drop it.

This should be enough to unblock the customer; we talked about implementing a `--strict` flag too but I don't think it's necessary for their use case.