### PR TITLE
go/libraries/doltcore/remotesrv: grpc.go: Respect X-Forwarded-Proto when generating HTTP download links in the gRPC server.

### DIFF
--- a/go/libraries/doltcore/remotesrv/grpc.go
+++ b/go/libraries/doltcore/remotesrv/grpc.go
@@ -337,10 +337,20 @@ func (rs *RemoteChunkStore) getHost(md metadata.MD) string {
 	return host
 }
 
+func (rs *RemoteChunkStore) getScheme(md metadata.MD) string {
+	scheme := rs.httpScheme
+	forwardedSchemes := md.Get("x-forwarded-proto")
+	if len(forwardedSchemes) > 0 {
+		scheme = forwardedSchemes[0]
+	}
+	return scheme
+}
+
 func (rs *RemoteChunkStore) getDownloadUrl(md metadata.MD, path string) *url.URL {
 	host := rs.getHost(md)
+	scheme := rs.getScheme(md)
 	return &url.URL{
-		Scheme: rs.httpScheme,
+		Scheme: scheme,
 		Host:   host,
 		Path:   path,
 	}

--- a/go/libraries/doltcore/remotesrv/grpc_test.go
+++ b/go/libraries/doltcore/remotesrv/grpc_test.go
@@ -1,0 +1,36 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remotesrv
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestGRPCSchemeSelection(t *testing.T) {
+	rs := &RemoteChunkStore{
+		httpScheme: "http",
+	}
+
+	md := metadata.New(nil)
+	scheme := rs.getScheme(md)
+	assert.Equal(t, scheme, "http")
+
+	md.Append("x-forwarded-proto", "https")
+	scheme = rs.getScheme(md)
+	assert.Equal(t, scheme, "https")
+}


### PR DESCRIPTION
Fixes #7961.