### PR TITLE
Update sql status to not report changes for unstaged tables that have changed but not visibly.

### DIFF
--- a/go/libraries/doltcore/diff/table_deltas.go
+++ b/go/libraries/doltcore/diff/table_deltas.go
@@ -404,6 +404,81 @@ func (td TableDelta) HasSchemaChanged(ctx context.Context) (bool, error) {
 	return !fromSchemaHash.Equal(toSchemaHash), nil
 }
 
+func (td TableDelta) HasChangesIgnoringColumnTags(ctx context.Context) (bool, error) {
+
+	if td.FromTable == nil && td.ToTable == nil {
+		return true, nil
+	}
+
+	if td.IsAdd() || td.IsDrop() {
+		return true, nil
+	}
+
+	if td.IsRename() {
+		return true, nil
+	}
+
+	if td.HasFKChanges() {
+		return true, nil
+	}
+
+	fromRowDataHash, err := td.FromTable.GetRowDataHash(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	toRowDataHash, err := td.ToTable.GetRowDataHash(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	// Any change to the table data counts as a change
+	if !fromRowDataHash.Equal(toRowDataHash) {
+		return true, nil
+	}
+
+	fromTableHash, err := td.FromTable.HashOf()
+	if err != nil {
+		return false, err
+	}
+
+	toTableHash, err := td.FromTable.HashOf()
+	if err != nil {
+		return false, err
+	}
+
+	// If the data hashes have changed, the table has obviously changed.
+	if !fromTableHash.Equal(toTableHash) {
+		return true, nil
+	}
+
+	fromSchemaHash, err := td.FromTable.GetSchemaHash(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	toSchemaHash, err := td.ToTable.GetSchemaHash(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	// If neither data nor schema hashes have changed, the table is obviously the same.
+	if fromSchemaHash.Equal(toSchemaHash) {
+		return false, nil
+	}
+
+	// The schema hash has changed but the data has remained the same. We must inspect the schema to determine
+	// whether the change is observable or if only column tags have changed.
+
+	fromSchema, toSchema, err := td.GetSchemas(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	// SchemasAreEqual correctly accounts for tags
+	return !schema.SchemasAreEqual(fromSchema, toSchema), nil
+}
+
 func (td TableDelta) HasDataChanged(ctx context.Context) (bool, error) {
 	// Database collation change is not a data change
 	if td.FromTable == nil && td.ToTable == nil {
@@ -445,6 +520,9 @@ func (td TableDelta) HasPrimaryKeySetChanged() bool {
 }
 
 func (td TableDelta) HasChanges() (bool, error) {
+	fromString := td.FromTable.DebugString(context.Background(), td.FromTable.NodeStore())
+	toString := td.ToTable.DebugString(context.Background(), td.ToTable.NodeStore())
+	_, _ = fromString, toString
 	hashChanged, err := td.HasHashChanged()
 	if err != nil {
 		return false, err

--- a/integration-tests/bats/sql-status.bats
+++ b/integration-tests/bats/sql-status.bats
@@ -175,7 +175,6 @@ SQL
 
     dolt add t1
 
-    dolt sql -r csv -q "select * from dolt_status;"
     run dolt sql -r csv -q "select * from dolt_status;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "t1,true,modified" ]] || false

--- a/integration-tests/bats/sql-status.bats
+++ b/integration-tests/bats/sql-status.bats
@@ -150,5 +150,33 @@ teardown() {
      run dolt sql -r csv -q "select * from dolt_status ORDER BY status"
      [ "$status" -eq 0 ]
      [[ "$output" =~ 'dolt_docs,false,conflict' ]] || false
-     [[ "$output" =~ 'dolt_docs,false,modified' ]] || false
+}
+
+@test "sql-status: tables with no observable changes don't show in status but can be staged" {
+dolt sql <<SQL
+create table t1 (id int primary key);
+insert into t1 values (1);
+SQL
+    dolt add -A && dolt commit -m "create table t1"
+    dolt sql <<SQL
+create table temp__t1 (id int primary key);
+insert into temp__t1 values (1);
+drop table t1;
+rename table temp__t1 to t1;
+SQL
+    dolt sql -q "select * from dolt_status;"
+    run dolt sql -q "select * from dolt_status;"
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 0 ]
+
+    run dolt diff t1
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 0 ]
+
+    dolt add t1
+
+    dolt sql -r csv -q "select * from dolt_status;"
+    run dolt sql -r csv -q "select * from dolt_status;"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "t1,true,modified" ]] || false
 }


### PR DESCRIPTION
Sometimes tables can change their hashes despite having no visible changes. The two ways I identified where this can happen are:

- The table has different column tags from the ancestor because it was originally a different table that got renamed.
- The table stores whether it's in a conflict and stores the hash of the other branch's table and the common ancestor table.

If these are the only changes to a table, we shouldn't report it as changed in `dolt status`.

These tables can still be staged and report as modified once staged.