### PR TITLE
Allow automatic merging in the presence of collation changes.

### DIFF
--- a/go/libraries/doltcore/merge/schema_merge_test.go
+++ b/go/libraries/doltcore/merge/schema_merge_test.go
@@ -16,6 +16,7 @@ package merge_test
 
 import (
 	"context"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
 	"testing"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -50,13 +51,14 @@ type schemaMergeTest struct {
 }
 
 type dataTest struct {
-	name         string
-	ancestor     []sql.Row
-	left, right  []sql.Row
-	merged       []sql.Row
-	dataConflict bool
-	skip         bool
-	skipFlip     bool
+	name                 string
+	ancestor             []sql.Row
+	left, right          []sql.Row
+	merged               []sql.Row
+	constraintViolations []constraintViolation
+	dataConflict         bool
+	skip                 bool
+	skipFlip             bool
 }
 
 type table struct {
@@ -77,6 +79,9 @@ func TestSchemaMerge(t *testing.T) {
 	})
 	t.Run("column default tests", func(t *testing.T) {
 		testSchemaMerge(t, columnDefaultTests)
+	})
+	t.Run("collation tests", func(t *testing.T) {
+		testSchemaMerge(t, collationTests)
 	})
 	t.Run("nullability tests", func(t *testing.T) {
 		testSchemaMerge(t, nullabilityTests)
@@ -218,6 +223,65 @@ var columnAddDropTests = []schemaMergeTest{
 				right:    singleRow(1, 3),
 				merged:   singleRow(1, nil, 3),
 				skipFlip: true,
+			},
+		},
+	},
+	{
+		name:     "left side column drop",
+		ancestor: tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int, a int)")),
+		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int)       ")),
+		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int, a int)")),
+		merged:   tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int)       ")),
+		dataTests: []dataTest{
+			{
+				name:     "no data change",
+				ancestor: singleRow(1, 2, 3),
+				left:     singleRow(1, 2),
+				right:    singleRow(1, 2, 3),
+				merged:   singleRow(1, 2),
+			},
+			{
+				name:         "one side sets to NULL, other drops non-NULL",
+				ancestor:     singleRow(1, 2, 3),
+				left:         singleRow(1, 2),
+				right:        singleRow(1, 2, nil),
+				dataConflict: true,
+				skip:         true,
+			},
+			{
+				name:         "one side sets to NULL, other drops non-NULL, plus data change",
+				ancestor:     singleRow(1, 2, 3),
+				left:         singleRow(1, 2),
+				right:        singleRow(1, 3, nil),
+				dataConflict: true,
+			},
+			{
+				name:         "one side sets to non-NULL, other drops NULL",
+				ancestor:     singleRow(1, 2, nil),
+				left:         singleRow(1, 2),
+				right:        singleRow(1, 2, 3),
+				dataConflict: true,
+			},
+			{
+				name:         "one side sets to non-NULL, other drops NULL, plus data change",
+				ancestor:     singleRow(1, 2, nil),
+				left:         singleRow(1, 3),
+				right:        singleRow(1, 2, 3),
+				dataConflict: true,
+			},
+			{
+				name:         "one side sets to non-NULL, other drops non-NULL",
+				ancestor:     singleRow(1, 2, 3),
+				left:         singleRow(1, 2),
+				right:        singleRow(1, 2, 4),
+				dataConflict: true,
+			},
+			{
+				name:     "one side drops column, other deletes row",
+				ancestor: []sql.Row{row(1, 2, 3), row(4, 5, 6)},
+				left:     []sql.Row{row(1, 2), row(4, 5)},
+				right:    []sql.Row{row(1, 2, 3)},
+				merged:   []sql.Row{row(1, 2)},
 			},
 		},
 	},
@@ -544,6 +608,94 @@ var columnAddDropTests = []schemaMergeTest{
 	},
 }
 
