### PR TITLE
[no-release-notes] Automated check to prevent future bash test bugs on Mac

### DIFF
--- a/integration-tests/bats/bats.bats
+++ b/integration-tests/bats/bats.bats
@@ -1,14 +1,13 @@
 #!/usr/bin/env bats
 
-
-@test "bats: all assertions work on Mac" {
-    run pwd
-    echo "PWD: $output"
-
+# Assert that all bash test constructs will correctly fail on Mac OS's older bash version
+# by ending them with '|| false'.
+# https://github.com/sstephenson/bats/issues/49
+@test "bats: all bash test constructs end with '|| false' {
     run grep -E ' *\]\][[:space:]]*$' -n *.bats
     # grep returns 0 if matches are found, 1 if matches are NOT found, and 2 if no input files were found
     echo -e "Incorrect bash test constructs: \n$output"
-    [ "$status" -eq 1 ]
-    [[ "$output" =~ "No tables to export." ]]
-    [[ "$output" =~ "another" ]]
+    [ $status -eq 1 ]
+    [[ $output =~ "No tables to export." ]]
+    [[ $output =~ "another" ]]
 }

--- a/integration-tests/bats/bats.bats
+++ b/integration-tests/bats/bats.bats
@@ -1,0 +1,14 @@
+#!/usr/bin/env bats
+
+
+@test "bats: all assertions work on Mac" {
+    run pwd
+    echo "PWD: $output"
+
+    run grep -E ' *\]\][[:space:]]*$' -n *.bats
+    # grep returns 0 if matches are found, 1 if matches are NOT found, and 2 if no input files were found
+    echo -e "Incorrect bash test constructs: \n$output"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "No tables to export." ]]
+    [[ "$output" =~ "another" ]]
+}

--- a/integration-tests/bats/bats.bats
+++ b/integration-tests/bats/bats.bats
@@ -8,6 +8,4 @@
     # grep returns 0 if matches are found, 1 if matches are NOT found, and 2 if no input files were found
     echo -e "Incorrect bash test constructs: \n$output"
     [ $status -eq 1 ]
-    [[ $output =~ "No tables to export." ]]
-    [[ $output =~ "another" ]]
 }


### PR DESCRIPTION
While merging in https://github.com/dolthub/dolt/pull/6478, I wondered if there was a further step we could take to totally prevent future problems with this quirk, so I added a very quick BATS test that greps for the missing `|| false` issue that affects Mac OS and prints out any lines that are missing. Plus, it's fun to run `bats bats.bats`. 🦇

When it finds a missing `|| false`, [it fails the tests](https://github.com/dolthub/dolt/actions/runs/5814358497/job/15763874102?pr=6480#step:18:248) and outputs a list of the files and lines missing `|| false`: 
```
not ok 112 bats: all assertions work on Mac
# (in test file ./bats.bats, line 11)
#   `[ "$status" -eq 1 ]' failed
# Incorrect bash test constructs:
# bats.bats:12:    [[ "$output" =~ "No tables to export." ]]
# bats.bats:13:    [[ "$output" =~ "another one" ]]
```