### PR TITLE
Add `dolt_schema_diff` table function

### DIFF
--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -1193,6 +1193,9 @@ func (p DoltDatabaseProvider) TableFunction(_ *sql.Context, name string) (sql.Ta
 	case "dolt_patch":
 		dtf := &PatchTableFunction{}
 		return dtf, nil
+	case "dolt_schema_diff":
+		dtf := &SchemaDiffTableFunction{}
+		return dtf, nil
 	}
 
 	return nil, sql.ErrTableFunctionNotFound.New(name)

--- a/go/libraries/doltcore/sqle/dolt_schema_diff_table_function.go
+++ b/go/libraries/doltcore/sqle/dolt_schema_diff_table_function.go
@@ -16,9 +16,6 @@ package sqle
 
 import (
 	"fmt"
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlfmt"
-	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
 	"io"
 	"sort"
 	"strings"
@@ -27,7 +24,10 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/types"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlfmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
 )
 
 var _ sql.TableFunction = (*SchemaDiffTableFunction)(nil)
@@ -301,7 +301,6 @@ func (ds *SchemaDiffTableFunction) RowIter(ctx *sql.Context, row sql.Row) (sql.R
 			fromCreate, // 2
 			toCreate,   // 3
 			"",         // 4
-			false,      // 5
 		}
 
 		schemaDiffsFound := false

