### PR TITLE
Give a little more information in dolt_diff_* when there is a pk change

### DIFF
--- a/go/libraries/doltcore/sqle/dtables/commit_diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/commit_diff_table.go
@@ -216,7 +216,7 @@ func (dt *CommitDiffTable) LookupPartitions(ctx *sql.Context, i sql.IndexLookup)
 		fromSch:  dt.targetSchema,
 	}
 
-	isDiffable, err := dp.isDiffablePartition(ctx)
+	isDiffable, _, err := dp.isDiffablePartition(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/dtables/diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/diff_table.go
@@ -684,7 +684,9 @@ func (dp DiffPartition) GetRowIter(ctx *sql.Context, ddb *doltdb.DoltDB, joiner 
 
 // isDiffablePartition checks if the commit pair for this partition is "diffable".
 // If the primary key sets changed between the two commits, it may not be
-// possible to diff them.
+// possible to diff them. We return two bools: simpleDiff is returned if the primary key sets are close enough that we
+// can confidently merge the diff (using schema.ArePrimaryKeySetsDiffable). fuzzyDiff is returned if the primary key
+// sets are not close enough to merge the diff, but we can still make an approximate comparison (using schema.MapSchemaBasedOnTagAndName).
 func (dp *DiffPartition) isDiffablePartition(ctx *sql.Context) (simpleDiff bool, fuzzyDiff bool, err error) {
 	// dp.to is nil when a table has been deleted previously. In this case, we return
 	// false, to stop processing diffs, since that previously deleted table is considered

--- a/go/libraries/doltcore/sqle/dtables/prolly_row_conv.go
+++ b/go/libraries/doltcore/sqle/dtables/prolly_row_conv.go
@@ -115,10 +115,14 @@ func (c ProllyRowConverter) putFields(ctx context.Context, tup val.Tuple, proj v
 	virtualOffset := 0
 	for i, j := range proj {
 		if j == -1 {
-			// Skip over virtual columns in non-pk cols as they are not stored
-			if !isPk && c.inSchema.GetNonPKCols().GetByIndex(i).Virtual {
-				virtualOffset++
+			nonPkCols := c.inSchema.GetNonPKCols()
+			if len(nonPkCols.GetColumns()) > i {
+				// Skip over virtual columns in non-pk cols as they are not stored
+				if !isPk && nonPkCols.GetByIndex(i).Virtual {
+					virtualOffset++
+				}
 			}
+
 			continue
 		}
 

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -559,7 +559,6 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 				Expected: []sql.Row{
 					{42, 23, nil, nil, "added"},
 					{nil, nil, nil, 23, "removed"},
-					{nil, 23, nil, nil, "added"},
 				},
 				ExpectedWarningsCount:           1,
 				ExpectedWarning:                 1105,
@@ -747,7 +746,6 @@ var Dolt1DiffSystemTableScripts = []queries.ScriptTest{
 				Query: "SELECT to_pk1, to_pk2, from_pk1, from_pk2, diff_type from dolt_diff_t;",
 				Expected: []sql.Row{
 					{"2", "2", nil, nil, "added"},
-					{"1", "1", nil, nil, "added"},
 				},
 			},
 		},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -127,7 +127,7 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "SELECT COUNT(*) FROM DOLT_DIFF_t",
-				Expected: []sql.Row{{2}},
+				Expected: []sql.Row{{4}},
 			},
 			{
 				Query: "SELECT to_pk, to_c, from_pk, from_c, diff_type FROM DOLT_DIFF_t WHERE TO_COMMIT=@Commit3 ORDER BY to_pk;",
@@ -528,11 +528,36 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 			},
 			{
 				Query:    "SELECT COUNT(*) FROM DOLT_DIFF_t;",
-				Expected: []sql.Row{{1}},
+				Expected: []sql.Row{{7}},
 			},
 			{
 				Query:    "SELECT to_pk, to_c1, from_pk, from_c1, diff_type FROM DOLT_DIFF_t where to_commit=@Commit4;",
 				Expected: []sql.Row{{7, 8, nil, nil, "added"}},
+			},
+		},
+	},
+	{
+		// Similar to previous test, but with one row to avoid ordering issues.
+		Name: "altered keyless table add pk with removed", // https://github.com/dolthub/dolt/issues/8625
+		SetUpScript: []string{
+			"create table tbl (i int, j int);",
+			"insert into tbl values (42, 23);",
+			"call dolt_commit('-Am', 'commit1');",
+			"alter table tbl add primary key(i);",
+			"call dolt_commit('-am', 'commit2');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "SELECT to_i,to_j,from_i,from_j,diff_type  FROM dolt_diff_tbl;",
+				// Output in the situation is admittedly wonky. Updating the PK leaves in a place where we can't really render
+				// the diff, but we want to show something. In the past we just returned an empty set in this case. The
+				// warning is kind of essential to understand what is happening.
+				Expected: []sql.Row{
+					{42, 23, nil, nil, "added"},
+					{nil, nil, nil, 23, "removed"},
+				},
+				ExpectedWarning:                 1105,
+				ExpectedWarningMessageSubstring: "due to primary key set change",
 			},
 		},
 	},
@@ -5298,6 +5323,7 @@ var CommitDiffSystemTableScriptTests = []queries.ScriptTest{
 			},
 		},
 	},
