### PR TITLE
[no-release-info] Add additional tests for manipulating large JSON documents and fix corner case bugs in JSON_LOOKUP and JSON_INSERT

### DIFF
--- a/go/store/prolly/tree/json_indexed_document_test.go
+++ b/go/store/prolly/tree/json_indexed_document_test.go
@@ -16,6 +16,10 @@ package tree
 
 import (
 	"context"
+	"fmt"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/expression/function/json"
+	"strings"
 	"testing"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -24,7 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// NewIndexedJsonDocumentFromBytes creates an IndexedJsonDocument from a byte sequence, which has already been validated and normalized
+// newIndexedJsonDocumentFromValue creates an IndexedJsonDocument from a provided value.
 func newIndexedJsonDocumentFromValue(t *testing.T, ctx context.Context, ns NodeStore, v interface{}) IndexedJsonDocument {
 	doc, _, err := types.JSON.Convert(v)
 	require.NoError(t, err)
@@ -33,8 +37,86 @@ func newIndexedJsonDocumentFromValue(t *testing.T, ctx context.Context, ns NodeS
 	return NewIndexedJsonDocument(ctx, root, ns)
 }
 
+// createLargeDocumentForTesting creates a JSON document large enough to be split across multiple chunks.
+// This is useful for testing mutation operations in large documents.
+// Every different possible jsonPathType appears on a chunk boundary, for better test coverage:
+// chunk 0 key: $[6].children[2].children[0].number(endOfValue)
+// chunk 2 key: $[7].children[5].children[4].children[2].children(arrayInitialElement)
+// chunk 5 key: $[8].children[6].children[4].children[3].children[0](startOfValue)
+// chunk 8 key: $[8].children[7].children[6].children[5].children[3].children[2].children[1](objectInitialElement)
+func createLargeDocumentForTesting(t *testing.T, ctx *sql.Context, ns NodeStore) IndexedJsonDocument {
+	leafDoc := make(map[string]interface{})
+	leafDoc["number"] = float64(1.0)
+	leafDoc["string"] = "dolt"
+	docExpression, err := json.NewJSONArray(expression.NewLiteral(newIndexedJsonDocumentFromValue(t, ctx, ns, leafDoc), types.JSON))
+	require.NoError(t, err)
+
+	for level := 0; level < 8; level++ {
+		childObjectExpression, err := json.NewJSONObject(expression.NewLiteral("children", types.Text), docExpression)
+		require.NoError(t, err)
+		docExpression, err = json.NewJSONArrayAppend(docExpression, expression.NewLiteral("$", types.Text), childObjectExpression)
+		require.NoError(t, err)
+	}
+	doc, err := docExpression.Eval(ctx, nil)
+	require.NoError(t, err)
+	return newIndexedJsonDocumentFromValue(t, ctx, ns, doc)
+}
+
+var jsonPathTypeNames = []string{
+	"startOfValue",
+	"objectInitialElement",
+	"arrayInitialElement",
+	"endOfValue",
+}
+
+type chunkBoundary struct {
+	chunkId  int
+	path     string
+	pathType jsonPathType
+}
+
+var largeDocumentChunkBoundaries = []chunkBoundary{
+	{
+		chunkId:  0,
+		path:     "$[6].children[2].children[0].number",
+		pathType: endOfValue,
+	},
+	{
+		chunkId:  2,
+		path:     "$[7].children[5].children[4].children[2].children",
+		pathType: arrayInitialElement,
+	},
+	{
+		chunkId:  5,
+		path:     "$[8].children[6].children[4].children[3].children[0]",
+		pathType: startOfValue,
+	},
+	{
+		chunkId:  8,
+		path:     "$[8].children[7].children[6].children[5].children[3].children[2].children[1]",
+		pathType: objectInitialElement,
+	},
+}
+
+// TestIndexedJsonDocument_ValidateChunks asserts that the values defined largeDocumentChunkBoundaries are accurate,
+// so they can be used in other tests.
+func TestIndexedJsonDocument_ValidateChunks(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	ns := NewTestNodeStore()
+	largeDoc := createLargeDocumentForTesting(t, ctx, ns)
+	for _, boundary := range largeDocumentChunkBoundaries {
+		t.Run(fmt.Sprintf("validate %v at chunk %v", jsonPathTypeNames[boundary.pathType], boundary.chunkId), func(t *testing.T) {
+			expectedKey, err := jsonPathElementsFromMySQLJsonPath([]byte(boundary.path))
+			require.NoError(t, err)
+			expectedKey.setScannerState(boundary.pathType)
+			actualKey := []byte(largeDoc.m.Root.GetKey(boundary.chunkId))
+			require.Equal(t, expectedKey.key, actualKey)
+		})
+	}
+}
+
 func TestIndexedJsonDocument_Insert(t *testing.T) {
-	ctx := context.Background()
+	ctx := sql.NewEmptyContext()
 	ns := NewTestNodeStore()
 	convertToIndexedJsonDocument := func(t *testing.T, s interface{}) interface{} {
 		return newIndexedJsonDocumentFromValue(t, ctx, ns, s)
@@ -42,6 +124,46 @@ func TestIndexedJsonDocument_Insert(t *testing.T) {
 
 	testCases := jsontests.JsonInsertTestCases(t, convertToIndexedJsonDocument)
 	jsontests.RunJsonTests(t, testCases)
+
+	t.Run("large document inserts", func(t *testing.T) {
+
+		largeDoc := createLargeDocumentForTesting(t, ctx, ns)
+
+		// Generate a value large enough that, if it's inserted, will guarantee a change in chunk boundaries.
+		valueToInsert, err := largeDoc.Lookup(ctx, "$[6]")
+		require.NoError(t, err)
+
+		for _, chunkBoundaries := range largeDocumentChunkBoundaries {
+			t.Run(jsonPathTypeNames[chunkBoundaries.pathType], func(t *testing.T) {
+				// Compute a location right before the chunk boundary, and insert a large value into it.
+				insertionPoint := chunkBoundaries.path[:strings.LastIndex(chunkBoundaries.path, ".")]
+				insertionPoint = fmt.Sprint(insertionPoint, ".a")
+				newDoc, changed, err := largeDoc.Insert(ctx, insertionPoint, valueToInsert)
+				require.NoError(t, err)
+				require.True(t, changed)
+
+				// test that new value is valid by converting it to interface{}
+				v, err := newDoc.ToInterface()
+				require.NoError(t, err)
+				newJsonDocument := types.JSONDocument{Val: v}
+
+				// test that the JSONDocument compares equal to the IndexedJSONDocument
+				cmp, err := types.JSON.Compare(newDoc, newJsonDocument)
+				require.NoError(t, err)
+				require.Equal(t, cmp, 0)
+
+				// extract the inserted value and confirm it's equal to the original inserted value.
+				result, err := newJsonDocument.Lookup(ctx, insertionPoint)
+				require.NoError(t, err)
+				require.NotNil(t, result)
+
+				cmp, err = types.JSON.Compare(valueToInsert, result)
+				require.NoError(t, err)
+				require.Equal(t, cmp, 0)
+			})
+		}
+	})
+
 }
 
 func TestIndexedJsonDocument_Extract(t *testing.T) {

--- a/go/store/prolly/tree/json_location.go
+++ b/go/store/prolly/tree/json_location.go
@@ -123,6 +123,7 @@ func jsonPathFromKey(pathKey []byte) (path jsonLocation) {
 			i += 1
 		} else if pathKey[i] == beginArrayKey {
 			ret.offsets = append(ret.offsets, i)
+			i += 1
 			i += varIntLength(pathKey[i])
 		} else {
 			i += 1

--- a/go/store/prolly/tree/json_location.go
+++ b/go/store/prolly/tree/json_location.go
@@ -72,6 +72,7 @@ const (
 )
 
 var unknownLocationKeyError = fmt.Errorf("A JSON document was written with a future version of Dolt, and the index metadata cannot be read. This will impact performance for large documents.")
+var unsupportedPathError = fmt.Errorf("The supplied JSON path is not supported for optimized lookup, falling back on unoptimized implementation.")
 
 const (
 	beginObjectKey byte = 0xFF
@@ -143,14 +144,24 @@ func varIntLength(firstByte byte) int {
 	return int(firstByte - 246)
 }
 
-func isValidJsonPathKey(key []byte) bool {
+func isUnsupportedJsonPathKey(key []byte) bool {
 	if bytes.Equal(key, []byte("*")) {
-		return false
+		return true
 	}
 	if bytes.Equal(key, []byte("**")) {
-		return false
+		return true
 	}
-	return true
+	return false
+}
+
+func isUnsupportedJsonArrayIndex(index []byte) bool {
+	if bytes.Equal(index, []byte("*")) {
+		return true
+	}
+	if bytes.Equal(index, []byte("last")) {
+		return true
+	}
+	return false
 }
 
 func errorIfNotSupportedLocation(key []byte) error {
@@ -199,11 +210,12 @@ func jsonPathElementsFromMySQLJsonPath(pathBytes []byte) (jsonLocation, error) {
 				return jsonLocation{}, fmt.Errorf("Invalid JSON path expression. Expected field name after '.' at character %v of %s", i, string(pathBytes))
 			}
 		case lexStateIdx:
-			if pathBytes[i] >= byte('0') && pathBytes[i] <= byte('9') {
+			if pathBytes[i] != byte(']') {
 				i += 1
 			} else {
-				if pathBytes[i] != ']' {
-					return jsonLocation{}, fmt.Errorf("Invalid JSON path expression %s.", string(pathBytes))
+				indexBytes := pathBytes[tok:i]
+				if isUnsupportedJsonArrayIndex(indexBytes) {
+					return jsonLocation{}, unsupportedPathError
 				}
 				conv, err := strconv.Atoi(string(pathBytes[tok:i]))
 				if err != nil {
@@ -219,10 +231,11 @@ func jsonPathElementsFromMySQLJsonPath(pathBytes []byte) (jsonLocation, error) {
 				i += 1
 			} else if pathBytes[i] == '.' || pathBytes[i] == '[' {
 				if tok == i {
-					return jsonLocation{}, fmt.Errorf("Invalid JSON path expression. Expected field name after '.' at character %v of %s", i, string(pathBytes))
+					// This could be a .[*] expression. Let the original implementation take a stab at it.
+					return jsonLocation{}, unsupportedPathError
 				}
-				if !isValidJsonPathKey(pathBytes[tok:i]) {
-					return jsonLocation{}, fmt.Errorf("Invalid JSON path expression. Expected field name after '.' at character %v of %s", tok, string(pathBytes))
+				if isUnsupportedJsonPathKey(pathBytes[tok:i]) {
+					return jsonLocation{}, unsupportedPathError
 				}
 				location.appendObjectKey(pathBytes[tok:i])
 				state = lexStatePath
@@ -235,8 +248,8 @@ func jsonPathElementsFromMySQLJsonPath(pathBytes []byte) (jsonLocation, error) {
 					return jsonLocation{}, fmt.Errorf("Invalid JSON path expression. Expected field name after '.' at character %v of %s", i, string(pathBytes))
 				}
 				pathKey := unescapeKey(pathBytes[tok+1 : i])
-				if !isValidJsonPathKey(pathKey) {
-					return jsonLocation{}, fmt.Errorf("Invalid JSON path expression. Expected field name after '.' at character %v of %s", tok, string(pathBytes))
+				if isUnsupportedJsonPathKey(pathKey) {
+					return jsonLocation{}, unsupportedPathError
 				}
 				location.appendObjectKey(pathKey)
 				state = lexStatePath
@@ -256,8 +269,8 @@ func jsonPathElementsFromMySQLJsonPath(pathBytes []byte) (jsonLocation, error) {
 		if tok == i {
 			return jsonLocation{}, fmt.Errorf("Invalid JSON path expression. Expected field name after '.' at character %v of %s", i, string(pathBytes))
 		}
-		if !isValidJsonPathKey(pathBytes[tok:i]) {
-			return jsonLocation{}, fmt.Errorf("Invalid JSON path expression. Expected field name after '.' at character %v of %s", tok, string(pathBytes))
+		if isUnsupportedJsonPathKey(pathBytes[tok:i]) {
+			return jsonLocation{}, unsupportedPathError
 		}
 		location.appendObjectKey(pathBytes[tok:i])
 		state = lexStatePath


### PR DESCRIPTION
This PR adds additional tests for calling JSON_INSERT on large JSON documents. It also fixes three issues with IndexedJsonDocuments:

1) Some operations are not supported by the new optimized implementation for JSON_LOOKUP, such as wildcards on array paths (eg `$[*]`). Instead of returning an error, we detect the error and fall back on the original implementation.

2) Attempting to insert a value into a document could cause an infinite loop.

3) We would fail to read some keys from an IndexedJsonDocument's StaticMap if the document contained arrays.