### PR TITLE
Feature: Data conflict resolution during interactive rebase

### DIFF
--- a/go/cmd/dolt/commands/rebase.go
+++ b/go/cmd/dolt/commands/rebase.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/rebase"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dprocedures"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 	"github.com/dolthub/dolt/go/libraries/utils/config"
 	"github.com/dolthub/dolt/go/libraries/utils/editor"
@@ -95,6 +96,12 @@ func (cmd RebaseCmd) Exec(ctx context.Context, commandStr string, args []string,
 		defer closeFunc()
 	}
 
+	// Set @@dolt_allow_commit_conflicts in case there are data conflicts that need to be resolved by the caller.
+	// Without this, the conflicts can't be committed to the branch working set, and the caller can't access them.
+	if _, err = GetRowsForSql(queryist, sqlCtx, "set @@dolt_allow_commit_conflicts=1;"); err != nil {
+		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+	}
+
 	branchName, err := getActiveBranchName(sqlCtx, queryist)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
@@ -118,65 +125,84 @@ func (cmd RebaseCmd) Exec(ctx context.Context, commandStr string, args []string,
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(errors.New("error: "+rows[0][1].(string))), usage)
 	}
 
+	// If the rebase was successful, or if it was aborted, print out the message and
+	// ensure the branch being rebased is checked out in the CLI
 	message := rows[0][1].(string)
