### PR TITLE
Bug fix: Apply replication settings for newly cloned databases

### DIFF
--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -461,7 +461,7 @@ func (p *DoltDatabaseProvider) CreateCollatedDatabase(ctx *sql.Context, name str
 type InitDatabaseHook func(ctx *sql.Context, pro *DoltDatabaseProvider, name string, env *env.DoltEnv, db dsess.SqlDatabase) error
 type DropDatabaseHook func(ctx *sql.Context, name string)
 
-// ConfigureReplicationDatabaseHook sets up replication for a newly created database as necessary
+// ConfigureReplicationDatabaseHook sets up the hooks to push to a remote to replicate a newly created database.
 // TODO: consider the replication heads / all heads setting
 func ConfigureReplicationDatabaseHook(ctx *sql.Context, p *DoltDatabaseProvider, name string, newEnv *env.DoltEnv, _ dsess.SqlDatabase) error {
 	_, replicationRemoteName, _ := sql.SystemVariables.GetGlobal(dsess.ReplicateToRemote)
@@ -723,8 +723,17 @@ func (p *DoltDatabaseProvider) registerNewDatabase(ctx *sql.Context, name string
 		}
 	}
 
+	mrEnv, err := env.MultiEnvForSingleEnv(ctx, newEnv)
+	if err != nil {
+		return err
+	}
+	dbs, err := ApplyReplicationConfig(ctx, sql.NewBackgroundThreads(), mrEnv, cli.CliErr, db)
+	if err != nil {
+		return err
+	}
+
 	formattedName := formatDbMapKeyName(db.Name())
-	p.databases[formattedName] = db
+	p.databases[formattedName] = dbs[0]
 	p.dbLocations[formattedName] = newEnv.FS
 	return nil
 }

--- a/go/libraries/doltcore/sqle/read_replica_database.go
+++ b/go/libraries/doltcore/sqle/read_replica_database.go
@@ -111,6 +111,8 @@ func (rrd ReadReplicaDatabase) DoltDatabases() []*doltdb.DoltDB {
 }
 
 func (rrd ReadReplicaDatabase) PullFromRemote(ctx *sql.Context) error {
+	ctx.GetLogger().Tracef("pulling from remote %s for database %s", rrd.remote.Name, rrd.Name())
+
 	_, headsArg, ok := sql.SystemVariables.GetGlobal(dsess.ReplicateHeads)
 	if !ok {
 		return sql.ErrUnknownSystemVariable.New(dsess.ReplicateHeads)

--- a/go/libraries/doltcore/sqle/replication.go
+++ b/go/libraries/doltcore/sqle/replication.go
@@ -120,7 +120,7 @@ func ApplyReplicationConfig(ctx context.Context, bThreads *sql.BackgroundThreads
 	for i, db := range dbs {
 		dEnv := mrEnv.GetEnv(db.Name())
 		if dEnv == nil {
-			outputDbs = append(outputDbs, db)
+			outputDbs[i] = db
 			continue
 		}
 		postCommitHooks, err := GetCommitHooks(ctx, bThreads, dEnv, logger)

--- a/go/libraries/doltcore/sqle/replication.go
+++ b/go/libraries/doltcore/sqle/replication.go
@@ -107,6 +107,11 @@ func newReplicaDatabase(ctx context.Context, name string, remoteName string, dEn
 		return ReadReplicaDatabase{}, err
 	}
 
+	if sqlCtx, ok := ctx.(*sql.Context); ok {
+		sqlCtx.GetLogger().Infof(
+			"replication enabled for database '%s' from remote '%s'", name, remoteName)
+	}
+
 	return rrd, nil
 }
 


### PR DESCRIPTION
Dolt SQL servers using remote-based replication will pull new databases if the [@@dolt_replication_remote_url_template system variable](https://docs.dolthub.com/sql-reference/version-control/dolt-sysvars#dolt_replication_remote_url_template) is configured, but those new databases weren't getting configured to continue pulling updates from the remote.

This change registers the newly cloned databases as `ReadReplicaDatabase` instances, so that they will poll their remote and pull new commits. It also adds some additional logging to help debug issues with remote-based replication. 