### PR TITLE
More flexibility for `filter-branch` command

### DIFF
--- a/go/cmd/dolt/commands/filter-branch.go
+++ b/go/cmd/dolt/commands/filter-branch.go
@@ -21,6 +21,10 @@ import (
 	"runtime"
 	"strings"
 
+	sqle "github.com/dolthub/go-mysql-server"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/analyzer"
+
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
@@ -33,9 +37,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 	"github.com/dolthub/dolt/go/store/hash"
-	sqle "github.com/dolthub/go-mysql-server"
-	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/go-mysql-server/sql/analyzer"
 )
 
 const (
@@ -110,7 +111,7 @@ func (cmd FilterBranchCmd) Exec(ctx context.Context, commandStr string, args []s
 	queryString := apr.GetValueOrDefault(QueryFlag, "")
 	verbose := apr.Contains(cli.VerboseFlag)
 	continueOnErr := apr.Contains(continueFlag)
-	
+
 	// If we didn't get a query string, read one from STDIN
 	if len(queryString) == 0 {
 		queryStringBytes, err := io.ReadAll(cli.InStream)
@@ -129,9 +130,9 @@ func (cmd FilterBranchCmd) Exec(ctx context.Context, commandStr string, args []s
 			if err != nil {
 				return nil, err
 			}
-			
+
 			cli.Printf("processing commit %s\n", cmHash.String())
-			
+
 			root, err = commit.GetRootValue(ctx)
 			if err != nil {
 				return nil, err
@@ -179,7 +180,7 @@ func (cmd FilterBranchCmd) Exec(ctx context.Context, commandStr string, args []s
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
-	
+
 	return 0
 }
 
@@ -216,15 +217,15 @@ func processFilterQuery(ctx context.Context, dEnv *env.DoltEnv, cm *doltdb.Commi
 	if err != nil {
 		return nil, err
 	}
-	
+
 	for scanner.Scan() {
 		q := scanner.Text()
-		
+
 		if verbose {
 			cli.Printf("executing query: %s\n", q)
 		}
-		
-		err = func () error {
+
+		err = func() error {
 			_, itr, err := eng.Query(sqlCtx, q)
 			if err != nil {
 				return err
@@ -240,7 +241,7 @@ func processFilterQuery(ctx context.Context, dEnv *env.DoltEnv, cm *doltdb.Commi
 			}
 			return itr.Close(sqlCtx)
 		}()
-		
+
 		if err != nil {
 			if continueOnErr {
 				if verbose {
@@ -255,7 +256,7 @@ func processFilterQuery(ctx context.Context, dEnv *env.DoltEnv, cm *doltdb.Commi
 			}
 		}
 	}
-	
+
 	sess := dsess.DSessFromSess(sqlCtx.Session)
 	ws, err := sess.WorkingSet(sqlCtx, filterDbName)
 	if err != nil {

--- a/go/libraries/doltcore/rebase/filter_branch_test.go
+++ b/go/libraries/doltcore/rebase/filter_branch_test.go
@@ -95,7 +95,7 @@ func filterBranchTests() []filterBranchTest {
 				{cmd.SqlCmd{}, args{"-q", "INSERT INTO test VALUES (7,7),(8,8),(9,9);"}},
 				{cmd.AddCmd{}, args{"-A"}},
 				{cmd.CommitCmd{}, args{"-m", "added more rows againg"}},
-				{cmd.FilterBranchCmd{}, args{"--all", "DELETE FROM test WHERE pk IN (5,8);"}},
+				{cmd.FilterBranchCmd{}, args{"--all", "-q", "DELETE FROM test WHERE pk IN (5,8);"}},
 			},
 			asserts: []testAssertion{
 				{
@@ -123,7 +123,7 @@ func filterBranchTests() []filterBranchTest {
 				{cmd.SqlCmd{}, args{"-q", "INSERT INTO test VALUES (7,7),(8,8),(9,9);"}},
 				{cmd.AddCmd{}, args{"-A"}},
 				{cmd.CommitCmd{}, args{"-m", "added more rows on main"}},
-				{cmd.FilterBranchCmd{}, args{"--all", "DELETE FROM test WHERE pk > 4;"}},
+				{cmd.FilterBranchCmd{}, args{"--all", "-q", "DELETE FROM test WHERE pk > 4;"}},
 			},
 			asserts: []testAssertion{
 				{
@@ -185,7 +185,7 @@ func filterBranchTests() []filterBranchTest {
 				{
 					setup: []testCommand{
 						// expeced error: "table not found: test"
-						{cmd.FilterBranchCmd{}, args{"DELETE FROM test WHERE pk > 1;"}},
+						{cmd.FilterBranchCmd{}, args{"--continue", "-q", "DELETE FROM test WHERE pk > 1;"}},
 					},
 				},
 				{

--- a/integration-tests/bats/filter-branch.bats
+++ b/integration-tests/bats/filter-branch.bats
@@ -154,7 +154,7 @@ SQL
     dolt add -A && dolt commit -m "dropped test"
 
     # filter-branch warns about missing table but doesn't error
-    run dolt filter-branch --continue -q "DELETE FROM test WHERE pk > 1;"
+    run dolt filter-branch --continue --verbose -q "DELETE FROM test WHERE pk > 1;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "table not found: test" ]] || false
 


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/6895

The command can now process multiple queries by default, and will ignore errors executing them with a `--continue` flag. This is a breaking change:

1. Previously, certain errors were detected and ignored by default. Now this behavior is controlled by the --continue flag.
2. Previously, the query to execute was specified as an argument. Now it's a flag, `--query`, or can be read via STDIN.