### PR TITLE
[no-release-notes] Fix copy-paste error in AdaptiveEncodingTypeHandler::SerializedCompare

### DIFF
--- a/go/store/val/adaptive_value.go
+++ b/go/store/val/adaptive_value.go
@@ -238,7 +238,7 @@ func (handler AdaptiveEncodingTypeHandler) SerializedCompare(ctx context.Context
 		}
 	}
 	if adaptiveValue2.IsOutOfBand() {
-		adaptiveValue1, err = adaptiveValue2.convertToInline(ctx, handler.vs, nil)
+		adaptiveValue2, err = adaptiveValue2.convertToInline(ctx, handler.vs, nil)
 		if err != nil {
 			return 0, err
 		}


### PR DESCRIPTION
This wasn't initially detected because AdaptiveEncodingTypeHandler is only used in Doltgres, and Doltgres was still automatically applying prefix lengths to indexes on TEXT and BLOB columns.