### PR TITLE
[no-release-notes] integration-tests/bats: garbage_collection.bats: Fix flakiness stemming from times appear in ls output that we use for cmp.

### DIFF
--- a/integration-tests/bats/garbage_collection.bats
+++ b/integration-tests/bats/garbage_collection.bats
@@ -475,16 +475,16 @@ SQL
     cd one/two
     dolt init
     rm -rf .dolt/stats
-    ls -laR > ../../before_gc
+    ls -laR | grep -v '^d' > ../../before_gc
     dolt gc
     manifest_first_gc=$(cat .dolt/noms/manifest)
     rm -rf .dolt/stats
-    ls -laR > ../../after_first_gc
+    ls -laR | grep -v '^d' > ../../after_first_gc
     cp ./.dolt/noms/manifest ../../manifest_after_first_gc
     dolt gc
     manifest_second_gc=$(cat .dolt/noms/manifest)
     rm -rf .dolt/stats
-    ls -laR > ../../after_second_gc
+    ls -laR | grep -v '^d' > ../../after_second_gc
     # This should exit 0 because the gc should have changed things.
     if cmp ../../before_gc ../../after_first_gc; then
         echo "expected dolt gc to change things, but it didn't."
@@ -504,14 +504,14 @@ SQL
     cd one/two
     dolt init
     rm -rf .dolt/stats
-    ls -laR > ../../before_gc
+    ls -laR | grep -v '^d' > ../../before_gc
     dolt gc --full
     rm -rf .dolt/stats
-    ls -laR > ../../after_first_gc
+    ls -laR | grep -v '^d' > ../../after_first_gc
     cp ./.dolt/noms/manifest ../../manifest_after_first_gc
     dolt gc --full
     rm -rf .dolt/stats
-    ls -laR > ../../after_second_gc
+    ls -laR | grep -v '^d' > ../../after_second_gc
     # This should exit 0 because the gc should have changed things.
     if cmp ../../before_gc ../../after_first_gc; then
         echo "expected dolt gc to change things, but it didn't."
@@ -531,14 +531,14 @@ SQL
     cd one/two
     dolt init
     rm -rf .dolt/stats
-    ls -laR > ../../before_gc
+    ls -laR | grep -v '^d' > ../../before_gc
     dolt gc --full
     rm -rf .dolt/stats
-    ls -laR > ../../after_first_gc
+    ls -laR | grep -v '^d' > ../../after_first_gc
     cp ./.dolt/noms/manifest ../../manifest_after_first_gc
     dolt gc
     rm -rf .dolt/stats
-    ls -laR > ../../after_second_gc
+    ls -laR | grep -v '^d' > ../../after_second_gc
     # This should exit 0 because the gc should have changed things.
     if cmp ../../before_gc ../../after_first_gc; then
         echo "expected dolt gc to change things, but it didn't."
@@ -558,10 +558,10 @@ SQL
     cd one/two
     dolt init
     rm -rf .dolt/stats
-    ls -laR > ../../files_before_gc
+    ls -laR | grep -v '^d' > ../../files_before_gc
     dolt gc
     rm -rf .dolt/stats
-    ls -laR > ../../files_after_first_gc
+    ls -laR | grep -v '^d' > ../../files_after_first_gc
     cp ./.dolt/noms/manifest ../../manifest_after_first_gc
     dolt gc --full
     rm -rf .dolt/stats


### PR DESCRIPTION
These bats tests perform some GCs and inspect filesystem state to assert that either nothing changed for a noop GC or that things actually did change for a non-noop GC. When the inspect the filesystem state, the `ls` output includes mtimes for the files and directories. `.dolt/stats` actually does, or at least can, change across these runs, and so it is explicitly removed before the comparison is done. That means the mtime on the `.dolt` directory itself changes. These timestamps are at minute resolution, and so the tests normally pass, but if the interactions happen in two separate minutes, they fail.

This change removes the directories themselves from the listing, leaving the files all in place. This asserts that the files' sizes and mtimes haven't (or have) changed across the `dolt gc` runs.