### PR TITLE
Consistently use pointer receivers for TextStorage methods.

### DIFF
--- a/go/store/val/value_store.go
+++ b/go/store/val/value_store.go
@@ -73,17 +73,17 @@ var _ sql.StringWrapper = &TextStorage{}
 var _ driver.Valuer = &TextStorage{}
 
 // IsExactLength implements sql.BytesWrapper
-func (t TextStorage) IsExactLength() bool {
+func (t *TextStorage) IsExactLength() bool {
 	return false
 }
 
 // MaxByteLength implements sql.BytesWrapper
-func (t TextStorage) MaxByteLength() int64 {
+func (t *TextStorage) MaxByteLength() int64 {
 	return t.maxByteLength
 }
 
 // Unwrap implements sql.BytesWrapper
-func (t TextStorage) Unwrap(ctx context.Context) (string, error) {
+func (t *TextStorage) Unwrap(ctx context.Context) (string, error) {
 	buf, err := t.GetBytes(ctx)
 	if err != nil {
 		return "", err
@@ -91,18 +91,18 @@ func (t TextStorage) Unwrap(ctx context.Context) (string, error) {
 	return string(buf), nil
 }
 
-func (t TextStorage) UnwrapAny(ctx context.Context) (interface{}, error) {
+func (t *TextStorage) UnwrapAny(ctx context.Context) (interface{}, error) {
 	return t.Unwrap(ctx)
 }
 
-func (t TextStorage) WithMaxByteLength(maxByteLength int64) *TextStorage {
+func (t *TextStorage) WithMaxByteLength(maxByteLength int64) *TextStorage {
 	return &TextStorage{
 		ImmutableValue: NewImmutableValue(t.Addr, t.vs),
 		maxByteLength:  maxByteLength,
 	}
 }
 
-func (t TextStorage) Compare(ctx context.Context, other interface{}) (cmp int, comparable bool, err error) {
+func (t *TextStorage) Compare(ctx context.Context, other interface{}) (cmp int, comparable bool, err error) {
 	otherTextStorage, ok := other.(TextStorage)
 	if !ok {
 		return 0, false, nil


### PR DESCRIPTION
For structs that are exclusively used in interfaces, there's no reason to not use pointer receivers instead of value receivers. Using value receivers can cause the struct to be copied every time the method is invoked.

Pointer receivers are also more correct here: copying the struct means that changes to the ImmutableValue field (such as setting its Buf field in ImmutableValue.GetBytes) won't be saved when the method exits, defeating the caching of values loaded from storage. 