### PR TITLE
[no-release-notes] Refactored config reading / initialization

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/command_line_config.go
+++ b/go/cmd/dolt/commands/sqlserver/command_line_config.go
@@ -79,7 +79,7 @@ func DefaultServerConfig() *commandLineServerConfig {
 		branchControlFilePath:   filepath.Join(defaultDataDir, defaultCfgDir, defaultBranchControlFilePath),
 		allowCleartextPasswords: defaultAllowCleartextPasswords,
 		maxLoggedQueryLen:       defaultMaxLoggedQueryLen,
-		valuesSet: map[string]struct{}{},
+		valuesSet:               map[string]struct{}{},
 	}
 }
 
@@ -486,7 +486,6 @@ func (cfg *commandLineServerConfig) withEventScheduler(es string) *commandLineSe
 }
 
 func (cfg *commandLineServerConfig) ValueSet(value string) bool {
-	_, ok :=  cfg.valuesSet[value]
+	_, ok := cfg.valuesSet[value]
 	return ok
 }
-

--- a/go/cmd/dolt/commands/sqlserver/command_line_config.go
+++ b/go/cmd/dolt/commands/sqlserver/command_line_config.go
@@ -55,6 +55,7 @@ type commandLineServerConfig struct {
 	remotesapiReadOnly      *bool
 	goldenMysqlConn         string
 	eventSchedulerStatus    string
+	valuesSet               map[string]struct{}
 }
 
 var _ ServerConfig = (*commandLineServerConfig)(nil)
@@ -78,6 +79,7 @@ func DefaultServerConfig() *commandLineServerConfig {
 		branchControlFilePath:   filepath.Join(defaultDataDir, defaultCfgDir, defaultBranchControlFilePath),
 		allowCleartextPasswords: defaultAllowCleartextPasswords,
 		maxLoggedQueryLen:       defaultMaxLoggedQueryLen,
+		valuesSet: map[string]struct{}{},
 	}
 }
 
@@ -374,6 +376,8 @@ func (cfg *commandLineServerConfig) withPassword(password string) *commandLineSe
 // withTimeout updates the timeout and returns the called `*commandLineServerConfig`, which is useful for chaining calls.
 func (cfg *commandLineServerConfig) withTimeout(timeout uint64) *commandLineServerConfig {
 	cfg.timeout = timeout
+	cfg.valuesSet[readTimeoutKey] = struct{}{}
+	cfg.valuesSet[writeTimeoutKey] = struct{}{}
 	return cfg
 }
 
@@ -393,6 +397,7 @@ func (cfg *commandLineServerConfig) withLogLevel(loglevel LogLevel) *commandLine
 // `*commandLineServerConfig`, which is useful for chaining calls.
 func (cfg *commandLineServerConfig) withMaxConnections(maxConnections uint64) *commandLineServerConfig {
 	cfg.maxConnections = maxConnections
+	cfg.valuesSet[maxConnectionsKey] = struct{}{}
 	return cfg
 }
 
