### PR TITLE
sql shell prompt can handle an empty DB name

### DIFF
--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -809,9 +809,8 @@ func execShell(sqlCtx *sql.Context, qryist cli.Queryist, format engine.PrintResu
 }
 
 // getDBFromSession returns the current database name for the session, handling all the errors along the way by printing
-// red error messages to the CLI. If there was an issue getting the db name, the second return value is false.
+// red error messages to the CLI, If there was an issue getting the db name, the second return value is false.
 func getDBFromSession(sqlCtx *sql.Context, qryist cli.Queryist) (db string, ok bool) {
-	db = "unknown"
 	_, resp, err := qryist.Query(sqlCtx, "select database()")
 	if err != nil {
 		cli.Println(color.RedString("Failure to get DB Name for session" + err.Error()))
@@ -827,11 +826,11 @@ func getDBFromSession(sqlCtx *sql.Context, qryist cli.Queryist) (db string, ok b
 		cli.Println(color.RedString("Failure to get DB Name for session" + err.Error()))
 		return db, false
 	}
-	if row[0] == nil || row[0].(string) == "" {
-		cli.Println(color.RedString("Empty Database name obtained" + err.Error()))
-		return db, false
+	if row[0] == nil {
+		db = ""
+	} else {
+		db = row[0].(string)
 	}
-	db = row[0].(string)
 	return db, true
 }
 

--- a/integration-tests/bats/sql-shell-empty-prompt.expect
+++ b/integration-tests/bats/sql-shell-empty-prompt.expect
@@ -1,0 +1,18 @@
+#!/usr/bin/expect -f
+
+set timeout 5
+spawn dolt sql
+
+expect "\r> " { send "select 1;\r"; }
+expect "+---+"
+expect "| 1 |"
+expect "+---+"
+expect "| 1 |"
+expect "+---+"
+expect "\r> " { send "exit;\r"; }
+
+expect eof
+
+set waitval [wait -i $spawn_id]
+set exval [lindex $waitval 3]
+exit $exval

--- a/integration-tests/bats/sql-shell.bats
+++ b/integration-tests/bats/sql-shell.bats
@@ -71,6 +71,19 @@ teardown() {
     $BATS_TEST_DIRNAME/sql-works-after-failing-query.expect
 }
 
+@test "sql-shell: empty DB in prompt is OK" {
+    skiponwindows "Need to install expect and make this script work on windows."
+integration-tests/bats/sql-shell.bats
+    if [ "$SQL_ENGINE" = "remote-engine" ]; then
+      skip "Presently sql command will not connect to remote server due to lack of lock file where there are not DBs."
+    else
+    # ignore common setup. Use an empty db with no server.
+    rm -rf .dolt
+    mkdir emptyDb
+    cd emptyDb
+    $BATS_TEST_DIRNAME/sql-shell-empty-prompt.expect
+}
+
 @test "sql-shell: delimiter" {
     skiponwindows "Need to install expect and make this script work on windows."
     mkdir doltsql

--- a/integration-tests/bats/sql-shell.bats
+++ b/integration-tests/bats/sql-shell.bats
@@ -73,10 +73,9 @@ teardown() {
 
 @test "sql-shell: empty DB in prompt is OK" {
     skiponwindows "Need to install expect and make this script work on windows."
-integration-tests/bats/sql-shell.bats
     if [ "$SQL_ENGINE" = "remote-engine" ]; then
       skip "Presently sql command will not connect to remote server due to lack of lock file where there are not DBs."
-    else
+    fi
     # ignore common setup. Use an empty db with no server.
     rm -rf .dolt
     mkdir emptyDb

--- a/integration-tests/bats/sql-works-after-failing-query.expect
+++ b/integration-tests/bats/sql-works-after-failing-query.expect
@@ -1,4 +1,4 @@
-#!/usr/bin/expect
+#!/usr/bin/expect -f
 
 set timeout 1
 spawn dolt sql
@@ -15,3 +15,4 @@ expect {
   "pid 0 is already in use" { exit 1 }
   " 1 " { exit 0 }
 }
+


### PR DESCRIPTION
Currently, if you were to run `select 1` in `dolt sql` session which was not connected to any database, it would result in a panic. This fixes that, and adds a test so we don't make this mistake again.