### PR TITLE
Fix windows file paths for dropping databases

### DIFF
--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -589,7 +590,7 @@ func (p *DoltDatabaseProvider) DropDatabase(ctx *sql.Context, name string) error
 	}
 
 	// If this database is re-created, we don't want to return any cached results.
-	err = dbfactory.DeleteFromSingletonCache(dropDbLoc + "/.dolt/noms")
+	err = dbfactory.DeleteFromSingletonCache(filepath.ToSlash(dropDbLoc + "/.dolt/noms"))
 	if err != nil {
 		return err
 	}

--- a/integration-tests/bats/sql-create-database.bats
+++ b/integration-tests/bats/sql-create-database.bats
@@ -75,8 +75,6 @@ SQL
 }
 
 @test "sql-create-database: drop database" {
-    skiponwindows "failing with file in use error"
-    
     dolt sql <<SQL
 create database mydb;
 use mydb;
@@ -195,8 +193,6 @@ SQL
 }
 
 @test "sql-create-database: create and drop new database in same session" {
-    skiponwindows "failing with file in use error"
-    
     run dolt sql << SQL
 CREATE DATABASE mydb;
 DROP DATABASE mydb;
@@ -211,8 +207,6 @@ SQL
 }
 
 @test "sql-create-database: create new database IF NOT EXISTS" {
-    skiponwindows "failing with file in use error"
-    
     # Test bad syntax.
     run dolt sql -q "CREATE DATABASE IF EXISTS test;"
     [ "$status" -eq 1 ]
@@ -290,8 +284,6 @@ SQL
 }
 
 @test "sql-create-database: SHOW DATABASES works after CREATE and DROP" {
-    skiponwindows "failing with file in use error"
-    
     run dolt sql -q "SHOW DATABASES"
     before=$output
 

--- a/integration-tests/bats/sql-create-database.bats
+++ b/integration-tests/bats/sql-create-database.bats
@@ -105,7 +105,7 @@ create database mydb;
 SQL
 
     [ "$status" -eq 0 ]
-    [ ! -d mydb ]
+    [ -d mydb ]
 }
 
 @test "sql-create-database: with data-dir" {

--- a/integration-tests/bats/sql-create-database.bats
+++ b/integration-tests/bats/sql-create-database.bats
@@ -97,6 +97,17 @@ SQL
     [ ! -d mydb ]
 }
 
+@test "sql-create-database: drop and recreate database" {
+    run dolt sql <<SQL
+create database mydb;
+drop database mydb;
+create database mydb;
+SQL
+
+    [ "$status" -eq 0 ]
+    [ ! -d mydb ]
+}
+
 @test "sql-create-database: with data-dir" {
     skiponwindows "failing with file in use error"
 


### PR DESCRIPTION
We have to convert windows file path separators to unix ones, when removing them from singleton cache.

Additionally, unskips some bats tests

Fixes https://github.com/dolthub/dolt/issues/7492