@@ -476,5 +481,12 @@ func (cfg *commandLineServerConfig) EventSchedulerStatus() string {
 
 func (cfg *commandLineServerConfig) withEventScheduler(es string) *commandLineServerConfig {
 	cfg.eventSchedulerStatus = es
+	cfg.valuesSet[eventSchedulerKey] = struct{}{}
 	return cfg
 }
+
+func (cfg *commandLineServerConfig) ValueSet(value string) bool {
+	_, ok :=  cfg.valuesSet[value]
+	return ok
+}
+

--- a/go/cmd/dolt/commands/sqlserver/command_line_config.go
+++ b/go/cmd/dolt/commands/sqlserver/command_line_config.go
@@ -1,0 +1,480 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlserver
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/cmd/dolt/commands"
+	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/cluster"
+	"github.com/dolthub/dolt/go/libraries/utils/argparser"
+)
+
+type commandLineServerConfig struct {
+	host                    string
+	port                    int
+	user                    string
+	password                string
+	timeout                 uint64
+	readOnly                bool
+	logLevel                LogLevel
+	dataDir                 string
+	cfgDir                  string
+	autoCommit              bool
+	doltTransactionCommit   bool
+	maxConnections          uint64
+	queryParallelism        int
+	tlsKey                  string
+	tlsCert                 string
+	requireSecureTransport  bool
+	maxLoggedQueryLen       int
+	shouldEncodeLoggedQuery bool
+	persistenceBehavior     string
+	privilegeFilePath       string
+	branchControlFilePath   string
+	allowCleartextPasswords bool
+	socket                  string
+	remotesapiPort          *int
+	remotesapiReadOnly      *bool
+	goldenMysqlConn         string
+	eventSchedulerStatus    string
+}
+
+var _ ServerConfig = (*commandLineServerConfig)(nil)
+
+// Host returns the domain that the server will run on. Accepts an IPv4 or IPv6 address, in addition to localhost.
+func (cfg *commandLineServerConfig) Host() string {
+	return cfg.host
+}
+
+// Port returns the port that the server will run on. The valid range is [1024, 65535].
+func (cfg *commandLineServerConfig) Port() int {
+	return cfg.port
+}
+
+// User returns the username that connecting clients must use.
+func (cfg *commandLineServerConfig) User() string {
+	return cfg.user
+}
+
+// Password returns the password that connecting clients must use.
+func (cfg *commandLineServerConfig) Password() string {
+	return cfg.password
+}
+
+// ReadTimeout returns the read and write timeouts.
+func (cfg *commandLineServerConfig) ReadTimeout() uint64 {
+	return cfg.timeout
+}
+
+// WriteTimeout returns the read and write timeouts.
+func (cfg *commandLineServerConfig) WriteTimeout() uint64 {
+	return cfg.timeout
+}
+
+// ReadOnly returns whether the server will only accept read statements or all statements.
+func (cfg *commandLineServerConfig) ReadOnly() bool {
+	return cfg.readOnly
+}
+
+// LogLevel returns the level of logging that the server will use.
+func (cfg *commandLineServerConfig) LogLevel() LogLevel {
+	return cfg.logLevel
+}
+
+// AutoCommit defines the value of the @@autocommit session variable used on every connection
+func (cfg *commandLineServerConfig) AutoCommit() bool {
+	return cfg.autoCommit
+}
+
+// DoltTransactionCommit defines the value of the @@dolt_transaction_commit session variable that enables Dolt
+// commits to be automatically created when a SQL transaction is committed. The default is false.
+func (cfg *commandLineServerConfig) DoltTransactionCommit() bool {
+	return cfg.doltTransactionCommit
+}
+
+// MaxConnections returns the maximum number of simultaneous connections the server will allow.  The default is 1
+func (cfg *commandLineServerConfig) MaxConnections() uint64 {
+	return cfg.maxConnections
+}
+
+// QueryParallelism returns the parallelism that should be used by the go-mysql-server analyzer
+func (cfg *commandLineServerConfig) QueryParallelism() int {
+	return cfg.queryParallelism
+}
+
+// PersistenceBehavior returns whether to autoload persisted server configuration
+func (cfg *commandLineServerConfig) PersistenceBehavior() string {
+	return cfg.persistenceBehavior
+}
+
+// TLSKey returns a path to the servers PEM-encoded private TLS key. "" if there is none.
+func (cfg *commandLineServerConfig) TLSKey() string {
+	return cfg.tlsKey
+}
+
+// TLSCert returns a path to the servers PEM-encoded TLS certificate chain. "" if there is none.
+func (cfg *commandLineServerConfig) TLSCert() string {
+	return cfg.tlsCert
+}
+
+// RequireSecureTransport is true if the server should reject non-TLS connections.
+func (cfg *commandLineServerConfig) RequireSecureTransport() bool {
+	return cfg.requireSecureTransport
+}
+
+// MaxLoggedQueryLen is the max length of queries written to the logs.  Queries longer than this number are truncated.
+// If this value is 0 then the query is not truncated and will be written to the logs in its entirety.  If the value
+// is less than 0 then the queries will be omitted from the logs completely
+func (cfg *commandLineServerConfig) MaxLoggedQueryLen() int {
+	return cfg.maxLoggedQueryLen
+}
+
+// ShouldEncodeLoggedQuery determines if logged queries are base64 encoded.
+// If true, queries will be logged as base64 encoded strings.
+// If false (default behavior), queries will be logged as strings, but newlines and tabs will be replaced with spaces.
+func (cfg *commandLineServerConfig) ShouldEncodeLoggedQuery() bool {
+	return cfg.shouldEncodeLoggedQuery
+}
+
+// DisableClientMultiStatements is true if we want the server to not
+// process incoming ComQuery packets as if they had multiple queries in
+// them, even if the client advertises support for MULTI_STATEMENTS.
+func (cfg *commandLineServerConfig) DisableClientMultiStatements() bool {
+	return false
+}
+
+// MetricsLabels returns labels that are applied to all prometheus metrics
+func (cfg *commandLineServerConfig) MetricsLabels() map[string]string {
+	return nil
+}
+
+func (cfg *commandLineServerConfig) MetricsHost() string {
+	return defaultMetricsHost
+}
+
+func (cfg *commandLineServerConfig) MetricsPort() int {
+	return defaultMetricsPort
+}
+
+func (cfg *commandLineServerConfig) RemotesapiPort() *int {
+	return cfg.remotesapiPort
+}
+
+func (cfg *commandLineServerConfig) RemotesapiReadOnly() *bool {
+	return cfg.remotesapiReadOnly
+}
+
+func (cfg *commandLineServerConfig) ClusterConfig() cluster.Config {
+	return nil
+}
+
+// PrivilegeFilePath returns the path to the file which contains all needed privilege information in the form of a
+// JSON string.
+func (cfg *commandLineServerConfig) PrivilegeFilePath() string {
+	return cfg.privilegeFilePath
+}
+
+// BranchControlFilePath returns the path to the file which contains the branch control permissions.
+func (cfg *commandLineServerConfig) BranchControlFilePath() string {
+	return cfg.branchControlFilePath
+}
+
+// UserVars is an array containing user specific session variables.
+func (cfg *commandLineServerConfig) UserVars() []UserSessionVars {
+	return nil
+}
+
+func (cfg *commandLineServerConfig) SystemVars() engine.SystemVariables {
+	return nil
+}
+
+func (cfg *commandLineServerConfig) JwksConfig() []engine.JwksConfig {
+	return nil
+}
+
+func (cfg *commandLineServerConfig) AllowCleartextPasswords() bool {
+	return cfg.allowCleartextPasswords
+}
+
+// DataDir is the path to a directory to use as the data dir, both to create new databases and locate existing ones.
+func (cfg *commandLineServerConfig) DataDir() string {
+	return cfg.dataDir
+}
+
+// CfgDir is the path to a directory to use to store the dolt configuration files.
+func (cfg *commandLineServerConfig) CfgDir() string {
+	return cfg.cfgDir
+}
+
+// Socket is a path to the unix socket file
+func (cfg *commandLineServerConfig) Socket() string {
+	return cfg.socket
+}
+
+// WithHost updates the host and returns the called `*commandLineServerConfig`, which is useful for chaining calls.
+func (cfg *commandLineServerConfig) WithHost(host string) *commandLineServerConfig {
+	cfg.host = host
+	return cfg
+}
+
+// WithPort updates the port and returns the called `*commandLineServerConfig`, which is useful for chaining calls.
+func (cfg *commandLineServerConfig) WithPort(port int) *commandLineServerConfig {
+	cfg.port = port
+	return cfg
+}
+
+// withUser updates the user and returns the called `*commandLineServerConfig`, which is useful for chaining calls.
+func (cfg *commandLineServerConfig) withUser(user string) *commandLineServerConfig {
+	cfg.user = user
+	return cfg
+}
+
+// withPassword updates the password and returns the called `*commandLineServerConfig`, which is useful for chaining calls.
+func (cfg *commandLineServerConfig) withPassword(password string) *commandLineServerConfig {
+	cfg.password = password
+	return cfg
+}
+
+// withTimeout updates the timeout and returns the called `*commandLineServerConfig`, which is useful for chaining calls.
+func (cfg *commandLineServerConfig) withTimeout(timeout uint64) *commandLineServerConfig {
+	cfg.timeout = timeout
+	return cfg
+}
+
+// withReadOnly updates the read only flag and returns the called `*commandLineServerConfig`, which is useful for chaining calls.
+func (cfg *commandLineServerConfig) withReadOnly(readonly bool) *commandLineServerConfig {
+	cfg.readOnly = readonly
+	return cfg
+}
+
+// withLogLevel updates the log level and returns the called `*commandLineServerConfig`, which is useful for chaining calls.
+func (cfg *commandLineServerConfig) withLogLevel(loglevel LogLevel) *commandLineServerConfig {
+	cfg.logLevel = loglevel
+	return cfg
+}
+
+// withMaxConnections updates the maximum number of concurrent connections and returns the called
+// `*commandLineServerConfig`, which is useful for chaining calls.
+func (cfg *commandLineServerConfig) withMaxConnections(maxConnections uint64) *commandLineServerConfig {
+	cfg.maxConnections = maxConnections
+	return cfg
+}
+
+// withQueryParallelism updates the query parallelism and returns the called `*commandLineServerConfig`, which is useful for chaining calls.
+func (cfg *commandLineServerConfig) withQueryParallelism(queryParallelism int) *commandLineServerConfig {
+	cfg.queryParallelism = queryParallelism
+	return cfg
+}
+
+// withDataDir updates the path to a directory to use as the data dir.
+func (cfg *commandLineServerConfig) withDataDir(dataDir string) *commandLineServerConfig {
+	cfg.dataDir = dataDir
+	return cfg
+}
+
+// withCfgDir updates the path to a directory to use to store the dolt configuration files.
+func (cfg *commandLineServerConfig) withCfgDir(cfgDir string) *commandLineServerConfig {
+	cfg.cfgDir = cfgDir
+	return cfg
+}
+
+// withPersistenceBehavior updates persistence behavior of system globals on server init
+func (cfg *commandLineServerConfig) withPersistenceBehavior(persistenceBehavior string) *commandLineServerConfig {
+	cfg.persistenceBehavior = persistenceBehavior
+	return cfg
+}
+
+// withPrivilegeFilePath updates the path to the file which contains all needed privilege information in the form of a JSON string
+func (cfg *commandLineServerConfig) withPrivilegeFilePath(privFilePath string) *commandLineServerConfig {
+	cfg.privilegeFilePath = privFilePath
+	return cfg
+}
+
+// withBranchControlFilePath updates the path to the file which contains the branch control permissions
+func (cfg *commandLineServerConfig) withBranchControlFilePath(branchControlFilePath string) *commandLineServerConfig {
+	cfg.branchControlFilePath = branchControlFilePath
+	return cfg
+}
+
+func (cfg *commandLineServerConfig) withAllowCleartextPasswords(allow bool) *commandLineServerConfig {
+	cfg.allowCleartextPasswords = allow
+	return cfg
+}
+
+// WithSocket updates the path to the unix socket file
+func (cfg *commandLineServerConfig) WithSocket(sockFilePath string) *commandLineServerConfig {
+	cfg.socket = sockFilePath
+	return cfg
+}
+
+// WithRemotesapiPort sets the remotesapi port to use.
+func (cfg *commandLineServerConfig) WithRemotesapiPort(port *int) *commandLineServerConfig {
+	cfg.remotesapiPort = port
+	return cfg
+}
+
+func (cfg *commandLineServerConfig) WithRemotesapiReadOnly(readonly *bool) *commandLineServerConfig {
+	cfg.remotesapiReadOnly = readonly
+	return cfg
+}
+
+func (cfg *commandLineServerConfig) goldenMysqlConnectionString() string {
+	return cfg.goldenMysqlConn
+}
+
+func (cfg *commandLineServerConfig) withGoldenMysqlConnectionString(cs string) *commandLineServerConfig {
+	cfg.goldenMysqlConn = cs
+	return cfg
+}
+
+func (cfg *commandLineServerConfig) EventSchedulerStatus() string {
+	switch cfg.eventSchedulerStatus {
+	case "", "1":
+		return "ON"
+	case "0":
+		return "OFF"
+	default:
+		return strings.ToUpper(cfg.eventSchedulerStatus)
+	}
+}
+
+func (cfg *commandLineServerConfig) withEventScheduler(es string) *commandLineServerConfig {
+	cfg.eventSchedulerStatus = es
+	return cfg
+}
+
+// DefaultServerConfig creates a `*ServerConfig` that has all of the options set to their default values.
+func DefaultServerConfig() *commandLineServerConfig {
+	return &commandLineServerConfig{
+		host:                    defaultHost,
+		port:                    defaultPort,
+		password:                defaultPass,
+		timeout:                 defaultTimeout,
+		readOnly:                defaultReadOnly,
+		logLevel:                defaultLogLevel,
+		autoCommit:              defaultAutoCommit,
+		maxConnections:          defaultMaxConnections,
+		queryParallelism:        defaultQueryParallelism,
+		persistenceBehavior:     defaultPersistenceBahavior,
+		dataDir:                 defaultDataDir,
+		cfgDir:                  filepath.Join(defaultDataDir, defaultCfgDir),
+		privilegeFilePath:       filepath.Join(defaultDataDir, defaultCfgDir, defaultPrivilegeFilePath),
+		branchControlFilePath:   filepath.Join(defaultDataDir, defaultCfgDir, defaultBranchControlFilePath),
+		allowCleartextPasswords: defaultAllowCleartextPasswords,
+		maxLoggedQueryLen:       defaultMaxLoggedQueryLen,
+	}
+}
+
+// NewCommandLineConfig returns server config based on the credentials and command line arguments given.
+func NewCommandLineConfig(creds *cli.UserPassword, apr *argparser.ArgParseResults) (ServerConfig, error) {
+	config := DefaultServerConfig()
+
+	if sock, ok := apr.GetValue(socketFlag); ok {
+		// defined without value gets default
+		if sock == "" {
+			sock = defaultUnixSocketFilePath
+		}
+		config.WithSocket(sock)
+	}
+
+	if host, ok := apr.GetValue(hostFlag); ok {
+		config.WithHost(host)
+	}
+
+	if port, ok := apr.GetInt(portFlag); ok {
+		config.WithPort(port)
+	}
+
+	if creds == nil {
+		if user, ok := apr.GetValue(cli.UserFlag); ok {
+			config.withUser(user)
+		}
+		if password, ok := apr.GetValue(cli.PasswordFlag); ok {
+			config.withPassword(password)
+		}
+	} else {
+		config.withUser(creds.Username)
+		config.withPassword(creds.Password)
+	}
+
+	if port, ok := apr.GetInt(remotesapiPortFlag); ok {
+		config.WithRemotesapiPort(&port)
+	}
+	if apr.Contains(remotesapiReadOnlyFlag) {
+		val := true
+		config.WithRemotesapiReadOnly(&val)
+	}
+
+	if persistenceBehavior, ok := apr.GetValue(persistenceBehaviorFlag); ok {
+		config.withPersistenceBehavior(persistenceBehavior)
+	}
+
+	if timeoutStr, ok := apr.GetValue(timeoutFlag); ok {
+		timeout, err := strconv.ParseUint(timeoutStr, 10, 64)
+
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for --timeout '%s'", timeoutStr)
+		}
+
+		config.withTimeout(timeout * 1000)
+	}
+
+	if _, ok := apr.GetValue(readonlyFlag); ok {
+		config.withReadOnly(true)
+		val := true
+		config.WithRemotesapiReadOnly(&val)
+	}
+
+	if logLevel, ok := apr.GetValue(logLevelFlag); ok {
+		config.withLogLevel(LogLevel(strings.ToLower(logLevel)))
+	}
+
+	if dataDir, ok := apr.GetValue(commands.MultiDBDirFlag); ok {
+		config.withDataDir(dataDir)
+	}
+
+	if dataDir, ok := apr.GetValue(commands.DataDirFlag); ok {
+		config.withDataDir(dataDir)
+	}
+
+	if queryParallelism, ok := apr.GetInt(queryParallelismFlag); ok {
+		config.withQueryParallelism(queryParallelism)
+	}
+
+	if maxConnections, ok := apr.GetInt(maxConnectionsFlag); ok {
+		config.withMaxConnections(uint64(maxConnections))
+	}
+
+	config.autoCommit = !apr.Contains(noAutoCommitFlag)
+	config.allowCleartextPasswords = apr.Contains(allowCleartextPasswordsFlag)
+
+	if connStr, ok := apr.GetValue(goldenMysqlConn); ok {
+		cli.Println(connStr)
+		config.withGoldenMysqlConnectionString(connStr)
+	}
+
+	if esStatus, ok := apr.GetValue(eventSchedulerStatus); ok {
+		// make sure to assign eventSchedulerStatus first here
+		config.withEventScheduler(strings.ToUpper(esStatus))
+	}
+
+	return config, nil
+}

