### PR TITLE
go: store/datas/pull: Error handling improvements. Target an approximate file size instead of a number of chunks when uploading files.

### DIFF
--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -60,7 +60,7 @@ const (
 	CreationBranch = "create"
 
 	// 1GB.
-	defaultTargetFileSize = 1<<30
+	defaultTargetFileSize = 1 << 30
 )
 
 var ErrMissingDoltDataDir = errors.New("missing dolt data directory")

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -59,7 +59,8 @@ const (
 const (
 	CreationBranch = "create"
 
-	defaultChunksPerTF = 256 * 1024
+	// 1GB.
+	defaultTargetFileSize = 1<<30
 )
 
 var ErrMissingDoltDataDir = errors.New("missing dolt data directory")
@@ -1883,7 +1884,7 @@ func pullHash(
 	waf := types.WalkAddrsForNBF(srcDB.Format(), skipHashes)
 
 	if datas.CanUsePuller(srcDB) && datas.CanUsePuller(destDB) {
-		puller, err := pull.NewPuller(ctx, tempDir, defaultChunksPerTF, srcCS, destCS, waf, targetHashes, statsCh)
+		puller, err := pull.NewPuller(ctx, tempDir, defaultTargetFileSize, srcCS, destCS, waf, targetHashes, statsCh)
 		if err == pull.ErrDBUpToDate {
 			return nil
 		} else if err != nil {

--- a/go/store/datas/pull/pull_chunk_fetcher.go
+++ b/go/store/datas/pull/pull_chunk_fetcher.go
@@ -16,10 +16,9 @@ package pull
 
 import (
 	"context"
+	"errors"
 	"io"
 	"sync"
-
-	"golang.org/x/sync/errgroup"
 
 	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/nbs"
@@ -37,7 +36,7 @@ func GetChunkFetcher(ctx context.Context, cs GetManyer) nbs.ChunkFetcher {
 	if fable, ok := cs.(ChunkFetcherable); ok {
 		return fable.ChunkFetcher(ctx)
 	}
-	return NewPullChunkFetcher(ctx, cs)
+	return NewPullChunkFetcher(cs)
 }
 
 // A PullChunkFetcher is a simple implementation of |ChunkFetcher| based on
@@ -45,95 +44,58 @@ func GetChunkFetcher(ctx context.Context, cs GetManyer) nbs.ChunkFetcher {
 //
 // It only has one outstanding GetManyCompressed call at a time.
 type PullChunkFetcher struct {
-	ctx context.Context
-	eg  *errgroup.Group
-
-	getter GetManyer
-
-	batchCh chan hash.HashSet
-	doneCh  chan struct{}
-	resCh   chan nbs.ToChunker
+	getter   GetManyer
+	resCh    chan nbs.ToChunker
+	closedCh chan struct{}
 }
 
-func NewPullChunkFetcher(ctx context.Context, getter GetManyer) *PullChunkFetcher {
-	eg, ctx := errgroup.WithContext(ctx)
+func NewPullChunkFetcher(getter GetManyer) *PullChunkFetcher {
 	ret := &PullChunkFetcher{
-		ctx:     ctx,
-		eg:      eg,
-		getter:  getter,
-		batchCh: make(chan hash.HashSet),
-		doneCh:  make(chan struct{}),
-		resCh:   make(chan nbs.ToChunker),
+		getter:   getter,
+		resCh:    make(chan nbs.ToChunker),
+		closedCh: make(chan struct{}),
 	}
-	ret.eg.Go(func() error {
-		return ret.fetcherThread(ctx)
-	})
 	return ret
 }
 
-func (f *PullChunkFetcher) fetcherThread(ctx context.Context) error {
-	for {
+func (f *PullChunkFetcher) Get(ctx context.Context, hashes hash.HashSet) error {
+	var mu sync.Mutex
+	missing := hashes.Copy()
+	// Blocking get, no concurrency, only one fetcher.
+	err := f.getter.GetManyCompressed(ctx, hashes, func(ctx context.Context, chk nbs.ToChunker) {
+		mu.Lock()
+		missing.Remove(chk.Hash())
+		mu.Unlock()
 		select {
-		case batch, ok := <-f.batchCh:
-			if !ok {
-				close(f.resCh)
-				return nil
-			}
+		case <-ctx.Done():
+		case f.resCh <- chk:
+		}
+	})
+	if err != nil {
+		return err
+	}
 
-			var mu sync.Mutex
-			missing := batch.Copy()
-
-			// Blocking get, no concurrency, only one fetcher.
-			err := f.getter.GetManyCompressed(ctx, batch, func(ctx context.Context, chk nbs.ToChunker) {
-				mu.Lock()
-				missing.Remove(chk.Hash())
-				mu.Unlock()
-				select {
-				case <-ctx.Done():
-				case f.resCh <- chk:
-				case <-f.doneCh:
-				}
-			})
-			if err != nil {
-				return err
-			}
-
-			for h := range missing {
-				select {
-				case <-ctx.Done():
-					return context.Cause(ctx)
-				case f.resCh <- nbs.CompressedChunk{H: h}:
-				case <-f.doneCh:
-					return nil
-				}
-			}
+	for h := range missing {
+		select {
 		case <-ctx.Done():
 			return context.Cause(ctx)
-		case <-f.doneCh:
-			return nil
+		case f.resCh <- nbs.CompressedChunk{H: h}:
+		case <-f.closedCh:
+			return errors.New("PullChunkFetcher: Get on closed Fetcher.")
 		}
 	}
-}
 
-func (f *PullChunkFetcher) Get(ctx context.Context, hashes hash.HashSet) error {
-	select {
-	case f.batchCh <- hashes:
-		return nil
-	case <-ctx.Done():
-		return context.Cause(ctx)
-	case <-f.ctx.Done():
-		return context.Cause(f.ctx)
-	}
+	return nil
 }
 
 func (f *PullChunkFetcher) CloseSend() error {
-	close(f.batchCh)
+	close(f.resCh)
 	return nil
 }
 
 func (f *PullChunkFetcher) Close() error {
-	close(f.doneCh)
-	return f.eg.Wait()
+	close(f.closedCh)
+	return nil
 }
 
 func (f *PullChunkFetcher) Recv(ctx context.Context) (nbs.ToChunker, error) {
@@ -145,7 +107,7 @@ func (f *PullChunkFetcher) Recv(ctx context.Context) (nbs.ToChunker, error) {
 		return res, nil
 	case <-ctx.Done():
 		return nbs.CompressedChunk{}, context.Cause(ctx)
-	case <-f.ctx.Done():
-		return nbs.CompressedChunk{}, context.Cause(f.ctx)
+	case <-f.closedCh:
+		return nbs.CompressedChunk{}, errors.New("PullChunkFetcher: Recv on closed Fetcher.")
 	}
 }

--- a/go/store/datas/pull/pull_chunk_tracker.go
+++ b/go/store/datas/pull/pull_chunk_tracker.go
@@ -18,8 +18,9 @@ import (
 	"context"
 	"errors"
 
-	"github.com/dolthub/dolt/go/store/hash"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 type HasManyer interface {

--- a/go/store/datas/pull/pull_chunk_tracker.go
+++ b/go/store/datas/pull/pull_chunk_tracker.go
@@ -17,9 +17,9 @@ package pull
 import (
 	"context"
 	"errors"
-	"sync"
 
 	"github.com/dolthub/dolt/go/store/hash"
+	"golang.org/x/sync/errgroup"
 )
 
 type HasManyer interface {
@@ -46,38 +46,37 @@ const hasManyThreadCount = 3
 // parallel with other work the Puller does and abstracts out the logic for
 // keeping track of seen, unchecked and to pull hcunk addresses.
 type PullChunkTracker struct {
-	ctx  context.Context
 	seen hash.HashSet
 	cfg  TrackerConfig
-	wg   sync.WaitGroup
 
 	uncheckedCh chan hash.Hash
 	processedCh chan struct{}
+	doneCh      chan struct{}
 	reqCh       chan *trackerGetAbsentReq
 }
 
-func NewPullChunkTracker(ctx context.Context, initial hash.HashSet, cfg TrackerConfig) *PullChunkTracker {
+func NewPullChunkTracker(cfg TrackerConfig) *PullChunkTracker {
 	ret := &PullChunkTracker{
-		ctx:         ctx,
 		seen:        make(hash.HashSet),
 		cfg:         cfg,
 		uncheckedCh: make(chan hash.Hash),
 		processedCh: make(chan struct{}),
+		doneCh:      make(chan struct{}),
 		reqCh:       make(chan *trackerGetAbsentReq),
 	}
-	ret.seen.InsertAll(initial)
-	ret.wg.Add(1)
-	go func() {
-		defer ret.wg.Done()
-		ret.reqRespThread(initial)
-	}()
 	return ret
 }
 
-func (t *PullChunkTracker) Seen(h hash.Hash) {
+func (t *PullChunkTracker) Run(ctx context.Context, initial hash.HashSet) error {
+	defer close(t.doneCh)
+	t.seen.InsertAll(initial)
+	return t.reqRespThread(ctx, initial)
+}
+
+func (t *PullChunkTracker) Seen(ctx context.Context, h hash.Hash) {
 	if !t.seen.Has(h) {
 		t.seen.Insert(h)
-		t.addUnchecked(h)
+		t.addUnchecked(ctx, h)
 	}
 }
 
@@ -85,39 +84,39 @@ func (t *PullChunkTracker) Seen(h hash.Hash) {
 //
 // GetChunksToFetch() requires a matching |TickProcessed| call for each
 // returned Hash before it will return |hasMany == false|.
-func (t *PullChunkTracker) TickProcessed() {
+func (t *PullChunkTracker) TickProcessed(ctx context.Context) {
 	select {
 	case t.processedCh <- struct{}{}:
-	case <-t.ctx.Done():
+	case <-ctx.Done():
 	}
 }
 
 func (t *PullChunkTracker) Close() {
 	close(t.uncheckedCh)
-	t.wg.Wait()
+	<-t.doneCh
 }
 
-func (t *PullChunkTracker) addUnchecked(h hash.Hash) {
+func (t *PullChunkTracker) addUnchecked(ctx context.Context, h hash.Hash) {
 	select {
 	case t.uncheckedCh <- h:
-	case <-t.ctx.Done():
+	case <-ctx.Done():
 	}
 }
 
-func (t *PullChunkTracker) GetChunksToFetch() (hash.HashSet, bool, error) {
+func (t *PullChunkTracker) GetChunksToFetch(ctx context.Context) (hash.HashSet, bool, error) {
 	var req trackerGetAbsentReq
 	req.ready = make(chan struct{})
 
 	select {
 	case t.reqCh <- &req:
-	case <-t.ctx.Done():
-		return nil, false, context.Cause(t.ctx)
+	case <-ctx.Done():
+		return nil, false, context.Cause(ctx)
 	}
 
 	select {
 	case <-req.ready:
-	case <-t.ctx.Done():
-		return nil, false, context.Cause(t.ctx)
+	case <-ctx.Done():
+		return nil, false, context.Cause(ctx)
 	}
 
 	return req.hs, req.ok, req.err
@@ -125,121 +124,120 @@ func (t *PullChunkTracker) GetChunksToFetch() (hash.HashSet, bool, error) {
 
 // The main logic of the PullChunkTracker, receives requests from other threads
 // and responds to them.
-func (t *PullChunkTracker) reqRespThread(initial hash.HashSet) {
+func (t *PullChunkTracker) reqRespThread(ctx context.Context, initial hash.HashSet) error {
 	doneCh := make(chan struct{})
 	hasManyReqCh := make(chan trackerHasManyReq)
 	hasManyRespCh := make(chan trackerHasManyResp)
 
-	var wg sync.WaitGroup
-	wg.Add(hasManyThreadCount)
+	eg, ctx := errgroup.WithContext(ctx)
 
 	for i := 0; i < hasManyThreadCount; i++ {
-		go func() {
-			defer wg.Done()
-			hasManyThread(t.ctx, t.cfg.HasManyer, hasManyReqCh, hasManyRespCh, doneCh)
-		}()
+		eg.Go(func() error {
+			return hasManyThread(ctx, t.cfg.HasManyer, hasManyReqCh, hasManyRespCh, doneCh)
+		})
 	}
 
-	defer func() {
-		close(doneCh)
-		wg.Wait()
-	}()
+	eg.Go(func() error {
+		defer close(doneCh)
 
-	unchecked := make([]hash.HashSet, 0)
-	absent := make([]hash.HashSet, 0)
+		unchecked := make([]hash.HashSet, 0)
+		absent := make([]hash.HashSet, 0)
 
-	var err error
-	outstanding := 0
-	unprocessed := 0
+		var err error
+		outstanding := 0
+		unprocessed := 0
 
-	if len(initial) > 0 {
-		unchecked = append(unchecked, initial)
-		outstanding += 1
-	}
-
-	for {
-		var thisReqCh = t.reqCh
-		if len(absent) == 0 && (outstanding != 0 || unprocessed != 0) {
-			// If we are waiting for a HasMany response and we don't currently have any
-			// absent addresses to return, block any absent requests.
-			thisReqCh = nil
+		if len(initial) > 0 {
+			unchecked = append(unchecked, initial)
+			outstanding += 1
 		}
 
-		var thisHasManyReqCh chan trackerHasManyReq
-		var hasManyReq trackerHasManyReq
-		if len(unchecked) > 0 {
-			hasManyReq.hs = unchecked[0]
-			thisHasManyReqCh = hasManyReqCh
-		}
+		for {
+			var thisReqCh = t.reqCh
+			if len(absent) == 0 && (outstanding != 0 || unprocessed != 0) {
+				// If we are waiting for a HasMany response and we don't currently have any
+				// absent addresses to return, block any absent requests.
+				thisReqCh = nil
+			}
 
-		select {
-		case h, ok := <-t.uncheckedCh:
-			if !ok {
-				return
+			var thisHasManyReqCh chan trackerHasManyReq
+			var hasManyReq trackerHasManyReq
+			if len(unchecked) > 0 {
+				hasManyReq.hs = unchecked[0]
+				thisHasManyReqCh = hasManyReqCh
 			}
-			if len(unchecked) == 0 || len(unchecked[len(unchecked)-1]) >= t.cfg.BatchSize {
-				outstanding += 1
-				unchecked = append(unchecked, make(hash.HashSet))
-			}
-			unchecked[len(unchecked)-1].Insert(h)
-		case resp := <-hasManyRespCh:
-			outstanding -= 1
-			if resp.err != nil {
-				err = errors.Join(err, resp.err)
-			} else if len(resp.hs) > 0 {
-				absent = append(absent, resp.hs)
-			}
-		case thisHasManyReqCh <- hasManyReq:
-			copy(unchecked[:], unchecked[1:])
-			if len(unchecked) > 1 {
-				unchecked[len(unchecked)-1] = nil
-			}
-			unchecked = unchecked[:len(unchecked)-1]
-		case <-t.processedCh:
-			unprocessed -= 1
-		case req := <-thisReqCh:
-			if err != nil {
-				req.err = err
-				close(req.ready)
-				err = nil
-			} else if len(absent) == 0 {
-				req.ok = false
-				close(req.ready)
-			} else {
-				req.ok = true
-				req.hs = absent[0]
-				var i int
-				for i = 1; i < len(absent); i++ {
-					l := len(absent[i])
-					if len(req.hs)+l < t.cfg.BatchSize {
-						req.hs.InsertAll(absent[i])
-					} else {
-						for h := range absent[i] {
-							if len(req.hs) >= t.cfg.BatchSize {
-								break
+
+			select {
+			case h, ok := <-t.uncheckedCh:
+				if !ok {
+					return nil
+				}
+				if len(unchecked) == 0 || len(unchecked[len(unchecked)-1]) >= t.cfg.BatchSize {
+					outstanding += 1
+					unchecked = append(unchecked, make(hash.HashSet))
+				}
+				unchecked[len(unchecked)-1].Insert(h)
+			case resp := <-hasManyRespCh:
+				outstanding -= 1
+				if resp.err != nil {
+					err = errors.Join(err, resp.err)
+				} else if len(resp.hs) > 0 {
+					absent = append(absent, resp.hs)
+				}
+			case thisHasManyReqCh <- hasManyReq:
+				copy(unchecked[:], unchecked[1:])
+				if len(unchecked) > 1 {
+					unchecked[len(unchecked)-1] = nil
+				}
+				unchecked = unchecked[:len(unchecked)-1]
+			case <-t.processedCh:
+				unprocessed -= 1
+			case req := <-thisReqCh:
+				if err != nil {
+					req.err = err
+					close(req.ready)
+					err = nil
+				} else if len(absent) == 0 {
+					req.ok = false
+					close(req.ready)
+				} else {
+					req.ok = true
+					req.hs = absent[0]
+					var i int
+					for i = 1; i < len(absent); i++ {
+						l := len(absent[i])
+						if len(req.hs)+l < t.cfg.BatchSize {
+							req.hs.InsertAll(absent[i])
+						} else {
+							for h := range absent[i] {
+								if len(req.hs) >= t.cfg.BatchSize {
+									break
+								}
+								req.hs.Insert(h)
+								absent[i].Remove(h)
 							}
-							req.hs.Insert(h)
-							absent[i].Remove(h)
+							break
 						}
-						break
 					}
+					copy(absent[:], absent[i:])
+					for j := len(absent) - i; j < len(absent); j++ {
+						absent[j] = nil
+					}
+					absent = absent[:len(absent)-i]
+					unprocessed += len(req.hs)
+					close(req.ready)
 				}
-				copy(absent[:], absent[i:])
-				for j := len(absent) - i; j < len(absent); j++ {
-					absent[j] = nil
-				}
-				absent = absent[:len(absent)-i]
-				unprocessed += len(req.hs)
-				close(req.ready)
+			case <-ctx.Done():
+				return context.Cause(ctx)
 			}
-		case <-t.ctx.Done():
-			return
 		}
-	}
+	})
+
+	return eg.Wait()
 }
 
 // Run by a PullChunkTracker, calls HasMany on a batch of addresses and delivers the results.
-func hasManyThread(ctx context.Context, hasManyer HasManyer, reqCh <-chan trackerHasManyReq, respCh chan<- trackerHasManyResp, doneCh <-chan struct{}) {
+func hasManyThread(ctx context.Context, hasManyer HasManyer, reqCh <-chan trackerHasManyReq, respCh chan<- trackerHasManyResp, doneCh <-chan struct{}) error {
 	for {
 		select {
 		case req := <-reqCh:
@@ -248,23 +246,23 @@ func hasManyThread(ctx context.Context, hasManyer HasManyer, reqCh <-chan tracke
 				select {
 				case respCh <- trackerHasManyResp{err: err}:
 				case <-ctx.Done():
-					return
+					return context.Cause(ctx)
 				case <-doneCh:
-					return
+					return nil
 				}
 			} else {
 				select {
 				case respCh <- trackerHasManyResp{hs: hs}:
 				case <-ctx.Done():
-					return
+					return context.Cause(ctx)
 				case <-doneCh:
-					return
+					return nil
 				}
 			}
 		case <-doneCh:
-			return
+			return nil
 		case <-ctx.Done():
-			return
+			return context.Cause(ctx)
 		}
 	}
 }

--- a/go/store/datas/pull/pull_chunk_tracker_test.go
+++ b/go/store/datas/pull/pull_chunk_tracker_test.go
@@ -19,10 +19,10 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 func TestPullChunkTracker(t *testing.T) {
@@ -216,7 +216,7 @@ func TestPullChunkTracker(t *testing.T) {
 			BatchSize: 64 * 1024,
 			HasManyer: haser,
 		})
-		
+
 		eg, ctx := errgroup.WithContext(context.Background())
 		eg.Go(func() error {
 			return tracker.Run(ctx, hs)

--- a/go/store/datas/pull/pull_chunk_tracker_test.go
+++ b/go/store/datas/pull/pull_chunk_tracker_test.go
@@ -20,134 +20,175 @@ import (
 	"testing"
 
 	"github.com/dolthub/dolt/go/store/hash"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPullChunkTracker(t *testing.T) {
 	t.Run("Empty", func(t *testing.T) {
-		tracker := NewPullChunkTracker(context.Background(), make(hash.HashSet), TrackerConfig{
+		eg, ctx := errgroup.WithContext(context.Background())
+		tracker := NewPullChunkTracker(TrackerConfig{
 			BatchSize: 64 * 1024,
 			HasManyer: nil,
 		})
-		hs, ok, err := tracker.GetChunksToFetch()
-		assert.Len(t, hs, 0)
-		assert.False(t, ok)
-		assert.NoError(t, err)
-		tracker.Close()
+		eg.Go(func() error {
+			return tracker.Run(ctx, make(hash.HashSet))
+		})
+		eg.Go(func() error {
+			hs, ok, err := tracker.GetChunksToFetch(ctx)
+			assert.Len(t, hs, 0)
+			assert.False(t, ok)
+			assert.NoError(t, err)
+			tracker.Close()
+			return nil
+		})
+		assert.NoError(t, eg.Wait())
 	})
 
 	t.Run("HasAllInitial", func(t *testing.T) {
+		eg, ctx := errgroup.WithContext(context.Background())
 		hs := make(hash.HashSet)
 		for i := byte(0); i < byte(10); i++ {
 			var h hash.Hash
 			h[0] = i
 			hs.Insert(h)
 		}
-		tracker := NewPullChunkTracker(context.Background(), hs, TrackerConfig{
+		tracker := NewPullChunkTracker(TrackerConfig{
 			BatchSize: 64 * 1024,
 			HasManyer: hasAllHaser{},
 		})
-		hs, ok, err := tracker.GetChunksToFetch()
-		assert.Len(t, hs, 0)
-		assert.False(t, ok)
-		assert.NoError(t, err)
-		tracker.Close()
+		eg.Go(func() error {
+			return tracker.Run(ctx, hs)
+		})
+		eg.Go(func() error {
+			hs, ok, err := tracker.GetChunksToFetch(ctx)
+			assert.Len(t, hs, 0)
+			assert.False(t, ok)
+			assert.NoError(t, err)
+			tracker.Close()
+			return nil
+		})
+		assert.NoError(t, eg.Wait())
 	})
 
 	t.Run("HasNoneInitial", func(t *testing.T) {
+		eg, ctx := errgroup.WithContext(context.Background())
 		hs := make(hash.HashSet)
 		for i := byte(1); i <= byte(10); i++ {
 			var h hash.Hash
 			h[0] = i
 			hs.Insert(h)
 		}
-		tracker := NewPullChunkTracker(context.Background(), hs, TrackerConfig{
+		tracker := NewPullChunkTracker(TrackerConfig{
 			BatchSize: 64 * 1024,
 			HasManyer: hasNoneHaser{},
 		})
-		hs, ok, err := tracker.GetChunksToFetch()
-		assert.Len(t, hs, 10)
-		assert.True(t, ok)
-		assert.NoError(t, err)
-		for _ = range hs {
-			tracker.TickProcessed()
-		}
-		hs, ok, err = tracker.GetChunksToFetch()
-		assert.Len(t, hs, 0)
-		assert.False(t, ok)
-		assert.NoError(t, err)
-
-		for i := byte(1); i <= byte(10); i++ {
-			var h hash.Hash
-			h[1] = i
-			tracker.Seen(h)
-		}
-
-		cnt := 0
-		for {
-			hs, ok, err := tracker.GetChunksToFetch()
+		eg.Go(func() error {
+			return tracker.Run(ctx, hs)
+		})
+		eg.Go(func() error {
+			hs, ok, err := tracker.GetChunksToFetch(ctx)
+			assert.Len(t, hs, 10)
+			assert.True(t, ok)
 			assert.NoError(t, err)
-			if !ok {
-				assert.Equal(t, 10, cnt)
-				break
-			}
-			cnt += len(hs)
 			for _ = range hs {
-				tracker.TickProcessed()
+				tracker.TickProcessed(ctx)
 			}
-		}
+			hs, ok, err = tracker.GetChunksToFetch(ctx)
+			assert.Len(t, hs, 0)
+			assert.False(t, ok)
+			assert.NoError(t, err)
 
-		tracker.Close()
+			for i := byte(1); i <= byte(10); i++ {
+				var h hash.Hash
+				h[1] = i
+				tracker.Seen(ctx, h)
+			}
+
+			cnt := 0
+			for {
+				hs, ok, err := tracker.GetChunksToFetch(ctx)
+				assert.NoError(t, err)
+				if !ok {
+					assert.Equal(t, 10, cnt)
+					break
+				}
+				cnt += len(hs)
+				for _ = range hs {
+					tracker.TickProcessed(ctx)
+				}
+			}
+
+			tracker.Close()
+			return nil
+		})
+		assert.NoError(t, eg.Wait())
 	})
 
 	t.Run("HasManyError", func(t *testing.T) {
+		eg, ctx := errgroup.WithContext(context.Background())
 		hs := make(hash.HashSet)
 		for i := byte(0); i < byte(10); i++ {
 			var h hash.Hash
 			h[0] = i
 			hs.Insert(h)
 		}
-		tracker := NewPullChunkTracker(context.Background(), hs, TrackerConfig{
+		tracker := NewPullChunkTracker(TrackerConfig{
 			BatchSize: 64 * 1024,
 			HasManyer: errHaser{},
 		})
-		_, _, err := tracker.GetChunksToFetch()
-		assert.Error(t, err)
-		tracker.Close()
+		eg.Go(func() error {
+			return tracker.Run(ctx, hs)
+		})
+		eg.Go(func() error {
+			_, _, err := tracker.GetChunksToFetch(ctx)
+			assert.Error(t, err)
+			tracker.Close()
+			return nil
+		})
+		assert.NoError(t, eg.Wait())
 	})
 
 	t.Run("InitialAreSeen", func(t *testing.T) {
+		eg, ctx := errgroup.WithContext(context.Background())
 		hs := make(hash.HashSet)
 		for i := byte(0); i < byte(10); i++ {
 			var h hash.Hash
 			h[0] = i
 			hs.Insert(h)
 		}
-		tracker := NewPullChunkTracker(context.Background(), hs, TrackerConfig{
+		tracker := NewPullChunkTracker(TrackerConfig{
 			BatchSize: 64 * 1024,
 			HasManyer: hasNoneHaser{},
 		})
-		hs, ok, err := tracker.GetChunksToFetch()
-		assert.Len(t, hs, 10)
-		assert.True(t, ok)
-		assert.NoError(t, err)
+		eg.Go(func() error {
+			return tracker.Run(ctx, hs)
+		})
+		eg.Go(func() error {
+			hs, ok, err := tracker.GetChunksToFetch(ctx)
+			assert.Len(t, hs, 10)
+			assert.True(t, ok)
+			assert.NoError(t, err)
 
-		for i := byte(0); i < byte(10); i++ {
-			var h hash.Hash
-			h[0] = i
-			tracker.Seen(h)
-		}
-		for _ = range hs {
-			tracker.TickProcessed()
-		}
+			for i := byte(0); i < byte(10); i++ {
+				var h hash.Hash
+				h[0] = i
+				tracker.Seen(ctx, h)
+			}
+			for _ = range hs {
+				tracker.TickProcessed(ctx)
+			}
 
-		hs, ok, err = tracker.GetChunksToFetch()
-		assert.Len(t, hs, 0)
-		assert.False(t, ok)
-		assert.NoError(t, err)
+			hs, ok, err = tracker.GetChunksToFetch(ctx)
+			assert.Len(t, hs, 0)
+			assert.False(t, ok)
+			assert.NoError(t, err)
 
-		tracker.Close()
+			tracker.Close()
+			return nil
+		})
+		assert.NoError(t, eg.Wait())
 	})
 
 	t.Run("StaticHaser", func(t *testing.T) {
@@ -171,43 +212,51 @@ func TestPullChunkTracker(t *testing.T) {
 			h[0] = i
 			hs.Insert(h)
 		}
-		tracker := NewPullChunkTracker(context.Background(), hs, TrackerConfig{
+		tracker := NewPullChunkTracker(TrackerConfig{
 			BatchSize: 64 * 1024,
 			HasManyer: haser,
 		})
-
-		// Should get back 03, 04, 05
-		hs, ok, err := tracker.GetChunksToFetch()
-		assert.Len(t, hs, 3)
-		assert.True(t, ok)
-		assert.NoError(t, err)
-		for _ = range hs {
-			tracker.TickProcessed()
-		}
-
-		for i := byte(1); i <= byte(10); i++ {
-			var h hash.Hash
-			h[0] = 1
-			h[1] = i
-			tracker.Seen(h)
-		}
-
-		// Should get back 13, 14, 15, 16, 17, 18, 19, 1(10).
-		cnt := 0
-		for {
-			hs, ok, err := tracker.GetChunksToFetch()
+		
+		eg, ctx := errgroup.WithContext(context.Background())
+		eg.Go(func() error {
+			return tracker.Run(ctx, hs)
+		})
+		eg.Go(func() error {
+			// Should get back 03, 04, 05
+			hs, ok, err := tracker.GetChunksToFetch(ctx)
+			assert.Len(t, hs, 3)
+			assert.True(t, ok)
 			assert.NoError(t, err)
-			if !ok {
-				break
-			}
-			cnt += len(hs)
 			for _ = range hs {
-				tracker.TickProcessed()
+				tracker.TickProcessed(ctx)
 			}
-		}
-		assert.Equal(t, 8, cnt)
 
-		tracker.Close()
+			for i := byte(1); i <= byte(10); i++ {
+				var h hash.Hash
+				h[0] = 1
+				h[1] = i
+				tracker.Seen(ctx, h)
+			}
+
+			// Should get back 13, 14, 15, 16, 17, 18, 19, 1(10).
+			cnt := 0
+			for {
+				hs, ok, err := tracker.GetChunksToFetch(ctx)
+				assert.NoError(t, err)
+				if !ok {
+					break
+				}
+				cnt += len(hs)
+				for _ = range hs {
+					tracker.TickProcessed(ctx)
+				}
+			}
+			assert.Equal(t, 8, cnt)
+
+			tracker.Close()
+			return nil
+		})
+		assert.NoError(t, eg.Wait())
 	})
 
 	t.Run("SmallBatches", func(t *testing.T) {
@@ -231,44 +280,52 @@ func TestPullChunkTracker(t *testing.T) {
 			h[0] = i
 			hs.Insert(h)
 		}
-		tracker := NewPullChunkTracker(context.Background(), hs, TrackerConfig{
+		tracker := NewPullChunkTracker(TrackerConfig{
 			BatchSize: 1,
 			HasManyer: haser,
 		})
 
-		// First call doesn't actually respect batch size.
-		hs, ok, err := tracker.GetChunksToFetch()
-		assert.Len(t, hs, 3)
-		assert.True(t, ok)
-		assert.NoError(t, err)
-		for _ = range hs {
-			tracker.TickProcessed()
-		}
-
-		for i := byte(1); i <= byte(10); i++ {
-			var h hash.Hash
-			h[0] = 1
-			h[1] = i
-			tracker.Seen(h)
-		}
-
-		// Should get back 13, 14, 15, 16, 17, 18, 19, 1(10); one at a time.
-		cnt := 0
-		for {
-			hs, ok, err := tracker.GetChunksToFetch()
+		eg, ctx := errgroup.WithContext(context.Background())
+		eg.Go(func() error {
+			return tracker.Run(ctx, hs)
+		})
+		eg.Go(func() error {
+			// First call doesn't actually respect batch size.
+			hs, ok, err := tracker.GetChunksToFetch(ctx)
+			assert.Len(t, hs, 3)
+			assert.True(t, ok)
 			assert.NoError(t, err)
-			if !ok {
-				break
-			}
-			assert.Len(t, hs, 1)
-			cnt += len(hs)
 			for _ = range hs {
-				tracker.TickProcessed()
+				tracker.TickProcessed(ctx)
 			}
-		}
-		assert.Equal(t, 8, cnt)
 
-		tracker.Close()
+			for i := byte(1); i <= byte(10); i++ {
+				var h hash.Hash
+				h[0] = 1
+				h[1] = i
+				tracker.Seen(ctx, h)
+			}
+
+			// Should get back 13, 14, 15, 16, 17, 18, 19, 1(10); one at a time.
+			cnt := 0
+			for {
+				hs, ok, err := tracker.GetChunksToFetch(ctx)
+				assert.NoError(t, err)
+				if !ok {
+					break
+				}
+				assert.Len(t, hs, 1)
+				cnt += len(hs)
+				for _ = range hs {
+					tracker.TickProcessed(ctx)
+				}
+			}
+			assert.Equal(t, 8, cnt)
+
+			tracker.Close()
+			return nil
+		})
+		assert.NoError(t, eg.Wait())
 	})
 }
 

--- a/go/store/datas/pull/pull_table_file_writer_test.go
+++ b/go/store/datas/pull/pull_table_file_writer_test.go
@@ -35,7 +35,7 @@ func TestPullTableFileWriter(t *testing.T) {
 		var s noopTableFileDestStore
 		wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 			ConcurrentUploads:    1,
-			TargetFileSize:       1<<20,
+			TargetFileSize:       1 << 20,
 			MaximumBufferedFiles: 1,
 			TempDir:              t.TempDir(),
 			DestStore:            &s,
@@ -55,7 +55,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			var s noopTableFileDestStore
 			wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 				ConcurrentUploads:    1,
-				TargetFileSize:       1<<20,
+				TargetFileSize:       1 << 20,
 				MaximumBufferedFiles: 1,
 				TempDir:              t.TempDir(),
 				DestStore:            &s,
@@ -66,7 +66,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			})
 
 			for i := 0; i < 32; i++ {
-				bs := make([]byte, 1<<20 / 32 * 4)
+				bs := make([]byte, 1<<20/32*4)
 				_, err := rand.Read(bs)
 				assert.NoError(t, err)
 				chk := chunks.NewChunk(bs)
@@ -86,7 +86,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			var s noopTableFileDestStore
 			wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 				ConcurrentUploads:    1,
-				TargetFileSize:       1<<20,
+				TargetFileSize:       1 << 20,
 				MaximumBufferedFiles: 1,
 				TempDir:              t.TempDir(),
 				DestStore:            &s,
@@ -119,7 +119,7 @@ func TestPullTableFileWriter(t *testing.T) {
 		s.writeDelay = 50 * time.Millisecond
 		wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 			ConcurrentUploads:    32,
-			TargetFileSize:       1<<20,
+			TargetFileSize:       1 << 20,
 			MaximumBufferedFiles: 1,
 			TempDir:              t.TempDir(),
 			DestStore:            &s,
@@ -154,7 +154,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			var s errTableFileDestStore
 			wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 				ConcurrentUploads:    1,
-				TargetFileSize:       1<<20,
+				TargetFileSize:       1 << 20,
 				MaximumBufferedFiles: 0,
 				TempDir:              t.TempDir(),
 				DestStore:            &s,
@@ -183,7 +183,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			var s errTableFileDestStore
 			wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 				ConcurrentUploads:    1,
-				TargetFileSize:       1<<20,
+				TargetFileSize:       1 << 20,
 				MaximumBufferedFiles: 0,
 				TempDir:              t.TempDir(),
 				DestStore:            &s,
@@ -194,7 +194,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			})
 
 			for i := 0; i < 8; i++ {
-				bs := make([]byte, 1<<20 / 8)
+				bs := make([]byte, 1<<20/8)
 				_, err := rand.Read(bs)
 				assert.NoError(t, err)
 				chk := chunks.NewChunk(bs)
@@ -229,7 +229,7 @@ func TestPullTableFileWriter(t *testing.T) {
 		s.onAdd = true
 		wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 			ConcurrentUploads:    1,
-			TargetFileSize:       1<<20,
+			TargetFileSize:       1 << 20,
 			MaximumBufferedFiles: 0,
 			TempDir:              t.TempDir(),
 			DestStore:            &s,
@@ -262,7 +262,7 @@ func TestPullTableFileWriter(t *testing.T) {
 		}
 		wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 			ConcurrentUploads:    1,
-			TargetFileSize:       1<<20,
+			TargetFileSize:       1 << 20,
 			MaximumBufferedFiles: 0,
 			TempDir:              t.TempDir(),
 			DestStore:            &s,
@@ -273,7 +273,7 @@ func TestPullTableFileWriter(t *testing.T) {
 		})
 
 		for i := 0; i < 8; i++ {
-			bs := make([]byte, 1<<20 / 8)
+			bs := make([]byte, 1<<20/8)
 			_, err := rand.Read(bs)
 			assert.NoError(t, err)
 			chk := chunks.NewChunk(bs)
@@ -307,7 +307,7 @@ func TestPullTableFileWriter(t *testing.T) {
 		}
 		wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 			ConcurrentUploads:    4,
-			TargetFileSize:       1<<20,
+			TargetFileSize:       1 << 20,
 			MaximumBufferedFiles: 0,
 			TempDir:              t.TempDir(),
 			DestStore:            &s,
@@ -318,7 +318,7 @@ func TestPullTableFileWriter(t *testing.T) {
 		})
 
 		for i := 0; i < 32; i++ {
-			bs := make([]byte, 1 << 20 / 32 * 4)
+			bs := make([]byte, 1<<20/32*4)
 			_, err := rand.Read(bs)
 			assert.NoError(t, err)
 			chk := chunks.NewChunk(bs)

--- a/go/store/datas/pull/pull_table_file_writer_test.go
+++ b/go/store/datas/pull/pull_table_file_writer_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/nbs"
@@ -32,14 +33,19 @@ import (
 func TestPullTableFileWriter(t *testing.T) {
 	t.Run("Empty", func(t *testing.T) {
 		var s noopTableFileDestStore
-		wr := NewPullTableFileWriter(context.Background(), PullTableFileWriterConfig{
+		wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 			ConcurrentUploads:    1,
 			ChunksPerFile:        8,
 			MaximumBufferedFiles: 1,
 			TempDir:              t.TempDir(),
 			DestStore:            &s,
 		})
-		assert.NoError(t, wr.Close())
+		eg, ctx := errgroup.WithContext(context.Background())
+		eg.Go(func() error {
+			return wr.Run(ctx)
+		})
+		wr.Close()
+		assert.NoError(t, eg.Wait())
 		assert.Equal(t, s.writeCalled.Load(), uint32(0))
 		assert.Equal(t, s.addCalled, 0)
 	})
@@ -47,12 +53,16 @@ func TestPullTableFileWriter(t *testing.T) {
 	t.Run("AddSomeChunks", func(t *testing.T) {
 		t.Run("FinishOnFullWriter", func(t *testing.T) {
 			var s noopTableFileDestStore
-			wr := NewPullTableFileWriter(context.Background(), PullTableFileWriterConfig{
+			wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 				ConcurrentUploads:    1,
 				ChunksPerFile:        8,
 				MaximumBufferedFiles: 1,
 				TempDir:              t.TempDir(),
 				DestStore:            &s,
+			})
+			eg, ctx := errgroup.WithContext(context.Background())
+			eg.Go(func() error {
+				return wr.Run(ctx)
 			})
 
 			for i := 0; i < 32; i++ {
@@ -61,11 +71,12 @@ func TestPullTableFileWriter(t *testing.T) {
 				assert.NoError(t, err)
 				chk := chunks.NewChunk(bs)
 				cChk := nbs.ChunkToCompressedChunk(chk)
-				err = wr.AddToChunker(context.Background(), cChk)
+				err = wr.AddToChunker(ctx, cChk)
 				assert.NoError(t, err)
 			}
 
-			assert.NoError(t, wr.Close())
+			wr.Close()
+			assert.NoError(t, eg.Wait())
 			assert.Equal(t, s.writeCalled.Load(), uint32(4))
 			assert.Equal(t, s.addCalled, 1)
 			assert.Len(t, s.manifest, 4)
@@ -73,12 +84,16 @@ func TestPullTableFileWriter(t *testing.T) {
 
 		t.Run("FinishOnPartialFile", func(t *testing.T) {
 			var s noopTableFileDestStore
-			wr := NewPullTableFileWriter(context.Background(), PullTableFileWriterConfig{
+			wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 				ConcurrentUploads:    1,
 				ChunksPerFile:        1024,
 				MaximumBufferedFiles: 1,
 				TempDir:              t.TempDir(),
 				DestStore:            &s,
+			})
+			eg, ctx := errgroup.WithContext(context.Background())
+			eg.Go(func() error {
+				return wr.Run(ctx)
 			})
 
 			for i := 0; i < 32; i++ {
@@ -87,11 +102,12 @@ func TestPullTableFileWriter(t *testing.T) {
 				assert.NoError(t, err)
 				chk := chunks.NewChunk(bs)
 				cChk := nbs.ChunkToCompressedChunk(chk)
-				err = wr.AddToChunker(context.Background(), cChk)
+				err = wr.AddToChunker(ctx, cChk)
 				assert.NoError(t, err)
 			}
 
-			assert.NoError(t, wr.Close())
+			wr.Close()
+			assert.NoError(t, eg.Wait())
 			assert.Equal(t, s.writeCalled.Load(), uint32(1))
 			assert.Equal(t, s.addCalled, 1)
 			assert.Len(t, s.manifest, 1)
@@ -101,12 +117,16 @@ func TestPullTableFileWriter(t *testing.T) {
 	t.Run("ConcurrentUpload", func(t *testing.T) {
 		var s noopTableFileDestStore
 		s.writeDelay = 50 * time.Millisecond
-		wr := NewPullTableFileWriter(context.Background(), PullTableFileWriterConfig{
+		wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 			ConcurrentUploads:    32,
 			ChunksPerFile:        8,
 			MaximumBufferedFiles: 1,
 			TempDir:              t.TempDir(),
 			DestStore:            &s,
+		})
+		eg, ctx := errgroup.WithContext(context.Background())
+		eg.Go(func() error {
+			return wr.Run(ctx)
 		})
 
 		start := time.Now()
@@ -117,11 +137,12 @@ func TestPullTableFileWriter(t *testing.T) {
 			assert.NoError(t, err)
 			chk := chunks.NewChunk(bs)
 			cChk := nbs.ChunkToCompressedChunk(chk)
-			err = wr.AddToChunker(context.Background(), cChk)
+			err = wr.AddToChunker(ctx, cChk)
 			assert.NoError(t, err)
 		}
 
-		assert.NoError(t, wr.Close())
+		wr.Close()
+		assert.NoError(t, eg.Wait())
 		assert.Equal(t, s.writeCalled.Load(), uint32(32))
 		assert.Equal(t, s.addCalled, 1)
 		assert.Len(t, s.manifest, 32)
@@ -131,12 +152,16 @@ func TestPullTableFileWriter(t *testing.T) {
 	t.Run("ErrorOnUpload", func(t *testing.T) {
 		t.Run("ErrAtClose", func(t *testing.T) {
 			var s errTableFileDestStore
-			wr := NewPullTableFileWriter(context.Background(), PullTableFileWriterConfig{
+			wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 				ConcurrentUploads:    1,
 				ChunksPerFile:        8,
 				MaximumBufferedFiles: 0,
 				TempDir:              t.TempDir(),
 				DestStore:            &s,
+			})
+			eg, ctx := errgroup.WithContext(context.Background())
+			eg.Go(func() error {
+				return wr.Run(ctx)
 			})
 
 			for i := 0; i < 8; i++ {
@@ -145,22 +170,27 @@ func TestPullTableFileWriter(t *testing.T) {
 				assert.NoError(t, err)
 				chk := chunks.NewChunk(bs)
 				cChk := nbs.ChunkToCompressedChunk(chk)
-				err = wr.AddToChunker(context.Background(), cChk)
+				err = wr.AddToChunker(ctx, cChk)
 				assert.NoError(t, err)
 			}
 
-			assert.EqualError(t, wr.Close(), "this dest store throws an error")
+			wr.Close()
+			assert.EqualError(t, eg.Wait(), "this dest store throws an error")
 			assert.Equal(t, s.addCalled, 0)
 		})
 
 		t.Run("ErrAtAdd", func(t *testing.T) {
 			var s errTableFileDestStore
-			wr := NewPullTableFileWriter(context.Background(), PullTableFileWriterConfig{
+			wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 				ConcurrentUploads:    1,
 				ChunksPerFile:        8,
 				MaximumBufferedFiles: 0,
 				TempDir:              t.TempDir(),
 				DestStore:            &s,
+			})
+			eg, ctx := errgroup.WithContext(context.Background())
+			eg.Go(func() error {
+				return wr.Run(ctx)
 			})
 
 			for i := 0; i < 8; i++ {
@@ -169,7 +199,7 @@ func TestPullTableFileWriter(t *testing.T) {
 				assert.NoError(t, err)
 				chk := chunks.NewChunk(bs)
 				cChk := nbs.ChunkToCompressedChunk(chk)
-				err = wr.AddToChunker(context.Background(), cChk)
+				err = wr.AddToChunker(ctx, cChk)
 				assert.NoError(t, err)
 			}
 
@@ -180,10 +210,11 @@ func TestPullTableFileWriter(t *testing.T) {
 				assert.NoError(t, err)
 				chk := chunks.NewChunk(bs)
 				cChk := nbs.ChunkToCompressedChunk(chk)
-				err = wr.AddToChunker(context.Background(), cChk)
+				err = wr.AddToChunker(ctx, cChk)
 				if err != nil {
 					assert.EqualError(t, err, "this dest store throws an error")
-					assert.EqualError(t, wr.Close(), "this dest store throws an error")
+					wr.Close()
+					assert.EqualError(t, eg.Wait(), "this dest store throws an error")
 					assert.Equal(t, s.addCalled, 0)
 					return
 				}
@@ -196,12 +227,16 @@ func TestPullTableFileWriter(t *testing.T) {
 	t.Run("ErrorOnAdd", func(t *testing.T) {
 		var s errTableFileDestStore
 		s.onAdd = true
-		wr := NewPullTableFileWriter(context.Background(), PullTableFileWriterConfig{
+		wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 			ConcurrentUploads:    1,
 			ChunksPerFile:        8,
 			MaximumBufferedFiles: 0,
 			TempDir:              t.TempDir(),
 			DestStore:            &s,
+		})
+		eg, ctx := errgroup.WithContext(context.Background())
+		eg.Go(func() error {
+			return wr.Run(ctx)
 		})
 
 		for i := 0; i < 8; i++ {
@@ -210,11 +245,12 @@ func TestPullTableFileWriter(t *testing.T) {
 			assert.NoError(t, err)
 			chk := chunks.NewChunk(bs)
 			cChk := nbs.ChunkToCompressedChunk(chk)
-			err = wr.AddToChunker(context.Background(), cChk)
+			err = wr.AddToChunker(ctx, cChk)
 			assert.NoError(t, err)
 		}
 
-		assert.EqualError(t, wr.Close(), "this dest store throws an error")
+		wr.Close()
+		assert.EqualError(t, eg.Wait(), "this dest store throws an error")
 		assert.Equal(t, s.addCalled, 1)
 	})
 
@@ -224,12 +260,16 @@ func TestPullTableFileWriter(t *testing.T) {
 			doWriteTableFile:   make(chan struct{}),
 			doneWriteTableFile: make(chan struct{}),
 		}
-		wr := NewPullTableFileWriter(context.Background(), PullTableFileWriterConfig{
+		wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 			ConcurrentUploads:    1,
 			ChunksPerFile:        8,
 			MaximumBufferedFiles: 0,
 			TempDir:              t.TempDir(),
 			DestStore:            &s,
+		})
+		eg, ctx := errgroup.WithContext(context.Background())
+		eg.Go(func() error {
+			return wr.Run(ctx)
 		})
 
 		for i := 0; i < 8; i++ {
@@ -238,7 +278,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			assert.NoError(t, err)
 			chk := chunks.NewChunk(bs)
 			cChk := nbs.ChunkToCompressedChunk(chk)
-			err = wr.AddToChunker(context.Background(), cChk)
+			err = wr.AddToChunker(ctx, cChk)
 			assert.NoError(t, err)
 		}
 
@@ -255,7 +295,8 @@ func TestPullTableFileWriter(t *testing.T) {
 		assert.Greater(t, wrStats.FinishedSendBytes, uint64(8*1024))
 		assert.Equal(t, wrStats.FinishedSendBytes, wrStats.BufferedSendBytes)
 
-		assert.NoError(t, wr.Close())
+		wr.Close()
+		assert.NoError(t, eg.Wait())
 	})
 
 	t.Run("UploadsAreParallel", func(t *testing.T) {
@@ -264,12 +305,16 @@ func TestPullTableFileWriter(t *testing.T) {
 			doWriteTableFile:   make(chan struct{}),
 			doneWriteTableFile: make(chan struct{}),
 		}
-		wr := NewPullTableFileWriter(context.Background(), PullTableFileWriterConfig{
+		wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 			ConcurrentUploads:    4,
 			ChunksPerFile:        8,
 			MaximumBufferedFiles: 0,
 			TempDir:              t.TempDir(),
 			DestStore:            &s,
+		})
+		eg, ctx := errgroup.WithContext(context.Background())
+		eg.Go(func() error {
+			return wr.Run(ctx)
 		})
 
 		for i := 0; i < 32; i++ {
@@ -278,7 +323,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			assert.NoError(t, err)
 			chk := chunks.NewChunk(bs)
 			cChk := nbs.ChunkToCompressedChunk(chk)
-			err = wr.AddToChunker(context.Background(), cChk)
+			err = wr.AddToChunker(ctx, cChk)
 			assert.NoError(t, err)
 		}
 
@@ -292,7 +337,8 @@ func TestPullTableFileWriter(t *testing.T) {
 			<-s.doneWriteTableFile
 		}
 
-		assert.NoError(t, wr.Close())
+		wr.Close()
+		assert.NoError(t, eg.Wait())
 	})
 }
 

--- a/go/store/datas/pull/pull_table_file_writer_test.go
+++ b/go/store/datas/pull/pull_table_file_writer_test.go
@@ -35,7 +35,7 @@ func TestPullTableFileWriter(t *testing.T) {
 		var s noopTableFileDestStore
 		wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 			ConcurrentUploads:    1,
-			ChunksPerFile:        8,
+			TargetFileSize:       1<<20,
 			MaximumBufferedFiles: 1,
 			TempDir:              t.TempDir(),
 			DestStore:            &s,
@@ -55,7 +55,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			var s noopTableFileDestStore
 			wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 				ConcurrentUploads:    1,
-				ChunksPerFile:        8,
+				TargetFileSize:       1<<20,
 				MaximumBufferedFiles: 1,
 				TempDir:              t.TempDir(),
 				DestStore:            &s,
@@ -66,7 +66,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			})
 
 			for i := 0; i < 32; i++ {
-				bs := make([]byte, 1024)
+				bs := make([]byte, 1<<20 / 32 * 4)
 				_, err := rand.Read(bs)
 				assert.NoError(t, err)
 				chk := chunks.NewChunk(bs)
@@ -86,7 +86,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			var s noopTableFileDestStore
 			wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 				ConcurrentUploads:    1,
-				ChunksPerFile:        1024,
+				TargetFileSize:       1<<20,
 				MaximumBufferedFiles: 1,
 				TempDir:              t.TempDir(),
 				DestStore:            &s,
@@ -119,7 +119,7 @@ func TestPullTableFileWriter(t *testing.T) {
 		s.writeDelay = 50 * time.Millisecond
 		wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 			ConcurrentUploads:    32,
-			ChunksPerFile:        8,
+			TargetFileSize:       1<<20,
 			MaximumBufferedFiles: 1,
 			TempDir:              t.TempDir(),
 			DestStore:            &s,
@@ -131,8 +131,8 @@ func TestPullTableFileWriter(t *testing.T) {
 
 		start := time.Now()
 
-		for i := 0; i < 8*32; i++ {
-			bs := make([]byte, 1024)
+		for i := 0; i < 32; i++ {
+			bs := make([]byte, 1<<20)
 			_, err := rand.Read(bs)
 			assert.NoError(t, err)
 			chk := chunks.NewChunk(bs)
@@ -154,7 +154,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			var s errTableFileDestStore
 			wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 				ConcurrentUploads:    1,
-				ChunksPerFile:        8,
+				TargetFileSize:       1<<20,
 				MaximumBufferedFiles: 0,
 				TempDir:              t.TempDir(),
 				DestStore:            &s,
@@ -183,7 +183,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			var s errTableFileDestStore
 			wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 				ConcurrentUploads:    1,
-				ChunksPerFile:        8,
+				TargetFileSize:       1<<20,
 				MaximumBufferedFiles: 0,
 				TempDir:              t.TempDir(),
 				DestStore:            &s,
@@ -194,7 +194,7 @@ func TestPullTableFileWriter(t *testing.T) {
 			})
 
 			for i := 0; i < 8; i++ {
-				bs := make([]byte, 1024)
+				bs := make([]byte, 1<<20 / 8)
 				_, err := rand.Read(bs)
 				assert.NoError(t, err)
 				chk := chunks.NewChunk(bs)
@@ -229,7 +229,7 @@ func TestPullTableFileWriter(t *testing.T) {
 		s.onAdd = true
 		wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 			ConcurrentUploads:    1,
-			ChunksPerFile:        8,
+			TargetFileSize:       1<<20,
 			MaximumBufferedFiles: 0,
 			TempDir:              t.TempDir(),
 			DestStore:            &s,
@@ -262,7 +262,7 @@ func TestPullTableFileWriter(t *testing.T) {
 		}
 		wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 			ConcurrentUploads:    1,
-			ChunksPerFile:        8,
+			TargetFileSize:       1<<20,
 			MaximumBufferedFiles: 0,
 			TempDir:              t.TempDir(),
 			DestStore:            &s,
@@ -273,7 +273,7 @@ func TestPullTableFileWriter(t *testing.T) {
 		})
 
 		for i := 0; i < 8; i++ {
-			bs := make([]byte, 1024)
+			bs := make([]byte, 1<<20 / 8)
 			_, err := rand.Read(bs)
 			assert.NoError(t, err)
 			chk := chunks.NewChunk(bs)
@@ -307,7 +307,7 @@ func TestPullTableFileWriter(t *testing.T) {
 		}
 		wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 			ConcurrentUploads:    4,
-			ChunksPerFile:        8,
+			TargetFileSize:       1<<20,
 			MaximumBufferedFiles: 0,
 			TempDir:              t.TempDir(),
 			DestStore:            &s,
@@ -318,7 +318,7 @@ func TestPullTableFileWriter(t *testing.T) {
 		})
 
 		for i := 0; i < 32; i++ {
-			bs := make([]byte, 1024)
+			bs := make([]byte, 1 << 20 / 32 * 4)
 			_, err := rand.Read(bs)
 			assert.NoError(t, err)
 			chk := chunks.NewChunk(bs)

--- a/go/store/datas/pull/puller.go
+++ b/go/store/datas/pull/puller.go
@@ -66,7 +66,7 @@ type Puller struct {
 func NewPuller(
 	ctx context.Context,
 	tempDir string,
-	chunksPerTF int,
+	targetFileSz uint64,
 	srcCS, sinkCS chunks.ChunkStore,
 	walkAddrs WalkAddrs,
 	hashes []hash.Hash,
@@ -114,7 +114,7 @@ func NewPuller(
 
 	wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 		ConcurrentUploads:    2,
-		ChunksPerFile:        chunksPerTF,
+		TargetFileSize:       targetFileSz,
 		MaximumBufferedFiles: 8,
 		TempDir:              tempDir,
 		DestStore:            sinkCS.(chunks.TableFileStore),

--- a/go/store/datas/pull/puller.go
+++ b/go/store/datas/pull/puller.go
@@ -54,7 +54,6 @@ type Puller struct {
 	hashes        hash.HashSet
 
 	wr *PullTableFileWriter
-	rd nbs.ChunkFetcher
 
 	pushLog *log.Logger
 
@@ -113,7 +112,7 @@ func NewPuller(
 		}
 	}
 
-	wr := NewPullTableFileWriter(ctx, PullTableFileWriterConfig{
+	wr := NewPullTableFileWriter(PullTableFileWriterConfig{
 		ConcurrentUploads:    2,
 		ChunksPerFile:        chunksPerTF,
 		MaximumBufferedFiles: 8,
@@ -121,8 +120,6 @@ func NewPuller(
 		DestStore:            sinkCS.(chunks.TableFileStore),
 		GetAddrs:             getAddrs,
 	})
-
-	rd := GetChunkFetcher(ctx, srcChunkStore)
 
 	var pushLogger *log.Logger
 	if dbg, ok := os.LookupEnv(dconfig.EnvPushLog); ok && strings.EqualFold(dbg, "true") {
@@ -140,7 +137,6 @@ func NewPuller(
 		sinkDBCS:      sinkCS,
 		hashes:        hash.NewHashSet(hashes...),
 		wr:            wr,
-		rd:            rd,
 		pushLog:       pushLogger,
 		statsCh:       statsCh,
 		stats: &stats{
@@ -313,25 +309,36 @@ func (p *Puller) Pull(ctx context.Context) error {
 
 	eg, ctx := errgroup.WithContext(ctx)
 
+	rd := GetChunkFetcher(ctx, p.srcChunkStore)
+
 	const batchSize = 64 * 1024
-	tracker := NewPullChunkTracker(ctx, p.hashes, TrackerConfig{
+	tracker := NewPullChunkTracker(TrackerConfig{
 		BatchSize: batchSize,
 		HasManyer: p.sinkDBCS,
 	})
 
+	eg.Go(func() error {
+		return tracker.Run(ctx, p.hashes)
+	})
+
+	eg.Go(func() error {
+		return p.wr.Run(ctx)
+	})
+
 	// One thread calls ChunkFetcher.Get on each batch.
 	eg.Go(func() error {
+		defer tracker.Close()
 		for {
-			toFetch, hasMore, err := tracker.GetChunksToFetch()
+			toFetch, hasMore, err := tracker.GetChunksToFetch(ctx)
 			if err != nil {
 				return err
 			}
 			if !hasMore {
-				return p.rd.CloseSend()
+				return rd.CloseSend()
 			}
 
 			atomic.AddUint64(&p.stats.totalSourceChunks, uint64(len(toFetch)))
-			err = p.rd.Get(ctx, toFetch)
+			err = rd.Get(ctx, toFetch)
 			if err != nil {
 				return err
 			}
@@ -339,9 +346,13 @@ func (p *Puller) Pull(ctx context.Context) error {
 	})
 
 	// One thread reads the received chunks, walks their addresses and writes them to the table file.
-	eg.Go(func() error {
+	eg.Go(func() (err error) {
+		defer func() {
+			cerr := rd.Close()
+			err = errors.Join(err, cerr)
+		}()
 		for {
-			cChk, err := p.rd.Recv(ctx)
+			cChk, err := rd.Recv(ctx)
 			if err == io.EOF {
 				// This means the requesting thread
 				// successfully saw all chunk addresses and
@@ -351,7 +362,8 @@ func (p *Puller) Pull(ctx context.Context) error {
 				// on uploading any table files and will write
 				// the new table files to the destination's
 				// manifest.
-				return p.wr.Close()
+				p.wr.Close()
+				return nil
 			}
 			if err != nil {
 				return err
@@ -373,13 +385,13 @@ func (p *Puller) Pull(ctx context.Context) error {
 			atomic.AddUint64(&p.stats.fetchedSourceBytes, uint64(len(chnk.Data())))
 
 			err = p.waf(chnk, func(h hash.Hash, _ bool) error {
-				tracker.Seen(h)
+				tracker.Seen(ctx, h)
 				return nil
 			})
 			if err != nil {
 				return err
 			}
-			tracker.TickProcessed()
+			tracker.TickProcessed(ctx)
 
 			err = p.wr.AddToChunker(ctx, cChk)
 			if err != nil {
@@ -388,12 +400,5 @@ func (p *Puller) Pull(ctx context.Context) error {
 		}
 	})
 
-	// Always close the reader outside of the errgroup threads above.
-	// Closing the reader will cause Get() to start returning errors, and
-	// we don't need to deliver that error to the Get thread. Both threads
-	// should exit and return any errors they encounter, after which the
-	// errgroup will report the error.
-	wErr := eg.Wait()
-	rErr := p.rd.Close()
-	return errors.Join(wErr, rErr)
+	return eg.Wait()
 }

--- a/go/store/datas/pull/puller_test.go
+++ b/go/store/datas/pull/puller_test.go
@@ -98,7 +98,7 @@ func TestPuller(t *testing.T) {
 		st, err := nbs.NewLocalJournalingStore(ctx, nbf, dir, q)
 		require.NoError(t, err)
 
-		plr, err := NewPuller(ctx, t.TempDir(), 128, gs, st, waf, []hash.Hash{ghost}, statsCh)
+		plr, err := NewPuller(ctx, t.TempDir(), 1<<20, gs, st, waf, []hash.Hash{ghost}, statsCh)
 		require.NoError(t, err)
 		err = plr.Pull(ctx)
 		require.ErrorIs(t, err, nbs.ErrGhostChunkRequested)
@@ -367,7 +367,7 @@ func testPuller(t *testing.T, makeDB datasFactory) {
 			require.NoError(t, err)
 			waf, err := types.WalkAddrsForChunkStore(datas.ChunkStoreFromDatabase(db))
 			require.NoError(t, err)
-			plr, err := NewPuller(ctx, tmpDir, 128, datas.ChunkStoreFromDatabase(db), datas.ChunkStoreFromDatabase(sinkdb), waf, []hash.Hash{rootAddr}, statsCh)
+			plr, err := NewPuller(ctx, tmpDir, 1<<20, datas.ChunkStoreFromDatabase(db), datas.ChunkStoreFromDatabase(sinkdb), waf, []hash.Hash{rootAddr}, statsCh)
 			require.NoError(t, err)
 
 			err = plr.Pull(ctx)


### PR DESCRIPTION
Our old heuristic was to cut a file and start uploading it when it reached a fixed number of chunks. We chose that number of chunks as just `(1<<30 / 4096)`, which is the average chunk size the chunker targets. But the chunk targets pre-compressed sizes. So file uploads which were hitting the target could vary a lot in size. It's better to just track how many bytes we've written so far and cut it when (approximately) appropriate. This is still best effort and only approximately.

Also improves error handling and structured concurrency a bit. Moves a number of goroutines up to the top-level errgroup in `Pull()`. Avoids creating – and thus potentially leaking – goroutines in `NewPuller()`, deferring them until `Pull` actually gets called. Gets rid of an unnecessary request-response thread structure in the implementation of `PullChunkFetcher`.