### PR TITLE
go/cmd/dolt: Implement new semantics for sql-server.lock.

### DIFF
--- a/go/Godeps/LICENSES
+++ b/go/Godeps/LICENSES
@@ -7143,34 +7143,6 @@ SOFTWARE.
 ================================================================================
 
 ================================================================================
-= github.com/mitchellh/go-ps licensed under: =
-
-The MIT License (MIT)
-
-Copyright (c) 2014 Mitchell Hashimoto
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-= LICENSE.md a7dd3ace9da06eac6975e1c97313e8c168d79722471171c96232fc91 =
-================================================================================
-
-================================================================================
 = github.com/mitchellh/hashstructure licensed under: =
 
 The MIT License (MIT)

--- a/go/cmd/dolt/commands/dump.go
+++ b/go/cmd/dolt/commands/dump.go
@@ -812,7 +812,7 @@ func addCreateDatabaseHeader(dEnv *env.DoltEnv, fPath, dbName string) errhand.Ve
 // TODO: find a more elegant way to get database name, possibly implement a method in DoltEnv
 // getActiveDatabaseName returns the name of the current active database
 func getActiveDatabaseName(ctx context.Context, dEnv *env.DoltEnv) (string, errhand.VerboseError) {
-	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
 	if err != nil {
 		return "", errhand.VerboseErrorFromError(err)
 	}

--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -83,10 +83,6 @@ func NewSqlEngine(
 	mrEnv *env.MultiRepoEnv,
 	config *SqlEngineConfig,
 ) (*SqlEngine, error) {
-	if ok, _ := mrEnv.IsLocked(); ok {
-		config.IsServerLocked = true
-	}
-
 	dbs, locations, err := CollectDBs(ctx, mrEnv, config.Bulk)
 	if err != nil {
 		return nil, err

--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -407,7 +407,7 @@ func doltSessionFactory(pro *dsqle.DoltDatabaseProvider, config config.ReadWrite
 // NewSqlEngineForEnv returns a SqlEngine configured for the environment provided, with a single root user.
 // Returns the new engine, the first database name, and any error that occurred.
 func NewSqlEngineForEnv(ctx context.Context, dEnv *env.DoltEnv) (*SqlEngine, string, error) {
-	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
 	if err != nil {
 		return nil, "", err
 	}

--- a/go/cmd/dolt/commands/filter-branch.go
+++ b/go/cmd/dolt/commands/filter-branch.go
@@ -104,9 +104,7 @@ func (cmd FilterBranchCmd) Exec(ctx context.Context, commandStr string, args []s
 		return HandleVErrAndExitCode(verr, usage)
 	}
 
-	if dEnv.IsLocked() {
-		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(env.ErrActiveServerLock.New(dEnv.LockFile())), help)
-	}
+	// TODO: Assert that dEnv.DoltDB.AccessMode() != ReadOnly
 
 	queryString := apr.GetValueOrDefault(QueryFlag, "")
 	verbose := apr.Contains(cli.VerboseFlag)
@@ -281,7 +279,7 @@ func rebaseSqlEngine(ctx context.Context, dEnv *env.DoltEnv, cm *doltdb.Commit) 
 		return nil, nil, err
 	}
 
-	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/cmd/dolt/commands/filter-branch.go
+++ b/go/cmd/dolt/commands/filter-branch.go
@@ -104,8 +104,6 @@ func (cmd FilterBranchCmd) Exec(ctx context.Context, commandStr string, args []s
 		return HandleVErrAndExitCode(verr, usage)
 	}
 
-	// TODO: Assert that dEnv.DoltDB.AccessMode() != ReadOnly
-
 	queryString := apr.GetValueOrDefault(QueryFlag, "")
 	verbose := apr.Contains(cli.VerboseFlag)
 	continueOnErr := apr.Contains(continueFlag)

--- a/go/cmd/dolt/commands/gc.go
+++ b/go/cmd/dolt/commands/gc.go
@@ -88,9 +88,7 @@ func (cmd GarbageCollectionCmd) Exec(ctx context.Context, commandStr string, arg
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, gcDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
-	if dEnv.IsLocked() {
-		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(env.ErrActiveServerLock.New(dEnv.LockFile())), help)
-	}
+	// TODO: Assert that dEnv.DoltDB.AccessMode() != ReadOnly?
 
 	var err error
 	if apr.Contains(cli.ShallowFlag) {

--- a/go/cmd/dolt/commands/indexcmds/rebuild.go
+++ b/go/cmd/dolt/commands/indexcmds/rebuild.go
@@ -71,8 +71,6 @@ func (cmd RebuildCmd) Exec(ctx context.Context, commandStr string, args []string
 		return HandleErr(errhand.BuildDError("Both the table and index names must be provided.").Build(), usage)
 	}
 
-	// TODO: Error if dEnv.DoltDB.AccessMode() == ReadOnly?
-
 	working, err := dEnv.WorkingRoot(context.Background())
 	if err != nil {
 		return HandleErr(errhand.BuildDError("Unable to get working.").AddCause(err).Build(), nil)

--- a/go/cmd/dolt/commands/indexcmds/rebuild.go
+++ b/go/cmd/dolt/commands/indexcmds/rebuild.go
@@ -20,7 +20,6 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
-	"github.com/dolthub/dolt/go/cmd/dolt/commands"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
@@ -72,9 +71,7 @@ func (cmd RebuildCmd) Exec(ctx context.Context, commandStr string, args []string
 		return HandleErr(errhand.BuildDError("Both the table and index names must be provided.").Build(), usage)
 	}
 
-	if dEnv.IsLocked() {
-		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(env.ErrActiveServerLock.New(dEnv.LockFile())), usage)
-	}
+	// TODO: Error if dEnv.DoltDB.AccessMode() == ReadOnly?
 
 	working, err := dEnv.WorkingRoot(context.Background())
 	if err != nil {

--- a/go/cmd/dolt/commands/schcmds/import.go
+++ b/go/cmd/dolt/commands/schcmds/import.go
@@ -170,9 +170,7 @@ func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string,
 		return 1
 	}
 
-	if dEnv.IsLocked() {
-		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(env.ErrActiveServerLock.New(dEnv.LockFile())), usage)
-	}
+	// TODO: Error if dEnv.DoltDB.AccessMode() == ReadOnly?
 
 	return commands.HandleVErrAndExitCode(importSchema(ctx, dEnv, apr), usage)
 }

--- a/go/cmd/dolt/commands/schcmds/import.go
+++ b/go/cmd/dolt/commands/schcmds/import.go
@@ -170,8 +170,6 @@ func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string,
 		return 1
 	}
 
-	// TODO: Error if dEnv.DoltDB.AccessMode() == ReadOnly?
-
 	return commands.HandleVErrAndExitCode(importSchema(ctx, dEnv, apr), usage)
 }
 

--- a/go/cmd/dolt/commands/sqlserver/creds.go
+++ b/go/cmd/dolt/commands/sqlserver/creds.go
@@ -29,7 +29,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 )
 
-const ServerLocalCredsFile = "sql-server.lock"
+const ServerLocalCredsFile = "sql-server.info"
 
 // LocalCreds is a struct that contains information about how to access the
 // locally running server for a CLI process which wants to operate against a
