### PR TITLE
Enforce a configurable max size for reflog data

### DIFF
--- a/go/libraries/doltcore/dconfig/envvars.go
+++ b/go/libraries/doltcore/dconfig/envvars.go
@@ -31,6 +31,7 @@ const (
 	EnvTestForceOpenEditor           = "DOLT_TEST_FORCE_OPEN_EDITOR"
 	EnvDisableChunkJournal           = "DOLT_DISABLE_CHUNK_JOURNAL"
 	EnvDisableReflog                 = "DOLT_DISABLE_REFLOG"
+	EnvReflogRecordLimit             = "DOLT_REFLOG_RECORD_LIMIT"
 	EnvOssEndpoint                   = "OSS_ENDPOINT"
 	EnvOssAccessKeyID                = "OSS_ACCESS_KEY_ID"
 	EnvOssAccessKeySecret            = "OSS_ACCESS_KEY_SECRET"

--- a/go/store/nbs/journal.go
+++ b/go/store/nbs/journal.go
@@ -39,7 +39,7 @@ const (
 )
 
 var reflogDisabled = false
-var reflogRecordLimit = 250_000
+var reflogRecordLimit = 100_000
 var loggedReflogMaxSizeWarning = false
 
 func init() {

--- a/go/store/nbs/journal.go
+++ b/go/store/nbs/journal.go
@@ -22,14 +22,16 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"sync"
 	"time"
 
-	"github.com/dolthub/fslock"
+	"github.com/sirupsen/logrus"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/dconfig"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/dolthub/fslock"
 )
 
 const (
@@ -37,10 +39,25 @@ const (
 )
 
 var reflogDisabled = false
+var reflogRecordLimit = 250_000
+var loggedReflogMaxSizeWarning = false
 
 func init() {
 	if os.Getenv(dconfig.EnvDisableReflog) != "" {
 		reflogDisabled = true
+	}
+
+	if limit := os.Getenv(dconfig.EnvReflogRecordLimit); limit != "" {
+		i, err := strconv.Atoi(limit)
+		if err != nil {
+			logrus.Warnf("unable to parse integer value for %s: %s", dconfig.EnvReflogRecordLimit, err.Error())
+		} else {
+			if i <= 0 {
+				reflogDisabled = true
+			} else {
+				reflogRecordLimit = i
+			}
+		}
 	}
 }
 
@@ -368,8 +385,14 @@ func (j *ChunkJournal) Update(ctx context.Context, lastLock addr, next manifestC
 	if !reflogDisabled {
 		j.mu.Lock()
 		defer j.mu.Unlock()
-		j.roots = append(j.roots, next.root.String())
-		j.rootTimestamps = append(j.rootTimestamps, time.Now())
+
+		if len(j.roots) < reflogRecordLimit {
+			j.roots = append(j.roots, next.root.String())
+			j.rootTimestamps = append(j.rootTimestamps, time.Now())
+		} else if !loggedReflogMaxSizeWarning {
+			loggedReflogMaxSizeWarning = true
+			logrus.Warnf("exceeded reflog record limit (%d)", reflogRecordLimit)
+		}
 	}
 
 	return j.contents, nil
@@ -412,6 +435,7 @@ func (j *ChunkJournal) UpdateGCGen(ctx context.Context, lastLock addr, next mani
 	if !reflogDisabled {
 		j.mu.Lock()
 		defer j.mu.Unlock()
+
 		if len(j.roots) == 0 {
 			return manifestContents{}, fmt.Errorf(
 				"ChunkJournal roots not intialized; no roots in memory")

--- a/go/store/nbs/journal_writer.go
+++ b/go/store/nbs/journal_writer.go
@@ -173,6 +173,7 @@ func (wr *journalWriter) bootstrapJournal(ctx context.Context) (last hash.Hash, 
 		wr.maxNovel = journalIndexDefaultMaxNovel
 	}
 	wr.ranges = newRangeIndex()
+	loggedReflogMaxSizeWarning := false
 
 	p := filepath.Join(filepath.Dir(wr.path), journalIndexFileName)
 	var ok bool
@@ -272,8 +273,13 @@ func (wr *journalWriter) bootstrapJournal(ctx context.Context) (last hash.Hash, 
 		case rootHashJournalRecKind:
 			last = hash.Hash(r.address)
 			if !reflogDisabled {
-				roots = append(roots, r.address.String())
-				times = append(times, r.timestamp)
+				if len(roots) < reflogRecordLimit {
+					roots = append(roots, r.address.String())
+					times = append(times, r.timestamp)
+				} else if !loggedReflogMaxSizeWarning {
+					loggedReflogMaxSizeWarning = true
+					logrus.Warnf("journal writer exceeded reflog record limit (%d)", reflogRecordLimit)
+				}
 			}
 
 		default:

--- a/integration-tests/bats/reflog.bats
+++ b/integration-tests/bats/reflog.bats
@@ -30,3 +30,17 @@ teardown() {
     [[ "$output"  =~ "initial commit" ]] || false
     [[ "$output"  =~ "Initialize data repository" ]] || false
 }
+
+@test "reflog: set DOLT_REFLOG_RECORD_LIMIT" {
+    export DOLT_REFLOG_RECORD_LIMIT=2
+    setup_common
+    dolt sql -q "create table t (i int primary key, j int);"
+    dolt sql -q "insert into t values (1, 1), (2, 2), (3, 3)";
+    dolt commit -Am "initial commit"
+    dolt commit --allow-empty -m "test commit"
+
+    run dolt sql -q "select * from dolt_reflog();"
+    [ "$status" -eq 0 ]
+    [[ "$output"  =~ "exceeded reflog record limit" ]] || false
+    [[ "$output"  =~ "Initialize data repository" ]] || false
+}


### PR DESCRIPTION
I'll replace this with a ring buffer very soon, but I wanted to get something in place to prevent the slice from growing too large. 