### PR TITLE
Improve `dolt checkout` error handling for missing tables

### DIFF
--- a/go/cmd/dolt/commands/checkout.go
+++ b/go/cmd/dolt/commands/checkout.go
@@ -226,6 +226,8 @@ func handleErrors(branchName string, err error) errhand.VerboseError {
 		return errhand.VerboseErrorFromError(err)
 	} else if strings.Contains(err.Error(), "error: could not find") {
 		return errhand.VerboseErrorFromError(err)
+	} else if strings.Contains(err.Error(), "did not match any table") {
+		return errhand.VerboseErrorFromError(err)
 	} else if doltdb.IsRootValUnreachable(err) {
 		return errhand.VerboseErrorFromError(err)
 	} else if actions.IsCheckoutWouldOverwrite(err) {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -3486,6 +3486,34 @@ var DoltCheckoutScripts = []queries.ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "dolt_checkout multiple tables with one missing",
+		SetUpScript: []string{
+			"create table t1 (pk int primary key, c int);",
+			"call dolt_commit('-Am', 'created table');",
+			"insert into t1 values (1,1);",
+			"call dolt_commit('-am', 'add row');",
+			"insert into t1 values (2,2);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:          "call dolt_checkout('t1', 'missing');",
+				ExpectedErrStr: "error: tablespec 'missing' did not match any table(s) known to dolt",
+			},
+			{
+				Query:    "select * from t1 order by 1;",
+				Expected: []sql.Row{{1, 1}},
+			},
+			{
+				Query:          "call dolt_checkout('t1', 'missing', 'missing2');",
+				ExpectedErrStr: "error: tablespec 'missing' did not match any table(s) known to dolt\nerror: tablespec 'missing2' did not match any table(s) known to dolt",
+			},
+			{
+				Query:          "call dolt_checkout('--', 'missing', 't1', 'missing2');",
+				ExpectedErrStr: "error: tablespec 'missing' did not match any table(s) known to dolt\nerror: tablespec 'missing2' did not match any table(s) known to dolt",
+			},
+		},
+	},
 }
 
 var DoltCheckoutReadOnlyScripts = []queries.ScriptTest{


### PR DESCRIPTION
Fix #9392 

 ###  Summary

  Enhances the dolt_checkout stored procedure to handle missing table specifications
   more gracefully by processing valid tables while providing detailed warnings for
  invalid ones, instead of failing immediately on the first missing table.

###   Changes Made

  - Enhanced Error Handling: Modified checkoutTablesFromHead() to collect warnings
  for missing tables instead of failing fast
  - Improved User Experience: Valid tables are now processed successfully even when
  some specified tables don't exist
  - Better Error Reporting: Multiple missing tables now show aggregated error
  messages
  - Added Test Coverage: Comprehensive tests for single and multiple missing table
  scenarios


###   Behavior Changes

  Before: call `dolt checkout valid_table missing_table` would fail entirely
  After: call `dolt_checkout valid_table missing_table` processes valid_table
  and returns warning about missing_table