### PR TITLE
Allow storing/reading 32 bit offsets in nodes.

### DIFF
--- a/go/store/prolly/message/address_map.go
+++ b/go/store/prolly/message/address_map.go
@@ -90,9 +90,9 @@ func getAddressMapKeys(msg serial.Message) (keys ItemAccess, err error) {
 		return keys, err
 	}
 	keys.bufStart = lookupVectorOffset(addressMapKeyItemsBytesVOffset, am.Table())
-	keys.bufLen = uint16(am.KeyItemsLength())
+	keys.bufLen = uint32(am.KeyItemsLength())
 	keys.offStart = lookupVectorOffset(addressMapKeyItemsOffsetsVOffset, am.Table())
-	keys.offLen = uint16(am.KeyOffsetsLength() * uint16Size)
+	keys.offLen = uint32(am.KeyOffsetsLength() * uint16Size)
 	return
 }
 
@@ -103,7 +103,7 @@ func getAddressMapValues(msg serial.Message) (values ItemAccess, err error) {
 		return values, err
 	}
 	values.bufStart = lookupVectorOffset(addressMapAddressArrayVOffset, am.Table())
-	values.bufLen = uint16(am.AddressArrayLength())
+	values.bufLen = uint32(am.AddressArrayLength())
 	values.itemWidth = hash.ByteLen
 	return
 }

--- a/go/store/prolly/message/blob.go
+++ b/go/store/prolly/message/blob.go
@@ -78,11 +78,11 @@ func getBlobValues(msg serial.Message) (values ItemAccess, err error) {
 	}
 	if b.TreeLevel() > 0 {
 		values.bufStart = lookupVectorOffset(blobAddressArrayVOffset, b.Table())
-		values.bufLen = uint16(b.AddressArrayLength())
+		values.bufLen = uint32(b.AddressArrayLength())
 		values.itemWidth = hash.ByteLen
 	} else {
 		values.bufStart = lookupVectorOffset(blobPayloadBytesVOffset, b.Table())
-		values.bufLen = uint16(b.PayloadLength())
+		values.bufLen = uint32(b.PayloadLength())
 		values.itemWidth = uint16(b.PayloadLength())
 	}
 	return

--- a/go/store/prolly/message/commit_closure.go
+++ b/go/store/prolly/message/commit_closure.go
@@ -40,7 +40,7 @@ func getCommitClosureKeys(msg serial.Message) (ItemAccess, error) {
 		return ret, err
 	}
 	ret.bufStart = lookupVectorOffset(commitClosureKeyItemBytesVOffset, m.Table())
-	ret.bufLen = uint16(m.KeyItemsLength())
+	ret.bufLen = uint32(m.KeyItemsLength())
 	ret.itemWidth = uint16(commitClosureKeyLength)
 	return ret, nil
 }
@@ -58,7 +58,7 @@ func getCommitClosureValues(msg serial.Message) (ItemAccess, error) {
 		ret.itemWidth = 0
 	} else {
 		ret.bufStart = lookupVectorOffset(commitClosureAddressArrayVOffset, m.Table())
-		ret.bufLen = uint16(m.AddressArrayLength())
+		ret.bufLen = uint32(m.AddressArrayLength())
 		ret.itemWidth = hash.ByteLen
 	}
 	return ret, nil

--- a/go/store/prolly/message/merge_artifacts.go
+++ b/go/store/prolly/message/merge_artifacts.go
@@ -113,22 +113,22 @@ func getArtifactMapKeysAndValues(msg serial.Message) (keys, values ItemAccess, l
 		return
 	}
 	keys.bufStart = lookupVectorOffset(mergeArtifactKeyItemBytesVOffset, ma.Table())
-	keys.bufLen = uint16(ma.KeyItemsLength())
+	keys.bufLen = uint32(ma.KeyItemsLength())
 	keys.offStart = lookupVectorOffset(mergeArtifactKeyOffsetsVOffset, ma.Table())
-	keys.offLen = uint16(ma.KeyOffsetsLength() * uint16Size)
+	keys.offLen = uint32(ma.KeyOffsetsLength() * uint16Size)
 
