### PR TITLE
--all option for dolt log

### DIFF
--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -289,6 +289,7 @@ func CreateLogArgParser(isTableFunction bool) *argparser.ArgParser {
 	ap.SupportsFlag(ParentsFlag, "", "Shows all parents of each commit in the log.")
 	ap.SupportsString(DecorateFlag, "", "decorate_fmt", "Shows refs next to commits. Valid options are short, full, no, and auto")
 	ap.SupportsStringList(NotFlag, "", "revision", "Excludes commits from revision.")
+	ap.SupportsFlag(AllFlag, "", "Automatically select every branch in database")
 	ap.SupportsFlag(ShowSignatureFlag, "", "Shows the signature of each commit.")
 	if isTableFunction {
 		ap.SupportsStringList(TablesFlag, "t", "table", "Restricts the log to commits that modified the specified tables.")

--- a/go/cmd/dolt/commands/log.go
+++ b/go/cmd/dolt/commands/log.go
@@ -194,7 +194,7 @@ func constructInterpolatedDoltLogQuery(apr *argparser.ArgParseResults, queryist 
 					params = append(params, arg)
 				} else {
 					_, err := GetRowsForSql(queryist, sqlCtx, "select hashof('"+arg+"')")
-					if err != nil {
+					if _, ok := seenRevs[arg]; ok || err != nil {
 						finishedRevs = true
 						if len(existingTables) == 0 {
 							existingTables, err = getExistingTables(apr.Args[:i], queryist, sqlCtx)
@@ -208,28 +208,12 @@ func constructInterpolatedDoltLogQuery(apr *argparser.ArgParseResults, queryist 
 						}
 						tableNames = append(tableNames, arg)
 					} else {
-						if _, ok := seenRevs[arg]; ok {
-							finishedRevs = true
-							if len(existingTables) == 0 {
-								existingTables, err = getExistingTables(apr.Args[:i], queryist, sqlCtx)
-							}
-							if err != nil {
-								return "", err
-							}
-
-							if _, ok := existingTables[arg]; !ok {
-								return "", fmt.Errorf("error: table %s does not exist", arg)
-							}
-							tableNames = append(tableNames, arg)
-						} else {
-							seenRevs[arg] = true
-						}
+						seenRevs[arg] = true
 						writeToBuffer("?")
 						params = append(params, arg)
 					}
 				}
 			}
-
 		}
 
 		if len(tableNames) > 0 {

--- a/integration-tests/bats/log.bats
+++ b/integration-tests/bats/log.bats
@@ -1057,7 +1057,6 @@ export NO_COLOR=1
     dolt commit --allow-empty -m "commit 1 br2"
     dolt checkout main
 
-
     run dolt log --all
 
     [ "$status" -eq 0 ]
@@ -1073,7 +1072,6 @@ export NO_COLOR=1
     [[ "$output" =~ "commit 1 br1" ]] || false
     [[ "$output" =~ "Initialize data repository" ]] || false
 }
-
 
 @test "log: --all works when specifying tables" {
     if [ "$SQL_ENGINE" = "remote-engine" ]; then
@@ -1093,5 +1091,4 @@ export NO_COLOR=1
     [[ "$output" =~ "A table for br1" ]] || false
     ! [[ "$output" =~ "Initialize data repository" ]] || false
     ! [[ "$output" =~ "commit 1 br2" ]] || false
-
 }

--- a/integration-tests/bats/log.bats
+++ b/integration-tests/bats/log.bats
@@ -1045,26 +1045,15 @@ export NO_COLOR=1
 
 }
 
-@test "log: --all correctly gets branches, from anywhere in the repo" {
-    if [ "$SQL_ENGINE" = "remote-engine" ]; then
-          skip "needs checkout which is unsupported for remote-engine"
-    fi
+@test "log: --all correctly gets branches" {
 
-    dolt checkout -b br1
     dolt commit --allow-empty -m "commit 1 br1"
-    dolt checkout main
-    dolt checkout -b br2
+    dolt branch br1
+    dolt reset --hard HEAD~1
     dolt commit --allow-empty -m "commit 1 br2"
-    dolt checkout main
+    dolt branch br2
+    dolt reset --hard HEAD~1
 
-    run dolt log --all
-
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ "commit 1 br2" ]] || false
-    [[ "$output" =~ "commit 1 br1" ]] || false
-    [[ "$output" =~ "Initialize data repository" ]] || false
-
-    dolt checkout br1
     run dolt log --all
 
     [ "$status" -eq 0 ]
@@ -1074,17 +1063,14 @@ export NO_COLOR=1
 }
 
 @test "log: --all works when specifying tables" {
-    if [ "$SQL_ENGINE" = "remote-engine" ]; then
-              skip "needs checkout which is unsupported for remote-engine"
-    fi
 
-    dolt checkout -b br1
     dolt sql -q "create table test (i int primary key)"
     dolt commit -A -m "A table for br1"
-    dolt checkout main
-    dolt checkout -b br2
+    dolt branch br1
+    dolt reset --hard HEAD~1
     dolt commit --allow-empty -m "commit 1 br2"
-    dolt checkout main
+    dolt branch br2
+    dolt reset --hard HEAD~1
 
     run dolt log --all test
     [ "$status" -eq 0 ]


### PR DESCRIPTION
Issue #8200 

Adds a `--all` option for dolt log. You can also specify tables after the all option, with `dolt lot --all table1 table2`. 

I still want to work on:

- [x] The code's a bit messy still, I think a helper function might be nice, especially to set the existingTables map.
- [x] Maybe make it work with `--not` to exclude branches?
- [x] I'm sort of wondering if the code handling the generation of the "query" we make could be improved. It might not be worth it, but for example if you have a table and branch with the same name, we reinsert that value into the `params` slice. We also reuse a bunch of code for the code handling the first non-revision argument.