### PR TITLE
manifest safety checks

### DIFF
--- a/go/store/nbs/file_manifest.go
+++ b/go/store/nbs/file_manifest.go
@@ -302,9 +302,6 @@ func writeManifest(temp io.Writer, contents manifestContents) error {
 	if contents.lock.IsEmpty() {
 		return errors.New("runtime error: Lock hash cannot be empty")
 	}
-	if contents.root.IsEmpty() {
-		return errors.New("runtime error: Root hash cannot be empty")
-	}
 
 	strs := make([]string, 2*len(contents.specs)+prefixLen)
 	strs[0], strs[1], strs[2], strs[3], strs[4] = StorageVersion, contents.nbfVers, contents.lock.String(), contents.root.String(), contents.gcGen.String()

--- a/go/store/nbs/file_manifest.go
+++ b/go/store/nbs/file_manifest.go
@@ -296,6 +296,16 @@ func parseManifest(r io.Reader) (manifestContents, error) {
 }
 
 func writeManifest(temp io.Writer, contents manifestContents) error {
+	if len(contents.nbfVers) == 0 {
+		return errors.New("runtime error: Noms format version cannot be empty")
+	}
+	if contents.lock.IsEmpty() {
+		return errors.New("runtime error: Lock hash cannot be empty")
+	}
+	if contents.root.IsEmpty() {
+		return errors.New("runtime error: Root hash cannot be empty")
+	}
+
 	strs := make([]string, 2*len(contents.specs)+prefixLen)
 	strs[0], strs[1], strs[2], strs[3], strs[4] = StorageVersion, contents.nbfVers, contents.lock.String(), contents.root.String(), contents.gcGen.String()
 	tableInfo := strs[prefixLen:]

--- a/go/store/nbs/store_test.go
+++ b/go/store/nbs/store_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dolthub/dolt/go/store/constants"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,6 +35,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/utils/set"
 	"github.com/dolthub/dolt/go/libraries/utils/test"
 	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/constants"
 	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/types"
 	"github.com/dolthub/dolt/go/store/util/tempfiles"

--- a/go/store/nbs/store_test.go
+++ b/go/store/nbs/store_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dolthub/dolt/go/store/constants"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -49,7 +50,10 @@ func makeTestLocalStore(t *testing.T, maxTableFiles int) (st *NomsBlockStore, no
 	// create a v5 manifest
 	fm, err := getFileManifest(ctx, nomsDir, asyncFlush)
 	require.NoError(t, err)
-	_, err = fm.Update(ctx, hash.Hash{}, manifestContents{}, &Stats{}, nil)
+	_, err = fm.Update(ctx, hash.Hash{}, manifestContents{
+		nbfVers: constants.FormatDoltString,
+		lock:    journalAddr, // Any valid address will do here
+	}, &Stats{}, nil)
 	require.NoError(t, err)
 
 	q = NewUnlimitedMemQuotaProvider()


### PR DESCRIPTION
Recent user report of a manifest landing that was missing it's format. This will at least prevent the generation of such a file in the future.