### PR TITLE
Prevent panic when sorting by `commit_hash` in various dolt system tables

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -480,6 +480,9 @@ func TestDoltDiffQueryPlans(t *testing.T) {
 	for _, tt := range DoltDiffPlanTests {
 		enginetest.TestQueryPlan(t, harness, e, tt.Query, tt.ExpectedPlan, sql.DescribeOptions{})
 	}
+	for _, tt := range DoltCommitPlanTests {
+		enginetest.TestQueryPlan(t, harness, e, tt.Query, tt.ExpectedPlan, sql.DescribeOptions{})
+	}
 }
 
 func TestBranchPlans(t *testing.T) {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -2273,6 +2273,38 @@ WHERE z IN (
 			},
 		},
 	},
+	{
+		Name: "can sort by dolt_log.commit",
+		SetUpScript: []string{
+		},
+		Assertions: []queries.ScriptTestAssertion {
+			{
+				Query: "select 'something' from dolt_log order by commit_hash;",
+				Expected: []sql.Row{
+					{"something"},
+					{"something"},
+				},
+			},
+			{
+				Query: "select 'something' from dolt_diff order by commit_hash;",
+				Expected: []sql.Row{
+					{"something"},
+					{"something"},
+				},
+			},
+			{
+				Query: "select 'something' from dolt_commits order by commit_hash;",
+				Expected: []sql.Row{},
+			},
+			{
+				Query: "select 'something' from dolt_commit_ancestors order by commit_hash;",
+				Expected: []sql.Row{
+					{"something"},
+					{"something"},
+				},
+			},
+		},
+	},
 }
 
 // BrokenHistorySystemTableScriptTests contains tests that work for non-prepared, but don't work

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -2285,11 +2285,11 @@ WHERE z IN (
 				},
 			},
 			{
-				Query: "select 'something' from dolt_diff order by commit_hash;",
+				Query:    "select 'something' from dolt_diff order by commit_hash;",
 				Expected: []sql.Row{},
 			},
 			{
-				Query:    "select 'something' from dolt_commits order by commit_hash;",
+				Query: "select 'something' from dolt_commits order by commit_hash;",
 				Expected: []sql.Row{
 					{"something"},
 					{"something"},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -2286,14 +2286,14 @@ WHERE z IN (
 			},
 			{
 				Query: "select 'something' from dolt_diff order by commit_hash;",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "select 'something' from dolt_commits order by commit_hash;",
 				Expected: []sql.Row{
 					{"something"},
 					{"something"},
 				},
-			},
-			{
-				Query:    "select 'something' from dolt_commits order by commit_hash;",
-				Expected: []sql.Row{},
 			},
 			{
 				Query: "select 'something' from dolt_commit_ancestors order by commit_hash;",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_query_plans.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_query_plans.go
@@ -70,18 +70,34 @@ var DoltDiffPlanTests = []queries.QueryPlanTest{
 var DoltCommitPlanTests = []queries.QueryPlanTest{
 	{
 		Query: "select * from dolt_log order by commit_hash;",
-		ExpectedPlan: "Sort(dolt_log.commit_hash ASC)\n └─ Exchange\n     └─ Table\n         └─ name: dolt_log\n",
+		ExpectedPlan: "Sort(dolt_log.commit_hash ASC)\n" +
+			" └─ Exchange\n" +
+			"     └─ Table\n" +
+			"         └─ name: dolt_log\n" +
+			"",
 	},
 	{
 		Query: "select * from dolt_diff order by commit_hash;",
-		ExpectedPlan: "Sort(dolt_diff.commit_hash ASC)\n └─ Exchange\n     └─ Table\n         └─ name: dolt_diff\n",
+		ExpectedPlan: "Sort(dolt_diff.commit_hash ASC)\n" +
+			" └─ Exchange\n" +
+			"     └─ Table\n" +
+			"         └─ name: dolt_diff\n" +
+			"",
 	},
 	{
 		Query: "select * from dolt_commits order by commit_hash;",
-		ExpectedPlan: "Sort(dolt_commits.commit_hash ASC)\n └─ Exchange\n     └─ Table\n         └─ name: dolt_commits\n",
+		ExpectedPlan: "Sort(dolt_commits.commit_hash ASC)\n" +
+			" └─ Exchange\n" +
+			"     └─ Table\n" +
+			"         └─ name: dolt_commits\n" +
+			"",
 	},
 	{
 		Query: "select * from dolt_commit_ancestors order by commit_hash;",
-		ExpectedPlan: "Sort(dolt_commit_ancestors.commit_hash ASC)\n └─ Exchange\n     └─ Table\n         └─ name: dolt_commit_ancestors\n",
+		ExpectedPlan: "Sort(dolt_commit_ancestors.commit_hash ASC)\n" +
+			" └─ Exchange\n" +
+			"     └─ Table\n" +
+			"         └─ name: dolt_commit_ancestors\n" +
+			"",
 	},
 }

--- a/go/libraries/doltcore/sqle/enginetest/dolt_query_plans.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_query_plans.go
@@ -66,3 +66,22 @@ var DoltDiffPlanTests = []queries.QueryPlanTest{
 			"",
 	},
 }
+
+var DoltCommitPlanTests = []queries.QueryPlanTest{
+	{
+		Query: "select * from dolt_log order by commit_hash;",
+		ExpectedPlan: "Sort(dolt_log.commit_hash ASC)\n └─ Exchange\n     └─ Table\n         └─ name: dolt_log\n",
+	},
+	{
+		Query: "select * from dolt_diff order by commit_hash;",
+		ExpectedPlan: "Sort(dolt_diff.commit_hash ASC)\n └─ Exchange\n     └─ Table\n         └─ name: dolt_diff\n",
+	},
+	{
+		Query: "select * from dolt_commits order by commit_hash;",
+		ExpectedPlan: "Sort(dolt_commits.commit_hash ASC)\n └─ Exchange\n     └─ Table\n         └─ name: dolt_commits\n",
+	},
+	{
+		Query: "select * from dolt_commit_ancestors order by commit_hash;",
+		ExpectedPlan: "Sort(dolt_commit_ancestors.commit_hash ASC)\n └─ Exchange\n     └─ Table\n         └─ name: dolt_commit_ancestors\n",
+	},
+}

--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -852,7 +852,9 @@ func (di *doltIndex) HasContentHashedField() bool {
 	}
 
 	contentHashedField := false
-
+	if di.indexSch == nil {
+		return false
+	}
 	indexPkCols := di.indexSch.GetPKCols()
 	indexPkCols.Iter(func(tag uint64, col schema.Column) (stop bool, err error) {
 		i := indexPkCols.TagToIdx[tag]
@@ -873,7 +875,7 @@ func (di *doltIndex) HasContentHashedField() bool {
 }
 
 func (di *doltIndex) Order() sql.IndexOrder {
-	if di.HasContentHashedField() {
+	if di.indexSch == nil || di.HasContentHashedField() {
 		return sql.IndexOrderNone
 	}
 

--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -842,6 +842,10 @@ func (di *doltIndex) HandledFilters(filters []sql.Expression) []sql.Expression {
 	return handled
 }
 
+func (di *doltIndex) isMockIndex() bool {
+	return di.indexSch == nil
+}
+
 // HasContentHashedField returns true if any of the fields in this index are "content-hashed", meaning that the index
 // stores a hash of the content, instead of the content itself. This is currently limited to unique indexes, which can
 // use this property to store hashes of TEXT or BLOB fields and still efficiently detect uniqueness.
@@ -852,7 +856,7 @@ func (di *doltIndex) HasContentHashedField() bool {
 	}
 
 	contentHashedField := false
-	if di.indexSch == nil {
+	if di.isMockIndex() {
 		return false
 	}
 	indexPkCols := di.indexSch.GetPKCols()
@@ -875,7 +879,7 @@ func (di *doltIndex) HasContentHashedField() bool {
 }
 
 func (di *doltIndex) Order() sql.IndexOrder {
-	if di.indexSch == nil || di.HasContentHashedField() {
+	if di.HasContentHashedField() {
 		return sql.IndexOrderNone
 	}
 


### PR DESCRIPTION
The analyzer rule `replacePkSort` does not work over certain types of indexes as some indexes are unordered.
Certain dolt system tables use a MockIndex because they are not backed by a datastore. 

Unfortunately, we don't have a proper `nil` check for the `idxSch`, leading to a panic when attempting to sort by columns in those mock indexes

This PR adds a nil check, so we don't try to use these indexes.

fixes https://github.com/dolthub/dolt/issues/7404