### PR TITLE
dolt_workspace_* update and delete support

### DIFF
--- a/go/libraries/doltcore/merge/schema_merge_test.go
+++ b/go/libraries/doltcore/merge/schema_merge_test.go
@@ -1882,7 +1882,7 @@ func makeRootWithTable(t *testing.T, ddb *doltdb.DoltDB, eo editor.Options, tbl 
 	require.NoError(t, err)
 	noop := func(ctx *sql.Context, dbName string, root doltdb.RootValue) (err error) { return }
 	sess := writer.NewWriteSession(ddb.Format(), ws, gst, eo)
-	wr, err := sess.GetTableWriter(sql.NewContext(ctx), doltdb.TableName{Name: tbl.ns.name}, "test", noop)
+	wr, err := sess.GetTableWriter(sql.NewContext(ctx), doltdb.TableName{Name: tbl.ns.name}, "test", noop, false)
 	require.NoError(t, err)
 
 	sctx := sql.NewEmptyContext()

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_applier.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_applier.go
@@ -764,7 +764,7 @@ func getTableWriter(ctx *sql.Context, engine *gms.Engine, tableName, databaseNam
 	ds := dsess.DSessFromSess(ctx.Session)
 	setter := ds.SetWorkingRoot
 
-	tableWriter, err := writeSession.GetTableWriter(ctx, doltdb.TableName{Name: tableName}, databaseName, setter)
+	tableWriter, err := writeSession.GetTableWriter(ctx, doltdb.TableName{Name: tableName}, databaseName, setter, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -399,11 +399,18 @@ func (db Database) getTableInsensitive(ctx *sql.Context, head *doltdb.Commit, ds
 		return dt, true, nil
 	case strings.HasPrefix(lwrName, doltdb.DoltWorkspaceTablePrefix):
 		sess := dsess.DSessFromSess(ctx.Session)
+
+		ws, err := sess.WorkingSet(ctx, db.RevisionQualifiedName())
+		if err != nil {
+			return nil, false, err
+		}
+
 		roots, _ := sess.GetRoots(ctx, db.RevisionQualifiedName())
+		head := roots.Head
 
 		userTable := tblName[len(doltdb.DoltWorkspaceTablePrefix):]
 
-		dt, err := dtables.NewWorkspaceTable(ctx, userTable, roots)
+		dt, err := dtables.NewWorkspaceTable(ctx, userTable, head, ws)
 		if err != nil {
 			return nil, false, err
 		}

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -410,7 +410,7 @@ func (db Database) getTableInsensitive(ctx *sql.Context, head *doltdb.Commit, ds
 
 		userTable := tblName[len(doltdb.DoltWorkspaceTablePrefix):]
 
-		dt, err := dtables.NewWorkspaceTable(ctx, userTable, head, ws)
+		dt, err := dtables.NewWorkspaceTable(ctx, tblName, userTable, head, ws)
 		if err != nil {
 			return nil, false, err
 		}

--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -952,6 +952,8 @@ func (d *DoltSession) SetWorkingRoot(ctx *sql.Context, dbName string, newRoot do
 	return d.SetWorkingSet(ctx, dbName, existingWorkingSet.WithWorkingRoot(newRoot))
 }
 
+// SetStagingRoot sets the staging root for the session's current database. This is useful when editing the staged
+// table without messing with the HEAD or working trees.
 func (d *DoltSession) SetStagingRoot(ctx *sql.Context, dbName string, newRoot doltdb.RootValue) error {
 	branchState, _, err := d.lookupDbState(ctx, dbName)
 	if err != nil {

--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -952,6 +952,26 @@ func (d *DoltSession) SetWorkingRoot(ctx *sql.Context, dbName string, newRoot do
 	return d.SetWorkingSet(ctx, dbName, existingWorkingSet.WithWorkingRoot(newRoot))
 }
 
+func (d *DoltSession) SetStagingRoot(ctx *sql.Context, dbName string, newRoot doltdb.RootValue) error {
+	branchState, _, err := d.lookupDbState(ctx, dbName)
+	if err != nil {
+		return err
+	}
+
+	existingWorkingSet := branchState.WorkingSet()
+	if existingWorkingSet == nil {
+		return doltdb.ErrOperationNotSupportedInDetachedHead
+	}
+	if rootsEqual(branchState.roots().Staged, newRoot) {
+		return nil
+	}
+
+	if branchState.readOnly {
+		return fmt.Errorf("cannot set root on read-only session")
+	}
+	return d.SetWorkingSet(ctx, dbName, existingWorkingSet.WithStagedRoot(newRoot))
+}
+
 // SetRoots sets new roots for the session for the database named. Typically, clients should only set the working root,
 // via setRoot. This method is for clients that need to update more of the session state, such as the dolt_ functions.
 // Unlike setting the working root, this method always marks the database state dirty.

--- a/go/libraries/doltcore/sqle/dsess/table_writer.go
+++ b/go/libraries/doltcore/sqle/dsess/table_writer.go
@@ -27,7 +27,7 @@ import (
 // It's responsible for creating and managing the lifecycle of TableWriter's.
 type WriteSession interface {
 	// GetTableWriter creates a TableWriter and adds it to the WriteSession.
-	GetTableWriter(ctx *sql.Context, table doltdb.TableName, db string, setter SessionRootSetter) (TableWriter, error)
+	GetTableWriter(ctx *sql.Context, table doltdb.TableName, db string, setter SessionRootSetter, targetStaging bool) (TableWriter, error)
 
 	// GetWorkingSet returns the session's current working set.
 	GetWorkingSet() *doltdb.WorkingSet

--- a/go/libraries/doltcore/sqle/dtables/docs_table.go
+++ b/go/libraries/doltcore/sqle/dtables/docs_table.go
@@ -258,7 +258,7 @@ func (iw *docsWriter) StatementBegin(ctx *sql.Context) {
 	}
 
 	if ws := dbState.WriteSession(); ws != nil {
-		tableWriter, err := ws.GetTableWriter(ctx, doltdb.TableName{Name: doltdb.DocTableName}, dbName, dSess.SetWorkingRoot)
+		tableWriter, err := ws.GetTableWriter(ctx, doltdb.TableName{Name: doltdb.DocTableName}, dbName, dSess.SetWorkingRoot, false)
 		if err != nil {
 			iw.errDuringStatementBegin = err
 			return

--- a/go/libraries/doltcore/sqle/dtables/ignore_table.go
+++ b/go/libraries/doltcore/sqle/dtables/ignore_table.go
@@ -274,7 +274,7 @@ func (iw *ignoreWriter) StatementBegin(ctx *sql.Context) {
 	}
 
 	if ws := dbState.WriteSession(); ws != nil {
-		tableWriter, err := ws.GetTableWriter(ctx, doltdb.TableName{Name: doltdb.IgnoreTableName}, dbName, dSess.SetWorkingRoot)
+		tableWriter, err := ws.GetTableWriter(ctx, doltdb.TableName{Name: doltdb.IgnoreTableName}, dbName, dSess.SetWorkingRoot, false)
 		if err != nil {
 			iw.errDuringStatementBegin = err
 			return

--- a/go/libraries/doltcore/sqle/dtables/workspace.go
+++ b/go/libraries/doltcore/sqle/dtables/workspace.go
@@ -20,6 +20,9 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/dolthub/go-mysql-server/sql"
+	sqltypes "github.com/dolthub/go-mysql-server/sql/types"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
@@ -34,8 +37,6 @@ import (
 	"github.com/dolthub/dolt/go/store/prolly/tree"
 	"github.com/dolthub/dolt/go/store/types"
 	"github.com/dolthub/dolt/go/store/val"
-	"github.com/dolthub/go-mysql-server/sql"
-	sqltypes "github.com/dolthub/go-mysql-server/sql/types"
 )
 
 type WorkspaceTable struct {

--- a/go/libraries/doltcore/sqle/dtables/workspace.go
+++ b/go/libraries/doltcore/sqle/dtables/workspace.go
@@ -101,9 +101,9 @@ func (wtu *WorkspaceTableUpdater) StatementBegin(ctx *sql.Context) {
 	wtu.sessionWriter = &sessionWriter
 }
 
-func (wtu *WorkspaceTableUpdater) DiscardChanges(ctx *sql.Context, errorEncountered error) error {
-	if wtu.tableWriter != nil {
-		err := (*wtu.tableWriter).DiscardChanges(ctx, errorEncountered)
+func (wtm *WorkspaceTableModifier) DiscardChanges(ctx *sql.Context, errorEncountered error) error {
+	if wtm.tableWriter != nil {
+		err := (*wtm.tableWriter).DiscardChanges(ctx, errorEncountered)
 		if err != nil {
 			return err
 		}
@@ -111,12 +111,13 @@ func (wtu *WorkspaceTableUpdater) DiscardChanges(ctx *sql.Context, errorEncounte
 	return nil
 }
 
-func (wtu *WorkspaceTableUpdater) StatementComplete(ctx *sql.Context) error {
-	if wtu.err != nil {
-		return *wtu.err
+// StatementComplete is common between WorkspaceTableModifier and WorkspaceTableUpdater
+func (wtm *WorkspaceTableModifier) StatementComplete(ctx *sql.Context) error {
+	if wtm.err != nil {
+		return *wtm.err
 	}
 
-	return wtu.statementComplete(ctx)
+	return wtm.statementComplete(ctx)
 }
 
 func (wtm *WorkspaceTableModifier) statementComplete(ctx *sql.Context) error {
@@ -201,24 +202,6 @@ func (wtd *WorkspaceTableDeleter) StatementBegin(ctx *sql.Context) {
 	}
 	wtd.tableWriter = &tableWriter
 	wtd.sessionWriter = &sessionWriter
-}
-
-func (wtd *WorkspaceTableDeleter) DiscardChanges(ctx *sql.Context, errorEncountered error) error {
-	if wtd.tableWriter != nil {
-		err := (*wtd.tableWriter).DiscardChanges(ctx, errorEncountered)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (wtd *WorkspaceTableDeleter) StatementComplete(ctx *sql.Context) error {
-	if wtd.err != nil {
-		return *wtd.err
-	}
-
-	return wtd.statementComplete(ctx)
 }
 
 func (wtd *WorkspaceTableDeleter) Delete(c *sql.Context, row sql.Row) error {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_workspace.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_workspace.go
@@ -397,6 +397,18 @@ var DoltWorkspaceScriptTests = []queries.ScriptTest{
 				},
 			},
 			{
+				Query: "select sum(y) from tbl AS OF STAGED",
+				Expected: []sql.Row{
+					{float64(95)},
+				},
+			},
+			{
+				Query: "select sum(y) from tbl AS OF WORKING",
+				Expected: []sql.Row{
+					{float64(162)},
+				},
+			},
+			{
 				// add everything.
 				Query: "update dolt_workspace_tbl set staged = 1",
 			},
@@ -726,6 +738,7 @@ var DoltWorkspaceScriptTests = []queries.ScriptTest{
 				Query: "update dolt_workspace_tbl set staged = false where id = 0",
 			},
 			{
+				// Removing the staged row should not affect the working row's final value, but it will change the from_ value.
 				Query: "select * from dolt_workspace_tbl",
 				Expected: []sql.Row{
 					{0, false, "modified", 42, "working", 42, "inserted"},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_workspace.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_workspace.go
@@ -333,4 +333,20 @@ var DoltWorkspaceScriptTests = []queries.ScriptTest{
 			*/
 		},
 	},
+	{
+		Name: "dolt_workspace_* prevent illegal updates",
+		SetUpScript: []string{
+			"create table tbl (pk int primary key, val int);",
+			"insert into tbl values (42,42);",
+			"call dolt_commit('-Am', 'creating table tbl');",
+			"update tbl set val=51 where pk=42;",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:          "update dolt_workspace_tbl set to_val = 108 where id = 0;",
+				ExpectedErrStr: "only update of column 'staged' is allowed",
+			},
+		},
+		// NM4 - new a test for deleting a row. Maybe? How about adding to the table??
+	},
 }

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -718,7 +718,7 @@ func (t *WritableDoltTable) getTableEditor(ctx *sql.Context) (ed dsess.TableWrit
 
 	setter := ds.SetWorkingRoot
 
-	ed, err = writeSession.GetTableWriter(ctx, t.TableName(), t.db.RevisionQualifiedName(), setter)
+	ed, err = writeSession.GetTableWriter(ctx, t.TableName(), t.db.RevisionQualifiedName(), setter, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1866,7 +1866,7 @@ func (t *AlterableDoltTable) RewriteInserter(
 	opts.ForeignKeyChecksDisabled = true
 	writeSession := writer.NewWriteSession(dt.Format(), newWs, ait, opts)
 
-	ed, err := writeSession.GetTableWriter(ctx, t.TableName(), t.db.RevisionQualifiedName(), sess.SetWorkingRoot)
+	ed, err := writeSession.GetTableWriter(ctx, t.TableName(), t.db.RevisionQualifiedName(), sess.SetWorkingRoot, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1915,7 +1915,7 @@ func fullTextRewriteEditor(
 	opts.ForeignKeyChecksDisabled = true
 	writeSession := writer.NewWriteSession(dt.Format(), newWs, ait, opts)
 
-	parentEditor, err := writeSession.GetTableWriter(ctx, t.TableName(), t.db.RevisionQualifiedName(), sess.SetWorkingRoot)
+	parentEditor, err := writeSession.GetTableWriter(ctx, t.TableName(), t.db.RevisionQualifiedName(), sess.SetWorkingRoot, false)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/temp_table.go
+++ b/go/libraries/doltcore/sqle/temp_table.go
@@ -144,7 +144,7 @@ func NewTempTable(
 		opts:      opts,
 	}
 
-	tempTable.ed, err = writeSession.GetTableWriter(ctx, doltdb.TableName{Name: name}, db, setTempTableRoot(tempTable))
+	tempTable.ed, err = writeSession.GetTableWriter(ctx, doltdb.TableName{Name: name}, db, setTempTableRoot(tempTable), false)
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +184,7 @@ func setTempTableRoot(t *TempTable) func(ctx *sql.Context, dbName string, newRoo
 		}
 
 		writeSession := writer.NewWriteSession(newTable.Format(), newWs, ait, t.opts)
-		t.ed, err = writeSession.GetTableWriter(ctx, doltdb.TableName{Name: t.tableName}, t.dbName, setTempTableRoot(t))
+		t.ed, err = writeSession.GetTableWriter(ctx, doltdb.TableName{Name: t.tableName}, t.dbName, setTempTableRoot(t), false)
 		if err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/sqle/writer/noms_write_session.go
+++ b/go/libraries/doltcore/sqle/writer/noms_write_session.go
@@ -50,10 +50,11 @@ var _ dsess.WriteSession = &nomsWriteSession{}
 func NewWriteSession(nbf *types.NomsBinFormat, ws *doltdb.WorkingSet, aiTracker globalstate.AutoIncrementTracker, opts editor.Options) dsess.WriteSession {
 	if types.IsFormat_DOLT(nbf) {
 		return &prollyWriteSession{
-			workingSet: ws,
-			tables:     make(map[doltdb.TableName]*prollyTableWriter),
-			aiTracker:  aiTracker,
-			mut:        &sync.RWMutex{},
+			workingSet:    ws,
+			tables:        make(map[doltdb.TableName]*prollyTableWriter),
+			aiTracker:     aiTracker,
+			mut:           &sync.RWMutex{},
+			targetStaging: opts.TargetStaging,
 		}
 	}
 
@@ -70,7 +71,12 @@ func (s *nomsWriteSession) GetWorkingSet() *doltdb.WorkingSet {
 	return s.workingSet
 }
 
-func (s *nomsWriteSession) GetTableWriter(ctx *sql.Context, table doltdb.TableName, db string, setter dsess.SessionRootSetter) (dsess.TableWriter, error) {
+func (s *nomsWriteSession) GetTableWriter(ctx *sql.Context, table doltdb.TableName, db string, setter dsess.SessionRootSetter, targetStaging bool) (dsess.TableWriter, error) {
+	if targetStaging {
+		// This would be fairly easy to implement, but we gotta stop luggin around the legacy storage format.
+		return nil, fmt.Errorf("Feature not suppported in legacy storage format")
+	}
+
 	s.mut.Lock()
 	defer s.mut.Unlock()
 

--- a/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
@@ -52,6 +52,8 @@ type prollyTableWriter struct {
 	flusher dsess.WriteSessionFlusher
 	setter  dsess.SessionRootSetter
 
+	targetStaging bool
+
 	errEncountered error
 }
 
@@ -374,5 +376,10 @@ func (w *prollyTableWriter) flush(ctx *sql.Context) error {
 	if err != nil {
 		return err
 	}
-	return w.setter(ctx, w.dbName, ws.WorkingRoot())
+
+	if w.targetStaging {
+		return w.setter(ctx, w.dbName, ws.StagedRoot())
+	} else {
+		return w.setter(ctx, w.dbName, ws.WorkingRoot())
+	}
 }

--- a/go/libraries/doltcore/table/editor/pk_table_editor.go
+++ b/go/libraries/doltcore/table/editor/pk_table_editor.go
@@ -95,7 +95,7 @@ type Options struct {
 	ForeignKeyChecksDisabled bool // If true, then ALL foreign key checks AND updates (through CASCADE, etc.) are skipped
 	Deaf                     DbEaFactory
 	Tempdir                  string
-	
+
 	// TargetStaging is true if the table is being edited in the staging root, as opposed to the working root (rare).
 	TargetStaging bool
 }

--- a/go/libraries/doltcore/table/editor/pk_table_editor.go
+++ b/go/libraries/doltcore/table/editor/pk_table_editor.go
@@ -95,6 +95,7 @@ type Options struct {
 	ForeignKeyChecksDisabled bool // If true, then ALL foreign key checks AND updates (through CASCADE, etc.) are skipped
 	Deaf                     DbEaFactory
 	Tempdir                  string
+	TargetStaging            bool // NM4 - not sure.
 }
 
 // WithDeaf returns a new Options with the given  edit accumulator factory class

--- a/go/libraries/doltcore/table/editor/pk_table_editor.go
+++ b/go/libraries/doltcore/table/editor/pk_table_editor.go
@@ -95,7 +95,9 @@ type Options struct {
 	ForeignKeyChecksDisabled bool // If true, then ALL foreign key checks AND updates (through CASCADE, etc.) are skipped
 	Deaf                     DbEaFactory
 	Tempdir                  string
-	TargetStaging            bool // NM4 - not sure.
+	
+	// TargetStaging is true if the table is being edited in the staging root, as opposed to the working root (rare).
+	TargetStaging bool
 }
 
 // WithDeaf returns a new Options with the given  edit accumulator factory class


### PR DESCRIPTION
This change adds the ability to update dolt_workspace_ tables. Updates can take two forms:
1)  The "staging" column of the table. may be toggled from it's current state. If setting from false to true, the working value will be written into the staged table. Setting from true to false will remove the row from staging, and leave the value in working as is.
2) You can delete any row which has a "staged" column of false. This will revert the workspace changes and return them to the original value.