### PR TITLE
feat(import,csv,psv): Add support for importing CSV and PSV files without header rows

### DIFF
--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -315,6 +315,12 @@ func validateImportArgs(apr *argparser.ArgParseResults) errhand.VerboseError {
 		return errhand.BuildDError("fatal: " + schemaParam + " is not supported for update or replace operations").Build()
 	}
 
+	if apr.Contains(createParam) && apr.NArg() <= 1 {
+		if !apr.Contains(schemaParam) {
+			return errhand.BuildDError("fatal: when importing from stdin with --create-table, you must provide a schema file with --schema").Build()
+		}
+	}
+
 	if apr.Contains(allTextParam) && !apr.Contains(createParam) {
 		return errhand.BuildDError("fatal: --%s is only supported for create operations", allTextParam).Build()
 	}

--- a/go/libraries/doltcore/mvdata/csv_helper.go
+++ b/go/libraries/doltcore/mvdata/csv_helper.go
@@ -1,0 +1,51 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mvdata
+
+import (
+	"github.com/dolthub/dolt/go/libraries/doltcore/table/untyped/csv"
+)
+
+// CreateCSVInfo creates a CSVInfo object based on the provided options.
+// This is a helper function that extracts and processes CSV-related options
+// from the generic options interface.
+func CreateCSVInfo(opts interface{}, defaultDelim string) *csv.CSVFileInfo {
+	hasHeaderLine := true
+	var columns []string
+	delim := defaultDelim
+
+	if opts != nil {
+		csvOpts, _ := opts.(CsvOptions)
+
+		if len(csvOpts.Delim) != 0 {
+			delim = csvOpts.Delim
+		}
+
+		if csvOpts.NoHeader {
+			hasHeaderLine = false
+		}
+
+		if len(csvOpts.Columns) > 0 {
+			columns = csvOpts.Columns
+		}
+	}
+
+	csvInfo := csv.NewCSVInfo().SetDelim(delim).SetHasHeaderLine(hasHeaderLine)
+	if len(columns) > 0 {
+		csvInfo = csvInfo.SetColumns(columns)
+	}
+
+	return csvInfo
+}

