### PR TITLE
Bug fix: `IndexedDoltTable` didn't fully implement `DoltTable`'s interface

### DIFF
--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -115,7 +115,7 @@ func NewSqlEngine(
 		return nil, err
 	}
 
-	all := append(dbs)
+	all := dbs[:]
 
 	clusterDB := config.ClusterController.ClusterDatabase()
 	if clusterDB != nil {


### PR DESCRIPTION
`IndexedDoltTable` wasn't fully compatible with `DoltTable`'s interface, which was causing some queries to execute incorrectly due to using the wrong field indexes. This only happened with queries where the table was used in a read-only context (such as an `AS OF` query), since in a read-write context `WritableIndexedDoltTable` is used, which is composed of a `WritableDoltTable`, so fully inherits the interface. `IndexedDoltTable` is now consistent with that, and is now composed of a `DoltTable` instance. This enables the GMS code in `assignExecIndexes` to use the correct, limited schema of the secondary index and to apply the correct field indexes. 

Fixes: https://github.com/dolthub/dolt/issues/7488