### PR TITLE
fixes `dolt version` out of date warning

### DIFF
--- a/integration-tests/bats/no-repo.bats
+++ b/integration-tests/bats/no-repo.bats
@@ -140,6 +140,14 @@ teardown() {
     [ "$status" -eq 0 ]
 }
 
+@test "no-repo: dolt version ahead of saved version does not print warning" {
+    echo "1.27.0" > $DOLT_ROOT_PATH/.dolt/version_check.txt
+
+    run dolt version
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "Warning: you are on an old version of Dolt" ]] || false
+}
+
 # Tests for dolt commands outside of a dolt repository
 NOT_VALID_REPO_ERROR="The current directory is not a valid dolt repository."
 @test "no-repo: dolt status outside of a dolt repository" {

--- a/integration-tests/bats/no-repo.bats
+++ b/integration-tests/bats/no-repo.bats
@@ -140,6 +140,14 @@ teardown() {
     [ "$status" -eq 0 ]
 }
 
+@test "no-repo: dolt version prints out of date warning" {
+    echo "2.0.0" > $DOLT_ROOT_PATH/.dolt/version_check.txt
+
+    run dolt version
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Warning: you are on an old version of Dolt" ]] || false
+}
+
 @test "no-repo: dolt version ahead of saved version does not print warning" {
     echo "1.27.0" > $DOLT_ROOT_PATH/.dolt/version_check.txt
 


### PR DESCRIPTION
Changes `dolt version` out of date warning to do a check against GitHub if the current build version is ahead of the stored latest release version. Fixes inconsistencies where the current build is running a version that was released within the past week.