### PR TITLE
[no-release-notes] Remove Python from `wait_for_connection` function in BATS

### DIFF
--- a/integration-tests/bats/helper/query-server-common.bash
+++ b/integration-tests/bats/helper/query-server-common.bash
@@ -17,7 +17,7 @@ wait_for_connection() {
   # exit code, so we need to temporarily enable 'set +e', but be sure to turn 'set -e' back on before we exit.
   set +e
   while [ $SECONDS -lt $end_time ]; do
-    mysql -u $user -h localhost --port $port --protocol TCP --connect-timeout 1 -e "SELECT 1;"
+    dolt sql-client -u $user --host localhost --port $port --timeout 1 -q "SELECT 1;"
     if [ $? -eq 0 ]; then
       echo "Connected successfully!"
       set -e

--- a/integration-tests/bats/helper/query-server-common.bash
+++ b/integration-tests/bats/helper/query-server-common.bash
@@ -2,14 +2,15 @@ SERVER_REQS_INSTALLED="FALSE"
 SERVER_PID=""
 DEFAULT_DB=""
 
-# wait_for_connection(<PORT>, <TIMEOUT IN MS>, <USER>) attempts to connect to the sql-server at the specified
-# port on localhost, using the specified user name, and trying once per second until the millisecond timeout
-# is reached. If a connection is successfully established, then this function returns 0. If a connection was
-# not able to be established within the timeout period, then this function returns 1.
+# wait_for_connection(<PORT>, <TIMEOUT IN MS>) attempts to connect to the sql-server at the specified
+# port on localhost, using the $SQL_USER (or 'dolt' if unspecified) as the user name, and trying once
+# per second until the millisecond timeout is reached. If a connection is successfully established,
+# this function returns 0. If a connection was not able to be established within the timeout period,
+# this function returns 1.
 wait_for_connection() {
   port=$1
   timeout=$2
-  user=$3
+  user=${SQL_USER:-dolt}
   end_time=$((SECONDS+($timeout/1000)))
 
   # BATS has 'set -e' enabled, which causes the script to fail immediately if any subcommand returns a non-zero
@@ -41,7 +42,7 @@ start_sql_server() {
         dolt sql-server --host 0.0.0.0 --port=$PORT --user "${SQL_USER:-dolt}" --socket "dolt.$PORT.sock" &
     fi
     SERVER_PID=$!
-    wait_for_connection $PORT 5000 ${SQL_USER:-dolt}
+    wait_for_connection $PORT 5000
 }
 
 # like start_sql_server, but the second argument is a string with all

--- a/integration-tests/bats/helper/query-server-common.bash
+++ b/integration-tests/bats/helper/query-server-common.bash
@@ -17,7 +17,7 @@ wait_for_connection() {
   # exit code, so we need to temporarily enable 'set +e', but be sure to turn 'set -e' back on before we exit.
   set +e
   while [ $SECONDS -lt $end_time ]; do
-    dolt sql-client -u $user --host localhost --port $port --timeout 1 -q "SELECT 1;"
+    dolt sql-client -u $user --host localhost --port $port --use-db $DEFAULT_DB --timeout 1 -q "SELECT 1;"
     if [ $? -eq 0 ]; then
       echo "Connected successfully!"
       set -e
@@ -26,7 +26,7 @@ wait_for_connection() {
     sleep 1
   done
 
-  echo "Failed to connect to the sql-server on port $port within $timeout ms."
+  echo "Failed to connect to database $DEFAULT_DB on port $port within $timeout ms."
   set -e
   return 1
 }

--- a/integration-tests/bats/helper/query-server-common.bash
+++ b/integration-tests/bats/helper/query-server-common.bash
@@ -17,7 +17,7 @@ wait_for_connection() {
   # exit code, so we need to temporarily enable 'set +e', but be sure to turn 'set -e' back on before we exit.
   set +e
   while [ $SECONDS -lt $end_time ]; do
-    dolt sql-client -u $user --host localhost --port $port --use-db $DEFAULT_DB --timeout 1 -q "SELECT 1;"
+    dolt sql-client -u $user --host localhost --port $port --use-db "$DEFAULT_DB" --timeout 1 -q "SELECT 1;"
     if [ $? -eq 0 ]; then
       echo "Connected successfully!"
       set -e

--- a/integration-tests/bats/helper/query-server-common.bash
+++ b/integration-tests/bats/helper/query-server-common.bash
@@ -2,12 +2,18 @@ SERVER_REQS_INSTALLED="FALSE"
 SERVER_PID=""
 DEFAULT_DB=""
 
+# wait_for_connection(<PORT>, <TIMEOUT IN MS>, <USER>) attempts to connect to the sql-server at the specified
+# port on localhost, using the specified user name, and trying once per second until the millisecond timeout
+# is reached. If a connection is successfully established, then this function returns 0. If a connection was
+# not able to be established within the timeout period, then this function returns 1.
 wait_for_connection() {
   port=$1
   timeout=$2
   user=$3
   end_time=$((SECONDS+($timeout/1000)))
 
+  # BATS has 'set -e' enabled, which causes the script to fail immediately if any subcommand returns a non-zero
+  # exit code, so we need to temporarily enable 'set +e', but be sure to turn 'set -e' back on before we exit.
   set +e
   while [ $SECONDS -lt $end_time ]; do
     mysql -u $user -h localhost --port $port --protocol TCP --connect-timeout 1 -e "SELECT 1;"

--- a/integration-tests/bats/sql-privs.bats
+++ b/integration-tests/bats/sql-privs.bats
@@ -58,7 +58,8 @@ teardown() {
     PORT=$( definePORT )
     dolt sql-server --host 0.0.0.0 --port=$PORT &
     SERVER_PID=$! # will get killed by teardown_common
-    sleep 5 # not using python wait so this works on windows
+    SQL_USER='root'
+    wait_for_connection $PORT 5000
 
     run dolt sql-client -P $PORT -u root --use-db test_db -q "select user from mysql.user order by user"
     [ $status -eq 0 ]
@@ -77,7 +78,8 @@ teardown() {
     PORT=$( definePORT )
     dolt sql-server --host 0.0.0.0 --port=$PORT &
     SERVER_PID=$! # will get killed by teardown_common
-    sleep 5 # not using python wait so this works on windows
+    SQL_USER='new_user'
+    wait_for_connection $PORT 5000
 
     run dolt sql-client -P $PORT -u root --use-db test_db -q "select user from mysql.user order by user"
     [ $status -ne 0 ]
@@ -599,6 +601,7 @@ behavior:
 
 @test "sql-privs: basic lack of privileges tests" {
      make_test_repo
+     SQL_USER='dolt'
      start_sql_server
 
      dolt sql-client -P $PORT -u dolt --use-db test_db -q "create table t1(c1 int)"
@@ -681,6 +684,7 @@ behavior:
 
 @test "sql-privs: deleting user prevents access by that user" {
      make_test_repo
+     SQL_USER='dolt'
      start_sql_server
 
      dolt sql-client -P $PORT -u dolt --use-db test_db -q "create table t1(c1 int)"

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -1675,15 +1675,7 @@ behavior:
     [ "$status" -eq 1 ]
     [[ "$output" =~ "database locked by another sql-server; either clone the database to run a second server" ]] || false
 
-    echo "import socket
-s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-s.bind(('', 0))
-addr = s.getsockname()
-print(addr[1])
-s.close()
-" > port_finder.py
-
-    PORT=$(python3 port_finder.py)
+    PORT=$( definePORT )
     run dolt sql-server --port=$PORT --socket "dolt.$PORT.sock"
     [ "$status" -eq 1 ]
     [[ "$output" =~ "database locked by another sql-server; either clone the database to run a second server" ]] || false
@@ -1747,7 +1739,7 @@ s.close()
     PORT=$( definePORT )
     dolt sql-server --host 0.0.0.0 --port=$PORT --user dolt --socket "dolt.$PORT.sock" &
     SERVER_PID=$! # will get killed by teardown_common
-    sleep 5 # not using python wait so this works on windows
+    wait_for_connection $PORT 5000
 
     dolt sql-client --host=0.0.0.0 --port=$PORT --user=dolt <<< "create database mydb1;"
     dolt sql-client --host=0.0.0.0 --port=$PORT --user=dolt <<< "exit;"


### PR DESCRIPTION
We've been seeing Python errors in the code that detects if a sql-server has fully started up yet. This PR removes the use of Python from `wait_for_connection` and instead just polls with bash. There is still a little bit of Python left in BATS that could be cleaned up/simplified further.

Fixes: https://github.com/dolthub/dolt/issues/6109