### PR TITLE
When a three-way merge contains an altered column, convert values to the new column type in order to prevent conflicts.

### DIFF
--- a/go/libraries/doltcore/merge/merge_prolly_rows.go
+++ b/go/libraries/doltcore/merge/merge_prolly_rows.go
@@ -1571,15 +1571,16 @@ func (m *valueMerger) processColumn(ctx context.Context, i int, left, right, bas
 		}
 		// conflicting inserts
 		return nil, true
-
 	}
 
-	// We can now assume that both left are right are modifications to an existing column.
-	// We want to know if they're the same modification, otherwise there's a conflict.
-	// Note that we can't just look at the bytes to determine this, because if a cell's byte representation changed,
+	// We can now assume that both left are right contain byte-level changes to an existing column.
+	// But we need to know if those byte-level changes represent a modification to the underlying value,
+	// and whether those changes represent the *same* modification, otherwise there's a conflict.
+
+	// We can't just look at the bytes to determine this, because if a cell's byte representation changed,
 	// but only because of a schema change, we shouldn't consider that a conflict.
-	//  Conversely, if there was a schema change on only one side, we shouldn't consider the cells equal
-	//  even if they have the same bytes.
+	// Conversely, if there was a schema change on only one side, we shouldn't consider the cells equal
+	// even if they have the same bytes.
 
 	// Thus, we must convert all cells to the type in the result schema before comparing them.
 

