### PR TITLE
Correctly resolve merge conflicts for types where two values with different representations can compare equal.

### DIFF
--- a/go/libraries/doltcore/doltdb/durable/index.go
+++ b/go/libraries/doltcore/doltdb/durable/index.go
@@ -15,6 +15,7 @@
 package durable
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -50,6 +51,8 @@ type Index interface {
 	// Returns the serialized bytes of the (top of the) index.
 	// Non-public. Used for flatbuffers Table persistence.
 	bytes() ([]byte, error)
+
+	DebugString(ctx context.Context) string
 }
 
 // IndexSet stores a collection secondary Indexes.
@@ -218,6 +221,10 @@ func (i nomsIndex) AddColumnToRows(ctx context.Context, newCol string, newSchema
 	return i, nil
 }
 
+func (i nomsIndex) DebugString(ctx context.Context) string {
+	panic("Not implemented")
+}
+
 type prollyIndex struct {
 	index prolly.Map
 }
@@ -327,6 +334,14 @@ func (i prollyIndex) AddColumnToRows(ctx context.Context, newCol string, newSche
 	}
 
 	return IndexFromProllyMap(newMap), nil
+}
+
+func (i prollyIndex) DebugString(ctx context.Context) string {
+	var b bytes.Buffer
+	i.index.WalkNodes(ctx, func(ctx context.Context, nd tree.Node) error {
+		return tree.OutputProllyNode(&b, nd)
+	})
+	return b.String()
 }
 
 // NewIndexSet returns an empty IndexSet.

--- a/go/libraries/doltcore/doltdb/durable/table.go
+++ b/go/libraries/doltcore/doltdb/durable/table.go
@@ -691,12 +691,7 @@ func (t doltDevTable) DebugString(ctx context.Context) string {
 		panic(err)
 	}
 
-	m := ProllyMapFromIndex(rows)
-	var b bytes.Buffer
-	m.WalkNodes(ctx, func(ctx context.Context, nd tree.Node) error {
-		return tree.OutputProllyNode(&b, nd)
-	})
-	return b.String()
+	return rows.DebugString(ctx)
 }
 
 var _ Table = doltDevTable{}

