### PR TITLE
Archive DDict cache and multi-file bug fixes

### DIFF
--- a/go/store/nbs/archive_build.go
+++ b/go/store/nbs/archive_build.go
@@ -277,7 +277,7 @@ func gatherAllChunks(ctx context.Context, cs chunkSource, idx tableIndex) (map[h
 		allChunks[h] = c
 	}, &stats)
 	if err != nil {
-		panic(err)
+		return nil, nil, err
 	}
 	if !allFound { // Unlikely to happen, given we got the list of chunks from this index.
 		return nil, nil, errors.New("missing chunks")

--- a/go/store/nbs/archive_chunk_source.go
+++ b/go/store/nbs/archive_chunk_source.go
@@ -81,7 +81,7 @@ func (acs archiveChunkSource) getMany(ctx context.Context, eg *errgroup.Group, r
 	foundAll := true
 	for _, req := range reqs {
 		data, err := acs.aRdr.get(*req.a)
-		if err != nil {
+		if err != nil || data == nil {
 			foundAll = false
 		} else {
 			chunk := chunks.NewChunk(data)
@@ -89,7 +89,7 @@ func (acs archiveChunkSource) getMany(ctx context.Context, eg *errgroup.Group, r
 			req.found = true
 		}
 	}
-	return foundAll, nil
+	return !foundAll, nil
 }
 
 func (acs archiveChunkSource) count() (uint32, error) {

--- a/go/store/nbs/archive_reader.go
+++ b/go/store/nbs/archive_reader.go
@@ -24,6 +24,7 @@ import (
 	"math/bits"
 
 	"github.com/dolthub/gozstd"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/pkg/errors"
 
 	"github.com/dolthub/dolt/go/store/hash"
@@ -36,6 +37,7 @@ type archiveReader struct {
 	chunkRefs []chunkRef
 	suffixes  []suffix
 	footer    footer
+	dictCache *lru.TwoQueueCache[uint32, *gozstd.DDict]
 }
 
 type chunkRef struct {
@@ -178,6 +180,11 @@ func newArchiveReader(reader io.ReaderAt, fileSize uint64) (archiveReader, error
 		}
 	}
 
+	dictCache, err := lru.New2Q[uint32, *gozstd.DDict](256)
+	if err != nil {
+		return archiveReader{}, err
+	}
+
 	return archiveReader{
 		reader:    reader,
 		prefixes:  prefixes,
@@ -185,6 +192,7 @@ func newArchiveReader(reader io.ReaderAt, fileSize uint64) (archiveReader, error
 		chunkRefs: chunks,
 		suffixes:  suffixes,
 		footer:    footer,
+		dictCache: dictCache,
 	}, nil
 }
 
@@ -260,16 +268,7 @@ func (ai archiveReader) get(hash hash.Hash) ([]byte, error) {
 	if dict == nil {
 		result, err = gozstd.Decompress(nil, data)
 	} else {
-		dcmpDict, e2 := gozstd.Decompress(nil, dict)
-		if e2 != nil {
-			return nil, e2
-		}
-
-		dDict, e2 := gozstd.NewDDict(dcmpDict)
-		if e2 != nil {
-			return nil, e2
-		}
-		result, err = gozstd.DecompressDict(nil, data, dDict)
+		result, err = gozstd.DecompressDict(nil, data, dict)
 	}
 	if err != nil {
 		return nil, err
@@ -301,7 +300,7 @@ func (ai archiveReader) readByteSpan(bs byteSpan) ([]byte, error) {
 // no error is returned in this case. Errors will only be returned if there is an io error.
 //
 // The data returned is still compressed, regardless of the dictionary being present or not.
-func (ai archiveReader) getRaw(hash hash.Hash) (dict, data []byte, err error) {
+func (ai archiveReader) getRaw(hash hash.Hash) (dict *gozstd.DDict, data []byte, err error) {
 	idx := ai.search(hash)
 	if idx < 0 {
 		return nil, nil, nil
@@ -309,10 +308,26 @@ func (ai archiveReader) getRaw(hash hash.Hash) (dict, data []byte, err error) {
 
 	chunkRef := ai.chunkRefs[idx]
 	if chunkRef.dict != 0 {
-		byteSpan := ai.byteSpans[chunkRef.dict]
-		dict, err = ai.readByteSpan(byteSpan)
-		if err != nil {
-			return nil, nil, err
+		if cached, cacheHit := ai.dictCache.Get(chunkRef.dict); cacheHit {
+			dict = cached
+		} else {
+			byteSpan := ai.byteSpans[chunkRef.dict]
+			dictBytes, err := ai.readByteSpan(byteSpan)
+			if err != nil {
+				return nil, nil, err
+			}
+			// Dictionaries are compressed with no dictionary.
+			dcmpDict, e2 := gozstd.Decompress(nil, dictBytes)
+			if e2 != nil {
+				return nil, nil, e2
+			}
+
+			dict, e2 = gozstd.NewDDict(dcmpDict)
+			if e2 != nil {
+				return nil, nil, e2
+			}
+
+			ai.dictCache.Add(chunkRef.dict, dict)
 		}
 	}
 

--- a/integration-tests/bats/archive.bats
+++ b/integration-tests/bats/archive.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+load $BATS_TEST_DIRNAME/helper/common.bash
+
+setup() {
+    setup_common
+
+    dolt sql -q "create table tbl (i int auto_increment primary key, guid char(36))"
+    dolt commit -A -m "crate tbl"
+
+    make_inserts
+}
+
+teardown() {
+    assert_feature_version
+    teardown_common
+}
+
+# Insert 25 new rows, then commit.
+make_inserts() {
+  for ((i=1; i<=25; i++))
+  do
+    dolt sql -q "INSERT INTO tbl (guid) VALUES (UUID())"
+  done
+  dolt commit -a -m "Add 25 values"
+}
+
+# Randomly update 10 rows, then commit.
+make_updates() {
+  for ((i=1; i<=10; i++))
+  do
+    dolt sql -q	"UPDATE tbl SET guid = UUID() WHERE i = (SELECT i FROM tbl ORDER BY RAND() LIMIT 1)"
+  done
+  dolt commit -a -m "Update 10 values."
+}
+
+@test "archive: too few chunks" {
+  make_updates
+  dolt gc
+
+  run dolt admin archive
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "Not enough samples to build default dictionary" ]] || false
+}
+
+@test "archive: single archive" {
+  # We need at least 25 chunks to create an archive.
+  for ((j=1; j<=10; j++))
+  do
+    make_updates
+    make_inserts
+  done
+
+  dolt gc
+  dolt admin archive
+
+  files=$(find . -name "*darc" | wc -l | sed 's/[ \t]//g')
+  [ "$files" -eq "1" ]
+}
+
+
+@test "archive: multiple archives" {
+  # We need at least 25 chunks to create an archive.
+  for ((j=1; j<=10; j++))
+  do
+    make_updates
+    make_inserts
+  done
+  dolt gc
+
+  for ((j=1; j<=10; j++))
+  do
+    make_updates
+    make_inserts
+  done
+  dolt gc
+
+  for ((j=1; j<=10; j++))
+  do
+    make_updates
+    make_inserts
+  done
+  dolt gc
+
+  dolt admin archive
+
+  files=$(find . -name "*darc" | wc -l | sed 's/[ \t]//g')
+  [ "$files" -eq "3" ]
+
+  # dolt log --stat will load every single chunk.
+  commits=$(dolt log --stat --oneline | wc -l | sed 's/[ \t]//g')
+  [ "$commits" -eq "186" ]
+}
+

--- a/integration-tests/bats/archive.bats
+++ b/integration-tests/bats/archive.bats
@@ -42,6 +42,8 @@ make_updates() {
   [[ "$output" =~ "Not enough samples to build default dictionary" ]] || false
 }
 
+# This test runs over 45 seconds, resulting in a timeout in lambdabats
+# bats test_tags=no_lambda
 @test "archive: single archive" {
   # We need at least 25 chunks to create an archive.
   for ((j=1; j<=10; j++))

--- a/integration-tests/bats/archive.bats
+++ b/integration-tests/bats/archive.bats
@@ -57,7 +57,8 @@ make_updates() {
   [ "$files" -eq "1" ]
 }
 
-
+# This test runs over 45 seconds, resulting in a timeout in lambdabats
+# bats test_tags=no_lambda
 @test "archive: multiple archives" {
   # We need at least 25 chunks to create an archive.
   for ((j=1; j<=10; j++))

--- a/integration-tests/bats/archive.bats
+++ b/integration-tests/bats/archive.bats
@@ -5,7 +5,7 @@ setup() {
     setup_common
 
     dolt sql -q "create table tbl (i int auto_increment primary key, guid char(36))"
-    dolt commit -A -m "crate tbl"
+    dolt commit -A -m "create tbl"
 
     make_inserts
 }


### PR DESCRIPTION
Two primary issues addressed in the `dolt admin archive` command:
1) Add caching to dictionaries. This improved performance significantly.
2) Fix multiple bugs related to having multiple table files. That was a gap in testing, so added a bats test for the command.