-	if strings.Contains(message, dprocedures.SuccessfulRebaseMessage) {
-		cli.Println(dprocedures.SuccessfulRebaseMessage + branchName)
-	} else if strings.Contains(message, dprocedures.RebaseAbortedMessage) {
-		cli.Println(dprocedures.RebaseAbortedMessage)
-	} else {
-		rebasePlan, err := getRebasePlan(cliCtx, sqlCtx, queryist, apr.Arg(0), branchName)
-		if err != nil {
-			// attempt to abort the rebase
-			_, _, _, _ = queryist.Query(sqlCtx, "CALL DOLT_REBASE('--abort');")
+	if strings.Contains(message, dprocedures.SuccessfulRebaseMessage) ||
+		strings.Contains(message, dprocedures.RebaseAbortedMessage) {
+		cli.Println(message)
+		if err = syncCliBranchToSqlSessionBranch(sqlCtx, dEnv); err != nil {
 			return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 		}
-
-		// if all uncommented lines are deleted in the editor, abort the rebase
-		if rebasePlan == nil || rebasePlan.Steps == nil || len(rebasePlan.Steps) == 0 {
-			rows, err := GetRowsForSql(queryist, sqlCtx, "CALL DOLT_REBASE('--abort');")
-			if err != nil {
-				return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-			}
-			status, err := getInt64ColAsInt64(rows[0][0])
-			if err != nil {
-				return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-			}
-			if status == 1 {
-				return HandleVErrAndExitCode(errhand.VerboseErrorFromError(errors.New("error: "+rows[0][1].(string))), usage)
-			}
-
-			cli.Println(dprocedures.RebaseAbortedMessage)
-		} else {
-			err = insertRebasePlanIntoDoltRebaseTable(rebasePlan, sqlCtx, queryist)
-			if err != nil {
-				// attempt to abort the rebase
-				_, _, _, _ = queryist.Query(sqlCtx, "CALL DOLT_REBASE('--abort');")
-				return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-			}
-
-			rows, err := GetRowsForSql(queryist, sqlCtx, "CALL DOLT_REBASE('--continue');")
-			if err != nil {
-				// attempt to abort the rebase
-				_, _, _, _ = queryist.Query(sqlCtx, "CALL DOLT_REBASE('--abort');")
-				return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-			}
-			status, err := getInt64ColAsInt64(rows[0][0])
-			if err != nil {
-				// attempt to abort the rebase
-				_, _, _, _ = queryist.Query(sqlCtx, "CALL DOLT_REBASE('--abort');")
-				return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-			}
-			if status == 1 {
-				// attempt to abort the rebase
-				_, _, _, _ = queryist.Query(sqlCtx, "CALL DOLT_REBASE('--abort');")
-				return HandleVErrAndExitCode(errhand.VerboseErrorFromError(errors.New("error: "+rows[0][1].(string))), usage)
-			}
-
-			cli.Println(dprocedures.SuccessfulRebaseMessage + branchName)
-		}
+		return 0
 	}
 
-	return HandleVErrAndExitCode(nil, usage)
+	rebasePlan, err := getRebasePlan(cliCtx, sqlCtx, queryist, apr.Arg(0), branchName)
+	if err != nil {
+		// attempt to abort the rebase
+		_, _, _, _ = queryist.Query(sqlCtx, "CALL DOLT_REBASE('--abort');")
+		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+	}
+
+	// if all uncommented lines are deleted in the editor, abort the rebase
+	if rebasePlan == nil || rebasePlan.Steps == nil || len(rebasePlan.Steps) == 0 {
+		rows, err := GetRowsForSql(queryist, sqlCtx, "CALL DOLT_REBASE('--abort');")
+		if err != nil {
+			return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+		}
+		status, err := getInt64ColAsInt64(rows[0][0])
+		if err != nil {
+			return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+		}
+		if status == 1 {
+			return HandleVErrAndExitCode(errhand.VerboseErrorFromError(errors.New("error: "+rows[0][1].(string))), usage)
+		}
+
+		cli.Println(dprocedures.RebaseAbortedMessage)
+		return 0
+	}
+
+	err = insertRebasePlanIntoDoltRebaseTable(rebasePlan, sqlCtx, queryist)
+	if err != nil {
+		// attempt to abort the rebase
+		_, _, _, _ = queryist.Query(sqlCtx, "CALL DOLT_REBASE('--abort');")
+		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+	}
+
+	rows, err = GetRowsForSql(queryist, sqlCtx, "CALL DOLT_REBASE('--continue');")
+	if err != nil {
+		// If the error is a data conflict, don't abort the rebase, but let the caller resolve the conflicts
+		if dprocedures.ErrRebaseDataConflict.Is(err) || strings.Contains(err.Error(), dprocedures.ErrRebaseDataConflict.Message[:40]) {
+			if checkoutErr := syncCliBranchToSqlSessionBranch(sqlCtx, dEnv); checkoutErr != nil {
+				return HandleVErrAndExitCode(errhand.VerboseErrorFromError(checkoutErr), usage)
+			}
+		} else {
+			_, _, _, _ = queryist.Query(sqlCtx, "CALL DOLT_REBASE('--abort');")
+			if checkoutErr := syncCliBranchToSqlSessionBranch(sqlCtx, dEnv); checkoutErr != nil {
+				return HandleVErrAndExitCode(errhand.VerboseErrorFromError(checkoutErr), usage)
+			}
+		}
+		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+	}
+
+	status, err = getInt64ColAsInt64(rows[0][0])
+	if err != nil {
+		_, _, _, _ = queryist.Query(sqlCtx, "CALL DOLT_REBASE('--abort');")
+		if err = syncCliBranchToSqlSessionBranch(sqlCtx, dEnv); err != nil {
+			return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+		}
+		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+	}
+	if status == 1 {
+		_, _, _, _ = queryist.Query(sqlCtx, "CALL DOLT_REBASE('--abort');")
+		if err = syncCliBranchToSqlSessionBranch(sqlCtx, dEnv); err != nil {
+			return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+		}
+		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(errors.New("error: "+rows[0][1].(string))), usage)
+	}
+
+	cli.Println(rows[0][1].(string))
+	return 0
 }
 
 // getRebasePlan opens an editor for users to edit the rebase plan and returns the parsed rebase plan from the editor.
@@ -312,4 +338,18 @@ func insertRebasePlanIntoDoltRebaseTable(plan *rebase.RebasePlan, sqlCtx *sql.Co
 	}
 
 	return nil
+}
+
+// syncCliBranchToSqlSessionBranch sets the current branch for the CLI (in repo_state.json) to the active branch
+// for the current session. This is needed during rebasing, since any conflicts need to be resolved while the
+// session is on the rebase working branch (e.g. dolt_rebase_t1) and after the rebase finishes, the session needs
+// to be back on the branch being rebased (e.g. t1).
+func syncCliBranchToSqlSessionBranch(ctx *sql.Context, dEnv *env.DoltEnv) error {
+	doltSession := dsess.DSessFromSess(ctx.Session)
+	currentBranch, err := doltSession.GetBranch()
+	if err != nil {
+		return err
+	}
+
+	return saveHeadBranch(dEnv.FS, currentBranch)
 }

