### PR TITLE
Empty Servers allow `dolt sql` connections without arguments

### DIFF
--- a/go/cmd/dolt/commands/init.go
+++ b/go/cmd/dolt/commands/init.go
@@ -96,7 +96,7 @@ func (cmd InitCmd) Exec(ctx context.Context, commandStr string, args []string, d
 		return 1
 	}
 
-	if dEnv.HasDoltDir() {
+	if dEnv.HasDoltDataDir() {
 		cli.PrintErrln(color.RedString("This directory has already been initialized."))
 		return 1
 	}

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -131,6 +131,7 @@ func Serve(
 		if err != nil {
 			return err, nil
 		}
+		dEnv.FS = fs
 	}
 
 	serverLock, startError := acquireGlobalSqlServerLock(serverConfig.Port(), dEnv)

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -387,7 +387,7 @@ func acquireGlobalSqlServerLock(port int, dEnv *env.DoltEnv) (*env.DBLock, error
 	}
 	if locked {
 		lockPath := dEnv.LockFile()
-		err = fmt.Errorf("Server can not start. Found lock file at '%s'", lockPath)
+		err = fmt.Errorf("Database locked by another sql-server; Lock file: %s", lockPath)
 		return nil, err
 	}
 

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -138,7 +138,7 @@ func Serve(
 	if startError != nil {
 		return
 	}
-	defer fs.Delete(dEnv.LockFile(), false)
+	defer dEnv.FS.Delete(dEnv.LockFile(), false)
 
 	mrEnv, err = env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), fs, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
 	if err != nil {

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -137,6 +137,7 @@ func Serve(
 	if startError != nil {
 		return
 	}
+	defer fs.Delete(dEnv.LockFile(), false)
 
 	mrEnv, err = env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), fs, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
 	if err != nil {

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -525,7 +525,7 @@ func runMain() int {
 	// variables like `${db_name}_default_branch` (maybe these should not be
 	// part of Dolt config in the first place!).
 
-	// Current working director is preserved to ensure that user provided path arguments are always calculated
+	// Current working directory is preserved to ensure that user provided path arguments are always calculated
 	// relative to this directory. The root environment's FS will be updated to be the --data-dir path if the user
 	// specified one.
 	cwdFS := dEnv.FS

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -530,6 +530,8 @@ func runMain() int {
 		cli.PrintErrln(color.RedString("Failed to set the data directory. %v", err))
 		return 1
 	}
+	dEnv.FS = dataDirFS
+
 	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dataDirFS, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
 	if err != nil {
 		cli.PrintErrln("failed to load database names")

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -1268,6 +1268,13 @@ func (dEnv *DoltEnv) Unlock() error {
 
 // WriteLockfile writes a lockfile encoding the pid of the calling process.
 func WriteLockfile(fs filesys.Filesys, lock *DBLock) error {
+	// if the DoltDir doesn't exist, create it.
+	doltDir, _ := fs.Abs(dbfactory.DoltDir)
+	err := fs.MkDirs(doltDir)
+	if err != nil {
+		return err
+	}
+
 	lockFile, _ := fs.Abs(filepath.Join(dbfactory.DoltDir, ServerLockFile))
 
 	portStr := strconv.Itoa(lock.Port)
@@ -1286,7 +1293,7 @@ func WriteLockfile(fs filesys.Filesys, lock *DBLock) error {
 		}
 	}
 
-	err := fs.WriteFile(lockFile, []byte(fmt.Sprintf("%d:%s:%s", lock.Pid, portStr, lock.Secret)))
+	err = fs.WriteFile(lockFile, []byte(fmt.Sprintf("%d:%s:%s", lock.Pid, portStr, lock.Secret)))
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -1203,7 +1203,7 @@ func NewDBLock(port int) DBLock {
 }
 
 // Lock writes this database's lockfile with the pid of the calling process or errors if it already exists
-func (dEnv *DoltEnv) Lock(lock DBLock) error {
+func (dEnv *DoltEnv) Lock(lock *DBLock) error {
 	if dEnv.IgnoreLockFile {
 		return nil
 	}
@@ -1267,7 +1267,7 @@ func (dEnv *DoltEnv) Unlock() error {
 }
 
 // WriteLockfile writes a lockfile encoding the pid of the calling process.
-func WriteLockfile(fs filesys.Filesys, lock DBLock) error {
+func WriteLockfile(fs filesys.Filesys, lock *DBLock) error {
 	lockFile, _ := fs.Abs(filepath.Join(dbfactory.DoltDir, ServerLockFile))
 
 	portStr := strconv.Itoa(lock.Port)

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -1282,7 +1283,7 @@ func WriteLockfile(fs filesys.Filesys, lock *DBLock) error {
 		portStr = "-"
 	}
 
-	if filesys.LocalFS == fs {
+	if reflect.TypeOf(fs) == reflect.TypeOf(filesys.LocalFS) {
 		_, err := os.Create(lockFile)
 		if err != nil {
 			return err

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -428,7 +428,15 @@ func (dEnv *DoltEnv) createDirectories(dir string) (string, error) {
 	}
 
 	if dEnv.hasDoltDir(dir) {
-		return "", fmt.Errorf(".dolt directory already exists at '%s'", dir)
+		// Special case a completely empty directory. We can allow that.
+		dotDolt := mustAbs(dEnv, dbfactory.DoltDir)
+		entries, err := os.ReadDir(dotDolt)
+		if err != nil {
+			return "", err
+		}
+		if len(entries) != 0 {
+			return "", fmt.Errorf(".dolt directory already exists at '%s'", dir)
+		}
 	}
 
 	absDataDir := filepath.Join(absPath, dbfactory.DoltDataDir)

--- a/go/libraries/doltcore/env/multi_repo_env.go
+++ b/go/libraries/doltcore/env/multi_repo_env.go
@@ -303,7 +303,7 @@ func (mrEnv *MultiRepoEnv) IsLocked() (bool, string) {
 
 // Lock locks all child envs. The DBLock contains the details to write to the lock files. If an error is returned, all
 // child envs will be returned with their initial lock state.
-func (mrEnv *MultiRepoEnv) Lock(lck DBLock) (err error) {
+func (mrEnv *MultiRepoEnv) Lock(lck *DBLock) (err error) {
 	if mrEnv.ignoreLockFile {
 		return nil
 	}

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_test.go
@@ -600,6 +600,13 @@ func stopDoltSqlServer(t *testing.T) {
 		err = os.Remove(lockFilepath)
 		require.NoError(t, err)
 	}
+	// Remove the global sql-server lock file as well
+	lockFilepath = filepath.Join(testDir, "dolt", ".dolt", "sql-server.lock")
+	stat, _ = os.Stat(lockFilepath)
+	if stat != nil {
+		err = os.Remove(lockFilepath)
+		require.NoError(t, err)
+	}
 }
 
 func startReplication(_ *testing.T, port int) {

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -406,7 +406,7 @@ func (p DoltDatabaseProvider) CreateCollatedDatabase(ctx *sql.Context, name stri
 	// be the first db creation if sql-server was started from a bare directory.
 	_, lckDeets := sqlserver.GetRunningServer()
 	if lckDeets != nil {
-		err = newEnv.Lock(*lckDeets)
+		err = newEnv.Lock(lckDeets)
 		if err != nil {
 			ctx.GetLogger().Warnf("Failed to lock newly created database: %s", err.Error())
 		}

--- a/integration-tests/bats/init.bats
+++ b/integration-tests/bats/init.bats
@@ -248,6 +248,33 @@ teardown() {
     [[ "$output" =~ "__DOLT__" ]] || false
 }
 
+@test "init: create a db when there is an empty .dolt dir works" {
+    set_dolt_user "baz", "baz@bash.com"
+
+    mkdir dbdir
+    cd dbdir
+    mkdir .dolt
+
+    dolt init
+}
+
+@test "init: Fail when there is anything in the .dolt dir" {
+    set_dolt_user "baz", "baz@bash.com"
+
+    mkdir dbdir
+    cd dbdir
+    mkdir .dolt
+
+    # Possible real world situation. sql-server crashes and leaves a lock file.
+    # Currently we don't handle this.
+    echo "42:3306:aebf244e-0693-4c36-8b2d-6eb0dfa4fe2d" > .dolt/sql-server.lock
+
+    run dolt init
+
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ ".dolt directory already exists" ]] || false
+}
+
 @test "init: fun flag produces an initial commit with the right hash" {
     set_dolt_user "baz", "baz@bash.com"	
     dolt init --fun

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -1969,6 +1969,4 @@ behavior:
     run dolt sql -q "select current_user"
     [ $status -eq 0 ]
     [[ "$output" =~ "__dolt_local_user__@localhost" ]] || false
-
-    teardown
 }

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -1924,3 +1924,26 @@ behavior:
     [[ "$output" =~ "main" ]] || false
     [[ ! "$output" =~ "other" ]] || false
 }
+
+@test "sql-server: server won't start where another server is running" {
+    baseDir=$(mktemp -d)
+    cd $baseDir
+
+    start_sql_server
+
+    run dolt sql-server
+
+    [ $status -eq 1 ]
+    [[ "$output" =~ "Database locked by another sql-server; Lock file" ]] || false
+}
+
+@test "sql-server: empty server can be connected to using sql with no args" {
+    baseDir=$(mktemp -d)
+    cd $baseDir
+
+    start_sql_server
+
+    run dolt sql -q "select current_user"
+    [ $status -eq 0 ]
+    [[ "$output" =~ "__dolt_local_user__@localhost" ]] || false
+}

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -1658,7 +1658,8 @@ behavior:
     PORT=$( definePORT )
     run dolt sql-server --port=$PORT --socket "dolt.$PORT.sock"
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "database locked by another sql-server; either clone the database to run a second server" ]] || false
+
+    [[ "$output" =~ "Database locked by another sql-server" ]] || false
     stop_sql_server 1
 }
 

--- a/integration-tests/bats/sql.bats
+++ b/integration-tests/bats/sql.bats
@@ -2875,3 +2875,18 @@ SQL
     [ "$status" -eq 0 ]
     [[ "$output" =~ "should be able to read this" ]] || false
 }
+
+@test "sql: ignore an empty .dolt directory" {
+    mkdir empty_dir
+    cd empty_dir
+
+    mkdir .dolt
+    dolt sql -q "select 1"
+
+    # If there is a zombie lock file, sql should delete it.
+    echo "42:3306:aebf244e-0693-4c36-8b2d-6eb0dfa4fe2d" > .dolt/sql-server.lock}
+
+    dolt sql -q "select 1"
+
+    [[ ! -f .dolt/sql-server.lock ]] || false
+}


### PR DESCRIPTION
WIth this change, starting `sql-server` will result in creating a .dolt/sql-server.lock file in the --data-dir (CWD by default). This file will be used for two purposes:
1) Ensuring another `dolt sql-server` is not started with the same data dir.
2) Allowing the `dolt sql` command to connect to it. See related issue: https://github.com/dolthub/dolt/issues/6508