### PR TITLE
Importing `NULL` doesn't violate foreign key constraints

### DIFF
--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -855,7 +855,7 @@ func emptyStringToNil(val interface{}) interface{} {
 	}
 
 	if s, canConvert := val.(string); canConvert {
-		if s == "" {
+		if s == "" || strings.ToLower(s) == "null" {
 			return nil
 		}
 	}

--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -761,6 +761,13 @@ func NameAndTypeTransform(row sql.Row, rowOperationSchema sql.PrimaryKeySchema, 
 	row = applyMapperToRow(row, rowOperationSchema, rdSchema, nameMapper)
 
 	for i, col := range rowOperationSchema.Schema {
+		if s, ok := row[i].(string); ok {
+			if strings.ToLower(s) == "null" {
+				row[i] = nil
+				continue
+			}
+		}
+
 		// Check if this a string that can be converted to a boolean
 		val, ok := detectAndConvertToBoolean(row[i], col.Type)
 		if ok {
@@ -855,7 +862,7 @@ func emptyStringToNil(val interface{}) interface{} {
 	}
 
 	if s, canConvert := val.(string); canConvert {
-		if s == "" || strings.ToLower(s) == "null" {
+		if s == "" {
 			return nil
 		}
 	}

--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -761,13 +761,6 @@ func NameAndTypeTransform(row sql.Row, rowOperationSchema sql.PrimaryKeySchema, 
 	row = applyMapperToRow(row, rowOperationSchema, rdSchema, nameMapper)
 
 	for i, col := range rowOperationSchema.Schema {
-		if s, ok := row[i].(string); ok {
-			if strings.ToLower(s) == "null" {
-				row[i] = nil
-				continue
-			}
-		}
-
 		// Check if this a string that can be converted to a boolean
 		val, ok := detectAndConvertToBoolean(row[i], col.Type)
 		if ok {

--- a/integration-tests/bats/import-create-tables.bats
+++ b/integration-tests/bats/import-create-tables.bats
@@ -816,7 +816,7 @@ DELIM
 @test "import-create-tables: import null foreign key value does not violate constraint" {
     cat <<DELIM > test.csv
 id, state_id, data
-1, ,poop
+1,,poop
 DELIM
 
     dolt sql <<SQL

--- a/integration-tests/bats/import-create-tables.bats
+++ b/integration-tests/bats/import-create-tables.bats
@@ -813,10 +813,10 @@ DELIM
     [ "${lines[1]}" = "nothing to commit, working tree clean" ]
 }
 
-@test "import-create-tables: import null foreign key value" {
+@test "import-create-tables: import null foreign key value does not violate constraint" {
     cat <<DELIM > test.csv
 id, state_id, data
-1, NULL,poop
+1, ,poop
 DELIM
 
     dolt sql <<SQL


### PR DESCRIPTION
Adds a test verifying that importing a `NULL` value doesn't violate foreign key constraints.

Related: https://github.com/dolthub/dolt/issues/2108