### PR TITLE
[no-release-notes] go/store/nbs: Check for context cancelation in SaveHashes.

### DIFF
--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -1821,6 +1821,13 @@ func (i *markAndSweeper) SaveHashes(ctx context.Context, hashes []hash.Hash) err
 	var mu sync.Mutex
 	first := true
 	for {
+		// We manually check context here, because in some cases
+		// the work we are doing here does not result in a timely
+		// error once the context is canceled.
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
 		if !first {
 			copy := toVisit.Copy()
 			for h := range toVisit {


### PR DESCRIPTION
In certain cases, the work that SaveHashes does doesn't naturally see a context cancelation in a timely manner. Make certain we do return after we see one.