### PR TITLE
default to text option for `dolt table import`

### DIFF
--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
 	"github.com/dolthub/go-mysql-server/sql"
 	gmstypes "github.com/dolthub/go-mysql-server/sql/types"
 	"github.com/dolthub/vitess/go/sqltypes"
@@ -44,6 +43,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/mvdata"
 	"github.com/dolthub/dolt/go/libraries/doltcore/rowconv"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlutil"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"

--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -20,10 +20,12 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync/atomic"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
 	"github.com/dolthub/go-mysql-server/sql"
 	gmstypes "github.com/dolthub/go-mysql-server/sql/types"
 	"github.com/dolthub/vitess/go/sqltypes"
@@ -68,6 +70,7 @@ const (
 	quiet             = "quiet"
 	ignoreSkippedRows = "ignore-skipped-rows" // alias for quiet
 	disableFkChecks   = "disable-fk-checks"
+	allTextParam      = "all-text"
 )
 
 var jsonInputFileHelp = "The expected JSON input file format is:" + `
@@ -109,7 +112,7 @@ During import, if there is an error importing any row, the import will be aborte
 In create, update, and replace scenarios the file's extension is used to infer the type of the file.  If a file does not have the expected extension then the {{.EmphasisLeft}}--file-type{{.EmphasisRight}} parameter should be used to explicitly define the format of the file in one of the supported formats (csv, psv, json, xlsx).  For files separated by a delimiter other than a ',' (type csv) or a '|' (type psv), the --delim parameter can be used to specify a delimiter`,
 
 	Synopsis: []string{
-		"-c [-f] [--pk {{.LessThan}}field{{.GreaterThan}}] [--schema {{.LessThan}}file{{.GreaterThan}}] [--map {{.LessThan}}file{{.GreaterThan}}] [--continue]  [--quiet] [--disable-fk-checks] [--file-type {{.LessThan}}type{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
+		"-c [-f] [--pk {{.LessThan}}field{{.GreaterThan}}] [--all-text] [--schema {{.LessThan}}file{{.GreaterThan}}] [--map {{.LessThan}}file{{.GreaterThan}}] [--continue]  [--quiet] [--disable-fk-checks] [--file-type {{.LessThan}}type{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
 		"-u [--map {{.LessThan}}file{{.GreaterThan}}] [--continue] [--quiet] [--file-type {{.LessThan}}type{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
 		"-a [--map {{.LessThan}}file{{.GreaterThan}}] [--continue] [--quiet] [--file-type {{.LessThan}}type{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
 		"-r [--map {{.LessThan}}file{{.GreaterThan}}] [--file-type {{.LessThan}}type{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
@@ -130,6 +133,7 @@ type importOptions struct {
 	srcOptions      interface{}
 	quiet           bool
 	disableFkChecks bool
+	allText         bool
 }
 
 func (m importOptions) IsBatched() bool {
@@ -193,6 +197,7 @@ func getImportMoveOptions(ctx context.Context, apr *argparser.ArgParseResults, d
 	contOnErr := apr.Contains(contOnErrParam)
 	quiet := apr.Contains(quiet)
 	disableFks := apr.Contains(disableFkChecks)
+	allText := apr.Contains(allTextParam)
 
 	val, _ := apr.GetValue(primaryKeyParam)
 	pks := funcitr.MapStrings(strings.Split(val, ","), strings.TrimSpace)
@@ -274,6 +279,7 @@ func getImportMoveOptions(ctx context.Context, apr *argparser.ArgParseResults, d
 		srcOptions:      srcOpts,
 		quiet:           quiet,
 		disableFkChecks: disableFks,
+		allText:         allText,
 	}, nil
 
 }
@@ -297,6 +303,14 @@ func validateImportArgs(apr *argparser.ArgParseResults) errhand.VerboseError {
 
 	if apr.Contains(schemaParam) && !apr.Contains(createParam) {
 		return errhand.BuildDError("fatal: " + schemaParam + " is not supported for update or replace operations").Build()
+	}
+
+	if apr.Contains(allTextParam) && !apr.Contains(createParam) {
+		return errhand.BuildDError("fatal: --%s is only supported for create operations", allTextParam).Build()
+	}
+
+	if apr.ContainsAll(allTextParam, schemaParam) {
+		return errhand.BuildDError("parameters %s and %s are mutually exclusive", allTextParam, schemaParam).Build()
 	}
 
 	tableName := apr.Arg(0)
@@ -364,8 +378,8 @@ func (cmd ImportCmd) ArgParser() *argparser.ArgParser {
 	ap.SupportsFlag(createParam, "c", "Create a new table, or overwrite an existing table (with the -f flag) from the imported data.")
 	ap.SupportsFlag(updateParam, "u", "Update an existing table with the imported data.")
 	ap.SupportsFlag(appendParam, "a", "Require that the operation will not modify any rows in the table.")
-	ap.SupportsFlag(forceParam, "f", "If a create operation is being executed, data already exists in the destination, the force flag will allow the target to be overwritten.")
 	ap.SupportsFlag(replaceParam, "r", "Replace existing table with imported data while preserving the original schema.")
+	ap.SupportsFlag(forceParam, "f", "If a create operation is being executed, data already exists in the destination, the force flag will allow the target to be overwritten.")
 	ap.SupportsFlag(contOnErrParam, "", "Continue importing when row import errors are encountered.")
 	ap.SupportsFlag(quiet, "", "Suppress any warning messages about invalid rows when using the --continue flag.")
 	ap.SupportsAlias(ignoreSkippedRows, quiet)
@@ -375,6 +389,7 @@ func (cmd ImportCmd) ArgParser() *argparser.ArgParser {
 	ap.SupportsString(primaryKeyParam, "pk", "primary_key", "Explicitly define the name of the field in the schema which should be used as the primary key.")
 	ap.SupportsString(fileTypeParam, "", "file_type", "Explicitly define the type of the file if it can't be inferred from the file extension.")
 	ap.SupportsString(delimParam, "", "delimiter", "Specify a delimiter for a csv style file with a non-comma delimiter.")
+	ap.SupportsFlag(allTextParam, "", "Treats all fields as text. Can only be used when creating a table.")
 	return ap
 }
 
@@ -699,6 +714,14 @@ func getImportSchema(ctx context.Context, dEnv *env.DoltEnv, impOpts *importOpti
 		}
 		defer rd.Close(ctx)
 
+		if impOpts.allText {
+			outSch, err := generateAllTextSchema(rd, impOpts)
+			if err != nil {
+				return nil, &mvdata.DataMoverCreationError{ErrType: mvdata.SchemaErr, Cause: err}
+			}
+			return outSch, nil
+		}
+
 		if impOpts.srcIsJson() {
 			return rd.GetSchema(), nil
 		}
@@ -724,6 +747,34 @@ func getImportSchema(ctx context.Context, dEnv *env.DoltEnv, impOpts *importOpti
 	defer tblRd.Close(ctx)
 
 	return tblRd.GetSchema(), nil
+}
+
+// generateAllTextSchema returns a schema where each column has a text type. Primary key columns will have type
+// varchar(16383) because text type is not supported for priamry keys.
+func generateAllTextSchema(rd table.ReadCloser, impOpts *importOptions) (schema.Schema, error) {
+	var cols []schema.Column
+	err := rd.GetSchema().GetAllCols().Iter(func(tag uint64, col schema.Column) (stop bool, err error) {
+		var colType typeinfo.TypeInfo
+		if slices.Contains(impOpts.primaryKeys, col.Name) {
+			colType = typeinfo.StringDefaultType
+		} else {
+			colType = typeinfo.TextType
+		}
+
+		col.Kind = colType.NomsKind()
+		col.TypeInfo = colType
+		col.Name = impOpts.ColNameMapper().Map(col.Name)
+		col.Tag = schema.ReservedTagMin + tag
+		// we don't check the file so can't safely add not null constraint
+		col.Constraints = []schema.ColConstraint(nil)
+
+		cols = append(cols, col)
+		return false, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return schema.SchemaFromCols(schema.NewColCollection(cols...))
 }
 
 func newDataMoverErrToVerr(mvOpts *importOptions, err *mvdata.DataMoverCreationError) errhand.VerboseError {

--- a/integration-tests/bats/import-append-tables.bats
+++ b/integration-tests/bats/import-append-tables.bats
@@ -133,3 +133,13 @@ CSV
     [[ "$output" =~ "Extra columns in import file:" ]] || false
     [[ "$output" =~ "	col2" ]] || false
 }
+
+@test "import-append-tables: can't use --all-text with -a" {
+    dolt sql -q "CREATE TABLE t (pk int primary key, col1 int);"
+    run dolt table import -a t --all-text <<CSV
+pk, col1
+1, 1
+CSV
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "fatal: --all-text is only supported for create operations" ]] || false
+}

--- a/integration-tests/bats/import-create-tables.bats
+++ b/integration-tests/bats/import-create-tables.bats
@@ -875,3 +875,26 @@ SQL
     [[ "$output" =~ "| 0  | NULL     | poop |" ]] || false
     [[ "$output" =~ "| 1  | NULL     | poop |" ]] || false
 }
+
+@test "import-create-tables: --all-text imports all columns as text" {
+    cat <<DELIM >test.csv
+id, state, data
+1,WA,"{""a"":1,""b"":""value""}"
+DELIM
+
+    run dolt table import -c --all-text --pk=id test test.csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Import completed successfully." ]] || false
+
+    run dolt sql -q "describe test"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "| id    | varchar(16383) |" ]] || false
+    [[ "$output" =~ "| state | text           |" ]] || false
+    [[ "$output" =~ "| data  | text           |" ]] || false
+}
+
+@test "import-create-tables: --all-text and --schema are mutually exclusive" {
+    run dolt table import -c -s `batshelper employees-sch.sql` --all-text employees `batshelper employees-tbl.json`
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "parameters all-text and schema are mutually exclusive" ]] || false
+}

