### PR TITLE
[no-release-notes] Fixing missing "|| false" in BATS files

### DIFF
--- a/integration-tests/bats/1pk5col-ints.bats
+++ b/integration-tests/bats/1pk5col-ints.bats
@@ -41,7 +41,7 @@ teardown() {
     
     run dolt status
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "Untracked tables" ]]
+    [[ "$output" =~ "Untracked tables" ]] || false
     [[ "$output" =~ new[[:space:]]table:[[:space:]]+test ]] || false
 }
 
@@ -51,21 +51,21 @@ teardown() {
     [ "$output" = "" ]
     run dolt status
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "Changes to be committed" ]]
+    [[ "$output" =~ "Changes to be committed" ]] || false
     [[ "$output" =~ "new table:" ]] || false
     run dolt reset test
     [ "$status" -eq 0 ]
     [ "$output" = "" ]
     run dolt status
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "Untracked tables" ]]
+    [[ "$output" =~ "Untracked tables" ]] || false
     [[ "$output" =~ "new table:" ]] || false
     run dolt add .
     [ "$status" -eq 0 ]
     [ "$output" = "" ]
     run dolt status
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "Changes to be committed" ]]
+    [[ "$output" =~ "Changes to be committed" ]] || false
     [[ "$output" =~ "new table:" ]] || false
     run dolt commit -m "test commit"
     [ "$status" -eq 0 ]
@@ -407,7 +407,7 @@ teardown() {
     dolt checkout main
     run dolt merge test-branch --no-commit
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "CONFLICT (content)" ]]
+    [[ "$output" =~ "CONFLICT (content)" ]] || false
     run dolt conflicts cat test
     [ "$status" -eq 0 ]
     [[ "$output" =~ \+[[:space:]]+\|[[:space:]]+ours[[:space:]] ]] || false
@@ -451,7 +451,7 @@ teardown() {
     dolt checkout main
     run dolt merge test-branch --no-commit
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "CONFLICT (content)" ]]
+    [[ "$output" =~ "CONFLICT (content)" ]] || false
     run dolt conflicts cat test
     [ "$status" -eq 0 ]
     [[ "$output" =~ \+[[:space:]]+\|[[:space:]]+ours[[:space:]] ]] || false

--- a/integration-tests/bats/checkout.bats
+++ b/integration-tests/bats/checkout.bats
@@ -326,7 +326,7 @@ SQL
   run dolt checkout "$sha"
   [ "$status" -ne 0 ]
   cmd=$(echo "${lines[1]}" | cut -d ' ' -f 1,2,3)
-  [[ $cmd =~ "dolt checkout $sha" ]]
+  [[ $cmd =~ "dolt checkout $sha" ]] || false
 }
 
 @test "checkout: commit --amend only changes commit message" {

--- a/integration-tests/bats/commit.bats
+++ b/integration-tests/bats/commit.bats
@@ -60,7 +60,7 @@ teardown() {
     [[ ! "$output" =~ "t1" ]] || false
 
     run dolt show HEAD
-    [[ "$output" =~ "| 1" ]]
+    [[ "$output" =~ "| 1" ]] || false
 }
 
 @test "commit: -m sets commit message properly" {

--- a/integration-tests/bats/commit_tags.bats
+++ b/integration-tests/bats/commit_tags.bats
@@ -89,8 +89,8 @@ teardown() {
     dolt tag v1 HEAD^
     run dolt diff v1
     [ $status -eq 0 ]
-    [[ "$output" =~ "- | 0" ]]
-    [[ "$output" =~ "+ | 3" ]]
+    [[ "$output" =~ "- | 0" ]] || false
+    [[ "$output" =~ "+ | 3" ]] || false
 }
 
 @test "commit_tags: use a tag as a ref for merge" {
@@ -106,11 +106,11 @@ teardown() {
     [ $status -eq 0 ]
     run dolt sql -q "select * from test"
     [ $status -eq 0 ]
-    [[ "$output" =~ "1" ]]
-    [[ "$output" =~ "2" ]]
-    [[ "$output" =~ "3" ]]
-    [[ "$output" =~ "8" ]]
-    [[ "$output" =~ "9" ]]
+    [[ "$output" =~ "1" ]] || false
+    [[ "$output" =~ "2" ]] || false
+    [[ "$output" =~ "3" ]] || false
+    [[ "$output" =~ "8" ]] || false
+    [[ "$output" =~ "9" ]] || false
 }
 
 @test "commit_tags: push/pull tags to/from a remote" {

--- a/integration-tests/bats/config.bats
+++ b/integration-tests/bats/config.bats
@@ -73,7 +73,7 @@ teardown() {
     [ "${#lines[@]}" -eq 3 ]
     run dolt config --global --unset test1 test2 test3
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "Config successfully updated" ]]
+    [[ "$output" =~ "Config successfully updated" ]] || false
     run dolt config --list
     [ "$status" -eq 0 ]
     [ "$output" = "" ]
@@ -248,15 +248,15 @@ teardown() {
     dolt config --list
     run dolt config --list
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "init.defaultbranch = master" ]]
+    [[ "$output" =~ "init.defaultbranch = master" ]] || false
 
     dolt init
     run dolt status
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "On branch master" ]]
+    [[ "$output" =~ "On branch master" ]] || false
     run dolt branch
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "* master" ]]
+    [[ "$output" =~ "* master" ]] || false
 
     # cleanup
     dolt config --global --unset init.defaultBranch
