### PR TITLE
go: sqle: cluster: When performing a graceful transition to standby, take mysql and dolt_branch_control replication state into account.

### DIFF
--- a/go/libraries/doltcore/sqle/cluster/branch_control_replica.go
+++ b/go/libraries/doltcore/sqle/cluster/branch_control_replica.go
@@ -148,6 +148,9 @@ func (r *branchControlReplica) Run() {
 }
 
 func (r *branchControlReplica) wait() {
+	if r.waitNotify != nil {
+		r.waitNotify()
+	}
 	if r.isCaughtUp() {
 		attempt := r.progressNotifier.BeginAttempt()
 		r.progressNotifier.RecordSuccess(attempt)
@@ -256,7 +259,7 @@ func (p *branchControlReplication) waitForReplication(timeout time.Duration) ([]
 	for i := range res {
 		res[i].database = "dolt_branch_control"
 		res[i].remote = replicas[i].client.remote
-		res[i].remoteUrl = replicas[i].client.url
+		res[i].remoteUrl = replicas[i].client.httpUrl()
 	}
 	var wg sync.WaitGroup
 	wg.Add(len(replicas))

--- a/go/libraries/doltcore/sqle/cluster/controller.go
+++ b/go/libraries/doltcore/sqle/cluster/controller.go
@@ -825,7 +825,7 @@ func (c *Controller) gracefulTransitionToStandby(saveConnID, minCaughtUpStandbys
 		return nil, errors.New("cluster/controller: failed to transition to standby; the set of replicated databases changed during the transition.")
 	}
 
-	res := make([]graceTransitionResult, 0, len(hookStates) + len(mysqlStates) + len(bcStates))
+	res := make([]graceTransitionResult, 0, len(hookStates)+len(mysqlStates)+len(bcStates))
 	res = append(res, hookStates...)
 	res = append(res, mysqlStates...)
 	res = append(res, bcStates...)

--- a/go/libraries/doltcore/sqle/cluster/mysqldb_persister.go
+++ b/go/libraries/doltcore/sqle/cluster/mysqldb_persister.go
@@ -282,11 +282,16 @@ func (p *replicatingMySQLDbPersister) LoadData(ctx context.Context) ([]byte, err
 	return ret, err
 }
 
-func (p *replicatingMySQLDbPersister) waitForReplication(timeout time.Duration) bool {
+func (p *replicatingMySQLDbPersister) waitForReplication(timeout time.Duration) ([]graceTransitionResult, error) {
 	p.mu.Lock()
 	replicas := make([]*mysqlDbReplica, len(p.replicas))
 	copy(replicas, p.replicas)
-	caughtup := make([]bool, len(replicas))
+	res := make([]graceTransitionResult, len(replicas))
+	for i := range replicas {
+		res[i].database = "mysql"
+		res[i].remote = replicas[i].client.remote
+		res[i].remoteUrl = replicas[i].client.url
+	}
 	var wg sync.WaitGroup
 	wg.Add(len(replicas))
 	for li, lr := range replicas {
@@ -294,9 +299,9 @@ func (p *replicatingMySQLDbPersister) waitForReplication(timeout time.Duration) 
 		r := lr
 		ok := r.setWaitNotify(func() {
 			// called with r.mu locked.
-			if !caughtup[i] {
+			if !res[i].caughtUp {
 				if r.isCaughtUp() {
-					caughtup[i] = true
+					res[i].caughtUp = true
 					wg.Done()
 				} else {
 				}
@@ -306,7 +311,7 @@ func (p *replicatingMySQLDbPersister) waitForReplication(timeout time.Duration) 
 			for j := li - 1; j >= 0; j-- {
 				replicas[j].setWaitNotify(nil)
 			}
-			return false
+			return nil, errors.New("cluster: mysqldb replication: could not wait for replication. Concurrent waiters conflicted with each other.")
 		}
 	}
 	p.mu.Unlock()
@@ -330,14 +335,12 @@ func (p *replicatingMySQLDbPersister) waitForReplication(timeout time.Duration) 
 	// Make certain we don't leak the wg.Wait goroutine in the failure case.
 	// At this point, none of the callbacks will ever be called again and
 	// ch.setWaitNotify grabs a lock and so establishes the happens before.
-	all := true
-	for _, b := range caughtup {
-		if !b {
+	for _, b := range res {
+		if !b.caughtUp {
 			wg.Done()
-			all = false
 		}
 	}
 	<-done
 
-	return all
+	return res, nil
 }

--- a/go/libraries/doltcore/sqle/cluster/mysqldb_persister.go
+++ b/go/libraries/doltcore/sqle/cluster/mysqldb_persister.go
@@ -290,7 +290,7 @@ func (p *replicatingMySQLDbPersister) waitForReplication(timeout time.Duration) 
 	for i := range replicas {
 		res[i].database = "mysql"
 		res[i].remote = replicas[i].client.remote
-		res[i].remoteUrl = replicas[i].client.url
+		res[i].remoteUrl = replicas[i].client.httpUrl()
 	}
 	var wg sync.WaitGroup
 	wg.Add(len(replicas))

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
@@ -886,7 +886,10 @@ tests:
     - query: "call dolt_cluster_transition_to_standby('2', '1')"
       result:
         columns: ["caught_up", "database", "remote", "remote_url"]
-        rows: [["1", "repo1", "standby", "http://localhost:3852/repo1"]]
+        rows:
+        - ["1", "repo1", "standby", "http://localhost:3852/repo1"]
+        - ["1", "mysql", "standby", "http://localhost:3852"]
+        - ["1", "dolt_branch_control", "standby", "http://localhost:3852"]
 - name: dolt_cluster_transition_to_standby too many standbys provided
   multi_repos:
   - name: server1
@@ -935,7 +938,7 @@ tests:
     - exec: 'create table vals (i int primary key)'
     - exec: 'insert into vals values (0),(1),(2),(3),(4)'
     - query: "call dolt_cluster_transition_to_standby('2', '2')"
-      error_match: failed to transition from primary to standby gracefully; could not ensure 2 replicas were caught up on all 1 databases. Only caught up 1 standbys fully.
+      error_match: failed to transition from primary to standby gracefully; could not ensure 2 replicas were caught up on all 3 databases. Only caught up 1 standbys fully.
 - name: create new database, primary replicates to standby, fails over, new primary replicates to standby, fails over, new primary has all writes
   multi_repos:
   - name: server1


### PR DESCRIPTION
Graceful transitions to standby block on the primary until a certain number of replicas are trued up. They then return a status of whether each database on each replica is caught up, so that a control plane agent can pick a caught up server to be next primary, for example.

The newly added replication of users and grants and branch control permissions did not used to participate in this graceful transition logic. This makes it so that the state of mysql and dolt_branch_control replication is reported in the rows returned from `call dolt_cluster_transition_to_standby` and those databases must also be caught up on a replica for the replica to be considered fully caught up.