### PR TITLE
Fix failing MacOS BATS tests

### DIFF
--- a/.github/workflows/ci-bats-macos.yaml
+++ b/.github/workflows/ci-bats-macos.yaml
@@ -66,6 +66,12 @@ jobs:
           pip install mysql-connector-python
           pip install pandas
           pip install pyarrow
+      - name: Install MySQL client LTS release (8.4)
+        run: |
+          brew update
+          brew install mysql-client@8.4
+          brew link mysql-client@8.4 --force
+          mysql --version
       - name: Install Dolt
         working-directory: ./go
         run: |

--- a/.github/workflows/ci-check-repo.yaml
+++ b/.github/workflows/ci-check-repo.yaml
@@ -152,6 +152,8 @@ jobs:
           cwd: "."
           pull: "--ff"
       - name: Check generated protobufs
+        env:
+          USE_BAZEL_VERSION: 7.4.0
         working-directory: ./proto
         run: |
           (cd third_party/protobuf && bazel build //:protoc)


### PR DESCRIPTION
Testing Dolt's `caching_sha2_password` auth support with the `mysql` client on MacOS [recently started failing with](https://github.com/dolthub/dolt/actions/runs/12894448219/job/35953113732?pr=8773#step:17:222): `mysql: command not found`

These tests were previously working, but the `mysql` client seems to no longer be available. This change adds a new step to ensure the current LTS `mysql` client is installed. 

These tests normally run nightly, but they [passed in an earlier CI run on this PR that triggered them](https://github.com/dolthub/dolt/actions/runs/12895036783/job/35955067001?pr=8773).