### PR TITLE
[no-release-notes] go/store/nbs: Fix some minor bugs affecting doltremoteapi in nbs/store.

### DIFF
--- a/go/store/nbs/aws_table_persister.go
+++ b/go/store/nbs/aws_table_persister.go
@@ -94,7 +94,11 @@ func (s3p awsTablePersister) Open(ctx context.Context, name hash.Hash, chunkCoun
 		return emptyChunkSource{}, err
 	}
 
-	e, err2 := s3p.Exists(ctx, name.String()+ArchiveFileSuffix, chunkCount, stats)
+	archiveKey := name.String() + ArchiveFileSuffix
+	if s3p.ns != "" {
+		archiveKey = s3p.ns + "/" + archiveKey
+	}
+	e, err2 := s3p.Exists(ctx, archiveKey, chunkCount, stats)
 	if e && err2 == nil {
 		return newAWSArchiveChunkSource(
 			ctx,

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -291,7 +291,7 @@ func (nbs *NomsBlockStore) conjoinIfRequired(ctx context.Context) (bool, error) 
 func (nbs *NomsBlockStore) UpdateManifest(ctx context.Context, updates map[hash.Hash]uint32) (ManifestInfo, error) {
 	chunkSources, _, err := nbs.openChunkSourcesForAddTableFiles(ctx, updates)
 	if err != nil {
-		return manifestContents{}, nil
+		return manifestContents{}, err
 	}
 	// If these sources get added to the store, they will get cloned.
 	// Either way, we want to close these instances when we are done.
@@ -409,7 +409,7 @@ func (nbs *NomsBlockStore) updateManifestAddFiles(ctx context.Context, updates m
 func (nbs *NomsBlockStore) UpdateManifestWithAppendix(ctx context.Context, updates map[hash.Hash]uint32, option ManifestAppendixOption) (ManifestInfo, error) {
 	chunkSources, _, err := nbs.openChunkSourcesForAddTableFiles(ctx, updates)
 	if err != nil {
-		return manifestContents{}, nil
+		return manifestContents{}, err
 	}
 	// If these sources get added to the store, they will get cloned.
 	// Either way, we want to close these instances when we are done.


### PR DESCRIPTION
UpdateManifest{,WithAppendex} accidentally dropped an error when opening the new table files failed. Make them correctly return the error.

awsTablePersister was not respecting the namespace setting when checking for an archive file's existence when opening a table file.