### PR TITLE
Argparser edge case for value options which are a prefix of flags

### DIFF
--- a/go/libraries/utils/argparser/parser.go
+++ b/go/libraries/utils/argparser/parser.go
@@ -205,9 +205,10 @@ func (ap *ArgParser) matchModalOptions(arg string) (matches []*Option, rest stri
 
 		// stop if we see a value option
 		for _, vo := range ap.sortedValueOptions() {
-			lv := len(vo)
-			isValOpt := len(rest) >= lv && rest[:lv] == vo
-			if isValOpt {
+			if rest == vo {
+				return matches, rest
+			}
+			if strings.HasPrefix(rest, vo+"=") {
 				return matches, rest
 			}
 		}

--- a/integration-tests/bats/diff.bats
+++ b/integration-tests/bats/diff.bats
@@ -1811,3 +1811,15 @@ SQL
     [ $status -eq 1 ]
     [[ $output =~ "invalid Arguments" ]] || false
 }
+
+@test "diff: diff --reverse" {
+  run dolt diff -R
+  [ $status -eq 0 ]
+  [[ $output =~ "diff --dolt a/test b/test" ]] || false
+  [[ $output =~ "deleted table" ]] || false
+
+  run dolt diff --reverse
+  [ $status -eq 0 ]
+  [[ $output =~ "diff --dolt a/test b/test" ]] || false
+  [[ $output =~ "deleted table" ]] || false
+}


### PR DESCRIPTION
This bug was preventing the `diff --reverse` flag from working properly. Not sure if this impacts other options, but it's pretty edgy.