### PR TITLE
[no-release-notes] go: sqle: Change how we run background threads for replication hooks. Add session lifecycle callbacks for replication hooks.

### DIFF
--- a/go/cmd/dolt/commands/filter-branch.go
+++ b/go/cmd/dolt/commands/filter-branch.go
@@ -351,8 +351,7 @@ func rebaseSqlEngine(ctx context.Context, dEnv *env.DoltEnv, root doltdb.RootVal
 	}
 
 	b := env.GetDefaultInitBranch(dEnv.Config)
-	bThreads := sql.NewBackgroundThreads()
-	pro, err := dsqle.NewDoltDatabaseProviderWithDatabase(b, mrEnv.FileSystem(), db, dEnv.FS, bThreads)
+	pro, err := dsqle.NewDoltDatabaseProviderWithDatabase(b, mrEnv.FileSystem(), db, dEnv.FS)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/cmd/dolt/commands/sql_test.go
+++ b/go/cmd/dolt/commands/sql_test.go
@@ -17,10 +17,8 @@ package commands
 import (
 	"context"
 	"fmt"
-	"io"
 	"testing"
 
-	"github.com/dolthub/go-mysql-server/sql"
 	_ "github.com/dolthub/go-mysql-server/sql/variables"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -29,7 +27,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/dtestutils"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 )
 
 var tableName = "people"
@@ -604,25 +601,5 @@ func TestDelete(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-func TestCommitHooksNoErrors(t *testing.T) {
-	ctx := context.Background()
-	dEnv, err := sqle.CreateEnvWithSeedData()
-	require.NoError(t, err)
-	defer dEnv.DoltDB(ctx).Close()
-
-	sql.SystemVariables.SetGlobal(dsess.ReplicateToRemote, "unknown")
-	hooks, err := sqle.GetCommitHooks(context.Background(), nil, dEnv, io.Discard)
-	assert.NoError(t, err)
-	if len(hooks) < 1 {
-		t.Error("failed to produce noop hook")
-	} else {
-		switch h := hooks[0].(type) {
-		case *sqle.LogHook:
-		default:
-			t.Errorf("expected LogHook, found: %s", h)
-		}
 	}
 }

--- a/go/libraries/doltcore/sqle/commit_hooks.go
+++ b/go/libraries/doltcore/sqle/commit_hooks.go
@@ -117,7 +117,7 @@ var _ doltdb.CommitHook = (*AsyncPushOnWriteHook)(nil)
 func NewAsyncPushOnWriteHook(destDB *doltdb.DoltDB, tmpDir string, logger io.Writer) (*AsyncPushOnWriteHook, RunAsyncThreads) {
 	ch := make(chan PushArg, asyncPushBufferSize)
 	runThreads := func(bThreads *sql.BackgroundThreads, ctxF func(context.Context) (*sql.Context, error)) error {
-		return RunAsyncReplicationThreads(bThreads, ch, destDB, tmpDir, logger)
+		return RunAsyncReplicationThreads(bThreads, ctxF, ch, destDB, tmpDir, logger)
 	}
 	return &AsyncPushOnWriteHook{ch: ch}, runThreads
 }
@@ -187,7 +187,7 @@ func (*LogHook) ExecuteForWorkingSets() bool {
 	return false
 }
 
-func RunAsyncReplicationThreads(bThreads *sql.BackgroundThreads, ch chan PushArg, destDB *doltdb.DoltDB, tmpDir string, logger io.Writer) error {
+func RunAsyncReplicationThreads(bThreads *sql.BackgroundThreads, ctxF func(context.Context) (*sql.Context, error), ch chan PushArg, destDB *doltdb.DoltDB, tmpDir string, logger io.Writer) error {
 	mu := &sync.Mutex{}
 	var newHeads = make(map[string]PushArg, asyncPushBufferSize)
 
@@ -245,16 +245,26 @@ func RunAsyncReplicationThreads(bThreads *sql.BackgroundThreads, ch chan PushArg
 		}
 		for id, newCm := range newHeadsCopy {
 			if latest, ok := latestHeads[id]; !ok || latest != newCm.hash {
-				// use background context to drain after sql context is canceled
-				err := pushDataset(context.Background(), destDB, newCm.db, newCm.ds, tmpDir)
-				if err != nil {
-					logger.Write([]byte("replication failed: " + err.Error()))
-				}
-				if newCm.hash.IsEmpty() {
-					delete(latestHeads, id)
-				} else {
-					latestHeads[id] = newCm.hash
-				}
+				func() {
+					// use background context to drain after sql context is canceled
+					sqlCtx, err := ctxF(context.Background())
+					if err != nil {
+						logger.Write([]byte("replication failed: could not create *sql.Context: " + err.Error()))
+					} else {
+						defer sql.SessionEnd(sqlCtx.Session)
+						sql.SessionCommandBegin(sqlCtx.Session)
+						defer sql.SessionCommandEnd(sqlCtx.Session)
+						err := pushDataset(sqlCtx, destDB, newCm.db, newCm.ds, tmpDir)
+						if err != nil {
+							logger.Write([]byte("replication failed: " + err.Error()))
+						}
+						if newCm.hash.IsEmpty() {
+							delete(latestHeads, id)
+						} else {
+							latestHeads[id] = newCm.hash
+						}
+					}
+				}()
 			}
 		}
 	}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
@@ -484,7 +484,7 @@ func (d *DoltHarness) NewReadOnlyEngine(provider sql.DatabaseProvider) (enginete
 		locations[i] = loc
 	}
 
-	readOnlyProvider, err := sqle.NewDoltDatabaseProviderWithDatabases("main", ddp.FileSystem(), dbs, locations, sql.NewBackgroundThreads())
+	readOnlyProvider, err := sqle.NewDoltDatabaseProviderWithDatabases("main", ddp.FileSystem(), dbs, locations)
 	if err != nil {
 		return nil, err
 	}
@@ -533,7 +533,7 @@ func (d *DoltHarness) newProvider(ctx context.Context) sql.MutableDatabaseProvid
 	d.multiRepoEnv = mrEnv
 
 	b := env.GetDefaultInitBranch(d.multiRepoEnv.Config())
-	pro, err := sqle.NewDoltDatabaseProvider(b, d.multiRepoEnv.FileSystem(), sql.NewBackgroundThreads())
+	pro, err := sqle.NewDoltDatabaseProvider(b, d.multiRepoEnv.FileSystem())
 	require.NoError(d.t, err)
 
 	return pro

--- a/go/libraries/doltcore/sqle/index/mergeable_indexes_setup_test.go
+++ b/go/libraries/doltcore/sqle/index/mergeable_indexes_setup_test.go
@@ -99,7 +99,7 @@ func setupIndexes(t *testing.T, tableName, insertQuery string) (*sqle.Engine, *s
 	mrEnv, err := env.MultiEnvForDirectory(context.Background(), dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
 	require.NoError(t, err)
 	b := env.GetDefaultInitBranch(dEnv.Config)
-	pro, err := dsqle.NewDoltDatabaseProviderWithDatabase(b, mrEnv.FileSystem(), db, dEnv.FS, sql.NewBackgroundThreads())
+	pro, err := dsqle.NewDoltDatabaseProviderWithDatabase(b, mrEnv.FileSystem(), db, dEnv.FS)
 	if err != nil {
 		return nil, nil, nil
 	}

--- a/go/libraries/doltcore/sqle/logictest/dolt/doltharness.go
+++ b/go/libraries/doltcore/sqle/logictest/dolt/doltharness.go
@@ -144,8 +144,11 @@ func innerInit(h *DoltHarness, dEnv *env.DoltEnv) error {
 		return err
 	}
 
+	statsPro := statspro.NewProvider(pro.(*dsql.DoltDatabaseProvider), statsnoms.NewNomsStatsFactory(env.NewGRPCDialProviderFromDoltEnv(dEnv)))
+	gcSafepointController := dsess.NewGCSafepointController()
+
 	config, _ := dEnv.Config.GetConfig(env.GlobalConfig)
-	sqlCtx := dsql.NewTestSQLCtxWithProvider(ctx, pro, config, statspro.NewProvider(pro.(*dsql.DoltDatabaseProvider), statsnoms.NewNomsStatsFactory(env.NewGRPCDialProviderFromDoltEnv(dEnv))), dsess.NewGCSafepointController())
+	sqlCtx := dsql.NewTestSQLCtxWithProvider(ctx, pro, config, statsPro, gcSafepointController)
 	h.sess = sqlCtx.Session.(*dsess.DoltSession)
 
 	dbs := h.engine.Analyzer.Catalog.AllDatabases(sqlCtx)
@@ -301,7 +304,7 @@ func sqlNewEngine(ctx context.Context, dEnv *env.DoltEnv) (*sqle.Engine, dsess.D
 	}
 
 	b := env.GetDefaultInitBranch(dEnv.Config)
-	pro, err := dsql.NewDoltDatabaseProviderWithDatabase(b, mrEnv.FileSystem(), db, dEnv.FS, sql.NewBackgroundThreads())
+	pro, err := dsql.NewDoltDatabaseProviderWithDatabase(b, mrEnv.FileSystem(), db, dEnv.FS)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/libraries/doltcore/sqle/replication_test.go
+++ b/go/libraries/doltcore/sqle/replication_test.go
@@ -36,8 +36,7 @@ func TestCommitHooksNoErrors(t *testing.T) {
 
 	sql.SystemVariables.SetGlobal(dsess.SkipReplicationErrors, true)
 	sql.SystemVariables.SetGlobal(dsess.ReplicateToRemote, "unknown")
-	bThreads := sql.NewBackgroundThreads()
-	hooks, err := GetCommitHooks(context.Background(), bThreads, dEnv, &buffer.Buffer{})
+	hooks, _, err := GetCommitHooks(context.Background(), dEnv, &buffer.Buffer{})
 	assert.NoError(t, err)
 	if len(hooks) < 1 {
 		t.Error("failed to produce noop hook")

--- a/go/libraries/doltcore/sqle/show_create_table.go
+++ b/go/libraries/doltcore/sqle/show_create_table.go
@@ -29,10 +29,11 @@ import (
 // These functions cannot be in the sqlfmt package as the reliance on the sqle package creates a circular reference.
 
 func PrepareCreateTableStmt(ctx context.Context, sqlDb dsess.SqlDatabase) (*sql.Context, *sqle.Engine, *dsess.DoltSession) {
-	pro, err := NewDoltDatabaseProviderWithDatabase(env.DefaultInitBranch, nil, sqlDb, nil, sql.NewBackgroundThreads())
+	pro, err := NewDoltDatabaseProviderWithDatabase(env.DefaultInitBranch, nil, sqlDb, nil)
 	if err != nil {
 		return nil, nil, nil
 	}
+
 	engine := sqle.NewDefault(pro)
 
 	sess := dsess.DefaultSession(pro, writer.NewWriteSession)

--- a/go/libraries/doltcore/sqle/sqlddl_test.go
+++ b/go/libraries/doltcore/sqle/sqlddl_test.go
@@ -1104,7 +1104,7 @@ func TestParseCreateTableStatement(t *testing.T) {
 }
 
 func newTestEngine(ctx context.Context, dEnv *env.DoltEnv) (*gms.Engine, *sql.Context) {
-	pro, err := NewDoltDatabaseProviderWithDatabases("main", dEnv.FS, nil, nil, sql.NewBackgroundThreads())
+	pro, err := NewDoltDatabaseProviderWithDatabases("main", dEnv.FS, nil, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -1119,7 +1119,6 @@ func newTestEngine(ctx context.Context, dEnv *env.DoltEnv) (*gms.Engine, *sql.Co
 	if err != nil {
 		panic(err)
 	}
-
 	sqlCtx := sql.NewContext(ctx, sql.WithSession(doltSession))
 	sqlCtx.SetCurrentDatabase(mrEnv.GetFirstDatabase())
 

--- a/go/libraries/doltcore/sqle/testutil.go
+++ b/go/libraries/doltcore/sqle/testutil.go
@@ -139,7 +139,7 @@ func NewTestSQLCtxWithProvider(ctx context.Context, pro dsess.DoltDatabaseProvid
 // NewTestEngine creates a new default engine, and a *sql.Context and initializes indexes and schema fragments.
 func NewTestEngine(dEnv *env.DoltEnv, ctx context.Context, db dsess.SqlDatabase) (*sqle.Engine, *sql.Context, error) {
 	b := env.GetDefaultInitBranch(dEnv.Config)
-	pro, err := NewDoltDatabaseProviderWithDatabase(b, dEnv.FS, db, dEnv.FS, sql.NewBackgroundThreads())
+	pro, err := NewDoltDatabaseProviderWithDatabase(b, dEnv.FS, db, dEnv.FS)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
This PR moves aims to add session lifecycle callbacks to the async replication thread that each push-on-write replication database runs. In order to accomplish this, we move the initialization of those background threads to be later in the process of our construction of the SqlEngine. We also have to move the installation of the InitDatabaseHook which is responsible for setting up replication on newly created databases to be later in the initialization, as opposed to installing it immediately when we construct the DatabaseProvider.