### PR TITLE
Add indexes to dolt_commit_diff_ tables that include the primary key of the underlying table

### DIFF
--- a/go/libraries/doltcore/sqle/dtablefunctions/dolt_diff.go
+++ b/go/libraries/doltcore/sqle/dtablefunctions/dolt_diff.go
@@ -186,7 +186,8 @@ func (dtf *DiffTableFunction) RowIter(ctx *sql.Context, _ sql.Row) (sql.RowIter,
 	}
 
 	ddb := sqledb.DbData().Ddb
-	dp := dtables.NewDiffPartition(dtf.tableDelta.ToTable, dtf.tableDelta.FromTable, toCommitStr, fromCommitStr, dtf.toDate, dtf.fromDate, dtf.tableDelta.ToSch, dtf.tableDelta.FromSch)
+	var indexLookup sql.IndexLookup
+	dp := dtables.NewDiffPartition(dtf.tableDelta.ToTable, dtf.tableDelta.FromTable, toCommitStr, fromCommitStr, dtf.toDate, dtf.fromDate, dtf.tableDelta.ToSch, dtf.tableDelta.FromSch, indexLookup)
 
 	return dtables.NewDiffPartitionRowIter(dp, ddb, dtf.joiner), nil
 }

--- a/go/libraries/doltcore/sqle/dtablefunctions/dolt_patch.go
+++ b/go/libraries/doltcore/sqle/dtablefunctions/dolt_patch.go
@@ -635,7 +635,8 @@ func getDiffQuery(ctx *sql.Context, dbData env.DbData[*sql.Context], td diff.Tab
 	columnsWithDiff := getColumnNamesWithDiff(td.FromSch, td.ToSch)
 	diffQuerySqlSch, projections := getDiffQuerySqlSchemaAndProjections(diffPKSch.Schema, columnsWithDiff)
 
-	dp := dtables.NewDiffPartition(td.ToTable, td.FromTable, toRefDetails.hashStr, fromRefDetails.hashStr, toRefDetails.commitTime, fromRefDetails.commitTime, td.ToSch, td.FromSch)
+	var indexLookup sql.IndexLookup
+	dp := dtables.NewDiffPartition(td.ToTable, td.FromTable, toRefDetails.hashStr, fromRefDetails.hashStr, toRefDetails.commitTime, fromRefDetails.commitTime, td.ToSch, td.FromSch, indexLookup)
 	ri := dtables.NewDiffPartitionRowIter(dp, dbData.Ddb, j)
 
 	return diffQuerySqlSch, projections, ri, nil

--- a/go/libraries/doltcore/sqle/dtables/column_diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/column_diff_table.go
@@ -527,7 +527,8 @@ func calculateColDelta(ctx *sql.Context, ddb *doltdb.DoltDB, delta *diff.TableDe
 
 	now := time.Now() // accurate commit time returned elsewhere
 	// TODO: schema name?
-	dp := NewDiffPartition(delta.ToTable, delta.FromTable, delta.ToName.Name, delta.FromName.Name, (*dtypes.Timestamp)(&now), (*dtypes.Timestamp)(&now), delta.ToSch, delta.FromSch)
+	var indexLookup sql.IndexLookup
+	dp := NewDiffPartition(delta.ToTable, delta.FromTable, delta.ToName.Name, delta.FromName.Name, (*dtypes.Timestamp)(&now), (*dtypes.Timestamp)(&now), delta.ToSch, delta.FromSch, indexLookup)
 	ri := NewDiffPartitionRowIter(dp, ddb, j)
 
 	var resultColNames []string

--- a/go/libraries/doltcore/sqle/dtables/commit_diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/commit_diff_table.go
@@ -41,6 +41,7 @@ type CommitDiffTable struct {
 	tableName   doltdb.TableName
 	dbName      string
 	ddb         *doltdb.DoltDB
+	table       *doltdb.Table
 	joiner      *rowconv.Joiner
 	sqlSch      sql.PrimaryKeySchema
 	workingRoot doltdb.RootValue
@@ -85,6 +86,7 @@ func NewCommitDiffTable(ctx *sql.Context, dbName string, tblName doltdb.TableNam
 	return &CommitDiffTable{
 		dbName:       dbName,
 		tableName:    tblName,
+		table:        table,
 		ddb:          ddb,
 		workingRoot:  wRoot,
 		stagedRoot:   sRoot,
@@ -126,7 +128,11 @@ func (dt *CommitDiffTable) Collation() sql.CollationID {
 
 // GetIndexes implements sql.IndexAddressable
 func (dt *CommitDiffTable) GetIndexes(ctx *sql.Context) ([]sql.Index, error) {
-	return []sql.Index{index.DoltToFromCommitIndex(dt.tableName.Name)}, nil
+	sch, err := dt.table.GetSchema(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return index.DoltToFromCommitIndexes(dt.tableName.Name, sch), nil
 }
 
 // IndexedAccess implements sql.IndexAddressable
@@ -153,7 +159,7 @@ func (dt *CommitDiffTable) LookupPartitions(ctx *sql.Context, i sql.IndexLookup)
 	if !ok {
 		return nil, fmt.Errorf("commit diff table requires MySQL ranges")
 	}
-	if len(ranges) != 1 || len(ranges[0]) != 2 {
+	if len(ranges) != 1 || len(ranges[0]) < 2 {
 		return nil, ErrInvalidCommitDiffTableArgs
 	}
 	to := ranges[0][0]
@@ -214,6 +220,7 @@ func (dt *CommitDiffTable) LookupPartitions(ctx *sql.Context, i sql.IndexLookup)
 		fromDate: fromDate,
 		toSch:    dt.targetSchema,
 		fromSch:  dt.targetSchema,
+		lookup:   i,
 	}
 
 	isDiffable, _, err := dp.isDiffablePartition(ctx)
@@ -303,5 +310,5 @@ func (dt *CommitDiffTable) rootValForHash(ctx *sql.Context, hashStr string) (dol
 
 func (dt *CommitDiffTable) PartitionRows(ctx *sql.Context, part sql.Partition) (sql.RowIter, error) {
 	dp := part.(DiffPartition)
-	return dp.GetRowIter(ctx, dt.ddb, dt.joiner, sql.IndexLookup{})
+	return dp.GetRowIter(ctx, dt.ddb, dt.joiner)
 }

--- a/go/libraries/doltcore/sqle/dtables/diff_iter.go
+++ b/go/libraries/doltcore/sqle/dtables/diff_iter.go
@@ -265,6 +265,8 @@ func newProllyDiffIter(ctx *sql.Context, dp DiffPartition, targetFromSchema, tar
 	var err error
 	if lookup.Index != nil {
 		for i := range lookup.Ranges.(sql.MySQLRangeCollection) {
+			// The first two columns of the index (to_commit and from_commit) don't actually exist on the underlying table.
+			// We strip them out here so that we can generate the correct ranges for the eventual Diff.
 			lookup.Ranges.(sql.MySQLRangeCollection)[i] = lookup.Ranges.(sql.MySQLRangeCollection)[i][2:]
 		}
 		ranges, err = index.ProllyRangesFromIndexLookup(ctx, lookup)

--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -218,7 +218,7 @@ func DoltToFromCommitIndexes(tbl string, sch schema.Schema) (indexes []sql.Index
 			order:                         sql.IndexOrderNone,
 			constrainedToLookupExpression: false,
 			// We pass a nil ValueStore into the key builder, because we don't have one. This would cause an issue
-			// if any of the columns uss Adaptive encoding, but that shouldn't be possible in the primary key.
+			// if any of the columns use Adaptive encoding, but that shouldn't be possible in the primary key.
 			keyBld: val.NewTupleBuilder(sch.GetKeyDescriptor(nil), nil),
 		})
 	}

--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -197,19 +197,32 @@ func DoltDiffIndexesFromTable(ctx context.Context, db, tbl string, t *doltdb.Tab
 	return indexes, nil
 }
 
-func DoltToFromCommitIndex(tbl string) sql.Index {
-	return &doltIndex{
-		id:      "commits",
-		tblName: doltdb.DoltCommitDiffTablePrefix + tbl,
-		columns: []schema.Column{
+func DoltToFromCommitIndexes(tbl string, sch schema.Schema) (indexes []sql.Index) {
+	for _, toFrom := range []string{"to", "from"} {
+		cols := make([]schema.Column, 0, len(sch.GetAllCols().GetColumns())+2)
+		cols = append(cols,
 			schema.NewColumn(ToCommitIndexId, schema.DiffCommitTag, types.StringKind, false),
 			schema.NewColumn(FromCommitIndexId, schema.DiffCommitTag, types.StringKind, false),
-		},
-		unique:                        true,
-		comment:                       "",
-		order:                         sql.IndexOrderNone,
-		constrainedToLookupExpression: false,
+		)
+		for _, col := range sch.GetPKCols().GetColumns() {
+			col.Name = toFrom + "_" + col.Name
+			cols = append(cols, col)
+		}
+
+		indexes = append(indexes, &doltIndex{
+			id:                            "commits_" + toFrom,
+			tblName:                       doltdb.DoltCommitDiffTablePrefix + tbl,
+			columns:                       cols,
+			unique:                        true,
+			comment:                       "",
+			order:                         sql.IndexOrderNone,
+			constrainedToLookupExpression: false,
+			// We pass a nil ValueStore into the key builder, because we don't have one. This would cause an issue
+			// if any of the columns uss Adaptive encoding, but that shouldn't be possible in the primary key.
+			keyBld: val.NewTupleBuilder(sch.GetKeyDescriptor(nil), nil),
+		})
 	}
+	return indexes
 }
 
 // MockIndex returns a sql.Index that is not backed by an actual datastore. It's useful for system tables and

--- a/integration-tests/bats/sql-commit-diff.bats
+++ b/integration-tests/bats/sql-commit-diff.bats
@@ -80,7 +80,6 @@ teardown() {
 
     run dolt sql -q "select from_pk1, from_pk2, to_pk1, to_pk2, diff_type from dolt_commit_diff_test_two_pk where from_commit = DOLT_HASHOF('initial') and to_commit = DOLT_HASHOF('update') and from_pk1 = 2;"
     [ $status -eq 0 ]
-    echo "$output"
     [[ "${#lines[@]}" = "6" ]] # 2 rows + 4 formatting lines
     [[ "$output" =~ "| 2        | 21       | 2      | 21     | modified  |" ]] || false
     [[ "$output" =~ "| 2        | 20       | NULL   | NULL   | removed   |" ]] || false

--- a/integration-tests/bats/sql-commit-diff.bats
+++ b/integration-tests/bats/sql-commit-diff.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+load $BATS_TEST_DIRNAME/helper/common.bash
+
+setup() {
+    setup_common
+
+    dolt sql <<SQL
+CREATE TABLE test (
+    pk int primary key,
+    v int
+);
+
+CREATE TABLE test_two_pk (
+    pk1 int,
+    pk2 int,
+    v int,
+    primary key (pk1, pk2)
+);
+
+CALL DOLT_ADD('.');
+CALL DOLT_COMMIT('-m', 'create table');
+CALL DOLT_BRANCH('create');
+
+INSERT INTO test VALUES (10, 10), (11, 11), (20, 20), (21, 21), (30, 30), (31, 31);
+INSERT INTO test_two_pk (pk1, pk2) VALUES (1, 10), (1, 11), (2, 20), (2, 21), (3, 30), (3, 31);
+CALL DOLT_ADD('.');
+CALL DOLT_COMMIT('-m', 'initial values');
+CALL DOLT_BRANCH('initial');
+
+INSERT INTO test VALUES (12, 12), (22, 22), (32, 32);
+INSERT INTO test_two_pk (pk1, pk2) VALUES (1, 12), (2, 22), (3, 32);
+DELETE FROM test WHERE pk = 1 OR pk = 20 OR pk = 30;
+DELETE FROM test_two_pk WHERE pk2 = 10 OR pk2 = 20 OR pk2 = 30;
+UPDATE test SET v = 0 WHERE pk = 11 OR pk = 21 OR pk = 31;
+UPDATE test_two_pk SET v = 1 WHERE pk2 = 11 OR pk2 = 21 OR pk2 = 31;
+
+CALL DOLT_ADD('.');
+CALL DOLT_COMMIT('-m', 'update values');
+CALL DOLT_BRANCH('update');
+SQL
+}
+
+teardown() {
+    assert_feature_version
+    teardown_common
+}
+
+@test "sql-commit-diff: DOLT_COMMIT_DIFF with a range on to_ key" {
+    run dolt sql -q "select from_pk, to_pk, diff_type from dolt_commit_diff_test where from_commit = DOLT_HASHOF('initial') and to_commit = DOLT_HASHOF('update') and to_pk > 12 and to_pk < 30;"
+    [ $status -eq 0 ]
+    [[ "${#lines[@]}" = "6" ]] # 2 rows + 4 formatting lines
+    [[ "$output" =~ "| NULL    | 22    | added     |" ]] || false
+    [[ "$output" =~ "| 21      | 21    | modified  |" ]] || false
+    run dolt sql -q "describe plan select * from dolt_commit_diff_test where from_commit = DOLT_HASHOF('create') and to_commit = DOLT_HASHOF('head') and to_pk > 0 and to_pk < 5;"
+    [ $status -eq 0 ]
+    [[ "$output" =~ "index: [dolt_commit_diff_test.to_commit,dolt_commit_diff_test.from_commit,dolt_commit_diff_test.to_pk]" ]] || false
+    [[ "$output" =~ "(0, 5)" ]] || false
+
+    run dolt sql -q "select from_pk1, from_pk2, to_pk1, to_pk2, diff_type from dolt_commit_diff_test_two_pk where from_commit = DOLT_HASHOF('initial') and to_commit = DOLT_HASHOF('update') and to_pk1 = 2;"
+    [ $status -eq 0 ]
+    [[ "${#lines[@]}" = "6" ]] # 2 rows + 4 formatting lines
+    [[ "$output" =~ "| 2        | 21       | 2      | 21     | modified  |" ]] || false
+    [[ "$output" =~ "| NULL     | NULL     | 2      | 22     | added     |" ]] || false
+    run dolt sql -q "describe plan select * from dolt_commit_diff_test_two_pk where from_commit = DOLT_HASHOF('create') and to_commit = DOLT_HASHOF('head') and to_pk1 = 2;"
+    [ $status -eq 0 ]
+    [[ "$output" =~ "index: [dolt_commit_diff_test_two_pk.to_commit,dolt_commit_diff_test_two_pk.from_commit,dolt_commit_diff_test_two_pk.to_pk1,dolt_commit_diff_test_two_pk.to_pk2]" ]] || false
+    [[ "$output" =~ "[2, 2], [NULL, ∞)" ]] || false
+}
+
+@test "sql-commit-diff: DOLT_COMMIT_DIFF with a range on from_ key" {
+    run dolt sql -q "select from_pk, to_pk, diff_type from dolt_commit_diff_test where from_commit = DOLT_HASHOF('initial') and to_commit = DOLT_HASHOF('update') and from_pk > 12 and from_pk < 30;"
+    [ $status -eq 0 ]
+    [[ "${#lines[@]}" = "6" ]] # 2 rows + 4 formatting lines
+    [[ "$output" =~ "| 20      | NULL  | removed   |" ]] || false
+    [[ "$output" =~ "| 21      | 21    | modified  |" ]] || false
+    run dolt sql -q "describe plan select * from dolt_commit_diff_test where from_commit = DOLT_HASHOF('create') and to_commit = DOLT_HASHOF('head') and from_pk > 0 and from_pk < 5;"
+    [ $status -eq 0 ]
+    [[ "$output" =~ "index: [dolt_commit_diff_test.to_commit,dolt_commit_diff_test.from_commit,dolt_commit_diff_test.from_pk]" ]] || false
+    [[ "$output" =~ "(0, 5)" ]] || false
+
+    run dolt sql -q "select from_pk1, from_pk2, to_pk1, to_pk2, diff_type from dolt_commit_diff_test_two_pk where from_commit = DOLT_HASHOF('initial') and to_commit = DOLT_HASHOF('update') and from_pk1 = 2;"
+    [ $status -eq 0 ]
+    echo "$output"
+    [[ "${#lines[@]}" = "6" ]] # 2 rows + 4 formatting lines
+    [[ "$output" =~ "| 2        | 21       | 2      | 21     | modified  |" ]] || false
+    [[ "$output" =~ "| 2        | 20       | NULL   | NULL   | removed   |" ]] || false
+    run dolt sql -q "describe plan select * from dolt_commit_diff_test_two_pk where from_commit = DOLT_HASHOF('create') and to_commit = DOLT_HASHOF('head') and from_pk1 = 2;"
+    [ $status -eq 0 ]
+    [[ "$output" =~ "index: [dolt_commit_diff_test_two_pk.to_commit,dolt_commit_diff_test_two_pk.from_commit,dolt_commit_diff_test_two_pk.from_pk1,dolt_commit_diff_test_two_pk.from_pk2]" ]] || false
+    [[ "$output" =~ "[2, 2], [NULL, ∞)" ]] || false
+}


### PR DESCRIPTION
The `dolt_commit_diff_` system tables allow for comparing a table at two different commits. They require a filter on the `to_commit` and `from_commit` fields, which the table exposes as an index.

This PR extends those indexes to have additional columns based on the primary keys of the underlying table. This allows a user to efficiently compare only a specific range of that table.

Specifically, if the table's primary key columns are named `pk1`, `pk2`, ... `pkN`, then the system table now provides two indexes:

- `to_commit`, `from_commit`, `from_pk1`, `from_pk2`... `from_pkN`
- `to_commit`, `from_commit`, `to_pk1`, `to_pk2`... `to_pkN`

If the select filter uses a prefix of either of these indexes, then we can implement the select as a Diff on only the intended range.

Because the `to_` columns are NULL for removed rows, and the `from_` columns are NULL for inserted rows, a filter on the `from_` columns will only return modifications and deletions, and a filter on the `to_` columns will only return modifications and additions. In hindsight, perhaps the primary key rows should have appeared in the diff as a single column instead of both a `to_` and `from_` column, but that ship has sailed.

As for the implementation, I don't love the fact that code paths that diff the entire table without accepting a range pass around a zero-valued `sql.Lookup`, which we then detect by checking to see if `lookup.index == nil`. It's a code smell for sure. But I couldn't think of a better way to do it.