### PR TITLE
Bug fix: keyless table constraint violations

### DIFF
--- a/go/libraries/doltcore/doltdb/table.go
+++ b/go/libraries/doltcore/doltdb/table.go
@@ -34,6 +34,8 @@ import (
 
 var ErrNoConflictsResolved = errors.New("no conflicts resolved")
 
+const dolt_row_hash_tag = 0
+
 // IsValidTableName checks if name is a valid identifer, and doesn't end with space characters
 func IsValidTableName(name string) bool {
 	if len(name) == 0 || unicode.IsSpace(rune(name[len(name)-1])) {
@@ -354,18 +356,19 @@ func (t *Table) GetConstraintViolationsSchema(ctx context.Context) (schema.Schem
 
 	colColl := schema.NewColCollection()
 
-	if t.Format() == types.Format_DOLT {
-		// the commit hash or working set hash of the right side during merge
-		colColl = colColl.Append(schema.NewColumn("from_root_ish", 0, types.StringKind, false))
-		colColl = colColl.Append(typeCol)
-		colColl = colColl.Append(sch.GetPKCols().GetColumns()...)
-		colColl = colColl.Append(sch.GetNonPKCols().GetColumns()...)
-		colColl = colColl.Append(infoCol)
+	// the commit hash or working set hash of the right side during merge
+	colColl = colColl.Append(schema.NewColumn("from_root_ish", 0, types.StringKind, false))
+	colColl = colColl.Append(typeCol)
+	if schema.IsKeyless(sch) {
+		// If this is a keyless table, we need to add a new column for the keyless table's generated row hash.
+		// We need to add this internal row hash value, in order to guarantee a unique primary key in the
+		// constraint violations table.
+		colColl = colColl.Append(schema.NewColumn("dolt_row_hash", dolt_row_hash_tag, types.BlobKind, true))
 	} else {
-		colColl = colColl.Append(typeCol)
-		colColl = colColl.Append(sch.GetAllCols().GetColumns()...)
-		colColl = colColl.Append(infoCol)
+		colColl = colColl.Append(sch.GetPKCols().GetColumns()...)
 	}
+	colColl = colColl.Append(sch.GetNonPKCols().GetColumns()...)
+	colColl = colColl.Append(infoCol)
 
 	return schema.SchemaFromCols(colColl)
 }

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
@@ -116,6 +116,16 @@ var MergeScripts = []queries.ScriptTest{
 				Query:    "DELETE FROM dolt_constraint_violations_aTable;",
 				Expected: []sql.Row{{types.NewOkResult(2)}},
 			},
+			{
+				// Commit the merge after resolving the constraint violations
+				Query:    "call dolt_commit('-am', 'merging in main and resolving unique constraint violations');",
+				Expected: []sql.Row{{doltCommit}},
+			},
+			{
+				// Merging again is a no-op
+				Query:    "call dolt_merge('main');",
+				Expected: []sql.Row{{doltCommit, 0, 0}},
+			},
 		},
 	},
 	{

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
@@ -100,10 +100,10 @@ var MergeScripts = []queries.ScriptTest{
 				Expected: []sql.Row{{"aTable", uint64(2)}},
 			},
 			{
-				Query: "SELECT from_root_ish, violation_type, aColumn, bColumn, CAST(violation_info as CHAR) FROM dolt_constraint_violations_aTable;",
+				Query: "SELECT from_root_ish, violation_type, hex(dolt_row_hash), aColumn, bColumn, CAST(violation_info as CHAR) FROM dolt_constraint_violations_aTable;",
 				Expected: []sql.Row{
-					{doltCommit, "unique index", 1, 2, `{"Columns":["aColumn"],"Name":"aColumn_UNIQUE"}`},
-					{doltCommit, "unique index", 1, 3, `{"Columns":["aColumn"],"Name":"aColumn_UNIQUE"}`},
+					{doltCommit, "unique index", "5A1ED8633E1842FCA8EE529E4F1C5944", 1, 2, `{"Columns":["aColumn"],"Name":"aColumn_UNIQUE"}`},
+					{doltCommit, "unique index", "A922BFBF4E5489501A3808BC5CD702C0", 1, 3, `{"Columns":["aColumn"],"Name":"aColumn_UNIQUE"}`},
 				},
 			},
 			{


### PR DESCRIPTION
Keyless tables didn't expose a unique row identifier in the `dolt_constraint_violations_<table>` system tables. This manifested as a panic when trying to delete the violation artifacts from the system table, but it also meant that we couldn't uniquely identify rows in the system table by the system table's PK for keyless tables. To enable keyless tables to use constraint violation artifacts, we now return the row's identifying hash from the source keyless table in the system table. Note that the `dolt_conflicts_<table>` system table did not have a similar issue because its primary key is a unique ID generated in the `dolt_conflict_id` field. 

Related to: https://github.com/dolthub/dolt/issues/7275