-	count = (keys.offLen / 2) - 1
+	count = uint16(keys.offLen/2) - 1
 	level = uint16(ma.TreeLevel())
 
 	vv := ma.ValueItemsBytes()
 	if vv != nil {
 		values.bufStart = lookupVectorOffset(mergeArtifactValueItemBytesVOffset, ma.Table())
-		values.bufLen = uint16(ma.ValueItemsLength())
+		values.bufLen = uint32(ma.ValueItemsLength())
 		values.offStart = lookupVectorOffset(mergeArtifactValueOffsetsVOffset, ma.Table())
-		values.offLen = uint16(ma.ValueOffsetsLength() * uint16Size)
+		values.offLen = uint32(ma.ValueOffsetsLength() * uint16Size)
 	} else {
 		values.bufStart = lookupVectorOffset(mergeArtifactAddressArrayVOffset, ma.Table())
-		values.bufLen = uint16(ma.AddressArrayLength())
+		values.bufLen = uint32(ma.AddressArrayLength())
 		values.itemWidth = hash.ByteLen
 	}
 	return

--- a/go/store/prolly/message/message.go
+++ b/go/store/prolly/message/message.go
@@ -124,11 +124,11 @@ func GetSubtrees(msg serial.Message) ([]uint64, error) {
 	}
 }
 
