### PR TITLE
Set the DB name on the sql.Context when in remote mode

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/sqlclient.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlclient.go
@@ -497,8 +497,14 @@ func BuildConnectionStringQueryist(ctx context.Context, cwdFS filesys.Filesys, c
 
 	queryist := ConnectionQueryist{connection: conn}
 
+	createSqlContext := func(ctx2 context.Context) (result *sql.Context) {
+		result = sql.NewContext(ctx2)
+		result.SetCurrentDatabase(database)
+		return
+	}
+
 	var lateBind cli.LateBindQueryist = func(ctx context.Context) (cli.Queryist, *sql.Context, func(), error) {
-		return queryist, sql.NewContext(ctx), func() { conn.Conn(ctx) }, nil
+		return queryist, createSqlContext(ctx), func() { conn.Conn(ctx) }, nil
 	}
 
 	return lateBind, nil


### PR DESCRIPTION
The SQL.Context used in the remote connection case is kind of an empty shell since the connection has all the details for working with the DB. One side effect of having a dummy sql.Context was not having the database name set in the context. The shell uses it to set it's prompt, but this could have ramifications elsewhere we haven't discovered.

https://github.com/dolthub/dolt/issues/6246