### PR TITLE
Use correct local branch name when setting upstream in `dolt_checkout`

### DIFF
--- a/go/libraries/doltcore/sqle/dprocedures/dolt_checkout.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_checkout.go
@@ -262,7 +262,7 @@ func checkoutNewBranch(ctx *sql.Context, dbName string, dbData env.DbData, apr *
 	}
 
 	if setTrackUpstream {
-		err = env.SetRemoteUpstreamForRefSpec(dbData.Rsw, refSpec, remoteName, ref.NewBranchRef(remoteBranchName))
+		err = env.SetRemoteUpstreamForRefSpec(dbData.Rsw, refSpec, remoteName, ref.NewBranchRef(newBranchName))
 		if err != nil {
 			return err
 		}
@@ -270,7 +270,7 @@ func checkoutNewBranch(ctx *sql.Context, dbName string, dbData env.DbData, apr *
 		remoteName, remoteBranchName = actions.ParseRemoteBranchName(startPt)
 		refSpec, err = ref.ParseRefSpecForRemote(remoteName, remoteBranchName)
 		if err == nil {
-			err = env.SetRemoteUpstreamForRefSpec(dbData.Rsw, refSpec, remoteName, ref.NewBranchRef(remoteBranchName))
+			err = env.SetRemoteUpstreamForRefSpec(dbData.Rsw, refSpec, remoteName, ref.NewBranchRef(newBranchName))
 			if err != nil {
 				return err
 			}

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -2075,6 +2075,51 @@ SQL
     [[ "$output" =~ "Everything up-to-date." ]] || false
 }
 
+@test "remotes: dolt sql -q 'call dolt_checkout("-b", "newbranch", "--track", "origin/feature")'' checks out new local branch 'newbranch' with upstream set" {
+    mkdir remote
+    mkdir repo1
+
+    cd repo1
+    dolt init
+    dolt remote add origin file://../remote
+    dolt push --set-upstream origin main
+    dolt checkout -b feature
+    dolt push --set-upstream origin feature
+
+    cd ..
+    dolt clone file://./remote repo2
+
+    cd repo2
+    run dolt branch
+    [[ ! "$output" =~ "feature" ]] || false
+
+    dolt sql -q 'call dolt_checkout("-b", "newbranch", "--track", "origin/feature");'
+
+    run dolt sql -q 'select * from dolt_branches;'
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "| origin | feature" ]] || false
+
+    run dolt pull
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Everything up-to-date." ]] || false
+
+    dolt checkout main
+    dolt branch -D newbranch
+
+    # branch.autosetupmerge configuration defaults to --track, so the upstream is set
+    run dolt sql -q 'call dolt_checkout("-b", "newbranch2", "origin/feature");'
+    echo "$output"
+    [ "$status" -eq 0 ]
+    run dolt sql -q 'select * from dolt_branches;'
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "| origin | feature" ]] || false
+
+
+    run dolt pull
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Everything up-to-date." ]] || false
+}
+
 @test "remotes: dolt branch track flag sets upstream" {
     mkdir remote
     mkdir repo1


### PR DESCRIPTION
I found an issue in `dolt_checkout` that occurs in the narrow case where both the `-b` and `--track` flags are provided, in order to create a new branch that tracks an upstream branch with a different name.

In that case, we fail to set the upstream correctly because we accidentally look for a local branch to mark using the remote branch name, instead of the local branch name.

I added a regression test.