### PR TITLE
Use a table's `workingRoot` when getting declared FKs.

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -49,7 +49,7 @@ var skipPrepared bool
 // SkipPreparedsCount is used by the "ci-check-repo CI workflow
 // as a reminder to consider prepareds when adding a new
 // enginetest suite.
-const SkipPreparedsCount = 83
+const SkipPreparedsCount = 82
 
 const skipPreparedFlag = "DOLT_SKIP_PREPARED_ENGINETESTS"
 

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -49,7 +49,7 @@ var skipPrepared bool
 // SkipPreparedsCount is used by the "ci-check-repo CI workflow
 // as a reminder to consider prepareds when adding a new
 // enginetest suite.
-const SkipPreparedsCount = 82
+const SkipPreparedsCount = 83
 
 const skipPreparedFlag = "DOLT_SKIP_PREPARED_ENGINETESTS"
 
@@ -1474,24 +1474,6 @@ func TestDescribeTableAsOf(t *testing.T) {
 	enginetest.TestScript(t, h, DescribeTableAsOfScriptTest)
 }
 
-func TestDescribeTableAsOfPrepared(t *testing.T) {
-	h := newDoltHarness(t)
-	defer h.Close()
-	enginetest.TestScriptPrepared(t, h, DescribeTableAsOfScriptTest)
-}
-
-func TestDescribeTableAsOfWithFk(t *testing.T) {
-	h := newDoltHarness(t)
-	defer h.Close()
-	enginetest.TestScript(t, h, DescribeTableAsOfWithFkScriptTest)
-}
-
-func TestDescribeTableAsOfWithFkPrepared(t *testing.T) {
-	h := newDoltHarness(t)
-	defer h.Close()
-	enginetest.TestScriptPrepared(t, h, DescribeTableAsOfWithFkScriptTest)
-}
-
 func TestShowCreateTable(t *testing.T) {
 	for _, script := range ShowCreateTableScriptTests {
 		func() {
@@ -1500,6 +1482,19 @@ func TestShowCreateTable(t *testing.T) {
 			enginetest.TestScript(t, h, script)
 		}()
 	}
+}
+
+func TestShowCreateTableWithFksAsOf(t *testing.T) {
+	h := newDoltHarness(t)
+	defer h.Close()
+	enginetest.TestScript(t, h, ShowCreateTableWithFksAsOfScriptTests)
+
+}
+
+func TestShowCreateTableWithFksAsOfPrepared(t *testing.T) {
+	h := newDoltHarness(t)
+	defer h.Close()
+	enginetest.TestScriptPrepared(t, h, ShowCreateTableWithFksAsOfScriptTests)
 }
 
 func TestViewsWithAsOf(t *testing.T) {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -49,7 +49,7 @@ var skipPrepared bool
 // SkipPreparedsCount is used by the "ci-check-repo CI workflow
 // as a reminder to consider prepareds when adding a new
 // enginetest suite.
-const SkipPreparedsCount = 83
+const SkipPreparedsCount = 82
 
 const skipPreparedFlag = "DOLT_SKIP_PREPARED_ENGINETESTS"
 
@@ -1484,17 +1484,14 @@ func TestShowCreateTable(t *testing.T) {
 	}
 }
 
-func TestShowCreateTableWithFksAsOf(t *testing.T) {
-	h := newDoltHarness(t)
-	defer h.Close()
-	enginetest.TestScript(t, h, ShowCreateTableWithFksAsOfScriptTests)
-
-}
-
-func TestShowCreateTableWithFksAsOfPrepared(t *testing.T) {
-	h := newDoltHarness(t)
-	defer h.Close()
-	enginetest.TestScriptPrepared(t, h, ShowCreateTableWithFksAsOfScriptTests)
+func TestShowCreateTablePrepared(t *testing.T) {
+	for _, script := range ShowCreateTableScriptTests {
+		func() {
+			h := newDoltHarness(t)
+			defer h.Close()
+			enginetest.TestScriptPrepared(t, h, script)
+		}()
+	}
 }
 
 func TestViewsWithAsOf(t *testing.T) {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -1474,6 +1474,24 @@ func TestDescribeTableAsOf(t *testing.T) {
 	enginetest.TestScript(t, h, DescribeTableAsOfScriptTest)
 }
 
+func TestDescribeTableAsOfPrepared(t *testing.T) {
+	h := newDoltHarness(t)
+	defer h.Close()
+	enginetest.TestScriptPrepared(t, h, DescribeTableAsOfScriptTest)
+}
+
+func TestDescribeTableAsOfWithFk(t *testing.T) {
+	h := newDoltHarness(t)
+	defer h.Close()
+	enginetest.TestScript(t, h, DescribeTableAsOfWithFkScriptTest)
+}
+
+func TestDescribeTableAsOfWithFkPrepared(t *testing.T) {
+	h := newDoltHarness(t)
+	defer h.Close()
+	enginetest.TestScriptPrepared(t, h, DescribeTableAsOfWithFkScriptTest)
+}
+
 func TestShowCreateTable(t *testing.T) {
 	for _, script := range ShowCreateTableScriptTests {
 		func() {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -99,11 +99,15 @@ var ShowCreateTableScriptTests = []queries.ScriptTest{
 			"set @Commit2 = '';",
 			"set @Commit3 = '';",
 			"set @Commit0 = hashof('main');",
-			"create table a (pk int primary key, c1 int);",
+			"create table parent(id int primary key,  pv1 int,  pv2 varchar(20), index v1 (pv1),  index v2 (pv2));",
+			"create table a (pk int primary key, c1 int, c3 int);",
+			"alter table a add constraint fk1 foreign key (c1) references parent(pv1);",
 			"call dolt_add('.');",
 			"call dolt_commit_hash_out(@Commit1, '-am', 'creating table a');",
 			"alter table a add column c2 varchar(20);",
-			"call dolt_commit_hash_out(@Commit2, '-am', 'adding column c2');",
+			"alter table a drop foreign key fk1;",
+			"alter table a add constraint fk2 foreign key (c2) references parent(pv2);",
+			"call dolt_commit_hash_out(@Commit2, '-am', 'adding column c2 and constraint');",
 			"alter table a drop column c1;",
 			"alter table a add constraint unique_c2 unique(c2);",
 			"call dolt_commit_hash_out(@Commit3, '-am', 'dropping column c1');",
@@ -119,7 +123,10 @@ var ShowCreateTableScriptTests = []queries.ScriptTest{
 					{"a", "CREATE TABLE `a` (\n" +
 						"  `pk` int NOT NULL,\n" +
 						"  `c1` int,\n" +
-						"  PRIMARY KEY (`pk`)\n" +
+						"  `c3` int,\n" +
+						"  PRIMARY KEY (`pk`),\n" +
+						"  KEY `c1` (`c1`),\n" +
+						"  CONSTRAINT `fk1` FOREIGN KEY (`c1`) REFERENCES `parent` (`pv1`)\n" +
 						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin",
 					},
 				},
@@ -130,8 +137,12 @@ var ShowCreateTableScriptTests = []queries.ScriptTest{
 					{"a", "CREATE TABLE `a` (\n" +
 						"  `pk` int NOT NULL,\n" +
 						"  `c1` int,\n" +
+						"  `c3` int,\n" +
 						"  `c2` varchar(20),\n" +
-						"  PRIMARY KEY (`pk`)\n" +
+						"  PRIMARY KEY (`pk`),\n" +
+						"  KEY `c1` (`c1`),\n" +
+						"  KEY `c2` (`c2`),\n" +
+						"  CONSTRAINT `fk2` FOREIGN KEY (`c2`) REFERENCES `parent` (`pv2`)\n" +
 						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin",
 					},
 				},
@@ -141,9 +152,11 @@ var ShowCreateTableScriptTests = []queries.ScriptTest{
 				Expected: []sql.Row{
 					{"a", "CREATE TABLE `a` (\n" +
 						"  `pk` int NOT NULL,\n" +
+						"  `c3` int,\n" +
 						"  `c2` varchar(20),\n" +
 						"  PRIMARY KEY (`pk`),\n" +
-						"  UNIQUE KEY `unique_c2` (`c2`)\n" +
+						"  UNIQUE KEY `unique_c2` (`c2`),\n" +
+						"  CONSTRAINT `fk2` FOREIGN KEY (`c2`) REFERENCES `parent` (`pv2`)\n" +
 						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin",
 					},
 				},
@@ -153,9 +166,11 @@ var ShowCreateTableScriptTests = []queries.ScriptTest{
 				Expected: []sql.Row{
 					{"a", "CREATE TABLE `a` (\n" +
 						"  `pk` int NOT NULL,\n" +
+						"  `c3` int,\n" +
 						"  `c2` varchar(20),\n" +
 						"  PRIMARY KEY (`pk`),\n" +
-						"  UNIQUE KEY `unique_c2` (`c2`)\n" +
+						"  UNIQUE KEY `unique_c2` (`c2`),\n" +
+						"  CONSTRAINT `fk2` FOREIGN KEY (`c2`) REFERENCES `parent` (`pv2`)\n" +
 						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin",
 					},
 				},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -229,89 +229,88 @@ var ShowCreateTableScriptTests = []queries.ScriptTest{
 			},
 		},
 	},
-}
-
-var ShowCreateTableWithFksAsOfScriptTests = queries.ScriptTest{
-	Name: "Show create table as of",
-	SetUpScript: []string{
-		"set @Commit0 = '';",
-		"set @Commit1 = '';",
-		"set @Commit2 = '';",
-		"set @Commit3 = '';",
-		"set @Commit0 = hashof('main');",
-		"create table parent(id int primary key,  pv1 int,  pv2 varchar(20), index v1 (pv1),  index v2 (pv2));",
-		"create table child (pk int primary key, c1 int, c3 int);",
-		"alter table child add constraint fk1 foreign key (c1) references parent(pv1);",
-		"call dolt_add('.');",
-		"call dolt_commit_hash_out(@Commit1, '-am', 'creating tables parent and child');",
-		"alter table child add column c2 varchar(20);",
-		"alter table child drop foreign key fk1;",
-		"alter table child add constraint fk2 foreign key (c2) references parent(pv2);",
-		"call dolt_commit_hash_out(@Commit2, '-am', 'adding column c2 and constraint');",
-		"alter table child drop column c1;",
-		"alter table child add constraint unique_c2 unique(c2);",
-		"call dolt_commit_hash_out(@Commit3, '-am', 'dropping column c1');",
-	},
-	Assertions: []queries.ScriptTestAssertion{
-		{
-			Query:       "show create table child as of @Commit0;",
-			ExpectedErr: sql.ErrTableNotFound,
+	{
+		Name: "Show create table as of with FKs",
+		SetUpScript: []string{
+			"set @Commit0 = '';",
+			"set @Commit1 = '';",
+			"set @Commit2 = '';",
+			"set @Commit3 = '';",
+			"set @Commit0 = hashof('main');",
+			"create table parent(id int primary key,  pv1 int,  pv2 varchar(20), index v1 (pv1),  index v2 (pv2));",
+			"create table child (pk int primary key, c1 int, c3 int);",
+			"alter table child add constraint fk1 foreign key (c1) references parent(pv1);",
+			"call dolt_add('.');",
+			"call dolt_commit_hash_out(@Commit1, '-am', 'creating tables parent and child');",
+			"alter table child add column c2 varchar(20);",
+			"alter table child drop foreign key fk1;",
+			"alter table child add constraint fk2 foreign key (c2) references parent(pv2);",
+			"call dolt_commit_hash_out(@Commit2, '-am', 'adding column c2 and constraint');",
+			"alter table child drop column c1;",
+			"alter table child add constraint unique_c2 unique(c2);",
+			"call dolt_commit_hash_out(@Commit3, '-am', 'dropping column c1');",
 		},
-		{
-			Query: "show create table child as of @Commit1;",
-			Expected: []sql.Row{
-				{"child", "CREATE TABLE `child` (\n" +
-					"  `pk` int NOT NULL,\n" +
-					"  `c1` int,\n" +
-					"  `c3` int,\n" +
-					"  PRIMARY KEY (`pk`),\n" +
-					"  KEY `c1` (`c1`),\n" +
-					"  CONSTRAINT `fk1` FOREIGN KEY (`c1`) REFERENCES `parent` (`pv1`)\n" +
-					") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin",
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:       "show create table child as of @Commit0;",
+				ExpectedErr: sql.ErrTableNotFound,
+			},
+			{
+				Query: "show create table child as of @Commit1;",
+				Expected: []sql.Row{
+					{"child", "CREATE TABLE `child` (\n" +
+						"  `pk` int NOT NULL,\n" +
+						"  `c1` int,\n" +
+						"  `c3` int,\n" +
+						"  PRIMARY KEY (`pk`),\n" +
+						"  KEY `c1` (`c1`),\n" +
+						"  CONSTRAINT `fk1` FOREIGN KEY (`c1`) REFERENCES `parent` (`pv1`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin",
+					},
 				},
 			},
-		},
-		{
-			Query: "show create table child as of @Commit2;",
-			Expected: []sql.Row{
-				{"child", "CREATE TABLE `child` (\n" +
-					"  `pk` int NOT NULL,\n" +
-					"  `c1` int,\n" +
-					"  `c3` int,\n" +
-					"  `c2` varchar(20),\n" +
-					"  PRIMARY KEY (`pk`),\n" +
-					"  KEY `c1` (`c1`),\n" +
-					"  KEY `c2` (`c2`),\n" +
-					"  CONSTRAINT `fk2` FOREIGN KEY (`c2`) REFERENCES `parent` (`pv2`)\n" +
-					") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin",
+			{
+				Query: "show create table child as of @Commit2;",
+				Expected: []sql.Row{
+					{"child", "CREATE TABLE `child` (\n" +
+						"  `pk` int NOT NULL,\n" +
+						"  `c1` int,\n" +
+						"  `c3` int,\n" +
+						"  `c2` varchar(20),\n" +
+						"  PRIMARY KEY (`pk`),\n" +
+						"  KEY `c1` (`c1`),\n" +
+						"  KEY `c2` (`c2`),\n" +
+						"  CONSTRAINT `fk2` FOREIGN KEY (`c2`) REFERENCES `parent` (`pv2`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin",
+					},
 				},
 			},
-		},
-		{
-			Query: "show create table child as of @Commit3;",
-			Expected: []sql.Row{
-				{"child", "CREATE TABLE `child` (\n" +
-					"  `pk` int NOT NULL,\n" +
-					"  `c3` int,\n" +
-					"  `c2` varchar(20),\n" +
-					"  PRIMARY KEY (`pk`),\n" +
-					"  UNIQUE KEY `unique_c2` (`c2`),\n" +
-					"  CONSTRAINT `fk2` FOREIGN KEY (`c2`) REFERENCES `parent` (`pv2`)\n" +
-					") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin",
+			{
+				Query: "show create table child as of @Commit3;",
+				Expected: []sql.Row{
+					{"child", "CREATE TABLE `child` (\n" +
+						"  `pk` int NOT NULL,\n" +
+						"  `c3` int,\n" +
+						"  `c2` varchar(20),\n" +
+						"  PRIMARY KEY (`pk`),\n" +
+						"  UNIQUE KEY `unique_c2` (`c2`),\n" +
+						"  CONSTRAINT `fk2` FOREIGN KEY (`c2`) REFERENCES `parent` (`pv2`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin",
+					},
 				},
 			},
-		},
-		{
-			Query: "show create table child as of HEAD;",
-			Expected: []sql.Row{
-				{"child", "CREATE TABLE `child` (\n" +
-					"  `pk` int NOT NULL,\n" +
-					"  `c3` int,\n" +
-					"  `c2` varchar(20),\n" +
-					"  PRIMARY KEY (`pk`),\n" +
-					"  UNIQUE KEY `unique_c2` (`c2`),\n" +
-					"  CONSTRAINT `fk2` FOREIGN KEY (`c2`) REFERENCES `parent` (`pv2`)\n" +
-					") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin",
+			{
+				Query: "show create table child as of HEAD;",
+				Expected: []sql.Row{
+					{"child", "CREATE TABLE `child` (\n" +
+						"  `pk` int NOT NULL,\n" +
+						"  `c3` int,\n" +
+						"  `c2` varchar(20),\n" +
+						"  PRIMARY KEY (`pk`),\n" +
+						"  UNIQUE KEY `unique_c2` (`c2`),\n" +
+						"  CONSTRAINT `fk2` FOREIGN KEY (`c2`) REFERENCES `parent` (`pv2`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin",
+					},
 				},
 			},
 		},

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -765,7 +765,7 @@ func checksInSchema(sch schema.Schema) []sql.CheckDefinition {
 
 // GetDeclaredForeignKeys implements sql.ForeignKeyTable
 func (t *DoltTable) GetDeclaredForeignKeys(ctx *sql.Context) ([]sql.ForeignKeyConstraint, error) {
-	root, err := t.getRoot(ctx)
+	root, err := t.workingRoot(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/6178