### PR TITLE
Query OK confirmation messages

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -811,7 +811,7 @@ var DoltScripts = []queries.ScriptTest{
 			},
 			{
 				Query:    "SET @hashofdb = dolt_hashof_db();",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "SELECT @hashofdb = dolt_hashof_db('HEAD');",
@@ -868,7 +868,7 @@ var DoltScripts = []queries.ScriptTest{
 
 			{
 				Query:    "SET @hashofdb = dolt_hashof_db();",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "SELECT @hashofdb = dolt_hashof_db('STAGED');",
@@ -918,7 +918,7 @@ var DoltScripts = []queries.ScriptTest{
 
 			{
 				Query:    "SET @hashofdb = dolt_hashof_db();",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "create procedure proc1() SELECT * FROM t3;",
@@ -3411,7 +3411,7 @@ var DoltCheckoutScripts = []queries.ScriptTest{
 			},
 			{
 				Query:    "SET @commit1 = (select commit_hash from dolt_log order by date desc limit 1);",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query: "call dolt_checkout(@commit1, 't1')",
@@ -7510,7 +7510,7 @@ var DoltCommitTests = []queries.ScriptTest{
 			},
 			{
 				Query:    "SET @hash=(SELECT commit_hash FROM dolt_log LIMIT 1);",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "SELECT COUNT(parent_hash) FROM dolt_commit_ancestors WHERE commit_hash= @hash;",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
@@ -1189,7 +1189,7 @@ var MergeScripts = []queries.ScriptTest{
 			},
 			{
 				Query:    "SET dolt_allow_commit_conflicts = 0",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:          "CALL DOLT_MERGE('feature-branch')",
@@ -3559,7 +3559,7 @@ var MergeArtifactsScripts = []queries.ScriptTest{
 			},
 			{
 				Query:    "SET FOREIGN_KEY_CHECKS=0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "UPDATE child set fk = 4;",
@@ -4098,7 +4098,7 @@ var OldFormatMergeConflictsAndCVsScripts = []queries.ScriptTest{
 				// transaction commit constraint violations that occur as a
 				// result of a merge.
 				Query:    "set autocommit = off, dolt_force_transaction_commit = on",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "DELETE FROM parent where pk = 1;",
@@ -4243,7 +4243,7 @@ var OldFormatMergeConflictsAndCVsScripts = []queries.ScriptTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "SET dolt_force_transaction_commit = 1",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "CALL DOLT_MERGE('other');",
@@ -4317,7 +4317,7 @@ var OldFormatMergeConflictsAndCVsScripts = []queries.ScriptTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "SET dolt_force_transaction_commit = 1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "CALL DOLT_MERGE('other');",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_schema_override.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_schema_override.go
@@ -44,7 +44,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// use the tip of main for our response schemas
 				Query:    "SET @@dolt_override_schema=@commit3;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query: "describe t;",
@@ -70,7 +70,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// use the first commit from main for our response schema (pk, c1)
 				Query:    "SET @@dolt_override_schema=@commit1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "select * from t;",
@@ -119,7 +119,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// turn off the schema override
 				Query:    "SET @@dolt_override_schema=NULL;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "select * from t;",
@@ -159,7 +159,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// use the tip of main for our response schema (pk, c1, c2, c3)
 				Query:    "SET @@dolt_override_schema=@commit3;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "select * from t;",
@@ -183,7 +183,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// use the previous commit from main for our response schema (pk, c1, c2)
 				Query:    "SET @@dolt_override_schema=@commit2;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "select * from t;",
@@ -204,7 +204,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// use the first commit from main for our response schemas (pk, c1)
 				Query:    "SET @@dolt_override_schema=@commit1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "select * from t;",
@@ -241,7 +241,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// use @commit2 response schema (pk, c1, c2, c3, c4, c6, c7)
 				Query:    "SET @@dolt_override_schema=@commit2;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "select * from t;",
@@ -274,7 +274,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// use @commit2 response schema (pk, c1, c2, c3, c4, c5, c6, c7)
 				Query:    "SET @@dolt_override_schema=@commit1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "select * from t;",
@@ -326,7 +326,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// use the tip of main for our response schema (pk, c2)
 				Query:    "SET @@dolt_override_schema=@commit2;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "select * from t;",
@@ -343,7 +343,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			},
 			{
 				Query:    "SET @@dolt_override_schema=@commit1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "select * from t;",
@@ -383,7 +383,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// Set an invalid commit that can't be resolved
 				Query:    "SET @@dolt_override_schema=doesNotExist;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:          "select * from t;",
@@ -397,7 +397,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// Set an invalid ancestor spec
 				Query:    "SET @@dolt_override_schema='HEA~D~^~~~';",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:          "select * from t;",
@@ -426,7 +426,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// use the first commit for our response schema (pk, c1)
 				Query:    "SET @@dolt_override_schema=@commit1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "select * from t;",
@@ -461,7 +461,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// use the first commit for our response schema (pk, c1)
 				Query:    "SET @@dolt_override_schema=@commit1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "select * from t;",
@@ -500,7 +500,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// use the tip of main for our response schemas
 				Query:    "SET @@dolt_override_schema=@commit2;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "select * from t;",
@@ -517,7 +517,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			},
 			{
 				Query:    "SET @@dolt_override_schema=@commit1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "select * from t;",
@@ -551,7 +551,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// use the tip of main for our response schemas (int, varchar(100))
 				Query:    "SET @@dolt_override_schema=@commit2;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "select * from t;",
@@ -569,7 +569,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// go back to the first commit, where the schema had a more narrow type (int, varchar(5))
 				Query:    "SET @@dolt_override_schema=@commit1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "select * from t;",
@@ -607,7 +607,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// use the tip of main for our response schemas (int, int)
 				Query:    "SET @@dolt_override_schema=@commit2;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "select * from t;",
@@ -625,7 +625,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// go back to the first commit, where the schema have an incompatible type (int, point)
 				Query:    "SET @@dolt_override_schema=@commit1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:          "select * from t;",
@@ -651,7 +651,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			},
 			{
 				Query:    "SET @@dolt_override_schema=@commit1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:          "SELECT * from addedTable;",
@@ -678,7 +678,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			},
 			{
 				Query:    "SET @@dolt_override_schema=@commit1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "SELECT * from deletedTable;",
@@ -705,7 +705,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			},
 			{
 				Query:    "SET @@dolt_override_schema=@commit1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "SELECT * from deletedTable AS OF @commit2;",
@@ -744,7 +744,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// Set the overridden schema to the point where an index existed
 				Query:    "SET @@dolt_override_schema=@commit1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				// Using the overridden index, we should still get the latest data, but without using the index
@@ -755,7 +755,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// Set the overridden schema to the point where an index existed
 				Query:    "SET @@dolt_override_schema=@commit2;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				// Going back to @commit1 for data, but using @commit2 for schema
@@ -788,7 +788,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// use the tip of main for our response schemas
 				Query:    "SET @@dolt_override_schema=@commit3;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "select * from t as of @commit1;",
@@ -807,7 +807,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// use the previous commit from main for our response schemas
 				Query:    "SET @@dolt_override_schema=@commit1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "select * from t as of @commit2;",
@@ -865,7 +865,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// use the most recent commit for our response schemas (pk, c2)
 				Query:    "SET @@dolt_override_schema=@commit3;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "select * from `mydb/branch3`.t as of @commit1;",
@@ -884,7 +884,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// use the first commit from main for our response schemas (pk, c1)
 				Query:    "SET @@dolt_override_schema=@commit1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "select * from `mydb/branch3`.t as of @commit2;",
@@ -940,7 +940,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// use the most recent commit for our response schemas (pk, c2)
 				Query:    "SET @@dolt_override_schema=@commit3;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "select * from `mydb/commit3`.t as of @commit1;",
@@ -959,7 +959,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// use the first commit from main for our response schemas (pk, c1)
 				Query:    "SET @@dolt_override_schema=@commit1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "select * from `mydb/commit3`.t as of @commit2;",
@@ -1012,7 +1012,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// use the most recent commit for our response schemas (pk, c2)
 				Query:    "SET @@dolt_override_schema=@commit3;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "select * from `mydb/main`.t as of @commit1;",
@@ -1031,7 +1031,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// use the first commit from main for our response schemas (pk, c1)
 				Query:    "SET @@dolt_override_schema=@commit1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "select * from `mydb/main`.t as of @commit2;",
@@ -1085,7 +1085,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// use the tip of main for our response schema (pk, c2)
 				Query:    "SET @@dolt_override_schema=@commit1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				Query:    "SELECT * from t1 JOIN t2 on t1.pk = t2.c1;",
@@ -1134,7 +1134,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			},
 			{
 				Query:    "SET @@dolt_override_schema=@commit1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				// After @@dolt_override_schema is applied, DDL statements error out
@@ -1149,7 +1149,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// Turn off the schema override
 				Query:    "SET @@dolt_override_schema=NULL;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				// Insert statements work again after turning off the schema override
@@ -1181,7 +1181,7 @@ var SchemaOverrideTests = []queries.ScriptTest{
 			{
 				// use the first commit for our schema override (pk, c1)
 				Query:    "SET @@dolt_override_schema=@commit1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{gmstypes.NewOkResult(0)}},
 			},
 			{
 				// sanity check that the schema override is working, before testing the system tables

--- a/go/libraries/doltcore/sqle/enginetest/dolt_transaction_commit_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_transaction_commit_test.go
@@ -46,7 +46,7 @@ func TestDoltTransactionCommitOneClient(t *testing.T) {
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "/* client a */ SET @@autocommit=0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			// start transaction implicitly commits the current transaction, so we have to do so before we turn on dolt commits
 			{
@@ -59,15 +59,15 @@ func TestDoltTransactionCommitOneClient(t *testing.T) {
 			},
 			{
 				Query:    "/* client a */ SET @@dolt_transaction_commit=1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ SET @initial_head=@@mydb_head;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ SET @initial_head=@@mydb_head;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ SELECT @@mydb_head like @initial_head;",
@@ -147,7 +147,7 @@ func TestDoltTransactionCommitOneClient(t *testing.T) {
 			},
 			{
 				Query:    "/* client a */ SET @@dolt_transaction_commit_message='Commit Message 42';",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ create table newTable(pk int primary key);",
@@ -219,11 +219,11 @@ func TestDoltTransactionCommitTwoClients(t *testing.T) {
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "/* client a */ SET @@autocommit=0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ SET @@autocommit=0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			// start transaction implicitly commits the current transaction, so we have to do so before we turn on dolt commits
 			{
@@ -252,19 +252,19 @@ func TestDoltTransactionCommitTwoClients(t *testing.T) {
 			// Now we have the two concurrent transactions commit their changes.
 			{
 				Query:    "/* client a */ SET @@dolt_transaction_commit=1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ SET @@dolt_transaction_commit=1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ SET @initial_head=@@mydb_head;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ SET @initial_head=@@mydb_head;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ INSERT INTO x VALUES (2,2);",
@@ -292,7 +292,7 @@ func TestDoltTransactionCommitTwoClients(t *testing.T) {
 			},
 			{
 				Query:    "/* client b */ SET @@dolt_transaction_commit_message='ClientB Commit';",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ COMMIT;",
@@ -304,7 +304,7 @@ func TestDoltTransactionCommitTwoClients(t *testing.T) {
 			},
 			{
 				Query:    "/* client a */ SET @@dolt_transaction_commit_message='ClientA Commit';",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ COMMIT;",
@@ -395,15 +395,15 @@ func TestDoltTransactionCommitAutocommit(t *testing.T) {
 			// these SET statements currently commit a transaction (since autocommit is on)
 			{
 				Query:    "/* client a */ SET @@dolt_transaction_commit=1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ SET @@dolt_transaction_commit=1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ SET @@dolt_transaction_commit_message='ClientB Commit';",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ INSERT INTO x VALUES (2,2);",
@@ -481,11 +481,11 @@ func TestDoltTransactionCommitLateFkResolution(t *testing.T) {
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "/* client a */ SET @@autocommit=0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ SET @@autocommit=0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ START TRANSACTION;",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_transaction_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_transaction_queries.go
@@ -754,7 +754,7 @@ var DoltTransactionTests = []queries.TransactionTest{
 			{
 				// Turn @@foreign_key_checks back on in client a
 				Query:    "/* client a */ SET @@foreign_key_checks=1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				// Reference the table with an unresolved FK, so that it gets loaded and resolved
@@ -859,7 +859,7 @@ var DoltConflictHandlingTests = []queries.TransactionTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "/* client a */ set autocommit = off",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ start transaction",
@@ -867,7 +867,7 @@ var DoltConflictHandlingTests = []queries.TransactionTest{
 			},
 			{
 				Query:    "/* client b */ set autocommit = off",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ start transaction",
@@ -910,7 +910,7 @@ var DoltConflictHandlingTests = []queries.TransactionTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "/* client a */ set autocommit = off, dolt_allow_commit_conflicts = on",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ start transaction",
@@ -918,7 +918,7 @@ var DoltConflictHandlingTests = []queries.TransactionTest{
 			},
 			{
 				Query:    "/* client b */ set autocommit = off, dolt_allow_commit_conflicts = on",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ start transaction",
@@ -961,7 +961,7 @@ var DoltConflictHandlingTests = []queries.TransactionTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "/* client a */ set autocommit = off, dolt_force_transaction_commit = on",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ start transaction",
@@ -969,7 +969,7 @@ var DoltConflictHandlingTests = []queries.TransactionTest{
 			},
 			{
 				Query:    "/* client b */ set autocommit = off, dolt_force_transaction_commit = on",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ start transaction",
@@ -1012,7 +1012,7 @@ var DoltConflictHandlingTests = []queries.TransactionTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "/* client a */ set autocommit = off, dolt_allow_commit_conflicts = on",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ start transaction",
@@ -1020,7 +1020,7 @@ var DoltConflictHandlingTests = []queries.TransactionTest{
 			},
 			{
 				Query:    "/* client b */ set autocommit = off, dolt_allow_commit_conflicts = on",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ start transaction",
@@ -1107,7 +1107,7 @@ var DoltConflictHandlingTests = []queries.TransactionTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "/* client a */ set autocommit = off, dolt_force_transaction_commit = on",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ start transaction",
@@ -1115,7 +1115,7 @@ var DoltConflictHandlingTests = []queries.TransactionTest{
 			},
 			{
 				Query:    "/* client b */ set autocommit = off, dolt_force_transaction_commit = on",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ start transaction",
@@ -1200,7 +1200,7 @@ var DoltConflictHandlingTests = []queries.TransactionTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "/* client a */ set autocommit = off",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ start transaction",
@@ -1208,7 +1208,7 @@ var DoltConflictHandlingTests = []queries.TransactionTest{
 			},
 			{
 				Query:    "/* client b */ set autocommit = off",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ start transaction",
@@ -1286,11 +1286,11 @@ var DoltConflictHandlingTests = []queries.TransactionTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "/* client a */ SET @@autocommit=0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ SET @@autocommit=0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ SELECT base_pk, base_col1, our_pk, our_col1, their_pk, their_col1 from dolt_conflicts_t;",
@@ -1312,7 +1312,7 @@ var DoltConflictHandlingTests = []queries.TransactionTest{
 			},
 			{
 				Query:    "/* client a */ SET dolt_allow_commit_conflicts = on;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ COMMIT;",
@@ -1493,7 +1493,7 @@ var DoltStoredProcedureTransactionTests = []queries.TransactionTest{
 			},
 			{
 				Query:    "/* client a */ set dolt_allow_commit_conflicts = 1",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ commit",
@@ -1525,7 +1525,7 @@ var DoltStoredProcedureTransactionTests = []queries.TransactionTest{
 			},
 			{
 				Query:    "/* client a */ SET @@dolt_allow_commit_conflicts = 0",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ select * from dolt_preview_merge_conflicts_summary('main', 'feature-branch')",
@@ -1942,7 +1942,7 @@ var DoltStoredProcedureTransactionTests = []queries.TransactionTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "/* client a */ set autocommit = off",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ call dolt_add('t1')",
@@ -1954,7 +1954,7 @@ var DoltStoredProcedureTransactionTests = []queries.TransactionTest{
 			},
 			{
 				Query:    "/* client b */ set autocommit = off",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ start transaction",
@@ -2078,11 +2078,11 @@ var DoltConstraintViolationTransactionTests = []queries.TransactionTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "/* client a */ SET @@autocommit=0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ SET @@autocommit=0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ START TRANSACTION;",
@@ -2175,7 +2175,7 @@ var DoltConstraintViolationTransactionTests = []queries.TransactionTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "/* client a */ SET FOREIGN_KEY_CHECKS = 0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ START TRANSACTION;",
@@ -2205,7 +2205,7 @@ var DoltConstraintViolationTransactionTests = []queries.TransactionTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "/* client a */ SET FOREIGN_KEY_CHECKS = 0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ START TRANSACTION;",
@@ -3088,11 +3088,11 @@ var MultiDbSavepointTests = []queries.TransactionTest{
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "/* client a */ set autocommit = off",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ set autocommit = off",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ start transaction",

--- a/go/libraries/doltcore/sqle/enginetest/prepared_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/prepared_queries.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dolthub/go-mysql-server/enginetest/queries"
 	"github.com/dolthub/go-mysql-server/enginetest/scriptgen/setup"
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,7 +33,8 @@ import (
 func DoltPreparedScripts(t *testing.T, harness enginetest.Harness) {
 	tests := []queries.QueryTest{
 		{
-			Query: "set @@SESSION.dolt_show_system_tables = 1",
+			Query:    "set @@SESSION.dolt_show_system_tables = 1",
+			Expected: []sql.Row{{types.NewOkResult(0)}},
 		},
 		{
 			Query: "SELECT table_name FROM information_schema.columns WHERE table_name = ? group by table_name ORDER BY ORDINAL_POSITION",

--- a/go/libraries/doltcore/sqle/enginetest/sysbench_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/sysbench_test.go
@@ -103,27 +103,27 @@ s_dist_07, s_dist_08, s_dist_09, s_dist_10, s_ytd, s_order_cnt, s_remote_cnt, s_
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query:    "/* client a */ SET SESSION transaction_isolation='REPEATABLE-READ';",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ SET SESSION transaction_isolation='REPEATABLE-READ';",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ SET FOREIGN_KEY_CHECKS=0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ SET FOREIGN_KEY_CHECKS=0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ SET autocommit=0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ SET autocommit=0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ BEGIN;",

--- a/integration-tests/bats/sql-shell.bats
+++ b/integration-tests/bats/sql-shell.bats
@@ -1038,3 +1038,33 @@ expect eof
         run $BATS_TEST_DIRNAME/sql-shell-commit-time.expect
         [ "$status" -eq 0 ]
 }
+
+@test "sql-shell: CREATE TABLE should show Query OK confirmation" {
+    run dolt sql -q "CREATE TABLE test_table (id int primary key, name varchar(50))"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Query OK, 0 rows affected" ]] || false
+}
+
+@test "sql-shell: CREATE TRIGGER should show Query OK confirmation" {
+    # First create the table that the trigger will reference
+    dolt sql -q "CREATE TABLE trigger_test (id int primary key, name varchar(50))"
+    
+    run dolt sql -q "CREATE TRIGGER test_trigger BEFORE INSERT ON trigger_test FOR EACH ROW SET NEW.name = UPPER(NEW.name)"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Query OK, 0 rows affected" ]] || false
+}
+
+@test "sql-shell: ALTER TABLE should show Query OK confirmation" {
+    # First create the table to alter
+    dolt sql -q "CREATE TABLE alter_test (id int primary key)"
+    
+    run dolt sql -q "ALTER TABLE alter_test ADD COLUMN name varchar(50)"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Query OK, 0 rows affected" ]] || false
+}
+
+@test "sql-shell: SET should show Query OK confirmation" {
+    run dolt sql -q "SET @@session.autocommit = 1"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Query OK, 0 rows affected" ]] || false
+}


### PR DESCRIPTION
`dolt sql` changes to properly print "Query OK" messages when we do things like create tables and triggers.

Depends on: https://github.com/dolthub/go-mysql-server/pull/3046

Fixes: https://github.com/dolthub/dolt/issues/9281