### PR TITLE
Fixed issues with branch control

### DIFF
--- a/go/libraries/doltcore/branch_control/access.go
+++ b/go/libraries/doltcore/branch_control/access.go
@@ -78,6 +78,7 @@ func (tbl *Access) Match(database string, branch string, user string, host strin
 	for _, result := range results {
 		if result.Length > length {
 			perms = result.Permissions
+			length = result.Length
 		} else if result.Length == length {
 			perms |= result.Permissions
 		}
@@ -257,4 +258,17 @@ OuterLoop:
 		return iter.access.rows[idx], true
 	}
 	return AccessRow{}, false
+}
+
+// Consolidate reduces the permission set down to the most representative permission. For example, having both admin and
+// write permissions are equivalent to only having the admin permission. Additionally, having no permissions is
+// equivalent to only having the read permission.
+func (perm Permissions) Consolidate() Permissions {
+	if perm&Permissions_Admin == Permissions_Admin {
+		return Permissions_Admin
+	} else if perm&Permissions_Write == Permissions_Write {
+		return Permissions_Write
+	} else {
+		return Permissions_Read
+	}
 }

--- a/go/libraries/doltcore/branch_control/namespace.go
+++ b/go/libraries/doltcore/branch_control/namespace.go
@@ -88,6 +88,7 @@ func (tbl *Namespace) CanCreate(database string, branch string, user string, hos
 		matchedValue := tbl.Values[matched]
 		// If we've found a longer match, then we reset the slice. We append to it in the following if statement.
 		if len(matchedValue.Branch) > longest {
+			longest = len(matchedValue.Branch)
 			filteredIndexes = filteredIndexes[:0]
 		}
 		if len(matchedValue.Branch) >= longest {

--- a/integration-tests/bats/branch-control.bats
+++ b/integration-tests/bats/branch-control.bats
@@ -13,7 +13,7 @@ teardown() {
 }
 
 setup_test_user() {
-    dolt sql -q "create user test"
+    dolt sql -q "create user test identified by ''"
     dolt sql -q "grant all on *.* to test"
     dolt sql -q "delete from dolt_branch_control where user='%'"
 }
@@ -101,9 +101,9 @@ setup_test_user() {
     [ $status -ne 0 ]
     [[ $output =~ "does not have the correct permissions" ]] || false
 
-    dolt -u test sql -q "call dolt_checkout('test-branch'); create table t (c1 int)"
+    dolt -u test -p '' sql -q "call dolt_checkout('test-branch'); create table t (c1 int)"
 
-    dolt -u test sql -q "call dolt_checkout('test-branch'); call dolt_add('t'); call dolt_commit('-m', 'Testing commit');"
+    dolt -u test -p '' sql -q "call dolt_checkout('test-branch'); call dolt_add('t'); call dolt_commit('-m', 'Testing commit');"
 
     # I should also have branch permissions on branches I create
     dolt sql -q "call dolt_checkout('-b', 'test-branch-2'); create table t (c1 int)"
@@ -117,7 +117,7 @@ setup_test_user() {
 @test "branch-control: test admin permissions" {
     setup_test_user
 
-    dolt sql -q "create user test2"
+    dolt sql -q "create user test2 identified by ''"
     dolt sql -q "grant all on *.* to test2"
 
     dolt sql -q "insert into dolt_branch_control values ('dolt-repo-$$', 'test-branch', 'test', '%', 'admin')"
@@ -126,16 +126,16 @@ setup_test_user() {
     start_sql_server
     
     # Admin has no write permission to branch not an admin on
-    run dolt -u test sql -q "create table t (c1 int)"
+    run dolt -u test -p '' sql -q "create table t (c1 int)"
     [ $status -ne 0 ]
     [[ $output =~ "does not have the correct permissions" ]] || false
     
     # Admin can write
-    dolt -u test sql -q "call dolt_checkout('test-branch'); create table t (c1 int)"
+    dolt -u test -p '' sql -q "call dolt_checkout('test-branch'); create table t (c1 int)"
 
     # Admin can make other users
-    dolt -u test sql -q "insert into dolt_branch_control values ('dolt-repo-$$', 'test-branch', 'test2', '%', 'write')"
-    run dolt -u test sql --result-format csv -q "select * from dolt_branch_control"
+    dolt -u test -p '' sql -q "insert into dolt_branch_control values ('dolt-repo-$$', 'test-branch', 'test2', '%', 'write')"
+    run dolt -u test -p '' sql --result-format csv -q "select * from dolt_branch_control"
     [ $status -eq 0 ]
     [ ${lines[0]} = "database,branch,user,host,permissions" ]
     [ ${lines[1]} = "dolt-repo-$$,test-branch,test,%,admin" ]
@@ -143,7 +143,7 @@ setup_test_user() {
     [ ${lines[3]} = "dolt-repo-$$,test-branch,test2,%,write" ]
 
     # test2 can see all branch permissions
-    run dolt -u test2 sql --result-format csv -q "select * from dolt_branch_control"
+    run dolt -u test2 -p '' sql --result-format csv -q "select * from dolt_branch_control"
     [ $status -eq 0 ]
     [ ${lines[0]} = "database,branch,user,host,permissions" ]
     [ ${lines[1]} = "dolt-repo-$$,test-branch,test,%,admin" ]
@@ -151,18 +151,18 @@ setup_test_user() {
     [ ${lines[3]} = "dolt-repo-$$,test-branch,test2,%,write" ]
 
     # test2 now has write permissions on test-branch
-    dolt -u test2 sql -q "call dolt_checkout('test-branch'); insert into t values(0)"
+    dolt -u test2 -p '' sql -q "call dolt_checkout('test-branch'); insert into t values(0)"
 
     # Remove test2 permissions
-    dolt -u test sql -q "delete from dolt_branch_control where user='test2'"
+    dolt -u test -p '' sql -q "delete from dolt_branch_control where user='test2'"
 
-    run dolt -u test sql --result-format csv -q "select * from dolt_branch_control"
+    run dolt -u test -p '' sql --result-format csv -q "select * from dolt_branch_control"
     [ $status -eq 0 ]
     [ ${lines[0]} = "database,branch,user,host,permissions" ]
     [ ${lines[1]} = "dolt-repo-$$,test-branch,test,%,admin" ]
 
     # test2 cannot write to branch
-    run dolt -u test2 sql -q "call dolt_checkout('test-branch'); insert into t values(1)"
+    run dolt -u test2 -p '' sql -q "call dolt_checkout('test-branch'); insert into t values(1)"
     [ $status -ne 0 ]
     [[ $output =~ "does not have the correct permissions" ]] || false
 }
@@ -174,9 +174,9 @@ setup_test_user() {
 
     start_sql_server
 
-    dolt -u test sql -q "call dolt_branch('test-branch')"
+    dolt -u test -p '' sql -q "call dolt_branch('test-branch')"
 
-    run dolt -u test sql --result-format csv -q "select * from dolt_branch_control"
+    run dolt -u test -p '' sql --result-format csv -q "select * from dolt_branch_control"
     [ $status -eq 0 ]
     [ ${lines[0]} = "database,branch,user,host,permissions" ]
     [ ${lines[1]} = "dolt-repo-$$,main,test,%,write" ]
@@ -186,7 +186,7 @@ setup_test_user() {
 @test "branch-control: test branch namespace control" {
     setup_test_user
 
-    dolt sql -q "create user test2"
+    dolt sql -q "create user test2 identified by ''"
     dolt sql -q "grant all on *.* to test2"
 
     dolt sql -q "insert into dolt_branch_control values ('dolt-repo-$$', 'test-
@@ -195,24 +195,24 @@ branch', 'test', '%', 'admin')"
 
     start_sql_server
 
-    run dolt -u test sql --result-format csv -q "select * from dolt_branch_namespace_control"
+    run dolt -u test -p '' sql --result-format csv -q "select * from dolt_branch_namespace_control"
     [ $status -eq 0 ]
     [ ${lines[0]} = "database,branch,user,host" ]
     [ ${lines[1]} = "dolt-repo-$$,test-%,test2,%" ]
 
     # test cannot create test-branch
-    run dolt -u test sql -q "call dolt_branch('test-branch')"
+    run dolt -u test -p '' sql -q "call dolt_branch('test-branch')"
     [ $status -ne 0 ]
     [[ $output =~ "cannot create a branch" ]] || false
 
     # test2 can create test-branch
-    dolt -u test2 sql -q "call dolt_branch('test-branch')"
+    dolt -u test2 -p '' sql -q "call dolt_branch('test-branch')"
 }
 
 @test "branch-control: test longest match in branch namespace control" {
     setup_test_user
 
-    dolt sql -q "create user test2"
+    dolt sql -q "create user test2 identified by ''"
     dolt sql -q "grant all on *.* to test2"
 
     dolt sql -q "insert into dolt_branch_namespace_control values ('dolt-repo-$$', 'test/%', 'test', '%')"
@@ -220,21 +220,21 @@ branch', 'test', '%', 'admin')"
 
     start_sql_server
 
-    # test can create a branch in its namesapce but not in test2
-    dolt -u test sql -q "call dolt_branch('test/branch1')"
-    run dolt -u test sql -q "call dolt_branch('test2/branch1')"
+    # test can create a branch in its namespace but not in test2
+    dolt -u test -p '' sql -q "call dolt_branch('test/branch1')"
+    run dolt -u test -p '' sql -q "call dolt_branch('test2/branch1')"
     [ $status -ne 0 ]
     [[ $output =~ "cannot create a branch" ]] || false
 
-    dolt -u test2 sql -q "call dolt_branch('test2/branch1')"
-    run dolt -u test2 sql -q "call dolt_branch('test/branch1')"
+    dolt -u test2 -p '' sql -q "call dolt_branch('test2/branch1')"
+    run dolt -u test2 -p '' sql -q "call dolt_branch('test/branch1')"
     [ $status -ne 0 ]
     [[ $output =~ "cannot create a branch" ]] || false   
 }
 
 @test "branch-control: test longest match in branch access control" {
   setup_test_user
-  dolt sql -q "create user admin"
+  dolt sql -q "create user admin identified by ''"
   dolt sql -q "grant all on *.* to admin"
   dolt sql -q "insert into dolt_branch_control values ('%', '%', 'admin', '%', 'admin')"
 
@@ -244,13 +244,13 @@ branch', 'test', '%', 'admin')"
 
   start_sql_server
 
-  run dolt -u test sql -q "call dolt_checkout('test-branch'); create table t (c1 int)"
+  run dolt -u test -p '' sql -q "call dolt_checkout('test-branch'); create table t (c1 int)"
   [ $status -ne 0 ]
   [[ $output =~ "does not have the correct permissions" ]] || false
 
-  dolt -u admin sql -q "delete from dolt_branch_control where branch = 'test-branch'"
+  dolt -u admin -p '' sql -q "delete from dolt_branch_control where branch = 'test-branch'"
 
-  run dolt -u test sql -q "call dolt_checkout('test-branch'); create table t (c1 int)"
+  run dolt -u test -p '' sql -q "call dolt_checkout('test-branch'); create table t (c1 int)"
   [ $status -eq 0 ]
   [[ ! $output =~ "does not have the correct permissions" ]] || false
 }
@@ -294,4 +294,65 @@ SQL
   run dolt sql -q "DELETE FROM dolt_branch_control;"
   [ $status -eq 0 ]
   [[ $output =~ "0 rows affected" ]] || false
+}
+
+@test "branch-control: Issue #8622 ttask" {
+  # https://github.com/dolthub/dolt/issues/8622
+  dolt sql <<SQL
+CREATE DATABASE t;
+CREATE USER IF NOT EXISTS 'tadmin'@'%' IDENTIFIED BY 't';
+CREATE USER IF NOT EXISTS 'ttask'@'%' IDENTIFIED BY 't';
+GRANT ALL ON t.* TO 'tadmin'@'%';
+GRANT ALL ON t.* TO 'ttask'@'%';
+INSERT INTO t.dolt_branch_namespace_control (database, branch, user, host) VALUES ('t', '%', '', '');
+INSERT INTO t.dolt_branch_namespace_control (database, branch, user, host) VALUES ('t', 'task%', 'ttask', '%');
+INSERT INTO t.dolt_branch_namespace_control (database, branch, user, host) VALUES ('t', '%', 'tadmin', '%');
+SQL
+  run dolt -u ttask -p t --use-db t sql -q "CALL DOLT_BRANCH('task_feature');"
+  [ $status -eq 0 ]
+  [[ ! $output =~ "cannot create" ]] || false
+}
+
+@test "branch-control: Issue #8622 tadmin" {
+  # https://github.com/dolthub/dolt/issues/8622
+  dolt sql <<SQL
+CREATE DATABASE t;
+CREATE USER IF NOT EXISTS 'tadmin'@'%' IDENTIFIED BY 't';
+CREATE USER IF NOT EXISTS 'ttask'@'%' IDENTIFIED BY 't';
+GRANT ALL ON t.* TO 'tadmin'@'%';
+GRANT ALL ON t.* TO 'ttask'@'%';
+INSERT INTO t.dolt_branch_namespace_control (database, branch, user, host) VALUES ('t', '%', '', '');
+INSERT INTO t.dolt_branch_namespace_control (database, branch, user, host) VALUES ('t', 'task%', 'ttask', '%');
+INSERT INTO t.dolt_branch_namespace_control (database, branch, user, host) VALUES ('t', '%', 'tadmin', '%');
+SQL
+  run dolt -u tadmin -p t --use-db t sql -q "CALL DOLT_BRANCH('task_feature');"
+  [ $status -ne 0 ]
+  [[ $output =~ "cannot create a branch" ]] || false
+}
+
+@test "branch-control: Issue #8623" {
+  # https://github.com/dolthub/dolt/issues/8623
+  dolt sql <<SQL
+CREATE DATABASE t;
+CREATE USER 'ttask'@'%' IDENTIFIED BY 't';
+GRANT ALL ON t.* TO 'ttask'@'%';
+SELECT * FROM t.dolt_branch_control;
+INSERT INTO t.dolt_branch_control (database, branch, user, host, permissions) VALUES ('t', 'task%', 'ttask', '%', 'admin');
+USE t;
+CALL DOLT_BRANCH('task_feature');
+SQL
+  # First we'll ensure that DOLT_ADD works when connecting to the database and using DOLT_CHECKOUT first
+  run dolt -u ttask -p t sql -r=json -q "USE t;CALL DOLT_CHECKOUT('task_feature');SELECT database(), active_branch();"
+  [ $status -eq 0 ]
+  [[ $output =~ '{"active_branch()":"task_feature","database()":"t"}' ]] || false
+  run dolt -u ttask -p t sql -q "USE t;CALL DOLT_CHECKOUT('task_feature');CALL DOLT_ADD('-A');"
+  [ $status -eq 0 ]
+  [[ ! $output =~ "does not have the correct permissions" ]] || false
+  # Next we'll ensure that DOLT_ADD works when connecting to the branch directly, without using DOLT_CHECKOUT
+  run dolt -u ttask -p t sql -r=json -q "USE t/task_feature;SELECT database(), active_branch();"
+  [ $status -eq 0 ]
+  [[ $output =~ '{"active_branch()":"task_feature","database()":"t/task_feature"}' ]] || false
+  run dolt -u ttask -p t sql -q "USE t/task_feature;CALL DOLT_ADD('-A');"
+  [ $status -eq 0 ]
+  [[ ! $output =~ "cannot create" ]] || false
 }

--- a/integration-tests/bats/helper/query-server-common.bash
+++ b/integration-tests/bats/helper/query-server-common.bash
@@ -1,3 +1,4 @@
+load helper/windows-compat
 SERVER_REQS_INSTALLED="FALSE"
 SERVER_PID=""
 DEFAULT_DB=""
@@ -38,9 +39,17 @@ start_sql_server() {
     PORT=$( definePORT )
     if [[ $logFile ]]
     then
-        dolt sql-server --host 0.0.0.0 --port=$PORT --user "${SQL_USER:-dolt}" --socket "dolt.$PORT.sock" > $logFile 2>&1 &
+        if [ "$IS_WINDOWS" == true ]; then
+          dolt sql-server --host 0.0.0.0 --port=$PORT --user "${SQL_USER:-dolt}" > $logFile 2>&1 &
+        else
+          dolt sql-server --host 0.0.0.0 --port=$PORT --user "${SQL_USER:-dolt}" --socket "dolt.$PORT.sock" > $logFile 2>&1 &
+        fi
     else
-        dolt sql-server --host 0.0.0.0 --port=$PORT --user "${SQL_USER:-dolt}" --socket "dolt.$PORT.sock" &
+        if [ "$IS_WINDOWS" == true ]; then
+          dolt sql-server --host 0.0.0.0 --port=$PORT --user "${SQL_USER:-dolt}" &
+        else
+          dolt sql-server --host 0.0.0.0 --port=$PORT --user "${SQL_USER:-dolt}" --socket "dolt.$PORT.sock" &
+        fi
     fi
     echo db:$DEFAULT_DB logFile:$logFile PORT:$PORT CWD:$PWD
     SERVER_PID=$!
@@ -53,7 +62,11 @@ start_sql_server() {
 start_sql_server_with_args() {
     DEFAULT_DB=""
     PORT=$( definePORT )
-    dolt sql-server "$@" --port=$PORT --socket "dolt.$PORT.sock" &
+    if [ "$IS_WINDOWS" == true ]; then
+      dolt sql-server "$@" --port=$PORT &
+    else
+      dolt sql-server "$@" --port=$PORT --socket "dolt.$PORT.sock" &
+    fi
     SERVER_PID=$!
     wait_for_connection $PORT 8500
 }
@@ -76,7 +89,11 @@ behavior:
   autocommit: false
 " > .cliconfig.yaml
     cat "$2" >> .cliconfig.yaml
-    dolt sql-server --config .cliconfig.yaml --socket "dolt.$PORT.sock" &
+    if [ "$IS_WINDOWS" == true ]; then
+      dolt sql-server --config .cliconfig.yaml &
+    else
+      dolt sql-server --config .cliconfig.yaml --socket "dolt.$PORT.sock" &
+    fi
     SERVER_PID=$!
     wait_for_connection $PORT 8500
 }
@@ -98,7 +115,11 @@ listener:
 behavior:
   autocommit: false
 " > .cliconfig.yaml
-    dolt sql-server --config .cliconfig.yaml --socket "dolt.$PORT.sock" &
+    if [ "$IS_WINDOWS" == true ]; then
+      dolt sql-server --config .cliconfig.yaml &
+    else
+      dolt sql-server --config .cliconfig.yaml --socket "dolt.$PORT.sock" &
+    fi
     SERVER_PID=$!
     wait_for_connection $PORT 8500
 }
@@ -106,7 +127,11 @@ behavior:
 start_multi_db_server() {
     DEFAULT_DB="$1"
     PORT=$( definePORT )
-    dolt sql-server --host 0.0.0.0 --port=$PORT --user dolt --data-dir ./ --socket "dolt.$PORT.sock" &
+    if [ "$IS_WINDOWS" == true ]; then
+      dolt sql-server --host 0.0.0.0 --port=$PORT --user dolt --data-dir ./ &
+    else
+      dolt sql-server --host 0.0.0.0 --port=$PORT --user dolt --data-dir ./ --socket "dolt.$PORT.sock" &
+    fi
     SERVER_PID=$!
     wait_for_connection $PORT 8500
 }


### PR DESCRIPTION
This is primarily to fix issues with:
* https://github.com/dolthub/dolt/issues/8622
* https://github.com/dolthub/dolt/issues/8623

For the first issue, we did not actually update the longest match counter, and it was therefore being ignored. The variable existed, but it was not being updated. I think this went so long without being caught (even with all of the tests in `enginetests` and `bats`) due to how we handle expression folding, where subset entries are completely ignored if a superset already exists.

The second issue is somewhat similar to the first, in that we were not checking the permission set when determining whether a new row is actually a subset. If an existing row is a superset, but the permissions are more restrictive than the new row, then it's _not an actual superset_, since it has more restrictive permissions. This is even in the documentation, so it's a simple mistake of forgetting to add that check to the code itself.

Lastly, the `bats` tests have been updated such that they rely on sockets now, and Windows does not support sockets. This was not caught since most Windows developers have moved to primary development on [Doltgres](https://github.com/dolthub/doltgresql), so this at least allows such developers to run the `bats` tests locally again.