### PR TITLE
Fix bounds check in import scanner

### DIFF
--- a/go/cmd/dolt/commands/sql_statement_scanner.go
+++ b/go/cmd/dolt/commands/sql_statement_scanner.go
@@ -96,16 +96,20 @@ func (s *streamScanner) Scan() bool {
 	}
 
 	// discard leading whitespace
-	for ; unicode.IsSpace(rune(s.buf[s.i])); s.i++ {
-		if s.buf[s.i] == '\n' {
-			s.lineNum++
-		}
+	for {
 		if s.i >= s.fill {
 			if err := s.read(); err != nil {
 				s.err = err
 				return false
 			}
 		}
+		if !unicode.IsSpace(rune(s.buf[s.i])) {
+			break
+		}
+		if s.buf[s.i] == '\n' {
+			s.lineNum++
+		}
+		s.i++
 	}
 	s.truncate()
 

--- a/go/cmd/dolt/commands/sql_statement_scanner_test.go
+++ b/go/cmd/dolt/commands/sql_statement_scanner_test.go
@@ -188,6 +188,7 @@ insert into foo values (1,2,3)|`,
 			lineNums: []int{1, 2},
 		},
 		{
+			// https://github.com/dolthub/dolt/issues/8495
 			input: strings.Repeat(" ", 4096) + `insert into foo values (1,2,3)`,
 			statements: []string{
 				"insert into foo values (1,2,3)",

--- a/go/cmd/dolt/commands/sql_statement_scanner_test.go
+++ b/go/cmd/dolt/commands/sql_statement_scanner_test.go
@@ -187,6 +187,13 @@ insert into foo values (1,2,3)|`,
 			},
 			lineNums: []int{1, 2},
 		},
+		{
+			input: strings.Repeat(" ", 4096) + `insert into foo values (1,2,3)`,
+			statements: []string{
+				"insert into foo values (1,2,3)",
+			},
+			lineNums: []int{1, 2},
+		},
 	}
 
 	for _, tt := range testcases {


### PR DESCRIPTION
fixes: https://github.com/dolthub/dolt/issues/8495

The before code checks whether `s.i` is valid after doing the buffer access:
```go
	for ; unicode.IsSpace(rune(s.buf[s.i])); s.i++ {
		if s.i >= s.fill {
			s.read()
		}
	}
```
The after code inverts the check to make sure `s.i` is valid before indexing into the buffer.
```go
	for {
		if s.i >= s.fill {
			s.read()
		}
		if !unicode.IsSpace(rune(s.buf[s.i])) {
			break
		}
		s.i++
        }
```