### PR TITLE
[no-release-notes] go: sqle: dolt_gc: Purge read caches associated with the DoltDB as we begin GC.

### DIFF
--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -2191,6 +2191,15 @@ func (ddb *DoltDB) PersistGhostCommits(ctx context.Context, ghostCommits hash.Ha
 	return ddb.db.Database.PersistGhostCommitIDs(ctx, ghostCommits)
 }
 
+// Purge in-memory read caches associated with this DoltDB. This needs
+// to be done at a specific point during a GC operation to ensure that
+// everything the application layer sees still exists in the database
+// after the GC operation is completed.
+func (ddb *DoltDB) PurgeCaches() {
+	ddb.vrw.PurgeCaches()
+	ddb.ns.PurgeCaches()
+}
+
 type FSCKReport struct {
 	ChunkCount uint32
 	Problems   []error

--- a/go/libraries/doltcore/doltdb/gc_test.go
+++ b/go/libraries/doltcore/doltdb/gc_test.go
@@ -139,7 +139,8 @@ func testGarbageCollection(t *testing.T, test gcTest) {
 		}
 	}
 
-	err := dEnv.DoltDB(ctx).GC(ctx, types.GCModeDefault, nil)
+	ddb := dEnv.DoltDB(ctx)
+	err := ddb.GC(ctx, types.GCModeDefault, purgingSafepointController{ddb})
 	require.NoError(t, err)
 	test.postGCFunc(ctx, t, dEnv.DoltDB(ctx), res)
 
