### PR TITLE
[no-release-notes] go: store/nbs: GhostBlockStore: Add refCheck which participates in updating hasRecords.

### DIFF
--- a/go/store/nbs/generational_chunk_store.go
+++ b/go/store/nbs/generational_chunk_store.go
@@ -250,7 +250,7 @@ func (gcs *GenerationalNBS) refCheck(recs []hasRecord) (hash.HashSet, error) {
 		return absent, nil
 	}
 
-	return gcs.ghostGen.hasMany(absent)
+	return gcs.ghostGen.refCheck(recs)
 }
 
 // Put caches c in the ChunkSource. Upon return, c must be visible to

--- a/go/store/nbs/ghost_store.go
+++ b/go/store/nbs/ghost_store.go
@@ -151,12 +151,12 @@ func (g GhostBlockStore) hasMany(hashes hash.HashSet) (absent hash.HashSet, err 
 
 func (g GhostBlockStore) refCheck(recs []hasRecord) (hash.HashSet, error) {
 	absent := hash.HashSet{}
-	for _, r := range recs {
-		if !r.has {
-			if g.skippedRefs.Has(*r.a) {
-				r.has = true
+	for i := range recs {
+		if !recs[i].has {
+			if g.skippedRefs.Has(*recs[i].a) {
+				recs[i].has = true
 			} else {
-				absent.Insert(*r.a)
+				absent.Insert(*recs[i].a)
 			}
 		}
 	}

--- a/go/store/nbs/ghost_store.go
+++ b/go/store/nbs/ghost_store.go
@@ -149,6 +149,20 @@ func (g GhostBlockStore) hasMany(hashes hash.HashSet) (absent hash.HashSet, err 
 	return absent, nil
 }
 
+func (g GhostBlockStore) refCheck(recs []hasRecord) (hash.HashSet, error) {
+	absent := hash.HashSet{}
+	for _, r := range recs {
+		if !r.has {
+			if g.skippedRefs.Has(*r.a) {
+				r.has = true
+			} else {
+				absent.Insert(*r.a)
+			}
+		}
+	}
+	return absent, nil
+}
+
 func (g GhostBlockStore) Put(ctx context.Context, c chunks.Chunk, getAddrs chunks.GetAddrsCurry) error {
 	panic("GhostBlockStore does not support Put")
 }


### PR DESCRIPTION
Fixes a bug in the current implementation of GenerationalNBS.refCheck where things that are found in the GhostBlockStore are not marked in the hasRecords as being found.