--- a/go/libraries/doltcore/sqle/dolt_schema_diff_table_function.go
+++ b/go/libraries/doltcore/sqle/dolt_schema_diff_table_function.go
@@ -36,11 +36,29 @@ var _ sql.ExecSourceRel = (*SchemaDiffTableFunction)(nil)
 type SchemaDiffTableFunction struct {
 	ctx *sql.Context
 
+	// the below expressions are set when the function is invoked in a particular way
+
+	// fromCommitExpr is the first expression, provided there are 2 or 3 expressions
+	// dolt_schema_diff('from_commit', 'to_commit') -> dolt_schema_diff('123', '456')
+	// dolt_schema_diff('from_commit', 'to_commit', 'table') -> dolt_schema_diff('123', '456', 'foo')
 	fromCommitExpr sql.Expression
-	toCommitExpr   sql.Expression
-	dotCommitExpr  sql.Expression
-	tableNameExpr  sql.Expression
-	database       sql.Database
+
+	// toCommitExpr is the second expression, provided there are 2 or 3 expressions
+	// dolt_schema_diff('from_commit', 'to_commit') -> dolt_schema_diff('123', '456')
+	// dolt_schema_diff('from_commit', 'to_commit', 'table_name') -> dolt_schema_diff('123', '456', 'foo')
+	toCommitExpr sql.Expression
+
+	// dotCommitExpr is the first expression, provided there are 1 or 2 expressions
+	// dolt_schema_diff('dot_commit') -> dolt_schema_diff('HEAD^..HEAD')
+	// dolt_schema_diff('dot_commit', 'table_name') -> dolt_schema_diff('HEAD^..HEAD', 'foo')
+	dotCommitExpr sql.Expression
+
+	// tableNameExpr is the expression that follows the commit expressions
+	// dolt_schema_diff('from_commit', 'to_commit', 'table_name') -> dolt_schema_diff('123', '456', 'my_table')
+	// dolt_schema_diff('dot_commit', 'table_name') -> dolt_schema_diff('123..456', 'my_table')
+	tableNameExpr sql.Expression
+
+	database sql.Database
 }
 
 var schemaDiffTableSchema = sql.Schema{
@@ -134,19 +152,28 @@ func (ds *SchemaDiffTableFunction) WithChildren(children ...sql.Node) (sql.Node,
 
 // CheckPrivileges implements the interface sql.Node.
 func (ds *SchemaDiffTableFunction) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
-	if ds.tableNameExpr == nil || !types.IsText(ds.tableNameExpr.Type()) {
-		return true
+	if ds.tableNameExpr != nil {
+		_, _, _, tableName, err := ds.evaluateArguments()
+		if err != nil {
+			return false
+		}
+
+		result := opChecker.UserHasPrivileges(ctx,
+			sql.NewPrivilegedOperation(ds.database.Name(), tableName, "", sql.PrivilegeType_Select))
+		return result
 	}
 
-	_, _, _, tableName, err := ds.evaluateArguments()
+	tblNames, err := ds.database.GetTableNames(ctx)
 	if err != nil {
 		return false
 	}
 
-	// TODO: Add tests for privilege checking
-	result := opChecker.UserHasPrivileges(ctx,
-		sql.NewPrivilegedOperation(ds.database.Name(), tableName, "", sql.PrivilegeType_Select))
-	return result
+	var operations []sql.PrivilegedOperation
+	for _, tblName := range tblNames {
+		operations = append(operations, sql.NewPrivilegedOperation(ds.database.Name(), tblName, "", sql.PrivilegeType_Select))
+	}
+
+	return opChecker.UserHasPrivileges(ctx, operations...)
 }
 
 // Expressions implements the sql.Expressioner interface.
@@ -187,7 +214,7 @@ func (ds *SchemaDiffTableFunction) WithExpressions(expression ...sql.Expression)
 		}
 	} else {
 		if len(expression) < 2 {
-			return nil, sql.ErrInvalidArgumentNumber.New(newDstf.Name(), "1 to 3", len(expression))
+			return nil, sql.ErrInvalidArgumentDetails.New(newDstf.Name(), "There are less than 2 arguments present, and the first does not contain '..'")
 		}
 		newDstf.fromCommitExpr = expression[0]
 		newDstf.toCommitExpr = expression[1]

--- a/go/libraries/doltcore/sqle/dolt_schema_diff_table_function.go
+++ b/go/libraries/doltcore/sqle/dolt_schema_diff_table_function.go
@@ -332,7 +332,6 @@ func (ds *SchemaDiffTableFunction) RowIter(ctx *sql.Context, row sql.Row) (sql.R
 			"",         // 4
 		}
 
-		schemaDiffsFound := false
 		statements, err := diff.GetNonCreateNonDropTableSqlSchemaDiff(delta, toSchemas, fromSchema, toSchema)
 		if err != nil {
 			return nil, err
@@ -341,11 +340,6 @@ func (ds *SchemaDiffTableFunction) RowIter(ctx *sql.Context, row sql.Row) (sql.R
 			row := baseRow.Copy()
 			row[4] = stmt
 			dataRows = append(dataRows, row)
-			schemaDiffsFound = true
-		}
-
-		if !schemaDiffsFound {
-			dataRows = append(dataRows, baseRow)
 		}
 	}
 

--- a/go/libraries/doltcore/sqle/dolt_schema_diff_table_function.go
+++ b/go/libraries/doltcore/sqle/dolt_schema_diff_table_function.go
@@ -1,0 +1,421 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqle
+
+import (
+	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlfmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
+)
+
+var _ sql.TableFunction = (*SchemaDiffTableFunction)(nil)
+var _ sql.ExecSourceRel = (*SchemaDiffTableFunction)(nil)
+
+type SchemaDiffTableFunction struct {
+	ctx *sql.Context
+
+	fromCommitExpr sql.Expression
+	toCommitExpr   sql.Expression
+	dotCommitExpr  sql.Expression
+	tableNameExpr  sql.Expression
+	database       sql.Database
+}
+
+var schemaDiffTableSchema = sql.Schema{
+	&sql.Column{Name: "from_table_name", Type: types.LongText, Nullable: false},   // 0
+	&sql.Column{Name: "to_table_name", Type: types.LongText, Nullable: false},     // 1
+	&sql.Column{Name: "from_create_statement", Type: types.Text, Nullable: false}, // 2
+	&sql.Column{Name: "to_create_statement", Type: types.Text, Nullable: false},   // 3
+	&sql.Column{Name: "alter_statement", Type: types.Text, Nullable: false},       // 4
+}
+
+// NewInstance creates a new instance of TableFunction interface
+func (ds *SchemaDiffTableFunction) NewInstance(ctx *sql.Context, db sql.Database, expressions []sql.Expression) (sql.Node, error) {
+	newInstance := &SchemaDiffTableFunction{
+		ctx:      ctx,
+		database: db,
+	}
+
+	node, err := newInstance.WithExpressions(expressions...)
+	if err != nil {
+		return nil, err
+	}
+
+	return node, nil
+}
+
+// Database implements the sql.Databaser interface
+func (ds *SchemaDiffTableFunction) Database() sql.Database {
+	return ds.database
+}
+
+// WithDatabase implements the sql.Databaser interface
+func (ds *SchemaDiffTableFunction) WithDatabase(database sql.Database) (sql.Node, error) {
+	nds := *ds
+	nds.database = database
+	return &nds, nil
+}
+
+// Name implements the sql.TableFunction interface
+func (ds *SchemaDiffTableFunction) Name() string {
+	return "dolt_schema_diff"
+}
+
+func (ds *SchemaDiffTableFunction) commitsResolved() bool {
+	if ds.dotCommitExpr != nil {
+		return ds.dotCommitExpr.Resolved()
+	}
+	return ds.fromCommitExpr.Resolved() && ds.toCommitExpr.Resolved()
+}
+
+// Resolved implements the sql.Resolvable interface
+func (ds *SchemaDiffTableFunction) Resolved() bool {
+	if ds.tableNameExpr != nil {
+		return ds.commitsResolved() && ds.tableNameExpr.Resolved()
+	}
+	return ds.commitsResolved()
+}
+
+// String implements the Stringer interface
+func (ds *SchemaDiffTableFunction) String() string {
+	if ds.dotCommitExpr != nil {
+		if ds.tableNameExpr != nil {
+			return fmt.Sprintf("DOLT_SCHEMA_DIFF(%s, %s)", ds.dotCommitExpr.String(), ds.tableNameExpr.String())
+		} else {
+			return fmt.Sprintf("DOLT_SCHEMA_DIFF(%s)", ds.dotCommitExpr.String())
+		}
+	}
+	if ds.tableNameExpr != nil {
+		return fmt.Sprintf("DOLT_SCHEMA_DIFF(%s, %s, %s)", ds.fromCommitExpr.String(), ds.toCommitExpr.String(), ds.tableNameExpr.String())
+	} else {
+		return fmt.Sprintf("DOLT_SCHEMA_DIFF(%s, %s)", ds.fromCommitExpr.String(), ds.toCommitExpr.String())
+	}
+}
+
+// Schema implements the sql.Node interface.
+func (ds *SchemaDiffTableFunction) Schema() sql.Schema {
+	return schemaDiffTableSchema
+}
+
+// Children implements the sql.Node interface.
+func (ds *SchemaDiffTableFunction) Children() []sql.Node {
+	return nil
+}
+
+// WithChildren implements the sql.Node interface.
+func (ds *SchemaDiffTableFunction) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, fmt.Errorf("unexpected children")
+	}
+	return ds, nil
+}
+
+// CheckPrivileges implements the interface sql.Node.
+func (ds *SchemaDiffTableFunction) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
+	if ds.tableNameExpr == nil || !types.IsText(ds.tableNameExpr.Type()) {
+		return true
+	}
+
+	_, _, _, tableName, err := ds.evaluateArguments()
+	if err != nil {
+		return false
+	}
+
+	// TODO: Add tests for privilege checking
+	result := opChecker.UserHasPrivileges(ctx,
+		sql.NewPrivilegedOperation(ds.database.Name(), tableName, "", sql.PrivilegeType_Select))
+	return result
+}
+
+// Expressions implements the sql.Expressioner interface.
+func (ds *SchemaDiffTableFunction) Expressions() []sql.Expression {
+	exprs := []sql.Expression{}
+	if ds.dotCommitExpr != nil {
+		exprs = append(exprs, ds.dotCommitExpr)
+	} else {
+		exprs = append(exprs, ds.fromCommitExpr, ds.toCommitExpr)
+	}
+	if ds.tableNameExpr != nil {
+		exprs = append(exprs, ds.tableNameExpr)
+	}
+	return exprs
+}
+
+// WithExpressions implements the sql.Expressioner interface.
+func (ds *SchemaDiffTableFunction) WithExpressions(expression ...sql.Expression) (sql.Node, error) {
+	if len(expression) < 1 || len(expression) > 3 {
+		return nil, sql.ErrInvalidArgumentNumber.New(ds.Name(), "1 to 3", len(expression))
+	}
+
+	for _, expr := range expression {
+		if !expr.Resolved() {
+			return nil, ErrInvalidNonLiteralArgument.New(ds.Name(), expr.String())
+		}
+		// prepared statements resolve functions beforehand, so above check fails
+		if _, ok := expr.(sql.FunctionExpression); ok {
+			return nil, ErrInvalidNonLiteralArgument.New(ds.Name(), expr.String())
+		}
+	}
+
+	newDstf := *ds
+	if strings.Contains(expression[0].String(), "..") {
+		newDstf.dotCommitExpr = expression[0]
+		if len(expression) > 1 {
+			newDstf.tableNameExpr = expression[1]
+		}
+	} else {
+		if len(expression) < 2 {
+			return nil, sql.ErrInvalidArgumentNumber.New(newDstf.Name(), "1 to 3", len(expression))
+		}
+		newDstf.fromCommitExpr = expression[0]
+		newDstf.toCommitExpr = expression[1]
+		if len(expression) > 2 {
+			newDstf.tableNameExpr = expression[2]
+		}
+	}
+
+	// validate the expressions
+	if newDstf.dotCommitExpr != nil {
+		if !types.IsText(newDstf.dotCommitExpr.Type()) {
+			return nil, sql.ErrInvalidArgumentDetails.New(newDstf.Name(), newDstf.dotCommitExpr.String())
+		}
+	} else {
+		if !types.IsText(newDstf.fromCommitExpr.Type()) {
+			return nil, sql.ErrInvalidArgumentDetails.New(newDstf.Name(), newDstf.fromCommitExpr.String())
+		}
+		if !types.IsText(newDstf.toCommitExpr.Type()) {
+			return nil, sql.ErrInvalidArgumentDetails.New(newDstf.Name(), newDstf.toCommitExpr.String())
+		}
+	}
+
+	if newDstf.tableNameExpr != nil && !types.IsText(newDstf.tableNameExpr.Type()) {
+		return nil, sql.ErrInvalidArgumentDetails.New(newDstf.Name(), newDstf.tableNameExpr.String())
+	}
+
+	return &newDstf, nil
+}
+
+// RowIter implements the sql.Node interface
+func (ds *SchemaDiffTableFunction) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
+	fromCommitVal, toCommitVal, dotCommitVal, tableName, err := ds.evaluateArguments()
+	if err != nil {
+		return nil, err
+	}
+
+	db := ds.database
+	sess := dsess.DSessFromSess(ctx.Session)
+	dbName := db.Name()
+
+	sqledb, ok := ds.database.(dsess.SqlDatabase)
+	if !ok {
+		return nil, fmt.Errorf("unexpected database type: %T", ds.database)
+	}
+
+	fromCommitStr, toCommitStr, err := loadCommitStrings(ctx, fromCommitVal, toCommitVal, dotCommitVal, sqledb)
+	if err != nil {
+		return nil, err
+	}
+
+	fromRoot, _, _, err := sess.ResolveRootForRef(ctx, dbName, fromCommitStr)
+	if err != nil {
+		return nil, err
+	}
+	toRoot, _, _, err := sess.ResolveRootForRef(ctx, dbName, toCommitStr)
+	if err != nil {
+		return nil, err
+	}
+
+	deltas, err := diff.GetTableDeltas(ctx, fromRoot, toRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(deltas, func(i, j int) bool {
+		return strings.Compare(deltas[i].ToName, deltas[j].ToName) < 0
+	})
+
+	dataRows := []sql.Row{}
+	for _, delta := range deltas {
+		shouldInclude := tableName == "" || tableName == delta.ToName || tableName == delta.FromName
+		if !shouldInclude {
+			continue
+		}
+
+		fromName := delta.FromName
+		toName := delta.ToName
+
+		var fromCreate, toCreate string
+		var fromSchema, toSchema schema.Schema
+
+		if delta.FromTable != nil {
+			fromSqlDb := NewUserSpaceDatabase(fromRoot, editor.Options{})
+			fromSqlCtx, fromEngine, _ := PrepareCreateTableStmt(ctx, fromSqlDb)
+			fromCreate, err = GetCreateTableStmt(fromSqlCtx, fromEngine, delta.FromName)
+			if err != nil {
+				return nil, err
+			}
+			fromSchema, err = delta.FromTable.GetSchema(ctx)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		if delta.ToTable != nil {
+			toSqlDb := NewUserSpaceDatabase(toRoot, editor.Options{})
+			toSqlCtx, toEngine, _ := PrepareCreateTableStmt(ctx, toSqlDb)
+			toCreate, err = GetCreateTableStmt(toSqlCtx, toEngine, delta.ToName)
+			if err != nil {
+				return nil, err
+			}
+			toSchema, err = delta.ToTable.GetSchema(ctx)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		baseRow := sql.Row{
+			fromName,   // 0
+			toName,     // 1
+			fromCreate, // 2
+			toCreate,   // 3
+			"",         // 4
+			false,      // 5
+		}
+
+		schemaDiffsFound := false
+		if fromSchema != nil && toSchema != nil {
+			colDiffs, unionTags := diff.DiffSchColumns(fromSchema, toSchema)
+			if len(colDiffs) > 0 {
+				schemaDiffsFound = true
+				addRow := func(alterStmt string) {
+					row := baseRow.Copy()
+					row[4] = alterStmt
+					dataRows = append(dataRows, row)
+				}
+				for _, tag := range unionTags {
+					cd := colDiffs[tag]
+					switch cd.DiffType {
+					case diff.SchDiffNone:
+					case diff.SchDiffAdded:
+						alterStmt := sqlfmt.AlterTableAddColStmt(toName, sqlfmt.GenerateCreateTableColumnDefinition(*cd.New))
+						addRow(alterStmt)
+					case diff.SchDiffRemoved:
+						alterStmt := sqlfmt.AlterTableDropColStmt(toName, cd.Old.Name)
+						addRow(alterStmt)
+					case diff.SchDiffModified:
+						pkChanged := cd.Old.IsPartOfPK != cd.New.IsPartOfPK
+						if pkChanged {
+							alterStmt := sqlfmt.AlterTableDropPks(toName)
+							addRow(alterStmt)
+							alterStmt = sqlfmt.AlterTableAddPrimaryKeys(toName, schema.NewColCollection(*cd.New))
+							addRow(alterStmt)
+						} else {
+							if cd.Old.Name != cd.New.Name {
+								// column is renamed
+								alterStmt := sqlfmt.AlterTableRenameColStmt(toName, cd.Old.Name, cd.New.Name)
+								addRow(alterStmt)
+							} else {
+								// column is modified, but its name is the same
+								alterStmt := sqlfmt.AlterTableModifyColStmt(toName, sqlfmt.GenerateCreateTableColumnDefinition(*cd.New))
+								addRow(alterStmt)
+							}
+						}
+					}
+				}
+			}
+		}
+
+		if !schemaDiffsFound {
+			dataRows = append(dataRows, baseRow)
+		}
+	}
+
+	iter := &schemaDiffTableFunctionRowIter{
+		rows: dataRows,
+		idx:  0,
+	}
+
+	return iter, nil
+}
+
+// evaluateArguments returns fromCommitVal, toCommitVal, dotCommitVal, and tableName.
+// It evaluates the argument expressions to turn them into values this DiffSummaryTableFunction
+// can use. Note that this method only evals the expressions, and doesn't validate the values.
+func (ds *SchemaDiffTableFunction) evaluateArguments() (interface{}, interface{}, interface{}, string, error) {
+	var tableName string
+	if ds.tableNameExpr != nil {
+		tableNameVal, err := ds.tableNameExpr.Eval(ds.ctx, nil)
+		if err != nil {
+			return nil, nil, nil, "", err
+		}
+		tn, ok := tableNameVal.(string)
+		if !ok {
+			return nil, nil, nil, "", ErrInvalidTableName.New(ds.tableNameExpr.String())
+		}
+		tableName = tn
+	}
+
+	if ds.dotCommitExpr != nil {
+		dotCommitVal, err := ds.dotCommitExpr.Eval(ds.ctx, nil)
+		if err != nil {
+			return nil, nil, nil, "", err
+		}
+
+		return nil, nil, dotCommitVal, tableName, nil
+	}
+
+	fromCommitVal, err := ds.fromCommitExpr.Eval(ds.ctx, nil)
+	if err != nil {
+		return nil, nil, nil, "", err
+	}
+
+	toCommitVal, err := ds.toCommitExpr.Eval(ds.ctx, nil)
+	if err != nil {
+		return nil, nil, nil, "", err
+	}
+
+	return fromCommitVal, toCommitVal, nil, tableName, nil
+}
+
+type schemaDiffTableFunctionRowIter struct {
+	rows []sql.Row
+	idx  int
+}
+
+func (s *schemaDiffTableFunctionRowIter) Next(ctx *sql.Context) (sql.Row, error) {
+	if s.idx >= len(s.rows) {
+		return nil, io.EOF
+	} else {
+		row := s.rows[s.idx]
+		s.idx++
+		return row, nil
+	}
+}
+
+func (s *schemaDiffTableFunctionRowIter) Close(context *sql.Context) error {
+	return nil
+}
+
+var _ sql.RowIter = (*schemaDiffTableFunctionRowIter)(nil)

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -2114,6 +2114,30 @@ func TestDiffSystemTablePrepared(t *testing.T) {
 	}
 }
 
+func TestSchemaDiffSystemTable(t *testing.T) {
+	harness := newDoltHarness(t)
+	defer harness.Close()
+	harness.Setup(setup.MydbData)
+	for _, test := range SchemaDiffSystemTableScriptTests {
+		harness.engine = nil
+		t.Run(test.Name, func(t *testing.T) {
+			enginetest.TestScript(t, harness, test)
+		})
+	}
+}
+
+func TestSchemaDiffSystemTablePrepared(t *testing.T) {
+	harness := newDoltHarness(t)
+	defer harness.Close()
+	harness.Setup(setup.MydbData)
+	for _, test := range SchemaDiffSystemTableScriptTests {
+		harness.engine = nil
+		t.Run(test.Name, func(t *testing.T) {
+			enginetest.TestScriptPrepared(t, harness, test)
+		})
+	}
+}
+
 func mustNewEngine(t *testing.T, h enginetest.Harness) *gms.Engine {
 	e, err := h.NewEngine(t)
 	if err != nil {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -1429,6 +1429,20 @@ var DoltUserPrivTests = []queries.UserPrivilegeTest{
 				ExpectedErr: sql.ErrDatabaseAccessDeniedForUser,
 			},
 			{
+				// After revoking access, dolt_schema_diff should fail against table 'test'
+				User:        "tester",
+				Host:        "localhost",
+				Query:       "SELECT * FROM dolt_schema_diff('HEAD^','HEAD','test');",
+				ExpectedErr: sql.ErrDatabaseAccessDeniedForUser,
+			},
+			{
+				// After revoking access, dolt_schema_diff should fail against the entire db
+				User:        "tester",
+				Host:        "localhost",
+				Query:       "SELECT * FROM dolt_schema_diff('HEAD^','HEAD');",
+				ExpectedErr: sql.ErrDatabaseAccessDeniedForUser,
+			},
+			{
 				// Grant global access to *.*
 				User:     "root",
 				Host:     "localhost",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -4883,6 +4883,18 @@ var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
 				ExpectedErrStr: "Invalid argument to dolt_schema_diff: There are less than 2 arguments present, and the first does not contain '..'",
 			},
 			{
+				Query:          "select * from dolt_schema_diff('HEAD', '');",
+				ExpectedErrStr: "expected strings for from and to revisions, got: HEAD, ",
+			},
+			{
+				Query:          "select * from dolt_schema_diff('HEAD', 'test');",
+				ExpectedErrStr: "branch not found: test",
+			},
+			{
+				Query:          "select * from dolt_schema_diff('test');",
+				ExpectedErrStr: "Invalid argument to dolt_schema_diff: There are less than 2 arguments present, and the first does not contain '..'",
+			},
+			{
 				Query: "select * from dolt_schema_diff('HEAD^..HEAD');",
 				Expected: []sql.Row{
 					{

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -4995,15 +4995,15 @@ var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` DROP `c2`;",
 					},
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` ADD `c3` varchar(10);",
 					},
 				},
@@ -5014,15 +5014,15 @@ var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` DROP `c2`;",
 					},
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` ADD `c3` varchar(10);",
 					},
 				},
@@ -5033,15 +5033,15 @@ var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` DROP `c2`;",
 					},
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` ADD `c3` varchar(10);",
 					},
 				},
