### PR TITLE
[nbs] getMany read planning and parallelize

### DIFF
--- a/go/store/nbs/journal_chunk_source.go
+++ b/go/store/nbs/journal_chunk_source.go
@@ -91,7 +91,9 @@ func (s journalChunkSource) getMany(ctx context.Context, eg *errgroup.Group, req
 	}, stats)
 }
 
-func (s journalChunkSource) getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, CompressedChunk), stats *Stats) (bool, error) {
+func (s journalChunkSource) getManyCompressed(ctx context.Context, _ *errgroup.Group, reqs []getRecord, found func(context.Context, CompressedChunk), stats *Stats) (bool, error) {
+	// todo(max): get rid of |eg| argument, have |found| return error
+	eg, ctx := errgroup.WithContext(ctx)
 	var remaining bool
 	var jReqs []journalRecord
 	for i, r := range reqs {

--- a/go/store/nbs/journal_writer.go
+++ b/go/store/nbs/journal_writer.go
@@ -337,6 +337,17 @@ func (wr *journalWriter) getCompressedChunk(h hash.Hash) (CompressedChunk, error
 	return NewCompressedChunk(hash.Hash(h), buf)
 }
 
+// getCompressedChunk reads the CompressedChunks with addr |h|.
+func (wr *journalWriter) getCompressedChunkAtRange(r Range, h hash.Hash) (CompressedChunk, error) {
+	wr.lock.RLock()
+	defer wr.lock.RUnlock()
+	buf := make([]byte, r.Length)
+	if _, err := wr.readAt(buf, int64(r.Offset)); err != nil {
+		return CompressedChunk{}, nil
+	}
+	return NewCompressedChunk(hash.Hash(h), buf)
+}
+
 // getRange returns a Range for the chunk with addr |h|.
 func (wr *journalWriter) getRange(h hash.Hash) (rng Range, ok bool, err error) {
 	// callers will use |rng| to read directly from the

--- a/go/store/nbs/journal_writer.go
+++ b/go/store/nbs/journal_writer.go
@@ -332,18 +332,16 @@ func (wr *journalWriter) getCompressedChunk(h hash.Hash) (CompressedChunk, error
 	}
 	buf := make([]byte, r.Length)
 	if _, err := wr.readAt(buf, int64(r.Offset)); err != nil {
-		return CompressedChunk{}, nil
+		return CompressedChunk{}, err
 	}
 	return NewCompressedChunk(hash.Hash(h), buf)
 }
 
 // getCompressedChunk reads the CompressedChunks with addr |h|.
 func (wr *journalWriter) getCompressedChunkAtRange(r Range, h hash.Hash) (CompressedChunk, error) {
-	wr.lock.RLock()
-	defer wr.lock.RUnlock()
 	buf := make([]byte, r.Length)
 	if _, err := wr.readAt(buf, int64(r.Offset)); err != nil {
-		return CompressedChunk{}, nil
+		return CompressedChunk{}, err
 	}
 	return NewCompressedChunk(hash.Hash(h), buf)
 }


### PR DESCRIPTION
Add read planning for journal getMany so instead of doing randIO we get seqIO. SeqIO has a large effect for disk storage systems. Also parallelize getMany calls. The biggest change here is the semantics around how reading locks the journal file. Reads hold the journal lock for longer, which could lower write throughput in some cases. If we see evidence of this, we can do more work to limit the amount of time batch reads can interruptibly holding the journal lock.