### PR TITLE
Allow `dolt sql` to always log in as the `root` superuser

### DIFF
--- a/go/cmd/dolt/commands/utils.go
+++ b/go/cmd/dolt/commands/utils.go
@@ -287,20 +287,9 @@ func newLateBindingEngine(
 			}
 
 		} else {
+			// Ensure a root user exists, with superuser privs
 			dbUser = DefaultUser
 			ed := rawDb.Editor()
-			user := rawDb.GetUser(ed, dbUser, config.ServerHost, false)
-			ed.Close()
-			if user != nil {
-				// Want to ensure that the user has an empty password. If it has a password, we'll error
-				err := passwordValidate(rawDb, salt, dbUser, nil)
-				if err != nil {
-					return nil, nil, nil, err
-				}
-			}
-
-			// If the user doesn't exist, we'll create it with superuser privs.
-			ed = rawDb.Editor()
 			defer ed.Close()
 			rawDb.AddSuperUser(ed, dbUser, config.ServerHost, "")
 		}

--- a/integration-tests/bats/sql-privs.bats
+++ b/integration-tests/bats/sql-privs.bats
@@ -84,6 +84,19 @@ teardown() {
     [ $status -ne 0 ]
 }
 
+# Asserts that `dolt sql` can always be used to access the database as a superuser. For example, if the root
+# user is assigned a password, `dolt sql` should still be able to log in as a superuser, since the user
+# already has access to the host and data directory.
+@test "sql-privs: superuser access is always available from dolt sql" {
+    # Create a root@% user with a password set
+    dolt sql -q "CREATE USER root@'%' identified by 'pass1'; grant all on *.* to root@'%' with grant option;"
+
+    # Make sure dolt sql can still log in as root, even though root has a password set now
+    run dolt sql -q "select user();"
+    [ $status -eq 0 ]
+    [[ $output =~ "root@localhost" ]] || false
+}
+
 @test "sql-privs: starting server with empty config works" {
     make_test_repo
     touch server.yaml


### PR DESCRIPTION
From the command line, when a sql-server is not running, `dolt sql` implicitly uses the `root` account to log, but if the `root` account exists with a password, `dolt sql` will fail to log in. Since the user has access to the host and the database data directory, we should allow `dolt sql` to log into the SQL shell, even if the `root` user has a password set. This change also makes this behavior match when a sql-server is running, and we allow superuser login through the `__dolt_local_user__` account (which only exists while a sql-server is running). 