### PR TITLE
Bug Fix: Error on merges that produce schema conflicts when `@@autocommit` is enabled

### DIFF
--- a/go/libraries/doltcore/sqle/dsess/transactions.go
+++ b/go/libraries/doltcore/sqle/dsess/transactions.go
@@ -565,8 +565,13 @@ func (tx *DoltTransaction) validateWorkingSetForCommit(ctx *sql.Context, working
 		return err
 	}
 
+	hasSchemaConflicts := false
+	if workingSet.MergeState() != nil {
+		hasSchemaConflicts = workingSet.MergeState().HasSchemaConflicts()
+	}
+
 	workingRoot := workingSet.WorkingRoot()
-	hasConflicts, err := workingRoot.HasConflicts(ctx)
+	hasDataConflicts, err := workingRoot.HasConflicts(ctx)
 	if err != nil {
 		return err
 	}
@@ -575,7 +580,7 @@ func (tx *DoltTransaction) validateWorkingSetForCommit(ctx *sql.Context, working
 		return err
 	}
 
-	if hasConflicts {
+	if hasDataConflicts || hasSchemaConflicts {
 		// TODO: Sometimes this returns the wrong error. Define an internal
 		// merge to be a merge that occurs inside a transaction. Define a
 		// transaction merge to be the merge that resolves changes between two

--- a/integration-tests/bats/schema-conflicts.bats
+++ b/integration-tests/bats/schema-conflicts.bats
@@ -29,7 +29,7 @@ setup_schema_conflict() {
 @test "schema-conflicts: sql merge, query schema conflicts" {
     setup_schema_conflict
 
-    dolt sql -q "call dolt_merge('other')"
+    dolt sql -q "set @@dolt_force_transaction_commit=1; call dolt_merge('other')"
 
     run dolt sql -q "select our_schema from dolt_schema_conflicts" -r csv
     [ "$status" -eq 0 ]

--- a/integration-tests/bats/sql-merge.bats
+++ b/integration-tests/bats/sql-merge.bats
@@ -969,8 +969,8 @@ SQL
     [[ "$output" =~ "CONSTRAINT \`c\` CHECK ((\`i\` < 10))" ]] || false
     dolt commit -am "changes to main"
 
-    run dolt sql -q "call dolt_merge('other', '-m', 'merge other')"
-    run dolt status
+    dolt sql -q "set @@dolt_force_transaction_commit=1; call dolt_merge('other', '-m', 'merge other')"
+    dolt status
     log_status_eq 0
     [[ "$output" =~ "schema conflict:" ]]
     run dolt sql -q "select count(*) from dolt_schema_conflicts"

--- a/integration-tests/bats/sql-merge.bats
+++ b/integration-tests/bats/sql-merge.bats
@@ -905,7 +905,7 @@ SQL
     [[ "$output" =~ "CONSTRAINT \`c1\` CHECK ((\`i\` < 0))" ]] || false
     dolt commit -am "changes to main"
 
-    dolt sql -q "call dolt_merge('other', '-m', 'merge other')"
+    dolt sql -q "set @@dolt_force_transaction_commit=1; call dolt_merge('other', '-m', 'merge other')"
 
     run dolt status
     log_status_eq 0
@@ -1041,7 +1041,7 @@ SQL
     dolt checkout main
     run dolt merge b1 -m "merge b1" --commit
     log_status_eq 0
-    dolt sql -q "call dolt_merge('b2', '-m', 'merge b2')"
+    dolt sql -q "set @@dolt_force_transaction_commit=1; call dolt_merge('b2', '-m', 'merge b2')"
     run dolt status
     log_status_eq 0
     [[ "$output" =~ "schema conflict:" ]]
@@ -1076,7 +1076,7 @@ SQL
     dolt checkout main
     run dolt sql -q "call dolt_merge('b1', '-m', 'merge b1')"
     log_status_eq 0
-    dolt sql -q "call dolt_merge('b2', '-m', 'merge b2')"
+    dolt sql -q "set @@dolt_force_transaction_commit=1; call dolt_merge('b2', '-m', 'merge b2')"
     run dolt status
     log_status_eq 0
     [[ "$output" =~ "schema conflict:" ]]

--- a/integration-tests/bats/sql-merge.bats
+++ b/integration-tests/bats/sql-merge.bats
@@ -970,12 +970,12 @@ SQL
     dolt commit -am "changes to main"
 
     dolt sql -q "set @@dolt_force_transaction_commit=1; call dolt_merge('other', '-m', 'merge other')"
-    dolt status
+    run dolt status
     log_status_eq 0
-    [[ "$output" =~ "schema conflict:" ]]
+    [[ "$output" =~ "schema conflict:" ]] || false
     run dolt sql -q "select count(*) from dolt_schema_conflicts"
     log_status_eq 0
-    [[ "$output" =~ "1" ]]
+    [[ "$output" =~ "1" ]] || false
     dolt sql -q "call dolt_conflicts_resolve('--ours', 't')"
     run dolt sql -q "show create table t"
     log_status_eq 0


### PR DESCRIPTION
If `@@autocommit` is enabled, then a SQL commit will be created after every SQL statement. If a `dolt_merge()` operation results in data conflicts, then we return an error, revert the working set, and prevent the SQL commit. Schema conflicts should have the same behavior when `@@autocommit` is enabled, but they were not getting caught by our transaction logic. 

Fixes https://github.com/dolthub/dolt/issues/6469