### PR TITLE
[no-release-notes] switch tps_multiplier name back

### DIFF
--- a/.github/scripts/performance-benchmarking/get-mysql-dolt-job-json.sh
+++ b/.github/scripts/performance-benchmarking/get-mysql-dolt-job-json.sh
@@ -51,7 +51,7 @@ meanMultiplierOverallQuery="select round(avg(multipliers), $precision) as overal
 
 tpccLatencyQuery="select f.test_name as tpcc_latency, f.server_name, f.server_version, avg(f.latency_percentile) as from_latency_p95, t.server_name, t.server_version, avg(t.latency_percentile) as to_latency_p95, ROUND(avg(t.latency_percentile) / (avg(f.latency_percentile) + .000001), $precision) as multiplier from from_results as f join to_results as t on f.test_name = t.test_name where f.test_name LIKE '$tpccRegex' group by f.test_name;"
 tpccTpsQuery="select f.test_name as tpcc_tps, f.server_name, f.server_version, avg(f.sql_transactions_per_second) as from_tps, t.test_name as test_name, t.server_name, t.server_version, avg(t.sql_transactions_per_second) as to_tps, ROUND(avg(t.latency_percentile) / (avg(f.latency_percentile) + .000001), $precision) as multiplier from from_results as f join to_results as t on f.test_name = t.test_name where f.test_name LIKE 'tpcc%' group by f.test_name;"
-tpccTpsMultiplierQuery="select ROUND(avg(t.sql_transactions_per_second) / (avg(f.sql_transactions_per_second) + .000001), $precision) as multiplier as tpcc_tps_multiplier from from_results as f join to_results as t on f.test_name = t.test_name where f.test_name like 'tpcc%' group by f.test_name"
+tpccTpsMultiplierQuery="select ROUND(avg(t.sql_transactions_per_second) / (avg(f.sql_transactions_per_second) + .000001), $precision) as tpcc_tps_multiplier as tpcc_tps_multiplier from from_results as f join to_results as t on f.test_name = t.test_name where f.test_name like 'tpcc%' group by f.test_name"
 
 echo '
 {


### PR DESCRIPTION
I think we depend on the `tpcc_tps_multiplier` name for updating docs.