### PR TITLE
Optimize when secondary indexes need to be fully rebuilt after a merge

### DIFF
--- a/go/libraries/doltcore/merge/merge_prolly_indexes.go
+++ b/go/libraries/doltcore/merge/merge_prolly_indexes.go
@@ -30,7 +30,7 @@ import (
 
 // mergeProllySecondaryIndexes merges the secondary indexes of the given |tbl|,
 // |mergeTbl|, and |ancTbl|. It stores the merged indexes into |tableToUpdate|
-// and returns its updated value. If |rebuildIndexes| is true, then all indexes
+// and returns its updated value. If |forceIndexRebuild| is true, then all indexes
 // will be rebuilt from the table's data, instead of relying on incremental
 // changes from the other side of the merge to have been merged in before this
 // function was called. This is safer, but less efficient.

--- a/go/libraries/doltcore/merge/merge_prolly_rows.go
+++ b/go/libraries/doltcore/merge/merge_prolly_rows.go
@@ -1100,6 +1100,7 @@ type secondaryMerger struct {
 	leftMut      []MutableSecondaryIdx
 	valueMerger  *valueMerger
 	mergedSchema schema.Schema
+	tableMerger  *TableMerger
 }
 
 const secondaryMergerPendingSize = 650_000
@@ -1127,10 +1128,11 @@ func newSecondaryMerger(ctx context.Context, tm *TableMerger, valueMerger *value
 		leftMut:      lm,
 		valueMerger:  valueMerger,
 		mergedSchema: mergedSchema,
+		tableMerger:  tm,
 	}, nil
 }
 
-func (m *secondaryMerger) merge(ctx context.Context, diff tree.ThreeWayDiff, sourceSch schema.Schema) error {
+func (m *secondaryMerger) merge(ctx *sql.Context, diff tree.ThreeWayDiff, sourceSch schema.Schema) error {
 	var err error
 	for _, idx := range m.leftMut {
 		switch diff.Op {
@@ -1148,8 +1150,12 @@ func (m *secondaryMerger) merge(ctx context.Context, diff tree.ThreeWayDiff, sou
 					return fmt.Errorf("cannot merge keyless tables with reordered columns")
 				}
 			} else {
-				valueMappedToMergeSchema := remapTuple(diff.Right, sourceSch.GetValueDescriptor(), m.valueMerger.rightMapping)
-				newTupleValue = val.NewTuple(m.valueMerger.syncPool, valueMappedToMergeSchema...)
+				tempTupleValue, err := remapTupleWithColumnDefaults(ctx, diff.Key, diff.Right, sourceSch.GetValueDescriptor(),
+					m.valueMerger.rightMapping, m.tableMerger, m.mergedSchema, m.valueMerger.syncPool, true)
+				if err != nil {
+					return err
+				}
+				newTupleValue = tempTupleValue
 			}
 
 			err = applyEdit(ctx, idx, diff.Key, diff.Base, newTupleValue)


### PR DESCRIPTION
At the end of a merge, Dolt was rebuilding some secondary indexes that did not need to be rebuilt. https://github.com/dolthub/dolt/issues/6951 shows one example where the destination side of a merge has an existing index that does not exist on the source side of the merge. Dolt's merge code correctly updates that secondary index in place as the merge diffs are processed, but we were still doing an unnecessary full rebuild on the secondary index after processing all the diffs for that table. 

Making this optimization uncovered another bug where column default values weren't being applied when merging a new row into a secondary index. This PR also fixes that bug, by ensuring that we remap a tuple and apply the column default value, before updating the secondary index with the new tuple. 