### PR TITLE
go: sqle/dprocedures: fetch,pull,push: Rebase the remote database before we interact with it.

### DIFF
--- a/go/libraries/doltcore/sqle/dprocedures/dolt_fetch.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_fetch.go
@@ -87,7 +87,7 @@ func doDoltFetch(ctx *sql.Context, args []string) (int, error) {
 
 	err = srcDB.Rebase(ctx)
 	if err != nil {
-		return 1, fmt.Errorf("failed to rebase remote db: %w", err)
+		return 1, fmt.Errorf("failed to read latest version of remote db: %w", err)
 	}
 
 	prune := apr.Contains(cli.PruneFlag)

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_fetch.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_fetch.go
@@ -85,6 +85,11 @@ func doDoltFetch(ctx *sql.Context, args []string) (int, error) {
 		return 1, err
 	}
 
+	err = srcDB.Rebase(ctx)
+	if err != nil {
+		return 1, fmt.Errorf("failed to rebase remote db: %w", err)
+	}
+
 	prune := apr.Contains(cli.PruneFlag)
 	mode := ref.UpdateMode{Force: true, Prune: prune}
 	err = actions.FetchRefSpecs(ctx, dbData, srcDB, refSpecs, defaultRefSpec, &remote, mode, runProgFuncs, stopProgFuncs)

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_pull.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_pull.go
@@ -134,7 +134,7 @@ func doDoltPull(ctx *sql.Context, args []string) (int, int, string, error) {
 
 	err = srcDB.Rebase(ctx)
 	if err != nil {
-		return noConflictsOrViolations, threeWayMerge, "", fmt.Errorf("failed to rebase remote db: %w", err)
+		return noConflictsOrViolations, threeWayMerge, "", fmt.Errorf("failed to read latest version of remote db: %w", err)
 	}
 
 	ws, err := sess.WorkingSet(ctx, dbName)

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_pull.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_pull.go
@@ -132,6 +132,11 @@ func doDoltPull(ctx *sql.Context, args []string) (int, int, string, error) {
 		return noConflictsOrViolations, threeWayMerge, "", fmt.Errorf("failed to get remote db; %w", err)
 	}
 
+	err = srcDB.Rebase(ctx)
+	if err != nil {
+		return noConflictsOrViolations, threeWayMerge, "", fmt.Errorf("failed to rebase remote db: %w", err)
+	}
+
 	ws, err := sess.WorkingSet(ctx, dbName)
 	if err != nil {
 		return noConflictsOrViolations, threeWayMerge, "", err

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_push.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_push.go
@@ -97,7 +97,7 @@ func doDoltPush(ctx *sql.Context, args []string) (int, string, error) {
 
 	err = remoteDB.Rebase(ctx)
 	if err != nil {
-		return cmdFailure, "", fmt.Errorf("error rebasing remote database %s@%s: %w", remote.Name, remote.Url, err)
+		return cmdFailure, "", fmt.Errorf("failed to read latest version of remote database %s@%s: %w", remote.Name, remote.Url, err)
 	}
 
 	tmpDir, err := dbData.Rsw.TempTableFilesDir()

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_push.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_push.go
@@ -95,6 +95,11 @@ func doDoltPush(ctx *sql.Context, args []string) (int, string, error) {
 		return cmdFailure, "", actions.HandleInitRemoteStorageClientErr(remote.Name, remote.Url, err)
 	}
 
+	err = remoteDB.Rebase(ctx)
+	if err != nil {
+		return cmdFailure, "", fmt.Errorf("error rebasing remote database %s@%s: %w", remote.Name, remote.Url, err)
+	}
+
 	tmpDir, err := dbData.Rsw.TempTableFilesDir()
 	if err != nil {
 		return cmdFailure, "", err

--- a/integration-tests/go-sql-server-driver/auto_gc_test.go
+++ b/integration-tests/go-sql-server-driver/auto_gc_test.go
@@ -86,11 +86,11 @@ type AutoGCTest struct {
 	StandbyServer *driver.SqlServer
 	StandbyDB     *sql.DB
 
-	Ports *DynamicPorts
+	Ports *DynamicResources
 }
 
 func (s *AutoGCTest) Setup(ctx context.Context, t *testing.T) {
-	s.Ports = &DynamicPorts{
+	s.Ports = &DynamicResources{
 		global: &GlobalPorts,
 		t:      t,
 	}

--- a/integration-tests/go-sql-server-driver/concurrent_gc_test.go
+++ b/integration-tests/go-sql-server-driver/concurrent_gc_test.go
@@ -256,7 +256,7 @@ func (gct gcTest) finalize(t *testing.T, ctx context.Context, db *sql.DB) {
 }
 
 func (gct gcTest) run(t *testing.T) {
-	var ports DynamicPorts
+	var ports DynamicResources
 	ports.global = &GlobalPorts
 	ports.t = t
 	u, err := driver.NewDoltUser()

--- a/integration-tests/go-sql-server-driver/gc_oldgen_conjoin_test.go
+++ b/integration-tests/go-sql-server-driver/gc_oldgen_conjoin_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestGCConjoinsOldgen(t *testing.T) {
 	t.Parallel()
-	var ports DynamicPorts
+	var ports DynamicResources
 	ports.global = &GlobalPorts
 	ports.t = t
 	u, err := driver.NewDoltUser()

--- a/integration-tests/go-sql-server-driver/sql_server_commit_concurrency_test.go
+++ b/integration-tests/go-sql-server-driver/sql_server_commit_concurrency_test.go
@@ -53,7 +53,7 @@ func testSQLTransactionWithAmendCommit(t *testing.T) {
 		Args:        []string{"--port", `{{get_port "server"}}`},
 		DynamicPort: "server",
 	}
-	var ports DynamicPorts
+	var ports DynamicResources
 	ports.global = &GlobalPorts
 	ports.t = t
 	server := MakeServer(t, repo, srvSettings, &ports)
@@ -141,7 +141,7 @@ func testSQLRacingAmend(t *testing.T) {
 		Args:        []string{"--port", `{{get_port "server"}}`},
 		DynamicPort: "server",
 	}
-	var ports DynamicPorts
+	var ports DynamicResources
 	ports.global = &GlobalPorts
 	ports.t = t
 	server := MakeServer(t, repo, srvSettings, &ports)

--- a/integration-tests/go-sql-server-driver/sql_server_max_conns_test.go
+++ b/integration-tests/go-sql-server-driver/sql_server_max_conns_test.go
@@ -59,7 +59,7 @@ func setupMaxConnsTest(t *testing.T, ctx context.Context, args ...string) (*sql.
 		Args:        args,
 		DynamicPort: "server",
 	}
-	var ports DynamicPorts
+	var ports DynamicResources
 	ports.global = &GlobalPorts
 	ports.t = t
 	server := MakeServer(t, repo, srvSettings, &ports)

--- a/integration-tests/go-sql-server-driver/sqlserver_info_test.go
+++ b/integration-tests/go-sql-server-driver/sqlserver_info_test.go
@@ -45,7 +45,7 @@ func TestSQLServerInfoFile(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Run("With server running in root", func(t *testing.T) {
-			var ports DynamicPorts
+			var ports DynamicResources
 			ports.global = &GlobalPorts
 			ports.t = t
 			RunServerUntilEndOfTest(t, rs, &driver.Server{
@@ -118,7 +118,7 @@ func TestSQLServerInfoFile(t *testing.T) {
 			require.ErrorIs(t, err, fs.ErrNotExist)
 		})
 		t.Run("With server running in db_one", func(t *testing.T) {
-			var ports DynamicPorts
+			var ports DynamicResources
 			ports.global = &GlobalPorts
 			ports.t = t
 			RunServerUntilEndOfTest(t, dbOne, &driver.Server{
@@ -161,7 +161,7 @@ func TestSQLServerInfoFile(t *testing.T) {
 			})
 		})
 		t.Run("Given a running dolt sql process in root", func(t *testing.T) {
-			var ports DynamicPorts
+			var ports DynamicResources
 			ports.global = &GlobalPorts
 			ports.t = t
 			RunDoltSQLUntilEndOfTest(t, rs)
@@ -199,7 +199,7 @@ func TestSQLServerInfoFile(t *testing.T) {
 			})
 		})
 		t.Run("Given a running dolt sql process in db_one", func(t *testing.T) {
-			var ports DynamicPorts
+			var ports DynamicResources
 			ports.global = &GlobalPorts
 			ports.t = t
 			RunDoltSQLUntilEndOfTest(t, dbOne)
@@ -248,7 +248,7 @@ func TestSQLServerInfoFile(t *testing.T) {
 			})
 		})
 		t.Run("With stale sql-server.info file in root", func(t *testing.T) {
-			var ports DynamicPorts
+			var ports DynamicResources
 			ports.global = &GlobalPorts
 			ports.t = t
 			Setup := func(t *testing.T) {
@@ -290,7 +290,7 @@ func TestSQLServerInfoFile(t *testing.T) {
 			})
 		})
 		t.Run("With malformed sql-server.info file in root", func(t *testing.T) {
-			var ports DynamicPorts
+			var ports DynamicResources
 			ports.global = &GlobalPorts
 			ports.t = t
 			Setup := func(t *testing.T) {
@@ -366,7 +366,7 @@ func TestSQLServerInfoFile(t *testing.T) {
 		// started, they can both run against it. Only one of their
 		// credential files will win the write.
 		t.Run("Can Run Two Servers At Once", func(t *testing.T) {
-			var ports DynamicPorts
+			var ports DynamicResources
 			ports.global = &GlobalPorts
 			ports.t = t
 			RunServerUntilEndOfTest(t, rs, &driver.Server{
@@ -419,7 +419,7 @@ func RunDoltSQLUntilEndOfTest(t *testing.T, dc driver.DoltCmdable) {
 // for doing things like making connections to it, this is only useful for
 // for asserting the behavior of other dolt commands which interact with the
 // server.
-func RunServerUntilEndOfTest(t *testing.T, dc driver.DoltCmdable, s *driver.Server, ports *DynamicPorts) {
+func RunServerUntilEndOfTest(t *testing.T, dc driver.DoltCmdable, s *driver.Server, ports *DynamicResources) {
 	server := MakeServer(t, dc, s, ports)
 	require.NotNil(t, server)
 	db, err := server.DB(driver.Connection{User: "root"})

--- a/integration-tests/go-sql-server-driver/tests/sql-server-orig.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-orig.yaml
@@ -416,3 +416,57 @@ tests:
     queries:
     - exec: "USE mydb"
     - exec: "CALL dolt_gc()"
+# Create three servers, all with a clone of a the same file remote.
+# Server #2 creates a table and pushes it.
+# Server #3 pulls the remote, inserts some rows into the table and pushes it.
+# Server #1 pulls the remote and asserts that the inserted rows are there.
+#
+# https://github.com/dolthub/dolt/issues/9164
+- name: file remotes update appropriately
+  multi_repos:
+  - name: server1
+    server:
+      args: ["--port", "{{get_port \"server1\"}}"]
+      dynamic_port: server1
+  - name: server2
+    server:
+      args: ["--port", "{{get_port \"server2\"}}"]
+      dynamic_port: server2
+  - name: server3
+    server:
+      args: ["--port", "{{get_port \"server3\"}}"]
+      dynamic_port: server3
+  connections:
+  - on: server1
+    queries:
+    - exec: "CREATE DATABASE mydb"
+    - exec: "USE mydb"
+    - exec: "CALL dolt_remote('add', 'origin', 'file://{{get_tempdir \"remote_storage\"}}')"
+    - exec: "CALL dolt_push('origin', 'main:main')"
+  - on: server2
+    queries:
+    - exec: "CALL dolt_clone('file://{{get_tempdir \"remote_storage\"}}', 'mydb')"
+  - on: server3
+    queries:
+    - exec: "CALL dolt_clone('file://{{get_tempdir \"remote_storage\"}}', 'mydb')"
+  - on: server2
+    queries:
+    - exec: "USE mydb"
+    - exec: "CREATE TABLE test (id INT PRIMARY KEY)"
+    - exec: "CALL dolt_commit('-Am', 'create test table')"
+    - exec: "CALL dolt_push('origin', 'main')"
+  - on: server3
+    queries:
+    - exec: "USE mydb"
+    - exec: "CALL dolt_pull('origin', 'main')"
+    - exec: "INSERT INTO test VALUES (1), (2), (47)"
+    - exec: "CALL dolt_commit('-am', 'Insert some initial values.')"
+    - exec: "CALL dolt_push('origin', 'main')"
+  - on: server1
+    queries:
+    - exec: "USE mydb"
+    - exec: "CALL dolt_pull('origin', 'main')"
+    - query: "SELECT * FROM test ORDER BY id ASC"
+      result:
+        columns: ["id"]
+        rows: [["1"], ["2"], ["47"]]

--- a/integration-tests/go-sql-server-driver/valctx_enabled_test.go
+++ b/integration-tests/go-sql-server-driver/valctx_enabled_test.go
@@ -27,7 +27,7 @@ import (
 func TestValctxEnabled(t *testing.T) {
 	t.Parallel()
 
-	var ports DynamicPorts
+	var ports DynamicResources
 	ports.global = &GlobalPorts
 	ports.t = t
 	u, err := driver.NewDoltUser()


### PR DESCRIPTION
We need to rebase a remote in order to see its latest changes.

Fixes #9164.