### PR TITLE
Use UTC timestamp in date comparison test.

### DIFF
--- a/integration-tests/bats/sql.bats
+++ b/integration-tests/bats/sql.bats
@@ -2544,7 +2544,7 @@ SQL
     [ "$status" -eq 0 ]
     [[ "$output" =~ "3" ]] || false
 
-    run dolt sql -q "SELECT COUNT(*) from dolt_diff_t where to_commit_date < now()"
+    run dolt sql -q "SELECT COUNT(*) from dolt_diff_t where to_commit_date < UTC_TIMESTAMP()"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "3" ]] || false
 }


### PR DESCRIPTION
Allows tests to run on laptops which aren't in UTC.