### PR TITLE
Bring back pretty content for commit when commiting to a local db

### DIFF
--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -85,26 +85,22 @@ func (cmd CommitCmd) RequiresRepo() bool {
 
 // Exec executes the command
 func (cmd CommitCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
-	res, skipped := performCommit(ctx, commandStr, args, cliCtx)
-	if res == 1 {
+	res, skipped := performCommit(ctx, commandStr, args, cliCtx, dEnv)
+	if res != 0 {
 		return res
 	}
 
 	if skipped {
 		iohelp.WriteLine(cli.CliOut, "Skipping empty commit")
-		return res
 	}
 
-	// TODO: switch to using the log command once dolt log is migrated to use sql queries
-	// if the commit was successful, print it out using the log command
-	// return LogCmd{}.Exec(ctx, "log", []string{"-n=1"}, dEnv, nil)
 	return 0
 }
 
 // performCommit creates a new Dolt commit using the specified |commandStr| and |args|. The response is an integer
 // status code indicating success or failure, as well as a boolean that indicates if the commit was skipped
 // (e.g. because --skip-empty was specified as an argument).
-func performCommit(ctx context.Context, commandStr string, args []string, cliCtx cli.CliContext) (int, bool) {
+func performCommit(ctx context.Context, commandStr string, args []string, cliCtx cli.CliContext, temporacyDEnv *env.DoltEnv) (int, bool) {
 	ap := cli.CreateCommitArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, commitDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
@@ -173,16 +169,21 @@ func performCommit(ctx context.Context, commandStr string, args []string, cliCtx
 		return 0, true
 	}
 
-	// TODO: when dolt log is migrated, remove this block printing out the commit and print with a dolt log call in Exec()
-	schema, rowIter, err = queryist.Query(sqlCtx, "select * from dolt_log() limit 1")
-	if err != nil {
-		cli.Println(err.Error())
-		return 1, false
-	}
-	err = engine.PrettyPrintResults(sqlCtx, engine.FormatTabular, schema, rowIter)
-	if err != nil {
-		cli.Println(err.Error())
-		return 1, false
+	if _, ok := queryist.(*engine.SqlEngine); ok {
+		// We have a local context, so we can call the classic (unmigrated) log command.
+		return LogCmd{}.Exec(ctx, "log", []string{"-n=1"}, temporacyDEnv, nil), false
+	} else {
+		// TODO: when dolt log is migrated, remove this block printing out the commit and print with a dolt log call in Exec()
+		schema, rowIter, err = queryist.Query(sqlCtx, "select * from dolt_log() limit 1")
+		if err != nil {
+			cli.Println(err.Error())
+			return 1, false
+		}
+		err = engine.PrettyPrintResults(sqlCtx, engine.FormatTabular, schema, rowIter)
+		if err != nil {
+			cli.Println(err.Error())
+			return 1, false
+		}
 	}
 
 	return 0, false

--- a/go/cmd/dolt/commands/merge.go
+++ b/go/cmd/dolt/commands/merge.go
@@ -594,7 +594,7 @@ func executeMergeAndCommit(ctx context.Context, sqlCtx *sql.Context, queryist cl
 
 	author := fmt.Sprintf("%s <%s>", spec.Name, spec.Email)
 
-	res, skipped := performCommit(ctx, "commit", []string{"-m", msg, "--author", author}, cliCtx)
+	res, skipped := performCommit(ctx, "commit", []string{"-m", msg, "--author", author}, cliCtx, dEnv)
 	if res != 0 || skipped {
 		return nil, fmt.Errorf("dolt commit failed after merging")
 	}

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -224,6 +224,8 @@ get_staged_tables() {
 }
 
 @test "sql-local-remote: verify dolt commit behavior is identical in switch between server/no server" {
+    skip # TODO - Enable after log command is used for results in remote contexts in commit.go
+
     cd altDB
     dolt sql -q "create table test1 (pk int primary key)"
     dolt sql -q "create table test2 (pk int primary key)"


### PR DESCRIPTION
The output of the commit command changed with: https://github.com/dolthub/dolt/pull/6138

This change brings back the pretty log command output when running in a local context. This is a temporary change since we probably won't get to the `log` command for awhile yet.


```
lcl:~/Documents/data_dir_1/db5$ dolt --use-db fooo commit -A -m "Create a table"
commit euckmmj63mvbjdqo53r5hmhitc8psk67 (HEAD -> main)
Author: Neil Macneale IV <neil@dolthub.com>
Date:  Tue Jun 27 08:00:24 -0700 2023

        Initialize data repository

[ START SERVER IN SEPARATE TERMINAL]
lcl:~/Documents/data_dir_1/db5$ dolt --use-db fooo sql  -q "create table tbl2  (id int primary key)"
lcl:~/Documents/data_dir_1/db5$ dolt --use-db fooo commit -A -m "Create a second table"
+----------------------------------+------------------+------------------+------------------------+-----------------------+
| commit_hash                      | committer        | email            | date                   | message               |
+----------------------------------+------------------+------------------+------------------------+-----------------------+
| l3294uphkmjturhd1ctc50jima2le6vh | Neil Macneale IV | neil@dolthub.com | 2023-06-27 15:06:28.87 | Create a second table |
+----------------------------------+------------------+------------------+------------------------+-----------------------+
```

