### PR TITLE
go: statspro: Make it possible for callers of StatsController.Stop() to block on the worker thread shutdown.

### DIFF
--- a/go/libraries/doltcore/sqle/statspro/controller.go
+++ b/go/libraries/doltcore/sqle/statspro/controller.go
@@ -80,6 +80,7 @@ type StatsController struct {
 	sq *jobqueue.SerialQueue
 
 	activeCtxCancel context.CancelFunc
+	workerDoneCh    chan struct {}
 	listeners       []listener
 
 	JobInterval time.Duration

--- a/go/libraries/doltcore/sqle/statspro/controller.go
+++ b/go/libraries/doltcore/sqle/statspro/controller.go
@@ -80,7 +80,7 @@ type StatsController struct {
 	sq *jobqueue.SerialQueue
 
 	activeCtxCancel context.CancelFunc
-	workerDoneCh    chan struct {}
+	workerDoneCh    chan struct{}
 	listeners       []listener
 
 	JobInterval time.Duration

--- a/go/libraries/doltcore/sqle/statspro/listener.go
+++ b/go/libraries/doltcore/sqle/statspro/listener.go
@@ -83,7 +83,7 @@ func (sc *StatsController) addListener(e listenerEvent) (chan listenerEvent, err
 	return l.c, nil
 }
 
-func (sc *StatsController) Stop() chan struct {} {
+func (sc *StatsController) Stop() chan struct{} {
 	// xxx: do not pause |sq|, analyze jobs still need to run
 	sc.mu.Lock()
 	defer sc.mu.Unlock()

--- a/go/libraries/doltcore/sqle/statspro/worker_test.go
+++ b/go/libraries/doltcore/sqle/statspro/worker_test.go
@@ -548,7 +548,7 @@ func TestDropOnlyDb(t *testing.T) {
 	// add first database, switch to prolly?
 	runBlock(t, ctx, sqlEng, "drop database mydb")
 
-	sc.Stop()
+	<-sc.Stop()
 
 	// empty memory KV
 	_, ok = sc.kv.(*memStats)
@@ -688,7 +688,7 @@ func emptySetup(t *testing.T, threads *sql.BackgroundThreads, memOnly bool, gcEn
 	require.NoError(t, executeQuery(ctx, sqlEng, "use mydb"))
 
 	require.NoError(t, executeQuery(ctx, sqlEng, "call dolt_stats_wait()"))
-	sc.Stop()
+	<-sc.Stop()
 
 	var sqlDbs []sqle.Database
 	for _, db := range sqlEng.Analyzer.Catalog.DbProvider.AllDatabases(ctx) {
@@ -915,7 +915,7 @@ func TestStatsGcConcurrency(t *testing.T) {
 		require.NoError(t, executeQuery(ctx, sqlEng, "call dolt_stats_wait()"))
 		require.NoError(t, executeQuery(ctx, sqlEng, "call dolt_stats_gc()"))
 
-		sc.Stop()
+		<-sc.Stop()
 
 		// 101 dbs, 100 with stats (not main)
 		require.Equal(t, iters/2, len(sc.Stats.stats))
@@ -1000,7 +1000,7 @@ func TestStatsBranchConcurrency(t *testing.T) {
 
 		err = executeQuery(ctx, sqlEng, "call dolt_stats_gc()")
 		require.NoError(t, err)
-		sc.Stop()
+		<-sc.Stop()
 
 		// at the end we should still have |iters/2| databases
 		require.Equal(t, iters/2, len(sc.Stats.stats))
@@ -1064,7 +1064,7 @@ func TestStatsCacheGrowth(t *testing.T) {
 		require.NoError(t, executeQuery(ctx, sqlEng, "call dolt_stats_wait()"))
 		require.NoError(t, executeQuery(ctx, sqlEng, "call dolt_stats_gc()"))
 
-		sc.Stop()
+		<-sc.Stop()
 
 		// at the end we should still have |iters/2| databases
 		require.Equal(t, iters, len(sc.Stats.stats))


### PR DESCRIPTION
Add pre-finalize blocking on the worker thread shutdown to dolt_gc safepoint controllers.

Add blocking on the worker thread shutdown to dolt_stats_stop(), so that a caller knows that stats have actually stopped by the time it returns.