### PR TITLE
adds test for reset handling ignored tables

### DIFF
--- a/integration-tests/bats/reset.bats
+++ b/integration-tests/bats/reset.bats
@@ -316,8 +316,8 @@ SQL
 CREATE TABLE test2 (
     pk int primary key
 );
-INSERT INTO test2 VALUES (1);
-INSERT INTO test1 VALUES (1, 1, 1);
+INSERT INTO test2 VALUES (9);
+INSERT INTO test1 VALUES (1, 2, 3);
 SQL
     dolt sql -q "insert into dolt_ignore values ('test2', true)"
 
@@ -334,5 +334,5 @@ SQL
 
     run dolt sql -q "select * from test2"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "1" ]] || false
+    [[ "$output" =~ "9" ]] || false
 }

--- a/integration-tests/bats/reset.bats
+++ b/integration-tests/bats/reset.bats
@@ -330,7 +330,9 @@ SQL
 
     run dolt status
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "nothing to commit, working tree clean" ]]
+    [[ "$output" =~ "Untracked tables:" ]] || false
+    [[ "$output" =~ "  (use \"dolt add <table>\" to include in what will be committed)" ]] || false
+    [[ "$output" =~ "	new table:        dolt_ignore" ]] || false
 
     run dolt sql -q "select * from test2"
     [ "$status" -eq 0 ]

--- a/integration-tests/bats/sql-reset.bats
+++ b/integration-tests/bats/sql-reset.bats
@@ -562,7 +562,7 @@ get_head_commit() {
 CREATE TABLE test2 (
     pk int primary key
 );
-INSERT INTO test2 VALUES (1);
+INSERT INTO test2 VALUES (9);
 INSERT INTO test VALUES (1);
 SQL
     dolt sql -q "insert into dolt_ignore values ('test2', true)"
@@ -580,5 +580,5 @@ SQL
 
     run dolt sql -q "select * from test2"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "1" ]] || false
+    [[ "$output" =~ "9" ]] || false
 }

--- a/integration-tests/bats/sql-reset.bats
+++ b/integration-tests/bats/sql-reset.bats
@@ -576,7 +576,8 @@ SQL
 
     run dolt sql -q "select * from dolt_status"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "" ]]
+    [[ "$output" =~ "| dolt_ignore | false  | new table |" ]] || false
+    [ "${#lines[@]}" -eq 6 ]
 
     run dolt sql -q "select * from test2"
     [ "$status" -eq 0 ]

--- a/integration-tests/bats/sql-reset.bats
+++ b/integration-tests/bats/sql-reset.bats
@@ -557,3 +557,28 @@ get_head_commit() {
     dolt log -n 1 | grep -m 1 commit | cut -c 13-44
 }
 
+@test "sql-reset: reset handles ignored tables" {
+    dolt sql << SQL
+CREATE TABLE test2 (
+    pk int primary key
+);
+INSERT INTO test2 VALUES (1);
+INSERT INTO test VALUES (1);
+SQL
+    dolt sql -q "insert into dolt_ignore values ('test2', true)"
+
+    run dolt sql -q "select * from dolt_status"
+    [ "$status" -eq 0 ]
+    [[ "$output" != "test2" ]] || false
+
+    run dolt sql -q "call dolt_reset('--hard')"
+    [ "$status" -eq 0 ]
+
+    run dolt sql -q "select * from dolt_status"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "" ]]
+
+    run dolt sql -q "select * from test2"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "1" ]] || false
+}


### PR DESCRIPTION
Adds tests for `dolt reset` and `dolt_reset()` to check their handling of ignored tables.