### PR TITLE
Changing primary index to use the Rewriter function, instead of Mutate

### DIFF
--- a/go/libraries/doltcore/merge/merge_prolly_rows.go
+++ b/go/libraries/doltcore/merge/merge_prolly_rows.go
@@ -133,7 +133,7 @@ func mergeProllyTableData(ctx *sql.Context, tm *TableMerger, finalSch schema.Sch
 	if err != nil {
 		return nil, nil, err
 	}
-	leftEditor := durable.ProllyMapFromIndex(lr).Mutate()
+	leftEditor := durable.ProllyMapFromIndex(lr).Rewriter(finalSch.GetKeyDescriptor(), finalSch.GetValueDescriptor())
 
 	ai, err := mergeTbl.GetArtifacts(ctx)
 	if err != nil {


### PR DESCRIPTION
Ensures that the tuple descriptors use the correct types, and don't do address validation on unnecessary data.