### PR TITLE
Enable larger statements for dolt_procedures

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_procedure_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_procedure_queries.go
@@ -409,4 +409,44 @@ end
 			},
 		},
 	},
+
+	{
+		Name: "create and call procedure which exceeds 1024 bytes",
+		SetUpScript: []string{
+			`CREATE PROCEDURE long_proc()
+BEGIN
+  DECLARE long_text TEXT;
+  SET long_text = CONCAT(
+			'Lorem ipsum dolor sit amet, consectetur adipiscing elit. ',
+			'Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ',
+			'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris ',
+			'nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in ',
+			'reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. ',
+			'Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia ',
+			'deserunt mollit anim id est laborum.',
+			'Lorem ipsum dolor sit amet, consectetur adipiscing elit. ',
+			'Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ',
+			'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris ',
+			'nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in ',
+			'reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. ',
+			'Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia ',
+			'deserunt mollit anim id est laborum.',
+			'Lorem ipsum dolor sit amet, consectetur adipiscing elit. ',
+			'Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ',
+			'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris ',
+			'nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in ',
+			'reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. ',
+			'Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia ',
+			'deserunt mollit anim id est laborum.');
+  SELECT SHA2(long_text,256) AS checksum, LENGTH(long_text) AS length;
+END
+`,
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "call long_proc();",
+				Expected: []sql.Row{{"a702e99e5ee2dc03095bb2efd58e28330b6ea085d036249de82977a5c0dbb4be", 1335}},
+			},
+		},
+	},
 }

--- a/go/libraries/doltcore/sqle/procedures_table.go
+++ b/go/libraries/doltcore/sqle/procedures_table.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
 	"github.com/dolthub/go-mysql-server/sql"
 	gmstypes "github.com/dolthub/go-mysql-server/sql/types"
 	"github.com/dolthub/vitess/go/sqltypes"
@@ -28,6 +27,7 @@ import (
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dtables"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/index"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlutil"

--- a/go/libraries/doltcore/sqle/procedures_table.go
+++ b/go/libraries/doltcore/sqle/procedures_table.go
@@ -133,7 +133,8 @@ func ProceduresTableSqlSchema() sql.PrimaryKeySchema {
 
 // The fixed dolt schema for the `dolt_procedures` table.
 func ProceduresTableSchema() schema.Schema {
-	t, err := gmstypes.CreateStringWithDefaults(sqltypes.VarChar, typeinfo.MaxVarcharLength)
+	// Max len is 8K - big enough to be useful, but not too big to exceed max total row len of 64K.
+	t, err := gmstypes.CreateStringWithDefaults(sqltypes.VarChar, typeinfo.MaxVarcharLength/2)
 	if err != nil {
 		panic(err) // should never happen. All constants.
 	}


### PR DESCRIPTION
Increase the supported stored procedure length from 1K to 8K.