### PR TITLE
Minor changes to support Doltgres `TEXT` columns

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -689,12 +689,15 @@ func ConfigureServices(
 	controller.Register(RunClusterController)
 
 	RunSQLServer := &svcs.AnonService{
-		RunF: func(context.Context) {
+		InitF: func(ctx context.Context) error {
 			sqlserver.SetRunningServer(mySQLServer)
-			defer sqlserver.UnsetRunningServer()
+			return nil
+		},
+		RunF: func(context.Context) {
 			mySQLServer.Start()
 		},
 		StopF: func() error {
+			sqlserver.UnsetRunningServer()
 			sqlServerClosed = true
 			return mySQLServer.Close()
 		},

--- a/go/go.mod
+++ b/go/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/creasty/defaults v1.6.0
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-mysql-server v0.18.2-0.20241002232427-c25ce0e8480e
+	github.com/dolthub/go-mysql-server v0.18.2-0.20241008231402-7443a099ffa8
 	github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63
 	github.com/dolthub/swiss v0.1.0
 	github.com/goccy/go-json v0.10.2

--- a/go/go.sum
+++ b/go/go.sum
@@ -185,6 +185,8 @@ github.com/dolthub/go-icu-regex v0.0.0-20240916130659-0118adc6b662 h1:aC17hZD6iw
 github.com/dolthub/go-icu-regex v0.0.0-20240916130659-0118adc6b662/go.mod h1:KPUcpx070QOfJK1gNe0zx4pA5sicIK1GMikIGLKC168=
 github.com/dolthub/go-mysql-server v0.18.2-0.20241002232427-c25ce0e8480e h1:L5WKxYlGSg+OtiJUakFfEbUoca8YKTBk1Ni008EPaHI=
 github.com/dolthub/go-mysql-server v0.18.2-0.20241002232427-c25ce0e8480e/go.mod h1:kXkvkPV9LdB2oCk1wC6mX+GpOayqwlmWJMjPnrGRgAk=
+github.com/dolthub/go-mysql-server v0.18.2-0.20241008231402-7443a099ffa8 h1:dfTpuTbQIKGluu0Fqq+eywFW2FwtqQvxq7uSGH57Loc=
+github.com/dolthub/go-mysql-server v0.18.2-0.20241008231402-7443a099ffa8/go.mod h1:lGbU2bK+QNnlETdUjOOaE+UnlEUu31VaQOFKAFGyZN4=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20240701202509-2b217167d718 h1:lT7hE5k+0nkBdj/1UOSFwjWpNxf+LCApbRHgnCA17XE=

--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -1006,6 +1006,16 @@ func (di *doltIndex) PrefixLengths() []uint16 {
 	return di.prefixLengths
 }
 
+// SetPrefixLengths implements sql.Index
+func (di *doltIndex) SetPrefixLengths(prefixLengths []uint16) {
+	di.prefixLengths = prefixLengths
+}
+
+// SetPrefixLengths implements sql.Index
+func (p *CommitIndex) SetPrefixLengths(prefixLengths []uint16) {
+	p.prefixLengths = prefixLengths
+}
+
 // IndexType implements sql.Index
 func (di *doltIndex) IndexType() string {
 	return "BTREE"


### PR DESCRIPTION
Minor changes to support Doltgres' use of `TEXT` columns in secondary indexes and unique constraints. 
* ensures `GetRunningServer()` is available when `controller.WaitForStart()` completes (this triggers after all `init` functions have run.
* updates `sql.Index` implementations so that prefix lengths can be set.
* adds a note explaining the issue with trying to pass addresses to `SerializedCompare()` without first de-reff'ing them.

Depends on: https://github.com/dolthub/go-mysql-server/pull/2687