### PR TITLE
cache table list

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/aliyun/aliyun-oss-go-sdk v2.2.5+incompatible
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/cespare/xxhash v1.1.0
+	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/creasty/defaults v1.6.0
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
 	github.com/dolthub/go-mysql-server v0.18.2-0.20240715180604-3d70c263a451
@@ -106,7 +107,6 @@ require (
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/apache/thrift v0.13.1-0.20201008052519-daf620915714 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dolthub/go-icu-regex v0.0.0-20230524105445-af7e7991c97e // indirect
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 // indirect

--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/cespare/xxhash"
+	"github.com/cespare/xxhash/v2"
 	"sort"
 	"strings"
 

--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -578,20 +578,20 @@ func (root *rootValue) GetTableNames(ctx context.Context, schemaName string) ([]
 		return nil, err
 	}
 
-	md5 := xxhash.New()
+	tablesHash := xxhash.New()
 
 	var names []string
 	err = tmIterAll(ctx, tableMap, func(name string, _ hash.Hash) {
-		md5.Write([]byte(name))
+		tablesHash.Write([]byte(name))
 		// avoid distinct table names converging to the same hash
-		md5.Write([]byte{0x0000})
+		tablesHash.Write([]byte{0x0000})
 		names = append(names, name)
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	root.tablesHash = md5.Sum64()
+	root.tablesHash = tablesHash.Sum64()
 
 	return names, nil
 }

--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -582,7 +582,8 @@ func (root *rootValue) GetTableNames(ctx context.Context, schemaName string) ([]
 	var names []string
 	err = tmIterAll(ctx, tableMap, func(name string, _ hash.Hash) {
 		md5.Write([]byte(name))
-		md5.Write([]byte{','})
+		// avoid distinct table names converging to the same hash
+		md5.Write([]byte{0x0000})
 		names = append(names, name)
 	})
 	if err != nil {

--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -19,10 +19,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/cespare/xxhash/v2"
 	"sort"
 	"strings"
 
+	"github.com/cespare/xxhash/v2"
 	flatbuffers "github.com/dolthub/flatbuffers/v23/go"
 	"github.com/dolthub/go-mysql-server/sql"
 

--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/cespare/xxhash"
 	"sort"
 	"strings"
 
@@ -108,17 +109,20 @@ type RootValue interface {
 	SetFeatureVersion(v FeatureVersion) (RootValue, error)
 	// SetTableHash sets the table with the given case-sensitive name to the new hash, and returns a new root.
 	SetTableHash(ctx context.Context, tName string, h hash.Hash) (RootValue, error)
+	// TableListHash returns a unique digest of the list of table names
+	TableListHash() uint64
 	// VRW returns this root's ValueReadWriter.
 	VRW() types.ValueReadWriter
 }
 
 // rootValue is Dolt's implementation of RootValue.
 type rootValue struct {
-	vrw  types.ValueReadWriter
-	ns   tree.NodeStore
-	st   rootValueStorage
-	fkc  *ForeignKeyCollection // cache the first load
-	hash hash.Hash             // cache the first load
+	vrw        types.ValueReadWriter
+	ns         tree.NodeStore
+	st         rootValueStorage
+	fkc        *ForeignKeyCollection // cache the first load
+	rootHash   hash.Hash             // cache the first load
+	tablesHash uint64
 }
 
 var _ RootValue = (*rootValue)(nil)
@@ -162,7 +166,7 @@ var NewRootValue = func(ctx context.Context, vrw types.ValueReadWriter, ns tree.
 		}
 	}
 
-	return &rootValue{vrw, ns, storage, nil, hash.Hash{}}, nil
+	return &rootValue{vrw, ns, storage, nil, hash.Hash{}, 0}, nil
 }
 
 // EmptyRootValue returns an empty RootValue. This is a variable as it's changed in Doltgres.
@@ -440,6 +444,10 @@ func GetAllSchemas(ctx context.Context, root RootValue) (map[string]schema.Schem
 	return m, nil
 }
 
+func (root *rootValue) TableListHash() uint64 {
+	return root.tablesHash
+}
+
 func (root *rootValue) GetTableHash(ctx context.Context, tName TableName) (hash.Hash, bool, error) {
 	tableMap, err := root.getTableMap(ctx, tName.Schema)
 	if err != nil {
@@ -569,13 +577,19 @@ func (root *rootValue) GetTableNames(ctx context.Context, schemaName string) ([]
 		return nil, err
 	}
 
+	md5 := xxhash.New()
+
 	var names []string
 	err = tmIterAll(ctx, tableMap, func(name string, _ hash.Hash) {
+		md5.Write([]byte(name))
+		md5.Write([]byte{','})
 		names = append(names, name)
 	})
 	if err != nil {
 		return nil, err
 	}
+
+	root.tablesHash = md5.Sum64()
 
 	return names, nil
 }
@@ -695,7 +709,7 @@ func (root *rootValue) IterTables(ctx context.Context, cb func(name TableName, t
 }
 
 func (root *rootValue) withStorage(st rootValueStorage) *rootValue {
-	return &rootValue{root.vrw, root.ns, st, nil, hash.Hash{}}
+	return &rootValue{root.vrw, root.ns, st, nil, hash.Hash{}, 0}
 }
 
 func (root *rootValue) NomsValue() types.Value {
@@ -857,14 +871,14 @@ func (root *rootValue) CreateDatabaseSchema(ctx context.Context, dbSchema schema
 
 // HashOf gets the hash of the root value
 func (root *rootValue) HashOf() (hash.Hash, error) {
-	if root.hash.IsEmpty() {
+	if root.rootHash.IsEmpty() {
 		var err error
-		root.hash, err = root.st.nomsValue().Hash(root.vrw.Format())
+		root.rootHash, err = root.st.nomsValue().Hash(root.vrw.Format())
 		if err != nil {
 			return hash.Hash{}, nil
 		}
 	}
-	return root.hash, nil
+	return root.rootHash, nil
 }
 
 // RenameTable renames a table by changing its string key in the RootValue's table map. In order to preserve


### PR DESCRIPTION
RootValue caches a hash of its table list, which is invalidated when we update the table address list. The hash is used to cache a map of table names in the root value and expedites table retrieval during `planbuilder`. The cache could be used elsewhere for performance in the future.

https://github.com/dolthub/doltgresql/pull/503