### PR TITLE
dolt sql-server: Add a system_variables: key to config.yaml, which allows setting global system variables.

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -162,6 +162,7 @@ func Serve(
 		Autocommit:              serverConfig.AutoCommit(),
 		DoltTransactionCommit:   serverConfig.DoltTransactionCommit(),
 		JwksConfig:              serverConfig.JwksConfig(),
+		SystemVariables:         serverConfig.SystemVars(),
 		ClusterController:       clusterController,
 		BinlogReplicaController: binlogreplication.DoltBinlogReplicaController,
 	}

--- a/go/cmd/dolt/commands/sqlserver/serverconfig.go
+++ b/go/cmd/dolt/commands/sqlserver/serverconfig.go
@@ -150,6 +150,8 @@ type ServerConfig interface {
 	BranchControlFilePath() string
 	// UserVars is an array containing user specific session variables
 	UserVars() []UserSessionVars
+	// SystemVars is a map setting global SQL system variables. For example, `secure_file_priv`.
+	SystemVars() engine.SystemVariables
 	// JwksConfig is an array containing jwks config
 	JwksConfig() []engine.JwksConfig
 	// AllowCleartextPasswords is true if the server should accept cleartext passwords.
@@ -338,6 +340,10 @@ func (cfg *commandLineServerConfig) BranchControlFilePath() string {
 
 // UserVars is an array containing user specific session variables.
 func (cfg *commandLineServerConfig) UserVars() []UserSessionVars {
+	return nil
+}
+
+func (cfg *commandLineServerConfig) SystemVars() engine.SystemVariables {
 	return nil
 }
 

--- a/go/cmd/dolt/commands/sqlserver/yaml_config.go
+++ b/go/cmd/dolt/commands/sqlserver/yaml_config.go
@@ -138,23 +138,25 @@ type UserSessionVars struct {
 
 // YAMLConfig is a ServerConfig implementation which is read from a yaml file
 type YAMLConfig struct {
-	LogLevelStr       *string               `yaml:"log_level,omitempty"`
-	MaxQueryLenInLogs *int                  `yaml:"max_logged_query_len,omitempty"`
-	EncodeLoggedQuery *bool                 `yaml:"encode_logged_query,omitempty"`
-	BehaviorConfig    BehaviorYAMLConfig    `yaml:"behavior"`
-	UserConfig        UserYAMLConfig        `yaml:"user"`
-	ListenerConfig    ListenerYAMLConfig    `yaml:"listener"`
-	PerformanceConfig PerformanceYAMLConfig `yaml:"performance"`
-	DataDirStr        *string               `yaml:"data_dir,omitempty"`
-	CfgDirStr         *string               `yaml:"cfg_dir,omitempty"`
-	MetricsConfig     MetricsYAMLConfig     `yaml:"metrics"`
-	RemotesapiConfig  RemotesapiYAMLConfig  `yaml:"remotesapi"`
-	ClusterCfg        *ClusterYAMLConfig    `yaml:"cluster,omitempty"`
-	PrivilegeFile     *string               `yaml:"privilege_file,omitempty"`
-	BranchControlFile *string               `yaml:"branch_control_file,omitempty"`
-	Vars              []UserSessionVars     `yaml:"user_session_vars"`
-	Jwks              []engine.JwksConfig   `yaml:"jwks"`
-	GoldenMysqlConn   *string               `yaml:"golden_mysql_conn,omitempty"`
+	LogLevelStr       *string                `yaml:"log_level,omitempty"`
+	MaxQueryLenInLogs *int                   `yaml:"max_logged_query_len,omitempty"`
+	EncodeLoggedQuery *bool                  `yaml:"encode_logged_query,omitempty"`
+	BehaviorConfig    BehaviorYAMLConfig     `yaml:"behavior"`
+	UserConfig        UserYAMLConfig         `yaml:"user"`
+	ListenerConfig    ListenerYAMLConfig     `yaml:"listener"`
+	PerformanceConfig PerformanceYAMLConfig  `yaml:"performance"`
+	DataDirStr        *string                `yaml:"data_dir,omitempty"`
+	CfgDirStr         *string                `yaml:"cfg_dir,omitempty"`
+	MetricsConfig     MetricsYAMLConfig      `yaml:"metrics"`
+	RemotesapiConfig  RemotesapiYAMLConfig   `yaml:"remotesapi"`
+	ClusterCfg        *ClusterYAMLConfig     `yaml:"cluster,omitempty"`
+	PrivilegeFile     *string                `yaml:"privilege_file,omitempty"`
+	BranchControlFile *string                `yaml:"branch_control_file,omitempty"`
+	// TODO: Rename to UserVars_
+	Vars              []UserSessionVars      `yaml:"user_session_vars"`
+	SystemVars_       engine.SystemVariables `yaml:"system_variables"`
+	Jwks              []engine.JwksConfig    `yaml:"jwks"`
+	GoldenMysqlConn   *string                `yaml:"golden_mysql_conn,omitempty"`
 }
 
 var _ ServerConfig = YAMLConfig{}
@@ -432,6 +434,10 @@ func (cfg YAMLConfig) UserVars() []UserSessionVars {
 	}
 
 	return nil
+}
+
+func (cfg YAMLConfig) SystemVars() engine.SystemVariables {
+	return cfg.SystemVars_
 }
 
 // JwksConfig is JSON Web Key Set config, and used to validate a user authed with a jwt (JSON Web Token).

--- a/go/cmd/dolt/commands/sqlserver/yaml_config.go
+++ b/go/cmd/dolt/commands/sqlserver/yaml_config.go
@@ -138,25 +138,25 @@ type UserSessionVars struct {
 
 // YAMLConfig is a ServerConfig implementation which is read from a yaml file
 type YAMLConfig struct {
-	LogLevelStr       *string                `yaml:"log_level,omitempty"`
-	MaxQueryLenInLogs *int                   `yaml:"max_logged_query_len,omitempty"`
-	EncodeLoggedQuery *bool                  `yaml:"encode_logged_query,omitempty"`
-	BehaviorConfig    BehaviorYAMLConfig     `yaml:"behavior"`
-	UserConfig        UserYAMLConfig         `yaml:"user"`
-	ListenerConfig    ListenerYAMLConfig     `yaml:"listener"`
-	PerformanceConfig PerformanceYAMLConfig  `yaml:"performance"`
-	DataDirStr        *string                `yaml:"data_dir,omitempty"`
-	CfgDirStr         *string                `yaml:"cfg_dir,omitempty"`
-	MetricsConfig     MetricsYAMLConfig      `yaml:"metrics"`
-	RemotesapiConfig  RemotesapiYAMLConfig   `yaml:"remotesapi"`
-	ClusterCfg        *ClusterYAMLConfig     `yaml:"cluster,omitempty"`
-	PrivilegeFile     *string                `yaml:"privilege_file,omitempty"`
-	BranchControlFile *string                `yaml:"branch_control_file,omitempty"`
+	LogLevelStr       *string               `yaml:"log_level,omitempty"`
+	MaxQueryLenInLogs *int                  `yaml:"max_logged_query_len,omitempty"`
+	EncodeLoggedQuery *bool                 `yaml:"encode_logged_query,omitempty"`
+	BehaviorConfig    BehaviorYAMLConfig    `yaml:"behavior"`
+	UserConfig        UserYAMLConfig        `yaml:"user"`
+	ListenerConfig    ListenerYAMLConfig    `yaml:"listener"`
+	PerformanceConfig PerformanceYAMLConfig `yaml:"performance"`
+	DataDirStr        *string               `yaml:"data_dir,omitempty"`
+	CfgDirStr         *string               `yaml:"cfg_dir,omitempty"`
+	MetricsConfig     MetricsYAMLConfig     `yaml:"metrics"`
+	RemotesapiConfig  RemotesapiYAMLConfig  `yaml:"remotesapi"`
+	ClusterCfg        *ClusterYAMLConfig    `yaml:"cluster,omitempty"`
+	PrivilegeFile     *string               `yaml:"privilege_file,omitempty"`
+	BranchControlFile *string               `yaml:"branch_control_file,omitempty"`
 	// TODO: Rename to UserVars_
-	Vars              []UserSessionVars      `yaml:"user_session_vars"`
-	SystemVars_       engine.SystemVariables `yaml:"system_variables"`
-	Jwks              []engine.JwksConfig    `yaml:"jwks"`
-	GoldenMysqlConn   *string                `yaml:"golden_mysql_conn,omitempty"`
+	Vars            []UserSessionVars      `yaml:"user_session_vars"`
+	SystemVars_     engine.SystemVariables `yaml:"system_variables"`
+	Jwks            []engine.JwksConfig    `yaml:"jwks"`
+	GoldenMysqlConn *string                `yaml:"golden_mysql_conn,omitempty"`
 }
 
 var _ ServerConfig = YAMLConfig{}

--- a/integration-tests/go-sql-server-driver/tests/sql-server-config.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-config.yaml
@@ -306,3 +306,74 @@ tests:
       result:
         columns: ["@@GLOBAL.dolt_log_level"]
         rows: [["info"]]
+- name: system variables in config.yaml can be read in show variables
+  repos:
+  - name: repo1
+    with_files:
+      - name: "config.yaml"
+        contents: |
+          system_variables:
+            secure_file_priv: "/dev/null"
+            max_connections: 1000
+    server:
+      args: ["-l", "trace", "--config", "config.yaml"]
+  connections:
+  - on: repo1
+    queries:
+    - query: "select @@GLOBAL.secure_file_priv, @@GLOBAL.max_connections"
+      result:
+        columns: ["@@GLOBAL.secure_file_priv", "@@GLOBAL.max_connections"]
+        rows: [["/dev/null", "1000"]]
+- name: secure_file_priv set to /dev/null prevents loading files
+  repos:
+  - name: repo1
+    with_files:
+      - name: "config.yaml"
+        contents: |
+          system_variables:
+            secure_file_priv: "/dev/null"
+    server:
+      args: ["-l", "trace", "--config", "config.yaml"]
+  connections:
+  - on: repo1
+    queries:
+    - query: "select LOAD_FILE('config.yaml')"
+      result:
+        columns: ["LOAD_FILE('config.yaml')"]
+        rows: [["NULL"]]
+    - query: "select LOAD_FILE('/etc/passwd')"
+      result:
+        columns: ["LOAD_FILE('/etc/passwd')"]
+        rows: [["NULL"]]
+    - exec: "create table loaded (contents text)"
+    - exec: "load data infile \"config.yaml\" into table loaded"
+      error_match: "LOAD DATA is unable to open file: open /dev/null/config.yaml"
+    - exec: "load data infile \"/config.yaml\" into table loaded"
+      error_match: "LOAD DATA is unable to open file: open /dev/null/config.yaml"
+- name: secure_file_priv set to empty strings allows loading files
+  repos:
+  - name: repo1
+    with_files:
+      - name: "config.yaml"
+        contents: |
+          system_variables:
+            secure_file_priv: ""
+    server:
+      args: ["-l", "trace", "--config", "config.yaml"]
+  connections:
+  - on: repo1
+    queries:
+    - query: "select LOAD_FILE('config.yaml')"
+      result:
+        columns: ["LOAD_FILE('config.yaml')"]
+        rows: [["system_variables:\n  secure_file_priv: \"\"\n"]]
+    - query: "select LOAD_FILE('./.dolt/../config.yaml')"
+      result:
+        columns: ["LOAD_FILE('./.dolt/../config.yaml')"]
+        rows: [["system_variables:\n  secure_file_priv: \"\"\n"]]
+    - exec: "create table loaded (contents text)"
+    - exec: "load data infile \"config.yaml\" into table loaded lines terminated by \"\\0\""
+    - query: "select contents from loaded"
+      result:
+        columns: ["contents"]
+        rows: [["system_variables:\n  secure_file_priv: \"\"\n"]]


### PR DESCRIPTION
For example, this can be used to set `secure_file_priv` when the server starts up. That variable is non-dynamic, so it cannot be set with `SET @@GLOBAL...`