### PR TITLE
Fix replace count test

### DIFF
--- a/integration-tests/bats/sql.bats
+++ b/integration-tests/bats/sql.bats
@@ -2074,14 +2074,13 @@ SQL
 }
 
 @test "sql: replace count" {
-    skip "right now we always count a replace as a delete and insert when we shouldn't"
     dolt sql -q "CREATE TABLE test(pk BIGINT PRIMARY KEY, v BIGINT);"
     run dolt sql -q "REPLACE INTO test VALUES (1, 1);"
     [ $status -eq 0 ]
-    [[ "${lines[3]}" =~ " 1 " ]] || false
+    [[ "$output" =~ "Query OK, 1 row affected" ]] || false
     run dolt sql -q "REPLACE INTO test VALUES (1, 2);"
     [ $status -eq 0 ]
-    [[ "${lines[3]}" =~ " 2 " ]] || false
+    [[ "$output" =~ "Query OK, 2 rows affected" ]] || false
 }
 
 @test "sql: unix_timestamp function" {


### PR DESCRIPTION
Claude insists that this behavior matches MySQL. It consulted the docs and ran tests against MySQL. 

I can confirm the tested behavior matches MariaDB which I have installed:

```
MariaDB [(none)]> CREATE DATABASE test_replace;
ERROR 1007 (HY000): Can't create database 'test_replace'; database exists
MariaDB [(none)]> DROP DATABASE IF EXISTS
    ->       test_replace;
Query OK, 1 row affected (0.057 sec)

MariaDB [(none)]> USE test_replace;
ERROR 1049 (42000): Unknown database 'test_replace'
MariaDB [(none)]> CREATE DATABASE test_replace;
Query OK, 1 row affected (0.003 sec)

MariaDB [(none)]> USE test_replace;
Database changed
MariaDB [test_replace]> CREATE TABLE test(pk BIGINT
    ->       PRIMARY KEY, v BIGINT);
Query OK, 0 rows affected (0.030 sec)

MariaDB [test_replace]> REPLACE INTO test
    ->       VALUES (1, 1);
Query OK, 1 row affected (0.001 sec)

MariaDB [test_replace]> REPLACE INTO test VALUES (1,
    ->       2);
Query OK, 2 rows affected (0.001 sec)
```