@@ -269,10 +269,10 @@ teardown() {
     dolt init
     run dolt status
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "On branch main" ]]
+    [[ "$output" =~ "On branch main" ]] || false
     run dolt branch
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "* main" ]]
+    [[ "$output" =~ "* main" ]] || false
 }
 
 @test "config: init accepts branch flag" {
@@ -282,8 +282,8 @@ teardown() {
     dolt init -b=vegan-btw
     run dolt status
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "On branch vegan-btw" ]]
+    [[ "$output" =~ "On branch vegan-btw" ]] || false
     run dolt branch
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "* vegan-btw" ]]
+    [[ "$output" =~ "* vegan-btw" ]] || false
 }

--- a/integration-tests/bats/conflict-cat.bats
+++ b/integration-tests/bats/conflict-cat.bats
@@ -83,17 +83,17 @@ SQL
     # trick to disable colors
     dolt conflicts cat . > output.txt
     run cat output.txt
-    [[ $output =~ "|     | base   | 1  | 1    |" ]]
-    [[ $output =~ "|  *  | ours   | 1  | 2    |" ]]
-    [[ $output =~ "|  *  | theirs | 1  | 3    |" ]]
-    [[ $output =~ "|     | base   | 2  | 2    |" ]]
-    [[ $output =~ "|  -  | ours   | 2  | 2    |" ]]
-    [[ $output =~ "|  *  | theirs | 2  | 0    |" ]]
-    [[ $output =~ "|     | base   | 3  | 3    |" ]]
-    [[ $output =~ "|  *  | ours   | 3  | 0    |" ]]
-    [[ $output =~ "|  -  | theirs | 3  | 3    |" ]]
-    [[ $output =~ "|  +  | ours   | 4  | 4    |" ]]
-    [[ $output =~ "|  +  | theirs | 4  | -4   |" ]]
+    [[ $output =~ "|     | base   | 1  | 1    |" ]] || false
+    [[ $output =~ "|  *  | ours   | 1  | 2    |" ]] || false
+    [[ $output =~ "|  *  | theirs | 1  | 3    |" ]] || false
+    [[ $output =~ "|     | base   | 2  | 2    |" ]] || false
+    [[ $output =~ "|  -  | ours   | 2  | 2    |" ]] || false
+    [[ $output =~ "|  *  | theirs | 2  | 0    |" ]] || false
+    [[ $output =~ "|     | base   | 3  | 3    |" ]] || false
+    [[ $output =~ "|  *  | ours   | 3  | 0    |" ]] || false
+    [[ $output =~ "|  -  | theirs | 3  | 3    |" ]] || false
+    [[ $output =~ "|  +  | ours   | 4  | 4    |" ]] || false
+    [[ $output =~ "|  +  | theirs | 4  | -4   |" ]] || false
 }
 
 @test "conflict-cat: conflicts should show using the union-schema (new schema on right)" {
@@ -115,9 +115,9 @@ SQL
     dolt merge right -m "merge right"
 
     run dolt conflicts cat .
-    [[ "$output" =~ "| a" ]]
-    [[ "$output" =~ "| b" ]]
-    [[ "$output" =~ "| c" ]]
+    [[ "$output" =~ "| a" ]] || false
+    [[ "$output" =~ "| b" ]] || false
+    [[ "$output" =~ "| c" ]] || false
 }
 
 @test "conflict-cat: conflicts should show using the union-schema (new schema on left)" {
@@ -138,7 +138,7 @@ SQL
     dolt merge right -m "merge left"
 
     run dolt conflicts cat .
-    [[ "$output" =~ "| a" ]]
-    [[ "$output" =~ "| b" ]]
-    [[ "$output" =~ "| c" ]]
+    [[ "$output" =~ "| a" ]] || false
+    [[ "$output" =~ "| b" ]] || false
+    [[ "$output" =~ "| c" ]] || false
 }

--- a/integration-tests/bats/constraint-violations.bats
+++ b/integration-tests/bats/constraint-violations.bats
@@ -2858,8 +2858,8 @@ CALL DOLT_CHECKOUT('main');
 SQL
     run dolt merge right
     log_status_eq 0
