### PR TITLE
Optimize JSON_SET and JSON_REPLACE on `IndexedJsonDocument`

### DIFF
--- a/go/store/prolly/tree/json_chunker.go
+++ b/go/store/prolly/tree/json_chunker.go
@@ -130,7 +130,7 @@ func (j *JsonChunker) Done(ctx context.Context) (Node, error) {
 	// When inserting into the beginning of an object or array, we need to add an extra comma.
 	// We could track then in the chunker, but it's easier to just check the next part of JSON to determine
 	// whether we need the comma.
-	if j.jScanner.currentPath.getScannerState() == endOfValue && jsonBytes[0] != '}' && jsonBytes[0] != ']' && jsonBytes[0] != ',' {
+	if j.jScanner.currentPath.getScannerState() == endOfValue && len(jsonBytes) > 0 && jsonBytes[0] != '}' && jsonBytes[0] != ']' && jsonBytes[0] != ',' {
 		j.appendJsonToBuffer([]byte(","))
 	}
 	// Append the rest of the JsonCursor, then continue until we either exhaust the cursor, or we coincide with a boundary from the original tree.

--- a/go/store/prolly/tree/json_indexed_document_test.go
+++ b/go/store/prolly/tree/json_indexed_document_test.go
@@ -259,6 +259,28 @@ func TestIndexedJsonDocument_Extract(t *testing.T) {
 	jsontests.RunJsonTests(t, testCases)
 }
 
+func TestIndexedJsonDocument_Replace(t *testing.T) {
+	ctx := context.Background()
+	ns := NewTestNodeStore()
+	convertToIndexedJsonDocument := func(t *testing.T, s interface{}) interface{} {
+		return newIndexedJsonDocumentFromValue(t, ctx, ns, s)
+	}
+
+	testCases := jsontests.JsonReplaceTestCases(t, convertToIndexedJsonDocument)
+	jsontests.RunJsonTests(t, testCases)
+}
+
+func TestIndexedJsonDocument_Set(t *testing.T) {
+	ctx := context.Background()
+	ns := NewTestNodeStore()
+	convertToIndexedJsonDocument := func(t *testing.T, s interface{}) interface{} {
+		return newIndexedJsonDocumentFromValue(t, ctx, ns, s)
+	}
+
+	testCases := jsontests.JsonSetTestCases(t, convertToIndexedJsonDocument)
+	jsontests.RunJsonTests(t, testCases)
+}
+
 func TestIndexedJsonDocument_Value(t *testing.T) {
 	ctx := context.Background()
 	ns := NewTestNodeStore()


### PR DESCRIPTION
This PR includes a new implementation of the JSON_SET and JSON_REPLACE functions that leverage the new indexed JSON storage format.

For JSON documents that span multiple chunks, only the affected chunks need to be loaded and modified, allowing operations to scale with the size of the removed value instead of the size of the entire document.
