### PR TITLE
Revert "[prolly] filteredIter optimization for exact prefix ranges (#…

### DIFF
--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -1129,7 +1129,7 @@ func (di *doltIndex) prollySpatialRanges(ranges []sql.Range) ([]prolly.Range, er
 			prevMinCell = minCell
 			prevMaxCell = maxCell
 			field := prolly.RangeField{
-				TargetIsUnique: false,
+				Exact: false,
 				Lo: prolly.Bound{
 					Binding:   true,
 					Inclusive: true,
@@ -1230,17 +1230,17 @@ func (di *doltIndex) prollyRangesFromSqlRanges(ctx context.Context, ns tree.Node
 		order := di.keyBld.Desc.Comparator()
 		for i, field := range fields {
 			// lookups on non-unique indexes can't be point lookups
-			typ := di.keyBld.Desc.Types[i]
-			cmp := order.CompareValues(i, field.Hi.Value, field.Lo.Value, typ)
-			fields[i].BoundsAreEqual = cmp == 0
-
 			if !di.unique {
-				fields[i].TargetIsUnique = false
+				fields[i].Exact = false
+				continue
 			}
 			if !field.Hi.Binding || !field.Lo.Binding {
-				// infinity bound
-				fields[i].BoundsAreEqual = false
+				fields[i].Exact = false
+				continue
 			}
+			typ := di.keyBld.Desc.Types[i]
+			cmp := order.CompareValues(i, field.Hi.Value, field.Lo.Value, typ)
+			fields[i].Exact = cmp == 0
 		}
 		pranges[k] = prolly.Range{
 			Fields: fields,

--- a/go/store/prolly/map_test.go
+++ b/go/store/prolly/map_test.go
@@ -377,7 +377,7 @@ func testGet(t *testing.T, om testMap, tuples [][2]val.Tuple) {
 	// test point lookup
 	for _, kv := range tuples {
 		rng := pointRangeFromTuple(kv[0], desc)
-		require.True(t, rng.IsStrictKeyLookup(desc))
+		require.True(t, rng.IsPointLookup(desc))
 
 		iter, err := om.IterRange(ctx, rng)
 		require.NoError(t, err)

--- a/go/store/prolly/tuple_map.go
+++ b/go/store/prolly/tuple_map.go
@@ -307,13 +307,8 @@ func (m Map) HasPrefix(ctx context.Context, preKey val.Tuple, preDesc val.TupleD
 }
 
 // IterRange returns a mutableMapIter that iterates over a Range.
-func (m Map) IterRange(ctx context.Context, rng Range) (iter MapIter, err error) {
-	stop, ok := rng.KeyRangeLookup(m.Pool())
-	if ok {
-		iter, err = m.IterKeyRange(ctx, rng.Tup, stop)
-	} else {
-		iter, err = treeIterFromRange(ctx, m.tuples.Root, m.tuples.NodeStore, rng)
-	}
+func (m Map) IterRange(ctx context.Context, rng Range) (MapIter, error) {
+	iter, err := treeIterFromRange(ctx, m.tuples.Root, m.tuples.NodeStore, rng)
 	if err != nil {
 		return nil, err
 	}

--- a/go/store/prolly/tuple_range.go
+++ b/go/store/prolly/tuple_range.go
@@ -17,8 +17,6 @@ package prolly
 import (
 	"sort"
 
-	"github.com/dolthub/dolt/go/store/pool"
-
 	"github.com/dolthub/dolt/go/store/prolly/tree"
 	"github.com/dolthub/dolt/go/store/val"
 )
@@ -61,14 +59,11 @@ type Range struct {
 // RangeField bounds one dimension of a Range.
 type RangeField struct {
 	Lo, Hi Bound
-	// BoundsAreEqual is |true| when |Lo.Value| == |Hi.Value|
-	BoundsAreEqual bool
-	// TargetIsUnique is |true| when the associated index is unique
-	TargetIsUnique bool
+	Exact  bool // Lo.Value == Hi.Value
 }
 
 type Bound struct {
-	Binding   bool // positive or negative infinity
+	Binding   bool
 	Inclusive bool
 	Value     []byte
 }
@@ -92,7 +87,7 @@ func (r Range) aboveStart(t val.Tuple) bool {
 			return false
 		}
 
-		if r.Fields[i].BoundsAreEqual && cmp == 0 {
+		if r.Fields[i].Exact && cmp == 0 {
 			// for exact bounds (operators '=' and 'IS')
 			// we can use subsequent columns to narrow
 			// physical index scans.
@@ -124,7 +119,7 @@ func (r Range) belowStop(t val.Tuple) bool {
 			return false
 		}
 
-		if r.Fields[i].BoundsAreEqual && cmp == 0 {
+		if r.Fields[i].Exact && cmp == 0 {
 			// for exact bounds (operators '=' and 'IS')
 			// we can use subsequent columns to narrow
 			// physical index scans.
@@ -145,7 +140,7 @@ func (r Range) Matches(t val.Tuple) bool {
 		field := r.Desc.GetField(i, t)
 		typ := r.Desc.Types[i]
 
-		if r.Fields[i].BoundsAreEqual {
+		if r.Fields[i].Exact {
 			v := r.Fields[i].Lo.Value
 			if order.CompareValues(i, field, v, typ) == 0 {
 				continue
@@ -172,147 +167,16 @@ func (r Range) Matches(t val.Tuple) bool {
 	return true
 }
 
-func (r Range) IsStrictKeyLookup(desc val.TupleDesc) bool {
-	// a strict key is a set of non-nil equality restrictions covering every field of a unique index
+func (r Range) IsPointLookup(desc val.TupleDesc) bool {
 	if len(r.Fields) < len(desc.Types) {
 		return false
 	}
 	for i := range r.Fields {
-		if !r.Fields[i].BoundsAreEqual {
+		if !r.Fields[i].Exact {
 			return false
 		}
 	}
 	return true
-}
-
-// KeyRangeLookup will return a stop key and true if the range can be scanned
-// from a start to stop tuple. Otherwise, return a nil key and false. A range
-// can be key range scanned if the prefix is exact, and the final field is
-// numeric or string. The stop key adds +1 to a numeric final field, and appends
-// '0' to a string final field.
-// TODO: support non-exact final field, and use range upper bound?
-func (r Range) KeyRangeLookup(pool pool.BuffPool) (val.Tuple, bool) {
-	if r.Tup == nil {
-		return nil, false
-	}
-	n := len(r.Fields) - 1
-	for i := range r.Fields {
-		if r.Fields[i].Lo.Value == nil {
-			if r.Fields[i].Hi.Value != nil {
-				return nil, false
-			}
-			n = i - 1
-			break
-		}
-		if !r.Fields[i].BoundsAreEqual {
-			return nil, false
-		}
-	}
-
-	if n < 0 {
-		// ex: range scan
-		return nil, false
-	}
-
-	for _, typ := range r.Desc.Types[n+1:] {
-		if !typ.Nullable {
-			// this is checked separately because fulltext descriptors
-			// do not match field lengths sometimes
-			// todo: why?
-			return nil, false
-		}
-	}
-
-	for i := n + 1; i < len(r.Fields); i++ {
-		if r.Fields[i].Lo.Value != nil ||
-			r.Fields[i].Hi.Value != nil {
-			// these shouldn't be possible with regular index semantics,
-			// but we manually inline indexes sometimes on the Dolt side,
-			// and it's possible we'd change analyzer indexing semantics
-			// in the future
-			return nil, false
-		}
-
-	}
-
-	tb := val.NewTupleBuilder(r.Desc)
-	for i := 0; i < n; i++ {
-		if i != n {
-			// direct copy all but the last field
-			tb.PutRaw(i, r.Tup.GetField(i))
-		}
-	}
-
-	// last field will be incremented by one to get the exclusive key
-	// range [key, key+1)
-	switch r.Desc.Types[n].Enc {
-	case val.StringEnc:
-		v := r.Fields[n].Lo.Value
-		tb.PutString(n, string(v)+"0")
-	case val.Int8Enc:
-		v, ok := r.Desc.GetInt8(n, r.Tup)
-		if !ok {
-			return nil, false
-		}
-		tb.PutInt8(n, v+1)
-	case val.Uint8Enc:
-		v, ok := r.Desc.GetUint8(n, r.Tup)
-		if !ok {
-			return nil, false
-		}
-		tb.PutUint8(n, v+1)
-	case val.Int16Enc:
-		v, ok := r.Desc.GetInt16(n, r.Tup)
-		if !ok {
-			return nil, false
-		}
-		tb.PutInt16(n, v+1)
-	case val.Uint16Enc:
-		v, ok := r.Desc.GetUint16(n, r.Tup)
-		if !ok {
-			return nil, false
-		}
-		tb.PutUint16(n, v+1)
-	case val.Int32Enc:
-		v, ok := r.Desc.GetInt32(n, r.Tup)
-		if !ok {
-			return nil, false
-		}
-		tb.PutInt32(n, v+1)
-	case val.Uint32Enc:
-		v, ok := r.Desc.GetUint32(n, r.Tup)
-		if !ok {
-			return nil, false
-		}
-		tb.PutUint32(n, v+1)
-	case val.Int64Enc:
-		v, ok := r.Desc.GetInt64(n, r.Tup)
-		if !ok {
-			return nil, false
-		}
-		tb.PutInt64(n, v+1)
-	case val.Uint64Enc:
-		v, ok := r.Desc.GetUint64(n, r.Tup)
-		if !ok {
-			return nil, false
-		}
-		tb.PutUint64(n, v+1)
-	case val.Float32Enc:
-		v, ok := r.Desc.GetFloat32(n, r.Tup)
-		if !ok {
-			return nil, false
-		}
-		tb.PutFloat32(n, v+1)
-	case val.Float64Enc:
-		v, ok := r.Desc.GetFloat64(n, r.Tup)
-		if !ok {
-			return nil, false
-		}
-		tb.PutFloat64(n, v+1)
-	default:
-		return nil, false
-	}
-	return tb.Build(pool), true
 }
 
 func rangeStartSearchFn(rng Range) tree.SearchFn {
@@ -346,14 +210,14 @@ func closedRange(start, stop val.Tuple, desc val.TupleDesc) (rng Range) {
 		Desc:   desc,
 	}
 	order := desc.Comparator()
+
 	for i := range rng.Fields {
 		lo := desc.GetField(i, start)
 		hi := desc.GetField(i, stop)
-		isEq := order.CompareValues(i, lo, hi, desc.Types[i]) == 0
 		rng.Fields[i] = RangeField{
-			Lo:             Bound{Binding: true, Inclusive: true, Value: lo},
-			Hi:             Bound{Binding: true, Inclusive: true, Value: hi},
-			BoundsAreEqual: isEq,
+			Lo:    Bound{Binding: true, Inclusive: true, Value: lo},
+			Hi:    Bound{Binding: true, Inclusive: true, Value: hi},
+			Exact: order.CompareValues(i, lo, hi, desc.Types[i]) == 0,
 		}
 	}
 	return
@@ -364,7 +228,7 @@ func openStartRange(start, stop val.Tuple, desc val.TupleDesc) (rng Range) {
 	rng = closedRange(start, stop, desc)
 	last := len(rng.Fields) - 1
 	rng.Fields[last].Lo.Inclusive = false
-	rng.Fields[last].BoundsAreEqual = false
+	rng.Fields[last].Exact = false
 	return rng
 }
 
@@ -373,7 +237,7 @@ func openStopRange(start, stop val.Tuple, desc val.TupleDesc) (rng Range) {
 	rng = closedRange(start, stop, desc)
 	last := len(rng.Fields) - 1
 	rng.Fields[last].Hi.Inclusive = false
-	rng.Fields[last].BoundsAreEqual = false
+	rng.Fields[last].Exact = false
 	return
 }
 
@@ -383,7 +247,7 @@ func openRange(start, stop val.Tuple, desc val.TupleDesc) (rng Range) {
 	last := len(rng.Fields) - 1
 	rng.Fields[last].Lo.Inclusive = false
 	rng.Fields[last].Hi.Inclusive = false
-	rng.Fields[last].BoundsAreEqual = false
+	rng.Fields[last].Exact = false
 	return
 }
 

--- a/go/store/prolly/tuple_range_test.go
+++ b/go/store/prolly/tuple_range_test.go
@@ -124,9 +124,9 @@ func TestRangeSearch(t *testing.T) {
 			testRange: Range{
 				Fields: []RangeField{
 					{
-						Lo:             Bound{Binding: true, Inclusive: true, Value: nil},
-						Hi:             Bound{Binding: true, Inclusive: true, Value: nil},
-						BoundsAreEqual: true,
+						Lo:    Bound{Binding: true, Inclusive: true, Value: nil},
+						Hi:    Bound{Binding: true, Inclusive: true, Value: nil},
+						Exact: true,
 					},
 				},
 				Desc: twoCol,
@@ -144,9 +144,9 @@ func TestRangeSearch(t *testing.T) {
 						Lo: Bound{Binding: true, Inclusive: false, Value: nil},
 					},
 					{
-						Lo:             Bound{Binding: true, Inclusive: true, Value: intVal(2)},
-						Hi:             Bound{Binding: true, Inclusive: true, Value: intVal(2)},
-						BoundsAreEqual: true,
+						Lo:    Bound{Binding: true, Inclusive: true, Value: intVal(2)},
+						Hi:    Bound{Binding: true, Inclusive: true, Value: intVal(2)},
+						Exact: true,
 					},
 				},
 				Desc: twoCol,
@@ -156,14 +156,12 @@ func TestRangeSearch(t *testing.T) {
 		},
 	}
 
-	ns := tree.NewTestNodeStore()
-
 	values := make([]val.Tuple, len(rangeTuples))
 	for i := range values {
 		values[i] = make(val.Tuple, 2)
 	}
 	testNode := tree.NewTupleLeafNode(rangeTuples, values)
-	tm := NewMap(testNode, ns, twoCol, val.TupleDesc{})
+	tm := NewMap(testNode, nil, twoCol, val.TupleDesc{})
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -180,7 +178,7 @@ func TestRangeSearch(t *testing.T) {
 			assert.Equal(t, hi, idx, "range should stop before index %d", hi)
 
 			// validate physical range (unfiltered iter)
-			iter, err := treeIterFromRange(ctx, testNode, ns, test.testRange)
+			iter, err := treeIterFromRange(ctx, testNode, nil, test.testRange)
 			require.NoError(t, err)
 			expected := rangeTuples[lo:hi]
 


### PR DESCRIPTION
…7966)"

This reverts commit 6ae4251c9d85916c83a95291282d5ebd5ff4089a.