-    [[ $output =~ "CONSTRAINT VIOLATION (content): Merge created constraint violation in t" ]]
-    [[ $output =~ "Automatic merge failed; 1 table(s) are unmerged." ]]
+    [[ $output =~ "CONSTRAINT VIOLATION (content): Merge created constraint violation in t" ]] || false
+    [[ $output =~ "Automatic merge failed; 1 table(s) are unmerged." ]] || false
 }
 
 @test "constraint-violations: altering FKs over PKs does not create bad index" {

--- a/integration-tests/bats/diff-stat.bats
+++ b/integration-tests/bats/diff-stat.bats
@@ -339,7 +339,7 @@ SQL
     dolt sql -q "alter table testdrop drop column col1"
     run dolt diff --stat
     [ $status -eq 0 ]
-    [[ $output =~ "1 Row Modified (100.00%)" ]]
+    [[ $output =~ "1 Row Modified (100.00%)" ]] || false
 }
 
 @test "diff-stat: stat/summary for renamed table" {

--- a/integration-tests/bats/diff.bats
+++ b/integration-tests/bats/diff.bats
@@ -1015,43 +1015,43 @@ SQL
     FIRST_COMMIT=`dolt log | grep commit | cut -d " " -f 2 | tail -1`
     run dolt diff $FIRST_COMMIT test-branch
     [ $status -eq 0 ]
-    [[ ! $output =~ "panic" ]]
+    [[ ! $output =~ "panic" ]] || false
     run dolt diff main@$FIRST_COMMIT test-branch
     [ $status -eq 1 ]
-    [[ ! $output =~ "panic" ]]
+    [[ ! $output =~ "panic" ]] || false
     run dolt diff ref.with.period test-branch
     [ $status -eq 1 ]
-    [[ ! $output =~ "panic" ]]
+    [[ ! $output =~ "panic" ]] || false
 
     run dolt diff $FIRST_COMMIT..test-branch
     [ $status -eq 0 ]
-    [[ ! $output =~ "panic" ]]
+    [[ ! $output =~ "panic" ]] || false
     run dolt diff main@$FIRST_COMMIT..test-branch
     [ $status -eq 1 ]
-    [[ ! $output =~ "panic" ]]
+    [[ ! $output =~ "panic" ]] || false
     run dolt diff ref.with.period..test-branch
     [ $status -eq 1 ]
-    [[ ! $output =~ "panic" ]]
+    [[ ! $output =~ "panic" ]] || false
 
     run dolt diff $FIRST_COMMIT...test-branch
     [ $status -eq 0 ]
-    [[ ! $output =~ "panic" ]]
+    [[ ! $output =~ "panic" ]] || false
     run dolt diff main@$FIRST_COMMIT...test-branch
     [ $status -eq 1 ]
-    [[ ! $output =~ "panic" ]]
+    [[ ! $output =~ "panic" ]] || false
     run dolt diff ref.with.period...test-branch
     [ $status -eq 1 ]
-    [[ ! $output =~ "panic" ]]
+    [[ ! $output =~ "panic" ]] || false
 
     run dolt diff --merge-base $FIRST_COMMIT test-branch
     [ $status -eq 0 ]
-    [[ ! $output =~ "panic" ]]
+    [[ ! $output =~ "panic" ]] || false
     run dolt diff --merge-base main@$FIRST_COMMIT test-branch
     [ $status -eq 1 ]
-    [[ ! $output =~ "panic" ]]
+    [[ ! $output =~ "panic" ]] || false
     run dolt diff --merge-base ref.with.period test-branch
     [ $status -eq 1 ]
-    [[ ! $output =~ "panic" ]]
+    [[ ! $output =~ "panic" ]] || false
 }
 
 @test "diff: binary data in sql output is hex encoded" {
@@ -1293,10 +1293,10 @@ SQL
     dolt diff -r sql
     run dolt diff -r sql
     [ $status -eq 0 ]
-    [[ "$output" =~ 'DELETE FROM `t` WHERE `pk`=1 AND `val`=1;' ]]
-    [[ "$output" =~ 'DELETE FROM `t` WHERE `pk`=1 AND `val`=1;' ]]
-    [[ "$output" =~ 'INSERT INTO `t` (`pk`,`val`) VALUES (1,2);' ]]
-    [[ "$output" =~ 'INSERT INTO `t` (`pk`,`val`) VALUES (1,2);' ]]
+    [[ "$output" =~ 'DELETE FROM `t` WHERE `pk`=1 AND `val`=1;' ]] || false
+    [[ "$output" =~ 'DELETE FROM `t` WHERE `pk`=1 AND `val`=1;' ]] || false
+    [[ "$output" =~ 'INSERT INTO `t` (`pk`,`val`) VALUES (1,2);' ]] || false
+    [[ "$output" =~ 'INSERT INTO `t` (`pk`,`val`) VALUES (1,2);' ]] || false
     [ "${#lines[@]}" = "4" ]
 
     dolt commit -am "cm4"
@@ -1582,7 +1582,7 @@ SQL
 +---+------+------+------+
 EOF
 )
-    [[ "$output" =~ "$EXPECTED_TABLE" ]]
+    [[ "$output" =~ "$EXPECTED_TABLE" ]] || false
 
     EXPECTED_TABLE=$(cat <<'EOF'
 +---+------+------+------+------+------+
@@ -1593,7 +1593,7 @@ EOF
 +---+------+------+------+------+------+
 EOF
 )
-    [[ "$output" =~ "$EXPECTED_TABLE" ]]
+    [[ "$output" =~ "$EXPECTED_TABLE" ]] || false
 }
 
 # This test was added to prevent short tuples from causing an empty diff.

--- a/integration-tests/bats/doltpy.bats
+++ b/integration-tests/bats/doltpy.bats
@@ -49,7 +49,7 @@ SQL
 
 @test "doltpy: hashof returns expected header names" {
     run dolt sql -r csv -q "select HASHOF('HEAD') as hash"
-    [[ $output =~ "hash" ]]
+    [[ $output =~ "hash" ]] || false
     [[ "${#lines[@]}" = "2" ]] || false
 }
 

