### PR TITLE
Expand `ItemAccess::itemWidth` to 32 bits

### DIFF
--- a/go/store/prolly/message/blob.go
+++ b/go/store/prolly/message/blob.go
@@ -83,7 +83,7 @@ func getBlobValues(msg serial.Message) (values ItemAccess, err error) {
 	} else {
 		values.bufStart = lookupVectorOffset(blobPayloadBytesVOffset, b.Table())
 		values.bufLen = uint32(b.PayloadLength())
-		values.itemWidth = uint16(b.PayloadLength())
+		values.itemWidth = uint32(b.PayloadLength())
 	}
 	return
 }

--- a/go/store/prolly/message/commit_closure.go
+++ b/go/store/prolly/message/commit_closure.go
@@ -41,7 +41,7 @@ func getCommitClosureKeys(msg serial.Message) (ItemAccess, error) {
 	}
 	ret.bufStart = lookupVectorOffset(commitClosureKeyItemBytesVOffset, m.Table())
 	ret.bufLen = uint32(m.KeyItemsLength())
-	ret.itemWidth = uint16(commitClosureKeyLength)
+	ret.itemWidth = uint32(commitClosureKeyLength)
 	return ret, nil
 }
 

--- a/go/store/prolly/message/item_access.go
+++ b/go/store/prolly/message/item_access.go
@@ -43,7 +43,7 @@ type ItemAccess struct {
 	// If the serial.Message does not contain an
 	// offset buffer (offStart is zero), then
 	// Items have a fixed width equal to itemWidth.
-	itemWidth  uint16
+	itemWidth  uint32
 	offsetSize offsetSize
 }
 

