### PR TITLE
test for temporary tables in stored procedures

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -7769,4 +7769,36 @@ var DoltTempTableScripts = []queries.ScriptTest{
 			},
 		},
 	},
+	{
+		Name:    "temporary tables in stored procedures",
+		Dialect: "mysql",
+		SetUpScript: []string{
+			`
+create procedure proc()
+begin
+  create temporary table tmp (i int primary key);
+  insert into tmp values (1), (2), (3);
+  select * from tmp;
+end;
+`,
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "call proc();",
+				Expected: []sql.Row{
+					{1},
+					{2},
+					{3},
+				},
+			},
+			{
+				Query: "select * from tmp;",
+				Expected: []sql.Row{
+					{1},
+					{2},
+					{3},
+				},
+			},
+		},
+	},
 }


### PR DESCRIPTION
The stored procedures rewrite fixed an issue where temporary tables aren't able to be created and selected within a stored procedure; this PR adds tests to specifically test for that case.

fixes: https://github.com/dolthub/dolt/issues/8762