### PR TITLE
Better view caching

### DIFF
--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -901,6 +901,7 @@ func (root *rootValue) putTable(ctx context.Context, tName TableName, ref types.
 		// certain updates can safely reuse the previous map
 		ret.schemaHashes = root.schemaHashes
 	}
+
 	return ret, nil
 }
 

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -1566,7 +1566,7 @@ func (db Database) GetViewDefinition(ctx *sql.Context, viewName string) (sql.Vie
 		return sql.ViewDefinition{Name: viewName, TextDefinition: blameViewTextDef, CreateViewStatement: fmt.Sprintf("CREATE VIEW `%s` AS %s", viewName, blameViewTextDef)}, true, nil
 	}
 
-	schTblHash, ok, err := root.GetTableHash(ctx, doltdb.TableName{Name: doltdb.SchemasTableName})
+	schTblHash, ok, err := root.GetTableHash(ctx, doltdb.TableName{Name: doltdb.SchemasTableName, Schema: db.schemaName})
 	if err != nil {
 		return sql.ViewDefinition{}, false, err
 	}

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -1566,7 +1566,7 @@ func (db Database) GetViewDefinition(ctx *sql.Context, viewName string) (sql.Vie
 		return sql.ViewDefinition{Name: viewName, TextDefinition: blameViewTextDef, CreateViewStatement: fmt.Sprintf("CREATE VIEW `%s` AS %s", viewName, blameViewTextDef)}, true, nil
 	}
 
-	scheTblHash, ok, err := root.GetTableHash(ctx, doltdb.TableName{Name: doltdb.SchemasTableName})
+	schTblHash, ok, err := root.GetTableHash(ctx, doltdb.TableName{Name: doltdb.SchemasTableName})
 	if err != nil {
 		return sql.ViewDefinition{}, false, err
 	}
@@ -1574,7 +1574,7 @@ func (db Database) GetViewDefinition(ctx *sql.Context, viewName string) (sql.Vie
 		return sql.ViewDefinition{}, false, nil
 	}
 
-	key := doltdb.DataCacheKey{scheTblHash}
+	key := doltdb.DataCacheKey{Hash: schTblHash}
 
 	ds := dsess.DSessFromSess(ctx.Session)
 	dbState, _, err := ds.LookupDbState(ctx, db.RevisionQualifiedName())

--- a/go/libraries/doltcore/sqle/schema_table.go
+++ b/go/libraries/doltcore/sqle/schema_table.go
@@ -201,8 +201,11 @@ func NewEmptySchemaTable() sql.Table {
 	return &SchemaTable{}
 }
 
-func NewSchemaTable(backingTable *WritableDoltTable) (sql.Table, error) {
-	return &SchemaTable{backingTable: backingTable}, nil
+func NewSchemaTable(backingTable sql.Table) *SchemaTable {
+	if backingTable == nil {
+		return &SchemaTable{}
+	}
+	return &SchemaTable{backingTable: backingTable.(*WritableDoltTable)}
 }
 
 // getOrCreateDoltSchemasTable returns the `dolt_schemas` table in `db`, creating it if it does not already exist.


### PR DESCRIPTION
Binding a table name to a catalog symbol previously always loaded the schemas table from disk to first attempt binding a view. Now we cache `dolt_schemas` using its hash. If the table does not exist, no views are defined, and we short circuit attempting to bind a name to a view.