--- a/go/gen/fb/serial/workingset.go
+++ b/go/gen/fb/serial/workingset.go
@@ -555,7 +555,31 @@ func (rcv *RebaseState) MutateCommitBecomesEmptyHandling(n byte) bool {
 	return rcv._tab.MutateByteSlot(12, n)
 }
 
-const RebaseStateNumFields = 5
+func (rcv *RebaseState) LastAttemptedStep() float32 {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(14))
+	if o != 0 {
+		return rcv._tab.GetFloat32(o + rcv._tab.Pos)
+	}
+	return 0.0
+}
+
+func (rcv *RebaseState) MutateLastAttemptedStep(n float32) bool {
+	return rcv._tab.MutateFloat32Slot(14, n)
+}
+
+func (rcv *RebaseState) RebasingStarted() bool {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(16))
+	if o != 0 {
+		return rcv._tab.GetBool(o + rcv._tab.Pos)
+	}
+	return false
+}
+
+func (rcv *RebaseState) MutateRebasingStarted(n bool) bool {
+	return rcv._tab.MutateBoolSlot(16, n)
+}
+
+const RebaseStateNumFields = 7
 
 func RebaseStateStart(builder *flatbuffers.Builder) {
 	builder.StartObject(RebaseStateNumFields)
@@ -583,6 +607,12 @@ func RebaseStateAddEmptyCommitHandling(builder *flatbuffers.Builder, emptyCommit
 }
 func RebaseStateAddCommitBecomesEmptyHandling(builder *flatbuffers.Builder, commitBecomesEmptyHandling byte) {
 	builder.PrependByteSlot(4, commitBecomesEmptyHandling, 0)
+}
+func RebaseStateAddLastAttemptedStep(builder *flatbuffers.Builder, lastAttemptedStep float32) {
+	builder.PrependFloat32Slot(5, lastAttemptedStep, 0.0)
+}
+func RebaseStateAddRebasingStarted(builder *flatbuffers.Builder, rebasingStarted bool) {
+	builder.PrependBoolSlot(6, rebasingStarted, false)
 }
 func RebaseStateEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()

--- a/go/libraries/doltcore/cherry_pick/cherry_pick.go
+++ b/go/libraries/doltcore/cherry_pick/cherry_pick.go
@@ -108,29 +108,15 @@ func CherryPick(ctx *sql.Context, commit string, options CherryPickOptions) (str
 		return "", mergeResult, nil
 	}
 
-	commitProps := actions.CommitStagedProps{
-		Date:    ctx.QueryTime(),
-		Name:    ctx.Client().User,
-		Email:   fmt.Sprintf("%s@%s", ctx.Client().User, ctx.Client().Address),
-		Message: commitMsg,
+	commitProps, err := CreateCommitStagedPropsFromCherryPickOptions(ctx, options)
+	if err != nil {
+		return "", nil, err
 	}
 
-	if options.CommitMessage != "" {
-		commitProps.Message = options.CommitMessage
-	}
-	if options.Amend {
-		commitProps.Amend = true
-	}
-	if options.EmptyCommitHandling == doltdb.KeepEmptyCommit {
-		commitProps.AllowEmpty = true
-	}
-
-	if options.CommitBecomesEmptyHandling == doltdb.DropEmptyCommit {
-		commitProps.SkipEmpty = true
-	} else if options.CommitBecomesEmptyHandling == doltdb.KeepEmptyCommit {
-		commitProps.AllowEmpty = true
-	} else if options.CommitBecomesEmptyHandling == doltdb.StopOnEmptyCommit {
-		return "", nil, fmt.Errorf("stop on empty commit is not currently supported")
+	// If no commit message was explicitly provided in the cherry-pick options,
+	// use the commit message from the cherry-picked commit.
+	if commitProps.Message == "" {
+		commitProps.Message = commitMsg
 	}
 
 	// NOTE: roots are old here (after staging the tables) and need to be refreshed
@@ -139,7 +125,7 @@ func CherryPick(ctx *sql.Context, commit string, options CherryPickOptions) (str
 		return "", nil, fmt.Errorf("failed to get roots for current session")
 	}
 
-	pendingCommit, err := doltSession.NewPendingCommit(ctx, dbName, roots, commitProps)
+	pendingCommit, err := doltSession.NewPendingCommit(ctx, dbName, roots, *commitProps)
 	if err != nil {
 		return "", nil, err
 	}
@@ -162,6 +148,36 @@ func CherryPick(ctx *sql.Context, commit string, options CherryPickOptions) (str
 	}
 
 	return h.String(), nil, nil
+}
+
+// CreateCommitStagedPropsFromCherryPickOptions converts the specified cherry-pick |options| into a CommitStagedProps
+// instance that can be used to create a pending commit.
+func CreateCommitStagedPropsFromCherryPickOptions(ctx *sql.Context, options CherryPickOptions) (*actions.CommitStagedProps, error) {
+	commitProps := actions.CommitStagedProps{
+		Date:  ctx.QueryTime(),
+		Name:  ctx.Client().User,
+		Email: fmt.Sprintf("%s@%s", ctx.Client().User, ctx.Client().Address),
+	}
+
+	if options.CommitMessage != "" {
+		commitProps.Message = options.CommitMessage
+	}
+	if options.Amend {
+		commitProps.Amend = true
+	}
+	if options.EmptyCommitHandling == doltdb.KeepEmptyCommit {
+		commitProps.AllowEmpty = true
+	}
+
+	if options.CommitBecomesEmptyHandling == doltdb.DropEmptyCommit {
+		commitProps.SkipEmpty = true
+	} else if options.CommitBecomesEmptyHandling == doltdb.KeepEmptyCommit {
+		commitProps.AllowEmpty = true
+	} else if options.CommitBecomesEmptyHandling == doltdb.StopOnEmptyCommit {
+		return nil, fmt.Errorf("stop on empty commit is not currently supported")
+	}
+
+	return &commitProps, nil
 }
 
 func previousCommitMessage(ctx *sql.Context) (string, error) {

--- a/go/libraries/doltcore/rebase/rebase.go
+++ b/go/libraries/doltcore/rebase/rebase.go
@@ -62,6 +62,13 @@ type RebasePlanStep struct {
 	CommitMsg   string
 }
 
+// RebaseOrderAsFloat returns the RebaseOrder as a float32. Float32 provides enough scale and precision to hold
+// rebase order values, since they are limited to two decimal points of precision and six total digits.
+func (rps *RebasePlanStep) RebaseOrderAsFloat() float32 {
+	f64, _ := rps.RebaseOrder.Float64()
+	return float32(f64)
+}
+
 // CreateDefaultRebasePlan creates and returns the default rebase plan for the commits between
 // |startCommit| and |upstreamCommit|, equivalent to the log of startCommit..upstreamCommit. The
 // default plan includes each of those commits, in the same order they were originally applied, and

--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -707,6 +707,31 @@ func (d *DoltSession) newPendingCommit(ctx *sql.Context, branchState *branchStat
 			mergeParentCommits = append(mergeParentCommits, parentCommit)
 		}
 
+		// If the commit message isn't set and we're amending the previous commit,
+		// go ahead and set the commit message from the current HEAD
+		if props.Message == "" && props.Amend {
+			cs, err := doltdb.NewCommitSpec("HEAD")
+			if err != nil {
+				return nil, err
+			}
+
+			headRef, err := branchState.dbData.Rsr.CWBHeadRef()
+			if err != nil {
+				return nil, err
+			}
+			optCmt, err := branchState.dbData.Ddb.Resolve(ctx, cs, headRef)
+			commit, ok := optCmt.ToCommit()
+			if !ok {
+				return nil, doltdb.ErrGhostCommitEncountered
+			}
+
+			meta, err := commit.GetCommitMeta(ctx)
+			if err != nil {
+				return nil, err
+			}
+			props.Message = meta.Description
+		}
+
 		// TODO: This is not the correct way to write this commit as an amend. While this commit is running
 		//  the branch head moves backwards and concurrency control here is not principled.
 		newRoots, err := actions.ResetSoftToRef(ctx, branchState.dbData, "HEAD~1")

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_rebase.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_rebase.go
@@ -869,6 +869,15 @@ var DoltRebaseScriptTests = []queries.ScriptTest{
 				Expected: []sql.Row{{0, "zero"}, {1, "uno"}},
 			},
 			{
+				// If we don't stage the table, then rebase will give us an error about having unstaged changes
+				Query:       "call dolt_rebase('--continue');",
+				ExpectedErr: dprocedures.ErrRebaseUnstagedChanges,
+			},
+			{
+				Query:    "call dolt_add('t');",
+				Expected: []sql.Row{{0}},
+			},
+			{
 				Query:       "call dolt_rebase('--continue');",
 				ExpectedErr: dprocedures.ErrRebaseDataConflict,
 			},
@@ -1000,10 +1009,6 @@ var DoltRebaseScriptTests = []queries.ScriptTest{
 				Expected: []sql.Row{{1, "uno", 1, "one", "modified", 1, "ein", "modified"}},
 			},
 			{
-				Query:    "select active_branch();",
-				Expected: []sql.Row{{"dolt_rebase_branch1"}},
-			},
-			{
 				Query: "select message from dolt_log;",
 				Expected: []sql.Row{
 					{"inserting row 1 on branch1"},
@@ -1022,6 +1027,15 @@ var DoltRebaseScriptTests = []queries.ScriptTest{
 				// Table t includes the change from the tip of main (0, "zero"), as well as the conflict we just resolved
 				Query:    "SELECT * FROM t;",
 				Expected: []sql.Row{{0, "zero"}, {1, "ein"}},
+			},
+			{
+				// If we don't stage the table, then rebase will give us an error about having unstaged changes
+				Query:       "call dolt_rebase('--continue');",
+				ExpectedErr: dprocedures.ErrRebaseUnstagedChanges,
+			},
+			{
+				Query:    "call dolt_add('t');",
+				Expected: []sql.Row{{0}},
 			},
 			{
 				Query:       "call dolt_rebase('--continue');",
@@ -1172,6 +1186,15 @@ var DoltRebaseScriptTests = []queries.ScriptTest{
 				Expected: []sql.Row{{0, "zero"}},
 			},
 			{
+				// If we don't stage the table, then rebase will give us an error about having unstaged changes
+				Query:       "call dolt_rebase('--continue');",
+				ExpectedErr: dprocedures.ErrRebaseUnstagedChanges,
+			},
+			{
+				Query:    "call dolt_add('t');",
+				Expected: []sql.Row{{0}},
+			},
+			{
 				Query:       "call dolt_rebase('--continue');",
 				ExpectedErr: dprocedures.ErrRebaseDataConflict,
 			},
@@ -1201,6 +1224,10 @@ var DoltRebaseScriptTests = []queries.ScriptTest{
 			{
 				// Accept the new values from the cherry-picked commit (1, "uno").
 				Query:    "CALL DOLT_CONFLICTS_RESOLVE('--theirs', 't');",
+				Expected: []sql.Row{{0}},
+			},
+			{
+				Query:    "call dolt_add('t');",
 				Expected: []sql.Row{{0}},
 			},
 			{
@@ -1315,6 +1342,15 @@ var DoltRebaseScriptTests = []queries.ScriptTest{
 				Expected: []sql.Row{{0, "zero"}},
 			},
 			{
+				// If we don't stage the table, then rebase will give us an error about having unstaged changes
+				Query:       "call dolt_rebase('--continue');",
+				ExpectedErr: dprocedures.ErrRebaseUnstagedChanges,
+			},
+			{
+				Query:    "call dolt_add('t');",
+				Expected: []sql.Row{{0}},
+			},
+			{
 				Query:       "call dolt_rebase('--continue');",
 				ExpectedErr: dprocedures.ErrRebaseDataConflict,
 			},
@@ -1340,6 +1376,10 @@ var DoltRebaseScriptTests = []queries.ScriptTest{
 			{
 				// Accept the new values from the cherry-picked commit (-1, "-1")
 				Query:    "CALL DOLT_CONFLICTS_RESOLVE('--theirs', 't');",
+				Expected: []sql.Row{{0}},
+			},
+			{
+				Query:    "call dolt_add('t');",
 				Expected: []sql.Row{{0}},
 			},
 			{

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_rebase.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_rebase.go
@@ -362,7 +362,7 @@ var DoltRebaseScriptTests = []queries.ScriptTest{
 			},
 			{
 				Query:       "call dolt_rebase('--continue');",
-				ExpectedErr: dprocedures.ErrRebaseDataConflictWithAutocommit,
+				ExpectedErr: dprocedures.ErrRebaseDataConflictsCantBeResolved,
 			},
 		},
 	},

--- a/go/serial/workingset.fbs
+++ b/go/serial/workingset.fbs
@@ -58,6 +58,15 @@ table RebaseState {
 
   // How to handle commits that become empty during rebasing
   commit_becomes_empty_handling:uint8;
+
+  // The last_attempted_step field indicates which step in the rebase plan was last executed. The step may have ended
+  // with a data conflict that the user has to manually resolve, or it may have been cherry-picked cleanly. This field
+  // is not valid unless the rebasing_started field is set to true.
+  last_attempted_step:float;
+
+  // The rebasing_started field indicates if execution of the rebase plan has been started or not. Once execution of the
+  // plan has been started, the last_attempted_step field holds a reference to the most recent plan step attempted.
+  rebasing_started:bool;
 }
 
 // KEEP THIS IN SYNC WITH fileidentifiers.go

--- a/go/store/datas/dataset.go
+++ b/go/store/datas/dataset.go
@@ -167,6 +167,8 @@ type RebaseState struct {
 	branch                     string
 	commitBecomesEmptyHandling uint8
 	emptyCommitHandling        uint8
+	lastAttemptedStep          float32
+	rebasingStarted            bool
 }
 
 func (rs *RebaseState) PreRebaseWorkingAddr() hash.Hash {
@@ -186,6 +188,14 @@ func (rs *RebaseState) OntoCommit(ctx context.Context, vr types.ValueReader) (*C
 		return LoadCommitAddr(ctx, vr, *rs.ontoCommitAddr)
 	}
 	return nil, nil
+}
+
+func (rs *RebaseState) LastAttemptedStep(_ context.Context) float32 {
+	return rs.lastAttemptedStep
+}
+
+func (rs *RebaseState) RebasingStarted(_ context.Context) bool {
+	return rs.rebasingStarted
 }
 
 func (rs *RebaseState) CommitBecomesEmptyHandling(_ context.Context) uint8 {
@@ -446,6 +456,8 @@ func (h serialWorkingSetHead) HeadWorkingSet() (*WorkingSetHead, error) {
 			string(rebaseState.BranchBytes()),
 			rebaseState.CommitBecomesEmptyHandling(),
 			rebaseState.EmptyCommitHandling(),
+			rebaseState.LastAttemptedStep(),
+			rebaseState.RebasingStarted(),
 		)
 	}
 

--- a/go/store/datas/workingset.go
+++ b/go/store/datas/workingset.go
@@ -194,6 +194,8 @@ func workingset_flatbuffer(working hash.Hash, staged *hash.Hash, mergeState *Mer
 		serial.RebaseStateAddOntoCommitAddr(builder, ontoAddrOffset)
 		serial.RebaseStateAddCommitBecomesEmptyHandling(builder, rebaseState.commitBecomesEmptyHandling)
 		serial.RebaseStateAddEmptyCommitHandling(builder, rebaseState.emptyCommitHandling)
+		serial.RebaseStateAddLastAttemptedStep(builder, rebaseState.lastAttemptedStep)
+		serial.RebaseStateAddRebasingStarted(builder, rebaseState.rebasingStarted)
 		rebaseStateOffset = serial.RebaseStateEnd(builder)
 	}
 
@@ -262,13 +264,15 @@ func NewMergeState(
 	}
 }
 
-func NewRebaseState(preRebaseWorkingRoot hash.Hash, commitAddr hash.Hash, branch string, commitBecomesEmptyHandling uint8, emptyCommitHandling uint8) *RebaseState {
+func NewRebaseState(preRebaseWorkingRoot hash.Hash, commitAddr hash.Hash, branch string, commitBecomesEmptyHandling uint8, emptyCommitHandling uint8, lastAttemptedStep float32, rebasingStarted bool) *RebaseState {
 	return &RebaseState{
 		preRebaseWorkingAddr:       &preRebaseWorkingRoot,
 		ontoCommitAddr:             &commitAddr,
 		branch:                     branch,
 		commitBecomesEmptyHandling: commitBecomesEmptyHandling,
 		emptyCommitHandling:        emptyCommitHandling,
+		lastAttemptedStep:          lastAttemptedStep,
+		rebasingStarted:            rebasingStarted,
 	}
 }
 

--- a/integration-tests/bats/rebase.bats
+++ b/integration-tests/bats/rebase.bats
@@ -359,6 +359,7 @@ setupCustomEditorScript() {
     [[ "$output" =~ "+  | ours   | 1  | 1 | NULL | NULL | NULL | NULL |" ]] || false
     [[ "$output" =~ "+  | theirs | 1  | 2 | NULL | NULL | NULL | NULL |" ]] || false
     dolt conflicts resolve --theirs t1
+    dolt add t1
 
     run dolt rebase --continue
     [ "$status" -eq 0 ]
@@ -400,7 +401,13 @@ setupCustomEditorScript() {
     [[ "$output" =~ "+  | theirs | 1  | 2 | NULL | NULL | NULL | NULL |" ]] || false
     dolt conflicts resolve --theirs t1
 
-    # Continue the rebase and hit the second data conflict
+    # Without staging the changed tables, trying to continue the rebase results in an error
+    run dolt rebase --continue
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "cannot continue a rebase with unstaged changes" ]] || false
+
+    # Stage the tables and then continue the rebase and hit the second data conflict
+    dolt add t1
     run dolt rebase --continue
     [ "$status" -eq 1 ]
     [[ "$output" =~ "data conflict detected while rebasing commit" ]] || false
@@ -419,6 +426,7 @@ setupCustomEditorScript() {
     dolt conflicts resolve --ours t1
 
     # Finish the rebase
+    dolt add t1
     run dolt rebase --continue
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Successfully rebased and updated refs/heads/b1" ]] || false

--- a/integration-tests/bats/rebase.bats
+++ b/integration-tests/bats/rebase.bats
@@ -336,7 +336,7 @@ setupCustomEditorScript() {
     ! [[ "$output" =~ "b1 merge commit" ]] || false
 }
 
-@test "rebase: rebase with data conflicts aborts" {
+@test "rebase: rebase with data conflict" {
     setupCustomEditorScript
 
     dolt checkout b1
@@ -345,15 +345,88 @@ setupCustomEditorScript() {
 
     run dolt rebase -i main
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "merge conflict detected while rebasing commit" ]] || false
-    [[ "$output" =~ "the rebase has been automatically aborted" ]] || false
+    [[ "$output" =~ "data conflict detected while rebasing commit" ]] || false
+    [[ "$output" =~ "b1 commit 2" ]] || false
+
+    # Assert that we are on the rebase working branch (not the branch being rebased)
+    run dolt sql -q "select active_branch();"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ " dolt_rebase_b1 " ]] || false
+
+    # Review and resolve the data conflict
+    run dolt conflicts cat .
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "+  | ours   | 1  | 1 | NULL | NULL | NULL | NULL |" ]] || false
+    [[ "$output" =~ "+  | theirs | 1  | 2 | NULL | NULL | NULL | NULL |" ]] || false
+    dolt conflicts resolve --theirs t1
 
     run dolt rebase --continue
-    [ "$status" -eq 1 ]
-    [[ "$output" =~ "no rebase in progress" ]] || false
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Successfully rebased and updated refs/heads/b1" ]] || false
 
+    # Assert that we are back on the branch being rebased
     run dolt branch
     [ "$status" -eq 0 ]
+    [[ "$output" =~ "b1" ]] || false
+    ! [[ "$output" =~ "dolt_rebase_b1" ]] || false
+}
+
+@test "rebase: rebase with multiple data conflicts" {
+    setupCustomEditorScript
+    dolt sql -q "INSERT INTO t1 VALUES (2,200);"
+    dolt commit -am "main commit 3"
+
+    dolt checkout b1
+    dolt sql -q "INSERT INTO t1 VALUES (1,2);"
+    dolt commit -am "b1 commit 2"
+    dolt sql -q "INSERT INTO t1 VALUES (2,3);"
+    dolt commit -am "b1 commit 3"
+
+    # Start the rebase
+    run dolt rebase -i main
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "data conflict detected while rebasing commit" ]] || false
+    [[ "$output" =~ "b1 commit 2" ]] || false
+
+    # Assert that we are on the rebase working branch now (not the branch being rebased)
+    run dolt sql -q "select active_branch();"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ " dolt_rebase_b1 " ]] || false
+
+    # Review and resolve the first data conflict
+    run dolt conflicts cat .
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "+  | ours   | 1  | 1 | NULL | NULL | NULL | NULL |" ]] || false
+    [[ "$output" =~ "+  | theirs | 1  | 2 | NULL | NULL | NULL | NULL |" ]] || false
+    dolt conflicts resolve --theirs t1
+
+    # Continue the rebase and hit the second data conflict
+    run dolt rebase --continue
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "data conflict detected while rebasing commit" ]] || false
+    [[ "$output" =~ "b1 commit 3" ]] || false
+
+    # Assert that we are still on the rebase working branch
+    run dolt sql -q "select active_branch();"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ " dolt_rebase_b1 " ]] || false
+
+    # Review and resolve the second data conflict
+    run dolt conflicts cat .
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "+  | ours   | 2  | 200 | NULL | NULL | NULL | NULL |" ]] || false
+    [[ "$output" =~ "+  | theirs | 2  | 3   | NULL | NULL | NULL | NULL |" ]] || false
+    dolt conflicts resolve --ours t1
+
+    # Finish the rebase
+    run dolt rebase --continue
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Successfully rebased and updated refs/heads/b1" ]] || false
+
+    # Assert that we are back on the branch that was rebased, and that the rebase working branch is gone
+    run dolt branch
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "b1" ]] || false
     ! [[ "$output" =~ "dolt_rebase_b1" ]] || false
 }
 
