### PR TITLE
Enable the GC process to write to archive files

### DIFF
--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -296,6 +296,7 @@ func CreateGCArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParserWithMaxArgs("gc", 0)
 	ap.SupportsFlag(ShallowFlag, "s", "perform a fast, but incomplete garbage collection pass")
 	ap.SupportsFlag(FullFlag, "f", "perform a full garbage collection, including the old generation")
+	ap.SupportsInt(ArchiveLevelParam, "", "archive compression level", "Specify the archive compression level garbage collection results. Default is 0. Max is 2")
 	return ap
 }
 

--- a/go/cmd/dolt/cli/flags.go
+++ b/go/cmd/dolt/cli/flags.go
@@ -22,6 +22,7 @@ const (
 	AllowEmptyFlag       = "allow-empty"
 	AmendFlag            = "amend"
 	AuthorParam          = "author"
+	ArchiveLevelParam    = "archive-level"
 	BranchParam          = "branch"
 	CachedFlag           = "cached"
 	CheckoutCreateBranch = "b"

--- a/go/cmd/dolt/commands/gc.go
+++ b/go/cmd/dolt/commands/gc.go
@@ -17,6 +17,9 @@ package commands
 import (
 	"context"
 
+	"github.com/gocraft/dbr/v2"
+	"github.com/gocraft/dbr/v2/dialect"
+
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	eventsapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
@@ -27,8 +30,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/nbs"
-	"github.com/gocraft/dbr/v2"
-	"github.com/gocraft/dbr/v2/dialect"
 )
 
 var gcDocs = cli.CommandDocumentationContent{

--- a/go/cmd/dolt/commands/gc.go
+++ b/go/cmd/dolt/commands/gc.go
@@ -27,6 +27,8 @@ import (
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/nbs"
+	"github.com/gocraft/dbr/v2"
+	"github.com/gocraft/dbr/v2/dialect"
 )
 
 var gcDocs = cli.CommandDocumentationContent{
@@ -103,7 +105,7 @@ func (cmd GarbageCollectionCmd) Exec(ctx context.Context, commandStr string, arg
 		defer closeFunc()
 	}
 
-	query, err := constructDoltGCQuery(apr)
+	query, err := cmd.constructDoltGCQuery(apr)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
@@ -117,16 +119,37 @@ func (cmd GarbageCollectionCmd) Exec(ctx context.Context, commandStr string, arg
 }
 
 // constructDoltGCQuery generates the sql query necessary to call DOLT_GC()
-func constructDoltGCQuery(apr *argparser.ArgParseResults) (string, error) {
-	query := "call DOLT_GC("
+func (cmd GarbageCollectionCmd) constructDoltGCQuery(apr *argparser.ArgParseResults) (string, error) {
+	var params []interface{}
+
+	extraFlag := ""
 	if apr.Contains(cli.ShallowFlag) {
-		query += "'--shallow'"
+		extraFlag = "--shallow"
+	} else if apr.Contains(cli.FullFlag) {
+		extraFlag = "--full"
 	}
-	if apr.Contains(cli.FullFlag) {
-		query += "'--full'"
+
+	archiveLevel := chunks.NoArchive
+	if apr.Contains(cli.ArchiveLevelParam) {
+		lvl, ok := apr.GetInt(cli.ArchiveLevelParam)
+		if !ok {
+			return "", errhand.BuildDError("Invalid Argument: --archive-level must be an integer").SetPrintUsage().Build()
+		}
+		// validation is done in the procedure.
+		archiveLevel = chunks.GCArchiveLevel(lvl)
 	}
-	query += ")"
-	return query, nil
+
+	params = append(params, archiveLevel)
+
+	query := "CALL DOLT_GC('--archive-level', ?"
+	if extraFlag != "" {
+		query += ", ?)"
+		params = append(params, extraFlag)
+	} else {
+		query += ")"
+	}
+
+	return dbr.InterpolateForDialect(query, params, dialect.MySQL)
 }
 
 func MaybeMigrateEnv(ctx context.Context, dEnv *env.DoltEnv) (*env.DoltEnv, error) {

--- a/go/cmd/dolt/commands/sqlserver/command_line_config.go
+++ b/go/cmd/dolt/commands/sqlserver/command_line_config.go
@@ -577,3 +577,5 @@ type stubAutoGCBehavior struct {
 func (stubAutoGCBehavior) Enable() bool {
 	return false
 }
+
+func (stubAutoGCBehavior) ArchiveLevel() int { return servercfg.DefaultCompressionLevel }

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/go-mysql-server/eventscheduler"
 	"github.com/dolthub/go-mysql-server/server"
 	"github.com/dolthub/go-mysql-server/server/golden"
@@ -61,6 +60,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/utils/config"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/libraries/utils/svcs"
+	"github.com/dolthub/dolt/go/store/chunks"
 )
 
 const (

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -271,18 +271,9 @@ func ConfigureServices(
 	InitAutoGCController := &svcs.AnonService{
 		InitF: func(context.Context) error {
 			if cfg.ServerConfig.AutoGCBehavior() != nil && cfg.ServerConfig.AutoGCBehavior().Enable() {
-
-				// NM4 - there has got to be a better way.
-				var cmp chunks.GCCompression
-				switch cfg.ServerConfig.AutoGCBehavior().ArchiveLevel() {
-				case 0:
-					cmp = chunks.OldSkhool
-				case 1:
-					cmp = chunks.NewSkhool
-				case 2:
-					cmp = chunks.FutureSkhool
-				default:
-					panic("invalid archive level")
+				cmp := chunks.GCArchiveLevel(cfg.ServerConfig.AutoGCBehavior().ArchiveLevel())
+				if cmp < chunks.NoArchive || cmp > chunks.MaxArchiveLevel {
+					return fmt.Errorf("invalid value for %s: %d", cli.ArchiveLevelParam, cmp)
 				}
 
 				config.AutoGCController = sqle.NewAutoGCController(cmp, lgr)

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/go-mysql-server/eventscheduler"
 	"github.com/dolthub/go-mysql-server/server"
 	"github.com/dolthub/go-mysql-server/server/golden"
@@ -269,9 +270,22 @@ func ConfigureServices(
 
 	InitAutoGCController := &svcs.AnonService{
 		InitF: func(context.Context) error {
-			if cfg.ServerConfig.AutoGCBehavior() != nil &&
-				cfg.ServerConfig.AutoGCBehavior().Enable() {
-				config.AutoGCController = sqle.NewAutoGCController(lgr)
+			if cfg.ServerConfig.AutoGCBehavior() != nil && cfg.ServerConfig.AutoGCBehavior().Enable() {
+
+				// NM4 - there has got to be a better way.
+				var cmp chunks.GCCompression
+				switch cfg.ServerConfig.AutoGCBehavior().ArchiveLevel() {
+				case 0:
+					cmp = chunks.OldSkhool
+				case 1:
+					cmp = chunks.NewSkhool
+				case 2:
+					cmp = chunks.FutureSkhool
+				default:
+					panic("invalid archive level")
+				}
+
+				config.AutoGCController = sqle.NewAutoGCController(cmp, lgr)
 			}
 			return nil
 		},

--- a/go/cmd/dolt/commands/sqlserver/server_test.go
+++ b/go/cmd/dolt/commands/sqlserver/server_test.go
@@ -590,6 +590,7 @@ func TestGenerateYamlConfig(t *testing.T) {
   # event_scheduler: "OFF"
   # auto_gc_behavior:
     # enable: false
+    # archive_level: 0
 
 listener:
   # host: localhost

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -1775,7 +1775,7 @@ func (ddb *DoltDB) Rebase(ctx context.Context) error {
 // until no possibly-stale ChunkStore state is retained in memory, or failing
 // certain in-progress operations which cannot be finalized in a timely manner,
 // etc.
-func (ddb *DoltDB) GC(ctx context.Context, mode types.GCMode, cmp chunks.GCCompression, safepointController types.GCSafepointController) error {
+func (ddb *DoltDB) GC(ctx context.Context, mode types.GCMode, cmp chunks.GCArchiveLevel, safepointController types.GCSafepointController) error {
 	collector, ok := ddb.db.Database.(datas.GarbageCollector)
 	if !ok {
 		return fmt.Errorf("this database does not support garbage collection")

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -1775,7 +1775,7 @@ func (ddb *DoltDB) Rebase(ctx context.Context) error {
 // until no possibly-stale ChunkStore state is retained in memory, or failing
 // certain in-progress operations which cannot be finalized in a timely manner,
 // etc.
-func (ddb *DoltDB) GC(ctx context.Context, mode types.GCMode, safepointController types.GCSafepointController, cmp chunks.GCCompression) error {
+func (ddb *DoltDB) GC(ctx context.Context, mode types.GCMode, cmp chunks.GCCompression, safepointController types.GCSafepointController) error {
 	collector, ok := ddb.db.Database.(datas.GarbageCollector)
 	if !ok {
 		return fmt.Errorf("this database does not support garbage collection")

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -1775,7 +1775,7 @@ func (ddb *DoltDB) Rebase(ctx context.Context) error {
 // until no possibly-stale ChunkStore state is retained in memory, or failing
 // certain in-progress operations which cannot be finalized in a timely manner,
 // etc.
-func (ddb *DoltDB) GC(ctx context.Context, mode types.GCMode, safepointController types.GCSafepointController) error {
+func (ddb *DoltDB) GC(ctx context.Context, mode types.GCMode, safepointController types.GCSafepointController, cmp chunks.GCCompression) error {
 	collector, ok := ddb.db.Database.(datas.GarbageCollector)
 	if !ok {
 		return fmt.Errorf("this database does not support garbage collection")
@@ -1819,7 +1819,7 @@ func (ddb *DoltDB) GC(ctx context.Context, mode types.GCMode, safepointControlle
 		return err
 	}
 
-	return collector.GC(ctx, mode, oldGen, newGen, safepointController)
+	return collector.GC(ctx, mode, cmp, oldGen, newGen, safepointController)
 }
 
 func (ddb *DoltDB) ShallowGC(ctx context.Context) error {

--- a/go/libraries/doltcore/doltdb/gc_test.go
+++ b/go/libraries/doltcore/doltdb/gc_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -140,7 +141,7 @@ func testGarbageCollection(t *testing.T, test gcTest) {
 	}
 
 	ddb := dEnv.DoltDB(ctx)
-	err := ddb.GC(ctx, types.GCModeDefault, purgingSafepointController{ddb})
+	err := ddb.GC(ctx, types.GCModeDefault, chunks.OldSkhool, purgingSafepointController{ddb})
 	require.NoError(t, err)
 	test.postGCFunc(ctx, t, dEnv.DoltDB(ctx), res)
 
@@ -209,7 +210,7 @@ func testGarbageCollectionHasCacheDataCorruptionBugFix(t *testing.T) {
 	_, err = ns.Write(ctx, c1.Node())
 	require.NoError(t, err)
 
-	err = ddb.GC(ctx, types.GCModeDefault, purgingSafepointController{ddb})
+	err = ddb.GC(ctx, types.GCModeDefault, chunks.OldSkhool, purgingSafepointController{ddb})
 	require.NoError(t, err)
 
 	c2 := newIntMap(t, ctx, ns, 2, 2)

--- a/go/libraries/doltcore/doltdb/gc_test.go
+++ b/go/libraries/doltcore/doltdb/gc_test.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,6 +31,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
+	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/nbs"
 	"github.com/dolthub/dolt/go/store/prolly"

--- a/go/libraries/doltcore/doltdb/gc_test.go
+++ b/go/libraries/doltcore/doltdb/gc_test.go
@@ -141,7 +141,7 @@ func testGarbageCollection(t *testing.T, test gcTest) {
 	}
 
 	ddb := dEnv.DoltDB(ctx)
-	err := ddb.GC(ctx, types.GCModeDefault, chunks.OldSkhool, purgingSafepointController{ddb})
+	err := ddb.GC(ctx, types.GCModeDefault, chunks.NoArchive, purgingSafepointController{ddb})
 	require.NoError(t, err)
 	test.postGCFunc(ctx, t, dEnv.DoltDB(ctx), res)
 
@@ -210,7 +210,7 @@ func testGarbageCollectionHasCacheDataCorruptionBugFix(t *testing.T) {
 	_, err = ns.Write(ctx, c1.Node())
 	require.NoError(t, err)
 
-	err = ddb.GC(ctx, types.GCModeDefault, chunks.OldSkhool, purgingSafepointController{ddb})
+	err = ddb.GC(ctx, types.GCModeDefault, chunks.NoArchive, purgingSafepointController{ddb})
 	require.NoError(t, err)
 
 	c2 := newIntMap(t, ctx, ns, 2, 2)

--- a/go/libraries/doltcore/servercfg/serverconfig.go
+++ b/go/libraries/doltcore/servercfg/serverconfig.go
@@ -74,6 +74,7 @@ const (
 	DefaultMySQLUnixSocketFilePath   = "/tmp/mysql.sock"
 	DefaultMaxLoggedQueryLen         = 0
 	DefaultEncodeLoggedQuery         = false
+	DefaultCompressionLevel          = 0
 )
 
 func ptr[T any](t T) *T {
@@ -239,7 +240,8 @@ func defaultServerConfigYAML() *YAMLConfig {
 			AutoCommit:            ptr(DefaultAutoCommit),
 			DoltTransactionCommit: ptr(DefaultDoltTransactionCommit),
 			AutoGCBehavior: &AutoGCBehaviorYAMLConfig{
-				Enable_: ptr(DefaultAutoGCBehaviorEnable),
+				Enable_:       ptr(DefaultAutoGCBehaviorEnable),
+				ArchiveLevel_: ptr(DefaultCompressionLevel),
 			},
 		},
 		UserConfig: UserYAMLConfig{
@@ -484,4 +486,5 @@ func CheckForUnixSocket(config ServerConfig) (string, bool, error) {
 
 type AutoGCBehavior interface {
 	Enable() bool
+	ArchiveLevel() int
 }

--- a/go/libraries/doltcore/servercfg/yaml_config.go
+++ b/go/libraries/doltcore/servercfg/yaml_config.go
@@ -986,7 +986,8 @@ func (cfg YAMLConfig) ValueSet(value string) bool {
 }
 
 type AutoGCBehaviorYAMLConfig struct {
-	Enable_ *bool `yaml:"enable,omitempty" minver:"1.50.0"`
+	Enable_       *bool `yaml:"enable,omitempty" minver:"1.50.0"`
+	ArchiveLevel_ *int  `yaml:"archive_level,omitempty" minver:"TBD"`
 }
 
 func (a *AutoGCBehaviorYAMLConfig) Enable() bool {
@@ -996,8 +997,16 @@ func (a *AutoGCBehaviorYAMLConfig) Enable() bool {
 	return *a.Enable_
 }
 
+func (a *AutoGCBehaviorYAMLConfig) ArchiveLevel() int {
+	if a.ArchiveLevel_ == nil {
+		return 0
+	}
+	return *a.ArchiveLevel_
+}
+
 func toAutoGCBehaviorYAML(a AutoGCBehavior) *AutoGCBehaviorYAMLConfig {
 	return &AutoGCBehaviorYAMLConfig{
-		Enable_: ptr(a.Enable()),
+		Enable_:       ptr(a.Enable()),
+		ArchiveLevel_: ptr(a.ArchiveLevel()),
 	}
 }

--- a/go/libraries/doltcore/servercfg/yaml_config_test.go
+++ b/go/libraries/doltcore/servercfg/yaml_config_test.go
@@ -36,6 +36,7 @@ behavior:
     event_scheduler: ON
     auto_gc_behavior:
         enable: false
+        archive_level: 0
 
 listener:
     host: localhost

--- a/go/libraries/doltcore/sqle/auto_gc.go
+++ b/go/libraries/doltcore/sqle/auto_gc.go
@@ -155,7 +155,7 @@ func (c *AutoGCController) doWork(ctx context.Context, work autoGCWork, ctxF fun
 	defer sql.SessionEnd(sqlCtx.Session)
 	sql.SessionCommandBegin(sqlCtx.Session)
 	defer sql.SessionCommandEnd(sqlCtx.Session)
-	err = dprocedures.RunDoltGC(sqlCtx, work.db, types.GCModeDefault, work.name, c.cmpLevel)
+	err = dprocedures.RunDoltGC(sqlCtx, work.db, types.GCModeDefault, c.cmpLevel, work.name)
 	if err != nil {
 		if !errors.Is(err, chunks.ErrNothingToCollect) {
 			c.lgr.Warnf("sqle/auto_gc: Attempt to auto GC database %s failed with error: %v", work.name, err)

--- a/go/libraries/doltcore/sqle/auto_gc.go
+++ b/go/libraries/doltcore/sqle/auto_gc.go
@@ -21,6 +21,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/sirupsen/logrus"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dprocedures"
@@ -28,8 +31,6 @@ import (
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/datas"
 	"github.com/dolthub/dolt/go/store/types"
-	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/sirupsen/logrus"
 )
 
 // Auto GC is the ability of a running SQL server engine to perform

--- a/go/libraries/doltcore/sqle/auto_gc_test.go
+++ b/go/libraries/doltcore/sqle/auto_gc_test.go
@@ -21,11 +21,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/datas"
 )
 

--- a/go/libraries/doltcore/sqle/auto_gc_test.go
+++ b/go/libraries/doltcore/sqle/auto_gc_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -39,12 +40,12 @@ func TestAutoGCController(t *testing.T) {
 	}
 	t.Run("Hook", func(t *testing.T) {
 		t.Run("NeverStarted", func(t *testing.T) {
-			controller := NewAutoGCController(NewLogger())
+			controller := NewAutoGCController(chunks.OldSkhool, NewLogger())
 			hook := controller.newCommitHook("some_database", nil)
 			hook.stop()
 		})
 		t.Run("StartedBeforeNewHook", func(t *testing.T) {
-			controller := NewAutoGCController(NewLogger())
+			controller := NewAutoGCController(chunks.OldSkhool, NewLogger())
 			bg := sql.NewBackgroundThreads()
 			defer bg.Shutdown()
 			err := controller.RunBackgroundThread(bg, CtxFactory)
@@ -56,7 +57,7 @@ func TestAutoGCController(t *testing.T) {
 			hook.stop()
 		})
 		t.Run("StartedAfterNewHook", func(t *testing.T) {
-			controller := NewAutoGCController(NewLogger())
+			controller := NewAutoGCController(chunks.OldSkhool, NewLogger())
 			bg := sql.NewBackgroundThreads()
 			defer bg.Shutdown()
 			ctx := context.Background()
@@ -68,7 +69,7 @@ func TestAutoGCController(t *testing.T) {
 			hook.stop()
 		})
 		t.Run("ExecuteOnCanceledCtx", func(t *testing.T) {
-			controller := NewAutoGCController(NewLogger())
+			controller := NewAutoGCController(chunks.OldSkhool, NewLogger())
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			dEnv := CreateTestEnvWithName("some_database")
@@ -78,7 +79,7 @@ func TestAutoGCController(t *testing.T) {
 		})
 	})
 	t.Run("gcBgThread", func(t *testing.T) {
-		controller := NewAutoGCController(NewLogger())
+		controller := NewAutoGCController(chunks.OldSkhool, NewLogger())
 		ctx, cancel := context.WithCancel(context.Background())
 		var wg sync.WaitGroup
 		wg.Add(1)
@@ -92,7 +93,7 @@ func TestAutoGCController(t *testing.T) {
 	})
 	t.Run("DatabaseProviderHooks", func(t *testing.T) {
 		t.Run("Unstarted", func(t *testing.T) {
-			controller := NewAutoGCController(NewLogger())
+			controller := NewAutoGCController(chunks.OldSkhool, NewLogger())
 			ctx, err := CtxFactory(context.Background())
 			require.NoError(t, err)
 			dEnv := CreateTestEnvWithName("some_database")
@@ -101,7 +102,7 @@ func TestAutoGCController(t *testing.T) {
 			controller.DropDatabaseHook()(nil, "some_database")
 		})
 		t.Run("Started", func(t *testing.T) {
-			controller := NewAutoGCController(NewLogger())
+			controller := NewAutoGCController(chunks.OldSkhool, NewLogger())
 			bg := sql.NewBackgroundThreads()
 			defer bg.Shutdown()
 			err := controller.RunBackgroundThread(bg, CtxFactory)

--- a/go/libraries/doltcore/sqle/auto_gc_test.go
+++ b/go/libraries/doltcore/sqle/auto_gc_test.go
@@ -40,12 +40,12 @@ func TestAutoGCController(t *testing.T) {
 	}
 	t.Run("Hook", func(t *testing.T) {
 		t.Run("NeverStarted", func(t *testing.T) {
-			controller := NewAutoGCController(chunks.OldSkhool, NewLogger())
+			controller := NewAutoGCController(chunks.NoArchive, NewLogger())
 			hook := controller.newCommitHook("some_database", nil)
 			hook.stop()
 		})
 		t.Run("StartedBeforeNewHook", func(t *testing.T) {
-			controller := NewAutoGCController(chunks.OldSkhool, NewLogger())
+			controller := NewAutoGCController(chunks.NoArchive, NewLogger())
 			bg := sql.NewBackgroundThreads()
 			defer bg.Shutdown()
 			err := controller.RunBackgroundThread(bg, CtxFactory)
@@ -57,7 +57,7 @@ func TestAutoGCController(t *testing.T) {
 			hook.stop()
 		})
 		t.Run("StartedAfterNewHook", func(t *testing.T) {
-			controller := NewAutoGCController(chunks.OldSkhool, NewLogger())
+			controller := NewAutoGCController(chunks.NoArchive, NewLogger())
 			bg := sql.NewBackgroundThreads()
 			defer bg.Shutdown()
 			ctx := context.Background()
@@ -69,7 +69,7 @@ func TestAutoGCController(t *testing.T) {
 			hook.stop()
 		})
 		t.Run("ExecuteOnCanceledCtx", func(t *testing.T) {
-			controller := NewAutoGCController(chunks.OldSkhool, NewLogger())
+			controller := NewAutoGCController(chunks.NoArchive, NewLogger())
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			dEnv := CreateTestEnvWithName("some_database")
@@ -79,7 +79,7 @@ func TestAutoGCController(t *testing.T) {
 		})
 	})
 	t.Run("gcBgThread", func(t *testing.T) {
-		controller := NewAutoGCController(chunks.OldSkhool, NewLogger())
+		controller := NewAutoGCController(chunks.NoArchive, NewLogger())
 		ctx, cancel := context.WithCancel(context.Background())
 		var wg sync.WaitGroup
 		wg.Add(1)
@@ -93,7 +93,7 @@ func TestAutoGCController(t *testing.T) {
 	})
 	t.Run("DatabaseProviderHooks", func(t *testing.T) {
 		t.Run("Unstarted", func(t *testing.T) {
-			controller := NewAutoGCController(chunks.OldSkhool, NewLogger())
+			controller := NewAutoGCController(chunks.NoArchive, NewLogger())
 			ctx, err := CtxFactory(context.Background())
 			require.NoError(t, err)
 			dEnv := CreateTestEnvWithName("some_database")
@@ -102,7 +102,7 @@ func TestAutoGCController(t *testing.T) {
 			controller.DropDatabaseHook()(nil, "some_database")
 		})
 		t.Run("Started", func(t *testing.T) {
-			controller := NewAutoGCController(chunks.OldSkhool, NewLogger())
+			controller := NewAutoGCController(chunks.NoArchive, NewLogger())
 			bg := sql.NewBackgroundThreads()
 			defer bg.Shutdown()
 			err := controller.RunBackgroundThread(bg, CtxFactory)

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_gc.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_gc.go
@@ -167,9 +167,6 @@ type sessionAwareSafepointController struct {
 
 	waiter *gcctx.GCSafepointWaiter
 	keeper func(hash.Hash) bool
-
-	// NM4 - Maybe here???
-	cmpLvl int
 }
 
 func (sc *sessionAwareSafepointController) visit(ctx context.Context, sess gcctx.GCRootsProvider) error {

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_gc.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_gc.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
@@ -31,6 +30,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/gcctx"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
+	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/types"
 )

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_gc.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_gc.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
@@ -166,6 +167,9 @@ type sessionAwareSafepointController struct {
 
 	waiter *gcctx.GCSafepointWaiter
 	keeper func(hash.Hash) bool
+
+	// NM4 - Maybe here???
+	cmpLvl int
 }
 
 func (sc *sessionAwareSafepointController) visit(ctx context.Context, sess gcctx.GCRootsProvider) error {
@@ -237,7 +241,19 @@ func doDoltGC(ctx *sql.Context, args []string) (int, error) {
 			mode = types.GCModeFull
 		}
 
-		err := RunDoltGC(ctx, ddb, mode, ctx.GetCurrentDatabase())
+		cmpLvl := chunks.OldSkhool
+		if apr.Contains(cli.ArchiveLevelParam) {
+			lvl, ok := apr.GetInt(cli.ArchiveLevelParam)
+			if !ok {
+				return cmdFailure, fmt.Errorf("parse error for value for %s: %s", cli.ArchiveLevelParam, apr.GetValues()[cli.ArchiveLevelParam])
+			}
+			if lvl < int(chunks.OldSkhool) || lvl > int(chunks.FutureSkhool) {
+				return cmdFailure, fmt.Errorf("invalid value for %s: %d", cli.ArchiveLevelParam, lvl)
+			}
+			cmpLvl = chunks.GCCompression(lvl)
+		}
+
+		err := RunDoltGC(ctx, ddb, mode, ctx.GetCurrentDatabase(), cmpLvl)
 		if err != nil {
 			return cmdFailure, err
 		}
@@ -246,7 +262,7 @@ func doDoltGC(ctx *sql.Context, args []string) (int, error) {
 	return cmdSuccess, nil
 }
 
-func RunDoltGC(ctx *sql.Context, ddb *doltdb.DoltDB, mode types.GCMode, dbname string) error {
+func RunDoltGC(ctx *sql.Context, ddb *doltdb.DoltDB, mode types.GCMode, dbname string, cmp chunks.GCCompression) error {
 	var sc types.GCSafepointController
 	if UseSessionAwareSafepointController {
 		dSess := dsess.DSessFromSess(ctx.Session)
@@ -280,5 +296,5 @@ func RunDoltGC(ctx *sql.Context, ddb *doltdb.DoltDB, mode types.GCMode, dbname s
 			doltDB:    ddb,
 		}
 	}
-	return ddb.GC(ctx, mode, sc)
+	return ddb.GC(ctx, mode, sc, cmp)
 }

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_gc.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_gc.go
@@ -241,16 +241,16 @@ func doDoltGC(ctx *sql.Context, args []string) (int, error) {
 			mode = types.GCModeFull
 		}
 
-		cmpLvl := chunks.OldSkhool
+		cmpLvl := chunks.NoArchive
 		if apr.Contains(cli.ArchiveLevelParam) {
 			lvl, ok := apr.GetInt(cli.ArchiveLevelParam)
 			if !ok {
 				return cmdFailure, fmt.Errorf("parse error for value for %s: %s", cli.ArchiveLevelParam, apr.GetValues()[cli.ArchiveLevelParam])
 			}
-			if lvl < int(chunks.OldSkhool) || lvl > int(chunks.FutureSkhool) {
+			if lvl < int(chunks.NoArchive) || lvl > int(chunks.MaxArchiveLevel) {
 				return cmdFailure, fmt.Errorf("invalid value for %s: %d", cli.ArchiveLevelParam, lvl)
 			}
-			cmpLvl = chunks.GCCompression(lvl)
+			cmpLvl = chunks.GCArchiveLevel(lvl)
 		}
 
 		err := RunDoltGC(ctx, ddb, mode, cmpLvl, ctx.GetCurrentDatabase())
@@ -262,7 +262,7 @@ func doDoltGC(ctx *sql.Context, args []string) (int, error) {
 	return cmdSuccess, nil
 }
 
-func RunDoltGC(ctx *sql.Context, ddb *doltdb.DoltDB, mode types.GCMode, cmp chunks.GCCompression, dbname string) error {
+func RunDoltGC(ctx *sql.Context, ddb *doltdb.DoltDB, mode types.GCMode, cmp chunks.GCArchiveLevel, dbname string) error {
 	var sc types.GCSafepointController
 	if UseSessionAwareSafepointController {
 		dSess := dsess.DSessFromSess(ctx.Session)

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_gc.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_gc.go
@@ -296,5 +296,5 @@ func RunDoltGC(ctx *sql.Context, ddb *doltdb.DoltDB, mode types.GCMode, cmp chun
 			doltDB:    ddb,
 		}
 	}
-	return ddb.GC(ctx, mode, sc, cmp)
+	return ddb.GC(ctx, mode, cmp, sc)
 }

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_gc.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_gc.go
@@ -236,7 +236,7 @@ func doDoltGC(ctx *sql.Context, args []string) (int, error) {
 			return cmdFailure, err
 		}
 	} else {
-		var mode types.GCMode = types.GCModeDefault
+		mode := types.GCModeDefault
 		if apr.Contains(cli.FullFlag) {
 			mode = types.GCModeFull
 		}
@@ -253,7 +253,7 @@ func doDoltGC(ctx *sql.Context, args []string) (int, error) {
 			cmpLvl = chunks.GCCompression(lvl)
 		}
 
-		err := RunDoltGC(ctx, ddb, mode, ctx.GetCurrentDatabase(), cmpLvl)
+		err := RunDoltGC(ctx, ddb, mode, cmpLvl, ctx.GetCurrentDatabase())
 		if err != nil {
 			return cmdFailure, err
 		}
@@ -262,7 +262,7 @@ func doDoltGC(ctx *sql.Context, args []string) (int, error) {
 	return cmdSuccess, nil
 }
 
-func RunDoltGC(ctx *sql.Context, ddb *doltdb.DoltDB, mode types.GCMode, dbname string, cmp chunks.GCCompression) error {
+func RunDoltGC(ctx *sql.Context, ddb *doltdb.DoltDB, mode types.GCMode, cmp chunks.GCCompression, dbname string) error {
 	var sc types.GCSafepointController
 	if UseSessionAwareSafepointController {
 		dSess := dsess.DSessFromSess(ctx.Session)

--- a/go/store/chunks/chunk_store.go
+++ b/go/store/chunks/chunk_store.go
@@ -208,6 +208,15 @@ const (
 	GCMode_Full
 )
 
+type GCCompression int
+
+// NM4 - not sure why the types package is where we define stuff like this...
+const (
+	OldSkhool GCCompression = iota
+	NewSkhool
+	FutureSkhool
+)
+
 // ChunkStoreGarbageCollector is a ChunkStore that supports garbage collection.
 type ChunkStoreGarbageCollector interface {
 	ChunkStore
@@ -236,7 +245,7 @@ type ChunkStoreGarbageCollector interface {
 	// filtered through the |filter| and their references are walked with
 	// |getAddrs|, each of those addresses being filtered and copied as
 	// well.
-	MarkAndSweepChunks(ctx context.Context, getAddrs GetAddrsCurry, filter HasManyFunc, dest ChunkStore, mode GCMode) (MarkAndSweeper, error)
+	MarkAndSweepChunks(ctx context.Context, getAddrs GetAddrsCurry, filter HasManyFunc, dest ChunkStore, mode GCMode, cmp GCCompression) (MarkAndSweeper, error)
 
 	// Count returns the number of chunks in the store.
 	Count() (uint32, error)

--- a/go/store/chunks/chunk_store.go
+++ b/go/store/chunks/chunk_store.go
@@ -208,13 +208,16 @@ const (
 	GCMode_Full
 )
 
-type GCCompression int
+type GCArchiveLevel int
 
-// NM4 - not sure why the types package is where we define stuff like this...
 const (
-	OldSkhool GCCompression = iota
-	NewSkhool
-	FutureSkhool
+	// NoArchive means that the GC process will write chunks into the classic table format with Snappy compression.
+	NoArchive GCArchiveLevel = iota
+	// SimpleArchive means that the GC process will write chunks into archives, using a single dictionary for all chunks.
+	SimpleArchive
+	// GroupedArchive means that the GC process will write chunks into archives, using chunk group dictionaries.
+	GroupedArchive
+	MaxArchiveLevel = SimpleArchive // Currently GroupedArchives are not supported in GC.
 )
 
 // ChunkStoreGarbageCollector is a ChunkStore that supports garbage collection.
@@ -245,7 +248,7 @@ type ChunkStoreGarbageCollector interface {
 	// filtered through the |filter| and their references are walked with
 	// |getAddrs|, each of those addresses being filtered and copied as
 	// well.
-	MarkAndSweepChunks(ctx context.Context, getAddrs GetAddrsCurry, filter HasManyFunc, dest ChunkStore, mode GCMode, cmp GCCompression) (MarkAndSweeper, error)
+	MarkAndSweepChunks(ctx context.Context, getAddrs GetAddrsCurry, filter HasManyFunc, dest ChunkStore, mode GCMode, cmp GCArchiveLevel) (MarkAndSweeper, error)
 
 	// Count returns the number of chunks in the store.
 	Count() (uint32, error)

--- a/go/store/chunks/memory_store.go
+++ b/go/store/chunks/memory_store.go
@@ -406,7 +406,7 @@ func (i *msvMarkAndSweeper) Close(context.Context) error {
 	return nil
 }
 
-func (ms *MemoryStoreView) MarkAndSweepChunks(ctx context.Context, getAddrs GetAddrsCurry, filter HasManyFunc, dest ChunkStore, _ GCMode, _ GCCompression) (MarkAndSweeper, error) {
+func (ms *MemoryStoreView) MarkAndSweepChunks(ctx context.Context, getAddrs GetAddrsCurry, filter HasManyFunc, dest ChunkStore, _ GCMode, _ GCArchiveLevel) (MarkAndSweeper, error) {
 	if dest != ms {
 		panic("unsupported")
 	}

--- a/go/store/chunks/memory_store.go
+++ b/go/store/chunks/memory_store.go
@@ -406,7 +406,7 @@ func (i *msvMarkAndSweeper) Close(context.Context) error {
 	return nil
 }
 
-func (ms *MemoryStoreView) MarkAndSweepChunks(ctx context.Context, getAddrs GetAddrsCurry, filter HasManyFunc, dest ChunkStore, mode GCMode) (MarkAndSweeper, error) {
+func (ms *MemoryStoreView) MarkAndSweepChunks(ctx context.Context, getAddrs GetAddrsCurry, filter HasManyFunc, dest ChunkStore, _ GCMode, _ GCCompression) (MarkAndSweeper, error) {
 	if dest != ms {
 		panic("unsupported")
 	}

--- a/go/store/chunks/test_utils.go
+++ b/go/store/chunks/test_utils.go
@@ -91,7 +91,7 @@ func (s *TestStoreView) EndGC(mode GCMode) {
 	collector.EndGC(mode)
 }
 
-func (s *TestStoreView) MarkAndSweepChunks(ctx context.Context, getAddrs GetAddrsCurry, filter HasManyFunc, dest ChunkStore, mode GCMode, cmp GCCompression) (MarkAndSweeper, error) {
+func (s *TestStoreView) MarkAndSweepChunks(ctx context.Context, getAddrs GetAddrsCurry, filter HasManyFunc, dest ChunkStore, mode GCMode, cmp GCArchiveLevel) (MarkAndSweeper, error) {
 	collector, ok := s.ChunkStore.(ChunkStoreGarbageCollector)
 	if !ok || dest != s {
 		return nil, ErrUnsupportedOperation

--- a/go/store/chunks/test_utils.go
+++ b/go/store/chunks/test_utils.go
@@ -91,12 +91,12 @@ func (s *TestStoreView) EndGC(mode GCMode) {
 	collector.EndGC(mode)
 }
 
-func (s *TestStoreView) MarkAndSweepChunks(ctx context.Context, getAddrs GetAddrsCurry, filter HasManyFunc, dest ChunkStore, mode GCMode) (MarkAndSweeper, error) {
+func (s *TestStoreView) MarkAndSweepChunks(ctx context.Context, getAddrs GetAddrsCurry, filter HasManyFunc, dest ChunkStore, mode GCMode, cmp GCCompression) (MarkAndSweeper, error) {
 	collector, ok := s.ChunkStore.(ChunkStoreGarbageCollector)
 	if !ok || dest != s {
 		return nil, ErrUnsupportedOperation
 	}
-	return collector.MarkAndSweepChunks(ctx, getAddrs, filter, collector, mode)
+	return collector.MarkAndSweepChunks(ctx, getAddrs, filter, collector, mode, cmp)
 }
 
 func (s *TestStoreView) Count() (uint32, error) {

--- a/go/store/datas/database.go
+++ b/go/store/datas/database.go
@@ -198,7 +198,7 @@ type GarbageCollector interface {
 
 	// GC traverses the database starting at the Root and removes
 	// all unreferenced data from persistent storage.
-	GC(ctx context.Context, mode types.GCMode, cmp chunks.GCCompression, oldGenRefs, newGenRefs hash.HashSet, safepointController types.GCSafepointController) error
+	GC(ctx context.Context, mode types.GCMode, cmp chunks.GCArchiveLevel, oldGenRefs, newGenRefs hash.HashSet, safepointController types.GCSafepointController) error
 }
 
 // CanUsePuller returns true if a datas.Puller can be used to pull data from one Database into another.  Not all

--- a/go/store/datas/database.go
+++ b/go/store/datas/database.go
@@ -198,7 +198,7 @@ type GarbageCollector interface {
 
 	// GC traverses the database starting at the Root and removes
 	// all unreferenced data from persistent storage.
-	GC(ctx context.Context, mode types.GCMode, oldGenRefs, newGenRefs hash.HashSet, safepointController types.GCSafepointController) error
+	GC(ctx context.Context, mode types.GCMode, cmp chunks.GCCompression, oldGenRefs, newGenRefs hash.HashSet, safepointController types.GCSafepointController) error
 }
 
 // CanUsePuller returns true if a datas.Puller can be used to pull data from one Database into another.  Not all

--- a/go/store/datas/database_common.go
+++ b/go/store/datas/database_common.go
@@ -1168,7 +1168,7 @@ func (db *database) doDelete(ctx context.Context, datasetIDstr string, workingse
 }
 
 // GC traverses the database starting at the Root and removes all unreferenced data from persistent storage.
-func (db *database) GC(ctx context.Context, mode types.GCMode, cmp chunks.GCCompression, oldGenRefs, newGenRefs hash.HashSet, safepointController types.GCSafepointController) error {
+func (db *database) GC(ctx context.Context, mode types.GCMode, cmp chunks.GCArchiveLevel, oldGenRefs, newGenRefs hash.HashSet, safepointController types.GCSafepointController) error {
 	return db.ValueStore.GC(ctx, mode, cmp, oldGenRefs, newGenRefs, safepointController)
 }
 

--- a/go/store/datas/database_common.go
+++ b/go/store/datas/database_common.go
@@ -1168,8 +1168,8 @@ func (db *database) doDelete(ctx context.Context, datasetIDstr string, workingse
 }
 
 // GC traverses the database starting at the Root and removes all unreferenced data from persistent storage.
-func (db *database) GC(ctx context.Context, mode types.GCMode, oldGenRefs, newGenRefs hash.HashSet, safepointController types.GCSafepointController) error {
-	return db.ValueStore.GC(ctx, mode, oldGenRefs, newGenRefs, safepointController)
+func (db *database) GC(ctx context.Context, mode types.GCMode, cmp chunks.GCCompression, oldGenRefs, newGenRefs hash.HashSet, safepointController types.GCSafepointController) error {
+	return db.ValueStore.GC(ctx, mode, cmp, oldGenRefs, newGenRefs, safepointController)
 }
 
 func (db *database) tryCommitChunks(ctx context.Context, newRootHash hash.Hash, currentRootHash hash.Hash) error {

--- a/go/store/nbs/archive_writer.go
+++ b/go/store/nbs/archive_writer.go
@@ -579,6 +579,18 @@ func (asw *ArchiveStreamWriter) GetMD5() []byte {
 	return asw.writer.fullMD5[:]
 }
 
+func (asw *ArchiveStreamWriter) Cancel() error {
+	rdr, err := asw.writer.output.Reader()
+	if err != nil {
+		return err
+	}
+	err = rdr.Close()
+	if err != nil {
+		return err
+	}
+	return asw.Remove()
+}
+
 func (asw *ArchiveStreamWriter) Remove() error {
 	return os.Remove(asw.writer.finalPath)
 }

--- a/go/store/nbs/cmp_chunk_table_writer.go
+++ b/go/store/nbs/cmp_chunk_table_writer.go
@@ -58,6 +58,8 @@ type GenericTableWriter interface {
 	GetMD5() []byte
 	// Remove cleans up and artifacts created by the table writer. Called after everything else is done.
 	Remove() error
+	// Terminate the inprogress write and attempt to cleanup any resources.
+	Cancel() error
 }
 
 const defaultTableSinkBlockSize = 2 * 1024 * 1024

--- a/go/store/nbs/gc_copier.go
+++ b/go/store/nbs/gc_copier.go
@@ -17,7 +17,6 @@ package nbs
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/dolthub/dolt/go/store/chunks"
@@ -53,7 +52,7 @@ type gcCopier struct {
 func newGarbageCollectionCopier(cmp chunks.GCCompression, tfp tableFilePersister) (*gcCopier, error) {
 	var writer GenericTableWriter
 	var err error
-	if os.Getenv("DOLT_ARCHIVE_PULL_STREAMER") != "" {
+	if cmp == chunks.NewSkhool { // NM4 - FutureSkhool too??? May need to group after?? Not sure how this is gonna work.
 		writer, err = NewArchiveStreamWriter("")
 	} else {
 		writer, err = NewCmpChunkTableWriter("")

--- a/go/store/nbs/gc_copier.go
+++ b/go/store/nbs/gc_copier.go
@@ -58,7 +58,7 @@ func newGarbageCollectionCopier(cmp chunks.GCArchiveLevel, tfp tableFilePersiste
 	case chunks.NoArchive:
 		writer, err = NewCmpChunkTableWriter("")
 	default:
-		return nil, fmt.Errorf("invalid archive level: %s", cmp)
+		return nil, fmt.Errorf("invalid archive level: %d", cmp)
 	}
 	if err != nil {
 		return nil, err

--- a/go/store/nbs/gc_copier.go
+++ b/go/store/nbs/gc_copier.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
 )
 
@@ -49,7 +50,7 @@ type gcCopier struct {
 	tfp    tableFilePersister
 }
 
-func newGarbageCollectionCopier(tfp tableFilePersister) (*gcCopier, error) {
+func newGarbageCollectionCopier(cmp chunks.GCCompression, tfp tableFilePersister) (*gcCopier, error) {
 	var writer GenericTableWriter
 	var err error
 	if os.Getenv("DOLT_ARCHIVE_PULL_STREAMER") != "" {

--- a/go/store/nbs/gc_copier.go
+++ b/go/store/nbs/gc_copier.go
@@ -49,13 +49,16 @@ type gcCopier struct {
 	tfp    tableFilePersister
 }
 
-func newGarbageCollectionCopier(cmp chunks.GCCompression, tfp tableFilePersister) (*gcCopier, error) {
+func newGarbageCollectionCopier(cmp chunks.GCArchiveLevel, tfp tableFilePersister) (*gcCopier, error) {
 	var writer GenericTableWriter
 	var err error
-	if cmp == chunks.NewSkhool { // NM4 - FutureSkhool too??? May need to group after?? Not sure how this is gonna work.
+	switch cmp {
+	case chunks.SimpleArchive:
 		writer, err = NewArchiveStreamWriter("")
-	} else {
+	case chunks.NoArchive:
 		writer, err = NewCmpChunkTableWriter("")
+	default:
+		return nil, fmt.Errorf("invalid archive level: %s", cmp)
 	}
 	if err != nil {
 		return nil, err

--- a/go/store/nbs/generational_chunk_store.go
+++ b/go/store/nbs/generational_chunk_store.go
@@ -530,7 +530,7 @@ func (gcs *GenerationalNBS) EndGC(mode chunks.GCMode) {
 	gcs.newGen.EndGC(mode)
 }
 
-func (gcs *GenerationalNBS) MarkAndSweepChunks(ctx context.Context, getAddrs chunks.GetAddrsCurry, filter chunks.HasManyFunc, dest chunks.ChunkStore, mode chunks.GCMode, cmp chunks.GCCompression) (chunks.MarkAndSweeper, error) {
+func (gcs *GenerationalNBS) MarkAndSweepChunks(ctx context.Context, getAddrs chunks.GetAddrsCurry, filter chunks.HasManyFunc, dest chunks.ChunkStore, mode chunks.GCMode, cmp chunks.GCArchiveLevel) (chunks.MarkAndSweeper, error) {
 	return markAndSweepChunks(ctx, gcs.newGen, gcs, dest, getAddrs, filter, mode, cmp)
 }
 

--- a/go/store/nbs/generational_chunk_store.go
+++ b/go/store/nbs/generational_chunk_store.go
@@ -530,8 +530,8 @@ func (gcs *GenerationalNBS) EndGC(mode chunks.GCMode) {
 	gcs.newGen.EndGC(mode)
 }
 
-func (gcs *GenerationalNBS) MarkAndSweepChunks(ctx context.Context, getAddrs chunks.GetAddrsCurry, filter chunks.HasManyFunc, dest chunks.ChunkStore, mode chunks.GCMode) (chunks.MarkAndSweeper, error) {
-	return markAndSweepChunks(ctx, gcs.newGen, gcs, dest, getAddrs, filter, mode)
+func (gcs *GenerationalNBS) MarkAndSweepChunks(ctx context.Context, getAddrs chunks.GetAddrsCurry, filter chunks.HasManyFunc, dest chunks.ChunkStore, mode chunks.GCMode, cmp chunks.GCCompression) (chunks.MarkAndSweeper, error) {
+	return markAndSweepChunks(ctx, gcs.newGen, gcs, dest, getAddrs, filter, mode, cmp)
 }
 
 func (gcs *GenerationalNBS) IterateAllChunks(ctx context.Context, cb func(chunk chunks.Chunk)) error {

--- a/go/store/nbs/nbs_metrics_wrapper.go
+++ b/go/store/nbs/nbs_metrics_wrapper.go
@@ -74,7 +74,7 @@ func (nbsMW *NBSMetricWrapper) EndGC(mode chunks.GCMode) {
 	nbsMW.nbs.EndGC(mode)
 }
 
-func (nbsMW *NBSMetricWrapper) MarkAndSweepChunks(ctx context.Context, getAddrs chunks.GetAddrsCurry, filter chunks.HasManyFunc, dest chunks.ChunkStore, mode chunks.GCMode, cmp chunks.GCCompression) (chunks.MarkAndSweeper, error) {
+func (nbsMW *NBSMetricWrapper) MarkAndSweepChunks(ctx context.Context, getAddrs chunks.GetAddrsCurry, filter chunks.HasManyFunc, dest chunks.ChunkStore, mode chunks.GCMode, cmp chunks.GCArchiveLevel) (chunks.MarkAndSweeper, error) {
 	return nbsMW.nbs.MarkAndSweepChunks(ctx, getAddrs, filter, dest, mode, cmp)
 }
 

--- a/go/store/nbs/nbs_metrics_wrapper.go
+++ b/go/store/nbs/nbs_metrics_wrapper.go
@@ -74,8 +74,8 @@ func (nbsMW *NBSMetricWrapper) EndGC(mode chunks.GCMode) {
 	nbsMW.nbs.EndGC(mode)
 }
 
-func (nbsMW *NBSMetricWrapper) MarkAndSweepChunks(ctx context.Context, getAddrs chunks.GetAddrsCurry, filter chunks.HasManyFunc, dest chunks.ChunkStore, mode chunks.GCMode) (chunks.MarkAndSweeper, error) {
-	return nbsMW.nbs.MarkAndSweepChunks(ctx, getAddrs, filter, dest, mode)
+func (nbsMW *NBSMetricWrapper) MarkAndSweepChunks(ctx context.Context, getAddrs chunks.GetAddrsCurry, filter chunks.HasManyFunc, dest chunks.ChunkStore, mode chunks.GCMode, cmp chunks.GCCompression) (chunks.MarkAndSweeper, error) {
+	return nbsMW.nbs.MarkAndSweepChunks(ctx, getAddrs, filter, dest, mode, cmp)
 }
 
 func (nbsMW *NBSMetricWrapper) Count() (uint32, error) {

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -1896,12 +1896,12 @@ func (nbs *NomsBlockStore) beginRead() (endRead func()) {
 	return nil
 }
 
-func (nbs *NomsBlockStore) MarkAndSweepChunks(ctx context.Context, getAddrs chunks.GetAddrsCurry, filter chunks.HasManyFunc, dest chunks.ChunkStore, mode chunks.GCMode, cmp chunks.GCCompression) (chunks.MarkAndSweeper, error) {
+func (nbs *NomsBlockStore) MarkAndSweepChunks(ctx context.Context, getAddrs chunks.GetAddrsCurry, filter chunks.HasManyFunc, dest chunks.ChunkStore, mode chunks.GCMode, cmp chunks.GCArchiveLevel) (chunks.MarkAndSweeper, error) {
 	valctx.ValidateContext(ctx)
 	return markAndSweepChunks(ctx, nbs, nbs, dest, getAddrs, filter, mode, cmp)
 }
 
-func markAndSweepChunks(_ context.Context, nbs *NomsBlockStore, src CompressedChunkStoreForGC, dest chunks.ChunkStore, getAddrs chunks.GetAddrsCurry, filter chunks.HasManyFunc, mode chunks.GCMode, cmp chunks.GCCompression) (chunks.MarkAndSweeper, error) {
+func markAndSweepChunks(_ context.Context, nbs *NomsBlockStore, src CompressedChunkStoreForGC, dest chunks.ChunkStore, getAddrs chunks.GetAddrsCurry, filter chunks.HasManyFunc, mode chunks.GCMode, cmp chunks.GCArchiveLevel) (chunks.MarkAndSweeper, error) {
 	ops := nbs.SupportedOperations()
 	if !ops.CanGC || !ops.CanPrune {
 		return nil, chunks.ErrUnsupportedOperation

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -1896,12 +1896,12 @@ func (nbs *NomsBlockStore) beginRead() (endRead func()) {
 	return nil
 }
 
-func (nbs *NomsBlockStore) MarkAndSweepChunks(ctx context.Context, getAddrs chunks.GetAddrsCurry, filter chunks.HasManyFunc, dest chunks.ChunkStore, mode chunks.GCMode) (chunks.MarkAndSweeper, error) {
+func (nbs *NomsBlockStore) MarkAndSweepChunks(ctx context.Context, getAddrs chunks.GetAddrsCurry, filter chunks.HasManyFunc, dest chunks.ChunkStore, mode chunks.GCMode, cmp chunks.GCCompression) (chunks.MarkAndSweeper, error) {
 	valctx.ValidateContext(ctx)
-	return markAndSweepChunks(ctx, nbs, nbs, dest, getAddrs, filter, mode)
+	return markAndSweepChunks(ctx, nbs, nbs, dest, getAddrs, filter, mode, cmp)
 }
 
-func markAndSweepChunks(ctx context.Context, nbs *NomsBlockStore, src CompressedChunkStoreForGC, dest chunks.ChunkStore, getAddrs chunks.GetAddrsCurry, filter chunks.HasManyFunc, mode chunks.GCMode) (chunks.MarkAndSweeper, error) {
+func markAndSweepChunks(_ context.Context, nbs *NomsBlockStore, src CompressedChunkStoreForGC, dest chunks.ChunkStore, getAddrs chunks.GetAddrsCurry, filter chunks.HasManyFunc, mode chunks.GCMode, cmp chunks.GCCompression) (chunks.MarkAndSweeper, error) {
 	ops := nbs.SupportedOperations()
 	if !ops.CanGC || !ops.CanPrune {
 		return nil, chunks.ErrUnsupportedOperation
@@ -1949,7 +1949,7 @@ func markAndSweepChunks(ctx context.Context, nbs *NomsBlockStore, src Compressed
 		return nil, fmt.Errorf("NBS does not support copying garbage collection")
 	}
 
-	gcc, err := newGarbageCollectionCopier(tfp)
+	gcc, err := newGarbageCollectionCopier(cmp, tfp)
 	if err != nil {
 		return nil, err
 	}

--- a/go/store/nbs/store_test.go
+++ b/go/store/nbs/store_test.go
@@ -339,7 +339,7 @@ func TestNBSCopyGC(t *testing.T) {
 	noopFilter := func(ctx context.Context, hashes hash.HashSet) (hash.HashSet, error) {
 		return hashes, nil
 	}
-	sweeper, err := st.MarkAndSweepChunks(ctx, noopGetAddrs, noopFilter, nil, chunks.GCMode_Full, chunks.OldSkhool)
+	sweeper, err := st.MarkAndSweepChunks(ctx, noopGetAddrs, noopFilter, nil, chunks.GCMode_Full, chunks.NoArchive)
 	require.NoError(t, err)
 	keepersSlice := make([]hash.Hash, 0, len(keepers))
 	for h := range keepers {

--- a/go/store/nbs/store_test.go
+++ b/go/store/nbs/store_test.go
@@ -339,7 +339,7 @@ func TestNBSCopyGC(t *testing.T) {
 	noopFilter := func(ctx context.Context, hashes hash.HashSet) (hash.HashSet, error) {
 		return hashes, nil
 	}
-	sweeper, err := st.MarkAndSweepChunks(ctx, noopGetAddrs, noopFilter, nil, chunks.GCMode_Full)
+	sweeper, err := st.MarkAndSweepChunks(ctx, noopGetAddrs, noopFilter, nil, chunks.GCMode_Full, chunks.OldSkhool)
 	require.NoError(t, err)
 	keepersSlice := make([]hash.Hash, 0, len(keepers))
 	for h := range keepers {

--- a/go/store/nbs/table_persister.go
+++ b/go/store/nbs/table_persister.go
@@ -84,7 +84,7 @@ type tableFilePersister interface {
 }
 
 type movingTableFilePersister interface {
-	TryMoveCmpChunkTableWriter(ctx context.Context, filename string, w *CmpChunkTableWriter) error
+	TryMoveCmpChunkTableWriter(ctx context.Context, filename string, w GenericTableWriter) error
 }
 
 type chunkSourcesByDescendingDataSize struct {

--- a/go/store/types/value_store.go
+++ b/go/store/types/value_store.go
@@ -547,7 +547,7 @@ type GCSafepointController interface {
 }
 
 // GC traverses the ValueStore from the root and removes unreferenced chunks from the ChunkStore
-func (lvs *ValueStore) GC(ctx context.Context, mode GCMode, cmp chunks.GCCompression, oldGenRefs, newGenRefs hash.HashSet, safepoint GCSafepointController) error {
+func (lvs *ValueStore) GC(ctx context.Context, mode GCMode, cmp chunks.GCArchiveLevel, oldGenRefs, newGenRefs hash.HashSet, safepoint GCSafepointController) error {
 	lvs.versOnce.Do(lvs.expectVersion)
 
 	lvs.transitionToOldGenGC()
@@ -718,7 +718,7 @@ func (lvs *ValueStore) gc(ctx context.Context,
 	toVisit hash.HashSet,
 	hashFilter chunks.HasManyFunc,
 	chksMode chunks.GCMode,
-	cmp chunks.GCCompression,
+	cmp chunks.GCArchiveLevel,
 	src, dest chunks.ChunkStoreGarbageCollector,
 	safepointController GCSafepointController,
 	finalize func() hash.HashSet) (chunks.GCFinalizer, error) {

--- a/go/store/types/value_store.go
+++ b/go/store/types/value_store.go
@@ -547,7 +547,7 @@ type GCSafepointController interface {
 }
 
 // GC traverses the ValueStore from the root and removes unreferenced chunks from the ChunkStore
-func (lvs *ValueStore) GC(ctx context.Context, mode GCMode, oldGenRefs, newGenRefs hash.HashSet, safepoint GCSafepointController) error {
+func (lvs *ValueStore) GC(ctx context.Context, mode GCMode, cmp chunks.GCCompression, oldGenRefs, newGenRefs hash.HashSet, safepoint GCSafepointController) error {
 	lvs.versOnce.Do(lvs.expectVersion)
 
 	lvs.transitionToOldGenGC()
@@ -605,7 +605,7 @@ func (lvs *ValueStore) GC(ctx context.Context, mode GCMode, oldGenRefs, newGenRe
 			newGenRefs.Insert(root)
 
 			var oldGenFinalizer, newGenFinalizer chunks.GCFinalizer
-			oldGenFinalizer, err = lvs.gc(ctx, oldGenRefs, oldGenHasMany, chksMode, collector, oldGen, nil, func() hash.HashSet {
+			oldGenFinalizer, err = lvs.gc(ctx, oldGenRefs, oldGenHasMany, chksMode, cmp, collector, oldGen, nil, func() hash.HashSet {
 				n := lvs.transitionToNewGenGC()
 				newGenRefs.InsertAll(n)
 				return make(hash.HashSet)
@@ -626,7 +626,7 @@ func (lvs *ValueStore) GC(ctx context.Context, mode GCMode, oldGenRefs, newGenRe
 				oldGenHasMany = newFileHasMany
 			}
 
-			newGenFinalizer, err = lvs.gc(ctx, newGenRefs, oldGenHasMany, chksMode, collector, newGen, safepoint, lvs.transitionToFinalizingGC)
+			newGenFinalizer, err = lvs.gc(ctx, newGenRefs, oldGenHasMany, chksMode, cmp, collector, newGen, safepoint, lvs.transitionToFinalizingGC)
 			if err != nil {
 				return err
 			}
@@ -686,7 +686,7 @@ func (lvs *ValueStore) GC(ctx context.Context, mode GCMode, oldGenRefs, newGenRe
 			newGenRefs.Insert(root)
 
 			var finalizer chunks.GCFinalizer
-			finalizer, err = lvs.gc(ctx, newGenRefs, unfilteredHashFunc, chunks.GCMode_Full, collector, collector, safepoint, lvs.transitionToFinalizingGC)
+			finalizer, err = lvs.gc(ctx, newGenRefs, unfilteredHashFunc, chunks.GCMode_Full, cmp, collector, collector, safepoint, lvs.transitionToFinalizingGC)
 			if err != nil {
 				return err
 			}
@@ -718,10 +718,11 @@ func (lvs *ValueStore) gc(ctx context.Context,
 	toVisit hash.HashSet,
 	hashFilter chunks.HasManyFunc,
 	chksMode chunks.GCMode,
+	cmp chunks.GCCompression,
 	src, dest chunks.ChunkStoreGarbageCollector,
 	safepointController GCSafepointController,
 	finalize func() hash.HashSet) (chunks.GCFinalizer, error) {
-	sweeper, err := src.MarkAndSweepChunks(ctx, lvs.getAddrs, hashFilter, dest, chksMode)
+	sweeper, err := src.MarkAndSweepChunks(ctx, lvs.getAddrs, hashFilter, dest, chksMode, cmp)
 	if err != nil {
 		return nil, err
 	}

--- a/go/store/types/value_store_test.go
+++ b/go/store/types/value_store_test.go
@@ -201,7 +201,7 @@ func TestGC(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(v2)
 
-	err = vs.GC(ctx, GCModeDefault, hash.HashSet{}, hash.HashSet{}, purgingSafepointController{vs})
+	err = vs.GC(ctx, GCModeDefault, chunks.OldSkhool, hash.HashSet{}, hash.HashSet{}, purgingSafepointController{vs})
 	require.NoError(t, err)
 
 	v1, err = vs.ReadValue(ctx, h1) // non-nil

--- a/go/store/types/value_store_test.go
+++ b/go/store/types/value_store_test.go
@@ -201,7 +201,7 @@ func TestGC(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(v2)
 
-	err = vs.GC(ctx, GCModeDefault, chunks.OldSkhool, hash.HashSet{}, hash.HashSet{}, purgingSafepointController{vs})
+	err = vs.GC(ctx, GCModeDefault, chunks.NoArchive, hash.HashSet{}, hash.HashSet{}, purgingSafepointController{vs})
 	require.NoError(t, err)
 
 	v1, err = vs.ReadValue(ctx, h1) // non-nil

--- a/integration-tests/bats/garbage_collection.bats
+++ b/integration-tests/bats/garbage_collection.bats
@@ -586,3 +586,30 @@ SQL
         false
     fi
 }
+
+@test "garbage_collection: dolt gc --archive-level not 0" {
+    dolt gc --archive-level 1
+    run dolt admin storage list
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Archive Metadata" ]] || false
+
+    run dolt gc --archive-level 2
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "invalid value for archive-level: 2" ]] || false
+
+    run dolt gc --archive-level -1
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "invalid value for archive-level: -1" ]] || false ]]
+}
+
+@test "garbage_collection: dolt gc --archive-level 0" {
+    dolt gc --archive-level 0
+    run dolt admin storage list
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "Archive Metadata" ]] || false
+}
+
+
+
+
+

--- a/integration-tests/bats/garbage_collection.bats
+++ b/integration-tests/bats/garbage_collection.bats
@@ -599,7 +599,7 @@ SQL
 
     run dolt gc --archive-level -1
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "invalid value for archive-level: -1" ]] || false ]]
+    [[ "$output" =~ "invalid value for archive-level: -1" ]] || false
 }
 
 @test "garbage_collection: dolt gc --archive-level 0" {


### PR DESCRIPTION
Enable the GC operation to output archive format storage files. This is exposed as the `--archive-level` argument in both the server config and as a `dolt_gc()` option.