### PR TITLE
parse user vars as `interface{}` instead of always `string`

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -903,7 +903,7 @@ func portInUse(hostPort string) bool {
 }
 
 func newSessionBuilder(se *engine.SqlEngine, config servercfg.ServerConfig) server.SessionBuilder {
-	userToSessionVars := make(map[string]map[string]string)
+	userToSessionVars := make(map[string]map[string]interface{})
 	userVars := config.UserVars()
 	for _, curr := range userVars {
 		userToSessionVars[curr.Name] = curr.Vars

--- a/go/libraries/doltcore/servercfg/testdata/minver_validation.txt
+++ b/go/libraries/doltcore/servercfg/testdata/minver_validation.txt
@@ -54,7 +54,7 @@ PrivilegeFile *string 0.0.0 privilege_file,omitempty
 BranchControlFile *string 0.0.0 branch_control_file,omitempty
 Vars []servercfg.UserSessionVars 0.0.0 user_session_vars
 -Name string 0.0.0 name
--Vars map[string]string 0.0.0 vars
+-Vars map[string]interface{} 0.0.0 vars
 SystemVars_ map[string]interface{} 1.11.1 system_variables,omitempty
 Jwks []servercfg.JwksConfig 0.0.0 jwks
 -Name string 0.0.0 name

--- a/go/libraries/doltcore/servercfg/yaml_config.go
+++ b/go/libraries/doltcore/servercfg/yaml_config.go
@@ -118,8 +118,8 @@ func (r RemotesapiYAMLConfig) ReadOnly() bool {
 }
 
 type UserSessionVars struct {
-	Name string            `yaml:"name"`
-	Vars map[string]string `yaml:"vars"`
+	Name string                 `yaml:"name"`
+	Vars map[string]interface{} `yaml:"vars"`
 }
 
 // YAMLConfig is a ServerConfig implementation which is read from a yaml file

--- a/go/libraries/doltcore/servercfg/yaml_config_test.go
+++ b/go/libraries/doltcore/servercfg/yaml_config_test.go
@@ -106,7 +106,7 @@ jwks:
 	expected.Vars = []UserSessionVars{
 		{
 			Name: "user0",
-			Vars: map[string]string{
+			Vars: map[string]interface{}{
 				"var1": "val0_1",
 				"var2": "val0_2",
 				"var3": "val0_3",
@@ -114,7 +114,7 @@ jwks:
 		},
 		{
 			Name: "user1",
-			Vars: map[string]string{
+			Vars: map[string]interface{}{
 				"var1": "val1_1",
 				"var2": "val1_2",
 				"var4": "val1_4",

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -190,16 +190,19 @@ user_session_vars:
   vars:
     aws_credentials_file: /Users/user0/.aws/config
     aws_credentials_profile: default
-    autocommit: 0
 - name: user1
   vars:
     aws_credentials_file: /Users/user1/.aws/config
-    aws_credentials_profile: lddev" > server.yaml
+    aws_credentials_profile: lddev
+- name: user3
+  vars:
+    autocommit: 0" > server.yaml
 
     dolt --privilege-file=privs.json sql -q "CREATE USER dolt@'127.0.0.1'"
     dolt --privilege-file=privs.json sql -q "CREATE USER user0@'127.0.0.1' IDENTIFIED BY 'pass0'"
     dolt --privilege-file=privs.json sql -q "CREATE USER user1@'127.0.0.1' IDENTIFIED BY 'pass1'"
     dolt --privilege-file=privs.json sql -q "CREATE USER user2@'127.0.0.1' IDENTIFIED BY 'pass2'"
+    dolt --privilege-file=privs.json sql -q "CREATE USER user3@'127.0.0.1' IDENTIFIED BY 'pass3'"
 
     start_sql_server_with_config "" server.yaml
 
@@ -217,6 +220,9 @@ user_session_vars:
 
     run dolt --host=127.0.0.1 --port=$PORT --no-tls --user=user2 --password=pass2 sql -q "SET @@aws_credentials_file='/Users/should_fail';"
     [[ "$output" =~ "Variable 'aws_credentials_file' is a read only variable" ]] || false
+
+    run dolt --host=127.0.0.1 --port=$PORT --no-tls --user=user3 --password=pass3 sql -q "SELECT @@autocommit;"
+    [[ "$output" =~ "1" ]] || false
 }
 
 @test "sql-server: read-only mode" {

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -222,7 +222,7 @@ user_session_vars:
     [[ "$output" =~ "Variable 'aws_credentials_file' is a read only variable" ]] || false
 
     run dolt --host=127.0.0.1 --port=$PORT --no-tls --user=user3 --password=pass3 sql -q "SELECT @@autocommit;"
-    [[ "$output" =~ "0" ]] || false
+
 }
 
 @test "sql-server: read-only mode" {

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -222,7 +222,7 @@ user_session_vars:
     [[ "$output" =~ "Variable 'aws_credentials_file' is a read only variable" ]] || false
 
     run dolt --host=127.0.0.1 --port=$PORT --no-tls --user=user3 --password=pass3 sql -q "SELECT @@autocommit;"
-    [[ "$output" =~ "1" ]] || false
+    [[ "$output" =~ "0" ]] || false
 }
 
 @test "sql-server: read-only mode" {

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -190,6 +190,7 @@ user_session_vars:
   vars:
     aws_credentials_file: /Users/user0/.aws/config
     aws_credentials_profile: default
+    autocommit: 0
 - name: user1
   vars:
     aws_credentials_file: /Users/user1/.aws/config
@@ -201,6 +202,9 @@ user_session_vars:
     dolt --privilege-file=privs.json sql -q "CREATE USER user2@'127.0.0.1' IDENTIFIED BY 'pass2'"
 
     start_sql_server_with_config "" server.yaml
+
+    run dolt --host=127.0.0.1 --port=$PORT --no-tls --user=user0 --password=pass0 sql -q "SELECT @@autocommit;"
+    [[ "$output" =~ "1" ]] || false
 
     run dolt --host=127.0.0.1 --port=$PORT --no-tls --user=user0 --password=pass0 sql -q "SELECT @@aws_credentials_file, @@aws_credentials_profile;"
     [[ "$output" =~ /Users/user0/.aws/config.*default ]] || false

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -206,9 +206,6 @@ user_session_vars:
 
     start_sql_server_with_config "" server.yaml
 
-    run dolt --host=127.0.0.1 --port=$PORT --no-tls --user=user0 --password=pass0 sql -q "SELECT @@autocommit;"
-    [[ "$output" =~ "1" ]] || false
-
     run dolt --host=127.0.0.1 --port=$PORT --no-tls --user=user0 --password=pass0 sql -q "SELECT @@aws_credentials_file, @@aws_credentials_profile;"
     [[ "$output" =~ /Users/user0/.aws/config.*default ]] || false
 
@@ -222,7 +219,7 @@ user_session_vars:
     [[ "$output" =~ "Variable 'aws_credentials_file' is a read only variable" ]] || false
 
     run dolt --host=127.0.0.1 --port=$PORT --no-tls --user=user3 --password=pass3 sql -q "SELECT @@autocommit;"
-
+    [[ "$output" =~ "0" ]] || false
 }
 
 @test "sql-server: read-only mode" {


### PR DESCRIPTION
The variable defined for the YAML Marshaller to write user variables to was defined as a `map[string]string`, which caused all variables to be read as a string even when they weren't quoted. Changing it to a `map[string]interface{}` fixes that.

fixes: https://github.com/dolthub/dolt/issues/8672