### PR TITLE
Add initial, no-op implementation for `ListBinaryLogs` API changes

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/cespare/xxhash v1.1.0
 	github.com/creasty/defaults v1.6.0
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-mysql-server v0.18.2-0.20240621214638-7bec4655f469
+	github.com/dolthub/go-mysql-server v0.18.2-0.20240624181432-99e5e216bffa
 	github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63
 	github.com/dolthub/swiss v0.1.0
 	github.com/goccy/go-json v0.10.2

--- a/go/go.sum
+++ b/go/go.sum
@@ -185,6 +185,8 @@ github.com/dolthub/go-icu-regex v0.0.0-20230524105445-af7e7991c97e h1:kPsT4a47cw
 github.com/dolthub/go-icu-regex v0.0.0-20230524105445-af7e7991c97e/go.mod h1:KPUcpx070QOfJK1gNe0zx4pA5sicIK1GMikIGLKC168=
 github.com/dolthub/go-mysql-server v0.18.2-0.20240621214638-7bec4655f469 h1:V2gkE6tUU49uR5U8+RqNjQNvNw333xKcDWbwIixnBNQ=
 github.com/dolthub/go-mysql-server v0.18.2-0.20240621214638-7bec4655f469/go.mod h1:XdiHsd2TX3OOhjwY6tPcw1ztT2BdBiP6Wp0m/7OYHn4=
+github.com/dolthub/go-mysql-server v0.18.2-0.20240624181432-99e5e216bffa h1:Nb1r262RYHNJUKw1z2nE/jshqv968MIoJGFquhds0tQ=
+github.com/dolthub/go-mysql-server v0.18.2-0.20240624181432-99e5e216bffa/go.mod h1:XdiHsd2TX3OOhjwY6tPcw1ztT2BdBiP6Wp0m/7OYHn4=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20221214210346-d7db0b066488 h1:0HHu0GWJH0N6a6keStrHhUAK5/o9LVfkh44pvsV4514=

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_primary_controller.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_primary_controller.go
@@ -82,8 +82,9 @@ func (d *doltBinlogPrimaryController) ListReplicas(ctx *sql.Context) error {
 }
 
 // ListBinaryLogs implements the BinlogPrimaryController interface.
-func (d *doltBinlogPrimaryController) ListBinaryLogs(ctx *sql.Context) error {
-	return fmt.Errorf("ListBinaryLogs not implemented in Dolt yet")
+func (d *doltBinlogPrimaryController) ListBinaryLogs(_ *sql.Context) ([]binlogreplication.BinaryLogFileMetadata, error) {
+	// TODO: No log file support yet, so just return an empty list
+	return nil, nil
 }
 
 // GetBinaryLogStatus implements the BinlogPrimaryController interface.


### PR DESCRIPTION
Adds a simple no-op implementation for `DoltBinlogPrimaryController.ListBinaryLogs` to keep it in sync with API changes in GMS.

Depends on https://github.com/dolthub/go-mysql-server/pull/2567