### PR TITLE
A new NBS Format

### DIFF
--- a/go/libraries/doltcore/remotestorage/chunk_cache.go
+++ b/go/libraries/doltcore/remotestorage/chunk_cache.go
@@ -22,20 +22,20 @@ import (
 // ChunkCache is an interface used for caching chunks
 type ChunkCache interface {
 	// Put puts a slice of chunks into the cache.
-	Put(c []nbs.CompressedChunk) bool
+	Put(c []nbs.ChunkRecord) bool
 
 	// Get gets a map of hash to chunk for a set of hashes.  In the event that a chunk is not in the cache, chunks.Empty.
 	// is put in it's place
-	Get(h hash.HashSet) map[hash.Hash]nbs.CompressedChunk
+	Get(h hash.HashSet) map[hash.Hash]nbs.ChunkRecord
 
 	// Has takes a set of hashes and returns the set of hashes that the cache currently does not have in it.
 	Has(h hash.HashSet) (absent hash.HashSet)
 
 	// PutChunk puts a single chunk in the cache.  true returns in the event that the chunk was cached successfully
 	// and false is returned if that chunk is already is the cache.
-	PutChunk(chunk nbs.CompressedChunk) bool
+	PutChunk(chunk nbs.ChunkRecord) bool
 
 	// GetAndClearChunksToFlush gets a map of hash to chunk which includes all the chunks that were put in the cache
 	// between the last time GetAndClearChunksToFlush was called and now.
-	GetAndClearChunksToFlush() map[hash.Hash]nbs.CompressedChunk
+	GetAndClearChunksToFlush() map[hash.Hash]nbs.ChunkRecord
 }

--- a/go/libraries/doltcore/remotestorage/chunk_store.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store.go
@@ -464,7 +464,7 @@ func (gr *GetRange) GetDownloadFunc(ctx context.Context, stats StatsRecorder, fe
 			s, e := gr.ChunkByteRange(i)
 			// Currently we assume that the data returned from remotes is only using nbs.BetaV. The HTTP response will need to
 			// indicate the version in the future.
-			cmpChnk, err := nbs.NewChunkRecord(hash.New(gr.Ranges[i].Hash), comprData[s:e], nbs.BetaV)
+			cmpChnk, err := nbs.DeserializeChunkRecord(hash.New(gr.Ranges[i].Hash), comprData[s:e], nbs.BetaV)
 			if err != nil {
 				return err
 			}

--- a/go/libraries/doltcore/remotestorage/chunk_store.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store.go
@@ -462,7 +462,7 @@ func (gr *GetRange) GetDownloadFunc(ctx context.Context, stats StatsRecorder, fe
 		// Send the chunk for each range included in GetRange.
 		for i := 0; i < len(gr.Ranges); i++ {
 			s, e := gr.ChunkByteRange(i)
-			cmpChnk, err := nbs.NewCompressedChunk(hash.New(gr.Ranges[i].Hash), comprData[s:e])
+			cmpChnk, err := nbs.NewCompressedChunk(hash.New(gr.Ranges[i].Hash), comprData[s:e], 0) // NM4 - This is f'ed. We need to get the version from somewhere
 			if err != nil {
 				return err
 			}
@@ -767,7 +767,7 @@ func (dcs *DoltChunkStore) HasMany(ctx context.Context, hashes hash.HashSet) (ha
 				absent[currHash] = struct{}{}
 				j++
 			} else {
-				c := nbs.ChunkToCompressedChunk(chunks.NewChunkWithHash(currHash, []byte{}))
+				c := nbs.ChunkToCompressedChunk(chunks.NewChunkWithHash(currHash, []byte{}), 0) // NM4
 				found = append(found, c)
 			}
 		}
@@ -818,7 +818,7 @@ func (dcs *DoltChunkStore) Put(ctx context.Context, c chunks.Chunk, getAddrs chu
 		return err
 	}
 
-	cc := nbs.ChunkToCompressedChunk(c)
+	cc := nbs.ChunkToCompressedChunk(c, 0) // NM4
 	if dcs.cache.Put([]nbs.CompressedChunk{cc}) {
 		return ErrCacheCapacityExceeded
 	}

--- a/go/libraries/doltcore/remotestorage/chunk_store.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store.go
@@ -462,7 +462,9 @@ func (gr *GetRange) GetDownloadFunc(ctx context.Context, stats StatsRecorder, fe
 		// Send the chunk for each range included in GetRange.
 		for i := 0; i < len(gr.Ranges); i++ {
 			s, e := gr.ChunkByteRange(i)
-			cmpChnk, err := nbs.NewChunkRecord(hash.New(gr.Ranges[i].Hash), comprData[s:e], 0) // NM4 - This is f'ed. We need to get the version from somewhere
+			// Currently we assume that the data returned from remotes is only using nbs.BetaV. The HTTP response will need to
+			// indicate the version in the future.
+			cmpChnk, err := nbs.NewChunkRecord(hash.New(gr.Ranges[i].Hash), comprData[s:e], nbs.BetaV)
 			if err != nil {
 				return err
 			}
@@ -767,7 +769,7 @@ func (dcs *DoltChunkStore) HasMany(ctx context.Context, hashes hash.HashSet) (ha
 				absent[currHash] = struct{}{}
 				j++
 			} else {
-				c := nbs.ChunkToChunkRecord(chunks.NewChunkWithHash(currHash, []byte{}), 0) // NM4
+				c := nbs.ChunkToChunkRecord(chunks.NewChunkWithHash(currHash, []byte{}), nbs.BetaV)
 				found = append(found, c)
 			}
 		}
@@ -818,7 +820,7 @@ func (dcs *DoltChunkStore) Put(ctx context.Context, c chunks.Chunk, getAddrs chu
 		return err
 	}
 
-	cc := nbs.ChunkToChunkRecord(c, 0) // NM4
+	cc := nbs.ChunkToChunkRecord(c, nbs.BetaV)
 	if dcs.cache.Put([]nbs.ChunkRecord{cc}) {
 		return ErrCacheCapacityExceeded
 	}

--- a/go/libraries/doltcore/remotestorage/map_chunk_cache.go
+++ b/go/libraries/doltcore/remotestorage/map_chunk_cache.go
@@ -63,7 +63,7 @@ func (mcc *mapChunkCache) Put(chnks []nbs.CompressedChunk) bool {
 			}
 		}
 
-		if mcc.cm.CapacityExceeded(len(c.FullCompressedChunk)) {
+		if mcc.cm.CapacityExceeded(int(c.Size())) {
 			return true
 		}
 
@@ -118,7 +118,7 @@ func (mcc *mapChunkCache) PutChunk(ch nbs.CompressedChunk) bool {
 
 	h := ch.Hash()
 	if existing, ok := mcc.hashToChunk[h]; !ok || existing.IsEmpty() {
-		if mcc.cm.CapacityExceeded(len(ch.FullCompressedChunk)) {
+		if mcc.cm.CapacityExceeded(int(ch.Size())) {
 			return true
 		}
 		mcc.hashToChunk[h] = ch

--- a/go/libraries/doltcore/remotestorage/map_chunk_cache_test.go
+++ b/go/libraries/doltcore/remotestorage/map_chunk_cache_test.go
@@ -37,7 +37,7 @@ func genRandomChunks(rng *rand.Rand, n int) (hash.HashSet, []nbs.ChunkRecord) {
 			bytes[j] = byte(rng.Int31n(255))
 		}
 
-		chk := nbs.ChunkToChunkRecord(chunks.NewChunk(bytes), 0) // NM4
+		chk := nbs.ChunkToChunkRecord(chunks.NewChunk(bytes), nbs.BetaV)
 		chks[i] = chk
 
 		hashes[chk.Hash()] = struct{}{}

--- a/go/libraries/doltcore/remotestorage/map_chunk_cache_test.go
+++ b/go/libraries/doltcore/remotestorage/map_chunk_cache_test.go
@@ -37,7 +37,7 @@ func genRandomChunks(rng *rand.Rand, n int) (hash.HashSet, []nbs.CompressedChunk
 			bytes[j] = byte(rng.Int31n(255))
 		}
 
-		chk := nbs.ChunkToCompressedChunk(chunks.NewChunk(bytes))
+		chk := nbs.ChunkToCompressedChunk(chunks.NewChunk(bytes), 0) // NM4
 		chks[i] = chk
 
 		hashes[chk.Hash()] = struct{}{}

--- a/go/libraries/doltcore/remotestorage/map_chunk_cache_test.go
+++ b/go/libraries/doltcore/remotestorage/map_chunk_cache_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/dolthub/dolt/go/store/nbs"
 )
 
-func genRandomChunks(rng *rand.Rand, n int) (hash.HashSet, []nbs.CompressedChunk) {
-	chks := make([]nbs.CompressedChunk, n)
+func genRandomChunks(rng *rand.Rand, n int) (hash.HashSet, []nbs.ChunkRecord) {
+	chks := make([]nbs.ChunkRecord, n)
 	hashes := make(hash.HashSet)
 	for i := 0; i < n; i++ {
 		size := int(rng.Int31n(99) + 1)
@@ -37,7 +37,7 @@ func genRandomChunks(rng *rand.Rand, n int) (hash.HashSet, []nbs.CompressedChunk
 			bytes[j] = byte(rng.Int31n(255))
 		}
 
-		chk := nbs.ChunkToCompressedChunk(chunks.NewChunk(bytes), 0) // NM4
+		chk := nbs.ChunkToChunkRecord(chunks.NewChunk(bytes), 0) // NM4
 		chks[i] = chk
 
 		hashes[chk.Hash()] = struct{}{}
@@ -88,7 +88,7 @@ func TestMapChunkCache(t *testing.T) {
 
 	toFlush = mapChunkCache.GetAndClearChunksToFlush()
 
-	expected := map[hash.Hash]nbs.CompressedChunk{moreChks[0].Hash(): moreChks[0]}
+	expected := map[hash.Hash]nbs.ChunkRecord{moreChks[0].Hash(): moreChks[0]}
 	eq := reflect.DeepEqual(toFlush, expected)
 	assert.True(t, eq, "Missing or unexpected chunks to flush (seed %d)", seed)
 }

--- a/go/libraries/doltcore/remotestorage/noop_chunk_cache.go
+++ b/go/libraries/doltcore/remotestorage/noop_chunk_cache.go
@@ -29,22 +29,22 @@ var noopChunkCache = &noopChunkCacheImpl{}
 type noopChunkCacheImpl struct {
 }
 
-func (*noopChunkCacheImpl) Put(chnks []nbs.CompressedChunk) bool {
+func (*noopChunkCacheImpl) Put(chnks []nbs.ChunkRecord) bool {
 	return false
 }
 
-func (*noopChunkCacheImpl) Get(hashes hash.HashSet) map[hash.Hash]nbs.CompressedChunk {
-	return make(map[hash.Hash]nbs.CompressedChunk)
+func (*noopChunkCacheImpl) Get(hashes hash.HashSet) map[hash.Hash]nbs.ChunkRecord {
+	return make(map[hash.Hash]nbs.ChunkRecord)
 }
 
 func (*noopChunkCacheImpl) Has(hashes hash.HashSet) (absent hash.HashSet) {
 	return hashes
 }
 
-func (*noopChunkCacheImpl) PutChunk(ch nbs.CompressedChunk) bool {
+func (*noopChunkCacheImpl) PutChunk(ch nbs.ChunkRecord) bool {
 	return false
 }
 
-func (*noopChunkCacheImpl) GetAndClearChunksToFlush() map[hash.Hash]nbs.CompressedChunk {
+func (*noopChunkCacheImpl) GetAndClearChunksToFlush() map[hash.Hash]nbs.ChunkRecord {
 	panic("noopChunkCache does not support GetAndClearChunksToFlush().")
 }

--- a/go/store/datas/pull/pull_table_file_writer.go
+++ b/go/store/datas/pull/pull_table_file_writer.go
@@ -229,7 +229,7 @@ LOOP:
 			}
 
 			if curWr == nil {
-				curWr, err = nbs.NewCmpChunkTableWriter(w.cfg.TempDir, 0) // NM4 - Until the client can tell us what version to use, we use nomsBetaVersion.
+				curWr, err = nbs.NewCmpChunkTableWriter(w.cfg.TempDir, nbs.BetaV)
 				if err != nil {
 					return err
 				}

--- a/go/store/datas/pull/pull_table_file_writer.go
+++ b/go/store/datas/pull/pull_table_file_writer.go
@@ -229,7 +229,7 @@ LOOP:
 			}
 
 			if curWr == nil {
-				curWr, err = nbs.NewCmpChunkTableWriter(w.cfg.TempDir)
+				curWr, err = nbs.NewCmpChunkTableWriter(w.cfg.TempDir, 0) // NM4 - Until the client can tell us what version to use, we use nomsBetaVersion.
 				if err != nil {
 					return err
 				}

--- a/go/store/datas/pull/pull_table_file_writer.go
+++ b/go/store/datas/pull/pull_table_file_writer.go
@@ -240,7 +240,7 @@ LOOP:
 			if err != nil {
 				return err
 			}
-			atomic.AddUint64(&w.bufferedSendBytes, uint64(len(newChnk.FullCompressedChunk)))
+			atomic.AddUint64(&w.bufferedSendBytes, uint64(newChnk.Size()))
 		}
 	}
 

--- a/go/store/datas/pull/pull_table_file_writer.go
+++ b/go/store/datas/pull/pull_table_file_writer.go
@@ -53,7 +53,7 @@ import (
 type PullTableFileWriter struct {
 	cfg PullTableFileWriterConfig
 
-	addChunkCh  chan nbs.CompressedChunk
+	addChunkCh  chan nbs.ChunkRecord
 	newWriterCh chan *nbs.CmpChunkTableWriter
 	egCtx       context.Context
 	eg          *errgroup.Group
@@ -94,7 +94,7 @@ type PullTableFileWriterStats struct {
 func NewPullTableFileWriter(ctx context.Context, cfg PullTableFileWriterConfig) *PullTableFileWriter {
 	ret := &PullTableFileWriter{
 		cfg:         cfg,
-		addChunkCh:  make(chan nbs.CompressedChunk),
+		addChunkCh:  make(chan nbs.ChunkRecord),
 		newWriterCh: make(chan *nbs.CmpChunkTableWriter, cfg.MaximumBufferedFiles),
 	}
 	ret.eg, ret.egCtx = errgroup.WithContext(ctx)
@@ -118,7 +118,7 @@ func (w *PullTableFileWriter) GetStats() PullTableFileWriterStats {
 // This method may block for arbitrary amounts of time if there is already a
 // lot of buffered table files and we are waiting for uploads to succeed before
 // creating more table files.
-func (w *PullTableFileWriter) AddCompressedChunk(ctx context.Context, chk nbs.CompressedChunk) error {
+func (w *PullTableFileWriter) AddCompressedChunk(ctx context.Context, chk nbs.ChunkRecord) error {
 	select {
 	case w.addChunkCh <- chk:
 		return nil
@@ -236,7 +236,7 @@ LOOP:
 			}
 
 			// Add the chunk to writer.
-			err = curWr.AddCmpChunk(newChnk)
+			err = curWr.AddChunkRecord(newChnk)
 			if err != nil {
 				return err
 			}

--- a/go/store/datas/pull/pull_table_file_writer_test.go
+++ b/go/store/datas/pull/pull_table_file_writer_test.go
@@ -60,7 +60,7 @@ func TestPullTableFileWriter(t *testing.T) {
 				_, err := rand.Read(bs)
 				assert.NoError(t, err)
 				chk := chunks.NewChunk(bs)
-				cChk := nbs.ChunkToChunkRecord(chk, 0) // NM4
+				cChk := nbs.ChunkToChunkRecord(chk, nbs.BetaV)
 				err = wr.AddCompressedChunk(context.Background(), cChk)
 				assert.NoError(t, err)
 			}
@@ -86,7 +86,7 @@ func TestPullTableFileWriter(t *testing.T) {
 				_, err := rand.Read(bs)
 				assert.NoError(t, err)
 				chk := chunks.NewChunk(bs)
-				cChk := nbs.ChunkToChunkRecord(chk, 0) // NM4
+				cChk := nbs.ChunkToChunkRecord(chk, nbs.BetaV)
 				err = wr.AddCompressedChunk(context.Background(), cChk)
 				assert.NoError(t, err)
 			}
@@ -116,7 +116,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			_, err := rand.Read(bs)
 			assert.NoError(t, err)
 			chk := chunks.NewChunk(bs)
-			cChk := nbs.ChunkToChunkRecord(chk, 0) // NM4
+			cChk := nbs.ChunkToChunkRecord(chk, nbs.BetaV)
 			err = wr.AddCompressedChunk(context.Background(), cChk)
 			assert.NoError(t, err)
 		}
@@ -144,7 +144,7 @@ func TestPullTableFileWriter(t *testing.T) {
 				_, err := rand.Read(bs)
 				assert.NoError(t, err)
 				chk := chunks.NewChunk(bs)
-				cChk := nbs.ChunkToChunkRecord(chk, 0) // NM4
+				cChk := nbs.ChunkToChunkRecord(chk, nbs.BetaV)
 				err = wr.AddCompressedChunk(context.Background(), cChk)
 				assert.NoError(t, err)
 			}
@@ -168,7 +168,7 @@ func TestPullTableFileWriter(t *testing.T) {
 				_, err := rand.Read(bs)
 				assert.NoError(t, err)
 				chk := chunks.NewChunk(bs)
-				cChk := nbs.ChunkToChunkRecord(chk, 0) // NM4
+				cChk := nbs.ChunkToChunkRecord(chk, nbs.BetaV)
 				err = wr.AddCompressedChunk(context.Background(), cChk)
 				assert.NoError(t, err)
 			}
@@ -179,7 +179,7 @@ func TestPullTableFileWriter(t *testing.T) {
 				_, err := rand.Read(bs)
 				assert.NoError(t, err)
 				chk := chunks.NewChunk(bs)
-				cChk := nbs.ChunkToChunkRecord(chk, 0) // NM4
+				cChk := nbs.ChunkToChunkRecord(chk, nbs.BetaV)
 				err = wr.AddCompressedChunk(context.Background(), cChk)
 				if err != nil {
 					assert.EqualError(t, err, "this dest store throws an error")
@@ -209,7 +209,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			_, err := rand.Read(bs)
 			assert.NoError(t, err)
 			chk := chunks.NewChunk(bs)
-			cChk := nbs.ChunkToChunkRecord(chk, 0) // NM4
+			cChk := nbs.ChunkToChunkRecord(chk, nbs.BetaV)
 			err = wr.AddCompressedChunk(context.Background(), cChk)
 			assert.NoError(t, err)
 		}
@@ -237,7 +237,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			_, err := rand.Read(bs)
 			assert.NoError(t, err)
 			chk := chunks.NewChunk(bs)
-			cChk := nbs.ChunkToChunkRecord(chk, 0) // NM4
+			cChk := nbs.ChunkToChunkRecord(chk, nbs.BetaV)
 			err = wr.AddCompressedChunk(context.Background(), cChk)
 			assert.NoError(t, err)
 		}
@@ -277,7 +277,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			_, err := rand.Read(bs)
 			assert.NoError(t, err)
 			chk := chunks.NewChunk(bs)
-			cChk := nbs.ChunkToChunkRecord(chk, 0) // NM4
+			cChk := nbs.ChunkToChunkRecord(chk, nbs.BetaV)
 			err = wr.AddCompressedChunk(context.Background(), cChk)
 			assert.NoError(t, err)
 		}

--- a/go/store/datas/pull/pull_table_file_writer_test.go
+++ b/go/store/datas/pull/pull_table_file_writer_test.go
@@ -60,7 +60,7 @@ func TestPullTableFileWriter(t *testing.T) {
 				_, err := rand.Read(bs)
 				assert.NoError(t, err)
 				chk := chunks.NewChunk(bs)
-				cChk := nbs.ChunkToCompressedChunk(chk)
+				cChk := nbs.ChunkToCompressedChunk(chk, 0) // NM4
 				err = wr.AddCompressedChunk(context.Background(), cChk)
 				assert.NoError(t, err)
 			}
@@ -86,7 +86,7 @@ func TestPullTableFileWriter(t *testing.T) {
 				_, err := rand.Read(bs)
 				assert.NoError(t, err)
 				chk := chunks.NewChunk(bs)
-				cChk := nbs.ChunkToCompressedChunk(chk)
+				cChk := nbs.ChunkToCompressedChunk(chk, 0) // NM4
 				err = wr.AddCompressedChunk(context.Background(), cChk)
 				assert.NoError(t, err)
 			}
@@ -116,7 +116,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			_, err := rand.Read(bs)
 			assert.NoError(t, err)
 			chk := chunks.NewChunk(bs)
-			cChk := nbs.ChunkToCompressedChunk(chk)
+			cChk := nbs.ChunkToCompressedChunk(chk, 0) // NM4
 			err = wr.AddCompressedChunk(context.Background(), cChk)
 			assert.NoError(t, err)
 		}
@@ -144,7 +144,7 @@ func TestPullTableFileWriter(t *testing.T) {
 				_, err := rand.Read(bs)
 				assert.NoError(t, err)
 				chk := chunks.NewChunk(bs)
-				cChk := nbs.ChunkToCompressedChunk(chk)
+				cChk := nbs.ChunkToCompressedChunk(chk, 0) // NM4
 				err = wr.AddCompressedChunk(context.Background(), cChk)
 				assert.NoError(t, err)
 			}
@@ -168,7 +168,7 @@ func TestPullTableFileWriter(t *testing.T) {
 				_, err := rand.Read(bs)
 				assert.NoError(t, err)
 				chk := chunks.NewChunk(bs)
-				cChk := nbs.ChunkToCompressedChunk(chk)
+				cChk := nbs.ChunkToCompressedChunk(chk, 0) // NM4
 				err = wr.AddCompressedChunk(context.Background(), cChk)
 				assert.NoError(t, err)
 			}
@@ -179,7 +179,7 @@ func TestPullTableFileWriter(t *testing.T) {
 				_, err := rand.Read(bs)
 				assert.NoError(t, err)
 				chk := chunks.NewChunk(bs)
-				cChk := nbs.ChunkToCompressedChunk(chk)
+				cChk := nbs.ChunkToCompressedChunk(chk, 0) // NM4
 				err = wr.AddCompressedChunk(context.Background(), cChk)
 				if err != nil {
 					assert.EqualError(t, err, "this dest store throws an error")
@@ -209,7 +209,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			_, err := rand.Read(bs)
 			assert.NoError(t, err)
 			chk := chunks.NewChunk(bs)
-			cChk := nbs.ChunkToCompressedChunk(chk)
+			cChk := nbs.ChunkToCompressedChunk(chk, 0) // NM4
 			err = wr.AddCompressedChunk(context.Background(), cChk)
 			assert.NoError(t, err)
 		}
@@ -237,7 +237,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			_, err := rand.Read(bs)
 			assert.NoError(t, err)
 			chk := chunks.NewChunk(bs)
-			cChk := nbs.ChunkToCompressedChunk(chk)
+			cChk := nbs.ChunkToCompressedChunk(chk, 0) // NM4
 			err = wr.AddCompressedChunk(context.Background(), cChk)
 			assert.NoError(t, err)
 		}
@@ -277,7 +277,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			_, err := rand.Read(bs)
 			assert.NoError(t, err)
 			chk := chunks.NewChunk(bs)
-			cChk := nbs.ChunkToCompressedChunk(chk)
+			cChk := nbs.ChunkToCompressedChunk(chk, 0) // NM4
 			err = wr.AddCompressedChunk(context.Background(), cChk)
 			assert.NoError(t, err)
 		}

--- a/go/store/datas/pull/pull_table_file_writer_test.go
+++ b/go/store/datas/pull/pull_table_file_writer_test.go
@@ -60,7 +60,7 @@ func TestPullTableFileWriter(t *testing.T) {
 				_, err := rand.Read(bs)
 				assert.NoError(t, err)
 				chk := chunks.NewChunk(bs)
-				cChk := nbs.ChunkToCompressedChunk(chk, 0) // NM4
+				cChk := nbs.ChunkToChunkRecord(chk, 0) // NM4
 				err = wr.AddCompressedChunk(context.Background(), cChk)
 				assert.NoError(t, err)
 			}
@@ -86,7 +86,7 @@ func TestPullTableFileWriter(t *testing.T) {
 				_, err := rand.Read(bs)
 				assert.NoError(t, err)
 				chk := chunks.NewChunk(bs)
-				cChk := nbs.ChunkToCompressedChunk(chk, 0) // NM4
+				cChk := nbs.ChunkToChunkRecord(chk, 0) // NM4
 				err = wr.AddCompressedChunk(context.Background(), cChk)
 				assert.NoError(t, err)
 			}
@@ -116,7 +116,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			_, err := rand.Read(bs)
 			assert.NoError(t, err)
 			chk := chunks.NewChunk(bs)
-			cChk := nbs.ChunkToCompressedChunk(chk, 0) // NM4
+			cChk := nbs.ChunkToChunkRecord(chk, 0) // NM4
 			err = wr.AddCompressedChunk(context.Background(), cChk)
 			assert.NoError(t, err)
 		}
@@ -144,7 +144,7 @@ func TestPullTableFileWriter(t *testing.T) {
 				_, err := rand.Read(bs)
 				assert.NoError(t, err)
 				chk := chunks.NewChunk(bs)
-				cChk := nbs.ChunkToCompressedChunk(chk, 0) // NM4
+				cChk := nbs.ChunkToChunkRecord(chk, 0) // NM4
 				err = wr.AddCompressedChunk(context.Background(), cChk)
 				assert.NoError(t, err)
 			}
@@ -168,7 +168,7 @@ func TestPullTableFileWriter(t *testing.T) {
 				_, err := rand.Read(bs)
 				assert.NoError(t, err)
 				chk := chunks.NewChunk(bs)
-				cChk := nbs.ChunkToCompressedChunk(chk, 0) // NM4
+				cChk := nbs.ChunkToChunkRecord(chk, 0) // NM4
 				err = wr.AddCompressedChunk(context.Background(), cChk)
 				assert.NoError(t, err)
 			}
@@ -179,7 +179,7 @@ func TestPullTableFileWriter(t *testing.T) {
 				_, err := rand.Read(bs)
 				assert.NoError(t, err)
 				chk := chunks.NewChunk(bs)
-				cChk := nbs.ChunkToCompressedChunk(chk, 0) // NM4
+				cChk := nbs.ChunkToChunkRecord(chk, 0) // NM4
 				err = wr.AddCompressedChunk(context.Background(), cChk)
 				if err != nil {
 					assert.EqualError(t, err, "this dest store throws an error")
@@ -209,7 +209,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			_, err := rand.Read(bs)
 			assert.NoError(t, err)
 			chk := chunks.NewChunk(bs)
-			cChk := nbs.ChunkToCompressedChunk(chk, 0) // NM4
+			cChk := nbs.ChunkToChunkRecord(chk, 0) // NM4
 			err = wr.AddCompressedChunk(context.Background(), cChk)
 			assert.NoError(t, err)
 		}
@@ -237,7 +237,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			_, err := rand.Read(bs)
 			assert.NoError(t, err)
 			chk := chunks.NewChunk(bs)
-			cChk := nbs.ChunkToCompressedChunk(chk, 0) // NM4
+			cChk := nbs.ChunkToChunkRecord(chk, 0) // NM4
 			err = wr.AddCompressedChunk(context.Background(), cChk)
 			assert.NoError(t, err)
 		}
@@ -277,7 +277,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			_, err := rand.Read(bs)
 			assert.NoError(t, err)
 			chk := chunks.NewChunk(bs)
-			cChk := nbs.ChunkToCompressedChunk(chk, 0) // NM4
+			cChk := nbs.ChunkToChunkRecord(chk, 0) // NM4
 			err = wr.AddCompressedChunk(context.Background(), cChk)
 			assert.NoError(t, err)
 		}

--- a/go/store/datas/pull/puller.go
+++ b/go/store/datas/pull/puller.go
@@ -346,13 +346,13 @@ func batchNovel(absent hash.HashSet, batch int) (remainder hash.HashSet, batches
 }
 
 func (p *Puller) getCmp(ctx context.Context, batch hash.HashSet, tracker *PullChunkTracker) error {
-	found := make(chan nbs.CompressedChunk, 4096)
-	processed := make(chan nbs.CompressedChunk, 4096)
+	found := make(chan nbs.ChunkRecord, 4096)
+	processed := make(chan nbs.ChunkRecord, 4096)
 
 	atomic.AddUint64(&p.stats.totalSourceChunks, uint64(len(batch)))
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
-		err := p.srcChunkStore.GetManyCompressed(ctx, batch, func(ctx context.Context, c nbs.CompressedChunk) {
+		err := p.srcChunkStore.GetManyCompressed(ctx, batch, func(ctx context.Context, c nbs.ChunkRecord) {
 			atomic.AddUint64(&p.stats.fetchedSourceBytes, uint64(c.Size()))
 			atomic.AddUint64(&p.stats.fetchedSourceChunks, uint64(1))
 			select {

--- a/go/store/datas/pull/puller.go
+++ b/go/store/datas/pull/puller.go
@@ -353,7 +353,7 @@ func (p *Puller) getCmp(ctx context.Context, batch hash.HashSet, tracker *PullCh
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
 		err := p.srcChunkStore.GetManyCompressed(ctx, batch, func(ctx context.Context, c nbs.CompressedChunk) {
-			atomic.AddUint64(&p.stats.fetchedSourceBytes, uint64(len(c.FullCompressedChunk)))
+			atomic.AddUint64(&p.stats.fetchedSourceBytes, uint64(c.Size()))
 			atomic.AddUint64(&p.stats.fetchedSourceChunks, uint64(1))
 			select {
 			case found <- c:

--- a/go/store/nbs/aws_chunk_source.go
+++ b/go/store/nbs/aws_chunk_source.go
@@ -39,7 +39,7 @@ func tableExistsInChunkSource(ctx context.Context, s3 *s3ObjectReader, al awsLim
 	if n != len(magic) {
 		return false, errors.New("failed to read all data")
 	}
-	return bytes.Equal(magic, []byte(magicNumber)), nil
+	return bytes.Equal(magic, []byte(nomsBetaMagicNumber)), nil
 }
 
 func newAWSChunkSource(ctx context.Context, s3 *s3ObjectReader, al awsLimits, name hash.Hash, chunkCount uint32, q MemoryQuotaProvider, stats *Stats) (cs chunkSource, err error) {

--- a/go/store/nbs/aws_table_persister.go
+++ b/go/store/nbs/aws_table_persister.go
@@ -116,8 +116,8 @@ func (s3p awsTablePersister) key(k string) string {
 }
 
 func (s3p awsTablePersister) Persist(ctx context.Context, mt *memTable, haver chunkReader, stats *Stats) (chunkSource, error) {
-	// NM4 - temporary? I guess an AWS file is currently always v1.
-	name, data, chunkCount, err := mt.write(haver, nomsBetaVersion, stats)
+	// Currently we only allow nbs.BetaV format for table files in S3.
+	name, data, chunkCount, err := mt.write(haver, BetaV, stats)
 
 	if err != nil {
 		return emptyChunkSource{}, err

--- a/go/store/nbs/aws_table_persister.go
+++ b/go/store/nbs/aws_table_persister.go
@@ -116,7 +116,8 @@ func (s3p awsTablePersister) key(k string) string {
 }
 
 func (s3p awsTablePersister) Persist(ctx context.Context, mt *memTable, haver chunkReader, stats *Stats) (chunkSource, error) {
-	name, data, chunkCount, err := mt.write(haver, stats)
+	// NM4 - temporary? I guess an AWS file is currently always v1.
+	name, data, chunkCount, err := mt.write(haver, nomsBetaVersion, stats)
 
 	if err != nil {
 		return emptyChunkSource{}, err

--- a/go/store/nbs/aws_table_persister_test.go
+++ b/go/store/nbs/aws_table_persister_test.go
@@ -504,7 +504,7 @@ func bytesToChunkSource(t *testing.T, bs ...[]byte) chunkSource {
 	}
 	maxSize := maxTableSize(uint64(len(bs)), uint64(sum))
 	buff := make([]byte, maxSize)
-	tw := newTableWriter(buff, nomsBetaVersion, nil)
+	tw := newTableWriter(buff, BetaV, nil)
 	for _, b := range bs {
 		tw.addChunk(computeAddr(b), b)
 	}

--- a/go/store/nbs/aws_table_persister_test.go
+++ b/go/store/nbs/aws_table_persister_test.go
@@ -504,7 +504,7 @@ func bytesToChunkSource(t *testing.T, bs ...[]byte) chunkSource {
 	}
 	maxSize := maxTableSize(uint64(len(bs)), uint64(sum))
 	buff := make([]byte, maxSize)
-	tw := newTableWriter(buff, nil)
+	tw := newTableWriter(buff, nomsBetaVersion, nil)
 	for _, b := range bs {
 		tw.addChunk(computeAddr(b), b)
 	}

--- a/go/store/nbs/bs_persister.go
+++ b/go/store/nbs/bs_persister.go
@@ -46,7 +46,7 @@ var _ tableFilePersister = &blobstorePersister{}
 // Persist makes the contents of mt durable. Chunks already present in
 // |haver| may be dropped in the process.
 func (bsp *blobstorePersister) Persist(ctx context.Context, mt *memTable, haver chunkReader, stats *Stats) (chunkSource, error) {
-	address, data, chunkCount, err := mt.write(haver, stats)
+	address, data, chunkCount, err := mt.write(haver, nomsBetaVersion, stats)
 	if err != nil {
 		return emptyChunkSource{}, err
 	} else if chunkCount == 0 {

--- a/go/store/nbs/bs_persister.go
+++ b/go/store/nbs/bs_persister.go
@@ -46,7 +46,7 @@ var _ tableFilePersister = &blobstorePersister{}
 // Persist makes the contents of mt durable. Chunks already present in
 // |haver| may be dropped in the process.
 func (bsp *blobstorePersister) Persist(ctx context.Context, mt *memTable, haver chunkReader, stats *Stats) (chunkSource, error) {
-	address, data, chunkCount, err := mt.write(haver, nomsBetaVersion, stats)
+	address, data, chunkCount, err := mt.write(haver, BetaV, stats)
 	if err != nil {
 		return emptyChunkSource{}, err
 	} else if chunkCount == 0 {

--- a/go/store/nbs/chunk_record.go
+++ b/go/store/nbs/chunk_record.go
@@ -1,0 +1,153 @@
+// Copyright 2019-2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package nbs
+
+import (
+	"errors"
+
+	"encoding/binary"
+
+	"github.com/golang/snappy"
+
+	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/hash"
+)
+
+var EmptyCompressedChunk CompressedChunk
+
+func init() {
+	EmptyCompressedChunk = ChunkToCompressedChunk(chunks.EmptyChunk, nomsBetaVersion)
+}
+
+// CompressedChunk represents a chunk of data in a table file which is still compressed, either raw data compressed with
+// snappy, or delta compressed type info preserved.
+type CompressedChunk struct {
+	// H is the hash of the chunk
+	H hash.Hash
+
+	// FullCompressedChunk is the entirety of the compressed chunk data including the crc
+	fullCompressedChunk []byte
+
+	// CompressedData is just the snappy encoded byte buffer that stores the chunk data
+	CompressedData []byte
+
+	nbsVer uint8 // NM4 - not sure if we want this. Everywhere we use these objects we should have the version near at hand. TBD.
+
+	// The full size of the chunk, including the type byte and the crc. This is how much space the chunk takes up on disk.
+	fullSize uint32
+}
+
+func (cmp CompressedChunk) Size() uint32 {
+	return cmp.fullSize
+}
+
+func (cmp CompressedChunk) WritableData() []byte {
+	return cmp.fullCompressedChunk
+}
+
+// NBSVersion returns the version of the noms data format that this chunk is encoded with. This is required in cases
+// where the origin of the CompressedChunk us unknown, and user of the object must ensure that the data is encoded
+// in the correct format.
+func (cmp CompressedChunk) NBSVersion() uint8 {
+	return cmp.nbsVer
+}
+
+// NewCompressedChunk creates a CompressedChunk, using the full chunk record bytes, which includes the crc.
+// Will error in the event that the crc does not match the data.
+func NewCompressedChunk(h hash.Hash, buff []byte, nbsVersion uint8) (CompressedChunk, error) {
+	fullSize := uint32(len(buff))
+	dataLen := uint64(len(buff)) - checksumSize
+	chksum := binary.BigEndian.Uint32(buff[dataLen:])
+
+	crcSum := crc(buff[:dataLen])
+
+	fullbuff := buff
+	if nbsVersion >= doltRev1Version {
+		// First byte is indicating metadata about the chunk. It is not part of the compressed payload, but is included
+		// in the CRC calculation.
+		// We don't use yet, but we need to skip it.
+		if buff[0] != 0 {
+			return CompressedChunk{}, errors.New("invalid chunk data - chunk type byte is not 0")
+		}
+
+		dataLen--
+		buff = buff[1:]
+	}
+
+	compressedData := buff[:dataLen]
+
+	if chksum != crcSum {
+		return CompressedChunk{}, errors.New("checksum error")
+	}
+
+	// NM4 - not sure if we want to continue carrying around the originam buff.
+	return CompressedChunk{H: h, fullCompressedChunk: fullbuff, fullSize: fullSize, CompressedData: compressedData, nbsVer: nbsVersion}, nil
+}
+
+// ToChunk snappy decodes the compressed data and returns a chunks.Chunk
+func (cmp CompressedChunk) ToChunk() (chunks.Chunk, error) {
+	data, err := snappy.Decode(nil, cmp.CompressedData)
+
+	if err != nil {
+		return chunks.Chunk{}, err
+	}
+
+	// NM4 - We don't verify the hash?? See comment in NewChunkWithHash which assume the caller trusts the Hash. We
+	// verify the CRC in NewCompressedChunk, but not the hash. I believe this is for per reasons. For my testing, I'd
+	// like to verify the hash here.
+
+	return chunks.NewChunkWithHash(cmp.H, data), nil
+}
+
+func ChunkToCompressedChunk(chunk chunks.Chunk, nbsVersion uint8) CompressedChunk {
+	// NM4 - need to figure out the optimal allocation strategy for this.
+	// See previous comment in history about snappy.MaxEncodedLen
+	raw := make([]byte, 1+checksumSize+snappy.MaxEncodedLen(chunk.Size()))
+	offset := 0
+
+	if nbsVersion >= doltRev1Version {
+		raw = append(raw, 0) // NM4.
+		offset++
+	}
+
+	compressed := snappy.Encode(raw[offset:], chunk.Data())
+	offset += len(compressed)
+
+	raw = append(raw, []byte{0, 0, 0, 0}...)
+	binary.BigEndian.PutUint32(raw[offset:], crc(raw[:offset]))
+	return CompressedChunk{H: chunk.Hash(), fullCompressedChunk: raw[:(offset + checksumSize)], CompressedData: raw[:offset], fullSize: uint32(offset + checksumSize), nbsVer: nbsVersion}
+}
+
+// Hash returns the hash of the data
+func (cmp CompressedChunk) Hash() hash.Hash {
+	return cmp.H
+}
+
+// IsEmpty returns true if the chunk contains no data.
+func (cmp CompressedChunk) IsEmpty() bool {
+	return len(cmp.CompressedData) == 0 || (len(cmp.CompressedData) == 1 && cmp.CompressedData[0] == 0)
+}
+
+// CompressedSize returns the size of this CompressedChunk.
+func (cmp CompressedChunk) CompressedSize() int {
+	return len(cmp.CompressedData)
+}

--- a/go/store/nbs/chunk_record.go
+++ b/go/store/nbs/chunk_record.go
@@ -60,18 +60,6 @@ type ChunkRecord struct {
 	rawChunkSize uint32
 }
 
-func (cmp ChunkRecord) Size() uint32 {
-	return cmp.fullSize
-}
-
-func (cmp ChunkRecord) RawChunkSize() uint32 {
-	return cmp.rawChunkSize
-}
-
-func (cmp ChunkRecord) WritableData() []byte {
-	return cmp.fullCompressedChunk
-}
-
 // NBSVersion returns the version of the noms data format that this chunk is encoded with. This is required in cases
 // where the origin of the ChunkRecord us unknown, and user of the object must ensure that the data is encoded
 // in the correct format.
@@ -159,6 +147,21 @@ func ChunkToChunkRecord(chunk chunks.Chunk, nbsVersion NbsVersion) ChunkRecord {
 		fullSize:            uint32(offset + checksumSize),
 		rawChunkSize:        uint32(rawChunkSize),
 		nbsVer:              nbsVersion}
+}
+
+// Size returns the bytes that the chunk record takes up in a table file.
+func (cmp ChunkRecord) Size() uint32 {
+	return cmp.fullSize
+}
+
+// RawChunkSize returns the size of the chunk data when it is fully resolved.
+func (cmp ChunkRecord) RawChunkSize() uint32 {
+	return cmp.rawChunkSize
+}
+
+// WritableData returns the full binary ChunkRecord that can be written to a table file.
+func (cmp ChunkRecord) WritableData() []byte {
+	return cmp.fullCompressedChunk
 }
 
 // Hash returns the hash of the data

--- a/go/store/nbs/cmp_chunk_table_writer.go
+++ b/go/store/nbs/cmp_chunk_table_writer.go
@@ -46,11 +46,11 @@ type CmpChunkTableWriter struct {
 	prefixes              prefixIndexSlice
 	blockAddr             *hash.Hash
 	path                  string
-	nbsVer                uint8
+	nbsVer                NbsVersion
 }
 
 // NewCmpChunkTableWriter creates a new CmpChunkTableWriter instance with a default ByteSink
-func NewCmpChunkTableWriter(tempDir string, nbsVersion uint8) (*CmpChunkTableWriter, error) {
+func NewCmpChunkTableWriter(tempDir string, nbsVersion NbsVersion) (*CmpChunkTableWriter, error) {
 	s, err := NewBufferedFileByteSink(tempDir, defaultTableSinkBlockSize, defaultChBufferSize)
 	if err != nil {
 		return nil, err
@@ -263,9 +263,9 @@ func (tw *CmpChunkTableWriter) writeFooter() error {
 	}
 
 	switch tw.nbsVer {
-	case doltRev1Version:
+	case Dolt1V:
 		_, err = tw.sink.Write([]byte(doltRev1MagicNumber))
-	case nomsBetaVersion:
+	case BetaV:
 		_, err = tw.sink.Write([]byte(nomsBetaMagicNumber))
 	default:
 		panic("unknown nbs version")

--- a/go/store/nbs/cmp_chunk_table_writer.go
+++ b/go/store/nbs/cmp_chunk_table_writer.go
@@ -99,7 +99,7 @@ func (tw *CmpChunkTableWriter) AddChunkRecord(c ChunkRecord) error {
 
 	// Stored in insertion order
 	tw.prefixes = append(tw.prefixes, prefixIndexRec{
-		c.H,
+		c.Hash(),
 		uint32(len(tw.prefixes)),
 		uint32(c.Size()),
 	})

--- a/go/store/nbs/cmp_chunk_table_writer.go
+++ b/go/store/nbs/cmp_chunk_table_writer.go
@@ -261,7 +261,7 @@ func (tw *CmpChunkTableWriter) writeFooter() error {
 	}
 
 	// magic number
-	_, err = tw.sink.Write([]byte(magicNumber))
+	_, err = tw.sink.Write([]byte(nomsBetaMagicNumber))
 
 	if err != nil {
 		return err

--- a/go/store/nbs/cmp_chunk_table_writer.go
+++ b/go/store/nbs/cmp_chunk_table_writer.go
@@ -216,8 +216,7 @@ func (tw *CmpChunkTableWriter) writeIndex() (gohash.Hash, error) {
 		if n != hash.PrefixLen {
 			return nil, errors.New("failed to copy all data")
 		}
-
-		pos += n
+		pos += hash.PrefixLen
 
 		// order
 		binary.BigEndian.PutUint32(buff[pos:], pi.order)

--- a/go/store/nbs/cmp_chunk_table_writer.go
+++ b/go/store/nbs/cmp_chunk_table_writer.go
@@ -86,8 +86,8 @@ func (tw *CmpChunkTableWriter) AddCmpChunk(c CompressedChunk) error {
 		return err
 	}
 
-	fullLen := len(c.FullCompressedChunk)
-	_, err = tw.sink.Write(c.FullCompressedChunk)
+	fullLen := c.Size()
+	_, err = tw.sink.Write(c.WritableData())
 
 	if err != nil {
 		return err

--- a/go/store/nbs/cmp_chunk_table_writer_test.go
+++ b/go/store/nbs/cmp_chunk_table_writer_test.go
@@ -56,7 +56,7 @@ func TestCmpChunkTableWriter(t *testing.T) {
 	require.NoError(t, eg.Wait())
 
 	// for all the chunks we find, write them using the compressed writer
-	tw, err := NewCmpChunkTableWriter("")
+	tw, err := NewCmpChunkTableWriter("", 0) // NM4
 	require.NoError(t, err)
 	for _, cmpChnk := range found {
 		err = tw.AddCmpChunk(cmpChnk)
@@ -67,7 +67,7 @@ func TestCmpChunkTableWriter(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("ErrDuplicateChunkWritten", func(t *testing.T) {
-		tw, err := NewCmpChunkTableWriter("")
+		tw, err := NewCmpChunkTableWriter("", 0) // NM4
 		require.NoError(t, err)
 		for _, cmpChnk := range found {
 			err = tw.AddCmpChunk(cmpChnk)

--- a/go/store/nbs/cmp_chunk_table_writer_test.go
+++ b/go/store/nbs/cmp_chunk_table_writer_test.go
@@ -48,10 +48,10 @@ func TestCmpChunkTableWriter(t *testing.T) {
 	}
 
 	reqs := toGetRecords(hashes)
-	found := make([]CompressedChunk, 0)
+	found := make([]ChunkRecord, 0)
 
 	eg, egCtx := errgroup.WithContext(ctx)
-	_, err = tr.getManyCompressed(egCtx, eg, reqs, func(ctx context.Context, c CompressedChunk) { found = append(found, c) }, &Stats{})
+	_, err = tr.getManyCompressed(egCtx, eg, reqs, func(ctx context.Context, c ChunkRecord) { found = append(found, c) }, &Stats{})
 	require.NoError(t, err)
 	require.NoError(t, eg.Wait())
 
@@ -59,7 +59,7 @@ func TestCmpChunkTableWriter(t *testing.T) {
 	tw, err := NewCmpChunkTableWriter("", 0) // NM4
 	require.NoError(t, err)
 	for _, cmpChnk := range found {
-		err = tw.AddCmpChunk(cmpChnk)
+		err = tw.AddChunkRecord(cmpChnk)
 		require.NoError(t, err)
 	}
 
@@ -70,9 +70,9 @@ func TestCmpChunkTableWriter(t *testing.T) {
 		tw, err := NewCmpChunkTableWriter("", 0) // NM4
 		require.NoError(t, err)
 		for _, cmpChnk := range found {
-			err = tw.AddCmpChunk(cmpChnk)
+			err = tw.AddChunkRecord(cmpChnk)
 			require.NoError(t, err)
-			err = tw.AddCmpChunk(cmpChnk)
+			err = tw.AddChunkRecord(cmpChnk)
 			require.NoError(t, err)
 		}
 		_, err = tw.Finish()

--- a/go/store/nbs/cmp_chunk_table_writer_test.go
+++ b/go/store/nbs/cmp_chunk_table_writer_test.go
@@ -56,7 +56,7 @@ func TestCmpChunkTableWriter(t *testing.T) {
 	require.NoError(t, eg.Wait())
 
 	// for all the chunks we find, write them using the compressed writer
-	tw, err := NewCmpChunkTableWriter("", 0) // NM4
+	tw, err := NewCmpChunkTableWriter("", BetaV)
 	require.NoError(t, err)
 	for _, cmpChnk := range found {
 		err = tw.AddChunkRecord(cmpChnk)
@@ -67,7 +67,7 @@ func TestCmpChunkTableWriter(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("ErrDuplicateChunkWritten", func(t *testing.T) {
-		tw, err := NewCmpChunkTableWriter("", 0) // NM4
+		tw, err := NewCmpChunkTableWriter("", BetaV)
 		require.NoError(t, err)
 		for _, cmpChnk := range found {
 			err = tw.AddChunkRecord(cmpChnk)

--- a/go/store/nbs/empty_chunk_source.go
+++ b/go/store/nbs/empty_chunk_source.go
@@ -50,7 +50,7 @@ func (ecs emptyChunkSource) getMany(ctx context.Context, eg *errgroup.Group, req
 	return true, nil
 }
 
-func (ecs emptyChunkSource) getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, CompressedChunk), stats *Stats) (bool, error) {
+func (ecs emptyChunkSource) getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, ChunkRecord), stats *Stats) (bool, error) {
 	return true, nil
 }
 

--- a/go/store/nbs/file_table_persister.go
+++ b/go/store/nbs/file_table_persister.go
@@ -86,9 +86,9 @@ func (ftp *fsTablePersister) Persist(ctx context.Context, mt *memTable, haver ch
 	defer stats.PersistLatency.SampleTimeSince(t1)
 
 	// NM4 - All fully materialized should use the new version for this test???
-	ver := nomsBetaVersion
+	ver := BetaV
 	if _, ok := os.LookupEnv("DOLT_NBS_EXP"); ok {
-		ver = doltRev1Version
+		ver = Dolt1V
 	}
 
 	name, data, chunkCount, err := mt.write(haver, ver, stats)

--- a/go/store/nbs/file_table_persister.go
+++ b/go/store/nbs/file_table_persister.go
@@ -85,7 +85,6 @@ func (ftp *fsTablePersister) Persist(ctx context.Context, mt *memTable, haver ch
 	t1 := time.Now()
 	defer stats.PersistLatency.SampleTimeSince(t1)
 
-	// NM4 - All fully materialized should use the new version for this test???
 	ver := BetaV
 	if _, ok := os.LookupEnv("DOLT_NBS_EXP"); ok {
 		ver = Dolt1V
@@ -193,7 +192,6 @@ func (ftp *fsTablePersister) persistTable(ctx context.Context, name hash.Hash, d
 			}
 		}()
 
-		// NM4 - Wholesale dump of the bytes from the memory table here. This kind of fucks us.
 		_, ferr = io.Copy(temp, bytes.NewReader(data))
 		if ferr != nil {
 			return "", cleanup, ferr

--- a/go/store/nbs/gc_copier.go
+++ b/go/store/nbs/gc_copier.go
@@ -48,7 +48,7 @@ type gcCopier struct {
 }
 
 func newGarbageCollectionCopier() (*gcCopier, error) {
-	writer, err := NewCmpChunkTableWriter("")
+	writer, err := NewCmpChunkTableWriter("", 0) // NM4 - should this trigger on the env var? probably
 	if err != nil {
 		return nil, err
 	}

--- a/go/store/nbs/gc_copier.go
+++ b/go/store/nbs/gc_copier.go
@@ -48,7 +48,7 @@ type gcCopier struct {
 }
 
 func newGarbageCollectionCopier() (*gcCopier, error) {
-	writer, err := NewCmpChunkTableWriter("", 0) // NM4 - should this trigger on the env var? probably
+	writer, err := NewCmpChunkTableWriter("", BetaV)
 	if err != nil {
 		return nil, err
 	}

--- a/go/store/nbs/gc_copier.go
+++ b/go/store/nbs/gc_copier.go
@@ -55,8 +55,8 @@ func newGarbageCollectionCopier() (*gcCopier, error) {
 	return &gcCopier{writer}, nil
 }
 
-func (gcc *gcCopier) addChunk(ctx context.Context, c CompressedChunk) error {
-	return gcc.writer.AddCmpChunk(c)
+func (gcc *gcCopier) addChunk(ctx context.Context, c ChunkRecord) error {
+	return gcc.writer.AddChunkRecord(c)
 }
 
 func (gcc *gcCopier) copyTablesToDir(ctx context.Context, tfp tableFilePersister) (ts []tableSpec, err error) {

--- a/go/store/nbs/generational_chunk_store.go
+++ b/go/store/nbs/generational_chunk_store.go
@@ -137,10 +137,10 @@ func (gcs *GenerationalNBS) GetMany(ctx context.Context, hashes hash.HashSet, fo
 	return gcs.ghostGen.GetMany(ctx, notFound, found)
 }
 
-func (gcs *GenerationalNBS) GetManyCompressed(ctx context.Context, hashes hash.HashSet, found func(context.Context, CompressedChunk)) error {
+func (gcs *GenerationalNBS) GetManyCompressed(ctx context.Context, hashes hash.HashSet, found func(context.Context, ChunkRecord)) error {
 	mu := &sync.Mutex{}
 	notInOldGen := hashes.Copy()
-	err := gcs.oldGen.GetManyCompressed(ctx, hashes, func(ctx context.Context, chunk CompressedChunk) {
+	err := gcs.oldGen.GetManyCompressed(ctx, hashes, func(ctx context.Context, chunk ChunkRecord) {
 		func() {
 			mu.Lock()
 			defer mu.Unlock()

--- a/go/store/nbs/journal.go
+++ b/go/store/nbs/journal.go
@@ -259,7 +259,7 @@ func (j *ChunkJournal) Persist(ctx context.Context, mt *memTable, haver chunkRea
 			continue
 		}
 		c := chunks.NewChunkWithHash(hash.Hash(*record.a), mt.chunks[*record.a])
-		err := j.wr.writeCompressedChunk(ChunkToCompressedChunk(c))
+		err := j.wr.writeCompressedChunk(ChunkToCompressedChunk(c, nomsBetaVersion))
 		if err != nil {
 			return nil, err
 		}

--- a/go/store/nbs/journal.go
+++ b/go/store/nbs/journal.go
@@ -259,7 +259,7 @@ func (j *ChunkJournal) Persist(ctx context.Context, mt *memTable, haver chunkRea
 			continue
 		}
 		c := chunks.NewChunkWithHash(hash.Hash(*record.a), mt.chunks[*record.a])
-		err := j.wr.writeCompressedChunk(ChunkToChunkRecord(c, nomsBetaVersion))
+		err := j.wr.writeCompressedChunk(ChunkToChunkRecord(c, BetaV))
 		if err != nil {
 			return nil, err
 		}

--- a/go/store/nbs/journal.go
+++ b/go/store/nbs/journal.go
@@ -646,6 +646,7 @@ func containsJournalSpec(specs []tableSpec) (ok bool) {
 	for _, spec := range specs {
 		if spec.name == journalAddr {
 			ok = true
+			break
 		}
 	}
 	return

--- a/go/store/nbs/journal.go
+++ b/go/store/nbs/journal.go
@@ -259,7 +259,7 @@ func (j *ChunkJournal) Persist(ctx context.Context, mt *memTable, haver chunkRea
 			continue
 		}
 		c := chunks.NewChunkWithHash(hash.Hash(*record.a), mt.chunks[*record.a])
-		err := j.wr.writeCompressedChunk(ChunkToCompressedChunk(c, nomsBetaVersion))
+		err := j.wr.writeCompressedChunk(ChunkToChunkRecord(c, nomsBetaVersion))
 		if err != nil {
 			return nil, err
 		}

--- a/go/store/nbs/journal_chunk_source.go
+++ b/go/store/nbs/journal_chunk_source.go
@@ -51,7 +51,7 @@ func (s journalChunkSource) hasMany(addrs []hasRecord) (missing bool, err error)
 	return
 }
 
-func (s journalChunkSource) getCompressed(_ context.Context, h hash.Hash, _ *Stats) (CompressedChunk, error) {
+func (s journalChunkSource) getCompressed(_ context.Context, h hash.Hash, _ *Stats) (ChunkRecord, error) {
 	return s.journal.getCompressedChunk(h)
 }
 
@@ -90,7 +90,7 @@ func (s journalChunkSource) getMany(ctx context.Context, _ *errgroup.Group, reqs
 	return remaining, nil
 }
 
-func (s journalChunkSource) getManyCompressed(ctx context.Context, _ *errgroup.Group, reqs []getRecord, found func(context.Context, CompressedChunk), stats *Stats) (bool, error) {
+func (s journalChunkSource) getManyCompressed(ctx context.Context, _ *errgroup.Group, reqs []getRecord, found func(context.Context, ChunkRecord), stats *Stats) (bool, error) {
 	var remaining bool
 	// todo: read planning
 	for i := range reqs {

--- a/go/store/nbs/journal_record.go
+++ b/go/store/nbs/journal_record.go
@@ -136,7 +136,7 @@ func writeChunkRecord(buf []byte, c ChunkRecord) (n uint32) {
 	// address
 	buf[n] = byte(addrJournalRecTag)
 	n += journalRecTagSz
-	copy(buf[n:], c.H[:])
+	copy(buf[n:], c.h[:])
 	n += journalRecAddrSz
 	// payload
 	buf[n] = byte(payloadJournalRecTag)

--- a/go/store/nbs/journal_record.go
+++ b/go/store/nbs/journal_record.go
@@ -109,7 +109,7 @@ func chunkRecordSize(c CompressedChunk) (recordSz, payloadOff uint32) {
 	recordSz += journalRecTagSz + journalRecAddrSz
 	recordSz += journalRecTagSz // payload tag
 	payloadOff = recordSz
-	recordSz += uint32(len(c.FullCompressedChunk))
+	recordSz += c.Size()
 	recordSz += journalRecChecksumSz
 	return
 }
@@ -141,8 +141,8 @@ func writeChunkRecord(buf []byte, c CompressedChunk) (n uint32) {
 	// payload
 	buf[n] = byte(payloadJournalRecTag)
 	n += journalRecTagSz
-	copy(buf[n:], c.FullCompressedChunk)
-	n += uint32(len(c.FullCompressedChunk))
+	copy(buf[n:], c.WritableData())
+	n += c.Size()
 	// checksum
 	writeUint32(buf[n:], crc(buf[:n]))
 	n += journalRecChecksumSz

--- a/go/store/nbs/journal_record.go
+++ b/go/store/nbs/journal_record.go
@@ -103,7 +103,7 @@ var journalRecordTimestampGenerator = func() uint64 {
 	return uint64(time.Now().Unix())
 }
 
-func chunkRecordSize(c CompressedChunk) (recordSz, payloadOff uint32) {
+func chunkRecordSize(c ChunkRecord) (recordSz, payloadOff uint32) {
 	recordSz += journalRecLenSz
 	recordSz += journalRecTagSz + journalRecKindSz
 	recordSz += journalRecTagSz + journalRecAddrSz
@@ -123,7 +123,7 @@ func rootHashRecordSize() (recordSz int) {
 	return
 }
 
-func writeChunkRecord(buf []byte, c CompressedChunk) (n uint32) {
+func writeChunkRecord(buf []byte, c ChunkRecord) (n uint32) {
 	// length
 	l, _ := chunkRecordSize(c)
 	writeUint32(buf[:journalRecLenSz], l)

--- a/go/store/nbs/journal_record_test.go
+++ b/go/store/nbs/journal_record_test.go
@@ -142,7 +142,7 @@ func randomMemTable(cnt int) (*memTable, map[hash.Hash]chunks.Chunk) {
 
 func makeChunkRecord() (journalRec, []byte) {
 	ch := chunks.NewChunk(randBuf(100))
-	cc := ChunkToChunkRecord(ch, 0) // NM4
+	cc := ChunkToChunkRecord(ch, BetaV)
 	payload := cc.WritableData()
 	sz, _ := chunkRecordSize(cc)
 
@@ -238,7 +238,7 @@ func writeCorruptJournalRecord(buf []byte) (n uint32) {
 
 func mustCompressedChunk(rec journalRec) ChunkRecord {
 	d.PanicIfFalse(rec.kind == chunkJournalRecKind)
-	cc, err := NewChunkRecord(rec.address, rec.payload, nomsBetaVersion)
+	cc, err := NewChunkRecord(rec.address, rec.payload, BetaV)
 	d.PanicIfError(err)
 	return cc
 }

--- a/go/store/nbs/journal_record_test.go
+++ b/go/store/nbs/journal_record_test.go
@@ -159,7 +159,7 @@ func makeChunkRecord() (journalRec, []byte) {
 	// address
 	buf[n] = byte(addrJournalRecTag)
 	n += journalRecTagSz
-	copy(buf[n:], cc.H[:])
+	copy(buf[n:], cc.h[:])
 	n += journalRecAddrSz
 	// payload
 	buf[n] = byte(payloadJournalRecTag)
@@ -173,7 +173,7 @@ func makeChunkRecord() (journalRec, []byte) {
 	r := journalRec{
 		length:   uint32(len(buf)),
 		kind:     chunkJournalRecKind,
-		address:  cc.H,
+		address:  cc.h,
 		payload:  payload,
 		checksum: c,
 	}

--- a/go/store/nbs/journal_record_test.go
+++ b/go/store/nbs/journal_record_test.go
@@ -142,7 +142,7 @@ func randomMemTable(cnt int) (*memTable, map[hash.Hash]chunks.Chunk) {
 
 func makeChunkRecord() (journalRec, []byte) {
 	ch := chunks.NewChunk(randBuf(100))
-	cc := ChunkToCompressedChunk(ch, 0) // NM4
+	cc := ChunkToChunkRecord(ch, 0) // NM4
 	payload := cc.WritableData()
 	sz, _ := chunkRecordSize(cc)
 
@@ -236,9 +236,9 @@ func writeCorruptJournalRecord(buf []byte) (n uint32) {
 	return
 }
 
-func mustCompressedChunk(rec journalRec) CompressedChunk {
+func mustCompressedChunk(rec journalRec) ChunkRecord {
 	d.PanicIfFalse(rec.kind == chunkJournalRecKind)
-	cc, err := NewCompressedChunk(rec.address, rec.payload, nomsBetaVersion)
+	cc, err := NewChunkRecord(rec.address, rec.payload, nomsBetaVersion)
 	d.PanicIfError(err)
 	return cc
 }

--- a/go/store/nbs/journal_record_test.go
+++ b/go/store/nbs/journal_record_test.go
@@ -238,7 +238,7 @@ func writeCorruptJournalRecord(buf []byte) (n uint32) {
 
 func mustCompressedChunk(rec journalRec) ChunkRecord {
 	d.PanicIfFalse(rec.kind == chunkJournalRecKind)
-	cc, err := NewChunkRecord(rec.address, rec.payload, BetaV)
+	cc, err := DeserializeChunkRecord(rec.address, rec.payload, BetaV)
 	d.PanicIfError(err)
 	return cc
 }

--- a/go/store/nbs/journal_record_test.go
+++ b/go/store/nbs/journal_record_test.go
@@ -142,8 +142,8 @@ func randomMemTable(cnt int) (*memTable, map[hash.Hash]chunks.Chunk) {
 
 func makeChunkRecord() (journalRec, []byte) {
 	ch := chunks.NewChunk(randBuf(100))
-	cc := ChunkToCompressedChunk(ch)
-	payload := cc.FullCompressedChunk
+	cc := ChunkToCompressedChunk(ch, 0) // NM4
+	payload := cc.WritableData()
 	sz, _ := chunkRecordSize(cc)
 
 	var n int

--- a/go/store/nbs/journal_record_test.go
+++ b/go/store/nbs/journal_record_test.go
@@ -238,7 +238,7 @@ func writeCorruptJournalRecord(buf []byte) (n uint32) {
 
 func mustCompressedChunk(rec journalRec) CompressedChunk {
 	d.PanicIfFalse(rec.kind == chunkJournalRecKind)
-	cc, err := NewCompressedChunk(hash.Hash(rec.address), rec.payload)
+	cc, err := NewCompressedChunk(rec.address, rec.payload, nomsBetaVersion)
 	d.PanicIfError(err)
 	return cc
 }

--- a/go/store/nbs/journal_test.go
+++ b/go/store/nbs/journal_test.go
@@ -118,7 +118,7 @@ func TestReadRecordRanges(t *testing.T) {
 		assert.Equal(t, data[h], ch1)
 
 		start, stop := rng.Offset, uint32(rng.Offset)+rng.Length
-		cc2, err := NewChunkRecord(h, buf[start:stop], nomsBetaVersion)
+		cc2, err := NewChunkRecord(h, buf[start:stop], BetaV)
 		assert.NoError(t, err)
 		ch2, err := cc2.ToChunk()
 		assert.NoError(t, err)

--- a/go/store/nbs/journal_test.go
+++ b/go/store/nbs/journal_test.go
@@ -118,7 +118,7 @@ func TestReadRecordRanges(t *testing.T) {
 		assert.Equal(t, data[h], ch1)
 
 		start, stop := rng.Offset, uint32(rng.Offset)+rng.Length
-		cc2, err := NewChunkRecord(h, buf[start:stop], BetaV)
+		cc2, err := DeserializeChunkRecord(h, buf[start:stop], BetaV)
 		assert.NoError(t, err)
 		ch2, err := cc2.ToChunk()
 		assert.NoError(t, err)

--- a/go/store/nbs/journal_test.go
+++ b/go/store/nbs/journal_test.go
@@ -118,7 +118,7 @@ func TestReadRecordRanges(t *testing.T) {
 		assert.Equal(t, data[h], ch1)
 
 		start, stop := rng.Offset, uint32(rng.Offset)+rng.Length
-		cc2, err := NewCompressedChunk(h, buf[start:stop], nomsBetaVersion)
+		cc2, err := NewChunkRecord(h, buf[start:stop], nomsBetaVersion)
 		assert.NoError(t, err)
 		ch2, err := cc2.ToChunk()
 		assert.NoError(t, err)

--- a/go/store/nbs/journal_test.go
+++ b/go/store/nbs/journal_test.go
@@ -118,7 +118,7 @@ func TestReadRecordRanges(t *testing.T) {
 		assert.Equal(t, data[h], ch1)
 
 		start, stop := rng.Offset, uint32(rng.Offset)+rng.Length
-		cc2, err := NewCompressedChunk(h, buf[start:stop])
+		cc2, err := NewCompressedChunk(h, buf[start:stop], nomsBetaVersion)
 		assert.NoError(t, err)
 		ch2, err := cc2.ToChunk()
 		assert.NoError(t, err)

--- a/go/store/nbs/journal_writer.go
+++ b/go/store/nbs/journal_writer.go
@@ -365,7 +365,7 @@ func (wr *journalWriter) writeCompressedChunk(cc ChunkRecord) error {
 	}
 	wr.unsyncd += uint64(recordLen)
 	_ = writeChunkRecord(buf, cc)
-	wr.ranges.put(cc.H, rng)
+	wr.ranges.put(cc.h, rng)
 
 	// To fulfill our durability guarantees, we technically only need to
 	// file.Sync() the journal when we commit a new root chunk. However,

--- a/go/store/nbs/journal_writer.go
+++ b/go/store/nbs/journal_writer.go
@@ -334,7 +334,7 @@ func (wr *journalWriter) getCompressedChunk(h hash.Hash) (CompressedChunk, error
 	if _, err := wr.readAt(buf, int64(r.Offset)); err != nil {
 		return CompressedChunk{}, nil
 	}
-	return NewCompressedChunk(hash.Hash(h), buf)
+	return NewCompressedChunk(hash.Hash(h), buf, nomsBetaVersion)
 }
 
 // getRange returns a Range for the chunk with addr |h|.
@@ -357,7 +357,7 @@ func (wr *journalWriter) writeCompressedChunk(cc CompressedChunk) error {
 	recordLen, payloadOff := chunkRecordSize(cc)
 	rng := Range{
 		Offset: uint64(wr.offset()) + uint64(payloadOff),
-		Length: uint32(len(cc.FullCompressedChunk)),
+		Length: cc.Size(),
 	}
 	buf, err := wr.getBytes(int(recordLen))
 	if err != nil {

--- a/go/store/nbs/journal_writer.go
+++ b/go/store/nbs/journal_writer.go
@@ -323,18 +323,18 @@ func (wr *journalWriter) hasAddr(h hash.Hash) (ok bool) {
 }
 
 // getCompressedChunk reads the CompressedChunks with addr |h|.
-func (wr *journalWriter) getCompressedChunk(h hash.Hash) (CompressedChunk, error) {
+func (wr *journalWriter) getCompressedChunk(h hash.Hash) (ChunkRecord, error) {
 	wr.lock.RLock()
 	defer wr.lock.RUnlock()
 	r, ok := wr.ranges.get(h)
 	if !ok {
-		return CompressedChunk{}, nil
+		return ChunkRecord{}, nil
 	}
 	buf := make([]byte, r.Length)
 	if _, err := wr.readAt(buf, int64(r.Offset)); err != nil {
-		return CompressedChunk{}, nil
+		return ChunkRecord{}, nil
 	}
-	return NewCompressedChunk(hash.Hash(h), buf, nomsBetaVersion)
+	return NewChunkRecord(hash.Hash(h), buf, nomsBetaVersion)
 }
 
 // getRange returns a Range for the chunk with addr |h|.
@@ -351,7 +351,7 @@ func (wr *journalWriter) getRange(h hash.Hash) (rng Range, ok bool, err error) {
 }
 
 // writeCompressedChunk writes |cc| to the journal.
-func (wr *journalWriter) writeCompressedChunk(cc CompressedChunk) error {
+func (wr *journalWriter) writeCompressedChunk(cc ChunkRecord) error {
 	wr.lock.Lock()
 	defer wr.lock.Unlock()
 	recordLen, payloadOff := chunkRecordSize(cc)

--- a/go/store/nbs/journal_writer.go
+++ b/go/store/nbs/journal_writer.go
@@ -334,7 +334,7 @@ func (wr *journalWriter) getCompressedChunk(h hash.Hash) (ChunkRecord, error) {
 	if _, err := wr.readAt(buf, int64(r.Offset)); err != nil {
 		return ChunkRecord{}, nil
 	}
-	return NewChunkRecord(hash.Hash(h), buf, nomsBetaVersion)
+	return NewChunkRecord(hash.Hash(h), buf, BetaV)
 }
 
 // getRange returns a Range for the chunk with addr |h|.

--- a/go/store/nbs/journal_writer.go
+++ b/go/store/nbs/journal_writer.go
@@ -334,7 +334,7 @@ func (wr *journalWriter) getCompressedChunk(h hash.Hash) (ChunkRecord, error) {
 	if _, err := wr.readAt(buf, int64(r.Offset)); err != nil {
 		return ChunkRecord{}, nil
 	}
-	return NewChunkRecord(hash.Hash(h), buf, BetaV)
+	return DeserializeChunkRecord(hash.Hash(h), buf, BetaV)
 }
 
 // getRange returns a Range for the chunk with addr |h|.

--- a/go/store/nbs/journal_writer_test.go
+++ b/go/store/nbs/journal_writer_test.go
@@ -259,9 +259,9 @@ func validateLookup(t *testing.T, j *journalWriter, r Range, cc CompressedChunk)
 	buf := make([]byte, r.Length)
 	_, err := j.readAt(buf, int64(r.Offset))
 	require.NoError(t, err)
-	act, err := NewCompressedChunk(cc.H, buf)
+	act, err := NewCompressedChunk(cc.H, buf, nomsBetaVersion)
 	assert.NoError(t, err)
-	assert.Equal(t, cc.FullCompressedChunk, act.FullCompressedChunk)
+	assert.Equal(t, cc.WritableData(), act.WritableData())
 }
 
 func TestJournalWriterSyncClose(t *testing.T) {
@@ -292,7 +292,7 @@ func TestJournalIndexBootstrap(t *testing.T) {
 	makeEpoch := func() (e epoch) {
 		e.records = randomCompressedChunks(64)
 		for h := range e.records {
-			e.last = hash.Hash(h)
+			e.last = h
 			break
 		}
 		return
@@ -407,7 +407,7 @@ func randomCompressedChunks(cnt int) (compressed map[hash.Hash]CompressedChunk) 
 		}
 		c := chunks.NewChunk(buf[:k])
 		buf = buf[k:]
-		compressed[c.Hash()] = ChunkToCompressedChunk(c)
+		compressed[c.Hash()] = ChunkToCompressedChunk(c, 0) // NM4
 	}
 	return
 }

--- a/go/store/nbs/journal_writer_test.go
+++ b/go/store/nbs/journal_writer_test.go
@@ -259,7 +259,7 @@ func validateLookup(t *testing.T, j *journalWriter, r Range, cc ChunkRecord) {
 	buf := make([]byte, r.Length)
 	_, err := j.readAt(buf, int64(r.Offset))
 	require.NoError(t, err)
-	act, err := NewChunkRecord(cc.h, buf, BetaV)
+	act, err := DeserializeChunkRecord(cc.h, buf, BetaV)
 	assert.NoError(t, err)
 	assert.Equal(t, cc.WritableData(), act.WritableData())
 }

--- a/go/store/nbs/journal_writer_test.go
+++ b/go/store/nbs/journal_writer_test.go
@@ -259,7 +259,7 @@ func validateLookup(t *testing.T, j *journalWriter, r Range, cc ChunkRecord) {
 	buf := make([]byte, r.Length)
 	_, err := j.readAt(buf, int64(r.Offset))
 	require.NoError(t, err)
-	act, err := NewChunkRecord(cc.H, buf, BetaV)
+	act, err := NewChunkRecord(cc.h, buf, BetaV)
 	assert.NoError(t, err)
 	assert.Equal(t, cc.WritableData(), act.WritableData())
 }
@@ -339,7 +339,7 @@ func TestJournalIndexBootstrap(t *testing.T) {
 				for _, cc := range e.records {
 					assert.NoError(t, j.writeCompressedChunk(cc))
 					if rand.Int()%10 == 0 { // periodic commits
-						assert.NoError(t, j.commitRootHash(cc.H))
+						assert.NoError(t, j.commitRootHash(cc.h))
 					}
 				}
 				o := j.offset()                             // precommit offset

--- a/go/store/nbs/journal_writer_test.go
+++ b/go/store/nbs/journal_writer_test.go
@@ -259,7 +259,7 @@ func validateLookup(t *testing.T, j *journalWriter, r Range, cc ChunkRecord) {
 	buf := make([]byte, r.Length)
 	_, err := j.readAt(buf, int64(r.Offset))
 	require.NoError(t, err)
-	act, err := NewChunkRecord(cc.H, buf, nomsBetaVersion)
+	act, err := NewChunkRecord(cc.H, buf, BetaV)
 	assert.NoError(t, err)
 	assert.Equal(t, cc.WritableData(), act.WritableData())
 }
@@ -407,7 +407,7 @@ func randomCompressedChunks(cnt int) (compressed map[hash.Hash]ChunkRecord) {
 		}
 		c := chunks.NewChunk(buf[:k])
 		buf = buf[k:]
-		compressed[c.Hash()] = ChunkToChunkRecord(c, 0) // NM4
+		compressed[c.Hash()] = ChunkToChunkRecord(c, BetaV)
 	}
 	return
 }

--- a/go/store/nbs/journal_writer_test.go
+++ b/go/store/nbs/journal_writer_test.go
@@ -234,9 +234,9 @@ func TestJournalWriterBootstrap(t *testing.T) {
 	}
 }
 
-func validateAllLookups(t *testing.T, j *journalWriter, data map[hash.Hash]CompressedChunk) {
+func validateAllLookups(t *testing.T, j *journalWriter, data map[hash.Hash]ChunkRecord) {
 	// move |data| to addr16-keyed map
-	prefixMap := make(map[addr16]CompressedChunk, len(data))
+	prefixMap := make(map[addr16]ChunkRecord, len(data))
 	var prefix addr16
 	for a, cc := range data {
 		copy(prefix[:], a[:])
@@ -255,11 +255,11 @@ func iterRangeIndex(idx rangeIndex, cb func(addr16, Range) (stop bool)) {
 	idx.cached.Iter(cb)
 }
 
-func validateLookup(t *testing.T, j *journalWriter, r Range, cc CompressedChunk) {
+func validateLookup(t *testing.T, j *journalWriter, r Range, cc ChunkRecord) {
 	buf := make([]byte, r.Length)
 	_, err := j.readAt(buf, int64(r.Offset))
 	require.NoError(t, err)
-	act, err := NewCompressedChunk(cc.H, buf, nomsBetaVersion)
+	act, err := NewChunkRecord(cc.H, buf, nomsBetaVersion)
 	assert.NoError(t, err)
 	assert.Equal(t, cc.WritableData(), act.WritableData())
 }
@@ -285,7 +285,7 @@ func newTestFilePath(t *testing.T) string {
 func TestJournalIndexBootstrap(t *testing.T) {
 	// potentially indexed region of a journal
 	type epoch struct {
-		records map[hash.Hash]CompressedChunk
+		records map[hash.Hash]ChunkRecord
 		last    hash.Hash
 	}
 
@@ -358,7 +358,7 @@ func TestJournalIndexBootstrap(t *testing.T) {
 				last, err := journal.bootstrapJournal(ctx, nil)
 				assert.NoError(t, err)
 				for _, e := range expected {
-					var act CompressedChunk
+					var act ChunkRecord
 					for a, exp := range e.records {
 						act, err = journal.getCompressedChunk(a)
 						assert.NoError(t, err)
@@ -396,8 +396,8 @@ func TestJournalIndexBootstrap(t *testing.T) {
 	}
 }
 
-func randomCompressedChunks(cnt int) (compressed map[hash.Hash]CompressedChunk) {
-	compressed = make(map[hash.Hash]CompressedChunk)
+func randomCompressedChunks(cnt int) (compressed map[hash.Hash]ChunkRecord) {
+	compressed = make(map[hash.Hash]ChunkRecord)
 	var buf []byte
 	for i := 0; i < cnt; i++ {
 		k := rand.Intn(51) + 50
@@ -407,7 +407,7 @@ func randomCompressedChunks(cnt int) (compressed map[hash.Hash]CompressedChunk) 
 		}
 		c := chunks.NewChunk(buf[:k])
 		buf = buf[k:]
-		compressed[c.Hash()] = ChunkToCompressedChunk(c, 0) // NM4
+		compressed[c.Hash()] = ChunkToChunkRecord(c, 0) // NM4
 	}
 	return
 }

--- a/go/store/nbs/mem_table.go
+++ b/go/store/nbs/mem_table.go
@@ -59,8 +59,7 @@ func writeChunksToMT(mt *memTable, chunks []chunks.Chunk) (string, []byte, error
 			return "", nil, errors.New("didn't create this memory table with enough space to add all the chunks")
 		}
 	}
-
-	// NM4 - not sure here. I believe this is always writing to the MemTable, which should always be BetaV. Right?
+	
 	var stats Stats
 	name, data, count, err := mt.write(nil, BetaV, &stats)
 

--- a/go/store/nbs/mem_table.go
+++ b/go/store/nbs/mem_table.go
@@ -60,9 +60,9 @@ func writeChunksToMT(mt *memTable, chunks []chunks.Chunk) (string, []byte, error
 		}
 	}
 
-	// NM4 - not sure here. I believe this is always writing to the MemTable, which should always be nomsBetaVersion. Right?
+	// NM4 - not sure here. I believe this is always writing to the MemTable, which should always be BetaV. Right?
 	var stats Stats
-	name, data, count, err := mt.write(nil, nomsBetaVersion, &stats)
+	name, data, count, err := mt.write(nil, BetaV, &stats)
 
 	if err != nil {
 		return "", nil, err
@@ -184,7 +184,7 @@ func (mt *memTable) getManyCompressed(ctx context.Context, eg *errgroup.Group, r
 		if data != nil {
 			c := chunks.NewChunkWithHash(hash.Hash(*r.a), data)
 			reqs[i].found = true
-			found(ctx, ChunkToChunkRecord(c, nomsBetaVersion))
+			found(ctx, ChunkToChunkRecord(c, BetaV))
 		} else {
 			remaining = true
 		}
@@ -201,7 +201,7 @@ func (mt *memTable) extract(ctx context.Context, chunks chan<- extractRecord) er
 	return nil
 }
 
-func (mt *memTable) write(haver chunkReader, nbsVersion uint8, stats *Stats) (name hash.Hash, data []byte, count uint32, err error) {
+func (mt *memTable) write(haver chunkReader, nbsVersion NbsVersion, stats *Stats) (name hash.Hash, data []byte, count uint32, err error) {
 	numChunks := uint64(len(mt.order))
 	if numChunks == 0 {
 		return hash.Hash{}, nil, 0, fmt.Errorf("mem table cannot write with zero chunks")

--- a/go/store/nbs/mem_table.go
+++ b/go/store/nbs/mem_table.go
@@ -177,14 +177,14 @@ func (mt *memTable) getMany(ctx context.Context, eg *errgroup.Group, reqs []getR
 	return remaining, nil
 }
 
-func (mt *memTable) getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, CompressedChunk), stats *Stats) (bool, error) {
+func (mt *memTable) getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, ChunkRecord), stats *Stats) (bool, error) {
 	var remaining bool
 	for i, r := range reqs {
 		data := mt.chunks[*r.a]
 		if data != nil {
 			c := chunks.NewChunkWithHash(hash.Hash(*r.a), data)
 			reqs[i].found = true
-			found(ctx, ChunkToCompressedChunk(c, nomsBetaVersion))
+			found(ctx, ChunkToChunkRecord(c, nomsBetaVersion))
 		} else {
 			remaining = true
 		}

--- a/go/store/nbs/mem_table_test.go
+++ b/go/store/nbs/mem_table_test.go
@@ -169,7 +169,7 @@ func TestMemTableWrite(t *testing.T) {
 	defer tr2.close()
 	assert.True(tr2.has(computeAddr(chunks[2])))
 
-	_, data, count, err := mt.write(chunkReaderGroup{tr1, tr2}, &Stats{})
+	_, data, count, err := mt.write(chunkReaderGroup{tr1, tr2}, doltRev1Version, &Stats{})
 	require.NoError(t, err)
 	assert.Equal(uint32(1), count)
 
@@ -223,7 +223,7 @@ func TestMemTableSnappyWriteOutOfLine(t *testing.T) {
 	}
 	mt.snapper = &outOfLineSnappy{[]bool{false, true, false}} // chunks[1] should trigger a panic
 
-	assert.Panics(func() { mt.write(nil, &Stats{}) })
+	assert.Panics(func() { mt.write(nil, doltRev1Version, &Stats{}) })
 }
 
 type outOfLineSnappy struct {

--- a/go/store/nbs/mem_table_test.go
+++ b/go/store/nbs/mem_table_test.go
@@ -299,7 +299,7 @@ func (crg chunkReaderGroup) getMany(ctx context.Context, eg *errgroup.Group, req
 	return true, nil
 }
 
-func (crg chunkReaderGroup) getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, CompressedChunk), stats *Stats) (bool, error) {
+func (crg chunkReaderGroup) getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, ChunkRecord), stats *Stats) (bool, error) {
 	for _, haver := range crg {
 		remaining, err := haver.getManyCompressed(ctx, eg, reqs, found, stats)
 		if err != nil {

--- a/go/store/nbs/mem_table_test.go
+++ b/go/store/nbs/mem_table_test.go
@@ -169,7 +169,7 @@ func TestMemTableWrite(t *testing.T) {
 	defer tr2.close()
 	assert.True(tr2.has(computeAddr(chunks[2])))
 
-	_, data, count, err := mt.write(chunkReaderGroup{tr1, tr2}, doltRev1Version, &Stats{})
+	_, data, count, err := mt.write(chunkReaderGroup{tr1, tr2}, Dolt1V, &Stats{})
 	require.NoError(t, err)
 	assert.Equal(uint32(1), count)
 
@@ -223,7 +223,7 @@ func TestMemTableSnappyWriteOutOfLine(t *testing.T) {
 	}
 	mt.snapper = &outOfLineSnappy{[]bool{false, true, false}} // chunks[1] should trigger a panic
 
-	assert.Panics(func() { mt.write(nil, doltRev1Version, &Stats{}) })
+	assert.Panics(func() { mt.write(nil, Dolt1V, &Stats{}) })
 }
 
 type outOfLineSnappy struct {

--- a/go/store/nbs/nbs_metrics_wrapper.go
+++ b/go/store/nbs/nbs_metrics_wrapper.go
@@ -91,7 +91,7 @@ func (nbsMW *NBSMetricWrapper) PruneTableFiles(ctx context.Context) error {
 // GetManyCompressed gets the compressed Chunks with |hashes| from the store. On return,
 // |found| will have been fully sent all chunks which have been
 // found. Any non-present chunks will silently be ignored.
-func (nbsMW *NBSMetricWrapper) GetManyCompressed(ctx context.Context, hashes hash.HashSet, found func(context.Context, CompressedChunk)) error {
+func (nbsMW *NBSMetricWrapper) GetManyCompressed(ctx context.Context, hashes hash.HashSet, found func(context.Context, ChunkRecord)) error {
 	atomic.AddInt32(&nbsMW.TotalChunkGets, int32(len(hashes)))
 	return nbsMW.nbs.GetManyCompressed(ctx, hashes, found)
 }

--- a/go/store/nbs/no_conjoin_bs_persister.go
+++ b/go/store/nbs/no_conjoin_bs_persister.go
@@ -41,7 +41,7 @@ var _ tableFilePersister = &noConjoinBlobstorePersister{}
 // Persist makes the contents of mt durable. Chunks already present in
 // |haver| may be dropped in the process.
 func (bsp *noConjoinBlobstorePersister) Persist(ctx context.Context, mt *memTable, haver chunkReader, stats *Stats) (chunkSource, error) {
-	address, data, chunkCount, err := mt.write(haver, stats)
+	address, data, chunkCount, err := mt.write(haver, nomsBetaVersion, stats)
 	if err != nil {
 		return emptyChunkSource{}, err
 	} else if chunkCount == 0 {

--- a/go/store/nbs/no_conjoin_bs_persister.go
+++ b/go/store/nbs/no_conjoin_bs_persister.go
@@ -41,7 +41,7 @@ var _ tableFilePersister = &noConjoinBlobstorePersister{}
 // Persist makes the contents of mt durable. Chunks already present in
 // |haver| may be dropped in the process.
 func (bsp *noConjoinBlobstorePersister) Persist(ctx context.Context, mt *memTable, haver chunkReader, stats *Stats) (chunkSource, error) {
-	address, data, chunkCount, err := mt.write(haver, nomsBetaVersion, stats)
+	address, data, chunkCount, err := mt.write(haver, BetaV, stats)
 	if err != nil {
 		return emptyChunkSource{}, err
 	} else if chunkCount == 0 {

--- a/go/store/nbs/root_tracker_test.go
+++ b/go/store/nbs/root_tracker_test.go
@@ -513,7 +513,7 @@ func (ftp fakeTablePersister) Persist(ctx context.Context, mt *memTable, haver c
 		return emptyChunkSource{}, nil
 	}
 
-	name, data, chunkCount, err := mt.write(haver, nomsBetaVersion, stats)
+	name, data, chunkCount, err := mt.write(haver, BetaV, stats)
 	if err != nil {
 		return emptyChunkSource{}, err
 	} else if chunkCount == 0 {
@@ -572,7 +572,7 @@ func compactSourcesToBuffer(sources chunkSources) (name hash.Hash, data []byte, 
 
 	maxSize := maxTableSize(uint64(chunkCount), totalData)
 	buff := make([]byte, maxSize) // This can blow up RAM
-	tw := newTableWriter(buff, nomsBetaVersion, nil)
+	tw := newTableWriter(buff, BetaV, nil)
 	errString := ""
 
 	ctx := context.Background()

--- a/go/store/nbs/root_tracker_test.go
+++ b/go/store/nbs/root_tracker_test.go
@@ -29,12 +29,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/constants"
 	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestChunkStoreZeroValue(t *testing.T) {
@@ -514,7 +513,7 @@ func (ftp fakeTablePersister) Persist(ctx context.Context, mt *memTable, haver c
 		return emptyChunkSource{}, nil
 	}
 
-	name, data, chunkCount, err := mt.write(haver, stats)
+	name, data, chunkCount, err := mt.write(haver, nomsBetaVersion, stats)
 	if err != nil {
 		return emptyChunkSource{}, err
 	} else if chunkCount == 0 {
@@ -573,7 +572,7 @@ func compactSourcesToBuffer(sources chunkSources) (name hash.Hash, data []byte, 
 
 	maxSize := maxTableSize(uint64(chunkCount), totalData)
 	buff := make([]byte, maxSize) // This can blow up RAM
-	tw := newTableWriter(buff, nil)
+	tw := newTableWriter(buff, nomsBetaVersion, nil)
 	errString := ""
 
 	ctx := context.Background()

--- a/go/store/nbs/stats_test.go
+++ b/go/store/nbs/stats_test.go
@@ -99,7 +99,7 @@ func TestStats(t *testing.T) {
 	// Now we have write IO
 	assert.Equal(uint64(1), stats(store).PersistLatency.Samples())
 	assert.Equal(uint64(3), stats(store).ChunksPerPersist.Sum())
-	assert.Equal(uint64(131), stats(store).BytesPerPersist.Sum())
+	assert.Equal(uint64(134), stats(store).BytesPerPersist.Sum())
 
 	// Now some gets that will incur read IO
 	_, err = store.Get(context.Background(), c1.Hash())
@@ -109,7 +109,7 @@ func TestStats(t *testing.T) {
 	_, err = store.Get(context.Background(), c3.Hash())
 	require.NoError(t, err)
 	assert.Equal(uint64(3), stats(store).FileReadLatency.Samples())
-	assert.Equal(uint64(27), stats(store).FileBytesPerRead.Sum())
+	assert.Equal(uint64(30), stats(store).FileBytesPerRead.Sum())
 
 	// Try A GetMany
 	chnx := make([]chunks.Chunk, 3)
@@ -129,7 +129,7 @@ func TestStats(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(uint64(4), stats(store).FileReadLatency.Samples())
-	assert.Equal(uint64(54), stats(store).FileBytesPerRead.Sum())
+	assert.Equal(uint64(60), stats(store).FileBytesPerRead.Sum())
 
 	// Force a conjoin
 	store.c = inlineConjoiner{2}

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -85,7 +85,7 @@ func makeGlobalCaches() {
 
 type NBSCompressedChunkStore interface {
 	chunks.ChunkStore
-	GetManyCompressed(context.Context, hash.HashSet, func(context.Context, CompressedChunk)) error
+	GetManyCompressed(context.Context, hash.HashSet, func(context.Context, ChunkRecord)) error
 }
 
 type NomsBlockStore struct {
@@ -890,7 +890,7 @@ func (nbs *NomsBlockStore) GetMany(ctx context.Context, hashes hash.HashSet, fou
 	})
 }
 
-func (nbs *NomsBlockStore) GetManyCompressed(ctx context.Context, hashes hash.HashSet, found func(context.Context, CompressedChunk)) error {
+func (nbs *NomsBlockStore) GetManyCompressed(ctx context.Context, hashes hash.HashSet, found func(context.Context, ChunkRecord)) error {
 	ctx, span := tracer.Start(ctx, "nbs.GetManyCompressed", trace.WithAttributes(attribute.Int("num_hashes", len(hashes))))
 	defer span.End()
 	return nbs.getManyWithFunc(ctx, hashes, func(ctx context.Context, cr chunkReader, eg *errgroup.Group, reqs []getRecord, stats *Stats) (bool, error) {
@@ -1644,7 +1644,7 @@ LOOP:
 			mu := new(sync.Mutex)
 			hashset := hash.NewHashSet(hs...)
 			found := 0
-			err := nbs.GetManyCompressed(ctx, hashset, func(ctx context.Context, c CompressedChunk) {
+			err := nbs.GetManyCompressed(ctx, hashset, func(ctx context.Context, c ChunkRecord) {
 				mu.Lock()
 				defer mu.Unlock()
 				if addErr != nil {

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -116,7 +116,8 @@ import (
   - Take the Ordinal discovered in Phase one
   - Calculate the Offset of your desired Chunk Record: Sum(Lengths[0]...Lengths[Ordinal-1])
   - Load Lengths[Ordinal] bytes from Table[Offset]
-  - Check the first 4 bytes of the loaded data against the last 4 bytes of your desired Hash. They should match, and the rest of the data is your Chunk data.
+  - Verify that the CRC of the loaded bytes matches the CRC stored in the Chunk Record.
+
 */
 
 const (

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -227,7 +227,7 @@ type chunkReader interface {
 
 	// getManyCompressed sets getRecord.found to true, and calls |found| for each present getRecord query.
 	// It returns true if any getRecord query was not found in this chunkReader.
-	getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, CompressedChunk), stats *Stats) (bool, error)
+	getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, ChunkRecord), stats *Stats) (bool, error)
 
 	// count returns the chunk count for this chunkReader.
 	count() (uint32, error)

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -148,15 +148,17 @@ const (
 	doltRev1MagicNumber = "DOLT___1"
 )
 
+type NbsVersion uint8
+
 const (
-	nomsBetaVersion uint8 = iota
-	doltRev1Version
+	BetaV NbsVersion = iota
+	Dolt1V
 )
 
 // nbsVersionMap maps magic numbers to version numbers. Version number bumps should be very uncommon.
-var nbsVersionMap = map[string]uint8{
-	nomsBetaMagicNumber: nomsBetaVersion,
-	doltRev1MagicNumber: doltRev1Version,
+var nbsVersionMap = map[string]NbsVersion{
+	nomsBetaMagicNumber: BetaV,
+	doltRev1MagicNumber: Dolt1V,
 }
 
 var crcTable = crc32.MakeTable(crc32.Castagnoli)

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -93,10 +93,11 @@ import (
    +----------------------+----------------------------------------+------------------+
 
      -Total Uncompressed Chunk Data is the sum of the uncompressed byte lengths of all contained chunk byte slices.
-     -Magic Number is the first 8 bytes of the SHA256 hash of "https://github.com/attic-labs/nbs".
+     -Magic Number the format indicator for the table file.
+       - NOMS original magic number is the first 8 bytes of the SHA256 hash of "https://github.com/attic-labs/nbs".
+       - DOLT Rev 1 is less magical: []bytes("DOLT___1")
 
     NOTE: Unsigned integer quanities, hashes and hash suffix are all encoded big-endian
-
 
   Looking up Chunks in an NBS Table
   There are two phases to loading chunk data for a given Hash from an NBS Table: Checking for the chunk's presence, and fetching the chunk's bytes. When performing a has-check, only the first phase is necessary.
@@ -126,12 +127,17 @@ const (
 	ordinalSize     = uint32Size
 	lengthSize      = uint32Size
 	offsetSize      = uint64Size
-	magicNumber     = "\xff\xb5\xd8\xc2\x24\x63\xee\x50"
-	magicNumberSize = 8 //len(magicNumber)
 	footerSize      = uint32Size + uint64Size + magicNumberSize
 	prefixTupleSize = hash.PrefixLen + ordinalSize
 	checksumSize    = uint32Size
 	maxChunkSize    = 0xffffffff // Snappy won't compress slices bigger than this
+)
+
+const (
+	magicNumberSize = 8
+	// If there was ever an example of over thinking things, it's this magic number:
+	nomsBetaMagicNumber = "\xff\xb5\xd8\xc2\x24\x63\xee\x50"
+	doltRev1MagicNumber = "DOLT___1"
 )
 
 var crcTable = crc32.MakeTable(crc32.Castagnoli)

--- a/go/store/nbs/table_index.go
+++ b/go/store/nbs/table_index.go
@@ -97,7 +97,7 @@ func ReadTableFooter(rd io.ReadSeeker) (chunkCount uint32, totalUncompressedData
 		return 0, 0, err
 	}
 
-	if string(footer[uint32Size+uint64Size:]) != magicNumber {
+	if string(footer[uint32Size+uint64Size:]) != nomsBetaMagicNumber {
 		return 0, 0, ErrInvalidTableFile
 	}
 

--- a/go/store/nbs/table_index.go
+++ b/go/store/nbs/table_index.go
@@ -189,18 +189,6 @@ func readTableIndexByCopy(ctx context.Context, rd io.ReadSeeker, q MemoryQuotaPr
 	return idx, err
 }
 
-func hashSetFromTableIndex(idx tableIndex) (hash.HashSet, error) {
-	set := hash.NewHashSet()
-	for i := uint32(0); i < idx.chunkCount(); i++ {
-		var h hash.Hash
-		if _, err := idx.indexEntry(i, &h); err != nil {
-			return nil, err
-		}
-		set.Insert(h)
-	}
-	return set, nil
-}
-
 type onHeapTableIndex struct {
 	// prefixTuples is a packed array of 12 byte tuples:
 	// (8 byte addr prefix, 4 byte uint32 ordinal)

--- a/go/store/nbs/table_index.go
+++ b/go/store/nbs/table_index.go
@@ -76,7 +76,7 @@ type tableIndex interface {
 	totalUncompressedData() uint64
 
 	// Version returns the version of the table file.
-	nbsVersion() uint8
+	nbsVersion() NbsVersion
 
 	// Close releases any resources used by this tableIndex.
 	Close() error
@@ -86,7 +86,7 @@ type tableIndex interface {
 	clone() (tableIndex, error)
 }
 
-func readTableFooter(rd io.ReadSeeker) (chunkCount uint32, totalUncompressedData uint64, version uint8, err error) {
+func readTableFooter(rd io.ReadSeeker) (chunkCount uint32, totalUncompressedData uint64, version NbsVersion, err error) {
 	footerSize := int64(magicNumberSize + uint64Size + uint32Size)
 	_, err = rd.Seek(-footerSize, io.SeekEnd)
 
@@ -220,7 +220,7 @@ type onHeapTableIndex struct {
 
 	// nbsVersion is the version of the table file based on the magic number in the footer. This will impact
 	// the generation and parsing of the table file.
-	nbsVer uint8
+	nbsVer NbsVersion
 }
 
 var _ tableIndex = &onHeapTableIndex{}
@@ -232,7 +232,7 @@ var _ tableIndex = &onHeapTableIndex{}
 // additional space) and the rest into the region of |indexBuff| previously
 // occupied by lengths. |onHeapTableIndex| computes directly on the given
 // |indexBuff| and |offsetsBuff1| buffers.
-func newOnHeapTableIndex(indexBuff []byte, offsetsBuff1 []byte, count uint32, totalUncompressedData uint64, version uint8, q MemoryQuotaProvider) (onHeapTableIndex, error) {
+func newOnHeapTableIndex(indexBuff []byte, offsetsBuff1 []byte, count uint32, totalUncompressedData uint64, version NbsVersion, q MemoryQuotaProvider) (onHeapTableIndex, error) {
 	if len(indexBuff) != int(indexSize(count)+footerSize) {
 		return onHeapTableIndex{}, ErrWrongBufferSize
 	}
@@ -521,7 +521,7 @@ func (ti onHeapTableIndex) totalUncompressedData() uint64 {
 	return ti.uncompressedSz
 }
 
-func (ti onHeapTableIndex) nbsVersion() uint8 {
+func (ti onHeapTableIndex) nbsVersion() NbsVersion {
 	return ti.nbsVer
 }
 

--- a/go/store/nbs/table_index.go
+++ b/go/store/nbs/table_index.go
@@ -320,8 +320,8 @@ func (ti onHeapTableIndex) getIndexEntry(ord uint32) indexEntry {
 	ordOff := ti.offsetAt(ord)
 	length := uint32(ordOff - prevOff)
 	return indexResult{
-		o: prevOff,
-		l: length,
+		offset: prevOff,
+		length: length,
 	}
 }
 

--- a/go/store/nbs/table_index_test.go
+++ b/go/store/nbs/table_index_test.go
@@ -258,7 +258,7 @@ func buildFakeChunkTable(chunks []fakeChunk) ([]byte, hash.Hash, error) {
 
 	buff := make([]byte, capacity)
 
-	tw := newTableWriter(buff, nomsBetaVersion, nil)
+	tw := newTableWriter(buff, BetaV, nil)
 
 	for _, chunk := range chunks {
 		tw.addChunk(chunk.address, chunk.data)

--- a/go/store/nbs/table_index_test.go
+++ b/go/store/nbs/table_index_test.go
@@ -258,7 +258,7 @@ func buildFakeChunkTable(chunks []fakeChunk) ([]byte, hash.Hash, error) {
 
 	buff := make([]byte, capacity)
 
-	tw := newTableWriter(buff, nil)
+	tw := newTableWriter(buff, nomsBetaVersion, nil)
 
 	for _, chunk := range chunks {
 		tw.addChunk(chunk.address, chunk.data)

--- a/go/store/nbs/table_persister.go
+++ b/go/store/nbs/table_persister.go
@@ -248,7 +248,7 @@ func planConjoin(sources []sourceWithSize, stats *Stats) (plan compactionPlan, e
 		pfxPos += ordinalSize
 	}
 
-	writeFooter(plan.mergedIndex[uint64(len(plan.mergedIndex))-footerSize:], plan.chunkCount, totalUncompressedData)
+	writeFooter(plan.mergedIndex[uint64(len(plan.mergedIndex))-footerSize:], plan.chunkCount, totalUncompressedData, nomsBetaVersion)
 
 	stats.BytesPerConjoin.Sample(uint64(plan.totalCompressedData) + uint64(len(plan.mergedIndex)))
 	return plan, nil

--- a/go/store/nbs/table_persister.go
+++ b/go/store/nbs/table_persister.go
@@ -248,7 +248,7 @@ func planConjoin(sources []sourceWithSize, stats *Stats) (plan compactionPlan, e
 		pfxPos += ordinalSize
 	}
 
-	writeFooter(plan.mergedIndex[uint64(len(plan.mergedIndex))-footerSize:], plan.chunkCount, totalUncompressedData, nomsBetaVersion)
+	writeFooter(plan.mergedIndex[uint64(len(plan.mergedIndex))-footerSize:], plan.chunkCount, totalUncompressedData, BetaV)
 
 	stats.BytesPerConjoin.Sample(uint64(plan.totalCompressedData) + uint64(len(plan.mergedIndex)))
 	return plan, nil

--- a/go/store/nbs/table_reader.go
+++ b/go/store/nbs/table_reader.go
@@ -76,7 +76,7 @@ type tableReader struct {
 	blockSize uint64
 
 	// NM4 - maybe this is where the nbsVer needs to live???
-	nbsVer uint8
+	nbsVer NbsVersion
 }
 
 // newTableReader parses a valid nbs table byte stream and returns a reader. buff must end with an NBS index
@@ -357,7 +357,7 @@ func (r readBatch) End() uint64 {
 	return last.offset + uint64(last.length)
 }
 
-func (s readBatch) ExtractChunkFromRead(buff []byte, idx int, version uint8) (ChunkRecord, error) {
+func (s readBatch) ExtractChunkFromRead(buff []byte, idx int, version NbsVersion) (ChunkRecord, error) {
 	rec := s[idx]
 
 	chunkStart := rec.offset - s.Start()

--- a/go/store/nbs/table_reader.go
+++ b/go/store/nbs/table_reader.go
@@ -116,16 +116,16 @@ type indexEntry interface {
 }
 
 type indexResult struct {
-	o uint64
-	l uint32
+	offset uint64
+	length uint32
 }
 
 func (ir indexResult) Offset() uint64 {
-	return ir.o
+	return ir.offset
 }
 
 func (ir indexResult) Length() uint32 {
-	return ir.l
+	return ir.length
 }
 
 type tableReaderAt interface {

--- a/go/store/nbs/table_reader.go
+++ b/go/store/nbs/table_reader.go
@@ -263,7 +263,7 @@ func (tr tableReader) get(ctx context.Context, h hash.Hash, stats *Stats) ([]byt
 		return nil, errors.New("failed to read all data")
 	}
 
-	cmp, err := NewCompressedChunk(hash.Hash(h), buff)
+	cmp, err := NewCompressedChunk(h, buff)
 
 	if err != nil {
 		return nil, err
@@ -675,7 +675,7 @@ func (tr tableReader) getRecordRanges(requests []getRecord) (map[hash.Hash]Range
 	}
 	ranges := make(map[hash.Hash]Range, len(recs))
 	for _, r := range recs {
-		ranges[hash.Hash(*r.a)] = Range{
+		ranges[*r.a] = Range{
 			Offset: r.offset,
 			Length: r.length,
 		}

--- a/go/store/nbs/table_reader.go
+++ b/go/store/nbs/table_reader.go
@@ -23,12 +23,10 @@ package nbs
 
 import (
 	"context"
-	"encoding/binary"
 	"errors"
 	"io"
 	"sort"
 
-	"github.com/golang/snappy"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/dolthub/dolt/go/store/chunks"
@@ -37,126 +35,6 @@ import (
 
 // Do not read more than 128MB at a time.
 const maxReadSize = 128 * 1024 * 1024
-
-// CompressedChunk represents a chunk of data in a table file which is still compressed, either raw data compressed with
-// snappy, or delta compressed type info preserved.
-type CompressedChunk struct {
-	// H is the hash of the chunk
-	H hash.Hash
-
-	// FullCompressedChunk is the entirety of the compressed chunk data including the crc
-	fullCompressedChunk []byte
-
-	// CompressedData is just the snappy encoded byte buffer that stores the chunk data
-	CompressedData []byte
-
-	nbsVer uint8 // NM4 - not sure if we want this. Everywhere we use these objects we should have the version near at hand. TBD.
-
-	// The full size of the chunk, including the type byte and the crc. This is how much space the chunk takes up on disk.
-	fullSize uint32
-}
-
-func (cmp CompressedChunk) Size() uint32 {
-	return cmp.fullSize
-}
-
-func (cmp CompressedChunk) WritableData() []byte {
-	return cmp.fullCompressedChunk
-}
-
-// NBSVersion returns the version of the noms data format that this chunk is encoded with. This is required in cases
-// where the origin of the CompressedChunk us unknown, and user of the object must ensure that the data is encoded
-// in the correct format.
-func (cmp CompressedChunk) NBSVersion() uint8 {
-	return cmp.nbsVer
-}
-
-// NewCompressedChunk creates a CompressedChunk, using the full chunk record bytes, which includes the crc.
-// Will error in the event that the crc does not match the data.
-func NewCompressedChunk(h hash.Hash, buff []byte, nbsVersion uint8) (CompressedChunk, error) {
-	fullSize := uint32(len(buff))
-	dataLen := uint64(len(buff)) - checksumSize
-	chksum := binary.BigEndian.Uint32(buff[dataLen:])
-
-	crcSum := crc(buff[:dataLen])
-
-	fullbuff := buff
-	if nbsVersion >= doltRev1Version {
-		// First byte is indicating metadata about the chunk. It is not part of the compressed payload, but is included
-		// in the CRC calculation.
-		// We don't use yet, but we need to skip it.
-		if buff[0] != 0 {
-			return CompressedChunk{}, errors.New("invalid chunk data - chunk type byte is not 0")
-		}
-
-		dataLen--
-		buff = buff[1:]
-	}
-
-	compressedData := buff[:dataLen]
-
-	if chksum != crcSum {
-		return CompressedChunk{}, errors.New("checksum error")
-	}
-
-	// NM4 - not sure if we want to continue carrying around the originam buff.
-	return CompressedChunk{H: h, fullCompressedChunk: fullbuff, fullSize: fullSize, CompressedData: compressedData, nbsVer: nbsVersion}, nil
-}
-
-// ToChunk snappy decodes the compressed data and returns a chunks.Chunk
-func (cmp CompressedChunk) ToChunk() (chunks.Chunk, error) {
-	data, err := snappy.Decode(nil, cmp.CompressedData)
-
-	if err != nil {
-		return chunks.Chunk{}, err
-	}
-
-	// NM4 - We don't verify the hash?? See comment in NewChunkWithHash which assume the caller trusts the Hash. We
-	// verify the CRC in NewCompressedChunk, but not the hash. I believe this is for per reasons. For my testing, I'd
-	// like to verify the hash here.
-
-	return chunks.NewChunkWithHash(cmp.H, data), nil
-}
-
-func ChunkToCompressedChunk(chunk chunks.Chunk, nbsVersion uint8) CompressedChunk {
-	// NM4 - need to figure out the optimal allocation strategy for this.
-	// See previous comment in history about snappy.MaxEncodedLen
-	raw := make([]byte, 1+checksumSize+snappy.MaxEncodedLen(chunk.Size()))
-	offset := 0
-
-	if nbsVersion >= doltRev1Version {
-		raw = append(raw, 0) // NM4.
-		offset++
-	}
-
-	compressed := snappy.Encode(raw[offset:], chunk.Data())
-	offset += len(compressed)
-
-	raw = append(raw, []byte{0, 0, 0, 0}...)
-	binary.BigEndian.PutUint32(raw[offset:], crc(raw[:offset]))
-	return CompressedChunk{H: chunk.Hash(), fullCompressedChunk: raw[:(offset + checksumSize)], CompressedData: raw[:offset], fullSize: uint32(offset + checksumSize), nbsVer: nbsVersion}
-}
-
-// Hash returns the hash of the data
-func (cmp CompressedChunk) Hash() hash.Hash {
-	return cmp.H
-}
-
-// IsEmpty returns true if the chunk contains no data.
-func (cmp CompressedChunk) IsEmpty() bool {
-	return len(cmp.CompressedData) == 0 || (len(cmp.CompressedData) == 1 && cmp.CompressedData[0] == 0)
-}
-
-// CompressedSize returns the size of this CompressedChunk.
-func (cmp CompressedChunk) CompressedSize() int {
-	return len(cmp.CompressedData)
-}
-
-var EmptyCompressedChunk CompressedChunk
-
-func init() {
-	EmptyCompressedChunk = ChunkToCompressedChunk(chunks.EmptyChunk, nomsBetaVersion)
-}
 
 // ErrInvalidTableFile is an error returned when a table file is corrupt or invalid.
 var ErrInvalidTableFile = errors.New("invalid or corrupt table file")

--- a/go/store/nbs/table_reader.go
+++ b/go/store/nbs/table_reader.go
@@ -196,7 +196,7 @@ func (tr tableReader) get(ctx context.Context, h hash.Hash, stats *Stats) ([]byt
 		return nil, errors.New("failed to read all data")
 	}
 
-	cmp, err := NewChunkRecord(h, buff, tr.nbsVer)
+	cmp, err := DeserializeChunkRecord(h, buff, tr.nbsVer)
 
 	if err != nil {
 		return nil, err
@@ -362,7 +362,7 @@ func (s readBatch) ExtractChunkFromRead(buff []byte, idx int, version NbsVersion
 
 	chunkStart := rec.offset - s.Start()
 
-	return NewChunkRecord(*rec.a, buff[chunkStart:chunkStart+uint64(rec.length)], version)
+	return DeserializeChunkRecord(*rec.a, buff[chunkStart:chunkStart+uint64(rec.length)], version)
 }
 
 func toReadBatches(offsets offsetRecSlice, blockSize uint64) []readBatch {
@@ -557,7 +557,7 @@ func (tr tableReader) extract(ctx context.Context, chunks chan<- extractRecord) 
 		if uint32(n) != or.length {
 			return errors.New("did not read all data")
 		}
-		cmp, err := NewChunkRecord(hash.Hash(*or.a), buff, tr.nbsVer)
+		cmp, err := DeserializeChunkRecord(*or.a, buff, tr.nbsVer)
 
 		if err != nil {
 			return err

--- a/go/store/nbs/table_reader_test.go
+++ b/go/store/nbs/table_reader_test.go
@@ -21,11 +21,11 @@ import (
 )
 
 func TestCompressedChunkIsEmpty(t *testing.T) {
-	if !EmptyCompressedChunk.IsEmpty() {
+	if !EmptyChunkRecord.IsEmpty() {
 		t.Fatal("EmptyCompressedChunkIsEmpty() should equal true.")
 	}
-	if !(CompressedChunk{}).IsEmpty() {
-		t.Fatal("CompressedChunk{}.IsEmpty() should equal true.")
+	if !(ChunkRecord{}).IsEmpty() {
+		t.Fatal("ChunkRecord{}.IsEmpty() should equal true.")
 	}
 }
 

--- a/go/store/nbs/table_set.go
+++ b/go/store/nbs/table_set.go
@@ -165,7 +165,7 @@ func (ts tableSet) getMany(ctx context.Context, eg *errgroup.Group, reqs []getRe
 	return f(ts.novel) && err == nil && f(ts.upstream), err
 }
 
-func (ts tableSet) getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, CompressedChunk), stats *Stats) (remaining bool, err error) {
+func (ts tableSet) getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, ChunkRecord), stats *Stats) (remaining bool, err error) {
 	f := func(css chunkSourceSet) bool {
 		for _, haver := range css {
 			remaining, err = haver.getManyCompressed(ctx, eg, reqs, found, stats)

--- a/go/store/nbs/table_test.go
+++ b/go/store/nbs/table_test.go
@@ -46,7 +46,7 @@ func buildTable(chunks [][]byte) ([]byte, hash.Hash, error) {
 
 	buff := make([]byte, capacity)
 
-	tw := newTableWriter(buff, nomsBetaVersion, nil)
+	tw := newTableWriter(buff, BetaV, nil)
 
 	for _, chunk := range chunks {
 		tw.addChunk(computeAddr(chunk), chunk)
@@ -171,7 +171,7 @@ func TestHasManySequentialPrefix(t *testing.T) {
 
 	capacity := maxTableSize(uint64(len(addrs)), totalData)
 	buff := make([]byte, capacity)
-	tw := newTableWriter(buff, nomsBetaVersion, nil)
+	tw := newTableWriter(buff, BetaV, nil)
 
 	for _, a := range addrs {
 		tw.addChunk(a, bogusData)
@@ -485,7 +485,7 @@ func TestEmpty(t *testing.T) {
 	assert := assert.New(t)
 
 	buff := make([]byte, footerSize)
-	tw := newTableWriter(buff, nomsBetaVersion, nil)
+	tw := newTableWriter(buff, BetaV, nil)
 	length, _, err := tw.finish()
 	require.NoError(t, err)
 	assert.True(length == footerSize)

--- a/go/store/nbs/table_test.go
+++ b/go/store/nbs/table_test.go
@@ -46,7 +46,7 @@ func buildTable(chunks [][]byte) ([]byte, hash.Hash, error) {
 
 	buff := make([]byte, capacity)
 
-	tw := newTableWriter(buff, nil)
+	tw := newTableWriter(buff, nomsBetaVersion, nil)
 
 	for _, chunk := range chunks {
 		tw.addChunk(computeAddr(chunk), chunk)
@@ -171,7 +171,7 @@ func TestHasManySequentialPrefix(t *testing.T) {
 
 	capacity := maxTableSize(uint64(len(addrs)), totalData)
 	buff := make([]byte, capacity)
-	tw := newTableWriter(buff, nil)
+	tw := newTableWriter(buff, nomsBetaVersion, nil)
 
 	for _, a := range addrs {
 		tw.addChunk(a, bogusData)
@@ -485,7 +485,7 @@ func TestEmpty(t *testing.T) {
 	assert := assert.New(t)
 
 	buff := make([]byte, footerSize)
-	tw := newTableWriter(buff, nil)
+	tw := newTableWriter(buff, nomsBetaVersion, nil)
 	length, _, err := tw.finish()
 	require.NoError(t, err)
 	assert.True(length == footerSize)

--- a/go/store/nbs/table_writer.go
+++ b/go/store/nbs/table_writer.go
@@ -209,7 +209,7 @@ func writeFooter(dst []byte, chunkCount uint32, uncData uint64) (consumed uint64
 	consumed += uint64Size
 
 	// magic number
-	copy(dst[consumed:], magicNumber)
+	copy(dst[consumed:], nomsBetaMagicNumber)
 	consumed += magicNumberSize
 	return
 }

--- a/go/store/nbs/util.go
+++ b/go/store/nbs/util.go
@@ -47,7 +47,7 @@ func IterChunks(ctx context.Context, rd io.ReadSeeker, cb func(chunk chunks.Chun
 				return err
 			}
 
-			cmpChnk, err := NewCompressedChunk(h, chunkBytes, idx.nbsVersion())
+			cmpChnk, err := NewChunkRecord(h, chunkBytes, idx.nbsVersion())
 			if err != nil {
 				return err
 			}

--- a/go/store/nbs/util.go
+++ b/go/store/nbs/util.go
@@ -47,7 +47,7 @@ func IterChunks(ctx context.Context, rd io.ReadSeeker, cb func(chunk chunks.Chun
 				return err
 			}
 
-			cmpChnk, err := NewChunkRecord(h, chunkBytes, idx.nbsVersion())
+			cmpChnk, err := DeserializeChunkRecord(h, chunkBytes, idx.nbsVersion())
 			if err != nil {
 				return err
 			}

--- a/go/store/nbs/util.go
+++ b/go/store/nbs/util.go
@@ -47,7 +47,7 @@ func IterChunks(ctx context.Context, rd io.ReadSeeker, cb func(chunk chunks.Chun
 				return err
 			}
 
-			cmpChnk, err := NewCompressedChunk(h, chunkBytes)
+			cmpChnk, err := NewCompressedChunk(h, chunkBytes, idx.nbsVersion())
 			if err != nil {
 				return err
 			}

--- a/go/store/spec/spec_test.go
+++ b/go/store/spec/spec_test.go
@@ -196,7 +196,10 @@ func TestNBSDatabaseSpec(t *testing.T) {
 
 		vrw := spec1.GetVRW(context.Background())
 
-		assert.Equal(s, mustValue(vrw.ReadValue(context.Background(), mustHash(s.Hash(vrw.Format())))))
+		h, err := s.Hash(vrw.Format())
+		v, e := vrw.ReadValue(context.Background(), mustHash(h, err))
+		foobar := mustValue(v, e)
+		assert.Equal(s, foobar)
 
 		// New databases can be created and read/written from.
 		store2 := filepath.Join(tmpDir, "store2")

--- a/go/store/types/value_store.go
+++ b/go/store/types/value_store.go
@@ -151,10 +151,11 @@ func NewValueStore(cs chunks.ChunkStore) *ValueStore {
 
 func newValueStoreWithCacheAndPending(cs chunks.ChunkStore, cacheSize, pendingMax uint64) *ValueStore {
 	vs := &ValueStore{
-		cs:            cs,
-		decodedChunks: sizecache.New(cacheSize),
-		versOnce:      sync.Once{},
-		gcNewAddrs:    make(hash.HashSet),
+		cs:                  cs,
+		decodedChunks:       sizecache.New(cacheSize),
+		versOnce:            sync.Once{},
+		gcNewAddrs:          make(hash.HashSet),
+		validateContentAddr: true, // NM4 - This should keep us honest while we're working on the new compression.
 	}
 	vs.gcCond = sync.NewCond(&vs.gcMu)
 	return vs


### PR DESCRIPTION
This NBS Format is step one of adding delta compression. It effectively adds a single null prefix byte to the ChunkRecord in the table file.  Key things to call out:
- CompressedChunk was renamed and pulled into it's own file - chunk_record.go. This more closely represents what it actually is.
- Needed to thread through a version identifier into the index, table writer, table reader, and chunk record. I'm not wild about this, but the code doesn't really share structures in a way that allows us track it once.
- This change is effectively a NO-OP unless you set an env var, DOLT_NBS_EXP, which will change the way that file_table_persister writes table files. All other nbsVersion information should be picked up from the table file itself, or assumed to be the legacy version if there isn't currently a way to thread through the version.
- I did not tackle the fact that there are multiple implementations of serializing the table index and footer. Currently there are only two impls which are aware of the new version. Conjoin is just going to need to wait.