### PR TITLE
Bug fix: no-op `dolt_pull()` was leaving working set dirty

### DIFF
--- a/go/libraries/doltcore/sqle/dprocedures/dolt_pull.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_pull.go
@@ -204,11 +204,6 @@ func doDoltPull(ctx *sql.Context, args []string) (int, int, string, error) {
 			if err != nil && !errors.Is(doltdb.ErrUpToDate, err) {
 				return conflicts, fastForward, "", err
 			}
-
-			err = sess.SetWorkingSet(ctx, dbName, ws)
-			if err != nil {
-				return conflicts, fastForward, "", err
-			}
 		}
 		if !rsSeen {
 			return noConflictsOrViolations, threeWayMerge, "", fmt.Errorf("%w: '%s'", ref.ErrInvalidRefSpec, refSpec.GetRemRefToLocal())


### PR DESCRIPTION
Customer-reported bug. Two `dolt_pull()` operations on two branches in the same session when local branches are already up to date, with `@@autocommit` off, leave the session unable to commit because two branch heads are considered dirty. See new bats test for details on reproducing.

The issue is that `DoltSession.SetWorkingSet()` marks that branch head dirty until the transaction is committed.  Most merge code paths used by pull involve performing a `dolt_commit`(), which has the side effect of zeroing out the current transaction, meaning the next statement would get a new transaction and fresh working sets loaded from disk, avoiding the dirty state problem. Only the code path where the branch head is already up to date is affected by this bug. All the merge library code that actually needs to call `DoltSession.SetWorkingSet()` (only necessary before a `dolt_commit` happens, or in the case of a squash where changes should remain in the working set) already does so, making the additional call in `dolt_pull.go` redundant and leading to this buggy behavior in the no-change case.

There are probably still related bugs for session state management during pull and merge operations, but I want to keep this fix narrow to address the customer issue while I build up more robust (non-bats) tests for pull.