### PR TITLE
Add testing for `show slave status`

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/dolthub/fslock v0.0.3
 	github.com/dolthub/ishell v0.0.0-20240701202509-2b217167d718
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20241121221517-3e7b5ffc22b0
+	github.com/dolthub/vitess v0.0.0-20241125223808-07f6e12611ec
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.13.0
 	github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568
@@ -57,7 +57,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/creasty/defaults v1.6.0
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-mysql-server v0.18.2-0.20241125210950-6625ccc05305
+	github.com/dolthub/go-mysql-server v0.18.2-0.20241125225118-7c3d81120e3e
 	github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63
 	github.com/dolthub/swiss v0.1.0
 	github.com/goccy/go-json v0.10.2

--- a/go/go.sum
+++ b/go/go.sum
@@ -185,6 +185,8 @@ github.com/dolthub/go-icu-regex v0.0.0-20240916130659-0118adc6b662 h1:aC17hZD6iw
 github.com/dolthub/go-icu-regex v0.0.0-20240916130659-0118adc6b662/go.mod h1:KPUcpx070QOfJK1gNe0zx4pA5sicIK1GMikIGLKC168=
 github.com/dolthub/go-mysql-server v0.18.2-0.20241125210950-6625ccc05305 h1:T1nzDqzpk0K64wHG5nwdKhGMgT0Yp1qBya7RMZNGWz4=
 github.com/dolthub/go-mysql-server v0.18.2-0.20241125210950-6625ccc05305/go.mod h1:2mA/v84EOCe8TQIKR8TN8ZRIQSbOqThGQHyevGRmawU=
+github.com/dolthub/go-mysql-server v0.18.2-0.20241125225118-7c3d81120e3e h1:d1Dh7G456udovQLfhhaiJ+9BMywckL+uveCM09Tm+Nw=
+github.com/dolthub/go-mysql-server v0.18.2-0.20241125225118-7c3d81120e3e/go.mod h1:CSp6i24qfW6JleRNYlR7LLJwO7aHlPrCnFoXivzTSZ4=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20240701202509-2b217167d718 h1:lT7hE5k+0nkBdj/1UOSFwjWpNxf+LCApbRHgnCA17XE=
@@ -199,6 +201,8 @@ github.com/dolthub/swiss v0.1.0 h1:EaGQct3AqeP/MjASHLiH6i4TAmgbG/c4rA6a1bzCOPc=
 github.com/dolthub/swiss v0.1.0/go.mod h1:BeucyB08Vb1G9tumVN3Vp/pyY4AMUnr9p7Rz7wJ7kAQ=
 github.com/dolthub/vitess v0.0.0-20241121221517-3e7b5ffc22b0 h1:C8X4RkkWKcrJG6rG+MsdFINX2PhB7ObpbBvFcWsI8K8=
 github.com/dolthub/vitess v0.0.0-20241121221517-3e7b5ffc22b0/go.mod h1:alcJgfdyIhFaAiYyEmuDCFSLCzedz3KCaIclLoCUtJg=
+github.com/dolthub/vitess v0.0.0-20241125223808-07f6e12611ec h1:4EpyVnCleDMSuIqg8oCHf5IpwW7DPhjSQEgYCWkKpTo=
+github.com/dolthub/vitess v0.0.0-20241125223808-07f6e12611ec/go.mod h1:alcJgfdyIhFaAiYyEmuDCFSLCzedz3KCaIclLoCUtJg=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=


### PR DESCRIPTION
This syntax is deprecated and will be removed in future MySQL versions (`SHOW REPLICA STATUS` should be preferred instead). However, some tools (e.g. Dolphie, MyDumper) still rely on this deprecated syntax, so we're adding support for it to keep compatibility with those tools.

Depends on: 
* https://github.com/dolthub/vitess/pull/381
* https://github.com/dolthub/go-mysql-server/pull/2767
