### PR TITLE
Optimize JSON_REMOVE on `IndexedJsonDocument`

### DIFF
--- a/go/store/prolly/tree/json_chunker.go
+++ b/go/store/prolly/tree/json_chunker.go
@@ -130,7 +130,7 @@ func (j *JsonChunker) Done(ctx context.Context) (Node, error) {
 	// When inserting into the beginning of an object or array, we need to add an extra comma.
 	// We could track then in the chunker, but it's easier to just check the next part of JSON to determine
 	// whether we need the comma.
-	if jsonBytes[0] != '}' && jsonBytes[0] != ']' && jsonBytes[0] != ',' {
+	if j.jScanner.currentPath.getScannerState() == endOfValue && jsonBytes[0] != '}' && jsonBytes[0] != ']' && jsonBytes[0] != ',' {
 		j.appendJsonToBuffer([]byte(","))
 	}
 	// Append the rest of the JsonCursor, then continue until we either exhaust the cursor, or we coincide with a boundary from the original tree.

--- a/go/store/prolly/tree/json_indexed_document_test.go
+++ b/go/store/prolly/tree/json_indexed_document_test.go
@@ -177,6 +177,17 @@ func TestIndexedJsonDocument_Insert(t *testing.T) {
 
 }
 
+func TestIndexedJsonDocument_Remove(t *testing.T) {
+	ctx := context.Background()
+	ns := NewTestNodeStore()
+	convertToIndexedJsonDocument := func(t *testing.T, s interface{}) interface{} {
+		return newIndexedJsonDocumentFromValue(t, ctx, ns, s)
+	}
+
+	testCases := jsontests.JsonRemoveTestCases(t, convertToIndexedJsonDocument)
+	jsontests.RunJsonTests(t, testCases)
+}
+
 func TestIndexedJsonDocument_Extract(t *testing.T) {
 	ctx := context.Background()
 	ns := NewTestNodeStore()

--- a/go/store/prolly/tree/json_indexed_document_test.go
+++ b/go/store/prolly/tree/json_indexed_document_test.go
@@ -17,6 +17,7 @@ package tree
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
@@ -178,7 +179,7 @@ func TestIndexedJsonDocument_Insert(t *testing.T) {
 }
 
 func TestIndexedJsonDocument_Remove(t *testing.T) {
-	ctx := context.Background()
+	ctx := sql.NewEmptyContext()
 	ns := NewTestNodeStore()
 	convertToIndexedJsonDocument := func(t *testing.T, s interface{}) interface{} {
 		return newIndexedJsonDocumentFromValue(t, ctx, ns, s)
@@ -186,6 +187,65 @@ func TestIndexedJsonDocument_Remove(t *testing.T) {
 
 	testCases := jsontests.JsonRemoveTestCases(t, convertToIndexedJsonDocument)
 	jsontests.RunJsonTests(t, testCases)
+
+	t.Run("large document removals", func(t *testing.T) {
+
+		largeDoc := createLargeDocumentForTesting(t, ctx, ns)
+
+		for _, chunkBoundary := range largeDocumentChunkBoundaries {
+			t.Run(jsonPathTypeNames[chunkBoundary.pathType], func(t *testing.T) {
+				// For each tested chunk boundary, get the path to the object containing that crosses that boundary, and remove it.
+				removalPointString := chunkBoundary.path[:strings.LastIndex(chunkBoundary.path, ".")]
+
+				removalPointLocation, err := jsonPathElementsFromMySQLJsonPath([]byte(removalPointString))
+				require.NoError(t, err)
+
+				// Test that the value exists prior to removal
+				result, err := largeDoc.Lookup(ctx, removalPointString)
+				require.NoError(t, err)
+				require.NotNil(t, result)
+
+				newDoc, changed, err := largeDoc.Remove(ctx, removalPointString)
+				require.NoError(t, err)
+				require.True(t, changed)
+
+				// test that new value is valid by calling ToInterface
+				v, err := newDoc.ToInterface()
+				require.NoError(t, err)
+
+				// If the removed value was an object key, check that the key no longer exists.
+				// If the removed value was an array element, check that the parent array has shrunk.
+				if removalPointLocation.getLastPathElement().isArrayIndex {
+					// Check that the parent array has shrunk.
+					arrayIndex := int(removalPointLocation.getLastPathElement().getArrayIndex())
+					parentLocation := removalPointLocation.Clone()
+					parentLocation.pop()
+
+					getParentArray := func(doc IndexedJsonDocument) []interface{} {
+						arrayWrapper, err := doc.lookupByLocation(ctx, parentLocation)
+						require.NoError(t, err)
+						arrayInterface, err := arrayWrapper.ToInterface()
+						require.NoError(t, err)
+						require.IsType(t, []interface{}{}, arrayInterface)
+						return arrayInterface.([]interface{})
+					}
+
+					oldArray := getParentArray(largeDoc)
+					newArray := getParentArray(newDoc.(IndexedJsonDocument))
+
+					oldArray = slices.Delete(oldArray, arrayIndex, arrayIndex+1)
+
+					require.Equal(t, oldArray, newArray)
+				} else {
+					// Check that the key no longer exists.
+					newJsonDocument := types.JSONDocument{Val: v}
+					result, err = newJsonDocument.Lookup(ctx, removalPointString)
+					require.NoError(t, err)
+					require.Nil(t, result)
+				}
+			})
+		}
+	})
 }
 
 func TestIndexedJsonDocument_Extract(t *testing.T) {

--- a/go/store/prolly/tree/json_location.go
+++ b/go/store/prolly/tree/json_location.go
@@ -71,6 +71,10 @@ const (
 	endOfValue
 )
 
+func (t jsonPathType) isInitialElement() bool {
+	return t == objectInitialElement || t == arrayInitialElement
+}
+
 var unknownLocationKeyError = fmt.Errorf("A JSON document was written with a future version of Dolt, and the index metadata cannot be read. This will impact performance for large documents.")
 var unsupportedPathError = fmt.Errorf("The supplied JSON path is not supported for optimized lookup, falling back on unoptimized implementation.")
 


### PR DESCRIPTION
This PR includes a new implementation of the `JSON_REMOVE` function that leverages the new indexed JSON storage format.

For JSON documents that span multiple chunks, only the affected chunks need to be loaded and modified, allowing operations to scale with the size of the removed value instead of the size of the entire document.