### PR TITLE
dolt checkout message

### DIFF
--- a/go/cmd/dolt/cli/messages.go
+++ b/go/cmd/dolt/cli/messages.go
@@ -1,0 +1,23 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+// This is a starting point for storing common messages. Doing this correctly would probably mean using language files
+// but that is overkill for the moment.
+const (
+	// Single variable - the name of the command. `dolt <command>` is how the commandString is formated in calls to the Exec method
+	// for dolt commands.
+	RemoteUnsupportedMsg = "%s can not currently be used when there is a local server running. Please stop your dolt sql-server and try again."
+)

--- a/go/cmd/dolt/commands/checkout.go
+++ b/go/cmd/dolt/commands/checkout.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 	"github.com/gocraft/dbr/v2"
 	"github.com/gocraft/dbr/v2/dialect"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	eventsapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"

--- a/go/cmd/dolt/commands/checkout.go
+++ b/go/cmd/dolt/commands/checkout.go
@@ -101,7 +101,7 @@ func (cmd CheckoutCmd) Exec(ctx context.Context, commandStr string, args []strin
 	if !ok {
 		// Currently checkout does not fully support remote connections. Prevent them from being used until we have better
 		// CLI session support.
-		msg := "dolt checkout can not currently be used when there is a local server running. Please stop your dolt sql-server and try again."
+		msg := fmt.Sprintf(cli.RemoteUnsupportedMsg, commandStr)
 		cli.Println(msg)
 		return 1
 	}

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -1033,3 +1033,16 @@ SQL
 
   [[ "$localCherryPickOutput" == "$remoteCherryPickOutput" ]] || false
 }
+
+@test "sql-local-remote: verify checkout will fail early when a server is running" {
+  cd altDB
+  dolt reset --hard
+  start_sql_server altDB
+
+  dolt branch br
+
+  run dolt checkout br
+  [ $status -eq 1 ]
+
+  [[ $output =~ "dolt checkout can not currently be used when there is a local server running. Please stop your dolt sql-server and try again." ]] || false
+}

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -20,6 +20,8 @@ CREATE TABLE table3 (pk int PRIMARY KEY);
 CREATE TABLE generated_foo (pk int PRIMARY KEY);
 SQL
   dolt add table1
+  # Note that we leave the table in a dirty state, which is useful to several tests, and harmless to others. For
+  # some, you need to ensure the repo is clean, and you should run `dolt reset --hard` at the beginning of the test.
   cd ..
 }
 
@@ -1036,7 +1038,7 @@ SQL
 
 @test "sql-local-remote: verify checkout will fail early when a server is running" {
   cd altDB
-  dolt reset --hard
+  dolt reset --hard # Ensure database is clean to start.
   start_sql_server altDB
 
   dolt branch br

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -232,6 +232,7 @@ get_commit_hash_at() {
 }
 
 @test "sql-local-remote: verify simple dolt checkout behavior." {
+    skip # currently checkout with a server is not supported
     start_sql_server altDB
     cd altDB
 


### PR DESCRIPTION
Currently the `dolt checkout` can't work with a server running on a local database. There are more details to be sorted out with session persistence in the server which aren't addressed yet.

The SQLEngine execution for using SQL as the backend is complete, but now we simply print a message stating that the user should stop the server.