### PR TITLE
Allow dumping wrapper values to SQL

### DIFF
--- a/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
@@ -542,6 +542,10 @@ func interfaceValueAsSqlString(ctx *sql.Context, ti typeinfo.TypeInfo, value int
 	case typeinfo.DatetimeTypeIdentifier:
 		return singleQuote + str + singleQuote, nil
 	case typeinfo.InlineBlobTypeIdentifier, typeinfo.VarBinaryTypeIdentifier:
+		value, err := sql.UnwrapAny(ctx, value)
+		if err != nil {
+			return "", err
+		}
 		switch v := value.(type) {
 		case []byte:
 			return hexEncodeBytes(v), nil

--- a/integration-tests/bats/export-tables.bats
+++ b/integration-tests/bats/export-tables.bats
@@ -114,8 +114,8 @@ if rows[2] != "9,8,7,6,5,4".split(","):
     diff --strip-trailing-cr $BATS_TEST_DIRNAME/helper/1pk5col-ints.sql export.sql
 
     # string columns
-    dolt sql -q "create table strings (a varchar(10) primary key, b char(10))"
-    dolt sql -q "insert into strings values ('abc', '123'), ('def', '456')"
+    dolt sql -q "create table strings (a varchar(10) primary key, b char(10), c text, d blob)"
+    dolt sql -q "insert into strings values ('abc', '123', 'do re me', 'qwe'), ('def', '456', 'fa so la', 'rty')"
     dolt add .
     dolt commit -am "Checkpoint"
 


### PR DESCRIPTION
This prevents an issue where commands like `dolt dump` would fail when trying to export a table as SQL statements if the table has a `BLOB` column, since it would fail to unwrap the text wrapper value to access the underlying bytes.