### PR TITLE
Print useful error message when running CliContext-using-commands outisde of a repo

### DIFF
--- a/integration-tests/bats/no-repo.bats
+++ b/integration-tests/bats/no-repo.bats
@@ -194,21 +194,22 @@ NOT_VALID_REPO_ERROR="The current directory is not a valid dolt repository."
 
 @test "no-repo: dolt sql outside of a dolt repository" {
     run dolt sql -q "show databases"
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "$NOT_VALID_REPO_ERROR" ]] || false
 }
 
 @test "no-repo: dolt sql statements with no databases" {
     run dolt sql -q "show tables"
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "no database selected" ]] || false
+    [[ "$output" =~ "$NOT_VALID_REPO_ERROR" ]] || false
 
     run dolt sql -q "create table a (a int primary key)"
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "no database selected" ]] || false
+    [[ "$output" =~ "$NOT_VALID_REPO_ERROR" ]] || false
 
     run dolt sql -q "show triggers"
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "no database selected" ]] || false
+    [[ "$output" =~ "$NOT_VALID_REPO_ERROR" ]] || false
 }
 
 @test "no-repo: dolt checkout outside of a dolt repository" {


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/6082

Currently, commands that use the new `CliContext` return unhelpful error messages when run outside a repo. This change standardizes these commands to print `The current directory is not a valid dolt repository.`, the same message currently returned by non-`CliContext` commands.

This is a change to `dolt sql`'s error messages, and additionally changes `dolt sql -q "show databases"` from a success to a failure. I'm not sure if we're okay with this, looking for feedback.