### PR TITLE
add warning message for unmigrated cli commands

### DIFF
--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -266,14 +266,6 @@ func (cmd SqlCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 func sqlHandleVErrAndExitCode(queryist cli.Queryist, verr errhand.VerboseError, usage cli.UsagePrinter) int {
 	if verr != nil {
 		if msg := verr.Verbose(); strings.TrimSpace(msg) != "" {
-			if _, ok := queryist.(*engine.SqlEngine); !ok {
-				// We are in a context where we are attempting to connect to a remote database. These errors
-				// are unstructured, so we add some additional context around them.
-				remoteUnsupportedMsg := `This command has not yet been migrated to function in a remote context. Please shut down your 
-server and try again. Or, reach out to us on discord (https://discord.gg/gqr7K4VNKe) if you need help.`
-				cli.PrintErrln(remoteUnsupportedMsg)
-				msg = fmt.Sprintf("A local server is running, and dolt is failing to connect. Error connecting to remote database: \"%s\".\n", msg)
-			}
 			cli.PrintErrln(msg)
 		}
 

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -269,11 +269,9 @@ func sqlHandleVErrAndExitCode(queryist cli.Queryist, verr errhand.VerboseError, 
 			if _, ok := queryist.(*engine.SqlEngine); !ok {
 				// We are in a context where we are attempting to connect to a remote database. These errors
 				// are unstructured, so we add some additional context around them.
-				tmpMsg := `You've encountered a new behavior in dolt which is not fully documented yet.
-A local dolt server is using your dolt data directory, and in an attempt to service your request, we are attempting to 
-connect to it. That has failed. You should stop the server, or reach out to @macneale on https://discord.gg/gqr7K4VNKe
-for help.`
-				cli.PrintErrln(tmpMsg)
+				remoteUnsupportedMsg := `This command has not yet been migrated to function in a remote context. Please shut down your 
+server and try again. Or, reach out to us on discord (https://discord.gg/gqr7K4VNKe) if you need help.`
+				cli.PrintErrln(remoteUnsupportedMsg)
 				msg = fmt.Sprintf("A local server is running, and dolt is failing to connect. Error connecting to remote database: \"%s\".\n", msg)
 			}
 			cli.PrintErrln(msg)

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -562,12 +562,13 @@ func runMain() int {
 	} else {
 		if args[0] != subcommandName {
 			if supportsGlobalArgs(subcommandName) {
-				cli.PrintErrln(color.RedString(`Global arguments are not supported for this command as it has not yet 
-been migrated to function in a remote context. Please shut down your server and try again. Or, reach out to us on discord 
-(https://discord.gg/gqr7K4VNKe) if you need help.`))
+				cli.PrintErrln(
+					`Global arguments are not supported for this command as it has not yet been migrated to function in a remote context. 
+If you're interested in running this command against a remote host, hit us up on discord (https://discord.gg/gqr7K4VNKe).`)
 			} else {
-				cli.PrintErrln(color.RedString(`This command does not support global arguments. Please try again without
-the global arguments or check the docs for questions about usage.`))
+				cli.PrintErrln(
+					`This command does not support global arguments. Please try again without the global arguments 
+or check the docs for questions about usage.`)
 			}
 			return 1
 		}

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -537,7 +537,7 @@ func runMain() int {
 			return 1
 		}
 	} else {
-		if apr.NArg() > 0 {
+		if args[0] != subcommandName {
 			cli.PrintErrln(color.RedString(`Global arguments are not supported for this command as it has not yet 
 been migrated to function in a remote context. Please shut down your server and try again. Or, reach out to us on discord 
 (https://discord.gg/gqr7K4VNKe) if you need help.`))

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -536,6 +536,13 @@ func runMain() int {
 			cli.PrintErrln(color.RedString("Unexpected Error: %v", err))
 			return 1
 		}
+	} else {
+		if apr.NArg() > 0 {
+			cli.PrintErrln(color.RedString(`Global arguments are not supported for this command as it has not yet 
+been migrated to function in a remote context. Please shut down your server and try again. Or, reach out to us on discord 
+(https://discord.gg/gqr7K4VNKe) if you need help.`))
+			return 1
+		}
 	}
 
 	ctx, stop := context.WithCancel(ctx)

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -152,8 +152,31 @@ var commandsWithoutCliCtx = []cli.Command{
 	&commands.Assist{},
 }
 
+var commandsWithoutGlobalArgSupport = []cli.Command{
+	commands.InitCmd{},
+	commands.CloneCmd{},
+	docscmds.Commands,
+	commands.MigrateCmd{},
+	commands.ReadTablesCmd{},
+	commands.LoginCmd{},
+	credcmds.Commands,
+	sqlserver.SqlServerCmd{VersionStr: Version},
+	sqlserver.SqlClientCmd{VersionStr: Version},
+	commands.VersionCmd{VersionStr: Version},
+	commands.ConfigCmd{},
+}
+
 func initCliContext(commandName string) bool {
 	for _, command := range commandsWithoutCliCtx {
+		if command.Name() == commandName {
+			return false
+		}
+	}
+	return true
+}
+
+func supportsGlobalArgs(commandName string) bool {
+	for _, command := range commandsWithoutGlobalArgSupport {
 		if command.Name() == commandName {
 			return false
 		}
@@ -538,9 +561,14 @@ func runMain() int {
 		}
 	} else {
 		if args[0] != subcommandName {
-			cli.PrintErrln(color.RedString(`Global arguments are not supported for this command as it has not yet 
+			if supportsGlobalArgs(subcommandName) {
+				cli.PrintErrln(color.RedString(`Global arguments are not supported for this command as it has not yet 
 been migrated to function in a remote context. Please shut down your server and try again. Or, reach out to us on discord 
 (https://discord.gg/gqr7K4VNKe) if you need help.`))
+			} else {
+				cli.PrintErrln(color.RedString(`This command does not support global arguments. Please try again without
+the global arguments or check the docs for questions about usage.`))
+			}
 			return 1
 		}
 	}

--- a/integration-tests/bats/no-repo.bats
+++ b/integration-tests/bats/no-repo.bats
@@ -358,10 +358,10 @@ NOT_VALID_REPO_ERROR="The current directory is not a valid dolt repository."
 }
 
 @test "no-repo: check that we correctly parse args when connecting with a username that matches a subcommand" {
-    run dolt --user ls version
+    run dolt --user ls sql -q "select 1"
 
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "version" ]] || false
+    [[ "$output" =~ "1" ]] || false
 }
 
 @test "no-repo: check that we error on commands with no subcommand" {

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -1095,3 +1095,11 @@ SQL
     [ $status -eq 1 ]
     [[ "$output" =~ "Global arguments are not supported for this command" ]]
 }
+
+@test "sql-local-remote: verify commands without global arg support will fail with warning" {
+    cd altDB
+    start_sql_server altDB
+    run dolt --user dolt version
+    [ $status -eq 1 ]
+    [[ "$output" =~ "This command does not support global arguments." ]]
+}

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -1087,3 +1087,11 @@ SQL
 
   [[ $output =~ "dolt checkout can not currently be used when there is a local server running. Please stop your dolt sql-server and try again." ]] || false
 }
+
+@test "sql-local-remote: verify unmigrated command will fail with warning" {
+    cd altDB
+    start_sql_server altDB
+    run dolt --user dolt log
+    [ $status -eq 1 ]
+    [[ "$output" =~ "Global arguments are not supported for this command" ]]
+}


### PR DESCRIPTION
Adds warning message for unmigrated cli commands when they are attempted to be used remotely.