### PR TITLE
dolt fetch default spec from empty repo should return silently

### DIFF
--- a/go/libraries/doltcore/env/actions/clone.go
+++ b/go/libraries/doltcore/env/actions/clone.go
@@ -320,7 +320,7 @@ func shallowCloneDataPull(ctx context.Context, destData env.DbData, srcDB *doltd
 		return nil, fmt.Errorf("remote %s not found", remoteName)
 	}
 
-	specs, err := env.ParseRefSpecs([]string{branch}, destData.Rsr, remote)
+	specs, _, err := env.ParseRefSpecs([]string{branch}, destData.Rsr, remote)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/env/actions/remotes.go
+++ b/go/libraries/doltcore/env/actions/remotes.go
@@ -496,6 +496,19 @@ func FetchRefSpecs(
 	return fetchRefSpecsWithDepth(ctx, dbData, srcDB, refSpecs, defaultRefSpec, remote, mode, -1, progStarter, progStopper)
 }
 
+// fetchRefSpecsWithDepth fetches the remote refSpecs from the source database to the destination database. It fetches
+// the commits and all underlying data from the source database to the destination database.
+// Parameters:
+// - ctx: the context
+// - dbData: the env.DbData object for handling repoState read and write
+// - srcDB: the remote *doltdb.DoltDB object that is used to fetch remote branches from
+// - refSpecs: the list of refSpecs to fetch
+// - defaultRefSpecs: a boolean that indicates whether the refSpecs are the default refSpecs. False if the user specifies anything.
+// - remote: the remote object
+// - mode: the ref.UpdateMode object that specifies the update mode (force or not, prune or not)
+// - depth: the depth of the fetch. If depth is greater than 0, it is a shallow clone.
+// - progStarter: function that starts the progress reporting
+// - progStopper: function that stops the progress reporting
 func fetchRefSpecsWithDepth(
 	ctx context.Context,
 	dbData env.DbData,

--- a/go/libraries/doltcore/env/remotes.go
+++ b/go/libraries/doltcore/env/remotes.go
@@ -416,12 +416,15 @@ func RemoteForFetchArgs(args []string, rsr RepoStateReader) (Remote, []string, e
 }
 
 // ParseRefSpecs returns the ref specs for the string arguments given for the remote provided, or the default ref
-// specs for that remote if no arguments are provided.
-func ParseRefSpecs(args []string, rsr RepoStateReader, remote Remote) ([]ref.RemoteRefSpec, error) {
+// specs for that remote if no arguments are provided. In the event that the default ref specs are returned, the
+// returned boolean value will be true.
+func ParseRefSpecs(args []string, rsr RepoStateReader, remote Remote) ([]ref.RemoteRefSpec, bool, error) {
 	if len(args) != 0 {
-		return ParseRSFromArgs(remote.Name, args)
+		specs, err := ParseRSFromArgs(remote.Name, args)
+		return specs, false, err
 	} else {
-		return GetRefSpecs(rsr, remote.Name)
+		specs, err := GetRefSpecs(rsr, remote.Name)
+		return specs, true, err
 	}
 }
 

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_fetch.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_fetch.go
@@ -69,7 +69,7 @@ func doDoltFetch(ctx *sql.Context, args []string) (int, error) {
 		return cmdFailure, validationErr
 	}
 
-	refSpecs, err := env.ParseRefSpecs(refSpecArgs, dbData.Rsr, remote)
+	refSpecs, defaultRefSpec, err := env.ParseRefSpecs(refSpecArgs, dbData.Rsr, remote)
 	if err != nil {
 		return cmdFailure, err
 	}
@@ -87,7 +87,7 @@ func doDoltFetch(ctx *sql.Context, args []string) (int, error) {
 
 	prune := apr.Contains(cli.PruneFlag)
 	mode := ref.UpdateMode{Force: true, Prune: prune}
-	err = actions.FetchRefSpecs(ctx, dbData, srcDB, refSpecs, &remote, mode, runProgFuncs, stopProgFuncs)
+	err = actions.FetchRefSpecs(ctx, dbData, srcDB, refSpecs, defaultRefSpec, &remote, mode, runProgFuncs, stopProgFuncs)
 	if err != nil {
 		return cmdFailure, fmt.Errorf("fetch failed: %w", err)
 	}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_pull.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_pull.go
@@ -152,7 +152,7 @@ func doDoltPull(ctx *sql.Context, args []string) (int, int, string, error) {
 	}
 
 	mode := ref.UpdateMode{Force: true, Prune: false}
-	err = actions.FetchRefSpecs(ctx, dbData, srcDB, pullSpec.RefSpecs, &pullSpec.Remote, mode, runProgFuncs, stopProgFuncs)
+	err = actions.FetchRefSpecs(ctx, dbData, srcDB, pullSpec.RefSpecs, false, &pullSpec.Remote, mode, runProgFuncs, stopProgFuncs)
 	if err != nil {
 		return noConflictsOrViolations, threeWayMerge, "", fmt.Errorf("fetch failed: %w", err)
 	}

--- a/integration-tests/bats/fetch.bats
+++ b/integration-tests/bats/fetch.bats
@@ -391,6 +391,19 @@ teardown() {
     [[ "$output" =~ "invalid fetch spec: ''" ]] || false
 }
 
+@test "fetch: fetching from empty remote" {
+    cd repo2
+    dolt remote add empty file://../empty
+
+    setup_remote_server
+
+    dolt fetch empty
+
+    run dolt fetch empty main
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "no branches found in remote 'empty'" ]] || false
+}
+
 @test "fetch: fetch from remote host fails" {
     run dolt --host hostedHost --port 3306 --user root --password password fetch origin
     [ "$status" -eq 1 ]


### PR DESCRIPTION
Git fetch returns without error when you fetch the default refspec. When you fetch a specific ref you get an error. Dolt now matches this behavior.

Fixes: https://github.com/dolthub/dolt/issues/7928