### PR TITLE
Disable performance bats test.

### DIFF
--- a/integration-tests/bats/performance.bats
+++ b/integration-tests/bats/performance.bats
@@ -1,6 +1,8 @@
 #!/usr/bin/env bats
 load $BATS_TEST_DIRNAME/helper/common.bash
 
+# NOTE: These are currently disabled because the high variance in GitHub CI makes them unreliable.
+
 # This BATS test attempts to detect performance regressions when using standard workflows on large datasets.
 # Please note that this is a rough approach that is not designed to detect all performance issues, merely an extra
 # safeguard against bugs that cause large (order-of-magnitude+) regressions.
@@ -31,6 +33,7 @@ create_repo() {
 }
 
 setup() {
+    skip
     cp -r $BATS_TEST_DIRNAME/performance-repo/ $BATS_TMPDIR/dolt-repo-$$
     cd $BATS_TMPDIR/dolt-repo-$$
 }


### PR DESCRIPTION
I originally settled on a 50-second timeout for these tests because a 100-second timeout was too high to consistently detect the performance regression that motivated https://github.com/dolthub/dolt/pull/7044.

I suspect that any timeout high enough to avoid spurious failures is too high to reliably detect actual regressions. Detecting performance regressions is important, but this isn't the way to do it.

We shouldn't be blocking CI on this. We should incorporate these performance tests into our daily benchmarking instead.