### PR TITLE
[no-release-notes] go: sqle,remotesrv: Implement sql.Session lifecycle callbacks for sql.Contexts used in remotesrv RPCs.

### DIFF
--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -47,6 +47,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/statspro"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/writer"
 	"github.com/dolthub/dolt/go/libraries/utils/config"
+	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 )
 
 // SqlEngine packages up the context necessary to run sql queries against dsqle.
@@ -55,6 +56,7 @@ type SqlEngine struct {
 	contextFactory contextFactory
 	dsessFactory   sessionFactory
 	engine         *gms.Engine
+	fs             filesys.Filesys
 }
 
 type sessionFactory func(mysqlSess *sql.BaseSession, pro sql.DatabaseProvider) (*dsess.DoltSession, error)
@@ -194,6 +196,7 @@ func NewSqlEngine(
 	sqlEngine.contextFactory = sqlContextFactory()
 	sqlEngine.dsessFactory = sessFactory
 	sqlEngine.engine = engine
+	sqlEngine.fs = pro.FileSystem()
 
 	// configuring stats depends on sessionBuilder
 	// sessionBuilder needs ref to statsProv
@@ -312,6 +315,10 @@ func (se *SqlEngine) Analyze(ctx *sql.Context, n sql.Node, qFlags *sql.QueryFlag
 
 func (se *SqlEngine) GetUnderlyingEngine() *gms.Engine {
 	return se.engine
+}
+
+func (se *SqlEngine) FileSystem() filesys.Filesys {
+	return se.fs
 }
 
 func (se *SqlEngine) Close() error {

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -567,7 +567,8 @@ func ConfigureServices(
 				ConcurrencyControl: remotesapi.PushConcurrencyControl_PUSH_CONCURRENCY_CONTROL_ASSERT_WORKING_SET,
 			}
 			var err error
-			args.FS, args.DBCache, err = sqle.RemoteSrvFSAndDBCache(sqlEngine.NewDefaultContext, sqle.DoNotCreateUnknownDatabases)
+			args.FS = sqlEngine.FileSystem()
+			args.DBCache, err = sqle.RemoteSrvDBCache(sqlEngine.NewDefaultContext, sqle.DoNotCreateUnknownDatabases)
 			if err != nil {
 				lgr.Errorf("error creating SQL engine context for remotesapi server: %v", err)
 				return err
@@ -621,6 +622,7 @@ func ConfigureServices(
 				lgr.Errorf("error creating SQL engine context for remotesapi server: %v", err)
 				return err
 			}
+			args.FS = sqlEngine.FileSystem()
 
 			clusterRemoteSrvTLSConfig, err := LoadClusterTLSConfig(serverConfig.ClusterConfig())
 			if err != nil {

--- a/go/libraries/doltcore/sqle/cluster/controller.go
+++ b/go/libraries/doltcore/sqle/cluster/controller.go
@@ -690,7 +690,7 @@ func (c *Controller) RemoteSrvServerArgs(ctxFactory func(context.Context) (*sql.
 	args.GrpcListenAddr = listenaddr
 	args.Options = c.ServerOptions()
 	var err error
-	args.FS, args.DBCache, err = sqle.RemoteSrvFSAndDBCache(ctxFactory, sqle.CreateUnknownDatabases)
+	args.DBCache, err = sqle.RemoteSrvDBCache(ctxFactory, sqle.CreateUnknownDatabases)
 	if err != nil {
 		return remotesrv.ServerArgs{}, err
 	}

--- a/go/libraries/doltcore/sqle/remotesrv.go
+++ b/go/libraries/doltcore/sqle/remotesrv.go
@@ -119,7 +119,7 @@ func GetInterceptorSqlContext(ctx context.Context) (*sql.Context, error) {
 	if v := ctx.Value(sqlContextInterceptorKey{}); v != nil {
 		return v.(*sql.Context), nil
 	}
-	return nil, errors.New("misconfiguration; a sql.Context should always be available from the intercetpor chain.")
+	return nil, errors.New("misconfiguration; a sql.Context should always be available from the interceptor chain.")
 }
 
 func (si SqlContextServerInterceptor) Stream() grpc.StreamServerInterceptor {

--- a/go/libraries/doltcore/sqle/remotesrv.go
+++ b/go/libraries/doltcore/sqle/remotesrv.go
@@ -22,7 +22,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/remotesrv"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
-	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/store/datas"
 )
 
@@ -81,17 +80,12 @@ type CreateUnknownDatabasesSetting bool
 const CreateUnknownDatabases CreateUnknownDatabasesSetting = true
 const DoNotCreateUnknownDatabases CreateUnknownDatabasesSetting = false
 
-// Considers |args| and returns a new |remotesrv.ServerArgs| instance which
-// will serve databases accessible through |ctxFactory|.
-func RemoteSrvFSAndDBCache(ctxFactory func(context.Context) (*sql.Context, error), createSetting CreateUnknownDatabasesSetting) (filesys.Filesys, remotesrv.DBCache, error) {
-	sqlCtx, err := ctxFactory(context.Background())
-	if err != nil {
-		return nil, nil, err
-	}
-	sess := dsess.DSessFromSess(sqlCtx.Session)
-	fs := sess.Provider().FileSystem()
+// Returns a remotesrv.DBCache instance which will use the *sql.Context
+// returned from |ctxFactory| to access a database in the session
+// DatabaseProvider.
+func RemoteSrvDBCache(ctxFactory func(context.Context) (*sql.Context, error), createSetting CreateUnknownDatabasesSetting) (remotesrv.DBCache, error) {
 	dbcache := remotesrvStore{ctxFactory, bool(createSetting)}
-	return fs, dbcache, nil
+	return dbcache, nil
 }
 
 func WithUserPasswordAuth(args remotesrv.ServerArgs, authnz remotesrv.AccessControl) remotesrv.ServerArgs {

--- a/go/libraries/doltcore/sqle/remotesrv.go
+++ b/go/libraries/doltcore/sqle/remotesrv.go
@@ -16,8 +16,11 @@ package sqle
 
 import (
 	"context"
+	"errors"
+	"net/http"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"google.golang.org/grpc"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/remotesrv"
@@ -95,4 +98,89 @@ func WithUserPasswordAuth(args remotesrv.ServerArgs, authnz remotesrv.AccessCont
 	}
 	args.Options = append(args.Options, si.Options()...)
 	return args
+}
+
+type SqlContextServerInterceptor struct {
+	Factory func(context.Context) (*sql.Context, error)
+}
+
+type serverStreamWrapper struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s serverStreamWrapper) Context() context.Context {
+	return s.ctx
+}
+
+type sqlContextInterceptorKey struct{}
+
+func GetInterceptorSqlContext(ctx context.Context) (*sql.Context, error) {
+	if v := ctx.Value(sqlContextInterceptorKey{}); v != nil {
+		return v.(*sql.Context), nil
+	}
+	return nil, errors.New("misconfiguration; a sql.Context should always be available from the intercetpor chain.")
+}
+
+func (si SqlContextServerInterceptor) Stream() grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		sqlCtx, err := si.Factory(ss.Context())
+		if err != nil {
+			return err
+		}
+		sql.SessionCommandBegin(sqlCtx.Session)
+		defer sql.SessionCommandEnd(sqlCtx.Session)
+		defer sql.SessionEnd(sqlCtx.Session)
+		newCtx := context.WithValue(ss.Context(), sqlContextInterceptorKey{}, sqlCtx)
+		newSs := serverStreamWrapper{
+			ServerStream: ss,
+			ctx:          newCtx,
+		}
+		return handler(srv, newSs)
+	}
+}
+
+func (si SqlContextServerInterceptor) Unary() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		sqlCtx, err := si.Factory(ctx)
+		if err != nil {
+			return nil, err
+		}
+		sql.SessionCommandBegin(sqlCtx.Session)
+		defer sql.SessionCommandEnd(sqlCtx.Session)
+		defer sql.SessionEnd(sqlCtx.Session)
+		newCtx := context.WithValue(ctx, sqlContextInterceptorKey{}, sqlCtx)
+		return handler(newCtx, req)
+	}
+}
+
+func (si SqlContextServerInterceptor) HTTP(existing func(http.Handler) http.Handler) func(http.Handler) http.Handler {
+	return func(h http.Handler) http.Handler {
+		this := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			sqlCtx, err := si.Factory(ctx)
+			if err != nil {
+				http.Error(w, "could not initialize sql.Context", http.StatusInternalServerError)
+				return
+			}
+			sql.SessionCommandBegin(sqlCtx.Session)
+			defer sql.SessionCommandEnd(sqlCtx.Session)
+			defer sql.SessionEnd(sqlCtx.Session)
+			newCtx := context.WithValue(ctx, sqlContextInterceptorKey{}, sqlCtx)
+			newReq := r.WithContext(newCtx)
+			h.ServeHTTP(w, newReq)
+		})
+		if existing != nil {
+			return existing(this)
+		} else {
+			return this
+		}
+	}
+}
+
+func (si SqlContextServerInterceptor) Options() []grpc.ServerOption {
+	return []grpc.ServerOption{
+		grpc.ChainUnaryInterceptor(si.Unary()),
+		grpc.ChainStreamInterceptor(si.Stream()),
+	}
 }


### PR DESCRIPTION
This PR changes each RPC invocation against the gRPC and HTTP servers
implementing remotesapi and cluster replication to create a sql.Context
which lives the duration of the call. The Session for that call gets
SessionCommand{Begin,End} and SessionEnd lifecycle callbacks so that it
can participate in GC safepoint rendezvous appropriately.

Previously the remotesrv.DBCache and the user/password remotesapi
authentication implementation would simply create new sql.Contexts
whenever they needed them. There could be multiple sql.Contexts for the
single server call.