### PR TITLE
Speed up fetch when there are many tags which haven't changed

### DIFF
--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -594,24 +594,26 @@ func (ddb *DoltDB) ResolveTag(ctx context.Context, tagRef ref.TagRef) (*Tag, err
 	return NewTag(ctx, tagRef.GetPath(), ds, ddb.vrw, ddb.ns)
 }
 
-// TagResolver is used to late bind tag resolution
+// TagResolver is used to late load tag metadata resolution. There are situations where we need to list all the tags, but
+// don't necessarily need to load their metadata. See GetTagResolvers
 type TagResolver struct {
 	ddb *DoltDB
 	ref ref.TagRef
 	h   hash.Hash
 }
 
+// Addr returns the hash of the object storing the Tag data. It is loaded and deserialize by the Resolve method.
 func (tr *TagResolver) Addr() hash.Hash {
 	return tr.h
 }
 
-// Resolve resolves the tag reference to a *Tag
+// Resolve resolves the tag reference to a *Tag, complete with its metadata.
 func (tr *TagResolver) Resolve(ctx context.Context) (*Tag, error) {
 	return tr.ddb.ResolveTag(ctx, tr.ref)
 }
 
-// ResolveTags takes a slice of TagRefs and returns the corresponding Tag objects.
-func (ddb *DoltDB) ResolveTags(ctx context.Context, tagRefs []ref.DoltRef) ([]TagResolver, error) {
+// GetTagResolvers takes a slice of TagRefs and returns the corresponding Tag objects.
+func (ddb *DoltDB) GetTagResolvers(ctx context.Context, tagRefs []ref.DoltRef) ([]TagResolver, error) {
 	datasets, err := ddb.db.Datasets(ctx)
 	if err != nil {
 		return nil, err
@@ -633,7 +635,7 @@ func (ddb *DoltDB) ResolveTags(ctx context.Context, tagRefs []ref.DoltRef) ([]Ta
 			tr := TagResolver{ddb: ddb, ref: val, h: addr}
 			results = append(results, tr)
 		}
-		return nil // NM4 - is it an error if we don't find it???? Probably need to delete it on --prune.
+		return nil
 	})
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/env/actions/remotes.go
+++ b/go/libraries/doltcore/env/actions/remotes.go
@@ -338,7 +338,7 @@ func Clone(ctx context.Context, srcDB, destDB *doltdb.DoltDB, eventCh chan<- pul
 // been fetched into the destination DB.
 // todo: potentially too expensive to iterate over all srcDB tags
 func FetchFollowTags(ctx context.Context, tempTableDir string, srcDB, destDB *doltdb.DoltDB, progStarter ProgStarter, progStopper ProgStopper) error {
-	err := IterResolvedTags(ctx, srcDB, func(tag *doltdb.TagResolver) (stop bool, err error) {
+	err := IterUnresolvedTags(ctx, srcDB, func(tag *doltdb.TagResolver) (stop bool, err error) {
 		tagHash := tag.Addr()
 
 		has, err := destDB.Has(ctx, tagHash)

--- a/go/libraries/doltcore/env/actions/tag.go
+++ b/go/libraries/doltcore/env/actions/tag.go
@@ -16,6 +16,8 @@ package actions
 
 import (
 	"context"
+	"fmt"
+	"sort"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
@@ -90,6 +92,47 @@ func DeleteTagsOnDB(ctx context.Context, ddb *doltdb.DoltDB, tagNames ...string)
 
 		if err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// IterResolvedTags iterates over tags in dEnv.DoltDB from newest to oldest, resolving the tag to a commit and calling cb().
+func IterResolvedTags(ctx context.Context, ddb *doltdb.DoltDB, cb func(tag *doltdb.Tag) (stop bool, err error)) error {
+	tagRefs, err := ddb.GetTags(ctx)
+
+	if err != nil {
+		return err
+	}
+
+	var resolved []*doltdb.Tag
+	for _, r := range tagRefs {
+		tr, ok := r.(ref.TagRef)
+		if !ok {
+			return fmt.Errorf("DoltDB.GetTags() returned non-tag DoltRef")
+		}
+
+		tag, err := ddb.ResolveTag(ctx, tr)
+		if err != nil {
+			return err
+		}
+
+		resolved = append(resolved, tag)
+	}
+
+	// iterate newest to oldest
+	sort.Slice(resolved, func(i, j int) bool {
+		return resolved[i].Meta.Timestamp > resolved[j].Meta.Timestamp
+	})
+
+	for _, tag := range resolved {
+		stop, err := cb(tag)
+
+		if err != nil {
+			return err
+		}
+		if stop {
+			break
 		}
 	}
 	return nil

--- a/go/libraries/doltcore/env/actions/tag.go
+++ b/go/libraries/doltcore/env/actions/tag.go
@@ -95,16 +95,14 @@ func DeleteTagsOnDB(ctx context.Context, ddb *doltdb.DoltDB, tagNames ...string)
 	return nil
 }
 
-// IterResolvedTags iterates over tags in dEnv.DoltDB from newest to oldest, resolving the tag to a commit and calling cb().
-func IterResolvedTags(ctx context.Context, ddb *doltdb.DoltDB, cb func(tag *doltdb.TagResolver) (stop bool, err error)) error {
+// IterUnresolvedTags iterates over tags in dEnv.DoltDB, and calls cb() for each with an unresovled Tag.
+func IterUnresolvedTags(ctx context.Context, ddb *doltdb.DoltDB, cb func(tag *doltdb.TagResolver) (stop bool, err error)) error {
 	tagRefs, err := ddb.GetTags(ctx)
-
 	if err != nil {
 		return err
 	}
 
-	tagResolvers, err := ddb.ResolveTags(ctx, tagRefs)
-	_ = tagResolvers
+	tagResolvers, err := ddb.GetTagResolvers(ctx, tagRefs)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
A user remarked that `dolt pull` took 2 hours to pull changes. This was the result of wasting time for every tag which had not changed. This change alters the tag iteration code to defers the loading of metadata until it's actually required. Testing against user takes less that 1min now.