### PR TITLE
Create pg_catalog by default for Doltgres

### DIFF
--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -700,7 +700,7 @@ func (db Database) getTable(ctx *sql.Context, root doltdb.RootValue, tableName s
 		}
 	}
 
-	table, err := db.newDoltTable(tableName, sch, tbl)
+	table, err := NewDoltSqlTable(db, tableName, sch, tbl)
 	if err != nil {
 		return nil, false, err
 	}
@@ -770,8 +770,9 @@ func (db Database) tableInsensitive(ctx *sql.Context, root doltdb.RootValue, tab
 	return tname, tbl, true, nil
 }
 
-// newDoltTable returns a sql.Table wrapping the given underlying dolt table
-func (db Database) newDoltTable(tableName string, sch schema.Schema, tbl *doltdb.Table) (sql.Table, error) {
+// NewDoltSqlTable returns a sql.Table wrapping the given underlying dolt table. This is modified by Doltgres, therefore
+// it is a variable function rather than a standard function.
+var NewDoltSqlTable = func(db Database, tableName string, sch schema.Schema, tbl *doltdb.Table) (sql.Table, error) {
 	readonlyTable, err := NewDoltTable(tableName, sch, tbl, db, db.editOpts)
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -495,7 +495,8 @@ func (p *DoltDatabaseProvider) CreateCollatedDatabase(ctx *sql.Context, name str
 		}
 	}
 
-	// If the search path is enabled, we need to create our initial schema object (public is available by default)
+	// If the search path is enabled, we need to create our initial schema object (public and pg_catalog are available
+	// by default)
 	if resolve.UseSearchPath {
 		workingRoot, err := newEnv.WorkingRoot(ctx)
 		if err != nil {
@@ -504,6 +505,12 @@ func (p *DoltDatabaseProvider) CreateCollatedDatabase(ctx *sql.Context, name str
 
 		workingRoot, err = workingRoot.CreateDatabaseSchema(ctx, schema.DatabaseSchema{
 			Name: "public",
+		})
+		if err != nil {
+			return err
+		}
+		workingRoot, err = workingRoot.CreateDatabaseSchema(ctx, schema.DatabaseSchema{
+			Name: "pg_catalog",
 		})
 		if err != nil {
 			return err

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -820,7 +820,7 @@ func emptyFulltextTable(
 		return nil, nil, err
 	}
 
-	newTable, err := parentTable.db.newDoltTable(fulltextTable.Name(), doltSchema, dt)
+	newTable, err := NewDoltSqlTable(parentTable.db, fulltextTable.Name(), doltSchema, dt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1656,7 +1656,7 @@ func (t *AlterableDoltTable) RewriteInserter(
 		}
 	} else {
 		// we need a temp version of a sql.Table here to get key columns
-		newTbl, err := t.db.newDoltTable(t.Name(), newSch, dt)
+		newTbl, err := NewDoltSqlTable(t.db, t.Name(), newSch, dt)
 		if err != nil {
 			return nil, err
 		}
@@ -1763,7 +1763,7 @@ func fullTextRewriteEditor(
 	workingRoot doltdb.RootValue,
 ) (sql.RowInserter, error) {
 
-	newTable, err := t.db.newDoltTable(t.Name(), newSch, dt)
+	newTable, err := NewDoltSqlTable(t.db, t.Name(), newSch, dt)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -820,7 +820,7 @@ func emptyFulltextTable(
 		return nil, nil, err
 	}
 
-	newTable, err := NewDoltSqlTable(parentTable.db, fulltextTable.Name(), doltSchema, dt)
+	newTable, err := parentTable.db.newDoltTable(fulltextTable.Name(), doltSchema, dt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1656,7 +1656,7 @@ func (t *AlterableDoltTable) RewriteInserter(
 		}
 	} else {
 		// we need a temp version of a sql.Table here to get key columns
-		newTbl, err := NewDoltSqlTable(t.db, t.Name(), newSch, dt)
+		newTbl, err := t.db.newDoltTable(t.Name(), newSch, dt)
 		if err != nil {
 			return nil, err
 		}
@@ -1763,7 +1763,7 @@ func fullTextRewriteEditor(
 	workingRoot doltdb.RootValue,
 ) (sql.RowInserter, error) {
 
-	newTable, err := NewDoltSqlTable(t.db, t.Name(), newSch, dt)
+	newTable, err := t.db.newDoltTable(t.Name(), newSch, dt)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This makes it such that `pg_catalog` is created by default when Doltgres is using Dolt. In addition, adds a new function to hook into schema functionality.