### PR TITLE
[no-release-notes] integration-tests/bats: ls.bats: Fix a flakey failure where an unlucky hash could cause a negative assertion to fail.

### DIFF
--- a/integration-tests/bats/ls.bats
+++ b/integration-tests/bats/ls.bats
@@ -3,10 +3,10 @@ load $BATS_TEST_DIRNAME/helper/common.bash
 
 setup() {
     setup_common
-    dolt sql -q "create table t1 (pk int PRIMARY KEY)"
-    dolt commit -Am "create table t1"
-    dolt sql -q "create table t2 (pk int PRIMARY KEY)"
-    dolt commit -Am "create table t2"
+    dolt sql -q "create table table_one (pk int PRIMARY KEY)"
+    dolt commit -Am "create table table_one"
+    dolt sql -q "create table table_two (pk int PRIMARY KEY)"
+    dolt commit -Am "create table table_two"
 }
 
 teardown() {
@@ -18,42 +18,42 @@ teardown() {
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" -eq 3 ]
     [[ "$output" =~ "Tables in working set:" ]] || false
-    [[ "$output" =~ "t1" ]] || false
-    [[ "$output" =~ "t2" ]] || false
+    [[ "$output" =~ "table_one" ]] || false
+    [[ "$output" =~ "table_two" ]] || false
 }
 
 @test "ls: ls includes unstaged table" {
-    dolt sql -q "create table t3 (pk int PRIMARY KEY)"
+    dolt sql -q "create table table_three (pk int PRIMARY KEY)"
     run dolt ls
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" -eq 4 ]
     [[ "$output" =~ "Tables in working set:" ]] || false
-    [[ "$output" =~ "t1" ]] || false
-    [[ "$output" =~ "t2" ]] || false
-    [[ "$output" =~ "t3" ]] || false
+    [[ "$output" =~ "table_one" ]] || false
+    [[ "$output" =~ "table_two" ]] || false
+    [[ "$output" =~ "table_three" ]] || false
 }
 
 @test "ls: ls includes staged table" {
-    dolt sql -q "create table t3 (pk int PRIMARY KEY)"
+    dolt sql -q "create table table_three (pk int PRIMARY KEY)"
     dolt add .
     run dolt ls
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" -eq 4 ]
     [[ "$output" =~ "Tables in working set:" ]] || false
-    [[ "$output" =~ "t1" ]] || false
-    [[ "$output" =~ "t2" ]] || false
-    [[ "$output" =~ "t3" ]] || false
+    [[ "$output" =~ "table_one" ]] || false
+    [[ "$output" =~ "table_two" ]] || false
+    [[ "$output" =~ "table_three" ]] || false
 }
 
 @test "ls: --verbose shows row count" {
-    dolt sql -q "insert into t1 values (1), (2), (3)"
+    dolt sql -q "insert into table_one values (1), (2), (3)"
 
     run dolt ls --verbose
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Tables in working set:" ]] || false
-    [[ "$output" =~ "t1" ]] || false
+    [[ "$output" =~ "table_one" ]] || false
     [[ "$output" =~ "3 rows" ]] || false
-    [[ "$output" =~ "t2" ]] || false
+    [[ "$output" =~ "table_two" ]] || false
     [[ "$output" =~ "0 rows" ]] || false
 }
 
@@ -71,24 +71,24 @@ teardown() {
     [[ "$output" =~ "dolt_remotes" ]] || false
     [[ "$output" =~ "dolt_branches" ]] || false
     [[ "$output" =~ "dolt_remote_branches" ]] || false
-    [[ "$output" =~ "dolt_constraint_violations_t1" ]] || false
-    [[ "$output" =~ "dolt_history_t1" ]] || false
-    [[ "$output" =~ "dolt_conflicts_t1" ]] || false
-    [[ "$output" =~ "dolt_diff_t1" ]] || false
-    [[ "$output" =~ "dolt_commit_diff_t1" ]] || false
-    [[ "$output" =~ "dolt_constraint_violations_t2" ]] || false
-    [[ "$output" =~ "dolt_history_t2" ]] || false
-    [[ "$output" =~ "dolt_conflicts_t2" ]] || false
-    [[ "$output" =~ "dolt_diff_t2" ]] || false
-    [[ "$output" =~ "dolt_commit_diff_t2" ]] || false
+    [[ "$output" =~ "dolt_constraint_violations_table_one" ]] || false
+    [[ "$output" =~ "dolt_history_table_one" ]] || false
+    [[ "$output" =~ "dolt_conflicts_table_one" ]] || false
+    [[ "$output" =~ "dolt_diff_table_one" ]] || false
+    [[ "$output" =~ "dolt_commit_diff_table_one" ]] || false
+    [[ "$output" =~ "dolt_constraint_violations_table_two" ]] || false
+    [[ "$output" =~ "dolt_history_table_two" ]] || false
+    [[ "$output" =~ "dolt_conflicts_table_two" ]] || false
+    [[ "$output" =~ "dolt_diff_table_two" ]] || false
+    [[ "$output" =~ "dolt_commit_diff_table_two" ]] || false
 }
 
 @test "ls: --all shows tables in working set and system tables" {
     run dolt ls --all
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Tables in working set:" ]] || false
-    [[ "$output" =~ "t1" ]] || false
-    [[ "$output" =~ "t2" ]] || false
+    [[ "$output" =~ "table_one" ]] || false
+    [[ "$output" =~ "table_two" ]] || false
     [[ "$output" =~ "System tables:" ]] || false
     [[ "$output" =~ "dolt_status" ]] || false
     [[ "$output" =~ "dolt_commits" ]] || false
@@ -99,27 +99,27 @@ teardown() {
     [[ "$output" =~ "dolt_remotes" ]] || false
     [[ "$output" =~ "dolt_branches" ]] || false
     [[ "$output" =~ "dolt_remote_branches" ]] || false
-    [[ "$output" =~ "dolt_constraint_violations_t1" ]] || false
-    [[ "$output" =~ "dolt_history_t1" ]] || false
-    [[ "$output" =~ "dolt_conflicts_t1" ]] || false
-    [[ "$output" =~ "dolt_diff_t1" ]] || false
-    [[ "$output" =~ "dolt_commit_diff_t1" ]] || false
-    [[ "$output" =~ "dolt_constraint_violations_t2" ]] || false
-    [[ "$output" =~ "dolt_history_t2" ]] || false
-    [[ "$output" =~ "dolt_conflicts_t2" ]] || false
-    [[ "$output" =~ "dolt_diff_t2" ]] || false
-    [[ "$output" =~ "dolt_commit_diff_t2" ]] || false
+    [[ "$output" =~ "dolt_constraint_violations_table_one" ]] || false
+    [[ "$output" =~ "dolt_history_table_one" ]] || false
+    [[ "$output" =~ "dolt_conflicts_table_one" ]] || false
+    [[ "$output" =~ "dolt_diff_table_one" ]] || false
+    [[ "$output" =~ "dolt_commit_diff_table_one" ]] || false
+    [[ "$output" =~ "dolt_constraint_violations_table_two" ]] || false
+    [[ "$output" =~ "dolt_history_table_two" ]] || false
+    [[ "$output" =~ "dolt_conflicts_table_two" ]] || false
+    [[ "$output" =~ "dolt_diff_table_two" ]] || false
+    [[ "$output" =~ "dolt_commit_diff_table_two" ]] || false
 }
 
 @test "ls: --all and --verbose shows row count for tables in working set" {
-    dolt sql -q "insert into t1 values (1), (2), (3)"
+    dolt sql -q "insert into table_one values (1), (2), (3)"
 
     run dolt ls --all --verbose
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Tables in working set:" ]] || false
-    [[ "$output" =~ "t1" ]] || false
+    [[ "$output" =~ "table_one" ]] || false
     [[ "$output" =~ "3 rows" ]] || false
-    [[ "$output" =~ "t2" ]] || false
+    [[ "$output" =~ "table_two" ]] || false
     [[ "$output" =~ "0 rows" ]] || false
     [[ "$output" =~ "System tables:" ]] || false
     [[ "$output" =~ "dolt_status" ]] || false
@@ -131,16 +131,16 @@ teardown() {
     [[ "$output" =~ "dolt_remotes" ]] || false
     [[ "$output" =~ "dolt_branches" ]] || false
     [[ "$output" =~ "dolt_remote_branches" ]] || false
-    [[ "$output" =~ "dolt_constraint_violations_t1" ]] || false
-    [[ "$output" =~ "dolt_history_t1" ]] || false
-    [[ "$output" =~ "dolt_conflicts_t1" ]] || false
-    [[ "$output" =~ "dolt_diff_t1" ]] || false
-    [[ "$output" =~ "dolt_commit_diff_t1" ]] || false
-    [[ "$output" =~ "dolt_constraint_violations_t2" ]] || false
-    [[ "$output" =~ "dolt_history_t2" ]] || false
-    [[ "$output" =~ "dolt_conflicts_t2" ]] || false
-    [[ "$output" =~ "dolt_diff_t2" ]] || false
-    [[ "$output" =~ "dolt_commit_diff_t2" ]] || false
+    [[ "$output" =~ "dolt_constraint_violations_table_one" ]] || false
+    [[ "$output" =~ "dolt_history_table_one" ]] || false
+    [[ "$output" =~ "dolt_conflicts_table_one" ]] || false
+    [[ "$output" =~ "dolt_diff_table_one" ]] || false
+    [[ "$output" =~ "dolt_commit_diff_table_one" ]] || false
+    [[ "$output" =~ "dolt_constraint_violations_table_two" ]] || false
+    [[ "$output" =~ "dolt_history_table_two" ]] || false
+    [[ "$output" =~ "dolt_conflicts_table_two" ]] || false
+    [[ "$output" =~ "dolt_diff_table_two" ]] || false
+    [[ "$output" =~ "dolt_commit_diff_table_two" ]] || false
 }
 
 @test "ls: --system and --all are mutually exclusive" {
@@ -153,33 +153,33 @@ teardown() {
     run dolt ls HEAD
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Tables in " ]] || false    # Tables in [hash]:
-    [[ "$output" =~ "t1" ]] || false
-    [[ "$output" =~ "t2" ]] || false
+    [[ "$output" =~ "table_one" ]] || false
+    [[ "$output" =~ "table_two" ]] || false
 
     run dolt ls HEAD~1
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Tables in " ]] || false    # Tables in [hash]:
-    [[ "$output" =~ "t1" ]] || false
-    ! [[ "$output" =~ "t2" ]] || false
+    [[ "$output" =~ "table_one" ]] || false
+    ! [[ "$output" =~ "table_two" ]] || false
 }
 
 @test "ls: ls with branch" {
     dolt checkout -b branch1
-    dolt sql -q "create table t3 (pk int primary key)"
-    dolt commit -Am "create table t3"
+    dolt sql -q "create table table_three (pk int primary key)"
+    dolt commit -Am "create table table_three"
     dolt checkout main
 
     run dolt ls branch1
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Tables in " ]] || false    # Tables in [hash]:
-    [[ "$output" =~ "t1" ]] || false
-    [[ "$output" =~ "t2" ]] || false
-    [[ "$output" =~ "t3" ]] || false
+    [[ "$output" =~ "table_one" ]] || false
+    [[ "$output" =~ "table_two" ]] || false
+    [[ "$output" =~ "table_three" ]] || false
 }
 
 @test "ls: no tables in working set" {
-    dolt sql -q "drop table t1"
-    dolt sql -q "drop table t2"
+    dolt sql -q "drop table table_one"
+    dolt sql -q "drop table table_two"
 
     run dolt ls
     [ "$status" -eq 0 ]


### PR DESCRIPTION
`ls.bats` was using test table names like `t1` and `t2` and making assertions against the output of `dolt ls`. But the output of `dolt ls` also sometimes includes a commit hash, which can itself contain these strings.

Change it so that we use names which will never appear in a commit hash.