### PR TITLE
Fix displaying AddressMap non-leaf nodes in `noms show`

### DIFF
--- a/go/store/cmd/noms/noms_show.go
+++ b/go/store/cmd/noms/noms_show.go
@@ -244,7 +244,12 @@ func outputEncodedValue(ctx context.Context, w io.Writer, value types.Value) err
 			if err != nil {
 				return err
 			}
-			return tree.OutputProllyNodeBytes(w, node)
+			fmt.Fprintf(w, "(rows %d, depth %d) #%s {",
+				node.Count(), node.Level()+1, node.HashOf().String()[:8])
+			err = tree.OutputAddressMapNode(w, node)
+			fmt.Fprintf(w, "}\n")
+			return err
+
 		default:
 			return types.WriteEncodedValue(ctx, w, value)
 		}


### PR DESCRIPTION
This fixes an index out of bounds panic when trying to display AddressMap non-leaf nodes in `noms show`.

I didn't add a regression test, because it turns out that all `noms show` tests only work against the old deprecated format, so adding more tests to the test suite wouldn't actually do anything. It's also mostly unused: we basically only use it as part `splunk.pl` to visualize chunks for debugging.

Instead of fixing the test suite, it would be a better use of my time to fully deprecate `noms show` and switch `splunk.pl` to use `dolt show` instead. Especially now that https://github.com/dolthub/dolt/pull/8143 added support for visualizing prolly tree chunks in `dolt show`, bringing it to feature parity with `noms show`.