### PR TITLE
go: mvdata: Improve dump, import and export so that these commands create a single SqlEngine over their lifetime.

### DIFF
--- a/go/cmd/dolt/commands/dump.go
+++ b/go/cmd/dolt/commands/dump.go
@@ -181,10 +181,6 @@ func (cmd DumpCmd) Exec(ctx context.Context, commandStr string, args []string, d
 		}
 
 		if !apr.Contains(noCreateDbFlag) {
-			dbName, err := getActiveDatabaseName(ctx, dEnv)
-			if err != nil {
-				return HandleVErrAndExitCode(err, usage)
-			}
 			err = addCreateDatabaseHeader(dEnv, fPath, dbName)
 			if err != nil {
 				return HandleVErrAndExitCode(err, usage)
@@ -807,25 +803,4 @@ func addCreateDatabaseHeader(dEnv *env.DoltEnv, fPath, dbName string) errhand.Ve
 	_ = writer.Close()
 
 	return nil
-}
-
-// TODO: find a more elegant way to get database name, possibly implement a method in DoltEnv
-// getActiveDatabaseName returns the name of the current active database
-func getActiveDatabaseName(ctx context.Context, dEnv *env.DoltEnv) (string, errhand.VerboseError) {
-	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
-	if err != nil {
-		return "", errhand.VerboseErrorFromError(err)
-	}
-
-	// Choose the first DB as the current one. This will be the DB in the working dir if there was one there
-	var dbName string
-	err = mrEnv.Iter(func(name string, _ *env.DoltEnv) (stop bool, err error) {
-		dbName = name
-		return true, nil
-	})
-	if err != nil {
-		return "", errhand.VerboseErrorFromError(err)
-	}
-
-	return dbName, nil
 }

--- a/go/cmd/dolt/commands/tblcmds/export.go
+++ b/go/cmd/dolt/commands/tblcmds/export.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/fatih/color"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
@@ -207,6 +208,9 @@ func (cmd ExportCmd) Exec(ctx context.Context, commandStr string, args []string,
 	if berr != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(berr), usage)
 	}
+	defer sql.SessionEnd(sqlCtx.Session)
+	sql.SessionCommandBegin(sqlCtx.Session)
+	defer sql.SessionCommandEnd(sqlCtx.Session)
 	sqlCtx.SetCurrentDatabase(dbName)
 
 	rd, err := mvdata.NewSqlEngineReader(sqlCtx, engine.GetUnderlyingEngine(), root, exOpts.tableName)

--- a/go/cmd/dolt/commands/tblcmds/export.go
+++ b/go/cmd/dolt/commands/tblcmds/export.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands"
+	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	eventsapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
@@ -197,7 +198,18 @@ func (cmd ExportCmd) Exec(ctx context.Context, commandStr string, args []string,
 		return commands.HandleVErrAndExitCode(verr, usage)
 	}
 
-	rd, err := mvdata.NewSqlEngineReader(ctx, dEnv, exOpts.tableName)
+	engine, dbName, berr := engine.NewSqlEngineForEnv(ctx, dEnv)
+	if berr != nil {
+		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(berr), usage)
+	}
+	defer engine.Close()
+	sqlCtx, berr := engine.NewLocalContext(ctx)
+	if berr != nil {
+		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(berr), usage)
+	}
+	sqlCtx.SetCurrentDatabase(dbName)
+
+	rd, err := mvdata.NewSqlEngineReader(sqlCtx, engine.GetUnderlyingEngine(), root, exOpts.tableName)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.BuildDError("Error creating reader for %s.", exOpts.SrcName()).AddCause(err).Build(), usage)
 	}

--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -448,6 +448,9 @@ func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string,
 		verr = errhand.BuildDError("could not build sql context for import").AddCause(err).Build()
 		return commands.HandleVErrAndExitCode(verr, usage)
 	}
+	defer sql.SessionEnd(sqlCtx.Session)
+	sql.SessionCommandBegin(sqlCtx.Session)
+	defer sql.SessionCommandEnd(sqlCtx.Session)
 	sqlCtx.SetCurrentDatabase(dbName)
 
 	mvOpts, verr := getImportMoveOptions(sqlCtx, apr, dEnv, eng.GetUnderlyingEngine())

