### PR TITLE
Rewrite `dolt status` subcommand to use SQL queries to generate results.

### DIFF
--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -334,6 +334,13 @@ func CreateGCArgParser() *argparser.ArgParser {
 	return ap
 }
 
+func CreateCountCommitsArgParser() *argparser.ArgParser {
+	ap := argparser.NewArgParserWithMaxArgs("gc", 0)
+	ap.SupportsString("from", "f", "commit id", "commit to start counting from")
+	ap.SupportsString("to", "t", "commit id", "commit to stop counting at")
+	return ap
+}
+
 var awsParams = []string{dbfactory.AWSRegionParam, dbfactory.AWSCredsTypeParam, dbfactory.AWSCredsFileParam, dbfactory.AWSCredsProfile}
 var ossParams = []string{dbfactory.OSSCredsFileParam, dbfactory.OSSCredsProfile}
 

--- a/go/cmd/dolt/commands/stashcmds/pop.go
+++ b/go/cmd/dolt/commands/stashcmds/pop.go
@@ -104,7 +104,7 @@ func (cmd StashPopCmd) Exec(ctx context.Context, commandStr string, args []strin
 		return handleStashPopErr(usage, err)
 	}
 
-	ret := commands.StatusCmd{}.Exec(ctx, "status", []string{}, dEnv, nil)
+	ret := commands.StatusCmd{}.Exec(ctx, "status", []string{}, dEnv, cliCtx)
 	if ret != 0 || !success {
 		cli.Println("The stash entry is kept in case you need it again.")
 		return 1

--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -19,11 +19,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql/types"
 	"strconv"
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
 	"github.com/fatih/color"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"

--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -345,7 +345,6 @@ func getRemoteInfo(queryist cli.Queryist, sqlCtx *sql.Context, branchName string
 			return ahead, behind, remoteBranchName, err
 		}
 
-		// remotes[0][2].(string)
 		var fetchSpecs []string
 		err = json.Unmarshal([]byte(fetchJsonText), &fetchSpecs)
 		if err != nil {
@@ -759,6 +758,9 @@ func getJsonDocumentColAsString(sqlCtx *sql.Context, col interface{}) (string, e
 	}
 }
 
+// getInt64ColAsInt64 returns the value of an int64 column as a string
+// This is necessary because Queryist may return an int64 column as an int64 (when using SQLEngine)
+// or as a string (when using ConnectionQueryist).
 func getInt64ColAsInt64(col interface{}) (int64, error) {
 	switch v := col.(type) {
 	case uint64:

--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"strconv"
 	"strings"
 
@@ -30,6 +29,7 @@ import (
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
+	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 )
 

--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -16,21 +16,48 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
+	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
+	"strconv"
+	"strings"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
-	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions/commitwalk"
-	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/fatih/color"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
-	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
-	"github.com/dolthub/dolt/go/libraries/doltcore/merge"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 )
+
+type printData struct {
+	branchName,
+	remoteName,
+	remoteBranchName string
+
+	ahead,
+	behind int64
+
+	conflictsPresent,
+	showIgnoredTables,
+	statusPresent,
+	mergeActive bool
+
+	stagedTables,
+	unstagedTables,
+	untrackedTables,
+	unmergedTables map[string]string
+
+	constraintViolationTables,
+	dataConflictTables,
+	schemaConflictTables map[string]bool
+
+	ignorePatterns doltdb.IgnorePatterns
+	ignoredTables  doltdb.IgnoredTables
+}
 
 var statusDocs = cli.CommandDocumentationContent{
 	ShortDesc: "Show the working status",
@@ -39,6 +66,12 @@ var statusDocs = cli.CommandDocumentationContent{
 }
 
 type StatusCmd struct{}
+
+func (cmd StatusCmd) RequiresRepo() bool {
+	return false
+}
+
+var _ cli.RepoNotRequiredCommand = StatusCmd{}
 
 // Name is returns the name of the Dolt cli command. This is what is used on the command line to invoke the command
 func (cmd StatusCmd) Name() string {
@@ -63,74 +96,551 @@ func (cmd StatusCmd) ArgParser() *argparser.ArgParser {
 
 // Exec executes the command
 func (cmd StatusCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
+	// parse arguments
 	ap := cmd.ArgParser()
 	help, _ := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, statusDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
+	showIgnoredTables := apr.Contains(cli.ShowIgnoredFlag)
 
-	roots, err := dEnv.Roots(ctx)
+	// configure SQL engine
+	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	if err != nil {
+		return handleStatusVErr(err)
+	}
+	if closeFunc != nil {
+		defer closeFunc()
+	}
+
+	// get status information from the database
+	pd, err := cmd.createPrintData(err, queryist, sqlCtx, showIgnoredTables)
 	if err != nil {
 		return handleStatusVErr(err)
 	}
 
-	staged, notStaged, err := diff.GetStagedUnstagedTableDeltas(ctx, roots)
+	// print everything
+	err = printEverything(pd)
 	if err != nil {
 		return handleStatusVErr(err)
 	}
 
-	ws, err := dEnv.WorkingSet(ctx)
-	if err != nil {
-		handleStatusVErr(err)
-	}
-
-	as, err := merge.GetMergeArtifactStatus(ctx, ws)
-	if err != nil {
-		handleStatusVErr(err)
-	}
-
-	err = PrintStatus(ctx, dEnv, staged, notStaged, apr.Contains(cli.ShowIgnoredFlag), as)
-	if err != nil {
-		return handleStatusVErr(err)
-	}
 	return 0
 }
 
-func PrintStatus(ctx context.Context, dEnv *env.DoltEnv, stagedTbls, notStagedTbls []diff.TableDelta, showIgnoredTables bool, as merge.ArtifactStatus) error {
-	headRef, err := dEnv.RepoStateReader().CWBHeadRef()
+func (cmd StatusCmd) createPrintData(err error, queryist cli.Queryist, sqlCtx *sql.Context, showIgnoredTables bool) (*printData, error) {
+	// get current branch name
+	branchName, err := getBranchName(queryist, sqlCtx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	cli.Printf(branchHeader, headRef.GetPath())
-
-	err = printRemoteRefTrackingInfo(ctx, dEnv)
+	// get ignored tables
+	ignorePatterns, err := getIgnoredTablePatternsFromSql(queryist, sqlCtx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	mergeActive, err := isMergeActive(ctx, dEnv)
+	// get staged/working tables
+	stagedTableNames := make(map[string]bool)
+	workingTableNames := make(map[string]bool)
+	diffs, err := getRowsForSql(queryist, sqlCtx, "select * from dolt_diff where commit_hash='WORKING' OR commit_hash='STAGED';")
 	if err != nil {
-		return err
+		return nil, err
+	}
+	for _, row := range diffs {
+		commitHash := row[0].(string)
+		tableName := row[1].(string)
+		if commitHash == "STAGED" {
+			stagedTableNames[tableName] = true
+		} else {
+			workingTableNames[tableName] = true
+		}
 	}
 
-	if mergeActive {
-		if as.HasConflicts() && as.HasConstraintViolations() {
+	// get constraint violations
+	constraintViolationTables := make(map[string]bool)
+	constraintViolations, err := getRowsForSql(queryist, sqlCtx, "select * from dolt_constraint_violations;")
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range constraintViolations {
+		tableName := row[0].(string)
+		constraintViolationTables[tableName] = true
+	}
+
+	// get data conflicts
+	dataConflictTables := make(map[string]bool)
+	dataConflicts, err := getRowsForSql(queryist, sqlCtx, "select * from dolt_conflicts;")
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range dataConflicts {
+		tableName := row[0].(string)
+		dataConflictTables[tableName] = true
+	}
+
+	// get merge status
+	mergeRows, err := getRowsForSql(queryist, sqlCtx, "select is_merging from dolt_merge_status;")
+	if err != nil {
+		return nil, err
+	}
+	// determine if a merge is active
+	mergeActive := false
+	if len(mergeRows) == 1 {
+		isMerging := mergeRows[0][0]
+		mergeActive, err = getTinyIntColAsBool(isMerging)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		mergeActive = true
+	}
+
+	// get local branches
+	localBranches, err := getRowsForSql(queryist, sqlCtx, "select name, hash, remote from dolt_branches;")
+	if err != nil {
+		return nil, err
+	}
+	var ahead int64 = 0
+	var behind int64 = 0
+	remoteName := ""
+	currentBranchCommit := ""
+	remoteBranchCommit := ""
+	remoteBranchName := ""
+	for _, row := range localBranches {
+		branch := row[0].(string)
+		if branch == branchName {
+			currentBranchCommit = row[1].(string)
+			remoteName = row[2].(string)
+		}
+	}
+	if currentBranchCommit == "" {
+		return nil, fmt.Errorf("could not find current branch commit")
+	}
+
+	if len(remoteName) > 0 {
+		// get dolt remotes
+		q := fmt.Sprintf("select name, url, fetch_specs, params from dolt_remotes where name = '%s';", remoteName)
+		remotes, err := getRowsForSql(queryist, sqlCtx, q)
+		if err != nil {
+			return nil, err
+		}
+		if len(remotes) != 1 {
+			return nil, fmt.Errorf("could not find remote %s", remoteName)
+		}
+
+		var fetchSpecs []string
+		err = json.Unmarshal([]byte(remotes[0][2].(string)), &fetchSpecs)
+		if err != nil {
+			return nil, err
+		}
+
+		var params map[string]string
+		err = json.Unmarshal([]byte(remotes[0][3].(string)), &params)
+		if err != nil {
+			return nil, err
+		}
+
+		remote := env.Remote{
+			Name:       remotes[0][0].(string),
+			Url:        remotes[0][1].(string),
+			FetchSpecs: fetchSpecs,
+			Params:     params,
+		}
+
+		branchRef := ref.NewBranchRef(branchName)
+		remoteRef, err := env.GetTrackingRef(branchRef, remote)
+		if err != nil {
+			return nil, err
+		}
+		remoteBranchName = remoteRef.GetPath()
+		remoteBranchRef := fmt.Sprintf("remotes/%s", remoteBranchName)
+
+		// get remote branches
+		q = fmt.Sprintf("select * from dolt_remote_branches where name = '%s';", remoteBranchRef)
+		remoteBranches, err := getRowsForSql(queryist, sqlCtx, q)
+		if err != nil {
+			return nil, err
+		}
+		if len(remoteBranches) != 1 {
+			return nil, fmt.Errorf("could not find remote branch %s", remoteBranchRef)
+		}
+		remoteBranchCommit = remoteBranches[0][1].(string)
+
+		q = fmt.Sprintf("call dolt_count_commits('--from', '%s', '--to', '%s')", currentBranchCommit, remoteBranchCommit)
+		rows, err := getRowsForSql(queryist, sqlCtx, q)
+		if err != nil {
+			return nil, err
+		}
+		if len(rows) != 1 {
+			return nil, fmt.Errorf("could not count commits between %s and %s", currentBranchCommit, remoteBranchCommit)
+		}
+		aheadDb := rows[0][0].(string)
+		behindDb := rows[0][1].(string)
+
+		ahead, err = strconv.ParseInt(aheadDb, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		behind, err = strconv.ParseInt(behindDb, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// get statuses
+	statusRows, err := getRowsForSql(queryist, sqlCtx, "select * from dolt_status;")
+	if err != nil {
+		return nil, err
+	}
+	statusPresent := len(statusRows) > 0
+
+	// find conflicts in statuses
+	conflictedTables := make(map[string]bool)
+	for _, row := range statusRows {
+		tableName := row[0].(string)
+		status := row[2].(string)
+		if status == "conflict" {
+			conflictedTables[tableName] = true
+		}
+	}
+
+	// sort tables into categories
+	conflictsPresent := false
+	stagedTables := map[string]string{}
+	unstagedTables := map[string]string{}
+	untrackedTables := map[string]string{}
+	unmergedTables := map[string]string{}
+	schemaConflictTables := map[string]bool{}
+	ignoredTables := doltdb.IgnoredTables{}
+	if statusPresent {
+		for _, row := range statusRows {
+			tableName := row[0].(string)
+			staged := row[1]
+			status := row[2].(string)
+
+			isStaged, err := getTinyIntColAsBool(staged)
+			if err != nil {
+				return nil, err
+			}
+
+			// determine if the table should be ignored
+			ignored, err := ignorePatterns.IsTableNameIgnored(tableName)
+			if conflict := doltdb.AsDoltIgnoreInConflict(err); conflict != nil {
+				ignoredTables.Conflicts = append(ignoredTables.Conflicts, *conflict)
+			} else if err != nil {
+				return nil, err
+			} else if ignored == doltdb.DontIgnore {
+				ignoredTables.DontIgnore = append(ignoredTables.DontIgnore, tableName)
+			} else if ignored == doltdb.Ignore {
+				ignoredTables.Ignore = append(ignoredTables.Ignore, tableName)
+			} else {
+				return nil, fmt.Errorf("unrecognized ignore result value: %v", ignored)
+			}
+			if err != nil {
+				return nil, err
+			}
+			shouldIgnoreTable := ignored == doltdb.Ignore
+
+			switch status {
+			case "renamed":
+				// for renamed tables, add both source and dest changes
+				parts := strings.Split(tableName, " -> ")
+				srcTableName := parts[0]
+				dstTableName := parts[1]
+
+				if workingTableNames[dstTableName] {
+					unstagedTables[srcTableName] = "deleted"
+					untrackedTables[dstTableName] = "new table"
+				} else if stagedTableNames[dstTableName] {
+					stagedTables[tableName] = status
+				}
+			case "conflict":
+				conflictsPresent = true
+				if isStaged {
+					stagedTables[tableName] = status
+				} else {
+					unmergedTables[tableName] = "both modified"
+				}
+			case "deleted", "modified", "added", "new table":
+				if shouldIgnoreTable {
+					continue
+				}
+
+				if isStaged {
+					stagedTables[tableName] = status
+				} else {
+					isTableConflicted := conflictedTables[tableName]
+					if !isTableConflicted {
+						if status == "new table" {
+							untrackedTables[tableName] = status
+						} else {
+							unstagedTables[tableName] = status
+						}
+					}
+				}
+			case "schema conflict":
+				conflictsPresent = true
+				schemaConflictTables[tableName] = true
+			default:
+				panic(fmt.Sprintf("table %s, unexpected merge status: %s", tableName, status))
+			}
+		}
+	}
+
+	pd := printData{
+		branchName:                branchName,
+		remoteName:                remoteName,
+		remoteBranchName:          remoteBranchName,
+		ahead:                     ahead,
+		behind:                    behind,
+		conflictsPresent:          conflictsPresent,
+		showIgnoredTables:         showIgnoredTables,
+		statusPresent:             statusPresent,
+		mergeActive:               mergeActive,
+		stagedTables:              stagedTables,
+		unstagedTables:            unstagedTables,
+		untrackedTables:           untrackedTables,
+		unmergedTables:            unmergedTables,
+		ignoredTables:             ignoredTables,
+		constraintViolationTables: constraintViolationTables,
+		schemaConflictTables:      schemaConflictTables,
+		ignorePatterns:            ignorePatterns,
+		dataConflictTables:        dataConflictTables,
+	}
+	return &pd, nil
+}
+
+func getBranchName(queryist cli.Queryist, sqlCtx *sql.Context) (string, error) {
+	rows, err := getRowsForSql(queryist, sqlCtx, "select active_branch()")
+	if err != nil {
+		return "", err
+	}
+	if len(rows) != 1 {
+		return "", errors.New("expected one row in dolt_branches")
+	}
+	branchName := rows[0][0].(string)
+	return branchName, nil
+}
+
+func getRowsForSql(queryist cli.Queryist, sqlCtx *sql.Context, q string) ([]sql.Row, error) {
+	schema, ri, err := queryist.Query(sqlCtx, q)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := sql.RowIterToRows(sqlCtx, schema, ri)
+	if err != nil {
+		return nil, err
+	}
+
+	return rows, nil
+}
+
+func getIgnoredTablePatternsFromSql(queryist cli.Queryist, sqlCtx *sql.Context) (doltdb.IgnorePatterns, error) {
+	var ignorePatterns []doltdb.IgnorePattern
+	ignoreRows, err := getRowsForSql(queryist, sqlCtx, fmt.Sprintf("select * from %s", doltdb.IgnoreTableName))
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range ignoreRows {
+		pattern := row[0].(string)
+		ignoreVal := row[1]
+
+		var ignore bool
+		if ignoreString, ok := ignoreVal.(string); ok {
+			ignore = ignoreString == "1"
+		} else if ignoreInt, ok := ignoreVal.(int8); ok {
+			ignore = ignoreInt == 1
+		} else {
+			return nil, errors.New(fmt.Sprintf("unexpected type for ignore column, value = %s", ignoreVal))
+		}
+
+		ip := doltdb.NewIgnorePattern(pattern, ignore)
+		ignorePatterns = append(ignorePatterns, ip)
+	}
+	return ignorePatterns, nil
+}
+
+func printEverything(data *printData) error {
+	statusFmt := "\t%-18s%s"
+	constraintViolationsExist := len(data.constraintViolationTables) > 0
+	changesPresent := false
+
+	// branch name
+	cli.Printf(branchHeader, data.branchName)
+
+	// remote info
+	if data.remoteName != "" {
+		remoteBranchName := data.remoteBranchName
+		ahead := data.ahead
+		behind := data.behind
+
+		if ahead > 0 && behind > 0 {
+			cli.Printf(`Your branch and '%s' have diverged,
+and have %v and %v different commits each, respectively.
+  (use "dolt pull" to update your local branch)`, remoteBranchName, ahead, behind)
+		} else if ahead > 0 {
+			s := ""
+			if ahead > 1 {
+				s = "s"
+			}
+			cli.Printf(`Your branch is ahead of '%s' by %v commit%s.
+  (use "dolt push" to publish your local commits)`, remoteBranchName, ahead, s)
+		} else if behind > 0 {
+			s := ""
+			if behind > 1 {
+				s = "s"
+			}
+			cli.Printf(`Your branch is behind '%s' by %v commit%s, and can be fast-forwarded.
+  (use "dolt pull" to update your local branch)`, remoteBranchName, behind, s)
+		} else {
+			cli.Printf("Your branch is up to date with '%s'.", remoteBranchName)
+		}
+		changesPresent = true
+	}
+
+	// merge info
+	if data.mergeActive {
+		if constraintViolationsExist && data.conflictsPresent {
 			cli.Println(fmt.Sprintf(unmergedTablesHeader, "conflicts and constraint violations"))
-		} else if as.HasConflicts() {
+		} else if data.conflictsPresent {
 			cli.Println(fmt.Sprintf(unmergedTablesHeader, "conflicts"))
-		} else if as.HasConstraintViolations() {
+		} else if constraintViolationsExist {
 			cli.Println(fmt.Sprintf(unmergedTablesHeader, "constraint violations"))
 		} else {
 			cli.Println(allMergedHeader)
 		}
 	}
 
-	n := printStagedDiffs(cli.CliOut, stagedTbls, true)
-	n, err = PrintDiffsNotStaged(ctx, dEnv, cli.CliOut, notStagedTbls, true, showIgnoredTables, n, as)
-	if err != nil {
-		return err
+	// staged tables
+	if len(data.stagedTables) > 0 {
+		cli.Println(stagedHeader)
+		cli.Println(stagedHeaderHelp)
+		for tableName, status := range data.stagedTables {
+			if !doltdb.IsReadOnlySystemTable(tableName) {
+				text := fmt.Sprintf(statusFmt, status+":", tableName)
+				greenText := color.GreenString(text)
+				cli.Println(greenText)
+				changesPresent = true
+			}
+		}
 	}
 
-	if !mergeActive && n == 0 {
+	// conflicts and violations
+	if data.conflictsPresent || constraintViolationsExist {
+		cli.Println(unmergedPathsHeader)
+		cli.Println(mergedTableHelp)
+
+		// conflicted tables
+		if data.conflictsPresent {
+			// show schema conflicts
+			for tableName := range data.schemaConflictTables {
+				text := fmt.Sprintf(statusFmt, schemaConflictLabel, tableName)
+				redText := color.RedString(text)
+				cli.Println(redText)
+				changesPresent = true
+			}
+			// show data conflicts
+			for tableName := range data.dataConflictTables {
+				text := fmt.Sprintf(statusFmt, bothModifiedLabel, tableName)
+				redText := color.RedString(text)
+				cli.Println(redText)
+				changesPresent = true
+			}
+		}
+
+		// constraint violations
+		if constraintViolationsExist {
+			for tableName := range data.constraintViolationTables {
+				hasConflicts := data.dataConflictTables[tableName] || data.schemaConflictTables[tableName]
+				if hasConflicts {
+					continue
+				}
+				text := fmt.Sprintf(statusFmt, "modified", tableName)
+				redText := color.RedString(text)
+				cli.Println(redText)
+				changesPresent = true
+			}
+		}
+	}
+
+	// unstaged tables
+	if len(data.unstagedTables) > 0 {
+		filteredUnstagedTables := make(map[string]string)
+		for tableName, status := range data.unstagedTables {
+			hasConflicts := data.dataConflictTables[tableName] || data.schemaConflictTables[tableName]
+			hasViolations := data.constraintViolationTables[tableName]
+			if hasConflicts || hasViolations {
+				continue
+			}
+			filteredUnstagedTables[tableName] = status
+		}
+
+		if len(filteredUnstagedTables) > 0 {
+			cli.Println(workingHeader)
+			cli.Println(workingHeaderHelp)
+			for tableName, status := range filteredUnstagedTables {
+				text := fmt.Sprintf(statusFmt, status+":", tableName)
+				redText := color.RedString(text)
+				cli.Println(redText)
+			}
+			changesPresent = true
+		}
+	}
+
+	// untracked tables
+	if len(data.untrackedTables) > 0 {
+		if changesPresent {
+			cli.Println()
+		}
+		cli.Println(untrackedHeader)
+		cli.Println(untrackedHeaderHelp)
+		for tableName, status := range data.untrackedTables {
+			ignoreResult, err := data.ignorePatterns.IsTableNameIgnored(tableName)
+			if err != nil {
+				return err
+			}
+			isIgnored := ignoreResult == doltdb.Ignore
+			if isIgnored {
+				continue
+			}
+			text := fmt.Sprintf(statusFmt, status+":", tableName)
+			redText := color.RedString(text)
+			cli.Println(redText)
+			changesPresent = true
+		}
+	}
+
+	// ignored tables
+	if data.showIgnoredTables && len(data.ignoredTables.Ignore) > 0 {
+		if changesPresent {
+			cli.Println()
+		}
+		cli.Println(ignoredHeader)
+		cli.Println(ignoredHeaderHelp)
+		for _, tableName := range data.ignoredTables.Ignore {
+			text := fmt.Sprintf(statusFmt, "new table:", tableName)
+			redText := color.RedString(text)
+			cli.Println(redText)
+			changesPresent = true
+		}
+	}
+
+	if len(data.ignoredTables.Conflicts) > 0 {
+		if changesPresent {
+			cli.Println()
+		}
+		cli.Println(conflictedIgnoredHeader)
+		cli.Println(conflictedIgnoredHeaderHelp)
+		for _, conflict := range data.ignoredTables.Conflicts {
+			text := fmt.Sprintf(statusFmt, "new table:", conflict.Table)
+			redText := color.RedString(text)
+			cli.Println(redText)
+			changesPresent = true
+		}
+	}
+
+	// nothing to commit
+	if !changesPresent {
 		cli.Println("nothing to commit, working tree clean")
 	}
 
@@ -142,136 +652,18 @@ func handleStatusVErr(err error) int {
 	return 1
 }
 
-// printRemoteRefTrackingInfo prints remote tracking information if there is a remote branch set upstream from current branch
-func printRemoteRefTrackingInfo(ctx context.Context, dEnv *env.DoltEnv) error {
-	ddb := dEnv.DoltDB
-	rsr := dEnv.RepoStateReader()
-	headRef, err := rsr.CWBHeadRef()
-	if err != nil {
-		return err
-	}
-	branches, err := rsr.GetBranches()
-	if err != nil {
-		return err
-	}
-	upstream, hasUpstream := branches[headRef.GetPath()]
-	if !hasUpstream {
-		return nil
-	}
-
-	// Get local head branch
-	headCommitSpec, err := doltdb.NewCommitSpec(headRef.GetPath())
-	if err != nil {
-		return err
-	}
-	headCommit, err := ddb.Resolve(ctx, headCommitSpec, headRef)
-	if err != nil {
-		return err
-	}
-	headHash, err := headCommit.HashOf()
-	if err != nil {
-		return err
-	}
-
-	// Get remote tracking branch
-	remotes, err := rsr.GetRemotes()
-	if err != nil {
-		return err
-	}
-	remote, remoteOK := remotes[upstream.Remote]
-	if !remoteOK {
-		return nil
-	}
-	remoteTrackingRef, err := env.GetTrackingRef(upstream.Merge.Ref, remote)
-	if err != nil {
-		return err
-	}
-	remoteCommitSpec, err := doltdb.NewCommitSpec(remoteTrackingRef.GetPath())
-	if err != nil {
-		return err
-	}
-	remoteCommit, err := ddb.Resolve(ctx, remoteCommitSpec, remoteTrackingRef)
-	if err != nil {
-		return err
-	}
-	remoteHash, err := remoteCommit.HashOf()
-	if err != nil {
-		return err
-	}
-
-	// get common ancestor
-	ancCommit, err := doltdb.GetCommitAncestor(ctx, headCommit, remoteCommit)
-	if err != nil {
-		return err
-	}
-	ancHash, err := ancCommit.HashOf()
-	if err != nil {
-		return err
-	}
-
-	ahead := 0
-	behind := 0
-	if headHash != remoteHash {
-		behind, err = countCommitsInRange(ctx, ddb, remoteHash, ancHash)
-		if err != nil {
-			return err
-		}
-		ahead, err = countCommitsInRange(ctx, ddb, headHash, ancHash)
-		if err != nil {
-			return err
-		}
-	}
-
-	cli.Println(getRemoteTrackingMsg(remoteTrackingRef.GetPath(), ahead, behind))
-	return nil
-}
-
-// countCommitsInRange returns the number of commits between the given starting point to trace back to the given target point.
-// The starting commit must be a descendant of the target commit. Target commit must be a common ancestor commit.
-func countCommitsInRange(ctx context.Context, ddb *doltdb.DoltDB, startCommitHash, targetCommitHash hash.Hash) (int, error) {
-	itr, iErr := commitwalk.GetTopologicalOrderIterator(ctx, ddb, []hash.Hash{startCommitHash}, nil)
-	if iErr != nil {
-		return 0, iErr
-	}
-	count := 0
-	for {
-		hash, _, err := itr.Next(ctx)
-		if err == io.EOF {
-			return 0, errors.New("no match found to ancestor commit")
-		} else if err != nil {
-			return 0, err
-		}
-
-		if hash == targetCommitHash {
-			break
-		}
-		count += 1
-	}
-
-	return count, nil
-}
-
-// getRemoteTrackingMsg returns remote tracking information with given remote branch name, number of commits ahead and/or behind.
-func getRemoteTrackingMsg(remoteBranchName string, ahead int, behind int) string {
-	if ahead > 0 && behind > 0 {
-		return fmt.Sprintf(`Your branch and '%s' have diverged,
-and have %v and %v different commits each, respectively.
-  (use "dolt pull" to update your local branch)`, remoteBranchName, ahead, behind)
-	} else if ahead > 0 {
-		s := ""
-		if ahead > 1 {
-			s = "s"
-		}
-		return fmt.Sprintf(`Your branch is ahead of '%s' by %v commit%s.
-  (use "dolt push" to publish your local commits)`, remoteBranchName, ahead, s)
-	} else if behind > 0 {
-		s := ""
-		if behind > 1 {
-			s = "s"
-		}
-		return fmt.Sprintf(`Your branch is behind '%s' by %v commit%s, and can be fast-forwarded.
-  (use "dolt pull" to update your local branch)`, remoteBranchName, behind, s)
-	} else {
-		return fmt.Sprintf("Your branch is up to date with '%s'.", remoteBranchName)
+// getTinyIntColAsBool returns the value of a tinyint column as a bool
+// This is necessary because Queryist may return a tinyint column as a bool (when using SQLEngine)
+// or as a string (when using ConnectionQueryist).
+func getTinyIntColAsBool(col interface{}) (bool, error) {
+	switch v := col.(type) {
+	case bool:
+		return v, nil
+	case int:
+		return v == 1, nil
+	case string:
+		return v == "1", nil
+	default:
+		return false, fmt.Errorf("unexpected type %T", v)
 	}
 }

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -162,7 +162,6 @@ var commandsWithoutCliCtx = []cli.Command{
 	dumpDocsCommand,
 	dumpZshCommand,
 	docscmds.Commands,
-	stashcmds.StashCommands,
 	&commands.Assist{},
 }
 

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -122,7 +122,6 @@ var doltSubCommands = []cli.Command{
 
 var commandsWithoutCliCtx = []cli.Command{
 	commands.InitCmd{},
-	commands.StatusCmd{},
 	commands.DiffCmd{},
 	commands.ResetCmd{},
 	commands.CleanCmd{},

--- a/go/libraries/doltcore/doltdb/ignore.go
+++ b/go/libraries/doltcore/doltdb/ignore.go
@@ -26,9 +26,13 @@ import (
 	"github.com/dolthub/dolt/go/store/val"
 )
 
-type ignorePattern struct {
-	pattern string
-	ignore  bool
+type IgnorePattern struct {
+	Pattern string
+	Ignore  bool
+}
+
+func NewIgnorePattern(pattern string, ignore bool) IgnorePattern {
+	return IgnorePattern{Pattern: pattern, Ignore: ignore}
 }
 
 // IgnoredTables contains the results of comparing a series of tables to a set of dolt_ignore patterns.
@@ -48,10 +52,10 @@ const (
 	ErrorOccurred                             // An error occured.
 )
 
-type IgnorePatterns []ignorePattern
+type IgnorePatterns []IgnorePattern
 
 func GetIgnoredTablePatterns(ctx context.Context, roots Roots) (IgnorePatterns, error) {
-	var ignorePatterns []ignorePattern
+	var ignorePatterns []IgnorePattern
 	workingSet := roots.Working
 	table, found, err := workingSet.GetTable(ctx, IgnoreTableName)
 	if err != nil {
@@ -100,7 +104,7 @@ func GetIgnoredTablePatterns(ctx context.Context, roots Roots) (IgnorePatterns, 
 			return nil, fmt.Errorf("could not read pattern")
 		}
 		ignore, ok := valueDesc.GetBool(0, valueTuple)
-		ignorePatterns = append(ignorePatterns, ignorePattern{pattern, ignore})
+		ignorePatterns = append(ignorePatterns, NewIgnorePattern(pattern, ignore))
 	}
 	return ignorePatterns, nil
 }
@@ -201,8 +205,8 @@ func (ip *IgnorePatterns) IsTableNameIgnored(tableName string) (IgnoreResult, er
 	trueMatches := []string{}
 	falseMatches := []string{}
 	for _, patternIgnore := range *ip {
-		pattern := patternIgnore.pattern
-		ignore := patternIgnore.ignore
+		pattern := patternIgnore.Pattern
+		ignore := patternIgnore.Ignore
 		patternRegExp, err := compilePattern(pattern)
 		if err != nil {
 			return ErrorOccurred, err

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_count_commits.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_count_commits.go
@@ -17,13 +17,15 @@ package dprocedures
 import (
 	"context"
 	"fmt"
+	"io"
+
+	"github.com/dolthub/go-mysql-server/sql"
+
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions/commitwalk"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"github.com/dolthub/dolt/go/store/hash"
-	"github.com/dolthub/go-mysql-server/sql"
-	"io"
 )
 
 func doltCountCommits(ctx *sql.Context, args ...string) (sql.RowIter, error) {

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_count_commits.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_count_commits.go
@@ -85,7 +85,6 @@ func countCommits(ctx *sql.Context, args ...string) (ahead uint64, behind uint64
 	if err != nil {
 		return 0, 0, err
 	}
-	fmt.Printf("from commit: %s\n", fromCommit.Value())
 
 	toSpec, err := doltdb.NewCommitSpec(toRef)
 	if err != nil {
@@ -99,7 +98,6 @@ func countCommits(ctx *sql.Context, args ...string) (ahead uint64, behind uint64
 	if err != nil {
 		return 0, 0, err
 	}
-	fmt.Printf("to commit: %s\n", toCommit.Value())
 
 	ancestor, err := doltdb.GetCommitAncestor(ctx, fromCommit, toCommit)
 	if err != nil {

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_count_commits.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_count_commits.go
@@ -1,0 +1,134 @@
+package dprocedures
+
+import (
+	"context"
+	"fmt"
+	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions/commitwalk"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
+	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/dolthub/go-mysql-server/sql"
+	"io"
+)
+
+func doltCountCommits(ctx *sql.Context, args ...string) (sql.RowIter, error) {
+	ahead, behind, err := countCommits(ctx, args...)
+	if err != nil {
+		return nil, err
+	}
+	return sql.RowsToRowIter(sql.Row{ahead, behind}), nil
+}
+
+func countCommits(ctx *sql.Context, args ...string) (ahead uint64, behind uint64, err error) {
+	dbName := ctx.GetCurrentDatabase()
+	if len(dbName) == 0 {
+		return 0, 0, fmt.Errorf("empty database name")
+	}
+
+	sess := dsess.DSessFromSess(ctx.Session)
+	apr, err := cli.CreateCountCommitsArgParser().Parse(args)
+	if err != nil {
+		return 0, 0, err
+	}
+	fromRef, ok := apr.GetValue("from")
+	if !ok {
+		return 0, 0, fmt.Errorf("missing from ref")
+	}
+	if len(fromRef) == 0 {
+		return 0, 0, fmt.Errorf("empty from ref")
+	}
+	toRef, ok := apr.GetValue("to")
+	if !ok {
+		return 0, 0, fmt.Errorf("missing to ref")
+	}
+	if len(toRef) == 0 {
+		return 0, 0, fmt.Errorf("empty to ref")
+	}
+
+	dbData, ok := sess.GetDbData(ctx, dbName)
+	if !ok {
+		return 0, 0, fmt.Errorf("could not load database %s", dbName)
+	}
+	ddb := dbData.Ddb
+	rsr := dbData.Rsr
+
+	fromSpec, err := doltdb.NewCommitSpec(fromRef)
+	if err != nil {
+		return 0, 0, err
+	}
+	headRef, err := rsr.CWBHeadRef()
+	if err != nil {
+		return 0, 0, err
+	}
+	fromCommit, err := ddb.Resolve(ctx, fromSpec, headRef)
+	if err != nil {
+		return 0, 0, err
+	}
+	fromHash, err := fromCommit.HashOf()
+	if err != nil {
+		return 0, 0, err
+	}
+	fmt.Printf("from commit: %s\n", fromCommit.Value())
+
+	toSpec, err := doltdb.NewCommitSpec(toRef)
+	if err != nil {
+		return 0, 0, err
+	}
+	toCommit, err := ddb.Resolve(ctx, toSpec, headRef)
+	if err != nil {
+		return 0, 0, err
+	}
+	toHash, err := toCommit.HashOf()
+	if err != nil {
+		return 0, 0, err
+	}
+	fmt.Printf("to commit: %s\n", toCommit.Value())
+
+	ancestor, err := doltdb.GetCommitAncestor(ctx, fromCommit, toCommit)
+	if err != nil {
+		return 0, 0, err
+	}
+	ancestorHash, err := ancestor.HashOf()
+	if err != nil {
+		return 0, 0, err
+	}
+
+	if fromHash != toHash {
+		behind, err = countCommitsInRange(ctx, ddb, toHash, ancestorHash)
+		if err != nil {
+			return 0, 0, err
+		}
+		ahead, err = countCommitsInRange(ctx, ddb, fromHash, ancestorHash)
+		if err != nil {
+			return 0, 0, err
+		}
+	}
+
+	return ahead, behind, nil
+}
+
+// countCommitsInRange returns the number of commits between the given starting point to trace back to the given target point.
+// The starting commit must be a descendant of the target commit. Target commit must be a common ancestor commit.
+func countCommitsInRange(ctx context.Context, ddb *doltdb.DoltDB, startCommitHash, targetCommitHash hash.Hash) (uint64, error) {
+	itr, iErr := commitwalk.GetTopologicalOrderIterator(ctx, ddb, []hash.Hash{startCommitHash}, nil)
+	if iErr != nil {
+		return 0, iErr
+	}
+	count := 0
+	for {
+		nextHash, _, err := itr.Next(ctx)
+		if err == io.EOF {
+			return 0, fmt.Errorf("no match found to ancestor commit")
+		} else if err != nil {
+			return 0, err
+		}
+
+		if nextHash == targetCommitHash {
+			break
+		}
+		count += 1
+	}
+
+	return uint64(count), nil
+}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_count_commits.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_count_commits.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package dprocedures
 
 import (

--- a/go/libraries/doltcore/sqle/dprocedures/init.go
+++ b/go/libraries/doltcore/sqle/dprocedures/init.go
@@ -30,6 +30,7 @@ var DoltProcedures = []sql.ExternalStoredProcedureDetails{
 	{Name: "dolt_commit", Schema: stringSchema("hash"), Function: doltCommit},
 	{Name: "dolt_commit_hash_out", Schema: stringSchema("hash"), Function: doltCommitHashOut},
 	{Name: "dolt_conflicts_resolve", Schema: int64Schema("status"), Function: doltConflictsResolve},
+	{Name: "dolt_count_commits", Schema: int64Schema("ahead", "behind"), Function: doltCountCommits},
 	{Name: "dolt_fetch", Schema: int64Schema("success"), Function: doltFetch},
 
 	// dolt_gc is enabled behind a feature flag for now, see dolt_gc.go

--- a/go/libraries/doltcore/sqle/dtables/branches_table.go
+++ b/go/libraries/doltcore/sqle/dtables/branches_table.go
@@ -74,7 +74,7 @@ func (bt *BranchesTable) Schema() sql.Schema {
 		tableName = doltdb.RemoteBranchesTableName
 	}
 
-	return []*sql.Column{
+	columns := []*sql.Column{
 		{Name: "name", Type: types.Text, Source: tableName, PrimaryKey: true, Nullable: false},
 		{Name: "hash", Type: types.Text, Source: tableName, PrimaryKey: false, Nullable: false},
 		{Name: "latest_committer", Type: types.Text, Source: tableName, PrimaryKey: false, Nullable: true},
@@ -82,6 +82,11 @@ func (bt *BranchesTable) Schema() sql.Schema {
 		{Name: "latest_commit_date", Type: types.Datetime, Source: tableName, PrimaryKey: false, Nullable: true},
 		{Name: "latest_commit_message", Type: types.Text, Source: tableName, PrimaryKey: false, Nullable: true},
 	}
+	if !bt.remote {
+		remote := &sql.Column{Name: "remote", Type: types.Text, Source: tableName, PrimaryKey: false, Nullable: true}
+		columns = append(columns, remote)
+	}
+	return columns
 }
 
 // Collation implements the sql.Table interface.
@@ -96,20 +101,23 @@ func (bt *BranchesTable) Partitions(*sql.Context) (sql.PartitionIter, error) {
 
 // PartitionRows is a sql.Table interface function that gets a row iterator for a partition
 func (bt *BranchesTable) PartitionRows(sqlCtx *sql.Context, part sql.Partition) (sql.RowIter, error) {
-	return NewBranchItr(sqlCtx, bt.db, bt.remote)
+	return NewBranchItr(sqlCtx, bt)
 }
 
 // BranchItr is a sql.RowItr implementation which iterates over each commit as if it's a row in the table.
 type BranchItr struct {
+	table    *BranchesTable
 	branches []string
 	commits  []*doltdb.Commit
 	idx      int
 }
 
 // NewBranchItr creates a BranchItr from the current environment.
-func NewBranchItr(ctx *sql.Context, db dsess.SqlDatabase, remote bool) (*BranchItr, error) {
+func NewBranchItr(ctx *sql.Context, table *BranchesTable) (*BranchItr, error) {
 	var branchRefs []ref.DoltRef
 	var err error
+	db := table.db
+	remote := table.remote
 
 	txRoot, err := dsess.TransactionRoot(ctx, db)
 	if err != nil {
@@ -148,7 +156,12 @@ func NewBranchItr(ctx *sql.Context, db dsess.SqlDatabase, remote bool) (*BranchI
 		commits[i] = commit
 	}
 
-	return &BranchItr{branchNames, commits, 0}, nil
+	return &BranchItr{
+		table:    table,
+		branches: branchNames,
+		commits:  commits,
+		idx:      0,
+	}, nil
 }
 
 // Next retrieves the next row. It will return io.EOF if it's the last row.
@@ -176,7 +189,23 @@ func (itr *BranchItr) Next(ctx *sql.Context) (sql.Row, error) {
 		return nil, err
 	}
 
-	return sql.NewRow(name, h.String(), meta.Name, meta.Email, meta.Time(), meta.Description), nil
+	remoteBranches := itr.table.remote
+	if remoteBranches {
+		return sql.NewRow(name, h.String(), meta.Name, meta.Email, meta.Time(), meta.Description), nil
+	} else {
+		branches, err := itr.table.db.DbData().Rsr.GetBranches()
+
+		if err != nil {
+			return nil, err
+		}
+
+		remoteName := ""
+		branch, ok := branches[name]
+		if ok {
+			remoteName = branch.Remote
+		}
+		return sql.NewRow(name, h.String(), meta.Name, meta.Email, meta.Time(), meta.Description, remoteName), nil
+	}
 }
 
 // Close closes the iterator.

--- a/go/libraries/doltcore/sqle/dtables/branches_table.go
+++ b/go/libraries/doltcore/sqle/dtables/branches_table.go
@@ -83,8 +83,8 @@ func (bt *BranchesTable) Schema() sql.Schema {
 		{Name: "latest_commit_message", Type: types.Text, Source: tableName, PrimaryKey: false, Nullable: true},
 	}
 	if !bt.remote {
-		remote := &sql.Column{Name: "remote", Type: types.Text, Source: tableName, PrimaryKey: false, Nullable: true}
-		columns = append(columns, remote)
+		columns = append(columns, &sql.Column{Name: "remote", Type: types.Text, Source: tableName, PrimaryKey: false, Nullable: true})
+		columns = append(columns, &sql.Column{Name: "branch", Type: types.Text, Source: tableName, PrimaryKey: false, Nullable: true})
 	}
 	return columns
 }
@@ -200,11 +200,13 @@ func (itr *BranchItr) Next(ctx *sql.Context) (sql.Row, error) {
 		}
 
 		remoteName := ""
+		branchName := ""
 		branch, ok := branches[name]
 		if ok {
 			remoteName = branch.Remote
+			branchName = branch.Merge.Ref.GetPath()
 		}
-		return sql.NewRow(name, h.String(), meta.Name, meta.Email, meta.Time(), meta.Description, remoteName), nil
+		return sql.NewRow(name, h.String(), meta.Name, meta.Email, meta.Time(), meta.Description, remoteName, branchName), nil
 	}
 }
 

--- a/go/libraries/doltcore/sqle/sqlselect_test.go
+++ b/go/libraries/doltcore/sqle/sqlselect_test.go
@@ -783,6 +783,7 @@ func BasicSelectTests() []SelectTest {
 					"billy bob", "bigbillieb@fake.horse",
 					time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC).In(LoadedLocalLocation()),
 					"Initialize data repository",
+					"",
 				},
 			},
 			ExpectedSqlSchema: sql.Schema{
@@ -792,6 +793,7 @@ func BasicSelectTests() []SelectTest {
 				&sql.Column{Name: "latest_committer_email", Type: gmstypes.Text},
 				&sql.Column{Name: "latest_commit_date", Type: gmstypes.Datetime},
 				&sql.Column{Name: "latest_commit_message", Type: gmstypes.Text},
+				&sql.Column{Name: "remote", Type: gmstypes.Text},
 			},
 		},
 	}

--- a/go/libraries/doltcore/sqle/sqlselect_test.go
+++ b/go/libraries/doltcore/sqle/sqlselect_test.go
@@ -784,6 +784,7 @@ func BasicSelectTests() []SelectTest {
 					time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC).In(LoadedLocalLocation()),
 					"Initialize data repository",
 					"",
+					"",
 				},
 			},
 			ExpectedSqlSchema: sql.Schema{

--- a/go/libraries/doltcore/sqle/sqlselect_test.go
+++ b/go/libraries/doltcore/sqle/sqlselect_test.go
@@ -794,6 +794,7 @@ func BasicSelectTests() []SelectTest {
 				&sql.Column{Name: "latest_commit_date", Type: gmstypes.Datetime},
 				&sql.Column{Name: "latest_commit_message", Type: gmstypes.Text},
 				&sql.Column{Name: "remote", Type: gmstypes.Text},
+				&sql.Column{Name: "branch", Type: gmstypes.Text},
 			},
 		},
 	}

--- a/integration-tests/bats/replication.bats
+++ b/integration-tests/bats/replication.bats
@@ -582,7 +582,6 @@ SQL
 
     run dolt status
     [ "$status" -eq 0 ]
-    [[ ! "$output" =~ "remote not found: 'unknown'" ]] || false
 }
 
 @test "replication: non-fast-forward pull fails replication" {

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -7,6 +7,19 @@ make_repo() {
   cd "$1"
   dolt init
   dolt sql -q "create table $1_tbl (id int)"
+  dolt sql <<SQL
+CREATE TABLE t (pk int PRIMARY KEY);
+CREATE TABLE u (pk int PRIMARY KEY);
+INSERT INTO dolt_ignore VALUES ('generated_*', 1);
+SQL
+  dolt add -A && dolt commit -m "tables t, u"
+  dolt sql <<SQL
+INSERT INTO  t VALUES (1),(2),(3);
+INSERT INTO  u VALUES (1),(2),(3);
+CREATE TABLE v (pk int PRIMARY KEY);
+CREATE TABLE generated_foo (pk int PRIMARY KEY);
+SQL
+  dolt add t
   cd ..
 }
 
@@ -157,4 +170,74 @@ get_staged_tables() {
     staged=$(get_staged_tables)
 
     [[ ! -z $(echo "$staged" | grep "testtable") ]] || false
+}
+
+@test "sql-local-remote: test 'status' and switch between server/no server" {
+    start_sql_server defaultDB
+
+    run dolt --user dolt status
+    [ "$status" -eq 0 ] || false
+    [[ "$output" =~ "On branch main" ]] || false
+    [[ "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ "  (use \"dolt reset <table>...\" to unstage)" ]] || false
+    [[ "$output" =~ "	modified:         t" ]] || false
+    [[ "$output" =~ "Changes not staged for commit:" ]] || false
+    [[ "$output" =~ "  (use \"dolt add <table>\" to update what will be committed)" ]] || false
+    [[ "$output" =~ "  (use \"dolt checkout <table>\" to discard changes in working directory)" ]] || false
+    [[ "$output" =~ "	modified:         u" ]] || false
+    [[ "$output" =~ "Untracked tables:" ]] || false
+    [[ "$output" =~ "  (use \"dolt add <table>\" to include in what will be committed)" ]] || false
+    [[ "$output" =~ "	new table:        v" ]] || false
+    ! [[ "$output" =~ "   new table:        generated_foo" ]] || false
+
+    run dolt --user dolt status --ignored
+    [ "$status" -eq 0 ] || false
+    [[ "$output" =~ "On branch main" ]] || false
+    [[ "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ "  (use \"dolt reset <table>...\" to unstage)" ]] || false
+    [[ "$output" =~ "	modified:         t" ]] || false
+    [[ "$output" =~ "Changes not staged for commit:" ]] || false
+    [[ "$output" =~ "  (use \"dolt add <table>\" to update what will be committed)" ]] || false
+    [[ "$output" =~ "  (use \"dolt checkout <table>\" to discard changes in working directory)" ]] || false
+    [[ "$output" =~ "	modified:         u" ]] || false
+    [[ "$output" =~ "Untracked tables:" ]] || false
+    [[ "$output" =~ "  (use \"dolt add <table>\" to include in what will be committed)" ]] || false
+    [[ "$output" =~ "	new table:        v" ]] || false
+    [[ "$output" =~ "Ignored tables:" ]] || false
+    [[ "$output" =~ "  (use \"dolt add -f <table>\" to include in what will be committed)" ]] || false
+    [[ "$output" =~ "	new table:        generated_foo" ]] || false
+
+    stop_sql_server 1
+
+    run dolt status
+    [ "$status" -eq 0 ] || false
+    [[ "$output" =~ "On branch main" ]] || false
+    [[ "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ "  (use \"dolt reset <table>...\" to unstage)" ]] || false
+    [[ "$output" =~ "	modified:         t" ]] || false
+    [[ "$output" =~ "Changes not staged for commit:" ]] || false
+    [[ "$output" =~ "  (use \"dolt add <table>\" to update what will be committed)" ]] || false
+    [[ "$output" =~ "  (use \"dolt checkout <table>\" to discard changes in working directory)" ]] || false
+    [[ "$output" =~ "	modified:         u" ]] || false
+    [[ "$output" =~ "Untracked tables:" ]] || false
+    [[ "$output" =~ "  (use \"dolt add <table>\" to include in what will be committed)" ]] || false
+    [[ "$output" =~ "	new table:        v" ]] || false
+    ! [[ "$output" =~ "   new table:        generated_foo" ]] || false
+
+    run dolt --user dolt status --ignored
+    [ "$status" -eq 0 ] || false
+    [[ "$output" =~ "On branch main" ]] || false
+    [[ "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ "  (use \"dolt reset <table>...\" to unstage)" ]] || false
+    [[ "$output" =~ "	modified:         t" ]] || false
+    [[ "$output" =~ "Changes not staged for commit:" ]] || false
+    [[ "$output" =~ "  (use \"dolt add <table>\" to update what will be committed)" ]] || false
+    [[ "$output" =~ "  (use \"dolt checkout <table>\" to discard changes in working directory)" ]] || false
+    [[ "$output" =~ "	modified:         u" ]] || false
+    [[ "$output" =~ "Untracked tables:" ]] || false
+    [[ "$output" =~ "  (use \"dolt add <table>\" to include in what will be committed)" ]] || false
+    [[ "$output" =~ "	new table:        v" ]] || false
+    [[ "$output" =~ "Ignored tables:" ]] || false
+    [[ "$output" =~ "  (use \"dolt add -f <table>\" to include in what will be committed)" ]] || false
+    [[ "$output" =~ "	new table:        generated_foo" ]] || false
 }

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -213,36 +213,10 @@ get_staged_tables() {
 
     run dolt status
     [ "$status" -eq 0 ] || false
-    [[ "$output" =~ "On branch main" ]] || false
-    [[ "$output" =~ "Changes to be committed:" ]] || false
-    [[ "$output" =~ "  (use \"dolt reset <table>...\" to unstage)" ]] || false
-    [[ "$output" =~ "	modified:         table1" ]] || false
-    [[ "$output" =~ "Changes not staged for commit:" ]] || false
-    [[ "$output" =~ "  (use \"dolt add <table>\" to update what will be committed)" ]] || false
-    [[ "$output" =~ "  (use \"dolt checkout <table>\" to discard changes in working directory)" ]] || false
-    [[ "$output" =~ "	modified:         table2" ]] || false
-    [[ "$output" =~ "Untracked tables:" ]] || false
-    [[ "$output" =~ "  (use \"dolt add <table>\" to include in what will be committed)" ]] || false
-    [[ "$output" =~ "	new table:        table3" ]] || false
-    ! [[ "$output" =~ "   new table:        generated_foo" ]] || false
     localOutput=$output
 
     run dolt --user dolt status --ignored
     [ "$status" -eq 0 ] || false
-    [[ "$output" =~ "On branch main" ]] || false
-    [[ "$output" =~ "Changes to be committed:" ]] || false
-    [[ "$output" =~ "  (use \"dolt reset <table>...\" to unstage)" ]] || false
-    [[ "$output" =~ "	modified:         table1" ]] || false
-    [[ "$output" =~ "Changes not staged for commit:" ]] || false
-    [[ "$output" =~ "  (use \"dolt add <table>\" to update what will be committed)" ]] || false
-    [[ "$output" =~ "  (use \"dolt checkout <table>\" to discard changes in working directory)" ]] || false
-    [[ "$output" =~ "	modified:         table2" ]] || false
-    [[ "$output" =~ "Untracked tables:" ]] || false
-    [[ "$output" =~ "  (use \"dolt add <table>\" to include in what will be committed)" ]] || false
-    [[ "$output" =~ "	new table:        table3" ]] || false
-    [[ "$output" =~ "Ignored tables:" ]] || false
-    [[ "$output" =~ "  (use \"dolt add -f <table>\" to include in what will be committed)" ]] || false
-    [[ "$output" =~ "	new table:        generated_foo" ]] || false
     localIgnoredOutput=$output
 
     [[ "$remoteOutput" == "$localOutput" ]] || false

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -8,18 +8,18 @@ make_repo() {
   dolt init
   dolt sql -q "create table $1_tbl (id int)"
   dolt sql <<SQL
-CREATE TABLE t (pk int PRIMARY KEY);
-CREATE TABLE u (pk int PRIMARY KEY);
+CREATE TABLE table1 (pk int PRIMARY KEY);
+CREATE TABLE table2 (pk int PRIMARY KEY);
 INSERT INTO dolt_ignore VALUES ('generated_*', 1);
 SQL
-  dolt add -A && dolt commit -m "tables t, u"
+  dolt add -A && dolt commit -m "tables table1, table2"
   dolt sql <<SQL
-INSERT INTO  t VALUES (1),(2),(3);
-INSERT INTO  u VALUES (1),(2),(3);
-CREATE TABLE v (pk int PRIMARY KEY);
+INSERT INTO  table1 VALUES (1),(2),(3);
+INSERT INTO  table2 VALUES (1),(2),(3);
+CREATE TABLE table3 (pk int PRIMARY KEY);
 CREATE TABLE generated_foo (pk int PRIMARY KEY);
 SQL
-  dolt add t
+  dolt add table1
   cd ..
 }
 
@@ -180,32 +180,34 @@ get_staged_tables() {
     [[ "$output" =~ "On branch main" ]] || false
     [[ "$output" =~ "Changes to be committed:" ]] || false
     [[ "$output" =~ "  (use \"dolt reset <table>...\" to unstage)" ]] || false
-    [[ "$output" =~ "	modified:         t" ]] || false
+    [[ "$output" =~ "	modified:         table1" ]] || false
     [[ "$output" =~ "Changes not staged for commit:" ]] || false
     [[ "$output" =~ "  (use \"dolt add <table>\" to update what will be committed)" ]] || false
     [[ "$output" =~ "  (use \"dolt checkout <table>\" to discard changes in working directory)" ]] || false
-    [[ "$output" =~ "	modified:         u" ]] || false
+    [[ "$output" =~ "	modified:         table2" ]] || false
     [[ "$output" =~ "Untracked tables:" ]] || false
     [[ "$output" =~ "  (use \"dolt add <table>\" to include in what will be committed)" ]] || false
-    [[ "$output" =~ "	new table:        v" ]] || false
+    [[ "$output" =~ "	new table:        table3" ]] || false
     ! [[ "$output" =~ "   new table:        generated_foo" ]] || false
+    remoteOutput=$output
 
     run dolt --user dolt status --ignored
     [ "$status" -eq 0 ] || false
     [[ "$output" =~ "On branch main" ]] || false
     [[ "$output" =~ "Changes to be committed:" ]] || false
     [[ "$output" =~ "  (use \"dolt reset <table>...\" to unstage)" ]] || false
-    [[ "$output" =~ "	modified:         t" ]] || false
+    [[ "$output" =~ "	modified:         table1" ]] || false
     [[ "$output" =~ "Changes not staged for commit:" ]] || false
     [[ "$output" =~ "  (use \"dolt add <table>\" to update what will be committed)" ]] || false
     [[ "$output" =~ "  (use \"dolt checkout <table>\" to discard changes in working directory)" ]] || false
-    [[ "$output" =~ "	modified:         u" ]] || false
+    [[ "$output" =~ "	modified:         table2" ]] || false
     [[ "$output" =~ "Untracked tables:" ]] || false
     [[ "$output" =~ "  (use \"dolt add <table>\" to include in what will be committed)" ]] || false
-    [[ "$output" =~ "	new table:        v" ]] || false
+    [[ "$output" =~ "	new table:        table3" ]] || false
     [[ "$output" =~ "Ignored tables:" ]] || false
     [[ "$output" =~ "  (use \"dolt add -f <table>\" to include in what will be committed)" ]] || false
     [[ "$output" =~ "	new table:        generated_foo" ]] || false
+    remoteIgnoredOutput=$output
 
     stop_sql_server 1
 
@@ -214,30 +216,35 @@ get_staged_tables() {
     [[ "$output" =~ "On branch main" ]] || false
     [[ "$output" =~ "Changes to be committed:" ]] || false
     [[ "$output" =~ "  (use \"dolt reset <table>...\" to unstage)" ]] || false
-    [[ "$output" =~ "	modified:         t" ]] || false
+    [[ "$output" =~ "	modified:         table1" ]] || false
     [[ "$output" =~ "Changes not staged for commit:" ]] || false
     [[ "$output" =~ "  (use \"dolt add <table>\" to update what will be committed)" ]] || false
     [[ "$output" =~ "  (use \"dolt checkout <table>\" to discard changes in working directory)" ]] || false
-    [[ "$output" =~ "	modified:         u" ]] || false
+    [[ "$output" =~ "	modified:         table2" ]] || false
     [[ "$output" =~ "Untracked tables:" ]] || false
     [[ "$output" =~ "  (use \"dolt add <table>\" to include in what will be committed)" ]] || false
-    [[ "$output" =~ "	new table:        v" ]] || false
+    [[ "$output" =~ "	new table:        table3" ]] || false
     ! [[ "$output" =~ "   new table:        generated_foo" ]] || false
+    localOutput=$output
 
     run dolt --user dolt status --ignored
     [ "$status" -eq 0 ] || false
     [[ "$output" =~ "On branch main" ]] || false
     [[ "$output" =~ "Changes to be committed:" ]] || false
     [[ "$output" =~ "  (use \"dolt reset <table>...\" to unstage)" ]] || false
-    [[ "$output" =~ "	modified:         t" ]] || false
+    [[ "$output" =~ "	modified:         table1" ]] || false
     [[ "$output" =~ "Changes not staged for commit:" ]] || false
     [[ "$output" =~ "  (use \"dolt add <table>\" to update what will be committed)" ]] || false
     [[ "$output" =~ "  (use \"dolt checkout <table>\" to discard changes in working directory)" ]] || false
-    [[ "$output" =~ "	modified:         u" ]] || false
+    [[ "$output" =~ "	modified:         table2" ]] || false
     [[ "$output" =~ "Untracked tables:" ]] || false
     [[ "$output" =~ "  (use \"dolt add <table>\" to include in what will be committed)" ]] || false
-    [[ "$output" =~ "	new table:        v" ]] || false
+    [[ "$output" =~ "	new table:        table3" ]] || false
     [[ "$output" =~ "Ignored tables:" ]] || false
     [[ "$output" =~ "  (use \"dolt add -f <table>\" to include in what will be committed)" ]] || false
     [[ "$output" =~ "	new table:        generated_foo" ]] || false
+    localIgnoredOutput=$output
+
+    [[ "$remoteOutput" == "$localOutput" ]] || false
+    [[ "$remoteIgnoredOutput" == "$localIgnoredOutput" ]] || false
 }

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -323,13 +323,13 @@ SQL
 
     # add some working changes
     dolt sql-client -P $PORT -u dolt -q "INSERT INTO test VALUES (7,7);"
-    run dolt status
+    run dolt --user=dolt status
     [ "$status" -eq 0 ]
     [[ "$output" =~ "test" ]] || false
 
     dolt sql-client -P $PORT -u dolt -q "CALL DOLT_RESET('--hard');"
 
-    run dolt status
+    run dolt --user=dolt status
     [ "$status" -eq 0 ]
     [[ "$output" =~ "working tree clean" ]] || false
     run dolt --user=dolt sql -q "SELECT sum(pk), sum(c0) FROM test;" -r csv
@@ -340,7 +340,7 @@ SQL
         INSERT INTO test VALUES (8,8);
         CALL DOLT_RESET('--hard');"
 
-    run dolt status
+    run dolt --user=dolt status
     [ "$status" -eq 0 ]
     [[ "$output" =~ "working tree clean" ]] || false
     run dolt --user=dolt sql -q "SELECT sum(pk), sum(c0) FROM test;" -r csv
@@ -591,7 +591,7 @@ SQL
      [[ $output =~ " 21 " ]] || false
      [[ $output =~ " 60 " ]] || false
 
-     run dolt status
+     run dolt --user=dolt status
      [ $status -eq 0 ]
      [[ "$output" =~ "nothing to commit, working tree clean" ]] || false
 }

--- a/integration-tests/mysql-client-tests/node/workbenchTests/branches.js
+++ b/integration-tests/mysql-client-tests/node/workbenchTests/branches.js
@@ -54,6 +54,7 @@ export const branchTests = [
         latest_committer_email: "mysql-test-runner@liquidata.co",
         latest_commit_date: "",
         latest_commit_message: "Initialize data repository",
+        remote: "",
       },
       {
         name: "mybranch",
@@ -62,6 +63,7 @@ export const branchTests = [
         latest_committer_email: "dolt@dolthub.com",
         latest_commit_date: "",
         latest_commit_message: "Create table test",
+        remote: "",
       },
     ],
     matcher: branchesMatcher,

--- a/integration-tests/mysql-client-tests/node/workbenchTests/branches.js
+++ b/integration-tests/mysql-client-tests/node/workbenchTests/branches.js
@@ -65,6 +65,7 @@ export const branchTests = [
         latest_commit_date: "",
         latest_commit_message: "Create table test",
         remote: "",
+        branch: "",
       },
     ],
     matcher: branchesMatcher,

--- a/integration-tests/mysql-client-tests/node/workbenchTests/branches.js
+++ b/integration-tests/mysql-client-tests/node/workbenchTests/branches.js
@@ -55,6 +55,7 @@ export const branchTests = [
         latest_commit_date: "",
         latest_commit_message: "Initialize data repository",
         remote: "",
+        branch: "",
       },
       {
         name: "mybranch",


### PR DESCRIPTION
Rewrite `dolt status` subcommand to use SQL queries to generate results.

This change adds `remote` column to the `dolt_branches` table. This column identifies the remote for the branch.
This change adds `dolt_count_commits` function, which returns the number of commits between two commits.
Added more BATS tests for `dolt status`.