### PR TITLE
[no-release-notes] bump feature version

### DIFF
--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -50,7 +50,7 @@ type FeatureVersion int64
 
 // DoltFeatureVersion is described in feature_version.md.
 // only variable for testing.
-var DoltFeatureVersion FeatureVersion = 6 // last bumped when changing geometry types to be stored as BLOBs
+var DoltFeatureVersion FeatureVersion = 7 // last bumped when fixing bug related to GeomAddrs not getting pushed
 
 // RootValue is the value of the Database and is the committed value in every Dolt commit.
 type RootValue struct {

--- a/go/libraries/doltcore/sqle/sqlselect_test.go
+++ b/go/libraries/doltcore/sqle/sqlselect_test.go
@@ -91,7 +91,7 @@ func BasicSelectTests() []SelectTest {
 	var headCommitHash string
 	switch types.Format_Default {
 	case types.Format_DOLT:
-		headCommitHash = "6665g1bg08efo1sr2ui23iulsc7h22hd"
+		headCommitHash = "ias4mf52sgeig337ce2le7ov9vpltppr"
 	case types.Format_LD_1:
 		headCommitHash = "73hc2robs4v0kt9taoe3m5hd49dmrgun"
 	}

--- a/integration-tests/bats/helper/common.bash
+++ b/integration-tests/bats/helper/common.bash
@@ -81,7 +81,7 @@ assert_feature_version() {
     # Tests that don't end in a valid dolt dir will fail the above
     # command, don't check its output in that case
     if [ "$status" -eq 0 ]; then
-        [[ "$output" =~ "feature version: 6" ]] || exit 1
+        [[ "$output" =~ "feature version: 7" ]] || exit 1
     else
       # Clear status to avoid BATS failing if this is the last run command
       status=0


### PR DESCRIPTION
Due to bug in `GeomAddrEnc`s not getting their chunks properly registered, we were deleting them on push and garbage collection. PR https://github.com/dolthub/dolt/pull/6973 addresses the issue, but it was a storage layer change, so a feature bump is necessary.

Related issue: https://github.com/dolthub/dolt/issues/6969
