### PR TITLE
support \checkout, \merge, \show

### DIFF
--- a/go/cmd/dolt/cli/cli_context.go
+++ b/go/cmd/dolt/cli/cli_context.go
@@ -27,7 +27,12 @@ import (
 
 // LateBindQueryist is a function that will be called the first time Queryist is needed for use. Input is a context which
 // is appropriate for the call to commence. Output is a Queryist, a sql.Context, a closer function, and an error.
-// The closer function is called when the Queryist is no longer needed, typically a defer right after getting it.
+//
+// The closer function is called when the Queryist is no longer needed, typically a defer right after getting it. If a nil
+// closer function is returned, then the caller knows that the queryist returned is being managed by another command. Effectively
+// this means you are running in another command's session. This is particularly interesting when running a \checkout in a
+// dolt sql session. It makes sense to do so in the context of `dolt sql`, but not in the context of `dolt checkout` when
+// connected to a remote server.
 type LateBindQueryist func(ctx context.Context) (Queryist, *sql.Context, func(), error)
 
 // CliContexct is used to pass top level command information down to subcommands.

--- a/go/cmd/dolt/cli/messages.go
+++ b/go/cmd/dolt/cli/messages.go
@@ -19,5 +19,5 @@ package cli
 const (
 	// Single variable - the name of the command. `dolt <command>` is how the commandString is formated in calls to the Exec method
 	// for dolt commands.
-	RemoteUnsupportedMsg = "%s can not currently be used when there is a local server running. Please stop your dolt sql-server and try again."
+	RemoteUnsupportedMsg = "%s can not currently be used when there is a local server running. Please stop your dolt sql-server or connect using `dolt sql` instead."
 )

--- a/go/cmd/dolt/commands/merge.go
+++ b/go/cmd/dolt/commands/merge.go
@@ -106,12 +106,12 @@ func (cmd MergeCmd) Exec(ctx context.Context, commandStr string, args []string, 
 	}
 	if closeFunc != nil {
 		defer closeFunc()
-	}
 
-	if _, ok := queryist.(*engine.SqlEngine); !ok {
-		msg := fmt.Sprintf(cli.RemoteUnsupportedMsg, commandStr)
-		cli.Println(msg)
-		return 1
+		if _, ok := queryist.(*engine.SqlEngine); !ok {
+			msg := fmt.Sprintf(cli.RemoteUnsupportedMsg, commandStr)
+			cli.Println(msg)
+			return 1
+		}
 	}
 
 	ok := validateDoltMergeArgs(apr, usage, cliCtx)

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -786,7 +786,7 @@ func execShell(sqlCtx *sql.Context, qryist cli.Queryist, format engine.PrintResu
 
 			sqlCtx := sql.NewContext(subCtx, sql.WithSession(sqlCtx.Session))
 
-			subCmd, foundCmd := findSlashCmd(query)
+			subCmd, foundCmd := isSlashQuery(query)
 			if foundCmd {
 				err := handleSlashCommand(sqlCtx, subCmd, query, cliCtx)
 				if err != nil {
@@ -829,6 +829,15 @@ func execShell(sqlCtx *sql.Context, qryist cli.Queryist, format engine.PrintResu
 	_ = iohelp.WriteLine(cli.CliOut, "Bye")
 
 	return nil
+}
+
+func isSlashQuery(query string) (cli.Command, bool) {
+	// strip leading whitespace
+	query = strings.TrimLeft(query, " \t\n\r\v\f")
+	if strings.HasPrefix(query, "\\") {
+		return findSlashCmd(query[1:])
+	}
+	return nil, false
 }
 
 // postCommandUpdate is a helper function that is run after the shell has completed a command. It updates the the database

--- a/go/cmd/dolt/commands/sql_slash.go
+++ b/go/cmd/dolt/commands/sql_slash.go
@@ -31,6 +31,7 @@ var slashCmds = []cli.Command{
 	StatusCmd{},
 	DiffCmd{},
 	LogCmd{},
+	ShowCmd{},
 	AddCmd{},
 	CommitCmd{},
 	CheckoutCmd{},

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -1089,7 +1089,7 @@ SQL
   run dolt checkout br
   [ $status -eq 1 ]
 
-  [[ $output =~ "dolt checkout can not currently be used when there is a local server running. Please stop your dolt sql-server and try again." ]] || false
+  [[ $output =~ "dolt checkout can not currently be used when there is a local server running. Please stop your dolt sql-server or connect using \`dolt sql\` instead." ]] || false
 }
 
 @test "sql-local-remote: verify unmigrated command will fail with warning" {

--- a/integration-tests/bats/sql-shell-slash-cmds.expect
+++ b/integration-tests/bats/sql-shell-slash-cmds.expect
@@ -84,11 +84,11 @@ expect_with_defaults_2 {Switched to branch 'main'}                      {dolt-re
 
 expect_with_defaults_2 {main cmt}                                       {dolt-repo-[0-9]+/main> }   { send "\\merge br1\r"; }
 
-expect_with_defaults_2 {Everything up-to-date}                          {dolt-repo-[0-9]+/main>}    { send "\\show\r"; }
+expect_with_defaults_2 {Everything up-to-date}                          {dolt-repo-[0-9]+/main> }   { send "\\show\r"; }
 
-expect_with_defaults_2 {Merge branch 'br1'}                             {dolt-repo-[0-9]+/main>}    { send "\\log\r"; }
+expect_with_defaults_2 {Merge branch 'br1'}                             {dolt-repo-[0-9]+/main> }   { send "\\log\r"; }
 
-expect_with_defaults_2 {empty cmt}                                      {dolt-repo-[0-9]+/main>}    { send "\\checkout br1\r"; }
+expect_with_defaults_2 {empty cmt}                                      {dolt-repo-[0-9]+/main> }   { send "\\checkout br1\r"; }
 
 expect_with_defaults_2 {Switched to branch 'br1'}                       {dolt-repo-[0-9]+/br1> }    { send "\\merge main\r"; }
 

--- a/integration-tests/bats/sql-shell-slash-cmds.expect
+++ b/integration-tests/bats/sql-shell-slash-cmds.expect
@@ -24,46 +24,79 @@ proc expect_with_defaults {pattern action} {
         }
     }
 }
+
 proc expect_with_defaults_2 {patternA patternB action} {
+    # First, match patternA
     expect {
         -re $patternA {
-#            puts "Matched pattern: $patternA"
-            exp_continue
-        }
-        -re $patternB {
-#            puts "Matched pattern: $patternB"
-            eval $action
+            puts "<<Matched expected pattern A: $patternA>>"
+            # Now match patternB
+            expect {
+                -re $patternB {
+                    puts "<<Matched expected pattern B: $patternB>>"
+                    eval $action
+                }
+                timeout {
+                    puts "<<Timeout waiting for pattern B>>"
+                    exit 1
+                }
+                eof {
+                    puts "<<End of File reached while waiting for pattern B>>"
+                    exit 1
+                }
+                failed {
+                    puts "<<Failed while waiting for pattern B>>"
+                    exit 1
+                }
+            }
         }
         timeout {
-            puts "<<Timeout>>";
+            puts "<<Timeout waiting for pattern A>>"
             exit 1
         }
         eof {
-            puts "<<End of File reached>>";
+            puts "<<End of File reached while waiting for pattern A>>"
             exit 1
         }
         failed {
-            puts "<<Failed>>";
+            puts "<<Failed while waiting for pattern A>>"
             exit 1
         }
     }
 }
 
 
-
 spawn dolt sql
 
-expect_with_defaults {dolt-repo-[0-9]+/main\*> } { send "\\commit -A -m \"sql-shell-slash-cmds commit\"\r"; }
+expect_with_defaults                                                    {dolt-repo-[0-9]+/main\*> } { send "\\commit -A -m \"sql-shell-slash-cmds commit\"\r"; }
 
-expect_with_defaults {dolt-repo-[0-9]+/main> }   { send "\\log -n 1;\r"; }
+expect_with_defaults                                                    {dolt-repo-[0-9]+/main> }   { send "\\log -n 1;\r"; }
 
-expect_with_defaults_2 {sql-shell-slash-cmds commit} {dolt-repo-[0-9]+/main> } { send "\\status\r"; }
+expect_with_defaults_2 {sql-shell-slash-cmds commit}                    {dolt-repo-[0-9]+/main> }   { send "\\status\r"; }
 
-expect_with_defaults {dolt-repo-[0-9]+/main> }   { send "\\reset HEAD~1;\r"; }
+expect_with_defaults_2 {nothing to commit, working tree clean}          {dolt-repo-[0-9]+/main> }   { send "\\checkout -b br1\r"; }
 
-expect_with_defaults {dolt-repo-[0-9]+/main\*> } { send "\\diff\r"; }
+expect_with_defaults_2 {Switched to branch 'br1'}                       {dolt-repo-[0-9]+/br1> }    { send "\\commit --allow-empty -m \"empty cmt\"\r"; }
 
-expect_with_defaults_2 {diff --dolt a/tbl b/tbl} {dolt-repo-[0-9]+/main\*> } {send "quit\r";}
+expect_with_defaults_2 {empty cmt}                                      {dolt-repo-[0-9]+/br1> }    { send "\\checkout main\r"; }
+
+expect_with_defaults_2 {Switched to branch 'main'}                      {dolt-repo-[0-9]+/main> }   { send "\\commit --allow-empty -m \"main cmt\"\r"; }
+
+expect_with_defaults_2 {main cmt}                                       {dolt-repo-[0-9]+/main> }   { send "\\merge br1\r"; }
+
+expect_with_defaults_2 {Everything up-to-date}                          {dolt-repo-[0-9]+/main>}    { send "\\log\r"; }
+
+expect_with_defaults_2 {empty cmt}                                      {dolt-repo-[0-9]+/main>}    { send "\\checkout br1\r"; }
+
+expect_with_defaults_2 {Switched to branch 'br1'}                       {dolt-repo-[0-9]+/br1> }    { send "\\merge main\r"; }
+
+expect_with_defaults_2 {Fast-forward}                                   {dolt-repo-[0-9]+/br1> }    { send "\\reset HEAD~3;\r"; }
+
+expect_with_defaults                                                    {dolt-repo-[0-9]+/br1\*> }  { send "\\diff\r"; }
+
+expect_with_defaults_2 {diff --dolt a/test b/test}                      {dolt-repo-[0-9]+/br1\*> }  { send "\\reset main\r"; }
+
+expect_with_defaults                                                    {dolt-repo-[0-9]+/br1> }    { send "quit\r" }
 
 expect eof
 exit

--- a/integration-tests/bats/sql-shell-slash-cmds.expect
+++ b/integration-tests/bats/sql-shell-slash-cmds.expect
@@ -86,7 +86,7 @@ expect_with_defaults_2 {main cmt}                                       {dolt-re
 
 expect_with_defaults_2 {Everything up-to-date}                          {dolt-repo-[0-9]+/main> }   { send "\\show\r"; }
 
-expect_with_defaults_2 {Merge branch 'br1'}                             {dolt-repo-[0-9]+/main> }   { send "\\log\r"; }
+expect_with_defaults_2 {Merge branch 'br1'}                             {dolt-repo-[0-9]+/main> }   { send "\\log -n 3\r"; }
 
 expect_with_defaults_2 {empty cmt}                                      {dolt-repo-[0-9]+/main> }   { send "\\checkout br1\r"; }
 

--- a/integration-tests/bats/sql-shell-slash-cmds.expect
+++ b/integration-tests/bats/sql-shell-slash-cmds.expect
@@ -84,7 +84,9 @@ expect_with_defaults_2 {Switched to branch 'main'}                      {dolt-re
 
 expect_with_defaults_2 {main cmt}                                       {dolt-repo-[0-9]+/main> }   { send "\\merge br1\r"; }
 
-expect_with_defaults_2 {Everything up-to-date}                          {dolt-repo-[0-9]+/main>}    { send "\\log\r"; }
+expect_with_defaults_2 {Everything up-to-date}                          {dolt-repo-[0-9]+/main>}    { send "\\show\r"; }
+
+expect_with_defaults_2 {Merge branch 'br1'}                             {dolt-repo-[0-9]+/main>}    { send "\\log\r"; }
 
 expect_with_defaults_2 {empty cmt}                                      {dolt-repo-[0-9]+/main>}    { send "\\checkout br1\r"; }
 


### PR DESCRIPTION
Until now there was an awkward behavior in `dolt sql` shell where the \checkout and \merge commands didn't really play nice when they could have. Specifically, if you used `dolt sql` and it was connected to a remote host, then running `\checkout` would give you an error telling you to stop the server. That is no longer the case. \checkout and \merge will work well in the `dolt sql` shell when connected to a remote host now.

Also added the \show command

And made the expect tests more correct and expanded.