### PR TITLE
go/libraries/events: Restructure events collection so that we can send events while the dolt process is running.

### DIFF
--- a/go/cmd/dolt/cli/command.go
+++ b/go/cmd/dolt/cli/command.go
@@ -245,7 +245,7 @@ func (hc SubCommandHandler) handleCommand(ctx context.Context, commandStr string
 	ret := cmd.Exec(ctx, commandStr, args, dEnv, cliCtx)
 
 	if evt != nil {
-		events.GlobalCollector.CloseEventAndAdd(evt)
+		events.GlobalCollector().CloseEventAndAdd(evt)
 	}
 
 	return ret

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -622,6 +622,8 @@ func newHeartbeatService(version string, dEnv *env.DoltEnv) *heartbeatService {
 		return &heartbeatService{} // will be defunct on Run()
 	}
 
+	events.SetGlobalCollector(events.NewCollector(version, emitter))
+
 	return &heartbeatService{
 		version:      version,
 		eventEmitter: emitter,
@@ -647,7 +649,7 @@ func (h *heartbeatService) Run(ctx context.Context) {
 			return
 		case <-ticker.C:
 			t := events.NowTimestamp()
-			err := h.eventEmitter.LogEvents(h.version, []*eventsapi.ClientEvent{
+			err := h.eventEmitter.LogEvents(ctx, h.version, []*eventsapi.ClientEvent{
 				{
 					Id:        uuid.New().String(),
 					StartTime: t,

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -453,6 +453,16 @@ func runMain() int {
 		return 1
 	}
 
+	strMetricsDisabled := dEnv.Config.GetStringOrDefault(config.MetricsDisabled, "false")
+	var metricsEmitter events.Emitter
+	metricsEmitter = events.NewFileEmitter(homeDir, dbfactory.DoltDir)
+	metricsDisabled, err := strconv.ParseBool(strMetricsDisabled)
+	if err != nil || metricsDisabled {
+		metricsEmitter = events.NullEmitter{}
+	}
+
+	events.SetGlobalCollector(events.NewCollector(Version, metricsEmitter))
+
 	if dEnv.CfgLoadErr != nil {
 		cli.PrintErrln(color.RedString("Failed to load the global config. %v", dEnv.CfgLoadErr))
 		return 1
@@ -495,7 +505,7 @@ func runMain() int {
 		return 1
 	}
 
-	defer emitUsageEvents(dEnv, homeDir, args)
+	defer emitUsageEvents(metricsEmitter, args)
 
 	if needsWriteAccess(subcommandName) {
 		err = reconfigIfTempFileMoveFails(dEnv)
@@ -770,16 +780,11 @@ func seedGlobalRand() {
 //  1. The config key |metrics.disabled|, when set to |true|, disables all metrics emission
 //  2. The environment key |DOLT_DISABLE_EVENT_FLUSH| allows writing events to disk but not sending them to the server.
 //     This is mostly used for testing.
-func emitUsageEvents(dEnv *env.DoltEnv, homeDir string, args []string) {
-	metricsDisabled := dEnv.Config.GetStringOrDefault(config.MetricsDisabled, "false")
-	disabled, err := strconv.ParseBool(metricsDisabled)
-	if err != nil || disabled {
-		return
-	}
-
+func emitUsageEvents(emitter events.Emitter, args []string) {
 	// write events
-	emitter := events.NewFileEmitter(homeDir, dbfactory.DoltDir)
-	_ = emitter.LogEvents(Version, events.GlobalCollector.Close())
+	collector := events.GlobalCollector()
+	ctx := context.Background()
+	_ = emitter.LogEvents(ctx, Version, collector.Close())
 
 	// flush events
 	if !eventFlushDisabled && len(args) > 0 && shouldFlushEvents(args[0]) {

--- a/go/libraries/doltcore/dbfactory/grpc.go
+++ b/go/libraries/doltcore/dbfactory/grpc.go
@@ -117,7 +117,7 @@ func (fact DoltRemoteFactory) newChunkStore(ctx context.Context, nbf *types.Noms
 		return nil, err
 	}
 
-	opts := append(cfg.DialOptions, grpc.WithChainUnaryInterceptor(remotestorage.EventsUnaryClientInterceptor(events.GlobalCollector)))
+	opts := append(cfg.DialOptions, grpc.WithChainUnaryInterceptor(remotestorage.EventsUnaryClientInterceptor(events.GlobalCollector())))
 	opts = append(opts, grpc.WithChainUnaryInterceptor(remotestorage.RetryingUnaryClientInterceptor))
 
 	conn, err := grpc.Dial(cfg.Endpoint, opts...)

--- a/go/libraries/events/collector.go
+++ b/go/libraries/events/collector.go
@@ -63,7 +63,7 @@ func SetGlobalCollector(c *Collector) {
 }
 
 const collChanBufferSize = 32
-const maxBatchedEvents = 1024
+const maxBatchedEvents = 64
 
 // Collector collects and stores Events later to be sent to an Emitter.
 type Collector struct {
@@ -93,8 +93,11 @@ func NewCollector(version string, emitter Emitter) *Collector {
 				c.events = nil
 			}
 		}
-		rest := c.st.stop()
-		c.events = append(rest, c.events...)
+		if len(c.events) > 0 {
+			c.st.batchCh <- c.events
+			c.events = nil
+		}
+		c.events = c.st.stop()
 	}()
 
 	return c

--- a/go/libraries/events/events_test.go
+++ b/go/libraries/events/events_test.go
@@ -25,7 +25,7 @@ import (
 func TestEvents(t *testing.T) {
 	remoteUrl := "https://dolthub.com/org/repo"
 
-	collector := NewCollector()
+	collector := NewCollector("invalid", nil)
 	testEvent := NewEvent(eventsapi.ClientEventType_CLONE)
 
 	testEvent.SetAttribute(eventsapi.AttributeID_REMOTE_URL_SCHEME, remoteUrl)

--- a/go/libraries/events/events_test.go
+++ b/go/libraries/events/events_test.go
@@ -15,6 +15,8 @@
 package events
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -58,4 +60,63 @@ func TestEvents(t *testing.T) {
 	assert.True(t, isCounter)
 	_, isTimer := clientEvents[0].Metrics[1].MetricOneof.(*eventsapi.ClientEventMetric_Duration)
 	assert.True(t, isTimer)
+}
+
+type failingEmitter struct {
+}
+
+func (failingEmitter) LogEvents(ctx context.Context, version string, evts []*eventsapi.ClientEvent) error {
+	return errors.New("i always fail")
+}
+
+func (failingEmitter) LogEventsRequest(ctx context.Context, req *eventsapi.LogEventsRequest) error {
+	return errors.New("i always fail")
+}
+
+func TestEventsCollectorEmitting(t *testing.T) {
+	for _, tc := range []struct {
+		Name    string
+		Emitter Emitter
+		NumLeft int
+	}{
+		{
+			"Failing",
+			failingEmitter{},
+			32 * maxBatchedEvents,
+		},
+		{
+			"Nil",
+			nil,
+			32 * maxBatchedEvents,
+		},
+		{
+			"Null",
+			NullEmitter{},
+			0,
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			collector := NewCollector("invalid", tc.Emitter)
+
+			for i := 0; i < 32*maxBatchedEvents; i++ {
+				remoteUrl := "https://dolthub.com/org/repo"
+				testEvent := NewEvent(eventsapi.ClientEventType_CLONE)
+
+				testEvent.SetAttribute(eventsapi.AttributeID_REMOTE_URL_SCHEME, remoteUrl)
+
+				counter := NewCounter(eventsapi.MetricID_METRIC_UNSPECIFIED)
+				counter.Inc()
+				testEvent.AddMetric(counter)
+
+				timer := NewTimer(eventsapi.MetricID_METRIC_UNSPECIFIED)
+				timer.Stop()
+				testEvent.AddMetric(timer)
+
+				collector.CloseEventAndAdd(testEvent)
+			}
+
+			clientEvents := collector.Close()
+			assert.Len(t, clientEvents, tc.NumLeft)
+		})
+	}
 }

--- a/go/libraries/events/events_test.go
+++ b/go/libraries/events/events_test.go
@@ -93,12 +93,12 @@ func TestEventsCollectorEmitting(t *testing.T) {
 		{
 			"Failing",
 			failingEmitter{},
-			32 * maxBatchedEvents - 1,
+			32*maxBatchedEvents - 1,
 		},
 		{
 			"Nil",
 			nil,
-			32 * maxBatchedEvents - 1,
+			32*maxBatchedEvents - 1,
 		},
 		{
 			"Null",
@@ -114,7 +114,7 @@ func TestEventsCollectorEmitting(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			collector := NewCollector("invalid", tc.Emitter)
 
-			for i := 0; i < 32*maxBatchedEvents - 1; i++ {
+			for i := 0; i < 32*maxBatchedEvents-1; i++ {
 				remoteUrl := "https://dolthub.com/org/repo"
 				testEvent := NewEvent(eventsapi.ClientEventType_CLONE)
 


### PR DESCRIPTION
We make the GlobalCollector mutable.

We give the Collector a sendingThread which can have an Emitter. When the Collector collects enough events, it forwards a batch of them to the sendingThread. If the sendingThread has an Emitter, it attempts to send its current batch on that Emitter.

On shutdown, contexts get canceled, background threads get waited on, and then an accumulated un-emitted events are returned from the Collector, same as previously.