### PR TITLE
update dolt blame to use sql backend and accept specific revision

### DIFF
--- a/go/cmd/dolt/commands/blame.go
+++ b/go/cmd/dolt/commands/blame.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/dolthub/dolt/go/libraries/utils/iohelp"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
@@ -26,6 +25,7 @@ import (
 	eventsapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
+	"github.com/dolthub/dolt/go/libraries/utils/iohelp"
 )
 
 const (

--- a/go/cmd/dolt/commands/blame.go
+++ b/go/cmd/dolt/commands/blame.go
@@ -28,8 +28,7 @@ import (
 )
 
 const (
-	blameQueryTemplate     = "SELECT * FROM dolt_blame_%s"
-	blameAsOfQueryTemplate = "SELECT * FROM dolt_blame_%s AS OF '%s'"
+	blameQueryTemplate = "SELECT * FROM dolt_blame_%s AS OF '%s'"
 )
 
 var blameDocs = cli.CommandDocumentationContent{
@@ -104,9 +103,9 @@ func (cmd BlameCmd) Exec(ctx context.Context, commandStr string, args []string, 
 	var schema sql.Schema
 	var ri sql.RowIter
 	if apr.NArg() == 1 {
-		schema, ri, err = queryist.Query(sqlCtx, fmt.Sprintf(blameQueryTemplate, apr.Arg(0)))
+		schema, ri, err = queryist.Query(sqlCtx, fmt.Sprintf(blameQueryTemplate, apr.Arg(0), "HEAD"))
 	} else {
-		schema, ri, err = queryist.Query(sqlCtx, fmt.Sprintf(blameAsOfQueryTemplate, apr.Arg(1), apr.Arg(0)))
+		schema, ri, err = queryist.Query(sqlCtx, fmt.Sprintf(blameQueryTemplate, apr.Arg(1), apr.Arg(0)))
 	}
 	if err != nil {
 		return 1

--- a/go/cmd/dolt/commands/blame.go
+++ b/go/cmd/dolt/commands/blame.go
@@ -19,14 +19,14 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
-	ref2 "github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 	eventsapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
+	ref2 "github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 	"github.com/dolthub/dolt/go/libraries/utils/iohelp"
 )

--- a/go/cmd/dolt/commands/blame.go
+++ b/go/cmd/dolt/commands/blame.go
@@ -62,6 +62,12 @@ func (cmd BlameCmd) ArgParser() *argparser.ArgParser {
 	return ap
 }
 
+func (cmd BlameCmd) RequiresRepo() bool {
+	return false
+}
+
+var _ cli.RepoNotRequiredCommand = BlameCmd{}
+
 // EventType returns the type of the event to log
 func (cmd BlameCmd) EventType() eventsapi.ClientEventType {
 	return eventsapi.ClientEventType_BLAME

--- a/go/cmd/dolt/commands/blame.go
+++ b/go/cmd/dolt/commands/blame.go
@@ -18,12 +18,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/dolthub/go-mysql-server/sql"
+
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 	eventsapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
-	"github.com/dolthub/go-mysql-server/sql"
 )
 
 const (

--- a/go/cmd/dolt/commands/blame.go
+++ b/go/cmd/dolt/commands/blame.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	blameQueryTemplate     = "SELECT * FROM dolt_blame_%s"
-	blameAsOfQueryTemplate = "SELECT * FROM dolt_blame_%s AS OF %s"
+	blameAsOfQueryTemplate = "SELECT * FROM dolt_blame_%s AS OF '%s'"
 )
 
 var blameDocs = cli.CommandDocumentationContent{

--- a/integration-tests/bats/blame.bats
+++ b/integration-tests/bats/blame.bats
@@ -50,55 +50,53 @@ SQL
     [[ "$output" =~ "usage" ]] || false
 }
 
+@test "blame: too many arguments shows usage" {
+    run dolt blame HEAD blame_test foo
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "blame has too many positional arguments" ]] || false
+}
+
 @test "blame: annotates a small table with simple history" {
     # should be the same as dolt blame HEAD blame_test
     run dolt blame blame_test
     [ "$status" -eq 0 ]
 
-    # TODO: Make these assertions better
-    [[ "$output" =~ "Thomas Foolery" ]] || false
-    [[ "$output" =~ "create blame_test table" ]] || false
+    [[ "$output" =~ "1".*"Thomas Foolery".*"create blame_test table" ]] || false
     [[ ! "$output" =~ "Richard Tracy" ]] || false
     [[ ! "$output" =~ "add richard to blame_test" ]] || false
-    [[ "$output" =~ "Harry Wombat" ]] || false
-    [[ "$output" =~ "replace richard" ]] || false
-    [[ "$output" =~ "Johnny Moolah" ]] || false
-    [[ "$output" =~ "add more people" ]] || false
+    [[ "$output" =~ "2".*"Harry Wombat".*"replace richard" ]] || false
+    [[ "$output" =~ "3".*"Johnny Moolah".*"add more people" ]] || false
+    [[ "$output" =~ "4".*"Johnny Moolah".*"add more people" ]] || false
 }
 
 @test "blame: blames HEAD when commit ref omitted" {
     run dolt blame blame_test
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "Thomas Foolery" ]] || false
-    [[ "$output" =~ "create blame_test table" ]] || false
+
+    [[ "$output" =~ "1".*"Thomas Foolery".*"create blame_test table" ]] || false
     [[ ! "$output" =~ "Richard Tracy" ]] || false
     [[ ! "$output" =~ "add richard to blame_test" ]] || false
