### PR TITLE
Bug fix:  Correctly detect uncommitted changes for `dolt_pull` when roots have different feature versions

### DIFF
--- a/go/libraries/doltcore/env/actions/checkout.go
+++ b/go/libraries/doltcore/env/actions/checkout.go
@@ -536,8 +536,15 @@ func clearFeatureVersion(ctx context.Context, roots doltdb.Roots) (doltdb.Roots,
 	}, nil
 }
 
-// RootHasUncommittedChanges returns whether the roots given have uncommitted changes, and the hashes of the working and staged roots
+// RootHasUncommittedChanges returns whether the roots given have uncommitted changes, and the hashes of
+// the working and staged roots are identical. This function will ignore any difference in feature
+// versions between the root values.
 func RootHasUncommittedChanges(roots doltdb.Roots) (hasChanges bool, workingHash hash.Hash, stagedHash hash.Hash, err error) {
+	roots, err = clearFeatureVersion(context.Background(), roots)
+	if err != nil {
+		return false, hash.Hash{}, hash.Hash{}, err
+	}
+
 	headHash, err := roots.Head.HashOf()
 	if err != nil {
 		return false, hash.Hash{}, hash.Hash{}, err

--- a/integration-tests/bats/feature-version.bats
+++ b/integration-tests/bats/feature-version.bats
@@ -144,3 +144,32 @@ SQL
     [ "$status" -eq 0 ]
     [[ "$output" =~ "main" ]] || false
 }
+
+@test "feature-version: dolt pull can be used when a source set has a different feature version than the dest" {
+    # Clear out the current Dolt repo and create subdirs for new repos
+    rm -rf .dolt/
+    mkdir remote
+    mkdir repo1
+
+    # Create a repo using an OLD feature version and push its remote
+    cd repo1
+    dolt --feature-version $OLD init
+    dolt --feature-version $OLD remote add origin file://../remote
+    dolt --feature-version $OLD push origin main
+
+    # Create a clone that we can use to test dolt pull
+    cd ..
+    dolt --feature-version $NEW clone file://./remote repo2
+
+    # Create a new commit on repo1, so that we have something to pull
+    cd repo1
+    dolt --feature-version $OLD sql -q 'create table t (pk int primary key);'
+    dolt --feature-version $OLD sql -q 'call dolt_commit("-Am", "new table with old format");'
+    dolt --feature-version $OLD push origin main
+
+    # Assert that we can successfully pull the changes into repo2
+    cd ../repo2
+    run dolt --feature-version $NEW sql -q 'call dolt_pull();'
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "cannot merge with uncommitted changes" ]] || false
+}


### PR DESCRIPTION
When pulling between two Dolt databases that have different feature versions, `dolt_pull()` can mistakenly interpret the difference in root value hash as being uncommitted changes. This change updates `dolt_pull()` to use the existing `actions.RootHasUncommittedChanges` function and changes that function to account for differing feature version when determining if roots have uncommitted changes. 