### PR TITLE
[no-release-notes] Disable "stats: boostrap abort over 1mm rows" BATS test in Lambda

### DIFF
--- a/integration-tests/bats/stats.bats
+++ b/integration-tests/bats/stats.bats
@@ -335,6 +335,7 @@ SQL
     [ "${lines[2]}" = "2" ]
 }
 
+# bats test_tags=no_lambda
 @test "stats: boostrap abort over 1mm rows" {
     cat <<EOF > data.py
 import random


### PR DESCRIPTION
This BATS test doesn't seem to run well in Lambda BATS. It failed for me four times in a row today, and I saw it failing a bunch last week, too. Disabling it in Lambda BATS. 