--- a/go/libraries/doltcore/merge/merge_prolly_rows.go
+++ b/go/libraries/doltcore/merge/merge_prolly_rows.go
@@ -1559,11 +1559,10 @@ func (m *valueMerger) processColumn(ctx context.Context, i int, left, right, bas
 		// There are three possible cases:
 		// - The base row doesn't exist, or
 		// - The column doesn't exist in the base row, or
-		// - The column was nullable and not reflected in the tuple.
+		// - The column was default-null and not reflected in the tuple. (TODO: verify this is handled correctly)
 		// Regardless, either both left and right are inserts, or one is an insert and the other
 		// is a no-op. If they're inserts of different types, then we would have already detected a conflict.
 		// Thus, we can assume that there is no schema change conflict here.
-		// TODO: What about the case with a nullable column, where one side inserts a value and the other side changes the type?
 		if m.resultVD.Comparator().CompareValues(i, leftCol, rightCol, m.resultVD.Types[i]) == 0 {
 			// columns are equal, return either.
 			return leftCol, false
@@ -1582,9 +1581,9 @@ func (m *valueMerger) processColumn(ctx context.Context, i int, left, right, bas
 		}
 	}
 
-	// Since we now know the column existed at base, if either left or right was not in the tuple, the column must have either
-	// been deleted, or removed from the tuple because it's nullable. Is it possible for us to distinguish between
-	// these cases?
+	// Since we now know the column existed at base, if either left or right was not in the tuple,
+	// then the column must have either been deleted, it's default-NULL and the value was NULLed.
+	// TODO: For now, assume it was deleted. Is it possible for us to distinguish between these cases?
 	if leftColumnIndex == -1 || rightColumnIndex == -1 {
 		return nil, false
 	}

--- a/go/libraries/doltcore/merge/merge_prolly_rows.go
+++ b/go/libraries/doltcore/merge/merge_prolly_rows.go
@@ -1660,5 +1660,5 @@ func convert(ctx context.Context, fromDesc, toDesc val.TupleDesc, toSchema schem
 	if !inRange {
 		return nil, false
 	}
-	return index.Serialize(ctx, ns, toDesc.Types[toIndex], convertedCell), true
+	return index.Serialize(ctx, ns, toDesc.Types[toIndex], convertedCell)
 }

--- a/go/libraries/doltcore/merge/merge_prolly_rows.go
+++ b/go/libraries/doltcore/merge/merge_prolly_rows.go
@@ -1557,6 +1557,8 @@ func (m *valueMerger) processColumn(ctx context.Context, i int, left, right, bas
 	rightCol, rightColIdx, rightColExists := getColumn(&right, &m.rightMapping, i)
 	resultType := m.resultVD.Types[i]
 
+	// We previously asserted that left and right are not nil: processColumn can currently get called in that case
+	// because it's not detected as a data conflict. But convergent inserts are detected, and result in a nil base.
 	if base == nil || !baseColExists {
 		// There are two possible cases:
 		// - The base row doesn't exist, or

--- a/go/libraries/doltcore/merge/merge_prolly_rows.go
+++ b/go/libraries/doltcore/merge/merge_prolly_rows.go
@@ -1499,7 +1499,7 @@ func migrateDataToMergedSchema(ctx *sql.Context, tm *TableMerger, vm *valueMerge
 // tuples. It returns the merged cell value tuple and a bool indicating if a
 // conflict occurred. tryMerge should only be called if left and right produce
 // non-identical diffs against base.
-func (m *valueMerger) tryMerge(left, right, base val.Tuple) (val.Tuple, bool) {
+func (m *valueMerger) tryMerge(ctx context.Context, left, right, base val.Tuple) (val.Tuple, bool) {
 	// If we're merging a keyless table and the keys match, but the values are different,
 	// that means that the row data is the same, but the cardinality has changed, and if the
 	// cardinality has changed in different ways on each merge side, we can't auto resolve.
@@ -1520,7 +1520,7 @@ func (m *valueMerger) tryMerge(left, right, base val.Tuple) (val.Tuple, bool) {
 
 	mergedValues := make([][]byte, m.numCols)
 	for i := 0; i < m.numCols; i++ {
-		v, isConflict := m.processColumn(i, left, right, base)
+		v, isConflict := m.processColumn(ctx, i, left, right, base)
 		if isConflict {
 			return nil, false
 		}
@@ -1532,7 +1532,7 @@ func (m *valueMerger) tryMerge(left, right, base val.Tuple) (val.Tuple, bool) {
 
 // processColumn returns the merged value of column |i| of the merged schema,
 // based on the |left|, |right|, and |base| schema.
-func (m *valueMerger) processColumn(i int, left, right, base val.Tuple) ([]byte, bool) {
+func (m *valueMerger) processColumn(ctx context.Context, i int, left, right, base val.Tuple) ([]byte, bool) {
 	// missing columns are coerced into NULL column values
 	var leftCol []byte
 	if l := m.leftMapping[i]; l != -1 {

--- a/go/libraries/doltcore/merge/merge_prolly_rows.go
+++ b/go/libraries/doltcore/merge/merge_prolly_rows.go
@@ -1560,8 +1560,8 @@ func (m *valueMerger) processColumn(ctx context.Context, i int, left, right, bas
 	rightCol, rightColIdx, rightColExists := getColumn(&right, &m.rightMapping, i)
 	resultType := m.resultVD.Types[i]
 
-	// We previously asserted that left and right are not nil: processColumn can currently get called in that case
-	// because it's not detected as a data conflict. But convergent inserts are detected, and result in a nil base.
+	// We previously asserted that left and right are not nil.
+	//But base can be nil in the event of convergent inserts.
 	if base == nil || !baseColExists {
 		// There are two possible cases:
 		// - The base row doesn't exist, or

--- a/go/libraries/doltcore/merge/row_merge_test.go
+++ b/go/libraries/doltcore/merge/row_merge_test.go
@@ -222,7 +222,8 @@ func TestRowMerge(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			v := newValueMerger(test.mergedSch, test.leftSch, test.rightSch, test.baseSch, syncPool, nil)
 
-			merged, ok := v.tryMerge(ctx, test.row, test.mergeRow, test.ancRow)
+			merged, ok, err := v.tryMerge(ctx, test.row, test.mergeRow, test.ancRow)
+			assert.NoError(t, err)
 			assert.Equal(t, test.expectConflict, !ok)
 			vD := test.mergedSch.GetValueDescriptor()
 			assert.Equal(t, vD.Format(test.expectedResult), vD.Format(merged))

--- a/go/libraries/doltcore/merge/row_merge_test.go
+++ b/go/libraries/doltcore/merge/row_merge_test.go
@@ -220,7 +220,7 @@ func TestRowMerge(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			v := newValueMerger(test.mergedSch, test.leftSch, test.rightSch, test.baseSch, syncPool)
+			v := newValueMerger(test.mergedSch, test.leftSch, test.rightSch, test.baseSch, syncPool, nil)
 
 			merged, ok := v.tryMerge(ctx, test.row, test.mergeRow, test.ancRow)
 			assert.Equal(t, test.expectConflict, !ok)

--- a/go/libraries/doltcore/merge/row_merge_test.go
+++ b/go/libraries/doltcore/merge/row_merge_test.go
@@ -211,6 +211,8 @@ func TestRowMerge(t *testing.T) {
 		t.Skip()
 	}
 
+	ctx := context.Background()
+
 	tests := make([]rowMergeTest, len(testCases))
 	for i, t := range testCases {
 		tests[i] = createRowMergeStruct(t)
@@ -220,7 +222,7 @@ func TestRowMerge(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			v := newValueMerger(test.mergedSch, test.leftSch, test.rightSch, test.baseSch, syncPool)
 
-			merged, ok := v.tryMerge(test.row, test.mergeRow, test.ancRow)
+			merged, ok := v.tryMerge(ctx, test.row, test.mergeRow, test.ancRow)
 			assert.Equal(t, test.expectConflict, !ok)
 			vD := test.mergedSch.GetValueDescriptor()
 			assert.Equal(t, vD.Format(test.expectedResult), vD.Format(merged))

--- a/go/libraries/doltcore/merge/schema_merge_test.go
+++ b/go/libraries/doltcore/merge/schema_merge_test.go
@@ -152,6 +152,7 @@ var columnAddDropTests = []schemaMergeTest{
 				merged:   singleRow(1, nil, 3),
 			},
 			{
+				// Skipped because of (https://github.com/dolthub/dolt/issues/6745)
 				name:     "left side adds column and assigns non-null value, extra column has data change on right",
 				ancestor: singleRow(1, 3),
 				left:     singleRow(1, 2, 3),
@@ -160,6 +161,7 @@ var columnAddDropTests = []schemaMergeTest{
 				skipFlip: true,
 			},
 			{
+				// Skipped because of (https://github.com/dolthub/dolt/issues/6745)
 				name:     "left side adds column and assigns non-null value, extra column has data change on right to NULL",
 				ancestor: singleRow(1, 3),
 				left:     singleRow(1, 2, 3),
@@ -168,6 +170,7 @@ var columnAddDropTests = []schemaMergeTest{
 				skipFlip: true,
 			},
 			{
+				// Skipped because of (https://github.com/dolthub/dolt/issues/6745)
 				name:     "left side adds column and assigns non-null value, extra column has data change on right to non-NULL",
 				ancestor: singleRow(1, nil),
 				left:     singleRow(1, 2, nil),
@@ -190,6 +193,7 @@ var columnAddDropTests = []schemaMergeTest{
 				merged:   singleRow(1, nil, nil),
 			},
 			{
+				// Skipped because of (https://github.com/dolthub/dolt/issues/6745)
 				name:     "left side adds column and assigns null value, extra column has data change on right",
 				ancestor: singleRow(1, 3),
 				left:     singleRow(1, nil, 3),
@@ -198,6 +202,7 @@ var columnAddDropTests = []schemaMergeTest{
 				skipFlip: true,
 			},
 			{
+				// Skipped because of (https://github.com/dolthub/dolt/issues/6745)
 				name:     "left side adds column and assigns null value, extra column has data change on right to NULL",
 				ancestor: singleRow(1, 3),
 				left:     singleRow(1, nil, 3),
@@ -206,6 +211,7 @@ var columnAddDropTests = []schemaMergeTest{
 				skipFlip: true,
 			},
 			{
+				// Skipped because of (https://github.com/dolthub/dolt/issues/6745)
 				name:     "left side adds column and assigns null value, extra column has data change on right to non-NULL",
 				ancestor: singleRow(1, nil),
 				left:     singleRow(1, nil, nil),
@@ -232,6 +238,7 @@ var columnAddDropTests = []schemaMergeTest{
 			{
 				// Skipped because the differ currently doesn't see this as a data conflict because
 				// both left and right tuple representations are the same.
+				// (https://github.com/dolthub/dolt/issues/6748)
 				name:         "one side sets to NULL, other drops non-NULL",
 				ancestor:     singleRow(1, 2, 3),
 				left:         singleRow(1, 2),
@@ -241,6 +248,7 @@ var columnAddDropTests = []schemaMergeTest{
 			},
 			{
 				// Skipped because the differ currently doesn't try to merge the dropped column.
+				// (https://github.com/dolthub/dolt/issues/6747)
 				name:         "one side sets to NULL, other drops non-NULL, plus data change",
 				ancestor:     singleRow(1, 2, 3),
 				left:         singleRow(1, 2),
@@ -251,6 +259,7 @@ var columnAddDropTests = []schemaMergeTest{
 			{
 				// Skipped because the differ doesn't see left as modified because
 				// it has the same tuple representation as ancestor.
+				// (https://github.com/dolthub/dolt/issues/6746)
 				name:         "one side sets to non-NULL, other drops NULL",
 				ancestor:     singleRow(1, 2, nil),
 				left:         singleRow(1, 2),
@@ -260,6 +269,7 @@ var columnAddDropTests = []schemaMergeTest{
 			},
 			{
 				// Skipped because the differ currently doesn't try to merge the dropped column.
+				// (https://github.com/dolthub/dolt/issues/6747)
 				name:         "one side sets to non-NULL, other drops NULL, plus data change",
 				ancestor:     singleRow(1, 2, nil),
 				left:         singleRow(1, 3),
@@ -269,6 +279,7 @@ var columnAddDropTests = []schemaMergeTest{
 			},
 			{
 				// Skipped because the differ currently doesn't try to merge the dropped column.
+				// (https://github.com/dolthub/dolt/issues/6747)
 				name:         "one side sets to non-NULL, other drops non-NULL",
 				ancestor:     singleRow(1, 2, 3),
 				left:         singleRow(1, 2),
@@ -294,6 +305,7 @@ var columnAddDropTests = []schemaMergeTest{
 			},
 			{
 				// Skipped because the differ currently doesn't try to merge the dropped column.
+				// (https://github.com/dolthub/dolt/issues/6747)
 				name:         "one side sets to NULL, other drops non-NULL",
 				ancestor:     singleRow(1, 2, 3),
 				left:         singleRow(1, 3),
@@ -303,6 +315,7 @@ var columnAddDropTests = []schemaMergeTest{
 			},
 			{
 				// Skipped because the differ currently doesn't try to merge the dropped column.
+				// (https://github.com/dolthub/dolt/issues/6747)
 				name:         "one side sets to NULL, other drops non-NULL, plus data change",
 				ancestor:     singleRow(1, 2, 4),
 				left:         singleRow(1, 3),
@@ -312,6 +325,7 @@ var columnAddDropTests = []schemaMergeTest{
 			},
 			{
 				// Skipped because the differ currently doesn't try to merge the dropped column.
+				// (https://github.com/dolthub/dolt/issues/6747)
 				name:         "one side sets to non-NULL, other drops NULL, plus data change",
 				ancestor:     singleRow(1, nil, 3),
 				left:         singleRow(1, 3),
@@ -321,6 +335,7 @@ var columnAddDropTests = []schemaMergeTest{
 			},
 			{
 				// Skipped because the differ currently doesn't try to merge the dropped column.
+				// (https://github.com/dolthub/dolt/issues/6747)
 				name:         "one side sets to non-NULL, other drops NULL, plus data change",
 				ancestor:     singleRow(1, nil, 3),
 				left:         singleRow(1, 4),
@@ -330,6 +345,7 @@ var columnAddDropTests = []schemaMergeTest{
 			},
 			{
 				// Skipped because the differ currently doesn't try to merge the dropped column.
+				// (https://github.com/dolthub/dolt/issues/6747)
 				name:         "one side sets to non-NULL, other drops non-NULL",
 				ancestor:     singleRow(1, 2, 3),
 				left:         singleRow(1, 3),
@@ -373,8 +389,9 @@ var columnAddDropTests = []schemaMergeTest{
 				merged:   singleRow(1, 2, nil),
 			},
 			{
-				// Skipped because the differ currently doesn't see the left change as
-				// a data change, because the tuple representation is the same.
+				// Skipped because the differ doesn't see left as modified because
+				// it has the same tuple representation as ancestor.
+				// (https://github.com/dolthub/dolt/issues/6746)
 				name:         "convergent adds with differing nullness",
 				ancestor:     singleRow(1, 2),
 				left:         singleRow(1, 2, nil),

--- a/go/libraries/doltcore/merge/schema_merge_test.go
+++ b/go/libraries/doltcore/merge/schema_merge_test.go
@@ -721,6 +721,20 @@ var typeChangeTests = []schemaMergeTest{
 				right:    singleRow(1, "hello world", 1, "hello world"),
 				merged:   singleRow(1, "hello world", 1, "hello world"),
 			},
+			{
+				name:     "convergent inserts",
+				ancestor: nil,
+				left:     singleRow(1, "test", 1, "test"),
+				right:    singleRow(1, "test", 1, "test"),
+				merged:   singleRow(1, "test", 1, "test"),
+			},
+			{
+				name:         "conflicting inserts",
+				ancestor:     nil,
+				left:         singleRow(1, "test", 1, "test"),
+				right:        singleRow(1, "hello world", 1, "hello world"),
+				dataConflict: true,
+			},
 		},
 	},
 }

--- a/go/libraries/doltcore/merge/schema_merge_test.go
+++ b/go/libraries/doltcore/merge/schema_merge_test.go
@@ -46,6 +46,16 @@ type schemaMergeTest struct {
 	skipOldFmt          bool
 	skipFlipOnNewFormat bool
 	skipFlipOnOldFormat bool
+	dataTests           []dataTest
+}
+
+type dataTest struct {
+	name         string
+	ancestor     []sql.Row
+	left, right  []sql.Row
+	merged       []sql.Row
+	dataConflict bool
+	skip         bool
 }
 
 type table struct {
@@ -98,17 +108,229 @@ var columnAddDropTests = []schemaMergeTest{
 	// one side changes columns
 	{
 		name:     "left side column add",
-		ancestor: tbl(sch("CREATE TABLE t (id int PRIMARY KEY)       "), row(1)),
-		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int)"), row(1, 2)),
-		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY)       "), row(1)),
-		merged:   tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int)"), row(1, 2)),
+		ancestor: tbl(sch("CREATE TABLE t (id int PRIMARY KEY)       ")),
+		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int)")),
+		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY)       ")),
+		merged:   tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int)")),
+		dataTests: []dataTest{
+			{
+				name:     "left side adds column and assigns non-null value",
+				ancestor: singleRow(1),
+				left:     singleRow(1, 2),
+				right:    singleRow(1),
+				merged:   singleRow(1, 2),
+			},
+			{
+				name:     "left side adds column and assigns null value",
+				ancestor: singleRow(1),
+				left:     singleRow(1, nil),
+				right:    singleRow(1),
+				merged:   singleRow(1, nil),
+			},
+		},
+	},
+	{
+		name:     "left side column add with additional column after",
+		ancestor: tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int)       ")),
+		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, b int)")),
+		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int)       ")),
+		merged:   tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, b int)")),
+		dataTests: []dataTest{
+			{
+				name:     "left side adds column and assigns non-null value, extra column is non-NULL",
+				ancestor: singleRow(1, 3),
+				left:     singleRow(1, 2, 3),
+				right:    singleRow(1, 3),
+				merged:   singleRow(1, 2, 3),
+			},
+			{
+				name:     "left side adds column and assigns null value, extra column is non-NULL",
+				ancestor: singleRow(1, 3),
+				left:     singleRow(1, nil, 3),
+				right:    singleRow(1, 3),
+				merged:   singleRow(1, nil, 3),
+			},
+			{
+				name:     "left side adds column and assigns non-null value, extra column has data change on right",
+				ancestor: singleRow(1, 3),
+				left:     singleRow(1, 2, 3),
+				right:    singleRow(1, 4),
+				merged:   singleRow(1, 2, 4),
+			},
+			{
+				name:     "left side adds column and assigns non-null value, extra column has data change on right to NULL",
+				ancestor: singleRow(1, 3),
+				left:     singleRow(1, 2, 3),
+				right:    singleRow(1, nil),
+				merged:   singleRow(1, 2, nil),
+			},
+			{
+				name:     "left side adds column and assigns non-null value, extra column has data change on right to non-NULL",
+				ancestor: singleRow(1, nil),
+				left:     singleRow(1, 2, nil),
+				right:    singleRow(1, 3),
+				merged:   singleRow(1, 2, 3),
+			},
+			{
+				name:     "left side adds column and assigns non-null value, extra column is NULL",
+				ancestor: singleRow(1, nil),
+				left:     singleRow(1, 2, nil),
+				right:    singleRow(1, nil),
+				merged:   singleRow(1, 2, nil),
+			},
+			{
+				name:     "left side adds column and assigns null value, extra column is NULL",
+				ancestor: singleRow(1, nil),
+				left:     singleRow(1, nil, nil),
+				right:    singleRow(1, nil),
+				merged:   singleRow(1, nil, nil),
+			},
+			{
+				name:     "left side adds column and assigns null value, extra column has data change on right",
+				ancestor: singleRow(1, 3),
+				left:     singleRow(1, nil, 3),
+				right:    singleRow(1, 4),
+				merged:   singleRow(1, nil, 4),
+			},
+			{
+				name:     "left side adds column and assigns null value, extra column has data change on right to NULL",
+				ancestor: singleRow(1, 3),
+				left:     singleRow(1, nil, 3),
+				right:    singleRow(1, nil),
+				merged:   singleRow(1, nil, nil),
+			},
+			{
+				name:     "left side adds column and assigns null value, extra column has data change on right to non-NULL",
+				ancestor: singleRow(1, nil),
+				left:     singleRow(1, nil, nil),
+				right:    singleRow(1, 3),
+				merged:   singleRow(1, nil, 3),
+			},
+		},
 	},
 	{
 		name:     "left side column drop",
-		ancestor: tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int)"), row(1, 2)),
-		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY)       "), row(1)),
-		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int)"), row(1, 2)),
-		merged:   tbl(sch("CREATE TABLE t (id int PRIMARY KEY)       "), row(1)),
+		ancestor: tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int, a int)")),
+		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int)       ")),
+		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int, a int)")),
+		merged:   tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int)       ")),
+		dataTests: []dataTest{
+			{
+				name:     "no data change",
+				ancestor: singleRow(1, 2, 3),
+				left:     singleRow(1, 2),
+				right:    singleRow(1, 2, 3),
+				merged:   singleRow(1, 2),
+			},
+			{
+				// Skipped because the differ currently doesn't see this as a data conflict because
+				// both left and right tuple representations are the same.
+				name:         "one side sets to NULL, other drops non-NULL",
+				ancestor:     singleRow(1, 2, 3),
+				left:         singleRow(1, 2),
+				right:        singleRow(1, 2, nil),
+				dataConflict: true,
+				skip:         true,
+			},
+			{
+				// Skipped because the differ currently doesn't try to merge the dropped column.
+				name:         "one side sets to NULL, other drops non-NULL, plus data change",
+				ancestor:     singleRow(1, 2, 3),
+				left:         singleRow(1, 2),
+				right:        singleRow(1, 3, nil),
+				dataConflict: true,
+				skip:         true,
+			},
+			{
+				// Skipped because the differ doesn't see left as modified because
+				// it has the same tuple representation as ancestor.
+				name:         "one side sets to non-NULL, other drops NULL",
+				ancestor:     singleRow(1, 2, nil),
+				left:         singleRow(1, 2),
+				right:        singleRow(1, 2, 3),
+				dataConflict: true,
+				skip:         true,
+			},
+			{
+				// Skipped because the differ currently doesn't try to merge the dropped column.
+				name:         "one side sets to non-NULL, other drops NULL, plus data change",
+				ancestor:     singleRow(1, 2, nil),
+				left:         singleRow(1, 3),
+				right:        singleRow(1, 2, 3),
+				dataConflict: true,
+				skip:         true,
+			},
+			{
+				// Skipped because the differ currently doesn't try to merge the dropped column.
+				name:         "one side sets to non-NULL, other drops non-NULL",
+				ancestor:     singleRow(1, 2, 3),
+				left:         singleRow(1, 2),
+				right:        singleRow(1, 2, 4),
+				dataConflict: true,
+				skip:         true,
+			},
+		},
+	},
+	{
+		name:     "left side column drop with additional column after",
+		ancestor: tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, b int)")),
+		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int)       ")),
+		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, b int)")),
+		merged:   tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int)       ")),
+		dataTests: []dataTest{
+			{
+				name:     "no data change",
+				ancestor: singleRow(1, 2, 3),
+				left:     singleRow(1, 3),
+				right:    singleRow(1, 2, 3),
+				merged:   singleRow(1, 3),
+			},
+			{
+				// Skipped because the differ currently doesn't try to merge the dropped column.
+				name:         "one side sets to NULL, other drops non-NULL",
+				ancestor:     singleRow(1, 2, 3),
+				left:         singleRow(1, 3),
+				right:        singleRow(1, nil, 3),
+				dataConflict: true,
+				skip:         true,
+			},
+			{
+				// Skipped because the differ currently doesn't try to merge the dropped column.
+				name:         "one side sets to NULL, other drops non-NULL, plus data change",
+				ancestor:     singleRow(1, 2, 4),
+				left:         singleRow(1, 3),
+				right:        singleRow(1, nil, 4),
+				dataConflict: true,
+				skip:         true,
+			},
+			{
+				// Skipped because the differ currently doesn't try to merge the dropped column.
+				name:         "one side sets to non-NULL, other drops NULL, plus data change",
+				ancestor:     singleRow(1, nil, 3),
+				left:         singleRow(1, 3),
+				right:        singleRow(1, 2, 3),
+				dataConflict: true,
+				skip:         true,
+			},
+			{
+				// Skipped because the differ currently doesn't try to merge the dropped column.
+				name:         "one side sets to non-NULL, other drops NULL, plus data change",
+				ancestor:     singleRow(1, nil, 3),
+				left:         singleRow(1, 4),
+				right:        singleRow(1, 2, 3),
+				dataConflict: true,
+				skip:         true,
+			},
+			{
+				// Skipped because the differ currently doesn't try to merge the dropped column.
+				name:         "one side sets to non-NULL, other drops non-NULL",
+				ancestor:     singleRow(1, 2, 3),
+				left:         singleRow(1, 3),
+				right:        singleRow(1, 4, 3),
+				dataConflict: true,
+				skip:         true,
+			},
+		},
 	},
 	// both sides change columns
 	{
@@ -131,17 +353,92 @@ var columnAddDropTests = []schemaMergeTest{
 	},
 	{
 		name:     "convergent column adds",
-		ancestor: tbl(sch("CREATE TABLE t (id int PRIMARY KEY)       "), row(1)),
-		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int)"), row(1, nil)),
-		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int)"), row(1, nil)),
-		merged:   tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int)"), row(1, nil)),
+		ancestor: tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int)       ")),
+		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int, a int)")),
+		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int, a int)")),
+		merged:   tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int, a int)")),
+		dataTests: []dataTest{
+			{
+				name:     "convergent adds assigning null",
+				ancestor: singleRow(1, 2),
+				left:     singleRow(1, 2, nil),
+				right:    singleRow(1, 2, nil),
+				merged:   singleRow(1, 2, nil),
+			},
+			{
+				// Skipped because the differ currently doesn't see the left change as
+				// a data change, because the tuple representation is the same.
+				name:         "convergent adds with differing nullness",
+				ancestor:     singleRow(1, 2),
+				left:         singleRow(1, 2, nil),
+				right:        singleRow(1, 2, 3),
+				dataConflict: true,
+				skip:         true,
+			},
+			{
+				name:         "convergent adds with differing nullness, plus convergent data change",
+				ancestor:     singleRow(1, 2),
+				left:         singleRow(1, 3, nil),
+				right:        singleRow(1, 3, 4),
+				dataConflict: true,
+			},
+		},
+	},
+	{
+		name:     "convergent column add in middle of schema",
+		ancestor: tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int)       ")),
+		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int, a int)")),
+		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int, a int)")),
+		merged:   tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int, a int)")),
+		dataTests: []dataTest{
+			{
+				name:     "convergent adds assigning null",
+				ancestor: singleRow(1, 2),
+				left:     singleRow(1, nil, 2),
+				right:    singleRow(1, nil, 2),
+				merged:   singleRow(1, nil, 2),
+			},
+			{
+				// Skipped because the differ currently doesn't see the left change as
+				// a data change, because the tuple representation is the same.
+				name:         "convergent adds with differing nullness",
+				ancestor:     singleRow(1, 2),
+				left:         singleRow(1, nil, 2),
+				right:        singleRow(1, 3, 2),
+				dataConflict: true,
+				//skip:         true,
+			},
+			{
+				name:         "convergent adds with differing nullness, plus convergent data change",
+				ancestor:     singleRow(1, 2),
+				left:         singleRow(1, nil, 3),
+				right:        singleRow(1, 4, 3),
+				dataConflict: true,
+			},
+		},
 	},
 	{
 		name:     "convergent column drops",
-		ancestor: tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int)"), row(1, 2)),
-		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY)       "), row(1)),
-		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY)       "), row(1)),
-		merged:   tbl(sch("CREATE TABLE t (id int PRIMARY KEY)       "), row(1)),
+		ancestor: tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int)")),
+		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY)       ")),
+		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY)       ")),
+		merged:   tbl(sch("CREATE TABLE t (id int PRIMARY KEY)       ")),
+		dataTests: []dataTest{
+			{
+				name:     "no data change",
+				ancestor: singleRow(1, 2),
+				left:     singleRow(1),
+				right:    singleRow(1),
+				merged:   singleRow(1),
+			},
+			{
+				name:     "convergent drops on new row",
+				ancestor: nil,
+				left:     singleRow(1),
+				right:    singleRow(1),
+				merged:   singleRow(1),
+			},
+		},
 	},
 	{
 		name:       "convergent column adds, independent drops",
@@ -347,6 +644,64 @@ var typeChangeTests = []schemaMergeTest{
 		merged:   tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a char(20), b int)"), row(1, "2", 3)),
 	},
 	// column changes one side, data changes other side
