### PR TITLE
Fix issue where JSON diff would fail under specific circumstances.

### DIFF
--- a/go/store/prolly/tree/json_scanner.go
+++ b/go/store/prolly/tree/json_scanner.go
@@ -38,7 +38,7 @@ type JsonScanner struct {
 	valueOffset int
 }
 
-var jsonParseError = fmt.Errorf("an error occurred while reading or writing JSON to/from the database. This is most likely a bug, but could indicate database corruption")
+var jsonParseError = fmt.Errorf("encountered invalid JSON while reading JSON from the database, or while preparing to write JSON to the database. This is most likely a bug in JSON diffing")
 
 func (j JsonScanner) Clone() JsonScanner {
 	return JsonScanner{


### PR DESCRIPTION
If all of the following are true during a JSON diff operation:
1. One document fits in a single chunk and the other doesn't
2. The location of the chunk boundary in the larger document is also present in the smaller document. (It doesn't correspond to a location that was added or removed)
3. The chunk boundary falls at the end of a value in the document (before the next key or comma/right brace/etc)

Then the differ would fail to advance the prolly tree cursor and would incorrectly see the larger document as corrupt.

This fixes that issue and improves the error messaging to make it seem less like the database is corrupt, since the error is much more likely to be a parsing bug like this one.