--- a/integration-tests/bats/garbage_collection.bats
+++ b/integration-tests/bats/garbage_collection.bats
@@ -199,17 +199,17 @@ setup_merge_with_cv() {
 
     run dolt sql -r csv -q "select base_pk, base_c0, our_pk, our_c0, their_pk, their_c0 from dolt_conflicts_test;"
     [ $status -eq 0 ]
-    [[ "$output" =~ ",,0,10,0,20" ]]
-    [[ "$output" =~ ",,1,11,1,21" ]]
-    [[ "$output" =~ ",,2,12,2,22" ]]
+    [[ "$output" =~ ",,0,10,0,20" ]] || false
+    [[ "$output" =~ ",,1,11,1,21" ]] || false
+    [[ "$output" =~ ",,2,12,2,22" ]] || false
 
     dolt gc
 
     run dolt sql -r csv -q "select base_pk, base_c0, our_pk, our_c0, their_pk, their_c0 from dolt_conflicts_test;"
     [ $status -eq 0 ]
-    [[ "$output" =~ ",,0,10,0,20" ]]
-    [[ "$output" =~ ",,1,11,1,21" ]]
-    [[ "$output" =~ ",,2,12,2,22" ]]
+    [[ "$output" =~ ",,0,10,0,20" ]] || false
+    [[ "$output" =~ ",,1,11,1,21" ]] || false
+    [[ "$output" =~ ",,2,12,2,22" ]] || false
 }
 
 @test "garbage_collection: leave constraint violations" {
@@ -218,13 +218,13 @@ setup_merge_with_cv() {
 
     run dolt sql -r csv -q "select pk, fk from dolt_constraint_violations_child;"
     [ $status -eq 0 ]
-    [[ "$output" =~ "1,1" ]]
+    [[ "$output" =~ "1,1" ]] || false
 
     dolt gc
 
     run dolt sql -r csv -q "select pk, fk from dolt_constraint_violations_child;"
     [ $status -eq 0 ]
-    [[ "$output" =~ "1,1" ]]
+    [[ "$output" =~ "1,1" ]] || false
 }
 
 @test "garbage_collection: leave merge commit" {

--- a/integration-tests/bats/import-create-tables.bats
+++ b/integration-tests/bats/import-create-tables.bats
@@ -546,10 +546,10 @@ pk1,pk2,v1
 DELIM
     run dolt table import -c --pk=pk test null-pk-1.csv
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "pk" ]]
+    [[ "$output" =~ "pk" ]] || false
     run dolt table import -c --pk=pk1,pk2 test null-pk-2.csv
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "pk2" ]]
+    [[ "$output" =~ "pk2" ]] || false
 }
 
 @test "import-create-tables: table import -c infers types from data" {
@@ -561,15 +561,15 @@ DELIM
     [ "$status" -eq 0 ]
     run dolt schema show test
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "CREATE TABLE \`test\`" ]]
-    [[ "$output" =~ "\`pk\` int" ]]
-    [[ "$output" =~ "\`str\` varchar(16383)" ]]
-    [[ "$output" =~ "\`int\` int" ]]
-    [[ "$output" =~ "\`bool\` tinyint" ]]
-    [[ "$output" =~ "\`float\` float" ]]
-    [[ "$output" =~ "\`date\` date" ]]
-    [[ "$output" =~ "\`time\` time" ]]
-    [[ "$output" =~ "\`datetime\` datetime" ]]
+    [[ "$output" =~ "CREATE TABLE \`test\`" ]] || false
+    [[ "$output" =~ "\`pk\` int" ]] || false
+    [[ "$output" =~ "\`str\` varchar(16383)" ]] || false
+    [[ "$output" =~ "\`int\` int" ]] || false
+    [[ "$output" =~ "\`bool\` tinyint" ]] || false
+    [[ "$output" =~ "\`float\` float" ]] || false
+    [[ "$output" =~ "\`date\` date" ]] || false
+    [[ "$output" =~ "\`time\` time" ]] || false
+    [[ "$output" =~ "\`datetime\` datetime" ]] || false
 }
 
 @test "import-create-tables: table import -c collects garbage" {

--- a/integration-tests/bats/import-update-tables.bats
+++ b/integration-tests/bats/import-update-tables.bats
@@ -235,7 +235,7 @@ SQL
     [[ "$output" =~ "Rows Processed: 3, Additions: 3, Modifications: 0, Had No Effect: 0" ]] || false
     [[ "$output" =~ "Import completed successfully." ]] || false
     run dolt schema export employees
-    [[ "$status" -eq 0 ]]
+    [[ "$status" -eq 0 ]] || false
     [[ "${lines[1]}" =~ "id" ]]         || false
     [[ "${lines[2]}" =~ "first name" ]] || false
     [[ "${lines[3]}" =~ "last name" ]]  || false
@@ -261,7 +261,7 @@ SQL
     [[ "$output" =~ "Rows Processed: 3, Additions: 3, Modifications: 0, Had No Effect: 0" ]] || false
     [[ "$output" =~ "Import completed successfully." ]] || false
     run dolt schema export employees
-    [[ "$status" -eq 0 ]]
+    [[ "$status" -eq 0 ]] || false
     [[ "${lines[1]}" =~ "id" ]]         || false
     [[ "${lines[2]}" =~ "first name" ]] || false
     [[ "${lines[3]}" =~ "last name" ]]  || false
@@ -1194,7 +1194,7 @@ DELIM
     [ "$status" -eq 1 ]
     [[ "$output" =~ "A bad row was encountered" ]] || false
     [[ "$output" =~ "CSV reader expected 3 values, but saw 2" ]] || false
-    [[ "$output" =~ "row values:" ]]
+    [[ "$output" =~ "row values:" ]] || false
     ! [[ "$output" =~ "with the following values left over: '[\"\"]'" ]] || false
 
     # Case there are more columns in the rows than the number of columns in the schema
@@ -1208,9 +1208,9 @@ DELIM
     [ "$status" -eq 1 ]
     [[ "$output" =~ "A bad row was encountered" ]] || false
     [[ "$output" =~ "CSV reader expected 2 values, but saw 3" ]] || false
-    [[ "$output" =~ "row values:" ]]
-    [[ "$output" =~ '"pk": "5"' ]]
-    [[ "$output" =~ '"v1": "7"' ]]
+    [[ "$output" =~ "row values:" ]] || false
+    [[ "$output" =~ '"pk": "5"' ]] || false
+    [[ "$output" =~ '"v1": "7"' ]] || false
     [[ "$output" =~ "with the following values left over: '[\"5\"]'" ]] || false
 
     # Add a continue statement

--- a/integration-tests/bats/init.bats
+++ b/integration-tests/bats/init.bats
@@ -196,7 +196,7 @@ teardown() {
 
     run dolt version
     [ $status -eq 0 ]
-    [[ $output =~ "no valid database in this directory" ]]
+    [[ $output =~ "no valid database in this directory" ]] || false
 }
 
 @test "init: run init with --new-format, CREATE DATABASE through sql-server running in new-format repo should create a new format database" {

--- a/integration-tests/bats/log.bats
+++ b/integration-tests/bats/log.bats
@@ -439,7 +439,7 @@ teardown() {
     [[ "$output" =~ "Commit3" ]] || false
     [[ ! "$output" =~ "Initialize data repository" ]] || false
     [[ ! "$output" =~ "Merge:" ]] || false
-    [[ ! "$output" =~ "Commit2" ]]
+    [[ ! "$output" =~ "Commit2" ]] || false
 
     dolt add test
     dolt commit -m "MergeCommit"

--- a/integration-tests/bats/migrate.bats
+++ b/integration-tests/bats/migrate.bats
@@ -323,11 +323,11 @@ SQL
     dolt migrate
     run dolt sql -r csv -q "select * from t order by col1 asc;"
     [ $status -eq 0 ]
-    [[ $output =~ "col1,col2,col3" ]]
-    [[ $output =~ "1,2,a" ]]
-    [[ $output =~ "2,3,b" ]]
-    [[ $output =~ "3,4,a" ]]
-    [[ $output =~ "5,6,b" ]]
+    [[ $output =~ "col1,col2,col3" ]] || false
+    [[ $output =~ "1,2,a" ]] || false
+    [[ $output =~ "2,3,b" ]] || false
+    [[ $output =~ "3,4,a" ]] || false
+    [[ $output =~ "5,6,b" ]] || false
 }
 
 @test "migrate: indexes, collation, and checks should be preserved" {

--- a/integration-tests/bats/no-repo.bats
+++ b/integration-tests/bats/no-repo.bats
@@ -342,8 +342,8 @@ NOT_VALID_REPO_ERROR="The current directory is not a valid dolt repository."
     HOME=/this/is/garbage
     run dolt status
     [ "$status" -eq 1 ]
-    [[ ! "$output" =~ "panic" ]]
-    [[ "$output" =~ "Failed to load the HOME directory" ]]
+    [[ ! "$output" =~ "panic" ]] || false
+    [[ "$output" =~ "Failed to load the HOME directory" ]] || false
 }
 
 @test "no-repo: dolt login exits when receiving SIGINT" {

--- a/integration-tests/bats/primary-key-changes.bats
+++ b/integration-tests/bats/primary-key-changes.bats
@@ -666,7 +666,7 @@ alter table mydb.test add primary key(pk);
 SQL
     run dolt sql -q "show create table mydb.test"
     [ $status -eq 0 ]
-    [[ "$output" =~ "PRIMARY KEY" ]]
+    [[ "$output" =~ "PRIMARY KEY" ]] || false
 }
 
 @test "primary-key-changes: can add and drop primary keys on keyless db.table named tables" {
@@ -680,7 +680,7 @@ SQL
     dolt sql -q "ALTER TABLE mydb.test DROP PRIMARY KEY"
     run dolt sql -q "SHOW CREATE TABLE mydb.test"
     [ $status -eq 0 ]
-    [[ ! "$output" =~ "PRIMARY KEY" ]]
+    [[ ! "$output" =~ "PRIMARY KEY" ]] || false
 
     dolt sql -q "SHOW CREATE TABLE mydb.test" > output.txt
     run grep 'NOT NULL' output.txt

--- a/integration-tests/bats/remotes-sql-server.bats
+++ b/integration-tests/bats/remotes-sql-server.bats
@@ -73,10 +73,10 @@ teardown() {
     dolt pull remote1
     run dolt sql -q "select * from test" -r csv
     [ "$status" -eq 0 ]
-    [[ "${lines[0]}" =~ "pk" ]]
-    [[ "${lines[1]}" =~ "0" ]]
-    [[ "${lines[2]}" =~ "1" ]]
-    [[ "${lines[3]}" =~ "2" ]]
+    [[ "${lines[0]}" =~ "pk" ]] || false
+    [[ "${lines[1]}" =~ "0" ]] || false
+    [[ "${lines[2]}" =~ "1" ]] || false
+    [[ "${lines[3]}" =~ "2" ]] || false
 }
 
 @test "remotes-sql-server: async push on sql-session commit" {
@@ -99,10 +99,10 @@ teardown() {
     
     run dolt sql -q "select * from test" -r csv
     [ "$status" -eq 0 ]
-    [[ "${lines[0]}" =~ "pk" ]]
-    [[ "${lines[1]}" =~ "0" ]]
-    [[ "${lines[2]}" =~ "1" ]]
-    [[ "${lines[3]}" =~ "2" ]]
+    [[ "${lines[0]}" =~ "pk" ]] || false
+    [[ "${lines[1]}" =~ "0" ]] || false
+    [[ "${lines[2]}" =~ "1" ]] || false
+    [[ "${lines[3]}" =~ "2" ]] || false
 }
 
 @test "remotes-sql-server: pull new commits on read" {

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -1086,7 +1086,7 @@ SQL
     dolt commit -m "conflicting row"
     run dolt pull origin
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "CONFLICT" ]]
+    [[ "$output" =~ "CONFLICT" ]] || false
     dolt conflicts resolve test --ours
     dolt add test
     dolt commit -m "Fixed conflicts"
@@ -1843,7 +1843,7 @@ setup_ref_test() {
     dolt fetch rem1
     dolt checkout other
     run dolt log
-    [[ "$output" =~ "adding table from other" ]]
+    [[ "$output" =~ "adding table from other" ]] || false
 }
 
 @test "remotes: dolt_remote uses the right db directory in a multidb env" {

--- a/integration-tests/bats/replication.bats
+++ b/integration-tests/bats/replication.bats
@@ -684,7 +684,7 @@ SQL
 
     run dolt sql -q "show tables"
     [ "$status" -eq 0 ]
-    [[ ! "$output" =~ "panic" ]]
+    [[ ! "$output" =~ "panic" ]] || false
     [[ "$output" =~ "remote not found: 'unknown'" ]] || false
 }
 

--- a/integration-tests/bats/reset.bats
+++ b/integration-tests/bats/reset.bats
@@ -67,13 +67,13 @@ merge_with_conflicts() {
     [ $status -eq 0 ]
 
     run dolt status
-    [[ "$output" =~ "nothing to commit, working tree clean" ]]
+    [[ "$output" =~ "nothing to commit, working tree clean" ]] || false
 
     run dolt merge --abort
-    [[ "$output" =~ "fatal: There is no merge to abort" ]]
+    [[ "$output" =~ "fatal: There is no merge to abort" ]] || false
 
     run dolt sql -q "SELECT * from dolt_merge_status;"
-    [[ "$output" =~ "false" ]]
+    [[ "$output" =~ "false" ]] || false
 }
 
 @test "reset: dolt reset --hard should clear a conflicted merge state" {
@@ -89,13 +89,13 @@ merge_with_conflicts() {
     [ $status -eq 0 ]
 
     run dolt status
-    [[ "$output" =~ "nothing to commit, working tree clean" ]]
+    [[ "$output" =~ "nothing to commit, working tree clean" ]] || false
 
     run dolt merge --abort
-    [[ "$output" =~ "fatal: There is no merge to abort" ]]
+    [[ "$output" =~ "fatal: There is no merge to abort" ]] || false
 
     run dolt sql -q "SELECT * from dolt_merge_status;"
-    [[ "$output" =~ "false" ]]
+    [[ "$output" =~ "false" ]] || false
 }
 
 @test "reset: dolt reset head works" {

--- a/integration-tests/bats/schema-conflicts.bats
+++ b/integration-tests/bats/schema-conflicts.bats
@@ -11,7 +11,7 @@ teardown() {
 
 @test "schema-conflicts: dolt_schema_conflicts smoke test" {
     run dolt sql -q "select * from dolt_schema_conflicts" -r csv
-    [[ "$output" =~ "table_name,base_schema,our_schema,their_schema,description" ]]
+    [[ "$output" =~ "table_name,base_schema,our_schema,their_schema,description" ]] || false
 }
 
 setup_schema_conflict() {
@@ -33,10 +33,10 @@ setup_schema_conflict() {
 
     run dolt sql -q "select our_schema from dolt_schema_conflicts" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "varchar(20)," ]]
+    [[ "$output" =~ "varchar(20)," ]] || false
     run dolt sql -q "select their_schema from dolt_schema_conflicts" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "datetime(6)," ]]
+    [[ "$output" =~ "datetime(6)," ]] || false
 }
 
 @test "schema-conflicts: cli merge, query schema conflicts" {
@@ -46,10 +46,10 @@ setup_schema_conflict() {
 
     run dolt sql -q "select our_schema from dolt_schema_conflicts" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "varchar(20)," ]]
+    [[ "$output" =~ "varchar(20)," ]] || false
     run dolt sql -q "select their_schema from dolt_schema_conflicts" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "datetime(6)," ]]
+    [[ "$output" =~ "datetime(6)," ]] || false
 }
 
 @test "schema-conflicts: resolve schema conflict with 'ours' via SQL" {
@@ -60,7 +60,7 @@ setup_schema_conflict() {
     dolt sql -q "call dolt_conflicts_resolve('--ours', 't')"
     run dolt schema show t
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "varchar(20)" ]]
+    [[ "$output" =~ "varchar(20)" ]] || false
 }
 
 @test "schema-conflicts: resolve schema conflict with 'theirs' via SQL" {
@@ -71,7 +71,7 @@ setup_schema_conflict() {
     dolt sql -q "call dolt_conflicts_resolve('--theirs', 't')"
     run dolt schema show t
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "datetime" ]]
+    [[ "$output" =~ "datetime" ]] || false
 }
 
 @test "schema-conflicts: resolve schema conflict with 'ours' via CLI" {
@@ -82,7 +82,7 @@ setup_schema_conflict() {
     dolt conflicts resolve --ours t
     run dolt schema show t
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "varchar(20)" ]]
+    [[ "$output" =~ "varchar(20)" ]] || false
 }
 
 @test "schema-conflicts: resolve schema conflict with 'theirs' via CLI" {
@@ -93,5 +93,5 @@ setup_schema_conflict() {
     dolt conflicts resolve --theirs t
     run dolt schema show t
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "datetime" ]]
+    [[ "$output" =~ "datetime" ]] || false
 }