@@ -87,7 +87,7 @@ func WriteLocalCreds(fs filesys.Filesys, creds *LocalCreds) error {
 
 // Starting at `fs`, look for the a ServerLocalCredsFile in the .dolt directory
 // of this directory and every parent directory, until we find one. When we
-// find we, we return its contents if we can open and parse it successfully.
+// find one, we return its contents if we can open and parse it successfully.
 // Otherwise, we return an error associated with attempting to read it. If we
 // do not find anything all the way up to the root of the filesystem, returns
 // `nil` *LocalCreds and a `nil` error.
@@ -136,14 +136,6 @@ func LoadLocalCreds(fs filesys.Filesys) (creds *LocalCreds, err error) {
 	data := strings.TrimSpace(string(b[:n]))
 
 	parts := strings.Split(data, ":")
-	if len(parts) == 1 {
-		// Legacy Lock file. We can remove this code path in a couple of months (6/2023)
-		pid, err := strconv.Atoi(parts[0])
-		if err != nil {
-			return nil, err
-		}
-		return &LocalCreds{Pid: pid, Port: -1, Secret: ""}, nil
-	}
 	if len(parts) != 3 {
 		return nil, fmt.Errorf("invalid lock file format")
 	}

--- a/go/cmd/dolt/commands/sqlserver/creds.go
+++ b/go/cmd/dolt/commands/sqlserver/creds.go
@@ -1,0 +1,127 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlserver
+
+import (
+	"os"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
+	"github.com/dolthub/dolt/go/libraries/utils/filesys"
+)
+
+const ServerLocalCredsFile = "sql-server.lock"
+
+// LocalCreds is a struct that contains information about how to access the
+// locally running server for a CLI process which wants to operate against a
+// database while a sql-server process is running. It contains the pid of the
+// process that created the lockfile, the port that the server is running on
+// and the password to be used connecting to the server.
+//
+// Pid is a legacy field which is retained for compatibility but no longer
+// influences the behavior of the running program(s).
+type LocalCreds struct {
+	Pid    int
+	Port   int
+	Secret string
+}
+
+func NewLocalCreds(port int) *LocalCreds {
+	return &LocalCreds{os.Getpid(), port, uuid.New().String()}
+}
+
+// Best effort attempt to remove local creds file persisted as the Filesys
+// rooted there.
+func RemoveLocalCreds(fs filesys.Filesys) {
+	credsFilePath, err := fs.Abs(filepath.Join(dbfactory.DoltDir, ServerLocalCredsFile))
+	if err != nil {
+		return
+	}
+	_ = fs.Delete(credsFilePath, false)
+}
+
+// WriteLocalCreds writes a file containing the contents of LocalCreds to the
+// DoltDir rooted at the provided Filesys.
+func WriteLocalCreds(fs filesys.Filesys, creds *LocalCreds) error {
+	// if the DoltDir doesn't exist, create it.
+	doltDir, err := fs.Abs(dbfactory.DoltDir)
+	if err != nil {
+		return err
+	}
+	err = fs.MkDirs(doltDir)
+	if err != nil {
+		return err
+	}
+
+	credsFile, err := fs.Abs(filepath.Join(dbfactory.DoltDir, ServerLocalCredsFile))
+	if err != nil {
+		return err
+	}
+
+	portStr := strconv.Itoa(creds.Port)
+	if creds.Port < 0 {
+		portStr = "-"
+	}
+
+	return fs.WriteFile(credsFile, []byte(fmt.Sprintf("%d:%s:%s", creds.Pid, portStr, creds.Secret)), 0600)
+}
+
+func LoadLocalCreds(fs filesys.Filesys, credsFilePath string) (creds *LocalCreds, err error) {
+	rd, err := fs.OpenForRead(credsFilePath)
+	if err != nil {
+		return nil, err
+	}
+	defer rd.Close()
+
+	b := make([]byte, 256)
+	n, err := rd.Read(b)
+	if err != nil {
+		return nil, err
+	}
+
+	data := strings.TrimSpace(string(b[:n]))
+
+	parts := strings.Split(data, ":")
+	if len(parts) == 1 {
+		// Legacy Lock file. We can remove this code path in a couple of months (6/2023)
+		pid, err := strconv.Atoi(parts[0])
+		if err != nil {
+			return nil, err
+		}
+		return &LocalCreds{Pid: pid, Port: -1, Secret: ""}, nil
+	}
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid lock file format")
+	}
+
+	pid, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return nil, err
+	}
+	port := -1
+	if parts[1] != "-" {
+		port, err = strconv.Atoi(parts[1])
+		if err != nil {
+			return nil, err
+		}
+	}
+	secret := parts[2]
+	return &LocalCreds{Pid: pid, Port: port, Secret: secret}, nil
+}

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -677,11 +677,6 @@ func newSessionBuilder(se *engine.SqlEngine, config ServerConfig) server.Session
 
 		dsess, err := se.NewDoltSession(ctx, mysqlBaseSess)
 		if err != nil {
-			if goerrors.Is(err, env.ErrFailedToAccessDB) {
-				if server := sqlserver.GetRunningServer(); server != nil {
-					_ = server.Close()
-				}
-			}
 			return nil, err
 		}
 

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -547,7 +547,7 @@ func Serve(
 
 	RunSQLServer := &svcs.AnonService{
 		RunF: func(context.Context) {
-			sqlserver.SetRunningServer(mySQLServer, serverLock)
+			sqlserver.SetRunningServer(mySQLServer)
 			defer sqlserver.UnsetRunningServer()
 			mySQLServer.Start()
 		},
@@ -696,7 +696,7 @@ func newSessionBuilder(se *engine.SqlEngine, config ServerConfig) server.Session
 		dsess, err := se.NewDoltSession(ctx, mysqlBaseSess)
 		if err != nil {
 			if goerrors.Is(err, env.ErrFailedToAccessDB) {
-				if server, _ := sqlserver.GetRunningServer(); server != nil {
+				if server := sqlserver.GetRunningServer(); server != nil {
 					_ = server.Close()
 				}
 			}

--- a/go/cmd/dolt/commands/stashcmds/clear.go
+++ b/go/cmd/dolt/commands/stashcmds/clear.go
@@ -72,8 +72,6 @@ func (cmd StashClearCmd) Exec(ctx context.Context, commandStr string, args []str
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, stashClearDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
-	// TODO: Error if dEnv.DoltDB.AccessMode() == ReadOnly?
-
 	if apr.NArg() != 0 {
 		usage()
 		return 1

--- a/go/cmd/dolt/commands/stashcmds/clear.go
+++ b/go/cmd/dolt/commands/stashcmds/clear.go
@@ -71,9 +71,8 @@ func (cmd StashClearCmd) Exec(ctx context.Context, commandStr string, args []str
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, stashClearDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
-	if dEnv.IsLocked() {
-		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(env.ErrActiveServerLock.New(dEnv.LockFile())), help)
-	}
+
+	// TODO: Error if dEnv.DoltDB.AccessMode() == ReadOnly?
 
 	if apr.NArg() != 0 {
 		usage()

--- a/go/cmd/dolt/commands/stashcmds/drop.go
+++ b/go/cmd/dolt/commands/stashcmds/drop.go
@@ -75,8 +75,6 @@ func (cmd StashDropCmd) Exec(ctx context.Context, commandStr string, args []stri
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, stashDropDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
-	// TODO: Error if dEnv.DoltDB.AccessMode() == ReadOnly?
-
 	var idx = 0
 	var err error
 	if apr.NArg() == 1 {

--- a/go/cmd/dolt/commands/stashcmds/drop.go
+++ b/go/cmd/dolt/commands/stashcmds/drop.go
@@ -74,9 +74,8 @@ func (cmd StashDropCmd) Exec(ctx context.Context, commandStr string, args []stri
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, stashDropDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
-	if dEnv.IsLocked() {
-		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(env.ErrActiveServerLock.New(dEnv.LockFile())), help)
-	}
+	
+	// TODO: Error if dEnv.DoltDB.AccessMode() == ReadOnly?
 
 	var idx = 0
 	var err error

--- a/go/cmd/dolt/commands/stashcmds/drop.go
+++ b/go/cmd/dolt/commands/stashcmds/drop.go
@@ -74,7 +74,7 @@ func (cmd StashDropCmd) Exec(ctx context.Context, commandStr string, args []stri
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, stashDropDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
-	
+
 	// TODO: Error if dEnv.DoltDB.AccessMode() == ReadOnly?
 
 	var idx = 0

--- a/go/cmd/dolt/commands/stashcmds/list.go
+++ b/go/cmd/dolt/commands/stashcmds/list.go
@@ -71,9 +71,8 @@ func (cmd StashListCmd) Exec(ctx context.Context, commandStr string, args []stri
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, stashListDocs, ap))
 	cli.ParseArgsOrDie(ap, args, help)
-	if dEnv.IsLocked() {
-		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(env.ErrActiveServerLock.New(dEnv.LockFile())), help)
-	}
+
+	// TODO: Error if dEnv.DoltDB.AccessMode() == ReadOnly?
 
 	err := listStashes(ctx, dEnv)
 	if err != nil {

--- a/go/cmd/dolt/commands/stashcmds/list.go
+++ b/go/cmd/dolt/commands/stashcmds/list.go
@@ -72,8 +72,6 @@ func (cmd StashListCmd) Exec(ctx context.Context, commandStr string, args []stri
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, stashListDocs, ap))
 	cli.ParseArgsOrDie(ap, args, help)
 
-	// TODO: Error if dEnv.DoltDB.AccessMode() == ReadOnly?
-
 	err := listStashes(ctx, dEnv)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)

--- a/go/cmd/dolt/commands/stashcmds/pop.go
+++ b/go/cmd/dolt/commands/stashcmds/pop.go
@@ -81,8 +81,6 @@ func (cmd StashPopCmd) Exec(ctx context.Context, commandStr string, args []strin
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, stashPopDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
-	// TODO: Error if dEnv.DoltDB.AccessMode() == ReadOnly?
-
 	_, sqlCtx, closer, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		cli.PrintErrln(err.Error())

--- a/go/cmd/dolt/commands/stashcmds/pop.go
+++ b/go/cmd/dolt/commands/stashcmds/pop.go
@@ -80,9 +80,8 @@ func (cmd StashPopCmd) Exec(ctx context.Context, commandStr string, args []strin
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, stashPopDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
-	if dEnv.IsLocked() {
-		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(env.ErrActiveServerLock.New(dEnv.LockFile())), help)
-	}
+
+	// TODO: Error if dEnv.DoltDB.AccessMode() == ReadOnly?
 
 	_, sqlCtx, closer, err := cliCtx.QueryEngine(ctx)
 	if err != nil {

--- a/go/cmd/dolt/commands/stashcmds/stash.go
+++ b/go/cmd/dolt/commands/stashcmds/stash.go
@@ -99,8 +99,6 @@ func (cmd StashCmd) Exec(ctx context.Context, commandStr string, args []string, 
 		return 1
 	}
 
-	// TODO: Error if dEnv.DoltDB.AccessMode() == ReadOnly?
-
 	err := stashChanges(ctx, dEnv, apr)
 	if err != nil {
 		return commands.HandleStageError(err)

--- a/go/cmd/dolt/commands/stashcmds/stash.go
+++ b/go/cmd/dolt/commands/stashcmds/stash.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands"
-	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	eventsapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
 	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
@@ -100,9 +99,7 @@ func (cmd StashCmd) Exec(ctx context.Context, commandStr string, args []string, 
 		return 1
 	}
 
-	if dEnv.IsLocked() {
-		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(env.ErrActiveServerLock.New(dEnv.LockFile())), help)
-	}
+	// TODO: Error if dEnv.DoltDB.AccessMode() == ReadOnly?
 
 	err := stashChanges(ctx, dEnv, apr)
 	if err != nil {

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -256,7 +256,6 @@ func runMain() int {
 	}
 
 	csMetrics := false
-	ignoreLockFile := false
 	verboseEngineSetup := false
 	if len(args) > 0 {
 		var doneDebugFlags bool
@@ -395,7 +394,7 @@ func runMain() int {
 				args = args[1:]
 
 			case ignoreLocksFlag:
-				ignoreLockFile = true
+				// Ignored -- deprecated option.
 				args = args[1:]
 
 			case featureVersionFlag:
@@ -440,9 +439,6 @@ func runMain() int {
 	var fs filesys.Filesys
 	fs = filesys.LocalFS
 	dEnv := env.Load(ctx, env.GetCurrentUserHomeDir, fs, doltdb.LocalDirDoltDB, Version)
-
-	// TODO: Decide what we're doing with --ignore-lock-file; does it mean always operate locally?
-	_ = ignoreLockFile
 
 	root, err := env.GetCurrentUserHomeDir()
 	if err != nil {

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -440,7 +440,9 @@ func runMain() int {
 	var fs filesys.Filesys
 	fs = filesys.LocalFS
 	dEnv := env.Load(ctx, env.GetCurrentUserHomeDir, fs, doltdb.LocalDirDoltDB, Version)
-	dEnv.IgnoreLockFile = ignoreLockFile
+
+	// TODO: Decide what we're doing with --ignore-lock-file; does it mean always operate locally?
+	_ = ignoreLockFile
 
 	root, err := env.GetCurrentUserHomeDir()
 	if err != nil {
@@ -550,7 +552,7 @@ func runMain() int {
 	}
 	dEnv.FS = dataDirFS
 
-	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dataDirFS, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dataDirFS, dEnv.Version, dEnv)
 	if err != nil {
 		cli.PrintErrln("failed to load database names")
 		return 1
@@ -699,7 +701,11 @@ If you're interested in running this command against a remote host, hit us up on
 		targetEnv = rootEnv
 	}
 
-	isLocked, lock, err := targetEnv.GetLock()
+	// TODO: if targetEnv.DoltDB.AccessMode() == ReadOnly...
+	// Need to go looking for local creds to use...
+	var isLocked bool
+	var lock *sqlserver.LocalCreds
+	var err error
 	if err != nil {
 		return nil, err
 	}

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -680,12 +680,17 @@ If you're interested in running this command against a remote host, hit us up on
 		}
 	}
 
+	usedEnv := targetEnv
+	if usedEnv == nil && useDb != "" {
+	        usedEnv = mrEnv.GetEnv(useDb)
+	}
+
 	// There is no target environment detected. This is allowed for a small number of commands.
 	// We don't expect that number to grow, so we list them here.
 	// It's also allowed when --help is passed.
 	// So we defer the error until the caller tries to use the cli.LateBindQueryist
 	isDoltEnvironmentRequired := subcommandName != "init" && subcommandName != "sql" && subcommandName != "sql-server" && subcommandName != "sql-client"
-	if targetEnv == nil && isDoltEnvironmentRequired {
+	if usedEnv == nil && isDoltEnvironmentRequired {
 		return func(ctx context.Context) (cli.Queryist, *sql.Context, func(), error) {
 			return nil, nil, nil, fmt.Errorf("The current directory is not a valid dolt repository.")
 		}, nil

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -678,7 +678,7 @@ If you're interested in running this command against a remote host, hit us up on
 
 	usedEnv := targetEnv
 	if usedEnv == nil && useDb != "" {
-	        usedEnv = mrEnv.GetEnv(useDb)
+		usedEnv = mrEnv.GetEnv(useDb)
 	}
 
 	// There is no target environment detected. This is allowed for a small number of commands.

--- a/go/go.mod
+++ b/go/go.mod
@@ -67,7 +67,6 @@ require (
 	github.com/jmoiron/sqlx v1.3.4
 	github.com/kch42/buzhash v0.0.0-20160816060738-9bdec3dec7c6
 	github.com/kylelemons/godebug v1.1.0
-	github.com/mitchellh/go-ps v1.0.0
 	github.com/prometheus/client_golang v1.13.0
 	github.com/rs/zerolog v1.28.0
 	github.com/shirou/gopsutil/v3 v3.22.1

--- a/go/go.sum
+++ b/go/go.sum
@@ -489,8 +489,6 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
-github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/hashstructure v1.1.0 h1:P6P1hdjqAAknpY/M1CGipelZgp+4y9ja9kmUZPXP+H0=

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -131,6 +131,10 @@ func (ddb *DoltDB) NomsRoot(ctx context.Context) (hash.Hash, error) {
 	return datas.ChunkStoreFromDatabase(ddb.db).Root(ctx)
 }
 
+func (ddb *DoltDB) AccessMode() chunks.ExclusiveAccessMode {
+	return datas.ChunkStoreFromDatabase(ddb.db).AccessMode()
+}
+
 // CommitRoot executes a chunkStore commit, atomically swapping the root hash of the database manifest
 func (ddb *DoltDB) CommitRoot(ctx context.Context, last, current hash.Hash) (bool, error) {
 	return datas.ChunkStoreFromDatabase(ddb.db).Commit(ctx, last, current)

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -35,6 +35,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/utils/concurrentmap"
 	"github.com/dolthub/dolt/go/libraries/utils/config"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
+	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/datas"
 	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/types"
@@ -52,8 +53,6 @@ const (
 	DefaultRemotesApiPort = "443"
 
 	tempTablesDir = "temptf"
-
-	ServerLockFile = "sql-server.lock"
 )
 
 var zeroHashStr = (hash.Hash{}).String()
@@ -1182,4 +1181,8 @@ func (dEnv *DoltEnv) BulkDbEaFactory() editor.DbEaFactory {
 		return nil
 	}
 	return editor.NewBulkImportTEAFactory(dEnv.DoltDB.ValueReadWriter(), tmpDir)
+}
+
+func (dEnv *DoltEnv) IsAccessModeReadOnly() bool {
+	return dEnv.DoltDB.AccessMode() == chunks.ExclusiveAccessMode_ReadOnly
 }

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -75,6 +75,7 @@ var ErrFailedToWriteRepoState = errors.New("failed to write repo state")
 var ErrRemoteAddressConflict = errors.New("address conflict with a remote")
 var ErrDoltRepositoryNotFound = errors.New("can no longer find .dolt dir on disk")
 var ErrFailedToAccessDB = goerrors.NewKind("failed to access '%s' database: can no longer find .dolt dir on disk")
+var ErrDatabaseIsLocked = errors.New("the database is locked by another dolt process")
 
 // DoltEnv holds the state of the current environment used by the cli.
 type DoltEnv struct {

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -20,12 +20,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
-	ps "github.com/mitchellh/go-ps"
 	goerrors "gopkg.in/src-d/go-errors.v1"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
@@ -97,7 +94,6 @@ type DoltEnv struct {
 	urlStr string
 	hdp    HomeDirProvider
 
-	IgnoreLockFile bool
 	UserPassConfig *creds.DoltCredsForPass
 }
 
@@ -1186,165 +1182,4 @@ func (dEnv *DoltEnv) BulkDbEaFactory() editor.DbEaFactory {
 		return nil
 	}
 	return editor.NewBulkImportTEAFactory(dEnv.DoltDB.ValueReadWriter(), tmpDir)
-}
-
-func (dEnv *DoltEnv) LockFile() string {
-	f, _ := dEnv.FS.Abs(filepath.Join(dbfactory.DoltDir, ServerLockFile))
-	return f
-}
-
-// IsLocked returns true if this database's lockfile exists and the pid contained in lockfile is alive.
-func (dEnv *DoltEnv) IsLocked() bool {
-	if dEnv.IgnoreLockFile {
-		return false
-	}
-
-	ans, _, _ := fsIsLocked(dEnv.FS)
-	return ans
-}
-
-// GetLock returns the lockfile for this database or nil if the database is not locked
-func (dEnv *DoltEnv) GetLock() (bool, *DBLock, error) {
-	if dEnv.IgnoreLockFile {
-		return false, nil, nil
-	}
-
-	return fsIsLocked(dEnv.FS)
-}
-
-// DBLock is a struct that contains the pid of the process that created the lockfile and the port that the server is running on
-// The secret is used by dolt to ensure that the contents of the lockfile are required to perform a local server connection
-type DBLock struct {
-	Pid    int
-	Port   int
-	Secret string
-}
-
-// DBLock constructor
-func NewDBLock(port int) DBLock {
-	return DBLock{Pid: os.Getpid(), Port: port, Secret: uuid.New().String()}
-}
-
-// Lock writes this database's lockfile with the pid of the calling process or errors if it already exists
-func (dEnv *DoltEnv) Lock(lock *DBLock) error {
-	if dEnv.IgnoreLockFile {
-		return nil
-	}
-
-	if dEnv.IsLocked() {
-		return ErrActiveServerLock.New(dEnv.LockFile())
-	}
-
-	return WriteLockfile(dEnv.FS, lock)
-}
-
-func LoadDBLockFile(fs filesys.Filesys, lockFilePath string) (lock *DBLock, err error) {
-	rd, err := fs.OpenForRead(lockFilePath)
-	if err != nil {
-		return nil, err
-	}
-	defer rd.Close()
-
-	b := make([]byte, 256)
-	n, err := rd.Read(b)
-	if err != nil {
-		return nil, err
-	}
-
-	data := strings.TrimSpace(string(b[:n]))
-
-	parts := strings.Split(data, ":")
-	if len(parts) == 1 {
-		// Legacy Lock file. We can remove this code path in a couple of months (6/2023)
-		pid, err := strconv.Atoi(parts[0])
-		if err != nil {
-			return nil, err
-		}
-		return &DBLock{Pid: pid, Port: -1, Secret: ""}, nil
-	}
-	if len(parts) != 3 {
-		return nil, fmt.Errorf("invalid lock file format")
-	}
-
-	pid, err := strconv.Atoi(parts[0])
-	if err != nil {
-		return nil, err
-	}
-	port := -1
-	if parts[1] != "-" {
-		port, err = strconv.Atoi(parts[1])
-		if err != nil {
-			return nil, err
-		}
-	}
-	secret := parts[2]
-	return &DBLock{Pid: pid, Port: port, Secret: secret}, nil
-}
-
-// Unlock deletes this database's lockfile
-func (dEnv *DoltEnv) Unlock() error {
-	if dEnv.IgnoreLockFile {
-		return nil
-	}
-
-	return dEnv.FS.DeleteFile(dEnv.LockFile())
-}
-
-// WriteLockfile writes a lockfile encoding the pid of the calling process.
-func WriteLockfile(fs filesys.Filesys, lock *DBLock) error {
-	// if the DoltDir doesn't exist, create it.
-	doltDir, _ := fs.Abs(dbfactory.DoltDir)
-	err := fs.MkDirs(doltDir)
-	if err != nil {
-		return err
-	}
-
-	lockFile, _ := fs.Abs(filepath.Join(dbfactory.DoltDir, ServerLockFile))
-
-	portStr := strconv.Itoa(lock.Port)
-	if lock.Port < 0 {
-		portStr = "-"
-	}
-
-	err = fs.WriteFile(lockFile, []byte(fmt.Sprintf("%d:%s:%s", lock.Pid, portStr, lock.Secret)), 0600)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// fsIsLocked returns true if the database in qeustion is locked. Two additional return values are lock and err. In the
-// event that the DB is locked (locked == true), then either the lock or an error is returned. In either case,
-// the caller should not attempt to use the DB. If lock is returned, in some cases you can use it to connect to the
-// server that has locked the DB. If an error is returned, then no further processing should be done.
-func fsIsLocked(fs filesys.Filesys) (locked bool, lock *DBLock, err error) {
-	lockFile, _ := fs.Abs(filepath.Join(dbfactory.DoltDir, ServerLockFile))
-
-	ok, _ := fs.Exists(lockFile)
-	if !ok {
-		return false, nil, nil
-	}
-
-	loadedLock, err := LoadDBLockFile(fs, lockFile)
-	if err != nil { // if there's any error assume that env is locked since the file exists
-		return true, nil, err
-	}
-
-	// If the PID is for this process, then ignore the lock file. This happens frequently with docker containers
-	// https://github.com/dolthub/dolt/issues/6183.
-	if os.Getpid() == loadedLock.Pid {
-		return false, nil, nil
-	}
-
-	// Check whether the pid that spawned the lock file is still running. Ignore it if not.
-	proc, err := ps.FindProcess(loadedLock.Pid)
-	if err != nil {
-		return true, nil, err // This will happen if we can't load the OS processes. Assume locked.
-	}
-	if proc != nil {
-		return true, loadedLock, nil // The process is still running. Return the lock details so the caller can connect to it if appropriate.
-	}
-
-	return false, nil, nil
 }

--- a/go/libraries/doltcore/env/multi_repo_env.go
+++ b/go/libraries/doltcore/env/multi_repo_env.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	"gopkg.in/src-d/go-errors.v1"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
@@ -31,8 +30,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/utils/set"
 	"github.com/dolthub/dolt/go/store/types"
 )
-
-var ErrActiveServerLock = errors.NewKind("database locked by another sql-server; either clone the database to run a second server, or delete the '%s' if no other sql-servers are active")
 
 // EnvNameAndPath is a simple tuple of the name of an environment and the path to where it is on disk
 type EnvNameAndPath struct {
@@ -49,10 +46,10 @@ type NamedEnv struct {
 
 // MultiRepoEnv is a type used to store multiple environments which can be retrieved by name
 type MultiRepoEnv struct {
-	envs           []NamedEnv
-	fs             filesys.Filesys
-	cfg            config.ReadWriteConfig
-	dialProvider   dbfactory.GRPCDialProvider
+	envs         []NamedEnv
+	fs           filesys.Filesys
+	cfg          config.ReadWriteConfig
+	dialProvider dbfactory.GRPCDialProvider
 }
 
 // NewMultiEnv returns a new MultiRepoEnv instance dirived from a root DoltEnv instance.
@@ -88,10 +85,10 @@ func MultiEnvForDirectory(
 	}
 
 	mrEnv := &MultiRepoEnv{
-		envs:           make([]NamedEnv, 0),
-		fs:             dataDirFS,
-		cfg:            config,
-		dialProvider:   NewGRPCDialProviderFromDoltEnv(newDEnv),
+		envs:         make([]NamedEnv, 0),
+		fs:           dataDirFS,
+		cfg:          config,
+		dialProvider: NewGRPCDialProviderFromDoltEnv(newDEnv),
 	}
 
 	envSet := map[string]*DoltEnv{}

--- a/go/libraries/doltcore/env/multi_repo_env.go
+++ b/go/libraries/doltcore/env/multi_repo_env.go
@@ -53,12 +53,11 @@ type MultiRepoEnv struct {
 	fs             filesys.Filesys
 	cfg            config.ReadWriteConfig
 	dialProvider   dbfactory.GRPCDialProvider
-	ignoreLockFile bool
 }
 
 // NewMultiEnv returns a new MultiRepoEnv instance dirived from a root DoltEnv instance.
 func MultiEnvForSingleEnv(ctx context.Context, env *DoltEnv) (*MultiRepoEnv, error) {
-	return MultiEnvForDirectory(ctx, env.Config.WriteableConfig(), env.FS, env.Version, env.IgnoreLockFile, env)
+	return MultiEnvForDirectory(ctx, env.Config.WriteableConfig(), env.FS, env.Version, env)
 }
 
 // MultiEnvForDirectory returns a MultiRepoEnv for the directory rooted at the file system given. The doltEnv from the
@@ -69,7 +68,6 @@ func MultiEnvForDirectory(
 	config config.ReadWriteConfig,
 	dataDirFS filesys.Filesys,
 	version string,
-	ignoreLockFile bool,
 	dEnv *DoltEnv,
 ) (*MultiRepoEnv, error) {
 	// Load current dataDirFS and put into mr env
@@ -94,7 +92,6 @@ func MultiEnvForDirectory(
 		fs:             dataDirFS,
 		cfg:            config,
 		dialProvider:   NewGRPCDialProviderFromDoltEnv(newDEnv),
-		ignoreLockFile: ignoreLockFile,
 	}
 
 	envSet := map[string]*DoltEnv{}

--- a/go/libraries/doltcore/env/multi_repo_env.go
+++ b/go/libraries/doltcore/env/multi_repo_env.go
@@ -211,57 +211,6 @@ func (mrEnv *MultiRepoEnv) GetFirstDatabase() string {
 	return currentDb
 }
 
-// IsLocked returns true if any env is locked
-func (mrEnv *MultiRepoEnv) IsLocked() (bool, string) {
-	if mrEnv.ignoreLockFile {
-		return false, ""
-	}
-
-	for _, e := range mrEnv.envs {
-		if e.env.IsLocked() {
-			return true, e.env.LockFile()
-		}
-	}
-	return false, ""
-}
-
-// Lock locks all child envs. The DBLock contains the details to write to the lock files. If an error is returned, all
-// child envs will be returned with their initial lock state.
-func (mrEnv *MultiRepoEnv) Lock(lck *DBLock) (err error) {
-	if mrEnv.ignoreLockFile {
-		return nil
-	}
-
-	if ok, f := mrEnv.IsLocked(); ok {
-		return ErrActiveServerLock.New(f)
-	}
-
-	for _, e := range mrEnv.envs {
-		err = e.env.Lock(lck)
-		if err != nil {
-			mrEnv.Unlock()
-			return err
-		}
-	}
-	return nil
-}
-
-// Unlock unlocks all child envs.
-func (mrEnv *MultiRepoEnv) Unlock() error {
-	if mrEnv.ignoreLockFile {
-		return nil
-	}
-
-	var err, retErr error
-	for _, e := range mrEnv.envs {
-		err = e.env.Unlock()
-		if err != nil && retErr == nil {
-			retErr = err
-		}
-	}
-	return retErr
-}
-
 func getRepoRootDir(path, pathSeparator string) string {
 	if pathSeparator != "/" {
 		path = strings.ReplaceAll(path, pathSeparator, "/")

--- a/go/libraries/doltcore/env/multi_repo_env_test.go
+++ b/go/libraries/doltcore/env/multi_repo_env_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
 	"github.com/dolthub/dolt/go/libraries/doltcore/dconfig"
-	"github.com/dolthub/dolt/go/libraries/utils/config"
 	"github.com/dolthub/dolt/go/libraries/utils/earl"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/libraries/utils/test"
@@ -189,22 +188,4 @@ func initMultiEnv(t *testing.T, testName string, names []string) (string, HomeDi
 	}
 
 	return rootPath, hdp, envs
-}
-
-func TestLoadMultiEnv(t *testing.T) {
-	names := []string{"env 1", " env  2", "env-3"}
-	rootPath, hdp, _ := initMultiEnv(t, "TestLoadMultiEnv", names)
-
-	envNamesAndPaths := make([]EnvNameAndPath, len(names))
-	for i, name := range names {
-		envNamesAndPaths[i] = EnvNameAndPath{name, filepath.Join(rootPath, name)}
-	}
-
-	mrEnv, err := MultiEnvForPaths(context.Background(), hdp, config.NewEmptyMapConfig(), filesys.LocalFS, "test", false, envNamesAndPaths...)
-	require.NoError(t, err)
-
-	for _, name := range names {
-		e := mrEnv.GetEnv(name)
-		assert.NotNil(t, e)
-	}
 }

--- a/go/libraries/doltcore/env/multi_repo_env_test.go
+++ b/go/libraries/doltcore/env/multi_repo_env_test.go
@@ -121,7 +121,7 @@ func TestMultiEnvForDirectory(t *testing.T) {
 	envPath := filepath.Join(rootPath, " test---name _ 123")
 	dEnv := initRepoWithRelativePath(t, envPath, hdp)
 
-	mrEnv, err := MultiEnvForDirectory(context.Background(), dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
+	mrEnv, err := MultiEnvForDirectory(context.Background(), dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
 	require.NoError(t, err)
 	assert.Len(t, mrEnv.envs, 1)
 
@@ -158,7 +158,7 @@ func TestMultiEnvForDirectoryWithMultipleRepos(t *testing.T) {
 	subEnv1 := initRepoWithRelativePath(t, filepath.Join(envPath, "abc"), hdp)
 	subEnv2 := initRepoWithRelativePath(t, filepath.Join(envPath, "def"), hdp)
 
-	mrEnv, err := MultiEnvForDirectory(context.Background(), dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
+	mrEnv, err := MultiEnvForDirectory(context.Background(), dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
 	require.NoError(t, err)
 	assert.Len(t, mrEnv.envs, 3)
 

--- a/go/libraries/doltcore/merge/integration_test.go
+++ b/go/libraries/doltcore/merge/integration_test.go
@@ -363,7 +363,7 @@ func setupConcurrencyTest(t *testing.T, ctx context.Context) (dEnv *env.DoltEnv)
 }
 
 func engineFromEnvironment(ctx context.Context, dEnv *env.DoltEnv) (dbName string, eng *engine.SqlEngine) {
-	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
 	if err != nil {
 		panic(err)
 	}

--- a/go/libraries/doltcore/mvdata/engine_table_reader.go
+++ b/go/libraries/doltcore/mvdata/engine_table_reader.go
@@ -42,7 +42,7 @@ type sqlEngineTableReader struct {
 }
 
 func NewSqlEngineReader(ctx context.Context, dEnv *env.DoltEnv, tableName string) (*sqlEngineTableReader, error) {
-	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/mvdata/engine_table_writer.go
+++ b/go/libraries/doltcore/mvdata/engine_table_writer.go
@@ -62,11 +62,9 @@ type SqlEngineTableWriter struct {
 }
 
 func NewSqlEngineTableWriter(ctx context.Context, dEnv *env.DoltEnv, createTableSchema, rowOperationSchema schema.Schema, options *MoverOptions, statsCB noms.StatsCB) (*SqlEngineTableWriter, error) {
-	if dEnv.IsLocked() {
-		return nil, env.ErrActiveServerLock.New(dEnv.LockFile())
-	}
+	// TODO: Assert that dEnv.DoltDB.AccessMode() != ReadOnly?
 
-	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/remotestorage/chunk_store.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store.go
@@ -828,6 +828,10 @@ func (dcs *DoltChunkStore) Version() string {
 	return dcs.metadata.NbfVersion
 }
 
+func (dcs *DoltChunkStore) AccessMode() chunks.ExclusiveAccessMode {
+	return chunks.ExclusiveAccessMode_Shared
+}
+
 // Rebase brings this ChunkStore into sync with the persistent storage's
 // current root.
 func (dcs *DoltChunkStore) Rebase(ctx context.Context) error {

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_metadata_persistence.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_metadata_persistence.go
@@ -26,7 +26,7 @@ import (
 // persistReplicationConfiguration saves the specified |replicaSourceInfo| to disk; if any problems are encountered
 // while saving to disk, an error is returned.
 func persistReplicationConfiguration(ctx *sql.Context, replicaSourceInfo *mysql_db.ReplicaSourceInfo) error {
-	server, _ := sqlserver.GetRunningServer()
+	server := sqlserver.GetRunningServer()
 	if server == nil {
 		return fmt.Errorf("no SQL server running; " +
 			"replication commands may only be used when running from dolt sql-server, and not from dolt sql")
@@ -42,7 +42,7 @@ func persistReplicationConfiguration(ctx *sql.Context, replicaSourceInfo *mysql_
 
 // loadReplicationConfiguration loads the replication configuration for default channel ("").
 func loadReplicationConfiguration(_ *sql.Context) (*mysql_db.ReplicaSourceInfo, error) {
-	server, _ := sqlserver.GetRunningServer()
+	server := sqlserver.GetRunningServer()
 	if server == nil {
 		return nil, fmt.Errorf("no SQL server running; " +
 			"replication commands may only be used when running from dolt sql-server, and not from dolt sql")
@@ -64,7 +64,7 @@ func loadReplicationConfiguration(_ *sql.Context) (*mysql_db.ReplicaSourceInfo, 
 
 // deleteReplicationConfiguration deletes all replication configuration for the default channel ("").
 func deleteReplicationConfiguration(ctx *sql.Context) error {
-	server, _ := sqlserver.GetRunningServer()
+	server := sqlserver.GetRunningServer()
 	if server == nil {
 		return fmt.Errorf("no SQL server running; " +
 			"replication commands may only be used when running from dolt sql-server, and not from dolt sql")

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_applier.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_applier.go
@@ -251,7 +251,7 @@ func (a *binlogReplicaApplier) startReplicationEventStream(ctx *sql.Context, con
 // replicaBinlogEventHandler runs a loop, processing binlog events until the applier's stop replication channel
 // receives a signal to stop.
 func (a *binlogReplicaApplier) replicaBinlogEventHandler(ctx *sql.Context) error {
-	server, _ := sqlserver.GetRunningServer()
+	server := sqlserver.GetRunningServer()
 	if server == nil {
 		return fmt.Errorf("unable to access a running SQL server")
 	}
@@ -870,7 +870,7 @@ func convertVitessJsonExpressionString(ctx *sql.Context, value sqltypes.Value) (
 		strValue = strValue[len("EXPRESSION(") : len(strValue)-1]
 	}
 
-	server, _ := sqlserver.GetRunningServer()
+	server := sqlserver.GetRunningServer()
 	if server == nil {
 		return nil, fmt.Errorf("unable to access running SQL server")
 	}

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_controller.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_controller.go
@@ -151,7 +151,7 @@ func (d *doltBinlogReplicaController) StartReplica(ctx *sql.Context) error {
 // created and locked to disable log ins, and if it does exist, but is missing super privs or is not
 // locked, it will be given super user privs and locked.
 func (d *doltBinlogReplicaController) configureReplicationUser(ctx *sql.Context) error {
-	server, _ := sqlserver.GetRunningServer()
+	server := sqlserver.GetRunningServer()
 	if server == nil {
 		return fmt.Errorf("unable to access a running SQL server")
 	}

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -665,17 +665,6 @@ func (p *DoltDatabaseProvider) registerNewDatabase(ctx *sql.Context, name string
 		return fmt.Errorf("unable to register new database without database provider mutex being locked")
 	}
 
-	// If we're running in a sql-server context, ensure the new database is locked so that it can't
-	// be edited from the CLI. We can't rely on looking for an existing lock file, since this could
-	// be the first db creation if sql-server was started from a bare directory.
-	_, lckDeets := sqlserver.GetRunningServer()
-	if lckDeets != nil {
-		err = newEnv.Lock(lckDeets)
-		if err != nil {
-			ctx.GetLogger().Warnf("Failed to lock newly created database: %s", err.Error())
-		}
-	}
-
 	fkChecks, err := ctx.GetSessionVariable(ctx, "foreign_key_checks")
 	if err != nil {
 		return err

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -705,7 +705,7 @@ func (p *DoltDatabaseProvider) invalidateDbStateInAllSessions(ctx *sql.Context, 
 	}
 
 	// If we have a running server, remove it from other sessions as well
-	runningServer, _ := sqlserver.GetRunningServer()
+	runningServer := sqlserver.GetRunningServer()
 	if runningServer != nil {
 		sessionManager := runningServer.SessionManager()
 		err := sessionManager.Iter(func(session sql.Session) (bool, error) {

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_branch.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_branch.go
@@ -300,7 +300,7 @@ func validateBranchNotActiveInAnySession(ctx *sql.Context, branchName string) er
 		return nil
 	}
 
-	runningServer, _ := sqlserver.GetRunningServer()
+	runningServer := sqlserver.GetRunningServer()
 	if runningServer == nil {
 		return nil
 	}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
@@ -420,7 +420,7 @@ func (d *DoltHarness) newProvider() sql.MutableDatabaseProvider {
 	store := dEnv.DoltDB.ValueReadWriter().(*types.ValueStore)
 	store.SetValidateContentAddresses(true)
 
-	mrEnv, err := env.MultiEnvForDirectory(context.Background(), dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(context.Background(), dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
 	require.NoError(d.t, err)
 	d.multiRepoEnv = mrEnv
 

--- a/go/libraries/doltcore/sqle/index/mergeable_indexes_setup_test.go
+++ b/go/libraries/doltcore/sqle/index/mergeable_indexes_setup_test.go
@@ -95,7 +95,7 @@ func setupIndexes(t *testing.T, tableName, insertQuery string) (*sqle.Engine, *s
 		cols: idxv2v1Cols,
 	}
 
-	mrEnv, err := env.MultiEnvForDirectory(context.Background(), dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(context.Background(), dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
 	require.NoError(t, err)
 	b := env.GetDefaultInitBranch(dEnv.Config)
 	pro, err := dsqle.NewDoltDatabaseProviderWithDatabase(b, mrEnv.FileSystem(), db, dEnv.FS)

--- a/go/libraries/doltcore/sqle/logictest/dolt/doltharness.go
+++ b/go/libraries/doltcore/sqle/logictest/dolt/doltharness.go
@@ -286,7 +286,7 @@ func sqlNewEngine(dEnv *env.DoltEnv) (*sqle.Engine, dsess.DoltDatabaseProvider, 
 		return nil, nil, err
 	}
 
-	mrEnv, err := env.MultiEnvForDirectory(context.Background(), dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(context.Background(), dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/libraries/doltcore/sqle/sqlddl_test.go
+++ b/go/libraries/doltcore/sqle/sqlddl_test.go
@@ -1108,7 +1108,7 @@ func newTestEngine(ctx context.Context, dEnv *env.DoltEnv) (*gms.Engine, *sql.Co
 		panic(err)
 	}
 
-	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
 	if err != nil {
 		panic(err)
 	}

--- a/go/performance/microsysbench/sysbench_test.go
+++ b/go/performance/microsysbench/sysbench_test.go
@@ -115,7 +115,7 @@ func setupBenchmark(t *testing.B, dEnv *env.DoltEnv) (*sql.Context, *engine.SqlE
 		Autocommit: true,
 	}
 
-	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv.IgnoreLockFile, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
 	require.NoError(t, err)
 
 	eng, err := engine.NewSqlEngine(ctx, mrEnv, config)

--- a/go/store/chunks/chunk_store.go
+++ b/go/store/chunks/chunk_store.go
@@ -32,7 +32,7 @@ import (
 // A ChunkStore's |ExclusiveAccessMode| can indicate to a client what type of
 // exclusive access and concurrency control are support by the ChunkStore, and
 // for a ChunkStore instance which the client is holding, what level of access
-// it has. Typically, a ChunkStore will by Mode_Shared, which means multiple
+// it has. Typically, a ChunkStore will be in Mode_Shared, which means multiple
 // processes can concurrently write to the chunk store and the chunk store can
 // change out from under the process. Other possible modes, currently only used
 // by local ChunkStores using the chunk journal in go/store/nbs are
@@ -42,6 +42,11 @@ import (
 // while this ChunkStore is open.
 type ExclusiveAccessMode uint8
 
+// Note: the order of these constants is relied on in nbs/GenerationalNBS. The
+// order should go from least restricted access to most restricted access. If a
+// client has many stores with different levels of accses, a common question
+// they want to answer is: what is the most restricted access across all of
+// these stores.
 const (
 	ExclusiveAccessMode_Shared = iota
 	ExclusiveAccessMode_Exclusive

--- a/go/store/chunks/chunk_store.go
+++ b/go/store/chunks/chunk_store.go
@@ -29,6 +29,25 @@ import (
 	"github.com/dolthub/dolt/go/store/hash"
 )
 
+// A ChunkStore's |ExclusiveAccessMode| can indicate to a client what type of
+// exclusive access and concurrency control are support by the ChunkStore, and
+// for a ChunkStore instance which the client is holding, what level of access
+// it has. Typically, a ChunkStore will by Mode_Shared, which means multiple
+// processes can concurrently write to the chunk store and the chunk store can
+// change out from under the process. Other possible modes, currently only used
+// by local ChunkStores using the chunk journal in go/store/nbs are
+// Mode_ReadOnly, which means the journal was opened in read only mode and all
+// attempts to write will fail, or Mode_Exclusive, which means the journal was
+// opened successfully in write mode and no other processes will write to it
+// while this ChunkStore is open.
+type ExclusiveAccessMode uint8
+
+const (
+	ExclusiveAccessMode_Shared = iota
+	ExclusiveAccessMode_Exclusive
+	ExclusiveAccessMode_ReadOnly
+)
+
 var ErrNothingToCollect = errors.New("no changes since last gc")
 
 type GetAddrsCb func(ctx context.Context, c Chunk) (hash.HashSet, error)
@@ -62,6 +81,9 @@ type ChunkStore interface {
 
 	// Returns the NomsBinFormat with which this ChunkSource is compatible.
 	Version() string
+
+	// Returns the current access mode for this opened ChunkStore.
+	AccessMode() ExclusiveAccessMode
 
 	// Rebase brings this ChunkStore into sync with the persistent storage's
 	// current root.

--- a/go/store/chunks/cs_metrics_wrapper.go
+++ b/go/store/chunks/cs_metrics_wrapper.go
@@ -110,6 +110,10 @@ func (csMW *CSMetricWrapper) Version() string {
 	return csMW.cs.Version()
 }
 
+func (csMW *CSMetricWrapper) AccessMode() ExclusiveAccessMode {
+	return csMW.cs.AccessMode()
+}
+
 // Rebase brings this ChunkStore into sync with the persistent storage's
 // current root.
 func (csMW *CSMetricWrapper) Rebase(ctx context.Context) error {

--- a/go/store/chunks/memory_store.go
+++ b/go/store/chunks/memory_store.go
@@ -202,6 +202,10 @@ func (ms *MemoryStoreView) Version() string {
 	return ms.version
 }
 
+func (ms *MemoryStoreView) AccessMode() ExclusiveAccessMode {
+	return ExclusiveAccessMode_Shared
+}
+
 func (ms *MemoryStoreView) errorIfDangling(ctx context.Context, addrs hash.HashSet) error {
 	absent := hash.NewHashSet()
 	for h := range addrs {

--- a/go/store/nbs/aws_table_persister.go
+++ b/go/store/nbs/aws_table_persister.go
@@ -98,6 +98,10 @@ func (s3p awsTablePersister) Path() string {
 	return s3p.bucket
 }
 
+func (s3p awsTablePersister) AccessMode() chunks.ExclusiveAccessMode {
+	return chunks.ExclusiveAccessMode_Shared
+}
+
 type s3UploadedPart struct {
 	idx  int64
 	etag string

--- a/go/store/nbs/benchmarks/file_block_store.go
+++ b/go/store/nbs/benchmarks/file_block_store.go
@@ -67,6 +67,10 @@ func (fb fileBlockStore) Version() string {
 	panic("not impl")
 }
 
+func (fb fileBlockStore) AccessMode() chunks.ExclusiveAccessMode {
+	panic("not impl")
+}
+
 func (fb fileBlockStore) Close() error {
 	fb.w.Close()
 	return nil

--- a/go/store/nbs/benchmarks/null_block_store.go
+++ b/go/store/nbs/benchmarks/null_block_store.go
@@ -59,6 +59,10 @@ func (nb nullBlockStore) Version() string {
 	panic("not impl")
 }
 
+func (nb nullBlockStore) AccessMode() chunks.ExclusiveAccessMode {
+	panic("not impl")
+}
+
 func (nb nullBlockStore) Close() error {
 	return nil
 }

--- a/go/store/nbs/bs_persister.go
+++ b/go/store/nbs/bs_persister.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/dolthub/dolt/go/store/blobstore"
+	"github.com/dolthub/dolt/go/store/chunks"
 )
 
 const (
@@ -172,6 +173,10 @@ func (bsp *blobstorePersister) PruneTableFiles(ctx context.Context, keeper func(
 
 func (bsp *blobstorePersister) Close() error {
 	return nil
+}
+
+func (bsp *blobstorePersister) AccessMode() chunks.ExclusiveAccessMode {
+	return chunks.ExclusiveAccessMode_Shared
 }
 
 func (bsp *blobstorePersister) Path() string {

--- a/go/store/nbs/file_table_persister.go
+++ b/go/store/nbs/file_table_persister.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"github.com/dolthub/dolt/go/libraries/utils/file"
+	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/util/tempfiles"
 )
 
@@ -417,4 +418,8 @@ func (ftp *fsTablePersister) PruneTableFiles(ctx context.Context, keeper func() 
 
 func (ftp *fsTablePersister) Close() error {
 	return nil
+}
+
+func (ftp *fsTablePersister) AccessMode() chunks.ExclusiveAccessMode {
+	return chunks.ExclusiveAccessMode_Shared
 }

--- a/go/store/nbs/generational_chunk_store.go
+++ b/go/store/nbs/generational_chunk_store.go
@@ -166,6 +166,15 @@ func (gcs *GenerationalNBS) Version() string {
 	return gcs.newGen.Version()
 }
 
+func (gcs *GenerationalNBS) AccessMode() chunks.ExclusiveAccessMode {
+	newGenMode := gcs.newGen.AccessMode()
+	oldGenMode := gcs.oldGen.AccessMode()
+	if oldGenMode > newGenMode {
+		return oldGenMode
+	}
+	return newGenMode
+}
+
 // Rebase brings this ChunkStore into sync with the persistent storage's
 // current root.
 func (gcs *GenerationalNBS) Rebase(ctx context.Context) error {

--- a/go/store/nbs/journal.go
+++ b/go/store/nbs/journal.go
@@ -528,7 +528,9 @@ func newJournalManifest(ctx context.Context, dir string) (m *journalManifest, er
 	var f *os.File
 	f, err = openIfExists(filepath.Join(dir, manifestFileName))
 	if err != nil {
-		_ = lock.Unlock()
+		if lock != nil {
+			_ = lock.Unlock()
+		}
 		return nil, err
 	} else if f == nil {
 		return m, nil
@@ -538,17 +540,23 @@ func newJournalManifest(ctx context.Context, dir string) (m *journalManifest, er
 			err = cerr // keep first error
 		}
 		if err != nil {
-			_ = lock.Unlock()
+			if lock != nil {
+				_ = lock.Unlock()
+			}
 		}
 	}()
 
 	var ok bool
 	ok, _, err = m.ParseIfExists(ctx, &Stats{}, nil)
 	if err != nil {
-		_ = lock.Unlock()
+		if lock != nil {
+			_ = lock.Unlock()
+		}
 		return nil, err
 	} else if !ok {
-		_ = lock.Unlock()
+		if lock != nil {
+			_ = lock.Unlock()
+		}
 		return nil, ErrUnreadableManifest
 	}
 	return

--- a/go/store/nbs/journal.go
+++ b/go/store/nbs/journal.go
@@ -484,6 +484,13 @@ func (j *ChunkJournal) Close() (err error) {
 	return err
 }
 
+func (j *ChunkJournal) AccessMode() chunks.ExclusiveAccessMode {
+	if j.backing.readOnly() {
+		return chunks.ExclusiveAccessMode_ReadOnly
+	}
+	return chunks.ExclusiveAccessMode_Exclusive
+}
+
 type journalConjoiner struct {
 	child conjoinStrategy
 }

--- a/go/store/nbs/root_tracker_test.go
+++ b/go/store/nbs/root_tracker_test.go
@@ -648,6 +648,10 @@ func (ftp fakeTablePersister) Close() error {
 	return nil
 }
 
+func (ftp fakeTablePersister) AccessMode() chunks.ExclusiveAccessMode {
+	return chunks.ExclusiveAccessMode_Shared
+}
+
 func extractAllChunks(ctx context.Context, src chunkSource, cb func(rec extractRecord)) (err error) {
 	var index tableIndex
 	if index, err = src.index(); err != nil {

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -1296,6 +1296,10 @@ func (nbs *NomsBlockStore) Version() string {
 	return nbs.upstream.nbfVers
 }
 
+func (nbs *NomsBlockStore) AccessMode() chunks.ExclusiveAccessMode {
+	return nbs.p.AccessMode()
+}
+
 func (nbs *NomsBlockStore) Close() (err error) {
 	if cerr := nbs.p.Close(); cerr != nil {
 		err = cerr

--- a/go/store/nbs/table_persister.go
+++ b/go/store/nbs/table_persister.go
@@ -30,6 +30,8 @@ import (
 	"io"
 	"sort"
 	"time"
+
+	"github.com/dolthub/dolt/go/store/chunks"
 )
 
 var errCacheMiss = errors.New("index cache miss")
@@ -62,6 +64,8 @@ type tablePersister interface {
 	// which are not in the included |keeper| set and have not be written or modified more recently
 	// than the provided |mtime|.
 	PruneTableFiles(ctx context.Context, keeper func() []addr, mtime time.Time) error
+
+	AccessMode() chunks.ExclusiveAccessMode
 
 	io.Closer
 }

--- a/go/store/valuefile/file_value_store.go
+++ b/go/store/valuefile/file_value_store.go
@@ -207,6 +207,10 @@ func (f *FileValueStore) Version() string {
 	return f.nbf.VersionString()
 }
 
+func (f *FileValueStore) AccessMode() chunks.ExclusiveAccessMode {
+	return chunks.ExclusiveAccessMode_Shared
+}
+
 // Rebase brings this ChunkStore into sync with the persistent storage's current root.  Has no impact here
 func (f *FileValueStore) Rebase(ctx context.Context) error {
 	f.chunkLock.Lock()

--- a/integration-tests/bats/init.bats
+++ b/integration-tests/bats/init.bats
@@ -261,16 +261,10 @@ teardown() {
 @test "init: Fail when there is anything in the .dolt dir" {
     set_dolt_user "baz", "baz@bash.com"
 
-    mkdir dbdir
+    mkdir -p dbdir/.dolt
     cd dbdir
-    mkdir .dolt
-
-    # Possible real world situation. sql-server crashes and leaves a lock file.
-    # Currently we don't handle this.
-    echo "42:3306:aebf244e-0693-4c36-8b2d-6eb0dfa4fe2d" > .dolt/sql-server.lock
-
+    touch .dolt/config.json
     run dolt init
-
     [ "$status" -eq 1 ]
     [[ "$output" =~ ".dolt directory already exists" ]] || false
 }

--- a/integration-tests/bats/sql-privs.bats
+++ b/integration-tests/bats/sql-privs.bats
@@ -72,7 +72,6 @@ teardown() {
     [[ $output =~ "new_user" ]] || false
 
     stop_sql_server
-    rm -f .dolt/sql-server.lock
 
     # restarting server
     PORT=$( definePORT )
@@ -238,7 +237,6 @@ behavior:
     ! [[ "$output" =~ "\"User\":\"privs_user\"" ]] || false
 
     # Restart server
-    rm -f ./.dolt/sql-server.lock
     stop_sql_server
     start_sql_server_with_args --host 0.0.0.0 --user=dolt --privilege-file=privs.json
 

--- a/integration-tests/bats/sql-server-remotesrv.bats
+++ b/integration-tests/bats/sql-server-remotesrv.bats
@@ -112,6 +112,7 @@ call dolt_commit('-m', 'add some vals');
     dolt sql-server --remotesapi-port 50051 &
     srv_pid=$!
 
+    sleep 2
     dolt clone http://localhost:50051/remote_one remote_one_cloned
 
     cd ../remote_two

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -1398,7 +1398,7 @@ data_dir: $DATA_DIR
     [ "$status" -eq 0 ]
 }
 
-@test "sql-server: sql-server lock cleanup" {
+@test "sql-server: sql-server info cleanup" {
     cd repo1
     start_sql_server
     stop_sql_server
@@ -1406,28 +1406,28 @@ data_dir: $DATA_DIR
     stop_sql_server
 }
 
-@test "sql-server: sql-server locks database" {
+@test "sql-server: sql-server info database" {
     cd repo1
     start_sql_server
-    [[ -f "$PWD/.dolt/sql-server.lock" ]] || false
+    [[ -f "$PWD/.dolt/sql-server.info" ]] || false
 
     PORT=$( definePORT )
     run dolt sql-server -P $PORT --socket "dolt.$PORT.sock"
     [ "$status" -eq 1 ]
 }
 
-@test "sql-server: sql-server sets permissions on sql-server.lock" {
+@test "sql-server: sql-server sets permissions on sql-server.info" {
     cd repo1
-    ! [[ -f "$PWD/.dolt/sql-server.lock" ]] || false
+    ! [[ -f "$PWD/.dolt/sql-server.info" ]] || false
     start_sql_server
-    [[ -f "$PWD/.dolt/sql-server.lock" ]] || false
+    [[ -f "$PWD/.dolt/sql-server.info" ]] || false
 
 
     if [[ `uname` == 'Darwin' ]]; then
-      run stat -x "$PWD/.dolt/sql-server.lock"
+      run stat -x "$PWD/.dolt/sql-server.info"
       [[ "$output" =~ "(0600/-rw-------)" ]] || false
     else
-      run stat "$PWD/.dolt/sql-server.lock"
+      run stat "$PWD/.dolt/sql-server.info"
       [[ "$output" =~ "(0600/-rw-------)" ]] || false
     fi
 }
@@ -1580,7 +1580,7 @@ behavior:
     kill -9 $SERVER_PID
 
     run ls .dolt
-    [[ "$output" =~ "sql-server.lock" ]] || false
+    [[ "$output" =~ "sql-server.info" ]] || false
 
     start_sql_server
     run dolt sql -q "select 1 as col1"

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -1052,9 +1052,6 @@ END""")
     [[ $output =~ "information_schema" ]] || false
     [[ $output =~ "test1" ]] ||	false
 
-    # Make sure the sql-server lock file is set for a newly created database
-    [[ -f "$PWD/test1/.dolt/sql-server.lock" ]] || false
-
     dolt sql -q "create table a(x int)"
     dolt sql -q "call dolt_add('.')"
     dolt sql -q "insert into a values (1), (2)"
@@ -1221,9 +1218,6 @@ END""")
     [[ $output =~ "mysql" ]] || false
     [[ $output =~ "information_schema" ]] || false
     [[ $output =~ "test1" ]] || false
-
-    # Make sure the sql-server lock file is set for a newly created database
-    [[ -f "$PWD/db_dir/test1/.dolt/sql-server.lock" ]] || false
 
     dolt --port $PORT --host 0.0.0.0 --no-tls -u dolt --use-db test1 sql -q "create table a(x int)"
     dolt --port $PORT --host 0.0.0.0 --no-tls -u dolt --use-db test1 sql -q "call dolt_add('.')"
@@ -1460,9 +1454,6 @@ data_dir: $DATA_DIR
     start_sql_server
     dolt sql -q "create database newdb"
 
-    # Make sure the sql-server lock file is set for the new database
-    [[ -f "$PWD/newdb/.dolt/sql-server.lock" ]] || false
-
     # Verify that we can't start a sql-server from the new database dir
     cd newdb
     PORT=$( definePORT )
@@ -1583,52 +1574,12 @@ behavior:
     [ "${#lines[@]}" -eq 1 ]
 }
 
-@test "sql-server: start server multidir creates sql-server.lock file in every rep" {
-    start_sql_server
-    run ls repo1/.dolt
-    [[ "$output" =~ "sql-server.lock" ]] || false
-
-    run ls repo2/.dolt
-    [[ "$output" =~ "sql-server.lock" ]] || false
-
-    stop_sql_server
-    run ls repo1/.dolt
-    ! [[ "$output" =~ "sql-server.lock" ]] || false
-
-    run ls repo2/.dolt
-    ! [[ "$output" =~ "sql-server.lock" ]] || false
-}
-
-@test "sql-server: running a dolt function in the same directory as a running server correctly errors" {
-    start_sql_server
-
-    cd repo1
-    run dolt gc
-    [ "$status" -eq 1 ]
-    [[ "$output" =~ "database locked by another sql-server; either clone the database to run a second server" ]] || false
-
-    PORT=$( definePORT )
-    run dolt sql-server --port=$PORT --socket "dolt.$PORT.sock"
-    [ "$status" -eq 1 ]
-
-    [[ "$output" =~ "Database locked by another sql-server" ]] || false
-    stop_sql_server 1
-}
-
 @test "sql-server: sigterm running server and restarting works correctly" {
     start_sql_server
-    run ls repo1/.dolt
-    [[ "$output" =~ "sql-server.lock" ]] || false
-
-    run ls repo2/.dolt
-    [[ "$output" =~ "sql-server.lock" ]] || false
 
     kill -9 $SERVER_PID
 
-    run ls repo1/.dolt
-    [[ "$output" =~ "sql-server.lock" ]] || false
-
-    run ls repo2/.dolt
+    run ls .dolt
     [[ "$output" =~ "sql-server.lock" ]] || false
 
     start_sql_server
@@ -1636,33 +1587,6 @@ behavior:
     [ $status -eq 0 ]
     [[ $output =~ col1 ]] || false
     [[ $output =~ " 1 " ]] || false
-    stop_sql_server
-
-    # Try adding fake pid numbers. Could happen via debugger or something
-    echo "423423" > repo1/.dolt/sql-server.lock
-    echo "4123423" > repo2/.dolt/sql-server.lock
-
-    start_sql_server
-    run dolt --port $PORT --host 0.0.0.0 --no-tls -u dolt --use-db repo2 sql -q "select 1 as col1"
-    [ $status -eq 0 ]
-    [[ $output =~ col1 ]] || false
-    [[ $output =~ " 1 " ]] || false
-    stop_sql_server
-
-    # Add malicious text to lockfile and expect to fail
-    echo "iamamaliciousactor" > repo1/.dolt/sql-server.lock
-
-    run start_sql_server
-    [[ "$output" =~ "database locked by another sql-server; either clone the database to run a second server" ]] || false
-    [ "$status" -eq 1 ]
-
-    rm repo1/.dolt/sql-server.lock
-
-    # this test was hanging as the server is stopped from the above error
-    # but stop_sql_server in teardown tries to kill process that is not
-    # running anymore, so start the server again, and it will be stopped in
-    # teardown
-    start_sql_server
 }
 
 @test "sql-server: create a database when no current database is set" {
@@ -1900,18 +1824,6 @@ behavior:
     [[ ! "$output" =~ "other" ]] || false
 }
 
-@test "sql-server: server won't start where another server is running" {
-    baseDir=$(mktemp -d)
-    cd $baseDir
-
-    start_sql_server
-
-    run dolt sql-server
-
-    [ $status -eq 1 ]
-    [[ "$output" =~ "Database locked by another sql-server; Lock file" ]] || false
-}
-
 @test "sql-server: empty server can be connected to using sql with no args" {
     baseDir=$(mktemp -d)
     cd $baseDir
@@ -1936,10 +1848,13 @@ behavior:
     [ $status -eq 0 ]
     [[ "$output" =~ "__dolt_local_user__@localhost" ]] || false
 
+    # We create a database here so that the server has exclusive access to this database.
+    # Starting another server attempting to serve it will fail.
+    dolt --data-dir=$baseDir sql -q "create database mydb"
+
     cd "$baseDir"
     run dolt sql-server
     [ $status -eq 1 ]
-    [[ "$output" =~ "Database locked by another sql-server; Lock file" ]] || false
 
     run dolt sql -q "select current_user"
     [ $status -eq 0 ]

--- a/integration-tests/bats/sql-shell.bats
+++ b/integration-tests/bats/sql-shell.bats
@@ -208,6 +208,10 @@ SQL
 }
 
 @test "sql-shell: specify data-dir" {
+    if [ "$SQL_ENGINE" = "remote-engine" ]; then
+      skip "Remote behavior differs"
+    fi
+
     # remove config files
     rm -rf .doltcfg
     rm -rf db_dir
@@ -378,6 +382,10 @@ SQL
 }
 
 @test "sql-shell: specify data-dir and doltcfg-dir" {
+    if [ "$SQL_ENGINE" = "remote-engine" ]; then
+      skip "Remote behavior differs"
+    fi
+
     # remove config files
     rm -rf .doltcfg
     rm -rf db_dir
@@ -477,6 +485,10 @@ SQL
 }
 
 @test "sql-shell: specify data-dir and privilege-file" {
+    if [ "$SQL_ENGINE" = "remote-engine" ]; then
+      skip "Remote behavior differs"
+    fi
+
     # remove config files
     rm -rf .doltcfg
     rm -rf db_dir
@@ -618,6 +630,10 @@ SQL
 }
 
 @test "sql-shell: specify data directory, cfg directory, and privilege file" {
+    if [ "$SQL_ENGINE" = "remote-engine" ]; then
+      skip "Remote behavior differs"
+    fi
+
     # remove config files
     rm -rf .doltcfg
     rm -rf db_dir
@@ -729,6 +745,10 @@ SQL
 
 
 @test "sql-shell: .doltcfg in parent directory errors" {
+    if [ "$SQL_ENGINE" = "remote-engine" ]; then
+      skip "Remote behavior differs"
+    fi
+
     # remove existing directories
     rm -rf .doltcfg
     rm -rf inner_db

--- a/integration-tests/bats/sql.bats
+++ b/integration-tests/bats/sql.bats
@@ -2897,11 +2897,4 @@ SQL
 
     mkdir .dolt
     dolt sql -q "select 1"
-
-    # If there is a zombie lock file, sql should delete it.
-    echo "42:3306:aebf244e-0693-4c36-8b2d-6eb0dfa4fe2d" > .dolt/sql-server.lock}
-
-    dolt sql -q "select 1"
-
-    [[ ! -f .dolt/sql-server.lock ]] || false
 }

--- a/integration-tests/bats/undrop.bats
+++ b/integration-tests/bats/undrop.bats
@@ -60,6 +60,10 @@ teardown() {
 }
 
 @test "undrop: undrop root database with hyphen replaced in its name" {
+  if [ "$SQL_ENGINE" = "remote-engine" ]; then
+   skip "Remote behavior differs"
+  fi
+
   export DOLT_DBNAME_REPLACE="true"
   setup_remote_server
   # Create a new Dolt database directory to use as a root database
@@ -97,6 +101,10 @@ EOF
 }
 
 @test "undrop: undrop root database with hyphen allowed in its name" {
+  if [ "$SQL_ENGINE" = "remote-engine" ]; then
+   skip "Remote behavior differs"
+  fi
+
   setup_remote_server
   # Create a new Dolt database directory to use as a root database
   # NOTE: We use hyphens here to test how db dirs are renamed.

--- a/integration-tests/go-sql-server-driver/sqlserver_info_test.go
+++ b/integration-tests/go-sql-server-driver/sqlserver_info_test.go
@@ -28,7 +28,7 @@ import (
 	driver "github.com/dolthub/dolt/go/libraries/doltcore/dtestutils/sql_server_driver"
 )
 
-func TestSQLServerLockFile(t *testing.T) {
+func TestSQLServerInfoFile(t *testing.T) {
 	t.Run("With Two Repos", func(t *testing.T) {
 		u, err := driver.NewDoltUser()
 		require.NoError(t, err)
@@ -46,8 +46,8 @@ func TestSQLServerLockFile(t *testing.T) {
 		t.Run("With server running in root", func(t *testing.T) {
 			RunServerUntilEndOfTest(t, rs, &driver.Server{})
 
-			t.Run("sql-server.lock file exists", func(t *testing.T) {
-				location := filepath.Join(rs.Dir, ".dolt/sql-server.lock")
+			t.Run("sql-server.info file exists", func(t *testing.T) {
+				location := filepath.Join(rs.Dir, ".dolt/sql-server.info")
 				f, err := os.Open(location)
 				require.NoError(t, err)
 				require.NoError(t, f.Close())
@@ -98,8 +98,8 @@ func TestSQLServerLockFile(t *testing.T) {
 				require.Regexp(t, "db_two", outstr)
 			})
 		})
-		t.Run("sql-server.lock in root no longer exists", func(t *testing.T) {
-			location := filepath.Join(rs.Dir, ".dolt/sql-server.lock")
+		t.Run("sql-server.info in root no longer exists", func(t *testing.T) {
+			location := filepath.Join(rs.Dir, ".dolt/sql-server.info")
 			f, err := os.Open(location)
 			if f != nil {
 				defer f.Close()
@@ -211,9 +211,9 @@ func TestSQLServerLockFile(t *testing.T) {
 				require.Error(t, err)
 			})
 		})
-		t.Run("With stale sql-server.lock file in root", func(t *testing.T) {
+		t.Run("With stale sql-server.info file in root", func(t *testing.T) {
 			Setup := func(t *testing.T) {
-				path := filepath.Join(rs.Dir, ".dolt/sql-server.lock")
+				path := filepath.Join(rs.Dir, ".dolt/sql-server.info")
 				err := os.WriteFile(path, []byte("1:3306:this_is_not_a_real_secret"), 0600)
 				require.NoError(t, err)
 				t.Cleanup(func() { os.Remove(path) })
@@ -244,9 +244,9 @@ func TestSQLServerLockFile(t *testing.T) {
 				require.Regexp(t, "db_one", outstr)
 			})
 		})
-		t.Run("With malformed sql-server.lock file in root", func(t *testing.T) {
+		t.Run("With malformed sql-server.info file in root", func(t *testing.T) {
 			Setup := func(t *testing.T) {
-				path := filepath.Join(rs.Dir, ".dolt/sql-server.lock")
+				path := filepath.Join(rs.Dir, ".dolt/sql-server.info")
 				err := os.WriteFile(path, []byte("1:3306:this_is_not_a_real_secret:extra:fields:make:it:fail"), 0600)
 				require.NoError(t, err)
 				t.Cleanup(func() { os.Remove(path) })

--- a/integration-tests/go-sql-server-driver/sqlserver_lock_test.go
+++ b/integration-tests/go-sql-server-driver/sqlserver_lock_test.go
@@ -29,269 +29,293 @@ import (
 )
 
 func TestSQLServerLockFile(t *testing.T) {
-	u, err := driver.NewDoltUser()
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		u.Cleanup()
-	})
+	t.Run("With Two Repos", func(t *testing.T) {
+		u, err := driver.NewDoltUser()
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			u.Cleanup()
+		})
 
-	rs, err := u.MakeRepoStore()
-	require.NoError(t, err)
-	dbOne, err := rs.MakeRepo("db_one")
-	require.NoError(t, err)
-	dbTwo, err := rs.MakeRepo("db_two")
-	require.NoError(t, err)
+		rs, err := u.MakeRepoStore()
+		require.NoError(t, err)
+		dbOne, err := rs.MakeRepo("db_one")
+		require.NoError(t, err)
+		dbTwo, err := rs.MakeRepo("db_two")
+		require.NoError(t, err)
 
-	t.Run("With server running in root", func(t *testing.T) {
-		RunServerUntilEndOfTest(t, rs, &driver.Server{})
+		t.Run("With server running in root", func(t *testing.T) {
+			RunServerUntilEndOfTest(t, rs, &driver.Server{})
 
-		t.Run("sql-server.lock file exists", func(t *testing.T) {
+			t.Run("sql-server.lock file exists", func(t *testing.T) {
+				location := filepath.Join(rs.Dir, ".dolt/sql-server.lock")
+				f, err := os.Open(location)
+				require.NoError(t, err)
+				require.NoError(t, f.Close())
+			})
+			t.Run("Running again in root fails", func(t *testing.T) {
+				_ = MakeServer(t, rs, &driver.Server{
+					ErrorMatches: []string{
+						"locked by another dolt process",
+					},
+				})
+			})
+			t.Run("Running in db_one fails", func(t *testing.T) {
+				_ = MakeServer(t, dbOne, &driver.Server{
+					ErrorMatches: []string{
+						"locked by another dolt process",
+					},
+				})
+			})
+			t.Run("Running dolt sql -q in /server connects to server", func(t *testing.T) {
+				cmd := rs.DoltCmd("sql", "-q", "show databases")
+				output, err := cmd.CombinedOutput()
+				outstr := string(output)
+				require.NoError(t, err)
+				require.Regexp(t, "db_one", outstr)
+				require.Regexp(t, "db_two", outstr)
+			})
+			t.Run("Running dolt sql -q in /server/db_two connects to server on db_two", func(t *testing.T) {
+				cmd := dbTwo.DoltCmd("sql", "-q", "select database()")
+				output, err := cmd.CombinedOutput()
+				outstr := string(output)
+				require.NoError(t, err)
+				require.Regexp(t, "db_two", outstr)
+			})
+			t.Run("Running dolt sql -q in /server/db_two/.dolt/noms connects to server on no database", func(t *testing.T) {
+				cmd := dbTwo.DoltCmd("sql", "-q", "select database()")
+				cmd.Dir = filepath.Join(cmd.Dir, ".dolt/noms")
+				output, err := cmd.CombinedOutput()
+				outstr := string(output)
+				require.NoError(t, err)
+				require.Regexp(t, "NULL", outstr)
+
+				cmd = dbTwo.DoltCmd("sql", "-q", "show databases")
+				cmd.Dir = filepath.Join(cmd.Dir, ".dolt/noms")
+				output, err = cmd.CombinedOutput()
+				outstr = string(output)
+				require.NoError(t, err)
+				require.Regexp(t, "db_one", outstr)
+				require.Regexp(t, "db_two", outstr)
+			})
+		})
+		t.Run("sql-server.lock in root no longer exists", func(t *testing.T) {
 			location := filepath.Join(rs.Dir, ".dolt/sql-server.lock")
 			f, err := os.Open(location)
-			require.NoError(t, err)
-			require.NoError(t, f.Close())
+			if f != nil {
+				defer f.Close()
+			}
+			require.ErrorIs(t, err, fs.ErrNotExist)
 		})
-		t.Run("Running again in root fails", func(t *testing.T) {
-			_ = MakeServer(t, rs, &driver.Server{
-				ErrorMatches: []string{
-					"locked by another dolt process",
-				},
-			})
-		})
-		t.Run("Running in db_one fails", func(t *testing.T) {
-			_ = MakeServer(t, dbOne, &driver.Server{
-				ErrorMatches: []string{
-					"locked by another dolt process",
-				},
-			})
-		})
-		t.Run("Running dolt sql -q in /server connects to server", func(t *testing.T) {
-			cmd := rs.DoltCmd("sql", "-q", "show databases")
-			output, err := cmd.CombinedOutput()
-			outstr := string(output)
-			require.NoError(t, err)
-			require.Regexp(t, "db_one", outstr)
-			require.Regexp(t, "db_two", outstr)
-		})
-		t.Run("Running dolt sql -q in /server/db_two connects to server on db_two", func(t *testing.T) {
-			cmd := dbTwo.DoltCmd("sql", "-q", "select database()")
-			output, err := cmd.CombinedOutput()
-			outstr := string(output)
-			require.NoError(t, err)
-			require.Regexp(t, "db_two", outstr)
-		})
-		t.Run("Running dolt sql -q in /server/db_two/.dolt/noms connects to server on no database", func(t *testing.T) {
-			cmd := dbTwo.DoltCmd("sql", "-q", "select database()")
-			cmd.Dir = filepath.Join(cmd.Dir, ".dolt/noms")
-			output, err := cmd.CombinedOutput()
-			outstr := string(output)
-			require.NoError(t, err)
-			require.Regexp(t, "NULL", outstr)
-
-			cmd = dbTwo.DoltCmd("sql", "-q", "show databases")
-			cmd.Dir = filepath.Join(cmd.Dir, ".dolt/noms")
-			output, err = cmd.CombinedOutput()
-			outstr = string(output)
-			require.NoError(t, err)
-			require.Regexp(t, "db_one", outstr)
-			require.Regexp(t, "db_two", outstr)
-		})
-	})
-	t.Run("sql-server.lock in root no longer exists", func(t *testing.T) {
-		location := filepath.Join(rs.Dir, ".dolt/sql-server.lock")
-		f, err := os.Open(location)
-		if f != nil {
-			defer f.Close()
-		}
-		require.ErrorIs(t, err, fs.ErrNotExist)
-	})
-	t.Run("With server running in db_one", func(t *testing.T) {
-		RunServerUntilEndOfTest(t, dbOne, &driver.Server{})
-
-		t.Run("Running server in root fails", func(t *testing.T) {
-			_ = MakeServer(t, rs, &driver.Server{
-				ErrorMatches: []string{
-					"locked by another dolt process",
-				},
-			})
-		})
-		t.Run("Running server in db_two succeeds", func(t *testing.T) {
-			RunServerUntilEndOfTest(t, dbTwo, &driver.Server{
-				Args: []string{"--port", "3310"},
-				Port: 3310,
-			})
-		})
-		t.Run("dolt sql -q in root succeeds", func(t *testing.T) {
-			cmd := rs.DoltCmd("sql", "-q", "show databases")
-			output, err := cmd.CombinedOutput()
-			outstr := string(output)
-			require.NoError(t, err)
-			require.Regexp(t, "db_one", outstr)
-			require.Regexp(t, "db_two", outstr)
-		})
-		t.Run("dolt sql -q in root can write to db_two", func(t *testing.T) {
-			cmd := rs.DoltCmd("sql", "-q", "create table db_two.vals (id int primary key)")
-			_, err := cmd.CombinedOutput()
-			require.NoError(t, err)
-		})
-		t.Run("dolt sql -q in root cannot write to db_one", func(t *testing.T) {
-			cmd := rs.DoltCmd("sql", "-q", "create table db_one.vals (id int primary key)")
-			_, err := cmd.CombinedOutput()
-			require.Error(t, err)
-		})
-	})
-	t.Run("Given a running dolt sql process in root", func(t *testing.T) {
-		RunDoltSQLUntilEndOfTest(t, rs)
-
-		t.Run("Running server in root fails", func(t *testing.T) {
-			_ = MakeServer(t, rs, &driver.Server{
-				ErrorMatches: []string{
-					"locked by another dolt process",
-				},
-			})
-		})
-		t.Run("Running server in db_one fails", func(t *testing.T) {
-			_ = MakeServer(t, dbOne, &driver.Server{
-				ErrorMatches: []string{
-					"locked by another dolt process",
-				},
-			})
-		})
-		t.Run("dolt sql -q in root succeeds", func(t *testing.T) {
-			cmd := rs.DoltCmd("sql", "-q", "show databases")
-			output, err := cmd.CombinedOutput()
-			outstr := string(output)
-			require.NoError(t, err)
-			require.Regexp(t, "db_one", outstr)
-			require.Regexp(t, "db_two", outstr)
-		})
-		t.Run("dolt sql -q in root cannot write to db_one", func(t *testing.T) {
-			cmd := rs.DoltCmd("sql", "-q", "create table db_one.vals (id int primary key)")
-			_, err := cmd.CombinedOutput()
-			require.Error(t, err)
-		})
-	})
-	t.Run("Given a running dolt sql process in db_one", func(t *testing.T) {
-		RunDoltSQLUntilEndOfTest(t, dbOne)
-
-		t.Run("Running server in root fails", func(t *testing.T) {
-			_ = MakeServer(t, rs, &driver.Server{
-				ErrorMatches: []string{
-					"locked by another dolt process",
-				},
-			})
-		})
-		t.Run("Running server in db_one fails", func(t *testing.T) {
-			_ = MakeServer(t, dbOne, &driver.Server{
-				ErrorMatches: []string{
-					"locked by another dolt process",
-				},
-			})
-		})
-		t.Run("Running server in db_two succeeds", func(t *testing.T) {
-			RunServerUntilEndOfTest(t, dbTwo, &driver.Server{})
-		})
-		t.Run("dolt sql -q in root succeeds", func(t *testing.T) {
-			cmd := rs.DoltCmd("sql", "-q", "show databases")
-			output, err := cmd.CombinedOutput()
-			outstr := string(output)
-			require.NoError(t, err)
-			require.Regexp(t, "db_one", outstr)
-			require.Regexp(t, "db_two", outstr)
-		})
-		t.Run("dolt sql -q in root can write to db_two", func(t *testing.T) {
-			cmd := rs.DoltCmd("sql", "-q", "create table db_two.another_vals (id int primary key)")
-			_, err := cmd.CombinedOutput()
-			require.NoError(t, err)
-		})
-		t.Run("dolt sql -q in root cannot write to db_one", func(t *testing.T) {
-			cmd := rs.DoltCmd("sql", "-q", "create table db_one.vals (id int primary key)")
-			_, err := cmd.CombinedOutput()
-			require.Error(t, err)
-		})
-	})
-	t.Run("With stale sql-server.lock file in root", func(t *testing.T) {
-		Setup := func(t *testing.T) {
-			path := filepath.Join(rs.Dir, ".dolt/sql-server.lock")
-			err := os.WriteFile(path, []byte("1:3306:this_is_not_a_real_secret"), 0600)
-			require.NoError(t, err)
-			t.Cleanup(func() { os.Remove(path) })
-		}
-		t.Run("sql-server can run in root", func(t *testing.T) {
-			Setup(t)
-			RunServerUntilEndOfTest(t, rs, &driver.Server{})
-		})
-		t.Run("sql-server can run in db_one", func(t *testing.T) {
-			Setup(t)
+		t.Run("With server running in db_one", func(t *testing.T) {
 			RunServerUntilEndOfTest(t, dbOne, &driver.Server{})
-		})
-		t.Run("sql can run in root", func(t *testing.T) {
-			Setup(t)
-			cmd := rs.DoltCmd("sql", "-q", "show databases")
-			output, err := cmd.CombinedOutput()
-			outstr := string(output)
-			require.NoError(t, err)
-			require.Regexp(t, "db_one", outstr)
-			require.Regexp(t, "db_two", outstr)
-		})
-		t.Run("sql can run in db_one", func(t *testing.T) {
-			Setup(t)
-			cmd := dbOne.DoltCmd("sql", "-q", "show databases")
-			output, err := cmd.CombinedOutput()
-			outstr := string(output)
-			require.NoError(t, err)
-			require.Regexp(t, "db_one", outstr)
-		})
-	})
-	t.Run("With malformed sql-server.lock file in root", func(t *testing.T) {
-		Setup := func(t *testing.T) {
-			path := filepath.Join(rs.Dir, ".dolt/sql-server.lock")
-			err := os.WriteFile(path, []byte("1:3306:this_is_not_a_real_secret:extra:fields:make:it:fail"), 0600)
-			require.NoError(t, err)
-			t.Cleanup(func() { os.Remove(path) })
-		}
-		t.Run("sql-server can run in root", func(t *testing.T) {
-			Setup(t)
-			RunServerUntilEndOfTest(t, rs, &driver.Server{})
-		})
-		t.Run("sql-server can run in db_one", func(t *testing.T) {
-			Setup(t)
-			RunServerUntilEndOfTest(t, rs, &driver.Server{})
-		})
-		t.Run("sql can run in root", func(t *testing.T) {
-			Setup(t)
-			cmd := rs.DoltCmd("sql", "-q", "show databases")
-			output, err := cmd.CombinedOutput()
-			outstr := string(output)
-			require.NoError(t, err)
-			require.Regexp(t, "db_one", outstr)
-			require.Regexp(t, "db_two", outstr)
-		})
-		t.Run("sql can run in db_one", func(t *testing.T) {
-			Setup(t)
-			cmd := dbOne.DoltCmd("sql", "-q", "show databases")
-			output, err := cmd.CombinedOutput()
-			outstr := string(output)
-			require.NoError(t, err)
-			require.Regexp(t, "db_one", outstr)
-		})
-		t.Run("with dolt sql running in db_one", func(t *testing.T) {
-			RunDoltSQLUntilEndOfTest(t, dbOne)
 
-			t.Run("dolt sql -q fails in db_one", func(t *testing.T) {
-				Setup(t)
-				cmd := dbOne.DoltCmd("sql", "-q", "show databases")
-				_, err = cmd.CombinedOutput()
+			t.Run("Running server in root fails", func(t *testing.T) {
+				_ = MakeServer(t, rs, &driver.Server{
+					ErrorMatches: []string{
+						"locked by another dolt process",
+					},
+				})
+			})
+			t.Run("Running server in db_two succeeds", func(t *testing.T) {
+				RunServerUntilEndOfTest(t, dbTwo, &driver.Server{
+					Args: []string{"--port", "3310"},
+					Port: 3310,
+				})
+			})
+			t.Run("dolt sql -q in root succeeds", func(t *testing.T) {
+				cmd := rs.DoltCmd("sql", "-q", "show databases")
+				output, err := cmd.CombinedOutput()
+				outstr := string(output)
+				require.NoError(t, err)
+				require.Regexp(t, "db_one", outstr)
+				require.Regexp(t, "db_two", outstr)
+			})
+			t.Run("dolt sql -q in root can write to db_two", func(t *testing.T) {
+				cmd := rs.DoltCmd("sql", "-q", "create table db_two.vals (id int primary key)")
+				_, err := cmd.CombinedOutput()
+				require.NoError(t, err)
+			})
+			t.Run("dolt sql -q in root cannot write to db_one", func(t *testing.T) {
+				cmd := rs.DoltCmd("sql", "-q", "create table db_one.vals (id int primary key)")
+				_, err := cmd.CombinedOutput()
 				require.Error(t, err)
 			})
-			t.Run("dolt sql -q succeeds in root", func(t *testing.T) {
+		})
+		t.Run("Given a running dolt sql process in root", func(t *testing.T) {
+			RunDoltSQLUntilEndOfTest(t, rs)
+
+			t.Run("Running server in root fails", func(t *testing.T) {
+				_ = MakeServer(t, rs, &driver.Server{
+					ErrorMatches: []string{
+						"locked by another dolt process",
+					},
+				})
+			})
+			t.Run("Running server in db_one fails", func(t *testing.T) {
+				_ = MakeServer(t, dbOne, &driver.Server{
+					ErrorMatches: []string{
+						"locked by another dolt process",
+					},
+				})
+			})
+			t.Run("dolt sql -q in root succeeds", func(t *testing.T) {
+				cmd := rs.DoltCmd("sql", "-q", "show databases")
+				output, err := cmd.CombinedOutput()
+				outstr := string(output)
+				require.NoError(t, err)
+				require.Regexp(t, "db_one", outstr)
+				require.Regexp(t, "db_two", outstr)
+			})
+			t.Run("dolt sql -q in root cannot write to db_one", func(t *testing.T) {
+				cmd := rs.DoltCmd("sql", "-q", "create table db_one.vals (id int primary key)")
+				_, err := cmd.CombinedOutput()
+				require.Error(t, err)
+			})
+		})
+		t.Run("Given a running dolt sql process in db_one", func(t *testing.T) {
+			RunDoltSQLUntilEndOfTest(t, dbOne)
+
+			t.Run("Running server in root fails", func(t *testing.T) {
+				_ = MakeServer(t, rs, &driver.Server{
+					ErrorMatches: []string{
+						"locked by another dolt process",
+					},
+				})
+			})
+			t.Run("Running server in db_one fails", func(t *testing.T) {
+				_ = MakeServer(t, dbOne, &driver.Server{
+					ErrorMatches: []string{
+						"locked by another dolt process",
+					},
+				})
+			})
+			t.Run("Running server in db_two succeeds", func(t *testing.T) {
+				RunServerUntilEndOfTest(t, dbTwo, &driver.Server{})
+			})
+			t.Run("dolt sql -q in root succeeds", func(t *testing.T) {
+				cmd := rs.DoltCmd("sql", "-q", "show databases")
+				output, err := cmd.CombinedOutput()
+				outstr := string(output)
+				require.NoError(t, err)
+				require.Regexp(t, "db_one", outstr)
+				require.Regexp(t, "db_two", outstr)
+			})
+			t.Run("dolt sql -q in root can write to db_two", func(t *testing.T) {
+				cmd := rs.DoltCmd("sql", "-q", "create table db_two.another_vals (id int primary key)")
+				_, err := cmd.CombinedOutput()
+				require.NoError(t, err)
+			})
+			t.Run("dolt sql -q in root cannot write to db_one", func(t *testing.T) {
+				cmd := rs.DoltCmd("sql", "-q", "create table db_one.vals (id int primary key)")
+				_, err := cmd.CombinedOutput()
+				require.Error(t, err)
+			})
+		})
+		t.Run("With stale sql-server.lock file in root", func(t *testing.T) {
+			Setup := func(t *testing.T) {
+				path := filepath.Join(rs.Dir, ".dolt/sql-server.lock")
+				err := os.WriteFile(path, []byte("1:3306:this_is_not_a_real_secret"), 0600)
+				require.NoError(t, err)
+				t.Cleanup(func() { os.Remove(path) })
+			}
+			t.Run("sql-server can run in root", func(t *testing.T) {
+				Setup(t)
+				RunServerUntilEndOfTest(t, rs, &driver.Server{})
+			})
+			t.Run("sql-server can run in db_one", func(t *testing.T) {
+				Setup(t)
+				RunServerUntilEndOfTest(t, dbOne, &driver.Server{})
+			})
+			t.Run("sql can run in root", func(t *testing.T) {
 				Setup(t)
 				cmd := rs.DoltCmd("sql", "-q", "show databases")
 				output, err := cmd.CombinedOutput()
-				require.NoError(t, err)
 				outstr := string(output)
+				require.NoError(t, err)
 				require.Regexp(t, "db_one", outstr)
 				require.Regexp(t, "db_two", outstr)
+			})
+			t.Run("sql can run in db_one", func(t *testing.T) {
+				Setup(t)
+				cmd := dbOne.DoltCmd("sql", "-q", "show databases")
+				output, err := cmd.CombinedOutput()
+				outstr := string(output)
+				require.NoError(t, err)
+				require.Regexp(t, "db_one", outstr)
+			})
+		})
+		t.Run("With malformed sql-server.lock file in root", func(t *testing.T) {
+			Setup := func(t *testing.T) {
+				path := filepath.Join(rs.Dir, ".dolt/sql-server.lock")
+				err := os.WriteFile(path, []byte("1:3306:this_is_not_a_real_secret:extra:fields:make:it:fail"), 0600)
+				require.NoError(t, err)
+				t.Cleanup(func() { os.Remove(path) })
+			}
+			t.Run("sql-server can run in root", func(t *testing.T) {
+				Setup(t)
+				RunServerUntilEndOfTest(t, rs, &driver.Server{})
+			})
+			t.Run("sql-server can run in db_one", func(t *testing.T) {
+				Setup(t)
+				RunServerUntilEndOfTest(t, rs, &driver.Server{})
+			})
+			t.Run("sql can run in root", func(t *testing.T) {
+				Setup(t)
+				cmd := rs.DoltCmd("sql", "-q", "show databases")
+				output, err := cmd.CombinedOutput()
+				outstr := string(output)
+				require.NoError(t, err)
+				require.Regexp(t, "db_one", outstr)
+				require.Regexp(t, "db_two", outstr)
+			})
+			t.Run("sql can run in db_one", func(t *testing.T) {
+				Setup(t)
+				cmd := dbOne.DoltCmd("sql", "-q", "show databases")
+				output, err := cmd.CombinedOutput()
+				outstr := string(output)
+				require.NoError(t, err)
+				require.Regexp(t, "db_one", outstr)
+			})
+			t.Run("with dolt sql running in db_one", func(t *testing.T) {
+				RunDoltSQLUntilEndOfTest(t, dbOne)
+
+				t.Run("dolt sql -q fails in db_one", func(t *testing.T) {
+					Setup(t)
+					cmd := dbOne.DoltCmd("sql", "-q", "show databases")
+					_, err = cmd.CombinedOutput()
+					require.Error(t, err)
+				})
+				t.Run("dolt sql -q succeeds in root", func(t *testing.T) {
+					Setup(t)
+					cmd := rs.DoltCmd("sql", "-q", "show databases")
+					output, err := cmd.CombinedOutput()
+					require.NoError(t, err)
+					outstr := string(output)
+					require.Regexp(t, "db_one", outstr)
+					require.Regexp(t, "db_two", outstr)
+				})
+			})
+		})
+	})
+	t.Run("With Empty RepoStore", func(t *testing.T) {
+		u, err := driver.NewDoltUser()
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			u.Cleanup()
+		})
+
+		rs, err := u.MakeRepoStore()
+		require.NoError(t, err)
+
+		// TODO: This is strange behavior which the current implementation allows.
+		// If the top-level directory is empty when both servers are
+		// started, they can both run against it. Only one of their
+		// credential files will win the write.
+		t.Run("Can Run Two Servers At Once", func(t *testing.T) {
+			RunServerUntilEndOfTest(t, rs, &driver.Server{})
+			RunServerUntilEndOfTest(t, rs, &driver.Server{
+				Args: []string{"--port", "3309"},
+				Port: 3309,
 			})
 		})
 	})

--- a/integration-tests/go-sql-server-driver/sqlserver_lock_test.go
+++ b/integration-tests/go-sql-server-driver/sqlserver_lock_test.go
@@ -1,0 +1,344 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	driver "github.com/dolthub/dolt/go/libraries/doltcore/dtestutils/sql_server_driver"
+)
+
+func TestSQLServerLockFile(t *testing.T) {
+	u, err := driver.NewDoltUser()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		u.Cleanup()
+	})
+
+	rs, err := u.MakeRepoStore()
+	require.NoError(t, err)
+	dbOne, err := rs.MakeRepo("db_one")
+	require.NoError(t, err)
+	dbTwo, err := rs.MakeRepo("db_two")
+	require.NoError(t, err)
+
+	t.Run("With server running in root", func(t *testing.T) {
+		RunServerUntilEndOfTest(t, rs, &driver.Server{})
+
+		t.Run("sql-server.lock file exists", func(t *testing.T) {
+			location := filepath.Join(rs.Dir, ".dolt/sql-server.lock")
+			f, err := os.Open(location)
+			require.NoError(t, err)
+			require.NoError(t, f.Close())
+		})
+		t.Run("Running again in root fails", func(t *testing.T) {
+			_ = MakeServer(t, rs, &driver.Server{
+				ErrorMatches: []string{
+					"locked by another dolt process",
+				},
+			})
+		})
+		t.Run("Running in db_one fails", func(t *testing.T) {
+			_ = MakeServer(t, dbOne, &driver.Server{
+				ErrorMatches: []string{
+					"locked by another dolt process",
+				},
+			})
+		})
+		t.Run("Running dolt sql -q in /server connects to server", func(t *testing.T) {
+			cmd := rs.DoltCmd("sql", "-q", "show databases")
+			output, err := cmd.CombinedOutput()
+			outstr := string(output)
+			require.NoError(t, err)
+			require.Regexp(t, "db_one", outstr)
+			require.Regexp(t, "db_two", outstr)
+		})
+		t.Run("Running dolt sql -q in /server/db_two connects to server on db_two", func(t *testing.T) {
+			cmd := dbTwo.DoltCmd("sql", "-q", "select database()")
+			output, err := cmd.CombinedOutput()
+			outstr := string(output)
+			require.NoError(t, err)
+			require.Regexp(t, "db_two", outstr)
+		})
+		t.Run("Running dolt sql -q in /server/db_two/.dolt/noms connects to server on no database", func(t *testing.T) {
+			cmd := dbTwo.DoltCmd("sql", "-q", "select database()")
+			cmd.Dir = filepath.Join(cmd.Dir, ".dolt/noms")
+			output, err := cmd.CombinedOutput()
+			outstr := string(output)
+			require.NoError(t, err)
+			require.Regexp(t, "NULL", outstr)
+
+			cmd = dbTwo.DoltCmd("sql", "-q", "show databases")
+			cmd.Dir = filepath.Join(cmd.Dir, ".dolt/noms")
+			output, err = cmd.CombinedOutput()
+			outstr = string(output)
+			require.NoError(t, err)
+			require.Regexp(t, "db_one", outstr)
+			require.Regexp(t, "db_two", outstr)
+		})
+	})
+	t.Run("sql-server.lock in root no longer exists", func(t *testing.T) {
+		location := filepath.Join(rs.Dir, ".dolt/sql-server.lock")
+		f, err := os.Open(location)
+		if f != nil {
+			defer f.Close()
+		}
+		require.ErrorIs(t, err, fs.ErrNotExist)
+	})
+	t.Run("With server running in db_one", func(t *testing.T) {
+		RunServerUntilEndOfTest(t, dbOne, &driver.Server{})
+
+		t.Run("Running server in root fails", func(t *testing.T) {
+			_ = MakeServer(t, rs, &driver.Server{
+				ErrorMatches: []string{
+					"locked by another dolt process",
+				},
+			})
+		})
+		t.Run("Running server in db_two succeeds", func(t *testing.T) {
+			RunServerUntilEndOfTest(t, dbTwo, &driver.Server{
+				Args: []string{"--port", "3310"},
+				Port: 3310,
+			})
+		})
+		t.Run("dolt sql -q in root succeeds", func(t *testing.T) {
+			cmd := rs.DoltCmd("sql", "-q", "show databases")
+			output, err := cmd.CombinedOutput()
+			outstr := string(output)
+			require.NoError(t, err)
+			require.Regexp(t, "db_one", outstr)
+			require.Regexp(t, "db_two", outstr)
+		})
+		t.Run("dolt sql -q in root can write to db_two", func(t *testing.T) {
+			cmd := rs.DoltCmd("sql", "-q", "create table db_two.vals (id int primary key)")
+			_, err := cmd.CombinedOutput()
+			require.NoError(t, err)
+		})
+		t.Run("dolt sql -q in root cannot write to db_one", func(t *testing.T) {
+			cmd := rs.DoltCmd("sql", "-q", "create table db_one.vals (id int primary key)")
+			_, err := cmd.CombinedOutput()
+			require.Error(t, err)
+		})
+	})
+	t.Run("Given a running dolt sql process in root", func(t *testing.T) {
+		RunDoltSQLUntilEndOfTest(t, rs)
+
+		t.Run("Running server in root fails", func(t *testing.T) {
+			_ = MakeServer(t, rs, &driver.Server{
+				ErrorMatches: []string{
+					"locked by another dolt process",
+				},
+			})
+		})
+		t.Run("Running server in db_one fails", func(t *testing.T) {
+			_ = MakeServer(t, dbOne, &driver.Server{
+				ErrorMatches: []string{
+					"locked by another dolt process",
+				},
+			})
+		})
+		t.Run("dolt sql -q in root succeeds", func(t *testing.T) {
+			cmd := rs.DoltCmd("sql", "-q", "show databases")
+			output, err := cmd.CombinedOutput()
+			outstr := string(output)
+			require.NoError(t, err)
+			require.Regexp(t, "db_one", outstr)
+			require.Regexp(t, "db_two", outstr)
+		})
+		t.Run("dolt sql -q in root cannot write to db_one", func(t *testing.T) {
+			cmd := rs.DoltCmd("sql", "-q", "create table db_one.vals (id int primary key)")
+			_, err := cmd.CombinedOutput()
+			require.Error(t, err)
+		})
+	})
+	t.Run("Given a running dolt sql process in db_one", func(t *testing.T) {
+		RunDoltSQLUntilEndOfTest(t, dbOne)
+
+		t.Run("Running server in root fails", func(t *testing.T) {
+			_ = MakeServer(t, rs, &driver.Server{
+				ErrorMatches: []string{
+					"locked by another dolt process",
+				},
+			})
+		})
+		t.Run("Running server in db_one fails", func(t *testing.T) {
+			_ = MakeServer(t, dbOne, &driver.Server{
+				ErrorMatches: []string{
+					"locked by another dolt process",
+				},
+			})
+		})
+		t.Run("Running server in db_two succeeds", func(t *testing.T) {
+			RunServerUntilEndOfTest(t, dbTwo, &driver.Server{})
+		})
+		t.Run("dolt sql -q in root succeeds", func(t *testing.T) {
+			cmd := rs.DoltCmd("sql", "-q", "show databases")
+			output, err := cmd.CombinedOutput()
+			outstr := string(output)
+			require.NoError(t, err)
+			require.Regexp(t, "db_one", outstr)
+			require.Regexp(t, "db_two", outstr)
+		})
+		t.Run("dolt sql -q in root can write to db_two", func(t *testing.T) {
+			cmd := rs.DoltCmd("sql", "-q", "create table db_two.another_vals (id int primary key)")
+			_, err := cmd.CombinedOutput()
+			require.NoError(t, err)
+		})
+		t.Run("dolt sql -q in root cannot write to db_one", func(t *testing.T) {
+			cmd := rs.DoltCmd("sql", "-q", "create table db_one.vals (id int primary key)")
+			_, err := cmd.CombinedOutput()
+			require.Error(t, err)
+		})
+	})
+	t.Run("With stale sql-server.lock file in root", func(t *testing.T) {
+		Setup := func(t *testing.T) {
+			path := filepath.Join(rs.Dir, ".dolt/sql-server.lock")
+			err := os.WriteFile(path, []byte("1:3306:this_is_not_a_real_secret"), 0600)
+			require.NoError(t, err)
+			t.Cleanup(func() { os.Remove(path) })
+		}
+		t.Run("sql-server can run in root", func(t *testing.T) {
+			Setup(t)
+			RunServerUntilEndOfTest(t, rs, &driver.Server{})
+		})
+		t.Run("sql-server can run in db_one", func(t *testing.T) {
+			Setup(t)
+			RunServerUntilEndOfTest(t, dbOne, &driver.Server{})
+		})
+		t.Run("sql can run in root", func(t *testing.T) {
+			Setup(t)
+			cmd := rs.DoltCmd("sql", "-q", "show databases")
+			output, err := cmd.CombinedOutput()
+			outstr := string(output)
+			require.NoError(t, err)
+			require.Regexp(t, "db_one", outstr)
+			require.Regexp(t, "db_two", outstr)
+		})
+		t.Run("sql can run in db_one", func(t *testing.T) {
+			Setup(t)
+			cmd := dbOne.DoltCmd("sql", "-q", "show databases")
+			output, err := cmd.CombinedOutput()
+			outstr := string(output)
+			require.NoError(t, err)
+			require.Regexp(t, "db_one", outstr)
+		})
+	})
+	t.Run("With malformed sql-server.lock file in root", func(t *testing.T) {
+		Setup := func(t *testing.T) {
+			path := filepath.Join(rs.Dir, ".dolt/sql-server.lock")
+			err := os.WriteFile(path, []byte("1:3306:this_is_not_a_real_secret:extra:fields:make:it:fail"), 0600)
+			require.NoError(t, err)
+			t.Cleanup(func() { os.Remove(path) })
+		}
+		t.Run("sql-server can run in root", func(t *testing.T) {
+			Setup(t)
+			RunServerUntilEndOfTest(t, rs, &driver.Server{})
+		})
+		t.Run("sql-server can run in db_one", func(t *testing.T) {
+			Setup(t)
+			RunServerUntilEndOfTest(t, rs, &driver.Server{})
+		})
+		t.Run("sql can run in root", func(t *testing.T) {
+			Setup(t)
+			cmd := rs.DoltCmd("sql", "-q", "show databases")
+			output, err := cmd.CombinedOutput()
+			outstr := string(output)
+			require.NoError(t, err)
+			require.Regexp(t, "db_one", outstr)
+			require.Regexp(t, "db_two", outstr)
+		})
+		t.Run("sql can run in db_one", func(t *testing.T) {
+			Setup(t)
+			cmd := dbOne.DoltCmd("sql", "-q", "show databases")
+			output, err := cmd.CombinedOutput()
+			outstr := string(output)
+			require.NoError(t, err)
+			require.Regexp(t, "db_one", outstr)
+		})
+		t.Run("with dolt sql running in db_one", func(t *testing.T) {
+			RunDoltSQLUntilEndOfTest(t, dbOne)
+
+			t.Run("dolt sql -q fails in db_one", func(t *testing.T) {
+				Setup(t)
+				cmd := dbOne.DoltCmd("sql", "-q", "show databases")
+				_, err = cmd.CombinedOutput()
+				require.Error(t, err)
+			})
+			t.Run("dolt sql -q succeeds in root", func(t *testing.T) {
+				Setup(t)
+				cmd := rs.DoltCmd("sql", "-q", "show databases")
+				output, err := cmd.CombinedOutput()
+				require.NoError(t, err)
+				outstr := string(output)
+				require.Regexp(t, "db_one", outstr)
+				require.Regexp(t, "db_two", outstr)
+			})
+		})
+	})
+}
+
+func RunDoltSQLUntilEndOfTest(t *testing.T, dc driver.DoltCmdable) {
+	// Spawn `dolt sql`, capturing output.
+	sqlCmd := dc.DoltCmd("sql")
+	in, err := sqlCmd.StdinPipe()
+	require.NoError(t, err)
+	out, err := sqlCmd.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, sqlCmd.Start())
+
+	// Send a query so we know it is fully initialized.
+	go func() {
+		io.WriteString(in, "show databases;\n")
+	}()
+
+	// Read lines of the response until we see an empty line.
+	scanner := bufio.NewScanner(out)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			break
+		}
+	}
+
+	// Register cleanup. We close stdin at the of the function and assert
+	// that `dolt sql` exited with exit code 0.
+	go func() {
+		io.Copy(io.Discard, out)
+	}()
+	t.Cleanup(func() {
+		assert.NoError(t, in.Close())
+		assert.NoError(t, sqlCmd.Wait())
+	})
+}
+
+// Run a server until the end of the test. Because we do not return the server
+// for doing things like making connections to it, this is only useful for
+// for asserting the behavior of other dolt commands which interact with the
+// server.
+func RunServerUntilEndOfTest(t *testing.T, dc driver.DoltCmdable, s *driver.Server) {
+	server := MakeServer(t, dc, s)
+	require.NotNil(t, server)
+	db, err := server.DB(driver.Connection{User: "root"})
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+}


### PR DESCRIPTION
Previously sql-server.lock served two purposes: (1) attempt to keep two sql-server's from running against a Dolt database at the same time and (2) allow the Dolt binary to work seamlessly as a client when it was run against a Dolt database where a sql-server was already running locally. The previous implementation involved writing process state into multiple directories across the disk and checking that filesystem state against currently running processes in an attempt to choose the correct behavior for a given Dolt invocation.

This changes the sql-server.lock file to only be responsible for discovery in the second case. The first case is handled by querying the storage layer for any Dolt databases which will be served as part of a running sql-server. In order for the sql-server to start successfully, it must have exclusive write access to every Dolt database it will be serving. `dolt sql-server` is changed to only write the sql-server.lock file into the top-level data_dir of the running server. In exchange, all other `dolt` invocations which are looking for a running server are changed to look in successive parents of their data_dir in an attempt to find connection details for the running server.

The `--ignore-lock-file` option is deprecated, but still successfully parsed and ignored to avoid needlessly breaking existing users.