### PR TITLE
Don't generate new tags for column type changes

### DIFF
--- a/go/libraries/doltcore/sqle/dolt_patch_table_function.go
+++ b/go/libraries/doltcore/sqle/dolt_patch_table_function.go
@@ -495,7 +495,6 @@ func getPatchNodes(ctx *sql.Context, dbData env.DbData, tableDeltas []diff.Table
 		// Get SCHEMA DIFF
 		var schemaStmts []string
 		if includeSchemaDiff {
-
 			schemaStmts, err = getSchemaSqlPatch(ctx, toRefDetails.root, td)
 			if err != nil {
 				return nil, err
@@ -660,6 +659,10 @@ func GetNonCreateNonDropTableSqlSchemaDiff(td diff.TableDelta, toSchemas map[str
 			}
 			if cd.Old.Name != cd.New.Name {
 				ddlStatements = append(ddlStatements, sqlfmt.AlterTableRenameColStmt(td.ToName, cd.Old.Name, cd.New.Name))
+			}
+			if cd.Old.TypeInfo != cd.New.TypeInfo {
+				ddlStatements = append(ddlStatements, sqlfmt.AlterTableModifyColStmt(td.ToName,
+					sqlfmt.GenerateCreateTableColumnDefinition(*cd.New, sql.CollationID(td.ToSch.GetCollation()))))
 			}
 		}
 	}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -2072,11 +2072,16 @@ var HistorySystemTableScriptTests = []queries.ScriptTest{
 				Expected: []sql.Row{{1, 3}, {4, 6}},
 			},
 			{
-				// When filtering on a column from the original table, we use the primary index here, but because
-				// column tags have changed in previous versions of the table, the index tags don't match up completely.
+				// When filtering on a column from the original table, we use the primary index here, but if column
+				// tags have changed in previous versions of the table, the index tags won't match up completely.
 				// https://github.com/dolthub/dolt/issues/6891
+				// NOTE: {4,5,nil} shows up as a row from the first commit, when c2 was a varchar type. The schema
+				//       for dolt_history_t uses the current table schema, and we can't extract an int from the older
+				//       version's tuple, so it shows up as a NULL. In the future, we could use a different tuple
+				//       descriptor based on the version of the row and pull the data out that way and try to convert
+				//       it to the new type, but it may not actually be worth it.
 				Query:    "select pk, c1, c2 from dolt_history_t where pk=4;",
-				Expected: []sql.Row{{4, 5, 6}},
+				Expected: []sql.Row{{4, 5, 6}, {4, 5, nil}},
 			},
 		},
 	},

--- a/integration-tests/MySQLDockerfile
+++ b/integration-tests/MySQLDockerfile
@@ -13,10 +13,10 @@ RUN apt update -y && \
         software-properties-common && \
     curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
     add-apt-repository ppa:deadsnakes/ppa -y && \
-    curl -OL https://packages.erlang-solutions.com/erlang/debian/pool/esl-erlang_22.3.4.9-1~ubuntu~focal_amd64.deb && \
-    dpkg -i esl-erlang_22.3.4.9-1~ubuntu~focal_amd64.deb && \
-    curl -LO https://packages.erlang-solutions.com/erlang/debian/pool/elixir_1.10.2-1~ubuntu~focal_all.deb && \
-    dpkg -i elixir_1.10.2-1~ubuntu~focal_all.deb
+    curl -OL https://binaries2.erlang-solutions.com/ubuntu/pool/contrib/e/esl-erlang/esl-erlang_25.0-1~ubuntu~focal_amd64.deb && \
+    dpkg -i esl-erlang_25.0-1~ubuntu~focal_amd64.deb && \
+    curl -LO https://binaries2.erlang-solutions.com/ubuntu/pool/contrib/e/elixir/elixir_1.14.3_1_otp_25.3~ubuntu~focal_all.deb && \
+    dpkg -i elixir_1.14.3_1_otp_25.3~ubuntu~focal_all.deb
 RUN apt update -y && \
     apt install -y \
         python3.8 \

