### PR TITLE
fix inf loop for creds search on windows

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/creds.go
+++ b/go/cmd/dolt/commands/sqlserver/creds.go
@@ -96,7 +96,7 @@ func FindAndLoadLocalCreds(fs filesys.Filesys) (creds *LocalCreds, err error) {
 	if err != nil {
 		return nil, err
 	}
-	for root != "" && root[len(root)-1] != '/' {
+	for root != "" && root[len(root)-1] != filepath.Separator {
 		creds, err := LoadLocalCreds(fs)
 		if err == nil {
 			return creds, err


### PR DESCRIPTION
There was an infinite loop for `dolt init` and `dolt sql` when there isn't a `.dolt` directory in current directory or any children directory. This issue was specific to windows, because we were only checking for `/` and not `\`.