### PR TITLE
Fix 9390, 9391 SELECT * FROM dolt_history_{{ table_name }} filter errors with result max1Row iterator returned more than one row

### DIFF
--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -330,6 +330,7 @@ func DoltHistoryIndexesFromTable(ctx context.Context, db, tbl string, t *doltdb.
 		// weren't asked for (because the index needed may not exist at all revisions)
 		di.order = sql.IndexOrderNone
 		di.constrainedToLookupExpression = false
+		di.unique = false
 		unorderedIndexes[i] = di
 	}
 


### PR DESCRIPTION
Fixes #9390, #9391
Dolt history table indexes are never marked as unique, regardless of the underlying table’s index properties: prevents unique constraints from being incorrectly reported or exported for history tables
