### PR TITLE
Migrate `dolt table cp` to use SQL.

### DIFF
--- a/go/cmd/dolt/commands/tblcmds/cp.go
+++ b/go/cmd/dolt/commands/tblcmds/cp.go
@@ -17,14 +17,16 @@ package tblcmds
 import (
 	"context"
 	"fmt"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/gocraft/dbr/v2"
+
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	eventsapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
-	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/gocraft/dbr/v2"
 )
 
 var tblCpDocs = cli.CommandDocumentationContent{

--- a/go/cmd/dolt/commands/utils.go
+++ b/go/cmd/dolt/commands/utils.go
@@ -18,14 +18,14 @@ import (
 	"context"
 	"crypto/sha1"
 	"fmt"
-	"github.com/gocraft/dbr/v2"
-	"github.com/gocraft/dbr/v2/dialect"
 	"net"
 	"path/filepath"
 	"time"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/mysql_db"
+	"github.com/gocraft/dbr/v2"
+	"github.com/gocraft/dbr/v2/dialect"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"

--- a/go/cmd/dolt/commands/utils.go
+++ b/go/cmd/dolt/commands/utils.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"crypto/sha1"
 	"fmt"
+	"github.com/gocraft/dbr/v2"
+	"github.com/gocraft/dbr/v2/dialect"
 	"net"
 	"path/filepath"
 	"time"
@@ -398,4 +400,12 @@ func buildAuthResponse(salt []byte, password string) []byte {
 	}
 
 	return shaPwd
+}
+
+func InterpolateAndRunQuery(queryist cli.Queryist, sqlCtx *sql.Context, queryTemplate string, params ...interface{}) ([]sql.Row, error) {
+	query, err := dbr.InterpolateForDialect(queryTemplate, params, dialect.MySQL)
+	if err != nil {
+		return nil, fmt.Errorf("error interpolating query: %w", err)
+	}
+	return GetRowsForSql(queryist, sqlCtx, query)
 }


### PR DESCRIPTION
Migrate `dolt table cp` to use SQL.
This change also adds a new convenience method, InterpolateAndRunQuery, which can be used to interpolate a query,  execute the query, and get all the result rows. Since this method does not return a schema, this method is useful only for fire-and-forget types of queries.