### PR TITLE
Fixed keyless secondary indexing for Doltgres

### DIFF
--- a/go/store/prolly/tuple_map.go
+++ b/go/store/prolly/tuple_map.go
@@ -435,9 +435,15 @@ func DebugFormat(ctx context.Context, m Map) (string, error) {
 func ConvertToSecondaryKeylessIndex(m Map) Map {
 	keyDesc, valDesc := m.Descriptors()
 	newTypes := make([]val.Type, len(keyDesc.Types)+1)
+	handlers := make([]val.TupleTypeHandler, len(keyDesc.Types)+1)
 	copy(newTypes, keyDesc.Types)
+	copy(handlers, keyDesc.Handlers)
 	newTypes[len(newTypes)-1] = val.Type{Enc: val.Hash128Enc}
-	newKeyDesc := val.NewTupleDescriptorWithArgs(val.TupleDescriptorArgs{Comparator: keyDesc.Comparator()}, newTypes...)
+	handlers[len(handlers)-1] = nil
+	newKeyDesc := val.NewTupleDescriptorWithArgs(val.TupleDescriptorArgs{
+		Comparator: keyDesc.Comparator(),
+		Handlers:   handlers,
+	}, newTypes...)
 	newTuples := m.tuples
 	newTuples.Order = newKeyDesc
 	return Map{

--- a/go/store/val/extended_comparator.go
+++ b/go/store/val/extended_comparator.go
@@ -71,7 +71,13 @@ func (c ExtendedTupleComparator) Suffix(n int) TupleComparator {
 
 // Validated implements the TupleComparator interface.
 func (c ExtendedTupleComparator) Validated(types []Type) TupleComparator {
-	innerCmp := c.innerCmp.Validated(types)
+	// If our inner comparator is an ExtendedTupleComparator, then we should use its inner comparator to reduce redundancy.
+	var innerCmp TupleComparator
+	if extendedInner, ok := c.innerCmp.(ExtendedTupleComparator); ok {
+		innerCmp = extendedInner.innerCmp.Validated(types)
+	} else {
+		innerCmp = c.innerCmp.Validated(types)
+	}
 	if len(c.handlers) == 0 {
 		c.handlers = make([]TupleTypeHandler, len(types))
 	} else if len(c.handlers) != len(types) {


### PR DESCRIPTION
* Companion PR: https://github.com/dolthub/doltgresql/pull/452

This PR fixes two issues with creating secondary indexes for Doltgres types. The first deals with handlers, as we were not adding a `nil` handler for the additional hash type, which would cause a panic as the counts were not equal (all non-Extended types should have a matching nil handler).

The second issue was due to the reuse of an `ExtendedTupleComparator`. When creating a new `ExtendedTupleComparator`, we pass in the previous `TupleTypeHandler` to handle all non-Extended types. If the previous `TupleTypeHandler` was `ExtendedTupleComparator` and the new one was also `ExtendedTupleComparator`, then we could end up with a misinterpretation of data that could lead to incorrect results, as the handler assumed a different type than the actual type. This has been changed so that `ExtendedTupleComparator` will always use the inner comparator of a previous `ExtendedTupleComparator`. For now this will always be the default comparator, but if we ever add another one, then this should properly handle that change.