### PR TITLE
[no-release-notes] map error race

### DIFF
--- a/go/libraries/doltcore/sqle/statspro/worker.go
+++ b/go/libraries/doltcore/sqle/statspro/worker.go
@@ -452,7 +452,7 @@ func (sc *StatsController) updateTable(ctx *sql.Context, newStats *rootStats, ta
 
 			_, template, err = sc.getTemplate(ctx, sqlTable, sqlIdx)
 			if err != nil {
-				return fmt.Errorf("stats collection failed to generate a statistic template: %s.%s.%s:%T; %s", sqlDb.RevisionQualifiedName(), tableName, sqlIdx, sqlIdx, err.Error())
+				return errors.Join(err, fmt.Errorf("stats collection failed to generate a statistic template: %s.%s.%s:%T; %s", sqlDb.RevisionQualifiedName(), tableName, sqlIdx, sqlIdx))
 			}
 			return nil
 		}); err != nil {


### PR DESCRIPTION
Address race suspect. It is difficult to test, but this line has a race reading/writing a map type. If `err` the problem joining the errors should be safer.