### PR TITLE
Fix: unstaged ignored tables are staged after a cherry-pick abort

### DIFF
--- a/go/libraries/doltcore/doltdb/ignore.go
+++ b/go/libraries/doltcore/doltdb/ignore.go
@@ -109,6 +109,33 @@ func GetIgnoredTablePatterns(ctx context.Context, roots Roots) (IgnorePatterns, 
 	return ignorePatterns, nil
 }
 
+func ExcludeIgnoredTables(ctx context.Context, roots Roots, tables []string) ([]string, error) {
+	ignorePatterns, err := GetIgnoredTablePatterns(ctx, roots)
+	if err != nil {
+		return nil, err
+	}
+	filteredTables := []string{}
+	for _, tbl := range tables {
+		ignored, err := ignorePatterns.IsTableNameIgnored(tbl)
+		if err != nil {
+			return nil, err
+		}
+		if conflict := AsDoltIgnoreInConflict(err); conflict != nil {
+			// no-op
+		} else if err != nil {
+			return nil, err
+		} else if ignored == DontIgnore {
+			// no-op
+		} else if ignored == Ignore {
+			continue
+		} else {
+			return nil, fmt.Errorf("IsTableNameIgnored returned ErrorOccurred but no error!")
+		}
+		filteredTables = append(filteredTables, tbl)
+	}
+	return filteredTables, nil
+}
+
 // compilePattern takes a dolt_ignore pattern and generate a Regexp that matches against the same table names as the pattern.
 func compilePattern(pattern string) (*regexp.Regexp, error) {
 	pattern = "^" + regexp.QuoteMeta(pattern) + "$"

--- a/go/libraries/doltcore/doltdb/ignore.go
+++ b/go/libraries/doltcore/doltdb/ignore.go
@@ -109,6 +109,9 @@ func GetIgnoredTablePatterns(ctx context.Context, roots Roots) (IgnorePatterns, 
 	return ignorePatterns, nil
 }
 
+// ExcludeIgnoredTables takes a list of table names and removes any tables that should be ignored,
+// as determined by the patterns in the dolt_ignore table.
+// The ignore patterns are read from the dolt_ignore table in the working set.
 func ExcludeIgnoredTables(ctx context.Context, roots Roots, tables []string) ([]string, error) {
 	ignorePatterns, err := GetIgnoredTablePatterns(ctx, roots)
 	if err != nil {

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_merge.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_merge.go
@@ -267,8 +267,23 @@ func abortMerge(ctx *sql.Context, workingSet *doltdb.WorkingSet, roots doltdb.Ro
 		return nil, err
 	}
 
-	// TODO: this doesn't seem right, it sets the root that we already edited above
-	workingSet = workingSet.AbortMerge()
+	preMergeWorkingRoot := workingSet.MergeState().PreMergeWorkingRoot()
+	preMergeWorkingTables, err := preMergeWorkingRoot.GetTableNames(ctx)
+	if err != nil {
+		return nil, err
+	}
+	nonIgnoredTables, err := doltdb.ExcludeIgnoredTables(ctx, roots, preMergeWorkingTables)
+	if err != nil {
+		return nil, err
+	}
+
+	newWorking, err := actions.MoveTablesBetweenRoots(ctx, nonIgnoredTables, preMergeWorkingRoot, roots.Working)
+	if err != nil {
+		return nil, err
+	}
+	workingSet = workingSet.WithWorkingRoot(newWorking)
+	workingSet = workingSet.ClearMerge()
+
 	return workingSet, nil
 }
 

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_merge.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_merge.go
@@ -276,12 +276,18 @@ func abortMerge(ctx *sql.Context, workingSet *doltdb.WorkingSet, roots doltdb.Ro
 	if err != nil {
 		return nil, err
 	}
+	someTablesAreIgnored := len(nonIgnoredTables) != len(preMergeWorkingTables)
 
-	newWorking, err := actions.MoveTablesBetweenRoots(ctx, nonIgnoredTables, preMergeWorkingRoot, roots.Working)
-	if err != nil {
-		return nil, err
+	if someTablesAreIgnored {
+		newWorking, err := actions.MoveTablesBetweenRoots(ctx, nonIgnoredTables, preMergeWorkingRoot, roots.Working)
+		if err != nil {
+			return nil, err
+		}
+		workingSet = workingSet.WithWorkingRoot(newWorking)
+	} else {
+		workingSet = workingSet.WithWorkingRoot(preMergeWorkingRoot)
 	}
-	workingSet = workingSet.WithWorkingRoot(newWorking)
+	workingSet = workingSet.WithStagedRoot(workingSet.WorkingRoot())
 	workingSet = workingSet.ClearMerge()
 
 	return workingSet, nil

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -4404,6 +4404,59 @@ var DoltCherryPickTests = []queries.ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "abort (@@autocommit=1) with ignored table",
+		SetUpScript: []string{
+			"INSERT INTO dolt_ignore VALUES ('generated_*', 1);",
+			"CREATE TABLE generated_foo (pk int PRIMARY KEY);",
+			"SET @@autocommit=1;",
+			"SET @@dolt_allow_commit_conflicts=1;",
+			"create table t (pk int primary key, v varchar(100));",
+			"insert into t values (0, 'zero');",
+			"call dolt_commit('-Am', 'create table t');",
+			"call dolt_checkout('-b', 'branch1');",
+			"insert into t values (1, \"one\");",
+			"call dolt_commit('-am', 'adding row 1');",
+			"insert into t values (2, \"two\");",
+			"call dolt_commit('-am', 'adding row 2');",
+			"alter table t drop column v;",
+			"call dolt_commit('-am', 'drop column v');",
+			"call dolt_checkout('main');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "call dolt_cherry_pick(hashof('branch1'));",
+				Expected: []sql.Row{{"", 1, 0, 0}},
+			},
+			{
+				Query:    "select * from dolt_conflicts;",
+				Expected: []sql.Row{{"t", uint64(2)}},
+			},
+			{
+				Query: "select base_pk, base_v, our_pk, our_diff_type, their_pk, their_diff_type from dolt_conflicts_t;",
+				Expected: []sql.Row{
+					{1, "one", nil, "removed", 1, "modified"},
+					{2, "two", nil, "removed", 2, "modified"},
+				},
+			},
+			{
+				Query:    "call dolt_cherry_pick('--abort');",
+				Expected: []sql.Row{{"", 0, 0, 0}},
+			},
+			{
+				Query:    "select * from dolt_conflicts;",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "select * from t;",
+				Expected: []sql.Row{{0, "zero"}},
+			},
+			{
+				Query:    "select * from dolt_status;",
+				Expected: []sql.Row{},
+			},
+		},
+	},
 }
 
 var DoltCommitTests = []queries.ScriptTest{

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
@@ -859,7 +859,7 @@ var MergeScripts = []queries.ScriptTest{
 		},
 	},
 	{
-		Name: "DOLT_MERGE(--abort) clears index state",
+		Name: "DOLT_MERGE(--abort) clears staged",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key);",
 			"INSERT INTO test VALUES (0),(1),(2);",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
@@ -859,6 +859,33 @@ var MergeScripts = []queries.ScriptTest{
 		},
 	},
 	{
+		Name: "DOLT_MERGE(--abort) clears index state",
+		SetUpScript: []string{
+			"CREATE TABLE test (pk int primary key);",
+			"INSERT INTO test VALUES (0),(1),(2);",
+			"set autocommit = off;",
+			"CREATE TABLE one_pk (pk1 BIGINT NOT NULL, c1 BIGINT, c2 BIGINT, PRIMARY KEY (pk1));",
+			"CALL DOLT_ADD('.');",
+			"call dolt_commit('-a', '-m', 'add tables');",
+			"call dolt_checkout('-b', 'feature-branch');",
+			"call dolt_checkout('main');",
+			"INSERT INTO one_pk (pk1,c1,c2) VALUES (0,0,0);",
+			"call dolt_commit('-a', '-m', 'changed main');",
+			"call dolt_checkout('feature-branch');",
+			"INSERT INTO one_pk (pk1,c1,c2) VALUES (0,1,1);",
+			"call dolt_commit('-a', '-m', 'changed feature branch');",
+			"call dolt_checkout('main');",
+			"call dolt_merge('feature-branch');",
+			"call dolt_merge('--abort');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "select * from dolt_status;",
+				Expected: []sql.Row{},
+			},
+		},
+	},
+	{
 		Name: "CALL DOLT_MERGE complains when a merge overrides local changes",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key, val int)",


### PR DESCRIPTION
Fix issue where unstaged ignored tables are staged after a cherry-pick abort