### PR TITLE
Allow `dolt config` to run in folders without write permissions

### DIFF
--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -171,6 +171,7 @@ var commandsWithoutGlobalArgSupport = []cli.Command{
 var commandsWithoutCurrentDirWrites = []cli.Command{
 	commands.VersionCmd{VersionStr: Version},
 	commands.ConfigCmd{},
+	commands.ProfileCmd{},
 }
 
 func initCliContext(commandName string) bool {

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -440,10 +440,6 @@ func runMain() int {
 	var fs filesys.Filesys
 	fs = filesys.LocalFS
 	dEnv := env.Load(ctx, env.GetCurrentUserHomeDir, fs, doltdb.LocalDirDoltDB, Version)
-	if dEnv.CfgLoadErr != nil {
-		cli.PrintErrln(color.RedString("Failed to load the global config. %v", dEnv.CfgLoadErr))
-		return 1
-	}
 	dEnv.IgnoreLockFile = ignoreLockFile
 
 	root, err := env.GetCurrentUserHomeDir()
@@ -452,6 +448,10 @@ func runMain() int {
 		return 1
 	}
 
+	if dEnv.CfgLoadErr != nil {
+		cli.PrintErrln(color.RedString("Failed to load the global config. %v", dEnv.CfgLoadErr))
+		return 1
+	}
 	globalConfig, ok := dEnv.Config.GetConfig(env.GlobalConfig)
 	if !ok {
 		cli.PrintErrln(color.RedString("Failed to get global config"))

--- a/integration-tests/bats/config.bats
+++ b/integration-tests/bats/config.bats
@@ -290,7 +290,6 @@ teardown() {
 
 @test "config: config doesn't need write permission in current dir" {
     chmod 111 .
-    run dolt config --list
-    [ "$status" -eq 0 ]
+    dolt config --list
     chmod 755 .
 }

--- a/integration-tests/bats/config.bats
+++ b/integration-tests/bats/config.bats
@@ -287,3 +287,10 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" =~ "* vegan-btw" ]] || false
 }
+
+@test "config: config doesn't need write permission in current dir" {
+    chmod 111 .
+    run dolt config --list
+    [ "$status" -eq 0 ]
+    chmod 755 .
+}

--- a/integration-tests/bats/no-repo.bats
+++ b/integration-tests/bats/no-repo.bats
@@ -130,8 +130,7 @@ teardown() {
 
 @test "no-repo: dolt version does not need write permissions" {
     chmod 111 .
-    run dolt version
-    [ "$status" -eq 0 ]
+    dolt version
     chmod 755 .
 }
 

--- a/integration-tests/bats/profile.bats
+++ b/integration-tests/bats/profile.bats
@@ -391,7 +391,6 @@ teardown() {
 
 @test "profile: profile doesn't need write permission in current dir" {
     chmod 111 .
-    run dolt profile
-    [ "$status" -eq 0 ]
+    dolt profile
     chmod 755 .
 }

--- a/integration-tests/bats/profile.bats
+++ b/integration-tests/bats/profile.bats
@@ -388,3 +388,10 @@ teardown() {
     [[ ! "$output" =~ "defaultTable" ]] || false
     [[ "$output" =~ "altTable" ]] || false
 }
+
+@test "profile: profile doesn't need write permission in current dir" {
+    chmod 111 .
+    run dolt profile
+    [ "$status" -eq 0 ]
+    chmod 755 .
+}


### PR DESCRIPTION
This change allows`dolt config` to run in folders without write permissions.

Fixes: https://github.com/dolthub/dolt/issues/2313