### PR TITLE
Sql-shell display warnings

### DIFF
--- a/go/cmd/dolt/commands/blame.go
+++ b/go/cmd/dolt/commands/blame.go
@@ -130,7 +130,7 @@ func (cmd BlameCmd) Exec(ctx context.Context, commandStr string, args []string, 
 		return 1
 	}
 
-	err = engine.PrettyPrintResults(sqlCtx, engine.FormatTabular, schema, ri, false)
+	err = engine.PrettyPrintResults(sqlCtx, engine.FormatTabular, schema, ri, false, false)
 	if err != nil {
 		iohelp.WriteLine(cli.CliOut, err.Error())
 		return 1

--- a/go/cmd/dolt/commands/cvcmds/verify_constraints.go
+++ b/go/cmd/dolt/commands/cvcmds/verify_constraints.go
@@ -181,7 +181,7 @@ func printViolationsForTable(ctx *sql.Context, dbName, tblName string, tbl *dolt
 
 	limitItr := &sqlLimitIter{itr: sqlItr, limit: 50}
 
-	err = engine.PrettyPrintResults(ctx, engine.FormatTabular, sqlSch, limitItr, false)
+	err = engine.PrettyPrintResults(ctx, engine.FormatTabular, sqlSch, limitItr, false, false)
 	if err != nil {
 		return errhand.BuildDError("Error outputting rows").AddCause(err).Build()
 	}

--- a/go/cmd/dolt/commands/engine/sql_print.go
+++ b/go/cmd/dolt/commands/engine/sql_print.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/fatih/color"
 	"io"
 	"time"
 
@@ -145,7 +146,7 @@ func prettyPrintResultsWithSummary(ctx *sql.Context, resultFormat PrintResultFor
 		if showWarnings {
 			warnings += "\n"
 			for _, warn := range ctx.Session.Warnings() {
-				warnings += fmt.Sprintf("\nWarning (Code %d): %s", warn.Code, warn.Message)
+				warnings += fmt.Sprintf(color.YellowString("\nWarning (Code %d): %s"), warn.Code, warn.Message)
 			}
 		}
 

--- a/go/cmd/dolt/commands/engine/sql_print.go
+++ b/go/cmd/dolt/commands/engine/sql_print.go
@@ -168,16 +168,11 @@ func printResultSetSummary(numRows int, numWarnings uint16, warningSummary bool,
 
 	warning := ""
 	if warningSummary && numWarnings > 0 {
-		warning = ", "
-
-		warningCount := fmt.Sprintf("%d", numWarnings)
-		warning += warningCount
-
-		if numWarnings == 1 {
-			warning += " warning"
-		} else {
-			warning += " warnings"
+		plural := ""
+		if numWarnings > 1 {
+			plural = "s"
 		}
+		warning = fmt.Sprintf(", %d warning%s", numWarnings, plural)
 	}
 
 	if numRows == 0 {
@@ -191,7 +186,7 @@ func printResultSetSummary(numRows int, numWarnings uint16, warningSummary bool,
 	}
 
 	secondsSinceStart := secondsSince(start, time.Now())
-	err := iohelp.WriteLine(cli.CliOut, fmt.Sprintf("%d %s in set%s (%.2f sec)%s", numRows, noun, warning, secondsSinceStart, warnings))
+	err := iohelp.WriteLine(cli.CliOut, fmt.Sprintf("%d %s in set%s (%.2f sec) %s", numRows, noun, warning, secondsSinceStart, warnings))
 	if err != nil {
 		return err
 	}

--- a/go/cmd/dolt/commands/engine/sql_print.go
+++ b/go/cmd/dolt/commands/engine/sql_print.go
@@ -144,9 +144,10 @@ func prettyPrintResultsWithSummary(ctx *sql.Context, resultFormat PrintResultFor
 		warningSummary, _ := ctx.GetSessionVariable(ctx, "sql_warnings")
 		warnings := ""
 		if showWarnings {
-			warnings += "\n"
+
+			warnings = "\n"
 			for _, warn := range ctx.Session.Warnings() {
-				warnings += fmt.Sprintf(color.YellowString("\nWarning (Code %d): %s"), warn.Code, warn.Message)
+				warnings += color.YellowString(fmt.Sprintf("\nWarning (Code %d): %s", warn.Code, warn.Message))
 			}
 		}
 

--- a/go/cmd/dolt/commands/engine/sql_print.go
+++ b/go/cmd/dolt/commands/engine/sql_print.go
@@ -142,12 +142,12 @@ func prettyPrintResultsWithSummary(ctx *sql.Context, resultFormat PrintResultFor
 	if summary == PrintRowCountAndTiming {
 		warningSummary, _ := ctx.GetSessionVariable(ctx, "sql_warnings")
 		warnings := ""
-		/*if showWarnings {
+		if showWarnings {
+			warnings += "\n"
 			for _, warn := range ctx.Session.Warnings() {
-				warnings += "\n"
 				warnings += fmt.Sprintf("\nWarning (Code %d): %s", warn.Code, warn.Message)
 			}
-		}*/
+		}
 
 		err = printResultSetSummary(numRows, ctx.WarningCount(), warningSummary.(int8) == 1, warnings, start)
 		if err != nil {

--- a/go/cmd/dolt/commands/engine/sql_print.go
+++ b/go/cmd/dolt/commands/engine/sql_print.go
@@ -18,12 +18,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/fatih/color"
 	"io"
 	"time"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/fatih/color"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"

--- a/go/cmd/dolt/commands/schcmds/tags.go
+++ b/go/cmd/dolt/commands/schcmds/tags.go
@@ -140,7 +140,7 @@ func (cmd TagsCmd) Exec(ctx context.Context, commandStr string, args []string, d
 	}
 
 	sqlCtx := sql.NewContext(ctx)
-	err = engine.PrettyPrintResults(sqlCtx, outputFmt, headerSchema, sql.RowsToRowIter(rows...), false)
+	err = engine.PrettyPrintResults(sqlCtx, outputFmt, headerSchema, sql.RowsToRowIter(rows...), false, false)
 
 	return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 }

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -797,6 +797,9 @@ func execShell(sqlCtx *sql.Context, qryist cli.Queryist, format engine.PrintResu
 			}
 
 			if cmdType == DoltCliCommand {
+				_, okOn := subCmd.(WarningOn)
+				_, okOff := subCmd.(WarningOff)
+
 				if _, ok := subCmd.(SlashPager); ok {
 					p, err := handlePagerCommand(query)
 					if err != nil {
@@ -804,7 +807,7 @@ func execShell(sqlCtx *sql.Context, qryist cli.Queryist, format engine.PrintResu
 					} else {
 						pagerEnabled = p
 					}
-				} else if _, ok := subCmd.(WarningOn); ok {
+				} else if okOn || okOff {
 					w, err := handleWarningCommand(query)
 					if err != nil {
 						shell.Println(color.RedString(err.Error()))

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -813,6 +813,11 @@ func execShell(sqlCtx *sql.Context, qryist cli.Queryist, format engine.PrintResu
 						shell.Println(color.RedString(err.Error()))
 					} else {
 						showWarnings = w
+						if showWarnings {
+							cli.Println("Show warnings enabled")
+						} else {
+							cli.Println("Show warnings disabled")
+						}
 					}
 				} else {
 					err := handleSlashCommand(sqlCtx, subCmd, query, cliCtx)

--- a/go/cmd/dolt/commands/sql_slash.go
+++ b/go/cmd/dolt/commands/sql_slash.go
@@ -212,7 +212,7 @@ func (s SlashEdit) Exec(ctx context.Context, commandStr string, args []string, d
 func (s SlashEdit) Docs() *cli.CommandDocumentation {
 	return &cli.CommandDocumentation{
 		ShortDesc: "Use $EDITOR to edit the last command.",
-		LongDesc:  "",
+		LongDesc:  "Start a text editor to edit your last command. Command will be executed after you finish editing.",
 		Synopsis:  []string{},
 		ArgParser: s.ArgParser(),
 	}

--- a/go/cmd/dolt/commands/sql_slash.go
+++ b/go/cmd/dolt/commands/sql_slash.go
@@ -210,8 +210,12 @@ func (s SlashEdit) Exec(ctx context.Context, commandStr string, args []string, d
 }
 
 func (s SlashEdit) Docs() *cli.CommandDocumentation {
-	//TODO implement me
-	return &cli.CommandDocumentation{}
+	return &cli.CommandDocumentation{
+		ShortDesc: "Use $EDITOR to edit the last command.",
+		LongDesc:  "",
+		Synopsis:  []string{},
+		ArgParser: s.ArgParser(),
+	}
 }
 
 func (s SlashEdit) ArgParser() *argparser.ArgParser {
@@ -222,8 +226,12 @@ func (s SlashEdit) ArgParser() *argparser.ArgParser {
 type SlashPager struct{}
 
 func (s SlashPager) Docs() *cli.CommandDocumentation {
-	//TODO
-	return &cli.CommandDocumentation{}
+	return &cli.CommandDocumentation{
+		ShortDesc: "Enable or Disable the result pager",
+		LongDesc:  "Returns results in pager form. Use pager [on|off].",
+		Synopsis:  []string{},
+		ArgParser: s.ArgParser(),
+	}
 }
 
 func (s SlashPager) ArgParser() *argparser.ArgParser {
@@ -272,8 +280,12 @@ func handlePagerCommand(fullCmd string) (bool, error) {
 type WarningCmd struct{}
 
 func (s WarningCmd) Docs() *cli.CommandDocumentation {
-	//TODO
-	return &cli.CommandDocumentation{}
+	return &cli.CommandDocumentation{
+		ShortDesc: "Toggle display of generated warnings after sql command.",
+		LongDesc:  "Displays a detailed list of the warnings generated after each sql command. Use \\W and \\w to enable and disable the setting, respectively.",
+		Synopsis:  []string{},
+		ArgParser: s.ArgParser(),
+	}
 }
 
 func (s WarningCmd) ArgParser() *argparser.ArgParser {
@@ -307,7 +319,7 @@ var _ cli.Command = WarningOff{}
 func (s WarningOff) Name() string { return "w" }
 
 func (s WarningOff) Description() string {
-	return "Hide warnings after sql command"
+	return "Hide generated warnings after sql command"
 }
 
 func handleWarningCommand(fullCmd string) (bool, error) {

--- a/go/cmd/dolt/commands/sql_slash.go
+++ b/go/cmd/dolt/commands/sql_slash.go
@@ -42,6 +42,7 @@ var slashCmds = []cli.Command{
 	SlashEdit{},
 	SlashPager{},
 	WarningOn{},
+	WarningOff{},
 }
 
 // parseSlashCmd parses a command line string into a slice of strings, splitting on spaces, but allowing spaces within
@@ -268,15 +269,25 @@ func handlePagerCommand(fullCmd string) (bool, error) {
 	return false, fmt.Errorf("Usage: \\pager [on|off]")
 }
 
-type WarningOn struct{}
+type WarningCmd struct{}
 
-func (s WarningOn) Docs() *cli.CommandDocumentation {
+func (s WarningCmd) Docs() *cli.CommandDocumentation {
 	//TODO
 	return &cli.CommandDocumentation{}
 }
 
-func (s WarningOn) ArgParser() *argparser.ArgParser {
+func (s WarningCmd) ArgParser() *argparser.ArgParser {
 	return &argparser.ArgParser{}
+}
+
+// Exec should never be called on warning command; It only changes which information is displayed.
+// handleWarningCommand should be used instead
+func (s WarningCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
+	panic("runtime error. Exec should never be called on warning display commands.")
+}
+
+type WarningOn struct {
+	WarningCmd
 }
 
 var _ cli.Command = WarningOn{}
@@ -287,35 +298,16 @@ func (s WarningOn) Description() string {
 	return "Show generated warnings after sql command"
 }
 
-// Exec should never be called on warning command; It only changes which information is displayed.
-// handleWarningCommand should be used instead
-func (s WarningOn) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
-	panic("runtime error. WarningOn.Exec should never be called.")
-}
-
-type WarningOff struct{}
-
-func (s WarningOff) Docs() *cli.CommandDocumentation {
-	//TODO
-	return &cli.CommandDocumentation{}
-}
-
-func (s WarningOff) ArgParser() *argparser.ArgParser {
-	return &argparser.ArgParser{}
+type WarningOff struct {
+	WarningCmd
 }
 
 var _ cli.Command = WarningOff{}
 
-func (s WarningOff) Name() string { return "W" }
+func (s WarningOff) Name() string { return "w" }
 
 func (s WarningOff) Description() string {
 	return "Hide warnings after sql command"
-}
-
-// Exec should never be called on warning command; It only changes which information is displayed.
-// handleWarningCommand should be used instead
-func (s WarningOff) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
-	panic("runtime error. WarningOff.Exec should never be called.")
 }
 
 func handleWarningCommand(fullCmd string) (bool, error) {
@@ -326,7 +318,7 @@ func handleWarningCommand(fullCmd string) (bool, error) {
 	}
 
 	//Copied from mysql, could also return an error if more argument are passed in?
-	if tokens[0] == "W" {
+	if tokens[0] == "\\W" {
 		return true, nil
 	} else {
 		return false, nil

--- a/go/cmd/dolt/commands/sql_slash.go
+++ b/go/cmd/dolt/commands/sql_slash.go
@@ -41,6 +41,7 @@ var slashCmds = []cli.Command{
 	SlashHelp{},
 	SlashEdit{},
 	SlashPager{},
+	WarningOn{},
 }
 
 // parseSlashCmd parses a command line string into a slice of strings, splitting on spaces, but allowing spaces within
@@ -265,4 +266,69 @@ func handlePagerCommand(fullCmd string) (bool, error) {
 	}
 
 	return false, fmt.Errorf("Usage: \\pager [on|off]")
+}
+
+type WarningOn struct{}
+
+func (s WarningOn) Docs() *cli.CommandDocumentation {
+	//TODO
+	return &cli.CommandDocumentation{}
+}
+
+func (s WarningOn) ArgParser() *argparser.ArgParser {
+	return &argparser.ArgParser{}
+}
+
+var _ cli.Command = WarningOn{}
+
+func (s WarningOn) Name() string { return "W" }
+
+func (s WarningOn) Description() string {
+	return "Show generated warnings after sql command"
+}
+
+// Exec should never be called on warning command; It only changes which information is displayed.
+// handleWarningCommand should be used instead
+func (s WarningOn) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
+	panic("runtime error. WarningOn.Exec should never be called.")
+}
+
+type WarningOff struct{}
+
+func (s WarningOff) Docs() *cli.CommandDocumentation {
+	//TODO
+	return &cli.CommandDocumentation{}
+}
+
+func (s WarningOff) ArgParser() *argparser.ArgParser {
+	return &argparser.ArgParser{}
+}
+
+var _ cli.Command = WarningOff{}
+
+func (s WarningOff) Name() string { return "W" }
+
+func (s WarningOff) Description() string {
+	return "Hide warnings after sql command"
+}
+
+// Exec should never be called on warning command; It only changes which information is displayed.
+// handleWarningCommand should be used instead
+func (s WarningOff) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
+	panic("runtime error. WarningOff.Exec should never be called.")
+}
+
+func handleWarningCommand(fullCmd string) (bool, error) {
+	tokens := strings.Split(fullCmd, " ")
+
+	if len(tokens) == 0 || (tokens[0] != "\\w" && tokens[0] != "\\W") {
+		return false, fmt.Errorf("runtime error: Expected \\w or \\W command.")
+	}
+
+	//Copied from mysql, could also return an error if more argument are passed in?
+	if tokens[0] == "W" {
+		return true, nil
+	} else {
+		return false, nil
+	}
 }

--- a/go/libraries/doltcore/sqle/system_variables.go
+++ b/go/libraries/doltcore/sqle/system_variables.go
@@ -516,6 +516,13 @@ func AddDoltSystemVariables() {
 			Type:    types.NewSystemBoolType("gpgsign"),
 			Default: int8(0),
 		},
+		&sql.MysqlSystemVariable{
+			Name:    "sql_warnings",
+			Dynamic: true,
+			Scope:   sql.GetMysqlScope(sql.SystemVariableScope_Both),
+			Type:    types.NewSystemBoolType("sql_warnings"),
+			Default: int8(1),
+		},
 	})
 	sql.SystemVariables.AddSystemVariables(DoltSystemVariables)
 }

--- a/integration-tests/bats/sql-shell.bats
+++ b/integration-tests/bats/sql-shell.bats
@@ -36,6 +36,29 @@ teardown() {
     [[ "$output" =~ "Division by 0" ]] || false
 }
 
+@test "sql-shell: can toggle warning details" {
+    skiponwindows "Need to install expect and make this script work on windows."
+
+    run $BATS_TEST_DIRNAME/sql-warning-summary.expect
+
+    [[ "$output" =~ "EXPLAIN Output is currently a placeholder" ]] || false
+    ! [[ "$output" =~ "Warning (Code 1365): Division by 0" ]] || false
+}
+
+@test "sql-shell: can toggle warning summary" {
+   skiponwindows "Need to install expect and make this script work on windows."
+
+   run $BATS_TEST_DIRNAME/sql-warning-detail.expect
+   echo -----------
+   echo "$output"
+   echo -----------
+
+   [[ "$output" =~ "1 row in set, 1 warning" ]] || false
+   [[ "$output" =~ "1 row in set, 2 warnings" ]] || false
+   ! [[ "$output" =~ "1 row in set, 3 warnings" ]] || false
+
+}
+
 @test "sql-shell: use user without privileges, and no superuser created" {
     rm -rf .doltcfg
 
@@ -1007,4 +1030,10 @@ expect eof
     [ $status -eq 0 ]
     [[ "$output" =~ "github.com/dolthub/dolt/go" ]] || false
     [[ "$output" =~ "github.com/dolthub/go-mysql-server" ]] || false
+}
+
+@test "sql-shell: toggle detailed warnings" {
+    skiponwindows "Need to install expect and make this script work on windows."
+
+
 }

--- a/integration-tests/bats/sql-shell.bats
+++ b/integration-tests/bats/sql-shell.bats
@@ -49,9 +49,6 @@ teardown() {
    skiponwindows "Need to install expect and make this script work on windows."
 
    run $BATS_TEST_DIRNAME/sql-warning-detail.expect
-   echo -----------
-   echo "$output"
-   echo -----------
 
    [[ "$output" =~ "1 row in set, 1 warning" ]] || false
    [[ "$output" =~ "1 row in set, 2 warnings" ]] || false

--- a/integration-tests/bats/sql-warning-detail.expect
+++ b/integration-tests/bats/sql-warning-detail.expect
@@ -1,0 +1,40 @@
+#!/usr/bin/expect
+
+set timeout 5
+set env(NO_COLOR) 1
+
+source  "$env(BATS_CWD)/helper/common_expect_functions.tcl"
+
+spawn dolt sql
+
+expect {
+    -re "dolt-repo-.*> " {send "select 1/0;\r"; }
+    timeout { exit 1; }
+    failed { exit 1; }
+}
+
+expect {
+    -re "dolt-repo-.*> " { send "select 1/0, 1/0;\r"; }
+    timeout { exit 1; }
+    failed { exit 1; }
+}
+
+expect {
+    -re "dolt-repo-.*> " { send "set sql_warnings = 0;\r"; }
+    timeout { exit 1; }
+    failed { exit 1; }
+}
+
+expect {
+    -re "dolt-repo-.*> " { send "select 1/0, 1/0, 1/0;\r"; }
+    timeout { exit 1; }
+    failed { exit 1; }
+}
+
+expect {
+    -re "dolt-repo-.*> " { send "exit;\r"; }
+    timeout { exit 1; }
+    failed { exit 1; }
+}
+
+expect eof

--- a/integration-tests/bats/sql-warning-summary.expect
+++ b/integration-tests/bats/sql-warning-summary.expect
@@ -1,0 +1,30 @@
+#!/usr/bin/expect
+
+set timeout 5
+set env(NO_COLOR) 1
+
+source  "$env(BATS_CWD)/helper/common_expect_functions.tcl"
+
+spawn dolt sql
+
+expect {
+    -re "dolt-repo-.*> " {send "explain select * from test;\r"; }
+    timeout { exit 1; }
+    failed { exit 1; }
+}
+
+expect_with_defaults                                                    {dolt-repo-.*>} { send "\\w\r"; }
+
+expect {
+    -re "dolt-repo-.*> " { send "select 1/0;\r"; }
+    timeout { exit 1; }
+    failed { exit 1; }
+}
+
+expect {
+    -re "dolt-repo-.*> " { send "exit;\r"; }
+    timeout { exit 1; }
+    failed { exit 1; }
+}
+
+expect eof


### PR DESCRIPTION
Fix issue #8875 

This pr adds support for warnings in the sql shell. There is now both a summary and detailed list of warnings. 

Running ```select 1/0;``` will produce, after the table:
```
1 row in set, 1 warning (0.0 sec)

Warning (Code 1365): Division by 0
```

You can disable/enable the ending list with ```\w ```and ```\W``` respectively, and turn off the summary with ```set sql_warnings = 0;```
