### PR TITLE
archive guard rails

### DIFF
--- a/go/cmd/dolt/commands/admin/archive.go
+++ b/go/cmd/dolt/commands/admin/archive.go
@@ -92,11 +92,25 @@ func (cmd ArchiveCmd) Exec(ctx context.Context, commandStr string, args []string
 		return 1
 	}
 
+	storageMetadata, err := env.GetMultiEnvStorageMetadata(dEnv.FS)
+	if err != nil {
+		cli.PrintErrln(err)
+		return 1
+	}
+	if len(storageMetadata) != 1 {
+		cli.PrintErrln("Runtime error: Multiple databases found where one expected")
+		return 1
+	}
+	var ourDbMD nbs.StorageMetadata
+	for _, md := range storageMetadata {
+		ourDbMD = md
+	}
+
 	progress := make(chan interface{}, 32)
 	handleProgress(ctx, progress)
 
 	if apr.Contains(revertFlag) {
-		err := nbs.UnArchive(ctx, cs, progress)
+		err := nbs.UnArchive(ctx, cs, ourDbMD, progress)
 		if err != nil {
 			cli.PrintErrln(err)
 			return 1

--- a/go/cmd/dolt/commands/backup.go
+++ b/go/cmd/dolt/commands/backup.go
@@ -267,6 +267,14 @@ func syncBackup(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.ArgParseR
 }
 
 func backup(ctx context.Context, dEnv *env.DoltEnv, b env.Remote) errhand.VerboseError {
+	metadata, err := env.GetMultiEnvStorageMetadata(dEnv.FS)
+	if err != nil {
+		return nil
+	}
+	if metadata.ArchiveFilesPresent() {
+		return errhand.BuildDError("error: archive files present. Please revert them with the --revert flag before running this command.").Build()
+	}
+
 	destDb, err := b.GetRemoteDB(ctx, dEnv.DoltDB.ValueReadWriter().Format(), dEnv)
 	if err != nil {
 		return errhand.BuildDError("error: unable to open destination.").AddCause(err).Build()

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -95,6 +95,10 @@ type DoltEnv struct {
 	UserPassConfig *creds.DoltCredsForPass
 }
 
+// IncompleteEnv returns a DoltEnv that is incomplete. There are cases where we want to know that the structure
+// of and database is correct on disk, but don't want to actually load the database.
+//
+// Callers of this method should not expect the returned DoltEnv to be useful as a database for running queries.
 func IncompleteEnv(FS filesys.Filesys) *DoltEnv {
 	return &DoltEnv{
 		Version:     doltversion.Version,

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -23,9 +23,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dolthub/dolt/go/cmd/dolt/doltversion"
 	goerrors "gopkg.in/src-d/go-errors.v1"
 
+	"github.com/dolthub/dolt/go/cmd/dolt/doltversion"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	"github.com/dolthub/dolt/go/libraries/doltcore/creds"
 	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dolthub/dolt/go/cmd/dolt/doltversion"
 	goerrors "gopkg.in/src-d/go-errors.v1"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
@@ -92,6 +93,19 @@ type DoltEnv struct {
 	hdp    HomeDirProvider
 
 	UserPassConfig *creds.DoltCredsForPass
+}
+
+func IncompleteEnv(FS filesys.Filesys) *DoltEnv {
+	return &DoltEnv{
+		Version:     doltversion.Version,
+		Config:      nil,
+		RepoState:   nil,
+		RSLoadErr:   nil,
+		DoltDB:      nil,
+		DBLoadError: nil,
+		FS:          FS,
+		urlStr:      "",
+	}
 }
 
 func (dEnv *DoltEnv) GetRemoteDB(ctx context.Context, format *types.NomsBinFormat, r Remote, withCaching bool) (*doltdb.DoltDB, error) {

--- a/go/libraries/doltcore/env/multi_repo_env.go
+++ b/go/libraries/doltcore/env/multi_repo_env.go
@@ -66,7 +66,6 @@ func (sms StorageMetadataMap) ArchiveFilesPresent() bool {
 }
 
 func GetMultiEnvStorageMetadata(dataDirFS filesys.Filesys) (StorageMetadataMap, error) {
-
 	dbMap := make(map[string]filesys.Filesys)
 
 	path, err := dataDirFS.Abs("")

--- a/go/libraries/doltcore/env/multi_repo_env.go
+++ b/go/libraries/doltcore/env/multi_repo_env.go
@@ -54,6 +54,8 @@ type MultiRepoEnv struct {
 	dialProvider dbfactory.GRPCDialProvider
 }
 
+// StorageMetadataMap is a map of table file and archive paths to their metadata. It is used to surface specific
+// information about the storage of a database without loading the storage files themselves.
 type StorageMetadataMap map[string]nbs.StorageMetadata
 
 func (sms StorageMetadataMap) ArchiveFilesPresent() bool {
@@ -84,16 +86,17 @@ func GetMultiEnvStorageMetadata(dataDirFS filesys.Filesys) (StorageMetadataMap, 
 
 		dir := filepath.Base(path)
 
-		newFs, er2 := dataDirFS.WithWorkingDir(dir)
-		if er2 != nil {
+		newFs, err := dataDirFS.WithWorkingDir(dir)
+		if err != nil {
 			return false
 		}
-		path, er2 = newFs.Abs("")
-		if er2 != nil {
+		path, err = newFs.Abs("")
+		if err != nil {
 			return false
 		}
 		envName := getRepoRootDir(path, string(os.PathSeparator))
 
+		// For an incomplete environment, the .Valid() check basically just checks if there is a .dolt directory.
 		falseEnv := IncompleteEnv(newFs)
 		if !falseEnv.Valid() {
 			return false

--- a/go/libraries/doltcore/env/multi_repo_env.go
+++ b/go/libraries/doltcore/env/multi_repo_env.go
@@ -22,7 +22,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/dolthub/dolt/go/store/nbs"
 	"github.com/sirupsen/logrus"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
@@ -30,6 +29,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/utils/config"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/libraries/utils/set"
+	"github.com/dolthub/dolt/go/store/nbs"
 	"github.com/dolthub/dolt/go/store/types"
 )
 

--- a/go/libraries/doltcore/remotesrv/server.go
+++ b/go/libraries/doltcore/remotesrv/server.go
@@ -85,7 +85,7 @@ func NewServer(args ServerArgs) (*Server, error) {
 		return nil, err
 	}
 	if storageMetadata.ArchiveFilesPresent() {
-		return nil, errors.New("archive files present")
+		return nil, errors.New("archive files present. Please run `dolt archive --revert` before running the server.")
 	}
 
 	s := new(Server)

--- a/go/libraries/doltcore/remotesrv/server.go
+++ b/go/libraries/doltcore/remotesrv/server.go
@@ -23,13 +23,13 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
 
 	remotesapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/remotesapi/v1alpha1"
+	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 )
 

--- a/go/libraries/doltcore/sqle/remotesrv.go
+++ b/go/libraries/doltcore/sqle/remotesrv.go
@@ -33,7 +33,7 @@ type remotesrvStore struct {
 
 var _ remotesrv.DBCache = remotesrvStore{}
 
-func (s remotesrvStore) Get(ctx context.Context, path, nbfVerStr string) (remotesrv.RemoteSrvStore, error) {
+func (s remotesrvStore) Get(ctx context.Context, path, _ string) (remotesrv.RemoteSrvStore, error) {
 	sqlCtx, err := s.ctxFactory(ctx)
 	if err != nil {
 		return nil, err

--- a/go/store/nbs/archive_build.go
+++ b/go/store/nbs/archive_build.go
@@ -73,7 +73,7 @@ func UnArchive(ctx context.Context, cs chunks.ChunkStore, smd StorageMetadata, p
 							return err
 						}
 
-						progress <- fmt.Sprintf("UnArchiving %s (bytes: %d)", chk.Hash().String(), len(chk.Data()))
+						progress <- fmt.Sprintf("Unarchiving %s (bytes: %d)", chk.Hash().String(), len(chk.Data()))
 						return nil
 					})
 					if err != nil {

--- a/go/store/nbs/archive_build.go
+++ b/go/store/nbs/archive_build.go
@@ -115,7 +115,9 @@ func BuildArchive(ctx context.Context, cs chunks.ChunkStore, dagGroups *ChunkRel
 		swapMap := make(map[hash.Hash]hash.Hash)
 
 		for tf, ogcs := range oldgen {
-			// NM4 - We should probably provide a way to pick a particular table file to build an archive for.
+			if _, ok := ogcs.(archiveChunkSource); ok {
+				continue
+			}
 
 			idx, err := ogcs.index()
 			if err != nil {

--- a/go/store/nbs/archive_build.go
+++ b/go/store/nbs/archive_build.go
@@ -52,7 +52,7 @@ func UnArchive(ctx context.Context, cs chunks.ChunkStore, smd StorageMetadata, p
 		for id, ogcs := range oldgen {
 			if arc, ok := ogcs.(archiveChunkSource); ok {
 				orginTfId := revertMap[id]
-				exists, err := smd.LoseOldGenTableExists(orginTfId)
+				exists, err := smd.oldGenTableExists(orginTfId)
 				if err != nil {
 					return err
 				}

--- a/go/store/nbs/archive_build.go
+++ b/go/store/nbs/archive_build.go
@@ -137,6 +137,10 @@ func BuildArchive(ctx context.Context, cs chunks.ChunkStore, dagGroups *ChunkRel
 			swapMap[tf] = archiveName
 		}
 
+		if len(swapMap) == 0 {
+			return fmt.Errorf("No tables found to archive. Run 'dolt gc' first")
+		}
+
 		//NM4 TODO: This code path must only be run on an offline database. We should add a check for that.
 		specs, err := gs.oldGen.tables.toSpecs()
 		newSpecs := make([]tableSpec, 0, len(specs))

--- a/go/store/nbs/archive_chunk_source.go
+++ b/go/store/nbs/archive_chunk_source.go
@@ -92,6 +92,12 @@ func (acs archiveChunkSource) getMany(ctx context.Context, eg *errgroup.Group, r
 	return !foundAll, nil
 }
 
+// iterate iterates over the archive chunks. The callback is called for each chunk in the archive. This is not optimized
+// as currently is it only used for un-archiving, which should be uncommon.
+func (acs archiveChunkSource) iterate(ctx context.Context, cb func(chunks.Chunk) error) error {
+	return acs.aRdr.iterate(ctx, cb)
+}
+
 func (acs archiveChunkSource) count() (uint32, error) {
 	return acs.aRdr.count(), nil
 }

--- a/go/store/nbs/archive_reader.go
+++ b/go/store/nbs/archive_reader.go
@@ -23,10 +23,10 @@ import (
 	"io"
 	"math/bits"
 
-	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/gozstd"
 	lru "github.com/hashicorp/golang-lru/v2"
 
+	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
 )
 

--- a/go/store/nbs/archive_reader.go
+++ b/go/store/nbs/archive_reader.go
@@ -157,6 +157,20 @@ func newArchiveReader(reader io.ReaderAt, fileSize uint64) (archiveReader, error
 	}, nil
 }
 
+// clone returns a new archiveReader with a new (provided) reader. All other fields are immutable or thread safe,
+// so they are copied.
+func (ar archiveReader) clone(newReader io.ReaderAt) archiveReader {
+	return archiveReader{
+		reader:    newReader,
+		prefixes:  ar.prefixes,
+		spanIndex: ar.spanIndex,
+		chunkRefs: ar.chunkRefs,
+		suffixes:  ar.suffixes,
+		footer:    ar.footer,
+		dictCache: ar.dictCache, // cache is thread safe.
+	}
+}
+
 func loadFooter(reader io.ReaderAt, fileSize uint64) (f footer, err error) {
 	section := io.NewSectionReader(reader, int64(fileSize-archiveFooterSize), int64(archiveFooterSize))
 

--- a/go/store/nbs/archive_reader.go
+++ b/go/store/nbs/archive_reader.go
@@ -15,12 +15,14 @@
 package nbs
 
 import (
+	"context"
 	"crypto/sha512"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"math/bits"
 
+	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/gozstd"
 	lru "github.com/hashicorp/golang-lru/v2"
 
@@ -195,30 +197,30 @@ func loadFooter(reader io.ReaderAt, fileSize uint64) (f footer, err error) {
 }
 
 // search returns the index of the hash in the archive. If the hash is not found, -1 is returned.
-func (ai archiveReader) search(hash hash.Hash) int {
+func (ar archiveReader) search(hash hash.Hash) int {
 	prefix := hash.Prefix()
-	possibleMatch := prollyBinSearch(ai.prefixes, prefix)
+	possibleMatch := prollyBinSearch(ar.prefixes, prefix)
 	targetSfx := hash.Suffix()
 
-	if possibleMatch < 0 || possibleMatch >= len(ai.prefixes) {
+	if possibleMatch < 0 || possibleMatch >= len(ar.prefixes) {
 		return -1
 	}
 
-	for idx := possibleMatch; idx < len(ai.prefixes) && ai.prefixes[idx] == prefix; idx++ {
-		if ai.getSuffixByID(uint32(idx)) == suffix(targetSfx) {
+	for idx := possibleMatch; idx < len(ar.prefixes) && ar.prefixes[idx] == prefix; idx++ {
+		if ar.getSuffixByID(uint32(idx)) == suffix(targetSfx) {
 			return idx
 		}
 	}
 	return -1
 }
 
-func (ai archiveReader) has(hash hash.Hash) bool {
-	return ai.search(hash) >= 0
+func (ar archiveReader) has(hash hash.Hash) bool {
+	return ar.search(hash) >= 0
 }
 
 // get returns the decompressed data for the given hash. If the hash is not found, nil is returned (not an error)
-func (ai archiveReader) get(hash hash.Hash) ([]byte, error) {
-	dict, data, err := ai.getRaw(hash)
+func (ar archiveReader) get(hash hash.Hash) ([]byte, error) {
+	dict, data, err := ar.getRaw(hash)
 	if err != nil || data == nil {
 		return nil, err
 	}
@@ -235,21 +237,21 @@ func (ai archiveReader) get(hash hash.Hash) ([]byte, error) {
 	return result, nil
 }
 
-func (ai archiveReader) count() uint32 {
-	return ai.footer.chunkCount
+func (ar archiveReader) count() uint32 {
+	return ar.footer.chunkCount
 }
 
-func (ai archiveReader) close() error {
-	if closer, ok := ai.reader.(io.Closer); ok {
+func (ar archiveReader) close() error {
+	if closer, ok := ar.reader.(io.Closer); ok {
 		return closer.Close()
 	}
 	return nil
 }
 
 // readByteSpan reads the byte span from the archive. This allocates a new byte slice and returns it to the caller.
-func (ai archiveReader) readByteSpan(bs byteSpan) ([]byte, error) {
+func (ar archiveReader) readByteSpan(bs byteSpan) ([]byte, error) {
 	buff := make([]byte, bs.length)
-	_, err := ai.reader.ReadAt(buff[:], int64(bs.offset))
+	_, err := ar.reader.ReadAt(buff[:], int64(bs.offset))
 	if err != nil {
 		return nil, err
 	}
@@ -260,19 +262,19 @@ func (ai archiveReader) readByteSpan(bs byteSpan) ([]byte, error) {
 // no error is returned in this case. Errors will only be returned if there is an io error.
 //
 // The data returned is still compressed, regardless of the dictionary being present or not.
-func (ai archiveReader) getRaw(hash hash.Hash) (dict *gozstd.DDict, data []byte, err error) {
-	idx := ai.search(hash)
+func (ar archiveReader) getRaw(hash hash.Hash) (dict *gozstd.DDict, data []byte, err error) {
+	idx := ar.search(hash)
 	if idx < 0 {
 		return nil, nil, nil
 	}
 
-	dictId, dataId := ai.getChunkRef(idx)
+	dictId, dataId := ar.getChunkRef(idx)
 	if dictId != 0 {
-		if cached, cacheHit := ai.dictCache.Get(dictId); cacheHit {
+		if cached, cacheHit := ar.dictCache.Get(dictId); cacheHit {
 			dict = cached
 		} else {
-			byteSpan := ai.getByteSpanByID(dictId)
-			dictBytes, err := ai.readByteSpan(byteSpan)
+			byteSpan := ar.getByteSpanByID(dictId)
+			dictBytes, err := ar.readByteSpan(byteSpan)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -287,12 +289,12 @@ func (ai archiveReader) getRaw(hash hash.Hash) (dict *gozstd.DDict, data []byte,
 				return nil, nil, e2
 			}
 
-			ai.dictCache.Add(dictId, dict)
+			ar.dictCache.Add(dictId, dict)
 		}
 	}
 
-	byteSpan := ai.getByteSpanByID(dataId)
-	data, err = ai.readByteSpan(byteSpan)
+	byteSpan := ar.getByteSpanByID(dataId)
+	data, err = ar.readByteSpan(byteSpan)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -300,47 +302,70 @@ func (ai archiveReader) getRaw(hash hash.Hash) (dict *gozstd.DDict, data []byte,
 }
 
 // getChunkRef returns the dictionary and data references for the chunk at the given index. Assumes good input!
-func (ai archiveReader) getChunkRef(idx int) (dict, data uint32) {
+func (ar archiveReader) getChunkRef(idx int) (dict, data uint32) {
 	// Chunk refs are stored as pairs of uint32s, so we need to double the index.
 	idx *= 2
-	return ai.chunkRefs[idx], ai.chunkRefs[idx+1]
+	return ar.chunkRefs[idx], ar.chunkRefs[idx+1]
 }
 
 // getByteSpanByID returns the byte span for the chunk at the given index. Assumes good input!
-func (ai archiveReader) getByteSpanByID(id uint32) byteSpan {
+func (ar archiveReader) getByteSpanByID(id uint32) byteSpan {
 	if id == 0 {
 		return byteSpan{}
 	}
 	// This works because byteOffSpan[0] == 0. See initialization.
-	offset := ai.spanIndex[id-1]
-	length := ai.spanIndex[id] - offset
+	offset := ar.spanIndex[id-1]
+	length := ar.spanIndex[id] - offset
 	return byteSpan{offset: offset, length: length}
 }
 
 // getSuffixByID returns the suffix for the chunk at the given index. Assumes good input!
-func (ai archiveReader) getSuffixByID(id uint32) suffix {
+func (ar archiveReader) getSuffixByID(id uint32) suffix {
 	start := id * hash.SuffixLen
-	return suffix(ai.suffixes[start : start+hash.SuffixLen])
+	return suffix(ar.suffixes[start : start+hash.SuffixLen])
 }
 
-func (ai archiveReader) getMetadata() ([]byte, error) {
-	return ai.readByteSpan(ai.footer.metadataSpan())
+func (ar archiveReader) getMetadata() ([]byte, error) {
+	return ar.readByteSpan(ar.footer.metadataSpan())
 }
 
 // verifyDataCheckSum verifies the checksum of the data section of the archive. Note - this requires a fully read of
 // the data section, which could be sizable.
-func (ai archiveReader) verifyDataCheckSum() error {
-	return verifyCheckSum(ai.reader, ai.footer.dataSpan(), ai.footer.dataCheckSum)
+func (ar archiveReader) verifyDataCheckSum() error {
+	return verifyCheckSum(ar.reader, ar.footer.dataSpan(), ar.footer.dataCheckSum)
 }
 
 // verifyIndexCheckSum verifies the checksum of the index section of the archive.
-func (ai archiveReader) verifyIndexCheckSum() error {
-	return verifyCheckSum(ai.reader, ai.footer.totalIndexSpan(), ai.footer.indexCheckSum)
+func (ar archiveReader) verifyIndexCheckSum() error {
+	return verifyCheckSum(ar.reader, ar.footer.totalIndexSpan(), ar.footer.indexCheckSum)
 }
 
 // verifyMetaCheckSum verifies the checksum of the metadata section of the archive.
-func (ai archiveReader) verifyMetaCheckSum() error {
-	return verifyCheckSum(ai.reader, ai.footer.metadataSpan(), ai.footer.metaCheckSum)
+func (ar archiveReader) verifyMetaCheckSum() error {
+	return verifyCheckSum(ar.reader, ar.footer.metadataSpan(), ar.footer.metaCheckSum)
+}
+
+func (ar archiveReader) iterate(ctx context.Context, cb func(chunks.Chunk) error) error {
+	for i := uint32(0); i < ar.footer.chunkCount; i++ {
+		var hasBytes [hash.ByteLen]byte
+
+		binary.BigEndian.PutUint64(hasBytes[:uint64Size], ar.prefixes[i])
+		suf := ar.getSuffixByID(i)
+		copy(hasBytes[hash.ByteLen-hash.SuffixLen:], suf[:])
+		h := hash.New(hasBytes[:])
+
+		data, err := ar.get(h)
+		if err != nil {
+			return err
+		}
+
+		chk := chunks.NewChunkWithHash(h, data)
+		err = cb(chk)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func verifyCheckSum(reader io.ReaderAt, span byteSpan, checkSum sha512Sum) error {

--- a/go/store/nbs/metadata.go
+++ b/go/store/nbs/metadata.go
@@ -117,7 +117,7 @@ func GetStorageMetadata(path string) (StorageMetadata, error) {
 	for i := 0; i < manifest.NumTableSpecs(); i++ {
 		tableSpecInfo := manifest.GetTableSpecInfo(i)
 
-		// If the oldgen/name exists, it's not an archive. If it doesn't exist with a .darc suffix, then it's an archive.
+		// If the oldgen/name exists, it's not an archive. If it exists with a .darc suffix, then it's an archive.
 		tfName := tableSpecInfo.GetName()
 		fullPath := filepath.Join(oldgen, tfName)
 		_, err := os.Stat(fullPath)

--- a/go/store/nbs/metadata.go
+++ b/go/store/nbs/metadata.go
@@ -68,7 +68,7 @@ func (sm *StorageMetadata) RevertMap() map[hash.Hash]hash.Hash {
 	return revertMap
 }
 
-func (sm *StorageMetadata) LoseOldGenTableExists(id hash.Hash) (bool, error) {
+func (sm *StorageMetadata) oldGenTableExists(id hash.Hash) (bool, error) {
 	path := filepath.Join(sm.root, ".dolt", "noms", "oldgen", id.String())
 	_, err := os.Stat(path)
 	if err != nil {

--- a/go/store/nbs/metadata.go
+++ b/go/store/nbs/metadata.go
@@ -1,0 +1,148 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package nbs
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/dolthub/dolt/go/libraries/utils/filesys"
+)
+
+type StorageType int
+
+const (
+	Journal StorageType = iota
+	TableFileNewGen
+	TableFileOldGen
+	Archive
+)
+
+type ArchiveMetadata struct {
+	originalTableFileId string
+}
+
+type StorageArtifact struct {
+	path        string
+	storageType StorageType
+	arcMetadata *ArchiveMetadata
+}
+
+type StorageMetadata struct {
+	artifacts []StorageArtifact
+}
+
+func (sm *StorageMetadata) ArchiveFilesPresent() bool {
+	for _, artifact := range sm.artifacts {
+		if artifact.storageType == Archive {
+			return true
+		}
+	}
+	return false
+}
+
+// GetStorageMetadata returns metadata about the local filesystem storage for a single database. The path given must be
+// the path to DB directory - ie, containing the .dolt directory.
+func GetStorageMetadata(path string) (StorageMetadata, error) {
+	err := validateDir(path)
+	if err != nil {
+		return StorageMetadata{}, err
+	}
+
+	//	newGen := filepath.Join(path, ".dolt", "noms")
+	//	newgenManifest := filepath.Join(newGen, "manifest")
+
+	oldgen := filepath.Join(path, ".dolt", "noms", "oldgen")
+	oldgenManifest := filepath.Join(oldgen, "manifest")
+
+	// create a io.Reader for the manifest file
+	manifestReader, err := os.Open(oldgenManifest)
+	if err != nil {
+		return StorageMetadata{}, err
+	}
+
+	manifest, err := ParseManifest(manifestReader)
+	if err != nil {
+		return StorageMetadata{}, err
+	}
+
+	var artifacts []StorageArtifact
+
+	// for each table in the manifest, get the table spec
+	for i := 0; i < manifest.NumTableSpecs(); i++ {
+		tableSpecInfo := manifest.GetTableSpecInfo(i)
+
+		// If the oldgen/name exists, it's not an archive. If it doesn't exist with a .darc suffix, then it's an archive.
+		tfName := tableSpecInfo.GetName()
+		fullPath := filepath.Join(oldgen, tfName)
+		_, err := os.Stat(fullPath)
+		if err == nil {
+			// exists.  Not an archive.
+			artifacts = append(artifacts, StorageArtifact{
+				path:        fullPath,
+				storageType: TableFileOldGen,
+			})
+		} else if os.IsNotExist(err) {
+			arcName := tfName + ".darc"
+			arcPath := filepath.Join(oldgen, arcName)
+			_, err := os.Stat(arcPath)
+			if err == nil {
+				// reader for the path. State. call
+				reader, fileSize, err := openReader(arcPath)
+				if err != nil {
+					return StorageMetadata{}, err
+				}
+
+				arcMetadata, err := newArchiveMetadata(reader, fileSize)
+				if err != nil {
+					return StorageMetadata{}, err
+				}
+
+				artifacts = append(artifacts, StorageArtifact{
+					path:        arcPath,
+					storageType: Archive,
+					arcMetadata: arcMetadata,
+				})
+			} else {
+				// any error is bad here. If the files don't exist, then the manifest is no good.
+				return StorageMetadata{}, err
+			}
+		} else {
+			// some other error.
+			return StorageMetadata{}, err
+		}
+	}
+
+	return StorageMetadata{artifacts}, nil
+}
+
+func validateDir(path string) error {
+	info, err := os.Stat(path)
+
+	if err != nil {
+		return err
+	} else if !info.IsDir() {
+		return filesys.ErrIsFile
+	}
+
+	return nil
+}

--- a/go/store/nbs/metadata.go
+++ b/go/store/nbs/metadata.go
@@ -11,13 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// This file incorporates work covered by the following copyright and
-// permission notice:
-//
-// Copyright 2016 Attic Labs, Inc. All rights reserved.
-// Licensed under the Apache License, version 2.0:
-// http://www.apache.org/licenses/LICENSE-2.0
 
 package nbs
 

--- a/integration-tests/bats/archive.bats
+++ b/integration-tests/bats/archive.bats
@@ -154,7 +154,7 @@ make_updates() {
 
 # This test runs over 45 seconds, resulting in a timeout in lambdabats
 # bats test_tags=no_lambda
-@test "archive: archive --reverse" {
+@test "archive: archive --revert" {
   # We need at least 25 chunks to create an archive.
   for ((j=1; j<=10; j++))
   do
@@ -163,10 +163,7 @@ make_updates() {
   done
   dolt gc
   dolt admin archive
-
-  dolt admin archive --reverse
-
-  # NM4 TODO: verify the darc files are gone.
+  dolt admin archive --revert
 
   # dolt log --stat will load every single chunk. 66 manually verified.
   commits=$(dolt log --stat --oneline | wc -l | sed 's/[ \t]//g')

--- a/integration-tests/bats/archive.bats
+++ b/integration-tests/bats/archive.bats
@@ -45,6 +45,12 @@ make_updates() {
   [[ "$output" =~ "Not enough samples to build default dictionary" ]] || false
 }
 
+@test "archive: require gc first" {
+  run dolt admin archive
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "Run 'dolt gc' first" ]] || false
+}
+
 # This test runs over 45 seconds, resulting in a timeout in lambdabats
 # bats test_tags=no_lambda
 @test "archive: single archive" {

--- a/integration-tests/bats/archive.bats
+++ b/integration-tests/bats/archive.bats
@@ -107,6 +107,8 @@ make_updates() {
   [ "$commits" -eq "186" ]
 }
 
+# This test runs over 45 seconds, resulting in a timeout in lambdabats
+# bats test_tags=no_lambda
 @test "archive: archive multiple times" {
   # We need at least 25 chunks to create an archive.
   for ((j=1; j<=10; j++))

--- a/integration-tests/bats/helper/local-remote.bash
+++ b/integration-tests/bats/helper/local-remote.bash
@@ -138,6 +138,7 @@ SKIP_SERVER_TESTS=$(cat <<-EOM
 ~ls.bats~
 ~rebase.bats~
 ~shallow-clone.bats~
+~archive.bats~
 EOM
 )
 


### PR DESCRIPTION
Add features to ensure that archive files are not used when running a remotesrv or when pushing backups.

Also provide the `--revert` flag which can return a database back to the classic format.