### PR TITLE
Remove the --new-format flag from dolt init

### DIFF
--- a/go/cmd/dolt/commands/init.go
+++ b/go/cmd/dolt/commands/init.go
@@ -35,7 +35,6 @@ const (
 	emailParamName      = "email"
 	usernameParamName   = "name"
 	initBranchParamName = "initial-branch"
-	newFormatFlag       = "new-format"
 	funHashFlag         = "fun"
 )
 
@@ -80,7 +79,6 @@ func (cmd InitCmd) ArgParser() *argparser.ArgParser {
 	ap.SupportsString(emailParamName, "", "email", fmt.Sprintf("The email address used. If not provided will be taken from {{.EmphasisLeft}}%s{{.EmphasisRight}} in the global config.", config.UserEmailKey))
 	ap.SupportsString(cli.DateParam, "", "date", "Specify the date used in the initial commit. If not specified the current system time is used.")
 	ap.SupportsString(initBranchParamName, "b", "branch", fmt.Sprintf("The branch name used to initialize this database. If not provided will be taken from {{.EmphasisLeft}}%s{{.EmphasisRight}} in the global config. If unset, the default initialized branch will be named '%s'.", config.InitBranchName, env.DefaultInitBranch))
-	ap.SupportsFlag(newFormatFlag, "", fmt.Sprintf("Specify this flag to use the new storage format (%s).", types.Format_DOLT.VersionString()))
 	ap.SupportsFlag(funHashFlag, "", "") // This flag is an easter egg. We can't currently prevent it from being listed in the help, but the description is deliberately left blank.
 	return ap
 }
@@ -99,9 +97,6 @@ func (cmd InitCmd) Exec(ctx context.Context, commandStr string, args []string, d
 	if dEnv.HasDoltDataDir() {
 		cli.PrintErrln(color.RedString("This directory has already been initialized."))
 		return 1
-	}
-	if apr.Contains(newFormatFlag) {
-		types.Format_Default = types.Format_DOLT
 	}
 
 	if dEnv.HasDoltSqlServerInfo() {

--- a/integration-tests/bats/init.bats
+++ b/integration-tests/bats/init.bats
@@ -186,23 +186,10 @@ teardown() {
   [[ "$output" =~ "error: unknown option" ]] || false
 }
 
-@test "init: running init with the new format, creates a new format database" {
-    set_dolt_user "baz", "baz@bash.com"
-
-    run dolt init --new-format
-    [ $status -eq 0 ]
-
-    run dolt init
-    [ "$status" -eq 1 ]
-
-    run cut -d ":" -f 2 .dolt/noms/manifest
-    [ "$output" = "__DOLT__" ]
-}
-
 @test "init: initing a new database displays the correct version" {
     set_dolt_user "baz", "baz@bash.com"
 
-    run dolt init --new-format
+    run dolt init
     [ $status -eq 0 ]
 
     run dolt version -v
@@ -210,28 +197,6 @@ teardown() {
     [[ $output =~ "database storage format: NEW ( __DOLT__ )" ]] || false
 
     run dolt sql -q "SELECT dolt_storage_format();"
-    [[ $output =~ "NEW ( __DOLT__ )" ]] || false
-}
-
-@test "init: run init with --new-format, CREATE DATABASE through sql-server running in new-format repo should create a new format database" {
-    set_dolt_user "baz", "baz@bash.com"
-
-    run dolt init --new-format
-    [ $status -eq 0 ]
-
-    run dolt version --verbose
-    [ "$status" -eq 0 ]
-    [[ ! $output =~ "OLD ( __LD_1__ )" ]] || false
-    [[ $output =~ "NEW ( __DOLT__ )" ]] || false
-
-    dolt sql -q "create database test"
-    run ls
-    [[ $output =~ "test" ]] || false
-
-    cd test
-    run dolt version --verbose
-    [ "$status" -eq 0 ]
-    [[ ! $output =~ "OLD ( __LD_1__ )" ]] || false
     [[ $output =~ "NEW ( __DOLT__ )" ]] || false
 }
 
@@ -247,7 +212,7 @@ teardown() {
     fi
 
     mkdir new_format && cd new_format
-    run dolt init --new-format
+    run dolt init
     [ $status -eq 0 ]
 
     run dolt version --verbose


### PR DESCRIPTION
This flag really makes no sense any more

This is a claude change. $0.80, two prompts.