### PR TITLE
allows dolt log outside dolt repos

### DIFF
--- a/go/cmd/dolt/commands/log.go
+++ b/go/cmd/dolt/commands/log.go
@@ -86,6 +86,10 @@ func (cmd LogCmd) ArgParser() *argparser.ArgParser {
 	return cli.CreateLogArgParser(false)
 }
 
+func (cmd LogCmd) RequiresRepo() bool {
+	return false
+}
+
 // Exec executes the command
 func (cmd LogCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	return cmd.logWithLoggerFunc(ctx, commandStr, args, dEnv, cliCtx)


### PR DESCRIPTION
Allows `dolt log` to be called outside of dolt repos