### PR TITLE
Remove schema overlap check for tables with same name

### DIFF
--- a/go/libraries/doltcore/diff/table_deltas.go
+++ b/go/libraries/doltcore/diff/table_deltas.go
@@ -270,12 +270,10 @@ func matchTableDeltas(fromDeltas, toDeltas []TableDelta) (deltas []TableDelta) {
 	for _, name := range matchedNames {
 		t := to[name]
 		f := from[name]
-		if schemasOverlap(t.ToSch, f.FromSch) {
-			matched := match(t, f)
-			deltas = append(deltas, matched)
-			delete(from, f.FromName)
-			delete(to, t.ToName)
-		}
+		matched := match(t, f)
+		deltas = append(deltas, matched)
+		delete(from, f.FromName)
+		delete(to, t.ToName)
 	}
 
 	for _, f := range from {

--- a/go/libraries/doltcore/diff/table_deltas.go
+++ b/go/libraries/doltcore/diff/table_deltas.go
@@ -278,6 +278,7 @@ func matchTableDeltas(fromDeltas, toDeltas []TableDelta) (deltas []TableDelta) {
 
 	for _, f := range from {
 		for _, t := range to {
+			// check for overlapping schemas to try and match tables when names don't match
 			if schemasOverlap(f.FromSch, t.ToSch) {
 				matched := match(t, f)
 				deltas = append(deltas, matched)

--- a/integration-tests/bats/import-create-tables.bats
+++ b/integration-tests/bats/import-create-tables.bats
@@ -793,7 +793,6 @@ DELIM
 }
 
 @test "import-create-tables: created table with force option can be added and committed as modified" {
-    skip "overwritten table cannot be added and committed as modified"
     run dolt table import -c --pk=id test `batshelper jails.csv`
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Import completed successfully." ]] || false


### PR DESCRIPTION
This change takes out the schema check for tables with the same name that get modified. Previously, only tables that get dropped and re-added with the same name and same schema would get labelled as modified. Now, tables that get dropped and re-added with the same name regardless of schema will get labelled as modified.

Fixes: https://github.com/dolthub/dolt/issues/5738