### PR TITLE
/go/libraries/doltcore/remotestorage/chunk_fetcher.go: fix nil pointer

### DIFF
--- a/go/libraries/doltcore/remotestorage/chunk_fetcher.go
+++ b/go/libraries/doltcore/remotestorage/chunk_fetcher.go
@@ -263,6 +263,9 @@ func fetcherRPCDownloadLocsThread(ctx context.Context, reqCh chan *remotesapi.Ge
 			if err != nil {
 				return NewRpcError(err, "StreamDownloadLocations", host, stream.AssociatedReq())
 			}
+			if resp == nil {
+				return NewRpcError(errors.New("no stream response"), "StreamDownloadLocations", host, stream.AssociatedReq())
+			}
 			if resp.RepoToken != "" {
 				storeRepoToken(resp.RepoToken)
 			}


### PR DESCRIPTION
We observe dolthubapi can crash with the following nil pointer error:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x29e14d1]

goroutine 399548427 [running]:
github.com/dolthub/dolt/go/libraries/doltcore/remotestorage.fetcherRPCDownloadLocsThread.func3()
    external/com_github_dolthub_dolt_go/libraries/doltcore/remotestorage/chunk_fetcher.go:266 +0xf1
golang.org/x/sync/errgroup.(*Group).Go.func1()
    external/org_golang_x_sync/errgroup/errgroup.go:78 +0x56
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 399548420
    external/org_golang_x_sync/errgroup/errgroup.go:75 +0x96
```

This pr aims to prevent this.