### PR TITLE
apply `filter-branch` changes to working/staged changes

### DIFF
--- a/go/cmd/dolt/commands/filter-branch.go
+++ b/go/cmd/dolt/commands/filter-branch.go
@@ -118,12 +118,6 @@ func (cmd FilterBranchCmd) Exec(ctx context.Context, commandStr string, args []s
 		queryString = string(queryStringBytes)
 	}
 
-	if hasChanges, err := HasLocalChanges(ctx, dEnv); err != nil {
-		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	} else if hasChanges {
-		verr := errhand.BuildDError("local changes detected, use dolt stash or commit changes before using filter-branch").Build()
-		return HandleVErrAndExitCode(verr, usage)
-	}
 	replay := func(ctx context.Context, commit, _, _ *doltdb.Commit) (doltdb.RootValue, error) {
 		var cmHash, before hash.Hash
 		var root doltdb.RootValue

--- a/go/cmd/dolt/commands/filter-branch.go
+++ b/go/cmd/dolt/commands/filter-branch.go
@@ -83,7 +83,7 @@ func (cmd FilterBranchCmd) ArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParserWithVariableArgs(cmd.Name())
 	ap.SupportsFlag(cli.VerboseFlag, "v", "logs more information")
 	ap.SupportsFlag(branchesFlag, "b", "filter all branches")
-	ap.SupportsFlag(uncommittedFlag, "", "apply changes to uncommitted changes")
+	ap.SupportsFlag(uncommittedFlag, "", "apply changes to uncommitted tables")
 	ap.SupportsFlag(cli.AllFlag, "a", "filter all branches and tags")
 	ap.SupportsFlag(continueFlag, "c", "log a warning and continue if any errors occur executing statements")
 	ap.SupportsString(QueryFlag, "q", "queries", "Queries to run, separated by semicolons. If not provided, queries are read from STDIN.")

--- a/go/cmd/dolt/commands/utils.go
+++ b/go/cmd/dolt/commands/utils.go
@@ -789,32 +789,3 @@ func HandleVErrAndExitCode(verr errhand.VerboseError, usage cli.UsagePrinter) in
 
 	return 0
 }
-
-// HasLocalChanges compares the working and staged hash against the head hash to determine if there are uncommitted changes.
-func HasLocalChanges(ctx context.Context, dEnv *env.DoltEnv) (bool, error) {
-	hRoot, err := dEnv.HeadRoot(ctx)
-	if err != nil {
-		return false, err
-	}
-	wRoot, err := dEnv.WorkingRoot(ctx)
-	if err != nil {
-		return false, err
-	}
-	sRoot, err := dEnv.StagedRoot(ctx)
-	if err != nil {
-		return false, err
-	}
-	hHash, err := hRoot.HashOf()
-	if err != nil {
-		return false, err
-	}
-	wHash, err := wRoot.HashOf()
-	if err != nil {
-		return false, err
-	}
-	sHash, err := sRoot.HashOf()
-	if err != nil {
-		return false, err
-	}
-	return !hHash.Equal(wHash) || !hHash.Equal(sHash), nil
-}

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -1246,56 +1246,6 @@ func (ddb *DoltDB) NewBranchAtCommit(ctx context.Context, branchRef ref.DoltRef,
 	return ddb.UpdateWorkingSet(ctx, wsRef, ws, currWsHash, TodoWorkingSetMeta(), replicationStatus)
 }
 