+type constraintViolation struct {
+	violationType merge.CvType
+	key, value    sql.Row
+}
+
+var collationTests = []schemaMergeTest{
+	{
+		name:     "left side changes collation",
+		ancestor: tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a varchar(10) collate utf8mb4_0900_bin unique)")),
+		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a varchar(10) collate utf8mb4_0900_ai_ci unique)")),
+		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a varchar(10) collate utf8mb4_0900_bin unique)")),
+		merged:   tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a varchar(10) collate utf8mb4_0900_ai_ci unique)")),
+		dataTests: []dataTest{
+			{
+				name:     "no data change",
+				ancestor: singleRow(1, "hello"),
+				left:     singleRow(1, "hello"),
+				right:    singleRow(1, "hello"),
+				merged:   singleRow(1, "hello"),
+			},
+			{
+				name:     "right side insert",
+				ancestor: []sql.Row{{1, "hello"}},
+				left:     []sql.Row{{1, "hello"}},
+				right:    []sql.Row{{1, "hello"}, {2, "world"}},
+				merged:   []sql.Row{{1, "hello"}, {2, "world"}},
+			},
+			{
+				name:     "right side delete",
+				ancestor: []sql.Row{{1, "hello"}, {2, "world"}},
+				left:     []sql.Row{{1, "hello"}, {2, "world"}},
+				right:    []sql.Row{{1, "hello"}},
+				merged:   []sql.Row{{1, "hello"}},
+			},
+			{
+				name:     "right side insert causes unique violation",
+				ancestor: []sql.Row{{1, "hello"}},
+				left:     []sql.Row{{1, "hello"}},
+				right:    []sql.Row{{1, "hello"}, {2, "HELLO"}},
+				constraintViolations: []constraintViolation{
+					{merge.CvType_UniqueIndex, sql.Row{int32(1)}, sql.Row{"hello"}},
+					{merge.CvType_UniqueIndex, sql.Row{int32(2)}, sql.Row{"HELLO"}},
+				},
+			},
+		},
+	},
+	{
+		name:     "left side changes table collation",
+		ancestor: tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a varchar(10) unique) collate utf8mb4_0900_bin")),
+		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a varchar(10) unique) collate utf8mb4_0900_ai_ci")),
+		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a varchar(10) unique) collate utf8mb4_0900_bin")),
+		merged:   tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a varchar(10) unique) collate utf8mb4_0900_ai_ci")),
+		dataTests: []dataTest{
+			{
+				name:     "no data change",
+				ancestor: singleRow(1, "hello"),
+				left:     singleRow(1, "hello"),
+				right:    singleRow(1, "hello"),
+				merged:   singleRow(1, "hello"),
+			},
+			{
+				name:     "right side insert",
+				ancestor: []sql.Row{{1, "hello"}},
+				left:     []sql.Row{{1, "hello"}},
+				right:    []sql.Row{{1, "hello"}, {2, "world"}},
+				merged:   []sql.Row{{1, "hello"}, {2, "world"}},
+			},
+			{
+				name:     "right side delete",
+				ancestor: []sql.Row{{1, "hello"}, {2, "world"}},
+				left:     []sql.Row{{1, "hello"}, {2, "world"}},
+				right:    []sql.Row{{1, "hello"}},
+				merged:   []sql.Row{{1, "hello"}},
+			},
+			{
+				name:     "right side insert causes unique violation",
+				ancestor: []sql.Row{{1, "hello"}},
+				left:     []sql.Row{{1, "hello"}},
+				right:    []sql.Row{{1, "hello"}, {2, "HELLO"}},
+				constraintViolations: []constraintViolation{
+					{merge.CvType_UniqueIndex, sql.Row{int32(1)}, sql.Row{"hello"}},
+					{merge.CvType_UniqueIndex, sql.Row{int32(2)}, sql.Row{"HELLO"}},
+				},
+			},
+		},
+	},
+}
+
 var columnDefaultTests = []schemaMergeTest{
 	{
 		name:     "left side add default",
@@ -665,6 +817,99 @@ var typeChangeTests = []schemaMergeTest{
 		ancestor: tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a varchar(20), b int, c varchar(20))")),
 		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a text, b int, c text)")),
 		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a varchar(20), b int, c varchar(20))")),
