### PR TITLE
Archive file format implemented

### DIFF
--- a/go/Godeps/LICENSES
+++ b/go/Godeps/LICENSES
@@ -8876,6 +8876,35 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ================================================================================
 
 ================================================================================
+= github.com/valyala/gozstd licensed under: =
+
+The MIT License (MIT)
+
+Copyright (c) 2018 Aliaksandr Valialkin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+= LICENSE beb6ee0edc0b866b69ed20e79514dc5e88491a1875ac7a166b8e7aed =
+================================================================================
+
+================================================================================
 = github.com/vbauerster/mpb/v8 licensed under: =
 
 This is free and unencumbered software released into the public domain.

--- a/go/cmd/dolt/commands/admin/admin.go
+++ b/go/cmd/dolt/commands/admin/admin.go
@@ -21,4 +21,5 @@ import (
 var Commands = cli.NewHiddenSubCommandHandler("admin", "Commands for directly working with Dolt storage for purposes of testing or database recovery", []cli.Command{
 	SetRefCmd{},
 	ShowRootCmd{},
+	DeltaCmd{},
 })

--- a/go/cmd/dolt/commands/admin/delta.go
+++ b/go/cmd/dolt/commands/admin/delta.go
@@ -1,0 +1,72 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admin
+
+import (
+	"context"
+
+	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/env"
+	"github.com/dolthub/dolt/go/libraries/utils/argparser"
+	"github.com/dolthub/dolt/go/store/datas"
+	"github.com/dolthub/dolt/go/store/nbs"
+)
+
+type DeltaCmd struct {
+}
+
+func (cmd DeltaCmd) Name() string {
+	return "delta"
+}
+
+// Description returns a description of the command
+func (cmd DeltaCmd) Description() string {
+	return "Hidden command to kick the tires with the new archive format."
+}
+func (cmd DeltaCmd) RequiresRepo() bool {
+	return true
+}
+func (cmd DeltaCmd) Docs() *cli.CommandDocumentation {
+	return nil
+}
+
+func (cmd DeltaCmd) ArgParser() *argparser.ArgParser {
+	ap := argparser.NewArgParserWithMaxArgs(cmd.Name(), 0)
+	return ap
+}
+func (cmd DeltaCmd) Hidden() bool {
+	return true
+}
+
+func (cmd DeltaCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
+
+	db := doltdb.HackDatasDatabaseFromDoltDB(dEnv.DoltDB)
+	cs := datas.ChunkStoreFromDatabase(db)
+	if _, ok := cs.(*nbs.GenerationalNBS); !ok {
+		cli.PrintErrln("Delta command requires a GenerationalNBS")
+		return 1
+	}
+
+	err := nbs.RunExperiment(cs, func(format string, args ...interface{}) {
+		cli.Printf(format, args...)
+	})
+	if err != nil {
+		cli.PrintErrln(err)
+		return 1
+	}
+
+	return 0
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -73,6 +73,7 @@ require (
 	github.com/shirou/gopsutil/v3 v3.22.1
 	github.com/tidwall/gjson v1.14.4
 	github.com/tidwall/sjson v1.2.5
+	github.com/valyala/gozstd v1.20.1
 	github.com/vbauerster/mpb v3.4.0+incompatible
 	github.com/vbauerster/mpb/v8 v8.0.2
 	github.com/xitongsys/parquet-go v1.6.1
@@ -146,7 +147,6 @@ require (
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tklauser/go-sysconf v0.3.9 // indirect
 	github.com/tklauser/numcpus v0.3.0 // indirect
-	github.com/valyala/gozstd v1.20.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect

--- a/go/go.mod
+++ b/go/go.mod
@@ -146,6 +146,7 @@ require (
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tklauser/go-sysconf v0.3.9 // indirect
 	github.com/tklauser/numcpus v0.3.0 // indirect
+	github.com/valyala/gozstd v1.20.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -684,6 +684,8 @@ github.com/tklauser/numcpus v0.3.0/go.mod h1:yFGUr7TUHQRAhyqBcEg0Ge34zDBAsIvJJcy
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/valyala/gozstd v1.20.1 h1:xPnnnvjmaDDitMFfDxmQ4vpx0+3CdTg2o3lALvXTU/g=
+github.com/valyala/gozstd v1.20.1/go.mod h1:y5Ew47GLlP37EkTB+B4s7r6A5rdaeB7ftbl9zoYiIPQ=
 github.com/vbauerster/mpb v3.4.0+incompatible h1:mfiiYw87ARaeRW6x5gWwYRUawxaW1tLAD8IceomUCNw=
 github.com/vbauerster/mpb v3.4.0+incompatible/go.mod h1:zAHG26FUhVKETRu+MWqYXcI70POlC6N8up9p1dID7SU=
 github.com/vbauerster/mpb/v8 v8.0.2 h1:alVQG69Jg5+Ku9Hu1dakDx50uACEHnIzS7i356NQ/Vs=

--- a/go/store/nbs/archive_builder.go
+++ b/go/store/nbs/archive_builder.go
@@ -21,11 +21,12 @@ import (
 	"os"
 	"sync"
 
-	"github.com/dolthub/dolt/go/store/chunks"
-	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/pkg/errors"
 	"github.com/valyala/gozstd"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 type PrintfFunc func(format string, args ...interface{})

--- a/go/store/nbs/archive_builder.go
+++ b/go/store/nbs/archive_builder.go
@@ -1,0 +1,186 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nbs
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/pkg/errors"
+	"github.com/valyala/gozstd"
+	"golang.org/x/sync/errgroup"
+)
+
+type PrintfFunc func(format string, args ...interface{})
+
+func RunExperiment(cs chunks.ChunkStore, p PrintfFunc) (err error) {
+	if gs, ok := cs.(*GenerationalNBS); ok {
+		oldgen := gs.oldGen.tables.upstream
+
+		for tf, ogcs := range oldgen {
+			p("Copying table file: %s\n", tf.String())
+
+			outPath := experimentOutputFile(tf)
+
+			idx, err := ogcs.index()
+			if err != nil {
+				return err
+			}
+
+			err = copyAllChunks(ogcs, idx, outPath)
+			if err != nil {
+				return err
+			}
+
+			err = verifyAllChunks(idx, outPath)
+			if err != nil {
+				return err
+			}
+
+			p("Verified table file: %s\n", outPath)
+		}
+
+	} else {
+		panic(fmt.Sprintf("Modern DB Expected"))
+	}
+
+	return
+}
+
+func experimentOutputFile(tf hash.Hash) string {
+	// For the purposes of the experiment, write to the CWD.
+	return fmt.Sprintf("%s.darc", tf.String())
+}
+
+// copyAllChunks copies all chunks from the given chunkSource to the given archive file. No grouping is currently done.
+func copyAllChunks(cs chunkSource, idx tableIndex, archivePath string) error {
+	records := make([]getRecord, idx.chunkCount())
+	for i := uint32(0); i < idx.chunkCount(); i++ {
+		var h hash.Hash
+		_, err := idx.indexEntry(i, &h)
+		if err != nil {
+			return err
+		}
+
+		records = append(records, getRecord{&h, h.Prefix(), false})
+	}
+
+	file, err := os.Create(archivePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	writer := io.Writer(file)
+
+	arcW := newArchiveWriter(writer)
+
+	group, ctx := errgroup.WithContext(context.TODO())
+
+	// Allocate buffer used to compress chunks.
+	cmpBuff := make([]byte, 0, maxChunkSize)
+	var innerErr error
+	bottleneck := sync.Mutex{} // This code doesn't cope with parallelism yet.
+	var stats Stats
+	allFound, err := cs.getMany(ctx, group, records, func(_ context.Context, c *chunks.Chunk) {
+		bottleneck.Lock()
+		defer bottleneck.Unlock()
+
+		// For the first pass, don't group any chunks. Simply write chunks to the archive.
+		compressed := gozstd.Compress(cmpBuff, c.Data())
+		id, err := arcW.writeByteSpan(compressed)
+		if err != nil {
+			innerErr = err
+		}
+		err = arcW.stageChunk(c.Hash(), 0, id)
+		if err != nil {
+			innerErr = err
+		}
+	}, &stats)
+	if err != nil {
+		return err
+	}
+	if innerErr != nil {
+		return innerErr
+	}
+
+	if !allFound { // Unlikely to happen, given we got the list of chunks from this index.
+		return errors.New("not all chunks found")
+	}
+	err = group.Wait()
+	if err != nil {
+		return err
+	}
+
+	n, err := arcW.writeIndex()
+	if err != nil {
+		return err
+	}
+	return arcW.writeFooter(n)
+}
+
+func verifyAllChunks(idx tableIndex, archiveFile string) error {
+	file, err := os.Open(archiveFile)
+	if err != nil {
+		return err
+	}
+
+	stat, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	fileSize := stat.Size()
+
+	index, err := newArchiveIndex(file, uint64(fileSize))
+	if err != nil {
+		return err
+	}
+
+	for i := uint32(0); i < idx.chunkCount(); i++ {
+		var h hash.Hash
+		_, err := idx.indexEntry(i, &h)
+		if err != nil {
+			return err
+		}
+
+		if !index.has(h) {
+			msg := fmt.Sprintf("chunk not found in archive: %s", h.String())
+			return errors.New(msg)
+		}
+
+		data, err := index.get(h)
+		if err != nil {
+			return err
+		}
+		if data == nil {
+			msg := fmt.Sprintf("nil data returned from archive for expected chunk: %s", h.String())
+			return errors.New(msg)
+		}
+
+		chk := chunks.NewChunk(data)
+
+		// Verify the hash of the chunk. This is the best sanity check that our data is being stored and retrieved
+		// without any errors.
+		if chk.Hash() != h {
+			msg := fmt.Sprintf("hash mismatch for chunk: %s", h.String())
+			return errors.New(msg)
+		}
+	}
+	return nil
+}

--- a/go/store/nbs/archive_reader.go
+++ b/go/store/nbs/archive_reader.go
@@ -1,0 +1,216 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nbs
+
+import (
+	"encoding/binary"
+	"io"
+
+	"github.com/dolthub/dolt/go/store/hash"
+)
+
+type archiveIndex struct {
+	reader    io.ReaderAt
+	prefixes  []uint64
+	byteSpans []byteSpan
+	chunkRefs []chunkRef
+	suffixes  []suffix
+}
+
+type byteSpan struct {
+	offset uint64
+	length uint64
+}
+
+type chunkRef struct {
+	dict uint32
+	data uint32
+}
+
+type suffix [hash.SuffixLen]byte
+
+// Our mix of using binary.ReadUvarint and binary.Read paints us in a bit of a corner here. To work around this
+// we wrap the section reader with the ByteReader interface. There may be a better way to do this.
+type sectionReaderByteReader struct {
+	sectionReader *io.SectionReader
+}
+
+// ReadByte - see op.SectionReader.ReadByte.
+func (r sectionReaderByteReader) ReadByte() (byte, error) {
+	buf := []byte{0}
+	_, err := r.sectionReader.Read(buf)
+	if err != nil {
+		return 0, err
+	}
+	return buf[0], nil
+}
+
+func newArchiveIndex(reader io.ReaderAt, fileSize uint64) (archiveIndex, error) {
+	idx, bs, cc, err := loadFooter(reader, fileSize)
+	if err != nil {
+		return archiveIndex{}, err
+	}
+
+	indexStart := fileSize - archiveFooterSize - uint64(idx)
+	section := io.NewSectionReader(reader, int64(indexStart), int64(idx))
+
+	byteSpans := make([]byteSpan, bs+1)
+	byteSpans = append(byteSpans, byteSpan{offset: 0, length: 0}) // Null byteSpan to simplify logic.
+
+	byteReader := sectionReaderByteReader{sectionReader: section}
+	for i := uint32(0); i < bs; i++ {
+		offset, err := binary.ReadUvarint(byteReader)
+		if err != nil {
+			return archiveIndex{}, err
+		}
+		length, err := binary.ReadUvarint(byteReader)
+		if err != nil {
+			return archiveIndex{}, err
+		}
+
+		byteSpans[i+1] = byteSpan{offset: offset, length: length}
+	}
+
+	prefixes := make([]uint64, cc)
+	for i := uint32(0); i < cc; i++ {
+		val := uint64(0)
+		err := binary.Read(section, binary.BigEndian, &val)
+		if err != nil {
+			return archiveIndex{}, err
+		}
+		prefixes[i] = val
+	}
+
+	chunks := make([]chunkRef, cc)
+	for i := uint32(0); i < cc; i++ {
+		dict64, err := binary.ReadUvarint(byteReader)
+		if err != nil {
+			return archiveIndex{}, err
+		}
+		data64, err := binary.ReadUvarint(byteReader)
+		if err != nil {
+			return archiveIndex{}, err
+		}
+		chunks[i] = chunkRef{dict: uint32(dict64), data: uint32(data64)}
+	}
+
+	suffixes := make([]suffix, cc)
+	for i := uint32(0); i < cc; i++ {
+		n, err := section.Read(suffixes[i][:])
+		if err != nil {
+			return archiveIndex{}, err
+		}
+		if n != hash.SuffixLen {
+			return archiveIndex{}, io.ErrUnexpectedEOF
+		}
+	}
+
+	return archiveIndex{
+		reader:    reader,
+		prefixes:  prefixes,
+		byteSpans: byteSpans,
+		chunkRefs: chunks,
+		suffixes:  suffixes,
+	}, nil
+}
+
+func loadFooter(reader io.ReaderAt, fileSize uint64) (indexSize, byteSpanCount, chunkCount uint32, err error) {
+	section := io.NewSectionReader(reader, int64(fileSize-archiveFooterSize), archiveFooterSize)
+
+	bytesRead := 0
+	buf := make([]byte, archiveFooterSize)
+	bytesRead, err = section.Read(buf)
+	if err != nil {
+		return
+	}
+	if bytesRead != archiveFooterSize {
+		err = io.ErrUnexpectedEOF
+		return
+	}
+
+	// Verify File Signature
+	if string(buf[13:]) != archiveFileSignature {
+		err = ErrInvalidFileSignature
+		return
+	}
+	// Verify Format Version. Currently only one version is supported, but we'll need to be more flexible in the future.
+	if buf[12] != archiveFormatVersion {
+		err = ErrInvalidFormatVersion
+		return
+	}
+
+	indexSize = binary.BigEndian.Uint32(buf[:uint32Size])
+	byteSpanCount = binary.BigEndian.Uint32(buf[uint32Size : uint32Size*2])
+	chunkCount = binary.BigEndian.Uint32(buf[uint32Size*2 : uint32Size*3])
+
+	return
+}
+
+func (ai archiveIndex) has(hash hash.Hash) bool {
+	prefix := hash.Prefix()
+	matchingIndexes := findMatchingPrefixes(ai.prefixes, prefix)
+	if len(matchingIndexes) == 0 {
+		return false
+	}
+
+	targetSfx := hash.Suffix()
+
+	for _, idx := range matchingIndexes {
+		if ai.suffixes[idx] == suffix(targetSfx) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// findMatchingPrefixes returns all indexes of the input slice that have a prefix that matches the target prefix.
+func findMatchingPrefixes(slice []uint64, target uint64) []int {
+	matchingIndexes := []int{}
+	anIdx := binarySearch(slice, target)
+	if anIdx == -1 {
+		return matchingIndexes
+	}
+
+	if anIdx > 0 {
+		// Ensure we are on the first matching index.
+		for anIdx > 0 && slice[anIdx-1] == target {
+			anIdx--
+		}
+	}
+
+	for anIdx < len(slice) && slice[anIdx] == target {
+		matchingIndexes = append(matchingIndexes, anIdx)
+		anIdx++
+	}
+
+	return matchingIndexes
+}
+
+func binarySearch(prefixes []uint64, target uint64) int {
+	low := 0
+	high := len(prefixes) - 1
+	for low <= high {
+		mid := low + (high-low)/2
+		if prefixes[mid] == target {
+			return mid // Found
+		} else if prefixes[mid] < target {
+			low = mid + 1 // Search right half
+		} else {
+			high = mid - 1 // Search left half
+		}
+	}
+	return -1 // Not found
+}

--- a/go/store/nbs/archive_reader.go
+++ b/go/store/nbs/archive_reader.go
@@ -19,8 +19,9 @@ import (
 	"hash/crc32"
 	"io"
 
-	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/valyala/gozstd"
+
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 type archiveIndex struct {

--- a/go/store/nbs/archive_reader.go
+++ b/go/store/nbs/archive_reader.go
@@ -158,22 +158,83 @@ func loadFooter(reader io.ReaderAt, fileSize uint64) (indexSize, byteSpanCount, 
 	return
 }
 
-func (ai archiveIndex) has(hash hash.Hash) bool {
+func (ai archiveIndex) search(hash hash.Hash) (bool, int) {
 	prefix := hash.Prefix()
 	matchingIndexes := findMatchingPrefixes(ai.prefixes, prefix)
 	if len(matchingIndexes) == 0 {
-		return false
+		return false, 0
 	}
 
 	targetSfx := hash.Suffix()
 
 	for _, idx := range matchingIndexes {
 		if ai.suffixes[idx] == suffix(targetSfx) {
-			return true
+			return true, idx
 		}
 	}
 
-	return false
+	return false, 0
+}
+
+func (ai archiveIndex) has(hash hash.Hash) bool {
+	found, _ := ai.search(hash)
+	return found
+}
+
+// getRaw returns the raw data for the given hash. If the hash is not found, nil is returned for both slices. Also,
+// no error is returned in this case. Errors will only be returned if there is an io error.
+func (ai archiveIndex) getRaw(hash hash.Hash) (dict, data []byte, err error) {
+	found, idx := ai.search(hash)
+	if !found {
+		return nil, nil, nil
+	}
+
+	chunkRef := ai.chunkRefs[idx]
+	if chunkRef.dict != 0 {
+		byteSpan := ai.byteSpans[chunkRef.dict]
+		dict = make([]byte, byteSpan.length)
+		read, err := ai.reader.ReadAt(dict, int64(byteSpan.offset))
+		if err != nil {
+			return nil, nil, err
+		}
+		if uint64(read) != byteSpan.length {
+			return nil, nil, io.ErrUnexpectedEOF
+		}
+		dict, err = verifyAndStripCRC(dict)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	byteSpan := ai.byteSpans[chunkRef.data]
+	data = make([]byte, byteSpan.length)
+	read, err := ai.reader.ReadAt(data, int64(byteSpan.offset))
+	if err != nil {
+		return nil, nil, err
+	}
+	if uint64(read) != byteSpan.length {
+		return nil, nil, io.ErrUnexpectedEOF
+	}
+	data, err = verifyAndStripCRC(data)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return
+}
+
+func verifyAndStripCRC(data []byte) ([]byte, error) {
+	if len(data) < 4 {
+		return nil, io.ErrUnexpectedEOF
+	}
+
+	crcVal := binary.BigEndian.Uint32(data[len(data)-4:])
+	crcCalc := crc(data[:len(data)-4])
+	if crcVal != crcCalc {
+		return nil, ErrCRCMismatch
+	}
+
+	return data[:len(data)-4], nil
 }
 
 // findMatchingPrefixes returns all indexes of the input slice that have a prefix that matches the target prefix.
@@ -199,6 +260,7 @@ func findMatchingPrefixes(slice []uint64, target uint64) []int {
 	return matchingIndexes
 }
 
+// binarySearch returns the index of the target in the input slice. If the target is not found, -1 is returned.
 func binarySearch(prefixes []uint64, target uint64) int {
 	low := 0
 	high := len(prefixes) - 1

--- a/go/store/nbs/archive_test.go
+++ b/go/store/nbs/archive_test.go
@@ -28,11 +28,11 @@ func TestArchiveSingleChunk(t *testing.T) {
 	writer := NewFixedBufferTableSink(make([]byte, 1024))
 
 	aw := newArchiveWriter(writer)
-
-	bsId, err := aw.writeByteSpan([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
+	testBlob := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	bsId, err := aw.writeByteSpan(testBlob)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(1), bsId)
-	assert.Equal(t, uint64(14), aw.bytesWritten) // 10 bytes + CRC
+	assert.Equal(t, uint64(14), aw.bytesWritten) // 14 ==  10 data bytes + CRC
 
 	oneHash := hashWithPrefix(t, 23)
 
@@ -41,12 +41,13 @@ func TestArchiveSingleChunk(t *testing.T) {
 
 	n, err := aw.writeIndex()
 	assert.NoError(t, err)
-	assert.Equal(t, uint32(24), n) // NM4 - verify manually before shipping.
+	assert.Equal(t, uint32(24), n) // Verified manually. A single chunk allows for single byte varints, so
+	// ByteSpan -> 2 bytes, Prefix -> 8 bytes, ChunkRef -> 2 bytes, Suffix -> 12 bytes. Total 24 bytes.
 
-	err = aw.writeFooter(24)
+	err = aw.writeFooter(n)
 	assert.NoError(t, err)
 
-	assert.Equal(t, uint64(58), aw.bytesWritten) // 14 + 24 + 20
+	assert.Equal(t, uint64(58), aw.bytesWritten) // 14 + 24 + 20 (footer is 20 bytes)
 
 	theBytes := writer.buff[:writer.pos]
 	fileSize := uint64(len(theBytes))
@@ -55,9 +56,159 @@ func TestArchiveSingleChunk(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, []uint64{23}, aIdx.prefixes)
-
 	assert.True(t, aIdx.has(oneHash))
 
+	dict, data, err := aIdx.getRaw(oneHash)
+	assert.NoError(t, err)
+	assert.Nil(t, dict)
+	assert.Equal(t, testBlob, data)
+}
+
+func TestArchiveSingleChunkWithDictionary(t *testing.T) {
+	writer := NewFixedBufferTableSink(make([]byte, 1024))
+
+	aw := newArchiveWriter(writer)
+	testDict := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	testData := []byte{9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+	_, _ = aw.writeByteSpan(testDict)
+	_, _ = aw.writeByteSpan(testData)
+
+	h := hashWithPrefix(t, 42)
+	err := aw.stageChunk(h, 1, 2)
+	assert.NoError(t, err)
+
+	n, _ := aw.writeIndex()
+	err = aw.writeFooter(n)
+	assert.NoError(t, err)
+
+	theBytes := writer.buff[:writer.pos]
+	fileSize := uint64(len(theBytes))
+	readerAt := bytes.NewReader(theBytes)
+	aIdx, err := newArchiveIndex(readerAt, fileSize)
+	assert.NoError(t, err)
+	assert.Equal(t, []uint64{42}, aIdx.prefixes)
+
+	assert.True(t, aIdx.has(h))
+
+	dict, data, err := aIdx.getRaw(h)
+	assert.NoError(t, err)
+	assert.Equal(t, testDict, dict)
+	assert.Equal(t, testData, data)
+}
+
+func TestArchiverMultipleChunksMultipleDictionaries(t *testing.T) {
+	writer := NewFixedBufferTableSink(make([]byte, 1024))
+
+	aw := newArchiveWriter(writer)
+	dict1 := []byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}           // span 1
+	dict2 := []byte{2, 2, 2, 2, 2, 2, 2, 2, 2, 2}           // span 2
+	dict3 := []byte{3, 3, 3, 3, 3, 3, 3, 3, 3, 3}           // span 3
+	dict4 := []byte{4, 4, 4, 4, 4, 4, 4, 4, 4, 4}           // span 4
+	data1 := []byte{11, 11, 11, 11, 11, 11, 11, 11, 11, 11} // span 5
+	data2 := []byte{22, 22, 22, 22, 22, 22, 22, 22, 22, 22} // span 6
+	data3 := []byte{33, 33, 33, 33, 33, 33, 33, 33, 33, 33} // span 7
+	data4 := []byte{44, 44, 44, 44, 44, 44, 44, 44, 44, 44} // span 8
+
+	_, _ = aw.writeByteSpan(dict1)
+	_, _ = aw.writeByteSpan(dict2)
+	_, _ = aw.writeByteSpan(dict3)
+	_, _ = aw.writeByteSpan(dict4)
+	_, _ = aw.writeByteSpan(data1)
+	_, _ = aw.writeByteSpan(data2)
+	_, _ = aw.writeByteSpan(data3)
+	_, _ = aw.writeByteSpan(data4)
+
+	h1 := hashWithPrefix(t, 42)
+	h2 := hashWithPrefix(t, 42)
+	h3 := hashWithPrefix(t, 42)
+	h4 := hashWithPrefix(t, 81)
+	h5 := hashWithPrefix(t, 21)
+	h6 := hashWithPrefix(t, 88)
+	h7 := hashWithPrefix(t, 42)
+
+	_ = aw.stageChunk(h1, 0, 5)
+	_ = aw.stageChunk(h2, 1, 6)
+	_ = aw.stageChunk(h3, 2, 7)
+	_ = aw.stageChunk(h4, 3, 8)
+	_ = aw.stageChunk(h5, 1, 5)
+	_ = aw.stageChunk(h6, 0, 6)
+	_ = aw.stageChunk(h7, 1, 7)
+
+	n, _ := aw.writeIndex()
+	_ = aw.writeFooter(n)
+
+	theBytes := writer.buff[:writer.pos]
+	fileSize := uint64(len(theBytes))
+	readerAt := bytes.NewReader(theBytes)
+	aIdx, err := newArchiveIndex(readerAt, fileSize)
+	assert.NoError(t, err)
+	assert.Equal(t, []uint64{21, 42, 42, 42, 42, 81, 88}, aIdx.prefixes)
+
+	assert.True(t, aIdx.has(h1))
+	assert.True(t, aIdx.has(h2))
+	assert.True(t, aIdx.has(h3))
+	assert.True(t, aIdx.has(h4))
+	assert.True(t, aIdx.has(h5))
+	assert.True(t, aIdx.has(h6))
+	assert.True(t, aIdx.has(h7))
+	assert.False(t, aIdx.has(hash.Hash{}))
+	assert.False(t, aIdx.has(hashWithPrefix(t, 42)))
+	assert.False(t, aIdx.has(hashWithPrefix(t, 55)))
+
+	dict, data, _ := aIdx.getRaw(h1)
+	assert.Nil(t, dict)
+	assert.Equal(t, data1, data)
+
+	dict, data, _ = aIdx.getRaw(h2)
+	assert.Equal(t, dict1, dict)
+	assert.Equal(t, data2, data)
+
+	dict, data, _ = aIdx.getRaw(h3)
+	assert.Equal(t, dict2, dict)
+	assert.Equal(t, data3, data)
+
+	dict, data, _ = aIdx.getRaw(h4)
+	assert.Equal(t, dict3, dict)
+	assert.Equal(t, data4, data)
+
+	dict, data, _ = aIdx.getRaw(h5)
+	assert.Equal(t, dict1, dict)
+	assert.Equal(t, data1, data)
+
+	dict, data, _ = aIdx.getRaw(h6)
+	assert.Nil(t, dict)
+	assert.Equal(t, data2, data)
+
+	dict, data, _ = aIdx.getRaw(h7)
+	assert.Equal(t, dict1, dict)
+	assert.Equal(t, data3, data)
+}
+
+func TestArchiveBlockCorruption(t *testing.T) {
+	writer := NewFixedBufferTableSink(make([]byte, 1024))
+	aw := newArchiveWriter(writer)
+	testBlob := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	_, _ = aw.writeByteSpan(testBlob)
+
+	h := hashWithPrefix(t, 23)
+	_ = aw.stageChunk(h, 0, 1)
+
+	n, _ := aw.writeIndex()
+	_ = aw.writeFooter(n)
+
+	theBytes := writer.buff[:writer.pos]
+	fileSize := uint64(len(theBytes))
+	readerAt := bytes.NewReader(theBytes)
+	idx, err := newArchiveIndex(readerAt, fileSize)
+	assert.NoError(t, err)
+
+	// Corrupt the data
+	theBytes[3] = 51
+
+	dict, data, err := idx.getRaw(h)
+	assert.Equal(t, ErrCRCMismatch, err)
+	assert.Nil(t, dict)
+	assert.Nil(t, data)
 }
 
 func TestPrefixSearch(t *testing.T) {
@@ -73,6 +224,11 @@ func TestPrefixSearch(t *testing.T) {
 
 	pf = []uint64{}
 	assert.Equal(t, []int{}, findMatchingPrefixes(pf, 42))
+
+	pf = []uint64{23, 23, 23}
+	assert.Equal(t, []int{0, 1, 2}, findMatchingPrefixes(pf, 23))
+	assert.Equal(t, []int{}, findMatchingPrefixes(pf, 24)) // Don't run off the end is busted ways.
+	assert.Equal(t, []int{}, findMatchingPrefixes(pf, 22))
 }
 
 func hashWithPrefix(t *testing.T, prefix uint64) hash.Hash {

--- a/go/store/nbs/archive_test.go
+++ b/go/store/nbs/archive_test.go
@@ -20,10 +20,11 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/dolthub/dolt/go/store/chunks"
-	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/stretchr/testify/assert"
 	"github.com/valyala/gozstd"
+
+	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 func TestArchiveSingleChunk(t *testing.T) {

--- a/go/store/nbs/archive_test.go
+++ b/go/store/nbs/archive_test.go
@@ -1,0 +1,86 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nbs
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/binary"
+	"testing"
+
+	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestArchiveSingleChunk(t *testing.T) {
+	writer := NewFixedBufferTableSink(make([]byte, 1024))
+
+	aw := newArchiveWriter(writer)
+
+	bsId, err := aw.writeByteSpan([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(1), bsId)
+	assert.Equal(t, uint64(14), aw.bytesWritten) // 10 bytes + CRC
+
+	oneHash := hashWithPrefix(t, 23)
+
+	err = aw.stageChunk(oneHash, 0, 1)
+	assert.NoError(t, err)
+
+	n, err := aw.writeIndex()
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(24), n) // NM4 - verify manually before shipping.
+
+	err = aw.writeFooter(24)
+	assert.NoError(t, err)
+
+	assert.Equal(t, uint64(58), aw.bytesWritten) // 14 + 24 + 20
+
+	theBytes := writer.buff[:writer.pos]
+	fileSize := uint64(len(theBytes))
+	readerAt := bytes.NewReader(theBytes)
+	aIdx, err := newArchiveIndex(readerAt, fileSize)
+	assert.NoError(t, err)
+
+	assert.Equal(t, []uint64{23}, aIdx.prefixes)
+
+	assert.True(t, aIdx.has(oneHash))
+
+}
+
+func TestPrefixSearch(t *testing.T) {
+	pf := []uint64{2, 3, 4, 4, 4, 5, 6, 7, 10, 10, 11, 12, 13}
+
+	assert.Equal(t, []int{}, findMatchingPrefixes(pf, 1))
+	assert.Equal(t, []int{0}, findMatchingPrefixes(pf, 2))
+	assert.Equal(t, []int{2, 3, 4}, findMatchingPrefixes(pf, 4))
+	assert.Equal(t, []int{}, findMatchingPrefixes(pf, 8))
+	assert.Equal(t, []int{8, 9}, findMatchingPrefixes(pf, 10))
+	assert.Equal(t, []int{12}, findMatchingPrefixes(pf, 13))
+	assert.Equal(t, []int{}, findMatchingPrefixes(pf, 14))
+
+	pf = []uint64{}
+	assert.Equal(t, []int{}, findMatchingPrefixes(pf, 42))
+}
+
+func hashWithPrefix(t *testing.T, prefix uint64) hash.Hash {
+	randomBytes := make([]byte, 20)
+	n, err := rand.Read(randomBytes)
+	assert.Equal(t, 20, n)
+	assert.NoError(t, err)
+
+	binary.BigEndian.PutUint64(randomBytes, prefix)
+	return hash.Hash(randomBytes)
+}

--- a/go/store/nbs/archive_writer.go
+++ b/go/store/nbs/archive_writer.go
@@ -163,7 +163,8 @@ func newArchiveWriter(output io.Writer) *archiveWriter {
 }
 
 // writeByteSpan writes a byte span to the archive, returning the ByteSpan ID if the write was successful. Note
-// that writing an empty byte span is a no-op and will return 0.
+// that writing an empty byte span is a no-op and will return 0. Also, the slice passed in is copied, so the caller
+// can reuse the slice after this call.
 func (aw *archiveWriter) writeByteSpan(b []byte) (uint32, error) {
 	if len(b) == 0 {
 		return 0, nil

--- a/go/store/nbs/archive_writer.go
+++ b/go/store/nbs/archive_writer.go
@@ -1,0 +1,341 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nbs
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"sort"
+
+	"github.com/dolthub/dolt/go/store/hash"
+)
+
+/*
+A Dolt Archive is a file format for storing a collection of Chunks in a single file. The archive is essentially many
+byte spans concatenated together, with an index at the end of the file. Chunk Addresses are used to lookup and retrieve
+Chunks from the Archive.
+
+There are byte spans with in the archive which are not addressable by a Chunk Address. These are used as internal data
+to aid in the compression of the Chunks.
+
+A Dolt Archive file follows the following format:
+   +------------+------------+-----+------------+-------+--------+
+   | ByteSpan 1 | ByteSpan 2 | ... | ByteSpan N | Index | Footer |
+   +------------+------------+-----+------------+-------+--------+
+
+In reverse order, since that's how we read it
+
+Footer:
+   +----------------------+-------------------------+----------------------+--------------------+--------------------+
+   | (Uint32) IndexLength | (Uint32) ByteSpan Count | (Uint32) Chunk Count | (1) Format Version | (7) File Signature |
+   +----------------------+-------------------------+----------------------+--------------------+--------------------+
+   - Index Length: The length of the Index in bytes.
+   - ByteSpan Count: (N) The number of ByteSpans in the Archive. (does not include the null ByteSpan)
+   - Chunk Count: (M) The number of Chunk Records in the Archive.
+      * These 3 values are all required to properly parse the Index. Note that the NBS Index has a deterministic size
+        based on the Chunk Count. This is not the case with a Dolt Archive.
+   - Format Version: Sequence starting at 1.
+   - File Signature: Some would call this a magic number. Not on my watch. Dolt Archives have a 7 byte signature: "DOLTARC"
+
+Index:
+   +--------------+------------+-----------------+----------+
+   | ByteSpan Map | Prefix Map | ChunkReferences | Suffixes |
+   +--------------+------------+-----------------+----------+
+
+   ByteSpan Map:
+       +------------------+------------------+-----+------------------+
+       | ByteSpanRecord 1 | ByteSpanRecord 2 | ... | ByteSpanRecord N |
+       +------------------+------------------+-----+------------------+
+       ByteSpanRecord:
+           +------------------+------------------+
+           | (uvarint) Offset | (uvarint) Length |
+           +------------------+------------------+
+           - Offset: The byte offset of the ByteSpan in the archive
+           - Length: The byte length of the ByteSpan (includes the CRC32)
+
+       The ByteSpan Map contains N ByteSpan Records. The index in the map is considered the ByteSpan's ID, and
+       is used to reference the ByteSpan in the ChunkRefs. Note that the ByteSpan ID is 1-based, as 0 is reserved to indicate
+       an empty ByteSpan.
+
+   Prefix Map:
+       +-------------------+-------------------+-----+---------------------------+
+       | (Uint64) Prefix 0 | (Uint64) Prefix 1 | ... | (Uint64) Prefix Tuple M-1 |
+       +-------------------+-------------------+-----+---------------------------+
+       - The Prefix Map contains M Prefixes - one for each Chunk Record in the Table.
+       - The Prefix Tuples are sorted, allowing for a binary search.
+       - NB: THE SAME PREFIX MAY APPEAR MULTIPLE TIMES, as distinct Hashes (referring to distinct Chunks) may share the same Prefix.
+       - The index into this map is the Ordinal of the Chunk Record.
+
+   ChunkReferences:
+       +------------+------------+-----+--------------+
+       | ChunkRef 0 | ChunkRef 1 | ... | ChunkRef M-1 |
+       +------------+------------+-----+--------------+
+       ChunkRef:
+           +-------------------------------+--------------------------+
+           | (uvarint) Dictionary ByteSpan | (uvarint) Chunk ByteSpan |
+           +-------------------------------+--------------------------+
+        - Dictionary: ID for a ByteSpan to be used as zstd dictionary. 0 refers to the empty ByteSpan, which indicates no dictionary.
+        - Chunk: ID for the ByteSpan containing the Chunk data. Never 0.
+
+   Suffixes:
+       +--------------------+--------------------+-----+----------------------+
+       | (12) Hash Suffix 0 | (12) Hash Suffix 1 | ... | (12) Hash Suffix M-1 |
+       +--------------------+--------------------+-----+----------------------+
+
+     - Each Hash Suffix is the last 12 bytes of a Chunk in this Table.
+     - Hash Suffix M must correspond to Prefix M and Chunk Record M
+
+ByteSpan:
+   +----------------+----------------+
+   | Data as []byte | (Uint32) CRC32 |
+   +----------------+----------------+
+     - Self Explanatory.
+
+
+Chunk Retrieval (phase 1 is similar to NBS):
+
+  Phase one: Chunk Presence
+  - Slice off the first 8 bytes of your Hash to create a Prefix
+  - Since the Prefix Tuples in the Prefix Map are in lexicographic order, binary search the Prefix Map for the desired
+    Prefix. To not mix terms with Index, we'll call this the Chunk Id, which is the 0-based index into the Prefix Map.
+  - Using the Chunk Id found with a binary search, search locally for additional matching Prefixes. The matching indexes
+    are all potential matches for the chunk you are looking for.
+    - For each Chunk Id found, grab the corresponding Suffix, and compare to the Suffix of the Hash you are looking for.
+    - If they match, your chunk is in this file in the Chunk Id which matched.
+    - If they don't match, continue to the next matching Chunk Id.
+  - If not found, your chunk is not in this Table.
+  - If found, the given Chunk Id is the same index into the ChunkRef Map for the desired chunk.
+
+  Phase two: Loading Chunk data
+  - Take the Chunk Id discovered in Phase one, and use it to grap that index from the ChunkRefs Map.
+  - Retrieve the ByteSpan Id for the Chunk data. Verify integrity with CRC.
+  - If Dictionary is 0:
+    - Decompress the Chunk data using zstd (no dictionary)
+  - Otherwise:
+    - Retrieve the ByteSpan ID for the Dictionary data. Verify integrity with CRC.
+    - Decompress the Chunk data using zstd with the Dictionary data.
+*/
+
+const archiveFormatVersion = 1
+const archiveFileSignature = "DOLTARC"
+const archiveFooterSize = 4 + 4 + 4 + 1 + 7
+
+var ErrInvalidChunkRange = errors.New("invalid chunk range")
+var ErrInvalidDictionaryRange = errors.New("invalid dictionary range")
+var ErrInvalidFileSignature = errors.New("invalid file signature")
+var ErrInvalidFormatVersion = errors.New("invalid format version")
+
+type stagedByteSpan struct {
+	offset uint64
+	length uint32
+}
+type stagedByteSpanSlice []stagedByteSpan
+
+type stagedChunkRef struct {
+	hash             hash.Hash
+	dictionary, data uint32
+}
+type stagedChunkRefSlice []stagedChunkRef
+
+type archiveWriter struct {
+	output       io.Writer
+	bytesWritten uint64
+	stagedBytes  stagedByteSpanSlice
+	stagedChunks stagedChunkRefSlice
+}
+
+func newArchiveWriter(output io.Writer) *archiveWriter {
+	return &archiveWriter{output: output}
+}
+
+// writeByteSpan writes a byte span to the archive, returning the ByteSpan ID if the write was successful. Note
+// that writing an empty byte span is a no-op and will return 0.
+func (aw *archiveWriter) writeByteSpan(b []byte) (uint32, error) {
+	if len(b) == 0 {
+		return 0, nil
+	}
+
+	offset := aw.bytesWritten
+
+	cr := crc(b)
+	written, err := aw.output.Write(b)
+	if err != nil {
+		return 0, err
+	}
+	if written != len(b) {
+		return 0, io.ErrShortWrite
+	}
+	aw.bytesWritten += uint64(written)
+
+	err = binary.Write(aw.output, binary.BigEndian, cr)
+	if err != nil {
+		return 0, err
+	}
+	aw.bytesWritten += uint32Size
+
+	aw.stagedBytes = append(aw.stagedBytes, stagedByteSpan{offset, uint32(aw.bytesWritten - offset)})
+
+	return uint32(len(aw.stagedBytes)), nil
+}
+
+func (aw *archiveWriter) stageChunk(hash hash.Hash, dictionary, data uint32) error {
+	if data == 0 || data > uint32(len(aw.stagedBytes)) {
+		return ErrInvalidChunkRange
+	}
+
+	if dictionary > uint32(len(aw.stagedBytes)) {
+		return ErrInvalidDictionaryRange
+	}
+
+	aw.stagedChunks = append(aw.stagedChunks, stagedChunkRef{hash, dictionary, data})
+	return nil
+}
+
+func (scrs stagedChunkRefSlice) Len() int {
+	return len(scrs)
+}
+func (scrs stagedChunkRefSlice) Less(i, j int) bool {
+	return scrs[i].hash.Prefix() < scrs[j].hash.Prefix()
+}
+func (scrs stagedChunkRefSlice) Swap(i, j int) {
+	scrs[i], scrs[j] = scrs[j], scrs[i]
+}
+
+func (aw *archiveWriter) finalize() error {
+	indexLen, err := aw.writeIndex()
+	if err != nil {
+		return err
+	}
+
+	return aw.writeFooter(indexLen)
+}
+
+func (aw *archiveWriter) writeFooter(indexLen uint32) error {
+	// Write out the index length
+	err := binary.Write(aw.output, binary.BigEndian, indexLen)
+	if err != nil {
+		return err
+	}
+	aw.bytesWritten += uint32Size
+
+	// Write out the byte span count
+	err = binary.Write(aw.output, binary.BigEndian, uint32(len(aw.stagedBytes)))
+	if err != nil {
+		return err
+	}
+	aw.bytesWritten += uint32Size
+
+	// Write out the chunk count
+	err = binary.Write(aw.output, binary.BigEndian, uint32(len(aw.stagedChunks)))
+	if err != nil {
+		return err
+	}
+	aw.bytesWritten += uint32Size
+
+	// Write out the format version
+	err = binary.Write(aw.output, binary.BigEndian, uint8(archiveFormatVersion))
+	if err != nil {
+		return err
+	}
+	aw.bytesWritten++
+
+	// Write out the file signature
+	_, err = aw.output.Write([]byte(archiveFileSignature))
+	if err != nil {
+		return err
+	}
+	aw.bytesWritten += 7
+
+	return nil
+}
+
+func (aw *archiveWriter) writeIndex() (uint32, error) {
+	startingByteCount := aw.bytesWritten
+
+	varIbuf := make([]byte, binary.MaxVarintLen64)
+
+	// Write out the stagedByteSpans
+	for _, bs := range aw.stagedBytes {
+		n := binary.PutUvarint(varIbuf, bs.offset)
+		written, err := aw.output.Write(varIbuf[:n])
+		if err != nil {
+			return 0, err
+		}
+		if written != n {
+			return 0, io.ErrShortWrite
+		}
+		aw.bytesWritten += uint64(written)
+
+		n = binary.PutUvarint(varIbuf, uint64(bs.length))
+		written, err = aw.output.Write(varIbuf[:n])
+		if err != nil {
+			return 0, err
+		}
+		if written != n {
+			return 0, io.ErrShortWrite
+		}
+		aw.bytesWritten += uint64(written)
+	}
+
+	// sort stagedChunks by hash.Prefix(). Note this isn't a perfect sort for hashes, we are just grouping them by prefix
+	sort.Sort(aw.stagedChunks)
+
+	// We lay down the sorted chunk list in it's three forms.
+	// Prefix Map
+	for _, scr := range aw.stagedChunks {
+		err := binary.Write(aw.output, binary.BigEndian, scr.hash.Prefix())
+		if err != nil {
+			return 0, err
+		}
+		aw.bytesWritten += uint64Size
+	}
+	// ChunkReferences
+	for _, scr := range aw.stagedChunks {
+		n := binary.PutUvarint(varIbuf, uint64(scr.dictionary))
+		written, err := aw.output.Write(varIbuf[:n])
+		if err != nil {
+			return 0, err
+		}
+		if written != n {
+			return 0, io.ErrShortWrite
+		}
+		aw.bytesWritten += uint64(written)
+
+		n = binary.PutUvarint(varIbuf, uint64(scr.data))
+		written, err = aw.output.Write(varIbuf[:n])
+		if err != nil {
+			return 0, err
+		}
+		if written != n {
+			return 0, io.ErrShortWrite
+		}
+		aw.bytesWritten += uint64(written)
+	}
+	// Suffixes
+	for _, scr := range aw.stagedChunks {
+		n, err := aw.output.Write(scr.hash.Suffix())
+		if err != nil {
+			return 0, err
+		}
+		if n != hash.SuffixLen {
+			return 0, io.ErrShortWrite
+		}
+
+		aw.bytesWritten += uint64(hash.SuffixLen)
+	}
+
+	return uint32(aw.bytesWritten - startingByteCount), nil
+}

--- a/go/store/nbs/archive_writer.go
+++ b/go/store/nbs/archive_writer.go
@@ -137,6 +137,7 @@ var ErrInvalidChunkRange = errors.New("invalid chunk range")
 var ErrInvalidDictionaryRange = errors.New("invalid dictionary range")
 var ErrInvalidFileSignature = errors.New("invalid file signature")
 var ErrInvalidFormatVersion = errors.New("invalid format version")
+var ErrCRCMismatch = errors.New("CRC mismatch")
 
 type stagedByteSpan struct {
 	offset uint64


### PR DESCRIPTION
This change doesn't expose any new functionality to users. It serves to lay down the new data file format. Includes
a hidden command which can take existing oldgen files, put them into the new format, and ensure that all data can
be retrieved correctly by checking the file hash.

Usage:
`dolt gc; dolt admin delta`