-func (ddb *DoltDB) NewBranchAtCommitWithWorkingSet(ctx context.Context, branchRef ref.DoltRef, commit *Commit, ws *WorkingSet, replicationStatus *ReplicationStatusController) error {
-	if !IsValidBranchRef(branchRef) {
-		panic(fmt.Sprintf("invalid branch name %s, use IsValidUserBranchName check", branchRef.String()))
-	}
-
-	ds, err := ddb.db.GetDataset(ctx, branchRef.String())
-	if err != nil {
-		return err
-	}
-
-	addr, err := commit.HashOf()
-	if err != nil {
-		return err
-	}
-
-	_, err = ddb.db.SetHead(ctx, ds, addr, "")
-	if err != nil {
-		return err
-	}
-
-	wsRef, err := ref.WorkingSetRefForHead(branchRef)
-	if ws == nil {
-		ws, err = ddb.ResolveWorkingSet(ctx, wsRef)
-		if err != nil {
-			if !errors.Is(err, ErrWorkingSetNotFound) {
-				return err
-			}
-			ws = EmptyWorkingSet(wsRef)
-		}
-	}
-
-	commitRoot, err := commit.GetRootValue(ctx)
-	if err != nil {
-		return err
-	}
-	if ws.WorkingRoot() == nil {
-		ws = ws.WithWorkingRoot(commitRoot)
-	}
-	if ws.StagedRoot() == nil {
-		ws = ws.WithStagedRoot(commitRoot)
-	}
-
-	currWsHash, err := ws.HashOf()
-	if err != nil {
-		return err
-	}
-
-	return ddb.UpdateWorkingSet(ctx, wsRef, ws, currWsHash, TodoWorkingSetMeta(), replicationStatus)
-}
-
 // CopyWorkingSet copies a WorkingSetRef from one ref to another. If `force` is
 // true, will overwrite any existing value in the destination ref. Otherwise
 // will fail if the destination ref exists.

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -1231,7 +1231,7 @@ func (ddb *DoltDB) NewBranchAtCommit(ctx context.Context, branchRef ref.DoltRef,
 	var ws *WorkingSet
 	var currWsHash hash.Hash
 	ws, err = ddb.ResolveWorkingSet(ctx, wsRef)
-	if err == ErrWorkingSetNotFound {
+	if errors.Is(err, ErrWorkingSetNotFound) {
 		ws = EmptyWorkingSet(wsRef)
 	} else if err != nil {
 		return err
@@ -1243,6 +1243,56 @@ func (ddb *DoltDB) NewBranchAtCommit(ctx context.Context, branchRef ref.DoltRef,
 	}
 
 	ws = ws.WithWorkingRoot(commitRoot).WithStagedRoot(commitRoot)
+	return ddb.UpdateWorkingSet(ctx, wsRef, ws, currWsHash, TodoWorkingSetMeta(), replicationStatus)
+}
+
+func (ddb *DoltDB) NewBranchAtCommitWithWorkingSet(ctx context.Context, branchRef ref.DoltRef, commit *Commit, ws *WorkingSet, replicationStatus *ReplicationStatusController) error {
+	if !IsValidBranchRef(branchRef) {
+		panic(fmt.Sprintf("invalid branch name %s, use IsValidUserBranchName check", branchRef.String()))
+	}
+
+	ds, err := ddb.db.GetDataset(ctx, branchRef.String())
+	if err != nil {
+		return err
+	}
+
+	addr, err := commit.HashOf()
+	if err != nil {
+		return err
+	}
+
+	_, err = ddb.db.SetHead(ctx, ds, addr, "")
+	if err != nil {
+		return err
+	}
+
+	wsRef, err := ref.WorkingSetRefForHead(branchRef)
+	if ws == nil {
+		ws, err = ddb.ResolveWorkingSet(ctx, wsRef)
+		if err != nil {
+			if !errors.Is(err, ErrWorkingSetNotFound) {
+				return err
+			}
+			ws = EmptyWorkingSet(wsRef)
+		}
+	}
+
+	commitRoot, err := commit.GetRootValue(ctx)
+	if err != nil {
+		return err
+	}
+	if ws.WorkingRoot() == nil {
+		ws = ws.WithWorkingRoot(commitRoot)
+	}
+	if ws.StagedRoot() == nil {
+		ws = ws.WithStagedRoot(commitRoot)
+	}
+
+	currWsHash, err := ws.HashOf()
+	if err != nil {
+		return err
+	}
+
 	return ddb.UpdateWorkingSet(ctx, wsRef, ws, currWsHash, TodoWorkingSetMeta(), replicationStatus)
 }
 

--- a/go/libraries/doltcore/rebase/filter_branch.go
+++ b/go/libraries/doltcore/rebase/filter_branch.go
@@ -65,7 +65,8 @@ type ReplayRootFn func(ctx context.Context, root, parentRoot, rebasedParentRoot 
 
 type ReplayCommitFn func(ctx context.Context, commit, parent, rebasedParent *doltdb.Commit) (rebaseRoot doltdb.RootValue, err error)
 
-func validBranchRefs(ctx context.Context, ddb *doltdb.DoltDB, refs ...ref.DoltRef) error {
+func validateBranchRefs(ctx context.Context, ddb *doltdb.DoltDB, refs ...ref.DoltRef) error {
+	return nil
 	for _, r := range refs {
 		headComm, err := ddb.ResolveCommitRef(ctx, r)
 		if err != nil {
@@ -114,6 +115,11 @@ func AllBranchesAndTags(ctx context.Context, dEnv *env.DoltEnv, replay ReplayCom
 		return err
 	}
 
+	err = validateBranchRefs(ctx, dEnv.DbData().Ddb, branches...)
+	if err != nil {
+		return err
+	}
+
 	tags, err := dEnv.DoltDB.GetTags(ctx)
 	if err != nil {
 		return err
@@ -128,7 +134,7 @@ func AllBranches(ctx context.Context, dEnv *env.DoltEnv, replay ReplayCommitFn, 
 		return err
 	}
 
-	err = validBranchRefs(ctx, dEnv.DbData().Ddb, branches...)
+	err = validateBranchRefs(ctx, dEnv.DbData().Ddb, branches...)
 	if err != nil {
 		return err
 	}
@@ -143,7 +149,7 @@ func CurrentBranch(ctx context.Context, dEnv *env.DoltEnv, replay ReplayCommitFn
 		return nil
 	}
 
-	err = validBranchRefs(ctx, dEnv.DbData().Ddb, headRef)
+	err = validateBranchRefs(ctx, dEnv.DbData().Ddb, headRef)
 	if err != nil {
 		return err
 	}
@@ -258,6 +264,8 @@ func rebaseRecursive(ctx context.Context, ddb *doltdb.DoltDB, replay ReplayCommi
 		allRebasedParents = append(allRebasedParents, rp)
 	}
 
+
+	// TODO: replace needs to work with rootvalue?
 	rebasedRoot, err := replay(ctx, commit, allParents[0], allRebasedParents[0])
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/rebase/filter_branch.go
+++ b/go/libraries/doltcore/rebase/filter_branch.go
@@ -61,10 +61,12 @@ func StopAtCommit(stopCommit *doltdb.Commit) NeedsRebaseFn {
 	}
 }
 
+// RootReplayer is something that takes a root value and rebases it with changes.
 type RootReplayer interface {
 	ReplayRoot(ctx context.Context, root, parentRoot, rebasedParentRoot doltdb.RootValue) (rebaseRoot doltdb.RootValue, err error)
 }
 
+// CommitReplayer is something that takes a commit and rebases it with changes.
 type CommitReplayer interface {
 	ReplayCommit(ctx context.Context, commit, parent, rebasedParent *doltdb.Commit) (rebaseRoot doltdb.RootValue, err error)
 }
@@ -214,7 +216,7 @@ func rebaseRefs(ctx context.Context, dbData env.DbData, applyUncommitted bool, c
 				return err
 			}
 
-			err = ddb.UpdateWorkingSet(ctx, wsRef, ws, currWsHash, doltdb.TodoWorkingSetMeta(), nil)
+			err = ddb.UpdateWorkingSet(ctx, wsRef, ws, currWsHash, ws.Meta(), nil)
 		case ref.TagRef:
 			// rewrite tag with new commit
 			var tag *doltdb.Tag

--- a/go/libraries/doltcore/rebase/filter_branch.go
+++ b/go/libraries/doltcore/rebase/filter_branch.go
@@ -209,7 +209,7 @@ func rebaseRefs(ctx context.Context, dbData env.DbData, applyUncommitted bool, c
 			}
 
 			var currWsHash hash.Hash
-			currWsHash, err = newWorkingSet.HashOf()
+			currWsHash, err = ws.HashOf()
 			if err != nil {
 				return err
 			}

--- a/integration-tests/bats/filter-branch.bats
+++ b/integration-tests/bats/filter-branch.bats
@@ -594,6 +594,12 @@ SQL
     [ "$status" -eq 0 ]
     [[ "$output" =~ "nothing to commit, working tree clean" ]] || false
 
+    # changes on other branch
+    run dolt sql -q "call dolt_checkout('other'); select * from dolt_status;"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "table_name,staged,status" ]] || false
+    [[ "$output" =~ "test,false,modified" ]] || false
+
     run dolt filter-branch --apply-to-uncommitted --branches -q "alter table test add column filter int"
     [ "$status" -eq 0 ]
 
@@ -602,20 +608,27 @@ SQL
     [ "$status" -eq 0 ]
     [[ "$output" =~ "nothing to commit, working tree clean" ]] || false
 
-
-    dolt checkout other
-    run dolt sql -r csv -q "select * from dolt_status"
+    # changes on other branch
+    run dolt sql -r csv -q "call dolt_checkout('other'); select * from dolt_status;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "table_name,staged,status" ]] || false
     [[ "$output" =~ "test,false,modified" ]] || false
 
-    run dolt sql -r csv -q "select * from test as of 'HEAD'"
+    run dolt sql -r csv -q "select * from test"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "pk,c0,filter" ]] || false
     [[ "$output" =~ "0,0," ]] || false
     [[ "$output" =~ "1,1," ]] || false
     [[ "$output" =~ "2,2," ]] || false
     [[ ! "$output" =~ "3,3," ]] || false
+
+    run dolt sql -r csv -q "call dolt_checkout('other'); select * from test;"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "pk,c0,filter" ]] || false
+    [[ "$output" =~ "0,0," ]] || false
+    [[ "$output" =~ "1,1," ]] || false
+    [[ "$output" =~ "2,2," ]] || false
+    [[ "$output" =~ "3,3," ]] || false
 }
 
 @test "filter-branch: --apply-to-uncommitted applies changes to staged tables on other branch" {
@@ -630,6 +643,12 @@ SQL
     [ "$status" -eq 0 ]
     [[ "$output" =~ "nothing to commit, working tree clean" ]] || false
 
+    # changes on other branch
+    run dolt sql -q "call dolt_checkout('other'); select * from dolt_status;"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "table_name,staged,status" ]] || false
+    [[ "$output" =~ "test,true,modified" ]] || false
+
     run dolt filter-branch --apply-to-uncommitted --branches -q "alter table test add column filter int"
     [ "$status" -eq 0 ]
 
