### PR TITLE
Generate `TEMPORARY TABLE` tags the same as normal `TABLE`s

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -148,15 +148,9 @@ func TestSingleScript(t *testing.T) {
 
 	var scripts = []queries.ScriptTest{
 		{
-			Name: "temporary table tag collision",
+			Name: "",
 			SetUpScript: []string{},
 			Assertions: []queries.ScriptTestAssertion{
-				{
-					Query:    "CREATE TEMPORARY TABLE tmp_tbl(a int, b int, c int, d int, e int, f int, g int);",
-					Expected: []sql.Row{
-						{gmstypes.NewOkResult(0)},
-					},
-				},
 			},
 		},
 	}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -148,72 +148,31 @@ func TestSingleScript(t *testing.T) {
 
 	var scripts = []queries.ScriptTest{
 		{
-			Name: "test hashof",
-			SetUpScript: []string{
-				"CREATE TABLE hashof_test (pk int primary key, c1 int)",
-				"INSERT INTO hashof_test values (1,1), (2,2), (3,3)",
-				"CALL DOLT_ADD('hashof_test')",
-				"CALL DOLT_COMMIT('-a', '-m', 'first commit')",
-				"SET @Commit1 = (SELECT commit_hash FROM DOLT_LOG() LIMIT 1)",
-				"INSERT INTO hashof_test values (4,4), (5,5), (6,6)",
-				"CALL DOLT_COMMIT('-a', '-m', 'second commit')",
-				"SET @Commit2 = (SELECT commit_hash from DOLT_LOG() LIMIT 1)",
-			},
+			Name: "temporary table tag collision",
+			SetUpScript: []string{},
 			Assertions: []queries.ScriptTestAssertion{
 				{
-					Query:    "SELECT (hashof(@Commit1) = hashof(@Commit2))",
-					Expected: []sql.Row{{false}},
-				},
-				{
-					Query: "SELECT (hashof(@Commit1) = hashof('HEAD~1'))",
+					Query:    "CREATE TEMPORARY TABLE tmp_tbl(a int, b int, c int, d int, e int, f int, g int);",
 					Expected: []sql.Row{
-						{true},
+						{gmstypes.NewOkResult(0)},
 					},
-				},
-				{
-					Query: "SELECT (hashof(@Commit2) = hashof('HEAD'))",
-					Expected: []sql.Row{
-						{true},
-					},
-				},
-				{
-					Query: "SELECT (hashof(@Commit2) = hashof('main'))",
-					Expected: []sql.Row{
-						{true},
-					},
-				},
-				{
-					Query:          "SELECT hashof('non_branch')",
-					ExpectedErrStr: "invalid ref spec",
-				},
-				{
-					// Test that a short commit is invalid. This may change in the future.
-					Query:          "SELECT hashof(left(@Commit2,30))",
-					ExpectedErrStr: "invalid ref spec",
 				},
 			},
 		},
 	}
 
-	tcc := &testCommitClock{}
-	cleanup := installTestCommitClock(tcc)
-	defer cleanup()
-
 	for _, script := range scripts {
-		sql.RunWithNowFunc(tcc.Now, func() error {
-			harness := newDoltHarness(t)
-			harness.Setup(setup.MydbData)
+		harness := newDoltHarness(t)
+		harness.Setup(setup.MydbData)
 
-			engine, err := harness.NewEngine(t)
-			if err != nil {
-				panic(err)
-			}
-			// engine.EngineAnalyzer().Debug = true
-			// engine.EngineAnalyzer().Verbose = true
+		engine, err := harness.NewEngine(t)
+		if err != nil {
+			panic(err)
+		}
+		// engine.EngineAnalyzer().Debug = true
+		// engine.EngineAnalyzer().Verbose = true
 
-			enginetest.TestScriptWithEngine(t, engine, harness, script)
-			return nil
-		})
+		enginetest.TestScriptWithEngine(t, engine, harness, script)
 	}
 }
 

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -150,8 +150,7 @@ func TestSingleScript(t *testing.T) {
 		{
 			Name:        "",
 			SetUpScript: []string{},
-			Assertions: []queries.ScriptTestAssertion{
-			},
+			Assertions:  []queries.ScriptTestAssertion{},
 		},
 	}
 

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -7131,4 +7131,18 @@ var DoltTempTableScripts = []queries.ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "temporary table tag collision",
+		SetUpScript: []string{
+			"CREATE TABLE note(a int, b int, userid int);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "CREATE TEMPORARY TABLE tmp_tbl(a int, b int, c int, d int, e int, f int, g int);",
+				Expected: []sql.Row{
+					{gmstypes.NewOkResult(0)},
+				},
+			},
+		},
+	},
 }

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -7140,7 +7140,7 @@ var DoltTempTableScripts = []queries.ScriptTest{
 			{
 				Query:    "CREATE TEMPORARY TABLE tmp_tbl(a int, b int, c int, d int, e int, f int, g int);",
 				Expected: []sql.Row{
-					{gmstypes.NewOkResult(0)},
+					{types.NewOkResult(0)},
 				},
 			},
 		},


### PR DESCRIPTION
This PR fixes this particular collision and makes collisions with other temporary tables more unlikely, probably, by using the deterministic random number generator used for generating tags for normal persisting tables.

fixes https://github.com/dolthub/dolt/issues/7995