### PR TITLE
[no-release-notes] Remove println used for debugging that accidentally got committed.

### DIFF
--- a/go/cmd/dolt/commands/branch.go
+++ b/go/cmd/dolt/commands/branch.go
@@ -467,7 +467,6 @@ func callStoredProcedure(sqlCtx *sql.Context, queryEngine cli.Queryist, args []s
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), nil)
 	}
-	fmt.Println(query)
 	schema, rowIter, err := queryEngine.Query(sqlCtx, query)
 	if err != nil {
 		if strings.Contains(err.Error(), "is not fully merged") {


### PR DESCRIPTION
A println used while debugging the `dolt branch` migration accidentally got committed and pulled into main. This removes that.