### PR TITLE
[no-release-notes] add more info to constraint violation error

### DIFF
--- a/go/libraries/doltcore/merge/violations_unique_prolly.go
+++ b/go/libraries/doltcore/merge/violations_unique_prolly.go
@@ -163,7 +163,7 @@ func (m NullViolationMeta) ToString(ctx *sql.Context) (string, error) {
 // CheckCVMeta holds metadata describing a check constraint violation.
 type CheckCVMeta struct {
 	Name       string `json:"Name"`
-	Expression string `jason:"Expression"`
+	Expression string `json:"Expression"`
 }
 
 var _ types.JSONValue = CheckCVMeta{}

--- a/go/libraries/doltcore/sqle/dsess/transactions.go
+++ b/go/libraries/doltcore/sqle/dsess/transactions.go
@@ -19,8 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
-	"github.com/dolthub/dolt/go/store/prolly"
 	"strings"
 	"sync"
 	"time"
@@ -30,12 +28,14 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/merge"
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
 	"github.com/dolthub/dolt/go/store/datas"
 	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/dolthub/dolt/go/store/prolly"
 )
 
 const (
@@ -587,12 +587,12 @@ func (tx *DoltTransaction) validateWorkingSetForCommit(ctx *sql.Context, working
 						if err != nil {
 							return err
 						}
-						s = fmt.Sprintf("\n" +
-							"Type: Foreign Key Constraint Violation\n" +
-							"\tForeignKey: %s,\n" +
-							"\tTable: %s,\n" +
-							"\tReferencedTable: %s,\n" +
-							"\tIndex: %s,\n" +
+						s = fmt.Sprintf("\n"+
+							"Type: Foreign Key Constraint Violation\n"+
+							"\tForeignKey: %s,\n"+
+							"\tTable: %s,\n"+
+							"\tReferencedTable: %s,\n"+
+							"\tIndex: %s,\n"+
 							"\tReferencedIndex: %s", m.ForeignKey, m.Table, m.ReferencedIndex, m.Index, m.ReferencedIndex)
 
 					case prolly.ArtifactTypeUniqueKeyViol:
@@ -601,9 +601,9 @@ func (tx *DoltTransaction) validateWorkingSetForCommit(ctx *sql.Context, working
 						if err != nil {
 							return err
 						}
-						s = fmt.Sprintf("\n" +
-							"Type: Unique Key Constraint Violation,\n" +
-							"\tName: %s,\n" +
+						s = fmt.Sprintf("\n"+
+							"Type: Unique Key Constraint Violation,\n"+
+							"\tName: %s,\n"+
 							"\tColumns: %v", m.Name, m.Columns)
 
 					case prolly.ArtifactTypeNullViol:
@@ -612,8 +612,8 @@ func (tx *DoltTransaction) validateWorkingSetForCommit(ctx *sql.Context, working
 						if err != nil {
 							return err
 						}
-						s = fmt.Sprintf("\n" +
-							"Type: Null Constraint Violation,\n" +
+						s = fmt.Sprintf("\n"+
+							"Type: Null Constraint Violation,\n"+
 							"\tColumns: %v", m.Columns)
 
 					case prolly.ArtifactTypeChkConsViol:
@@ -622,9 +622,9 @@ func (tx *DoltTransaction) validateWorkingSetForCommit(ctx *sql.Context, working
 						if err != nil {
 							return err
 						}
-						s = fmt.Sprintf("\n" +
-							"Type: Check Constraint Violation,\n" +
-							"\tName: %s,\n" +
+						s = fmt.Sprintf("\n"+
+							"Type: Check Constraint Violation,\n"+
+							"\tName: %s,\n"+
 							"\tExpression: %v", m.Name, m.Expression)
 					}
 					if err != nil {
@@ -640,7 +640,7 @@ func (tx *DoltTransaction) validateWorkingSetForCommit(ctx *sql.Context, working
 				return rollbackErr
 			}
 
-			return fmt.Errorf("%s\n" +
+			return fmt.Errorf("%s\n"+
 				"Constraint violations: %s", ErrUnresolvedConstraintViolationsCommit, strings.Join(violations, ", "))
 		}
 	}

--- a/go/libraries/doltcore/sqle/dsess/transactions.go
+++ b/go/libraries/doltcore/sqle/dsess/transactions.go
@@ -544,12 +544,16 @@ func (tx *DoltTransaction) validateWorkingSetForCommit(ctx *sql.Context, working
 		// TODO: We need to add more granularity in terms of what types of constraint violations can be committed. For example,
 		// in the case of foreign_key_checks=0 you should be able to commit foreign key violations.
 		if forceTransactionCommit.(int8) != 1 {
+			badTbls, err := workingRoot.TablesWithConstraintViolations(ctx)
+			if err != nil {
+				return err
+			}
 			rollbackErr := tx.rollback(ctx)
 			if rollbackErr != nil {
 				return rollbackErr
 			}
 
-			return ErrUnresolvedConstraintViolationsCommit
+			return fmt.Errorf("%s Constraint violations in tables: %v", ErrUnresolvedConstraintViolationsCommit, badTbls)
 		}
 	}
 

--- a/go/libraries/doltcore/sqle/enginetest/dolt_transaction_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_transaction_queries.go
@@ -1996,7 +1996,7 @@ var DoltConstraintViolationTransactionTests = []queries.TransactionTest{
 					"This constraint violation may be the result of a previous merge or the result of transaction sequencing. " +
 					"Constraint violations from a merge can be resolved using the dolt_constraint_violations table before committing the transaction. " +
 					"To allow transactions to be committed with constraint violations from a merge or transaction sequencing set @@dolt_force_transaction_commit=1. " +
-					"Constraint violations in tables: [child]",
+					"Constraint violations: Columns: [parent_fk]\nOnDelete: RESTRICT\nReferencedColumns: [pk]\nReferencedIndex: \nTable: child\nForeignKey: 0050p5ek\nIndex: parent_fk\nOnUpdate: RESTRICT\nReferencedTable: parent\n",
 			},
 			{
 				Query:          "/* client b */ INSERT INTO child VALUES (1, 1);",
@@ -2026,7 +2026,7 @@ var DoltConstraintViolationTransactionTests = []queries.TransactionTest{
 					"This constraint violation may be the result of a previous merge or the result of transaction sequencing. " +
 					"Constraint violations from a merge can be resolved using the dolt_constraint_violations table before committing the transaction. " +
 					"To allow transactions to be committed with constraint violations from a merge or transaction sequencing set @@dolt_force_transaction_commit=1. " +
-					"Constraint violations in tables: [t]",
+					"Constraint violations: Columns: [col1]\nName: col1\n",
 			},
 			{
 				Query:    "/* client a */ SELECT * from DOLT_CONSTRAINT_VIOLATIONS;",
@@ -2110,7 +2110,7 @@ var DoltConstraintViolationTransactionTests = []queries.TransactionTest{
 					"This constraint violation may be the result of a previous merge or the result of transaction sequencing. " +
 					"Constraint violations from a merge can be resolved using the dolt_constraint_violations table before committing the transaction. " +
 					"To allow transactions to be committed with constraint violations from a merge or transaction sequencing set @@dolt_force_transaction_commit=1. " +
-					"Constraint violations in tables: [child]",
+					"Constraint violations: Table: child\nForeignKey: fk_name\nOnUpdate: RESTRICT\nReferencedTable: parent\nReferencedColumns: [v1]\nReferencedIndex: v1\nColumns: [v1]\nIndex: v1\nOnDelete: RESTRICT\n",
 			},
 		},
 	},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_transaction_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_transaction_queries.go
@@ -1995,7 +1995,8 @@ var DoltConstraintViolationTransactionTests = []queries.TransactionTest{
 				ExpectedErrStr: "Committing this transaction resulted in a working set with constraint violations, transaction rolled back. " +
 					"This constraint violation may be the result of a previous merge or the result of transaction sequencing. " +
 					"Constraint violations from a merge can be resolved using the dolt_constraint_violations table before committing the transaction. " +
-					"To allow transactions to be committed with constraint violations from a merge or transaction sequencing set @@dolt_force_transaction_commit=1.",
+					"To allow transactions to be committed with constraint violations from a merge or transaction sequencing set @@dolt_force_transaction_commit=1. " +
+					"Constraint violations in tables: [child]",
 			},
 			{
 				Query:          "/* client b */ INSERT INTO child VALUES (1, 1);",
@@ -2024,7 +2025,8 @@ var DoltConstraintViolationTransactionTests = []queries.TransactionTest{
 				ExpectedErrStr: "Committing this transaction resulted in a working set with constraint violations, transaction rolled back. " +
 					"This constraint violation may be the result of a previous merge or the result of transaction sequencing. " +
 					"Constraint violations from a merge can be resolved using the dolt_constraint_violations table before committing the transaction. " +
-					"To allow transactions to be committed with constraint violations from a merge or transaction sequencing set @@dolt_force_transaction_commit=1.",
+					"To allow transactions to be committed with constraint violations from a merge or transaction sequencing set @@dolt_force_transaction_commit=1. " +
+					"Constraint violations in tables: [t]",
 			},
 			{
 				Query:    "/* client a */ SELECT * from DOLT_CONSTRAINT_VIOLATIONS;",
@@ -2107,7 +2109,8 @@ var DoltConstraintViolationTransactionTests = []queries.TransactionTest{
 				ExpectedErrStr: "Committing this transaction resulted in a working set with constraint violations, transaction rolled back. " +
 					"This constraint violation may be the result of a previous merge or the result of transaction sequencing. " +
 					"Constraint violations from a merge can be resolved using the dolt_constraint_violations table before committing the transaction. " +
-					"To allow transactions to be committed with constraint violations from a merge or transaction sequencing set @@dolt_force_transaction_commit=1.",
+					"To allow transactions to be committed with constraint violations from a merge or transaction sequencing set @@dolt_force_transaction_commit=1. " +
+					"Constraint violations in tables: [child]",
 			},
 		},
 	},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_transaction_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_transaction_queries.go
@@ -1995,8 +1995,14 @@ var DoltConstraintViolationTransactionTests = []queries.TransactionTest{
 				ExpectedErrStr: "Committing this transaction resulted in a working set with constraint violations, transaction rolled back. " +
 					"This constraint violation may be the result of a previous merge or the result of transaction sequencing. " +
 					"Constraint violations from a merge can be resolved using the dolt_constraint_violations table before committing the transaction. " +
-					"To allow transactions to be committed with constraint violations from a merge or transaction sequencing set @@dolt_force_transaction_commit=1. " +
-					"Constraint violations: Columns: [parent_fk]\nOnDelete: RESTRICT\nReferencedColumns: [pk]\nReferencedIndex: \nTable: child\nForeignKey: 0050p5ek\nIndex: parent_fk\nOnUpdate: RESTRICT\nReferencedTable: parent\n",
+					"To allow transactions to be committed with constraint violations from a merge or transaction sequencing set @@dolt_force_transaction_commit=1.\n" +
+					"Constraint violations: \n" +
+					"Type: Foreign Key Constraint Violation\n" +
+					"\tForeignKey: 0050p5ek,\n" +
+					"\tTable: child,\n" +
+					"\tReferencedTable: ,\n" +
+					"\tIndex: parent_fk,\n" +
+					"\tReferencedIndex: ",
 			},
 			{
 				Query:          "/* client b */ INSERT INTO child VALUES (1, 1);",
@@ -2025,8 +2031,11 @@ var DoltConstraintViolationTransactionTests = []queries.TransactionTest{
 				ExpectedErrStr: "Committing this transaction resulted in a working set with constraint violations, transaction rolled back. " +
 					"This constraint violation may be the result of a previous merge or the result of transaction sequencing. " +
 					"Constraint violations from a merge can be resolved using the dolt_constraint_violations table before committing the transaction. " +
-					"To allow transactions to be committed with constraint violations from a merge or transaction sequencing set @@dolt_force_transaction_commit=1. " +
-					"Constraint violations: Columns: [col1]\nName: col1\n",
+					"To allow transactions to be committed with constraint violations from a merge or transaction sequencing set @@dolt_force_transaction_commit=1.\n" +
+					"Constraint violations: \n" +
+					"Type: Unique Key Constraint Violation,\n" +
+					"\tName: col1,\n" +
+					"\tColumns: [col1]",
 			},
 			{
 				Query:    "/* client a */ SELECT * from DOLT_CONSTRAINT_VIOLATIONS;",
@@ -2109,8 +2118,14 @@ var DoltConstraintViolationTransactionTests = []queries.TransactionTest{
 				ExpectedErrStr: "Committing this transaction resulted in a working set with constraint violations, transaction rolled back. " +
 					"This constraint violation may be the result of a previous merge or the result of transaction sequencing. " +
 					"Constraint violations from a merge can be resolved using the dolt_constraint_violations table before committing the transaction. " +
-					"To allow transactions to be committed with constraint violations from a merge or transaction sequencing set @@dolt_force_transaction_commit=1. " +
-					"Constraint violations: Table: child\nForeignKey: fk_name\nOnUpdate: RESTRICT\nReferencedTable: parent\nReferencedColumns: [v1]\nReferencedIndex: v1\nColumns: [v1]\nIndex: v1\nOnDelete: RESTRICT\n",
+					"To allow transactions to be committed with constraint violations from a merge or transaction sequencing set @@dolt_force_transaction_commit=1.\n" +
+					"Constraint violations: \n" +
+					"Type: Foreign Key Constraint Violation\n" +
+					"\tForeignKey: fk_name,\n" +
+					"\tTable: child,\n" +
+					"\tReferencedTable: v1,\n" +
+					"\tIndex: v1,\n" +
+					"\tReferencedIndex: v1",
 			},
 		},
 	},


### PR DESCRIPTION
Changed `ErrUnresolvedConstraintViolationsCommit` to print all the information we have on the violation for easier debugging.