### PR TITLE
dolt bootstrap refactor

### DIFF
--- a/go/cmd/dolt/cli/cli_context.go
+++ b/go/cmd/dolt/cli/cli_context.go
@@ -47,8 +47,8 @@ type CliContext interface {
 
 // NewCliContext creates a new CliContext instance. Arguments must not be nil.
 func NewCliContext(args *argparser.ArgParseResults, config *env.DoltCliConfig, cwd filesys.Filesys, latebind LateBindQueryist) (CliContext, errhand.VerboseError) {
-	if args == nil || config == nil || latebind == nil {
-		return nil, errhand.VerboseErrorFromError(errors.New("Invariant violated. args, config, and latebind must be non nil."))
+	if args == nil || config == nil || cwd == nil || latebind == nil {
+		return nil, errhand.VerboseErrorFromError(errors.New("Invariant violated. args, config, cwd, and latebind must be non nil."))
 	}
 
 	return LateBindCliContext{

--- a/go/cmd/dolt/cli/cli_context.go
+++ b/go/cmd/dolt/cli/cli_context.go
@@ -18,12 +18,12 @@ import (
 	"context"
 	"errors"
 
-	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
+	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 )
 
 // LateBindQueryist is a function that will be called the first time Queryist is needed for use. Input is a context which

--- a/go/cmd/dolt/commands/init_test.go
+++ b/go/cmd/dolt/commands/init_test.go
@@ -72,7 +72,7 @@ func TestInit(t *testing.T) {
 			gCfg.SetStrings(test.GlobalConfig)
 			apr := argparser.ArgParseResults{}
 			latebind := func(ctx context.Context) (cli.Queryist, *sql.Context, func(), error) { return nil, nil, func() {}, nil }
-			cliCtx, _ := cli.NewCliContext(&apr, dEnv.Config, latebind)
+			cliCtx, _ := cli.NewCliContext(&apr, dEnv.Config, dEnv.FS, latebind)
 
 			result := InitCmd{}.Exec(context.Background(), "dolt init", test.Args, dEnv, cliCtx)
 			defer dEnv.DoltDB.Close()

--- a/go/cmd/dolt/commands/signed_commits_test.go
+++ b/go/cmd/dolt/commands/signed_commits_test.go
@@ -149,7 +149,7 @@ func execCommand(ctx context.Context, wd string, cmd cli.Command, args []string,
 		return
 	}
 
-	cliCtx, err := cli.NewCliContext(apr, cfg, latebind)
+	cliCtx, err := cli.NewCliContext(apr, cfg, dEnv.FS, latebind)
 	if err != nil {
 		err = fmt.Errorf("error creating cli context: %w", err)
 		return

--- a/go/cmd/dolt/commands/sql_test.go
+++ b/go/cmd/dolt/commands/sql_test.go
@@ -43,7 +43,7 @@ func TestSqlConsole(t *testing.T) {
 		require.NoError(t, err)
 		defer dEnv.DoltDB.Close()
 
-		cliCtx, err := NewArgFreeCliContext(ctx, dEnv)
+		cliCtx, err := NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 		require.NoError(t, err)
 
 		args := []string{}
@@ -76,7 +76,7 @@ func TestSqlBatchMode(t *testing.T) {
 			require.NoError(t, err)
 			defer dEnv.DoltDB.Close()
 
-			cliCtx, err := NewArgFreeCliContext(ctx, dEnv)
+			cliCtx, err := NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 			require.NoError(t, err)
 
 			args := []string{"-b", "-q", test.query}
@@ -119,7 +119,7 @@ func TestSqlSelect(t *testing.T) {
 			require.NoError(t, err)
 			defer dEnv.DoltDB.Close()
 
-			cliCtx, err := NewArgFreeCliContext(ctx, dEnv)
+			cliCtx, err := NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 			require.NoError(t, err)
 
 			args := []string{"-q", test.query}
@@ -149,7 +149,7 @@ func TestSqlShow(t *testing.T) {
 			require.NoError(t, err)
 			defer dEnv.DoltDB.Close()
 
-			cliCtx, err := NewArgFreeCliContext(ctx, dEnv)
+			cliCtx, err := NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 			require.NoError(t, err)
 
 			args := []string{"-q", test.query}
@@ -188,7 +188,7 @@ func TestCreateTable(t *testing.T) {
 			assert.NoError(t, err)
 			assert.False(t, has, "table exists before creating it")
 
-			cliCtx, err := NewArgFreeCliContext(ctx, dEnv)
+			cliCtx, err := NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 			require.NoError(t, err)
 
 			args := []string{"-q", test.query}
@@ -232,7 +232,7 @@ func TestShowTables(t *testing.T) {
 			require.NoError(t, err)
 			defer dEnv.DoltDB.Close()
 
-			cliCtx, err := NewArgFreeCliContext(ctx, dEnv)
+			cliCtx, err := NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 			require.NoError(t, err)
 
 			args := []string{"-q", test.query}
@@ -268,7 +268,7 @@ func TestAlterTable(t *testing.T) {
 			require.NoError(t, err)
 			defer dEnv.DoltDB.Close()
 
-			cliCtx, err := NewArgFreeCliContext(ctx, dEnv)
+			cliCtx, err := NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 			require.NoError(t, err)
 
 			args := []string{"-q", test.query}
@@ -299,7 +299,7 @@ func TestDropTable(t *testing.T) {
 			require.NoError(t, err)
 			defer dEnv.DoltDB.Close()
 
-			cliCtx, err := NewArgFreeCliContext(ctx, dEnv)
+			cliCtx, err := NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 			require.NoError(t, err)
 
 			args := []string{"-q", test.query}
@@ -420,7 +420,7 @@ func TestInsert(t *testing.T) {
 			require.NoError(t, err)
 			defer dEnv.DoltDB.Close()
 
-			cliCtx, err := NewArgFreeCliContext(ctx, dEnv)
+			cliCtx, err := NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 			require.NoError(t, err)
 
 			args := []string{"-q", test.query}
@@ -504,7 +504,7 @@ func TestUpdate(t *testing.T) {
 			require.NoError(t, err)
 			defer dEnv.DoltDB.Close()
 
-			cliCtx, err := NewArgFreeCliContext(ctx, dEnv)
+			cliCtx, err := NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 			require.NoError(t, err)
 
 			args := []string{"-q", test.query}
@@ -582,7 +582,7 @@ func TestDelete(t *testing.T) {
 			require.NoError(t, err)
 			defer dEnv.DoltDB.Close()
 
-			cliCtx, err := NewArgFreeCliContext(ctx, dEnv)
+			cliCtx, err := NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 			require.NoError(t, err)
 
 			args := []string{"-q", test.query}

--- a/go/cmd/dolt/commands/sqlserver/command_line_config.go
+++ b/go/cmd/dolt/commands/sqlserver/command_line_config.go
@@ -146,7 +146,7 @@ func NewCommandLineConfig(creds *cli.UserPassword, apr *argparser.ArgParseResult
 		config.withDataDir(dataDir)
 	}
 
-	// We explicitly don't use the dataDir flag from the APR here. The data dif flag is pull out early and converted
+	// We explicitly don't use the dataDir flag from the APR here. The data dir flag is pulled out early and converted
 	// to an absolute path. It is read in the GetDataDirPreStart function, which is called early in dolt.go to get the
 	// data dir for any dolt process. This complexity exists because the server's config.yaml config file can contain the
 	// dataDir, but we don't execute any server specific logic until after the database environment is initialized.

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -156,21 +156,32 @@ func ConfigureServices(
 	fs := dEnv.FS
 	InitDataDir := &svcs.AnonService{
 		InitF: func(ctx context.Context) (err error) {
+			/* NM4 - For the moment let's just ignore the arg at this point.
 			if len(serverConfig.DataDir()) > 0 && serverConfig.DataDir() != "." {
+
 				absDataDir, err := dEnv.FS.Abs("")
 				if err != nil {
 					return err
 				}
-				if serverConfig.DataDir() != absDataDir {
+
+				scDataDir := serverConfig.DataDir()
+				scDataDir, err = fs.Abs(scDataDir)
+				if err != nil {
+					return err
+				}
+
+				if scDataDir != absDataDir {
 					return errors.New("runtime error: server configured datadir mismatch")
 				}
+			}
 
 				// Load any persisted global variables from the new datadir's local configuration store
 				err = dsess.InitPersistedSystemVars(dEnv)
 				if err != nil {
 					logrus.Errorf("failed to load persisted global variables: %s\n", err.Error())
 				}
-			}
+			*/
+
 			dEnv.Config.SetFailsafes(env.DefaultFailsafeConfig)
 			return nil
 		},

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -154,39 +154,13 @@ func ConfigureServices(
 	controller.Register(newHeartbeatService(version, dEnv))
 
 	fs := dEnv.FS
-	InitDataDir := &svcs.AnonService{
+	InitFailsafes := &svcs.AnonService{
 		InitF: func(ctx context.Context) (err error) {
-			/* NM4 - For the moment let's just ignore the arg at this point.
-			if len(serverConfig.DataDir()) > 0 && serverConfig.DataDir() != "." {
-
-				absDataDir, err := dEnv.FS.Abs("")
-				if err != nil {
-					return err
-				}
-
-				scDataDir := serverConfig.DataDir()
-				scDataDir, err = fs.Abs(scDataDir)
-				if err != nil {
-					return err
-				}
-
-				if scDataDir != absDataDir {
-					return errors.New("runtime error: server configured datadir mismatch")
-				}
-			}
-
-				// Load any persisted global variables from the new datadir's local configuration store
-				err = dsess.InitPersistedSystemVars(dEnv)
-				if err != nil {
-					logrus.Errorf("failed to load persisted global variables: %s\n", err.Error())
-				}
-			*/
-
 			dEnv.Config.SetFailsafes(env.DefaultFailsafeConfig)
 			return nil
 		},
 	}
-	controller.Register(InitDataDir)
+	controller.Register(InitFailsafes)
 
 	var mrEnv *env.MultiRepoEnv
 	InitMultiEnv := &svcs.AnonService{

--- a/go/cmd/dolt/commands/sqlserver/server_test.go
+++ b/go/cmd/dolt/commands/sqlserver/server_test.go
@@ -77,7 +77,7 @@ func TestServerArgs(t *testing.T) {
 			"-t", "5",
 			"-l", "info",
 			"-r",
-		}, dEnv, controller)
+		}, dEnv, dEnv.FS, controller)
 	}()
 	err = controller.WaitForStart()
 	require.NoError(t, err)
@@ -118,7 +118,7 @@ listener:
 		dEnv.FS.WriteFile("config.yaml", []byte(yamlConfig), os.ModePerm)
 		StartServer(context.Background(), "0.0.0", "dolt sql-server", []string{
 			"--config", "config.yaml",
-		}, dEnv, controller)
+		}, dEnv, dEnv.FS, controller)
 	}()
 	err = controller.WaitForStart()
 	require.NoError(t, err)
@@ -151,7 +151,7 @@ func TestServerBadArgs(t *testing.T) {
 		t.Run(strings.Join(test, " "), func(t *testing.T) {
 			controller := svcs.NewController()
 			go func() {
-				StartServer(context.Background(), "test", "dolt sql-server", test, env, controller)
+				StartServer(context.Background(), "test", "dolt sql-server", test, env, env.FS, controller)
 			}()
 			if !assert.Error(t, controller.WaitForStart()) {
 				controller.Stop()
@@ -286,7 +286,7 @@ func TestServerFailsIfPortInUse(t *testing.T) {
 			"-t", "5",
 			"-l", "info",
 			"-r",
-		}, dEnv, controller)
+		}, dEnv, dEnv.FS, controller)
 	}()
 
 	err = controller.WaitForStart()

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -262,19 +262,28 @@ func StartServer(ctx context.Context, versionStr, commandStr string, args []stri
 }
 
 // GetDataDirPreStart returns the data dir to use for the process. This is called early in the bootstrapping of the process
-// to ensure that we load the database once and only once. Later in sql-server start up we validate that the datadir
-// hasn't changed for unexpected reasons.
+// to ensure that we know the data dir early. This function first parses the args for the --data-dir flag,
+// then attempts to find it in the server's yaml config file if it was specified.
+//
+// The returned value is non-empty only if we found a data dir. The string will be an absolute path to the data dir. An
+// empty string indicates that there was no data dir specified, and the caller should determine the data dir.
 func GetDataDirPreStart(fs filesys.Filesys, args []string) (string, error) {
 	ap := SqlServerCmd{}.ArgParser()
 	apr, err := cli.ParseArgs(ap, args, nil)
 	if err != nil {
-		// Parse failure at this stage is ignored. We'll handle it during command execution.
+		// Parse failure at this stage is ignored. We'll handle it during command execution, to be more consistent with
+		// other commands.
 		return "", nil
 	}
 
 	dataDir, hasDataDirArg := apr.GetValue(commands.DataDirFlag)
 	if hasDataDirArg {
 		// NM4 - ensure that dd is not specified in the config file before returning???
+		dataDir, err := fs.Abs(dataDir)
+		if err != nil {
+			return "", err
+		}
+
 		return dataDir, nil
 	}
 
@@ -287,11 +296,15 @@ func GetDataDirPreStart(fs filesys.Filesys, args []string) (string, error) {
 		}
 
 		if cfg.DataDir() != "" {
-			return cfg.DataDir(), nil
+			dataDir, err := fs.Abs(cfg.DataDir())
+			if err != nil {
+				return "", err
+			}
+			return dataDir, nil
 		}
 	}
 
-	return fs.Abs("")
+	return "", nil
 }
 
 // ServerConfigFromArgs returns a ServerConfig from the given args
@@ -313,7 +326,12 @@ func ServerConfigFromArgsWithReader(
 		return nil, err
 	}
 
-	serverConfig, err := getServerConfig(dEnv.FS, apr, reader)
+	dataDir, err := dEnv.FS.Abs("")
+	if err != nil {
+		return nil, err
+	}
+
+	serverConfig, err := getServerConfig(dEnv.FS, apr, dataDir, reader)
 	if err != nil {
 		return nil, fmt.Errorf("bad configuration: %w", err)
 	}
@@ -327,10 +345,10 @@ func ServerConfigFromArgsWithReader(
 
 // getServerConfig returns ServerConfig that is set either from yaml file if given, if not it is set with values defined
 // on command line. Server config variables not defined are set to default values.
-func getServerConfig(cwdFS filesys.Filesys, apr *argparser.ArgParseResults, reader ServerConfigReader) (servercfg.ServerConfig, error) {
+func getServerConfig(cwdFS filesys.Filesys, apr *argparser.ArgParseResults, dataDirOverride string, reader ServerConfigReader) (servercfg.ServerConfig, error) {
 	cfgFile, ok := apr.GetValue(configFileFlag)
 	if !ok {
-		return reader.ReadConfigArgs(apr)
+		return reader.ReadConfigArgs(apr, dataDirOverride)
 	}
 
 	cfg, err := reader.ReadConfigFile(cwdFS, cfgFile)
@@ -365,7 +383,7 @@ func GetClientConfig(cwdFS filesys.Filesys, creds *cli.UserPassword, apr *argpar
 	cfgFile, hasCfgFile := apr.GetValue(configFileFlag)
 
 	if !hasCfgFile {
-		return NewCommandLineConfig(creds, apr)
+		return NewCommandLineConfig(creds, apr, "") // NM4.
 	}
 
 	var yamlCfg servercfg.YAMLConfig

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -393,7 +393,7 @@ func GetClientConfig(cwdFS filesys.Filesys, creds *cli.UserPassword, apr *argpar
 	cfgFile, hasCfgFile := apr.GetValue(configFileFlag)
 
 	if !hasCfgFile {
-		return NewCommandLineConfig(creds, apr, "") // NM4.
+		return NewCommandLineConfig(creds, apr, "")
 	}
 
 	var yamlCfg servercfg.YAMLConfig

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -341,7 +341,7 @@ func ServerConfigFromArgsWithReader(
 		return nil, err
 	}
 
-	serverConfig, err := getServerConfig(dEnv.FS, apr, dataDir, reader)
+	serverConfig, err := getServerConfig(cwd, apr, dataDir, reader)
 	if err != nil {
 		return nil, fmt.Errorf("bad configuration: %w", err)
 	}

--- a/go/cmd/dolt/commands/utils.go
+++ b/go/cmd/dolt/commands/utils.go
@@ -106,7 +106,7 @@ func MaybeGetCommitWithVErr(dEnv *env.DoltEnv, maybeCommit string) (*doltdb.Comm
 }
 
 // NewArgFreeCliContext creates a new CliContext instance with no arguments using a local SqlEngine. This is useful for testing primarily
-func NewArgFreeCliContext(ctx context.Context, dEnv *env.DoltEnv) (cli.CliContext, errhand.VerboseError) {
+func NewArgFreeCliContext(ctx context.Context, dEnv *env.DoltEnv, cwd filesys.Filesys) (cli.CliContext, errhand.VerboseError) {
 	mrEnv, err := env.MultiEnvForSingleEnv(ctx, dEnv)
 	if err != nil {
 		return nil, errhand.VerboseErrorFromError(err)
@@ -119,7 +119,7 @@ func NewArgFreeCliContext(ctx context.Context, dEnv *env.DoltEnv) (cli.CliContex
 	if err != nil {
 		return nil, verr
 	}
-	return cli.NewCliContext(argparser.NewEmptyResults(), dEnv.Config, lateBind)
+	return cli.NewCliContext(argparser.NewEmptyResults(), dEnv.Config, cwd, lateBind)
 }
 
 // BuildSqlEngineQueryist Utility function to build a local SQLEngine for use interacting with data on disk using

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -1020,17 +1020,27 @@ func injectProfileArgs(apr *argparser.ArgParseResults, profileName, profilesJson
 					hasPassword = value.Bool()
 				} else if flag == cli.NoTLSFlag {
 					if value.Bool() {
-						aprUpdated = aprUpdated.InsertArgument(flag, "true")
+						// There is currently no way to unset a flag, but setting is to the empty string at least sets it to true.
+						aprUpdated, err = aprUpdated.SetArgument(flag, "")
+						if err != nil {
+							return nil, err
+						}
 					}
 				} else {
 					if value.Str != "" {
-						aprUpdated = aprUpdated.InsertArgument(flag, value.Str)
+						aprUpdated, err = aprUpdated.SetArgument(flag, value.Str)
+						if err != nil {
+							return nil, err
+						}
 					}
 				}
 			}
 		}
 		if !apr.Contains(cli.PasswordFlag) && hasPassword {
-			aprUpdated = aprUpdated.InsertArgument(cli.PasswordFlag, password)
+			aprUpdated, err = aprUpdated.SetArgument(cli.PasswordFlag, password)
+			if err != nil {
+				return nil, err
+			}
 		}
 		return aprUpdated, nil
 	} else {

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -571,7 +571,7 @@ func runMain() int {
 	defer emitUsageEvents(metricsEmitter, args)
 
 	if needsWriteAccess(subcommandName) {
-		err = reconfigIfTempFileMoveFails(dEnv)
+		err = reconfigIfTempFileMoveFails(dataDirFS)
 
 		if err != nil {
 			cli.PrintErrln(color.RedString("Failed to setup the temporary directory. %v`", err))

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -641,11 +641,11 @@ func resolveDataDir(gArgs *argparser.ArgParseResults, subCmd string, fs filesys.
 		if ok, dir := fs.Exists(dataDir); !ok || !dir {
 			return "", errors.New(fmt.Sprintf("Provided data directory does not exist: %s", dataDir))
 		}
+		globalDir = dataDir
 	}
 
-	// What do we return as default? CWD I guess?
 	if subCmd == "sql-server" {
-		panic("Why you like servers so much?")
+		// Load the server config??
 	}
 
 	return globalDir, nil

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -885,7 +885,14 @@ type bootstrapConfig struct {
 // |terminate| is set to true if the process should end for any reason. Errors or messages to the user will be printed already.
 // |status| is the exit code to terminate with, and can be ignored if |terminate| is false.
 func createBootstrapConfig(ctx context.Context, args []string) (cfg *bootstrapConfig, terminate bool, status int) {
-	cwdFs := filesys.LocalFS
+	lfs := filesys.LocalFS
+	cwd, err := lfs.Abs("")
+	cwdFs, err := lfs.WithWorkingDir(cwd)
+	if err != nil {
+		cli.PrintErrln(color.RedString("Failed to load the current working directory: %v", err))
+		return nil, true, 1
+	}
+
 	tmpEnv := env.LoadWithoutDB(ctx, env.GetCurrentUserHomeDir, cwdFs, doltversion.Version)
 	var globalConfig config.ReadWriteConfig
 

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -605,6 +605,7 @@ or check the docs for questions about usage.`)
 	return res
 }
 
+// NM4 - resolveDataDir
 func resolveDataDir(gArgs *argparser.ArgParseResults, subCmd string, remainingArgs []string, fs filesys.Filesys) (string, error) {
 	// global config is the dolt --data-dir <foo> sub-command version. Applies to most CLI commands.
 	globalDir, hasGlobalDataDir := gArgs.GetValue(commands.DataDirFlag)
@@ -625,7 +626,10 @@ func resolveDataDir(gArgs *argparser.ArgParseResults, subCmd string, remainingAr
 		if err != nil {
 			return "", err
 		}
-		return dd, nil
+
+		if dd != "" {
+			return dd, nil
+		}
 	}
 
 	if globalDir == "" {
@@ -978,8 +982,8 @@ func parseGlobalArgsAndSubCommandName(ctx context.Context, args []string) (cfg *
 // NM4 -Update DOCs
 // getProfile retrieves the given profile from the provided list of profiles and returns the args (as flags) and values
 // for that profile in a []string. If the profile is not found, an error is returned.
-func injectProfileArgs(apr *argparser.ArgParseResults, profileName, profiles string) (aprUpdated *argparser.ArgParseResults, err error) {
-	prof := gjson.Get(profiles, profileName)
+func injectProfileArgs(apr *argparser.ArgParseResults, profileName, profilesJson string) (aprUpdated *argparser.ArgParseResults, err error) {
+	prof := gjson.Get(profilesJson, profileName)
 	aprUpdated = apr
 	if prof.Exists() {
 		hasPassword := false
@@ -992,7 +996,6 @@ func injectProfileArgs(apr *argparser.ArgParseResults, profileName, profiles str
 					hasPassword = value.Bool()
 				} else if flag == cli.NoTLSFlag {
 					if value.Bool() {
-						// NM4 - I don't think this is right. Test it, or make another accessor.
 						aprUpdated = aprUpdated.InsertArgument(flag, "true")
 					}
 				} else {

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -132,7 +132,6 @@ var doltSubCommands = []cli.Command{
 
 var commandsWithoutCliCtx = []cli.Command{
 	admin.Commands,
-	sqlserver.SqlServerCmd{VersionStr: doltversion.Version},
 	commands.CloneCmd{},
 	commands.BackupCmd{},
 	commands.LoginCmd{},
@@ -564,7 +563,7 @@ func runMain() int {
 			return 1
 		}
 
-		cliCtx, err = cli.NewCliContext(cfg.apr, dEnv.Config, lateBind)
+		cliCtx, err = cli.NewCliContext(cfg.apr, dEnv.Config, cfg.cwdFS, lateBind)
 		if err != nil {
 			cli.PrintErrln(color.RedString("Unexpected Error: %v", err))
 			return 1

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -30,6 +30,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/fatih/color"
+	"github.com/pkg/profile"
+	"github.com/tidwall/gjson"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/jaeger"
+	"go.opentelemetry.io/otel/sdk/resource"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
+
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands/admin"
@@ -56,15 +66,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/store/nbs"
 	"github.com/dolthub/dolt/go/store/util/tempfiles"
-	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/fatih/color"
-	"github.com/pkg/profile"
-	"github.com/tidwall/gjson"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/jaeger"
-	"go.opentelemetry.io/otel/sdk/resource"
-	tracesdk "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 )
 
 var dumpDocsCommand = &commands.DumpDocsCmd{}

--- a/go/cmd/dolt/system_checks.go
+++ b/go/cmd/dolt/system_checks.go
@@ -59,7 +59,6 @@ func reconfigIfTempFileMoveFails(dataDir filesys.Filesys) error {
 		tmpDirCreated = true
 
 	} else if !stat.IsDir() {
-		// Should the file exist?? If it does is it a problem? Is it a directory??
 		return fmt.Errorf("attempting to use '%s' as a temp directory, but there exists a file with that name", doltTmpDir)
 	}
 

--- a/go/cmd/dolt/system_checks.go
+++ b/go/cmd/dolt/system_checks.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/utils/file"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/store/util/tempfiles"
@@ -47,7 +48,7 @@ func reconfigIfTempFileMoveFails(dataDir filesys.Filesys) error {
 		dotDoltCreated = true
 	}
 
-	doltTmpDir := filepath.Join(doltDir, "tmp")
+	doltTmpDir := filepath.Join(doltDir, env.TmpDirName)
 	stat, err = os.Stat(doltTmpDir)
 	if err != nil {
 		err := os.MkdirAll(doltTmpDir, os.ModePerm)
@@ -76,7 +77,7 @@ func reconfigIfTempFileMoveFails(dataDir filesys.Filesys) error {
 
 	err = file.Rename(name, movedName)
 	if err == nil {
-		// tmp file system is the same as the data dir, so no need to change it.
+		// If rename was successful, then the tmp dir is fine, so no need to change it. Clean up the things we created.
 		_ = file.Remove(movedName)
 
 		if tmpDirCreated {
@@ -89,7 +90,7 @@ func reconfigIfTempFileMoveFails(dataDir filesys.Filesys) error {
 
 		return nil
 	}
-	_ = file.Remove(movedName)
+	_ = file.Remove(name)
 
 	// Rename failed. So we force the tmp dir to be the data dir.
 	tempfiles.MovableTempFileProvider = tempfiles.NewTempFileProviderAt(doltTmpDir)

--- a/go/cmd/dolt/system_checks.go
+++ b/go/cmd/dolt/system_checks.go
@@ -19,14 +19,15 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/utils/file"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/store/util/tempfiles"
 )
 
-// reconfigIfTempFileMoveFails checks to see if the file system used for the data directory supports moved from TMPDIR.
-// If this is not possible, we can't perform automic moves of storage files, so we force the temp dir to be the data dir
+// reconfigIfTempFileMoveFails checks to see if the file system used for the data directory supports moves from TMPDIR.
+// If this is not possible, we can't perform atomic moves of storage files, so we force the temp dir to be in the datadir
 // to assure they are on the same file system.
 func reconfigIfTempFileMoveFails(dataDir filesys.Filesys) error {
 	absP, err := dataDir.Abs("")
@@ -37,7 +38,7 @@ func reconfigIfTempFileMoveFails(dataDir filesys.Filesys) error {
 	dotDoltCreated := false
 	tmpDirCreated := false
 
-	doltDir := filepath.Join(absP, ".dolt")
+	doltDir := filepath.Join(absP, dbfactory.DoltDir)
 	stat, err := os.Stat(doltDir)
 	if err != nil {
 		err := os.MkdirAll(doltDir, os.ModePerm)

--- a/go/libraries/doltcore/doltdb/feature_version_test.go
+++ b/go/libraries/doltcore/doltdb/feature_version_test.go
@@ -59,7 +59,7 @@ func (cmd fvCommand) exec(ctx context.Context, dEnv *env.DoltEnv) int {
 	doltdb.DoltFeatureVersion = cmd.user.vers
 	defer func() { doltdb.DoltFeatureVersion = DoltFeatureVersionCopy }()
 
-	cliCtx, _ := commands.NewArgFreeCliContext(ctx, dEnv)
+	cliCtx, _ := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 
 	return cmd.cmd.Exec(ctx, cmd.cmd.Name(), cmd.args, dEnv, cliCtx)
 }

--- a/go/libraries/doltcore/doltdb/foreign_key_test.go
+++ b/go/libraries/doltcore/doltdb/foreign_key_test.go
@@ -109,7 +109,7 @@ func TestForeignKeyErrors(t *testing.T) {
 
 	ctx := context.Background()
 	dEnv := dtestutils.CreateTestEnv()
-	cliCtx, err := commands.NewArgFreeCliContext(ctx, dEnv)
+	cliCtx, err := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, err)
 
 	for _, c := range cmds {
@@ -154,7 +154,7 @@ func testForeignKeys(t *testing.T, test foreignKeyTest) {
 	ctx := context.Background()
 	dEnv := dtestutils.CreateTestEnv()
 
-	cliCtx, verr := commands.NewArgFreeCliContext(ctx, dEnv)
+	cliCtx, verr := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, verr)
 
 	for _, c := range fkSetupCommon {

--- a/go/libraries/doltcore/doltdb/gc_test.go
+++ b/go/libraries/doltcore/doltdb/gc_test.go
@@ -122,7 +122,7 @@ func testGarbageCollection(t *testing.T, test gcTest) {
 	dEnv := dtestutils.CreateTestEnv()
 	defer dEnv.DoltDB.Close()
 
-	cliCtx, verr := commands.NewArgFreeCliContext(ctx, dEnv)
+	cliCtx, verr := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, verr)
 
 	for _, c := range gcSetupCommon {

--- a/go/libraries/doltcore/dtestutils/testcommands/multienv.go
+++ b/go/libraries/doltcore/dtestutils/testcommands/multienv.go
@@ -168,7 +168,7 @@ func (mr *MultiRepoTestSetup) NewBranch(dbName, branchName string) {
 
 func (mr *MultiRepoTestSetup) CheckoutBranch(dbName, branchName string) {
 	dEnv := mr.envs[dbName]
-	cliCtx, _ := cmd.NewArgFreeCliContext(context.Background(), dEnv)
+	cliCtx, _ := cmd.NewArgFreeCliContext(context.Background(), dEnv, dEnv.FS)
 	_, sqlCtx, closeFunc, err := cliCtx.QueryEngine(context.Background())
 	if err != nil {
 		mr.Errhand(err)

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -149,7 +149,7 @@ func (dEnv *DoltEnv) ReloadRepoState() error {
 	return nil
 }
 
-func LoadWithoutDB(ctx context.Context, hdp HomeDirProvider, fs filesys.Filesys, version string) *DoltEnv {
+func LoadWithoutDB(_ context.Context, hdp HomeDirProvider, fs filesys.Filesys, version string) *DoltEnv {
 	cfg, cfgErr := LoadDoltCliConfig(hdp, fs)
 
 	repoState, rsErr := createRepoState(fs)

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -51,6 +51,8 @@ const (
 	DefaultRemotesApiPort = "443"
 
 	tempTablesDir = "temptf"
+
+	TmpDirName = "tmp"
 )
 
 var zeroHashStr = (hash.Hash{}).String()
@@ -450,13 +452,21 @@ func (dEnv *DoltEnv) createDirectories(dir string) (string, error) {
 	}
 
 	if dEnv.hasDoltDir(dir) {
-		// Special case a completely empty directory. We can allow that.
+		// Special case a completely empty directory, or one which has a "tmp" directory but nothing else.
+		// The `.dolt/tmp` directory is created while verifying that we can rename table files which is early
+		// in the startup process. It will only exist if we need it because the TMPDIR environment variable is set to
+		// a path which is on a different partition than the .dolt directory.
 		dotDolt := mustAbs(dEnv, dbfactory.DoltDir)
 		entries, err := os.ReadDir(dotDolt)
 		if err != nil {
 			return "", err
 		}
-		if len(entries) != 0 {
+
+		if len(entries) == 1 {
+			if !entries[0].IsDir() || entries[0].Name() != TmpDirName {
+				return "", fmt.Errorf(".dolt directory already exists at '%s'", dir)
+			}
+		} else if len(entries) != 0 {
 			return "", fmt.Errorf(".dolt directory already exists at '%s'", dir)
 		}
 	}

--- a/go/libraries/doltcore/merge/keyless_integration_test.go
+++ b/go/libraries/doltcore/merge/keyless_integration_test.go
@@ -114,7 +114,7 @@ func TestKeylessMerge(t *testing.T) {
 			require.NoError(t, err)
 			err = dEnv.UpdateWorkingRoot(ctx, root)
 			require.NoError(t, err)
-			cliCtx, err := cmd.NewArgFreeCliContext(ctx, dEnv)
+			cliCtx, err := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 			require.NoError(t, err)
 
 			for _, c := range test.setup {
@@ -249,7 +249,7 @@ func TestKeylessMergeConflicts(t *testing.T) {
 		require.NoError(t, err)
 		err = dEnv.UpdateWorkingRoot(ctx, root)
 		require.NoError(t, err)
-		cliCtx, err := cmd.NewArgFreeCliContext(ctx, dEnv)
+		cliCtx, err := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 		require.NoError(t, err)
 
 		for _, c := range cc {
@@ -282,7 +282,7 @@ func TestKeylessMergeConflicts(t *testing.T) {
 			defer dEnv.DoltDB.Close()
 
 			setupTest(t, ctx, dEnv, test.setup)
-			cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv)
+			cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 			require.NoError(t, verr)
 
 			resolve := cnfcmds.ResolveCmd{}
@@ -302,7 +302,7 @@ func TestKeylessMergeConflicts(t *testing.T) {
 			defer dEnv.DoltDB.Close()
 
 			setupTest(t, ctx, dEnv, test.setup)
-			cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv)
+			cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 			require.NoError(t, verr)
 
 			resolve := cnfcmds.ResolveCmd{}

--- a/go/libraries/doltcore/merge/schema_integration_test.go
+++ b/go/libraries/doltcore/merge/schema_integration_test.go
@@ -40,7 +40,7 @@ type testCommand struct {
 }
 
 func (tc testCommand) exec(t *testing.T, ctx context.Context, dEnv *env.DoltEnv) int {
-	cliCtx, err := commands.NewArgFreeCliContext(ctx, dEnv)
+	cliCtx, err := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, err)
 	return tc.cmd.Exec(ctx, tc.cmd.Name(), tc.args, dEnv, cliCtx)
 }
@@ -559,7 +559,7 @@ func testMergeSchemas(t *testing.T, test mergeSchemaTest) {
 	defer dEnv.DoltDB.Close()
 	ctx := context.Background()
 
-	cliCtx, _ := commands.NewArgFreeCliContext(ctx, dEnv)
+	cliCtx, _ := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 
 	for _, c := range setupCommon {
 		exit := c.exec(t, ctx, dEnv)
@@ -618,7 +618,7 @@ func testMergeSchemasWithConflicts(t *testing.T, test mergeSchemaConflictTest) {
 		require.Equal(t, 0, exit)
 	}
 
-	cliCtx, _ := commands.NewArgFreeCliContext(ctx, dEnv)
+	cliCtx, _ := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 
 	// assert that we're on main
 	exitCode := commands.CheckoutCmd{}.Exec(ctx, "checkout", []string{env.DefaultInitBranch}, dEnv, cliCtx)
@@ -680,7 +680,7 @@ func testMergeForeignKeys(t *testing.T, test mergeForeignKeyTest) {
 		require.Equal(t, 0, exit)
 	}
 
-	cliCtx, _ := commands.NewArgFreeCliContext(ctx, dEnv)
+	cliCtx, _ := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 
 	// assert that we're on main
 	exitCode := commands.CheckoutCmd{}.Exec(ctx, "checkout", []string{env.DefaultInitBranch}, dEnv, cliCtx)

--- a/go/libraries/doltcore/migrate/integration_test.go
+++ b/go/libraries/doltcore/migrate/integration_test.go
@@ -170,7 +170,7 @@ func setupMigrationTest(t *testing.T, ctx context.Context, test migrationTest) *
 		dEnv, err = test.hook(ctx, dEnv)
 		require.NoError(t, err)
 	}
-	cliCtx, err := commands.NewArgFreeCliContext(ctx, dEnv)
+	cliCtx, err := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, err)
 
 	cmd := commands.SqlCmd{}

--- a/go/libraries/doltcore/rebase/filter_branch_test.go
+++ b/go/libraries/doltcore/rebase/filter_branch_test.go
@@ -202,7 +202,7 @@ func filterBranchTests() []filterBranchTest {
 func setupFilterBranchTests(t *testing.T) *env.DoltEnv {
 	ctx := context.Background()
 	dEnv := dtestutils.CreateTestEnv()
-	cliCtx, err := cmd.NewArgFreeCliContext(ctx, dEnv)
+	cliCtx, err := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, err)
 
 	for _, c := range setupCommon {
@@ -217,7 +217,7 @@ func testFilterBranch(t *testing.T, test filterBranchTest) {
 	ctx := context.Background()
 	dEnv := setupFilterBranchTests(t)
 	defer dEnv.DoltDB.Close()
-	cliCtx, err := cmd.NewArgFreeCliContext(ctx, dEnv)
+	cliCtx, err := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, err)
 
 	for _, c := range test.setup {

--- a/go/libraries/doltcore/schema/integration_test.go
+++ b/go/libraries/doltcore/schema/integration_test.go
@@ -176,7 +176,7 @@ func TestGetKeyTags(t *testing.T) {
 func runTestSql(t *testing.T, ctx context.Context, setup []string) (*doltdb.DoltDB, doltdb.RootValue) {
 	dEnv := dtestutils.CreateTestEnv()
 	cmd := commands.SqlCmd{}
-	cliCtx, verr := commands.NewArgFreeCliContext(ctx, dEnv)
+	cliCtx, verr := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, verr)
 
 	for _, query := range setup {

--- a/go/libraries/doltcore/sqle/integration_test/database_revision_test.go
+++ b/go/libraries/doltcore/sqle/integration_test/database_revision_test.go
@@ -152,7 +152,7 @@ func TestDbRevision(t *testing.T) {
 			dEnv := dtestutils.CreateTestEnv()
 			defer dEnv.DoltDB.Close()
 
-			cliCtx, _ := cmd.NewArgFreeCliContext(ctx, dEnv)
+			cliCtx, _ := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 
 			setup := append(setupCommon, test.setup...)
 			for _, c := range setup {

--- a/go/libraries/doltcore/sqle/integration_test/history_table_test.go
+++ b/go/libraries/doltcore/sqle/integration_test/history_table_test.go
@@ -212,7 +212,7 @@ var INIT = ""   // HEAD~4
 func setupHistoryTests(t *testing.T) *env.DoltEnv {
 	ctx := context.Background()
 	dEnv := dtestutils.CreateTestEnv()
-	cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv)
+	cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, verr)
 
 	for _, c := range setupCommon {
@@ -239,7 +239,7 @@ func setupHistoryTests(t *testing.T) *env.DoltEnv {
 
 func testHistoryTable(t *testing.T, test historyTableTest, dEnv *env.DoltEnv) {
 	ctx := context.Background()
-	cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv)
+	cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, verr)
 
 	for _, c := range test.setup {

--- a/go/libraries/doltcore/sqle/integration_test/json_value_test.go
+++ b/go/libraries/doltcore/sqle/integration_test/json_value_test.go
@@ -127,7 +127,7 @@ func TestJsonValues(t *testing.T) {
 func testJsonValue(t *testing.T, test jsonValueTest, setupCommon []testCommand) {
 	ctx := context.Background()
 	dEnv := dtestutils.CreateTestEnv()
-	cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv)
+	cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, verr)
 
 	setup := append(setupCommon, test.setup...)

--- a/go/libraries/utils/argparser/parser_test.go
+++ b/go/libraries/utils/argparser/parser_test.go
@@ -169,3 +169,16 @@ func TestArgParser(t *testing.T) {
 		}
 	}
 }
+
+func TestArgParserSet(t *testing.T) {
+	ap := createParserWithOptionalArgs()
+	apr, err := ap.Parse([]string{"-o", "optional value", "-f", "foo", "bar"})
+	require.NoError(t, err)
+
+	apr, err = apr.SetArgument("param", "abcdefg")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"flag": "", "optional": "optional value", "param": "abcdefg"}, apr.options)
+
+	apr, err = apr.SetArgument("garbage", "garbage value")
+	require.Error(t, err)
+}

--- a/go/libraries/utils/argparser/results.go
+++ b/go/libraries/utils/argparser/results.go
@@ -144,6 +144,18 @@ func (res *ArgParseResults) DropValue(name string) *ArgParseResults {
 	return &ArgParseResults{newNamedArgs, res.Args, res.parser, NO_POSITIONAL_ARGS}
 }
 
+// InsertArgument inserts a new argument into the results. A new ArgParseResults object is returned with the new
+// argument added. // NM4 - error when is exists??
+func (res *ArgParseResults) InsertArgument(name, val string) *ArgParseResults {
+	newNamedArgs := make(map[string]string, len(res.options)+1)
+	for flag, origVal := range res.options {
+		newNamedArgs[flag] = origVal
+	}
+	newNamedArgs[name] = val
+
+	return &ArgParseResults{newNamedArgs, res.Args, res.parser, NO_POSITIONAL_ARGS}
+}
+
 func (res *ArgParseResults) MustGetValue(name string) string {
 	val, ok := res.options[name]
 

--- a/go/performance/microsysbench/sysbench_test.go
+++ b/go/performance/microsysbench/sysbench_test.go
@@ -178,7 +178,7 @@ func populateRepo(dEnv *env.DoltEnv, insertData string) {
 	execSql := func(dEnv *env.DoltEnv, q string) int {
 		ctx := context.Background()
 		args := []string{"-r", "null", "-q", q}
-		cliCtx, err := commands.NewArgFreeCliContext(ctx, dEnv)
+		cliCtx, err := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 		if err != nil {
 			panic(err)
 		}

--- a/integration-tests/bats/profile.bats
+++ b/integration-tests/bats/profile.bats
@@ -48,7 +48,7 @@ teardown() {
 
     run dolt --profile nonExistentProfile sql -q "select * from altDB_tbl"
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "Failure to parse arguments: profile nonExistentProfile not found" ]] || false
+    [[ "$output" =~ "Failed to inject profile arguments: profile nonExistentProfile not found" ]] || false
 }
 
 @test "profile: additional flag gets used" {

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -1362,7 +1362,7 @@ END""")
     [[ $output =~ "test2" ]] || false
 }
 
-@test "sql-server: fetch uses database tempdir from different working directory" {
+@test "sql-server: fetch uses database data dir from different working directory" {
     skiponwindows "Missing dependencies"
 
     mkdir remote1


### PR DESCRIPTION
This change alters the way we resolve the data-dir and initialized dolt processes. It originated from discovering that the tmp dir `replace` test at startup was leaving a test file in the current working directory. Long story short - the resolution of data-dir was too late in the process startup when sql-server was starting.

External behavior which will change:
1) Specifying `data_dir` in sql-server config file will correctly test the ability to rename files on the same partition, and override the TMPDIR environment variable when necessary, using $DATADIR/tmp when the user specified directory is on the wrong partition
2) Fail to start the server when the data-dir is specified multiple times. This will result in server startup failure for existing deployments which "work" (we choose the data-dir deterministically now, but not in the expected precedence)

Fixes: https://github.com/dolthub/dolt/issues/8498