### PR TITLE
[no-release-notes] Changing sysbench_runner CI test to explicitly specify script tests

### DIFF
--- a/go/performance/continuous_integration/config.json
+++ b/go/performance/continuous_integration/config.json
@@ -18,6 +18,22 @@
     }
   ],
   "ScriptDir":"/sysbench-lua-scripts",
+  "Tests": [
+    {
+      "Name":"covering_index_scan",
+      "N" : 1,
+      "FromScript": true
+    },
+    {
+      "Name":"index_join",
+      "N" : 1,
+      "FromScript": true
+    },
+    {
+      "Name":"groupby_scan",
+      "N" : 1,
+      "FromScript": true
+    }],
   "TestOptions": ["--rand-seed=1", "--table-size=30"],
   "InitBigRepo": true
 }


### PR DESCRIPTION
We have a separate CI job to test that the `sysbench_runner` util is working. It wasn't specifying any tests, so all tests in the `ScriptDir` were being run. Once postgres specific tests landed there, it started failing this CI job. 

This changes the configuration for the `sysbench_runner` CI test job to explicitly specify which tests to run, and includes three basic tests, just for a smoke test to ensure `sysbench_runner` is working correctly (not actually for the perf results). 