### PR TITLE
[sqle] don't panic reading history table

### DIFF
--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -354,7 +354,14 @@ func (db Database) getTableInsensitive(ctx *sql.Context, head *doltdb.Commit, ds
 			}
 		}
 
-		return NewHistoryTable(baseTable.(*AlterableDoltTable).DoltTable, db.ddb, head), true, nil
+		switch t := baseTable.(type) {
+		case *AlterableDoltTable:
+			return NewHistoryTable(t.DoltTable, db.ddb, head), true, nil
+		case *WritableDoltTable:
+			return NewHistoryTable(t.DoltTable, db.ddb, head), true, nil
+		default:
+			return nil, false, fmt.Errorf("expected Alterable or WritableDoltTable, found %T", baseTable)
+		}
 
 	case strings.HasPrefix(lwrName, doltdb.DoltConfTablePrefix):
 		suffix := tblName[len(doltdb.DoltConfTablePrefix):]

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -2788,6 +2788,13 @@ func TestPrepared(t *testing.T) {
 	enginetest.TestPrepared(t, h)
 }
 
+func TestDoltPreparedScripts(t *testing.T) {
+	skipPreparedTests(t)
+	h := newDoltHarness(t)
+	defer h.Close()
+	DoltPreparedScripts(t, h)
+}
+
 func TestPreparedInsert(t *testing.T) {
 	skipPreparedTests(t)
 	h := newDoltHarness(t)

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -1701,6 +1701,22 @@ var HistorySystemTableScriptTests = []queries.ScriptTest{
 		},
 	},
 	{
+		Name: "history table panic",
+		SetUpScript: []string{
+			"create table t (n int, c varchar(20));",
+			"call dolt_add('.')",
+			"set @Commit1 = '';",
+			"call dolt_commit_hash_out(@Commit1, '-am', 'creating table t');",
+			"set @@SESSION.dolt_show_system_tables = 1",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "SELECT table_name FROM information_schema.columns WHERE table_name = 'dolt_history_t' group by table_name ORDER BY ORDINAL_POSITION",
+				Expected: []sql.Row{{"dolt_history_t"}},
+			},
+		},
+	},
+	{
 		Name: "keyless table",
 		SetUpScript: []string{
 			"create table foo1 (n int, de varchar(20));",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -1701,22 +1701,6 @@ var HistorySystemTableScriptTests = []queries.ScriptTest{
 		},
 	},
 	{
-		Name: "history table panic",
-		SetUpScript: []string{
-			"create table t (n int, c varchar(20));",
-			"call dolt_add('.')",
-			"set @Commit1 = '';",
-			"call dolt_commit_hash_out(@Commit1, '-am', 'creating table t');",
-			"set @@SESSION.dolt_show_system_tables = 1",
-		},
-		Assertions: []queries.ScriptTestAssertion{
-			{
-				Query:    "SELECT table_name FROM information_schema.columns WHERE table_name = 'dolt_history_t' group by table_name ORDER BY ORDINAL_POSITION",
-				Expected: []sql.Row{{"dolt_history_t"}},
-			},
-		},
-	},
-	{
 		Name: "keyless table",
 		SetUpScript: []string{
 			"create table foo1 (n int, de varchar(20));",

--- a/go/libraries/doltcore/sqle/enginetest/prepared_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/prepared_queries.go
@@ -1,0 +1,60 @@
+// Copyright 2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enginetest
+
+import (
+	"fmt"
+	"github.com/dolthub/go-mysql-server/enginetest"
+	"github.com/dolthub/go-mysql-server/enginetest/queries"
+	"github.com/dolthub/go-mysql-server/enginetest/scriptgen/setup"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/vitess/go/sqltypes"
+	"github.com/dolthub/vitess/go/vt/proto/query"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// DoltPreparedScripts tests dolt-specific prepared statements through
+// the handler interface.
+func DoltPreparedScripts(t *testing.T, harness enginetest.Harness) {
+	tests := []queries.QueryTest{
+		{
+			Query: "set @@SESSION.dolt_show_system_tables = 1",
+		},
+		{
+			Query: "SELECT table_name FROM information_schema.columns WHERE table_name = ? group by table_name ORDER BY ORDINAL_POSITION",
+			Bindings: map[string]*query.BindVariable{
+				"v1": sqltypes.StringBindVariable("dolt_history_mytable"),
+			},
+			Expected: []sql.Row{{"dolt_history_mytable"}},
+		},
+	}
+
+	harness.Setup(setup.MydbData, setup.MytableData)
+	e, err := harness.NewEngine(t)
+	require.NoError(t, err)
+	defer e.Close()
+
+	enginetest.RunQueryWithContext(t, e, harness, nil, "CREATE TABLE a (x int, y int, z int)")
+	enginetest.RunQueryWithContext(t, e, harness, nil, "INSERT INTO a VALUES (0,1,1), (1,1,1), (2,1,1), (3,2,2), (4,2,2)")
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s", tt.Query), func(t *testing.T) {
+			ctx := enginetest.NewContext(harness)
+			_, err := e.PrepareQuery(ctx, tt.Query)
+			require.NoError(t, err)
+			enginetest.TestQueryWithContext(t, ctx, e, harness, tt.Query, tt.Expected, tt.ExpectedColumns, tt.Bindings)
+		})
+	}
+}

--- a/go/libraries/doltcore/sqle/enginetest/prepared_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/prepared_queries.go
@@ -16,6 +16,8 @@ package enginetest
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/dolthub/go-mysql-server/enginetest"
 	"github.com/dolthub/go-mysql-server/enginetest/queries"
 	"github.com/dolthub/go-mysql-server/enginetest/scriptgen/setup"
@@ -23,7 +25,6 @@ import (
 	"github.com/dolthub/vitess/go/sqltypes"
 	"github.com/dolthub/vitess/go/vt/proto/query"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 // DoltPreparedScripts tests dolt-specific prepared statements through


### PR DESCRIPTION
Found an issue with the history table while testing GORM. It's specific to the ComPrepare interface, this doesn't trigger with a simple PREPARE query.

```
DEBU[0197] preparing query                               paramsCount=2 query="SELECT column_name, column_default, is_nullable = 'YES', data_type, character_maximum_length, column_type, column_key, extra, column_comment, numeric_precision, numeric_scale , datetime_precision FROM information_schema.columns WHERE table_schema = ? AND table_name = ? ORDER BY ORDINAL_POSITION" statementId=2

ERRO[0197] mysql_server caught panic:
interface conversion: sql.Table is *sqle.WritableDoltTable, not *sqle.AlterableDoltTable
/Users/maxhoffman/go/pkg/mod/github.com/dolthub/go-mysql-server@v0.18.1-0.20240313225114-4a2f2300d770/sql/planbuilder/parse.go:169 (0x101612ae7)
	com/dolthub/go-mysql-server/sql/planbuilder.(*Builder).BindOnly.func1: panic(r)
/usr/local/go/src/runtime/panic.go:914 (0x1000d2187)
	gopanic: done = runOpenDeferFrame(d)
/usr/local/go/src/runtime/iface.go:263 (0x1000a516f)
	panicdottypeE: panic(&TypeAssertionError{iface, have, want, ""})
/usr/local/go/src/runtime/iface.go:273 (0x1000a5128)
	panicdottypeI: panicdottypeE(t, want, iface)
/Users/maxhoffman/go/github.com/dolthub/dolt/go/libraries/doltcore/sqle/database.go:357 (0x101a1f1a7)
	com/dolthub/dolt/go/libraries/doltcore/sqle.Database.getTableInsensitive: return NewHistoryTable(baseTable.(*AlterableDoltTable).DoltTable, db.ddb, head), true, nil
```