### PR TITLE
More detailed warning message for import schema not matching

### DIFF
--- a/integration-tests/bats/import-append-tables.bats
+++ b/integration-tests/bats/import-append-tables.bats
@@ -118,3 +118,18 @@ CSV
     [[ "$output" =~ "color: green" ]] || false
     [[ "$output" =~ "Errors during import can be ignored using '--continue'" ]] || false
 }
+
+@test "import-append-tables: different schema warning lists differing columns" {
+    dolt sql -q "CREATE TABLE t (pk int primary key, col1 int);"
+    run dolt table import -a t <<CSV
+pk, col2
+1, 1
+CSV
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Warning: The import file's schema does not match the table's schema" ]] || false
+    [[ "$output" =~ "If unintentional, check for any typos in the import file's header" ]] || false
+    [[ "$output" =~ "Missing columns in t:" ]] || false
+    [[ "$output" =~ "	col1" ]] || false
+    [[ "$output" =~ "Extra columns in import file:" ]] || false
+    [[ "$output" =~ "	col2" ]] || false
+}

--- a/integration-tests/bats/import-create-tables.bats
+++ b/integration-tests/bats/import-create-tables.bats
@@ -153,7 +153,7 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Import completed successfully." ]] || false
     # Sanity Check
-    ! [[ "$output" =~ "Warning: There are fewer columns in the import file's schema than the table's schema" ]] || false
+    ! [[ "$output" =~ "Warning: The import file's schema does not match the table's schema" ]] || false
 
     run dolt sql -q "select * from test"
     [ "$status" -eq 0 ]
@@ -719,7 +719,7 @@ DELIM
 
     run dolt table import -s schema.sql -c subset data.csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "Warning: There are fewer columns in the import file's schema than the table's schema" ]] || false
+    [[ "$output" =~ "Warning: The import file's schema does not match the table's schema" ]] || false
 
     # schema argument subsets the data and adds empty column
     run dolt sql -r csv -q "select * from subset ORDER BY pk"


### PR DESCRIPTION
Updates the warning message for `dolt table import` to print when the import schema does not match the destination table's schema, not just when there are fewer columns in the import file. Also updates the warning message to list the column names that differ between the import file and the destination table's schema.

Resolves: https://github.com/dolthub/dolt/issues/6113