### PR TITLE
Add the archive --purge flag to clean up table files

### DIFF
--- a/go/cmd/dolt/commands/archive.go
+++ b/go/cmd/dolt/commands/archive.go
@@ -54,6 +54,7 @@ table files into archives. Currently, for safety, table files are left in place.
 
 const groupChunksFlag = "group-chunks"
 const revertFlag = "revert"
+const purgeFlag = "purge"
 
 // Description returns a description of the command
 func (cmd ArchiveCmd) Description() string {
@@ -71,9 +72,7 @@ func (cmd ArchiveCmd) ArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParserWithMaxArgs(cmd.Name(), 0)
 	ap.SupportsFlag(groupChunksFlag, "", "Attempt to group chunks. This will produce smaller archives, but can take much longer to build.")
 	ap.SupportsFlag(revertFlag, "", "Return to unpurged table files, or rebuilt table files from archives")
-	/* TODO: Implement these flags
-	ap.SupportsFlag("purge", "", "remove table files after archiving")
-	*/
+	ap.SupportsFlag(purgeFlag, "", "remove table files after archiving")
 	return ap
 }
 func (cmd ArchiveCmd) Hidden() bool {
@@ -137,7 +136,9 @@ func (cmd ArchiveCmd) Exec(ctx context.Context, commandStr string, args []string
 			}
 		}
 
-		err = nbs.BuildArchive(ctx, cs, &groupings, progress)
+		purge := apr.Contains(purgeFlag)
+
+		err = nbs.BuildArchive(ctx, cs, &groupings, purge, progress)
 		if err != nil {
 			cli.PrintErrln(err)
 			return 1

--- a/integration-tests/bats/archive.bats
+++ b/integration-tests/bats/archive.bats
@@ -128,13 +128,24 @@ mutations_and_gc_statement() {
 @test "archive: archive --revert (rebuild)" {
   dolt sql -q "$(mutations_and_gc_statement)"
   dolt archive
-  dolt gc                         # This will delete the unused table files.
   dolt archive --revert
 
   # dolt log --stat will load every single chunk. 66 manually verified.
   commits=$(dolt log --stat --oneline | wc -l | sed 's/[ \t]//g')
   [ "$commits" -eq "66" ]
 }
+
+@test "archive: archive --purge" {
+  dolt sql -q "$(mutations_and_gc_statement)"
+
+  tablefile=$(find ./.dolt/noms/oldgen -type f -regex '.*/[a-v0-9]\{32\}')
+
+  [ -e "$tablefile" ] # extreme paranoia. make sure it exists before.
+  dolt archive --purge
+  # Ensure the table file is gone.
+  [ ! -e "$tablefile" ]
+}
+
 
 @test "archive: can clone archived repository" {
     mkdir -p remote/.dolt

--- a/integration-tests/bats/archive.bats
+++ b/integration-tests/bats/archive.bats
@@ -138,7 +138,8 @@ mutations_and_gc_statement() {
 @test "archive: archive --purge" {
   dolt sql -q "$(mutations_and_gc_statement)"
 
-  tablefile=$(find ./.dolt/noms/oldgen -type f -regex '.*/[a-v0-9]\{32\}')
+  # find impl differences by platform makes this a pain.
+  tablefile=$(find .dolt/noms/oldgen -type f -print | awk -F/ 'length($NF) == 32 && $NF ~ /^[a-v0-9]{32}$/')
 
   [ -e "$tablefile" ] # extreme paranoia. make sure it exists before.
   dolt archive --purge


### PR DESCRIPTION
The `dolt archive` command is extra safe, and doesn't cleanup table files is converts. The --purge flag will delete table files after the conversion is done.