--- a/integration-tests/bats/sql-branch.bats
+++ b/integration-tests/bats/sql-branch.bats
@@ -57,12 +57,12 @@ teardown() {
     dolt branch existing_branch
     run dolt sql -q "CALL DOLT_BRANCH('existing_branch')"
     [ $status -eq 1 ]
-    [[ "$output" =~ "fatal: A branch named 'existing_branch' already exists." ]]
+    [[ "$output" =~ "fatal: A branch named 'existing_branch' already exists." ]] || false
 
     # empty branch
     run dolt sql -q "CALL DOLT_BRANCH('')"
     [ $status -eq 1 ]
-    [[ "$output" =~ "error: cannot branch empty string" ]]
+    [[ "$output" =~ "error: cannot branch empty string" ]] || false
 }
 
 @test "sql-branch: CALL DOLT_BRANCH -c copies not current branch and stays on current branch" {
@@ -103,12 +103,12 @@ SQL
     # branch copying from is empty
     run dolt sql -q "CALL DOLT_BRANCH('-c','','copy')"
     [ $status -eq 1 ]
-    [[ "$output" =~ "error: cannot branch empty string" ]]
+    [[ "$output" =~ "error: cannot branch empty string" ]] || false
 
     # branch copying to is empty
     run dolt sql -q "CALL DOLT_BRANCH('-c','main','')"
     [ $status -eq 1 ]
-    [[ "$output" =~ "error: cannot branch empty string" ]]
+    [[ "$output" =~ "error: cannot branch empty string" ]] || false
 
     dolt branch 'existing_branch'
     run dolt branch
@@ -119,12 +119,12 @@ SQL
     # branch copying from that don't exist
     run dolt sql -q "CALL DOLT_BRANCH('-c', 'original', 'copy');"
     [ $status -eq 1 ]
-    [[ "$output" =~ "fatal: A branch named 'original' not found" ]]
+    [[ "$output" =~ "fatal: A branch named 'original' not found" ]] || false
 
     # branch copying to that exists
     run dolt sql -q "CALL DOLT_BRANCH('-c', 'main', 'existing_branch');"
     [ $status -eq 1 ]
-    [[ "$output" =~ "fatal: A branch named 'existing_branch' already exists." ]]
+    [[ "$output" =~ "fatal: A branch named 'existing_branch' already exists." ]] || false
 }
 
 @test "sql-branch: CALL DOLT_BRANCH works as insert into dolt_branches table" {

--- a/integration-tests/bats/sql-config.bats
+++ b/integration-tests/bats/sql-config.bats
@@ -96,7 +96,7 @@ teardown() {
     echo '{"sqlserver.global.unknown":"1000"}' > .dolt/config.json
     run dolt sql -q "SELECT @@GLOBAL.unknown" -r csv
     [ "$status" -eq 1 ]
-    [[ ! "$output" =~ "panic" ]]
+    [[ ! "$output" =~ "panic" ]] || false
     [[ "$output" =~ "Unknown system variable 'unknown'" ]] || false
 }
 
@@ -104,8 +104,8 @@ teardown() {
     echo '{"sqlserver.global.max_connections":"string"}' > .dolt/config.json
     run dolt sql -q "SELECT @@GLOBAL.max_connections" -r csv
     [ "$status" -eq 0 ]
-    [[ ! "$output" =~ "panic" ]]
+    [[ ! "$output" =~ "panic" ]] || false
     [[ "$output" =~ "failed to load persisted global variables: key: 'max_connections'" ]] || false
     [[ "$output" =~ "invalid syntax" ]] || false
-    [[ "$output" =~ "151" ]]
+    [[ "$output" =~ "151" ]] || false
 }

--- a/integration-tests/bats/sql-conflicts.bats
+++ b/integration-tests/bats/sql-conflicts.bats
@@ -65,13 +65,13 @@ teardown() {
 
   run dolt conflicts cat one_pk
   [ "$status" -eq 0 ]
-  [[ ! "$output" =~ "base" ]]
+  [[ ! "$output" =~ "base" ]] || false
   [[ "$output" =~ \+[[:space:]]+\|[[:space:]]+ours[[:space:]] ]] || false
   [[ "$output" =~ \+[[:space:]]+\|[[:space:]]+theirs[[:space:]] ]] || false
 
   run dolt conflicts cat two_pk
   [ "$status" -eq 0 ]
-  [[ ! "$output" =~ "base" ]]
+  [[ ! "$output" =~ "base" ]] || false
   [[ "$output" =~ \+[[:space:]]+\|[[:space:]]+ours[[:space:]] ]] || false
   [[ "$output" =~ \+[[:space:]]+\|[[:space:]]+theirs[[:space:]] ]] || false
 
@@ -127,13 +127,13 @@ SQL
 
   run dolt conflicts cat one_pk
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "base" ]]
+  [[ "$output" =~ "base" ]] || false
   [[ "$output" =~ \*[[:space:]]*\|[[:space:]]+ours[[:space:]] ]] || false
   [[ "$output" =~ \*[[:space:]]*\|[[:space:]]+theirs[[:space:]] ]] || false
 
   run dolt conflicts cat two_pk
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "base" ]]
+  [[ "$output" =~ "base" ]] || false
   [[ "$output" =~ \*[[:space:]]*\|[[:space:]]+ours[[:space:]] ]] || false
   [[ "$output" =~ \*[[:space:]]*\|[[:space:]]+theirs[[:space:]] ]] || false
 
