### PR TITLE
[no-release-notes] Refactor NewEmptyIndex to avoid adding parameters for keyless and vector indexes

### DIFF
--- a/go/cmd/dolt/commands/schcmds/import.go
+++ b/go/cmd/dolt/commands/schcmds/import.go
@@ -330,7 +330,7 @@ func putEmptyTableWithSchema(ctx context.Context, tblName string, root doltdb.Ro
 		return nil, errhand.BuildDError("error: failed to get table.").AddCause(err).Build()
 	}
 
-	empty, err := durable.NewEmptyIndex(ctx, root.VRW(), root.NodeStore(), sch, false)
+	empty, err := durable.NewEmptyPrimaryIndex(ctx, root.VRW(), root.NodeStore(), sch)
 	if err != nil {
 		return nil, errhand.BuildDError("error: failed to get table.").AddCause(err).Build()
 	}

--- a/go/libraries/doltcore/doltdb/commit_hooks_test.go
+++ b/go/libraries/doltcore/doltdb/commit_hooks_test.go
@@ -251,7 +251,7 @@ func TestAsyncPushOnWrite(t *testing.T) {
 			assert.NoError(t, err)
 
 			tSchema := createTestSchema(t)
-			rowData, err := durable.NewEmptyIndex(ctx, ddb.vrw, ddb.ns, tSchema, false)
+			rowData, err := durable.NewEmptyPrimaryIndex(ctx, ddb.vrw, ddb.ns, tSchema)
 			require.NoError(t, err)
 			tbl, err := CreateTestTable(ddb.vrw, ddb.ns, tSchema, rowData)
 			require.NoError(t, err)

--- a/go/libraries/doltcore/doltdb/doltdb_test.go
+++ b/go/libraries/doltcore/doltdb/doltdb_test.go
@@ -83,7 +83,7 @@ func CreateTestTable(vrw types.ValueReadWriter, ns tree.NodeStore, tSchema schem
 
 func createTestRowData(t *testing.T, vrw types.ValueReadWriter, ns tree.NodeStore, sch schema.Schema) durable.Index {
 	if types.Format_Default == types.Format_DOLT {
-		idx, err := durable.NewEmptyIndex(context.Background(), vrw, ns, sch, false)
+		idx, err := durable.NewEmptyPrimaryIndex(context.Background(), vrw, ns, sch)
 		require.NoError(t, err)
 		return idx
 	}
@@ -303,7 +303,7 @@ func TestLDNoms(t *testing.T) {
 
 		ctx := context.Background()
 		tSchema := createTestSchema(t)
-		rowData, err := durable.NewEmptyIndex(ctx, ddb.vrw, ddb.ns, tSchema, false)
+		rowData, err := durable.NewEmptyPrimaryIndex(ctx, ddb.vrw, ddb.ns, tSchema)
 		if err != nil {
 			t.Fatal("Failed to create new empty index")
 		}

--- a/go/libraries/doltcore/doltdb/durable/index.go
+++ b/go/libraries/doltcore/doltdb/durable/index.go
@@ -123,10 +123,12 @@ func indexFromAddr(ctx context.Context, vrw types.ValueReadWriter, ns tree.NodeS
 	}
 }
 
+// NewEmptyPrimaryIndex creates a new empty Index for use as the primary index in a table.
 func NewEmptyPrimaryIndex(ctx context.Context, vrw types.ValueReadWriter, ns tree.NodeStore, sch schema.Schema) (Index, error) {
 	return newEmptyIndex(ctx, vrw, ns, sch, false)
 }
 
+// NewEmptyIndexFromSchemaIndex creates a new empty Index described by a schema.Index.
 func NewEmptyIndexFromSchemaIndex(ctx context.Context, vrw types.ValueReadWriter, ns tree.NodeStore, idx schema.Index) (Index, error) {
 	sch := idx.Schema()
 	return newEmptyIndex(ctx, vrw, ns, sch, schema.IsKeyless(sch))

--- a/go/libraries/doltcore/doltdb/durable/index.go
+++ b/go/libraries/doltcore/doltdb/durable/index.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql/expression/function/vector"
 	"io"
 	"strings"
 
@@ -125,16 +124,16 @@ func indexFromAddr(ctx context.Context, vrw types.ValueReadWriter, ns tree.NodeS
 }
 
 func NewEmptyPrimaryIndex(ctx context.Context, vrw types.ValueReadWriter, ns tree.NodeStore, sch schema.Schema) (Index, error) {
-	return newEmptyIndex(ctx, vrw, ns, sch, false, false)
+	return newEmptyIndex(ctx, vrw, ns, sch, false)
 }
 
 func NewEmptyIndexFromSchemaIndex(ctx context.Context, vrw types.ValueReadWriter, ns tree.NodeStore, idx schema.Index) (Index, error) {
 	sch := idx.Schema()
-	return newEmptyIndex(ctx, vrw, ns, sch, idx.IsVector(), schema.IsKeyless(sch))
+	return newEmptyIndex(ctx, vrw, ns, sch, schema.IsKeyless(sch))
 }
 
 // newEmptyIndex returns an index with no rows.
-func newEmptyIndex(ctx context.Context, vrw types.ValueReadWriter, ns tree.NodeStore, sch schema.Schema, isVector bool, isKeylessSecondary bool) (Index, error) {
+func newEmptyIndex(ctx context.Context, vrw types.ValueReadWriter, ns tree.NodeStore, sch schema.Schema, isKeylessSecondary bool) (Index, error) {
 	switch vrw.Format() {
 	case types.Format_LD_1:
 		m, err := types.NewMap(ctx, vrw)

--- a/go/libraries/doltcore/doltdb/durable/index.go
+++ b/go/libraries/doltcore/doltdb/durable/index.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/dolthub/go-mysql-server/sql/expression/function/vector"
 	"io"
 	"strings"
 
@@ -123,8 +124,17 @@ func indexFromAddr(ctx context.Context, vrw types.ValueReadWriter, ns tree.NodeS
 	}
 }
 
-// NewEmptyIndex returns an index with no rows.
-func NewEmptyIndex(ctx context.Context, vrw types.ValueReadWriter, ns tree.NodeStore, sch schema.Schema, isKeylessSecondary bool) (Index, error) {
+func NewEmptyPrimaryIndex(ctx context.Context, vrw types.ValueReadWriter, ns tree.NodeStore, sch schema.Schema) (Index, error) {
+	return newEmptyIndex(ctx, vrw, ns, sch, false, false)
+}
+
+func NewEmptyIndexFromSchemaIndex(ctx context.Context, vrw types.ValueReadWriter, ns tree.NodeStore, idx schema.Index) (Index, error) {
+	sch := idx.Schema()
+	return newEmptyIndex(ctx, vrw, ns, sch, idx.IsVector(), schema.IsKeyless(sch))
+}
+
+// newEmptyIndex returns an index with no rows.
+func newEmptyIndex(ctx context.Context, vrw types.ValueReadWriter, ns tree.NodeStore, sch schema.Schema, isVector bool, isKeylessSecondary bool) (Index, error) {
 	switch vrw.Format() {
 	case types.Format_LD_1:
 		m, err := types.NewMap(ctx, vrw)
@@ -138,15 +148,19 @@ func NewEmptyIndex(ctx context.Context, vrw types.ValueReadWriter, ns tree.NodeS
 		if isKeylessSecondary {
 			kd = prolly.AddHashToSchema(kd)
 		}
-		m, err := prolly.NewMapFromTuples(ctx, ns, kd, vd)
-		if err != nil {
-			return nil, err
-		}
-		return IndexFromProllyMap(m), nil
+		return NewEmptyProllyIndex(ctx, ns, kd, vd)
 
 	default:
 		return nil, errNbfUnknown
 	}
+}
+
+func NewEmptyProllyIndex(ctx context.Context, ns tree.NodeStore, kd, vd val.TupleDesc) (Index, error) {
+	m, err := prolly.NewMapFromTuples(ctx, ns, kd, vd)
+	if err != nil {
+		return nil, err
+	}
+	return IndexFromProllyMap(m), nil
 }
 
 type nomsIndex struct {
@@ -393,7 +407,7 @@ func NewIndexSetWithEmptyIndexes(ctx context.Context, vrw types.ValueReadWriter,
 		return nil, err
 	}
 	for _, index := range sch.Indexes().AllIndexes() {
-		empty, err := NewEmptyIndex(ctx, vrw, ns, index.Schema(), false)
+		empty, err := NewEmptyIndexFromSchemaIndex(ctx, vrw, ns, index)
 		if err != nil {
 			return nil, err
 		}

--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -924,7 +924,7 @@ func (root *rootValue) putTable(ctx context.Context, tName TableName, ref types.
 func CreateEmptyTable(ctx context.Context, root RootValue, tName TableName, sch schema.Schema) (RootValue, error) {
 	ns := root.NodeStore()
 	vrw := root.VRW()
-	empty, err := durable.NewEmptyIndex(ctx, vrw, ns, sch, false)
+	empty, err := durable.NewEmptyPrimaryIndex(ctx, vrw, ns, sch)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/doltdb/table.go
+++ b/go/libraries/doltcore/doltdb/table.go
@@ -92,7 +92,7 @@ func NewTableFromDurable(table durable.Table) *Table {
 }
 
 func NewEmptyTable(ctx context.Context, vrw types.ValueReadWriter, ns tree.NodeStore, sch schema.Schema) (*Table, error) {
-	rows, err := durable.NewEmptyIndex(ctx, vrw, ns, sch, false)
+	rows, err := durable.NewEmptyPrimaryIndex(ctx, vrw, ns, sch)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/dtestutils/testcommands/multienv.go
+++ b/go/libraries/doltcore/dtestutils/testcommands/multienv.go
@@ -390,7 +390,7 @@ func createTestTable(dEnv *env.DoltEnv, tableName string, sch schema.Schema) err
 	vrw := dEnv.DoltDB.ValueReadWriter()
 	ns := dEnv.DoltDB.NodeStore()
 
-	idx, err := durable.NewEmptyIndex(ctx, vrw, ns, sch, false)
+	idx, err := durable.NewEmptyPrimaryIndex(ctx, vrw, ns, sch)
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/merge/fulltext_rebuild.go
+++ b/go/libraries/doltcore/merge/fulltext_rebuild.go
@@ -330,7 +330,7 @@ func purgeFulltextTableData(ctx *sql.Context, root doltdb.RootValue, tableNames 
 		if err != nil {
 			return nil, err
 		}
-		rows, err := durable.NewEmptyIndex(ctx, tbl.ValueReadWriter(), tbl.NodeStore(), sch, false)
+		rows, err := durable.NewEmptyPrimaryIndex(ctx, tbl.ValueReadWriter(), tbl.NodeStore(), sch)
 		if err != nil {
 			return nil, err
 		}

--- a/go/libraries/doltcore/merge/violations_fk.go
+++ b/go/libraries/doltcore/merge/violations_fk.go
@@ -370,7 +370,7 @@ func parentFkConstraintViolations(
 	}
 	var idx durable.Index
 	if empty {
-		idx, err = durable.NewEmptyIndexFromSchemaIndex(ctx, postChild.Table.ValueReadWriter(), postParent.Table.NodeStore(), postParent.Index)
+		idx, err = durable.NewEmptyForeignKeyIndex(ctx, postChild.Table.ValueReadWriter(), postParent.Table.NodeStore(), postParent.Index.Schema())
 		if err != nil {
 			return err
 		}
@@ -405,7 +405,7 @@ func childFkConstraintViolations(
 	}
 	var idx durable.Index
 	if empty {
-		idx, err = durable.NewEmptyIndexFromSchemaIndex(ctx, postChild.Table.ValueReadWriter(), postChild.Table.NodeStore(), postChild.Index)
+		idx, err = durable.NewEmptyForeignKeyIndex(ctx, postChild.Table.ValueReadWriter(), postChild.Table.NodeStore(), postChild.Index.Schema())
 		if err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/merge/violations_fk.go
+++ b/go/libraries/doltcore/merge/violations_fk.go
@@ -107,7 +107,7 @@ func GetForeignKeyViolations(ctx context.Context, newRoot, baseRoot doltdb.RootV
 				return err
 			}
 			// Parent does not exist in the ancestor so we use an empty map
-			emptyIdx, err := durable.NewEmptyIndex(ctx, postParent.Table.ValueReadWriter(), postParent.Table.NodeStore(), postParent.Schema, false)
+			emptyIdx, err := durable.NewEmptyPrimaryIndex(ctx, postParent.Table.ValueReadWriter(), postParent.Table.NodeStore(), postParent.Schema)
 			if err != nil {
 				return err
 			}
@@ -129,7 +129,7 @@ func GetForeignKeyViolations(ctx context.Context, newRoot, baseRoot doltdb.RootV
 				return err
 			}
 			// Child does not exist in the ancestor so we use an empty map
-			emptyIdx, err := durable.NewEmptyIndex(ctx, postChild.Table.ValueReadWriter(), postChild.Table.NodeStore(), postChild.Schema, false)
+			emptyIdx, err := durable.NewEmptyPrimaryIndex(ctx, postChild.Table.ValueReadWriter(), postChild.Table.NodeStore(), postChild.Schema)
 			if err != nil {
 				return err
 			}
@@ -370,7 +370,7 @@ func parentFkConstraintViolations(
 	}
 	var idx durable.Index
 	if empty {
-		idx, err = durable.NewEmptyIndex(ctx, postChild.Table.ValueReadWriter(), postParent.Table.NodeStore(), postParent.Schema, false)
+		idx, err = durable.NewEmptyIndexFromSchemaIndex(ctx, postChild.Table.ValueReadWriter(), postParent.Table.NodeStore(), postParent.Index)
 		if err != nil {
 			return err
 		}
@@ -405,7 +405,7 @@ func childFkConstraintViolations(
 	}
 	var idx durable.Index
 	if empty {
-		idx, err = durable.NewEmptyIndex(ctx, postChild.Table.ValueReadWriter(), postChild.Table.NodeStore(), postChild.Schema, false)
+		idx, err = durable.NewEmptyIndexFromSchemaIndex(ctx, postChild.Table.ValueReadWriter(), postChild.Table.NodeStore(), postChild.Index)
 		if err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/sqle/alterschema_test.go
+++ b/go/libraries/doltcore/sqle/alterschema_test.go
@@ -269,7 +269,7 @@ func makePeopleTable(ctx context.Context, dEnv *env.DoltEnv) (*env.DoltEnv, erro
 	if err != nil {
 		return nil, err
 	}
-	rows, err := durable.NewEmptyIndex(ctx, root.VRW(), root.NodeStore(), sch, false)
+	rows, err := durable.NewEmptyPrimaryIndex(ctx, root.VRW(), root.NodeStore(), sch)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/common_test.go
+++ b/go/libraries/doltcore/sqle/common_test.go
@@ -181,7 +181,7 @@ func CreateTestTable(t *testing.T, dEnv *env.DoltEnv, tableName string, sch sche
 	vrw := dEnv.DoltDB.ValueReadWriter()
 	ns := dEnv.DoltDB.NodeStore()
 
-	rows, err := durable.NewEmptyIndex(ctx, vrw, ns, sch, false)
+	rows, err := durable.NewEmptyPrimaryIndex(ctx, vrw, ns, sch)
 	require.NoError(t, err)
 	tbl, err := doltdb.NewTable(ctx, vrw, ns, sch, rows, nil, nil)
 	require.NoError(t, err)

--- a/go/libraries/doltcore/sqle/dtables/conflicts_tables_prolly.go
+++ b/go/libraries/doltcore/sqle/dtables/conflicts_tables_prolly.go
@@ -415,7 +415,7 @@ func (itr *prollyConflictRowIter) loadTableMaps(ctx *sql.Context, baseHash, thei
 
 		var idx durable.Index
 		if !ok {
-			idx, err = durable.NewEmptyIndex(ctx, itr.vrw, itr.ns, itr.ourSch, false)
+			idx, err = durable.NewEmptyPrimaryIndex(ctx, itr.vrw, itr.ns, itr.ourSch)
 		} else {
 			idx, err = baseTbl.GetRowData(ctx)
 		}

--- a/go/libraries/doltcore/sqle/dtables/diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/diff_table.go
@@ -599,7 +599,7 @@ func tableData(ctx *sql.Context, tbl *doltdb.Table, ddb *doltdb.DoltDB) (durable
 	var err error
 
 	if tbl == nil {
-		data, err = durable.NewEmptyIndex(ctx, ddb.ValueReadWriter(), ddb.NodeStore(), schema.EmptySchema, false)
+		data, err = durable.NewEmptyPrimaryIndex(ctx, ddb.ValueReadWriter(), ddb.NodeStore(), schema.EmptySchema)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -1041,7 +1041,7 @@ func (t *WritableDoltTable) truncate(
 	}
 
 	for _, idx := range sch.Indexes().AllIndexes() {
-		empty, err := durable.NewEmptyIndexFromSchemaIndex(ctx, table.ValueReadWriter(), table.NodeStore(), idx)
+		empty, err := durable.NewEmptyIndexFromTableSchema(ctx, table.ValueReadWriter(), table.NodeStore(), idx, sch)
 		if err != nil {
 			return nil, err
 		}

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -937,7 +937,7 @@ func emptyFulltextTable(
 		return nil, nil, err
 	}
 
-	empty, err := durable.NewEmptyIndex(ctx, dt.ValueReadWriter(), dt.NodeStore(), doltSchema, false)
+	empty, err := durable.NewEmptyPrimaryIndex(ctx, dt.ValueReadWriter(), dt.NodeStore(), doltSchema)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1041,7 +1041,7 @@ func (t *WritableDoltTable) truncate(
 	}
 
 	for _, idx := range sch.Indexes().AllIndexes() {
-		empty, err := durable.NewEmptyIndex(ctx, table.ValueReadWriter(), table.NodeStore(), idx.Schema(), false)
+		empty, err := durable.NewEmptyIndexFromSchemaIndex(ctx, table.ValueReadWriter(), table.NodeStore(), idx)
 		if err != nil {
 			return nil, err
 		}
@@ -1065,7 +1065,7 @@ func (t *WritableDoltTable) truncate(
 		}
 	}
 
-	empty, err := durable.NewEmptyIndex(ctx, table.ValueReadWriter(), table.NodeStore(), sch, false)
+	empty, err := durable.NewEmptyPrimaryIndex(ctx, table.ValueReadWriter(), table.NodeStore(), sch)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/temp_table.go
+++ b/go/libraries/doltcore/sqle/temp_table.go
@@ -109,7 +109,7 @@ func NewTempTable(
 	vrw := ddb.ValueReadWriter()
 	ns := ddb.NodeStore()
 
-	idx, err := durable.NewEmptyIndex(ctx, vrw, ns, sch, false)
+	idx, err := durable.NewEmptyPrimaryIndex(ctx, vrw, ns, sch)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/testutil.go
+++ b/go/libraries/doltcore/sqle/testutil.go
@@ -425,7 +425,7 @@ func CreateEmptyTestTable(dEnv *env.DoltEnv, tableName string, sch schema.Schema
 	vrw := dEnv.DoltDB.ValueReadWriter()
 	ns := dEnv.DoltDB.NodeStore()
 
-	rows, err := durable.NewEmptyIndex(ctx, vrw, ns, sch, false)
+	rows, err := durable.NewEmptyPrimaryIndex(ctx, vrw, ns, sch)
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/table/editor/creation/external_build_index.go
+++ b/go/libraries/doltcore/table/editor/creation/external_build_index.go
@@ -41,7 +41,7 @@ const (
 // single prolly tree materialization by presorting the index keys in an
 // intermediate file format.
 func BuildProllyIndexExternal(ctx *sql.Context, vrw types.ValueReadWriter, ns tree.NodeStore, sch schema.Schema, tableName string, idx schema.Index, primary prolly.Map, uniqCb DupEntryCb) (durable.Index, error) {
-	empty, err := durable.NewEmptyIndexFromSchemaIndex(ctx, vrw, ns, idx)
+	empty, err := durable.NewEmptyIndexFromTableSchema(ctx, vrw, ns, idx, sch)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/table/editor/creation/external_build_index.go
+++ b/go/libraries/doltcore/table/editor/creation/external_build_index.go
@@ -41,7 +41,7 @@ const (
 // single prolly tree materialization by presorting the index keys in an
 // intermediate file format.
 func BuildProllyIndexExternal(ctx *sql.Context, vrw types.ValueReadWriter, ns tree.NodeStore, sch schema.Schema, tableName string, idx schema.Index, primary prolly.Map, uniqCb DupEntryCb) (durable.Index, error) {
-	empty, err := durable.NewEmptyIndexFromSchemaIndex(ctx, vrw, ns, idx.Schema())
+	empty, err := durable.NewEmptyIndexFromSchemaIndex(ctx, vrw, ns, idx)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/table/editor/creation/external_build_index.go
+++ b/go/libraries/doltcore/table/editor/creation/external_build_index.go
@@ -41,7 +41,7 @@ const (
 // single prolly tree materialization by presorting the index keys in an
 // intermediate file format.
 func BuildProllyIndexExternal(ctx *sql.Context, vrw types.ValueReadWriter, ns tree.NodeStore, sch schema.Schema, tableName string, idx schema.Index, primary prolly.Map, uniqCb DupEntryCb) (durable.Index, error) {
-	empty, err := durable.NewEmptyIndex(ctx, vrw, ns, idx.Schema(), schema.IsKeyless(sch))
+	empty, err := durable.NewEmptyIndexFromSchemaIndex(ctx, vrw, ns, idx.Schema())
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/table/editor/creation/index.go
+++ b/go/libraries/doltcore/table/editor/creation/index.go
@@ -214,7 +214,7 @@ func BuildUniqueProllyIndex(
 	primary prolly.Map,
 	cb DupEntryCb,
 ) (durable.Index, error) {
-	empty, err := durable.NewEmptyIndexFromSchemaIndex(ctx, vrw, ns, idx)
+	empty, err := durable.NewEmptyIndexFromTableSchema(ctx, vrw, ns, idx, sch)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/table/editor/creation/index.go
+++ b/go/libraries/doltcore/table/editor/creation/index.go
@@ -214,7 +214,7 @@ func BuildUniqueProllyIndex(
 	primary prolly.Map,
 	cb DupEntryCb,
 ) (durable.Index, error) {
-	empty, err := durable.NewEmptyIndex(ctx, vrw, ns, idx.Schema(), schema.IsKeyless(sch))
+	empty, err := durable.NewEmptyIndexFromSchemaIndex(ctx, vrw, ns, idx)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/table/untyped/sqlexport/sqlwriter_test.go
+++ b/go/libraries/doltcore/table/untyped/sqlexport/sqlwriter_test.go
@@ -92,7 +92,7 @@ func TestEndToEnd(t *testing.T) {
 			root, err := dEnv.WorkingRoot(ctx)
 			require.NoError(t, err)
 
-			empty, err := durable.NewEmptyIndex(ctx, root.VRW(), root.NodeStore(), tt.sch, false)
+			empty, err := durable.NewEmptyPrimaryIndex(ctx, root.VRW(), root.NodeStore(), tt.sch)
 			require.NoError(t, err)
 
 			indexes, err := durable.NewIndexSet(ctx, root.VRW(), root.NodeStore())


### PR DESCRIPTION
Instead of continuing to add parameters to `NewEmptyIndex`, I'm breaking it out into multiple functions that are more clear about where and how they're being used.