### PR TITLE
Nathan/commit time

### DIFF
--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -121,6 +121,12 @@ func performCommit(ctx context.Context, commandStr string, args []string, cliCtx
 		defer closeFunc()
 	}
 
+	// cliCtx always uses the session start as its time. We want the current time,
+	// which is stored in ctx.
+	if c, ok := ctx.(*sql.Context); ok {
+		sqlCtx.SetQueryTime(c.QueryTime())
+	}
+
 	// dolt_commit performs this check as well. This nips the problem in the bud early, but is not required.
 	err = branch_control.CheckAccess(sqlCtx, branch_control.Permissions_Write)
 	if err != nil {

--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -123,9 +123,9 @@ func performCommit(ctx context.Context, commandStr string, args []string, cliCtx
 
 	// cliCtx always uses the session start as its time. We want the current time,
 	// which is stored in ctx.
-	if c, ok := ctx.(*sql.Context); ok {
+	/*if c, ok := ctx.(*sql.Context); ok {
 		sqlCtx.SetQueryTime(c.QueryTime())
-	}
+	}*/
 
 	// dolt_commit performs this check as well. This nips the problem in the bud early, but is not required.
 	err = branch_control.CheckAccess(sqlCtx, branch_control.Permissions_Write)

--- a/integration-tests/bats/sql-shell-commit-time.expect
+++ b/integration-tests/bats/sql-shell-commit-time.expect
@@ -1,0 +1,26 @@
+#!/usr/bin/expect
+
+set timeout 5
+set env(NO_COLOR) 1
+exp_internal 1
+
+source  "$env(BATS_CWD)/helper/common_expect_functions.tcl"
+
+spawn dolt sql
+
+expect_with_defaults                                                    {dolt-repo-[0-9]+/main\*> } { send "\\commit -A -m \"created a table\"\r"; }
+
+expect_with_defaults                                                    {Date:\s+(.+)}              { set first_commit_date $expect_out(1,string) }
+
+expect_with_defaults                                                    {dolt-repo-[0-9]+/main> }   { send "insert into test (pk) values (1);\r"; }
+
+after 1000 # We want to check for different timestamps, so we wait a second to ensure that.
+
+expect_with_defaults                                                    {dolt-repo-[0-9]+/main> }   { send "\\commit -A -m \"added a row\"\r"; }
+
+expect_with_defaults                                                    {Date:\s+(.+)}              { set second_commit_date $expect_out(1, string)}
+
+expect_with_defaults_2 {Date:\s+(.+)}                                                    {dolt-repo-[0-9]+/main> }    { send "quit\r" }
+
+expect eof
+exit

--- a/integration-tests/bats/sql-shell.bats
+++ b/integration-tests/bats/sql-shell.bats
@@ -1030,3 +1030,13 @@ expect eof
     [[ "$output" =~ "github.com/dolthub/dolt/go" ]] || false
     [[ "$output" =~ "github.com/dolthub/go-mysql-server" ]] || false
 }
+
+# bats test_tags=no_lambda
+@test "sql-shell: commit time set correctly in shell" {
+        skiponwindows "Need to install expect and make this script work on windows."
+        run $BATS_TEST_DIRNAME/sql-shell-commit-time.expect
+
+        echo "$output"
+
+        [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
(Temporarily) fixes issue #8477. Commits in the shell created via `\commit` now have the correct time.