### PR TITLE
Poorly formatted version doesn't error

### DIFF
--- a/go/cmd/dolt/commands/version.go
+++ b/go/cmd/dolt/commands/version.go
@@ -155,6 +155,13 @@ func checkAndPrintVersionOutOfDateWarning(curVersion string, dEnv *env.DoltEnv) 
 			if verr != nil {
 				return verr
 			}
+		} else {
+			if !isVersionFormattedCorrectly(latestRelease) {
+				latestRelease, verr = getLatestDoltReleaseAndRecord(path, dEnv)
+				if verr != nil {
+					return verr
+				}
+			}
 		}
 	} else {
 		latestRelease, verr = getLatestDoltReleaseAndRecord(path, dEnv)
@@ -216,4 +223,21 @@ func isOutOfDate(curVersion, latestRelease string) (bool, errhand.VerboseError) 
 	}
 
 	return false, nil
+}
+
+// isVersionFormattedCorrectly checks if the given version string is formatted correctly, i.e. is of the form
+// major.minor.patch where each part is an integer.
+func isVersionFormattedCorrectly(version string) bool {
+	versionParts := strings.Split(version, ".")
+	if len(versionParts) != 3 {
+		return false
+	}
+
+	for _, part := range versionParts {
+		if _, err := strconv.Atoi(part); err != nil {
+			return false
+		}
+	}
+
+	return true
 }

--- a/go/cmd/dolt/commands/version.go
+++ b/go/cmd/dolt/commands/version.go
@@ -148,7 +148,7 @@ func checkAndPrintVersionOutOfDateWarning(curVersion string, dEnv *env.DoltEnv) 
 			return errhand.BuildDError("error: failed to read version check file").AddCause(err).Build()
 		}
 
-		latestRelease = string(vCheck)
+		latestRelease = strings.ReplaceAll(string(vCheck), "\n", "")
 		lastCheckDate, _ := dEnv.FS.LastModified(path)
 		if lastCheckDate.Before(time.Now().AddDate(0, 0, -7)) {
 			latestRelease, verr = getLatestDoltReleaseAndRecord(path, dEnv)

--- a/integration-tests/bats/no-repo.bats
+++ b/integration-tests/bats/no-repo.bats
@@ -156,6 +156,14 @@ teardown() {
     [[ ! "$output" =~ "Warning: you are on an old version of Dolt" ]] || false
 }
 
+@test "no-repo: dolt version with bad version_check.txt does not print error" {
+    echo "bad version" > $DOLT_ROOT_PATH/.dolt/version_check.txt
+
+    run dolt version
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 1 ]
+}
+
 # Tests for dolt commands outside of a dolt repository
 NOT_VALID_REPO_ERROR="The current directory is not a valid dolt repository."
 @test "no-repo: dolt status outside of a dolt repository" {

--- a/integration-tests/bats/no-repo.bats
+++ b/integration-tests/bats/no-repo.bats
@@ -161,7 +161,7 @@ teardown() {
 
     run dolt version
     [ "$status" -eq 0 ]
-    [ "${#lines[@]}" -eq 1 ]
+    [[ ! "$output" =~ "error" ]] || false
 }
 
 # Tests for dolt commands outside of a dolt repository

--- a/integration-tests/bats/no-repo.bats
+++ b/integration-tests/bats/no-repo.bats
@@ -161,7 +161,7 @@ teardown() {
 
     run dolt version
     [ "$status" -eq 0 ]
-    [[ ! "$output" =~ "error" ]] || false
+    [[ ! "$output" =~ "failed to parse version number" ]] || false
 }
 
 # Tests for dolt commands outside of a dolt repository


### PR DESCRIPTION
Fixes an issue where bad data in `version_check.txt` returns an error. This change makes version overwrite any bad data in this file instead.

Fixes: https://github.com/dolthub/dolt/issues/7138