### PR TITLE
go: sqle: cluster: Create missing remotes for cluster replication on startup if they do not already exist.

### DIFF
--- a/go/libraries/doltcore/sqle/cluster/controller.go
+++ b/go/libraries/doltcore/sqle/cluster/controller.go
@@ -305,7 +305,7 @@ func (c *Controller) applyCommitHooks(ctx context.Context, name string, bt *sql.
 			remote = env.NewRemote(r.Name(), remoteUrl, nil)
 			err := denv.AddRemote(remote)
 			if err != nil {
-				return nil, fmt.Errorf("sqle: cluster: standby replication: could not create remote %s for database %s: %v", r.Name(), name, err)
+				return nil, fmt.Errorf("sqle: cluster: standby replication: could not create remote %s for database %s: %w", r.Name(), name, err)
 			}
 		}
 		commitHook := newCommitHook(c.lgr, r.Name(), remote.Url, name, c.role, func(ctx context.Context) (*doltdb.DoltDB, error) {

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
@@ -1736,3 +1736,89 @@ tests:
   - on: server1
     queries:
     - exec: "call dolt_assume_cluster_role('primary', '3')"
+# Assert that we can add a new standby to an existing server and bring the server up.
+- name: adding new remotes to the config creates those remotes on startup
+  multi_repos:
+  - name: server1
+    with_files:
+    - name: onestandby.yaml
+      contents: |
+        log_level: trace
+        listener:
+          host: 0.0.0.0
+          port: 3309
+        cluster:
+          standby_remotes:
+          - name: standby_one
+            remote_url_template: http://localhost:3852/{database}
+          bootstrap_role: primary
+          bootstrap_epoch: 1
+          remotesapi:
+            port: 3851
+    - name: twostandbys.yaml
+      contents: |
+        log_level: trace
+        listener:
+          host: 0.0.0.0
+          port: 3309
+        cluster:
+          standby_remotes:
+          - name: standby_one
+            remote_url_template: http://localhost:3852/{database}
+          - name: standby_two
+            remote_url_template: http://localhost:3853/{database}
+          bootstrap_role: primary
+          bootstrap_epoch: 1
+          remotesapi:
+            port: 3851
+    server:
+      args: ["--config", "onestandby.yaml"]
+      port: 3309
+  - name: standby
+    with_files:
+    - name: config.yaml
+      contents: |
+        log_level: trace
+        listener:
+          host: 0.0.0.0
+          port: 3310
+        cluster:
+          standby_remotes:
+          - name: standby
+            remote_url_template: http://localhost:3851/{database}
+          bootstrap_role: standby
+          bootstrap_epoch: 1
+          remotesapi:
+            port: 3853
+    server:
+      args: ["--config", "config.yaml"]
+      port: 3310
+  connections:
+  - on: server1
+    queries:
+    - exec: "create database testdb"
+  - on: server1
+    restart_server:
+      args: ["--config", "twostandbys.yaml"]
+  - on: server1
+    queries:
+    - exec: "use testdb"
+    - query: "select count(*) from dolt_remotes"
+      result:
+        columns: ["count(*)"]
+        rows:
+        - ["2"]
+    - exec: 'SET @@GLOBAL.dolt_cluster_ack_writes_timeout_secs = 1'
+    - exec: "create table vals (id int primary key)"
+    - query: "show warnings"
+      result:
+        columns: ["Level", "Code", "Message"]
+        rows:
+        - ["Warning", "3024", "Timed out replication of commit to 1 out of 2 replicas."]
+  - on: standby
+    queries:
+    - query: "select count(*) from `testdb`.`vals`"
+      result:
+        columns: ["count(*)"]
+        rows:
+        - ["0"]

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
@@ -1774,7 +1774,7 @@ tests:
     server:
       args: ["--config", "onestandby.yaml"]
       port: 3309
-  - name: standby
+  - name: standby_one
     with_files:
     - name: config.yaml
       contents: |
@@ -1789,13 +1789,33 @@ tests:
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3853
+            port: 3852
     server:
       args: ["--config", "config.yaml"]
       port: 3310
+  - name: standby_two
+    with_files:
+    - name: config.yaml
+      contents: |
+        log_level: trace
+        listener:
+          host: 0.0.0.0
+          port: 3311
+        cluster:
+          standby_remotes:
+          - name: standby
+            remote_url_template: http://localhost:3851/{database}
+          bootstrap_role: standby
+          bootstrap_epoch: 1
+          remotesapi:
+            port: 3853
+    server:
+      args: ["--config", "config.yaml"]
+      port: 3311
   connections:
   - on: server1
     queries:
+    - exec: 'SET @@GLOBAL.dolt_cluster_ack_writes_timeout_secs = 10'
     - exec: "create database testdb"
   - on: server1
     restart_server:
@@ -1808,14 +1828,14 @@ tests:
         columns: ["count(*)"]
         rows:
         - ["2"]
-    - exec: 'SET @@GLOBAL.dolt_cluster_ack_writes_timeout_secs = 1'
+    - exec: 'SET @@GLOBAL.dolt_cluster_ack_writes_timeout_secs = 10'
     - exec: "create table vals (id int primary key)"
     - query: "show warnings"
       result:
         columns: ["Level", "Code", "Message"]
         rows:
-        - ["Warning", "3024", "Timed out replication of commit to 1 out of 2 replicas."]
-  - on: standby
+        - []
+  - on: standby_two
     queries:
     - query: "select count(*) from `testdb`.`vals`"
       result:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
@@ -183,36 +183,6 @@ tests:
       result:
         columns: ["name","url"]
         rows: [["standby","http://localhost:3852/a_new_database"]]
-- name: fails to start if a configured remote is missing
-  multi_repos:
-  - name: server1
-    repos:
-    - name: repo1
-      with_remotes:
-      - name: standby
-        url: http://localhost:3852/repo1
-    - name: repo2
-      with_remotes:
-    with_files:
-    - name: server.yaml
-      contents: |
-        log_level: trace
-        listener:
-          host: 0.0.0.0
-          port: 3309
-        cluster:
-          standby_remotes:
-          - name: standby
-            remote_url_template: http://localhost:3852/{database}
-          bootstrap_role: primary
-          bootstrap_epoch: 10
-          remotesapi:
-            port: 3851
-    server:
-      args: ["--config", "server.yaml"]
-      port: 3309
-      error_matches:
-      - destination remote standby does not exist
 - name: primary comes up and replicates to standby
   multi_repos:
   - name: server1
@@ -1817,6 +1787,8 @@ tests:
     queries:
     - exec: 'SET @@GLOBAL.dolt_cluster_ack_writes_timeout_secs = 10'
     - exec: "create database testdb"
+    - exec: "use testdb"
+    - exec: "create table vals (id int primary key)"
   - on: server1
     restart_server:
       args: ["--config", "twostandbys.yaml"]
@@ -1829,16 +1801,15 @@ tests:
         rows:
         - ["2"]
     - exec: 'SET @@GLOBAL.dolt_cluster_ack_writes_timeout_secs = 10'
-    - exec: "create table vals (id int primary key)"
+    - exec: "insert into vals values (0),(1),(2)"
     - query: "show warnings"
       result:
         columns: ["Level", "Code", "Message"]
-        rows:
-        - []
+        rows: []
   - on: standby_two
     queries:
     - query: "select count(*) from `testdb`.`vals`"
       result:
         columns: ["count(*)"]
         rows:
-        - ["0"]
+        - ["3"]


### PR DESCRIPTION
Previously `dolt sql-server` would error if there were existing databases and they were missing any of the remotes listed as cluster replication remotes in the config.yaml. This changes it so that those remotes are automatically created at startup instead.