### PR TITLE
[no-release-notes] Have TextStorage and ByteArray implement driver.Value

### DIFF
--- a/go/store/prolly/tree/prolly_fields.go
+++ b/go/store/prolly/tree/prolly_fields.go
@@ -122,7 +122,7 @@ func GetField(ctx context.Context, td val.TupleDesc, i int, tup val.Tuple, ns No
 		var h hash.Hash
 		h, ok = td.GetBytesAddr(i, tup)
 		if ok {
-			v = val.NewByteArray(h, ns)
+			v = val.NewByteArray(ctx, h, ns)
 		}
 	case val.JSONAddrEnc:
 		var h hash.Hash
@@ -134,7 +134,7 @@ func GetField(ctx context.Context, td val.TupleDesc, i int, tup val.Tuple, ns No
 		var h hash.Hash
 		h, ok = td.GetStringAddr(i, tup)
 		if ok {
-			v = val.NewTextStorage(h, ns)
+			v = val.NewTextStorage(ctx, h, ns)
 		}
 	case val.BytesAdaptiveEnc:
 		v, ok, err = td.GetBytesAdaptiveValue(i, ns, tup)

--- a/go/store/val/adaptive_value.go
+++ b/go/store/val/adaptive_value.go
@@ -176,7 +176,7 @@ func (v AdaptiveValue) convertToByteArray(ctx context.Context, vs ValueStore, bu
 	}
 	length, lengthBytes := uvarint.Uvarint(outOfBandValue)
 	address := hash.New(outOfBandValue[lengthBytes:])
-	return NewByteArray(address, vs).WithMaxByteLength(int64(length)), nil
+	return NewByteArray(ctx, address, vs).WithMaxByteLength(int64(length)), nil
 }
 
 func (v AdaptiveValue) convertToTextStorage(ctx context.Context, vs ValueStore, buf []byte) (*TextStorage, error) {
@@ -187,7 +187,7 @@ func (v AdaptiveValue) convertToTextStorage(ctx context.Context, vs ValueStore, 
 	}
 	length, lengthBytes := uvarint.Uvarint(outOfBandValue)
 	address := hash.New(outOfBandValue[lengthBytes:])
-	return NewTextStorage(address, vs).WithMaxByteLength(int64(length)), nil
+	return NewTextStorage(ctx, address, vs).WithMaxByteLength(int64(length)), nil
 }
 
 // AdaptiveEncodingTypeHandler is an implementation of TypeHandler for adaptive encoding types,

--- a/go/store/val/tuple_builder_test.go
+++ b/go/store/val/tuple_builder_test.go
@@ -297,7 +297,7 @@ func TestTupleBuilderAdaptiveEncodings(t *testing.T) {
 			longByteArray := make([]byte, defaultTupleLengthTarget*2)
 			h, err := vs.WriteBytes(ctx, longByteArray)
 			require.NoError(t, err)
-			byteArray := NewByteArray(h, vs).WithMaxByteLength(int64(len(longByteArray)))
+			byteArray := NewByteArray(ctx, h, vs).WithMaxByteLength(int64(len(longByteArray)))
 			tb.PutAdaptiveBytesFromOutline(0, byteArray)
 
 			tup, err := tb.Build(testPool)


### PR DESCRIPTION
These types can now get returned by the engine, as alternate representations of text and blob types respectively.

Implementing the `driver.Value` interface ensures that they work correctly with go's SQL drivers.