### PR TITLE
[no-release-notes] compress dictionary

### DIFF
--- a/go/store/nbs/archive_writer.go
+++ b/go/store/nbs/archive_writer.go
@@ -24,8 +24,9 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/gozstd"
+
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 type stagedByteSpanSlice []byteSpan

--- a/go/store/nbs/archive_writer.go
+++ b/go/store/nbs/archive_writer.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 
 	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/dolthub/gozstd"
 )
 
 type stagedByteSpanSlice []byteSpan
@@ -544,8 +545,11 @@ func (asw *ArchiveStreamWriter) writeArchiveToChunker(chunker ArchiveToChunker) 
 	var err error
 	dictId, ok := asw.dictMap[dict]
 	if !ok {
+		// compress the raw bytes of the dictionary before persisting it.
+		compressedDict := gozstd.Compress(nil, *dict.rawDictionary)
+
 		// New dictionary. Write it out, and add id to the map.
-		dictId, err = asw.writer.writeByteSpan(*dict.rawDictionary)
+		dictId, err = asw.writer.writeByteSpan(compressedDict)
 		if err != nil {
 			return 0, err
 		}


### PR DESCRIPTION
Missed compressing the dictionary when building an archive streaming writer.

Added test which fails without the fix.