### PR TITLE
/docker/{docker-entrypoint.sh,serverDockerfile}: change image to pass all args to dolt sql-server command

### DIFF
--- a/docker/serverDockerfile
+++ b/docker/serverDockerfile
@@ -21,8 +21,7 @@ VOLUME /var/lib/dolt
 
 COPY docker/docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
-ENTRYPOINT ["tini", "--", "docker-entrypoint.sh"]
 
 EXPOSE 3306 33060
 WORKDIR /var/lib/dolt
-CMD [ "dolt", "sql-server", "--host=0.0.0.0" , "--port=3306" ]
+ENTRYPOINT ["tini", "--", "docker-entrypoint.sh"]


### PR DESCRIPTION
This PR fixes https://github.com/dolthub/dolt/issues/8079. Now when running `dolthub/dolt-sql-server` if the args `dolt sql-server` are passed to the image, it will error. This will also prevent accidentally starting two Dolt servers in the container.