### PR TITLE
Add per-table locking for AutoIncrementTracker

### DIFF
--- a/go/libraries/doltcore/sqle/dsess/autoincrement_tracker.go
+++ b/go/libraries/doltcore/sqle/dsess/autoincrement_tracker.go
@@ -16,18 +16,19 @@ package dsess
 
 import (
 	"context"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess/mutexmap"
-	"github.com/dolthub/go-mysql-server/sql"
-	gmstypes "github.com/dolthub/go-mysql-server/sql/types"
 	"io"
 	"math"
 	"strings"
 	"sync"
 
+	"github.com/dolthub/go-mysql-server/sql"
+	gmstypes "github.com/dolthub/go-mysql-server/sql/types"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess/mutexmap"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/globalstate"
 	"github.com/dolthub/dolt/go/store/prolly/tree"
 	"github.com/dolthub/dolt/go/store/types"

--- a/go/libraries/doltcore/sqle/dsess/mutexmap/mutexmap.go
+++ b/go/libraries/doltcore/sqle/dsess/mutexmap/mutexmap.go
@@ -1,0 +1,65 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mutexmap
+
+import (
+	"sync"
+)
+
+// MutexMap holds a dynamic number of mutexes identified by keys. When a mutex is no longer needed, it's removed from
+// the map.
+type MutexMap struct {
+	mu           sync.Mutex // Access to the map itself must be synchronized.
+	keyedMutexes map[interface{}]*mapMutex
+}
+
+type mapMutex struct {
+	key      interface{}
+	mu       sync.Mutex
+	parent   *MutexMap
+	refcount int
+}
+
+func NewMutexMap() *MutexMap {
+	return &MutexMap{keyedMutexes: make(map[interface{}]*mapMutex)}
+}
+
+func (mm *MutexMap) Lock(key interface{}) func() {
+	mm.mu.Lock()
+	defer mm.mu.Unlock()
+
+	keyedMutex, hasKey := mm.keyedMutexes[key]
+	if !hasKey {
+		keyedMutex = &mapMutex{parent: mm, key: key}
+		mm.keyedMutexes[key] = keyedMutex
+	}
+	keyedMutex.refcount++
+
+	keyedMutex.mu.Lock()
+
+	return func() { keyedMutex.Unlock() }
+}
+
+func (mm *mapMutex) Unlock() {
+	mutexMap := mm.parent
+	mutexMap.mu.Lock()
+	defer mutexMap.mu.Unlock()
+
+	mm.refcount--
+	if mm.refcount < 1 {
+		delete(mutexMap.keyedMutexes, mm.key)
+	}
+	mm.mu.Unlock()
+}


### PR DESCRIPTION
This PR refactors the AutoIncrementTracker to hold a separate mutex for each table instead of a single mutex for the entire database.

# Why are we doing this?

This relates to supporting the `innodb_autoinc_lock_mode` variable, described here: https://github.com/dolthub/dolt/issues/7634

Currently, the engine acquires the AutoIncrementTracker lock once per inserted row and holds it only while that row is being inserted. However, when `innodb_autoinc_lock_mode` is set to any value other than its default, the engine must instead hold the lock for the duration of the insert statement.

Unfortunately, there is a specific corner case that causes `innodb_autoinc_lock_mode` to interact poorly with a single global lock: if a table has a trigger, and that trigger attempts to insert into a different table, then a second insert statement begins executing before the first insert statement completes. In this case, the engine may attempt to acquire the global lock while it's already being held.

There are four possible ways to fix this:
1 - Use reentrant/recursive locks
2 - Analyze the entire execution plan to determine whether it will require the lock, and then acquire the lock at most once.
3 - Add additional logic to determine whether a session already holds the lock and avoid reacquiring it
4 - Use per-table locks

Option 1 is controversial: golang does not support recursive mutexes by design, and their use is discouraged by many. Option 2 will hold the lock for longer than is required, which would negatively impact performance. Option 3 is error prone and may result in deadlocks if implemented incorrectly.

Thus, option 4 is the best option.

# What is the impact of this PR?

Concurrent inserts into two different tables with auto-increment columns should be faster because of reduced lock contention, at the cost of the additional overhead of managing multiple mutexes when the inserts are not concurrent. The magnitude of this impact is difficult to predict or measure, but is likely overall positive.

# Why are there no tests?

This change should have no observable effect on query results. Our existing integration test suite is comprehensive enough that if no existing integration tests break, this should be safe.