### PR TITLE
[no-release-notes] Fix Ci; Silent error during forkExec if empty trailing arg

### DIFF
--- a/go/performance/import_benchmarker/testdef.go
+++ b/go/performance/import_benchmarker/testdef.go
@@ -289,7 +289,6 @@ func newServer(u driver.DoltUser, r driver.TestRepo) (*driver.SqlServer, error) 
 	if err != nil {
 		return nil, err
 	}
-	r.Server.Args = append(r.Server.Args, "")
 	server, err := MakeServer(repo, r.Server)
 	if err != nil {
 		return nil, err

--- a/go/performance/sysbench/testdef.go
+++ b/go/performance/sysbench/testdef.go
@@ -555,8 +555,6 @@ func newServer(u driver.DoltUser, r driver.TestRepo, conf Config) (*driver.SqlSe
 	if conf.Verbose {
 		log.Printf("database at: '%s'", repo.Dir)
 	}
-
-	r.Server.Args = append(r.Server.Args, "")
 	server, err := MakeServer(repo, r.Server)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes CI for system table benchmarks and import benchmarks.