### PR TITLE
[no-release-notes] NewGen -> OldGen admin script

### DIFF
--- a/go/cmd/dolt/commands/admin/admin.go
+++ b/go/cmd/dolt/commands/admin/admin.go
@@ -24,5 +24,6 @@ var Commands = cli.NewHiddenSubCommandHandler("admin", "Commands for directly wo
 	ShowRootCmd{},
 	ZstdCmd{},
 	StorageCmd{},
+	NewGenToOldGenCmd{},
 	createchunk.Commands,
 })

--- a/go/cmd/dolt/commands/admin/newgen_to_oldgen.go
+++ b/go/cmd/dolt/commands/admin/newgen_to_oldgen.go
@@ -37,7 +37,7 @@ func (cmd NewGenToOldGenCmd) Name() string {
 
 var newGenToOldGenDocs = cli.CommandDocumentationContent{
 	ShortDesc: "Promote everything in newgen to oldgen. Skips GC.",
-	LongDesc:  `Admin command to force the promotion of all tables in the new generation to the old generation.`,
+	LongDesc:  `Admin command to force the promotion of all table files in the new generation to the old generation.`,
 	Synopsis:  []string{},
 }
 

--- a/go/cmd/dolt/commands/admin/newgen_to_oldgen.go
+++ b/go/cmd/dolt/commands/admin/newgen_to_oldgen.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Dolthub, Inc.
+// Copyright 2025 Dolthub, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/go/cmd/dolt/commands/admin/newgen_to_oldgen.go
+++ b/go/cmd/dolt/commands/admin/newgen_to_oldgen.go
@@ -19,13 +19,14 @@ import (
 	"os"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 	"github.com/dolthub/dolt/go/store/datas"
 	"github.com/dolthub/dolt/go/store/nbs"
-	"golang.org/x/sync/errgroup"
 )
 
 type NewGenToOldGenCmd struct {

--- a/go/cmd/dolt/commands/admin/newgen_to_oldgen.go
+++ b/go/cmd/dolt/commands/admin/newgen_to_oldgen.go
@@ -1,0 +1,163 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admin
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/env"
+	"github.com/dolthub/dolt/go/libraries/utils/argparser"
+	"github.com/dolthub/dolt/go/store/datas"
+	"github.com/dolthub/dolt/go/store/nbs"
+)
+
+type NewGenToOldGenCmd struct {
+}
+
+func (cmd NewGenToOldGenCmd) Name() string {
+	return "newgen-to-oldgen"
+}
+
+var newGenToOldGenDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Promote everything in newgen to oldgen. Skips GC.",
+	LongDesc:  `Admin command to force the promotion of all tables in the new generation to the old generation.`,
+	Synopsis:  []string{},
+}
+
+// Description returns a description of the command
+func (cmd NewGenToOldGenCmd) Description() string {
+	return "Admin command to move all storage from newgen to oldgen."
+}
+func (cmd NewGenToOldGenCmd) RequiresRepo() bool {
+	return true
+}
+func (cmd NewGenToOldGenCmd) Docs() *cli.CommandDocumentation {
+	ap := cmd.ArgParser()
+	return cli.NewCommandDocumentation(newGenToOldGenDocs, ap)
+}
+
+func (cmd NewGenToOldGenCmd) ArgParser() *argparser.ArgParser {
+	ap := argparser.NewArgParserWithMaxArgs(cmd.Name(), 0)
+	return ap
+}
+func (cmd NewGenToOldGenCmd) Hidden() bool {
+	return true
+}
+
+func (cmd NewGenToOldGenCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
+	db := doltdb.HackDatasDatabaseFromDoltDB(dEnv.DoltDB(ctx))
+	cs := datas.ChunkStoreFromDatabase(db)
+	if _, ok := cs.(*nbs.GenerationalNBS); !ok {
+		cli.PrintErrln("compare-and-swap-storage command requires a GenerationalNBS")
+		return 1
+	}
+
+	wg := sync.WaitGroup{}
+	progress := make(chan interface{}, 32)
+	handleNewGenToOldGenProgress(ctx, &wg, progress)
+
+	defer func() {
+		close(progress)
+		wg.Wait()
+		os.Stdout.Sync()
+		os.Stderr.Sync()
+	}()
+
+	err := nbs.MoveNewGenToOldGen(ctx, cs, progress)
+	if err != nil {
+		cli.PrintErrf("Error during newgen-to-oldgen: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+// NM4 - update to be more cas specfific.
+func handleNewGenToOldGenProgress(ctx context.Context, wg *sync.WaitGroup, progress chan interface{}) {
+	go func() {
+		wg.Add(1)
+		defer wg.Done()
+
+		rotation := 0
+		p := cli.NewEphemeralPrinter()
+		currentMessage := "Converting NewGen to OldGen"
+		var lastProgressMsg *nbs.ArchiveBuildProgressMsg
+		lastUpdateTime := time.Now()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case msg, ok := <-progress:
+				if !ok {
+					return
+				}
+				switch v := msg.(type) {
+				case string:
+					cli.Printf("%s\n", v)
+				case nbs.ArchiveBuildProgressMsg:
+					if v.Total == v.Completed {
+						p.Printf("%s: Done\n", v.Stage)
+						lastProgressMsg = nil
+						currentMessage = ""
+						p.Display()
+						cli.Printf("\n")
+					} else {
+						lastProgressMsg = &v
+					}
+				default:
+					cli.Printf("Unexpected Message: %v\n", v)
+				}
+			// If no events come in, we still want to update the progress bar every second.
+			case <-time.After(1 * time.Second):
+			}
+
+			if now := time.Now(); now.Sub(lastUpdateTime) > 1*time.Second {
+				rotation++
+				switch rotation % 4 {
+				case 0:
+					p.Printf("- ")
+				case 1:
+					p.Printf("\\ ")
+				case 2:
+					p.Printf("| ")
+				case 3:
+					p.Printf("/ ")
+				}
+
+				if lastProgressMsg != nil {
+					percentDone := 0.0
+					totalCount := lastProgressMsg.Total
+					if lastProgressMsg.Total > 0 {
+						percentDone = float64(lastProgressMsg.Completed) / float64(lastProgressMsg.Total)
+						percentDone *= 100.0
+					}
+
+					currentMessage = fmt.Sprintf("%s: %d/%d (%.2f%%)", lastProgressMsg.Stage, lastProgressMsg.Completed, totalCount, percentDone)
+				}
+
+				p.Printf("%s", currentMessage) // Don't update message, but allow ticker to turn.
+				lastUpdateTime = now
+
+				p.Display()
+			}
+		}
+	}()
+}

--- a/go/store/nbs/admin_newgen_to_oldgen.go
+++ b/go/store/nbs/admin_newgen_to_oldgen.go
@@ -1,0 +1,114 @@
+// Copyright 2025 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nbs
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/hash"
+)
+
+func MoveNewGenToOldGen(
+	ctx context.Context,
+	cs chunks.ChunkStore,
+	progress chan interface{},
+) error {
+	if gs, ok := cs.(*GenerationalNBS); ok {
+		srcPath, _ := gs.newGen.Path()
+		dstPath, _ := gs.oldGen.Path()
+
+		allFiles := make([]hash.Hash, 0, len(gs.newGen.tables.upstream))
+		sourceSet := gs.newGen.tables.upstream
+		for tf := range sourceSet {
+			allFiles = append(allFiles, tf)
+		}
+
+		for _, h := range allFiles {
+			fileName := h.String()
+			arcExists, err := archiveFileExists(ctx, srcPath, h.String())
+			if err != nil {
+				return err
+			}
+			if arcExists {
+				fileName = fileName + ArchiveFileSuffix
+			}
+
+			srcFile := filepath.Join(srcPath, fileName)
+			dstFile := filepath.Join(dstPath, fileName)
+
+			progress <- "Moving " + srcFile + " to " + dstFile
+
+			err = nonAtomicSwap(ctx, h, gs.newGen, gs.oldGen, srcFile, dstFile)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		return errors.New("runtime error: GenerationalNBS Expected")
+	}
+	return nil
+}
+
+func nonAtomicSwap(ctx context.Context, id hash.Hash, src, dst *NomsBlockStore, srcPath, dstPath string) error {
+	srcSpecs, err := src.tables.toSpecs()
+	if err != nil {
+		return err
+	}
+
+	specFound := false
+	var movedTs tableSpec
+	newSrcSpecs := make([]tableSpec, 0, len(srcSpecs)-1)
+	for _, spec := range srcSpecs {
+		if id == spec.name {
+			movedTs = spec
+			specFound = true
+		} else {
+			newSrcSpecs = append(newSrcSpecs, spec)
+		}
+	}
+
+	if !specFound {
+		return errors.New("table spec not found in source: " + id.String())
+	}
+
+	dstSpecs, err := dst.tables.toSpecs()
+	if err != nil {
+		return err
+	}
+	newDstSpecs := make([]tableSpec, 0, len(dstSpecs)+1)
+	for _, spec := range dstSpecs {
+		newDstSpecs = append(newDstSpecs, spec)
+	}
+	// Add the moved table spec to the destination specs
+	newDstSpecs = append(newDstSpecs, movedTs)
+
+	err = src.swapTables(ctx, newSrcSpecs, chunks.GCMode_Default)
+	if err != nil {
+		return err
+	}
+	err = os.Rename(srcPath, dstPath)
+	if err != nil {
+		return err
+	}
+	err = dst.swapTables(ctx, newDstSpecs, chunks.GCMode_Default)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/go/store/nbs/admin_newgen_to_oldgen.go
+++ b/go/store/nbs/admin_newgen_to_oldgen.go
@@ -27,7 +27,7 @@ import (
 func MoveNewGenToOldGen(
 	ctx context.Context,
 	cs chunks.ChunkStore,
-	progress chan interface{},
+	progress chan string,
 ) error {
 	if gs, ok := cs.(*GenerationalNBS); ok {
 		srcPath, _ := gs.newGen.Path()

--- a/go/store/nbs/admin_newgen_to_oldgen.go
+++ b/go/store/nbs/admin_newgen_to_oldgen.go
@@ -36,6 +36,9 @@ func MoveNewGenToOldGen(
 		allFiles := make([]hash.Hash, 0, len(gs.newGen.tables.upstream))
 		sourceSet := gs.newGen.tables.upstream
 		for tf := range sourceSet {
+			if isJournalAddr(tf) {
+				continue
+			}
 			allFiles = append(allFiles, tf)
 		}
 


### PR DESCRIPTION
GC is prohibitively expensive for the media_wiki repo, and we know that the table files downloaded from DoltHub don't contain garbage. This admin tool moves everything from newgen to oldgen so that GC won't spend it's time on moving chunks we know aren't garbage.