### PR TITLE
Optimize dolt_diff_ tables for lookups on primary key ranges.

### DIFF
--- a/go/libraries/doltcore/sqle/dtablefunctions/dolt_diff.go
+++ b/go/libraries/doltcore/sqle/dtablefunctions/dolt_diff.go
@@ -186,8 +186,7 @@ func (dtf *DiffTableFunction) RowIter(ctx *sql.Context, _ sql.Row) (sql.RowIter,
 	}
 
 	ddb := sqledb.DbData().Ddb
-	var indexLookup sql.IndexLookup
-	dp := dtables.NewDiffPartition(dtf.tableDelta.ToTable, dtf.tableDelta.FromTable, toCommitStr, fromCommitStr, dtf.toDate, dtf.fromDate, dtf.tableDelta.ToSch, dtf.tableDelta.FromSch, indexLookup)
+	dp := dtables.NewDiffPartition(dtf.tableDelta.ToTable, dtf.tableDelta.FromTable, toCommitStr, fromCommitStr, dtf.toDate, dtf.fromDate, dtf.tableDelta.ToSch, dtf.tableDelta.FromSch, nil)
 
 	return dtables.NewDiffPartitionRowIter(dp, ddb, dtf.joiner), nil
 }

--- a/go/libraries/doltcore/sqle/dtablefunctions/dolt_patch.go
+++ b/go/libraries/doltcore/sqle/dtablefunctions/dolt_patch.go
@@ -635,8 +635,7 @@ func getDiffQuery(ctx *sql.Context, dbData env.DbData[*sql.Context], td diff.Tab
 	columnsWithDiff := getColumnNamesWithDiff(td.FromSch, td.ToSch)
 	diffQuerySqlSch, projections := getDiffQuerySqlSchemaAndProjections(diffPKSch.Schema, columnsWithDiff)
 
-	var indexLookup sql.IndexLookup
-	dp := dtables.NewDiffPartition(td.ToTable, td.FromTable, toRefDetails.hashStr, fromRefDetails.hashStr, toRefDetails.commitTime, fromRefDetails.commitTime, td.ToSch, td.FromSch, indexLookup)
+	dp := dtables.NewDiffPartition(td.ToTable, td.FromTable, toRefDetails.hashStr, fromRefDetails.hashStr, toRefDetails.commitTime, fromRefDetails.commitTime, td.ToSch, td.FromSch, nil)
 	ri := dtables.NewDiffPartitionRowIter(dp, dbData.Ddb, j)
 
 	return diffQuerySqlSch, projections, ri, nil

--- a/go/libraries/doltcore/sqle/dtables/column_diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/column_diff_table.go
@@ -527,8 +527,7 @@ func calculateColDelta(ctx *sql.Context, ddb *doltdb.DoltDB, delta *diff.TableDe
 
 	now := time.Now() // accurate commit time returned elsewhere
 	// TODO: schema name?
-	var indexLookup sql.IndexLookup
-	dp := NewDiffPartition(delta.ToTable, delta.FromTable, delta.ToName.Name, delta.FromName.Name, (*dtypes.Timestamp)(&now), (*dtypes.Timestamp)(&now), delta.ToSch, delta.FromSch, indexLookup)
+	dp := NewDiffPartition(delta.ToTable, delta.FromTable, delta.ToName.Name, delta.FromName.Name, (*dtypes.Timestamp)(&now), (*dtypes.Timestamp)(&now), delta.ToSch, delta.FromSch, nil)
 	ri := NewDiffPartitionRowIter(dp, ddb, j)
 
 	var resultColNames []string

--- a/go/libraries/doltcore/sqle/dtables/diff_iter.go
+++ b/go/libraries/doltcore/sqle/dtables/diff_iter.go
@@ -235,7 +235,7 @@ var _ sql.RowIter = prollyDiffIter{}
 // than |targetFromSchema| or |targetToSchema|. We convert the rows from the
 // schema of |from| to |targetFromSchema| and the schema of |to| to
 // |targetToSchema|. See the tablediff_prolly package.
-func newProllyDiffIter(ctx *sql.Context, dp DiffPartition, targetFromSchema, targetToSchema schema.Schema, lookup sql.IndexLookup) (prollyDiffIter, error) {
+func newProllyDiffIter(ctx *sql.Context, dp DiffPartition, targetFromSchema, targetToSchema schema.Schema, ranges []prolly.Range) (prollyDiffIter, error) {
 	fromCm := commitInfo2{
 		name: dp.fromName,
 		ts:   (*time.Time)(dp.fromDate),
@@ -257,16 +257,6 @@ func newProllyDiffIter(ctx *sql.Context, dp DiffPartition, targetFromSchema, tar
 			return prollyDiffIter{}, err
 		}
 		if fsch, err = dp.from.GetSchema(ctx); err != nil {
-			return prollyDiffIter{}, err
-		}
-	}
-
-	var ranges []prolly.Range
-	lookup = copyIndexLookupWithoutCommitRanges(lookup)
-	if lookup.Index != nil {
-		var err error
-		ranges, err = index.ProllyRangesFromIndexLookup(ctx, lookup)
-		if err != nil {
 			return prollyDiffIter{}, err
 		}
 	}

--- a/go/libraries/doltcore/sqle/dtables/diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/diff_table.go
@@ -166,6 +166,10 @@ func (dt *DiffTable) Collation() sql.CollationID {
 }
 
 func (dt *DiffTable) Partitions(ctx *sql.Context) (sql.PartitionIter, error) {
+	return dt.PartitionRanges(ctx, nil)
+}
+
+func (dt *DiffTable) PartitionRanges(ctx *sql.Context, ranges []prolly.Range) (sql.PartitionIter, error) {
 	cmItr := doltdb.CommitItrForRoots[*sql.Context](dt.ddb, dt.head)
 
 	sf, err := SelectFuncForFilters(ctx, dt.ddb.ValueReadWriter(), dt.partitionFilters)
@@ -206,6 +210,7 @@ func (dt *DiffTable) Partitions(ctx *sql.Context) (sql.PartitionIter, error) {
 		selectFunc:      sf,
 		toSch:           dt.targetSch,
 		fromSch:         dt.targetSch,
+		ranges:          ranges,
 	}, nil
 }
 
@@ -278,7 +283,11 @@ func (dt *DiffTable) LookupPartitions(ctx *sql.Context, lookup sql.IndexLookup) 
 		}
 		return dt.fromCommitLookupPartitions(ctx, hashes, commits)
 	default:
-		return dt.Partitions(ctx)
+		ranges, err := index.ProllyRangesFromIndexLookup(ctx, lookup)
+		if err != nil {
+			return nil, err
+		}
+		return dt.PartitionRanges(ctx, ranges)
 	}
 }
 
@@ -653,10 +662,10 @@ type DiffPartition struct {
 	// fromSch and toSch are usually identical. It is the schema of the table at head.
 	toSch   schema.Schema
 	fromSch schema.Schema
-	lookup  sql.IndexLookup
+	ranges  []prolly.Range
 }
 
-func NewDiffPartition(to, from *doltdb.Table, toName, fromName string, toDate, fromDate *types.Timestamp, toSch, fromSch schema.Schema, lookup sql.IndexLookup) *DiffPartition {
+func NewDiffPartition(to, from *doltdb.Table, toName, fromName string, toDate, fromDate *types.Timestamp, toSch, fromSch schema.Schema, ranges []prolly.Range) *DiffPartition {
 	return &DiffPartition{
 		to:       to,
 		from:     from,
@@ -666,7 +675,7 @@ func NewDiffPartition(to, from *doltdb.Table, toName, fromName string, toDate, f
 		fromDate: fromDate,
 		toSch:    toSch,
 		fromSch:  fromSch,
-		lookup:   lookup,
+		ranges:   ranges,
 	}
 }
 
@@ -676,11 +685,7 @@ func (dp DiffPartition) Key() []byte {
 }
 
 func (dp DiffPartition) GetRowIter(ctx *sql.Context, ddb *doltdb.DoltDB, joiner *rowconv.Joiner) (sql.RowIter, error) {
-	if types.IsFormat_DOLT(ddb.Format()) {
-		return newProllyDiffIter(ctx, dp, dp.fromSch, dp.toSch, dp.lookup)
-	} else {
-		return newLdDiffIter(ctx, ddb, joiner, dp, dp.lookup)
-	}
+	return newProllyDiffIter(ctx, dp, dp.fromSch, dp.toSch, dp.ranges)
 }
 
 // isDiffablePartition checks if the commit pair for this partition is "diffable".
@@ -775,6 +780,7 @@ type DiffPartitions struct {
 	toSch           schema.Schema
 	fromSch         schema.Schema
 	stopNext        bool
+	ranges          []prolly.Range
 }
 
 // processCommit is called in a commit iteration loop. Adds partitions when it finds a commit and its parent that have
@@ -807,6 +813,7 @@ func (dps *DiffPartitions) processCommit(ctx *sql.Context, cmHash hash.Hash, cm 
 			fromDate: &ts,
 			fromSch:  dps.fromSch,
 			toSch:    dps.toSch,
+			ranges:   dps.ranges,
 		}
 		selected, err := dps.selectFunc(ctx, partition)
 

--- a/go/libraries/doltcore/sqle/enginetest/dolt_query_plans.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_query_plans.go
@@ -39,6 +39,15 @@ var DoltDiffPlanTests = []queries.QueryPlanTest{
 			"",
 	},
 	{
+		Query: `select * from dolt_diff_one_pk where from_pk>=10 and from_pk<=100`,
+		ExpectedPlan: "Filter\n" +
+			" ├─ ((dolt_diff_one_pk.from_pk >= 10) AND (dolt_diff_one_pk.from_pk <= 100))\n" +
+			" └─ IndexedTableAccess(dolt_diff_one_pk)\n" +
+			"     ├─ index: [dolt_diff_one_pk.from_pk]\n" +
+			"     └─ filters: [{[10, 100]}]\n" +
+			"",
+	},
+	{
 		Query: `select * from dolt_diff_two_pk where to_pk1=1`,
 		ExpectedPlan: "Filter\n" +
 			" ├─ (dolt_diff_two_pk.to_pk1 = 1)\n" +
@@ -63,6 +72,15 @@ var DoltDiffPlanTests = []queries.QueryPlanTest{
 			" └─ IndexedTableAccess(dolt_diff_two_pk)\n" +
 			"     ├─ index: [dolt_diff_two_pk.to_pk1,dolt_diff_two_pk.to_pk2]\n" +
 			"     └─ filters: [{(NULL, 1), (10, ∞)}]\n" +
+			"",
+	},
+	{
+		Query: `select * from dolt_diff_two_pk where from_pk1 < 1 and from_pk2 = 10`,
+		ExpectedPlan: "Filter\n" +
+			" ├─ ((dolt_diff_two_pk.from_pk1 < 1) AND (dolt_diff_two_pk.from_pk2 = 10))\n" +
+			" └─ IndexedTableAccess(dolt_diff_two_pk)\n" +
+			"     ├─ index: [dolt_diff_two_pk.from_pk1,dolt_diff_two_pk.from_pk2]\n" +
+			"     └─ filters: [{(NULL, 1), [10, 10]}]\n" +
 			"",
 	},
 }


### PR DESCRIPTION
The `dolt_diff_` tables expose an index that matches the primary keys of the underlying table. We even already have tests that this index gets chosen for select expressions that limit the key to a specific value or range.

However, in practice this index wasn't actually used.

As of this PR, the index will actually be used to optimize the ranges that are scanned at each commit.

I'm not sure of an obvious way to test this: ordinarily I'd add a test that a query selects the index and returns the correct answer (and I added such a test for the index on the `from_` keys)... but the engine was already using the index and then discarding it.