### PR TITLE
[no-release-notes] go/store/nbs: During a GC process, take dependencies on chunks that are read through the ChunkStore.

### DIFF
--- a/go/store/nbs/archive_build.go
+++ b/go/store/nbs/archive_build.go
@@ -425,7 +425,7 @@ func gatherAllChunks(ctx context.Context, cs chunkSource, idx tableIndex, stats 
 			return nil, nil, err
 		}
 
-		bytes, err := cs.get(ctx, h, stats)
+		bytes, _, err := cs.get(ctx, h, nil, stats)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -907,7 +907,7 @@ func (csc *simpleChunkSourceCache) get(ctx context.Context, h hash.Hash, stats *
 		return chk, nil
 	}
 
-	bytes, err := csc.cs.get(ctx, h, stats)
+	bytes, _, err := csc.cs.get(ctx, h, nil, stats)
 	if bytes == nil || err != nil {
 		return nil, err
 	}
@@ -919,7 +919,8 @@ func (csc *simpleChunkSourceCache) get(ctx context.Context, h hash.Hash, stats *
 
 // has returns true if the chunk is in the ChunkSource. This is not related to what is cached, just a helper.
 func (csc *simpleChunkSourceCache) has(h hash.Hash) (bool, error) {
-	return csc.cs.has(h)
+	res, _, err := csc.cs.has(h, nil)
+	return res, err
 }
 
 // addresses get all chunk addresses of the ChunkSource as a hash.HashSet.

--- a/go/store/nbs/archive_chunk_source.go
+++ b/go/store/nbs/archive_chunk_source.go
@@ -106,7 +106,10 @@ func (acs archiveChunkSource) getMany(ctx context.Context, eg *errgroup.Group, r
 	for i, req := range reqs {
 		h := *req.a
 		data, err := acs.aRdr.get(h)
-		if err != nil || data == nil {
+		if err != nil {
+			return true, gcBehavior_Continue, err
+		}
+		if data == nil {
 			foundAll = false
 		} else {
 			if keeper != nil && keeper(h) {

--- a/go/store/nbs/archive_chunk_source.go
+++ b/go/store/nbs/archive_chunk_source.go
@@ -64,42 +64,60 @@ func openReader(file string) (io.ReaderAt, uint64, error) {
 	return f, uint64(stat.Size()), nil
 }
 
-func (acs archiveChunkSource) has(h hash.Hash) (bool, error) {
-	return acs.aRdr.has(h), nil
+func (acs archiveChunkSource) has(h hash.Hash, keeper keeperF) (bool, gcBehavior, error) {
+	res := acs.aRdr.has(h)
+	if res && keeper != nil && keeper(h) {
+		return false, gcBehavior_Block, nil
+	}
+	return res, gcBehavior_Continue, nil
 }
 
-func (acs archiveChunkSource) hasMany(addrs []hasRecord) (bool, error) {
+func (acs archiveChunkSource) hasMany(addrs []hasRecord, keeper keeperF) (bool, gcBehavior, error) {
 	// single threaded first pass.
 	foundAll := true
 	for i, addr := range addrs {
-		if acs.aRdr.has(*(addr.a)) {
+		h := *addr.a
+		if acs.aRdr.has(h) {
+			if keeper != nil && keeper(h) {
+				return false, gcBehavior_Block, nil
+			}
 			addrs[i].has = true
 		} else {
 			foundAll = false
 		}
 	}
-	return !foundAll, nil
+	return !foundAll, gcBehavior_Continue, nil
 }
 
-func (acs archiveChunkSource) get(ctx context.Context, h hash.Hash, stats *Stats) ([]byte, error) {
-	// ctx, stats ? NM4.
-	return acs.aRdr.get(h)
+func (acs archiveChunkSource) get(ctx context.Context, h hash.Hash, keeper keeperF, stats *Stats) ([]byte, gcBehavior, error) {
+	res, err := acs.aRdr.get(h)
+	if err != nil {
+		return nil, gcBehavior_Continue, err
+	}
+	if res != nil && keeper != nil && keeper(h) {
+		return nil, gcBehavior_Block, nil
+	}
+	return res, gcBehavior_Continue, nil
 }
 
-func (acs archiveChunkSource) getMany(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, *chunks.Chunk), stats *Stats) (bool, error) {
+func (acs archiveChunkSource) getMany(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, *chunks.Chunk), keeper keeperF, stats *Stats) (bool, gcBehavior, error) {
 	// single threaded first pass.
 	foundAll := true
 	for i, req := range reqs {
-		data, err := acs.aRdr.get(*req.a)
+		h := *req.a
+		data, err := acs.aRdr.get(h)
 		if err != nil || data == nil {
 			foundAll = false
 		} else {
+			if keeper != nil && keeper(h) {
+				return true, gcBehavior_Block, nil
+			}
 			chunk := chunks.NewChunk(data)
 			found(ctx, &chunk)
 			reqs[i].found = true
 		}
 	}
-	return !foundAll, nil
+	return !foundAll, gcBehavior_Continue, nil
 }
 
 // iterate iterates over the archive chunks. The callback is called for each chunk in the archive. This is not optimized
@@ -146,14 +164,14 @@ func (acs archiveChunkSource) clone() (chunkSource, error) {
 	return archiveChunkSource{acs.file, rdr}, nil
 }
 
-func (acs archiveChunkSource) getRecordRanges(_ context.Context, _ []getRecord) (map[hash.Hash]Range, error) {
-	return nil, errors.New("Archive chunk source does not support getRecordRanges")
+func (acs archiveChunkSource) getRecordRanges(_ context.Context, _ []getRecord, _ keeperF) (map[hash.Hash]Range, gcBehavior, error) {
+	return nil, gcBehavior_Continue, errors.New("Archive chunk source does not support getRecordRanges")
 }
 
-func (acs archiveChunkSource) getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, CompressedChunk), stats *Stats) (bool, error) {
+func (acs archiveChunkSource) getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, CompressedChunk), keeper keeperF, stats *Stats) (bool, gcBehavior, error) {
 	return acs.getMany(ctx, eg, reqs, func(ctx context.Context, chk *chunks.Chunk) {
 		found(ctx, ChunkToCompressedChunk(*chk))
-	}, stats)
+	}, keeper, stats)
 }
 
 func (acs archiveChunkSource) iterateAllChunks(ctx context.Context, cb func(chunks.Chunk)) error {

--- a/go/store/nbs/archive_test.go
+++ b/go/store/nbs/archive_test.go
@@ -655,28 +655,28 @@ type testChunkSource struct {
 
 var _ chunkSource = (*testChunkSource)(nil)
 
-func (tcs *testChunkSource) get(_ context.Context, h hash.Hash, _ *Stats) ([]byte, error) {
+func (tcs *testChunkSource) get(_ context.Context, h hash.Hash, _ keeperF, _ *Stats) ([]byte, gcBehavior, error) {
 	for _, chk := range tcs.chunks {
 		if chk.Hash() == h {
-			return chk.Data(), nil
+			return chk.Data(), gcBehavior_Continue, nil
 		}
 	}
-	return nil, errors.New("not found")
+	return nil, gcBehavior_Continue, errors.New("not found")
 }
 
-func (tcs *testChunkSource) has(h hash.Hash) (bool, error) {
+func (tcs *testChunkSource) has(h hash.Hash, keeper keeperF) (bool, gcBehavior, error) {
 	panic("never used")
 }
 
-func (tcs *testChunkSource) hasMany(addrs []hasRecord) (bool, error) {
+func (tcs *testChunkSource) hasMany(addrs []hasRecord, keeper keeperF) (bool, gcBehavior, error) {
 	panic("never used")
 }
 
-func (tcs *testChunkSource) getMany(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, *chunks.Chunk), stats *Stats) (bool, error) {
+func (tcs *testChunkSource) getMany(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, *chunks.Chunk), keeper keeperF, stats *Stats) (bool, gcBehavior, error) {
 	panic("never used")
 }
 
-func (tcs *testChunkSource) getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, CompressedChunk), stats *Stats) (bool, error) {
+func (tcs *testChunkSource) getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, CompressedChunk), keeper keeperF, stats *Stats) (bool, gcBehavior, error) {
 	panic("never used")
 }
 
@@ -700,7 +700,7 @@ func (tcs *testChunkSource) reader(ctx context.Context) (io.ReadCloser, uint64, 
 	panic("never used")
 }
 
-func (tcs *testChunkSource) getRecordRanges(ctx context.Context, requests []getRecord) (map[hash.Hash]Range, error) {
+func (tcs *testChunkSource) getRecordRanges(ctx context.Context, requests []getRecord, keeper keeperF) (map[hash.Hash]Range, gcBehavior, error) {
 	panic("never used")
 }
 

--- a/go/store/nbs/aws_table_persister_test.go
+++ b/go/store/nbs/aws_table_persister_test.go
@@ -90,7 +90,7 @@ func TestAWSTablePersisterPersist(t *testing.T) {
 				s3svc := makeFakeS3(t)
 				s3p := awsTablePersister{s3: s3svc, bucket: "bucket", limits: limits5mb, ns: ns, q: &UnlimitedQuotaProvider{}}
 
-				src, err := s3p.Persist(context.Background(), mt, nil, &Stats{})
+				src, _, err := s3p.Persist(context.Background(), mt, nil, nil, &Stats{})
 				require.NoError(t, err)
 				defer src.close()
 
@@ -108,7 +108,7 @@ func TestAWSTablePersisterPersist(t *testing.T) {
 				s3svc := makeFakeS3(t)
 				s3p := awsTablePersister{s3: s3svc, bucket: "bucket", limits: limits64mb, ns: ns, q: &UnlimitedQuotaProvider{}}
 
-				src, err := s3p.Persist(context.Background(), mt, nil, &Stats{})
+				src, _, err := s3p.Persist(context.Background(), mt, nil, nil, &Stats{})
 				require.NoError(t, err)
 				defer src.close()
 				if assert.True(mustUint32(src.count()) > 0) {
@@ -133,7 +133,7 @@ func TestAWSTablePersisterPersist(t *testing.T) {
 				s3svc := makeFakeS3(t)
 				s3p := awsTablePersister{s3: s3svc, bucket: "bucket", limits: limits5mb, ns: ns, q: &UnlimitedQuotaProvider{}}
 
-				src, err := s3p.Persist(context.Background(), mt, existingTable, &Stats{})
+				src, _, err := s3p.Persist(context.Background(), mt, existingTable, nil, &Stats{})
 				require.NoError(t, err)
 				defer src.close()
 				assert.True(mustUint32(src.count()) == 0)
@@ -148,7 +148,7 @@ func TestAWSTablePersisterPersist(t *testing.T) {
 				s3svc := &failingFakeS3{makeFakeS3(t), sync.Mutex{}, 1}
 				s3p := awsTablePersister{s3: s3svc, bucket: "bucket", limits: limits5mb, ns: ns, q: &UnlimitedQuotaProvider{}}
 
-				_, err := s3p.Persist(context.Background(), mt, nil, &Stats{})
+				_, _, err := s3p.Persist(context.Background(), mt, nil, nil, &Stats{})
 				assert.Error(err)
 			})
 		}
@@ -306,7 +306,7 @@ func TestAWSTablePersisterConjoinAll(t *testing.T) {
 			for i := 0; i < len(chunks); i++ {
 				mt := newMemTable(uint64(2 * targetPartSize))
 				mt.addChunk(computeAddr(chunks[i]), chunks[i])
-				cs, err := s3p.Persist(context.Background(), mt, nil, &Stats{})
+				cs, _, err := s3p.Persist(context.Background(), mt, nil, nil, &Stats{})
 				require.NoError(t, err)
 				sources = append(sources, cs)
 			}
@@ -379,7 +379,7 @@ func TestAWSTablePersisterConjoinAll(t *testing.T) {
 			}
 
 			var err error
-			sources[i], err = s3p.Persist(context.Background(), mt, nil, &Stats{})
+			sources[i], _, err = s3p.Persist(context.Background(), mt, nil, nil, &Stats{})
 			require.NoError(t, err)
 		}
 		src, _, err := s3p.ConjoinAll(context.Background(), sources, &Stats{})
@@ -417,9 +417,9 @@ func TestAWSTablePersisterConjoinAll(t *testing.T) {
 			rand.Read(medChunks[i])
 			mt.addChunk(computeAddr(medChunks[i]), medChunks[i])
 		}
-		cs1, err := s3p.Persist(context.Background(), mt, nil, &Stats{})
+		cs1, _, err := s3p.Persist(context.Background(), mt, nil, nil, &Stats{})
 		require.NoError(t, err)
-		cs2, err := s3p.Persist(context.Background(), mtb, nil, &Stats{})
+		cs2, _, err := s3p.Persist(context.Background(), mtb, nil, nil, &Stats{})
 		require.NoError(t, err)
 		sources := chunkSources{cs1, cs2}
 
@@ -450,7 +450,7 @@ func TestAWSTablePersisterConjoinAll(t *testing.T) {
 			mt := newMemTable(uint64(2 * targetPartSize))
 			mt.addChunk(computeAddr(smallChunks[i]), smallChunks[i])
 			var err error
-			sources[i], err = s3p.Persist(context.Background(), mt, nil, &Stats{})
+			sources[i], _, err = s3p.Persist(context.Background(), mt, nil, nil, &Stats{})
 			require.NoError(t, err)
 		}
 
@@ -461,7 +461,7 @@ func TestAWSTablePersisterConjoinAll(t *testing.T) {
 		}
 
 		var err error
-		cs, err := s3p.Persist(context.Background(), mt, nil, &Stats{})
+		cs, _, err := s3p.Persist(context.Background(), mt, nil, nil, &Stats{})
 		require.NoError(t, err)
 		sources = append(sources, cs)
 
@@ -474,7 +474,7 @@ func TestAWSTablePersisterConjoinAll(t *testing.T) {
 			mt.addChunk(computeAddr(medChunks[i]), medChunks[i])
 		}
 
-		cs, err = s3p.Persist(context.Background(), mt, nil, &Stats{})
+		cs, _, err = s3p.Persist(context.Background(), mt, nil, nil, &Stats{})
 		require.NoError(t, err)
 		sources = append(sources, cs)
 

--- a/go/store/nbs/cmp_chunk_table_writer_test.go
+++ b/go/store/nbs/cmp_chunk_table_writer_test.go
@@ -51,7 +51,7 @@ func TestCmpChunkTableWriter(t *testing.T) {
 	found := make([]CompressedChunk, 0)
 
 	eg, egCtx := errgroup.WithContext(ctx)
-	_, err = tr.getManyCompressed(egCtx, eg, reqs, func(ctx context.Context, c CompressedChunk) { found = append(found, c) }, &Stats{})
+	_, _, err = tr.getManyCompressed(egCtx, eg, reqs, func(ctx context.Context, c CompressedChunk) { found = append(found, c) }, nil, &Stats{})
 	require.NoError(t, err)
 	require.NoError(t, eg.Wait())
 
@@ -146,7 +146,7 @@ func readAllChunks(ctx context.Context, hashes hash.HashSet, reader tableReader)
 	reqs := toGetRecords(hashes)
 	found := make([]*chunks.Chunk, 0)
 	eg, ctx := errgroup.WithContext(ctx)
-	_, err := reader.getMany(ctx, eg, reqs, func(ctx context.Context, c *chunks.Chunk) { found = append(found, c) }, &Stats{})
+	_, _, err := reader.getMany(ctx, eg, reqs, func(ctx context.Context, c *chunks.Chunk) { found = append(found, c) }, nil, &Stats{})
 	if err != nil {
 		return nil, err
 	}

--- a/go/store/nbs/conjoiner_test.go
+++ b/go/store/nbs/conjoiner_test.go
@@ -63,7 +63,7 @@ func makeTestSrcs(t *testing.T, tableSizes []uint32, p tablePersister) (srcs chu
 			c := nextChunk()
 			mt.addChunk(computeAddr(c), c)
 		}
-		cs, err := p.Persist(context.Background(), mt, nil, &Stats{})
+		cs, _, err := p.Persist(context.Background(), mt, nil, nil, &Stats{})
 		require.NoError(t, err)
 		c, err := cs.clone()
 		require.NoError(t, err)
@@ -180,7 +180,7 @@ func testConjoin(t *testing.T, factory func(t *testing.T) tablePersister) {
 		mt := newMemTable(testMemTableSize)
 		data := []byte{0xde, 0xad}
 		mt.addChunk(computeAddr(data), data)
-		src, err := p.Persist(context.Background(), mt, nil, &Stats{})
+		src, _, err := p.Persist(context.Background(), mt, nil, nil, &Stats{})
 		require.NoError(t, err)
 		defer src.close()
 		return tableSpec{src.hash(), mustUint32(src.count())}

--- a/go/store/nbs/conjoiner_test.go
+++ b/go/store/nbs/conjoiner_test.go
@@ -159,11 +159,11 @@ func testConjoin(t *testing.T, factory func(t *testing.T) tablePersister) {
 				var ok bool
 				for _, act := range actualSrcs {
 					var err error
-					ok, err = act.has(rec.a)
+					ok, _, err = act.has(rec.a, nil)
 					require.NoError(t, err)
 					var buf []byte
 					if ok {
-						buf, err = act.get(ctx, rec.a, stats)
+						buf, _, err = act.get(ctx, rec.a, nil, stats)
 						require.NoError(t, err)
 						assert.Equal(t, rec.data, buf)
 						break

--- a/go/store/nbs/empty_chunk_source.go
+++ b/go/store/nbs/empty_chunk_source.go
@@ -34,24 +34,24 @@ import (
 
 type emptyChunkSource struct{}
 
-func (ecs emptyChunkSource) has(h hash.Hash) (bool, error) {
-	return false, nil
+func (ecs emptyChunkSource) has(h hash.Hash, _ keeperF) (bool, gcBehavior, error) {
+	return false, gcBehavior_Continue, nil
 }
 
-func (ecs emptyChunkSource) hasMany(addrs []hasRecord) (bool, error) {
-	return true, nil
+func (ecs emptyChunkSource) hasMany(addrs []hasRecord, _ keeperF) (bool, gcBehavior, error) {
+	return true, gcBehavior_Continue, nil
 }
 
-func (ecs emptyChunkSource) get(ctx context.Context, h hash.Hash, stats *Stats) ([]byte, error) {
-	return nil, nil
+func (ecs emptyChunkSource) get(ctx context.Context, h hash.Hash, keeper keeperF, stats *Stats) ([]byte, gcBehavior, error) {
+	return nil, gcBehavior_Continue, nil
 }
 
-func (ecs emptyChunkSource) getMany(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, *chunks.Chunk), stats *Stats) (bool, error) {
-	return true, nil
+func (ecs emptyChunkSource) getMany(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, *chunks.Chunk), keeper keeperF, stats *Stats) (bool, gcBehavior, error) {
+	return true, gcBehavior_Continue, nil
 }
 
-func (ecs emptyChunkSource) getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, CompressedChunk), stats *Stats) (bool, error) {
-	return true, nil
+func (ecs emptyChunkSource) getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, CompressedChunk), keeper keeperF, stats *Stats) (bool, gcBehavior, error) {
+	return true, gcBehavior_Continue, nil
 }
 
 func (ecs emptyChunkSource) count() (uint32, error) {
@@ -74,8 +74,8 @@ func (ecs emptyChunkSource) reader(context.Context) (io.ReadCloser, uint64, erro
 	return io.NopCloser(&bytes.Buffer{}), 0, nil
 }
 
-func (ecs emptyChunkSource) getRecordRanges(ctx context.Context, requests []getRecord) (map[hash.Hash]Range, error) {
-	return map[hash.Hash]Range{}, nil
+func (ecs emptyChunkSource) getRecordRanges(ctx context.Context, requests []getRecord, keeper keeperF) (map[hash.Hash]Range, gcBehavior, error) {
+	return map[hash.Hash]Range{}, gcBehavior_Continue, nil
 }
 
 func (ecs emptyChunkSource) currentSize() uint64 {

--- a/go/store/nbs/file_table_persister_test.go
+++ b/go/store/nbs/file_table_persister_test.go
@@ -96,7 +96,8 @@ func persistTableData(p tablePersister, chunx ...[]byte) (src chunkSource, err e
 			return nil, fmt.Errorf("memTable too full to add %s", computeAddr(c))
 		}
 	}
-	return p.Persist(context.Background(), mt, nil, &Stats{})
+	src, _, err = p.Persist(context.Background(), mt, nil, nil, &Stats{})
+	return src, err
 }
 
 func TestFSTablePersisterPersistNoData(t *testing.T) {
@@ -113,7 +114,7 @@ func TestFSTablePersisterPersistNoData(t *testing.T) {
 	defer file.RemoveAll(dir)
 	fts := newFSTablePersister(dir, &UnlimitedQuotaProvider{})
 
-	src, err := fts.Persist(context.Background(), mt, existingTable, &Stats{})
+	src, _, err := fts.Persist(context.Background(), mt, existingTable, nil, &Stats{})
 	require.NoError(t, err)
 	assert.True(mustUint32(src.count()) == 0)
 
@@ -177,7 +178,7 @@ func TestFSTablePersisterConjoinAllDups(t *testing.T) {
 	}
 
 	var err error
-	sources[0], err = fts.Persist(ctx, mt, nil, &Stats{})
+	sources[0], _, err = fts.Persist(ctx, mt, nil, nil, &Stats{})
 	require.NoError(t, err)
 	sources[1], err = sources[0].clone()
 	require.NoError(t, err)

--- a/go/store/nbs/frag/main.go
+++ b/go/store/nbs/frag/main.go
@@ -153,14 +153,14 @@ func main() {
 			if i+1 == numGroups { // last group
 				go func(i int) {
 					defer wg.Done()
-					reads[i], _, err = nbs.CalcReads(store, orderedChildren[i*branchFactor:].HashSet(), 0)
+					reads[i], _, _, err = nbs.CalcReads(store, orderedChildren[i*branchFactor:].HashSet(), 0, nil)
 					d.PanicIfError(err)
 				}(i)
 				continue
 			}
 			go func(i int) {
 				defer wg.Done()
-				reads[i], _, err = nbs.CalcReads(store, orderedChildren[i*branchFactor:(i+1)*branchFactor].HashSet(), 0)
+				reads[i], _, _, err = nbs.CalcReads(store, orderedChildren[i*branchFactor:(i+1)*branchFactor].HashSet(), 0, nil)
 				d.PanicIfError(err)
 			}(i)
 		}

--- a/go/store/nbs/generational_chunk_store.go
+++ b/go/store/nbs/generational_chunk_store.go
@@ -118,7 +118,9 @@ func (gcs *GenerationalNBS) GetMany(ctx context.Context, hashes hash.HashSet, fo
 		return nil
 	}
 
-	err = gcs.newGen.GetMany(ctx, notFound, func(ctx context.Context, chunk *chunks.Chunk) {
+	hashes = notFound
+	notFound = hashes.Copy()
+	err = gcs.newGen.GetMany(ctx, hashes, func(ctx context.Context, chunk *chunks.Chunk) {
 		func() {
 			mu.Lock()
 			defer mu.Unlock()
@@ -202,14 +204,30 @@ func (gcs *GenerationalNBS) Has(ctx context.Context, h hash.Hash) (bool, error) 
 }
 
 // HasMany returns a new HashSet containing any members of |hashes| that are absent from the store.
-func (gcs *GenerationalNBS) HasMany(ctx context.Context, hashes hash.HashSet) (absent hash.HashSet, err error) {
-	gcs.newGen.mu.RLock()
-	defer gcs.newGen.mu.RUnlock()
-	return gcs.hasMany(toHasRecords(hashes))
+func (gcs *GenerationalNBS) HasMany(ctx context.Context, hashes hash.HashSet) (hash.HashSet, error) {
+	absent, err := gcs.newGen.HasMany(ctx, hashes)
+	if err != nil {
+		return nil, err
+	}
+	if len(absent) == 0 {
+		return nil, err
+	}
+
+	absent, err = gcs.oldGen.HasMany(ctx, absent)
+	if err != nil {
+		return nil, err
+	}
+	if len(absent) == 0 || gcs.ghostGen == nil {
+		return nil, err
+	}
+
+	return gcs.ghostGen.HasMany(ctx, absent)
 }
 
-func (gcs *GenerationalNBS) hasMany(recs []hasRecord) (absent hash.HashSet, err error) {
-	absent, err = gcs.newGen.hasMany(recs)
+// |refCheck| is called from write processes in newGen, so it is called with
+// newGen.mu held. oldGen.mu is not held however.
+func (gcs *GenerationalNBS) refCheck(recs []hasRecord) (hash.HashSet, error) {
+	absent, err := gcs.newGen.refCheck(recs)
 	if err != nil {
 		return nil, err
 	} else if len(absent) == 0 {
@@ -219,12 +237,11 @@ func (gcs *GenerationalNBS) hasMany(recs []hasRecord) (absent hash.HashSet, err 
 	absent, err = func() (hash.HashSet, error) {
 		gcs.oldGen.mu.RLock()
 		defer gcs.oldGen.mu.RUnlock()
-		return gcs.oldGen.hasMany(recs)
+		return gcs.oldGen.refCheck(recs)
 	}()
 	if err != nil {
 		return nil, err
 	}
-
 	if len(absent) == 0 || gcs.ghostGen == nil {
 		return absent, nil
 	}
@@ -237,7 +254,7 @@ func (gcs *GenerationalNBS) hasMany(recs []hasRecord) (absent hash.HashSet, err 
 // to Flush(). Put may be called concurrently with other calls to Put(),
 // Get(), GetMany(), Has() and HasMany().
 func (gcs *GenerationalNBS) Put(ctx context.Context, c chunks.Chunk, getAddrs chunks.GetAddrsCurry) error {
-	return gcs.newGen.putChunk(ctx, c, getAddrs, gcs.hasMany)
+	return gcs.newGen.putChunk(ctx, c, getAddrs, gcs.refCheck)
 }
 
 // Returns the NomsBinFormat with which this ChunkSource is compatible.
@@ -277,7 +294,7 @@ func (gcs *GenerationalNBS) Root(ctx context.Context) (hash.Hash, error) {
 // persisted root hash from last to current (or keeps it the same).
 // If last doesn't match the root in persistent storage, returns false.
 func (gcs *GenerationalNBS) Commit(ctx context.Context, current, last hash.Hash) (bool, error) {
-	return gcs.newGen.commit(ctx, current, last, gcs.hasMany)
+	return gcs.newGen.commit(ctx, current, last, gcs.refCheck)
 }
 
 // Stats may return some kind of struct that reports statistics about the
@@ -400,18 +417,18 @@ func (gcs *GenerationalNBS) AddTableFilesToManifest(ctx context.Context, fileIdT
 
 // PruneTableFiles deletes old table files that are no longer referenced in the manifest of the new or old gen chunkstores
 func (gcs *GenerationalNBS) PruneTableFiles(ctx context.Context) error {
-	err := gcs.oldGen.pruneTableFiles(ctx, gcs.hasMany)
+	err := gcs.oldGen.pruneTableFiles(ctx)
 
 	if err != nil {
 		return err
 	}
 
-	return gcs.newGen.pruneTableFiles(ctx, gcs.hasMany)
+	return gcs.newGen.pruneTableFiles(ctx)
 }
 
 // SetRootChunk changes the root chunk hash from the previous value to the new root for the newgen cs
 func (gcs *GenerationalNBS) SetRootChunk(ctx context.Context, root, previous hash.Hash) error {
-	return gcs.newGen.setRootChunk(ctx, root, previous, gcs.hasMany)
+	return gcs.newGen.setRootChunk(ctx, root, previous, gcs.refCheck)
 }
 
 // SupportedOperations returns a description of the support TableFile operations. Some stores only support reading table files, not writing.

--- a/go/store/nbs/ghost_store.go
+++ b/go/store/nbs/ghost_store.go
@@ -91,6 +91,10 @@ func (g GhostBlockStore) GetMany(ctx context.Context, hashes hash.HashSet, found
 }
 
 func (g GhostBlockStore) GetManyCompressed(ctx context.Context, hashes hash.HashSet, found func(context.Context, CompressedChunk)) error {
+	return g.getManyCompressed(ctx, hashes, found, gcDependencyMode_TakeDependency)
+}
+
+func (g GhostBlockStore) getManyCompressed(ctx context.Context, hashes hash.HashSet, found func(context.Context, CompressedChunk), gcDepMode gcDependencyMode) error {
 	for h := range hashes {
 		if g.skippedRefs.Has(h) {
 			found(ctx, NewGhostCompressedChunk(h))

--- a/go/store/nbs/journal.go
+++ b/go/store/nbs/journal.go
@@ -248,7 +248,8 @@ func (j *ChunkJournal) Persist(ctx context.Context, mt *memTable, haver chunkRea
 
 	if haver != nil {
 		sort.Sort(hasRecordByPrefix(mt.order)) // hasMany() requires addresses to be sorted.
-		if _, err := haver.hasMany(mt.order); err != nil {
+		// TODO: keeperF
+		if _, _, err := haver.hasMany(mt.order, nil); err != nil {
 			return nil, err
 		}
 		sort.Sort(hasRecordByOrder(mt.order)) // restore "insertion" order for write

--- a/go/store/nbs/journal_chunk_source.go
+++ b/go/store/nbs/journal_chunk_source.go
@@ -39,20 +39,29 @@ type journalChunkSource struct {
 
 var _ chunkSource = journalChunkSource{}
 
-func (s journalChunkSource) has(h hash.Hash) (bool, error) {
-	return s.journal.hasAddr(h), nil
+func (s journalChunkSource) has(h hash.Hash, keeper keeperF) (bool, gcBehavior, error) {
+	res := s.journal.hasAddr(h)
+	if res && keeper != nil && keeper(h) {
+		return false, gcBehavior_Block, nil
+	}
+	return res, gcBehavior_Continue, nil
 }
 
-func (s journalChunkSource) hasMany(addrs []hasRecord) (missing bool, err error) {
+func (s journalChunkSource) hasMany(addrs []hasRecord, keeper keeperF) (bool, gcBehavior, error) {
+	missing := false
 	for i := range addrs {
-		ok := s.journal.hasAddr(*addrs[i].a)
+		h := *addrs[i].a
+		ok := s.journal.hasAddr(h)
 		if ok {
+			if keeper != nil && keeper(h) {
+				return true, gcBehavior_Block, nil
+			}
 			addrs[i].has = true
 		} else {
 			missing = true
 		}
 	}
-	return
+	return missing, gcBehavior_Continue, nil
 }
 
 func (s journalChunkSource) getCompressed(ctx context.Context, h hash.Hash, _ *Stats) (CompressedChunk, error) {
@@ -60,20 +69,23 @@ func (s journalChunkSource) getCompressed(ctx context.Context, h hash.Hash, _ *S
 	return s.journal.getCompressedChunk(h)
 }
 
-func (s journalChunkSource) get(ctx context.Context, h hash.Hash, _ *Stats) ([]byte, error) {
+func (s journalChunkSource) get(ctx context.Context, h hash.Hash, keeper keeperF, _ *Stats) ([]byte, gcBehavior, error) {
 	defer trace.StartRegion(ctx, "journalChunkSource.get").End()
 
 	cc, err := s.journal.getCompressedChunk(h)
 	if err != nil {
-		return nil, err
+		return nil, gcBehavior_Continue, err
 	} else if cc.IsEmpty() {
-		return nil, nil
+		return nil, gcBehavior_Continue, nil
+	}
+	if keeper != nil && keeper(h) {
+		return nil, gcBehavior_Block, nil
 	}
 	ch, err := cc.ToChunk()
 	if err != nil {
-		return nil, err
+		return nil, gcBehavior_Continue, err
 	}
-	return ch.Data(), nil
+	return ch.Data(), gcBehavior_Continue, nil
 }
 
 type journalRecord struct {
@@ -83,7 +95,7 @@ type journalRecord struct {
 	idx int
 }
 
-func (s journalChunkSource) getMany(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, *chunks.Chunk), stats *Stats) (bool, error) {
+func (s journalChunkSource) getMany(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, *chunks.Chunk), keeper keeperF, stats *Stats) (bool, gcBehavior, error) {
 	return s.getManyCompressed(ctx, eg, reqs, func(ctx context.Context, cc CompressedChunk) {
 		ch, err := cc.ToChunk()
 		if err != nil {
@@ -94,7 +106,7 @@ func (s journalChunkSource) getMany(ctx context.Context, eg *errgroup.Group, req
 		}
 		chWHash := chunks.NewChunkWithHash(cc.Hash(), ch.Data())
 		found(ctx, &chWHash)
-	}, stats)
+	}, keeper, stats)
 }
 
 // getManyCompressed implements chunkReader. Here we (1) synchronously check
@@ -103,7 +115,7 @@ func (s journalChunkSource) getMany(ctx context.Context, eg *errgroup.Group, req
 // and then (4) asynchronously perform reads. We release the journal read
 // lock after returning when all reads are completed, which can be after the
 // function returns.
-func (s journalChunkSource) getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, CompressedChunk), stats *Stats) (bool, error) {
+func (s journalChunkSource) getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, CompressedChunk), keeper keeperF, stats *Stats) (bool, gcBehavior, error) {
 	defer trace.StartRegion(ctx, "journalChunkSource.getManyCompressed").End()
 
 	var remaining bool
@@ -114,10 +126,15 @@ func (s journalChunkSource) getManyCompressed(ctx context.Context, eg *errgroup.
 		if r.found {
 			continue
 		}
-		rang, ok := s.journal.ranges.get(*r.a)
+		h := *r.a
+		rang, ok := s.journal.ranges.get(h)
 		if !ok {
 			remaining = true
 			continue
+		}
+		if keeper != nil && keeper(h) {
+			s.journal.lock.RUnlock()
+			return true, gcBehavior_Block, nil
 		}
 		jReqs = append(jReqs, journalRecord{r: rang, idx: i})
 		reqs[i].found = true
@@ -150,7 +167,7 @@ func (s journalChunkSource) getManyCompressed(ctx context.Context, eg *errgroup.
 		wg.Wait()
 		s.journal.lock.RUnlock()
 	}()
-	return remaining, nil
+	return remaining, gcBehavior_Continue, nil
 }
 
 func (s journalChunkSource) count() (uint32, error) {
@@ -171,22 +188,26 @@ func (s journalChunkSource) reader(ctx context.Context) (io.ReadCloser, uint64, 
 	return rdr, uint64(sz), err
 }
 
-func (s journalChunkSource) getRecordRanges(ctx context.Context, requests []getRecord) (map[hash.Hash]Range, error) {
+func (s journalChunkSource) getRecordRanges(ctx context.Context, requests []getRecord, keeper keeperF) (map[hash.Hash]Range, gcBehavior, error) {
 	ranges := make(map[hash.Hash]Range, len(requests))
 	for _, req := range requests {
 		if req.found {
 			continue
 		}
-		rng, ok, err := s.journal.getRange(ctx, *req.a)
+		h := *req.a
+		rng, ok, err := s.journal.getRange(ctx, h)
 		if err != nil {
-			return nil, err
+			return nil, gcBehavior_Continue, err
 		} else if !ok {
 			continue
 		}
+		if keeper != nil && keeper(h) {
+			return nil, gcBehavior_Block, nil
+		}
 		req.found = true // update |requests|
-		ranges[hash.Hash(*req.a)] = rng
+		ranges[h] = rng
 	}
-	return ranges, nil
+	return ranges, gcBehavior_Continue, nil
 }
 
 // size implements chunkSource.

--- a/go/store/nbs/journal_test.go
+++ b/go/store/nbs/journal_test.go
@@ -67,7 +67,7 @@ func TestChunkJournalPersist(t *testing.T) {
 	haver := emptyChunkSource{}
 	for i := 0; i < iters; i++ {
 		memTbl, chunkMap := randomMemTable(16)
-		source, err := j.Persist(ctx, memTbl, haver, stats)
+		source, _, err := j.Persist(ctx, memTbl, haver, nil, stats)
 		assert.NoError(t, err)
 
 		for h, ch := range chunkMap {
@@ -96,7 +96,7 @@ func TestReadRecordRanges(t *testing.T) {
 		gets = append(gets, getRecord{a: &h, prefix: h.Prefix()})
 	}
 
-	jcs, err := j.Persist(ctx, mt, emptyChunkSource{}, &Stats{})
+	jcs, _, err := j.Persist(ctx, mt, emptyChunkSource{}, nil, &Stats{})
 	require.NoError(t, err)
 
 	rdr, sz, err := jcs.(journalChunkSource).journal.snapshot(context.Background())

--- a/go/store/nbs/journal_test.go
+++ b/go/store/nbs/journal_test.go
@@ -71,10 +71,10 @@ func TestChunkJournalPersist(t *testing.T) {
 		assert.NoError(t, err)
 
 		for h, ch := range chunkMap {
-			ok, err := source.has(h)
+			ok, _, err := source.has(h, nil)
 			assert.NoError(t, err)
 			assert.True(t, ok)
-			data, err := source.get(ctx, h, stats)
+			data, _, err := source.get(ctx, h, nil, stats)
 			assert.NoError(t, err)
 			assert.Equal(t, ch.Data(), data)
 		}
@@ -108,11 +108,11 @@ func TestReadRecordRanges(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int(sz), n)
 
-	ranges, err := jcs.getRecordRanges(ctx, gets)
+	ranges, _, err := jcs.getRecordRanges(ctx, gets, nil)
 	require.NoError(t, err)
 
 	for h, rng := range ranges {
-		b, err := jcs.get(ctx, h, &Stats{})
+		b, _, err := jcs.get(ctx, h, nil, &Stats{})
 		assert.NoError(t, err)
 		ch1 := chunks.NewChunkWithHash(h, b)
 		assert.Equal(t, data[h], ch1)

--- a/go/store/nbs/journal_writer_test.go
+++ b/go/store/nbs/journal_writer_test.go
@@ -228,7 +228,7 @@ func TestJournalWriterBootstrap(t *testing.T) {
 
 	source := journalChunkSource{journal: j}
 	for a, cc := range data {
-		buf, err := source.get(ctx, a, nil)
+		buf, _, err := source.get(ctx, a, nil, nil)
 		require.NoError(t, err)
 		ch, err := cc.ToChunk()
 		require.NoError(t, err)

--- a/go/store/nbs/mem_table.go
+++ b/go/store/nbs/mem_table.go
@@ -135,22 +135,27 @@ func (mt *memTable) uncompressedLen() (uint64, error) {
 	return mt.totalData, nil
 }
 
-func (mt *memTable) has(h hash.Hash) (bool, error) {
+func (mt *memTable) has(h hash.Hash, keeper keeperF) (bool, gcBehavior, error) {
 	_, has := mt.chunks[h]
-	return has, nil
+	if has && keeper != nil && keeper(h) {
+		return false, gcBehavior_Block, nil
+	}
+	return has, gcBehavior_Continue, nil
 }
 
-func (mt *memTable) hasMany(addrs []hasRecord) (bool, error) {
+func (mt *memTable) hasMany(addrs []hasRecord, keeper keeperF) (bool, gcBehavior, error) {
 	var remaining bool
 	for i, addr := range addrs {
 		if addr.has {
 			continue
 		}
 
-		ok, err := mt.has(*addr.a)
-
+		ok, gcb, err := mt.has(*addr.a, keeper)
 		if err != nil {
-			return false, err
+			return false, gcBehavior_Continue, err
+		}
+		if gcb != gcBehavior_Continue {
+			return ok, gcb, nil
 		}
 
 		if ok {
@@ -159,18 +164,25 @@ func (mt *memTable) hasMany(addrs []hasRecord) (bool, error) {
 			remaining = true
 		}
 	}
-	return remaining, nil
+	return remaining, gcBehavior_Continue, nil
 }
 
-func (mt *memTable) get(ctx context.Context, h hash.Hash, stats *Stats) ([]byte, error) {
-	return mt.chunks[h], nil
+func (mt *memTable) get(ctx context.Context, h hash.Hash, keeper keeperF, stats *Stats) ([]byte, gcBehavior, error) {
+	c, ok := mt.chunks[h]
+	if ok && keeper != nil && keeper(h) {
+		return nil, gcBehavior_Block, nil
+	}
+	return c, gcBehavior_Continue, nil
 }
 
-func (mt *memTable) getMany(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, *chunks.Chunk), stats *Stats) (bool, error) {
+func (mt *memTable) getMany(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, *chunks.Chunk), keeper keeperF, stats *Stats) (bool, gcBehavior, error) {
 	var remaining bool
 	for i, r := range reqs {
 		data := mt.chunks[*r.a]
 		if data != nil {
+			if keeper != nil && keeper(*r.a) {
+				return true, gcBehavior_Block, nil
+			}
 			c := chunks.NewChunkWithHash(hash.Hash(*r.a), data)
 			reqs[i].found = true
 			found(ctx, &c)
@@ -178,14 +190,17 @@ func (mt *memTable) getMany(ctx context.Context, eg *errgroup.Group, reqs []getR
 			remaining = true
 		}
 	}
-	return remaining, nil
+	return remaining, gcBehavior_Continue, nil
 }
 
-func (mt *memTable) getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, CompressedChunk), stats *Stats) (bool, error) {
+func (mt *memTable) getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, CompressedChunk), keeper keeperF, stats *Stats) (bool, gcBehavior, error) {
 	var remaining bool
 	for i, r := range reqs {
 		data := mt.chunks[*r.a]
 		if data != nil {
+			if keeper != nil && keeper(*r.a) {
+				return true, gcBehavior_Block, nil
+			}
 			c := chunks.NewChunkWithHash(hash.Hash(*r.a), data)
 			reqs[i].found = true
 			found(ctx, ChunkToCompressedChunk(c))
@@ -194,7 +209,7 @@ func (mt *memTable) getManyCompressed(ctx context.Context, eg *errgroup.Group, r
 		}
 	}
 
-	return remaining, nil
+	return remaining, gcBehavior_Continue, nil
 }
 
 func (mt *memTable) extract(ctx context.Context, chunks chan<- extractRecord) error {
@@ -217,8 +232,8 @@ func (mt *memTable) write(haver chunkReader, stats *Stats) (name hash.Hash, data
 
 	if haver != nil {
 		sort.Sort(hasRecordByPrefix(mt.order)) // hasMany() requires addresses to be sorted.
-		_, err := haver.hasMany(mt.order)
-
+		// TODO: keeperF
+		_, _, err := haver.hasMany(mt.order, nil)
 		if err != nil {
 			return hash.Hash{}, nil, 0, err
 		}

--- a/go/store/nbs/mem_table.go
+++ b/go/store/nbs/mem_table.go
@@ -61,7 +61,7 @@ func writeChunksToMT(mt *memTable, chunks []chunks.Chunk) (string, []byte, error
 	}
 
 	var stats Stats
-	name, data, count, err := mt.write(nil, &stats)
+	name, data, count, _, err := mt.write(nil, nil, &stats)
 
 	if err != nil {
 		return "", nil, err
@@ -220,10 +220,11 @@ func (mt *memTable) extract(ctx context.Context, chunks chan<- extractRecord) er
 	return nil
 }
 
-func (mt *memTable) write(haver chunkReader, stats *Stats) (name hash.Hash, data []byte, count uint32, err error) {
+func (mt *memTable) write(haver chunkReader, keeper keeperF, stats *Stats) (name hash.Hash, data []byte, count uint32, gcb gcBehavior, err error) {
+	gcb = gcBehavior_Continue
 	numChunks := uint64(len(mt.order))
 	if numChunks == 0 {
-		return hash.Hash{}, nil, 0, fmt.Errorf("mem table cannot write with zero chunks")
+		return hash.Hash{}, nil, 0, gcBehavior_Continue, fmt.Errorf("mem table cannot write with zero chunks")
 	}
 	maxSize := maxTableSize(uint64(len(mt.order)), mt.totalData)
 	// todo: memory quota
@@ -232,10 +233,12 @@ func (mt *memTable) write(haver chunkReader, stats *Stats) (name hash.Hash, data
 
 	if haver != nil {
 		sort.Sort(hasRecordByPrefix(mt.order)) // hasMany() requires addresses to be sorted.
-		// TODO: keeperF
-		_, _, err := haver.hasMany(mt.order, nil)
+		_, gcb, err = haver.hasMany(mt.order, keeper)
 		if err != nil {
-			return hash.Hash{}, nil, 0, err
+			return hash.Hash{}, nil, 0, gcBehavior_Continue, err
+		}
+		if gcb != gcBehavior_Continue {
+			return hash.Hash{}, nil, 0, gcb, err
 		}
 
 		sort.Sort(hasRecordByOrder(mt.order)) // restore "insertion" order for write
@@ -251,7 +254,7 @@ func (mt *memTable) write(haver chunkReader, stats *Stats) (name hash.Hash, data
 	tableSize, name, err := tw.finish()
 
 	if err != nil {
-		return hash.Hash{}, nil, 0, err
+		return hash.Hash{}, nil, 0, gcBehavior_Continue, err
 	}
 
 	if count > 0 {
@@ -261,7 +264,7 @@ func (mt *memTable) write(haver chunkReader, stats *Stats) (name hash.Hash, data
 		stats.ChunksPerPersist.Sample(uint64(count))
 	}
 
-	return name, buff[:tableSize], count, nil
+	return name, buff[:tableSize], count, gcBehavior_Continue, nil
 }
 
 func (mt *memTable) close() error {

--- a/go/store/nbs/mem_table_test.go
+++ b/go/store/nbs/mem_table_test.go
@@ -169,7 +169,7 @@ func TestMemTableWrite(t *testing.T) {
 	defer tr2.close()
 	assert.True(tr2.has(computeAddr(chunks[2]), nil))
 
-	_, data, count, err := mt.write(chunkReaderGroup{tr1, tr2}, &Stats{})
+	_, data, count, _, err := mt.write(chunkReaderGroup{tr1, tr2}, nil, &Stats{})
 	require.NoError(t, err)
 	assert.Equal(uint32(1), count)
 
@@ -223,7 +223,7 @@ func TestMemTableSnappyWriteOutOfLine(t *testing.T) {
 	}
 	mt.snapper = &outOfLineSnappy{[]bool{false, true, false}} // chunks[1] should trigger a panic
 
-	assert.Panics(func() { mt.write(nil, &Stats{}) })
+	assert.Panics(func() { mt.write(nil, nil, &Stats{}) })
 }
 
 type outOfLineSnappy struct {

--- a/go/store/nbs/root_tracker_test.go
+++ b/go/store/nbs/root_tracker_test.go
@@ -661,7 +661,7 @@ func extractAllChunks(ctx context.Context, src chunkSource, cb func(rec extractR
 			return err
 		}
 
-		data, err := src.get(ctx, h, nil)
+		data, _, err := src.get(ctx, h, nil, nil)
 		if err != nil {
 			return err
 		}

--- a/go/store/nbs/root_tracker_test.go
+++ b/go/store/nbs/root_tracker_test.go
@@ -399,7 +399,7 @@ func interloperWrite(fm *fakeManifest, p tablePersister, rootChunk []byte, chunk
 	persisted = append(chunks, rootChunk)
 
 	var src chunkSource
-	src, err = p.Persist(context.Background(), createMemTable(persisted), nil, &Stats{})
+	src, _, err = p.Persist(context.Background(), createMemTable(persisted), nil, nil, &Stats{})
 	if err != nil {
 		return hash.Hash{}, nil, err
 	}
@@ -505,16 +505,18 @@ type fakeTablePersister struct {
 
 var _ tablePersister = fakeTablePersister{}
 
-func (ftp fakeTablePersister) Persist(ctx context.Context, mt *memTable, haver chunkReader, stats *Stats) (chunkSource, error) {
+func (ftp fakeTablePersister) Persist(ctx context.Context, mt *memTable, haver chunkReader, keeper keeperF, stats *Stats) (chunkSource, gcBehavior, error) {
 	if mustUint32(mt.count()) == 0 {
-		return emptyChunkSource{}, nil
+		return emptyChunkSource{}, gcBehavior_Continue, nil
 	}
 
-	name, data, chunkCount, err := mt.write(haver, stats)
+	name, data, chunkCount, gcb, err := mt.write(haver, keeper, stats)
 	if err != nil {
-		return emptyChunkSource{}, err
+		return emptyChunkSource{}, gcBehavior_Continue, err
+	} else if gcb != gcBehavior_Continue {
+		return emptyChunkSource{}, gcb, nil
 	} else if chunkCount == 0 {
-		return emptyChunkSource{}, nil
+		return emptyChunkSource{}, gcBehavior_Continue, nil
 	}
 
 	ftp.mu.Lock()
@@ -523,14 +525,14 @@ func (ftp fakeTablePersister) Persist(ctx context.Context, mt *memTable, haver c
 
 	ti, err := parseTableIndexByCopy(ctx, data, ftp.q)
 	if err != nil {
-		return nil, err
+		return nil, gcBehavior_Continue, err
 	}
 
 	cs, err := newTableReader(ti, tableReaderAtFromBytes(data), fileBlockSize)
 	if err != nil {
-		return emptyChunkSource{}, err
+		return emptyChunkSource{}, gcBehavior_Continue, err
 	}
-	return chunkSourceAdapter{cs, name}, nil
+	return chunkSourceAdapter{cs, name}, gcBehavior_Continue, nil
 }
 
 func (ftp fakeTablePersister) ConjoinAll(ctx context.Context, sources chunkSources, stats *Stats) (chunkSource, cleanupFunc, error) {

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -90,6 +90,7 @@ type NBSCompressedChunkStore interface {
 }
 
 type gcDependencyMode int
+
 const (
 	gcDependencyMode_TakeDependency gcDependencyMode = iota
 	gcDependencyMode_NoDependency

--- a/go/store/nbs/store_test.go
+++ b/go/store/nbs/store_test.go
@@ -209,7 +209,7 @@ func TestNBSPruneTableFiles(t *testing.T) {
 			addrs.Insert(c.Hash())
 			return nil
 		}
-	}, st.hasMany)
+	}, st.refCheck)
 	require.NoError(t, err)
 	require.True(t, ok)
 	ok, err = st.Commit(ctx, st.upstream.root, st.upstream.root)

--- a/go/store/nbs/store_test.go
+++ b/go/store/nbs/store_test.go
@@ -377,7 +377,7 @@ func persistTableFileSources(t *testing.T, p tablePersister, numTableFiles int) 
 		require.True(t, ok)
 		tableFileMap[fileIDHash] = uint32(i + 1)
 		mapIds[i] = fileIDHash
-		cs, err := p.Persist(context.Background(), createMemTable(chunkData), nil, &Stats{})
+		cs, _, err := p.Persist(context.Background(), createMemTable(chunkData), nil, nil, &Stats{})
 		require.NoError(t, err)
 		require.NoError(t, cs.close())
 

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -199,7 +199,7 @@ const (
 	// Operation was successful, go forward with the result.
 	gcBehavior_Continue gcBehavior = false
 	// Operation needs to block until the GC is over and then retry.
-	gcBehavior_Block               = true
+	gcBehavior_Block = true
 )
 
 type keeperF func(hash.Hash) bool

--- a/go/store/nbs/table_persister.go
+++ b/go/store/nbs/table_persister.go
@@ -47,7 +47,7 @@ type cleanupFunc func()
 type tablePersister interface {
 	// Persist makes the contents of mt durable. Chunks already present in
 	// |haver| may be dropped in the process.
-	Persist(ctx context.Context, mt *memTable, haver chunkReader, stats *Stats) (chunkSource, error)
+	Persist(ctx context.Context, mt *memTable, haver chunkReader, keeper keeperF, stats *Stats) (chunkSource, gcBehavior, error)
 
 	// ConjoinAll conjoins all chunks in |sources| into a single, new
 	// chunkSource. It returns a |cleanupFunc| which can be called to

--- a/go/store/nbs/table_reader.go
+++ b/go/store/nbs/table_reader.go
@@ -178,7 +178,7 @@ func newTableReader(index tableIndex, r tableReaderAt, blockSize uint64) (tableR
 }
 
 // Scan across (logically) two ordered slices of address prefixes.
-func (tr tableReader) hasMany(addrs []hasRecord) (bool, error) {
+func (tr tableReader) hasMany(addrs []hasRecord, keeper keeperF) (bool, gcBehavior, error) {
 	filterIdx := uint32(0)
 	filterLen := uint32(tr.idx.chunkCount())
 
@@ -206,7 +206,7 @@ func (tr tableReader) hasMany(addrs []hasRecord) (bool, error) {
 		}
 
 		if filterIdx >= filterLen {
-			return true, nil
+			return true, gcBehavior_Continue, nil
 		}
 
 		if addr.prefix != tr.prefixes[filterIdx] {
@@ -218,9 +218,12 @@ func (tr tableReader) hasMany(addrs []hasRecord) (bool, error) {
 		for j := filterIdx; j < filterLen && addr.prefix == tr.prefixes[j]; j++ {
 			m, err := tr.idx.entrySuffixMatches(j, addr.a)
 			if err != nil {
-				return false, err
+				return false, gcBehavior_Continue, err
 			}
 			if m {
+				if keeper != nil && keeper(*addr.a) {
+					return true, gcBehavior_Block, nil
+				}
 				addrs[i].has = true
 				break
 			}
@@ -231,7 +234,7 @@ func (tr tableReader) hasMany(addrs []hasRecord) (bool, error) {
 		}
 	}
 
-	return remaining, nil
+	return remaining, gcBehavior_Continue, nil
 }
 
 func (tr tableReader) count() (uint32, error) {
@@ -247,20 +250,27 @@ func (tr tableReader) index() (tableIndex, error) {
 }
 
 // returns true iff |h| can be found in this table.
-func (tr tableReader) has(h hash.Hash) (bool, error) {
+func (tr tableReader) has(h hash.Hash, keeper keeperF) (bool, gcBehavior, error) {
 	_, ok, err := tr.idx.lookup(&h)
-	return ok, err
+	if ok && keeper != nil && keeper(h) {
+		return false, gcBehavior_Block, nil
+	}
+	return ok, gcBehavior_Continue, err
 }
 
 // returns the storage associated with |h|, iff present. Returns nil if absent. On success,
 // the returned byte slice directly references the underlying storage.
-func (tr tableReader) get(ctx context.Context, h hash.Hash, stats *Stats) ([]byte, error) {
+func (tr tableReader) get(ctx context.Context, h hash.Hash, keeper keeperF, stats *Stats) ([]byte, gcBehavior, error) {
 	e, found, err := tr.idx.lookup(&h)
 	if err != nil {
-		return nil, err
+		return nil, gcBehavior_Continue, err
 	}
 	if !found {
-		return nil, nil
+		return nil, gcBehavior_Continue, nil
+	}
+
+	if keeper != nil && keeper(h) {
+		return nil, gcBehavior_Block, nil
 	}
 
 	offset := e.Offset()
@@ -270,30 +280,30 @@ func (tr tableReader) get(ctx context.Context, h hash.Hash, stats *Stats) ([]byt
 	n, err := tr.r.ReadAtWithStats(ctx, buff, int64(offset), stats)
 
 	if err != nil {
-		return nil, err
+		return nil, gcBehavior_Continue, err
 	}
 
 	if n != int(length) {
-		return nil, errors.New("failed to read all data")
+		return nil, gcBehavior_Continue, errors.New("failed to read all data")
 	}
 
 	cmp, err := NewCompressedChunk(h, buff)
 
 	if err != nil {
-		return nil, err
+		return nil, gcBehavior_Continue, err
 	}
 
 	if len(cmp.CompressedData) == 0 {
-		return nil, errors.New("failed to get data")
+		return nil, gcBehavior_Continue, errors.New("failed to get data")
 	}
 
 	chnk, err := cmp.ToChunk()
 
 	if err != nil {
-		return nil, err
+		return nil, gcBehavior_Continue, err
 	}
 
-	return chnk.Data(), nil
+	return chnk.Data(), gcBehavior_Continue, nil
 }
 
 type offsetRec struct {
@@ -380,26 +390,33 @@ func (tr tableReader) getMany(
 	eg *errgroup.Group,
 	reqs []getRecord,
 	found func(context.Context, *chunks.Chunk),
-	stats *Stats) (bool, error) {
+	keeper keeperF,
+	stats *Stats) (bool, gcBehavior, error) {
 
 	// Pass #1: Iterate over |reqs| and |tr.prefixes| (both sorted by address) and build the set
 	// of table locations which must be read in order to satisfy the getMany operation.
-	offsetRecords, remaining, err := tr.findOffsets(reqs)
+	offsetRecords, remaining, gcb, err := tr.findOffsets(reqs, keeper)
 	if err != nil {
-		return false, err
+		return false, gcBehavior_Continue, err
+	}
+	if gcb != gcBehavior_Continue {
+		return remaining, gcb, nil
 	}
 	err = tr.getManyAtOffsets(ctx, eg, offsetRecords, found, stats)
-	return remaining, err
+	return remaining, gcBehavior_Continue, err
 }
-func (tr tableReader) getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, CompressedChunk), stats *Stats) (bool, error) {
+func (tr tableReader) getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, CompressedChunk), keeper keeperF, stats *Stats) (bool, gcBehavior, error) {
 	// Pass #1: Iterate over |reqs| and |tr.prefixes| (both sorted by address) and build the set
 	// of table locations which must be read in order to satisfy the getMany operation.
-	offsetRecords, remaining, err := tr.findOffsets(reqs)
+	offsetRecords, remaining, gcb, err := tr.findOffsets(reqs, keeper)
 	if err != nil {
-		return false, err
+		return false, gcb, err
+	}
+	if gcb != gcBehavior_Continue {
+		return remaining, gcb, nil
 	}
 	err = tr.getManyCompressedAtOffsets(ctx, eg, offsetRecords, found, stats)
-	return remaining, err
+	return remaining, gcBehavior_Continue, err
 }
 
 func (tr tableReader) getManyCompressedAtOffsets(ctx context.Context, eg *errgroup.Group, offsetRecords offsetRecSlice, found func(context.Context, CompressedChunk), stats *Stats) error {
@@ -498,7 +515,7 @@ func (tr tableReader) getManyAtOffsetsWithReadFunc(
 // chunks remaining will be set to false upon return. If some are not here,
 // then remaining will be true. The result offsetRecSlice is sorted in offset
 // order.
-func (tr tableReader) findOffsets(reqs []getRecord) (ors offsetRecSlice, remaining bool, err error) {
+func (tr tableReader) findOffsets(reqs []getRecord, keeper keeperF) (ors offsetRecSlice, remaining bool, gcb gcBehavior, err error) {
 	filterIdx := uint32(0)
 	filterLen := uint32(len(tr.prefixes))
 	ors = make(offsetRecSlice, 0, len(reqs))
@@ -541,13 +558,16 @@ func (tr tableReader) findOffsets(reqs []getRecord) (ors offsetRecSlice, remaini
 		for j := filterIdx; j < filterLen && req.prefix == tr.prefixes[j]; j++ {
 			m, err := tr.idx.entrySuffixMatches(j, req.a)
 			if err != nil {
-				return nil, false, err
+				return nil, false, gcBehavior_Continue, err
 			}
 			if m {
+				if keeper != nil && keeper(*req.a) {
+					return nil, false, gcBehavior_Block, nil
+				}
 				reqs[i].found = true
 				entry, err := tr.idx.indexEntry(j, nil)
 				if err != nil {
-					return nil, false, err
+					return nil, false, gcBehavior_Continue, err
 				}
 				ors = append(ors, offsetRec{req.a, entry.Offset(), entry.Length()})
 				break
@@ -560,7 +580,7 @@ func (tr tableReader) findOffsets(reqs []getRecord) (ors offsetRecSlice, remaini
 	}
 
 	sort.Sort(ors)
-	return ors, remaining, nil
+	return ors, remaining, gcBehavior_Continue, nil
 }
 
 func canReadAhead(fRec offsetRec, curStart, curEnd, blockSize uint64) (newEnd uint64, canRead bool) {
@@ -584,12 +604,15 @@ func canReadAhead(fRec offsetRec, curStart, curEnd, blockSize uint64) (newEnd ui
 	return fRec.offset + uint64(fRec.length), true
 }
 
-func (tr tableReader) calcReads(reqs []getRecord, blockSize uint64) (reads int, remaining bool, err error) {
+func (tr tableReader) calcReads(reqs []getRecord, blockSize uint64, keeper keeperF) (int, bool, gcBehavior, error) {
 	var offsetRecords offsetRecSlice
 	// Pass #1: Build the set of table locations which must be read in order to find all the elements of |reqs| which are present in this table.
-	offsetRecords, remaining, err = tr.findOffsets(reqs)
+	offsetRecords, remaining, gcb, err := tr.findOffsets(reqs, keeper)
 	if err != nil {
-		return 0, false, err
+		return 0, false, gcb, err
+	}
+	if gcb != gcBehavior_Continue {
+		return 0, false, gcb, nil
 	}
 
 	// Now |offsetRecords| contains all locations within the table which must
@@ -597,6 +620,7 @@ func (tr tableReader) calcReads(reqs []getRecord, blockSize uint64) (reads int, 
 	// location). Scan forward, grouping sequences of reads into large physical
 	// reads.
 
+	var reads int
 	var readStart, readEnd uint64
 	readStarted := false
 
@@ -622,7 +646,7 @@ func (tr tableReader) calcReads(reqs []getRecord, blockSize uint64) (reads int, 
 		readStarted = false
 	}
 
-	return
+	return reads, remaining, gcBehavior_Continue, err
 }
 
 func (tr tableReader) extract(ctx context.Context, chunks chan<- extractRecord) error {
@@ -681,11 +705,14 @@ func (tr tableReader) reader(ctx context.Context) (io.ReadCloser, uint64, error)
 	return r, sz, nil
 }
 
-func (tr tableReader) getRecordRanges(ctx context.Context, requests []getRecord) (map[hash.Hash]Range, error) {
+func (tr tableReader) getRecordRanges(ctx context.Context, requests []getRecord, keeper keeperF) (map[hash.Hash]Range, gcBehavior, error) {
 	// findOffsets sets getRecord.found
-	recs, _, err := tr.findOffsets(requests)
+	recs, _, gcb, err := tr.findOffsets(requests, keeper)
 	if err != nil {
-		return nil, err
+		return nil, gcb, err
+	}
+	if gcb != gcBehavior_Continue {
+		return nil, gcb, nil
 	}
 	ranges := make(map[hash.Hash]Range, len(recs))
 	for _, r := range recs {
@@ -694,7 +721,7 @@ func (tr tableReader) getRecordRanges(ctx context.Context, requests []getRecord)
 			Length: r.length,
 		}
 	}
-	return ranges, nil
+	return ranges, gcBehavior_Continue, nil
 }
 
 func (tr tableReader) currentSize() uint64 {

--- a/go/store/nbs/table_set.go
+++ b/go/store/nbs/table_set.go
@@ -385,7 +385,8 @@ func (ts tableSet) append(ctx context.Context, mt *memTable, checker refCheck, h
 		return tableSet{}, fmt.Errorf("%w: found dangling references to %s", ErrDanglingRef, absent.String())
 	}
 
-	cs, err := ts.p.Persist(ctx, mt, ts, stats)
+	// TODO: keeperF
+	cs, _, err := ts.p.Persist(ctx, mt, ts, nil, stats)
 	if err != nil {
 		return tableSet{}, err
 	}

--- a/go/store/nbs/table_set_test.go
+++ b/go/store/nbs/table_set_test.go
@@ -146,7 +146,7 @@ func persist(t *testing.T, p tablePersister, chunks ...[]byte) {
 	for _, c := range chunks {
 		mt := newMemTable(testMemTableSize)
 		mt.addChunk(computeAddr(c), c)
-		cs, err := p.Persist(context.Background(), mt, nil, &Stats{})
+		cs, _, err := p.Persist(context.Background(), mt, nil, nil, &Stats{})
 		require.NoError(t, err)
 		require.NoError(t, cs.close())
 	}

--- a/go/store/nbs/table_set_test.go
+++ b/go/store/nbs/table_set_test.go
@@ -41,7 +41,7 @@ var hasManyHasAll = func([]hasRecord) (hash.HashSet, error) {
 func TestTableSetPrependEmpty(t *testing.T) {
 	hasCache, err := lru.New2Q[hash.Hash, struct{}](1024)
 	require.NoError(t, err)
-	ts, err := newFakeTableSet(&UnlimitedQuotaProvider{}).append(context.Background(), newMemTable(testMemTableSize), hasManyHasAll, hasCache, &Stats{})
+	ts, _, err := newFakeTableSet(&UnlimitedQuotaProvider{}).append(context.Background(), newMemTable(testMemTableSize), hasManyHasAll, nil, hasCache, &Stats{})
 	require.NoError(t, err)
 	specs, err := ts.toSpecs()
 	require.NoError(t, err)
@@ -61,7 +61,7 @@ func TestTableSetPrepend(t *testing.T) {
 	mt.addChunk(computeAddr(testChunks[0]), testChunks[0])
 	hasCache, err := lru.New2Q[hash.Hash, struct{}](1024)
 	require.NoError(t, err)
-	ts, err = ts.append(context.Background(), mt, hasManyHasAll, hasCache, &Stats{})
+	ts, _, err = ts.append(context.Background(), mt, hasManyHasAll, nil, hasCache, &Stats{})
 	require.NoError(t, err)
 
 	firstSpecs, err := ts.toSpecs()
@@ -71,7 +71,7 @@ func TestTableSetPrepend(t *testing.T) {
 	mt = newMemTable(testMemTableSize)
 	mt.addChunk(computeAddr(testChunks[1]), testChunks[1])
 	mt.addChunk(computeAddr(testChunks[2]), testChunks[2])
-	ts, err = ts.append(context.Background(), mt, hasManyHasAll, hasCache, &Stats{})
+	ts, _, err = ts.append(context.Background(), mt, hasManyHasAll, nil, hasCache, &Stats{})
 	require.NoError(t, err)
 
 	secondSpecs, err := ts.toSpecs()
@@ -93,17 +93,17 @@ func TestTableSetToSpecsExcludesEmptyTable(t *testing.T) {
 	mt.addChunk(computeAddr(testChunks[0]), testChunks[0])
 	hasCache, err := lru.New2Q[hash.Hash, struct{}](1024)
 	require.NoError(t, err)
-	ts, err = ts.append(context.Background(), mt, hasManyHasAll, hasCache, &Stats{})
+	ts, _, err = ts.append(context.Background(), mt, hasManyHasAll, nil, hasCache, &Stats{})
 	require.NoError(t, err)
 
 	mt = newMemTable(testMemTableSize)
-	ts, err = ts.append(context.Background(), mt, hasManyHasAll, hasCache, &Stats{})
+	ts, _, err = ts.append(context.Background(), mt, hasManyHasAll, nil, hasCache, &Stats{})
 	require.NoError(t, err)
 
 	mt = newMemTable(testMemTableSize)
 	mt.addChunk(computeAddr(testChunks[1]), testChunks[1])
 	mt.addChunk(computeAddr(testChunks[2]), testChunks[2])
-	ts, err = ts.append(context.Background(), mt, hasManyHasAll, hasCache, &Stats{})
+	ts, _, err = ts.append(context.Background(), mt, hasManyHasAll, nil, hasCache, &Stats{})
 	require.NoError(t, err)
 
 	specs, err = ts.toSpecs()
@@ -124,17 +124,17 @@ func TestTableSetFlattenExcludesEmptyTable(t *testing.T) {
 	mt.addChunk(computeAddr(testChunks[0]), testChunks[0])
 	hasCache, err := lru.New2Q[hash.Hash, struct{}](1024)
 	require.NoError(t, err)
-	ts, err = ts.append(context.Background(), mt, hasManyHasAll, hasCache, &Stats{})
+	ts, _, err = ts.append(context.Background(), mt, hasManyHasAll, nil, hasCache, &Stats{})
 	require.NoError(t, err)
 
 	mt = newMemTable(testMemTableSize)
-	ts, err = ts.append(context.Background(), mt, hasManyHasAll, hasCache, &Stats{})
+	ts, _, err = ts.append(context.Background(), mt, hasManyHasAll, nil, hasCache, &Stats{})
 	require.NoError(t, err)
 
 	mt = newMemTable(testMemTableSize)
 	mt.addChunk(computeAddr(testChunks[1]), testChunks[1])
 	mt.addChunk(computeAddr(testChunks[2]), testChunks[2])
-	ts, err = ts.append(context.Background(), mt, hasManyHasAll, hasCache, &Stats{})
+	ts, _, err = ts.append(context.Background(), mt, hasManyHasAll, nil, hasCache, &Stats{})
 	require.NoError(t, err)
 
 	ts, err = ts.flatten(context.Background())
@@ -164,7 +164,7 @@ func TestTableSetRebase(t *testing.T) {
 		for _, c := range chunks {
 			mt := newMemTable(testMemTableSize)
 			mt.addChunk(computeAddr(c), c)
-			ts, err = ts.append(context.Background(), mt, hasManyHasAll, hasCache, &Stats{})
+			ts, _, err = ts.append(context.Background(), mt, hasManyHasAll, nil, hasCache, &Stats{})
 			require.NoError(t, err)
 		}
 		return ts
@@ -213,13 +213,13 @@ func TestTableSetPhysicalLen(t *testing.T) {
 	mt.addChunk(computeAddr(testChunks[0]), testChunks[0])
 	hasCache, err := lru.New2Q[hash.Hash, struct{}](1024)
 	require.NoError(t, err)
-	ts, err = ts.append(context.Background(), mt, hasManyHasAll, hasCache, &Stats{})
+	ts, _, err = ts.append(context.Background(), mt, hasManyHasAll, nil, hasCache, &Stats{})
 	require.NoError(t, err)
 
 	mt = newMemTable(testMemTableSize)
 	mt.addChunk(computeAddr(testChunks[1]), testChunks[1])
 	mt.addChunk(computeAddr(testChunks[2]), testChunks[2])
-	ts, err = ts.append(context.Background(), mt, hasManyHasAll, hasCache, &Stats{})
+	ts, _, err = ts.append(context.Background(), mt, hasManyHasAll, nil, hasCache, &Stats{})
 	require.NoError(t, err)
 
 	assert.True(mustUint64(ts.physicalLen()) > indexSize(mustUint32(ts.count())))


### PR DESCRIPTION
Previously GC was constructed to walk the transitive closure of reachable chunks from when it started, and to take additional dependencies on any chunks that were written to the ChunkStore during the GC process. This change makes it so that we can additionally take dependencies on any chunks that are read from the ChunkStore during the GC process.

For the `nbs` layer to signal a new dependency during a GC, it makes use of a `keeperFunc`, which is passed into the `BeginGC` call. The contract is that, if `keeperFunc` is non-`nil` and it returns `false`, the chunk address which was given to the function will make its way back to a call to `SaveHashes` on some `MarkAndSweeper` whose contents  will end up in the final store once the GC is completed. `keeperFunc`, however, is allowed to return `true`, which signals to the block store that the in-progress GC has passed a certain point in time and can no longer make that guarantee. As a result, anytime `keeperFunc` returns `true`, the block store implementation needs to block until the GC process is over, and then it should resume the operation from the beginning.

That machinery already exists for the `Put()` and `Commit()` use case. This PR adds machinery to do all of that on various read paths that explicitly touch chunks, such as `Has`, `HasMany`, `Get`, `GetMany` and `GetManyCompressed`. In order to add dependency tracking on the read path, it's important for the GC process itself to not cause the chunks it has read to form additional dependencies. This PR makes a slight change to `markAndSweeper` so that it can fetch chunks from the source store without recording unnecessary duplicate dependencies and potentially becoming mired in deadlocks.