### PR TITLE
Bump actions/setup-go and use Go version from go.mod file

### DIFF
--- a/.github/workflows/bump-dependency.yaml
+++ b/.github/workflows/bump-dependency.yaml
@@ -96,9 +96,10 @@ jobs:
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Set up Go 1.x
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: ^1.21
+          go-version-file: go/go.mod
+          check-latest: true
       - name: Bump dependency
         working-directory: go
         run: |

--- a/.github/workflows/cd-release-pgo.yaml
+++ b/.github/workflows/cd-release-pgo.yaml
@@ -41,9 +41,10 @@ jobs:
         with:
           ref: main
       - name: Set up Go 1.x
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: ^1.21
+          go-version-file: go/go.mod
+          check-latest: true
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2.2.0
         with:

--- a/.github/workflows/ci-bats-macos.yaml
+++ b/.github/workflows/ci-bats-macos.yaml
@@ -39,6 +39,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-duration-seconds: 10800 # 3 hours D:
+      - uses: actions/checkout@v3
       - name: Setup Go 1.x
         uses: actions/setup-go@v5
         with:
@@ -49,7 +50,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: ^16

--- a/.github/workflows/ci-bats-macos.yaml
+++ b/.github/workflows/ci-bats-macos.yaml
@@ -40,9 +40,10 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-duration-seconds: 10800 # 3 hours D:
       - name: Setup Go 1.x
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: ^1.21
+          go-version-file: go/go.mod
+          check-latest: true
         id: go
       - name: Setup Python 3.x
         uses: actions/setup-python@v4

--- a/.github/workflows/ci-bats-unix-remote.yaml
+++ b/.github/workflows/ci-bats-unix-remote.yaml
@@ -24,6 +24,8 @@ jobs:
       use_credentials: ${{ secrets.AWS_SECRET_ACCESS_KEY != '' && secrets.AWS_ACCESS_KEY_ID != '' }}
     # We only run these as seaparte workflow if we do not have AWS credentials.
     steps:
+      - uses: actions/checkout@v3
+        if: ${{ env.use_credentials != 'true' }}
       - name: Setup Go 1.x
         if: ${{ env.use_credentials != 'true' }}
         uses: actions/setup-go@v5
@@ -36,8 +38,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-      - uses: actions/checkout@v3
-        if: ${{ env.use_credentials != 'true' }}
       - uses: actions/setup-node@v3
         if: ${{ env.use_credentials != 'true' }}
         with:

--- a/.github/workflows/ci-bats-unix-remote.yaml
+++ b/.github/workflows/ci-bats-unix-remote.yaml
@@ -26,9 +26,10 @@ jobs:
     steps:
       - name: Setup Go 1.x
         if: ${{ env.use_credentials != 'true' }}
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: ^1.21
+          go-version-file: go/go.mod
+          check-latest: true
         id: go
       - name: Setup Python 3.x
         if: ${{ env.use_credentials != 'true' }}

--- a/.github/workflows/ci-bats-unix.yaml
+++ b/.github/workflows/ci-bats-unix.yaml
@@ -48,9 +48,10 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-duration-seconds: 10800 # 3 hours D:
       - name: Setup Go 1.x
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: ^1.21
+          go-version-file: go/go.mod
+          check-latest: true
         id: go
       - name: Setup Python 3.x
         uses: actions/setup-python@v4

--- a/.github/workflows/ci-bats-unix.yaml
+++ b/.github/workflows/ci-bats-unix.yaml
@@ -47,6 +47,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-duration-seconds: 10800 # 3 hours D:
+      - uses: actions/checkout@v3
       - name: Setup Go 1.x
         uses: actions/setup-go@v5
         with:
@@ -57,7 +58,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: ^16

--- a/.github/workflows/ci-bats-windows.yaml
+++ b/.github/workflows/ci-bats-windows.yaml
@@ -93,9 +93,10 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-duration-seconds: 3600
       - name: Setup Go 1.x
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: ^1.21
+          go-version-file: go/go.mod
+          check-latest: true
         id: go
       - name: Setup Python 3.x
         uses: actions/setup-python@v4

--- a/.github/workflows/ci-bats-windows.yaml
+++ b/.github/workflows/ci-bats-windows.yaml
@@ -92,6 +92,10 @@ jobs:
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-duration-seconds: 3600
+      - uses: actions/checkout@v3
+        if: ${{ github.event_name == 'repository_dispatch' }}
+        with:
+          ref: ${{ github.event.client_payload.ref }}
       - name: Setup Go 1.x
         uses: actions/setup-go@v5
         with:
@@ -102,10 +106,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-      - uses: actions/checkout@v3
-        if: ${{ github.event_name == 'repository_dispatch' }}
-        with:
-          ref: ${{ github.event.client_payload.ref }}
       - uses: actions/checkout@v3
         if: ${{ github.event_name == 'workflow_dispatch' }}
       - uses: actions/setup-node@v3

