### PR TITLE
Add the `dirty` column to the dolt_branches table

### DIFF
--- a/go/libraries/doltcore/sqle/dtables/branches_table.go
+++ b/go/libraries/doltcore/sqle/dtables/branches_table.go
@@ -15,6 +15,7 @@
 package dtables
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -237,6 +238,10 @@ func isDirty(ctx *sql.Context, ddb *doltdb.DoltDB, commit *doltdb.Commit, branch
 	}
 	ws, err := ddb.ResolveWorkingSetAtRoot(ctx, wsRef, txRoot)
 	if err != nil {
+		if errors.Is(err, doltdb.ErrWorkingSetNotFound) {
+			// If there is no working set for this branch, then it is never dirty. This happens on servers commonly.
+			return false, nil
+		}
 		return false, err
 	}
 

--- a/go/libraries/doltcore/sqle/dtables/branches_table.go
+++ b/go/libraries/doltcore/sqle/dtables/branches_table.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/index"
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 const branchesDefaultRowCount = 10

--- a/go/libraries/doltcore/sqle/dtables/branches_table.go
+++ b/go/libraries/doltcore/sqle/dtables/branches_table.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
 
@@ -90,6 +91,7 @@ func (bt *BranchesTable) Schema() sql.Schema {
 	if !bt.remote {
 		columns = append(columns, &sql.Column{Name: "remote", Type: types.Text, Source: bt.tableName, PrimaryKey: false, Nullable: true})
 		columns = append(columns, &sql.Column{Name: "branch", Type: types.Text, Source: bt.tableName, PrimaryKey: false, Nullable: true})
+		columns = append(columns, &sql.Column{Name: "dirty", Type: types.Boolean, Source: bt.tableName, PrimaryKey: false, Nullable: true})
 	}
 	return columns
 }
@@ -114,6 +116,7 @@ type BranchItr struct {
 	table    *BranchesTable
 	branches []string
 	commits  []*doltdb.Commit
+	dirty    []bool
 	idx      int
 }
 
