### PR TITLE
Silence branch create

### DIFF
--- a/go/cmd/dolt/commands/branch.go
+++ b/go/cmd/dolt/commands/branch.go
@@ -403,7 +403,10 @@ func moveBranch(sqlCtx *sql.Context, queryEngine cli.Queryist, apr *argparser.Ar
 		return 1
 	}
 
-	var newName = apr.Arg(1)
+	var newName = apr.Arg(0)
+	if apr.NArg() == 2 {
+		newName = apr.Arg(1)
+	}
 	if !doltdb.IsValidUserBranchName(newName) {
 		cli.PrintErrf("%s is an invalid branch name", newName)
 		return 1
@@ -433,9 +436,12 @@ func copyBranch(sqlCtx *sql.Context, queryEngine cli.Queryist, apr *argparser.Ar
 		return 1
 	}
 
-	var branchName = apr.Arg(1)
-	if !doltdb.IsValidUserBranchName(branchName) {
-		cli.PrintErrf("%s is an invalid branch name", branchName)
+	var toName = apr.Arg(0)
+	if apr.NArg() == 2 {
+		toName = apr.Arg(1)
+	}
+	if !doltdb.IsValidUserBranchName(toName) {
+		cli.PrintErrf("%s is an invalid branch name", toName)
 		return 1
 	}
 

--- a/go/cmd/dolt/commands/branch.go
+++ b/go/cmd/dolt/commands/branch.go
@@ -403,6 +403,12 @@ func moveBranch(sqlCtx *sql.Context, queryEngine cli.Queryist, apr *argparser.Ar
 		return 1
 	}
 
+	var newName = apr.Arg(1)
+	if !doltdb.IsValidUserBranchName(newName) {
+		cli.PrintErrf("%s is an invalid branch name", newName)
+		return 1
+	}
+
 	return callStoredProcedure(sqlCtx, queryEngine, args)
 }
 
@@ -424,6 +430,12 @@ func copyBranch(sqlCtx *sql.Context, queryEngine cli.Queryist, apr *argparser.Ar
 
 	if apr.Contains(cli.RemoteParam) {
 		cli.PrintErrln("--remote/-r can only be supplied when listing or deleting branches, not when copying branches")
+		return 1
+	}
+
+	var branchName = apr.Arg(1)
+	if !doltdb.IsValidUserBranchName(branchName) {
+		cli.PrintErrf("%s is an invalid branch name", branchName)
 		return 1
 	}
 

--- a/go/cmd/dolt/commands/branch.go
+++ b/go/cmd/dolt/commands/branch.go
@@ -122,12 +122,6 @@ func (cmd BranchCmd) Exec(ctx context.Context, commandStr string, args []string,
 		return 1
 	}
 
-	for _, arg := range apr.Args {
-		if !doltdb.IsValidUserBranchName(arg) {
-			cli.PrintErrf("%s is an invalid branch name", arg)
-		}
-	}
-
 	switch {
 	case apr.Contains(cli.MoveFlag):
 		return moveBranch(sqlCtx, queryEngine, apr, args, usage)
@@ -321,6 +315,7 @@ func generateBranchSql(args []string) (string, error) {
 }
 
 func createBranch(sqlCtx *sql.Context, queryEngine cli.Queryist, apr *argparser.ArgParseResults, args []string, usage cli.UsagePrinter) int {
+
 	trackVal, setTrackUpstream := apr.GetValue(cli.TrackFlag)
 	if setTrackUpstream {
 		if trackVal == "inherit" {
@@ -365,6 +360,12 @@ func createBranch(sqlCtx *sql.Context, queryEngine cli.Queryist, apr *argparser.
 
 	if apr.Contains(cli.RemoteParam) {
 		cli.PrintErrln("--remote/-r can only be supplied when listing or deleting branches, not when creating branches")
+		return 1
+	}
+
+	var branchName = apr.Arg(0)
+	if !doltdb.IsValidUserBranchName(branchName) {
+		cli.PrintErrf("%s is an invalid branch name", branchName)
 		return 1
 	}
 

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -2801,6 +2801,10 @@ var DoltBranchScripts = []queries.ScriptTest{
 				Query:    "CALL DOLT_BRANCH('-m', 'myNewBranch2', 'myNewBranch3')",
 				Expected: []sql.Row{{0}},
 			},
+			{
+				Query:          "CALL DOLT_BRANCH('-m', 'myNewBranch3', 'HEAD')",
+				ExpectedErrStr: "not a valid user branch name",
+			},
 		},
 	},
 	{
@@ -2840,6 +2844,10 @@ var DoltBranchScripts = []queries.ScriptTest{
 			{
 				Query:    "CALL DOLT_BRANCH('-cf', 'myNewBranch1', 'myNewBranch2')",
 				Expected: []sql.Row{{0}},
+			},
+			{
+				Query:          "CALL DOLT_BRANCH('-c', 'myNewBranch1', 'HEAD')",
+				ExpectedErrStr: "fatal: 'HEAD' is not a valid branch name.",
 			},
 		},
 	},

--- a/integration-tests/bats/branch.bats
+++ b/integration-tests/bats/branch.bats
@@ -283,4 +283,20 @@ teardown() {
     run dolt branch -c altBranch $hash
     [ $status -eq "1" ]
     [[ "$output" =~ "is an invalid branch name" ]] || false
+
+    dolt checkout altBranch
+
+    run dolt branch -m HEAD
+    [ $status -eq "1" ]
+    [[ "$output" == "HEAD is an invalid branch name" ]] || false
+    run dolt branch -m $hash
+    [ $status -eq "1" ]
+    [[ "$output" =~ "is an invalid branch name" ]] || false
+
+    run dolt branch -c HEAD
+    [ $status -eq "1" ]
+    [[ "$output" == "HEAD is an invalid branch name" ]] || false
+    run dolt branch -c $hash
+    [ $status -eq "1" ]
+    [[ "$output" =~ "is an invalid branch name" ]] || false
 }

--- a/integration-tests/bats/branch.bats
+++ b/integration-tests/bats/branch.bats
@@ -267,4 +267,20 @@ teardown() {
     [ $status -eq "1" ]
     [[ "$output" =~ "is an invalid branch name" ]] || false
     [[ ! "$output" =~ "HEAD" ]] || false
+
+    dolt branch altBranch HEAD
+
+    run dolt branch -m altBranch HEAD
+    [ $status -eq "1" ]
+    [[ "$output" == "HEAD is an invalid branch name" ]] || false
+    run dolt branch -m altBranch $hash
+    [ $status -eq "1" ]
+    [[ "$output" =~ "is an invalid branch name" ]] || false
+
+    run dolt branch -c altBranch HEAD
+    [ $status -eq "1" ]
+    [[ "$output" == "HEAD is an invalid branch name" ]] || false
+    run dolt branch -c altBranch $hash
+    [ $status -eq "1" ]
+    [[ "$output" =~ "is an invalid branch name" ]] || false
 }

--- a/integration-tests/bats/branch.bats
+++ b/integration-tests/bats/branch.bats
@@ -238,3 +238,33 @@ teardown() {
     [[ $output =~ "0" ]] || false
 }
 
+@test "branch: print nothing on successfull create" {
+    run dolt branch newbranch1 HEAD
+    [ $status -eq "0" ]
+    [[ $output == "" ]] || false
+
+    # Get the current commit - bare.
+    run dolt merge-base HEAD HEAD
+    [ $status -eq "0" ]
+    hash="$output"
+   
+    run dolt branch newbranch2 $hash
+    [ $status -eq "0" ]
+    [[ $output == "" ]] || false
+}
+
+@test "branch: don't allow branch creation with HEAD or a commit id as a name" {
+    # Get the current commit - bare.
+    run dolt merge-base HEAD HEAD
+    [ $status -eq "0" ]
+    hash="$output"
+
+    run dolt branch HEAD $hash
+    [ $status -eq "1" ]
+    [[ "$output" == "HEAD is an invalid branch name" ]] || false
+
+    run dolt branch $hash HEAD
+    [ $status -eq "1" ]
+    [[ "$output" =~ "is an invalid branch name" ]] || false
+    [[ ! "$output" =~ "HEAD" ]] || false
+}


### PR DESCRIPTION
Previously `dolt branch foobar HEAD` would print a statement that HEAD is an invalid branch name. It would succeed though, and return an exit status of 0. So tests passed.

This is no longer the case.