--- a/integration-tests/bats/import-replace-tables.bats
+++ b/integration-tests/bats/import-replace-tables.bats
@@ -446,3 +446,20 @@ DELIM
     [ "$status" -eq 1 ]
     [[ "$output" =~ "cannot truncate table colors as it is referenced in foreign key" ]] || false
 }
+
+@test "import-replace-tables: can't use --all-text with -r" {
+    dolt sql <<SQL
+CREATE TABLE test (
+  pk BIGINT NOT NULL COMMENT 'tag:0',
+  c1 BIGINT COMMENT 'tag:1',
+  c2 BIGINT COMMENT 'tag:2',
+  c3 BIGINT COMMENT 'tag:3',
+  c4 BIGINT COMMENT 'tag:4',
+  c5 BIGINT COMMENT 'tag:5',
+  PRIMARY KEY (pk)
+);
+SQL
+    run dolt table import -r --all-text test `batshelper 1pk5col-ints.csv`
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "fatal: --all-text is only supported for create operations" ]] || false
+}

--- a/integration-tests/bats/import-tables.bats
+++ b/integration-tests/bats/import-tables.bats
@@ -19,9 +19,6 @@ teardown() {
 
 @test "import-tables: error if multiple operations are provided" {
     run dolt table import -c -u -r t test.csv
-
-    echo "$output"
-
     [ "$status" -eq 1 ]
     [[ "$output" =~ "Must specify exactly one of -c, -u, -a, or -r." ]] || false
 }

--- a/integration-tests/bats/import-update-tables.bats
+++ b/integration-tests/bats/import-update-tables.bats
@@ -1479,3 +1479,10 @@ DELIM
     [ $status -eq 0 ]
     [[ "$output" = "$expected" ]] || false
 }
+
+@test "import-update-tables: can't use --all-text with -u" {
+    dolt sql < 1pk5col-ints-sch.sql
+    run dolt table import -u --all-text test `batshelper 1pk5col-ints.csv`
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "fatal: --all-text is only supported for create operations" ]] || false
+}


### PR DESCRIPTION
Adds the `--all-text` option to `dolt table import` which will default all columns to `TEXT` type.

Resolves: https://github.com/dolthub/dolt/issues/6471