--- a/.github/workflows/ci-check-repo.yaml
+++ b/.github/workflows/ci-check-repo.yaml
@@ -15,14 +15,14 @@ jobs:
     outputs:
       format: ${{ steps.should_format.outputs.format }}
     steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
       - name: Setup Go 1.x
         uses: actions/setup-go@v5
         with:
           go-version-file: go/go.mod
           check-latest: true
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
       - name: Check all
         id: should_format
         working-directory: ./go
@@ -67,16 +67,16 @@ jobs:
     name: Get artifacts
     runs-on: ubuntu-22.04
     steps:
-      - name: Setup Go 1.x
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go/go.mod
-          check-latest: true
       - uses: actions/checkout@v3
         with:
           ref: "main"
           repository: "dolthub/dolt"
           submodules: true
+      - name: Setup Go 1.x
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go/go.mod
+          check-latest: true
       - name: Copy script
         working-directory: ./go/utils/repofmt
         run: cp format_repo.sh _format_repo.sh
@@ -97,17 +97,17 @@ jobs:
     name: Format PR
     runs-on: ubuntu-22.04
     steps:
-      - name: Setup Go 1.x
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go/go.mod
-          check-latest: true
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           submodules: true
           token: ${{ secrets.REPO_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Setup Go 1.x
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go/go.mod
+          check-latest: true
       - name: Run go mod tidy
         run: go mod tidy
         working-directory: ./go

--- a/.github/workflows/ci-check-repo.yaml
+++ b/.github/workflows/ci-check-repo.yaml
@@ -16,9 +16,10 @@ jobs:
       format: ${{ steps.should_format.outputs.format }}
     steps:
       - name: Setup Go 1.x
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: ^1.21
+          go-version-file: go/go.mod
+          check-latest: true
       - uses: actions/checkout@v3
         with:
           submodules: true
@@ -67,9 +68,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Setup Go 1.x
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: ^1.21
+          go-version-file: go/go.mod
+          check-latest: true
       - uses: actions/checkout@v3
         with:
           ref: "main"
@@ -96,9 +98,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Setup Go 1.x
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: ^1.21
+          go-version-file: go/go.mod
+          check-latest: true
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}

--- a/.github/workflows/ci-compatibility-tests.yaml
+++ b/.github/workflows/ci-compatibility-tests.yaml
@@ -20,13 +20,13 @@ jobs:
       matrix:
         os: [ ubuntu-22.04 ]
     steps:
+      - uses: actions/checkout@v3
       - name: Setup Go 1.x
         uses: actions/setup-go@v5
         with:
           go-version-file: go/go.mod
           check-latest: true
         id: go
-      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: ^16

--- a/.github/workflows/ci-compatibility-tests.yaml
+++ b/.github/workflows/ci-compatibility-tests.yaml
@@ -21,9 +21,10 @@ jobs:
         os: [ ubuntu-22.04 ]
     steps:
       - name: Setup Go 1.x
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: ^1.21
+          go-version-file: go/go.mod
+          check-latest: true
         id: go
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/ci-go-race-tests.yaml
+++ b/.github/workflows/ci-go-race-tests.yaml
@@ -20,13 +20,13 @@ jobs:
         os: [ ubuntu-22.04 ]
         dolt_fmt: [ "__DOLT__" ]
     steps:
+    - uses: actions/checkout@v3
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
         go-version-file: go/go.mod
         check-latest: true
       id: go
-    - uses: actions/checkout@v3
     - name: Test engine
       working-directory: ./go
       run: |

--- a/.github/workflows/ci-go-race-tests.yaml
+++ b/.github/workflows/ci-go-race-tests.yaml
@@ -21,9 +21,10 @@ jobs:
         dolt_fmt: [ "__DOLT__" ]
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: ^1.21
+        go-version-file: go/go.mod
+        check-latest: true
       id: go
     - uses: actions/checkout@v3
     - name: Test engine

--- a/.github/workflows/ci-go-tests.yaml
+++ b/.github/workflows/ci-go-tests.yaml
@@ -24,9 +24,10 @@ jobs:
         os: [macos-latest, ubuntu-22.04, windows-latest]
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: ^1.21
+        go-version-file: go/go.mod
+        check-latest: true
       id: go
     - uses: actions/checkout@v3
     - name: Test All
@@ -71,9 +72,10 @@ jobs:
         os: [macos-latest, ubuntu-22.04, windows-latest]
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: ^1.21
+        go-version-file: go/go.mod
+        check-latest: true
       id: go
     - uses: actions/checkout@v3
     - name: Test All

--- a/.github/workflows/ci-go-tests.yaml
+++ b/.github/workflows/ci-go-tests.yaml
@@ -23,13 +23,13 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-22.04, windows-latest]
     steps:
