### PR TITLE
Temporarily restrict `dolt_conflicts_resolve()` from resolving schema conflicts

### DIFF
--- a/go/libraries/doltcore/sqle/dprocedures/dolt_conflicts_resolve.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_conflicts_resolve.go
@@ -344,6 +344,22 @@ func ResolveSchemaConflicts(ctx *sql.Context, ddb *doltdb.DoltDB, ws *doltdb.Wor
 		return ws, nil // no schema conflicts
 	}
 
+	// TODO: There's an issue with using `dolt conflicts resolve` for schema conflicts, since having
+	//       schema conflicts reported means that we haven't yet merged the table data. In some case,
+	//       such as when there have ONLY been schema changes and no data changes that need to be
+	//       merged, it is safe to use `dolt conflicts resolve`, but there are many other cases where the
+	//       data changes would not be merged and could surprise customers. So, we are being cautious to
+	//       prevent auto-resolution of schema changes with `dolt conflicts resolve` until we have a fix
+	//       for resolving schema changes AND merging data (including dealing with any data conflicts).
+	//       For more details, see: https://github.com/dolthub/dolt/issues/6616
+	if ws.MergeState().HasSchemaConflicts() {
+		return nil, fmt.Errorf("Unable to automatically resolve schema conflicts since data changes may " +
+			"not have been fully merged yet. " +
+			"To continue, abort this merge (dolt merge --abort) then apply ALTER TABLE statements to one " +
+			"side of this merge to get the two schemas in sync with the desired schema, then rerun the merge. " +
+			"To track resolution of this limitation, follow https://github.com/dolthub/dolt/issues/6616")
+	}
+
 	tblSet := set.NewStrSet(tables)
 	updates := make(map[string]*doltdb.Table)
 	err := ws.MergeState().IterSchemaConflicts(ctx, ddb, func(table string, conflict doltdb.SchemaConflict) error {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
@@ -437,6 +437,11 @@ var MergeScripts = []queries.ScriptTest{
 		},
 	},
 	{
+		// TODO: These tests are skipped, because we have temporarily disabled dolt_conflicts_resolve
+		//       when there are schema conflicts, since schema conflicts prevent table data from being
+		//       merged, and resolving the schema changes, but not completing the data merge will likely
+		//       give customers unexpected results.
+		//       https://github.com/dolthub/dolt/issues/6616
 		Name: "CALL DOLT_MERGE with schema conflicts can be correctly resolved using dolt_conflicts_resolve when autocommit is off",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk int primary key, val int)",
@@ -453,54 +458,67 @@ var MergeScripts = []queries.ScriptTest{
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
+				Skip:     true,
 				Query:    "CALL DOLT_MERGE('feature-branch', '-m', 'this is a merge')",
 				Expected: []sql.Row{{"", 0, 1}},
 			},
 			{
+				Skip:     true,
 				Query:    "SELECT is_merging, source, target, unmerged_tables FROM DOLT_MERGE_STATUS;",
 				Expected: []sql.Row{{true, "feature-branch", "refs/heads/main", "test"}},
 			},
 			{
+				Skip:     true,
 				Query:    "SELECT * from dolt_status",
 				Expected: []sql.Row{{"test", false, "schema conflict"}},
 			},
 			{
+				Skip:     true,
 				Query:    "SELECT COUNT(*) FROM dolt_log",
 				Expected: []sql.Row{{4}},
 			},
 			{
+				Skip:     true,
 				Query:    "select message from dolt_log where date < '2022-08-08' order by date DESC LIMIT 1;",
 				Expected: []sql.Row{{"update val col"}},
 			},
 			{
+				Skip:     true,
 				Query:    "SELECT COUNT(*) FROM dolt_conflicts",
 				Expected: []sql.Row{{1}},
 			},
 			{
+				Skip:     true,
 				Query:    "CALL DOLT_CONFLICTS_RESOLVE('--ours', 'test');",
 				Expected: []sql.Row{{0}},
 			},
 			{
+				Skip:     true,
 				Query:    "SELECT is_merging, source, target, unmerged_tables FROM DOLT_MERGE_STATUS;",
 				Expected: []sql.Row{{true, "feature-branch", "refs/heads/main", ""}},
 			},
 			{
+				Skip:     true,
 				Query:    "SELECT COUNT(*) FROM dolt_conflicts",
 				Expected: []sql.Row{{0}},
 			},
 			{
+				Skip:     true,
 				Query:    "SELECT * from dolt_status",
 				Expected: []sql.Row{{"test", true, "merged"}},
 			},
 			{
+				Skip:             true,
 				Query:            "CALL DOLT_COMMIT('-m', 'merged');",
 				SkipResultsCheck: true,
 			},
 			{
+				Skip:     true,
 				Query:    "SELECT * from dolt_status",
 				Expected: []sql.Row{},
 			},
 			{
+				Skip:     true,
 				Query:    "SHOW CREATE TABLE test",
 				Expected: []sql.Row{{"test", "CREATE TABLE `test` (\n  `pk` int NOT NULL,\n  `val` smallint,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},

--- a/integration-tests/bats/schema-conflicts.bats
+++ b/integration-tests/bats/schema-conflicts.bats
@@ -53,6 +53,8 @@ setup_schema_conflict() {
 }
 
 @test "schema-conflicts: resolve schema conflict with 'ours' via SQL" {
+    skip "auto conflict resolution for schema merges is blocked until https://github.com/dolthub/dolt/issues/6616 is fixed"
+
     setup_schema_conflict
 
     dolt merge other
@@ -64,6 +66,8 @@ setup_schema_conflict() {
 }
 
 @test "schema-conflicts: resolve schema conflict with 'theirs' via SQL" {
+    skip "auto conflict resolution for schema merges is blocked until https://github.com/dolthub/dolt/issues/6616 is fixed"
+
     setup_schema_conflict
 
     dolt merge other
@@ -75,6 +79,8 @@ setup_schema_conflict() {
 }
 
 @test "schema-conflicts: resolve schema conflict with 'ours' via CLI" {
+    skip "auto conflict resolution for schema merges is blocked until https://github.com/dolthub/dolt/issues/6616 is fixed"
+
     setup_schema_conflict
 
     dolt merge other
@@ -86,6 +92,8 @@ setup_schema_conflict() {
 }
 
 @test "schema-conflicts: resolve schema conflict with 'theirs' via CLI" {
+    skip "auto conflict resolution for schema merges is blocked until https://github.com/dolthub/dolt/issues/6616 is fixed"
+
     setup_schema_conflict
 
     dolt merge other

--- a/integration-tests/bats/sql-merge.bats
+++ b/integration-tests/bats/sql-merge.bats
@@ -887,6 +887,8 @@ SQL
 }
 
 @test "sql-merge: different check constraints on same column throw conflict" {
+    skip "auto conflict resolution for schema merges is blocked until https://github.com/dolthub/dolt/issues/6616 is fixed"
+
     dolt sql -q "create table t (i int)"
     dolt add .
     dolt commit -am "initial commit"
@@ -949,6 +951,8 @@ SQL
 }
 
 @test "sql-merge: dropping constraint in one branch and modifying same in other results in conflict" {
+    skip "auto conflict resolution for schema merges is blocked until https://github.com/dolthub/dolt/issues/6616 is fixed"
+
     dolt sql -q "create table t (i int)"
     dolt add .
     dolt sql -q "alter table t add constraint c check (i > 0)"
@@ -1017,6 +1021,8 @@ SQL
 }
 
 @test "sql-merge: check constraint with name collision" {
+    skip "auto conflict resolution for schema merges is blocked until https://github.com/dolthub/dolt/issues/6616 is fixed"
+
     dolt sql -q "create table t (i int)"
     dolt add .
     dolt commit -am "initial commit"
@@ -1055,6 +1061,8 @@ SQL
 }
 
 @test "sql-merge: check constraint for deleted column in another table" {
+    skip "auto conflict resolution for schema merges is blocked until https://github.com/dolthub/dolt/issues/6616 is fixed"
+
     dolt sql -q "create table t (i int primary key, j int)"
     dolt add .
     dolt commit -am "initial commit"


### PR DESCRIPTION
Until we fix the workflow around merging data **after** schema conflicts have been resolved, customers may be surprised by the results of `dolt_conflicts_resolve()` when there are schema changes, so putting this block in out of extra caution. 

For more details, see issue https://github.com/dolthub/dolt/issues/6616