### PR TITLE
[no-release-notes] Fix races in doltgres

### DIFF
--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -212,15 +212,21 @@ func NewSqlEngine(
 		dprocedures.UseSessionAwareSafepointController = true
 	}
 
+	var statsPro sql.StatsProvider
 	_, enabled, _ := sql.SystemVariables.GetGlobal(dsess.DoltStatsEnabled)
 	if enabled.(int8) == 1 {
-		config.StatsController = statspro.NewStatsController(logrus.StandardLogger(), mrEnv.GetEnv(mrEnv.GetFirstDatabase()))
+		statsPro = statspro.NewStatsController(logrus.StandardLogger(), mrEnv.GetEnv(mrEnv.GetFirstDatabase()))
 	} else {
-		config.StatsController = statspro.StatsNoop{}
+		statsPro = statspro.StatsNoop{}
 	}
 
+<<<<<<< Updated upstream
+=======
+	engine.Analyzer.Catalog.StatsProvider = statsPro
+
+>>>>>>> Stashed changes
 	engine.Analyzer.ExecBuilder = rowexec.NewOverrideBuilder(kvexec.Builder{})
-	sessFactory := doltSessionFactory(pro, config.StatsController, mrEnv.Config(), bcController, gcSafepointController, config.Autocommit)
+	sessFactory := doltSessionFactory(pro, statsPro, mrEnv.Config(), bcController, gcSafepointController, config.Autocommit)
 	sqlEngine.provider = pro
 	sqlEngine.contextFactory = sqlContextFactory
 	sqlEngine.dsessFactory = sessFactory
