### PR TITLE
go: cmd/dolt: commands/sql: Fix the displayed query time in interactive mode after a query completes.

### DIFF
--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -787,6 +787,7 @@ func execShell(sqlCtx *sql.Context, qryist cli.Queryist, format engine.PrintResu
 			sqlCtx, cancel = sqlCtx.NewSubContext()
 			stopAfter := context.AfterFunc(subCtx, cancel)
 			defer stopAfter()
+			sqlCtx.SetQueryTime(time.Now())
 
 			cmdType, subCmd, newQuery, err := preprocessQuery(query, lastSqlCmd, cliCtx)
 			if err != nil {

--- a/integration-tests/bats/sql-shell.bats
+++ b/integration-tests/bats/sql-shell.bats
@@ -979,3 +979,25 @@ SQL
     [[ "$output" =~ "active_branch()" ]] || false
     [[ "$output" =~ "tmp_br" ]] || false
 }
+
+# bats test_tags=no_lambda
+@test "sql-shell: printed query time is accurate" {
+    expect -c '
+set timeout 2
+spawn dolt sql
+for {set i 0} {$i < 3} {incr i} {
+  expect "> "
+  send -- "select sleep(1);\r"
+  expect {
+    timeout {
+      puts "test failure: expected to see a query result that took ~1 second, but did not"
+      exit 1;
+    }
+    "1 row in set (1"
+  }
+}
+expect "> "
+send -- "quit;\r"
+expect eof
+'
+}


### PR DESCRIPTION
The migration to subcontexts of the Queryist sql.Context meant that we lost the default setting of the query start time. Restore it in the sql command implementation itself.