### PR TITLE
go/store/nbs: Improve GC behavior when non-persisted changes have been made to the store.

### DIFF
--- a/go/store/nbs/bs_manifest.go
+++ b/go/store/nbs/bs_manifest.go
@@ -17,7 +17,6 @@ package nbs
 import (
 	"bytes"
 	"context"
-	"errors"
 
 	"github.com/dolthub/dolt/go/store/blobstore"
 	"github.com/dolthub/dolt/go/store/chunks"
@@ -87,18 +86,7 @@ func (bsm blobstoreManifest) Update(ctx context.Context, lastLock hash.Hash, new
 }
 
 func (bsm blobstoreManifest) UpdateGCGen(ctx context.Context, lastLock hash.Hash, newContents manifestContents, stats *Stats, writeHook func() error) (manifestContents, error) {
-	checker := func(upstream, contents manifestContents) error {
-		if contents.gcGen == upstream.gcGen {
-			return errors.New("UpdateGCGen() must update the garbage collection generation")
-		}
-
-		if contents.root != upstream.root {
-			return errors.New("UpdateGCGen() cannot update the root")
-		}
-		return nil
-	}
-
-	return updateBSWithChecker(ctx, bsm.bs, checker, lastLock, newContents, writeHook)
+	return updateBSWithChecker(ctx, bsm.bs, updateGCGenManifestCheck, lastLock, newContents, writeHook)
 }
 
 func updateBSWithChecker(ctx context.Context, bs blobstore.Blobstore, validate manifestChecker, lastLock hash.Hash, newContents manifestContents, writeHook func() error) (mc manifestContents, err error) {

--- a/go/store/nbs/file_manifest.go
+++ b/go/store/nbs/file_manifest.go
@@ -207,16 +207,7 @@ func (fm fileManifest) UpdateGCGen(ctx context.Context, lastLock hash.Hash, newC
 		}
 	}()
 
-	checker := func(upstream, contents manifestContents) error {
-		if contents.gcGen == upstream.gcGen {
-			return errors.New("UpdateGCGen() must update the garbage collection generation")
-		} else if contents.root != upstream.root {
-			return errors.New("UpdateGCGen() cannot update the root")
-		}
-		return nil
-	}
-
-	return updateWithChecker(ctx, fm.dir, fm.mode, checker, lastLock, newContents, writeHook)
+	return updateWithChecker(ctx, fm.dir, fm.mode, updateGCGenManifestCheck, lastLock, newContents, writeHook)
 }
 
 // parseV5Manifest parses the v5 manifest from the Reader given. Assumes the first field (the manifest version and

--- a/go/store/nbs/journal.go
+++ b/go/store/nbs/journal.go
@@ -640,15 +640,21 @@ func (jm *journalManifest) UpdateGCGen(ctx context.Context, lastLock hash.Hash, 
 
 	t1 := time.Now()
 	defer func() { stats.WriteManifestLatency.SampleTimeSince(t1) }()
-	checker := func(upstream, contents manifestContents) error {
-		if contents.gcGen == upstream.gcGen {
-			return errors.New("UpdateGCGen() must update the garbage collection generation")
-		} else if contents.root != upstream.root {
-			return errors.New("UpdateGCGen() cannot update the root")
-		}
+	return updateWithChecker(ctx, jm.dir, syncFlush, updateGCGenManifestCheck, lastLock, newContents, writeHook)
+}
+
+func updateGCGenManifestCheck(upstream, contents manifestContents) error {
+	if contents.root != upstream.root {
+		return errors.New("UpdateGCGen() cannot update the root")
+	} else if contents.gcGen == upstream.gcGen {
+		// Allow a no-op update.  These can happen
+		// when we went through a GC cycle because the
+		// store had novelty (novel upstreams,
+		// memtables), but the end state was still the
+		// same as what was in the manifest.
 		return nil
 	}
-	return updateWithChecker(ctx, jm.dir, syncFlush, checker, lastLock, newContents, writeHook)
+	return nil
 }
 
 func (jm *journalManifest) Close() (err error) {


### PR DESCRIPTION
GC has a fast-path check so that it performs a noop if there have been no changes to the database since the last time GC ran successfully. This change improves those checks so that GC works appropriately in more cases. In particular:

1) When GC is running against a database that has in-flight writes, it will now still run, potentially collecting garbage created by the inflight writes, instead of not doing anything.

2) When GC is running against a database that has a journal file, but where the journal file has never been persisted into the state of the manifest of the database because it only has inflight writes which have never committed or updated the root, GC will now run appropriately and will collect the contents of the journal file if it is appropriate to do so.