### PR TITLE
Update Dolt's binary size in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Dolt is a single ~103 megabyte program.
 
 ```bash
 dolt $ du -h /Users/timsehn/go/bin/dolt
- 103M	/Users/timsehn/go/bin/dolt
+103M	/Users/timsehn/go/bin/dolt
 ```
 
 It's really easy to install. Download it and put it on your `PATH`. 

--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ Valid commands for dolt are
 
 # Installation
 
-Dolt is a single ~68 megabyte program. 
+Dolt is a single ~103 megabyte program. 
 
 ```bash
-dolt $ du -h /Users/timsehn//go/bin/dolt
- 68M	/Users/timsehn/go/bin/dolt
+dolt $ du -h /Users/timsehn/go/bin/dolt
+ 103M	/Users/timsehn/go/bin/dolt
 ```
 
 It's really easy to install. Download it and put it on your `PATH`. 


### PR DESCRIPTION
We went from 68M to 103M because of the new collations.