### PR TITLE
When removing from a secondary index during merging, use the pre-merge ordinal mapping, not the merged mapping, to identify the secondary key to be removed.

### DIFF
--- a/go/libraries/doltcore/merge/merge_prolly_rows.go
+++ b/go/libraries/doltcore/merge/merge_prolly_rows.go
@@ -142,7 +142,7 @@ func mergeProllyTableData(ctx *sql.Context, tm *TableMerger, finalSch schema.Sch
 	if err != nil {
 		return nil, nil, err
 	}
-	sec, err := newSecondaryMerger(ctx, tm, valueMerger, finalSch, mergeInfo)
+	sec, err := newSecondaryMerger(ctx, tm, valueMerger, tm.leftSch, finalSch, mergeInfo)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1275,14 +1275,14 @@ type secondaryMerger struct {
 
 const secondaryMergerPendingSize = 650_000
 
-func newSecondaryMerger(ctx *sql.Context, tm *TableMerger, valueMerger *valueMerger, mergedSchema schema.Schema, mergeInfo MergeInfo) (*secondaryMerger, error) {
+func newSecondaryMerger(ctx *sql.Context, tm *TableMerger, valueMerger *valueMerger, leftSchema, mergedSchema schema.Schema, mergeInfo MergeInfo) (*secondaryMerger, error) {
 	ls, err := tm.leftTbl.GetIndexSet(ctx)
 	if err != nil {
 		return nil, err
 	}
 	// Use the mergedSchema to work with the secondary indexes, to pull out row data using the right
 	// pri_index -> sec_index mapping.
-	lm, err := GetMutableSecondaryIdxsWithPending(ctx, mergedSchema, tm.name, ls, secondaryMergerPendingSize)
+	lm, err := GetMutableSecondaryIdxsWithPending(ctx, leftSchema, mergedSchema, tm.name, ls, secondaryMergerPendingSize)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/merge/mutable_secondary_index.go
+++ b/go/libraries/doltcore/merge/mutable_secondary_index.go
@@ -147,12 +147,6 @@ func (m MutableSecondaryIdx) UpdateEntry(ctx context.Context, key, currValue, ne
 		return err
 	}
 
-	defer func() {
-		if r := recover(); r != nil {
-			currKey, err = m.leftBuilder.SecondaryKeyFromRow(ctx, key, currValue)
-			_ = currKey
-		}
-	}()
 	newKey, err := m.mergedBuilder.SecondaryKeyFromRow(ctx, key, newValue)
 	if err != nil {
 		return err

--- a/go/libraries/doltcore/merge/mutable_secondary_index.go
+++ b/go/libraries/doltcore/merge/mutable_secondary_index.go
@@ -16,6 +16,7 @@ package merge
 
 import (
 	"context"
+
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"

--- a/go/libraries/doltcore/merge/mutable_secondary_index.go
+++ b/go/libraries/doltcore/merge/mutable_secondary_index.go
@@ -16,7 +16,6 @@ package merge
 
 import (
 	"context"
-
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
@@ -27,7 +26,7 @@ import (
 )
 
 // GetMutableSecondaryIdxs returns a MutableSecondaryIdx for each secondary index in |indexes|.
-func GetMutableSecondaryIdxs(ctx *sql.Context, sch schema.Schema, tableName string, indexes durable.IndexSet) ([]MutableSecondaryIdx, error) {
+func GetMutableSecondaryIdxs(ctx *sql.Context, ourSch, sch schema.Schema, tableName string, indexes durable.IndexSet) ([]MutableSecondaryIdx, error) {
 	mods := make([]MutableSecondaryIdx, sch.Indexes().Count())
 	for i, index := range sch.Indexes().AllIndexes() {
 		idx, err := indexes.GetIndex(ctx, sch, nil, index.Name())
@@ -38,7 +37,7 @@ func GetMutableSecondaryIdxs(ctx *sql.Context, sch schema.Schema, tableName stri
 		if schema.IsKeyless(sch) {
 			m = prolly.ConvertToSecondaryKeylessIndex(m)
 		}
-		mods[i], err = NewMutableSecondaryIdx(ctx, m, sch, tableName, index)
+		mods[i], err = NewMutableSecondaryIdx(ctx, m, ourSch, sch, tableName, index)
 		if err != nil {
 			return nil, err
 		}
@@ -49,7 +48,7 @@ func GetMutableSecondaryIdxs(ctx *sql.Context, sch schema.Schema, tableName stri
 // GetMutableSecondaryIdxsWithPending returns a MutableSecondaryIdx for each secondary index in |indexes|. If an index
 // is listed in the given |sch|, but does not exist in the given |indexes|, then it is skipped. This is useful when
 // merging a schema that has a new index, but the index does not exist on the index set being modified.
-func GetMutableSecondaryIdxsWithPending(ctx *sql.Context, sch schema.Schema, tableName string, indexes durable.IndexSet, pendingSize int) ([]MutableSecondaryIdx, error) {
+func GetMutableSecondaryIdxsWithPending(ctx *sql.Context, ourSch, sch schema.Schema, tableName string, indexes durable.IndexSet, pendingSize int) ([]MutableSecondaryIdx, error) {
 	mods := make([]MutableSecondaryIdx, 0, sch.Indexes().Count())
 	for _, index := range sch.Indexes().AllIndexes() {
 
@@ -87,7 +86,7 @@ func GetMutableSecondaryIdxsWithPending(ctx *sql.Context, sch schema.Schema, tab
 		if schema.IsKeyless(sch) {
 			m = prolly.ConvertToSecondaryKeylessIndex(m)
 		}
-		newMutableSecondaryIdx, err := NewMutableSecondaryIdx(ctx, m, sch, tableName, index)
+		newMutableSecondaryIdx, err := NewMutableSecondaryIdx(ctx, m, ourSch, sch, tableName, index)
 		if err != nil {
 			return nil, err
 		}
@@ -102,29 +101,31 @@ func GetMutableSecondaryIdxsWithPending(ctx *sql.Context, sch schema.Schema, tab
 // provides the InsertEntry, UpdateEntry, and DeleteEntry functions which can be
 // used to modify the index based on a modification to corresponding primary row.
 type MutableSecondaryIdx struct {
-	Name    string
-	mut     *prolly.MutableMap
-	builder index.SecondaryKeyBuilder
+	Name                       string
+	mut                        *prolly.MutableMap
+	leftBuilder, mergedBuilder index.SecondaryKeyBuilder
 }
 
 // NewMutableSecondaryIdx returns a MutableSecondaryIdx. |m| is the secondary idx data.
-func NewMutableSecondaryIdx(ctx *sql.Context, idx prolly.Map, sch schema.Schema, tableName string, def schema.Index) (MutableSecondaryIdx, error) {
-	b, err := index.NewSecondaryKeyBuilder(ctx, tableName, sch, def, idx.KeyDesc(), idx.Pool(), idx.NodeStore())
+func NewMutableSecondaryIdx(ctx *sql.Context, idx prolly.Map, ourSch, mergedSch schema.Schema, tableName string, def schema.Index) (MutableSecondaryIdx, error) {
+	leftBuilder, err := index.NewSecondaryKeyBuilder(ctx, tableName, ourSch, def, idx.KeyDesc(), idx.Pool(), idx.NodeStore())
+	mergedBuilder, err := index.NewSecondaryKeyBuilder(ctx, tableName, mergedSch, def, idx.KeyDesc(), idx.Pool(), idx.NodeStore())
 	if err != nil {
 		return MutableSecondaryIdx{}, err
 	}
 
 	return MutableSecondaryIdx{
-		Name:    def.Name(),
-		mut:     idx.Mutate(),
-		builder: b,
+		Name:          def.Name(),
+		mut:           idx.Mutate(),
+		leftBuilder:   leftBuilder,
+		mergedBuilder: mergedBuilder,
 	}, nil
 }
 
 // InsertEntry inserts a secondary index entry given the key and new value
 // of the primary row.
 func (m MutableSecondaryIdx) InsertEntry(ctx context.Context, key, newValue val.Tuple) error {
-	newKey, err := m.builder.SecondaryKeyFromRow(ctx, key, newValue)
+	newKey, err := m.mergedBuilder.SecondaryKeyFromRow(ctx, key, newValue)
 	if err != nil {
 		return err
 	}
@@ -140,12 +141,18 @@ func (m MutableSecondaryIdx) InsertEntry(ctx context.Context, key, newValue val.
 // UpdateEntry modifies the corresponding secondary index entry given the key
 // and curr/new values of the primary row.
 func (m MutableSecondaryIdx) UpdateEntry(ctx context.Context, key, currValue, newValue val.Tuple) error {
-	currKey, err := m.builder.SecondaryKeyFromRow(ctx, key, currValue)
+	currKey, err := m.leftBuilder.SecondaryKeyFromRow(ctx, key, currValue)
 	if err != nil {
 		return err
 	}
 
-	newKey, err := m.builder.SecondaryKeyFromRow(ctx, key, newValue)
+	defer func() {
+		if r := recover(); r != nil {
+			currKey, err = m.leftBuilder.SecondaryKeyFromRow(ctx, key, currValue)
+			_ = currKey
+		}
+	}()
+	newKey, err := m.mergedBuilder.SecondaryKeyFromRow(ctx, key, newValue)
 	if err != nil {
 		return err
 	}
@@ -159,7 +166,7 @@ func (m MutableSecondaryIdx) UpdateEntry(ctx context.Context, key, currValue, ne
 
 // DeleteEntry deletes a secondary index entry given they key and value of the primary row.
 func (m MutableSecondaryIdx) DeleteEntry(ctx context.Context, key val.Tuple, value val.Tuple) error {
-	currKey, err := m.builder.SecondaryKeyFromRow(ctx, key, value)
+	currKey, err := m.leftBuilder.SecondaryKeyFromRow(ctx, key, value)
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/merge/schema_merge_test.go
+++ b/go/libraries/doltcore/merge/schema_merge_test.go
@@ -1083,6 +1083,20 @@ var secondaryIndexTests = []schemaMergeTest{
 		skipOldFmt:          true,
 		skipFlipOnOldFormat: true,
 	},
+	{
+		name:     "dropping column on right shifts column index between compatible types (see pr/8154)",
+		ancestor: *tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, b char(20), c char(20), INDEX(c))"), row(1, 1, "2", "3")),
+		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, b char(20), c char(20), INDEX (c))"), row(1, 2, "2", "3")),
+		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, c char(20), INDEX (c))"), row(1, 1, "4")),
+		merged:   *tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, c char(20), INDEX (c))"), row(1, 2, "4")),
+	},
+	{
+		name:     "dropping column on right shifts column index between incompatible types (see pr/8154)",
+		ancestor: *tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, b tinyint, c int, INDEX(c))"), row(1, 1, 2, 3)),
+		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, b tinyint, c int, INDEX (c))"), row(1, 2, 2, 3)),
+		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, c int, INDEX (c))"), row(1, 1, 4)),
+		merged:   *tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, c int, INDEX (c))"), row(1, 2, 4)),
+	},
 }
 
 var simpleConflictTests = []schemaMergeTest{

--- a/go/libraries/doltcore/merge/schema_merge_test.go
+++ b/go/libraries/doltcore/merge/schema_merge_test.go
@@ -1084,13 +1084,6 @@ var secondaryIndexTests = []schemaMergeTest{
 		skipFlipOnOldFormat: true,
 	},
 	{
-		name:     "dropping column on right shifts column index between compatible types (see pr/8154)",
-		ancestor: *tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, b char(20), c char(20), INDEX(c))"), row(1, 1, "2", "3")),
-		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, b char(20), c char(20), INDEX (c))"), row(1, 2, "2", "3")),
-		right:    tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, c char(20), INDEX (c))"), row(1, 1, "4")),
-		merged:   *tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, c char(20), INDEX (c))"), row(1, 2, "4")),
-	},
-	{
 		name:     "dropping column on right shifts column index between incompatible types (see pr/8154)",
 		ancestor: *tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, b tinyint, c int, INDEX(c))"), row(1, 1, 2, 3)),
 		left:     tbl(sch("CREATE TABLE t (id int PRIMARY KEY, a int, b tinyint, c int, INDEX (c))"), row(1, 2, 2, 3)),

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_conflicts_resolve.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_conflicts_resolve.go
@@ -75,7 +75,7 @@ func getProllyRowMaps(ctx *sql.Context, vrw types.ValueReadWriter, ns tree.NodeS
 	return durable.ProllyMapFromIndex(idx), nil
 }
 
-func resolveProllyConflicts(ctx *sql.Context, tbl *doltdb.Table, tblName string, sch schema.Schema) (*doltdb.Table, error) {
+func resolveProllyConflicts(ctx *sql.Context, tbl *doltdb.Table, tblName string, ourSch, sch schema.Schema) (*doltdb.Table, error) {
 	var err error
 	artifactIdx, err := tbl.GetArtifacts(ctx)
 	if err != nil {
@@ -101,7 +101,7 @@ func resolveProllyConflicts(ctx *sql.Context, tbl *doltdb.Table, tblName string,
 	if err != nil {
 		return nil, err
 	}
-	mutIdxs, err := merge.GetMutableSecondaryIdxs(ctx, sch, tblName, idxSet)
+	mutIdxs, err := merge.GetMutableSecondaryIdxs(ctx, ourSch, sch, tblName, idxSet)
 	if err != nil {
 		return nil, err
 	}
@@ -432,7 +432,7 @@ func ResolveDataConflicts(ctx *sql.Context, dSess *dsess.DoltSession, root doltd
 
 		if !ours {
 			if tbl.Format() == types.Format_DOLT {
-				tbl, err = resolveProllyConflicts(ctx, tbl, tblName, sch)
+				tbl, err = resolveProllyConflicts(ctx, tbl, tblName, ourSch, sch)
 			} else {
 				state, _, err := dSess.LookupDbState(ctx, dbName)
 				if err != nil {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
@@ -4353,10 +4353,8 @@ var GeneratedColumnMergeTestScripts = []queries.ScriptTest{
 // This enables us to test merges in both directions, since the merge code is asymmetric and some code paths currently
 // only run on the left side of the merge.
 func convertMergeScriptTest(mst MergeScriptTest, flipSides bool) queries.ScriptTest {
-	setupScript := make([]string, 100)
-
 	// Ancestor setup
-	setupScript = append(setupScript, mst.AncSetUpScript...)
+	setupScript := mst.AncSetUpScript
 	setupScript = append(setupScript, "CALL DOLT_COMMIT('-Am', 'ancestor commit');")
 	setupScript = append(setupScript, "CALL DOLT_BRANCH('right');")
 

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_schema_merge.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_schema_merge.go
@@ -1961,6 +1961,27 @@ var SchemaChangeTestsSchemaConflicts = []MergeScriptTest{
 			},
 		},
 	},
+	{
+		Name: "dropping column on right shifts column index between compatible types",
+		AncSetUpScript: []string{
+			"set @@autocommit=0;",
+			"CREATE TABLE t (id int PRIMARY KEY, a int, b char(20), c char(20), INDEX(c));",
+			`INSERT INTO t VALUES (1, 1, "2", "3")`,
+		},
+		RightSetUpScript: []string{
+			"ALTER TABLE t DROP COLUMN b;",
+			`UPDATE t SET c = "4";`,
+		},
+		LeftSetUpScript: []string{
+			"UPDATE t SET a = 2;",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "call dolt_merge('right');",
+				Expected: []sql.Row{{doltCommit, 0, 0, "merge successful"}},
+			},
+		},
+	},
 
 	// Unsupported automatic merge cases
 	{


### PR DESCRIPTION
Basically, we have a bug where dropping a column on the remote side of a merge can interfere with updating secondary indexes.

Example:

Base Schema: (pk INT PRIMARY KEY, a TINYINT, b INT, UNIQUE KEY b_idx (b))

"theirs" drops column a

Merged Schema: (pk INT PRIMARY KEY, b INT, UNIQUE KEY b_idx (b))

In effect, the merger would see that in the final table, `b` is the second column. Then, when updating `b_idx` for each resolved row, it would use the second column of "ours" to find the index entry to remove. But this is incorrect, because the second column of "ours" is `a`.

If the user is lucky, these two columns will be different sizes and the merger will panic. But if the two columns are the same size, merge proceeds with an incorrect value. This will cause it to either fail to remove the old row from the secondary index, or remove a different row. Either way, the secondary index is now incorrect.
