### PR TITLE
dolt add --patch

### DIFF
--- a/go/cmd/dolt/cli/flags.go
+++ b/go/cmd/dolt/cli/flags.go
@@ -58,6 +58,7 @@ const (
 	OursFlag             = "ours"
 	OutputOnlyFlag       = "output-only"
 	ParentsFlag          = "parents"
+	PatchFlag            = "patch"
 	PasswordFlag         = "password"
 	PortFlag             = "port"
 	PruneFlag            = "prune"

--- a/go/cmd/dolt/commands/add.go
+++ b/go/cmd/dolt/commands/add.go
@@ -17,14 +17,21 @@ package commands
 import (
 	"bytes"
 	"context"
-
-	"github.com/dolthub/go-mysql-server/sql"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/ishell"
+	"github.com/fatih/color"
+	"golang.org/x/exp/slices"
 )
 
 var addDocs = cli.CommandDocumentationContent{
@@ -101,6 +108,10 @@ func generateAddSql(apr *argparser.ArgParseResults) string {
 // Exec executes the command
 func (cmd AddCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cli.CreateAddArgParser()
+
+	// This flag is only supported in a CLI context, not the in the dolt procedure.
+	ap.SupportsFlag("patch", "p", "Interactively select changes to add to the staged set.")
+
 	apr, _, terminate, status := ParseArgsOrPrintHelp(ap, commandStr, args, addDocs)
 	if terminate {
 		return status
@@ -123,7 +134,7 @@ func (cmd AddCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 	}
 
 	if apr.Contains("patch") {
-		return patchWorkflow(sqlCtx, queryist, args, cliCtx)
+		return patchWorkflow(sqlCtx, queryist, apr.Args)
 	} else {
 		for _, tableName := range apr.Args {
 			if tableName != "." && !doltdb.IsValidTableName(tableName) {
@@ -147,4 +158,435 @@ func (cmd AddCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 	return 0
 }
 
+func patchWorkflow(sqlCtx *sql.Context, queryist cli.Queryist, tables []string) int {
+	if len(tables) == 0 {
+		// Get the list of tables to patch
+		_, rowIter, _, err := queryist.Query(sqlCtx, "select table_name from dolt_status where not staged")
+		if err != nil {
+			cli.PrintErrln(errhand.VerboseErrorFromError(err))
+			return 1
+		}
+
+		rows, err := sql.RowIterToRows(sqlCtx, rowIter)
+		if err != nil {
+			cli.PrintErrln(errhand.VerboseErrorFromError(err))
+			return 1
+		}
+
+		for _, r := range rows {
+			tbl := r[0].(string)
+			tables = append(tables, tbl)
+		}
+	}
+	sort.Strings(tables)
+	runAddPatchShell(sqlCtx, queryist, tables)
+
+	return 0
+}
+
+// changeCount is a struct that holds the summary of details for a single table's unstaged changes.
+// This includes the number of added, modified, and removed rows, and the ID of the first and last rows where
+// staged == false.
+type changeCount struct {
+	add      int
+	modifies int
+	removes  int
+	firstId  int
+	lastId   int
+}
+
+func (c *changeCount) total() int {
+	return c.add + c.modifies + c.removes
+}
+
+func runAddPatchShell(sqlCtx *sql.Context, queryist cli.Queryist, tables []string) int {
+	state, err := newState(sqlCtx, queryist, tables)
+	if err != nil {
+		cli.PrintErrln(errhand.VerboseErrorFromError(err))
+		return 1
+	}
+
+	shell := ishell.New()
+	shell.AutoHelp(false)
+
+	shell.AddCmd(&ishell.Cmd{
+		Name: "?",
+		Help: "show this help",
+		Func: opHelp,
+	})
+	shell.AddCmd(&ishell.Cmd{
+		Name: "y",
+		Help: "stage the current change",
+		Func: state.opYes,
+	})
+	shell.AddCmd(&ishell.Cmd{
+		Name: "n",
+		Help: "do not stage the current change",
+		Func: state.opNo,
+	})
+	shell.AddCmd(&ishell.Cmd{
+		Name: "q",
+		Help: "quit",
+		Func: func(c *ishell.Context) {
+			c.Stop()
+		},
+	})
+	shell.AddCmd(&ishell.Cmd{
+		Name: "a",
+		Help: "add all changes in this table",
+		Func: state.opAddAllOfTable,
+	})
+	shell.AddCmd(&ishell.Cmd{
+		Name: "d",
+		Help: "do not stage any further changes in this table",
+		Func: state.opSkipTable,
+	})
+	shell.AddCmd(&ishell.Cmd{
+		Name: "s",
+		Help: "show summary of unstaged changes and start over",
+		Func: state.reset,
+	})
+
+	prompt := "Stage this row [y,n,q,a,d,s,?]? "
+	prompt = color.HiGreenString(prompt)
+	shell.SetPrompt(prompt)
+
+	// run shell. This blocks until the user exits.
+	shell.Run()
+
+	if state.err != nil {
+		cli.PrintErrln(errhand.VerboseErrorFromError(state.err))
+		return 1
+	}
+	return 0
+}
+
+// queryForUnstagedChanges queries the dolt_workspace_* tables for the add/modify/remove counts for each table.
+func queryForUnstagedChanges(sqlCtx *sql.Context, queryist cli.Queryist, tables []string) (map[string]*changeCount, error) {
+	changeCounts := make(map[string]*changeCount)
+	for _, tableName := range tables {
+		// Now get the add/drop/modify counts. This query is hand crafted which seems like a bad idea, but it's only the
+		// table name that is inserted, and that comes from our data, not user input.
+		qry := fmt.Sprintf("SELECT diff_type,count(*) AS count FROM dolt_workspace_%s WHERE NOT staged GROUP BY diff_type", tableName)
+		_, rowIter, _, err := queryist.Query(sqlCtx, qry)
+		if err != nil {
+			return nil, err
+		}
+		rows, err := sql.RowIterToRows(sqlCtx, rowIter)
+		if err != nil {
+			return nil, err
+		}
+
+		changeCounts[tableName] = &changeCount{}
+		for _, row := range rows {
+			diffType := row[0].(string)
+			count, err := coerceToInt(row[1])
+			if err != nil {
+				return nil, err
+			}
+			switch diffType {
+			case "added":
+				changeCounts[tableName].add = count
+			case "modified":
+				changeCounts[tableName].modifies = count
+			case "removed":
+				changeCounts[tableName].removes = count
+			default:
+				return nil, errors.New("Unexpected diff type: " + diffType)
+			}
+		}
+
+		// Kind of lame to do another query, but so be it.
+		qry = fmt.Sprintf("SELECT min(id) as first_id, max(id) as last_id FROM dolt_workspace_%s WHERE NOT staged", tableName)
+		_, rowIter, _, err = queryist.Query(sqlCtx, qry)
+		if err != nil {
+			return nil, err
+		}
+		rows, err = sql.RowIterToRows(sqlCtx, rowIter)
+		if err != nil {
+			return nil, err
+		}
+		if len(rows) != 1 {
+			return nil, errors.New("Expectedlyone row")
+		}
+		firstId, err := coerceToInt(rows[0][0])
+		if err != nil {
+			return nil, err
+		}
+		changeCounts[tableName].firstId = firstId
+		lastId, err := coerceToInt(rows[0][1])
+		if err != nil {
+			return nil, err
+		}
+		changeCounts[tableName].lastId = lastId
+	}
+
+	return changeCounts, nil
+}
+
+func coerceToInt(val interface{}) (int, error) {
+	switch v := val.(type) {
+	case int:
+		return v, nil
+	case int64:
+		return int(v), nil
+	case string:
+		i, err := strconv.Atoi(v)
+		if err != nil {
+			return 0, err
+		}
+		return i, nil
+	default:
+		return 0, errors.New("Expected int, int64 or string")
+	}
+}
+
+func queryForSingleChange(sqlCtx *sql.Context, queryist cli.Queryist, tableName string, rowId int) (sql.Row, error) {
+	qry := fmt.Sprintf("SELECT * FROM dolt_workspace_%s WHERE ID = %d LIMIT 1", tableName, rowId)
+	_, rowIter, _, err := queryist.Query(sqlCtx, qry)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := sql.RowIterToRows(sqlCtx, rowIter)
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 || len(rows) > 1 {
+		return nil, errors.New("Expected exactly one row")
+	}
+	return rows[0], nil
+}
+
+func firstFoundTable(tables []string, changeCounts map[string]*changeCount) string {
+	for _, tableName := range tables {
+		if _, ok := changeCounts[tableName]; ok {
+			return tableName
+		}
+	}
+	return ""
+}
+
+func opHelp(_ *ishell.Context) {
+	help := `y - stage the current change
+n - do not stage the current change
+q - quit
+a - add all changes in this table
+d - do not stage any further changes in this table
+s - show summary of unstaged changes and start over
+? - show this help`
+	help = color.CyanString(help)
+	cli.Println(help)
+}
+
+type patchState struct {
+	sqlCtx                *sql.Context
+	queryist              cli.Queryist
+	tables                []string
+	changeCounts          map[string]*changeCount
+	currentTable          string
+	currentTableLastRowId int
+	currentRowId          int
+	currentRow            sql.Row
+	err                   error
+}
+
+func (ps *patchState) opYes(c *ishell.Context) {
+	qry := fmt.Sprintf("UPDATE dolt_workspace_%s SET staged = TRUE WHERE id = %d", ps.currentTable, ps.currentRowId)
+	_, iter, _, err := ps.queryist.Query(ps.sqlCtx, qry)
+	if err != nil {
+		ps.err = err
+		c.Stop()
+		return
+	}
+
+	for {
+		_, err = iter.Next(ps.sqlCtx)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			ps.err = err
+			c.Stop()
+			return
+		}
+	}
+	err = iter.Close(ps.sqlCtx)
+	if err != nil {
+		ps.err = err
+		c.Stop()
+		return
+	}
+
+	ps.currentRowId++
+	if ps.currentRowId <= ps.currentTableLastRowId {
+		ps.setCurrentRowState(c)
+	} else {
+		ps.nextTable(c)
+	}
+}
+
+func (ps *patchState) opNo(c *ishell.Context) {
+	ps.currentRowId++
+	if ps.currentRowId <= ps.currentTableLastRowId {
+		ps.setCurrentRowState(c)
+	} else {
+		ps.nextTable(c)
+	}
+}
+
+func (ps *patchState) opSkipTable(c *ishell.Context) {
+	ps.nextTable(c)
+}
+
+func (ps *patchState) opAddAllOfTable(c *ishell.Context) {
+	// grab the row id.
+	id, err := coerceToInt(ps.currentRow[0])
+	if err != nil {
+		ps.err = err
+		c.Stop()
+		return
+	}
+
+	qry := fmt.Sprintf("UPDATE dolt_workspace_%s SET staged = TRUE WHERE id >= %d", ps.currentTable, id)
+	_, iter, _, err := ps.queryist.Query(ps.sqlCtx, qry)
+	if err != nil {
+		ps.err = err
+		c.Stop()
+		return
+	}
+
+	for {
+		_, err = iter.Next(ps.sqlCtx)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			ps.err = err
+			c.Stop()
+			return
+		}
+	}
+	err = iter.Close(ps.sqlCtx)
+	if err != nil {
+		ps.err = err
+		c.Stop()
+		return
+	}
+	ps.nextTable(c)
+}
+
+func (ps *patchState) reset(c *ishell.Context) {
+	changeCounts, err := queryForUnstagedChanges(ps.sqlCtx, ps.queryist, ps.tables)
+	if err != nil {
+		ps.err = err
+		if c != nil {
+			c.Stop()
+		}
+	}
+	ps.changeCounts = changeCounts
+
+	printTableSummary(ps.tables, changeCounts)
+	ps.nextTable(c)
+
+	ps.currentRow, err = queryForSingleChange(ps.sqlCtx, ps.queryist, ps.currentTable, ps.currentRowId)
+	if err != nil {
+		ps.err = err
+		if c != nil {
+			c.Stop()
+		}
+	}
+}
+
+func (ps *patchState) setCurrentRowState(c *ishell.Context) {
+	if ps.currentRowId > ps.currentTableLastRowId {
+		ps.nextTable(c)
+		return
+	}
+
+	newRow, err := queryForSingleChange(ps.sqlCtx, ps.queryist, ps.currentTable, ps.currentRowId)
+	if err != nil {
+		ps.err = err
+		if c != nil {
+			c.Stop()
+		}
+		return
+	}
+
+	ps.currentRow = newRow
+
+	printSingleChange(ps.sqlCtx, ps.queryist, ps.currentTable, ps.currentRow)
+}
+
+// Move the state to work on the next table. Print the header for the table. If there are no more tables false is returned.
+func (ps *patchState) nextTable(c *ishell.Context) {
+	tblIdx := -1
+	if ps.currentTable != "" {
+		// The currentTable is always in the tables slice. No need to check if == -1.
+		tblIdx = slices.Index(ps.tables, ps.currentTable)
+	}
+	tblIdx++
+
+	if tblIdx < len(ps.tables) {
+		nextTbl := ps.tables[tblIdx]
+		if _, ok := ps.changeCounts[nextTbl]; !ok {
+			// It's possible that a table has no more change if the user restarted the workflow.
+			ps.nextTable(c)
+			return
+		}
+		ps.currentTable = nextTbl
+		changes := ps.changeCounts[ps.currentTable]
+		ps.currentRowId = changes.firstId
+		ps.currentTableLastRowId = changes.lastId
+
+		cli.Printf("=============\n")
+		cli.Printf("Table: %s\n", ps.currentTable)
+
+		ps.setCurrentRowState(c)
+	} else {
+		c.Stop()
+	}
+}
+
+func newState(sqlCtx *sql.Context, queryist cli.Queryist, tables []string) (*patchState, error) {
+	ans := &patchState{sqlCtx: sqlCtx, queryist: queryist, tables: tables}
+	ans.reset(nil)
+
+	if ans.err != nil {
+		return nil, ans.err
+	}
+	return ans, nil
+}
+
+func printSingleChange(sqlCtx *sql.Context, queryist cli.Queryist, tableName string, row sql.Row) {
+	cli.Printf("I'm a change: %v\n", row)
+}
+
+// printTableSummary prints a summary of the changes in the tables. tables slice should be the table names in alphabetical order.
+// counts map should be the change counts for each table.
+func printTableSummary(tables []string, counts map[string]*changeCount) {
+	header := "Table                              Added / Modified / Removed\n"
+	header += "=====                              =====   ========   =======\n"
+	header = color.YellowString(header)
+
+	cli.Printf(header)
+
+	totalChgCount := 0
+
+	// Print each entry with aligned columns
+	for _, tbl := range tables {
+		c := counts[tbl]
+		addStr := color.GreenString("%-7d", c.add)
+		modifiesStr := color.YellowString("%-10d", c.modifies)
+		removesStr := color.RedString("%d", c.removes)
+
+		cli.Printf("%-34s %s %s %s\n", tbl, addStr, modifiesStr, removesStr)
+
+		totalChgCount += c.total()
+	}
+
+	if totalChgCount > 25 {
+		warning := `You have %d changes in total. Consider updating dolt_workspace_* tables directly as
+'add --patch' requires you to individually evaluate each changed row.
+`
+		warning = color.YellowString(warning)
+		cli.Printf(warning, totalChgCount)
+	}
 }

--- a/go/cmd/dolt/commands/add.go
+++ b/go/cmd/dolt/commands/add.go
@@ -24,6 +24,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/ishell"
+	"github.com/fatih/color"
+	"golang.org/x/exp/slices"
+
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
@@ -32,10 +37,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/untyped/tabular"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 	"github.com/dolthub/dolt/go/libraries/utils/iohelp"
-	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/ishell"
-	"github.com/fatih/color"
-	"golang.org/x/exp/slices"
 )
 
 var addDocs = cli.CommandDocumentationContent{

--- a/go/cmd/dolt/commands/add.go
+++ b/go/cmd/dolt/commands/add.go
@@ -551,13 +551,24 @@ func (ps *patchState) nextTable(c *ishell.Context) {
 		ps.currentTableLastRowId = changes.lastId
 		ps.currentTableSchema = changes.schema
 
-		cli.Printf("=============\n")
-		cli.Printf("Table: %s\n", ps.currentTable)
+		cli.Printf("%s", tableHeader(ps.currentTable))
 
 		ps.setCurrentRowState(c)
 	} else {
 		c.Stop()
 	}
+}
+
+func tableHeader(tableName string) string {
+	width := 7 + len(tableName)
+	eqs := strings.Repeat("=", width)
+	eqs = color.YellowString(eqs)
+
+	label := color.YellowString("Table:")
+	textLine := fmt.Sprintf("%s %s", label, tableName)
+	textLine = color.YellowString(textLine)
+
+	return eqs + "\n" + textLine + "\n" + eqs + "\n"
 }
 
 func newState(sqlCtx *sql.Context, queryist cli.Queryist, tables []string) (*patchState, error) {

--- a/go/cmd/dolt/commands/stashcmds/stash.go
+++ b/go/cmd/dolt/commands/stashcmds/stash.go
@@ -101,7 +101,8 @@ func (cmd StashCmd) Exec(ctx context.Context, commandStr string, args []string, 
 
 	err := stashChanges(ctx, dEnv, apr)
 	if err != nil {
-		return commands.HandleStageError(err)
+		commands.PrintStagingError(err)
+		return 1
 	}
 	return 0
 }

--- a/go/cmd/dolt/commands/utils.go
+++ b/go/cmd/dolt/commands/utils.go
@@ -849,3 +849,38 @@ func stringSliceToInterfaceSlice(ss []string) []interface{} {
 func buildPlaceholdersString(count int) string {
 	return strings.Join(make([]string, count), "?, ") + "?"
 }
+
+func PrintStagingError(err error) {
+	vErr := func() errhand.VerboseError {
+		switch {
+		case doltdb.IsRootValUnreachable(err):
+			rt := doltdb.GetUnreachableRootType(err)
+			bdr := errhand.BuildDError("Unable to read %s.", rt.String())
+			bdr.AddCause(doltdb.GetUnreachableRootCause(err))
+			return bdr.Build()
+
+		case actions.IsTblNotExist(err):
+			tbls := actions.GetTablesForError(err)
+			bdr := errhand.BuildDError("Some of the specified tables or docs were not found")
+			bdr.AddDetails("Unknown tables or docs: %v", tbls)
+
+			return bdr.Build()
+
+		case actions.IsTblInConflict(err) || actions.IsTblViolatesConstraints(err):
+			tbls := actions.GetTablesForError(err)
+			bdr := errhand.BuildDError("error: not all tables merged")
+
+			for _, tbl := range tbls {
+				bdr.AddDetails("  %s", tbl)
+			}
+
+			return bdr.Build()
+		case doltdb.AsDoltIgnoreInConflict(err) != nil:
+			return errhand.VerboseErrorFromError(err)
+		default:
+			return errhand.BuildDError("Unknown error").AddCause(err).Build()
+		}
+	}()
+
+	cli.PrintErrln(vErr.Verbose())
+}

--- a/go/libraries/doltcore/sqle/dtables/workspace.go
+++ b/go/libraries/doltcore/sqle/dtables/workspace.go
@@ -453,9 +453,9 @@ func workspaceSchema(fromSch, toSch schema.Schema) (schema.Schema, error) {
 	cols := make([]schema.Column, 0, 3+toSch.GetAllCols().Size()+fromSch.GetAllCols().Size())
 
 	cols = append(cols,
-		schema.NewColumn("id", 0, types.UintKind, true),
-		schema.NewColumn("staged", 0, types.BoolKind, false),
-		schema.NewColumn("diff_type", 0, types.StringKind, false),
+		schema.NewColumn("id", 0, types.UintKind, true, schema.NotNullConstraint{}),
+		schema.NewColumn("staged", 0, types.BoolKind, false, schema.NotNullConstraint{}),
+		schema.NewColumn("diff_type", 0, types.StringKind, false, schema.NotNullConstraint{}),
 	)
 
 	transformer := func(sch schema.Schema, namer func(string) string) error {
@@ -485,7 +485,11 @@ func workspaceSchema(fromSch, toSch schema.Schema) (schema.Schema, error) {
 		return nil, err
 	}
 
-	return schema.UnkeyedSchemaFromCols(schema.NewColCollection(cols...)), nil
+	newSchema, err := schema.NewSchema(schema.NewColCollection(cols...), nil, schema.Collation_Default, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return newSchema, nil
 }
 
 func (wt *WorkspaceTable) Collation() sql.CollationID { return sql.Collation_Default }


### PR DESCRIPTION
CLI update to enable the "--patch" option for dolt add.

This option is only supported in a CLI context (sql shell included) because the `dolt_add` stored procedure doesn't allow for a user interactive workflow.

Currently this change lacks tests. I'll work on that after I ship the blog post.

Fixes: https://github.com/dolthub/dolt/issues/2465