### PR TITLE
go: doltcore/remotestorage: reliable: Fix leaked goroutines when the context is canceled while reading the HTTP response.

### DIFF
--- a/go/libraries/doltcore/remotestorage/internal/reliable/http.go
+++ b/go/libraries/doltcore/remotestorage/internal/reliable/http.go
@@ -221,7 +221,7 @@ func StreamingRangeDownload(ctx context.Context, req StreamingRangeRequest) Stre
 	}()
 
 	return StreamingResponse{
-		Body:   r,
+		Body: r,
 		cancel: func() {
 			r.Close()
 			cancel()

--- a/go/libraries/doltcore/remotestorage/internal/reliable/http.go
+++ b/go/libraries/doltcore/remotestorage/internal/reliable/http.go
@@ -222,7 +222,10 @@ func StreamingRangeDownload(ctx context.Context, req StreamingRangeRequest) Stre
 
 	return StreamingResponse{
 		Body:   r,
-		cancel: cancel,
+		cancel: func() {
+			r.Close()
+			cancel()
+		},
 	}
 }
 


### PR DESCRIPTION
io.Copy into an io.PipeWriter will block until all the bytes have been delivered or the reader is closed. reliable/http StreamingResponse was constructed to only cancel the request context on Close(), not also clear the Reader. The Reader should also be closed to ensure all finalization can still happen if the Write to the PipeWriter is currently blocked when the context is canceled.