### PR TITLE
[prolly] Writing a node skips writing internal addr references

### DIFF
--- a/go/store/prolly/message/message.go
+++ b/go/store/prolly/message/message.go
@@ -109,6 +109,25 @@ func WalkAddresses(ctx context.Context, msg serial.Message, cb func(ctx context.
 	}
 }
 
+func WalkInsertAddresses(ctx context.Context, msg serial.Message, cb func(ctx context.Context, addr hash.Hash) error) error {
+	id := serial.GetFileID(msg)
+	switch id {
+	case serial.ProllyTreeNodeFileID:
+		//return walkProllyMapAddresses(ctx, msg, cb)
+		return nil
+	case serial.AddressMapFileID:
+		return walkAddressMapAddresses(ctx, msg, cb)
+	case serial.MergeArtifactsFileID:
+		return walkMergeArtifactAddresses(ctx, msg, cb)
+	case serial.CommitClosureFileID:
+		return walkCommitClosureAddresses(ctx, msg, cb)
+	case serial.BlobFileID:
+		return walkBlobAddresses(ctx, msg, cb)
+	default:
+		panic(fmt.Sprintf("unknown message id %s", id))
+	}
+}
+
 func GetTreeCount(msg serial.Message) (int, error) {
 	id := serial.GetFileID(msg)
 	switch id {

--- a/go/store/prolly/message/message.go
+++ b/go/store/prolly/message/message.go
@@ -115,7 +115,7 @@ func WalkInsertAddresses(ctx context.Context, msg serial.Message, cb func(ctx co
 	case serial.ProllyTreeNodeFileID:
 		return nil
 	case serial.AddressMapFileID:
-		return nil
+		return walkAddressMapAddresses(ctx, msg, cb)
 	case serial.MergeArtifactsFileID:
 		return walkMergeArtifactAddresses(ctx, msg, cb)
 	case serial.CommitClosureFileID:

--- a/go/store/prolly/message/message.go
+++ b/go/store/prolly/message/message.go
@@ -115,13 +115,13 @@ func WalkInsertAddresses(ctx context.Context, msg serial.Message, cb func(ctx co
 	case serial.ProllyTreeNodeFileID:
 		return nil
 	case serial.AddressMapFileID:
-		return walkAddressMapAddresses(ctx, msg, cb)
+		return nil
 	case serial.MergeArtifactsFileID:
 		return walkMergeArtifactAddresses(ctx, msg, cb)
 	case serial.CommitClosureFileID:
 		return walkCommitClosureAddresses(ctx, msg, cb)
 	case serial.BlobFileID:
-		return walkBlobAddresses(ctx, msg, cb)
+		return nil
 	default:
 		panic(fmt.Sprintf("unknown message id %s", id))
 	}

--- a/go/store/prolly/message/message.go
+++ b/go/store/prolly/message/message.go
@@ -113,7 +113,6 @@ func WalkInsertAddresses(ctx context.Context, msg serial.Message, cb func(ctx co
 	id := serial.GetFileID(msg)
 	switch id {
 	case serial.ProllyTreeNodeFileID:
-		//return walkProllyMapAddresses(ctx, msg, cb)
 		return nil
 	case serial.AddressMapFileID:
 		return walkAddressMapAddresses(ctx, msg, cb)

--- a/go/store/prolly/tree/node_store.go
+++ b/go/store/prolly/tree/node_store.go
@@ -151,7 +151,7 @@ func (ns nodeStore) Write(ctx context.Context, nd Node) (hash.Hash, error) {
 
 	getAddrs := func(ctx context.Context, ch chunks.Chunk) (addrs hash.HashSet, err error) {
 		addrs = hash.NewHashSet()
-		err = message.WalkAddresses(ctx, ch.Data(), func(ctx context.Context, a hash.Hash) error {
+		err = message.WalkInsertAddresses(ctx, ch.Data(), func(ctx context.Context, a hash.Hash) error {
 			addrs.Insert(a)
 			return nil
 		})


### PR DESCRIPTION
AFAICT the previous implementation writes every internal address for a prolly node on every write. This is unnecessary when the chunker already puts every new node. This disproportionately affects large databases because a point write will add ~200 extra address writes at each full layer of the tree touched.

Re: TPC-C,  average of 3500 refs/transaction written before, vs 475 refs/transaction now (300 skipping table addresses). This appears to affect OSX more than linux unfortunately, ~40% speedup vs 10%. I've manually verified the CI numbers below, it's consistent at least.