@@ -638,18 +657,25 @@ SQL
     [ "$status" -eq 0 ]
     [[ "$output" =~ "nothing to commit, working tree clean" ]] || false
 
-
-    dolt checkout other
-    run dolt sql -r csv -q "select * from dolt_status"
+    # changes on other branch
+    run dolt sql -q "call dolt_checkout('other'); select * from dolt_status;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "table_name,staged,status" ]] || false
     [[ "$output" =~ "test,true,modified" ]] || false
 
-    run dolt sql -r csv -q "select * from test as of 'HEAD'"
+    run dolt sql -r csv -q "select * from test"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "pk,c0,filter" ]] || false
     [[ "$output" =~ "0,0," ]] || false
     [[ "$output" =~ "1,1," ]] || false
     [[ "$output" =~ "2,2," ]] || false
     [[ ! "$output" =~ "3,3," ]] || false
+
+    run dolt sql -r csv -q "call dolt_checkout('other'); select * from test;"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "pk,c0,filter" ]] || false
+    [[ "$output" =~ "0,0," ]] || false
+    [[ "$output" =~ "1,1," ]] || false
+    [[ "$output" =~ "2,2," ]] || false
+    [[ "$output" =~ "3,3," ]] || false
 }

--- a/integration-tests/bats/filter-branch.bats
+++ b/integration-tests/bats/filter-branch.bats
@@ -405,12 +405,12 @@ SQL
 
     run dolt filter-branch -q "alter table test add column filter int"
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "local changes detected on branch refs/heads/main, use dolt stash or commit changes before using filter-branch" ]] || false
+    [[ "$output" =~ "local changes detected on branch refs/heads/main, clear uncommitted changes (dolt stash dolt commit) before using filter-branch, or use --apply-to-uncommitted" ]] || false
 
     dolt add .
     run dolt filter-branch -q "alter table test add column filter int"
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "local changes detected on branch refs/heads/main, use dolt stash or commit changes before using filter-branch" ]] || false
+    [[ "$output" =~ "local changes detected on branch refs/heads/main, clear uncommitted changes (dolt stash dolt commit) before using filter-branch, or use --apply-to-uncommitted" ]] || false
 
     dolt commit -m "added row"
     run dolt filter-branch -q "alter table test add column filter int"
