### PR TITLE
add --silent option for push, pull, fetch

### DIFF
--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -106,6 +106,7 @@ func CreatePushArgParser() *argparser.ArgParser {
 	ap.SupportsFlag(SetUpstreamFlag, "u", "For every branch that is up to date or successfully pushed, add upstream (tracking) reference, used by argument-less {{.EmphasisLeft}}dolt pull{{.EmphasisRight}} and other commands.")
 	ap.SupportsFlag(ForceFlag, "f", "Update the remote with local history, overwriting any conflicting history in the remote.")
 	ap.SupportsFlag(AllFlag, "", "Push all branches.")
+	ap.SupportsFlag(SilentFlag, "", "Suppress progress information.")
 	return ap
 }
 
@@ -171,6 +172,7 @@ func CreateFetchArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParserWithVariableArgs("fetch")
 	ap.SupportsString(UserFlag, "u", "user", "User name to use when authenticating with the remote. Gets password from the environment variable {{.EmphasisLeft}}DOLT_REMOTE_PASSWORD{{.EmphasisRight}}.")
 	ap.SupportsFlag(PruneFlag, "p", "After fetching, remove any remote-tracking references that don't exist on the remote.")
+	ap.SupportsFlag(SilentFlag, "", "Suppress progress information.")
 	return ap
 }
 
@@ -194,6 +196,7 @@ func CreatePullArgParser() *argparser.ArgParser {
 	ap.SupportsFlag(NoCommitFlag, "", "Perform the merge and stop just before creating a merge commit. Note this will not prevent a fast-forward merge; use the --no-ff arg together with the --no-commit arg to prevent both fast-forwards and merge commits.")
 	ap.SupportsFlag(NoEditFlag, "", "Use an auto-generated commit message when creating a merge commit. The default for interactive CLI sessions is to open an editor.")
 	ap.SupportsString(UserFlag, "u", "user", "User name to use when authenticating with the remote. Gets password from the environment variable {{.EmphasisLeft}}DOLT_REMOTE_PASSWORD{{.EmphasisRight}}.")
+	ap.SupportsFlag(SilentFlag, "", "Suppress progress information.")
 	return ap
 }
 

--- a/go/cmd/dolt/cli/flags.go
+++ b/go/cmd/dolt/cli/flags.go
@@ -58,6 +58,7 @@ const (
 	SetUpstreamFlag      = "set-upstream"
 	ShallowFlag          = "shallow"
 	ShowIgnoredFlag      = "ignored"
+	SilentFlag           = "silent"
 	SkipEmptyFlag        = "skip-empty"
 	SoftResetParam       = "soft"
 	SquashParam          = "squash"

--- a/go/cmd/dolt/commands/fetch.go
+++ b/go/cmd/dolt/commands/fetch.go
@@ -105,10 +105,12 @@ func (cmd FetchCmd) Exec(ctx context.Context, commandStr string, args []string, 
 	}()
 
 	spinner := TextSpinner{}
-	cli.Print(spinner.next() + " Fetching...")
-	defer func() {
-		cli.DeleteAndPrint(len(" Fetching...")+1, "")
-	}()
+	if !apr.Contains(cli.SilentFlag) {
+		cli.Print(spinner.next() + " Fetching...")
+		defer func() {
+			cli.DeleteAndPrint(len(" Fetching...")+1, "")
+		}()
+	}
 
 	for {
 		select {
@@ -127,7 +129,9 @@ func (cmd FetchCmd) Exec(ctx context.Context, commandStr string, args []string, 
 			}
 			return HandleVErrAndExitCode(nil, usage)
 		case <-time.After(time.Millisecond * 50):
-			cli.DeleteAndPrint(len(" Fetching...")+1, spinner.next()+" Fetching...")
+			if !apr.Contains(cli.SilentFlag) {
+				cli.DeleteAndPrint(len(" Fetching...")+1, spinner.next()+" Fetching...")
+			}
 		}
 	}
 }

