### PR TITLE
Add support for parquet as an output format for `dolt sql`

### DIFF
--- a/go/cmd/dolt/commands/engine/sql_print.go
+++ b/go/cmd/dolt/commands/engine/sql_print.go
@@ -28,6 +28,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlutil"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/typed/json"
+	"github.com/dolthub/dolt/go/libraries/doltcore/table/typed/parquet"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/untyped/csv"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/untyped/tabular"
 	"github.com/dolthub/dolt/go/libraries/utils/iohelp"
@@ -41,6 +42,7 @@ const (
 	FormatJson
 	FormatNull // used for profiling
 	FormatVertical
+	FormatParquet
 )
 
 type PrintSummaryBehavior byte
@@ -96,6 +98,12 @@ func prettyPrintResultsWithSummary(ctx *sql.Context, resultFormat PrintResultFor
 		wr = nullWriter{}
 	case FormatVertical:
 		wr = newVerticalRowWriter(iohelp.NopWrCloser(cli.CliOut), sqlSch)
+	case FormatParquet:
+		var err error
+		wr, err = parquet.NewParquetRowWriter(sqlSch, iohelp.NopWrCloser(cli.CliOut))
+		if err != nil {
+			return err
+		}
 	}
 
 	numRows, err := writeResultSet(ctx, rowIter, wr)

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -147,7 +147,7 @@ func (cmd SqlCmd) Docs() *cli.CommandDocumentation {
 func (cmd SqlCmd) ArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParserWithMaxArgs(cmd.Name(), 0)
 	ap.SupportsString(QueryFlag, "q", "SQL query to run", "Runs a single query and exits.")
-	ap.SupportsString(FormatFlag, "r", "result output format", "How to format result output. Valid values are tabular, csv, json, vertical, and pq. Defaults to tabular.")
+	ap.SupportsString(FormatFlag, "r", "result output format", "How to format result output. Valid values are tabular, csv, json, vertical, and parquet. Defaults to tabular.")
 	ap.SupportsString(saveFlag, "s", "saved query name", "Used with --query, save the query to the query catalog with the name provided. Saved queries can be examined in the dolt_query_catalog system table.")
 	ap.SupportsString(executeFlag, "x", "saved query name", "Executes a saved query with the given name.")
 	ap.SupportsFlag(listSavedFlag, "l", "List all saved queries.")
@@ -323,7 +323,7 @@ func (cmd SqlCmd) handleLegacyArguments(ap *argparser.ArgParser, commandStr stri
 	if err != nil {
 		legacyParser := argparser.NewArgParserWithMaxArgs(cmd.Name(), 0)
 		legacyParser.SupportsString(QueryFlag, "q", "SQL query to run", "Runs a single query and exits.")
-		legacyParser.SupportsString(FormatFlag, "r", "result output format", "How to format result output. Valid values are tabular, csv, json, vertical, and pq. Defaults to tabular.")
+		legacyParser.SupportsString(FormatFlag, "r", "result output format", "How to format result output. Valid values are tabular, csv, json, vertical, and parquet. Defaults to tabular.")
 		legacyParser.SupportsString(saveFlag, "s", "saved query name", "Used with --query, save the query to the query catalog with the name provided. Saved queries can be examined in the dolt_query_catalog system table.")
 		legacyParser.SupportsString(executeFlag, "x", "saved query name", "Executes a saved query with the given name.")
 		legacyParser.SupportsFlag(listSavedFlag, "l", "List all saved queries.")
@@ -584,7 +584,7 @@ func GetResultFormat(format string) (engine.PrintResultFormat, errhand.VerboseEr
 		return engine.FormatNull, nil
 	case "vertical":
 		return engine.FormatVertical, nil
-	case "pq":
+	case "parquet":
 		return engine.FormatParquet, nil
 	default:
 		return engine.FormatTabular, errhand.BuildDError("Invalid argument for --result-format. Valid values are tabular, csv, json").Build()

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -147,7 +147,7 @@ func (cmd SqlCmd) Docs() *cli.CommandDocumentation {
 func (cmd SqlCmd) ArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParserWithMaxArgs(cmd.Name(), 0)
 	ap.SupportsString(QueryFlag, "q", "SQL query to run", "Runs a single query and exits.")
-	ap.SupportsString(FormatFlag, "r", "result output format", "How to format result output. Valid values are tabular, csv, json, vertical. Defaults to tabular.")
+	ap.SupportsString(FormatFlag, "r", "result output format", "How to format result output. Valid values are tabular, csv, json, vertical, and pq. Defaults to tabular.")
 	ap.SupportsString(saveFlag, "s", "saved query name", "Used with --query, save the query to the query catalog with the name provided. Saved queries can be examined in the dolt_query_catalog system table.")
 	ap.SupportsString(executeFlag, "x", "saved query name", "Executes a saved query with the given name.")
 	ap.SupportsFlag(listSavedFlag, "l", "List all saved queries.")
@@ -323,7 +323,7 @@ func (cmd SqlCmd) handleLegacyArguments(ap *argparser.ArgParser, commandStr stri
 	if err != nil {
 		legacyParser := argparser.NewArgParserWithMaxArgs(cmd.Name(), 0)
 		legacyParser.SupportsString(QueryFlag, "q", "SQL query to run", "Runs a single query and exits.")
-		legacyParser.SupportsString(FormatFlag, "r", "result output format", "How to format result output. Valid values are tabular, csv, json, vertical. Defaults to tabular.")
+		legacyParser.SupportsString(FormatFlag, "r", "result output format", "How to format result output. Valid values are tabular, csv, json, vertical, and pq. Defaults to tabular.")
 		legacyParser.SupportsString(saveFlag, "s", "saved query name", "Used with --query, save the query to the query catalog with the name provided. Saved queries can be examined in the dolt_query_catalog system table.")
 		legacyParser.SupportsString(executeFlag, "x", "saved query name", "Executes a saved query with the given name.")
 		legacyParser.SupportsFlag(listSavedFlag, "l", "List all saved queries.")
@@ -584,6 +584,8 @@ func GetResultFormat(format string) (engine.PrintResultFormat, errhand.VerboseEr
 		return engine.FormatNull, nil
 	case "vertical":
 		return engine.FormatVertical, nil
+	case "pq":
+		return engine.FormatParquet, nil
 	default:
 		return engine.FormatTabular, errhand.BuildDError("Invalid argument for --result-format. Valid values are tabular, csv, json").Build()
 	}

--- a/go/libraries/doltcore/mvdata/file_data_loc.go
+++ b/go/libraries/doltcore/mvdata/file_data_loc.go
@@ -195,7 +195,7 @@ func (dl FileDataLocation) NewCreatingWriter(ctx context.Context, mvOpts DataMov
 			return sqlexport.OpenSQLExportWriter(ctx, wr, root, mvOpts.SrcName(), mvOpts.IsAutocommitOff(), outSch, opts)
 		}
 	case ParquetFile:
-		return parquet.NewParquetWriter(outSch, mvOpts.DestName())
+		return parquet.NewParquetRowWriterForFile(outSch, mvOpts.DestName())
 	}
 
 	panic("Invalid Data Format." + string(dl.Format))

--- a/go/libraries/doltcore/table/typed/parquet/writer_test.go
+++ b/go/libraries/doltcore/table/typed/parquet/writer_test.go
@@ -63,7 +63,7 @@ func getSampleRows() []sql.Row {
 	}
 }
 
-func writeToParquet(pWr *ParquetWriter, rows []sql.Row, t *testing.T) {
+func writeToParquet(pWr *ParquetRowWriter, rows []sql.Row, t *testing.T) {
 	func() {
 		defer pWr.Close(context.Background())
 
@@ -92,7 +92,7 @@ Andy Anderson,27,
 
 	rows := getSampleRows()
 
-	pWr, err := NewParquetWriter(rowSch, path)
+	pWr, err := NewParquetRowWriterForFile(rowSch, path)
 	if err != nil {
 		t.Fatal("Could not open CSVWriter", err)
 	}

--- a/integration-tests/bats/sql.bats
+++ b/integration-tests/bats/sql.bats
@@ -1040,7 +1040,7 @@ SQL
     [ $status -eq 0 ]
     [[ "$output" =~ "utf8mb4" ]] || false
 
-    dolt sql -r pq -q "select * from test order by a" > out.parquet
+    dolt sql -r parquet -q "select * from test order by a" > out.parquet
     run parquet cat out.parquet
     [ "$status" -eq 0 ]
     [[ "$output" =~ '{"a": 1, "b": 1.5, "c": "1", "d": 1577836800000000}' ]] || false
@@ -1050,7 +1050,7 @@ SQL
     [[ "$output" =~ '{"a": 5, "b": 5.5, "c": "5", "d": null}' ]] || false
     [ "${#lines[@]}" -eq 5 ]
 
-    run dolt sql -r pq -q "select @@character_set_client"
+    run dolt sql -r parquet -q "select @@character_set_client"
     [ $status -eq 0 ]
     [[ "$output" =~ "utf8mb4" ]] || false
 }
@@ -1069,7 +1069,7 @@ SQL
     [ $status -eq 0 ]
     [[ "$output" =~ "{}" ]] || false
 
-    dolt sql -r pq -q "select * from test order by a" > out.parquet
+    dolt sql -r parquet -q "select * from test order by a" > out.parquet
     run parquet cat out.parquet
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" -eq 0 ]
@@ -1097,7 +1097,7 @@ SQL
     [[ "$output" =~ '1,"{""key"": ""value""}"' ]] || false
     [[ "$output" =~ '2,"""Hello"""' ]] || false
 
-    dolt sql -r pq -q "select * from test order by a" > out.parquet
+    dolt sql -r parquet -q "select * from test order by a" > out.parquet
     run parquet cat out.parquet
     [ $status -eq 0 ]
     [[ "$output" =~ '{"a": 1, "v": "{\"key\": \"value\"}"}' ]] || false


### PR DESCRIPTION
Adds support for outputting the results of queries as parquet data. For example, `dolt sql -r parquet -q "select * from mytable;" > out.parquet` will select all rows from `mytable`, output them to stdout as parquet data, and redirect that output to the `out.parquet` file. 