### PR TITLE
feat: adding zsh plugin

### DIFF
--- a/dolt.plugin.zsh
+++ b/dolt.plugin.zsh
@@ -1,0 +1,13 @@
+if (( $+commands[dolt] )); then
+  # gen-zsh writes a file to the command line, and does not output the completion script like
+  # most other cli tools. For this reason, we write the file to the local directory and source it
+  local completion_path=${0:h}/_dolt
+
+  if [[ ! -e "$completion_path" ]]; then
+    # creates a completion file in the current directory
+    dolt gen-zsh --file="$completion_path"
+  fi
+
+  source "$completion_path"
+  compdef _dolt dolt
+fi


### PR DESCRIPTION
This isn't perfect, but it's a starting point. What would be better:

* Create a separate repo for just this script (`dolthub/zsh`) for easier installation
* Change gen-zsh to output the script to stdout like `gh`, `op`, and other popular tools

You can use this via a `for` loop in zinit like:

```
zinit wait lucid for \
  'https://github.com/iloveitaly/dolt/blob/zsh-plugin/dolt.plugin.zsh'
```