### PR TITLE
[no-release-notes] Fix issue where `dolt diff` fails to display changes to database schema if database name begins or ends with A, B, D, E, S, T,  or _ (case sensitive)

### DIFF
--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -910,7 +910,7 @@ func getDatabaseInfoAtRef(queryist cli.Queryist, sqlCtx *sql.Context, tableName 
 func getDatabaseSchemaAtRef(queryist cli.Queryist, sqlCtx *sql.Context, tableName string, ref string) (string, error) {
 	var rows []sql.Row
 	// TODO: implement `show create database as of ...`
-	tableName = strings.Trim(tableName, diff.DBPrefix)
+	tableName = strings.TrimPrefix(tableName, diff.DBPrefix)
 	interpolatedQuery, err := dbr.InterpolateForDialect("SHOW CREATE DATABASE ?", []interface{}{dbr.I(tableName)}, dialect.MySQL)
 	if err != nil {
 		return "", fmt.Errorf("error interpolating query: %w", err)

--- a/integration-tests/bats/diff.bats
+++ b/integration-tests/bats/diff.bats
@@ -58,12 +58,14 @@ EOF
     run dolt diff -r sql
     [ "$status" -eq 0 ]
     [[ "$output" =~ "ALTER DATABASE \`colldb\` COLLATE='utf8mb4_spanish_ci';" ]] || false
+}
 
-    # regression test for dolt diff failing when database name starts or ends with any of the characters in __DATABASE__
-
-    cd ..
-    mv colldb COLLDB
+@test "diff: db collation diff regression test" {
+    dolt sql -q "create database COLLDB"
     cd COLLDB
+
+    dolt sql -q "alter database COLLDB collate utf8mb4_spanish_ci"
+    # regression test for dolt diff failing when database name starts or ends with any of the characters in __DATABASE__
 
     run dolt diff -r sql
     [ "$status" -eq 0 ]

--- a/integration-tests/bats/diff.bats
+++ b/integration-tests/bats/diff.bats
@@ -30,17 +30,17 @@ teardown() {
 
     run dolt diff
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "CREATE DATABASE `colldb`" ]] || false
+    [[ "$output" =~ 'CREATE DATABASE `colldb`' ]] || false
     [[ "$output" =~ "40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_spanish_ci" ]] || false
 
     run dolt diff --data
     [ "$status" -eq 0 ]
-    [[ ! "$output" =~ "CREATE DATABASE `colldb`" ]] || false
+    [[ ! "$output" =~ 'CREATE DATABASE `colldb`' ]] || false
     [[ ! "$output" =~ "40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_spanish_ci" ]] || false
 
     run dolt diff --schema
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "CREATE DATABASE `colldb`" ]] || false
+    [[ "$output" =~ 'CREATE DATABASE `colldb`' ]] || false
     [[ "$output" =~ "40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_spanish_ci" ]] || false
 
     run dolt diff --summary
@@ -58,6 +58,16 @@ EOF
     run dolt diff -r sql
     [ "$status" -eq 0 ]
     [[ "$output" =~ "ALTER DATABASE \`colldb\` COLLATE='utf8mb4_spanish_ci';" ]] || false
+
+    # regression test for dolt diff failing when database name starts or ends with any of the characters in __DATABASE__
+
+    cd ..
+    mv colldb COLLDB
+    cd COLLDB
+
+    run dolt diff -r sql
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "ALTER DATABASE \`COLLDB\` COLLATE='utf8mb4_spanish_ci';" ]] || false
 }
 
 @test "diff: row, line, in-place, context diff modes" {


### PR DESCRIPTION
This was discovered by running [`golangci-lint`](https://golangci-lint.run/), which returned the following check failure:

```
cmd/dolt/commands/diff.go:913:38: SA1024: cutset contains duplicate characters (staticcheck)
        tableName = strings.Trim(tableName, diff.DBPrefix)
```

Reproduction example:

```
> # correct behavior
> mkdir doltRepo
> cd doltRepo
> dolt init
> dolt sql -q "ALTER DATABASE doltRepo COLLATE latin1_swedish_ci;"
> dolt diff
diff --dolt a/__DATABASE__doltRepo b/__DATABASE__doltRepo
--- a/__DATABASE__doltRepo
+++ b/__DATABASE__doltRepo
+CREATE DATABASE `doltRepo` /*!40100 DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci */;

> # incorrect behavior
> cd ..
> mv doltRepo DoltRepo
> cd DoltRepo
> dolt diff
diff --dolt a/__DATABASE__DoltRepo b/__DATABASE__DoltRepo
--- a/__DATABASE__DoltRepo
+++ b/__DATABASE__DoltRepo
Primary key sets differ between revisions for table '__DATABASE__DoltRepo', skipping data diff
```

The culprit is this line in `diff.go`:

```go
tableName = strings.Trim(tableName, diff.DBPrefix)
```

`strings.Trim` does not remove a prefix. Rather, it removes every character from the start and end of the input string that matches a character in the second parameter. In this case, the second parameter is the constant string `__DATABASE__`, leading to all of these characters getting stripped from the table name.

We actually want to call `strings.TrimPrefix` instead.