### PR TITLE
[statspro] stats ignore non prolly indexes

### DIFF
--- a/go/cmd/dolt/commands/debug.go
+++ b/go/cmd/dolt/commands/debug.go
@@ -360,10 +360,8 @@ func debugAnalyze(ctx *sql.Context, tempDir string, sqlEng *engine.SqlEngine, sq
 
 	eng := sqlEng.GetUnderlyingEngine()
 	eng.Analyzer.Debug = true
-	eng.Analyzer.Verbose = true
 	defer func() {
 		eng.Analyzer.Debug = false
-		eng.Analyzer.Verbose = false
 	}()
 	analysisFile, err := os.Create(filepath.Join(tempDir, "analysis.txt"))
 	if err != nil {
@@ -377,8 +375,6 @@ func debugAnalyze(ctx *sql.Context, tempDir string, sqlEng *engine.SqlEngine, sq
 	}
 	defer planFile.Close()
 	planBuf := bufio.NewWriter(planFile)
-
-	defer planBuf.Flush()
 
 	analyzer.SetOutput(analysisFile)
 	logrus.SetOutput(analysisFile)
@@ -417,7 +413,6 @@ func debugAnalyze(ctx *sql.Context, tempDir string, sqlEng *engine.SqlEngine, sq
 
 		planned, err := eng.AnalyzeQuery(ctx, query)
 		if err != nil {
-			fmt.Fprintf(planBuf, "error: %s\n", err.Error())
 			return err
 		}
 
@@ -426,7 +421,7 @@ func debugAnalyze(ctx *sql.Context, tempDir string, sqlEng *engine.SqlEngine, sq
 		fmt.Fprintf(planBuf, "debug plan: \n%s", sql.DebugString(planned))
 	}
 
-	return nil
+	return planBuf.Flush()
 }
 
 func execDebugMode(ctx *sql.Context, qryist cli.Queryist, queryFile *os.File, continueOnErr bool, format engine.PrintResultFormat) error {

--- a/go/libraries/doltcore/doltdb/durable/index.go
+++ b/go/libraries/doltcore/doltdb/durable/index.go
@@ -277,6 +277,17 @@ func ProllyMapFromIndex(i Index) prolly.Map {
 	return i.(prollyIndex).index
 }
 
+// xxx: don't use this, temporary fix waiting for bigger
+// fix in stats 2.0
+func MaybeProllyMapFromIndex(i Index) (prolly.Map, bool) {
+	ret, ok := i.(prollyIndex)
+	if ok {
+		return ret.index, true
+	} else {
+		return prolly.Map{}, false
+	}
+}
+
 // MapFromIndex unwraps the Index and returns the underlying map as an interface.
 func MapFromIndex(i Index) prolly.MapInterfaceWithMutable {
 	switch indexType := i.(type) {

--- a/go/libraries/doltcore/sqle/enginetest/stats_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/stats_queries.go
@@ -332,6 +332,31 @@ var DoltStatsStorageTests = []queries.ScriptTest{
 		},
 	},
 	{
+		Name: "issue 8964: alternative indexes panic",
+		SetUpScript: []string{
+			"create table geom_tbl(g geometry not null srid 0)",
+			"insert into geom_tbl values (point(0,0)), (linestring(point(1,1), point(2,2)))",
+			"alter table geom_tbl add spatial index (g)",
+			"CREATE TABLE fullt_tbl (pk BIGINT UNSIGNED PRIMARY KEY, v1 VARCHAR(200), v2 VARCHAR(200), FULLTEXT idx (v1, v2));",
+			"INSERT INTO fullt_tbl VALUES (1, 'abc', 'def pqr'), (2, 'ghi', 'jkl'), (3, 'mno', 'mno'), (4, 'stu vwx', 'xyz zyx yzx'), (5, 'ghs', 'mno shg');",
+			"create table vector_tbl (id int primary key, v json);",
+			`insert into vector_tbl values (1, '[4.0,3.0]'), (2, '[0.0,0.0]'), (3, '[-1.0,1.0]'), (4, '[0.0,-2.0]');`,
+			`create vector index v_idx on vector_tbl(v);`,
+			"create table gen_tbl (a  int primary key, b int as (a + 1) stored)",
+			"insert into gen_tbl (a) values (0), (1), (2)",
+			"create index i1 on gen_tbl(b)",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "analyze table geom_tbl, fullt_tbl, vector_tbl, gen_tbl",
+			},
+			{
+				Query:    "select table_name, index_name from dolt_statistics",
+				Expected: []sql.Row{{"fullt_tbl", "primary"}, {"gen_tbl", "primary"}, {"gen_tbl", "i1"}, {"vector_tbl", "primary"}},
+			},
+		},
+	},
+	{
 		Name: "comma encoding bug",
 		SetUpScript: []string{
 			`create table a (a varbinary (32) primary key)`,

--- a/go/libraries/doltcore/sqle/statspro/auto_refresh.go
+++ b/go/libraries/doltcore/sqle/statspro/auto_refresh.go
@@ -228,9 +228,12 @@ func (p *Provider) checkRefresh(ctx *sql.Context, sqlDb sql.Database, dbName, br
 			}
 			ctx.GetLogger().Debugf("statistics refresh index: %s", qual.String())
 
-			updateMeta, err := newIdxMeta(ctx, curStat, dTab, index, curStat.Columns())
+			updateMeta, ok, err := newIdxMeta(ctx, curStat, dTab, index, curStat.Columns())
 			if err != nil {
 				ctx.GetLogger().Debugf("statistics refresh error: %s", err.Error())
+				continue
+			}
+			if !ok {
 				continue
 			}
 			curCnt := float64(len(curStat.Active))

--- a/go/libraries/doltcore/sqle/statspro/update.go
+++ b/go/libraries/doltcore/sqle/statspro/update.go
@@ -53,6 +53,10 @@ func createNewStatsBuckets(ctx *sql.Context, sqlTable sql.Table, dTab *doltdb.Ta
 	ret := make(map[sql.StatQualifier]*DoltStats)
 
 	for _, meta := range idxMetas {
+		sqlIdx := nameToIdx[strings.ToLower(meta.qual.Index())]
+		if sqlIdx.IsSpatial() || sqlIdx.IsFullText() || sqlIdx.IsGenerated() || sqlIdx.IsVector() {
+			continue
+		}
 		var idx durable.Index
 		var err error
 		if strings.EqualFold(meta.qual.Index(), "PRIMARY") {
@@ -67,7 +71,6 @@ func createNewStatsBuckets(ctx *sql.Context, sqlTable sql.Table, dTab *doltdb.Ta
 		prollyMap := durable.ProllyMapFromIndex(idx)
 		keyBuilder := val.NewTupleBuilder(prollyMap.KeyDesc())
 
-		sqlIdx := nameToIdx[strings.ToLower(meta.qual.Index())]
 		fds, colSet, err := stats.IndexFds(meta.qual.Table(), sqlTable.Schema(), sqlIdx)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Stats collection skips non-prolly indexes. A more complete/safe refactoring of index use is in the new stats PR.

fixes: https://github.com/dolthub/dolt/issues/8964