### PR TITLE
[statspro] Restart drop db

### DIFF
--- a/go/libraries/doltcore/sqle/statspro/configure.go
+++ b/go/libraries/doltcore/sqle/statspro/configure.go
@@ -147,8 +147,6 @@ func (p *Provider) Load(ctx *sql.Context, fs filesys.Filesys, db dsess.SqlDataba
 		}
 	}
 
-	p.mu.Lock()
-	defer p.mu.Unlock()
 	p.setStatDb(strings.ToLower(db.Name()), statsDb)
 	return
 }

--- a/go/libraries/doltcore/sqle/statspro/initdbhook.go
+++ b/go/libraries/doltcore/sqle/statspro/initdbhook.go
@@ -37,15 +37,15 @@ func NewStatsInitDatabaseHook(
 		denv *env.DoltEnv,
 		db dsess.SqlDatabase,
 	) error {
-		statsDb, err := statsProv.sf.Init(ctx, db, statsProv.pro, denv.FS, env.GetCurrentUserHomeDir)
-		if err != nil {
-			ctx.GetLogger().Debugf("statistics load error: %s", err.Error())
-			return nil
+		dbName := strings.ToLower(db.Name())
+		if _, ok := statsProv.getStatDb(dbName); !ok {
+			statsDb, err := statsProv.sf.Init(ctx, db, statsProv.pro, denv.FS, env.GetCurrentUserHomeDir)
+			if err != nil {
+				ctx.GetLogger().Debugf("statistics load error: %s", err.Error())
+				return nil
+			}
+			statsProv.setStatDb(dbName, statsDb)
 		}
-		statsProv.mu.Lock()
-		statsProv.setStatDb(strings.ToLower(db.Name()), statsDb)
-		statsProv.mu.Unlock()
-
 		ctx.GetLogger().Debugf("statistics refresh: initialize %s", name)
 		return statsProv.InitAutoRefresh(ctxFactory, name, bThreads)
 	}

--- a/go/libraries/doltcore/sqle/statspro/stats_provider.go
+++ b/go/libraries/doltcore/sqle/statspro/stats_provider.go
@@ -186,6 +186,8 @@ func (p *Provider) GetTableDoltStats(ctx *sql.Context, branch, db, table string)
 }
 
 func (p *Provider) setStatDb(name string, db Database) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.statDbs[name] = db
 }
 

--- a/integration-tests/bats/stats.bats
+++ b/integration-tests/bats/stats.bats
@@ -130,6 +130,25 @@ teardown() {
     [ "$status" -eq 1 ]
 }
 
+@test "stats: restart in shell doesn't drop db, issue#8345" {
+    cd repo2
+
+    dolt sql -q "insert into xy values (0,0), (1,1), (2,2), (3,3), (4,4)"
+    dolt sql -q "insert into ab values (0,0), (1,1), (2,2), (3,3), (4,4)"
+    dolt sql -q "ANALYZE table xy, ab"
+    dolt sql <<EOF
+select count(*) from dolt_statistics;
+set @@GLOBAL.dolt_stats_auto_refresh_interval = 2;
+call dolt_stats_restart();
+select count(*) from dolt_statistics;
+select sleep(3);
+select count(*) from dolt_statistics;
+EOF
+
+    run stat .dolt/repo2
+    [ "$status" -eq 1 ]
+}
+
 @test "stats: stats roundtrip restart" {
     cd repo2
 

--- a/integration-tests/bats/stats.bats
+++ b/integration-tests/bats/stats.bats
@@ -136,7 +136,7 @@ teardown() {
     dolt sql -q "insert into xy values (0,0), (1,1), (2,2), (3,3), (4,4)"
     dolt sql -q "insert into ab values (0,0), (1,1), (2,2), (3,3), (4,4)"
     dolt sql -q "ANALYZE table xy, ab"
-    dolt sql <<EOF
+    run dolt sql -r csv <<EOF
 select count(*) from dolt_statistics;
 set @@GLOBAL.dolt_stats_auto_refresh_interval = 2;
 call dolt_stats_restart();
@@ -144,9 +144,10 @@ select count(*) from dolt_statistics;
 select sleep(3);
 select count(*) from dolt_statistics;
 EOF
-
-    run stat .dolt/repo2
-    [ "$status" -eq 1 ]
+    [ "${lines[1]}" = "4" ]
+    [ "${lines[5]}" = "4" ]
+    [ "${lines[9]}" = "4" ]
+    [ "$status" -eq 0 ]
 }
 
 @test "stats: stats roundtrip restart" {
@@ -402,6 +403,7 @@ SQL
     dolt sql <<SQL
 use repo2;
 insert into xy values (0,0);
+analyze table xy;
 SQL
 
     sleep 1


### PR DESCRIPTION
Quick fix for at least one of the problems in https://github.com/dolthub/dolt/issues/8345.

The specific example fails because the restart function refreshes the stats database instance, but does not reload the stats contained within. So the contents in memory did not track the contents on disk. This was only noticeable when restart and read were called within the same shell context.