### PR TITLE
Migrate the clean command to sql

### DIFF
--- a/go/cmd/dolt/commands/clean.go
+++ b/go/cmd/dolt/commands/clean.go
@@ -18,11 +18,12 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/gocraft/dbr/v2"
+	"github.com/gocraft/dbr/v2/dialect"
+
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
-	"github.com/gocraft/dbr/v2"
-	"github.com/gocraft/dbr/v2/dialect"
 )
 
 const (

--- a/go/cmd/dolt/commands/clean.go
+++ b/go/cmd/dolt/commands/clean.go
@@ -105,7 +105,7 @@ func (cmd CleanCmd) Exec(ctx context.Context, commandStr string, args []string, 
 			firstParamDone = true
 		}
 	}
-	buffer.WriteString((")"))
+	buffer.WriteString(")")
 	query := buffer.String()
 
 	if len(params) > 0 {

--- a/go/cmd/dolt/commands/clean.go
+++ b/go/cmd/dolt/commands/clean.go
@@ -15,13 +15,14 @@
 package commands
 
 import (
+	"bytes"
 	"context"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
-	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
-	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
+	"github.com/gocraft/dbr/v2"
+	"github.com/gocraft/dbr/v2/dialect"
 )
 
 const (
@@ -64,34 +65,61 @@ func (cmd CleanCmd) ArgParser() *argparser.ArgParser {
 	return cli.CreateCleanArgParser()
 }
 
+func (cmd CleanCmd) RequiresRepo() bool {
+	return false
+}
+
 // Exec executes the command
 func (cmd CleanCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cli.CreateCleanArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, cleanDocContent, ap))
+	help, _ := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, cleanDocContent, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
-	if dEnv.IsLocked() {
-		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(env.ErrActiveServerLock.New(dEnv.LockFile())), help)
+	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	if err != nil {
+		cli.Println(err.Error())
+		return 1
+	}
+	if closeFunc != nil {
+		defer closeFunc()
 	}
 
-	roots, err := dEnv.Roots(ctx)
-	if err != nil {
-		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+	var params []interface{}
+
+	firstParamDone := false
+	var buffer bytes.Buffer
+	buffer.WriteString("CALL DOLT_CLEAN(")
+	if apr.Contains(cli.DryRunFlag) {
+		buffer.WriteString("\"--dry-run\"")
+		firstParamDone = true
+	}
+	if apr.NArg() > 0 {
+		// loop over apr.Args() and add them to the buffer
+		for i := 0; i < apr.NArg(); i++ {
+			if firstParamDone {
+				buffer.WriteString(", ")
+			}
+			buffer.WriteString("?")
+			params = append(params, apr.Arg(i))
+			firstParamDone = true
+		}
+	}
+	buffer.WriteString((")"))
+	query := buffer.String()
+
+	if len(params) > 0 {
+		query, err = dbr.InterpolateForDialect(query, params, dialect.MySQL)
+		if err != nil {
+			cli.Println(err.Error())
+			return 1
+		}
 	}
 
-	ws, err := dEnv.WorkingSet(ctx)
+	_, err = GetRowsForSql(queryist, sqlCtx, query)
 	if err != nil {
-		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+		cli.Println(err.Error())
+		return 1
 	}
 
-	roots, err = actions.CleanUntracked(ctx, roots, apr.Args, apr.Contains(DryrunCleanParam), false)
-	if err != nil {
-		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-	err = dEnv.UpdateWorkingSet(ctx, ws.WithWorkingRoot(roots.Working).WithStagedRoot(roots.Staged).ClearMerge())
-	if err != nil {
-		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-
-	return handleResetError(err, usage)
+	return 0
 }

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -121,7 +121,6 @@ var doltSubCommands = []cli.Command{
 }
 
 var commandsWithoutCliCtx = []cli.Command{
-	commands.CleanCmd{},
 	admin.Commands,
 	sqlserver.SqlServerCmd{VersionStr: Version},
 	sqlserver.SqlClientCmd{VersionStr: Version},

--- a/integration-tests/bats/helper/local-remote.bash
+++ b/integration-tests/bats/helper/local-remote.bash
@@ -81,7 +81,6 @@ SKIP_SERVER_TESTS=$(cat <<-EOM
 ~large-update.bats~
 ~remotes.bats~
 ~create-views.bats~
-~sql-clean.bats~
 ~blame.bats~
 ~multiple-tables.bats~
 ~json-new-fmt.bats~

--- a/integration-tests/bats/sql-clean.bats
+++ b/integration-tests/bats/sql-clean.bats
@@ -23,8 +23,7 @@ teardown() {
     # call proc
     dolt sql -q "create table test2 (pk int primary key)"
 
-    run dolt sql -q "call dolt_clean()"
-    [ $status -eq 0 ]
+    dolt sql -q "call dolt_clean()"
 
     run dolt status
     [ "$status" -eq 0 ]
@@ -33,8 +32,7 @@ teardown() {
 
     # call dproc
     dolt sql -q "create table test2 (pk int primary key)"
-    run dolt sql -q "call dclean('--dry-run')"
-    [ $status -eq 0 ]
+    dolt sql -q "call dclean('--dry-run')"
 
     run dolt status
     [ "$status" -eq 0 ]

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -795,7 +795,7 @@ SQL
     [[ $output =~ 'Revert "Commit ABCDEF"' ]] || false
 }
 
-@test "sql-local-remote: Ensure the dolt clean works for each mode" {
+@test "sql-local-remote: Ensure that dolt clean works for each mode" {
     dolt reset --hard
     dolt sql -q "create table tbl (pk int primary key)"
 

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -795,6 +795,44 @@ SQL
     [[ $output =~ 'Revert "Commit ABCDEF"' ]] || false
 }
 
+@test "sql-local-remote: Ensure the dolt clean works for each mode" {
+    dolt reset --hard
+    dolt sql -q "create table tbl (pk int primary key)"
+
+    start_sql_server altDB
+
+    run dolt --verbose-engine-setup clean --dry-run
+    [ $status -eq 0 ]
+    [[ $output =~ "starting remote mode" ]] || false
+
+    run dolt status
+    [ $status -eq 0 ]
+    [[ $output =~ "Untracked tables" ]] || false
+
+    dolt clean
+
+    run dolt status
+    [ $status -eq 0 ]
+    [[ $output =~ "nothing to commit, working tree clean" ]] || false
+
+    stop_sql_server 1
+
+    dolt sql -q "create table tbl (pk int primary key)"
+    run dolt --verbose-engine-setup clean --dry-run
+    [ $status -eq 0 ]
+    [[ $output =~ "starting local mode" ]] || false
+
+    run dolt status
+    [ $status -eq 0 ]
+    [[ $output =~ "Untracked tables" ]] || false
+
+    dolt clean
+
+    run dolt status
+    [ $status -eq 0 ]
+    [[ $output =~ "nothing to commit, working tree clean" ]] || false
+}
+
 @test "sql-local-remote: verify dolt tag behavior" {
   cd altDB
 


### PR DESCRIPTION
The dolt_clean() stored procedure pretty much does exactly what the CLI does, so this was an easy migration. What the `dolt clean` command doesn't have is tests, and neither does the dolt_clean() procedure for that matter. Unfortunately, the command experience itself isn't great, and differs significantly from `git clean` (https://github.com/dolthub/dolt/issues/6313). So instead of spending time on testing and a full rewrite of `dolt clean`, I'm making this small tactical change to do nothing but the migration.

Related: https://github.com/dolthub/dolt/issues/3922