### PR TITLE
Passing through schema name to fix index creation bug in Doltgres

### DIFF
--- a/go/cmd/dolt/commands/schcmds/import.go
+++ b/go/cmd/dolt/commands/schcmds/import.go
@@ -428,6 +428,7 @@ func CombineColCollections(ctx context.Context, root doltdb.RootValue, inferredC
 		return nil, verr
 	}
 
+	// NOTE: This code is only used in the import codepath for Dolt, so we don't use a schema to qualify the table name
 	newCols, err := doltdb.GenerateTagsForNewColColl(ctx, root, impOpts.tableName, newCols)
 	if err != nil {
 		return nil, errhand.BuildDError("failed to generate new schema").AddCause(err).Build()

--- a/go/libraries/doltcore/mvdata/data_mover.go
+++ b/go/libraries/doltcore/mvdata/data_mover.go
@@ -158,6 +158,7 @@ func InferSchema(ctx context.Context, root doltdb.RootValue, rd table.ReadCloser
 		}
 	}
 
+	// NOTE: This code is only used in the import codepath for Dolt, so we don't use a schema to qualify the table name
 	newCols, err = doltdb.GenerateTagsForNewColColl(ctx, root, tableName, newCols)
 	if err != nil {
 		return nil, errhand.BuildDError("failed to generate new schema").AddCause(err).Build()

--- a/go/libraries/doltcore/mvdata/engine_table_reader.go
+++ b/go/libraries/doltcore/mvdata/engine_table_reader.go
@@ -88,7 +88,9 @@ func NewSqlEngineReader(ctx context.Context, dEnv *env.DoltEnv, tableName string
 		return nil, err
 	}
 
-	doltSchema, err := sqlutil.ToDoltSchema(ctx, root, tableName, create.PrimaryKeySchema, nil, sql.Collation_Default)
+	// NOTE: We don't support setting a schema name to qualify the table name here, so this code will not work
+	//       correctly with Doltgres yet.
+	doltSchema, err := sqlutil.ToDoltSchema(ctx, root, doltdb.TableName{Name: tableName}, create.PrimaryKeySchema, nil, sql.Collation_Default)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +111,9 @@ func NewSqlEngineTableReaderWithEngine(sqlCtx *sql.Context, se *sqle.Engine, db 
 		return nil, err
 	}
 
-	doltSchema, err := sqlutil.ToDoltSchema(sqlCtx, root, tableName, sql.NewPrimaryKeySchema(sch), nil, sql.Collation_Default)
+	// NOTE: We don't support setting a schema name to qualify the table name here, so this code will not work
+	//       correctly with Doltgres yet.
+	doltSchema, err := sqlutil.ToDoltSchema(sqlCtx, root, doltdb.TableName{Name: tableName}, sql.NewPrimaryKeySchema(sch), nil, sql.Collation_Default)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -1181,7 +1181,7 @@ OuterLoop:
 }
 
 // createSqlTable is the private version of CreateTable. It doesn't enforce any table name checks.
