### PR TITLE
`LOAD DATA` bats tests improvements

### DIFF
--- a/integration-tests/bats/sql-load-data.bats
+++ b/integration-tests/bats/sql-load-data.bats
@@ -433,8 +433,6 @@ SQL
     [ $status -ne 0 ]
     [[ $output =~ "Incorrect datetime value" ]] || false
 }
-    
-
 
 @test "sql-load-data: schema with not null constraints" {
     cat <<CSV > in.csv

--- a/integration-tests/bats/sql-load-data.bats
+++ b/integration-tests/bats/sql-load-data.bats
@@ -1,11 +1,13 @@
 #!/usr/bin/env bats
 load $BATS_TEST_DIRNAME/helper/common.bash
+load $BATS_TEST_DIRNAME/helper/query-server-common.bash
 
 setup() {
     setup_common
 }
 
 teardown() {
+    stop_sql_server
     assert_feature_version
     teardown_common
 }
@@ -17,12 +19,10 @@ pk||c1||c2||c3||c4||c5
 1||1||2||3||4||5
 DELIM
 
-    run dolt sql << SQL
+    dolt sql << SQL
 CREATE TABLE test(pk int primary key, c1 int, c2 int, c3 int, c4 int, c5 int);
 LOAD DATA INFILE '1pk5col-ints.csv' INTO TABLE test CHARACTER SET UTF8MB4 FIELDS TERMINATED BY '||' ESCAPED BY '' LINES TERMINATED BY '\n' IGNORE 1 LINES;
 SQL
-
-    [ "$status" -eq 0 ]
 
     run dolt sql -r csv -q "select * from test"
 
@@ -56,12 +56,10 @@ pk||c1||c2||c3||c4||c5
 "1"||"1"||"2"||"3"||"4"||"5"
 DELIM
 
-    run dolt sql << SQL
+    dolt sql << SQL
 CREATE TABLE test(pk int primary key, c1 int, c2 int, c3 int, c4 int, c5 int);
 LOAD DATA INFILE '1pk5col-ints.csv' INTO TABLE test CHARACTER SET UTF8MB4 FIELDS TERMINATED BY '||' ENCLOSED BY '"'  ESCAPED BY '' LINES TERMINATED BY '\n' IGNORE 1 LINES;
 SQL
-
-    [ "$status" -eq 0 ]
 
     run dolt sql -r csv -q "select * from test"
 
@@ -80,12 +78,10 @@ ignore me
 sssYo
 DELIM
 
-    run dolt sql << SQL
+    dolt sql << SQL
 CREATE TABLE test(pk longtext);
 LOAD DATA INFILE 'prefixed.txt' INTO TABLE test CHARACTER SET UTF8MB4 LINES STARTING BY 'sss' IGNORE 1 LINES;
 SQL
-
-    [ "$status" -eq 0 ]
 
     run dolt sql -r csv -q "select * from test ORDER BY pk"
 
@@ -103,12 +99,10 @@ pk,c1
 1,1
 DELIM
 
-    run dolt sql << SQL
+    dolt sql << SQL
 CREATE TABLE test(pk int primary key, c1 int, c2 int);
 LOAD DATA INFILE '1pk2col-ints.csv' INTO TABLE test FIELDS TERMINATED BY ',' IGNORE 1 LINES;
 SQL
-
-    [ "$status" -eq 0 ]
 
     run dolt sql -r csv -q "select * from test"
 
@@ -126,12 +120,10 @@ pk  c1
 1 1
 DELIM
 
-    run dolt sql << SQL
+    dolt sql << SQL
 CREATE TABLE test(pk int primary key, c1 int);
 LOAD DATA INFILE '1pk2col-ints.csv' INTO TABLE test FIELDS TERMINATED BY '\t' IGNORE 1 LINES;
 SQL
-
-    [ "$status" -eq 0 ]
 
     run dolt sql -r csv -q "select * from test"
 
@@ -148,12 +140,10 @@ pk
 NULL
 DELIM
 
-    run dolt sql << SQL
+    dolt sql << SQL
 CREATE TABLE test(pk longtext);
 LOAD DATA INFILE '1pk2col-ints.csv' INTO TABLE test FIELDS IGNORE 1 LINES;
 SQL
-
-    [ "$status" -eq 0 ]
 
     run dolt sql -q "select COUNT(*) from test WHERE pk IS NULL"
     [ "$status" -eq 0 ]
@@ -169,12 +159,10 @@ pk,c1
 "hello","2"
 DELIM
 
-    run dolt sql << SQL
+    dolt sql << SQL
 CREATE TABLE test(pk int, c1 longtext);
 LOAD DATA INFILE '1pk2col-ints.csv' INTO TABLE test FIELDS ENCLOSED BY '"' TERMINATED BY ',' IGNORE 1 LINES (c1,pk);
 SQL
-
-    [ "$status" -eq 0 ]
 
     run dolt sql -r csv -q "select * from test"
 
@@ -193,12 +181,10 @@ SQL
 4,"a string containing a \", quote and comma",102.20
 DELIM
 
-     run dolt sql << SQL
+     dolt sql << SQL
 CREATE TABLE test(pk int, c1 longtext, c2 float);
 LOAD DATA INFILE 'complex.csv' INTO TABLE test FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"';
 SQL
-
-    [ "$status" -eq 0 ]
 
     run dolt sql -r csv -q "select * from test"
 
@@ -219,12 +205,10 @@ SQL
 "new\ns"
 DELIM
 
-     run dolt sql << SQL
+     dolt sql << SQL
 CREATE TABLE loadtable(pk longtext);
 LOAD DATA INFILE './testdata/test5.txt' INTO TABLE loadtable FIELDS ENCLOSED BY '\"';
 SQL
-
-    [ "$status" -eq 0 ]
 
     run dolt sql -r csv -q "select * from test"
 
@@ -244,12 +228,15 @@ pk||c1||c2||c3||c4||c5
 1||1||2||3||4||5||6
 DELIM
 
-    run dolt sql << SQL
+    dolt sql << SQL
 CREATE TABLE test(pk int primary key, c1 int, c2 int, c3 int, c4 int, c5 int);
-LOAD DATA INFILE '1pk5col-ints.csv' INTO TABLE test CHARACTER SET UTF8MB4 FIELDS TERMINATED BY '||' ESCAPED BY '' LINES TERMINATED BY '\n' IGNORE 1 LINES;
+LOAD DATA INFILE '1pk5col-ints.csv' INTO TABLE test
+CHARACTER SET UTF8MB4
+FIELDS TERMINATED BY '||'
+ESCAPED BY ''
+LINES TERMINATED BY '\n'
+IGNORE 1 LINES;
 SQL
-
-    [ "$status" -eq 0 ]
 
     run dolt sql -r csv -q "select * from test"
 
@@ -257,4 +244,151 @@ SQL
     [ "${lines[0]}" = "pk,c1,c2,c3,c4,c5" ]
     [ "${lines[1]}" = "0,1,2,3,4,5" ]
     [ "${lines[2]}" = "1,1,2,3,4,5" ]
+}
+
+@test "sql-load-data: load data ignore" {
+    cat <<CSV > in.csv
+0,0,0
+1,1,1
+CSV
+
+    dolt sql -q "create table t (pk int primary key, c1 int, c2 int)"
+    dolt sql -q "insert into t values (0,0,0)"
+    skip "load data ignore not supported"
+    run dolt sql <<SQL
+load data infile 'in.csv' ignore into table t
+fields terminated by ','
+lines terminated by '\n'
+SQL
+    [ $status -eq 0 ]
+
+    run dolt sql -r csv -q "select * from t"
+    [ $status -eq 0 ]
+    [[ $output =~ 0,0,0 ]] || false
+    [[ $output =~ 1,1,1 ]] || false
+    
+}
+
+@test "sql-load-data: load data replace" {
+    cat <<CSV > in.csv
+0,0,1
+1,1,1
+CSV
+
+    dolt sql -q "create table t (pk int primary key, c1 int, c2 int)"
+    dolt sql -q "insert into t values (0,0,0)"
+    skip "load data replace not supported"
+    run dolt sql <<SQL
+load data infile 'in.csv' replace into table t
+fields terminated by ','
+lines terminated by '\n'
+SQL
+    [ $status -eq 0 ]
+    ! [[ $output =~ 0,0,0 ]] || false
+    [[ $output =~ 0,0,1 ]] || false
+    [[ $output =~ 1,1,1 ]] || false
+}
+
+
+@test "sql-load-data: keyless table" {
+
+}
+
+@test "sql-load-data: test schema with many types" {
+
+}
+
+@test "sql-load-data: test schema with not null constraints" {
+
+}
+
+@test "sql-load-data: test schema with column defaults" {
+
+}
+
+@test "sql-load-data: test schema with check constraints" {
+
+}
+
+@test "sql-load-data: test schema with foreign keys" {
+
+}
+
+@test "sql-load-data: test load data defaults" {
+
+}
+
+@test "sql-load-data: load data local" {
+    cat <<CSV > in.csv
+0,0,0
+1,1,1
+CSV
+    
+    dolt sql -q "create table t (pk int primary key, c1 int, c2 int)"
+
+    run dolt sql <<SQL
+load data local infile 'in.csv' into table t
+fields terminated by ','
+lines terminated by '\n'
+SQL
+    [ $status -eq 1 ]
+    [[ $output =~ "LOCAL supported only in sql-server mode" ]]
+
+    start_sql_server 
+
+    run dolt sql-client -P $PORT -u dolt -q "
+load data local infile 'in.csv' into table t
+fields terminated by ','
+lines terminated by '\n'
+"
+    [ $status -ne 0 ]
+    [[ $output =~ "local_infile needs to be set to 1 to use LOCAL" ]]
+
+    # This should work but does not because of dolt sql-client
+    # mysql -e works locally
+    run dolt sql-client -P $PORT -u dolt -q "
+set global local_infile=1;
+load data local infile 'in.csv' into table t
+fields terminated by ','
+lines terminated by '\n'
+"
+    [ $status -ne 0 ]
+    [[ $output =~ "local file 'in.csv' is not registered" ]] || false
+    
+    stop_sql_server
+
+    skip "dolt sql-client does not work with local infile but a mysql client does"
+    
+    run dolt sql -r csv -q "select * from t"
+    [ $status -eq 0 ]
+    [[ $output =~ "0,0,0" ]] || false
+    [[ $output =~ "1,1,1" ]] || false
+}
+
+@test "sql-load-data: sql-server mode" {
+    cat <<CSV > in.csv
+0,0,0
+1,1,1
+CSV
+    dolt sql -q "create table t (pk int primary key, c1 int, c2 int)"
+
+    start_sql_server
+
+    # File not found errors
+    run dolt sql-client -P $PORT -u dolt -q "load data infile 'foo.csv' into table t"
+    [ $status -ne 0 ]
+    [[ $output =~ "no such file or directory" ]] || false
+    
+    dolt sql-client -P $PORT -u dolt -q "
+load data infile 'in.csv' into table t                                    
+fields terminated by ','
+lines terminated by '\n'
+"
+
+    stop_sql_server
+    
+    run dolt sql -r csv -q "select * from t"
+    [ $status -eq 0 ]
+    [[ $output =~ "0,0,0" ]] || false
+    [[ $output =~ "1,1,1" ]] || false
 }


### PR DESCRIPTION
A customer ran into some issues using `LOAD DATA` with Hosted Dolt. Added some additional testing in response. Pleasantly surprised with our compatibility. Adds skipped tests for #5982 and #5983. 