### PR TITLE
When a table is deleted on one branch and has its data modified on the other, record this as a schema conflict.

### DIFF
--- a/go/libraries/doltcore/merge/merge.go
+++ b/go/libraries/doltcore/merge/merge.go
@@ -256,7 +256,7 @@ func MergeRoots(
 			// If a Full-Text table was both modified and deleted, then we want to ignore the deletion.
 			// If there's a true conflict, then the parent table will catch the conflict.
 			stats = &MergeStats{Operation: TableModified}
-		} else if errors.Is(ErrTableDeletedAndSchemaModified, err) {
+		} else if errors.Is(ErrTableDeletedAndSchemaModified, err) || errors.Is(ErrTableDeletedAndModified, err) {
 			tblToStats[tblName] = &MergeStats{
 				Operation:       TableModified,
 				SchemaConflicts: 1,

--- a/go/libraries/doltcore/sqle/dtables/schema_conflicts_table.go
+++ b/go/libraries/doltcore/sqle/dtables/schema_conflicts_table.go
@@ -167,6 +167,7 @@ func newSchemaConflict(ctx *sql.Context, table doltdb.TableName, baseRoot doltdb
 
 	baseFKs, _ := fkc.KeysForTable(table)
 
+	var description string
 	var base string
 	if baseSch != nil {
 		var err error
@@ -187,6 +188,12 @@ func newSchemaConflict(ctx *sql.Context, table doltdb.TableName, baseRoot doltdb
 		}
 	} else {
 		ours = "<deleted>"
+		if schema.SchemasAreEqual(baseSch, c.FromSch) {
+			// If the schemas are equal, then this conflict represents a dropped table conflicting with a data conflict.
+			description = "cannot merge a table deletion with data modification"
+		} else {
+			description = "cannot merge a table deletion with schema modification"
+		}
 	}
 
 	var theirs string
@@ -198,6 +205,12 @@ func newSchemaConflict(ctx *sql.Context, table doltdb.TableName, baseRoot doltdb
 		}
 	} else {
 		theirs = "<deleted>"
+		if schema.SchemasAreEqual(baseSch, c.ToSch) {
+			// If the schemas are equal, then this conflict represents a dropped table conflicting with a data conflict.
+			description = "cannot merge a table deletion with data modification"
+		} else {
+			description = "cannot merge a table deletion with schema modification"
+		}
 	}
 
 	if c.ToSch == nil || c.FromSch == nil {
@@ -206,7 +219,7 @@ func newSchemaConflict(ctx *sql.Context, table doltdb.TableName, baseRoot doltdb
 			baseSch:     base,
 			ourSch:      ours,
 			theirSch:    theirs,
-			description: "cannot merge a table deletion with schema modification",
+			description: description,
 		}, nil
 	}
 

--- a/integration-tests/bats/merge.bats
+++ b/integration-tests/bats/merge.bats
@@ -751,7 +751,19 @@ SQL
     run dolt merge feature-branch
 
     log_status_eq 1
-    [[ "$output" =~ "conflict: table with same name deleted and modified" ]] || false
+    [[ "$output" =~ "CONFLICT (schema): Merge conflict in test" ]] || false
+
+    run dolt conflicts cat .
+    [[ "$output" =~ "+------------+-------------------------------------------------------------------+-------------------------------------------------------------------+------------------------------------------------------+" ]] || false
+    [[ "$output" =~ "| our_schema | their_schema                                                      | base_schema                                                       | description                                          |" ]] || false
+    [[ "$output" =~ "+------------+-------------------------------------------------------------------+-------------------------------------------------------------------+------------------------------------------------------+" ]] || false
+    [[ "$output" =~ '| <deleted>  | CREATE TABLE `test2` (                                            | CREATE TABLE `test2` (                                            | cannot merge a table deletion with data modification |' ]] || false
+    [[ "$output" =~ '|            |   `pk` int NOT NULL,                                              |   `pk` int NOT NULL,                                              |                                                      |' ]] || false
+    [[ "$output" =~ '|            |   `c1` int,                                                       |   `c1` int,                                                       |                                                      |' ]] || false
+    [[ "$output" =~ '|            |   PRIMARY KEY (`pk`)                                              |   PRIMARY KEY (`pk`)                                              |                                                      |' ]] || false
+    [[ "$output" =~ '|            | ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin; | ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin; |                                                      |' ]] || false
+    [[ "$output" =~ "+------------+-------------------------------------------------------------------+-------------------------------------------------------------------+------------------------------------------------------+" ]] || false
+
 }
 
 @test "merge: merge a branch that edits the schema of a deleted table" {
@@ -812,7 +824,20 @@ SQL
     run dolt merge feature-branch
 
     log_status_eq 1
-    [[ "$output" =~ "conflict: table with same name deleted and modified" ]] || false
+    [[ "$output" =~ "CONFLICT (schema): Merge conflict in test" ]] || false
+
+    run dolt conflicts cat .
+    echo "$output"
+    [[ "$output" =~ "+-------------------------------------------------------------------+--------------+-------------------------------------------------------------------+------------------------------------------------------+" ]] || false
+    [[ "$output" =~ "| our_schema                                                        | their_schema | base_schema                                                       | description                                          |" ]] || false
+    [[ "$output" =~ "+-------------------------------------------------------------------+--------------+-------------------------------------------------------------------+------------------------------------------------------+" ]] || false
+    [[ "$output" =~ '| CREATE TABLE `test2` (                                            | <deleted>    | CREATE TABLE `test2` (                                            | cannot merge a table deletion with data modification |' ]] || false
+    [[ "$output" =~ '|   `pk` int NOT NULL,                                              |              |   `pk` int NOT NULL,                                              |                                                      |' ]] || false
+    [[ "$output" =~ '|   `c1` int,                                                       |              |   `c1` int,                                                       |                                                      |' ]] || false
+    [[ "$output" =~ '|   PRIMARY KEY (`pk`)                                              |              |   PRIMARY KEY (`pk`)                                              |                                                      |' ]] || false
+    [[ "$output" =~ '| ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin; |              | ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin; |                                                      |' ]] || false
+    [[ "$output" =~ "+-------------------------------------------------------------------+--------------+-------------------------------------------------------------------+------------------------------------------------------+" ]] || false
+
 }
 
 @test "merge: merge a branch that deletes a schema-edited table" {
@@ -1076,7 +1101,17 @@ SQL
 
     run dolt merge merge_branch
     log_status_eq 1
-    [[ "$output" =~ "conflict: table with same name deleted and modified" ]] || false
+    run dolt conflicts cat .
+    [[ "$output" =~ "+------------+-------------------------------------------------------------------+-------------------------------------------------------------------+------------------------------------------------------+" ]] || false
+    [[ "$output" =~ "| our_schema | their_schema                                                      | base_schema                                                       | description                                          |" ]] || false
+    [[ "$output" =~ "+------------+-------------------------------------------------------------------+-------------------------------------------------------------------+------------------------------------------------------+" ]] || false
+    [[ "$output" =~ '| <deleted>  | CREATE TABLE `test1` (                                            | CREATE TABLE `test1` (                                            | cannot merge a table deletion with data modification |' ]] || false
+    [[ "$output" =~ '|            |   `pk` int NOT NULL,                                              |   `pk` int NOT NULL,                                              |                                                      |' ]] || false
+    [[ "$output" =~ '|            |   `c1` int,                                                       |   `c1` int,                                                       |                                                      |' ]] || false
+    [[ "$output" =~ '|            |   PRIMARY KEY (`pk`)                                              |   PRIMARY KEY (`pk`)                                              |                                                      |' ]] || false
+    [[ "$output" =~ '|            | ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin; | ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin; |                                                      |' ]] || false
+    [[ "$output" =~ "+------------+-------------------------------------------------------------------+-------------------------------------------------------------------+------------------------------------------------------+" ]] || false
+
 }
 
 @test "merge: ourRoot renames, theirRoot modifies the schema" {
@@ -1119,7 +1154,7 @@ SQL
 
     run dolt merge merge_branch
     log_status_eq 1
-    [[ "$output" =~ "conflict: table with same name deleted and modified" ]] || false
+    [[ "$output" =~ "cannot create column pk on table new_name, the tag 9571 was already used in table test1" ]] || false
 }
 
 @test "merge: ourRoot modifies the schema, theirRoot renames" {


### PR DESCRIPTION
Currently, attempting to merge when a table has been drop on one branch and had its data modified on the other produces an immediate error that aborts the merge. This error does not necessarily have enough context to determine the affected table, which makes resolving the merge difficult.

Given that we already handle a simultaneous drop + *schema* modification (by treating it as a schema conflict), we should be able to handle the simpler case of data modifications as well.

Since dropping a table is technically a schema change, this should now get reported as a schema conflict, and pause the merge, allowing the user to query `dolt_schema_conflicts` for more information.

I'm not thrilled about the behavioral change observed in the BATS test "merge: ourRoot renames, theirRoot modifies the schema".

What's happening there is that a renamed table is seen as a drop + a create. So the merge code sees a create with no conflicts, and attempts to add it to the same root as the original table (which is now in a conflict state.) Since both tables contain duplicate tags, this causes an error. This probably isn't what we want to happen, and we should figure out the intended behavior before merging this PR.