### PR TITLE
dolt_clone and --user

### DIFF
--- a/go/libraries/doltcore/env/actions/clone.go
+++ b/go/libraries/doltcore/env/actions/clone.go
@@ -157,6 +157,7 @@ func sortedKeys(m map[string]iohelp.ReadStats) []string {
 	return keys
 }
 
+// CloneRemote - common entry point for both dolt_clone() and `dolt clone`
 func CloneRemote(ctx context.Context, srcDB *doltdb.DoltDB, remoteName, branch string, singleBranch bool, dEnv *env.DoltEnv) error {
 	eventCh := make(chan pull.TableFileEvent, 128)
 

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -533,8 +533,7 @@ func (p *DoltDatabaseProvider) cloneDatabaseFromRemote(
 		return fmt.Errorf("unable to clone remote database; no remote dialer configured")
 	}
 
-	// TODO: params for AWS, others that need them
-	r := env.NewRemote(remoteName, remoteUrl, nil)
+	r := env.NewRemote(remoteName, remoteUrl, remoteParams)
 	srcDB, err := r.GetRemoteDB(ctx, types.Format_Default, p.remoteDialer)
 	if err != nil {
 		return err

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_clone.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_clone.go
@@ -50,6 +50,8 @@ func doltClone(ctx *sql.Context, args ...string) (sql.RowIter, error) {
 		return nil, errhand.BuildDError("error: '%s' is not valid.", urlStr).Build()
 	}
 
+	// There are several remote params (AWS/GCP/OCI paths, creds, etc) which are pulled from the global server using
+	// server config, environment vars and such. The --user flag is the only one that we can override with a command flag.
 	remoteParms := map[string]string{}
 	if user, hasUser := apr.GetValue(cli.UserFlag); hasUser {
 		remoteParms[dbfactory.GRPCUsernameAuthParam] = user

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_clone.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_clone.go
@@ -17,6 +17,7 @@ package dprocedures
 import (
 	"path"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
@@ -49,7 +50,12 @@ func doltClone(ctx *sql.Context, args ...string) (sql.RowIter, error) {
 		return nil, errhand.BuildDError("error: '%s' is not valid.", urlStr).Build()
 	}
 
-	err = sess.Provider().CloneDatabaseFromRemote(ctx, dir, branch, remoteName, remoteUrl, map[string]string{})
+	remoteParms := map[string]string{}
+	if user, hasUser := apr.GetValue(cli.UserFlag); hasUser {
+		remoteParms[dbfactory.GRPCUsernameAuthParam] = user
+	}
+
+	err = sess.Provider().CloneDatabaseFromRemote(ctx, dir, branch, remoteName, remoteUrl, remoteParms)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_clone.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_clone.go
@@ -17,11 +17,11 @@ package dprocedures
 import (
 	"path"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
+	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"


### PR DESCRIPTION
Previously the dolt_clone() stored procedure would take the --user flag, but not use it in a gRPC call to a sql-server. This
addresses this limitation, and adds a test to verify it works.