### PR TITLE
go: sqle/cluster: When in standby mode, take the epoch of the primary.

### DIFF
--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
@@ -337,6 +337,117 @@ tests:
     queries:
     - exec: "use repo1"
     - exec: "create table vals (i int primary key)"
+- name: standby server takes primary epoch
+  multi_repos:
+  - name: server1
+    repos:
+    - name: repo1
+      with_remotes:
+      - name: standby
+        url: http://localhost:3852/repo1
+    - name: repo2
+      with_remotes:
+      - name: standby
+        url: http://localhost:3852/repo2
+    with_files:
+    - name: server.yaml
+      contents: |
+        log_level: trace
+        listener:
+          host: 0.0.0.0
+          port: 3309
+        cluster:
+          standby_remotes:
+          - name: standby
+            remote_url_template: http://localhost:3852/{database}
+          bootstrap_role: primary
+          bootstrap_epoch: 10
+          remotesapi:
+            port: 3851
+    server:
+      args: ["--port", "3309"]
+      port: 3309
+  - name: server2
+    repos:
+    - name: repo1
+      with_remotes:
+      - name: standby
+        url: http://localhost:3851/repo1
+    - name: repo2
+      with_remotes:
+      - name: standby
+        url: http://localhost:3851/repo2
+    with_files:
+    - name: server.yaml
+      contents: |
+        log_level: trace
+        listener:
+          host: 0.0.0.0
+          port: 3310
+        cluster:
+          standby_remotes:
+          - name: standby
+            remote_url_template: http://localhost:3851/{database}
+          bootstrap_role: standby
+          bootstrap_epoch: 1
+          remotesapi:
+            port: 3852
+    server:
+      args: ["--config", "server.yaml"]
+      port: 3310
+  connections:
+  - on: server1
+    queries:
+    - exec: "use repo1"
+    - exec: "create table vals (i int primary key)"
+    - exec: "insert into vals values (1),(2),(3),(4),(5)"
+    restart_server:
+      args: ["--config", "server.yaml"]
+  - on: server1
+    queries:
+    - exec: "use dolt_cluster"
+    - query: "select `database`, standby_remote, role, epoch, replication_lag_millis, current_error from dolt_cluster_status order by `database` asc"
+      result:
+        columns: ["database","standby_remote","role","epoch","replication_lag_millis","current_error"]
+        rows:
+        - ["repo1","standby","primary","10","0","NULL"]
+        - ["repo2","standby","primary","10","0","NULL"]
+      retry_attempts: 100
+  - on: server2
+    queries:
+    - exec: "use repo1"
+    - query: "select count(*) from vals"
+      result:
+        columns: ["count(*)"]
+        rows: [["5"]]
+    - query: "select @@global.dolt_cluster_role_epoch"
+      result:
+        columns: ["@@global.dolt_cluster_role_epoch"]
+        rows: [["10"]]
+  - on: server1
+    queries:
+    - exec: "use repo1"
+    - exec: "call dolt_assume_cluster_role('primary', 11)"
+    - exec: "insert into vals values (6),(7),(8),(9),(10)"
+    - exec: "use dolt_cluster"
+    - query: "select `database`, standby_remote, role, epoch, replication_lag_millis, current_error from dolt_cluster_status order by `database` asc"
+      result:
+        columns: ["database","standby_remote","role","epoch","replication_lag_millis","current_error"]
+        rows:
+        - ["repo1","standby","primary","11","0","NULL"]
+        - ["repo2","standby","primary","11","0","NULL"]
+      retry_attempts: 100
+  - on: server2
+    queries:
+    - exec: "use repo1"
+    - query: "select count(*) from vals"
+      result:
+        columns: ["count(*)"]
+        rows: [["10"]]
+    - query: "select @@global.dolt_cluster_role_epoch"
+      result:
+        columns: ["@@global.dolt_cluster_role_epoch"]
+        rows: [["11"]]
 - name: standby transitioned to primary becomes read write
   multi_repos:
   - name: server1


### PR DESCRIPTION
When in detected_broken_config, become standby if we see a higher numbered primary.