@@ -439,11 +439,12 @@ SQL
     [[ "$output" =~ "0,0," ]] || false
     [[ "$output" =~ "1,1," ]] || false
     [[ "$output" =~ "2,2," ]] || false
+    [[ ! "$output" =~ "3,3," ]] || false
 
     dolt checkout other
     run dolt filter-branch -q "alter table test add column filter int"
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "local changes detected on branch refs/heads/other, use dolt stash or commit changes before using filter-branch" ]] || false
+    [[ "$output" =~ "local changes detected on branch refs/heads/other, clear uncommitted changes (dolt stash dolt commit) before using filter-branch, or use --apply-to-uncommitted" ]] || false
 }
 
 @test "filter-branch: --all fails with working and staged changes on other branch" {
@@ -454,14 +455,14 @@ SQL
 
     run dolt filter-branch --all -q "alter table test add column filter int"
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "local changes detected on branch refs/heads/other, use dolt stash or commit changes before using filter-branch" ]] || false
+    [[ "$output" =~ "local changes detected on branch refs/heads/other, clear uncommitted changes (dolt stash dolt commit) before using filter-branch, or use --apply-to-uncommitted" ]] || false
 
     dolt checkout other
 
     dolt add .
     run dolt filter-branch --all -q "alter table test add column filter int"
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "local changes detected on branch refs/heads/other, use dolt stash or commit changes before using filter-branch" ]] || false
+    [[ "$output" =~ "local changes detected on branch refs/heads/other, clear uncommitted changes (dolt stash dolt commit) before using filter-branch, or use --apply-to-uncommitted" ]] || false
 
     dolt commit -m "added row"
     run dolt filter-branch --all -q "alter table test add column filter int"
