### PR TITLE
During CWBHeadRef/SetCWBHeadRef, surface RSLoadErr if it is present.

### DIFF
--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -663,10 +663,16 @@ type repoStateReader struct {
 }
 
 func (r *repoStateReader) CWBHeadRef() (ref.DoltRef, error) {
+	if r.RSLoadErr != nil {
+		return nil, r.RSLoadErr
+	}
 	return r.RepoState.CWBHeadRef(), nil
 }
 
 func (r *repoStateReader) CWBHeadSpec() (*doltdb.CommitSpec, error) {
+	if r.RSLoadErr != nil {
+		return nil, r.RSLoadErr
+	}
 	return r.RepoState.CWBHeadSpec(), nil
 }
 
@@ -679,6 +685,10 @@ type repoStateWriter struct {
 }
 
 func (r *repoStateWriter) SetCWBHeadRef(ctx context.Context, marshalableRef ref.MarshalableRef) error {
+	if r.RSLoadErr != nil {
+		return r.RSLoadErr
+	}
+
 	r.RepoState.Head = marshalableRef
 	err := r.RepoState.Save(r.FS)
 


### PR DESCRIPTION
This avoids the panic seen in https://github.com/dolthub/dolt/issues/6306 by surfacing the un-processed error `RSLoadErr` during CWBHeadRef/SetCWBHeadRef calls.