### PR TITLE
Bug fix: panic in schema merge when schema contains BLOB columns

### DIFF
--- a/go/libraries/doltcore/merge/merge_prolly_rows.go
+++ b/go/libraries/doltcore/merge/merge_prolly_rows.go
@@ -1376,7 +1376,7 @@ func migrateDataToMergedSchema(ctx *sql.Context, tm *TableMerger, vm *valueMerge
 		return err
 	}
 	leftRows := durable.ProllyMapFromIndex(lr)
-	mut := leftRows.Mutate()
+	mut := leftRows.Rewriter(mergedSch.GetKeyDescriptor(), mergedSch.GetValueDescriptor())
 	mapIter, err := mut.IterAll(ctx)
 	if err != nil {
 		return err

--- a/go/store/prolly/tuple_map.go
+++ b/go/store/prolly/tuple_map.go
@@ -208,6 +208,11 @@ func (m Map) Mutate() *MutableMap {
 	return newMutableMap(m)
 }
 
+// Rewriter returns a mutator that intends to rewrite this map with the key and value descriptors provided.
+func (m Map) Rewriter(kd, vd val.TupleDesc) *MutableMap {
+	return newMutableMapWithDescriptors(m, kd, vd)
+}
+
 // Count returns the number of key-value pairs in the Map.
 func (m Map) Count() (int, error) {
 	return m.tuples.Count()

--- a/go/store/prolly/tuple_mutable_map.go
+++ b/go/store/prolly/tuple_mutable_map.go
@@ -60,6 +60,17 @@ func newMutableMap(m Map) *MutableMap {
 	}
 }
 
+// newMutableMapWithDescriptors returns a new MutableMap with the key and value TupleDescriptors overridden to the
+// values specified in |kd| and |vd|. This is useful if you are rewriting the data in a map to change its schema.
+func newMutableMapWithDescriptors(m Map, kd, vd val.TupleDesc) *MutableMap {
+	return &MutableMap{
+		tuples:     m.tuples.Mutate(),
+		keyDesc:    kd,
+		valDesc:    vd,
+		maxPending: defaultMaxPending,
+	}
+}
+
 // Map materializes all pending and applied mutations in the MutableMap.
 func (mut *MutableMap) Map(ctx context.Context) (Map, error) {
 	s := message.NewProllyMapSerializer(mut.valDesc, mut.NodeStore().Pool())


### PR DESCRIPTION
When processing a schema merge, we need to update existing, stored data in the primary index. We weren't updating the value descriptor in the prolly map to the new version from the changed schema, which started causing a problem with `BLOB`/`TEXT` types since validation checked that the value stored in those fields was a valid address pointing outside of the table to the real data. 

Related to https://github.com/dolthub/dolt/pull/6496 – the reason that PR wasn't able to cleanly repro the exact failure was because the merge was getting short circuited, since the right and left sides weren't both making changes, so essentially the merge was getting fast-forwarded instead. 