### PR TITLE
[statspro] Avoid stopping the world during stats updates

### DIFF
--- a/go/libraries/doltcore/sqle/statsnoms/database.go
+++ b/go/libraries/doltcore/sqle/statsnoms/database.go
@@ -151,6 +151,9 @@ func (n *NomsStatsDatabase) LoadBranchStats(ctx *sql.Context, branch string) err
 }
 
 func (n *NomsStatsDatabase) getBranchStats(branch string) dbStats {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
 	for i, b := range n.branches {
 		if strings.EqualFold(b, branch) {
 			return n.stats[i]
@@ -174,7 +177,7 @@ func (n *NomsStatsDatabase) ListStatQuals(branch string) []sql.StatQualifier {
 	return ret
 }
 
-func (n *NomsStatsDatabase) SetStat(ctx context.Context, branch string, qual sql.StatQualifier, stats *statspro.DoltStats) error {
+func (n *NomsStatsDatabase) setStat(ctx context.Context, branch string, qual sql.StatQualifier, stats *statspro.DoltStats) error {
 	var statsMap *prolly.MutableMap
 	for i, b := range n.branches {
 		if strings.EqualFold(branch, b) {
@@ -194,6 +197,12 @@ func (n *NomsStatsDatabase) SetStat(ctx context.Context, branch string, qual sql
 	}
 
 	return n.replaceStats(ctx, statsMap, stats)
+}
+func (n *NomsStatsDatabase) SetStat(ctx context.Context, branch string, qual sql.StatQualifier, stats *statspro.DoltStats) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	return n.setStat(ctx, branch, qual, stats)
 }
 
 func (n *NomsStatsDatabase) trackBranch(ctx context.Context, branch string) error {
@@ -220,6 +229,9 @@ func (n *NomsStatsDatabase) initMutable(ctx context.Context, i int) error {
 }
 
 func (n *NomsStatsDatabase) DeleteStats(branch string, quals ...sql.StatQualifier) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
 	for i, b := range n.branches {
 		if strings.EqualFold(b, branch) {
 			for _, qual := range quals {
@@ -230,6 +242,9 @@ func (n *NomsStatsDatabase) DeleteStats(branch string, quals ...sql.StatQualifie
 }
 
 func (n *NomsStatsDatabase) DeleteBranchStats(ctx context.Context, branch string, flush bool) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
 	for i, b := range n.branches {
 		if strings.EqualFold(b, branch) {
 			n.branches = append(n.branches[:i], n.branches[i+1:]...)
@@ -245,6 +260,9 @@ func (n *NomsStatsDatabase) DeleteBranchStats(ctx context.Context, branch string
 }
 
 func (n *NomsStatsDatabase) ReplaceChunks(ctx context.Context, branch string, qual sql.StatQualifier, targetHashes []hash.Hash, dropChunks, newChunks []sql.HistogramBucket) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
 	var dbStat dbStats
 	for i, b := range n.branches {
 		if strings.EqualFold(b, branch) {
@@ -274,10 +292,13 @@ func (n *NomsStatsDatabase) ReplaceChunks(ctx context.Context, branch string, qu
 	dbStat[qual].UpdateActive()
 
 	// let |n.SetStats| update memory and disk
-	return n.SetStat(ctx, branch, qual, dbStat[qual])
+	return n.setStat(ctx, branch, qual, dbStat[qual])
 }
 
 func (n *NomsStatsDatabase) Flush(ctx context.Context, branch string) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
 	for i, b := range n.branches {
 		if strings.EqualFold(b, branch) {
 			if n.dirty[i] != nil {

--- a/go/libraries/doltcore/sqle/statspro/analyze.go
+++ b/go/libraries/doltcore/sqle/statspro/analyze.go
@@ -85,7 +85,7 @@ func (p *Provider) BootstrapDatabaseStats(ctx *sql.Context, db string) error {
 
 func (p *Provider) RefreshTableStatsWithBranch(ctx *sql.Context, table sql.Table, db string, branch string) error {
 	if !p.TryLockForUpdate(table.Name(), db, branch) {
-		return nil
+		return fmt.Errorf("already updating statistics")
 	}
 	defer p.UnlockTable(table.Name(), db, branch)
 

--- a/go/libraries/doltcore/sqle/statspro/analyze.go
+++ b/go/libraries/doltcore/sqle/statspro/analyze.go
@@ -84,6 +84,11 @@ func (p *Provider) BootstrapDatabaseStats(ctx *sql.Context, db string) error {
 }
 
 func (p *Provider) RefreshTableStatsWithBranch(ctx *sql.Context, table sql.Table, db string, branch string) error {
+	if !p.TryLockForUpdate(table.Name(), db, branch) {
+		return nil
+	}
+	defer p.UnlockTable(table.Name(), db, branch)
+
 	dSess := dsess.DSessFromSess(ctx.Session)
 
 	sqlDb, err := dSess.Provider().Database(ctx, p.branchQualifiedDatabase(db, branch))
@@ -92,8 +97,8 @@ func (p *Provider) RefreshTableStatsWithBranch(ctx *sql.Context, table sql.Table
 	}
 
 	// lock only after accessing DatabaseProvider
-	p.mu.Lock()
-	defer p.mu.Unlock()
+	//p.mu.Lock()
+	//defer p.mu.Unlock()
 
 	tableName := strings.ToLower(table.Name())
 	dbName := strings.ToLower(db)

--- a/go/libraries/doltcore/sqle/statspro/analyze.go
+++ b/go/libraries/doltcore/sqle/statspro/analyze.go
@@ -97,8 +97,6 @@ func (p *Provider) RefreshTableStatsWithBranch(ctx *sql.Context, table sql.Table
 	}
 
 	// lock only after accessing DatabaseProvider
-	//p.mu.Lock()
-	//defer p.mu.Unlock()
 
 	tableName := strings.ToLower(table.Name())
 	dbName := strings.ToLower(db)

--- a/go/libraries/doltcore/sqle/statspro/auto_refresh.go
+++ b/go/libraries/doltcore/sqle/statspro/auto_refresh.go
@@ -107,8 +107,6 @@ func (p *Provider) InitAutoRefreshWithParams(ctxFactory func(ctx context.Context
 }
 
 func (p *Provider) checkRefresh(ctx *sql.Context, sqlDb sql.Database, dbName, branch string, updateThresh float64) error {
-	//p.mu.Lock()
-	//defer p.mu.Unlock()
 	if !p.TryLockForUpdate("", dbName, branch) {
 		return nil
 	}

--- a/go/libraries/doltcore/sqle/statspro/auto_refresh.go
+++ b/go/libraries/doltcore/sqle/statspro/auto_refresh.go
@@ -107,8 +107,12 @@ func (p *Provider) InitAutoRefreshWithParams(ctxFactory func(ctx context.Context
 }
 
 func (p *Provider) checkRefresh(ctx *sql.Context, sqlDb sql.Database, dbName, branch string, updateThresh float64) error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
+	//p.mu.Lock()
+	//defer p.mu.Unlock()
+	if !p.TryLockForUpdate("", dbName, branch) {
+		return nil
+	}
+	defer p.UnlockTable("", dbName, branch)
 
 	// Iterate all dbs, tables, indexes. Each db will collect
 	// []indexMeta above refresh threshold. We read and process those
@@ -131,6 +135,10 @@ func (p *Provider) checkRefresh(ctx *sql.Context, sqlDb sql.Database, dbName, br
 	}
 
 	for _, table := range tables {
+		if !p.TryLockForUpdate(table, dbName, branch) {
+			continue
+		}
+		defer p.UnlockTable(table, dbName, branch)
 		sqlTable, dTab, err := GetLatestTable(ctx, table, sqlDb)
 		if err != nil {
 			return err

--- a/go/libraries/doltcore/sqle/statspro/stats_provider.go
+++ b/go/libraries/doltcore/sqle/statspro/stats_provider.go
@@ -115,8 +115,6 @@ func (p *Provider) UnlockTable(table string, db string, branch string) {
 
 func (p *Provider) StartRefreshThread(ctx *sql.Context, pro dsess.DoltDatabaseProvider, name string, env *env.DoltEnv, db dsess.SqlDatabase) error {
 	err := p.starter(ctx, pro.(*sqle.DoltDatabaseProvider), name, env, db)
-	p.mu.Lock()
-	defer p.mu.Unlock()
 
 	if err != nil {
 		p.UpdateStatus(name, fmt.Sprintf("error restarting thread %s: %s", name, err.Error()))


### PR DESCRIPTION
The stats provider holds a lock that was required to (1) update stats, and (2) access statistics.

The new behavior
- Reject duplicate update requests on the same database/branch/table. So an `analyze table <t>` will error if a conflicting job is active.
- Only lock the provider in critical sections. Update threads only grab the lock to read current statistics or write updates. So regular reads/writes will not hang waiting for the stats provider mutex longer than it takes to finish a critical section.