### PR TITLE
support `STAGED` as commit hash

### DIFF
--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -343,7 +343,7 @@ func (db Database) getTableInsensitive(ctx *sql.Context, head *doltdb.Commit, ds
 		if err != nil {
 			return nil, false, err
 		}
-		dt, err := dtables.NewCommitDiffTable(ctx, db.Name(), suffix, db.ddb, ws.WorkingRoot(), ws.StagedRoot())
+		dt, err := dtables.NewCommitDiffTable(ctx, db.Name(), suffix, db.ddb, root, ws.StagedRoot())
 		if err != nil {
 			return nil, false, err
 		}

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -339,7 +339,11 @@ func (db Database) getTableInsensitive(ctx *sql.Context, head *doltdb.Commit, ds
 
 	case strings.HasPrefix(lwrName, doltdb.DoltCommitDiffTablePrefix):
 		suffix := tblName[len(doltdb.DoltCommitDiffTablePrefix):]
-		dt, err := dtables.NewCommitDiffTable(ctx, db.Name(), suffix, db.ddb, root)
+		ws, err := ds.WorkingSet(ctx, db.RevisionQualifiedName())
+		if err != nil {
+			return nil, false, err
+		}
+		dt, err := dtables.NewCommitDiffTable(ctx, db.Name(), suffix, db.ddb, ws.WorkingRoot(), ws.StagedRoot())
 		if err != nil {
 			return nil, false, err
 		}

--- a/go/libraries/doltcore/sqle/dtables/commit_diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/commit_diff_table.go
@@ -44,6 +44,7 @@ type CommitDiffTable struct {
 	joiner      *rowconv.Joiner
 	sqlSch      sql.PrimaryKeySchema
 	workingRoot doltdb.RootValue
+	stagedRoot  doltdb.RootValue
 	// toCommit and fromCommit are set via the
 	// sql.IndexAddressable interface
 	toCommit          string
@@ -56,7 +57,7 @@ var _ sql.Table = (*CommitDiffTable)(nil)
 var _ sql.IndexAddressable = (*CommitDiffTable)(nil)
 var _ sql.StatisticsTable = (*CommitDiffTable)(nil)
 
-func NewCommitDiffTable(ctx *sql.Context, dbName, tblName string, ddb *doltdb.DoltDB, root doltdb.RootValue) (sql.Table, error) {
+func NewCommitDiffTable(ctx *sql.Context, dbName, tblName string, ddb *doltdb.DoltDB, root, stagedRoot doltdb.RootValue) (sql.Table, error) {
 	diffTblName := doltdb.DoltCommitDiffTablePrefix + tblName
 
 	// TODO: schema
@@ -88,6 +89,7 @@ func NewCommitDiffTable(ctx *sql.Context, dbName, tblName string, ddb *doltdb.Do
 		name:         tblName,
 		ddb:          ddb,
 		workingRoot:  root,
+		stagedRoot:   stagedRoot,
 		joiner:       j,
 		sqlSch:       sqlSch,
 		targetSchema: sch,
@@ -260,8 +262,10 @@ func (itr *SliceOfPartitionsItr) Close(*sql.Context) error {
 func (dt *CommitDiffTable) rootValForHash(ctx *sql.Context, hashStr string) (doltdb.RootValue, string, *types.Timestamp, error) {
 	var root doltdb.RootValue
 	var commitTime *types.Timestamp
-	if strings.ToLower(hashStr) == "working" {
+	if strings.EqualFold(hashStr, doltdb.Working) {
 		root = dt.workingRoot
+	} else if strings.EqualFold(hashStr, doltdb.Staged) {
+		root = dt.stagedRoot
 	} else {
 		cs, err := doltdb.NewCommitSpec(hashStr)
 		if err != nil {

--- a/go/libraries/doltcore/sqle/dtables/commit_diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/commit_diff_table.go
@@ -57,11 +57,11 @@ var _ sql.Table = (*CommitDiffTable)(nil)
 var _ sql.IndexAddressable = (*CommitDiffTable)(nil)
 var _ sql.StatisticsTable = (*CommitDiffTable)(nil)
 
-func NewCommitDiffTable(ctx *sql.Context, dbName, tblName string, ddb *doltdb.DoltDB, root, stagedRoot doltdb.RootValue) (sql.Table, error) {
+func NewCommitDiffTable(ctx *sql.Context, dbName, tblName string, ddb *doltdb.DoltDB, wRoot, sRoot doltdb.RootValue) (sql.Table, error) {
 	diffTblName := doltdb.DoltCommitDiffTablePrefix + tblName
 
 	// TODO: schema
-	table, _, ok, err := doltdb.GetTableInsensitive(ctx, root, doltdb.TableName{Name: tblName})
+	table, _, ok, err := doltdb.GetTableInsensitive(ctx, wRoot, doltdb.TableName{Name: tblName})
 	if err != nil {
 		return nil, err
 	}
@@ -88,8 +88,8 @@ func NewCommitDiffTable(ctx *sql.Context, dbName, tblName string, ddb *doltdb.Do
 		dbName:       dbName,
 		name:         tblName,
 		ddb:          ddb,
-		workingRoot:  root,
-		stagedRoot:   stagedRoot,
+		workingRoot:  wRoot,
+		stagedRoot:   sRoot,
 		joiner:       j,
 		sqlSch:       sqlSch,
 		targetSchema: sch,

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -3622,14 +3622,14 @@ var UnscopedDiffSystemTableScriptTests = []queries.ScriptTest{
 				Expected: []sql.Row{},
 			},
 			{
-				Query:    "SELECT commit_hash, table_name FROM DOLT_DIFF WHERE commit_hash = 'WORKING'",
+				Query: "SELECT commit_hash, table_name FROM DOLT_DIFF WHERE commit_hash = 'WORKING'",
 				Expected: []sql.Row{
 					{"WORKING", "newRenamedEmptyTable"},
 					{"WORKING", "regularTable"},
 				},
 			},
 			{
-				Query:    "SELECT commit_hash, table_name FROM DOLT_DIFF WHERE commit_hash = 'STAGED'",
+				Query: "SELECT commit_hash, table_name FROM DOLT_DIFF WHERE commit_hash = 'STAGED'",
 				Expected: []sql.Row{
 					{"STAGED", "addedTable"},
 					{"STAGED", "droppedTable"},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -3622,6 +3622,20 @@ var UnscopedDiffSystemTableScriptTests = []queries.ScriptTest{
 				Expected: []sql.Row{},
 			},
 			{
+				Query:    "SELECT commit_hash, table_name FROM DOLT_DIFF WHERE commit_hash = 'WORKING'",
+				Expected: []sql.Row{
+					{"WORKING", "newRenamedEmptyTable"},
+					{"WORKING", "regularTable"},
+				},
+			},
+			{
+				Query:    "SELECT commit_hash, table_name FROM DOLT_DIFF WHERE commit_hash = 'STAGED'",
+				Expected: []sql.Row{
+					{"STAGED", "addedTable"},
+					{"STAGED", "droppedTable"},
+				},
+			},
+			{
 				Query: "SELECT commit_hash, table_name FROM DOLT_DIFF WHERE commit_hash <> @Commit1 AND commit_hash NOT IN ('STAGED') ORDER BY table_name;",
 				Expected: []sql.Row{
 					{"WORKING", "newRenamedEmptyTable"},
@@ -4859,6 +4873,44 @@ var CommitDiffSystemTableScriptTests = []queries.ScriptTest{
 				Expected: []sql.Row{
 					// TODO: Missing rows here see TestDiffSystemTable tests
 					{100, 101, nil, nil, "added"},
+				},
+			},
+		},
+	},
+	{
+		Name: "working and staged commits",
+		SetUpScript: []string{
+			"create table t (pk int primary key, c1 int, c2 int);",
+			"call dolt_commit('-Am', 'created table');",
+			"set @Commit0 = HASHOF('HEAD');",
+			"insert into t values (1, 2, 3);",
+			"call dolt_add('.');",
+			"insert into t values (4, 5, 6);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type FROM DOLT_COMMIT_DIFF_t WHERE TO_COMMIT='WORKING' and FROM_COMMIT=@Commit0;",
+				Expected: []sql.Row{
+					{1, 2, 3, nil, nil, nil, "added"},
+					{4, 5, 6, nil, nil, nil, "added"},
+				},
+			},
+			{
+				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type FROM DOLT_COMMIT_DIFF_t WHERE TO_COMMIT='STAGED' and FROM_COMMIT=@Commit0;",
+				Expected: []sql.Row{
+					{1, 2, 3, nil, nil, nil, "added"},
+				},
+			},
+			{
+				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type FROM DOLT_COMMIT_DIFF_t WHERE TO_COMMIT='WORKING' and FROM_COMMIT='STAGED';",
+				Expected: []sql.Row{
+					{4, 5, 6, nil, nil, nil, "added"},
+				},
+			},
+			{
+				Query: "SELECT to_pk, to_c1, to_c2, from_pk, from_c1, from_c2, diff_type FROM DOLT_COMMIT_DIFF_t WHERE TO_COMMIT='STAGED' and FROM_COMMIT='WORKING';",
+				Expected: []sql.Row{
+					{nil, nil, nil, 4, 5, 6, "removed"},
 				},
 			},
 		},

--- a/go/libraries/doltcore/sqle/history_table.go
+++ b/go/libraries/doltcore/sqle/history_table.go
@@ -133,9 +133,6 @@ func (ht *HistoryTable) LookupPartitions(ctx *sql.Context, lookup sql.IndexLooku
 		var commits []*doltdb.Commit
 		var metas []*datas.CommitMeta
 		for _, hs := range hs {
-			if hs == doltdb.Working {
-
-			}
 			h, ok := hash.MaybeParse(hs)
 			if !ok {
 				continue
@@ -246,8 +243,10 @@ func substituteWorkingHash(h hash.Hash, f []sql.Expression) []sql.Expression {
 		ret[i], _, _ = transform.Expr(e, func(e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 			switch e := e.(type) {
 			case *expression.Literal:
-				if e.Value() == doltdb.Working {
-					return expression.NewLiteral(h.String(), e.Type()), transform.NewTree, nil
+				if str, isStr := e.Value().(string); isStr {
+					if strings.EqualFold(str, doltdb.Working) || strings.EqualFold(str, doltdb.Staged) {
+						return expression.NewLiteral(h.String(), e.Type()), transform.NewTree, nil
+					}
 				}
 			default:
 			}


### PR DESCRIPTION
This PR adds support for `STAGED` as a commit_hash when filtering dolt diff system tables.

fixes for https://github.com/dolthub/dolt/issues/7978