### PR TITLE
fix panic in `dolt_history_<table>`

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -2114,6 +2114,22 @@ ORDER BY
 					{300, doltCommit},
 				},
 			},
+			{
+				Query: `
+SELECT z
+FROM xyz
+WHERE z IN (
+  SELECT z
+  FROM dolt_history_xyz
+  LEFT JOIN dolt_commits
+  ON dolt_history_xyz.commit_hash = dolt_commits.commit_hash
+);;`,
+				Expected: []sql.Row{
+					{100},
+					{200},
+					{300},
+				},
+			},
 		},
 	},
 }

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -2028,7 +2028,7 @@ var HistorySystemTableScriptTests = []queries.ScriptTest{
 		},
 	},
 	{
-		Name: "dolt_history table primary key",
+		Name: "dolt_history table primary key with join",
 		SetUpScript: []string{
 			"create table xyz (x int, y int, z int, primary key(x, y));",
 			"call dolt_add('.');",
@@ -2042,36 +2042,76 @@ var HistorySystemTableScriptTests = []queries.ScriptTest{
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
-				Query: "select x, y, z from dolt_history_xyz",
+
+				Query: `
+SELECT
+  dolt_history_xyz.x as x,
+  dolt_history_xyz.y as y,
+  dolt_history_xyz.z as z,
+  dolt_commits.commit_hash as comm
+FROM
+  dolt_history_xyz
+  LEFT JOIN
+  dolt_commits
+  ON
+  dolt_history_xyz.commit_hash = dolt_commits.commit_hash
+ORDER BY
+  dolt_history_xyz.x,
+  dolt_history_xyz.y,
+  dolt_history_xyz.z;`,
 				Expected: []sql.Row{
-					{0, 1, 100},
-					{2, 3, 200},
-					{4, 5, 300},
-					{0, 1, 100},
-					{0, 1, 100},
-					{2, 3, 200},
+					{0, 1, 100, doltCommit},
+					{0, 1, 100, doltCommit},
+					{0, 1, 100, doltCommit},
+					{2, 3, 200, doltCommit},
+					{2, 3, 200, doltCommit},
+					{4, 5, 300, doltCommit},
 				},
 			},
 			{
-				Query: "select y, z from dolt_history_xyz",
+				Query: `
+SELECT
+  dolt_history_xyz.y as y,
+  dolt_history_xyz.z as z,
+  dolt_commits.commit_hash as comm
+FROM
+  dolt_history_xyz
+  LEFT JOIN
+  dolt_commits
+  ON
+  dolt_history_xyz.commit_hash = dolt_commits.commit_hash
+ORDER BY
+  dolt_history_xyz.y,
+  dolt_history_xyz.z;`,
 				Expected: []sql.Row{
-					{1, 100},
-					{3, 200},
-					{5, 300},
-					{1, 100},
-					{1, 100},
-					{3, 200},
+					{1, 100, doltCommit},
+					{1, 100, doltCommit},
+					{1, 100, doltCommit},
+					{3, 200, doltCommit},
+					{3, 200, doltCommit},
+					{5, 300, doltCommit},
 				},
 			},
 			{
-				Query: "select z from dolt_history_xyz",
+				Query: `
+SELECT
+  dolt_history_xyz.z as z,
+  dolt_commits.commit_hash as comm
+FROM
+  dolt_history_xyz
+  LEFT JOIN
+  dolt_commits
+  ON
+  dolt_history_xyz.commit_hash = dolt_commits.commit_hash
+ORDER BY
+  dolt_history_xyz.z;`,
 				Expected: []sql.Row{
-					{100},
-					{200},
-					{300},
-					{100},
-					{100},
-					{200},
+					{100, doltCommit},
+					{100, doltCommit},
+					{100, doltCommit},
+					{200, doltCommit},
+					{200, doltCommit},
+					{300, doltCommit},
 				},
 			},
 		},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -2027,6 +2027,55 @@ var HistorySystemTableScriptTests = []queries.ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "dolt_history table primary key",
+		SetUpScript: []string{
+			"create table xyz (x int, y int, z int, primary key(x, y));",
+			"call dolt_add('.');",
+			"call dolt_commit('-m', 'creating table');",
+			"insert into xyz values (0, 1, 100);",
+			"call dolt_commit('-am', 'add data');",
+			"insert into xyz values (2, 3, 200);",
+			"call dolt_commit('-am', 'add data');",
+			"insert into xyz values (4, 5, 300);",
+			"call dolt_commit('-am', 'add data');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "select x, y, z from dolt_history_xyz",
+				Expected: []sql.Row{
+					{0, 1, 100},
+					{2, 3, 200},
+					{4, 5, 300},
+					{0, 1, 100},
+					{0, 1, 100},
+					{2, 3, 200},
+				},
+			},
+			{
+				Query: "select y, z from dolt_history_xyz",
+				Expected: []sql.Row{
+					{1, 100},
+					{3, 200},
+					{5, 300},
+					{1, 100},
+					{1, 100},
+					{3, 200},
+				},
+			},
+			{
+				Query: "select z from dolt_history_xyz",
+				Expected: []sql.Row{
+					{100},
+					{200},
+					{300},
+					{100},
+					{100},
+					{200},
+				},
+			},
+		},
+	},
 }
 
 // BrokenHistorySystemTableScriptTests contains tests that work for non-prepared, but don't work

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -1578,6 +1578,10 @@ var HistorySystemTableScriptTests = []queries.ScriptTest{
 				Expected: []sql.Row{{1, "Eins", nil}, {2, "Zwei", nil}, {3, "Drei", nil}},
 			},
 			{
+				Query:    "select de, fr from dolt_history_T1 where commit_hash = @Commit1;",
+				Expected: []sql.Row{{"Eins", nil}, {"Zwei", nil}, {"Drei", nil}},
+			},
+			{
 				Query:    "select n, de, fr from dolt_history_T1 where commit_hash = @Commit2;",
 				Expected: []sql.Row{{1, "Eins", nil}, {2, "Zwei", nil}, {3, "Drei", nil}, {4, "Vier", "Quatre"}},
 			},

--- a/go/libraries/doltcore/sqle/history_table.go
+++ b/go/libraries/doltcore/sqle/history_table.go
@@ -77,7 +77,7 @@ func (ht *HistoryTable) PrimaryKeySchema() sql.PrimaryKeySchema {
 	}
 
 	// Returning a schema from a single table with multiple table names can confuse parts of the analyzer
-	for i, col := range basePkSch.Schema {
+	for i, col := range basePkSch.Schema.Copy() {
 		col.Source = tableName
 		newSch.Schema[i] = col
 	}


### PR DESCRIPTION
The `dolt_history_...` table derives its schema from the base table + 3 additional columns [historyTableSchema()](https://github.com/dolthub/dolt/pull/6389/files#diff-bde037bd1753c546c0e70386a347eeddca4756f13d3976419a2eb3472e783867L146).

However, when we have a projection over the table, the schema returned from `HistoryTable.Schema()` is trimmed to only the columns we look at. This is problematic when we're join planning as we look over all indexes and panic when we find an index over a column that isn't in the schema; in this case, it's the Primary key.

By having `HistoryTable` implement `PrimaryKeySchema`, we can return a schema with all the columns, and the index picking portion of join planning works.

Fix for: https://github.com/dolthub/dolt/issues/6382