### PR TITLE
sql shell prompt includes branch name

### DIFF
--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -910,8 +910,7 @@ func isDirty(sqlCtx *sql.Context, qryist cli.Queryist) (bool, error) {
 		return false, fmt.Errorf("invalid column count")
 	}
 
-	foo := row[0].(bool)
-	return foo, nil
+	return getStrBoolColAsBool(row[0])
 }
 
 // Returns a new auto completer with table names, column names, and SQL keywords.

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -835,8 +835,9 @@ func formattedPrompts(db, branch string) (string, string) {
 	return fmt.Sprintf("%s/%s> ", cyanDb, yellowBr), multi
 }
 
-// getDBBranchFromSession returns the current database name for the session, handling all the errors along the way by printing
-// red error messages to the CLI. If there was an issue getting the db name, the ok return value will be false.
+// getDBBranchFromSession returns the current database name and current branch  for the session, handling all the errors
+// along the way by printing red error messages to the CLI. If there was an issue getting the db name, the ok return
+// value will be false and the strings will be empty.
 func getDBBranchFromSession(sqlCtx *sql.Context, qryist cli.Queryist) (db string, branch string, ok bool) {
 	_, resp, err := qryist.Query(sqlCtx, "select database() as db, active_branch() as branch")
 	if err != nil {
@@ -864,7 +865,7 @@ func getDBBranchFromSession(sqlCtx *sql.Context, qryist cli.Queryist) (db string
 	} else {
 		db = row[0].(string)
 
-		// It is possilbe to `use mydb/branch`, and as far as your session is concerned your database is mydb/branch. We
+		// It is possible to `use mydb/branch`, and as far as your session is concerned your database is mydb/branch. We
 		// allow that, but also want to show the user the branch name in the prompt. So we munge the DB in this case.
 		if strings.HasSuffix(db, "/"+branch) {
 			db = db[:len(db)-len(branch)-1]

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -839,8 +839,8 @@ func formattedPrompts(db, branch string, dirty bool) (string, string) {
 	promptLen := len(db) + len(branch) + 3
 	dirtyStr := ""
 	if dirty {
-		dirtyStr = color.RedString(" **")
-		promptLen += 3
+		dirtyStr = color.RedString("*")
+		promptLen += 1
 	}
 
 	multi := fmt.Sprintf(fmt.Sprintf("%%%ds", promptLen), "-> ")

--- a/go/cmd/dolt/commands/utils.go
+++ b/go/cmd/dolt/commands/utils.go
@@ -368,6 +368,19 @@ func getInt64ColAsInt64(col interface{}) (int64, error) {
 	}
 }
 
+// getStringColAsString returns the value of the input as a bool. This is required because depending on if we
+// go over the wire or not we may get a string or a bool when we expect a bool.
+func getStrBoolColAsBool(col interface{}) (bool, error) {
+	switch v := col.(type) {
+	case bool:
+		return col.(bool), nil
+	case string:
+		return strings.ToLower(col.(string)) == "true", nil
+	default:
+		return false, fmt.Errorf("unexpected type %T, was expecting bool or string", v)
+	}
+}
+
 func getActiveBranchName(sqlCtx *sql.Context, queryEngine cli.Queryist) (string, error) {
 	query := "SELECT active_branch()"
 	rows, err := GetRowsForSql(queryEngine, sqlCtx, query)

--- a/integration-tests/bats/sql-delimiter.expect
+++ b/integration-tests/bats/sql-delimiter.expect
@@ -3,32 +3,32 @@
 set timeout 2
 spawn dolt sql
 expect {
-  "doltsql/main> " { send "CREATE TABLE test(pk BIGINT PRIMARY KEY, v1 BIGINT);\r"; }
+  "> " { send "CREATE TABLE test(pk BIGINT PRIMARY KEY, v1 BIGINT);\r"; }
   timeout { exit 1; }
   failed { exit 1; }
 }
 expect {
-  "doltsql/main> " { send "INSERT INTO test VALUES (0,0);\r"; }
+  "> " { send "INSERT INTO test VALUES (0,0);\r"; }
   timeout { exit 1; }
   failed { exit 1; }
 }
 expect {
-  "doltsql/main> " { send "DELIMITER $$\r"; }
+  "> " { send "DELIMITER $$\r"; }
   timeout { exit 1; }
   failed { exit 1; }
 }
 expect {
-  "doltsql/main> " { send "INSERT INTO test VALUES (1,1)$$\r"; }
+  "> " { send "INSERT INTO test VALUES (1,1)$$\r"; }
   timeout { exit 1; }
   failed { exit 1; }
 }
 expect {
-  "doltsql/main> " { send "delimiter #\r"; }
+  "> " { send "delimiter #\r"; }
   timeout { exit 1; }
   failed { exit 1; }
 }
 expect {
-  "doltsql/main> " { send "CREATE TRIGGER tt BEFORE INSERT ON test FOR EACH ROW\r"; }
+  "> " { send "CREATE TRIGGER tt BEFORE INSERT ON test FOR EACH ROW\r"; }
   timeout { exit 1; }
   failed { exit 1; }
 }
@@ -53,7 +53,7 @@ expect {
   failed { exit 1; }
 }
 expect {
-  "doltsql/main> " { send "DeLiMiTeR ;\r"; }
+  "> " { send "DeLiMiTeR ;\r"; }
   timeout { exit 1; }
   failed { exit 1; }
 }

--- a/integration-tests/bats/sql-delimiter.expect
+++ b/integration-tests/bats/sql-delimiter.expect
@@ -3,32 +3,32 @@
 set timeout 2
 spawn dolt sql
 expect {
-  "doltsql> " { send "CREATE TABLE test(pk BIGINT PRIMARY KEY, v1 BIGINT);\r"; }
+  "doltsql/main> " { send "CREATE TABLE test(pk BIGINT PRIMARY KEY, v1 BIGINT);\r"; }
   timeout { exit 1; }
   failed { exit 1; }
 }
 expect {
-  "doltsql> " { send "INSERT INTO test VALUES (0,0);\r"; }
+  "doltsql/main> " { send "INSERT INTO test VALUES (0,0);\r"; }
   timeout { exit 1; }
   failed { exit 1; }
 }
 expect {
-  "doltsql> " { send "DELIMITER $$\r"; }
+  "doltsql/main> " { send "DELIMITER $$\r"; }
   timeout { exit 1; }
   failed { exit 1; }
 }
 expect {
-  "doltsql> " { send "INSERT INTO test VALUES (1,1)$$\r"; }
+  "doltsql/main> " { send "INSERT INTO test VALUES (1,1)$$\r"; }
   timeout { exit 1; }
   failed { exit 1; }
 }
 expect {
-  "doltsql> " { send "delimiter #\r"; }
+  "doltsql/main> " { send "delimiter #\r"; }
   timeout { exit 1; }
   failed { exit 1; }
 }
 expect {
-  "doltsql> " { send "CREATE TRIGGER tt BEFORE INSERT ON test FOR EACH ROW\r"; }
+  "doltsql/main> " { send "CREATE TRIGGER tt BEFORE INSERT ON test FOR EACH ROW\r"; }
   timeout { exit 1; }
   failed { exit 1; }
 }
@@ -53,7 +53,7 @@ expect {
   failed { exit 1; }
 }
 expect {
-  "doltsql> " { send "DeLiMiTeR ;\r"; }
+  "doltsql/main> " { send "DeLiMiTeR ;\r"; }
   timeout { exit 1; }
   failed { exit 1; }
 }

--- a/integration-tests/bats/sql-shell-prompt.expect
+++ b/integration-tests/bats/sql-shell-prompt.expect
@@ -1,5 +1,6 @@
 #!/usr/bin/expect
 
+set timeout 5
 spawn dolt sql
 
 expect {

--- a/integration-tests/bats/sql-shell-prompt.expect
+++ b/integration-tests/bats/sql-shell-prompt.expect
@@ -1,0 +1,49 @@
+#!/usr/bin/expect
+
+spawn dolt sql
+
+expect {
+    -re "> " { send "create database mydb;\r"; }
+    timeout { exit 1; }
+    failed { exit 1; }
+}
+expect {
+    -re "> " { send "use mydb;\r"; }
+    timeout { exit 1; }
+    failed { exit 1; }
+}
+expect {
+    -re ".*mydb.*/.*main.*> " { send "create table tbl (i int);\r"; }
+    timeout { exit 1; }
+    failed { exit 1; }
+}
+
+# Dirty workspace should show in prompt as a "*" before the ">"
+# (all the .* instances here are to account for ansi colors chars.
+expect {
+    -re ".*mydb.*/.*main.*\\*.*> " { send "call dolt_commit('-Am', 'msg');\r"; }
+    timeout { exit 1; }
+    failed { exit 1; }
+}
+
+expect {
+    -re ".*mydb.*/.*main.*> " { send "call dolt_checkout('-b','other','HEAD');\r"; }
+    timeout { exit 1; }
+    failed { exit 1; }
+}
+
+expect {
+    -re ".*mydb.*/.*main.*> " { send "use mysql;\r"; }
+    timeout { exit 1; }
+    failed { exit 1; }
+}
+
+# using a non dolt db should result in a prompt without a slash. The brackets
+# are required to get expect to properly parse this regex.
+expect {
+    -re {.*mysql[^\\/]*> } { send "exit;\r"; }
+    timeout { exit 1; }
+    failed { exit 1; }
+}
+
+expect eof

--- a/integration-tests/bats/sql-shell.bats
+++ b/integration-tests/bats/sql-shell.bats
@@ -68,6 +68,17 @@ teardown() {
 }
 
 # bats test_tags=no_lambda
+@test "sql-shell: sql shell prompt updates" {
+    skiponwindows "Need to install expect and make this script work on windows."
+
+    # start in an empty directory
+    mkdir sql_shell_test
+    cd sql_shell_test
+
+    $BATS_TEST_DIRNAME/sql-shell-prompt.expect
+}
+
+# bats test_tags=no_lambda
 @test "sql-shell: shell works after failing query" {
     skiponwindows "Need to install expect and make this script work on windows."
     $BATS_TEST_DIRNAME/sql-works-after-failing-query.expect

--- a/integration-tests/bats/sql-shell.bats
+++ b/integration-tests/bats/sql-shell.bats
@@ -70,8 +70,12 @@ teardown() {
 # bats test_tags=no_lambda
 @test "sql-shell: sql shell prompt updates" {
     skiponwindows "Need to install expect and make this script work on windows."
+    if [ "$SQL_ENGINE" = "remote-engine" ]; then
+      skip "Presently sql command will not connect to remote server due to lack of lock file where there are not DBs."
+    fi
 
     # start in an empty directory
+    rm -rf .dolt
     mkdir sql_shell_test
     cd sql_shell_test
 

--- a/integration-tests/bats/sql-unique-error.expect
+++ b/integration-tests/bats/sql-unique-error.expect
@@ -4,34 +4,34 @@ set timeout 2
 spawn dolt sql
 
 expect {
-  "doltsql/main> " { send "CREATE TABLE test(pk BIGINT PRIMARY KEY, v1 BIGINT UNIQUE);\r"; }
+  "> " { send "CREATE TABLE test(pk BIGINT PRIMARY KEY, v1 BIGINT UNIQUE);\r"; }
   timeout { exit 1; }
   failed { exit 1; }
 }
 
 expect {
-  "doltsql/main> " { send "INSERT INTO test VALUES (0,0);\r"; }
+  "> " { send "INSERT INTO test VALUES (0,0);\r"; }
   timeout { exit 1; }
   failed { exit 1; }
 }
 
 expect {
-  "doltsql/main> " { send "INSERT INTO test VALUES (1,0);\r"; }
+  "> " { send "INSERT INTO test VALUES (1,0);\r"; }
   timeout { exit 1; }
   "UNIQUE" { exp_continue; }
   failed { exp_continue; }
 }
 
 expect {
-  "doltsql/main> " { send "INSERT INTO test VALUES (1,1);\r"; }
+  "> " { send "INSERT INTO test VALUES (1,1);\r"; }
   timeout { exit 1; }
   failed { exit 1; }
 }
 
 expect {
-  "doltsql/main> " { send "INSERT INTO test VALUES (2,2);\r"; }
-  timeout { exit 1; }
-  failed { exit 1; }
-}
+  "> " { send "INSERT INTO test VALUES (2,2);\r"; }
+   timeout { exit 1; }
+   failed { exit 1; }
+ }
 
 expect eof

--- a/integration-tests/bats/sql-unique-error.expect
+++ b/integration-tests/bats/sql-unique-error.expect
@@ -4,32 +4,32 @@ set timeout 2
 spawn dolt sql
 
 expect {
-  "doltsql> " { send "CREATE TABLE test(pk BIGINT PRIMARY KEY, v1 BIGINT UNIQUE);\r"; }
+  "doltsql/main> " { send "CREATE TABLE test(pk BIGINT PRIMARY KEY, v1 BIGINT UNIQUE);\r"; }
   timeout { exit 1; }
   failed { exit 1; }
 }
 
 expect {
-  "doltsql> " { send "INSERT INTO test VALUES (0,0);\r"; }
+  "doltsql/main> " { send "INSERT INTO test VALUES (0,0);\r"; }
   timeout { exit 1; }
   failed { exit 1; }
 }
 
 expect {
-  "doltsql> " { send "INSERT INTO test VALUES (1,0);\r"; }
+  "doltsql/main> " { send "INSERT INTO test VALUES (1,0);\r"; }
   timeout { exit 1; }
   "UNIQUE" { exp_continue; }
   failed { exp_continue; }
 }
 
 expect {
-  "doltsql> " { send "INSERT INTO test VALUES (1,1);\r"; }
+  "doltsql/main> " { send "INSERT INTO test VALUES (1,1);\r"; }
   timeout { exit 1; }
   failed { exit 1; }
 }
 
 expect {
-  "doltsql> " { send "INSERT INTO test VALUES (2,2);\r"; }
+  "doltsql/main> " { send "INSERT INTO test VALUES (2,2);\r"; }
   timeout { exit 1; }
   failed { exit 1; }
 }

--- a/integration-tests/bats/sql-use.expect
+++ b/integration-tests/bats/sql-use.expect
@@ -7,7 +7,7 @@ spawn dolt sql
 # error output includes the line of the failed test expectation
 
 expect {
-    "*doltsql> " { send -- "use `doltsql/test`;\r"; }
+    "*doltsql/main> " { send -- "use `doltsql/test`;\r"; }
     timeout { puts "$TESTFAILURE"; }
 }
 
@@ -37,26 +37,26 @@ expect {
 }
 
 expect {
-    -re "|.*db1.*|\r.*db1> " { send -- "select database();\r"; }
+    -re "|.*db1.*|\r.*db1.*> " { send -- "select database();\r"; }
     timeout { puts "$TESTFAILURE"; }
 }
 
 expect {
-    "*db1>" { send -- "use db2;\r"; }
+    "*db1/main>" { send -- "use db2;\r"; }
     timeout { puts "$TESTFAILURE"; }
 }
 
 expect {
-    "*db2> " { send -- "select database();\r"; }
+    "*db2/main> " { send -- "select database();\r"; }
     timeout { puts "$TESTFAILURE"; }
 }
 
 expect {
-    -re "|.*db2.*|.*\rdb2>" { send -- "use mydb;\r"; }
+    -re "|.*db2.*|.*\rdb2/main>" { send -- "use mydb;\r"; }
     timeout { puts "$TESTFAILURE"; }
 }
 
 expect {
-    "mydb> " { send -- "exit ;\r"; }
+    "mydb/main> " { send -- "exit ;\r"; }
     timeout { puts "$TESTFAILURE"; }
 }

--- a/integration-tests/bats/sql-use.expect
+++ b/integration-tests/bats/sql-use.expect
@@ -7,32 +7,32 @@ spawn dolt sql
 # error output includes the line of the failed test expectation
 
 expect {
-    "*doltsql/main> " { send -- "use `doltsql/test`;\r"; }
+    -re ".*doltsql.*/.*main.*> " { send -- "use `doltsql/test`;\r"; }
     timeout { puts "$TESTFAILURE"; }
 }
 
 expect {
-    "*doltsql/test> " { send -- "show tables;\r"; }
+    -re ".*doltsql.*/.*test.*> " { send -- "show tables;\r"; }
     timeout { puts "$TESTFAILURE"; }
 }
 
 expect {
-    "*doltsql/test> " { send -- "use information_schema;\r"; }
+    -re ".*doltsql.*/.*test.*> " { send -- "use information_schema;\r"; }
     timeout { puts "$TESTFAILURE"; }
 }
 
 expect {
-    "*information_schema> " { send -- "show tables;\r"; }
+    -re ".*information_schema.*> " { send -- "show tables;\r"; }
     timeout { puts "$TESTFAILURE"; }
 }
 
 expect {
-    "*information_schema> " { send -- "CREATE DATABASE mydb;\r"; }
+    -re ".*information_schema.*> " { send -- "CREATE DATABASE mydb;\r"; }
     timeout { puts "$TESTFAILURE"; }
 }
 
 expect {
-    "*information_schema> " { send -- "use db1;\r"; }
+    -re ".*information_schema.*> " { send -- "use db1;\r"; }
     timeout { puts "$TESTFAILURE"; }
 }
 
@@ -42,12 +42,12 @@ expect {
 }
 
 expect {
-    "*db1/main>" { send -- "use db2;\r"; }
+    -re ".*db1.*/.*main.*>" { send -- "use db2;\r"; }
     timeout { puts "$TESTFAILURE"; }
 }
 
 expect {
-    "*db2/main> " { send -- "select database();\r"; }
+    -re ".*db2.*/.*main.*> " { send -- "select database();\r"; }
     timeout { puts "$TESTFAILURE"; }
 }
 
@@ -57,6 +57,6 @@ expect {
 }
 
 expect {
-    "mydb/main> " { send -- "exit ;\r"; }
+    -re ".*mydb.*/.*main.*> " { send -- "exit ;\r"; }
     timeout { puts "$TESTFAILURE"; }
 }


### PR DESCRIPTION
Three changes to the `dolt sql` shell:
 * Show the branch you are on: `mydb/main>`
 * Show the workspace is dirty with a "*" in the prompt
 * Add color to the DB name, branch, and dirty status.