### PR TITLE
allow `dolt init` on dolt repo with just `config.json`

### DIFF
--- a/go/libraries/doltcore/env/config.go
+++ b/go/libraries/doltcore/env/config.go
@@ -145,13 +145,17 @@ func (dcc *DoltCliConfig) createLocalConfigAt(dir string, vals map[string]string
 	}
 
 	path := filepath.Join(dir, getLocalConfigPath())
-	cfg, err := config.NewFileConfig(path, dcc.fs, vals)
+	if exists, _ := dcc.fs.Exists(path); exists {
+		return nil
+	}
 
+	cfg, err := config.NewFileConfig(path, dcc.fs, vals)
 	if err != nil {
 		return err
 	}
 
 	dcc.ch.AddConfig(localConfigName, cfg)
+
 
 	return nil
 }

--- a/go/libraries/doltcore/env/config.go
+++ b/go/libraries/doltcore/env/config.go
@@ -156,7 +156,6 @@ func (dcc *DoltCliConfig) createLocalConfigAt(dir string, vals map[string]string
 
 	dcc.ch.AddConfig(localConfigName, cfg)
 
-
 	return nil
 }
 

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -499,7 +499,8 @@ func (dEnv *DoltEnv) createDirectories(dir string) (string, error) {
 		}
 
 		if len(entries) == 1 {
-			if (!entries[0].IsDir() && entries[0].Name() != TmpDirName) && (!entries[0].IsDir() && entries[0].Name() != configFile) {
+			entry := entries[0]
+			if (entry.IsDir() && entry.Name() != TmpDirName) || (!entry.IsDir() && entry.Name() != configFile) {
 				return "", fmt.Errorf(".dolt directory already exists at '%s'", dir)
 			}
 		} else if len(entries) != 0 {

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -499,7 +499,7 @@ func (dEnv *DoltEnv) createDirectories(dir string) (string, error) {
 		}
 
 		if len(entries) == 1 {
-			if !entries[0].IsDir() || entries[0].Name() != TmpDirName {
+			if (!entries[0].IsDir() && entries[0].Name() != TmpDirName) && (!entries[0].IsDir() && entries[0].Name() != configFile) {
 				return "", fmt.Errorf(".dolt directory already exists at '%s'", dir)
 			}
 		} else if len(entries) != 0 {

--- a/integration-tests/bats/init.bats
+++ b/integration-tests/bats/init.bats
@@ -287,7 +287,7 @@ teardown() {
 
     mkdir -p dbdir/.dolt
     cd dbdir
-    touch .dolt/config.json
+    touch .dolt/not_config.json
     run dolt init
     [ "$status" -eq 1 ]
     [[ "$output" =~ ".dolt directory already exists" ]] || false

--- a/integration-tests/bats/init.bats
+++ b/integration-tests/bats/init.bats
@@ -64,10 +64,8 @@ teardown() {
 
   mkdir .dolt
 
-  run dolt config --add user.name foo
-  [ "$status" -eq 0 ]
-  run dolt config --add user.email foo@bar.com
-  [ "$status" -eq 0 ]
+  dolt config --add user.name foo
+  dolt config --add user.email foo@bar.com
 
   run dolt config --local --get user.name
   [ "$status" -eq 0 ]

--- a/integration-tests/bats/init.bats
+++ b/integration-tests/bats/init.bats
@@ -59,6 +59,30 @@ teardown() {
   assert_valid_repository
 }
 
+@test "init: explicit local configuration for config file" {
+  set_dolt_user "baz", "baz@bash.com"
+
+  mkdir .dolt
+
+  run dolt config --add user.name foo
+  [ "$status" -eq 0 ]
+  run dolt config --add user.email foo@bar.com
+  [ "$status" -eq 0 ]
+
+  run dolt config --local --get user.name
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "foo" ]] || false
+
+  run dolt config --local --get user.email
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "foo@bar.com" ]] || false
+
+  run dolt init
+  [ "$status" -eq 0 ]
+
+  assert_valid_repository
+}
+
 @test "init: explicit local configuration for name and email" {
   set_dolt_user "baz", "baz@bash.com"
 


### PR DESCRIPTION
This PR changes `dolt init` to allow the dolt repo to still be created when there are no global users, but there are local users in `.dolt/config.json`.

In order to get to that state you must do
```shell
mkdir .dolt
dolt config --add user.email <email>
dolt config --add user.name <name>
```


related: https://github.com/dolthub/dolt/issues/8835