### PR TITLE
go/libraries/doltcore/dbfactory, misc: Ensure we close a *grpc.ClientConn when we are done with it.

### DIFF
--- a/go/cmd/dolt/commands/credcmds/check.go
+++ b/go/cmd/dolt/commands/credcmds/check.go
@@ -158,6 +158,7 @@ func checkCredAndPrintSuccess(ctx context.Context, dEnv *env.DoltEnv, dc creds.D
 	if err != nil {
 		return errhand.BuildDError("error: unable to connect to server with credentials.").AddCause(err).Build()
 	}
+	defer conn.Close()
 
 	grpcClient := remotesapi.NewCredentialsServiceClient(conn)
 

--- a/go/cmd/dolt/commands/credcmds/import.go
+++ b/go/cmd/dolt/commands/credcmds/import.go
@@ -173,6 +173,7 @@ func updateProfileWithCredentials(ctx context.Context, dEnv *env.DoltEnv, c cred
 	if err != nil {
 		return fmt.Errorf("error: unable to connect to server with credentials: %w", err)
 	}
+	defer conn.Close()
 	grpcClient := remotesapi.NewCredentialsServiceClient(conn)
 	resp, err := grpcClient.WhoAmI(ctx, &remotesapi.WhoAmIRequest{})
 	if err != nil {

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -596,6 +596,7 @@ type heartbeatService struct {
 	version      string
 	eventEmitter events.Emitter
 	interval     time.Duration
+	closer       func() error
 }
 
 func newHeartbeatService(version string, dEnv *env.DoltEnv) *heartbeatService {
@@ -620,7 +621,7 @@ func newHeartbeatService(version string, dEnv *env.DoltEnv) *heartbeatService {
 		return &heartbeatService{} // will be defunct on Run()
 	}
 
-	emitter, err := commands.NewEmitter(emitterType, dEnv)
+	emitter, closer, err := commands.NewEmitter(emitterType, dEnv)
 	if err != nil {
 		return &heartbeatService{} // will be defunct on Run()
 	}
@@ -631,11 +632,18 @@ func newHeartbeatService(version string, dEnv *env.DoltEnv) *heartbeatService {
 		version:      version,
 		eventEmitter: emitter,
 		interval:     duration,
+		closer:       closer,
 	}
 }
 
 func (h *heartbeatService) Init(ctx context.Context) error { return nil }
-func (h *heartbeatService) Stop() error                    { return nil }
+
+func (h *heartbeatService) Stop() error {
+	if h.closer != nil {
+		return h.closer()
+	}
+	return nil
+}
 
 func (h *heartbeatService) Run(ctx context.Context) {
 	// Faulty config settings or disabled metrics can cause us to not have a valid event emitter

--- a/go/libraries/doltcore/dbfactory/grpc.go
+++ b/go/libraries/doltcore/dbfactory/grpc.go
@@ -128,13 +128,15 @@ func (fact DoltRemoteFactory) newChunkStore(ctx context.Context, nbf *types.Noms
 	csClient := remotesapi.NewChunkStoreServiceClient(conn)
 	cs, err := remotestorage.NewDoltChunkStoreFromPath(ctx, nbf, urlObj.Path, urlObj.Host, wsValidate, csClient)
 	if err != nil {
+		conn.Close()
 		return nil, fmt.Errorf("could not access dolt url '%s': %w", urlObj.String(), err)
 	}
 	cs = cs.WithHTTPFetcher(cfg.HTTPFetcher)
+	cs.SetFinalizer(conn.Close)
 
 	if _, ok := params[NoCachingParameter]; ok {
 		cs = cs.WithNoopChunkCache()
 	}
 
-	return cs, err
+	return cs, nil
 }

--- a/go/libraries/doltcore/sqle/cluster/controller.go
+++ b/go/libraries/doltcore/sqle/cluster/controller.go
@@ -224,6 +224,9 @@ func (c *Controller) Run() {
 		c.bcReplication.Run()
 	}()
 	wg.Wait()
+	for _, client := range c.replicationClients {
+		client.closer()
+	}
 }
 
 func (c *Controller) GracefulStop() error {
@@ -1127,6 +1130,7 @@ type replicationServiceClient struct {
 	url    string
 	tls    bool
 	client replicationapi.ReplicationServiceClient
+	closer func() error
 }
 
 func (c *Controller) replicationServiceDialOptions() []grpc.DialOption {
@@ -1164,6 +1168,7 @@ func (c *Controller) replicationServiceClients(ctx context.Context) ([]*replicat
 			url:    grpcTarget,
 			tls:    c.tlsCfg != nil,
 			client: client,
+			closer: cc.Close,
 		})
 	}
 	return ret, nil

--- a/go/libraries/doltcore/sqle/cluster/mysqldb_persister.go
+++ b/go/libraries/doltcore/sqle/cluster/mysqldb_persister.go
@@ -106,6 +106,7 @@ func (r *mysqlDbReplica) Run() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.lgr.Tracef("mysqlDbReplica[%s]: running", r.client.remote)
+	defer r.client.closer()
 	for !r.shutdown {
 		if r.role != RolePrimary {
 			r.wait()

--- a/go/libraries/events/emitter.go
+++ b/go/libraries/events/emitter.go
@@ -116,13 +116,12 @@ func (we WriterEmitter) LogEventsRequest(ctx context.Context, req *eventsapi.Log
 // GrpcEmitter sends events to a GRPC service implementing the eventsapi
 type GrpcEmitter struct {
 	client eventsapi.ClientEventsServiceClient
-	conn   *grpc.ClientConn
 }
 
 // NewGrpcEmitter creates a new GrpcEmitter
 func NewGrpcEmitter(conn *grpc.ClientConn) *GrpcEmitter {
 	client := eventsapi.NewClientEventsServiceClient(conn)
-	return &GrpcEmitter{client, conn}
+	return &GrpcEmitter{client}
 }
 
 func (em *GrpcEmitter) LogEvents(ctx context.Context, version string, evts []*eventsapi.ClientEvent) error {

--- a/go/libraries/events/emitter.go
+++ b/go/libraries/events/emitter.go
@@ -116,12 +116,13 @@ func (we WriterEmitter) LogEventsRequest(ctx context.Context, req *eventsapi.Log
 // GrpcEmitter sends events to a GRPC service implementing the eventsapi
 type GrpcEmitter struct {
 	client eventsapi.ClientEventsServiceClient
+	conn   *grpc.ClientConn
 }
 
 // NewGrpcEmitter creates a new GrpcEmitter
 func NewGrpcEmitter(conn *grpc.ClientConn) *GrpcEmitter {
 	client := eventsapi.NewClientEventsServiceClient(conn)
-	return &GrpcEmitter{client}
+	return &GrpcEmitter{client, conn}
 }
 
 func (em *GrpcEmitter) LogEvents(ctx context.Context, version string, evts []*eventsapi.ClientEvent) error {


### PR DESCRIPTION
In the cluster commithook, we had a failure mode where we would leak a *grpc.ClientConn without closing it. It turns out, if an outbound request has made on a ClientConn, it will continue retrying the connection. And we would leak one on a fixed interval, resulting in ever-increasing CPU utilization.