@@ -484,14 +485,14 @@ SQL
 
     run dolt filter-branch --branches -q "alter table test add column filter int"
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "local changes detected on branch refs/heads/other, use dolt stash or commit changes before using filter-branch" ]] || false
+    [[ "$output" =~ "local changes detected on branch refs/heads/other, clear uncommitted changes (dolt stash dolt commit) before using filter-branch, or use --apply-to-uncommitted" ]] || false
 
     dolt checkout other
 
     dolt add .
     run dolt filter-branch --branches -q "alter table test add column filter int"
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "local changes detected on branch refs/heads/other, use dolt stash or commit changes before using filter-branch" ]] || false
+    [[ "$output" =~ "local changes detected on branch refs/heads/other, clear uncommitted changes (dolt stash dolt commit) before using filter-branch, or use --apply-to-uncommitted" ]] || false
 
     dolt commit -m "added row"
     run dolt filter-branch --branches -q "alter table test add column filter int"
@@ -511,12 +512,12 @@ SQL
 
     run dolt filter-branch --continue -q "alter table test add column filter int"
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "local changes detected on branch refs/heads/main, use dolt stash or commit changes before using filter-branch" ]] || false
+    [[ "$output" =~ "local changes detected on branch refs/heads/main, clear uncommitted changes (dolt stash dolt commit) before using filter-branch, or use --apply-to-uncommitted" ]] || false
 
     dolt add .
     run dolt filter-branch --continue -q "alter table test add column filter int"
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "local changes detected on branch refs/heads/main, use dolt stash or commit changes before using filter-branch" ]] || false
+    [[ "$output" =~ "local changes detected on branch refs/heads/main, clear uncommitted changes (dolt stash dolt commit) before using filter-branch, or use --apply-to-uncommitted" ]] || false
 
     dolt commit -m "added row"
     run dolt filter-branch --continue -q "alter table test add column filter int"
@@ -531,3 +532,124 @@ SQL
     [[ "$output" =~ "3,3," ]] || false
 }
 
