### PR TITLE
dolt clone: Fix dolt clone run against a sql-server where the database has been GCd.

### DIFF
--- a/go/libraries/doltcore/remotesrv/grpc.go
+++ b/go/libraries/doltcore/remotesrv/grpc.go
@@ -588,7 +588,7 @@ func getTableFileInfo(
 	}
 	appendixTableFileInfo := make([]*remotesapi.TableFileInfo, 0)
 	for _, t := range tableList {
-		url := rs.getDownloadUrl(md, prefix+"/"+t.FileID())
+		url := rs.getDownloadUrl(md, prefix+"/"+t.LocationPrefix()+t.FileID())
 		url, err = rs.sealer.Seal(url)
 		if err != nil {
 			return nil, status.Error(codes.Internal, "failed to get seal download url for "+t.FileID())

--- a/go/libraries/doltcore/remotestorage/chunk_store.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store.go
@@ -1379,9 +1379,25 @@ type DoltRemoteTableFile struct {
 	info *remotesapi.TableFileInfo
 }
 
+// LocationPrefix
+func (drtf DoltRemoteTableFile) LocationPrefix() string {
+	return ""
+}
+
 // FileID gets the id of the file
 func (drtf DoltRemoteTableFile) FileID() string {
-	return drtf.info.FileId
+	id := drtf.info.FileId
+
+	// Early versions of |dolt| could return GenerationalChunkStore
+	// TableFile implementations where FileID included an `oldgen/` prefix.
+	// If we are communicating with a removesrv from one of those versions,
+	// we may see this prefix. This is not relevant to how we want to
+	// address the table file locally, so we prune it here.
+	if strings.HasPrefix(id, "oldgen/") {
+		id = strings.TrimPrefix(id, "oldgen/")
+	}
+
+	return id
 }
 
 // NumChunks returns the number of chunks in a table file

--- a/go/store/chunks/tablefilestore.go
+++ b/go/store/chunks/tablefilestore.go
@@ -28,6 +28,9 @@ type TableFile interface {
 	// FileID gets the id of the file
 	FileID() string
 
+	// LocationPrefix
+	LocationPrefix() string
+
 	// NumChunks returns the number of chunks in a table file
 	NumChunks() int
 

--- a/go/store/datas/pull/clone.go
+++ b/go/store/datas/pull/clone.go
@@ -210,7 +210,10 @@ func clone(ctx context.Context, srcTS, sinkTS chunks.TableFileStore, sinkCS chun
 		}
 	}
 
-	sinkTS.AddTableFilesToManifest(ctx, fileIDToNumChunks)
+	err = sinkTS.AddTableFilesToManifest(ctx, fileIDToNumChunks)
+	if err != nil {
+		return err
+	}
 
 	// AddTableFilesToManifest can set the root chunk if there is a chunk
 	// journal which we downloaded in the clone. If that happened, the

--- a/go/store/nbs/generational_chunk_store.go
+++ b/go/store/nbs/generational_chunk_store.go
@@ -266,8 +266,8 @@ type prefixedTableFile struct {
 	prefix string
 }
 
-func (p prefixedTableFile) FileID() string {
-	return filepath.ToSlash(filepath.Join(p.prefix, p.TableFile.FileID()))
+func (p prefixedTableFile) LocationPrefix() string {
+	return p.prefix + "/"
 }
 
 // Sources retrieves the current root hash, a list of all the table files (which may include appendix table files),

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -1340,6 +1340,11 @@ type tableFile struct {
 	open func(ctx context.Context) (io.ReadCloser, uint64, error)
 }
 
+// LocationPrefix
+func (tf tableFile) LocationPrefix() string {
+	return ""
+}
+
 // FileID gets the id of the file
 func (tf tableFile) FileID() string {
 	return tf.info.GetName()

--- a/integration-tests/go-sql-server-driver/main_test.go
+++ b/integration-tests/go-sql-server-driver/main_test.go
@@ -28,6 +28,10 @@ func TestCluster(t *testing.T) {
 	RunTestsFile(t, "tests/sql-server-cluster.yaml")
 }
 
+func TestRemotesAPI(t *testing.T) {
+	RunTestsFile(t, "tests/sql-server-remotesapi.yaml")
+}
+
 // TestSingle is a convenience method for running a single test from within an IDE. Unskip and set to the file and name
 // of the test you want to debug. See README.md in the `tests` directory for more debugging info.
 func TestSingle(t *testing.T) {

--- a/integration-tests/go-sql-server-driver/tests/sql-server-remotesapi.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-remotesapi.yaml
@@ -1,0 +1,83 @@
+tests:
+- name: can clone from server1 remotesapi endpoint
+  multi_repos:
+  - name: server1
+    repos:
+    - name: repo1
+    - name: repo2
+    server:
+      args: ["--remotesapi-port", "50051", "--port", "3309"]
+      port: 3309
+  - name: server2
+    repos:
+    - name: repo1
+    with_files:
+    - name: server.yaml
+      contents: |
+        log_level: trace
+        listener:
+          host: 0.0.0.0
+          port: 3308
+    server:
+      args: ["--config", "server.yaml"]
+      port: 3308
+  connections:
+  - on: server1
+    queries:
+    - exec: "use repo2"
+    - exec: "create table vals (id int primary key)"
+    - exec: "insert into vals values (0),(1),(2),(3),(4)"
+    - exec: "call dolt_commit('-Am', 'insert some data')"
+  - on: server2
+    queries:
+    - exec: "use repo1"
+    - exec: "call dolt_clone('http://localhost:50051/repo2')"
+    - exec: "use repo2"
+    - query: "select count(*) from vals"
+      result:
+        columns: ["count(*)"]
+        rows: [["5"]]
+- name: can clone from server1 remotesapi endpoint after a gc
+  multi_repos:
+  - name: server1
+    repos:
+    - name: repo1
+    - name: repo2
+    server:
+      args: ["--remotesapi-port", "50051", "--port", "3309"]
+      port: 3309
+  - name: server2
+    repos:
+    - name: repo1
+    with_files:
+    - name: server.yaml
+      contents: |
+        log_level: trace
+        listener:
+          host: 0.0.0.0
+          port: 3308
+    server:
+      args: ["--config", "server.yaml"]
+      port: 3308
+  connections:
+  - on: server1
+    queries:
+    - exec: "use repo2"
+    - exec: "create table vals (id int primary key)"
+    - exec: "insert into vals values (0),(1),(2),(3),(4)"
+    - exec: "call dolt_commit('-Am', 'insert some data')"
+    - exec: "call dolt_gc()"
+  - on: server1
+    queries:
+    - exec: "use repo2"
+    - exec: "insert into vals values (5),(6),(7),(8),(9)"
+    - exec: "call dolt_commit('-Am', 'insert some more data')"
+  - on: server2
+    queries:
+    - exec: "use repo1"
+    - exec: "call dolt_clone('http://localhost:50051/repo2')"
+    - exec: "use repo2"
+    - query: "select count(*) from vals"
+      result:
+        columns: ["count(*)"]
+        rows: [["10"]]


### PR DESCRIPTION
A long-standing bug in the remotesapi which the sql-server exposes could cause a `dolt clone` to fail when running against a database which had been garbage collected. This change fixes the bug in the server. It also patches the client behavior so that it will tolerate responses from older versions of dolt.