### PR TITLE
Print an error when server arges don't validate

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -217,6 +217,7 @@ func startServer(ctx context.Context, versionStr, commandStr string, args []stri
 
 	apr := cli.ParseArgsOrDie(ap, args, help)
 	if err := validateSqlServerArgs(apr); err != nil {
+		cli.PrintErrln(color.RedString(err.Error()))
 		return 1
 	}
 	serverConfig, err := GetServerConfig(dEnv.FS, apr)


### PR DESCRIPTION
We aren't printing any errors from sql-server when there are unparsable flags.

Previous Behavior:

```
$ dolt sql-server --rasdjdsdlsdk
$ echo $?
1
```
New Behavior:
```
$ dolt sql-server --rasdjdsdlsdk
error: sql-server does not take positional arguments, but found 1: asdjdsdlsdk
$ echo $?
1
```
