### PR TITLE
go/store/nbs: file_table_persister: fsync whole table file writes.

### DIFF
--- a/go/store/nbs/file_table_persister.go
+++ b/go/store/nbs/file_table_persister.go
@@ -125,6 +125,11 @@ func (ftp *fsTablePersister) CopyTableFile(ctx context.Context, r io.Reader, fil
 			return "", cleanup, err
 		}
 
+		err = temp.Sync()
+		if err != nil {
+			return "", cleanup, err
+		}
+
 		return temp.Name(), cleanup, nil
 	}()
 	defer f()
@@ -185,6 +190,11 @@ func (ftp *fsTablePersister) persistTable(ctx context.Context, name addr, data [
 			return "", cleanup, ferr
 		}
 
+		ferr = temp.Sync()
+		if ferr != nil {
+			return "", cleanup, ferr
+		}
+
 		return temp.Name(), cleanup, nil
 	}()
 	defer f()
@@ -236,7 +246,6 @@ func (ftp *fsTablePersister) ConjoinAll(ctx context.Context, sources chunkSource
 
 		defer func() {
 			closeErr := temp.Close()
-
 			if ferr == nil {
 				ferr = closeErr
 			}
@@ -268,6 +277,11 @@ func (ftp *fsTablePersister) ConjoinAll(ctx context.Context, sources chunkSource
 
 		_, ferr = temp.Write(plan.mergedIndex)
 
+		if ferr != nil {
+			return "", cleanup, ferr
+		}
+
+		ferr = temp.Sync()
 		if ferr != nil {
 			return "", cleanup, ferr
 		}


### PR DESCRIPTION
Dolt sometimes persists whole table files, instead of appending blocks to the chunk journal. In order to be as crash resistent as the chunk journal, we should fsync the writes before we add the new table file to the database.

Cases which use this code path and could have seen reduced durability across crashes include: dolt_fetch, dolt_pull, dolt_clone, dolt_gc, and dolt_push/dolt_backup to a file remote.