### PR TITLE
[stats]: fix panic for empty table stats with one root chunk

### DIFF
--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -16,6 +16,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"runtime"
 	"strconv"
@@ -192,7 +193,7 @@ func NewSqlEngine(
 	// configuring stats depends on sessionBuilder
 	// sessionBuilder needs ref to statsProv
 	if err = statsPro.Configure(ctx, sqlEngine.NewDefaultContext, bThreads, pro, dbs); err != nil {
-		return nil, err
+		fmt.Fprintln(cli.CliErr, err)
 	}
 
 	// Load MySQL Db information

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -2110,7 +2110,11 @@ func TestStatsFunctions(t *testing.T) {
 	harness.configureStats = true
 	for _, test := range StatProcTests {
 		t.Run(test.Name, func(t *testing.T) {
-			enginetest.TestScript(t, harness, test)
+			// reset engine so provider statistics are clean
+			harness.engine = nil
+			e := mustNewEngine(t, harness)
+			defer e.Close()
+			enginetest.TestScriptWithEngine(t, e, harness, test)
 		})
 	}
 }

--- a/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
@@ -247,7 +247,7 @@ func (d *DoltHarness) NewEngine(t *testing.T) (enginetest.QueryEngine, error) {
 	// Get a fresh session if we are reusing the engine
 	if !initializeEngine {
 		var err error
-		d.session, err = dsess.NewDoltSession(enginetest.NewBaseSession(), d.provider, d.multiRepoEnv.Config(), d.branchControl, nil)
+		d.session, err = dsess.NewDoltSession(enginetest.NewBaseSession(), d.provider, d.multiRepoEnv.Config(), d.branchControl, d.statsPro)
 		require.NoError(t, err)
 	}
 

--- a/go/libraries/doltcore/sqle/stats/stats_provider.go
+++ b/go/libraries/doltcore/sqle/stats/stats_provider.go
@@ -359,6 +359,11 @@ func (p *Provider) Load(ctx *sql.Context, dbs []dsess.SqlDatabase) error {
 			} else if err != nil {
 				return err
 			}
+			if cnt, err := m.Count(); err != nil {
+				return err
+			} else if cnt == 0 {
+				return nil
+			}
 			stats, err := loadStats(ctx, db, m)
 			if errors.Is(err, dtables.ErrIncompatibleVersion) {
 				ctx.Warn(0, err.Error())

--- a/go/libraries/doltcore/sqle/stats/update.go
+++ b/go/libraries/doltcore/sqle/stats/update.go
@@ -80,7 +80,6 @@ func updateStats(ctx *sql.Context, sqlTable sql.Table, dTab *doltdb.Table, index
 		} else if cnt == 0 {
 			// table is empty
 			ret[meta.qual] = NewDoltStats()
-			ret[meta.qual].chunks = meta.allAddrs
 			ret[meta.qual].CreatedAt = time.Now()
 			ret[meta.qual].Columns = meta.cols
 			ret[meta.qual].Types = types
@@ -190,6 +189,10 @@ func mergeStatUpdates(newStats *DoltStats, idxMeta indexMeta) *DoltStats {
 			mergeHist = append(mergeHist, newHist[j])
 			j++
 		}
+	}
+
+	if len(mergeHist) == 0 {
+		return newStats
 	}
 
 	newStats.Histogram = mergeHist

--- a/go/store/types/serial_message.go
+++ b/go/store/types/serial_message.go
@@ -91,6 +91,13 @@ func (sm SerialMessage) humanReadableStringAtIndentationLevel(level int) string 
 		printWithIndendationLevel(level, ret, "\tHeadCommitAddr: #%s\n", hash.New(msg.HeadCommitAddrBytes()).String())
 		printWithIndendationLevel(level, ret, "}")
 		return ret.String()
+	case serial.StatisticFileID:
+		msg, _ := serial.TryGetRootAsStatistic(sm, serial.MessagePrefixSz)
+		ret := &strings.Builder{}
+		printWithIndendationLevel(level, ret, "{\n")
+		printWithIndendationLevel(level, ret, "\tStatsRoot: #%s\n", hash.New(msg.RootBytes()).String())
+		printWithIndendationLevel(level, ret, "}")
+		return ret.String()
 	case serial.TagFileID:
 		msg, _ := serial.TryGetRootAsTag(sm, serial.MessagePrefixSz)
 		ret := &strings.Builder{}


### PR DESCRIPTION
There's one root chunk for an empty table that needs special handling because there is no histogram bucket for it.