### PR TITLE
Disable remote-engine tests.

### DIFF
--- a/.github/workflows/ci-bats-unix.yaml
+++ b/.github/workflows/ci-bats-unix.yaml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-22.04, macos-latest ]
-        sql_engine: [ remote-engine, local-engine ]
+        sql_engine: [ local-engine ]
     env:
       use_credentials: ${{ secrets.AWS_SECRET_ACCESS_KEY != '' && secrets.AWS_ACCESS_KEY_ID != '' }}
     steps:

--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -48,6 +48,8 @@ type SqlEngine struct {
 	engine         *gms.Engine
 }
 
+// random comment
+
 type sessionFactory func(mysqlSess *sql.BaseSession, pro sql.DatabaseProvider) (*dsess.DoltSession, error)
 type contextFactory func(ctx context.Context, session sql.Session) (*sql.Context, error)
 


### PR DESCRIPTION
This test configuration may be triggering CI failures.