### PR TITLE
More consistent return types for dolt procedures

### DIFF
--- a/go/libraries/doltcore/sqle/dprocedures/dolt_cherry_pick.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_cherry_pick.go
@@ -58,7 +58,7 @@ func doltCherryPick(ctx *sql.Context, args ...string) (sql.RowIter, error) {
 	if err != nil {
 		return nil, err
 	}
-	return rowToIter(newCommitHash, dataConflicts, schemaConflicts, constraintViolations), nil
+	return rowToIter(newCommitHash, int64(dataConflicts), int64(schemaConflicts), int64(constraintViolations)), nil
 }
 
 // doDoltCherryPick attempts to perform a cherry-pick merge based on the arguments specified in |args| and returns

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_conflicts_resolve.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_conflicts_resolve.go
@@ -48,7 +48,7 @@ func doltConflictsResolve(ctx *sql.Context, args ...string) (sql.RowIter, error)
 	if err != nil {
 		return nil, err
 	}
-	return rowToIter(res), nil
+	return rowToIter(int64(res)), nil
 }
 
 // DoltConflictsCatFunc runs a `dolt commit` in the SQL context, committing staged changes to head.

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_remote.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_remote.go
@@ -36,7 +36,7 @@ func doltRemote(ctx *sql.Context, args ...string) (sql.RowIter, error) {
 	if err != nil {
 		return nil, err
 	}
-	return rowToIter(res), nil
+	return rowToIter(int64(res)), nil
 }
 
 // doDoltRemote is used as sql dolt_remote command for only creating or deleting remotes, not listing.

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_tag.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_tag.go
@@ -30,7 +30,7 @@ func doltTag(ctx *sql.Context, args ...string) (sql.RowIter, error) {
 	if err != nil {
 		return nil, err
 	}
-	return rowToIter(res), nil
+	return rowToIter(int64(res)), nil
 }
 
 // doDoltTag is used as sql dolt_tag command for only creating or deleting tags, not listing.

--- a/integration-tests/mysql-client-tests/node/workbenchTests/databases.js
+++ b/integration-tests/mysql-client-tests/node/workbenchTests/databases.js
@@ -51,8 +51,8 @@ export const databaseTests = [
   {
     q: `SELECT dolt_version()`,
     res: [{ "dolt_version()": "0.0.0" }],
-    matcher: (_, exp) => {
-      return exp[0]["dolt_version()"].length > 0;
+    matcher: (res) => {
+      return res[0]["dolt_version()"].length > 0;
     },
   },
 ];


### PR DESCRIPTION
Most procedures that return integers return `int64`, but there are a few exceptions. The procedures that return `int` break in doltgres [here](https://github.com/dolthub/doltgresql/blob/main/server/functions/dolt_procedures.go#L144)