### PR TITLE
Fix dolt status formatting

### DIFF
--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -481,7 +481,8 @@ func printEverything(data *printData) error {
 		if ahead > 0 && behind > 0 {
 			cli.Printf(`Your branch and '%s' have diverged,
 and have %v and %v different commits each, respectively.
-  (use "dolt pull" to update your local branch)`, remoteBranchRef, ahead, behind)
+  (use "dolt pull" to update your local branch)
+	`, remoteBranchRef, ahead, behind)
 			changesPresent = true
 		} else if ahead > 0 {
 			s := ""
@@ -489,7 +490,8 @@ and have %v and %v different commits each, respectively.
 				s = "s"
 			}
 			cli.Printf(`Your branch is ahead of '%s' by %v commit%s.
-  (use "dolt push" to publish your local commits)`, remoteBranchRef, ahead, s)
+  (use "dolt push" to publish your local commits)
+	`, remoteBranchRef, ahead, s)
 			changesPresent = true
 		} else if behind > 0 {
 			s := ""
@@ -497,7 +499,8 @@ and have %v and %v different commits each, respectively.
 				s = "s"
 			}
 			cli.Printf(`Your branch is behind '%s' by %v commit%s, and can be fast-forwarded.
-  (use "dolt pull" to update your local branch)`, remoteBranchRef, behind, s)
+  (use "dolt pull" to update your local branch)
+	`, remoteBranchRef, behind, s)
 			changesPresent = true
 		} else {
 			cli.Printf("Your branch is up to date with '%s'.", remoteBranchRef)
@@ -582,6 +585,7 @@ and have %v and %v different commits each, respectively.
 		}
 
 		if len(filteredUnstagedTables) > 0 {
+			cli.Println()
 			cli.Println(workingHeader)
 			cli.Println(workingHeaderHelp)
 			for tableName, status := range filteredUnstagedTables {


### PR DESCRIPTION
`dolt status` output was missing some new lines

```bash
taylor@MacBook-Pro-3 test % dolt status
On branch main
Your branch is ahead of 'origin/main' by 1 commit.
  (use "dolt push" to publish your local commits)Changes not staged for commit:
  (use "dolt add <table>" to update what will be committed)
  (use "dolt checkout <table>" to discard changes in working directory)
	modified:         table1
taylor@MacBook-Pro-3 test % dolt status
```

```bash
taylor@MacBook-Pro-3 test % dolt status
On branch main
Your branch is up to date with 'origin/main'.nothing to commit, working tree clean
```