### PR TITLE
release: simplify homebrew bump job

### DIFF
--- a/.github/workflows/cd-bump-homebrew.yaml
+++ b/.github/workflows/cd-bump-homebrew.yaml
@@ -1,11 +1,6 @@
 name: Bump Dolt on Homebrew
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'SemVer format release tag, i.e. 0.24.5'
-        required: true
   repository_dispatch:
     types: [ bump-homebrew ]
 
@@ -19,28 +14,6 @@ jobs:
         if: ${{ github.event_name == 'repository_dispatch' }}
         with:
           formula-name: dolt
-          homebrew-tap: Homebrew/homebrew-core
-          base-branch: master
           tag-name: ${{format('refs/tags/v{0}', github.event.client_payload.version)}}
-          download-url: ${{format('https://github.com/dolthub/dolt/archive/v{0}.tar.gz', github.event.client_payload.version)}}
-          commit-message: |
-            ${{format('dolt {0}', github.event.client_payload.version)}}
-
-            Created by https://github.com/mislav/bump-homebrew-formula-action
-        env:
-          COMMITTER_TOKEN: ${{secrets.REPO_ACCESS_TOKEN}}
-      - name: Create Homebrew PR
-        uses: mislav/bump-homebrew-formula-action@v2.1
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        with:
-          formula-name: dolt
-          homebrew-tap: Homebrew/homebrew-core
-          base-branch: master
-          tag-name: ${{format('refs/tags/v{0}', github.event.inputs.version)}}
-          download-url: ${{format('https://github.com/dolthub/dolt/archive/v{0}.tar.gz', github.event.inputs.version)}}
-          commit-message: |
-            ${{format('dolt {0}', github.event.inputs.version)}}
-
-            Created by https://github.com/mislav/bump-homebrew-formula-action
         env:
           COMMITTER_TOKEN: ${{secrets.REPO_ACCESS_TOKEN}}


### PR DESCRIPTION
not sure why, but currently the build does not quite work, https://github.com/dolthub/dolt/actions/runs/5158143131/jobs/9291442093

this PR is just to simplify the job (using the defaults by removing the redundant specifications), also the workflow_dispatch job can be totally replaced with `brew bump --open-pr dolt` (this is what i am doing with [this PR](https://github.com/Homebrew/homebrew-core/pull/132677)). In other words, if needed, I think we can just apply `brew bump --open-pr` for the workflow_dispatch event (no need to specify the version, it would bump to the latest release automatically)