### PR TITLE
[no-release-notes] need stats to run on dolt servers

### DIFF
--- a/go/performance/utils/benchmark_runner/sysbench.go
+++ b/go/performance/utils/benchmark_runner/sysbench.go
@@ -164,14 +164,14 @@ func (t *sysbenchTesterImpl) Test(ctx context.Context) (*Result, error) {
 }
 
 func (t *sysbenchTesterImpl) collectStats(ctx context.Context) error {
-	if !strings.EqualFold(t.serverConfig.GetServerExec(), "dolt") {
-		return nil
+	if strings.Contains(t.serverConfig.GetServerExec(), "dolt") && !strings.Contains(t.serverConfig.GetServerExec(), "doltgres") {
+		db, err := sqlx.Open("mysql", fmt.Sprintf("root:@tcp(%s:%d)/test", t.serverConfig.GetHost(), t.serverConfig.GetPort()))
+		if err != nil {
+			return err
+		}
+		return collectStats(ctx, db)
 	}
-	db, err := sqlx.Open("mysql", fmt.Sprintf("root:@tcp(%s:%d)/test", t.serverConfig.GetHost(), t.serverConfig.GetPort()))
-	if err != nil {
-		return err
-	}
-	return collectStats(ctx, db)
+	return nil
 }
 
 func collectStats(ctx context.Context, db *sqlx.DB) error {

--- a/go/performance/utils/benchmark_runner/tpcc.go
+++ b/go/performance/utils/benchmark_runner/tpcc.go
@@ -55,14 +55,14 @@ func (t *tpccTesterImpl) outputToResult(output []byte) (*Result, error) {
 }
 
 func (t *tpccTesterImpl) collectStats(ctx context.Context) error {
-	if !strings.EqualFold(t.serverConfig.GetServerExec(), "dolt") {
-		return nil
+	if strings.Contains(t.serverConfig.GetServerExec(), "dolt") && !strings.Contains(t.serverConfig.GetServerExec(), "doltgres") {
+		db, err := sqlx.Open("mysql", fmt.Sprintf("root:@tcp(%s:%d)/sbt", t.serverConfig.GetHost(), t.serverConfig.GetPort()))
+		if err != nil {
+			return err
+		}
+		return collectStats(ctx, db)
 	}
-	db, err := sqlx.Open("mysql", fmt.Sprintf("root:@tcp(%s:%d)/sbt", t.serverConfig.GetHost(), t.serverConfig.GetPort()))
-	if err != nil {
-		return err
-	}
-	return collectStats(ctx, db)
+	return nil
 }
 
 func (t *tpccTesterImpl) prepare(ctx context.Context) error {


### PR DESCRIPTION
It looks like sysbench and tpcc are not using stats since the recent change for doltgres. If the server name is a full specified path, I think this version will permit dolt but disable doltgres/mysql stats.