### PR TITLE
Feature: Auto-start binlog replication on server restart

### DIFF
--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -334,6 +334,7 @@ func configureBinlogReplicaController(config *SqlEngineConfig, engine *gms.Engin
 		return err
 	}
 	dblr.DoltBinlogReplicaController.SetExecutionContext(executionCtx)
+	dblr.DoltBinlogReplicaController.SetEngine(engine)
 	engine.Analyzer.Catalog.BinlogReplicaController = config.BinlogReplicaController
 
 	return nil

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -648,6 +648,17 @@ func ConfigureServices(
 	}
 	controller.Register(InitSQLServer)
 
+	AutoStartBinlogReplica := &svcs.AnonService{
+		InitF: func(ctx context.Context) error {
+			err := binlogreplication.DoltBinlogReplicaController.AutoStartIfEnabled(ctx)
+			if err != nil {
+				logrus.Errorf("unable to restart replication: %s", err.Error())
+			}
+			return nil
+		},
+	}
+	controller.Register(AutoStartBinlogReplica)
+
 	RunClusterController := &svcs.AnonService{
 		InitF: func(context.Context) error {
 			if clusterController == nil {

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -648,10 +648,11 @@ func ConfigureServices(
 	}
 	controller.Register(InitSQLServer)
 
+	// Automatically restart binlog replication if replication was enabled when the server was last shut down
 	AutoStartBinlogReplica := &svcs.AnonService{
 		InitF: func(ctx context.Context) error {
-			err := binlogreplication.DoltBinlogReplicaController.AutoStartIfEnabled(ctx)
-			if err != nil {
+			// If we're unable to restart replication, log an error, but don't prevent the server from starting up
+			if err := binlogreplication.DoltBinlogReplicaController.AutoStart(ctx); err != nil {
 				logrus.Errorf("unable to restart replication: %s", err.Error())
 			}
 			return nil

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_metadata_persistence.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_metadata_persistence.go
@@ -73,11 +73,12 @@ func persistReplicaRunningState(ctx *sql.Context, state replicaRunningState) err
 	doltSession := dsess.DSessFromSess(ctx.Session)
 	filesys := doltSession.Provider().FileSystem()
 
-	// TODO: Do we need to create this dir if it doesn't exist?
-	//       Could reuse code from binlogPositionStore if so.
-	//filesys.Exists(replicationRunningStateDirectory)
+	// The .doltcfg dir may not exist yet, so create it if necessary.
+	err := createDoltCfgDir(filesys)
+	if err != nil {
+		return err
+	}
 
-	// TODO: a helper function could create this path?
 	replicationRunningStateFilepath, err := filesys.Abs(
 		filepath.Join(replicationRunningStateDirectory, replicaRunningFilename))
 	if err != nil {

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_position_store.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_position_store.go
@@ -102,14 +102,8 @@ func (store *binlogPositionStore) Save(ctx *sql.Context, position *mysql.Positio
 	filesys := doltSession.Provider().FileSystem()
 
 	// The .doltcfg dir may not exist yet, so create it if necessary.
-	exists, isDir := filesys.Exists(binlogPositionDirectory)
-	if !exists {
-		err := filesys.MkDirs(binlogPositionDirectory)
-		if err != nil {
-			return fmt.Errorf("unable to save binlog position: %s", err)
-		}
-	} else if !isDir {
-		return fmt.Errorf("unable to save binlog position: %s exists as a file, not a dir", binlogPositionDirectory)
+	if err := createDoltCfgDir(filesys); err != nil {
+		return err
 	}
 
 	filePath, err := filesys.Abs(filepath.Join(binlogPositionDirectory, binlogPositionFilename))
@@ -132,4 +126,19 @@ func (store *binlogPositionStore) Delete(ctx *sql.Context) error {
 	filesys := doltSession.Provider().FileSystem()
 
 	return filesys.Delete(filepath.Join(binlogPositionDirectory, binlogPositionFilename), false)
+}
+
+// createDoltCfgDir creates the .doltcfg directory if it doesn't already exist.
+func createDoltCfgDir(filesys filesys.Filesys) error {
+	exists, isDir := filesys.Exists(binlogPositionDirectory)
+	if !exists {
+		err := filesys.MkDirs(binlogPositionDirectory)
+		if err != nil {
+			return fmt.Errorf("unable to save binlog metadata: %s", err)
+		}
+	} else if !isDir {
+		return fmt.Errorf("unable to save binlog metadata: %s exists as a file, not a dir", binlogPositionDirectory)
+	}
+
+	return nil
 }

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_applier.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_applier.go
@@ -63,6 +63,7 @@ type binlogReplicaApplier struct {
 	currentPosition       *mysql.Position // successfully executed GTIDs
 	filters               *filterConfiguration
 	running               atomic.Bool
+	engine                *gms.Engine
 }
 
 func newBinlogReplicaApplier(filters *filterConfiguration) *binlogReplicaApplier {
@@ -117,7 +118,7 @@ func (a *binlogReplicaApplier) connectAndStartReplicationEventStream(ctx *sql.Co
 	var conn *mysql.Conn
 	var err error
 	for connectionAttempts := uint64(0); ; connectionAttempts++ {
-		replicaSourceInfo, err := loadReplicationConfiguration(ctx)
+		replicaSourceInfo, err := loadReplicationConfiguration(ctx, a.engine.Analyzer.Catalog.MySQLDb)
 
 		if replicaSourceInfo == nil {
 			err = ErrServerNotConfiguredAsReplica
@@ -259,11 +260,7 @@ func (a *binlogReplicaApplier) startReplicationEventStream(ctx *sql.Context, con
 // replicaBinlogEventHandler runs a loop, processing binlog events until the applier's stop replication channel
 // receives a signal to stop.
 func (a *binlogReplicaApplier) replicaBinlogEventHandler(ctx *sql.Context) error {
-	server := sqlserver.GetRunningServer()
-	if server == nil {
-		return fmt.Errorf("unable to access a running SQL server")
-	}
-	engine := server.Engine
+	engine := a.engine
 
 	var conn *mysql.Conn
 	var eventProducer *binlogEventProducer
@@ -352,12 +349,12 @@ func (a *binlogReplicaApplier) processBinlogEvent(ctx *sql.Context, engine *gms.
 		// A RAND_EVENT contains two seed values that set the rand_seed1 and rand_seed2 system variables that are
 		// used to compute the random number. For more details, see: https://mariadb.com/kb/en/rand_event/
 		// Note: it is written only before a QUERY_EVENT and is NOT used with row-based logging.
-		ctx.GetLogger().Debug("Received binlog event: Rand")
+		ctx.GetLogger().Trace("Received binlog event: Rand")
 
 	case event.IsXID():
 		// An XID event is generated for a COMMIT of a transaction that modifies one or more tables of an
 		// XA-capable storage engine. For more details, see: https://mariadb.com/kb/en/xid_event/
-		ctx.GetLogger().Debug("Received binlog event: XID")
+		ctx.GetLogger().Trace("Received binlog event: XID")
 		createCommit = true
 		commitToAllDatabases = true
 
@@ -376,7 +373,7 @@ func (a *binlogReplicaApplier) processBinlogEvent(ctx *sql.Context, engine *gms.
 			"query":    query.SQL,
 			"options":  fmt.Sprintf("0x%x", query.Options),
 			"sql_mode": fmt.Sprintf("0x%x", query.SqlMode),
-		}).Debug("Received binlog event: Query")
+		}).Trace("Received binlog event: Query")
 
 		// When executing SQL statements sent from the primary, we can't be sure what database was modified unless we
 		// look closely at the statement. For example, we could be connected to db01, but executed
@@ -427,7 +424,7 @@ func (a *binlogReplicaApplier) processBinlogEvent(ctx *sql.Context, engine *gms.
 		// pointing to the next file in the sequence. ROTATE_EVENT is generated locally and written to the binary log
 		// on the source server and it's also written when a FLUSH LOGS statement occurs on the source server.
 		// For more details, see: https://mariadb.com/kb/en/rotate_event/
-		ctx.GetLogger().Debug("Received binlog event: Rotate")
+		ctx.GetLogger().Trace("Received binlog event: Rotate")
 
 	case event.IsFormatDescription():
 		// This is a descriptor event that is written to the beginning of a binary log file, at position 4 (after
@@ -442,7 +439,7 @@ func (a *binlogReplicaApplier) processBinlogEvent(ctx *sql.Context, engine *gms.
 			"formatVersion": a.format.FormatVersion,
 			"serverVersion": a.format.ServerVersion,
 			"checksum":      a.format.ChecksumAlgorithm,
-		}).Debug("Received binlog event: FormatDescription")
+		}).Trace("Received binlog event: FormatDescription")
 
 	case event.IsPreviousGTIDs():
 		// Logged in every binlog to record the current replication state. Consists of the last GTID seen for each
@@ -453,7 +450,7 @@ func (a *binlogReplicaApplier) processBinlogEvent(ctx *sql.Context, engine *gms.
 		}
 		ctx.GetLogger().WithFields(logrus.Fields{
 			"previousGtids": position.GTIDSet.String(),
-		}).Debug("Received binlog event: PreviousGTIDs")
+		}).Trace("Received binlog event: PreviousGTIDs")
 
 	case event.IsGTID():
 		// For global transaction ID, used to start a new transaction event group, instead of the old BEGIN query event,
@@ -468,12 +465,12 @@ func (a *binlogReplicaApplier) processBinlogEvent(ctx *sql.Context, engine *gms.
 		ctx.GetLogger().WithFields(logrus.Fields{
 			"gtid":    gtid,
 			"isBegin": isBegin,
-		}).Debug("Received binlog event: GTID")
+		}).Trace("Received binlog event: GTID")
 		a.currentGtid = gtid
 		// if the source's UUID hasn't been set yet, set it and persist it
 		if a.replicationSourceUuid == "" {
 			uuid := fmt.Sprintf("%v", gtid.SourceServer())
-			err = persistSourceUuid(ctx, uuid)
+			err = persistSourceUuid(ctx, uuid, a.engine.Analyzer.Catalog.MySQLDb)
 			if err != nil {
 				return err
 			}
@@ -497,7 +494,7 @@ func (a *binlogReplicaApplier) processBinlogEvent(ctx *sql.Context, engine *gms.
 			"flags":     convertToHexString(tableMap.Flags),
 			"metadata":  tableMap.Metadata,
 			"types":     tableMap.Types,
-		}).Debug("Received binlog event: TableMap")
+		}).Trace("Received binlog event: TableMap")
 
 		if tableId == 0xFFFFFF {
 			// Table ID 0xFFFFFF is a special value that indicates table maps can be freed.
@@ -537,7 +534,7 @@ func (a *binlogReplicaApplier) processBinlogEvent(ctx *sql.Context, engine *gms.
 			// network by a primary to a replica to let it know that the primary is still alive, and is only sent
 			// when the primary has no binlog events to send to replica servers.
 			// For more details, see: https://mariadb.com/kb/en/heartbeat_log_event/
-			ctx.GetLogger().Debug("Received binlog event: Heartbeat")
+			ctx.GetLogger().Trace("Received binlog event: Heartbeat")
 		} else {
 			return fmt.Errorf("received unknown event: %v", event)
 		}
@@ -590,7 +587,7 @@ func (a *binlogReplicaApplier) processRowEvent(ctx *sql.Context, event mysql.Bin
 	default:
 		return fmt.Errorf("unsupported event type: %v", event)
 	}
-	ctx.GetLogger().Debugf("Received binlog event: %s", eventType)
+	ctx.GetLogger().Tracef("Received binlog event: %s", eventType)
 
 	tableId := event.TableID(*a.format)
 	tableMap, ok := a.tableMapsById[tableId]
@@ -609,7 +606,7 @@ func (a *binlogReplicaApplier) processRowEvent(ctx *sql.Context, event mysql.Bin
 
 	ctx.GetLogger().WithFields(logrus.Fields{
 		"flags": fmt.Sprintf("%x", rows.Flags),
-	}).Debugf("Processing rows from %s event", eventType)
+	}).Tracef("Processing rows from %s event", eventType)
 
 	flags := rows.Flags
 	foreignKeyChecksDisabled := false
@@ -633,11 +630,11 @@ func (a *binlogReplicaApplier) processRowEvent(ctx *sql.Context, event mysql.Bin
 
 	switch {
 	case event.IsDeleteRows():
-		ctx.GetLogger().Debugf(" - Deleted Rows (table: %s)", tableMap.Name)
+		ctx.GetLogger().Tracef(" - Deleted Rows (table: %s)", tableMap.Name)
 	case event.IsUpdateRows():
-		ctx.GetLogger().Debugf(" - Updated Rows (table: %s)", tableMap.Name)
+		ctx.GetLogger().Tracef(" - Updated Rows (table: %s)", tableMap.Name)
 	case event.IsWriteRows():
-		ctx.GetLogger().Debugf(" - Inserted Rows (table: %s)", tableMap.Name)
+		ctx.GetLogger().Tracef(" - Inserted Rows (table: %s)", tableMap.Name)
 	}
 
 	writeSession, tableWriter, err := getTableWriter(ctx, engine, tableName, tableMap.Database, foreignKeyChecksDisabled)
@@ -652,7 +649,7 @@ func (a *binlogReplicaApplier) processRowEvent(ctx *sql.Context, event mysql.Bin
 			if err != nil {
 				return err
 			}
-			ctx.GetLogger().Debugf("     - Identity: %v ", sql.FormatRow(identityRow))
+			ctx.GetLogger().Tracef("     - Identity: %v ", sql.FormatRow(identityRow))
 		}
 
 		if len(row.Data) > 0 {
@@ -660,7 +657,7 @@ func (a *binlogReplicaApplier) processRowEvent(ctx *sql.Context, event mysql.Bin
 			if err != nil {
 				return err
 			}
-			ctx.GetLogger().Debugf("     - Data: %v ", sql.FormatRow(dataRow))
+			ctx.GetLogger().Tracef("     - Data: %v ", sql.FormatRow(dataRow))
 		}
 
 		switch {

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_controller.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_controller.go
@@ -15,13 +15,15 @@
 package binlogreplication
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqlserver"
+	"github.com/sirupsen/logrus"
 
+	sqle "github.com/dolthub/go-mysql-server"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/binlogreplication"
 	"github.com/dolthub/go-mysql-server/sql/mysql_db"
@@ -65,6 +67,7 @@ type doltBinlogReplicaController struct {
 
 	// operationMutex blocks concurrent access to the START/STOP/RESET REPLICA operations
 	operationMutex *sync.Mutex
+	engine         *sqle.Engine
 }
 
 var _ binlogreplication.BinlogReplicaController = (*doltBinlogReplicaController)(nil)
@@ -113,7 +116,7 @@ func (d *doltBinlogReplicaController) StartReplica(ctx *sql.Context) error {
 		return fmt.Errorf("unable to start replication: %s", err.Error())
 	}
 
-	configuration, err := loadReplicationConfiguration(ctx)
+	configuration, err := loadReplicationConfiguration(ctx, d.engine.Analyzer.Catalog.MySQLDb)
 	if err != nil {
 		return err
 	} else if configuration == nil {
@@ -143,6 +146,13 @@ func (d *doltBinlogReplicaController) StartReplica(ctx *sql.Context) error {
 
 	ctx.GetLogger().Info("starting binlog replication...")
 	d.applier.Go(d.ctx)
+
+	// Attempt to record that the replica has started replication so that it will
+	// start automatically the next time the replica server is started.
+	if err := persistReplicaRunningState(ctx, running); err != nil {
+		ctx.GetLogger().Errorf("unable to persist replica running state: %s", err.Error())
+	}
+
 	return nil
 }
 
@@ -151,11 +161,7 @@ func (d *doltBinlogReplicaController) StartReplica(ctx *sql.Context) error {
 // created and locked to disable log ins, and if it does exist, but is missing super privs or is not
 // locked, it will be given super user privs and locked.
 func (d *doltBinlogReplicaController) configureReplicationUser(ctx *sql.Context) error {
-	server := sqlserver.GetRunningServer()
-	if server == nil {
-		return fmt.Errorf("unable to access a running SQL server")
-	}
-	mySQLDb := server.Engine.Analyzer.Catalog.MySQLDb
+	mySQLDb := d.engine.Analyzer.Catalog.MySQLDb
 	ed := mySQLDb.Editor()
 	defer ed.Close()
 
@@ -201,12 +207,18 @@ func (d *doltBinlogReplicaController) StopReplica(ctx *sql.Context) error {
 		status.ReplicaSqlRunning = binlogreplication.ReplicaSqlNotRunning
 	})
 
+	// Attempt to record that the replica has stopped replication so that it will not
+	// start automatically the next time the replica server is started.
+	if err := persistReplicaRunningState(ctx, notRunning); err != nil {
+		ctx.GetLogger().Errorf("unable to persist replica running state: %s", err.Error())
+	}
+
 	return nil
 }
 
 // SetReplicationSourceOptions implements the BinlogReplicaController interface.
 func (d *doltBinlogReplicaController) SetReplicationSourceOptions(ctx *sql.Context, options []binlogreplication.ReplicationOption) error {
-	replicaSourceInfo, err := loadReplicationConfiguration(ctx)
+	replicaSourceInfo, err := loadReplicationConfiguration(ctx, d.engine.Analyzer.Catalog.MySQLDb)
 	if err != nil {
 		return err
 	}
@@ -267,7 +279,7 @@ func (d *doltBinlogReplicaController) SetReplicationSourceOptions(ctx *sql.Conte
 	}
 
 	// Persist the updated replica source configuration to disk
-	return persistReplicationConfiguration(ctx, replicaSourceInfo)
+	return persistReplicationConfiguration(ctx, replicaSourceInfo, d.engine.Analyzer.Catalog.MySQLDb)
 }
 
 // SetReplicationFilterOptions implements the BinlogReplicaController interface.
@@ -308,19 +320,19 @@ func (d *doltBinlogReplicaController) SetReplicationFilterOptions(_ *sql.Context
 
 // GetReplicaStatus implements the BinlogReplicaController interface
 func (d *doltBinlogReplicaController) GetReplicaStatus(ctx *sql.Context) (*binlogreplication.ReplicaStatus, error) {
-	replicaSourceInfo, err := loadReplicationConfiguration(ctx)
+	replicaSourceInfo, err := loadReplicationConfiguration(ctx, d.engine.Analyzer.Catalog.MySQLDb)
 	if err != nil {
 		return nil, err
-	}
-
-	if replicaSourceInfo == nil {
-		return nil, nil
 	}
 
 	// Lock to read status consistently
 	d.statusMutex.Lock()
 	defer d.statusMutex.Unlock()
 	var copy = d.status
+
+	if replicaSourceInfo == nil {
+		return &copy, nil
+	}
 
 	copy.SourceUser = replicaSourceInfo.User
 	copy.SourceHost = replicaSourceInfo.Host
@@ -359,7 +371,7 @@ func (d *doltBinlogReplicaController) ResetReplica(ctx *sql.Context, resetAll bo
 	})
 
 	if resetAll {
-		err := deleteReplicationConfiguration(ctx)
+		err := deleteReplicationConfiguration(ctx, d.engine.Analyzer.Catalog.MySQLDb)
 		if err != nil {
 			return err
 		}
@@ -409,6 +421,31 @@ func (d *doltBinlogReplicaController) setSqlError(errno uint, message string) {
 	d.status.LastSqlErrorTimestamp = &currentTime
 	d.status.LastSqlErrNumber = errno
 	d.status.LastSqlError = message
+}
+
+func (d *doltBinlogReplicaController) AutoStartIfEnabled(_ context.Context) error {
+	logrus.Error("ReplicaController:AutoStartIfEnabled")
+
+	runningState, err := loadReplicationRunningState(d.ctx)
+	if err != nil {
+		logrus.Errorf("Unable to load replication running state: %s", err.Error())
+		return err
+	}
+
+	if runningState == notRunning {
+		logrus.Trace("no previous replication running state; not auto starting replication")
+		return nil
+	}
+
+	logrus.Info("auto-starting binlog replication from source...")
+	return d.StartReplica(d.ctx)
+}
+
+// SetEngine sets the SQL engine this replica will use when running replicated statements and
+// when loading the Catalog to find the "mysql" database.
+func (d *doltBinlogReplicaController) SetEngine(engine *sqle.Engine) {
+	d.engine = engine
+	d.applier.engine = engine
 }
 
 //

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_test.go
@@ -267,11 +267,11 @@ func TestResetReplica(t *testing.T) {
 	rows, err = replicaDatabase.Queryx("RESET REPLICA ALL;")
 	require.NoError(t, err)
 	require.NoError(t, rows.Close())
-
-	rows, err = replicaDatabase.Queryx("SHOW REPLICA STATUS;")
-	require.NoError(t, err)
-	require.False(t, rows.Next())
-	require.NoError(t, rows.Close())
+	status = queryReplicaStatus(t)
+	require.Equal(t, "", status["Source_Host"])
+	require.Equal(t, "", status["Source_User"])
+	require.Equal(t, "No", status["Replica_IO_Running"])
+	require.Equal(t, "No", status["Replica_SQL_Running"])
 
 	rows, err = replicaDatabase.Queryx("select * from mysql.slave_master_info;")
 	require.NoError(t, err)


### PR DESCRIPTION
Once replication has been started with `START REPLICA;`, replication now automatically restarts when the server is restarted. If replication is stopped with `STOP REPLICA;`, it is not restarted automatically on server restart. This matches MySQL's behavior. 

This PR also includes a few other small improvements to binlog replication:
* allows 'show replica status' before replication is started
* moves logging of binlog messages from `DEBUG` to `TRACE` level
* removes several references to `GetRunningServer()` global function

Resolves https://github.com/dolthub/dolt/issues/8168