### PR TITLE
Synchronize the two queryist implementations

### DIFF
--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -265,13 +265,13 @@ func (cmd SqlCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 				return sqlHandleVErrAndExitCode(queryist, errhand.VerboseErrorFromError(err), usage)
 			}
 		} else if runInBatchMode {
-			se, ok := queryist.(*engine.SqlEngine)
+			seq, ok := queryist.(SqlEngineQueryist)
 			if !ok {
 				misuse := fmt.Errorf("Using batch with non-local access pattern. Stop server if it is running")
 				return sqlHandleVErrAndExitCode(queryist, errhand.VerboseErrorFromError(misuse), usage)
 			}
 
-			verr := execBatch(sqlCtx, se, input, continueOnError, format)
+			verr := execBatch(sqlCtx, seq.se, input, continueOnError, format)
 			if verr != nil {
 				return sqlHandleVErrAndExitCode(queryist, verr, usage)
 			}
@@ -292,7 +292,7 @@ func (cmd SqlCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 func sqlHandleVErrAndExitCode(queryist cli.Queryist, verr errhand.VerboseError, usage cli.UsagePrinter) int {
 	if verr != nil {
 		if msg := verr.Verbose(); strings.TrimSpace(msg) != "" {
-			if _, ok := queryist.(*engine.SqlEngine); !ok {
+			if _, ok := queryist.(SqlEngineQueryist); !ok {
 				// We are in a context where we are attempting to connect to a remote database. These errors
 				// are unstructured, so we add some additional context around them.
 				tmpMsg := `You've encountered a new behavior in dolt which is not fully documented yet.
@@ -415,14 +415,14 @@ func queryMode(
 	_, continueOnError := apr.GetValue(continueFlag)
 
 	if batchMode {
-		se, ok := qryist.(*engine.SqlEngine)
+		seq, ok := qryist.(SqlEngineQueryist)
 		if !ok {
 			misuse := fmt.Errorf("Using batch with non-local access pattern. Stop server if it is running")
-			return sqlHandleVErrAndExitCode(se, errhand.VerboseErrorFromError(misuse), usage)
+			return sqlHandleVErrAndExitCode(qryist, errhand.VerboseErrorFromError(misuse), usage)
 		}
 
 		batchInput := strings.NewReader(query)
-		verr := execBatch(ctx, se, batchInput, continueOnError, format)
+		verr := execBatch(ctx, seq.se, batchInput, continueOnError, format)
 		if verr != nil {
 			return sqlHandleVErrAndExitCode(qryist, verr, usage)
 		}

--- a/go/cmd/dolt/commands/sql_engine_queryist.go
+++ b/go/cmd/dolt/commands/sql_engine_queryist.go
@@ -85,7 +85,7 @@ func (s SqlEngineRowIter) valToString(ctx *sql.Context, index int, val interface
 	case uint64:
 		switch ct.(type) {
 		case types.BitType_:
-			newValue = fmt.Sprintf("%v", string(t))
+			newValue = string(rune(t))
 		default:
 			newValue = fmt.Sprintf("%d", t)
 		}

--- a/go/cmd/dolt/commands/sql_engine_queryist.go
+++ b/go/cmd/dolt/commands/sql_engine_queryist.go
@@ -1,0 +1,133 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/shopspring/decimal"
+	"time"
+)
+
+type SqlEngineQueryist struct {
+	se *engine.SqlEngine
+}
+
+func (s SqlEngineQueryist) Query(ctx *sql.Context, query string) (sql.Schema, sql.RowIter, error) {
+	schema, iter, err := s.se.Query(ctx, query)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	newIter := NewSqlEngineRowIter(iter, schema)
+	return newIter.newSchema, newIter, nil
+}
+
+var _ cli.Queryist = SqlEngineQueryist{}
+
+func NewSqlEngineQueryist(se *engine.SqlEngine) cli.Queryist {
+	return SqlEngineQueryist{se}
+}
+
+type SqlEngineRowIter struct {
+	iter      sql.RowIter
+	oldSchema sql.Schema
+	newSchema sql.Schema
+}
+
+func (s SqlEngineRowIter) Next(ctx *sql.Context) (sql.Row, error) {
+	row, err := s.iter.Next(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	sqlRow := make(sql.Row, len(row))
+	for i, val := range row {
+		if val != nil {
+			newValue, err := s.valToString(ctx, i, val)
+			if err != nil {
+				return nil, err
+			}
+			sqlRow[i] = newValue
+		}
+	}
+
+	return sqlRow, nil
+}
+
+func (s SqlEngineRowIter) valToString(ctx *sql.Context, index int, val interface{}) (string, error) {
+	column := s.oldSchema[index]
+	ct := column.Type
+	var err error
+	var newValue string
+	switch t := val.(type) {
+	case string:
+		newValue = t
+	case types.OkResult:
+		newValue = "OK"
+	case int8:
+		newValue = fmt.Sprintf("%d", t)
+	case int16:
+		newValue = fmt.Sprintf("%d", t)
+	case int32:
+		newValue = fmt.Sprintf("%d", t)
+	case float32:
+		newValue = fmt.Sprintf("%g", t)
+	case float64:
+		newValue = fmt.Sprintf("%g", t)
+	case int64:
+		newValue = fmt.Sprintf("%d", t)
+	case decimal.Decimal:
+		decimalType := ct.(types.DecimalType_)
+		scale := decimalType.Scale()
+		newValue = t.StringFixed(int32(scale))
+	case uint64:
+		switch ct.(type) {
+		case types.BitType_:
+			newValue = fmt.Sprintf("%v", string(t))
+		default:
+			newValue = fmt.Sprintf("%d", t)
+		}
+	case time.Time:
+		sqlVal, err := ct.SQL(ctx, nil, t)
+		if err != nil {
+			return "", fmt.Errorf("unexpected time type %T", t)
+		}
+		newValue = sqlVal.ToString()
+	case types.Timespan:
+		newValue = t.String()
+	case []uint8:
+		newValue = string(t)
+	case types.JSONDocument:
+		newValue, err = t.ToString(nil)
+		if err != nil {
+			return "", fmt.Errorf("error converting JSONDocument type %T to string", t)
+		}
+	default:
+		return "", fmt.Errorf("unexpected type %T", t)
+	}
+	return newValue, nil
+}
+
+func (s SqlEngineRowIter) Close(c *sql.Context) error {
+	return s.iter.Close(c)
+}
+
+var _ sql.RowIter = (*SqlEngineRowIter)(nil)
+
+func NewSqlEngineRowIter(iter sql.RowIter, schema sql.Schema) *SqlEngineRowIter {
+	newSchema := make(sql.Schema, len(schema))
+	for i, col := range schema {
+		newSchema[i] = &sql.Column{
+			Name:     col.Name,
+			Type:     types.LongText,
+			Nullable: true,
+		}
+	}
+	return &SqlEngineRowIter{
+		iter:      iter,
+		oldSchema: schema,
+		newSchema: newSchema,
+	}
+}

--- a/go/cmd/dolt/commands/sqlserver/sqlclient.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlclient.go
@@ -461,6 +461,10 @@ type ConnectionQueryist struct {
 
 var _ cli.Queryist = ConnectionQueryist{}
 
+func NewConnectionQueryist(connection *dbr.Connection) ConnectionQueryist {
+	return ConnectionQueryist{connection: connection}
+}
+
 func (c ConnectionQueryist) Query(ctx *sql.Context, query string) (sql.Schema, sql.RowIter, error) {
 	rows, err := c.connection.QueryContext(ctx, query)
 	if err != nil {
@@ -495,7 +499,7 @@ func BuildConnectionStringQueryist(ctx context.Context, cwdFS filesys.Filesys, a
 
 	conn := &dbr.Connection{DB: mysql.OpenDB(mysqlConnector), EventReceiver: nil, Dialect: dialect.MySQL}
 
-	queryist := ConnectionQueryist{connection: conn}
+	queryist := NewConnectionQueryist(conn)
 
 	var lateBind cli.LateBindQueryist = func(ctx context.Context) (cli.Queryist, *sql.Context, func(), error) {
 		return queryist, sql.NewContext(ctx), func() { conn.Conn(ctx) }, nil

--- a/go/cmd/dolt/commands/utils.go
+++ b/go/cmd/dolt/commands/utils.go
@@ -240,7 +240,10 @@ func newLateBindingEngine(
 
 		// Set client to specified user
 		sqlCtx.Session.SetClient(sql.Client{User: config.ServerUser, Address: config.ServerHost, Capabilities: 0})
-		return se, sqlCtx, func() { se.Close() }, nil
+
+		queryist := NewSqlEngineQueryist(se)
+
+		return queryist, sqlCtx, func() { se.Close() }, nil
 
 	}
 

--- a/go/cmd/dolt/queryist_test.go
+++ b/go/cmd/dolt/queryist_test.go
@@ -1,0 +1,296 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/cmd/dolt/commands"
+	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
+	"github.com/dolthub/dolt/go/cmd/dolt/commands/sqlserver"
+	"github.com/dolthub/dolt/go/libraries/doltcore/dtestutils"
+	"github.com/dolthub/dolt/go/libraries/doltcore/env"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/gocraft/dbr/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+)
+
+type testcase struct {
+	query               string
+	expectedResult      []interface{}
+	expectedSchemaTypes []sql.Type
+}
+
+var tests = []testcase{
+	{
+		query: "show create table data",
+	},
+	{
+		query:               "select bit1 from data",
+		expectedResult:      []interface{}{"!"},
+		expectedSchemaTypes: []sql.Type{types.LongText},
+	},
+	{
+		query:               "select integer2 from data",
+		expectedResult:      []interface{}{"2"},
+		expectedSchemaTypes: []sql.Type{types.LongText},
+	},
+	{
+		query:               "select smallint3 from data",
+		expectedResult:      []interface{}{"3"},
+		expectedSchemaTypes: []sql.Type{types.LongText},
+	},
+	{
+		query:               "select float_4 from data",
+		expectedResult:      []interface{}{"4"},
+		expectedSchemaTypes: []sql.Type{types.LongText},
+	},
+	{
+		query:               "select double5 from data",
+		expectedResult:      []interface{}{"5"},
+		expectedSchemaTypes: []sql.Type{types.LongText},
+	},
+	{
+		query:               "select bigInt6 from data",
+		expectedResult:      []interface{}{"6"},
+		expectedSchemaTypes: []sql.Type{types.LongText},
+	},
+	{
+		query:               "select bool7 from data",
+		expectedResult:      []interface{}{"1"},
+		expectedSchemaTypes: []sql.Type{types.LongText},
+	},
+	{
+		query:               "select tinyint8 from data",
+		expectedResult:      []interface{}{"8"},
+		expectedSchemaTypes: []sql.Type{types.LongText},
+	},
+	{
+		query:               "select smallint9 from data",
+		expectedResult:      []interface{}{"9"},
+		expectedSchemaTypes: []sql.Type{types.LongText},
+	},
+	{
+		query:               "select mediumint10 from data",
+		expectedResult:      []interface{}{"10"},
+		expectedSchemaTypes: []sql.Type{types.LongText},
+	},
+	{
+		query:               "select decimal11 from data",
+		expectedResult:      []interface{}{"11.01230"},
+		expectedSchemaTypes: []sql.Type{types.LongText},
+	},
+	{
+		query:               "select date12, time13, datetime14 from data",
+		expectedResult:      []interface{}{"2023-05-31", "18:45:39", "2023-05-31 18:45:39"},
+		expectedSchemaTypes: []sql.Type{types.LongText, types.LongText, types.LongText},
+	},
+	{
+		query:               "select year15 from data",
+		expectedResult:      []interface{}{"2015"},
+		expectedSchemaTypes: []sql.Type{types.LongText},
+	},
+	{
+		query:               "select char16 from data",
+		expectedResult:      []interface{}{"char16"},
+		expectedSchemaTypes: []sql.Type{types.LongText},
+	},
+	{
+		query:               "select varchar17 from data",
+		expectedResult:      []interface{}{"varchar17"},
+		expectedSchemaTypes: []sql.Type{types.LongText},
+	},
+	{
+		query:               "select binary18 from data",
+		expectedResult:      []interface{}{"binary--18"},
+		expectedSchemaTypes: []sql.Type{types.LongText},
+	},
+	{
+		query:               "select varbinary19 from data",
+		expectedResult:      []interface{}{"vbinary19"},
+		expectedSchemaTypes: []sql.Type{types.LongText},
+	},
+	{
+		query:          "select json20 from data",
+		expectedResult: []interface{}{"[1, 2, 3]"},
+	},
+}
+var setupScripts = []string{
+	`create table data (
+		id BIGINT primary key,
+		bit1 BIT(6),
+		integer2 INTEGER,
+		smallint3 SMALLINT,
+		float_4 FLOAT,
+		double5 DOUBLE,
+		bigInt6 BIGINT,
+		bool7 BOOLEAN,
+		tinyint8 TINYINT,
+		smallint9 SMALLINT,
+		mediumint10 MEDIUMINT,
+		decimal11 DECIMAL(10, 5),
+		date12 DATE,
+		time13 TIME,
+		datetime14 DATETIME,
+		year15 YEAR,
+		char16 CHAR(10),
+		varchar17 VARCHAR(10),
+		binary18 BINARY(10),
+		varbinary19 VARBINARY(10),
+		json20 JSON
+	 );`,
+	`insert into data values (
+		100, 33, 2, 3, 4, 5, 6,
+		true, 8, 9, 10, 11.0123, "2023-05-31", "18:45:39", "2023-05-31 18:45:39",
+		2015, "char16", "varchar17", "binary--18", "vbinary19",
+		"[1 , 2 , 3]");`,
+}
+
+func TestQueryistCases(t *testing.T) {
+	for _, test := range tests {
+		RunSingleTest(t, test)
+	}
+}
+
+func RunSingleTest(t *testing.T, test testcase) {
+	t.Run(test.query+"-SqlEngineQueryist", func(t *testing.T) {
+		// setup server engine
+		ctx := context.Background()
+		dEnv := dtestutils.CreateTestEnv()
+		defer dEnv.DoltDB.Close()
+		sqlEngine, dbName, err := engine.NewSqlEngineForEnv(ctx, dEnv)
+		require.NoError(t, err)
+		sqlCtx, err := sqlEngine.NewLocalContext(ctx)
+		require.NoError(t, err)
+		sqlCtx.SetCurrentDatabase(dbName)
+		queryist := commands.NewSqlEngineQueryist(sqlEngine)
+
+		// initialize server
+		initServer(t, sqlCtx, queryist)
+
+		// run test
+		runTestcase(t, sqlCtx, queryist, test)
+	})
+	t.Run(test.query+"-ConnectionQueryist", func(t *testing.T) {
+		// setup server
+		dEnv, sc, serverConfig := startServer(t, true, "", "")
+		err := sc.WaitForStart()
+		require.NoError(t, err)
+		defer dEnv.DoltDB.Close()
+		conn, _ := newConnection(t, serverConfig)
+		queryist := sqlserver.NewConnectionQueryist(conn)
+		ctx := context.TODO()
+		sqlCtx := sql.NewContext(ctx)
+
+		// initialize server
+		initServer(t, sqlCtx, queryist)
+
+		// run test
+		runTestcase(t, sqlCtx, queryist, test)
+
+		// close server
+		require.NoError(t, conn.Close())
+		sc.StopServer()
+		err = sc.WaitForClose()
+		require.NoError(t, err)
+	})
+}
+
+func runTestcase(t *testing.T, sqlCtx *sql.Context, queryist cli.Queryist, test testcase) {
+	// run test
+	schema, rowIter, err := queryist.Query(sqlCtx, test.query)
+	require.NoError(t, err)
+
+	// get a row of data
+	row, err := rowIter.Next(sqlCtx)
+	require.NoError(t, err)
+
+	if len(test.expectedResult) > 0 {
+		// test result row
+		assert.Equal(t, len(test.expectedResult), len(row))
+
+		for i, val := range row {
+			expected := test.expectedResult[i]
+			assert.Equal(t, expected, val)
+		}
+	} else {
+		// log result row
+		sb := strings.Builder{}
+		for i, val := range row {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+			sb.WriteString(fmt.Sprintf("%v", val))
+		}
+		t.Logf("result: %s", sb.String())
+	}
+
+	// test result schema
+	if len(test.expectedSchemaTypes) > 0 {
+		for i, col := range schema {
+			expected := test.expectedSchemaTypes[i]
+			actual := col.Type
+			assert.Equal(t, expected, actual,
+				"schema type mismatch for column %s: %s != %s", col.Name, expected.String(), actual.String())
+		}
+	}
+}
+
+func initServer(t *testing.T, sqlCtx *sql.Context, queryist cli.Queryist) {
+	for _, setupScript := range setupScripts {
+		_, rowIter, err := queryist.Query(sqlCtx, setupScript)
+		require.NoError(t, err)
+
+		for {
+			row, err := rowIter.Next(sqlCtx)
+			if err == io.EOF {
+				break
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, row)
+			}
+		}
+	}
+}
+
+// startServer will start sql-server with given host, unix socket file path and whether to use specific port, which is defined randomly.
+func startServer(t *testing.T, withPort bool, host string, unixSocketPath string) (*env.DoltEnv, *sqlserver.ServerController, sqlserver.ServerConfig) {
+	dEnv := dtestutils.CreateTestEnv()
+	serverConfig := sqlserver.DefaultServerConfig()
+
+	if withPort {
+		rand.Seed(time.Now().UnixNano())
+		port := 15403 + rand.Intn(25)
+		serverConfig = serverConfig.WithPort(port)
+	}
+	if host != "" {
+		serverConfig = serverConfig.WithHost(host)
+	}
+	if unixSocketPath != "" {
+		serverConfig = serverConfig.WithSocket(unixSocketPath)
+	}
+
+	sc := sqlserver.NewServerController()
+	go func() {
+		_, _ = sqlserver.Serve(context.Background(), "0.0.0", serverConfig, sc, dEnv)
+	}()
+	err := sc.WaitForStart()
+	require.NoError(t, err)
+
+	return dEnv, sc, serverConfig
+}
+
+// newConnection takes sqlserver.serverConfig and opens a connection, and will return that connection with a new session
+func newConnection(t *testing.T, serverConfig sqlserver.ServerConfig) (*dbr.Connection, *dbr.Session) {
+	const dbName = "dolt"
+	conn, err := dbr.Open("mysql", sqlserver.ConnectionString(serverConfig, dbName), nil)
+	require.NoError(t, err)
+	sess := conn.NewSession(nil)
+	return conn, sess
+}

--- a/go/cmd/dolt/queryist_test.go
+++ b/go/cmd/dolt/queryist_test.go
@@ -118,7 +118,7 @@ var tests = []testcase{
 	},
 	{
 		query:          "select json20 from data",
-		expectedResult: []interface{}{"[1, 2, 3]"},
+		expectedResult: []interface{}{`[1, 2, 3, "four", {"a": 1, "b": "2", "c": 3, "d": {"e": 1, "f": 2, "g": 3}}]`},
 	},
 }
 var setupScripts = []string{
@@ -145,11 +145,13 @@ var setupScripts = []string{
 		varbinary19 VARBINARY(10),
 		json20 JSON
 	 );`,
+
 	`insert into data values (
 		100, 33, 2, 3, 4, 5, 6,
 		true, 8, 9, 10, 11.0123, "2023-05-31", "18:45:39", "2023-05-31 18:45:39",
 		2015, "char16", "varchar17", "binary--18", "vbinary19",
-		"[1 , 2 , 3]");`,
+		"[ 1 , 2 , 3 , ""four"" , { ""a"": 1, ""b"": ""2"", ""c"": 3, ""d"": { ""e"": 1, ""f"": 2, ""g"": 3 } }]"
+		);`,
 }
 
 func TestQueryistCases(t *testing.T) {


### PR DESCRIPTION
Synchronize the two queryist implementations so they produce the same results.

- keep the current MySQL iterator that returns everything as a string
- add SqlEngineQueryist, which wraps calls to SqlEngine and returns all data as a string
- SqlEngineQueryist is only going to be used by dolt subcommands, so no one is being broken by this change

## More info about this change

The current Queryist logic flips between 2 implementations:
1. SQLEngine querying - here, we access Dolt directly, and get back properly typed responses. We're also receiving `bool` objects in some cases, like with [the `staged` column  on `dolt_status` table](https://github.com/dolthub/dolt/blob/main/go/libraries/doltcore/sqle/dtables/status_table.go#L49). This mode is used when we are running `dolt foo` from a dolt directory.
2. MySQL querying - we are currently using MysqlRowWrapper, an existing wrapper that considers every column a string and returns strings. This mode is used when we are running `dolt foo` commands against a remote server.

So with the current Queryist logic, if we execute the query `select * from dolt_status`, then the 2nd column will either be `bool` (with SQLEngine) or `string` (with MySQL).
That means that currently Queryist consumers would have to consider and handle both cases.

This PR synchronizes the two flavors of Queryist implementations by always returning strings from dolt. This is a smaller change than the previous version of this PR and does not impact any dolt consumers.