### PR TITLE
Skip `remotes-sql-server.bats` and `sql-server.bats` when running BATS in remote-engine configuration.

### DIFF
--- a/integration-tests/bats/remotes-sql-server.bats
+++ b/integration-tests/bats/remotes-sql-server.bats
@@ -10,6 +10,9 @@ make_repo() {
 }
 
 setup() {
+    if [ "$SQL_ENGINE" = "remote-engine" ]; then
+      skip "This test tests remote connections directly, SQL_ENGINE is not needed."
+    fi
     setup_no_dolt_init
     make_repo repo1
     mkdir rem1

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -11,6 +11,9 @@ make_repo() {
 
 setup() {
     skiponwindows "tests are flaky on Windows"
+    if [ "$SQL_ENGINE" = "remote-engine" ]; then
+      skip "This test tests remote connections directly, SQL_ENGINE is not needed."
+    fi
     setup_no_dolt_init
     make_repo repo1
     make_repo repo2


### PR DESCRIPTION
This should prevent the test failures that are blocking PRs, even if I don't fully understand why these test failures are happening.