### PR TITLE
move from forward to back slashes in sql shell

### DIFF
--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -97,7 +97,7 @@ const (
 
 	welcomeMsg = `# Welcome to the DoltSQL shell.
 # Statements must be terminated with ';'.
-# "exit" or "quit" (or Ctrl-D) to exit. "/help;" for help.`
+# "exit" or "quit" (or Ctrl-D) to exit. "\help;" for help.`
 )
 
 // TODO: get rid of me, use a real integration point to define system variables
@@ -755,7 +755,7 @@ func execShell(sqlCtx *sql.Context, qryist cli.Queryist, format engine.PrintResu
 		var nextPrompt string
 		var multiPrompt string
 
-		re := regexp.MustCompile(`\s*/(.*)`)
+		re := regexp.MustCompile(`\s*\\(.*)`)
 		matches := re.FindStringSubmatch(query)
 		// If the query starts with a slash, it's a shell command. We don't want to print the query in that case.
 		if len(matches) > 1 {

--- a/go/cmd/dolt/commands/sql_slash.go
+++ b/go/cmd/dolt/commands/sql_slash.go
@@ -103,7 +103,7 @@ func (s SlashHelp) Description() string {
 
 func (s SlashHelp) Docs() *cli.CommandDocumentation {
 	return &cli.CommandDocumentation{
-		CommandStr: "/help",
+		CommandStr: "\\help",
 		ShortDesc:  "What you see right now.",
 		LongDesc:   "It would seem that you are crying out for help. Please join us on Discord (https://discord.gg/gqr7K4VNKe)!",
 		Synopsis:   []string{},
@@ -138,13 +138,13 @@ func (s SlashHelp) Exec(ctx context.Context, _ string, args []string, _ *env.Dol
 
 	cli.Println("Dolt SQL Shell Help")
 	cli.Printf("Default behavior is to interpret SQL statements.     (e.g. '%sselect * from my_table;')\n", prompt)
-	cli.Printf("Dolt CLI commands can be invoked with a leading '/'. (e.g. '%s/status;')\n", prompt)
+	cli.Printf("Dolt CLI commands can be invoked with a leading '\\'. (e.g. '%s\\status;')\n", prompt)
 	cli.Println("All statements are terminated with a ';'.")
 	cli.Println("\nAvailable commands:")
 	for _, cmdInst := range slashCmds {
 		cli.Println(fmt.Sprintf("  %10s - %s", cmdInst.Name(), cmdInst.Description()))
 	}
-	cli.Printf("\nFor more information on a specific command, type '/help <command>;' (e.g. '%s/help status;')\n", prompt)
+	cli.Printf("\nFor more information on a specific command, type '\\help <command>;' (e.g. '%s\\help status;')\n", prompt)
 
 	moreWords := `
 -+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-

--- a/integration-tests/bats/sql-shell-slash-cmds.expect
+++ b/integration-tests/bats/sql-shell-slash-cmds.expect
@@ -53,15 +53,15 @@ proc expect_with_defaults_2 {patternA patternB action} {
 
 spawn dolt sql
 
-expect_with_defaults {dolt-repo-[0-9]+/main\*> } { send "/commit -A -m \"sql-shell-slash-cmds commit\";\r"; }
+expect_with_defaults {dolt-repo-[0-9]+/main\*> } { send "\\commit -A -m \"sql-shell-slash-cmds commit\";\r"; }
 
-expect_with_defaults {dolt-repo-[0-9]+/main> }   { send "/log -n 1;\r"; }
+expect_with_defaults {dolt-repo-[0-9]+/main> }   { send "\\log -n 1;\r"; }
 
-expect_with_defaults_2 {sql-shell-slash-cmds commit} {dolt-repo-[0-9]+/main> } { send "/status;\r"; }
+expect_with_defaults_2 {sql-shell-slash-cmds commit} {dolt-repo-[0-9]+/main> } { send "\\status;\r"; }
 
-expect_with_defaults {dolt-repo-[0-9]+/main> }   { send "/reset HEAD~1;\r"; }
+expect_with_defaults {dolt-repo-[0-9]+/main> }   { send "\\reset HEAD~1;\r"; }
 
-expect_with_defaults {dolt-repo-[0-9]+/main\*> } { send "/diff;\r"; }
+expect_with_defaults {dolt-repo-[0-9]+/main\*> } { send "\\diff;\r"; }
 
 expect_with_defaults_2 {diff --dolt a/tbl b/tbl} {dolt-repo-[0-9]+/main\*> } {send "quit\r";}
 


### PR DESCRIPTION
Decided to move from `/` to `\` for sql shell commands to may the mysql client.

Work remaining:
1) Forbid delimiter `/` with message: `ERROR: DELIMITER cannot contain a backslash character`. This requires a change in the ishell packages (which we forked).
2) Dolt test to ensure (1).