--- a/go/libraries/doltcore/mvdata/data_mover.go
+++ b/go/libraries/doltcore/mvdata/data_mover.go
@@ -33,7 +33,9 @@ import (
 )
 
 type CsvOptions struct {
-	Delim string
+	Delim    string
+	NoHeader bool
+	Columns  []string
 }
 
 type XlsxOptions struct {

--- a/go/libraries/doltcore/mvdata/file_data_loc.go
+++ b/go/libraries/doltcore/mvdata/file_data_loc.go
@@ -94,22 +94,14 @@ func (dl FileDataLocation) NewReader(ctx context.Context, dEnv *env.DoltEnv, opt
 
 	switch dl.Format {
 	case CsvFile:
-		delim := ","
-
-		if opts != nil {
-			csvOpts, _ := opts.(CsvOptions)
-
-			if len(csvOpts.Delim) != 0 {
-				delim = csvOpts.Delim
-			}
-		}
-
-		rd, err := csv.OpenCSVReader(root.VRW().Format(), dl.Path, fs, csv.NewCSVInfo().SetDelim(delim))
+		csvInfo := CreateCSVInfo(opts, ",")
+		rd, err := csv.OpenCSVReader(root.VRW().Format(), dl.Path, fs, csvInfo)
 
 		return rd, false, err
 
 	case PsvFile:
-		rd, err := csv.OpenCSVReader(root.VRW().Format(), dl.Path, fs, csv.NewCSVInfo().SetDelim("|"))
+		csvInfo := CreateCSVInfo(opts, "|")
+		rd, err := csv.OpenCSVReader(root.VRW().Format(), dl.Path, fs, csvInfo)
 		return rd, false, err
 
 	case XlsxFile:

--- a/go/libraries/doltcore/mvdata/stream_data_loc.go
+++ b/go/libraries/doltcore/mvdata/stream_data_loc.go
@@ -56,22 +56,14 @@ func (dl StreamDataLocation) NewReader(ctx context.Context, dEnv *env.DoltEnv, o
 
 	switch dl.Format {
 	case CsvFile:
-		delim := ","
-
-		if opts != nil {
-			csvOpts, _ := opts.(CsvOptions)
-
-			if len(csvOpts.Delim) != 0 {
-				delim = csvOpts.Delim
-			}
-		}
-
-		rd, err := csv.NewCSVReader(root.VRW().Format(), io.NopCloser(dl.Reader), csv.NewCSVInfo().SetDelim(delim))
+		csvInfo := CreateCSVInfo(opts, ",")
+		rd, err := csv.NewCSVReader(root.VRW().Format(), io.NopCloser(dl.Reader), csvInfo)
 
 		return rd, false, err
 
 	case PsvFile:
-		rd, err := csv.NewCSVReader(root.VRW().Format(), io.NopCloser(dl.Reader), csv.NewCSVInfo().SetDelim("|"))
+		csvInfo := CreateCSVInfo(opts, "|")
+		rd, err := csv.NewCSVReader(root.VRW().Format(), io.NopCloser(dl.Reader), csvInfo)
 		return rd, false, err
 	}
 

--- a/integration-tests/bats/helper/local-remote.bash
+++ b/integration-tests/bats/helper/local-remote.bash
@@ -142,6 +142,8 @@ SKIP_SERVER_TESTS=$(cat <<-EOM
 ~archive.bats~
 ~fsck.bats~
 ~createchunk.bats~
+~import-no-header-csv.bats~
+~import-no-header-psv.bats~
 EOM
 )
 

--- a/integration-tests/bats/import-no-header-csv.bats
+++ b/integration-tests/bats/import-no-header-csv.bats
@@ -1,0 +1,165 @@
+#!/usr/bin/env bats
+load $BATS_TEST_DIRNAME/helper/common.bash
+
+setup() {
+    setup_common
+
+    # Create a CSV file with no header row
+    cat <<DELIM > no-header.csv
+1,John,Doe,35,New York
+2,Jane,Smith,28,Los Angeles
+3,Bob,Johnson,42,Chicago
+DELIM
+}
+
+teardown() {
+    teardown_common
+}
+
+@test "import-no-header-csv: import with --no-header and --columns options" {
+    # Test regular import with no header (first row is row of data; not column names)
+    run dolt table import -c --no-header --columns id,first_name,last_name,age,city people no-header.csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Import completed successfully" ]] || false
+
+    # Verify the data was imported correctly, including the first row
+    run dolt sql -q "SELECT COUNT(*) FROM people"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "3" ]] || false
+
+    # Verify that column names came from --columns option, not from first row
+    run dolt sql -q "DESCRIBE people"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "id" ]] || false
+    [[ "$output" =~ "first_name" ]] || false
+    [[ "$output" =~ "last_name" ]] || false
+    [[ "$output" =~ "age" ]] || false
+    [[ "$output" =~ "city" ]] || false
+
+    # Verify the first row was imported as data
+    run dolt sql -q "SELECT * FROM people WHERE id = 1"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "John" ]] || false
+    [[ "$output" =~ "Doe" ]] || false
+    [[ "$output" =~ "35" ]] || false
+    [[ "$output" =~ "New York" ]] || false
+}
+
+@test "import-no-header-csv: import with --no-header but without --columns (error case)" {
+    # Should fail with a helpful error message for create
+    run dolt table import -c --no-header people no-header.csv
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "must also specify --columns" ]] || false
+    [[ "$output" =~ "create table" ]] || false
+
+    # Create a table for update test
+    dolt sql -q "CREATE TABLE existing_table (id int, first_name varchar(255), last_name varchar(255), age int, city varchar(255))"
+
+    # Should also fail with update operations but with a different message
+    run dolt table import -u --no-header existing_table no-header.csv
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "must also specify --columns" ]] || false
+    [[ "$output" =~ "existing tables" ]] || false
+}
+
+@test "import-no-header-csv: import with --no-header and --columns for existing table" {
+    # Create a table first
+    dolt sql -q "CREATE TABLE existing_table2 (id int, first_name varchar(255), last_name varchar(255), age int, city varchar(255))"
+
+    # Import into existing table with no-header and columns
+    run dolt table import -u --no-header --columns id,first_name,last_name,age,city existing_table2 no-header.csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Import completed successfully" ]] || false
+
+    # Verify the data was imported correctly
+    run dolt sql -q "SELECT COUNT(*) FROM existing_table2"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "3" ]] || false
+
+    # Verify the first row data is in the table
+    run dolt sql -q "SELECT * FROM existing_table2 WHERE id = 1"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "John" ]] || false
+    [[ "$output" =~ "35" ]] || false
+}
+
+@test "import-no-header-csv: import without --no-header (original behavior)" {
+    # Test regular import without no-header (should use first row as header)
+    run dolt table import -c people no-header.csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Import completed successfully" ]] || false
+
+    # Verify that column names came from first row
+    run dolt sql -q "DESCRIBE people"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "1" ]] || false
+    [[ "$output" =~ "John" ]] || false
+    [[ "$output" =~ "Doe" ]] || false
+    [[ "$output" =~ "35" ]] || false
+
+    # Verify that first row was NOT imported as data
+    run dolt sql -q "SELECT COUNT(*) FROM people"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "2" ]] || false
+}
+
+@test "import-no-header-csv: import with --columns but without --no-header (override column names)" {
+    # Test import with columns option but without no-header flag
+    # This should use the custom column names instead of the names from the first row
+    run dolt table import -c --columns col1,col2,col3,col4,col5 with_columns_table no-header.csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Import completed successfully" ]] || false
+
+    # Verify that column names came from --columns option, not from first row
+    run dolt sql -q "DESCRIBE with_columns_table"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "col1" ]] || false
+    [[ "$output" =~ "col2" ]] || false
+    [[ "$output" =~ "col3" ]] || false
+    [[ "$output" =~ "col4" ]] || false
+    [[ "$output" =~ "col5" ]] || false
+
+    # Verify that first row was NOT imported as data (still treated as header)
+    run dolt sql -q "SELECT COUNT(*) FROM with_columns_table"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "2" ]] || false
+
+    # Verify second row was imported as data
+    run dolt sql -q "SELECT * FROM with_columns_table WHERE col1 = 2"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Jane" ]] || false
+    [[ "$output" =~ "Smith" ]] || false
+    [[ "$output" =~ "28" ]] || false
+    [[ "$output" =~ "Los Angeles" ]] || false
+}
+
+@test "import-no-header-csv: import from stdin with --create-table requires schema file" {
+    # Test importing from stdin with --create-table but without a schema file
+    # This should fail with a specific error message
+    run bash -c "cat no-header.csv | dolt table import -c --no-header --columns id,first_name,last_name,age,city stdin_table"
+    [ "$status" -eq 1 ]
+    
+    # Check for a specific error message about schema
+    [[ "$output" =~ "fatal: when importing from stdin with --create-table, you must provide a schema file with --schema" ]] || false
+    
+    # Verify that trying to use stdin with --create-table and --columns but without --schema also fails
+    run bash -c "cat no-header.csv | dolt table import -c --columns id,first_name,last_name,age,city stdin_table"
+    [ "$status" -eq 1 ]
+    
+    # Check for the same error message
+    [[ "$output" =~ "fatal: when importing from stdin with --create-table, you must provide a schema file with --schema" ]] || false
+    
+    # Show that the workaround is to create the table first, then import with -u
+    # Create the table
+    dolt sql -q "CREATE TABLE stdin_table (id int PRIMARY KEY, first_name text, last_name text, age int, city text)"
+    
+    # Import data with -u instead of -c
+    run bash -c "cat no-header.csv | dolt table import -u --no-header --columns id,first_name,last_name,age,city stdin_table"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Import completed successfully" ]] || false
+    
+    # Verify the import worked
+    run dolt sql -q "SELECT COUNT(*) FROM stdin_table"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "3" ]] || false
+}

