### PR TITLE
Less docker layers and more compact Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,9 +6,10 @@ ARG BUILDARCH
 
 RUN apt update -y && \
     apt install -y \
-        tini
-
-RUN apt-get update -y && apt-get install -y ca-certificates
+        tini \
+        ca-certificates && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ADD https://github.com/dolthub/dolt/releases/download/v${DOLT_VERSION}/dolt-linux-${BUILDARCH}.tar.gz dolt-linux-${BUILDARCH}.tar.gz
 RUN tar zxvf dolt-linux-${BUILDARCH}.tar.gz && \

--- a/docker/serverDockerfile
+++ b/docker/serverDockerfile
@@ -6,9 +6,10 @@ ARG BUILDARCH
 
 RUN apt update -y && \
     apt install -y \
-        tini
-
-RUN apt-get update -y && apt-get install -y ca-certificates
+        tini \
+        ca-certificates && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ADD https://github.com/dolthub/dolt/releases/download/v${DOLT_VERSION}/dolt-linux-${BUILDARCH}.tar.gz dolt-linux-${BUILDARCH}.tar.gz
 RUN tar zxvf dolt-linux-${BUILDARCH}.tar.gz && \


### PR DESCRIPTION
Install both packages on one Docker layer and delete package cache after installation.
Docker image size decreased from 259 MB to 210 MB.