### PR TITLE
Split DB loading into two stages.

### DIFF
--- a/go/libraries/doltcore/dbfactory/aws.go
+++ b/go/libraries/doltcore/dbfactory/aws.go
@@ -30,9 +30,7 @@ import (
 
 	"github.com/dolthub/dolt/go/libraries/utils/awsrefreshcreds"
 	"github.com/dolthub/dolt/go/store/chunks"
-	"github.com/dolthub/dolt/go/store/datas"
 	"github.com/dolthub/dolt/go/store/nbs"
-	"github.com/dolthub/dolt/go/store/prolly/tree"
 	"github.com/dolthub/dolt/go/store/types"
 )
 
@@ -117,19 +115,14 @@ func (fact AWSFactory) PrepareDB(ctx context.Context, nbf *types.NomsBinFormat, 
 }
 
 // CreateDB creates an AWS backed database
-func (fact AWSFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, urlObj *url.URL, params map[string]interface{}) (datas.Database, types.ValueReadWriter, tree.NodeStore, error) {
-	var db datas.Database
+func (fact AWSFactory) GetDBLoader(ctx context.Context, nbf *types.NomsBinFormat, urlObj *url.URL, params map[string]interface{}) (DBLoader, error) {
 	cs, err := fact.newChunkStore(ctx, nbf, urlObj, params)
 
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 
-	vrw := types.NewValueStore(cs)
-	ns := tree.NewNodeStore(cs)
-	db = datas.NewTypesDatabase(vrw, ns)
-
-	return db, vrw, ns, nil
+	return ChunkStoreLoader{cs: cs}, nil
 }
 
 func (fact AWSFactory) newChunkStore(ctx context.Context, nbf *types.NomsBinFormat, urlObj *url.URL, params map[string]interface{}) (chunks.ChunkStore, error) {

--- a/go/libraries/doltcore/dbfactory/oss.go
+++ b/go/libraries/doltcore/dbfactory/oss.go
@@ -28,9 +28,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/dconfig"
 	"github.com/dolthub/dolt/go/store/blobstore"
 	"github.com/dolthub/dolt/go/store/chunks"
-	"github.com/dolthub/dolt/go/store/datas"
 	"github.com/dolthub/dolt/go/store/nbs"
-	"github.com/dolthub/dolt/go/store/prolly/tree"
 	"github.com/dolthub/dolt/go/store/types"
 )
 
@@ -67,17 +65,13 @@ func (fact OSSFactory) PrepareDB(ctx context.Context, nbf *types.NomsBinFormat, 
 }
 
 // CreateDB creates an OSS backed database
-func (fact OSSFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, urlObj *url.URL, params map[string]interface{}) (datas.Database, types.ValueReadWriter, tree.NodeStore, error) {
+func (fact OSSFactory) GetDBLoader(ctx context.Context, nbf *types.NomsBinFormat, urlObj *url.URL, params map[string]interface{}) (DBLoader, error) {
 	ossStore, err := fact.newChunkStore(ctx, nbf, urlObj, params)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 
-	vrw := types.NewValueStore(ossStore)
-	ns := tree.NewNodeStore(ossStore)
-	db := datas.NewTypesDatabase(vrw, ns)
-
-	return db, vrw, ns, nil
+	return ChunkStoreLoader{cs: ossStore}, nil
 }
 
 func (fact OSSFactory) newChunkStore(ctx context.Context, nbf *types.NomsBinFormat, urlObj *url.URL, params map[string]interface{}) (chunks.ChunkStore, error) {

--- a/go/libraries/doltcore/env/multi_repo_env.go
+++ b/go/libraries/doltcore/env/multi_repo_env.go
@@ -187,7 +187,7 @@ func MultiEnvForDirectory(
 			version = dEnv.Version
 		}
 
-		newEnv := LoadWithoutDB(ctx, GetCurrentUserHomeDir, newFs, doltdb.LocalDirDoltDB, version)
+		newEnv := Load(ctx, GetCurrentUserHomeDir, newFs, doltdb.LocalDirDoltDB, version)
 		if newEnv.Valid() {
 			envSet[dbfactory.DirToDBName(dir)] = newEnv
 		} else {
@@ -246,7 +246,12 @@ func (mrEnv *MultiRepoEnv) ReloadDBs(
 			}
 		}
 	}
-	mrEnv.envs = enforceSingleFormat(ctx, mrEnv.envs)
+	// We can skip the format check if there's only one environment.
+	// This is vital because it allows us to defer loading the database if there's only one.
+	// TODO: Can we determine the format without loading the database?
+	if len(mrEnv.envs) > 1 {
+		mrEnv.envs = enforceSingleFormat(ctx, mrEnv.envs)
+	}
 }
 
 func (mrEnv *MultiRepoEnv) FileSystem() filesys.Filesys {

--- a/go/store/nbs/file_manifest.go
+++ b/go/store/nbs/file_manifest.go
@@ -95,8 +95,7 @@ func MaybeMigrateFileManifest(ctx context.Context, dir string) (bool, error) {
 }
 
 // getFileManifest makes a new file manifest.
-func getFileManifest(ctx context.Context, dir string, mode updateMode) (m manifest, err error) {
-	lock := fslock.New(filepath.Join(dir, lockFileName))
+func getFileManifest(ctx context.Context, lock *fslock.Lock, dir string, mode updateMode) (m manifest, err error) {
 	m = fileManifest{dir: dir, mode: mode, lock: lock}
 
 	var f *os.File

--- a/integration-tests/bats/helper/query-server-common.bash
+++ b/integration-tests/bats/helper/query-server-common.bash
@@ -53,6 +53,7 @@ start_sql_server() {
     fi
     echo db:$DEFAULT_DB logFile:$logFile PORT:$PORT CWD:$PWD
     SERVER_PID=$!
+    export DOLT_FORBID_DB_LOAD_FOR_TEST=1
     wait_for_connection $PORT 8500
 }
 
@@ -74,6 +75,7 @@ start_sql_server_with_args_no_port() {
       dolt sql-server "$@" --socket "dolt.$PORT.sock" &
     fi
     SERVER_PID=$!
+    export DOLT_FORBID_DB_LOAD_FOR_TEST=1
     wait_for_connection $PORT 8500
 }
 
@@ -98,6 +100,7 @@ behavior:
       dolt sql-server --config .cliconfig.yaml --socket "dolt.$PORT.sock" &
     fi
     SERVER_PID=$!
+    export DOLT_FORBID_DB_LOAD_FOR_TEST=1
     wait_for_connection $PORT 8500
 }
 
@@ -124,6 +127,7 @@ behavior:
       dolt sql-server --config .cliconfig.yaml --socket "dolt.$PORT.sock" &
     fi
     SERVER_PID=$!
+    export DOLT_FORBID_DB_LOAD_FOR_TEST=1
     wait_for_connection $PORT 8500
 }
 
@@ -159,6 +163,7 @@ stop_sql_server() {
         fi;
     fi
     SERVER_PID=
+    unset DOLT_FORBID_DB_LOAD_FOR_TEST
 }
 
 definePORT() {

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -2077,3 +2077,22 @@ EOF
     [[ "$output" =~ "br3  | true" ]] || false
     [[ "$output" =~ "main | false" ]] || false
 }
+
+@test "sql-server: confirm DOLT_FORBID_DB_LOAD_FOR_TEST blocks attempts to load the DB" {
+  export DOLT_FORBID_DB_LOAD_FOR_TEST=1
+  run dolt sql -q "select 1"
+  [ $status -ne 0 ]
+  [[ $output =~ "attempted to load DB, but DOLT_FORBID_DB_LOAD_FOR_TEST environment variable was set" ]] || false
+}
+
+@test "sql-server: confirm DOLT_FORBID_DB_LOAD_FOR_TEST works" {
+  cd repo1
+  start_sql_server
+  run echo $DOLT_FORBID_DB_LOAD_FOR_TEST
+  [ $status -eq 0 ]
+  [[ $output =~ "1" ]] || false
+
+  # Although $DOLT_FORBID_DB_LOAD_FOR_TEST is set, this succeeds because the DB is not loaded.
+  run dolt sql -q "select 1"
+  [ $status -eq 0 ]
+}


### PR DESCRIPTION
This is a follow up to https://github.com/dolthub/dolt/pull/8783, which was supposed to defer loading the DB for commands where it wasn't necessary. The main motivation was for situations where the Dolt CLI doesn't need to load a local DB because it connects to an already-running server instead.

In practice, the prior PR didn't actually accomplish much because in order to determine whether Dolt should connect to an already running server, it checks to see if there's a lock on the local DB, and in order to do that it tries to load it.

In order for CLI commands against an already-running server to avoid loading the DB, we need to either:
- Detect a lock on the DB without loading it
- Look for a ServerLocalCredsFile before determining whether or not to connect to a remote server.

This PR tries to tackle the former, although in hindsight the latter might be a cleaner, simpler fix.

Basically, this PR allows us to detect locks without loading the DB by splitting the DB load into two phases:
Phase 1: Acquire any necessary exclusive resources (like locks)
Phase 2: Finish loading the DB

We accomplish this by modifying the `DBFactory` interface. Previously, it had a `CreateDB` method that fully loads the DB. Now, it has a `GetDBLoader` method that performs the first phase and returns an instance of the `DBLoader` interface. `DBLoader` has a method `LoadDB` that performs the second phase and returns the fully loaded database.

This allows us to add other methods to `DBLoader` to inspect qualities of the DB that were ascertained during the first phase, such as whether or not we were able to acquire an exclusive lock.

Notes:
- This still needs additional tests
- As written, for multigenerational file stores, we only acquire the lock on the newgen during the first phase, and only acquire the oldgen lock during the second phase. I don't think this can lead to any race conditions: both phases are guarded by the same mutex and their results are cached. But it is potentially confusing and it might be better to acquire both file locks at the same time.