### PR TITLE
make `GeomAddrEnc` known as an address encoding

### DIFF
--- a/go/store/val/tuple_compare.go
+++ b/go/store/val/tuple_compare.go
@@ -135,6 +135,8 @@ func compare(typ Type, left, right []byte) int {
 		return compareByteString(readByteString(left), readByteString(right))
 	case Hash128Enc:
 		return compareHash128(readHash128(left), readHash128(right))
+	case GeomAddrEnc:
+		return compareAddr(readAddr(left), readAddr(right))
 	case BytesAddrEnc:
 		return compareAddr(readAddr(left), readAddr(right))
 	case CommitAddrEnc:

--- a/go/store/val/tuple_descriptor.go
+++ b/go/store/val/tuple_descriptor.go
@@ -76,7 +76,7 @@ func IterAddressFields(td TupleDesc, cb func(int, Type)) {
 	for i, typ := range td.Types {
 		switch typ.Enc {
 		case BytesAddrEnc, StringAddrEnc,
-			JSONAddrEnc, CommitAddrEnc:
+			JSONAddrEnc, CommitAddrEnc, GeomAddrEnc:
 			cb(i, typ)
 		}
 	}

--- a/go/store/val/tuple_descriptor_test.go
+++ b/go/store/val/tuple_descriptor_test.go
@@ -32,10 +32,11 @@ func TestTupleDescriptorAddressTypes(t *testing.T) {
 		{Enc: CommitAddrEnc},
 		{Enc: StringAddrEnc},
 		{Enc: JSONAddrEnc},
+		{Enc: GeomAddrEnc},
 	}
 	td := NewTupleDescriptor(types...)
 
-	assert.Equal(t, 4, td.AddressFieldCount())
+	assert.Equal(t, 5, td.AddressFieldCount())
 	IterAddressFields(td, func(i int, typ Type) {
 		assert.Equal(t, types[i], typ)
 	})

--- a/integration-tests/bats/sql-spatial-types.bats
+++ b/integration-tests/bats/sql-spatial-types.bats
@@ -75,6 +75,7 @@ teardown() {
 }
 
 @test "sql-spatial-types: can create large geometry" {
+    skip "This test is too slow to run on CI"
     run dolt sql < $BATS_TEST_DIRNAME/helper/big_spatial.sql
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Query OK" ]] || false

--- a/integration-tests/bats/sql-spatial-types.bats
+++ b/integration-tests/bats/sql-spatial-types.bats
@@ -75,7 +75,6 @@ teardown() {
 }
 
 @test "sql-spatial-types: can create large geometry" {
-    skip "This test is too slow to run on CI"
     run dolt sql < $BATS_TEST_DIRNAME/helper/big_spatial.sql
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Query OK" ]] || false

--- a/integration-tests/bats/sql-spatial-types.bats
+++ b/integration-tests/bats/sql-spatial-types.bats
@@ -107,6 +107,38 @@ teardown() {
     [[ "$output" =~ "POINT(1 2)" ]] || false
 }
 
+@test "sql-spatial-types: geometry survives dolt push" {
+    # create geometry table
+    run dolt sql -q "create table geom_tbl (g geometry)"
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ] || false
+
+    # inserting point
+    run dolt sql -q "insert into geom_tbl values (point(1,2))"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Query OK" ]] || false
+
+    run dolt add .
+    [ "$status" -eq 0 ]
+    run dolt commit -m "creating geometry table"
+    [ "$status" -eq 0 ]
+
+    run dolt sql -q "select st_aswkt(g) from geom_tbl"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "POINT(1 2)" ]] || false
+
+    mkdir rem1
+    dolt remote add origin file://rem1
+    dolt push origin main
+
+    dolt clone file://rem1 repo2
+    cd repo2
+
+    run dolt sql -q "select st_aswkt(g) from geom_tbl"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "POINT(1 2)" ]] || false
+}
+
 @test "sql-spatial-types: create geometry table and insert existing spatial types" {
 
     # create geometry table

--- a/integration-tests/bats/sql-spatial-types.bats
+++ b/integration-tests/bats/sql-spatial-types.bats
@@ -84,6 +84,29 @@ teardown() {
     [[ "$output" =~ "1" ]] || false
 }
 
+@test "sql-spatial-types: geometry survives dolt gc" {
+    # create geometry table
+    run dolt sql -q "create table geom_tbl (g geometry)"
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ] || false
+
+    # inserting point
+    run dolt sql -q "insert into geom_tbl values (point(1,2))"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Query OK" ]] || false
+
+    run dolt sql -q "select st_aswkt(g) from geom_tbl"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "POINT(1 2)" ]] || false
+
+    run dolt gc
+    [ "$status" -eq 0 ]
+
+    run dolt sql -q "select st_aswkt(g) from geom_tbl"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "POINT(1 2)" ]] || false
+}
+
 @test "sql-spatial-types: create geometry table and insert existing spatial types" {
 
     # create geometry table


### PR DESCRIPTION
The addition of the new `GeomAddrEnc` needs to be explicitly known as an address type, so that `dolt gc` doesn't delete the chunks created.

fixes https://github.com/dolthub/dolt/issues/6969