-func (db Database) createSqlTable(ctx *sql.Context, tableName string, schemaName string, sch sql.PrimaryKeySchema, collation sql.CollationID, comment string) error {
+func (db Database) createSqlTable(ctx *sql.Context, table string, schemaName string, sch sql.PrimaryKeySchema, collation sql.CollationID, comment string) error {
 	ws, err := db.GetWorkingSet(ctx)
 	if err != nil {
 		return err
@@ -1196,10 +1196,11 @@ func (db Database) createSqlTable(ctx *sql.Context, tableName string, schemaName
 		db.schemaName = schemaName
 	}
 
-	if exists, err := root.HasTable(ctx, doltdb.TableName{Name: tableName, Schema: schemaName}); err != nil {
+	tableName := doltdb.TableName{Name: table, Schema: schemaName}
+	if exists, err := root.HasTable(ctx, tableName); err != nil {
 		return err
 	} else if exists {
-		return sql.ErrTableAlreadyExists.New(tableName)
+		return sql.ErrTableAlreadyExists.New(table)
 	}
 
 	headRoot, err := db.GetHeadRoot(ctx)
@@ -1215,7 +1216,7 @@ func (db Database) createSqlTable(ctx *sql.Context, tableName string, schemaName
 
 	// Prevent any tables that use Spatial Types as Primary Key from being created
 	if schema.IsUsingSpatialColAsKey(doltSch) {
-		return schema.ErrUsingSpatialKey.New(tableName)
+		return schema.ErrUsingSpatialKey.New(tableName.Name)
 	}
 
 	// Prevent any tables that use BINARY, CHAR, VARBINARY, VARCHAR prefixes
@@ -1225,14 +1226,14 @@ func (db Database) createSqlTable(ctx *sql.Context, tableName string, schemaName
 		if err != nil {
 			return err
 		}
-		ait.AddNewTable(tableName)
+		ait.AddNewTable(tableName.Name)
 	}
 
-	return db.createDoltTable(ctx, tableName, schemaName, root, doltSch)
+	return db.createDoltTable(ctx, tableName.Name, tableName.Schema, root, doltSch)
 }
 
 // createIndexedSqlTable is the private version of createSqlTable. It doesn't enforce any table name checks.
-func (db Database) createIndexedSqlTable(ctx *sql.Context, tableName string, schemaName string, sch sql.PrimaryKeySchema, idxDef sql.IndexDef, collation sql.CollationID) error {
+func (db Database) createIndexedSqlTable(ctx *sql.Context, table string, schemaName string, sch sql.PrimaryKeySchema, idxDef sql.IndexDef, collation sql.CollationID) error {
 	ws, err := db.GetWorkingSet(ctx)
 	if err != nil {
 		return err
@@ -1247,10 +1248,11 @@ func (db Database) createIndexedSqlTable(ctx *sql.Context, tableName string, sch
 		db.schemaName = schemaName
 	}
 
-	if exists, err := root.HasTable(ctx, doltdb.TableName{Name: tableName, Schema: schemaName}); err != nil {
+	tableName := doltdb.TableName{Name: table, Schema: schemaName}
+	if exists, err := root.HasTable(ctx, tableName); err != nil {
 		return err
 	} else if exists {
-		return sql.ErrTableAlreadyExists.New(tableName)
+		return sql.ErrTableAlreadyExists.New(tableName.Name)
 	}
 
 	headRoot, err := db.GetHeadRoot(ctx)
@@ -1265,7 +1267,7 @@ func (db Database) createIndexedSqlTable(ctx *sql.Context, tableName string, sch
 
 	// Prevent any tables that use Spatial Types as Primary Key from being created
 	if schema.IsUsingSpatialColAsKey(doltSch) {
-		return schema.ErrUsingSpatialKey.New(tableName)
+		return schema.ErrUsingSpatialKey.New(tableName.Name)
 	}
 
 	// Prevent any tables that use BINARY, CHAR, VARBINARY, VARCHAR prefixes in Primary Key
@@ -1281,10 +1283,10 @@ func (db Database) createIndexedSqlTable(ctx *sql.Context, tableName string, sch
 		if err != nil {
 			return err
 		}
-		ait.AddNewTable(tableName)
+		ait.AddNewTable(tableName.Name)
 	}
 
-	return db.createDoltTable(ctx, tableName, schemaName, root, doltSch)
+	return db.createDoltTable(ctx, tableName.Name, tableName.Schema, root, doltSch)
 }
 
 // createDoltTable creates a table on the database using the given dolt schema while not enforcing table baseName checks.

--- a/go/libraries/doltcore/sqle/schema_override.go
+++ b/go/libraries/doltcore/sqle/schema_override.go
@@ -266,7 +266,7 @@ func newRowConverterForDoltTable(ctx *sql.Context, t *DoltTable) (func(ctx *sql.
 		return nil, fmt.Errorf("unable to get roots for database '%s'", t.db.Name())
 	}
 
-	doltSchema, err := sqlutil.ToDoltSchema(ctx, roots.Working, t.Name(), t.sqlSch, roots.Head, t.Collation())
+	doltSchema, err := sqlutil.ToDoltSchema(ctx, roots.Working, t.TableName(), t.sqlSch, roots.Head, t.Collation())
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/sqlutil/convert.go
+++ b/go/libraries/doltcore/sqle/sqlutil/convert.go
@@ -77,7 +77,7 @@ func FromDoltSchema(dbName, tableName string, sch schema.Schema) (sql.PrimaryKey
 func ToDoltSchema(
 	ctx context.Context,
 	root doltdb.RootValue,
-	tableName string,
+	tableName doltdb.TableName,
 	sqlSchema sql.PrimaryKeySchema,
 	headRoot doltdb.RootValue,
 	collation sql.CollationID,

--- a/go/libraries/doltcore/sqle/sqlutil/schema.go
+++ b/go/libraries/doltcore/sqle/sqlutil/schema.go
@@ -40,7 +40,9 @@ func ParseCreateTableStatement(ctx *sql.Context, root doltdb.RootValue, engine *
 		return "", nil, fmt.Errorf("expected create table, found %T", create)
 	}
 
-	sch, err := ToDoltSchema(ctx, root, create.Name(), create.PkSchema(), nil, create.Collation)
+	// NOTE: We don't support setting a schema name here since this code is only intended to be used from the Dolt
+	//       codebase, and will not work correctly from Doltgres.
+	sch, err := ToDoltSchema(ctx, root, doltdb.TableName{Name: create.Name()}, create.PkSchema(), nil, create.Collation)
 	if err != nil {
 		return "", nil, err
 	}

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -922,7 +922,7 @@ func emptyFulltextTable(
 	}
 
 	// TODO: this should be the head root, not working root
-	doltSchema, err := sqlutil.ToDoltSchema(ctx, workingRoot, doltTable.tableName, sql.NewPrimaryKeySchema(fulltextSch), workingRoot, parentTable.Collation())
+	doltSchema, err := sqlutil.ToDoltSchema(ctx, workingRoot, doltTable.TableName(), sql.NewPrimaryKeySchema(fulltextSch), workingRoot, parentTable.Collation())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1594,7 +1594,7 @@ func (t *AlterableDoltTable) AddColumn(ctx *sql.Context, column *sql.Column, ord
 	if err != nil {
 		return err
 	}
-	tags, err := doltdb.GenerateTagsForNewColumns(ctx, root, t.tableName, []string{column.Name}, []types.NomsKind{ti.NomsKind()}, nil)
+	tags, err := doltdb.GenerateTagsForNewColumns(ctx, root, t.TableName(), []string{column.Name}, []types.NomsKind{ti.NomsKind()}, nil)
 	if err != nil {
 		return err
 	}
@@ -2108,7 +2108,7 @@ func validateFullTextColumnChange(ctx *sql.Context, idx schema.Index, oldColumn 
 func (t *AlterableDoltTable) createSchemaForColumnChange(ctx context.Context, oldColumn, newColumn *sql.Column, oldSch schema.Schema, newSchema sql.PrimaryKeySchema, root, headRoot doltdb.RootValue) (schema.Schema, error) {
 	// Adding or dropping a column
 	if oldColumn == nil || newColumn == nil {
-		newSch, err := sqlutil.ToDoltSchema(ctx, root, t.Name(), newSchema, headRoot, sql.CollationID(oldSch.GetCollation()))
+		newSch, err := sqlutil.ToDoltSchema(ctx, root, t.TableName(), newSchema, headRoot, sql.CollationID(oldSch.GetCollation()))
 		if err != nil {
 			return nil, err
 		}
@@ -2116,7 +2116,7 @@ func (t *AlterableDoltTable) createSchemaForColumnChange(ctx context.Context, ol
 	}
 
 	// Modifying a column
-	newSch, err := sqlutil.ToDoltSchema(ctx, root, t.Name(), newSchema, headRoot, sql.CollationID(oldSch.GetCollation()))
+	newSch, err := sqlutil.ToDoltSchema(ctx, root, t.TableName(), newSchema, headRoot, sql.CollationID(oldSch.GetCollation()))
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/temp_table.go
+++ b/go/libraries/doltcore/sqle/temp_table.go
@@ -95,7 +95,9 @@ func NewTempTable(
 		colKinds[i] = ti.NomsKind()
 	}
 
-	tags, err := doltdb.GenerateTagsForNewColumns(ctx, ws.WorkingRoot(), name, colNames, colKinds, ws.WorkingRoot())
+	// NOTE: We don't support setting a schema name to qualify the table name here, so this code will not work
+	//       correctly with Doltgres yet.
+	tags, err := doltdb.GenerateTagsForNewColumns(ctx, ws.WorkingRoot(), doltdb.TableName{Name: name}, colNames, colKinds, ws.WorkingRoot())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Bug fix for schema name being lost when adding a unique index to a table through Doltgres.

Fixes: https://github.com/dolthub/doltgresql/issues/725