### PR TITLE
Consistently use pointer receiver for ByteArray

### DIFF
--- a/go/store/val/value_store.go
+++ b/go/store/val/value_store.go
@@ -185,7 +185,7 @@ func (b *ByteArray) UnwrapAny(ctx context.Context) (interface{}, error) {
 }
 
 // Unwrap implements sql.BytesWrapper
-func (b ByteArray) Unwrap(ctx context.Context) ([]byte, error) {
+func (b *ByteArray) Unwrap(ctx context.Context) ([]byte, error) {
 	return b.GetBytes(ctx)
 }
 


### PR DESCRIPTION
Similar to https://github.com/dolthub/dolt/pull/9100

For structs that are exclusively used in interfaces, there's no reason to not use pointer receivers instead of value receivers. Using value receivers can cause the struct to be copied every time the method is invoked.

Pointer receivers are also more correct here: copying the struct means that changes to the ImmutableValue field (such as setting its Buf field in ImmutableValue.GetBytes) won't be saved when the method exits, defeating the caching of values loaded from storage.
