### PR TITLE
Move storage format version to only be displayed with `dolt version --verbose`

### DIFF
--- a/go/cmd/dolt/commands/version.go
+++ b/go/cmd/dolt/commands/version.go
@@ -26,6 +26,7 @@ import (
 
 const (
 	featureVersionFlag = "feature"
+	verboseFlag        = "verbose"
 )
 
 type VersionCmd struct {
@@ -55,6 +56,7 @@ func (cmd VersionCmd) Docs() *cli.CommandDocumentation {
 func (cmd VersionCmd) ArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParserWithMaxArgs(cmd.Name(), 0)
 	ap.SupportsFlag(featureVersionFlag, "f", "query the feature version of this repository.")
+	ap.SupportsFlag(verboseFlag, "v", "include additional details on this repository's storage format.")
 	return ap
 }
 
@@ -63,16 +65,18 @@ func (cmd VersionCmd) ArgParser() *argparser.ArgParser {
 func (cmd VersionCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	cli.Println("dolt version", cmd.VersionStr)
 
-	if dEnv.HasDoltDir() && dEnv.RSLoadErr == nil && !cli.CheckEnvIsValid(dEnv) {
-		return 2
-	} else if dEnv.HasDoltDir() && dEnv.RSLoadErr == nil {
-		nbf := dEnv.DoltDB.Format()
-		cli.Printf("database storage format: %s\n", dfunctions.GetStorageFormatDisplayString(nbf))
-	}
-
 	usage := func() {}
 	ap := cmd.ArgParser()
 	apr := cli.ParseArgsOrDie(ap, args, usage)
+
+	if apr.Contains(verboseFlag) {
+		if dEnv.HasDoltDir() && dEnv.RSLoadErr == nil && !cli.CheckEnvIsValid(dEnv) {
+			return 2
+		} else if dEnv.HasDoltDir() && dEnv.RSLoadErr == nil {
+			nbf := dEnv.DoltDB.Format()
+			cli.Printf("database storage format: %s\n", dfunctions.GetStorageFormatDisplayString(nbf))
+		}
+	}
 
 	var verr errhand.VerboseError
 	if apr.Contains(featureVersionFlag) {

--- a/go/cmd/dolt/commands/version.go
+++ b/go/cmd/dolt/commands/version.go
@@ -55,8 +55,8 @@ func (cmd VersionCmd) Docs() *cli.CommandDocumentation {
 
 func (cmd VersionCmd) ArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParserWithMaxArgs(cmd.Name(), 0)
-	ap.SupportsFlag(featureVersionFlag, "f", "query the feature version of this repository.")
-	ap.SupportsFlag(verboseFlag, "v", "include additional details on this repository's storage format.")
+	ap.SupportsFlag(featureVersionFlag, "f", "display the feature version of this repository.")
+	ap.SupportsFlag(verboseFlag, "v", "display verbose details, including the storage format of this repository.")
 	return ap
 }
 

--- a/integration-tests/bats/init.bats
+++ b/integration-tests/bats/init.bats
@@ -183,7 +183,7 @@ teardown() {
     run dolt init --new-format
     [ $status -eq 0 ]
 
-    run dolt version
+    run dolt version -v
     [ $status -eq 0 ]
     [[ $output =~ "database storage format: NEW ( __DOLT__ )" ]] || false
 
@@ -197,7 +197,7 @@ teardown() {
     run dolt init --new-format
     [ $status -eq 0 ]
 
-    run dolt version
+    run dolt version --verbose
     [ "$status" -eq 0 ]
     [[ ! $output =~ "OLD ( __LD_1__ )" ]] || false
     [[ $output =~ "NEW ( __DOLT__ )" ]] || false
@@ -207,7 +207,7 @@ teardown() {
     [[ $output =~ "test" ]] || false
 
     cd test
-    run dolt version
+    run dolt version --verbose
     [ "$status" -eq 0 ]
     [[ ! $output =~ "OLD ( __LD_1__ )" ]] || false
     [[ $output =~ "NEW ( __DOLT__ )" ]] || false
@@ -228,13 +228,13 @@ teardown() {
     run dolt init --new-format
     [ $status -eq 0 ]
 
-    run dolt version
+    run dolt version --verbose
     [ "$status" -eq 0 ]
     [[ ! $output =~ "OLD ( __LD_1__ )" ]] || false
     [[ $output =~ "NEW ( __DOLT__ )" ]] || false
 
     cd ..
-    run dolt version
+    run dolt version --verbose
     [ "$status" -eq 0 ]
     ! [[ $output =~ "no valid database in this directory" ]] || false
 
@@ -243,7 +243,7 @@ teardown() {
     [[ $output =~ "test" ]] || false
 
     cd test
-    run dolt version
+    run dolt version --verbose
     [ "$status" -eq 0 ]
     [[ "$output" =~ "__DOLT__" ]] || false
 }

--- a/integration-tests/bats/no-repo.bats
+++ b/integration-tests/bats/no-repo.bats
@@ -126,6 +126,7 @@ teardown() {
     [ "$status" -eq 0 ]
     regex='dolt version [0-9]+.[0-9]+.[0-9]+'
     [[ "$output" =~ $regex ]] || false
+    [[ ! "$output" =~ "database storage format" ]] || false
 }
 
 @test "no-repo: dolt version does not need write permissions" {


### PR DESCRIPTION
`dolt version` displayed the storage format version by default, but this information is less relevant now that almost all Dolt databases have been migrated to the new storage format. This change adds a new `--verbose` /  `-v` flag that customers can specify if they do want to see the storage format version for a repository. 

Fixes https://github.com/dolthub/dolt/issues/6528