### PR TITLE
Add @GLOBAL.dolt_auto_gc_enabled system variable to inspect whether auto GC is enabled.

### DIFF
--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -229,6 +229,13 @@ func NewSqlEngine(
 		pro.DropDatabaseHooks = append(pro.DropDatabaseHooks, config.AutoGCController.DropDatabaseHook())
 		// XXX: We force session aware safepoint controller if auto_gc is on.
 		dprocedures.UseSessionAwareSafepointController = true
+		sql.SystemVariables.AssignValues(map[string]interface{}{
+			dsess.DoltAutoGCEnabled: int8(1),
+		})
+	} else {
+		sql.SystemVariables.AssignValues(map[string]interface{}{
+			dsess.DoltAutoGCEnabled: int8(0),
+		})
 	}
 
 	var statsPro sql.StatsProvider

--- a/go/libraries/doltcore/sqle/dsess/variables.go
+++ b/go/libraries/doltcore/sqle/dsess/variables.go
@@ -66,6 +66,8 @@ const (
 	DoltStatsJobInterval = "dolt_stats_job_interval"
 	DoltStatsGCInterval  = "dolt_stats_gc_interval"
 	DoltStatsGCEnabled   = "dolt_stats_gc_enabled"
+
+	DoltAutoGCEnabled = "dolt_auto_gc_enabled"
 )
 
 const URLTemplateDatabasePlaceholder = "{database}"

--- a/go/libraries/doltcore/sqle/system_variables.go
+++ b/go/libraries/doltcore/sqle/system_variables.go
@@ -268,6 +268,13 @@ var DoltSystemVariables = []sql.SystemVariable{
 		Type:    types.NewSystemStringType(dsess.DoltStatsBranches),
 		Default: "",
 	},
+	&sql.MysqlSystemVariable{
+		Name:    dsess.DoltAutoGCEnabled,
+		Dynamic: false,
+		Scope:   sql.GetMysqlScope(sql.SystemVariableScope_Global),
+		Type:    types.NewSystemBoolType(dsess.DoltAutoGCEnabled),
+		Default: int8(0),
+	},
 }
 
 func AddDoltSystemVariables() {

--- a/integration-tests/go-sql-server-driver/tests/sql-server-config.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-config.yaml
@@ -284,6 +284,42 @@ tests:
       result:
         columns: ["@@GLOBAL.dolt_log_level"]
         rows: [["info"]]
+- name: "@@global.dolt_auto_gc_enabled false"
+  repos:
+  - name: repo1
+    server:
+      args: ["-P", '{{get_port "repo1"}}']
+      dynamic_port: repo1
+  connections:
+  - on: repo1
+    queries:
+    - query: "select @@GLOBAL.dolt_auto_gc_enabled"
+      result:
+        columns: ["@@GLOBAL.dolt_auto_gc_enabled"]
+        rows: [[0]]
+    - exec: "SET @@GLOBAL.dolt_auto_gc_enabled = 1"
+      error_match: "Variable 'dolt_auto_gc_enabled' is a read only variable"
+- name: "@@global.dolt_auto_gc_enabled true"
+  repos:
+  - name: repo1
+    with_files:
+      - name: "config.yaml"
+        contents: |
+          behavior:
+            auto_gc_behavior:
+              enable: true
+          listener:
+            port: {{get_port "repo1"}}
+    server:
+      args: ["--config", "config.yaml"]
+      dynamic_port: repo1
+  connections:
+  - on: repo1
+    queries:
+    - query: "select @@GLOBAL.dolt_auto_gc_enabled"
+      result:
+        columns: ["@@GLOBAL.dolt_auto_gc_enabled"]
+        rows: [[1]]
 - name: system variables in config.yaml can be read in show variables
   repos:
   - name: repo1


### PR DESCRIPTION
The system variable is read-only. The only way to enable Auto GC remains setting:

behavior:
  auto_gc_behavior:
    enable: true

in the config.yaml file which is given to `dolt sql-server` in its `--config` parameter.