### PR TITLE
When performing a three-way merge, Use a patchBuffer to build the new primary index instead of a MutableMap.

### DIFF
--- a/go/store/prolly/tuple_map.go
+++ b/go/store/prolly/tuple_map.go
@@ -35,7 +35,7 @@ type Map struct {
 	valDesc val.TupleDesc
 }
 
-// NewMap creates an empty prolly Tree Map
+// NewMap creates a Map from the supplied root node
 func NewMap(node tree.Node, ns tree.NodeStore, keyDesc, valDesc val.TupleDesc) Map {
 	tuples := tree.StaticMap[val.Tuple, val.Tuple, val.TupleDesc]{
 		Root:      node,


### PR DESCRIPTION
MutableMaps are designed for caching point modifications to a table. But during merge, the new primary index is computed sequentially. There's no benefit to using a MutableMap here.

MutableMaps are built on top of the `ApplyMutations` function, which takes a sequential stream of modifications (called a PatchBuffer) and applies them to a chunker. This has the added benefit of being parallelizable: the patches are produced in one goroutine and consumed in another.

Instead of using the MutableMap, we can extract the underlying PatchBuffer and use it directly. This should be both more performant, and more correct as it avoids a failure case with schema merges where the MutableMap flushes changes to disk and writes a chunk containing rows with different schemas.