### PR TITLE
Fix --branch global option always flagging error "no valid repository"

### DIFF
--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -136,9 +136,9 @@ func (cmd StatusCmd) Exec(ctx context.Context, commandStr string, args []string,
 func createPrintData(err error, queryist cli.Queryist, sqlCtx *sql.Context, showIgnoredTables bool, cliCtx cli.CliContext) (*printData, error) {
 	var branchName string
 
-	if brName, hasBranch := cliCtx.GlobalArgs().GetValue("branch"); hasBranch {
+	if brName, hasBranch := cliCtx.GlobalArgs().GetValue(cli.BranchParam); hasBranch {
 		branchName = brName
-	} else if useDb, hasUseDb := cliCtx.GlobalArgs().GetValue("use-db"); hasUseDb {
+	} else if useDb, hasUseDb := cliCtx.GlobalArgs().GetValue(UseDbFlag); hasUseDb {
 		_, branchName = dsess.SplitRevisionDbName(useDb)
 	} else {
 		var err error

--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -17,7 +17,6 @@ package commands
 import (
 	"context"
 	"fmt"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -29,6 +28,7 @@ import (
 	eventsapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 )
 

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -630,14 +630,17 @@ If you're interested in running this command against a remote host, hit us up on
 		}
 	}
 
+	var dbName string
+
 	if hasUseDb {
-		dbName, _ := dsess.SplitRevisionDbName(useDb)
+		dbName, _ = dsess.SplitRevisionDbName(useDb)
 		targetEnv = mrEnv.GetEnv(dbName)
 		if targetEnv == nil {
 			return nil, fmt.Errorf("The provided --use-db %s does not exist.", dbName)
 		}
 	} else {
-		useDb = mrEnv.GetFirstDatabase()
+		dbName = mrEnv.GetFirstDatabase()
+		useDb = dbName
 		if hasBranch {
 			useDb += "/" + useBranch
 		}
@@ -646,7 +649,7 @@ If you're interested in running this command against a remote host, hit us up on
 	// If our targetEnv is still |nil| and we don't have an environment
 	// which we will be using based on |useDb|, then our initialization
 	// here did not find a repository we will be operating against.
-	noValidRepository := targetEnv == nil && (useDb == "" || mrEnv.GetEnv(useDb) == nil)
+	noValidRepository := targetEnv == nil && (useDb == "" || mrEnv.GetEnv(dbName) == nil)
 
 	// Not having a valid repository as we start to execute a CLI command
 	// implementation is allowed for a small number of commands.  We don't

--- a/integration-tests/bats/global-args.bats
+++ b/integration-tests/bats/global-args.bats
@@ -135,3 +135,19 @@ SQL
     [ "$status" -eq 0 ]
     [[ "$output" =~ "\"sqlserver.global.log_bin\":\"1\"" ]] || false
 }
+
+@test "global-args: can use --branch on valid branch" {
+    dolt checkout -b br1
+    run dolt --branch br1 status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "On branch br1" ]] || false
+    [[ "$output" =~ "nothing to commit, working tree clean" ]] || false
+}
+
+
+
+@test "global-args: cannot use --branch on invalid branch" {
+    run dolt --branch invalidBr status
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "The provided --branch invalidBr does not exist" ]] || false
+}

--- a/integration-tests/bats/global-args.bats
+++ b/integration-tests/bats/global-args.bats
@@ -147,7 +147,8 @@ SQL
 
 
 @test "global-args: cannot use --branch on invalid branch" {
+    cd db1
     run dolt --branch invalidBr status
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "Error 1049 (HY000): database not found: db1/invalidBr" ]] || false  #TODO: change this to the correct output
+    [[ "$output" =~ "database not found: db1/invalidBr" ]] || false  #TODO: change this to the correct output
 }

--- a/integration-tests/bats/global-args.bats
+++ b/integration-tests/bats/global-args.bats
@@ -144,8 +144,6 @@ SQL
     [[ "$output" =~ "nothing to commit, working tree clean" ]] || false
 }
 
-
-
 @test "global-args: cannot use --branch on invalid branch" {
     cd db1
     run dolt --branch invalidBr status

--- a/integration-tests/bats/global-args.bats
+++ b/integration-tests/bats/global-args.bats
@@ -149,5 +149,5 @@ SQL
 @test "global-args: cannot use --branch on invalid branch" {
     run dolt --branch invalidBr status
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "The provided --branch invalidBr does not exist" ]] || false
+    [[ "$output" =~ "Error 1049 (HY000): database not found: db1/invalidBr" ]] || false  #TODO: change this to the correct output
 }

--- a/integration-tests/bats/global-args.bats
+++ b/integration-tests/bats/global-args.bats
@@ -137,6 +137,7 @@ SQL
 }
 
 @test "global-args: can use --branch on valid branch" {
+    cd db1
     dolt checkout -b br1
     run dolt --branch br1 status
     [ "$status" -eq 0 ]

--- a/integration-tests/bats/global-args.bats
+++ b/integration-tests/bats/global-args.bats
@@ -150,5 +150,5 @@ SQL
     cd db1
     run dolt --branch invalidBr status
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "database not found: db1/invalidBr" ]] || false  #TODO: change this to the correct output
+    [[ "$output" =~ "database not found: db1/invalidBr" ]] || false
 }

--- a/integration-tests/bats/global-args.bats
+++ b/integration-tests/bats/global-args.bats
@@ -138,10 +138,9 @@ SQL
 
 @test "global-args: can use --branch on valid branch" {
     cd db1
-    dolt checkout -b br1
-    run dolt --branch br1 status
+    run dolt --branch b1 status
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "On branch br1" ]] || false
+    [[ "$output" =~ "On branch b1" ]] || false
     [[ "$output" =~ "nothing to commit, working tree clean" ]] || false
 }
 


### PR DESCRIPTION
Fix issue #6979 

We define ```noValidRepository``` to ensure the command has a valid target, but in that definition we call ```mrEnv.GetEnv()``` on the wrong string, so it's always null with the --branch flag. We should call it just on the name of the database, excluding the branch. 

A string with the database and branch is also needed later, so we need to save both variables.