### PR TITLE
`dolt archive` updates

### DIFF
--- a/go/store/nbs/archive_build.go
+++ b/go/store/nbs/archive_build.go
@@ -130,7 +130,7 @@ func BuildArchive(ctx context.Context, cs chunks.ChunkStore, dagGroups *ChunkRel
 			return err
 		}
 	} else {
-		return errors.New("Modern DB Expected")
+		return errors.New("runtime error: GenerationalNBS Expected")
 	}
 	return nil
 }
@@ -475,7 +475,8 @@ func compressChunksInParallel(
 					}
 					cmpBuff = gozstd.CompressDict(cmpBuff[:0], c.Data(), defaultDict)
 
-					// Make a private copy of the compressed data
+					// Make a private copy of the compressed data for the result channel.
+					// Unfortunate alloc. Could use a pool of buffers if this proves to be a bottleneck.
 					privateCopy := make([]byte, len(cmpBuff))
 					copy(privateCopy, cmpBuff)
 					resultCh <- compressedChunk{h: h, data: privateCopy}

--- a/go/store/nbs/archive_build.go
+++ b/go/store/nbs/archive_build.go
@@ -161,6 +161,8 @@ func archiveSingleBlockStore(ctx context.Context, bscb func() *NomsBlockStore, d
 			continue
 		}
 
+		progress <- fmt.Sprintf("Archiving TableFile %s\n", tf.String())
+
 		idx, err := cs.index()
 		if err != nil {
 			return err

--- a/go/store/nbs/archive_build.go
+++ b/go/store/nbs/archive_build.go
@@ -385,7 +385,6 @@ func writeDataToArchive(
 				groupCount++
 
 				cmpBuff = gozstd.Compress(cmpBuff[:0], cg.dict)
-
 				dictId, err := arcW.writeByteSpan(cmpBuff)
 				if err != nil {
 					return 0, 0, 0, err
@@ -473,7 +472,11 @@ func compressChunksInParallel(
 						return
 					}
 					cmpBuff = gozstd.CompressDict(cmpBuff[:0], c.Data(), defaultDict)
-					resultCh <- compressedChunk{h: h, data: cmpBuff}
+
+					// Make a private copy of the compressed data
+					privateCopy := make([]byte, len(cmpBuff))
+					copy(privateCopy, cmpBuff)
+					resultCh <- compressedChunk{h: h, data: privateCopy}
 				}
 			}
 		}()

--- a/integration-tests/bats/archive.bats
+++ b/integration-tests/bats/archive.bats
@@ -70,7 +70,7 @@ mutations_and_gc_statement() {
   run dolt archive
   [ "$status" -eq 0 ]
 
-  lines="$(echo "$output" | grep -cE '^Not enough chunks to build archive for [a-z0-9]+\. Skipping\.$')"
+  lines="$(echo "$output" | grep -ci 'Not enough chunks to build archive.*skipping')"
   [ "$lines" -eq "2" ]
 }
 

--- a/integration-tests/bats/archive.bats
+++ b/integration-tests/bats/archive.bats
@@ -68,8 +68,10 @@ mutations_and_gc_statement() {
   dolt gc
 
   run dolt archive
-  [ "$status" -eq 1 ]
-  [[ "$output" =~ "Not enough samples to build default dictionary" ]] || false
+  [ "$status" -eq 0 ]
+
+  lines="$(echo "$output" | grep -cE '^Not enough chunks to build archive for [a-z0-9]+\. Skipping\.$')"
+  [ "$lines" -eq "2" ]
 }
 
 @test "archive: single archive oldgen" {


### PR DESCRIPTION
Convert all files, not just oldgen

Parallelize compression. Results in a moderate improvement in speed, but now we are IO blocked.

Incrementally update the DB table sets after each conversion.