### PR TITLE
Allow sql-client to get the username from the config file

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/sqlclient.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlclient.go
@@ -109,11 +109,6 @@ func (cmd SqlClientCmd) Exec(ctx context.Context, commandStr string, args []stri
 	var serverController *ServerController
 	var err error
 
-	if _, ok := apr.GetValue(commands.UserFlag); !ok {
-		cli.PrintErrln(color.RedString("--user or -u argument is required"))
-		return 1
-	}
-
 	if apr.Contains(sqlClientDualFlag) {
 		if !dEnv.Valid() {
 			if !cli.CheckEnvIsValid(dEnv) {
@@ -212,6 +207,12 @@ func (cmd SqlClientCmd) Exec(ctx context.Context, commandStr string, args []stri
 		cli.PrintErrln(err.Error())
 		return 1
 	}
+
+	if parsedMySQLConfig.User == "" {
+		cli.PrintErrln(color.RedString("--user or -u argument is required"))
+		return 1
+	}
+
 	parsedMySQLConfig.DBName = dbToUse
 	mysqlConnector, err := mysqlDriver.NewConnector(parsedMySQLConfig)
 	if err != nil {

--- a/integration-tests/bats/sql-client.bats
+++ b/integration-tests/bats/sql-client.bats
@@ -69,12 +69,6 @@ teardown() {
     [ "${lines[8]}" = '+-----------------+' ]
 }
 
-@test "sql-client: --user argument is required" {
-    run dolt sql-client
-    [ "$status" -eq 1 ]
-    [[ "$output" =~  "--user or -u argument is required" ]] || false
-}
-
 @test "sql-client: multiple statments in --query" {
     cd repo1
     start_sql_server repo1


### PR DESCRIPTION
Previously the --user option was forced for `sql-client` which is overly strict since users can provide it in a config.yaml file.