### PR TITLE
Build Archives more robustly

### DIFF
--- a/go/cmd/dolt/commands/admin/archive.go
+++ b/go/cmd/dolt/commands/admin/archive.go
@@ -141,7 +141,7 @@ func handleProgress(ctx context.Context, progress chan interface{}) {
 				}
 				switch v := msg.(type) {
 				case string:
-					cli.Printf("LOG: %s", v)
+					cli.Printf("LOG: %s\n", v)
 				case nbs.ArchiveBuildProgressMsg:
 					if v.Total == v.Completed {
 						p.Printf("%s: Done\n", v.Stage)

--- a/go/cmd/dolt/commands/admin/archive.go
+++ b/go/cmd/dolt/commands/admin/archive.go
@@ -156,6 +156,7 @@ func handleProgress(ctx context.Context, progress chan interface{}) {
 				default:
 					cli.Printf("Unexpected Message: %v\n", v)
 				}
+			// If no events come in, we still want to update the progress bar every second.
 			case <-time.After(1 * time.Second):
 			}
 

--- a/go/cmd/dolt/commands/admin/archive.go
+++ b/go/cmd/dolt/commands/admin/archive.go
@@ -48,11 +48,11 @@ var docs = cli.CommandDocumentationContent{
 table files into archives. Currently, for safety, table files are left in place.`,
 
 	Synopsis: []string{
-		`[--no-grouping]`,
+		`[--group-chunks]`,
 	},
 }
 
-const noGroupingFlag = "no-grouping"
+const groupChunksFlag = "group-chunks"
 
 // Description returns a description of the command
 func (cmd ArchiveCmd) Description() string {
@@ -68,7 +68,7 @@ func (cmd ArchiveCmd) Docs() *cli.CommandDocumentation {
 
 func (cmd ArchiveCmd) ArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParserWithMaxArgs(cmd.Name(), 0)
-	ap.SupportsFlag(noGroupingFlag, "", "Do not attempt to group chunks. Default dictionary will be used for all chunks")
+	ap.SupportsFlag(groupChunksFlag, "", "Attempt to group chunks. This will produce smaller archives, but can take much longer to build.")
 	/* TODO: Implement these flags
 	ap.SupportsFlag("purge", "", "remove table files after archiving")
 	ap.SupportsFlag("revert", "", "Return to unpurged table files, or rebuilt table files from archives")
@@ -104,7 +104,7 @@ func (cmd ArchiveCmd) Exec(ctx context.Context, commandStr string, args []string
 	})
 
 	groupings := nbs.NewChunkRelations()
-	if !apr.Contains(noGroupingFlag) {
+	if apr.Contains(groupChunksFlag) {
 		err = historicalFuzzyMatching(ctx, hs, &groupings, dEnv.DoltDB)
 		if err != nil {
 			cli.PrintErrln(err)

--- a/go/cmd/dolt/commands/admin/archive.go
+++ b/go/cmd/dolt/commands/admin/archive.go
@@ -144,21 +144,20 @@ func handleProgress(progress chan interface{}) {
 					if v.FinishedOne {
 						finishedGroupCount++
 					}
-
-					if now := time.Now(); now.Sub(lastUpdateTime) > 3*time.Second {
-						percentDone := 0.0
-						if totalGroupCount > 0 {
-							percentDone = float64(finishedGroupCount) / float64(totalGroupCount)
-						}
-
-						cli.Printf("Groups: %d/%d (%f)\n", finishedGroupCount, totalGroupCount, percentDone)
-						lastUpdateTime = now
-					}
 				default:
 					cli.Printf("Unexpected Message: %v\n", v)
 				}
 			case <-time.After(3 * time.Second):
-				cli.Println("tick")
+			}
+
+			if now := time.Now(); now.Sub(lastUpdateTime) > 3*time.Second {
+				percentDone := 0.0
+				if totalGroupCount > 0 {
+					percentDone = float64(finishedGroupCount) / float64(totalGroupCount)
+				}
+
+				cli.Printf("Groups: %d/%d (%f)\n", finishedGroupCount, totalGroupCount, percentDone)
+				lastUpdateTime = now
 			}
 		}
 	}()

--- a/go/cmd/dolt/commands/admin/archive.go
+++ b/go/cmd/dolt/commands/admin/archive.go
@@ -110,7 +110,7 @@ func (cmd ArchiveCmd) Exec(ctx context.Context, commandStr string, args []string
 		cli.Printf("Found %d possible relations by walking history\n", groupings.Count())
 	}
 
-	progress := make(chan interface{})
+	progress := make(chan interface{}, 32)
 	handleProgress(progress)
 
 	err = nbs.BuildArchive(ctx, cs, &groupings, progress)

--- a/go/store/nbs/archive.go
+++ b/go/store/nbs/archive.go
@@ -182,6 +182,18 @@ const ( // afr = Archive FooteR
 	afrSigOffset         = afrVersionOffset + 1
 )
 
+// Archive Metadata Data Keys are the fields in the archive metadata that are stored in the footer. These are used
+// to store information about the archive that is semi-structured. The data is stored in JSON format, all values are strings.
+const ( //amdk = Archive Metadata Data Key
+	// The version of Dolt that created the archive.
+	amdkDoltVersion = "dolt_version"
+	// The id of the table file that the archive was created from. This value can be used during the reverse process
+	// to quickly get back to the original table file if it is still available.
+	amdkOriginTableFile = "origin_table_file"
+	// The timestamp of when the archive was created.
+	amdkConversionTime = "conversion_time"
+)
+
 var ErrInvalidChunkRange = errors.New("invalid chunk range")
 var ErrInvalidDictionaryRange = errors.New("invalid dictionary range")
 var ErrInvalidFileSignature = errors.New("invalid file signature")

--- a/go/store/nbs/archive_build.go
+++ b/go/store/nbs/archive_build.go
@@ -26,12 +26,13 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/dolthub/dolt/go/cmd/dolt/doltversion"
-	"github.com/dolthub/dolt/go/store/chunks"
-	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/gozstd"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/dolthub/dolt/go/cmd/dolt/doltversion"
+	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 const defaultDictionarySize = 1 << 12 // NM4 - maybe just select the largest chunk. TBD.

--- a/go/store/nbs/archive_build.go
+++ b/go/store/nbs/archive_build.go
@@ -576,7 +576,6 @@ func (cr *ChunkRelations) convertToChunkGroups(ctx context.Context, chks *Simple
 	wg.Add(numThreads)
 	for i := 0; i < numThreads; i++ {
 		go func() {
-			progress <- "Starting group converter goroutine."
 			buff := make([]byte, 0, maxChunkSize)
 			defer wg.Done()
 			for hs := range groupChannel {

--- a/go/store/nbs/archive_build.go
+++ b/go/store/nbs/archive_build.go
@@ -22,16 +22,16 @@ import (
 	"math/rand"
 	"os"
 	"sort"
-	"sync"
-
-	"github.com/dolthub/gozstd"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/dolthub/gozstd"
+	lru "github.com/hashicorp/golang-lru/v2"
 )
 
 const defaultDictionarySize = 1 << 12 // NM4 - maybe just select the largest chunk. TBD.
+const maxSamples = 1000
+const minSamples = 25
 
 func BuildArchive(ctx context.Context, cs chunks.ChunkStore, dagGroups *ChunkRelations) (err error) {
 	if gs, ok := cs.(*GenerationalNBS); ok {
@@ -90,18 +90,19 @@ func convertTableFileToArchive(ctx context.Context, cs chunkSource, idx tableInd
 	}
 
 	var defaultDict []byte
-	if len(defaultSamples) > 25 {
+	if len(defaultSamples) >= minSamples {
 		defaultDict = buildDictionary(defaultSamples)
 	} else {
 		return "", hash.Hash{}, errors.New("Not enough samples to build default dictionary")
 	}
+	defaultSamples = nil
 
 	defaultCDict, err := gozstd.NewCDict(defaultDict)
 	if err != nil {
 		return "", hash.Hash{}, err
 	}
 
-	cgList := dagGroups.convertToChunkGroups(allChunks, defaultCDict)
+	cgList, err := dagGroups.convertToChunkGroups(ctx, allChunks, defaultCDict)
 	sort.Slice(cgList, func(i, j int) bool {
 		return cgList[i].totalBytesSavedWDict > cgList[j].totalBytesSavedWDict
 	})
@@ -127,7 +128,7 @@ func convertTableFileToArchive(ctx context.Context, cs chunkSource, idx tableInd
 		return "", hash.Hash{}, err
 	}
 
-	_, grouped, singles, err := writeChunkGroupToArchive(cmpBuff, allChunks, cgList, defaultDictByteSpanId, defaultCDict, arcW)
+	_, grouped, singles, err := writeChunkGroupToArchive(ctx, cmpBuff, allChunks, cgList, defaultDictByteSpanId, defaultCDict, arcW)
 	if err != nil {
 		return "", hash.Hash{}, err
 	}
@@ -184,13 +185,20 @@ func indexAndFinalizeArchive(arcW *archiveWriter, archivePath string) error {
 }
 
 func writeChunkGroupToArchive(
+	ctx context.Context,
 	cmpBuff []byte,
-	allChunks map[hash.Hash]*chunks.Chunk,
+	chunkCache *SimpleChunkSourceCache,
 	cgList []*chunkGroup,
 	defaultSpanId uint32,
 	defaultDict *gozstd.CDict,
 	arcW *archiveWriter,
 ) (groupCount, groupedChunkCount, individualChunkCount uint32, err error) {
+	var allChunks hash.HashSet
+	allChunks, err = chunkCache.addresses()
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
 	for _, cg := range cgList {
 		if cg.totalBytesSavedWDict > cg.totalBytesSavedDefaultDict {
 			groupCount++
@@ -203,29 +211,38 @@ func writeChunkGroupToArchive(
 			}
 
 			for _, cs := range cg.chks {
-				c := cs.chunk
-				if !arcW.chunkSeen(c.Hash()) {
+				c, e2 := chunkCache.get(ctx, cs.chunkId)
+				if e2 != nil {
+					return 0, 0, 0, e2
+				}
+
+				if !arcW.chunkSeen(cs.chunkId) {
 					compressed := gozstd.CompressDict(cmpBuff, c.Data(), cg.cDict)
 
 					dataId, err := arcW.writeByteSpan(compressed)
 					if err != nil {
 						return 0, 0, 0, err
 					}
-					err = arcW.stageChunk(c.Hash(), dictId, dataId)
+					err = arcW.stageChunk(cs.chunkId, dictId, dataId)
 					if err != nil {
 						return 0, 0, 0, err
 					}
 					groupedChunkCount++
 				}
-				delete(allChunks, c.Hash())
+				allChunks.Remove(cs.chunkId)
 			}
 		}
 	}
 
 	// Any chunks remaining will be written out individually.
-	for h, c := range allChunks {
+	for h := range allChunks {
 		var compressed []byte
 		dictId := uint32(0)
+
+		c, e2 := chunkCache.get(ctx, h)
+		if e2 != nil {
+			return 0, 0, 0, e2
+		}
 
 		compressed = gozstd.CompressDict(cmpBuff, c.Data(), defaultDict)
 		dictId = defaultSpanId
@@ -247,48 +264,32 @@ func writeChunkGroupToArchive(
 // gatherAllChunks reads all the chunks from the chunk source and returns them in a map. The map is keyed by the hash of
 // the chunk. This is going to take up a bunch of memory.
 // It also returns a list of default samples, which are the first 1000 chunks that are read. These are used to build the default dictionary.
-func gatherAllChunks(ctx context.Context, cs chunkSource, idx tableIndex) (map[hash.Hash]*chunks.Chunk, []*chunks.Chunk, error) {
-	records := make([]getRecord, idx.chunkCount())
-	for i := uint32(0); i < idx.chunkCount(); i++ {
+func gatherAllChunks(ctx context.Context, cs chunkSource, idx tableIndex) (*SimpleChunkSourceCache, []*chunks.Chunk, error) {
+	sampleCount := min(idx.chunkCount(), maxSamples)
+
+	defaultSamples := make([]*chunks.Chunk, 0, sampleCount)
+	for i := uint32(0); i < sampleCount; i++ {
 		var h hash.Hash
 		_, err := idx.indexEntry(i, &h)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		records = append(records, getRecord{&h, h.Prefix(), false})
-	}
-
-	group, ctx := errgroup.WithContext(ctx)
-
-	allChunks := map[hash.Hash]*chunks.Chunk{}
-	defaultSamples := make([]*chunks.Chunk, 0, 1000)
-
-	bottleneck := sync.Mutex{} // This code doesn't cope with parallelism yet.
-	var stats Stats
-	allFound, err := cs.getMany(ctx, group, records, func(_ context.Context, c *chunks.Chunk) {
-		bottleneck.Lock()
-		defer bottleneck.Unlock()
-
-		if len(defaultSamples) < cap(defaultSamples) {
-			defaultSamples = append(defaultSamples, c)
+		bytes, err := cs.get(ctx, h, nil)
+		if err != nil {
+			return nil, nil, err
 		}
 
-		h := c.Hash()
-		allChunks[h] = c
-	}, &stats)
-	if err != nil {
-		return nil, nil, err
+		chk := chunks.NewChunk(bytes)
+		defaultSamples = append(defaultSamples, &chk)
 	}
-	if !allFound { // Unlikely to happen, given we got the list of chunks from this index.
-		return nil, nil, errors.New("missing chunks")
-	}
-	err = group.Wait()
+
+	chkCache, err := newSimpleChunkSourceCache(cs)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return allChunks, defaultSamples, nil
+	return chkCache, defaultSamples, nil
 }
 func verifyAllChunks(idx tableIndex, archiveFile string) error {
 	file, err := os.Open(archiveFile)
@@ -366,27 +367,34 @@ type chunkGroup struct {
 	avgRawChunkSize            int
 }
 
-// chunkCmpScore wraps a chunk and its compression score for use by the chunkGroup.
+// chunkCmpScore wraps a chunk and its compression score for use by the chunkGroup. This score includes the
 type chunkCmpScore struct {
-	chunk              *chunks.Chunk
-	score              float64
-	dictCmpSize        int
+	chunkId hash.Hash
+	// The compression score. Higher is better. This is the ratio of the compressed size to the raw size, using the group's
+	// dictionary. IE, this number only has meaning withing the group
+	score float64
+	// The size of the compressed chunk using the group's dictionary.
+	dictCmpSize int
+	// The size of the compressed chunk using the default dictionary. If this is smaller than dictCmpSize, then this chunk
+	// is not a good candidate for the group.
 	defaultDictCmpSize int
 }
 
 // newChunkGroup creates a new chunkGroup from a set of chunks.
-func newChunkGroup(cmpBuff []byte, chks []*chunks.Chunk, defaultDict *gozstd.CDict) *chunkGroup {
+func newChunkGroup(ctx context.Context, chunkCache *SimpleChunkSourceCache, cmpBuff []byte, chks hash.HashSet, defaultDict *gozstd.CDict) (*chunkGroup, error) {
 	scored := make([]chunkCmpScore, len(chks))
-	for i, c := range chks {
-		scored[i] = chunkCmpScore{c, 0.0, 0, 0}
+	i := 0
+	for h := range chks {
+		scored[i] = chunkCmpScore{h, 0.0, 0, 0}
+		i++
 	}
-	result := chunkGroup{dict: nil, cDict: nil, chks: scored}
-	result.rebuild(cmpBuff, defaultDict)
-	return &result
-}
 
-func (cg *chunkGroup) getLeader() *chunks.Chunk {
-	return cg.chks[0].chunk
+	result := chunkGroup{dict: nil, cDict: nil, chks: scored}
+	err := result.rebuild(ctx, chunkCache, cmpBuff, defaultDict)
+	if err != nil {
+		return nil, err
+	}
+	return &result, err
 }
 
 // For whatever reason, we need 7 or more samples to build a dictionary. But in principle we only need 1. So duplicate
@@ -406,15 +414,15 @@ func padSamples(chks []*chunks.Chunk) []*chunks.Chunk {
 // use testChunk to determine if this chunk should be added.
 //
 // The chunkGroup will be recalculated after this chunk is added.
-func (cg *chunkGroup) addChunk(cmpBuff []byte, c *chunks.Chunk, defaultDict *gozstd.CDict) error {
+func (cg *chunkGroup) addChunk(ctx context.Context, chunkChache *SimpleChunkSourceCache, cmpBuff []byte, c *chunks.Chunk, defaultDict *gozstd.CDict) error {
 	scored := chunkCmpScore{
-		chunk:       c,
+		chunkId:     c.Hash(),
 		score:       0.0,
 		dictCmpSize: 0,
 	}
 
 	cg.chks = append(cg.chks, scored)
-	return cg.rebuild(cmpBuff, defaultDict)
+	return cg.rebuild(ctx, chunkChache, cmpBuff, defaultDict)
 }
 
 // worstZScore returns the z-score of the worst chunk in the group. The z-score is a measure of how many standard
@@ -446,10 +454,15 @@ func (cg *chunkGroup) worstZScore() float64 {
 
 // rebuild - recalculate the entire group's compression ratio. Dictionary and total compression ratio are updated as well.
 // This method is called after a new chunk is added to the group. Ensures that stats about the group are up-to-date.
-func (cg *chunkGroup) rebuild(cmpBuff []byte, defaultDict *gozstd.CDict) error {
+func (cg *chunkGroup) rebuild(ctx context.Context, chunkCache *SimpleChunkSourceCache, cmpBuff []byte, defaultDict *gozstd.CDict) error {
 	chks := make([]*chunks.Chunk, len(cg.chks))
+
 	for i, cs := range cg.chks {
-		chks[i] = cs.chunk
+		chk, err := chunkCache.get(ctx, cs.chunkId)
+		if err != nil {
+			return err
+		}
+		chks[i] = chk
 	}
 
 	dct := buildDictionary(padSamples(chks))
@@ -462,18 +475,25 @@ func (cg *chunkGroup) rebuild(cmpBuff []byte, defaultDict *gozstd.CDict) error {
 
 	cmpDct := gozstd.Compress(nil, dct)
 
+	raw := 0
+	dictCmpSize := len(cmpDct)
+	noDictCmpSize := 0
 	scored := make([]chunkCmpScore, len(chks))
 	for i, c := range chks {
 		d := c.Data()
 		comp := gozstd.CompressDict(cmpBuff, d, cDict)
 		defaultDictComp := gozstd.CompressDict(cmpBuff, d, defaultDict)
 
-		scored[i] = chunkCmpScore{
-			chunk:              c,
+		ccs := chunkCmpScore{
+			chunkId:            c.Hash(),
 			score:              float64(len(d)-len(comp)) / float64(len(d)),
 			dictCmpSize:        len(comp),
 			defaultDictCmpSize: len(defaultDictComp),
 		}
+		scored[i] = ccs
+		raw += len(c.Data())
+		dictCmpSize += ccs.dictCmpSize
+		noDictCmpSize += ccs.defaultDictCmpSize
 	}
 	sort.Slice(scored, func(i, j int) bool {
 		return scored[i].score > scored[j].score
@@ -482,17 +502,6 @@ func (cg *chunkGroup) rebuild(cmpBuff []byte, defaultDict *gozstd.CDict) error {
 	cg.dict = dct
 	cg.cDict = cDict
 	cg.chks = scored
-
-	raw := 0
-	dictCmpSize := 0
-	noDictCmpSize := 0
-	for _, cs := range cg.chks {
-		c := cs.chunk
-		raw += len(c.Data())
-		dictCmpSize += cs.dictCmpSize
-		noDictCmpSize += cs.defaultDictCmpSize
-	}
-	dictCmpSize += len(cmpDct)
 
 	cg.totalRatioWDict = float64(raw-dictCmpSize) / float64(raw)
 	cg.totalBytesSavedWDict = raw - dictCmpSize
@@ -544,28 +553,35 @@ func (cr *ChunkRelations) Count() int {
 	return len(cr.manyToGroup)
 }
 
-func (cr *ChunkRelations) convertToChunkGroups(chks map[hash.Hash]*chunks.Chunk, defaultDict *gozstd.CDict) []*chunkGroup {
+func (cr *ChunkRelations) convertToChunkGroups(ctx context.Context, chks *SimpleChunkSourceCache, defaultDict *gozstd.CDict) ([]*chunkGroup, error) {
 	result := make([]*chunkGroup, 0, cr.Count())
 	buff := make([]byte, 0, maxChunkSize)
 
-	// For each group, look up the addresses and build a chunk group.
+	hs := hash.NewHashSet()
+	// For each relation set, look up the addresses and build a chunk group.
 	for _, v := range cr.groups() {
-		var c []*chunks.Chunk
 		for h := range v {
 			// There will be chunks referenced in the chunk group which are not in the chks map. This is because
 			// we walk the history to get the chunk groups, but the map comes from a specific table file only - which
 			// may not contain all the chunks of the DB.
-			chk := chks[h]
-			if chk != nil {
-				c = append(c, chk)
+			has, err := chks.has(h)
+			if err != nil {
+				return nil, err
+			}
+			if has {
+				hs.Insert(h)
 			}
 		}
 
-		if len(c) > 1 {
-			result = append(result, newChunkGroup(buff, c, defaultDict))
+		if len(hs) > 1 {
+			chkGrp, err := newChunkGroup(ctx, chks, buff, hs, defaultDict)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, chkGrp)
 		}
 	}
-	return result
+	return result, nil
 }
 
 func (cr *ChunkRelations) groups() []hash.HashSet {
@@ -627,4 +643,62 @@ func (cr *ChunkRelations) Add(a, b hash.Hash) {
 	for h := range merged {
 		cr.manyToGroup[h] = &merged
 	}
+}
+
+// SimpleChunkSourceCache is a simple cache for chunks. For the purposes of building archives, we want to avoid storing
+// all chunks in memory.
+type SimpleChunkSourceCache struct {
+	cache *lru.TwoQueueCache[hash.Hash, *chunks.Chunk]
+	cs    chunkSource
+}
+
+// newSimpleChunkSourceCache creates a new SimpleChunkSourceCache. The cache size is fixed, should use approximately
+// 12Gb of memory.
+func newSimpleChunkSourceCache(cs chunkSource) (*SimpleChunkSourceCache, error) {
+	// Chunks are 4K on average, so 3M chunks should be about 12Gb.
+	lruCache, err := lru.New2Q[hash.Hash, *chunks.Chunk](3000000)
+	if err != nil {
+		return nil, err
+	}
+	return &SimpleChunkSourceCache{lruCache, cs}, nil
+}
+
+// get a chunk from the cache. If the chunk is not in the cache, it will be fetched from the ChunkSource.
+func (csc *SimpleChunkSourceCache) get(ctx context.Context, h hash.Hash) (*chunks.Chunk, error) {
+	if chk, ok := csc.cache.Get(h); ok {
+		return chk, nil
+	}
+
+	bytes, err := csc.cs.get(ctx, h, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	chk := chunks.NewChunk(bytes)
+	csc.cache.Add(h, &chk)
+	return &chk, nil
+}
+
+// has returns true if the chunk is in the ChunkSource. This is not related to what is cached, just a helper.
+func (csc *SimpleChunkSourceCache) has(h hash.Hash) (bool, error) {
+	return csc.cs.has(h)
+}
+
+// addresses get all chunk addresses of the ChunkSource as a hash.HashSet. This is not related to what is cached, just a helper.
+func (csc *SimpleChunkSourceCache) addresses() (hash.HashSet, error) {
+	idx, err := csc.cs.index()
+	if err != nil {
+		return nil, err
+	}
+
+	result := hash.NewHashSet()
+	for i := uint32(0); i < idx.chunkCount(); i++ {
+		var h hash.Hash
+		_, err := idx.indexEntry(i, &h)
+		if err != nil {
+			return nil, err
+		}
+		result.Insert(h)
+	}
+	return result, nil
 }

--- a/go/store/nbs/archive_test.go
+++ b/go/store/nbs/archive_test.go
@@ -606,12 +606,12 @@ func generateDictionary(seed int64) ([]byte, *gozstd.CDict) {
 	return rawDict, cDict
 }
 
-func addChunkToCache(cache *SimpleChunkSourceCache, chk *chunks.Chunk) {
+func addChunkToCache(cache *simpleChunkSourceCache, chk *chunks.Chunk) {
 	internal, _ := cache.cs.(*testChunkSource)
 	internal.chunks = append(internal.chunks, chk)
 }
 
-func generateSimilarChunks(seed int64, count int) ([]*chunks.Chunk, *SimpleChunkSourceCache, hash.HashSet) {
+func generateSimilarChunks(seed int64, count int) ([]*chunks.Chunk, *simpleChunkSourceCache, hash.HashSet) {
 	chks := make([]*chunks.Chunk, count)
 	for i := 0; i < count; i++ {
 		chks[i] = generateRandomChunk(seed, 1000+i)
@@ -637,7 +637,7 @@ func generateRandomBytes(seed int64, len int) []byte {
 	return data
 }
 
-func buildTestChunkSource(chks []*chunks.Chunk) (*SimpleChunkSourceCache, hash.HashSet) {
+func buildTestChunkSource(chks []*chunks.Chunk) (*simpleChunkSourceCache, hash.HashSet) {
 	cpy := make([]*chunks.Chunk, len(chks))
 	copy(cpy, chks)
 	tcs := &testChunkSource{chunks: cpy}

--- a/go/store/nbs/archive_test.go
+++ b/go/store/nbs/archive_test.go
@@ -540,7 +540,7 @@ func TestArchiveChunkGroup(t *testing.T) {
 	cg, err := newChunkGroup(context.TODO(), cache, hs, defDict, &stats)
 	require.NoError(t, err)
 	assertFloatBetween(t, cg.totalRatioWDict, 0.86, 0.87)
-	assertIntBetween(t, cg.totalBytesSavedWDict, 8690, 8710)
+	assertIntBetween(t, cg.totalBytesSavedWDict, 8690, 8720)
 	assertIntBetween(t, cg.avgRawChunkSize, 1004, 1005)
 
 	unsimilar := generateRandomChunk(23, 980) // 20 bytes shorter to effect the average size.

--- a/go/store/nbs/archive_writer.go
+++ b/go/store/nbs/archive_writer.go
@@ -105,7 +105,7 @@ func (aw *archiveWriter) writeByteSpan(b []byte) (uint32, error) {
 	}
 
 	if len(b) == 0 {
-		return 0, nil
+		return 0, fmt.Errorf("Rutime error: empty compressed byte span")
 	}
 
 	offset := aw.bytesWritten

--- a/integration-tests/bats/shallow-clone.bats
+++ b/integration-tests/bats/shallow-clone.bats
@@ -28,7 +28,7 @@ stop_remotesrv() {
 
 # serial repository is 7 commits:
 # (init) <- (table create) <- (val 1) <- (val 2) <- (val 3) <- (val 4) <- (val 5) [main]
-seed_and_start_serial_remote() {
+seed_local_remote() {
     mkdir remote
     cd remote
     dolt init
@@ -42,6 +42,13 @@ seed_and_start_serial_remote() {
     done
 
     dolt tag nonheadtag HEAD~2
+    cd ..
+}
+
+
+seed_and_start_serial_remote() {
+    seed_local_remote
+    cd remote
 
     remotesrv --http-port 1234 --repo-mode &
     remotesrv_pid=$!
@@ -94,8 +101,7 @@ seed_and_start_serial_remote() {
 }
 
 @test "shallow-clone: shallow clone with a file path" {
-    seed_and_start_serial_remote
-    stop_remotesrv
+    seed_local_remote
     cd remote
     dolt remote add origin file://../file-remote
     dolt push origin main


### PR DESCRIPTION
This change is long in coming. Several findings from building a large user database are incorporated here. Specifically:
* No longer storing all chunks in memory
* Cancellable process with `^C`
* Progress reporting for major stages of the build
* No chunk grouping by default, `--group-chunks` to enable. Pathological cgo dictionary building problem needs to be fixed before we enable by default.
* Writing a useful metadata json block with dolt version and origin table file ID.