### PR TITLE
fix status command after removing origin from remote

### DIFF
--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -335,8 +335,8 @@ func getRemoteInfo(queryist cli.Queryist, sqlCtx *sql.Context, branchName string
 		if err != nil {
 			return ahead, behind, err
 		}
-		if len(remoteBranches) != 1 {
-			return ahead, behind, fmt.Errorf("could not find remote branch %s", remoteBranchRef)
+		if len(remoteBranches) == 0 {
+			return ahead, behind, nil
 		}
 		remoteBranchCommit := remoteBranches[0][1].(string)
 

--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -335,7 +335,9 @@ func getRemoteInfo(queryist cli.Queryist, sqlCtx *sql.Context, branchName string
 		if err != nil {
 			return ahead, behind, err
 		}
-		if len(remoteBranches) == 0 {
+		if len(remoteBranches) > 1 {
+			return ahead, behind, fmt.Errorf("runtime error: too many results returned for remote branch %s", remoteBranchRef)
+		} else if len(remoteBranches) == 0 {
 			return ahead, behind, nil
 		}
 		remoteBranchCommit := remoteBranches[0][1].(string)

--- a/integration-tests/bats/status.bats
+++ b/integration-tests/bats/status.bats
@@ -580,3 +580,25 @@ SQL
     [ "$status" -eq 0 ]
     [[ "$output" =~ "modified:         t1" ]] || false
 }
+
+@test "status: after remove remote" {
+    remotesrv --grpc-port 1234 --http-port 1234 --repo-mode &
+    remotesrv_pid=$!
+
+    dolt clone http://localhost:1234/test-org/test-repo repo1
+
+    cd repo1
+
+    run dolt remote -v
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "origin http://localhost:1234/test-org/test-repo" ]] || false
+
+    dolt remote rm origin
+
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "On branch main" ]] || false
+
+    kill "$remotesrv_pid"
+    wait "$remotesrv_pid" || :
+}

--- a/integration-tests/bats/status.bats
+++ b/integration-tests/bats/status.bats
@@ -582,23 +582,25 @@ SQL
 }
 
 @test "status: after remove remote" {
-    remotesrv --grpc-port 1234 --http-port 1234 --repo-mode &
-    remotesrv_pid=$!
-
-    dolt clone http://localhost:1234/test-org/test-repo repo1
+    mkdir remote
+    mkdir repo1
 
     cd repo1
+    dolt init
+    dolt remote add origin file://../remote
+    dolt push origin main
+
+    cd ..
+    dolt clone file://./remote repo2
+    cd repo2
 
     run dolt remote -v
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "origin http://localhost:1234/test-org/test-repo" ]] || false
+    [[ "$output" =~ "origin file:///" ]] || false
 
     dolt remote rm origin
 
     run dolt status
     [ "$status" -eq 0 ]
     [[ "$output" =~ "On branch main" ]] || false
-
-    kill "$remotesrv_pid"
-    wait "$remotesrv_pid" || :
 }


### PR DESCRIPTION
Fix #9130 and  #9069.

```bash
$ dolt clone timsehn/docs
$ cd docs
$ dolt remote -v
origin https://doltremoteapi.dolthub.com/timsehn/docs
$ dolt remote rm origin
$ dolt status
On branch main
Your branch is up to date with 'origin/main'.
nothing to commit, working tree clean
```