### PR TITLE
Remove skip on now passing test for multi-db joins on tables with the same name

### DIFF
--- a/integration-tests/bats/sql-multi-db.bats
+++ b/integration-tests/bats/sql-multi-db.bats
@@ -92,7 +92,6 @@ seed_repos_with_tables_with_use_statements() {
             CREATE TABLE r2_t1 (pk BIGINT, c1 BIGINT, PRIMARY KEY(pk));
             INSERT INTO r2_t1 (pk, c1) values (2,200),(3,300),(4,400);"
     run dolt --data-dir ./ sql -q "select * from repo1.r2_t1 join repo2.r2_t1 on repo1.r2_t1.pk=repo2.r2_t1.pk"
-    skip "Fails on Not unique table/alias"
     [ "$status" -eq 0 ]
     [[ ! $output =~ "Not unique table/alias" ]] || false
 }


### PR DESCRIPTION
Unskipped a bats test I added for a join across multiple databases on tables of the same name that is now fixed.