### PR TITLE
chore: fmt modify

### DIFF
--- a/go/cmd/dolt/commands/assist.go
+++ b/go/cmd/dolt/commands/assist.go
@@ -466,7 +466,7 @@ func getInitialPrompt(ctx *sql.Context, sqlEngine *engine.SqlEngine, dEnv *env.D
 		"Let's try a few more. You ask me some questions and I'll give you some responses in JSON. We'll just keep doing"+
 		" that. Go ahead when you're ready."))
 
-	messages = mustAppendJson(messages, "user", fmt.Sprintf("who wrote the most recent commit?"))
+	messages = mustAppendJson(messages, "user", "who wrote the most recent commit?")
 
 	responseJson, err := json.Marshal(map[string]string{"action": "DOLT_QUERY", "content": "dolt log -n 1"})
 	if err != nil {

--- a/go/cmd/dolt/commands/dump.go
+++ b/go/cmd/dolt/commands/dump.go
@@ -146,9 +146,9 @@ func (cmd DumpCmd) Exec(ctx context.Context, commandStr string, args []string, d
 	case emptyFileExt, sqlFileExt:
 		var defaultName string
 		if schemaOnly {
-			defaultName = fmt.Sprintf("doltdump_schema_only.sql")
+			defaultName = "doltdump_schema_only.sql"
 		} else {
-			defaultName = fmt.Sprintf("doltdump.sql")
+			defaultName = "doltdump.sql"
 		}
 
 		if outputFileOrDirName == emptyStr {
@@ -285,7 +285,7 @@ func dumpProcedures(sqlCtx *sql.Context, engine *engine.SqlEngine, root *doltdb.
 			return err
 		}
 
-		err = iohelp.WriteLine(writer, fmt.Sprintf("delimiter END_PROCEDURE"))
+		err = iohelp.WriteLine(writer, "delimiter END_PROCEDURE")
 		if err != nil {
 			return err
 		}
@@ -295,7 +295,7 @@ func dumpProcedures(sqlCtx *sql.Context, engine *engine.SqlEngine, root *doltdb.
 			return err
 		}
 
-		err = iohelp.WriteLine(writer, fmt.Sprintf("END_PROCEDURE\ndelimiter ;"))
+		err = iohelp.WriteLine(writer, "END_PROCEDURE\ndelimiter ;")
 		if err != nil {
 			return err
 		}
@@ -637,7 +637,7 @@ func newTableArgs(tblName string, destination mvdata.DataLocation, batched, auto
 func dumpNonSqlTables(ctx context.Context, root *doltdb.RootValue, dEnv *env.DoltEnv, force bool, tblNames []string, rf string, dirName string, batched bool) errhand.VerboseError {
 	var fName string
 	if dirName == emptyStr {
-		dirName = fmt.Sprintf("doltdump/")
+		dirName = "doltdump/"
 	} else {
 		if !strings.HasSuffix(dirName, "/") {
 			dirName = fmt.Sprintf("%s/", dirName)

--- a/go/cmd/dolt/commands/engine/jwtplugin_test.go
+++ b/go/cmd/dolt/commands/engine/jwtplugin_test.go
@@ -33,7 +33,7 @@ func TestJWTAuth(t *testing.T) {
 	jwksConfig := []JwksConfig{
 		{
 			Name:        jwksName,
-			LocationUrl: fmt.Sprintf("file:///testdata/test_jwks.json"),
+			LocationUrl: "file:///testdata/test_jwks.json",
 			Claims: map[string]string{
 				"alg": "RS256",
 				"aud": aud,

--- a/go/cmd/dolt/commands/log.go
+++ b/go/cmd/dolt/commands/log.go
@@ -592,7 +592,7 @@ func logCompact(pager *outputpager.Pager, opts *logOpts, commits []logNode) {
 		}
 
 		formattedDesc := strings.Replace(comm.commitMeta.Description, "\n", " ", -1) + "\n"
-		pager.Writer.Write([]byte(fmt.Sprintf("%s", formattedDesc)))
+		pager.Writer.Write([]byte(formattedDesc))
 	}
 }
 
@@ -617,7 +617,7 @@ func PrintCommit(pager *outputpager.Pager, minParents int, showParents bool, dec
 	}
 
 	if len(comm.parentHashes) > 1 {
-		pager.Writer.Write([]byte(fmt.Sprintf("\nMerge:")))
+		pager.Writer.Write([]byte("\nMerge:"))
 		for _, h := range comm.parentHashes {
 			pager.Writer.Write([]byte(fmt.Sprintf(" " + h.String())))
 		}
@@ -629,7 +629,7 @@ func PrintCommit(pager *outputpager.Pager, minParents int, showParents bool, dec
 	pager.Writer.Write([]byte(fmt.Sprintf("\nDate:  %s", timeStr)))
 
 	formattedDesc := "\n\n\t" + strings.Replace(comm.commitMeta.Description, "\n", "\n\t", -1) + "\n\n"
-	pager.Writer.Write([]byte(fmt.Sprintf("%s", formattedDesc)))
+	pager.Writer.Write([]byte(formattedDesc))
 }
 
 func logDefault(pager *outputpager.Pager, opts *logOpts, commits []logNode) {

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -157,7 +157,7 @@ func (cmd SqlServerCmd) ArgParserWithName(name string) *argparser.ArgParser {
 	ap.SupportsString(commands.MultiDBDirFlag, "", "directory", "Deprecated, use `--data-dir` instead.")
 	ap.SupportsString(commands.CfgDirFlag, "", "directory", "Defines a directory that contains non-database storage for dolt. Defaults to `$data-dir/.doltcfg`. Will be created automatically as needed.")
 	ap.SupportsFlag(noAutoCommitFlag, "", "Set @@autocommit = off for the server.")
-	ap.SupportsInt(queryParallelismFlag, "", "num-go-routines", fmt.Sprintf("Deprecated, no effect in current versions of Dolt"))
+	ap.SupportsInt(queryParallelismFlag, "", "num-go-routines", "Deprecated, no effect in current versions of Dolt")
 	ap.SupportsInt(maxConnectionsFlag, "", "max-connections", fmt.Sprintf("Set the number of connections handled by the server. Defaults to `%d`.", serverConfig.MaxConnections()))
 	ap.SupportsString(persistenceBehaviorFlag, "", "persistence-behavior", fmt.Sprintf("Indicate whether to `load` or `ignore` persisted global variables. Defaults to `%s`.", serverConfig.PersistenceBehavior()))
 	ap.SupportsString(commands.PrivsFilePathFlag, "", "privilege file", "Path to a file to load and store users and grants. Defaults to `$doltcfg-dir/privileges.db`. Will be created as needed.")

--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -16,7 +16,6 @@ package commands
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -456,7 +455,7 @@ func getIgnoredTablePatternsFromSql(queryist cli.Queryist, sqlCtx *sql.Context) 
 		} else if ignoreInt, ok := ignoreVal.(int8); ok {
 			ignore = ignoreInt == 1
 		} else {
-			return nil, errors.New(fmt.Sprintf("unexpected type for ignore column, value = %s", ignoreVal))
+			return nil, fmt.Errorf("unexpected type for ignore column, value = %s", ignoreVal)
 		}
 
 		ip := doltdb.NewIgnorePattern(pattern, ignore)

--- a/go/libraries/doltcore/mvdata/channel_row_source.go
+++ b/go/libraries/doltcore/mvdata/channel_row_source.go
@@ -15,7 +15,6 @@
 package mvdata
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -43,7 +42,7 @@ func (c *ChannelRowSource) Resolved() bool {
 
 // String implements the sql.Node interface.
 func (c *ChannelRowSource) String() string {
-	return fmt.Sprintf("ChannelRowSource()")
+	return "ChannelRowSource()"
 }
 
 // Schema implements the sql.Node interface.

--- a/go/libraries/doltcore/mvdata/engine_table_writer.go
+++ b/go/libraries/doltcore/mvdata/engine_table_writer.go
@@ -134,13 +134,13 @@ func (s *SqlEngineTableWriter) WriteRows(ctx context.Context, inputChannel chan 
 		return err
 	}
 
-	_, _, err = s.se.Query(s.sqlCtx, fmt.Sprintf("START TRANSACTION"))
+	_, _, err = s.se.Query(s.sqlCtx, "START TRANSACTION")
 	if err != nil {
 		return err
 	}
 
 	if s.disableFks {
-		_, _, err = s.se.Query(s.sqlCtx, fmt.Sprintf("SET FOREIGN_KEY_CHECKS = 0"))
+		_, _, err = s.se.Query(s.sqlCtx, "SET FOREIGN_KEY_CHECKS = 0")
 		if err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/mvdata/file_data_loc.go
+++ b/go/libraries/doltcore/mvdata/file_data_loc.go
@@ -127,14 +127,14 @@ func (dl FileDataLocation) NewReader(ctx context.Context, root *doltdb.RootValue
 			}
 			tbl, exists, err := root.GetTable(context.TODO(), jsonOpts.TableName)
 			if !exists {
-				return nil, false, errors.New(fmt.Sprintf("The following table could not be found:\n%v", jsonOpts.TableName))
+				return nil, false, fmt.Errorf("The following table could not be found:\n%v", jsonOpts.TableName)
 			}
 			if err != nil {
-				return nil, false, errors.New(fmt.Sprintf("An error occurred attempting to read the table:\n%v", err.Error()))
+				return nil, false, fmt.Errorf("An error occurred attempting to read the table:\n%v", err.Error())
 			}
 			sch, err = tbl.GetSchema(context.TODO())
 			if err != nil {
-				return nil, false, errors.New(fmt.Sprintf("An error occurred attempting to read the table schema:\n%v", err.Error()))
+				return nil, false, fmt.Errorf("An error occurred attempting to read the table schema:\n%v", err.Error())
 			}
 		}
 
@@ -159,14 +159,14 @@ func (dl FileDataLocation) NewReader(ctx context.Context, root *doltdb.RootValue
 			}
 			tbl, tableExists, tErr := root.GetTable(context.TODO(), parquetOpts.TableName)
 			if !tableExists {
-				return nil, false, errors.New(fmt.Sprintf("The following table could not be found:\n%v", parquetOpts.TableName))
+				return nil, false, fmt.Errorf("The following table could not be found:\n%v", parquetOpts.TableName)
 			}
 			if tErr != nil {
-				return nil, false, errors.New(fmt.Sprintf("An error occurred attempting to read the table:\n%v", err.Error()))
+				return nil, false, fmt.Errorf("An error occurred attempting to read the table:\n%v", err.Error())
 			}
 			tableSch, err = tbl.GetSchema(context.TODO())
 			if err != nil {
-				return nil, false, errors.New(fmt.Sprintf("An error occurred attempting to read the table schema:\n%v", err.Error()))
+				return nil, false, fmt.Errorf("An error occurred attempting to read the table schema:\n%v", err.Error())
 			}
 		}
 		rd, rErr := parquet.OpenParquetReader(root.VRW(), dl.Path, tableSch)

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_reconnect_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_reconnect_test.go
@@ -79,7 +79,7 @@ func TestBinlogReplicationAutoReconnect(t *testing.T) {
 // connection retry interval. This is used for testing connection retry logic without waiting the full default period.
 func configureFastConnectionRetry(_ *testing.T) {
 	replicaDatabase.MustExec(
-		fmt.Sprintf("change replication source to SOURCE_CONNECT_RETRY=5;"))
+		"change replication source to SOURCE_CONNECT_RETRY=5;")
 }
 
 // testInitialReplicaStatus tests the data returned by SHOW REPLICA STATUS and errors

--- a/go/libraries/doltcore/sqle/dfunctions/active_branch.go
+++ b/go/libraries/doltcore/sqle/dfunctions/active_branch.go
@@ -15,8 +15,6 @@
 package dfunctions
 
 import (
-	"fmt"
-
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
 
@@ -71,7 +69,7 @@ func (ab *ActiveBranchFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, er
 
 // String implements the Stringer interface.
 func (ab *ActiveBranchFunc) String() string {
-	return fmt.Sprint("ACTIVE_BRANCH()")
+	return "ACTIVE_BRANCH()"
 }
 
 // IsNullable implements the Expression interface.

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_branch.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_branch.go
@@ -424,13 +424,13 @@ func copyABranch(ctx *sql.Context, dbData env.DbData, srcBr string, destBr strin
 	err := actions.CopyBranchOnDB(ctx, dbData.Ddb, srcBr, destBr, force, rsc)
 	if err != nil {
 		if err == doltdb.ErrBranchNotFound {
-			return errors.New(fmt.Sprintf("fatal: A branch named '%s' not found", srcBr))
+			return fmt.Errorf("fatal: A branch named '%s' not found", srcBr)
 		} else if err == actions.ErrAlreadyExists {
-			return errors.New(fmt.Sprintf("fatal: A branch named '%s' already exists.", destBr))
+			return fmt.Errorf("fatal: A branch named '%s' already exists.", destBr)
 		} else if err == doltdb.ErrInvBranchName {
-			return errors.New(fmt.Sprintf("fatal: '%s' is not a valid branch name.", destBr))
+			return fmt.Errorf("fatal: '%s' is not a valid branch name.", destBr)
 		} else {
-			return errors.New(fmt.Sprintf("fatal: Unexpected error copying branch from '%s' to '%s'", srcBr, destBr))
+			return fmt.Errorf("fatal: Unexpected error copying branch from '%s' to '%s'", srcBr, destBr)
 		}
 	}
 	err = branch_control.AddAdminForContext(ctx, destBr)

--- a/go/libraries/doltcore/sqle/dtables/diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/diff_table.go
@@ -152,7 +152,7 @@ func (dt *DiffTable) Partitions(ctx *sql.Context) (sql.PartitionIter, error) {
 	}
 
 	if !ok {
-		return nil, errors.New(fmt.Sprintf("table: %s does not exist", dt.name))
+		return nil, fmt.Errorf("table: %s does not exist", dt.name)
 	}
 
 	wrTblHash, _, err := dt.workingRoot.GetTableHash(ctx, exactName)
@@ -268,7 +268,7 @@ func (dt *DiffTable) fromCommitLookupPartitions(ctx *sql.Context, hashes []hash.
 	if err != nil {
 		return nil, err
 	} else if !ok {
-		return nil, errors.New(fmt.Sprintf("table: %s does not exist", dt.name))
+		return nil, fmt.Errorf("table: %s does not exist", dt.name)
 	}
 
 	var parentHashes []hash.Hash
@@ -434,7 +434,7 @@ func (dt *DiffTable) toCommitLookupPartitions(ctx *sql.Context, hashes []hash.Ha
 	if err != nil {
 		return nil, err
 	} else if !ok {
-		return nil, errors.New(fmt.Sprintf("table: %s does not exist", dt.name))
+		return nil, fmt.Errorf("table: %s does not exist", dt.name)
 	}
 
 	working, err := dt.head.HashOf()

--- a/go/libraries/doltcore/sqle/index/mergeable_indexes_test.go
+++ b/go/libraries/doltcore/sqle/index/mergeable_indexes_test.go
@@ -1351,7 +1351,7 @@ func TestMergeableIndexes(t *testing.T) {
 					}
 				}
 			} else {
-				t.Log(fmt.Sprintf("%v != %v", test.finalRanges, finalRanges))
+				t.Logf("%v != %v", test.finalRanges, finalRanges)
 			}
 		})
 	}
@@ -1557,7 +1557,7 @@ func TestMergeableIndexesNulls(t *testing.T) {
 					}
 				}
 			} else {
-				t.Log(fmt.Sprintf("%v != %v", test.finalRanges, finalRanges))
+				t.Logf("%v != %v", test.finalRanges, finalRanges)
 			}
 		})
 	}

--- a/go/libraries/doltcore/sqle/integration_test/history_table_test.go
+++ b/go/libraries/doltcore/sqle/integration_test/history_table_test.go
@@ -181,7 +181,7 @@ func historyTableTests() []historyTableTest {
 		},
 		{
 			name:  "commit is not null",
-			query: fmt.Sprintf("select pk, c0, commit_hash from dolt_history_test where commit_hash is not null;"),
+			query: "select pk, c0, commit_hash from dolt_history_test where commit_hash is not null;",
 			rows: []sql.Row{
 				{int32(0), int32(10), HEAD},
 				{int32(1), int32(1), HEAD},

--- a/go/libraries/doltcore/table/untyped/csv/reader.go
+++ b/go/libraries/doltcore/table/untyped/csv/reader.go
@@ -75,10 +75,10 @@ func OpenCSVReader(nbf *types.NomsBinFormat, path string, fs filesys.ReadableFS,
 // NewCSVReader creates a CSVReader from a given ReadCloser.  The CSVFileInfo should describe the csv file being read.
 func NewCSVReader(nbf *types.NomsBinFormat, r io.ReadCloser, info *CSVFileInfo) (*CSVReader, error) {
 	if len(info.Delim) < 1 {
-		return nil, errors.New(fmt.Sprintf("delimiter '%s' has invalid length", info.Delim))
+		return nil, fmt.Errorf("delimiter '%s' has invalid length", info.Delim)
 	}
 	if !validDelim(info.Delim) {
-		return nil, errors.New(fmt.Sprintf("invalid delimiter: %s", string(info.Delim)))
+		return nil, fmt.Errorf("invalid delimiter: %s", string(info.Delim))
 	}
 
 	br := bufio.NewReaderSize(r, ReadBufSize)

--- a/go/performance/utils/sysbench_runner/mysql.go
+++ b/go/performance/utils/sysbench_runner/mysql.go
@@ -170,7 +170,7 @@ func SetupDB(ctx context.Context, mConfig MysqlConfig, databaseName string) (err
 	if err != nil {
 		return err
 	}
-	_, err = db.ExecContext(ctx, fmt.Sprintf("SET GLOBAL local_infile = 'ON'"))
+	_, err = db.ExecContext(ctx, "SET GLOBAL local_infile = 'ON'")
 	if err != nil {
 		return err
 	}

--- a/go/performance/utils/sysbench_runner/run.go
+++ b/go/performance/utils/sysbench_runner/run.go
@@ -51,14 +51,14 @@ func Run(config *Config) error {
 			return err
 		}
 
-		fmt.Println(fmt.Sprintf("Successfuly finished %s", serverConfig.Server))
+		fmt.Printf("Successfuly finished %s\n", serverConfig.Server)
 
 		err = WriteResults(serverConfig, results)
 		if err != nil {
 			return err
 		}
 
-		fmt.Println(fmt.Sprintf("Successfuly wrote results for %s", serverConfig.Server))
+		fmt.Printf("Successfuly wrote results for %s\n", serverConfig.Server)
 	}
 	return nil
 }

--- a/go/performance/utils/tpcc_runner/run.go
+++ b/go/performance/utils/tpcc_runner/run.go
@@ -57,7 +57,7 @@ func Run(config *TpccBenchmarkConfig) error {
 			return err
 		}
 
-		fmt.Println(fmt.Sprintf("Successfuly wrote results for %s", serverConfig.Server))
+		fmt.Printf("Successfuly wrote results for %s\n", serverConfig.Server)
 	}
 
 	return nil

--- a/go/store/datas/stashlist.go
+++ b/go/store/datas/stashlist.go
@@ -76,7 +76,7 @@ func (s *StashList) RemoveStashAtIdx(ctx context.Context, vw types.ValueWriter, 
 		return hash.Hash{}, err
 	}
 	if amCount <= idx {
-		return hash.Hash{}, errors.New(fmt.Sprintf("fatal: log for 'stash' only has %v entries", amCount))
+		return hash.Hash{}, fmt.Errorf("fatal: log for 'stash' only has %v entries", amCount)
 	}
 
 	stash, err := getNthStash(ctx, s.am, amCount, idx)
@@ -131,7 +131,7 @@ func (s *StashList) getStashAtIdx(ctx context.Context, idx int) (hash.Hash, erro
 		return hash.Hash{}, err
 	}
 	if amCount <= idx {
-		return hash.Hash{}, errors.New(fmt.Sprintf("fatal: log for 'stash' only has %v entries", amCount))
+		return hash.Hash{}, fmt.Errorf("fatal: log for 'stash' only has %v entries", amCount)
 	}
 
 	stash, err := getNthStash(ctx, s.am, amCount, idx)

--- a/go/store/prolly/benchmark/benchmark_read_test.go
+++ b/go/store/prolly/benchmark/benchmark_read_test.go
@@ -103,7 +103,7 @@ func BenchmarkNomsParallelGetLarge(b *testing.B) {
 func benchmarkProllyMapGet(b *testing.B, size uint64) {
 	bench := generateProllyBench(b, size)
 	b.ResetTimer()
-	b.Run(fmt.Sprintf("benchmark new format reads"), func(b *testing.B) {
+	b.Run("benchmark new format reads", func(b *testing.B) {
 		ctx := context.Background()
 
 		for i := 0; i < b.N; i++ {
@@ -120,7 +120,7 @@ func benchmarkProllyMapGet(b *testing.B, size uint64) {
 func benchmarkTypesMapGet(b *testing.B, size uint64) {
 	bench := generateTypesBench(b, size)
 	b.ResetTimer()
-	b.Run(fmt.Sprintf("benchmark old format reads"), func(b *testing.B) {
+	b.Run("benchmark old format reads", func(b *testing.B) {
 		ctx := context.Background()
 		for i := 0; i < b.N; i++ {
 			idx := rand.Uint64() % uint64(len(bench.tups))
@@ -133,7 +133,7 @@ func benchmarkTypesMapGet(b *testing.B, size uint64) {
 func benchmarkBBoltMapGet(b *testing.B, size uint64) {
 	bench := generateBBoltBench(b, size)
 	b.ResetTimer()
-	b.Run(fmt.Sprintf("benchmark bbolt reads"), func(b *testing.B) {
+	b.Run("benchmark bbolt reads", func(b *testing.B) {
 		tx, err := bench.db.Begin(false)
 		require.NoError(b, err)
 		bck := tx.Bucket(bucket)

--- a/go/store/prolly/tree/node_splitter_test.go
+++ b/go/store/prolly/tree/node_splitter_test.go
@@ -72,7 +72,7 @@ func TestKeySplitterDistribution(t *testing.T) {
 	})
 	t.Run("summarize node distribution for item sizes (8,54)", func(t *testing.T) {
 		for sz := 8; sz <= 54; sz++ {
-			fmt.Println(fmt.Sprintf("Summary for map Size %d", sz))
+			fmt.Printf("Summary for map Size %d\n", sz)
 			nd, ns := makeProllyTreeWithSizes(t, factory, 100_000, sz, sz)
 			PrintTreeSummaryByLevel(t, nd, ns)
 			fmt.Println()

--- a/go/store/spec/absolute_path_test.go
+++ b/go/store/spec/absolute_path_test.go
@@ -48,7 +48,7 @@ func TestAbsolutePathToAndFromString(t *testing.T) {
 
 	h, err := types.Float(42).Hash(types.Format_Default) // arbitrary hash
 	assert.NoError(err)
-	test(fmt.Sprintf("/refs/heads/main"))
+	test("/refs/heads/main")
 	test(fmt.Sprintf("#%s", h.String()))
 }
 


### PR DESCRIPTION
unnecessary use of fmt.Sprintf
use fmt.Errorf(...) instead of errors.New(fmt.Sprintf(...))
use fmt.Printf instead of fmt.Println(fmt.Sprintf(...)) (but don't forget the newline)