### PR TITLE
Drop the nbs.addr type in favor of hash.Hash type

### DIFF
--- a/go/store/hash/base32.go
+++ b/go/store/hash/base32.go
@@ -25,11 +25,13 @@ import "encoding/base32"
 
 var encoding = base32.NewEncoding("0123456789abcdefghijklmnopqrstuv")
 
-func encode(data []byte) string {
+// Encode returns the base32 encoding in the Dolt alphabet.
+func Encode(data []byte) string {
 	return encoding.EncodeToString(data)
 }
 
-func decode(s string) []byte {
+// Decode returns the bytes represented by the Base32 string using the Dolt alphabet.
+func Decode(s string) []byte {
 	slice, _ := encoding.DecodeString(s)
 	return slice
 }

--- a/go/store/hash/base32.go
+++ b/go/store/hash/base32.go
@@ -25,13 +25,13 @@ import "encoding/base32"
 
 var encoding = base32.NewEncoding("0123456789abcdefghijklmnopqrstuv")
 
-// Encode returns the base32 encoding in the Dolt alphabet.
-func Encode(data []byte) string {
+// encode returns the base32 encoding in the Dolt alphabet.
+func encode(data []byte) string {
 	return encoding.EncodeToString(data)
 }
 
-// Decode returns the bytes represented by the Base32 string using the Dolt alphabet.
-func Decode(s string) []byte {
+// decode returns the bytes represented by the Base32 string using the Dolt alphabet.
+func decode(s string) []byte {
 	slice, _ := encoding.DecodeString(s)
 	return slice
 }

--- a/go/store/hash/base32_test.go
+++ b/go/store/hash/base32_test.go
@@ -31,53 +31,53 @@ func TestBase32Encode(t *testing.T) {
 	assert := assert.New(t)
 
 	d := make([]byte, ByteLen)
-	assert.Equal("00000000000000000000000000000000", encode(d))
+	assert.Equal("00000000000000000000000000000000", Encode(d))
 	d[19] = 1
-	assert.Equal("00000000000000000000000000000001", encode(d))
+	assert.Equal("00000000000000000000000000000001", Encode(d))
 	d[19] = 10
-	assert.Equal("0000000000000000000000000000000a", encode(d))
+	assert.Equal("0000000000000000000000000000000a", Encode(d))
 	d[19] = 20
-	assert.Equal("0000000000000000000000000000000k", encode(d))
+	assert.Equal("0000000000000000000000000000000k", Encode(d))
 	d[19] = 31
-	assert.Equal("0000000000000000000000000000000v", encode(d))
+	assert.Equal("0000000000000000000000000000000v", Encode(d))
 	d[19] = 32
-	assert.Equal("00000000000000000000000000000010", encode(d))
+	assert.Equal("00000000000000000000000000000010", Encode(d))
 	d[19] = 63
-	assert.Equal("0000000000000000000000000000001v", encode(d))
+	assert.Equal("0000000000000000000000000000001v", Encode(d))
 	d[19] = 64
-	assert.Equal("00000000000000000000000000000020", encode(d))
+	assert.Equal("00000000000000000000000000000020", Encode(d))
 
 	// Largest!
 	for i := 0; i < ByteLen; i++ {
 		d[i] = 0xff
 	}
-	assert.Equal("vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv", encode(d))
+	assert.Equal("vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv", Encode(d))
 }
 
 func TestBase32Decode(t *testing.T) {
 	assert := assert.New(t)
 
 	d := make([]byte, ByteLen)
-	assert.Equal(d, decode("00000000000000000000000000000000"))
+	assert.Equal(d, Decode("00000000000000000000000000000000"))
 
 	d[19] = 1
-	assert.Equal(d, decode("00000000000000000000000000000001"))
+	assert.Equal(d, Decode("00000000000000000000000000000001"))
 	d[19] = 10
-	assert.Equal(d, decode("0000000000000000000000000000000a"))
+	assert.Equal(d, Decode("0000000000000000000000000000000a"))
 	d[19] = 20
-	assert.Equal(d, decode("0000000000000000000000000000000k"))
+	assert.Equal(d, Decode("0000000000000000000000000000000k"))
 	d[19] = 31
-	assert.Equal(d, decode("0000000000000000000000000000000v"))
+	assert.Equal(d, Decode("0000000000000000000000000000000v"))
 	d[19] = 32
-	assert.Equal(d, decode("00000000000000000000000000000010"))
+	assert.Equal(d, Decode("00000000000000000000000000000010"))
 	d[19] = 63
-	assert.Equal(d, decode("0000000000000000000000000000001v"))
+	assert.Equal(d, Decode("0000000000000000000000000000001v"))
 	d[19] = 64
-	assert.Equal(d, decode("00000000000000000000000000000020"))
+	assert.Equal(d, Decode("00000000000000000000000000000020"))
 
 	// Largest!
 	for i := 0; i < ByteLen; i++ {
 		d[i] = 0xff
 	}
-	assert.Equal(d, decode("vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv"))
+	assert.Equal(d, Decode("vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv"))
 }

--- a/go/store/hash/base32_test.go
+++ b/go/store/hash/base32_test.go
@@ -31,53 +31,53 @@ func TestBase32Encode(t *testing.T) {
 	assert := assert.New(t)
 
 	d := make([]byte, ByteLen)
-	assert.Equal("00000000000000000000000000000000", Encode(d))
+	assert.Equal("00000000000000000000000000000000", encode(d))
 	d[19] = 1
-	assert.Equal("00000000000000000000000000000001", Encode(d))
+	assert.Equal("00000000000000000000000000000001", encode(d))
 	d[19] = 10
-	assert.Equal("0000000000000000000000000000000a", Encode(d))
+	assert.Equal("0000000000000000000000000000000a", encode(d))
 	d[19] = 20
-	assert.Equal("0000000000000000000000000000000k", Encode(d))
+	assert.Equal("0000000000000000000000000000000k", encode(d))
 	d[19] = 31
-	assert.Equal("0000000000000000000000000000000v", Encode(d))
+	assert.Equal("0000000000000000000000000000000v", encode(d))
 	d[19] = 32
-	assert.Equal("00000000000000000000000000000010", Encode(d))
+	assert.Equal("00000000000000000000000000000010", encode(d))
 	d[19] = 63
-	assert.Equal("0000000000000000000000000000001v", Encode(d))
+	assert.Equal("0000000000000000000000000000001v", encode(d))
 	d[19] = 64
-	assert.Equal("00000000000000000000000000000020", Encode(d))
+	assert.Equal("00000000000000000000000000000020", encode(d))
 
 	// Largest!
 	for i := 0; i < ByteLen; i++ {
 		d[i] = 0xff
 	}
-	assert.Equal("vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv", Encode(d))
+	assert.Equal("vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv", encode(d))
 }
 
 func TestBase32Decode(t *testing.T) {
 	assert := assert.New(t)
 
 	d := make([]byte, ByteLen)
-	assert.Equal(d, Decode("00000000000000000000000000000000"))
+	assert.Equal(d, decode("00000000000000000000000000000000"))
 
 	d[19] = 1
-	assert.Equal(d, Decode("00000000000000000000000000000001"))
+	assert.Equal(d, decode("00000000000000000000000000000001"))
 	d[19] = 10
-	assert.Equal(d, Decode("0000000000000000000000000000000a"))
+	assert.Equal(d, decode("0000000000000000000000000000000a"))
 	d[19] = 20
-	assert.Equal(d, Decode("0000000000000000000000000000000k"))
+	assert.Equal(d, decode("0000000000000000000000000000000k"))
 	d[19] = 31
-	assert.Equal(d, Decode("0000000000000000000000000000000v"))
+	assert.Equal(d, decode("0000000000000000000000000000000v"))
 	d[19] = 32
-	assert.Equal(d, Decode("00000000000000000000000000000010"))
+	assert.Equal(d, decode("00000000000000000000000000000010"))
 	d[19] = 63
-	assert.Equal(d, Decode("0000000000000000000000000000001v"))
+	assert.Equal(d, decode("0000000000000000000000000000001v"))
 	d[19] = 64
-	assert.Equal(d, Decode("00000000000000000000000000000020"))
+	assert.Equal(d, decode("00000000000000000000000000000020"))
 
 	// Largest!
 	for i := 0; i < ByteLen; i++ {
 		d[i] = 0xff
 	}
-	assert.Equal(d, Decode("vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv"))
+	assert.Equal(d, decode("vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv"))
 }

--- a/go/store/hash/hash.go
+++ b/go/store/hash/hash.go
@@ -86,7 +86,7 @@ func (h Hash) IsEmpty() bool {
 
 // String returns a string representation of the hash using Base32 encoding.
 func (h Hash) String() string {
-	return Encode(h[:])
+	return encode(h[:])
 }
 
 // Of computes a new Hash from data.
@@ -112,7 +112,7 @@ func MaybeParse(s string) (Hash, bool) {
 	if match == nil {
 		return emptyHash, false
 	}
-	return New(Decode(s)), true
+	return New(decode(s)), true
 }
 
 // IsValid returns true if the provided string is a valid base32 encoded hash and false if it is not.

--- a/go/store/hash/hash.go
+++ b/go/store/hash/hash.go
@@ -48,6 +48,7 @@ package hash
 import (
 	"bytes"
 	"crypto/sha512"
+	"encoding/binary"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -59,6 +60,12 @@ import (
 const (
 	// ByteLen is the number of bytes used to represent the Hash.
 	ByteLen = 20
+
+	// PrefixLen is the number of bytes used to represent the Prefix of the Hash.
+	PrefixLen = 8 // uint64
+
+	// SuffixLen is the number of bytes which come after the Prefix.
+	SuffixLen = ByteLen - PrefixLen
 
 	// StringLen is the number of characters need to represent the Hash using Base32.
 	StringLen = 32 // 20 * 8 / log2(32)
@@ -121,6 +128,16 @@ func Parse(s string) Hash {
 		d.PanicIfError(fmt.Errorf("cound not parse Hash: %s", s))
 	}
 	return r
+}
+
+// Prefix returns the first 8 bytes of the hash as a unit64. Used for chunk indexing
+func (h Hash) Prefix() uint64 {
+	return binary.BigEndian.Uint64(h[:PrefixLen])
+}
+
+// Suffix returns the last 12 bytes of the hash. Used for chunk indexing
+func (h Hash) Suffix() []byte {
+	return h[PrefixLen:]
 }
 
 // Less compares two hashes returning whether this Hash is less than other.

--- a/go/store/hash/hash.go
+++ b/go/store/hash/hash.go
@@ -86,7 +86,7 @@ func (h Hash) IsEmpty() bool {
 
 // String returns a string representation of the hash using Base32 encoding.
 func (h Hash) String() string {
-	return encode(h[:])
+	return Encode(h[:])
 }
 
 // Of computes a new Hash from data.
@@ -112,7 +112,7 @@ func MaybeParse(s string) (Hash, bool) {
 	if match == nil {
 		return emptyHash, false
 	}
-	return New(decode(s)), true
+	return New(Decode(s)), true
 }
 
 // IsValid returns true if the provided string is a valid base32 encoded hash and false if it is not.

--- a/go/store/nbs/aws_chunk_source.go
+++ b/go/store/nbs/aws_chunk_source.go
@@ -26,9 +26,11 @@ import (
 	"context"
 	"errors"
 	"time"
+
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
-func tableExistsInChunkSource(ctx context.Context, s3 *s3ObjectReader, al awsLimits, name addr, chunkCount uint32, q MemoryQuotaProvider, stats *Stats) (bool, error) {
+func tableExistsInChunkSource(ctx context.Context, s3 *s3ObjectReader, al awsLimits, name hash.Hash, chunkCount uint32, q MemoryQuotaProvider, stats *Stats) (bool, error) {
 	magic := make([]byte, magicNumberSize)
 	n, _, err := s3.ReadFromEnd(ctx, name, magic, stats)
 	if err != nil {
@@ -40,7 +42,7 @@ func tableExistsInChunkSource(ctx context.Context, s3 *s3ObjectReader, al awsLim
 	return bytes.Equal(magic, []byte(magicNumber)), nil
 }
 
-func newAWSChunkSource(ctx context.Context, s3 *s3ObjectReader, al awsLimits, name addr, chunkCount uint32, q MemoryQuotaProvider, stats *Stats) (cs chunkSource, err error) {
+func newAWSChunkSource(ctx context.Context, s3 *s3ObjectReader, al awsLimits, name hash.Hash, chunkCount uint32, q MemoryQuotaProvider, stats *Stats) (cs chunkSource, err error) {
 	var tra tableReaderAt
 	index, err := loadTableIndex(ctx, stats, chunkCount, q, func(p []byte) error {
 		n, _, err := s3.ReadFromEnd(ctx, name, p, stats)

--- a/go/store/nbs/aws_table_persister.go
+++ b/go/store/nbs/aws_table_persister.go
@@ -36,6 +36,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/dolthub/dolt/go/store/hash"
 
 	"github.com/dolthub/dolt/go/store/atomicerr"
 	"github.com/dolthub/dolt/go/store/chunks"
@@ -66,7 +67,7 @@ type awsLimits struct {
 	partTarget, partMin, partMax uint64
 }
 
-func (s3p awsTablePersister) Open(ctx context.Context, name addr, chunkCount uint32, stats *Stats) (chunkSource, error) {
+func (s3p awsTablePersister) Open(ctx context.Context, name hash.Hash, chunkCount uint32, stats *Stats) (chunkSource, error) {
 	return newAWSChunkSource(
 		ctx,
 		&s3ObjectReader{s3: s3p.s3, bucket: s3p.bucket, readRl: s3p.rl, ns: s3p.ns},
@@ -78,7 +79,7 @@ func (s3p awsTablePersister) Open(ctx context.Context, name addr, chunkCount uin
 	)
 }
 
-func (s3p awsTablePersister) Exists(ctx context.Context, name addr, chunkCount uint32, stats *Stats) (bool, error) {
+func (s3p awsTablePersister) Exists(ctx context.Context, name hash.Hash, chunkCount uint32, stats *Stats) (bool, error) {
 	return tableExistsInChunkSource(
 		ctx,
 		&s3ObjectReader{s3: s3p.s3, bucket: s3p.bucket, readRl: s3p.rl, ns: s3p.ns},
@@ -482,7 +483,7 @@ func (s3p awsTablePersister) uploadPart(ctx context.Context, data []byte, key, u
 	return
 }
 
-func (s3p awsTablePersister) PruneTableFiles(ctx context.Context, keeper func() []addr, t time.Time) error {
+func (s3p awsTablePersister) PruneTableFiles(ctx context.Context, keeper func() []hash.Hash, t time.Time) error {
 	return chunks.ErrUnsupportedOperation
 }
 

--- a/go/store/nbs/aws_table_persister.go
+++ b/go/store/nbs/aws_table_persister.go
@@ -36,10 +36,10 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
-	"github.com/dolthub/dolt/go/store/hash"
 
 	"github.com/dolthub/dolt/go/store/atomicerr"
 	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/util/verbose"
 )
 

--- a/go/store/nbs/aws_table_persister_test.go
+++ b/go/store/nbs/aws_table_persister_test.go
@@ -33,9 +33,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
-	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 func randomChunks(t *testing.T, r *rand.Rand, sz int) [][]byte {

--- a/go/store/nbs/aws_table_persister_test.go
+++ b/go/store/nbs/aws_table_persister_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -160,22 +161,22 @@ func TestAWSTablePersisterPersist(t *testing.T) {
 }
 
 type waitOnStoreTableCache struct {
-	readers map[addr]io.ReaderAt
+	readers map[hash.Hash]io.ReaderAt
 	mu      sync.RWMutex
 	storeWG sync.WaitGroup
 }
 
-func (mtc *waitOnStoreTableCache) checkout(h addr) (io.ReaderAt, error) {
+func (mtc *waitOnStoreTableCache) checkout(h hash.Hash) (io.ReaderAt, error) {
 	mtc.mu.RLock()
 	defer mtc.mu.RUnlock()
 	return mtc.readers[h], nil
 }
 
-func (mtc *waitOnStoreTableCache) checkin(h addr) error {
+func (mtc *waitOnStoreTableCache) checkin(h hash.Hash) error {
 	return nil
 }
 
-func (mtc *waitOnStoreTableCache) store(h addr, data io.Reader, size uint64) error {
+func (mtc *waitOnStoreTableCache) store(h hash.Hash, data io.Reader, size uint64) error {
 	defer mtc.storeWG.Done()
 	mtc.mu.Lock()
 	defer mtc.mu.Unlock()

--- a/go/store/nbs/bs_manifest.go
+++ b/go/store/nbs/bs_manifest.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/dolthub/dolt/go/store/blobstore"
 	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 const (
@@ -74,7 +75,7 @@ func (bsm blobstoreManifest) ParseIfExists(ctx context.Context, stats *Stats, re
 }
 
 // Update updates the contents of the manifest in the blobstore
-func (bsm blobstoreManifest) Update(ctx context.Context, lastLock addr, newContents manifestContents, stats *Stats, writeHook func() error) (manifestContents, error) {
+func (bsm blobstoreManifest) Update(ctx context.Context, lastLock hash.Hash, newContents manifestContents, stats *Stats, writeHook func() error) (manifestContents, error) {
 	checker := func(upstream, contents manifestContents) error {
 		if contents.gcGen != upstream.gcGen {
 			return chunks.ErrGCGenerationExpired
@@ -85,7 +86,7 @@ func (bsm blobstoreManifest) Update(ctx context.Context, lastLock addr, newConte
 	return updateBSWithChecker(ctx, bsm.bs, checker, lastLock, newContents, writeHook)
 }
 
-func (bsm blobstoreManifest) UpdateGCGen(ctx context.Context, lastLock addr, newContents manifestContents, stats *Stats, writeHook func() error) (manifestContents, error) {
+func (bsm blobstoreManifest) UpdateGCGen(ctx context.Context, lastLock hash.Hash, newContents manifestContents, stats *Stats, writeHook func() error) (manifestContents, error) {
 	checker := func(upstream, contents manifestContents) error {
 		if contents.gcGen == upstream.gcGen {
 			return errors.New("UpdateGCGen() must update the garbage collection generation")
@@ -100,7 +101,7 @@ func (bsm blobstoreManifest) UpdateGCGen(ctx context.Context, lastLock addr, new
 	return updateBSWithChecker(ctx, bsm.bs, checker, lastLock, newContents, writeHook)
 }
 
-func updateBSWithChecker(ctx context.Context, bs blobstore.Blobstore, validate manifestChecker, lastLock addr, newContents manifestContents, writeHook func() error) (mc manifestContents, err error) {
+func updateBSWithChecker(ctx context.Context, bs blobstore.Blobstore, validate manifestChecker, lastLock hash.Hash, newContents manifestContents, writeHook func() error) (mc manifestContents, err error) {
 	if writeHook != nil {
 		panic("Write hooks not supported")
 	}

--- a/go/store/nbs/bs_persister.go
+++ b/go/store/nbs/bs_persister.go
@@ -22,11 +22,11 @@ import (
 	"io"
 	"time"
 
-	"github.com/dolthub/dolt/go/store/hash"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/dolthub/dolt/go/store/blobstore"
 	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 const (

--- a/go/store/nbs/bs_persister.go
+++ b/go/store/nbs/bs_persister.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/dolthub/dolt/go/store/hash"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/dolthub/dolt/go/store/blobstore"
@@ -160,15 +161,15 @@ func (bsp *blobstorePersister) getRecordsSubObject(ctx context.Context, cs chunk
 }
 
 // Open a table named |name|, containing |chunkCount| chunks.
-func (bsp *blobstorePersister) Open(ctx context.Context, name addr, chunkCount uint32, stats *Stats) (chunkSource, error) {
+func (bsp *blobstorePersister) Open(ctx context.Context, name hash.Hash, chunkCount uint32, stats *Stats) (chunkSource, error) {
 	return newBSChunkSource(ctx, bsp.bs, name, chunkCount, bsp.q, stats)
 }
 
-func (bsp *blobstorePersister) Exists(ctx context.Context, name addr, chunkCount uint32, stats *Stats) (bool, error) {
+func (bsp *blobstorePersister) Exists(ctx context.Context, name hash.Hash, chunkCount uint32, stats *Stats) (bool, error) {
 	return bsp.bs.Exists(ctx, name.String())
 }
 
-func (bsp *blobstorePersister) PruneTableFiles(ctx context.Context, keeper func() []addr, t time.Time) error {
+func (bsp *blobstorePersister) PruneTableFiles(ctx context.Context, keeper func() []hash.Hash, t time.Time) error {
 	return nil
 }
 
@@ -275,7 +276,7 @@ func (bsTRA *bsTableReaderAt) ReadAtWithStats(ctx context.Context, p []byte, off
 	return totalRead, nil
 }
 
-func newBSChunkSource(ctx context.Context, bs blobstore.Blobstore, name addr, chunkCount uint32, q MemoryQuotaProvider, stats *Stats) (cs chunkSource, err error) {
+func newBSChunkSource(ctx context.Context, bs blobstore.Blobstore, name hash.Hash, chunkCount uint32, q MemoryQuotaProvider, stats *Stats) (cs chunkSource, err error) {
 	index, err := loadTableIndex(ctx, stats, chunkCount, q, func(p []byte) error {
 		rc, _, err := bs.Get(ctx, name.String(), blobstore.NewBlobRange(-int64(len(p)), 0))
 		if err != nil {

--- a/go/store/nbs/chunk_source_adapter.go
+++ b/go/store/nbs/chunk_source_adapter.go
@@ -14,18 +14,22 @@
 
 package nbs
 
-import "context"
+import (
+	"context"
+
+	"github.com/dolthub/dolt/go/store/hash"
+)
 
 type chunkSourceAdapter struct {
 	tableReader
-	h addr
+	h hash.Hash
 }
 
-func (csa chunkSourceAdapter) hash() addr {
+func (csa chunkSourceAdapter) hash() hash.Hash {
 	return csa.h
 }
 
-func newReaderFromIndexData(ctx context.Context, q MemoryQuotaProvider, idxData []byte, name addr, tra tableReaderAt, blockSize uint64) (cs chunkSource, err error) {
+func newReaderFromIndexData(ctx context.Context, q MemoryQuotaProvider, idxData []byte, name hash.Hash, tra tableReaderAt, blockSize uint64) (cs chunkSource, err error) {
 	index, err := parseTableIndexByCopy(ctx, idxData, q)
 	if err != nil {
 		return nil, err

--- a/go/store/nbs/cmp_chunk_table_writer.go
+++ b/go/store/nbs/cmp_chunk_table_writer.go
@@ -23,8 +23,9 @@ import (
 	"os"
 	"sort"
 
-	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/golang/snappy"
+
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 const defaultTableSinkBlockSize = 2 * 1024 * 1024

--- a/go/store/nbs/conjoiner.go
+++ b/go/store/nbs/conjoiner.go
@@ -27,8 +27,9 @@ import (
 	"sort"
 	"time"
 
-	"github.com/dolthub/dolt/go/store/hash"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 type conjoinStrategy interface {

--- a/go/store/nbs/conjoiner.go
+++ b/go/store/nbs/conjoiner.go
@@ -27,6 +27,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/dolthub/dolt/go/store/hash"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -171,8 +172,8 @@ func conjoin(ctx context.Context, s conjoinStrategy, upstream manifestContents, 
 			upstream, appendixSpecs = upstream.removeAppendixSpecs()
 		}
 
-		conjoineeSet := map[addr]struct{}{}
-		upstreamNames := map[addr]struct{}{}
+		conjoineeSet := map[hash.Hash]struct{}{}
+		upstreamNames := map[hash.Hash]struct{}{}
 		for _, spec := range upstream.specs {
 			upstreamNames[spec.name] = struct{}{}
 		}

--- a/go/store/nbs/conjoiner_test.go
+++ b/go/store/nbs/conjoiner_test.go
@@ -111,7 +111,7 @@ func TestConjoin(t *testing.T) {
 
 func testConjoin(t *testing.T, factory func(t *testing.T) tablePersister) {
 	stats := &Stats{}
-	setup := func(lock addr, root hash.Hash, sizes []uint32) (fm *fakeManifest, p tablePersister, upstream manifestContents) {
+	setup := func(lock hash.Hash, root hash.Hash, sizes []uint32) (fm *fakeManifest, p tablePersister, upstream manifestContents) {
 		p = factory(t)
 		fm = &fakeManifest{}
 		fm.set(constants.FormatLD1String, lock, root, makeTestTableSpecs(t, sizes, p), nil)
@@ -257,7 +257,7 @@ func testConjoin(t *testing.T, factory func(t *testing.T) tablePersister) {
 		}
 	})
 
-	setupAppendix := func(lock addr, root hash.Hash, specSizes, appendixSizes []uint32) (fm *fakeManifest, p tablePersister, upstream manifestContents) {
+	setupAppendix := func(lock hash.Hash, root hash.Hash, specSizes, appendixSizes []uint32) (fm *fakeManifest, p tablePersister, upstream manifestContents) {
 		p = newFakeTablePersister(&UnlimitedQuotaProvider{})
 		fm = &fakeManifest{}
 		fm.set(constants.FormatLD1String, lock, root, makeTestTableSpecs(t, specSizes, p), makeTestTableSpecs(t, appendixSizes, p))
@@ -403,7 +403,7 @@ type updatePreemptManifest struct {
 	preUpdate func()
 }
 
-func (u updatePreemptManifest) Update(ctx context.Context, lastLock addr, newContents manifestContents, stats *Stats, writeHook func() error) (manifestContents, error) {
+func (u updatePreemptManifest) Update(ctx context.Context, lastLock hash.Hash, newContents manifestContents, stats *Stats, writeHook func() error) (manifestContents, error) {
 	if u.preUpdate != nil {
 		u.preUpdate()
 	}

--- a/go/store/nbs/dynamo_manifest.go
+++ b/go/store/nbs/dynamo_manifest.go
@@ -146,7 +146,7 @@ func validateManifest(item map[string]*dynamodb.AttributeValue) (valid, hasSpecs
 	return false, false, false
 }
 
-func (dm dynamoManifest) Update(ctx context.Context, lastLock addr, newContents manifestContents, stats *Stats, writeHook func() error) (manifestContents, error) {
+func (dm dynamoManifest) Update(ctx context.Context, lastLock hash.Hash, newContents manifestContents, stats *Stats, writeHook func() error) (manifestContents, error) {
 	t1 := time.Now()
 	defer func() { stats.WriteManifestLatency.SampleTimeSince(t1) }()
 
@@ -174,7 +174,7 @@ func (dm dynamoManifest) Update(ctx context.Context, lastLock addr, newContents 
 	}
 
 	expr := valueEqualsExpression
-	if lastLock == (addr{}) {
+	if lastLock.IsEmpty() {
 		expr = valueNotExistsOrEqualsExpression
 	}
 

--- a/go/store/nbs/empty_chunk_source.go
+++ b/go/store/nbs/empty_chunk_source.go
@@ -34,7 +34,7 @@ import (
 
 type emptyChunkSource struct{}
 
-func (ecs emptyChunkSource) has(h addr) (bool, error) {
+func (ecs emptyChunkSource) has(h hash.Hash) (bool, error) {
 	return false, nil
 }
 
@@ -42,7 +42,7 @@ func (ecs emptyChunkSource) hasMany(addrs []hasRecord) (bool, error) {
 	return true, nil
 }
 
-func (ecs emptyChunkSource) get(ctx context.Context, h addr, stats *Stats) ([]byte, error) {
+func (ecs emptyChunkSource) get(ctx context.Context, h hash.Hash, stats *Stats) ([]byte, error) {
 	return nil, nil
 }
 
@@ -62,8 +62,8 @@ func (ecs emptyChunkSource) uncompressedLen() (uint64, error) {
 	return 0, nil
 }
 
-func (ecs emptyChunkSource) hash() addr {
-	return addr{}
+func (ecs emptyChunkSource) hash() hash.Hash {
+	return hash.Hash{}
 }
 
 func (ecs emptyChunkSource) index() (tableIndex, error) {

--- a/go/store/nbs/file_table_persister_test.go
+++ b/go/store/nbs/file_table_persister_test.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 
 	"github.com/dolthub/dolt/go/libraries/utils/file"
+	"github.com/dolthub/dolt/go/store/hash"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,23 +42,23 @@ func makeTempDir(t *testing.T) string {
 	return dir
 }
 
-func writeTableData(dir string, chunx ...[]byte) (addr, error) {
+func writeTableData(dir string, chunx ...[]byte) (hash.Hash, error) {
 	tableData, name, err := buildTable(chunx)
 
 	if err != nil {
-		return addr{}, err
+		return hash.Hash{}, err
 	}
 
 	err = os.WriteFile(filepath.Join(dir, name.String()), tableData, 0666)
 
 	if err != nil {
-		return addr{}, err
+		return hash.Hash{}, err
 	}
 
 	return name, nil
 }
 
-func removeTables(dir string, names ...addr) error {
+func removeTables(dir string, names ...hash.Hash) error {
 	for _, name := range names {
 		if err := file.Remove(filepath.Join(dir, name.String())); err != nil {
 			return err

--- a/go/store/nbs/file_table_reader.go
+++ b/go/store/nbs/file_table_reader.go
@@ -29,18 +29,20 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 type fileTableReader struct {
 	tableReader
-	h addr
+	h hash.Hash
 }
 
 const (
 	fileBlockSize = 1 << 12
 )
 
-func tableFileExists(ctx context.Context, dir string, h addr) (bool, error) {
+func tableFileExists(ctx context.Context, dir string, h hash.Hash) (bool, error) {
 	path := filepath.Join(dir, h.String())
 	_, err := os.Stat(path)
 
@@ -51,7 +53,7 @@ func tableFileExists(ctx context.Context, dir string, h addr) (bool, error) {
 	return err == nil, err
 }
 
-func newFileTableReader(ctx context.Context, dir string, h addr, chunkCount uint32, q MemoryQuotaProvider) (cs chunkSource, err error) {
+func newFileTableReader(ctx context.Context, dir string, h hash.Hash, chunkCount uint32, q MemoryQuotaProvider) (cs chunkSource, err error) {
 	path := filepath.Join(dir, h.String())
 
 	var f *os.File
@@ -134,7 +136,7 @@ func newFileTableReader(ctx context.Context, dir string, h addr, chunkCount uint
 	}, nil
 }
 
-func (ftr *fileTableReader) hash() addr {
+func (ftr *fileTableReader) hash() hash.Hash {
 	return ftr.h
 }
 

--- a/go/store/nbs/gc_copier.go
+++ b/go/store/nbs/gc_copier.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 	"strings"
+
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 type gcErrAccum map[string]error
@@ -72,10 +74,9 @@ func (gcc *gcCopier) copyTablesToDir(ctx context.Context, tfp tableFilePersister
 		_ = gcc.writer.Remove()
 	}()
 
-	var addr addr
-	addr, err = parseAddr(filename)
-	if err != nil {
-		return nil, err
+	addr, ok := hash.MaybeParse(filename)
+	if !ok {
+		return nil, fmt.Errorf("invalid filename: %s", filename)
 	}
 
 	exists, err := tfp.Exists(ctx, addr, uint32(gcc.writer.ChunkCount()), nil)

--- a/go/store/nbs/index_transformer.go
+++ b/go/store/nbs/index_transformer.go
@@ -18,6 +18,8 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 var (
@@ -27,7 +29,7 @@ var (
 func NewIndexTransformer(src io.Reader, chunkCount int) io.Reader {
 	tuplesSize := chunkCount * prefixTupleSize
 	lengthsSize := chunkCount * lengthSize
-	suffixesSize := chunkCount * addrSuffixSize
+	suffixesSize := chunkCount * hash.SuffixLen
 
 	tupleReader := io.LimitReader(src, int64(tuplesSize))
 	lengthsReader := io.LimitReader(src, int64(lengthsSize))

--- a/go/store/nbs/index_transformer_test.go
+++ b/go/store/nbs/index_transformer_test.go
@@ -22,10 +22,10 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/dolt/go/libraries/utils/test"
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 // minByteReader is a copy of smallerByteReader from testing/iotest

--- a/go/store/nbs/index_transformer_test.go
+++ b/go/store/nbs/index_transformer_test.go
@@ -22,6 +22,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/dolt/go/libraries/utils/test"
@@ -166,7 +167,7 @@ func TestIndexTransformer(t *testing.T) {
 	offsetBytes := get64Bytes(offsets)
 
 	tupleBytes := test.RandomData(chunkCount * prefixTupleSize)
-	suffixBytes := test.RandomData(chunkCount * addrSuffixSize)
+	suffixBytes := test.RandomData(chunkCount * hash.SuffixLen)
 
 	var inBytes []byte
 	inBytes = append(inBytes, tupleBytes...)

--- a/go/store/nbs/journal.go
+++ b/go/store/nbs/journal.go
@@ -276,7 +276,7 @@ func (j *ChunkJournal) ConjoinAll(ctx context.Context, sources chunkSources, sta
 }
 
 // Open implements tablePersister.
-func (j *ChunkJournal) Open(ctx context.Context, name addr, chunkCount uint32, stats *Stats) (chunkSource, error) {
+func (j *ChunkJournal) Open(ctx context.Context, name hash.Hash, chunkCount uint32, stats *Stats) (chunkSource, error) {
 	if name == journalAddr {
 		if err := j.maybeInit(ctx); err != nil {
 			return nil, err
@@ -287,12 +287,12 @@ func (j *ChunkJournal) Open(ctx context.Context, name addr, chunkCount uint32, s
 }
 
 // Exists implements tablePersister.
-func (j *ChunkJournal) Exists(ctx context.Context, name addr, chunkCount uint32, stats *Stats) (bool, error) {
+func (j *ChunkJournal) Exists(ctx context.Context, name hash.Hash, chunkCount uint32, stats *Stats) (bool, error) {
 	return j.persister.Exists(ctx, name, chunkCount, stats)
 }
 
 // PruneTableFiles implements tablePersister.
-func (j *ChunkJournal) PruneTableFiles(ctx context.Context, keeper func() []addr, mtime time.Time) error {
+func (j *ChunkJournal) PruneTableFiles(ctx context.Context, keeper func() []hash.Hash, mtime time.Time) error {
 	if j.backing.readOnly() {
 		return errReadOnlyManifest
 	}
@@ -326,7 +326,7 @@ func (j *ChunkJournal) Name() string {
 }
 
 // Update implements manifest.
-func (j *ChunkJournal) Update(ctx context.Context, lastLock addr, next manifestContents, stats *Stats, writeHook func() error) (manifestContents, error) {
+func (j *ChunkJournal) Update(ctx context.Context, lastLock hash.Hash, next manifestContents, stats *Stats, writeHook func() error) (manifestContents, error) {
 	if j.backing.readOnly() {
 		return j.contents, errReadOnlyManifest
 	}
@@ -372,7 +372,7 @@ func (j *ChunkJournal) Update(ctx context.Context, lastLock addr, next manifestC
 }
 
 // UpdateGCGen implements manifestGCGenUpdater.
-func (j *ChunkJournal) UpdateGCGen(ctx context.Context, lastLock addr, next manifestContents, stats *Stats, writeHook func() error) (manifestContents, error) {
+func (j *ChunkJournal) UpdateGCGen(ctx context.Context, lastLock hash.Hash, next manifestContents, stats *Stats, writeHook func() error) (manifestContents, error) {
 	if j.backing.readOnly() {
 		return j.contents, errReadOnlyManifest
 	} else if j.wr == nil {
@@ -589,7 +589,7 @@ func (jm *journalManifest) ParseIfExists(ctx context.Context, stats *Stats, read
 }
 
 // Update implements manifest.
-func (jm *journalManifest) Update(ctx context.Context, lastLock addr, newContents manifestContents, stats *Stats, writeHook func() error) (mc manifestContents, err error) {
+func (jm *journalManifest) Update(ctx context.Context, lastLock hash.Hash, newContents manifestContents, stats *Stats, writeHook func() error) (mc manifestContents, err error) {
 	if jm.readOnly() {
 		_, mc, err = jm.ParseIfExists(ctx, stats, nil)
 		if err != nil {
@@ -611,7 +611,7 @@ func (jm *journalManifest) Update(ctx context.Context, lastLock addr, newContent
 }
 
 // UpdateGCGen implements manifest.
-func (jm *journalManifest) UpdateGCGen(ctx context.Context, lastLock addr, newContents manifestContents, stats *Stats, writeHook func() error) (mc manifestContents, err error) {
+func (jm *journalManifest) UpdateGCGen(ctx context.Context, lastLock hash.Hash, newContents manifestContents, stats *Stats, writeHook func() error) (mc manifestContents, err error) {
 	if jm.readOnly() {
 		_, mc, err = jm.ParseIfExists(ctx, stats, nil)
 		if err != nil {

--- a/go/store/nbs/journal_chunk_source.go
+++ b/go/store/nbs/journal_chunk_source.go
@@ -35,7 +35,7 @@ type journalChunkSource struct {
 
 var _ chunkSource = journalChunkSource{}
 
-func (s journalChunkSource) has(h addr) (bool, error) {
+func (s journalChunkSource) has(h hash.Hash) (bool, error) {
 	return s.journal.hasAddr(h), nil
 }
 
@@ -51,11 +51,11 @@ func (s journalChunkSource) hasMany(addrs []hasRecord) (missing bool, err error)
 	return
 }
 
-func (s journalChunkSource) getCompressed(_ context.Context, h addr, _ *Stats) (CompressedChunk, error) {
+func (s journalChunkSource) getCompressed(_ context.Context, h hash.Hash, _ *Stats) (CompressedChunk, error) {
 	return s.journal.getCompressedChunk(h)
 }
 
-func (s journalChunkSource) get(_ context.Context, h addr, _ *Stats) ([]byte, error) {
+func (s journalChunkSource) get(_ context.Context, h hash.Hash, _ *Stats) ([]byte, error) {
 	cc, err := s.journal.getCompressedChunk(h)
 	if err != nil {
 		return nil, err
@@ -118,7 +118,7 @@ func (s journalChunkSource) uncompressedLen() (uint64, error) {
 	return s.journal.uncompressedSize(), nil
 }
 
-func (s journalChunkSource) hash() addr {
+func (s journalChunkSource) hash() hash.Hash {
 	return journalAddr
 }
 
@@ -170,7 +170,7 @@ func equalSpecs(left, right []tableSpec) bool {
 	if len(left) != len(right) {
 		return false
 	}
-	l := make(map[addr]struct{}, len(left))
+	l := make(map[hash.Hash]struct{}, len(left))
 	for _, s := range left {
 		l[s.name] = struct{}{}
 	}
@@ -180,9 +180,4 @@ func equalSpecs(left, right []tableSpec) bool {
 		}
 	}
 	return true
-}
-
-func emptyAddr(a addr) bool {
-	var b addr
-	return a == b
 }

--- a/go/store/nbs/journal_index_record.go
+++ b/go/store/nbs/journal_index_record.go
@@ -234,11 +234,11 @@ func processIndexRecords(ctx context.Context, r io.ReadSeeker, sz int64, cb func
 }
 
 type lookup struct {
-	a addr
+	a hash.Hash
 	r Range
 }
 
-const lookupSize = addrSize + offsetSize + lengthSize
+const lookupSize = hash.ByteLen + offsetSize + lengthSize
 
 // serializeLookups serializes |lookups| using the table file chunk index format.
 func serializeLookups(lookups []lookup) (index []byte) {
@@ -249,7 +249,7 @@ func serializeLookups(lookups []lookup) (index []byte) {
 	buf := index
 	for _, l := range lookups {
 		copy(buf, l.a[:])
-		buf = buf[addrSize:]
+		buf = buf[hash.ByteLen:]
 		binary.BigEndian.PutUint64(buf, l.r.Offset)
 		buf = buf[offsetSize:]
 		binary.BigEndian.PutUint32(buf, l.r.Length)
@@ -262,7 +262,7 @@ func deserializeLookups(index []byte) (lookups []lookup) {
 	lookups = make([]lookup, len(index)/lookupSize)
 	for i := range lookups {
 		copy(lookups[i].a[:], index)
-		index = index[addrSize:]
+		index = index[hash.ByteLen:]
 		lookups[i].r.Offset = binary.BigEndian.Uint64(index)
 		index = index[offsetSize:]
 		lookups[i].r.Length = binary.BigEndian.Uint32(index)

--- a/go/store/nbs/journal_index_record_test.go
+++ b/go/store/nbs/journal_index_record_test.go
@@ -190,12 +190,12 @@ func mustPayload(rec indexRec) []byte {
 
 func makeLookups(cnt int) (lookups []lookup) {
 	lookups = make([]lookup, cnt)
-	buf := make([]byte, cnt*addrSize)
+	buf := make([]byte, cnt*hash.ByteLen)
 	rand.Read(buf)
 	var off uint64
 	for i := range lookups {
 		copy(lookups[i].a[:], buf)
-		buf = buf[addrSize:]
+		buf = buf[hash.ByteLen:]
 		lookups[i].r.Offset = off
 		l := rand.Uint32() % 1024
 		lookups[i].r.Length = l

--- a/go/store/nbs/journal_record.go
+++ b/go/store/nbs/journal_record.go
@@ -47,7 +47,7 @@ import (
 type journalRec struct {
 	length    uint32
 	kind      journalRecKind
-	address   addr
+	address   hash.Hash
 	payload   []byte
 	timestamp time.Time
 	checksum  uint32
@@ -150,7 +150,7 @@ func writeChunkRecord(buf []byte, c CompressedChunk) (n uint32) {
 	return
 }
 
-func writeRootHashRecord(buf []byte, root addr) (n uint32) {
+func writeRootHashRecord(buf []byte, root hash.Hash) (n uint32) {
 	// length
 	l := rootHashRecordSize()
 	writeUint32(buf[:journalRecLenSz], uint32(l))

--- a/go/store/nbs/journal_record_test.go
+++ b/go/store/nbs/journal_record_test.go
@@ -127,11 +127,11 @@ func TestProcessJournalRecords(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func randomMemTable(cnt int) (*memTable, map[addr]chunks.Chunk) {
-	chnx := make(map[addr]chunks.Chunk, cnt)
+func randomMemTable(cnt int) (*memTable, map[hash.Hash]chunks.Chunk) {
+	chnx := make(map[hash.Hash]chunks.Chunk, cnt)
 	for i := 0; i < cnt; i++ {
 		ch := chunks.NewChunk(randBuf(100))
-		chnx[addr(ch.Hash())] = ch
+		chnx[ch.Hash()] = ch
 	}
 	mt := newMemTable(uint64(cnt) * 256)
 	for a, ch := range chnx {
@@ -173,7 +173,7 @@ func makeChunkRecord() (journalRec, []byte) {
 	r := journalRec{
 		length:   uint32(len(buf)),
 		kind:     chunkJournalRecKind,
-		address:  addr(cc.H),
+		address:  cc.H,
 		payload:  payload,
 		checksum: c,
 	}
@@ -181,7 +181,7 @@ func makeChunkRecord() (journalRec, []byte) {
 }
 
 func makeRootHashRecord() (journalRec, []byte) {
-	a := addr(hash.Of(randBuf(8)))
+	a := hash.Of(randBuf(8))
 	var n int
 	buf := make([]byte, rootHashRecordSize())
 	// length

--- a/go/store/nbs/journal_test.go
+++ b/go/store/nbs/journal_test.go
@@ -112,17 +112,17 @@ func TestReadRecordRanges(t *testing.T) {
 	require.NoError(t, err)
 
 	for h, rng := range ranges {
-		b, err := jcs.get(ctx, addr(h), &Stats{})
+		b, err := jcs.get(ctx, h, &Stats{})
 		assert.NoError(t, err)
 		ch1 := chunks.NewChunkWithHash(h, b)
-		assert.Equal(t, data[addr(h)], ch1)
+		assert.Equal(t, data[h], ch1)
 
 		start, stop := rng.Offset, uint32(rng.Offset)+rng.Length
 		cc2, err := NewCompressedChunk(h, buf[start:stop])
 		assert.NoError(t, err)
 		ch2, err := cc2.ToChunk()
 		assert.NoError(t, err)
-		assert.Equal(t, data[addr(h)], ch2)
+		assert.Equal(t, data[h], ch2)
 	}
 }
 

--- a/go/store/nbs/manifest.go
+++ b/go/store/nbs/manifest.go
@@ -501,7 +501,7 @@ func formatSpecs(specs []tableSpec, tableInfo []string) {
 // persisted manifest against the lock hash it saw last time it loaded the
 // contents of a manifest. If they do not match, the client must not update
 // the persisted manifest.
-func generateLockHash(root hash.Hash, specs []tableSpec, appendix []tableSpec) (lock hash.Hash) {
+func generateLockHash(root hash.Hash, specs []tableSpec, appendix []tableSpec) hash.Hash {
 	blockHash := sha512.New()
 	blockHash.Write(root[:])
 	for _, spec := range appendix {

--- a/go/store/nbs/mem_table.go
+++ b/go/store/nbs/mem_table.go
@@ -113,6 +113,7 @@ func (mt *memTable) addChunk(h hash.Hash, data []byte) addChunkResult {
 
 func (mt *memTable) addChildRefs(addrs hash.HashSet) {
 	for h := range addrs {
+		h := h
 		mt.pendingRefs = append(mt.pendingRefs, hasRecord{
 			a:      &h,
 			prefix: h.Prefix(),

--- a/go/store/nbs/mem_table_test.go
+++ b/go/store/nbs/mem_table_test.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/golang/snappy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -243,7 +244,7 @@ func (o *outOfLineSnappy) Encode(dst, src []byte) []byte {
 
 type chunkReaderGroup []chunkReader
 
-func (crg chunkReaderGroup) has(h addr) (bool, error) {
+func (crg chunkReaderGroup) has(h hash.Hash) (bool, error) {
 	for _, haver := range crg {
 		ok, err := haver.has(h)
 
@@ -258,7 +259,7 @@ func (crg chunkReaderGroup) has(h addr) (bool, error) {
 	return false, nil
 }
 
-func (crg chunkReaderGroup) get(ctx context.Context, h addr, stats *Stats) ([]byte, error) {
+func (crg chunkReaderGroup) get(ctx context.Context, h hash.Hash, stats *Stats) ([]byte, error) {
 	for _, haver := range crg {
 		if data, err := haver.get(ctx, h, stats); err != nil {
 			return nil, err

--- a/go/store/nbs/mem_table_test.go
+++ b/go/store/nbs/mem_table_test.go
@@ -28,7 +28,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/golang/snappy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,6 +35,7 @@ import (
 
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/d"
+	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/types"
 )
 

--- a/go/store/nbs/must_test.go
+++ b/go/store/nbs/must_test.go
@@ -16,7 +16,6 @@ package nbs
 
 import (
 	"github.com/dolthub/dolt/go/store/d"
-	"github.com/dolthub/dolt/go/store/hash"
 )
 
 func mustUint32(val uint32, err error) uint32 {
@@ -27,9 +26,4 @@ func mustUint32(val uint32, err error) uint32 {
 func mustUint64(val uint64, err error) uint64 {
 	d.PanicIfError(err)
 	return val
-}
-
-func mustAddr(h hash.Hash, err error) hash.Hash {
-	d.PanicIfError(err)
-	return h
 }

--- a/go/store/nbs/must_test.go
+++ b/go/store/nbs/must_test.go
@@ -14,7 +14,10 @@
 
 package nbs
 
-import "github.com/dolthub/dolt/go/store/d"
+import (
+	"github.com/dolthub/dolt/go/store/d"
+	"github.com/dolthub/dolt/go/store/hash"
+)
 
 func mustUint32(val uint32, err error) uint32 {
 	d.PanicIfError(err)
@@ -26,7 +29,7 @@ func mustUint64(val uint64, err error) uint64 {
 	return val
 }
 
-func mustAddr(h addr, err error) addr {
+func mustAddr(h hash.Hash, err error) hash.Hash {
 	d.PanicIfError(err)
 	return h
 }

--- a/go/store/nbs/no_conjoin_bs_persister.go
+++ b/go/store/nbs/no_conjoin_bs_persister.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/fatih/color"
 	"golang.org/x/sync/errgroup"
 
@@ -68,15 +69,15 @@ func (bsp *noConjoinBlobstorePersister) ConjoinAll(ctx context.Context, sources 
 }
 
 // Open a table named |name|, containing |chunkCount| chunks.
-func (bsp *noConjoinBlobstorePersister) Open(ctx context.Context, name addr, chunkCount uint32, stats *Stats) (chunkSource, error) {
+func (bsp *noConjoinBlobstorePersister) Open(ctx context.Context, name hash.Hash, chunkCount uint32, stats *Stats) (chunkSource, error) {
 	return newBSChunkSource(ctx, bsp.bs, name, chunkCount, bsp.q, stats)
 }
 
-func (bsp *noConjoinBlobstorePersister) Exists(ctx context.Context, name addr, chunkCount uint32, stats *Stats) (bool, error) {
+func (bsp *noConjoinBlobstorePersister) Exists(ctx context.Context, name hash.Hash, chunkCount uint32, stats *Stats) (bool, error) {
 	return bsp.bs.Exists(ctx, name.String())
 }
 
-func (bsp *noConjoinBlobstorePersister) PruneTableFiles(ctx context.Context, keeper func() []addr, t time.Time) error {
+func (bsp *noConjoinBlobstorePersister) PruneTableFiles(ctx context.Context, keeper func() []hash.Hash, t time.Time) error {
 	return nil
 }
 

--- a/go/store/nbs/no_conjoin_bs_persister.go
+++ b/go/store/nbs/no_conjoin_bs_persister.go
@@ -21,12 +21,12 @@ import (
 	"io"
 	"time"
 
-	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/fatih/color"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/dolthub/dolt/go/store/blobstore"
 	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 type noConjoinBlobstorePersister struct {

--- a/go/store/nbs/root_tracker_test.go
+++ b/go/store/nbs/root_tracker_test.go
@@ -446,7 +446,7 @@ func (fm *fakeManifest) Name() string { return fm.name }
 func (fm *fakeManifest) ParseIfExists(ctx context.Context, stats *Stats, readHook func() error) (bool, manifestContents, error) {
 	fm.mu.RLock()
 	defer fm.mu.RUnlock()
-	if fm.contents.lock != (hash.Hash{}) {
+	if !fm.contents.lock.IsEmpty() {
 		return true, fm.contents, nil
 	}
 

--- a/go/store/nbs/s3_fake_test.go
+++ b/go/store/nbs/s3_fake_test.go
@@ -77,7 +77,7 @@ type fakeS3Multipart struct {
 	etags    []string
 }
 
-func (m *fakeS3) readerForTable(ctx context.Context, name addr) (chunkReader, error) {
+func (m *fakeS3) readerForTable(ctx context.Context, name hash.Hash) (chunkReader, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if buff, present := m.data[name.String()]; present {
@@ -95,7 +95,7 @@ func (m *fakeS3) readerForTable(ctx context.Context, name addr) (chunkReader, er
 	return nil, nil
 }
 
-func (m *fakeS3) readerForTableWithNamespace(ctx context.Context, ns string, name addr) (chunkReader, error) {
+func (m *fakeS3) readerForTableWithNamespace(ctx context.Context, ns string, name hash.Hash) (chunkReader, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	key := name.String()

--- a/go/store/nbs/s3_table_reader.go
+++ b/go/store/nbs/s3_table_reader.go
@@ -36,9 +36,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
-	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/jpillora/backoff"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 const (

--- a/go/store/nbs/s3_table_reader.go
+++ b/go/store/nbs/s3_table_reader.go
@@ -36,6 +36,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/jpillora/backoff"
 	"golang.org/x/sync/errgroup"
 )
@@ -47,7 +48,7 @@ const (
 
 type s3TableReaderAt struct {
 	s3 *s3ObjectReader
-	h  addr
+	h  hash.Hash
 }
 
 func (s3tra *s3TableReaderAt) Close() error {
@@ -81,11 +82,11 @@ func (s3or *s3ObjectReader) key(k string) string {
 	return k
 }
 
-func (s3or *s3ObjectReader) Reader(ctx context.Context, name addr) (io.ReadCloser, error) {
+func (s3or *s3ObjectReader) Reader(ctx context.Context, name hash.Hash) (io.ReadCloser, error) {
 	return s3or.reader(ctx, name)
 }
 
-func (s3or *s3ObjectReader) ReadAt(ctx context.Context, name addr, p []byte, off int64, stats *Stats) (n int, err error) {
+func (s3or *s3ObjectReader) ReadAt(ctx context.Context, name hash.Hash, p []byte, off int64, stats *Stats) (n int, err error) {
 	t1 := time.Now()
 
 	defer func() {
@@ -105,7 +106,7 @@ func s3RangeHeader(off, length int64) string {
 const maxS3ReadFromEndReqSize = 256 * 1024 * 1024       // 256MB
 const preferredS3ReadFromEndReqSize = 128 * 1024 * 1024 // 128MB
 
-func (s3or *s3ObjectReader) ReadFromEnd(ctx context.Context, name addr, p []byte, stats *Stats) (n int, sz uint64, err error) {
+func (s3or *s3ObjectReader) ReadFromEnd(ctx context.Context, name hash.Hash, p []byte, stats *Stats) (n int, sz uint64, err error) {
 	defer func(t1 time.Time) {
 		stats.S3BytesPerRead.Sample(uint64(len(p)))
 		stats.S3ReadLatency.SampleTimeSince(t1)
@@ -149,7 +150,7 @@ func (s3or *s3ObjectReader) ReadFromEnd(ctx context.Context, name addr, p []byte
 	return s3or.readRange(ctx, name, p, fmt.Sprintf("%s=-%d", s3RangePrefix, len(p)))
 }
 
-func (s3or *s3ObjectReader) reader(ctx context.Context, name addr) (io.ReadCloser, error) {
+func (s3or *s3ObjectReader) reader(ctx context.Context, name hash.Hash) (io.ReadCloser, error) {
 	input := &s3.GetObjectInput{
 		Bucket: aws.String(s3or.bucket),
 		Key:    aws.String(s3or.key(name.String())),
@@ -161,7 +162,7 @@ func (s3or *s3ObjectReader) reader(ctx context.Context, name addr) (io.ReadClose
 	return result.Body, nil
 }
 
-func (s3or *s3ObjectReader) readRange(ctx context.Context, name addr, p []byte, rangeHeader string) (n int, sz uint64, err error) {
+func (s3or *s3ObjectReader) readRange(ctx context.Context, name hash.Hash, p []byte, rangeHeader string) (n int, sz uint64, err error) {
 	read := func() (int, uint64, error) {
 		if s3or.readRl != nil {
 			s3or.readRl <- struct{}{}

--- a/go/store/nbs/store_test.go
+++ b/go/store/nbs/store_test.go
@@ -49,7 +49,7 @@ func makeTestLocalStore(t *testing.T, maxTableFiles int) (st *NomsBlockStore, no
 	// create a v5 manifest
 	fm, err := getFileManifest(ctx, nomsDir, asyncFlush)
 	require.NoError(t, err)
-	_, err = fm.Update(ctx, addr{}, manifestContents{}, &Stats{}, nil)
+	_, err = fm.Update(ctx, hash.Hash{}, manifestContents{}, &Stats{}, nil)
 	require.NoError(t, err)
 
 	q = NewUnlimitedMemQuotaProvider()

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -22,7 +22,6 @@
 package nbs
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha512"
 	"hash/crc32"
@@ -146,12 +145,6 @@ func computeHashDefault(data []byte) hash.Hash {
 }
 
 var computeAddr = computeHashDefault
-
-type addrSlice []hash.Hash
-
-func (hs addrSlice) Len() int           { return len(hs) }
-func (hs addrSlice) Less(i, j int) bool { return bytes.Compare(hs[i][:], hs[j][:]) < 0 }
-func (hs addrSlice) Swap(i, j int)      { hs[i], hs[j] = hs[j], hs[i] }
 
 type hasRecord struct {
 	a      *hash.Hash

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -25,7 +25,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha512"
-	"encoding/base32"
 	"hash/crc32"
 	"io"
 
@@ -143,36 +142,12 @@ func crc(b []byte) uint32 {
 	return crc32.Update(0, crcTable, b)
 }
 
-// NM4 - change name?
-func computeAddrDefault(data []byte) hash.Hash {
+func computeHashDefault(data []byte) hash.Hash {
 	r := sha512.Sum512(data)
 	return hash.New(r[:hash.ByteLen])
 }
 
-var computeAddr = computeAddrDefault
-
-// type addr [addrSize]byte
-
-var encoding = base32.NewEncoding("0123456789abcdefghijklmnopqrstuv")
-
-/*
-	NM4
-
-	func (a addr) String() string {
-		return encoding.EncodeToString(a[:])
-	}
-
-	func parseAddr(str string) (addr, error) {
-		var h addr
-		_, err := encoding.Decode(h[:], []byte(str))
-		return h, err
-	}
-
-	func ValidateAddr(s string) bool {
-		_, err := encoding.DecodeString(s)
-		return err == nil
-	}
-*/
+var computeAddr = computeHashDefault
 
 type addrSlice []hash.Hash
 

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -121,8 +121,6 @@ import (
 */
 
 const (
-	//	addrPrefixSize  = 8
-	//	addrSuffixSize  = hash.ByteLen - addrPrefixSize
 	uint64Size      = 8
 	uint32Size      = 4
 	ordinalSize     = uint32Size

--- a/go/store/nbs/table_index.go
+++ b/go/store/nbs/table_index.go
@@ -496,7 +496,7 @@ func (ti onHeapTableIndex) padStringAndDecode(s string, p string) uint64 {
 	}
 
 	// Decode
-	h, _ := encoding.DecodeString(s)
+	h := hash.Decode(s)
 	return binary.BigEndian.Uint64(h)
 }
 

--- a/go/store/nbs/table_index.go
+++ b/go/store/nbs/table_index.go
@@ -484,20 +484,21 @@ func (ti onHeapTableIndex) prefixIdxUBound(prefix uint64) (idx uint32) {
 }
 
 func (ti onHeapTableIndex) padStringAndDecode(s string, p string) uint64 {
-	// Pad string
-	if p == "0" {
-		for i := len(s); i < 16; i++ {
-			s = s + p
-		}
-	} else {
-		for i := len(s); i < 16; i++ {
-			s = p + s
+	if len(p) != 1 {
+		panic("pad string must be of length 1") // This is a programmer error that should never get out of PR.
+	}
+
+	for len(s) < hash.StringLen {
+		if p == "0" {
+			s = s + p // Pad on the right side.
+		} else {
+			s = p + s // pad on the left side.
 		}
 	}
 
 	// Decode
-	h := hash.Decode(s)
-	return binary.BigEndian.Uint64(h)
+	h := hash.Parse(s)
+	return binary.BigEndian.Uint64(h[:])
 }
 
 func (ti onHeapTableIndex) chunkCount() uint32 {

--- a/go/store/nbs/table_index_test.go
+++ b/go/store/nbs/table_index_test.go
@@ -21,9 +21,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 func TestParseTableIndex(t *testing.T) {

--- a/go/store/nbs/table_index_test.go
+++ b/go/store/nbs/table_index_test.go
@@ -239,13 +239,14 @@ var fakeData = []byte("supercalifragilisticexpialidocious")
 
 func addrFromPrefix(prefix string) hash.Hash {
 	// create a full length addr from a prefix
-	for i := 0; i < hash.ByteLen; i++ {
-		prefix += "0"
+	for {
+		if len(prefix) < hash.StringLen {
+			prefix += "0"
+		} else {
+			break
+		}
 	}
-
-	// base32 decode string
-	h := hash.Decode(prefix)
-	return hash.New(h[:hash.ByteLen])
+	return hash.Parse(prefix)
 }
 
 func buildFakeChunkTable(chunks []fakeChunk) ([]byte, hash.Hash, error) {

--- a/go/store/nbs/table_index_test.go
+++ b/go/store/nbs/table_index_test.go
@@ -243,7 +243,7 @@ func addrFromPrefix(prefix string) hash.Hash {
 	}
 
 	// base32 decode string
-	h, _ := encoding.DecodeString(prefix)
+	h := hash.Decode(prefix)
 	return hash.New(h[:hash.ByteLen])
 }
 

--- a/go/store/nbs/table_reader.go
+++ b/go/store/nbs/table_reader.go
@@ -233,14 +233,14 @@ func (tr tableReader) index() (tableIndex, error) {
 }
 
 // returns true iff |h| can be found in this table.
-func (tr tableReader) has(h addr) (bool, error) {
+func (tr tableReader) has(h hash.Hash) (bool, error) {
 	_, ok, err := tr.idx.lookup(&h)
 	return ok, err
 }
 
 // returns the storage associated with |h|, iff present. Returns nil if absent. On success,
 // the returned byte slice directly references the underlying storage.
-func (tr tableReader) get(ctx context.Context, h addr, stats *Stats) ([]byte, error) {
+func (tr tableReader) get(ctx context.Context, h hash.Hash, stats *Stats) ([]byte, error) {
 	e, found, err := tr.idx.lookup(&h)
 	if err != nil {
 		return nil, err
@@ -283,7 +283,7 @@ func (tr tableReader) get(ctx context.Context, h addr, stats *Stats) ([]byte, er
 }
 
 type offsetRec struct {
-	a      *addr
+	a      *hash.Hash
 	offset uint64
 	length uint32
 }
@@ -639,12 +639,12 @@ func (tr tableReader) extract(ctx context.Context, chunks chan<- extractRecord) 
 
 	var ors offsetRecSlice
 	for i := uint32(0); i < tr.idx.chunkCount(); i++ {
-		a := new(addr)
-		e, err := tr.idx.indexEntry(i, a)
+		h := new(hash.Hash)
+		e, err := tr.idx.indexEntry(i, h)
 		if err != nil {
 			return err
 		}
-		ors = append(ors, offsetRec{a, e.Offset(), e.Length()})
+		ors = append(ors, offsetRec{h, e.Offset(), e.Length()})
 	}
 	sort.Sort(ors)
 	for _, or := range ors {

--- a/go/store/nbs/table_set.go
+++ b/go/store/nbs/table_set.go
@@ -29,11 +29,11 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/dolthub/dolt/go/store/hash"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 // Returned when a chunk with a reference to a non-existence chunk is

--- a/go/store/nbs/table_set_test.go
+++ b/go/store/nbs/table_set_test.go
@@ -39,7 +39,7 @@ var hasManyHasAll = func([]hasRecord) (hash.HashSet, error) {
 }
 
 func TestTableSetPrependEmpty(t *testing.T) {
-	hasCache, err := lru.New2Q[addr, struct{}](1024)
+	hasCache, err := lru.New2Q[hash.Hash, struct{}](1024)
 	require.NoError(t, err)
 	ts, err := newFakeTableSet(&UnlimitedQuotaProvider{}).append(context.Background(), newMemTable(testMemTableSize), hasManyHasAll, hasCache, &Stats{})
 	require.NoError(t, err)
@@ -59,7 +59,7 @@ func TestTableSetPrepend(t *testing.T) {
 	assert.Empty(specs)
 	mt := newMemTable(testMemTableSize)
 	mt.addChunk(computeAddr(testChunks[0]), testChunks[0])
-	hasCache, err := lru.New2Q[addr, struct{}](1024)
+	hasCache, err := lru.New2Q[hash.Hash, struct{}](1024)
 	require.NoError(t, err)
 	ts, err = ts.append(context.Background(), mt, hasManyHasAll, hasCache, &Stats{})
 	require.NoError(t, err)
@@ -91,7 +91,7 @@ func TestTableSetToSpecsExcludesEmptyTable(t *testing.T) {
 	assert.Empty(specs)
 	mt := newMemTable(testMemTableSize)
 	mt.addChunk(computeAddr(testChunks[0]), testChunks[0])
-	hasCache, err := lru.New2Q[addr, struct{}](1024)
+	hasCache, err := lru.New2Q[hash.Hash, struct{}](1024)
 	require.NoError(t, err)
 	ts, err = ts.append(context.Background(), mt, hasManyHasAll, hasCache, &Stats{})
 	require.NoError(t, err)
@@ -122,7 +122,7 @@ func TestTableSetFlattenExcludesEmptyTable(t *testing.T) {
 	assert.Empty(specs)
 	mt := newMemTable(testMemTableSize)
 	mt.addChunk(computeAddr(testChunks[0]), testChunks[0])
-	hasCache, err := lru.New2Q[addr, struct{}](1024)
+	hasCache, err := lru.New2Q[hash.Hash, struct{}](1024)
 	require.NoError(t, err)
 	ts, err = ts.append(context.Background(), mt, hasManyHasAll, hasCache, &Stats{})
 	require.NoError(t, err)
@@ -156,7 +156,7 @@ func TestTableSetRebase(t *testing.T) {
 	assert := assert.New(t)
 	q := NewUnlimitedMemQuotaProvider()
 	persister := newFakeTablePersister(q)
-	hasCache, err := lru.New2Q[addr, struct{}](1024)
+	hasCache, err := lru.New2Q[hash.Hash, struct{}](1024)
 	require.NoError(t, err)
 
 	insert := func(ts tableSet, chunks ...[]byte) tableSet {
@@ -211,7 +211,7 @@ func TestTableSetPhysicalLen(t *testing.T) {
 	assert.Empty(specs)
 	mt := newMemTable(testMemTableSize)
 	mt.addChunk(computeAddr(testChunks[0]), testChunks[0])
-	hasCache, err := lru.New2Q[addr, struct{}](1024)
+	hasCache, err := lru.New2Q[hash.Hash, struct{}](1024)
 	require.NoError(t, err)
 	ts, err = ts.append(context.Background(), mt, hasManyHasAll, hasCache, &Stats{})
 	require.NoError(t, err)

--- a/go/store/nbs/table_test.go
+++ b/go/store/nbs/table_test.go
@@ -134,7 +134,7 @@ func TestHasMany(t *testing.T) {
 	require.NoError(t, err)
 	defer tr.close()
 
-	addrs := addrSlice{computeAddr(chunks[0]), computeAddr(chunks[1]), computeAddr(chunks[2])}
+	addrs := hash.HashSlice{computeAddr(chunks[0]), computeAddr(chunks[1]), computeAddr(chunks[2])}
 	hasAddrs := []hasRecord{
 		{&addrs[0], binary.BigEndian.Uint64(addrs[0][:hash.PrefixLen]), 0, false},
 		{&addrs[1], binary.BigEndian.Uint64(addrs[1][:hash.PrefixLen]), 1, false},
@@ -203,7 +203,7 @@ func TestHasManySequentialPrefix(t *testing.T) {
 func BenchmarkHasMany(b *testing.B) {
 	const cnt = 64 * 1024
 	chnks := make([][]byte, cnt)
-	addrs := make(addrSlice, cnt)
+	addrs := make(hash.HashSlice, cnt)
 	hrecs := make([]hasRecord, cnt)
 	sparse := make([]hasRecord, cnt/1024)
 
@@ -279,7 +279,7 @@ func TestGetMany(t *testing.T) {
 	require.NoError(t, err)
 	defer tr.close()
 
-	addrs := addrSlice{computeAddr(data[0]), computeAddr(data[1]), computeAddr(data[2])}
+	addrs := hash.HashSlice{computeAddr(data[0]), computeAddr(data[1]), computeAddr(data[2])}
 	getBatch := []getRecord{
 		{&addrs[0], binary.BigEndian.Uint64(addrs[0][:hash.PrefixLen]), false},
 		{&addrs[1], binary.BigEndian.Uint64(addrs[1][:hash.PrefixLen]), false},
@@ -314,7 +314,7 @@ func TestCalcReads(t *testing.T) {
 	tr, err := newTableReader(ti, tableReaderAtFromBytes(tableData), 0)
 	require.NoError(t, err)
 	defer tr.close()
-	addrs := addrSlice{computeAddr(chunks[0]), computeAddr(chunks[1]), computeAddr(chunks[2])}
+	addrs := hash.HashSlice{computeAddr(chunks[0]), computeAddr(chunks[1]), computeAddr(chunks[2])}
 	getBatch := []getRecord{
 		{&addrs[0], binary.BigEndian.Uint64(addrs[0][:hash.PrefixLen]), false},
 		{&addrs[1], binary.BigEndian.Uint64(addrs[1][:hash.PrefixLen]), false},
@@ -354,7 +354,7 @@ func TestExtract(t *testing.T) {
 	require.NoError(t, err)
 	defer tr.close()
 
-	addrs := addrSlice{computeAddr(chunks[0]), computeAddr(chunks[1]), computeAddr(chunks[2])}
+	addrs := hash.HashSlice{computeAddr(chunks[0]), computeAddr(chunks[1]), computeAddr(chunks[2])}
 
 	chunkChan := make(chan extractRecord)
 	go func() {

--- a/go/store/nbs/table_test.go
+++ b/go/store/nbs/table_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/dolthub/dolt/go/store/hash"
 )
 
-func buildTable(chunks [][]byte) ([]byte, addr, error) {
+func buildTable(chunks [][]byte) ([]byte, hash.Hash, error) {
 	totalData := uint64(0)
 	for _, chunk := range chunks {
 		totalData += uint64(len(chunk))
@@ -55,7 +55,7 @@ func buildTable(chunks [][]byte) ([]byte, addr, error) {
 	length, blockHash, err := tw.finish()
 
 	if err != nil {
-		return nil, addr{}, err
+		return nil, hash.Hash{}, err
 	}
 
 	return buff[:length], blockHash, nil
@@ -136,9 +136,9 @@ func TestHasMany(t *testing.T) {
 
 	addrs := addrSlice{computeAddr(chunks[0]), computeAddr(chunks[1]), computeAddr(chunks[2])}
 	hasAddrs := []hasRecord{
-		{&addrs[0], binary.BigEndian.Uint64(addrs[0][:addrPrefixSize]), 0, false},
-		{&addrs[1], binary.BigEndian.Uint64(addrs[1][:addrPrefixSize]), 1, false},
-		{&addrs[2], binary.BigEndian.Uint64(addrs[2][:addrPrefixSize]), 2, false},
+		{&addrs[0], binary.BigEndian.Uint64(addrs[0][:hash.PrefixLen]), 0, false},
+		{&addrs[1], binary.BigEndian.Uint64(addrs[1][:hash.PrefixLen]), 1, false},
+		{&addrs[2], binary.BigEndian.Uint64(addrs[2][:hash.PrefixLen]), 2, false},
 	}
 	sort.Sort(hasRecordByPrefix(hasAddrs))
 
@@ -161,9 +161,9 @@ func TestHasManySequentialPrefix(t *testing.T) {
 		"0rfgadopg6h3fk7d253ivbjsij4qo9nv",
 	}
 
-	addrs := make([]addr, len(addrStrings))
+	addrs := make([]hash.Hash, len(addrStrings))
 	for i, s := range addrStrings {
-		addrs[i] = addr(hash.Parse(s))
+		addrs[i] = hash.Parse(s)
 	}
 
 	bogusData := []byte("bogus") // doesn't matter what this is. hasMany() won't check chunkRecords
@@ -218,7 +218,7 @@ func BenchmarkHasMany(b *testing.B) {
 	for i := range hrecs {
 		hrecs[i] = hasRecord{
 			a:      &addrs[i],
-			prefix: prefixOf(addrs[i]),
+			prefix: addrs[i].Prefix(),
 			order:  i,
 		}
 	}
@@ -226,7 +226,7 @@ func BenchmarkHasMany(b *testing.B) {
 		j := i * 64
 		hrecs[i] = hasRecord{
 			a:      &addrs[j],
-			prefix: prefixOf(addrs[j]),
+			prefix: addrs[j].Prefix(),
 			order:  j,
 		}
 	}
@@ -261,10 +261,6 @@ func BenchmarkHasMany(b *testing.B) {
 	})
 }
 
-func prefixOf(a addr) uint64 {
-	return binary.BigEndian.Uint64(a[:addrPrefixSize])
-}
-
 func TestGetMany(t *testing.T) {
 	ctx := context.Background()
 	assert := assert.New(t)
@@ -285,9 +281,9 @@ func TestGetMany(t *testing.T) {
 
 	addrs := addrSlice{computeAddr(data[0]), computeAddr(data[1]), computeAddr(data[2])}
 	getBatch := []getRecord{
-		{&addrs[0], binary.BigEndian.Uint64(addrs[0][:addrPrefixSize]), false},
-		{&addrs[1], binary.BigEndian.Uint64(addrs[1][:addrPrefixSize]), false},
-		{&addrs[2], binary.BigEndian.Uint64(addrs[2][:addrPrefixSize]), false},
+		{&addrs[0], binary.BigEndian.Uint64(addrs[0][:hash.PrefixLen]), false},
+		{&addrs[1], binary.BigEndian.Uint64(addrs[1][:hash.PrefixLen]), false},
+		{&addrs[2], binary.BigEndian.Uint64(addrs[2][:hash.PrefixLen]), false},
 	}
 	sort.Sort(getRecordByPrefix(getBatch))
 
@@ -320,9 +316,9 @@ func TestCalcReads(t *testing.T) {
 	defer tr.close()
 	addrs := addrSlice{computeAddr(chunks[0]), computeAddr(chunks[1]), computeAddr(chunks[2])}
 	getBatch := []getRecord{
-		{&addrs[0], binary.BigEndian.Uint64(addrs[0][:addrPrefixSize]), false},
-		{&addrs[1], binary.BigEndian.Uint64(addrs[1][:addrPrefixSize]), false},
-		{&addrs[2], binary.BigEndian.Uint64(addrs[2][:addrPrefixSize]), false},
+		{&addrs[0], binary.BigEndian.Uint64(addrs[0][:hash.PrefixLen]), false},
+		{&addrs[1], binary.BigEndian.Uint64(addrs[1][:hash.PrefixLen]), false},
+		{&addrs[2], binary.BigEndian.Uint64(addrs[2][:hash.PrefixLen]), false},
 	}
 
 	gb2 := []getRecord{getBatch[0], getBatch[2]}
@@ -420,7 +416,7 @@ func Test65k(t *testing.T) {
 
 // Ensure all addresses share the first 7 bytes. Useful for easily generating tests which have
 // "prefix" collisions.
-func computeAddrCommonPrefix(data []byte) addr {
+func computeAddrCommonPrefix(data []byte) hash.Hash {
 	a := computeAddrDefault(data)
 	a[0] = 0x01
 	a[1] = 0x23

--- a/go/store/nbs/table_test.go
+++ b/go/store/nbs/table_test.go
@@ -417,7 +417,7 @@ func Test65k(t *testing.T) {
 // Ensure all addresses share the first 7 bytes. Useful for easily generating tests which have
 // "prefix" collisions.
 func computeAddrCommonPrefix(data []byte) hash.Hash {
-	a := computeAddrDefault(data)
+	a := computeHashDefault(data)
 	a[0] = 0x01
 	a[1] = 0x23
 	a[2] = 0x45
@@ -475,7 +475,7 @@ func Test65kGetMany(t *testing.T) {
 func Test2kGetManyCommonPrefix(t *testing.T) {
 	computeAddr = computeAddrCommonPrefix
 	defer func() {
-		computeAddr = computeAddrDefault
+		computeAddr = computeHashDefault
 	}()
 
 	doTestNGetMany(t, 1<<11)

--- a/go/store/nbs/util.go
+++ b/go/store/nbs/util.go
@@ -33,21 +33,21 @@ func IterChunks(ctx context.Context, rd io.ReadSeeker, cb func(chunk chunks.Chun
 
 	defer idx.Close()
 
-	seen := make(map[addr]bool)
+	seen := make(map[hash.Hash]bool)
 	for i := uint32(0); i < idx.chunkCount(); i++ {
-		var a addr
-		ie, err := idx.indexEntry(i, &a)
+		var h hash.Hash
+		ie, err := idx.indexEntry(i, &h)
 		if err != nil {
 			return err
 		}
-		if _, ok := seen[a]; !ok {
-			seen[a] = true
+		if _, ok := seen[h]; !ok {
+			seen[h] = true
 			chunkBytes, err := readNFrom(rd, ie.Offset(), ie.Length())
 			if err != nil {
 				return err
 			}
 
-			cmpChnk, err := NewCompressedChunk(hash.Hash(a), chunkBytes)
+			cmpChnk, err := NewCompressedChunk(h, chunkBytes)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
These two types were essentially the same, with the addition of the Prefix and Suffix methods to hash.Hash they are
the same.