### PR TITLE
Bug fix: binlog replication: logging levels, use MySQL's older date serialization format

### DIFF
--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_primary_streamer.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_primary_streamer.go
@@ -94,7 +94,7 @@ func (streamer *binlogStreamer) startStream(ctx *sql.Context, conn *mysql.Conn, 
 			err := streamer.streamNextEvents(ctx, conn,
 				*binlogFormat, binlogEventMeta, filepath.Dir(logfile), executedGtids)
 			if err == io.EOF {
-				logrus.Debug("End of binlog file! Pausing for new events...")
+				logrus.Trace("End of binlog file! Pausing for new events...")
 				time.Sleep(250 * time.Millisecond)
 			} else if err != nil {
 				return err

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_producer.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_producer.go
@@ -509,6 +509,11 @@ func (b *binlogProducer) createRowEvents(ctx *sql.Context, tableDeltas []diff.Ta
 func (b *binlogProducer) currentGtidPosition() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
+	if b.gtidPosition == nil {
+		return ""
+	}
+
 	return b.gtidPosition.String()
 }
 

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_type_serialization.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_type_serialization.go
@@ -452,7 +452,8 @@ func (d dateSerializer) serialize(_ *sql.Context, typ sql.Type, descriptor val.T
 }
 
 func (d dateSerializer) metadata(_ *sql.Context, typ sql.Type) (byte, uint16) {
-	return mysql.TypeNewDate, 0
+	// NOTE: MySQL still sends the old date type (not mysql.TypeNewDate), so for compatibility we use that here
+	return mysql.TypeDate, 0
 }
 
 // timestampSerializer loads a TIMESTAMP type value from Dolt's storage and encodes it

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_type_serialization_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_type_serialization_test.go
@@ -411,7 +411,7 @@ func TestDateSerializer(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte{0x43, 0xb5, 0x0f}, bytes)
 	typeId, metadata := s.metadata(nil, gmstypes.Date)
-	require.EqualValues(t, mysql.TypeNewDate, typeId)
+	require.EqualValues(t, mysql.TypeDate, typeId)
 	require.EqualValues(t, 0, metadata)
 }
 


### PR DESCRIPTION
Small bug fixes for binlog replication while testing with the `python-mysql-replication` library:
* Adjusting `DEBUG` logging to be less verbose 
* Using MySQL's older date serialization format for compatibility 
* Adding a `nil` check for `gtidPosition` 