### PR TITLE
Made dolt diff --stat -r sql an error

### DIFF
--- a/go/cmd/dolt/commands/diff_output.go
+++ b/go/cmd/dolt/commands/diff_output.go
@@ -297,8 +297,7 @@ func (s sqlDiffWriter) WriteViewDiff(ctx context.Context, viewName, oldDefn, new
 }
 
 func (s sqlDiffWriter) WriteTableDiffStats(diffStats []diffStatistics, oldColLen, newColLen int, areTablesKeyless bool) error {
-	// TODO: implement this
-	return errors.New("diff stats are not supported for sql output")
+	return errors.New("SQL format diffs only rendered for schema or data changes")
 }
 
 func (s sqlDiffWriter) RowWriter(fromTableInfo, toTableInfo *diff.TableInfo, tds diff.TableDeltaSummary, unionSch sql.Schema) (diff.SqlRowDiffWriter, error) {

--- a/go/cmd/dolt/commands/diff_output.go
+++ b/go/cmd/dolt/commands/diff_output.go
@@ -297,7 +297,7 @@ func (s sqlDiffWriter) WriteViewDiff(ctx context.Context, viewName, oldDefn, new
 }
 
 func (s sqlDiffWriter) WriteTableDiffStats(diffStats []diffStatistics, oldColLen, newColLen int, areTablesKeyless bool) error {
-	return errors.New("SQL format diffs only rendered for schema or data changes")
+	return errors.New("invalid output format: sql. SQL format diffs only rendered for schema or data changes")
 }
 
 func (s sqlDiffWriter) RowWriter(fromTableInfo, toTableInfo *diff.TableInfo, tds diff.TableDeltaSummary, unionSch sql.Schema) (diff.SqlRowDiffWriter, error) {

--- a/integration-tests/bats/sql-diff.bats
+++ b/integration-tests/bats/sql-diff.bats
@@ -888,5 +888,5 @@ EOF
     dolt sql -q "create table t (i int primary key);"
     run dolt diff --stat -r sql
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "SQL format diffs only rendered for schema or data changes" ]] || false
+    [[ "$output" =~ "invalid output format: sql. SQL format diffs only rendered for schema or data changes" ]] || false
 }

--- a/integration-tests/bats/sql-diff.bats
+++ b/integration-tests/bats/sql-diff.bats
@@ -888,5 +888,5 @@ EOF
     dolt sql -q "create table t (i int primary key);"
     run dolt diff --stat -r sql
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "diff stats are not supported for sql output" ]] || false
+    [[ "$output" =~ "SQL format diffs only rendered for schema or data changes" ]] || false
 }


### PR DESCRIPTION
Fixes #7817

From Claude:
```
⏺ Perfect! The changes are working correctly. Let me summarize what I've
  implemented:

  Summary

  I successfully implemented the fix for GitHub issue #7817. The issue was
  that dolt diff --stat -r sql was throwing a generic "unsupported" error,
  but it should return a more specific error message explaining that SQL
  format diffs are only for schema or data changes.

  Changes Made:

  1. Updated the error message in
  /Users/timsehn/dolthub/git/dolt/go/cmd/dolt/commands/diff_output.go:
    - Changed from: "diff stats are not supported for sql output"
    - Changed to: "SQL format diffs only rendered for schema or data 
  changes"
  2. Updated the test in
  /Users/timsehn/dolthub/git/dolt/integration-tests/bats/sql-diff.bats:
    - Updated the expected error message in the test case to match the new
  error message

  Reasoning:

  The --stat flag shows statistics about diffs (like number of rows
  changed), which cannot be meaningfully represented as SQL statements. SQL
   format should only be used for actual schema or data changes that can be
   expressed as executable SQL commands. The new error message clearly
  communicates this limitation to users.

  The implementation correctly returns an error when someone tries to use
  dolt diff --stat -r sql, and the tests confirm that:
  1. The specific error case now returns the improved error message
  2. Normal SQL diff functionality continues to work as expected

> /cost 
  ⎿ Total cost:            $3.08
    Total duration (API):  11m 9.9s
    Total duration (wall): 25m 15.4s
    Total code changes:    2 lines added, 3 lines removed
    Token usage by model:
        claude-3-5-haiku:  79.9k input, 1.9k output, 0 cache read, 0 cache 
    write
           claude-sonnet:  23.2k input, 15.3k output, 4.1m cache read, 
    396.2k cache write
```