### PR TITLE
dolt gc --full: Implement a flag for GC which will collect everything, including the old gen.

### DIFF
--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -294,6 +294,7 @@ func CreateLogArgParser(isTableFunction bool) *argparser.ArgParser {
 func CreateGCArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParserWithMaxArgs("gc", 0)
 	ap.SupportsFlag(ShallowFlag, "s", "perform a fast, but incomplete garbage collection pass")
+	ap.SupportsFlag(FullFlag, "f", "perform a full garbage collection, including the old generation")
 	return ap
 }
 

--- a/go/cmd/dolt/cli/flags.go
+++ b/go/cmd/dolt/cli/flags.go
@@ -37,6 +37,7 @@ const (
 	DryRunFlag           = "dry-run"
 	EmptyParam           = "empty"
 	ForceFlag            = "force"
+	FullFlag             = "full"
 	GraphFlag            = "graph"
 	HardResetParam       = "hard"
 	HostFlag             = "host"

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -1623,6 +1623,12 @@ func (ddb *DoltDB) Rebase(ctx context.Context) error {
 	return datas.ChunkStoreFromDatabase(ddb.db).Rebase(ctx)
 }
 
+type GCMode int
+const (
+	GCModeDefault GCMode = iota
+	GCModeFull
+)
+
 // GC performs garbage collection on this ddb.
 //
 // If |safepointF| is non-nil, it will be called at some point after the GC begins
@@ -1633,7 +1639,7 @@ func (ddb *DoltDB) Rebase(ctx context.Context) error {
 // until no possibly-stale ChunkStore state is retained in memory, or failing
 // certain in-progress operations which cannot be finalized in a timely manner,
 // etc.
-func (ddb *DoltDB) GC(ctx context.Context, safepointF func() error) error {
+func (ddb *DoltDB) GC(ctx context.Context, mode GCMode, safepointF func() error) error {
 	collector, ok := ddb.db.Database.(datas.GarbageCollector)
 	if !ok {
 		return fmt.Errorf("this database does not support garbage collection")

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -1623,13 +1623,6 @@ func (ddb *DoltDB) Rebase(ctx context.Context) error {
 	return datas.ChunkStoreFromDatabase(ddb.db).Rebase(ctx)
 }
 
-type GCMode int
-
-const (
-	GCModeDefault GCMode = iota
-	GCModeFull
-)
-
 // GC performs garbage collection on this ddb.
 //
 // If |safepointF| is non-nil, it will be called at some point after the GC begins
@@ -1640,7 +1633,7 @@ const (
 // until no possibly-stale ChunkStore state is retained in memory, or failing
 // certain in-progress operations which cannot be finalized in a timely manner,
 // etc.
-func (ddb *DoltDB) GC(ctx context.Context, mode GCMode, safepointF func() error) error {
+func (ddb *DoltDB) GC(ctx context.Context, mode types.GCMode, safepointF func() error) error {
 	collector, ok := ddb.db.Database.(datas.GarbageCollector)
 	if !ok {
 		return fmt.Errorf("this database does not support garbage collection")
@@ -1684,7 +1677,7 @@ func (ddb *DoltDB) GC(ctx context.Context, mode GCMode, safepointF func() error)
 		return err
 	}
 
-	return collector.GC(ctx, oldGen, newGen, safepointF)
+	return collector.GC(ctx, mode, oldGen, newGen, safepointF)
 }
 
 func (ddb *DoltDB) ShallowGC(ctx context.Context) error {

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -1624,6 +1624,7 @@ func (ddb *DoltDB) Rebase(ctx context.Context) error {
 }
 
 type GCMode int
+
 const (
 	GCModeDefault GCMode = iota
 	GCModeFull

--- a/go/libraries/doltcore/doltdb/gc_test.go
+++ b/go/libraries/doltcore/doltdb/gc_test.go
@@ -139,7 +139,7 @@ func testGarbageCollection(t *testing.T, test gcTest) {
 		}
 	}
 
-	err := dEnv.DoltDB.GC(ctx, doltdb.GCModeDefault, nil)
+	err := dEnv.DoltDB.GC(ctx, types.GCModeDefault, nil)
 	require.NoError(t, err)
 	test.postGCFunc(ctx, t, dEnv.DoltDB, res)
 
@@ -208,7 +208,7 @@ func testGarbageCollectionHasCacheDataCorruptionBugFix(t *testing.T) {
 	_, err = ns.Write(ctx, c1.Node())
 	require.NoError(t, err)
 
-	err = ddb.GC(ctx, doltdb.GCModeDefault, nil)
+	err = ddb.GC(ctx, types.GCModeDefault, nil)
 	require.NoError(t, err)
 
 	c2 := newIntMap(t, ctx, ns, 2, 2)

--- a/go/libraries/doltcore/doltdb/gc_test.go
+++ b/go/libraries/doltcore/doltdb/gc_test.go
@@ -139,7 +139,7 @@ func testGarbageCollection(t *testing.T, test gcTest) {
 		}
 	}
 
-	err := dEnv.DoltDB.GC(ctx, nil)
+	err := dEnv.DoltDB.GC(ctx, doltdb.GCModeDefault, nil)
 	require.NoError(t, err)
 	test.postGCFunc(ctx, t, dEnv.DoltDB, res)
 
@@ -208,7 +208,7 @@ func testGarbageCollectionHasCacheDataCorruptionBugFix(t *testing.T) {
 	_, err = ns.Write(ctx, c1.Node())
 	require.NoError(t, err)
 
-	err = ddb.GC(ctx, nil)
+	err = ddb.GC(ctx, doltdb.GCModeDefault, nil)
 	require.NoError(t, err)
 
 	c2 := newIntMap(t, ctx, ns, 2, 2)

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_gc.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_gc.go
@@ -73,7 +73,7 @@ func doDoltGC(ctx *sql.Context, args []string) (int, error) {
 	}
 
 	if apr.NArg() != 0 {
-		return cmdFailure, fmt.Errorf("cannot supply both --shallow and --full to dolt_gc: %w", InvalidArgErr)
+		return cmdFailure, InvalidArgErr
 	}
 
 	dSess := dsess.DSessFromSess(ctx.Session)
@@ -83,7 +83,7 @@ func doDoltGC(ctx *sql.Context, args []string) (int, error) {
 	}
 
 	if apr.Contains(cli.ShallowFlag) && apr.Contains(cli.FullFlag) {
-		return cmdFailure, InvalidArgErr
+		return cmdFailure, fmt.Errorf("cannot supply both --shallow and --full to dolt_gc: %w", InvalidArgErr)
 	}
 
 	if apr.Contains(cli.ShallowFlag) {

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_gc.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_gc.go
@@ -26,8 +26,8 @@ import (
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/dconfig"
-	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
+	"github.com/dolthub/dolt/go/store/types"
 )
 
 const (
@@ -111,9 +111,9 @@ func doDoltGC(ctx *sql.Context, args []string) (int, error) {
 			origepoch = epoch.(int)
 		}
 
-		var mode doltdb.GCMode = doltdb.GCModeDefault
+		var mode types.GCMode = types.GCModeDefault
 		if apr.Contains(cli.FullFlag) {
-			mode = doltdb.GCModeFull
+			mode = types.GCModeFull
 		}
 
 		// TODO: If we got a callback at the beginning and an

--- a/go/store/chunks/chunk_store.go
+++ b/go/store/chunks/chunk_store.go
@@ -152,6 +152,32 @@ type LoggingChunkStore interface {
 
 var ErrAddChunkMustBlock = errors.New("chunk keeper: add chunk must block")
 
+type HasManyF func(ctx context.Context, hashes hash.HashSet) (absent hash.HashSet, err error)
+
+// A GCFinalizer is returned from MarkAndSweepChunks after the keep hashes channel is closed.
+//
+// A GCFinalizer is a handle to one or more table files which has been
+// constructed as part of the GC process. It can be used to add the table files
+// to the existing store, as we do in the case of a default-mode collection
+// into the old gen, and it can be used to replace all existing table files in
+// the store with the new table files, as we do in the collection into the new
+// gen.
+//
+// In addition, adding the table files to an existing store exposes a HasMany
+// implementation which inspects only the table files that were added, not all
+// the table files in the resulting store. This is an important part of the
+// full gc protocol, which works as follows:
+//
+// * Collect everything reachable from old gen refs into a new table file in the old gen.
+// * Add the new table file to the old gen.
+// * Collect everything reachable from new gen refs into the new gen, skipping stuff that is in the new old gen table file.
+// * Swap to the new gen table file.
+// * Swap to the old gen table file.
+type GCFinalizer interface {
+	AddChunksToStore(ctx context.Context) (HasManyF, error)
+	SwapChunksInStore(ctx context.Context) error
+}
+
 // ChunkStoreGarbageCollector is a ChunkStore that supports garbage collection.
 type ChunkStoreGarbageCollector interface {
 	ChunkStore
@@ -185,7 +211,7 @@ type ChunkStoreGarbageCollector interface {
 	// This behavior is a little different for ValueStore.GC()'s
 	// interactions with generational stores. See ValueStore and
 	// NomsBlockStore/GenerationalNBS for details.
-	MarkAndSweepChunks(ctx context.Context, hashes <-chan []hash.Hash, dest ChunkStore) error
+	MarkAndSweepChunks(ctx context.Context, hashes <-chan []hash.Hash, dest ChunkStore) (GCFinalizer, error)
 
 	// Count returns the number of chunks in the store.
 	Count() (uint32, error)

--- a/go/store/chunks/chunk_store.go
+++ b/go/store/chunks/chunk_store.go
@@ -152,7 +152,9 @@ type LoggingChunkStore interface {
 
 var ErrAddChunkMustBlock = errors.New("chunk keeper: add chunk must block")
 
-type HasManyF func(ctx context.Context, hashes hash.HashSet) (absent hash.HashSet, err error)
+// The function type for ChunkStore.HasMany. Used as a return value in the
+// GCFinalizer interface.
+type HasManyFunc func(ctx context.Context, hashes hash.HashSet) (absent hash.HashSet, err error)
 
 // A GCFinalizer is returned from MarkAndSweepChunks after the keep hashes channel is closed.
 //
@@ -174,7 +176,7 @@ type HasManyF func(ctx context.Context, hashes hash.HashSet) (absent hash.HashSe
 // * Swap to the new gen table file.
 // * Swap to the old gen table file.
 type GCFinalizer interface {
-	AddChunksToStore(ctx context.Context) (HasManyF, error)
+	AddChunksToStore(ctx context.Context) (HasManyFunc, error)
 	SwapChunksInStore(ctx context.Context) error
 }
 

--- a/go/store/chunks/memory_store.go
+++ b/go/store/chunks/memory_store.go
@@ -343,7 +343,24 @@ func (ms *MemoryStoreView) EndGC() {
 	ms.transitionToNoGC()
 }
 
-func (ms *MemoryStoreView) MarkAndSweepChunks(ctx context.Context, hashes <-chan []hash.Hash, dest ChunkStore) error {
+type msvGcFinalizer struct {
+	ms      *MemoryStoreView
+	keepers map[hash.Hash]Chunk
+}
+
+func (mgcf msvGcFinalizer) AddChunksToStore(ctx context.Context) (HasManyF, error) {
+	panic("unsupported")
+}
+
+func (mgcf msvGcFinalizer) SwapChunksInStore(ctx context.Context) error {
+	mgcf.ms.mu.Lock()
+	defer mgcf.ms.mu.Unlock()
+	mgcf.ms.storage = &MemoryStorage{rootHash: mgcf.ms.rootHash, data: mgcf.keepers}
+	mgcf.ms.pending = map[hash.Hash]Chunk{}
+	return nil
+}
+
+func (ms *MemoryStoreView) MarkAndSweepChunks(ctx context.Context, hashes <-chan []hash.Hash, dest ChunkStore) (GCFinalizer, error) {
 	if dest != ms {
 		panic("unsupported")
 	}
@@ -366,20 +383,16 @@ LOOP:
 			for _, h := range hs {
 				c, err := ms.Get(ctx, h)
 				if err != nil {
-					return err
+					return nil, err
 				}
 				keepers[h] = c
 			}
 		case <-ctx.Done():
-			return ctx.Err()
+			return nil, ctx.Err()
 		}
 	}
 
-	ms.mu.Lock()
-	defer ms.mu.Unlock()
-	ms.storage = &MemoryStorage{rootHash: ms.rootHash, data: keepers}
-	ms.pending = map[hash.Hash]Chunk{}
-	return nil
+	return msvGcFinalizer{ms, keepers}, nil
 }
 
 func (ms *MemoryStoreView) Count() (uint32, error) {

--- a/go/store/chunks/memory_store.go
+++ b/go/store/chunks/memory_store.go
@@ -348,7 +348,7 @@ type msvGcFinalizer struct {
 	keepers map[hash.Hash]Chunk
 }
 
-func (mgcf msvGcFinalizer) AddChunksToStore(ctx context.Context) (HasManyF, error) {
+func (mgcf msvGcFinalizer) AddChunksToStore(ctx context.Context) (HasManyFunc, error) {
 	panic("unsupported")
 }
 

--- a/go/store/chunks/test_utils.go
+++ b/go/store/chunks/test_utils.go
@@ -91,10 +91,10 @@ func (s *TestStoreView) EndGC() {
 	collector.EndGC()
 }
 
-func (s *TestStoreView) MarkAndSweepChunks(ctx context.Context, hashes <-chan []hash.Hash, dest ChunkStore) error {
+func (s *TestStoreView) MarkAndSweepChunks(ctx context.Context, hashes <-chan []hash.Hash, dest ChunkStore) (GCFinalizer, error) {
 	collector, ok := s.ChunkStore.(ChunkStoreGarbageCollector)
 	if !ok || dest != s {
-		return ErrUnsupportedOperation
+		return nil, ErrUnsupportedOperation
 	}
 	return collector.MarkAndSweepChunks(ctx, hashes, collector)
 }

--- a/go/store/datas/database.go
+++ b/go/store/datas/database.go
@@ -194,7 +194,7 @@ type GarbageCollector interface {
 
 	// GC traverses the database starting at the Root and removes
 	// all unreferenced data from persistent storage.
-	GC(ctx context.Context, oldGenRefs, newGenRefs hash.HashSet, safepointF func() error) error
+	GC(ctx context.Context, mode types.GCMode, oldGenRefs, newGenRefs hash.HashSet, safepointF func() error) error
 }
 
 // CanUsePuller returns true if a datas.Puller can be used to pull data from one Database into another.  Not all

--- a/go/store/datas/database_common.go
+++ b/go/store/datas/database_common.go
@@ -1148,8 +1148,8 @@ func (db *database) doDelete(ctx context.Context, datasetIDstr string, workingse
 }
 
 // GC traverses the database starting at the Root and removes all unreferenced data from persistent storage.
-func (db *database) GC(ctx context.Context, oldGenRefs, newGenRefs hash.HashSet, safepointF func() error) error {
-	return db.ValueStore.GC(ctx, oldGenRefs, newGenRefs, safepointF)
+func (db *database) GC(ctx context.Context, mode types.GCMode, oldGenRefs, newGenRefs hash.HashSet, safepointF func() error) error {
+	return db.ValueStore.GC(ctx, mode, oldGenRefs, newGenRefs, safepointF)
 }
 
 func (db *database) tryCommitChunks(ctx context.Context, newRootHash hash.Hash, currentRootHash hash.Hash) error {

--- a/go/store/nbs/archive_chunk_source.go
+++ b/go/store/nbs/archive_chunk_source.go
@@ -151,7 +151,9 @@ func (acs archiveChunkSource) getRecordRanges(_ context.Context, _ []getRecord) 
 }
 
 func (acs archiveChunkSource) getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, CompressedChunk), stats *Stats) (bool, error) {
-	return false, errors.New("Archive chunk source does not support getManyCompressed")
+	return acs.getMany(ctx, eg, reqs, func(ctx context.Context, chk *chunks.Chunk) {
+		found(ctx, ChunkToCompressedChunk(*chk))
+	}, stats)
 }
 
 func (acs archiveChunkSource) iterateAllChunks(ctx context.Context, cb func(chunks.Chunk)) error {

--- a/go/store/nbs/nbs_metrics_wrapper.go
+++ b/go/store/nbs/nbs_metrics_wrapper.go
@@ -79,7 +79,7 @@ func (nbsMW *NBSMetricWrapper) EndGC() {
 	nbsMW.nbs.EndGC()
 }
 
-func (nbsMW *NBSMetricWrapper) MarkAndSweepChunks(ctx context.Context, hashes <-chan []hash.Hash, dest chunks.ChunkStore) error {
+func (nbsMW *NBSMetricWrapper) MarkAndSweepChunks(ctx context.Context, hashes <-chan []hash.Hash, dest chunks.ChunkStore) (chunks.GCFinalizer, error) {
 	return nbsMW.nbs.MarkAndSweepChunks(ctx, hashes, dest)
 }
 

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -1037,7 +1037,7 @@ func (nbs *NomsBlockStore) HasMany(ctx context.Context, hashes hash.HashSet) (ha
 	return nbs.hasMany(toHasRecords(hashes))
 }
 
-func (nbs *NomsBlockStore) hasManyInSources(ctx context.Context, srcs []hash.Hash, hashes hash.HashSet) (hash.HashSet, error) {
+func (nbs *NomsBlockStore) hasManyInSources(srcs []hash.Hash, hashes hash.HashSet) (hash.HashSet, error) {
 	if hashes.Size() == 0 {
 		return nil, nil
 	}
@@ -1657,14 +1657,14 @@ type gcFinalizer struct {
 	specs []tableSpec
 }
 
-func (gcf gcFinalizer) AddChunksToStore(ctx context.Context) (chunks.HasManyF, error) {
+func (gcf gcFinalizer) AddChunksToStore(ctx context.Context) (chunks.HasManyFunc, error) {
 	fileIdToNumChunks := tableSpecsToMap(gcf.specs)
 	var addrs []hash.Hash
 	for _, spec := range gcf.specs {
 		addrs = append(addrs, spec.name)
 	}
 	f := func(ctx context.Context, hashes hash.HashSet) (hash.HashSet, error) {
-		return gcf.nbs.hasManyInSources(ctx, addrs, hashes)
+		return gcf.nbs.hasManyInSources(addrs, hashes)
 	}
 	return f, gcf.nbs.AddTableFilesToManifest(ctx, fileIdToNumChunks)
 }

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -1592,14 +1592,18 @@ func (nbs *NomsBlockStore) MarkAndSweepChunks(ctx context.Context, hashes <-chan
 		return err
 	}
 
-	destNBS := nbs
+	var destNBS *NomsBlockStore
 	if dest != nil {
 		switch typed := dest.(type) {
 		case *NomsBlockStore:
 			destNBS = typed
 		case NBSMetricWrapper:
 			destNBS = typed.nbs
+		default:
+			return fmt.Errorf("cannot MarkAndSweep into a non-NomsBlockStore ChunkStore: %w", chunks.ErrUnsupportedOperation)
 		}
+	} else {
+		destNBS = nbs
 	}
 
 	specs, err := nbs.copyMarkedChunks(ctx, hashes, destNBS)

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -1658,7 +1658,6 @@ type gcFinalizer struct {
 }
 
 func (gcf gcFinalizer) AddChunksToStore(ctx context.Context) (chunks.HasManyF, error) {
-	// TODO: HasManyF
 	fileIdToNumChunks := tableSpecsToMap(gcf.specs)
 	var addrs []hash.Hash
 	for _, spec := range gcf.specs {

--- a/go/store/nbs/store_test.go
+++ b/go/store/nbs/store_test.go
@@ -339,7 +339,11 @@ func TestNBSCopyGC(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		require.NoError(t, st.BeginGC(nil))
-		msErr = st.MarkAndSweepChunks(ctx, keepChan, nil)
+		var finalizer chunks.GCFinalizer
+		finalizer, msErr = st.MarkAndSweepChunks(ctx, keepChan, nil)
+		if msErr == nil {
+			msErr = finalizer.SwapChunksInStore(ctx)
+		}
 		st.EndGC()
 		wg.Done()
 	}()

--- a/go/store/nbs/table_set.go
+++ b/go/store/nbs/table_set.go
@@ -115,6 +115,15 @@ func (ts tableSet) hasMany(addrs []hasRecord) (bool, error) {
 	return f(ts.upstream)
 }
 
+// Updates the records in |addrs| for whether they exist in this table set, but
+// only consults tables whose names appear in |srcs|, ignoring all other tables
+// in the table set. Returns |remaining| as true if all addresses were not
+// found in the consulted tables, and false otherwise.
+//
+// Intended to be exactly like |hasMany|, except filtering for the files
+// consulted. Only used for part of the GC workflow where we want to have
+// access to all chunks in the store but need to check for existing chunk
+// presence in only a subset of its files.
 func (ts tableSet) hasManyInSources(srcs []hash.Hash, addrs []hasRecord) (remaining bool, err error) {
 	for _, rec := range addrs {
 		if !rec.has {

--- a/go/store/types/value_store.go
+++ b/go/store/types/value_store.go
@@ -585,12 +585,6 @@ func (lvs *ValueStore) GC(ctx context.Context, mode GCMode, oldGenRefs, newGenRe
 		var oldGenHasMany chunks.HasManyF
 		switch mode {
 		case GCModeDefault:
-			// We use the newGen directly as a the collector here,
-			// since all chunks we will ever source come from
-			// newGen. This allows dolt gc to continue working with
-			// old gens that contain archive files, whereas |dolt
-			// gc --full| does not currently support them.
-			collector = newGen
 			oldGenHasMany = oldGen.HasMany
 		case GCModeFull:
 			oldGenHasMany = unfilteredHashFunc

--- a/go/store/types/value_store.go
+++ b/go/store/types/value_store.go
@@ -585,6 +585,12 @@ func (lvs *ValueStore) GC(ctx context.Context, mode GCMode, oldGenRefs, newGenRe
 		var oldGenHasMany chunks.HasManyF
 		switch mode {
 		case GCModeDefault:
+			// We use the newGen directly as a the collector here,
+			// since all chunks we will ever source come from
+			// newGen. This allows dolt gc to continue working with
+			// old gens that contain archive files, whereas |dolt
+			// gc --full| does not currently support them.
+			collector = newGen
 			oldGenHasMany = oldGen.HasMany
 		case GCModeFull:
 			oldGenHasMany = unfilteredHashFunc

--- a/go/store/types/value_store.go
+++ b/go/store/types/value_store.go
@@ -584,12 +584,12 @@ func (lvs *ValueStore) GC(ctx context.Context, mode GCMode, oldGenRefs, newGenRe
 
 		var oldGenHasMany chunks.HasManyF
 		switch mode {
-			case GCModeDefault:
-				oldGenHasMany = oldGen.HasMany
-			case GCModeFull:
-				oldGenHasMany = unfilteredHashFunc
-			default:
-				return fmt.Errorf("unsupported GCMode %v", mode)
+		case GCModeDefault:
+			oldGenHasMany = oldGen.HasMany
+		case GCModeFull:
+			oldGenHasMany = unfilteredHashFunc
+		default:
+			return fmt.Errorf("unsupported GCMode %v", mode)
 		}
 
 		err := collector.BeginGC(lvs.gcAddChunk)
@@ -646,18 +646,18 @@ func (lvs *ValueStore) GC(ctx context.Context, mode GCMode, oldGenRefs, newGenRe
 			return err
 		}
 
+		err = newGenFinalizer.SwapChunksInStore(ctx)
+		if err != nil {
+			collector.EndGC()
+			return err
+		}
+
 		if mode == GCModeFull {
 			err = oldGenFinalizer.SwapChunksInStore(ctx)
 			if err != nil {
 				collector.EndGC()
 				return err
 			}
-		}
-
-		err = newGenFinalizer.SwapChunksInStore(ctx)
-		if err != nil {
-			collector.EndGC()
-			return err
 		}
 
 		collector.EndGC()

--- a/go/store/types/value_store_test.go
+++ b/go/store/types/value_store_test.go
@@ -198,7 +198,7 @@ func TestGC(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(v2)
 
-	err = vs.GC(ctx, hash.HashSet{}, hash.HashSet{}, nil)
+	err = vs.GC(ctx, GCModeDefault, hash.HashSet{}, hash.HashSet{}, nil)
 	require.NoError(t, err)
 
 	v1, err = vs.ReadValue(ctx, h1) // non-nil


### PR DESCRIPTION
Dolt GC is generational. By default, it moves all chunks reachable from commits into the old gen, and it leaves uncommitted data in the new gen. By default, it never revisits the chunks in the old gen. This means that if a branch with a lot of unique data exists during a GC, and then gets deleted, the storage taken up by that branch is never reclaimed by future garbage collection.

This PR implements `dolt gc --full`, which performs a collection on the entire database, ignoring the generational aspects of previous collections and visiting the entire set of live data. At the end of a successful `dolt gc --full`, only data which was reachable at the start of the run and data which has been written during the run will be present in the database.

Note: `dolt gc --full` visits every reachable chunk in the database and can be resource intensive. As a consequence of running `dolt gc --full`, any previously archived table files will be unarchived, and storage savings from the archiving will be lost. `dolt gc --full` involves copying chunks into new storage files, and fully materializing the new files before the old files are deleted; as a consequence, peak disk utilisation while  running `dolt gc --full` can be up to 2x the existing size of the database.