@@ -185,13 +185,13 @@ SQL
 
   run dolt conflicts cat one_pk
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "base" ]]
+  [[ "$output" =~ "base" ]] || false
   [[ "$output" =~ \*[[:space:]]*\|[[:space:]]+ours[[:space:]] ]] || false
   [[ "$output" =~ \-[[:space:]]*\|[[:space:]]+theirs[[:space:]] ]] || false
 
   run dolt conflicts cat two_pk
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "base" ]]
+  [[ "$output" =~ "base" ]] || false
   [[ "$output" =~ \*[[:space:]]*\|[[:space:]]+ours[[:space:]] ]] || false
   [[ "$output" =~ \-[[:space:]]*\|[[:space:]]+theirs[[:space:]] ]] || false
 

--- a/integration-tests/bats/sql-load-data.bats
+++ b/integration-tests/bats/sql-load-data.bats
@@ -574,7 +574,7 @@ fields terminated by ','
 lines terminated by '\n'
 SQL
     [ $status -eq 1 ]
-    [[ $output =~ "LOCAL supported only in sql-server mode" ]]
+    [[ $output =~ "LOCAL supported only in sql-server mode" ]] || false
 
     start_sql_server 
 
@@ -584,7 +584,7 @@ fields terminated by ','
 lines terminated by '\n'
 "
     [ $status -ne 0 ]