+		merged:   tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a text, b int, c text)")),
+		dataTests: []dataTest{
+			{
+				name:     "schema change, no data change",
+				ancestor: singleRow(1, "test", 1, "test"),
+				left:     singleRow(1, "test", 1, "test"),
+				right:    singleRow(1, "test", 1, "test"),
+				merged:   singleRow(1, "test", 1, "test"),
+			},
+			{
+				name:     "insert and schema change on left, no change on right",
+				ancestor: nil,
+				left:     singleRow(1, "test", 1, "test"),
+				right:    nil,
+				merged:   singleRow(1, "test", 1, "test"),
+			},
+			{
+				name:     "insert on right, schema change on left",
+				ancestor: nil,
+				left:     nil,
+				right:    singleRow(1, "test", 1, "test"),
+				merged:   singleRow(1, "test", 1, "test"),
+			},
+			{
+				name:     "data and schema change on left, no change on right",
+				ancestor: singleRow(1, "test", 1, "test"),
+				left:     singleRow(1, "hello world", 1, "hello world"),
+				right:    singleRow(1, "test", 1, "test"),
+				merged:   singleRow(1, "hello world", 1, "hello world"),
+			},
+			{
+				name:     "data change on right, schema change on left",
+				ancestor: singleRow(1, "test", 1, "test"),
+				left:     singleRow(1, "test", 1, "test"),
+				right:    singleRow(1, "hello world", 1, "hello world"),
+				merged:   singleRow(1, "hello world", 1, "hello world"),
+			},
+			{
+				name:     "data set and schema change on left, no change on right",
+				ancestor: singleRow(1, nil, 1, nil),
+				left:     singleRow(1, "hello world", 1, "hello world"),
+				right:    singleRow(1, nil, 1, nil),
+				merged:   singleRow(1, "hello world", 1, "hello world"),
+			},
+			{
+				name:     "data set on right, schema change on left",
+				ancestor: singleRow(1, nil, 1, nil),
+				left:     singleRow(1, nil, 1, nil),
+				right:    singleRow(1, "hello world", 1, "hello world"),
+				merged:   singleRow(1, "hello world", 1, "hello world"),
+			},
+			{
+				name:     "convergent inserts",
+				ancestor: nil,
+				left:     singleRow(1, "test", 1, "test"),
+				right:    singleRow(1, "test", 1, "test"),
+				merged:   singleRow(1, "test", 1, "test"),
+			},
+			{
+				name:         "conflicting inserts",
+				ancestor:     nil,
+				left:         singleRow(1, "test", 1, "test"),
+				right:        singleRow(1, "hello world", 1, "hello world"),
+				dataConflict: true,
+			},
+			{
+				name:     "delete and schema change on left",
+				ancestor: singleRow(1, "test", 1, "test"),
+				left:     nil,
+				right:    singleRow(1, "test", 1, "test"),
+				merged:   nil,
+			},
+			{
+				name:     "schema change on left, delete on right",
+				ancestor: singleRow(1, "test", 1, "test"),
+				left:     singleRow(1, "test", 1, "test"),
+				right:    nil,
+				merged:   nil,
+			},
+			{
+				name:         "schema and value change on left, delete on right",
+				ancestor:     singleRow(1, "test", 1, "test"),
+				left:         singleRow(1, "hello", 1, "hello"),
+				right:        nil,
+				dataConflict: true,
+			},
+		},
+	},
+	{
+		name:     "modify column type on the left side between compatible string types with unique secondary index",
+		ancestor: tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a varchar(20) unique, b int, c varchar(20) unique)")),
+		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a text, b int, c text)")),
+		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a varchar(20) unique, b int, c varchar(20) unique)")),
 		merged:   tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a text, b int, c text)")),
 		dataTests: []dataTest{
 			{
@@ -934,7 +1179,7 @@ func testSchemaMergeHelper(t *testing.T, tests []schemaMergeTest, flipSides bool
 		}
 
 		t.Run(test.name, func(t *testing.T) {
-			runTest := func(t *testing.T, test schemaMergeTest, expectDataConflict bool) {
+			runTest := func(t *testing.T, test schemaMergeTest, expectDataConflict bool, expConstraintViolations []constraintViolation) {
 				a, l, r, m := setupSchemaMergeTest(t, test)
 
 				ctx := context.Background()
@@ -980,33 +1225,62 @@ func testSchemaMergeHelper(t *testing.T, tests []schemaMergeTest, flipSides bool
 							require.NoError(t, err)
 							require.False(t, hasConflict, "Unexpected data conflict")
 
-							if !assert.Equal(t, addr, a) {
-								expTbl, _, err := m.GetTable(ctx, name)
+							numConstraintViolations, err := actTbl.NumConstraintViolations(ctx)
+							require.NoError(t, err)
+							require.EqualValues(t, numConstraintViolations, len(expConstraintViolations))
+
+							if len(expConstraintViolations) > 0 {
+								artifacts, err := actTbl.GetArtifacts(ctx)
 								require.NoError(t, err)
-								t.Logf("expected rows: %s", expTbl.DebugString(ctx))
-								t.Logf("actual rows: %s", actTbl.DebugString(ctx))
+								artifactMap := durable.ProllyMapFromArtifactIndex(artifacts)
+								artifactIter, err := artifactMap.IterAllCVs(ctx)
+								require.NoError(t, err)
+
+								sch, err := actTbl.GetSchema(ctx)
+								require.NoError(t, err)
+
+								kd, vd := sch.GetMapDescriptors()
+
+								// value tuples encoded in ConstraintViolationMeta may
+								// violate the not null constraints assumed by fixed access
+								kd = kd.WithoutFixedAccess()
+								vd = vd.WithoutFixedAccess()
+								for _, expectedViolation := range expConstraintViolations {
+									violationType, key, value, err := merge.NextConstraintViolation(ctx, artifactIter, kd, vd, artifactMap.NodeStore())
+									require.NoError(t, err)
+									require.EqualValues(t, expectedViolation.violationType, violationType)
+									require.EqualValues(t, expectedViolation.key, key)
+									require.EqualValues(t, expectedViolation.value, value)
+								}
+							} else {
+								if !assert.Equal(t, addr, a) {
+									expTbl, _, err := m.GetTable(ctx, name)
+									require.NoError(t, err)
+									t.Logf("expected rows: %s", expTbl.DebugString(ctx))
+									t.Logf("actual rows: %s", actTbl.DebugString(ctx))
+								}
 							}
 						}
 					}
 				}
 			}
 			t.Run("test schema merge", func(t *testing.T) {
-				runTest(t, test, false)
+				runTest(t, test, false, nil)
 			})
 			for _, data := range test.dataTests {
 				// Copy the test so that the values from one data test don't affect subsequent data tests.
-				dataDest := test
-				dataDest.ancestor.rows = data.ancestor
-				dataDest.left.rows = data.left
-				dataDest.right.rows = data.right
-				dataDest.merged.rows = data.merged
-				dataDest.skipNewFmt = dataDest.skipNewFmt || data.skip
-				dataDest.skipFlipOnNewFormat = dataDest.skipFlipOnNewFormat || data.skipFlip
+				dataTest := test
+				dataTest.ancestor.rows = data.ancestor
+				dataTest.left.rows = data.left
+				dataTest.right.rows = data.right
+				dataTest.merged.rows = data.merged
+				dataTest.skipNewFmt = dataTest.skipNewFmt || data.skip
+				dataTest.skipFlipOnNewFormat = dataTest.skipFlipOnNewFormat || data.skipFlip
 				t.Run(data.name, func(t *testing.T) {
 					if data.skip {
 						t.Skip()
 					}
-					runTest(t, dataDest, data.dataConflict)
+					runTest(t, dataTest, data.dataConflict, data.constraintViolations)
 				})
 			}
 		})

--- a/go/libraries/doltcore/merge/schema_merge_test.go
+++ b/go/libraries/doltcore/merge/schema_merge_test.go
@@ -16,7 +16,6 @@ package merge_test
 
 import (
 	"context"
-	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
 	"testing"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -25,6 +24,7 @@ import (
 
 	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
 	"github.com/dolthub/dolt/go/libraries/doltcore/dtestutils"
 	"github.com/dolthub/dolt/go/libraries/doltcore/merge"
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
@@ -223,65 +223,6 @@ var columnAddDropTests = []schemaMergeTest{
 				right:    singleRow(1, 3),
 				merged:   singleRow(1, nil, 3),
 				skipFlip: true,
-			},
-		},
-	},
-	{
-		name:     "left side column drop",
-		ancestor: tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int, a int)")),
-		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int)       ")),
-		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int, a int)")),
-		merged:   tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int)       ")),
-		dataTests: []dataTest{
-			{
-				name:     "no data change",
-				ancestor: singleRow(1, 2, 3),
-				left:     singleRow(1, 2),
-				right:    singleRow(1, 2, 3),
-				merged:   singleRow(1, 2),
-			},
-			{
-				name:         "one side sets to NULL, other drops non-NULL",
-				ancestor:     singleRow(1, 2, 3),
-				left:         singleRow(1, 2),
-				right:        singleRow(1, 2, nil),
-				dataConflict: true,
-				skip:         true,
-			},
-			{
-				name:         "one side sets to NULL, other drops non-NULL, plus data change",
-				ancestor:     singleRow(1, 2, 3),
-				left:         singleRow(1, 2),
-				right:        singleRow(1, 3, nil),
-				dataConflict: true,
-			},
-			{
-				name:         "one side sets to non-NULL, other drops NULL",
-				ancestor:     singleRow(1, 2, nil),
-				left:         singleRow(1, 2),
-				right:        singleRow(1, 2, 3),
-				dataConflict: true,
-			},
-			{
-				name:         "one side sets to non-NULL, other drops NULL, plus data change",
-				ancestor:     singleRow(1, 2, nil),
-				left:         singleRow(1, 3),
-				right:        singleRow(1, 2, 3),
-				dataConflict: true,
-			},
-			{
-				name:         "one side sets to non-NULL, other drops non-NULL",
-				ancestor:     singleRow(1, 2, 3),
-				left:         singleRow(1, 2),
-				right:        singleRow(1, 2, 4),
-				dataConflict: true,
-			},
-			{
-				name:     "one side drops column, other deletes row",
-				ancestor: []sql.Row{row(1, 2, 3), row(4, 5, 6)},
-				left:     []sql.Row{row(1, 2), row(4, 5)},
-				right:    []sql.Row{row(1, 2, 3)},
-				merged:   []sql.Row{row(1, 2)},
 			},
 		},
 	},

