### PR TITLE
When checking out a branch, consider it clean if the working set differs from the head only by feature version.

### DIFF
--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -547,7 +547,7 @@ func (ddb *DoltDB) WriteRootValue(ctx context.Context, rv *RootValue) (*RootValu
 }
 
 func (ddb *DoltDB) writeRootValue(ctx context.Context, rv *RootValue) (*RootValue, types.Ref, error) {
-	rv, err := rv.setFeatureVersion(DoltFeatureVersion)
+	rv, err := rv.SetFeatureVersion(DoltFeatureVersion)
 	if err != nil {
 		return nil, types.Ref{}, err
 	}

--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -382,7 +382,7 @@ func (root *RootValue) GetFeatureVersion(ctx context.Context) (ver FeatureVersio
 	return root.st.GetFeatureVersion()
 }
 
-func (root *RootValue) setFeatureVersion(v FeatureVersion) (*RootValue, error) {
+func (root *RootValue) SetFeatureVersion(v FeatureVersion) (*RootValue, error) {
 	newStorage, err := root.st.SetFeatureVersion(v)
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/dtestutils/testcommands/multienv.go
+++ b/go/libraries/doltcore/dtestutils/testcommands/multienv.go
@@ -173,7 +173,7 @@ func (mr *MultiRepoTestSetup) CheckoutBranch(dbName, branchName string) {
 		mr.Errhand(err)
 	}
 	defer closeFunc()
-	err = dprocedures.MoveWorkingSetToBranch(sqlCtx, branchName, false)
+	err = dprocedures.MoveWorkingSetToBranch(sqlCtx, branchName, false, false)
 	if err != nil {
 		mr.Errhand(err)
 	}

--- a/go/libraries/doltcore/env/actions/checkout.go
+++ b/go/libraries/doltcore/env/actions/checkout.go
@@ -471,7 +471,30 @@ func writeTableHashes(ctx context.Context, head *doltdb.RootValue, tblHashes map
 // This means that if both working sets are present (ie there are changes on both source and dest branches),
 // we check if the changes are identical before allowing a clobbering checkout.
 // Working set errors are ignored by this function, because they are properly handled elsewhere.
-func CheckoutWouldStompWorkingSetChanges(sourceRoots, destRoots doltdb.Roots) bool {
+func CheckoutWouldStompWorkingSetChanges(ctx context.Context, sourceRoots, destRoots doltdb.Roots) (bool, error) {
+
+	wouldStomp := doRootsHaveIncompatibleChanges(sourceRoots, destRoots)
+
+	if !wouldStomp {
+		return false, nil
+	}
+
+	// In some cases, a working set differs from its head only by the feature version.
+	// If this is the case, moving the working set is safe.
+	modifiedSourceRoots, err := clearFeatureVersion(ctx, sourceRoots)
+	if err != nil {
+		return true, err
+	}
+
+	modifiedDestRoots, err := clearFeatureVersion(ctx, destRoots)
+	if err != nil {
+		return true, err
+	}
+
+	return doRootsHaveIncompatibleChanges(modifiedSourceRoots, modifiedDestRoots), nil
+}
+
+func doRootsHaveIncompatibleChanges(sourceRoots, destRoots doltdb.Roots) bool {
 	sourceHasChanges, sourceWorkingHash, sourceStagedHash, err := RootHasUncommittedChanges(sourceRoots)
 	if err != nil {
 		return false
@@ -485,6 +508,32 @@ func CheckoutWouldStompWorkingSetChanges(sourceRoots, destRoots doltdb.Roots) bo
 	// This is a stomping checkout operation if both the source and dest have uncommitted changes, and they're not the
 	// same uncommitted changes
 	return sourceHasChanges && destHasChanges && (sourceWorkingHash != destWorkingHash || sourceStagedHash != destStagedHash)
+}
+
+// clearFeatureVersion creates a new version of the provided roots where all three roots have the same
+// feature version. By hashing these new roots, we can easily determine whether the roots differ only by
+// their feature version.
+func clearFeatureVersion(ctx context.Context, roots doltdb.Roots) (doltdb.Roots, error) {
+	currentBranchFeatureVersion, _, err := roots.Head.GetFeatureVersion(ctx)
+	if err != nil {
+		return doltdb.Roots{}, err
+	}
+
+	modifiedWorking, err := roots.Working.SetFeatureVersion(currentBranchFeatureVersion)
+	if err != nil {
+		return doltdb.Roots{}, err
+	}
+
+	modifiedStaged, err := roots.Staged.SetFeatureVersion(currentBranchFeatureVersion)
+	if err != nil {
+		return doltdb.Roots{}, err
+	}
+
+	return doltdb.Roots{
+		Head:    roots.Head,
+		Working: modifiedWorking,
+		Staged:  modifiedStaged,
+	}, nil
 }
 
 // RootHasUncommittedChanges returns whether the roots given have uncommitted changes, and the hashes of the working and staged roots

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_checkout.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_checkout.go
@@ -365,7 +365,7 @@ func checkoutNewBranch(ctx *sql.Context, dbName string, dbData env.DbData, apr *
 	}
 
 	if isMove {
-		return newBranchName, remoteAndBranch, doGlobalCheckout(ctx, newBranchName, apr.Contains(cli.ForceFlag))
+		return newBranchName, remoteAndBranch, doGlobalCheckout(ctx, newBranchName, apr.Contains(cli.ForceFlag), true)
 	} else {
 
 		wsRef, err := ref.WorkingSetRefForHead(ref.NewBranchRef(newBranchName))
@@ -396,7 +396,7 @@ func checkoutExistingBranch(ctx *sql.Context, dbName string, branchName string, 
 	dSess := dsess.DSessFromSess(ctx.Session)
 
 	if apr.Contains(cli.MoveFlag) {
-		return doGlobalCheckout(ctx, branchName, apr.Contains(cli.ForceFlag))
+		return doGlobalCheckout(ctx, branchName, apr.Contains(cli.ForceFlag), false)
 	} else {
 
 		err = dSess.SwitchWorkingSet(ctx, dbName, wsRef)
@@ -410,9 +410,9 @@ func checkoutExistingBranch(ctx *sql.Context, dbName string, branchName string, 
 
 // doGlobalCheckout implements the behavior of the `dolt checkout` command line, moving the working set into
 // the new branch and persisting the checked-out branch into future sessions
-func doGlobalCheckout(ctx *sql.Context, branchName string, isForce bool) error {
+func doGlobalCheckout(ctx *sql.Context, branchName string, isForce bool, isNewBranch bool) error {
 
-	err := MoveWorkingSetToBranch(ctx, branchName, isForce)
+	err := MoveWorkingSetToBranch(ctx, branchName, isForce, isNewBranch)
 	if err != nil && err != doltdb.ErrAlreadyOnBranch {
 		return err
 	}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_checkout_helpers.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_checkout_helpers.go
@@ -29,7 +29,7 @@ import (
 
 // MoveWorkingSetToBranch moves the working set from the currently checked out branch onto the branch specified
 // by `brName`. This is a POTENTIALLY DESTRUCTIVE ACTION used during command line checkout
-func MoveWorkingSetToBranch(ctx *sql.Context, brName string, force bool) error {
+func MoveWorkingSetToBranch(ctx *sql.Context, brName string, force bool, isNewBranch bool) error {
 	branchRef := ref.NewBranchRef(brName)
 	dSess := dsess.DSessFromSess(ctx.Session)
 	dbName := dSess.GetCurrentDatabase()
@@ -78,7 +78,7 @@ func MoveWorkingSetToBranch(ctx *sql.Context, brName string, force bool) error {
 		if err != nil {
 			return err
 		}
-		if actions.CheckoutWouldStompWorkingSetChanges(currentRoots, newBranchRoots) {
+		if !isNewBranch && actions.CheckoutWouldStompWorkingSetChanges(currentRoots, newBranchRoots) {
 			return actions.ErrWorkingSetsOnBothBranches
 		}
 	}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_checkout_helpers.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_checkout_helpers.go
@@ -15,7 +15,6 @@
 package dprocedures
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -79,20 +78,12 @@ func MoveWorkingSetToBranch(ctx *sql.Context, brName string, force bool, isNewBr
 		if err != nil {
 			return err
 		}
-		if !isNewBranch && actions.CheckoutWouldStompWorkingSetChanges(currentRoots, newBranchRoots) {
-			// In some cases, a working set differs from its head only by the feature version.
-			// If this is the case, moving the working set is safe.
-			modifiedCurrentRoots, err := clearFeatureVersion(ctx, currentRoots)
+		if !isNewBranch {
+			wouldStomp, err := actions.CheckoutWouldStompWorkingSetChanges(ctx, currentRoots, newBranchRoots)
 			if err != nil {
 				return err
 			}
-
-			modifiedNewRoots, err := clearFeatureVersion(ctx, newBranchRoots)
-			if err != nil {
-				return err
-			}
-
-			if !isNewBranch && actions.CheckoutWouldStompWorkingSetChanges(modifiedCurrentRoots, modifiedNewRoots) {
+			if wouldStomp {
 				return actions.ErrWorkingSetsOnBothBranches
 			}
 		}
@@ -152,32 +143,6 @@ func MoveWorkingSetToBranch(ctx *sql.Context, brName string, force bool, isNewBr
 	}
 
 	return nil
-}
-
-// clearFeatureVersion creates a new version of the provided roots where all three roots have the same
-// feature version. By hashing these new roots, we can easily determine whether the roots differ only by
-// their feature version.
-func clearFeatureVersion(ctx context.Context, roots doltdb.Roots) (doltdb.Roots, error) {
-	currentBranchFeatureVersion, _, err := roots.Head.GetFeatureVersion(ctx)
-	if err != nil {
-		return doltdb.Roots{}, err
-	}
-
-	modifiedWorking, err := roots.Working.SetFeatureVersion(currentBranchFeatureVersion)
-	if err != nil {
-		return doltdb.Roots{}, err
-	}
-
-	modifiedStaged, err := roots.Staged.SetFeatureVersion(currentBranchFeatureVersion)
-	if err != nil {
-		return doltdb.Roots{}, err
-	}
-
-	return doltdb.Roots{
-		Head:    roots.Head,
-		Working: modifiedWorking,
-		Staged:  modifiedStaged,
-	}, nil
 }
 
 // transferWorkingChanges computes new roots for `branchRef` by applying the changes from the staged and working sets

--- a/integration-tests/bats/feature-version.bats
+++ b/integration-tests/bats/feature-version.bats
@@ -131,7 +131,7 @@ SQL
     popd
 }
 
-@test "checkout: dolt checkout can be used when a working set has a different feature version than its head" {
+@test "feature-version: dolt checkout can be used when a working set has a different feature version than its head" {
     rm -rf .dolt/
     dolt --feature-version $OLD init
     dolt --feature-version $NEW sql -q "create table a (b int);"

--- a/integration-tests/bats/feature-version.bats
+++ b/integration-tests/bats/feature-version.bats
@@ -130,3 +130,17 @@ SQL
     dolt --feature-version $OLD checkout other
     popd
 }
+
+@test "checkout: dolt checkout can be used when a working set has a different feature version than its head" {
+    rm -rf .dolt/
+    dolt --feature-version $OLD init
+    dolt --feature-version $NEW sql -q "create table a (b int);"
+    dolt --feature-version $NEW checkout -b other
+    run dolt --feature-version $NEW status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "other" ]] || false
+    dolt --feature-version $NEW checkout main
+    run dolt --feature-version $NEW status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "main" ]] || false
+}


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/6524

`RootValue` is backed by a flatbuffer, but access to the flatbuffer is hidden behind interfaces. We check if two `RootValues` are equal by checking the RootValue's hash. This makes it awkward to check to see if two `RootValues` differ only by a single field.

The solution here is both simple and noninvasive: we create modified root values with the same feature version and hash them again.

This also adds an escape hatch when creating new branches, since we know that the new branches will be clean. We only do this extra check when checking out an existing branch.