### PR TITLE
go: sqle: cluster: commithook: When shutting down the server, the cluster replication commithook could deadlock after the replication thread missed a wakeup signal.

### DIFF
--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -214,7 +214,10 @@ func (nbs *NomsBlockStore) UpdateManifest(ctx context.Context, updates map[hash.
 		return
 	}
 
-	nbs.checkAllManifestUpdatesExist(ctx, updates)
+	err = nbs.checkAllManifestUpdatesExist(ctx, updates)
+	if err != nil {
+		return
+	}
 
 	nbs.mm.LockForUpdate()
 	defer func() {
@@ -301,7 +304,10 @@ func (nbs *NomsBlockStore) UpdateManifestWithAppendix(ctx context.Context, updat
 		return
 	}
 
-	nbs.checkAllManifestUpdatesExist(ctx, updates)
+	err = nbs.checkAllManifestUpdatesExist(ctx, updates)
+	if err != nil {
+		return
+	}
 
 	nbs.mm.LockForUpdate()
 	defer func() {

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster-users-and-grants.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster-users-and-grants.yaml
@@ -264,6 +264,12 @@ tests:
       result:
         columns: ["Level", "Code", "Message"]
         rows: []
+  - on: server2
+    queries:
+    - query: 'show warnings'
+      result:
+        columns: ["Level", "Code", "Message"]
+        rows: []
 - name: users and grants block on write replication
   multi_repos:
   - name: server1


### PR DESCRIPTION
Fix it so that the wakeup thread is guaranteed to see the canceled context or the wakeup signal.