@@ -239,7 +245,7 @@ func NewSqlEngine(
 
 	// configuring stats depends on sessionBuilder
 	// sessionBuilder needs ref to statsProv
-	if sc, ok := config.StatsController.(*statspro.StatsController); ok {
+	if sc, ok := statsPro.(*statspro.StatsController); ok {
 		_, memOnly, _ := sql.SystemVariables.GetGlobal(dsess.DoltStatsMemoryOnly)
 		sc.SetMemOnly(memOnly.(int8) == 1)
 

--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -219,12 +219,9 @@ func NewSqlEngine(
 	} else {
 		statsPro = statspro.StatsNoop{}
 	}
-
-<<<<<<< Updated upstream
-=======
+	
 	engine.Analyzer.Catalog.StatsProvider = statsPro
 
->>>>>>> Stashed changes
 	engine.Analyzer.ExecBuilder = rowexec.NewOverrideBuilder(kvexec.Builder{})
 	sessFactory := doltSessionFactory(pro, statsPro, mrEnv.Config(), bcController, gcSafepointController, config.Autocommit)
 	sqlEngine.provider = pro

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -19,6 +19,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/statspro"
 	"net"
 	"net/http"
 	"os"
@@ -356,6 +357,45 @@ func ConfigureServices(
 		},
 	}
 	controller.Register(PersistNondeterministicSystemVarDefaults)
+
+	InitStatsController := &svcs.AnonService{
+		InitF: func(ctx context.Context) error {
+			// configuring stats depends on sessionBuilder
+			// sessionBuilder needs ref to statsProv
+			pro := sqlEngine.GetUnderlyingEngine().Analyzer.Catalog.DbProvider.(*sqle.DoltDatabaseProvider)
+			sqlCtx, err := sqlEngine.NewLocalContext(ctx)
+			if err != nil {
+				return err
+			}
+			dbs := pro.AllDatabases(sqlCtx)
+			statsPro := sqlEngine.GetUnderlyingEngine().Analyzer.Catalog.StatsProvider
+			if sc, ok := statsPro.(*statspro.StatsController); ok {
+				_, memOnly, _ := sql.SystemVariables.GetGlobal(dsess.DoltStatsMemoryOnly)
+				sc.SetMemOnly(memOnly.(int8) == 1)
+
+				pro.InitDatabaseHooks = append(pro.InitDatabaseHooks, statspro.NewInitDatabaseHook(sc))
+				pro.DropDatabaseHooks = append(pro.DropDatabaseHooks, statspro.NewDropDatabaseHook(sc))
+
+				var sqlDbs []sql.Database
+				for _, db := range dbs {
+					sqlDbs = append(sqlDbs, db)
+				}
+
+				err = sc.Init(ctx, pro, sqlEngine.NewDefaultContext, sqlDbs)
+				if err != nil {
+					return err
+				}
+
+				if _, paused, _ := sql.SystemVariables.GetGlobal(dsess.DoltStatsPaused); paused.(int8) == 0 {
+					if err = sc.Restart(); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		},
+	}
+	controller.Register(InitStatsController)
 
 	InitBinlogging := &svcs.AnonService{
 		InitF: func(context.Context) error {

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -55,7 +55,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/cluster"
 	_ "github.com/dolthub/dolt/go/libraries/doltcore/sqle/dfunctions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/statspro"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqlserver"
 	"github.com/dolthub/dolt/go/libraries/events"
 	"github.com/dolthub/dolt/go/libraries/utils/config"

--- a/go/cmd/dolt/commands/utils.go
+++ b/go/cmd/dolt/commands/utils.go
@@ -261,6 +261,10 @@ func newLateBindingEngine(
 			return nil, nil, nil, err
 		}
 
+		if err := se.InitStats(ctx2); err != nil {
+			return nil, nil, nil, err
+		}
+
 		sqlCtx, err := se.NewDefaultContext(ctx2)
 		if err != nil {
 			return nil, nil, nil, err

--- a/go/libraries/doltcore/doltdb/durable/index.go
+++ b/go/libraries/doltcore/doltdb/durable/index.go
@@ -282,17 +282,6 @@ func ProllyMapFromIndex(i Index) (prolly.Map, error) {
 	}
 }
 
-// xxx: don't use this, temporary fix waiting for bigger
-// fix in stats 2.0
-func MaybeProllyMapFromIndex(i Index) (prolly.Map, bool) {
-	ret, ok := i.(prollyIndex)
-	if ok {
-		return ret.index, true
-	} else {
-		return prolly.Map{}, false
-	}
-}
-
 // MapFromIndex unwraps the Index and returns the underlying map as an interface.
 func MapFromIndex(i Index) prolly.MapInterfaceWithMutable {
 	switch indexType := i.(type) {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
@@ -50,6 +50,7 @@ type DoltHarness struct {
 	statsPro              *statspro.StatsController
 	multiRepoEnv          *env.MultiRepoEnv
 	session               *dsess.DoltSession
+	statsSession          *dsess.DoltSession
 	branchControl         *branch_control.Controller
 	gcSafepointController *dsess.GCSafepointController
 	parallelism           int
@@ -251,14 +252,18 @@ func (d *DoltHarness) NewEngine(t *testing.T) (enginetest.QueryEngine, error) {
 
 		bThreads := sql.NewBackgroundThreads()
 
+		var err error
+		d.statsSession, err = dsess.NewDoltSession(enginetest.NewBaseSession(), d.provider, d.multiRepoEnv.Config(), d.branchControl, d.statsPro, writer.NewWriteSession, nil)
+		require.NoError(t, err)
 		ctxGen := func(ctx context.Context) (*sql.Context, error) {
 			client := sql.Client{Address: "localhost", User: "root"}
-			return sql.NewContext(context.Background(), sql.WithSession(d.newSessionWithClient(client))), nil
+			return sql.NewContext(context.Background(), sql.WithSession(d.newStatsSessionWithClient(client))), nil
 		}
-		statsPro := statspro.NewStatsController(logrus.StandardLogger(), d.multiRepoEnv.GetEnv(d.multiRepoEnv.GetFirstDatabase()))
+		// xxx: stats threads can't be tied to single test cycle,
+		// this is only OK for enginetests
+		statsPro := statspro.NewStatsController(logrus.StandardLogger(), sql.NewBackgroundThreads(), d.multiRepoEnv.GetEnv(d.multiRepoEnv.GetFirstDatabase()))
 		d.statsPro = statsPro
 
-		var err error
 		d.session, err = dsess.NewDoltSession(enginetest.NewBaseSession(), d.provider, d.multiRepoEnv.Config(), d.branchControl, d.statsPro, writer.NewWriteSession, d.gcSafepointController)
 		require.NoError(t, err)
 
@@ -293,11 +298,8 @@ func (d *DoltHarness) NewEngine(t *testing.T) (enginetest.QueryEngine, error) {
 
 		e = e.WithBackgroundThreads(bThreads)
 
-		// xxx: stats threads can't be tied to single test cycle,
-		// this is only OK for enginetests
-		statsThreads := sql.NewBackgroundThreads()
 		if d.configureStats {
-			err = statsPro.Init(ctx, doltProvider, ctxGen, statsThreads, databases)
+			err = statsPro.Init(ctx, doltProvider, ctxGen, databases)
 			if err != nil {
 				return nil, err
 			}
@@ -324,6 +326,14 @@ func (d *DoltHarness) NewEngine(t *testing.T) (enginetest.QueryEngine, error) {
 
 	// Reset the mysql DB table to a clean state for this new engine
 	ctx := enginetest.NewContext(d)
+
+	if d.configureStats {
+		err := d.statsPro.Purge(ctx)
+		require.NoError(t, err)
+		
+		err = d.statsPro.Restart()
+		require.NoError(t, err)
+	}
 
 	d.engine.Analyzer.Catalog.MySQLDb = mysql_db.CreateEmptyMySQLDb()
 	d.engine.Analyzer.Catalog.MySQLDb.AddRootAccount()
@@ -413,6 +423,16 @@ func (d *DoltHarness) NewSession() *sql.Context {
 func (d *DoltHarness) newSessionWithClient(client sql.Client) *dsess.DoltSession {
 	localConfig := d.multiRepoEnv.Config()
 	pro := d.session.Provider()
+
+	dSession, err := dsess.NewDoltSession(sql.NewBaseSessionWithClientServer("address", client, 1), pro.(dsess.DoltDatabaseProvider), localConfig, d.branchControl, d.statsPro, writer.NewWriteSession, nil)
+	dSession.SetCurrentDatabase("mydb")
+	require.NoError(d.t, err)
+	return dSession
+}
+
+func (d *DoltHarness) newStatsSessionWithClient(client sql.Client) *dsess.DoltSession {
+	localConfig := d.multiRepoEnv.Config()
+	pro := d.statsSession.Provider()
 
 	dSession, err := dsess.NewDoltSession(sql.NewBaseSessionWithClientServer("address", client, 1), pro.(dsess.DoltDatabaseProvider), localConfig, d.branchControl, d.statsPro, writer.NewWriteSession, nil)
 	dSession.SetCurrentDatabase("mydb")

--- a/go/libraries/doltcore/sqle/statspro/controller.go
+++ b/go/libraries/doltcore/sqle/statspro/controller.go
@@ -516,8 +516,9 @@ func (sc *StatsController) lockedRotateStorage(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer sql.SessionEnd(sqlCtx.Session)
+
 	sql.SessionCommandBegin(sqlCtx.Session)
+	defer sql.SessionEnd(sqlCtx.Session)
 	defer sql.SessionCommandEnd(sqlCtx.Session)
 
 	newKv, err := sc.initStorage(sqlCtx, newStorageTarget)

--- a/go/libraries/doltcore/sqle/statspro/controller.go
+++ b/go/libraries/doltcore/sqle/statspro/controller.go
@@ -125,7 +125,7 @@ func (rs *rootStats) String() string {
 	return string(str)
 }
 
-func NewStatsController(logger *logrus.Logger, dEnv *env.DoltEnv) *StatsController {
+func NewStatsController(logger *logrus.Logger, bgThreads *sql.BackgroundThreads, dEnv *env.DoltEnv) *StatsController {
 	sq := jobqueue.NewSerialQueue().WithErrorCb(func(err error) {
 		logger.Error(err)
 	})
@@ -141,6 +141,7 @@ func NewStatsController(logger *logrus.Logger, dEnv *env.DoltEnv) *StatsControll
 		closed:      make(chan struct{}),
 		kv:          NewMemStats(),
 		hdpEnv:      dEnv,
+		bgThreads:   bgThreads,
 		genCnt:      atomic.Uint64{},
 	}
 }

--- a/go/libraries/doltcore/sqle/statspro/jobqueue/serialqueue.go
+++ b/go/libraries/doltcore/sqle/statspro/jobqueue/serialqueue.go
@@ -18,10 +18,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/libraries/utils/circular"
 )

--- a/go/libraries/doltcore/sqle/statspro/jobqueue/serialqueue.go
+++ b/go/libraries/doltcore/sqle/statspro/jobqueue/serialqueue.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/dolthub/go-mysql-server/sql"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -247,6 +248,37 @@ func (s *SerialQueue) DoSync(ctx context.Context, f func() error) error {
 	case <-w.done:
 		return nil
 	case <-ctx.Done():
+		return context.Cause(ctx)
+	case <-s.completed:
+		return ErrCompletedQueue
+	}
+}
+
+// DoSyncSessionAware initializes a session command before running
+// a worker callback. If the context is cancelled midway we either
+// finish calling the function, or return without calling the function.
+// No return leaves the session in an incomplete state.
+func (s *SerialQueue) DoSyncSessionAware(ctx *sql.Context, f func() error) error {
+	started := atomic.Bool{}
+	nf := func() error {
+		if started.Swap(true) {
+			return nil
+		}
+		sql.SessionCommandBegin(ctx.Session)
+		defer sql.SessionCommandEnd(ctx.Session)
+		return f()
+	}
+	w, err := s.submitWork(schedPriority_Normal, nf)
+	if err != nil {
+		return err
+	}
+	select {
+	case <-w.done:
+		return nil
+	case <-ctx.Done():
+		if started.Swap(true) {
+			<-w.done
+		}
 		return context.Cause(ctx)
 	case <-s.completed:
 		return ErrCompletedQueue

--- a/go/libraries/doltcore/sqle/statspro/listener.go
+++ b/go/libraries/doltcore/sqle/statspro/listener.go
@@ -150,10 +150,9 @@ func (sc *StatsController) RunQueue() {
 }
 
 // Init should only be called once
-func (sc *StatsController) Init(ctx context.Context, pro *sqle.DoltDatabaseProvider, ctxGen ctxFactory, bthreads *sql.BackgroundThreads, dbs []sql.Database) error {
+func (sc *StatsController) Init(ctx context.Context, pro *sqle.DoltDatabaseProvider, ctxGen ctxFactory, dbs []sql.Database) error {
 	sc.pro = pro
 	sc.ctxGen = ctxGen
-	sc.bgThreads = bthreads
 
 	sc.RunQueue()
 	sqlCtx, err := sc.ctxGen(ctx)

--- a/go/libraries/doltcore/sqle/statspro/listener.go
+++ b/go/libraries/doltcore/sqle/statspro/listener.go
@@ -159,7 +159,7 @@ func (sc *StatsController) Init(ctx context.Context, pro *sqle.DoltDatabaseProvi
 	if err != nil {
 		return err
 	}
-	
+
 	sql.SessionCommandBegin(sqlCtx.Session)
 	defer sql.SessionEnd(sqlCtx.Session)
 	defer sql.SessionCommandEnd(sqlCtx.Session)

--- a/go/libraries/doltcore/sqle/statspro/listener.go
+++ b/go/libraries/doltcore/sqle/statspro/listener.go
@@ -159,8 +159,9 @@ func (sc *StatsController) Init(ctx context.Context, pro *sqle.DoltDatabaseProvi
 	if err != nil {
 		return err
 	}
-	defer sql.SessionEnd(sqlCtx.Session)
+	
 	sql.SessionCommandBegin(sqlCtx.Session)
+	defer sql.SessionEnd(sqlCtx.Session)
 	defer sql.SessionCommandEnd(sqlCtx.Session)
 
 	for i, db := range dbs {

--- a/go/libraries/doltcore/sqle/statspro/stats_kv.go
+++ b/go/libraries/doltcore/sqle/statspro/stats_kv.go
@@ -527,8 +527,8 @@ func (sc *StatsController) Flush(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer sql.SessionEnd(sqlCtx.Session)
 	sql.SessionCommandBegin(sqlCtx.Session)
+	defer sql.SessionEnd(sqlCtx.Session)
 	defer sql.SessionCommandEnd(sqlCtx.Session)
 
 	sc.mu.Lock()

--- a/go/libraries/doltcore/sqle/statspro/worker.go
+++ b/go/libraries/doltcore/sqle/statspro/worker.go
@@ -292,7 +292,7 @@ func (sc *StatsController) collectIndexNodes(ctx *sql.Context, prollyMap prolly.
 	keyBuilder := val.NewTupleBuilder(prollyMap.KeyDesc().PrefixDesc(idxLen))
 
 	firstNodeHash := nodes[0].HashOf()
-	lowerBound, ok := sc.kv.GetBound(firstNodeHash, idxLen)
+	lowerBound, ok := sc.GetBound(firstNodeHash, idxLen)
 	if !ok {
 		sc.sq.DoSync(ctx, func() error {
 			sql.SessionCommandBegin(ctx.Session)
@@ -306,7 +306,7 @@ func (sc *StatsController) collectIndexNodes(ctx *sql.Context, prollyMap prolly.
 				log.Printf("put bound:  %s: %v\n", firstNodeHash.String()[:5], lowerBound)
 			}
 
-			sc.kv.PutBound(firstNodeHash, lowerBound, idxLen)
+			sc.PutBound(firstNodeHash, lowerBound, idxLen)
 			return nil
 		})
 	}

--- a/go/libraries/doltcore/sqle/statspro/worker.go
+++ b/go/libraries/doltcore/sqle/statspro/worker.go
@@ -237,7 +237,7 @@ func (sc *StatsController) newStatsForRoot(baseCtx context.Context, gcKv *memSta
 
 			for _, sqlDb := range schDbs {
 				switch sqlDb.SchemaName() {
-				case "dolt", "information_schema", "pg_catalog":
+				case "dolt", sql.InformationSchemaDatabaseName, "pg_catalog":
 					continue
 				}
 				var tableNames []string

--- a/go/libraries/doltcore/sqle/statspro/worker.go
+++ b/go/libraries/doltcore/sqle/statspro/worker.go
@@ -399,6 +399,7 @@ func (sc *StatsController) updateTable(ctx *sql.Context, newStats *rootStats, ta
 	if err := sc.sq.DoSync(ctx, func() error {
 		sql.SessionCommandBegin(ctx.Session)
 		defer sql.SessionCommandEnd(ctx.Session)
+		var err error
 		sqlTable, dTab, err = GetLatestTable(ctx, tableName, sqlDb)
 		return err
 	}); err != nil {
@@ -431,6 +432,7 @@ func (sc *StatsController) updateTable(ctx *sql.Context, newStats *rootStats, ta
 	if err := sc.sq.DoSync(ctx, func() error {
 		sql.SessionCommandBegin(ctx.Session)
 		defer sql.SessionCommandEnd(ctx.Session)
+		var err error
 		indexes, err = sqlTable.GetIndexes(ctx)
 		return err
 	}); err != nil {
@@ -466,6 +468,7 @@ func (sc *StatsController) updateTable(ctx *sql.Context, newStats *rootStats, ta
 		if err := sc.sq.DoSync(ctx, func() error {
 			sql.SessionCommandBegin(ctx.Session)
 			defer sql.SessionCommandEnd(ctx.Session)
+			var err error
 			_, template, err = sc.getTemplate(ctx, sqlTable, sqlIdx)
 			if err != nil {
 				return fmt.Errorf("stats collection failed to generate a statistic template: %s.%s.%s:%T; %s", sqlDb.RevisionQualifiedName(), tableName, sqlIdx, sqlIdx, err.Error())
@@ -482,9 +485,10 @@ func (sc *StatsController) updateTable(ctx *sql.Context, newStats *rootStats, ta
 		idxLen := len(sqlIdx.Expressions())
 
 		var levelNodes []tree.Node
-		if err = sc.sq.DoSync(ctx, func() error {
+		if err := sc.sq.DoSync(ctx, func() error {
 			sql.SessionCommandBegin(ctx.Session)
 			defer sql.SessionCommandEnd(ctx.Session)
+			var err error
 			levelNodes, err = tree.GetHistogramLevel(ctx, prollyMap.Tuples(), bucketLowCnt)
 			if err != nil {
 				sc.descError("get level", err)

--- a/go/libraries/doltcore/sqle/statspro/worker.go
+++ b/go/libraries/doltcore/sqle/statspro/worker.go
@@ -173,7 +173,7 @@ func (sc *StatsController) trySwapStats(ctx context.Context, prevGen uint64, new
 func (sc *StatsController) newStatsForRoot(baseCtx context.Context, gcKv *memStats) (newStats *rootStats, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("issuer panicked running work: %s", r)
+			err = fmt.Errorf("worker panicked running work: %s", r)
 		}
 		if err != nil {
 			sc.descError("stats update interrupted", err)
@@ -202,14 +202,11 @@ func (sc *StatsController) newStatsForRoot(baseCtx context.Context, gcKv *memSta
 		}
 
 		var branches []ref.DoltRef
-		if err := sc.sq.DoSync(ctx, func() error {
-			sql.SessionCommandBegin(ctx.Session)
-			defer sql.SessionCommandEnd(ctx.Session)
+		if err := sc.sq.DoSyncSessionAware(ctx, func() (err error) {
 			ddb, ok := dSess.GetDoltDB(ctx, db.Name())
 			if !ok {
 				return fmt.Errorf("get dolt db dolt database not found %s", db.Name())
 			}
-			var err error // races with outer err
 			branches, err = ddb.GetBranches(ctx)
 			return err
 		}); err != nil {
@@ -225,9 +222,7 @@ func (sc *StatsController) newStatsForRoot(baseCtx context.Context, gcKv *memSta
 			}
 
 			var schDbs []sql.DatabaseSchema
-			if err := sc.sq.DoSync(ctx, func() error {
-				sql.SessionCommandBegin(ctx.Session)
-				defer sql.SessionCommandEnd(ctx.Session)
+			if err := sc.sq.DoSyncSessionAware(ctx, func() (err error) {
 				schDbs, err = sqlDb.AllSchemas(ctx)
 				return err
 			}); err != nil {
@@ -241,9 +236,7 @@ func (sc *StatsController) newStatsForRoot(baseCtx context.Context, gcKv *memSta
 					continue
 				}
 				var tableNames []string
-				if err := sc.sq.DoSync(ctx, func() error {
-					sql.SessionCommandBegin(ctx.Session)
-					defer sql.SessionCommandEnd(ctx.Session)
+				if err := sc.sq.DoSyncSessionAware(ctx, func() (err error) {
 					tableNames, err = sqlDb.GetTableNames(ctx)
 					return err
 				}); err != nil {
@@ -294,10 +287,7 @@ func (sc *StatsController) collectIndexNodes(ctx *sql.Context, prollyMap prolly.
 	firstNodeHash := nodes[0].HashOf()
 	lowerBound, ok := sc.GetBound(firstNodeHash, idxLen)
 	if !ok {
-		sc.sq.DoSync(ctx, func() error {
-			sql.SessionCommandBegin(ctx.Session)
-			defer sql.SessionCommandEnd(ctx.Session)
-			var err error
+		sc.sq.DoSyncSessionAware(ctx, func() (err error) {
 			lowerBound, err = firstRowForIndex(ctx, idxLen, prollyMap, keyBuilder)
 			if err != nil {
 				return fmt.Errorf("get histogram bucket for node; %w", err)
@@ -314,10 +304,7 @@ func (sc *StatsController) collectIndexNodes(ctx *sql.Context, prollyMap prolly.
 	var writes int
 	var offset uint64
 	for i := 0; i < len(nodes); {
-		err := sc.sq.DoSync(ctx, func() error {
-			sql.SessionCommandBegin(ctx.Session)
-			defer sql.SessionCommandEnd(ctx.Session)
-
+		err := sc.sq.DoSyncSessionAware(ctx, func() (err error) {
 			newWrites := 0
 			for i < len(nodes) && newWrites < collectBatchSize {
 				n := nodes[i]
@@ -396,10 +383,7 @@ func (sc *StatsController) updateTable(ctx *sql.Context, newStats *rootStats, ta
 	var err error
 	var sqlTable *sqle.DoltTable
 	var dTab *doltdb.Table
-	if err := sc.sq.DoSync(ctx, func() error {
-		sql.SessionCommandBegin(ctx.Session)
-		defer sql.SessionCommandEnd(ctx.Session)
-		var err error
+	if err := sc.sq.DoSyncSessionAware(ctx, func() (err error) {
 		sqlTable, dTab, err = GetLatestTable(ctx, tableName, sqlDb)
 		return err
 	}); err != nil {
@@ -429,10 +413,7 @@ func (sc *StatsController) updateTable(ctx *sql.Context, newStats *rootStats, ta
 	}
 
 	var indexes []sql.Index
-	if err := sc.sq.DoSync(ctx, func() error {
-		sql.SessionCommandBegin(ctx.Session)
-		defer sql.SessionCommandEnd(ctx.Session)
-		var err error
+	if err := sc.sq.DoSyncSessionAware(ctx, func() (err error) {
 		indexes, err = sqlTable.GetIndexes(ctx)
 		return err
 	}); err != nil {
@@ -447,9 +428,8 @@ func (sc *StatsController) updateTable(ctx *sql.Context, newStats *rootStats, ta
 		var idx durable.Index
 		var err error
 		var prollyMap prolly.Map
-		func() {
-			sql.SessionCommandBegin(ctx.Session)
-			defer sql.SessionCommandEnd(ctx.Session)
+		var template stats.Statistic
+		if sc.sq.DoSyncSessionAware(ctx, func() (err error) {
 			if strings.EqualFold(sqlIdx.ID(), "PRIMARY") {
 				idx, err = dTab.GetRowData(ctx)
 			} else {
@@ -457,18 +437,11 @@ func (sc *StatsController) updateTable(ctx *sql.Context, newStats *rootStats, ta
 			}
 			if err == nil {
 				prollyMap, err = durable.ProllyMapFromIndex(idx)
+				if err != nil {
+					return err
+				}
 			}
-		}()
-		if err != nil {
-			sc.descError("GetRowData", err)
-			continue
-		}
 
-		var template stats.Statistic
-		if err := sc.sq.DoSync(ctx, func() error {
-			sql.SessionCommandBegin(ctx.Session)
-			defer sql.SessionCommandEnd(ctx.Session)
-			var err error
 			_, template, err = sc.getTemplate(ctx, sqlTable, sqlIdx)
 			if err != nil {
 				return fmt.Errorf("stats collection failed to generate a statistic template: %s.%s.%s:%T; %s", sqlDb.RevisionQualifiedName(), tableName, sqlIdx, sqlIdx, err.Error())
@@ -485,10 +458,7 @@ func (sc *StatsController) updateTable(ctx *sql.Context, newStats *rootStats, ta
 		idxLen := len(sqlIdx.Expressions())
 
 		var levelNodes []tree.Node
-		if err := sc.sq.DoSync(ctx, func() error {
-			sql.SessionCommandBegin(ctx.Session)
-			defer sql.SessionCommandEnd(ctx.Session)
-			var err error
+		if err := sc.sq.DoSyncSessionAware(ctx, func() (err error) {
 			levelNodes, err = tree.GetHistogramLevel(ctx, prollyMap.Tuples(), bucketLowCnt)
 			if err != nil {
 				sc.descError("get level", err)

--- a/go/libraries/doltcore/sqle/statspro/worker_test.go
+++ b/go/libraries/doltcore/sqle/statspro/worker_test.go
@@ -806,7 +806,7 @@ func newTestEngine(ctx context.Context, dEnv *env.DoltEnv, threads *sql.Backgrou
 		panic(err)
 	}
 
-	sc := NewStatsController(logrus.StandardLogger(), dEnv)
+	sc := NewStatsController(logrus.StandardLogger(), threads, dEnv)
 
 	gcSafepointController := dsess.NewGCSafepointController()
 
@@ -834,7 +834,7 @@ func newTestEngine(ctx context.Context, dEnv *env.DoltEnv, threads *sql.Backgrou
 		IsServerLocked: false,
 	})
 
-	if err := sc.Init(sqlCtx, pro, ctxGen, threads, pro.AllDatabases(sqlCtx)); err != nil {
+	if err := sc.Init(sqlCtx, pro, ctxGen, pro.AllDatabases(sqlCtx)); err != nil {
 		log.Fatal(err)
 	}
 	sqlEng.Analyzer.Catalog.StatsProvider = sc


### PR DESCRIPTION
- avoid harness session re-use and sharing between test execution and stats
- move stats background threads outside of the harness re-use lifecycle of one query
- organize stats initialization in a way that plays nice with doltgres, dolt server, and shell
- fix when serialQueue synchronous callback exits early but still runs async in background
- fix various stats races