+@test "filter-branch: --apply-to-uncommitted applies changes to unstaged tables on current branch" {
+    dolt sql -q "insert into test values (3, 3)"
+
+    run dolt sql -r csv -q "select * from dolt_status"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "table_name,staged,status" ]] || false
+    [[ "$output" =~ "test,false,modified" ]] || false
+
+    run dolt filter-branch --apply-to-uncommitted -q "alter table test add column filter int"
+    [ "$status" -eq 0 ]
+
+    run dolt sql -r csv -q "select * from dolt_status"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "table_name,staged,status" ]] || false
+    [[ "$output" =~ "test,false,modified" ]] || false
+
+    run dolt sql -r csv -q "select * from test as of 'HEAD'"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "pk,c0,filter" ]] || false
+    [[ "$output" =~ "0,0," ]] || false
+    [[ "$output" =~ "1,1," ]] || false
+    [[ "$output" =~ "2,2," ]] || false
+    [[ ! "$output" =~ "3,3," ]] || false
+}
+
+@test "filter-branch: --apply-to-uncommitted applies changes to staged tables on current branch" {
+    dolt sql -q "insert into test values (3, 3)"
+    dolt add .
+
+    run dolt sql -r csv -q "select * from dolt_status"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "table_name,staged,status" ]] || false
+    [[ "$output" =~ "test,true,modified" ]] || false
+
+    run dolt filter-branch --apply-to-uncommitted -q "alter table test add column filter int"
+    [ "$status" -eq 0 ]
+
+    run dolt sql -r csv -q "select * from dolt_status"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "table_name,staged,status" ]] || false
+    [[ "$output" =~ "test,true,modified" ]] || false
+
+    run dolt sql -r csv -q "select * from test as of 'HEAD'"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "pk,c0,filter" ]] || false
+    [[ "$output" =~ "0,0," ]] || false
+    [[ "$output" =~ "1,1," ]] || false
+    [[ "$output" =~ "2,2," ]] || false
+    [[ ! "$output" =~ "3,3," ]] || false
+}
+
+@test "filter-branch: --apply-to-uncommitted applies changes to unstaged tables on other branch" {
+    dolt sql << SQL
+call dolt_checkout('-b', 'other');
+insert into test values (3, 3);
+SQL
+
+    # no changes on main branch
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "nothing to commit, working tree clean" ]] || false
+
+    run dolt filter-branch --apply-to-uncommitted --branches -q "alter table test add column filter int"
+    [ "$status" -eq 0 ]
+
+    # still no changes on main branch
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "nothing to commit, working tree clean" ]] || false
+
+
+    dolt checkout other
+    run dolt sql -r csv -q "select * from dolt_status"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "table_name,staged,status" ]] || false
+    [[ "$output" =~ "test,false,modified" ]] || false
+
+    run dolt sql -r csv -q "select * from test as of 'HEAD'"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "pk,c0,filter" ]] || false
+    [[ "$output" =~ "0,0," ]] || false
+    [[ "$output" =~ "1,1," ]] || false
+    [[ "$output" =~ "2,2," ]] || false
+    [[ ! "$output" =~ "3,3," ]] || false
+}
+
+@test "filter-branch: --apply-to-uncommitted applies changes to staged tables on other branch" {
+    dolt sql << SQL
+call dolt_checkout('-b', 'other');
+insert into test values (3, 3);
+call dolt_add('.');
+SQL
+
+    # no changes on main branch
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "nothing to commit, working tree clean" ]] || false
+
+    run dolt filter-branch --apply-to-uncommitted --branches -q "alter table test add column filter int"
+    [ "$status" -eq 0 ]
+
+    # still no changes on main branch
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "nothing to commit, working tree clean" ]] || false
+
+
+    dolt checkout other
+    run dolt sql -r csv -q "select * from dolt_status"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "table_name,staged,status" ]] || false
+    [[ "$output" =~ "test,true,modified" ]] || false
+
+    run dolt sql -r csv -q "select * from test as of 'HEAD'"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "pk,c0,filter" ]] || false
+    [[ "$output" =~ "0,0," ]] || false
+    [[ "$output" =~ "1,1," ]] || false
+    [[ "$output" =~ "2,2," ]] || false
+    [[ ! "$output" =~ "3,3," ]] || false
+}

--- a/integration-tests/bats/filter-branch.bats
+++ b/integration-tests/bats/filter-branch.bats
@@ -595,7 +595,7 @@ SQL
     [[ "$output" =~ "nothing to commit, working tree clean" ]] || false
 
     # changes on other branch
-    run dolt sql -q "call dolt_checkout('other'); select * from dolt_status;"
+    run dolt sql -r csv -q "call dolt_checkout('other'); select * from dolt_status;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "table_name,staged,status" ]] || false
     [[ "$output" =~ "test,false,modified" ]] || false
@@ -644,7 +644,7 @@ SQL
     [[ "$output" =~ "nothing to commit, working tree clean" ]] || false
 
     # changes on other branch
-    run dolt sql -q "call dolt_checkout('other'); select * from dolt_status;"
+    run dolt sql -r csv -q "call dolt_checkout('other'); select * from dolt_status;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "table_name,staged,status" ]] || false
     [[ "$output" =~ "test,true,modified" ]] || false
@@ -658,7 +658,7 @@ SQL
     [[ "$output" =~ "nothing to commit, working tree clean" ]] || false
 
     # changes on other branch
-    run dolt sql -q "call dolt_checkout('other'); select * from dolt_status;"
+    run dolt sql -r csv -q "call dolt_checkout('other'); select * from dolt_status;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "table_name,staged,status" ]] || false
     [[ "$output" =~ "test,true,modified" ]] || false


### PR DESCRIPTION
This PR adds support for a `--apply-to-uncommitted` option to `dolt filter-branch`, which applies the `filter-branch` changes to the working and staged roots. 

fixes https://github.com/dolthub/dolt/issues/7902