### PR TITLE
[DRAFT] Root Object Conflicts & Merging

### DIFF
--- a/go/cmd/dolt/commands/merge.go
+++ b/go/cmd/dolt/commands/merge.go
@@ -558,7 +558,7 @@ func printConflictsAndViolations(tblToStats map[string]*merge.MergeStats) (confl
 	for tblName, stats := range tblToStats {
 		if stats.HasArtifacts() {
 			cli.Println("Auto-merging", tblName)
-			if stats.HasDataConflicts() {
+			if stats.HasDataConflicts() || stats.HasRootObjectConflicts() {
 				cli.Println("CONFLICT (content): Merge conflict in", tblName)
 				hasConflicts = true
 			}

--- a/go/libraries/doltcore/doltdb/root_object.go
+++ b/go/libraries/doltcore/doltdb/root_object.go
@@ -18,13 +18,26 @@ import (
 	"context"
 
 	"github.com/dolthub/dolt/go/store/hash"
+
+	"github.com/dolthub/go-mysql-server/sql"
 )
 
 // RootObject is an object that is located on the root, rather than inside another object (table, schema, etc.). This is
 // primarily used by Doltgres to store root-level objects (sequences, functions, etc.).
 type RootObject interface {
+	// HasConflicts returns whether the root object contains conflicts.
+	HasConflicts(ctx context.Context) (bool, error)
 	// HashOf returns the hash of the underlying struct.
 	HashOf(ctx context.Context) (hash.Hash, error)
-	// Name returns the name of the custom table.
+	// Name returns the name of the root object.
 	Name() TableName
+}
+
+// ConflictRootObject is a RootObject that contains conflict information.
+type ConflictRootObject interface {
+	RootObject
+	// Schema returns the schema that should be displayed.
+	Schema(originatingTableName string) sql.Schema
+	// Rows returns the rows that represent conflicting portions of a root object.
+	Rows(ctx *sql.Context) (sql.RowIter, error)
 }

--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -70,6 +70,10 @@ type RootValue interface {
 	GetCollation(ctx context.Context) (schema.Collation, error)
 	// GetRootObject will retrieve a root object by its case-sensitive name.
 	GetRootObject(ctx context.Context, objName TableName) (RootObject, bool, error)
+	// GetRootObjectConflicts will retrieve a conflict root object by its case-sensitive name.
+	GetRootObjectConflicts(ctx context.Context, tName TableName) (ConflictRootObject, bool, error)
+	// GetRootObjectsWithConflicts retrieves all root objects that have conflicts.
+	GetRootObjectsWithConflicts(ctx context.Context) ([]RootObject, error)
 	// GetDatabaseSchemas returns all schemas. These differ from a table's schema.
 	GetDatabaseSchemas(ctx context.Context) ([]schema.DatabaseSchema, error)
 	// GetFeatureVersion returns the feature version of this root, if one is written
@@ -306,6 +310,16 @@ func (root *rootValue) SetCollation(ctx context.Context, collation schema.Collat
 // GetRootObject is only used by Doltgres.
 func (root *rootValue) GetRootObject(ctx context.Context, tName TableName) (RootObject, bool, error) {
 	return nil, false, nil
+}
+
+// GetRootObjectConflicts is only used by Doltgres.
+func (root *rootValue) GetRootObjectConflicts(ctx context.Context, tName TableName) (ConflictRootObject, bool, error) {
+	return nil, false, nil
+}
+
+// GetRootObjectsWithConflicts is only used by Doltgres.
+func (root *rootValue) GetRootObjectsWithConflicts(ctx context.Context) ([]RootObject, error) {
+	return nil, nil
 }
 
 func (root *rootValue) GetTableSchemaHash(ctx context.Context, tName TableName) (hash.Hash, error) {

--- a/go/libraries/doltcore/merge/merge_stats.go
+++ b/go/libraries/doltcore/merge/merge_stats.go
@@ -30,6 +30,7 @@ type MergeStats struct {
 	Modifications        int
 	DataConflicts        int
 	SchemaConflicts      int
+	RootObjectConflicts  int
 	ConstraintViolations int
 }
 
@@ -38,7 +39,7 @@ func (ms *MergeStats) HasArtifacts() bool {
 }
 
 func (ms *MergeStats) HasConflicts() bool {
-	return ms.HasDataConflicts() || ms.HasSchemaConflicts()
+	return ms.HasDataConflicts() || ms.HasSchemaConflicts() || ms.HasRootObjectConflicts()
 }
 
 func (ms *MergeStats) HasDataConflicts() bool {
@@ -47,6 +48,10 @@ func (ms *MergeStats) HasDataConflicts() bool {
 
 func (ms *MergeStats) HasSchemaConflicts() bool {
 	return ms.SchemaConflicts > 0
+}
+
+func (ms *MergeStats) HasRootObjectConflicts() bool {
+	return ms.RootObjectConflicts > 0
 }
 
 func (ms *MergeStats) HasConstraintViolations() bool {

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -476,7 +476,16 @@ func (db Database) getTableInsensitive(ctx *sql.Context, head *doltdb.Commit, ds
 		if err != nil {
 			return nil, false, err
 		} else if !ok {
-			return nil, false, nil
+			// If we can't find a normal table, then we'll check for a root object
+			rootObject, ok, err := root.GetRootObjectConflicts(ctx, doltdb.TableName{Name: baseTableName, Schema: db.schemaName})
+			if !ok || err != nil {
+				return nil, false, err
+			}
+			dt, err := dtables.NewConflictsTableRootObject(ctx, baseTableName, rootObject, root, dtables.RootSetter(db))
+			if err != nil {
+				return nil, false, err
+			}
+			return dt, true, nil
 		}
 		dt, err := dtables.NewConflictsTable(ctx, tname, srcTable, root, dtables.RootSetter(db))
 		if err != nil {

--- a/go/libraries/doltcore/sqle/dtables/conflicts_tables_root_objects.go
+++ b/go/libraries/doltcore/sqle/dtables/conflicts_tables_root_objects.go
@@ -1,0 +1,157 @@
+// Copyright 2025 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dtables
+
+import (
+	"io"
+	"errors"
+
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+)
+
+// NewConflictsTableRootObject returns a new conflicts table for root objects.
+func NewConflictsTableRootObject(ctx *sql.Context, baseTableName string, rootObject doltdb.ConflictRootObject, root doltdb.RootValue, rs RootSetter) (sql.Table, error) {
+	return ConflictsTableRootObject{
+		baseTableName: baseTableName,
+		sqlSch:        rootObject.Schema(baseTableName),
+		root:          root,
+		rootObject:    rootObject,
+		rs:            rs,
+	}, nil
+}
+
+// ConflictsTableRootObject is a sql.Table implementation that provides access to the conflicts that exist on a root
+// object.
+type ConflictsTableRootObject struct {
+	baseTableName string
+	sqlSch        sql.Schema
+	root          doltdb.RootValue
+	rootObject    doltdb.ConflictRootObject
+	rs            RootSetter
+}
+
+var _ sql.Table = ConflictsTableRootObject{}
+var _ sql.DeletableTable = ConflictsTableRootObject{}
+
+// Name implements the interface sql.Table.
+func (ct ConflictsTableRootObject) Name() string {
+	return ct.baseTableName
+}
+
+// String implements the interface sql.Table.
+func (ct ConflictsTableRootObject) String() string {
+	return ct.baseTableName
+}
+
+// Schema implements the interface sql.Table.
+func (ct ConflictsTableRootObject) Schema() sql.Schema {
+	return ct.sqlSch
+}
+
+// Collation implements the interface sql.Table.
+func (ct ConflictsTableRootObject) Collation() sql.CollationID {
+	return sql.Collation_Default
+}
+
+// Partitions implements the interface sql.Table.
+func (ct ConflictsTableRootObject) Partitions(ctx *sql.Context) (sql.PartitionIter, error) {
+	return &conflictRootObjectPartitionIter{
+		table: ct,
+		done:  false,
+	}, nil
+}
+
+// PartitionRows implements the interface sql.Table.
+func (ct ConflictsTableRootObject) PartitionRows(ctx *sql.Context, part sql.Partition) (sql.RowIter, error) {
+	conflictPart, ok := part.(conflictRootObjectPartition)
+	if !ok {
+		return nil, errors.New("unexpected partition type for root object conflicts table")
+	}
+	return conflictPart.table.rootObject.Rows(ctx)
+}
+
+// Deleter implements the interface sql.DeletableTable.
+func (ct ConflictsTableRootObject) Deleter(ctx *sql.Context) sql.RowDeleter {
+	return &conflictRootObjectDeleter{}
+}
+
+// conflictRootObjectPartitionIter is a partition iterator for ConflictsTableRootObject.
+type conflictRootObjectPartitionIter struct {
+	table ConflictsTableRootObject
+	done  bool
+}
+
+var _ sql.PartitionIter = (*conflictRootObjectPartitionIter)(nil)
+
+// Next implements the interface sql.PartitionIter.
+func (itr *conflictRootObjectPartitionIter) Next(ctx *sql.Context) (sql.Partition, error) {
+	if !itr.done {
+		itr.done = true
+		return conflictRootObjectPartition{itr.table}, nil
+	}
+	return nil, io.EOF
+}
+
+// Close implements the interface sql.PartitionIter.
+func (itr *conflictRootObjectPartitionIter) Close(*sql.Context) error {
+	return nil
+}
+
+// conflictRootObjectPartition is a partition for conflictRootObjectPartitionIter.
+type conflictRootObjectPartition struct {
+	table ConflictsTableRootObject
+}
+
+var _ sql.Partition = conflictRootObjectPartition{}
+
+// Key implements the interface sql.Partition.
+func (c conflictRootObjectPartition) Key() []byte {
+	return []byte{1}
+}
+
+type conflictRootObjectDeleter struct {
+	ct ConflictsTable
+	rs RootSetter
+}
+
+var _ sql.RowDeleter = &conflictRootObjectDeleter{}
+
+// Delete deletes the given row. Returns ErrDeleteRowNotFound if the row was not found. Delete will be called once for
+// each row to process for the delete operation, which may involve many rows. After all rows have been processed,
+// Close is called.
+func (cd *conflictRootObjectDeleter) Delete(ctx *sql.Context, r sql.Row) error {
+	return errors.New("deletion logic not yet implemented")
+}
+
+// StatementBegin implements the interface sql.TableEditor.
+func (cd *conflictRootObjectDeleter) StatementBegin(ctx *sql.Context) {}
+
+// DiscardChanges implements the interface sql.TableEditor.
+func (cd *conflictRootObjectDeleter) DiscardChanges(ctx *sql.Context, errorEncountered error) error {
+	return nil
+}
+
+// StatementComplete implements the interface sql.TableEditor.
+func (cd *conflictRootObjectDeleter) StatementComplete(ctx *sql.Context) error {
+	return nil
+}
+
+// Close finalizes the delete operation, persisting the result.
+func (cd *conflictRootObjectDeleter) Close(ctx *sql.Context) error {
+	// TODO: finalize the changes made
+	return nil
+}

--- a/go/libraries/doltcore/sqle/dtables/table_of_tables_in_conflict.go
+++ b/go/libraries/doltcore/sqle/dtables/table_of_tables_in_conflict.go
@@ -145,6 +145,13 @@ func (ct *TableOfTablesInConflict) Partitions(ctx *sql.Context) (sql.PartitionIt
 			partitions = append(partitions, &tableInConflict{name: tblName.Name, size: n})
 		}
 	}
+	rootObjects, err := root.GetRootObjectsWithConflicts(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, rootObject := range rootObjects {
+		partitions = append(partitions, &tableInConflict{name: rootObject.Name().String(), size: 1})
+	}
 
 	return &tablesInConflict{partitions: partitions}, nil
 }


### PR DESCRIPTION
This adds a new root object type, `Conflict`, which is specially handled by Dolt to represent conflicts between root objects. As Doltgres does not have to worry about the CLI (only Dolt functions and system tables), the implementation surface area is a bit smaller, and this is specifically designed for conflict resolution via those methods. This is incomplete (tests will fail in CI due to invalid go.mod configuration), but shows the general strategy that I'm working towards.

Relies on:
* https://github.com/dolthub/doltgresql/pull/1647

The new example test fully works, although it returns mockup data. Each root object will have its own special diff logic, since they all will want to diff (and merge) fundamentally different aspects about themselves. This opens up a level of granularity that wouldn't be possible otherwise (such as merging the return type of a function from "their" branch, while retaining logic changes from "our" branch).