### PR TITLE
sqle: cluster: Add dolt_cluster_transition_to_standby stored procedure.

### DIFF
--- a/go/libraries/doltcore/sqle/cluster/assume_role.go
+++ b/go/libraries/doltcore/sqle/cluster/assume_role.go
@@ -84,11 +84,12 @@ func newTransitionToStandbyProcedure(controller *Controller) sql.ExternalStoredP
 				Nullable: false,
 			},
 		},
-		Function: func(ctx *sql.Context, epoch, minStandbysHealthy int) (sql.RowIter, error) {
+		Function: func(ctx *sql.Context, epoch, minCaughtUpStandbys int) (sql.RowIter, error) {
 			saveConnID := int(ctx.Session.ID())
 			res, err := controller.setRoleAndEpoch("standby", epoch, roleTransitionOptions{
-				graceful:   true,
-				saveConnID: &saveConnID,
+				graceful:            true,
+				minCaughtUpStandbys: minCaughtUpStandbys,
+				saveConnID:          &saveConnID,
 			})
 			if err != nil {
 				// We did not transition, no need to set our session to read-only, etc.

--- a/go/libraries/doltcore/sqle/cluster/assume_role.go
+++ b/go/libraries/doltcore/sqle/cluster/assume_role.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Dolthub, Inc.
+// Copyright 2022-2023 Dolthub, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package cluster
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
@@ -39,17 +40,81 @@ func newAssumeRoleProcedure(controller *Controller) sql.ExternalStoredProcedureD
 			if role == string(RoleDetectedBrokenConfig) {
 				return nil, errors.New("cannot set role to detected_broken_config; valid values are 'primary' and 'standby'")
 			}
-			changerole, err := controller.setRoleAndEpoch(role, epoch, true /* graceful */, int(ctx.Session.ID()))
+			saveConnID := int(ctx.Session.ID())
+			res, err := controller.setRoleAndEpoch(role, epoch, roleTransitionOptions{
+				graceful:   true,
+				saveConnID: &saveConnID,
+			})
 			if err != nil {
 				// We did not transition, no need to set our session to read-only, etc.
 				return nil, err
 			}
-			if changerole {
+			if res.changedRole {
 				// We transitioned, make sure we do not run anymore queries on this session.
 				ctx.Session.SetTransaction(nil)
 				dsess.DSessFromSess(ctx.Session).SetValidateErr(ErrServerTransitionedRolesErr)
 			}
 			return sql.RowsToRowIter(sql.Row{0}), nil
+		},
+	}
+}
+
+func newTransitionToStandbyProcedure(controller *Controller) sql.ExternalStoredProcedureDetails {
+	return sql.ExternalStoredProcedureDetails{
+		Name: "dolt_cluster_transition_to_standby",
+		Schema: sql.Schema{
+			&sql.Column{
+				Name:     "caught_up",
+				Type:     types.Int8,
+				Nullable: false,
+			},
+			&sql.Column{
+				Name:     "database",
+				Type:     types.LongText,
+				Nullable: false,
+			},
+			&sql.Column{
+				Name:     "remote",
+				Type:     types.LongText,
+				Nullable: false,
+			},
+			&sql.Column{
+				Name:     "remote_url",
+				Type:     types.LongText,
+				Nullable: false,
+			},
+		},
+		Function: func(ctx *sql.Context, epoch, minStandbysHealthy int) (sql.RowIter, error) {
+			saveConnID := int(ctx.Session.ID())
+			res, err := controller.setRoleAndEpoch("standby", epoch, roleTransitionOptions{
+				graceful:   true,
+				saveConnID: &saveConnID,
+			})
+			if err != nil {
+				// We did not transition, no need to set our session to read-only, etc.
+				return nil, err
+			}
+			if res.changedRole {
+				// We transitioned, make sure we do not run anymore queries on this session.
+				ctx.Session.SetTransaction(nil)
+				dsess.DSessFromSess(ctx.Session).SetValidateErr(ErrServerTransitionedRolesErr)
+				rows := make([]sql.Row, len(res.gracefulTransitionResults))
+				for i, r := range res.gracefulTransitionResults {
+					var caughtUp int8
+					if r.caughtUp {
+						caughtUp = 1
+					}
+					rows[i] = sql.Row{
+						caughtUp,
+						r.database,
+						r.remote,
+						r.remoteUrl,
+					}
+				}
+				return sql.RowsToRowIter(rows...), nil
+			} else {
+				return nil, fmt.Errorf("failed to transition server to standby; it is already standby.")
+			}
 		},
 	}
 }

--- a/go/libraries/doltcore/sqle/cluster/commithook.go
+++ b/go/libraries/doltcore/sqle/cluster/commithook.go
@@ -38,6 +38,7 @@ type commithook struct {
 	rootLgr              *logrus.Entry
 	lgr                  atomic.Value // *logrus.Entry
 	remotename           string
+	remoteurl            string
 	dbname               string
 	mu                   sync.Mutex
 	wg                   sync.WaitGroup
@@ -87,7 +88,7 @@ var errDestDBRootHashMoved error = errors.New("cluster/commithook: standby repli
 const logFieldThread = "thread"
 const logFieldRole = "role"
 
-func newCommitHook(lgr *logrus.Logger, remotename, dbname string, role Role, destDBF func(context.Context) (*doltdb.DoltDB, error), srcDB *doltdb.DoltDB, tempDir string) *commithook {
+func newCommitHook(lgr *logrus.Logger, remotename, remoteurl, dbname string, role Role, destDBF func(context.Context) (*doltdb.DoltDB, error), srcDB *doltdb.DoltDB, tempDir string) *commithook {
 	var ret commithook
 	ret.rootLgr = lgr.WithField(logFieldThread, "Standby Replication - "+dbname+" to "+remotename)
 	ret.lgr.Store(ret.rootLgr.WithField(logFieldRole, string(role)))

--- a/go/libraries/doltcore/sqle/cluster/commithook.go
+++ b/go/libraries/doltcore/sqle/cluster/commithook.go
@@ -93,6 +93,7 @@ func newCommitHook(lgr *logrus.Logger, remotename, remoteurl, dbname string, rol
 	ret.rootLgr = lgr.WithField(logFieldThread, "Standby Replication - "+dbname+" to "+remotename)
 	ret.lgr.Store(ret.rootLgr.WithField(logFieldRole, string(role)))
 	ret.remotename = remotename
+	ret.remoteurl = remoteurl
 	ret.dbname = dbname
 	ret.role = role
 	ret.destDBF = destDBF

--- a/go/libraries/doltcore/sqle/cluster/commithook_test.go
+++ b/go/libraries/doltcore/sqle/cluster/commithook_test.go
@@ -35,7 +35,7 @@ func TestCommitHookStartsNotCaughtUp(t *testing.T) {
 		destEnv.DoltDB.Close()
 	})
 
-	hook := newCommitHook(logrus.StandardLogger(), "origin", "mydb", RolePrimary, func(context.Context) (*doltdb.DoltDB, error) {
+	hook := newCommitHook(logrus.StandardLogger(), "origin", "https://localhost:50051/mydb", "mydb", RolePrimary, func(context.Context) (*doltdb.DoltDB, error) {
 		return destEnv.DoltDB, nil
 	}, srcEnv.DoltDB, t.TempDir())
 

--- a/go/libraries/doltcore/sqle/cluster/controller.go
+++ b/go/libraries/doltcore/sqle/cluster/controller.go
@@ -262,6 +262,7 @@ func (c *Controller) RegisterStoredProcedures(store procedurestore) {
 		return
 	}
 	store.Register(newAssumeRoleProcedure(c))
+	store.Register(newTransitionToStandbyProcedure(c))
 }
 
 func (c *Controller) ClusterDatabase() sql.Database {

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
@@ -887,6 +887,55 @@ tests:
       result:
         columns: ["caught_up", "database", "remote", "remote_url"]
         rows: [["1", "repo1", "standby", "http://localhost:3852/repo1"]]
+- name: dolt_cluster_transition_to_standby too many standbys provided
+  multi_repos:
+  - name: server1
+    with_files:
+    - name: server.yaml
+      contents: |
+        log_level: trace
+        listener:
+          host: 0.0.0.0
+          port: 3309
+        cluster:
+          standby_remotes:
+          - name: standby
+            remote_url_template: http://localhost:3852/{database}
+          bootstrap_role: primary
+          bootstrap_epoch: 1
+          remotesapi:
+            port: 3851
+    server:
+      args: ["--config", "server.yaml"]
+      port: 3309
+  - name: server2
+    with_files:
+    - name: server.yaml
+      contents: |
+        log_level: trace
+        listener:
+          host: 0.0.0.0
+          port: 3310
+        cluster:
+          standby_remotes:
+          - name: standby
+            remote_url_template: http://localhost:3851/{database}
+          bootstrap_role: standby
+          bootstrap_epoch: 1
+          remotesapi:
+            port: 3852
+    server:
+      args: ["--config", "server.yaml"]
+      port: 3310
+  connections:
+  - on: server1
+    queries:
+    - exec: 'create database repo1'
+    - exec: "use repo1"
+    - exec: 'create table vals (i int primary key)'
+    - exec: 'insert into vals values (0),(1),(2),(3),(4)'
+    - query: "call dolt_cluster_transition_to_standby('2', '2')"
+      error_match: failed to transition from primary to standby gracefully; could not ensure 2 replicas were caught up on all 1 databases. Only caught up 1 standbys fully.
 - name: create new database, primary replicates to standby, fails over, new primary replicates to standby, fails over, new primary has all writes
   multi_repos:
   - name: server1

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
@@ -836,6 +836,57 @@ tests:
       error_match: failed to transition from primary to standby gracefully
     - exec: "create table vals (i int primary key)"
     - exec: "insert into vals values (0)"
+- name: dolt_cluster_transition_to_standby
+  multi_repos:
+  - name: server1
+    with_files:
+    - name: server.yaml
+      contents: |
+        log_level: trace
+        listener:
+          host: 0.0.0.0
+          port: 3309
+        cluster:
+          standby_remotes:
+          - name: standby
+            remote_url_template: http://localhost:3852/{database}
+          bootstrap_role: primary
+          bootstrap_epoch: 1
+          remotesapi:
+            port: 3851
+    server:
+      args: ["--config", "server.yaml"]
+      port: 3309
+  - name: server2
+    with_files:
+    - name: server.yaml
+      contents: |
+        log_level: trace
+        listener:
+          host: 0.0.0.0
+          port: 3310
+        cluster:
+          standby_remotes:
+          - name: standby
+            remote_url_template: http://localhost:3851/{database}
+          bootstrap_role: standby
+          bootstrap_epoch: 1
+          remotesapi:
+            port: 3852
+    server:
+      args: ["--config", "server.yaml"]
+      port: 3310
+  connections:
+  - on: server1
+    queries:
+    - exec: 'create database repo1'
+    - exec: "use repo1"
+    - exec: 'create table vals (i int primary key)'
+    - exec: 'insert into vals values (0),(1),(2),(3),(4)'
+    - query: "call dolt_cluster_transition_to_standby('2', '1')"
+      result:
+        columns: ["caught_up", "database", "remote", "remote_url"]
+        rows: [["1", "repo1", "standby", "http://localhost:3852/repo1"]]
 - name: create new database, primary replicates to standby, fails over, new primary replicates to standby, fails over, new primary has all writes
   multi_repos:
   - name: server1


### PR DESCRIPTION
This new stored procedure can be used to gracefully transition a primary to a standby while not all replicas in the cluster are up and able to become current. In contrast to `dolt_assume_cluster_role`, this stored procedure can only transition to role `standby`, but takes a second integer parameter representing the number of replica servers in the cluster which must be made current in order for the transition to succeed.