### PR TITLE
enable key range iter

### DIFF
--- a/go/store/prolly/tuple_map.go
+++ b/go/store/prolly/tuple_map.go
@@ -307,10 +307,12 @@ func (m Map) HasPrefix(ctx context.Context, preKey val.Tuple, preDesc val.TupleD
 }
 
 // IterRange returns a mutableMapIter that iterates over a Range.
-func (m Map) IterRange(ctx context.Context, rng Range) (MapIter, error) {
-	iter, err := treeIterFromRange(ctx, m.tuples.Root, m.tuples.NodeStore, rng)
-	if err != nil {
-		return nil, err
+func (m Map) IterRange(ctx context.Context, rng Range) (iter MapIter, err error) {
+	stop, ok := rng.KeyRangeLookup(m.Pool())
+	if ok {
+		iter, err = m.IterKeyRange(ctx, rng.Tup, stop)
+	} else {
+		iter, err = treeIterFromRange(ctx, m.tuples.Root, m.tuples.NodeStore, rng)
 	}
 	return filteredIter{iter: iter, rng: rng}, nil
 }


### PR DESCRIPTION
There was an issue merging https://github.com/dolthub/dolt/pull/8025 ontop of a revert. Enable the key iteration optimization.