### PR TITLE
[RFC] dolt sql shell slash command support

### DIFF
--- a/go/cmd/dolt/commands/add.go
+++ b/go/cmd/dolt/commands/add.go
@@ -103,7 +103,10 @@ func generateAddSql(apr *argparser.ArgParseResults) string {
 func (cmd AddCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cli.CreateAddArgParser()
 	helpPr, _ := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, addDocs, ap))
-	apr := cli.ParseArgsOrDie(ap, args, helpPr)
+	apr, err := cli.ParseArgs(ap, args, helpPr)
+	if err != nil {
+		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), nil)
+	}
 
 	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
 	if err != nil {

--- a/go/cmd/dolt/commands/branch.go
+++ b/go/cmd/dolt/commands/branch.go
@@ -106,7 +106,10 @@ func (cmd BranchCmd) EventType() eventsapi.ClientEventType {
 func (cmd BranchCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, branchDocs, ap))
-	apr := cli.ParseArgsOrDie(ap, args, help)
+	apr, err := cli.ParseArgs(ap, args, help)
+	if err != nil {
+		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+	}
 
 	queryEngine, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
 	if err != nil {

--- a/go/cmd/dolt/commands/checkout.go
+++ b/go/cmd/dolt/commands/checkout.go
@@ -87,7 +87,10 @@ func (cmd CheckoutCmd) EventType() eventsapi.ClientEventType {
 func (cmd CheckoutCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cli.CreateCheckoutArgParser()
 	helpPrt, usagePrt := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, checkoutDocs, ap))
-	apr := cli.ParseArgsOrDie(ap, args, helpPrt)
+	apr, err := cli.ParseArgs(ap, args, helpPrt)
+	if err != nil {
+		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usagePrt)
+	}
 
 	queryEngine, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
 	if err != nil {

--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -105,7 +105,10 @@ func (cmd CommitCmd) Exec(ctx context.Context, commandStr string, args []string,
 func performCommit(ctx context.Context, commandStr string, args []string, cliCtx cli.CliContext, temporaryDEnv *env.DoltEnv) (int, bool) {
 	ap := cli.CreateCommitArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, commitDocs, ap))
-	apr := cli.ParseArgsOrDie(ap, args, help)
+	apr, err := cli.ParseArgs(ap, args, help)
+	if err != nil {
+		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage), false
+	}
 
 	if err := cli.VerifyCommitArgs(apr); err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), help), false

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -184,7 +184,10 @@ func (cmd DiffCmd) RequiresRepo() bool {
 func (cmd DiffCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, diffDocs, ap))
