### PR TITLE
Bug fix: loading persisted `@@server_id` from config.json

### DIFF
--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_alltypes_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_alltypes_test.go
@@ -28,7 +28,7 @@ import (
 // data types can be successfully replicated.
 func TestBinlogReplicationForAllTypes(t *testing.T) {
 	defer teardown(t)
-	startSqlServers(t)
+	startSqlServersWithDoltSystemVars(t, doltReplicaSystemVars)
 	startReplication(t, mySqlPort)
 
 	// Set the session's timezone to UTC, to avoid TIMESTAMP test values changing

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_filters_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_filters_test.go
@@ -25,7 +25,7 @@ import (
 // filtering option is correctly applied and honored.
 func TestBinlogReplicationFilters_ignoreTablesOnly(t *testing.T) {
 	defer teardown(t)
-	startSqlServers(t)
+	startSqlServersWithDoltSystemVars(t, doltReplicaSystemVars)
 	startReplication(t, mySqlPort)
 
 	// Ignore replication events for db01.t2. Also tests that the first filter setting is overwritten by
@@ -76,7 +76,7 @@ func TestBinlogReplicationFilters_ignoreTablesOnly(t *testing.T) {
 // filtering option is correctly applied and honored.
 func TestBinlogReplicationFilters_doTablesOnly(t *testing.T) {
 	defer teardown(t)
-	startSqlServers(t)
+	startSqlServersWithDoltSystemVars(t, doltReplicaSystemVars)
 	startReplication(t, mySqlPort)
 
 	// Do replication events for db01.t1. Also tests that the first filter setting is overwritten by
@@ -127,7 +127,7 @@ func TestBinlogReplicationFilters_doTablesOnly(t *testing.T) {
 // replication filtering options are correctly applied and honored when used together.
 func TestBinlogReplicationFilters_doTablesAndIgnoreTables(t *testing.T) {
 	defer teardown(t)
-	startSqlServers(t)
+	startSqlServersWithDoltSystemVars(t, doltReplicaSystemVars)
 	startReplication(t, mySqlPort)
 
 	// Do replication events for db01.t1, and db01.t2

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_multidb_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_multidb_test.go
@@ -24,7 +24,7 @@ import (
 // applied by a replica.
 func TestBinlogReplicationMultiDb(t *testing.T) {
 	defer teardown(t)
-	startSqlServers(t)
+	startSqlServersWithDoltSystemVars(t, doltReplicaSystemVars)
 	startReplication(t, mySqlPort)
 
 	// Make changes on the primary to db01 and db02
@@ -126,7 +126,7 @@ func TestBinlogReplicationMultiDb(t *testing.T) {
 // multiple DBs are applied correctly to a replica.
 func TestBinlogReplicationMultiDbTransactions(t *testing.T) {
 	defer teardown(t)
-	startSqlServers(t)
+	startSqlServersWithDoltSystemVars(t, doltReplicaSystemVars)
 	startReplication(t, mySqlPort)
 
 	// Make changes on the primary to db01 and db02

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_reconnect_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_reconnect_test.go
@@ -36,7 +36,7 @@ var proxyPort int
 // reestablished if it drops.
 func TestBinlogReplicationAutoReconnect(t *testing.T) {
 	defer teardown(t)
-	startSqlServers(t)
+	startSqlServersWithDoltSystemVars(t, doltReplicaSystemVars)
 	configureToxiProxy(t)
 	configureFastConnectionRetry(t)
 	startReplication(t, proxyPort)

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_restart_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_restart_test.go
@@ -26,7 +26,7 @@ import (
 // server process can be restarted and replica can be restarted without problems.
 func TestBinlogReplicationServerRestart(t *testing.T) {
 	defer teardown(t)
-	startSqlServers(t)
+	startSqlServersWithDoltSystemVars(t, doltReplicaSystemVars)
 	startReplication(t, mySqlPort)
 
 	primaryDatabase.MustExec("create table t (pk int auto_increment primary key)")


### PR DESCRIPTION
This fixes binlog replicas loading `@@server_id` values persisted in config.json so that they are properly converted from strings to the right type.

Also added extra connection error logging