### PR TITLE
Create dolt_help system table

### DIFF
--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -60,6 +60,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dfunctions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dtables"
 	"github.com/dolthub/dolt/go/libraries/events"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 	"github.com/dolthub/dolt/go/libraries/utils/config"
@@ -226,6 +227,8 @@ func init() {
 	if _, ok := os.LookupEnv(disableEventFlushEnvVar); ok {
 		eventFlushDisabled = true
 	}
+
+	dtables.DoltCommand = doltCommand
 }
 
 const pprofServerFlag = "--pprof-server"

--- a/go/libraries/doltcore/doltdb/system_table.go
+++ b/go/libraries/doltcore/doltdb/system_table.go
@@ -217,6 +217,7 @@ var getGeneratedSystemTables = func() []string {
 		GetCommitAncestorsTableName(),
 		GetStatusTableName(),
 		GetRemotesTableName(),
+		GetHelpTableName(),
 	}
 }
 
@@ -378,6 +379,11 @@ var GetStatusTableName = func() string {
 // GetTagsTableName returns the tags table name
 var GetTagsTableName = func() string {
 	return TagsTableName
+}
+
+// GetHelpTableName returns the help table name
+var GetHelpTableName = func() string {
+	return HelpTableName
 }
 
 const (
@@ -584,4 +590,8 @@ const (
 	// ProceduresTableSqlModeCol is the name of the column that stores the SQL_MODE string used when this fragment
 	// was originally defined. Mode settings, such as ANSI_QUOTES, are needed to correctly parse the fragment.
 	ProceduresTableSqlModeCol = "sql_mode"
+)
+
+const (
+	HelpTableName = "dolt_help"
 )

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -714,6 +714,14 @@ func (db Database) getTableInsensitive(ctx *sql.Context, head *doltdb.Commit, ds
 			return nil, false, err
 		}
 		dt = NewSchemaTable(backingTable)
+	case doltdb.GetHelpTableName(), doltdb.HelpTableName:
+		isDoltgresSystemTable, err := resolve.IsDoltgresSystemTable(ctx, tname, root)
+		if err != nil {
+			return nil, false, err
+		}
+		if !resolve.UseSearchPath || isDoltgresSystemTable {
+			dt, found = dtables.NewHelpTable(ctx, db.Name(), lwrName), true
+		}
 	}
 
 	if found {

--- a/go/libraries/doltcore/sqle/dtables/help_table.go
+++ b/go/libraries/doltcore/sqle/dtables/help_table.go
@@ -1,0 +1,211 @@
+// Copyright 2025 Dolthub, Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// 	http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dtables
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dprocedures"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/index"
+	"github.com/dolthub/go-mysql-server/sql"
+	sqlTypes "github.com/dolthub/go-mysql-server/sql/types"
+)
+
+type HelpTable struct {
+	dbName    string
+	tableName string
+}
+
+var HelpTableTypes = []string{
+	"system_table",
+	"procedure",
+	"function",
+	"variable",
+}
+
+// NewHelpTable creates a HelpTable
+func NewHelpTable(_ *sql.Context, dbName, tableName string) sql.Table {
+	return &HelpTable{dbName: dbName, tableName: tableName}
+}
+
+// Name is a sql.Table interface function which returns the name of the table.
+func (ht *HelpTable) Name() string {
+	return ht.tableName
+}
+
+// String is a sql.Table interface function which returns the name of the table.
+func (ht *HelpTable) String() string {
+	return ht.tableName
+}
+
+// Schema is a sql.Table interface function that gets the sql.Schema of the help system table.
+func (ht *HelpTable) Schema() sql.Schema {
+	return []*sql.Column{
+		{
+			Name:           "target",
+			Type:           sqlTypes.TinyText,
+			Source:         ht.tableName,
+			PrimaryKey:     true,
+			DatabaseSource: ht.dbName,
+		},
+		{
+			Name:           "type",
+			Type:           sqlTypes.MustCreateEnumType(HelpTableTypes, sql.Collation_Default),
+			Source:         ht.tableName,
+			PrimaryKey:     false,
+			DatabaseSource: ht.dbName,
+		},
+		{
+			Name:           "short_description",
+			Type:           sqlTypes.LongText,
+			Source:         ht.tableName,
+			PrimaryKey:     false,
+			DatabaseSource: ht.dbName,
+		},
+		{
+			Name:           "long_description",
+			Type:           sqlTypes.LongText,
+			Source:         ht.tableName,
+			PrimaryKey:     false,
+			DatabaseSource: ht.dbName,
+		},
+		{
+			Name:           "arguments",
+			Type:           sqlTypes.JSON,
+			Source:         ht.tableName,
+			PrimaryKey:     false,
+			DatabaseSource: ht.dbName,
+		},
+	}
+}
+
+// Collation implements the sql.Table interface.
+func (ht *HelpTable) Collation() sql.CollationID {
+	return sql.Collation_Default
+}
+
+// Partitions is a sql.Table interface function that returns a partition
+// of the data. Currently the data is unpartitioned.
+func (ht *HelpTable) Partitions(*sql.Context) (sql.PartitionIter, error) {
+	return index.SinglePartitionIterFromNomsMap(nil), nil
+}
+
+// PartitionRows is a sql.Table interface function that gets a row iterator for a partition.
+func (ht *HelpTable) PartitionRows(_ *sql.Context, _ sql.Partition) (sql.RowIter, error) {
+	return NewHelpRowIter(), nil
+}
+
+type HelpRowIter struct {
+	idx  *int
+	rows *[]sql.Row
+}
+
+func NewHelpRowIter() HelpRowIter {
+	idx := 0
+	var nilRows []sql.Row
+	return HelpRowIter{idx: &idx, rows: &nilRows}
+}
+
+// DoltCommand is set in cmd/dolt/dolt.go to avoid circular dependency.
+var DoltCommand cli.SubCommandHandler
+
+func (itr HelpRowIter) Next(_ *sql.Context) (sql.Row, error) {
+	helpRows := *itr.rows
+	if helpRows == nil {
+		var err error
+		helpRows, err = generateProcedureHelpRows(DoltCommand.Name(), DoltCommand.Subcommands)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if *itr.idx >= len(helpRows) {
+		return nil, io.EOF
+	}
+
+	row := helpRows[*itr.idx]
+	(*itr.idx)++
+	return row, nil
+}
+
+func (itr HelpRowIter) Close(_ *sql.Context) error {
+	return nil
+}
+
+// generateProcedureHelpRows generates a sql row for each procedure that has an equivalent CLI command.
+func generateProcedureHelpRows(cmdStr string, subCommands []cli.Command) ([]sql.Row, error) {
+	rows := []sql.Row{}
+
+	for _, curr := range subCommands {
+		if hidCmd, ok := curr.(cli.HiddenCommand); ok && hidCmd.Hidden() {
+			continue
+		}
+
+		if subCmdHandler, ok := curr.(cli.SubCommandHandler); ok {
+			if subCmdHandler.Unspecified != nil {
+				newRows, err := generateProcedureHelpRows(cmdStr, []cli.Command{subCmdHandler.Unspecified})
+				if err != nil {
+					return nil, err
+				}
+				rows = append(rows, newRows...)
+			}
+			newRows, err := generateProcedureHelpRows(cmdStr+"_"+subCmdHandler.Name(), subCmdHandler.Subcommands)
+			if err != nil {
+				return nil, err
+			}
+			rows = append(rows, newRows...)
+		} else {
+			nameFormatted := fmt.Sprintf("%s_%s", cmdStr, curr.Name())
+
+			nameComparable := strings.ReplaceAll(nameFormatted, "-", "_")
+
+			hasProcedure := false
+			for _, procedure := range dprocedures.DoltProcedures {
+				if procedure.Name == nameComparable {
+					hasProcedure = true
+					break
+				}
+			}
+
+			docs := curr.Docs()
+
+			if hasProcedure && docs != nil {
+				argsMap := map[string]string{}
+				for _, argHelp := range curr.Docs().ArgParser.ArgListHelp {
+					argsMap[argHelp[0]] = argHelp[1]
+				}
+
+				argsJson, err := json.Marshal(argsMap)
+				if err != nil {
+					return nil, err
+				}
+
+				rows = append(rows, sql.NewRow(
+					nameFormatted,
+					"procedure",
+					curr.Docs().ShortDesc,
+					curr.Docs().LongDesc,
+					argsJson,
+				))
+			}
+		}
+	}
+
+	return rows, nil
+}

--- a/integration-tests/bats/system-tables.bats
+++ b/integration-tests/bats/system-tables.bats
@@ -36,6 +36,7 @@ teardown() {
     [[ "$output" =~ "dolt_remote_branches" ]] || false
     [[ "$output" =~ "dolt_remotes" ]] || false
     [[ "$output" =~ "dolt_status" ]] || false
+    [[ "$output" =~ "dolt_help" ]] || false
     [[ "$output" =~ "test" ]] || false
 
     dolt add test
@@ -619,4 +620,24 @@ SQL
       run dolt sql -q "select * from dolt_schema_diff('tag2', 'tag2');"
       [ "$status" -eq 0 ]
       [ "$output" = "" ]
+}
+
+@test "system-tables: query dolt_help system table" {
+    run dolt sql -q "select type from dolt_help where target='dolt_rebase'"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "procedure" ]] || false
+
+    run dolt sql -q "select short_description from dolt_help where target='dolt_commit'"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Record changes to the database" ]] || false
+
+    run dolt sql -q "select long_description from dolt_help where target='dolt_add'"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "This command updates the list of tables using the current content found in the working root" ]] || false
+    [[ "$output" =~ "This command can be performed multiple times before a commit." ]] || false
+
+    run dolt sql -q "select arguments from dolt_help where target='dolt_pull'"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "remote".*"The name of the remote to pull from." ]] || false
+    [[ "$output" =~ "remoteBranch".*"The name of a branch on the specified remote to be merged into the current working set." ]] || false
 }


### PR DESCRIPTION
Created the dolt_help system table. This table is meant to store documentation for system tables, procedures, functions, and variables. Currently dolt_help is only populated with documentation for procedures, and only procedures that have equivalent CLI commands.

Part of #7984