### PR TITLE
add disable version check warning

### DIFF
--- a/go/cmd/dolt/commands/version.go
+++ b/go/cmd/dolt/commands/version.go
@@ -43,7 +43,9 @@ const (
 
 var versionDocs = cli.CommandDocumentationContent{
 	ShortDesc: "Displays the version for the Dolt binary.",
-	LongDesc:  `Displays the version for the Dolt binary.`,
+	LongDesc: `Displays the version for the Dolt binary.
+
+The out-of-date check can be disabled by running {{.EmphasisLeft}}dolt config --global --add versioncheck.disabled true{{.EmphasisRight}}.`,
 	Synopsis: []string{
 		`[--verbose] [--feature]`,
 	},

--- a/go/cmd/dolt/commands/version.go
+++ b/go/cmd/dolt/commands/version.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dolthub/dolt/go/libraries/utils/config"
 	"github.com/fatih/color"
 	"github.com/google/go-github/v57/github"
 
@@ -32,6 +31,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dfunctions"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
+	"github.com/dolthub/dolt/go/libraries/utils/config"
 )
 
 const (

--- a/go/libraries/utils/config/keys.go
+++ b/go/libraries/utils/config/keys.go
@@ -30,6 +30,7 @@ var ConfigOptions = map[string]struct{}{
 	MetricsInsecure:       {},
 	PushAutoSetupRemote:   {},
 	ProfileKey:            {},
+	VersionCheckDisabled:  {},
 }
 
 const UserEmailKey = "user.email"
@@ -61,3 +62,5 @@ const MetricsInsecure = "metrics.insecure"
 const PushAutoSetupRemote = "push.autosetupremote"
 
 const ProfileKey = "profile"
+
+const VersionCheckDisabled = "versioncheck.disabled"

--- a/integration-tests/bats/no-repo.bats
+++ b/integration-tests/bats/no-repo.bats
@@ -164,6 +164,29 @@ teardown() {
     [[ ! "$output" =~ "failed to parse version number" ]] || false
 }
 
+@test "no-repo: disabling version check suppresses out of date warning" {
+    echo "2.0.0" > $DOLT_ROOT_PATH/.dolt/version_check.txt
+    dolt config --global --add versioncheck.disabled true
+
+    run dolt version
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "Warning: you are on an old version of Dolt" ]] || false
+}
+
+@test "no-repo: disable version check warning only appears once" {
+    echo "2.0.0" > $DOLT_ROOT_PATH/.dolt/version_check.txt
+
+    run dolt version
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Warning: you are on an old version of Dolt" ]] || false
+    [[ "$output" =~ "To disable this warning, run 'dolt config --global --add versioncheck.disabled true'" ]] || false
+
+    run dolt version
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Warning: you are on an old version of Dolt" ]] || false
+    [[ ! "$output" =~ "To disable this warning, run 'dolt config --global --add versioncheck.disabled true'" ]] || false
+}
+
 # Tests for dolt commands outside of a dolt repository
 NOT_VALID_REPO_ERROR="The current directory is not a valid dolt repository."
 @test "no-repo: dolt status outside of a dolt repository" {


### PR DESCRIPTION
Adds a message to provide instructions on how to disable the version out-of-date check. This message will print once per version.

Related: https://github.com/dolthub/dolt/issues/7435