### PR TITLE
Switch reflog data to be stored in a ring buffer

### DIFF
--- a/go/store/nbs/journal.go
+++ b/go/store/nbs/journal.go
@@ -407,17 +407,7 @@ func (j *ChunkJournal) UpdateGCGen(ctx context.Context, lastLock addr, next mani
 	// entry, and double check that it matches the root stored in the manifest.
 	if !reflogDisabled {
 		j.reflogRingBuffer.TruncateToLastRecord()
-
-		if len(j.roots) == 0 {
-			return manifestContents{}, fmt.Errorf(
-				"ChunkJournal roots not intialized; no roots in memory")
-		}
-		j.roots = j.roots[len(j.roots)-1:]
-		j.rootTimestamps = j.rootTimestamps[len(j.rootTimestamps)-1:]
-		if j.roots[0] != latest.root.String() {
-			return manifestContents{}, fmt.Errorf(
-				"ChunkJournal root doesn't match manifest root")
-		}
+		// TODO: sanity check that j.reflogRingBuffer.Peek matches latest.root ?
 	}
 
 	return latest, nil

--- a/go/store/nbs/journal.go
+++ b/go/store/nbs/journal.go
@@ -39,7 +39,7 @@ const (
 )
 
 var reflogDisabled = false
-var reflogRecordLimit = 250_000
+var reflogRecordLimit = 100_000
 var loggedReflogMaxSizeWarning = false
 
 func init() {

--- a/go/store/nbs/journal_writer_test.go
+++ b/go/store/nbs/journal_writer_test.go
@@ -184,7 +184,7 @@ func newTestJournalWriter(t *testing.T, path string) *journalWriter {
 	j, err := createJournalWriter(ctx, path)
 	require.NoError(t, err)
 	require.NotNil(t, j)
-	_, _, _, err = j.bootstrapJournal(ctx)
+	_, err = j.bootstrapJournal(ctx, nil)
 	require.NoError(t, err)
 	return j
 }
@@ -217,8 +217,10 @@ func TestJournalWriterBootstrap(t *testing.T) {
 
 	j, _, err := openJournalWriter(ctx, path)
 	require.NoError(t, err)
-	_, _, _, err = j.bootstrapJournal(ctx)
+	reflogBuffer := newReflogRingBuffer(10)
+	last, err = j.bootstrapJournal(ctx, reflogBuffer)
 	require.NoError(t, err)
+	assertExpectedIterationOrder(t, reflogBuffer, []string{last.String()})
 
 	validateAllLookups(t, j, data)
 
@@ -353,7 +355,7 @@ func TestJournalIndexBootstrap(t *testing.T) {
 				require.NoError(t, err)
 				require.True(t, ok)
 				// bootstrap journal and validate chunk records
-				last, _, _, err := journal.bootstrapJournal(ctx)
+				last, err := journal.bootstrapJournal(ctx, nil)
 				assert.NoError(t, err)
 				for _, e := range expected {
 					var act CompressedChunk
@@ -388,9 +390,8 @@ func TestJournalIndexBootstrap(t *testing.T) {
 			jnl, ok, err := openJournalWriter(ctx, idxPath)
 			require.NoError(t, err)
 			require.True(t, ok)
-			_, _, _, err = jnl.bootstrapJournal(ctx)
+			_, err = jnl.bootstrapJournal(ctx, nil)
 			assert.Error(t, err)
-
 		})
 	}
 }

--- a/go/store/nbs/reflog_ring_buffer.go
+++ b/go/store/nbs/reflog_ring_buffer.go
@@ -1,0 +1,156 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nbs
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// reflogRootHashEntry is a data container for a root hash update that was recorded to the chunk journal. It contains
+// the root and the time at which it was written.
+type reflogRootHashEntry struct {
+	root      string
+	timestamp time.Time
+}
+
+// reflogRingBuffer is a fixed size circular buffer that allows the most recent N entries to be iterated over (where
+// N is equal to the size requested when this ring buffer is constructed. Its locking strategy assumes that
+// only new entries are written to the head (through Push) and that existing entries will never need to be
+// updated. Internally, it allocates a slice that is twice as large as the requested size, so that less locking
+// is needed when iterating over entries to read them.
+type reflogRingBuffer struct {
+	items         []reflogRootHashEntry
+	mu            *sync.Mutex
+	requestedSize int
+	totalSize     int
+	insertIndex   int
+	itemCount     int
+}
+
+// newReflogRingBuffer creates a new reflogRingBuffer that allows the reflog to query up to |size| records.
+// Internally, the ring buffer allocates extra storage so that |size| records can be read while new root entries
+// are still being recorded.
+func newReflogRingBuffer(size int) *reflogRingBuffer {
+	if size < 0 {
+		panic(fmt.Sprintf("invalid size specified in newReflogRingBuffer construction: %d", size))
+	}
+
+	return &reflogRingBuffer{
+		requestedSize: size,
+		totalSize:     size * 2,
+		items:         make([]reflogRootHashEntry, size*2),
+		mu:            &sync.Mutex{},
+		insertIndex:   0,
+		itemCount:     0,
+	}
+}
+
+// Push pushes |newItem| onto this ring buffer, replacing the oldest entry in this ring buffer once the buffer
+// is fully populated.
+func (rb *reflogRingBuffer) Push(newItem reflogRootHashEntry) {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+
+	rb.items[rb.insertIndex] = newItem
+	rb.insertIndex = (rb.insertIndex + 1) % len(rb.items)
+	if rb.itemCount < rb.requestedSize {
+		rb.itemCount++
+	}
+}
+
+// Iterate traverses the entries in this ring buffer and invokes the specified callback function, |f|, on each
+// entry. Iteration starts with the oldest entries inserted into this ring buffer and ends with the most recent
+// entry. This function will iterate over at most N entries, where N is the requested size the caller specified
+// when constructing this ring buffer.
+func (rb *reflogRingBuffer) Iterate(f func(item reflogRootHashEntry) error) error {
+	startPosition, endPosition := rb.getIterationIndexes()
+	if startPosition == endPosition {
+		return nil
+	}
+
+	for idx := startPosition; ; {
+		// The ring buffer holds twice as many entries as we ever expose through the Iterate function, so that
+		// entries can still be inserted without having to lock the whole ring buffer during iteration. However,
+		// as a sanity check, before we look at an index, we make sure the current insertion index doesn't conflict.
+		// TODO: this works if we happen to catch the currentInsertIndex at exactly the right time, but it could fly
+		//       over with us missing it. It would be a better sanity check to make sure the current insertion index
+		//       isn't within a range – perhaps 20% of the requested size?
+		rb.mu.Lock()
+		currentInsertIndex := rb.insertIndex
+		rb.mu.Unlock()
+
+		if idx == currentInsertIndex {
+			return fmt.Errorf("unable to finish iteration: insertion index has wrapped around into read range")
+		}
+
+		err := f(rb.items[idx])
+		if err != nil {
+			return err
+		}
+
+		// Move to next spot
+		idx = (idx + 1) % rb.totalSize
+		if idx == endPosition {
+			break
+		}
+	}
+
+	return nil
+}
+
+// TruncateToLastRecord resets this ring buffer so that it only exposes the single, most recently written record.
+// If this ring buffer has not already had any records pushed in it, then this is a no-op and the ring buffer
+// remains with a zero item count.
+func (rb *reflogRingBuffer) TruncateToLastRecord() {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+
+	if rb.itemCount == 0 {
+		return
+	}
+
+	rb.itemCount = 1
+}
+
+// getIterationIndexes returns the start (inclusive) and end (exclusive) positions for iterating over the
+// entries in this ring buffer. Note that the end position may be less than the start position, which
+// indicates that iteration should wrap around the ring buffer.
+func (rb *reflogRingBuffer) getIterationIndexes() (int, int) {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+
+	// If the buffer is empty, return the start position equal to the end position so that iteration is a no-op
+	if rb.itemCount == 0 || rb.totalSize == 0 {
+		return rb.insertIndex, rb.insertIndex
+	}
+
+	// When the ring buffer isn't fully populated yet, we need to be careful to limit iteration to the number
+	// of items that have actually been inserted. Once more entries have been inserted than the requested size
+	// of this ring buffer, we will iterate over only the most recent entries and limit to the requested size.
+	itemCount := rb.itemCount
+	if itemCount > rb.requestedSize {
+		itemCount = rb.requestedSize
+	}
+
+	endPosition := rb.insertIndex
+	startPosition := (endPosition - itemCount) % rb.totalSize
+	if startPosition < 0 {
+		startPosition = rb.totalSize + startPosition
+	}
+
+	return startPosition, endPosition
+}

--- a/go/store/nbs/reflog_ring_buffer_test.go
+++ b/go/store/nbs/reflog_ring_buffer_test.go
@@ -16,7 +16,6 @@ package nbs
 
 import (
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -116,9 +115,9 @@ func TestTruncateToLastRecord(t *testing.T) {
 	assertExpectedIterationOrder(t, buffer, []string{"mmmm"})
 }
 
-// TestSlowIteration asserts that when iterating through a reflog ring buffer too slowly and the insertion index
-// wraps around into the iteration range, that iteration stops early and an error is returned.
-func TestSlowIteration(t *testing.T) {
+// TestIterationConflict asserts that when iterating through a reflog ring buffer and new items are written to the
+// buffer and wrap around into the iteration range, that iteration stops early and an error is returned.
+func TestIterationConflict(t *testing.T) {
 	buffer := newReflogRingBuffer(5)
 	buffer.Push(reflogRootHashEntry{"aaaa", time.Now()})
 	buffer.Push(reflogRootHashEntry{"bbbb", time.Now()})
@@ -126,32 +125,14 @@ func TestSlowIteration(t *testing.T) {
 	buffer.Push(reflogRootHashEntry{"dddd", time.Now()})
 	buffer.Push(reflogRootHashEntry{"eeee", time.Now()})
 
-	// Create a wait group to allow our two go routines to complete before
-	wg := sync.WaitGroup{}
-	wg.Add(2)
-
-	// Create one goroutine that *very* slowly iterates through the buffer
-	var err error
 	iterationCount := 0
-	go func() {
-		err = buffer.Iterate(func(item reflogRootHashEntry) error {
-			time.Sleep(1 * time.Second)
-			iterationCount++
-			return nil
-		})
-		wg.Done()
-	}()
-
-	// Create a second goroutine that quickly inserts more data than the buffer can hold
-	go func() {
-		for i := 0; i < 20; i++ {
+	err := buffer.Iterate(func(item reflogRootHashEntry) error {
+		for i := 0; i < 100; i++ {
 			buffer.Push(reflogRootHashEntry{fmt.Sprintf("i-%d", i), time.Now()})
 		}
-		wg.Done()
-	}()
-
-	// Wait for both goroutines to complete, then assert that the conflict detection logic triggered
-	wg.Wait()
+		iterationCount++
+		return nil
+	})
 	require.Error(t, err)
 	require.Equal(t, errUnsafeIteration, err)
 	require.True(t, iterationCount < 5)
@@ -166,11 +147,12 @@ func insertTestRecord(buffer *reflogRingBuffer, root string) {
 
 func assertExpectedIterationOrder(t *testing.T, buffer *reflogRingBuffer, expectedRoots []string) {
 	i := 0
-	buffer.Iterate(func(item reflogRootHashEntry) error {
+	err := buffer.Iterate(func(item reflogRootHashEntry) error {
 		assert.Equal(t, expectedRoots[i], item.root)
 		assert.False(t, time.Time.IsZero(item.timestamp))
 		i++
 		return nil
 	})
+	assert.NoError(t, err)
 	assert.Equal(t, len(expectedRoots), i)
 }

--- a/go/store/nbs/reflog_ring_buffer_test.go
+++ b/go/store/nbs/reflog_ring_buffer_test.go
@@ -1,0 +1,131 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nbs
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+// TestIteration asserts that we can iterate over the contents of a reflog ring buffer as the ring buffer grows.
+func TestIteration(t *testing.T) {
+	buffer := newReflogRingBuffer(5)
+
+	// Assert that Iterate returns the correct items in the correct order when the buffer
+	// contains fewer items than the requested buffer size.
+	insertTestRecord(buffer, "aaaa")
+	insertTestRecord(buffer, "bbbb")
+	insertTestRecord(buffer, "cccc")
+	assertExpectedIterationOrder(t, buffer, []string{"aaaa", "bbbb", "cccc"})
+
+	// Assert that Iterate returns the correct items in the correct order when the buffer
+	// contains the same number of items as the requested buffer size.
+	insertTestRecord(buffer, "dddd")
+	insertTestRecord(buffer, "eeee")
+	assertExpectedIterationOrder(t, buffer, []string{"aaaa", "bbbb", "cccc", "dddd", "eeee"})
+
+	// Insert two new records that cause the buffer to exclude the first two records
+	insertTestRecord(buffer, "ffff")
+	insertTestRecord(buffer, "gggg")
+	assertExpectedIterationOrder(t, buffer, []string{"cccc", "dddd", "eeee", "ffff", "gggg"})
+
+	// Insert three records to fill up the buffer's internal capacity
+	insertTestRecord(buffer, "hhhh")
+	insertTestRecord(buffer, "iiii")
+	insertTestRecord(buffer, "jjjj")
+	assertExpectedIterationOrder(t, buffer, []string{"ffff", "gggg", "hhhh", "iiii", "jjjj"})
+
+	// Insert four records to test the buffer wrapping around for the first time
+	insertTestRecord(buffer, "kkkk")
+	insertTestRecord(buffer, "llll")
+	insertTestRecord(buffer, "mmmm")
+	insertTestRecord(buffer, "nnnn")
+	assertExpectedIterationOrder(t, buffer, []string{"jjjj", "kkkk", "llll", "mmmm", "nnnn"})
+
+	// Insert 10 records to test the buffer wrapping around a second time
+	insertTestRecord(buffer, "oooo")
+	insertTestRecord(buffer, "pppp")
+	insertTestRecord(buffer, "qqqq")
+	insertTestRecord(buffer, "rrrr")
+	insertTestRecord(buffer, "ssss")
+	insertTestRecord(buffer, "tttt")
+	insertTestRecord(buffer, "uuuu")
+	insertTestRecord(buffer, "vvvv")
+	insertTestRecord(buffer, "wwww")
+	insertTestRecord(buffer, "xxxx")
+	assertExpectedIterationOrder(t, buffer, []string{"tttt", "uuuu", "vvvv", "wwww", "xxxx"})
+}
+
+// TestTruncateToLastRecord asserts that the TruncateToLastRecord works correctly regardless of how much data
+// is currently stored in the buffer.
+func TestTruncateToLastRecord(t *testing.T) {
+	buffer := newReflogRingBuffer(5)
+
+	// When the buffer is empty, TruncateToLastRecord is a no-op
+	buffer.TruncateToLastRecord()
+	assertExpectedIterationOrder(t, buffer, []string{})
+	buffer.TruncateToLastRecord()
+	assertExpectedIterationOrder(t, buffer, []string{})
+
+	// When the buffer contains only a single item, TruncateToLastRecord is a no-op
+	insertTestRecord(buffer, "aaaa")
+	buffer.TruncateToLastRecord()
+	assertExpectedIterationOrder(t, buffer, []string{"aaaa"})
+	buffer.TruncateToLastRecord()
+	assertExpectedIterationOrder(t, buffer, []string{"aaaa"})
+
+	// When the buffer is not full, TruncateToLastRecord reduces the buffer to the most recent logical record
+	insertTestRecord(buffer, "bbbb")
+	insertTestRecord(buffer, "cccc")
+	insertTestRecord(buffer, "dddd")
+	buffer.TruncateToLastRecord()
+	assertExpectedIterationOrder(t, buffer, []string{"dddd"})
+
+	// When the buffer is full, TruncateToLastRecord reduces the buffer to the most recent logical record
+	insertTestRecord(buffer, "aaaa")
+	insertTestRecord(buffer, "bbbb")
+	insertTestRecord(buffer, "cccc")
+	insertTestRecord(buffer, "dddd")
+	insertTestRecord(buffer, "eeee")
+	insertTestRecord(buffer, "ffff")
+	insertTestRecord(buffer, "gggg")
+	insertTestRecord(buffer, "hhhh")
+	insertTestRecord(buffer, "iiii")
+	insertTestRecord(buffer, "jjjj")
+	insertTestRecord(buffer, "kkkk")
+	insertTestRecord(buffer, "llll")
+	insertTestRecord(buffer, "mmmm")
+	buffer.TruncateToLastRecord()
+	assertExpectedIterationOrder(t, buffer, []string{"mmmm"})
+}
+
+func insertTestRecord(buffer *reflogRingBuffer, root string) {
+	buffer.Push(reflogRootHashEntry{
+		root:      root,
+		timestamp: time.Now(),
+	})
+}
+
+func assertExpectedIterationOrder(t *testing.T, buffer *reflogRingBuffer, expectedRoots []string) {
+	i := 0
+	buffer.Iterate(func(item reflogRootHashEntry) error {
+		assert.Equal(t, expectedRoots[i], item.root)
+		assert.False(t, time.Time.IsZero(item.timestamp))
+		i++
+		return nil
+	})
+	assert.Equal(t, len(expectedRoots), i)
+}

--- a/integration-tests/bats/reflog.bats
+++ b/integration-tests/bats/reflog.bats
@@ -6,18 +6,22 @@ teardown() {
     teardown_common
 }
 
+# Asserts that when DOLT_DISABLE_REFLOG is set, the dolt_reflog() table
+# function returns an empty result set with no error.
 @test "reflog: disabled with DOLT_DISABLE_REFLOG" {
     export DOLT_DISABLE_REFLOG=true
     setup_common
     dolt sql -q "create table t (i int primary key, j int);"
     dolt sql -q "insert into t values (1, 1), (2, 2), (3, 3)";
     dolt commit -Am "initial commit"
+    dolt commit --allow-empty -m "test commit 1"
 
     run dolt sql -q "select * from dolt_reflog();"
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" -eq 0 ]
 }
 
+# Sanity check for the most basic case of querying the Dolt reflog
 @test "reflog: enabled by default" {
     setup_common
     dolt sql -q "create table t (i int primary key, j int);"
@@ -31,16 +35,22 @@ teardown() {
     [[ "$output"  =~ "Initialize data repository" ]] || false
 }
 
+# Asserts that when DOLT_REFLOG_RECORD_LIMIT has been set, the reflog only contains the
+# most recent entries and is limited by the env var's value.
 @test "reflog: set DOLT_REFLOG_RECORD_LIMIT" {
     export DOLT_REFLOG_RECORD_LIMIT=2
     setup_common
     dolt sql -q "create table t (i int primary key, j int);"
     dolt sql -q "insert into t values (1, 1), (2, 2), (3, 3)";
     dolt commit -Am "initial commit"
-    dolt commit --allow-empty -m "test commit"
+    dolt commit --allow-empty -m "test commit 1"
+    dolt commit --allow-empty -m "test commit 2"
 
+    # Only the most recent two ref changes should appear in the log
     run dolt sql -q "select * from dolt_reflog();"
     [ "$status" -eq 0 ]
-    [[ "$output"  =~ "exceeded reflog record limit" ]] || false
-    [[ "$output"  =~ "Initialize data repository" ]] || false
+    [[ "$output" =~ "test commit 1" ]] || false
+    [[ "$output" =~ "test commit 2" ]] || false
+    [[ ! "$output" =~ "initial commit" ]] || false
+    [[ ! "$output" =~ "Initialize data repository" ]] || false
 }


### PR DESCRIPTION
Changes the in-memory reflog buffer to be a ring buffer, to limit on how much memory is used. 

Although we do have an `async.RingBuffer` type already, it has slightly different use case. This implementation is more tailored to the reflog buffer's needs, including supporting iteration, and less locking and synchronization. 