--- a/go/store/prolly/message/prolly_map_test.go
+++ b/go/store/prolly/message/prolly_map_test.go
@@ -48,7 +48,7 @@ func TestGetKeyValueOffsetsVectors(t *testing.T) {
 
 func TestItemAccessSize(t *testing.T) {
 	sz := unsafe.Sizeof(ItemAccess{})
-	assert.Equal(t, 20, int(sz))
+	assert.Equal(t, 24, int(sz))
 }
 
 func randomByteSlices(t *testing.T, count int) (keys, values [][]byte) {

--- a/go/store/prolly/tree/json_chunker.go
+++ b/go/store/prolly/tree/json_chunker.go
@@ -56,13 +56,6 @@ func SerializeJsonToAddr(ctx context.Context, ns NodeStore, j sql.JSONWrapper) (
 	}
 	jsonChunker.appendJsonToBuffer(jsonBytes)
 	err = jsonChunker.processBuffer(ctx)
-	if largeJsonStringError.Is(err) {
-		// Due to current limits on chunk sizes, and an inability of older clients to read
-		// string keys and values split across multiple chunks, we can't use the JSON chunker for documents
-		// with extremely long strings.
-		node, _, err := serializeJsonToBlob(ctx, ns, j)
-		return node, err
-	}
 	if err != nil {
 		return Node{}, err
 	}

--- a/go/store/prolly/tree/json_indexed_document.go
+++ b/go/store/prolly/tree/json_indexed_document.go
@@ -114,7 +114,7 @@ func tryWithFallback(
 	tryFunc func() error,
 	fallbackFunc func(document types.JSONDocument) error) error {
 	err := tryFunc()
-	if err == unknownLocationKeyError || err == unsupportedPathError || err == jsonParseError || largeJsonStringError.Is(err) {
+	if err == unknownLocationKeyError || err == unsupportedPathError || err == jsonParseError {
 		if err != unsupportedPathError {
 			if sqlCtx, ok := ctx.(*sql.Context); ok {
 				sqlCtx.GetLogger().Warn(err)

--- a/go/store/prolly/tree/json_scanner.go
+++ b/go/store/prolly/tree/json_scanner.go
@@ -17,8 +17,6 @@ package tree
 import (
 	"fmt"
 	"io"
-
-	errorkinds "gopkg.in/src-d/go-errors.v1"
 )
 
 // JsonScanner is a state machine that parses already-normalized JSON while keeping track of the path to the current value.
@@ -40,15 +38,7 @@ type JsonScanner struct {
 	valueOffset int
 }
 
-// The JSONChunker can't draw a chunk boundary within an object key.
-// This can lead to large chunks that may cause problems.
-// We've observed chunks getting written incorrectly if they exceed 48KB.
-// Since boundaries are always drawn once a chunk exceeds maxChunkSize (16KB),
-// this is the largest length that can be appended to a chunk without exceeding 48KB.
-var maxJsonStringLength = 48*1024 - maxChunkSize
-
 var jsonParseError = fmt.Errorf("encountered invalid JSON while reading JSON from the database, or while preparing to write JSON to the database. This is most likely a bug in JSON diffing")
-var largeJsonStringError = errorkinds.NewKind("encountered JSON key with length %s, larger than max allowed length %s")
 
 func (j JsonScanner) Clone() JsonScanner {
 	return JsonScanner{
@@ -215,9 +205,6 @@ func (s *JsonScanner) acceptKeyString() (stringBytes []byte, err error) {
 		}
 		s.valueOffset++
 	}
-	if s.valueOffset-stringStart > maxJsonStringLength {
-		return nil, largeJsonStringError.New(s.valueOffset-stringStart, maxJsonStringLength)
-	}
 	result := s.jsonBuffer[stringStart:s.valueOffset]
 	// Advance past the ending quotes
 	s.valueOffset++
@@ -233,19 +220,12 @@ func (s *JsonScanner) acceptValueString() (finishedString bool, err error) {
 }
 
 func (s *JsonScanner) acceptRestOfValueString() (finishedString bool, err error) {
-	stringStart := s.valueOffset
 	for s.current() != '"' {
 		switch s.current() {
 		case '\\':
 			s.valueOffset++
 		}
 		s.valueOffset++
-	}
-	// We don't currently split value strings across chunks because it causes issues being read by older clients.
-	// Instead, by returning largeJsonStringError, we trigger the fallback behavior where the JSON document
-	// gets treated as a non-indexed blob.
-	if s.valueOffset-stringStart > maxJsonStringLength {
-		return false, largeJsonStringError.New(s.valueOffset-stringStart, maxJsonStringLength)
 	}
 	// Advance past the ending quotes
 	s.valueOffset++

--- a/go/store/prolly/tree/node_test.go
+++ b/go/store/prolly/tree/node_test.go
@@ -68,7 +68,7 @@ func TestRoundTripNodeItems(t *testing.T) {
 
 func TestNodeSize(t *testing.T) {
 	sz := unsafe.Sizeof(Node{})
-	assert.Equal(t, 80, int(sz))
+	assert.Equal(t, 88, int(sz))
 }
 
 func BenchmarkNodeGet(b *testing.B) {

--- a/integration-tests/bats/json.bats
+++ b/integration-tests/bats/json.bats
@@ -298,24 +298,3 @@ SQL
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Blob" ]] || false
 }
-
-# Older clients have a bug that prevents them from reading indexed JSON documents with strings split across chunks,
-# And making one large chunk can causes issues with the journal.
-# Thus, we expect that the document gets stored as a blob.
-@test "json: document with large string value doesn't get indexed" {
-    run dolt sql <<SQL
-    CREATE TABLE js (
-        pk int PRIMARY KEY,
-        js json
-    );
-    insert into js values (1, '{"key": "`head -c 2097152 < /dev/zero | tr '\0' '\141'`" }');
-    insert into js values (2, '{"`head -c 2097152 < /dev/zero | tr '\0' '\141'`": "value" }');
-SQL
-    # If the documents aren't put into an IndexedJsonDocument, they will contain the following hashes.
-    run dolt show 9erat0qpsqrmmr53fhu6b7gnjj5n1v9i
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ "Blob" ]] || false
-    run dolt show 69cm31n0k392sch3snf5jc7ndfiaund8
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ "Blob" ]] || false
-}

--- a/integration-tests/bats/json.bats
+++ b/integration-tests/bats/json.bats
@@ -272,14 +272,10 @@ SQL
 
     dolt sql -f $BATS_TEST_DIRNAME/json-large-value-insert.sql
 
-    # TODO: Retrieving the JSON errors with a JSON truncated message
-    #       Unskip this once the JSON truncation issue is fixed and
-    #       fill in the expected length below.
-    skip "Function Support is currently disabled"
-
+    dolt sql -q "SELECT pk, length(j1) FROM t;" -r csv
     run dolt sql -q "SELECT pk, length(j1) FROM t;" -r csv
     [ "$status" -eq 0 ]
-    [ "${lines[1]}" = '1,???' ]
+    [ "${lines[1]}" = '1,3145771' ]
 }
 
 # This test inserts a large JSON document with the `dolt_dont_optimize_json` flag set.


### PR DESCRIPTION
`ItemAccess` is a class used to read data out of prolly tree nodes. Because the `itemWidth` field was limited to 16 bits, reading any value larger than 2^16 bytes would result in silent truncation.

We don't usually store values this large, although it should be safe to do so. 

This issue was discovered because the new JSON chunker (introduced in https://github.com/dolthub/dolt/pull/7912) always stores embedded strings as a single chunk, so a document containing a string larger than 32KB would result in a node with a single value whose length didn't fit in 16 bits.

While we were investigating this issue, we created https://github.com/dolthub/dolt/pull/8723 to disable the new JSON chunker in the presence of these long strings. This PR partially reverts that one, resuming the smart chunking of JSON even in the presence of large embedded strings.