### PR TITLE
Bug fixes for replication

### DIFF
--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_primary_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_primary_test.go
@@ -33,6 +33,7 @@ var doltReplicationPrimarySystemVars = map[string]string{
 	"log_bin":                  "1",
 	"enforce_gtid_consistency": "ON",
 	"gtid_mode":                "ON",
+	"server_id":                "42",
 }
 
 // TestBinlogPrimary_BinlogNotEnabled tests that when binary logging is NOT enabled, primary commands such as
@@ -1023,9 +1024,6 @@ func setupForDoltToMySqlReplication() {
 	var tempDatabase = primaryDatabase
 	primaryDatabase = replicaDatabase
 	replicaDatabase = tempDatabase
-
-	// On the Primary, make sure we have a unique, non-zero SERVER_ID set
-	primaryDatabase.MustExec("set GLOBAL SERVER_ID=42;")
 
 	// Set the session's timezone to UTC, to avoid TIMESTAMP test values changing
 	// when they are converted to UTC for storage.

--- a/go/libraries/doltcore/sqle/binlogreplication/system_variable_utils.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/system_variable_utils.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
 // getServerId returns the @@server_id global system variable value. If the value of @@server_id is 0 or is not a
@@ -29,7 +30,14 @@ func getServerId() (uint32, error) {
 		return 0, fmt.Errorf("global variable 'server_id' not found")
 	}
 
-	if i, ok := value.(uint32); ok {
+	// Attempt to convert the server_id value into a UINT32, in case it has been loaded as a string
+	// through global JSON configuration.
+	convertedValue, _, err := types.Uint32.Convert(value)
+	if err != nil {
+		return 0, err
+	}
+
+	if i, ok := convertedValue.(uint32); ok {
 		if i == 0 {
 			return 0, fmt.Errorf("@@server_id is zero – must be set to a non-zero value")
 		}


### PR DESCRIPTION
* Convert `@@server_id` to uint32 value when it gets loaded as a string from config.json
* Send binary logfile name in server heartbeat events, now required in MySQL 8.4