### PR TITLE
Bug fix: `dolt_blame_<tablename>` view should backtick quote identifiers

### DIFF
--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -1130,7 +1130,7 @@ func (db Database) GetViewDefinition(ctx *sql.Context, viewName string) (sql.Vie
 		if err != nil {
 			return sql.ViewDefinition{}, false, err
 		}
-		return sql.ViewDefinition{Name: viewName, TextDefinition: blameViewTextDef, CreateViewStatement: fmt.Sprintf("CREATE VIEW %s AS %s", viewName, blameViewTextDef)}, true, nil
+		return sql.ViewDefinition{Name: viewName, TextDefinition: blameViewTextDef, CreateViewStatement: fmt.Sprintf("CREATE VIEW `%s` AS %s", viewName, blameViewTextDef)}, true, nil
 	}
 
 	key, err := doltdb.NewDataCacheKey(root)

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -1004,8 +1004,7 @@ var DoltScripts = []queries.ScriptTest{
 			"CREATE TABLE t(pk varchar(20), val int)",
 			"ALTER TABLE t ADD PRIMARY KEY (pk, val)",
 			"INSERT INTO t VALUES ('zzz',4),('mult',1),('sub',2),('add',5)",
-			"CALL dolt_add('.');",
-			"CALL dolt_commit('-am', 'add rows');",
+			"CALL dolt_commit('-Am', 'add rows');",
 			"INSERT INTO t VALUES ('dolt',0),('alt',12),('del',8),('ctl',3)",
 			"CALL dolt_commit('-am', 'add more rows');",
 		},
@@ -1021,6 +1020,25 @@ var DoltScripts = []queries.ScriptTest{
 					{"mult", 1, "add rows"},
 					{"sub", 2, "add rows"},
 					{"zzz", 4, "add rows"},
+				},
+			},
+		},
+	},
+	{
+		Name: "blame: table and pk require identifier quoting",
+		SetUpScript: []string{
+			"create table `t-1` (`p-k` int primary key, col1 varchar(100));",
+			"insert into `t-1` values (1, 'one');",
+			"CALL dolt_commit('-Am', 'adding table t-1');",
+			"insert into `t-1` values (2, 'two');",
+			"CALL dolt_commit('-Am', 'adding another row to t-1');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "SELECT `p-k`, message FROM `dolt_blame_t-1`;",
+				Expected: []sql.Row{
+					{1, "adding table t-1"},
+					{2, "adding another row to t-1"},
 				},
 			},
 		},


### PR DESCRIPTION
Fixes the `dolt_blame_<tablename>` view definitions so that table names and primary key column names are backtick quoted. Without this, customers can't use the `dolt_blame_<tablename>` views if the table name or primary key columns contain characters (e.g. "-") that require identifier quoting. 