### PR TITLE
Implemented --prune for fetch command procedure

### DIFF
--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -202,6 +202,7 @@ func CreateCherryPickArgParser() *argparser.ArgParser {
 func CreateFetchArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParserWithVariableArgs("fetch")
 	ap.SupportsString(UserFlag, "u", "user", "User name to use when authenticating with the remote. Gets password from the environment variable {{.EmphasisLeft}}DOLT_REMOTE_PASSWORD{{.EmphasisRight}}.")
+	ap.SupportsFlag(PruneFlag, "p", "After fetching, remove any remote-tracking references that don't exist on the remote.")
 	return ap
 }
 

--- a/go/cmd/dolt/cli/flags.go
+++ b/go/cmd/dolt/cli/flags.go
@@ -53,6 +53,7 @@ const (
 	ParentsFlag      = "parents"
 	PasswordFlag     = "password"
 	PortFlag         = "port"
+	PruneFlag        = "prune"
 	RemoteParam      = "remote"
 	SetUpstreamFlag  = "set-upstream"
 	ShallowFlag      = "shallow"

--- a/go/cmd/dolt/commands/dump.go
+++ b/go/cmd/dolt/commands/dump.go
@@ -137,7 +137,7 @@ func (cmd DumpCmd) Exec(ctx context.Context, commandStr string, args []string, d
 	resFormat, _ := apr.GetValue(FormatFlag)
 	resFormat = strings.TrimPrefix(resFormat, ".")
 
-	outputFileOrDirName, vErr := validateArgs(apr)
+	outputFileOrDirName, vErr := validateDumpArgs(apr)
 	if vErr != nil {
 		return HandleVErrAndExitCode(vErr, usage)
 	}
@@ -575,9 +575,9 @@ func getDumpDestination(path string) mvdata.DataLocation {
 	return destLoc
 }
 
-// validateArgs returns either filename of directory name after checking each cases of user input arguments,
+// validateDumpArgs returns either filename of directory name after checking each cases of user input arguments,
 // handling errors for invalid arguments
-func validateArgs(apr *argparser.ArgParseResults) (string, errhand.VerboseError) {
+func validateDumpArgs(apr *argparser.ArgParseResults) (string, errhand.VerboseError) {
 	rf, _ := apr.GetValue(FormatFlag)
 	rf = strings.TrimPrefix(rf, ".")
 	fn, fnOk := apr.GetValue(filenameFlag)

--- a/go/cmd/dolt/commands/fetch.go
+++ b/go/cmd/dolt/commands/fetch.go
@@ -72,7 +72,7 @@ func (cmd FetchCmd) Exec(ctx context.Context, commandStr string, args []string, 
 	ap := cli.CreateFetchArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, fetchDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
-	
+
 	r, remainingArgs, err := env.RemoteForFetchArgs(apr.Args, dEnv.RepoStateReader())
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
@@ -87,7 +87,7 @@ func (cmd FetchCmd) Exec(ctx context.Context, commandStr string, args []string, 
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
-	
+
 	var verr errhand.VerboseError
 	dEnv.UserPassConfig, verr = getRemoteUserAndPassConfig(apr)
 	if verr != nil {
@@ -111,8 +111,8 @@ func (cmd FetchCmd) Exec(ctx context.Context, commandStr string, args []string, 
 // validateFetchArgs returns an error if the arguments provided aren't valid
 func validateFetchArgs(apr *argparser.ArgParseResults, refSpecArgs []string) errhand.VerboseError {
 	if len(refSpecArgs) > 0 && apr.Contains(cli.PruneFlag) {
-		// The current prune implementation assumes that we're processing all branch specs on the remote, so if an 
-		// explicit ref spec is provided we refuse to execute 
+		// The current prune implementation assumes that we're processing all branch specs on the remote, so if an
+		// explicit ref spec is provided we refuse to execute
 		return errhand.BuildDError("--prune option cannot be provided with a ref spec").Build()
 	}
 

--- a/go/cmd/dolt/commands/fetch.go
+++ b/go/cmd/dolt/commands/fetch.go
@@ -83,7 +83,7 @@ func (cmd FetchCmd) Exec(ctx context.Context, commandStr string, args []string, 
 		return HandleVErrAndExitCode(validationErr, usage)
 	}
 
-	refSpecs, err := env.ParseRefSpecs(args, dEnv.RepoStateReader(), r)
+	refSpecs, err := env.ParseRefSpecs(remainingArgs, dEnv.RepoStateReader(), r)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}

--- a/go/cmd/dolt/commands/fetch.go
+++ b/go/cmd/dolt/commands/fetch.go
@@ -83,13 +83,15 @@ func (cmd FetchCmd) Exec(ctx context.Context, commandStr string, args []string, 
 	if verr != nil {
 		return HandleVErrAndExitCode(verr, usage)
 	}
-
+	
 	srcDB, err := r.GetRemoteDBWithoutCaching(ctx, dEnv.DbData().Ddb.ValueReadWriter().Format(), dEnv)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	err = actions.FetchRefSpecs(ctx, dEnv.DbData(), srcDB, refSpecs, r, ref.UpdateMode{Force: true}, buildProgStarter(downloadLanguage), stopProgFuncs)
+	prune := apr.Contains(cli.PruneFlag)
+	mode := ref.UpdateMode{Force: true, Prune: prune}
+	err = actions.FetchRefSpecs(ctx, dEnv.DbData(), srcDB, refSpecs, r, mode, buildProgStarter(downloadLanguage), stopProgFuncs)
 	if err != nil && err != doltdb.ErrUpToDate {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}

--- a/go/cmd/dolt/commands/fetch.go
+++ b/go/cmd/dolt/commands/fetch.go
@@ -110,7 +110,7 @@ func (cmd FetchCmd) Exec(ctx context.Context, commandStr string, args []string, 
 
 // validateFetchArgs returns an error if the arguments provided aren't valid.
 func validateFetchArgs(apr *argparser.ArgParseResults, refSpecArgs []string) errhand.VerboseError {
-	if len(refSpecArgs) > 0 && apr.ContainsArg(cli.PruneFlag) {
+	if len(refSpecArgs) > 0 && apr.Contains(cli.PruneFlag) {
 		// The current prune implementation assumes that we're processing branch specs, which 
 		return errhand.BuildDError("--prune option cannot be provided with a ref spec").Build()
 	}

--- a/go/cmd/dolt/commands/fetch.go
+++ b/go/cmd/dolt/commands/fetch.go
@@ -108,10 +108,11 @@ func (cmd FetchCmd) Exec(ctx context.Context, commandStr string, args []string, 
 	return HandleVErrAndExitCode(nil, usage)
 }
 
-// validateFetchArgs returns an error if the arguments provided aren't valid.
+// validateFetchArgs returns an error if the arguments provided aren't valid
 func validateFetchArgs(apr *argparser.ArgParseResults, refSpecArgs []string) errhand.VerboseError {
 	if len(refSpecArgs) > 0 && apr.Contains(cli.PruneFlag) {
-		// The current prune implementation assumes that we're processing branch specs, which 
+		// The current prune implementation assumes that we're processing all branch specs on the remote, so if an 
+		// explicit ref spec is provided we refuse to execute 
 		return errhand.BuildDError("--prune option cannot be provided with a ref spec").Build()
 	}
 

--- a/go/libraries/doltcore/env/actions/remotes.go
+++ b/go/libraries/doltcore/env/actions/remotes.go
@@ -526,17 +526,17 @@ func pruneBranches(ctx context.Context, dbData env.DbData, remoteRefs []doltdb.R
 	}
 
 	// Delete any remote branch not present in the remoteRefs
-	for _, remoteRef := range remoteRefs {
+	for _, localRemoteRef := range localRemoteRefs {
 		found := false
-		for _, localRemoteRef := range localRemoteRefs {
-			if localRemoteRef == remoteRef.Ref {
+		for _, remoteRef := range remoteRefs {
+			if remoteRef.Ref == localRemoteRef {
 				found = true
 				break
 			}
 		}
 		
 		if !found {
-			err = dbData.Ddb.DeleteBranch(ctx, remoteRef.Ref, nil)
+			err = dbData.Ddb.DeleteBranch(ctx, localRemoteRef, nil)
 			if err != nil {
 				return err
 			}

--- a/go/libraries/doltcore/env/actions/remotes.go
+++ b/go/libraries/doltcore/env/actions/remotes.go
@@ -541,6 +541,7 @@ func pruneBranches(ctx context.Context, dbData env.DbData, remote env.Remote, re
 		}
 		
 		if !found {
+			// TODO: this isn't thread-safe in a SQL context
 			err = dbData.Ddb.DeleteBranch(ctx, localRemoteRef, nil)
 			if err != nil {
 				return err

--- a/go/libraries/doltcore/env/remotes.go
+++ b/go/libraries/doltcore/env/remotes.go
@@ -267,11 +267,11 @@ func RemoteForFetchArgs(args []string, rsr RepoStateReader) (Remote, []string, e
 		msg := "does not appear to be a dolt database. could not read from the remote database. please make sure you have the correct access rights and the database exists"
 		return NoRemote, nil, fmt.Errorf("%w; '%s' %s", ErrUnknownRemote, remName, msg)
 	}
-	
+
 	return remote, args, nil
 }
 
-// ParseRefSpecs returns the ref specs for the string arguments given for the remote provided, or the default ref 
+// ParseRefSpecs returns the ref specs for the string arguments given for the remote provided, or the default ref
 // specs for that remote if no arguments are provided.
 func ParseRefSpecs(args []string, rsr RepoStateReader, remote Remote) ([]ref.RemoteRefSpec, error) {
 	if len(args) != 0 {

--- a/go/libraries/doltcore/env/remotes.go
+++ b/go/libraries/doltcore/env/remotes.go
@@ -242,9 +242,8 @@ func NewPushOpts(ctx context.Context, apr *argparser.ArgParseResults, rsr RepoSt
 	return opts, nil
 }
 
-// NewFetchOpts returns remote and refSpec for given remote name. If remote name is not defined,
-// default remote is used. Default remote is "origin" if there are multiple remotes for now.
-func NewFetchOpts(args []string, rsr RepoStateReader) (Remote, []ref.RemoteRefSpec, error) {
+// RemoteForFetchArgs returns the remote and remaining arg strings for a fetch command
+func RemoteForFetchArgs(args []string, rsr RepoStateReader) (Remote, []string, error) {
 	var err error
 	remotes, err := rsr.GetRemotes()
 	if err != nil {
@@ -268,19 +267,18 @@ func NewFetchOpts(args []string, rsr RepoStateReader) (Remote, []ref.RemoteRefSp
 		msg := "does not appear to be a dolt database. could not read from the remote database. please make sure you have the correct access rights and the database exists"
 		return NoRemote, nil, fmt.Errorf("%w; '%s' %s", ErrUnknownRemote, remName, msg)
 	}
+	
+	return remote, args, nil
+}
 
-	var rs []ref.RemoteRefSpec
+// ParseRefSpecs returns the ref specs for the string arguments given for the remote provided, or the default ref 
+// specs for that remote if no arguments are provided.
+func ParseRefSpecs(args []string, rsr RepoStateReader, remote Remote) ([]ref.RemoteRefSpec, error) {
 	if len(args) != 0 {
-		rs, err = ParseRSFromArgs(remName, args)
+		return ParseRSFromArgs(remote.Name, args)
 	} else {
-		rs, err = GetRefSpecs(rsr, remName)
+		return GetRefSpecs(rsr, remote.Name)
 	}
-
-	if err != nil {
-		return NoRemote, nil, err
-	}
-
-	return remote, rs, err
 }
 
 func ParseRSFromArgs(remName string, args []string) ([]ref.RemoteRefSpec, error) {

--- a/go/libraries/doltcore/ref/ref.go
+++ b/go/libraries/doltcore/ref/ref.go
@@ -78,10 +78,11 @@ func PrefixForType(refType RefType) string {
 
 type UpdateMode struct {
 	Force bool
+	Prune bool
 }
 
-var ForceUpdate = UpdateMode{true}
-var FastForwardOnly = UpdateMode{false}
+var ForceUpdate = UpdateMode{true, false}
+var FastForwardOnly = UpdateMode{false, false}
 
 // DoltRef is a reference to a commit.
 type DoltRef interface {

--- a/go/libraries/doltcore/ref/ref_spec.go
+++ b/go/libraries/doltcore/ref/ref_spec.go
@@ -224,7 +224,7 @@ func newLocalToRemoteTrackingRef(remote string, srcRef BranchRef, destRef Remote
 		if srcWCs == 0 {
 			srcPattern := strPattern(srcRef.GetPath())
 			destPattern := strPattern(destRef.GetPath())
-			srcToDestMapper := identityBranchMapper(destRef.GetPath()[len(remoteInRef):])
+			srcToDestMapper := identityBranchMapper(destRef.GetPath()[len(remoteInRef)+1:])
 			destToSrcMapper := identityBranchMapper(srcRef.GetPath())
 
 			return BranchToTrackingBranchRefSpec{

--- a/go/libraries/doltcore/ref/ref_spec_test.go
+++ b/go/libraries/doltcore/ref/ref_spec_test.go
@@ -14,7 +14,12 @@
 
 package ref
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
 func TestRefSpec(t *testing.T) {
 	tests := []struct {
@@ -22,95 +27,99 @@ func TestRefSpec(t *testing.T) {
 		refSpecStr string
 		isValid    bool
 		inToExpOut map[string]string
+		skip       bool
 	}{
 		{
-			"origin",
-			"refs/heads/*:refs/remotes/origin/*",
-			true,
-			map[string]string{
+			remote:     "origin",
+			refSpecStr: "refs/heads/*:refs/remotes/origin/*",
+			isValid:    true,
+			inToExpOut: map[string]string{
 				"refs/heads/main":          "refs/remotes/origin/main",
 				"refs/heads/feature":       "refs/remotes/origin/feature",
 				"refs/remotes/origin/main": "refs/nil/",
 			},
 		}, {
-			"borigin",
-			"refs/heads/main:refs/remotes/borigin/mymain",
-			true,
-			map[string]string{
+			remote:     "borigin",
+			refSpecStr: "refs/heads/main:refs/remotes/borigin/mymain",
+			isValid:    true,
+			inToExpOut: map[string]string{
 				"refs/heads/main":    "refs/remotes/borigin/mymain",
 				"refs/heads/feature": "refs/nil/",
 			},
 		}, {
-			"",
-			"refs/heads/*/main:refs/remotes/borigin/*/mymain",
-			true,
-			map[string]string{
+			refSpecStr: "refs/heads/*/main:refs/remotes/borigin/*/mymain",
+			isValid:    true,
+			inToExpOut: map[string]string{
 				"refs/heads/main":    "refs/nil/",
 				"refs/heads/bh/main": "refs/remotes/borigin/bh/mymain",
 				"refs/heads/as/main": "refs/remotes/borigin/as/mymain",
 			},
 		}, {
-			"",
-			"main",
-			true,
-			map[string]string{
+			refSpecStr: "main",
+			isValid:    true,
+			inToExpOut: map[string]string{
 				"refs/heads/main":    "refs/heads/main",
 				"refs/heads/feature": "refs/nil/",
 			},
 		}, {
-			"",
-			"main:main",
-			true,
-			map[string]string{
+			refSpecStr: "main:main",
+			isValid:    true,
+			inToExpOut: map[string]string{
 				"refs/heads/main":    "refs/heads/main",
 				"refs/heads/feature": "refs/nil/",
 			},
 		}, {
-			"origin",
-			"refs/heads/main:refs/remotes/not_borigin/mymain",
-			false,
-			nil,
+			remote:     "origin",
+			refSpecStr: "refs/heads/main:refs/remotes/not_borigin/mymain",
 		}, {
-			"origin",
-			"refs/heads/*:refs/remotes/origin/branchname",
-			false,
-			nil,
+			remote:     "origin",
+			refSpecStr: "refs/heads/*:refs/remotes/origin/branchname",
 		}, {
-			"origin",
-			"refs/heads/branchname:refs/remotes/origin/*",
-			false,
-			nil,
+			remote:     "origin",
+			refSpecStr: "refs/heads/branchname:refs/remotes/origin/*",
 		}, {
-			"origin",
-			"refs/heads/*/*:refs/remotes/origin/*/*",
-			false,
-			nil,
+			remote:     "origin",
+			refSpecStr: "refs/heads/*/*:refs/remotes/origin/*/*",
+		}, {
+			refSpecStr: "refs/tags/*:refs/tags/*",
+			isValid:    true,
+			inToExpOut: map[string]string{
+				"refs/tags/v1": "refs/tags/v1",
+			},
+			skip: true,
 		},
 	}
 
 	for _, test := range tests {
-		var refSpec RefSpec
-		var err error
-
-		if test.remote == "" {
-			refSpec, err = ParseRefSpec(test.refSpecStr)
-		} else {
-			refSpec, err = ParseRefSpecForRemote(test.remote, test.refSpecStr)
-		}
-
-		if (err == nil) != test.isValid {
-			t.Error(test.refSpecStr, "is valid:", err == nil)
-		} else if err == nil {
-			for in, out := range test.inToExpOut {
-				inRef, _ := Parse(in)
-				outRef, _ := Parse(out)
-
-				actual := refSpec.DestRef(inRef)
-
-				if !Equals(actual, outRef) {
-					t.Error(test.refSpecStr, "mapped", in, "to", actual.String(), "expected", outRef.String())
-				}
+		t.Run(test.refSpecStr, func(t *testing.T) {
+			if test.skip {
+				t.Skip()
 			}
-		}
+			
+			var refSpec RefSpec
+			var err error
+
+			if test.remote == "" {
+				refSpec, err = ParseRefSpec(test.refSpecStr)
+			} else {
+				refSpec, err = ParseRefSpecForRemote(test.remote, test.refSpecStr)
+			}
+
+			if test.isValid {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+
+			for in, out := range test.inToExpOut {
+				inRef, err := Parse(in)
+				require.NoError(t, err)
+				// outRef could be nil because of test construction, which is valid
+				expectedOutRef, _ := Parse(out)
+
+				outRef := refSpec.DestRef(inRef)
+				assert.Equal(t, expectedOutRef, outRef)
+			}
+		})
 	}
 }

--- a/go/libraries/doltcore/ref/ref_spec_test.go
+++ b/go/libraries/doltcore/ref/ref_spec_test.go
@@ -95,7 +95,7 @@ func TestRefSpec(t *testing.T) {
 			if test.skip {
 				t.Skip()
 			}
-			
+
 			var refSpec RefSpec
 			var err error
 

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_fetch.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_fetch.go
@@ -17,7 +17,6 @@ package dprocedures
 import (
 	"fmt"
 
-	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
@@ -26,6 +25,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
+	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 )
 
 // doltFetch is the stored procedure version for the CLI command `dolt fetch`.
@@ -77,7 +77,7 @@ func doDoltFetch(ctx *sql.Context, args []string) (int, error) {
 	if err != nil {
 		return 1, err
 	}
-	
+
 	prune := apr.Contains(cli.PruneFlag)
 	mode := ref.UpdateMode{Force: true, Prune: prune}
 	err = actions.FetchRefSpecs(ctx, dbData, srcDB, refSpecs, remote, mode, runProgFuncs, stopProgFuncs)
@@ -90,7 +90,7 @@ func doDoltFetch(ctx *sql.Context, args []string) (int, error) {
 // validateFetchArgs returns an error if the arguments provided aren't valid.
 func validateFetchArgs(apr *argparser.ArgParseResults, refSpecArgs []string) error {
 	if len(refSpecArgs) > 0 && apr.Contains(cli.PruneFlag) {
-		// The current prune implementation assumes that we're processing branch specs, which 
+		// The current prune implementation assumes that we're processing branch specs, which
 		return fmt.Errorf("--prune option cannot be provided with a ref spec")
 	}
 

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_fetch.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_fetch.go
@@ -67,7 +67,10 @@ func doDoltFetch(ctx *sql.Context, args []string) (int, error) {
 		return 1, err
 	}
 
-	err = actions.FetchRefSpecs(ctx, dbData, srcDB, refSpecs, remote, ref.UpdateMode{Force: true}, runProgFuncs, stopProgFuncs)
+
+	prune := apr.Contains(cli.PruneFlag)
+	mode := ref.UpdateMode{Force: true, Prune: prune}
+	err = actions.FetchRefSpecs(ctx, dbData, srcDB, refSpecs, remote, mode, runProgFuncs, stopProgFuncs)
 	if err != nil {
 		return cmdFailure, fmt.Errorf("fetch failed: %w", err)
 	}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_fetch.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_fetch.go
@@ -89,7 +89,7 @@ func doDoltFetch(ctx *sql.Context, args []string) (int, error) {
 
 // validateFetchArgs returns an error if the arguments provided aren't valid.
 func validateFetchArgs(apr *argparser.ArgParseResults, refSpecArgs []string) error {
-	if len(refSpecArgs) > 0 && apr.ContainsArg(cli.PruneFlag) {
+	if len(refSpecArgs) > 0 && apr.Contains(cli.PruneFlag) {
 		// The current prune implementation assumes that we're processing branch specs, which 
 		return fmt.Errorf("--prune option cannot be provided with a ref spec")
 	}

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -2391,7 +2391,6 @@ SQL
     run dolt branch -va
     [[ "$output" =~ "main" ]] || false
 
-    
     dolt remote add remote2 file://../remote2
     dolt fetch
     dolt fetch remote2

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -2420,4 +2420,8 @@ SQL
     [ "$status" -eq 0 ]
     [[ ! "$output" =~ "origin/b1" ]] || false
     [[ ! "$output" =~ "remote2/b2" ]] || false
+
+    run dolt fetch --prune remote2 'refs/heads/main:refs/remotes/remote2/othermain'
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "--prune option cannot be provided with a ref spec" ]] || false
 }

--- a/integration-tests/bats/sql-fetch.bats
+++ b/integration-tests/bats/sql-fetch.bats
@@ -431,6 +431,10 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ ! "$output" =~ "origin/b1" ]] || false
     [[ ! "$output" =~ "remote2/b2" ]] || false
+
+    run dolt sql -q "call dolt_fetch('--prune', 'remote2', 'refs/heads/main:refs/remotes/remote2/othermain')"
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "--prune option cannot be provided with a ref spec" ]] || false
 }
 
 @test "sql-fetch: dolt_fetch unknown remote fails" {

--- a/integration-tests/bats/sql-fetch.bats
+++ b/integration-tests/bats/sql-fetch.bats
@@ -379,6 +379,60 @@ teardown() {
     [[ "$output" =~ "t2" ]] || false
 }
 
+@test "sql-fetch: fetch --prune deletes remote refs not on remote" {
+    mkdir firstRepo
+    mkdir secondRepo
+
+    cd firstRepo
+    dolt init
+    dolt remote add origin file://../remote1
+    dolt remote add remote2 file://../remote2
+    dolt branch b1
+    dolt branch b2
+    dolt push origin main
+    dolt push remote2 main
+    dolt push origin b1
+    dolt push remote2 b2
+
+    cd ..
+    dolt clone file://./remote1 secondRepo
+
+    cd secondRepo
+    run dolt branch -va
+    [[ "$output" =~ "main" ]] || false
+
+    dolt remote add remote2 file://../remote2
+    dolt fetch
+    dolt fetch remote2
+
+    run dolt branch -r
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "origin/b1" ]] || false
+    [[ "$output" =~ "remote2/b2" ]] || false
+
+    # delete the branches on the remote
+    cd ../firstRepo
+    dolt push origin :b1
+    dolt push remote2 :b2
+
+    cd ../secondRepo
+    dolt sql -q "call dolt_fetch('--prune')"
+
+    # prune should have deleted the origin/b1 branch, but not the one on the other remote
+    run dolt branch -r
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "origin/b1" ]] || false
+    [[ "$output" =~ "remote2/b2" ]] || false
+
+    # now the other remote
+    dolt sql -q "call dolt_fetch('--prune', 'remote2')"
+
+    run dolt branch -r
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "origin/b1" ]] || false
+    [[ ! "$output" =~ "remote2/b2" ]] || false
+}
+
 @test "sql-fetch: dolt_fetch unknown remote fails" {
     cd repo2
     dolt remote remove origin


### PR DESCRIPTION
`dolt fetch --prune` deletes any local remote refs that are not present on the remote being fetched. This is simpler than the equivalent git command, as it only operates on branches, not other kinds of refs.

Fixes https://github.com/dolthub/dolt/issues/6413