### PR TITLE
Removed the `performance` server config block

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/command_line_config.go
+++ b/go/cmd/dolt/commands/sqlserver/command_line_config.go
@@ -41,7 +41,6 @@ type commandLineServerConfig struct {
 	autoCommit              bool
 	doltTransactionCommit   bool
 	maxConnections          uint64
-	queryParallelism        int
 	tlsKey                  string
 	tlsCert                 string
 	requireSecureTransport  bool
@@ -71,7 +70,6 @@ func DefaultCommandLineServerConfig() *commandLineServerConfig {
 		logLevel:                servercfg.DefaultLogLevel,
 		autoCommit:              servercfg.DefaultAutoCommit,
 		maxConnections:          servercfg.DefaultMaxConnections,
-		queryParallelism:        servercfg.DefaultQueryParallelism,
 		dataDir:                 servercfg.DefaultDataDir,
 		cfgDir:                  filepath.Join(servercfg.DefaultDataDir, servercfg.DefaultCfgDir),
 		privilegeFilePath:       filepath.Join(servercfg.DefaultDataDir, servercfg.DefaultCfgDir, servercfg.DefaultPrivilegeFilePath),
@@ -150,10 +148,6 @@ func NewCommandLineConfig(creds *cli.UserPassword, apr *argparser.ArgParseResult
 		config.withDataDir(dataDir)
 	}
 
-	if queryParallelism, ok := apr.GetInt(queryParallelismFlag); ok {
-		config.withQueryParallelism(queryParallelism)
-	}
-
 	if maxConnections, ok := apr.GetInt(maxConnectionsFlag); ok {
 		config.withMaxConnections(uint64(maxConnections))
 	}
@@ -228,11 +222,6 @@ func (cfg *commandLineServerConfig) DoltTransactionCommit() bool {
 // MaxConnections returns the maximum number of simultaneous connections the server will allow.  The default is 1
 func (cfg *commandLineServerConfig) MaxConnections() uint64 {
 	return cfg.maxConnections
-}
-
-// QueryParallelism returns the parallelism that should be used by the go-mysql-server analyzer
-func (cfg *commandLineServerConfig) QueryParallelism() int {
-	return cfg.queryParallelism
 }
 
 // TLSKey returns a path to the servers PEM-encoded private TLS key. "" if there is none.
@@ -388,12 +377,6 @@ func (cfg *commandLineServerConfig) withLogLevel(loglevel servercfg.LogLevel) *c
 func (cfg *commandLineServerConfig) withMaxConnections(maxConnections uint64) *commandLineServerConfig {
 	cfg.maxConnections = maxConnections
 	cfg.valuesSet[servercfg.MaxConnectionsKey] = struct{}{}
-	return cfg
-}
-
-// withQueryParallelism updates the query parallelism and returns the called `*commandLineServerConfig`, which is useful for chaining calls.
-func (cfg *commandLineServerConfig) withQueryParallelism(queryParallelism int) *commandLineServerConfig {
-	cfg.queryParallelism = queryParallelism
 	return cfg
 }
 

--- a/go/libraries/doltcore/servercfg/serverconfig.go
+++ b/go/libraries/doltcore/servercfg/serverconfig.go
@@ -50,7 +50,6 @@ const (
 	DefaultAutoCommit              = true
 	DefaultDoltTransactionCommit   = false
 	DefaultMaxConnections          = 100
-	DefaultQueryParallelism        = 0
 	DefaultDataDir                 = "."
 	DefaultCfgDir                  = ".doltcfg"
 	DefaultPrivilegeFilePath       = "privileges.db"
@@ -147,8 +146,6 @@ type ServerConfig interface {
 	CfgDir() string
 	// MaxConnections returns the maximum number of simultaneous connections the server will allow.  The default is 1
 	MaxConnections() uint64
-	// QueryParallelism returns the parallelism that should be used by the go-mysql-server analyzer
-	QueryParallelism() int
 	// TLSKey returns a path to the servers PEM-encoded private TLS key. "" if there is none.
 	TLSKey() string
 	// TLSCert returns a path to the servers PEM-encoded TLS certificate chain. "" if there is none.
@@ -224,7 +221,7 @@ func DefaultServerConfig() ServerConfig {
 			WriteTimeoutMillis:      ptr(uint64(DefaultTimeout)),
 			AllowCleartextPasswords: ptr(DefaultAllowCleartextPasswords),
 		},
-		PerformanceConfig: PerformanceYAMLConfig{QueryParallelism: ptr(DefaultQueryParallelism)},
+		PerformanceConfig: PerformanceYAMLConfig{},
 		DataDirStr:        ptr(DefaultDataDir),
 		CfgDirStr:         ptr(filepath.Join(DefaultDataDir, DefaultCfgDir)),
 		PrivilegeFile:     ptr(filepath.Join(DefaultDataDir, DefaultCfgDir, DefaultPrivilegeFilePath)),

--- a/go/libraries/doltcore/servercfg/serverconfig.go
+++ b/go/libraries/doltcore/servercfg/serverconfig.go
@@ -221,7 +221,6 @@ func DefaultServerConfig() ServerConfig {
 			WriteTimeoutMillis:      ptr(uint64(DefaultTimeout)),
 			AllowCleartextPasswords: ptr(DefaultAllowCleartextPasswords),
 		},
-		PerformanceConfig: PerformanceYAMLConfig{},
 		DataDirStr:        ptr(DefaultDataDir),
 		CfgDirStr:         ptr(filepath.Join(DefaultDataDir, DefaultCfgDir)),
 		PrivilegeFile:     ptr(filepath.Join(DefaultDataDir, DefaultCfgDir, DefaultPrivilegeFilePath)),

--- a/go/libraries/doltcore/servercfg/testdata/minver_validation.txt
+++ b/go/libraries/doltcore/servercfg/testdata/minver_validation.txt
@@ -26,7 +26,7 @@ ListenerConfig servercfg.ListenerYAMLConfig 0.0.0 listener
 -AllowCleartextPasswords *bool 0.0.0 allow_cleartext_passwords
 -Socket *string 0.0.0 socket,omitempty
 PerformanceConfig servercfg.PerformanceYAMLConfig 0.0.0 performance
--QueryParallelism *int 0.0.0 query_parallelism
+-QueryParallelism *int 0.0.0 query_parallelism,omitempty
 DataDirStr *string 0.0.0 data_dir,omitempty
 CfgDirStr *string 0.0.0 cfg_dir,omitempty
 MetricsConfig servercfg.MetricsYAMLConfig 0.0.0 metrics

--- a/go/libraries/doltcore/servercfg/testdata/minver_validation.txt
+++ b/go/libraries/doltcore/servercfg/testdata/minver_validation.txt
@@ -25,7 +25,7 @@ ListenerConfig servercfg.ListenerYAMLConfig 0.0.0 listener
 -RequireSecureTransport *bool 0.0.0 require_secure_transport
 -AllowCleartextPasswords *bool 0.0.0 allow_cleartext_passwords
 -Socket *string 0.0.0 socket,omitempty
-PerformanceConfig servercfg.PerformanceYAMLConfig 0.0.0 performance
+PerformanceConfig *servercfg.PerformanceYAMLConfig 0.0.0 performance,omitempty
 -QueryParallelism *int 0.0.0 query_parallelism,omitempty
 DataDirStr *string 0.0.0 data_dir,omitempty
 CfgDirStr *string 0.0.0 cfg_dir,omitempty

--- a/go/libraries/doltcore/servercfg/yaml_config.go
+++ b/go/libraries/doltcore/servercfg/yaml_config.go
@@ -94,7 +94,8 @@ type ListenerYAMLConfig struct {
 
 // PerformanceYAMLConfig contains configuration parameters for performance tweaking
 type PerformanceYAMLConfig struct {
-	QueryParallelism *int `yaml:"query_parallelism"`
+	// QueryParallelism is deprecated but still present to prevent breaking YAML config that still uses it
+	QueryParallelism *int `yaml:"query_parallelism,omitempty"`
 }
 
 type MetricsYAMLConfig struct {
@@ -202,9 +203,7 @@ func ServerConfigAsYAMLConfig(cfg ServerConfig) *YAMLConfig {
 			AllowCleartextPasswords: nillableBoolPtr(cfg.AllowCleartextPasswords()),
 			Socket:                  nillableStrPtr(cfg.Socket()),
 		},
-		PerformanceConfig: PerformanceYAMLConfig{
-			QueryParallelism: nillableIntPtr(cfg.QueryParallelism()),
-		},
+		PerformanceConfig: PerformanceYAMLConfig{},
 		DataDirStr: ptr(cfg.DataDir()),
 		CfgDirStr:  ptr(cfg.CfgDir()),
 		MetricsConfig: MetricsYAMLConfig{
@@ -473,15 +472,6 @@ func (cfg YAMLConfig) AllowCleartextPasswords() bool {
 		return DefaultAllowCleartextPasswords
 	}
 	return *cfg.ListenerConfig.AllowCleartextPasswords
-}
-
-// QueryParallelism returns the parallelism that should be used by the go-mysql-server analyzer
-func (cfg YAMLConfig) QueryParallelism() int {
-	if cfg.PerformanceConfig.QueryParallelism == nil {
-		return DefaultQueryParallelism
-	}
-
-	return *cfg.PerformanceConfig.QueryParallelism
 }
 
 // TLSKey returns a path to the servers PEM-encoded private TLS key. "" if there is none.

--- a/go/libraries/doltcore/servercfg/yaml_config.go
+++ b/go/libraries/doltcore/servercfg/yaml_config.go
@@ -130,7 +130,7 @@ type YAMLConfig struct {
 	BehaviorConfig    BehaviorYAMLConfig    `yaml:"behavior"`
 	UserConfig        UserYAMLConfig        `yaml:"user"`
 	ListenerConfig    ListenerYAMLConfig    `yaml:"listener"`
-	PerformanceConfig PerformanceYAMLConfig `yaml:"performance"`
+	PerformanceConfig *PerformanceYAMLConfig `yaml:"performance,omitempty"`
 	DataDirStr        *string               `yaml:"data_dir,omitempty"`
 	CfgDirStr         *string               `yaml:"cfg_dir,omitempty"`
 	MetricsConfig     MetricsYAMLConfig     `yaml:"metrics"`
@@ -203,7 +203,6 @@ func ServerConfigAsYAMLConfig(cfg ServerConfig) *YAMLConfig {
 			AllowCleartextPasswords: nillableBoolPtr(cfg.AllowCleartextPasswords()),
 			Socket:                  nillableStrPtr(cfg.Socket()),
 		},
-		PerformanceConfig: PerformanceYAMLConfig{},
 		DataDirStr: ptr(cfg.DataDir()),
 		CfgDirStr:  ptr(cfg.CfgDir()),
 		MetricsConfig: MetricsYAMLConfig{

--- a/go/libraries/doltcore/servercfg/yaml_config.go
+++ b/go/libraries/doltcore/servercfg/yaml_config.go
@@ -124,20 +124,20 @@ type UserSessionVars struct {
 
 // YAMLConfig is a ServerConfig implementation which is read from a yaml file
 type YAMLConfig struct {
-	LogLevelStr       *string               `yaml:"log_level,omitempty"`
-	MaxQueryLenInLogs *int                  `yaml:"max_logged_query_len,omitempty"`
-	EncodeLoggedQuery *bool                 `yaml:"encode_logged_query,omitempty"`
-	BehaviorConfig    BehaviorYAMLConfig    `yaml:"behavior"`
-	UserConfig        UserYAMLConfig        `yaml:"user"`
-	ListenerConfig    ListenerYAMLConfig    `yaml:"listener"`
+	LogLevelStr       *string                `yaml:"log_level,omitempty"`
+	MaxQueryLenInLogs *int                   `yaml:"max_logged_query_len,omitempty"`
+	EncodeLoggedQuery *bool                  `yaml:"encode_logged_query,omitempty"`
+	BehaviorConfig    BehaviorYAMLConfig     `yaml:"behavior"`
+	UserConfig        UserYAMLConfig         `yaml:"user"`
+	ListenerConfig    ListenerYAMLConfig     `yaml:"listener"`
 	PerformanceConfig *PerformanceYAMLConfig `yaml:"performance,omitempty"`
-	DataDirStr        *string               `yaml:"data_dir,omitempty"`
-	CfgDirStr         *string               `yaml:"cfg_dir,omitempty"`
-	MetricsConfig     MetricsYAMLConfig     `yaml:"metrics"`
-	RemotesapiConfig  RemotesapiYAMLConfig  `yaml:"remotesapi"`
-	ClusterCfg        *ClusterYAMLConfig    `yaml:"cluster,omitempty"`
-	PrivilegeFile     *string               `yaml:"privilege_file,omitempty"`
-	BranchControlFile *string               `yaml:"branch_control_file,omitempty"`
+	DataDirStr        *string                `yaml:"data_dir,omitempty"`
+	CfgDirStr         *string                `yaml:"cfg_dir,omitempty"`
+	MetricsConfig     MetricsYAMLConfig      `yaml:"metrics"`
+	RemotesapiConfig  RemotesapiYAMLConfig   `yaml:"remotesapi"`
+	ClusterCfg        *ClusterYAMLConfig     `yaml:"cluster,omitempty"`
+	PrivilegeFile     *string                `yaml:"privilege_file,omitempty"`
+	BranchControlFile *string                `yaml:"branch_control_file,omitempty"`
 	// TODO: Rename to UserVars_
 	Vars            []UserSessionVars      `yaml:"user_session_vars"`
 	SystemVars_     map[string]interface{} `yaml:"system_variables,omitempty" minver:"1.11.1"`


### PR DESCRIPTION
Its only member was 'query_parallelism`, which was unused. Existing config files with this key will still parse.