### PR TITLE
updates dolt reset to use sql queries

### DIFF
--- a/go/cmd/dolt/commands/reset.go
+++ b/go/cmd/dolt/commands/reset.go
@@ -124,9 +124,7 @@ func (cmd ResetCmd) Exec(ctx context.Context, commandStr string, args []string, 
 		return 1
 	}
 
-	if !apr.Contains(HardResetParam) {
-		printNotStaged(sqlCtx, queryist)
-	}
+	printNotStaged(sqlCtx, queryist)
 
 	return 0
 }

--- a/go/cmd/dolt/commands/reset.go
+++ b/go/cmd/dolt/commands/reset.go
@@ -20,15 +20,16 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/gocraft/dbr/v2"
+	"github.com/gocraft/dbr/v2/dialect"
+
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
-	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/gocraft/dbr/v2"
-	"github.com/gocraft/dbr/v2/dialect"
 )
 
 const (

--- a/go/cmd/dolt/commands/reset.go
+++ b/go/cmd/dolt/commands/reset.go
@@ -116,8 +116,7 @@ func (cmd ResetCmd) Exec(ctx context.Context, commandStr string, args []string, 
 	query, err := constructInterpolatedDoltResetQuery(apr)
 	_, _, err = queryist.Query(sqlCtx, query)
 	if err != nil {
-		cli.Println(err.Error())
-		return 1
+		return handleResetError(err, usage)
 	}
 
 	printNotStaged(sqlCtx, queryist)

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -122,7 +122,6 @@ var doltSubCommands = []cli.Command{
 
 var commandsWithoutCliCtx = []cli.Command{
 	commands.DiffCmd{},
-	commands.ResetCmd{},
 	commands.CleanCmd{},
 	admin.Commands,
 	sqlserver.SqlServerCmd{VersionStr: Version},

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_reset.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_reset.go
@@ -151,8 +151,10 @@ func doDoltReset(ctx *sql.Context, args []string) (int, error) {
 			}
 		} else {
 			// check if the input is a table name or commit ref
-			_, ok, _ := roots.Head.ResolveTableName(ctx, apr.Arg(0))
-			if ok {
+			_, okHead, _ := roots.Head.ResolveTableName(ctx, apr.Arg(0))
+			_, okStaged, _ := roots.Staged.ResolveTableName(ctx, apr.Arg(0))
+			_, okWorking, _ := roots.Working.ResolveTableName(ctx, apr.Arg(0))
+			if okHead || okStaged || okWorking {
 				roots, err = actions.ResetSoftTables(ctx, dbData, apr, roots)
 				if err != nil {
 					return 1, err

--- a/integration-tests/bats/helper/local-remote.bash
+++ b/integration-tests/bats/helper/local-remote.bash
@@ -136,7 +136,7 @@ SKIP_SERVER_TESTS=$(cat <<-EOM
 ~stash.bats~
 ~commit.bats~
 ~sql-commit.bats~
-~reset.bats
+~reset.bats~
 ~sql-reset.bats~
 EOM
 )

--- a/integration-tests/bats/helper/local-remote.bash
+++ b/integration-tests/bats/helper/local-remote.bash
@@ -133,6 +133,10 @@ SKIP_SERVER_TESTS=$(cat <<-EOM
 ~sql-batch.bats~
 ~send-metrics.bats~
 ~stash.bats~
+~commit.bats~
+~sql-commit.bats~
+~reset.bats
+~sql-reset.bats~
 EOM
 )
 

--- a/integration-tests/bats/helper/local-remote.bash
+++ b/integration-tests/bats/helper/local-remote.bash
@@ -2,7 +2,6 @@ load helper/query-server-common
 
 SKIP_SERVER_TESTS=$(cat <<-EOM
 ~sql-spatial-types.bats~
-~commit.bats~
 ~column_tags.bats~
 ~migration-integration.bats~
 ~sql.bats~
@@ -31,7 +30,6 @@ SKIP_SERVER_TESTS=$(cat <<-EOM
 ~remotes-file-system.bats~
 ~sql-charsets-collations.bats~
 ~sql-cherry-pick.bats~
-~sql-commit.bats~
 ~sql-local-remote.bats~
 ~primary-key-changes.bats~
 ~common.bash.bats~
@@ -62,7 +60,6 @@ SKIP_SERVER_TESTS=$(cat <<-EOM
 ~deleted-branches.bats~
 ~schema-export.bats~
 ~sql-reserved-column-name.bats~
-~reset.bats~
 ~dump-docs.bats~
 ~tableplus.bats~
 ~multidb.bats~
@@ -86,7 +83,6 @@ SKIP_SERVER_TESTS=$(cat <<-EOM
 ~remotes.bats~
 ~create-views.bats~
 ~diff.bats~
-~sql-reset.bats~
 ~sql-clean.bats~
 ~blame.bats~
 ~multiple-tables.bats~

--- a/integration-tests/bats/reset.bats
+++ b/integration-tests/bats/reset.bats
@@ -113,7 +113,7 @@ merge_with_conflicts() {
 
     run dolt status
     [ $status -eq 0 ]
-    [[ "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ "Changes not staged for commit:" ]] || false
 }
 
 @test "reset: --hard works on unstaged and staged table changes" {

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -441,16 +441,17 @@ get_staged_tables() {
 
 @test "sql-local-remote: verify simple dolt reset behavior" {
     start_sql_server altDB
-    dolt --user dolt sql -q "create table test1 (pk int primary key)"
-    dolt --user dolt add test1
-    dolt --user dolt commit -m "create table test1"
+    dolt sql -q "create table test1 (pk int primary key)"
+    dolt add test1
+    dolt commit -m "create table test1"
 
-    dolt --user dolt sql -q "insert into test1 values (1)"
-    dolt --user dolt add test1
-    run dolt --verbose-engine-setup --user dolt reset
+    dolt dolt sql -q "insert into test1 values (1)"
+    dolt add test1
+    run dolt --verbose-engine-setup reset
     [ "$status" -eq 0 ]
+    [[ "$output" =~ "starting remote mode" ]] || false
 
-    run dolt --verbose-engine-setup --user dolt status
+    run dolt status
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Changes not staged for commit:" ]] || false
     [[ "$output" =~ ([[:space:]]*modified:[[:space:]]*test) ]] || false
@@ -458,10 +459,11 @@ get_staged_tables() {
     stop_sql_server 1
 
     dolt --user dolt add test1
-    run dolt --verbose-engine-setup --user dolt reset
+    run dolt --verbose-engine-setup reset
     [ "$status" -eq 0 ]
+    [[ "$output" =~ "starting local mode" ]] || false
 
-    run dolt --verbose-engine-setup --user dolt status
+    run dolt status
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Changes not staged for commit:" ]] || false
     [[ "$output" =~ ([[:space:]]*modified:[[:space:]]*test) ]] || false

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -438,4 +438,20 @@ get_staged_tables() {
     run dolt sql -q "show tables"
     [ "$status" -eq 1 ]
     [[ "$output" =~ "When a password is provided, a user must also be provided" ]] || false
+
+@test "sql-local-remote: verify simple dolt reset behavior" {
+    start_sql_server altDB
+    dolt --verbose-engine-setup --user dolt sql -q "create table test1 (pk int primary key)"
+    dolt --verbose-engine-setup --user dolt add test1
+    dolt --verbose-engine-setup --user dolt commit -m "create table test1"
+
+    dolt --verbose-engine-setup --user dolt sql -q "insert into test1 values (1)"
+    dolt --verbose-engine-setup --user dolt add test1
+    run dolt --verbose-engine-setup --user dolt reset
+    [ "$status" -eq 0 ]
+
+    run dolt --verbose-engine-setup --user dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Changes not staged for commit:" ]] || false
+    [[ "$output" =~ ([[:space:]]*modified:[[:space:]]*test) ]] || false
 }

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -441,12 +441,23 @@ get_staged_tables() {
 
 @test "sql-local-remote: verify simple dolt reset behavior" {
     start_sql_server altDB
-    dolt --verbose-engine-setup --user dolt sql -q "create table test1 (pk int primary key)"
-    dolt --verbose-engine-setup --user dolt add test1
-    dolt --verbose-engine-setup --user dolt commit -m "create table test1"
+    dolt --user dolt sql -q "create table test1 (pk int primary key)"
+    dolt --user dolt add test1
+    dolt --user dolt commit -m "create table test1"
 
-    dolt --verbose-engine-setup --user dolt sql -q "insert into test1 values (1)"
-    dolt --verbose-engine-setup --user dolt add test1
+    dolt --user dolt sql -q "insert into test1 values (1)"
+    dolt --user dolt add test1
+    run dolt --verbose-engine-setup --user dolt reset
+    [ "$status" -eq 0 ]
+
+    run dolt --verbose-engine-setup --user dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Changes not staged for commit:" ]] || false
+    [[ "$output" =~ ([[:space:]]*modified:[[:space:]]*test) ]] || false
+
+    stop_sql_server 1
+
+    dolt --user dolt add test1
     run dolt --verbose-engine-setup --user dolt reset
     [ "$status" -eq 0 ]
 

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -588,7 +588,7 @@ EOF
     dolt add test1
     dolt commit -m "create table test1"
 
-    dolt dolt sql -q "insert into test1 values (1)"
+    dolt sql -q "insert into test1 values (1)"
     dolt add test1
     run dolt --verbose-engine-setup reset
     [ "$status" -eq 0 ]
@@ -601,7 +601,7 @@ EOF
 
     stop_sql_server 1
 
-    dolt --user dolt add test1
+    dolt add test1
     run dolt --verbose-engine-setup reset
     [ "$status" -eq 0 ]
     [[ "$output" =~ "starting local mode" ]] || false

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -580,6 +580,7 @@ EOF
     run dolt sql -q "show tables"
     [ "$status" -eq 1 ]
     [[ "$output" =~ "When a password is provided, a user must also be provided" ]] || false
+}
 
 @test "sql-local-remote: verify simple dolt reset behavior" {
     start_sql_server altDB

--- a/integration-tests/bats/sql-reset.bats
+++ b/integration-tests/bats/sql-reset.bats
@@ -186,7 +186,7 @@ teardown() {
 
     run dolt status
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "Changes not staged for commit:" ]] || false
+    [[ "$output" =~ "Changes to be committed:" ]] || false
     [[ "$output" =~ ([[:space:]]*modified:[[:space:]]*test) ]] || false
 }
 
@@ -209,7 +209,7 @@ teardown() {
 
     run dolt status
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "Changes not staged for commit:" ]] || false
+    [[ "$output" =~ "Changes to be committed:" ]] || false
     [[ "$output" =~ ([[:space:]]*modified:[[:space:]]*test) ]] || false
 }
 

--- a/integration-tests/bats/status.bats
+++ b/integration-tests/bats/status.bats
@@ -426,9 +426,9 @@ SQL
     run dolt status
 
     [ "$status" -eq 0 ]
-    echo "$output"
-    [[ "$output" =~ "Changes to be committed:" ]] || false
-    [[ "$output" =~ "  (use \"dolt reset <table>...\" to unstage)" ]] || false
+    [[ "$output" =~ "Changes not staged for commit:" ]] || false
+    [[ "$output" =~ "  (use \"dolt add <table>\" to update what will be committed)" ]] || false
+    [[ "$output" =~ "  (use \"dolt checkout <table>\" to discard changes in working directory)" ]] || false
     [[ "$output" =~ "	modified:         tbl" ]] || false
 }
 

--- a/integration-tests/bats/status.bats
+++ b/integration-tests/bats/status.bats
@@ -426,17 +426,17 @@ SQL
     run dolt status
 
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "Changes not staged for commit:" ]] || false
-    [[ "$output" =~ "  (use \"dolt add <table>\" to update what will be committed)" ]] || false
-    [[ "$output" =~ "  (use \"dolt checkout <table>\" to discard changes in working directory)" ]] || false
+    echo "$output"
+    [[ "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ "  (use \"dolt reset <table>...\" to unstage)" ]] || false
     [[ "$output" =~ "	modified:         tbl" ]] || false
 }
 
 @test "status: dolt reset throws errors for unknown ref/table" {
     run dolt reset test
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "Invalid Ref or Table" ]] || false
-    [[ "$output" =~ "test" ]] || false
+    [[ "$output" =~ "Failed to reset changes." ]] || false
+    [[ "$output" =~ "branch not found" ]] || false
 }
 
 @test "status: roots runs even if status fails" {


### PR DESCRIPTION
This change updates `dolt reset` to use the appropriate sql engine to generate results.

Related: https://github.com/dolthub/dolt/issues/3922