### PR TITLE
[no-release-notes] `dolt show` and splunk should show all the data in a TableSchemaFile

### DIFF
--- a/go/store/types/serial_message.go
+++ b/go/store/types/serial_message.go
@@ -286,8 +286,51 @@ func (sm SerialMessage) HumanReadableStringAtIndentationLevel(level int) string 
 		level -= 1
 		printWithIndendationLevel(level, ret, "]\n")
 
+		clusteredIndex, _ := msg.TryClusteredIndex(nil)
+		printWithIndendationLevel(level, ret, "Primary Index: {\n")
+		level += 1
+		printIndex(level, ret, clusteredIndex)
 		level -= 1
-		printWithIndendationLevel(level, ret, "}")
+		printWithIndendationLevel(level, ret, "}\n")
+
+		printWithIndendationLevel(level, ret, "Secondary Indexes: [\n")
+		level += 1
+		numSecondaryIndexes := msg.SecondaryIndexesLength()
+		for i := 0; i < numSecondaryIndexes; i++ {
+			var index *serial.Index
+			_, _ = msg.TrySecondaryIndexes(index, i)
+			printWithIndendationLevel(level, ret, "{\n")
+			printIndex(level+1, ret, index)
+			printWithIndendationLevel(level, ret, "}\n")
+		}
+		level -= 1
+		printWithIndendationLevel(level, ret, "]\n")
+
+		printWithIndendationLevel(level, ret, "Comment: %s\n", string(msg.Comment()))
+
+		printWithIndendationLevel(level, ret, "has_features_after_try_accessors: %v\n", msg.HasFeaturesAfterTryAccessors())
+
+		printWithIndendationLevel(level, ret, "Checks: [\n")
+		level += 1
+		for i := 0; i < msg.ChecksLength(); i++ {
+			var check *serial.CheckConstraint
+			_, _ = msg.TryChecks(check, i)
+			printWithIndendationLevel(level, ret, "{\n")
+			level += 1
+			printWithIndendationLevel(level, ret, "Name: %s\n", string(check.Name()))
+			printWithIndendationLevel(level, ret, "Expression: %s\n", string(check.Expression()))
+			printWithIndendationLevel(level, ret, "Enforced: %v\n", check.Enforced())
+			level -= 1
+			printWithIndendationLevel(level, ret, "}\n")
+
+		}
+		level -= 1
+		printWithIndendationLevel(level, ret, "]\n")
+
+		printWithIndendationLevel(level, ret, "Collation: %v\n", msg.Collation().String())
+
+		level -= 1
+		printWithIndendationLevel(level, ret, "}\n")
 		return ret.String()
 	case serial.ProllyTreeNodeFileID:
 		ret := &strings.Builder{}
@@ -311,6 +354,37 @@ func (sm SerialMessage) HumanReadableStringAtIndentationLevel(level int) string 
 
 		return fmt.Sprintf("SerialMessage (HumanReadableString not implemented), [%v]: %s", id, strings.ToUpper(hex.EncodeToString(sm)))
 	}
+}
+
+func printIndex(level int, ret *strings.Builder, index *serial.Index) {
+	printWithIndendationLevel(level, ret, "Name: %s\n", string(index.Name()))
+	printWithIndendationLevel(level, ret, "Comment: %s\n", string(index.Comment()))
+	printWithIndendationLevel(level, ret, "Index Columns: [")
+	for i := 0; i < index.IndexColumnsLength(); i++ {
+		fmt.Fprintf(ret, "%v, ", index.IndexColumns(i))
+	}
+	ret.WriteString("]\n")
+	printWithIndendationLevel(level, ret, "Key Columns: [")
+	for i := 0; i < index.KeyColumnsLength(); i++ {
+		fmt.Fprintf(ret, "%v, ", index.KeyColumns(i))
+	}
+	ret.WriteString("]\n")
+	printWithIndendationLevel(level, ret, "Value Columns: [")
+	for i := 0; i < index.ValueColumnsLength(); i++ {
+		fmt.Fprintf(ret, "%v, ", index.ValueColumns(i))
+	}
+	ret.WriteString("]\n")
+	printWithIndendationLevel(level, ret, "Is Primary: %v\n", index.PrimaryKey())
+	printWithIndendationLevel(level, ret, "Is Unique: %v\n", index.UniqueKey())
+	printWithIndendationLevel(level, ret, "Is System Defined: %v\n", index.SystemDefined())
+	printWithIndendationLevel(level, ret, "Is Spatial: %v\n", index.SpatialKey())
+	printWithIndendationLevel(level, ret, "Is Fulltext: %v\n", index.FulltextKey())
+
+	printWithIndendationLevel(level, ret, "Prefix Lengths: [")
+	for i := 0; i < index.PrefixLengthsLength(); i++ {
+		fmt.Fprintf(ret, "%v, ", index.PrefixLengths(i))
+	}
+	ret.WriteString("]\n")
 }
 
 func OutputBlobNodeBytes(w *strings.Builder, indentationLevel int, msg serial.Message) error {

--- a/integration-tests/bats/show.bats
+++ b/integration-tests/bats/show.bats
@@ -270,3 +270,20 @@ EOF
     [[ "$output" =~ "{ key: d5010000 ref: #5eiul2kmip341rse0besd0bv0u07jhf1 }" ]] || false
     [[ "$output" =~ "{ key: f40b0000 ref: #vpuf5ccvph0i6stls48a0bj7as5k2aka }" ]] || false
 }
+
+@test "show: schema" {
+    dolt sql <<EOF
+create table test(pk int primary key);
+insert into test values (1);
+EOF
+    for i in {1..10}; do dolt sql -q "insert ignore into test select pk*2+$i from test;"; done
+    run dolt show "#svtgrd12uf2u1q492it1aod9i5cqssv9"
+    [ $status -eq 0 ]
+    [[ "$output" =~ "SerialMessage" ]] || false
+    [[ "$output" =~ "Columns: [" ]] || false
+    [[ "$output" =~ "Primary Index: {" ]] || false
+    [[ "$output" =~ "Secondary Indexes: [" ]] || false
+    [[ "$output" =~ "Comment: " ]] || false
+    [[ "$output" =~ "Checks: [" ]] || false
+    [[ "$output" =~ "Collation: utf8mb4_0900_bin" ]] || false
+}


### PR DESCRIPTION
Previously `dolt show` would only show some of the data for schemas, which was potentially confusing because two schemas with different hashes could have the same output.