### PR TITLE
Improve Error Handling for Tags

### DIFF
--- a/go/libraries/doltcore/env/actions/branch.go
+++ b/go/libraries/doltcore/env/actions/branch.go
@@ -365,12 +365,13 @@ func createBranch(ctx context.Context, dbData env.DbData, newBranch, startingPoi
 var emptyHash = hash.Hash{}
 
 func IsBranch(ctx context.Context, ddb *doltdb.DoltDB, str string) (bool, error) {
-	return IsBranchOnDB(ctx, ddb, str)
-}
-
-func IsBranchOnDB(ctx context.Context, ddb *doltdb.DoltDB, str string) (bool, error) {
 	dref := ref.NewBranchRef(str)
 	return ddb.HasRef(ctx, dref)
+}
+
+func IsTag(ctx context.Context, ddb *doltdb.DoltDB, str string) (bool, error) {
+	tRef := ref.NewTagRef(str)
+	return ddb.HasRef(ctx, tRef)
 }
 
 func MaybeGetCommit(ctx context.Context, dEnv *env.DoltEnv, str string) (*doltdb.Commit, error) {

--- a/go/libraries/doltcore/env/actions/clone.go
+++ b/go/libraries/doltcore/env/actions/clone.go
@@ -172,7 +172,7 @@ func CloneRemote(ctx context.Context, srcDB *doltdb.DoltDB, remoteName, branch s
 	}
 	// prevent cloning tags (branches in detached head state)
 	for _, srcRef := range srcRefHashes {
-		if strings.EqualFold(srcRef.Ref.GetPath(), branch) {
+		if srcRef.Ref.GetType() == ref.TagRefType && strings.EqualFold(srcRef.Ref.GetPath(), branch) {
 			return doltdb.ErrOperationNotSupportedInDetachedHead
 		}
 	}

--- a/go/libraries/doltcore/env/actions/clone.go
+++ b/go/libraries/doltcore/env/actions/clone.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/dustin/go-humanize"
@@ -168,6 +169,12 @@ func CloneRemote(ctx context.Context, srcDB *doltdb.DoltDB, remoteName, branch s
 	srcRefHashes, branch, err := getSrcRefs(ctx, branch, srcDB, dEnv)
 	if err != nil {
 		return fmt.Errorf("%w; %s", ErrCloneFailed, err.Error())
+	}
+	// prevent cloning tags (branches in detached head state)
+	for _, srcRef := range srcRefHashes {
+		if strings.EqualFold(srcRef.Ref.GetPath(), branch) {
+			return doltdb.ErrOperationNotSupportedInDetachedHead
+		}
 	}
 	if remoteName == "" {
 		remoteName = "origin"

--- a/go/libraries/doltcore/env/actions/workspace.go
+++ b/go/libraries/doltcore/env/actions/workspace.go
@@ -36,7 +36,7 @@ func CreateWorkspace(ctx context.Context, dEnv *env.DoltEnv, name, startPoint st
 }
 
 func CreateWorkspaceOnDB(ctx context.Context, ddb *doltdb.DoltDB, name, startPoint string, headRef ref.DoltRef) error {
-	isBranch, err := IsBranchOnDB(ctx, ddb, name)
+	isBranch, err := IsBranch(ctx, ddb, name)
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_checkout.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_checkout.go
@@ -163,12 +163,6 @@ func doDoltCheckout(ctx *sql.Context, args []string) (statusCode int, successMes
 		return 0, generateSuccessMessage(branchName, ""), nil
 	}
 
-	if isTag, err := actions.IsTag(ctx, dbData.Ddb, branchName); err != nil {
-		return 1, "", err
-	} else if isTag {
-		return 1, "", fmt.Errorf("error: tag '%s' is not a branch", branchName)
-	}
-
 	roots, ok := dSess.GetRoots(ctx, currentDbName)
 	if !ok {
 		return 1, "", fmt.Errorf("Could not load database %s", currentDbName)

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_checkout.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_checkout.go
@@ -304,7 +304,7 @@ func checkoutRemoteBranch(ctx *sql.Context, dSess *dsess.DoltSession, dbName str
 			}
 		}
 
-		if doltdb.IsValidCommitHash(branchName)  {
+		if doltdb.IsValidCommitHash(branchName) {
 			// User tried to enter a detached head state, which we don't support.
 			// Inform and suggest that they check-out a new branch at this commit instead.
 			if apr.Contains(cli.MoveFlag) {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -4678,6 +4678,36 @@ var DoltTagTestScripts = []queries.ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "dolt-tag: checkout errors",
+		SetUpScript: []string{
+			"CREATE TABLE test(pk int primary key);",
+			"CALL DOLT_COMMIT('-Am','created table test');",
+			"CALL DOLT_TAG('v1');",
+			"INSERT INTO test VALUES (0),(1),(2);",
+			"CALL DOLT_COMMIT('-am','inserted rows into test');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "SELECT tag_name FROM dolt_tags",
+				Expected: []sql.Row{
+					{"v1"},
+				},
+			},
+			{
+				Query: "select * from test;",
+				Expected: []sql.Row{
+					{0},
+					{1},
+					{2},
+				},
+			},
+			{
+				Query:          "call dolt_checkout('v1');",
+				ExpectedErrStr: "error: could not find v1",
+			},
+		},
+	},
 }
 
 var DoltRemoteTestScripts = []queries.ScriptTest{

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -4704,7 +4704,7 @@ var DoltTagTestScripts = []queries.ScriptTest{
 			},
 			{
 				Query:          "call dolt_checkout('v1');",
-				ExpectedErrStr: "error: could not find v1",
+				ExpectedErrStr: "dolt does not support a detached head state. To create a branch at this tag, run: \n\tCALL DOLT_CHECKOUT('v1', '-b', <new_branch_name>)",
 			},
 		},
 	},

--- a/integration-tests/bats/commit_tags.bats
+++ b/integration-tests/bats/commit_tags.bats
@@ -75,8 +75,8 @@ teardown() {
 }
 
 @test "commit_tags: commit onto checked out tag" {
-    dolt tag v1 HEAD^
     skip "need to implement detached head first"
+    dolt tag v1 HEAD^
     dolt checkout v1
     run dolt sql -q "insert into test values (8),(9)"
     [ $status -eq 0 ]
@@ -95,7 +95,8 @@ teardown() {
 
 @test "commit_tags: use a tag as a ref for merge" {
     dolt tag v1 HEAD
-    dolt checkout -b other HEAD~
+    dolt branch other HEAD~
+    dolt checkout other
     dolt sql -q "insert into test values (8),(9)"
     dolt add -A && dolt commit -m 'made changes'
     run dolt merge v1 -m "merge v1"

--- a/integration-tests/bats/commit_tags.bats
+++ b/integration-tests/bats/commit_tags.bats
@@ -94,11 +94,8 @@ teardown() {
 }
 
 @test "commit_tags: use a tag as a ref for merge" {
-    if [ "$SQL_ENGINE" = "remote-engine" ]; then
-      skip "This test relies on dolt checkout, which has not been migrated yet."
-    fi
     dolt tag v1 HEAD
-    dolt checkout -b other HEAD^
+    dolt checkout -b other HEAD~
     dolt sql -q "insert into test values (8),(9)"
     dolt add -A && dolt commit -m 'made changes'
     run dolt merge v1 -m "merge v1"

--- a/integration-tests/bats/commit_tags.bats
+++ b/integration-tests/bats/commit_tags.bats
@@ -167,6 +167,28 @@ teardown() {
     [[ "$output" =~ "SAMO" ]] || false
 }
 
+@test "commit_tags: prevent cloning tags" {
+    # reset env
+    rm -rf .dolt
+    mkdir repo remote
+    cd repo
+
+    dolt init
+    dolt sql -q "create table test (pk int primary key);"
+    dolt sql -q "insert into test values (0),(1),(2);"
+    dolt add -A && dolt commit -m "table test"
+    dolt tag v1 HEAD
+
+    dolt remote add origin file://./../remote
+    dolt push origin main
+    dolt push origin v1
+
+    cd ..
+    run dolt clone --branch v1 file://./remote repo_clone
+    [ $status -eq 1 ]
+    [[ "$output" =~ "this operation is not supported while in a detached head state" ]] || false
+}
+
 @test "commit_tags: create a tag with semver string" {
     dolt tag v1.0.0 HEAD^
 

--- a/integration-tests/bats/commit_tags.bats
+++ b/integration-tests/bats/commit_tags.bats
@@ -94,6 +94,9 @@ teardown() {
 }
 
 @test "commit_tags: use a tag as a ref for merge" {
+    if [ "$SQL_ENGINE" = "remote-engine" ]; then
+      skip "This test relies on dolt checkout, which has not been migrated yet."
+    fi
     dolt tag v1 HEAD
     dolt checkout -b other HEAD^
     dolt sql -q "insert into test values (8),(9)"

--- a/integration-tests/bats/commit_tags.bats
+++ b/integration-tests/bats/commit_tags.bats
@@ -94,6 +94,9 @@ teardown() {
 }
 
 @test "commit_tags: use a tag as a ref for merge" {
+    if [ "$SQL_ENGINE" = "remote-engine" ]; then
+      skip "needs checkout which is unsupported for remote-engine"
+    fi
     dolt tag v1 HEAD
     dolt branch other HEAD~
     dolt checkout other


### PR DESCRIPTION
Changes: 
- Prevent cloning from a tag through `--branch` option
- Return detached head error for checking out branch through cli

Fixes: https://github.com/dolthub/dolt/issues/8377