### PR TITLE
Tidy up journal writer code comments and error handling

### DIFF
--- a/go/libraries/doltcore/dconfig/envvars.go
+++ b/go/libraries/doltcore/dconfig/envvars.go
@@ -43,7 +43,6 @@ const (
 	EnvDoltAuthorDate                = "DOLT_AUTHOR_DATE"
 	EnvDoltCommitterDate             = "DOLT_COMMITTER_DATE"
 	EnvDbNameReplace                 = "DOLT_DBNAME_REPLACE"
-	EnvSkipInvalidJournalRecords     = "DOLT_SKIP_INVALID_JOURNAL_RECORDS"
 	EnvDoltRootHost                  = "DOLT_ROOT_HOST"
 	EnvDoltRootPassword              = "DOLT_ROOT_PASSWORD"
 )

--- a/go/libraries/doltcore/dconfig/envvars.go
+++ b/go/libraries/doltcore/dconfig/envvars.go
@@ -43,6 +43,7 @@ const (
 	EnvDoltAuthorDate                = "DOLT_AUTHOR_DATE"
 	EnvDoltCommitterDate             = "DOLT_COMMITTER_DATE"
 	EnvDbNameReplace                 = "DOLT_DBNAME_REPLACE"
+	EnvSkipInvalidJournalRecords     = "DOLT_SKIP_INVALID_JOURNAL_RECORDS"
 	EnvDoltRootHost                  = "DOLT_ROOT_HOST"
 	EnvDoltRootPassword              = "DOLT_ROOT_PASSWORD"
 )

--- a/go/store/nbs/journal_record_test.go
+++ b/go/store/nbs/journal_record_test.go
@@ -18,14 +18,12 @@ import (
 	"bytes"
 	"context"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/dconfig"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/d"
 	"github.com/dolthub/dolt/go/store/hash"
@@ -120,20 +118,8 @@ func TestProcessJournalRecords(t *testing.T) {
 	assert.Equal(t, int(off), int(n))
 	require.NoError(t, err)
 
-	// write a bogus record to the end and verify that we get an error
+	// write a bogus record to the end and verify that we don't get an error
 	i, sum = 0, 0
-	writeCorruptJournalRecord(journal[off:])
-	n, err = processJournalRecords(ctx, bytes.NewReader(journal), 0, check)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "CRC checksum does not match")
-	assert.Equal(t, cnt, i)
-	// Since an error was encountered, the returned offset is 0
-	assert.Equal(t, 0, int(n))
-
-	// Turn on the env setting to stop processing journal records once we hit an invalid record
-	require.NoError(t, os.Setenv(dconfig.EnvSkipInvalidJournalRecords, "1"))
-	i, sum = 0, 0
-	// write a bogus record to the end and process again
 	writeCorruptJournalRecord(journal[off:])
 	n, err = processJournalRecords(ctx, bytes.NewReader(journal), 0, check)
 	require.NoError(t, err)

--- a/go/store/nbs/journal_writer.go
+++ b/go/store/nbs/journal_writer.go
@@ -35,13 +35,17 @@ import (
 )
 
 const (
+	// chunkJournalFileSize is the size we initialize the journal file to when it is first created. We
+	// create a 16KB block of zero-initialized data and then sync the file to the first byte. We do this
+	// to ensure that we can write to the journal file and that we have some space for initial records.
+	// This probably isn't strictly necessary, but it also doesn't hurt.
 	chunkJournalFileSize = 16 * 1024
 
-	// todo(andy): buffer must be able to hold an entire record,
-	//   but we don't have a hard limit on record size right now.
-	//   JSON data has cases where it won't chunk down as small as other data,
-	//   so we have increased this to 5MB. If/when JSON chunking handles those
-	//   cases, we could decrease this size to 1MB again.
+	// journalWriterBuffSize is the size of the statically allocated buffer where journal records are
+	// built before being written to the journal file on disk. There is not a hard limit on the size
+	// of records – specifically, some newer data chunking formats (i.e. optimized JSON storage) can
+	// produce chunks (and therefore chunk records) that are megabytes in size. The current limit of
+	// 5MB should be large enough to cover all but the most extreme cases.
 	journalWriterBuffSize = 5 * 1024 * 1024
 
 	chunkJournalAddr = chunks.JournalFileID
@@ -118,6 +122,9 @@ func createJournalWriter(ctx context.Context, path string) (wr *journalWriter, e
 		return nil, err
 	}
 
+	// Open the journal file and initialize it with 16KB of zero bytes. This is intended to
+	// ensure that we can write to the journal and to allocate space for the first set of
+	// records, but probably isn't strictly necessary.
 	if f, err = os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0666); err != nil {
 		return nil, err
 	}
@@ -183,7 +190,7 @@ var _ io.Closer = &journalWriter{}
 // The journal index will bw truncated to the last valid batch of lookups. Lookups with offsets
 // larger than the position of the last valid lookup metadata are rewritten to the index as they
 // are added to the novel ranges map. If the number of novel lookups exceeds |wr.maxNovel|, we
-// extend the jounral index with one metadata flush before existing this function to save indexing
+// extend the journal index with one metadata flush before existing this function to save indexing
 // progress.
 func (wr *journalWriter) bootstrapJournal(ctx context.Context, reflogRingBuffer *reflogRingBuffer) (last hash.Hash, err error) {
 	wr.lock.Lock()


### PR DESCRIPTION
Before this change, the code that iterates over journal records would silently stop processing journal records once it encountered any invalid record. This change turns those invalid records into errors so that data isn't silently ignored. Customers can opt-in to the previous behavior by setting the `DOLT_SKIP_INVALID_JOURNAL_RECORDS ` environment variable to any value. 