### PR TITLE
Adding an env var to disable reflog data tracking

### DIFF
--- a/go/libraries/doltcore/dconfig/envvars.go
+++ b/go/libraries/doltcore/dconfig/envvars.go
@@ -30,6 +30,7 @@ const (
 	EnvDefaultBinFormat              = "DOLT_DEFAULT_BIN_FORMAT"
 	EnvTestForceOpenEditor           = "DOLT_TEST_FORCE_OPEN_EDITOR"
 	EnvDisableChunkJournal           = "DOLT_DISABLE_CHUNK_JOURNAL"
+	EnvDisableReflog                 = "DOLT_DISABLE_REFLOG"
 	EnvOssEndpoint                   = "OSS_ENDPOINT"
 	EnvOssAccessKeyID                = "OSS_ACCESS_KEY_ID"
 	EnvOssAccessKeySecret            = "OSS_ACCESS_KEY_SECRET"

--- a/go/store/nbs/journal_writer.go
+++ b/go/store/nbs/journal_writer.go
@@ -271,8 +271,10 @@ func (wr *journalWriter) bootstrapJournal(ctx context.Context) (last hash.Hash, 
 
 		case rootHashJournalRecKind:
 			last = hash.Hash(r.address)
-			roots = append(roots, r.address.String())
-			times = append(times, r.timestamp)
+			if !reflogDisabled {
+				roots = append(roots, r.address.String())
+				times = append(times, r.timestamp)
+			}
 
 		default:
 			return fmt.Errorf("unknown journal record kind (%d)", r.kind)

--- a/integration-tests/bats/reflog.bats
+++ b/integration-tests/bats/reflog.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+load $BATS_TEST_DIRNAME/helper/common.bash
+
+teardown() {
+    assert_feature_version
+    teardown_common
+}
+
+@test "reflog: disabled with DOLT_DISABLE_REFLOG" {
+    export DOLT_DISABLE_REFLOG=true
+    setup_common
+    dolt sql -q "create table t (i int primary key, j int);"
+    dolt sql -q "insert into t values (1, 1), (2, 2), (3, 3)";
+    dolt commit -Am "initial commit"
+
+    run dolt sql -q "select * from dolt_reflog();"
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 0 ]
+}
+
+@test "reflog: enabled by default" {
+    setup_common
+    dolt sql -q "create table t (i int primary key, j int);"
+    dolt sql -q "insert into t values (1, 1), (2, 2), (3, 3)";
+    dolt commit -Am "initial commit"
+
+    run dolt sql -q "select * from dolt_reflog();"
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 6 ]
+    [[ "$output"  =~ "initial commit" ]] || false
+    [[ "$output"  =~ "Initialize data repository" ]] || false
+}


### PR DESCRIPTION
Allows customers to set `DOLT_DISABLE_REFLOG` to disable reflog data from being kept in memory. 