### PR TITLE
[no-release-notes] go/libraries/doltcore/sqle: remotesrv.go: Small cleanup so that CreateUnknownDatabases is a property of the SQL DBCache, not remotesrv.ServerArgs.

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -676,7 +676,7 @@ func persistServerLocalCreds(port int, dEnv *env.DoltEnv) (*LocalCreds, error) {
 type remotesapiAuth struct {
 	// ctxFactory is a function that returns a new sql.Context. This will create a new conext every time it is called,
 	// so it should be called once per API request.
-	ctxFactory func() (*sql.Context, error)
+	ctxFactory func(context.Context) (*sql.Context, error)
 	rawDb      *mysql_db.MySQLDb
 }
 

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -399,19 +399,20 @@ func ConfigureServices(
 			}
 
 			listenaddr := fmt.Sprintf(":%d", port)
-			args, err := sqle.RemoteSrvServerArgs(sqlEngine.NewDefaultContext, remotesrv.ServerArgs{
+			args := remotesrv.ServerArgs{
 				Logger:         logrus.NewEntry(lgr),
 				ReadOnly:       apiReadOnly || serverConfig.ReadOnly(),
 				HttpListenAddr: listenaddr,
 				GrpcListenAddr: listenaddr,
-			})
+			}
+			var err error
+			args.FS, args.DBCache, err = sqle.RemoteSrvFSAndDBCache(sqlEngine.NewDefaultContext, sqle.DoNotCreateUnknownDatabases)
 			if err != nil {
 				lgr.Errorf("error creating SQL engine context for remotesapi server: %v", err)
 				return err
 			}
 
-			ctxFactory := func() (*sql.Context, error) { return sqlEngine.NewDefaultContext(ctx) }
-			authenticator := newAccessController(ctxFactory, sqlEngine.GetUnderlyingEngine().Analyzer.Catalog.MySQLDb)
+			authenticator := newAccessController(sqlEngine.NewDefaultContext, sqlEngine.GetUnderlyingEngine().Analyzer.Catalog.MySQLDb)
 			args = sqle.WithUserPasswordAuth(args, authenticator)
 			args.TLSConfig = serverConf.TLSConfig
 
@@ -679,7 +680,7 @@ type remotesapiAuth struct {
 	rawDb      *mysql_db.MySQLDb
 }
 
-func newAccessController(ctxFactory func() (*sql.Context, error), rawDb *mysql_db.MySQLDb) remotesrv.AccessControl {
+func newAccessController(ctxFactory func(context.Context) (*sql.Context, error), rawDb *mysql_db.MySQLDb) remotesrv.AccessControl {
 	return &remotesapiAuth{ctxFactory, rawDb}
 }
 
@@ -704,7 +705,7 @@ func (r *remotesapiAuth) ApiAuthenticate(ctx context.Context) (context.Context, 
 		}
 	}
 
-	sqlCtx, err := r.ctxFactory()
+	sqlCtx, err := r.ctxFactory(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("API Runtime error: %v", err)
 	}

--- a/go/libraries/doltcore/remotesrv/server.go
+++ b/go/libraries/doltcore/remotesrv/server.go
@@ -69,10 +69,6 @@ type ServerArgs struct {
 	// listeners. The scheme used in the URLs returned from the gRPC server
 	// will be https.
 	TLSConfig *tls.Config
-
-	// In the cluster context, we want to create the databases automatically when pushed to. Other contexts we want to
-	// error when the user pushes to a database that doesn't exist.
-	CreateUnknownDatabases bool
 }
 
 func NewServer(args ServerArgs) (*Server, error) {

--- a/go/libraries/doltcore/sqle/cluster/controller.go
+++ b/go/libraries/doltcore/sqle/cluster/controller.go
@@ -689,8 +689,7 @@ func (c *Controller) RemoteSrvServerArgs(ctxFactory func(context.Context) (*sql.
 	args.GrpcListenAddr = listenaddr
 	args.Options = c.ServerOptions()
 	var err error
-	args.CreateUnknownDatabases = true
-	args, err = sqle.RemoteSrvServerArgs(ctxFactory, args)
+	args.FS, args.DBCache, err = sqle.RemoteSrvFSAndDBCache(ctxFactory, sqle.CreateUnknownDatabases)
 	if err != nil {
 		return remotesrv.ServerArgs{}, err
 	}


### PR DESCRIPTION
remotesrv.ServerArgs should be purely concerned with providing the values to the remotesrv implementation that it needs to actually run the gRPC server. This setting, CreateUnknownDatabases, it not in the control of the gRPC server itself, as currently implemented, but is purely a behavior of the DBCache implementation given the remotesrv Server.

Move this argument to (only) place where it actually has an effect.