### PR TITLE
Add ignore support to dolt_cherry_pick procedure.

### DIFF
--- a/go/cmd/dolt/commands/stashcmds/stash.go
+++ b/go/cmd/dolt/commands/stashcmds/stash.go
@@ -153,7 +153,7 @@ func hasLocalChanges(ctx context.Context, dEnv *env.DoltEnv, roots doltdb.Roots,
 	}
 
 	// --all was not set, so we can ignore tables. Is every table ignored?
-	allIgnored, err := workingSetContainsOnlyIgnoredTables(ctx, roots)
+	allIgnored, err := diff.WorkingSetContainsOnlyIgnoredTables(ctx, roots)
 	if err != nil {
 		return false, err
 	}
@@ -279,35 +279,6 @@ func workingSetContainsOnlyUntrackedTables(ctx context.Context, roots doltdb.Roo
 	// All ignored files are also untracked files
 	for _, tableDelta := range unstaged {
 		if !tableDelta.IsAdd() {
-			return false, nil
-		}
-	}
-
-	return true, nil
-}
-
-// workingSetContainsOnlyIgnoredTables returns true if all changes in working set are ignored tables.
-// Note that only unstaged tables are subject to dolt_ignore (this is consistent with what git does.)
-func workingSetContainsOnlyIgnoredTables(ctx context.Context, roots doltdb.Roots) (bool, error) {
-	_, unstaged, err := diff.GetStagedUnstagedTableDeltas(ctx, roots)
-	if err != nil {
-		return false, err
-	}
-
-	ignorePatterns, err := doltdb.GetIgnoredTablePatterns(ctx, roots)
-	if err != nil {
-		return false, err
-	}
-
-	for _, tableDelta := range unstaged {
-		if !(tableDelta.IsAdd()) {
-			return false, nil
-		}
-		isIgnored, err := ignorePatterns.IsTableNameIgnored(tableDelta.ToName)
-		if err != nil {
-			return false, err
-		}
-		if isIgnored != doltdb.Ignore {
 			return false, nil
 		}
 	}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_cherry_pick.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_cherry_pick.go
@@ -17,12 +17,13 @@ package dprocedures
 import (
 	"errors"
 	"fmt"
-	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
+
 	"github.com/dolthub/go-mysql-server/sql"
 	gmstypes "github.com/dolthub/go-mysql-server/sql/types"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
+	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/merge"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"

--- a/integration-tests/bats/sql-cherry-pick.bats
+++ b/integration-tests/bats/sql-cherry-pick.bats
@@ -4,7 +4,10 @@ load $BATS_TEST_DIRNAME/helper/common.bash
 setup() {
     setup_common
 
-    dolt sql -q "CREATE TABLE test(pk BIGINT PRIMARY KEY, v varchar(10))"
+    dolt sql <<SQL
+CREATE TABLE test(pk BIGINT PRIMARY KEY, v varchar(10));
+INSERT INTO dolt_ignore VALUES ('generated_*', 1);
+SQL
     dolt add .
     dolt commit -am "Created table"
     dolt checkout -b branch1
@@ -14,6 +17,8 @@ setup() {
     dolt commit -am "Inserted 2"
     dolt sql -q "INSERT INTO test VALUES (3, 'c')"
     dolt commit -am "Inserted 3"
+
+    dolt sql -q "CREATE TABLE generated_foo (pk int PRIMARY KEY);"
 
     run dolt sql -q "SELECT * FROM test" -r csv
     [[ "$output" =~ "1,a" ]] || false


### PR DESCRIPTION
This updates the `dolt_cherry_pick` procedure to properly work with ignored tables.