--- a/go/libraries/doltcore/mvdata/data_mover.go
+++ b/go/libraries/doltcore/mvdata/data_mover.go
@@ -19,8 +19,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dolthub/go-mysql-server/sql"
 	sqle "github.com/dolthub/go-mysql-server"
+	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"

--- a/go/libraries/doltcore/mvdata/data_mover.go
+++ b/go/libraries/doltcore/mvdata/data_mover.go
@@ -19,14 +19,16 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
+	"github.com/dolthub/go-mysql-server/sql"
+	sqle "github.com/dolthub/go-mysql-server"
+
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
-	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlutil"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table"
+	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/libraries/utils/set"
 )
 
@@ -41,11 +43,15 @@ type XlsxOptions struct {
 type JSONOptions struct {
 	TableName string
 	SchFile   string
+	SqlCtx    *sql.Context
+	Engine    *sqle.Engine
 }
 
 type ParquetOptions struct {
 	TableName string
 	SchFile   string
+	SqlCtx    *sql.Context
+	Engine    *sqle.Engine
 }
 
 type MoverOptions struct {
@@ -89,30 +95,14 @@ func (dmce *DataMoverCreationError) String() string {
 }
 
 // SchAndTableNameFromFile reads a SQL schema file and creates a Dolt schema from it.
-func SchAndTableNameFromFile(ctx context.Context, path string, dEnv *env.DoltEnv) (string, schema.Schema, error) {
-	root, err := dEnv.WorkingRoot(ctx)
-	if err != nil {
-		return "", nil, err
-	}
-	fs := dEnv.FS
-
+func SchAndTableNameFromFile(ctx *sql.Context, path string, fs filesys.Filesys, root doltdb.RootValue, engine *sqle.Engine) (string, schema.Schema, error) {
 	if path != "" {
 		data, err := fs.ReadFile(path)
 		if err != nil {
 			return "", nil, err
 		}
 
-		eng, dbName, err := engine.NewSqlEngineForEnv(ctx, dEnv)
-		if err != nil {
-			return "", nil, err
-		}
-
-		sqlCtx, err := eng.NewDefaultContext(ctx)
-		if err != nil {
-			return "", nil, err
-		}
-		sqlCtx.SetCurrentDatabase(dbName)
-		tn, sch, err := sqlutil.ParseCreateTableStatement(sqlCtx, root, eng.GetUnderlyingEngine(), string(data))
+		tn, sch, err := sqlutil.ParseCreateTableStatement(ctx, root, engine, string(data))
 
 		if err != nil {
 			return "", nil, fmt.Errorf("%s in schema file %s", err.Error(), path)

--- a/go/libraries/doltcore/mvdata/engine_table_writer.go
+++ b/go/libraries/doltcore/mvdata/engine_table_writer.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"sync/atomic"
 
+	sqle "github.com/dolthub/go-mysql-server"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/analyzer/analyzererrors"
 	"github.com/dolthub/go-mysql-server/sql/plan"
@@ -27,8 +28,6 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/rowexec"
 	"github.com/dolthub/go-mysql-server/sql/transform"
 
-	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
-	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlutil"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/typed/noms"
@@ -42,7 +41,7 @@ const (
 
 // SqlEngineTableWriter is a utility for importing a set of rows through the sql engine.
 type SqlEngineTableWriter struct {
-	se     *engine.SqlEngine
+	se     *sqle.Engine
 	sqlCtx *sql.Context
 
 	tableName  string
@@ -60,42 +59,11 @@ type SqlEngineTableWriter struct {
 	rowOperationSchema sql.PrimaryKeySchema
 }
 
-func NewSqlEngineTableWriter(ctx context.Context, dEnv *env.DoltEnv, createTableSchema, rowOperationSchema schema.Schema, options *MoverOptions, statsCB noms.StatsCB) (*SqlEngineTableWriter, error) {
-	// TODO: Assert that dEnv.DoltDB(ctx).AccessMode() != ReadOnly?
-
-	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
-	if err != nil {
-		return nil, err
-	}
-
-	// Simplest path would have our import path be a layer over load data
-	config := &engine.SqlEngineConfig{
-		ServerUser: "root",
-		Autocommit: false, // We set autocommit == false to ensure to improve performance. Bulk import should not commit on each row.
-		Bulk:       true,
-	}
-	se, err := engine.NewSqlEngine(
-		ctx,
-		mrEnv,
-		config,
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer se.Close()
-
-	dbName := mrEnv.GetFirstDatabase()
-
-	if se.GetUnderlyingEngine().IsReadOnly() {
+func NewSqlEngineTableWriter(ctx *sql.Context, engine *sqle.Engine, createTableSchema, rowOperationSchema schema.Schema, options *MoverOptions, statsCB noms.StatsCB) (*SqlEngineTableWriter, error) {
+	if engine.IsReadOnly() {
 		// SqlEngineTableWriter does not respect read only mode
-		return nil, analyzererrors.ErrReadOnlyDatabase.New(dbName)
+		return nil, analyzererrors.ErrReadOnlyDatabase.New(ctx.GetCurrentDatabase())
 	}
-
-	sqlCtx, err := se.NewLocalContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-	sqlCtx.SetCurrentDatabase(dbName)
 
 	doltCreateTableSchema, err := sqlutil.FromDoltSchema("", options.TableToWriteTo, createTableSchema)
 	if err != nil {
@@ -108,13 +76,13 @@ func NewSqlEngineTableWriter(ctx context.Context, dEnv *env.DoltEnv, createTable
 	}
 
 	return &SqlEngineTableWriter{
-		se:         se,
-		sqlCtx:     sqlCtx,
+		se:         engine,
+		sqlCtx:     ctx,
 		contOnErr:  options.ContinueOnErr,
 		force:      options.Force,
 		disableFks: options.DisableFks,
 
-		database:  dbName,
+		database:  ctx.GetCurrentDatabase(),
 		tableName: options.TableToWriteTo,
 
 		statsCB: statsCB,
@@ -374,7 +342,7 @@ func (s *SqlEngineTableWriter) getInsertNode(inputChannel chan sql.Row, replace 
 		sep = ", "
 	}
 
-	sqlEngine := s.se.GetUnderlyingEngine()
+	sqlEngine := s.se
 	binder := planbuilder.New(s.sqlCtx, sqlEngine.Analyzer.Catalog, sqlEngine.EventScheduler, sqlEngine.Parser)
 	insert := fmt.Sprintf("insert into `%s` (%s) VALUES (%s)%s", s.tableName, colNames, values, duplicate)
 	parsed, _, _, qFlags, err := binder.Parse(insert, nil, false)
@@ -401,7 +369,7 @@ func (s *SqlEngineTableWriter) getInsertNode(inputChannel chan sql.Row, replace 
 
 	parsedIns.Ignore = s.contOnErr
 	parsedIns.IsReplace = replace
-	analyzed, err := s.se.Analyze(s.sqlCtx, parsedIns, qFlags)
+	analyzed, err := s.se.Analyzer.Analyze(s.sqlCtx, parsedIns, nil, qFlags)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/mvdata/file_data_loc.go
+++ b/go/libraries/doltcore/mvdata/file_data_loc.go
@@ -121,7 +121,7 @@ func (dl FileDataLocation) NewReader(ctx context.Context, dEnv *env.DoltEnv, opt
 		var sch schema.Schema
 		jsonOpts, _ := opts.(JSONOptions)
 		if jsonOpts.SchFile != "" {
-			tn, s, err := SchAndTableNameFromFile(ctx, jsonOpts.SchFile, dEnv)
+			tn, s, err := SchAndTableNameFromFile(jsonOpts.SqlCtx, jsonOpts.SchFile, dEnv.FS, root, jsonOpts.Engine)
 			if err != nil {
 				return nil, false, err
 			}
@@ -153,7 +153,7 @@ func (dl FileDataLocation) NewReader(ctx context.Context, dEnv *env.DoltEnv, opt
 		var tableSch schema.Schema
 		parquetOpts, _ := opts.(ParquetOptions)
 		if parquetOpts.SchFile != "" {
-			tn, s, tnErr := SchAndTableNameFromFile(ctx, parquetOpts.SchFile, dEnv)
+			tn, s, tnErr := SchAndTableNameFromFile(parquetOpts.SqlCtx, parquetOpts.SchFile, dEnv.FS, root, parquetOpts.Engine)
 			if tnErr != nil {
 				return nil, false, tnErr
 			}


### PR DESCRIPTION
Pass the SqlEngine along and reuse it in the operations where we dump table contents, parse import schemas, etc.