### PR TITLE
chore: update  lib:eventsapi 2022-> 2024

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/bcicen/jstream v1.0.0
 	github.com/boltdb/bolt v1.3.1
 	github.com/denisbrodbeck/machineid v1.0.1
-	github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20201005193433-3ee972b1d078
+	github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20240802204753-c290ade4ea30
 	github.com/dolthub/fslock v0.0.3
 	github.com/dolthub/ishell v0.0.0-20240701202509-2b217167d718
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81

--- a/go/go.sum
+++ b/go/go.sum
@@ -177,8 +177,6 @@ github.com/denisbrodbeck/machineid v1.0.1/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbj
 github.com/denisenkom/go-mssqldb v0.10.0 h1:QykgLZBorFE95+gO3u9esLd0BmbvpWp0/waNNZfHBM8=
 github.com/denisenkom/go-mssqldb v0.10.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
-github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20201005193433-3ee972b1d078 h1:nrkoh/RcgTq5EsWTcbSBF8KQghCtM+1dhyslghbBoj8=
-github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20201005193433-3ee972b1d078/go.mod h1:8Jdiq6CVg8HM4n9fF17sGgXUpFa98zDyscW0A7OQmuM=
 github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20240802204753-c290ade4ea30 h1:peN26hllc2GDD7GGvkzsAyV8IcweAc6sZKDb4IPWiY4=
 github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20240802204753-c290ade4ea30/go.mod h1:L5RDYZbC9BBWmoU2+TjTekeqqhFXX5EqH9ln00O0stY=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=
@@ -857,7 +855,6 @@ golang.org/x/net v0.0.0-20200501053045-e0ff5e5a1de5/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200506145744-7e3656a0809f/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
-golang.org/x/net v0.0.0-20200602114024-627f9648deb9/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
@@ -934,7 +931,6 @@ golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200620081246-981b61492c35/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200828194041-157a740278f4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1104,7 +1100,6 @@ google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200515170657-fc4c6c6a6587/go.mod h1:YsZOwe1myG/8QRHRsmBRE1LrgQY60beZKjly0O1fX9U=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
-google.golang.org/genproto v0.0.0-20200622133129-d0ee0c36e670/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=

--- a/go/go.sum
+++ b/go/go.sum
@@ -179,6 +179,8 @@ github.com/denisenkom/go-mssqldb v0.10.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20201005193433-3ee972b1d078 h1:nrkoh/RcgTq5EsWTcbSBF8KQghCtM+1dhyslghbBoj8=
 github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20201005193433-3ee972b1d078/go.mod h1:8Jdiq6CVg8HM4n9fF17sGgXUpFa98zDyscW0A7OQmuM=
+github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20240802204753-c290ade4ea30 h1:peN26hllc2GDD7GGvkzsAyV8IcweAc6sZKDb4IPWiY4=
+github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20240802204753-c290ade4ea30/go.mod h1:L5RDYZbC9BBWmoU2+TjTekeqqhFXX5EqH9ln00O0stY=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2/go.mod h1:mIEZOHnFx4ZMQeawhw9rhsj+0zwQj7adVsnBX7t+eKY=
 github.com/dolthub/fslock v0.0.3 h1:iLMpUIvJKMKm92+N1fmHVdxJP5NdyDK5bK7z7Ba2s2U=


### PR DESCRIPTION
Ran into issues when I ran: 

```
go install github.com/dolthub/dolt/go/cmd/dolt@main
# github.com/dolthub/dolt/go/cmd/dolt/commands
/go/pkg/mod/github.com/dolthub/dolt/go@v0.40.5-0.20240802204753-c290ade4ea30/cmd/dolt/commands/cherry-pick.go:79:19: undefined: eventsapi.ClientEventType_CHERRY_PICK
/go/pkg/mod/github.com/dolthub/dolt/go@v0.40.5-0.20240802204753-c290ade4ea30/cmd/dolt/commands/dump.go:112:19: undefined: eventsapi.ClientEventType_DUMP
/go/pkg/mod/github.com/dolthub/dolt/go@v0.40.5-0.20240802204753-c290ade4ea30/cmd/dolt/commands/filter-branch.go:95:19: undefined: eventsapi.ClientEventType_FILTER_BRANCH
/go/pkg/mod/github.com/dolthub/dolt/go@v0.40.5-0.20240802204753-c290ade4ea30/cmd/dolt/commands/gc.go:76:19: undefined: eventsapi.ClientEventType_GARBAGE_COLLECTION
/go/pkg/mod/github.com/dolthub/dolt/go@v0.40.5-0.20240802204753-c290ade4ea30/cmd/dolt/commands/migrate.go:74:19: undefined: eventsapi.ClientEventType_MIGRATE
/go/pkg/mod/github.com/dolthub/dolt/go@v0.40.5-0.20240802204753-c290ade4ea30/cmd/dolt/commands/profile.go:89:19: undefined: eventsapi.ClientEventType_PROFILE
/go/pkg/mod/github.com/dolthub/dolt/go@v0.40.5-0.20240802204753-c290ade4ea30/cmd/dolt/commands/rebase.go:74:19: undefined: eventsapi.ClientEventType_REBASE
/go/pkg/mod/github.com/dolthub/dolt/go@v0.40.5-0.20240802204753-c290ade4ea30/cmd/dolt/commands/reflog.go:63:19: undefined: eventsapi.ClientEventType_REFLOG
/go/pkg/mod/github.com/dolthub/dolt/go@v0.40.5-0.20240802204753-c290ade4ea30/cmd/dolt/commands/show.go:72:19: undefined: eventsapi.ClientEventType_SHOW
/go/pkg/mod/github.com/dolthub/dolt/go@v0.40.5-0.20240802204753-c290ade4ea30/cmd/dolt/commands/tag.go:81:19: undefined: eventsapi.ClientEventType_TAG
/go/pkg/mod/github.com/dolthub/dolt/go@v0.40.5-0.20240802204753-c290ade4ea30/cmd/dolt/commands/tag.go:81:19: too many errors
```

Realized the eventsapi library version in `go.mod` is outdated