-    [[ "$output" =~ "Harry Wombat" ]] || false
-    [[ "$output" =~ "replace richard" ]] || false
-    [[ "$output" =~ "Johnny Moolah" ]] || false
-    [[ "$output" =~ "add more people" ]] || false
+    [[ "$output" =~ "2".*"Harry Wombat".*"replace richard" ]] || false
+    [[ "$output" =~ "3".*"Johnny Moolah".*"add more people" ]] || false
+    [[ "$output" =~ "4".*"Johnny Moolah".*"add more people" ]] || false
 }
 
 @test "blame: works with HEAD as the commit ref" {
-    skip "SQL views do no support AS OF queries"
-
     run dolt blame HEAD blame_test
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "Thomas Foolery" ]] || false
-    [[ "$output" =~ "create blame_test table" ]] || false
+
+    [[ "$output" =~ "1".*"Thomas Foolery".*"create blame_test table" ]] || false
     [[ ! "$output" =~ "Richard Tracy" ]] || false
     [[ ! "$output" =~ "add richard to blame_test" ]] || false
-    [[ "$output" =~ "Harry Wombat" ]] || false
-    [[ "$output" =~ "replace richard" ]] || false
-    [[ "$output" =~ "Johnny Moolah" ]] || false
-    [[ "$output" =~ "add more people" ]] || false
+    [[ "$output" =~ "2".*"Harry Wombat".*"replace richard" ]] || false
+    [[ "$output" =~ "3".*"Johnny Moolah".*"add more people" ]] || false
+    [[ "$output" =~ "4".*"Johnny Moolah".*"add more people" ]] || false
 }
 
 @test "blame: works with HEAD~1 as the commit ref" {
-    skip "SQL views do no support AS OF queries"
-
     run dolt blame HEAD~1 blame_test
     [ "$status" -eq 0 ]
+
     [[ "$output" =~ "Thomas Foolery" ]] || false
     [[ "$output" =~ "create blame_test table" ]] || false
     [[ ! "$output" =~ "Richard Tracy" ]] || false

--- a/integration-tests/bats/blame.bats
+++ b/integration-tests/bats/blame.bats
@@ -108,7 +108,7 @@ SQL
 }
 
 @test "blame: works with HEAD~2 as the commit ref" {
-    skip "SQL views do no support AS OF queries"
+    skip "SQL views return incorrect data when using AS OF with commits that modify existing data"
 
     run dolt blame HEAD~2 blame_test
     [ "$status" -eq 0 ]

--- a/integration-tests/bats/blame.bats
+++ b/integration-tests/bats/blame.bats
@@ -123,10 +123,9 @@ SQL
 }
 
 @test "blame: works with HEAD~3 as the commit ref" {
-    skip "SQL views do no support AS OF queries"
-
     run dolt blame HEAD~3 blame_test
     [ "$status" -eq 0 ]
+
     [[ "$output" =~ "Thomas Foolery" ]] || false
     [[ "$output" =~ "create blame_test table" ]] || false
     [[ ! "$output" =~ "Richard Tracy" ]] || false

--- a/integration-tests/bats/blame.bats
+++ b/integration-tests/bats/blame.bats
@@ -137,10 +137,9 @@ SQL
 }
 
 @test "blame: returns an error when the table is not found in the given revision" {
-    skip "SQL views do no support AS OF queries"
     run dolt blame HEAD~4 blame_test
-    [ "$status" -eq 1 ]
-    [[ "$output" =~ "no table named blame_test found" ]] || false
+    [ "$status" -eq 0 ]
+    [[ "$output" = "" ]] || false
 }
 
 @test "blame: pk ordered output" {

--- a/integration-tests/bats/blame.bats
+++ b/integration-tests/bats/blame.bats
@@ -61,12 +61,13 @@ SQL
     run dolt blame blame_test
     [ "$status" -eq 0 ]
 
-    [[ "$output" =~ "1".*"Thomas Foolery".*"create blame_test table" ]] || false
+    [[ "${lines[1]}" =~ "pk".*"commit".*"commit_date".*"committer".*"email".*"message" ]] || false
+    [[ "$output" =~ "1  |".+"|".+"| Thomas Foolery, | bats-1@email.fake | create blame_test table       |" ]] || false
     [[ ! "$output" =~ "Richard Tracy" ]] || false
     [[ ! "$output" =~ "add richard to blame_test" ]] || false
-    [[ "$output" =~ "2".*"Harry Wombat".*"replace richard" ]] || false
-    [[ "$output" =~ "3".*"Johnny Moolah".*"add more people" ]] || false
-    [[ "$output" =~ "4".*"Johnny Moolah".*"add more people" ]] || false
+    [[ "$output" =~ "2  |".+"|".+"| Harry Wombat,   | bats-3@email.fake | replace richard with harry    |" ]] || false
+    [[ "$output" =~ "3  |".+"|".+"| Johnny Moolah,  | bats-4@email.fake | add more people to blame_test |" ]] || false
+    [[ "$output" =~ "4  |".+"|".+"| Johnny Moolah,  | bats-4@email.fake | add more people to blame_test |" ]] || false
 }
 
 @test "blame: blames HEAD when commit ref omitted" {

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -109,8 +109,7 @@ teardown() {
 }
 
 @test "sql-local-remote: verify dolt blame behavior is identical in switch between server/no server" {
-    cd defaultDB
-
+    cd altDB
     dolt sql -q "create table test (pk int primary key)"
     dolt sql -q "insert into test values (1)"
     dolt add test
@@ -118,8 +117,9 @@ teardown() {
     dolt sql -q "insert into test values (2), (3)"
     dolt add test
     dolt commit -m "insert more values into test"
+    cd ..
 
-    start_sql_server defaultDB
+    start_sql_server altDB
     run dolt --user dolt blame test
     [ "$status" -eq 0 ]
     export out="$output"

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -122,15 +122,11 @@ teardown() {
     start_sql_server defaultDB
     run dolt --user dolt blame test
     [ "$status" -eq 0 ]
-    [[ "$output" =~  "1".*"insert initial value into test" ]] || false
-    [[ "$output" =~  "2".*"insert more values into test" ]] || false
-    [[ "$output" =~  "3".*"insert more values into test" ]] || false
+    export out="$output"
     stop_sql_server 1
 
     run dolt blame test
     [ "$status" -eq 0 ]
-    [[ "$output" =~  "1".*"insert initial value into test" ]] || false
-    [[ "$output" =~  "2".*"insert more values into test" ]] || false
-    [[ "$output" =~  "3".*"insert more values into test" ]] || false
+    [[ "$output" =  $out ]] || false
 }
 


### PR DESCRIPTION
This change updates `dolt blame` to use the appropriate sql engine to generate results. This change also allows users to specify a specific revision to annotate from.

Related: https://github.com/dolthub/dolt/issues/3922