### PR TITLE
adding `--name-only` option for `dolt diff`

### DIFF
--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -50,7 +50,7 @@ type diffPart int
 const (
 	SchemaOnlyDiff diffPart = 1  // 0b0000 0001
 	DataOnlyDiff   diffPart = 2  // 0b0000 0010
-	NameOnlyDiff  diffPart = 4  // 0b0000 0100
+	NameOnlyDiff   diffPart = 4  // 0b0000 0100
 	Stat           diffPart = 8  // 0b0000 1000
 	Summary        diffPart = 16 // 0b0001 0000
 
@@ -60,17 +60,17 @@ const (
 	SQLDiffOutput     diffOutput = 2
 	JsonDiffOutput    diffOutput = 3
 
-	DataFlag      = "data"
-	SchemaFlag    = "schema"
-	NameOnlyFlag  = "name-only"
-	StatFlag      = "stat"
-	SummaryFlag   = "summary"
-	whereParam    = "where"
-	limitParam    = "limit"
-	SkinnyFlag    = "skinny"
-	MergeBase     = "merge-base"
-	DiffMode      = "diff-mode"
-	ReverseFlag   = "reverse"
+	DataFlag     = "data"
+	SchemaFlag   = "schema"
+	NameOnlyFlag = "name-only"
+	StatFlag     = "stat"
+	SummaryFlag  = "summary"
+	whereParam   = "where"
+	limitParam   = "limit"
+	SkinnyFlag   = "skinny"
+	MergeBase    = "merge-base"
+	DiffMode     = "diff-mode"
+	ReverseFlag  = "reverse"
 )
 
 var diffDocs = cli.CommandDocumentationContent{

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -50,7 +50,7 @@ type diffPart int
 const (
 	SchemaOnlyDiff diffPart = 1  // 0b0000 0001
 	DataOnlyDiff   diffPart = 2  // 0b0000 0010
-	TableOnlyDiff  diffPart = 4  // 0b0000 0100
+	NameOnlyDiff  diffPart = 4  // 0b0000 0100
 	Stat           diffPart = 8  // 0b0000 1000
 	Summary        diffPart = 16 // 0b0001 0000
 
@@ -248,7 +248,7 @@ func parseDiffDisplaySettings(apr *argparser.ArgParseResults) *diffDisplaySettin
 	} else if apr.Contains(SummaryFlag) {
 		displaySettings.diffParts = Summary
 	} else if apr.Contains(NameOnlyFlag) {
-		displaySettings.diffParts = TableOnlyDiff
+		displaySettings.diffParts = NameOnlyDiff
 	}
 
 	displaySettings.skinny = apr.Contains(SkinnyFlag)
@@ -1045,7 +1045,7 @@ func diffUserTable(
 	fromTable := tableSummary.FromTableName
 	toTable := tableSummary.ToTableName
 
-	if dArgs.diffParts&TableOnlyDiff == 0 {
+	if dArgs.diffParts&NameOnlyDiff == 0 {
 		err := dw.BeginTable(tableSummary.FromTableName, tableSummary.ToTableName, tableSummary.IsAdd(), tableSummary.IsDrop())
 		if err != nil {
 			return errhand.VerboseErrorFromError(err)
@@ -1068,7 +1068,7 @@ func diffUserTable(
 		tableName = toTable
 	}
 
-	if dArgs.diffParts&TableOnlyDiff != 0 {
+	if dArgs.diffParts&NameOnlyDiff != 0 {
 		cli.Println(tableName)
 		return errhand.VerboseErrorFromError(nil)
 	}

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -48,10 +48,11 @@ type diffOutput int
 type diffPart int
 
 const (
-	SchemaOnlyDiff diffPart = 1 // 0b0001
-	DataOnlyDiff   diffPart = 2 // 0b0010
-	Stat           diffPart = 4 // 0b0100
-	Summary        diffPart = 8 // 0b1000
+	SchemaOnlyDiff diffPart = 1  // 0b0000 0001
+	DataOnlyDiff   diffPart = 2  // 0b0000 0010
+	TableOnlyDiff  diffPart = 4  // 0b0000 0100
+	Stat           diffPart = 8  // 0b0000 1000
+	Summary        diffPart = 16 // 0b0001 0000
 
 	SchemaAndDataDiff = SchemaOnlyDiff | DataOnlyDiff
 
@@ -59,16 +60,17 @@ const (
 	SQLDiffOutput     diffOutput = 2
 	JsonDiffOutput    diffOutput = 3
 
-	DataFlag    = "data"
-	SchemaFlag  = "schema"
-	StatFlag    = "stat"
-	SummaryFlag = "summary"
-	whereParam  = "where"
-	limitParam  = "limit"
-	SkinnyFlag  = "skinny"
-	MergeBase   = "merge-base"
-	DiffMode    = "diff-mode"
-	ReverseFlag = "reverse"
+	DataFlag      = "data"
+	SchemaFlag    = "schema"
+	TableOnlyFlag = "table-only"
+	StatFlag      = "stat"
+	SummaryFlag   = "summary"
+	whereParam    = "where"
+	limitParam    = "limit"
+	SkinnyFlag    = "skinny"
+	MergeBase     = "merge-base"
+	DiffMode      = "diff-mode"
+	ReverseFlag   = "reverse"
 )
 
 var diffDocs = cli.CommandDocumentationContent{
@@ -174,6 +176,7 @@ func (cmd DiffCmd) ArgParser() *argparser.ArgParser {
 	ap.SupportsFlag(MergeBase, "", "Uses merge base of the first commit and second commit (or HEAD if not supplied) as the first commit")
 	ap.SupportsString(DiffMode, "", "diff mode", "Determines how to display modified rows with tabular output. Valid values are row, line, in-place, context. Defaults to context.")
 	ap.SupportsFlag(ReverseFlag, "R", "Reverses the direction of the diff.")
+	ap.SupportsFlag(TableOnlyFlag, "", "Only shows table names.")
 	return ap
 }
 
@@ -238,6 +241,8 @@ func parseDiffDisplaySettings(apr *argparser.ArgParseResults) *diffDisplaySettin
 		displaySettings.diffParts = Stat
 	} else if apr.Contains(SummaryFlag) {
 		displaySettings.diffParts = Summary
+	} else if apr.Contains(TableOnlyFlag) {
+		displaySettings.diffParts = TableOnlyDiff
 	}
 
 	displaySettings.skinny = apr.Contains(SkinnyFlag)
@@ -1034,9 +1039,11 @@ func diffUserTable(
 	fromTable := tableSummary.FromTableName
 	toTable := tableSummary.ToTableName
 
-	err := dw.BeginTable(tableSummary.FromTableName, tableSummary.ToTableName, tableSummary.IsAdd(), tableSummary.IsDrop())
-	if err != nil {
-		return errhand.VerboseErrorFromError(err)
+	if dArgs.diffParts&TableOnlyDiff == 0 {
+		err := dw.BeginTable(tableSummary.FromTableName, tableSummary.ToTableName, tableSummary.IsAdd(), tableSummary.IsDrop())
+		if err != nil {
+			return errhand.VerboseErrorFromError(err)
+		}
 	}
 
 	var fromTableInfo, toTableInfo *diff.TableInfo
@@ -1053,6 +1060,11 @@ func diffUserTable(
 	tableName := fromTable
 	if tableName == "" {
 		tableName = toTable
+	}
+
+	if dArgs.diffParts&TableOnlyDiff != 0 {
+		cli.Println(tableName)
+		return errhand.VerboseErrorFromError(nil)
 	}
 
 	if dArgs.diffParts&Stat != 0 {

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -219,6 +219,12 @@ func (cmd DiffCmd) validateArgs(apr *argparser.ArgParseResults) errhand.VerboseE
 		}
 	}
 
+	if apr.Contains(TableOnlyFlag) {
+		if apr.Contains(SchemaFlag) || apr.Contains(DataFlag) || apr.Contains(StatFlag) || apr.Contains(SummaryFlag) {
+			return errhand.BuildDError("invalid Arguments: --table-only cannot be combined with --schema, --data, --stat, or --summary").Build()
+		}
+	}
+
 	f, _ := apr.GetValue(FormatFlag)
 	switch strings.ToLower(f) {
 	case "tabular", "sql", "json", "":

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -62,7 +62,7 @@ const (
 
 	DataFlag      = "data"
 	SchemaFlag    = "schema"
-	TableOnlyFlag = "table-only"
+	NameOnlyFlag  = "name-only"
 	StatFlag      = "stat"
 	SummaryFlag   = "summary"
 	whereParam    = "where"
@@ -176,7 +176,7 @@ func (cmd DiffCmd) ArgParser() *argparser.ArgParser {
 	ap.SupportsFlag(MergeBase, "", "Uses merge base of the first commit and second commit (or HEAD if not supplied) as the first commit")
 	ap.SupportsString(DiffMode, "", "diff mode", "Determines how to display modified rows with tabular output. Valid values are row, line, in-place, context. Defaults to context.")
 	ap.SupportsFlag(ReverseFlag, "R", "Reverses the direction of the diff.")
-	ap.SupportsFlag(TableOnlyFlag, "", "Only shows table names.")
+	ap.SupportsFlag(NameOnlyFlag, "", "Only shows table names.")
 	return ap
 }
 
@@ -219,9 +219,9 @@ func (cmd DiffCmd) validateArgs(apr *argparser.ArgParseResults) errhand.VerboseE
 		}
 	}
 
-	if apr.Contains(TableOnlyFlag) {
+	if apr.Contains(NameOnlyFlag) {
 		if apr.Contains(SchemaFlag) || apr.Contains(DataFlag) || apr.Contains(StatFlag) || apr.Contains(SummaryFlag) {
-			return errhand.BuildDError("invalid Arguments: --table-only cannot be combined with --schema, --data, --stat, or --summary").Build()
+			return errhand.BuildDError("invalid Arguments: --name-only cannot be combined with --schema, --data, --stat, or --summary").Build()
 		}
 	}
 
@@ -247,7 +247,7 @@ func parseDiffDisplaySettings(apr *argparser.ArgParseResults) *diffDisplaySettin
 		displaySettings.diffParts = Stat
 	} else if apr.Contains(SummaryFlag) {
 		displaySettings.diffParts = Summary
-	} else if apr.Contains(TableOnlyFlag) {
+	} else if apr.Contains(NameOnlyFlag) {
 		displaySettings.diffParts = TableOnlyDiff
 	}
 

--- a/go/cmd/dolt/commands/diff_output.go
+++ b/go/cmd/dolt/commands/diff_output.go
@@ -71,6 +71,10 @@ func newDiffWriter(diffOutput diffOutput) (diffWriter, error) {
 	}
 }
 
+func printTableOnlyDiff(tableName string) {
+	cli.Println(tableName)
+}
+
 func printDiffStat(diffStats []diffStatistics, oldColLen, newColLen int, areTablesKeyless bool) errhand.VerboseError {
 	acc := diff.DiffStatProgress{}
 	var count int64

--- a/go/cmd/dolt/commands/diff_output.go
+++ b/go/cmd/dolt/commands/diff_output.go
@@ -71,10 +71,6 @@ func newDiffWriter(diffOutput diffOutput) (diffWriter, error) {
 	}
 }
 
-func printTableOnlyDiff(tableName string) {
-	cli.Println(tableName)
-}
-
 func printDiffStat(diffStats []diffStatistics, oldColLen, newColLen int, areTablesKeyless bool) errhand.VerboseError {
 	acc := diff.DiffStatProgress{}
 	var count int64

--- a/integration-tests/bats/diff.bats
+++ b/integration-tests/bats/diff.bats
@@ -1709,3 +1709,55 @@ SQL
     [[ "$output" =~ "CREATE TRIGGER trigger1 BEFORE INSERT ON mytable FOR EACH ROW SET new.v1 = -2*new.v1;" ]] || false
     [[ "$output" =~ "CREATE VIEW view1 AS SELECT v1 FROM mytable;" ]] || false
 }
+
+@test "diff: table-only option" {
+    dolt sql <<SQL
+create table t1 (i int);
+create table t2 (i int);
+create table t3 (i int);
+SQL
+
+    dolt add .
+    dolt commit -m "commit 1"
+
+    dolt sql <<SQL
+drop table t1;
+alter table t2 add column j int;
+insert into t3 values (1);
+create table t4 (i int);
+SQL
+
+    run dolt diff --summary
+    [ $status -eq 0 ]
+    [ "${lines[0]}" = "+------------+-----------+-------------+---------------+" ]
+    [ "${lines[1]}" = "| Table name | Diff type | Data change | Schema change |" ]
+    [ "${lines[2]}" = "+------------+-----------+-------------+---------------+" ]
+    [ "${lines[3]}" = "| t1         | dropped   | false       | true          |" ]
+    [ "${lines[4]}" = "| t2         | modified  | false       | true          |" ]
+    [ "${lines[5]}" = "| t3         | modified  | true        | false         |" ]
+    [ "${lines[6]}" = "| t4         | added     | false       | true          |" ]
+    [ "${lines[7]}" = "+------------+-----------+-------------+---------------+" ]
+
+    run dolt diff --table-only
+    [ $status -eq 0 ]
+    [ "${lines[0]}" = "t1" ]
+    [ "${lines[1]}" = "t2" ]
+    [ "${lines[2]}" = "t3" ]
+    [ "${lines[3]}" = "t4" ]
+
+    run dolt diff --table-only --schema
+    [ $status -eq 1 ]
+    [[ $output =~ "invalid Arguments" ]]
+
+    run dolt diff --table-only --data
+    [ $status -eq 1 ]
+    [[ $output =~ "invalid Arguments" ]]
+
+    run dolt diff --table-only --stat
+    [ $status -eq 1 ]
+    [[ $output =~ "invalid Arguments" ]]
+
+    run dolt diff --table-only --summary
+    [ $status -eq 1 ]
+    [[ $output =~ "invalid Arguments" ]]
+}

--- a/integration-tests/bats/diff.bats
+++ b/integration-tests/bats/diff.bats
@@ -1747,17 +1747,17 @@ SQL
 
     run dolt diff --table-only --schema
     [ $status -eq 1 ]
-    [[ $output =~ "invalid Arguments" ]]
+    [[ $output =~ "invalid Arguments" ]] || false
 
     run dolt diff --table-only --data
     [ $status -eq 1 ]
-    [[ $output =~ "invalid Arguments" ]]
+    [[ $output =~ "invalid Arguments" ]] || false
 
     run dolt diff --table-only --stat
     [ $status -eq 1 ]
-    [[ $output =~ "invalid Arguments" ]]
+    [[ $output =~ "invalid Arguments" ]] || false
 
     run dolt diff --table-only --summary
     [ $status -eq 1 ]
-    [[ $output =~ "invalid Arguments" ]]
+    [[ $output =~ "invalid Arguments" ]] || false
 }

--- a/integration-tests/bats/diff.bats
+++ b/integration-tests/bats/diff.bats
@@ -1738,26 +1738,26 @@ SQL
     [ "${lines[6]}" = "| t4         | added     | false       | true          |" ]
     [ "${lines[7]}" = "+------------+-----------+-------------+---------------+" ]
 
-    run dolt diff --table-only
+    run dolt diff --name-only
     [ $status -eq 0 ]
     [ "${lines[0]}" = "t1" ]
     [ "${lines[1]}" = "t2" ]
     [ "${lines[2]}" = "t3" ]
     [ "${lines[3]}" = "t4" ]
 
-    run dolt diff --table-only --schema
+    run dolt diff --name-only --schema
     [ $status -eq 1 ]
     [[ $output =~ "invalid Arguments" ]] || false
 
-    run dolt diff --table-only --data
+    run dolt diff --name-only --data
     [ $status -eq 1 ]
     [[ $output =~ "invalid Arguments" ]] || false
 
-    run dolt diff --table-only --stat
+    run dolt diff --name-only --stat
     [ $status -eq 1 ]
     [[ $output =~ "invalid Arguments" ]] || false
 
-    run dolt diff --table-only --summary
+    run dolt diff --name-only --summary
     [ $status -eq 1 ]
     [[ $output =~ "invalid Arguments" ]] || false
 }


### PR DESCRIPTION
This PR adds support for `--name-only` option for `dolt diff`, which just prints the tables that have changed between the two commits. This mirrors `git diff --name-only`.

fixes: https://github.com/dolthub/dolt/issues/7797