### PR TITLE
fix `column_diff_table` for modifed json columns

### DIFF
--- a/go/libraries/doltcore/sqle/dtables/column_diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/column_diff_table.go
@@ -553,7 +553,12 @@ func calculateColDelta(ctx *sql.Context, ddb *doltdb.DoltDB, delta *diff.TableDe
 			toIdx := diffTableCols.TagToIdx[toColTag]
 			fromIdx := diffTableCols.TagToIdx[fromColTag]
 
-			if r[toIdx] != r[fromIdx] {
+			toCol := delta.ToSch.GetAllCols().GetByIndex(toIdx)
+			cmp, err := toCol.TypeInfo.ToSqlType().Compare(r[toIdx], r[fromIdx])
+			if err != nil {
+				return nil, nil, err
+			}
+			if cmp != 0 {
 				colNamesSet[col] = struct{}{}
 			}
 		}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -4623,6 +4623,29 @@ var ColumnDiffSystemTableScriptTests = []queries.ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "json column change",
+		SetUpScript: []string{
+			"create table t (pk int primary key, j json);",
+			`insert into t values (1, '{"test": 123}');`,
+			"call dolt_add('.')",
+			"call dolt_commit('-m', 'commit1');",
+
+			`update t set j = '{"nottest": 321}'`,
+			"call dolt_add('.')",
+			"call dolt_commit('-m', 'commit2');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "select column_name, diff_type from dolt_column_diff;",
+				Expected: []sql.Row{
+					{"j", "modified"},
+					{"pk", "added"},
+					{"j", "added"},
+				},
+			},
+		},
+	},
 }
 
 var CommitDiffSystemTableScriptTests = []queries.ScriptTest{

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -4637,7 +4637,7 @@ var ColumnDiffSystemTableScriptTests = []queries.ScriptTest{
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
-				Query:    "select column_name, diff_type from dolt_column_diff;",
+				Query: "select column_name, diff_type from dolt_column_diff;",
 				Expected: []sql.Row{
 					{"j", "modified"},
 					{"pk", "added"},


### PR DESCRIPTION
JSON types are represented as `map[string]interface{}`, which panics in Golang when used with `!=` operator. 
This PR changes the logic to use our `gmstypes.Compare()` logic instead,

fixes https://github.com/dolthub/dolt/issues/7140