-    [[ $output =~ "local_infile needs to be set to 1 to use LOCAL" ]]
+    [[ $output =~ "local_infile needs to be set to 1 to use LOCAL" ]] || false
 
     # This should work but does not because of dolt sql-client
     # mysql -e works locally

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -1093,7 +1093,7 @@ SQL
     start_sql_server altDB
     run dolt --user dolt log
     [ $status -eq 1 ]
-    [[ "$output" =~ "Global arguments are not supported for this command" ]]
+    [[ "$output" =~ "Global arguments are not supported for this command" ]] || false
 }
 
 @test "sql-local-remote: verify commands without global arg support will fail with warning" {
@@ -1101,5 +1101,5 @@ SQL
     start_sql_server altDB
     run dolt --user dolt version
     [ $status -eq 1 ]
-    [[ "$output" =~ "This command does not support global arguments." ]]
+    [[ "$output" =~ "This command does not support global arguments." ]] || false
 }

--- a/integration-tests/bats/sql-merge.bats
+++ b/integration-tests/bats/sql-merge.bats
@@ -909,10 +909,10 @@ SQL
 
     run dolt status
     log_status_eq 0
-    [[ "$output" =~ "schema conflict:" ]]
+    [[ "$output" =~ "schema conflict:" ]] || false
     run dolt sql -q "select count(*) from dolt_schema_conflicts"
     log_status_eq 0
