### PR TITLE
Bug fix: Encode binary values in hex for SQL patch statements

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -119,57 +119,21 @@ func TestSingleScript(t *testing.T) {
 
 	var scripts = []queries.ScriptTest{
 		{
-			Name: "delete all rows in table in all branches",
+			// TODO: Move these to the dolt_patch enginetests
+			Name: "https://github.com/dolthub/dolt/issues/6350",
 			SetUpScript: []string{
-				"create table t (a int primary key auto_increment, b int)",
-				"call dolt_add('.')",
-				"call dolt_commit('-am', 'empty table')",
-				"call dolt_branch('branch1')",
-				"call dolt_branch('branch2')",
-				"insert into t (b) values (1), (2)",
-				"call dolt_commit('-am', 'two values on main')",
-				"call dolt_checkout('branch1')",
-				"insert into t (b) values (3), (4)",
-				"call dolt_commit('-am', 'two values on branch1')",
-				"call dolt_checkout('branch2')",
-				"insert into t (b) values (5), (6)",
-				"call dolt_checkout('main')",
+				"create table t (pk varbinary(16) primary key, c1  binary(16));",
+				"insert into t values (0x012345, NULL), (0x054321, binary 'efg_!4');",
+				"call dolt_commit('-Am', 'new table with binary pk')",
 			},
 			Assertions: []queries.ScriptTestAssertion{
 				{
-					Query:    "delete from t",
-					Expected: []sql.Row{{gmstypes.NewOkResult(2)}},
-				},
-				{
-					Query:    "delete from `mydb/branch1`.t",
-					Expected: []sql.Row{{gmstypes.NewOkResult(2)}},
-				},
-				{
-					Query:    "delete from `mydb/branch2`.t",
-					Expected: []sql.Row{{gmstypes.NewOkResult(2)}},
-				},
-				{
-					Query:            "alter table `mydb/branch1`.t auto_increment = 1",
-					SkipResultsCheck: true,
-				},
-				{
-					Query:            "alter table `mydb/branch2`.t auto_increment = 1",
-					SkipResultsCheck: true,
-				},
-				{
-					Query:            "alter table t auto_increment = 1",
-					SkipResultsCheck: true,
-				},
-				{
-					// empty tables, start at 1
-					Query:    "insert into t (b) values (7), (8)",
-					Expected: []sql.Row{{gmstypes.OkResult{RowsAffected: 2, InsertID: 1}}},
-				},
-				{
-					Query: "select * from t order by a",
+					// TODO: Dolt diff will have a similar issue; add BATS tests for sql diff patch output through the CLI
+					Query: "select statement from dolt_patch('HEAD~', 'HEAD', 't');",
 					Expected: []sql.Row{
-						{1, 7},
-						{2, 8},
+						{"CREATE TABLE `t` (\n  `pk` varbinary(16) NOT NULL,\n  `c1` binary(16),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;"},
+						{"INSERT INTO `t` (`pk`,`c1`) VALUES (0x012345,NULL);"},
+						{"INSERT INTO `t` (`pk`,`c1`) VALUES (0x054321,0x6566675f213400000000000000000000);"},
 					},
 				},
 			},

--- a/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
@@ -534,13 +534,13 @@ func interfaceValueAsSqlString(ti typeinfo.TypeInfo, value interface{}) (string,
 		return singleQuote + str + singleQuote, nil
 	case typeinfo.DatetimeTypeIdentifier:
 		return singleQuote + str + singleQuote, nil
-	case typeinfo.InlineBlobTypeIdentifier, typeinfo.BlobStringTypeIdentifier, typeinfo.VarBinaryTypeIdentifier:
+	case typeinfo.InlineBlobTypeIdentifier, typeinfo.VarBinaryTypeIdentifier:
 		bytes, ok := value.([]byte)
 		if !ok {
 			return "", fmt.Errorf("unexpected type for binary value: %T", value)
 		}
 		return hexEncodeBytes(bytes), nil
-	case typeinfo.JSONTypeIdentifier, typeinfo.EnumTypeIdentifier, typeinfo.SetTypeIdentifier:
+	case typeinfo.JSONTypeIdentifier, typeinfo.EnumTypeIdentifier, typeinfo.SetTypeIdentifier, typeinfo.BlobStringTypeIdentifier:
 		return quoteAndEscapeString(str), nil
 	case typeinfo.VarStringTypeIdentifier:
 		s, ok := value.(string)

--- a/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
@@ -535,11 +535,14 @@ func interfaceValueAsSqlString(ti typeinfo.TypeInfo, value interface{}) (string,
 	case typeinfo.DatetimeTypeIdentifier:
 		return singleQuote + str + singleQuote, nil
 	case typeinfo.InlineBlobTypeIdentifier, typeinfo.VarBinaryTypeIdentifier:
-		bytes, ok := value.([]byte)
-		if !ok {
-			return "", fmt.Errorf("unexpected type for binary value: %T", value)
+		switch v := value.(type) {
+		case []byte:
+			return hexEncodeBytes(v), nil
+		case string:
+			return hexEncodeBytes([]byte(v)), nil
+		default:
+			return "", fmt.Errorf("unexpected type for binary value: %T (SQL type info: %v)", value, ti)
 		}
-		return hexEncodeBytes(bytes), nil
 	case typeinfo.JSONTypeIdentifier, typeinfo.EnumTypeIdentifier, typeinfo.SetTypeIdentifier, typeinfo.BlobStringTypeIdentifier:
 		return quoteAndEscapeString(str), nil
 	case typeinfo.VarStringTypeIdentifier:


### PR DESCRIPTION
Current SQL formatting code converts binary values to strings, which won't round-trip back to the database correctly. This PR changes binary values to be hex-encoded. 

Fixes https://github.com/dolthub/dolt/issues/6350