### PR TITLE
go: sqle: cluster: Improvements for DROP DATABASE replication.

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -278,85 +278,82 @@ func Serve(
 	var remoteSrv *remotesrv.Server
 	if serverConfig.RemotesapiPort() != nil {
 		port := *serverConfig.RemotesapiPort()
-		if remoteSrvSqlCtx, err := sqlEngine.NewDefaultContext(ctx); err == nil {
-			listenaddr := fmt.Sprintf(":%d", port)
-			args := sqle.RemoteSrvServerArgs(remoteSrvSqlCtx, remotesrv.ServerArgs{
-				Logger:         logrus.NewEntry(lgr),
-				ReadOnly:       true,
-				HttpListenAddr: listenaddr,
-				GrpcListenAddr: listenaddr,
-			})
-
-			ctxFactory := func() (*sql.Context, error) { return sqlEngine.NewDefaultContext(ctx) }
-			authenticator := newAuthenticator(ctxFactory, sqlEngine.GetUnderlyingEngine().Analyzer.Catalog.MySQLDb)
-			args = sqle.WithUserPasswordAuth(args, authenticator)
-
-			args.TLSConfig = serverConf.TLSConfig
-			remoteSrv, err = remotesrv.NewServer(args)
-			if err != nil {
-				lgr.Errorf("error creating remotesapi server on port %d: %v", port, err)
-				startError = err
-				return
-			}
-			listeners, err := remoteSrv.Listeners()
-			if err != nil {
-				lgr.Errorf("error starting remotesapi server listeners on port %d: %v", port, err)
-				startError = err
-				return
-			} else {
-				go remoteSrv.Serve(listeners)
-			}
-		} else {
+		listenaddr := fmt.Sprintf(":%d", port)
+		args, err := sqle.RemoteSrvServerArgs(sqlEngine.NewDefaultContext, remotesrv.ServerArgs{
+			Logger:         logrus.NewEntry(lgr),
+			ReadOnly:       true,
+			HttpListenAddr: listenaddr,
+			GrpcListenAddr: listenaddr,
+		})
+		if err != nil {
 			lgr.Errorf("error creating SQL engine context for remotesapi server: %v", err)
 			startError = err
 			return
+		}
+
+		ctxFactory := func() (*sql.Context, error) { return sqlEngine.NewDefaultContext(ctx) }
+		authenticator := newAuthenticator(ctxFactory, sqlEngine.GetUnderlyingEngine().Analyzer.Catalog.MySQLDb)
+		args = sqle.WithUserPasswordAuth(args, authenticator)
+
+		args.TLSConfig = serverConf.TLSConfig
+		remoteSrv, err = remotesrv.NewServer(args)
+		if err != nil {
+			lgr.Errorf("error creating remotesapi server on port %d: %v", port, err)
+			startError = err
+			return
+		}
+		listeners, err := remoteSrv.Listeners()
+		if err != nil {
+			lgr.Errorf("error starting remotesapi server listeners on port %d: %v", port, err)
+			startError = err
+			return
+		} else {
+			go remoteSrv.Serve(listeners)
 		}
 	}
 
 	var clusterRemoteSrv *remotesrv.Server
 	if clusterController != nil {
-		if remoteSrvSqlCtx, err := sqlEngine.NewDefaultContext(ctx); err == nil {
-			args := clusterController.RemoteSrvServerArgs(remoteSrvSqlCtx, remotesrv.ServerArgs{
-				Logger: logrus.NewEntry(lgr),
-			})
-
-			clusterRemoteSrvTLSConfig, err := LoadClusterTLSConfig(serverConfig.ClusterConfig())
-			if err != nil {
-				lgr.Errorf("error starting remotesapi server for cluster config, could not load tls config: %v", err)
-				startError = err
-				return
-			}
-			args.TLSConfig = clusterRemoteSrvTLSConfig
-
-			clusterRemoteSrv, err = remotesrv.NewServer(args)
-			if err != nil {
-				lgr.Errorf("error creating remotesapi server on port %d: %v", *serverConfig.RemotesapiPort(), err)
-				startError = err
-				return
-			}
-			clusterController.RegisterGrpcServices(clusterRemoteSrv.GrpcServer())
-
-			listeners, err := clusterRemoteSrv.Listeners()
-			if err != nil {
-				lgr.Errorf("error starting remotesapi server listeners for cluster config on %s: %v", clusterController.RemoteSrvListenAddr(), err)
-				startError = err
-				return
-			}
-
-			go clusterRemoteSrv.Serve(listeners)
-			go clusterController.Run()
-
-			clusterController.ManageQueryConnections(
-				mySQLServer.SessionManager().Iter,
-				sqlEngine.GetUnderlyingEngine().ProcessList.Kill,
-				mySQLServer.SessionManager().KillConnection,
-			)
-		} else {
+		args, err := clusterController.RemoteSrvServerArgs(sqlEngine.NewDefaultContext, remotesrv.ServerArgs{
+			Logger: logrus.NewEntry(lgr),
+		})
+		if err != nil {
 			lgr.Errorf("error creating SQL engine context for remotesapi server: %v", err)
 			startError = err
 			return
 		}
 
+		clusterRemoteSrvTLSConfig, err := LoadClusterTLSConfig(serverConfig.ClusterConfig())
+		if err != nil {
+			lgr.Errorf("error starting remotesapi server for cluster config, could not load tls config: %v", err)
+			startError = err
+			return
+		}
+		args.TLSConfig = clusterRemoteSrvTLSConfig
+
+		clusterRemoteSrv, err = remotesrv.NewServer(args)
+		if err != nil {
+			lgr.Errorf("error creating remotesapi server on port %d: %v", *serverConfig.RemotesapiPort(), err)
+			startError = err
+			return
+		}
+		clusterController.RegisterGrpcServices(clusterRemoteSrv.GrpcServer())
+
+		listeners, err := clusterRemoteSrv.Listeners()
+		if err != nil {
+			lgr.Errorf("error starting remotesapi server listeners for cluster config on %s: %v", clusterController.RemoteSrvListenAddr(), err)
+			startError = err
+			return
+		}
+
+		go clusterRemoteSrv.Serve(listeners)
+		go clusterController.Run()
+
+		clusterController.ManageQueryConnections(
+			mySQLServer.SessionManager().Iter,
+			sqlEngine.GetUnderlyingEngine().ProcessList.Kill,
+			mySQLServer.SessionManager().KillConnection,
+		)
 	}
 
 	if ok, f := mrEnv.IsLocked(); ok {

--- a/go/libraries/doltcore/remotesrv/dbcache.go
+++ b/go/libraries/doltcore/remotesrv/dbcache.go
@@ -15,13 +15,15 @@
 package remotesrv
 
 import (
+	"context"
+
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/nbs"
 )
 
 type DBCache interface {
-	Get(path, nbfVerStr string) (RemoteSrvStore, error)
+	Get(ctx context.Context, path, nbfVerStr string) (RemoteSrvStore, error)
 }
 
 type RemoteSrvStore interface {

--- a/go/libraries/doltcore/remotesrv/grpc.go
+++ b/go/libraries/doltcore/remotesrv/grpc.go
@@ -93,7 +93,7 @@ func (rs *RemoteChunkStore) HasChunks(ctx context.Context, req *remotesapi.HasCh
 	logger = logger.WithField(RepoPathField, repoPath)
 	defer func() { logger.Info("finished") }()
 
-	cs, err := rs.getStore(logger, repoPath)
+	cs, err := rs.getStore(ctx, logger, repoPath)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ func (rs *RemoteChunkStore) GetDownloadLocations(ctx context.Context, req *remot
 	logger = logger.WithField(RepoPathField, repoPath)
 	defer func() { logger.Info("finished") }()
 
-	cs, err := rs.getStore(logger, repoPath)
+	cs, err := rs.getStore(ctx, logger, repoPath)
 	if err != nil {
 		return nil, err
 	}
@@ -255,7 +255,7 @@ func (rs *RemoteChunkStore) StreamDownloadLocations(stream remotesapi.ChunkStore
 		if nextPath != repoPath {
 			repoPath = nextPath
 			logger = ologger.WithField(RepoPathField, repoPath)
-			cs, err = rs.getStore(logger, repoPath)
+			cs, err = rs.getStore(stream.Context(), logger, repoPath)
 			if err != nil {
 				return err
 			}
@@ -368,7 +368,7 @@ func (rs *RemoteChunkStore) GetUploadLocations(ctx context.Context, req *remotes
 	logger = logger.WithField(RepoPathField, repoPath)
 	defer func() { logger.Info("finished") }()
 
-	_, err := rs.getStore(logger, repoPath)
+	_, err := rs.getStore(ctx, logger, repoPath)
 	if err != nil {
 		return nil, err
 	}
@@ -426,7 +426,7 @@ func (rs *RemoteChunkStore) Rebase(ctx context.Context, req *remotesapi.RebaseRe
 	logger = logger.WithField(RepoPathField, repoPath)
 	defer func() { logger.Info("finished") }()
 
-	_, err := rs.getStore(logger, repoPath)
+	_, err := rs.getStore(ctx, logger, repoPath)
 	if err != nil {
 		return nil, err
 	}
@@ -443,7 +443,7 @@ func (rs *RemoteChunkStore) Root(ctx context.Context, req *remotesapi.RootReques
 	logger = logger.WithField(RepoPathField, repoPath)
 	defer func() { logger.Info("finished") }()
 
-	cs, err := rs.getStore(logger, repoPath)
+	cs, err := rs.getStore(ctx, logger, repoPath)
 	if err != nil {
 		return nil, err
 	}
@@ -466,7 +466,7 @@ func (rs *RemoteChunkStore) Commit(ctx context.Context, req *remotesapi.CommitRe
 	logger = logger.WithField(RepoPathField, repoPath)
 	defer func() { logger.Info("finished") }()
 
-	cs, err := rs.getStore(logger, repoPath)
+	cs, err := rs.getStore(ctx, logger, repoPath)
 	if err != nil {
 		return nil, err
 	}
@@ -509,7 +509,7 @@ func (rs *RemoteChunkStore) GetRepoMetadata(ctx context.Context, req *remotesapi
 	logger = logger.WithField(RepoPathField, repoPath)
 	defer func() { logger.Info("finished") }()
 
-	cs, err := rs.getOrCreateStore(logger, repoPath, req.ClientRepoFormat.NbfVersion)
+	cs, err := rs.getOrCreateStore(ctx, logger, repoPath, req.ClientRepoFormat.NbfVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -536,7 +536,7 @@ func (rs *RemoteChunkStore) ListTableFiles(ctx context.Context, req *remotesapi.
 	logger = logger.WithField(RepoPathField, repoPath)
 	defer func() { logger.Info("finished") }()
 
-	cs, err := rs.getStore(logger, repoPath)
+	cs, err := rs.getStore(ctx, logger, repoPath)
 	if err != nil {
 		return nil, err
 	}
@@ -614,7 +614,7 @@ func (rs *RemoteChunkStore) AddTableFiles(ctx context.Context, req *remotesapi.A
 	logger = logger.WithField(RepoPathField, repoPath)
 	defer func() { logger.Info("finished") }()
 
-	cs, err := rs.getStore(logger, repoPath)
+	cs, err := rs.getStore(ctx, logger, repoPath)
 	if err != nil {
 		return nil, err
 	}
@@ -637,12 +637,12 @@ func (rs *RemoteChunkStore) AddTableFiles(ctx context.Context, req *remotesapi.A
 	return &remotesapi.AddTableFilesResponse{Success: true}, nil
 }
 
-func (rs *RemoteChunkStore) getStore(logger *logrus.Entry, repoPath string) (RemoteSrvStore, error) {
-	return rs.getOrCreateStore(logger, repoPath, types.Format_Default.VersionString())
+func (rs *RemoteChunkStore) getStore(ctx context.Context, logger *logrus.Entry, repoPath string) (RemoteSrvStore, error) {
+	return rs.getOrCreateStore(ctx, logger, repoPath, types.Format_Default.VersionString())
 }
 
-func (rs *RemoteChunkStore) getOrCreateStore(logger *logrus.Entry, repoPath, nbfVerStr string) (RemoteSrvStore, error) {
-	cs, err := rs.csCache.Get(repoPath, nbfVerStr)
+func (rs *RemoteChunkStore) getOrCreateStore(ctx context.Context, logger *logrus.Entry, repoPath, nbfVerStr string) (RemoteSrvStore, error) {
+	cs, err := rs.csCache.Get(ctx, repoPath, nbfVerStr)
 	if err != nil {
 		logger.WithError(err).Error("Failed to retrieve chunkstore")
 		if errors.Is(err, ErrUnimplemented) {

--- a/go/libraries/doltcore/remotesrv/http.go
+++ b/go/libraries/doltcore/remotesrv/http.go
@@ -286,7 +286,7 @@ func writeTableFile(ctx context.Context, logger *logrus.Entry, dbCache DBCache, 
 		return logger, http.StatusBadRequest
 	}
 
-	cs, err := dbCache.Get(path, types.Format_Default.VersionString())
+	cs, err := dbCache.Get(ctx, path, types.Format_Default.VersionString())
 	if err != nil {
 		logger = logger.WithField("status", http.StatusInternalServerError)
 		logger.WithError(err).Error("failed to get repository")

--- a/go/libraries/doltcore/sqle/cluster/initdbhook.go
+++ b/go/libraries/doltcore/sqle/cluster/initdbhook.go
@@ -50,6 +50,7 @@ func NewInitDatabaseHook(controller *Controller, bt *sql.BackgroundThreads, orig
 
 			err := denv.AddRemote(r)
 			if err != nil {
+				// XXX: An error here means we are not replicating.
 				return err
 			}
 
@@ -59,16 +60,25 @@ func NewInitDatabaseHook(controller *Controller, bt *sql.BackgroundThreads, orig
 			remoteUrls = append(remoteUrls, remoteUrl)
 		}
 
+		// When we create a new database, we stop trying to replicate a
+		// previous drop of that database to the replicas. Successfully
+		// replicating a new head update will set the state of any
+		// existing database to the state of this new database going
+		// forward.
+		controller.cancelDropDatabaseReplication(name)
+
 		role, _ := controller.roleAndEpoch()
 		for i, r := range controller.cfg.StandbyRemotes() {
 			ttfdir, err := denv.TempTableFilesDir()
 			if err != nil {
+				// XXX: An error here means we are not replicating to every standby.
 				return err
 			}
 			commitHook := newCommitHook(controller.lgr, r.Name(), remoteUrls[i], name, role, remoteDBs[i], denv.DoltDB, ttfdir)
 			denv.DoltDB.PrependCommitHook(ctx, commitHook)
 			controller.registerCommitHook(commitHook)
 			if err := commitHook.Run(bt); err != nil {
+				// XXX: An error here means we are not replicating to every standby.
 				return err
 			}
 		}

--- a/go/libraries/doltcore/sqle/cluster/remotesrv.go
+++ b/go/libraries/doltcore/sqle/cluster/remotesrv.go
@@ -26,8 +26,8 @@ type remotesrvStoreCache struct {
 	controller *Controller
 }
 
-func (s remotesrvStoreCache) Get(path, nbfVerStr string) (remotesrv.RemoteSrvStore, error) {
-	rss, err := s.DBCache.Get(path, nbfVerStr)
+func (s remotesrvStoreCache) Get(ctx context.Context, path, nbfVerStr string) (remotesrv.RemoteSrvStore, error) {
+	rss, err := s.DBCache.Get(ctx, path, nbfVerStr)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -638,12 +638,6 @@ func (p DoltDatabaseProvider) DropDatabase(ctx *sql.Context, name string) error 
 		return err
 	}
 
-	if p.DropDatabaseHook != nil {
-		// For symmetry with InitDatabaseHook and the names we see in
-		// MultiEnv initialization, we use `name` here, not `dbKey`.
-		p.DropDatabaseHook(name)
-	}
-
 	rootDbLoc, err := p.fs.Abs("")
 	if err != nil {
 		return err
@@ -672,6 +666,12 @@ func (p DoltDatabaseProvider) DropDatabase(ctx *sql.Context, name string) error 
 	err = p.fs.Delete(dirToDelete, true)
 	if err != nil {
 		return err
+	}
+
+	if p.DropDatabaseHook != nil {
+		// For symmetry with InitDatabaseHook and the names we see in
+		// MultiEnv initialization, we use `name` here, not `dbKey`.
+		p.DropDatabaseHook(name)
 	}
 
 	// We not only have to delete this database, but any derivative ones that we've stored as a result of USE or

--- a/go/store/nbs/journal.go
+++ b/go/store/nbs/journal.go
@@ -458,6 +458,7 @@ func newJournalManifest(ctx context.Context, dir string) (m *journalManifest, er
 		}
 	}()
 
+
 	var ok bool
 	ok, _, err = m.ParseIfExists(ctx, &Stats{}, nil)
 	if err != nil {

--- a/go/utils/remotesrv/cscache.go
+++ b/go/utils/remotesrv/cscache.go
@@ -43,7 +43,7 @@ func NewLocalCSCache(filesys filesys.Filesys) *LocalCSCache {
 	}
 }
 
-func (cache *LocalCSCache) Get(repopath, nbfVerStr string) (remotesrv.RemoteSrvStore, error) {
+func (cache *LocalCSCache) Get(ctx context.Context, repopath, nbfVerStr string) (remotesrv.RemoteSrvStore, error) {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
@@ -62,7 +62,7 @@ func (cache *LocalCSCache) Get(repopath, nbfVerStr string) (remotesrv.RemoteSrvS
 		return nil, err
 	}
 
-	newCS, err := nbs.NewLocalStore(context.TODO(), nbfVerStr, path, defaultMemTableSize, nbs.NewUnlimitedMemQuotaProvider())
+	newCS, err := nbs.NewLocalStore(ctx, nbfVerStr, path, defaultMemTableSize, nbs.NewUnlimitedMemQuotaProvider())
 	if err != nil {
 		return nil, err
 	}
@@ -76,6 +76,6 @@ type SingletonCSCache struct {
 	s remotesrv.RemoteSrvStore
 }
 
-func (cache SingletonCSCache) Get(path, nbfVerStr string) (remotesrv.RemoteSrvStore, error) {
+func (cache SingletonCSCache) Get(_ context.Context, path, nbfVerStr string) (remotesrv.RemoteSrvStore, error) {
 	return cache.s, nil
 }

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
@@ -1417,71 +1417,6 @@ tests:
     - exec: 'call dolt_gc()'
       error_match: "must be the primary"
     - exec: 'call dolt_gc("--shallow")'
-- name: dropped database no longer in dolt_cluster_status
-  multi_repos:
-  - name: server1
-    with_files:
-    - name: server.yaml
-      contents: |
-        log_level: trace
-        listener:
-          host: 0.0.0.0
-          port: 3309
-        cluster:
-          standby_remotes:
-          - name: standby
-            remote_url_template: http://localhost:3852/{database}
-          bootstrap_role: primary
-          bootstrap_epoch: 1
-          remotesapi:
-            port: 3851
-    server:
-      args: ["--config", "server.yaml"]
-      port: 3309
-  - name: server2
-    with_files:
-    - name: server.yaml
-      contents: |
-        log_level: trace
-        listener:
-          host: 0.0.0.0
-          port: 3310
-        cluster:
-          standby_remotes:
-          - name: standby
-            remote_url_template: http://localhost:3851/{database}
-          bootstrap_role: standby
-          bootstrap_epoch: 1
-          remotesapi:
-            port: 3852
-    server:
-      args: ["--config", "server.yaml"]
-      port: 3310
-  connections:
-  - on: server1
-    queries:
-    - exec: 'create database repo1'
-    - exec: 'use repo1'
-    - exec: 'SET @@GLOBAL.dolt_cluster_ack_writes_timeout_secs = 10'
-    - exec: 'create table vals (i int primary key)'
-    - query: "select `database`, standby_remote, role, epoch, replication_lag_millis is not null as `replication_lag_millis`, current_error from dolt_cluster.dolt_cluster_status"
-      result:
-        columns: ["database","standby_remote","role","epoch","replication_lag_millis","current_error"]
-        rows:
-        - ["repo1", "standby", "primary", "1", "1", "NULL"]
-    - exec: 'use dolt_cluster'
-    - exec: 'drop database repo1'
-    - query: 'show databases'
-      result:
-        columns: ["Database"]
-        rows:
-        - ["dolt_cluster"]
-        - ["information_schema"]
-        - ["mysql"]
-    - query: "select `database`, standby_remote, role, epoch, replication_lag_millis is not null as `replication_lag_millis`, current_error from dolt_cluster.dolt_cluster_status"
-      result:
-        columns: ["database","standby_remote","role","epoch","replication_lag_millis","current_error"]
-        rows: []
 - name: dropped database is no longer present on replica
   multi_repos:
   - name: server1
@@ -1570,3 +1505,100 @@ tests:
         columns: ["database","standby_remote","role","epoch",]
         rows:
         - ["repo1", "standby", "standby", "1"]
+- name: dropped database recreated quiesces to expected state
+  multi_repos:
+  - name: server1
+    with_files:
+    - name: server.yaml
+      contents: |
+        log_level: trace
+        listener:
+          host: 0.0.0.0
+          port: 3309
+        cluster:
+          standby_remotes:
+          - name: standby
+            remote_url_template: http://localhost:3852/{database}
+          bootstrap_role: primary
+          bootstrap_epoch: 1
+          remotesapi:
+            port: 3851
+    server:
+      args: ["--config", "server.yaml"]
+      port: 3309
+  - name: server2
+    with_files:
+    - name: server.yaml
+      contents: |
+        log_level: trace
+        listener:
+          host: 0.0.0.0
+          port: 3310
+        cluster:
+          standby_remotes:
+          - name: standby
+            remote_url_template: http://localhost:3851/{database}
+          bootstrap_role: standby
+          bootstrap_epoch: 1
+          remotesapi:
+            port: 3852
+    server:
+      args: ["--config", "server.yaml"]
+      port: 3310
+  connections:
+  - on: server1
+    queries:
+    - exec: 'SET @@GLOBAL.dolt_cluster_ack_writes_timeout_secs = 10'
+    - exec: 'create database repo1'
+    - exec: 'use repo1'
+    - exec: 'create table vals (a int)'
+    - exec: 'use mysql'
+    - exec: 'drop database repo1'
+    - exec: 'create database repo1'
+    - exec: 'use repo1'
+    - exec: 'create table vals (b int)'
+    - exec: 'use mysql'
+    - exec: 'drop database repo1'
+    - exec: 'create database repo1'
+    - exec: 'use repo1'
+    - exec: 'create table vals (c int)'
+    - exec: 'use mysql'
+    - exec: 'drop database repo1'
+    - query: "select `database`, standby_remote, role, epoch, replication_lag_millis is not null as `replication_lag_millis`, current_error from dolt_cluster.dolt_cluster_status"
+      result:
+        columns: ["database","standby_remote","role","epoch","replication_lag_millis","current_error"]
+        rows: []
+  - on: server2
+    queries:
+    - query: 'show databases'
+      result:
+        columns: ["Database"]
+        rows:
+        - ["dolt_cluster"]
+        - ["information_schema"]
+        - ["mysql"]
+      retry_attempts: 100
+    - query: "select `database`, standby_remote, role, epoch from dolt_cluster.dolt_cluster_status"
+      result:
+        columns: ["database","standby_remote","role","epoch",]
+        rows: []
+  - on: server1
+    queries:
+    - exec: 'create database repo1'
+    - exec: 'use repo1'
+    - exec: 'create table vals (d int)'
+  - on: server2
+    queries:
+    - query: 'show databases'
+      result:
+        columns: ["Database"]
+        rows:
+        - ["dolt_cluster"]
+        - ["information_schema"]
+        - ["mysql"]
+        - ["repo1"]
+    - exec: 'use repo1'
+    - query: "select d from vals"
+      result:
+        columns: ["d"]
+        rows: []


### PR DESCRIPTION
Fix a bug in session handling for the replication api endpoint which would prevent a dropped database from being recreated on a replica.

Fix a race condition when a database is recreated after it is dropped. In that case, we stop attempting to replicate the drop, so that it does not replicate after the new database does.