### PR TITLE
Minor changes to support `SET DEFAULT` FK referential action

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/creasty/defaults v1.6.0
 	github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-mysql-server v0.19.1-0.20250417175424-f6c04d7aec8d
+	github.com/dolthub/go-mysql-server v0.19.1-0.20250418172107-a3bedc3d39a5
 	github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63
 	github.com/esote/minmaxheap v1.0.0
 	github.com/goccy/go-json v0.10.2

--- a/go/go.sum
+++ b/go/go.sum
@@ -223,6 +223,8 @@ github.com/dolthub/go-icu-regex v0.0.0-20250327004329-6799764f2dad h1:66ZPawHszN
 github.com/dolthub/go-icu-regex v0.0.0-20250327004329-6799764f2dad/go.mod h1:ylU4XjUpsMcvl/BKeRRMXSH7e7WBrPXdSLvnRJYrxEA=
 github.com/dolthub/go-mysql-server v0.19.1-0.20250417175424-f6c04d7aec8d h1:Dhyd5oDq+4enyCdyyqPEr+hKNZAZJcF3ZqJ0Wn5yc4s=
 github.com/dolthub/go-mysql-server v0.19.1-0.20250417175424-f6c04d7aec8d/go.mod h1:bOB8AJAqzKtYw/xDA9UININeFU1Il4eYEqSP3lZOqIA=
+github.com/dolthub/go-mysql-server v0.19.1-0.20250418172107-a3bedc3d39a5 h1:+gjTnEGw5zBCd79HXU+lLMlAsPV5vJu+e4BMbAQqTQY=
+github.com/dolthub/go-mysql-server v0.19.1-0.20250418172107-a3bedc3d39a5/go.mod h1:bOB8AJAqzKtYw/xDA9UININeFU1Il4eYEqSP3lZOqIA=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20240701202509-2b217167d718 h1:lT7hE5k+0nkBdj/1UOSFwjWpNxf+LCApbRHgnCA17XE=

--- a/go/libraries/doltcore/doltdb/foreign_key_coll.go
+++ b/go/libraries/doltcore/doltdb/foreign_key_coll.go
@@ -83,6 +83,7 @@ const (
 	ForeignKeyReferentialAction_NoAction
 	ForeignKeyReferentialAction_Restrict
 	ForeignKeyReferentialAction_SetNull
+	ForeignKeyReferentialAction_SetDefault
 )
 
 // ForeignKey is the complete, internal representation of a Foreign Key.
@@ -771,6 +772,8 @@ func (refOp ForeignKeyReferentialAction) String() string {
 		return "RESTRICT"
 	case ForeignKeyReferentialAction_SetNull:
 		return "SET NULL"
+	case ForeignKeyReferentialAction_SetDefault:
+		return "SET DEFAULT"
 	default:
 		return "INVALID"
 	}
@@ -786,6 +789,8 @@ func (refOp ForeignKeyReferentialAction) ReducedString() string {
 		return "CASCADE"
 	case ForeignKeyReferentialAction_SetNull:
 		return "SET NULL"
+	case ForeignKeyReferentialAction_SetDefault:
+		return "SET DEFAULT"
 	default:
 		return "INVALID"
 	}

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -2998,6 +2998,8 @@ func toReferentialAction(opt doltdb.ForeignKeyReferentialAction) sql.ForeignKeyR
 		return sql.ForeignKeyReferentialAction_Restrict
 	case doltdb.ForeignKeyReferentialAction_SetNull:
 		return sql.ForeignKeyReferentialAction_SetNull
+	case doltdb.ForeignKeyReferentialAction_SetDefault:
+		return sql.ForeignKeyReferentialAction_SetDefault
 	default:
 		panic(fmt.Sprintf("Unhandled foreign key referential action %v", opt))
 	}
@@ -3016,7 +3018,7 @@ func ParseFkReferentialAction(refOp sql.ForeignKeyReferentialAction) (doltdb.For
 	case sql.ForeignKeyReferentialAction_SetNull:
 		return doltdb.ForeignKeyReferentialAction_SetNull, nil
 	case sql.ForeignKeyReferentialAction_SetDefault:
-		return doltdb.ForeignKeyReferentialAction_DefaultAction, sql.ErrForeignKeySetDefault.New()
+		return doltdb.ForeignKeyReferentialAction_SetDefault, nil
 	default:
 		return doltdb.ForeignKeyReferentialAction_DefaultAction, fmt.Errorf("unknown foreign key referential action: %v", refOp)
 	}


### PR DESCRIPTION
MySQL parses the `ON UPDATE/DELETE SET DEFAULT` syntax, but does not actually support executing it. These minor changes allow the `SET DEFAULT` referential action to be used from Doltgres, but do not enable it for Dolt, to preserve MySQL compatibility. 

Depends on: https://github.com/dolthub/go-mysql-server/pull/2944