### PR TITLE
Archive index rework to make loading faster

### DIFF
--- a/go/store/nbs/archive_build.go
+++ b/go/store/nbs/archive_build.go
@@ -84,7 +84,6 @@ func BuildArchive(ctx context.Context, cs chunks.ChunkStore, dagGroups *ChunkRel
 }
 
 func convertTableFileToArchive(ctx context.Context, cs chunkSource, idx tableIndex, dagGroups *ChunkRelations, archivePath string) (string, hash.Hash, error) {
-
 	allChunks, defaultSamples, err := gatherAllChunks(ctx, cs, idx)
 	if err != nil {
 		return "", hash.Hash{}, err
@@ -153,7 +152,7 @@ func convertTableFileToArchive(ctx context.Context, cs chunkSource, idx tableInd
 }
 
 // indexAndFinalizeArchive writes the index, metadata, and footer to the archive file. It also flushes the archive writer
-// to the directory provided. The name is calculate from the footer, and can be obtained by calling getName on the archive.
+// to the directory provided. The name is calculated from the footer, and can be obtained by calling getName on the archive.
 func indexAndFinalizeArchive(arcW *archiveWriter, archivePath string) error {
 	err := arcW.finalizeByteSpans()
 	if err != nil {

--- a/go/store/nbs/archive_reader.go
+++ b/go/store/nbs/archive_reader.go
@@ -21,9 +21,10 @@ import (
 	"io"
 	"math/bits"
 
-	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/gozstd"
 	lru "github.com/hashicorp/golang-lru/v2"
+
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 // archiveReader is a reader for the archive format. We use primitive type slices where possible. These are read directly

--- a/go/store/nbs/archive_reader.go
+++ b/go/store/nbs/archive_reader.go
@@ -311,7 +311,7 @@ func (ai archiveReader) getByteSpanByID(id uint32) byteSpan {
 	if id == 0 {
 		return byteSpan{}
 	}
-	// This works because bytePffSpan[0] == 0. See initialization.
+	// This works because byteOffSpan[0] == 0. See initialization.
 	offset := ai.byteOffSpans[id-1]
 	length := ai.byteOffSpans[id] - offset
 	return byteSpan{offset: offset, length: length}

--- a/go/store/nbs/archive_reader.go
+++ b/go/store/nbs/archive_reader.go
@@ -311,6 +311,7 @@ func (ai archiveReader) getByteSpanByID(id uint32) byteSpan {
 	if id == 0 {
 		return byteSpan{}
 	}
+	// This works because bytePffSpan[0] == 0. See initialization.
 	offset := ai.byteOffSpans[id-1]
 	length := ai.byteOffSpans[id] - offset
 	return byteSpan{offset: offset, length: length}

--- a/go/store/nbs/archive_test.go
+++ b/go/store/nbs/archive_test.go
@@ -48,8 +48,8 @@ func TestArchiveSingleChunk(t *testing.T) {
 	err = aw.writeIndex()
 	assert.NoError(t, err)
 	// The 'uncompressed' size of the index is 23 bytes. Compressing such small data is not worth it, but we do verify
-	// that the index is 35 bytes in this situation.
-	assert.Equal(t, uint32(35), aw.indexLen)
+	// that the index is 35 bytes in this situation. NM4???
+	assert.Equal(t, uint32(36), aw.indexLen)
 
 	err = aw.writeMetadata([]byte(""))
 	assert.NoError(t, err)
@@ -57,7 +57,7 @@ func TestArchiveSingleChunk(t *testing.T) {
 	err = aw.writeFooter()
 	assert.NoError(t, err)
 
-	assert.Equal(t, 10+35+archiveFooterSize, aw.bytesWritten) // 10 data bytes, 35 index bytes + footer
+	assert.Equal(t, 10+36+archiveFooterSize, aw.bytesWritten) // 10 data bytes, 35 index bytes + footer
 
 	theBytes := writer.buff[:writer.pos]
 	fileSize := uint64(len(theBytes))

--- a/go/store/nbs/archive_test.go
+++ b/go/store/nbs/archive_test.go
@@ -47,8 +47,8 @@ func TestArchiveSingleChunk(t *testing.T) {
 
 	err = aw.writeIndex()
 	assert.NoError(t, err)
-	// The 'uncompressed' size of the index is 23 bytes. Compressing such small data is not worth it, but we do verify
-	// that the index is 35 bytes in this situation. NM4???
+	// Index size is not deterministic from the number of chunks, but when no dictionaries are in play, 36 bytes is correct
+	// because: 8 (uint64,prefix) + 8 (uint64,offset) + 4 (uint32,dict) + 4 (uint32,data) + 12 (hash.Suffix) = 36
 	assert.Equal(t, uint32(36), aw.indexLen)
 
 	err = aw.writeMetadata([]byte(""))
@@ -57,7 +57,7 @@ func TestArchiveSingleChunk(t *testing.T) {
 	err = aw.writeFooter()
 	assert.NoError(t, err)
 
-	assert.Equal(t, 10+36+archiveFooterSize, aw.bytesWritten) // 10 data bytes, 35 index bytes + footer
+	assert.Equal(t, 10+36+archiveFooterSize, aw.bytesWritten) // 10 data bytes, 36 index bytes + footer
 
 	theBytes := writer.buff[:writer.pos]
 	fileSize := uint64(len(theBytes))


### PR DESCRIPTION
The initial impl of archive indexes over optimized for space. This resulted in being 10x slower to load the index of archives than noms table files. To address this:
 - Dropped the end to end compression of the index
 - Dropped the use of var ints for offset deltas and chunk refs
 - Altered the use of byte span offsets, and instead used a end-offset approach which requires no delta processing on load.
 - Used only slices of primitive types in the index memory. Constant time read path with a little more complexity, but allows us to read directly off disk into memory.

Testing indicates that on a 41 Gb archive file, this returned load performance to match classic table files, and the size of the index increased by about 350Mb (total ~ 1Gb)