### PR TITLE
Allow `--` to escape arg parsing

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -2815,6 +2815,32 @@ var DoltBranchScripts = []queries.ScriptTest{
 			},
 		},
 	},
+	{
+		// https://github.com/dolthub/dolt/issues/6001
+		Name: "-- allows escaping arg parsing to create/delete branch names that look like flags",
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "select count(*) from dolt_branches where name='-b';",
+				Expected: []sql.Row{{0}},
+			},
+			{
+				Query:    "call dolt_branch('--', '-b');",
+				Expected: []sql.Row{{0}},
+			},
+			{
+				Query:    "select count(*) from dolt_branches where name='-b';",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				Query:    "call dolt_branch('-d', '-f', '--', '-b');",
+				Expected: []sql.Row{{0}},
+			},
+			{
+				Query:    "select count(*) from dolt_branches where name='-b';",
+				Expected: []sql.Row{{0}},
+			},
+		},
+	},
 }
 
 var DoltReset = []queries.ScriptTest{

--- a/go/libraries/utils/argparser/parser.go
+++ b/go/libraries/utils/argparser/parser.go
@@ -305,13 +305,20 @@ func (ap *ArgParser) ParseGlobalArgs(args []string) (apr *ArgParseResults, remai
 func (ap *ArgParser) Parse(args []string) (*ArgParseResults, error) {
 	positionalArgs := make([]string, 0, 16)
 	namedArgs := make(map[string]string)
+	onlyPositionalArgsLeft := false
 
 	index := 0
 	for ; index < len(args); index++ {
 		arg := args[index]
 
-		if len(arg) == 0 || arg[0] != '-' || arg == "--" { // empty strings should get passed through like other naked words
+		// empty strings should get passed through like other naked words
+		if len(arg) == 0 || arg[0] != '-' || onlyPositionalArgsLeft {
 			positionalArgs = append(positionalArgs, arg)
+			continue
+		}
+
+		if arg == "--" {
+			onlyPositionalArgsLeft = true
 			continue
 		}
 

--- a/integration-tests/bats/branch.bats
+++ b/integration-tests/bats/branch.bats
@@ -220,3 +220,21 @@ teardown() {
     [ "$status" -ne 0 ]
     [[ "$output" =~ "--remote/-r can only be supplied when listing or deleting branches, not when creating branches" ]] || false
 }
+
+@test "branch: -- escapes arg parsing" {
+    # use -- to turn off arg parsing for the remaining arguments and treat
+    # them all as position arguments
+    dolt branch -- -b
+
+    # verify that the '-b' branch was created successfully
+    run dolt sql -r csv -q "select count(*) from dolt_branches where name='-b';"
+    [ $status -eq 0 ]
+    [[ $output =~ "1" ]] || false
+
+    # verify that we can use -- to delete the -b branch
+    dolt branch -d -f  -- -b
+    run dolt sql -r csv -q "select count(*) from dolt_branches where name='-b';"
+    [ $status -eq 0 ]
+    [[ $output =~ "0" ]] || false
+}
+


### PR DESCRIPTION
Fixes: https://github.com/dolthub/dolt/issues/6001