### PR TITLE
Remove duplicate `github.com/vbauerster/mpb` dependency

### DIFF
--- a/go/cmd/dolt/cli/stdio_test.go
+++ b/go/cmd/dolt/cli/stdio_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/vbauerster/mpb/cwriter"
 )
 
 func TestEphemeralPrinter(t *testing.T) {
@@ -64,6 +63,15 @@ func TestEphemeralPrinter(t *testing.T) {
 	})
 }
 
+// clearLinesTxt moves cursor up n lines and clears the screen from the cursor position to the end.
+// Inspired by https://github.com/vbauerster/mpb/blob/v8.0.2/cwriter/writer.go#L11-L15.
 func clearLinesTxt(n int) string {
-	return fmt.Sprintf("%c[%dA", cwriter.ESC, n) + fmt.Sprintf("%c[J", cwriter.ESC)
+	// These are ANSI escape codes, see
+	//  - https://en.wikipedia.org/wiki/ANSI_escape_code#C0_control_codes1
+	//  - https://en.wikipedia.org/wiki/ANSI_escape_code#Control_Sequence_Introducer_commands
+	//
+	// \x1b: ESC (Escape)
+	// [%dA: CUU (Cursor Up). [5A means moves the cursor up 5 lines
+	// [J  : ED (Erase in Display)
+	return fmt.Sprintf("\x1b[%dA\x1b[J", n)
 }

--- a/go/go.mod
+++ b/go/go.mod
@@ -80,7 +80,6 @@ require (
 	github.com/shirou/gopsutil/v3 v3.22.1
 	github.com/tidwall/gjson v1.14.4
 	github.com/tidwall/sjson v1.2.5
-	github.com/vbauerster/mpb v3.4.0+incompatible
 	github.com/vbauerster/mpb/v8 v8.0.2
 	github.com/xitongsys/parquet-go v1.6.1
 	github.com/xitongsys/parquet-go-source v0.0.0-20211010230925-397910c5e371

--- a/go/go.sum
+++ b/go/go.sum
@@ -722,8 +722,6 @@ github.com/tklauser/numcpus v0.3.0/go.mod h1:yFGUr7TUHQRAhyqBcEg0Ge34zDBAsIvJJcy
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/vbauerster/mpb v3.4.0+incompatible h1:mfiiYw87ARaeRW6x5gWwYRUawxaW1tLAD8IceomUCNw=
-github.com/vbauerster/mpb v3.4.0+incompatible/go.mod h1:zAHG26FUhVKETRu+MWqYXcI70POlC6N8up9p1dID7SU=
 github.com/vbauerster/mpb/v8 v8.0.2 h1:alVQG69Jg5+Ku9Hu1dakDx50uACEHnIzS7i356NQ/Vs=
 github.com/vbauerster/mpb/v8 v8.0.2/go.mod h1:Z9VJYIzXls7xZwirZjShGsi+14enzJhQfGyb/XZK0ZQ=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=


### PR DESCRIPTION
https://github.com/dolthub/dolt/blob/b7c0ddb4aac3702114c4e060651007d590a8be8c/go/cmd/dolt/cli/stdio.go#L28

https://github.com/dolthub/dolt/blob/b7c0ddb4aac3702114c4e060651007d590a8be8c/go/cmd/dolt/cli/stdio_test.go#L23

It's weird that we use the tagged `v8` version in the source code but non-tagged version in the test.