@@ -366,7 +439,7 @@ setupCustomEditorScript() {
 
     run dolt rebase -i main
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "merge conflict detected while rebasing commit" ]] || false
+    [[ "$output" =~ "schema conflict detected while rebasing commit" ]] || false
     [[ "$output" =~ "the rebase has been automatically aborted" ]] || false
 
     run dolt rebase --continue

--- a/integration-tests/bats/rebase.bats
+++ b/integration-tests/bats/rebase.bats
@@ -367,7 +367,7 @@ setupCustomEditorScript() {
     # Assert that we are back on the branch being rebased
     run dolt branch
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "b1" ]] || false
+    [[ "$output" =~ "* b1" ]] || false
     ! [[ "$output" =~ "dolt_rebase_b1" ]] || false
 }
 


### PR DESCRIPTION
When data conflicts occur during an interactive rebase, customers can now use [Dolt's conflict resolution](https://docs.dolthub.com/concepts/dolt/git/conflicts) tools to resolve the conflicts and continue the rebase operation. Note that schema conflicts are not supported yet.

Example:
```sql
> select * from dolt_rebase;
+--------------+--------+----------------------------------+----------------------------+
| rebase_order | action | commit_hash                      | commit_message             |
+--------------+--------+----------------------------------+----------------------------+
| 1.00         | drop   | iumpo2t0hd6drcn11jo8osdack1jmafp | inserting row 1 on branch1 |
| 2.00         | pick   | us2uaji20dj77cnf1i2l698itr5392se | updating row 1 on branch1  |
+--------------+--------+----------------------------------+----------------------------+

> call dolt_rebase('--continue');
data conflict detected while rebasing commit us2uaji20dj77cnf1i2l698itr5392se (updating row 1 on branch1). 

Resolve the conflicts and remove them from the dolt_conflicts_<table> tables, then continue the rebase by calling dolt_rebase('--continue')

> select * from dolt_conflicts_t;
+----------------------------------+---------+---------+--------+--------+---------------+----------+----------+-----------------+------------------------+
| from_root_ish                    | base_pk | base_c1 | our_pk | our_c1 | our_diff_type | their_pk | their_c1 | their_diff_type | dolt_conflict_id       |
+----------------------------------+---------+---------+--------+--------+---------------+----------+----------+-----------------+------------------------+
| us2uaji20dj77cnf1i2l698itr5392se | 1       | one     | NULL   | NULL   | removed       | 1        | uno      | modified        | B1dLxGtGIlHRKJo88tigpw |
+----------------------------------+---------+---------+--------+--------+---------------+----------+----------+-----------------+------------------------+

> call dolt_conflicts_resolve('--theirs', 't');
+--------+
| status |
+--------+
| 0      |
+--------+

> call dolt_rebase('--continue');
+--------+-----------------------------------------------------+
| status | message                                             |
+--------+-----------------------------------------------------+
| 0      | Successfully rebased and updated refs/heads/branch1 |
+--------+-----------------------------------------------------+
```

Customer issue: https://github.com/dolthub/dolt/issues/7820