### PR TITLE
Check for `StringType` support before casting 

### DIFF
--- a/go/libraries/doltcore/schema/schema_impl.go
+++ b/go/libraries/doltcore/schema/schema_impl.go
@@ -524,9 +524,10 @@ func (si *schemaImpl) getKeyColumnsDescriptor(convertAddressColumns bool) val.Tu
 			}
 		}
 		tt = append(tt, t)
-		if queryType == query.Type_CHAR || queryType == query.Type_VARCHAR || queryType == query.Type_TEXT {
+		stringType, isStringType := sqlType.(sql.StringType)
+		if isStringType && (queryType == query.Type_CHAR || queryType == query.Type_VARCHAR || queryType == query.Type_TEXT) {
 			useCollations = true
-			collations = append(collations, sqlType.(sql.StringType).Collation())
+			collations = append(collations, stringType.Collation())
 		} else {
 			collations = append(collations, sql.Collation_Unspecified)
 		}


### PR DESCRIPTION
Check for `StringType` support before casting, now that Doltgres extended types can support query types without implementing `StringType`.