@@ -5052,15 +5052,15 @@ var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` DROP `c2`;",
 					},
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` ADD `c3` varchar(10);",
 					},
 				},
@@ -5071,15 +5071,15 @@ var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` DROP `c2`;",
 					},
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` ADD `c3` varchar(10);",
 					},
 				},
@@ -5090,15 +5090,15 @@ var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` DROP `c2`;",
 					},
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` ADD `c3` varchar(10);",
 					},
 				},
@@ -5110,15 +5110,15 @@ var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` DROP `c3`;",
 					},
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` ADD `c2` int;",
 					},
 				},
@@ -5129,15 +5129,15 @@ var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` DROP `c3`;",
 					},
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` ADD `c2` int;",
 					},
 				},
@@ -5148,15 +5148,15 @@ var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` DROP `c3`;",
 					},
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` ADD `c2` int;",
 					},
 				},
@@ -5167,15 +5167,15 @@ var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` DROP `c3`;",
 					},
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` ADD `c2` int;",
 					},
 				},
@@ -5186,15 +5186,15 @@ var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` DROP `c3`;",
 					},
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` ADD `c2` int;",
 					},
 				},
@@ -5205,15 +5205,15 @@ var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` DROP `c3`;",
 					},
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` ADD `c2` int;",
 					},
 				},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -4880,7 +4880,7 @@ var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
 			},
 			{
 				Query:          "select * from dolt_schema_diff('HEAD');",
-				ExpectedErrStr: "function 'dolt_schema_diff' expected 1 to 3 arguments, 1 received",
+				ExpectedErrStr: "Invalid argument to dolt_schema_diff: There are less than 2 arguments present, and the first does not contain '..'",
 			},
 			{
 				Query: "select * from dolt_schema_diff('HEAD^..HEAD');",
@@ -4910,7 +4910,6 @@ var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
 						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
 						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
 						"ALTER TABLE `test` DROP `c2`;",
-						false,
 					},
 					{
 						"test",
@@ -4918,7 +4917,6 @@ var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
 						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
 						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
 						"ALTER TABLE `test` ADD `c3` varchar(10);",
-						false,
 					},
 				},
 			},
