### PR TITLE
Bug fix: Allow `dolt_checkout()` and `dolt status` when running in read-only mode

### DIFF
--- a/go/libraries/doltcore/sqle/dprocedures/init.go
+++ b/go/libraries/doltcore/sqle/dprocedures/init.go
@@ -23,14 +23,14 @@ var DoltProcedures = []sql.ExternalStoredProcedureDetails{
 	{Name: "dolt_add", Schema: int64Schema("status"), Function: doltAdd},
 	{Name: "dolt_backup", Schema: int64Schema("status"), Function: doltBackup},
 	{Name: "dolt_branch", Schema: int64Schema("status"), Function: doltBranch},
-	{Name: "dolt_checkout", Schema: doltCheckoutSchema, Function: doltCheckout},
+	{Name: "dolt_checkout", Schema: doltCheckoutSchema, Function: doltCheckout, ReadOnly: true},
 	{Name: "dolt_cherry_pick", Schema: cherryPickSchema, Function: doltCherryPick},
 	{Name: "dolt_clean", Schema: int64Schema("status"), Function: doltClean},
 	{Name: "dolt_clone", Schema: int64Schema("status"), Function: doltClone},
 	{Name: "dolt_commit", Schema: stringSchema("hash"), Function: doltCommit},
 	{Name: "dolt_commit_hash_out", Schema: stringSchema("hash"), Function: doltCommitHashOut},
 	{Name: "dolt_conflicts_resolve", Schema: int64Schema("status"), Function: doltConflictsResolve},
-	{Name: "dolt_count_commits", Schema: int64Schema("ahead", "behind"), Function: doltCountCommits},
+	{Name: "dolt_count_commits", Schema: int64Schema("ahead", "behind"), Function: doltCountCommits, ReadOnly: true},
 	{Name: "dolt_fetch", Schema: int64Schema("status"), Function: doltFetch},
 
 	// dolt_gc is enabled behind a feature flag for now, see dolt_gc.go
@@ -49,7 +49,7 @@ var DoltProcedures = []sql.ExternalStoredProcedureDetails{
 	// TODO: Add new procedure aliases in doltProcedureAliasSet in go-mysql-server/sql/information_schema/routines.go file
 	{Name: "dadd", Schema: int64Schema("status"), Function: doltAdd},
 	{Name: "dbranch", Schema: int64Schema("status"), Function: doltBranch},
-	{Name: "dcheckout", Schema: doltCheckoutSchema, Function: doltCheckout},
+	{Name: "dcheckout", Schema: doltCheckoutSchema, Function: doltCheckout, ReadOnly: true},
 	{Name: "dcherry_pick", Schema: cherryPickSchema, Function: doltCherryPick},
 	{Name: "dclean", Schema: int64Schema("status"), Function: doltClean},
 	{Name: "dclone", Schema: int64Schema("status"), Function: doltClone},

--- a/go/libraries/doltcore/sqle/dprocedures/init.go
+++ b/go/libraries/doltcore/sqle/dprocedures/init.go
@@ -21,7 +21,7 @@ import (
 
 var DoltProcedures = []sql.ExternalStoredProcedureDetails{
 	{Name: "dolt_add", Schema: int64Schema("status"), Function: doltAdd},
-	{Name: "dolt_backup", Schema: int64Schema("status"), Function: doltBackup},
+	{Name: "dolt_backup", Schema: int64Schema("status"), Function: doltBackup, ReadOnly: true},
 	{Name: "dolt_branch", Schema: int64Schema("status"), Function: doltBranch},
 	{Name: "dolt_checkout", Schema: doltCheckoutSchema, Function: doltCheckout, ReadOnly: true},
 	{Name: "dolt_cherry_pick", Schema: cherryPickSchema, Function: doltCherryPick},

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -202,6 +202,26 @@ SQL
     [[ "$output" =~ "Variable 'aws_credentials_file' is a read only variable" ]] || false
 }
 
+@test "sql-server: read-only mode" {
+    skiponwindows "Missing dependencies"
+
+    # Create a second branch to test `call dolt_checkout()`
+    # and push to a remote to test `dolt status`
+    cd repo1
+    dolt sql -q "call dolt_branch('other');"
+    mkdir ../repo1-remote
+    dolt remote add origin file://../repo1-remote
+    dolt push origin main
+
+    # Start up the server in read-only mode
+    start_sql_server_with_args "--readonly" "--user dolt"
+
+    # Assert that we can still checkout other branches and run dolt status
+    # while the sql-server is running in read-only mode
+    dolt sql -q "call dolt_checkout('other');"
+    dolt sql -q "call dolt_count_commits('--from', 'HEAD', '--to', 'HEAD');"
+    dolt status
+}
 
 @test "sql-server: inspect sql-server using CLI" {
     skiponwindows "Missing dependencies"


### PR DESCRIPTION
The stored procedures for `dolt_checkout` and `dolt_count_commits` weren't marked as being read-only, so when run against a read-only sql-server, they resulted in an error about the database being read-only. 

Fixes: https://github.com/dolthub/dolt/issues/6730