### PR TITLE
Fix for updated issue 8623

### DIFF
--- a/integration-tests/bats/branch-control.bats
+++ b/integration-tests/bats/branch-control.bats
@@ -333,6 +333,11 @@ SQL
 @test "branch-control: Issue #8623" {
   # https://github.com/dolthub/dolt/issues/8623
   dolt sql <<SQL
+DELETE FROM dolt_branch_namespace_control WHERE true;
+DELETE FROM dolt_branch_control WHERE true;
+DROP USER IF EXISTS 'tadmin'@'%';
+DROP USER IF EXISTS 'ttask'@'%';
+DROP DATABASE IF EXISTS t;
 CREATE DATABASE t;
 CREATE USER 'ttask'@'%' IDENTIFIED BY 't';
 GRANT ALL ON t.* TO 'ttask'@'%';


### PR DESCRIPTION
This is an actual fix for the following issue. Additional information was added, which actually exposes the root issue at hand. It's possible for the db/revision combo to make it to branch control, which expects just the branch name (since the revision is given under "branch"). This adds the proper split, so that we always get the database name.
* https://github.com/dolthub/dolt/issues/8623