### PR TITLE
Changing database init/drop hooks to be a slice of hooks

### DIFF
--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -133,12 +133,13 @@ func NewSqlEngine(
 	pro = pro.WithRemoteDialer(mrEnv.RemoteDialProvider())
 
 	config.ClusterController.RegisterStoredProcedures(pro)
-	pro.InitDatabaseHook = cluster.NewInitDatabaseHook(config.ClusterController, bThreads, pro.InitDatabaseHook)
+	if config.ClusterController != nil {
+		pro.InitDatabaseHooks = append(pro.InitDatabaseHooks, cluster.NewInitDatabaseHook(config.ClusterController, bThreads))
+		pro.DropDatabaseHooks = append(pro.DropDatabaseHooks, config.ClusterController.DropDatabaseHook())
+		config.ClusterController.SetDropDatabase(pro.DropDatabase)
+	}
 
 	sqlEngine := &SqlEngine{}
-
-	pro.DropDatabaseHook = config.ClusterController.DropDatabaseHook()
-	config.ClusterController.SetDropDatabase(pro.DropDatabase)
 
 	// Create the engine
 	engine := gms.New(analyzer.NewBuilder(pro).WithParallelism(parallelism).Build(), &gms.Config{

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_type_serialization.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_type_serialization.go
@@ -752,9 +752,17 @@ func (j jsonSerializer) serialize(ctx *sql.Context, typ sql.Type, descriptor val
 		return nil, err
 	}
 	if json != nil {
-		jsonDoc, ok := json.(gmstypes.JSONDocument)
-		if !ok {
-			return nil, fmt.Errorf("supported JSON type: %T", json)
+		var jsonDoc gmstypes.JSONDocument
+		if lazyJsonDoc, ok := json.(*gmstypes.LazyJSONDocument); ok {
+			i, err := lazyJsonDoc.ToInterface()
+			if err != nil {
+				return nil, err
+			}
+			jsonDoc = gmstypes.JSONDocument{Val: i}
+		} else if _, ok := json.(gmstypes.JSONDocument); ok {
+			jsonDoc = json.(gmstypes.JSONDocument)
+		} else {
+			return nil, fmt.Errorf("unsupported JSON type: %T", json)
 		}
 
 		jsonBuffer, err := encodeJsonDoc(jsonDoc)

--- a/go/libraries/doltcore/sqle/cluster/controller.go
+++ b/go/libraries/doltcore/sqle/cluster/controller.go
@@ -348,11 +348,11 @@ func (c *Controller) SetDropDatabase(dropDatabase func(*sql.Context, string) err
 
 // DropDatabaseHook gets called when the database provider drops a
 // database. This is how we learn that we need to replicate a drop database.
-func (c *Controller) DropDatabaseHook() func(context.Context, string) {
+func (c *Controller) DropDatabaseHook() func(*sql.Context, string) {
 	return c.dropDatabaseHook
 }
 
-func (c *Controller) dropDatabaseHook(_ context.Context, dbname string) {
+func (c *Controller) dropDatabaseHook(_ *sql.Context, dbname string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/go/libraries/doltcore/sqle/cluster/controller.go
+++ b/go/libraries/doltcore/sqle/cluster/controller.go
@@ -346,16 +346,13 @@ func (c *Controller) SetDropDatabase(dropDatabase func(*sql.Context, string) err
 	c.dropDatabase = dropDatabase
 }
 
-// Our DropDatabaseHook gets called when the database provider drops a
+// DropDatabaseHook gets called when the database provider drops a
 // database. This is how we learn that we need to replicate a drop database.
-func (c *Controller) DropDatabaseHook() func(string) {
-	if c == nil {
-		return nil
-	}
+func (c *Controller) DropDatabaseHook() func(context.Context, string) {
 	return c.dropDatabaseHook
 }
 
-func (c *Controller) dropDatabaseHook(dbname string) {
+func (c *Controller) dropDatabaseHook(_ context.Context, dbname string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/go/libraries/doltcore/sqle/cluster/initdbhook.go
+++ b/go/libraries/doltcore/sqle/cluster/initdbhook.go
@@ -28,17 +28,8 @@ import (
 	"github.com/dolthub/dolt/go/store/types"
 )
 
-func NewInitDatabaseHook(controller *Controller, bt *sql.BackgroundThreads, orig sqle.InitDatabaseHook) sqle.InitDatabaseHook {
-	if controller == nil {
-		return orig
-	}
+func NewInitDatabaseHook(controller *Controller, bt *sql.BackgroundThreads) sqle.InitDatabaseHook {
 	return func(ctx *sql.Context, pro *sqle.DoltDatabaseProvider, name string, denv *env.DoltEnv, db dsess.SqlDatabase) error {
-		var err error
-		err = orig(ctx, pro, name, denv, db)
-		if err != nil {
-			return err
-		}
-
 		dialprovider := controller.gRPCDialProvider(denv)
 		var remoteDBs []func(context.Context) (*doltdb.DoltDB, error)
 		var remoteUrls []string

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -52,8 +52,8 @@ type DoltDatabaseProvider struct {
 	functions          map[string]sql.Function
 	tableFunctions     map[string]sql.TableFunction
 	externalProcedures sql.ExternalStoredProcedureRegistry
-	InitDatabaseHook   InitDatabaseHook
-	DropDatabaseHook   DropDatabaseHook
+	InitDatabaseHooks  []InitDatabaseHook
+	DropDatabaseHooks  []DropDatabaseHook
 	mu                 *sync.RWMutex
 
 	droppedDatabaseManager *droppedDatabaseManager
@@ -146,7 +146,7 @@ func NewDoltDatabaseProviderWithDatabases(defaultBranch string, fs filesys.Files
 		fs:                     fs,
 		defaultBranch:          defaultBranch,
 		dbFactoryUrl:           dbFactoryUrl,
-		InitDatabaseHook:       ConfigureReplicationDatabaseHook,
+		InitDatabaseHooks:      []InitDatabaseHook{ConfigureReplicationDatabaseHook},
 		isStandby:              new(bool),
 		droppedDatabaseManager: newDroppedDatabaseManager(fs),
 	}, nil
@@ -459,7 +459,7 @@ func (p *DoltDatabaseProvider) CreateCollatedDatabase(ctx *sql.Context, name str
 }
 
 type InitDatabaseHook func(ctx *sql.Context, pro *DoltDatabaseProvider, name string, env *env.DoltEnv, db dsess.SqlDatabase) error
-type DropDatabaseHook func(name string)
+type DropDatabaseHook func(ctx context.Context, name string)
 
 // ConfigureReplicationDatabaseHook sets up replication for a newly created database as necessary
 // TODO: consider the replication heads / all heads setting
@@ -630,10 +630,10 @@ func (p *DoltDatabaseProvider) DropDatabase(ctx *sql.Context, name string) error
 		return err
 	}
 
-	if p.DropDatabaseHook != nil {
+	for _, dropHook := range p.DropDatabaseHooks {
 		// For symmetry with InitDatabaseHook and the names we see in
 		// MultiEnv initialization, we use `name` here, not `dbKey`.
-		p.DropDatabaseHook(name)
+		dropHook(ctx, name)
 	}
 
 	// We not only have to delete tracking metadata for this database, but also for any derivative
@@ -707,12 +707,14 @@ func (p *DoltDatabaseProvider) registerNewDatabase(ctx *sql.Context, name string
 		return err
 	}
 
-	// If we have an initialization hook, invoke it.  By default, this will
-	// be ConfigureReplicationDatabaseHook, which will setup replication
-	// for the new database if a remote url template is set.
-	err = p.InitDatabaseHook(ctx, p, name, newEnv, db)
-	if err != nil {
-		return err
+	// If we have any initialization hooks, invoke them, until any error is returned.
+	// By default, this will be ConfigureReplicationDatabaseHook, which will set up
+	// replication for the new database if a remote url template is set.
+	for _, initHook := range p.InitDatabaseHooks {
+		err = initHook(ctx, p, name, newEnv, db)
+		if err != nil {
+			return err
+		}
 	}
 
 	formattedName := formatDbMapKeyName(db.Name())

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -459,7 +459,7 @@ func (p *DoltDatabaseProvider) CreateCollatedDatabase(ctx *sql.Context, name str
 }
 
 type InitDatabaseHook func(ctx *sql.Context, pro *DoltDatabaseProvider, name string, env *env.DoltEnv, db dsess.SqlDatabase) error
-type DropDatabaseHook func(ctx context.Context, name string)
+type DropDatabaseHook func(ctx *sql.Context, name string)
 
 // ConfigureReplicationDatabaseHook sets up replication for a newly created database as necessary
 // TODO: consider the replication heads / all heads setting

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -3287,12 +3287,14 @@ func TestCreateDatabaseErrorCleansUp(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, e)
 
-	dh.provider.(*sqle.DoltDatabaseProvider).InitDatabaseHook = func(_ *sql.Context, _ *sqle.DoltDatabaseProvider, name string, _ *env.DoltEnv, _ dsess.SqlDatabase) error {
-		if name == "cannot_create" {
-			return fmt.Errorf("there was an error initializing this database. abort!")
-		}
-		return nil
-	}
+	doltDatabaseProvider := dh.provider.(*sqle.DoltDatabaseProvider)
+	doltDatabaseProvider.InitDatabaseHooks = append(doltDatabaseProvider.InitDatabaseHooks,
+		func(_ *sql.Context, _ *sqle.DoltDatabaseProvider, name string, _ *env.DoltEnv, _ dsess.SqlDatabase) error {
+			if name == "cannot_create" {
+				return fmt.Errorf("there was an error initializing this database. abort!")
+			}
+			return nil
+		})
 
 	err = dh.provider.CreateDatabase(enginetest.NewContext(dh), "can_create")
 	require.NoError(t, err)

--- a/go/libraries/doltcore/sqle/statspro/configure.go
+++ b/go/libraries/doltcore/sqle/statspro/configure.go
@@ -54,7 +54,7 @@ func (p *Provider) Configure(ctx context.Context, ctxFactory func(ctx context.Co
 		thresholdf64 = threshold.(float64)
 
 		p.pro.InitDatabaseHooks = append(p.pro.InitDatabaseHooks, NewStatsInitDatabaseHook(p, ctxFactory, bThreads))
-		p.pro.DropDatabaseHooks = append(p.pro.DropDatabaseHooks, NewStatsDropDatabaseHook(p, ctxFactory))
+		p.pro.DropDatabaseHooks = append(p.pro.DropDatabaseHooks, NewStatsDropDatabaseHook(p))
 	}
 
 	eg, ctx := loadCtx.NewErrgroup()

--- a/go/libraries/doltcore/sqle/statspro/configure.go
+++ b/go/libraries/doltcore/sqle/statspro/configure.go
@@ -29,7 +29,7 @@ import (
 )
 
 func (p *Provider) Configure(ctx context.Context, ctxFactory func(ctx context.Context) (*sql.Context, error), bThreads *sql.BackgroundThreads, dbs []dsess.SqlDatabase) error {
-	p.SetStarter(NewInitDatabaseHook(p, ctxFactory, bThreads, nil))
+	p.SetStarter(NewStatsInitDatabaseHook(p, ctxFactory, bThreads))
 
 	if _, disabled, _ := sql.SystemVariables.GetGlobal(dsess.DoltStatsMemoryOnly); disabled == int8(1) {
 		return nil
@@ -53,8 +53,8 @@ func (p *Provider) Configure(ctx context.Context, ctxFactory func(ctx context.Co
 		intervalSec = time.Second * time.Duration(interval64.(int64))
 		thresholdf64 = threshold.(float64)
 
-		p.pro.InitDatabaseHook = NewInitDatabaseHook(p, ctxFactory, bThreads, p.pro.InitDatabaseHook)
-		p.pro.DropDatabaseHook = NewDropDatabaseHook(p, ctxFactory, p.pro.DropDatabaseHook)
+		p.pro.InitDatabaseHooks = append(p.pro.InitDatabaseHooks, NewStatsInitDatabaseHook(p, ctxFactory, bThreads))
+		p.pro.DropDatabaseHooks = append(p.pro.DropDatabaseHooks, NewStatsDropDatabaseHook(p, ctxFactory))
 	}
 
 	eg, ctx := loadCtx.NewErrgroup()

--- a/go/libraries/doltcore/sqle/statspro/initdbhook.go
+++ b/go/libraries/doltcore/sqle/statspro/initdbhook.go
@@ -51,18 +51,14 @@ func NewStatsInitDatabaseHook(
 	}
 }
 
-func NewStatsDropDatabaseHook(statsProv *Provider, ctxFactory func(ctx context.Context) (*sql.Context, error)) sqle.DropDatabaseHook {
-	return func(ctx context.Context, name string) {
-		sqlCtx, err := ctxFactory(ctx)
-		if err != nil {
-			return
-		}
+func NewStatsDropDatabaseHook(statsProv *Provider) sqle.DropDatabaseHook {
+	return func(ctx *sql.Context, name string) {
 		statsProv.CancelRefreshThread(name)
-		statsProv.DropDbStats(sqlCtx, name, false)
+		statsProv.DropDbStats(ctx, name, false)
 
 		if db, ok := statsProv.getStatDb(name); ok {
 			if err := db.Close(); err != nil {
-				sqlCtx.GetLogger().Debugf("failed to close stats database: %s", err)
+				ctx.GetLogger().Debugf("failed to close stats database: %s", err)
 			}
 		}
 	}


### PR DESCRIPTION
The Dolt database provider currently has a single init hook and a single drop hook. We have a few hooks, and in order to support multiple hooks, we chain them together. Binlog replication will also need to register a similar init and drop hook to capture database create/drop actions, so to prepare for that, this PR turns the single init hook and single drop hook into a slice of init hooks and a slice of drop hooks. 