### PR TITLE
fix output for `dolt diff --stat -r json`

### DIFF
--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -754,8 +754,6 @@ func diffUserTables(queryist cli.Queryist, sqlCtx *sql.Context, dArgs *diffArgs)
 		return errhand.VerboseErrorFromError(err)
 	}
 
-	defer dw.Close(sqlCtx)
-
 	ignoredTablePatterns, err := getIgnoredTablePatternsFromSql(queryist, sqlCtx)
 	if err != nil {
 		return errhand.VerboseErrorFromError(fmt.Errorf("couldn't get ignored table patterns, cause: %w", err))
@@ -810,6 +808,7 @@ func diffUserTables(queryist cli.Queryist, sqlCtx *sql.Context, dArgs *diffArgs)
 		}
 	}
 
+	dw.Close(sqlCtx)
 	return nil
 }
 

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -1091,7 +1091,13 @@ func diffUserTable(
 			return errhand.BuildDError("cannot retrieve diff stats between '%s' and '%s'", dArgs.fromRef, dArgs.toRef).AddCause(err).Build()
 		}
 
-		return printDiffStat(diffStats, fromColLen, toColLen, areTablesKeyless)
+		// TODO: diffStats needs to take into account the diff writer format
+		err = dw.WriteTableDiffStats(diffStats, fromColLen, toColLen, areTablesKeyless)
+		if err != nil {
+			return errhand.VerboseErrorFromError(err)
+		}
+		return nil
+		//return printDiffStat(diffStats, fromColLen, toColLen, areTablesKeyless)
 	}
 
 	if dArgs.diffParts&SchemaOnlyDiff != 0 {

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -808,7 +808,11 @@ func diffUserTables(queryist cli.Queryist, sqlCtx *sql.Context, dArgs *diffArgs)
 		}
 	}
 
-	dw.Close(sqlCtx)
+	err = dw.Close(sqlCtx)
+	if err != nil {
+		return errhand.VerboseErrorFromError(err)
+	}
+
 	return nil
 }
 

