### PR TITLE
More flexible `diff` printing when schema changes type of column

### DIFF
--- a/go/libraries/doltcore/diff/diffsplitter.go
+++ b/go/libraries/doltcore/diff/diffsplitter.go
@@ -49,7 +49,7 @@ type RowDiff struct {
 }
 
 // NewDiffSplitter returns a splitter that knows how to split unified diff query rows.
-// |querySch| is the result schema from the dolt_dif(...) table function
+// |querySch| is the result schema from the dolt_diff(...) table function
 // it contains "from_..." and "to..." columns corresponding to the "from"
 // and "to" schemas used to generate the diff.
 // |targetSch| is the output schema used to print the diff and is computed

--- a/go/libraries/utils/argparser/parser.go
+++ b/go/libraries/utils/argparser/parser.go
@@ -205,9 +205,10 @@ func (ap *ArgParser) matchModalOptions(arg string) (matches []*Option, rest stri
 
 		// stop if we see a value option
 		for _, vo := range ap.sortedValueOptions() {
-			lv := len(vo)
-			isValOpt := len(rest) >= lv && rest[:lv] == vo
-			if isValOpt {
+			if rest == vo {
+				return matches, rest
+			}
+			if strings.HasPrefix(rest, vo+"=") {
 				return matches, rest
 			}
 		}

--- a/integration-tests/bats/diff.bats
+++ b/integration-tests/bats/diff.bats
@@ -1811,3 +1811,15 @@ SQL
     [ $status -eq 1 ]
     [[ $output =~ "invalid Arguments" ]] || false
 }
+
+@test "diff: diff --reverse" {
+  run dolt diff -R
+  [ $status -eq 0 ]
+  [[ $output =~ "diff --dolt a/test b/test" ]] || false
+  [[ $output =~ "deleted table" ]] || false
+
+  run dolt diff --reverse
+  [ $status -eq 0 ]
+  [[ $output =~ "diff --dolt a/test b/test" ]] || false
+  [[ $output =~ "deleted table" ]] || false
+}


### PR DESCRIPTION
This partially addresses an old bug described in the fixed issue. There are certainly more complete solutions, but this seems like the right amount of effort for something pretty edge casey.

Fixes: https://github.com/dolthub/dolt/issues/8133