@@ -4931,7 +4929,6 @@ var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
 						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` DROP `c2`;",
-						false,
 					},
 					{
 						"test",
@@ -4939,7 +4936,6 @@ var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
 						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
 						"ALTER TABLE `test` ADD `c3` varchar(10);",
-						false,
 					},
 				},
 			},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -4891,7 +4891,6 @@ var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
 						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
 						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
 						"ALTER TABLE `test` DROP `c2`;", // alter statement 1
-						false,                           // pk_changed
 					},
 					{
 						"test", // from table
@@ -4899,7 +4898,6 @@ var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
 						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
 						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
 						"ALTER TABLE `test` ADD `c3` varchar(10);", // alter statement 2
-						false, // pk_changed
 					},
 				},
 			},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -4862,6 +4862,93 @@ var CommitDiffSystemTableScriptTests = []queries.ScriptTest{
 	},
 }
 
+var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
+	{
+		Name: "basic schema changes",
+		SetUpScript: []string{
+			"create table test (pk int primary key, c1 int, c2 int);",
+			"call dolt_add('.')",
+			"call dolt_commit('-m', 'commit 1');",
+			"alter table test drop column c2, add column c3 varchar(10);",
+			"call dolt_add('.')",
+			"call dolt_commit('-m', 'commit 2');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:          "select * from dolt_schema_diff();",
+				ExpectedErrStr: "function 'dolt_schema_diff' expected 1 to 3 arguments, 0 received",
+			},
+			{
+				Query:          "select * from dolt_schema_diff('HEAD');",
+				ExpectedErrStr: "function 'dolt_schema_diff' expected 1 to 3 arguments, 1 received",
+			},
+			{
+				Query: "select * from dolt_schema_diff('HEAD^..HEAD');",
+				Expected: []sql.Row{
+					{
+						"test", // from table
+						"test", // to table
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"ALTER TABLE `test` DROP `c2`;", // alter statement 1
+						false,                           // pk_changed
+					},
+					{
+						"test", // from table
+						"test", // to table
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"ALTER TABLE `test` ADD `c3` varchar(10);", // alter statement 2
+						false, // pk_changed
+					},
+				},
+			},
+			{
+				Query: "select * from dolt_schema_diff('HEAD^', 'HEAD');",
+				Expected: []sql.Row{
+					{
+						"test",
+						"test",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"ALTER TABLE `test` DROP `c2`;",
+						false,
+					},
+					{
+						"test",
+						"test",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"ALTER TABLE `test` ADD `c3` varchar(10);",
+						false,
+					},
+				},
+			},
+			{
+				Query: "select * from dolt_schema_diff('HEAD^', 'HEAD', 'test');",
+				Expected: []sql.Row{
+					{
+						"test",
+						"test",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"ALTER TABLE `test` DROP `c2`;",
+						false,
+					},
+					{
+						"test",
+						"test",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"ALTER TABLE `test` ADD `c3` varchar(10);",
+						false,
+					},
+				},
+			},
+		},
+	},
+}
+
 type systabScript struct {
 	name    string
 	setup   []string

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -4866,14 +4866,29 @@ var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
 	{
 		Name: "basic schema changes",
 		SetUpScript: []string{
+			"call dolt_checkout('-b', 'branch1');",
 			"create table test (pk int primary key, c1 int, c2 int);",
 			"call dolt_add('.')",
-			"call dolt_commit('-m', 'commit 1');",
+			"set @Commit1 = '';",
+			"call dolt_commit_hash_out(@Commit1, '-am', 'commit 1');",
+			"call dolt_tag('tag1');",
+
+			"call dolt_checkout('-b', 'branch2');",
 			"alter table test drop column c2, add column c3 varchar(10);",
 			"call dolt_add('.')",
-			"call dolt_commit('-m', 'commit 2');",
+			"set @Commit2 = '';",
+			"call dolt_commit_hash_out(@Commit2, '-m', 'commit 2');",
+			"call dolt_tag('tag2');",
+
+			"call dolt_checkout('-b', 'branch3');",
+			"insert into test values (1, 2, 3);",
+			"call dolt_add('.')",
+			"set @Commit3 = '';",
+			"call dolt_commit_hash_out(@Commit3, '-m', 'commit 3');",
+			"call dolt_tag('tag3');",
 		},
 		Assertions: []queries.ScriptTestAssertion{
+			// Error cases
 			{
 				Query:          "select * from dolt_schema_diff();",
 				ExpectedErrStr: "function 'dolt_schema_diff' expected 1 to 3 arguments, 0 received",
@@ -4883,8 +4898,24 @@ var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
 				ExpectedErrStr: "Invalid argument to dolt_schema_diff: There are less than 2 arguments present, and the first does not contain '..'",
 			},
 			{
+				Query:          "select * from dolt_schema_diff(@Commit1);",
+				ExpectedErrStr: "Invalid argument to dolt_schema_diff: There are less than 2 arguments present, and the first does not contain '..'",
+			},
+			{
+				Query:          "select * from dolt_schema_diff('branc1');",
+				ExpectedErrStr: "Invalid argument to dolt_schema_diff: There are less than 2 arguments present, and the first does not contain '..'",
+			},
+			{
+				Query:          "select * from dolt_schema_diff('tag1');",
+				ExpectedErrStr: "Invalid argument to dolt_schema_diff: There are less than 2 arguments present, and the first does not contain '..'",
+			},
+			{
 				Query:          "select * from dolt_schema_diff('HEAD', '');",
 				ExpectedErrStr: "expected strings for from and to revisions, got: HEAD, ",
+			},
+			{
+				Query:          "select * from dolt_schema_diff('tag1', '');",
+				ExpectedErrStr: "expected strings for from and to revisions, got: tag1, ",
 			},
 			{
 				Query:          "select * from dolt_schema_diff('HEAD', 'test');",
@@ -4895,26 +4926,71 @@ var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
 				ExpectedErrStr: "Invalid argument to dolt_schema_diff: There are less than 2 arguments present, and the first does not contain '..'",
 			},
 			{
-				Query: "select * from dolt_schema_diff('HEAD^..HEAD');",
-				Expected: []sql.Row{
-					{
-						"test", // from table
-						"test", // to table
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
-						"ALTER TABLE `test` DROP `c2`;", // alter statement 1
-					},
-					{
-						"test", // from table
-						"test", // to table
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
-						"ALTER TABLE `test` ADD `c3` varchar(10);", // alter statement 2
-					},
-				},
+				Query:          "select * from dolt_schema_diff('tag3', 'tag4');",
+				ExpectedErrStr: "branch not found: tag4",
 			},
 			{
-				Query: "select * from dolt_schema_diff('HEAD^', 'HEAD');",
+				Query:          "select * from dolt_schema_diff('tag3', 'tag4', 'test');",
+				ExpectedErrStr: "branch not found: tag4",
+			},
+			// Empty diffs due to same refs
+			{
+				Query:    "select * from dolt_schema_diff('HEAD', 'HEAD');",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "select * from dolt_schema_diff(@Commit1, @Commit1);",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "select * from dolt_schema_diff('branch1', 'branch1');",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "select * from dolt_schema_diff('tag1', 'tag1');",
+				Expected: []sql.Row{},
+			},
+			// Empty diffs due to fake table
+			{
+				Query:    "select * from dolt_schema_diff(@Commit1, @Commit2, 'fake-table');",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "select * from dolt_schema_diff('tag1', 'tag2', 'fake-table');",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "select * from dolt_schema_diff('branch1', 'branch2', 'fake-table');",
+				Expected: []sql.Row{},
+			},
+			// Empty diffs due to no changes between different commits
+			{
+				Query:    "select * from dolt_schema_diff(@Commit2, @Commit3);",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "select * from dolt_schema_diff(@Commit2, @Commit3, 'test');",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "select * from dolt_schema_diff('tag2', 'tag3');",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "select * from dolt_schema_diff('tag2', 'tag3', 'test');",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "select * from dolt_schema_diff('branch2', 'branch3');",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "select * from dolt_schema_diff('branch2', 'branch3', 'test');",
+				Expected: []sql.Row{},
+			},
+			// Compare two different commits, get expected results
+			{
+				Query: "select * from dolt_schema_diff(@Commit1, @Commit2);",
 				Expected: []sql.Row{
 					{
 						"test",
@@ -4933,21 +5009,212 @@ var SchemaDiffSystemTableScriptTests = []queries.ScriptTest{
 				},
 			},
 			{
-				Query: "select * from dolt_schema_diff('HEAD^', 'HEAD', 'test');",
+				Query: "select * from dolt_schema_diff(@Commit1, @Commit2, 'test');",
 				Expected: []sql.Row{
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
 						"ALTER TABLE `test` DROP `c2`;",
 					},
 					{
 						"test",
 						"test",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
-						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
 						"ALTER TABLE `test` ADD `c3` varchar(10);",
+					},
+				},
+			},
+			{
+				Query: "select * from dolt_schema_diff('branch1', 'branch2');",
+				Expected: []sql.Row{
+					{
+						"test",
+						"test",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"ALTER TABLE `test` DROP `c2`;",
+					},
+					{
+						"test",
+						"test",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"ALTER TABLE `test` ADD `c3` varchar(10);",
+					},
+				},
+			},
+			{
+				Query: "select * from dolt_schema_diff('branch1', 'branch2', 'test');",
+				Expected: []sql.Row{
+					{
+						"test",
+						"test",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"ALTER TABLE `test` DROP `c2`;",
+					},
+					{
+						"test",
+						"test",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"ALTER TABLE `test` ADD `c3` varchar(10);",
+					},
+				},
+			},
+			{
+				Query: "select * from dolt_schema_diff('tag1', 'tag2');",
+				Expected: []sql.Row{
+					{
+						"test",
+						"test",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"ALTER TABLE `test` DROP `c2`;",
+					},
+					{
+						"test",
+						"test",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"ALTER TABLE `test` ADD `c3` varchar(10);",
+					},
+				},
+			},
+			{
+				Query: "select * from dolt_schema_diff('tag1', 'tag2', 'test');",
+				Expected: []sql.Row{
+					{
+						"test",
+						"test",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"ALTER TABLE `test` DROP `c2`;",
+					},
+					{
+						"test",
+						"test",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"ALTER TABLE `test` ADD `c3` varchar(10);",
+					},
+				},
+			},
+			// Swap the order of the refs, get opposite diff
+			{
+				Query: "select * from dolt_schema_diff(@Commit2, @Commit1);",
+				Expected: []sql.Row{
+					{
+						"test",
+						"test",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"ALTER TABLE `test` DROP `c3`;",
+					},
+					{
+						"test",
+						"test",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"ALTER TABLE `test` ADD `c2` int;",
+					},
+				},
+			},
+			{
+				Query: "select * from dolt_schema_diff(@Commit2, @Commit1, 'test');",
+				Expected: []sql.Row{
+					{
+						"test",
+						"test",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"ALTER TABLE `test` DROP `c3`;",
+					},
+					{
+						"test",
+						"test",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"ALTER TABLE `test` ADD `c2` int;",
+					},
+				},
+			},
+			{
+				Query: "select * from dolt_schema_diff('branch2', 'branch1');",
+				Expected: []sql.Row{
+					{
+						"test",
+						"test",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"ALTER TABLE `test` DROP `c3`;",
+					},
+					{
+						"test",
+						"test",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"ALTER TABLE `test` ADD `c2` int;",
+					},
+				},
+			},
+			{
+				Query: "select * from dolt_schema_diff('branch2', 'branch1', 'test');",
+				Expected: []sql.Row{
+					{
+						"test",
+						"test",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"ALTER TABLE `test` DROP `c3`;",
+					},
+					{
+						"test",
+						"test",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"ALTER TABLE `test` ADD `c2` int;",
+					},
+				},
+			},
+			{
+				Query: "select * from dolt_schema_diff('tag2', 'tag1');",
+				Expected: []sql.Row{
+					{
+						"test",
+						"test",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"ALTER TABLE `test` DROP `c3`;",
+					},
+					{
+						"test",
+						"test",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"ALTER TABLE `test` ADD `c2` int;",
+					},
+				},
+			},
+			{
+				Query: "select * from dolt_schema_diff('tag2', 'tag1', 'test');",
+				Expected: []sql.Row{
+					{
+						"test",
+						"test",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"ALTER TABLE `test` DROP `c3`;",
+					},
+					{
+						"test",
+						"test",
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c3` varchar(10),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;", // to create statement
+						"CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `c1` int,\n  `c2` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;",         // from create statement
+						"ALTER TABLE `test` ADD `c2` int;",
 					},
 				},
 			},

