### PR TITLE
Bug fix: Use correct log position in Dolt to MySQL replication heartbeats

### DIFF
--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_primary_streamer.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_primary_streamer.go
@@ -82,6 +82,7 @@ func (streamer *binlogStreamer) startStream(ctx *sql.Context, conn *mysql.Conn, 
 				if err := conn.WriteBinlogEvent(event, false); err != nil {
 					return err
 				}
+				binlogEventMeta.NextLogPosition += event.Length()
 			}
 			if err := conn.FlushBuffer(); err != nil {
 				return fmt.Errorf("unable to flush binlog connection: %s", err.Error())


### PR DESCRIPTION
Ensure heartbeat events sent from a Dolt primary to a MySQL replica have the latest nextLogPosition populated, otherwise the MySQL replica will close the binlog event stream. 