-func lookupVectorOffset(vo fb.VOffsetT, tab fb.Table) uint16 {
+func lookupVectorOffset(vo fb.VOffsetT, tab fb.Table) uint32 {
 	off := fb.UOffsetT(tab.Offset(vo)) + tab.Pos
 	off += fb.GetUOffsetT(tab.Bytes[off:])
 	// data starts after metadata containing the vector length
-	return uint16(off + fb.UOffsetT(fb.SizeUOffsetT))
+	return uint32(off + fb.UOffsetT(fb.SizeUOffsetT))
 }
 
 func assertTrue(b bool, msg string) {

--- a/go/store/prolly/message/prolly_map.go
+++ b/go/store/prolly/message/prolly_map.go
@@ -111,22 +111,22 @@ func getProllyMapKeysAndValues(msg serial.Message) (keys, values ItemAccess, lev
 		return
 	}
 	keys.bufStart = lookupVectorOffset(prollyMapKeyItemBytesVOffset, pm.Table())
-	keys.bufLen = uint16(pm.KeyItemsLength())
+	keys.bufLen = uint32(pm.KeyItemsLength())
 	keys.offStart = lookupVectorOffset(prollyMapKeyOffsetsVOffset, pm.Table())
-	keys.offLen = uint16(pm.KeyOffsetsLength() * uint16Size)
+	keys.offLen = uint32(pm.KeyOffsetsLength() * uint16Size)
 
-	count = (keys.offLen / 2) - 1
+	count = uint16(keys.offLen/2) - 1
 	level = uint16(pm.TreeLevel())
 
 	vv := pm.ValueItemsBytes()
 	if vv != nil {
 		values.bufStart = lookupVectorOffset(prollyMapValueItemBytesVOffset, pm.Table())
-		values.bufLen = uint16(pm.ValueItemsLength())
+		values.bufLen = uint32(pm.ValueItemsLength())
 		values.offStart = lookupVectorOffset(prollyMapValueOffsetsVOffset, pm.Table())
-		values.offLen = uint16(pm.ValueOffsetsLength() * uint16Size)
+		values.offLen = uint32(pm.ValueOffsetsLength() * uint16Size)
 	} else {
 		values.bufStart = lookupVectorOffset(prollyMapAddressArrayBytesVOffset, pm.Table())
-		values.bufLen = uint16(pm.AddressArrayLength())
+		values.bufLen = uint32(pm.AddressArrayLength())
 		values.itemWidth = hash.ByteLen
 	}
 	return

--- a/go/store/prolly/message/prolly_map_test.go
+++ b/go/store/prolly/message/prolly_map_test.go
@@ -48,7 +48,7 @@ func TestGetKeyValueOffsetsVectors(t *testing.T) {
 
 func TestItemAccessSize(t *testing.T) {
 	sz := unsafe.Sizeof(ItemAccess{})
-	assert.Equal(t, 10, int(sz))
+	assert.Equal(t, 20, int(sz))
 }
 
 func randomByteSlices(t *testing.T, count int) (keys, values [][]byte) {

--- a/go/store/prolly/message/serialize.go
+++ b/go/store/prolly/message/serialize.go
@@ -62,6 +62,17 @@ func writeItemOffsets(b *fb.Builder, items [][]byte, sumSz int) fb.UOffsetT {
 	return b.EndVector(len(items) + 1)
 }
 
+func writeItemOffsets32(b *fb.Builder, items [][]byte, sumSz int) fb.UOffsetT {
+	var off = sumSz
+	for i := len(items) - 1; i >= 0; i-- {
+		b.PrependUint32(uint32(off))
+		off -= len(items[i])
+	}
+	assertTrue(off == 0, "incorrect final value after serializing offStart")
+	b.PrependUint32(uint32(off))
+	return b.EndVector(len(items) + 1)
+}
+
 // countAddresses returns the number of chunk addresses stored within |items|.
 func countAddresses(items [][]byte, td val.TupleDesc) (cnt int) {
 	for i := len(items) - 1; i >= 0; i-- {

--- a/go/store/prolly/tree/node_test.go
+++ b/go/store/prolly/tree/node_test.go
@@ -68,7 +68,7 @@ func TestRoundTripNodeItems(t *testing.T) {
 
 func TestNodeSize(t *testing.T) {
 	sz := unsafe.Sizeof(Node{})
-	assert.Equal(t, 56, int(sz))
+	assert.Equal(t, 80, int(sz))
 }
 
 func BenchmarkNodeGet(b *testing.B) {

--- a/go/store/val/codec.go
+++ b/go/store/val/codec.go
@@ -306,7 +306,7 @@ func compareInt32(l, r int32) int {
 	}
 }
 
-func readUint32(val []byte) uint32 {
+func ReadUint32(val []byte) uint32 {
 	expectSize(val, uint32Size)
 	return binary.LittleEndian.Uint32(val)
 }
@@ -368,7 +368,7 @@ func compareUint64(l, r uint64) int {
 
 func readFloat32(val []byte) float32 {
 	expectSize(val, float32Size)
-	return math.Float32frombits(readUint32(val))
+	return math.Float32frombits(ReadUint32(val))
 }
 
 func writeFloat32(buf []byte, val float32) {
@@ -490,7 +490,7 @@ const (
 
 func readDate(val []byte) (date time.Time) {
 	expectSize(val, dateSize)
-	t := readUint32(val)
+	t := ReadUint32(val)
 	y := t >> yearShift
 	m := (t & monthMask) >> monthShift
 	d := (t & dayMask)

--- a/go/store/val/codec_test.go
+++ b/go/store/val/codec_test.go
@@ -457,7 +457,7 @@ func roundTripUints(t *testing.T) {
 	for _, value := range uintegers {
 		exp := uint32(value)
 		writeUint32(buf, exp)
-		assert.Equal(t, exp, readUint32(buf))
+		assert.Equal(t, exp, ReadUint32(buf))
 		zero(buf)
 	}
 

--- a/go/store/val/tuple_compare.go
+++ b/go/store/val/tuple_compare.go
@@ -104,7 +104,7 @@ func compare(typ Type, left, right []byte) int {
 	case Int32Enc:
 		return compareInt32(readInt32(left), readInt32(right))
 	case Uint32Enc:
-		return compareUint32(readUint32(left), readUint32(right))
+		return compareUint32(ReadUint32(left), ReadUint32(right))
 	case Int64Enc:
 		return compareInt64(readInt64(left), readInt64(right))
 	case Uint64Enc:

--- a/go/store/val/tuple_descriptor.go
+++ b/go/store/val/tuple_descriptor.go
@@ -282,7 +282,7 @@ func (td TupleDesc) GetUint32(i int, tup Tuple) (v uint32, ok bool) {
 	td.expectEncoding(i, Uint32Enc)
 	b := td.GetField(i, tup)
 	if b != nil {
-		v, ok = readUint32(b), true
+		v, ok = ReadUint32(b), true
 	}
 	return
 }
@@ -590,7 +590,7 @@ func (td TupleDesc) formatValue(enc Encoding, i int, value []byte) string {
 		v := readInt32(value)
 		return strconv.Itoa(int(v))
 	case Uint32Enc:
-		v := readUint32(value)
+		v := ReadUint32(value)
 		return strconv.Itoa(int(v))
 	case Int64Enc:
 		v := readInt64(value)


### PR DESCRIPTION
This change allows future node messages to use 32 bit offsets in their encoding.

This increases the side of the Node struct, but given that each Node is much smaller than the message that it backs, this isn't really a memory concern.

Currently, none of the node types use this, so this change shouldn't have any immediate effect on observable behavior.