### PR TITLE
go/utils/publishrelease: Bump MUSL toolchains used for cutting releases.

### DIFF
--- a/go/Godeps/LICENSES
+++ b/go/Godeps/LICENSES
@@ -240,6 +240,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 = LICENSE ed6066ae50f153e2965216c6d4b9335900f1f8b2b526527f49a619d7 =
 ================================================================================
+
 ================================================================================
 = Some copies of Dolt include portions of musl, statically linked, licensed under: =
 
@@ -438,6 +439,34 @@ permissive licensing, and of not having licensing issues being an
 obstacle to adoption, that text has been removed.
 
 = MUSL_COPYRIGHT 7eabc8241856c097564dfaf6585a2a7a3dad1c85eaa11d2cd80e03b3 =
+================================================================================
+
+================================================================================
+= Some copies of Dolt include portions of mimalloc, statically linked, licensed under: =
+
+MIT License
+
+Copyright (c) 2018-2021 Microsoft Corporation, Daan Leijen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+= MIMALLOC_LICENSE 723271586dbcd941ce1102864b0190dfe4fc501e26566bec73465450 =
 ================================================================================
 
 ================================================================================

--- a/go/utils/3pdeps/MIMALLOC_LICENSE
+++ b/go/utils/3pdeps/MIMALLOC_LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018-2021 Microsoft Corporation, Daan Leijen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/go/utils/3pdeps/main.go
+++ b/go/utils/3pdeps/main.go
@@ -90,6 +90,7 @@ func main() {
 	PrintDoltLicense(out)
 	PrintGoLicense(out, root)
 	PrintMuslLicense(out)
+	PrintMimallocLicense(out)
 
 	sort.Strings(mods)
 	var l string
@@ -131,9 +132,16 @@ func PrintDoltLicense(out io.Writer) {
 }
 
 func PrintMuslLicense(out io.Writer) {
-	fmt.Fprintf(out, "================================================================================\n")
+	fmt.Fprintf(out, "\n================================================================================\n")
 	fmt.Fprintf(out, "= Some copies of Dolt include portions of musl, statically linked, licensed under: =\n\n")
 	PrintLicense(out, "utils/3pdeps/MUSL_COPYRIGHT")
+	fmt.Fprintf(out, "================================================================================\n")
+}
+
+func PrintMimallocLicense(out io.Writer) {
+	fmt.Fprintf(out, "\n================================================================================\n")
+	fmt.Fprintf(out, "= Some copies of Dolt include portions of mimalloc, statically linked, licensed under: =\n\n")
+	PrintLicense(out, "utils/3pdeps/MIMALLOC_LICENSE")
 	fmt.Fprintf(out, "================================================================================\n")
 }
 

--- a/go/utils/publishrelease/buildpgobinaries.sh
+++ b/go/utils/publishrelease/buildpgobinaries.sh
@@ -15,7 +15,7 @@ set -o pipefail
 apt-get update && apt-get install -y p7zip-full pigz curl xz-utils mingw-w64 clang-15
 
 cd /
-curl -o optcross.tar.xz https://dolthub-tools.s3.us-west-2.amazonaws.com/optcross/"$(uname -m)"-linux_20240425_0.0.1.tar.xz
+curl -o optcross.tar.xz https://dolthub-tools.s3.us-west-2.amazonaws.com/optcross/"$(uname -m)"-linux_20240515_0.0.2.tar.xz
 tar Jxf optcross.tar.xz
 export PATH=/opt/cross/bin:"$PATH"
 


### PR DESCRIPTION
The new toolchain uses MUSL + mimalloc.

Include the mimalloc license in our released LICENSES notice.