### PR TITLE
[no-release-notes] go/store/nbs: NomsBlockStore.UpdateManifest{,WithAppendix} pre-open table files before the manifest updates.

### DIFF
--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -418,26 +418,6 @@ func (nbs *NomsBlockStore) UpdateManifestWithAppendix(ctx context.Context, updat
 	return mi, err
 }
 
-func (nbs *NomsBlockStore) checkAllManifestUpdatesExist(ctx context.Context, updates map[hash.Hash]uint32) error {
-	eg, ctx := errgroup.WithContext(ctx)
-	eg.SetLimit(128)
-	for h, c := range updates {
-		name := h
-		c := c
-		eg.Go(func() error {
-			ok, err := nbs.p.Exists(ctx, name.String(), c, nbs.stats)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return fmt.Errorf("missing table file referenced in UpdateManifest call: %v", h)
-			}
-			return nil
-		})
-	}
-	return eg.Wait()
-}
-
 func fromManifestAppendixOptionNewContents(upstream manifestContents, appendixSpecs []tableSpec, option ManifestAppendixOption) (manifestContents, error) {
 	contents, upstreamAppendixSpecs := upstream.removeAppendixSpecs()
 	switch option {


### PR DESCRIPTION
This brings them in line with AddTableFilesToManifest.

UpdateManifest{,WithAppendix} are used by some implementations of dolt.services.remotesapi.v1alpha1.ChunkStoreService. Opening the table files is only less efficient if updateManifestAddFiles encounters an error, but it is safer because it ensures the table files are able to be opened before the added to the manifest itself. We do not expect updateManifestAddFiles to encounter errors - its only error condition is an I/O error on updating the manifest itself, or, previously, errors on opening the newly added table files.