--- a/integration-tests/bats/import-no-header.bats
+++ b/integration-tests/bats/import-no-header.bats
@@ -1,0 +1,134 @@
+#!/usr/bin/env bats
+load $BATS_TEST_DIRNAME/helper/common.bash
+
+setup() {
+    setup_common
+
+    # Create a CSV file with no header row
+    cat <<DELIM > no-header.csv
+1,John,Doe,35,New York
+2,Jane,Smith,28,Los Angeles
+3,Bob,Johnson,42,Chicago
+DELIM
+}
+
+teardown() {
+    teardown_common
+}
+
+@test "import-no-header: import with --no-header and --columns options" {
+    # Test regular import with no header (first row is row of data; not column names)
+    run dolt table import -c --no-header --columns id,first_name,last_name,age,city people no-header.csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Import completed successfully" ]] || false
+    
+    # Verify the data was imported correctly, including the first row
+    run dolt sql -q "SELECT COUNT(*) FROM people"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "3" ]] || false
+    
+    # Verify that column names came from --columns option, not from first row
+    run dolt sql -q "DESCRIBE people"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "id" ]] || false
+    [[ "$output" =~ "first_name" ]] || false
+    [[ "$output" =~ "last_name" ]] || false
+    [[ "$output" =~ "age" ]] || false
+    [[ "$output" =~ "city" ]] || false
+    
+    # Verify the first row was imported as data
+    run dolt sql -q "SELECT * FROM people WHERE id = 1"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "John" ]] || false
+    [[ "$output" =~ "Doe" ]] || false
+    [[ "$output" =~ "35" ]] || false
+    [[ "$output" =~ "New York" ]] || false
+}
+
+@test "import-no-header: import with --no-header but without --columns (error case)" {
+    # Should fail with a helpful error message for create
+    run dolt table import -c --no-header people no-header.csv
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "must also specify --columns" ]] || false
+    [[ "$output" =~ "create table" ]] || false
+
+    # Create a table for update test
+    dolt sql -q "CREATE TABLE existing_table (id int, first_name varchar(255), last_name varchar(255), age int, city varchar(255))"
+
+    # Should also fail with update operations but with a different message
+    run dolt table import -u --no-header existing_table no-header.csv
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "must also specify --columns" ]] || false
+    [[ "$output" =~ "existing tables" ]] || false
+}
+
+@test "import-no-header: import with --no-header and --columns for existing table" {
+    # Create a table first
+    dolt sql -q "CREATE TABLE existing_table2 (id int, first_name varchar(255), last_name varchar(255), age int, city varchar(255))"
+
+    # Import into existing table with no-header and columns
+    run dolt table import -u --no-header --columns id,first_name,last_name,age,city existing_table2 no-header.csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Import completed successfully" ]] || false
+
+    # Verify the data was imported correctly
+    run dolt sql -q "SELECT COUNT(*) FROM existing_table2"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "3" ]] || false
+
+    # Verify the first row data is in the table
+    run dolt sql -q "SELECT * FROM existing_table2 WHERE id = 1"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "John" ]] || false
+    [[ "$output" =~ "35" ]] || false
+}
+
+@test "import-no-header: import without --no-header (original behavior)" {
+    # Test regular import without no-header (should use first row as header)
+    run dolt table import -c people no-header.csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Import completed successfully" ]] || false
+    
+    # Verify that column names came from first row
+    run dolt sql -q "DESCRIBE people"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "1" ]] || false
+    [[ "$output" =~ "John" ]] || false
+    [[ "$output" =~ "Doe" ]] || false
+    [[ "$output" =~ "35" ]] || false
+    
+    # Verify that first row was NOT imported as data
+    run dolt sql -q "SELECT COUNT(*) FROM people"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "2" ]] || false
+}
+
+@test "import-no-header: import with --columns but without --no-header (override column names)" {
+    # Test import with columns option but without no-header flag
+    # This should use the custom column names instead of the names from the first row
+    run dolt table import -c --columns col1,col2,col3,col4,col5 with_columns_table no-header.csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Import completed successfully" ]] || false
+    
+    # Verify that column names came from --columns option, not from first row
+    run dolt sql -q "DESCRIBE with_columns_table"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "col1" ]] || false
+    [[ "$output" =~ "col2" ]] || false
+    [[ "$output" =~ "col3" ]] || false
+    [[ "$output" =~ "col4" ]] || false
+    [[ "$output" =~ "col5" ]] || false
+    
+    # Verify that first row was NOT imported as data (still treated as header)
+    run dolt sql -q "SELECT COUNT(*) FROM with_columns_table"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "2" ]] || false
+    
+    # Verify second row was imported as data
+    run dolt sql -q "SELECT * FROM with_columns_table WHERE col1 = 2"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Jane" ]] || false
+    [[ "$output" =~ "Smith" ]] || false
+    [[ "$output" =~ "28" ]] || false
+    [[ "$output" =~ "Los Angeles" ]] || false
+}


### PR DESCRIPTION
## Summary

- Add --no-header flag to treat the first row in CSV/PSV files as data instead of column names
- Add --columns option to specify column names when importing files without headers
- Fix nil pointer panic when importing from stdin with --create-table

In short, this feature makes Dolt more compatible with MySQL/SQLite workflows and provides users with more flexibility when importing data.

## Problem

Previously, Dolt always expected the first row of CSV/PSV files to contain column names. This differs from MySQL and SQLite which support importing files where the first row contains data. Users migrating from these systems or working with headerless data files couldn't import them without modifying their files.

Additionally, when users attempted to import data from stdin using --create-table, they would encounter a nil pointer panic instead of receiving a error message.

## Solution

The implementation adds:
1. A new --no-header flag that treats the first row as data instead of column headers
2. A complementary --columns option to specify column names when headers aren't present
3. Proper validation to ensure correct flag combinations
4. Comprehensive error handling for stdin imports with clear error messages
5. Integration tests for both CSV and PSV files

## Testing

- Added integration tests for both CSV and PSV files that verify:
- Importing files with --no-header and --columns options
- Error cases when required options are missing
- Original behavior is maintained when not using --no-header
- Behavior of --columns with and without --no-header
- Edge cases like stdin imports