### PR TITLE
[no-release-notes] Human Readable CommitClosure printing

### DIFF
--- a/go/store/cmd/noms/noms_show.go
+++ b/go/store/cmd/noms/noms_show.go
@@ -157,6 +157,8 @@ func typeString(value types.Value) string {
 			typeString = "ProllyTreeNode"
 		case serial.AddressMapFileID:
 			typeString = "AddressMap"
+		case serial.CommitClosureFileID:
+			typeString = "CommitClosure"
 		default:
 			t, err := types.TypeOf(value)
 			util.CheckErrorNoUsage(err)
@@ -249,8 +251,6 @@ func outputEncodedValue(ctx context.Context, w io.Writer, value types.Value) err
 		case serial.ProllyTreeNodeFileID:
 			fallthrough
 		case serial.AddressMapFileID:
-			fallthrough
-		case serial.CommitClosureFileID:
 			node, err := shim.NodeFromValue(value)
 			if err != nil {
 				return err


### PR DESCRIPTION
Previously, `noms show` was panicking whenever it encountered a CommitClosure. This change fixes that.

splunk.pl output:

```
> 1
     Commit - {
        Name: macneale
        Desc: Commit 99
        Email: neil@dolthub.com
        Timestamp: 2024-01-09 09:50:00.585 -0800 PST
        UserTimestamp: 2024-01-09 09:50:00.585 -0800 PST
        Height: 102
        RootValue: {
1)              #35dg4sptca4emt0k9orosh3la006uva5
        }
        Parents: {
2)              #fbouk8diedhbcn9u4en864rnicjf6o1v
        }
        ParentClosure: {
3)              #lpmpi89fvo7929f4vatojn6kblma3a2n
        }
     }
> 3
     CommitClosure - {
        SubTree {
1)              #ul2o0kblv5dm7jigm7aq9kbut8t1an2u
2)              #u3q2qqtah9ltt03523gnbic5ra8vra7l
        }
        Commits {
        }
     }
> 2
     CommitClosure - {
        SubTree {
        }
        Commits {
1)              #00j5cnf3fbpvil46s6fjni5hb861t3t5 (height: 92)
2)              #t3f9c1k554408rkb6ckuare4scs5448p (height: 93)
3)              #1qv8hgbapm89ambqah6bkvkmh5ibr7v9 (height: 94)
4)              #3eamq2ql2qbst6pet3vbeu72is5l9hvm (height: 95)
5)              #fvlsit802ov9e068l5mi4epdovfo9tbv (height: 96)
6)              #4udg013qj22eujk6shd338t89c0qgg8q (height: 97)
7)              #mv1bohj5a6ejaehnk7e8esh5t51voqj1 (height: 98)
8)              #jf6fm3uehsuhhf6vaf6h4k40jhsv38a4 (height: 99)
9)              #tefgo1j7r597s53oh17qsatubrot4mje (height: 100)
10)             #fbouk8diedhbcn9u4en864rnicjf6o1v (height: 101)
        }
     }
>
```