### PR TITLE
Allow `WritableDoltTable.UpdateForeignKey()` to update FK name

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/cespare/xxhash v1.1.0
 	github.com/creasty/defaults v1.6.0
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-mysql-server v0.18.2-0.20240604235838-5d11cec1718f
+	github.com/dolthub/go-mysql-server v0.18.2-0.20240606221921-89cf8303d3c8
 	github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63
 	github.com/dolthub/swiss v0.1.0
 	github.com/goccy/go-json v0.10.2

--- a/go/go.sum
+++ b/go/go.sum
@@ -185,6 +185,8 @@ github.com/dolthub/go-icu-regex v0.0.0-20230524105445-af7e7991c97e h1:kPsT4a47cw
 github.com/dolthub/go-icu-regex v0.0.0-20230524105445-af7e7991c97e/go.mod h1:KPUcpx070QOfJK1gNe0zx4pA5sicIK1GMikIGLKC168=
 github.com/dolthub/go-mysql-server v0.18.2-0.20240604235838-5d11cec1718f h1:e2Xyty29+ht/mL8ffvPyeKiVjaFcTo3N1OYuj6EnlmA=
 github.com/dolthub/go-mysql-server v0.18.2-0.20240604235838-5d11cec1718f/go.mod h1:GT7JcQavIf7bAO17/odujkgHM/N0t4b1HfAPBJ2jzXo=
+github.com/dolthub/go-mysql-server v0.18.2-0.20240606221921-89cf8303d3c8 h1:QJjMrna8ABj+e7Jiv4aw1xYjERXnNjp1vNPnSDiunSA=
+github.com/dolthub/go-mysql-server v0.18.2-0.20240606221921-89cf8303d3c8/go.mod h1:GT7JcQavIf7bAO17/odujkgHM/N0t4b1HfAPBJ2jzXo=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20221214210346-d7db0b066488 h1:0HHu0GWJH0N6a6keStrHhUAK5/o9LVfkh44pvsV4514=

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -2709,6 +2709,7 @@ func (t *WritableDoltTable) UpdateForeignKey(ctx *sql.Context, fkName string, sq
 		return sql.ErrForeignKeyNotFound.New(fkName, t.tableName)
 	}
 	fkc.RemoveKeyByName(doltFk.Name)
+	doltFk.Name = sqlFk.Name
 	doltFk.TableName = sqlFk.Table
 	doltFk.ReferencedTableName = sqlFk.ParentTable
 	doltFk.UnresolvedFKDetails.TableColumns = sqlFk.Columns


### PR DESCRIPTION
https://github.com/dolthub/go-mysql-server/pull/2536 changes `RENAME TABLE` to rename auto-generated foreign keys, and requires implementations of `UpdateForeignKey()` to honor the new name passed in for the foreign key.

Related to https://github.com/dolthub/dolt/issues/7959