### PR TITLE
Various test utils and small fixes

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -168,4 +168,4 @@ require (
 
 replace github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi => ./gen/proto/dolt/services/eventsapi
 
-go 1.22
+go 1.22.2

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_controller.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_controller.go
@@ -253,6 +253,14 @@ func (d *doltBinlogReplicaController) SetReplicationSourceOptions(ctx *sql.Conte
 				return err
 			}
 			replicaSourceInfo.ConnectRetryCount = uint64(intValue)
+		case "SOURCE_AUTO_POSITION":
+			intValue, err := getOptionValueAsInt(option)
+			if err != nil {
+				return err
+			}
+			if intValue < 1 {
+				return fmt.Errorf("SOURCE_AUTO_POSITION cannot be disabled")
+			}
 		default:
 			return fmt.Errorf("unknown replication source option: %s", option.Name)
 		}

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_reconnect_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_reconnect_test.go
@@ -191,13 +191,37 @@ func turnOnLimitDataToxic(t *testing.T) {
 // More info at the end of this issue: https://github.com/jmoiron/sqlx/issues/225
 func convertMapScanResultToStrings(m map[string]interface{}) map[string]interface{} {
 	for key, value := range m {
-		if bytes, ok := value.([]uint8); ok {
-			m[key] = string(bytes)
-		}
-		if i, ok := value.(int64); ok {
-			m[key] = strconv.FormatInt(i, 10)
+		switch v := value.(type) {
+		case []uint8:
+			m[key] = string(v)
+		case int64:
+			m[key] = strconv.FormatInt(v, 10)
+		case uint64:
+			m[key] = strconv.FormatUint(v, 10)
 		}
 	}
 
 	return m
+}
+
+// convertSliceScanResultToStrings returns a new slice, formed by converting each value in the slice |ss| into a string.
+// This is necessary because SliceScan doesn't honor (or know about) the correct underlying SQL types –it
+// gets results back as strings, typed as []byte, or as int64 values.
+// More info at the end of this issue: https://github.com/jmoiron/sqlx/issues/225
+func convertSliceScanResultToStrings(ss []any) []any {
+	row := make([]any, len(ss))
+	for i, value := range ss {
+		switch v := value.(type) {
+		case []uint8:
+			row[i] = string(v)
+		case int64:
+			row[i] = strconv.FormatInt(v, 10)
+		case uint64:
+			row[i] = strconv.FormatUint(v, 10)
+		default:
+			row[i] = v
+		}
+	}
+
+	return row
 }

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_restart_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_restart_test.go
@@ -49,7 +49,7 @@ func TestBinlogReplicationServerRestart(t *testing.T) {
 	time.Sleep(1000 * time.Millisecond)
 
 	var err error
-	doltPort, doltProcess, err = startDoltSqlServer(testDir)
+	doltPort, doltProcess, err = startDoltSqlServer(testDir, nil)
 	require.NoError(t, err)
 
 	// Check replication status on the replica and assert configuration persisted

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_test.go
@@ -49,7 +49,7 @@ var originalWorkingDir string
 
 func teardown(t *testing.T) {
 	if mySqlProcess != nil {
-		mySqlProcess.Kill()
+		stopMySqlServer(t)
 	}
 	if doltProcess != nil {
 		stopDoltSqlServer(t)
@@ -142,11 +142,9 @@ func TestFlushLogs(t *testing.T) {
 	primaryDatabase.MustExec("insert into t values (1), (2), (3);")
 	waitForReplicaToCatchUp(t)
 
-	rows, err := replicaDatabase.Queryx("select * from db01.t;")
-	require.NoError(t, err)
-	allRows := readAllRows(t, rows)
-	require.Equal(t, 3, len(allRows))
-	require.NoError(t, rows.Close())
+	requireReplicaResults(t, "select * from db01.t;", [][]any{
+		{"1"}, {"2"}, {"3"},
+	})
 }
 
 // TestResetReplica tests that "RESET REPLICA" and "RESET REPLICA ALL" correctly clear out
@@ -167,9 +165,7 @@ func TestResetReplica(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, rows.Close())
 
-	rows, err = replicaDatabase.Queryx("SHOW REPLICA STATUS;")
-	require.NoError(t, err)
-	status := convertMapScanResultToStrings(readNextRow(t, rows))
+	status := queryReplicaStatus(t)
 	require.Equal(t, "0", status["Last_Errno"])
 	require.Equal(t, "", status["Last_Error"])
 	require.Equal(t, "0", status["Last_IO_Errno"])
@@ -178,7 +174,6 @@ func TestResetReplica(t *testing.T) {
 	require.Equal(t, "0", status["Last_SQL_Errno"])
 	require.Equal(t, "", status["Last_SQL_Error"])
 	require.Equal(t, "", status["Last_SQL_Error_Timestamp"])
-	require.NoError(t, rows.Close())
 
 	// Calling RESET REPLICA ALL clears out all replica configuration
 	rows, err = replicaDatabase.Queryx("RESET REPLICA ALL;")
@@ -358,7 +353,7 @@ func TestDoltCommits(t *testing.T) {
 	// Verify that commit timestamps are unique
 	rows, err = replicaDatabase.Queryx("select distinct date from db01.dolt_log;")
 	require.NoError(t, err)
-	allRows := readAllRows(t, rows)
+	allRows := readAllRowsIntoMaps(t, rows)
 	require.Equal(t, 5, len(allRows)) // 4 transactions + 1 initial commit
 }
 
@@ -534,7 +529,9 @@ func readNextRow(t *testing.T, rows *sqlx.Rows) map[string]interface{} {
 	return row
 }
 
-func readAllRows(t *testing.T, rows *sqlx.Rows) []map[string]interface{} {
+// readAllRowsIntoMaps reads all data from |rows| and returns a slice of maps, where each key
+// in the map is the field name, and each value is the string representation of the field value.
+func readAllRowsIntoMaps(t *testing.T, rows *sqlx.Rows) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0)
 	for {
 		row := make(map[string]interface{})
@@ -548,7 +545,31 @@ func readAllRows(t *testing.T, rows *sqlx.Rows) []map[string]interface{} {
 	}
 }
 
+// readAllRowsIntoSlices reads all data from |rows| and returns a slice of slices, with
+// all values converted to strings.
+func readAllRowsIntoSlices(t *testing.T, rows *sqlx.Rows) [][]any {
+	result := make([][]any, 0)
+	for {
+		if rows.Next() == false {
+			return result
+		}
+		row, err := rows.SliceScan()
+		require.NoError(t, err)
+		row = convertSliceScanResultToStrings(row)
+		result = append(result, row)
+	}
+}
+
+// startSqlServers starts a MySQL server and a Dolt sql-server for use in tests.
 func startSqlServers(t *testing.T) {
+	startSqlServersWithDoltSystemVars(t, nil)
+}
+
+// startSqlServersWithDoltSystemVars starts a MySQL server and a Dolt sql-server for use in tests. Before the
+// Dolt sql-server is started, the specified |doltPersistentSystemVars| are persisted in the Dolt sql-server's
+// local configuration. These are useful when you need to set system variables that must be available when the
+// sql-server starts up, such as replication system variables.
+func startSqlServersWithDoltSystemVars(t *testing.T, doltPersistentSystemVars map[string]string) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping binlog replication integ tests on Windows OS")
 	} else if runtime.GOOS == "darwin" && os.Getenv("CI") == "true" {
@@ -570,10 +591,18 @@ func startSqlServers(t *testing.T) {
 	// Start up primary and replica databases
 	mySqlPort, mySqlProcess, err = startMySqlServer(testDir)
 	require.NoError(t, err)
-	doltPort, doltProcess, err = startDoltSqlServer(testDir)
+	doltPort, doltProcess, err = startDoltSqlServer(testDir, doltPersistentSystemVars)
 	require.NoError(t, err)
 }
 
+// stopMySqlServer stops the running MySQL server. If any errors are encountered while stopping
+// the MySQL server, this function will fail the current test.
+func stopMySqlServer(t *testing.T) {
+	require.NoError(t, mySqlProcess.Kill())
+}
+
+// stopDoltSqlServer stops the running Dolt sql-server. If any errors are encountered while
+// stopping the Dolt sql-server, this function will fail the current test.
 func stopDoltSqlServer(t *testing.T) {
 	// Use the negative process ID so that we grab the entire process group.
 	// This is necessary to kill all the processes the child spawns.
@@ -605,8 +634,9 @@ func stopDoltSqlServer(t *testing.T) {
 func startReplication(_ *testing.T, port int) {
 	replicaDatabase.MustExec("SET @@GLOBAL.server_id=123;")
 	replicaDatabase.MustExec(
-		fmt.Sprintf("change replication source to SOURCE_HOST='localhost', SOURCE_USER='replicator', "+
-			"SOURCE_PASSWORD='Zqr8_blrGm1!', SOURCE_PORT=%v;", port))
+		fmt.Sprintf("change replication source to SOURCE_HOST='localhost', "+
+			"SOURCE_USER='replicator', SOURCE_PASSWORD='Zqr8_blrGm1!', "+
+			"SOURCE_PORT=%v, SOURCE_AUTO_POSITION=1, SOURCE_CONNECT_RETRY=5;", port))
 
 	replicaDatabase.MustExec("start replica;")
 }
@@ -686,16 +716,21 @@ func startMySqlServer(dir string) (int, *os.Process, error) {
 		username = "mysql"
 	}
 
-	// Create a fresh MySQL server for the primary
-	chmodCmd := exec.Command("mysqld",
-		"--no-defaults",
-		"--user="+username,
-		"--initialize-insecure",
-		"--datadir="+dataDir,
-		"--default-authentication-plugin=mysql_native_password")
-	output, err = chmodCmd.CombinedOutput()
-	if err != nil {
-		return -1, nil, fmt.Errorf("unable to execute command %v: %v – %v", cmd.String(), err.Error(), string(output))
+	// Check to see if the MySQL data directory has the "mysql" directory in it, which
+	// tells us whether this MySQL instance has been initialized yet or not.
+	initialized := directoryExists(filepath.Join(dataDir, "mysql"))
+	if !initialized {
+		// Create a fresh MySQL server for the primary
+		chmodCmd := exec.Command("mysqld",
+			"--no-defaults",
+			"--user="+username,
+			"--initialize-insecure",
+			"--datadir="+dataDir,
+			"--default-authentication-plugin=mysql_native_password")
+		output, err = chmodCmd.CombinedOutput()
+		if err != nil {
+			return -1, nil, fmt.Errorf("unable to execute command %v: %v – %v", cmd.String(), err.Error(), string(output))
+		}
 	}
 
 	cmd = exec.Command("mysqld",
@@ -703,6 +738,7 @@ func startMySqlServer(dir string) (int, *os.Process, error) {
 		"--user="+username,
 		"--datadir="+dataDir,
 		"--gtid-mode=ON",
+		"--skip-replica-start=ON",
 		"--enforce-gtid-consistency=ON",
 		fmt.Sprintf("--port=%v", mySqlPort),
 		"--server-id=11223344",
@@ -734,8 +770,12 @@ func startMySqlServer(dir string) (int, *os.Process, error) {
 		return -1, nil, err
 	}
 
-	// Create the initial database on the MySQL server
-	primaryDatabase.MustExec("create database db01;")
+	// Create the initial database and replication user on the MySQL server if this is the first launch
+	if !initialized {
+		primaryDatabase.MustExec("create database db01;")
+		primaryDatabase.MustExec("CREATE USER 'replicator'@'%' IDENTIFIED BY 'Zqr8_blrGm1!';")
+		primaryDatabase.MustExec("GRANT REPLICATION SLAVE ON *.* TO 'replicator'@'%';")
+	}
 
 	dsn = fmt.Sprintf("root@tcp(127.0.0.1:%v)/db01", mySqlPort)
 	primaryDatabase = sqlx.MustOpen("mysql", dsn)
@@ -743,13 +783,26 @@ func startMySqlServer(dir string) (int, *os.Process, error) {
 	os.Chdir(originalCwd)
 	fmt.Printf("MySQL server started on port %v \n", mySqlPort)
 
-	primaryDatabase.MustExec("CREATE USER 'replicator'@'%' IDENTIFIED BY 'Zqr8_blrGm1!';")
-	primaryDatabase.MustExec("GRANT REPLICATION SLAVE ON *.* TO 'replicator'@'%';")
-
 	return mySqlPort, cmd.Process, nil
 }
 
+// directoryExists returns true if the specified |path| is to a directory that exists, otherwise,
+// if the path doesn't exist or isn't a directory, false is returned.
+func directoryExists(path string) bool {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return info.IsDir()
+}
+
+var cachedDoltDevBuildPath = ""
+
 func initializeDevDoltBuild(dir string, goDirPath string) string {
+	if cachedDoltDevBuildPath != "" {
+		return cachedDoltDevBuildPath
+	}
+
 	// If we're not in a CI environment, don't worry about building a dev build
 	if os.Getenv("CI") != "true" {
 		return ""
@@ -771,17 +824,26 @@ func initializeDevDoltBuild(dir string, goDirPath string) string {
 	if err != nil {
 		panic("unable to build dolt for binlog integration tests: " + err.Error() + "\nFull output: " + string(output) + "\n")
 	}
-	return fullpath
+	cachedDoltDevBuildPath = fullpath
+
+	return cachedDoltDevBuildPath
 }
 
-func startDoltSqlServer(dir string) (int, *os.Process, error) {
+// startDoltSqlServer starts a Dolt sql-server on a free port from the specified directory |dir|. If
+// |doltPeristentSystemVars| is populated, then those system variables will be set, persistently, for
+// the Dolt database, before the Dolt sql-server is started.
+func startDoltSqlServer(dir string, doltPersistentSystemVars map[string]string) (int, *os.Process, error) {
 	dir = filepath.Join(dir, "dolt")
 	err := os.MkdirAll(dir, 0777)
 	if err != nil {
 		return -1, nil, err
 	}
 
-	doltPort = findFreePort()
+	// If we already assigned a port, re-use it. This is useful when testing restarting a primary, since
+	// we want the primary to come back up on the same port, so the replica can reconnect.
+	if doltPort == 0 {
+		doltPort = findFreePort()
+	}
 	fmt.Printf("Starting Dolt sql-server on port: %d, with data dir %s\n", doltPort, dir)
 
 	// take the CWD and move up four directories to find the go directory
@@ -802,6 +864,22 @@ func startDoltSqlServer(dir string) (int, *os.Process, error) {
 
 	// use an admin user NOT named "root" to test that we don't require the "root" account
 	adminUser := "admin"
+
+	if doltPersistentSystemVars != nil && len(doltPersistentSystemVars) > 0 {
+		// Initialize the dolt directory first
+		err = runDoltCommand(dir, goDirPath, "init")
+		if err != nil {
+			return -1, nil, err
+		}
+
+		for systemVar, value := range doltPersistentSystemVars {
+			query := fmt.Sprintf("SET @@PERSIST.%s=%s;", systemVar, value)
+			err = runDoltCommand(dir, goDirPath, "sql", fmt.Sprintf("-q=%s", query))
+			if err != nil {
+				return -1, nil, err
+			}
+		}
+	}
 
 	args := []string{"go", "run", "./cmd/dolt",
 		"sql-server",
@@ -864,6 +942,31 @@ func startDoltSqlServer(dir string) (int, *os.Process, error) {
 	return doltPort, cmd.Process, nil
 }
 
+// runDoltCommand runs a short-lived dolt CLI command with the specified arguments from |doltArgs|. The Dolt data
+// directory is specified from |doltDataDir| and |goDirPath| is the path to the go directory within the Dolt repo.
+// This function will only return when the Dolt CLI command has completed, so it is not suitable for running
+// long-lived commands such as "sql-server". If the command fails, an error is returned with the combined output.
+func runDoltCommand(doltDataDir string, goDirPath string, doltArgs ...string) error {
+	// If we're running in CI, use a precompiled dolt binary instead of go run
+	devDoltPath := initializeDevDoltBuild(doltDataDir, goDirPath)
+
+	args := append([]string{"go", "run", "./cmd/dolt",
+		fmt.Sprintf("--data-dir=%s", doltDataDir)},
+		doltArgs...)
+	if devDoltPath != "" {
+		args[2] = devDoltPath
+		args = args[2:]
+	}
+	cmd := exec.Command(args[0], args[1:]...)
+	fmt.Printf("Running Dolt CMD: %s\n", cmd.String())
+	output, err := cmd.CombinedOutput()
+	fmt.Printf("Dolt CMD output: %s\n", string(output))
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, string(output))
+	}
+	return nil
+}
+
 // waitForSqlServerToStart polls the specified database to wait for it to become available, pausing
 // between retry attempts, and returning an error if it is not able to verify that the database is
 // available.
@@ -911,4 +1014,41 @@ func assertRepoStateFileExists(t *testing.T, db string) {
 
 	_, err := os.Stat(repoStateFile)
 	require.NoError(t, err)
+}
+
+// requireReplicaResults runs the specified |query| on the replica database and asserts that the results match
+// |expectedResults|. Note that the actual results are converted to string values in almost all cases, due to
+// limitations in the SQL library we use to query the replica database, so |expectedResults| should generally
+// be expressed in strings.
+func requireReplicaResults(t *testing.T, query string, expectedResults [][]any) {
+	requireResults(t, replicaDatabase, query, expectedResults)
+}
+
+// requireReplicaResults runs the specified |query| on the primary database and asserts that the results match
+// |expectedResults|. Note that the actual results are converted to string values in almost all cases, due to
+// limitations in the SQL library we use to query the replica database, so |expectedResults| should generally
+// be expressed in strings.
+func requirePrimaryResults(t *testing.T, query string, expectedResults [][]any) {
+	requireResults(t, primaryDatabase, query, expectedResults)
+}
+
+func requireResults(t *testing.T, db *sqlx.DB, query string, expectedResults [][]any) {
+	rows, err := db.Queryx(query)
+	require.NoError(t, err)
+	allRows := readAllRowsIntoSlices(t, rows)
+	require.Equal(t, len(expectedResults), len(allRows), "Expected %v, got %v", expectedResults, allRows)
+	for i := range expectedResults {
+		require.Equal(t, expectedResults[i], allRows[i], "Expected %v, got %v", expectedResults[i], allRows[i])
+	}
+	require.NoError(t, rows.Close())
+}
+
+// queryReplicaStatus returns the results of `SHOW REPLICA STATUS` as a map, for the replica
+// database. If any errors are encountered, this function will fail the current test.
+func queryReplicaStatus(t *testing.T) map[string]any {
+	rows, err := replicaDatabase.Queryx("SHOW REPLICA STATUS;")
+	require.NoError(t, err)
+	status := convertMapScanResultToStrings(readNextRow(t, rows))
+	require.NoError(t, rows.Close())
+	return status
 }

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_test.go
@@ -217,6 +217,13 @@ func TestStartReplicaErrors(t *testing.T) {
 	require.ErrorContains(t, err, "Invalid (empty) username")
 	require.Nil(t, rows)
 
+	// SOURCE_AUTO_POSITION cannot be disabled – we only support GTID positioning
+	rows, err = replicaDatabase.Queryx("CHANGE REPLICATION SOURCE TO SOURCE_PORT=1234, " +
+		"SOURCE_HOST='localhost', SOURCE_USER='replicator', SOURCE_AUTO_POSITION=0;")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "Error 1105 (HY000): SOURCE_AUTO_POSITION cannot be disabled")
+	require.Nil(t, rows)
+
 	// START REPLICA logs a warning if replication is already running
 	startReplication(t, mySqlPort)
 	replicaDatabase.MustExec("START REPLICA;")

--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -1474,7 +1474,7 @@ func (d *DoltSession) RemoveAllPersistedGlobals() error {
 	return d.globalsConf.Unset(allVars)
 }
 
-// RemoveAllPersistedGlobals implements sql.PersistableSession
+// GetPersistedValue implements sql.PersistableSession
 func (d *DoltSession) GetPersistedValue(k string) (interface{}, error) {
 	if d.globalsConf == nil {
 		return nil, ErrSessionNotPersistable

--- a/go/store/val/tuple_descriptor.go
+++ b/go/store/val/tuple_descriptor.go
@@ -375,8 +375,8 @@ func (td TupleDesc) GetDate(i int, tup Tuple) (v time.Time, ok bool) {
 	return
 }
 
-// GetSqlTime reads a string encoded Time value from the ith field of the Tuple.
-// If the ith field is NULL, |ok| is set to false.
+// GetSqlTime reads an int64 encoded Time value, representing a duration as a number of microseconds,
+// from the ith field of the Tuple. If the ith field is NULL, |ok| is set to false.
 func (td TupleDesc) GetSqlTime(i int, tup Tuple) (v int64, ok bool) {
 	td.expectEncoding(i, TimeEnc)
 	b := td.GetField(i, tup)

--- a/integration-tests/go-sql-server-driver/go.mod
+++ b/integration-tests/go-sql-server-driver/go.mod
@@ -1,6 +1,6 @@
 module github.com/dolthub/dolt/integration-tests/go-sql-server-driver
 
-go 1.22
+go 1.22.2
 
 require (
 	github.com/dolthub/dolt/go v0.40.4


### PR DESCRIPTION
As part of the work for binlog source support (on [fulghum/binlog_prototype branch](https://github.com/dolthub/dolt/tree/fulghum/binlog_prototype)), these are various smaller changes to tidy up docs, packaging, small bug fixes, and add new test utils that I've pulled out into this PR to review separately.

Notable changes:
- Adds the third version component to the go version in our `go.mod`. [Two component versions indicate a development version, not a release version and cause an error about not being able to download a toolchain.](https://github.com/golang/go/issues/62278#issuecomment-1693538776)
- Allows Dolt binlog replicas to accept the `SOURCE_AUTO_POSITION` config parameter, and errors if a user attempts to disable GTID auto positioning. 
- Adds several new test util functions specific to binlog testing.