--- a/go/cmd/dolt/commands/sqlserver/serverconfig.go
+++ b/go/cmd/dolt/commands/sqlserver/serverconfig.go
@@ -172,6 +172,8 @@ type ServerConfig interface {
 	ClusterConfig() cluster.Config
 	// EventSchedulerStatus is the configuration for enabling or disabling the event scheduler in this server.
 	EventSchedulerStatus() string
+	// ValueSet returns whether the value string provided was explicitly set in the config
+	ValueSet(value string) bool
 }
 
 // WritableServerConfig is a ServerConfig that support overwriting certain values.
@@ -218,30 +220,37 @@ func ValidateConfig(config ServerConfig) error {
 	return ValidateClusterConfig(config.ClusterConfig())
 }
 
+const (
+	maxConnectionsKey = "max_connections"
+	readTimeoutKey     = "net_read_timeout"
+	writeTimeoutKey    = "net_write_timeout"
+	eventSchedulerKey  = "event_scheduler"
+)
+
 // ApplySystemVariables sets the global system variables based on the given `ServerConfig`.
 func ApplySystemVariables(cfg ServerConfig) error {
-	if cfg.MaxConnections() > 0 {
+	if cfg.ValueSet(maxConnectionsKey) {
 		err := sql.SystemVariables.SetGlobal("max_connections", cfg.MaxConnections())
 		if err != nil {
 			return err
 		}
 	}
 
-	if cfg.ReadTimeout() > 0 {
+	if cfg.ValueSet(readTimeoutKey) {
 		err := sql.SystemVariables.SetGlobal("net_read_timeout", cfg.ReadTimeout())
 		if err != nil {
 			return err
 		}
 	}
 
-	if cfg.WriteTimeout() > 0 {
+	if cfg.ValueSet(writeTimeoutKey) {
 		err := sql.SystemVariables.SetGlobal("net_write_timeout", cfg.WriteTimeout())
 		if err != nil {
 			return err
 		}
 	}
 
-	if len(cfg.EventSchedulerStatus()) > 0 {
+	if cfg.ValueSet(eventSchedulerKey) {
 		err := sql.SystemVariables.SetGlobal("event_scheduler", cfg.EventSchedulerStatus())
 		if err != nil {
 			return err

--- a/go/cmd/dolt/commands/sqlserver/serverconfig.go
+++ b/go/cmd/dolt/commands/sqlserver/serverconfig.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"path/filepath"
 	"strings"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
@@ -170,8 +169,6 @@ type ServerConfig interface {
 	ClusterConfig() cluster.Config
 	// EventSchedulerStatus is the configuration for enabling or disabling the event scheduler in this server.
 	EventSchedulerStatus() string
-	// ApplySystemVariables applies any system variables specified by this config to the global system variables.
-	ApplySystemVariables() error
 }
 
 type validatingServerConfig interface {
@@ -179,391 +176,6 @@ type validatingServerConfig interface {
 	// goldenMysqlConnectionString returns a connection string for a mysql
 	// instance that can be used to validate query results
 	goldenMysqlConnectionString() string
-}
-
-type commandLineServerConfig struct {
-	host                    string
-	port                    int
-	user                    string
-	password                string
-	timeout                 uint64
-	readOnly                bool
-	logLevel                LogLevel
-	dataDir                 string
-	cfgDir                  string
-	autoCommit              bool
-	doltTransactionCommit   bool
-	maxConnections          uint64
-	queryParallelism        int
-	tlsKey                  string
-	tlsCert                 string
-	requireSecureTransport  bool
-	maxLoggedQueryLen       int
-	shouldEncodeLoggedQuery bool
-	persistenceBehavior     string
-	privilegeFilePath       string
-	branchControlFilePath   string
-	allowCleartextPasswords bool
-	socket                  string
-	remotesapiPort          *int
-	remotesapiReadOnly      *bool
-	goldenMysqlConn         string
-	eventSchedulerStatus    string
-}
-
-func (cfg *commandLineServerConfig) ApplySystemVariables() error {
-	if cfg.timeout > 0 {
-		err := sql.SystemVariables.SetGlobal("net_read_timeout", cfg.timeout*1000)
-		if err != nil {
-			return fmt.Errorf("failed to set net_read_timeout. Error: %w", err)
-		}
-		err = sql.SystemVariables.SetGlobal("net_write_timeout", cfg.timeout*1000)
-		if err != nil {
-			return fmt.Errorf("failed to set net_write_timeout. Error: %w", err)
-		}
-	}
-
-	if len(cfg.eventSchedulerStatus) > 0 {
-		err := sql.SystemVariables.SetGlobal("event_scheduler", cfg.EventSchedulerStatus())
-		if err != nil {
-			return fmt.Errorf("failed to set event_scheduler. Error: %w", err)
-		}
-	}
-
-	if cfg.maxConnections > 0 {
-		err := sql.SystemVariables.SetGlobal("max_connections", cfg.maxConnections)
-		if err != nil {
-			return fmt.Errorf("failed to set max_connections. Error: %w", err)
-		}
-	}
-
-	return nil
-}
-
-var _ ServerConfig = (*commandLineServerConfig)(nil)
-
-// Host returns the domain that the server will run on. Accepts an IPv4 or IPv6 address, in addition to localhost.
-func (cfg *commandLineServerConfig) Host() string {
-	return cfg.host
-}
-
-// Port returns the port that the server will run on. The valid range is [1024, 65535].
-func (cfg *commandLineServerConfig) Port() int {
-	return cfg.port
-}
-
-// User returns the username that connecting clients must use.
-func (cfg *commandLineServerConfig) User() string {
-	return cfg.user
-}
-
-// Password returns the password that connecting clients must use.
-func (cfg *commandLineServerConfig) Password() string {
-	return cfg.password
-}
-
-// ReadTimeout returns the read and write timeouts.
-func (cfg *commandLineServerConfig) ReadTimeout() uint64 {
-	return cfg.timeout
-}
-
-// WriteTimeout returns the read and write timeouts.
-func (cfg *commandLineServerConfig) WriteTimeout() uint64 {
-	return cfg.timeout
-}
-
-// ReadOnly returns whether the server will only accept read statements or all statements.
-func (cfg *commandLineServerConfig) ReadOnly() bool {
-	return cfg.readOnly
-}
-
-// LogLevel returns the level of logging that the server will use.
-func (cfg *commandLineServerConfig) LogLevel() LogLevel {
-	return cfg.logLevel
-}
-
-// AutoCommit defines the value of the @@autocommit session variable used on every connection
-func (cfg *commandLineServerConfig) AutoCommit() bool {
-	return cfg.autoCommit
-}
-
-// DoltTransactionCommit defines the value of the @@dolt_transaction_commit session variable that enables Dolt
-// commits to be automatically created when a SQL transaction is committed. The default is false.
-func (cfg *commandLineServerConfig) DoltTransactionCommit() bool {
-	return cfg.doltTransactionCommit
-}
-
-// MaxConnections returns the maximum number of simultaneous connections the server will allow.  The default is 1
-func (cfg *commandLineServerConfig) MaxConnections() uint64 {
-	return cfg.maxConnections
-}
-
-// QueryParallelism returns the parallelism that should be used by the go-mysql-server analyzer
-func (cfg *commandLineServerConfig) QueryParallelism() int {
-	return cfg.queryParallelism
-}
-
-// PersistenceBehavior returns whether to autoload persisted server configuration
-func (cfg *commandLineServerConfig) PersistenceBehavior() string {
-	return cfg.persistenceBehavior
-}
-
-// TLSKey returns a path to the servers PEM-encoded private TLS key. "" if there is none.
-func (cfg *commandLineServerConfig) TLSKey() string {
-	return cfg.tlsKey
-}
-
-// TLSCert returns a path to the servers PEM-encoded TLS certificate chain. "" if there is none.
-func (cfg *commandLineServerConfig) TLSCert() string {
-	return cfg.tlsCert
-}
-
-// RequireSecureTransport is true if the server should reject non-TLS connections.
-func (cfg *commandLineServerConfig) RequireSecureTransport() bool {
-	return cfg.requireSecureTransport
-}
-
-// MaxLoggedQueryLen is the max length of queries written to the logs.  Queries longer than this number are truncated.
-// If this value is 0 then the query is not truncated and will be written to the logs in its entirety.  If the value
-// is less than 0 then the queries will be omitted from the logs completely
-func (cfg *commandLineServerConfig) MaxLoggedQueryLen() int {
-	return cfg.maxLoggedQueryLen
-}
-
-// ShouldEncodeLoggedQuery determines if logged queries are base64 encoded.
-// If true, queries will be logged as base64 encoded strings.
-// If false (default behavior), queries will be logged as strings, but newlines and tabs will be replaced with spaces.
-func (cfg *commandLineServerConfig) ShouldEncodeLoggedQuery() bool {
-	return cfg.shouldEncodeLoggedQuery
-}
-
-// DisableClientMultiStatements is true if we want the server to not
-// process incoming ComQuery packets as if they had multiple queries in
-// them, even if the client advertises support for MULTI_STATEMENTS.
-func (cfg *commandLineServerConfig) DisableClientMultiStatements() bool {
-	return false
-}
-
-// MetricsLabels returns labels that are applied to all prometheus metrics
-func (cfg *commandLineServerConfig) MetricsLabels() map[string]string {
-	return nil
-}
-
-func (cfg *commandLineServerConfig) MetricsHost() string {
-	return defaultMetricsHost
-}
-
-func (cfg *commandLineServerConfig) MetricsPort() int {
-	return defaultMetricsPort
-}
-
-func (cfg *commandLineServerConfig) RemotesapiPort() *int {
-	return cfg.remotesapiPort
-}
-
-func (cfg *commandLineServerConfig) RemotesapiReadOnly() *bool {
-	return cfg.remotesapiReadOnly
-}
-
-func (cfg *commandLineServerConfig) ClusterConfig() cluster.Config {
-	return nil
-}
-
-// PrivilegeFilePath returns the path to the file which contains all needed privilege information in the form of a
-// JSON string.
-func (cfg *commandLineServerConfig) PrivilegeFilePath() string {
-	return cfg.privilegeFilePath
-}
-
-// BranchControlFilePath returns the path to the file which contains the branch control permissions.
-func (cfg *commandLineServerConfig) BranchControlFilePath() string {
-	return cfg.branchControlFilePath
-}
-
-// UserVars is an array containing user specific session variables.
-func (cfg *commandLineServerConfig) UserVars() []UserSessionVars {
-	return nil
-}
-
-func (cfg *commandLineServerConfig) SystemVars() engine.SystemVariables {
-	return nil
-}
-
-func (cfg *commandLineServerConfig) JwksConfig() []engine.JwksConfig {
-	return nil
-}
-
-func (cfg *commandLineServerConfig) AllowCleartextPasswords() bool {
-	return cfg.allowCleartextPasswords
-}
-
-// DataDir is the path to a directory to use as the data dir, both to create new databases and locate existing ones.
-func (cfg *commandLineServerConfig) DataDir() string {
-	return cfg.dataDir
-}
-
-// CfgDir is the path to a directory to use to store the dolt configuration files.
-func (cfg *commandLineServerConfig) CfgDir() string {
-	return cfg.cfgDir
-}
-
-// Socket is a path to the unix socket file
-func (cfg *commandLineServerConfig) Socket() string {
-	return cfg.socket
-}
-
-// WithHost updates the host and returns the called `*commandLineServerConfig`, which is useful for chaining calls.
-func (cfg *commandLineServerConfig) WithHost(host string) *commandLineServerConfig {
-	cfg.host = host
-	return cfg
-}
-
-// WithPort updates the port and returns the called `*commandLineServerConfig`, which is useful for chaining calls.
-func (cfg *commandLineServerConfig) WithPort(port int) *commandLineServerConfig {
-	cfg.port = port
-	return cfg
-}
-
-// withUser updates the user and returns the called `*commandLineServerConfig`, which is useful for chaining calls.
-func (cfg *commandLineServerConfig) withUser(user string) *commandLineServerConfig {
-	cfg.user = user
-	return cfg
-}
-
-// withPassword updates the password and returns the called `*commandLineServerConfig`, which is useful for chaining calls.
-func (cfg *commandLineServerConfig) withPassword(password string) *commandLineServerConfig {
-	cfg.password = password
-	return cfg
-}
-
-// withTimeout updates the timeout and returns the called `*commandLineServerConfig`, which is useful for chaining calls.
-func (cfg *commandLineServerConfig) withTimeout(timeout uint64) *commandLineServerConfig {
-	cfg.timeout = timeout
-	return cfg
-}
-
-// withReadOnly updates the read only flag and returns the called `*commandLineServerConfig`, which is useful for chaining calls.
-func (cfg *commandLineServerConfig) withReadOnly(readonly bool) *commandLineServerConfig {
-	cfg.readOnly = readonly
-	return cfg
-}
-
-// withLogLevel updates the log level and returns the called `*commandLineServerConfig`, which is useful for chaining calls.
-func (cfg *commandLineServerConfig) withLogLevel(loglevel LogLevel) *commandLineServerConfig {
-	cfg.logLevel = loglevel
-	return cfg
-}
-
-// withMaxConnections updates the maximum number of concurrent connections and returns the called
-// `*commandLineServerConfig`, which is useful for chaining calls.
-func (cfg *commandLineServerConfig) withMaxConnections(maxConnections uint64) *commandLineServerConfig {
-	cfg.maxConnections = maxConnections
-	return cfg
-}
-
-// withQueryParallelism updates the query parallelism and returns the called `*commandLineServerConfig`, which is useful for chaining calls.
-func (cfg *commandLineServerConfig) withQueryParallelism(queryParallelism int) *commandLineServerConfig {
-	cfg.queryParallelism = queryParallelism
-	return cfg
-}
-
-// withDataDir updates the path to a directory to use as the data dir.
-func (cfg *commandLineServerConfig) withDataDir(dataDir string) *commandLineServerConfig {
-	cfg.dataDir = dataDir
-	return cfg
-}
-
-// withCfgDir updates the path to a directory to use to store the dolt configuration files.
-func (cfg *commandLineServerConfig) withCfgDir(cfgDir string) *commandLineServerConfig {
-	cfg.cfgDir = cfgDir
-	return cfg
-}
-
-// withPersistenceBehavior updates persistence behavior of system globals on server init
-func (cfg *commandLineServerConfig) withPersistenceBehavior(persistenceBehavior string) *commandLineServerConfig {
-	cfg.persistenceBehavior = persistenceBehavior
-	return cfg
-}
-
-// withPrivilegeFilePath updates the path to the file which contains all needed privilege information in the form of a JSON string
-func (cfg *commandLineServerConfig) withPrivilegeFilePath(privFilePath string) *commandLineServerConfig {
-	cfg.privilegeFilePath = privFilePath
-	return cfg
-}
-
-// withBranchControlFilePath updates the path to the file which contains the branch control permissions
-func (cfg *commandLineServerConfig) withBranchControlFilePath(branchControlFilePath string) *commandLineServerConfig {
-	cfg.branchControlFilePath = branchControlFilePath
-	return cfg
-}
-
-func (cfg *commandLineServerConfig) withAllowCleartextPasswords(allow bool) *commandLineServerConfig {
-	cfg.allowCleartextPasswords = allow
-	return cfg
-}
-
-// WithSocket updates the path to the unix socket file
-func (cfg *commandLineServerConfig) WithSocket(sockFilePath string) *commandLineServerConfig {
-	cfg.socket = sockFilePath
-	return cfg
-}
-
-// WithRemotesapiPort sets the remotesapi port to use.
-func (cfg *commandLineServerConfig) WithRemotesapiPort(port *int) *commandLineServerConfig {
-	cfg.remotesapiPort = port
-	return cfg
-}
-
-func (cfg *commandLineServerConfig) WithRemotesapiReadOnly(readonly *bool) *commandLineServerConfig {
-	cfg.remotesapiReadOnly = readonly
-	return cfg
-}
-
-func (cfg *commandLineServerConfig) goldenMysqlConnectionString() string {
-	return cfg.goldenMysqlConn
-}
-
-func (cfg *commandLineServerConfig) withGoldenMysqlConnectionString(cs string) *commandLineServerConfig {
-	cfg.goldenMysqlConn = cs
-	return cfg
-}
-
-func (cfg *commandLineServerConfig) EventSchedulerStatus() string {
-	switch cfg.eventSchedulerStatus {
-	case "", "1":
-		return "ON"
-	case "0":
-		return "OFF"
-	default:
-		return strings.ToUpper(cfg.eventSchedulerStatus)
-	}
-}
-
-func (cfg *commandLineServerConfig) withEventScheduler(es string) *commandLineServerConfig {
-	cfg.eventSchedulerStatus = es
-	return cfg
-}
-
-// DefaultServerConfig creates a `*ServerConfig` that has all of the options set to their default values.
-func DefaultServerConfig() *commandLineServerConfig {
-	return &commandLineServerConfig{
-		host:                    defaultHost,
-		port:                    defaultPort,
-		password:                defaultPass,
-		timeout:                 defaultTimeout,
-		readOnly:                defaultReadOnly,
-		logLevel:                defaultLogLevel,
-		autoCommit:              defaultAutoCommit,
-		maxConnections:          defaultMaxConnections,
-		queryParallelism:        defaultQueryParallelism,
-		persistenceBehavior:     defaultPersistenceBahavior,
-		dataDir:                 defaultDataDir,
-		cfgDir:                  filepath.Join(defaultDataDir, defaultCfgDir),
-		privilegeFilePath:       filepath.Join(defaultDataDir, defaultCfgDir, defaultPrivilegeFilePath),
-		branchControlFilePath:   filepath.Join(defaultDataDir, defaultCfgDir, defaultBranchControlFilePath),
-		allowCleartextPasswords: defaultAllowCleartextPasswords,
-		maxLoggedQueryLen:       defaultMaxLoggedQueryLen,
-	}
 }
 
 // ValidateConfig returns an `error` if any field is not valid.
@@ -584,6 +196,39 @@ func ValidateConfig(config ServerConfig) error {
 		return fmt.Errorf("require_secure_transport can only be `true` when a tls_key and tls_cert are provided.")
 	}
 	return ValidateClusterConfig(config.ClusterConfig())
+}
+
+// ApplySystemVariables sets the global system variables based on the given `ServerConfig`.
+func ApplySystemVariables(cfg ServerConfig) error {
+	if cfg.MaxConnections() > 0 {
+		err := sql.SystemVariables.SetGlobal("max_connections", cfg.MaxConnections())
+		if err != nil {
+			return err
+		}
+	}
+
+	if cfg.ReadTimeout() > 0 {
+		err := sql.SystemVariables.SetGlobal("net_read_timeout", cfg.ReadTimeout())
+		if err != nil {
+			return err
+		}
+	}
+	
+	if cfg.WriteTimeout() > 0 {
+		err := sql.SystemVariables.SetGlobal("net_write_timeout", cfg.WriteTimeout())
+		if err != nil {
+			return err
+		}
+	}
+	
+	if len(cfg.EventSchedulerStatus()) > 0 {
+		err := sql.SystemVariables.SetGlobal("event_scheduler", cfg.EventSchedulerStatus())
+		if err != nil {
+			return err
+		}
+	}
+	
+	return nil
 }
 
 func ValidateClusterConfig(config cluster.Config) error {
@@ -669,3 +314,4 @@ func LoadTLSConfig(cfg ServerConfig) (*tls.Config, error) {
 		},
 	}, nil
 }
+

--- a/go/cmd/dolt/commands/sqlserver/serverconfig.go
+++ b/go/cmd/dolt/commands/sqlserver/serverconfig.go
@@ -222,9 +222,9 @@ func ValidateConfig(config ServerConfig) error {
 
 const (
 	maxConnectionsKey = "max_connections"
-	readTimeoutKey     = "net_read_timeout"
-	writeTimeoutKey    = "net_write_timeout"
-	eventSchedulerKey  = "event_scheduler"
+	readTimeoutKey    = "net_read_timeout"
+	writeTimeoutKey   = "net_write_timeout"
+	eventSchedulerKey = "event_scheduler"
 )
 
 // ApplySystemVariables sets the global system variables based on the given `ServerConfig`.

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -291,15 +291,14 @@ func ServerConfigFromArgsWithReader(
 // getServerConfig returns ServerConfig that is set either from yaml file if given, if not it is set with values defined
 // on command line. Server config variables not defined are set to default values.
 func getServerConfig(cwdFS filesys.Filesys, apr *argparser.ArgParseResults, reader ServerConfigReader) (ServerConfig, error) {
-	var cfg ServerConfig
-	if cfgFile, ok := apr.GetValue(configFileFlag); ok {
-		var err error
-		cfg, err = reader.ReadConfigFile(cwdFS, cfgFile)
-		if err != nil {
-			return nil, err
-		}
-	} else {
+	cfgFile, ok := apr.GetValue(configFileFlag)
+	if !ok {
 		return reader.ReadConfigArgs(apr)
+	}
+
+	cfg, err := reader.ReadConfigFile(cwdFS, cfgFile)
+	if err != nil {
+		return nil, err
 	}
 
 	// if command line user argument was given, override the config file's user and password

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/fatih/color"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
@@ -465,15 +464,6 @@ func getCommandLineConfig(creds *cli.UserPassword, apr *argparser.ArgParseResult
 		}
 
 		config.withTimeout(timeout * 1000)
-
-		err = sql.SystemVariables.SetGlobal("net_read_timeout", timeout*1000)
-		if err != nil {
-			return nil, fmt.Errorf("failed to set net_read_timeout. Error: %s", err.Error())
-		}
-		err = sql.SystemVariables.SetGlobal("net_write_timeout", timeout*1000)
-		if err != nil {
-			return nil, fmt.Errorf("failed to set net_write_timeout. Error: %s", err.Error())
-		}
 	}
 
 	if _, ok := apr.GetValue(readonlyFlag); ok {
@@ -500,10 +490,6 @@ func getCommandLineConfig(creds *cli.UserPassword, apr *argparser.ArgParseResult
 
 	if maxConnections, ok := apr.GetInt(maxConnectionsFlag); ok {
 		config.withMaxConnections(uint64(maxConnections))
-		err := sql.SystemVariables.SetGlobal("max_connections", uint64(maxConnections))
-		if err != nil {
-			return nil, fmt.Errorf("failed to set max_connections. Error: %s", err.Error())
-		}
 	}
 
 	config.autoCommit = !apr.Contains(noAutoCommitFlag)
@@ -517,10 +503,6 @@ func getCommandLineConfig(creds *cli.UserPassword, apr *argparser.ArgParseResult
 	if esStatus, ok := apr.GetValue(eventSchedulerStatus); ok {
 		// make sure to assign eventSchedulerStatus first here
 		config.withEventScheduler(strings.ToUpper(esStatus))
-		err := sql.SystemVariables.SetGlobal("event_scheduler", config.EventSchedulerStatus())
-		if err != nil {
-			return nil, fmt.Errorf("failed to set event_scheduler. Error: %s", err.Error())
-		}
 	}
 
 	return config, nil
@@ -537,31 +519,6 @@ func getYAMLServerConfig(fs filesys.Filesys, path string) (ServerConfig, error) 
 	if err != nil {
 		return nil, fmt.Errorf("Failed to parse yaml file '%s'. Error: %s", path, err.Error())
 	}
-
-	if cfg.ListenerConfig.MaxConnections != nil {
-		err = sql.SystemVariables.SetGlobal("max_connections", *cfg.ListenerConfig.MaxConnections)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to set max_connections from yaml file '%s'. Error: %s", path, err.Error())
-		}
-	}
-	if cfg.ListenerConfig.ReadTimeoutMillis != nil {
-		err = sql.SystemVariables.SetGlobal("net_read_timeout", *cfg.ListenerConfig.ReadTimeoutMillis)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to set net_read_timeout from yaml file '%s'. Error: %s", path, err.Error())
-		}
-	}
-	if cfg.ListenerConfig.WriteTimeoutMillis != nil {
-		err = sql.SystemVariables.SetGlobal("net_write_timeout", *cfg.ListenerConfig.WriteTimeoutMillis)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to set net_write_timeout from yaml file '%s'. Error: %s", path, err.Error())
-		}
-	}
-	if cfg.BehaviorConfig.EventSchedulerStatus != nil {
-		err = sql.SystemVariables.SetGlobal("event_scheduler", cfg.EventSchedulerStatus())
-		if err != nil {
-			return nil, fmt.Errorf("Failed to set event_scheduler from yaml file '%s'. Error: %s", path, err.Error())
-		}
-	}
-
+	
 	return cfg, nil
 }

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -239,6 +239,11 @@ func StartServer(ctx context.Context, versionStr, commandStr string, args []stri
 		return err
 	}
 
+	err = ApplySystemVariables(serverConfig)
+	if err != nil {
+		return err
+	}
+
 	cli.PrintErrf("Starting server with Config %v\n", ConfigInfo(serverConfig))
 
 	startError, closeError := Serve(ctx, versionStr, serverConfig, controller, dEnv)

--- a/go/cmd/dolt/commands/sqlserver/yaml_config.go
+++ b/go/cmd/dolt/commands/sqlserver/yaml_config.go
@@ -191,8 +191,8 @@ func YamlConfigFromFile(fs filesys.Filesys, path string) (ServerConfig, error) {
 	return cfg, nil
 }
 
-func ServerConfigAsYAMLConfig(cfg ServerConfig) YAMLConfig {
-	return YAMLConfig{
+func ServerConfigAsYAMLConfig(cfg ServerConfig) *YAMLConfig {
+	return &YAMLConfig{
 		LogLevelStr:       strPtr(string(cfg.LogLevel())),
 		MaxQueryLenInLogs: nillableIntPtr(cfg.MaxLoggedQueryLen()),
 		EncodeLoggedQuery: nillableBoolPtr(cfg.ShouldEncodeLoggedQuery()),

--- a/go/cmd/dolt/commands/sqlserver/yaml_config.go
+++ b/go/cmd/dolt/commands/sqlserver/yaml_config.go
@@ -685,3 +685,17 @@ func (c ClusterRemotesAPIYAMLConfig) ServerNameURLMatches() []string {
 func (c ClusterRemotesAPIYAMLConfig) ServerNameDNSMatches() []string {
 	return c.DNSMatches
 }
+
+func (cfg YAMLConfig) ValueSet(value string) bool {
+	switch value {
+	case readTimeoutKey:
+		return cfg.ListenerConfig.ReadTimeoutMillis != nil
+	case writeTimeoutKey:
+		return cfg.ListenerConfig.WriteTimeoutMillis != nil
+	case maxConnectionsKey:
+		return cfg.ListenerConfig.MaxConnections != nil
+	case eventSchedulerKey:
+		return cfg.BehaviorConfig.EventSchedulerStatus != nil
+	}
+	return false
+}

--- a/go/cmd/dolt/commands/sqlserver/yaml_config.go
+++ b/go/cmd/dolt/commands/sqlserver/yaml_config.go
@@ -166,14 +166,14 @@ var _ ServerConfig = YAMLConfig{}
 var _ validatingServerConfig = YAMLConfig{}
 var _ WritableServerConfig = &YAMLConfig{}
 
-func NewYamlConfig(configFileData []byte) (YAMLConfig, error) {
+func NewYamlConfig(configFileData []byte) (*YAMLConfig, error) {
 	var cfg YAMLConfig
 	err := yaml.UnmarshalStrict(configFileData, &cfg)
 	if cfg.LogLevelStr != nil {
 		loglevel := strings.ToLower(*cfg.LogLevelStr)
 		cfg.LogLevelStr = &loglevel
 	}
-	return cfg, err
+	return &cfg, err
 }
 
 // YamlConfigFromFile returns server config variables with values defined in yaml file.
@@ -340,11 +340,11 @@ func (cfg YAMLConfig) User() string {
 	return *cfg.UserConfig.Name
 }
 
-func (cfg YAMLConfig) SetUserName(s string) {
+func (cfg *YAMLConfig) SetUserName(s string) {
 	cfg.UserConfig.Name = &s
 }
 
-func (cfg YAMLConfig) SetPassword(s string) {
+func (cfg *YAMLConfig) SetPassword(s string) {
 	cfg.UserConfig.Password = &s
 }
 

--- a/go/cmd/dolt/commands/sqlserver/yaml_config.go
+++ b/go/cmd/dolt/commands/sqlserver/yaml_config.go
@@ -164,6 +164,7 @@ type YAMLConfig struct {
 
 var _ ServerConfig = YAMLConfig{}
 var _ validatingServerConfig = YAMLConfig{}
+var _ WritableServerConfig = &YAMLConfig{}
 
 func NewYamlConfig(configFileData []byte) (YAMLConfig, error) {
 	var cfg YAMLConfig
@@ -337,6 +338,14 @@ func (cfg YAMLConfig) User() string {
 	}
 
 	return *cfg.UserConfig.Name
+}
+
+func (cfg YAMLConfig) SetUserName(s string) {
+	cfg.UserConfig.Name = &s
+}
+
+func (cfg YAMLConfig) SetPassword(s string) {
+	cfg.UserConfig.Password = &s
 }
 
 // Password returns the password that connecting clients must use.

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -594,6 +594,7 @@ func runMain() int {
 		return false, nil
 	})
 
+	// TODO: we set persisted vars here, and this should be deferred until after we know what command line arguments might change them
 	err = dsess.InitPersistedSystemVars(dEnv)
 	if err != nil {
 		cli.Printf("error: failed to load persisted global variables: %s\n", err.Error())


### PR DESCRIPTION
This change:

* Decouples reading config from setting SQL globals
* Puts command line config in its own file
* Introduces new interfaces to allow alternate Config implementations. This is to support DoltgreSQL, which will have different config options than Dolt itself.