### PR TITLE
Replace `jpillora/backoff` with `cenkalti/backoff/v4`

### DIFF
--- a/go/Godeps/LICENSES
+++ b/go/Godeps/LICENSES
@@ -10943,34 +10943,6 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 ================================================================================
 
 ================================================================================
-= github.com/jpillora/backoff licensed under: =
-
-The MIT License (MIT)
-
-Copyright (c) 2017 Jaime Pillora
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-= LICENSE 83831995a7e93db77f95ee20af5603b91e303ef348cb9bde1b13c8c0 =
-================================================================================
-
-================================================================================
 = github.com/juju/gnuflag licensed under: =
 
 Copyright (c) 2012 The Go Authors. All rights reserved.

--- a/go/go.mod
+++ b/go/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/gocraft/dbr/v2 v2.7.2
 	github.com/golang/snappy v0.0.4
 	github.com/google/uuid v1.6.0
-	github.com/jpillora/backoff v1.0.0
 	github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d
 	github.com/mattn/go-isatty v0.0.17
 	github.com/mattn/go-runewidth v0.0.13

--- a/go/go.sum
+++ b/go/go.sum
@@ -456,7 +456,6 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/jmoiron/sqlx v1.3.4 h1:wv+0IJZfL5z0uZoUjlpKgHkgaFSYD+r9CfrXjEXsO7w=
 github.com/jmoiron/sqlx v1.3.4/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
-github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=


### PR DESCRIPTION
This is a drop-in replacement.

Both [`github.com/jpillora/backoff`](https://pkg.go.dev/github.com/jpillora/backoff) and [`github.com/cenkalti/backoff/v4`](https://pkg.go.dev/github.com/cenkalti/backoff/v4) provide exponential backoff implementations. Since we already use `github.com/cenkalti/backoff/v4` elsewhere in the codebase, this change standardizes our dependency by using a single implementation consistently.