### PR TITLE
[store] index flush buff perf

### DIFF
--- a/go/store/nbs/journal_writer.go
+++ b/go/store/nbs/journal_writer.go
@@ -420,8 +420,6 @@ func (wr *journalWriter) commitRootHashUnlocked(root hash.Hash) error {
 // flushIndexRecord writes a new record to the out-of-band journal index file. Index records
 // accelerate journal bootstrapping by reducing the amount of the journal that must be processed.
 func (wr *journalWriter) flushIndexRecord(root hash.Hash, end int64) (err error) {
-	// TODO combine these two, don't make two buffers
-	//payload := serializeLookups(wr.ranges.novelLookups())
 	size := journalIndexRecordSize(wr.ranges.novelLookups())
 	buf := make([]byte, size)
 	writeJournalIndexRecord(buf, root, size, uint64(wr.indexed), uint64(end), wr.ranges.novelLookups())


### PR DESCRIPTION
We currently serialize index lookups into a buffer, and then copy that buffer into a separate buffer. The lookups are most of the payload, so bit expensive. This cuts out the middleman, serializes directly to the payload buffer.