-	apr := cli.ParseArgsOrDie(ap, args, help)
+	apr, err := cli.ParseArgs(ap, args, help)
+	if err != nil {
+		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+	}
 
 	verr := cmd.validateArgs(apr)
 	if verr != nil {

--- a/go/cmd/dolt/commands/log.go
+++ b/go/cmd/dolt/commands/log.go
@@ -98,7 +98,10 @@ func (cmd LogCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 func (cmd LogCmd) logWithLoggerFunc(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
 	help, _ := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, logDocs, ap))
-	apr := cli.ParseArgsOrDie(ap, args, help)
+	apr, err := cli.ParseArgs(ap, args, help)
+	if err != nil {
+		return handleErrAndExit(err)
+	}
 
 	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
 	if err != nil {

--- a/go/cmd/dolt/commands/merge.go
+++ b/go/cmd/dolt/commands/merge.go
@@ -92,7 +92,10 @@ func (cmd MergeCmd) RequiresRepo() bool {
 func (cmd MergeCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cli.CreateMergeArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, mergeDocs, ap))
-	apr := cli.ParseArgsOrDie(ap, args, help)
+	apr, err := cli.ParseArgs(ap, args, help)
+	if err != nil {
+		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+	}
 
 	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
 	if err != nil {

--- a/go/cmd/dolt/commands/reset.go
+++ b/go/cmd/dolt/commands/reset.go
@@ -92,7 +92,10 @@ func (cmd ResetCmd) RequiresRepo() bool {
 func (cmd ResetCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cli.CreateResetArgParser()
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, resetDocContent, ap))
-	apr := cli.ParseArgsOrDie(ap, args, help)
+	apr, err := cli.ParseArgs(ap, args, help)
+	if err != nil {
+		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+	}
 
 	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
 	if err != nil {

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -256,7 +256,7 @@ func (cmd SqlCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 		}
 
 		if isTty {
-			err := execShell(sqlCtx, queryist, format)
+			err := execShell(sqlCtx, queryist, format, cliCtx)
 			if err != nil {
 				return sqlHandleVErrAndExitCode(queryist, errhand.VerboseErrorFromError(err), usage)
 			}
@@ -680,7 +680,7 @@ func buildBatchSqlErr(stmtStartLine int, query string, err error) error {
 
 // execShell starts a SQL shell. Returns when the user exits the shell. The Root of the sqlEngine may
 // be updated by any queries which were processed.
-func execShell(sqlCtx *sql.Context, qryist cli.Queryist, format engine.PrintResultFormat) error {
+func execShell(sqlCtx *sql.Context, qryist cli.Queryist, format engine.PrintResultFormat, cliCtx cli.CliContext) error {
 	_ = iohelp.WriteLine(cli.CliOut, welcomeMsg)
 
 	historyFile := filepath.Join(".sqlhistory") // history file written to working dir
@@ -740,63 +740,87 @@ func execShell(sqlCtx *sql.Context, qryist cli.Queryist, format engine.PrintResu
 			return
 		}
 
-		closureFormat := format
-
-		// TODO: there's a bug in the readline library when editing multi-line history entries.
-		// Longer term we need to switch to a new readline library, like in this bug:
-		// https://github.com/cockroachdb/cockroach/issues/15460
-		// For now, we store all history entries as single-line strings to avoid the issue.
-		singleLine := strings.ReplaceAll(query, "\n", " ")
-
-		if err := shell.AddHistory(singleLine); err != nil {
-			// TODO: handle better, like by turning off history writing for the rest of the session
-			shell.Println(color.RedString(err.Error()))
-		}
-
-		query = strings.TrimSuffix(query, shell.LineTerminator())
-
-		// TODO: it would be better to build this into the statement parser rather than special case it here
-		for _, terminator := range verticalOutputLineTerminators {
-			if strings.HasSuffix(query, terminator) {
-				closureFormat = engine.FormatVertical
-			}
-			query = strings.TrimSuffix(query, terminator)
-		}
-
+		cont := true
 		var nextPrompt string
-		var sqlSch sql.Schema
-		var rowIter sql.RowIter
 
-		cont := func() bool {
-			subCtx, stop := signal.NotifyContext(initialCtx, os.Interrupt, syscall.SIGTERM)
-			defer stop()
+		// If the query starts with a slash, it's a shell command. We don't want to print the query in that case.
+		if strings.HasPrefix(query, "/") {
+			// cli cmd everything after the slash
+			cliCmd := query[1:]
 
-			sqlCtx := sql.NewContext(subCtx, sql.WithSession(sqlCtx.Session))
+			// TODO: determine if we can get rid of the ";" as the terminator for cli commands.
+			cliCmd = strings.TrimSuffix(cliCmd, ";")
 
-			if sqlSch, rowIter, err = processQuery(sqlCtx, query, qryist); err != nil {
-				verr := formatQueryError("", err)
-				shell.Println(verr.Verbose())
-			} else if rowIter != nil {
-				switch closureFormat {
-				case engine.FormatTabular, engine.FormatVertical:
-					err = engine.PrettyPrintResultsExtended(sqlCtx, closureFormat, sqlSch, rowIter)
-				default:
-					err = engine.PrettyPrintResults(sqlCtx, closureFormat, sqlSch, rowIter)
-				}
-
-				if err != nil {
-					shell.Println(color.RedString(err.Error()))
-				}
-			}
-
-			db, ok := getDBFromSession(sqlCtx, qryist)
-			if ok {
-				sqlCtx.SetCurrentDatabase(db)
+			// TODO: Run the string through an arg parser of some sort.
+			switch cliCmd {
+			case "status":
+				StatusCmd{}.Exec(sqlCtx, cliCmd, []string{}, nil, cliCtx)
+			case "add":
+				// this adds everything. need args!
+				AddCmd{}.Exec(sqlCtx, cliCmd, []string{"."}, nil, cliCtx)
+			case "commit":
+				CommitCmd{}.Exec(sqlCtx, cliCmd, []string{}, nil, cliCtx)
 			}
 			nextPrompt = fmt.Sprintf("%s> ", sqlCtx.GetCurrentDatabase())
+		} else {
 
-			return true
-		}()
+			closureFormat := format
+
+			// TODO: there's a bug in the readline library when editing multi-line history entries.
+			// Longer term we need to switch to a new readline library, like in this bug:
+			// https://github.com/cockroachdb/cockroach/issues/15460
+			// For now, we store all history entries as single-line strings to avoid the issue.
+			singleLine := strings.ReplaceAll(query, "\n", " ")
+
+			if err := shell.AddHistory(singleLine); err != nil {
+				// TODO: handle better, like by turning off history writing for the rest of the session
+				shell.Println(color.RedString(err.Error()))
+			}
+
+			query = strings.TrimSuffix(query, shell.LineTerminator())
+
+			// TODO: it would be better to build this into the statement parser rather than special case it here
+			for _, terminator := range verticalOutputLineTerminators {
+				if strings.HasSuffix(query, terminator) {
+					closureFormat = engine.FormatVertical
+				}
+				query = strings.TrimSuffix(query, terminator)
+			}
+
+			var sqlSch sql.Schema
+			var rowIter sql.RowIter
+
+			cont = func() bool {
+				subCtx, stop := signal.NotifyContext(initialCtx, os.Interrupt, syscall.SIGTERM)
+				defer stop()
+
+				sqlCtx := sql.NewContext(subCtx, sql.WithSession(sqlCtx.Session))
+
+				if sqlSch, rowIter, err = processQuery(sqlCtx, query, qryist); err != nil {
+					verr := formatQueryError("", err)
+					shell.Println(verr.Verbose())
+				} else if rowIter != nil {
+					switch closureFormat {
+					case engine.FormatTabular, engine.FormatVertical:
+						err = engine.PrettyPrintResultsExtended(sqlCtx, closureFormat, sqlSch, rowIter)
+					default:
+						err = engine.PrettyPrintResults(sqlCtx, closureFormat, sqlSch, rowIter)
+					}
+
+					if err != nil {
+						shell.Println(color.RedString(err.Error()))
+					}
+				}
+
+				db, ok := getDBFromSession(sqlCtx, qryist)
+				if ok {
+					sqlCtx.SetCurrentDatabase(db)
+				}
+				nextPrompt = fmt.Sprintf("%s> ", sqlCtx.GetCurrentDatabase())
+
+				return true
+			}()
+		}
 
 		if !cont {
 			return

--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -105,7 +105,11 @@ func (cmd StatusCmd) Exec(ctx context.Context, commandStr string, args []string,
 	// parse arguments
 	ap := cmd.ArgParser()
 	help, _ := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, statusDocs, ap))
-	apr := cli.ParseArgsOrDie(ap, args, help)
+	apr, err := cli.ParseArgs(ap, args, help)
+	if err != nil {
+		return handleStatusVErr(err)
+	}
+
 	showIgnoredTables := apr.Contains(cli.ShowIgnoredFlag)
 
 	// configure SQL engine


### PR DESCRIPTION
More fully fleshed out POC for https://github.com/dolthub/dolt/issues/6874. No automated testing (and I haven't even run all the commands). Checkout and merge definitely DONT work

```
# Welcome to the DoltSQL shell.
# Statements must be terminated with ';'.
# "exit" or "quit" (or Ctrl-D) to exit. "/help;" for help.
foobar> /help;
Dolt SQL Shell Help
Default behavior is to interpret SQL statements.     (e.g. 'foobar> select * from my_table;')
Dolt CLI commands can be invoked with a leading '/'. (e.g. 'foobar> /status;')
All statements are terminated with a ';'.

Available commands:
      status - Show the working tree status.
        diff - Diff a table.
         log - Show commit logs.
         add - Add table changes to the list of staged table changes.
      commit - Record changes to the repository.
    checkout - Checkout a branch or overwrite a table from HEAD.
       reset - Remove table changes from the list of staged table changes.
      branch - Create, list, edit, delete branches.
       merge - Merge a branch.
        help - What you see right now.

For more information on a specific command, type '/help <command>;' (e.g. 'foobar> /help status;')

-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-
Still need assistance? Talk directly to Dolt developers on Discord! https://discord.gg/gqr7K4VNKe
Found a bug? Want additional features? Please let us know! https://github.com/dolthub/dolt/issues
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-
```


* Nice follow on: /help dolt_commit should show docs for stored procedure