### PR TITLE
Add support for visualizing prolly tree and blob messages in `dolt show`

### DIFF
--- a/go/store/prolly/tree/node.go
+++ b/go/store/prolly/tree/node.go
@@ -284,43 +284,7 @@ func OutputProllyNode(ctx context.Context, w io.Writer, node Node, ns NodeStore,
 // manner. Interior nodes have their child hash references spelled out, leaf nodes have value tuples delineated like
 // the keys
 func OutputProllyNodeBytes(w io.Writer, node Node) error {
-	for i := 0; i < int(node.count); i++ {
-		k := node.GetKey(i)
-		kt := val.Tuple(k)
-
-		w.Write([]byte("\n    { key: "))
-		for j := 0; j < kt.Count(); j++ {
-			if j > 0 {
-				w.Write([]byte(", "))
-			}
-
-			w.Write([]byte(hex.EncodeToString(kt.GetField(j))))
-		}
-
-		if node.IsLeaf() {
-			v := node.GetValue(i)
-			vt := val.Tuple(v)
-
-			w.Write([]byte(" value: "))
-			for j := 0; j < vt.Count(); j++ {
-				if j > 0 {
-					w.Write([]byte(", "))
-				}
-				w.Write([]byte(hex.EncodeToString(vt.GetField(j))))
-			}
-
-			w.Write([]byte(" }"))
-		} else {
-			ref := node.getAddress(i)
-
-			w.Write([]byte(" ref: #"))
-			w.Write([]byte(ref.String()))
-			w.Write([]byte(" }"))
-		}
-	}
-
-	w.Write([]byte("\n"))
-	return nil
+	return types.OutputProllyNodeBytes(w, node.msg)
 }
 
 func OutputAddressMapNode(w io.Writer, node Node) error {

--- a/go/store/types/serial_message.go
+++ b/go/store/types/serial_message.go
@@ -20,11 +20,12 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"github.com/dolthub/dolt/go/store/val"
 	"io"
 	"slices"
 	"strings"
 	"time"
+
+	"github.com/dolthub/dolt/go/store/val"
 
 	"github.com/dolthub/dolt/go/gen/fb/serial"
 	"github.com/dolthub/dolt/go/store/hash"

--- a/go/store/types/serial_message.go
+++ b/go/store/types/serial_message.go
@@ -298,10 +298,56 @@ func (sm SerialMessage) HumanReadableStringAtIndentationLevel(level int) string 
 		level -= 1
 		printWithIndendationLevel(level, ret, "}")
 		return ret.String()
+	case serial.BlobFileID:
+		ret := &strings.Builder{}
+		printWithIndendationLevel(level, ret, "{\n")
+		level++
+		_ = OutputBlobNodeBytes(ret, level, serial.Message(sm))
+		level -= 1
+		printWithIndendationLevel(level, ret, "}")
+		return ret.String()
 	default:
 
 		return fmt.Sprintf("SerialMessage (HumanReadableString not implemented), [%v]: %s", id, strings.ToUpper(hex.EncodeToString(sm)))
 	}
+}
+
+func OutputBlobNodeBytes(w *strings.Builder, indentationLevel int, msg serial.Message) error {
+	keys, values, treeLevel, count, err := message.UnpackFields(msg)
+	if err != nil {
+		return err
+	}
+	isLeaf := treeLevel == 0
+
+	if isLeaf {
+		printWithIndendationLevel(indentationLevel, w, "Blob - ")
+		w.Write(values.GetItem(0, msg))
+		w.WriteString("\n")
+		return nil
+	}
+
+	for i := 0; i < int(count); i++ {
+		k := keys.GetItem(i, msg)
+		kt := val.Tuple(k)
+
+		w.Write([]byte("\n    { key: "))
+		for j := 0; j < kt.Count(); j++ {
+			if j > 0 {
+				w.Write([]byte(", "))
+			}
+
+			w.Write([]byte(hex.EncodeToString(kt.GetField(j))))
+		}
+
+		ref := hash.New(values.GetItem(i, msg))
+
+		w.Write([]byte(" ref: #"))
+		w.Write([]byte(ref.String()))
+		w.Write([]byte(" }"))
+	}
+
+	w.Write([]byte("\n"))
+	return nil
 }
 
 func OutputProllyNodeBytes(w io.Writer, msg serial.Message) error {


### PR DESCRIPTION
This PR does a couple things:

1. `dolt show #address` can now display the internals of a ProllyTreeMap message (typically used for storing indexes). Previously, only `splunk`/`noms show` could do this.
2. Both `dolt show` and `splunk` can now display the contents of a Blob message.
3. If a ProllyTreeMap leaf node contains a value that is itself an address (example: the value of text and json columns), that value is shown as a human readable address, which can be fed back into `dolt show` or `splunk` to explore the whole tree.