--- a/go/cmd/dolt/commands/pull.go
+++ b/go/cmd/dolt/commands/pull.go
@@ -184,10 +184,12 @@ func (cmd PullCmd) Exec(ctx context.Context, commandStr string, args []string, d
 	}()
 
 	spinner := TextSpinner{}
-	cli.Print(spinner.next() + " Pulling...")
-	defer func() {
-		cli.DeleteAndPrint(len(" Pulling...")+1, "")
-	}()
+	if !apr.Contains(cli.SilentFlag) {
+		cli.Print(spinner.next() + " Pulling...")
+		defer func() {
+			cli.DeleteAndPrint(len(" Pulling...")+1, "")
+		}()
+	}
 
 	for {
 		select {
@@ -206,7 +208,9 @@ func (cmd PullCmd) Exec(ctx context.Context, commandStr string, args []string, d
 			}
 			return HandleVErrAndExitCode(nil, usage)
 		case <-time.After(time.Millisecond * 50):
-			cli.DeleteAndPrint(len(" Pulling...")+1, spinner.next()+" Pulling...")
+			if !apr.Contains(cli.SilentFlag) {
+				cli.DeleteAndPrint(len(" Pulling...")+1, spinner.next()+" Pulling...")
+			}
 		}
 	}
 }

--- a/go/cmd/dolt/commands/push.go
+++ b/go/cmd/dolt/commands/push.go
@@ -120,10 +120,12 @@ func (cmd PushCmd) Exec(ctx context.Context, commandStr string, args []string, d
 	}()
 
 	spinner := TextSpinner{}
-	cli.Print(spinner.next() + " Uploading...")
-	defer func() {
-		cli.DeleteAndPrint(len(" Uploading...")+1, "")
-	}()
+	if !apr.Contains(cli.SilentFlag) {
+		cli.Print(spinner.next() + " Uploading...")
+		defer func() {
+			cli.DeleteAndPrint(len(" Uploading...")+1, "")
+		}()
+	}
 
 	for {
 		select {
@@ -142,7 +144,9 @@ func (cmd PushCmd) Exec(ctx context.Context, commandStr string, args []string, d
 			}
 			return HandleVErrAndExitCode(nil, usage)
 		case <-time.After(time.Millisecond * 50):
-			cli.DeleteAndPrint(len(" Uploading...")+1, spinner.next()+" Uploading...")
+			if !apr.Contains(cli.SilentFlag) {
+				cli.DeleteAndPrint(len(" Uploading...")+1, spinner.next()+" Uploading...")
+			}
 		}
 	}
 }

--- a/integration-tests/bats/fetch.bats
+++ b/integration-tests/bats/fetch.bats
@@ -359,3 +359,10 @@ teardown() {
     # fetch should print some kind of status message
     [[ "$output" =~ "Fetching..." ]] || false
 }
+
+@test "fetch: --silent suppresses progress message" {
+    cd repo2
+    run dolt fetch --silent
+    [ "$status" -eq 0 ]
+    ! [[ "$output" =~ "Fetching..." ]] || false
+}

--- a/integration-tests/bats/pull.bats
+++ b/integration-tests/bats/pull.bats
@@ -453,3 +453,10 @@ SQL
     [ "$status" -eq 0 ]
     [[ "$output" =~ "merge from origin" ]] || false
 }
+
+@test "pull: --silent suppresses progress message" {
+    cd repo2
+    run dolt pull origin --silent
+    [ "$status" -eq 0 ]
+    ! [[ "$output" =~ "Pulling..." ]] || false
+}

--- a/integration-tests/bats/push.bats
+++ b/integration-tests/bats/push.bats
@@ -220,3 +220,10 @@ teardown() {
     [ "$status" -eq 1 ]
     [[ "$output" =~ "invalid ref spec: ''" ]] || false
 }
+
+@test "push: --silent suppresses progress message" {
+    cd repo1
+    run dolt push origin main --silent
+    [ "$status" -eq 0 ]
+    ! [[ "$output" =~ "Uploading..." ]] || false
+}


### PR DESCRIPTION
Adds a `--silent` option for `push`, `pull`, `fetch` to suppress output of progress information.

Resolves: https://github.com/dolthub/dolt/issues/6828