@@ -145,11 +148,19 @@ func NewBranchItr(ctx *sql.Context, table *BranchesTable) (*BranchItr, error) {
 
 	branchNames := make([]string, len(branchRefs))
 	commits := make([]*doltdb.Commit, len(branchRefs))
+	dirtyBits := make([]bool, len(branchRefs))
 	for i, branch := range branchRefs {
 		commit, err := ddb.ResolveCommitRefAtRoot(ctx, branch, txRoot)
-
 		if err != nil {
 			return nil, err
+		}
+
+		var dirty bool
+		if !remote {
+			dirty, err = isDirty(ctx, ddb, commit, branch, txRoot)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		if branch.GetType() == ref.RemoteRefType {
@@ -158,6 +169,7 @@ func NewBranchItr(ctx *sql.Context, table *BranchesTable) (*BranchItr, error) {
 			branchNames[i] = branch.GetPath()
 		}
 
+		dirtyBits[i] = dirty
 		commits[i] = commit
 	}
 
@@ -165,6 +177,7 @@ func NewBranchItr(ctx *sql.Context, table *BranchesTable) (*BranchItr, error) {
 		table:    table,
 		branches: branchNames,
 		commits:  commits,
+		dirty:    dirtyBits,
 		idx:      0,
 	}, nil
 }
@@ -182,6 +195,7 @@ func (itr *BranchItr) Next(ctx *sql.Context) (sql.Row, error) {
 
 	name := itr.branches[itr.idx]
 	cm := itr.commits[itr.idx]
+	dirty := itr.dirty[itr.idx]
 	meta, err := cm.GetCommitMeta(ctx)
 
 	if err != nil {
@@ -211,8 +225,49 @@ func (itr *BranchItr) Next(ctx *sql.Context) (sql.Row, error) {
 			remoteName = branch.Remote
 			branchName = branch.Merge.Ref.GetPath()
 		}
-		return sql.NewRow(name, h.String(), meta.Name, meta.Email, meta.Time(), meta.Description, remoteName, branchName), nil
+		return sql.NewRow(name, h.String(), meta.Name, meta.Email, meta.Time(), meta.Description, remoteName, branchName, dirty), nil
 	}
+}
+
+// isDirty returns true if the working ref points to a dirty branch.
+func isDirty(ctx *sql.Context, ddb *doltdb.DoltDB, commit *doltdb.Commit, branch ref.DoltRef, txRoot hash.Hash) (bool, error) {
+	wsRef, err := ref.WorkingSetRefForHead(branch)
+	if err != nil {
+		return false, err
+	}
+	ws, err := ddb.ResolveWorkingSetAtRoot(ctx, wsRef, txRoot)
+	if err != nil {
+		return false, err
+	}
+
+	workingRoot := ws.WorkingRoot()
+	workingRootHash, err := workingRoot.HashOf()
+	if err != nil {
+		return false, err
+	}
+	stagedRoot := ws.StagedRoot()
+	stagedRootHash, err := stagedRoot.HashOf()
+	if err != nil {
+		return false, err
+	}
+
+	dirty := false
+	if workingRootHash != stagedRootHash {
+		dirty = true
+	} else {
+		cmRt, err := commit.GetRootValue(ctx)
+		if err != nil {
+			return false, err
+		}
+		cmRtHash, err := cmRt.HashOf()
+		if err != nil {
+			return false, err
+		}
+		if cmRtHash != workingRootHash {
+			dirty = true
+		}
+	}
+	return dirty, nil
 }
 
 // Close closes the iterator.

--- a/go/libraries/doltcore/sqle/sqlselect_test.go
+++ b/go/libraries/doltcore/sqle/sqlselect_test.go
@@ -784,6 +784,7 @@ func BasicSelectTests() []SelectTest {
 					"Initialize data repository",
 					"",
 					"",
+					true, // Test setup has a dirty workspace.
 				},
 			},
 			ExpectedSqlSchema: sql.Schema{
@@ -795,6 +796,7 @@ func BasicSelectTests() []SelectTest {
 				&sql.Column{Name: "latest_commit_message", Type: gmstypes.Text},
 				&sql.Column{Name: "remote", Type: gmstypes.Text},
 				&sql.Column{Name: "branch", Type: gmstypes.Text},
+				&sql.Column{Name: "dirty", Type: gmstypes.Boolean},
 			},
 		},
 	}

--- a/go/libraries/doltcore/sqle/testutil.go
+++ b/go/libraries/doltcore/sqle/testutil.go
@@ -452,7 +452,7 @@ func CreateEmptyTestTable(dEnv *env.DoltEnv, tableName string, sch schema.Schema
 	return dEnv.UpdateWorkingRoot(ctx, newRoot)
 }
 
-// CreateTestDatabase creates a test database with the test data set in it.
+// CreateTestDatabase creates a test database with the test data set in it. Has a dirty workspace as well.
 func CreateTestDatabase() (*env.DoltEnv, error) {
 	ctx := context.Background()
 	dEnv, err := CreateEmptyTestDatabase()

--- a/integration-tests/mysql-client-tests/node/workbenchTests/branches.js
+++ b/integration-tests/mysql-client-tests/node/workbenchTests/branches.js
@@ -58,6 +58,7 @@ export const branchTests = [
         latest_commit_message: "Initialize data repository",
         remote: "",
         branch: "",
+        dirty: 0,
       },
       {
         name: "mybranch",
@@ -68,6 +69,7 @@ export const branchTests = [
         latest_commit_message: "Create table test",
         remote: "",
         branch: "",
+        dirty: 0,
       },
     ],
     matcher: branchesMatcher,


### PR DESCRIPTION
This change allows users, particularly on servers, to quickly determine which branches have a dirty working set.