-    [[ "$output" =~ "1" ]]
+    [[ "$output" =~ "1" ]] || false
     dolt sql -q "call dolt_conflicts_resolve('--ours', 't')"
     dolt sql -q "show create table t"
     run dolt sql -q "show create table t"
@@ -972,10 +972,10 @@ SQL
     run dolt sql -q "call dolt_merge('other', '-m', 'merge other')"
     run dolt status
     log_status_eq 0
-    [[ "$output" =~ "schema conflict:" ]]
+    [[ "$output" =~ "schema conflict:" ]] || false
     run dolt sql -q "select count(*) from dolt_schema_conflicts"
     log_status_eq 0
-    [[ "$output" =~ "1" ]]
+    [[ "$output" =~ "1" ]] || false
     dolt sql -q "call dolt_conflicts_resolve('--ours', 't')"
     run dolt sql -q "show create table t"
     log_status_eq 0
@@ -1044,10 +1044,10 @@ SQL
     dolt sql -q "call dolt_merge('b2', '-m', 'merge b2')"
     run dolt status
     log_status_eq 0
-    [[ "$output" =~ "schema conflict:" ]]
+    [[ "$output" =~ "schema conflict:" ]] || false
     run dolt sql -q "select count(*) from dolt_schema_conflicts"
     log_status_eq 0
-    [[ "$output" =~ "1" ]]
+    [[ "$output" =~ "1" ]] || false
     dolt sql -q "call dolt_conflicts_resolve('--ours', 't')"
     run dolt sql -q "show create table t"
     log_status_eq 0
@@ -1079,10 +1079,10 @@ SQL
     dolt sql -q "call dolt_merge('b2', '-m', 'merge b2')"
     run dolt status
     log_status_eq 0
-    [[ "$output" =~ "schema conflict:" ]]
+    [[ "$output" =~ "schema conflict:" ]] || false
     run dolt sql -q "select count(*) from dolt_schema_conflicts"
     log_status_eq 0
-    [[ "$output" =~ "1" ]]
+    [[ "$output" =~ "1" ]] || false
     dolt sql -q "call dolt_conflicts_resolve('--ours', 't')"
     run dolt sql -q "show create table t"
     log_status_eq 0

--- a/integration-tests/bats/sql-tags.bats
+++ b/integration-tests/bats/sql-tags.bats
@@ -67,8 +67,8 @@ teardown() {
     dolt sql -q "CALL DOLT_TAG('v1', 'HEAD^')"
     run dolt diff v1
     [ $status -eq 0 ]
-    [[ "$output" =~ "- | 0" ]]
-    [[ "$output" =~ "+ | 3" ]]
+    [[ "$output" =~ "- | 0" ]] || false
+    [[ "$output" =~ "+ | 3" ]] || false
 }
 
 @test "sql-tags: use a tag as a ref for merge" {
@@ -80,9 +80,9 @@ teardown() {
     [ $status -eq 0 ]
     run dolt sql -q "select * from test"
     [ $status -eq 0 ]
-    [[ "$output" =~ "1" ]]
-    [[ "$output" =~ "2" ]]
-    [[ "$output" =~ "3" ]]
-    [[ "$output" =~ "8" ]]
-    [[ "$output" =~ "9" ]]
+    [[ "$output" =~ "1" ]] || false
+    [[ "$output" =~ "2" ]] || false
+    [[ "$output" =~ "3" ]] || false
+    [[ "$output" =~ "8" ]] || false
+    [[ "$output" =~ "9" ]] || false
 }

--- a/integration-tests/bats/sql.bats
+++ b/integration-tests/bats/sql.bats
@@ -45,7 +45,7 @@ teardown() {
     # default user is root
     run dolt sql -q "select user from mysql.user"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "root" ]]
+    [[ "$output" =~ "root" ]] || false
 
     # create user
     run dolt sql -q "create user new_user@'localhost'"


### PR DESCRIPTION
I ran into one of these missing ` || false` statements yesterday in another PR. It's confusing when the BATS tests pass locally and you can't repro a CI failure because of this quirk. I figured I'd do a quick audit to fix up any others. 

The command I used, was:
```
sed -E -i '' 's/\]\][[:space:]]*$/]] || false/' *.bats 
```