### PR TITLE
dolt_pull performance improvement

### DIFF
--- a/go/libraries/doltcore/sqle/dprocedures/dolt_pull.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_pull.go
@@ -148,14 +148,9 @@ func doDoltPull(ctx *sql.Context, args []string) (int, int, error) {
 			}
 
 			rsSeen = true
-			tmpDir, err := dbData.Rsw.TempTableFilesDir()
-			if err != nil {
-				return noConflictsOrViolations, threeWayMerge, err
-			}
 
-			// TODO - we don't need to fetch again. this is hold over from the past to get the srcDBCommit.
-			// todo: can we pass nil for either of the channels?
-			srcDBCommit, err := actions.FetchRemoteBranch(ctx, tmpDir, pullSpec.Remote, srcDB, dbData.Ddb, branchRef, runProgFuncs, stopProgFuncs)
+			cs, _ := doltdb.NewCommitSpec(branchRef.String())
+			srcDBCommit, err := srcDB.Resolve(ctx, cs, nil)
 			if err != nil {
 				return noConflictsOrViolations, threeWayMerge, err
 			}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_pull.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_pull.go
@@ -125,7 +125,6 @@ func doDoltPull(ctx *sql.Context, args []string) (int, int, error) {
 			fmt.Errorf("branch %q not found on remote", pullSpec.Branch.GetPath())
 	}
 
-	// Do the mega fetch, like in dolt_fetch.go
 	mode := ref.UpdateMode{Force: true, Prune: false}
 	err = actions.FetchRefSpecs(ctx, dbData, srcDB, pullSpec.RefSpecs, pullSpec.Remote, mode, runProgFuncs, stopProgFuncs)
 	if err != nil {

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_pull.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_pull.go
@@ -153,7 +153,7 @@ func doDoltPull(ctx *sql.Context, args []string) (int, int, error) {
 				return noConflictsOrViolations, threeWayMerge, err
 			}
 
-			// TODO - we don't need to fetch again. this is
+			// TODO - we don't need to fetch again. this is hold over from the past to get the srcDBCommit.
 			// todo: can we pass nil for either of the channels?
 			srcDBCommit, err := actions.FetchRemoteBranch(ctx, tmpDir, pullSpec.Remote, srcDB, dbData.Ddb, branchRef, runProgFuncs, stopProgFuncs)
 			if err != nil {


### PR DESCRIPTION
`dolt_pull` currently performs unnecessary FastForwards for remote branches. There is a more optimal mechanism to fetch all remotes, actions.FetchRefSpecs, and by using that we greatly increase the speed of `dolt_pull` when there are lot of remote branches.