--- a/go/cmd/dolt/commands/diff_output.go
+++ b/go/cmd/dolt/commands/diff_output.go
@@ -17,7 +17,8 @@ package commands
 import (
 	"context"
 	ejson "encoding/json"
-	"fmt"
+	"errors"
+"fmt"
 	"io"
 
 	textdiff "github.com/andreyvit/diff"
@@ -296,7 +297,8 @@ func (s sqlDiffWriter) WriteViewDiff(ctx context.Context, viewName, oldDefn, new
 }
 
 func (s sqlDiffWriter) WriteTableDiffStats(diffStats []diffStatistics, oldColLen, newColLen int, areTablesKeyless bool) error {
-	return nil
+	// TODO: implement this
+	return errors.New("diff stats are not supported for sql output")
 }
 
 func (s sqlDiffWriter) RowWriter(fromTableInfo, toTableInfo *diff.TableInfo, tds diff.TableDeltaSummary, unionSch sql.Schema) (diff.SqlRowDiffWriter, error) {

--- a/go/cmd/dolt/commands/diff_output.go
+++ b/go/cmd/dolt/commands/diff_output.go
@@ -398,12 +398,7 @@ func (j *jsonDiffWriter) WriteTableSchemaDiff(fromTableInfo, toTableInfo *diff.T
 		}
 	}
 
-	err = jsonSchDiffWriter.Close()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return jsonSchDiffWriter.Close()
 }
 
 func (j *jsonDiffWriter) RowWriter(fromTableInfo, toTableInfo *diff.TableInfo, tds diff.TableDeltaSummary, unionSch sql.Schema) (diff.SqlRowDiffWriter, error) {

--- a/go/cmd/dolt/doltversion/version.go
+++ b/go/cmd/dolt/doltversion/version.go
@@ -16,5 +16,5 @@
 package doltversion
 
 const (
-	Version = "1.35.11"
+	Version = "1.35.12"
 )

--- a/go/libraries/doltcore/diff/diff.go
+++ b/go/libraries/doltcore/diff/diff.go
@@ -87,5 +87,5 @@ type SchemaDiffWriter interface {
 	// many SQL statements for a single diff. WriteSchemaDiff will be called before any row diffs via |WriteRow|
 	WriteSchemaDiff(schemaDiffStatement string) error
 	// Close finalizes the work of this writer.
-	Close(ctx context.Context) error
+	Close() error
 }

--- a/go/libraries/doltcore/table/typed/json/json_diff_writer.go
+++ b/go/libraries/doltcore/table/typed/json/json_diff_writer.go
@@ -27,28 +27,28 @@ import (
 	"github.com/dolthub/dolt/go/libraries/utils/iohelp"
 )
 
-type JsonDiffWriter struct {
+type jsonRowDiffWriter struct {
 	rowWriter   *RowWriter
 	wr          io.WriteCloser
 	inModified  bool
 	rowsWritten int
 }
 
-var _ diff.SqlRowDiffWriter = (*JsonDiffWriter)(nil)
+var _ diff.SqlRowDiffWriter = (*jsonRowDiffWriter)(nil)
 
-func NewJsonDiffWriter(wr io.WriteCloser, outSch schema.Schema) (*JsonDiffWriter, error) {
+func NewJSONRowDiffWriter(wr io.WriteCloser, outSch schema.Schema) (*jsonRowDiffWriter, error) {
 	writer, err := NewJSONWriterWithHeader(iohelp.NopWrCloser(wr), outSch, "", "", "")
 	if err != nil {
 		return nil, err
 	}
 
-	return &JsonDiffWriter{
+	return &jsonRowDiffWriter{
 		rowWriter: writer,
 		wr:        wr,
 	}, nil
 }
 
-func (j *JsonDiffWriter) WriteRow(
+func (j *jsonRowDiffWriter) WriteRow(
 	ctx context.Context,
 	row sql.Row,
 	rowDiffType diff.ChangeType,
@@ -110,7 +110,7 @@ func (j *JsonDiffWriter) WriteRow(
 		j.inModified = !j.inModified
 	case diff.Added:
 	case diff.Removed:
-		err := iohelp.WriteAll(j.wr, []byte(fmt.Sprintf(`,"%s":{}`, "to_row")))
+		err := iohelp.WriteAll(j.wr, []byte(fmt.Sprintf(",\"%s\":{}", "to_row")))
 		if err != nil {
 			return err
 		}
@@ -127,11 +127,11 @@ func (j *JsonDiffWriter) WriteRow(
 	return nil
 }
 
-func (j *JsonDiffWriter) WriteCombinedRow(ctx context.Context, oldRow, newRow sql.Row, mode diff.Mode) error {
+func (j *jsonRowDiffWriter) WriteCombinedRow(ctx context.Context, oldRow, newRow sql.Row, mode diff.Mode) error {
 	return fmt.Errorf("json format is unable to output diffs for combined rows")
 }
 
-func (j *JsonDiffWriter) Close(ctx context.Context) error {
+func (j *jsonRowDiffWriter) Close(ctx context.Context) error {
 	err := iohelp.WriteAll(j.wr, []byte("]"))
 	if err != nil {
 		return err
@@ -152,9 +152,9 @@ type SchemaDiffWriter struct {
 
 var _ diff.SchemaDiffWriter = (*SchemaDiffWriter)(nil)
 
-// TODO: this header should be "schema_diff: ["
-const jsonSchemaHeader = `[`
-const jsonSchemaFooter = `]`
+const jsonSchemaHeader = `"schema_diff":[`
+const jsonSchemaFooter = `],`
+const jsonSchemaSep = `,`
 
 func NewSchemaDiffWriter(wr io.WriteCloser) (*SchemaDiffWriter, error) {
 	err := iohelp.WriteAll(wr, []byte(jsonSchemaHeader))
@@ -169,24 +169,35 @@ func NewSchemaDiffWriter(wr io.WriteCloser) (*SchemaDiffWriter, error) {
 
 func (j *SchemaDiffWriter) WriteSchemaDiff(schemaDiffStatement string) error {
 	if j.schemaStmtsWritten > 0 {
-		err := iohelp.WriteAll(j.wr, []byte(","))
+		err := iohelp.WriteAll(j.wr, []byte(jsonSchemaSep))
 		if err != nil {
 			return err
 		}
 	}
 
+	jsonSchemaDiffStmt := fmt.Sprintf("%s", jsonEscape(schemaDiffStatement))
+	err := iohelp.WriteAll(j.wr, []byte(jsonSchemaDiffStmt))
+	if err != nil {
+		return err
+	}
+
 	j.schemaStmtsWritten++
 
-	return iohelp.WriteAll(j.wr, []byte(fmt.Sprintf(`"%s"`, jsonEscape(schemaDiffStatement))))
+	return nil
 }
 
-func (j *SchemaDiffWriter) Close(ctx context.Context) error {
+func (j *SchemaDiffWriter) Close() error {
 	err := iohelp.WriteAll(j.wr, []byte(jsonSchemaFooter))
 	if err != nil {
 		return err
 	}
 
-	return j.wr.Close()
+	err = j.wr.Close()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func jsonEscape(s string) string {
@@ -194,6 +205,5 @@ func jsonEscape(s string) string {
 	if err != nil {
 		panic(err)
 	}
-	// Trim the beginning and trailing " character
-	return string(b[1 : len(b)-1])
+	return string(b)
 }

--- a/go/libraries/doltcore/table/typed/json/json_diff_writer.go
+++ b/go/libraries/doltcore/table/typed/json/json_diff_writer.go
@@ -152,6 +152,7 @@ type SchemaDiffWriter struct {
 
 var _ diff.SchemaDiffWriter = (*SchemaDiffWriter)(nil)
 
+// TODO: this header should be "schema_diff: ["
 const jsonSchemaHeader = `[`
 const jsonSchemaFooter = `]`
 

--- a/go/libraries/doltcore/table/typed/json/json_diff_writer.go
+++ b/go/libraries/doltcore/table/typed/json/json_diff_writer.go
@@ -110,7 +110,7 @@ func (j *jsonRowDiffWriter) WriteRow(
 		j.inModified = !j.inModified
 	case diff.Added:
 	case diff.Removed:
-		err := iohelp.WriteAll(j.wr, []byte(fmt.Sprintf(",\"%s\":{}", "to_row")))
+		err := iohelp.WriteAll(j.wr, []byte(fmt.Sprintf(`,"%s":{}`, "to_row")))
 		if err != nil {
 			return err
 		}

--- a/integration-tests/bats/json-diff.bats
+++ b/integration-tests/bats/json-diff.bats
@@ -73,7 +73,6 @@ delete from test where pk = 1;
 update test set c1 = 100 where pk = 4;
 SQL
 
-    dolt diff -r json
     run dolt diff -r json
 
     EXPECTED=$(cat <<'EOF'
@@ -100,7 +99,7 @@ EOF
     dolt diff -r json --data
     run dolt diff -r json --data
     EXPECTED=$(cat <<'EOF'
-{"tables":[{"name":"test","schema_diff":[],"data_diff":[{"from_row":{"c1":2,"c2":3,"pk":1},"to_row":{}},{"from_row":{"c1":5,"c2":6,"pk":4},"to_row":{"c1":100,"pk":4}},{"from_row":{},"to_row":{"c1":8,"c3":"9","pk":7}}]}]}
+{"tables":[{"name":"test","data_diff":[{"from_row":{"c1":2,"c2":3,"pk":1},"to_row":{}},{"from_row":{"c1":5,"c2":6,"pk":4},"to_row":{"c1":100,"pk":4}},{"from_row":{},"to_row":{"c1":8,"c3":"9","pk":7}}]}]}
 EOF
 )
     
@@ -113,7 +112,7 @@ EOF
     dolt diff -r json --data
     run dolt diff -r json --data
     EXPECTED=$(cat <<'EOF'
-{"tables":[{"name":"test","schema_diff":[],"data_diff":[{"from_row":{"c1":100,"pk":4},"to_row":{"c1new":200,"pk":4}},{"from_row":{"c1":8,"c3":"9","pk":7},"to_row":{"c1new":16,"c3":"9","pk":7}}]}]}
+{"tables":[{"name":"test","data_diff":[{"from_row":{"c1":100,"pk":4},"to_row":{"c1new":200,"pk":4}},{"from_row":{"c1":8,"c3":"9","pk":7},"to_row":{"c1new":16,"c3":"9","pk":7}}]}]}
 EOF
 )
     [ "$status" -eq 0 ]

--- a/integration-tests/bats/sql-diff.bats
+++ b/integration-tests/bats/sql-diff.bats
@@ -864,3 +864,10 @@ EOF
 
     diff -w expected actual    
 }
+
+@test "sql-diff: stat" {
+    dolt diff --stat -r sql
+    run dolt diff --stat -r sql
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "diff stats are not supported for sql output" ]] || false
+}

--- a/integration-tests/bats/sql-diff.bats
+++ b/integration-tests/bats/sql-diff.bats
@@ -866,7 +866,7 @@ EOF
 }
 
 @test "sql-diff: stat" {
-    dolt diff --stat -r sql
+    dolt sql -q "create table t (i int primary key);"
     run dolt diff --stat -r sql
     [ "$status" -eq 1 ]
     [[ "$output" =~ "diff stats are not supported for sql output" ]] || false


### PR DESCRIPTION
This PR tidys up the code for printing diffs, specifically for JSON result format, and prints `--stat` correctly for JSON result format.
Additionally, we throw an error for SQL result format instead of just returning incorrect output. It might be worth implenting now, but I can just make an issue for it.

fixes: https://github.com/dolthub/dolt/issues/7800