### PR TITLE
Migrate AWS SDK for JavaScript v2 APIs to v3

### DIFF
--- a/.github/actions/ses-email-action/index.js
+++ b/.github/actions/ses-email-action/index.js
@@ -1,5 +1,10 @@
 const core = require('@actions/core');
 const aws = require('aws-sdk');
+
+const {
+    SES
+} = require("@aws-sdk/client-ses");
+
 const fs = require('fs');
 
 const region = core.getInput('region');
@@ -27,6 +32,9 @@ const templated = {
 };
 
 // Set the region
+// JS SDK v3 does not support global configuration.
+// Codemod has attempted to pass values to each service client in this file.
+// You may need to update clients outside of this file, if they use global config.
 aws.config.update({ region });
 
 // Create sendEmail params
@@ -45,7 +53,14 @@ console.log(params)
 
 // Create the promise and SES service object
 // const sendPromise = new aws.SES({apiVersion: '2010-12-01'}).sendEmail(params).promise();
-const sendPromise = new aws.SES({apiVersion: '2010-12-01'}).sendTemplatedEmail(params).promise();
+const sendPromise = new SES({
+    // The transformation for apiVersion is not implemented.
+    // Refer to UPGRADING.md on aws-sdk-js-v3 for changes needed.
+    // Please create/upvote feature request on aws-sdk-js-codemod for apiVersion.
+    apiVersion: '2010-12-01',
+
+    region
+}).sendTemplatedEmail(params).promise();
 
 // Handle promise's fulfilled/rejected states
 sendPromise

--- a/.github/actions/ses-email-action/index.js
+++ b/.github/actions/ses-email-action/index.js
@@ -1,9 +1,5 @@
 const core = require('@actions/core');
-const aws = require('aws-sdk');
-
-const {
-    SES
-} = require("@aws-sdk/client-ses");
+const { SES } = require("@aws-sdk/client-ses");
 
 const fs = require('fs');
 
@@ -31,12 +27,6 @@ const templated = {
     body,
 };
 
-// Set the region
-// JS SDK v3 does not support global configuration.
-// Codemod has attempted to pass values to each service client in this file.
-// You may need to update clients outside of this file, if they use global config.
-aws.config.update({ region });
-
 // Create sendEmail params
 const params = {
     Destination: { /* required */
@@ -52,15 +42,7 @@ const params = {
 console.log(params)
 
 // Create the promise and SES service object
-// const sendPromise = new aws.SES({apiVersion: '2010-12-01'}).sendEmail(params).promise();
-const sendPromise = new SES({
-    // The transformation for apiVersion is not implemented.
-    // Refer to UPGRADING.md on aws-sdk-js-v3 for changes needed.
-    // Please create/upvote feature request on aws-sdk-js-codemod for apiVersion.
-    apiVersion: '2010-12-01',
-
-    region
-}).sendTemplatedEmail(params).promise();
+const sendPromise = new SES({region}).sendTemplatedEmail(params);
 
 // Handle promise's fulfilled/rejected states
 sendPromise

--- a/.github/actions/ses-email-action/package-lock.json
+++ b/.github/actions/ses-email-action/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.9.1",
-        "aws-sdk": "^2.1354.0"
+        "@aws-sdk/client-ses": "^3.441.0"
       }
     },
     "node_modules/@actions/core": {
@@ -38,258 +38,1139 @@
         "tunnel": "^0.0.6"
       }
     },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+    "node_modules/@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
       }
     },