--- a/go/libraries/doltcore/merge/merge_prolly_rows.go
+++ b/go/libraries/doltcore/merge/merge_prolly_rows.go
@@ -1367,6 +1367,12 @@ func (m *secondaryMerger) merge(ctx *sql.Context, diff tree.ThreeWayDiff, leftSc
 			err = applyEdit(ctx, idx, diff.Key, baseTupleValue, newTupleValue)
 		case tree.DiffOpRightDelete:
 			err = applyEdit(ctx, idx, diff.Key, diff.Base, diff.Right)
+		case tree.DiffOpDivergentDeleteResolved:
+			// If the left-side has the delete, the index is already correct and no work needs to be done.
+			// If the right-side has the delete, remove the key from the index.
+			if diff.Right == nil {
+				err = applyEdit(ctx, idx, diff.Key, diff.Base, nil)
+			}
 		default:
 			// Any changes to the left-side of the merge are not needed, since we currently
 			// always default to using the left side of the merge as the final result, so all

--- a/go/libraries/doltcore/merge/merge_prolly_rows.go
+++ b/go/libraries/doltcore/merge/merge_prolly_rows.go
@@ -1861,8 +1861,14 @@ func (m *valueMerger) processColumn(ctx context.Context, i int, left, right, bas
 		}
 
 		if isEqual(i, leftCol, rightCol, resultType) {
-			// columns are equal, return either.
-			return leftCol, false, nil
+			// Columns are equal, returning either would be correct.
+			// However, for certain types the two columns may have different bytes.
+			// We need to ensure that merges are deterministic regardless of the merge direction.
+			// To achieve this, we sort the two values and return the higher one.
+			if bytes.Compare(leftCol, rightCol) > 0 {
+				return leftCol, false, nil
+			}
+			return rightCol, false, nil
 		}
 
 		// generated columns will be updated as part of the merge later on, so choose either value for now
@@ -1916,8 +1922,14 @@ func (m *valueMerger) processColumn(ctx context.Context, i int, left, right, bas
 		return nil, true, nil
 	}
 	if isEqual(i, leftCol, rightCol, resultType) {
-		// columns are equal, return either.
-		return leftCol, false, nil
+		// Columns are equal, returning either would be correct.
+		// However, for certain types the two columns may have different bytes.
+		// We need to ensure that merges are deterministic regardless of the merge direction.
+		// To achieve this, we sort the two values and return the higher one.
+		if bytes.Compare(leftCol, rightCol) > 0 {
+			return leftCol, false, nil
+		}
+		return rightCol, false, nil
 	}
 
 	leftModified = !isEqual(i, leftCol, baseCol, resultType)

--- a/go/libraries/doltcore/merge/merge_prolly_rows.go
+++ b/go/libraries/doltcore/merge/merge_prolly_rows.go
@@ -1104,6 +1104,10 @@ func (m *primaryMerger) merge(ctx *sql.Context, diff tree.ThreeWayDiff, sourceSc
 	case tree.DiffOpRightDelete:
 		return m.mut.Put(ctx, diff.Key, diff.Right)
 	case tree.DiffOpDivergentDeleteResolved:
+		// WARNING: In theory, we should only have to call MutableMap::Delete if the key is actually being deleted
+		// from the left branch. However, because of https://github.com/dolthub/dolt/issues/7192,
+		// if the left side of the merge is an empty table and we don't attempt to modify the map,
+		// the table will have an unexpected root hash.
 		return m.mut.Delete(ctx, diff.Key)
 	case tree.DiffOpDivergentModifyResolved:
 		// any generated columns need to be re-resolved because their computed values may have changed as a result of

--- a/go/libraries/doltcore/merge/schema_merge_test.go
+++ b/go/libraries/doltcore/merge/schema_merge_test.go
@@ -1194,11 +1194,41 @@ func testSchemaMergeHelper(t *testing.T, tests []schemaMergeTest, flipSides bool
 									require.EqualValues(t, expectedViolation.value, value)
 								}
 							} else {
-								if !assert.Equal(t, addr, a) {
+								if addr != a {
 									expTbl, _, err := m.GetTable(ctx, name)
 									require.NoError(t, err)
-									t.Logf("expected rows: %s", expTbl.DebugString(ctx))
-									t.Logf("actual rows: %s", actTbl.DebugString(ctx))
+									expRowDataHash, err := expTbl.GetRowDataHash(ctx)
+									require.NoError(t, err)
+									actRowDataHash, err := actTbl.GetRowDataHash(ctx)
+									require.NoError(t, err)
+									if expRowDataHash != actRowDataHash {
+										t.Error("Rows unequal")
+										t.Logf("expected rows: %s", expTbl.DebugString(ctx))
+										t.Logf("actual rows: %s", actTbl.DebugString(ctx))
+									}
+									expIndexSet, err := expTbl.GetIndexSet(ctx)
+									require.NoError(t, err)
+									actIndexSet, err := actTbl.GetIndexSet(ctx)
+									require.NoError(t, err)
+									expSchema, err := expTbl.GetSchema(ctx)
+									require.NoError(t, err)
+									expSchema.Indexes().Iter(func(index schema.Index) (stop bool, err error) {
+										expIndex, err := expIndexSet.GetIndex(ctx, expSchema, index.Name())
+										require.NoError(t, err)
+										actIndex, err := actIndexSet.GetIndex(ctx, expSchema, index.Name())
+										require.NoError(t, err)
+										expIndexHash, err := expIndex.HashOf()
+										require.NoError(t, err)
+										actIndexHash, err := actIndex.HashOf()
+										require.NoError(t, err)
+										if expIndexHash != actIndexHash {
+											t.Errorf("Index %s unequal", index.Name())
+											t.Logf("expected rows: %s", expIndex.DebugString(ctx))
+											t.Logf("actual rows: %s", actIndex.DebugString(ctx))
+										}
+										return false, nil
+									})
+
 								}
 							}
 						}

--- a/go/libraries/doltcore/merge/schema_merge_test.go
+++ b/go/libraries/doltcore/merge/schema_merge_test.go
@@ -16,10 +16,10 @@ package merge_test
 
 import (
 	"context"
-	"github.com/shopspring/decimal"
 	"testing"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 


### PR DESCRIPTION
Prior to this PR, we used the column's comparison operator when attempting to detect if concurrent changes to a column could be resolved during a merge operation.

However, this can cause a problem when a type has two different representations that compare equal.

- Some types have different representations that compare equal but can exhibit different behavior. For example, strings in a case-insensitive text column compare equal but behave differently when used in a context with a different collation and when displayed to the user. In this case, the merge algorithm should not consider them equal.
- Other types have different representations that compare equal and exhibit identical behavior. For example, we store Decimal types as a (integer, exponent) pair, but we don't normalize this pair. So pairs like (45, 1), (450, 0), and (4500, -1) are all indistinguishable, including comparing equal. Since there's no way to distinguish these and the user should not have to know or care which representation is used, there is no danger in resolving potential merge conflicts by simply choosing a value. However, care must be taken that the same value is used regardless of the direction of the merge, in order to guarentee that the final table hash is the same.

In order to accomplish both of these, this PR does two things:
- Forces the three-way merge algorithm to use a default comparator instead of the table's comparator. This defaults to a binary collation for strings.
- In the event that a merge conflict is auto-resolvable because the two values being assigned are equal to each other, sort them and use the higher one instead of choosing one branch arbitrarily.