@@ -208,7 +209,7 @@ func testGarbageCollectionHasCacheDataCorruptionBugFix(t *testing.T) {
 	_, err = ns.Write(ctx, c1.Node())
 	require.NoError(t, err)
 
-	err = ddb.GC(ctx, types.GCModeDefault, nil)
+	err = ddb.GC(ctx, types.GCModeDefault, purgingSafepointController{ddb})
 	require.NoError(t, err)
 
 	c2 := newIntMap(t, ctx, ns, 2, 2)
@@ -264,4 +265,27 @@ func newAddrMap(t *testing.T, ctx context.Context, ns tree.NodeStore, key string
 	require.NoError(t, err)
 
 	return m
+}
+
+type purgingSafepointController struct {
+	ddb *doltdb.DoltDB
+}
+
+var _ (types.GCSafepointController) = purgingSafepointController{}
+
+
+func (c purgingSafepointController) BeginGC(ctx context.Context, keeper func(h hash.Hash) bool) error {
+	c.ddb.PurgeCaches()
+	return nil
+}
+
+func (c purgingSafepointController) EstablishPreFinalizeSafepoint(context.Context) error {
+	return nil
+}
+
+func (c purgingSafepointController) EstablishPostFinalizeSafepoint(context.Context) error{
+	return nil
+}
+
+func (c purgingSafepointController) CancelSafepoint() {
 }

--- a/go/libraries/doltcore/doltdb/gc_test.go
+++ b/go/libraries/doltcore/doltdb/gc_test.go
@@ -273,7 +273,6 @@ type purgingSafepointController struct {
 
 var _ (types.GCSafepointController) = purgingSafepointController{}
 
-
 func (c purgingSafepointController) BeginGC(ctx context.Context, keeper func(h hash.Hash) bool) error {
 	c.ddb.PurgeCaches()
 	return nil
@@ -283,7 +282,7 @@ func (c purgingSafepointController) EstablishPreFinalizeSafepoint(context.Contex
 	return nil
 }
 
-func (c purgingSafepointController) EstablishPostFinalizeSafepoint(context.Context) error{
+func (c purgingSafepointController) EstablishPostFinalizeSafepoint(context.Context) error {
 	return nil
 }
 

--- a/go/store/nbs/gc_copier.go
+++ b/go/store/nbs/gc_copier.go
@@ -73,13 +73,13 @@ func (gcc *gcCopier) copyTablesToDir(ctx context.Context) (ts []tableSpec, err e
 		return nil, err
 	}
 
+	defer func() {
+		gcc.writer.Cancel()
+	}()
+
 	if gcc.writer.ChunkCount() == 0 {
 		return []tableSpec{}, nil
 	}
-
-	defer func() {
-		_ = gcc.writer.Remove()
-	}()
 
 	addr, ok := hash.MaybeParse(filename)
 	if !ok {

--- a/go/store/prolly/tree/node_cache.go
+++ b/go/store/prolly/tree/node_cache.go
@@ -48,6 +48,12 @@ func (c nodeCache) insert(addr hash.Hash, node Node) {
 	s.insert(addr, node)
 }
 
+func (c nodeCache) purge() {
+	for _, s := range c.stripes {
+		s.purge()
+	}
+}
+
 type centry struct {
 	a    hash.Hash
 	n    Node
@@ -81,6 +87,15 @@ func removeFromList(e *centry) {
 	e.next.prev = e.prev
 	e.prev = e
 	e.next = e
+}
+
+func (s *stripe) purge() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.chunks = make(map[hash.Hash]*centry)
+	s.head = nil
+	s.sz = 0
+	s.rev = 0
 }
 
 func (s *stripe) moveToFront(e *centry) {

--- a/go/store/prolly/tree/node_cache_test.go
+++ b/go/store/prolly/tree/node_cache_test.go
@@ -1,0 +1,47 @@
+// Copyright 2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tree
+
+import (
+	"testing"
+
+	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNodeCache(t *testing.T) {
+	t.Run("InsertGetPurge", func(t *testing.T) {
+		// Simple smoke screen test of insert, get, purge.
+		var addr hash.Hash
+		var n Node
+		n.msg = make([]byte, 1024)
+		cache := newChunkCache(64 * 1024)
+		for i := 0; i < 32; i++ {
+			addr[0] = byte(i)
+			cache.insert(addr, n)
+		}
+		for i := 0; i < 32; i++ {
+			addr[0] = byte(i)
+			_, ok := cache.get(addr)
+			assert.True(t, ok)
+		}
+		cache.purge()
+		for i := 0; i < 32; i++ {
+			addr[0] = byte(i)
+			_, ok := cache.get(addr)
+			assert.False(t, ok)
+		}
+	})
+}

--- a/go/store/prolly/tree/node_cache_test.go
+++ b/go/store/prolly/tree/node_cache_test.go
@@ -17,8 +17,9 @@ package tree
 import (
 	"testing"
 
-	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 func TestNodeCache(t *testing.T) {

--- a/go/store/prolly/tree/node_store.go
+++ b/go/store/prolly/tree/node_store.go
@@ -49,6 +49,8 @@ type NodeStore interface {
 
 	BlobBuilder() *BlobBuilder
 	PutBlobBuilder(*BlobBuilder)
+
+	PurgeCaches()
 }
 
 type nodeStore struct {
@@ -193,4 +195,8 @@ func (ns nodeStore) Format() *types.NomsBinFormat {
 		panic(err)
 	}
 	return nbf
+}
+
+func (ns nodeStore) PurgeCaches() {
+	ns.cache.purge()
 }

--- a/go/store/prolly/tree/node_store.go
+++ b/go/store/prolly/tree/node_store.go
@@ -50,6 +50,10 @@ type NodeStore interface {
 	BlobBuilder() *BlobBuilder
 	PutBlobBuilder(*BlobBuilder)
 
+	// Delete any cached chunks associated with this NodeStore.
+	// Used by GC during safepoint establishment to ensure deleted
+	// chunks do not float around in the application layer after GC
+	// completes.
 	PurgeCaches()
 }
 

--- a/go/store/prolly/tree/testutils.go
+++ b/go/store/prolly/tree/testutils.go
@@ -333,6 +333,10 @@ func (v nodeStoreValidator) PutBlobBuilder(bb *BlobBuilder) {
 	v.bbp.Put(bb)
 }
 
+func (v nodeStoreValidator) PurgeCaches() {
+	v.ns.PurgeCaches()
+}
+
 func (v nodeStoreValidator) Format() *types.NomsBinFormat {
 	return v.ns.Format()
 }

--- a/go/store/types/value_store_test.go
+++ b/go/store/types/value_store_test.go
@@ -198,7 +198,7 @@ func TestGC(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(v2)
 
-	err = vs.GC(ctx, GCModeDefault, hash.HashSet{}, hash.HashSet{}, nil)
+	err = vs.GC(ctx, GCModeDefault, hash.HashSet{}, hash.HashSet{}, purgingSafepointController{vs})
 	require.NoError(t, err)
 
 	v1, err = vs.ReadValue(ctx, h1) // non-nil
@@ -215,4 +215,27 @@ type badVersionStore struct {
 
 func (b *badVersionStore) Version() string {
 	return "BAD"
+}
+
+type purgingSafepointController struct {
+	vs *ValueStore
+}
+
+var _ (GCSafepointController) = purgingSafepointController{}
+
+
+func (c purgingSafepointController) BeginGC(ctx context.Context, keeper func(h hash.Hash) bool) error {
+	c.vs.PurgeCaches()
+	return nil
+}
+
+func (c purgingSafepointController) EstablishPreFinalizeSafepoint(context.Context) error {
+	return nil
+}
+
+func (c purgingSafepointController) EstablishPostFinalizeSafepoint(context.Context) error{
+	return nil
+}
+
+func (c purgingSafepointController) CancelSafepoint() {
 }

--- a/go/store/types/value_store_test.go
+++ b/go/store/types/value_store_test.go
@@ -223,7 +223,6 @@ type purgingSafepointController struct {
 
 var _ (GCSafepointController) = purgingSafepointController{}
 
-
 func (c purgingSafepointController) BeginGC(ctx context.Context, keeper func(h hash.Hash) bool) error {
 	c.vs.PurgeCaches()
 	return nil
@@ -233,7 +232,7 @@ func (c purgingSafepointController) EstablishPreFinalizeSafepoint(context.Contex
 	return nil
 }
 
-func (c purgingSafepointController) EstablishPostFinalizeSafepoint(context.Context) error{
+func (c purgingSafepointController) EstablishPostFinalizeSafepoint(context.Context) error {
 	return nil
 }
 

--- a/go/store/valuefile/file_value_store.go
+++ b/go/store/valuefile/file_value_store.go
@@ -161,6 +161,9 @@ func (f *FileValueStore) CacheHas(h hash.Hash) bool {
 	return ok
 }
 
+func (f *FileValueStore) PurgeCaches() {
+}
+
 // HasMany returns the set of hashes that are absent from the store
 func (f *FileValueStore) HasMany(ctx context.Context, hashes hash.HashSet) (absent hash.HashSet, err error) {
 	f.chunkLock.Lock()

--- a/integration-tests/go-sql-server-driver/concurrent_gc_test.go
+++ b/integration-tests/go-sql-server-driver/concurrent_gc_test.go
@@ -116,6 +116,7 @@ func (gct gcTest) doUpdate(t *testing.T, ctx context.Context, db *sql.DB, i int)
 			return nil
 		}
 	} else if err != nil {
+		require.NotContains(t, err.Error(), "connection refused")
 		t.Logf("err in Conn: %v", err)
 		return nil
 	}
@@ -162,6 +163,7 @@ func (gct gcTest) doGC(t *testing.T, ctx context.Context, db *sql.DB) error {
 			return nil
 		}
 	} else if err != nil {
+		require.NotContains(t, err.Error(), "connection refused")
 		t.Logf("err in Conn for dolt_gc: %v", err)
 		return nil
 	}


### PR DESCRIPTION
The right place to do this is in the safepoint controller, at BeginGC. We need to do it after keeperFunc is installed on the NomsBlockStore, so that all read dependencies are taken. We also need to do it before we register all sessions whose cached state we need to visit.