### PR TITLE
Prevent panic when dropping columns in schema merge

### DIFF
--- a/go/libraries/doltcore/merge/merge_prolly_rows.go
+++ b/go/libraries/doltcore/merge/merge_prolly_rows.go
@@ -1823,7 +1823,7 @@ func (m *valueMerger) processBaseColumn(ctx context.Context, i int, left, right,
 	if err != nil {
 		return false, err
 	}
-	if modifiedVD.Comparator().CompareValues(i, baseCol, modifiedCol, modifiedVD.Types[i]) == 0 {
+	if modifiedVD.Comparator().CompareValues(i, baseCol, modifiedCol, modifiedVD.Types[modifiedColIdx]) == 0 {
 		return false, nil
 	}
 	return true, nil

--- a/go/libraries/doltcore/merge/merge_schema.go
+++ b/go/libraries/doltcore/merge/merge_schema.go
@@ -583,7 +583,7 @@ func checkSchemaConflicts(columnMappings columnMappings) ([]ColConflict, error) 
 			case theirs == nil && anc != nil:
 				// Column doesn't exist on their side, but does exist in ancestor
 				// This means the column was deleted on theirs side
-				if !anc.Equals(*ours) {
+				if !anc.EqualsWithoutTag(*ours) {
 					// col altered on our branch and deleted on their branch
 					conflicts = append(conflicts, ColConflict{
 						Kind: NameCollision,
@@ -623,7 +623,7 @@ func checkSchemaConflicts(columnMappings columnMappings) ([]ColConflict, error) 
 			case theirs != nil && anc != nil:
 				// Column exists on their side and in ancestor
 				// If ancs doesn't match theirs, the column was altered on both sides
-				if !anc.Equals(*theirs) {
+				if !anc.EqualsWithoutTag(*theirs) {
 					// col deleted on our branch and altered on their branch
 					conflicts = append(conflicts, ColConflict{
 						Kind:   NameCollision,

--- a/go/libraries/doltcore/merge/schema_merge_test.go
+++ b/go/libraries/doltcore/merge/schema_merge_test.go
@@ -706,7 +706,6 @@ var columnDefaultTests = []schemaMergeTest{
 	},
 	// one side changes columns, the other inserts rows
 	{
-		// TODO: this test silently does the wrong thing without erroring
 		name:     "left side column add, right side insert row",
 		ancestor: *tbl(sch("CREATE TABLE t (id int PRIMARY KEY)                  "), row(1)),
 		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int DEFAULT 42)"), row(1, 42)),

--- a/go/libraries/doltcore/merge/schema_merge_test.go
+++ b/go/libraries/doltcore/merge/schema_merge_test.go
@@ -351,13 +351,11 @@ var columnAddDropTests = []schemaMergeTest{
 		skipOldFmt: true,
 	},
 	{
-		name:       "independent column drops",
-		ancestor:   *tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, b int)"), row(1, 2, 3)),
-		left:       tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int)       "), row(1, 2)),
-		right:      tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int)       "), row(1, 3)),
-		merged:     *tbl(sch("CREATE TABLE t (id int PRIMARY KEY)              "), row(1)),
-		skipNewFmt: true,
-		skipOldFmt: true,
+		name:     "independent column drops",
+		ancestor: *tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, b int)"), row(1, 2, 3)),
+		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int)       "), row(1, 2)),
+		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int)       "), row(1, 3)),
+		merged:   *tbl(sch("CREATE TABLE t (id int PRIMARY KEY)              "), row(1)),
 	},
 	{
 		name:     "convergent column adds",
@@ -443,13 +441,11 @@ var columnAddDropTests = []schemaMergeTest{
 		},
 	},
 	{
-		name:       "convergent column adds, independent drops",
-		ancestor:   *tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, b int)"), row(1, 2, 3)),
-		left:       tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int, c int)"), row(1, 3, 4)),
-		right:      tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, c int)"), row(1, 2, 4)),
-		merged:     *tbl(sch("CREATE TABLE t (id int PRIMARY KEY, c int)       "), row(1, 4)),
-		skipNewFmt: true,
-		skipOldFmt: true,
+		name:     "convergent column adds, independent drops",
+		ancestor: *tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, b int)"), row(1, 2, 3)),
+		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int, c int)"), row(1, 3, 4)),
+		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, c int)"), row(1, 2, 4)),
+		merged:   *tbl(sch("CREATE TABLE t (id int PRIMARY KEY, c int)       "), row(1, 4)),
 	},
 	{
 		name:       "convergent column drops, independent adds",
@@ -469,13 +465,11 @@ var columnAddDropTests = []schemaMergeTest{
 		merged:   *tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int)"), row(1, 2), row(11, nil)),
 	},
 	{
-		name:                "left side column drop, right side insert row",
-		ancestor:            *tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int)"), row(1, 2)),
-		left:                tbl(sch("CREATE TABLE t (id int PRIMARY KEY)       "), row(1)),
-		right:               tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int)"), row(1, 2), row(11, 22)),
-		merged:              *tbl(sch("CREATE TABLE t (id int PRIMARY KEY)       "), row(1), row(11)),
-		skipNewFmt:          true,
-		skipFlipOnOldFormat: true,
+		name:     "left side column drop, right side insert row",
+		ancestor: *tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int)"), row(1, 2)),
+		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY)       "), row(1)),
+		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int)"), row(1, 2), row(11, 22)),
+		merged:   *tbl(sch("CREATE TABLE t (id int PRIMARY KEY)       "), row(1), row(11)),
 	},
 	// both sides change columns and insert rows
 	{
@@ -488,13 +482,11 @@ var columnAddDropTests = []schemaMergeTest{
 		skipOldFmt: true,
 	},
 	{
-		name:       "independent column drops, both sides insert independent rows",
-		ancestor:   *tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, b int)"), row(1, 2, 3)),
-		left:       tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int)       "), row(1, 2), row(12, 22)),
-		right:      tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int)       "), row(1, 3), row(13, 33)),
-		merged:     *tbl(sch("CREATE TABLE t (id int PRIMARY KEY)              "), row(1), row(12), row(13)),
-		skipNewFmt: true,
-		skipOldFmt: true,
+		name:     "independent column drops, both sides insert independent rows",
+		ancestor: *tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, b int)"), row(1, 2, 3)),
+		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int)       "), row(1, 2), row(12, 22)),
+		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int)       "), row(1, 3), row(13, 33)),
+		merged:   *tbl(sch("CREATE TABLE t (id int PRIMARY KEY)              "), row(1), row(12), row(13)),
 	},
 	{
 		name:     "convergent column adds, both sides insert independent rows",
@@ -520,13 +512,11 @@ var columnAddDropTests = []schemaMergeTest{
 		skipOldFmt: true,
 	},
 	{
-		name:       "independent column drops, both sides insert same row",
-		ancestor:   *tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, b int)"), row(1, 2, 3)),
-		left:       tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int)       "), row(1, 2), row(12, 22)),
-		right:      tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int)       "), row(1, 3), row(12, 33)),
-		merged:     *tbl(sch("CREATE TABLE t (id int PRIMARY KEY)              "), row(1), row(12)),
-		skipNewFmt: true,
-		skipOldFmt: true,
+		name:     "independent column drops, both sides insert same row",
+		ancestor: *tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, b int)"), row(1, 2, 3)),
+		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int)       "), row(1, 2), row(12, 22)),
+		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY, b int)       "), row(1, 3), row(12, 33)),
+		merged:   *tbl(sch("CREATE TABLE t (id int PRIMARY KEY)              "), row(1), row(12)),
 	},
 	{
 		name:     "right side drops and adds column of same type",
@@ -717,13 +707,11 @@ var columnDefaultTests = []schemaMergeTest{
 	// one side changes columns, the other inserts rows
 	{
 		// TODO: this test silently does the wrong thing without erroring
-		skipNewFmt: true,
-		skipOldFmt: true,
-		name:       "left side column add, right side insert row",
-		ancestor:   *tbl(sch("CREATE TABLE t (id int PRIMARY KEY)                  "), row(1)),
-		left:       tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int DEFAULT 42)"), row(1, 42)),
-		right:      tbl(sch("CREATE TABLE t (id int PRIMARY KEY)                  "), row(1), row(12)),
-		merged:     *tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int DEFAULT 42)"), row(1, 42), row(12, 42)),
+		name:     "left side column add, right side insert row",
+		ancestor: *tbl(sch("CREATE TABLE t (id int PRIMARY KEY)                  "), row(1)),
+		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int DEFAULT 42)"), row(1, 42)),
+		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY)                  "), row(1), row(12)),
+		merged:   *tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int DEFAULT 42)"), row(1, 42), row(12, 42)),
 	},
 	// both sides change columns and insert rows
 	{
@@ -1445,17 +1433,16 @@ func testSchemaMergeHelper(t *testing.T, tests []schemaMergeTest, flipSides bool
 							require.NoError(t, err)
 							require.EqualValues(t, numConstraintViolations, len(expConstraintViolations))
 
+							sch, err := actTbl.GetSchema(ctx)
+							require.NoError(t, err)
+							kd, vd := sch.GetMapDescriptors()
+
 							if len(expConstraintViolations) > 0 {
 								artifacts, err := actTbl.GetArtifacts(ctx)
 								require.NoError(t, err)
 								artifactMap := durable.ProllyMapFromArtifactIndex(artifacts)
 								artifactIter, err := artifactMap.IterAllCVs(ctx)
 								require.NoError(t, err)
-
-								sch, err := actTbl.GetSchema(ctx)
-								require.NoError(t, err)
-
-								kd, vd := sch.GetMapDescriptors()
 
 								// value tuples encoded in ConstraintViolationMeta may
 								// violate the not null constraints assumed by fixed access
@@ -1472,10 +1459,18 @@ func testSchemaMergeHelper(t *testing.T, tests []schemaMergeTest, flipSides bool
 								if addr != a {
 									expTbl, _, err := m.GetTable(ctx, doltdb.TableName{Name: name})
 									require.NoError(t, err)
+									expSchema, err := expTbl.GetSchema(ctx)
+									require.NoError(t, err)
 									expRowDataHash, err := expTbl.GetRowDataHash(ctx)
 									require.NoError(t, err)
 									actRowDataHash, err := actTbl.GetRowDataHash(ctx)
 									require.NoError(t, err)
+									if !expSchema.GetKeyDescriptor().Equals(kd) {
+										t.Fatal("Primary key descriptors unequal")
+									}
+									if !expSchema.GetValueDescriptor().Equals(vd) {
+										t.Fatal("Value descriptors unequal")
+									}
 									if expRowDataHash != actRowDataHash {
 										t.Error("Rows unequal")
 										t.Logf("expected rows: %s", expTbl.DebugString(ctx, m.NodeStore()))
@@ -1484,8 +1479,6 @@ func testSchemaMergeHelper(t *testing.T, tests []schemaMergeTest, flipSides bool
 									expIndexSet, err := expTbl.GetIndexSet(ctx)
 									require.NoError(t, err)
 									actIndexSet, err := actTbl.GetIndexSet(ctx)
-									require.NoError(t, err)
-									expSchema, err := expTbl.GetSchema(ctx)
 									require.NoError(t, err)
 									expSchema.Indexes().Iter(func(index schema.Index) (stop bool, err error) {
 										expIndex, err := expIndexSet.GetIndex(ctx, expSchema, index.Name())

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_schema_merge.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_schema_merge.go
@@ -2541,35 +2541,4 @@ var SchemaChangeTestsForJsonConflicts = []MergeScriptTest{
 
 // These tests are not run because they cause panics during set-up.
 // Each one is labeled with a GitHub issue.
-var DisabledSchemaChangeTests = []MergeScriptTest{
-	{
-		Name: "panic regression test https://github.com/dolthub/dolt/issues/7762",
-		AncSetUpScript: []string{
-			"CREATE table t (pk int primary key, col1 int, col2 int);",
-			"INSERT into t values (1, 10, 100), (2, 20, 200);",
-		},
-		RightSetUpScript: []string{
-			"alter table t drop column col2;",
-			"insert into t values (3, 30), (4, 40);",
-		},
-		LeftSetUpScript: []string{
-			"alter table t drop column col1;",
-			"alter table t rename column col2 to col1;",
-			"insert into t values (5, 50), (6, 60);",
-		},
-		Assertions: []queries.ScriptTestAssertion{
-			{
-				Query:    "call dolt_merge('right');",
-				Expected: []sql.Row{{doltCommit, 0, 0, "merge successful"}},
-			},
-			{
-				Query: "select * from t;",
-				Expected: []sql.Row{
-					{1, 10}, {2, 20},
-					{3, 30}, {4, 40},
-					{5, 50}, {6, 60},
-				},
-			},
-		},
-	},
-}
+var DisabledSchemaChangeTests = []MergeScriptTest{}

--- a/go/store/prolly/tree/node.go
+++ b/go/store/prolly/tree/node.go
@@ -223,14 +223,14 @@ func OutputProllyNode(ctx context.Context, w io.Writer, node Node, ns NodeStore,
 				w.Write([]byte(", "))
 			}
 
-			isAddr := val.IsAddrEncoding(kd.Types[i].Enc)
+			isAddr := val.IsAddrEncoding(kd.Types[j].Enc)
 			if isAddr {
 				w.Write([]byte("#"))
 			}
 			w.Write([]byte(hex.EncodeToString(kd.GetField(j, kt))))
 			if isAddr {
 				w.Write([]byte(" ("))
-				key, err := GetField(ctx, kd, i, kt, ns)
+				key, err := GetField(ctx, kd, j, kt, ns)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/7762

In certain cases, performing a schema merge when the merged schema had fewer columns than the base schema would cause a panic.

We actually had a test for this, but the test was disabled because a limitation in how the test harness generated column tags was causing incorrect detection of merge conflicts.

To re-enable these tests, this PR slightly relaxes the logic for merge conflicts wrt column tags. This is safe to do because column tags shouldn't influence the result of merges outside of helping to identify renamed columns, so long as the merge behaves the same in both directions.