+    - uses: actions/checkout@v3
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
         go-version-file: go/go.mod
         check-latest: true
       id: go
-    - uses: actions/checkout@v3
     - name: Test All
       working-directory: ./go
       run: |
@@ -71,13 +71,13 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-22.04, windows-latest]
     steps:
+    - uses: actions/checkout@v3
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
         go-version-file: go/go.mod
         check-latest: true
       id: go
-    - uses: actions/checkout@v3
     - name: Test All
       working-directory: ./go
       run: |

--- a/.github/workflows/ci-lambdabats-unix.yaml
+++ b/.github/workflows/ci-lambdabats-unix.yaml
@@ -43,10 +43,11 @@ jobs:
       - uses: actions/checkout@v3
         if: ${{ env.use_credentials == 'true' }}
       - name: Setup Go 1.x
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         if: ${{ env.use_credentials == 'true' }}
         with:
-          go-version: ^1.21
+          go-version-file: go/go.mod
+          check-latest: true
         id: go
       - name: install lambdabats
         if: ${{ env.use_credentials == 'true' }}

--- a/.github/workflows/ci-sql-server-integration-tests.yaml
+++ b/.github/workflows/ci-sql-server-integration-tests.yaml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         os:  [ ubuntu-22.04 ]
     steps:
+      - uses: actions/checkout@v3
       - name: Setup Go 1.x
         uses: actions/setup-go@v5
         with:
@@ -32,7 +33,6 @@ jobs:
       - name: Create CI Bin
         run: |
           mkdir -p ./.ci_bin
-      - uses: actions/checkout@v3
       - name: Install Dolt
         working-directory: ./go
         run: |

--- a/.github/workflows/ci-sql-server-integration-tests.yaml
+++ b/.github/workflows/ci-sql-server-integration-tests.yaml
@@ -24,9 +24,10 @@ jobs:
         os:  [ ubuntu-22.04 ]
     steps:
       - name: Setup Go 1.x
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: ^1.21
+          go-version-file: go/go.mod
+          check-latest: true
         id: go
       - name: Create CI Bin
         run: |

--- a/.github/workflows/import-perf.yaml
+++ b/.github/workflows/import-perf.yaml
@@ -16,6 +16,10 @@ jobs:
       fail-fast: true
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.client_payload.version }}
+
     - name: Set up Go 1.x
       id: go
       uses: actions/setup-go@v5
@@ -27,10 +31,6 @@ jobs:
       id: version
       run: |
         version=${{ github.event.client_payload.version }}
-
-    - uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.client_payload.version }}
 
     - name: Install dolt
       working-directory: ./go

--- a/.github/workflows/import-perf.yaml
+++ b/.github/workflows/import-perf.yaml
@@ -18,9 +18,10 @@ jobs:
     steps:
     - name: Set up Go 1.x
       id: go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: ^1.21
+        go-version-file: go/go.mod
+        check-latest: true
 
     - name: Dolt version
       id: version

--- a/.github/workflows/merge-perf.yaml
+++ b/.github/workflows/merge-perf.yaml
@@ -18,9 +18,10 @@ jobs:
     steps:
     - name: Set up Go 1.x
       id: go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: ^1.21
+        go-version-file: go/go.mod
+        check-latest: true
 
     - name: Setup Python 3.x
       uses: actions/setup-python@v4

--- a/.github/workflows/merge-perf.yaml
+++ b/.github/workflows/merge-perf.yaml
@@ -16,6 +16,10 @@ jobs:
       fail-fast: true
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.client_payload.version }}
+
     - name: Set up Go 1.x
       id: go
       uses: actions/setup-go@v5
@@ -32,10 +36,6 @@ jobs:
       id: version
       run: |
         version=${{ github.event.client_payload.version }}
-
-    - uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.client_payload.version }}
 
     - name: Install dolt
       working-directory: ./go

--- a/.github/workflows/sysbench-perf.yaml
+++ b/.github/workflows/sysbench-perf.yaml
@@ -18,9 +18,10 @@ jobs:
     steps:
     - name: Set up Go 1.x
       id: go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: ^1.21
+        go-version-file: go/go.mod
+        check-latest: true
 
     - name: Dolt version
       id: version

--- a/.github/workflows/sysbench-perf.yaml
+++ b/.github/workflows/sysbench-perf.yaml
@@ -16,6 +16,10 @@ jobs:
       fail-fast: true
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.client_payload.version }}
+
     - name: Set up Go 1.x
       id: go
       uses: actions/setup-go@v5
@@ -27,10 +31,6 @@ jobs:
       id: version
       run: |
         version=${{ github.event.client_payload.version }}
-
-    - uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.client_payload.version }}
 
     - name: install sysbench
       run: |


### PR DESCRIPTION
Changes:
- Bump actions/setup-go
- Use Go version from go.mod file
- Move actions/checkout before actions/setup-go