### PR TITLE
Reuse DoltEnv when creating MultiEnv

### DIFF
--- a/go/cmd/dolt/commands/backup.go
+++ b/go/cmd/dolt/commands/backup.go
@@ -335,7 +335,7 @@ func restoreBackup(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.ArgPar
 		return errhand.VerboseErrorFromError(err)
 	}
 
-	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv, false)
 	if err != nil {
 		return errhand.BuildDError("error: Unable to list databases").AddCause(err).Build()
 	}

--- a/go/cmd/dolt/commands/dump.go
+++ b/go/cmd/dolt/commands/dump.go
@@ -813,7 +813,7 @@ func addCreateDatabaseHeader(dEnv *env.DoltEnv, fPath, dbName string) errhand.Ve
 // TODO: find a more elegant way to get database name, possibly implement a method in DoltEnv
 // getActiveDatabaseName returns the name of the current active database
 func getActiveDatabaseName(ctx context.Context, dEnv *env.DoltEnv) (string, errhand.VerboseError) {
-	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv, false)
 	if err != nil {
 		return "", errhand.VerboseErrorFromError(err)
 	}

--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -435,7 +435,7 @@ func doltSessionFactory(pro *dsqle.DoltDatabaseProvider, statsPro sql.StatsProvi
 // NewSqlEngineForEnv returns a SqlEngine configured for the environment provided, with a single root user.
 // Returns the new engine, the first database name, and any error that occurred.
 func NewSqlEngineForEnv(ctx context.Context, dEnv *env.DoltEnv) (*SqlEngine, string, error) {
-	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv, false)
 	if err != nil {
 		return nil, "", err
 	}

--- a/go/cmd/dolt/commands/filter-branch.go
+++ b/go/cmd/dolt/commands/filter-branch.go
@@ -346,7 +346,7 @@ func rebaseSqlEngine(ctx context.Context, dEnv *env.DoltEnv, root doltdb.RootVal
 		return nil, nil, err
 	}
 
-	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -182,7 +182,7 @@ func ConfigureServices(
 	var mrEnv *env.MultiRepoEnv
 	InitMultiEnv := &svcs.AnonService{
 		InitF: func(ctx context.Context) (err error) {
-			mrEnv, err = env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), fs, dEnv.Version, dEnv)
+			mrEnv, err = env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), fs, dEnv.Version, dEnv, false)
 			return err
 		},
 	}

