### PR TITLE
Actually run bats tests in a configuration where all commands connect to a server process.

### DIFF
--- a/.github/workflows/ci-bats-unix.yaml
+++ b/.github/workflows/ci-bats-unix.yaml
@@ -111,7 +111,7 @@ jobs:
         run: expect -v
       - name: Test all Unix
         env:
-          SQL_ENGINE: ${{ matrix.sql-engine }}
+          SQL_ENGINE: ${{ matrix.sql_engine }}
           PARQUET_RUNTIME_JAR: ${{ steps.parquet_cli.outputs.runtime_jar }}
           BATS_TEST_RETRIES: "3"
         run: |

--- a/integration-tests/bats/replication-multidb.bats
+++ b/integration-tests/bats/replication-multidb.bats
@@ -52,7 +52,7 @@ teardown() {
     cd $BATS_TMPDIR
 
     if ! [ "$DOLT_DEFAULT_BIN_FORMAT" = "__DOLT__" ]; then
-      dolt config --list | awk '{ print $1 }' | grep sqlserver.global | xargs --no-run-if-empty dolt config --global --unset
+      dolt config --list | awk '{ print $1 }' | grep sqlserver.global | xargs -r dolt config --global --unset
     fi
 }
 

--- a/integration-tests/bats/replication-multidb.bats
+++ b/integration-tests/bats/replication-multidb.bats
@@ -52,7 +52,7 @@ teardown() {
     cd $BATS_TMPDIR
 
     if ! [ "$DOLT_DEFAULT_BIN_FORMAT" = "__DOLT__" ]; then
-      dolt config --list | awk '{ print $1 }' | grep sqlserver.global | xargs dolt config --global --unset
+      dolt config --list | awk '{ print $1 }' | grep sqlserver.global | xargs --no-run-if-empty dolt config --global --unset
     fi
 }
 

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -132,23 +132,3 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" =  $out ]] || false
 }
-
-@test "sql-local-remote: verify simple dolt add behavior." {
-    start_sql_server altDB
-
-    cd altDB
-
-    run dolt --verbose-engine-setup --user dolt sql -q "create table testtable (pk int PRIMARY KEY)"
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ "starting remote mode" ]] || false
-
-    run dolt --verbose-engine-setup --user dolt add .
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ "starting remote mode" ]] || false
-
-    stop_sql_server 1
-
-    staged=$(get_staged_tables)
-
-    [[ ! -z $(echo "$staged" | grep "testtable") ]] || false
-}

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -132,9 +132,9 @@ teardown() {
 }
 
 @test "sql-local-remote: verify simple dolt add behavior." {
-    start_sql_server altDb
+    start_sql_server altDB
 
-    cd altDb
+    cd altDB
 
     run dolt --verbose-engine-setup --user dolt sql -q "create table testtable (pk int PRIMARY KEY)"
     [ "$status" -eq 0 ]

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -11,7 +11,9 @@ make_repo() {
 }
 
 setup() {
-    setup_remote_server
+    if [ "$SQL_ENGINE" = "remote-engine" ]; then
+      skip "This test tests remote connections directly, SQL_ENGINE is not needed."
+    fi
     setup_no_dolt_init
     make_repo defaultDB
     make_repo altDB


### PR DESCRIPTION
Due to a typo in the .yaml script, we weren't actually running bats tests with the `$SQL_ENGINE` environment variable set, which meant that we weren't actually testing the ability for commands to seamlessly connect to running server processes. This PR fixes this.