### PR TITLE
change commit to print with printCommitInfo

### DIFF
--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/dolthub/dolt/go/store/util/outputpager"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/fatih/color"
 	"github.com/gocraft/dbr/v2"
@@ -41,6 +40,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/utils/iohelp"
 	"github.com/dolthub/dolt/go/libraries/utils/set"
 	"github.com/dolthub/dolt/go/store/datas"
+	"github.com/dolthub/dolt/go/store/util/outputpager"
 )
 
 var commitDocs = cli.CommandDocumentationContent{

--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -171,12 +171,14 @@ func performCommit(ctx context.Context, commandStr string, args []string, cliCtx
 	}
 
 	commit, err := getCommitInfo(queryist, sqlCtx, "HEAD")
-	cli.ExecuteWithStdioRestored(func() {
-		pager := outputpager.Start()
-		defer pager.Stop()
+	if cli.ExecuteWithStdioRestored != nil {
+		cli.ExecuteWithStdioRestored(func() {
+			pager := outputpager.Start()
+			defer pager.Stop()
 
-		printCommitInfo(pager, 0, false, "auto", commit)
-	})
+			printCommitInfo(pager, 0, false, "auto", commit)
+		})
+	}
 
 	return 0, false
 }

--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/dolthub/dolt/go/store/util/outputpager"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/fatih/color"
 	"github.com/gocraft/dbr/v2"
@@ -29,7 +30,6 @@ import (
 	goisatty "github.com/mattn/go-isatty"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
-	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
@@ -170,22 +170,14 @@ func performCommit(ctx context.Context, commandStr string, args []string, cliCtx
 		return 0, true
 	}
 
-	if _, ok := queryist.(*engine.SqlEngine); ok {
-		// We have a local context, so we can call the classic (unmigrated) log command.
-		return LogCmd{}.Exec(ctx, "log", []string{"-n=1"}, temporacyDEnv, nil), false
-	} else {
-		// TODO: when dolt log is migrated, remove this block printing out the commit and print with a dolt log call in Exec()
-		schema, rowIter, err = queryist.Query(sqlCtx, "select * from dolt_log() limit 1")
-		if err != nil {
-			cli.Println(err.Error())
-			return 1, false
-		}
-		err = engine.PrettyPrintResults(sqlCtx, engine.FormatTabular, schema, rowIter)
-		if err != nil {
-			cli.Println(err.Error())
-			return 1, false
-		}
-	}
+	// TODO: when dolt log is migrated, remove this block printing out the commit and print with a dolt log call in Exec()
+	commit, err := getCommitInfo(queryist, sqlCtx, "HEAD")
+	cli.ExecuteWithStdioRestored(func() {
+		pager := outputpager.Start()
+		defer pager.Stop()
+
+		printCommitInfo(pager, 0, false, "auto", commit)
+	})
 
 	return 0, false
 }

--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -170,7 +170,6 @@ func performCommit(ctx context.Context, commandStr string, args []string, cliCtx
 		return 0, true
 	}
 
-	// TODO: when dolt log is migrated, remove this block printing out the commit and print with a dolt log call in Exec()
 	commit, err := getCommitInfo(queryist, sqlCtx, "HEAD")
 	cli.ExecuteWithStdioRestored(func() {
 		pager := outputpager.Start()

--- a/go/cmd/dolt/commands/show.go
+++ b/go/cmd/dolt/commands/show.go
@@ -522,7 +522,7 @@ func getCommitInfo(queryist cli.Queryist, sqlCtx *sql.Context, ref string) (*com
 	}
 
 	if parent != "" {
-		ci.parentHashes = []string{parent}
+		ci.parentHashes = strings.Split(parent, ", ")
 	}
 
 	return ci, nil

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -276,8 +276,6 @@ assert_has_key_value() {
 }
 
 @test "sql-local-remote: verify dolt commit behavior is identical in switch between server/no server" {
-    skip # TODO - Enable after log command is used for results in remote contexts in commit.go
-
     cd altDB
     dolt sql -q "create table test1 (pk int primary key)"
     dolt sql -q "create table test2 (pk int primary key)"

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -309,6 +309,14 @@ assert_has_key_value() {
     [[ "$output" =~ "committing locally" ]] || false
 }
 
+@test "sql-local-remote: verify dolt commit print" {
+    run dolt --use-db altDB commit -A -m "Wonderful Commit"
+    [[ "${lines[0]}" =~ "commit " ]] || false
+    [[ "${lines[1]}" =~ "Author: Bats Tests <bats@email.fake>" ]] || false
+    [[ "${lines[2]}" =~ "Date: " ]] || false
+    [[ "${lines[3]}" =~ "	Wonderful Commit" ]] || false
+}
+
 @test "sql-local-remote: verify simple dolt branch behavior." {
     start_sql_server altDB
     cd altDB


### PR DESCRIPTION
Changes `commit` to print with `printCommitInfo`. This prevents seg fault errors from using `dolt log` as was previously done.