### PR TITLE
[no-release-notes] Log failures in shallow-clone.bats, and change the port number

### DIFF
--- a/integration-tests/bats/shallow-clone.bats
+++ b/integration-tests/bats/shallow-clone.bats
@@ -43,7 +43,7 @@ seed_and_start_serial_remote() {
 
     dolt tag nonheadtag HEAD~2
 
-    remotesrv --http-port 1234 --repo-mode &
+    remotesrv --http-port 12345 --repo-mode &> ./remotesrv.log 3>&- &
     remotesrv_pid=$!
 
     cd ..


### PR DESCRIPTION
This is mainly a shot in the dark regarding the shallow clone failures in CI. I changed the port number based on a hunch. The remotesrv process now has a log file. How we get that in an event of failure - I'm not sure. But we follow this pattern other tests.