### PR TITLE
Adding tests for column name metadata through MySQL C++ and Rust Connector

### DIFF
--- a/integration-tests/mysql-client-tests/cpp/mysql-connector-cpp-test.cpp
+++ b/integration-tests/mysql-client-tests/cpp/mysql-connector-cpp-test.cpp
@@ -3,7 +3,6 @@
 #include <sstream>
 #include <stdexcept>
 
-
 #include "mysql_driver.h"
 #include "mysql_connection.h"
 #include "mysql_error.h"
@@ -64,10 +63,19 @@ int main(int argc, char **argv) {
       sql::Statement *stmt = con->createStatement();
 
       if ( is_update[i] ) {
-	int affected_rows = stmt->executeUpdate(queries[i]);
+        int affected_rows = stmt->executeUpdate(queries[i]);
       } else {
-	sql::ResultSet *res = stmt->executeQuery(queries[i]);
-	delete res;
+        sql::ResultSet *res = stmt->executeQuery(queries[i]);
+
+        // Assert that all columns have colum name metadata populated
+        sql::ResultSetMetaData* metadata = res->getMetaData();
+        const uint columnCount = metadata->getColumnCount();
+        for (uint columnIndex = 1; columnIndex <= columnCount; ++columnIndex) {
+            sql::SQLString columnName = metadata->getColumnName(columnIndex);
+            assert(columnName.length() > 0);
+        }
+
+        delete res;
       }
     
       delete stmt;

--- a/integration-tests/mysql-client-tests/rust/src/mysql_connector_test.rs
+++ b/integration-tests/mysql-client-tests/rust/src/mysql_connector_test.rs
@@ -33,6 +33,19 @@ fn main() {
         let result = conn.query(query);
         let response : Vec<Row> = result.expect("Error: bad response");
         println!("{:?}", response);
+
+        // Assert that row metadata is populated
+        if response.len() > 0 {
+            let row = &response[0];
+            for column in row.columns_ref() {
+                if column.name_str().len() == 0 {
+                    println!("FAIL: Column name is empty");
+                    exit(1);
+                }
+            }
+        }
+
+        // Assert that the expected number of rows are returned
         if response.len() != expected {
             println!("LENGTH: {}", response.len());
             println!("QUERY: {}", query);


### PR DESCRIPTION
Added assertions that result set column name metadata is populated for the C++ and Rust MySQL Connector libraries. 