### PR TITLE
migrate `dolt gc` to use sql queries

### DIFF
--- a/go/cmd/dolt/commands/gc.go
+++ b/go/cmd/dolt/commands/gc.go
@@ -33,9 +33,7 @@ var gcDocs = cli.CommandDocumentationContent{
 	ShortDesc: "Cleans up unreferenced data from the repository.",
 	LongDesc: `Searches the repository for data that is no longer referenced and no longer needed.
 
-If the {{.EmphasisLeft}}--shallow{{.EmphasisRight}} flag is supplied, a faster but less thorough garbage collection will be performed.
-
-{{.EmphasisLeft}}dolt gc{{.EmphasisRight}} won't work if there is a running server. Use {{.EmphasisLeft}}dolt sql -q 'call dolt_gc()'{{.EmphasisRight}} instead.`,
+If the {{.EmphasisLeft}}--shallow{{.EmphasisRight}} flag is supplied, a faster but less thorough garbage collection will be performed.`,
 	Synopsis: []string{
 		"[--shallow]",
 	},

--- a/go/cmd/dolt/commands/gc.go
+++ b/go/cmd/dolt/commands/gc.go
@@ -16,9 +16,6 @@ package commands
 
 import (
 	"context"
-	"errors"
-
-	"github.com/fatih/color"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
@@ -82,48 +79,39 @@ func (cmd GarbageCollectionCmd) EventType() eventsapi.ClientEventType {
 // Version displays the version of the running dolt client
 // Exec executes the command
 func (cmd GarbageCollectionCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
-	var verr errhand.VerboseError
-
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, gcDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
-	// We assert this here simply because the implementation of GC can
-	// delay actually trying to write to the chunk store for a long time
-	// after doing a lot or work. It's better to fail early.
-	if dEnv.IsAccessModeReadOnly() {
-		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(env.ErrDatabaseIsLocked), help)
+	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	if err != nil {
+		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+	}
+	if closeFunc != nil {
+		defer closeFunc()
 	}
 
-	var err error
+	query, err := constructDoltGCQuery(apr)
+	if err != nil {
+		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+	}
+
+	_, _, err = queryist.Query(sqlCtx, query)
+	if err != nil && err != chunks.ErrNothingToCollect {
+		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+	}
+
+	return HandleVErrAndExitCode(nil, usage)
+}
+
+// constructDoltGCQuery generates the sql query necessary to call DOLT_GC()
+func constructDoltGCQuery(apr *argparser.ArgParseResults) (string, error) {
+	query := "call DOLT_GC("
 	if apr.Contains(cli.ShallowFlag) {
-		err = dEnv.DoltDB.ShallowGC(ctx)
-		if err != nil {
-			if err == chunks.ErrUnsupportedOperation {
-				verr = errhand.BuildDError("this database does not support shallow garbage collection").Build()
-				return HandleVErrAndExitCode(verr, usage)
-			}
-			verr = errhand.BuildDError("an error occurred during garbage collection").AddCause(err).Build()
-		}
-	} else {
-		// full gc
-		dEnv, err = MaybeMigrateEnv(ctx, dEnv)
-		if err != nil {
-			verr = errhand.BuildDError("could not load manifest for gc").AddCause(err).Build()
-			return HandleVErrAndExitCode(verr, usage)
-		}
-
-		err = dEnv.DoltDB.GC(ctx, nil)
-		if err != nil {
-			if errors.Is(err, chunks.ErrNothingToCollect) {
-				cli.PrintErrln(color.YellowString("Nothing to collect."))
-			} else {
-				verr = errhand.BuildDError("an error occurred during garbage collection").AddCause(err).Build()
-			}
-		}
+		query += "'--shallow'"
 	}
-
-	return HandleVErrAndExitCode(verr, usage)
+	query += ")"
+	return query, nil
 }
 
 func MaybeMigrateEnv(ctx context.Context, dEnv *env.DoltEnv) (*env.DoltEnv, error) {

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -139,7 +139,6 @@ var commandsWithoutCliCtx = []cli.Command{
 	commands.MigrateCmd{},
 	indexcmds.Commands,
 	commands.ReadTablesCmd{},
-	commands.GarbageCollectionCmd{},
 	commands.FilterBranchCmd{},
 	commands.RootsCmd{},
 	commands.VersionCmd{VersionStr: Version},

--- a/integration-tests/bats/helper/local-remote.bash
+++ b/integration-tests/bats/helper/local-remote.bash
@@ -135,7 +135,6 @@ SKIP_SERVER_TESTS=$(cat <<-EOM
 ~cli-hosted.bats~
 ~profile.bats~
 ~ls.bats~
-~reflog.bats~
 EOM
 )
 

--- a/integration-tests/bats/reflog.bats
+++ b/integration-tests/bats/reflog.bats
@@ -190,7 +190,12 @@ SQL
 
     run dolt reflog
     [ "$status" -eq 0 ]
-    [ "${#lines[@]}" -eq 0 ]
+    if [ "$SQL_ENGINE" = "remote-engine" ]; then
+      [ "${#lines[@]}" -eq 1 ]
+      [[ "$output" =~ "Initialize data repository" ]] || false
+    else
+      [ "${#lines[@]}" -eq 0 ]
+    fi
 }
 
 @test "reflog: garbage collection with newgen data" {
@@ -219,7 +224,12 @@ SQL
 
     run dolt reflog main
     [ "$status" -eq 0 ]
-    [ "${#lines[@]}" -eq 0 ]
+    if [ "$SQL_ENGINE" = "remote-engine" ]; then
+      [ "${#lines[@]}" -eq 1 ]
+      [[ "$output" =~ "inserting row 2" ]] || false
+    else
+      [ "${#lines[@]}" -eq 0 ]
+    fi
 }
 
 @test "reflog: too many arguments given" {

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -1294,3 +1294,47 @@ SQL
 
     [[ "$localOutput" == "$remoteOutput" ]] || false
 }
+
+@test "sql-local-remote: verify dolt gc behavior" {
+    cd altDB
+    dolt sql <<SQL
+CREATE TABLE test (pk int PRIMARY KEY);
+INSERT INTO test VALUES
+    (1),(2),(3),(4),(5);
+SQL
+    run dolt sql -q 'select count(*) from test' -r csv
+    [ "$status" -eq "0" ]
+    [[ "$output" =~ "5" ]] || false
+
+    run dolt --verbose-engine-setup gc
+    [ $status -eq 0 ]
+    [[ "$output" =~ "starting local mode" ]] || false
+
+    run dolt sql -q 'select count(*) from test' -r csv
+    [ "$status" -eq "0" ]
+    [[ "$output" =~ "5" ]] || false
+
+    start_sql_server altDB
+    dolt sql <<SQL
+CREATE TABLE test2 (pk int PRIMARY KEY);
+INSERT INTO test2 VALUES
+    (1),(2),(3),(4),(5);
+SQL
+    run dolt sql -q 'select count(*) from test' -r csv
+    [ "$status" -eq "0" ]
+    [[ "$output" =~ "5" ]] || false
+    run dolt sql -q 'select count(*) from test2' -r csv
+    [ "$status" -eq "0" ]
+    [[ "$output" =~ "5" ]] || false
+
+    run dolt --verbose-engine-setup gc
+    [ $status -eq 0 ]
+    [[ "$output" =~ "starting remote mode" ]] || false
+
+    run dolt sql -q 'select count(*) from test' -r csv
+    [ "$status" -eq "0" ]
+    [[ "$output" =~ "5" ]] || false
+    run dolt sql -q 'select count(*) from test2' -r csv
+    [ "$status" -eq "0" ]
+    [[ "$output" =~ "5" ]] || false
+}


### PR DESCRIPTION
This change updates `dolt gc` to use the appropriate sql engine to generate results.

Related: https://github.com/dolthub/dolt/issues/3922