### PR TITLE
migrate dolt merge-base to use sql queries

### DIFF
--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -143,7 +143,6 @@ var commandsWithoutCliCtx = []cli.Command{
 	commands.ReadTablesCmd{},
 	commands.GarbageCollectionCmd{},
 	commands.FilterBranchCmd{},
-	commands.MergeBaseCmd{},
 	commands.RootsCmd{},
 	commands.VersionCmd{VersionStr: Version},
 	commands.DumpCmd{},

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -1215,3 +1215,24 @@ SQL
     [ $status -eq 0 ]
     [[ "$output" =~ "cm3" ]] || false
 }
+
+@test "sql-local-remote: verify dolt merge-base behavior" {
+    cd altDB
+    dolt checkout -b feature
+    dolt sql -q "create table table4 (pk int PRIMARY KEY)"
+    dolt add .
+    dolt commit -m "created table3"
+
+    run dolt --verbose-engine-setup merge-base main feature
+    [ $status -eq 0 ]
+    [[ "$output" =~ "starting local mode" ]] || false
+    localOutput="${lines[1]}"
+
+    start_sql_server altDB
+    run dolt --verbose-engine-setup merge-base main feature
+    [ $status -eq 0 ]
+    [[ "$output" =~ "starting remote mode" ]] || false
+    remoteOutput="${lines[1]}"
+
+    [[ "$localOutput" == "$remoteOutput" ]] || false
+}


### PR DESCRIPTION
This change updates dolt merge-base to use the appropriate sql engine to generate results.

Related: https://github.com/dolthub/dolt/issues/3922