### PR TITLE
Compare strings with `strings.EqualFold`

### DIFF
--- a/go/cmd/dolt/cli/command.go
+++ b/go/cmd/dolt/cli/command.go
@@ -192,8 +192,7 @@ func (hc SubCommandHandler) Exec(ctx context.Context, commandStr string, args []
 	}
 
 	for _, cmd := range hc.Subcommands {
-		lwrName := strings.ToLower(cmd.Name())
-		if lwrName == subCommandStr {
+		if strings.EqualFold(cmd.Name(), subCommandStr) {
 			return hc.handleCommand(ctx, commandStr+" "+subCommandStr, cmd, args[1:], dEnv, cliCtx)
 		}
 	}

--- a/go/cmd/dolt/commands/assist.go
+++ b/go/cmd/dolt/commands/assist.go
@@ -159,7 +159,7 @@ func agreeToTerms(scanner *bufio.Scanner) bool {
 
 	scanner.Scan()
 	input := strings.TrimSpace(scanner.Text())
-	if strings.ToLower(input) == "y" {
+	if strings.EqualFold(input, "y") {
 		cli.Println(wordWrap("# ", "You can disable this check in the future by setting the DOLT_ASSIST_AGREE "+
 			"environment variable."))
 		return true

--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -212,9 +212,9 @@ func NewSqlEngine(
 		return nil, err
 	}
 
-	if dbg, ok := os.LookupEnv(dconfig.EnvSqlDebugLog); ok && strings.ToLower(dbg) == "true" {
+	if dbg, ok := os.LookupEnv(dconfig.EnvSqlDebugLog); ok && strings.EqualFold(dbg, "true") {
 		engine.Analyzer.Debug = true
-		if verbose, ok := os.LookupEnv(dconfig.EnvSqlDebugLogVerbose); ok && strings.ToLower(verbose) == "true" {
+		if verbose, ok := os.LookupEnv(dconfig.EnvSqlDebugLogVerbose); ok && strings.EqualFold(verbose, "true") {
 			engine.Analyzer.Verbose = true
 		}
 	}

--- a/go/cmd/dolt/commands/show.go
+++ b/go/cmd/dolt/commands/show.go
@@ -141,8 +141,7 @@ func (cmd ShowCmd) Exec(ctx context.Context, commandStr string, args []string, d
 		isDEnvRequired = true
 	}
 	for _, specRef := range opts.specRefs {
-		upperCaseSpecRef := strings.ToUpper(specRef)
-		if !hashRegex.MatchString(specRef) && upperCaseSpecRef != "HEAD" {
+		if !hashRegex.MatchString(specRef) && !strings.EqualFold(specRef, "HEAD") {
 			isDEnvRequired = true
 		}
 	}
@@ -225,10 +224,9 @@ func getValueFromRefSpec(ctx context.Context, dEnv *env.DoltEnv, specRef string)
 	var refHash hash.Hash
 	var err error
 	roots, err := dEnv.Roots(ctx)
-	upperCaseSpecRef := strings.ToUpper(specRef)
-	if upperCaseSpecRef == doltdb.Working {
+	if strings.EqualFold(specRef, doltdb.Working) {
 		refHash, err = roots.Working.HashOf()
-	} else if upperCaseSpecRef == doltdb.Staged {
+	} else if strings.EqualFold(specRef, doltdb.Staged) {
 		refHash, err = roots.Staged.HashOf()
 	} else if hashRegex.MatchString(specRef) {
 		refHash, err = parseHashString(specRef)

--- a/go/cmd/dolt/commands/utils.go
+++ b/go/cmd/dolt/commands/utils.go
@@ -398,7 +398,7 @@ func getStrBoolColAsBool(col interface{}) (bool, error) {
 	case bool:
 		return col.(bool), nil
 	case string:
-		return strings.ToLower(col.(string)) == "true" || strings.ToLower(col.(string)) == "1", nil
+		return strings.EqualFold(col.(string), "true") || strings.EqualFold(col.(string), "1"), nil
 	default:
 		return false, fmt.Errorf("unexpected type %T, was expecting bool or string", v)
 	}

--- a/go/libraries/doltcore/doltdb/commit_spec.go
+++ b/go/libraries/doltcore/doltdb/commit_spec.go
@@ -102,7 +102,7 @@ func NewCommitSpec(cSpecStr string) (*CommitSpec, error) {
 		return nil, err
 	}
 
-	if strings.ToLower(name) == head {
+	if strings.EqualFold(name, head) {
 		return &CommitSpec{head, headCommitSpec, as}, nil
 	}
 	if hashRegex.MatchString(name) {

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -1184,7 +1184,7 @@ func (ddb *DoltDB) GetRefByNameInsensitive(ctx context.Context, refName string) 
 		return nil, err
 	}
 	for _, branchRef := range branchRefs {
-		if strings.ToLower(branchRef.GetPath()) == strings.ToLower(refName) {
+		if strings.EqualFold(branchRef.GetPath(), refName) {
 			return branchRef, nil
 		}
 	}
@@ -1194,7 +1194,7 @@ func (ddb *DoltDB) GetRefByNameInsensitive(ctx context.Context, refName string) 
 		return nil, err
 	}
 	for _, headRef := range headRefs {
-		if strings.ToLower(headRef.GetPath()) == strings.ToLower(refName) {
+		if strings.EqualFold(headRef.GetPath(), refName) {
 			return headRef, nil
 		}
 	}
@@ -1204,7 +1204,7 @@ func (ddb *DoltDB) GetRefByNameInsensitive(ctx context.Context, refName string) 
 		return nil, err
 	}
 	for _, tagRef := range tagRefs {
-		if strings.ToLower(tagRef.GetPath()) == strings.ToLower(refName) {
+		if strings.EqualFold(tagRef.GetPath(), refName) {
 			return tagRef, nil
 		}
 	}

--- a/go/libraries/doltcore/doltdb/durable/index.go
+++ b/go/libraries/doltcore/doltdb/durable/index.go
@@ -278,7 +278,7 @@ func (i prollyIndex) AddColumnToRows(ctx context.Context, newCol string, newSche
 	colIdx, iCol := 0, 0
 	newSchema.GetNonPKCols().Iter(func(tag uint64, col schema.Column) (stop bool, err error) {
 		last = false
-		if strings.ToLower(col.Name) == strings.ToLower(newCol) {
+		if strings.EqualFold(col.Name, newCol) {
 			last = true
 			colIdx = iCol
 		}

--- a/go/libraries/doltcore/doltdb/foreign_key_coll.go
+++ b/go/libraries/doltcore/doltdb/foreign_key_coll.go
@@ -278,7 +278,7 @@ func CombinedHash(fks []ForeignKey) (hash.Hash, error) {
 
 // IsSelfReferential returns whether the table declaring the foreign key is also referenced by the foreign key.
 func (fk ForeignKey) IsSelfReferential() bool {
-	return strings.ToLower(fk.TableName) == strings.ToLower(fk.ReferencedTableName)
+	return strings.EqualFold(fk.TableName, fk.ReferencedTableName)
 }
 
 // IsResolved returns whether the foreign key has been resolved.
@@ -402,7 +402,7 @@ func (fkc *ForeignKeyCollection) GetByNameCaseInsensitive(foreignKeyName string)
 		return ForeignKey{}, false
 	}
 	for _, fk := range fkc.foreignKeys {
-		if strings.ToLower(fk.Name) == strings.ToLower(foreignKeyName) {
+		if strings.EqualFold(fk.Name, foreignKeyName) {
 			return fk, true
 		}
 	}
@@ -589,12 +589,11 @@ func (fkc *ForeignKeyCollection) Iter(cb func(fk ForeignKey) (stop bool, err err
 // all foreign keys in which this table is the referenced table. If the table contains a self-referential foreign key,
 // it will be present in both declaresFk and referencedByFk. Each array is sorted by name ascending.
 func (fkc *ForeignKeyCollection) KeysForTable(tableName TableName) (declaredFk, referencedByFk []ForeignKey) {
-	lowercaseTblName := tableName.ToLower()
 	for _, foreignKey := range fkc.foreignKeys {
-		if strings.ToLower(foreignKey.TableName) == lowercaseTblName.Name {
+		if strings.EqualFold(foreignKey.TableName, tableName.Name) {
 			declaredFk = append(declaredFk, foreignKey)
 		}
-		if strings.ToLower(foreignKey.ReferencedTableName) == lowercaseTblName.Name {
+		if strings.EqualFold(foreignKey.ReferencedTableName, tableName.Name) {
 			referencedByFk = append(referencedByFk, foreignKey)
 		}
 	}
@@ -627,7 +626,7 @@ func (fkc *ForeignKeyCollection) RemoveKeys(fks ...ForeignKey) {
 func (fkc *ForeignKeyCollection) RemoveKeyByName(foreignKeyName string) bool {
 	var key string
 	for k, fk := range fkc.foreignKeys {
-		if strings.ToLower(fk.Name) == strings.ToLower(foreignKeyName) {
+		if strings.EqualFold(fk.Name, foreignKeyName) {
 			key = k
 			break
 		}

--- a/go/libraries/doltcore/doltdb/ignore.go
+++ b/go/libraries/doltcore/doltdb/ignore.go
@@ -234,7 +234,7 @@ func resolveConflictingPatterns(trueMatches, falseMatches []string, tableName Ta
 func (ip *IgnorePatterns) IsTableNameIgnored(tableName TableName) (IgnoreResult, error) {
 	// The dolt_rebase table is automatically ignored by Dolt – it shouldn't ever
 	// be checked in to a Dolt database.
-	if strings.ToLower(tableName.Name) == strings.ToLower(RebaseTableName) {
+	if strings.EqualFold(tableName.Name, RebaseTableName) {
 		return Ignore, nil
 	}
 

--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -380,7 +380,7 @@ func GenerateTagsForNewColumns(
 		for i := range newColNames {
 			// Only re-use tags if the noms kind didn't change
 			// TODO: revisit this when new storage format is further along
-			if strings.ToLower(newColNames[i]) == strings.ToLower(col.Name) &&
+			if strings.EqualFold(newColNames[i], col.Name) &&
 				newColKinds[i] == col.TypeInfo.NomsKind() {
 				newTags[i] = &col.Tag
 				break
@@ -520,10 +520,9 @@ func (root *rootValue) ResolveTableName(ctx context.Context, tName TableName) (s
 	}
 
 	found := false
-	lwrName := strings.ToLower(tName.Name)
 	resolvedName := tName.Name
 	err = tmIterAll(ctx, tableMap, func(name string, addr hash.Hash) {
-		if found == false && lwrName == strings.ToLower(name) {
+		if found == false && strings.EqualFold(tName.Name, name) {
 			resolvedName = name
 			found = true
 		}

--- a/go/libraries/doltcore/doltdb/system_table.go
+++ b/go/libraries/doltcore/doltdb/system_table.go
@@ -80,7 +80,7 @@ func IsReadOnlySystemTable(name string) bool {
 // IsNonAlterableSystemTable returns whether the table name given is a system table that cannot be dropped or altered
 // by the user.
 func IsNonAlterableSystemTable(name string) bool {
-	return (IsReadOnlySystemTable(name) && !IsFullTextTable(name)) || strings.ToLower(name) == SchemasTableName
+	return (IsReadOnlySystemTable(name) && !IsFullTextTable(name)) || strings.EqualFold(name, SchemasTableName)
 }
 
 // GetNonSystemTableNames gets non-system table names

--- a/go/libraries/doltcore/ref/ref.go
+++ b/go/libraries/doltcore/ref/ref.go
@@ -122,7 +122,7 @@ func EqualsCaseInsensitive(dr, other DoltRef) bool {
 		return false
 	}
 
-	return dr.GetType() == other.GetType() && strings.ToLower(dr.GetPath()) == strings.ToLower(other.GetPath())
+	return dr.GetType() == other.GetType() && strings.EqualFold(dr.GetPath(), other.GetPath())
 }
 
 // EqualsStr compares a DoltRef to a reference string to see if they are referring to the same thing

--- a/go/libraries/doltcore/schema/check_coll.go
+++ b/go/libraries/doltcore/schema/check_coll.go
@@ -65,7 +65,7 @@ type checkCollection struct {
 
 func (c *checkCollection) AddCheck(name, expression string, enforce bool) (Check, error) {
 	for _, chk := range c.checks {
-		if strings.ToLower(name) == strings.ToLower(chk.name) {
+		if strings.EqualFold(name, chk.name) {
 			// Engine is supposed to enforce this for us, but just in case
 			return nil, fmt.Errorf("name %s in use", name)
 		}
@@ -83,7 +83,7 @@ func (c *checkCollection) AddCheck(name, expression string, enforce bool) (Check
 
 func (c *checkCollection) DropCheck(name string) error {
 	for i, chk := range c.checks {
-		if strings.ToLower(name) == strings.ToLower(chk.name) {
+		if strings.EqualFold(name, chk.name) {
 			c.checks = append(c.checks[:i], c.checks[i+1:]...)
 			return nil
 		}

--- a/go/libraries/doltcore/schema/col_coll.go
+++ b/go/libraries/doltcore/schema/col_coll.go
@@ -171,7 +171,7 @@ func (cc *ColCollection) IndexOf(colName string) int {
 		defer func() {
 			i++
 		}()
-		if strings.ToLower(col.Name) == strings.ToLower(colName) {
+		if strings.EqualFold(col.Name, colName) {
 			idx = i
 			stop = true
 		}

--- a/go/libraries/doltcore/schema/index_coll.go
+++ b/go/libraries/doltcore/schema/index_coll.go
@@ -302,7 +302,7 @@ func (ixc *indexCollectionImpl) GetByName(indexName string) Index {
 
 func (ixc *indexCollectionImpl) GetByNameCaseInsensitive(indexName string) (Index, bool) {
 	for name, ix := range ixc.indexes {
-		if strings.ToLower(name) == strings.ToLower(indexName) {
+		if strings.EqualFold(name, indexName) {
 			return ix, true
 		}
 	}

--- a/go/libraries/doltcore/schema/schema.go
+++ b/go/libraries/doltcore/schema/schema.go
@@ -253,7 +253,7 @@ func GetSharedCols(schema Schema, cmpNames []string, cmpKinds []types.NomsKind) 
 
 	for i, colName := range cmpNames {
 		if col, ok := existingCols[colName]; ok {
-			if col.Kind == cmpKinds[i] && strings.ToLower(col.Name) == strings.ToLower(cmpNames[i]) {
+			if col.Kind == cmpKinds[i] && strings.EqualFold(col.Name, cmpNames[i]) {
 				shared = append(shared, col)
 			}
 		}

--- a/go/libraries/doltcore/schema/schema_impl.go
+++ b/go/libraries/doltcore/schema/schema_impl.go
@@ -623,7 +623,7 @@ func (si *schemaImpl) SetCollation(collation Collation) {
 func (si *schemaImpl) indexOf(colName string) int {
 	i, idx := 0, -1
 	si.allCols.Iter(func(tag uint64, col Column) (stop bool, err error) {
-		if strings.ToLower(col.Name) == strings.ToLower(colName) {
+		if strings.EqualFold(col.Name, colName) {
 			idx = i
 			return true, nil
 		}

--- a/go/libraries/doltcore/sqle/alterschema.go
+++ b/go/libraries/doltcore/sqle/alterschema.go
@@ -135,7 +135,7 @@ func validateNewColumn(
 	err = cols.Iter(func(currColTag uint64, currCol schema.Column) (stop bool, err error) {
 		if currColTag == tag {
 			return false, schema.ErrTagPrevUsed(tag, newColName, tblName, tblName)
-		} else if strings.ToLower(currCol.Name) == strings.ToLower(newColName) {
+		} else if strings.EqualFold(currCol.Name, newColName) {
 			return true, fmt.Errorf("A column with the name %s already exists in table %s.", newColName, tblName)
 		}
 

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_applier.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_applier.go
@@ -409,7 +409,7 @@ func (a *binlogReplicaApplier) processBinlogEvent(ctx *sql.Context, engine *gms.
 
 		ctx.SetCurrentDatabase(query.Database)
 		executeQueryWithEngine(ctx, engine, query.SQL)
-		createCommit = strings.ToLower(query.SQL) != "begin"
+		createCommit = !strings.EqualFold(query.SQL, "begin")
 
 	case event.IsRotate():
 		// When a binary log file exceeds the configured size limit, a ROTATE_EVENT is written at the end of the file,

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -1579,7 +1579,7 @@ func getViewDefinitionFromSchemaFragmentsOfView(ctx *sql.Context, tbl *WritableD
 			}
 		}
 
-		if strings.ToLower(fragment.name) == strings.ToLower(viewName) {
+		if strings.EqualFold(fragment.name, viewName) {
 			found = true
 			viewDef = views[i]
 		}
@@ -1727,7 +1727,7 @@ func (db Database) GetEvent(ctx *sql.Context, name string) (sql.EventDefinition,
 	}
 
 	for _, frag := range frags {
-		if strings.ToLower(frag.name) == strings.ToLower(name) {
+		if strings.EqualFold(frag.name, name) {
 			event, err := db.createEventDefinitionFromFragment(ctx, frag)
 			if err != nil {
 				return sql.EventDefinition{}, false, err

--- a/go/libraries/doltcore/sqle/dfunctions/hashof.go
+++ b/go/libraries/doltcore/sqle/dfunctions/hashof.go
@@ -80,7 +80,7 @@ func (t *HashOf) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	}
 
 	var cm *doltdb.Commit
-	if strings.ToUpper(name) == "HEAD" {
+	if strings.EqualFold(name, "HEAD") {
 		sess := dsess.DSessFromSess(ctx.Session)
 
 		// TODO: this should resolve the current DB through the analyzer so it can use the revision qualified name here

--- a/go/libraries/doltcore/sqle/dolt_diff_table_function.go
+++ b/go/libraries/doltcore/sqle/dolt_diff_table_function.go
@@ -195,13 +195,13 @@ func (dtf *DiffTableFunction) RowIter(ctx *sql.Context, _ sql.Row) (sql.RowIter,
 func findMatchingDelta(deltas []diff.TableDelta, tableName string) diff.TableDelta {
 	tableName = strings.ToLower(tableName)
 	for _, d := range deltas {
-		if strings.ToLower(d.ToName.Name) == tableName {
+		if strings.EqualFold(d.ToName.Name, tableName) {
 			return d
 		}
 	}
 
 	for _, d := range deltas {
-		if strings.ToLower(d.FromName.Name) == tableName {
+		if strings.EqualFold(d.FromName.Name, tableName) {
 			return d
 		}
 	}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_branch.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_branch.go
@@ -241,7 +241,7 @@ func deleteBranches(ctx *sql.Context, dbData env.DbData, apr *argparser.ArgParse
 
 		// If we deleted the branch this client is connected to, change the current branch to the default
 		// TODO: this would be nice to do for every other session (or maybe invalidate sessions on this branch)
-		if strings.ToLower(currBranch) == strings.ToLower(branchName) {
+		if strings.EqualFold(currBranch, branchName) {
 			ctx.SetCurrentDatabase(currBase)
 		}
 

--- a/go/libraries/doltcore/sqle/dropped_databases.go
+++ b/go/libraries/doltcore/sqle/dropped_databases.go
@@ -224,7 +224,7 @@ func (dd *droppedDatabaseManager) validateUndropDatabase(ctx *sql.Context, name 
 func hasCaseInsensitivePath(fs filesys.Filesys, target string) bool {
 	found := false
 	fs.Iter(filepath.Dir(target), false, func(path string, size int64, isDir bool) (stop bool) {
-		if strings.ToLower(filepath.Base(path)) == strings.ToLower(filepath.Base(target)) {
+		if strings.EqualFold(filepath.Base(path), filepath.Base(target)) {
 			found = true
 		}
 		return found
@@ -238,9 +238,8 @@ func hasCaseInsensitivePath(fs filesys.Filesys, target string) bool {
 func hasCaseInsensitiveMatch(candidates []string, target string) (bool, string) {
 	found := false
 	exactCaseName := ""
-	lowercaseName := strings.ToLower(target)
 	for _, s := range candidates {
-		if lowercaseName == strings.ToLower(s) {
+		if strings.EqualFold(target, s) {
 			exactCaseName = s
 			found = true
 			break

--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -524,7 +524,7 @@ func (d *DoltSession) validateDoltCommit(ctx *sql.Context, dirtyBranchState *bra
 	currDbBaseName, rev := SplitRevisionDbName(currDb)
 	dirtyDbBaseName := dirtyBranchState.dbState.dbName
 
-	if strings.ToLower(currDbBaseName) != strings.ToLower(dirtyDbBaseName) {
+	if !strings.EqualFold(currDbBaseName, dirtyDbBaseName) {
 		return fmt.Errorf("no changes to dolt_commit on database %s", currDbBaseName)
 	}
 
@@ -540,7 +540,7 @@ func (d *DoltSession) validateDoltCommit(ctx *sql.Context, dirtyBranchState *bra
 		rev = dbState.checkedOutRevSpec
 	}
 
-	if strings.ToLower(rev) != strings.ToLower(dirtyBranchState.head) {
+	if !strings.EqualFold(rev, dirtyBranchState.head) {
 		return fmt.Errorf("no changes to dolt_commit on branch %s", rev)
 	}
 
@@ -1175,7 +1175,7 @@ func (d *DoltSession) SetSessionVariable(ctx *sql.Context, key string, value int
 		return sql.ErrSystemVariableReadOnly.New(key)
 	}
 
-	if strings.ToLower(key) == "foreign_key_checks" {
+	if strings.EqualFold(key, "foreign_key_checks") {
 		return d.setForeignKeyChecksSessionVar(ctx, key, value)
 	}
 
@@ -1372,7 +1372,7 @@ func (d *DoltSession) AddTemporaryTable(ctx *sql.Context, db string, tbl sql.Tab
 func (d *DoltSession) DropTemporaryTable(ctx *sql.Context, db, name string) {
 	tables := d.tempTables[strings.ToLower(db)]
 	for i, tbl := range d.tempTables[strings.ToLower(db)] {
-		if strings.ToLower(tbl.Name()) == strings.ToLower(name) {
+		if strings.EqualFold(tbl.Name(), name) {
 			tables = append(tables[:i], tables[i+1:]...)
 			break
 		}
@@ -1382,7 +1382,7 @@ func (d *DoltSession) DropTemporaryTable(ctx *sql.Context, db, name string) {
 
 func (d *DoltSession) GetTemporaryTable(ctx *sql.Context, db, name string) (sql.Table, bool) {
 	for _, tbl := range d.tempTables[strings.ToLower(db)] {
-		if strings.ToLower(tbl.Name()) == strings.ToLower(name) {
+		if strings.EqualFold(tbl.Name(), name) {
 			return tbl, true
 		}
 	}

--- a/go/libraries/doltcore/sqle/dsess/transactions.go
+++ b/go/libraries/doltcore/sqle/dsess/transactions.go
@@ -755,7 +755,7 @@ func (tx *DoltTransaction) CreateSavepoint(name string, roots map[string]doltdb.
 // findSavepoint returns the index of the savepoint with the name given, or -1 if it doesn't exist
 func (tx *DoltTransaction) findSavepoint(name string) int {
 	for i, s := range tx.savepoints {
-		if strings.ToLower(s.name) == strings.ToLower(name) {
+		if strings.EqualFold(s.name, name) {
 			return i
 		}
 	}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
@@ -191,7 +191,7 @@ func (d *DoltHarness) resetScripts() []setup.SetupScript {
 			tableName := tableNameRow[0].(string)
 
 			// special handling for auto_increment_tbl, which is expected to start with particular values
-			if strings.ToLower(tableName) == "auto_increment_tbl" {
+			if strings.EqualFold(tableName, "auto_increment_tbl") {
 				resetCmds = append(resetCmds, setup.AutoincrementData...)
 				continue
 			}

--- a/go/libraries/doltcore/sqle/reflog_table_function.go
+++ b/go/libraries/doltcore/sqle/reflog_table_function.go
@@ -138,7 +138,7 @@ func (rltf *ReflogTableFunction) RowIter(ctx *sql.Context, row sql.Row) (sql.Row
 				}
 
 				// Skip refs that don't match the target we're looking for
-				if strings.ToLower(id) != strings.ToLower(refName) {
+				if !strings.EqualFold(id, refName) {
 					return nil
 				}
 			}

--- a/go/libraries/doltcore/sqle/schema_table.go
+++ b/go/libraries/doltcore/sqle/schema_table.go
@@ -391,7 +391,7 @@ func fragFromSchemasTable(ctx *sql.Context, tbl *WritableDoltTable, fragType str
 		}
 
 		// These columns are case insensitive, make sure to do a case-insensitive comparison
-		if strings.ToLower(sqlRow[typeIdx].(string)) == fragType && strings.ToLower(sqlRow[nameIdx].(string)) == name {
+		if strings.EqualFold(sqlRow[typeIdx].(string), fragType) && strings.EqualFold(sqlRow[nameIdx].(string), name) {
 			return sqlRow, true, nil
 		}
 	}

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -2042,7 +2042,7 @@ func modifyIndexesForTableRewrite(ctx *sql.Context, oldSch schema.Schema, oldCol
 		var colNames []string
 		prefixLengths := index.PrefixLengths()
 		for i, colName := range index.ColumnNames() {
-			if strings.ToLower(oldColumn.Name) == strings.ToLower(colName) {
+			if strings.EqualFold(oldColumn.Name, colName) {
 				colNames = append(colNames, newColumn.Name)
 				if len(prefixLengths) > 0 {
 					if !sqltypes.IsText(newColumn.Type) {
@@ -2731,7 +2731,7 @@ func (t *AlterableDoltTable) AddForeignKey(ctx *sql.Context, sqlFk sql.ForeignKe
 	if sqlFk.Name != "" && !doltdb.IsValidIdentifier(sqlFk.Name) {
 		return fmt.Errorf("invalid foreign key name `%s`", sqlFk.Name)
 	}
-	if strings.ToLower(sqlFk.Database) != strings.ToLower(sqlFk.ParentDatabase) || strings.ToLower(sqlFk.Database) != strings.ToLower(t.db.Name()) {
+	if !strings.EqualFold(sqlFk.Database, sqlFk.ParentDatabase) || !strings.EqualFold(sqlFk.Database, t.db.Name()) {
 		return fmt.Errorf("only foreign keys on the same database are currently supported")
 	}
 
@@ -3265,7 +3265,7 @@ func (t *AlterableDoltTable) constraintNameExists(ctx *sql.Context, name string)
 	}
 
 	for _, key := range keys {
-		if strings.ToLower(key.Name) == strings.ToLower(name) {
+		if strings.EqualFold(key.Name, name) {
 			return true, nil
 		}
 	}
@@ -3276,7 +3276,7 @@ func (t *AlterableDoltTable) constraintNameExists(ctx *sql.Context, name string)
 	}
 
 	for _, check := range checks {
-		if strings.ToLower(check.Name) == strings.ToLower(name) {
+		if strings.EqualFold(check.Name, name) {
 			return true, nil
 		}
 	}

--- a/go/store/datas/pull/puller.go
+++ b/go/store/datas/pull/puller.go
@@ -112,7 +112,7 @@ func NewPuller(
 	rd := GetChunkFetcher(ctx, srcChunkStore)
 
 	var pushLogger *log.Logger
-	if dbg, ok := os.LookupEnv(dconfig.EnvPushLog); ok && strings.ToLower(dbg) == "true" {
+	if dbg, ok := os.LookupEnv(dconfig.EnvPushLog); ok && strings.EqualFold(dbg, "true") {
 		logFilePath := filepath.Join(tempDir, "push.log")
 		f, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.ModePerm)
 


### PR DESCRIPTION
![2024-09-13_23-00](https://github.com/user-attachments/assets/ca79add6-3237-4cde-9c91-ceef647908c7)

This PR fixes a Staticcheck warning (https://staticcheck.dev/docs/checks/#SA6005). Comparing two strings to the same case with `strings.ToLower` and `strings.ToUpper` is more computational expensive than `strings.EqualFold`.


Sample benchmark:

```go
func BenchmarkToUpperSingle(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if strings.ToUpper("foobar") != "FOOBAR" {
			b.Fail()
		}
	}
}

func BenchmarkToUpperDouble(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if strings.ToUpper("foobar") != strings.ToUpper("FOOBAR") {
			b.Fail()
		}
	}
}

func BenchmarkToLowerSingle(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if strings.ToLower("FOOBAR") != "foobar" {
			b.Fail()
		}
	}
}

func BenchmarkToLowerDouble(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if strings.ToLower("FOOBAR") != strings.ToLower("foobar") {
			b.Fail()
		}
	}
}

func BenchmarkEqualFold(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if !strings.EqualFold("FOOBAR", "foobar") {
			b.Fail()
		}
	}
}
```

Result:

```
goos: linux
goarch: amd64
pkg: github.com/dolthub/dolt/go
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkToUpperSingle-16    	 9589896	       113.8 ns/op	       8 B/op	       1 allocs/op
BenchmarkToUpperDouble-16    	 7097330	       155.9 ns/op	       8 B/op	       1 allocs/op
BenchmarkToLowerSingle-16    	12346219	       106.5 ns/op	       8 B/op	       1 allocs/op
BenchmarkToLowerDouble-16    	 8084006	       143.6 ns/op	       8 B/op	       1 allocs/op
BenchmarkEqualFold-16        	63650023	        18.76 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/dolthub/dolt/go	6.456s
```