--- a/go/cmd/dolt/commands/utils.go
+++ b/go/cmd/dolt/commands/utils.go
@@ -101,7 +101,7 @@ func MaybeGetCommitWithVErr(dEnv *env.DoltEnv, maybeCommit string) (*doltdb.Comm
 
 // NewArgFreeCliContext creates a new CliContext instance with no arguments using a local SqlEngine. This is useful for testing primarily
 func NewArgFreeCliContext(ctx context.Context, dEnv *env.DoltEnv) (cli.CliContext, errhand.VerboseError) {
-	mrEnv, err := env.MultiEnvForSingleEnv(ctx, dEnv)
+	mrEnv, err := env.MultiEnvForSingleEnv(ctx, dEnv, false)
 	if err != nil {
 		return nil, errhand.VerboseErrorFromError(err)
 	}

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -592,7 +592,7 @@ func runMain() int {
 	// variables like `${db_name}_default_branch` (maybe these should not be
 	// part of Dolt config in the first place!).
 
-	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dataDirFS, dEnv.Version, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dataDirFS, dEnv.Version, dEnv, false)
 	if err != nil {
 		cli.PrintErrln("failed to load database names")
 		return 1

--- a/go/libraries/doltcore/dtestutils/sql_server_driver/cmd.go
+++ b/go/libraries/doltcore/dtestutils/sql_server_driver/cmd.go
@@ -128,7 +128,11 @@ func (u DoltUser) DoltDebug(debuggerPort int, args ...string) *exec.Cmd {
 
 func (u DoltUser) DoltExec(args ...string) error {
 	cmd := u.DoltCmd(args...)
-	return cmd.Run()
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("error while running `dolt %v`: %w.\nOutput: %v", args, err, string(output))
+	}
+	return err
 }
 
 func (u DoltUser) MakeRepoStore() (RepoStore, error) {

--- a/go/libraries/doltcore/env/actions/clone.go
+++ b/go/libraries/doltcore/env/actions/clone.go
@@ -75,10 +75,11 @@ func EnvForClone(ctx context.Context, nbf *types.NomsBinFormat, r env.Remote, di
 
 	dEnv := env.Load(ctx, homeProvider, newFs, doltdb.LocalDirDoltDB, version)
 	if errors.Is(dEnv.DBLoadError, doltdb.ErrMissingDoltDataDir) {
-		err = dEnv.InitRepoWithNoData(ctx, nbf)
-		if err != nil {
-			return nil, fmt.Errorf("failed to init repo: %w", err)
-		}
+		dEnv.DBLoadError = nil
+	}
+	err = dEnv.InitRepoWithNoData(ctx, nbf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init repo: %w", err)
 	}
 
 	dEnv.RSLoadErr = nil

--- a/go/libraries/doltcore/env/actions/clone.go
+++ b/go/libraries/doltcore/env/actions/clone.go
@@ -74,9 +74,12 @@ func EnvForClone(ctx context.Context, nbf *types.NomsBinFormat, r env.Remote, di
 	}
 
 	dEnv := env.Load(ctx, homeProvider, newFs, doltdb.LocalDirDoltDB, version)
-	err = dEnv.InitRepoWithNoData(ctx, nbf)
-	if err != nil {
-		return nil, fmt.Errorf("failed to init repo: %w", err)
+	if errors.Is(dEnv.DBLoadError, doltdb.ErrMissingDoltDataDir) {
+		err = dEnv.InitRepoWithNoData(ctx, nbf)
+		if err != nil {
+			return nil, fmt.Errorf("failed to init repo: %w", err)
+		}
+		dEnv.DBLoadError = nil
 	}
 
 	dEnv.RSLoadErr = nil

--- a/go/libraries/doltcore/env/actions/clone.go
+++ b/go/libraries/doltcore/env/actions/clone.go
@@ -79,7 +79,6 @@ func EnvForClone(ctx context.Context, nbf *types.NomsBinFormat, r env.Remote, di
 		if err != nil {
 			return nil, fmt.Errorf("failed to init repo: %w", err)
 		}
-		dEnv.DBLoadError = nil
 	}
 
 	dEnv.RSLoadErr = nil

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -505,6 +505,10 @@ func (dEnv *DoltEnv) InitDBAndRepoStateWithCommitMetaGenerator(ctx context.Conte
 	err := dEnv.InitDBWithCommitMetaGenerator(ctx, nbf, branchName, commitMeta)
 	if err != nil {
 		return err
+	} else {
+		if dEnv.DBLoadError == doltdb.ErrMissingDoltDataDir {
+			dEnv.DBLoadError = nil
+		}
 	}
 
 	return dEnv.InitializeRepoState(ctx, branchName)

--- a/go/libraries/doltcore/env/multi_repo_env.go
+++ b/go/libraries/doltcore/env/multi_repo_env.go
@@ -153,7 +153,7 @@ func MultiEnvForDirectory(
 		envName := getRepoRootDir(path, string(os.PathSeparator))
 		dbName = dbfactory.DirToDBName(envName)
 
-		newDEnv = Load(ctx, GetCurrentUserHomeDir, dataDirFS, doltdb.LocalDirDoltDB, version)
+		// newDEnv = Load(ctx, GetCurrentUserHomeDir, dataDirFS, doltdb.LocalDirDoltDB, version)
 	}
 
 	mrEnv := &MultiRepoEnv{

--- a/go/libraries/doltcore/env/multi_repo_env.go
+++ b/go/libraries/doltcore/env/multi_repo_env.go
@@ -144,7 +144,6 @@ func MultiEnvForDirectory(
 	var newDEnv *DoltEnv = dEnv
 
 	// InMemFS is used only for testing.
-	// All other FS Types should get a newly created Environment which will serve as the primary env in the MultiRepoEnv
 	if _, ok := dataDirFS.(*filesys.InMemFS); !ok {
 		path, err := dataDirFS.Abs("")
 		if err != nil {
@@ -152,8 +151,6 @@ func MultiEnvForDirectory(
 		}
 		envName := getRepoRootDir(path, string(os.PathSeparator))
 		dbName = dbfactory.DirToDBName(envName)
-
-		// newDEnv = Load(ctx, GetCurrentUserHomeDir, dataDirFS, doltdb.LocalDirDoltDB, version)
 	}
 
 	mrEnv := &MultiRepoEnv{

--- a/go/libraries/doltcore/env/multi_repo_env_test.go
+++ b/go/libraries/doltcore/env/multi_repo_env_test.go
@@ -122,7 +122,7 @@ func TestMultiEnvForDirectory(t *testing.T) {
 	envPath := filepath.Join(rootPath, " test---name _ 123")
 	dEnv := initRepoWithRelativePath(t, envPath, hdp)
 
-	mrEnv, err := MultiEnvForDirectory(context.Background(), dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
+	mrEnv, err := MultiEnvForDirectory(context.Background(), dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv, false)
 	require.NoError(t, err)
 	assert.Len(t, mrEnv.envs, 1)
 
@@ -159,7 +159,7 @@ func TestMultiEnvForDirectoryWithMultipleRepos(t *testing.T) {
 	subEnv1 := initRepoWithRelativePath(t, filepath.Join(envPath, "abc"), hdp)
 	subEnv2 := initRepoWithRelativePath(t, filepath.Join(envPath, "def"), hdp)
 
-	mrEnv, err := MultiEnvForDirectory(context.Background(), dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
+	mrEnv, err := MultiEnvForDirectory(context.Background(), dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv, false)
 	require.NoError(t, err)
 	assert.Len(t, mrEnv.envs, 3)
 

--- a/go/libraries/doltcore/merge/integration_test.go
+++ b/go/libraries/doltcore/merge/integration_test.go
@@ -363,7 +363,7 @@ func setupConcurrencyTest(t *testing.T, ctx context.Context) (dEnv *env.DoltEnv)
 }
 
 func engineFromEnvironment(ctx context.Context, dEnv *env.DoltEnv) (dbName string, eng *engine.SqlEngine) {
-	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv, false)
 	if err != nil {
 		panic(err)
 	}

--- a/go/libraries/doltcore/mvdata/engine_table_reader.go
+++ b/go/libraries/doltcore/mvdata/engine_table_reader.go
@@ -42,7 +42,7 @@ type sqlEngineTableReader struct {
 }
 
 func NewSqlEngineReader(ctx context.Context, dEnv *env.DoltEnv, tableName string) (*sqlEngineTableReader, error) {
-	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv, false)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/mvdata/engine_table_writer.go
+++ b/go/libraries/doltcore/mvdata/engine_table_writer.go
@@ -64,7 +64,7 @@ type SqlEngineTableWriter struct {
 func NewSqlEngineTableWriter(ctx context.Context, dEnv *env.DoltEnv, createTableSchema, rowOperationSchema schema.Schema, options *MoverOptions, statsCB noms.StatsCB) (*SqlEngineTableWriter, error) {
 	// TODO: Assert that dEnv.DoltDB.AccessMode() != ReadOnly?
 
-	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv, false)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -765,7 +765,7 @@ func (p *DoltDatabaseProvider) registerNewDatabase(ctx *sql.Context, name string
 		}
 	}
 
-	mrEnv, err := env.MultiEnvForSingleEnv(ctx, newEnv)
+	mrEnv, err := env.MultiEnvForSingleEnv(ctx, newEnv, true)
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
@@ -520,7 +520,7 @@ func (d *DoltHarness) newProvider() sql.MutableDatabaseProvider {
 	store := dEnv.DoltDB.ValueReadWriter().(*types.ValueStore)
 	store.SetValidateContentAddresses(true)
 
-	mrEnv, err := env.MultiEnvForDirectory(context.Background(), dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(context.Background(), dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv, false)
 	require.NoError(d.t, err)
 	d.multiRepoEnv = mrEnv
 

--- a/go/libraries/doltcore/sqle/index/mergeable_indexes_setup_test.go
+++ b/go/libraries/doltcore/sqle/index/mergeable_indexes_setup_test.go
@@ -95,7 +95,7 @@ func setupIndexes(t *testing.T, tableName, insertQuery string) (*sqle.Engine, *s
 		cols: idxv2v1Cols,
 	}
 
-	mrEnv, err := env.MultiEnvForDirectory(context.Background(), dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(context.Background(), dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv, false)
 	require.NoError(t, err)
 	b := env.GetDefaultInitBranch(dEnv.Config)
 	pro, err := dsqle.NewDoltDatabaseProviderWithDatabase(b, mrEnv.FileSystem(), db, dEnv.FS)

--- a/go/libraries/doltcore/sqle/logictest/dolt/doltharness.go
+++ b/go/libraries/doltcore/sqle/logictest/dolt/doltharness.go
@@ -293,7 +293,7 @@ func sqlNewEngine(dEnv *env.DoltEnv) (*sqle.Engine, dsess.DoltDatabaseProvider, 
 		return nil, nil, err
 	}
 
-	mrEnv, err := env.MultiEnvForDirectory(context.Background(), dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(context.Background(), dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/libraries/doltcore/sqle/sqlddl_test.go
+++ b/go/libraries/doltcore/sqle/sqlddl_test.go
@@ -1108,7 +1108,7 @@ func newTestEngine(ctx context.Context, dEnv *env.DoltEnv) (*gms.Engine, *sql.Co
 		panic(err)
 	}
 
-	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv, false)
 	if err != nil {
 		panic(err)
 	}

--- a/go/performance/microsysbench/sysbench_test.go
+++ b/go/performance/microsysbench/sysbench_test.go
@@ -115,7 +115,7 @@ func setupBenchmark(t *testing.B, dEnv *env.DoltEnv) (*sql.Context, *engine.SqlE
 		Autocommit: true,
 	}
 
-	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
+	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv, false)
 	require.NoError(t, err)
 
 	eng, err := engine.NewSqlEngine(ctx, mrEnv, config)


### PR DESCRIPTION
I thought this would speed up startup latency by as much as 50% when garbage hasn't been collected in a while. Previously we were loading the environment (including the index) from disk twice. Now we only do it once.

It turns out that reading from the db is cached so this won't actually affect startup latency. But it simplifies the code flow in most cases.