### PR TITLE
Allow 'old' versions of Dolt to handle future table file versions

### DIFF
--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -728,7 +728,15 @@ If you're interested in running this command against a remote host, hit us up on
 
 	if noValidRepository && isValidRepositoryRequired {
 		return func(ctx context.Context) (cli.Queryist, *sql.Context, func(), error) {
-			return nil, nil, nil, fmt.Errorf("The current directory is not a valid dolt repository.")
+			err := fmt.Errorf("The current directory is not a valid dolt repository.")
+			if rootEnv.DBLoadError == nbs.ErrUnsupportedTableFileFormat {
+				// This is fairly targeted and specific to allow for better error messaging. We should consider
+				// breaking this out into its own function if we add more conditions.
+
+				err = fmt.Errorf("The data in this database is in an unsupported format. Please upgrade to the latest version of Dolt.")
+			}
+
+			return nil, nil, nil, err
 		}, nil
 	}
 

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -729,7 +729,7 @@ If you're interested in running this command against a remote host, hit us up on
 	if noValidRepository && isValidRepositoryRequired {
 		return func(ctx context.Context) (cli.Queryist, *sql.Context, func(), error) {
 			err := fmt.Errorf("The current directory is not a valid dolt repository.")
-			if rootEnv.DBLoadError == nbs.ErrUnsupportedTableFileFormat {
+			if errors.Is(rootEnv.DBLoadError, nbs.ErrUnsupportedTableFileFormat) {
 				// This is fairly targeted and specific to allow for better error messaging. We should consider
 				// breaking this out into its own function if we add more conditions.
 

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -58,6 +58,8 @@ const (
 	defaultChunksPerTF = 256 * 1024
 )
 
+var ErrMissingDoltDataDir = errors.New("missing dolt data directory")
+
 // LocalDirDoltDB stores the db in the current directory
 var LocalDirDoltDB = "file://./" + dbfactory.DoltDataDir
 var LocalDirStatsDB = "file://./" + dbfactory.DoltStatsDir
@@ -103,7 +105,7 @@ func LoadDoltDBWithParams(ctx context.Context, nbf *types.NomsBinFormat, urlStr 
 	if urlStr == LocalDirDoltDB {
 		exists, isDir := fs.Exists(dbfactory.DoltDataDir)
 		if !exists {
-			return nil, errors.New("missing dolt data directory")
+			return nil, ErrMissingDoltDataDir
 		} else if !isDir {
 			return nil, errors.New("file exists where the dolt data directory should be")
 		}

--- a/go/libraries/doltcore/env/multi_repo_env.go
+++ b/go/libraries/doltcore/env/multi_repo_env.go
@@ -16,6 +16,7 @@ package env
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"sort"
@@ -118,6 +119,17 @@ func MultiEnvForDirectory(
 		newEnv := Load(ctx, GetCurrentUserHomeDir, newFs, doltdb.LocalDirDoltDB, version)
 		if newEnv.Valid() {
 			envSet[dbfactory.DirToDBName(dir)] = newEnv
+		} else {
+			dbErr := newEnv.DBLoadError
+			if dbErr != nil {
+				if !errors.Is(dbErr, doltdb.ErrMissingDoltDataDir) {
+					logrus.Warnf("failed to load database at %s with error: %s", path, dbErr.Error())
+				}
+			}
+			cfgErr := newEnv.CfgLoadErr
+			if cfgErr != nil {
+				logrus.Warnf("failed to load database configuration at %s with error: %s", path, cfgErr.Error())
+			}
 		}
 		return false
 	})

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -132,6 +132,9 @@ const (
 	prefixTupleSize = hash.PrefixLen + ordinalSize
 	checksumSize    = uint32Size
 	maxChunkSize    = 0xffffffff // Snappy won't compress slices bigger than this
+
+	doltMagicNumber = "DOLTARC" // NBS doesn't support this, but we want to give a reasonable error message if one is encountered.
+	doltMagicSize   = 7         // len(doltMagicNumber)
 )
 
 var crcTable = crc32.MakeTable(crc32.Castagnoli)

--- a/go/store/nbs/table_index.go
+++ b/go/store/nbs/table_index.go
@@ -98,6 +98,12 @@ func ReadTableFooter(rd io.ReadSeeker) (chunkCount uint32, totalUncompressedData
 	}
 
 	if string(footer[uint32Size+uint64Size:]) != magicNumber {
+		// Give a nice error message if this is a table file format which we will support in the future.
+		possibleDarc := string(footer[len(footer)-doltMagicSize:])
+		if possibleDarc == doltMagicNumber {
+			return 0, 0, ErrUnsupportedTableFileFormat
+		}
+
 		return 0, 0, ErrInvalidTableFile
 	}
 

--- a/go/store/nbs/table_index_test.go
+++ b/go/store/nbs/table_index_test.go
@@ -15,7 +15,9 @@
 package nbs
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"os"
@@ -227,6 +229,39 @@ func TestAmbiguousShortHash(t *testing.T) {
 			assert.Len(t, res, test.sz)
 		})
 	}
+}
+
+func TestReadTableFooter(t *testing.T) {
+	// Less than 20 bytes is not enough to read the footer
+	reader := bytes.NewReader(make([]byte, 19))
+	_, _, err := ReadTableFooter(reader)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "negative position")
+
+	data := make([]byte, 20)
+	binary.BigEndian.PutUint32(data[:4], 98765)   // Chunk Count.
+	binary.BigEndian.PutUint64(data[4:12], 12345) // Total Size
+	copy(data[12:], magicNumber)
+	reader = bytes.NewReader(data)
+	chunkCount, totalSize, err := ReadTableFooter(reader)
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(98765), chunkCount)
+	assert.Equal(t, uint64(12345), totalSize)
+
+	// Now with a future magic number
+	data[12] = 0
+	copy(data[13:], doltMagicNumber)
+	reader = bytes.NewReader(data)
+	_, _, err = ReadTableFooter(reader)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported table file format")
+
+	// Now with corrupted info that we don't recognize.
+	copy(data[12:], "DEADBEEF")
+	reader = bytes.NewReader(data)
+	_, _, err = ReadTableFooter(reader)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid or corrupt table file")
 }
 
 // fakeChunk is chunk with a faked address

--- a/go/store/nbs/table_reader.go
+++ b/go/store/nbs/table_reader.go
@@ -109,6 +109,7 @@ func init() {
 
 // ErrInvalidTableFile is an error returned when a table file is corrupt or invalid.
 var ErrInvalidTableFile = errors.New("invalid or corrupt table file")
+var ErrUnsupportedTableFileFormat = errors.New("unsupported table file format")
 
 type indexEntry interface {
 	Offset() uint64


### PR DESCRIPTION
Now that we are fairly certain that the dolt table format for compressed history files will have a new file signature, we want current versions of dolt to provide decent messages if one of those files is encountered.

Automated testing of this is tricky at the moment. I hand edited an existing table file to ensure that a sane message comes back.

Also, `dolt sql-server` doesn't currently print a message at all when a bad table file is encountered.