### PR TITLE
Add dolt_workspace_* system tables

### DIFF
--- a/go/libraries/doltcore/doltdb/system_table.go
+++ b/go/libraries/doltcore/doltdb/system_table.go
@@ -185,10 +185,6 @@ var generatedSystemTables = []string{
 	RemotesTableName,
 }
 
-var generatedSystemViewPrefixes = []string{
-	DoltBlameViewPrefix,
-}
-
 var generatedSystemTablePrefixes = []string{
 	DoltDiffTablePrefix,
 	DoltCommitDiffTablePrefix,

--- a/go/libraries/doltcore/doltdb/system_table.go
+++ b/go/libraries/doltcore/doltdb/system_table.go
@@ -191,6 +191,7 @@ var generatedSystemTablePrefixes = []string{
 	DoltHistoryTablePrefix,
 	DoltConfTablePrefix,
 	DoltConstViolTablePrefix,
+	DoltWorkspaceTablePrefix,
 }
 
 const (
@@ -260,6 +261,8 @@ const (
 	DoltConfTablePrefix = "dolt_conflicts_"
 	// DoltConstViolTablePrefix is the prefix assigned to all the generated constraint violation tables
 	DoltConstViolTablePrefix = "dolt_constraint_violations_"
+	// DoltWorkspaceTablePrefix is the prefix assigned to all the generated workspace tables
+	DoltWorkspaceTablePrefix = "dolt_workspace_"
 )
 
 const (

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -399,32 +399,11 @@ func (db Database) getTableInsensitive(ctx *sql.Context, head *doltdb.Commit, ds
 		return dt, true, nil
 	case strings.HasPrefix(lwrName, doltdb.DoltWorkspaceTablePrefix):
 		sess := dsess.DSessFromSess(ctx.Session)
-		/*
-			adapter := dsess.NewSessionStateAdapter(
-				sess, db.RevisionQualifiedName(),
-				concurrentmap.New[string, env.Remote](),
-				concurrentmap.New[string, env.BranchConfig](),
-				concurrentmap.New[string, env.Remote](),
-			)
-		*/
-		if head == nil {
-			var err error
-			head, err = ds.GetHeadCommit(ctx, db.RevisionQualifiedName())
+		roots, _ := sess.GetRoots(ctx, db.RevisionQualifiedName())
 
-			if err != nil {
-				return nil, false, err
-			}
-		}
-		baseRoot, err := head.GetRootValue(ctx)
+		userTable := tblName[len(doltdb.DoltWorkspaceTablePrefix):]
 
-		ws, err := sess.WorkingSet(ctx, db.RevisionQualifiedName())
-		if err != nil {
-			return nil, false, err
-		}
-
-		suffix := tblName[len(doltdb.DoltWorkspaceTablePrefix):]
-
-		dt, err := dtables.NewWorkspaceTable(ctx, suffix, baseRoot, ws)
+		dt, err := dtables.NewWorkspaceTable(ctx, userTable, roots)
 		if err != nil {
 			return nil, false, err
 		}

--- a/go/libraries/doltcore/sqle/dolt_diff_table_function.go
+++ b/go/libraries/doltcore/sqle/dolt_diff_table_function.go
@@ -186,7 +186,7 @@ func (dtf *DiffTableFunction) RowIter(ctx *sql.Context, _ sql.Row) (sql.RowIter,
 	ddb := sqledb.DbData().Ddb
 	dp := dtables.NewDiffPartition(dtf.tableDelta.ToTable, dtf.tableDelta.FromTable, toCommitStr, fromCommitStr, dtf.toDate, dtf.fromDate, dtf.tableDelta.ToSch, dtf.tableDelta.FromSch)
 
-	return dtables.NewDiffPartitionRowIter(*dp, ddb, dtf.joiner), nil
+	return dtables.NewDiffPartitionRowIter(dp, ddb, dtf.joiner), nil
 }
 
 // findMatchingDelta returns the best matching table delta for the table name

--- a/go/libraries/doltcore/sqle/dolt_patch_table_function.go
+++ b/go/libraries/doltcore/sqle/dolt_patch_table_function.go
@@ -632,7 +632,7 @@ func getDiffQuery(ctx *sql.Context, dbData env.DbData, td diff.TableDelta, fromR
 	diffQuerySqlSch, projections := getDiffQuerySqlSchemaAndProjections(diffPKSch.Schema, columnsWithDiff)
 
 	dp := dtables.NewDiffPartition(td.ToTable, td.FromTable, toRefDetails.hashStr, fromRefDetails.hashStr, toRefDetails.commitTime, fromRefDetails.commitTime, td.ToSch, td.FromSch)
-	ri := dtables.NewDiffPartitionRowIter(*dp, dbData.Ddb, j)
+	ri := dtables.NewDiffPartitionRowIter(dp, dbData.Ddb, j)
 
 	return diffQuerySqlSch, projections, ri, nil
 }

--- a/go/libraries/doltcore/sqle/dtables/column_diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/column_diff_table.go
@@ -527,7 +527,7 @@ func calculateColDelta(ctx *sql.Context, ddb *doltdb.DoltDB, delta *diff.TableDe
 	now := time.Now() // accurate commit time returned elsewhere
 	// TODO: schema name?
 	dp := NewDiffPartition(delta.ToTable, delta.FromTable, delta.ToName.Name, delta.FromName.Name, (*dtypes.Timestamp)(&now), (*dtypes.Timestamp)(&now), delta.ToSch, delta.FromSch)
-	ri := NewDiffPartitionRowIter(*dp, ddb, j)
+	ri := NewDiffPartitionRowIter(dp, ddb, j)
 
 	var resultColNames []string
 	var resultDiffTypes []string

--- a/go/libraries/doltcore/sqle/dtables/diff_iter.go
+++ b/go/libraries/doltcore/sqle/dtables/diff_iter.go
@@ -502,13 +502,13 @@ var _ sql.RowIter = (*diffPartitionRowIter)(nil)
 type diffPartitionRowIter struct {
 	ddb              *doltdb.DoltDB
 	joiner           *rowconv.Joiner
-	currentPartition *sql.Partition
+	currentPartition *DiffPartition
 	currentRowIter   *sql.RowIter
 }
 
-func NewDiffPartitionRowIter(partition sql.Partition, ddb *doltdb.DoltDB, joiner *rowconv.Joiner) *diffPartitionRowIter {
+func NewDiffPartitionRowIter(partition *DiffPartition, ddb *doltdb.DoltDB, joiner *rowconv.Joiner) *diffPartitionRowIter {
 	return &diffPartitionRowIter{
-		currentPartition: &partition,
+		currentPartition: partition,
 		ddb:              ddb,
 		joiner:           joiner,
 	}
@@ -520,8 +520,7 @@ func (itr *diffPartitionRowIter) Next(ctx *sql.Context) (sql.Row, error) {
 			return nil, io.EOF
 		}
 		if itr.currentRowIter == nil {
-			dp := (*itr.currentPartition).(DiffPartition)
-			rowIter, err := dp.GetRowIter(ctx, itr.ddb, itr.joiner, sql.IndexLookup{})
+			rowIter, err := itr.currentPartition.GetRowIter(ctx, itr.ddb, itr.joiner, sql.IndexLookup{})
 			if err != nil {
 				return nil, err
 			}

--- a/go/libraries/doltcore/sqle/dtables/diff_iter.go
+++ b/go/libraries/doltcore/sqle/dtables/diff_iter.go
@@ -369,7 +369,7 @@ func (itr prollyDiffIter) queueRows(ctx context.Context) {
 // todo(andy): copy string fields
 func (itr prollyDiffIter) makeDiffRowItr(ctx context.Context, d tree.Diff) (*repeatingRowIter, error) {
 	if !itr.keyless {
-		r, err := itr.getDiffRow(ctx, d)
+		r, err := itr.getDiffTableRow(ctx, d)
 		if err != nil {
 			return nil, err
 		}
@@ -401,7 +401,7 @@ func (itr prollyDiffIter) getDiffRowAndCardinality(ctx context.Context, d tree.D
 		}
 	}
 
-	r, err = itr.getDiffRow(ctx, d)
+	r, err = itr.getDiffTableRow(ctx, d)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -409,7 +409,9 @@ func (itr prollyDiffIter) getDiffRowAndCardinality(ctx context.Context, d tree.D
 	return r, n, nil
 }
 
-func (itr prollyDiffIter) getDiffRow(ctx context.Context, dif tree.Diff) (row sql.Row, err error) {
+// getDiffTableRow returns a row for the diff table given the diff type and the row from the source and target tables. The
+// output schema is intended for dolt_diff_* tables and dolt_diff function.
+func (itr prollyDiffIter) getDiffTableRow(ctx context.Context, dif tree.Diff) (row sql.Row, err error) {
 	tLen := schemaSize(itr.targetToSch)
 	fLen := schemaSize(itr.targetFromSch)
 

--- a/go/libraries/doltcore/sqle/dtables/diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/diff_table.go
@@ -674,7 +674,7 @@ func (dp DiffPartition) GetRowIter(ctx *sql.Context, ddb *doltdb.DoltDB, joiner 
 	if types.IsFormat_DOLT(ddb.Format()) {
 		return newProllyDiffIter(ctx, dp, dp.fromSch, dp.toSch)
 	} else {
-		return newNomsDiffIter(ctx, ddb, joiner, dp, lookup)
+		return newLdDiffIter(ctx, ddb, joiner, dp, lookup)
 	}
 }
 

--- a/go/libraries/doltcore/sqle/dtables/workspace.go
+++ b/go/libraries/doltcore/sqle/dtables/workspace.go
@@ -20,6 +20,9 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/dolthub/go-mysql-server/sql"
+	sqltypes "github.com/dolthub/go-mysql-server/sql/types"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
@@ -31,8 +34,6 @@ import (
 	"github.com/dolthub/dolt/go/store/prolly/tree"
 	"github.com/dolthub/dolt/go/store/types"
 	"github.com/dolthub/dolt/go/store/val"
-	"github.com/dolthub/go-mysql-server/sql"
-	sqltypes "github.com/dolthub/go-mysql-server/sql/types"
 )
 
 type WorkspaceTable struct {

--- a/go/libraries/doltcore/sqle/dtables/workspace.go
+++ b/go/libraries/doltcore/sqle/dtables/workspace.go
@@ -1,0 +1,594 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dtables
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/index"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/resolve"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlutil"
+	"github.com/dolthub/dolt/go/store/prolly"
+	"github.com/dolthub/dolt/go/store/prolly/tree"
+	"github.com/dolthub/dolt/go/store/types"
+	"github.com/dolthub/dolt/go/store/val"
+	"github.com/dolthub/go-mysql-server/sql"
+	sqltypes "github.com/dolthub/go-mysql-server/sql/types"
+)
+
+type WorkspaceTable struct {
+	base          doltdb.RootValue
+	ws            *doltdb.WorkingSet
+	tableName     string
+	nomsSchema    schema.Schema
+	sqlSchema     sql.Schema
+	stagedDeltas  *diff.TableDelta
+	workingDeltas *diff.TableDelta
+
+	headSchema schema.Schema
+
+	ddb *doltdb.DoltDB
+}
+
+var _ sql.Table = (*WorkspaceTable)(nil)
+
+// NM4 - drop ctx? error
+func NewWorkspaceTable(ctx *sql.Context, tblName string, root doltdb.RootValue, ws *doltdb.WorkingSet) (sql.Table, error) {
+	stageDlt, err := diff.GetTableDeltas(ctx, root, ws.StagedRoot())
+	if err != nil {
+		return nil, err
+	}
+	var stgDel *diff.TableDelta
+	for _, delta := range stageDlt {
+		if delta.ToName.Name == tblName {
+			stgDel = &delta
+			break
+		}
+	}
+
+	workingDlt, err := diff.GetTableDeltas(ctx, root, ws.WorkingRoot())
+	if err != nil {
+		return nil, err
+	}
+
+	var wkDel *diff.TableDelta
+	for _, delta := range workingDlt {
+		if delta.ToName.Name == tblName {
+			wkDel = &delta
+			break
+		}
+	}
+
+	if wkDel == nil && stgDel == nil {
+		emptyTable := emptyWorkspaceTable{tableName: tblName}
+		return &emptyTable, nil
+	}
+
+	var toSch, fromSch schema.Schema
+	if stgDel == nil {
+		toSch, err = wkDel.ToTable.GetSchema(ctx)
+		if err != nil {
+			return nil, err
+		}
+		fromSch, err = wkDel.FromTable.GetSchema(ctx)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		toSch, err = stgDel.ToTable.GetSchema(ctx)
+		if err != nil {
+			return nil, err
+		}
+		fromSch, err = stgDel.FromTable.GetSchema(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	totalSch, err := workspaceSchema(fromSch, toSch)
+	if err != nil {
+		return nil, err
+	}
+	finalSch, err := sqlutil.FromDoltSchema("", "", totalSch)
+	if err != nil {
+		return nil, err
+	}
+
+	return &WorkspaceTable{
+		base:          root,
+		ws:            ws,
+		tableName:     tblName,
+		nomsSchema:    totalSch,
+		sqlSchema:     finalSch.Schema,
+		stagedDeltas:  stgDel,
+		workingDeltas: wkDel,
+		headSchema:    fromSch, // NM4 - convince myself this is correct.
+		ddb:           nil,     // NM4 - not sure what this is for. Drop? I think we'll need it eventually....
+	}, nil
+}
+
+func (wt *WorkspaceTable) Name() string {
+	return doltdb.DoltWorkspaceTablePrefix + wt.tableName
+}
+
+func (wt *WorkspaceTable) String() string {
+	return wt.Name()
+}
+
+func (wt *WorkspaceTable) Schema() sql.Schema {
+	return wt.sqlSchema
+}
+
+// CalculateDiffSchema returns the schema for the dolt_diff table based on the schemas from the from and to tables.
+// Either may be nil, in which case the nil argument will use the schema of the non-nil argument
+func workspaceSchema(fromSch, toSch schema.Schema) (schema.Schema, error) {
+	if fromSch == nil && toSch == nil {
+		return nil, errors.New("Runtime error:non-nil argument required to CalculateDiffSchema")
+	} else if fromSch == nil {
+		fromSch = toSch
+	} else if toSch == nil {
+		toSch = fromSch
+	}
+
+	cols := make([]schema.Column, 0, 2+toSch.GetAllCols().Size()+fromSch.GetAllCols().Size())
+
+	cols = append(cols,
+		schema.NewColumn("id", 0, types.UintKind, true),
+		schema.NewColumn("staged", 1, types.BoolKind, false),
+		schema.NewColumn("diff_type", 2, types.StringKind, false),
+	)
+
+	transformer := func(sch schema.Schema, namer func(string) string) error {
+		return sch.GetAllCols().Iter(func(tag uint64, col schema.Column) (stop bool, err error) {
+			c, err := schema.NewColumnWithTypeInfo(
+				namer(col.Name),
+				uint64(len(cols)),
+				col.TypeInfo,
+				false,
+				col.Default,
+				false,
+				col.Comment)
+			if err != nil {
+				return true, err
+			}
+			cols = append(cols, c)
+			return false, nil
+		})
+	}
+
+	err := transformer(toSch, diff.ToColNamer)
+	if err != nil {
+		return nil, err
+	}
+	err = transformer(fromSch, diff.FromColNamer)
+	if err != nil {
+		return nil, err
+	}
+
+	return schema.UnkeyedSchemaFromCols(schema.NewColCollection(cols...)), nil
+}
+
+func (wt *WorkspaceTable) Collation() sql.CollationID { return sql.Collation_Default }
+
+type WorkspacePartitionItr struct {
+	partition *WorkspacePartition
+}
+
+func (w *WorkspacePartitionItr) Close(_ *sql.Context) error {
+	return nil
+}
+
+func (w *WorkspacePartitionItr) Next(_ *sql.Context) (sql.Partition, error) {
+	if w.partition == nil {
+		return nil, io.EOF
+	}
+	ans := w.partition
+	w.partition = nil
+	return ans, nil
+}
+
+type WorkspacePartition struct {
+	base       *doltdb.Table
+	baseSch    schema.Schema
+	working    *doltdb.Table
+	workingSch schema.Schema
+	staging    *doltdb.Table
+	stagingSch schema.Schema
+}
+
+var _ sql.Partition = (*WorkspacePartition)(nil)
+
+func (w *WorkspacePartition) Key() []byte {
+	// NM4 - is there ever used? We return the table names in the DiffPartition. What is the purpose of this?
+	return []byte("hello world")
+}
+
+func (wt *WorkspaceTable) Partitions(ctx *sql.Context) (sql.PartitionIter, error) {
+	_, baseTable, baseTableExists, err := resolve.Table(ctx, wt.base, wt.tableName)
+	if err != nil {
+		return nil, err
+	}
+	if !baseTableExists {
+		return nil, sql.ErrTableNotFound.New(wt.tableName) // NM4 - not an error. Just no changes. test/fix.
+	}
+	var baseSchema schema.Schema = schema.EmptySchema
+	if baseSchema, err = baseTable.GetSchema(ctx); err != nil {
+		return nil, err
+	}
+
+	_, stagingTable, tableExists, err := resolve.Table(ctx, wt.ws.StagedRoot(), wt.tableName)
+	if err != nil {
+		return nil, err
+	}
+	if !tableExists {
+		return nil, sql.ErrTableNotFound.New(tableName) // NM4 - not an error. Just no changes. test/fix.
+	}
+	var stagingSchema schema.Schema = schema.EmptySchema
+	if stagingSchema, err = stagingTable.GetSchema(ctx); err != nil {
+		return nil, err
+	}
+
+	_, workingTable, tableExists, err := resolve.Table(ctx, wt.ws.WorkingRoot(), wt.tableName)
+	if err != nil {
+		return nil, err
+	}
+	if !tableExists {
+		return nil, sql.ErrTableNotFound.New(tableName) // NM4 - not an error. Just no changes. test/fix.
+	}
+	var workingSchema schema.Schema = schema.EmptySchema
+	if workingSchema, err = workingTable.GetSchema(ctx); err != nil {
+		return nil, err
+	}
+
+	part := WorkspacePartition{
+		base:       baseTable,
+		baseSch:    baseSchema,
+		staging:    stagingTable,
+		stagingSch: stagingSchema,
+		working:    workingTable,
+		workingSch: workingSchema,
+	}
+
+	return &WorkspacePartitionItr{&part}, nil
+}
+
+func (wt *WorkspaceTable) PartitionRows(ctx *sql.Context, part sql.Partition) (sql.RowIter, error) {
+	wp, ok := part.(*WorkspacePartition)
+	if !ok {
+		return nil, fmt.Errorf("Runtime Exception: expected a WorkspacePartition, got %T", part)
+	}
+
+	return newWorkspaceDiffIter(ctx, *wp) // NM4 - base schema. should we use base and staged?
+}
+
+type workspaceDiffIter struct {
+	base    prolly.Map
+	working prolly.Map
+	staging prolly.Map
+
+	baseConverter    ProllyRowConverter
+	workingConverter ProllyRowConverter
+	stagingConverter ProllyRowConverter
+
+	tgtBaseSch    schema.Schema
+	tgtWorkingSch schema.Schema
+	tgtStagingSch schema.Schema
+
+	keyless bool
+
+	rows    chan sql.Row
+	errChan chan error
+	cancel  func()
+}
+
+func (itr workspaceDiffIter) Next(ctx *sql.Context) (sql.Row, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case err := <-itr.errChan:
+		return nil, err
+	case row, ok := <-itr.rows:
+		if !ok {
+			return nil, io.EOF
+		}
+		return row, nil
+	}
+}
+
+func (itr workspaceDiffIter) Close(c *sql.Context) error {
+	itr.cancel()
+	return nil
+}
+
+func getWorkspaceRowAndCardinality(
+	ctx context.Context,
+	idx int,
+	staging bool,
+	toSch schema.Schema,
+	fromSch schema.Schema,
+	toConverter ProllyRowConverter,
+	fromConverter ProllyRowConverter,
+	d tree.Diff,
+) (r sql.Row, n uint64, err error) {
+	switch d.Type {
+	case tree.AddedDiff:
+		n = val.ReadKeylessCardinality(val.Tuple(d.To))
+	case tree.RemovedDiff:
+		n = val.ReadKeylessCardinality(val.Tuple(d.From))
+	case tree.ModifiedDiff:
+		fN := val.ReadKeylessCardinality(val.Tuple(d.From))
+		tN := val.ReadKeylessCardinality(val.Tuple(d.To))
+		if fN < tN {
+			n = tN - fN
+			d.Type = tree.AddedDiff
+		} else {
+			n = fN - tN
+			d.Type = tree.RemovedDiff
+		}
+	}
+
+	r, err = getWorkspaceTableRow(ctx, idx, staging, toSch, fromSch, toConverter, fromConverter, d)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return r, n, nil
+}
+
+// getWorkspaceTableRow returns a row for the diff table given the diff type and the row from the source and target tables. The
+// output schema is intended for dolt_workspace_* tables.
+func getWorkspaceTableRow(
+	ctx context.Context,
+	rowId int,
+	staged bool,
+	toSch schema.Schema,
+	fromSch schema.Schema,
+	toConverter ProllyRowConverter,
+	fromConverter ProllyRowConverter,
+	dif tree.Diff,
+) (row sql.Row, err error) {
+	tLen := schemaSize(toSch)
+	fLen := schemaSize(fromSch)
+
+	if fLen == 0 && dif.Type == tree.AddedDiff {
+		fLen = tLen
+	} else if tLen == 0 && dif.Type == tree.RemovedDiff {
+		tLen = fLen
+	}
+
+	row = make(sql.Row, 3+tLen+fLen)
+
+	row[0] = rowId
+	row[1] = staged
+	row[2] = diffTypeString(dif)
+
+	idx := 3
+
+	if dif.Type != tree.RemovedDiff {
+		err = toConverter.PutConverted(ctx, val.Tuple(dif.Key), val.Tuple(dif.To), row[idx:idx+tLen])
+		if err != nil {
+			return nil, err
+		}
+	}
+	idx += tLen
+
+	if dif.Type != tree.AddedDiff {
+		err = fromConverter.PutConverted(ctx, val.Tuple(dif.Key), val.Tuple(dif.From), row[idx:idx+fLen])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return row, nil
+}
+
+// NM4 - Virtually identical to prollyDiffIter.queueRows, but for workspaces. Dedupe this.
+func (itr *workspaceDiffIter) queueWorkspaceRows(ctx context.Context) {
+
+	idx := 0
+
+	err := prolly.DiffMaps(ctx, itr.base, itr.staging, false, func(ctx context.Context, d tree.Diff) error {
+		dItr, err := itr.makeWorkspaceRowItr(ctx, idx, true, itr.tgtStagingSch, itr.tgtBaseSch, itr.stagingConverter, itr.baseConverter, d)
+		if err != nil {
+			return err
+		}
+		for {
+			r, err := dItr.Next(ctx)
+			if err == io.EOF {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case itr.rows <- r:
+				idx++
+				continue
+			}
+		}
+	})
+
+	if err != nil && err != io.EOF {
+		select {
+		case <-ctx.Done():
+		case itr.errChan <- err:
+		}
+		return
+	}
+
+	err = prolly.DiffMaps(ctx, itr.staging, itr.working, false, func(ctx context.Context, d tree.Diff) error {
+		dItr, err := itr.makeWorkspaceRowItr(ctx, idx, false, itr.tgtWorkingSch, itr.tgtStagingSch, itr.workingConverter, itr.stagingConverter, d)
+		if err != nil {
+			return err
+		}
+		for {
+			r, err := dItr.Next(ctx)
+			if err == io.EOF {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case itr.rows <- r:
+				idx++
+				continue
+			}
+		}
+	})
+
+	// we need to drain itr.rows before returning io.EOF
+	close(itr.rows)
+}
+
+func (itr *workspaceDiffIter) makeWorkspaceRowItr(
+	ctx context.Context,
+	idx int,
+	staging bool,
+	toSch schema.Schema,
+	fromSch schema.Schema,
+	toConverter ProllyRowConverter,
+	fromConverter ProllyRowConverter,
+	d tree.Diff,
+) (*repeatingRowIter, error) {
+	if !itr.keyless {
+		r, err := getWorkspaceTableRow(ctx, idx, staging, toSch, fromSch, toConverter, fromConverter, d)
+		if err != nil {
+			return nil, err
+		}
+		return &repeatingRowIter{row: r, n: 1}, nil
+	}
+
+	r, n, err := getWorkspaceRowAndCardinality(ctx, idx, staging, toSch, fromSch, toConverter, fromConverter, d)
+	if err != nil {
+		return nil, err
+	}
+	return &repeatingRowIter{row: r, n: n}, nil
+}
+
+// NM4 - virtually identical to newProllyDiffIter, but for workspaces. Dedupe this.
+func newWorkspaceDiffIter(ctx *sql.Context, wp WorkspacePartition) (workspaceDiffIter, error) {
+	var base, working, staging prolly.Map
+
+	if wp.base != nil {
+		idx, err := wp.base.GetRowData(ctx)
+		if err != nil {
+			return workspaceDiffIter{}, err
+		}
+		base = durable.ProllyMapFromIndex(idx)
+	}
+
+	if wp.staging != nil {
+		idx, err := wp.staging.GetRowData(ctx)
+		if err != nil {
+			return workspaceDiffIter{}, err
+		}
+		staging = durable.ProllyMapFromIndex(idx)
+	}
+
+	if wp.working != nil {
+		idx, err := wp.working.GetRowData(ctx)
+		if err != nil {
+			return workspaceDiffIter{}, err
+		}
+		working = durable.ProllyMapFromIndex(idx)
+	}
+
+	nodeStore := wp.base.NodeStore()
+
+	baseConverter, err := NewProllyRowConverter(wp.baseSch, wp.baseSch, ctx.Warn, nodeStore)
+	if err != nil {
+		return workspaceDiffIter{}, err
+	}
+
+	stagingConverter, err := NewProllyRowConverter(wp.stagingSch, wp.stagingSch, ctx.Warn, nodeStore)
+	if err != nil {
+		return workspaceDiffIter{}, err
+	}
+
+	workingConverter, err := NewProllyRowConverter(wp.workingSch, wp.workingSch, ctx.Warn, nodeStore)
+	if err != nil {
+		return workspaceDiffIter{}, err
+	}
+
+	keyless := schema.IsKeyless(wp.baseSch) && schema.IsKeyless(wp.stagingSch) && schema.IsKeyless(wp.workingSch)
+	child, cancel := context.WithCancel(ctx)
+	iter := workspaceDiffIter{
+		base:    base,
+		working: working,
+		staging: staging,
+
+		tgtBaseSch:    wp.baseSch,
+		tgtWorkingSch: wp.workingSch,
+		tgtStagingSch: wp.stagingSch,
+
+		baseConverter:    baseConverter,
+		workingConverter: workingConverter,
+		stagingConverter: stagingConverter,
+
+		keyless: keyless,
+		rows:    make(chan sql.Row, 64),
+		errChan: make(chan error),
+		cancel:  cancel,
+	}
+
+	go func() {
+		iter.queueWorkspaceRows(child)
+	}()
+
+	return iter, nil
+}
+
+type emptyWorkspaceTable struct {
+	tableName string
+}
+
+var _ sql.Table = (*emptyWorkspaceTable)(nil)
+
+func (e emptyWorkspaceTable) Name() string {
+	return "dolt_workspace_" + e.tableName
+}
+
+func (e emptyWorkspaceTable) String() string {
+	return e.Name()
+}
+
+func (e emptyWorkspaceTable) Schema() sql.Schema {
+	return []*sql.Column{
+		{Name: "id", Type: sqltypes.Int32, Nullable: false},
+		{Name: "staged", Type: sqltypes.Boolean, Nullable: false},
+	}
+}
+
+func (e emptyWorkspaceTable) Collation() sql.CollationID { return sql.Collation_Default }
+
+func (e emptyWorkspaceTable) Partitions(c *sql.Context) (sql.PartitionIter, error) {
+	return index.SinglePartitionIterFromNomsMap(nil), nil
+}
+
+func (e emptyWorkspaceTable) PartitionRows(c *sql.Context, partition sql.Partition) (sql.RowIter, error) {
+	return sql.RowsToRowIter(), nil
+}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -2052,3 +2052,8 @@ func TestStatsAutoRefreshConcurrency(t *testing.T) {
 		wg.Wait()
 	}
 }
+
+func TestDoltWorkspace(t *testing.T) {
+	harness := newDoltEnginetestHarness(t)
+	RunDoltWorkspaceTests(t, harness)
+}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_tests.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_tests.go
@@ -1960,3 +1960,13 @@ func RunDoltReflogTestsPrepared(t *testing.T, h DoltEnginetestHarness) {
 		}()
 	}
 }
+
+func RunDoltWorkspaceTests(t *testing.T, h DoltEnginetestHarness) {
+	for _, script := range DoltWorkspaceScriptTests {
+		func() {
+			h = h.NewHarness(t)
+			defer h.Close()
+			enginetest.TestScript(t, h, script)
+		}()
+	}
+}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -7176,6 +7176,7 @@ var DoltSystemVariables = []queries.ScriptTest{
 					{"dolt_remote_branches"},
 					{"dolt_remotes"},
 					{"dolt_status"},
+					{"dolt_workspace_test"},
 					{"test"},
 				},
 			},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_workspace.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_workspace.go
@@ -20,6 +20,7 @@ import (
 )
 
 var DoltWorkspaceScriptTests = []queries.ScriptTest{
+
 	{
 		Name: "dolt_workspace_* multiple edits of a single row",
 		SetUpScript: []string{
@@ -226,6 +227,46 @@ var DoltWorkspaceScriptTests = []queries.ScriptTest{
 				Expected: []sql.Row{
 					{0, true, "removed", nil, nil, 42, 42},
 					{1, true, "removed", nil, nil, 43, 43},
+				},
+			},
+		},
+	},
+
+	{
+		Name: "dolt_workspace_* keyless table",
+		SetUpScript: []string{
+			"create table tbl (x int, y int);",
+			"insert into tbl values (42,42);",
+			"insert into tbl values (42,42);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "select * from dolt_workspace_tbl",
+				Expected: []sql.Row{
+					{0, false, "added", 42, 42, nil, nil},
+					{1, false, "added", 42, 42, nil, nil},
+				},
+			},
+
+			{
+				Query: "call dolt_add('tbl');",
+			},
+			{
+				Query: "select * from dolt_workspace_tbl",
+				Expected: []sql.Row{
+					{0, true, "added", 42, 42, nil, nil},
+					{1, true, "added", 42, 42, nil, nil},
+				},
+			},
+			{
+				Query: "insert into tbl values (42,42);",
+			},
+			{
+				Query: "select * from dolt_workspace_tbl",
+				Expected: []sql.Row{
+					{0, true, "added", 42, 42, nil, nil},
+					{1, true, "added", 42, 42, nil, nil},
+					{2, false, "added", 42, 42, nil, nil},
 				},
 			},
 		},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_workspace.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_workspace.go
@@ -91,7 +91,7 @@ var DoltWorkspaceScriptTests = []queries.ScriptTest{
 
 			"insert into tbl values (42,42);",
 			"insert into tbl values (43,43);",
-			"call dolt_commit('-am', 'inserting rows 3 rows at HEAD');",
+			"call dolt_commit('-am', 'inserting 2 rows at HEAD');",
 			"insert into tbl values (44,44);",
 		},
 		Assertions: []queries.ScriptTestAssertion{

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_workspace.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_workspace.go
@@ -159,7 +159,7 @@ var DoltWorkspaceScriptTests = []queries.ScriptTest{
 
 			"insert into tbl values (42,42);",
 			"insert into tbl values (43,43);",
-			"call dolt_commit('-am', 'inserting rows 3 rows at HEAD');",
+			"call dolt_commit('-am', 'inserting 2 rows at HEAD');",
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_workspace.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_workspace.go
@@ -33,7 +33,6 @@ var DoltWorkspaceScriptTests = []queries.ScriptTest{
 			"update tbl set val=51 where pk=42;",
 			"call dolt_add('tbl');",
 		},
-
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query: "select * from dolt_workspace_tbl",
@@ -74,7 +73,6 @@ var DoltWorkspaceScriptTests = []queries.ScriptTest{
 
 			"update tbl set val=51 where pk=42;",
 		},
-
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query: "select * from dolt_workspace_tbl",
@@ -95,7 +93,6 @@ var DoltWorkspaceScriptTests = []queries.ScriptTest{
 			"call dolt_commit('-am', 'inserting rows 3 rows at HEAD');",
 			"insert into tbl values (44,44);",
 		},
-
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query: "select * from dolt_workspace_tbl",
@@ -124,7 +121,6 @@ var DoltWorkspaceScriptTests = []queries.ScriptTest{
 			},
 		},
 	},
-
 	{
 		Name: "dolt_workspace_* deleted row",
 		SetUpScript: []string{
@@ -136,7 +132,6 @@ var DoltWorkspaceScriptTests = []queries.ScriptTest{
 			"call dolt_commit('-am', 'inserting rows 3 rows at HEAD');",
 			"delete from tbl where pk = 42;",
 		},
-
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query: "select * from dolt_workspace_tbl",
@@ -155,7 +150,6 @@ var DoltWorkspaceScriptTests = []queries.ScriptTest{
 			},
 		},
 	},
-
 	{
 		Name: "dolt_workspace_* clean workspace",
 		SetUpScript: []string{
@@ -166,7 +160,6 @@ var DoltWorkspaceScriptTests = []queries.ScriptTest{
 			"insert into tbl values (43,43);",
 			"call dolt_commit('-am', 'inserting rows 3 rows at HEAD');",
 		},
-
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "select * from dolt_workspace_tbl",
@@ -175,6 +168,65 @@ var DoltWorkspaceScriptTests = []queries.ScriptTest{
 			{
 				Query:    "select * from dolt_workspace_unknowntable",
 				Expected: []sql.Row{},
+			},
+		},
+	},
+
+	{
+		Name: "dolt_workspace_* created table",
+		SetUpScript: []string{
+			"create table tbl (pk int primary key, val int);",
+			"insert into tbl values (42,42);",
+			"insert into tbl values (43,43);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "select * from dolt_workspace_tbl",
+				Expected: []sql.Row{
+					{0, false, "added", 42, 42, nil, nil},
+					{1, false, "added", 43, 43, nil, nil},
+				},
+			},
+			{
+				Query: "call dolt_add('tbl');",
+			},
+			{
+				Query: "select * from dolt_workspace_tbl",
+				Expected: []sql.Row{
+					{0, true, "added", 42, 42, nil, nil},
+					{1, true, "added", 43, 43, nil, nil},
+				},
+			},
+		},
+	},
+	{
+		Name: "dolt_workspace_* dropped table",
+		SetUpScript: []string{
+			"create table tbl (pk int primary key, val int);",
+			"call dolt_commit('-Am', 'creating table t');",
+
+			"insert into tbl values (42,42);",
+			"insert into tbl values (43,43);",
+			"call dolt_commit('-am', 'inserting rows 3 rows at HEAD');",
+			"drop table tbl",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "select * from dolt_workspace_tbl",
+				Expected: []sql.Row{
+					{0, false, "removed", nil, nil, 42, 42},
+					{1, false, "removed", nil, nil, 43, 43},
+				},
+			},
+			{
+				Query: "call dolt_add('tbl');",
+			},
+			{
+				Query: "select * from dolt_workspace_tbl",
+				Expected: []sql.Row{
+					{0, true, "removed", nil, nil, 42, 42},
+					{1, true, "removed", nil, nil, 43, 43},
+				},
 			},
 		},
 	},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_workspace.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_workspace.go
@@ -130,7 +130,7 @@ var DoltWorkspaceScriptTests = []queries.ScriptTest{
 
 			"insert into tbl values (42,42);",
 			"insert into tbl values (43,43);",
-			"call dolt_commit('-am', 'inserting rows 3 rows at HEAD');",
+			"call dolt_commit('-am', 'inserting 2 rows at HEAD');",
 			"delete from tbl where pk = 42;",
 		},
 		Assertions: []queries.ScriptTestAssertion{

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_workspace.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_workspace.go
@@ -1,0 +1,181 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enginetest
+
+import (
+	"github.com/dolthub/go-mysql-server/enginetest/queries"
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+var DoltWorkspaceScriptTests = []queries.ScriptTest{
+	{
+		Name: "dolt_workspace_* multiple edits of a single row",
+		SetUpScript: []string{
+			"create table tbl (pk int primary key, val int);",
+			"call dolt_commit('-Am', 'creating table t');",
+
+			"insert into tbl values (42,42);",
+			"insert into tbl values (43,43);",
+			"call dolt_commit('-am', 'inserting rows 3 rows at HEAD');",
+
+			"update tbl set val=51 where pk=42;",
+			"call dolt_add('tbl');",
+		},
+
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "select * from dolt_workspace_tbl",
+				Expected: []sql.Row{
+					{0, true, "modified", 42, 51, 42, 42},
+				},
+			},
+			{
+				Query: "update tbl set val= 108 where pk = 42;",
+			},
+			{
+				Query: "select * from dolt_workspace_tbl",
+				Expected: []sql.Row{
+					{0, true, "modified", 42, 51, 42, 42},
+					{1, false, "modified", 42, 108, 42, 51},
+				},
+			},
+			{
+				Query: "call dolt_add('tbl');",
+			},
+			{
+				Query: "select * from dolt_workspace_tbl",
+				Expected: []sql.Row{
+					{0, true, "modified", 42, 108, 42, 42},
+				},
+			},
+		},
+	},
+	{
+		Name: "dolt_workspace_* single unstaged row",
+		SetUpScript: []string{
+			"create table tbl (pk int primary key, val int);",
+			"call dolt_commit('-Am', 'creating table t');",
+
+			"insert into tbl values (42,42);",
+			"insert into tbl values (43,43);",
+			"call dolt_commit('-am', 'inserting rows 3 rows at HEAD');",
+
+			"update tbl set val=51 where pk=42;",
+		},
+
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "select * from dolt_workspace_tbl",
+				Expected: []sql.Row{
+					{0, false, "modified", 42, 51, 42, 42},
+				},
+			},
+		},
+	},
+	{
+		Name: "dolt_workspace_* inserted row",
+		SetUpScript: []string{
+			"create table tbl (pk int primary key, val int);",
+			"call dolt_commit('-Am', 'creating table t');",
+
+			"insert into tbl values (42,42);",
+			"insert into tbl values (43,43);",
+			"call dolt_commit('-am', 'inserting rows 3 rows at HEAD');",
+			"insert into tbl values (44,44);",
+		},
+
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "select * from dolt_workspace_tbl",
+				Expected: []sql.Row{
+					{0, false, "added", 44, 44, nil, nil},
+				},
+			},
+			{
+				Query: "call dolt_add('tbl');",
+			},
+			{
+				Query: "select * from dolt_workspace_tbl",
+				Expected: []sql.Row{
+					{0, true, "added", 44, 44, nil, nil},
+				},
+			},
+			{
+				Query: "update tbl set val = 108 where pk = 44;",
+			},
+			{
+				Query: "select * from dolt_workspace_tbl",
+				Expected: []sql.Row{
+					{0, true, "added", 44, 44, nil, nil},
+					{1, false, "modified", 44, 108, 44, 44},
+				},
+			},
+		},
+	},
+
+	{
+		Name: "dolt_workspace_* deleted row",
+		SetUpScript: []string{
+			"create table tbl (pk int primary key, val int);",
+			"call dolt_commit('-Am', 'creating table t');",
+
+			"insert into tbl values (42,42);",
+			"insert into tbl values (43,43);",
+			"call dolt_commit('-am', 'inserting rows 3 rows at HEAD');",
+			"delete from tbl where pk = 42;",
+		},
+
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "select * from dolt_workspace_tbl",
+				Expected: []sql.Row{
+					{0, false, "removed", nil, nil, 42, 42},
+				},
+			},
+			{
+				Query: "call dolt_add('tbl');",
+			},
+			{
+				Query: "select * from dolt_workspace_tbl",
+				Expected: []sql.Row{
+					{0, true, "removed", nil, nil, 42, 42},
+				},
+			},
+		},
+	},
+
+	{
+		Name: "dolt_workspace_* clean workspace",
+		SetUpScript: []string{
+			"create table tbl (pk int primary key, val int);",
+			"call dolt_commit('-Am', 'creating table t');",
+
+			"insert into tbl values (42,42);",
+			"insert into tbl values (43,43);",
+			"call dolt_commit('-am', 'inserting rows 3 rows at HEAD');",
+		},
+
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "select * from dolt_workspace_tbl",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "select * from dolt_workspace_unknowntable",
+				Expected: []sql.Row{},
+			},
+		},
+	},
+}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_workspace.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_workspace.go
@@ -29,7 +29,7 @@ var DoltWorkspaceScriptTests = []queries.ScriptTest{
 
 			"insert into tbl values (42,42);",
 			"insert into tbl values (43,43);",
-			"call dolt_commit('-am', 'inserting rows 3 rows at HEAD');",
+			"call dolt_commit('-am', 'inserting 2 rows at HEAD');",
 
 			"update tbl set val=51 where pk=42;",
 			"call dolt_add('tbl');",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_workspace.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_workspace.go
@@ -70,7 +70,7 @@ var DoltWorkspaceScriptTests = []queries.ScriptTest{
 
 			"insert into tbl values (42,42);",
 			"insert into tbl values (43,43);",
-			"call dolt_commit('-am', 'inserting rows 3 rows at HEAD');",
+			"call dolt_commit('-am', 'inserting 2 rows at HEAD');",
 
 			"update tbl set val=51 where pk=42;",
 		},

--- a/integration-tests/bats/ls.bats
+++ b/integration-tests/bats/ls.bats
@@ -60,7 +60,7 @@ teardown() {
 @test "ls: --system shows system tables" {
     run dolt ls --system
     [ "$status" -eq 0 ]
-    [ "${#lines[@]}" -eq 20 ]
+    [ "${#lines[@]}" -eq 22 ]
     [[ "$output" =~ "System tables:" ]] || false
     [[ "$output" =~ "dolt_status" ]] || false
     [[ "$output" =~ "dolt_commits" ]] || false
@@ -81,6 +81,8 @@ teardown() {
     [[ "$output" =~ "dolt_conflicts_table_two" ]] || false
     [[ "$output" =~ "dolt_diff_table_two" ]] || false
     [[ "$output" =~ "dolt_commit_diff_table_two" ]] || false
+    [[ "$output" =~ "dolt_workspace_table_one" ]] || false
+    [[ "$output" =~ "dolt_workspace_table_two" ]] || false
 }
 
 @test "ls: --all shows tables in working set and system tables" {


### PR DESCRIPTION
This is the read only addition of the `dolt_workspace_{table}` s. These dynamically generated tables are always relative to HEAD for the given session of the caller. There are no commits as a result, and the schema of the output looks like:

| ID (int) | STAGED (bool) | DIFF_TYPE (string) | to_A | to_B | ... | from_A | from_B | ... |

Currently there is no mechanism to update this table directly, but in the future that will make it possible to have fine grain modification of your workspace, similar to `git add --patch`