### PR TITLE
[no-release-notes] integration-tests/go-sql-server-driver: Add dynamic port allocation and run these tests in parallel.

### DIFF
--- a/integration-tests/go-sql-server-driver/gc_oldgen_conjoin_test.go
+++ b/integration-tests/go-sql-server-driver/gc_oldgen_conjoin_test.go
@@ -29,6 +29,10 @@ import (
 )
 
 func TestGCConjoinsOldgen(t *testing.T) {
+	t.Parallel()
+	var ports DynamicPorts
+	ports.global = &GlobalPorts
+	ports.t = t
 	u, err := driver.NewDoltUser()
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -41,7 +45,10 @@ func TestGCConjoinsOldgen(t *testing.T) {
 	repo, err := rs.MakeRepo("concurrent_gc_test")
 	require.NoError(t, err)
 
-	server := MakeServer(t, repo, &driver.Server{})
+	server := MakeServer(t, repo, &driver.Server{
+		Args: []string{"--port", "{{get_port \"server\"}}"},
+		DynamicPort: "server",
+	}, &ports)
 	server.DBName = "concurrent_gc_test"
 
 	db, err := server.DB(driver.Connection{User: "root"})

--- a/integration-tests/go-sql-server-driver/gc_oldgen_conjoin_test.go
+++ b/integration-tests/go-sql-server-driver/gc_oldgen_conjoin_test.go
@@ -46,7 +46,7 @@ func TestGCConjoinsOldgen(t *testing.T) {
 	require.NoError(t, err)
 
 	server := MakeServer(t, repo, &driver.Server{
-		Args: []string{"--port", "{{get_port \"server\"}}"},
+		Args: []string{"--port", `{{get_port "server"}}`},
 		DynamicPort: "server",
 	}, &ports)
 	server.DBName = "concurrent_gc_test"

--- a/integration-tests/go-sql-server-driver/genjwt_test.go
+++ b/integration-tests/go-sql-server-driver/genjwt_test.go
@@ -20,7 +20,7 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -61,7 +61,7 @@ func GenerateTestJWTs(dir string) error {
 		return fmt.Errorf("could not generate jwt: %w", err)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(dir, "token.jwt"), []byte(jwt), 0644)
+	err = os.WriteFile(filepath.Join(dir, "token.jwt"), []byte(jwt), 0644)
 	if err != nil {
 		return fmt.Errorf("could not write jwt to file: %w", err)
 	}
@@ -82,7 +82,7 @@ func writeJWKSToFile(dir string, pubKey crypto.PublicKey, kid string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(filepath.Join(dir, "test_jwks.json"), jwksjson, 0644)
+	err = os.WriteFile(filepath.Join(dir, "test_jwks.json"), jwksjson, 0644)
 	if err != nil {
 		return err
 	}

--- a/integration-tests/go-sql-server-driver/main_test.go
+++ b/integration-tests/go-sql-server-driver/main_test.go
@@ -49,26 +49,41 @@ func TestMain(m *testing.M) {
 	}
 	os.Setenv("TESTGENDIR", gendir)
 	flag.Parse()
+	InitGlobalDynamicPorts()
 	os.Exit(m.Run())
 }
 
+func InitGlobalDynamicPorts() {
+	// XXX: Max and min here could be supplied by flags. Currently
+	// tests use at most 6 ports, so this may run out of ports if
+	// we have more than ~40 concurrent processes.
+	for i := 0; i < 256; i++ {
+		GlobalPorts.available = append(GlobalPorts.available, 3306 + i)
+	}
+}
+
 func TestConfig(t *testing.T) {
+	t.Parallel()
 	RunTestsFile(t, "tests/sql-server-config.yaml")
 }
 
 func TestJWTAuth(t *testing.T) {
+	t.Parallel()
 	RunTestsFile(t, "tests/sql-server-jwt-auth.yaml")
 }
 
 func TestCluster(t *testing.T) {
+	t.Parallel()
 	RunTestsFile(t, "tests/sql-server-cluster.yaml")
 }
 
 func TestClusterUsersAndGrants(t *testing.T) {
+	t.Parallel()
 	RunTestsFile(t, "tests/sql-server-cluster-users-and-grants.yaml")
 }
 
 func TestRemotesAPI(t *testing.T) {
+	t.Parallel()
 	RunTestsFile(t, "tests/sql-server-remotesapi.yaml")
 }
 
@@ -80,17 +95,21 @@ func TestSingle(t *testing.T) {
 }
 
 func TestClusterTLS(t *testing.T) {
+	t.Parallel()
 	RunTestsFile(t, "tests/sql-server-cluster-tls.yaml")
 }
 
 func TestOriginal(t *testing.T) {
+	t.Parallel()
 	RunTestsFile(t, "tests/sql-server-orig.yaml")
 }
 
 func TestTLS(t *testing.T) {
+	t.Parallel()
 	RunTestsFile(t, "tests/sql-server-tls.yaml")
 }
 
 func TestClusterReadOnly(t *testing.T) {
+	t.Parallel()
 	RunTestsFile(t, "tests/sql-server-cluster-read-only.yaml")
 }

--- a/integration-tests/go-sql-server-driver/sqlserver_info_test.go
+++ b/integration-tests/go-sql-server-driver/sqlserver_info_test.go
@@ -49,7 +49,7 @@ func TestSQLServerInfoFile(t *testing.T) {
 			ports.global = &GlobalPorts
 			ports.t = t
 			RunServerUntilEndOfTest(t, rs, &driver.Server{
-				Args: []string{"--port", "{{get_port \"server_one\"}}"},
+				Args: []string{"--port", `{{get_port "server_one"}}`},
 				DynamicPort: "server_one",
 			}, &ports)
 
@@ -61,7 +61,7 @@ func TestSQLServerInfoFile(t *testing.T) {
 			})
 			t.Run("Running again in root fails", func(t *testing.T) {
 				_ = MakeServer(t, rs, &driver.Server{
-					Args: []string{"--port", "{{get_port \"server_two\"}}"},
+					Args: []string{"--port", `{{get_port "server_two"}}`},
 					DynamicPort: "server_two",
 					ErrorMatches: []string{
 						"locked by another dolt process",
@@ -70,7 +70,7 @@ func TestSQLServerInfoFile(t *testing.T) {
 			})
 			t.Run("Running in db_one fails", func(t *testing.T) {
 				_ = MakeServer(t, dbOne, &driver.Server{
-					Args: []string{"--port", "{{get_port \"server_two\"}}"},
+					Args: []string{"--port", `{{get_port "server_two"}}`},
 					DynamicPort: "server_two",
 					ErrorMatches: []string{
 						"locked by another dolt process",
@@ -122,13 +122,13 @@ func TestSQLServerInfoFile(t *testing.T) {
 			ports.global = &GlobalPorts
 			ports.t = t
 			RunServerUntilEndOfTest(t, dbOne, &driver.Server{
-				Args: []string{"--port", "{{get_port \"server_one\"}}"},
+				Args: []string{"--port", `{{get_port "server_one"}}`},
 				DynamicPort: "server_one",
 			}, &ports)
 
 			t.Run("Running server in root fails", func(t *testing.T) {
 				_ = MakeServer(t, rs, &driver.Server{
-					Args: []string{"--port", "{{get_port \"server_two\"}}"},
+					Args: []string{"--port", `{{get_port "server_two"}}`},
 					DynamicPort: "server_two",
 					ErrorMatches: []string{
 						"locked by another dolt process",
@@ -137,7 +137,7 @@ func TestSQLServerInfoFile(t *testing.T) {
 			})
 			t.Run("Running server in db_two succeeds", func(t *testing.T) {
 				RunServerUntilEndOfTest(t, dbTwo, &driver.Server{
-					Args: []string{"--port", "{{get_port \"server_two\"}}"},
+					Args: []string{"--port", `{{get_port "server_two"}}`},
 					DynamicPort: "server_two",
 				}, &ports)
 			})
@@ -168,7 +168,7 @@ func TestSQLServerInfoFile(t *testing.T) {
 
 			t.Run("Running server in root fails", func(t *testing.T) {
 				_ = MakeServer(t, rs, &driver.Server{
-					Args: []string{"--port", "{{get_port \"server_two\"}}"},
+					Args: []string{"--port", `{{get_port "server_two"}}`},
 					DynamicPort: "server_two",
 					ErrorMatches: []string{
 						"locked by another dolt process",
@@ -177,7 +177,7 @@ func TestSQLServerInfoFile(t *testing.T) {
 			})
 			t.Run("Running server in db_one fails", func(t *testing.T) {
 				_ = MakeServer(t, dbOne, &driver.Server{
-					Args: []string{"--port", "{{get_port \"server_two\"}}"},
+					Args: []string{"--port", `{{get_port "server_two"}}`},
 					DynamicPort: "server_two",
 					ErrorMatches: []string{
 						"locked by another dolt process",
@@ -206,7 +206,7 @@ func TestSQLServerInfoFile(t *testing.T) {
 
 			t.Run("Running server in root fails", func(t *testing.T) {
 				_ = MakeServer(t, rs, &driver.Server{
-					Args: []string{"--port", "{{get_port \"server_two\"}}"},
+					Args: []string{"--port", `{{get_port "server_two"}}`},
 					DynamicPort: "server_two",
 					ErrorMatches: []string{
 						"locked by another dolt process",
@@ -215,7 +215,7 @@ func TestSQLServerInfoFile(t *testing.T) {
 			})
 			t.Run("Running server in db_one fails", func(t *testing.T) {
 				_ = MakeServer(t, dbOne, &driver.Server{
-					Args: []string{"--port", "{{get_port \"server_two\"}}"},
+					Args: []string{"--port", `{{get_port "server_two"}}`},
 					DynamicPort: "server_two",
 					ErrorMatches: []string{
 						"locked by another dolt process",
@@ -224,7 +224,7 @@ func TestSQLServerInfoFile(t *testing.T) {
 			})
 			t.Run("Running server in db_two succeeds", func(t *testing.T) {
 				RunServerUntilEndOfTest(t, dbTwo, &driver.Server{
-					Args: []string{"--port", "{{get_port \"server_two\"}}"},
+					Args: []string{"--port", `{{get_port "server_two"}}`},
 					DynamicPort: "server_two",
 				}, &ports)
 			})
@@ -260,14 +260,14 @@ func TestSQLServerInfoFile(t *testing.T) {
 			t.Run("sql-server can run in root", func(t *testing.T) {
 				Setup(t)
 				RunServerUntilEndOfTest(t, rs, &driver.Server{
-					Args: []string{"--port", "{{get_port \"server_one\"}}"},
+					Args: []string{"--port", `{{get_port "server_one"}}`},
 					DynamicPort: "server_one",
 				}, &ports)
 			})
 			t.Run("sql-server can run in db_one", func(t *testing.T) {
 				Setup(t)
 				RunServerUntilEndOfTest(t, dbOne, &driver.Server{
-					Args: []string{"--port", "{{get_port \"server_one\"}}"},
+					Args: []string{"--port", `{{get_port "server_one"}}`},
 					DynamicPort: "server_one",
 				}, &ports)
 			})
@@ -302,14 +302,14 @@ func TestSQLServerInfoFile(t *testing.T) {
 			t.Run("sql-server can run in root", func(t *testing.T) {
 				Setup(t)
 				RunServerUntilEndOfTest(t, rs, &driver.Server{
-					Args: []string{"--port", "{{get_port \"server_one\"}}"},
+					Args: []string{"--port", `{{get_port "server_one"}}`},
 					DynamicPort: "server_one",
 				}, &ports)
 			})
 			t.Run("sql-server can run in db_one", func(t *testing.T) {
 				Setup(t)
 				RunServerUntilEndOfTest(t, rs, &driver.Server{
-					Args: []string{"--port", "{{get_port \"server_one\"}}"},
+					Args: []string{"--port", `{{get_port "server_one"}}`},
 					DynamicPort: "server_one",
 				}, &ports)
 			})
@@ -370,11 +370,11 @@ func TestSQLServerInfoFile(t *testing.T) {
 			ports.global = &GlobalPorts
 			ports.t = t
 			RunServerUntilEndOfTest(t, rs, &driver.Server{
-				Args: []string{"--port", "{{get_port \"server_one\"}}"},
+				Args: []string{"--port", `{{get_port "server_one"}}`},
 				DynamicPort: "server_one",
 			}, &ports)
 			RunServerUntilEndOfTest(t, rs, &driver.Server{
-				Args: []string{"--port", "{{get_port \"server_two\"}}"},
+				Args: []string{"--port", `{{get_port "server_two"}}`},
 				DynamicPort: "server_two",
 			}, &ports)
 		})

--- a/integration-tests/go-sql-server-driver/sqlserver_info_test.go
+++ b/integration-tests/go-sql-server-driver/sqlserver_info_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestSQLServerInfoFile(t *testing.T) {
+	t.Parallel()
 	t.Run("With Two Repos", func(t *testing.T) {
 		u, err := driver.NewDoltUser()
 		require.NoError(t, err)
@@ -44,7 +45,13 @@ func TestSQLServerInfoFile(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Run("With server running in root", func(t *testing.T) {
-			RunServerUntilEndOfTest(t, rs, &driver.Server{})
+			var ports DynamicPorts
+			ports.global = &GlobalPorts
+			ports.t = t
+			RunServerUntilEndOfTest(t, rs, &driver.Server{
+				Args: []string{"--port", "{{get_port \"server_one\"}}"},
+				DynamicPort: "server_one",
+			}, &ports)
 
 			t.Run("sql-server.info file exists", func(t *testing.T) {
 				location := filepath.Join(rs.Dir, ".dolt/sql-server.info")
@@ -54,17 +61,21 @@ func TestSQLServerInfoFile(t *testing.T) {
 			})
 			t.Run("Running again in root fails", func(t *testing.T) {
 				_ = MakeServer(t, rs, &driver.Server{
+					Args: []string{"--port", "{{get_port \"server_two\"}}"},
+					DynamicPort: "server_two",
 					ErrorMatches: []string{
 						"locked by another dolt process",
 					},
-				})
+				}, &ports)
 			})
 			t.Run("Running in db_one fails", func(t *testing.T) {
 				_ = MakeServer(t, dbOne, &driver.Server{
+					Args: []string{"--port", "{{get_port \"server_two\"}}"},
+					DynamicPort: "server_two",
 					ErrorMatches: []string{
 						"locked by another dolt process",
 					},
-				})
+				}, &ports)
 			})
 			t.Run("Running dolt sql -q in /server connects to server", func(t *testing.T) {
 				cmd := rs.DoltCmd("sql", "-q", "show databases")
@@ -107,20 +118,28 @@ func TestSQLServerInfoFile(t *testing.T) {
 			require.ErrorIs(t, err, fs.ErrNotExist)
 		})
 		t.Run("With server running in db_one", func(t *testing.T) {
-			RunServerUntilEndOfTest(t, dbOne, &driver.Server{})
+			var ports DynamicPorts
+			ports.global = &GlobalPorts
+			ports.t = t
+			RunServerUntilEndOfTest(t, dbOne, &driver.Server{
+				Args: []string{"--port", "{{get_port \"server_one\"}}"},
+				DynamicPort: "server_one",
+			}, &ports)
 
 			t.Run("Running server in root fails", func(t *testing.T) {
 				_ = MakeServer(t, rs, &driver.Server{
+					Args: []string{"--port", "{{get_port \"server_two\"}}"},
+					DynamicPort: "server_two",
 					ErrorMatches: []string{
 						"locked by another dolt process",
 					},
-				})
+				}, &ports)
 			})
 			t.Run("Running server in db_two succeeds", func(t *testing.T) {
 				RunServerUntilEndOfTest(t, dbTwo, &driver.Server{
-					Args: []string{"--port", "3310"},
-					Port: 3310,
-				})
+					Args: []string{"--port", "{{get_port \"server_two\"}}"},
+					DynamicPort: "server_two",
+				}, &ports)
 			})
 			t.Run("dolt sql -q in root succeeds", func(t *testing.T) {
 				cmd := rs.DoltCmd("sql", "-q", "show databases")
@@ -142,21 +161,28 @@ func TestSQLServerInfoFile(t *testing.T) {
 			})
 		})
 		t.Run("Given a running dolt sql process in root", func(t *testing.T) {
+			var ports DynamicPorts
+			ports.global = &GlobalPorts
+			ports.t = t
 			RunDoltSQLUntilEndOfTest(t, rs)
 
 			t.Run("Running server in root fails", func(t *testing.T) {
 				_ = MakeServer(t, rs, &driver.Server{
+					Args: []string{"--port", "{{get_port \"server_two\"}}"},
+					DynamicPort: "server_two",
 					ErrorMatches: []string{
 						"locked by another dolt process",
 					},
-				})
+				}, &ports)
 			})
 			t.Run("Running server in db_one fails", func(t *testing.T) {
 				_ = MakeServer(t, dbOne, &driver.Server{
+					Args: []string{"--port", "{{get_port \"server_two\"}}"},
+					DynamicPort: "server_two",
 					ErrorMatches: []string{
 						"locked by another dolt process",
 					},
-				})
+				}, &ports)
 			})
 			t.Run("dolt sql -q in root succeeds", func(t *testing.T) {
 				cmd := rs.DoltCmd("sql", "-q", "show databases")
@@ -173,24 +199,34 @@ func TestSQLServerInfoFile(t *testing.T) {
 			})
 		})
 		t.Run("Given a running dolt sql process in db_one", func(t *testing.T) {
+			var ports DynamicPorts
+			ports.global = &GlobalPorts
+			ports.t = t
 			RunDoltSQLUntilEndOfTest(t, dbOne)
 
 			t.Run("Running server in root fails", func(t *testing.T) {
 				_ = MakeServer(t, rs, &driver.Server{
+					Args: []string{"--port", "{{get_port \"server_two\"}}"},
+					DynamicPort: "server_two",
 					ErrorMatches: []string{
 						"locked by another dolt process",
 					},
-				})
+				}, &ports)
 			})
 			t.Run("Running server in db_one fails", func(t *testing.T) {
 				_ = MakeServer(t, dbOne, &driver.Server{
+					Args: []string{"--port", "{{get_port \"server_two\"}}"},
+					DynamicPort: "server_two",
 					ErrorMatches: []string{
 						"locked by another dolt process",
 					},
-				})
+				}, &ports)
 			})
 			t.Run("Running server in db_two succeeds", func(t *testing.T) {
-				RunServerUntilEndOfTest(t, dbTwo, &driver.Server{})
+				RunServerUntilEndOfTest(t, dbTwo, &driver.Server{
+					Args: []string{"--port", "{{get_port \"server_two\"}}"},
+					DynamicPort: "server_two",
+				}, &ports)
 			})
 			t.Run("dolt sql -q in root succeeds", func(t *testing.T) {
 				cmd := rs.DoltCmd("sql", "-q", "show databases")
@@ -212,6 +248,9 @@ func TestSQLServerInfoFile(t *testing.T) {
 			})
 		})
 		t.Run("With stale sql-server.info file in root", func(t *testing.T) {
+			var ports DynamicPorts
+			ports.global = &GlobalPorts
+			ports.t = t
 			Setup := func(t *testing.T) {
 				path := filepath.Join(rs.Dir, ".dolt/sql-server.info")
 				err := os.WriteFile(path, []byte("1:3306:this_is_not_a_real_secret"), 0600)
@@ -220,11 +259,17 @@ func TestSQLServerInfoFile(t *testing.T) {
 			}
 			t.Run("sql-server can run in root", func(t *testing.T) {
 				Setup(t)
-				RunServerUntilEndOfTest(t, rs, &driver.Server{})
+				RunServerUntilEndOfTest(t, rs, &driver.Server{
+					Args: []string{"--port", "{{get_port \"server_one\"}}"},
+					DynamicPort: "server_one",
+				}, &ports)
 			})
 			t.Run("sql-server can run in db_one", func(t *testing.T) {
 				Setup(t)
-				RunServerUntilEndOfTest(t, dbOne, &driver.Server{})
+				RunServerUntilEndOfTest(t, dbOne, &driver.Server{
+					Args: []string{"--port", "{{get_port \"server_one\"}}"},
+					DynamicPort: "server_one",
+				}, &ports)
 			})
 			t.Run("sql can run in root", func(t *testing.T) {
 				Setup(t)
@@ -245,6 +290,9 @@ func TestSQLServerInfoFile(t *testing.T) {
 			})
 		})
 		t.Run("With malformed sql-server.info file in root", func(t *testing.T) {
+			var ports DynamicPorts
+			ports.global = &GlobalPorts
+			ports.t = t
 			Setup := func(t *testing.T) {
 				path := filepath.Join(rs.Dir, ".dolt/sql-server.info")
 				err := os.WriteFile(path, []byte("1:3306:this_is_not_a_real_secret:extra:fields:make:it:fail"), 0600)
@@ -253,11 +301,17 @@ func TestSQLServerInfoFile(t *testing.T) {
 			}
 			t.Run("sql-server can run in root", func(t *testing.T) {
 				Setup(t)
-				RunServerUntilEndOfTest(t, rs, &driver.Server{})
+				RunServerUntilEndOfTest(t, rs, &driver.Server{
+					Args: []string{"--port", "{{get_port \"server_one\"}}"},
+					DynamicPort: "server_one",
+				}, &ports)
 			})
 			t.Run("sql-server can run in db_one", func(t *testing.T) {
 				Setup(t)
-				RunServerUntilEndOfTest(t, rs, &driver.Server{})
+				RunServerUntilEndOfTest(t, rs, &driver.Server{
+					Args: []string{"--port", "{{get_port \"server_one\"}}"},
+					DynamicPort: "server_one",
+				}, &ports)
 			})
 			t.Run("sql can run in root", func(t *testing.T) {
 				Setup(t)
@@ -312,11 +366,17 @@ func TestSQLServerInfoFile(t *testing.T) {
 		// started, they can both run against it. Only one of their
 		// credential files will win the write.
 		t.Run("Can Run Two Servers At Once", func(t *testing.T) {
-			RunServerUntilEndOfTest(t, rs, &driver.Server{})
+			var ports DynamicPorts
+			ports.global = &GlobalPorts
+			ports.t = t
 			RunServerUntilEndOfTest(t, rs, &driver.Server{
-				Args: []string{"--port", "3309"},
-				Port: 3309,
-			})
+				Args: []string{"--port", "{{get_port \"server_one\"}}"},
+				DynamicPort: "server_one",
+			}, &ports)
+			RunServerUntilEndOfTest(t, rs, &driver.Server{
+				Args: []string{"--port", "{{get_port \"server_two\"}}"},
+				DynamicPort: "server_two",
+			}, &ports)
 		})
 	})
 }
@@ -359,8 +419,8 @@ func RunDoltSQLUntilEndOfTest(t *testing.T, dc driver.DoltCmdable) {
 // for doing things like making connections to it, this is only useful for
 // for asserting the behavior of other dolt commands which interact with the
 // server.
-func RunServerUntilEndOfTest(t *testing.T, dc driver.DoltCmdable, s *driver.Server) {
-	server := MakeServer(t, dc, s)
+func RunServerUntilEndOfTest(t *testing.T, dc driver.DoltCmdable, s *driver.Server, ports *DynamicPorts) {
+	server := MakeServer(t, dc, s, ports)
 	require.NotNil(t, server)
 	db, err := server.DB(driver.Connection{User: "root"})
 	require.NoError(t, err)

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster-read-only.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster-read-only.yaml
@@ -1,3 +1,4 @@
+parallel: false
 tests:
 - name: users and grants cannot be run on standby
   multi_repos:
@@ -8,18 +9,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -27,18 +28,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server2
     queries:
@@ -55,18 +56,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -74,18 +75,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server2
     queries:
@@ -100,18 +101,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -119,18 +120,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -152,18 +153,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -171,18 +172,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server2
     queries:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster-tls.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster-tls.yaml
@@ -1,3 +1,4 @@
+parallel: true
 tests:
 - name: tls, bad root, failover to standby fails
   multi_repos:
@@ -8,15 +9,15 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: https://localhost:3852/{database}
+            remote_url_template: https://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
             tls_key: key.pem
             tls_cert: cert.pem
             tls_ca: root.pem
@@ -28,7 +29,7 @@ tests:
       source_path: $TESTGENDIR/ed25519_root.pem
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -36,15 +37,15 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: https://localhost:3851/{database}
+            remote_url_template: https://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
             tls_key: key.pem
             tls_cert: cert.pem
             tls_ca: root.pem
@@ -56,7 +57,7 @@ tests:
       source_path: $TESTGENDIR/rsa_root.pem
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -75,15 +76,15 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: https://localhost:3852/{database}
+            remote_url_template: https://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
             tls_key: key.pem
             tls_cert: cert.pem
             tls_ca: root.pem
@@ -95,7 +96,7 @@ tests:
       source_path: $TESTGENDIR/rsa_root.pem
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -103,15 +104,15 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: https://localhost:3851/{database}
+            remote_url_template: https://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
             tls_key: key.pem
             tls_cert: cert.pem
             tls_ca: root.pem
@@ -123,7 +124,7 @@ tests:
       source_path: $TESTGENDIR/rsa_root.pem
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -142,15 +143,15 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: https://localhost:3852/{database}
+            remote_url_template: https://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
             tls_key: key.pem
             tls_cert: cert.pem
             tls_ca: root.pem
@@ -163,7 +164,7 @@ tests:
       source_path: $TESTGENDIR/rsa_root.pem
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -171,15 +172,15 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: https://localhost:3851/{database}
+            remote_url_template: https://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
             tls_key: key.pem
             tls_cert: cert.pem
             tls_ca: root.pem
@@ -191,7 +192,7 @@ tests:
       source_path: $TESTGENDIR/rsa_root.pem
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -210,15 +211,15 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: https://localhost:3852/{database}
+            remote_url_template: https://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
             tls_key: key.pem
             tls_cert: cert.pem
             tls_ca: root.pem
@@ -231,7 +232,7 @@ tests:
       source_path: $TESTGENDIR/rsa_root.pem
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -239,15 +240,15 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: https://localhost:3851/{database}
+            remote_url_template: https://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
             tls_key: key.pem
             tls_cert: cert.pem
             tls_ca: root.pem
@@ -259,7 +260,7 @@ tests:
       source_path: $TESTGENDIR/rsa_root.pem
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -278,15 +279,15 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: https://localhost:3852/{database}
+            remote_url_template: https://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
             tls_key: key.pem
             tls_cert: cert.pem
             tls_ca: root.pem
@@ -298,7 +299,7 @@ tests:
       source_path: $TESTGENDIR/rsa_root.pem
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -306,15 +307,15 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: https://localhost:3851/{database}
+            remote_url_template: https://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
             tls_key: key.pem
             tls_cert: cert.pem
             tls_ca: root.pem
@@ -326,7 +327,7 @@ tests:
       source_path: $TESTGENDIR/rsa_root.pem
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -385,15 +386,15 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: https://localhost:3852/{database}
+            remote_url_template: https://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
             tls_key: key.pem
             tls_cert: cert.pem
             tls_ca: root.pem
@@ -407,7 +408,7 @@ tests:
       source_path: $TESTGENDIR/ed25519_root.pem
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -415,15 +416,15 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: https://localhost:3851/{database}
+            remote_url_template: https://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
             tls_key: key.pem
             tls_cert: cert.pem
             tls_ca: root.pem
@@ -437,7 +438,7 @@ tests:
       source_path: $TESTGENDIR/ed25519_root.pem
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster-users-and-grants.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster-users-and-grants.yaml
@@ -255,6 +255,7 @@ tests:
     restart_server: {}
   - on: server1
     queries:
+    - exec: 'SET @@PERSIST.dolt_cluster_ack_writes_timeout_secs = 10'
     - exec: 'use repo1'
     - exec: 'delete from dolt_branch_control'
     - query: 'show warnings'
@@ -329,6 +330,8 @@ tests:
     restart_server: {}
   - on: server1
     queries:
+    # Because we run in parallel, do not be too agressive about the timeout...
+    - exec: 'SET @@PERSIST.dolt_cluster_ack_writes_timeout_secs = 10'
     - exec: 'create user "brian"@"%" IDENTIFIED BY "brianspassword"'
     - query: 'show warnings'
       result:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster-users-and-grants.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster-users-and-grants.yaml
@@ -1,3 +1,4 @@
+parallel: true
 tests:
 - name: users and grants replicate
   multi_repos:
@@ -8,18 +9,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -27,18 +28,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -74,18 +75,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -93,18 +94,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -197,18 +198,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -216,24 +217,24 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     - name: nocluster.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
     server:
       args: ["--config", "nocluster.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -275,18 +276,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -294,24 +295,24 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     - name: nocluster.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
     server:
       args: ["--config", "nocluster.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -350,20 +351,20 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby1
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           - name: standby2
-            remote_url_template: http://localhost:3853/{database}
+            remote_url_template: http://localhost:{{get_port "server3_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -371,20 +372,20 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby1
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           - name: standby2
-            remote_url_template: http://localhost:3853/{database}
+            remote_url_template: http://localhost:{{get_port "server3_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   - name: server3
     with_files:
     - name: server.yaml
@@ -392,20 +393,20 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3311
+          port: {{get_port "server3"}}
         cluster:
           standby_remotes:
           - name: standby1
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           - name: standby2
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3853
+            port: {{get_port "server3_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3311
+      dynamic_port: server3
   connections:
   - on: server1
     queries:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
@@ -1,3 +1,4 @@
+parallel: true
 tests:
 - name: persisted role and epoch take precedence over bootstrap values
   multi_repos:
@@ -6,43 +7,43 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo1
+        url: http://localhost:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo2
+        url: http://localhost:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: standby_server.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 10
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     - name: primary_server.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 15
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "standby_server.yaml"]
-      port: 3309
+      dynamic_port: server1
   connections:
   - on: server1
     queries:
@@ -74,29 +75,29 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo1
+        url: http://localhost:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo2
+        url: http://localhost:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 10
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   connections:
   - on: server1
     queries:
@@ -151,29 +152,29 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo1
+        url: http://localhost:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo2
+        url: http://localhost:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   connections:
   - on: server1
     queries:
@@ -182,7 +183,7 @@ tests:
     - query: "select name, url from dolt_remotes"
       result:
         columns: ["name","url"]
-        rows: [["standby","http://localhost:3852/a_new_database"]]
+        rows: [["standby","http://localhost:{{get_port \"server2_cluster\"}}/a_new_database"]]
 - name: primary comes up and replicates to standby
   multi_repos:
   - name: server1
@@ -190,57 +191,57 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo1
+        url: http://localhost:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo2
+        url: http://localhost:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
-      args: ["--port", "3309"]
-      port: 3309
+      args: ["--port", "{{get_port \"server1\"}}"]
+      dynamic_port: server1
   - name: server2
     repos:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:3851/repo1
+        url: http://localhost:{{get_port "server1_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:3851/repo2
+        url: http://localhost:{{get_port "server1_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 10
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -273,29 +274,29 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo1
+        url: http://localhost:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo2
+        url: http://localhost:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: standby_server.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 10
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "standby_server.yaml"]
-      port: 3309
+      dynamic_port: server1
   connections:
   - on: server1
     queries:
@@ -309,29 +310,29 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo1
+        url: http://localhost:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo2
+        url: http://localhost:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   connections:
   - on: server1
     queries:
@@ -344,57 +345,57 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo1
+        url: http://localhost:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo2
+        url: http://localhost:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
-      args: ["--port", "3309"]
-      port: 3309
+      args: ["--port", "{{get_port \"server1\"}}"]
+      dynamic_port: server1
   - name: server2
     repos:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:3851/repo1
+        url: http://localhost:{{get_port "server1_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:3851/repo2
+        url: http://localhost:{{get_port "server1_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -455,29 +456,29 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo1
+        url: http://localhost:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo2
+        url: http://localhost:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: standby_server.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 10
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "standby_server.yaml"]
-      port: 3309
+      dynamic_port: server1
   connections:
   - on: server1
     queries:
@@ -503,57 +504,57 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo1
+        url: http://localhost:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo2
+        url: http://localhost:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     repos:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:3851/repo1
+        url: http://localhost:{{get_port "server1_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:3851/repo2
+        url: http://localhost:{{get_port "server1_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 10
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -580,57 +581,57 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo1
+        url: http://localhost:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo2
+        url: http://localhost:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     repos:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:3851/repo1
+        url: http://localhost:{{get_port "server1_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:3851/repo2
+        url: http://localhost:{{get_port "server1_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     retry_attempts: 100
@@ -659,69 +660,69 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo1
+        url: http://localhost:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo2
+        url: http://localhost:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: preserver.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
     - name: server.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 15
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "preserver.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     repos:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:3851/repo1
+        url: http://localhost:{{get_port "server1_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:3851/repo2
+        url: http://localhost:{{get_port "server1_cluster"}}/repo2
     with_files:
     - name: preserver.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
     - name: server.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "preserver.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -770,69 +771,69 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo1
+        url: http://localhost:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo2
+        url: http://localhost:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: preserver.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
     - name: server.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "preserver.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     repos:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:3851/repo1
+        url: http://localhost:{{get_port "server1_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:3851/repo2
+        url: http://localhost:{{get_port "server1_cluster"}}/repo2
     with_files:
     - name: preserver.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
     - name: server.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 15
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "preserver.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -886,29 +887,29 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo1
+        url: http://localhost:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:3852/repo2
+        url: http://localhost:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   connections:
   - on: server1
     queries:
@@ -926,18 +927,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -945,18 +946,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -968,9 +969,9 @@ tests:
       result:
         columns: ["caught_up", "database", "remote", "remote_url"]
         rows:
-        - ["1", "repo1", "standby", "http://localhost:3852/repo1"]
-        - ["1", "mysql", "standby", "http://localhost:3852"]
-        - ["1", "dolt_branch_control", "standby", "http://localhost:3852"]
+        - ["1", "repo1", "standby", "http://localhost:{{get_port \"server2_cluster\"}}/repo1"]
+        - ["1", "mysql", "standby", "http://localhost:{{get_port \"server2_cluster\"}}"]
+        - ["1", "dolt_branch_control", "standby", "http://localhost:{{get_port \"server2_cluster\"}}"]
 - name: dolt_cluster_transition_to_standby too many standbys provided
   multi_repos:
   - name: server1
@@ -980,18 +981,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -999,18 +1000,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -1029,18 +1030,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -1048,18 +1049,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -1118,18 +1119,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -1137,18 +1138,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -1186,18 +1187,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -1205,18 +1206,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -1253,18 +1254,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -1272,18 +1273,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   # This test writes new commits on the primary and quickly checks for them on
   # the secondary. If dolt_cluster_ack_writes_timeout_secs is working as
   # intended, the new writes will always be present.
@@ -1404,18 +1405,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   connections:
   - on: server1
     queries:
@@ -1436,18 +1437,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -1455,18 +1456,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -1505,18 +1506,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -1524,18 +1525,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -1580,18 +1581,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -1599,18 +1600,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -1668,18 +1669,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -1687,18 +1688,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -1737,18 +1738,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -1756,18 +1757,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -1836,18 +1837,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: server2
     with_files:
     - name: server.yaml
@@ -1855,18 +1856,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3310
+      dynamic_port: server2
   connections:
   - on: server1
     queries:
@@ -1897,34 +1898,34 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby_one
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     - name: twostandbys.yaml
       contents: |
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3309
+          port: {{get_port "server1"}}
         cluster:
           standby_remotes:
           - name: standby_one
-            remote_url_template: http://localhost:3852/{database}
+            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
           - name: standby_two
-            remote_url_template: http://localhost:3853/{database}
+            remote_url_template: http://localhost:{{get_port "server3_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
-            port: 3851
+            port: {{get_port "server1_cluster"}}
     server:
       args: ["--config", "onestandby.yaml"]
-      port: 3309
+      dynamic_port: server1
   - name: standby_one
     with_files:
     - name: config.yaml
@@ -1932,18 +1933,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3310
+          port: {{get_port "server2"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3852
+            port: {{get_port "server2_cluster"}}
     server:
       args: ["--config", "config.yaml"]
-      port: 3310
+      dynamic_port: server2
   - name: standby_two
     with_files:
     - name: config.yaml
@@ -1951,18 +1952,18 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3311
+          port: {{get_port "server3"}}
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:3851/{database}
+            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
-            port: 3853
+            port: {{get_port "server3_cluster"}}
     server:
       args: ["--config", "config.yaml"]
-      port: 3311
+      dynamic_port: server3
   connections:
   - on: server1
     queries:
@@ -2001,28 +2002,28 @@ tests:
         - name: repo1
           with_remotes:
             - name: standby
-              url: http://localhost:3852/repo1
+              url: http://localhost:{{get_port "server2_cluster"}}/repo1
         - name: repo2
           with_remotes:
             - name: standby
-              url: http://localhost:3852/repo2
+              url: http://localhost:{{get_port "server2_cluster"}}/repo2
       with_files:
         - name: server.yaml
           contents: |
             log_level: trace
             listener:
               host: 0.0.0.0
-              port: 3309
+              port: {{get_port "server1"}}
             cluster:
               standby_remotes:
               - name: standby
-                remote_url_template: http://localhost:3852/{database}
+                remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
               bootstrap_role: primary
               remotesapi:
-                port: 3851
+                port: {{get_port "server1_cluster"}}
       server:
         args: ["--config", "server.yaml"]
-        port: 3309
+        dynamic_port: server1
   connections:
     - on: server1
       queries:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-config.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-config.yaml
@@ -1,3 +1,4 @@
+parallel: true
 tests:
 - name: persist global variable before server startup
   repos:
@@ -7,7 +8,8 @@ tests:
         contents: |
           {"sqlserver.global.max_connections":"1000"}
     server:
-      args: ["-l", "trace"]
+      args: ["-l", "trace", "-P", '{{get_port "repo1"}}']
+      dynamic_port: repo1
   connections:
   - on: repo1
     queries:
@@ -23,7 +25,8 @@ tests:
         contents: |
           {"sqlserver.global.unknown":"1000"}
     server:
-      args: ["-l", "trace"]
+      args: ["-l", "trace", "-P", '{{get_port "repo1"}}']
+      dynamic_port: repo1
       log_matches:
       - "warning: persisted system variable unknown was not loaded since its definition does not exist."
   connections:
@@ -36,6 +39,8 @@ tests:
         contents: |
           {"sqlserver.global.max_connections":"string"}
     server:
+      args: ["-P", '{{get_port "repo1"}}']
+      dynamic_port: repo1
       log_matches:
       - "error: failed to load persisted global variables: key: 'max_connections'; strconv.ParseInt: parsing \"string\": invalid syntax"
   connections:
@@ -44,7 +49,8 @@ tests:
   repos:
   - name: repo1
     server:
-      args: ["-l", "trace"]
+      args: ["-l", "trace", "-P", '{{get_port "repo1"}}']
+      dynamic_port: repo1
   connections:
   - on: repo1
     queries:
@@ -64,7 +70,8 @@ tests:
   repos:
   - name: repo1
     server:
-      args: ["-l", "trace"]
+      args: ["-l", "trace", "-P", '{{get_port "repo1"}}']
+      dynamic_port: repo1
   connections:
   - on: repo1
     queries:
@@ -92,7 +99,8 @@ tests:
   repos:
   - name: repo1
     server:
-      args: ["-l", "trace"]
+      args: ["-l", "trace", "-P", '{{get_port "repo1"}}']
+      dynamic_port: repo1
   connections:
   - on: repo1
     queries:
@@ -120,7 +128,8 @@ tests:
   repos:
   - name: repo1
     server:
-      args: ["-l", "trace"]
+      args: ["-l", "trace", "-P", '{{get_port "repo1"}}']
+      dynamic_port: repo1
   connections:
   - on: repo1
     queries:
@@ -157,7 +166,8 @@ tests:
   repos:
   - name: repo1
     server:
-      args: ["-l", "trace"]
+      args: ["-l", "trace", "-P", '{{get_port "repo1"}}']
+      dynamic_port: repo1
   connections:
   - on: repo1
     queries:
@@ -178,7 +188,8 @@ tests:
   repos:
   - name: repo1
     server:
-      args: ["-l", "trace"]
+      args: ["-l", "trace", "-P", '{{get_port "repo1"}}']
+      dynamic_port: repo1
   connections:
   - on: repo1
     queries:
@@ -187,7 +198,9 @@ tests:
 - name: persist invalid global variable value during server session
   repos:
   - name: repo1
-    server: {}
+    server:
+      args: ["-P", '{{get_port "repo1"}}']
+      dynamic_port: repo1
   connections:
   - on: repo1
     queries:
@@ -202,8 +215,10 @@ tests:
           log_level: trace
           listener:
             max_connections: 999
+            port: {{get_port "repo1"}}
     server:
       args: ["--config", "server.yaml"]
+      dynamic_port: repo1
   connections:
   - on: repo1
     queries:
@@ -215,7 +230,8 @@ tests:
   repos:
   - name: repo1
     server:
-      args: []
+      args: ["-P", '{{get_port "repo1"}}']
+      dynamic_port: repo1
   connections:
   - on: repo1
     queries:
@@ -227,7 +243,8 @@ tests:
   repos:
   - name: repo1
     server:
-      args: ["--max-connections", "555"]
+      args: ["--max-connections", "555", "-P", '{{get_port "repo1"}}']
+      dynamic_port: repo1
   connections:
   - on: repo1
     queries:
@@ -239,7 +256,8 @@ tests:
   repos:
   - name: repo1
     server:
-      args: ["-l", "warning"]
+      args: ["-l", "warning", "-P", '{{get_port "repo1"}}']
+      dynamic_port: repo1
       log_matches:
       - "Starting query"
   connections:
@@ -259,7 +277,7 @@ tests:
         columns: ["@@GLOBAL.dolt_log_level"]
         rows: [["trace"]]
     restart_server:
-      args: ["-l", "info"]
+      args: ["-l", "info", "-P", '{{get_port "repo1"}}']
   - on: repo1
     queries:
     - query: "select @@GLOBAL.dolt_log_level"
@@ -275,8 +293,11 @@ tests:
           system_variables:
             secure_file_priv: "/dev/null"
             max_connections: 1000
+          listener:
+            port: {{get_port "repo1"}}
     server:
       args: ["-l", "trace", "--config", "config.yaml"]
+      dynamic_port: repo1
   connections:
   - on: repo1
     queries:
@@ -292,8 +313,11 @@ tests:
         contents: |
           system_variables:
             secure_file_priv: "/dev/null"
+          listener:
+            port: {{get_port "repo1"}}
     server:
       args: ["-l", "trace", "--config", "config.yaml"]
+      dynamic_port: repo1
   connections:
   - on: repo1
     queries:
@@ -318,21 +342,28 @@ tests:
         contents: |
           system_variables:
             secure_file_priv: ""
+          listener:
+            port: {{get_port "repo1"}}
+      - name: "known_contents"
+        contents: |
+          system_variables:
+            secure_file_priv: ""
     server:
       args: ["-l", "trace", "--config", "config.yaml"]
+      dynamic_port: repo1
   connections:
   - on: repo1
     queries:
-    - query: "select LOAD_FILE('config.yaml')"
+    - query: "select LOAD_FILE('known_contents')"
       result:
-        columns: ["LOAD_FILE('config.yaml')"]
+        columns: ["LOAD_FILE('known_contents')"]
         rows: [["system_variables:\n  secure_file_priv: \"\"\n"]]
-    - query: "select LOAD_FILE('./.dolt/../config.yaml')"
+    - query: "select LOAD_FILE('./.dolt/../known_contents')"
       result:
-        columns: ["LOAD_FILE('./.dolt/../config.yaml')"]
+        columns: ["LOAD_FILE('./.dolt/../known_contents')"]
         rows: [["system_variables:\n  secure_file_priv: \"\"\n"]]
     - exec: "create table loaded (contents text)"
-    - exec: "load data infile \"config.yaml\" into table loaded lines terminated by \"\\0\""
+    - exec: "load data infile \"known_contents\" into table loaded lines terminated by \"\\0\""
     - query: "select contents from loaded"
       result:
         columns: ["contents"]

--- a/integration-tests/go-sql-server-driver/tests/sql-server-jwt-auth.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-jwt-auth.yaml
@@ -1,3 +1,4 @@
+parallel: true
 tests:
 - name: jwt auth from config
   repos:
@@ -15,6 +16,7 @@ tests:
           tls_key: chain_key.pem
           tls_cert: chain_cert.pem
           require_secure_transport: true
+          port: {{get_port "server1"}}
         jwks:
         - name: jwksname
           location_url: file:///test_jwks.json
@@ -26,6 +28,7 @@ tests:
           fields_to_log: [on_behalf_of,id]
     server:
       args: ["--config", "server.yaml"]
+      dynamic_port: server1
   connections:
   - on: repo1
     queries:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-orig.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-orig.yaml
@@ -1,15 +1,19 @@
+parallel: true
 tests:
 - name: read-only flag prevents modification
   repos:
   - name: repo1
     server:
       args: ["--config", "readonly.yaml"]
+      dynamic_port: server1
     with_files:
     - name: readonly.yaml
       contents: |
         log_level: trace
         behavior:
           read_only: true
+        listener:
+          port: {{get_port "server1"}}
   connections:
   - on: repo1
     queries:
@@ -26,12 +30,16 @@ tests:
 - name: read-only flag still allows select
   repos:
   - name: repo1
-    server: {}
+    server:
+      args: ["--port", "{{get_port \"server1\"}}"]
+      dynamic_port: server1
     with_files:
     - name: readonly.yaml
       contents: |
         behavior:
           read_only: true
+        listener:
+          port: {{get_port "server1"}}
   connections:
   - on: repo1
     queries:
@@ -51,12 +59,15 @@ tests:
   - name: repo1
     server:
       args: ["--config", "readonly.yaml"]
+      dynamic_port: server1
     with_files:
     - name: readonly.yaml
       contents: |
         log_level: trace
         behavior:
           read_only: true
+        listener:
+          port: {{get_port "server1"}}
   connections:
   - on: repo1
     queries:
@@ -66,13 +77,17 @@ tests:
   skip: read-only flag does not prevent dolt_reset
   repos:
   - name: repo1
-    server: {}
+    server:
+      args: ["--port", "{{get_port \"server1\"}}"]
+      dynamic_port: server1
     with_files:
     - name: readonly.yaml
       contents: |
         log_level: trace
         behavior:
           read_only: true
+        listener:
+          port: {{get_port "server1"}}
   connections:
   - on: repo1
     queries:
@@ -86,15 +101,21 @@ tests:
 - name: port in use
   repos:
   - name: repo1
-    server: {}
+    server:
+      args: ["--port", "{{get_port \"server1\"}}"]
+      dynamic_port: server1
   - name: repo2
     server:
+      args: ["--port", "{{get_port \"server1\"}}"]
+      dynamic_port: server1
       error_matches:
       - "already in use"
 - name: test autocommit
   repos:
   - name: repo1
-    server: {}
+    server:
+      args: ["--port", "{{get_port \"server1\"}}"]
+      dynamic_port: server1
   connections:
   - on: repo1
     queries:
@@ -109,7 +130,9 @@ tests:
 - name: test basic querying via dolt sql-server
   repos:
   - name: repo1
-    server: {}
+    server:
+      args: ["--port", "{{get_port \"server1\"}}"]
+      dynamic_port: server1
   connections:
   - on: repo1
     queries:
@@ -163,7 +186,9 @@ tests:
 - name: test multiple queries on same connection
   repos:
   - name: repo1
-    server: {}
+    server:
+      args: ["--port", "{{get_port \"server1\"}}"]
+      dynamic_port: server1
   connections:
   - on: repo1
     queries:
@@ -198,7 +223,9 @@ tests:
 - name: test CREATE and DROP database via sql-server
   repos:
   - name: repo1
-    server: {}
+    server:
+      args: ["--port", "{{get_port \"server1\"}}"]
+      dynamic_port: server1
   connections:
   - on: repo1
     queries:
@@ -223,7 +250,9 @@ tests:
 - name: LOAD DATA LOCAL INFILE works
   repos:
   - name: repo1
-    server: {}
+    server:
+      args: ["--port", "{{get_port \"server1\"}}"]
+      dynamic_port: server1
   connections:
   - on: repo1
     queries:
@@ -239,7 +268,9 @@ tests:
 - name: LOAD DATA LOCAL INFILE automatically ignores row with existing primary key
   repos:
   - name: repo1
-    server: {}
+    server:
+      args: ["--port", "{{get_port \"server1\"}}"]
+      dynamic_port: server1
   connections:
   - on: repo1
     queries:
@@ -256,7 +287,9 @@ tests:
 - name: LOAD DATA LOCAL INFILE can replace row with existing primary key
   repos:
   - name: repo1
-    server: {}
+    server:
+      args: ["--port", "{{get_port \"server1\"}}"]
+      dynamic_port: server1
   connections:
   - on: repo1
     queries:
@@ -273,7 +306,9 @@ tests:
 - name: JSON queries
   repos:
   - name: repo1
-    server: {}
+    server:
+      args: ["--port", "{{get_port \"server1\"}}"]
+      dynamic_port: server1
   connections:
   - on: repo1
     queries:
@@ -296,7 +331,9 @@ tests:
 - name: select a branch with the USE syntax
   repos:
   - name: repo1
-    server: {}
+    server:
+      args: ["--port", "{{get_port \"server1\"}}"]
+      dynamic_port: server1
   connections:
   - on: repo1
     queries:
@@ -321,7 +358,9 @@ tests:
 - name: auto increment for a table should reset between drops
   repos:
   - name: repo1
-    server: {}
+    server:
+      args: ["--port", "{{get_port \"server1\"}}"]
+      dynamic_port: server1
   connections:
   - on: repo1
     queries:
@@ -341,7 +380,9 @@ tests:
 - name: Create a temporary table and validate that it doesn't persist after a session closes
   repos:
   - name: repo1
-    server: {}
+    server:
+      args: ["--port", "{{get_port \"server1\"}}"]
+      dynamic_port: server1
   connections:
   - on: repo1
     queries:
@@ -360,6 +401,8 @@ tests:
   - name: server1
     server:
       envs: ["DOLT_DISABLE_CHUNK_JOURNAL=true"]
+      args: ["--port", "{{get_port \"server1\"}}"]
+      dynamic_port: server1
   connections:
   - on: server1
     queries:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-remotesapi.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-remotesapi.yaml
@@ -1,3 +1,4 @@
+parallel: true
 tests:
 - name: can clone from server1 remotesapi endpoint
   multi_repos:
@@ -6,8 +7,8 @@ tests:
     - name: repo1
     - name: repo2
     server:
-      args: ["--remotesapi-port", "50051", "--port", "3309"]
-      port: 3309
+      args: ["--remotesapi-port", "{{get_port \"remotesapi_port\"}}", "--port", "{{get_port \"server_port\"}}"]
+      dynamic_port: server_port
   - name: server2
     repos:
     - name: repo1
@@ -17,10 +18,10 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3308
+          port: {{get_port "server2_port"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3308
+      dynamic_port: server2_port
   connections:
   - on: server1
     queries:
@@ -31,7 +32,7 @@ tests:
   - on: server2
     queries:
     - exec: "use repo1"
-    - exec: "call dolt_clone('http://localhost:50051/repo2')"
+    - exec: "call dolt_clone('http://localhost:{{get_port \"remotesapi_port\"}}/repo2')"
     - exec: "use repo2"
     - query: "select count(*) from vals"
       result:
@@ -44,8 +45,8 @@ tests:
     - name: repo1
     - name: repo2
     server:
-      args: ["--remotesapi-port", "50051", "--port", "3309"]
-      port: 3309
+      args: ["--remotesapi-port", "{{get_port \"remotesapi_port\"}}", "--port", "{{get_port \"server_port\"}}"]
+      dynamic_port: server_port
   - name: server2
     repos:
     - name: repo1
@@ -55,10 +56,10 @@ tests:
         log_level: trace
         listener:
           host: 0.0.0.0
-          port: 3308
+          port: {{get_port "server2_port"}}
     server:
       args: ["--config", "server.yaml"]
-      port: 3308
+      dynamic_port: server2_port
   connections:
   - on: server1
     queries:
@@ -75,7 +76,7 @@ tests:
   - on: server2
     queries:
     - exec: "use repo1"
-    - exec: "call dolt_clone('http://localhost:50051/repo2')"
+    - exec: "call dolt_clone('http://localhost:{{get_port \"remotesapi_port\"}}/repo2')"
     - exec: "use repo2"
     - query: "select count(*) from vals"
       result:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-tls.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-tls.yaml
@@ -1,3 +1,4 @@
+parallel: true
 tests:
 - name: require_secure_transport no key or cert
   repos:
@@ -7,8 +8,10 @@ tests:
       contents: |
         listener:
           require_secure_transport: true
+          port: {{get_port "server"}}
     server:
       args: ["--config", "server.yaml"]
+      dynamic_port: server
       error_matches:
       - "require_secure_transport can only be `true` when a tls_key and tls_cert are provided."
 - name: tls_key non-existent
@@ -24,8 +27,10 @@ tests:
         listener:
           tls_key: doesnotexist_key.pem
           tls_cert: chain_cert.pem
+          port: {{get_port "server"}}
     server:
       args: ["--config", "server.yaml"]
+      dynamic_port: server
       error_matches:
       - "no such file or directory"
 - name: tls_cert non-existent
@@ -41,8 +46,10 @@ tests:
         listener:
           tls_key: chain_key.pem
           tls_cert: doesnotexist_key.pem
+          port: {{get_port "server"}}
     server:
       args: ["--config", "server.yaml"]
+      dynamic_port: server
       error_matches:
       - "no such file or directory"
 
@@ -62,8 +69,10 @@ tests:
           tls_key: chain_key.pem
           tls_cert: chain_cert.pem
           require_secure_transport: true
+          port: {{get_port "server"}}
     server:
       args: ["--config", "server.yaml"]
+      dynamic_port: server
   connections:
   - on: repo1
     queries:


### PR DESCRIPTION
Takes local runtime from 500+s to ~100s.