+	{
+		name:     "modify column type on the left side between compatible string types",
+		ancestor: tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a varchar(20), b int, c varchar(20))")),
+		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a text, b int, c text)")),
+		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a varchar(20), b int, c varchar(20))")),
+		merged:   tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a text, b int, c text)")),
+		dataTests: []dataTest{
+			{
+				name:     "schema change, no data change",
+				ancestor: singleRow(1, "test", 1, "test"),
+				left:     singleRow(1, "test", 1, "test"),
+				right:    singleRow(1, "test", 1, "test"),
+				merged:   singleRow(1, "test", 1, "test"),
+			},
+			{
+				name:     "insert and schema change on left, no change on right",
+				ancestor: nil,
+				left:     singleRow(1, "test", 1, "test"),
+				right:    nil,
+				merged:   singleRow(1, "test", 1, "test"),
+			},
+			{
+				name:     "insert on right, schema change on left",
+				ancestor: nil,
+				left:     nil,
+				right:    singleRow(1, "test", 1, "test"),
+				merged:   singleRow(1, "test", 1, "test"),
+			},
+			{
+				name:     "data and schema change on left, no change on right",
+				ancestor: singleRow(1, "test", 1, "test"),
+				left:     singleRow(1, "hello world", 1, "hello world"),
+				right:    singleRow(1, "test", 1, "test"),
+				merged:   singleRow(1, "hello world", 1, "hello world"),
+			},
+			{
+				name:     "data change on right, schema change on left",
+				ancestor: singleRow(1, "test", 1, "test"),
+				left:     singleRow(1, "test", 1, "test"),
+				right:    singleRow(1, "hello world", 1, "hello world"),
+				merged:   singleRow(1, "hello world", 1, "hello world"),
+			},
+			{
+				name:     "data set and schema change on left, no change on right",
+				ancestor: singleRow(1, nil, 1, nil),
+				left:     singleRow(1, "hello world", 1, "hello world"),
+				right:    singleRow(1, nil, 1, nil),
+				merged:   singleRow(1, "hello world", 1, "hello world"),
+			},
+			{
+				name:     "data set on right, schema change on left",
+				ancestor: singleRow(1, nil, 1, nil),
+				left:     singleRow(1, nil, 1, nil),
+				right:    singleRow(1, "hello world", 1, "hello world"),
+				merged:   singleRow(1, "hello world", 1, "hello world"),
+			},
+		},
+	},
 }
 
 var keyChangeTests = []schemaMergeTest{
@@ -520,42 +875,84 @@ func testSchemaMergeHelper(t *testing.T, tests []schemaMergeTest, flipSides bool
 			tmp := test.left
 			test.left = test.right
 			test.right = tmp
+			for i, _ := range test.dataTests {
+				tmp := test.dataTests[i].left
+				test.dataTests[i].left = test.dataTests[i].right
+				test.dataTests[i].right = tmp
+			}
 		}
 
 		t.Run(test.name, func(t *testing.T) {
-			a, l, r, m := setupSchemaMergeTest(t, test)
+			runTest := func(t *testing.T, test schemaMergeTest, expectDataConflict bool) {
+				a, l, r, m := setupSchemaMergeTest(t, test)
 
-			ctx := context.Background()
-			var mo merge.MergeOpts
-			var eo editor.Options
-			eo = eo.WithDeaf(editor.NewInMemDeaf(a.VRW()))
-			// attempt merge before skipping to assert no panics
-			result, err := merge.MergeRoots(sql.NewContext(ctx), l, r, a, rootish{r}, rootish{a}, eo, mo)
-			maybeSkip(t, a.VRW().Format(), test, flipSides)
+				ctx := context.Background()
+				var mo merge.MergeOpts
+				var eo editor.Options
+				eo = eo.WithDeaf(editor.NewInMemDeaf(a.VRW()))
+				// attempt merge before skipping to assert no panics
+				result, err := merge.MergeRoots(sql.NewContext(ctx), l, r, a, rootish{r}, rootish{a}, eo, mo)
+				maybeSkip(t, a.VRW().Format(), test, flipSides)
 
-			if test.conflict {
-				// TODO: Test the conflict error message more deeply
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				exp, err := m.MapTableHashes(ctx)
-				assert.NoError(t, err)
-				act, err := result.Root.MapTableHashes(ctx)
-				assert.NoError(t, err)
+				if test.conflict {
+					// TODO: Test the conflict error message more deeply
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+					exp, err := m.MapTableHashes(ctx)
+					assert.NoError(t, err)
+					act, err := result.Root.MapTableHashes(ctx)
+					assert.NoError(t, err)
 
-				assert.Equal(t, len(exp), len(act))
-				for name, addr := range exp {
-					a, ok := act[name]
-					assert.True(t, ok)
-					if !assert.Equal(t, addr, a) {
-						expTbl, _, err := m.GetTable(ctx, name)
-						require.NoError(t, err)
-						t.Logf("expected rows: %s", expTbl.DebugString(ctx))
-						actTbl, _, err := result.Root.GetTable(ctx, name)
-						require.NoError(t, err)
-						t.Logf("actual rows: %s", actTbl.DebugString(ctx))
+					assert.Equal(t, len(exp), len(act))
+
+					if expectDataConflict {
+						foundDataConflict := false
+						for name, _ := range exp {
+							_, ok := act[name]
+							assert.True(t, ok)
+							actTbl, _, err := result.Root.GetTable(ctx, name)
+							require.NoError(t, err)
+							hasConflict, err := actTbl.HasConflicts(ctx)
+							require.NoError(t, err)
+							foundDataConflict = foundDataConflict || hasConflict
+						}
+						require.Equal(t, expectDataConflict, foundDataConflict)
+					} else {
+						for name, addr := range exp {
+							a, ok := act[name]
+							assert.True(t, ok)
+
+							actTbl, _, err := result.Root.GetTable(ctx, name)
+							require.NoError(t, err)
+							hasConflict, err := actTbl.HasConflicts(ctx)
+							require.NoError(t, err)
+							require.False(t, hasConflict, "Unexpected data conflict")
+
+							if !assert.Equal(t, addr, a) {
+								expTbl, _, err := m.GetTable(ctx, name)
+								require.NoError(t, err)
+								t.Logf("expected rows: %s", expTbl.DebugString(ctx))
+								t.Logf("actual rows: %s", actTbl.DebugString(ctx))
+							}
+						}
 					}
 				}
+			}
+			t.Run("test schema merge", func(t *testing.T) {
+				runTest(t, test, false)
+			})
+			for _, data := range test.dataTests {
+				test.ancestor.rows = data.ancestor
+				test.left.rows = data.left
+				test.right.rows = data.right
+				test.merged.rows = data.merged
+				t.Run(data.name, func(t *testing.T) {
+					if data.skip {
+						t.Skip()
+					}
+					runTest(t, test, data.dataConflict)
+				})
 			}
 		})
 	}
@@ -613,6 +1010,10 @@ func sch(definition string) namedSchema {
 
 func row(values ...any) sql.Row {
 	return sql.NewRow(values...)
+}
+
+func singleRow(values ...any) []sql.Row {
+	return []sql.Row{row(values...)}
 }
 
 func makeRootWithTable(t *testing.T, ddb *doltdb.DoltDB, eo editor.Options, tbl table) *doltdb.RootValue {

--- a/go/libraries/doltcore/sqle/index/prolly_fields.go
+++ b/go/libraries/doltcore/sqle/index/prolly_fields.go
@@ -131,108 +131,65 @@ func GetField(ctx context.Context, td val.TupleDesc, i int, tup val.Tuple, ns tr
 }
 
 // Serialize writes an interface{} to the ith field of the Tuple being built.
-func Serialize(ctx context.Context, ns tree.NodeStore, t val.Type, v interface{}) []byte {
+func Serialize(ctx context.Context, ns tree.NodeStore, t val.Type, v interface{}) ([]byte, bool) {
 	var res []byte
 
 	if v == nil {
-		return res // NULL
+		return res, true // NULL
 	}
 
 	enc := t.Enc
 	switch enc {
 	case val.Int8Enc:
-		return []byte{byte(convInt(v))}
+		return []byte{byte(convInt(v))}, true
 	case val.Uint8Enc:
-		return []byte{byte(convUint(v))}
+		return []byte{byte(convUint(v))}, true
 	case val.Int16Enc:
-		return binary.LittleEndian.AppendUint16(res, uint16(convInt(v)))
+		return binary.LittleEndian.AppendUint16(res, uint16(convInt(v))), true
 	case val.Uint16Enc:
-		return binary.LittleEndian.AppendUint16(res, uint16(convUint(v)))
-		/*
-			case val.Int32Enc:
-				tb.PutInt32(i, int32(convInt(v)))
-			case val.Uint32Enc:
-				tb.PutUint32(i, uint32(convUint(v)))
-			case val.Int64Enc:
-				tb.PutInt64(i, int64(convInt(v)))
-			case val.Uint64Enc:
-				tb.PutUint64(i, uint64(convUint(v)))
-			case val.Float32Enc:
-				tb.PutFloat32(i, v.(float32))
-			case val.Float64Enc:
-				tb.PutFloat64(i, v.(float64))
-			case val.Bit64Enc:
-				tb.PutBit(i, uint64(convUint(v)))
-			case val.DecimalEnc:
-				tb.PutDecimal(i, v.(decimal.Decimal))
-			case val.YearEnc:
-				tb.PutYear(i, v.(int16))
-			case val.DateEnc:
-				tb.PutDate(i, v.(time.Time))
-			case val.TimeEnc:
-				tb.PutSqlTime(i, int64(v.(types.Timespan)))
-			case val.DatetimeEnc:
-				tb.PutDatetime(i, v.(time.Time))
-			case val.EnumEnc:
-				tb.PutEnum(i, v.(uint16))
-			case val.SetEnc:
-				tb.PutSet(i, v.(uint64))*/
+		return binary.LittleEndian.AppendUint16(res, uint16(convUint(v))), true
+	case val.Int32Enc:
+		return binary.LittleEndian.AppendUint32(res, uint32(convInt(v))), true
+	case val.Uint32Enc:
+		return binary.LittleEndian.AppendUint32(res, uint32(convUint(v))), true
+	case val.Int64Enc:
+		return binary.LittleEndian.AppendUint64(res, uint64(convInt(v))), true
+	case val.Uint64Enc:
+		return binary.LittleEndian.AppendUint64(res, uint64(convUint(v))), true
+	case val.EnumEnc:
+		return binary.LittleEndian.AppendUint16(res, v.(uint16)), true
+	case val.SetEnc:
+		return binary.LittleEndian.AppendUint64(res, v.(uint64)), true
 	case val.StringEnc:
 		s := v.(string)
 		res = make([]byte, len(s)+1)
 		copy(res, s)
 		res[len(s)] = byte(0)
-		/*
-			case val.ByteStringEnc:
-				if s, ok := v.(string); ok {
-					if len(s) > math.MaxUint16 {
-						return ErrValueExceededMaxFieldSize
-					}
-					v = []byte(s)
-				}
-				tb.PutByteString(i, v.([]byte))
-			case val.Hash128Enc:
-				tb.PutHash128(i, v.([]byte))
-			case val.GeometryEnc:
-				geo := serializeGeometry(v)
-				if len(geo) > math.MaxUint16 {
-					return ErrValueExceededMaxFieldSize
-				}
-				tb.PutGeometry(i, geo)
-			case val.JSONAddrEnc:
-				buf, err := convJson(v)
-				if err != nil {
-					return err
-				}
-				h, err := serializeBytesToAddr(ctx, ns, bytes.NewReader(buf), len(buf))
-				if err != nil {
-					return err
-				}
-				tb.PutJSONAddr(i, h)
-			case val.BytesAddrEnc:
-				h, err := serializeBytesToAddr(ctx, ns, bytes.NewReader(v.([]byte)), len(v.([]byte)))
-				if err != nil {
-					return err
-				}
-				tb.PutBytesAddr(i, h)*/
+		return res, true
+	case val.ByteStringEnc:
+		if s, ok := v.(string); ok {
+			if len(s) > math.MaxUint16 {
+				return nil, false
+			}
+			res = make([]byte, len(s)+1)
+			copy(res, s)
+			res[len(s)] = byte(0)
+			return res, true
+		}
+
+		b := v.([]byte)
+		res = make([]byte, len(b)+1)
+		copy(res, b)
+		return res, true
 	case val.StringAddrEnc:
 		//todo: v will be []byte after daylon's changes
 		h, err := serializeBytesToAddr(ctx, ns, bytes.NewReader([]byte(v.(string))), len(v.(string)))
 		if err != nil {
 			panic("return err")
 		}
-		return h[:]
-		/*case val.CommitAddrEnc:
-			tb.PutCommitAddr(i, v.(hash.Hash))
-		case val.CellEnc:
-			if _, ok := v.([]byte); ok {
-				v = deserializeGeometry(v.([]byte))
-			}
-			tb.PutCell(i, ZCell(v.(types.GeometryValue)))*/
-	default:
-		panic(fmt.Sprintf("unknown encoding %v %v", enc, v))
+		return h[:], true
 	}
-	return nil
+	panic(fmt.Sprintf("unknown encoding, or convert not defined for %v %v", enc, v))
 }
 
 // PutField writes an interface{} to the ith field of the Tuple being built.

--- a/go/libraries/doltcore/sqle/index/prolly_fields.go
+++ b/go/libraries/doltcore/sqle/index/prolly_fields.go
@@ -130,7 +130,7 @@ func GetField(ctx context.Context, td val.TupleDesc, i int, tup val.Tuple, ns tr
 	return v, err
 }
 
-// Serialize writes an interface{} to the ith field of the Tuple being built.
+// Serialize writes an interface{} into the byte string representation used in val.Tuple.
 func Serialize(ctx context.Context, ns tree.NodeStore, t val.Type, v interface{}) ([]byte, bool) {
 	var res []byte
 

--- a/go/libraries/doltcore/sqle/index/prolly_fields.go
+++ b/go/libraries/doltcore/sqle/index/prolly_fields.go
@@ -131,7 +131,7 @@ func GetField(ctx context.Context, td val.TupleDesc, i int, tup val.Tuple, ns tr
 }
 
 // Serialize writes an interface{} to the ith field of the Tuple being built.
-func Serialize(ctx context.Context, ns tree.NodeStore, t val.Type, v interface{}, tb *val.TupleBuilder) []byte {
+func Serialize(ctx context.Context, ns tree.NodeStore, t val.Type, v interface{}) []byte {
 	var res []byte
 
 	if v == nil {

--- a/go/libraries/doltcore/sqle/index/prolly_fields.go
+++ b/go/libraries/doltcore/sqle/index/prolly_fields.go
@@ -132,14 +132,14 @@ func GetField(ctx context.Context, td val.TupleDesc, i int, tup val.Tuple, ns tr
 
 // Serialize writes an interface{} into the byte string representation used in val.Tuple, and returns the byte string,
 // and a boolean indicating success.
-func Serialize(ctx context.Context, ns tree.NodeStore, t val.Type, v interface{}) (result []byte, success bool) {
+func Serialize(ctx context.Context, ns tree.NodeStore, t val.Type, v interface{}) (result []byte, err error) {
 	newTupleDesc := val.NewTupleDescriptor(t)
 	tb := val.NewTupleBuilder(newTupleDesc)
-	err := PutField(ctx, ns, tb, 0, v)
+	err = PutField(ctx, ns, tb, 0, v)
 	if err != nil {
-		return nil, false
+		return nil, err
 	}
-	return newTupleDesc.GetField(0, tb.Build(pool.NewBuffPool())), true
+	return newTupleDesc.GetField(0, tb.Build(pool.NewBuffPool())), nil
 }
 
 // PutField writes an interface{} to the ith field of the Tuple being built.

--- a/go/libraries/doltcore/sqle/index/prolly_fields.go
+++ b/go/libraries/doltcore/sqle/index/prolly_fields.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/dolthub/dolt/go/store/pool"
 	"io"
 	"math"
 	"time"
@@ -29,6 +28,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/dolthub/dolt/go/store/pool"
 	"github.com/dolthub/dolt/go/store/prolly/tree"
 	"github.com/dolthub/dolt/go/store/val"
 )

--- a/go/store/prolly/tree/three_way_differ.go
+++ b/go/store/prolly/tree/three_way_differ.go
@@ -38,7 +38,7 @@ type ThreeWayDiffer[K ~[]byte, O Ordering[K]] struct {
 
 //var _ DiffIter = (*threeWayDiffer[Item, val.TupleDesc])(nil)
 
-type resolveCb func(val.Tuple, val.Tuple, val.Tuple) (val.Tuple, bool)
+type resolveCb func(context.Context, val.Tuple, val.Tuple, val.Tuple) (val.Tuple, bool)
 
 func NewThreeWayDiffer[K, V ~[]byte, O Ordering[K]](
 	ctx context.Context,
@@ -165,7 +165,7 @@ func (d *ThreeWayDiffer[K, O]) Next(ctx context.Context) (ThreeWayDiff, error) {
 			} else if d.lDiff.Type == d.rDiff.Type && bytes.Equal(d.lDiff.To, d.rDiff.To) {
 				res = d.newConvergentEdit(d.lDiff.Key, d.lDiff.To, d.lDiff.Type)
 			} else {
-				resolved, ok := d.resolveCb(val.Tuple(d.lDiff.To), val.Tuple(d.rDiff.To), val.Tuple(d.lDiff.From))
+				resolved, ok := d.resolveCb(ctx, val.Tuple(d.lDiff.To), val.Tuple(d.rDiff.To), val.Tuple(d.lDiff.From))
 				if !ok {
 					res = d.newDivergentClashConflict(d.lDiff.Key, d.lDiff.From, d.lDiff.To, d.rDiff.To)
 				} else {

--- a/go/store/prolly/tree/three_way_differ.go
+++ b/go/store/prolly/tree/three_way_differ.go
@@ -38,7 +38,7 @@ type ThreeWayDiffer[K ~[]byte, O Ordering[K]] struct {
 
 //var _ DiffIter = (*threeWayDiffer[Item, val.TupleDesc])(nil)
 
-type resolveCb func(context.Context, val.Tuple, val.Tuple, val.Tuple) (val.Tuple, bool)
+type resolveCb func(context.Context, val.Tuple, val.Tuple, val.Tuple) (val.Tuple, bool, error)
 
 func NewThreeWayDiffer[K, V ~[]byte, O Ordering[K]](
 	ctx context.Context,
@@ -165,7 +165,10 @@ func (d *ThreeWayDiffer[K, O]) Next(ctx context.Context) (ThreeWayDiff, error) {
 			} else if d.lDiff.Type == d.rDiff.Type && bytes.Equal(d.lDiff.To, d.rDiff.To) {
 				res = d.newConvergentEdit(d.lDiff.Key, d.lDiff.To, d.lDiff.Type)
 			} else {
-				resolved, ok := d.resolveCb(ctx, val.Tuple(d.lDiff.To), val.Tuple(d.rDiff.To), val.Tuple(d.lDiff.From))
+				resolved, ok, err := d.resolveCb(ctx, val.Tuple(d.lDiff.To), val.Tuple(d.rDiff.To), val.Tuple(d.lDiff.From))
+				if err != nil {
+					return ThreeWayDiff{}, err
+				}
 				if !ok {
 					res = d.newDivergentClashConflict(d.lDiff.Key, d.lDiff.From, d.lDiff.To, d.rDiff.To)
 				} else {

--- a/go/store/prolly/tree/three_way_differ_test.go
+++ b/go/store/prolly/tree/three_way_differ_test.go
@@ -215,8 +215,8 @@ func TestThreeWayDiffer(t *testing.T) {
 	}
 }
 
-func testResolver(t *testing.T, ns NodeStore, valDesc val.TupleDesc, valBuilder *val.TupleBuilder) func(val.Tuple, val.Tuple, val.Tuple) (val.Tuple, bool) {
-	return func(l, r, b val.Tuple) (val.Tuple, bool) {
+func testResolver(t *testing.T, ns NodeStore, valDesc val.TupleDesc, valBuilder *val.TupleBuilder) func(context.Context, val.Tuple, val.Tuple, val.Tuple) (val.Tuple, bool) {
+	return func(_ context.Context, l, r, b val.Tuple) (val.Tuple, bool) {
 		for i := range valDesc.Types {
 			var base, left, right int64
 			var ok bool

--- a/go/store/prolly/tree/three_way_differ_test.go
+++ b/go/store/prolly/tree/three_way_differ_test.go
@@ -215,8 +215,8 @@ func TestThreeWayDiffer(t *testing.T) {
 	}
 }
 
-func testResolver(t *testing.T, ns NodeStore, valDesc val.TupleDesc, valBuilder *val.TupleBuilder) func(context.Context, val.Tuple, val.Tuple, val.Tuple) (val.Tuple, bool) {
-	return func(_ context.Context, l, r, b val.Tuple) (val.Tuple, bool) {
+func testResolver(t *testing.T, ns NodeStore, valDesc val.TupleDesc, valBuilder *val.TupleBuilder) func(context.Context, val.Tuple, val.Tuple, val.Tuple) (val.Tuple, bool, error) {
+	return func(_ context.Context, l, r, b val.Tuple) (val.Tuple, bool, error) {
 		for i := range valDesc.Types {
 			var base, left, right int64
 			var ok bool
@@ -236,7 +236,7 @@ func testResolver(t *testing.T, ns NodeStore, valDesc val.TupleDesc, valBuilder 
 			}
 
 			if base != left && base != right && left != right {
-				return nil, false
+				return nil, false, nil
 			} else if base != left {
 				valBuilder.PutInt64(i, left)
 			} else if base != right {
@@ -245,7 +245,7 @@ func testResolver(t *testing.T, ns NodeStore, valDesc val.TupleDesc, valBuilder 
 				valBuilder.PutInt64(i, base)
 			}
 		}
-		return valBuilder.Build(ns.Pool()), true
+		return valBuilder.Build(ns.Pool()), true, nil
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/6660

I thought this was going to be a simple tweak, but it turns out that three-way merges in the presence of altered columns has some interesting subtleties.

First off, we don't just compare the bytes of cells when merging, we actually de-serialize them and check for equality. I suspect this doesn't matter in most cases, but is done because:
- Some types may have multiple ways to represent the same value, and
- In the event of an altered column, two distinct values (of different types) may have the same representation.

This leads to some subtle edge cases: for example, if once branch alters a column type, and then modifies a row so the cell as the same representation as the original, unaltered value, we still need to detect that as a modification, otherwise we might silently drop it during the merge.

On the other side of the coin, if one branch alters a column and the other branch modifies that column, that's not necessarily a conflict even though the representations of both cells have changed.

The logic for merging cells is more complicated now than it was before, but I added comments that should make it easy to follow. In brief, we detect when columns have been altered and convert values as appropriate before checking to see if they've been modified by the branch.

In slightly more detail, if we have a cell with value `base` (of type A), a branch `right` which alters the column to have type B, and a branch `left` which modifies the cell (but is still type A):

- We convert `base` to type B in order to detect whether the branch `right` also modified the cell.
- We also convert the value on `left` to type B in order to detect whether a conflict exists with the value on `right`.

I'm still writing extra tests, and the `Convert` method doesn't support every type yet, but the design is ready for feedback.