### PR TITLE
Log errors on a binlog connection

### DIFF
--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_applier.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_applier.go
@@ -325,6 +325,7 @@ func (a *binlogReplicaApplier) replicaBinlogEventHandler(ctx *sql.Context) error
 
 		case err := <-eventProducer.ErrorChan():
 			if sqlError, isSqlError := err.(*mysql.SQLError); isSqlError {
+				ctx.GetLogger().Infof("error on replication connection: %v", err)
 				badConnection := sqlError.Message == io.EOF.Error() ||
 					strings.HasPrefix(sqlError.Message, io.ErrUnexpectedEOF.Error())
 				if badConnection {


### PR DESCRIPTION
When a SQL error is sent from the replication source to the replica, the connection is closed out, but the error wasn't getting logged. This made it difficult to debug why the replication connection was erroring out. 