### PR TITLE
Don't panic when attempting to publish metrics if config is unparsable

### DIFF
--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -459,6 +459,11 @@ func runMain() int {
 		return 1
 	}
 
+	if dEnv.CfgLoadErr != nil {
+		cli.PrintErrln(color.RedString("Failed to load the global config. %v", dEnv.CfgLoadErr))
+		return 1
+	}
+
 	emitter := events.NewFileEmitter(root, dbfactory.DoltDir)
 
 	defer func() {
@@ -485,11 +490,6 @@ func runMain() int {
 			// log.Print(err)
 		}
 	}()
-
-	if dEnv.CfgLoadErr != nil {
-		cli.PrintErrln(color.RedString("Failed to load the global config. %v", dEnv.CfgLoadErr))
-		return 1
-	}
 
 	err = reconfigIfTempFileMoveFails(dEnv)
 


### PR DESCRIPTION
Currently if you have an unparsable config_global.json, we print a message say as much, then produce a panic attempting to use the config to print metrics. This just drops the attempt to produce the metrics.