### PR TITLE
Revert transaction-unsafe implementation of `SessionStateAdapter::SetCWBHeadRef`

### DIFF
--- a/go/libraries/doltcore/env/actions/branch.go
+++ b/go/libraries/doltcore/env/actions/branch.go
@@ -44,17 +44,6 @@ func RenameBranch(ctx context.Context, dbData env.DbData, oldBranch, newBranch s
 		return err
 	}
 
-	headRef, err := dbData.Rsr.CWBHeadRef()
-	if err != nil {
-		return err
-	}
-	if ref.Equals(headRef, oldRef) {
-		err = dbData.Rsw.SetCWBHeadRef(ctx, ref.MarshalableRef{Ref: newRef})
-		if err != nil {
-			return err
-		}
-	}
-
 	fromWSRef, err := ref.WorkingSetRefForHead(oldRef)
 	if err != nil {
 		if !errors.Is(err, ref.ErrWorkingSetUnsupported) {

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_branch.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_branch.go
@@ -170,13 +170,13 @@ func renameBranch(ctx *sql.Context, dbData env.DbData, apr *argparser.ArgParseRe
 		}
 	}
 
+	err = sess.RenameBranchState(ctx, dbName, oldBranchName, newBranchName)
+	if err != nil {
+		return err
+	}
+
 	// If the active branch of the SQL session was renamed, switch to the new branch.
 	if oldBranchName == activeSessionBranch {
-		err = sess.RenameBranchState(ctx, dbName, oldBranchName, newBranchName)
-		if err != nil {
-			return err
-		}
-
 		wsRef, err := ref.WorkingSetRefForHead(ref.NewBranchRef(newBranchName))
 		if err != nil {
 			return err

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_branch.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_branch.go
@@ -172,14 +172,9 @@ func renameBranch(ctx *sql.Context, dbData env.DbData, apr *argparser.ArgParseRe
 
 	// If the active branch of the SQL session was renamed, switch to the new branch.
 	if oldBranchName == activeSessionBranch {
-		currentTx := ctx.GetTransaction()
-		if currentTx != nil {
-			err := sess.CommitTransaction(ctx, currentTx)
-			if err != nil {
-				return err
-			}
-			newTx, err := sess.StartTransaction(ctx, sql.ReadWrite)
-			ctx.SetTransaction(newTx)
+		err = sess.RenameBranchState(ctx, dbName, oldBranchName, newBranchName)
+		if err != nil {
+			return err
 		}
 
 		wsRef, err := ref.WorkingSetRefForHead(ref.NewBranchRef(newBranchName))

--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -277,6 +277,7 @@ func (d *DoltSession) RenameBranchState(ctx *sql.Context, dbName string, oldBran
 
 	if !ok {
 		// nothing to rename
+		d.mu.Unlock()
 		return nil
 	}
 

--- a/go/libraries/doltcore/sqle/dsess/session_state_adapter.go
+++ b/go/libraries/doltcore/sqle/dsess/session_state_adapter.go
@@ -37,24 +37,7 @@ type SessionStateAdapter struct {
 }
 
 func (s SessionStateAdapter) SetCWBHeadRef(ctx context.Context, newRef ref.MarshalableRef) error {
-	sqlCtx := sql.NewContext(ctx, sql.WithSession(s.session))
-
-	err := s.session.CommitTransaction(sqlCtx, sqlCtx.GetTransaction())
-	if err != nil {
-		return err
-	}
-
-	wsRef, err := ref.WorkingSetRefForHead(newRef.Ref)
-	if err != nil {
-		return err
-	}
-
-	err = s.session.SwitchWorkingSet(sqlCtx, s.dbName, wsRef)
-	if err != nil {
-		return err
-	}
-
-	return s.session.CommitTransaction(sqlCtx, sqlCtx.GetTransaction())
+	return fmt.Errorf("Cannot set cwb head ref with a SessionStateAdapter")
 }
 
 var _ env.RepoStateReader = SessionStateAdapter{}

--- a/integration-tests/bats/branch.bats
+++ b/integration-tests/bats/branch.bats
@@ -44,6 +44,8 @@ teardown() {
 @test "branch: moving current working branch takes its working set" {
     dolt sql -q 'create table test (id int primary key);'
     dolt branch -m main new_main
+    run dolt branch --show-current
+    [[ "$output" =~ "new_main" ]] || false
     run dolt sql -q 'show tables'
     [[ "$output" =~ "test" ]] || false
 }

--- a/integration-tests/bats/sql-branch.bats
+++ b/integration-tests/bats/sql-branch.bats
@@ -195,7 +195,9 @@ SQL
 
 @test "sql-branch: CALL DOLT_BRANCH -m on session active branch (dolt sql)" {
     dolt branch other
-    echo "call dolt_checkout('other'); call dolt_branch('-m', 'other', 'newOther')" | dolt sql
+    run dolt sql -q "call dolt_checkout('other'); call dolt_branch('-m', 'other', 'newOther'); select active_branch();"
+    [ $status -eq 0 ]
+    [[ "$output" =~ "newOther" ]] || false
     run dolt branch
     [ $status -eq 0 ]
     [[ "$output" =~ "newOther" ]] || false

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -1914,7 +1914,9 @@ behavior:
     cd repo1
     dolt branch other
     start_sql_server
-    dolt sql-client -P $PORT -u dolt --use-db repo1 -q "call dolt_checkout('other'); call dolt_branch('-m', 'other', 'newOther')"
+    run dolt sql-client -P $PORT -u dolt --use-db repo1 -q "call dolt_checkout('other'); call dolt_branch('-m', 'other', 'newOther'); select active_branch();"
+    [ $status -eq 0 ]
+    [[ "$output" =~ "newOther" ]] || false
     run dolt --user dolt branch
     [ $status -eq 0 ]
     [[ "$output" =~ "newOther" ]] || false


### PR DESCRIPTION
This recently added implementation of `SetCWBHeadRef` was a designed to fix an issue when evalutating `call dolt_branch('-m', $ACTIVE_BRANCH, $NEW_BRANCH)` (which would cause a panic) by changing the active branch on the SQL session to match the new branch. However, this implementation has some problems.

When operating on the DB from a SQL-context, we use transactions to ensure that changes are applied atomically. However currently, renaming branches doesn't use transactions because they touch multiple branches at once and we can't really model that as a transaction. This becomes a problem when mixed with `DoltSession` operations, which do use transactions.

My original implementation attempted to work around this by calling `commitTransaction` before and after setting the new current working branch. This would allow `SwitchActiveBranch` to see the newly created branch. However, this is not a correct use of manual transaction management and is not generally safe.

No matter the solution to the original bug, doing manual transaction management in `SetCWBHeadRef` is not a good idea. It's been reverted, and the call to `SetCWBHeadRef` within `RenameBranch` has been removed.

The last commit in this PR is an attempt to implement the branch switch within `RenameBranch` itself. This also uses manual transaction management, but this is isolated to a single execution path. I welcome feedback on whether there's a better way to do this.