### PR TITLE
Bug fix: Check constraint merging

### DIFF
--- a/go/libraries/doltcore/merge/merge_schema.go
+++ b/go/libraries/doltcore/merge/merge_schema.go
@@ -1033,7 +1033,7 @@ func checksInCommon(ourChks, theirChks, ancChks []schema.Check) ([]schema.Check,
 
 		// NO CONFLICT: CHECK was only modified in their branch, so update check definition with theirs
 		if ancChk == ourChk {
-			common = append(common, ourChk)
+			common = append(common, theirChk)
 			continue
 		}
 


### PR DESCRIPTION
We had a typo in the check constraint merging code that was only triggered when an existing check constraint was altered on the "source" side of the merge and the "destination" side of the merge had the exact same definition as the common ancestor. The new test shows a concrete example. Note that the schema merge tests run in both directions, from left to right, and from left to right, so they are better at catching bugs like this that only appear in one merge direction. 