### PR TITLE
CLI Docs: Adding docs for `system_variables` field in config.yaml for sql-server command

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -110,6 +110,8 @@ SUPPORTED CONFIG FILE FIELDS:
 
 {{.EmphasisLeft}}remotesapi.read_only{{.EmphasisRight}}: Boolean flag which disables the ability to perform pushes against the server.
 
+{{.EmphasisLeft}}system_variables{{.EmphasisRight}}: A map of system variable name to desired value for all system variable values to override.
+
 {{.EmphasisLeft}}user_session_vars{{.EmphasisRight}}: A map of user name to a map of session variables to set on connection for each session.
 
 {{.EmphasisLeft}}cluster{{.EmphasisRight}}: Settings related to running this server in a replicated cluster. For information on setting these values, see https://docs.dolthub.com/sql-reference/server/replication

--- a/go/cmd/dolt/commands/sqlserver/yaml_config.go
+++ b/go/cmd/dolt/commands/sqlserver/yaml_config.go
@@ -157,7 +157,7 @@ type YAMLConfig struct {
 	BranchControlFile *string               `yaml:"branch_control_file,omitempty"`
 	// TODO: Rename to UserVars_
 	Vars            []UserSessionVars       `yaml:"user_session_vars"`
-	SystemVars_     *engine.SystemVariables `yaml:"system_variables" minver:"1.11.1"`
+	SystemVars_     *engine.SystemVariables `yaml:"system_variables,omitempty" minver:"1.11.1"`
 	Jwks            []engine.JwksConfig     `yaml:"jwks"`
 	GoldenMysqlConn *string                 `yaml:"golden_mysql_conn,omitempty"`
 }

--- a/go/cmd/dolt/commands/sqlserver/yaml_config.go
+++ b/go/cmd/dolt/commands/sqlserver/yaml_config.go
@@ -157,7 +157,7 @@ type YAMLConfig struct {
 	BranchControlFile *string               `yaml:"branch_control_file,omitempty"`
 	// TODO: Rename to UserVars_
 	Vars            []UserSessionVars       `yaml:"user_session_vars"`
-	SystemVars_     *engine.SystemVariables `yaml:"system_variables,omitempty" minver:"1.11.1"`
+	SystemVars_     *engine.SystemVariables `yaml:"system_variables" minver:"1.11.1"`
 	Jwks            []engine.JwksConfig     `yaml:"jwks"`
 	GoldenMysqlConn *string                 `yaml:"golden_mysql_conn,omitempty"`
 }
@@ -192,6 +192,7 @@ func YamlConfigFromFile(fs filesys.Filesys, path string) (ServerConfig, error) {
 }
 
 func ServerConfigAsYAMLConfig(cfg ServerConfig) *YAMLConfig {
+	systemVars := cfg.SystemVars()
 	return &YAMLConfig{
 		LogLevelStr:       strPtr(string(cfg.LogLevel())),
 		MaxQueryLenInLogs: nillableIntPtr(cfg.MaxLoggedQueryLen()),
@@ -237,6 +238,7 @@ func ServerConfigAsYAMLConfig(cfg ServerConfig) *YAMLConfig {
 		ClusterCfg:        clusterConfigAsYAMLConfig(cfg.ClusterConfig()),
 		PrivilegeFile:     strPtr(cfg.PrivilegeFilePath()),
 		BranchControlFile: strPtr(cfg.BranchControlFilePath()),
+		SystemVars_:       &systemVars,
 		Vars:              cfg.UserVars(),
 		Jwks:              cfg.JwksConfig(),
 	}

--- a/go/cmd/dolt/commands/sqlserver/yaml_config_test.go
+++ b/go/cmd/dolt/commands/sqlserver/yaml_config_test.go
@@ -105,6 +105,7 @@ jwks:
 		},
 	}
 	expected.DataDirStr = strPtr("some nonsense")
+	expected.SystemVars_ = nil
 	expected.Vars = []UserSessionVars{
 		{
 			Name: "user0",


### PR DESCRIPTION
The [CLI docs for sql-server](https://docs.dolthub.com/cli-reference/cli#dolt-sql-server) doesn't include the `system_variables` field available in `config.yaml`.