### PR TITLE
dolt admin archive

### DIFF
--- a/go/cmd/dolt/commands/admin/admin.go
+++ b/go/cmd/dolt/commands/admin/admin.go
@@ -21,6 +21,7 @@ import (
 var Commands = cli.NewHiddenSubCommandHandler("admin", "Commands for directly working with Dolt storage for purposes of testing or database recovery", []cli.Command{
 	SetRefCmd{},
 	ShowRootCmd{},
+	ArchiveCmd{},
 
 	ZstdCmd{},
 })

--- a/go/cmd/dolt/commands/admin/archive.go
+++ b/go/cmd/dolt/commands/admin/archive.go
@@ -1,0 +1,224 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admin
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
+	"github.com/dolthub/dolt/go/libraries/doltcore/env"
+	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions/commitwalk"
+	"github.com/dolthub/dolt/go/libraries/utils/argparser"
+	"github.com/dolthub/dolt/go/store/datas"
+	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/dolthub/dolt/go/store/nbs"
+	"github.com/dolthub/dolt/go/store/prolly/tree"
+)
+
+type ArchiveCmd struct {
+}
+
+func (cmd ArchiveCmd) Name() string {
+	return "archive"
+}
+
+var docs = cli.CommandDocumentationContent{
+	ShortDesc: "Create archive files using native or cgo compression, then verify.",
+	LongDesc:  `Run this command on a dolt database only after running 'dolt gc'. This command will create an archive file to the CWD. Suffix: .darc. After the new file is generated, it will read every chunk from the new file and verify that the chunk hashes to the correct addr.`,
+
+	Synopsis: []string{
+		`--no-group`,
+	},
+}
+
+// Description returns a description of the command
+func (cmd ArchiveCmd) Description() string {
+	return "Hidden command to kick the tires with the new archive format."
+}
+func (cmd ArchiveCmd) RequiresRepo() bool {
+	return true
+}
+func (cmd ArchiveCmd) Docs() *cli.CommandDocumentation {
+	ap := cmd.ArgParser()
+	return cli.NewCommandDocumentation(docs, ap)
+}
+
+func (cmd ArchiveCmd) ArgParser() *argparser.ArgParser {
+	ap := argparser.NewArgParserWithMaxArgs(cmd.Name(), 0)
+	/* TODO: Implement these flags
+	ap.SupportsFlag("raw", "", "Create an archive file with 0 compression")
+	ap.SupportsFlag("no-manifest", "", "Do not alter the manifest file. Generate the archive file only")
+	ap.SupportsFlag("no-grouping", "", "Do not attempt to group chunks. Default dictionary will be used for all chunks")
+	ap.SupportsFlag("verify-existing", "", "Skip generation altogether and just verify the existing archive file.")
+	*/
+	return ap
+}
+func (cmd ArchiveCmd) Hidden() bool {
+	return true
+}
+
+func (cmd ArchiveCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
+	ap := cmd.ArgParser()
+	help, _ := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, docs, ap))
+	_ = cli.ParseArgsOrDie(ap, args, help)
+
+	db := doltdb.HackDatasDatabaseFromDoltDB(dEnv.DoltDB)
+	cs := datas.ChunkStoreFromDatabase(db)
+	if _, ok := cs.(*nbs.GenerationalNBS); !ok {
+		cli.PrintErrln("archive command requires a GenerationalNBS")
+		return 1
+	}
+
+	datasets, err := db.Datasets(ctx)
+	if err != nil {
+		cli.PrintErrln(err)
+		return 1
+	}
+
+	hs := hash.NewHashSet()
+	err = datasets.IterAll(ctx, func(id string, hash hash.Hash) error {
+		hs.Insert(hash)
+		return nil
+	})
+
+	v := dEnv.DoltDB
+
+	groupings := nbs.NewChunkRelations()
+	err = historicalFuzzyMatching(ctx, hs, &groupings, v)
+	if err != nil {
+		cli.PrintErrln(err)
+		return 1
+	}
+	cli.Printf("Found %d possible relations by walking history\n", groupings.Count())
+
+	err = nbs.BuildArchive(ctx, cs, &groupings)
+	if err != nil {
+		cli.PrintErrln(err)
+		return 1
+	}
+
+	return 0
+}
+
+func historicalFuzzyMatching(ctx context.Context, heads hash.HashSet, groupings *nbs.ChunkRelations, db *doltdb.DoltDB) error {
+	hs := []hash.Hash{}
+	for h := range heads {
+		_, err := db.ReadCommit(ctx, h)
+		if err != nil {
+			continue
+		}
+		hs = append(hs, h)
+	}
+
+	iterator, err := commitwalk.GetTopologicalOrderIterator(ctx, db, hs, func(cmt *doltdb.OptionalCommit) (bool, error) {
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+	for {
+		h, _, err := iterator.Next(ctx)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+
+		err = relateChunkToParents(ctx, h, groupings, db)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func relateChunkToParents(ctx context.Context, commit hash.Hash, groupings *nbs.ChunkRelations, db *doltdb.DoltDB) error {
+	oCmt, err := db.ReadCommit(ctx, commit)
+	if err != nil {
+		return nil // Only want commits. Skip others.
+	}
+	cmt, ok := oCmt.ToCommit()
+	if !ok {
+		return fmt.Errorf("Ghost commit. Must run on a full clone.")
+	}
+	cmtRv, err := cmt.GetRootValue(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Dolt supports only 1 or 2 parents, but the logic is the same for each. And if there are no parents, no op.
+	for i := 0; i < cmt.NumParents(); i++ {
+		oCmt, err = cmt.GetParent(ctx, i)
+		parent, exists := oCmt.ToCommit()
+		if !exists {
+			return fmt.Errorf("Ghost commit")
+		}
+
+		parentRv, err := parent.GetRootValue(ctx)
+		if err != nil {
+			return err
+		}
+
+		deltas, err := diff.GetTableDeltas(ctx, cmtRv, parentRv)
+		if err != nil {
+			return err
+		}
+
+		for _, delta := range deltas {
+			schChg, err := delta.HasSchemaChanged(ctx)
+			if err != nil {
+				return err
+			}
+			if schChg {
+				continue
+			}
+			if delta.HasPrimaryKeySetChanged() {
+				continue
+			}
+
+			changed, err := delta.HasDataChanged(ctx)
+			if err != nil {
+				return err
+			}
+			if !changed {
+				continue
+			}
+
+			from, to, err := delta.GetRowData(ctx)
+
+			f := durable.ProllyMapFromIndex(from)
+			t := durable.ProllyMapFromIndex(to)
+
+			if f.Node().Level() != t.Node().Level() {
+				continue
+			}
+			err = tree.ChunkAddressDiffOrderedTrees(ctx, f.Tuples(), t.Tuples(), func(ctx context.Context, diff tree.AddrDiff) error {
+				groupings.Add(diff.From, diff.To)
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/go/store/nbs/archive.go
+++ b/go/store/nbs/archive.go
@@ -152,6 +152,7 @@ const (
 		archiveCheckSumSize +
 		1 + // version byte
 		archiveFileSigSize
+	archiveFileSuffix = ".darc"
 )
 
 /*

--- a/go/store/nbs/archive_build.go
+++ b/go/store/nbs/archive_build.go
@@ -1,0 +1,304 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nbs
+
+import (
+	"math"
+	"sort"
+
+	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/dolthub/gozstd"
+)
+
+const defaultDictionarySize = 1 << 12 // NM4 - maybe just select the largest chunk. TBD.
+
+// chunkGroup is a collection of chunks that are compressed together using the same Dictionary. It also contains
+// calculated statistics about the group, specifically the total compression ratio and the average raw chunk size.
+type chunkGroup struct {
+	dict  []byte
+	cDict *gozstd.CDict
+	// Sorted list of chunks and their compression score. Higher is better. The score doesn't include the dictionary size.
+	chks []chunkCmpScore
+	// The total ratio _includes_ the dictionary size.
+	totalRatioWDict            float64
+	totalBytesSavedWDict       int
+	totalRatioDefaultDict      float64
+	totalBytesSavedDefaultDict int
+	avgRawChunkSize            int
+}
+
+// chunkCmpScore wraps a chunk and its compression score for use by the chunkGroup.
+type chunkCmpScore struct {
+	chunk              *chunks.Chunk
+	score              float64
+	dictCmpSize        int
+	defaultDictCmpSize int
+}
+
+// newChunkGroup creates a new chunkGroup from a set of chunks.
+func newChunkGroup(cmpBuff []byte, chks []*chunks.Chunk, defaultDict *gozstd.CDict) *chunkGroup {
+	scored := make([]chunkCmpScore, len(chks))
+	for i, c := range chks {
+		scored[i] = chunkCmpScore{c, 0.0, 0, 0}
+	}
+	result := chunkGroup{dict: nil, cDict: nil, chks: scored}
+	result.rebuild(cmpBuff, defaultDict)
+	return &result
+}
+
+func (cg *chunkGroup) getLeader() *chunks.Chunk {
+	return cg.chks[0].chunk
+}
+
+// For whatever reason, we need 7 or more samples to build a dictionary. But in principle we only need 1. So duplicate
+// the samples until we have enough. Note that we need to add each chunk the same number of times do we don't end up
+// with bias in the dictionary.
+func padSamples(chks []*chunks.Chunk) []*chunks.Chunk {
+	samples := []*chunks.Chunk{}
+	for len(samples) < 7 {
+		for _, c := range chks {
+			samples = append(samples, c)
+		}
+	}
+	return samples
+}
+
+// Add this chunk into the group. It does not attempt to determine if this is a good addition. The caller should
+// use testChunk to determine if this chunk should be added.
+//
+// The chunkGroup will be recalculated after this chunk is added.
+func (cg *chunkGroup) addChunk(cmpBuff []byte, c *chunks.Chunk, defaultDict *gozstd.CDict) error {
+	scored := chunkCmpScore{
+		chunk:       c,
+		score:       0.0,
+		dictCmpSize: 0,
+	}
+
+	cg.chks = append(cg.chks, scored)
+	return cg.rebuild(cmpBuff, defaultDict)
+}
+
+// worstZScore returns the z-score of the worst chunk in the group. The z-score is a measure of how many standard
+// deviations from the mean the value is. This value will always be negative (If something has a positive
+// z-score, it would make it better than the mean, and we don't care about that).
+func (cg *chunkGroup) worstZScore() float64 {
+	// Calculate the mean
+	var sum float64
+	for _, v := range cg.chks {
+		sum += v.score
+	}
+	mean := sum / float64(len(cg.chks))
+
+	// Calculate the sum of squares of differences from the mean
+	var sumSquares float64
+	for _, v := range cg.chks {
+		diff := v.score - mean
+		sumSquares += diff * diff
+	}
+
+	// Calculate the standard deviation
+	stdDev := math.Sqrt(sumSquares / float64(len(cg.chks)))
+
+	// Calculate z-score for the given value
+	zScore := (cg.chks[len(cg.chks)-1].score - mean) / stdDev
+
+	return zScore
+}
+
+// rebuild - recalculate the entire group's compression ratio. Dictionary and total compression ratio are updated as well.
+// This method is called after a new chunk is added to the group. Ensures that stats about the group are up-to-date.
+func (cg *chunkGroup) rebuild(cmpBuff []byte, defaultDict *gozstd.CDict) error {
+	chks := make([]*chunks.Chunk, len(cg.chks))
+	for i, cs := range cg.chks {
+		chks[i] = cs.chunk
+	}
+
+	dct := buildDictionary(padSamples(chks))
+
+	var cDict *gozstd.CDict
+	cDict, err := gozstd.NewCDict(dct)
+	if err != nil {
+		return err
+	}
+
+	cmpDct := gozstd.Compress(nil, dct)
+
+	scored := make([]chunkCmpScore, len(chks))
+	for i, c := range chks {
+		d := c.Data()
+		comp := gozstd.CompressDict(cmpBuff, d, cDict)
+		defaultDictComp := gozstd.CompressDict(cmpBuff, d, defaultDict)
+
+		scored[i] = chunkCmpScore{
+			chunk:              c,
+			score:              float64(len(d)-len(comp)) / float64(len(d)),
+			dictCmpSize:        len(comp),
+			defaultDictCmpSize: len(defaultDictComp),
+		}
+	}
+	sort.Slice(scored, func(i, j int) bool {
+		return scored[i].score > scored[j].score
+	})
+
+	cg.dict = dct
+	cg.cDict = cDict
+	cg.chks = scored
+
+	raw := 0
+	dictCmpSize := 0
+	noDictCmpSize := 0
+	for _, cs := range cg.chks {
+		c := cs.chunk
+		raw += len(c.Data())
+		dictCmpSize += cs.dictCmpSize
+		noDictCmpSize += cs.defaultDictCmpSize
+	}
+	dictCmpSize += len(cmpDct)
+
+	cg.totalRatioWDict = float64(raw-dictCmpSize) / float64(raw)
+	cg.totalBytesSavedWDict = raw - dictCmpSize
+
+	cg.totalRatioDefaultDict = float64(raw-noDictCmpSize) / float64(raw)
+	cg.totalBytesSavedDefaultDict = raw - noDictCmpSize
+
+	cg.avgRawChunkSize = raw / len(chks)
+	return nil
+}
+
+// Helper method to build new dictionary objects from a set of chunks.
+func buildDictionary(chks []*chunks.Chunk) (ans []byte) {
+	samples := make([][]uint8, 0, len(chks))
+	for _, c := range chks {
+		samples = append(samples, c.Data())
+	}
+	return gozstd.BuildDict(samples, defaultDictionarySize)
+}
+
+// Returns true if the chunk's compression ratio (using the existing dictionary) is better than the group's worst chunk.
+func (cg *chunkGroup) testChunk(c *chunks.Chunk) (bool, error) {
+	comp := gozstd.CompressDict(nil, c.Data(), cg.cDict)
+
+	ratio := float64(len(c.Data())-len(comp)) / float64(len(c.Data()))
+
+	if ratio > cg.chks[len(cg.chks)-1].score {
+		return true, nil
+	}
+	return false, nil
+}
+
+func NewChunkRelations() ChunkRelations {
+	m := make(map[hash.Hash]*hash.HashSet)
+	return ChunkRelations{m}
+}
+
+// ChunkRelations is holds chunks that are related to each other. Currently the only relationship type is for chunks
+// which we know are related based on modifications of a Prolly Tree, and relationships are fully transitive:
+// A is related to B, and B is related to C, then A is related to C.
+type ChunkRelations struct {
+	// Fully transitive relationships between chunks. The key is a chunk hash, and the value is a set of chunk hashes
+	// it is related to. The value is a pointer to the set, so that we can update the set in place, and many keys
+	// can map to it.
+	manyToGroup map[hash.Hash]*hash.HashSet
+}
+
+func (cr *ChunkRelations) Count() int {
+	return len(cr.manyToGroup)
+}
+
+func (cr *ChunkRelations) convertToChunkGroups(chks map[hash.Hash]*chunks.Chunk, defaultDict *gozstd.CDict) []*chunkGroup {
+	result := make([]*chunkGroup, 0, cr.Count())
+	buff := make([]byte, 0, maxChunkSize)
+
+	// For each group, look up the addresses and build a chunk group.
+	for _, v := range cr.groups() {
+		var c []*chunks.Chunk
+		for h := range v {
+			// There will be chunks referenced in the chunk group which are not in the chks map. This is because
+			// we walk the history to get the chunk groups, but the map comes from a specific table file only - which
+			// may not contain all the chunks of the DB.
+			chk := chks[h]
+			if chk != nil {
+				c = append(c, chk)
+			}
+		}
+
+		if len(c) > 1 {
+			result = append(result, newChunkGroup(buff, c, defaultDict))
+		}
+	}
+	return result
+}
+
+func (cr *ChunkRelations) groups() []hash.HashSet {
+	seen := map[*hash.HashSet]struct{}{}
+	groups := make([]hash.HashSet, 0, len(cr.manyToGroup))
+	for _, v := range cr.manyToGroup {
+		if _, ok := seen[v]; !ok {
+			groups = append(groups, *v)
+			seen[v] = struct{}{}
+		}
+	}
+	return groups
+}
+
+func (cr *ChunkRelations) Contains(h hash.Hash) bool {
+	_, ok := cr.manyToGroup[h]
+	return ok
+}
+
+// Add a pair of hashes to the relations. If either chunk is already in a group, the other chunk will be added to that.
+// This method has no access to the chunks themselves, so it cannot determine if the chunks are similar. This method
+// is used if you know from other sources that the chunks are similar.
+func (cr *ChunkRelations) Add(a, b hash.Hash) {
+	_, haveA := cr.manyToGroup[a]
+	_, haveB := cr.manyToGroup[b]
+
+	if !haveA && !haveB {
+		newGroup := hash.NewHashSet(a, b)
+		cr.manyToGroup[a] = &newGroup
+		cr.manyToGroup[b] = &newGroup
+		return
+	}
+
+	if haveA && !haveB {
+		cr.manyToGroup[a].Insert(b)
+		cr.manyToGroup[b] = cr.manyToGroup[a]
+		return
+	}
+
+	if !haveA { // haveB must be true
+		cr.manyToGroup[b].Insert(a)
+		cr.manyToGroup[a] = cr.manyToGroup[b]
+		return
+	}
+
+	// Both are not new, and they are already in the same group.
+	if cr.manyToGroup[a] == cr.manyToGroup[b] {
+		return
+	}
+
+	// Both are not new, and they are in different groups. Merge the groups.
+	merged := hash.NewHashSet()
+	for h := range *cr.manyToGroup[a] {
+		merged.Insert(h)
+	}
+	for h := range *cr.manyToGroup[b] {
+		merged.Insert(h)
+	}
+	for h := range merged {
+		cr.manyToGroup[h] = &merged
+	}
+}

--- a/go/store/nbs/archive_chunk_source.go
+++ b/go/store/nbs/archive_chunk_source.go
@@ -1,0 +1,108 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nbs
+
+import (
+	"context"
+	"io"
+
+	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+)
+
+type archiveChunkSource struct {
+	aRdr archiveReader
+}
+
+var _ chunkSource = &archiveChunkSource{}
+
+func (acs archiveChunkSource) has(h hash.Hash) (bool, error) {
+	return acs.aRdr.has(h), nil
+}
+
+func (acs archiveChunkSource) hasMany(addrs []hasRecord) (bool, error) {
+	// single threaded first pass.
+	foundAll := true
+	for _, addr := range addrs {
+		if acs.aRdr.has(*(addr.a)) {
+			addr.has = true
+		} else {
+			foundAll = false
+		}
+	}
+	return foundAll, nil
+}
+
+func (acs archiveChunkSource) get(ctx context.Context, h hash.Hash, stats *Stats) ([]byte, error) {
+	// ctx, stats ? NM4.
+	return acs.aRdr.get(h)
+}
+
+func (acs archiveChunkSource) getMany(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, *chunks.Chunk), stats *Stats) (bool, error) {
+	// single threaded first pass.
+	foundAll := true
+	for _, req := range reqs {
+		data, err := acs.aRdr.get(*req.a)
+		if err != nil {
+			foundAll = false
+		} else {
+			chunk := chunks.NewChunk(data)
+			found(ctx, &chunk)
+			req.found = true
+		}
+	}
+	return foundAll, nil
+}
+
+func (acs archiveChunkSource) count() (uint32, error) {
+	return acs.aRdr.count(), nil
+}
+
+func (acs archiveChunkSource) close() error {
+	return acs.aRdr.close()
+}
+
+func (acs archiveChunkSource) hash() hash.Hash {
+	return acs.aRdr.footer.hash
+}
+
+func (acs archiveChunkSource) currentSize() uint64 {
+	return acs.aRdr.footer.fileSize
+}
+
+func (acs archiveChunkSource) reader(ctx context.Context) (io.ReadCloser, uint64, error) {
+	return nil, 0, errors.New("Archive chunk source does not support reader")
+}
+func (acs archiveChunkSource) uncompressedLen() (uint64, error) {
+	return 0, errors.New("Archive chunk source does not support uncompressedLen")
+}
+
+func (acs archiveChunkSource) index() (tableIndex, error) {
+	return nil, errors.New("Archive chunk source does not expose table file indexes")
+}
+
+func (acs archiveChunkSource) clone() (chunkSource, error) {
+	return nil, errors.New("Archive chunk source does not support clone")
+}
+
+func (acs archiveChunkSource) getRecordRanges(requests []getRecord) (map[hash.Hash]Range, error) {
+	return nil, errors.New("Archive chunk source does not support getRecordRanges")
+}
+
+func (acs archiveChunkSource) getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, CompressedChunk), stats *Stats) (bool, error) {
+	return false, errors.New("Archive chunk source does not support getManyCompressed")
+}

--- a/go/store/nbs/archive_reader.go
+++ b/go/store/nbs/archive_reader.go
@@ -256,7 +256,12 @@ func (ai archiveReader) get(hash hash.Hash) ([]byte, error) {
 	if dict == nil {
 		result, err = gozstd.Decompress(nil, data)
 	} else {
-		dDict, e2 := gozstd.NewDDict(dict)
+		dcmpDict, e2 := gozstd.Decompress(nil, dict)
+		if e2 != nil {
+			return nil, e2
+		}
+
+		dDict, e2 := gozstd.NewDDict(dcmpDict)
 		if e2 != nil {
 			return nil, e2
 		}

--- a/go/store/nbs/archive_reader.go
+++ b/go/store/nbs/archive_reader.go
@@ -56,6 +56,7 @@ type footer struct {
 	formatVersion byte
 	fileSignature string
 	fileSize      uint64 // Not actually part of the footer, but necessary for calculating offsets.
+	hash          hash.Hash
 }
 
 // dataSpan returns the span of the data section of the archive. This is not generally used directly since we usually
@@ -218,6 +219,11 @@ func loadFooter(reader io.ReaderAt, fileSize uint64) (f footer, err error) {
 	f.metaCheckSum = sha512Sum(buf[afrMetaChkSumOffset : afrMetaChkSumOffset+sha512.Size])
 	f.fileSize = fileSize
 
+	// calculate the has of the footer. We don't currently verify that this is what was used to load the content.
+	sha := sha512.New()
+	sha.Write(buf)
+	f.hash = hash.New(sha.Sum(nil)[:hash.ByteLen])
+
 	return
 }
 
@@ -271,6 +277,17 @@ func (ai archiveReader) get(hash hash.Hash) ([]byte, error) {
 		return nil, err
 	}
 	return result, nil
+}
+
+func (ai archiveReader) count() uint32 {
+	return ai.footer.chunkCount
+}
+
+func (ai archiveReader) close() error {
+	if closer, ok := ai.reader.(io.Closer); ok {
+		return closer.Close()
+	}
+	return nil
 }
 
 func (ai archiveReader) readByteSpan(bs byteSpan) ([]byte, error) {

--- a/go/store/nbs/archive_test.go
+++ b/go/store/nbs/archive_test.go
@@ -214,7 +214,8 @@ func TestArchiveDictDecompression(t *testing.T) {
 
 	aw := newArchiveWriterWithSink(writer)
 
-	dictId, err := aw.writeByteSpan(dict)
+	cmpDict := gozstd.Compress(nil, dict)
+	dictId, err := aw.writeByteSpan(cmpDict)
 	for _, chk := range chks {
 		cmp := gozstd.CompressDict(nil, chk.Data(), cDict)
 
@@ -487,12 +488,17 @@ func generateSimilarChunks(seed int64, count int) []*chunks.Chunk {
 }
 
 func generateRandomChunk(seed int64, len int) *chunks.Chunk {
+	c := chunks.NewChunk(generateRandomBytes(seed, len))
+	return &c
+}
+
+func generateRandomBytes(seed int64, len int) []byte {
 	r := rand.NewSource(seed)
 
 	data := make([]byte, len)
 	for i := range data {
 		data[i] = byte(r.Int63())
 	}
-	c := chunks.NewChunk(data)
-	return &c
+
+	return data
 }

--- a/go/store/nbs/archive_writer.go
+++ b/go/store/nbs/archive_writer.go
@@ -83,6 +83,18 @@ When all of these steps have been completed without error, the ByteSink used to 
 to complete the archive writing process.
 */
 
+// newArchiveWriter - Create an *archiveWriter with the given output ByteSync, which will be used to materialize an archive on disk.
+func newArchiveWriter() (*archiveWriter, error) {
+	// NM4 - get a real tmp.
+	bs, err := NewBufferedFileByteSink("/tmp", defaultTableSinkBlockSize, defaultChBufferSize)
+	if err != nil {
+		return nil, err
+	}
+
+	hbs := NewSHA512HashingByteSink(bs)
+	return &archiveWriter{output: hbs, seenChunks: hash.HashSet{}}, nil
+}
+
 func newArchiveWriterWithSink(bs ByteSink) *archiveWriter {
 	hbs := NewSHA512HashingByteSink(bs)
 	return &archiveWriter{output: hbs, seenChunks: hash.HashSet{}}

--- a/go/store/nbs/file_table_persister.go
+++ b/go/store/nbs/file_table_persister.go
@@ -78,7 +78,12 @@ func (ftp *fsTablePersister) Exists(ctx context.Context, name hash.Hash, chunkCo
 	if ftp.toKeep != nil {
 		ftp.toKeep[filepath.Join(ftp.dir, name.String())] = struct{}{}
 	}
-	return tableFileExists(ctx, ftp.dir, name)
+
+	exists, err := tableFileExists(ctx, ftp.dir, name)
+	if exists || err != nil {
+		return exists, err
+	}
+	return archiveFileExists(ctx, ftp.dir, name)
 }
 
 func (ftp *fsTablePersister) Persist(ctx context.Context, mt *memTable, haver chunkReader, stats *Stats) (chunkSource, error) {

--- a/go/store/nbs/table_set.go
+++ b/go/store/nbs/table_set.go
@@ -403,7 +403,7 @@ func (ts tableSet) rebase(ctx context.Context, specs []tableSpec, stats *Stats) 
 		// open missing tables in parallel
 		spec := s
 		eg.Go(func() error {
-			cs, err := ts.p.Open(ctx, spec.name, spec.chunkCount, stats)
+			cs, err := ts.p.Open(ctx, spec.name, spec.chunkCount, stats) // NM4 - spec.name is the tf/arch name.
 			if err != nil {
 				return err
 			}

--- a/go/store/prolly/tree/addr_diff.go
+++ b/go/store/prolly/tree/addr_diff.go
@@ -1,0 +1,105 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tree
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/dolthub/dolt/go/store/hash"
+)
+
+// AddrDiff is a pair of hash.Hash values representing the addresses of two nodes two different trees which are likely
+// to be very similar.
+type AddrDiff struct {
+	From, To hash.Hash
+}
+
+type AddrDiffStream[K ~[]byte, O Ordering[K]] struct {
+	fromNs NodeStore
+	toNs   NodeStore
+	from   Node
+	to     Node
+	dfr    []Differ[K, O]
+}
+
+func (ads *AddrDiffStream[K, O]) Next(ctx context.Context) (AddrDiff, error) {
+	for {
+		if len(ads.dfr) > 0 {
+			difr := ads.dfr[len(ads.dfr)-1]
+			dif, err := difr.Next(ctx)
+			if err != nil {
+				if err != io.EOF {
+					return AddrDiff{}, err
+				}
+				ads.dfr = ads.dfr[:len(ads.dfr)-1]
+				continue
+			}
+
+			if dif.Type == ModifiedDiff {
+				return AddrDiff{hash.Hash(dif.From), hash.Hash(dif.To)}, nil
+			} // else, continue
+		} else {
+			return AddrDiff{}, io.EOF
+		}
+	}
+}
+
+var ErrRootDepthMismatch = errors.New("root depth mismatch")
+var ErrShallowTree = errors.New("tree too shallow") // NM4 We can do better than this. TBD.
+var ErrInvalidDepth = errors.New("invalid depth. must be > 0")
+
+// layerDifferFromRoots returns a Differ that will compare the trees rooted at |from| and |to|, but for the purposes
+// of comparing specific layers of the tree. If the trees are not the same depth, the Differ will return an error.
+func layerDifferFromRoots[K ~[]byte, O Ordering[K]](
+	ctx context.Context,
+	fromNs NodeStore, toNs NodeStore,
+	from, to Node,
+	order O,
+) (AddrDiffStream[K, O], error) {
+	// Currently we are punting on trees which aren't the same depth.
+	if from.Level() != to.Level() {
+		return AddrDiffStream[K, O]{}, ErrRootDepthMismatch
+	}
+
+	differs := make([]Differ[K, O], 0, from.Level())
+	for i := from.Level(); i > 0; i-- {
+		// We use the standard leaf diff walker, but adjust the cursors to the desired level.
+		leafDiffer, err := DifferFromRoots[K, O](ctx, fromNs, toNs, from, to, order, false)
+		if err != nil {
+			return AddrDiffStream[K, O]{}, err
+		}
+
+		for leafDiffer.from.nd.Level() < i {
+			leafDiffer.from = leafDiffer.from.parent
+			leafDiffer.to = leafDiffer.to.parent
+			leafDiffer.fromStop = leafDiffer.fromStop.parent
+			leafDiffer.toStop = leafDiffer.toStop.parent
+		}
+
+		differs = append(differs, leafDiffer)
+	}
+
+	stream := AddrDiffStream[K, O]{
+		fromNs: fromNs,
+		toNs:   toNs,
+		from:   from,
+		to:     to,
+		dfr:    differs,
+	}
+	return stream, nil
+
+}

--- a/go/store/prolly/tree/addr_diff_test.go
+++ b/go/store/prolly/tree/addr_diff_test.go
@@ -1,0 +1,152 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tree
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/dolthub/dolt/go/store/val"
+	"github.com/stretchr/testify/assert"
+)
+
+// Single layer trees are entirly root nodes - which are imbedded in the table flatbuffer, so we don't
+// currently use them for purposes of grouping chunks.
+func TestAddressDifferFromRootsOneLayer(t *testing.T) {
+	fromTups, desc := AscendingUintTuples(42)
+	fromRoot := makeTree(t, fromTups)
+	assert.Equal(t, 42, fromRoot.Count())
+	assert.Equal(t, 0, fromRoot.Level())
+
+	toTups := make([][2]val.Tuple, len(fromTups))
+	// Copy elements from the original slice to the new slice
+	copy(toTups, fromTups)
+	bld := val.NewTupleBuilder(desc)
+	// modify value in the first half of the tree
+	bld.PutUint32(0, uint32(42))
+	toTups[23][1] = bld.Build(sharedPool)
+	toRoot := makeTree(t, toTups)
+
+	ctx := context.Background()
+	ns := NewTestNodeStore()
+
+	dfr, err := layerDifferFromRoots(ctx, ns, ns, fromRoot, toRoot, desc)
+	assert.NoError(t, err)
+
+	_, err = dfr.Next(ctx)
+	assert.Equal(t, io.EOF, err)
+}
+
+func TestAddressDifferFromRootsTwoLayer(t *testing.T) {
+	fromTups, desc := AscendingUintTuples(416)
+	fromRoot := makeTree(t, fromTups)
+	assert.Equal(t, 2, fromRoot.Count())
+	assert.Equal(t, 1, fromRoot.Level())
+
+	before := fromRoot.getAddress(0)
+	unchanged := fromRoot.getAddress(1)
+
+	toTups := make([][2]val.Tuple, len(fromTups))
+	// Copy elements from the original slice to the new slice
+	copy(toTups, fromTups)
+	bld := val.NewTupleBuilder(desc)
+	// modify value early in the tree, to ensure the modification happens on the first child of the root.
+	bld.PutUint32(0, uint32(42))
+	toTups[23][1] = bld.Build(sharedPool)
+	toRoot := makeTree(t, toTups)
+
+	after := toRoot.getAddress(0)
+	assert.NotEqual(t, before, after)
+	assert.Equal(t, unchanged, toRoot.getAddress(1))
+
+	ctx := context.Background()
+	ns := NewTestNodeStore()
+
+	dfr, err := layerDifferFromRoots(ctx, ns, ns, fromRoot, toRoot, desc)
+	assert.NoError(t, err)
+
+	dif, err := dfr.Next(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, before, dif.From)
+	assert.Equal(t, after, dif.To)
+
+	_, err = dfr.Next(ctx)
+	assert.Equal(t, io.EOF, err)
+}
+
+func TestAddressDifferFromRootsThreeLayer(t *testing.T) {
+	// 23800 - results in a 3 level tree, where the root has two children. The second child will have one child.
+	// of its own, which is the content. If we alter the content in the last ~250 elements of the tuple, it should
+	// result in a modification of the second child of the root.
+	fromTups, desc := AscendingUintTuples(23800)
+	fromRoot := makeTree(t, fromTups)
+	assert.Equal(t, 2, fromRoot.Count())
+	assert.Equal(t, 2, fromRoot.Level())
+
+	toTups := make([][2]val.Tuple, len(fromTups))
+	// Copy elements from the original slice to the new slice
+	copy(toTups, fromTups)
+	bld := val.NewTupleBuilder(desc)
+	// modify value in the first half of the tree
+	bld.PutUint32(0, uint32(42))
+	toTups[23700][1] = bld.Build(sharedPool)
+	toRoot := makeTree(t, toTups)
+
+	ctx := context.Background()
+	ns := NewTestNodeStore()
+	dfr, err := layerDifferFromRoots(ctx, ns, ns, fromRoot, toRoot, desc)
+	assert.NoError(t, err)
+
+	// Manually grab the items from the tree we expect to see from out of the differ.
+	fromMidLayerAddr := fromRoot.getAddress(1)
+	toMidLayerAddr := toRoot.getAddress(1)
+
+	fromContentNode, _ := ns.Read(ctx, fromMidLayerAddr)
+	fromContentAddr := fromContentNode.getAddress(0)
+	toContentNode, _ := ns.Read(ctx, toMidLayerAddr)
+	toContentAddr := toContentNode.getAddress(0)
+
+	// Items returned from the diff stream will start at the content addresses, then mid layer, and end at the root.
+	dif, err := dfr.Next(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, fromContentAddr, dif.From)
+	assert.Equal(t, toContentAddr, dif.To)
+
+	dif, err = dfr.Next(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, fromMidLayerAddr, dif.From)
+	assert.Equal(t, toMidLayerAddr, dif.To)
+
+	dif, err = dfr.Next(ctx)
+	assert.Equal(t, io.EOF, err)
+}
+
+func TestAddressDifferFromRootsLayerMismatch(t *testing.T) {
+	fromTups, desc := AscendingUintTuples(416)
+	fromRoot := makeTree(t, fromTups)
+	assert.Equal(t, 2, fromRoot.Count())
+	assert.Equal(t, 1, fromRoot.Level())
+
+	toTups := fromTups[:415]
+	toRoot := makeTree(t, toTups)
+	assert.Equal(t, 415, toRoot.Count())
+	assert.Equal(t, 0, toRoot.Level())
+
+	ctx := context.Background()
+	ns := NewTestNodeStore()
+	_, err := layerDifferFromRoots(ctx, ns, ns, fromRoot, toRoot, desc)
+	assert.Equal(t, ErrRootDepthMismatch, err)
+}

--- a/go/store/prolly/tree/diff.go
+++ b/go/store/prolly/tree/diff.go
@@ -17,7 +17,6 @@ package tree
 import (
 	"bytes"
 	"context"
-	"errors"
 	"io"
 )
 
@@ -176,19 +175,20 @@ func (td Differ[K, O]) Next(ctx context.Context) (diff Diff, err error) {
 	return Diff{}, io.EOF
 }
 
-// NM4. gdoc.
+/*
+// NM4. gdoc. Not sure if this is in the right place at all.
 func ChunkAddressDiffOrderedTrees[K, V ~[]byte, O Ordering[K]](
 	ctx context.Context,
 	from, to StaticMap[K, V, O],
 	cb DiffFn,
 ) error {
-	differ, layerDepth, err := AddressDifferFromRoots[K](ctx, from.NodeStore, to.NodeStore, from.Root, to.Root, from.Order, 1000)
+	differ, err := layerDifferFromRoots[K](ctx, from.NodeStore, to.NodeStore, from.Root, to.Root, from.Order)
 	if err != nil {
 		return err
 	}
 	for {
 		for {
-			var diff Diff
+			var diff AddrDiff
 			if diff, err = differ.Next(ctx); err != nil {
 				break
 			}
@@ -198,7 +198,7 @@ func ChunkAddressDiffOrderedTrees[K, V ~[]byte, O Ordering[K]](
 			}
 		}
 		if layerDepth > 0 {
-			differ, layerDepth, err = AddressDifferFromRoots[K](ctx, from.NodeStore, to.NodeStore, from.Root, to.Root, from.Order, layerDepth)
+			differ, layerDepth, err = layerDifferFromRoots[K](ctx, from.NodeStore, to.NodeStore, from.Root, to.Root, from.Order)
 			if err != nil {
 				return err
 			}
@@ -208,46 +208,7 @@ func ChunkAddressDiffOrderedTrees[K, V ~[]byte, O Ordering[K]](
 	}
 	return err
 }
-
-var ErrShallowTree = errors.New("tree too shallow") // NM4 We can do better than this. TBD.
-func AddressDifferFromRoots[K ~[]byte, O Ordering[K]](
-	ctx context.Context,
-	fromNs NodeStore, toNs NodeStore,
-	from, to Node,
-	order O,
-	desiredLayer int,
-) (Differ[K, O], int, error) {
-	orig, err := DifferFromRoots[K, O](ctx, fromNs, toNs, from, to, order, false)
-	if err != nil {
-		return orig, -1, err
-	}
-
-	depthActual := depth(orig.from)
-	if depthActual < desiredLayer {
-		desiredLayer = depthActual
-	}
-
-	for desiredLayer <= depthActual {
-		orig.from = orig.from.parent
-		orig.to = orig.to.parent
-		orig.fromStop = orig.fromStop.parent
-		orig.toStop = orig.toStop.parent
-
-		if orig.from == nil || orig.to == nil || orig.fromStop == nil || orig.toStop == nil {
-			return orig, -1, ErrShallowTree
-		}
-		depthActual--
-	}
-
-	return orig, depthActual, err
-}
-
-func depth(n *cursor) int {
-	if n == nil {
-		return 0
-	}
-	return 1 + depth(n.parent)
-}
+*/
 
 func sendRemoved(ctx context.Context, from *cursor) (diff Diff, err error) {
 	diff = Diff{

--- a/go/store/prolly/tree/diff.go
+++ b/go/store/prolly/tree/diff.go
@@ -17,6 +17,7 @@ package tree
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 )
 
@@ -173,6 +174,79 @@ func (td Differ[K, O]) Next(ctx context.Context) (diff Diff, err error) {
 	}
 
 	return Diff{}, io.EOF
+}
+
+// NM4. gdoc.
+func ChunkAddressDiffOrderedTrees[K, V ~[]byte, O Ordering[K]](
+	ctx context.Context,
+	from, to StaticMap[K, V, O],
+	cb DiffFn,
+) error {
+	differ, layerDepth, err := AddressDifferFromRoots[K](ctx, from.NodeStore, to.NodeStore, from.Root, to.Root, from.Order, 1000)
+	if err != nil {
+		return err
+	}
+	for {
+		for {
+			var diff Diff
+			if diff, err = differ.Next(ctx); err != nil {
+				break
+			}
+
+			if err = cb(ctx, diff); err != nil {
+				break
+			}
+		}
+		if layerDepth > 0 {
+			differ, layerDepth, err = AddressDifferFromRoots[K](ctx, from.NodeStore, to.NodeStore, from.Root, to.Root, from.Order, layerDepth)
+			if err != nil {
+				return err
+			}
+		} else {
+			break
+		}
+	}
+	return err
+}
+
+var ErrShallowTree = errors.New("tree too shallow") // NM4 We can do better than this. TBD.
+func AddressDifferFromRoots[K ~[]byte, O Ordering[K]](
+	ctx context.Context,
+	fromNs NodeStore, toNs NodeStore,
+	from, to Node,
+	order O,
+	desiredLayer int,
+) (Differ[K, O], int, error) {
+	orig, err := DifferFromRoots[K, O](ctx, fromNs, toNs, from, to, order, false)
+	if err != nil {
+		return orig, -1, err
+	}
+
+	depthActual := depth(orig.from)
+	if depthActual < desiredLayer {
+		desiredLayer = depthActual
+	}
+
+	for desiredLayer <= depthActual {
+		orig.from = orig.from.parent
+		orig.to = orig.to.parent
+		orig.fromStop = orig.fromStop.parent
+		orig.toStop = orig.toStop.parent
+
+		if orig.from == nil || orig.to == nil || orig.fromStop == nil || orig.toStop == nil {
+			return orig, -1, ErrShallowTree
+		}
+		depthActual--
+	}
+
+	return orig, depthActual, err
+}
+
+func depth(n *cursor) int {
+	if n == nil {
+		return 0
+	}
+	return 1 + depth(n.parent)
 }
 
 func sendRemoved(ctx context.Context, from *cursor) (diff Diff, err error) {

--- a/go/store/prolly/tree/diff_test.go
+++ b/go/store/prolly/tree/diff_test.go
@@ -1,0 +1,58 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tree
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/dolthub/dolt/go/store/val"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDifferFromRoots tests the DifferFromRoots function, very minimally. We don't have any direct tests of this
+// method, and when developing the layerDifferFromRoots method I wanted to verify some assumptions.
+// TODO - test DifferFromRoots more thoroughly.
+func TestDifferFromRoots(t *testing.T) {
+	ctx := context.Background()
+
+	fromTups, desc := AscendingUintTuples(1234)
+	fromRoot := makeTree(t, fromTups)
+
+	toTups := make([][2]val.Tuple, len(fromTups))
+	// Copy elements from the original slice to the new slice
+	copy(toTups, fromTups)
+	bld := val.NewTupleBuilder(desc)
+	bld.PutUint32(0, uint32(42))
+	toTups[23][1] = bld.Build(sharedPool) // modify value at index 23.
+	toRoot := makeTree(t, toTups)
+
+	ns := NewTestNodeStore()
+
+	dfr, err := DifferFromRoots(ctx, ns, ns, fromRoot, toRoot, desc, false)
+	assert.NoError(t, err)
+
+	dif, err := dfr.Next(ctx)
+	assert.NoError(t, err)
+	assert.NotNil(t, dif)
+	assert.Equal(t, fromTups[23][0], val.Tuple(dif.Key))
+	assert.Equal(t, fromTups[23][1], val.Tuple(dif.From))
+	assert.Equal(t, toTups[23][1], val.Tuple(dif.To))
+	assert.Equal(t, ModifiedDiff, dif.Type)
+
+	dif, err = dfr.Next(ctx)
+	assert.Equal(t, io.EOF, err)
+}


### PR DESCRIPTION
This hidden admin command will convert the table files in oldgen into archive files, then update the manifest so that you can run queries against the archive for performance testing. Currently we assume that `dolt gc` has been run immediately prior to using this command.

After the build is complete, we lookup every chunk in the archive using the index of the originating table file. We then verify each chunk's key checks out. If this verification fails, exit status 1.

Lot of rough edges still:
 - Currently no feedback as the build progresses. This is annoying because it can take a fair amount of time
 - ChunkSource interface is single threaded, so getMany and hasMany are not going to perform well.
 - Lacking checks to ensure that the server isn't running and we have the LOCK on oldgen.
 - No bats tests, and this is kind of a temporary thing. There are go tests on key bits.