### PR TITLE
Skip filter iter, with more test fixes

### DIFF
--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -1209,7 +1209,9 @@ func (di *doltIndex) prollyRangesFromSqlRanges(ctx context.Context, ns tree.Node
 		skipRangeMatchCallback := true
 		for j, expr := range rng {
 			if !sqltypes.IsInteger(expr.Typ) {
-				// decimal, float, datetime are imperfectly serialized
+				// String, decimal, float, datetime ranges can return
+				// false positive prefix matches. More precise range.Matches
+				// comparison is required.
 				skipRangeMatchCallback = false
 			}
 			if rangeCutIsBinding(expr.LowerBound) {

--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -1206,7 +1206,12 @@ func (di *doltIndex) prollyRangesFromSqlRanges(ctx context.Context, ns tree.Node
 	pranges := make([]prolly.Range, len(ranges))
 	for k, rng := range ranges {
 		fields := make([]prolly.RangeField, len(rng))
+		onlyPreciseTypes := true
 		for j, expr := range rng {
+			if !(sqltypes.IsInteger(expr.Typ) || sqltypes.IsText(expr.Typ)) {
+				// decimal, float, datetime are imperfectly serialized
+				onlyPreciseTypes = false
+			}
 			if rangeCutIsBinding(expr.LowerBound) {
 				// accumulate bound values in |tb|
 				v, err := getRangeCutValue(expr.LowerBound, rng[j].Typ)
@@ -1266,6 +1271,8 @@ func (di *doltIndex) prollyRangesFromSqlRanges(ctx context.Context, ns tree.Node
 		}
 
 		order := di.keyBld.Desc.Comparator()
+		var foundDiscontinuity bool
+		var isContiguous bool = true
 		for i, field := range fields {
 			// lookups on non-unique indexes can't be point lookups
 			typ := di.keyBld.Desc.Types[i]
@@ -1279,11 +1286,22 @@ func (di *doltIndex) prollyRangesFromSqlRanges(ctx context.Context, ns tree.Node
 				// infinity bound
 				fields[i].BoundsAreEqual = false
 			}
+
+			nilBound := field.Lo.Value == nil && field.Hi.Value == nil
+			if foundDiscontinuity || nilBound {
+				// A discontinous variable followed by any restriction
+				// can partition the key space.
+				isContiguous = false
+			}
+			foundDiscontinuity = foundDiscontinuity || !fields[i].BoundsAreEqual || nilBound
+
 		}
 		pranges[k] = prolly.Range{
-			Fields: fields,
-			Desc:   di.keyBld.Desc,
-			Tup:    tup,
+			Fields:       fields,
+			Desc:         di.keyBld.Desc,
+			Tup:          tup,
+			PreciseTypes: onlyPreciseTypes,
+			IsContiguous: isContiguous,
 		}
 	}
 	return pranges, nil

--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -1206,11 +1206,11 @@ func (di *doltIndex) prollyRangesFromSqlRanges(ctx context.Context, ns tree.Node
 	pranges := make([]prolly.Range, len(ranges))
 	for k, rng := range ranges {
 		fields := make([]prolly.RangeField, len(rng))
-		onlyPreciseTypes := true
+		skipRangeMatchCallback := true
 		for j, expr := range rng {
-			if !(sqltypes.IsInteger(expr.Typ) || sqltypes.IsText(expr.Typ)) {
+			if !sqltypes.IsInteger(expr.Typ) {
 				// decimal, float, datetime are imperfectly serialized
-				onlyPreciseTypes = false
+				skipRangeMatchCallback = false
 			}
 			if rangeCutIsBinding(expr.LowerBound) {
 				// accumulate bound values in |tb|
@@ -1297,11 +1297,11 @@ func (di *doltIndex) prollyRangesFromSqlRanges(ctx context.Context, ns tree.Node
 
 		}
 		pranges[k] = prolly.Range{
-			Fields:       fields,
-			Desc:         di.keyBld.Desc,
-			Tup:          tup,
-			PreciseTypes: onlyPreciseTypes,
-			IsContiguous: isContiguous,
+			Fields:                 fields,
+			Desc:                   di.keyBld.Desc,
+			Tup:                    tup,
+			SkipRangeMatchCallback: skipRangeMatchCallback,
+			IsContiguous:           isContiguous,
 		}
 	}
 	return pranges, nil

--- a/go/libraries/doltcore/sqle/index/index_reader.go
+++ b/go/libraries/doltcore/sqle/index/index_reader.go
@@ -421,7 +421,7 @@ type coveringIndexImplBuilder struct {
 	keyMap, valMap, ordMap val.OrdinalMapping
 }
 
-func NewSequenceMapIter(ctx context.Context, ib IndexScanBuilder, ranges []prolly.Range, reverse bool) (prolly.MapIter, error) {
+func NewSequenceRangeIter(ctx context.Context, ib IndexScanBuilder, ranges []prolly.Range, reverse bool) (prolly.MapIter, error) {
 	if len(ranges) == 0 {
 		return &strictLookupIter{}, nil
 	}

--- a/go/libraries/doltcore/sqle/kvexec/builder.go
+++ b/go/libraries/doltcore/sqle/kvexec/builder.go
@@ -326,7 +326,7 @@ func getSourceKv(ctx *sql.Context, n sql.Node, isSrc bool) (prolly.Map, prolly.M
 				return prolly.Map{}, nil, nil, nil, nil, nil, err
 			}
 
-			srcIter, err = index.NewSequenceMapIter(ctx, lb, prollyRanges, l.IsReverse)
+			srcIter, err = index.NewSequenceRangeIter(ctx, lb, prollyRanges, l.IsReverse)
 			if err != nil {
 				return prolly.Map{}, nil, nil, nil, nil, nil, err
 			}

--- a/go/store/prolly/tuple_map.go
+++ b/go/store/prolly/tuple_map.go
@@ -314,7 +314,15 @@ func (m Map) IterRange(ctx context.Context, rng Range) (iter MapIter, err error)
 	} else {
 		iter, err = treeIterFromRange(ctx, m.tuples.Root, m.tuples.NodeStore, rng)
 	}
-	return filteredIter{iter: iter, rng: rng}, nil
+	if err != nil {
+		return nil, err
+	}
+	if !rng.PreciseTypes || !rng.IsContiguous {
+		// range.Matches check is required if a type is imprecise
+		// or a key range is non-contiguous on disk
+		iter = filteredIter{iter: iter, rng: rng}
+	}
+	return iter, nil
 }
 
 // IterRangeReverse returns a mutableMapIter that iterates over a Range backwards.

--- a/go/store/prolly/tuple_map.go
+++ b/go/store/prolly/tuple_map.go
@@ -317,7 +317,7 @@ func (m Map) IterRange(ctx context.Context, rng Range) (iter MapIter, err error)
 	if err != nil {
 		return nil, err
 	}
-	if !rng.PreciseTypes || !rng.IsContiguous {
+	if !rng.SkipRangeMatchCallback || !rng.IsContiguous {
 		// range.Matches check is required if a type is imprecise
 		// or a key range is non-contiguous on disk
 		iter = filteredIter{iter: iter, rng: rng}

--- a/go/store/prolly/tuple_range.go
+++ b/go/store/prolly/tuple_range.go
@@ -58,6 +58,14 @@ type Range struct {
 	Fields []RangeField
 	Desc   val.TupleDesc
 	Tup    val.Tuple
+	// PreciseTypes is false if any type in the range
+	// expression can be serialized with a loss of precision.
+	PreciseTypes bool
+	// IsContiguous indicates whether this range expression is a
+	// single contiguous set of keys on disk. Permit a sequence of
+	// (1) zero or more equality restrictions, (2) zero or one
+	// non-equality, and (3) no further restrictions.
+	IsContiguous bool
 }
 
 // RangeField bounds one dimension of a Range.

--- a/go/store/prolly/tuple_range.go
+++ b/go/store/prolly/tuple_range.go
@@ -58,9 +58,10 @@ type Range struct {
 	Fields []RangeField
 	Desc   val.TupleDesc
 	Tup    val.Tuple
-	// PreciseTypes is false if any type in the range
-	// expression can be serialized with a loss of precision.
-	PreciseTypes bool
+	// SkipRangeMatchCallback is false if any type in the index range
+	// expression can return a false positive match. Strings, datetimes,
+	// floats, and decimals ranges can prefix match invalid values.
+	SkipRangeMatchCallback bool
 	// IsContiguous indicates whether this range expression is a
 	// single contiguous set of keys on disk. Permit a sequence of
 	// (1) zero or more equality restrictions, (2) zero or one


### PR DESCRIPTION
This is the same as https://github.com/dolthub/dolt/pull/8242 with one change and new test in GMS https://github.com/dolthub/go-mysql-server/pull/2639. The change prevents string comparisons from skipping range.Matches, because the index range iterators can return false positives/prefix matches.