### PR TITLE
Allow `dolt version` in folders without full permissions

### DIFF
--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -496,11 +496,14 @@ func runMain() int {
 		}
 	}()
 
-	err = reconfigIfTempFileMoveFails(dEnv)
+	// version does not need write permissions
+	if subcommandName != "version" {
+		err = reconfigIfTempFileMoveFails(dEnv)
 
-	if err != nil {
-		cli.PrintErrln(color.RedString("Failed to setup the temporary directory. %v`", err))
-		return 1
+		if err != nil {
+			cli.PrintErrln(color.RedString("Failed to setup the temporary directory. %v`", err))
+			return 1
+		}
 	}
 
 	defer tempfiles.MovableTempFileProvider.Clean()

--- a/integration-tests/bats/no-repo.bats
+++ b/integration-tests/bats/no-repo.bats
@@ -132,7 +132,6 @@ teardown() {
 @test "no-repo: dolt version does not need write permissions" {
     chmod 111 .
     run dolt version
-    skip "dolt version needs write perms"
     [ "$status" -eq 0 ]
     chmod 755 .
 }


### PR DESCRIPTION
This change allows `dolt version` to run in folders without write permissions.

Resolves: https://github.com/dolthub/dolt/issues/2898