### PR TITLE
Update unique constraint violations when rows are deleted

### DIFF
--- a/go/store/prolly/artifact_map.go
+++ b/go/store/prolly/artifact_map.go
@@ -316,7 +316,7 @@ type ArtifactsEditor struct {
 }
 
 // BuildArtifactKey builds a val.Tuple to be used to look up a value in this ArtifactsEditor. The key is composed
-// of |srcKey, the primary key fields from the original table, followed by the hash of the source root, |srcRootish|,
+// of |srcKey|, the primary key fields from the original table, followed by the hash of the source root, |srcRootish|,
 // and then the artifact type, |artType|.
 func (wr *ArtifactsEditor) BuildArtifactKey(_ context.Context, srcKey val.Tuple, srcRootish hash.Hash, artType ArtifactType) val.Tuple {
 	for i := 0; i < srcKey.Count(); i++ {

--- a/go/store/prolly/artifact_map.go
+++ b/go/store/prolly/artifact_map.go
@@ -409,6 +409,7 @@ func (wr *ArtifactsEditor) Delete(ctx context.Context, key val.Tuple) error {
 	return wr.mut.Delete(ctx, key)
 }
 
+// Has returns true if |key| is present in the underlying map being edited, including any in-flight edits.
 func (wr *ArtifactsEditor) Has(ctx context.Context, key val.Tuple) (bool, error) {
 	return wr.mut.Has(ctx, key)
 }


### PR DESCRIPTION
Issue https://github.com/dolthub/dolt/issues/6319 shows a case where our unique constraint checker reports false positives. This can happen when a row that is removed and a row that is inserted have duplicate values for columns that have a unique index declared over them. The root cause is that the deleted row is being incorrectly included in the rows checked for the unique constraint. 

I made two changes in this PR to fix this issue: 
- when row inserts or row deletes are processed by the unique constraint validator, it was previously not updating the data in it's index copy. This means if a row delete diff event comes in first, it wasn't getting removed from the index and when the row insert event comes in, it thinks there is a legitimate unique constraint violation with the deleted row. (Note that this local secondary index data is a copy of the secondary index data maintained by other parts of the prolly table merger. The primary and secondary index mergers were correctly updating the primary and secondary indexes on disk, but the copies held by the uniqueValidator were not being updated. It would be ideal if these mutable maps were shared by the various merge validators in the future.)
- when a row delete event is processed by the unique constraint validator, in addition to removing the row from the secondary index copy as described above, the code now looks in the artifact map, which is where violations are stored, and removes any unique constraint violations for this row, and if there is only one unique constraint violation left for the same unique values in the index, that last violation is also removed (i.e. it's not ever valid to have one row that violates a unique constraint). 

I briefly considered other ways to address this, such as processing all row deletion events first, and then resetting the row diff iterator to replay other diff events, but directly updating the violation artifacts felt like the most efficient approach, although the logic is a bit complicated. 