### PR TITLE
Fix for cherry-pick docs and PK mapping error message

### DIFF
--- a/go/cmd/dolt/commands/cherry-pick.go
+++ b/go/cmd/dolt/commands/cherry-pick.go
@@ -34,9 +34,9 @@ var cherryPickDocs = cli.CommandDocumentationContent{
 	LongDesc: `
 Applies the changes from an existing commit and creates a new commit from the current HEAD. This requires your working tree to be clean (no modifications from the HEAD commit).
 
-Cherry-picking merge commits or commits with schema changes or rename or drop tables is not currently supported. Row data changes are allowed as long as the two table schemas are exactly identical.
+Cherry-picking merge commits or commits with table drops/renames is not currently supported. 
 
-If applying the row data changes from the cherry-picked commit results in a data conflict, the cherry-pick operation is aborted and no changes are made to the working tree or committed.
+If any data conflicts, schema conflicts, or constraint violations are detected during cherry-picking, you can use Dolt's conflict resolution features to resolve them. For more information on resolving conflicts, see: https://docs.dolthub.com/concepts/dolt/git/conflicts.
 `,
 	Synopsis: []string{
 		`{{.LessThan}}commit{{.GreaterThan}}`,

--- a/go/libraries/doltcore/schema/schema.go
+++ b/go/libraries/doltcore/schema/schema.go
@@ -282,8 +282,8 @@ func MapSchemaBasedOnTagAndName(inSch, outSch Schema) ([]int, []int, error) {
 
 	err := inSch.GetPKCols().Iter(func(tag uint64, col Column) (stop bool, err error) {
 		i := inSch.GetPKCols().TagToIdx[tag]
-		if col, ok := outSch.GetPKCols().GetByTag(tag); ok {
-			j := outSch.GetPKCols().TagToIdx[col.Tag]
+		if foundCol, ok := outSch.GetPKCols().GetByTag(tag); ok {
+			j := outSch.GetPKCols().TagToIdx[foundCol.Tag]
 			keyMapping[i] = j
 		} else {
 			return true, fmt.Errorf("could not map primary key column %s", col.Name)


### PR DESCRIPTION
- Update cherry-pick docs now that schema and data conflicts are supported in cherry-pick.
- Fix a bug in schema.go where the incorrect column name (`Invalid`) was being printed out due to a shadowed `col` variable.