### PR TITLE
use database name that is the same as directory name on disk

### DIFF
--- a/go/libraries/doltcore/dbfactory/dirtodbname.go
+++ b/go/libraries/doltcore/dbfactory/dirtodbname.go
@@ -25,11 +25,14 @@ import (
 // DirToDBName takes the physical directory name, |dirName|, and replaces any unsupported characters to create a
 // valid logical database name. For example, spaces are replaced with underscores.
 func DirToDBName(dirName string) string {
-	// this environment variable is used whether to replace hyphens in the database name with underscores.
-	var translateHyphensToUnderscores = os.Getenv(dconfig.EnvDbNameReplaceHyphens) != ""
+	// this environment variable is used whether to replace hyphen and space characters in the database name with underscores.
+	if os.Getenv(dconfig.EnvDbNameReplace) == "" {
+		return dirName
+	}
+
 	dbName := strings.TrimSpace(dirName)
 	dbName = strings.Map(func(r rune) rune {
-		if unicode.IsSpace(r) || (translateHyphensToUnderscores && r == '-') {
+		if unicode.IsSpace(r) || r == '-' {
 			return '_'
 		}
 		return r

--- a/go/libraries/doltcore/dconfig/envvars.go
+++ b/go/libraries/doltcore/dconfig/envvars.go
@@ -42,5 +42,5 @@ const (
 	EnvDoltAssistAgree               = "DOLT_ASSIST_AGREE"
 	EnvDoltAuthorDate                = "DOLT_AUTHOR_DATE"
 	EnvDoltCommitterDate             = "DOLT_COMMITTER_DATE"
-	EnvDbNameReplaceHyphens          = "DOLT_DBNAME_REPLACE_HYPHENS"
+	EnvDbNameReplace                 = "DOLT_DBNAME_REPLACE"
 )

--- a/go/libraries/doltcore/env/multi_repo_env_test.go
+++ b/go/libraries/doltcore/env/multi_repo_env_test.go
@@ -38,7 +38,7 @@ func TestDirToDBName(t *testing.T) {
 		"  real - name     ": "real_name",
 	}
 
-	err := os.Setenv(dconfig.EnvDbNameReplaceHyphens, "true")
+	err := os.Setenv(dconfig.EnvDbNameReplace, "true")
 	require.NoError(t, err)
 
 	for dirName, expected := range replaceHyphenTests {
@@ -49,10 +49,10 @@ func TestDirToDBName(t *testing.T) {
 	allowHyphenTests := map[string]string{
 		"irs":                "irs",
 		"corona-virus":       "corona-virus",
-		"  fake - name     ": "fake_-_name",
+		"  fake - name     ": "  fake - name     ",
 	}
 
-	err = os.Setenv(dconfig.EnvDbNameReplaceHyphens, "")
+	err = os.Setenv(dconfig.EnvDbNameReplace, "")
 	require.NoError(t, err)
 
 	for dirName, expected := range allowHyphenTests {
@@ -133,7 +133,7 @@ func TestMultiEnvForDirectory(t *testing.T) {
 
 	expected := []envCmp{
 		{
-			name:    "test---name_123",
+			name:    " test---name _ 123",
 			doltDir: dEnv.GetDoltDir(),
 		},
 	}
@@ -164,7 +164,7 @@ func TestMultiEnvForDirectoryWithMultipleRepos(t *testing.T) {
 	assert.Len(t, mrEnv.envs, 3)
 
 	expected := make(map[string]string)
-	expected["test---name_123"] = dEnv.GetDoltDir()
+	expected[" test---name _ 123"] = dEnv.GetDoltDir()
 	expected["abc"] = subEnv1.GetDoltDir()
 	expected["def"] = subEnv2.GetDoltDir()
 

--- a/integration-tests/bats/db-revision-specifiers.bats
+++ b/integration-tests/bats/db-revision-specifiers.bats
@@ -3,7 +3,7 @@ load $BATS_TEST_DIRNAME/helper/common.bash
 
 setup() {
     setup_common
-    export DOLT_DBNAME_REPLACE_HYPHENS="true"
+    export DOLT_DBNAME_REPLACE="true"
     database_name=dolt_repo_$$
 
     dolt sql -q "CREATE TABLE test(pk int PRIMARY KEY, color varchar(200))"

--- a/integration-tests/bats/deleted-branches.bats
+++ b/integration-tests/bats/deleted-branches.bats
@@ -6,7 +6,7 @@ setup() {
     skiponwindows "Missing dependencies"
 
     setup_common
-    export DOLT_DBNAME_REPLACE_HYPHENS="true"
+    export DOLT_DBNAME_REPLACE="true"
 }
 
 teardown() {

--- a/integration-tests/bats/dump.bats
+++ b/integration-tests/bats/dump.bats
@@ -16,6 +16,28 @@ teardown() {
     [[ "$output" =~ "No tables to export." ]] || false
 }
 
+@test "dump: roundtrip on database with leading space character and hyphen" {
+    mkdir ' test-db'
+    cd ' test-db'
+    dolt init
+    create_tables
+    insert_data_into_tables
+
+    run dolt dump
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Successfully exported data." ]] || false
+    [ -f doltdump.sql ]
+
+    mkdir roundtrip
+    cd roundtrip
+    dolt init
+
+    dolt sql < ../doltdump.sql
+    run dolt sql -q "show databases"
+    [ $status -eq 0 ]
+    [[ $output =~ "|  test-db" ]] || false
+}
+
 @test "dump: SQL type - with multiple tables" {
     dolt sql -q "CREATE TABLE new_table(pk int primary key);"
     dolt sql -q "INSERT INTO new_table VALUES (1);"

--- a/integration-tests/bats/sql-checkout.bats
+++ b/integration-tests/bats/sql-checkout.bats
@@ -130,7 +130,7 @@ SQL
 }
 
 @test "sql-checkout: DOLT_CHECKOUT updates the head ref session var" {
-    export DOLT_DBNAME_REPLACE_HYPHENS="true"
+    export DOLT_DBNAME_REPLACE="true"
     run dolt sql  <<SQL
 call dolt_checkout('-b', 'feature-branch');
 select @@dolt_repo_$$_head_ref;
@@ -141,7 +141,7 @@ SQL
 }
 
 @test "sql-checkout: CALL DOLT_CHECKOUT updates the head ref session var" {
-    export DOLT_DBNAME_REPLACE_HYPHENS="true"
+    export DOLT_DBNAME_REPLACE="true"
     run dolt sql  <<SQL
 CALL DOLT_CHECKOUT('-b', 'feature-branch');
 select @@dolt_repo_$$_head_ref;

--- a/integration-tests/bats/sql-client.bats
+++ b/integration-tests/bats/sql-client.bats
@@ -134,7 +134,7 @@ teardown() {
     [[ $output =~ "not found" ]] || false
 }
 
-@test "sql-client: handle dashes for implicit database with hyphen disabled" {
+@test "sql-client: handle dashes for implicit database" {
     make_repo test-dashes
     cd test-dashes
     PORT=$( definePORT )
@@ -146,19 +146,6 @@ teardown() {
     run	dolt sql-client -u root -P $PORT -q "show databases"
     [ $status -eq 0 ]
     [[ $output =~ " test_dashes " ]] || false
-}
-
-@test "sql-client: handle dashes for implicit database with hyphen allowed" {
-    make_repo test-dashes
-    cd test-dashes
-    PORT=$( definePORT )
-    dolt sql-server --user=root --port=$PORT &
-    SERVER_PID=$! # will get killed by teardown_common
-    sleep 5 # not using python wait so this works on windows
-
-    run	dolt sql-client -u root -P $PORT -q "show databases"
-    [ $status -eq 0 ]
-    [[ $output =~ " test-dashes " ]] || false
 }
 
 @test "sql-client: select statement prints accurate query timing" {

--- a/integration-tests/bats/sql-client.bats
+++ b/integration-tests/bats/sql-client.bats
@@ -138,7 +138,7 @@ teardown() {
     make_repo test-dashes
     cd test-dashes
     PORT=$( definePORT )
-    export DOLT_DBNAME_REPLACE_HYPHENS="true"
+    export DOLT_DBNAME_REPLACE="true"
     dolt sql-server --user=root --port=$PORT &
     SERVER_PID=$! # will get killed by teardown_common
     sleep 5 # not using python wait so this works on windows

--- a/integration-tests/bats/sql-commit.bats
+++ b/integration-tests/bats/sql-commit.bats
@@ -212,7 +212,7 @@ SQL
 }
 
 @test "sql-commit: DOLT_COMMIT updates session variables" {
-    export DOLT_DBNAME_REPLACE_HYPHENS="true"
+    export DOLT_DBNAME_REPLACE="true"
     head_variable=@@dolt_repo_$$_head
     head_commit=$(get_head_commit)
     run dolt sql << SQL
@@ -233,7 +233,7 @@ SQL
 }
 
 @test "sql-commit: CALL DOLT_COMMIT updates session variables" {
-    export DOLT_DBNAME_REPLACE_HYPHENS="true"
+    export DOLT_DBNAME_REPLACE="true"
     head_variable=@@dolt_repo_$$_head
     head_commit=$(get_head_commit)
     run dolt sql << SQL
@@ -254,7 +254,7 @@ SQL
 }
 
 @test "sql-commit: DOLT_COMMIT with unstaged tables leaves them in the working set" {
-    export DOLT_DBNAME_REPLACE_HYPHENS="true"
+    export DOLT_DBNAME_REPLACE="true"
     head_variable=@@dolt_repo_$$_head
 
     run dolt sql << SQL
@@ -314,7 +314,7 @@ SQL
 }
 
 @test "sql-commit: CALL DOLT_COMMIT with unstaged tables leaves them in the working set" {
-    export DOLT_DBNAME_REPLACE_HYPHENS="true"
+    export DOLT_DBNAME_REPLACE="true"
     head_variable=@@dolt_repo_$$_head
 
     run dolt sql << SQL

--- a/integration-tests/bats/sql-create-database.bats
+++ b/integration-tests/bats/sql-create-database.bats
@@ -321,3 +321,32 @@ SQL
     [[ "$output" =~ "def,metabase,utf8mb4,utf8mb4_unicode_ci,,NO" ]] || false
     cd ..
 }
+
+@test "sql-create-database: creating database with hyphen and space characters replaced" {
+    mkdir 'test- dashes'
+    cd 'test- dashes'
+    dolt init
+    export DOLT_DBNAME_REPLACE="true"
+
+    # aliasing with 'a' allows check on the exact length of the database name
+    run dolt sql << SQL
+USE test_dashes;
+SELECT DATABASE() AS a;
+SQL
+    [ $status -eq 0 ]
+    [[ $output =~ "| test_dashes |" ]] || false
+}
+
+@test "sql-create-database: creating database with hyphen and space characters allowed" {
+    mkdir ' test- db _  '
+    cd ' test- db _  '
+    dolt init
+
+    # aliasing with 'a' allows check on the exact length of the database name
+    run dolt sql << SQL
+USE \` test- db _  \`;
+SELECT DATABASE() AS a;
+SQL
+    [ $status -eq 0 ]
+    [[ $output =~ "|  test- db _   |" ]] || false
+}

--- a/integration-tests/bats/sql-merge.bats
+++ b/integration-tests/bats/sql-merge.bats
@@ -197,7 +197,7 @@ SQL
 }
 
 @test "sql-merge: DOLT_MERGE correctly returns head and working session variables." {
-    export DOLT_DBNAME_REPLACE_HYPHENS="true"
+    export DOLT_DBNAME_REPLACE="true"
     dolt sql << SQL
 call dolt_commit('-a', '-m', 'Step 1');
 call dolt_checkout('-b', 'feature-branch');
@@ -317,7 +317,7 @@ SQL
 }
 
 @test "sql-merge: DOLT_MERGE -no-ff correctly changes head and working session variables." {
-    export DOLT_DBNAME_REPLACE_HYPHENS="true"
+    export DOLT_DBNAME_REPLACE="true"
     dolt sql << SQL
 call dolt_commit('-a', '-m', 'Step 1');
 call dolt_checkout('-b', 'feature-branch');

--- a/integration-tests/bats/sql-reset.bats
+++ b/integration-tests/bats/sql-reset.bats
@@ -280,7 +280,7 @@ SQL
 }
 
 @test "sql-reset: CALL DOLT_RESET --hard properly maintains session variables." {
-    export DOLT_DBNAME_REPLACE_HYPHENS="true"
+    export DOLT_DBNAME_REPLACE="true"
     head_variable=@@dolt_repo_$$_head
     head_hash=$(get_head_commit)
     run dolt sql << SQL
@@ -318,7 +318,7 @@ SQL
 }
 
 @test "sql-reset: CALL DOLT_RESET soft maintains staged session variable" {
-    export DOLT_DBNAME_REPLACE_HYPHENS="true"
+    export DOLT_DBNAME_REPLACE="true"
     working_hash_var=@@dolt_repo_$$_working
     run dolt sql -q "SELECT $working_hash_var"
     working_hash=$output

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -1789,7 +1789,7 @@ behavior:
 
 @test "sql-server: dropping database with '-' in it but replaced with underscore" {
     skiponwindows "Missing dependencies"
-    export DOLT_DBNAME_REPLACE_HYPHENS="true"
+    export DOLT_DBNAME_REPLACE="true"
     mkdir my-db
     cd my-db
     dolt init

--- a/integration-tests/bats/sql.bats
+++ b/integration-tests/bats/sql.bats
@@ -3,7 +3,7 @@ load $BATS_TEST_DIRNAME/helper/common.bash
 
 setup() {
     setup_common
-    export DOLT_DBNAME_REPLACE_HYPHENS="true"
+    export DOLT_DBNAME_REPLACE="true"
     dolt sql <<SQL
 CREATE TABLE one_pk (
   pk BIGINT NOT NULL,

--- a/integration-tests/bats/undrop.bats
+++ b/integration-tests/bats/undrop.bats
@@ -60,7 +60,7 @@ teardown() {
 }
 
 @test "undrop: undrop root database with hyphen replaced in its name" {
-  export DOLT_DBNAME_REPLACE_HYPHENS="true"
+  export DOLT_DBNAME_REPLACE="true"
   setup_remote_server
   # Create a new Dolt database directory to use as a root database
   # NOTE: We use hyphens here to test how db dirs are renamed.
@@ -111,24 +111,24 @@ call dolt_commit('-Am', 'creating table t1');
 EOF
   run dolt sql -q "show databases;"
   [ $status -eq 0 ]
-  [[ $output =~ "test-_db-1" ]] || false
+  [[ $output =~ " test- db-1 " ]] || false
 
   # Drop the root database
-  dolt sql -q "drop database \`test-_db-1\`;"
+  dolt sql -q "drop database \` test- db-1 \`;"
   run dolt sql -q "show databases;"
   [ $status -eq 0 ]
-  [[ ! $output =~ "test-_db-1" ]] || false
+  [[ ! $output =~ " test- db-1 " ]] || false
 
-  # Undrop the test-_db-1 database
+  # Undrop the ' test- db-1 ' database
   # NOTE: After being undropped, the database is no longer the root database,
   #       but contained in a subdirectory like a non-root database.
-  dolt sql -q "call dolt_undrop('test-_db-1');"
+  dolt sql -q "call dolt_undrop(' test- db-1 ');"
   run dolt sql -q "show databases;"
   [ $status -eq 0 ]
-  [[ $output =~ "test-_db-1" ]] || false
+  [[ $output =~ " test- db-1 " ]] || false
 
   # Sanity check querying some data
-  run dolt sql -r csv -q "select * from \`test-_db-1\`.t1;"
+  run dolt sql -r csv -q "select * from \` test- db-1 \`.t1;"
   [ $status -eq 0 ]
   [[ $output =~ "1,one" ]] || false
 }
@@ -136,7 +136,7 @@ EOF
 # Asserts that a non-root database can be dropped and then restored with dolt_undrop(), even when
 # the case of the database name given to dolt_undrop() doesn't match match the original case.
 @test "undrop: undrop non-root database with hyphen replaced in its name" {
-  export DOLT_DBNAME_REPLACE_HYPHENS="true"
+  export DOLT_DBNAME_REPLACE="true"
   setup_remote_server
   dolt sql << EOF
 use drop_me_2;
@@ -170,28 +170,28 @@ EOF
 @test "undrop: undrop non-root database with hyphen allowed in its name" {
   setup_remote_server
   dolt sql << EOF
-use \`drop-_me-2\`;
+use \` drop- me-2 \`;
 create table t1 (pk int primary key, c1 varchar(200));
 insert into t1 values (1, "one");
 call dolt_commit('-Am', 'creating table t1');
 EOF
   run dolt sql -q "show databases;"
   [ $status -eq 0 ]
-  [[ $output =~ "drop-_me-2" ]] || false
+  [[ $output =~ " drop- me-2 " ]] || false
 
-  dolt sql -q "drop database \`drop-_me-2\`;"
+  dolt sql -q "drop database \` drop- me-2 \`;"
   run dolt sql -q "show databases;"
   [ $status -eq 0 ]
-  [[ ! $output =~ "drop-_me-2" ]] || false
+  [[ ! $output =~ " drop- me-2 " ]] || false
 
   # Call dolt_undrop() with non-matching case for the database name to
   # ensure dolt_undrop() works with case-insensitive database names.
-  dolt sql -q "call dolt_undrop('DrOp-_mE-2');"
+  dolt sql -q "call dolt_undrop(' DrOp- mE-2 ');"
   run dolt sql -q "show databases;"
   [ $status -eq 0 ]
-  [[ $output =~ "drop-_me-2" ]] || false
+  [[ $output =~ " drop- me-2 " ]] || false
 
-  run dolt sql -r csv -q "select * from \`drop-_me-2\`.t1;"
+  run dolt sql -r csv -q "select * from \` drop- me-2 \`.t1;"
   [ $status -eq 0 ]
   [[ $output =~ "1,one" ]] || false
 }


### PR DESCRIPTION
As of Dolt version `1.27.0`, we allow hyphens in database name and replace space characters with underscores and reduce multiple underscore characters side by side into single underscore character.

This PR resolves: 
- Using the database name the same as directory name on disk allows round-trip to the database location on disk.

Note:
- A potential issue might arise when the directory name has trailing space characters. MySQL do not allow database name with trailing space characters such as `mydb `, whereas Dolt allows. This will cause failing import of dolt dump to MySQL. 