### PR TITLE
`dolt version` only prints the dolt version if there is no dolt database in the directory.

### DIFF
--- a/go/cmd/dolt/commands/version.go
+++ b/go/cmd/dolt/commands/version.go
@@ -68,8 +68,6 @@ func (cmd VersionCmd) Exec(ctx context.Context, commandStr string, args []string
 	} else if dEnv.HasDoltDir() && dEnv.RSLoadErr == nil {
 		nbf := dEnv.DoltDB.Format()
 		cli.Printf("database storage format: %s\n", dfunctions.GetStorageFormatDisplayString(nbf))
-	} else {
-		cli.Println("no valid database in this directory")
 	}
 
 	usage := func() {}

--- a/integration-tests/bats/init.bats
+++ b/integration-tests/bats/init.bats
@@ -244,7 +244,7 @@ teardown() {
     cd ..
     run dolt version
     [ "$status" -eq 0 ]
-    [[ $output =~ "no valid database in this directory" ]] || false
+    ! [[ $output =~ "no valid database in this directory" ]] || false
 
     dolt sql -q "create database test"
     run ls

--- a/integration-tests/bats/init.bats
+++ b/integration-tests/bats/init.bats
@@ -191,14 +191,6 @@ teardown() {
     [[ $output =~ "NEW ( __DOLT__ )" ]] || false
 }
 
-@test "init: empty database folder displays no version" {
-    set_dolt_user "baz", "bazbash.com"
-
-    run dolt version
-    [ $status -eq 0 ]
-    [[ $output =~ "no valid database in this directory" ]] || false
-}
-
 @test "init: run init with --new-format, CREATE DATABASE through sql-server running in new-format repo should create a new format database" {
     set_dolt_user "baz", "baz@bash.com"
 


### PR DESCRIPTION
Remove "no valid database in this directory" from `dolt version` in the case of no dolt database found.