### PR TITLE
Fix panics on schema changes

### DIFF
--- a/go/libraries/doltcore/sqle/statspro/analyze.go
+++ b/go/libraries/doltcore/sqle/statspro/analyze.go
@@ -135,6 +135,24 @@ func (p *Provider) RefreshTableStatsWithBranch(ctx *sql.Context, table sql.Table
 		p.setStatDb(dbName, statDb)
 	}
 
+	schHash, err := dTab.GetSchemaHash(ctx)
+	if err != nil {
+		return err
+	}
+
+	if statDb.GetSchemaHash(branch, tableName) != schHash {
+		ctx.GetLogger().Debugf("statistics refresh: detected table schema change: %s,%s/%s", dbName, table, branch)
+		statDb.SetSchemaHash(branch, tableName, schHash)
+
+		stats, err := p.GetTableDoltStats(ctx, branch, dbName, tableName)
+		if err != nil {
+			return err
+		}
+		for _, stat := range stats {
+			statDb.DeleteStats(ctx, branch, stat.Qualifier())
+		}
+	}
+
 	tablePrefix := fmt.Sprintf("%s.", tableName)
 	var idxMetas []indexMeta
 	for _, idx := range indexes {

--- a/go/libraries/doltcore/sqle/statspro/analyze.go
+++ b/go/libraries/doltcore/sqle/statspro/analyze.go
@@ -140,7 +140,9 @@ func (p *Provider) RefreshTableStatsWithBranch(ctx *sql.Context, table sql.Table
 		return err
 	}
 
-	if statDb.GetSchemaHash(branch, tableName) != schHash {
+	if oldSchHash := statDb.GetSchemaHash(branch, tableName); oldSchHash.IsEmpty() {
+		statDb.SetSchemaHash(branch, tableName, schHash)
+	} else if oldSchHash != schHash {
 		ctx.GetLogger().Debugf("statistics refresh: detected table schema change: %s,%s/%s", dbName, table, branch)
 		statDb.SetSchemaHash(branch, tableName, schHash)
 

--- a/go/libraries/doltcore/sqle/statspro/auto_refresh.go
+++ b/go/libraries/doltcore/sqle/statspro/auto_refresh.go
@@ -163,7 +163,9 @@ func (p *Provider) checkRefresh(ctx *sql.Context, sqlDb sql.Database, dbName, br
 			return err
 		}
 
-		if statDb.GetSchemaHash(branch, table) != schHash {
+		if oldSchHash := statDb.GetSchemaHash(branch, table); oldSchHash.IsEmpty() {
+			statDb.SetSchemaHash(branch, table, schHash)
+		} else if oldSchHash != schHash {
 			ctx.GetLogger().Debugf("statistics refresh: detected table schema change: %s,%s/%s", dbName, table, branch)
 			statDb.SetSchemaHash(branch, table, schHash)
 

--- a/go/libraries/doltcore/sqle/statspro/auto_refresh.go
+++ b/go/libraries/doltcore/sqle/statspro/auto_refresh.go
@@ -149,13 +149,31 @@ func (p *Provider) checkRefresh(ctx *sql.Context, sqlDb sql.Database, dbName, br
 			return err
 		}
 
-		if statDb.GetLatestHash(branch, table) == tableHash {
+		if statDb.GetTableHash(branch, table) == tableHash {
 			// no data changes since last check
 			tableExistsAndSkipped[table] = true
 			ctx.GetLogger().Debugf("statistics refresh: table hash unchanged since last check: %s", tableHash)
 			continue
 		} else {
 			ctx.GetLogger().Debugf("statistics refresh: new table hash: %s", tableHash)
+		}
+
+		schHash, err := dTab.GetSchemaHash(ctx)
+		if err != nil {
+			return err
+		}
+
+		if statDb.GetSchemaHash(branch, table) != schHash {
+			ctx.GetLogger().Debugf("statistics refresh: detected table schema change: %s,%s/%s", dbName, table, branch)
+			statDb.SetSchemaHash(branch, table, schHash)
+
+			stats, err := p.GetTableDoltStats(ctx, branch, dbName, table)
+			if err != nil {
+				return err
+			}
+			for _, stat := range stats {
+				statDb.DeleteStats(ctx, branch, stat.Qualifier())
+			}
 		}
 
 		iat, ok := sqlTable.(sql.IndexAddressableTable)
@@ -205,7 +223,7 @@ func (p *Provider) checkRefresh(ctx *sql.Context, sqlDb sql.Database, dbName, br
 				// mark index for updating
 				idxMetas = append(idxMetas, updateMeta)
 				// update latest hash if we haven't already
-				statDb.SetLatestHash(branch, table, tableHash)
+				statDb.SetTableHash(branch, table, tableHash)
 			}
 		}
 

--- a/go/libraries/doltcore/sqle/statspro/interface.go
+++ b/go/libraries/doltcore/sqle/statspro/interface.go
@@ -50,8 +50,10 @@ type Database interface {
 	Flush(ctx context.Context, branch string) error
 	// Close finalizes any file references.
 	Close() error
-	SetLatestHash(branch, tableName string, h hash.Hash)
-	GetLatestHash(branch, tableName string) hash.Hash
+	SetTableHash(branch, tableName string, h hash.Hash)
+	GetTableHash(branch, tableName string) hash.Hash
+	SetSchemaHash(branch, tableName string, h hash.Hash)
+	GetSchemaHash(branch, tableName string) hash.Hash
 	Branches() []string
 }
 

--- a/integration-tests/bats/stats.bats
+++ b/integration-tests/bats/stats.bats
@@ -120,10 +120,10 @@ teardown() {
 
     start_sql_server
     run dolt sql -q "insert into xy values (0,0), (1,1)"
-    sleep 5
+    sleep 1
     stop_sql_server
 
-    dolt sql -r csv -q "select count(*) from dolt_statistics"
+    run dolt sql -r csv -q "select count(*) from dolt_statistics"
     [ "$status" -eq 0 ]
     [ "${lines[1]}" = "2" ]
 }

--- a/integration-tests/bats/stats.bats
+++ b/integration-tests/bats/stats.bats
@@ -120,7 +120,7 @@ teardown() {
 
     start_sql_server
     run dolt sql -q "insert into xy values (0,0), (1,1)"
-    sleep 3
+    sleep 5
     stop_sql_server
 
     dolt sql -r csv -q "select count(*) from dolt_statistics"

--- a/integration-tests/bats/stats.bats
+++ b/integration-tests/bats/stats.bats
@@ -120,7 +120,7 @@ teardown() {
 
     start_sql_server
     dolt sql -q "insert into xy values (0,0), (1,1)"
-    sleep 1
+    sleep 2
     stop_sql_server
 
     run dolt sql -r csv -q "select count(*) from dolt_statistics"

--- a/integration-tests/bats/stats.bats
+++ b/integration-tests/bats/stats.bats
@@ -123,7 +123,7 @@ teardown() {
     sleep 2
     stop_sql_server
 
-    run dolt sql -r csv -q "select count(*) from dolt_statistics"
+    dolt sql -r csv -q "select count(*) from dolt_statistics"
     [ "$status" -eq 0 ]
     [ "${lines[1]}" = "2" ]
 }

--- a/integration-tests/bats/stats.bats
+++ b/integration-tests/bats/stats.bats
@@ -119,8 +119,8 @@ teardown() {
     [ "${lines[1]}" = "0" ]
 
     start_sql_server
-    dolt sql -q "insert into xy values (0,0), (1,1)"
-    sleep 2
+    run dolt sql -q "insert into xy values (0,0), (1,1)"
+    sleep 3
     stop_sql_server
 
     dolt sql -r csv -q "select count(*) from dolt_statistics"


### PR DESCRIPTION
fixes: https://github.com/dolthub/dolt/issues/8504

Use schema hash to detect when database statistics might be incompatible. Drops all statistics for schema update. This could be improved to a subset of statistics if we wanted in the future.