### PR TITLE
Bug fix: Commits created with `cherry-pick` should only have one parent commit

### DIFF
--- a/go/gen/fb/serial/workingset.go
+++ b/go/gen/fb/serial/workingset.go
@@ -370,7 +370,19 @@ func (rcv *MergeState) UnmergableTablesLength() int {
 	return 0
 }
 
-const MergeStateNumFields = 4
+func (rcv *MergeState) IsCherryPick() bool {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(12))
+	if o != 0 {
+		return rcv._tab.GetBool(o + rcv._tab.Pos)
+	}
+	return false
+}
+
+func (rcv *MergeState) MutateIsCherryPick(n bool) bool {
+	return rcv._tab.MutateBoolSlot(12, n)
+}
+
+const MergeStateNumFields = 5
 
 func MergeStateStart(builder *flatbuffers.Builder) {
 	builder.StartObject(MergeStateNumFields)
@@ -395,6 +407,9 @@ func MergeStateAddUnmergableTables(builder *flatbuffers.Builder, unmergableTable
 }
 func MergeStateStartUnmergableTablesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
+}
+func MergeStateAddIsCherryPick(builder *flatbuffers.Builder, isCherryPick bool) {
+	builder.PrependBoolSlot(4, isCherryPick, false)
 }
 func MergeStateEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()

--- a/go/libraries/doltcore/doltdb/workingset.go
+++ b/go/libraries/doltcore/doltdb/workingset.go
@@ -244,6 +244,18 @@ func (ws *WorkingSet) MergeActive() bool {
 	return ws.mergeState != nil
 }
 
+// MergeCommitParents returns true if there is an active merge in progress and
+// the recorded commit being merged into the active branch should be included as
+// a second parent of the created commit. This is the expected behavior for a
+// normal merge, but not for other pseudo-merges, like cherry-picks or reverts,
+// where the created commit should only have one parent.
+func (ws *WorkingSet) MergeCommitParents() bool {
+	if !ws.MergeActive() {
+		return false
+	}
+	return ws.MergeState().IsCherryPick() == false
+}
+
 func (ws WorkingSet) Meta() *datas.WorkingSetMeta {
 	return ws.meta
 }

--- a/go/libraries/doltcore/doltdb/workingset.go
+++ b/go/libraries/doltcore/doltdb/workingset.go
@@ -317,6 +317,7 @@ func newWorkingSet(ctx context.Context, name string, vrw types.ValueReadWriter, 
 			commitSpecStr:    commitSpec,
 			preMergeWorking:  preMergeWorkingRoot,
 			unmergableTables: unmergableTables,
+			IsCherryPick:     dsws.MergeState.IsCherryPick,
 		}
 	}
 
@@ -391,7 +392,7 @@ func (ws *WorkingSet) writeValues(ctx context.Context, db *DoltDB) (
 			return types.Ref{}, types.Ref{}, nil, err
 		}
 
-		mergeState, err = datas.NewMergeState(ctx, db.vrw, preMergeWorking, dCommit, ws.mergeState.commitSpecStr, ws.mergeState.unmergableTables)
+		mergeState, err = datas.NewMergeState(ctx, db.vrw, preMergeWorking, dCommit, ws.mergeState.commitSpecStr, ws.mergeState.unmergableTables, ws.mergeState.IsCherryPick)
 		if err != nil {
 			return types.Ref{}, types.Ref{}, nil, err
 		}

--- a/go/libraries/doltcore/doltdb/workingset.go
+++ b/go/libraries/doltcore/doltdb/workingset.go
@@ -35,6 +35,7 @@ type MergeState struct {
 	commitSpecStr    string
 	preMergeWorking  *RootValue
 	unmergableTables []string
+	IsCherryPick     bool
 }
 
 // todo(andy): this might make more sense in pkg merge
@@ -193,6 +194,18 @@ func (ws WorkingSet) StartMerge(commit *Commit, commitSpecStr string) *WorkingSe
 	return &ws
 }
 
