### PR TITLE
Separate out log arg parsers

### DIFF
--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -281,19 +281,7 @@ func CreateVerifyConstraintsArgParser(name string) *argparser.ArgParser {
 	return ap
 }
 
-func CreateLogArgParser() *argparser.ArgParser {
-	ap := argparser.NewArgParserWithVariableArgs("log")
-	ap.SupportsInt(NumberFlag, "n", "num_commits", "Limit the number of commits to output.")
-	ap.SupportsInt(MinParentsFlag, "", "parent_count", "The minimum number of parents a commit must have to be included in the log.")
-	ap.SupportsFlag(MergesFlag, "", "Equivalent to min-parents == 2, this will limit the log to commits with 2 or more parents.")
-	ap.SupportsFlag(ParentsFlag, "", "Shows all parents of each commit in the log.")
-	ap.SupportsString(DecorateFlag, "", "decorate_fmt", "Shows refs next to commits. Valid options are short, full, no, and auto")
-	ap.SupportsFlag(OneLineFlag, "", "Shows logs in a compact format.")
-	ap.SupportsStringList(NotFlag, "", "revision", "Excludes commits from revision.")
-	return ap
-}
-
-func CreateLogTableArgParser() *argparser.ArgParser {
+func CreateLogArgParser(isTableFunction bool) *argparser.ArgParser {
 	ap := argparser.NewArgParserWithVariableArgs("log")
 	ap.SupportsInt(NumberFlag, "n", "num_commits", "Limit the number of commits to output.")
 	ap.SupportsInt(MinParentsFlag, "", "parent_count", "The minimum number of parents a commit must have to be included in the log.")
@@ -301,7 +289,11 @@ func CreateLogTableArgParser() *argparser.ArgParser {
 	ap.SupportsFlag(ParentsFlag, "", "Shows all parents of each commit in the log.")
 	ap.SupportsString(DecorateFlag, "", "decorate_fmt", "Shows refs next to commits. Valid options are short, full, no, and auto")
 	ap.SupportsStringList(NotFlag, "", "revision", "Excludes commits from revision.")
-	ap.SupportsStringList(TablesFlag, "t", "table", "Restricts the log to commits that modified the specified tables.")
+	if isTableFunction {
+		ap.SupportsStringList(TablesFlag, "t", "table", "Restricts the log to commits that modified the specified tables.")
+	} else {
+		ap.SupportsFlag(OneLineFlag, "", "Shows logs in a compact format.")
+	}
 	return ap
 }
 

--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -290,6 +290,17 @@ func CreateLogArgParser() *argparser.ArgParser {
 	ap.SupportsString(DecorateFlag, "", "decorate_fmt", "Shows refs next to commits. Valid options are short, full, no, and auto")
 	ap.SupportsFlag(OneLineFlag, "", "Shows logs in a compact format.")
 	ap.SupportsStringList(NotFlag, "", "revision", "Excludes commits from revision.")
+	return ap
+}
+
+func CreateLogTableArgParser() *argparser.ArgParser {
+	ap := argparser.NewArgParserWithVariableArgs("log")
+	ap.SupportsInt(NumberFlag, "n", "num_commits", "Limit the number of commits to output.")
+	ap.SupportsInt(MinParentsFlag, "", "parent_count", "The minimum number of parents a commit must have to be included in the log.")
+	ap.SupportsFlag(MergesFlag, "", "Equivalent to min-parents == 2, this will limit the log to commits with 2 or more parents.")
+	ap.SupportsFlag(ParentsFlag, "", "Shows all parents of each commit in the log.")
+	ap.SupportsString(DecorateFlag, "", "decorate_fmt", "Shows refs next to commits. Valid options are short, full, no, and auto")
+	ap.SupportsStringList(NotFlag, "", "revision", "Excludes commits from revision.")
 	ap.SupportsStringList(TablesFlag, "t", "table", "Restricts the log to commits that modified the specified tables.")
 	return ap
 }

--- a/go/cmd/dolt/commands/log.go
+++ b/go/cmd/dolt/commands/log.go
@@ -83,7 +83,7 @@ func (cmd LogCmd) Docs() *cli.CommandDocumentation {
 }
 
 func (cmd LogCmd) ArgParser() *argparser.ArgParser {
-	return cli.CreateLogArgParser()
+	return cli.CreateLogArgParser(false)
 }
 
 // Exec executes the command

--- a/go/libraries/doltcore/sqle/dolt_log_table_function.go
+++ b/go/libraries/doltcore/sqle/dolt_log_table_function.go
@@ -220,7 +220,7 @@ func (ltf *LogTableFunction) addOptions(expression []sql.Expression) error {
 		return err
 	}
 
-	apr, err := cli.CreateLogTableArgParser().Parse(args)
+	apr, err := cli.CreateLogArgParser(true).Parse(args)
 	if err != nil {
 		return sql.ErrInvalidArgumentDetails.New(ltf.Name(), err.Error())
 	}

--- a/go/libraries/doltcore/sqle/dolt_log_table_function.go
+++ b/go/libraries/doltcore/sqle/dolt_log_table_function.go
@@ -220,7 +220,7 @@ func (ltf *LogTableFunction) addOptions(expression []sql.Expression) error {
 		return err
 	}
 
-	apr, err := cli.CreateLogArgParser().Parse(args)
+	apr, err := cli.CreateLogTableArgParser().Parse(args)
 	if err != nil {
 		return sql.ErrInvalidArgumentDetails.New(ltf.Name(), err.Error())
 	}


### PR DESCRIPTION
Creates a separate arg parser for `dolt log` and `dolt_log` to avoid supporting unneeded flags.