### PR TITLE
Smart routing for sql command execution against running local servers

### DIFF
--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -295,7 +295,12 @@ func sqlHandleVErrAndExitCode(queryist cli.Queryist, verr errhand.VerboseError, 
 			if _, ok := queryist.(*engine.SqlEngine); !ok {
 				// We are in a context where we are attempting to connect to a remote database. These errors
 				// are unstructured, so we add some additional context around them.
-				msg = fmt.Sprintf("Error connecting to remote database: \"%s\".", msg)
+				tmpMsg := `You've encountered a new behavior in dolt which is not fully documented yet.
+A local dolt server is using your dolt data directory, and in an attempt to service your request, we are attempting to 
+connect to it. That has failed. You should stop the server, or reach out to @macneale on https://discord.gg/gqr7K4VNKe
+for help.`
+				cli.PrintErrln(tmpMsg)
+				msg = fmt.Sprintf("A local server is running, and dolt is failing to connect. Error connecting to remote database: \"%s\".\n", msg)
 			}
 			cli.PrintErrln(msg)
 		}

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -105,6 +105,7 @@ const (
 	UserFlag              = "user"
 	DefaultUser           = "root"
 	DefaultHost           = "localhost"
+	UseDbFlag             = "use-db"
 
 	welcomeMsg = `# Welcome to the DoltSQL shell.
 # Statements must be terminated with ';'.
@@ -436,29 +437,6 @@ func execSaveQuery(ctx *sql.Context, dEnv *env.DoltEnv, qryist cli.Queryist, apr
 	}
 
 	return 0
-}
-
-// getMultiRepoEnv returns an appropriate MultiRepoEnv for this invocation of the command
-func getMultiRepoEnv(ctx context.Context, workingDir string, dEnv *env.DoltEnv) (mrEnv *env.MultiRepoEnv, resolvedDir string, verr errhand.VerboseError) {
-	var err error
-	fs := dEnv.FS
-	if len(workingDir) > 0 {
-		fs, err = fs.WithWorkingDir(workingDir)
-	}
-	if err != nil {
-		return nil, "", errhand.VerboseErrorFromError(err)
-	}
-	resolvedDir, err = fs.Abs("")
-	if err != nil {
-		return nil, "", errhand.VerboseErrorFromError(err)
-	}
-
-	mrEnv, err = env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), fs, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
-	if err != nil {
-		return nil, "", errhand.VerboseErrorFromError(err)
-	}
-
-	return mrEnv, resolvedDir, nil
 }
 
 func execBatch(

--- a/go/cmd/dolt/commands/sqlserver/sqlclient.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlclient.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/abiosoft/readline"
+	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
 	"github.com/dolthub/ishell"
@@ -135,7 +136,7 @@ func (cmd SqlClientCmd) Exec(ctx context.Context, commandStr string, args []stri
 			return 1
 		}
 
-		serverConfig, err = GetServerConfig(dEnv, apr)
+		serverConfig, err = GetServerConfig(dEnv.FS, apr)
 		if err != nil {
 			cli.PrintErrln(color.RedString("Bad Configuration"))
 			cli.PrintErrln(err.Error())
@@ -158,7 +159,7 @@ func (cmd SqlClientCmd) Exec(ctx context.Context, commandStr string, args []stri
 			return 1
 		}
 	} else {
-		serverConfig, err = GetServerConfig(dEnv, apr)
+		serverConfig, err = GetServerConfig(dEnv.FS, apr)
 		if err != nil {
 			cli.PrintErrln(color.RedString("Bad Configuration"))
 			cli.PrintErrln(err.Error())
@@ -473,8 +474,8 @@ var _ cli.Queryist = ConnectionQueryist{}
 
 // BuildConnectionStringQueryist returns a Queryist that connects to the server specified by the given server config. Presence in this
 // module isn't ideal, but it's the only way to get the server config into the queryist.
-func BuildConnectionStringQueryist(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.ArgParseResults, port int, database string) (cli.LateBindQueryist, error) {
-	serverConfig, err := GetServerConfig(dEnv, apr)
+func BuildConnectionStringQueryist(ctx context.Context, cwdFS filesys.Filesys, apr *argparser.ArgParseResults, port int, database string) (cli.LateBindQueryist, error) {
+	serverConfig, err := GetServerConfig(cwdFS, apr)
 	if err != nil {
 		return nil, err
 	}

--- a/go/cmd/dolt/commands/sqlserver/sqlclient.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlclient.go
@@ -44,7 +44,6 @@ import (
 const (
 	sqlClientDualFlag     = "dual"
 	SqlClientQueryFlag    = "query"
-	SqlClientUseDbFlag    = "use-db"
 	sqlClientResultFormat = "result-format"
 )
 
@@ -85,7 +84,7 @@ func (cmd SqlClientCmd) ArgParser() *argparser.ArgParser {
 	ap := SqlServerCmd{}.ArgParserWithName(cmd.Name())
 	ap.SupportsFlag(sqlClientDualFlag, "d", "Causes this command to spawn a dolt server that is automatically connected to.")
 	ap.SupportsString(SqlClientQueryFlag, "q", "string", "Sends the given query to the server and immediately exits.")
-	ap.SupportsString(SqlClientUseDbFlag, "", "db_name", fmt.Sprintf("Selects the given database before executing a query. "+
+	ap.SupportsString(commands.UseDbFlag, "", "db_name", fmt.Sprintf("Selects the given database before executing a query. "+
 		"By default, uses the current folder's name. Must be used with the --%s flag.", SqlClientQueryFlag))
 	ap.SupportsString(sqlClientResultFormat, "", "format", fmt.Sprintf("Returns the results in the given format. Must be used with the --%s flag.", SqlClientQueryFlag))
 	return ap
@@ -127,8 +126,8 @@ func (cmd SqlClientCmd) Exec(ctx context.Context, commandStr string, args []stri
 			cli.PrintErrln(color.RedString(fmt.Sprintf("--%s flag may not be used with --%s", sqlClientDualFlag, SqlClientQueryFlag)))
 			return 1
 		}
-		if apr.Contains(SqlClientUseDbFlag) {
-			cli.PrintErrln(color.RedString(fmt.Sprintf("--%s flag may not be used with --%s", sqlClientDualFlag, SqlClientUseDbFlag)))
+		if apr.Contains(commands.UseDbFlag) {
+			cli.PrintErrln(color.RedString(fmt.Sprintf("--%s flag may not be used with --%s", sqlClientDualFlag, commands.UseDbFlag)))
 			return 1
 		}
 		if apr.Contains(sqlClientResultFormat) {
@@ -168,13 +167,13 @@ func (cmd SqlClientCmd) Exec(ctx context.Context, commandStr string, args []stri
 	}
 
 	query, hasQuery := apr.GetValue(SqlClientQueryFlag)
-	dbToUse, hasUseDb := apr.GetValue(SqlClientUseDbFlag)
+	dbToUse, hasUseDb := apr.GetValue(commands.UseDbFlag)
 	resultFormat, hasResultFormat := apr.GetValue(sqlClientResultFormat)
 	if !hasQuery && hasUseDb {
-		cli.PrintErrln(color.RedString(fmt.Sprintf("--%s may only be used with --%s", SqlClientUseDbFlag, SqlClientQueryFlag)))
+		cli.PrintErrln(color.RedString(fmt.Sprintf("--%s may only be used with --%s", commands.UseDbFlag, SqlClientQueryFlag)))
 		return 1
 	} else if !hasQuery && hasResultFormat {
-		cli.PrintErrln(color.RedString(fmt.Sprintf("--%s may only be used with --%s", SqlClientUseDbFlag, sqlClientResultFormat)))
+		cli.PrintErrln(color.RedString(fmt.Sprintf("--%s may only be used with --%s", commands.UseDbFlag, sqlClientResultFormat)))
 		return 1
 	}
 	if !hasUseDb && hasQuery {

--- a/go/cmd/dolt/commands/sqlserver/sqlclient.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlclient.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/abiosoft/readline"
-	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
 	"github.com/dolthub/ishell"
@@ -39,6 +38,7 @@ import (
 	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
+	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/libraries/utils/iohelp"
 )
 

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -207,7 +207,7 @@ func startServer(ctx context.Context, versionStr, commandStr string, args []stri
 	if err := validateSqlServerArgs(apr); err != nil {
 		return 1
 	}
-	serverConfig, err := GetServerConfig(dEnv, apr)
+	serverConfig, err := GetServerConfig(dEnv.FS, apr)
 	if err != nil {
 		if serverController != nil {
 			serverController.StopServer()
@@ -246,16 +246,16 @@ func startServer(ctx context.Context, versionStr, commandStr string, args []stri
 
 // GetServerConfig returns ServerConfig that is set either from yaml file if given, if not it is set with values defined
 // on command line. Server config variables not defined are set to default values.
-func GetServerConfig(dEnv *env.DoltEnv, apr *argparser.ArgParseResults) (ServerConfig, error) {
+func GetServerConfig(cwdFS filesys.Filesys, apr *argparser.ArgParseResults) (ServerConfig, error) {
 	var yamlCfg YAMLConfig
 	if cfgFile, ok := apr.GetValue(configFileFlag); ok {
-		cfg, err := getYAMLServerConfig(dEnv.FS, cfgFile)
+		cfg, err := getYAMLServerConfig(cwdFS, cfgFile)
 		if err != nil {
 			return nil, err
 		}
 		yamlCfg = cfg.(YAMLConfig)
 	} else {
-		return getCommandLineServerConfig(dEnv, apr)
+		return getCommandLineServerConfig(apr)
 	}
 
 	// if command line user argument was given, replace yaml's user and password
@@ -350,7 +350,7 @@ func SetupDoltConfig(dEnv *env.DoltEnv, apr *argparser.ArgParseResults, config S
 
 // getCommandLineServerConfig sets server config variables and persisted global variables with values defined on command line.
 // If not defined, it sets variables to default values.
-func getCommandLineServerConfig(dEnv *env.DoltEnv, apr *argparser.ArgParseResults) (ServerConfig, error) {
+func getCommandLineServerConfig(apr *argparser.ArgParseResults) (ServerConfig, error) {
 	serverConfig := DefaultServerConfig()
 
 	if sock, ok := apr.GetValue(socketFlag); ok {

--- a/go/cmd/dolt/commands/utils.go
+++ b/go/cmd/dolt/commands/utils.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
@@ -29,6 +28,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
+	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 )
 
 var fwtStageName = "fwt"

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -342,7 +342,42 @@ func runMain() int {
 		return exit
 	}
 
-	dEnv := env.Load(ctx, env.GetCurrentUserHomeDir, filesys.LocalFS, doltdb.LocalDirDoltDB, Version)
+	globalArgs, args, initCliContext, printUsage, err := splitArgsOnSubCommand(args)
+	_, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString("dolt", doc, globalArgParser))
+	if printUsage {
+		doltCommand.PrintUsage("dolt")
+
+		specialMsg := `
+Dolt subcommands are in transition to using the flags listed below as global flags.
+The sql subcommand is currently the only command that uses these flags. All other commands will ignore them.
+`
+		cli.Println(specialMsg)
+		usage()
+
+		return 0
+	}
+	if err != nil {
+		cli.PrintErrln(color.RedString("Failure to parse arguments: %v", err))
+		return 1
+	}
+	apr := cli.ParseArgsOrDie(globalArgParser, globalArgs, usage)
+
+	var fs filesys.Filesys
+	fs = filesys.LocalFS
+	dataDir, hasDataDir := apr.GetValue(commands.DataDirFlag)
+	if hasDataDir {
+		// If a relative path was provided, this ensures we have an absolute path everywhere.
+		dataDir, err = fs.Abs(dataDir)
+		if err != nil {
+			cli.PrintErrln(color.RedString("Failed to get absolute path for %s: %v", dataDir, err))
+			return 1
+		}
+		if ok, dir := fs.Exists(dataDir); !ok || !dir {
+			cli.Println(color.RedString("Provided data directory does not exist: %s", dataDir))
+			return 1
+		}
+	}
+	dEnv := env.Load(ctx, env.GetCurrentUserHomeDir, fs, doltdb.LocalDirDoltDB, Version)
 	dEnv.IgnoreLockFile = ignoreLockFile
 
 	root, err := env.GetCurrentUserHomeDir()
@@ -409,7 +444,12 @@ func runMain() int {
 	// variables like `${db_name}_default_branch` (maybe these should not be
 	// part of Dolt config in the first place!).
 
-	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
+	dataDirFS, err := dEnv.FS.WithWorkingDir(dataDir)
+	if err != nil {
+		cli.PrintErrln(color.RedString("Failed to set the data directory. %v", err))
+		return 1
+	}
+	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dataDirFS, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
 	if err != nil {
 		cli.PrintErrln("failed to load database names")
 		return 1
@@ -424,31 +464,10 @@ func runMain() int {
 		cli.Printf("error: failed to load persisted global variables: %s\n", err.Error())
 	}
 
-	globalArgs, args, initCliContext, printUsage, err := splitArgsOnSubCommand(args)
-	if printUsage {
-		doltCommand.PrintUsage("dolt")
-		_, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString("dolt", doc, globalArgParser))
-
-		specialMsg := `
-Dolt subcommands are in transition to using the flags listed below as global flags.
-The sql subcommand is currently the only command that uses these flags. All other commands will ignore them.
-`
-		cli.Println(specialMsg)
-		usage()
-
-		return 0
-	}
-	if err != nil {
-		cli.PrintErrln(color.RedString("Failure to parse arguments: %v", err))
-		return 1
-	}
-
 	var cliCtx cli.CliContext = nil
 	if initCliContext {
-		_, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString("dolt", doc, globalArgParser))
-		apr := cli.ParseArgsOrDie(globalArgParser, globalArgs, usage)
 
-		lateBind, err := commands.BuildSqlEngineQueryist(ctx, dEnv, apr)
+		lateBind, err := commands.BuildSqlEngineQueryist(ctx, dEnv, mrEnv, apr)
 		if err != nil {
 			cli.PrintErrln(color.RedString("Failure to Load SQL Engine: %v", err))
 			return 1
@@ -574,6 +593,7 @@ func buildGlobalArgs() *argparser.ArgParser {
 	ap.SupportsString(commands.CfgDirFlag, "", "directory", "Defines a directory that contains configuration files for dolt. Defaults to `$data-dir/.doltcfg`. Will only be created if there is a change to configuration settings.")
 	ap.SupportsString(commands.PrivsFilePathFlag, "", "privilege file", "Path to a file to load and store users and grants. Defaults to `$doltcfg-dir/privileges.db`. Will only be created if there is a change to privileges.")
 	ap.SupportsString(commands.BranchCtrlPathFlag, "", "branch control file", "Path to a file to load and store branch control permissions. Defaults to `$doltcfg-dir/branch_control.db`. Will only be created if there is a change to branch control permissions.")
+	ap.SupportsString(commands.UseDbFlag, "", "database", "The name of the database to use when executing SQL queries. Defaults to the first database alphabetically.")
 
 	return ap
 }

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -471,7 +471,7 @@ The sql subcommand is currently the only command that uses these flags. All othe
 
 	var cliCtx cli.CliContext = nil
 	if initCliContext {
-		lateBind, err := buildLateBinder(ctx, dEnv, mrEnv, apr, verboseEngineSetup)
+		lateBind, err := buildLateBinder(ctx, dEnv.FS, mrEnv, apr, verboseEngineSetup)
 		if err != nil {
 			cli.PrintErrln(color.RedString("Failure to Load SQL Engine: %v", err))
 			return 1
@@ -504,7 +504,7 @@ The sql subcommand is currently the only command that uses these flags. All othe
 	return res
 }
 
-func buildLateBinder(ctx context.Context, dEnv *env.DoltEnv, mrEnv *env.MultiRepoEnv, apr *argparser.ArgParseResults, verbose bool) (cli.LateBindQueryist, error) {
+func buildLateBinder(ctx context.Context, cwdFS filesys.Filesys, mrEnv *env.MultiRepoEnv, apr *argparser.ArgParseResults, verbose bool) (cli.LateBindQueryist, error) {
 
 	var targetEnv *env.DoltEnv = nil
 
@@ -532,14 +532,14 @@ func buildLateBinder(ctx context.Context, dEnv *env.DoltEnv, mrEnv *env.MultiRep
 			if verbose {
 				cli.Println("verbose: starting remote mode")
 			}
-			return sqlserver.BuildConnectionStringQueryist(ctx, dEnv, apr, lock.Port, useDb)
+			return sqlserver.BuildConnectionStringQueryist(ctx, cwdFS, apr, lock.Port, useDb)
 		}
 	}
 
 	if verbose {
 		cli.Println("verbose: starting local mode")
 	}
-	return commands.BuildSqlEngineQueryist(ctx, dEnv, mrEnv, apr)
+	return commands.BuildSqlEngineQueryist(ctx, cwdFS, mrEnv, apr)
 }
 
 // splitArgsOnSubCommand splits the args into two slices, the first containing all args before the first subcommand,

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -518,31 +518,28 @@ func buildLateBinder(ctx context.Context, dEnv *env.DoltEnv, mrEnv *env.MultiRep
 		useDb = mrEnv.GetFirstDatabase()
 	}
 
-	if targetEnv == nil {
+	if targetEnv == nil && useDb != "" {
 		targetEnv = mrEnv.GetEnv(useDb)
-		if targetEnv == nil {
-			return nil, fmt.Errorf("database %s doesn't exist.", useDb)
+	}
+
+	// nil targetEnv will happen if the user ran a command in an empty directory - which we support in some cases.
+	if targetEnv != nil {
+		isLocked, lock, err := targetEnv.GetLock()
+		if err != nil {
+			return nil, err
+		}
+		if isLocked {
+			if verbose {
+				cli.Println("verbose: starting remote mode")
+			}
+			return sqlserver.BuildConnectionStringQueryist(ctx, dEnv, apr, lock.Port, useDb)
 		}
 	}
 
-	isLocked, lock, err := targetEnv.GetLock()
-	if err != nil {
-		return nil, err
+	if verbose {
+		cli.Println("verbose: starting local mode")
 	}
-	if isLocked {
-		if verbose {
-			cli.Println("verbose: starting remote mode")
-		}
-
-		mrEnv.GetFirstDatabase()
-
-		return sqlserver.BuildConnectionStringQueryist(ctx, dEnv, apr, lock.Port, useDb)
-	} else {
-		if verbose {
-			cli.Println("verbose: starting local mode")
-		}
-		return commands.BuildSqlEngineQueryist(ctx, dEnv, mrEnv, apr)
-	}
+	return commands.BuildSqlEngineQueryist(ctx, dEnv, mrEnv, apr)
 }
 
 // splitArgsOnSubCommand splits the args into two slices, the first containing all args before the first subcommand,

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -140,6 +140,7 @@ const stdOutFlag = "--stdout"
 const stdErrFlag = "--stderr"
 const stdOutAndErrFlag = "--out-and-err"
 const ignoreLocksFlag = "--ignore-lock-file"
+const verboseEngineSetupFlag = "--verbose-engine-setup"
 
 const cpuProf = "cpu"
 const memProf = "mem"
@@ -168,6 +169,7 @@ func runMain() int {
 
 	csMetrics := false
 	ignoreLockFile := false
+	verboseEngineSetup := false
 	if len(args) > 0 {
 		var doneDebugFlags bool
 		for !doneDebugFlags && len(args) > 0 {
@@ -324,6 +326,9 @@ func runMain() int {
 
 				args = args[2:]
 
+			case verboseEngineSetupFlag:
+				verboseEngineSetup = true
+				args = args[1:]
 			default:
 				doneDebugFlags = true
 			}
@@ -466,7 +471,7 @@ The sql subcommand is currently the only command that uses these flags. All othe
 
 	var cliCtx cli.CliContext = nil
 	if initCliContext {
-		lateBind, err := buildLateBinder(ctx, dEnv, mrEnv, apr, true)
+		lateBind, err := buildLateBinder(ctx, dEnv, mrEnv, apr, verboseEngineSetup)
 		if err != nil {
 			cli.PrintErrln(color.RedString("Failure to Load SQL Engine: %v", err))
 			return 1

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -633,7 +633,7 @@ func buildGlobalArgs() *argparser.ArgParser {
 	ap.SupportsString(commands.CfgDirFlag, "", "directory", "Defines a directory that contains configuration files for dolt. Defaults to `$data-dir/.doltcfg`. Will only be created if there is a change to configuration settings.")
 	ap.SupportsString(commands.PrivsFilePathFlag, "", "privilege file", "Path to a file to load and store users and grants. Defaults to `$doltcfg-dir/privileges.db`. Will only be created if there is a change to privileges.")
 	ap.SupportsString(commands.BranchCtrlPathFlag, "", "branch control file", "Path to a file to load and store branch control permissions. Defaults to `$doltcfg-dir/branch_control.db`. Will only be created if there is a change to branch control permissions.")
-	ap.SupportsString(commands.UseDbFlag, "", "database", "The name of the database to use when executing SQL queries. Defaults to the first database alphabetically.")
+	ap.SupportsString(commands.UseDbFlag, "", "database", "The name of the database to use when executing SQL queries. Defaults the database of the root directory, if it exists, and the first alphabetically if not.")
 
 	return ap
 }

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -1142,7 +1142,18 @@ func (dEnv *DoltEnv) IsLocked() bool {
 	if dEnv.IgnoreLockFile {
 		return false
 	}
-	return FsIsLocked(dEnv.FS)
+
+	ans, _, _ := fsIsLocked(dEnv.FS)
+	return ans
+}
+
+// GetLock returns the lockfile for this database or nil if the database is not locked
+func (dEnv *DoltEnv) GetLock() (bool, *DBLock, error) {
+	if dEnv.IgnoreLockFile {
+		return false, nil, nil
+	}
+
+	return fsIsLocked(dEnv.FS)
 }
 
 // DBLock is a struct that contains the pid of the process that created the lockfile and the port that the server is running on
@@ -1252,24 +1263,27 @@ func WriteLockfile(fs filesys.Filesys, lock DBLock) error {
 
 // FsIsLocked returns true if a lockFile exists with the same pid as
 // any live process.
-func FsIsLocked(fs filesys.Filesys) bool {
+func fsIsLocked(fs filesys.Filesys) (bool, *DBLock, error) {
 	lockFile, _ := fs.Abs(filepath.Join(dbfactory.DoltDir, ServerLockFile))
 
 	ok, _ := fs.Exists(lockFile)
 	if !ok {
-		return false
+		return false, nil, nil
 	}
 
 	loadedLock, err := LoadDBLockFile(fs, lockFile)
 	if err != nil { // if there's any error assume that env is locked since the file exists
-		return true
+		return true, nil, err
 	}
 
 	// Check whether the pid that spawned the lock file is still running. Ignore it if not.
 	p, err := ps.FindProcess(loadedLock.Pid)
 	if err != nil {
-		return false
+		return false, nil, nil
 	}
 
-	return p != nil
+	if p != nil {
+		return true, loadedLock, nil
+	}
+	return false, nil, nil
 }

--- a/go/libraries/doltcore/env/multi_repo_env.go
+++ b/go/libraries/doltcore/env/multi_repo_env.go
@@ -69,31 +69,31 @@ func MultiEnvForSingleEnv(ctx context.Context, env *DoltEnv) (*MultiRepoEnv, err
 func MultiEnvForDirectory(
 	ctx context.Context,
 	config config.ReadWriteConfig,
-	fs filesys.Filesys, // fs which is the root of the multi-env. This is essentially the --data-dir flag or cwd.
+	dataDirFS filesys.Filesys,
 	version string,
 	ignoreLockFile bool,
 	dEnv *DoltEnv,
 ) (*MultiRepoEnv, error) {
-	// Load current fs and put into mr env
+	// Load current dataDirFS and put into mr env
 	var dbName string = "dolt"
 	var newDEnv *DoltEnv = dEnv
 
 	// InMemFS is used only for testing.
-	// All other FS Types should get a newly created Envronment which will serve as the primary env in the MultiRepoEnv
-	if _, ok := fs.(*filesys.InMemFS); !ok {
-		path, err := fs.Abs("")
+	// All other FS Types should get a newly created Environment which will serve as the primary env in the MultiRepoEnv
+	if _, ok := dataDirFS.(*filesys.InMemFS); !ok {
+		path, err := dataDirFS.Abs("")
 		if err != nil {
 			return nil, err
 		}
 		envName := getRepoRootDir(path, string(os.PathSeparator))
 		dbName = dirToDBName(envName)
 
-		newDEnv = Load(ctx, GetCurrentUserHomeDir, fs, doltdb.LocalDirDoltDB, version)
+		newDEnv = Load(ctx, GetCurrentUserHomeDir, dataDirFS, doltdb.LocalDirDoltDB, version)
 	}
 
 	mrEnv := &MultiRepoEnv{
 		envs:           make([]NamedEnv, 0),
-		fs:             fs,
+		fs:             dataDirFS,
 		cfg:            config,
 		dialProvider:   NewGRPCDialProviderFromDoltEnv(newDEnv),
 		ignoreLockFile: ignoreLockFile,
@@ -105,14 +105,14 @@ func MultiEnvForDirectory(
 	}
 
 	// If there are other directories in the directory, try to load them as additional databases
-	fs.Iter(".", false, func(path string, size int64, isDir bool) (stop bool) {
+	dataDirFS.Iter(".", false, func(path string, size int64, isDir bool) (stop bool) {
 		if !isDir {
 			return false
 		}
 
 		dir := filepath.Base(path)
 
-		newFs, err := fs.WithWorkingDir(dir)
+		newFs, err := dataDirFS.WithWorkingDir(dir)
 		if err != nil {
 			return false
 		}

--- a/go/libraries/doltcore/env/multi_repo_env.go
+++ b/go/libraries/doltcore/env/multi_repo_env.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"unicode"
 
@@ -138,8 +139,14 @@ func MultiEnvForDirectory(
 		delete(envSet, dbName)
 	}
 
-	for dbName, env := range envSet {
-		mrEnv.addEnv(dbName, env)
+	// get the keys from the envSet keys as a sorted list
+	sortedKeys := make([]string, 0, len(envSet))
+	for k := range envSet {
+		sortedKeys = append(sortedKeys, k)
+	}
+	sort.Strings(sortedKeys)
+	for _, dbName := range sortedKeys {
+		mrEnv.addEnv(dbName, envSet[dbName])
 	}
 
 	return mrEnv, nil

--- a/go/libraries/doltcore/env/multi_repo_env.go
+++ b/go/libraries/doltcore/env/multi_repo_env.go
@@ -58,6 +58,11 @@ type MultiRepoEnv struct {
 	ignoreLockFile bool
 }
 
+// NewMultiEnv returns a new MultiRepoEnv instance dirived from a root DoltEnv instance.
+func MultiEnvForSingleEnv(ctx context.Context, env *DoltEnv) (*MultiRepoEnv, error) {
+	return MultiEnvForDirectory(ctx, env.Config.WriteableConfig(), env.FS, env.Version, env.IgnoreLockFile, env)
+}
+
 // MultiEnvForDirectory returns a MultiRepoEnv for the directory rooted at the file system given. The doltEnv from the
 // invoking context is included. If it's non-nil and valid, it will be included in the returned MultiRepoEnv, and will
 // be the first database in all iterations.

--- a/integration-tests/bats/replication-multidb.bats
+++ b/integration-tests/bats/replication-multidb.bats
@@ -249,6 +249,7 @@ call dolt_commit('-am', 'new table');
 SQL
 
     cd $TMPDIRS
+    mkdir -p "dbs2"
 
     # this is a hack: we have to change our persisted global server
     # vars for the sql command to work on the replica TODO: fix this

--- a/integration-tests/bats/sql-create-database.bats
+++ b/integration-tests/bats/sql-create-database.bats
@@ -1,3 +1,4 @@
+#!/usr/bin/env bats
 load $BATS_TEST_DIRNAME/helper/common.bash
 
 setup() {

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -43,7 +43,8 @@ teardown() {
     start_sql_server altDb
     ROOT_DIR=$(pwd)
 
-    cd /tmp
+    mkdir someplace_else
+    cd someplace_else
 
     run dolt --verbose-engine-setup --data-dir="$ROOT_DIR" --user dolt --use-db altDB sql -q "show tables"
     [ "$status" -eq 0 ]
@@ -83,7 +84,8 @@ teardown() {
     start_sql_server altDb
     ROOT_DIR=$(pwd)
 
-    cd /tmp
+    mkdir -p someplace_new/fun
+    cd someplace_new/fun
 
     run dolt --verbose-engine-setup --data-dir="$ROOT_DIR/altDB" --user dolt sql -q "show tables"
     [ "$status" -eq 0 ]

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -21,7 +21,7 @@ teardown() {
     teardown_common
 }
 
-@test "sql: test switch between server/no server" {
+@test "sql-local-remote: test switch between server/no server" {
     start_sql_server defaultDB
 
     run dolt --verbose-engine-setup --user dolt sql -q "show databases" 
@@ -39,7 +39,7 @@ teardown() {
     [[ "$output" =~ "altDB" ]] || false
 }
 
-@test "sql: check --data-dir pointing to a server root can be used when in different directory." {
+@test "sql-local-remote: check --data-dir pointing to a server root can be used when in different directory." {
     start_sql_server altDb
     ROOT_DIR=$(pwd)
 
@@ -79,7 +79,7 @@ teardown() {
 }
 
 
-@test "sql: check --data-dir pointing to a database root can be used when in different directory." {
+@test "sql-local-remote: check --data-dir pointing to a database root can be used when in different directory." {
     start_sql_server altDb
     ROOT_DIR=$(pwd)
 

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -1,0 +1,108 @@
+#! /usr/bin/env bats
+load $BATS_TEST_DIRNAME/helper/common.bash
+load $BATS_TEST_DIRNAME/helper/query-server-common.bash
+
+make_repo() {
+  mkdir "$1"
+  cd "$1"
+  dolt init
+  dolt sql -q "create table $1_tbl (id int)"
+  cd ..
+}
+
+setup() {
+    setup_no_dolt_init
+    make_repo defaultDB
+    make_repo altDB
+}
+
+teardown() {
+    stop_sql_server 1
+    teardown_common
+}
+
+@test "sql: test switch between server/no server" {
+    start_sql_server defaultDB
+
+    run dolt --verbose-engine-setup --user dolt sql -q "show databases" 
+    [ "$status" -eq 0 ] || false
+    [[ "$output" =~ "starting remote mode" ]] || false
+    [[ "$output" =~ "defaultDB" ]] || false
+    [[ "$output" =~ "altDB" ]] || false
+
+    stop_sql_server 1
+
+    run dolt --verbose-engine-setup sql -q "show databases" 
+    [ "$status" -eq 0 ] || false
+    [[ "$output" =~ "starting local mode" ]] || false
+    [[ "$output" =~ "defaultDB" ]] || false
+    [[ "$output" =~ "altDB" ]] || false
+}
+
+@test "sql: check --data-dir pointing to a server root can be used when in different directory." {
+    start_sql_server altDb
+    ROOT_DIR=$(pwd)
+
+    cd /tmp
+
+    run dolt --verbose-engine-setup --data-dir="$ROOT_DIR" --user dolt --use-db altDB sql -q "show tables"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "starting remote mode" ]] || false
+    [[ "$output" =~ "altDB_tbl" ]] || false
+
+    run dolt --verbose-engine-setup --data-dir="$ROOT_DIR" --user dolt --use-db defaultDB sql -q "show tables"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "starting remote mode" ]] || false
+    [[ "$output" =~ "defaultDB_tbl" ]] || false
+
+    run dolt --verbose-engine-setup --data-dir="$ROOT_DIR" --user dolt sql -q "show tables"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "starting remote mode" ]] || false
+    [[ "$output" =~ "altDB_tbl" ]] || false
+
+    stop_sql_server 1
+
+    run dolt --verbose-engine-setup --data-dir="$ROOT_DIR" --user dolt --use-db altDB sql -q "show tables"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "starting local mode" ]] || false
+    [[ "$output" =~ "altDB_tbl" ]] || false
+
+    run dolt --verbose-engine-setup --data-dir="$ROOT_DIR" --user dolt --use-db defaultDB sql -q "show tables"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "starting local mode" ]] || false
+    [[ "$output" =~ "defaultDB_tbl" ]] || false
+
+    run dolt --verbose-engine-setup --data-dir="$ROOT_DIR" --user dolt sql -q "show tables"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "starting local mode" ]] || false
+    [[ "$output" =~ "altDB_tbl" ]] || false
+}
+
+
+@test "sql: check --data-dir pointing to a database root can be used when in different directory." {
+    start_sql_server altDb
+    ROOT_DIR=$(pwd)
+
+    cd /tmp
+
+    run dolt --verbose-engine-setup --data-dir="$ROOT_DIR/altDB" --user dolt sql -q "show tables"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "starting remote mode" ]] || false
+    [[ "$output" =~ "altDB_tbl" ]] || false
+
+    run dolt --verbose-engine-setup --data-dir="$ROOT_DIR/altDB" --user dolt --use-db defaultDB sql -q "show tables"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "defaultDB does not exist" ]] || false
+
+    stop_sql_server 1
+
+    run dolt --verbose-engine-setup --data-dir="$ROOT_DIR/altDB" --user dolt sql -q "show tables"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "starting local mode" ]] || false
+    [[ "$output" =~ "altDB_tbl" ]] || false
+
+    run dolt --verbose-engine-setup --data-dir="$ROOT_DIR/altDB" --user dolt --use-db defaultDB sql -q "show tables"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "defaultDB does not exist" ]] || false
+}
+

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -202,7 +202,7 @@ SQL
     # Add rows on the command line
     run dolt --verbose-engine-setup --user=dolt sql -q "insert into one_pk values (1,1,1)"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "NM4 Starting remote mode" ]] || false
+    [[ "$output" =~ "starting remote mode" ]] || false
     run dolt sql-client -P $PORT -u dolt -q "SELECT * FROM one_pk"
     [ $status -eq 0 ]
     [[ $output =~ " 1 " ]] || false
@@ -747,7 +747,7 @@ SQL
 
     run dolt --verbose-engine-setup  --user=dolt --use-db repo1 sql -q "drop table one_pk"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "NM4 Starting remote mode" ]] || false
+    [[ "$output" =~ "starting remote mode" ]] || false
 
     dolt sql-client -P $PORT -u dolt --use-db repo1 -q "call dolt_add('.')"
     dolt sql-client -P $PORT -u dolt --use-db repo1 -q "call dolt_commit('-am', 'Dropped table one_pk')"
@@ -1504,7 +1504,7 @@ databases:
 
     run dolt --verbose-engine-setup --user dolt sql -q "create table b (x int primary key)"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "NM4 Starting remote mode" ]] || false
+    [[ "$output" =~ "starting remote mode" ]] || false
 }
 
 @test "sql-server: start server without socket flag should set default socket path" {

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -1498,8 +1498,10 @@ databases:
     cd repo2
     dolt sql -q "create table a (x int primary key)"
     start_sql_server
+
     run dolt --verbose-engine-setup sql -q "create table b (x int primary key)"
     [ "$status" -eq 1 ]
+    [[ "$output" =~ "Error connecting to remote database" ]] || false
     [[ "$output" =~ "User not found 'root'" ]] || false
 
     run dolt --verbose-engine-setup --user dolt sql -q "create table b (x int primary key)"

--- a/integration-tests/bats/sql-shell.bats
+++ b/integration-tests/bats/sql-shell.bats
@@ -478,8 +478,7 @@ teardown() {
     ! [[ "$output" =~ ".doltcfg" ]] || false
 
     # create new user
-    run dolt --data-dir=db_dir --privilege-file=privs.db sql <<< "create user new_user"
-    [ "$status" -eq 0 ]
+    dolt --data-dir=db_dir --privilege-file=privs.db sql <<< "create user new_user"
 
     # show users, expect root user and new_user
     run dolt --data-dir=db_dir --privilege-file=privs.db sql <<< "select user from mysql.user;"

--- a/integration-tests/bats/sql.bats
+++ b/integration-tests/bats/sql.bats
@@ -2828,5 +2828,5 @@ SQL
     # Use of the use-db flag when we have a different DB specified by data-dir should error.
     run dolt --data-dir="$ROOT_DIR/dbb" --use-db=dba sql -q "show tables"
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "database not found" ]] || false
+    [[ "$output" =~ "provided --use-db dba does not exist or is not a directory" ]] || false
 }

--- a/integration-tests/bats/sql.bats
+++ b/integration-tests/bats/sql.bats
@@ -1031,7 +1031,7 @@ SQL
     run dolt sql -r csv -q "select @@character_set_client"
     [ $status -eq 0 ]
     [[ "$output" =~ "utf8mb4" ]] || false
-    
+
     run dolt sql -r json -q "select * from test order by a"
     [ $status -eq 0 ]
     [ "$output" == '{"rows": [{"a":1,"b":1.5,"c":"1","d":"2020-01-01 00:00:00"},{"a":2,"b":2.5,"c":"2","d":"2020-02-02 00:00:00"},{"a":3,"c":"3","d":"2020-03-03 00:00:00"},{"a":4,"b":4.5,"d":"2020-04-04 00:00:00"},{"a":5,"b":5.5,"c":"5"}]}' ]
@@ -2775,4 +2775,58 @@ SQL
 [[ "$output" =~ "Query OK, 1 row affected (1".*" sec)" ]] || false
 [[ "$output" =~ "Query OK, 1 row affected (2".*" sec)" ]] || false
 [[ "$output" =~ "Query OK, 1 row affected (3".*" sec)" ]] || false
+}
+
+
+@test "sql: check --data-dir used from a completely different location and still resolve DB names" {
+    # remove config files
+    rm -rf .doltcfg
+    rm -rf db_dir
+
+    mkdir db_dir
+    cd db_dir
+    ROOT_DIR=$(pwd)
+
+    # create an alternate database, without the table
+    mkdir dba
+    cd dba
+    dolt init
+    cd ..
+    dolt sql -q "create table dba_tbl (id int)"
+
+    mkdir dbb
+    cd dbb
+    dolt init
+    dolt sql -q "create table dbb_tbl (id int)"
+
+    # Ensure --data-dir flag is really used by changing the cwd.
+    cd /tmp
+
+    run dolt --data-dir="$ROOT_DIR/dbb" sql -q "show tables"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "dbb_tbl" ]] || false
+
+    run dolt --data-dir="$ROOT_DIR/dba" sql -q "show tables"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "dba_tbl" ]] || false
+
+    # Default to first DB alphabetically.
+    run dolt --data-dir="$ROOT_DIR" sql -q "show tables"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "dba_tbl" ]] || false
+
+    # --use-db arg can be used to be specific.
+    run dolt --data-dir="$ROOT_DIR" --use-db=dbb sql -q "show tables"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "dbb_tbl" ]] || false
+
+    # Redundant use of the flag is OK.
+    run dolt --data-dir="$ROOT_DIR/dbb" --use-db=dbb sql -q "show tables"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "dbb_tbl" ]] || false
+
+    # Use of the use-db flag when we have a different DB specified by data-dir should error.
+    run dolt --data-dir="$ROOT_DIR/dbb" --use-db=dba sql -q "show tables"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "database not found" ]] || false
 }


### PR DESCRIPTION
When `dolt sql` commands are executed against a database which is in used by a sql server, connect to it through the sql port. Currently this does not support authenticated transport. If the root user is still active, we'll use that be default. Otherwise, the `--user` flag can be used to specify a user, but no authentication token is supported. That will come in the next round of changes.

A step towards: https://github.com/dolthub/dolt/issues/3922