### PR TITLE
Fix a load data bats test with tabs instead of spaces

### DIFF
--- a/integration-tests/bats/sql-load-data.bats
+++ b/integration-tests/bats/sql-load-data.bats
@@ -113,7 +113,6 @@ SQL
 }
 
 @test "sql-load-data: works with fields separated by tabs" {
-    skip "This is a test problem with CI preserving tabs in this file. Tabs work locally."
     cat <<DELIM > 1pk2col-ints.csv
 pk  c1
 0 1


### PR DESCRIPTION
The skip suggests CI can't preserve tabs. I'm pressing X to doubt.