### PR TITLE
Return a different error message for tx commit conflicts depending on `@autocommit`

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
@@ -556,7 +556,7 @@ var MergeScripts = []queries.ScriptTest{
 			{
 				// errors because creating a new branch implicitly commits the current transaction
 				Query:          "CALL DOLT_CHECKOUT('-b', 'other-branch')",
-				ExpectedErrStr: "Merge conflict detected, transaction rolled back. Merge conflicts must be resolved using the dolt_conflicts tables before committing a transaction. To commit transactions with merge conflicts, set @@dolt_allow_commit_conflicts = 1",
+				ExpectedErrStr: dsess.ErrUnresolvedConflictsCommit.Error(),
 			},
 		},
 	},
@@ -944,7 +944,7 @@ var MergeScripts = []queries.ScriptTest{
 			},
 			{
 				Query:          "CALL DOLT_MERGE('feature-branch')",
-				ExpectedErrStr: dsess.ErrUnresolvedConflictsCommit.Error(),
+				ExpectedErrStr: dsess.ErrUnresolvedConflictsAutoCommit.Error(),
 			},
 			{
 				Query:    "SELECT count(*) from dolt_conflicts_test", // transaction has been rolled back, 0 results
@@ -3486,7 +3486,7 @@ var SchemaConflictScripts = []queries.ScriptTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:          "call dolt_merge('other')",
-				ExpectedErrStr: "Merge conflict detected, transaction rolled back. Merge conflicts must be resolved using the dolt_conflicts tables before committing a transaction. To commit transactions with merge conflicts, set @@dolt_allow_commit_conflicts = 1",
+				ExpectedErrStr: dsess.ErrUnresolvedConflictsAutoCommit.Error(),
 			},
 			{
 				Query:    "select * from dolt_schema_conflicts",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_transaction_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_transaction_queries.go
@@ -1228,7 +1228,7 @@ var DoltConflictHandlingTests = []queries.TransactionTest{
 			{
 				Query: "/* client b */ COMMIT;",
 				// Retrying did not help. But at-least the error makes sense.
-				ExpectedErrStr: "Merge conflict detected, transaction rolled back. Merge conflicts must be resolved using the dolt_conflicts tables before committing a transaction. To commit transactions with merge conflicts, set @@dolt_allow_commit_conflicts = 1",
+				ExpectedErrStr: dsess.ErrUnresolvedConflictsCommit.Error(),
 			},
 		},
 	},
@@ -1419,7 +1419,7 @@ var DoltStoredProcedureTransactionTests = []queries.TransactionTest{
 			},
 			{
 				Query:          "/* client a */ CALL DOLT_MERGE('feature-branch')",
-				ExpectedErrStr: dsess.ErrUnresolvedConflictsCommit.Error(),
+				ExpectedErrStr: dsess.ErrUnresolvedConflictsAutoCommit.Error(),
 			},
 			{ // client rolled back on merge with conflicts
 				Query:    "/* client a */ SELECT count(*) from dolt_conflicts_test",


### PR DESCRIPTION
When a transaction commit conflict occurs, the next steps to take are slightly different depending on whether `@autocommit` is enabled or not. This PR changes the error message we return to describe those steps in more detail when `@autocommit` is enabled. 