### PR TITLE
[no-release-notes] Add Archive Backup and AWS support

### DIFF
--- a/go/cmd/dolt/commands/archive.go
+++ b/go/cmd/dolt/commands/archive.go
@@ -92,7 +92,7 @@ func (cmd ArchiveCmd) Exec(ctx context.Context, commandStr string, args []string
 		return 1
 	}
 
-	storageMetadata, err := env.GetMultiEnvStorageMetadata(dEnv.FS)
+	storageMetadata, err := env.GetMultiEnvStorageMetadata(ctx, dEnv.FS)
 	if err != nil {
 		cli.PrintErrln(err)
 		return 1

--- a/go/cmd/dolt/commands/backup.go
+++ b/go/cmd/dolt/commands/backup.go
@@ -267,14 +267,6 @@ func syncBackup(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.ArgParseR
 }
 
 func backup(ctx context.Context, dEnv *env.DoltEnv, b env.Remote) errhand.VerboseError {
-	metadata, err := env.GetMultiEnvStorageMetadata(dEnv.FS)
-	if err != nil {
-		return nil
-	}
-	if metadata.ArchiveFilesPresent() {
-		return errhand.BuildDError("error: archive files present. Please revert them with the --revert flag before running this command.").Build()
-	}
-
 	destDb, err := b.GetRemoteDB(ctx, dEnv.DoltDB(ctx).ValueReadWriter().Format(), dEnv)
 	if err != nil {
 		return errhand.BuildDError("error: unable to open destination.").AddCause(err).Build()

--- a/go/libraries/doltcore/env/multi_repo_env.go
+++ b/go/libraries/doltcore/env/multi_repo_env.go
@@ -67,7 +67,7 @@ func (sms StorageMetadataMap) ArchiveFilesPresent() bool {
 	return false
 }
 
-func GetMultiEnvStorageMetadata(dataDirFS filesys.Filesys) (StorageMetadataMap, error) {
+func GetMultiEnvStorageMetadata(ctx context.Context, dataDirFS filesys.Filesys) (StorageMetadataMap, error) {
 	dbMap := make(map[string]filesys.Filesys)
 
 	path, err := dataDirFS.Abs("")
@@ -115,7 +115,7 @@ func GetMultiEnvStorageMetadata(dataDirFS filesys.Filesys) (StorageMetadataMap, 
 			return nil, err
 		}
 
-		sm, err := nbs.GetStorageMetadata(fsStr)
+		sm, err := nbs.GetStorageMetadata(ctx, fsStr, &nbs.Stats{})
 		if err != nil {
 			return nil, err
 		}

--- a/go/store/nbs/archive_build.go
+++ b/go/store/nbs/archive_build.go
@@ -441,19 +441,14 @@ func gatherAllChunks(ctx context.Context, cs chunkSource, idx tableIndex, stats 
 
 	return chkCache, defaultSamples, nil
 }
+
 func verifyAllChunks(ctx context.Context, idx tableIndex, archiveFile string, progress chan interface{}, stats *Stats) error {
-	file, err := os.Open(archiveFile)
+	fra, err := newFileReaderAt(archiveFile)
 	if err != nil {
 		return err
 	}
 
-	stat, err := file.Stat()
-	if err != nil {
-		return err
-	}
-	fileSize := stat.Size()
-
-	index, err := newArchiveReader(newFlexibleReader(file), uint64(fileSize))
+	index, err := newArchiveReader(ctx, fra, uint64(fra.sz), stats)
 	if err != nil {
 		return err
 	}

--- a/go/store/nbs/archive_build.go
+++ b/go/store/nbs/archive_build.go
@@ -75,7 +75,7 @@ func UnArchive(ctx context.Context, cs chunks.ChunkStore, smd StorageMetadata, p
 
 						progress <- fmt.Sprintf("Unarchiving %s (bytes: %d)", chk.Hash().String(), len(chk.Data()))
 						return nil
-					})
+					}, &Stats{})
 					if err != nil {
 						return err
 					}
@@ -150,7 +150,7 @@ func BuildArchive(ctx context.Context, cs chunks.ChunkStore, dagGroups *ChunkRel
 			}
 			archiveSize := fileInfo.Size()
 
-			err = verifyAllChunks(idx, archivePath, progress)
+			err = verifyAllChunks(ctx, idx, archivePath, progress, &stats)
 			if err != nil {
 				return err
 			}
@@ -441,7 +441,7 @@ func gatherAllChunks(ctx context.Context, cs chunkSource, idx tableIndex, stats 
 
 	return chkCache, defaultSamples, nil
 }
-func verifyAllChunks(idx tableIndex, archiveFile string, progress chan interface{}) error {
+func verifyAllChunks(ctx context.Context, idx tableIndex, archiveFile string, progress chan interface{}, stats *Stats) error {
 	file, err := os.Open(archiveFile)
 	if err != nil {
 		return err
@@ -453,7 +453,7 @@ func verifyAllChunks(idx tableIndex, archiveFile string, progress chan interface
 	}
 	fileSize := stat.Size()
 
-	index, err := newArchiveReader(file, uint64(fileSize))
+	index, err := newArchiveReader(newFlexibleReader(file), uint64(fileSize))
 	if err != nil {
 		return err
 	}
@@ -483,7 +483,7 @@ func verifyAllChunks(idx tableIndex, archiveFile string, progress chan interface
 			return errors.New(msg)
 		}
 
-		data, err := index.get(h)
+		data, err := index.get(ctx, h, stats)
 		if err != nil {
 			return fmt.Errorf("error reading chunk: %s (err: %w)", h.String(), err)
 		}

--- a/go/store/nbs/archive_chunk_source.go
+++ b/go/store/nbs/archive_chunk_source.go
@@ -150,7 +150,14 @@ func (acs archiveChunkSource) currentSize() uint64 {
 }
 
 func (acs archiveChunkSource) reader(ctx context.Context) (io.ReadCloser, uint64, error) {
-	return nil, 0, errors.New("Archive chunk source does not support reader")
+	rdr := acs.aRdr.reader
+	chks, err := acs.count()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	rc := io.NewSectionReader(rdr, 0, int64(acs.currentSize()))
+	return io.NopCloser(rc), uint64(chks), nil
 }
 func (acs archiveChunkSource) uncompressedLen() (uint64, error) {
 	return 0, errors.New("Archive chunk source does not support uncompressedLen")

--- a/go/store/nbs/archive_chunk_source.go
+++ b/go/store/nbs/archive_chunk_source.go
@@ -148,8 +148,8 @@ func (acs archiveChunkSource) hash() hash.Hash {
 	return acs.aRdr.footer.hash
 }
 
-func (acs archiveChunkSource) name() string {
-	return acs.hash().String() + ArchiveFileSuffix
+func (acs archiveChunkSource) suffix() string {
+	return ArchiveFileSuffix
 }
 
 func (acs archiveChunkSource) currentSize() uint64 {

--- a/go/store/nbs/archive_test.go
+++ b/go/store/nbs/archive_test.go
@@ -67,13 +67,15 @@ func TestArchiveSingleChunk(t *testing.T) {
 	theBytes := writer.buff[:writer.pos]
 	fileSize := uint64(len(theBytes))
 	readerAt := bytes.NewReader(theBytes)
-	aIdx, err := newArchiveReader(readerAt, fileSize)
+	fr := newFlexibleReader(readerAt)
+
+	aIdx, err := newArchiveReader(fr, fileSize)
 	assert.NoError(t, err)
 
 	assert.Equal(t, []uint64{23}, aIdx.prefixes)
 	assert.True(t, aIdx.has(oneHash))
 
-	dict, data, err := aIdx.getRaw(oneHash)
+	dict, data, err := aIdx.getRaw(context.Background(), oneHash, &Stats{})
 	assert.NoError(t, err)
 	assert.Nil(t, dict)
 	assert.Equal(t, testBlob, data)
@@ -100,13 +102,14 @@ func TestArchiveSingleChunkWithDictionary(t *testing.T) {
 	theBytes := writer.buff[:writer.pos]
 	fileSize := uint64(len(theBytes))
 	readerAt := bytes.NewReader(theBytes)
-	aIdx, err := newArchiveReader(readerAt, fileSize)
+	fr := newFlexibleReader(readerAt)
+	aIdx, err := newArchiveReader(fr, fileSize)
 	assert.NoError(t, err)
 	assert.Equal(t, []uint64{42}, aIdx.prefixes)
 
 	assert.True(t, aIdx.has(h))
 
-	dict, data, err := aIdx.getRaw(h)
+	dict, data, err := aIdx.getRaw(context.Background(), h, &Stats{})
 	assert.NoError(t, err)
 	assert.NotNil(t, dict)
 	assert.Equal(t, testData, data)
@@ -168,7 +171,8 @@ func TestArchiverMultipleChunksMultipleDictionaries(t *testing.T) {
 	theBytes := writer.buff[:writer.pos]
 	fileSize := uint64(len(theBytes))
 	readerAt := bytes.NewReader(theBytes)
-	aIdx, err := newArchiveReader(readerAt, fileSize)
+	fr := newFlexibleReader(readerAt)
+	aIdx, err := newArchiveReader(fr, fileSize)
 	assert.NoError(t, err)
 	assert.Equal(t, []uint64{21, 42, 42, 42, 42, 81, 88}, aIdx.prefixes)
 
@@ -183,31 +187,34 @@ func TestArchiverMultipleChunksMultipleDictionaries(t *testing.T) {
 	assert.False(t, aIdx.has(hashWithPrefix(t, 42)))
 	assert.False(t, aIdx.has(hashWithPrefix(t, 55)))
 
-	dict, data, _ := aIdx.getRaw(h1)
+	c := context.Background()
+	s := &Stats{}
+
+	dict, data, _ := aIdx.getRaw(c, h1, s)
 	assert.NotNil(t, dict)
 	assert.Equal(t, data1, data)
 
-	dict, data, _ = aIdx.getRaw(h2)
+	dict, data, _ = aIdx.getRaw(c, h2, s)
 	assert.NotNil(t, dict)
 	assert.Equal(t, data2, data)
 
-	dict, data, _ = aIdx.getRaw(h3)
+	dict, data, _ = aIdx.getRaw(c, h3, s)
 	assert.NotNil(t, dict)
 	assert.Equal(t, data3, data)
 
-	dict, data, _ = aIdx.getRaw(h4)
+	dict, data, _ = aIdx.getRaw(c, h4, s)
 	assert.Nil(t, dict)
 	assert.Equal(t, data, data)
 
-	dict, data, _ = aIdx.getRaw(h5)
+	dict, data, _ = aIdx.getRaw(c, h5, s)
 	assert.NotNil(t, dict)
 	assert.Equal(t, data1, data)
 
-	dict, data, _ = aIdx.getRaw(h6)
+	dict, data, _ = aIdx.getRaw(c, h6, s)
 	assert.NotNil(t, dict)
 	assert.Equal(t, data1, data)
 
-	dict, data, _ = aIdx.getRaw(h7)
+	dict, data, _ = aIdx.getRaw(c, h7, s)
 	assert.NotNil(t, dict)
 	assert.Equal(t, data3, data)
 }
@@ -252,12 +259,16 @@ func TestArchiveDictDecompression(t *testing.T) {
 	theBytes := writer.buff[:writer.pos]
 	fileSize := uint64(len(theBytes))
 	readerAt := bytes.NewReader(theBytes)
-	aIdx, err := newArchiveReader(readerAt, fileSize)
+	fr := newFlexibleReader(readerAt)
+	aIdx, err := newArchiveReader(fr, fileSize)
 	assert.NoError(t, err)
+
+	c := context.Background()
+	s := &Stats{}
 
 	// Now verify that we can look up the chunks by their original addresses, and the data is the same.
 	for _, chk := range chks {
-		roundTripData, err := aIdx.get(chk.Hash())
+		roundTripData, err := aIdx.get(c, chk.Hash(), s)
 		assert.NoError(t, err)
 		assert.Equal(t, chk.Data(), roundTripData)
 	}
@@ -278,10 +289,11 @@ func TestMetadata(t *testing.T) {
 	theBytes := writer.buff[:writer.pos]
 	fileSize := uint64(len(theBytes))
 	readerAt := bytes.NewReader(theBytes)
-	rdr, err := newArchiveReader(readerAt, fileSize)
+	fr := newFlexibleReader(readerAt)
+	rdr, err := newArchiveReader(fr, fileSize)
 	assert.NoError(t, err)
 
-	md, err := rdr.getMetadata()
+	md, err := rdr.getMetadata(context.Background(), &Stats{})
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("All work and no play"), md)
 }
@@ -308,13 +320,14 @@ func TestArchiveChunkCorruption(t *testing.T) {
 	theBytes := writer.buff[:writer.pos]
 	fileSize := uint64(len(theBytes))
 	readerAt := bytes.NewReader(theBytes)
-	idx, err := newArchiveReader(readerAt, fileSize)
+	fr := newFlexibleReader(readerAt)
+	idx, err := newArchiveReader(fr, fileSize)
 	assert.NoError(t, err)
 
 	// Corrupt the data
 	writer.buff[len(defDict)+3] = writer.buff[len(defDict)+3] + 1
 
-	data, err := idx.get(h)
+	data, err := idx.get(context.Background(), h, &Stats{})
 	assert.ErrorContains(t, err, "cannot decompress invalid src")
 	assert.Nil(t, data)
 }
@@ -341,7 +354,8 @@ func TestArchiveCheckSumValidations(t *testing.T) {
 	theBytes := writer.buff[:writer.pos]
 	fileSize := uint64(len(theBytes))
 	readerAt := bytes.NewReader(theBytes)
-	rdr, err := newArchiveReader(readerAt, fileSize)
+	fr := newFlexibleReader(readerAt)
+	rdr, err := newArchiveReader(fr, fileSize)
 	assert.NoError(t, err)
 
 	err = rdr.verifyDataCheckSum()
@@ -464,7 +478,8 @@ func TestFooterVersionAndSignature(t *testing.T) {
 	theBytes := writer.buff[:writer.pos]
 	fileSize := uint64(len(theBytes))
 	readerAt := bytes.NewReader(theBytes)
-	rdr, err := newArchiveReader(readerAt, fileSize)
+	fr := newFlexibleReader(readerAt)
+	rdr, err := newArchiveReader(fr, fileSize)
 	assert.NoError(t, err)
 
 	assert.Equal(t, archiveFormatVersion, rdr.footer.formatVersion)
@@ -473,14 +488,16 @@ func TestFooterVersionAndSignature(t *testing.T) {
 	// Corrupt the version
 	theBytes[fileSize-archiveFooterSize+afrVersionOffset] = 23
 	readerAt = bytes.NewReader(theBytes)
-	_, err = newArchiveReader(readerAt, fileSize)
+	fr = newFlexibleReader(readerAt)
+	_, err = newArchiveReader(fr, fileSize)
 	assert.ErrorContains(t, err, "invalid format version")
 
 	// Corrupt the signature, but first restore the version.
 	theBytes[fileSize-archiveFooterSize+afrVersionOffset] = archiveFormatVersion
 	theBytes[fileSize-archiveFooterSize+afrSigOffset+2] = 'X'
 	readerAt = bytes.NewReader(theBytes)
-	_, err = newArchiveReader(readerAt, fileSize)
+	fr = newFlexibleReader(readerAt)
+	_, err = newArchiveReader(fr, fileSize)
 	assert.ErrorContains(t, err, "invalid file signature")
 
 }

--- a/go/store/nbs/archive_test.go
+++ b/go/store/nbs/archive_test.go
@@ -726,7 +726,7 @@ func (tcs *testChunkSource) hash() hash.Hash {
 	panic("never used")
 }
 
-func (tcs *testChunkSource) name() string {
+func (tcs *testChunkSource) suffix() string {
 	panic("never used")
 }
 

--- a/go/store/nbs/aws_chunk_source.go
+++ b/go/store/nbs/aws_chunk_source.go
@@ -32,7 +32,7 @@ import (
 
 func tableExistsInChunkSource(ctx context.Context, s3 *s3ObjectReader, al awsLimits, name hash.Hash, chunkCount uint32, q MemoryQuotaProvider, stats *Stats) (bool, error) {
 	magic := make([]byte, magicNumberSize)
-	n, _, err := s3.ReadFromEnd(ctx, name, magic, stats)
+	n, err := readS3TableFileFromEnd(ctx, s3, name.String(), magic, stats)
 	if err != nil {
 		return false, err
 	}
@@ -42,10 +42,11 @@ func tableExistsInChunkSource(ctx context.Context, s3 *s3ObjectReader, al awsLim
 	return bytes.Equal(magic, []byte(magicNumber)), nil
 }
 
+// NM4 - Rename to newAWSTableFileChunkSource, maybe?
 func newAWSChunkSource(ctx context.Context, s3 *s3ObjectReader, al awsLimits, name hash.Hash, chunkCount uint32, q MemoryQuotaProvider, stats *Stats) (cs chunkSource, err error) {
 	var tra tableReaderAt
 	index, err := loadTableIndex(ctx, stats, chunkCount, q, func(p []byte) error {
-		n, _, err := s3.ReadFromEnd(ctx, name, p, stats)
+		n, err := readS3TableFileFromEnd(ctx, s3, name.String(), p, stats)
 		if err != nil {
 			return err
 		}

--- a/go/store/nbs/aws_table_chunk_source.go
+++ b/go/store/nbs/aws_table_chunk_source.go
@@ -24,7 +24,6 @@ package nbs
 import (
 	"context"
 	"errors"
-	"io"
 	"time"
 
 	"github.com/dolthub/dolt/go/store/hash"
@@ -77,16 +76,3 @@ func loadTableIndex(ctx context.Context, stats *Stats, cnt uint32, q MemoryQuota
 	}
 	return idx, err
 }
-
-// NM4 - See if we can get rid of this.
-type s3ReaderAt struct {
-	name string
-	rdr  *s3ObjectReader
-}
-
-func (s s3ReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
-	// NM4 - need a read context. Stats maybe not?
-	return s.rdr.ReadAt(context.Background(), s.name, p, off, &Stats{})
-}
-
-var _ io.ReaderAt = &s3ReaderAt{}

--- a/go/store/nbs/aws_table_chunk_source.go
+++ b/go/store/nbs/aws_table_chunk_source.go
@@ -32,14 +32,14 @@ import (
 func newAWSTableFileChunkSource(ctx context.Context, s3 *s3ObjectReader, al awsLimits, name hash.Hash, chunkCount uint32, q MemoryQuotaProvider, stats *Stats) (cs chunkSource, err error) {
 	var tra tableReaderAt
 	index, err := loadTableIndex(ctx, stats, chunkCount, q, func(p []byte) error {
-		n, err := s3.readS3ObjectFromEnd(ctx, name.String(), p, stats)
+		n, _, err := s3.readS3ObjectFromEnd(ctx, name.String(), p, stats)
 		if err != nil {
 			return err
 		}
 		if len(p) != n {
 			return errors.New("failed to read all data")
 		}
-		tra = &s3TableReaderAt{h: name, s3: s3}
+		tra = &s3TableReaderAt{key: name.String(), s3: s3}
 		return nil
 	})
 	if err != nil {

--- a/go/store/nbs/aws_table_chunk_source.go
+++ b/go/store/nbs/aws_table_chunk_source.go
@@ -25,27 +25,36 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
+	"strings"
 	"time"
 
 	"github.com/dolthub/dolt/go/store/hash"
 )
 
-func tableExistsInChunkSource(ctx context.Context, s3 *s3ObjectReader, name hash.Hash, stats *Stats) (bool, error) {
+// NM4 - rename to objectExistsInChunkSource
+func tableExistsInChunkSource(ctx context.Context, s3 *s3ObjectReader, name string, stats *Stats) (bool, error) {
 	magic := make([]byte, magicNumberSize)
-	n, err := readS3TableFileFromEnd(ctx, s3, name.String(), magic, stats)
+	n, err := s3.readS3TableFileFromEnd(ctx, name, magic, stats)
 	if err != nil {
 		return false, err
 	}
 	if n != len(magic) {
 		return false, errors.New("failed to read all data")
 	}
-	return bytes.Equal(magic, []byte(magicNumber)), nil
+
+	if strings.HasSuffix(name, ArchiveFileSuffix) {
+		// dolt magic number is a version byte + DOLTARC. We ignore the version byte here.
+		return bytes.Equal(magic[magicNumberSize-doltMagicSize:], []byte(doltMagicNumber)), nil
+	} else {
+		return bytes.Equal(magic, []byte(magicNumber)), nil
+	}
 }
 
 func newAWSTableFileChunkSource(ctx context.Context, s3 *s3ObjectReader, al awsLimits, name hash.Hash, chunkCount uint32, q MemoryQuotaProvider, stats *Stats) (cs chunkSource, err error) {
 	var tra tableReaderAt
 	index, err := loadTableIndex(ctx, stats, chunkCount, q, func(p []byte) error {
-		n, err := readS3TableFileFromEnd(ctx, s3, name.String(), p, stats)
+		n, err := s3.readS3TableFileFromEnd(ctx, name.String(), p, stats)
 		if err != nil {
 			return err
 		}
@@ -65,6 +74,31 @@ func newAWSTableFileChunkSource(ctx context.Context, s3 *s3ObjectReader, al awsL
 		return &chunkSourceAdapter{}, err
 	}
 	return &chunkSourceAdapter{tr, name}, nil
+}
+
+func newAWSArchiveChunkSource(ctx context.Context,
+	s3 *s3ObjectReader,
+	al awsLimits,
+	name string,
+	chunkCount uint32,
+	q MemoryQuotaProvider,
+	stats *Stats) (cs chunkSource, err error) {
+
+	// Perform a readrange of the footer to get the size of the file.
+	footer := make([]byte, archiveFooterSize)
+
+	_, sz, err := s3.readRange(ctx, name, footer, httpEndRangeHeader(int(archiveFooterSize)))
+	if err != nil {
+		return emptyChunkSource{}, err
+	}
+
+	rdr := s3ReaderAt{name, s3}
+
+	aRdr, err := newArchiveReader(rdr, sz)
+	if err != nil {
+		return archiveChunkSource{}, err
+	}
+	return archiveChunkSource{"panic if we use this", aRdr}, nil
 }
 
 func loadTableIndex(ctx context.Context, stats *Stats, cnt uint32, q MemoryQuotaProvider, loadIndexBytes func(p []byte) error) (tableIndex, error) {
@@ -89,3 +123,16 @@ func loadTableIndex(ctx context.Context, stats *Stats, cnt uint32, q MemoryQuota
 	}
 	return idx, err
 }
+
+// NM4 - See if we can get rid of this.
+type s3ReaderAt struct {
+	name string
+	rdr  *s3ObjectReader
+}
+
+func (s s3ReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
+	// NM4 - need a read context. Stats maybe not?
+	return s.rdr.ReadAt(context.Background(), s.name, p, off, &Stats{})
+}
+
+var _ io.ReaderAt = &s3ReaderAt{}

--- a/go/store/nbs/aws_table_chunk_source.go
+++ b/go/store/nbs/aws_table_chunk_source.go
@@ -30,7 +30,7 @@ import (
 	"github.com/dolthub/dolt/go/store/hash"
 )
 
-func tableExistsInChunkSource(ctx context.Context, s3 *s3ObjectReader, al awsLimits, name hash.Hash, chunkCount uint32, q MemoryQuotaProvider, stats *Stats) (bool, error) {
+func tableExistsInChunkSource(ctx context.Context, s3 *s3ObjectReader, name hash.Hash, stats *Stats) (bool, error) {
 	magic := make([]byte, magicNumberSize)
 	n, err := readS3TableFileFromEnd(ctx, s3, name.String(), magic, stats)
 	if err != nil {

--- a/go/store/nbs/aws_table_chunk_source.go
+++ b/go/store/nbs/aws_table_chunk_source.go
@@ -42,8 +42,7 @@ func tableExistsInChunkSource(ctx context.Context, s3 *s3ObjectReader, al awsLim
 	return bytes.Equal(magic, []byte(magicNumber)), nil
 }
 
-// NM4 - Rename to newAWSTableFileChunkSource, maybe?
-func newAWSChunkSource(ctx context.Context, s3 *s3ObjectReader, al awsLimits, name hash.Hash, chunkCount uint32, q MemoryQuotaProvider, stats *Stats) (cs chunkSource, err error) {
+func newAWSTableFileChunkSource(ctx context.Context, s3 *s3ObjectReader, al awsLimits, name hash.Hash, chunkCount uint32, q MemoryQuotaProvider, stats *Stats) (cs chunkSource, err error) {
 	var tra tableReaderAt
 	index, err := loadTableIndex(ctx, stats, chunkCount, q, func(p []byte) error {
 		n, err := readS3TableFileFromEnd(ctx, s3, name.String(), p, stats)

--- a/go/store/nbs/aws_table_chunk_source_test.go
+++ b/go/store/nbs/aws_table_chunk_source_test.go
@@ -43,7 +43,7 @@ func TestAWSChunkSource(t *testing.T) {
 	s3or := &s3ObjectReader{s3, "bucket", nil, ""}
 
 	makeSrc := func(chunkMax int) chunkSource {
-		cs, err := newAWSChunkSource(
+		cs, err := newAWSTableFileChunkSource(
 			context.Background(),
 			s3or,
 			awsLimits{},

--- a/go/store/nbs/aws_table_persister.go
+++ b/go/store/nbs/aws_table_persister.go
@@ -158,7 +158,7 @@ func (s3p awsTablePersister) Persist(ctx context.Context, mt *memTable, haver ch
 		return emptyChunkSource{}, gcBehavior_Continue, err
 	}
 
-	tra := &s3TableReaderAt{&s3ObjectReader{s3: s3p.s3, bucket: s3p.bucket, readRl: s3p.rl, ns: s3p.ns}, name}
+	tra := &s3TableReaderAt{&s3ObjectReader{s3: s3p.s3, bucket: s3p.bucket, readRl: s3p.rl, ns: s3p.ns}, name.String()}
 	src, err := newReaderFromIndexData(ctx, s3p.q, data, name, tra, s3BlockSize)
 	if err != nil {
 		return emptyChunkSource{}, gcBehavior_Continue, err
@@ -253,7 +253,7 @@ func (s3p awsTablePersister) ConjoinAll(ctx context.Context, sources chunkSource
 
 	verbose.Logger(ctx).Sugar().Debugf("Compacted table of %d Kb in %s", plan.totalCompressedData/1024, time.Since(t1))
 
-	tra := &s3TableReaderAt{&s3ObjectReader{s3: s3p.s3, bucket: s3p.bucket, readRl: s3p.rl, ns: s3p.ns}, name}
+	tra := &s3TableReaderAt{&s3ObjectReader{s3: s3p.s3, bucket: s3p.bucket, readRl: s3p.rl, ns: s3p.ns}, name.String()}
 	cs, err := newReaderFromIndexData(ctx, s3p.q, plan.mergedIndex, name, tra, s3BlockSize)
 	return cs, func() {}, err
 }

--- a/go/store/nbs/aws_table_persister.go
+++ b/go/store/nbs/aws_table_persister.go
@@ -68,7 +68,7 @@ type awsLimits struct {
 }
 
 func (s3p awsTablePersister) Open(ctx context.Context, name hash.Hash, chunkCount uint32, stats *Stats) (chunkSource, error) {
-	return newAWSChunkSource(
+	return newAWSTableFileChunkSource(
 		ctx,
 		&s3ObjectReader{s3: s3p.s3, bucket: s3p.bucket, readRl: s3p.rl, ns: s3p.ns},
 		s3p.limits,

--- a/go/store/nbs/bs_persister.go
+++ b/go/store/nbs/bs_persister.go
@@ -173,8 +173,8 @@ func (bsp *blobstorePersister) Open(ctx context.Context, name hash.Hash, chunkCo
 	return newBSChunkSource(ctx, bsp.bs, name, chunkCount, bsp.q, stats)
 }
 
-func (bsp *blobstorePersister) Exists(ctx context.Context, name hash.Hash, chunkCount uint32, stats *Stats) (bool, error) {
-	return bsp.bs.Exists(ctx, name.String())
+func (bsp *blobstorePersister) Exists(ctx context.Context, name string, chunkCount uint32, stats *Stats) (bool, error) {
+	return bsp.bs.Exists(ctx, name)
 }
 
 func (bsp *blobstorePersister) PruneTableFiles(ctx context.Context, keeper func() []hash.Hash, t time.Time) error {

--- a/go/store/nbs/chunk_source_adapter.go
+++ b/go/store/nbs/chunk_source_adapter.go
@@ -29,8 +29,8 @@ func (csa chunkSourceAdapter) hash() hash.Hash {
 	return csa.h
 }
 
-func (csa chunkSourceAdapter) name() string {
-	return csa.h.String()
+func (csa chunkSourceAdapter) suffix() string {
+	return ""
 }
 
 func newReaderFromIndexData(ctx context.Context, q MemoryQuotaProvider, idxData []byte, name hash.Hash, tra tableReaderAt, blockSize uint64) (cs chunkSource, err error) {

--- a/go/store/nbs/empty_chunk_source.go
+++ b/go/store/nbs/empty_chunk_source.go
@@ -66,8 +66,8 @@ func (ecs emptyChunkSource) hash() hash.Hash {
 	return hash.Hash{}
 }
 
-func (ecs emptyChunkSource) name() string {
-	return ecs.hash().String()
+func (ecs emptyChunkSource) suffix() string {
+	return ""
 }
 
 func (ecs emptyChunkSource) index() (tableIndex, error) {

--- a/go/store/nbs/file_table_persister.go
+++ b/go/store/nbs/file_table_persister.go
@@ -72,17 +72,21 @@ func (ftp *fsTablePersister) Open(ctx context.Context, name hash.Hash, chunkCoun
 	return newFileTableReader(ctx, ftp.dir, name, chunkCount, ftp.q)
 }
 
-func (ftp *fsTablePersister) Exists(ctx context.Context, name hash.Hash, chunkCount uint32, stats *Stats) (bool, error) {
+func (ftp *fsTablePersister) Exists(ctx context.Context, name string, chunkCount uint32, stats *Stats) (bool, error) {
 	ftp.removeMu.Lock()
 	defer ftp.removeMu.Unlock()
 	if ftp.toKeep != nil {
-		ftp.toKeep[filepath.Join(ftp.dir, name.String())] = struct{}{}
+		ftp.toKeep[filepath.Join(ftp.dir, name)] = struct{}{}
 	}
 
-	exists, err := tableFileExists(ctx, ftp.dir, name)
-	if exists || err != nil {
-		return exists, err
+	if h, ok := hash.MaybeParse(name); ok {
+		exists, err := tableFileExists(ctx, ftp.dir, h)
+		if exists || err != nil {
+			return exists, err
+		}
+
 	}
+
 	return archiveFileExists(ctx, ftp.dir, name)
 }
 

--- a/go/store/nbs/file_table_persister.go
+++ b/go/store/nbs/file_table_persister.go
@@ -69,7 +69,7 @@ var _ tablePersister = &fsTablePersister{}
 var _ tableFilePersister = &fsTablePersister{}
 
 func (ftp *fsTablePersister) Open(ctx context.Context, name hash.Hash, chunkCount uint32, stats *Stats) (chunkSource, error) {
-	return newFileTableReader(ctx, ftp.dir, name, chunkCount, ftp.q)
+	return newFileTableReader(ctx, ftp.dir, name, chunkCount, ftp.q, stats)
 }
 
 func (ftp *fsTablePersister) Exists(ctx context.Context, name string, chunkCount uint32, stats *Stats) (bool, error) {

--- a/go/store/nbs/file_table_reader.go
+++ b/go/store/nbs/file_table_reader.go
@@ -167,8 +167,8 @@ func (ftr *fileTableReader) hash() hash.Hash {
 	return ftr.h
 }
 
-func (ftr *fileTableReader) name() string {
-	return ftr.h.String()
+func (ftr *fileTableReader) suffix() string {
+	return ""
 }
 
 func (ftr *fileTableReader) Close() error {

--- a/go/store/nbs/file_table_reader.go
+++ b/go/store/nbs/file_table_reader.go
@@ -57,12 +57,10 @@ func tableFileExists(ctx context.Context, dir string, h hash.Hash) (bool, error)
 }
 
 func archiveFileExists(ctx context.Context, dir string, name string) (bool, error) {
-	// NM4 - is name short or long??
 	if !strings.HasSuffix(name, ArchiveFileSuffix) {
-		// It should be a hash, right?
 		_, ok := hash.MaybeParse(name)
 		if !ok {
-			panic("Not sure if this will ever happen")
+			return false, errors.New(fmt.Sprintf("invalid archive file name: %s", name))
 		}
 
 		name = fmt.Sprintf("%s%s", name, ArchiveFileSuffix)

--- a/go/store/nbs/file_table_reader.go
+++ b/go/store/nbs/file_table_reader.go
@@ -76,7 +76,7 @@ func archiveFileExists(ctx context.Context, dir string, name string) (bool, erro
 	return err == nil, err
 }
 
-func newFileTableReader(ctx context.Context, dir string, h hash.Hash, chunkCount uint32, q MemoryQuotaProvider) (cs chunkSource, err error) {
+func newFileTableReader(ctx context.Context, dir string, h hash.Hash, chunkCount uint32, q MemoryQuotaProvider, stats *Stats) (cs chunkSource, err error) {
 	// we either have a table file or an archive file
 	tfExists, err := tableFileExists(ctx, dir, h)
 	if err != nil {
@@ -89,84 +89,72 @@ func newFileTableReader(ctx context.Context, dir string, h hash.Hash, chunkCount
 	if err != nil {
 		return nil, err
 	} else if afExists {
-		return newArchiveChunkSource(ctx, dir, h, chunkCount, q)
+		return newArchiveChunkSource(ctx, dir, h, chunkCount, q, stats)
 	}
 	return nil, fmt.Errorf("error opening table file: %w: %s/%s", ErrTableFileNotFound, dir, h.String())
 }
 
-func nomsFileTableReader(ctx context.Context, path string, h hash.Hash, chunkCount uint32, q MemoryQuotaProvider) (cs chunkSource, err error) {
-	var f *os.File
-	index, sz, err := func() (ti onHeapTableIndex, sz int64, err error) {
-		// Be careful with how |f| is used below. |RefFile| returns a cached
-		// os.File pointer so the code needs to use f in a concurrency-safe
-		// manner. Moving the file offset is BAD.
-		f, err = os.Open(path)
-		if err != nil {
-			return
-		}
-
-		// Since we can't move the file offset, get the size of the file and use
-		// ReadAt to load the index instead.
-		var fi os.FileInfo
-		fi, err = f.Stat()
-
-		if err != nil {
-			return
-		}
-
-		if fi.Size() < 0 {
-			// Size returns the number of bytes for regular files and is system dependent for others (Some of which can be negative).
-			err = fmt.Errorf("%s has invalid size: %d", path, fi.Size())
-			return
-		}
-
-		idxSz := int64(indexSize(chunkCount) + footerSize)
-		sz = fi.Size()
-		indexOffset := sz - idxSz
-		r := io.NewSectionReader(f, indexOffset, idxSz)
-
-		if int64(int(idxSz)) != idxSz {
-			err = fmt.Errorf("table file %s is too large to read on this platform. index size %d > max int.", path, idxSz)
-			return
-		}
-
-		var b []byte
-		b, err = q.AcquireQuotaBytes(ctx, int(idxSz))
-		if err != nil {
-			return
-		}
-
-		_, err = io.ReadFull(r, b)
-		if err != nil {
-			q.ReleaseQuotaBytes(len(b))
-			return
-		}
-
-		ti, err = parseTableIndex(ctx, b, q)
-		if err != nil {
-			q.ReleaseQuotaBytes(len(b))
-			return
-		}
-
-		return
-	}()
+func newFileReaderAt(path string) (*fileReaderAt, error) {
+	f, err := os.Open(path)
 	if err != nil {
-		if f != nil {
-			f.Close()
-		}
 		return nil, err
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if fi.Size() < 0 {
+		// Size returns the number of bytes for regular files and is system dependent for others (Some of which can be negative).
+		return nil, fmt.Errorf("%s has invalid size: %d", path, fi.Size())
+	}
+	return &fileReaderAt{f, path, fi.Size()}, nil
+}
+
+func nomsFileTableReader(ctx context.Context, path string, h hash.Hash, chunkCount uint32, q MemoryQuotaProvider) (cs chunkSource, err error) {
+	fra, err := newFileReaderAt(path)
+	if err != nil {
+		return nil, err
+	}
+
+	idxSz := int64(indexSize(chunkCount) + footerSize)
+	indexOffset := fra.sz - idxSz
+	r := io.NewSectionReader(fra.f, indexOffset, idxSz)
+	if int64(int(idxSz)) != idxSz {
+		err = fmt.Errorf("table file %s is too large to read on this platform. index size %d > max int.", path, idxSz)
+		return
+	}
+
+	var b []byte
+	b, err = q.AcquireQuotaBytes(ctx, int(idxSz))
+	if err != nil {
+		fra.Close()
+		return
+	}
+
+	_, err = io.ReadFull(r, b)
+	if err != nil {
+		q.ReleaseQuotaBytes(len(b))
+		fra.Close()
+		return
+	}
+
+	index, err := parseTableIndex(ctx, b, q)
+	if err != nil {
+		q.ReleaseQuotaBytes(len(b))
+		fra.Close()
+		return
 	}
 
 	if chunkCount != index.chunkCount() {
 		index.Close()
-		f.Close()
+		fra.Close()
 		return nil, errors.New("unexpected chunk count")
 	}
 
-	tr, err := newTableReader(index, &fileReaderAt{f, path, sz}, fileBlockSize)
+	tr, err := newTableReader(index, fra, fileBlockSize)
 	if err != nil {
 		index.Close()
-		f.Close()
+		fra.Close()
 		return nil, err
 	}
 	return &fileTableReader{

--- a/go/store/nbs/file_table_reader_test.go
+++ b/go/store/nbs/file_table_reader_test.go
@@ -51,7 +51,7 @@ func TestMmapTableReader(t *testing.T) {
 	err = os.WriteFile(filepath.Join(dir, h.String()), tableData, 0666)
 	require.NoError(t, err)
 
-	trc, err := newFileTableReader(ctx, dir, h, uint32(len(chunks)), &UnlimitedQuotaProvider{})
+	trc, err := newFileTableReader(ctx, dir, h, uint32(len(chunks)), &UnlimitedQuotaProvider{}, &Stats{})
 	require.NoError(t, err)
 	defer trc.close()
 	assertChunksInReader(chunks, trc, assert)

--- a/go/store/nbs/gc_copier.go
+++ b/go/store/nbs/gc_copier.go
@@ -86,7 +86,7 @@ func (gcc *gcCopier) copyTablesToDir(ctx context.Context) (ts []tableSpec, err e
 		return nil, fmt.Errorf("invalid filename: %s", filename)
 	}
 
-	exists, err := gcc.tfp.Exists(ctx, addr, uint32(gcc.writer.ChunkCount()), nil)
+	exists, err := gcc.tfp.Exists(ctx, filename, uint32(gcc.writer.ChunkCount()), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/go/store/nbs/journal.go
+++ b/go/store/nbs/journal.go
@@ -296,7 +296,7 @@ func (j *ChunkJournal) Open(ctx context.Context, name hash.Hash, chunkCount uint
 }
 
 // Exists implements tablePersister.
-func (j *ChunkJournal) Exists(ctx context.Context, name hash.Hash, chunkCount uint32, stats *Stats) (bool, error) {
+func (j *ChunkJournal) Exists(ctx context.Context, name string, chunkCount uint32, stats *Stats) (bool, error) {
 	return j.persister.Exists(ctx, name, chunkCount, stats)
 }
 

--- a/go/store/nbs/journal_chunk_source.go
+++ b/go/store/nbs/journal_chunk_source.go
@@ -185,8 +185,8 @@ func (s journalChunkSource) hash() hash.Hash {
 	return journalAddr
 }
 
-func (s journalChunkSource) name() string {
-	return s.hash().String()
+func (s journalChunkSource) suffix() string {
+	return ""
 }
 
 // reader implements chunkSource.

--- a/go/store/nbs/metadata.go
+++ b/go/store/nbs/metadata.go
@@ -177,7 +177,7 @@ func buildArtifact(info TableSpecInfo, genPath string) (StorageArtifact, error) 
 			storageType: TypeNoms,
 		}, nil
 	} else {
-		reader, fileSize, err := openReader(fullPath)
+		reader, fileSize, err := openFileReader(fullPath)
 		if err != nil {
 			return StorageArtifact{}, err
 		}

--- a/go/store/nbs/no_conjoin_bs_persister.go
+++ b/go/store/nbs/no_conjoin_bs_persister.go
@@ -77,8 +77,8 @@ func (bsp *noConjoinBlobstorePersister) Open(ctx context.Context, name hash.Hash
 	return newBSChunkSource(ctx, bsp.bs, name, chunkCount, bsp.q, stats)
 }
 
-func (bsp *noConjoinBlobstorePersister) Exists(ctx context.Context, name hash.Hash, chunkCount uint32, stats *Stats) (bool, error) {
-	return bsp.bs.Exists(ctx, name.String())
+func (bsp *noConjoinBlobstorePersister) Exists(ctx context.Context, name string, chunkCount uint32, stats *Stats) (bool, error) {
+	return bsp.bs.Exists(ctx, name)
 }
 
 func (bsp *noConjoinBlobstorePersister) PruneTableFiles(ctx context.Context, keeper func() []hash.Hash, t time.Time) error {

--- a/go/store/nbs/root_tracker_test.go
+++ b/go/store/nbs/root_tracker_test.go
@@ -631,8 +631,13 @@ func (ftp fakeTablePersister) Open(ctx context.Context, name hash.Hash, chunkCou
 	return chunkSourceAdapter{cs, name}, nil
 }
 
-func (ftp fakeTablePersister) Exists(ctx context.Context, name hash.Hash, chunkCount uint32, stats *Stats) (bool, error) {
-	if _, ok := ftp.sourcesToFail[name]; ok {
+func (ftp fakeTablePersister) Exists(ctx context.Context, name string, chunkCount uint32, stats *Stats) (bool, error) {
+	h, ok := hash.MaybeParse(name)
+	if !ok {
+		panic("object store name expected to be a hash in test")
+	}
+
+	if _, ok := ftp.sourcesToFail[h]; ok {
 		return false, errors.New("intentional failure")
 	}
 	return true, nil

--- a/go/store/nbs/s3_object_reader.go
+++ b/go/store/nbs/s3_object_reader.go
@@ -238,3 +238,14 @@ func isConnReset(err error) bool {
 	scErr, ok := nErr.Err.(*os.SyscallError)
 	return ok && scErr.Err == syscall.ECONNRESET
 }
+
+type s3ReaderAtWithStats struct {
+	name string
+	rdr  *s3ObjectReader
+}
+
+func (s s3ReaderAtWithStats) ReadAtWithStats(ctx context.Context, p []byte, off int64, stats *Stats) (n int, err error) {
+	return s.rdr.ReadAt(ctx, s.name, p, off, stats)
+}
+
+var _ ReaderAtWithStats = s3ReaderAtWithStats{}

--- a/go/store/nbs/s3_object_reader.go
+++ b/go/store/nbs/s3_object_reader.go
@@ -22,13 +22,16 @@
 package nbs
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"os"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -36,10 +39,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/jpillora/backoff"
+	"golang.org/x/sync/errgroup"
 )
 
 // s3ObjectReader is a wrapper for S3 that gives us some nice to haves for reading objects from S3.
-// TODO: Bring all the multipart upload and remote-conjoin stuff over here and make this a better analogue to ddbTableStore
+// TODO: Bring all the multipart upload and remote-conjoin stuff in.
 type s3ObjectReader struct {
 	s3     s3iface.S3API
 	bucket string
@@ -156,57 +160,74 @@ func (s3or *s3ObjectReader) readRange(ctx context.Context, name string, p []byte
 	return n, sz, err
 }
 
-// NM4 - still table specific. Clean up. Doesn't need to be, IMO.
-func (s3or *s3ObjectReader) readS3TableFileFromEnd(ctx context.Context, name string, p []byte, stats *Stats) (n int, err error) {
+// readS3ObjectFromEnd reads the last |len(p)| bytes of the named object into |p|. The number of bytes read is returned,
+func (s3or *s3ObjectReader) readS3ObjectFromEnd(ctx context.Context, name string, p []byte, stats *Stats) (n int, err error) {
 	defer func(t1 time.Time) {
 		stats.S3BytesPerRead.Sample(uint64(len(p)))
 		stats.S3ReadLatency.SampleTimeSince(t1)
 	}(time.Now())
 
 	if len(p) > maxS3ReadFromEndReqSize {
-		panic("ReadAtFromEnd: re-instate!")
-		/*
-			totalN := uint64(0)
-			// If we're bigger than 256MB, parallelize the read...
-			// Read the footer first and capture the size of the entire table file.
-			n, sz, err := s3or.readRange(ctx, name, p[len(p)-footerSize:], httpEndRangeHeader(footerSize))
-			if err != nil {
-				return n, err
+		totalN := uint64(0)
+		// If we're bigger than 256MB, parallelize the read...
+		// Read the last |footerSize| bytes to get the size of the file. We know that all table files are at least this big.
+		n, sz, err := s3or.readRange(ctx, name, p[len(p)-footerSize:], httpEndRangeHeader(footerSize))
+		if err != nil {
+			return n, err
+		}
+		totalN += uint64(n)
+		eg, egctx := errgroup.WithContext(ctx)
+		start := 0
+		for start < len(p)-footerSize {
+			// Make parallel read requests of up to 128MB.
+			end := start + preferredS3ReadFromEndReqSize
+			if end > len(p)-footerSize {
+				end = len(p) - footerSize
 			}
-			totalN += uint64(n)
-			eg, egctx := errgroup.WithContext(ctx)
-			start := 0
-			for start < len(p)-footerSize {
-				// Make parallel read requests of up to 128MB.
-				end := start + preferredS3ReadFromEndReqSize
-				if end > len(p)-footerSize {
-					end = len(p) - footerSize
+			bs := p[start:end]
+			rangeStart := sz - uint64(len(p)) + uint64(start)
+			rangeEnd := sz - uint64(len(p)) + uint64(end) - 1
+			length := rangeEnd - rangeStart
+			eg.Go(func() error {
+				n, _, err := s3or.readRange(egctx, name, bs, httpRangeHeader(int64(rangeStart), int64(length)))
+				if err != nil {
+					return err
 				}
-				bs := p[start:end]
-				rangeStart := sz - uint64(len(p)) + uint64(start)
-				rangeEnd := sz - uint64(len(p)) + uint64(end) - 1
-				length := rangeEnd - rangeStart
-				eg.Go(func() error {
-					n, _, err := s3or.readRange(egctx, name, bs, httpRangeHeader(int64(rangeStart), int64(length)))
-					if err != nil {
-						return err
-					}
-					atomic.AddUint64(&totalN, uint64(n))
-					return nil
-				})
-				start = end
-			}
-			err = eg.Wait()
-			if err != nil {
-				return 0, err
-			}
-			return int(totalN), nil
+				atomic.AddUint64(&totalN, uint64(n))
+				return nil
+			})
+			start = end
+		}
+		err = eg.Wait()
+		if err != nil {
+			return 0, err
+		}
+		return int(totalN), nil
+	} else {
+		n, _, err = s3or.readRange(ctx, name, p, httpEndRangeHeader(len(p)))
+		return n, err
+	}
+}
 
-		*/
+// objectExistsInChunkSource returns true if the object exists in the chunk source, and it verifies that
+// the object signatures matches the |name|. A |name| which ends in .darc indicates an archive file, otherwise
+// we verify the Noms magic number. True is returned if the object is legitimate, and false with an error if not.
+func (s3or *s3ObjectReader) objectExistsInChunkSource(ctx context.Context, name string, stats *Stats) (bool, error) {
+	magic := make([]byte, magicNumberSize)
+	n, err := s3or.readS3ObjectFromEnd(ctx, name, magic, stats)
+	if err != nil {
+		return false, err
+	}
+	if n != len(magic) {
+		return false, errors.New("failed to read all data")
 	}
 
-	n, _, err = s3or.readRange(ctx, name, p, httpEndRangeHeader(len(p)))
-	return n, err
+	if strings.HasSuffix(name, ArchiveFileSuffix) {
+		// dolt magic number is a version byte + DOLTARC. We ignore the version byte here.
+		return bytes.Equal(magic[magicNumberSize-doltMagicSize:], []byte(doltMagicNumber)), nil
+	} else {
+		return bytes.Equal(magic, []byte(magicNumber)), nil
+	}
 }
 
 func isConnReset(err error) bool {

--- a/go/store/nbs/s3_object_reader.go
+++ b/go/store/nbs/s3_object_reader.go
@@ -1,0 +1,160 @@
+// Copyright 2025 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package nbs
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/jpillora/backoff"
+)
+
+// s3ObjectReader is a wrapper for S3 that gives us some nice to haves for reading objects from S3.
+// TODO: Bring all the multipart upload and remote-conjoin stuff over here and make this a better analogue to ddbTableStore
+type s3ObjectReader struct {
+	s3     s3iface.S3API
+	bucket string
+	readRl chan struct{}
+	ns     string
+}
+
+// s3RangeHeader returns a string for the HTTP range header ("bytes=23-42") for a range starting at |off| and ending at |length|
+// Intended to be used with the |readRange| method.
+func s3RangeHeader(off, length int64) string {
+	lastByte := off + length - 1 // insanely, the HTTP range header specifies ranges inclusively.
+	return fmt.Sprintf("%s=%d-%d", s3RangePrefix, off, lastByte)
+}
+
+func (s3or *s3ObjectReader) key(name string) string {
+	if s3or.ns != "" {
+		return s3or.ns + "/" + name
+	}
+	return name
+}
+
+// ReadAt gets the named object, and reads |len(p)| bytes into |p| starting at |off|. The number of bytes read is returned,
+// along with an error if one occurs.
+func (s3or *s3ObjectReader) ReadAt(ctx context.Context, name string, p []byte, off int64, stats *Stats) (n int, err error) {
+	t1 := time.Now()
+
+	defer func() {
+		stats.S3BytesPerRead.Sample(uint64(len(p)))
+		stats.S3ReadLatency.SampleTimeSince(t1)
+	}()
+
+	n, _, err = s3or.readRange(ctx, name, p, s3RangeHeader(off, int64(len(p))))
+	return
+}
+
+// reader gets the full object from S3 as a ReadCloser. Useful when downloading the entire object.
+func (s3or *s3ObjectReader) reader(ctx context.Context, name string) (io.ReadCloser, error) {
+	input := &s3.GetObjectInput{
+		Bucket: aws.String(s3or.bucket),
+		Key:    aws.String(s3or.key(name)),
+	}
+	result, err := s3or.s3.GetObjectWithContext(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return result.Body, nil
+}
+
+// readRange implements the raw calls to S3 for the purpose of reading a range of bytes from an |name| object. Contents
+// are read into |p| and the range is specified as a string, which you should get using the |s3RangeHeader| function.
+// The return value is the number of bytes |n| read and the total size |sz| of the object. The size of the object comes from the Content-Range
+// HTTP header, and can be used if manually breaking of the file into range chunks
+func (s3or *s3ObjectReader) readRange(ctx context.Context, name string, p []byte, rangeHeader string) (n int, sz uint64, err error) {
+	read := func() (int, uint64, error) {
+		if s3or.readRl != nil {
+			s3or.readRl <- struct{}{}
+			defer func() {
+				<-s3or.readRl
+			}()
+		}
+
+		input := &s3.GetObjectInput{
+			Bucket: aws.String(s3or.bucket),
+			Key:    aws.String(s3or.key(name)),
+			Range:  aws.String(rangeHeader),
+		}
+
+		result, err := s3or.s3.GetObjectWithContext(ctx, input)
+		if err != nil {
+			return 0, 0, err
+		}
+		defer result.Body.Close()
+
+		if *result.ContentLength != int64(len(p)) {
+			return 0, 0, fmt.Errorf("failed to read entire range, key: %v, len(p): %d, rangeHeader: %s, ContentLength: %d", s3or.key(name), len(p), rangeHeader, *result.ContentLength)
+		}
+
+		sz := uint64(0)
+		if result.ContentRange != nil {
+			i := strings.Index(*result.ContentRange, "/")
+			if i != -1 {
+				sz, err = strconv.ParseUint((*result.ContentRange)[i+1:], 10, 64)
+				if err != nil {
+					return 0, 0, err
+				}
+			}
+		}
+		n, err = io.ReadFull(result.Body, p)
+		return n, sz, err
+	}
+
+	n, sz, err = read()
+	// We hit the point of diminishing returns investigating #3255, so add retries. In conversations with AWS people, it's not surprising to get transient failures when talking to S3, though SDKs are intended to have their own retrying. The issue may be that, in Go, making the S3 request and reading the data are separate operations, and the SDK kind of can't do its own retrying to handle failures in the latter.
+	if isConnReset(err) {
+		// We are backing off here because its possible and likely that the rate of requests to S3 is the underlying issue.
+		b := &backoff.Backoff{
+			Min:    128 * time.Microsecond,
+			Max:    1024 * time.Millisecond,
+			Factor: 2,
+			Jitter: true,
+		}
+		for ; isConnReset(err); n, sz, err = read() {
+			dur := b.Duration()
+			time.Sleep(dur)
+		}
+	}
+
+	return n, sz, err
+}
+
+func isConnReset(err error) bool {
+	nErr, ok := err.(*net.OpError)
+	if !ok {
+		return false
+	}
+	scErr, ok := nErr.Err.(*os.SyscallError)
+	return ok && scErr.Err == syscall.ECONNRESET
+}

--- a/go/store/nbs/s3_object_reader.go
+++ b/go/store/nbs/s3_object_reader.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Dolthub, Inc.
+// Copyright 2019-2025 Dolthub, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+// Copyright 2016 Attic Labs, Inc. All rights reserved.
+// Licensed under the Apache License, version 2.0:
+// http://www.apache.org/licenses/LICENSE-2.0
 
 package nbs
 

--- a/go/store/nbs/s3_object_reader.go
+++ b/go/store/nbs/s3_object_reader.go
@@ -11,13 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// This file incorporates work covered by the following copyright and
-// permission notice:
-//
-// Copyright 2016 Attic Labs, Inc. All rights reserved.
-// Licensed under the Apache License, version 2.0:
-// http://www.apache.org/licenses/LICENSE-2.0
 
 package nbs
 

--- a/go/store/nbs/s3_table_reader.go
+++ b/go/store/nbs/s3_table_reader.go
@@ -24,8 +24,6 @@ package nbs
 import (
 	"context"
 	"io"
-
-	"github.com/dolthub/dolt/go/store/hash"
 )
 
 const (
@@ -34,8 +32,8 @@ const (
 )
 
 type s3TableReaderAt struct {
-	s3 *s3ObjectReader
-	h  hash.Hash
+	s3  *s3ObjectReader
+	key string
 }
 
 func (s3tra *s3TableReaderAt) Close() error {
@@ -47,11 +45,11 @@ func (s3tra *s3TableReaderAt) clone() (tableReaderAt, error) {
 }
 
 func (s3tra *s3TableReaderAt) Reader(ctx context.Context) (io.ReadCloser, error) {
-	return s3tra.s3.reader(ctx, s3tra.h.String())
+	return s3tra.s3.reader(ctx, s3tra.key)
 }
 
 func (s3tra *s3TableReaderAt) ReadAtWithStats(ctx context.Context, p []byte, off int64, stats *Stats) (n int, err error) {
-	return s3tra.s3.ReadAt(ctx, s3tra.h.String(), p, off, stats)
+	return s3tra.s3.ReadAt(ctx, s3tra.key, p, off, stats)
 }
 
 const maxS3ReadFromEndReqSize = 256 * 1024 * 1024       // 256MB

--- a/go/store/nbs/s3_table_reader.go
+++ b/go/store/nbs/s3_table_reader.go
@@ -25,18 +25,9 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net"
-	"os"
-	"strconv"
-	"strings"
 	"sync/atomic"
-	"syscall"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3/s3iface"
-	"github.com/jpillora/backoff"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/dolthub/dolt/go/store/hash"
@@ -61,53 +52,17 @@ func (s3tra *s3TableReaderAt) clone() (tableReaderAt, error) {
 }
 
 func (s3tra *s3TableReaderAt) Reader(ctx context.Context) (io.ReadCloser, error) {
-	return s3tra.s3.Reader(ctx, s3tra.h)
+	return s3tra.s3.reader(ctx, s3tra.h.String())
 }
 
 func (s3tra *s3TableReaderAt) ReadAtWithStats(ctx context.Context, p []byte, off int64, stats *Stats) (n int, err error) {
-	return s3tra.s3.ReadAt(ctx, s3tra.h, p, off, stats)
-}
-
-// TODO: Bring all the multipart upload and remote-conjoin stuff over here and make this a better analogue to ddbTableStore
-type s3ObjectReader struct {
-	s3     s3iface.S3API
-	bucket string
-	readRl chan struct{}
-	ns     string
-}
-
-func (s3or *s3ObjectReader) key(k string) string {
-	if s3or.ns != "" {
-		return s3or.ns + "/" + k
-	}
-	return k
-}
-
-func (s3or *s3ObjectReader) Reader(ctx context.Context, name hash.Hash) (io.ReadCloser, error) {
-	return s3or.reader(ctx, name)
-}
-
-func (s3or *s3ObjectReader) ReadAt(ctx context.Context, name hash.Hash, p []byte, off int64, stats *Stats) (n int, err error) {
-	t1 := time.Now()
-
-	defer func() {
-		stats.S3BytesPerRead.Sample(uint64(len(p)))
-		stats.S3ReadLatency.SampleTimeSince(t1)
-	}()
-
-	n, _, err = s3or.readRange(ctx, name, p, s3RangeHeader(off, int64(len(p))))
-	return
-}
-
-func s3RangeHeader(off, length int64) string {
-	lastByte := off + length - 1 // insanely, the HTTP range header specifies ranges inclusively.
-	return fmt.Sprintf("%s=%d-%d", s3RangePrefix, off, lastByte)
+	return s3tra.s3.ReadAt(ctx, s3tra.h.String(), p, off, stats)
 }
 
 const maxS3ReadFromEndReqSize = 256 * 1024 * 1024       // 256MB
 const preferredS3ReadFromEndReqSize = 128 * 1024 * 1024 // 128MB
 
-func (s3or *s3ObjectReader) ReadFromEnd(ctx context.Context, name hash.Hash, p []byte, stats *Stats) (n int, sz uint64, err error) {
+func readS3TableFileFromEnd(ctx context.Context, s3or *s3ObjectReader, name string, p []byte, stats *Stats) (n int, err error) {
 	defer func(t1 time.Time) {
 		stats.S3BytesPerRead.Sample(uint64(len(p)))
 		stats.S3ReadLatency.SampleTimeSince(t1)
@@ -118,7 +73,7 @@ func (s3or *s3ObjectReader) ReadFromEnd(ctx context.Context, name hash.Hash, p [
 		// Read the footer first and capture the size of the entire table file.
 		n, sz, err := s3or.readRange(ctx, name, p[len(p)-footerSize:], fmt.Sprintf("%s=-%d", s3RangePrefix, footerSize))
 		if err != nil {
-			return n, sz, err
+			return n, err
 		}
 		totalN += uint64(n)
 		eg, egctx := errgroup.WithContext(ctx)
@@ -144,88 +99,10 @@ func (s3or *s3ObjectReader) ReadFromEnd(ctx context.Context, name hash.Hash, p [
 		}
 		err = eg.Wait()
 		if err != nil {
-			return 0, 0, err
+			return 0, err
 		}
-		return int(totalN), sz, nil
+		return int(totalN), nil
 	}
-	return s3or.readRange(ctx, name, p, fmt.Sprintf("%s=-%d", s3RangePrefix, len(p)))
-}
-
-func (s3or *s3ObjectReader) reader(ctx context.Context, name hash.Hash) (io.ReadCloser, error) {
-	input := &s3.GetObjectInput{
-		Bucket: aws.String(s3or.bucket),
-		Key:    aws.String(s3or.key(name.String())),
-	}
-	result, err := s3or.s3.GetObjectWithContext(ctx, input)
-	if err != nil {
-		return nil, err
-	}
-	return result.Body, nil
-}
-
-func (s3or *s3ObjectReader) readRange(ctx context.Context, name hash.Hash, p []byte, rangeHeader string) (n int, sz uint64, err error) {
-	read := func() (int, uint64, error) {
-		if s3or.readRl != nil {
-			s3or.readRl <- struct{}{}
-			defer func() {
-				<-s3or.readRl
-			}()
-		}
-
-		input := &s3.GetObjectInput{
-			Bucket: aws.String(s3or.bucket),
-			Key:    aws.String(s3or.key(name.String())),
-			Range:  aws.String(rangeHeader),
-		}
-
-		result, err := s3or.s3.GetObjectWithContext(ctx, input)
-		if err != nil {
-			return 0, 0, err
-		}
-		defer result.Body.Close()
-
-		if *result.ContentLength != int64(len(p)) {
-			return 0, 0, fmt.Errorf("failed to read entire range, key: %v, len(p): %d, rangeHeader: %s, ContentLength: %d", s3or.key(name.String()), len(p), rangeHeader, *result.ContentLength)
-		}
-
-		sz := uint64(0)
-		if result.ContentRange != nil {
-			i := strings.Index(*result.ContentRange, "/")
-			if i != -1 {
-				sz, err = strconv.ParseUint((*result.ContentRange)[i+1:], 10, 64)
-				if err != nil {
-					return 0, 0, err
-				}
-			}
-		}
-		n, err = io.ReadFull(result.Body, p)
-		return n, sz, err
-	}
-
-	n, sz, err = read()
-	// We hit the point of diminishing returns investigating #3255, so add retries. In conversations with AWS people, it's not surprising to get transient failures when talking to S3, though SDKs are intended to have their own retrying. The issue may be that, in Go, making the S3 request and reading the data are separate operations, and the SDK kind of can't do its own retrying to handle failures in the latter.
-	if isConnReset(err) {
-		// We are backing off here because its possible and likely that the rate of requests to S3 is the underlying issue.
-		b := &backoff.Backoff{
-			Min:    128 * time.Microsecond,
-			Max:    1024 * time.Millisecond,
-			Factor: 2,
-			Jitter: true,
-		}
-		for ; isConnReset(err); n, sz, err = read() {
-			dur := b.Duration()
-			time.Sleep(dur)
-		}
-	}
-
-	return n, sz, err
-}
-
-func isConnReset(err error) bool {
-	nErr, ok := err.(*net.OpError)
-	if !ok {
-		return false
-	}
-	scErr, ok := nErr.Err.(*os.SyscallError)
-	return ok && scErr.Err == syscall.ECONNRESET
+	n, _, err = s3or.readRange(ctx, name, p, fmt.Sprintf("%s=-%d", s3RangePrefix, len(p)))
+	return n, err
 }

--- a/go/store/nbs/s3_table_reader_test.go
+++ b/go/store/nbs/s3_table_reader_test.go
@@ -54,7 +54,7 @@ func TestS3TableReaderAt(t *testing.T) {
 		assert := assert.New(t)
 
 		baseline := s3.getCount
-		tra := &s3TableReaderAt{&s3ObjectReader{makeFlakyS3(s3), "bucket", nil, ""}, h}
+		tra := &s3TableReaderAt{&s3ObjectReader{makeFlakyS3(s3), "bucket", nil, ""}, h.String()}
 		scratch := make([]byte, len(tableData))
 		_, err := tra.ReadAtWithStats(context.Background(), scratch, 0, &Stats{})
 		require.NoError(t, err)
@@ -81,7 +81,7 @@ func TestS3TableReaderAtNamespace(t *testing.T) {
 	require.NoError(t, err)
 	s3.data["a-prefix-here/"+h.String()] = tableData
 
-	tra := &s3TableReaderAt{&s3ObjectReader{s3, "bucket", nil, ns}, h}
+	tra := &s3TableReaderAt{&s3ObjectReader{s3, "bucket", nil, ns}, h.String()}
 	scratch := make([]byte, len(tableData))
 	_, err = tra.ReadAtWithStats(context.Background(), scratch, 0, &Stats{})
 	require.NoError(t, err)

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -421,10 +421,10 @@ func (nbs *NomsBlockStore) checkAllManifestUpdatesExist(ctx context.Context, upd
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.SetLimit(128)
 	for h, c := range updates {
-		h := h
+		name := h
 		c := c
 		eg.Go(func() error {
-			ok, err := nbs.p.Exists(ctx, h, c, nbs.stats)
+			ok, err := nbs.p.Exists(ctx, name.String(), c, nbs.stats)
 			if err != nil {
 				return err
 			}

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -165,12 +165,7 @@ func (nbs *NomsBlockStore) GetChunkLocationsWithPaths(ctx context.Context, hashe
 	res := make(map[string]map[hash.Hash]Range, len(sourcesToRanges))
 	for csP, ranges := range sourcesToRanges {
 		cs := *csP
-		suffix := ""
-		if _, ok := cs.(archiveChunkSource); ok {
-			suffix = ArchiveFileSuffix
-		}
-
-		res[cs.hash().String()+suffix] = ranges
+		res[cs.hash().String()+cs.suffix()] = ranges
 	}
 	return res, nil
 }

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -243,9 +243,8 @@ type chunkSource interface {
 	// hash returns the hash address of this chunkSource.
 	hash() hash.Hash
 
-	// name is the on disk short name for this chunkSource. Classically, this was a hash. Having files
-	// with suffixes (eg darc) was useful.
-	name() string
+	// suffix returns the file suffix of this chunkSource. File name can be produces with `cs.hash().String() + cs.suffix()`
+	suffix() string
 
 	// opens a Reader to the first byte of the chunkData segment of this table.
 	reader(context.Context) (io.ReadCloser, uint64, error)

--- a/go/store/nbs/table_persister.go
+++ b/go/store/nbs/table_persister.go
@@ -59,7 +59,7 @@ type tablePersister interface {
 	Open(ctx context.Context, name hash.Hash, chunkCount uint32, stats *Stats) (chunkSource, error)
 
 	// Exists checks if a table named |name| exists.
-	Exists(ctx context.Context, name hash.Hash, chunkCount uint32, stats *Stats) (bool, error)
+	Exists(ctx context.Context, name string, chunkCount uint32, stats *Stats) (bool, error)
 
 	// PruneTableFiles deletes table files which the persister would normally be responsible for and
 	// which are not in the included |keeper| set and have not be written or modified more recently

--- a/go/store/nbs/table_reader.go
+++ b/go/store/nbs/table_reader.go
@@ -505,9 +505,9 @@ func (tr tableReader) getManyAtOffsetsWithReadFunc(
 	offsetRecords offsetRecSlice,
 	stats *Stats,
 	readAtOffsets func(
-	ctx context.Context,
-	rb readBatch,
-	stats *Stats) error,
+		ctx context.Context,
+		rb readBatch,
+		stats *Stats) error,
 ) error {
 	batches := toReadBatches(offsetRecords, tr.blockSize)
 	for i := range batches {

--- a/go/store/nbs/table_reader.go
+++ b/go/store/nbs/table_reader.go
@@ -25,7 +25,6 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"io"
 	"sort"
 
@@ -162,67 +161,6 @@ type tableReaderAt interface {
 	Close() error
 	clone() (tableReaderAt, error)
 }
-
-// flexTableReaderAt is a type that can be either an io.ReaderAt or a ReaderAtWithStats. It's very close to the
-// tableReaderAt interface, with the exception that it can't be cloned or converted to a Reader.
-type flexTableReaderAt struct {
-	ioRdr    *io.ReaderAt
-	nbsRdrWs *ReaderAtWithStats
-}
-
-func newFlexibleReader(input interface{}) flexTableReaderAt {
-	if r, ok := input.(ReaderAtWithStats); ok {
-		return flexTableReaderAt{nbsRdrWs: &r}
-	}
-	if r, ok := input.(io.ReaderAt); ok {
-		return flexTableReaderAt{ioRdr: &r}
-	}
-	panic(fmt.Sprintf("runtime error: invalid input to newFlexibleReader of type %T", input))
-}
-
-func (fb flexTableReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
-	if fb.nbsRdrWs != nil {
-		return (*fb.nbsRdrWs).ReadAtWithStats(context.Background(), p, off, &Stats{})
-	}
-	if fb.ioRdr != nil {
-		return (*fb.ioRdr).ReadAt(p, off)
-	}
-	panic("runtime error: invalid state in flexTableReaderAt")
-}
-
-func (fb flexTableReaderAt) ReadAtWithStats(ctx context.Context, p []byte, off int64, stats *Stats) (n int, err error) {
-	if fb.nbsRdrWs != nil {
-		return (*fb.nbsRdrWs).ReadAtWithStats(ctx, p, off, stats)
-	}
-	if fb.ioRdr != nil {
-		return (*fb.ioRdr).ReadAt(p, off)
-	}
-	panic("runtime error: invalid state in flexTableReaderAt")
-}
-
-func (fb flexTableReaderAt) close() {
-	if c, ok := (*fb.nbsRdrWs).(io.Closer); ok {
-		_ = c.Close()
-	}
-}
-
-func (fb flexTableReaderAt) Close() error {
-	if fb.nbsRdrWs != nil {
-		if c, ok := (*fb.nbsRdrWs).(io.Closer); ok {
-			return c.Close()
-		}
-	}
-	if fb.ioRdr != nil {
-		if c, ok := (*fb.ioRdr).(io.Closer); ok {
-			return c.Close()
-		}
-	}
-	return nil
-}
-
-var _ ReaderAtWithStats = flexTableReaderAt{}
-var _ io.ReaderAt = flexTableReaderAt{}
-var _ io.Closer = flexTableReaderAt{}
 
 // tableReader implements get & has queries against a single nbs table. goroutine safe.
 // |blockSize| refers to the block-size of the underlying storage. We assume that, each
@@ -567,9 +505,9 @@ func (tr tableReader) getManyAtOffsetsWithReadFunc(
 	offsetRecords offsetRecSlice,
 	stats *Stats,
 	readAtOffsets func(
-		ctx context.Context,
-		rb readBatch,
-		stats *Stats) error,
+	ctx context.Context,
+	rb readBatch,
+	stats *Stats) error,
 ) error {
 	batches := toReadBatches(offsetRecords, tr.blockSize)
 	for i := range batches {

--- a/go/utils/copyrightshdrs/main.go
+++ b/go/utils/copyrightshdrs/main.go
@@ -156,7 +156,8 @@ var CopiedNomsFiles []CopiedNomsFile = []CopiedNomsFile{
 	{Path: "store/metrics/histogram.go", NomsPath: "go/metrics/histogram.go", HadCopyrightNotice: true},
 	{Path: "store/metrics/histogram_test.go", NomsPath: "go/metrics/histogram_test.go", HadCopyrightNotice: true},
 	{Path: "store/nbs/aws_table_chunk_source.go", NomsPath: "go/nbs/aws_chunk_source.go", HadCopyrightNotice: true},
-	{Path: "store/nbs/aws_chunk_source_test.go", NomsPath: "go/nbs/aws_chunk_source_test.go", HadCopyrightNotice: true},
+	{Path: "store/nbs/aws_table_chunk_source_test.go", NomsPath: "go/nbs/aws_chunk_source_test.go", HadCopyrightNotice: true},
+
 	{Path: "store/nbs/aws_table_persister.go", NomsPath: "go/nbs/aws_table_persister.go", HadCopyrightNotice: true},
 	{Path: "store/nbs/aws_table_persister_test.go", NomsPath: "go/nbs/aws_table_persister_test.go", HadCopyrightNotice: true},
 	{Path: "store/nbs/benchmarks/block_store_benchmarks.go", NomsPath: "go/nbs/benchmarks/block_store_benchmarks.go", HadCopyrightNotice: true},

--- a/go/utils/copyrightshdrs/main.go
+++ b/go/utils/copyrightshdrs/main.go
@@ -155,7 +155,7 @@ var CopiedNomsFiles []CopiedNomsFile = []CopiedNomsFile{
 	{Path: "store/merge/three_way_test.go", NomsPath: "go/merge/three_way_test.go", HadCopyrightNotice: true},
 	{Path: "store/metrics/histogram.go", NomsPath: "go/metrics/histogram.go", HadCopyrightNotice: true},
 	{Path: "store/metrics/histogram_test.go", NomsPath: "go/metrics/histogram_test.go", HadCopyrightNotice: true},
-	{Path: "store/nbs/aws_chunk_source.go", NomsPath: "go/nbs/aws_chunk_source.go", HadCopyrightNotice: true},
+	{Path: "store/nbs/aws_table_chunk_source.go", NomsPath: "go/nbs/aws_chunk_source.go", HadCopyrightNotice: true},
 	{Path: "store/nbs/aws_chunk_source_test.go", NomsPath: "go/nbs/aws_chunk_source_test.go", HadCopyrightNotice: true},
 	{Path: "store/nbs/aws_table_persister.go", NomsPath: "go/nbs/aws_table_persister.go", HadCopyrightNotice: true},
 	{Path: "store/nbs/aws_table_persister_test.go", NomsPath: "go/nbs/aws_table_persister_test.go", HadCopyrightNotice: true},

--- a/go/utils/copyrightshdrs/main.go
+++ b/go/utils/copyrightshdrs/main.go
@@ -39,7 +39,7 @@ var ExpectedHeader = regexp.MustCompile(`// Copyright (2019|2020|2021|2022|2023|
 
 `)
 
-var ExpectedHeaderForFileFromNoms = regexp.MustCompile(`// Copyright (2019|2020|2021|2022|2023|2019-2020|2019-2021|2019-2022|2019-2023|2020-2021|2020-2022|2020-2023|2021-2022|2021-2023|2022-2023) Dolthub, Inc.
+var ExpectedHeaderForFileFromNoms = regexp.MustCompile(`// Copyright (2019|2020|2021|2022|2023|2019-2020|2019-2021|2019-2022|2019-2023|2019-2025|2020-2021|2020-2022|2020-2023|2021-2022|2021-2023|2022-2023) Dolthub, Inc.
 //
 // Licensed under the Apache License, Version 2.0 \(the "License"\);
 // you may not use this file except in compliance with the License.
@@ -76,6 +76,7 @@ var CopiedNomsFiles []CopiedNomsFile = []CopiedNomsFile{
 	{Path: "store/prolly/tree/chunker.go", NomsPath: "go/types/sequence_chunker.go", HadCopyrightNotice: true},
 	{Path: "store/prolly/tree/node_cursor.go", NomsPath: "go/types/sequence_cursor.go", HadCopyrightNotice: true},
 	{Path: "store/prolly/tree/node_splitter.go", NomsPath: "go/types/rolling_value_hasher.go", HadCopyrightNotice: true},
+	{Path: "store/nbs/s3_object_reader.go", NomsPath: "go/nbs/s3_table_reader.go", HadCopyrightNotice: true},
 
 	// These included source files from noms did not have copyright notices.
 	{Path: "store/types/common_supertype.go", NomsPath: "go/types/common_supertype.go", HadCopyrightNotice: false},

--- a/integration-tests/bats/archive-aws.bats
+++ b/integration-tests/bats/archive-aws.bats
@@ -1,0 +1,108 @@
+
+load $BATS_TEST_DIRNAME/helper/common.bash
+
+setup() {
+    setup_common
+}
+
+teardown() {
+    teardown_common
+}
+
+skip_if_no_aws_tests() {
+    if [ -z "$DOLT_BATS_AWS_TABLE" ] || [ -z "$DOLT_BATS_AWS_BUCKET" ]; then
+      skip "skipping aws tests; set DOLT_BATS_AWS_TABLE and DOLT_BATS_AWS_BUCKET to run"
+    fi
+}
+
+# bats test_tags=no_lambda
+@test "archive-aws: can backup and restore/clone archive" {
+  skip_if_no_aws_tests
+  rm -rf .dolt
+
+  random_repo=`openssl rand -hex 16`
+
+  mkdir -p original/.dolt
+  cp -R $BATS_TEST_DIRNAME/archive-test-repo/* original/.dolt
+  cd original
+
+  url='aws://['"$DOLT_BATS_AWS_TABLE"':'"$DOLT_BATS_AWS_BUCKET"']/'"$random_repo"
+
+  dolt backup add backup1 "$url"
+  dolt backup sync backup1
+
+  cd ../
+  dolt backup restore "$url" restoreddb
+  cd restoreddb
+
+  # Verify we can read data
+  run dolt sql -q 'select sum(i) from tbl;'
+  [[ "$status" -eq 0 ]] || false
+  [[ "$output" =~ "138075" ]] || false # i = 1 - 525, sum is 138075
+
+  cd ../
+  ## We can clone this thing too, even though it has archive files. Pushing archive
+  ## files currently converts them to table files, so using the backup files
+  ## is currently the only way we can get archive files from AWS backed databases
+  ## when cloning.
+  dolt clone "$url" cloneddb
+  # Verify we can read data
+  run dolt sql -q 'select sum(i) from tbl;'
+  [[ "$status" -eq 0 ]] || false
+  [[ "$output" =~ "138075" ]] || false # i = 1 - 525, sum is 138075
+}
+
+# bats test_tags=no_lambda
+@test "archive-aws: can backup and restore archive with workspace changes" {
+  skip_if_no_aws_tests
+  rm -rf .dolt
+
+  random_repo=`openssl rand -hex 16`
+
+  mkdir -p original/.dolt
+  cp -R $BATS_TEST_DIRNAME/archive-test-repo/* original/.dolt
+  cd original
+
+  # dirty the database. Should be visible after we restore.
+  dolt sql -q "delete from tbl where i = 42;"
+
+  url='aws://['"$DOLT_BATS_AWS_TABLE"':'"$DOLT_BATS_AWS_BUCKET"']/'"$random_repo"
+
+  dolt backup add backup1 "$url"
+  dolt backup sync backup1
+
+  cd ../
+  dolt backup restore "$url" restoreddb
+  cd restoreddb
+
+  # Verify we can read data
+  run dolt sql -q 'select sum(i) from tbl;'
+  [[ "$status" -eq 0 ]] || false
+  [[ "$output" =~ "138033" ]] || false # i = 1 - 525, sum is 138075, then substract 42
+}
+
+# bats test_tags=no_lambda
+@test "archive-aws: can push and and clone archive" {
+  skip_if_no_aws_tests
+  rm -rf .dolt
+
+  random_repo=`openssl rand -hex 16`
+
+  mkdir -p original/.dolt
+  cp -R $BATS_TEST_DIRNAME/archive-test-repo/* original/.dolt
+  cd original
+
+  url='aws://['"$DOLT_BATS_AWS_TABLE"':'"$DOLT_BATS_AWS_BUCKET"']/'"$random_repo"
+
+  dolt remote add rmt1 "$url"
+  dolt push rmt1 main:main
+
+  cd ../
+  dolt clone "$url" cloneddb
+  cd cloneddb
+
+  # Verify we can read data
+  run dolt sql -q 'select sum(i) from tbl;'
+  [[ "$status" -eq 0 ]] || false
+  [[ "$output" =~ "138075" ]] || false # i = 1 - 525, sum is 138075
+}

--- a/integration-tests/bats/archive-aws.bats
+++ b/integration-tests/bats/archive-aws.bats
@@ -46,10 +46,13 @@ skip_if_no_aws_tests() {
   ## is currently the only way we can get archive files from AWS backed databases
   ## when cloning.
   dolt clone "$url" cloneddb
+  cd cloneddb
   # Verify we can read data
   run dolt sql -q 'select sum(i) from tbl;'
   [[ "$status" -eq 0 ]] || false
   [[ "$output" =~ "138075" ]] || false # i = 1 - 525, sum is 138075
+
+  dolt fsck
 }
 
 # bats test_tags=no_lambda
@@ -79,10 +82,12 @@ skip_if_no_aws_tests() {
   run dolt sql -q 'select sum(i) from tbl;'
   [[ "$status" -eq 0 ]] || false
   [[ "$output" =~ "138033" ]] || false # i = 1 - 525, sum is 138075, then substract 42
+
+  dolt fsck
 }
 
 # bats test_tags=no_lambda
-@test "archive-aws: can push and and clone archive" {
+@test "archive-aws: can push and clone archive" {
   skip_if_no_aws_tests
   rm -rf .dolt
 
@@ -105,4 +110,11 @@ skip_if_no_aws_tests() {
   run dolt sql -q 'select sum(i) from tbl;'
   [[ "$status" -eq 0 ]] || false
   [[ "$output" =~ "138075" ]] || false # i = 1 - 525, sum is 138075
+
+  dolt fsck
 }
+
+## NM4 - Need additional tests when we support streaming to archive files.
+##  - Push archive content to AWS, verify it is in archive format when we clone.
+##  - Incremental push/fetch produces archive files (remote and local).
+##  - GC then Archive, then push to AWS.


### PR DESCRIPTION
These changes enable Dolt databases containing archive storage to perform file based backups/restores, and AWS backups/restores, push, pull, and clone operations.

Currently all incremental pushes and fetches produce table files, not archives. The use of `backup`
allows us to get archive files pushed into S3 for testing.