### PR TITLE
When aborting a merge/cherry-pick, avoid resetting ignored tables.

### DIFF
--- a/go/libraries/doltcore/merge/action.go
+++ b/go/libraries/doltcore/merge/action.go
@@ -165,6 +165,10 @@ func AbortMerge(ctx *sql.Context, workingSet *doltdb.WorkingSet, roots doltdb.Ro
 	if err != nil {
 		return nil, err
 	}
+	tbls, err = doltdb.ExcludeIgnoredTables(ctx, roots, tbls)
+	if err != nil {
+		return nil, err
+	}
 
 	roots, err = actions.MoveTablesFromHeadToWorking(ctx, roots, tbls)
 	if err != nil {

--- a/go/libraries/doltcore/merge/action.go
+++ b/go/libraries/doltcore/merge/action.go
@@ -195,7 +195,8 @@ func AbortMerge(ctx *sql.Context, workingSet *doltdb.WorkingSet, roots doltdb.Ro
 	} else {
 		workingSet = workingSet.WithWorkingRoot(preMergeWorkingRoot)
 	}
-	workingSet = workingSet.WithStagedRoot(workingSet.WorkingRoot())
+	// Unstage everything by making Staged match Head
+	workingSet = workingSet.WithStagedRoot(roots.Head)
 	workingSet = workingSet.ClearMerge()
 
 	return workingSet, nil


### PR DESCRIPTION
Tables that match `dolt_ignore` in the working set should be ignored by most operations.

(CAVEAT: If we want to match git, these tables should only be ignored if there are not staged/HEAD versions of those tables. But we appear to not match git in that regard right now.)

This PR changes the logic for aborting merges to avoid modifying any tables match `dolt_ignore`