### PR TITLE
[statsnoms] MCV encoding needs to be delimiter safe

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/stats_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/stats_queries.go
@@ -332,18 +332,30 @@ var DoltStatsIOTests = []queries.ScriptTest{
 		},
 	},
 	{
-		Name: "varbinary encoding bug",
+		Name: "comma encoding bug",
 		SetUpScript: []string{
 			`create table a (a varbinary (32) primary key)`,
 			"insert into a values ('hello, world')",
+			"analyze table a",
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
-				Query: `analyze table a`,
-			},
-			{
 				Query:    "select count(*) from dolt_statistics",
 				Expected: []sql.Row{{1}},
+			},
+		},
+	},
+	{
+		Name: "comma encoding mcv bug",
+		SetUpScript: []string{
+			`create table ab (a int primary key, b varbinary (32), t timestamp, index (b,t))`,
+			"insert into ab values (1, 'no thank you, world', '2024-03-12 01:18:53'), (2, 'hi, world', '2024-03-12 01:18:53'), (3, 'hello, world', '2024-03-12 01:18:53'), (4, 'hello, world', '2024-03-12 01:18:53'),(5, 'hello, world', '2024-03-12 01:18:53'), (6, 'hello, world', '2024-03-12 01:18:53')",
+			"analyze table ab",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "select count(*) from dolt_statistics",
+				Expected: []sql.Row{{2}},
 			},
 		},
 	},

--- a/go/libraries/doltcore/sqle/statsnoms/write.go
+++ b/go/libraries/doltcore/sqle/statsnoms/write.go
@@ -129,7 +129,11 @@ func putIndexRows(ctx context.Context, statsMap *prolly.MutableMap, dStats *stat
 		valueBuilder.PutInt64(8, int64(h.BoundCount()))
 		valueBuilder.PutDatetime(9, statspro.DoltBucketCreated(h))
 		for i, r := range h.Mcvs() {
-			valueBuilder.PutString(10+i, stats.StringifyKey(r, dStats.Statistic.Typs))
+			mcvRow, err := EncodeRow(ctx, statsMap.NodeStore(), r, dStats.Tb)
+			if err != nil {
+				return err
+			}
+			valueBuilder.PutString(10+i, string(mcvRow))
 		}
 		var mcvCntsRow sql.Row
 		for _, v := range h.McvCounts() {


### PR DESCRIPTION
The PR from earlier in the week encoded stats bucket bound rows with prolly formatting. I neglected to encode MCVs in the same way, which are also rows and are subject to the same bugs.