### PR TITLE
Concurrent backups map2

### DIFF
--- a/go/cmd/dolt/commands/backup.go
+++ b/go/cmd/dolt/commands/backup.go
@@ -208,7 +208,7 @@ func printBackups(dEnv *env.DoltEnv, apr *argparser.ArgParseResults) errhand.Ver
 		return errhand.BuildDError("Unable to get backups from the local directory").AddCause(err).Build()
 	}
 
-	for _, r := range backups {
+	for _, r := range backups.Snapshot() {
 		if apr.Contains(cli.VerboseFlag) {
 			paramStr := make([]byte, 0)
 			if len(r.Params) > 0 {
@@ -256,7 +256,7 @@ func syncBackup(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.ArgParseR
 		return errhand.BuildDError("Unable to get backups from the local directory").AddCause(err).Build()
 	}
 
-	b, ok := backups[backupName]
+	b, ok := backups.Get(backupName)
 	if !ok {
 		return errhand.BuildDError("error: unknown backup: '%s' ", backupName).Build()
 	}

--- a/go/libraries/doltcore/env/environment_test.go
+++ b/go/libraries/doltcore/env/environment_test.go
@@ -53,7 +53,7 @@ func createTestEnv(isInitialized bool, hasLocalConfig bool) (*DoltEnv, *filesys.
 		initialDirs = append(initialDirs, doltDataDir)
 
 		mainRef := ref.NewBranchRef(DefaultInitBranch)
-		repoState := &RepoState{Head: ref.MarshalableRef{Ref: mainRef}, Remotes: concurrentmap.New[string, Remote]()}
+		repoState := &RepoState{Head: ref.MarshalableRef{Ref: mainRef}, Remotes: concurrentmap.New[string, Remote](), Backups: concurrentmap.New[string, Remote]()}
 		repoStateData, err := json.Marshal(repoState)
 
 		if err != nil {

--- a/go/libraries/doltcore/env/memory.go
+++ b/go/libraries/doltcore/env/memory.go
@@ -209,7 +209,7 @@ func (m MemoryRepoState) SetCWBHeadRef(_ context.Context, r ref.MarshalableRef) 
 }
 
 func (m MemoryRepoState) GetRemotes() (*concurrentmap.Map[string, Remote], error) {
-	return &concurrentmap.Map[string, Remote]{}, nil
+	return concurrentmap.New[string, Remote](), nil
 }
 
 func (m MemoryRepoState) AddRemote(r Remote) error {
@@ -232,7 +232,7 @@ func (m MemoryRepoState) TempTableFilesDir() (string, error) {
 	return os.TempDir(), nil
 }
 
-func (m MemoryRepoState) GetBackups() (map[string]Remote, error) {
+func (m MemoryRepoState) GetBackups() (*concurrentmap.Map[string, Remote], error) {
 	panic("cannot get backups on in memory database")
 }
 

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -419,7 +419,7 @@ func (db Database) getTableInsensitive(ctx *sql.Context, head *doltdb.Commit, ds
 			sess, db.RevisionQualifiedName(),
 			concurrentmap.New[string, env.Remote](),
 			map[string]env.BranchConfig{},
-			map[string]env.Remote{})
+			concurrentmap.New[string, env.Remote]())
 		ws, err := sess.WorkingSet(ctx, db.RevisionQualifiedName())
 		if err != nil {
 			return nil, false, err

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_backup.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_backup.go
@@ -224,7 +224,7 @@ func syncBackupViaName(ctx *sql.Context, dbData env.DbData, sess *dsess.DoltSess
 		return err
 	}
 
-	b, ok := backups[backupName]
+	b, ok := backups.Get(backupName)
 	if !ok {
 		return fmt.Errorf("error: unknown backup: '%s'; %v", backupName, backups)
 	}

--- a/go/libraries/doltcore/sqle/dsess/database_session_state.go
+++ b/go/libraries/doltcore/sqle/dsess/database_session_state.go
@@ -43,7 +43,7 @@ type InitialDbState struct {
 	DbData   env.DbData
 	Remotes  *concurrentmap.Map[string, env.Remote]
 	Branches map[string]env.BranchConfig
-	Backups  map[string]env.Remote
+	Backups  *concurrentmap.Map[string, env.Remote]
 
 	// If err is set, this InitialDbState is partially invalid, but may be
 	// usable to initialize a database at a revision specifier, for


### PR DESCRIPTION
This PR converts all instances of the RepoState.Backups to a concurrent map (implementation found in utils). Avoids issues when the backups field is accessed concurrently from different routines.