### PR TITLE
Feature: support for --empty=[drop|keep] in dolt_rebase()

### DIFF
--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -97,10 +97,11 @@ func CreateMergeArgParser() *argparser.ArgParser {
 }
 
 func CreateRebaseArgParser() *argparser.ArgParser {
-	ap := argparser.NewArgParserWithMaxArgs("merge", 1)
+	ap := argparser.NewArgParserWithMaxArgs("rebase", 1)
 	ap.TooManyArgsErrorFunc = func(receivedArgs []string) error {
 		return errors.New("rebase takes at most one positional argument.")
 	}
+	ap.SupportsString(EmptyParam, "", "empty", "How to handle commits that are not empty to start, but which become empty after rebasing. Valid values are: drop (default) or keep")
 	ap.SupportsFlag(AbortParam, "", "Abort an interactive rebase and return the working set to the pre-rebase state")
 	ap.SupportsFlag(ContinueFlag, "", "Continue an interactive rebase after adjusting the rebase plan")
 	ap.SupportsFlag(InteractiveFlag, "i", "Start an interactive rebase")
@@ -172,6 +173,9 @@ func CreateCheckoutArgParser() *argparser.ArgParser {
 func CreateCherryPickArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParserWithMaxArgs("cherrypick", 1)
 	ap.SupportsFlag(AbortParam, "", "Abort the current conflict resolution process, and revert all changes from the in-process cherry-pick operation.")
+	ap.SupportsFlag(AllowEmptyFlag, "", "Allow empty commits to be cherry-picked. "+
+		"Note that use of this option only keeps commits that were initially empty. "+
+		"Commits which become empty, due to a previous commit, will cause cherry-pick to fail.")
 	ap.TooManyArgsErrorFunc = func(receivedArgs []string) error {
 		return errors.New("cherry-picking multiple commits is not supported yet.")
 	}

--- a/go/cmd/dolt/cli/flags.go
+++ b/go/cmd/dolt/cli/flags.go
@@ -35,6 +35,7 @@ const (
 	DeleteForceFlag      = "D"
 	DepthFlag            = "depth"
 	DryRunFlag           = "dry-run"
+	EmptyParam           = "empty"
 	ForceFlag            = "force"
 	GraphFlag            = "graph"
 	HardResetParam       = "hard"

--- a/go/cmd/dolt/commands/cherry-pick.go
+++ b/go/cmd/dolt/commands/cherry-pick.go
@@ -20,8 +20,6 @@ import (
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/gocraft/dbr/v2"
-	"github.com/gocraft/dbr/v2/dialect"
 	"gopkg.in/src-d/go-errors.v1"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
@@ -154,13 +152,7 @@ hint: commit your changes (dolt commit -am \"<message>\") or reset them (dolt re
 		return fmt.Errorf("error: failed to set @@dolt_force_transaction_commit: %w", err)
 	}
 
-	interfaceArgs := make([]interface{}, 0, len(args))
-	for _, arg := range args {
-		interfaceArgs = append(interfaceArgs, arg)
-	}
-
-	placeholders := strings.Join(make([]string, len(args)), "?, ") + "?"
-	q, err := dbr.InterpolateForDialect("call dolt_cherry_pick("+placeholders+")", interfaceArgs, dialect.MySQL)
+	q, err := interpolateStoredProcedureCall("DOLT_CHERRY_PICK", args)
 	if err != nil {
 		return fmt.Errorf("error: failed to interpolate query: %w", err)
 	}

--- a/go/cmd/dolt/commands/cherry-pick.go
+++ b/go/cmd/dolt/commands/cherry-pick.go
@@ -154,7 +154,7 @@ hint: commit your changes (dolt commit -am \"<message>\") or reset them (dolt re
 		return fmt.Errorf("error: failed to set @@dolt_force_transaction_commit: %w", err)
 	}
 
-	interfaceArgs := make([]interface{}, 0)
+	interfaceArgs := make([]interface{}, 0, len(args))
 	for _, arg := range args {
 		interfaceArgs = append(interfaceArgs, arg)
 	}

--- a/go/cmd/dolt/commands/rebase.go
+++ b/go/cmd/dolt/commands/rebase.go
@@ -102,7 +102,7 @@ func (cmd RebaseCmd) Exec(ctx context.Context, commandStr string, args []string,
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	query, err := constructInterpolatedDoltRebaseQuery(apr)
+	query, err := constructInterpolatedDoltRebaseQuery(args)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
@@ -183,26 +183,14 @@ func (cmd RebaseCmd) Exec(ctx context.Context, commandStr string, args []string,
 
 // constructInterpolatedDoltRebaseQuery generates the sql query necessary to call the DOLT_REBASE() function.
 // Also interpolates this query to prevent sql injection.
-func constructInterpolatedDoltRebaseQuery(apr *argparser.ArgParseResults) (string, error) {
-	var params []interface{}
-	var args []string
-
-	if apr.NArg() == 1 {
-		params = append(params, apr.Arg(0))
-		args = append(args, "?")
-	}
-	if apr.Contains(cli.InteractiveFlag) {
-		args = append(args, "'--interactive'")
-	}
-	if apr.Contains(cli.ContinueFlag) {
-		args = append(args, "'--continue'")
-	}
-	if apr.Contains(cli.AbortParam) {
-		args = append(args, "'--abort'")
+func constructInterpolatedDoltRebaseQuery(args []string) (string, error) {
+	interfaceArgs := make([]interface{}, 0, len(args))
+	for _, arg := range args {
+		interfaceArgs = append(interfaceArgs, arg)
 	}
 
-	query := fmt.Sprintf("CALL DOLT_REBASE(%s);", strings.Join(args, ", "))
-	return dbr.InterpolateForDialect(query, params, dialect.MySQL)
+	placeholders := strings.Join(make([]string, len(args)), "?, ") + "?"
+	return dbr.InterpolateForDialect("CALL DOLT_REBASE("+placeholders+");", interfaceArgs, dialect.MySQL)
 }
 
 // getRebasePlan opens an editor for users to edit the rebase plan and returns the parsed rebase plan from the editor.

--- a/go/cmd/dolt/commands/rebase.go
+++ b/go/cmd/dolt/commands/rebase.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/gocraft/dbr/v2"
-	"github.com/gocraft/dbr/v2/dialect"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
@@ -102,7 +100,7 @@ func (cmd RebaseCmd) Exec(ctx context.Context, commandStr string, args []string,
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	query, err := constructInterpolatedDoltRebaseQuery(args)
+	query, err := interpolateStoredProcedureCall("DOLT_REBASE", args)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
@@ -179,18 +177,6 @@ func (cmd RebaseCmd) Exec(ctx context.Context, commandStr string, args []string,
 	}
 
 	return HandleVErrAndExitCode(nil, usage)
-}
-
-// constructInterpolatedDoltRebaseQuery generates the sql query necessary to call the DOLT_REBASE() function.
-// Also interpolates this query to prevent sql injection.
-func constructInterpolatedDoltRebaseQuery(args []string) (string, error) {
-	interfaceArgs := make([]interface{}, 0, len(args))
-	for _, arg := range args {
-		interfaceArgs = append(interfaceArgs, arg)
-	}
-
-	placeholders := strings.Join(make([]string, len(args)), "?, ") + "?"
-	return dbr.InterpolateForDialect("CALL DOLT_REBASE("+placeholders+");", interfaceArgs, dialect.MySQL)
 }
 
 // getRebasePlan opens an editor for users to edit the rebase plan and returns the parsed rebase plan from the editor.

--- a/go/cmd/dolt/commands/utils.go
+++ b/go/cmd/dolt/commands/utils.go
@@ -818,3 +818,25 @@ func HandleVErrAndExitCode(verr errhand.VerboseError, usage cli.UsagePrinter) in
 
 	return 0
 }
+
+// interpolateStoredProcedureCall returns an interpolated query to call |storedProcedureName| with the arguments
+// |args|.
+func interpolateStoredProcedureCall(storedProcedureName string, args []string) (string, error) {
+	query := fmt.Sprintf("CALL %s(%s);", storedProcedureName, buildPlaceholdersString(len(args)))
+	return dbr.InterpolateForDialect(query, stringSliceToInterfaceSlice(args), dialect.MySQL)
+}
+
+// stringSliceToInterfaceSlice converts the string slice |ss| into an interface slice with the same values.
+func stringSliceToInterfaceSlice(ss []string) []interface{} {
+	retSlice := make([]interface{}, 0, len(ss))
+	for _, s := range ss {
+		retSlice = append(retSlice, s)
+	}
+	return retSlice
+}
+
+// buildPlaceholdersString returns a placeholder string to use in an interpolated query with the specified
+// |count| of parameter placeholders.
+func buildPlaceholdersString(count int) string {
+	return strings.Join(make([]string, count), "?, ") + "?"
+}

--- a/go/gen/fb/serial/workingset.go
+++ b/go/gen/fb/serial/workingset.go
@@ -531,7 +531,31 @@ func (rcv *RebaseState) MutateOntoCommitAddr(j int, n byte) bool {
 	return false
 }
 
-const RebaseStateNumFields = 3
+func (rcv *RebaseState) EmptyCommitHandling() byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
+	if o != 0 {
+		return rcv._tab.GetByte(o + rcv._tab.Pos)
+	}
+	return 0
+}
+
+func (rcv *RebaseState) MutateEmptyCommitHandling(n byte) bool {
+	return rcv._tab.MutateByteSlot(10, n)
+}
+
+func (rcv *RebaseState) CommitBecomesEmptyHandling() byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(12))
+	if o != 0 {
+		return rcv._tab.GetByte(o + rcv._tab.Pos)
+	}
+	return 0
+}
+
+func (rcv *RebaseState) MutateCommitBecomesEmptyHandling(n byte) bool {
+	return rcv._tab.MutateByteSlot(12, n)
+}
+
+const RebaseStateNumFields = 5
 
 func RebaseStateStart(builder *flatbuffers.Builder) {
 	builder.StartObject(RebaseStateNumFields)
@@ -553,6 +577,12 @@ func RebaseStateAddOntoCommitAddr(builder *flatbuffers.Builder, ontoCommitAddr f
 }
 func RebaseStateStartOntoCommitAddrVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(1, numElems, 1)
+}
+func RebaseStateAddEmptyCommitHandling(builder *flatbuffers.Builder, emptyCommitHandling byte) {
+	builder.PrependByteSlot(3, emptyCommitHandling, 0)
+}
+func RebaseStateAddCommitBecomesEmptyHandling(builder *flatbuffers.Builder, commitBecomesEmptyHandling byte) {
+	builder.PrependByteSlot(4, commitBecomesEmptyHandling, 0)
 }
 func RebaseStateEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()

--- a/go/libraries/doltcore/doltdb/workingset.go
+++ b/go/libraries/doltcore/doltdb/workingset.go
@@ -29,14 +29,20 @@ import (
 	"github.com/dolthub/dolt/go/store/types"
 )
 
-// EmptyCommitHandling describes how a cherry-pick action should handle empty commits. This includes commits that
-// start off as empty, as well as commits whose changes are applied, but are redundant, and become empty.
+// EmptyCommitHandling describes how a cherry-pick action should handle empty commits. This applies to commits that
+// start off as empty, as well as commits whose changes are applied, but are redundant, and become empty. Note that
+// cherry-pick and rebase treat these two cases separately – commits that start as empty versus commits that become
+// empty while being rebased or cherry-picked.
 type EmptyCommitHandling int
 
 const (
+	// ErrorOnEmptyCommit instructs a cherry-pick or rebase operation to fail with an error when an empty commit
+	// is encountered.
+	ErrorOnEmptyCommit = iota
+
 	// DropEmptyCommit instructs a cherry-pick or rebase operation to drop empty commits and to not create new
 	// commits for them.
-	DropEmptyCommit = iota
+	DropEmptyCommit
 
 	// KeepEmptyCommit instructs a cherry-pick or rebase operation to keep empty commits.
 	KeepEmptyCommit
@@ -44,10 +50,6 @@ const (
 	// StopOnEmptyCommit instructs a cherry-pick or rebase operation to stop and let the user take additional action
 	// to decide how to handle an empty commit.
 	StopOnEmptyCommit
-
-	// ErrorOnEmptyCommit instructs a cherry-pick or rebase operation to fail with an error when an empty commit
-	// is encountered.
-	ErrorOnEmptyCommit
 )
 
 // RebaseState tracks the state of an in-progress rebase action. It records the name of the branch being rebased, the

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_cherry_pick.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_cherry_pick.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/cherry_pick"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 )
 
 var ErrEmptyCherryPick = errors.New("cannot cherry-pick empty string")
@@ -95,7 +96,14 @@ func doDoltCherryPick(ctx *sql.Context, args []string) (string, int, int, int, e
 		return "", 0, 0, 0, ErrEmptyCherryPick
 	}
 
-	commit, mergeResult, err := cherry_pick.CherryPick(ctx, cherryStr, cherry_pick.CherryPickOptions{})
+	cherryPickOptions := cherry_pick.NewCherryPickOptions()
+
+	// If --allow-empty is specified, then empty commits are allowed to be cherry-picked
+	if apr.Contains(cli.AllowEmptyFlag) {
+		cherryPickOptions.EmptyCommitHandling = doltdb.KeepEmptyCommit
+	}
+
+	commit, mergeResult, err := cherry_pick.CherryPick(ctx, cherryStr, cherryPickOptions)
 	if err != nil {
 		return "", 0, 0, 0, err
 	}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_rebase.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_rebase.go
@@ -141,7 +141,7 @@ func doDoltRebase(ctx *sql.Context, args []string) (int, string, error) {
 			return 1, "", err
 		}
 
-		// The default for handling commits that start off empty is to keep them
+		// The default, in rebase, for handling commits that start off empty is to keep them
 		// TODO: Add support for --keep-empty and --no-keep-empty flags
 		emptyCommitHandling := doltdb.EmptyCommitHandling(doltdb.KeepEmptyCommit)
 
@@ -175,7 +175,10 @@ func doDoltRebase(ctx *sql.Context, args []string) (int, string, error) {
 func processCommitBecomesEmptyParams(apr *argparser.ArgParseResults) (doltdb.EmptyCommitHandling, error) {
 	commitBecomesEmptyParam, isCommitBecomesEmptySpecified := apr.GetValue(cli.EmptyParam)
 	if !isCommitBecomesEmptySpecified {
-		// If no option is specified, then by default, commits that become empty are dropped
+		// If no option is specified, then by default, commits that become empty are dropped. Git has the same
+		// default for non-interactive rebases; for interactive rebases, Git uses the default action of "stop" to
+		// let the user examine the changes and decide what to do next. We don't support the "stop" action yet, so
+		// we default to "drop" even in the interactive rebase case.
 		return doltdb.DropEmptyCommit, nil
 	}
 
@@ -522,7 +525,7 @@ func processRebasePlanStep(ctx *sql.Context, planStep *rebase.RebasePlanStep,
 	}
 
 	// Override the default empty commit handling options for cherry-pick, since
-	// rebase has different defaults
+	// rebase has slightly different defaults
 	options := cherry_pick.NewCherryPickOptions()
 	options.CommitBecomesEmptyHandling = commitBecomesEmptyHandling
 	options.EmptyCommitHandling = emptyCommitHandling

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_rebase.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_rebase.go
@@ -17,6 +17,7 @@ package dprocedures
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
@@ -31,6 +32,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/rebase"
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
+	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 )
 
 var doltRebaseProcedureSchema = []*sql.Column{
@@ -134,6 +136,15 @@ func doDoltRebase(ctx *sql.Context, args []string) (int, string, error) {
 		}
 
 	default:
+		commitBecomesEmptyHandling, err := processCommitBecomesEmptyParams(apr)
+		if err != nil {
+			return 1, "", err
+		}
+
+		// The default for handling commits that start off empty is to keep them
+		// TODO: Add support for --keep-empty and --no-keep-empty flags
+		emptyCommitHandling := doltdb.EmptyCommitHandling(doltdb.KeepEmptyCommit)
+
 		if apr.NArg() == 0 {
 			return 1, "", fmt.Errorf("not enough args")
 		} else if apr.NArg() > 1 {
@@ -142,7 +153,7 @@ func doDoltRebase(ctx *sql.Context, args []string) (int, string, error) {
 		if !apr.Contains(cli.InteractiveFlag) {
 			return 1, "", fmt.Errorf("non-interactive rebases not currently supported")
 		}
-		err = startRebase(ctx, apr.Arg(0))
+		err = startRebase(ctx, apr.Arg(0), commitBecomesEmptyHandling, emptyCommitHandling)
 		if err != nil {
 			return 1, "", err
 		}
@@ -158,7 +169,30 @@ func doDoltRebase(ctx *sql.Context, args []string) (int, string, error) {
 	}
 }
 
-func startRebase(ctx *sql.Context, upstreamPoint string) error {
+// processCommitBecomesEmptyParams examines the parsed arguments in |apr| for the "empty" arg
+// and returns the empty commit handling strategy to use when a commit being rebased becomes
+// empty. If an invalid argument value is encountered, an error is returned.
+func processCommitBecomesEmptyParams(apr *argparser.ArgParseResults) (doltdb.EmptyCommitHandling, error) {
+	commitBecomesEmptyParam, isCommitBecomesEmptySpecified := apr.GetValue(cli.EmptyParam)
+	if !isCommitBecomesEmptySpecified {
+		// If no option is specified, then by default, commits that become empty are dropped
+		return doltdb.DropEmptyCommit, nil
+	}
+
+	if strings.EqualFold(commitBecomesEmptyParam, "keep") {
+		return doltdb.KeepEmptyCommit, nil
+	} else if strings.EqualFold(commitBecomesEmptyParam, "drop") {
+		return doltdb.DropEmptyCommit, nil
+	} else {
+		return -1, fmt.Errorf("unsupported option for the empty flag (%s); "+
+			"only 'keep' or 'drop' are allowed", commitBecomesEmptyParam)
+	}
+}
+
+// startRebase starts a new interactive rebase operation. |upstreamPoint| specifies the commit where the new rebased
+// commits will be based off of, |commitBecomesEmptyHandling| specifies how to  handle commits that are not empty, but
+// do not produce any changes when applied, and |emptyCommitHandling| specifies how to handle empty commits.
+func startRebase(ctx *sql.Context, upstreamPoint string, commitBecomesEmptyHandling doltdb.EmptyCommitHandling, emptyCommitHandling doltdb.EmptyCommitHandling) error {
 	if upstreamPoint == "" {
 		return fmt.Errorf("no upstream branch specified")
 	}
@@ -245,7 +279,8 @@ func startRebase(ctx *sql.Context, upstreamPoint string) error {
 		return err
 	}
 
-	newWorkingSet, err := workingSet.StartRebase(ctx, upstreamCommit, rebaseBranch, branchRoots.Working)
+	newWorkingSet, err := workingSet.StartRebase(ctx, upstreamCommit, rebaseBranch, branchRoots.Working,
+		commitBecomesEmptyHandling, emptyCommitHandling)
 	if err != nil {
 		return err
 	}
@@ -415,7 +450,9 @@ func continueRebase(ctx *sql.Context) (string, error) {
 	}
 
 	for _, step := range rebasePlan.Steps {
-		err = processRebasePlanStep(ctx, &step)
+		err = processRebasePlanStep(ctx, &step,
+			workingSet.RebaseState().CommitBecomesEmptyHandling(),
+			workingSet.RebaseState().EmptyCommitHandling())
 		if err != nil {
 			return "", err
 		}
@@ -471,7 +508,8 @@ func continueRebase(ctx *sql.Context) (string, error) {
 	}, doltSession.Provider(), nil)
 }
 
-func processRebasePlanStep(ctx *sql.Context, planStep *rebase.RebasePlanStep) error {
+func processRebasePlanStep(ctx *sql.Context, planStep *rebase.RebasePlanStep,
+	commitBecomesEmptyHandling doltdb.EmptyCommitHandling, emptyCommitHandling doltdb.EmptyCommitHandling) error {
 	// Make sure we have a transaction opened for the session
 	// NOTE: After our first call to cherry-pick, the tx is committed, so a new tx needs to be started
 	//       as we process additional rebase actions.
@@ -483,19 +521,24 @@ func processRebasePlanStep(ctx *sql.Context, planStep *rebase.RebasePlanStep) er
 		}
 	}
 
+	// Override the default empty commit handling options for cherry-pick, since
+	// rebase has different defaults
+	options := cherry_pick.NewCherryPickOptions()
+	options.CommitBecomesEmptyHandling = commitBecomesEmptyHandling
+	options.EmptyCommitHandling = emptyCommitHandling
+
 	switch planStep.Action {
 	case rebase.RebaseActionDrop:
 		return nil
 
 	case rebase.RebaseActionPick, rebase.RebaseActionReword:
-		options := cherry_pick.CherryPickOptions{}
 		if planStep.Action == rebase.RebaseActionReword {
 			options.CommitMessage = planStep.CommitMsg
 		}
 		return handleRebaseCherryPick(ctx, planStep.CommitHash, options)
 
 	case rebase.RebaseActionSquash, rebase.RebaseActionFixup:
-		options := cherry_pick.CherryPickOptions{Amend: true}
+		options.Amend = true
 		if planStep.Action == rebase.RebaseActionSquash {
 			commitMessage, err := squashCommitMessage(ctx, planStep.CommitHash)
 			if err != nil {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_rebase.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_rebase.go
@@ -240,6 +240,133 @@ var DoltRebaseScriptTests = []queries.ScriptTest{
 		},
 	},
 	{
+		Name: "dolt_rebase: rebased commit becomes empty; --empty not specified",
+		SetUpScript: []string{
+			"create table t (pk int primary key);",
+			"call dolt_commit('-Am', 'creating table t');",
+			"call dolt_branch('branch1');",
+
+			"insert into t values (0);",
+			"call dolt_commit('-am', 'inserting row 0 on main');",
+
+			"call dolt_checkout('branch1');",
+			"insert into t values (0);",
+			"call dolt_commit('-am', 'inserting row 0 on branch1');",
+			"insert into t values (10);",
+			"call dolt_commit('-am', 'inserting row 10 on branch1');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "call dolt_rebase('-i', 'main');",
+				Expected: []sql.Row{{0, "interactive rebase started on branch dolt_rebase_branch1; " +
+					"adjust the rebase plan in the dolt_rebase table, then " +
+					"continue rebasing by calling dolt_rebase('--continue')"}},
+			},
+			{
+				Query:    "select active_branch();",
+				Expected: []sql.Row{{"dolt_rebase_branch1"}},
+			},
+			{
+				Query:    "call dolt_rebase('--continue');",
+				Expected: []sql.Row{{0, "Successfully rebased and updated refs/heads/branch1"}},
+			},
+			{
+				Query: "select message from dolt_log;",
+				Expected: []sql.Row{
+					{"inserting row 10 on branch1"},
+					{"inserting row 0 on main"},
+					{"creating table t"},
+					{"Initialize data repository"},
+				},
+			},
+		},
+	},
+	{
+		Name: "dolt_rebase: rebased commit becomes empty; --empty=keep",
+		SetUpScript: []string{
+			"create table t (pk int primary key);",
+			"call dolt_commit('-Am', 'creating table t');",
+			"call dolt_branch('branch1');",
+
+			"insert into t values (0);",
+			"call dolt_commit('-am', 'inserting row 0 on main');",
+
+			"call dolt_checkout('branch1');",
+			"insert into t values (0);",
+			"call dolt_commit('-am', 'inserting row 0 on branch1');",
+			"insert into t values (10);",
+			"call dolt_commit('-am', 'inserting row 10 on branch1');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "call dolt_rebase('-i', '--empty', 'keep', 'main');",
+				Expected: []sql.Row{{0, "interactive rebase started on branch dolt_rebase_branch1; " +
+					"adjust the rebase plan in the dolt_rebase table, then " +
+					"continue rebasing by calling dolt_rebase('--continue')"}},
+			},
+			{
+				Query:    "select active_branch();",
+				Expected: []sql.Row{{"dolt_rebase_branch1"}},
+			},
+			{
+				Query:    "call dolt_rebase('--continue');",
+				Expected: []sql.Row{{0, "Successfully rebased and updated refs/heads/branch1"}},
+			},
+			{
+				Query: "select message from dolt_log;",
+				Expected: []sql.Row{
+					{"inserting row 10 on branch1"},
+					{"inserting row 0 on branch1"},
+					{"inserting row 0 on main"},
+					{"creating table t"},
+					{"Initialize data repository"},
+				},
+			},
+		},
+	},
+	{
+		Name: "dolt_rebase: rebased commit becomes empty; --empty=drop",
+		SetUpScript: []string{
+			"create table t (pk int primary key);",
+			"call dolt_commit('-Am', 'creating table t');",
+			"call dolt_branch('branch1');",
+
+			"insert into t values (0);",
+			"call dolt_commit('-am', 'inserting row 0 on main');",
+
+			"call dolt_checkout('branch1');",
+			"insert into t values (0);",
+			"call dolt_commit('-am', 'inserting row 0 on branch1');",
+			"insert into t values (10);",
+			"call dolt_commit('-am', 'inserting row 10 on branch1');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "call dolt_rebase('-i', '--empty', 'drop', 'main');",
+				Expected: []sql.Row{{0, "interactive rebase started on branch dolt_rebase_branch1; " +
+					"adjust the rebase plan in the dolt_rebase table, then " +
+					"continue rebasing by calling dolt_rebase('--continue')"}},
+			},
+			{
+				Query:    "select active_branch();",
+				Expected: []sql.Row{{"dolt_rebase_branch1"}},
+			},
+			{
+				Query:    "call dolt_rebase('--continue');",
+				Expected: []sql.Row{{0, "Successfully rebased and updated refs/heads/branch1"}},
+			},
+			{
+				Query: "select message from dolt_log;",
+				Expected: []sql.Row{
+					{"inserting row 10 on branch1"},
+					{"inserting row 0 on main"},
+					{"creating table t"},
+					{"Initialize data repository"},
+				},
+			},
+		},
+	},
+	{
 		Name: "dolt_rebase: no commits to rebase",
 		SetUpScript: []string{
 			"create table t (pk int primary key);",

--- a/go/serial/workingset.fbs
+++ b/go/serial/workingset.fbs
@@ -52,6 +52,12 @@ table RebaseState {
 
   // The commit that we are rebasing onto.
   onto_commit_addr:[ubyte] (required);
+
+  // How to handle commits that start off empty
+  empty_commit_handling:uint8;
+
+  // How to handle commits that become empty during rebasing
+  commit_becomes_empty_handling:uint8;
 }
 
 // KEEP THIS IN SYNC WITH fileidentifiers.go

--- a/go/store/datas/dataset.go
+++ b/go/store/datas/dataset.go
@@ -162,9 +162,11 @@ type WorkingSetHead struct {
 }
 
 type RebaseState struct {
-	preRebaseWorkingAddr *hash.Hash
-	ontoCommitAddr       *hash.Hash
-	branch               string
+	preRebaseWorkingAddr       *hash.Hash
+	ontoCommitAddr             *hash.Hash
+	branch                     string
+	commitBecomesEmptyHandling uint8
+	emptyCommitHandling        uint8
 }
 
 func (rs *RebaseState) PreRebaseWorkingAddr() hash.Hash {
@@ -184,6 +186,14 @@ func (rs *RebaseState) OntoCommit(ctx context.Context, vr types.ValueReader) (*C
 		return LoadCommitAddr(ctx, vr, *rs.ontoCommitAddr)
 	}
 	return nil, nil
+}
+
+func (rs *RebaseState) CommitBecomesEmptyHandling(_ context.Context) uint8 {
+	return rs.commitBecomesEmptyHandling
+}
+
+func (rs *RebaseState) EmptyCommitHandling(_ context.Context) uint8 {
+	return rs.emptyCommitHandling
 }
 
 type MergeState struct {
@@ -433,7 +443,10 @@ func (h serialWorkingSetHead) HeadWorkingSet() (*WorkingSetHead, error) {
 		ret.RebaseState = NewRebaseState(
 			hash.New(rebaseState.PreWorkingRootAddrBytes()),
 			hash.New(rebaseState.OntoCommitAddrBytes()),
-			string(rebaseState.BranchBytes()))
+			string(rebaseState.BranchBytes()),
+			rebaseState.CommitBecomesEmptyHandling(),
+			rebaseState.EmptyCommitHandling(),
+		)
 	}
 
 	return &ret, nil

--- a/go/store/datas/workingset.go
+++ b/go/store/datas/workingset.go
@@ -192,6 +192,8 @@ func workingset_flatbuffer(working hash.Hash, staged *hash.Hash, mergeState *Mer
 		serial.RebaseStateAddPreWorkingRootAddr(builder, preRebaseRootAddrOffset)
 		serial.RebaseStateAddBranch(builder, branchOffset)
 		serial.RebaseStateAddOntoCommitAddr(builder, ontoAddrOffset)
+		serial.RebaseStateAddCommitBecomesEmptyHandling(builder, rebaseState.commitBecomesEmptyHandling)
+		serial.RebaseStateAddEmptyCommitHandling(builder, rebaseState.emptyCommitHandling)
 		rebaseStateOffset = serial.RebaseStateEnd(builder)
 	}
 
@@ -260,11 +262,13 @@ func NewMergeState(
 	}
 }
 
-func NewRebaseState(preRebaseWorkingRoot hash.Hash, commitAddr hash.Hash, branch string) *RebaseState {
+func NewRebaseState(preRebaseWorkingRoot hash.Hash, commitAddr hash.Hash, branch string, commitBecomesEmptyHandling uint8, emptyCommitHandling uint8) *RebaseState {
 	return &RebaseState{
-		preRebaseWorkingAddr: &preRebaseWorkingRoot,
-		ontoCommitAddr:       &commitAddr,
-		branch:               branch,
+		preRebaseWorkingAddr:       &preRebaseWorkingRoot,
+		ontoCommitAddr:             &commitAddr,
+		branch:                     branch,
+		commitBecomesEmptyHandling: commitBecomesEmptyHandling,
+		emptyCommitHandling:        emptyCommitHandling,
 	}
 }
 

--- a/integration-tests/bats/cherry-pick.bats
+++ b/integration-tests/bats/cherry-pick.bats
@@ -78,9 +78,16 @@ teardown() {
 @test "cherry-pick: no changes" {
     dolt commit --allow-empty -am "empty commit"
     dolt checkout main
+
+    # If an empty commit is cherry-picked, Git will stop the cherry-pick and allow you to manually commit it
+    # with the --allow-empty flag. We don't support that yet, so instead, empty commits generate an error.
     run dolt cherry-pick branch1
+    [ "$status" -eq "1" ]
+    [[ "$output" =~ "The previous cherry-pick commit is empty. Use --allow-empty to cherry-pick empty commits." ]] || false
+
+    # If the --allow-empty flag is specified, then empty commits can be automatically cherry-picked.
+    run dolt cherry-pick --allow-empty branch1
     [ "$status" -eq "0" ]
-    [[ "$output" =~ "No changes were made" ]] || false
 }
 
 @test "cherry-pick: invalid hash" {

--- a/integration-tests/bats/cherry-pick.bats
+++ b/integration-tests/bats/cherry-pick.bats
@@ -75,7 +75,7 @@ teardown() {
     [[ "$output" =~ "ancestor" ]] || false
 }
 
-@test "cherry-pick: no changes" {
+@test "cherry-pick: empty commit handling" {
     dolt commit --allow-empty -am "empty commit"
     dolt checkout main
 

--- a/integration-tests/bats/sql-cherry-pick.bats
+++ b/integration-tests/bats/sql-cherry-pick.bats
@@ -94,7 +94,13 @@ CALL DOLT_CHECKOUT('main');
 CALL DOLT_CHERRY_PICK('branch1');
 SQL
     [ "$status" -eq "1" ]
-    [[ "$output" =~ "no changes were made, nothing to commit" ]] || false
+    [[ "$output" =~ "The previous cherry-pick commit is empty. Use --allow-empty to cherry-pick empty commits." ]] || false
+
+    # Calling dolt_cherry_pick with --allow-empty creates the empty commit
+    run dolt sql<<SQL
+CALL DOLT_CHERRY_PICK('--allow-empty', 'branch1');
+SQL
+    [ "$status" -eq "0" ]
 }
 
 @test "sql-cherry-pick: invalid hash" {

--- a/integration-tests/bats/sql-cherry-pick.bats
+++ b/integration-tests/bats/sql-cherry-pick.bats
@@ -87,7 +87,7 @@ SQL
     [[ "$output" =~ "ancestor" ]] || false
 }
 
-@test "sql-cherry-pick: no changes" {
+@test "sql-cherry-pick: empty commit handling" {
     run dolt sql<<SQL
 CALL DOLT_COMMIT('--allow-empty', '-m', 'empty commit');
 CALL DOLT_CHECKOUT('main');
@@ -98,6 +98,7 @@ SQL
 
     # Calling dolt_cherry_pick with --allow-empty creates the empty commit
     run dolt sql<<SQL
+CALL DOLT_CHECKOUT('main');
 CALL DOLT_CHERRY_PICK('--allow-empty', 'branch1');
 SQL
     [ "$status" -eq "0" ]


### PR DESCRIPTION
Adds support for the `--empty` option to `dolt_rebase()`. This option controls how commits that **become** empty are handled. For example, if a branch is rebased and all the changes in one commit on that branch have already been applied to the upstream branch, then when that commit is reapplied, it will end up being empty. The two initially supported values are `drop` and `keep`. (Git also supports a `stop` value, which lets the user manually intervene.)

Also adds support for the `--allow-empty` flag for `dolt_cherry_pick()`. This flag controls whether Dolt will cherry-pick empty commits (i.e. commits that start off as empty, not commits that become empty after they are applied). 

These behaviors are slightly confusing for two reasons: 1) Git distinguishes between a commit that starts off empty and a commit that becomes empty while applying its changes, and 2) rebase and cherry-pick have slightly different default values for these two options. The differences are summarized below.

|  | Commits that start empty | Commits that become empty |
|-----| --------------------------| ------------------------------|
| `rebase` | default: `keep`, can be overridden with `--no-keep-empty` (`--keep-empty` is also supported) | default: `drop`, can be overridden with `--empty=keep`. For interactive rebases, the default changes to `stop`, which is not supported by Dolt yet.  |
| `cherry-pick` | default: `fail`, can be overridden with `--allow-empty` | default: `stop`, can be overridden with `--empty=keep` or `--empty=drop`. Dolt does not support `stop` yet, so Dolt's default is to fail.  |

Related issue: https://github.com/dolthub/dolt/issues/7830