### PR TITLE
Make show command more resilient when resolving references

### DIFF
--- a/go/cmd/dolt/commands/show.go
+++ b/go/cmd/dolt/commands/show.go
@@ -131,7 +131,7 @@ func (cmd ShowCmd) Exec(ctx context.Context, commandStr string, args []string, d
 	for _, specRef := range opts.specRefs {
 		if !hashRegex.MatchString(specRef) && !strings.EqualFold(specRef, "HEAD") {
 			// Call "dolt_hashof" to resolve the ref to a hash. the --no-pretty flag gets around the commit requirement, but
-			// requires the full object name so it will match the hashRegex and never his this code block.
+			// requires the full object name so it will match the hashRegex and never hit this code block.
 			h, err2 := getHashOf(queryist, sqlCtx, specRef)
 			if err2 != nil {
 				cli.PrintErrln("error: failed to resolve ref to commit: %s ", specRef)

--- a/go/cmd/dolt/commands/show.go
+++ b/go/cmd/dolt/commands/show.go
@@ -129,12 +129,15 @@ func (cmd ShowCmd) Exec(ctx context.Context, commandStr string, args []string, d
 
 	resolvedRefs := make([]string, 0, len(opts.specRefs))
 	for _, specRef := range opts.specRefs {
-		if !hashRegex.MatchString(specRef) && !strings.EqualFold(specRef, "HEAD") {
+		if !hashRegex.MatchString(specRef) &&
+			!strings.EqualFold(specRef, "HEAD") &&
+			!strings.EqualFold(specRef, "WORKING") &&
+			!strings.EqualFold(specRef, "STAGED") {
 			// Call "dolt_hashof" to resolve the ref to a hash. the --no-pretty flag gets around the commit requirement, but
 			// requires the full object name so it will match the hashRegex and never hit this code block.
 			h, err2 := getHashOf(queryist, sqlCtx, specRef)
 			if err2 != nil {
-				cli.PrintErrln("error: failed to resolve ref to commit: %s ", specRef)
+				cli.PrintErrln(fmt.Sprintf("branch not found: %s", specRef))
 				return 1
 			}
 			resolvedRefs = append(resolvedRefs, h)

--- a/go/cmd/dolt/commands/show.go
+++ b/go/cmd/dolt/commands/show.go
@@ -160,7 +160,7 @@ func (cmd ShowCmd) Exec(ctx context.Context, commandStr string, args []string, d
 		if dEnv == nil {
 			// Logic below requires a non-nil dEnv when --no-pretty is set.
 			// TODO: remove all usage of dEnv entirely from this command.
-			cli.PrintErrln("`\\show` is not fully supported in the SQL shell.")
+			cli.PrintErrln("`\\show --no-pretty` is not supported in the SQL shell.")
 			return 1
 		}
 
@@ -199,7 +199,7 @@ func (cmd ShowCmd) Exec(ctx context.Context, commandStr string, args []string, d
 				return 1
 			}
 			if dEnv == nil {
-				cli.PrintErrln("`dolt show (NON_COMMIT_HASH)` requires a local environment. Not intended to common use.")
+				cli.PrintErrln("`dolt show (NON_COMMIT_HASH)` requires a local environment. Not intended for common use.")
 				return 1
 			}
 			if !dEnv.DoltDB.Format().UsesFlatbuffers() {

--- a/integration-tests/bats/show.bats
+++ b/integration-tests/bats/show.bats
@@ -191,7 +191,7 @@ assert_has_key_value() {
     dolt add .
     dolt sql -q "create table table3 (pk int PRIMARY KEY)"
     dolt sql -q "insert into table1 values (7), (8), (9)"
-    run dolt show WORKING
+    run dolt show --no-pretty WORKING
     [ $status -eq 0 ]
     [[ "$output" =~ "table1" ]] || false
     [[ "$output" =~ "table2" ]] || false
@@ -208,7 +208,7 @@ assert_has_key_value() {
     dolt add .
     dolt sql -q "create table table3 (pk int PRIMARY KEY)"
     dolt sql -q "insert into table1 values (7), (8), (9)"
-    run dolt show STAGED
+    run dolt show --no-pretty STAGED
     [ $status -eq 0 ]
     [[ "$output" =~ "table1" ]] || false
     [[ "$output" =~ "table2" ]] || false
@@ -225,16 +225,15 @@ assert_has_key_value() {
     dolt add .
     dolt sql -q "create table table3 (pk int PRIMARY KEY)"
     dolt sql -q "insert into table1 values (7), (8), (9)"
-    workingRoot=$(dolt show WORKING)
+    workingRoot=$(dolt show --no-pretty WORKING)
     tableAddress=$(extract_value table1 "$workingRoot")
 
-    run dolt show $tableAddress
+    run dolt show --no-pretty $tableAddress
     assert_has_key Schema "$output"
     assert_has_key Violations "$output"
     assert_has_key Autoinc "$output"
     assert_has_key "Primary index" "$output"
     assert_has_key "Secondary indexes" "$output"
-
 }
 
 @test "show: pretty commit from hash" {


### PR DESCRIPTION
Currently the show command can print internal objects, which requires a local environment. This goes against the sql migration expectations that there is no environment. This change only makes the situation less bad. Splitting out the admin operations into another command is the right approach.

Fixes: https://github.com/dolthub/dolt/issues/8727