### PR TITLE
Normalize AUTO_INCREMENT values in tables.

### DIFF
--- a/go/libraries/doltcore/doltdb/durable/table.go
+++ b/go/libraries/doltcore/doltdb/durable/table.go
@@ -1100,6 +1100,7 @@ func (t doltDevTable) SetConstraintViolations(ctx context.Context, violations ty
 	return doltDevTable{t.vrw, t.ns, msg}, nil
 }
 
+// GetAutoIncrement returns the next value to be used for the AUTO_INCREMENT column.
 func (t doltDevTable) GetAutoIncrement(ctx context.Context) (uint64, error) {
 	res := t.msg.AutoIncrementValue()
 	if res == 0 {
@@ -1108,7 +1109,14 @@ func (t doltDevTable) GetAutoIncrement(ctx context.Context) (uint64, error) {
 	return res, nil
 }
 
+// SetAutoIncrement sets the next value to be used for the AUTO_INCREMENT column.
+// Since AUTO_INCREMENT starts at 1, setting this to either 0 or 1 will result in the field being unset.
 func (t doltDevTable) SetAutoIncrement(ctx context.Context, val uint64) (Table, error) {
+	// AUTO_INCREMENT starts at 1, so a value of 1 is the same as being unset.
+	// Normalizing both values to 0 ensures that they both result in the same hash as the field being unset.
+	if val == 1 {
+		val = 0
+	}
 	// TODO: This clones before checking if the mutate will work.
 	msg := t.clone()
 	if !msg.MutateAutoIncrementValue(val) {

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -1148,7 +1148,7 @@ func (t *WritableDoltTable) AutoIncrementSetter(ctx *sql.Context) sql.AutoIncrem
 	return te
 }
 
-// PeekNextAutoIncrementValue implements sql.AutoIncrementTable
+// PeekNextAutoIncrementValue implements sql.AutoIncrementGetter
 func (t *WritableDoltTable) PeekNextAutoIncrementValue(ctx *sql.Context) (uint64, error) {
 	if !t.autoIncCol.AutoIncrement {
 		return 0, sql.ErrNoAutoIncrementCol

--- a/integration-tests/bats/auto_increment.bats
+++ b/integration-tests/bats/auto_increment.bats
@@ -10,6 +10,7 @@ CREATE TABLE test (
   c0 int
 );
 SQL
+    dolt commit -Am "initial commit"
 
 }
 
@@ -877,4 +878,47 @@ SQL
     run dolt sql -q 'show create table t as of `HEAD^`'
     [ "$status" -eq 0 ]
     [[ "$output" =~ AUTO_INCREMENT ]] || false
+}
+
+@test "auto_increment: setting auto_increment to 1 vs 0 produces identical hashes and no diffs" {
+    dolt branch auto_increment_0
+    dolt branch auto_increment_1
+
+    dolt checkout auto_increment_0
+    dolt sql -q "ALTER TABLE test AUTO_INCREMENT=0;"
+    run dolt commit -Am "explicitly set AUTO_INCREMENT to 0"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "no changes added to commit" ]] || false
+    # Make a new commit by touching an unrelated table
+    dolt sql -q "CREATE TABLE other (pk int primary key)"
+    run dolt commit -Am "create other table"
+
+    dolt checkout auto_increment_1
+    dolt sql -q "ALTER TABLE test AUTO_INCREMENT=1;"
+    run dolt commit -Am "explicitly set AUTO_INCREMENT to 1"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "no changes added to commit" ]] || false
+    # Make a new commit by touching an unrelated table
+    dolt sql -q "CREATE TABLE other (pk char(1) primary key)"
+    run dolt commit -Am "create other table"
+
+    # Verify that tables produce no diff
+    run dolt diff main auto_increment_0 test
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 0 ]
+
+    run dolt diff main auto_increment_1 test
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 0 ]
+
+    # Verify that tables have the same hash
+    dolt checkout main
+    main_hash=$(dolt sql -r csv -q "SELECT DOLT_HASHOF_TABLE('test')")
+    dolt checkout auto_increment_0
+    ai0_hash=$(dolt sql -r csv -q "SELECT DOLT_HASHOF_TABLE('test')")
+    dolt checkout auto_increment_1
+    ai1_hash=$(dolt sql -r csv -q "SELECT DOLT_HASHOF_TABLE('test')")
+
+    [[ "$main_hash" = "$ai0_hash" ]] || false
+    [[ "$main_hash" = "$ai1_hash" ]] || false
 }

--- a/integration-tests/bats/auto_increment.bats
+++ b/integration-tests/bats/auto_increment.bats
@@ -702,8 +702,6 @@ SQL
 
 @test "auto_increment: globally distinct auto increment values" {
     dolt sql  <<SQL
-call dolt_add('.');
-call dolt_commit('-am', 'empty table');
 call dolt_branch('branch1');
 call dolt_branch('branch2');
 
@@ -780,8 +778,6 @@ SQL
 
 @test "auto_increment: newly cloned database" {
     dolt sql  <<SQL
-call dolt_add('.');
-call dolt_commit('-am', 'empty table');
 call dolt_branch('branch1');
 call dolt_branch('branch2');
 


### PR DESCRIPTION
When the AUTO_INCREMENT field is unset, the value of the next AUTO_INCREMENT column defaults to 1. Thus, setting it to 0 and 1 produce identical behavior.

By normalizing the value as its written, we ensure that both operations produce the same table hash as if the value was unset.