### PR TITLE
refactor: using clear to simplify the code

### DIFF
--- a/go/libraries/doltcore/sqle/dsess/session_cache.go
+++ b/go/libraries/doltcore/sqle/dsess/session_cache.go
@@ -156,9 +156,7 @@ func (c *SessionCache) ClearTableCache() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	for k := range c.tables {
-		delete(c.tables, k)
-	}
+	clear(c.tables)
 }
 
 type TableCacheKey struct {

--- a/go/store/hash/hash.go
+++ b/go/store/hash/hash.go
@@ -217,9 +217,7 @@ func (hs HashSet) Equals(other HashSet) bool {
 }
 
 func (hs HashSet) Empty() {
-	for h := range hs {
-		delete(hs, h)
-	}
+	clear(hs)
 }
 
 func (hs HashSet) ToSlice() HashSlice {

--- a/go/store/util/sizecache/size_cache.go
+++ b/go/store/util/sizecache/size_cache.go
@@ -144,9 +144,7 @@ func (c *SizeCache) Purge() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	for key := range c.cache {
-		delete(c.cache, key)
-	}
+	clear(c.cache)
 	c.totalSize = 0
 	c.lru = list.List{}
 }


### PR DESCRIPTION
This is a [new built-in function](https://pkg.go.dev/builtin@go1.21.0#clear) added in the go1.21 standard library, which can make the code more concise and easy to read.