--- a/go/libraries/doltcore/merge/type_compatibility_test.go
+++ b/go/libraries/doltcore/merge/type_compatibility_test.go
@@ -57,6 +57,7 @@ var point = typeinfo.CreatePointTypeFromSqlPointType(gmstypes.PointType{SRID: ui
 var varchar10 = typeinfo.CreateVarStringTypeFromSqlType(gmstypes.MustCreateString(sqltypes.VarChar, 10, sql.Collation_Default))
 var varchar10ci = typeinfo.CreateVarStringTypeFromSqlType(gmstypes.MustCreateString(sqltypes.VarChar, 10, sql.Collation_utf8mb4_0900_ai_ci))
 var varchar10bin = typeinfo.CreateVarStringTypeFromSqlType(gmstypes.MustCreateString(sqltypes.VarChar, 10, sql.Collation_utf8mb4_0900_bin))
+var varchar10utf16bin = typeinfo.CreateVarStringTypeFromSqlType(gmstypes.MustCreateString(sqltypes.VarChar, 10, sql.Collation_utf16_bin))
 var varchar20 = typeinfo.CreateVarStringTypeFromSqlType(gmstypes.MustCreateString(sqltypes.VarChar, 20, sql.Collation_Default))
 var varchar300 = typeinfo.CreateVarStringTypeFromSqlType(gmstypes.MustCreateString(sqltypes.VarChar, 300, sql.Collation_Default))
 var varchar10BinaryCollation = typeinfo.CreateVarStringTypeFromSqlType(gmstypes.MustCreateString(sqltypes.VarChar, 10, sql.Collation_binary))
@@ -200,6 +201,14 @@ func TestDoltIsTypeChangeCompatible(t *testing.T) {
 			name:       "geometry: non-identical types are incompatible",
 			from:       geo,
 			to:         point,
+			compatible: false,
+		},
+
+		// Charset changes
+		{
+			name:       "incompatible: VARCHAR(10) charset change",
+			from:       varchar10bin,
+			to:         varchar10utf16bin,
 			compatible: false,
 		},
 

--- a/go/libraries/doltcore/merge/type_compatibility_test.go
+++ b/go/libraries/doltcore/merge/type_compatibility_test.go
@@ -27,11 +27,12 @@ import (
 )
 
 type typeChangeCompatibilityTest struct {
-	name       string
-	from       typeinfo.TypeInfo
-	to         typeinfo.TypeInfo
-	compatible bool
-	rewrite    bool
+	name                       string
+	from                       typeinfo.TypeInfo
+	to                         typeinfo.TypeInfo
+	compatible                 bool
+	rewrite                    bool
+	invalidateSecondaryIndexes bool
 }
 
 // Enum test data
@@ -54,6 +55,8 @@ var point = typeinfo.CreatePointTypeFromSqlPointType(gmstypes.PointType{SRID: ui
 
 // String type test data
 var varchar10 = typeinfo.CreateVarStringTypeFromSqlType(gmstypes.MustCreateString(sqltypes.VarChar, 10, sql.Collation_Default))
+var varchar10ci = typeinfo.CreateVarStringTypeFromSqlType(gmstypes.MustCreateString(sqltypes.VarChar, 10, sql.Collation_utf8mb4_0900_ai_ci))
+var varchar10bin = typeinfo.CreateVarStringTypeFromSqlType(gmstypes.MustCreateString(sqltypes.VarChar, 10, sql.Collation_utf8mb4_0900_bin))
 var varchar20 = typeinfo.CreateVarStringTypeFromSqlType(gmstypes.MustCreateString(sqltypes.VarChar, 20, sql.Collation_Default))
 var varchar300 = typeinfo.CreateVarStringTypeFromSqlType(gmstypes.MustCreateString(sqltypes.VarChar, 300, sql.Collation_Default))
 var varchar10BinaryCollation = typeinfo.CreateVarStringTypeFromSqlType(gmstypes.MustCreateString(sqltypes.VarChar, 10, sql.Collation_binary))
@@ -200,6 +203,16 @@ func TestDoltIsTypeChangeCompatible(t *testing.T) {
 			compatible: false,
 		},
 
+		// Collation changes
+		{
+			name:                       "compatible: VARCHAR(10) collation change",
+			from:                       varchar10ci,
+			to:                         varchar10bin,
+			compatible:                 true,
+			rewrite:                    false,
+			invalidateSecondaryIndexes: true,
+		},
+
 		// Type width changes
 		{
 			name:       "type widening: VARCHAR(10) to VARCHAR(20)",
@@ -213,50 +226,55 @@ func TestDoltIsTypeChangeCompatible(t *testing.T) {
 			to:         varchar10,
 			compatible: false,
 		}, {
-			name:       "type widening: VARCHAR to TEXT",
-			from:       varchar10,
-			to:         text,
-			compatible: true,
-			rewrite:    true,
+			name:                       "type widening: VARCHAR to TEXT",
+			from:                       varchar10,
+			to:                         text,
+			compatible:                 true,
+			rewrite:                    true,
+			invalidateSecondaryIndexes: true,
 		}, {
 			name:       "type narrowing: TEXT to VARCHAR(10)",
 			from:       text,
 			to:         varchar10,
 			compatible: false,
 		}, {
-			name:       "type widening: TINYTEXT to VARCHAR(300)",
-			from:       tinyText,
-			to:         varchar300,
-			compatible: true,
-			rewrite:    true,
+			name:                       "type widening: TINYTEXT to VARCHAR(300)",
+			from:                       tinyText,
+			to:                         varchar300,
+			compatible:                 true,
+			rewrite:                    true,
+			invalidateSecondaryIndexes: true,
 		}, {
-			name:       "type widening: varbinary to BLOB",
-			from:       varbinary10,
-			to:         blob,
-			compatible: true,
-			rewrite:    true,
+			name:                       "type widening: varbinary to BLOB",
+			from:                       varbinary10,
+			to:                         blob,
+			compatible:                 true,
+			rewrite:                    true,
+			invalidateSecondaryIndexes: true,
 		}, {
 			name:       "type narrowing: BLOB to varbinary",
 			from:       blob,
 			to:         varbinary10,
 			compatible: false,
 		}, {
-			name:       "type widening: TEXT to MEDIUMTEXT",
-			from:       text,
-			to:         mediumText,
-			compatible: true,
-			rewrite:    false,
+			name:                       "type widening: TEXT to MEDIUMTEXT",
+			from:                       text,
+			to:                         mediumText,
+			compatible:                 true,
+			rewrite:                    false,
+			invalidateSecondaryIndexes: false,
 		}, {
 			name:       "type narrowing: MEDIUMTEXT to TEXT",
 			from:       mediumText,
 			to:         text,
 			compatible: false,
 		}, {
-			name:       "type widening: BLOB to MEDIUMBLOB",
-			from:       blob,
-			to:         mediumBlob,
-			compatible: true,
-			rewrite:    false,
+			name:                       "type widening: BLOB to MEDIUMBLOB",
+			from:                       blob,
+			to:                         mediumBlob,
+			compatible:                 true,
+			rewrite:                    false,
+			invalidateSecondaryIndexes: false,
 		}, {
 			name:       "type narrowing: MEDIUMBLOB to BLOB",
 			from:       mediumBlob,
@@ -292,9 +310,11 @@ func TestDoltIsTypeChangeCompatible(t *testing.T) {
 func runTypeCompatibilityTests(t *testing.T, compatChecker TypeCompatibilityChecker, tests []typeChangeCompatibilityTest) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			compatible, requiresRewrite := compatChecker.IsTypeChangeCompatible(tt.from, tt.to)
-			assert.Equal(t, tt.compatible, compatible, "expected compatible to be %t, but was %t", tt.compatible, compatible)
-			assert.Equal(t, tt.rewrite, requiresRewrite, "expected rewrite required to be %t, but was %t", tt.rewrite, requiresRewrite)
+			compatibilityResults := compatChecker.IsTypeChangeCompatible(tt.from, tt.to)
+			assert.Equal(t, tt.compatible, compatibilityResults.compatible, "expected compatible to be %t, but was %t", tt.compatible, compatibilityResults.compatible)
+			assert.Equal(t, tt.rewrite, compatibilityResults.rewriteRows, "expected rewrite required to be %t, but was %t", tt.rewrite, compatibilityResults.rewriteRows)
+			assert.Equal(t, tt.invalidateSecondaryIndexes, compatibilityResults.invalidateSecondaryIndexes, "expected secondary index rewrite to be %t, but was %t", tt.invalidateSecondaryIndexes, compatibilityResults.invalidateSecondaryIndexes)
+
 		})
 	}
 }

--- a/go/libraries/doltcore/merge/violations_prolly.go
+++ b/go/libraries/doltcore/merge/violations_prolly.go
@@ -1,0 +1,74 @@
+package merge
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/index"
+	"github.com/dolthub/dolt/go/store/prolly"
+	"github.com/dolthub/dolt/go/store/prolly/tree"
+	"github.com/dolthub/dolt/go/store/val"
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+func NextConstraintViolation(ctx context.Context, itr prolly.ArtifactIter, kd, vd val.TupleDesc, ns tree.NodeStore) (violationType uint64, key sql.Row, value sql.Row, err error) {
+	art, err := itr.Next(ctx)
+	if err != nil {
+		return
+	}
+
+	key = make(sql.Row, kd.Count())
+	for i := 0; i < kd.Count(); i++ {
+		key[i], err = index.GetField(ctx, kd, i, art.SourceKey, ns)
+		if err != nil {
+			return
+		}
+	}
+
+	var meta prolly.ConstraintViolationMeta
+	err = json.Unmarshal(art.Metadata, &meta)
+	if err != nil {
+		return
+	}
+
+	value = make(sql.Row, vd.Count())
+	for i := 0; i < vd.Count(); i++ {
+		value[i], err = index.GetField(ctx, vd, i, meta.Value, ns)
+		if err != nil {
+			return
+		}
+	}
+
+	return MapCVType(art.ArtType), key, value, nil
+}
+
+func MapCVType(artifactType prolly.ArtifactType) (outType uint64) {
+	switch artifactType {
+	case prolly.ArtifactTypeForeignKeyViol:
+		outType = uint64(CvType_ForeignKey)
+	case prolly.ArtifactTypeUniqueKeyViol:
+		outType = uint64(CvType_UniqueIndex)
+	case prolly.ArtifactTypeChkConsViol:
+		outType = uint64(CvType_CheckConstraint)
+	case prolly.ArtifactTypeNullViol:
+		outType = uint64(CvType_NotNull)
+	default:
+		panic("unhandled cv type")
+	}
+	return
+}
+
+func UnmapCVType(in CvType) (out prolly.ArtifactType) {
+	switch in {
+	case CvType_ForeignKey:
+		out = prolly.ArtifactTypeForeignKeyViol
+	case CvType_UniqueIndex:
+		out = prolly.ArtifactTypeUniqueKeyViol
+	case CvType_CheckConstraint:
+		out = prolly.ArtifactTypeChkConsViol
+	case CvType_NotNull:
+		out = prolly.ArtifactTypeNullViol
+	default:
+		panic("unhandled cv type")
+	}
+	return
+}

--- a/go/libraries/doltcore/merge/violations_prolly.go
+++ b/go/libraries/doltcore/merge/violations_prolly.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package merge
 
 import (

--- a/go/libraries/doltcore/merge/violations_prolly.go
+++ b/go/libraries/doltcore/merge/violations_prolly.go
@@ -17,11 +17,13 @@ package merge
 import (
 	"context"
 	"encoding/json"
+
+	"github.com/dolthub/go-mysql-server/sql"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/index"
 	"github.com/dolthub/dolt/go/store/prolly"
 	"github.com/dolthub/dolt/go/store/prolly/tree"
 	"github.com/dolthub/dolt/go/store/val"
-	"github.com/dolthub/go-mysql-server/sql"
 )
 
 func NextConstraintViolation(ctx context.Context, itr prolly.ArtifactIter, kd, vd val.TupleDesc, ns tree.NodeStore) (violationType uint64, key sql.Row, value sql.Row, err error) {

--- a/go/libraries/doltcore/sqle/dtables/constraint_violations_prolly.go
+++ b/go/libraries/doltcore/sqle/dtables/constraint_violations_prolly.go
@@ -16,6 +16,7 @@ package dtables
 
 import (
 	"encoding/json"
+
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"

--- a/go/store/prolly/tree/three_way_differ.go
+++ b/go/store/prolly/tree/three_way_differ.go
@@ -42,12 +42,14 @@ type ThreeWayDiffer[K ~[]byte, O Ordering[K]] struct {
 type resolveCb func(context.Context, val.Tuple, val.Tuple, val.Tuple) (val.Tuple, bool, error)
 
 // ThreeWayDiffInfo stores contextual data that can influence the diff.
-// If |LeftSchemaChange| is true, then the left side has a different schema from the base, and every row
-// in both Left and Base should be considered a modification, even if they have the same bytes.
-// If |RightSchemaChange| is true, then the right side has a different schema from the base, and every row
-// in both Right and Base should be considered a modification, even if they have the same bytes.
-// If |LeftAndRightSchemasDiffer| is true, then the left and right sides of the diff have a different schema,
-// so there cannot be any convergent edits, even if two rows in Left and Right have the same bytes.
+// If |LeftSchemaChange| is true, then the left side's bytes have a different interpretation from the base,
+// so every row in both Left and Base should be considered a modification, even if they have the same bytes.
+// If |RightSchemaChange| is true, then the right side's bytes have a different interpretation from the base,
+// so every row in both Right and Base should be considered a modification, even if they have the same bytes.
+// Note that these values aren't set for schema changes that have no effect on the meaning of the bytes,
+// such as collation.
+// If |LeftAndRightSchemasDiffer| is true, then the left and right sides of the diff have a different interpretation
+// of their bytes, so there cannot be any convergent edits, even if two rows in Left and Right have the same bytes.
 type ThreeWayDiffInfo struct {
 	LeftSchemaChange          bool
 	RightSchemaChange         bool


### PR DESCRIPTION
This allows automatic merging in the case where:
- One branch changes the collation of the column.
- The other branch modifies cells in that column.

It's still a requirement that only one branch is allowed to modify the column definition. So for instance, if one branch changes the collation, and the other branch widens the column, that will still be a schema merge conflict. There's no reason we can't allow it, but the logic is more complicated so I'm saving it for a follow-up PR.