### PR TITLE
Bug Fix: Merge with convergent schema changes

### DIFF
--- a/go/libraries/doltcore/merge/merge_schema.go
+++ b/go/libraries/doltcore/merge/merge_schema.go
@@ -367,14 +367,10 @@ func mergeColumns(format *storetypes.NomsBinFormat, ourCC, theirCC, ancCC *schem
 				oursChanged := !anc.Equals(*ours)
 				theirsChanged := !anc.Equals(*theirs)
 				if oursChanged && theirsChanged {
+					// If both columns changed in the same way, the modifications converge, so accept the column.
+					// If not, don't report a conflict, since this case is already handled in checkForColumnConflicts.
 					if ours.Equals(*theirs) {
 						mergedColumns = append(mergedColumns, *theirs)
-					} else {
-						conflicts = append(conflicts, ColConflict{
-							Kind:   NameCollision,
-							Ours:   *ours,
-							Theirs: *theirs,
-						})
 					}
 				} else if theirsChanged {
 					// In this case, only theirsChanged, so we need to check if moving from ours->theirs
@@ -405,15 +401,10 @@ func mergeColumns(format *storetypes.NomsBinFormat, ourCC, theirCC, ancCC *schem
 					mergedColumns = append(mergedColumns, *ours)
 				}
 			} else {
+				// If both columns changed in the same way, the modifications converge, so accept the column.
+				// If not, don't report a conflict, since this case is already handled in checkForColumnConflicts.
 				if ours.Equals(*theirs) {
-					// if the columns are identical, just use ours
 					mergedColumns = append(mergedColumns, *ours)
-				} else {
-					conflicts = append(conflicts, ColConflict{
-						Kind:   NameCollision,
-						Ours:   *ours,
-						Theirs: *theirs,
-					})
 				}
 			}
 		}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
@@ -4486,7 +4486,7 @@ var ThreeWayMergeWithSchemaChangeTestScripts = []MergeScriptTest{
 			},
 			{
 				Query:    "show create table t;",
-				Expected: []sql.Row{{"t", "CREATE TABLE `t` (\n  `pk` int NOT NULL,\n  `col1` int,\n  `col3` int,\n  PRIMARY KEY (`pk`),\n  KEY `idx1` (`col3`,`col1`),\n  CONSTRAINT `fk1` FOREIGN KEY (`col3`) REFERENCES `parent` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+				Expected: []sql.Row{{"t", "CREATE TABLE `t` (\n  `pk` int NOT NULL,\n  `col1` int NOT NULL,\n  `col3` int,\n  PRIMARY KEY (`pk`),\n  KEY `idx1` (`col3`,`col1`),\n  CONSTRAINT `fk1` FOREIGN KEY (`col3`) REFERENCES `parent` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},
 			{
 				Query:    "select * from t;",


### PR DESCRIPTION
There were a couple of gaps in our schema merge logic and testing when convergent schema changes happen on both sides of a merge. This change fixes an issue where columns could be omitted if they changed in exactly the same way, and also an issue with spurious FK conflicts if identical FKs were added on both sides of a merge. 