+
 	{
 		Name: "added and dropped table",
 		SetUpScript: []string{

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -127,7 +127,7 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "SELECT COUNT(*) FROM DOLT_DIFF_t",
-				Expected: []sql.Row{{4}},
+				Expected: []sql.Row{{2}},
 			},
 			{
 				Query: "SELECT to_pk, to_c, from_pk, from_c, diff_type FROM DOLT_DIFF_t WHERE TO_COMMIT=@Commit3 ORDER BY to_pk;",
@@ -550,11 +550,16 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 			{
 				Query: "SELECT to_i,to_j,from_i,from_j,diff_type  FROM dolt_diff_tbl;",
 				// Output in the situation is admittedly wonky. Updating the PK leaves in a place where we can't really render
-				// the diff, but we want to show something. In the past we just returned an empty set in this case. The
+				// the diff, but we want to show something. In this case, the 'pk' column tag changes, so in the last two rows
+				// of the output you see we add "nil,23" and remove "nil,23" when in fact those columns were "42" with a different
+				// tag.
+				//
+				// In the past we just returned an empty set in this case. The
 				// warning is kind of essential to understand what is happening.
 				Expected: []sql.Row{
 					{42, 23, nil, nil, "added"},
 					{nil, nil, nil, 23, "removed"},
+					{nil, 23, nil, nil, "added"},
 				},
 				ExpectedWarning:                 1105,
 				ExpectedWarningMessageSubstring: "due to primary key set change",
@@ -738,8 +743,11 @@ var Dolt1DiffSystemTableScripts = []queries.ScriptTest{
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
-				Query:    "SELECT to_pk1, to_pk2, from_pk1, from_pk2, diff_type from dolt_diff_t;",
-				Expected: []sql.Row{{"2", "2", nil, nil, "added"}},
+				Query: "SELECT to_pk1, to_pk2, from_pk1, from_pk2, diff_type from dolt_diff_t;",
+				Expected: []sql.Row{
+					{"2", "2", nil, nil, "added"},
+					{"1", "1", nil, nil, "added"},
+				},
 			},
 		},
 	},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -538,7 +538,7 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 	},
 	{
 		// Similar to previous test, but with one row to avoid ordering issues.
-		Name: "altered keyless table add pk with removed", // https://github.com/dolthub/dolt/issues/8625
+		Name: "altered keyless table add pk", // https://github.com/dolthub/dolt/issues/8625
 		SetUpScript: []string{
 			"create table tbl (i int, j int);",
 			"insert into tbl values (42, 23);",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -561,6 +561,7 @@ var DiffSystemTableScriptTests = []queries.ScriptTest{
 					{nil, nil, nil, 23, "removed"},
 					{nil, 23, nil, nil, "added"},
 				},
+				ExpectedWarningsCount:           1,
 				ExpectedWarning:                 1105,
 				ExpectedWarningMessageSubstring: "due to primary key set change",
 			},


### PR DESCRIPTION
This change makes the dolt_diff_* system table a little more forgiving when schema changes occur that we can _kind of_ map from one commit to the next. In the case of the issue, adding a primary key to a key keyless table. This doesn't work in both directions though - if you can't map the schema, we stop walking history (same as before).

Minor bump required due to behavior of the dolt_diff_* table changing are a result of this change.

Fixes: https://github.com/dolthub/dolt/issues/8625