### PR TITLE
More flexible connection settings

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/command_line_config.go
+++ b/go/cmd/dolt/commands/sqlserver/command_line_config.go
@@ -181,9 +181,9 @@ func NewCommandLineConfig(creds *cli.UserPassword, apr *argparser.ArgParseResult
 	if maxWaitConnsTimeoutStr, ok := apr.GetValue(maxWaitConsTimeoutFlag); ok {
 		maxWaitConnsTimeout, err := time.ParseDuration(maxWaitConnsTimeoutStr)
 		if err != nil {
-			return nil, fmt.Errorf("invalid value for --max-wait-connections-timeout '%s'", maxWaitConnsTimeoutStr)
+			return nil, fmt.Errorf("invalid duration value for --max-wait-connections-timeout '%s'", maxWaitConnsTimeoutStr)
 		}
-		config.maxWaitConnsTimeout = maxWaitConnsTimeout
+		config.withMaxWaitConnectionsTimeout(maxWaitConnsTimeout)
 	}
 
 	config.autoCommit = !apr.Contains(noAutoCommitFlag)

--- a/go/cmd/dolt/commands/sqlserver/command_line_config.go
+++ b/go/cmd/dolt/commands/sqlserver/command_line_config.go
@@ -42,6 +42,7 @@ type commandLineServerConfig struct {
 	autoCommit              bool
 	doltTransactionCommit   bool
 	maxConnections          uint64
+	maxWaitConnections      uint32
 	tlsKey                  string
 	tlsCert                 string
 	requireSecureTransport  bool
@@ -72,6 +73,7 @@ func DefaultCommandLineServerConfig() *commandLineServerConfig {
 		logFormat:               servercfg.DefaultLogFormat,
 		autoCommit:              servercfg.DefaultAutoCommit,
 		maxConnections:          servercfg.DefaultMaxConnections,
+		maxWaitConnections:      servercfg.DefaultMaxWaitConnections,
 		dataDir:                 servercfg.DefaultDataDir,
 		cfgDir:                  filepath.Join(servercfg.DefaultDataDir, servercfg.DefaultCfgDir),
 		privilegeFilePath:       filepath.Join(servercfg.DefaultDataDir, servercfg.DefaultCfgDir, servercfg.DefaultPrivilegeFilePath),
@@ -169,6 +171,10 @@ func NewCommandLineConfig(creds *cli.UserPassword, apr *argparser.ArgParseResult
 		config.withMaxConnections(uint64(maxConnections))
 	}
 
+	if maxWaitConnections, ok := apr.GetInt(maxWaitConnectionsFlag); ok {
+		config.maxWaitConnections = uint32(maxWaitConnections)
+	}
+
 	config.autoCommit = !apr.Contains(noAutoCommitFlag)
 	if apr.Contains(noAutoCommitFlag) {
 		config.valuesSet[servercfg.AutoCommitKey] = struct{}{}
@@ -256,6 +262,12 @@ func (cfg *commandLineServerConfig) DoltTransactionCommit() bool {
 // MaxConnections returns the maximum number of simultaneous connections the server will allow.  The default is 1
 func (cfg *commandLineServerConfig) MaxConnections() uint64 {
 	return cfg.maxConnections
+}
+
+// MaxWaitConnections returns the maximum number of simultaneous connections that the server will allow to block waiting
+// for a connection before new connections result in immediate rejection.
+func (cfg *commandLineServerConfig) MaxWaitConnections() uint32 {
+	return cfg.maxWaitConnections
 }
 
 // TLSKey returns a path to the servers PEM-encoded private TLS key. "" if there is none.

--- a/go/cmd/dolt/commands/sqlserver/command_line_config.go
+++ b/go/cmd/dolt/commands/sqlserver/command_line_config.go
@@ -172,7 +172,7 @@ func NewCommandLineConfig(creds *cli.UserPassword, apr *argparser.ArgParseResult
 	}
 
 	if maxWaitConnections, ok := apr.GetInt(maxWaitConnectionsFlag); ok {
-		config.maxWaitConnections = uint32(maxWaitConnections)
+		config.withMaxWaitConnections(uint32(maxWaitConnections))
 	}
 
 	config.autoCommit = !apr.Contains(noAutoCommitFlag)
@@ -434,6 +434,12 @@ func (cfg *commandLineServerConfig) withLogFormat(logformat servercfg.LogFormat)
 func (cfg *commandLineServerConfig) withMaxConnections(maxConnections uint64) *commandLineServerConfig {
 	cfg.maxConnections = maxConnections
 	cfg.valuesSet[servercfg.MaxConnectionsKey] = struct{}{}
+	return cfg
+}
+
+func (cfg *commandLineServerConfig) withMaxWaitConnections(maxWaitConnections uint32) *commandLineServerConfig {
+	cfg.maxWaitConnections = maxWaitConnections
+	cfg.valuesSet[servercfg.MaxWaitConnectionsKey] = struct{}{}
 	return cfg
 }
 

--- a/go/cmd/dolt/commands/sqlserver/command_line_config.go
+++ b/go/cmd/dolt/commands/sqlserver/command_line_config.go
@@ -452,7 +452,6 @@ func (cfg *commandLineServerConfig) withMaxConnections(maxConnections uint64) *c
 	return cfg
 }
 
-// NM4 - I think we can drop this. Or take a str?
 func (cfg *commandLineServerConfig) withMaxWaitConnections(maxWaitConnections uint32) *commandLineServerConfig {
 	cfg.maxWaitConnections = maxWaitConnections
 	cfg.valuesSet[servercfg.MaxWaitConnectionsKey] = struct{}{}

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -1086,6 +1086,7 @@ func getConfigFromServerConfig(serverConfig servercfg.ServerConfig, plf server.P
 	serverConf.ConnWriteTimeout = writeTimeout
 	serverConf.MaxConnections = serverConfig.MaxConnections()
 	serverConf.MaxWaitConnections = serverConfig.MaxWaitConnections()
+	serverConf.MaxWaitConnectionsTimeout = serverConfig.MaxWaitConnectionsTimeout()
 	serverConf.TLSConfig = tlsConfig
 	serverConf.RequireSecureTransport = serverConfig.RequireSecureTransport()
 	serverConf.MaxLoggedQueryLen = serverConfig.MaxLoggedQueryLen()

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -1085,6 +1085,7 @@ func getConfigFromServerConfig(serverConfig servercfg.ServerConfig, plf server.P
 	serverConf.ConnReadTimeout = readTimeout
 	serverConf.ConnWriteTimeout = writeTimeout
 	serverConf.MaxConnections = serverConfig.MaxConnections()
+	serverConf.MaxWaitConnections = serverConfig.MaxWaitConnections()
 	serverConf.TLSConfig = tlsConfig
 	serverConf.RequireSecureTransport = serverConfig.RequireSecureTransport()
 	serverConf.MaxLoggedQueryLen = serverConfig.MaxLoggedQueryLen()

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -49,6 +49,7 @@ const (
 	queryParallelismFlag        = "query-parallelism"
 	maxConnectionsFlag          = "max-connections"
 	maxWaitConnectionsFlag      = "back-log"
+	maxWaitConsTimeoutFlag      = "max-connections-timeout"
 	allowCleartextPasswordsFlag = "allow-cleartext-passwords"
 	socketFlag                  = "socket"
 	remotesapiPortFlag          = "remotesapi-port"
@@ -109,6 +110,8 @@ SUPPORTED CONFIG FILE FIELDS:
 {{.EmphasisLeft}}listener.max_connections{{.EmphasisRight}}: The number of simultaneous connections that the server will accept
 
 {{.EmphasisLeft}}listener.back_log{{.EmphasisRight}}: The number of simultaneous connections that the server will allow to block waiting for a connection before new connections result in immediate rejection. Default 50.
+
+{{.EmphasisLeft}}listener.max_wait_connections_timeout{{.EmphasisRight}}: The maximum amount of time that a connection will block waiting for a connection before being rejected.
 
 {{.EmphasisLeft}}listener.read_timeout_millis{{.EmphasisRight}}: The number of milliseconds that the server will wait for a read operation
 
@@ -183,6 +186,7 @@ func (cmd SqlServerCmd) ArgParserWithName(name string) *argparser.ArgParser {
 	ap.SupportsInt(queryParallelismFlag, "", "num-go-routines", "Deprecated, no effect in current versions of Dolt")
 	ap.SupportsInt(maxConnectionsFlag, "", "max-connections", fmt.Sprintf("Set the number of connections handled by the server. Defaults to `%d`.", serverConfig.MaxConnections()))
 	ap.SupportsInt(maxWaitConnectionsFlag, "", "back-log", fmt.Sprintf("Set the number of connections that can block waiting for a connection before new connections are rejected. Defaults to `%d`.", serverConfig.MaxWaitConnections()))
+	ap.SupportsString(maxWaitConsTimeoutFlag, "", "max-connections-timeout", fmt.Sprintf("Set the maximum duration that a connection will block waiting for a connection before being rejected. Defaults to `%v`.", serverConfig.MaxWaitConnectionsTimeout()))
 	ap.SupportsString(commands.PrivsFilePathFlag, "", "privilege file", "Path to a file to load and store users and grants. Defaults to `$doltcfg-dir/privileges.db`. Will be created as needed.")
 	ap.SupportsString(commands.BranchCtrlPathFlag, "", "branch control file", "Path to a file to load and store branch control permissions. Defaults to `$doltcfg-dir/branch_control.db`. Will be created as needed.")
 	ap.SupportsString(allowCleartextPasswordsFlag, "", "allow-cleartext-passwords", "Allows use of cleartext passwords. Defaults to false.")

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -48,6 +48,7 @@ const (
 	configFileFlag              = "config"
 	queryParallelismFlag        = "query-parallelism"
 	maxConnectionsFlag          = "max-connections"
+	maxWaitConnectionsFlag      = "back-log"
 	allowCleartextPasswordsFlag = "allow-cleartext-passwords"
 	socketFlag                  = "socket"
 	remotesapiPortFlag          = "remotesapi-port"
@@ -106,6 +107,8 @@ SUPPORTED CONFIG FILE FIELDS:
 {{.EmphasisLeft}}listener.port{{.EmphasisRight}}: The port that the server should listen on
 
 {{.EmphasisLeft}}listener.max_connections{{.EmphasisRight}}: The number of simultaneous connections that the server will accept
+
+{{.EmphasisLeft}}listener.back_log{{.EmphasisRight}}: The number of simultaneous connections that the server will allow to block waiting for a connection before new connections result in immediate rejection. Default 50.
 
 {{.EmphasisLeft}}listener.read_timeout_millis{{.EmphasisRight}}: The number of milliseconds that the server will wait for a read operation
 
@@ -179,6 +182,7 @@ func (cmd SqlServerCmd) ArgParserWithName(name string) *argparser.ArgParser {
 	ap.SupportsFlag(noAutoCommitFlag, "", "Set @@autocommit = off for the server.")
 	ap.SupportsInt(queryParallelismFlag, "", "num-go-routines", "Deprecated, no effect in current versions of Dolt")
 	ap.SupportsInt(maxConnectionsFlag, "", "max-connections", fmt.Sprintf("Set the number of connections handled by the server. Defaults to `%d`.", serverConfig.MaxConnections()))
+	ap.SupportsInt(maxWaitConnectionsFlag, "", "back-log", fmt.Sprintf("Set the number of connections that can block waiting for a connection before new connections are rejected. Defaults to `%d`.", serverConfig.MaxWaitConnections()))
 	ap.SupportsString(commands.PrivsFilePathFlag, "", "privilege file", "Path to a file to load and store users and grants. Defaults to `$doltcfg-dir/privileges.db`. Will be created as needed.")
 	ap.SupportsString(commands.BranchCtrlPathFlag, "", "branch control file", "Path to a file to load and store branch control permissions. Defaults to `$doltcfg-dir/branch_control.db`. Will be created as needed.")
 	ap.SupportsString(allowCleartextPasswordsFlag, "", "allow-cleartext-passwords", "Allows use of cleartext passwords. Defaults to false.")

--- a/go/libraries/doltcore/servercfg/serverconfig.go
+++ b/go/libraries/doltcore/servercfg/serverconfig.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 )
 
 var DefaultUnixSocketFilePath = DefaultMySQLUnixSocketFilePath
@@ -47,29 +48,30 @@ const (
 )
 
 const (
-	DefaultHost                    = "localhost"
-	DefaultPort                    = 3306
-	DefaultUser                    = "root"
-	DefaultPass                    = ""
-	DefaultTimeout                 = 8 * 60 * 60 * 1000 // 8 hours, same as MySQL
-	DefaultReadOnly                = false
-	DefaultLogLevel                = LogLevel_Info
-	DefaultLogFormat               = LogFormat_Text
-	DefaultAutoCommit              = true
-	DefaultAutoGCBehaviorEnable    = false
-	DefaultDoltTransactionCommit   = false
-	DefaultMaxConnections          = 1000
-	DefaultMaxWaitConnections      = 50
-	DefaultDataDir                 = "."
-	DefaultCfgDir                  = ".doltcfg"
-	DefaultPrivilegeFilePath       = "privileges.db"
-	DefaultBranchControlFilePath   = "branch_control.db"
-	DefaultMetricsHost             = ""
-	DefaultMetricsPort             = -1
-	DefaultAllowCleartextPasswords = false
-	DefaultMySQLUnixSocketFilePath = "/tmp/mysql.sock"
-	DefaultMaxLoggedQueryLen       = 0
-	DefaultEncodeLoggedQuery       = false
+	DefaultHost                      = "localhost"
+	DefaultPort                      = 3306
+	DefaultUser                      = "root"
+	DefaultPass                      = ""
+	DefaultTimeout                   = 8 * 60 * 60 * 1000 // 8 hours, same as MySQL
+	DefaultReadOnly                  = false
+	DefaultLogLevel                  = LogLevel_Info
+	DefaultLogFormat                 = LogFormat_Text
+	DefaultAutoCommit                = true
+	DefaultAutoGCBehaviorEnable      = false
+	DefaultDoltTransactionCommit     = false
+	DefaultMaxConnections            = 1000
+	DefaultMaxWaitConnections        = 50
+	DefaultMaxWaitConnectionsTimeout = 60 * time.Second
+	DefaultDataDir                   = "."
+	DefaultCfgDir                    = ".doltcfg"
+	DefaultPrivilegeFilePath         = "privileges.db"
+	DefaultBranchControlFilePath     = "branch_control.db"
+	DefaultMetricsHost               = ""
+	DefaultMetricsPort               = -1
+	DefaultAllowCleartextPasswords   = false
+	DefaultMySQLUnixSocketFilePath   = "/tmp/mysql.sock"
+	DefaultMaxLoggedQueryLen         = 0
+	DefaultEncodeLoggedQuery         = false
 )
 
 func ptr[T any](t T) *T {
@@ -163,6 +165,8 @@ type ServerConfig interface {
 	// MaxWaitConnections returns the maximum number of simultaneous connections that the server will allow to block waiting
 	// for a connection before new connections result in immediate rejection
 	MaxWaitConnections() uint32
+	// MaxWaitConnectionsTimeout returns the maximum amount of time that a connection will block waiting for a connection
+	MaxWaitConnectionsTimeout() time.Duration
 	// TLSKey returns a path to the servers PEM-encoded private TLS key. "" if there is none.
 	TLSKey() string
 	// TLSCert returns a path to the servers PEM-encoded TLS certificate chain. "" if there is none.
@@ -245,6 +249,7 @@ func defaultServerConfigYAML() *YAMLConfig {
 			PortNumber:              ptr(DefaultPort),
 			MaxConnections:          ptr(uint64(DefaultMaxConnections)),
 			BackLog:                 ptr(uint32(DefaultMaxWaitConnections)),
+			MaxConnectionsTimeoutMs: ptr(uint32(DefaultMaxWaitConnectionsTimeout.Seconds())),
 			ReadTimeoutMillis:       ptr(uint64(DefaultTimeout)),
 			WriteTimeoutMillis:      ptr(uint64(DefaultTimeout)),
 			AllowCleartextPasswords: ptr(DefaultAllowCleartextPasswords),
@@ -312,6 +317,7 @@ const (
 	CfgDirKey                       = "cfg_dir"
 	MaxConnectionsKey               = "max_connections"
 	MaxWaitConnectionsKey           = "back_log"
+	MaxWaitConnectionsTimeoutKey    = "max_connections_timeout"
 	TLSKeyKey                       = "tls_key"
 	TLSCertKey                      = "tls_cert"
 	RequireSecureTransportKey       = "require_secure_transport"

--- a/go/libraries/doltcore/servercfg/serverconfig.go
+++ b/go/libraries/doltcore/servercfg/serverconfig.go
@@ -249,7 +249,7 @@ func defaultServerConfigYAML() *YAMLConfig {
 			PortNumber:              ptr(DefaultPort),
 			MaxConnections:          ptr(uint64(DefaultMaxConnections)),
 			BackLog:                 ptr(uint32(DefaultMaxWaitConnections)),
-			MaxConnectionsTimeoutMs: ptr(uint32(DefaultMaxWaitConnectionsTimeout.Seconds())),
+			MaxConnectionsTimeoutMs: ptr(uint64(DefaultMaxWaitConnectionsTimeout.Milliseconds())),
 			ReadTimeoutMillis:       ptr(uint64(DefaultTimeout)),
 			WriteTimeoutMillis:      ptr(uint64(DefaultTimeout)),
 			AllowCleartextPasswords: ptr(DefaultAllowCleartextPasswords),

--- a/go/libraries/doltcore/servercfg/serverconfig.go
+++ b/go/libraries/doltcore/servercfg/serverconfig.go
@@ -59,6 +59,7 @@ const (
 	DefaultAutoGCBehaviorEnable    = false
 	DefaultDoltTransactionCommit   = false
 	DefaultMaxConnections          = 1000
+	DefaultMaxWaitConnections      = 50
 	DefaultDataDir                 = "."
 	DefaultCfgDir                  = ".doltcfg"
 	DefaultPrivilegeFilePath       = "privileges.db"
@@ -159,6 +160,9 @@ type ServerConfig interface {
 	CfgDir() string
 	// MaxConnections returns the maximum number of simultaneous connections the server will allow.  The default is 1
 	MaxConnections() uint64
+	// MaxWaitConnections returns the maximum number of simultaneous connections that the server will allow to block waiting
+	// for a connection before new connections result in immediate rejection
+	MaxWaitConnections() uint32
 	// TLSKey returns a path to the servers PEM-encoded private TLS key. "" if there is none.
 	TLSKey() string
 	// TLSCert returns a path to the servers PEM-encoded TLS certificate chain. "" if there is none.
@@ -240,6 +244,7 @@ func defaultServerConfigYAML() *YAMLConfig {
 			HostStr:                 ptr(DefaultHost),
 			PortNumber:              ptr(DefaultPort),
 			MaxConnections:          ptr(uint64(DefaultMaxConnections)),
+			BackLog:                 ptr(uint32(DefaultMaxWaitConnections)),
 			ReadTimeoutMillis:       ptr(uint64(DefaultTimeout)),
 			WriteTimeoutMillis:      ptr(uint64(DefaultTimeout)),
 			AllowCleartextPasswords: ptr(DefaultAllowCleartextPasswords),

--- a/go/libraries/doltcore/servercfg/serverconfig.go
+++ b/go/libraries/doltcore/servercfg/serverconfig.go
@@ -311,6 +311,7 @@ const (
 	DataDirKey                      = "data_dir"
 	CfgDirKey                       = "cfg_dir"
 	MaxConnectionsKey               = "max_connections"
+	MaxWaitConnectionsKey           = "back_log"
 	TLSKeyKey                       = "tls_key"
 	TLSCertKey                      = "tls_cert"
 	RequireSecureTransportKey       = "require_secure_transport"

--- a/go/libraries/doltcore/servercfg/yaml_config.go
+++ b/go/libraries/doltcore/servercfg/yaml_config.go
@@ -80,6 +80,7 @@ type ListenerYAMLConfig struct {
 	HostStr            *string `yaml:"host,omitempty"`
 	PortNumber         *int    `yaml:"port,omitempty"`
 	MaxConnections     *uint64 `yaml:"max_connections,omitempty"`
+	BackLog            *uint32 `yaml:"back_log,omitempty"`
 	ReadTimeoutMillis  *uint64 `yaml:"read_timeout_millis,omitempty"`
 	WriteTimeoutMillis *uint64 `yaml:"write_timeout_millis,omitempty"`
 	// TLSKey is a file system path to an unencrypted private TLS key in PEM format.
@@ -487,6 +488,9 @@ func (cfg YAMLConfig) withDefaultsFilledIn() YAMLConfig {
 	if withDefaults.ListenerConfig.MaxConnections == nil {
 		withDefaults.ListenerConfig.MaxConnections = defaults.ListenerConfig.MaxConnections
 	}
+	if withDefaults.ListenerConfig.BackLog == nil {
+		withDefaults.ListenerConfig.BackLog = defaults.ListenerConfig.BackLog
+	}
 	if withDefaults.ListenerConfig.ReadTimeoutMillis == nil {
 		withDefaults.ListenerConfig.ReadTimeoutMillis = defaults.ListenerConfig.ReadTimeoutMillis
 	}
@@ -657,6 +661,14 @@ func (cfg YAMLConfig) MaxConnections() uint64 {
 	}
 
 	return *cfg.ListenerConfig.MaxConnections
+}
+
+func (cfg YAMLConfig) MaxWaitConnections() uint32 {
+	if cfg.ListenerConfig.BackLog == nil {
+		return DefaultMaxWaitConnections
+	}
+
+	return *cfg.ListenerConfig.BackLog
 }
 
 // DisableClientMultiStatements returns true if the server should run in a mode

--- a/go/libraries/doltcore/servercfg/yaml_config.go
+++ b/go/libraries/doltcore/servercfg/yaml_config.go
@@ -198,6 +198,7 @@ func ServerConfigAsYAMLConfig(cfg ServerConfig) *YAMLConfig {
 			HostStr:                 ptr(cfg.Host()),
 			PortNumber:              ptr(cfg.Port()),
 			MaxConnections:          ptr(cfg.MaxConnections()),
+			BackLog:                 ptr(cfg.MaxWaitConnections()),
 			ReadTimeoutMillis:       ptr(cfg.ReadTimeout()),
 			WriteTimeoutMillis:      ptr(cfg.WriteTimeout()),
 			TLSKey:                  nillableStrPtr(cfg.TLSKey()),
@@ -268,6 +269,7 @@ func ServerConfigSetValuesAsYAMLConfig(cfg ServerConfig) *YAMLConfig {
 			HostStr:                 zeroIf(ptr(cfg.Host()), !cfg.ValueSet(HostKey)),
 			PortNumber:              zeroIf(ptr(cfg.Port()), !cfg.ValueSet(PortKey)),
 			MaxConnections:          zeroIf(ptr(cfg.MaxConnections()), !cfg.ValueSet(MaxConnectionsKey)),
+			BackLog:                 zeroIf(ptr(cfg.MaxWaitConnections()), !cfg.ValueSet(MaxWaitConnectionsKey)),
 			ReadTimeoutMillis:       zeroIf(ptr(cfg.ReadTimeout()), !cfg.ValueSet(ReadTimeoutKey)),
 			WriteTimeoutMillis:      zeroIf(ptr(cfg.WriteTimeout()), !cfg.ValueSet(WriteTimeoutKey)),
 			TLSKey:                  zeroIf(ptr(cfg.TLSKey()), !cfg.ValueSet(TLSKeyKey)),
@@ -958,6 +960,8 @@ func (cfg YAMLConfig) ValueSet(value string) bool {
 		return cfg.ListenerConfig.WriteTimeoutMillis != nil
 	case MaxConnectionsKey:
 		return cfg.ListenerConfig.MaxConnections != nil
+	case MaxWaitConnectionsKey:
+		return cfg.ListenerConfig.BackLog != nil
 	case EventSchedulerKey:
 		return cfg.BehaviorConfig.EventSchedulerStatus != nil
 	}

--- a/integration-tests/bats/sql-server-config-file-generation.bats
+++ b/integration-tests/bats/sql-server-config-file-generation.bats
@@ -99,7 +99,7 @@ EOF
         --timeout 7777777 \
         --allow-cleartext-passwords true \
         --back-log 767 \
-        --max-connections-timeout 13s \
+        --max-connections-timeout 6m13s \
         --host 0.0.0.0
 
     run cat "$CONFIG_FILE_NAME"
@@ -111,12 +111,7 @@ EOF
     [[ "$output" =~ "write_timeout_millis: 7777777" ]] || false
     [[ "$output" =~ "allow_cleartext_passwords: true" ]] || false
     [[ "$output" =~ "back_log: 767" ]] || false
-
-    echo "--------------------------"
-    echo "$output"
-    echo "--------------------------"
-
-    [[ "$output" =~ "max_connections_timeout: 676" ]] || false
+    [[ "$output" =~ "max_connections_timeout_millis: 373000" ]] || false
 }
 
 @test "sql-server-config-file-generation: generated config file uses default values as placeholders for unset fields" {

--- a/integration-tests/bats/sql-server-config-file-generation.bats
+++ b/integration-tests/bats/sql-server-config-file-generation.bats
@@ -99,6 +99,7 @@ EOF
         --timeout 7777777 \
         --allow-cleartext-passwords true \
         --back-log 767 \
+        --max-connections-timeout 13s \
         --host 0.0.0.0
 
     run cat "$CONFIG_FILE_NAME"
@@ -110,6 +111,12 @@ EOF
     [[ "$output" =~ "write_timeout_millis: 7777777" ]] || false
     [[ "$output" =~ "allow_cleartext_passwords: true" ]] || false
     [[ "$output" =~ "back_log: 767" ]] || false
+
+    echo "--------------------------"
+    echo "$output"
+    echo "--------------------------"
+
+    [[ "$output" =~ "max_connections_timeout: 676" ]] || false
 }
 
 @test "sql-server-config-file-generation: generated config file uses default values as placeholders for unset fields" {

--- a/integration-tests/bats/sql-server-config-file-generation.bats
+++ b/integration-tests/bats/sql-server-config-file-generation.bats
@@ -98,6 +98,7 @@ EOF
         --max-connections 77 \
         --timeout 7777777 \
         --allow-cleartext-passwords true \
+        --back-log 767 \
         --host 0.0.0.0
 
     run cat "$CONFIG_FILE_NAME"
@@ -108,6 +109,7 @@ EOF
     [[ "$output" =~ "read_timeout_millis: 7777777" ]] || false
     [[ "$output" =~ "write_timeout_millis: 7777777" ]] || false
     [[ "$output" =~ "allow_cleartext_passwords: true" ]] || false
+    [[ "$output" =~ "back_log: 767" ]] || false
 }
 
 @test "sql-server-config-file-generation: generated config file uses default values as placeholders for unset fields" {


### PR DESCRIPTION
This surfaces configuration in vitess to limit the back log of waiting connections and give them timeouts. Changes in
dolt are primarily tests and validation.

Related: https://github.com/dolthub/dolt/issues/8943