### PR TITLE
Allow `@@dolt_transaction_commit` to be set through sql-server config

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -177,6 +177,7 @@ func Serve(
 		ServerPass:              serverConfig.Password(),
 		ServerHost:              serverConfig.Host(),
 		Autocommit:              serverConfig.AutoCommit(),
+		DoltTransactionCommit:   serverConfig.DoltTransactionCommit(),
 		JwksConfig:              serverConfig.JwksConfig(),
 		ClusterController:       clusterController,
 		BinlogReplicaController: binlogreplication.DoltBinlogReplicaController,

--- a/go/cmd/dolt/commands/sqlserver/serverconfig.go
+++ b/go/cmd/dolt/commands/sqlserver/serverconfig.go
@@ -48,6 +48,7 @@ const (
 	defaultReadOnly                = false
 	defaultLogLevel                = LogLevel_Info
 	defaultAutoCommit              = true
+	defaultDoltTransactionCommit   = false
 	defaultMaxConnections          = 100
 	defaultQueryParallelism        = 2
 	defaultPersistenceBahavior     = loadPerisistentGlobals
@@ -108,6 +109,9 @@ type ServerConfig interface {
 	LogLevel() LogLevel
 	// Autocommit defines the value of the @@autocommit session variable used on every connection
 	AutoCommit() bool
+	// DoltTransactionCommit defines the value of the @@dolt_transaction_commit session variable that enables Dolt
+	// commits to be automatically created when a SQL transaction is committed.
+	DoltTransactionCommit() bool
 	// DatabaseNamesAndPaths returns an array of env.EnvNameAndPathObjects corresponding to the databases to be loaded in
 	// a multiple db configuration. If nil is returned the server will look for a database in the current directory and
 	// give it a name automatically.
@@ -185,6 +189,7 @@ type commandLineServerConfig struct {
 	dataDir                 string
 	cfgDir                  string
 	autoCommit              bool
+	doltTransactionCommit   bool
 	maxConnections          uint64
 	queryParallelism        int
 	tlsKey                  string
@@ -246,6 +251,12 @@ func (cfg *commandLineServerConfig) LogLevel() LogLevel {
 // AutoCommit defines the value of the @@autocommit session variable used on every connection
 func (cfg *commandLineServerConfig) AutoCommit() bool {
 	return cfg.autoCommit
+}
+
+// DoltTransactionCommit defines the value of the @@dolt_transaction_commit session variable that enables Dolt
+// commits to be automatically created when a SQL transaction is committed. The default is false.
+func (cfg *commandLineServerConfig) DoltTransactionCommit() bool {
+	return cfg.doltTransactionCommit
 }
 
 // MaxConnections returns the maximum number of simultaneous connections the server will allow.  The default is 1

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -73,11 +73,13 @@ var sqlServerDocs = cli.CommandDocumentationContent{
 		indentLines(serverConfigAsYAMLConfig(DefaultServerConfig()).String()) + "\n\n" + `
 SUPPORTED CONFIG FILE FIELDS:
 
-{{.EmphasisLeft}}vlog_level{{.EmphasisRight}}: Level of logging provided. Options are: {{.EmphasisLeft}}trace{{.EmphasisRight}}, {{.EmphasisLeft}}debug{{.EmphasisRight}}, {{.EmphasisLeft}}info{{.EmphasisRight}}, {{.EmphasisLeft}}warning{{.EmphasisRight}}, {{.EmphasisLeft}}error{{.EmphasisRight}}, and {{.EmphasisLeft}}fatal{{.EmphasisRight}}.
+{{.EmphasisLeft}}log_level{{.EmphasisRight}}: Level of logging provided. Options are: {{.EmphasisLeft}}trace{{.EmphasisRight}}, {{.EmphasisLeft}}debug{{.EmphasisRight}}, {{.EmphasisLeft}}info{{.EmphasisRight}}, {{.EmphasisLeft}}warning{{.EmphasisRight}}, {{.EmphasisLeft}}error{{.EmphasisRight}}, and {{.EmphasisLeft}}fatal{{.EmphasisRight}}.
 
 {{.EmphasisLeft}}behavior.read_only{{.EmphasisRight}}: If true database modification is disabled
 
 {{.EmphasisLeft}}behavior.autocommit{{.EmphasisRight}}: If true write queries will automatically alter the working set. When working with autocommit enabled it is highly recommended that listener.max_connections be set to 1 as concurrency issues will arise otherwise
+
+{{.EmphasisLeft}}behavior.dolt_transaction_commit{{.EmphasisRight}}: If true all SQL transaction commits will automatically create a Dolt commit, with a generated commit message. This is useful when a system working with Dolt wants to create versioned data, but doesn't want to directly use Dolt features such as dolt_commit(). 
 
 {{.EmphasisLeft}}user.name{{.EmphasisRight}}: The username that connections should use for authentication
 

--- a/go/cmd/dolt/commands/sqlserver/yaml_config.go
+++ b/go/cmd/dolt/commands/sqlserver/yaml_config.go
@@ -70,6 +70,9 @@ type BehaviorYAMLConfig struct {
 	// (such as a CREATE TRIGGER), then those incoming queries will be
 	// misprocessed.
 	DisableClientMultiStatements *bool `yaml:"disable_client_multi_statements"`
+	// DoltTransactionCommit enables the @@dolt_transaction_commit system variable, which
+	// automatically creates a Dolt commit when any SQL transaction is committed.
+	DoltTransactionCommit *bool `yaml:"dolt_transaction_commit"`
 }
 
 // UserYAMLConfig contains server configuration regarding the user account clients must use to connect
@@ -170,6 +173,7 @@ func serverConfigAsYAMLConfig(cfg ServerConfig) YAMLConfig {
 			boolPtr(cfg.AutoCommit()),
 			strPtr(cfg.PersistenceBehavior()),
 			boolPtr(cfg.DisableClientMultiStatements()),
+			boolPtr(cfg.DoltTransactionCommit()),
 		},
 		UserConfig: UserYAMLConfig{strPtr(cfg.User()), strPtr(cfg.Password())},
 		ListenerConfig: ListenerYAMLConfig{
@@ -290,6 +294,16 @@ func (cfg YAMLConfig) AutoCommit() bool {
 	}
 
 	return *cfg.BehaviorConfig.AutoCommit
+}
+
+// DoltTransactionCommit defines the value of the @@dolt_transaction_commit session variable that enables Dolt
+// commits to be automatically created when a SQL transaction is committed.
+func (cfg YAMLConfig) DoltTransactionCommit() bool {
+	if cfg.BehaviorConfig.DoltTransactionCommit == nil {
+		return defaultDoltTransactionCommit
+	}
+
+	return *cfg.BehaviorConfig.DoltTransactionCommit
 }
 
 // LogLevel returns the level of logging that the server will use.

--- a/go/cmd/dolt/commands/sqlserver/yaml_config_test.go
+++ b/go/cmd/dolt/commands/sqlserver/yaml_config_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 )
 
+var trueValue = true
+
 func TestUnmarshall(t *testing.T) {
 	testStr := `
 log_level: info
@@ -31,6 +33,7 @@ log_level: info
 behavior:
     read_only: false
     autocommit: true
+    dolt_transaction_commit: true
     persistence_behavior: load
     disable_client_multi_statements: false
 
@@ -87,6 +90,7 @@ jwks:
     fields_to_log:
 `
 	expected := serverConfigAsYAMLConfig(DefaultServerConfig())
+	expected.BehaviorConfig.DoltTransactionCommit = &trueValue
 	expected.DatabaseConfig = []DatabaseYAMLConfig{
 		{
 			Name: "irs_soi",
@@ -335,6 +339,7 @@ func TestYAMLConfigDefaults(t *testing.T) {
 	assert.Equal(t, defaultReadOnly, cfg.ReadOnly())
 	assert.Equal(t, defaultLogLevel, cfg.LogLevel())
 	assert.Equal(t, defaultAutoCommit, cfg.AutoCommit())
+	assert.Equal(t, defaultDoltTransactionCommit, cfg.DoltTransactionCommit())
 	assert.Equal(t, uint64(defaultMaxConnections), cfg.MaxConnections())
 	assert.Equal(t, "", cfg.TLSKey())
 	assert.Equal(t, "", cfg.TLSCert())

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -1600,7 +1600,8 @@ listener:
   socket: dolt.$PORT.sock
 
 behavior:
-  autocommit: true" > server.yaml
+  autocommit: true
+  dolt_transaction_commit: true" > server.yaml
 
     dolt sql-server --config server.yaml > log.txt 2>&1 &
     SERVER_PID=$!
@@ -1610,6 +1611,11 @@ behavior:
     [ $status -eq 0 ]
     [[ $output =~ col1 ]] || false
     [[ $output =~ " 1 " ]] || false
+
+    run dolt sql-client -P $PORT -u dolt --use-db repo2 -q "select @@dolt_transaction_commit"
+    [ $status -eq 0 ]
+    [[ $output =~ " 1 " ]] || false
+
 
     run grep "dolt.$PORT.sock" log.txt
     [ "$status" -eq 0 ]


### PR DESCRIPTION
Dolt sql-server YAML configuration can now specify `dolt_transaction_commit` in the behavior section to automatically set the global value of [`@@dolt_transaction_commit`](https://docs.dolthub.com/sql-reference/version-control/dolt-sysvars#dolt_transaction_commit) for a sql-server.

Prereq for https://github.com/dolthub/hosted-issues/issues/99