### PR TITLE
Added new session variable

### DIFF
--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -50,6 +50,7 @@ var ErrSessionNotPersistable = errors.New("session is not persistable")
 // DoltSession is the sql.Session implementation used by dolt. It is accessible through a *sql.Context instance
 type DoltSession struct {
 	sql.Session
+	DoltgresSessObj  any // This is used by Doltgres to persist objects in the session. This is not used by Dolt.
 	username         string
 	email            string
 	dbStates         map[string]*DatabaseSessionState


### PR DESCRIPTION
Adds a new session variable that is used from within Doltgres. Currently, Doltgres uses a map as there were test failures due to potential race conditions with the inner `context`, so this replaces its usage with a session object instead.