--- a/integration-tests/bats/system-tables.bats
+++ b/integration-tests/bats/system-tables.bats
@@ -152,7 +152,7 @@ teardown() {
     dolt remote add rem1 file://./remote1
     dolt push rem1 b1
     dolt branch -d b1
-    
+
     run dolt sql -q "select name, latest_commit_message from dolt_branches"
     [ $status -eq 0 ]
     [[ "$output" =~ main.*Initialize\ data\ repository ]] || false
@@ -164,13 +164,13 @@ teardown() {
     [[ ! "$output" =~ main.*Initialize\ data\ repository ]] || false
     [[ ! "$output" =~ create-table-branch.*Added\ test\ table ]] || false
     [[ "$output" =~ "remotes/rem1/b1" ]] || false
-    
+
     run dolt sql -q "select name from dolt_remote_branches where latest_commit_message ='Initialize data repository'"
     [ $status -eq 0 ]
     [[ ! "$output" =~ "main" ]] || false
     [[ ! "$output" =~ "create-table-branch" ]] || false
     [[ ! "$output" =~ "remotes/rem1/b1" ]] || false
-    
+
     run dolt sql -q "select name from dolt_remote_branches where latest_commit_message ='Added test table'"
     [ $status -eq 0 ]
     [[ ! "$output" =~ "main" ]] || false
@@ -612,4 +612,34 @@ SQL
     [[ "$output" =~ "tag v1 from main" ]] || false
     [[ "$output" =~ "tag v2 from branch1" ]] || false
     [[ "$output" =~ "tag v3 from branch1" ]] || false
+}
+
+@test "system-tables: query dolt_schema_diff" {
+			dolt sql <<SQL
+call dolt_checkout('-b', 'branch1');
+create table test (pk int primary key, c1 int, c2 int);
+call dolt_add('.');
+call dolt_commit('-am', 'commit 1');
+call dolt_tag('tag1');
+call dolt_checkout('-b', 'branch2');
+alter table test drop column c2, add column c3 varchar(10);
+call dolt_add('.');
+call dolt_commit('-m', 'commit 2');
+call dolt_tag('tag2');
+call dolt_checkout('-b', 'branch3');
+insert into test values (1, 2, 3);
+call dolt_add('.');
+call dolt_commit('-m', 'commit 3');
+call dolt_tag('tag3');
+SQL
+
+      run dolt sql -q "select * from dolt_schema_diff('branch1', 'branch2');"
+      [ "$status" -eq 0 ]
+      [[ "$output" =~ "ALTER TABLE \`test\` DROP \`c2\`;" ]] || false
+      [[ "$output" =~ "ALTER TABLE \`test\` ADD \`c3\` varchar(10);" ]] || false
+
+      run dolt sql -q "select * from dolt_schema_diff('tag2', 'tag1');"
+      [ "$status" -eq 0 ]
+      [[ "$output" =~ "ALTER TABLE \`test\` DROP \`c3\`;" ]] || false
+      [[ "$output" =~ "ALTER TABLE \`test\` ADD \`c2\` int;" ]] || false
 }


### PR DESCRIPTION
`dolt_schema_diff` will return the schema diffs between refs and optionally will filter those changes to a specific table.

This is a new table function that provides us with the information we need for dolt diff.

The [original PR](https://github.com/dolthub/dolt/pull/6185) for this change was accidentally merged too early. The comments from that PR have been integrated into this change.