--- a/integration-tests/bats/column_tags.bats
+++ b/integration-tests/bats/column_tags.bats
@@ -240,7 +240,7 @@ DELIM
     [[ "$output" =~ "ints_table,c5,12796" ]] || false
 }
 
-@test "column_tags: Round-tripping a column type through different NomsKinds restores original tag" {
+@test "column_tags: Round-tripping a column type through different NomsKinds preserves its tag" {
     dolt sql -q "CREATE TABLE t (pk INT PRIMARY KEY, col1 int);"
     run dolt schema tags
     [ $status -eq 0 ]
@@ -249,7 +249,7 @@ DELIM
     dolt sql -q "ALTER TABLE t MODIFY COLUMN col1 VARCHAR(100);"
     run dolt schema tags
     [ $status -eq 0 ]
-    [[ $output =~ "col1   | 16050" ]] || false
+    [[ $output =~ "col1   | 10878" ]] || false
 
     dolt sql -q "ALTER TABLE t MODIFY COLUMN col1 int;"
     run dolt schema tags
@@ -274,7 +274,7 @@ DELIM
     [[ $output =~ "col1   | 16050" ]] || false
 }
 
-@test "column_tags: Round-tripping a column type after some other column has been altered" {
+@test "column_tags: Round-tripping a column type after other column is altered preserves column tag" {
     dolt sql -q "CREATE TABLE t (pk INT PRIMARY KEY, col1 int);"
     run dolt schema tags
     [ $status -eq 0 ]
@@ -285,12 +285,12 @@ DELIM
     dolt sql -q "ALTER TABLE t MODIFY COLUMN col1 VARCHAR(100);"
     run dolt schema tags
     [ $status -eq 0 ]
-    [[ $output =~ "col1   | 11127" ]] || false
+    [[ $output =~ "col1   | 10878" ]] || false
 
     dolt sql -q "ALTER TABLE t MODIFY COLUMN col1 int;"
     run dolt schema tags
     [ $status -eq 0 ]
-    [[ $output =~ "col1   | 10186" ]] || false
+    [[ $output =~ "col1   | 10878" ]] || false
 }
 
 @test "column_tags: update-tag only available on __DOLT__" {


### PR DESCRIPTION
Currently, when a column's type changes to a new type family (e.g. changing from `varchar` to `int`), we assign a new column tag. This prevents us from easily identifying the column across type changes. For example:
* If column X is renamed and then its type is later changed, we can't track it across the rename or type change anymore. This usage pattern removes the value that column tags were intended to provide. 
* If column X changes its type, we can't easily differentiate between column X being dropped and a new column X being added. Heuristically, we can look at all the data in the table if it's all exactly identical, then we know it's a rename, but this is a somewhat hacky heuristic that can become ambiguous in more nuanced cases. This currently causes us to generate incorrect SQL patch statements that drops the renamed column and adds a new column. If customers were to apply these incorrect patch statements, it would drop all the data from their existing column, instead of converting it to the new type. This affects `dolt_patch()` and `dolt diff -r sql` and also prevents us from generating correct DDL statements for binlog replication.

This PR changes schema alterations so that columns now retain their original column tag across type changes, which fixes the issues above. 

A side effect of this change is that if a customer is working on a branch, creates a column, and changes its type, the tag won't match if the schema on another branch is updated to the final type change (i.e. without going through the initial/intermediary type). Code was originally added for this case (see: https://github.com/dolthub/dolt/issues/3950), however, since then, we have added support for schema merging and this isn't an issue anymore. I've confirmed that we can successfully merge non-matching column tags, from both directions, and added a test for this case, too.

Longer-term, I agree we should continue exploring removing tags completely, but in the short-term, this fixes a correctness problem with SQL patch statement generation that binlog support needs. 

Related to: https://github.com/dolthub/dolt/issues/6710#issuecomment-1734318087