+// TODO: godocs!
+func (ws WorkingSet) StartCherryPick(commit *Commit, commitSpecStr string) *WorkingSet {
+	ws.mergeState = &MergeState{
+		commit:          commit,
+		commitSpecStr:   commitSpecStr,
+		preMergeWorking: ws.workingRoot,
+		IsCherryPick:    true,
+	}
+
+	return &ws
+}
+
 func (ws WorkingSet) AbortMerge() *WorkingSet {
 	ws.workingRoot = ws.mergeState.PreMergeWorkingRoot()
 	ws.stagedRoot = ws.workingRoot
@@ -345,7 +358,6 @@ func (ws *WorkingSet) writeValues(ctx context.Context, db *DoltDB) (
 	mergeState *datas.MergeState,
 	err error,
 ) {
-
 	if ws.stagedRoot == nil || ws.workingRoot == nil {
 		return types.Ref{}, types.Ref{}, nil, fmt.Errorf("StagedRoot and workingRoot must be set. This is a bug.")
 	}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_cherry_pick.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_cherry_pick.go
@@ -287,7 +287,7 @@ func cherryPick(ctx *sql.Context, dSess *dsess.DoltSession, roots doltdb.Roots, 
 			if err != nil {
 				return nil, "", err
 			}
-			newWorkingSet := ws.StartMerge(cherryCommit, cherryStr)
+			newWorkingSet := ws.StartCherryPick(cherryCommit, cherryStr)
 			err = dSess.SetWorkingSet(ctx, dbName, newWorkingSet)
 			if err != nil {
 				return nil, "", err

--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -657,7 +657,7 @@ func (d *DoltSession) newPendingCommit(ctx *sql.Context, branchState *branchStat
 	}
 
 	var mergeParentCommits []*doltdb.Commit
-	if branchState.WorkingSet().MergeActive() && branchState.WorkingSet().MergeState().IsCherryPick() == false {
+	if branchState.WorkingSet().MergeCommitParents() {
 		mergeParentCommits = []*doltdb.Commit{branchState.WorkingSet().MergeState().Commit()}
 	} else if props.Amend {
 		numParentsHeadForAmend := headCommit.NumParents()

--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -657,7 +657,7 @@ func (d *DoltSession) newPendingCommit(ctx *sql.Context, branchState *branchStat
 	}
 
 	var mergeParentCommits []*doltdb.Commit
-	if branchState.WorkingSet().MergeActive() && branchState.WorkingSet().MergeState().IsCherryPick == false {
+	if branchState.WorkingSet().MergeActive() && branchState.WorkingSet().MergeState().IsCherryPick() == false {
 		mergeParentCommits = []*doltdb.Commit{branchState.WorkingSet().MergeState().Commit()}
 	} else if props.Amend {
 		numParentsHeadForAmend := headCommit.NumParents()

--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -657,7 +657,7 @@ func (d *DoltSession) newPendingCommit(ctx *sql.Context, branchState *branchStat
 	}
 
 	var mergeParentCommits []*doltdb.Commit
-	if branchState.WorkingSet().MergeActive() {
+	if branchState.WorkingSet().MergeActive() && branchState.WorkingSet().MergeState().IsCherryPick == false {
 		mergeParentCommits = []*doltdb.Commit{branchState.WorkingSet().MergeState().Commit()}
 	} else if props.Amend {
 		numParentsHeadForAmend := headCommit.NumParents()

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -4645,6 +4645,15 @@ var DoltCherryPickTests = []queries.ScriptTest{
 				Query:    "select * from t;",
 				Expected: []sql.Row{{0}},
 			},
+			{
+				Query:    "call dolt_commit('-am', 'committing cherry-pick');",
+				Expected: []sql.Row{{doltCommit}},
+			},
+			{
+				// Assert that our new commit only has one parent (i.e. not a merge commit)
+				Query:    "select count(*) from dolt_commit_ancestors where commit_hash = hashof('HEAD');",
+				Expected: []sql.Row{{1}},
+			},
 		},
 	},
 	{

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -4348,6 +4348,11 @@ var DoltCherryPickTests = []queries.ScriptTest{
 				Query:    "SELECT * FROM t order by pk;",
 				Expected: []sql.Row{{1, "one"}, {2, "two"}},
 			},
+			{
+				// Assert that our new commit only has one parent (i.e. not a merge commit)
+				Query:    "select count(*) from dolt_commit_ancestors where commit_hash = hashof('HEAD');",
+				Expected: []sql.Row{{1}},
+			},
 		},
 	},
 	{
@@ -4394,6 +4399,11 @@ var DoltCherryPickTests = []queries.ScriptTest{
 			{
 				Query:    "call dolt_cherry_pick(@commit1);",
 				Expected: []sql.Row{{doltCommit, 0, 0, 0}},
+			},
+			{
+				// Assert that our new commit only has one parent (i.e. not a merge commit)
+				Query:    "select count(*) from dolt_commit_ancestors where commit_hash = hashof('HEAD');",
+				Expected: []sql.Row{{1}},
 			},
 			{
 				Query:    "SHOW TABLES;",
@@ -4694,6 +4704,15 @@ var DoltCherryPickTests = []queries.ScriptTest{
 			{
 				Query:    `SELECT * FROM t;`,
 				Expected: []sql.Row{{1, "ein"}},
+			},
+			{
+				Query:    "call dolt_commit('-am', 'committing cherry-pick');",
+				Expected: []sql.Row{{doltCommit}},
+			},
+			{
+				// Assert that our new commit only has one parent (i.e. not a merge commit)
+				Query:    "select count(*) from dolt_commit_ancestors where commit_hash = hashof('HEAD');",
+				Expected: []sql.Row{{1}},
 			},
 		},
 	},

--- a/go/serial/workingset.fbs
+++ b/go/serial/workingset.fbs
@@ -38,6 +38,8 @@ table MergeState {
   from_commit_spec_str:string;
 
   unmergable_tables:[string];
+
+  is_cherry_pick:bool;
 }
 
 // KEEP THIS IN SYNC WITH fileidentifiers.go

--- a/go/store/datas/dataset.go
+++ b/go/store/datas/dataset.go
@@ -165,6 +165,7 @@ type MergeState struct {
 	fromCommitAddr      *hash.Hash
 	fromCommitSpec      string
 	unmergableTables    []string
+	IsCherryPick        bool
 
 	nomsMergeStateRef *types.Ref
 	nomsMergeState    *types.Struct

--- a/go/store/datas/dataset.go
+++ b/go/store/datas/dataset.go
@@ -165,7 +165,7 @@ type MergeState struct {
 	fromCommitAddr      *hash.Hash
 	fromCommitSpec      string
 	unmergableTables    []string
-	IsCherryPick        bool
+	isCherryPick        bool
 
 	nomsMergeStateRef *types.Ref
 	nomsMergeState    *types.Struct
@@ -255,6 +255,13 @@ func (ms *MergeState) FromCommitSpec(ctx context.Context, vr types.ValueReader) 
 	}
 
 	return string(commitSpecStr.(types.String)), nil
+}
+
+func (ms *MergeState) IsCherryPick(_ context.Context, vr types.ValueReader) (bool, error) {
+	if vr.Format().UsesFlatbuffers() {
+		return ms.isCherryPick, nil
+	}
+	return false, nil
 }
 
 func (ms *MergeState) UnmergableTables(ctx context.Context, vr types.ValueReader) ([]string, error) {
@@ -382,7 +389,7 @@ func (h serialWorkingSetHead) HeadWorkingSet() (*WorkingSetHead, error) {
 		for i := range ret.MergeState.unmergableTables {
 			ret.MergeState.unmergableTables[i] = string(mergeState.UnmergableTables(i))
 		}
-		ret.MergeState.IsCherryPick = mergeState.IsCherryPick()
+		ret.MergeState.isCherryPick = mergeState.IsCherryPick()
 	}
 	return &ret, nil
 }

--- a/go/store/datas/dataset.go
+++ b/go/store/datas/dataset.go
@@ -382,6 +382,7 @@ func (h serialWorkingSetHead) HeadWorkingSet() (*WorkingSetHead, error) {
 		for i := range ret.MergeState.unmergableTables {
 			ret.MergeState.unmergableTables[i] = string(mergeState.UnmergableTables(i))
 		}
+		ret.MergeState.IsCherryPick = mergeState.IsCherryPick()
 	}
 	return &ret, nil
 }

--- a/go/store/datas/workingset.go
+++ b/go/store/datas/workingset.go
@@ -202,6 +202,7 @@ func NewMergeState(
 	commit *Commit,
 	commitSpecStr string,
 	unmergableTables []string,
+	isCherryPick bool,
 ) (*MergeState, error) {
 	if vrw.Format().UsesFlatbuffers() {
 		ms := &MergeState{
@@ -209,6 +210,7 @@ func NewMergeState(
 			fromCommitAddr:      new(hash.Hash),
 			fromCommitSpec:      commitSpecStr,
 			unmergableTables:    unmergableTables,
+			IsCherryPick:        isCherryPick,
 		}
 		*ms.preMergeWorkingAddr = preMergeWorking.TargetHash()
 		*ms.fromCommitAddr = commit.Addr()
@@ -223,6 +225,7 @@ func NewMergeState(
 			return nil, err
 		}
 		return &MergeState{
+			IsCherryPick:      isCherryPick,
 			nomsMergeStateRef: &ref,
 			nomsMergeState:    &v,
 		}, nil

--- a/go/store/datas/workingset.go
+++ b/go/store/datas/workingset.go
@@ -168,7 +168,7 @@ func workingset_flatbuffer(working hash.Hash, staged *hash.Hash, mergeState *Mer
 		serial.MergeStateAddFromCommitAddr(builder, fromaddroff)
 		serial.MergeStateAddFromCommitSpecStr(builder, fromspecoff)
 		serial.MergeStateAddUnmergableTables(builder, unmergableoff)
-		serial.MergeStateAddIsCherryPick(builder, mergeState.IsCherryPick)
+		serial.MergeStateAddIsCherryPick(builder, mergeState.isCherryPick)
 		mergeStateOff = serial.MergeStateEnd(builder)
 	}
 
@@ -211,7 +211,7 @@ func NewMergeState(
 			fromCommitAddr:      new(hash.Hash),
 			fromCommitSpec:      commitSpecStr,
 			unmergableTables:    unmergableTables,
-			IsCherryPick:        isCherryPick,
+			isCherryPick:        isCherryPick,
 		}
 		*ms.preMergeWorkingAddr = preMergeWorking.TargetHash()
 		*ms.fromCommitAddr = commit.Addr()
@@ -226,7 +226,7 @@ func NewMergeState(
 			return nil, err
 		}
 		return &MergeState{
-			IsCherryPick:      isCherryPick,
+			isCherryPick:      isCherryPick,
 			nomsMergeStateRef: &ref,
 			nomsMergeState:    &v,
 		}, nil

--- a/go/store/datas/workingset.go
+++ b/go/store/datas/workingset.go
@@ -168,6 +168,7 @@ func workingset_flatbuffer(working hash.Hash, staged *hash.Hash, mergeState *Mer
 		serial.MergeStateAddFromCommitAddr(builder, fromaddroff)
 		serial.MergeStateAddFromCommitSpecStr(builder, fromspecoff)
 		serial.MergeStateAddUnmergableTables(builder, unmergableoff)
+		serial.MergeStateAddIsCherryPick(builder, mergeState.IsCherryPick)
 		mergeStateOff = serial.MergeStateEnd(builder)
 	}
 

--- a/proto/README.md
+++ b/proto/README.md
@@ -6,7 +6,9 @@ Protobuf message and service definitions.
 Dependencies
 ------------
 
-Dependencies are git submodules in //proto/third_party.
+Dependencies are git submodules in //proto/third_party. Make sure you have all these
+submodules synced. If not, you can sync them initially with:
+  git submodule update --init 
 
 * You need to build protoc in //proto/third_party/protobuf by running `bazel
   build //:protoc` from that directory. Currently tested with bazel version 3.1.0.


### PR DESCRIPTION
When a cherry-pick requires conflict resolution, we set MergeState metadata in the working set to mark that a merge is in progress. `dolt commit` sees this metadata and incorrectly records the cherry-picked commit as a parent of the new, created commit. This PR fixes this, so that commits created by cherry-pick always have only one parent. To do this, we record an extra flag in MergeState that the current merge is a cherry-pick. 