### PR TITLE
Small ci fixes

### DIFF
--- a/go/cmd/dolt/commands/ci/destroy.go
+++ b/go/cmd/dolt/commands/ci/destroy.go
@@ -17,14 +17,13 @@ package ci
 import (
 	"context"
 	"fmt"
-	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
-
-	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions/dolt_ci"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands"
+	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
+	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions/dolt_ci"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
 )
 

--- a/go/cmd/dolt/commands/ci/destroy.go
+++ b/go/cmd/dolt/commands/ci/destroy.go
@@ -16,6 +16,8 @@ package ci
 
 import (
 	"context"
+	"fmt"
+	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions/dolt_ci"
 
@@ -84,6 +86,13 @@ func (cmd DestroyCmd) Exec(ctx context.Context, commandStr string, args []string
 	}
 	if closeFunc != nil {
 		defer closeFunc()
+
+		_, ok := queryist.(*engine.SqlEngine)
+		if !ok {
+			msg := fmt.Sprintf(cli.RemoteUnsupportedMsg, commandStr)
+			cli.Println(msg)
+			return 1
+		}
 	}
 
 	db, err := newDatabase(sqlCtx, sqlCtx.GetCurrentDatabase(), dEnv, false)

--- a/go/cmd/dolt/commands/ci/export.go
+++ b/go/cmd/dolt/commands/ci/export.go
@@ -17,6 +17,7 @@ package ci
 import (
 	"context"
 	"fmt"
+	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 	"io"
 	"os"
 	"path/filepath"
@@ -97,6 +98,13 @@ func (cmd ExportCmd) Exec(ctx context.Context, commandStr string, args []string,
 	}
 	if closeFunc != nil {
 		defer closeFunc()
+
+		_, ok := queryist.(*engine.SqlEngine)
+		if !ok {
+			msg := fmt.Sprintf(cli.RemoteUnsupportedMsg, commandStr)
+			cli.Println(msg)
+			return 1
+		}
 	}
 
 	user, email, err := env.GetNameAndEmail(dEnv.Config)

--- a/go/cmd/dolt/commands/ci/export.go
+++ b/go/cmd/dolt/commands/ci/export.go
@@ -17,7 +17,6 @@ package ci
 import (
 	"context"
 	"fmt"
-	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 	"io"
 	"os"
 	"path/filepath"
@@ -27,6 +26,7 @@ import (
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands"
+	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions/dolt_ci"

--- a/go/cmd/dolt/commands/ci/import.go
+++ b/go/cmd/dolt/commands/ci/import.go
@@ -17,7 +17,6 @@ package ci
 import (
 	"context"
 	"fmt"
-	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 	"os"
 	"path/filepath"
 	"strings"
@@ -26,6 +25,7 @@ import (
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands"
+	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions/dolt_ci"

--- a/go/cmd/dolt/commands/ci/import.go
+++ b/go/cmd/dolt/commands/ci/import.go
@@ -17,6 +17,7 @@ package ci
 import (
 	"context"
 	"fmt"
+	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 	"os"
 	"path/filepath"
 	"strings"
@@ -100,6 +101,13 @@ func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string,
 	}
 	if closeFunc != nil {
 		defer closeFunc()
+
+		_, ok := queryist.(*engine.SqlEngine)
+		if !ok {
+			msg := fmt.Sprintf(cli.RemoteUnsupportedMsg, commandStr)
+			cli.Println(msg)
+			return 1
+		}
 	}
 
 	user, email, err := env.GetNameAndEmail(dEnv.Config)

--- a/go/cmd/dolt/commands/ci/init.go
+++ b/go/cmd/dolt/commands/ci/init.go
@@ -17,6 +17,7 @@ package ci
 import (
 	"context"
 	"fmt"
+
 	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"

--- a/go/cmd/dolt/commands/ci/init.go
+++ b/go/cmd/dolt/commands/ci/init.go
@@ -17,6 +17,7 @@ package ci
 import (
 	"context"
 	"fmt"
+	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands"
@@ -84,6 +85,13 @@ func (cmd InitCmd) Exec(ctx context.Context, commandStr string, args []string, d
 	}
 	if closeFunc != nil {
 		defer closeFunc()
+
+		_, ok := queryist.(*engine.SqlEngine)
+		if !ok {
+			msg := fmt.Sprintf(cli.RemoteUnsupportedMsg, commandStr)
+			cli.Println(msg)
+			return 1
+		}
 	}
 
 	db, err := newDatabase(sqlCtx, sqlCtx.GetCurrentDatabase(), dEnv, false)

--- a/go/cmd/dolt/commands/ci/ls.go
+++ b/go/cmd/dolt/commands/ci/ls.go
@@ -17,12 +17,12 @@ package ci
 import (
 	"context"
 	"fmt"
-	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 
 	"github.com/fatih/color"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands"
+	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions/dolt_ci"

--- a/go/cmd/dolt/commands/ci/ls.go
+++ b/go/cmd/dolt/commands/ci/ls.go
@@ -17,6 +17,7 @@ package ci
 import (
 	"context"
 	"fmt"
+	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 
 	"github.com/fatih/color"
 
@@ -86,6 +87,13 @@ func (cmd ListCmd) Exec(ctx context.Context, commandStr string, args []string, d
 	}
 	if closeFunc != nil {
 		defer closeFunc()
+
+		_, ok := queryist.(*engine.SqlEngine)
+		if !ok {
+			msg := fmt.Sprintf(cli.RemoteUnsupportedMsg, commandStr)
+			cli.Println(msg)
+			return 1
+		}
 	}
 
 	db, err := newDatabase(sqlCtx, sqlCtx.GetCurrentDatabase(), dEnv, false)

--- a/go/cmd/dolt/commands/ci/remove.go
+++ b/go/cmd/dolt/commands/ci/remove.go
@@ -17,6 +17,7 @@ package ci
 import (
 	"context"
 	"fmt"
+
 	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"

--- a/go/cmd/dolt/commands/ci/remove.go
+++ b/go/cmd/dolt/commands/ci/remove.go
@@ -17,6 +17,7 @@ package ci
 import (
 	"context"
 	"fmt"
+	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands"
@@ -91,6 +92,13 @@ func (cmd RemoveCmd) Exec(ctx context.Context, commandStr string, args []string,
 	}
 	if closeFunc != nil {
 		defer closeFunc()
+
+		_, ok := queryist.(*engine.SqlEngine)
+		if !ok {
+			msg := fmt.Sprintf(cli.RemoteUnsupportedMsg, commandStr)
+			cli.Println(msg)
+			return 1
+		}
 	}
 
 	user, email, err := env.GetNameAndEmail(dEnv.Config)

--- a/go/libraries/doltcore/doltdb/system_table.go
+++ b/go/libraries/doltcore/doltdb/system_table.go
@@ -591,7 +591,7 @@ const (
 	WorkflowSavedQueryStepExpectedRowColumnResultsExpectedColumnCountComparisonTypeColName = "expected_column_count_comparison_type"
 
 	// WorkflowSavedQueryStepExpectedRowColumnResultsExpectedRowCountComparisonTypeColName is the name of the expected row count comparison type column on the workflow saved query step expected row column results table
-	WorkflowSavedQueryStepExpectedRowColumnResultsExpectedRowCountComparisonTypeColName = "expected_column_row_comparison_type"
+	WorkflowSavedQueryStepExpectedRowColumnResultsExpectedRowCountComparisonTypeColName = "expected_row_count_comparison_type"
 
 	// WorkflowSavedQueryStepExpectedRowColumnResultsExpectedColumnCountColName is the name of the expected column count column on the workflow saved query step expected row column results table
 	WorkflowSavedQueryStepExpectedRowColumnResultsExpectedColumnCountColName = "expected_column_count"

--- a/integration-tests/bats/ci.bats
+++ b/integration-tests/bats/ci.bats
@@ -228,7 +228,7 @@ EOF
     [ "$status" -eq 0 ]
     [[ ${output} == *"(new)"* ]] || false
     [[ ${output} == *"dolt_ci_workflow_steps"* ]] || false
-    [[ ${output} == *"expected_column_row_comparison_type"* ]] || false
+    [[ ${output} == *"expected_row_count_comparison_type"* ]] || false
     [[ ${output} == *"dolt_ci_workflow_saved_query_step_expected_row_column_results"* ]] || false
 }
 


### PR DESCRIPTION
This PR fixes 2 small issues with the CI commands:

1. Currently the CI commands panic if you have an open server or shell. I added a temporary fix so that the commands just error early, similar to checkout.
2. There was a typo in the `dolt_ci_workflow_saved_query_step_expected_row_column_results`. 