### PR TITLE
Unskip feature version bats test that now passes

### DIFF
--- a/integration-tests/bats/feature-version.bats
+++ b/integration-tests/bats/feature-version.bats
@@ -105,7 +105,6 @@ SQL
 }
 
 @test "feature-version: older client maintains access to feature branch" {
-    skip https://github.com/dolthub/dolt/issues/6303
     setup_remote_tests
 
     pushd clone_repo


### PR DESCRIPTION
It looks like someone has fixed this feature version issue and Codex identified it:

https://github.com/dolthub/dolt/issues/6303