### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/go/store/nbs/generational_chunk_store.go
+++ b/go/store/nbs/generational_chunk_store.go
@@ -270,10 +270,7 @@ func (gcs *GenerationalNBS) Version() string {
 func (gcs *GenerationalNBS) AccessMode() chunks.ExclusiveAccessMode {
 	newGenMode := gcs.newGen.AccessMode()
 	oldGenMode := gcs.oldGen.AccessMode()
-	if oldGenMode > newGenMode {
-		return oldGenMode
-	}
-	return newGenMode
+	return max(oldGenMode, newGenMode)
 }
 
 // Rebase brings this ChunkStore into sync with the persistent storage's


### PR DESCRIPTION
Use the built-in max/min from the standard library in Go 1.21 to simplify the code.  https://pkg.go.dev/builtin@go1.21.0#max