### PR TITLE
[no-release-notes]: go/store/nbs: Improve cleanup if we encounter an error during GC.

### DIFF
--- a/go/store/chunks/chunk_store.go
+++ b/go/store/chunks/chunk_store.go
@@ -172,7 +172,9 @@ type MarkAndSweeper interface {
 	// chunks is accessed and copied.
 	SaveHashes(context.Context, []hash.Hash) error
 
-	Close(context.Context) (GCFinalizer, error)
+	Finalize(context.Context) (GCFinalizer, error)
+
+	Close(context.Context) error
 }
 
 // A GCFinalizer is returned from a MarkAndSweeper after it is closed.

--- a/go/store/chunks/memory_store.go
+++ b/go/store/chunks/memory_store.go
@@ -398,8 +398,12 @@ func (i *msvMarkAndSweeper) SaveHashes(ctx context.Context, hashes []hash.Hash) 
 	return nil
 }
 
-func (i *msvMarkAndSweeper) Close(context.Context) (GCFinalizer, error) {
+func (i *msvMarkAndSweeper) Finalize(context.Context) (GCFinalizer, error) {
 	return msvGcFinalizer{i.ms, i.keepers}, nil
+}
+
+func (i *msvMarkAndSweeper) Close(context.Context) error {
+	return nil
 }
 
 func (ms *MemoryStoreView) MarkAndSweepChunks(ctx context.Context, getAddrs GetAddrsCurry, filter HasManyFunc, dest ChunkStore, mode GCMode) (MarkAndSweeper, error) {

--- a/go/store/nbs/cmp_chunk_table_writer.go
+++ b/go/store/nbs/cmp_chunk_table_writer.go
@@ -173,6 +173,21 @@ func (tw *CmpChunkTableWriter) Remove() error {
 	return os.Remove(tw.path)
 }
 
+// Cancel the inprogress write and attempt to cleanup any
+// resources associated with it. It is an error to call
+// Flush{,ToFile} or Reader after canceling the writer.
+func (tw *CmpChunkTableWriter) Cancel() error {
+	closer, err := tw.sink.Reader()
+	if err != nil {
+		return err
+	}
+	err = closer.Close()
+	if err != nil {
+		return err
+	}
+	return tw.Remove()
+}
+
 func containsDuplicates(prefixes prefixIndexSlice) bool {
 	if len(prefixes) == 0 {
 		return false

--- a/go/store/nbs/store_test.go
+++ b/go/store/nbs/store_test.go
@@ -345,8 +345,9 @@ func TestNBSCopyGC(t *testing.T) {
 		keepersSlice = append(keepersSlice, h)
 	}
 	require.NoError(t, sweeper.SaveHashes(ctx, keepersSlice))
-	finalizer, err := sweeper.Close(ctx)
+	finalizer, err := sweeper.Finalize(ctx)
 	require.NoError(t, err)
+	require.NoError(t, sweeper.Close(ctx))
 	require.NoError(t, finalizer.SwapChunksInStore(ctx))
 	st.EndGC()
 

--- a/go/store/types/value_store.go
+++ b/go/store/types/value_store.go
@@ -727,7 +727,7 @@ func (lvs *ValueStore) gc(ctx context.Context,
 
 	err = sweeper.SaveHashes(ctx, toVisit.ToSlice())
 	if err != nil {
-		_, cErr := sweeper.Close(ctx)
+		cErr := sweeper.Close(ctx)
 		return nil, errors.Join(err, cErr)
 	}
 	toVisit = nil
@@ -738,7 +738,7 @@ func (lvs *ValueStore) gc(ctx context.Context,
 	next := lvs.readAndResetNewGenToVisit()
 	err = sweeper.SaveHashes(ctx, next.ToSlice())
 	if err != nil {
-		_, cErr := sweeper.Close(ctx)
+		cErr := sweeper.Close(ctx)
 		return nil, errors.Join(err, cErr)
 	}
 	next = nil
@@ -746,18 +746,22 @@ func (lvs *ValueStore) gc(ctx context.Context,
 	final := finalize()
 	err = sweeper.SaveHashes(ctx, final.ToSlice())
 	if err != nil {
-		_, cErr := sweeper.Close(ctx)
+		cErr := sweeper.Close(ctx)
 		return nil, errors.Join(err, cErr)
 	}
 
 	if safepointF != nil {
 		err = safepointF()
 		if err != nil {
-			_, cErr := sweeper.Close(ctx)
+			cErr := sweeper.Close(ctx)
 			return nil, errors.Join(err, cErr)
 		}
 	}
-	return sweeper.Close(ctx)
+	finalizer, err := sweeper.Finalize(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return finalizer, sweeper.Close(ctx)
 }
 
 // Close closes the underlying ChunkStore


### PR DESCRIPTION
During GC if we encounter an error we should cleanup the table writer. We can do it without finalizing the file, writing its index, etc. This improves the error path to be more correct and to leave less lingering state around.