### PR TITLE
go/libraries/doltcore/env/actions: Improve error message when a clone fails mid-download.

### DIFF
--- a/go/libraries/doltcore/env/actions/clone.go
+++ b/go/libraries/doltcore/env/actions/clone.go
@@ -261,6 +261,10 @@ func fullClone(ctx context.Context, srcDB *doltdb.DoltDB, dEnv *env.DoltEnv, src
 	close(eventCh)
 	wg.Wait()
 
+	if err != nil {
+		return nil, err
+	}
+
 	cs, _ := doltdb.NewCommitSpec(branch)
 	optCmt, err := dEnv.DoltDB.Resolve(ctx, cs, nil)
 	if err != nil {


### PR DESCRIPTION
Fixes a dropped error return in the clone implementation.