### PR TITLE
Initialize persisted `root` superuser on SQL server startup

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -121,9 +121,8 @@ _main() {
 
     # If DOLT_ROOT_HOST has been specified – create a root user for that host with the specified password
     if [ -n "$DOLT_ROOT_HOST" ] && [ "$DOLT_ROOT_HOST" != 'localhost' ]; then
-       echo "Ensuring root@{$DOLT_ROOT_HOST} superuser exists (DOLT_ROOT_HOST was specified)"
-       dolt -u root -p ${DOLT_ROOT_PASSWORD} sql -q "
-                    CREATE USER IF NOT EXISTS 'root'@'${DOLT_ROOT_HOST}' IDENTIFIED BY '${DOLT_ROOT_PASSWORD}';
+       echo "Ensuring root@${DOLT_ROOT_HOST} superuser exists (DOLT_ROOT_HOST was specified)"
+       dolt sql -q "CREATE USER IF NOT EXISTS 'root'@'${DOLT_ROOT_HOST}' IDENTIFIED BY '${DOLT_ROOT_PASSWORD}';
                     ALTER USER 'root'@'${DOLT_ROOT_HOST}' IDENTIFIED BY '${DOLT_ROOT_PASSWORD}';
                     GRANT ALL ON *.* TO 'root'@'${DOLT_ROOT_HOST}' WITH GRANT OPTION;"
     fi

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -119,12 +119,28 @@ _main() {
         set -- "$@" --config=$CONFIG_PROVIDED
     fi
 
+    # If DOLT_ROOT_HOST has been specified – create a root user for that host with the specified password
+    if [ -n "$DOLT_ROOT_HOST" ] && [ "$DOLT_ROOT_HOST" != 'localhost' ]; then
+       echo "Ensuring root@{$DOLT_ROOT_HOST} superuser exists (DOLT_ROOT_HOST was specified)"
+       dolt -u root -p ${DOLT_ROOT_PASSWORD} sql -q "
+                    CREATE USER IF NOT EXISTS 'root'@'${DOLT_ROOT_HOST}' IDENTIFIED BY '${DOLT_ROOT_PASSWORD}';
+                    ALTER USER 'root'@'${DOLT_ROOT_HOST}' IDENTIFIED BY '${DOLT_ROOT_PASSWORD}';
+                    GRANT ALL ON *.* TO 'root'@'${DOLT_ROOT_HOST}' WITH GRANT OPTION;"
+    fi
+
+     # Ensure the root@localhost user exists, with the requested password
+     echo "Ensuring root@localhost user exists"
+     dolt sql -q "CREATE USER IF NOT EXISTS 'root'@'localhost' IDENTIFIED BY '${DOLT_ROOT_PASSWORD}';
+                  ALTER USER 'root'@'localhost' IDENTIFIED BY '${DOLT_ROOT_PASSWORD}';
+                  GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION;"
+
     if [[ ! -f $INIT_COMPLETED ]]; then
         # run any file provided in /docker-entrypoint-initdb.d directory before the server starts
         docker_process_init_files /docker-entrypoint-initdb.d/*
         touch $INIT_COMPLETED
     fi
 
+    # switch this process over to executing dolt sql-server
     exec dolt sql-server --host=0.0.0.0 --port=3306 "$@"
 }
 

--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -63,22 +63,23 @@ type contextFactory func(ctx context.Context, session sql.Session) (*sql.Context
 type SystemVariables map[string]interface{}
 
 type SqlEngineConfig struct {
-	IsReadOnly              bool
-	IsServerLocked          bool
-	DoltCfgDirPath          string
-	PrivFilePath            string
-	BranchCtrlFilePath      string
-	ServerUser              string
-	ServerPass              string
-	ServerHost              string
-	Autocommit              bool
-	DoltTransactionCommit   bool
-	Bulk                    bool
-	JwksConfig              []servercfg.JwksConfig
-	SystemVariables         SystemVariables
-	ClusterController       *cluster.Controller
-	BinlogReplicaController binlogreplication.BinlogReplicaController
-	EventSchedulerStatus    eventscheduler.SchedulerStatus
+	IsReadOnly                 bool
+	IsServerLocked             bool
+	DoltCfgDirPath             string
+	PrivFilePath               string
+	BranchCtrlFilePath         string
+	ServerUser                 string
+	ServerPass                 string
+	ServerHost                 string
+	SkipRootUserInitialization bool
+	Autocommit                 bool
+	DoltTransactionCommit      bool
+	Bulk                       bool
+	JwksConfig                 []servercfg.JwksConfig
+	SystemVariables            SystemVariables
+	ClusterController          *cluster.Controller
+	BinlogReplicaController    binlogreplication.BinlogReplicaController
+	EventSchedulerStatus       eventscheduler.SchedulerStatus
 }
 
 // NewSqlEngine returns a SqlEngine

--- a/go/cmd/dolt/commands/sqlserver/command_line_config.go
+++ b/go/cmd/dolt/commands/sqlserver/command_line_config.go
@@ -29,32 +29,33 @@ import (
 )
 
 type commandLineServerConfig struct {
-	host                    string
-	port                    int
-	user                    string
-	password                string
-	timeout                 uint64
-	readOnly                bool
-	logLevel                servercfg.LogLevel
-	dataDir                 string
-	cfgDir                  string
-	autoCommit              bool
-	doltTransactionCommit   bool
-	maxConnections          uint64
-	tlsKey                  string
-	tlsCert                 string
-	requireSecureTransport  bool
-	maxLoggedQueryLen       int
-	shouldEncodeLoggedQuery bool
-	privilegeFilePath       string
-	branchControlFilePath   string
-	allowCleartextPasswords bool
-	socket                  string
-	remotesapiPort          *int
-	remotesapiReadOnly      *bool
-	goldenMysqlConn         string
-	eventSchedulerStatus    string
-	valuesSet               map[string]struct{}
+	host                       string
+	port                       int
+	user                       string
+	password                   string
+	skipRootUserInitialization bool
+	timeout                    uint64
+	readOnly                   bool
+	logLevel                   servercfg.LogLevel
+	dataDir                    string
+	cfgDir                     string
+	autoCommit                 bool
+	doltTransactionCommit      bool
+	maxConnections             uint64
+	tlsKey                     string
+	tlsCert                    string
+	requireSecureTransport     bool
+	maxLoggedQueryLen          int
+	shouldEncodeLoggedQuery    bool
+	privilegeFilePath          string
+	branchControlFilePath      string
+	allowCleartextPasswords    bool
+	socket                     string
+	remotesapiPort             *int
+	remotesapiReadOnly         *bool
+	goldenMysqlConn            string
+	eventSchedulerStatus       string
+	valuesSet                  map[string]struct{}
 }
 
 var _ servercfg.ServerConfig = (*commandLineServerConfig)(nil)
@@ -114,6 +115,10 @@ func NewCommandLineConfig(creds *cli.UserPassword, apr *argparser.ArgParseResult
 	} else {
 		config.withUser(creds.Username)
 		config.withPassword(creds.Password)
+	}
+
+	if apr.Contains(skipRootUserInitialization) {
+		config.skipRootUserInitialization = true
 	}
 
 	if port, ok := apr.GetInt(remotesapiPortFlag); ok {
@@ -202,9 +207,20 @@ func (cfg *commandLineServerConfig) User() string {
 	return cfg.user
 }
 
+// UserIsSpecified returns true if the configuration explicitly specified a user.
+func (cfg *commandLineServerConfig) UserIsSpecified() bool {
+	return cfg.user != ""
+}
+
 // Password returns the password that connecting clients must use.
 func (cfg *commandLineServerConfig) Password() string {
 	return cfg.password
+}
+
+// SkipRootUserInitialization returns whether the server should skip creating the implicit root
+// superuser the first time a sql-server instance is launched.
+func (cfg *commandLineServerConfig) SkipRootUserInitialization() bool {
+	return cfg.skipRootUserInitialization
 }
 
 // ReadTimeout returns the read and write timeouts.

--- a/go/cmd/dolt/commands/sqlserver/command_line_config.go
+++ b/go/cmd/dolt/commands/sqlserver/command_line_config.go
@@ -29,33 +29,32 @@ import (
 )
 
 type commandLineServerConfig struct {
-	host                       string
-	port                       int
-	user                       string
-	password                   string
-	skipRootUserInitialization bool
-	timeout                    uint64
-	readOnly                   bool
-	logLevel                   servercfg.LogLevel
-	dataDir                    string
-	cfgDir                     string
-	autoCommit                 bool
-	doltTransactionCommit      bool
-	maxConnections             uint64
-	tlsKey                     string
-	tlsCert                    string
-	requireSecureTransport     bool
-	maxLoggedQueryLen          int
-	shouldEncodeLoggedQuery    bool
-	privilegeFilePath          string
-	branchControlFilePath      string
-	allowCleartextPasswords    bool
-	socket                     string
-	remotesapiPort             *int
-	remotesapiReadOnly         *bool
-	goldenMysqlConn            string
-	eventSchedulerStatus       string
-	valuesSet                  map[string]struct{}
+	host                    string
+	port                    int
+	user                    string
+	password                string
+	timeout                 uint64
+	readOnly                bool
+	logLevel                servercfg.LogLevel
+	dataDir                 string
+	cfgDir                  string
+	autoCommit              bool
+	doltTransactionCommit   bool
+	maxConnections          uint64
+	tlsKey                  string
+	tlsCert                 string
+	requireSecureTransport  bool
+	maxLoggedQueryLen       int
+	shouldEncodeLoggedQuery bool
+	privilegeFilePath       string
+	branchControlFilePath   string
+	allowCleartextPasswords bool
+	socket                  string
+	remotesapiPort          *int
+	remotesapiReadOnly      *bool
+	goldenMysqlConn         string
+	eventSchedulerStatus    string
+	valuesSet               map[string]struct{}
 }
 
 var _ servercfg.ServerConfig = (*commandLineServerConfig)(nil)
@@ -115,10 +114,6 @@ func NewCommandLineConfig(creds *cli.UserPassword, apr *argparser.ArgParseResult
 	} else {
 		config.withUser(creds.Username)
 		config.withPassword(creds.Password)
-	}
-
-	if apr.Contains(skipRootUserInitialization) {
-		config.skipRootUserInitialization = true
 	}
 
 	if port, ok := apr.GetInt(remotesapiPortFlag); ok {
@@ -215,12 +210,6 @@ func (cfg *commandLineServerConfig) UserIsSpecified() bool {
 // Password returns the password that connecting clients must use.
 func (cfg *commandLineServerConfig) Password() string {
 	return cfg.password
-}
-
-// SkipRootUserInitialization returns whether the server should skip creating the implicit root
-// superuser the first time a sql-server instance is launched.
-func (cfg *commandLineServerConfig) SkipRootUserInitialization() bool {
-	return cfg.skipRootUserInitialization
 }
 
 // ReadTimeout returns the read and write timeouts.

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -82,13 +82,14 @@ func Serve(
 	serverConfig servercfg.ServerConfig,
 	controller *svcs.Controller,
 	dEnv *env.DoltEnv,
+	skipRootUserInitialization bool,
 ) (startError error, closeError error) {
 	// Code is easier to work through if we assume that serverController is never nil
 	if controller == nil {
 		controller = svcs.NewController()
 	}
 
-	ConfigureServices(serverConfig, controller, version, dEnv)
+	ConfigureServices(serverConfig, controller, version, dEnv, skipRootUserInitialization)
 
 	go controller.Start(ctx)
 	err := controller.WaitForStart()
@@ -103,6 +104,7 @@ func ConfigureServices(
 	controller *svcs.Controller,
 	version string,
 	dEnv *env.DoltEnv,
+	skipRootUserInitialization bool,
 ) {
 	ValidateConfigStep := &svcs.AnonService{
 		InitF: func(context.Context) error {
@@ -234,7 +236,7 @@ func ConfigureServices(
 				SystemVariables:            serverConfig.SystemVars(),
 				ClusterController:          clusterController,
 				BinlogReplicaController:    binlogreplication.DoltBinlogReplicaController,
-				SkipRootUserInitialization: serverConfig.SkipRootUserInitialization(),
+				SkipRootUserInitialization: skipRootUserInitialization,
 			}
 			return nil
 		},

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -56,6 +57,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqlserver"
 	"github.com/dolthub/dolt/go/libraries/events"
 	"github.com/dolthub/dolt/go/libraries/utils/config"
+	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/libraries/utils/svcs"
 )
 
@@ -219,19 +221,20 @@ func ConfigureServices(
 	InitSqlEngineConfig := &svcs.AnonService{
 		InitF: func(context.Context) error {
 			config = &engine.SqlEngineConfig{
-				IsReadOnly:              serverConfig.ReadOnly(),
-				PrivFilePath:            serverConfig.PrivilegeFilePath(),
-				BranchCtrlFilePath:      serverConfig.BranchControlFilePath(),
-				DoltCfgDirPath:          serverConfig.CfgDir(),
-				ServerUser:              serverConfig.User(),
-				ServerPass:              serverConfig.Password(),
-				ServerHost:              serverConfig.Host(),
-				Autocommit:              serverConfig.AutoCommit(),
-				DoltTransactionCommit:   serverConfig.DoltTransactionCommit(),
-				JwksConfig:              serverConfig.JwksConfig(),
-				SystemVariables:         serverConfig.SystemVars(),
-				ClusterController:       clusterController,
-				BinlogReplicaController: binlogreplication.DoltBinlogReplicaController,
+				IsReadOnly:                 serverConfig.ReadOnly(),
+				PrivFilePath:               serverConfig.PrivilegeFilePath(),
+				BranchCtrlFilePath:         serverConfig.BranchControlFilePath(),
+				DoltCfgDirPath:             serverConfig.CfgDir(),
+				ServerUser:                 serverConfig.User(),
+				ServerPass:                 serverConfig.Password(),
+				ServerHost:                 serverConfig.Host(),
+				Autocommit:                 serverConfig.AutoCommit(),
+				DoltTransactionCommit:      serverConfig.DoltTransactionCommit(),
+				JwksConfig:                 serverConfig.JwksConfig(),
+				SystemVariables:            serverConfig.SystemVars(),
+				ClusterController:          clusterController,
+				BinlogReplicaController:    binlogreplication.DoltBinlogReplicaController,
+				SkipRootUserInitialization: serverConfig.SkipRootUserInitialization(),
 			}
 			return nil
 		},
@@ -363,30 +366,75 @@ func ConfigureServices(
 	}
 	controller.Register(InitBinlogging)
 
-	// Add superuser if specified user exists; add root superuser if no user specified and no existing privileges
-	InitSuperUser := &svcs.AnonService{
-		InitF: func(context.Context) error {
-			userSpecified := config.ServerUser != ""
+	// MySQL creates a root superuser when the mysql install is first initialized. Depending on the options
+	// specified, the root superuser is created without a password, or with a random password. This varies
+	// slightly in some OS-specific installers. Dolt initializes the root superuser the first time a
+	// sql-server is started and initializes its privileges database. We do this on sql-server initialization,
+	// instead of dolt db initialization, because we only want to create the privileges database when it's
+	// used for a server, and because we want the same root initialization logic when a sql-server is started
+	// for a clone. More details: https://dev.mysql.com/doc/mysql-security-excerpt/8.0/en/default-privileges.html
+	//
+	// NOTE: The MySQL root user is created for host 'localhost', not any host ('%'). We could do the same here,
+	//       but it seems like it would cause problems for users who want to connect from outside of Docker.
+	InitImplicitRootSuperUser := &svcs.AnonService{
+		InitF: func(ctx context.Context) error {
+			// If privileges.db has already been initialized, indicating that this is NOT the
+			// first time sql-server has been launched, then don't initialize the root superuser.
+			if permissionDbExists, err := doesPrivilegesDbExist(dEnv, serverConfig.PrivilegeFilePath()); err != nil {
+				return err
+			} else if permissionDbExists {
+				logrus.Debug("privileges.db already exists, not creating root superuser")
+				return nil
+			}
 
+			// We always persist the privileges.db file, to signal that the privileges system has been initialized
 			mysqlDb := sqlEngine.GetUnderlyingEngine().Analyzer.Catalog.MySQLDb
 			ed := mysqlDb.Editor()
-			var numUsers int
-			ed.VisitUsers(func(*mysql_db.User) { numUsers += 1 })
-			privsExist := numUsers != 0
+			defer ed.Close()
+
+			// If no ephemeral superuser has been configured and root user initialization wasn't skipped,
+			// then create a root@localhost superuser.
+			if !serverConfig.UserIsSpecified() && !config.SkipRootUserInitialization {
+				logrus.Info("Creating root@localhost superuser")
+				mysqlDb.AddSuperUser(ed, servercfg.DefaultUser, "localhost", servercfg.DefaultPass)
+			}
+
+			// TODO: The in-memory filesystem doesn't work with the GMS API
+			//       for persisting the privileges database. The filesys API
+			//       is in the Dolt layer, so when the file path is passed to
+			//       GMS, it expects it to be a path on disk, and errors out.
+			if _, isInMemFs := dEnv.FS.(*filesys.InMemFS); isInMemFs {
+				return nil
+			} else {
+				sqlCtx, err := sqlEngine.NewDefaultContext(context.Background())
+				if err != nil {
+					return err
+				}
+				return mysqlDb.Persist(sqlCtx, ed)
+			}
+		},
+	}
+	controller.Register(InitImplicitRootSuperUser)
+
+	// Add an ephemeral superuser if one was requested
+	InitEphemeralSuperUser := &svcs.AnonService{
+		InitF: func(context.Context) error {
+			mysqlDb := sqlEngine.GetUnderlyingEngine().Analyzer.Catalog.MySQLDb
+			ed := mysqlDb.Editor()
+
+			userSpecified := config.ServerUser != ""
 			if userSpecified {
 				superuser := mysqlDb.GetUser(ed, config.ServerUser, "%", false)
-				if userSpecified && superuser == nil {
-					mysqlDb.AddSuperUser(ed, config.ServerUser, "%", config.ServerPass)
+				if superuser == nil {
+					mysqlDb.AddEphemeralSuperUser(ed, config.ServerUser, "%", config.ServerPass)
 				}
-			} else if !privsExist {
-				mysqlDb.AddSuperUser(ed, servercfg.DefaultUser, "%", servercfg.DefaultPass)
 			}
 			ed.Close()
 
 			return nil
 		},
 	}
-	controller.Register(InitSuperUser)
+	controller.Register(InitEphemeralSuperUser)
 
 	var metListener *metricsListener
 	InitMetricsListener := &svcs.AnonService{
@@ -406,7 +454,7 @@ func ConfigureServices(
 		InitF: func(context.Context) error {
 			mysqlDb := sqlEngine.GetUnderlyingEngine().Analyzer.Catalog.MySQLDb
 			ed := mysqlDb.Editor()
-			mysqlDb.AddSuperUser(ed, LocalConnectionUser, "localhost", localCreds.Secret)
+			mysqlDb.AddEphemeralSuperUser(ed, LocalConnectionUser, "localhost", localCreds.Secret)
 			ed.Close()
 			return nil
 		},
@@ -856,6 +904,29 @@ func (r *remotesapiAuth) ApiAuthorize(ctx context.Context, superUserRequired boo
 		}
 		return false, fmt.Errorf("API Authorization Failure: %s has not been granted CLONE_ADMIN access", sqlCtx.Session.Client().User)
 	}
+	return true, nil
+}
+
+// doesPrivilegesDbExist looks for an existing privileges database as the specified |privilegeFilePath|. If
+// |privilegeFilePath| is an absolute path, it is used directly. If it is a relative path, then it is resolved
+// relative to the root of the specified |dEnv|.
+func doesPrivilegesDbExist(dEnv *env.DoltEnv, privilegeFilePath string) (exists bool, err error) {
+	if !filepath.IsAbs(privilegeFilePath) {
+		privilegeFilePath, err = dEnv.FS.Abs(privilegeFilePath)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	_, err = os.Stat(privilegeFilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		} else {
+			return false, err
+		}
+	}
+
 	return true, nil
 }
 

--- a/go/cmd/dolt/commands/sqlserver/server_test.go
+++ b/go/cmd/dolt/commands/sqlserver/server_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 
+	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/libraries/doltcore/dtestutils/testcommands"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/servercfg"
@@ -189,7 +190,7 @@ func TestServerGoodParams(t *testing.T) {
 		t.Run(servercfg.ConfigInfo(test), func(t *testing.T) {
 			sc := svcs.NewController()
 			go func(config servercfg.ServerConfig, sc *svcs.Controller) {
-				_, _ = Serve(context.Background(), "0.0.0", config, sc, env)
+				_, _ = Serve(context.Background(), "0.0.0", config, sc, env, false)
 			}(test, sc)
 			err := sc.WaitForStart()
 			require.NoError(t, err)
@@ -216,7 +217,7 @@ func TestServerSelect(t *testing.T) {
 	sc := svcs.NewController()
 	defer sc.Stop()
 	go func() {
-		_, _ = Serve(context.Background(), "0.0.0", serverConfig, sc, env)
+		_, _ = Serve(context.Background(), "0.0.0", serverConfig, sc, env, false)
 	}()
 	err = sc.WaitForStart()
 	require.NoError(t, err)
@@ -315,7 +316,7 @@ func TestServerSetDefaultBranch(t *testing.T) {
 	sc := svcs.NewController()
 	defer sc.Stop()
 	go func() {
-		_, _ = Serve(context.Background(), "0.0.0", serverConfig, sc, dEnv)
+		_, _ = Serve(context.Background(), "0.0.0", serverConfig, sc, dEnv, false)
 	}()
 	err = sc.WaitForStart()
 	require.NoError(t, err)
@@ -479,7 +480,7 @@ func TestReadReplica(t *testing.T) {
 
 	os.Chdir(multiSetup.DbPaths[readReplicaDbName])
 	go func() {
-		err, _ = Serve(context.Background(), "0.0.0", serverConfig, sc, multiSetup.GetEnv(readReplicaDbName))
+		err, _ = Serve(context.Background(), "0.0.0", serverConfig, sc, multiSetup.GetEnv(readReplicaDbName), false)
 		require.NoError(t, err)
 	}()
 	require.NoError(t, sc.WaitForStart())
@@ -618,7 +619,8 @@ branch_control_file: dir1/dir2/abc.db
 	cwdFs, err := filesys.LocalFilesysWithWorkingDir(cwd)
 	require.NoError(t, err)
 
-	serverConfig, err := ServerConfigFromArgs(ap, nil, args, dEnv, cwdFs)
+	apr := cli.ParseArgsOrDie(ap, args, nil)
+	serverConfig, err := ServerConfigFromArgs(apr, dEnv, cwdFs)
 	require.NoError(t, err)
 
 	assert.Equal(t, expected, generateYamlConfig(serverConfig))

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -242,7 +242,8 @@ func validateSqlServerArgs(apr *argparser.ArgParseResults) error {
 func StartServer(ctx context.Context, versionStr, commandStr string, args []string, dEnv *env.DoltEnv, cwd filesys.Filesys, controller *svcs.Controller) error {
 	ap := SqlServerCmd{}.ArgParser()
 	help, _ := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, sqlServerDocs, ap))
-	serverConfig, err := ServerConfigFromArgs(ap, help, args, dEnv, cwd)
+	apr := cli.ParseArgsOrDie(ap, args, help)
+	serverConfig, err := ServerConfigFromArgs(apr, dEnv, cwd)
 	if err != nil {
 		return err
 	}
@@ -259,7 +260,8 @@ func StartServer(ctx context.Context, versionStr, commandStr string, args []stri
 
 	cli.PrintErrf("Starting server with Config %v\n", servercfg.ConfigInfo(serverConfig))
 
-	startError, closeError := Serve(ctx, versionStr, serverConfig, controller, dEnv)
+	skipRootUserInitialization := apr.Contains(skipRootUserInitialization)
+	startError, closeError := Serve(ctx, versionStr, serverConfig, controller, dEnv, skipRootUserInitialization)
 	if startError != nil {
 		return startError
 	}
@@ -325,20 +327,17 @@ func GetDataDirPreStart(fs filesys.Filesys, args []string) (string, error) {
 }
 
 // ServerConfigFromArgs returns a ServerConfig from the given args
-func ServerConfigFromArgs(ap *argparser.ArgParser, help cli.UsagePrinter, args []string, dEnv *env.DoltEnv, cwd filesys.Filesys) (servercfg.ServerConfig, error) {
-	return ServerConfigFromArgsWithReader(ap, help, args, dEnv, cwd, DoltServerConfigReader{})
+func ServerConfigFromArgs(apr *argparser.ArgParseResults, dEnv *env.DoltEnv, cwd filesys.Filesys) (servercfg.ServerConfig, error) {
+	return ServerConfigFromArgsWithReader(apr, dEnv, cwd, DoltServerConfigReader{})
 }
 
 // ServerConfigFromArgsWithReader returns a ServerConfig from the given args, using the provided ServerConfigReader
 func ServerConfigFromArgsWithReader(
-	ap *argparser.ArgParser,
-	help cli.UsagePrinter,
-	args []string,
+	apr *argparser.ArgParseResults,
 	dEnv *env.DoltEnv,
 	cwd filesys.Filesys,
 	reader ServerConfigReader,
 ) (servercfg.ServerConfig, error) {
-	apr := cli.ParseArgsOrDie(ap, args, help)
 	if err := validateSqlServerArgs(apr); err != nil {
 		cli.PrintErrln(color.RedString(err.Error()))
 		return nil, err
@@ -380,12 +379,6 @@ func getServerConfig(cwdFS filesys.Filesys, apr *argparser.ArgParseResults, data
 			pass, _ := apr.GetValue(passwordFlag)
 			wcfg.SetUserName(user)
 			wcfg.SetPassword(pass)
-		}
-	}
-
-	if apr.Contains(skipRootUserInitialization) {
-		if wcfg, ok := cfg.(servercfg.WritableServerConfig); ok {
-			wcfg.SetSkipRootUserInitialization(true)
 		}
 	}
 

--- a/go/cmd/dolt/commands/utils.go
+++ b/go/cmd/dolt/commands/utils.go
@@ -291,7 +291,7 @@ func newLateBindingEngine(
 			dbUser = DefaultUser
 			ed := rawDb.Editor()
 			defer ed.Close()
-			rawDb.AddSuperUser(ed, dbUser, config.ServerHost, "")
+			rawDb.AddEphemeralSuperUser(ed, dbUser, config.ServerHost, "")
 		}
 
 		// Set client to specified user

--- a/go/go.mod
+++ b/go/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/dolthub/fslock v0.0.3
 	github.com/dolthub/ishell v0.0.0-20240701202509-2b217167d718
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20241231200706-18992bb25fdc
+	github.com/dolthub/vitess v0.0.0-20250115003116-d6f17c220028
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.13.0
 	github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568
@@ -56,7 +56,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/creasty/defaults v1.6.0
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-mysql-server v0.19.1-0.20250110212422-29e26f9e54ea
+	github.com/dolthub/go-mysql-server v0.19.1-0.20250115014825-57e56668593e
 	github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63
 	github.com/dolthub/swiss v0.1.0
 	github.com/goccy/go-json v0.10.2

--- a/go/go.sum
+++ b/go/go.sum
@@ -181,6 +181,8 @@ github.com/dolthub/go-icu-regex v0.0.0-20241215010122-db690dd53c90 h1:Sni8jrP0sy
 github.com/dolthub/go-icu-regex v0.0.0-20241215010122-db690dd53c90/go.mod h1:ylU4XjUpsMcvl/BKeRRMXSH7e7WBrPXdSLvnRJYrxEA=
 github.com/dolthub/go-mysql-server v0.19.1-0.20250110212422-29e26f9e54ea h1:0fxESRqbbjeYfxpqNnCcvydDymd/wvs6djqcH/nOvCw=
 github.com/dolthub/go-mysql-server v0.19.1-0.20250110212422-29e26f9e54ea/go.mod h1:ycL4Q6pJ5b+D8fnOa6GRmoB6PmvHAYn2w/IHYPbcQR0=
+github.com/dolthub/go-mysql-server v0.19.1-0.20250115014825-57e56668593e h1:5eodNf3ZGZNs6NHPckrbt1+6NV6LRiAQhb4EQ+B5Ldw=
+github.com/dolthub/go-mysql-server v0.19.1-0.20250115014825-57e56668593e/go.mod h1:5HtKnb+IAiv+27bo50KGANbUB4HAzGEF9rlFF2ZBLZg=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20240701202509-2b217167d718 h1:lT7hE5k+0nkBdj/1UOSFwjWpNxf+LCApbRHgnCA17XE=
@@ -195,6 +197,8 @@ github.com/dolthub/swiss v0.1.0 h1:EaGQct3AqeP/MjASHLiH6i4TAmgbG/c4rA6a1bzCOPc=
 github.com/dolthub/swiss v0.1.0/go.mod h1:BeucyB08Vb1G9tumVN3Vp/pyY4AMUnr9p7Rz7wJ7kAQ=
 github.com/dolthub/vitess v0.0.0-20241231200706-18992bb25fdc h1:3FuwEDwyue/JuHdnwGSbQhE9xKAFM+k1y3uXi58h7Gk=
 github.com/dolthub/vitess v0.0.0-20241231200706-18992bb25fdc/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
+github.com/dolthub/vitess v0.0.0-20250115003116-d6f17c220028 h1:lgcIsCUaNDde+lS+aYGYGML95qrQlBMEpaXFN1Pmk+4=
+github.com/dolthub/vitess v0.0.0-20250115003116-d6f17c220028/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=

--- a/go/libraries/doltcore/dconfig/envvars.go
+++ b/go/libraries/doltcore/dconfig/envvars.go
@@ -43,4 +43,6 @@ const (
 	EnvDoltAuthorDate                = "DOLT_AUTHOR_DATE"
 	EnvDoltCommitterDate             = "DOLT_COMMITTER_DATE"
 	EnvDbNameReplace                 = "DOLT_DBNAME_REPLACE"
+	EnvDoltRootHost                  = "DOLT_ROOT_HOST"
+	EnvDoltRootPassword              = "DOLT_ROOT_PASSWORD"
 )

--- a/go/libraries/doltcore/servercfg/serverconfig.go
+++ b/go/libraries/doltcore/servercfg/serverconfig.go
@@ -129,9 +129,6 @@ type ServerConfig interface {
 	UserIsSpecified() bool
 	// Password returns the password that connecting clients must use.
 	Password() string
-	// SkipRootUserInitialization returns whether the server should skip initializing the default root superuser.
-	// This option is only valid the first time a sql-server is started, when the root user is being initialized.
-	SkipRootUserInitialization() bool
 	// ReadTimeout returns the read timeout in milliseconds
 	ReadTimeout() uint64
 	// WriteTimeout returns the write timeout in milliseconds
@@ -244,9 +241,6 @@ type WritableServerConfig interface {
 	SetUserName(string)
 	// SetPassword sets the password for servers with no other auth established
 	SetPassword(string)
-	// SetSkipRootUserInitialization controls whether the default root superuser should be initialized,
-	// or if it should be skipped and not created.
-	SetSkipRootUserInitialization(bool)
 }
 
 type ValidatingServerConfig interface {

--- a/go/libraries/doltcore/servercfg/serverconfig.go
+++ b/go/libraries/doltcore/servercfg/serverconfig.go
@@ -125,8 +125,13 @@ type ServerConfig interface {
 	Port() int
 	// User returns the username that connecting clients must use.
 	User() string
+	// UserIsSpecified returns true if a user was explicitly provided in the configuration.
+	UserIsSpecified() bool
 	// Password returns the password that connecting clients must use.
 	Password() string
+	// SkipRootUserInitialization returns whether the server should skip initializing the default root superuser.
+	// This option is only valid the first time a sql-server is started, when the root user is being initialized.
+	SkipRootUserInitialization() bool
 	// ReadTimeout returns the read timeout in milliseconds
 	ReadTimeout() uint64
 	// WriteTimeout returns the write timeout in milliseconds
@@ -239,6 +244,9 @@ type WritableServerConfig interface {
 	SetUserName(string)
 	// SetPassword sets the password for servers with no other auth established
 	SetPassword(string)
+	// SetSkipRootUserInitialization controls whether the default root superuser should be initialized,
+	// or if it should be skipped and not created.
+	SetSkipRootUserInitialization(bool)
 }
 
 type ValidatingServerConfig interface {

--- a/go/libraries/doltcore/servercfg/testdata/minver_validation.txt
+++ b/go/libraries/doltcore/servercfg/testdata/minver_validation.txt
@@ -14,6 +14,7 @@ BehaviorConfig servercfg.BehaviorYAMLConfig 0.0.0 behavior,omitempty
 UserConfig servercfg.UserYAMLConfig 0.0.0 user,omitempty
 -Name *string 0.0.0 name,omitempty
 -Password *string 0.0.0 password,omitempty
+SkipRootUserInit *bool 0.0.0 skip_root_user_initialization,omitempty
 ListenerConfig servercfg.ListenerYAMLConfig 0.0.0 listener,omitempty
 -HostStr *string 0.0.0 host,omitempty
 -PortNumber *int 0.0.0 port,omitempty

--- a/go/libraries/doltcore/servercfg/testdata/minver_validation.txt
+++ b/go/libraries/doltcore/servercfg/testdata/minver_validation.txt
@@ -14,7 +14,6 @@ BehaviorConfig servercfg.BehaviorYAMLConfig 0.0.0 behavior,omitempty
 UserConfig servercfg.UserYAMLConfig 0.0.0 user,omitempty
 -Name *string 0.0.0 name,omitempty
 -Password *string 0.0.0 password,omitempty
-SkipRootUserInit *bool 0.0.0 skip_root_user_initialization,omitempty
 ListenerConfig servercfg.ListenerYAMLConfig 0.0.0 listener,omitempty
 -HostStr *string 0.0.0 host,omitempty
 -PortNumber *int 0.0.0 port,omitempty

--- a/go/libraries/doltcore/servercfg/yaml_config.go
+++ b/go/libraries/doltcore/servercfg/yaml_config.go
@@ -129,6 +129,7 @@ type YAMLConfig struct {
 	EncodeLoggedQuery *bool                  `yaml:"encode_logged_query,omitempty"`
 	BehaviorConfig    BehaviorYAMLConfig     `yaml:"behavior,omitempty"`
 	UserConfig        UserYAMLConfig         `yaml:"user,omitempty"`
+	SkipRootUserInit  *bool                  `yaml:"skip_root_user_initialization,omitempty"`
 	ListenerConfig    ListenerYAMLConfig     `yaml:"listener,omitempty"`
 	PerformanceConfig *PerformanceYAMLConfig `yaml:"performance,omitempty"`
 	DataDirStr        *string                `yaml:"data_dir,omitempty"`
@@ -582,6 +583,27 @@ func (cfg YAMLConfig) User() string {
 	}
 
 	return *cfg.UserConfig.Name
+}
+
+// UserIsSpecified returns true if the configuration explicitly specified a user.
+func (cfg YAMLConfig) UserIsSpecified() bool {
+	return cfg.UserConfig.Name != nil
+}
+
+// SkipRootUserInitialization returns whether the server should skip initializing the default, root
+// superuser.
+func (cfg YAMLConfig) SkipRootUserInitialization() bool {
+	if cfg.SkipRootUserInit == nil {
+		return false
+	}
+
+	return *cfg.SkipRootUserInit
+}
+
+// SetSkipRootUserInitialization sets whether the server should skip initializing the default, root
+// superuser.
+func (cfg YAMLConfig) SetSkipRootUserInitialization(b bool) {
+	cfg.SkipRootUserInit = &b
 }
 
 func (cfg *YAMLConfig) SetUserName(s string) {

--- a/go/libraries/doltcore/servercfg/yaml_config.go
+++ b/go/libraries/doltcore/servercfg/yaml_config.go
@@ -129,7 +129,6 @@ type YAMLConfig struct {
 	EncodeLoggedQuery *bool                  `yaml:"encode_logged_query,omitempty"`
 	BehaviorConfig    BehaviorYAMLConfig     `yaml:"behavior,omitempty"`
 	UserConfig        UserYAMLConfig         `yaml:"user,omitempty"`
-	SkipRootUserInit  *bool                  `yaml:"skip_root_user_initialization,omitempty"`
 	ListenerConfig    ListenerYAMLConfig     `yaml:"listener,omitempty"`
 	PerformanceConfig *PerformanceYAMLConfig `yaml:"performance,omitempty"`
 	DataDirStr        *string                `yaml:"data_dir,omitempty"`
@@ -588,22 +587,6 @@ func (cfg YAMLConfig) User() string {
 // UserIsSpecified returns true if the configuration explicitly specified a user.
 func (cfg YAMLConfig) UserIsSpecified() bool {
 	return cfg.UserConfig.Name != nil
-}
-
-// SkipRootUserInitialization returns whether the server should skip initializing the default, root
-// superuser.
-func (cfg YAMLConfig) SkipRootUserInitialization() bool {
-	if cfg.SkipRootUserInit == nil {
-		return false
-	}
-
-	return *cfg.SkipRootUserInit
-}
-
-// SetSkipRootUserInitialization sets whether the server should skip initializing the default, root
-// superuser.
-func (cfg YAMLConfig) SetSkipRootUserInitialization(b bool) {
-	cfg.SkipRootUserInit = &b
 }
 
 func (cfg *YAMLConfig) SetUserName(s string) {

--- a/go/libraries/doltcore/servercfg/yaml_config_test.go
+++ b/go/libraries/doltcore/servercfg/yaml_config_test.go
@@ -325,6 +325,7 @@ func TestYAMLConfigDefaults(t *testing.T) {
 	assert.Equal(t, DefaultHost, cfg.Host())
 	assert.Equal(t, DefaultPort, cfg.Port())
 	assert.Equal(t, DefaultUser, cfg.User())
+	assert.False(t, cfg.UserIsSpecified())
 	assert.Equal(t, DefaultPass, cfg.Password())
 	assert.Equal(t, uint64(DefaultTimeout), cfg.WriteTimeout())
 	assert.Equal(t, uint64(DefaultTimeout), cfg.ReadTimeout())

--- a/go/libraries/doltcore/sqle/enginetest/dolt_server_tests.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_server_tests.go
@@ -550,7 +550,7 @@ func makeDestinationSlice(t *testing.T, columnTypes []*gosql.ColumnType) []inter
 func startServerOnEnv(t *testing.T, serverConfig servercfg.ServerConfig, dEnv *env.DoltEnv) (*svcs.Controller, servercfg.ServerConfig) {
 	sc := svcs.NewController()
 	go func() {
-		_, _ = sqlserver.Serve(context.Background(), "0.0.0", serverConfig, sc, dEnv)
+		_, _ = sqlserver.Serve(context.Background(), "0.0.0", serverConfig, sc, dEnv, false)
 	}()
 	err := sc.WaitForStart()
 	require.NoError(t, err)

--- a/go/performance/replicationbench/replica_test.go
+++ b/go/performance/replicationbench/replica_test.go
@@ -171,7 +171,7 @@ func executeServerQueries(ctx context.Context, b *testing.B, dEnv *env.DoltEnv, 
 
 	//b.Logf("Starting server with Config %v\n", srv.ConfigInfo(cfg))
 	eg.Go(func() (err error) {
-		startErr, closeErr := srv.Serve(ctx, "", cfg, sc, dEnv)
+		startErr, closeErr := srv.Serve(ctx, "", cfg, sc, dEnv, false)
 		if startErr != nil {
 			return startErr
 		}

--- a/go/performance/serverbench/bench_test.go
+++ b/go/performance/serverbench/bench_test.go
@@ -183,7 +183,7 @@ func executeServerQueries(ctx context.Context, b *testing.B, dEnv *env.DoltEnv, 
 
 	//b.Logf("Starting server with Config %v\n", srv.ConfigInfo(cfg))
 	eg.Go(func() (err error) {
-		startErr, closeErr := srv.Serve(ctx, "", cfg, sc, dEnv)
+		startErr, closeErr := srv.Serve(ctx, "", cfg, sc, dEnv, false)
 		if startErr != nil {
 			return startErr
 		}

--- a/integration-tests/bats/events.bats
+++ b/integration-tests/bats/events.bats
@@ -263,7 +263,7 @@ SQL
     [ $status -eq 0 ]
     [[ $output =~ '| repo1 | eventTest1 | `__dolt_local_user__`@`localhost` | SYSTEM    | RECURRING | NULL       | 1              | SECOND         | 2020-02-20 00:00:00 | NULL | ENABLED | 0          | utf8mb4              | utf8mb4_0900_bin     | utf8mb4_0900_bin   |' ]] || false
 
-    # Sleep for a few seconds to give the scheduler timer to run this event and verify that it executed
+    # Sleep for a few seconds to give the scheduler time to run this event and verify that it executed
     sleep 2
     run dolt sql -q "SELECT (SELECT COUNT(*) FROM totals) > 0;"
     [ $status -eq 0 ]
@@ -286,7 +286,7 @@ SQL
     run dolt sql -q "SHOW EVENTS;"
     [[ $output =~ '| repo1 | eventTest1 | `__dolt_local_user__`@`localhost` | SYSTEM    | RECURRING | NULL       | 1              | SECOND         | 2020-02-20 00:00:00 | NULL | ENABLED | 0          | utf8mb4              | utf8mb4_0900_bin     | utf8mb4_0900_bin   |' ]] || false
 
-    # Sleep for a few seconds to give the scheduler timer to run this event and verify that it is still enabled
+    # Sleep for a few seconds to give the scheduler time to run this event and verify that it is still enabled
     sleep 2
     run dolt sql -q "SHOW EVENTS"
     [ $status -eq 0 ]

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -145,17 +145,17 @@ get_commit_hash_at() {
 
     stop_sql_server 1
 
-    run dolt --verbose-engine-setup --data-dir="$ROOT_DIR" --user dolt --password "" --use-db altDB sql -q "show tables"
+    run dolt --verbose-engine-setup --data-dir="$ROOT_DIR" --use-db altDB sql -q "show tables"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "starting local mode" ]] || false
     [[ "$output" =~ "altDB_tbl" ]] || false
 
-    run dolt --verbose-engine-setup --data-dir="$ROOT_DIR" --user dolt --password "" --use-db defaultDB sql -q "show tables"
+    run dolt --verbose-engine-setup --data-dir="$ROOT_DIR" --use-db defaultDB sql -q "show tables"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "starting local mode" ]] || false
     [[ "$output" =~ "defaultDB_tbl" ]] || false
 
-    run dolt --verbose-engine-setup --data-dir="$ROOT_DIR" --user dolt --password "" sql -q "show tables"
+    run dolt --verbose-engine-setup --data-dir="$ROOT_DIR" sql -q "show tables"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "starting local mode" ]] || false
     [[ "$output" =~ "altDB_tbl" ]] || false
@@ -310,7 +310,7 @@ get_commit_hash_at() {
   [ "$status" -eq 0 ] || false
   localOutput=$output
 
-  run dolt --user dolt --password "" status --ignored
+  run dolt status --ignored
   [ "$status" -eq 0 ] || false
   localIgnoredOutput=$output
 
@@ -376,11 +376,11 @@ get_commit_hash_at() {
 
     stop_sql_server 1
 
-    run dolt --verbose-engine-setup --user dolt --password "" branch b2
+    run dolt --verbose-engine-setup branch b2
     [ "$status" -eq 0 ]
     [[ "$output" =~ "starting local mode" ]] || false
 
-    run dolt --verbose-engine-setup --user dolt --password "" branch
+    run dolt --verbose-engine-setup branch
     [ "$status" -eq 0 ]
     [[ "$output" =~ "starting local mode" ]] || false
     [[ "$output" =~ "main" ]] || false

--- a/integration-tests/bats/sql-privs.bats
+++ b/integration-tests/bats/sql-privs.bats
@@ -53,35 +53,106 @@ teardown() {
     teardown_common
 }
 
-@test "sql-privs: default user is root. create new user destroys default user." {
-    make_test_repo
+# Asserts that the root@% superuser is automatically created when a sql-server is started
+# for the first time and no users are defined yet. As additional users are created, the
+# root@% superuser remains and can be manually removed without coming back.
+@test "sql-privs: implicit root superuser doesn't disappear after adding users" {
     PORT=$( definePORT )
-    dolt sql-server --host 0.0.0.0 --port=$PORT &
-    SERVER_PID=$! # will get killed by teardown_common
-    SQL_USER='root'
-    wait_for_connection $PORT 8500
+    dolt sql-server --port $PORT &
+    SERVER_PID=$!
+    sleep 1
 
-    run dolt sql -q "select user from mysql.user order by user"
+    # Assert that the root user can log in and run a query
+    run dolt -u root sql -q "select user, host from mysql.user where user='root';"
     [ $status -eq 0 ]
-    [[ $output =~ "root" ]] || false
+    [[ $output =~ "| root | localhost |" ]] || false
 
-    dolt sql -q "create user new_user"
-    run dolt sql -q "select user from mysql.user order by user"
+    # Create a new user
+    dolt -u root sql -q "CREATE USER user1@localhost; GRANT ALL PRIVILEGES on *.* to user1@localhost;"
+
+    # Restart the SQL server
+    stop_sql_server 1 && sleep 0.5
+    dolt sql-server --port $PORT &
+    SERVER_PID=$!
+    sleep 1
+
+    # Assert that both users are still present
+    run dolt -u root sql -q "select user, host from mysql.user where user in ('root', 'user1');"
     [ $status -eq 0 ]
-    [[ $output =~ "root" ]] || false
-    [[ $output =~ "new_user" ]] || false
+    [[ $output =~ "| root  | localhost |" ]] || false
+    [[ $output =~ "| user1 | localhost |" ]] || false
 
-    stop_sql_server
+    # Delete the root user
+    dolt -u root sql -q "DROP USER root@localhost;"
 
-    # restarting server
+    # Restart the SQL server
+    stop_sql_server 1 && sleep 0.5
+    dolt sql-server --port $PORT &
+    SERVER_PID=$!
+    sleep 1
+
+    # Assert that the root user is gone
+    run dolt -u user1 sql -q "select user, host from mysql.user where user in ('root', 'user1');"
+    [ $status -eq 0 ]
+    ! [[ $output =~ "root" ]] || false
+    [[ $output =~ "| user1 | localhost |" ]] || false
+}
+
+# Asserts that creating users via 'dolt sql' before starting a sql-server causes the privileges.db to be
+# initialized and prevents the root superuser from being created, since the customer has already started
+# manually managing user accounts.
+@test "sql-privs: implicit root superuser doesn't get created when users are created before the server starts" {
+    dolt sql -q "CREATE USER user1@localhost; GRANT ALL PRIVILEGES on *.* to user1@localhost;"
+
     PORT=$( definePORT )
-    dolt sql-server --host 0.0.0.0 --port=$PORT &
-    SERVER_PID=$! # will get killed by teardown_common
-    SQL_USER='new_user'
-    wait_for_connection $PORT 8500
+    dolt sql-server --port $PORT &
+    SERVER_PID=$!
+    sleep 1
 
-    run dolt -u root sql -q "select user from mysql.user order by user"
+    # Assert that the root superuser was not automatically created
+    run dolt -u user1 sql -q "select user, host from mysql.user where user in ('root', 'user1');"
+    echo "OUTPUT: $output"
+    [ $status -eq 0 ]
+    ! [[ $output =~ "root" ]] || false
+    [[ $output =~ "| user1 | localhost |" ]] || false
+}
+
+# Asserts that the root@% superuser does not get created when a temporary superuser is specified the
+# first time a sql-server is started and privileges.db is initialized.
+@test "sql-privs: implicit root superuser doesn't get created when specifying a temporary superuser" {
+    PORT=$( definePORT )
+    dolt sql-server --port $PORT -u temp1 &
+    SERVER_PID=$!
+    sleep 1
+
+    # Assert that there is no root user
+    run dolt -u temp1 sql -q "select user, host from mysql.user where user='root';"
+    [ $status -eq 0 ]
+    ! [[ $output =~ "root" ]] || false
+}
+
+# Asserts that the root@% superuser is not created when the --skip-default-root-user flag is specified
+# when first running sql-server and initializing privileges.db.
+@test "sql-privs: implicit root superuser doesn't get created when skipped" {
+    PORT=$( definePORT )
+    dolt sql-server --port $PORT --skip-root-user-initialization &
+    SERVER_PID=$!
+    sleep 1
+
+    # Assert that the root user cannot log in
+    run dolt -u root sql -q "select user, host from mysql.user where user='root';"
     [ $status -ne 0 ]
+
+    # Restart the SQL server with a temporary superuser
+    stop_sql_server 1 && sleep 0.5
+    dolt sql-server --port $PORT --u user1 &
+    SERVER_PID=$!
+    sleep 1
+
+    # Assert that there is no root user
+    run dolt -u user1 sql -q "select user, host from mysql.user where user='root';"
+    [ $status -eq 0 ]
+    ! [[ $output =~ "root" ]] || false
 }
 
 # Asserts that `dolt sql` can always be used to access the database as a superuser. For example, if the root
@@ -258,6 +329,7 @@ behavior:
     [[ $output =~ dolt ]] || false
     [[ $output =~ new_user ]] || false
     [[ $output =~ privs_user ]] || false
+    [[ $output =~ __dolt_local_user__ ]] || false
 }
 
 @test "sql-privs: errors instead of panic when reading badly formatted privilege file" {
@@ -276,7 +348,7 @@ behavior:
     start_sql_server test_db
 
     run ls -a
-    ! [[ "$output" =~ ".doltcfg" ]] || false
+    [[ "$output" =~ ".doltcfg" ]] || false
 
     run dolt sql -q "select user from mysql.user"
     [ $status -eq 0 ]
@@ -334,7 +406,7 @@ behavior:
     ! [[ "$output" =~ "privileges.db" ]] || false
 
     run ls -a db_dir
-    ! [[ "$output" =~ ".doltcfg" ]] || false
+    [[ "$output" =~ ".doltcfg" ]] || false
     ! [[ "$output" =~ "privileges.db" ]] || false
 
     run dolt -u dolt --port $PORT --host 0.0.0.0 --no-tls --use-db db1 sql -q "show databases"
@@ -375,7 +447,7 @@ behavior:
 
     run ls -a
     ! [[ "$output" =~ ".doltcfg" ]] || false
-    ! [[ "$output" =~ "doltcfgdir" ]] || false
+    [[ "$output" =~ "doltcfgdir" ]] || false
 
     run dolt sql -q "select user from mysql.user"
     [ $status -eq 0 ]
@@ -402,8 +474,12 @@ behavior:
     start_sql_server_with_args --host 0.0.0.0 --user=dolt --privilege-file=privs.db
 
     run ls -a
-    ! [[ "$output" =~ ".doltcfg" ]] || false
-    ! [[ "$output" =~ "privs.db" ]] || false
+    [[ "$output" =~ ".doltcfg" ]] || false
+    [[ "$output" =~ "privs.db" ]] || false
+    ! [[ "$output" =~ "privileges.db" ]] || false
+
+    run ls .doltcfg
+    ! [[ "$output" =~ "privileges.db" ]] || false
 
     run dolt sql -q "select user from mysql.user"
     [ $status -eq 0 ]
@@ -415,6 +491,7 @@ behavior:
     [ $status -eq 0 ]
     [[ $output =~ dolt ]] || false
     [[ $output =~ new_user ]] || false
+    ! [[ $output =~ root ]] || false
 
     run ls -a
     [[ "$output" =~ ".doltcfg" ]] || false
@@ -428,7 +505,7 @@ behavior:
 
     run ls -a
     ! [[ "$output" =~ ".doltcfg" ]] || false
-    ! [[ "$output" =~ "doltcfgdir" ]] || false
+    [[ "$output" =~ "doltcfgdir" ]] || false
     ! [[ "$output" =~ "privileges.db" ]] || false
 
     run ls -a db_dir
@@ -474,10 +551,10 @@ behavior:
 
     run ls -a
     ! [[ "$output" =~ ".doltcfg" ]] || false
-    ! [[ "$output" =~ "privs.db" ]] || false
+    [[ "$output" =~ "privs.db" ]] || false
 
     run ls -a db_dir
-    ! [[ "$output" =~ ".doltcfg" ]] || false
+    [[ "$output" =~ ".doltcfg" ]] || false
     ! [[ "$output" =~ "privs.db" ]] || false
 
     run dolt -u dolt --port $PORT --host 0.0.0.0 --no-tls --use-db db1 sql -q "show databases"
@@ -518,8 +595,9 @@ behavior:
 
     run ls -a
     ! [[ "$output" =~ ".doltcfg" ]] || false
-    ! [[ "$output" =~ "doltcfgdir" ]] || false
-    ! [[ "$output" =~ "privs.db" ]] || false
+    [[ "$output" =~ "doltcfgdir" ]] || false
+    [[ "$output" =~ "privs.db" ]] || false
+    ! [[ "$output" =~ "privileges.db" ]] || false
 
     run dolt sql -q "select user from mysql.user"
     [ $status -eq 0 ]
@@ -549,9 +627,9 @@ behavior:
 
     run ls -a
     ! [[ "$output" =~ ".doltcfg" ]] || false
-    ! [[ "$output" =~ "doltcfgdir" ]] || false
+    [[ "$output" =~ "doltcfgdir" ]] || false
     ! [[ "$output" =~ "privileges.db" ]] || false
-    ! [[ "$output" =~ "privs.db" ]] || false
+    [[ "$output" =~ "privs.db" ]] || false
 
     run dolt -u dolt --port $PORT --host 0.0.0.0 --no-tls --use-db db1 sql -q "show databases"
     [ $status -eq 0 ]

--- a/integration-tests/bats/sql-privs.bats
+++ b/integration-tests/bats/sql-privs.bats
@@ -132,6 +132,19 @@ teardown() {
     [[ $output =~ "| root | % " ]] || false
 }
 
+# Asserts that `dolt sql` can always be used to access the database as a superuser. For example, if the root
+# user is assigned a password, `dolt sql` should still be able to log in as a superuser, since the user
+# already has access to the host and data directory.
+@test "sql-privs: superuser access is always available from dolt sql" {
+    # Create a root@% user with a password set
+    dolt sql -q "CREATE USER root@'%' identified by 'pass1'; grant all on *.* to root@'%' with grant option;"
+
+    # Make sure dolt sql can still log in as root, even though root has a password set now
+    run dolt sql -q "select user();"
+    [ $status -eq 0 ]
+    [[ $output =~ "root@localhost" ]] || false
+}
+
 # Asserts that creating users via 'dolt sql' before starting a sql-server causes the privileges.db to be
 # initialized and prevents the root superuser from being created, since the customer has already started
 # manually managing user accounts.

--- a/integration-tests/bats/sql-privs.bats
+++ b/integration-tests/bats/sql-privs.bats
@@ -202,19 +202,6 @@ teardown() {
     ! [[ $output =~ "root" ]] || false
 }
 
-# Asserts that `dolt sql` can always be used to access the database as a superuser. For example, if the root
-# user is assigned a password, `dolt sql` should still be able to log in as a superuser, since the user
-# already has access to the host and data directory.
-@test "sql-privs: superuser access is always available from dolt sql" {
-    # Create a root@% user with a password set
-    dolt sql -q "CREATE USER root@'%' identified by 'pass1'; grant all on *.* to root@'%' with grant option;"
-
-    # Make sure dolt sql can still log in as root, even though root has a password set now
-    run dolt sql -q "select user();"
-    [ $status -eq 0 ]
-    [[ $output =~ "root@localhost" ]] || false
-}
-
 @test "sql-privs: starting server with empty config works" {
     make_test_repo
     touch server.yaml

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -711,7 +711,7 @@ SQL
 
      # verify changes outside the session
      cd newdb
-     run dolt --user=dolt sql -q "show tables"
+     run dolt sql -q "show tables"
      [ "$status" -eq 0 ]
      [[ "$output" =~ "test" ]] || false
 }
@@ -1095,7 +1095,7 @@ END""")
     [ "$status" -eq 0 ]
     [[ "$output" =~ "new table a" ]] || false
 
-    run dolt --user=dolt sql -q "show tables"
+    run dolt sql -q "show tables"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "a" ]] || false
 
@@ -1104,7 +1104,7 @@ END""")
     [ "$status" -eq 0 ]
     [[ "$output" =~ "new table b" ]] || false
 
-    run dolt --user=dolt sql -q "show tables"
+    run dolt sql -q "show tables"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "b" ]] || false
 
@@ -1337,7 +1337,7 @@ END""")
     [ "$status" -eq 0 ]
     [[ "$output" =~ "new table a" ]] || false
 
-    run dolt --user=dolt sql -q "show tables"
+    run dolt sql -q "show tables"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "a" ]] || false
 
@@ -1346,7 +1346,7 @@ END""")
     [ "$status" -eq 0 ]
     [[ "$output" =~ "new table b" ]] || false
 
-    run dolt --user=dolt sql -q "show tables"
+    run dolt sql -q "show tables"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "b" ]] || false
 


### PR DESCRIPTION
Previously, Dolt would only create a `root` superuser on sql-server startup when no other user accounts had been created. This resulted in a behavior where users would run `dolt sql-server`, create user accounts, then the next time they restart the sql-server, the `root` account would no longer be present. This behavior has surprised several customers (see https://github.com/dolthub/dolt/issues/5759) and is different from MySQL's behavior, which creates a persistent `root` superuser as part of initialization. 

This change modifies this behavior so that a `root` superuser is created, and persisted, the first time a SQL server is started for a database, unless the `--skip-root-user-initialization` flag is specified, or if an ephemeral super user is requested with the `--user` option. Subsequent runs of `dolt sql-server` do **not** automatically create the `root` superuser – only the first time `dolt sql-server` is started when there is no privileges database yet, will trigger the `root` user to be created and the privileges database to be initialized

Internally, this is implemented by detecting the presence of any user account and privilege data stored to disk (by default, in the `.doltcfg/privileges.db` file). When no user account and privilege data exists, the `root` superuser initialization logic will run. This means the `privileges.db` data is now always created on the first run of `dolt sql-server`, even if the data is empty. 

As part of this change, the `root` superuser is now scoped to `localhost`, instead of `%` (i.e. any host). This improves the default security posture of a Dolt sql-server and better aligns with MySQL's behavior. Customers who rely on using the `root` account to connect from non-localhost hosts, will need to either log in and alter the `root` account to allow connections from the hosts they need, or they can specify the `DOLT_ROOT_HOST` and/or `DOLT_ROOT_PASSWORD` environment variables to override the default host (localhost) and password ("") for the `root` account when it is initialized the first time a sql-server is launched. 

One side effect of this change is that `dolt sql -u <user>` may work differently for some uses. Previously, if there was no user account and privilege data persisted to disk yet (i.e. the `.doltcfg/privileges.db` file), then users could specify any username and password to `dolt sql` (e.g. `dolt sql -u doesnotexist`) and they would still be logged in – user authentication was ignored since no user account and privilege data existed. Now that the user account and privilege data is always initialized when running `dolt sql-server`, customers may no longer use `dolt sql --user <user>` to log in with unknown user accounts. The workaround for this is to simply run `dolt sql` without the `--user` option, and Dolt will use the default local account. 

Fixes: https://github.com/dolthub/dolt/issues/5759

Depends on: https://github.com/dolthub/go-mysql-server/pull/2797

Related to: https://github.com/dolthub/doltgresql/pull/1113

Documentation updates: https://github.com/dolthub/docs/pull/2460