### PR TITLE
(#9281)fix: return schema and row iterator for DDL queries to show confirmation

### DIFF
--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -1199,15 +1199,11 @@ func processParsedQuery(ctx *sql.Context, query string, qryist cli.Queryist, sql
 		}
 		return nil, nil, nil, nil
 	case *sqlparser.DDL:
-		_, ri, _, err := qryist.Query(ctx, query)
+		sch, ri, _, err := qryist.Query(ctx, query)
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		_, err = sql.RowIterToRows(ctx, ri)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		return nil, nil, nil, nil
+		return sch, ri, nil, nil
 	case *sqlparser.Load:
 		if s.Local {
 			return nil, nil, nil, fmt.Errorf("LOCAL supported only in sql-server mode")


### PR DESCRIPTION
#9281 fix: return schema and row iterator for DDL queries to show confirmation

## What I did: 
In `processParsedQuery` inside `dolt/go/cmd/dolt/commands/sql.go` , DDL statements (like `CREATE TABLE` ) were returning nil for both schema and row iterator, which caused the shell to skip printing the usual confirmation message (`Query OK, 0 rows affected`).

I modified the DDL case to return the `schema` and `rowIter` from `qryist.Query(...)`, allowing the shell to process the result and print the confirmation message just like it does for other statements.

In `dolt/go/cmd/dolt/commands/sql.go` , inside `processParsedQuery` function :
``` go
        return nil, nil, nil, nil
	case *sqlparser.DDL:
		sch, ri, _, err := qryist.Query(ctx, query)
		if err != nil {
			return nil, nil, nil, err
		}
		return sch, ri, nil, nil
	case *sqlparser.Load:
```

## Tests: 

- Ran `go test ./cmd/dolt/commands -v` and confirmed all tests pass:
```
PASS
ok      github.com/dolthub/dolt/go/cmd/dolt/commands    0.872s
```
- Manually tested in the SQL shell and confirmed the confirmation message:
![Screenshot From 2025-05-31 14-27-32](https://github.com/user-attachments/assets/710dbb1f-dfe8-4101-b492-0a3fffa1d552)


## Feedback:
Any feedback would be appreciated, It was my first time contributing to this project, looking forward to do more in the future!

Thanks,
Aaryan.