### PR TITLE
integration-tests/bats: Add some waits on the remotesrv_pid exit for bats tests which spawn a background remotesrv.

### DIFF
--- a/integration-tests/bats/garbage_collection.bats
+++ b/integration-tests/bats/garbage_collection.bats
@@ -19,6 +19,8 @@ setup() {
 teardown() {
     teardown_common
     kill $remotesrv_pid
+    wait $remotesrv_pid || :
+    remotesrv_pid=""
     rm -rf $BATS_TMPDIR/remotes-$$
 }
 

--- a/integration-tests/bats/remotes-push-pull.bats
+++ b/integration-tests/bats/remotes-push-pull.bats
@@ -18,6 +18,8 @@ setup() {
 teardown() {
     teardown_common
     kill $remotesrv_pid
+    wait $remotesrv_pid || :
+    remotesrv_pid=""
     rm -rf $BATS_TMPDIR/remotes-$$
 }
 

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -18,6 +18,8 @@ setup() {
 teardown() {
     teardown_common
     kill $remotesrv_pid
+    wait $remotesrv_pid || :
+    remotesrv_pid=""
     rm -rf $BATS_TMPDIR/remotes-$$
 }
 

--- a/integration-tests/bats/remotesrv.bats
+++ b/integration-tests/bats/remotesrv.bats
@@ -14,13 +14,15 @@ setup() {
 }
 
 teardown() {
-    teardown_common
     stop_remotesrv
+    teardown_common
 }
 
 stop_remotesrv() {
     if [ -n "$remotesrv_pid" ]; then
-        kill $remotesrv_pid || :
+        kill "$remotesrv_pid" || :
+        wait "$remotesrv_pid" || :
+        remotesrv_pid=""
     fi
 }
 

--- a/integration-tests/bats/shallow-clone.bats
+++ b/integration-tests/bats/shallow-clone.bats
@@ -10,17 +10,18 @@ load $BATS_TEST_DIRNAME/helper/common.bash
 remotesrv_pid=""
 setup() {
     skiponwindows "tests are flaky on Windows"
-    setup_common
+    setup_no_dolt_init
 }
 
 teardown() {
-    teardown_common
     stop_remotesrv
+    teardown_common
 }
 
 stop_remotesrv() {
     if [ -n "$remotesrv_pid" ]; then
-        kill $remotesrv_pid || :
+        kill "$remotesrv_pid"
+        wait "$remotesrv_pid" || :
         remotesrv_pid=""
     fi
 }

--- a/integration-tests/bats/system-tables.bats
+++ b/integration-tests/bats/system-tables.bats
@@ -10,7 +10,6 @@ teardown() {
     skiponwindows "tests are flaky on Windows"
     assert_feature_version
     teardown_common
-    kill $remotesrv_pid
     rm -rf $BATS_TMPDIR/remotes-$$
 }
 


### PR DESCRIPTION
Attempts to fix some observed flakiness in bats tests.