### PR TITLE
Allow `call dolt_branch` to rename the active session branch.

### DIFF
--- a/go/libraries/doltcore/sqle/dprocedures/dolt_branch.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_branch.go
@@ -235,6 +235,10 @@ func validateBranchNotActiveInAnySession(ctx *sql.Context, branchName string) er
 	branchRef := ref.NewBranchRef(branchName)
 
 	return sessionManager.Iter(func(session sql.Session) (bool, error) {
+		if session.ID() == ctx.Session.ID() {
+			return false, nil
+		}
+
 		sess, ok := session.(*dsess.DoltSession)
 		if !ok {
 			return false, fmt.Errorf("unexpected session type: %T", session)

--- a/go/libraries/doltcore/sqle/dsess/session_state_adapter.go
+++ b/go/libraries/doltcore/sqle/dsess/session_state_adapter.go
@@ -36,8 +36,15 @@ type SessionStateAdapter struct {
 	branches map[string]env.BranchConfig
 }
 
-func (s SessionStateAdapter) SetCWBHeadRef(_ context.Context, _ ref.MarshalableRef) error {
-	return fmt.Errorf("Cannot set cwb head ref with a SessionStateAdapter")
+func (s SessionStateAdapter) SetCWBHeadRef(ctx context.Context, newRef ref.MarshalableRef) error {
+	sqlCtx := sql.NewContext(ctx)
+
+	wsRef, err := ref.WorkingSetRefForHead(newRef.Ref)
+	if err != nil {
+		return err
+	}
+
+	return s.session.SwitchWorkingSet(sqlCtx, s.dbName, wsRef)
 }
 
 var _ env.RepoStateReader = SessionStateAdapter{}

--- a/go/libraries/doltcore/sqle/dsess/session_state_adapter.go
+++ b/go/libraries/doltcore/sqle/dsess/session_state_adapter.go
@@ -37,7 +37,7 @@ type SessionStateAdapter struct {
 }
 
 func (s SessionStateAdapter) SetCWBHeadRef(ctx context.Context, newRef ref.MarshalableRef) error {
-	sqlCtx := sql.NewContext(ctx)
+	sqlCtx := sql.NewContext(ctx, sql.WithSession(s.session))
 
 	wsRef, err := ref.WorkingSetRefForHead(newRef.Ref)
 	if err != nil {

--- a/go/libraries/doltcore/sqle/dsess/session_state_adapter.go
+++ b/go/libraries/doltcore/sqle/dsess/session_state_adapter.go
@@ -39,7 +39,17 @@ type SessionStateAdapter struct {
 func (s SessionStateAdapter) SetCWBHeadRef(ctx context.Context, newRef ref.MarshalableRef) error {
 	sqlCtx := sql.NewContext(ctx, sql.WithSession(s.session))
 
+	err := s.session.CommitTransaction(sqlCtx, sqlCtx.GetTransaction())
+	if err != nil {
+		return err
+	}
+
 	wsRef, err := ref.WorkingSetRefForHead(newRef.Ref)
+	if err != nil {
+		return err
+	}
+
+	err = s.session.CommitTransaction(sqlCtx, sqlCtx.GetTransaction())
 	if err != nil {
 		return err
 	}

--- a/integration-tests/bats/sql-branch.bats
+++ b/integration-tests/bats/sql-branch.bats
@@ -172,3 +172,13 @@ SQL
     [ $status -eq 1 ]
     [[ "$output" =~ "attempted to delete checked out branch" ]] || false
 }
+
+@test "sql-branch: CALL DOLT_BRANCH -m on session active branch (dolt sql)" {
+    dolt branch other
+    echo "call dolt_checkout('other'); call dolt_branch('-m', 'other', 'newOther')" | dolt sql
+    run dolt branch
+    [ $status -eq 0 ]
+    [[ "$output" =~ "newOther" ]] || false
+    [[ "$output" =~ "main" ]] || false
+    [[ ! "$output" =~ "other" ]] || false
+}

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -1934,7 +1934,7 @@ behavior:
     cd repo1
     dolt branch other
     start_sql_server
-    dolt sql-client -P $PORT -u dolt --use-db '' -q "call dolt_checkout('other'); call dolt_branch('-m', 'main', 'newMain')"
+    dolt sql-client -P $PORT -u dolt --use-db repo1 -q "call dolt_checkout('other'); call dolt_branch('-m', 'other', 'newOther')"
     run dolt branch
     [ $status -eq 0 ]
     [[ "$output" =~ "newOther" ]] || false

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -1929,3 +1929,15 @@ behavior:
     [ $status -eq 0 ]
     [[ "$output" =~ "0x1C4C4E338AD7442184509D5182816AC3" ]] || false
 }
+
+@test "sql-server: CALL DOLT_BRANCH -m on session active branch (dolt sql-server)" {
+    cd repo1
+    dolt branch other
+    start_sql_server
+    dolt sql-client -P $PORT -u dolt --use-db '' -q "call dolt_checkout('other'); call dolt_branch('-m', 'main', 'newMain')"
+    run dolt branch
+    [ $status -eq 0 ]
+    [[ "$output" =~ "newOther" ]] || false
+    [[ "$output" =~ "main" ]] || false
+    [[ ! "$output" =~ "other" ]] || false
+}


### PR DESCRIPTION
Fixes the first two bugs outlined in #6100

Basically, `SessionStateAdapter.SetCWBHeadRef` was previously unimplemented, but has fairly straightforward behavior.

This also fixes logic where all branches are considered to be "conflicting changes with other sessions" because they're being compared to themselves.