-    "node_modules/aws-sdk": {
-      "version": "2.1354.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1354.0.tgz",
-      "integrity": "sha512-3aDxvyuOqMB9DqJguCq6p8momdsz0JR1axwkWOOCzHA7a35+Bw+WLmqt3pWwRjR1tGIwkkZ2CvGJObYHsOuw3w==",
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
       "dependencies": {
-        "buffer": "4.9.2",
-        "events": "1.1.1",
-        "ieee754": "1.1.13",
-        "jmespath": "0.16.0",
-        "querystring": "0.2.0",
-        "sax": "1.2.1",
-        "url": "0.10.3",
-        "util": "^0.12.4",
-        "uuid": "8.0.0",
-        "xml2js": "0.5.0"
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-ses": {
+      "version": "3.441.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.441.0.tgz",
+      "integrity": "sha512-p0FRCxTaAPvCFil5w1dbfiEFh+WoA4NdBMZ3Qgzn/6N+mlH7JhYDMxqQOFuffeUskmj2unklKBUKt2hZvUEcWA==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.441.0",
+        "@aws-sdk/core": "3.441.0",
+        "@aws-sdk/credential-provider-node": "3.441.0",
+        "@aws-sdk/middleware-host-header": "3.433.0",
+        "@aws-sdk/middleware-logger": "3.433.0",
+        "@aws-sdk/middleware-recursion-detection": "3.433.0",
+        "@aws-sdk/middleware-signing": "3.433.0",
+        "@aws-sdk/middleware-user-agent": "3.438.0",
+        "@aws-sdk/region-config-resolver": "3.433.0",
+        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/util-endpoints": "3.438.0",
+        "@aws-sdk/util-user-agent-browser": "3.433.0",
+        "@aws-sdk/util-user-agent-node": "3.437.0",
+        "@smithy/config-resolver": "^2.0.16",
+        "@smithy/fetch-http-handler": "^2.2.4",
+        "@smithy/hash-node": "^2.0.12",
+        "@smithy/invalid-dependency": "^2.0.12",
+        "@smithy/middleware-content-length": "^2.0.14",
+        "@smithy/middleware-endpoint": "^2.1.3",
+        "@smithy/middleware-retry": "^2.0.18",
+        "@smithy/middleware-serde": "^2.0.12",
+        "@smithy/middleware-stack": "^2.0.6",
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/node-http-handler": "^2.1.8",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/smithy-client": "^2.1.12",
+        "@smithy/types": "^2.4.0",
+        "@smithy/url-parser": "^2.0.12",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.16",
+        "@smithy/util-defaults-mode-node": "^2.0.21",
+        "@smithy/util-endpoints": "^1.0.2",
+        "@smithy/util-retry": "^2.0.5",
+        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/util-waiter": "^2.0.12",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.441.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.441.0.tgz",
+      "integrity": "sha512-gndGymu4cEIN7WWhQ67RO0JMda09EGBlay2L8IKCHBK/65Y34FHUX1tCNbO2qezEzsi6BPW5o2n53Rd9QqpHUw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.441.0",
+        "@aws-sdk/middleware-host-header": "3.433.0",
+        "@aws-sdk/middleware-logger": "3.433.0",
+        "@aws-sdk/middleware-recursion-detection": "3.433.0",
+        "@aws-sdk/middleware-user-agent": "3.438.0",
+        "@aws-sdk/region-config-resolver": "3.433.0",
+        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/util-endpoints": "3.438.0",
+        "@aws-sdk/util-user-agent-browser": "3.433.0",
+        "@aws-sdk/util-user-agent-node": "3.437.0",
+        "@smithy/config-resolver": "^2.0.16",
+        "@smithy/fetch-http-handler": "^2.2.4",
+        "@smithy/hash-node": "^2.0.12",
+        "@smithy/invalid-dependency": "^2.0.12",
+        "@smithy/middleware-content-length": "^2.0.14",
+        "@smithy/middleware-endpoint": "^2.1.3",
+        "@smithy/middleware-retry": "^2.0.18",
+        "@smithy/middleware-serde": "^2.0.12",
+        "@smithy/middleware-stack": "^2.0.6",
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/node-http-handler": "^2.1.8",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/smithy-client": "^2.1.12",
+        "@smithy/types": "^2.4.0",
+        "@smithy/url-parser": "^2.0.12",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.16",
+        "@smithy/util-defaults-mode-node": "^2.0.21",
+        "@smithy/util-endpoints": "^1.0.2",
+        "@smithy/util-retry": "^2.0.5",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.441.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.441.0.tgz",
+      "integrity": "sha512-GL0Cw2v7XL1cn0T+Sk5VHLlgBJoUdMsysXsHa1mFdk0l6XHMAAnwXVXiNnjmoDSPrG0psz7dL2AKzPVRXbIUjA==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.441.0",
+        "@aws-sdk/credential-provider-node": "3.441.0",
+        "@aws-sdk/middleware-host-header": "3.433.0",
+        "@aws-sdk/middleware-logger": "3.433.0",
+        "@aws-sdk/middleware-recursion-detection": "3.433.0",
+        "@aws-sdk/middleware-sdk-sts": "3.433.0",
+        "@aws-sdk/middleware-signing": "3.433.0",
+        "@aws-sdk/middleware-user-agent": "3.438.0",
+        "@aws-sdk/region-config-resolver": "3.433.0",
+        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/util-endpoints": "3.438.0",
+        "@aws-sdk/util-user-agent-browser": "3.433.0",
+        "@aws-sdk/util-user-agent-node": "3.437.0",
+        "@smithy/config-resolver": "^2.0.16",
+        "@smithy/fetch-http-handler": "^2.2.4",
+        "@smithy/hash-node": "^2.0.12",
+        "@smithy/invalid-dependency": "^2.0.12",
+        "@smithy/middleware-content-length": "^2.0.14",
+        "@smithy/middleware-endpoint": "^2.1.3",
+        "@smithy/middleware-retry": "^2.0.18",
+        "@smithy/middleware-serde": "^2.0.12",
+        "@smithy/middleware-stack": "^2.0.6",
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/node-http-handler": "^2.1.8",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/smithy-client": "^2.1.12",
+        "@smithy/types": "^2.4.0",
+        "@smithy/url-parser": "^2.0.12",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.16",
+        "@smithy/util-defaults-mode-node": "^2.0.21",
+        "@smithy/util-endpoints": "^1.0.2",
+        "@smithy/util-retry": "^2.0.5",
+        "@smithy/util-utf8": "^2.0.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.441.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.441.0.tgz",
+      "integrity": "sha512-gV0eQwR0VnSPUYAbgDkbBtfXbSpZgl/K6UB13DP1IFFjQYbF/BxYwvcQe4jHoPOBifSgjEbl8MfOOeIyI7k9vg==",
+      "dependencies": {
+        "@smithy/smithy-client": "^2.1.12"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.433.0.tgz",
+      "integrity": "sha512-Vl7Qz5qYyxBurMn6hfSiNJeUHSqfVUlMt0C1Bds3tCkl3IzecRWwyBOlxtxO3VCrgVeW3HqswLzCvhAFzPH6nQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.441.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.441.0.tgz",
+      "integrity": "sha512-SQipQYxYqDUuSOfIhDmaTdwPTcndGQotGZXWJl56mMWqAhU8MkwjK+oMf3VgRt/umJC0QwUCF5HUHIj7gSB1JA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.433.0",
+        "@aws-sdk/credential-provider-process": "3.433.0",
+        "@aws-sdk/credential-provider-sso": "3.441.0",
+        "@aws-sdk/credential-provider-web-identity": "3.433.0",
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.441.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.441.0.tgz",
+      "integrity": "sha512-WB9p37yHq6fGJt6Vll29ijHbkh9VDbPM/n5ns73bTAgFD7R0ht5kPmdmHGQA6m3RKjcHLPbymQ3lXykkMwWf/Q==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.433.0",
+        "@aws-sdk/credential-provider-ini": "3.441.0",
+        "@aws-sdk/credential-provider-process": "3.433.0",
+        "@aws-sdk/credential-provider-sso": "3.441.0",
+        "@aws-sdk/credential-provider-web-identity": "3.433.0",
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.433.0.tgz",
+      "integrity": "sha512-W7FcGlQjio9Y/PepcZGRyl5Bpwb0uWU7qIUCh+u4+q2mW4D5ZngXg8V/opL9/I/p4tUH9VXZLyLGwyBSkdhL+A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.441.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.441.0.tgz",
+      "integrity": "sha512-pTg16G+62mWCE8yGKuQnEBqPdpG5g71remf2jUqXaI1c7GCzbnkQDV9eD4DaAGOvzIs0wo9zAQnS2kVDPFlCYA==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.441.0",
+        "@aws-sdk/token-providers": "3.438.0",
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.433.0.tgz",
+      "integrity": "sha512-RlwjP1I5wO+aPpwyCp23Mk8nmRbRL33hqRASy73c4JA2z2YiRua+ryt6MalIxehhwQU6xvXUKulJnPG9VaMFZg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.433.0.tgz",
+      "integrity": "sha512-mBTq3UWv1UzeHG+OfUQ2MB/5GEkt5LTKFaUqzL7ESwzW8XtpBgXnjZvIwu3Vcd3sEetMwijwaGiJhY0ae/YyaA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.433.0.tgz",
+      "integrity": "sha512-We346Fb5xGonTGVZC9Nvqtnqy74VJzYuTLLiuuftA5sbNzftBDy/22QCfvYSTOAl3bvif+dkDUzQY2ihc5PwOQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.433.0.tgz",
+      "integrity": "sha512-HEvYC9PQlWY/ccUYtLvAlwwf1iCif2TSAmLNr3YTBRVa98x6jKL0hlCrHWYklFeqOGSKy6XhE+NGJMUII0/HaQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.433.0.tgz",
+      "integrity": "sha512-ORYbJnBejUyonFl5FwIqhvI3Cq6sAp9j+JpkKZtFNma9tFPdrhmYgfCeNH32H/wGTQV/tUoQ3luh0gA4cuk6DA==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.433.0",
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.433.0.tgz",
+      "integrity": "sha512-jxPvt59NZo/epMNLNTu47ikmP8v0q217I6bQFGJG7JVFnfl36zDktMwGw+0xZR80qiK47/2BWrNpta61Zd2FxQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/signature-v4": "^2.0.0",
+        "@smithy/types": "^2.4.0",
+        "@smithy/util-middleware": "^2.0.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.438.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.438.0.tgz",
+      "integrity": "sha512-a+xHT1wOxT6EA6YyLmrfaroKWOkwwyiktUfXKM0FsUutGzNi4fKhb5NZ2al58NsXzHgHFrasSDp+Lqbd/X2cEw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/util-endpoints": "3.438.0",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.433.0.tgz",
+      "integrity": "sha512-xpjRjCZW+CDFdcMmmhIYg81ST5UAnJh61IHziQEk0FXONrg4kjyYPZAOjEdzXQ+HxJQuGQLKPhRdzxmQnbX7pg==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/types": "^2.4.0",
+        "@smithy/util-config-provider": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.438.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.438.0.tgz",
+      "integrity": "sha512-G2fUfTtU6/1ayYRMu0Pd9Ln4qYSvwJOWCqJMdkDgvXSwdgcOSOLsnAIk1AHGJDAvgLikdCzuyOsdJiexr9Vnww==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.433.0",
+        "@aws-sdk/middleware-logger": "3.433.0",
+        "@aws-sdk/middleware-recursion-detection": "3.433.0",
+        "@aws-sdk/middleware-user-agent": "3.438.0",
+        "@aws-sdk/region-config-resolver": "3.433.0",
+        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/util-endpoints": "3.438.0",
+        "@aws-sdk/util-user-agent-browser": "3.433.0",
+        "@aws-sdk/util-user-agent-node": "3.437.0",
+        "@smithy/config-resolver": "^2.0.16",
+        "@smithy/fetch-http-handler": "^2.2.4",
+        "@smithy/hash-node": "^2.0.12",
+        "@smithy/invalid-dependency": "^2.0.12",
+        "@smithy/middleware-content-length": "^2.0.14",
+        "@smithy/middleware-endpoint": "^2.1.3",
+        "@smithy/middleware-retry": "^2.0.18",
+        "@smithy/middleware-serde": "^2.0.12",
+        "@smithy/middleware-stack": "^2.0.6",
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/node-http-handler": "^2.1.8",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/smithy-client": "^2.1.12",
+        "@smithy/types": "^2.4.0",
+        "@smithy/url-parser": "^2.0.12",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.16",
+        "@smithy/util-defaults-mode-node": "^2.0.21",
+        "@smithy/util-endpoints": "^1.0.2",
+        "@smithy/util-retry": "^2.0.5",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.438.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.438.0.tgz",
+      "integrity": "sha512-6VyPTq1kN3GWxwFt5DdZfOsr6cJZPLjWh0troY/0uUv3hK74C9o3Y0Xf/z8UAUvQFkVqZse12O0/BgPVMImvfA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/util-endpoints": "^1.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
+      "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.433.0.tgz",
+      "integrity": "sha512-2Cf/Lwvxbt5RXvWFXrFr49vXv0IddiUwrZoAiwhDYxvsh+BMnh+NUFot+ZQaTrk/8IPZVDeLPWZRdVy00iaVXQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/types": "^2.4.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.437.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.437.0.tgz",
+      "integrity": "sha512-JVEcvWaniamtYVPem4UthtCNoTBCfFTwYj7Y3CrWZ2Qic4TqrwLkAfaBGtI2TGrhIClVr77uzLI6exqMTN7orA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@smithy/abort-controller": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.12.tgz",
+      "integrity": "sha512-YIJyefe1mi3GxKdZxEBEuzYOeQ9xpYfqnFmWzojCssRAuR7ycxwpoRQgp965vuW426xUAQhCV5rCaWElQ7XsaA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.16.tgz",
+      "integrity": "sha512-1k+FWHQDt2pfpXhJsOmNMmlAZ3NUQ98X5tYsjQhVGq+0X6cOBMhfh6Igd0IX3Ut6lEO6DQAdPMI/blNr3JZfMQ==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/types": "^2.4.0",
+        "@smithy/util-config-provider": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.18.tgz",
+      "integrity": "sha512-QnPBi6D2zj6AHJdUTo5zXmk8vwHJ2bNevhcVned1y+TZz/OI5cizz5DsYNkqFUIDn8tBuEyKNgbmKVNhBbuY3g==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/property-provider": "^2.0.13",
+        "@smithy/types": "^2.4.0",
+        "@smithy/url-parser": "^2.0.12",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.12.tgz",
+      "integrity": "sha512-ZZQLzHBJkbiAAdj2C5K+lBlYp/XJ+eH2uy+jgJgYIFW/o5AM59Hlj7zyI44/ZTDIQWmBxb3EFv/c5t44V8/g8A==",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.4.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.4.tgz",
+      "integrity": "sha512-gIPRFEGi+c6V52eauGKrjDzPWF2Cu7Z1r5F8A3j2wcwz25sPG/t8kjsbEhli/tS/2zJp/ybCZXe4j4ro3yv/HA==",
+      "dependencies": {
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/querystring-builder": "^2.0.12",
+        "@smithy/types": "^2.4.0",
+        "@smithy/util-base64": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.12.tgz",
+      "integrity": "sha512-fDZnTr5j9t5qcbeJ037aMZXxMka13Znqwrgy3PAqYj6Dm3XHXHftTH3q+NWgayUxl1992GFtQt1RuEzRMy3NnQ==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
+        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.12.tgz",
+      "integrity": "sha512-p5Y+iMHV3SoEpy3VSR7mifbreHQwVSvHSAz/m4GdoXfOzKzaYC8hYv10Ks7Deblkf7lhas8U+lAp9ThbBM+ZXA==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
+      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.14.tgz",
+      "integrity": "sha512-poUNgKTw9XwPXfX9nEHpVgrMNVpaSMZbshqvPxFVoalF4wp6kRzYKOfdesSVectlQ51VtigoLfbXcdyPwvxgTg==",
+      "dependencies": {
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.1.3.tgz",
+      "integrity": "sha512-ZrQ0/YX6hNVTxqMEHtEaDbDv6pNeEji/a5Vk3HuFC5R3ZY8lfoATyxmOGxBVYnF3NUvZLNC7umEv1WzWGWvCGQ==",
+      "dependencies": {
+        "@smithy/middleware-serde": "^2.0.12",
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/shared-ini-file-loader": "^2.2.2",
+        "@smithy/types": "^2.4.0",
+        "@smithy/url-parser": "^2.0.12",
+        "@smithy/util-middleware": "^2.0.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.18.tgz",
+      "integrity": "sha512-VyrHQRldGSb3v9oFOB5yPxmLT7U2sQic2ytylOnYlnsmVOLlFIaI6sW22c+w2675yq+XZ6HOuzV7x2OBYCWRNA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/service-error-classification": "^2.0.5",
+        "@smithy/types": "^2.4.0",
+        "@smithy/util-middleware": "^2.0.5",
+        "@smithy/util-retry": "^2.0.5",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.12.tgz",
+      "integrity": "sha512-IBeco157lIScecq2Z+n0gq56i4MTnfKxS7rbfrAORveDJgnbBAaEQgYqMqp/cYqKrpvEXcyTjwKHrBjCCIZh2A==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.6.tgz",
+      "integrity": "sha512-YSvNZeOKWLJ0M/ycxwDIe2Ztkp6Qixmcml1ggsSv2fdHKGkBPhGrX5tMzPGMI1yyx55UEYBi2OB4s+RriXX48A==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.3.tgz",
+      "integrity": "sha512-J6lXvRHGVnSX3n1PYi+e1L5HN73DkkJpUviV3Ebf+8wSaIjAf+eVNbzyvh/S5EQz7nf4KVfwbD5vdoZMAthAEQ==",
+      "dependencies": {
+        "@smithy/property-provider": "^2.0.13",
+        "@smithy/shared-ini-file-loader": "^2.2.2",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.8.tgz",
+      "integrity": "sha512-KZylM7Wff/So5SmCiwg2kQNXJ+RXgz34wkxS7WNwIUXuZrZZpY/jKJCK+ZaGyuESDu3TxcaY+zeYGJmnFKbQsA==",
+      "dependencies": {
+        "@smithy/abort-controller": "^2.0.12",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/querystring-builder": "^2.0.12",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.13.tgz",
+      "integrity": "sha512-VJqUf2CbsQX6uUiC5dUPuoEATuFjkbkW3lJHbRnpk9EDC9X+iKqhfTK+WP+lve5EQ9TcCI1Q6R7hrg41FyC54w==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.8.tgz",
+      "integrity": "sha512-SHJvYeWq8q0FK8xHk+xjV9dzDUDjFMT+G1pZbV+XB6OVoac/FSVshlMNPeUJ8AmSkcDKHRu5vASnRqZHgD3qhw==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.12.tgz",
+      "integrity": "sha512-cDbF07IuCjiN8CdGvPzfJjXIrmDSelScRfyJYrYBNBbKl2+k7QD/KqiHhtRyEKgID5mmEVrV6KE6L/iPJ98sFw==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
+        "@smithy/util-uri-escape": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.12.tgz",
+      "integrity": "sha512-fytyTcXaMzPBuNtPlhj5v6dbl4bJAnwKZFyyItAGt4Tgm9HFPZNo7a9r1SKPr/qdxUEBzvL9Rh+B9SkTX3kFxg==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.5.tgz",
+      "integrity": "sha512-M0SeJnEgD2ywJyV99Fb1yKFzmxDe9JfpJiYTVSRMyRLc467BPU0qsuuDPzMCdB1mU8M8u1rVOdkqdoyFN8UFTw==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.2.tgz",
+      "integrity": "sha512-noyQUPn7b1M8uB0GEXc/Zyxq+5K2b7aaqWnLp+hgJ7+xu/FCvtyWy5eWLDjQEsHnAet2IZhS5QF8872OR69uNg==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.12.tgz",
+      "integrity": "sha512-6Kc2lCZEVmb1nNYngyNbWpq0d82OZwITH11SW/Q0U6PX5fH7B2cIcFe7o6eGEFPkTZTP8itTzmYiGcECL0D0Lw==",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^2.0.12",
+        "@smithy/is-array-buffer": "^2.0.0",
+        "@smithy/types": "^2.4.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.5",
+        "@smithy/util-uri-escape": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.12.tgz",
+      "integrity": "sha512-XXqhridfkKnpj+lt8vM6HRlZbqUAqBjVC74JIi13F/AYQd/zTj9SOyGfxnbp4mjY9q28LityxIuV8CTinr9r5w==",
+      "dependencies": {
+        "@smithy/middleware-stack": "^2.0.6",
+        "@smithy/types": "^2.4.0",
+        "@smithy/util-stream": "^2.0.17",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
+      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.12.tgz",
+      "integrity": "sha512-qgkW2mZqRvlNUcBkxYB/gYacRaAdck77Dk3/g2iw0S9F0EYthIS3loGfly8AwoWpIvHKhkTsCXXQfzksgZ4zIA==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^2.0.12",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.0.tgz",
+      "integrity": "sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
+      "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
+      "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
+      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
+      "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.16.tgz",
+      "integrity": "sha512-Uv5Cu8nVkuvLn0puX+R9zWbSNpLIR3AxUlPoLJ7hC5lvir8B2WVqVEkJLwtixKAncVLasnTVjPDCidtAUTGEQw==",
+      "dependencies": {
+        "@smithy/property-provider": "^2.0.13",
+        "@smithy/smithy-client": "^2.1.12",
+        "@smithy/types": "^2.4.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.21.tgz",
+      "integrity": "sha512-cUEsttVZ79B7Al2rWK2FW03HBpD9LyuqFtm+1qFty5u9sHSdesr215gS2Ln53fTopNiPgeXpdoM3IgjvIO0rJw==",
+      "dependencies": {
+        "@smithy/config-resolver": "^2.0.16",
+        "@smithy/credential-provider-imds": "^2.0.18",
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/property-provider": "^2.0.13",
+        "@smithy/smithy-client": "^2.1.12",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.0.2.tgz",
+      "integrity": "sha512-QEdq+sP68IJHAMVB2ugKVVZEWeKQtZLuf+akHzc8eTVElsZ2ZdVLWC6Cp+uKjJ/t4yOj1qu6ZzyxJQEQ8jdEjg==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
+      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.5.tgz",
+      "integrity": "sha512-1lyT3TcaMJQe+OFfVI+TlomDkPuVzb27NZYdYtmSTltVmLaUjdCyt4KE+OH1CnhZKsz4/cdCL420Lg9UH5Z2Mw==",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.5.tgz",
+      "integrity": "sha512-x3t1+MQAJ6QONk3GTbJNcugCFDVJ+Bkro5YqQQK1EyVesajNDqxFtCx9WdOFNGm/Cbm7tUdwVEmfKQOJoU2Vtw==",
+      "dependencies": {
+        "@smithy/service-error-classification": "^2.0.5",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.17.tgz",
+      "integrity": "sha512-fP/ZQ27rRvHsqItds8yB7jerwMpZFTL3QqbQbidUiG0+mttMoKdP0ZqnvM8UK5q0/dfc3/pN7g4XKPXOU7oRWw==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^2.2.4",
+        "@smithy/node-http-handler": "^2.1.8",
+        "@smithy/types": "^2.4.0",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
+      "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
+      "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.12.tgz",
+      "integrity": "sha512-3sENmyVa1NnOPoiT2NCApPmu7ukP7S/v7kL9IxNmnygkDldn7/yK0TP42oPJLwB2k3mospNsSePIlqdXEUyPHA==",
+      "dependencies": {
+        "@smithy/abort-controller": "^2.0.12",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
       "funding": [
         {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
           "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
+          "url": "https://github.com/sponsors/NaturalIntelligence"
         }
-      ]
-    },
-    "node_modules/buffer": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      ],
       "dependencies": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
-      }
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "strnum": "^1.0.5"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
-    "node_modules/events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-      "engines": {
-        "node": ">=0.4.x"
-      }
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
-    "node_modules/for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-      "dependencies": {
-        "is-callable": "^1.1.3"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "dependencies": {
-        "has-symbols": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "node_modules/is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-typed-array": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
-      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
-    "node_modules/jmespath": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
-      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-    },
-    "node_modules/querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
-    "node_modules/sax": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
+    "node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -297,74 +1178,6 @@
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
-      }
-    },
-    "node_modules/url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-      "dependencies": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    },
-    "node_modules/util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/which-typed-array": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
-      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.10"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/xml2js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "engines": {
-        "node": ">=4.0"
       }
     }
   },
@@ -393,235 +1206,963 @@
         "tunnel": "^0.0.6"
       }
     },
-    "available-typed-arrays": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
-    },
-    "aws-sdk": {
-      "version": "2.1354.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1354.0.tgz",
-      "integrity": "sha512-3aDxvyuOqMB9DqJguCq6p8momdsz0JR1axwkWOOCzHA7a35+Bw+WLmqt3pWwRjR1tGIwkkZ2CvGJObYHsOuw3w==",
+    "@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
       "requires": {
-        "buffer": "4.9.2",
-        "events": "1.1.1",
-        "ieee754": "1.1.13",
-        "jmespath": "0.16.0",
-        "querystring": "0.2.0",
-        "sax": "1.2.1",
-        "url": "0.10.3",
-        "util": "^0.12.4",
-        "uuid": "8.0.0",
-        "xml2js": "0.5.0"
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
-    "buffer": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+    "@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
-    "call-bind": {
+    "@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "requires": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "requires": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/client-ses": {
+      "version": "3.441.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.441.0.tgz",
+      "integrity": "sha512-p0FRCxTaAPvCFil5w1dbfiEFh+WoA4NdBMZ3Qgzn/6N+mlH7JhYDMxqQOFuffeUskmj2unklKBUKt2hZvUEcWA==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.441.0",
+        "@aws-sdk/core": "3.441.0",
+        "@aws-sdk/credential-provider-node": "3.441.0",
+        "@aws-sdk/middleware-host-header": "3.433.0",
+        "@aws-sdk/middleware-logger": "3.433.0",
+        "@aws-sdk/middleware-recursion-detection": "3.433.0",
+        "@aws-sdk/middleware-signing": "3.433.0",
+        "@aws-sdk/middleware-user-agent": "3.438.0",
+        "@aws-sdk/region-config-resolver": "3.433.0",
+        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/util-endpoints": "3.438.0",
+        "@aws-sdk/util-user-agent-browser": "3.433.0",
+        "@aws-sdk/util-user-agent-node": "3.437.0",
+        "@smithy/config-resolver": "^2.0.16",
+        "@smithy/fetch-http-handler": "^2.2.4",
+        "@smithy/hash-node": "^2.0.12",
+        "@smithy/invalid-dependency": "^2.0.12",
+        "@smithy/middleware-content-length": "^2.0.14",
+        "@smithy/middleware-endpoint": "^2.1.3",
+        "@smithy/middleware-retry": "^2.0.18",
+        "@smithy/middleware-serde": "^2.0.12",
+        "@smithy/middleware-stack": "^2.0.6",
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/node-http-handler": "^2.1.8",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/smithy-client": "^2.1.12",
+        "@smithy/types": "^2.4.0",
+        "@smithy/url-parser": "^2.0.12",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.16",
+        "@smithy/util-defaults-mode-node": "^2.0.21",
+        "@smithy/util-endpoints": "^1.0.2",
+        "@smithy/util-retry": "^2.0.5",
+        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/util-waiter": "^2.0.12",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.441.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.441.0.tgz",
+      "integrity": "sha512-gndGymu4cEIN7WWhQ67RO0JMda09EGBlay2L8IKCHBK/65Y34FHUX1tCNbO2qezEzsi6BPW5o2n53Rd9QqpHUw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.441.0",
+        "@aws-sdk/middleware-host-header": "3.433.0",
+        "@aws-sdk/middleware-logger": "3.433.0",
+        "@aws-sdk/middleware-recursion-detection": "3.433.0",
+        "@aws-sdk/middleware-user-agent": "3.438.0",
+        "@aws-sdk/region-config-resolver": "3.433.0",
+        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/util-endpoints": "3.438.0",
+        "@aws-sdk/util-user-agent-browser": "3.433.0",
+        "@aws-sdk/util-user-agent-node": "3.437.0",
+        "@smithy/config-resolver": "^2.0.16",
+        "@smithy/fetch-http-handler": "^2.2.4",
+        "@smithy/hash-node": "^2.0.12",
+        "@smithy/invalid-dependency": "^2.0.12",
+        "@smithy/middleware-content-length": "^2.0.14",
+        "@smithy/middleware-endpoint": "^2.1.3",
+        "@smithy/middleware-retry": "^2.0.18",
+        "@smithy/middleware-serde": "^2.0.12",
+        "@smithy/middleware-stack": "^2.0.6",
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/node-http-handler": "^2.1.8",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/smithy-client": "^2.1.12",
+        "@smithy/types": "^2.4.0",
+        "@smithy/url-parser": "^2.0.12",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.16",
+        "@smithy/util-defaults-mode-node": "^2.0.21",
+        "@smithy/util-endpoints": "^1.0.2",
+        "@smithy/util-retry": "^2.0.5",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.441.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.441.0.tgz",
+      "integrity": "sha512-GL0Cw2v7XL1cn0T+Sk5VHLlgBJoUdMsysXsHa1mFdk0l6XHMAAnwXVXiNnjmoDSPrG0psz7dL2AKzPVRXbIUjA==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.441.0",
+        "@aws-sdk/credential-provider-node": "3.441.0",
+        "@aws-sdk/middleware-host-header": "3.433.0",
+        "@aws-sdk/middleware-logger": "3.433.0",
+        "@aws-sdk/middleware-recursion-detection": "3.433.0",
+        "@aws-sdk/middleware-sdk-sts": "3.433.0",
+        "@aws-sdk/middleware-signing": "3.433.0",
+        "@aws-sdk/middleware-user-agent": "3.438.0",
+        "@aws-sdk/region-config-resolver": "3.433.0",
+        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/util-endpoints": "3.438.0",
+        "@aws-sdk/util-user-agent-browser": "3.433.0",
+        "@aws-sdk/util-user-agent-node": "3.437.0",
+        "@smithy/config-resolver": "^2.0.16",
+        "@smithy/fetch-http-handler": "^2.2.4",
+        "@smithy/hash-node": "^2.0.12",
+        "@smithy/invalid-dependency": "^2.0.12",
+        "@smithy/middleware-content-length": "^2.0.14",
+        "@smithy/middleware-endpoint": "^2.1.3",
+        "@smithy/middleware-retry": "^2.0.18",
+        "@smithy/middleware-serde": "^2.0.12",
+        "@smithy/middleware-stack": "^2.0.6",
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/node-http-handler": "^2.1.8",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/smithy-client": "^2.1.12",
+        "@smithy/types": "^2.4.0",
+        "@smithy/url-parser": "^2.0.12",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.16",
+        "@smithy/util-defaults-mode-node": "^2.0.21",
+        "@smithy/util-endpoints": "^1.0.2",
+        "@smithy/util-retry": "^2.0.5",
+        "@smithy/util-utf8": "^2.0.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/core": {
+      "version": "3.441.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.441.0.tgz",
+      "integrity": "sha512-gV0eQwR0VnSPUYAbgDkbBtfXbSpZgl/K6UB13DP1IFFjQYbF/BxYwvcQe4jHoPOBifSgjEbl8MfOOeIyI7k9vg==",
+      "requires": {
+        "@smithy/smithy-client": "^2.1.12"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.433.0.tgz",
+      "integrity": "sha512-Vl7Qz5qYyxBurMn6hfSiNJeUHSqfVUlMt0C1Bds3tCkl3IzecRWwyBOlxtxO3VCrgVeW3HqswLzCvhAFzPH6nQ==",
+      "requires": {
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.441.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.441.0.tgz",
+      "integrity": "sha512-SQipQYxYqDUuSOfIhDmaTdwPTcndGQotGZXWJl56mMWqAhU8MkwjK+oMf3VgRt/umJC0QwUCF5HUHIj7gSB1JA==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.433.0",
+        "@aws-sdk/credential-provider-process": "3.433.0",
+        "@aws-sdk/credential-provider-sso": "3.441.0",
+        "@aws-sdk/credential-provider-web-identity": "3.433.0",
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.441.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.441.0.tgz",
+      "integrity": "sha512-WB9p37yHq6fGJt6Vll29ijHbkh9VDbPM/n5ns73bTAgFD7R0ht5kPmdmHGQA6m3RKjcHLPbymQ3lXykkMwWf/Q==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.433.0",
+        "@aws-sdk/credential-provider-ini": "3.441.0",
+        "@aws-sdk/credential-provider-process": "3.433.0",
+        "@aws-sdk/credential-provider-sso": "3.441.0",
+        "@aws-sdk/credential-provider-web-identity": "3.433.0",
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.433.0.tgz",
+      "integrity": "sha512-W7FcGlQjio9Y/PepcZGRyl5Bpwb0uWU7qIUCh+u4+q2mW4D5ZngXg8V/opL9/I/p4tUH9VXZLyLGwyBSkdhL+A==",
+      "requires": {
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.441.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.441.0.tgz",
+      "integrity": "sha512-pTg16G+62mWCE8yGKuQnEBqPdpG5g71remf2jUqXaI1c7GCzbnkQDV9eD4DaAGOvzIs0wo9zAQnS2kVDPFlCYA==",
+      "requires": {
+        "@aws-sdk/client-sso": "3.441.0",
+        "@aws-sdk/token-providers": "3.438.0",
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.433.0.tgz",
+      "integrity": "sha512-RlwjP1I5wO+aPpwyCp23Mk8nmRbRL33hqRASy73c4JA2z2YiRua+ryt6MalIxehhwQU6xvXUKulJnPG9VaMFZg==",
+      "requires": {
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.433.0.tgz",
+      "integrity": "sha512-mBTq3UWv1UzeHG+OfUQ2MB/5GEkt5LTKFaUqzL7ESwzW8XtpBgXnjZvIwu3Vcd3sEetMwijwaGiJhY0ae/YyaA==",
+      "requires": {
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.433.0.tgz",
+      "integrity": "sha512-We346Fb5xGonTGVZC9Nvqtnqy74VJzYuTLLiuuftA5sbNzftBDy/22QCfvYSTOAl3bvif+dkDUzQY2ihc5PwOQ==",
+      "requires": {
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.433.0.tgz",
+      "integrity": "sha512-HEvYC9PQlWY/ccUYtLvAlwwf1iCif2TSAmLNr3YTBRVa98x6jKL0hlCrHWYklFeqOGSKy6XhE+NGJMUII0/HaQ==",
+      "requires": {
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.433.0.tgz",
+      "integrity": "sha512-ORYbJnBejUyonFl5FwIqhvI3Cq6sAp9j+JpkKZtFNma9tFPdrhmYgfCeNH32H/wGTQV/tUoQ3luh0gA4cuk6DA==",
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.433.0",
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.433.0.tgz",
+      "integrity": "sha512-jxPvt59NZo/epMNLNTu47ikmP8v0q217I6bQFGJG7JVFnfl36zDktMwGw+0xZR80qiK47/2BWrNpta61Zd2FxQ==",
+      "requires": {
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/signature-v4": "^2.0.0",
+        "@smithy/types": "^2.4.0",
+        "@smithy/util-middleware": "^2.0.5",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.438.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.438.0.tgz",
+      "integrity": "sha512-a+xHT1wOxT6EA6YyLmrfaroKWOkwwyiktUfXKM0FsUutGzNi4fKhb5NZ2al58NsXzHgHFrasSDp+Lqbd/X2cEw==",
+      "requires": {
+        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/util-endpoints": "3.438.0",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/region-config-resolver": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.433.0.tgz",
+      "integrity": "sha512-xpjRjCZW+CDFdcMmmhIYg81ST5UAnJh61IHziQEk0FXONrg4kjyYPZAOjEdzXQ+HxJQuGQLKPhRdzxmQnbX7pg==",
+      "requires": {
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/types": "^2.4.0",
+        "@smithy/util-config-provider": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.5",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/token-providers": {
+      "version": "3.438.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.438.0.tgz",
+      "integrity": "sha512-G2fUfTtU6/1ayYRMu0Pd9Ln4qYSvwJOWCqJMdkDgvXSwdgcOSOLsnAIk1AHGJDAvgLikdCzuyOsdJiexr9Vnww==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.433.0",
+        "@aws-sdk/middleware-logger": "3.433.0",
+        "@aws-sdk/middleware-recursion-detection": "3.433.0",
+        "@aws-sdk/middleware-user-agent": "3.438.0",
+        "@aws-sdk/region-config-resolver": "3.433.0",
+        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/util-endpoints": "3.438.0",
+        "@aws-sdk/util-user-agent-browser": "3.433.0",
+        "@aws-sdk/util-user-agent-node": "3.437.0",
+        "@smithy/config-resolver": "^2.0.16",
+        "@smithy/fetch-http-handler": "^2.2.4",
+        "@smithy/hash-node": "^2.0.12",
+        "@smithy/invalid-dependency": "^2.0.12",
+        "@smithy/middleware-content-length": "^2.0.14",
+        "@smithy/middleware-endpoint": "^2.1.3",
+        "@smithy/middleware-retry": "^2.0.18",
+        "@smithy/middleware-serde": "^2.0.12",
+        "@smithy/middleware-stack": "^2.0.6",
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/node-http-handler": "^2.1.8",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/smithy-client": "^2.1.12",
+        "@smithy/types": "^2.4.0",
+        "@smithy/url-parser": "^2.0.12",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.16",
+        "@smithy/util-defaults-mode-node": "^2.0.21",
+        "@smithy/util-endpoints": "^1.0.2",
+        "@smithy/util-retry": "^2.0.5",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "requires": {
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-endpoints": {
+      "version": "3.438.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.438.0.tgz",
+      "integrity": "sha512-6VyPTq1kN3GWxwFt5DdZfOsr6cJZPLjWh0troY/0uUv3hK74C9o3Y0Xf/z8UAUvQFkVqZse12O0/BgPVMImvfA==",
+      "requires": {
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/util-endpoints": "^1.0.2",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
+      "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.433.0.tgz",
+      "integrity": "sha512-2Cf/Lwvxbt5RXvWFXrFr49vXv0IddiUwrZoAiwhDYxvsh+BMnh+NUFot+ZQaTrk/8IPZVDeLPWZRdVy00iaVXQ==",
+      "requires": {
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/types": "^2.4.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.437.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.437.0.tgz",
+      "integrity": "sha512-JVEcvWaniamtYVPem4UthtCNoTBCfFTwYj7Y3CrWZ2Qic4TqrwLkAfaBGtI2TGrhIClVr77uzLI6exqMTN7orA==",
+      "requires": {
+        "@aws-sdk/types": "3.433.0",
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@smithy/abort-controller": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.12.tgz",
+      "integrity": "sha512-YIJyefe1mi3GxKdZxEBEuzYOeQ9xpYfqnFmWzojCssRAuR7ycxwpoRQgp965vuW426xUAQhCV5rCaWElQ7XsaA==",
+      "requires": {
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/config-resolver": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.16.tgz",
+      "integrity": "sha512-1k+FWHQDt2pfpXhJsOmNMmlAZ3NUQ98X5tYsjQhVGq+0X6cOBMhfh6Igd0IX3Ut6lEO6DQAdPMI/blNr3JZfMQ==",
+      "requires": {
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/types": "^2.4.0",
+        "@smithy/util-config-provider": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.5",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/credential-provider-imds": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.18.tgz",
+      "integrity": "sha512-QnPBi6D2zj6AHJdUTo5zXmk8vwHJ2bNevhcVned1y+TZz/OI5cizz5DsYNkqFUIDn8tBuEyKNgbmKVNhBbuY3g==",
+      "requires": {
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/property-provider": "^2.0.13",
+        "@smithy/types": "^2.4.0",
+        "@smithy/url-parser": "^2.0.12",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/eventstream-codec": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.12.tgz",
+      "integrity": "sha512-ZZQLzHBJkbiAAdj2C5K+lBlYp/XJ+eH2uy+jgJgYIFW/o5AM59Hlj7zyI44/ZTDIQWmBxb3EFv/c5t44V8/g8A==",
+      "requires": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.4.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/fetch-http-handler": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.4.tgz",
+      "integrity": "sha512-gIPRFEGi+c6V52eauGKrjDzPWF2Cu7Z1r5F8A3j2wcwz25sPG/t8kjsbEhli/tS/2zJp/ybCZXe4j4ro3yv/HA==",
+      "requires": {
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/querystring-builder": "^2.0.12",
+        "@smithy/types": "^2.4.0",
+        "@smithy/util-base64": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/hash-node": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.12.tgz",
+      "integrity": "sha512-fDZnTr5j9t5qcbeJ037aMZXxMka13Znqwrgy3PAqYj6Dm3XHXHftTH3q+NWgayUxl1992GFtQt1RuEzRMy3NnQ==",
+      "requires": {
+        "@smithy/types": "^2.4.0",
+        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/invalid-dependency": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.12.tgz",
+      "integrity": "sha512-p5Y+iMHV3SoEpy3VSR7mifbreHQwVSvHSAz/m4GdoXfOzKzaYC8hYv10Ks7Deblkf7lhas8U+lAp9ThbBM+ZXA==",
+      "requires": {
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/is-array-buffer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
+      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/middleware-content-length": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.14.tgz",
+      "integrity": "sha512-poUNgKTw9XwPXfX9nEHpVgrMNVpaSMZbshqvPxFVoalF4wp6kRzYKOfdesSVectlQ51VtigoLfbXcdyPwvxgTg==",
+      "requires": {
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/middleware-endpoint": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.1.3.tgz",
+      "integrity": "sha512-ZrQ0/YX6hNVTxqMEHtEaDbDv6pNeEji/a5Vk3HuFC5R3ZY8lfoATyxmOGxBVYnF3NUvZLNC7umEv1WzWGWvCGQ==",
+      "requires": {
+        "@smithy/middleware-serde": "^2.0.12",
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/shared-ini-file-loader": "^2.2.2",
+        "@smithy/types": "^2.4.0",
+        "@smithy/url-parser": "^2.0.12",
+        "@smithy/util-middleware": "^2.0.5",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/middleware-retry": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.18.tgz",
+      "integrity": "sha512-VyrHQRldGSb3v9oFOB5yPxmLT7U2sQic2ytylOnYlnsmVOLlFIaI6sW22c+w2675yq+XZ6HOuzV7x2OBYCWRNA==",
+      "requires": {
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/service-error-classification": "^2.0.5",
+        "@smithy/types": "^2.4.0",
+        "@smithy/util-middleware": "^2.0.5",
+        "@smithy/util-retry": "^2.0.5",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
+    },
+    "@smithy/middleware-serde": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.12.tgz",
+      "integrity": "sha512-IBeco157lIScecq2Z+n0gq56i4MTnfKxS7rbfrAORveDJgnbBAaEQgYqMqp/cYqKrpvEXcyTjwKHrBjCCIZh2A==",
+      "requires": {
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/middleware-stack": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.6.tgz",
+      "integrity": "sha512-YSvNZeOKWLJ0M/ycxwDIe2Ztkp6Qixmcml1ggsSv2fdHKGkBPhGrX5tMzPGMI1yyx55UEYBi2OB4s+RriXX48A==",
+      "requires": {
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/node-config-provider": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.3.tgz",
+      "integrity": "sha512-J6lXvRHGVnSX3n1PYi+e1L5HN73DkkJpUviV3Ebf+8wSaIjAf+eVNbzyvh/S5EQz7nf4KVfwbD5vdoZMAthAEQ==",
+      "requires": {
+        "@smithy/property-provider": "^2.0.13",
+        "@smithy/shared-ini-file-loader": "^2.2.2",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/node-http-handler": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.8.tgz",
+      "integrity": "sha512-KZylM7Wff/So5SmCiwg2kQNXJ+RXgz34wkxS7WNwIUXuZrZZpY/jKJCK+ZaGyuESDu3TxcaY+zeYGJmnFKbQsA==",
+      "requires": {
+        "@smithy/abort-controller": "^2.0.12",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/querystring-builder": "^2.0.12",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/property-provider": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.13.tgz",
+      "integrity": "sha512-VJqUf2CbsQX6uUiC5dUPuoEATuFjkbkW3lJHbRnpk9EDC9X+iKqhfTK+WP+lve5EQ9TcCI1Q6R7hrg41FyC54w==",
+      "requires": {
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/protocol-http": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.8.tgz",
+      "integrity": "sha512-SHJvYeWq8q0FK8xHk+xjV9dzDUDjFMT+G1pZbV+XB6OVoac/FSVshlMNPeUJ8AmSkcDKHRu5vASnRqZHgD3qhw==",
+      "requires": {
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/querystring-builder": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.12.tgz",
+      "integrity": "sha512-cDbF07IuCjiN8CdGvPzfJjXIrmDSelScRfyJYrYBNBbKl2+k7QD/KqiHhtRyEKgID5mmEVrV6KE6L/iPJ98sFw==",
+      "requires": {
+        "@smithy/types": "^2.4.0",
+        "@smithy/util-uri-escape": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/querystring-parser": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.12.tgz",
+      "integrity": "sha512-fytyTcXaMzPBuNtPlhj5v6dbl4bJAnwKZFyyItAGt4Tgm9HFPZNo7a9r1SKPr/qdxUEBzvL9Rh+B9SkTX3kFxg==",
+      "requires": {
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/service-error-classification": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.5.tgz",
+      "integrity": "sha512-M0SeJnEgD2ywJyV99Fb1yKFzmxDe9JfpJiYTVSRMyRLc467BPU0qsuuDPzMCdB1mU8M8u1rVOdkqdoyFN8UFTw==",
+      "requires": {
+        "@smithy/types": "^2.4.0"
+      }
+    },
+    "@smithy/shared-ini-file-loader": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.2.tgz",
+      "integrity": "sha512-noyQUPn7b1M8uB0GEXc/Zyxq+5K2b7aaqWnLp+hgJ7+xu/FCvtyWy5eWLDjQEsHnAet2IZhS5QF8872OR69uNg==",
+      "requires": {
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/signature-v4": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.12.tgz",
+      "integrity": "sha512-6Kc2lCZEVmb1nNYngyNbWpq0d82OZwITH11SW/Q0U6PX5fH7B2cIcFe7o6eGEFPkTZTP8itTzmYiGcECL0D0Lw==",
+      "requires": {
+        "@smithy/eventstream-codec": "^2.0.12",
+        "@smithy/is-array-buffer": "^2.0.0",
+        "@smithy/types": "^2.4.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.5",
+        "@smithy/util-uri-escape": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/smithy-client": {
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.12.tgz",
+      "integrity": "sha512-XXqhridfkKnpj+lt8vM6HRlZbqUAqBjVC74JIi13F/AYQd/zTj9SOyGfxnbp4mjY9q28LityxIuV8CTinr9r5w==",
+      "requires": {
+        "@smithy/middleware-stack": "^2.0.6",
+        "@smithy/types": "^2.4.0",
+        "@smithy/util-stream": "^2.0.17",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/types": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
+      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/url-parser": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.12.tgz",
+      "integrity": "sha512-qgkW2mZqRvlNUcBkxYB/gYacRaAdck77Dk3/g2iw0S9F0EYthIS3loGfly8AwoWpIvHKhkTsCXXQfzksgZ4zIA==",
+      "requires": {
+        "@smithy/querystring-parser": "^2.0.12",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-base64": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.0.tgz",
+      "integrity": "sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==",
+      "requires": {
+        "@smithy/util-buffer-from": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-body-length-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
+      "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-body-length-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
+      "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-buffer-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
+      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+      "requires": {
+        "@smithy/is-array-buffer": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-config-provider": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
+      "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-defaults-mode-browser": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.16.tgz",
+      "integrity": "sha512-Uv5Cu8nVkuvLn0puX+R9zWbSNpLIR3AxUlPoLJ7hC5lvir8B2WVqVEkJLwtixKAncVLasnTVjPDCidtAUTGEQw==",
+      "requires": {
+        "@smithy/property-provider": "^2.0.13",
+        "@smithy/smithy-client": "^2.1.12",
+        "@smithy/types": "^2.4.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-defaults-mode-node": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.21.tgz",
+      "integrity": "sha512-cUEsttVZ79B7Al2rWK2FW03HBpD9LyuqFtm+1qFty5u9sHSdesr215gS2Ln53fTopNiPgeXpdoM3IgjvIO0rJw==",
+      "requires": {
+        "@smithy/config-resolver": "^2.0.16",
+        "@smithy/credential-provider-imds": "^2.0.18",
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/property-provider": "^2.0.13",
+        "@smithy/smithy-client": "^2.1.12",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-endpoints": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.0.2.tgz",
+      "integrity": "sha512-QEdq+sP68IJHAMVB2ugKVVZEWeKQtZLuf+akHzc8eTVElsZ2ZdVLWC6Cp+uKjJ/t4yOj1qu6ZzyxJQEQ8jdEjg==",
       "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
       }
     },
-    "events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
-    },
-    "for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+    "@smithy/util-hex-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
+      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
       "requires": {
-        "is-callable": "^1.1.3"
+        "tslib": "^2.5.0"
       }
     },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
-    "get-intrinsic": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+    "@smithy/util-middleware": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.5.tgz",
+      "integrity": "sha512-1lyT3TcaMJQe+OFfVI+TlomDkPuVzb27NZYdYtmSTltVmLaUjdCyt4KE+OH1CnhZKsz4/cdCL420Lg9UH5Z2Mw==",
       "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.3"
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
       }
     },
-    "gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+    "@smithy/util-retry": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.5.tgz",
+      "integrity": "sha512-x3t1+MQAJ6QONk3GTbJNcugCFDVJ+Bkro5YqQQK1EyVesajNDqxFtCx9WdOFNGm/Cbm7tUdwVEmfKQOJoU2Vtw==",
       "requires": {
-        "get-intrinsic": "^1.1.3"
+        "@smithy/service-error-classification": "^2.0.5",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
       }
     },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+    "@smithy/util-stream": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.17.tgz",
+      "integrity": "sha512-fP/ZQ27rRvHsqItds8yB7jerwMpZFTL3QqbQbidUiG0+mttMoKdP0ZqnvM8UK5q0/dfc3/pN7g4XKPXOU7oRWw==",
       "requires": {
-        "function-bind": "^1.1.1"
+        "@smithy/fetch-http-handler": "^2.2.4",
+        "@smithy/node-http-handler": "^2.1.8",
+        "@smithy/types": "^2.4.0",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
       }
     },
-    "has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
-    },
-    "has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+    "@smithy/util-uri-escape": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
+      "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
       "requires": {
-        "has-symbols": "^1.0.2"
+        "tslib": "^2.5.0"
       }
     },
-    "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+    "@smithy/util-utf8": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
+      "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
       "requires": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "@smithy/util-buffer-from": "^2.0.0",
+        "tslib": "^2.5.0"
       }
     },
-    "is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
-    },
-    "is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+    "@smithy/util-waiter": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.12.tgz",
+      "integrity": "sha512-3sENmyVa1NnOPoiT2NCApPmu7ukP7S/v7kL9IxNmnygkDldn7/yK0TP42oPJLwB2k3mospNsSePIlqdXEUyPHA==",
       "requires": {
-        "has-tostringtag": "^1.0.0"
+        "@smithy/abort-controller": "^2.0.12",
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
       }
     },
-    "is-typed-array": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
-      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
+    "fast-xml-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
       "requires": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0"
+        "strnum": "^1.0.5"
       }
     },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
-    "jmespath": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
-      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
-    },
-    "punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-    },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
-    },
-    "sax": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
+    "tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "tunnel": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
-    },
-    "url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    },
-    "util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
-      }
-    },
-    "uuid": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
-    },
-    "which-typed-array": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
-      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
-      "requires": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.10"
-      }
-    },
-    "xml2js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      }
-    },
-    "xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     }
   }
 }

--- a/.github/actions/ses-email-action/package.json
+++ b/.github/actions/ses-email-action/package.json
@@ -11,6 +11,6 @@
   },
   "dependencies": {
     "@actions/core": "^1.9.1",
-    "aws-sdk": "^2.1354.0"
+    "@aws-sdk/client-ses": "^3.441.0"
   }
 }


### PR DESCRIPTION
### Issue

From AWS SDK for JavaScript v2 [README](https://github.com/aws/aws-sdk-js):
> We are formalizing our plans to make the Maintenance Announcement (Phase 2) for AWS SDK for JavaScript v2 in 2023.

### Description

This PR migrates AWS SDK for JavaScript v2 APIs to v3 using [aws-sdk-js-codemod](https://www.npmjs.com/package/aws-sdk-js-codemod).

```console
$ npx aws-sdk-js-codemod@0.26.1 -t v2-to-v3 .github/actions/ses-email-action/index.js
```