### PR TITLE
Add support for `--skip-empty` to `dolt commit` and `dolt_commit()`

### DIFF
--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -141,8 +141,8 @@ var branchForceFlagDesc = "Reset {{.LessThan}}branchname{{.GreaterThan}} to {{.L
 func CreateCommitArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParserWithMaxArgs("commit", 0)
 	ap.SupportsString(MessageArg, "m", "msg", "Use the given {{.LessThan}}msg{{.GreaterThan}} as the commit message.")
-	ap.SupportsFlag(AllowEmptyFlag, "", "Allow recording a commit that has the exact same data as its sole parent. This is usually a mistake, so it is disabled by default. This option bypasses that safety.")
-	ap.SupportsFlag(SkipEmptyFlag, "", "Only create a commit if there are staged changes. If no changes are staged, the call to commit is a no-op.")
+	ap.SupportsFlag(AllowEmptyFlag, "", "Allow recording a commit that has the exact same data as its sole parent. This is usually a mistake, so it is disabled by default. This option bypasses that safety. Cannot be used with --skip-empty.")
+	ap.SupportsFlag(SkipEmptyFlag, "", "Only create a commit if there are staged changes. If no changes are staged, the call to commit is a no-op. Cannot be used with --allow-empty.")
 	ap.SupportsString(DateParam, "", "date", "Specify the date used in the commit. If not specified the current system time is used.")
 	ap.SupportsFlag(ForceFlag, "f", "Ignores any foreign key warnings and proceeds with the commit.")
 	ap.SupportsString(AuthorParam, "", "author", "Specify an explicit author using the standard A U Thor {{.LessThan}}author@example.com{{.GreaterThan}} format.")

--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -77,6 +77,7 @@ func ParseAuthor(authorStr string) (string, string, error) {
 
 const (
 	AllowEmptyFlag   = "allow-empty"
+	SkipEmptyFlag    = "skip-empty"
 	DateParam        = "date"
 	MessageArg       = "message"
 	AuthorParam      = "author"
@@ -141,6 +142,7 @@ func CreateCommitArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParserWithMaxArgs("commit", 0)
 	ap.SupportsString(MessageArg, "m", "msg", "Use the given {{.LessThan}}msg{{.GreaterThan}} as the commit message.")
 	ap.SupportsFlag(AllowEmptyFlag, "", "Allow recording a commit that has the exact same data as its sole parent. This is usually a mistake, so it is disabled by default. This option bypasses that safety.")
+	ap.SupportsFlag(SkipEmptyFlag, "", "Only create a commit if there are staged changes. If no changes are staged, the call to commit is a no-op.")
 	ap.SupportsString(DateParam, "", "date", "Specify the date used in the commit. If not specified the current system time is used.")
 	ap.SupportsFlag(ForceFlag, "f", "Ignores any foreign key warnings and proceeds with the commit.")
 	ap.SupportsString(AuthorParam, "", "author", "Specify an explicit author using the standard A U Thor {{.LessThan}}author@example.com{{.GreaterThan}} format.")
@@ -399,6 +401,16 @@ func VerifyNoAwsParams(apr *argparser.ArgParseResults) error {
 
 		keysStr := strings.Join(awsParamKeys, ",")
 		return fmt.Errorf("The parameters %s, are only valid for aws remotes", keysStr)
+	}
+
+	return nil
+}
+
+// VerifyCommitArgs validates the arguments in |apr| for `dolt commit` and returns an error
+// if any validation problems were encountered.
+func VerifyCommitArgs(apr *argparser.ArgParseResults) error {
+	if apr.Contains(AllowEmptyFlag) && apr.Contains(SkipEmptyFlag) {
+		return fmt.Errorf("error: cannot use both --allow-empty and --skip-empty")
 	}
 
 	return nil

--- a/go/cmd/dolt/commands/merge.go
+++ b/go/cmd/dolt/commands/merge.go
@@ -580,8 +580,8 @@ func executeMergeAndCommit(ctx context.Context, dEnv *env.DoltEnv, spec *merge.M
 
 	author := fmt.Sprintf("%s <%s>", spec.Name, spec.Email)
 
-	res := performCommit(ctx, "commit", []string{"-m", msg, "--author", author}, dEnv)
-	if res != 0 {
+	res, skipped := performCommit(ctx, "commit", []string{"-m", msg, "--author", author}, dEnv)
+	if res != 0 || skipped {
 		return nil, fmt.Errorf("dolt commit failed after merging")
 	}
 

--- a/go/libraries/doltcore/env/actions/commit.go
+++ b/go/libraries/doltcore/env/actions/commit.go
@@ -27,6 +27,7 @@ type CommitStagedProps struct {
 	Message    string
 	Date       time.Time
 	AllowEmpty bool
+	SkipEmpty  bool
 	Amend      bool
 	Force      bool
 	Name       string
@@ -62,6 +63,10 @@ func GetCommitStaged(
 
 	isEmpty := len(staged) == 0
 	allowEmpty := ws.MergeActive() || props.AllowEmpty || props.Amend
+
+	if isEmpty && props.SkipEmpty {
+		return nil, nil
+	}
 	if isEmpty && !allowEmpty {
 		return nil, NothingStaged{notStaged}
 	}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_cherry_pick.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_cherry_pick.go
@@ -93,7 +93,8 @@ func doDoltCherryPick(ctx *sql.Context, args []string) (string, error) {
 		return "", fmt.Errorf("dolt add failed")
 	}
 
-	return doDoltCommit(ctx, []string{"-m", commitMsg})
+	commitHash, _, err := doDoltCommit(ctx, []string{"-m", commitMsg})
+	return commitHash, err
 }
 
 // cherryPick checks that the current working set is clean, verifies the cherry-pick commit is not a merge commit

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_merge.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_merge.go
@@ -222,7 +222,7 @@ func performMerge(ctx *sql.Context, sess *dsess.DoltSession, roots doltdb.Roots,
 
 	if !noCommit {
 		author := fmt.Sprintf("%s <%s>", spec.Name, spec.Email)
-		_, err = doDoltCommit(ctx, []string{"-m", msg, "--author", author})
+		_, _, err = doDoltCommit(ctx, []string{"-m", msg, "--author", author})
 		if err != nil {
 			return ws, noConflictsOrViolations, threeWayMerge, fmt.Errorf("dolt_commit failed")
 		}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_revert.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_revert.go
@@ -128,7 +128,7 @@ func doDoltRevert(ctx *sql.Context, args []string) (int, error) {
 		if err != nil {
 			return 1, err
 		}
-		_, err = doDoltCommit(ctx, commitArgs)
+		_, _, err = doDoltCommit(ctx, commitArgs)
 		if err != nil {
 			return 1, err
 		}

--- a/integration-tests/bats/helper/common.bash
+++ b/integration-tests/bats/helper/common.bash
@@ -38,6 +38,11 @@ current_dolt_user_email() {
     dolt config --global --get user.email
 }
 
+# get_head_commit returns the commit hash for the current HEAD
+get_head_commit() {
+    dolt log -n 1 | grep -m 1 commit | cut -c 13-44
+}
+
 setup_no_dolt_init() {
     export PATH=$PATH:~/go/bin
     cd $BATS_TMPDIR


### PR DESCRIPTION
The new `--skip-empty` flag can be passed to `dolt commit ...` or `call dolt_commit(...)` and have the commit operation be a no-op, instead of an error, if there are no changes staged to commit. It is an error to use `--skip-empty` together with `--allow-empty`.

Fixes: https://github.com/dolthub/dolt/issues/5678