### PR TITLE
Feature: Allow `*` wildcard in `@@dolt_replicate_heads`

### DIFF
--- a/go/libraries/doltcore/sqle/read_replica_database.go
+++ b/go/libraries/doltcore/sqle/read_replica_database.go
@@ -151,10 +151,27 @@ func (rrd ReadReplicaDatabase) PullFromRemote(ctx *sql.Context) error {
 		if !ok {
 			return sql.ErrInvalidSystemVariableValue.New(dsess.ReplicateHeads)
 		}
-		branches := strings.Split(heads, ",")
+
 		branchesToPull := make(map[string]bool)
-		for _, branch := range branches {
-			branchesToPull[branch] = true
+		for _, branch := range strings.Split(heads, ",") {
+			if !containsWildcards(branch) {
+				branchesToPull[branch] = true
+			} else {
+				expandedBranches, err := rrd.expandWildcardBranchPattern(ctx, branch)
+				if err != nil {
+					return err
+				}
+
+				for _, expandedBranch := range expandedBranches {
+					branchesToPull[expandedBranch] = true
+				}
+
+				if len(expandedBranches) == 0 {
+					ctx.GetLogger().Warnf("branch pattern '%s' did not match any branches", branch)
+				} else {
+					ctx.GetLogger().Debugf("expanded '%s' to: %s", branch, strings.Join(expandedBranches, ","))
+				}
+			}
 		}
 
 		// Reduce the remote branch list to only the ones configured to replicate
@@ -379,6 +396,22 @@ func pullBranches(
 	}
 
 	return remoteRefsByPath, nil
+}
+
+// expandWildcardBranchPattern evaluates |pattern| and returns a list of branch names from the source database that
+// match the branch name pattern. The '*' wildcard may be used in the pattern to match zero or more characters.
+func (rrd ReadReplicaDatabase) expandWildcardBranchPattern(ctx context.Context, pattern string) ([]string, error) {
+	sourceBranches, err := rrd.srcDB.GetBranches(ctx)
+	if err != nil {
+		return nil, err
+	}
+	expandedBranches := make([]string, 0)
+	for _, sourceBranch := range sourceBranches {
+		if match(pattern, sourceBranch.GetPath()) {
+			expandedBranches = append(expandedBranches, sourceBranch.GetPath())
+		}
+	}
+	return expandedBranches, nil
 }
 
 func (rrd ReadReplicaDatabase) createNewBranchFromRemote(ctx *sql.Context, remoteRef doltdb.RefWithHash, trackingRef ref.RemoteRef) error {

--- a/go/libraries/doltcore/sqle/read_replica_database.go
+++ b/go/libraries/doltcore/sqle/read_replica_database.go
@@ -407,7 +407,7 @@ func (rrd ReadReplicaDatabase) expandWildcardBranchPattern(ctx context.Context, 
 	}
 	expandedBranches := make([]string, 0)
 	for _, sourceBranch := range sourceBranches {
-		if match(pattern, sourceBranch.GetPath()) {
+		if matchWildcardPattern(pattern, sourceBranch.GetPath()) {
 			expandedBranches = append(expandedBranches, sourceBranch.GetPath())
 		}
 	}

--- a/go/libraries/doltcore/sqle/wildcard.go
+++ b/go/libraries/doltcore/sqle/wildcard.go
@@ -19,9 +19,9 @@ import (
 	"strings"
 )
 
-// match returns true if |s| fully matches |pattern|. |pattern| may contain '*' wildcards
-// which match 0 or more characters.
-func match(pattern string, s string) bool {
+// matchWildcardPattern returns true if |s| fully matches |pattern|. |pattern| may contain '*' wildcards
+// which matchWildcardPattern 0 or more characters.
+func matchWildcardPattern(pattern string, s string) bool {
 	result, _ := regexp.MatchString(wildcardToRegexp(pattern), s)
 	return result
 }

--- a/go/libraries/doltcore/sqle/wildcard.go
+++ b/go/libraries/doltcore/sqle/wildcard.go
@@ -1,0 +1,52 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqle
+
+import (
+	"regexp"
+	"strings"
+)
+
+// match returns true if |s| fully matches |pattern|. |pattern| may contain '*' wildcards
+// which match 0 or more characters.
+func match(pattern string, s string) bool {
+	result, _ := regexp.MatchString(wildcardToRegexp(pattern), s)
+	return result
+}
+
+// containsWildcards return true if the string |s| contains any '*' wildcard characters.
+func containsWildcards(s string) bool {
+	return strings.Contains(s, "*")
+}
+
+// wildcardToRegexp converts a wildcard pattern to a regular expression pattern.
+func wildcardToRegexp(pattern string) string {
+	components := strings.Split(pattern, "*")
+	if len(components) == 1 {
+		// if len is 1, there are no *'s, return exact match pattern
+		return "^" + pattern + "$"
+	}
+	var result strings.Builder
+	for i, literal := range components {
+		// Replace * with .*
+		if i > 0 {
+			result.WriteString(".*")
+		}
+
+		// Quote regex meta characters in the literal text.
+		result.WriteString(regexp.QuoteMeta(literal))
+	}
+	return "^" + result.String() + "$"
+}

--- a/go/libraries/doltcore/sqle/wildcard_test.go
+++ b/go/libraries/doltcore/sqle/wildcard_test.go
@@ -1,0 +1,46 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqle
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMatch(t *testing.T) {
+	assert.False(t, match("", "abcdefgh"))
+	assert.True(t, match("*", "abcdefgh"))
+	assert.True(t, match("**", "abcdefgh"))
+
+	assert.False(t, match("*cdefg", "abcdefgh"))
+	assert.True(t, match("*cdefgh", "abcdefgh"))
+	assert.True(t, match("*cdef*", "abcdefgh"))
+	assert.True(t, match("abcd*efgh", "abcdefgh"))
+	assert.True(t, match("a*cdef*h", "abcdefgh"))
+	assert.True(t, match("a*", "abcdefgh"))
+	assert.True(t, match("*h", "abcdefgh"))
+	assert.True(t, match("*abcdefgh", "abcdefgh"))
+	assert.False(t, match("*abcdefg", "abcdefgh"))
+	assert.True(t, match("*abcdefgh*", "abcdefgh"))
+}
+
+func TestContainsWildcard(t *testing.T) {
+	assert.False(t, containsWildcards(""))
+	assert.False(t, containsWildcards("abc"))
+	assert.True(t, containsWildcards("*"))
+	assert.True(t, containsWildcards("a*c"))
+	assert.True(t, containsWildcards("ab*"))
+	assert.True(t, containsWildcards("*bc"))
+}

--- a/go/libraries/doltcore/sqle/wildcard_test.go
+++ b/go/libraries/doltcore/sqle/wildcard_test.go
@@ -15,8 +15,9 @@
 package sqle
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMatch(t *testing.T) {

--- a/go/libraries/doltcore/sqle/wildcard_test.go
+++ b/go/libraries/doltcore/sqle/wildcard_test.go
@@ -21,20 +21,20 @@ import (
 )
 
 func TestMatch(t *testing.T) {
-	assert.False(t, match("", "abcdefgh"))
-	assert.True(t, match("*", "abcdefgh"))
-	assert.True(t, match("**", "abcdefgh"))
+	assert.False(t, matchWildcardPattern("", "abcdefgh"))
+	assert.True(t, matchWildcardPattern("*", "abcdefgh"))
+	assert.True(t, matchWildcardPattern("**", "abcdefgh"))
 
-	assert.False(t, match("*cdefg", "abcdefgh"))
-	assert.True(t, match("*cdefgh", "abcdefgh"))
-	assert.True(t, match("*cdef*", "abcdefgh"))
-	assert.True(t, match("abcd*efgh", "abcdefgh"))
-	assert.True(t, match("a*cdef*h", "abcdefgh"))
-	assert.True(t, match("a*", "abcdefgh"))
-	assert.True(t, match("*h", "abcdefgh"))
-	assert.True(t, match("*abcdefgh", "abcdefgh"))
-	assert.False(t, match("*abcdefg", "abcdefgh"))
-	assert.True(t, match("*abcdefgh*", "abcdefgh"))
+	assert.False(t, matchWildcardPattern("*cdefg", "abcdefgh"))
+	assert.True(t, matchWildcardPattern("*cdefgh", "abcdefgh"))
+	assert.True(t, matchWildcardPattern("*cdef*", "abcdefgh"))
+	assert.True(t, matchWildcardPattern("abcd*efgh", "abcdefgh"))
+	assert.True(t, matchWildcardPattern("a*cdef*h", "abcdefgh"))
+	assert.True(t, matchWildcardPattern("a*", "abcdefgh"))
+	assert.True(t, matchWildcardPattern("*h", "abcdefgh"))
+	assert.True(t, matchWildcardPattern("*abcdefgh", "abcdefgh"))
+	assert.False(t, matchWildcardPattern("*abcdefg", "abcdefgh"))
+	assert.True(t, matchWildcardPattern("*abcdefgh*", "abcdefgh"))
 }
 
 func TestContainsWildcard(t *testing.T) {


### PR DESCRIPTION
This change allows customers to use `*` as a wildcard in the [`@@dolt_replicate_heads` system variable](https://docs.dolthub.com/sql-reference/version-control/dolt-sysvars#dolt_replicate_heads) to match zero or more characters in a branch name. For example, to replicate the `main` branch and all branches that start with `feature`, the following configuration can now be applied:
```
    dolt config --local --add sqlserver.global.dolt_replicate_heads main,feature*
```

Documentation: https://github.com/dolthub/docs/pull/1698

Fixes: https://github.com/dolthub/dolt/issues/6486