### PR TITLE
[no-release-notes] archive conjoin logic

### DIFF
--- a/go/store/nbs/archive_test.go
+++ b/go/store/nbs/archive_test.go
@@ -795,12 +795,10 @@ func TestArchiveConjoinAll(t *testing.T) {
 
 	// Test conjoinAll method
 	readers := []archiveReader{archiveReader1, archiveReader2}
-	combinedReader, err := awCombined.conjoinAll(readers)
+	combinedReader, err := awCombined.conjoinAll(context.Background(), readers)
 
-	// Since conjoinAll is not implemented yet, we expect a specific error
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "conjoinAll not yet implemented")
-	assert.Equal(t, archiveReader{}, combinedReader)
+	// conjoinAll should succeed
+	assert.NoError(t, err)
 
 	// Verify combined reader contains all chunks
 	assert.True(t, combinedReader.has(hashes1[0]))
@@ -1001,7 +999,9 @@ func createTestArchive(t *testing.T, prefix uint64, chunks [][]byte, metadata st
 	// Write chunks and stage them
 	var hashes []hash.Hash
 	for _, chunkData := range chunks {
-		bsId, err := aw.writeByteSpan(chunkData)
+		// Compress the chunk data using the default dictionary
+		compressedData := gozstd.CompressDict(nil, chunkData, defaultCDict)
+		bsId, err := aw.writeByteSpan(compressedData)
 		assert.NoError(t, err)
 
 		chunkHash := hashWithPrefix(t, prefix)

--- a/go/store/nbs/archive_test.go
+++ b/go/store/nbs/archive_test.go
@@ -784,6 +784,8 @@ func TestArchiveConjoinAll(t *testing.T) {
 	chunks2 := [][]byte{
 		{30, 31, 32, 33, 34, 35, 36, 37, 38, 39},
 		{40, 41, 42, 43, 44, 45, 46, 47, 48, 49},
+		{50, 51, 52, 53, 54, 55, 56, 57, 58, 59},
+		{60, 61, 62, 63, 64, 65, 66, 67, 68, 69},
 	}
 	archiveReader2, hashes2 := createTestArchive(t, 84, chunks2, "archive2")
 
@@ -803,30 +805,20 @@ func TestArchiveConjoinAll(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify combined reader contains all chunks
-	assert.True(t, combinedReader.has(hashes1[0]))
-	assert.True(t, combinedReader.has(hashes1[1]))
-	assert.True(t, combinedReader.has(hashes2[0]))
-	assert.True(t, combinedReader.has(hashes2[1]))
-
-	// Verify data integrity
 	ctx := context.Background()
 	stats := &Stats{}
-
-	data, err := combinedReader.get(ctx, hashes1[0], stats)
-	assert.NoError(t, err)
-	assert.Equal(t, chunks1[0], data)
-
-	data, err = combinedReader.get(ctx, hashes1[1], stats)
-	assert.NoError(t, err)
-	assert.Equal(t, chunks1[1], data)
-
-	data, err = combinedReader.get(ctx, hashes2[0], stats)
-	assert.NoError(t, err)
-	assert.Equal(t, chunks2[0], data)
-
-	data, err = combinedReader.get(ctx, hashes2[1], stats)
-	assert.NoError(t, err)
-	assert.Equal(t, chunks2[1], data)
+	for i, h := range hashes1 {
+		assert.True(t, combinedReader.has(h))
+		data, err := combinedReader.get(ctx, h, stats)
+		assert.NoError(t, err)
+		assert.Equal(t, chunks1[i], data)
+	}
+	for i, h := range hashes2 {
+		assert.True(t, combinedReader.has(h))
+		data, err := combinedReader.get(ctx, h, stats)
+		assert.NoError(t, err)
+		assert.Equal(t, chunks2[i], data)
+	}
 }
 
 func assertFloatBetween(t *testing.T, actual, min, max float64) {

--- a/go/store/nbs/archive_writer.go
+++ b/go/store/nbs/archive_writer.go
@@ -816,10 +816,8 @@ func (aw *archiveWriter) conjoinAll(ctx context.Context, readers []archiveReader
 			copy(hashBytes[hash.PrefixLen:], suffix[:])
 			chunkHash := hash.New(hashBytes)
 
-			// Error on duplicates for the time being.
-			if aw.seenChunks.Has(chunkHash) {
-				return fmt.Errorf("Duplicate chunk found during conjoinAll: %s", chunkHash.String())
-			}
+			// Add to seen chunks and staged chunks. Note that we allow duplicates here, whereas we don't we doing
+			// a chunk-by-chunk build of an archive.
 			aw.seenChunks.Insert(chunkHash)
 
 			// Adjust byte span IDs for the combined archive
@@ -837,7 +835,7 @@ func (aw *archiveWriter) conjoinAll(ctx context.Context, readers []archiveReader
 			})
 		}
 	}
-	
+
 	err = indexFinalize(aw, hash.Hash{})
 	if err != nil {
 		return fmt.Errorf("failed to finalize archive: %w", err)

--- a/go/store/nbs/archive_writer.go
+++ b/go/store/nbs/archive_writer.go
@@ -32,6 +32,7 @@ import (
 	"github.com/dolthub/dolt/go/store/hash"
 )
 
+
 type stagedByteSpanSlice []byteSpan
 
 type stagedChunkRef struct {
@@ -56,10 +57,12 @@ type archiveWriter struct {
 	md5Summer *HashingByteSink
 	// SHA512 is calculated on chunks of the output stream, so will be reset at appropriate times. This
 	// sinker is what archive code writes to, and it wraps the MD5 sink.
-	output           *HashingByteSink
-	bytesWritten     uint64
-	stagedBytes      stagedByteSpanSlice
-	stagedChunks     stagedChunkRefSlice
+	output       *HashingByteSink
+	bytesWritten uint64
+	stagedBytes  stagedByteSpanSlice
+	stagedChunks stagedChunkRefSlice
+	// seenChunks is used when building archives chunk-by-chunk, to ensure that we do not write the same chunk multiple
+	// times. It is not used for any other purpose, and there are cases where we bypass checking it (e.g. conjoining archives).
 	seenChunks       hash.HashSet
 	indexLen         uint64
 	metadataLen      uint32
@@ -730,55 +733,10 @@ func (aw *archiveWriter) conjoinAll(ctx context.Context, readers []archiveReader
 
 	stats := &Stats{}
 
-	// Process first reader - write data blocks and collect byte span info
-	firstReader := readers[0]
-
-	// Write the entire data section from the first reader using io.Copy
-	dataSpan := firstReader.footer.dataSpan()
-	sectionReader := newSectionReader(ctx, firstReader.reader, int64(dataSpan.offset), int64(dataSpan.length), stats)
-
-	written, err := io.Copy(aw.output, sectionReader)
-	if err != nil {
-		return fmt.Errorf("failed to copy data from first archive: %w", err)
-	}
-	aw.bytesWritten += uint64(written)
-
-	// Build byte span index from first reader
-	for i := uint32(1); i <= firstReader.footer.byteSpanCount; i++ {
-		span := firstReader.getByteSpanByID(i)
-		aw.stagedBytes = append(aw.stagedBytes, span)
-	}
-
-	// Process chunks from first reader and build hash set
-	for i := 0; i < int(firstReader.footer.chunkCount); i++ {
-		// Get chunk reference
-		dictId, dataId := firstReader.getChunkRef(i)
-
-		// Reconstruct the hash from prefix and suffix
-		prefix := firstReader.prefixes[i]
-		suffix := firstReader.getSuffixByID(uint64(i))
-
-		// Create hash from prefix and suffix
-		hashBytes := make([]byte, hash.ByteLen)
-		binary.BigEndian.PutUint64(hashBytes[:hash.PrefixLen], prefix)
-		copy(hashBytes[hash.PrefixLen:], suffix[:])
-		chunkHash := hash.New(hashBytes)
-
-		// Add to seen chunks and staged chunks
-		aw.seenChunks.Insert(chunkHash)
-		aw.stagedChunks = append(aw.stagedChunks, stagedChunkRef{
-			hash:       chunkHash,
-			dictionary: dictId,
-			data:       dataId,
-		})
-	}
-
-	// Process remaining readers
-	for _, reader := range readers[1:] {
-		// Track the current byte offset to adjust byte span IDs
+	for _, reader := range readers {
 		currentByteOffset := aw.bytesWritten
 
-		// Write the entire data section - this is not the final solution because of duplicate chunks.
+		// Write the entire data section for the current reader.
 		dataSpan := reader.footer.dataSpan()
 		sectionReader := newSectionReader(ctx, reader.reader, int64(dataSpan.offset), int64(dataSpan.length), stats)
 
@@ -790,8 +748,6 @@ func (aw *archiveWriter) conjoinAll(ctx context.Context, readers []archiveReader
 
 		// Map byte span IDs from this reader to the combined archive
 		spanIdOffset := uint32(len(aw.stagedBytes))
-
-		// Add byte spans from this reader, adjusting offsets
 		for i := uint32(1); i <= reader.footer.byteSpanCount; i++ {
 			span := reader.getByteSpanByID(i)
 			adjustedSpan := byteSpan{
@@ -801,23 +757,16 @@ func (aw *archiveWriter) conjoinAll(ctx context.Context, readers []archiveReader
 			aw.stagedBytes = append(aw.stagedBytes, adjustedSpan)
 		}
 
-		// Process chunks from this reader
 		for i := 0; i < int(reader.footer.chunkCount); i++ {
-			// Get chunk reference
 			dictId, dataId := reader.getChunkRef(i)
 
 			// Reconstruct the hash from prefix and suffix
 			prefix := reader.prefixes[i]
 			suffix := reader.getSuffixByID(uint64(i))
+			chunkHash := reconstructHashFromPrefixAndSuffix(prefix, suffix)
 
-			// Create hash from prefix and suffix
-			hashBytes := make([]byte, hash.ByteLen)
-			binary.BigEndian.PutUint64(hashBytes[:hash.PrefixLen], prefix)
-			copy(hashBytes[hash.PrefixLen:], suffix[:])
-			chunkHash := hash.New(hashBytes)
-
-			// Add to seen chunks and staged chunks. Note that we allow duplicates here, whereas we don't we doing
-			// a chunk-by-chunk build of an archive.
+			// Add to seen chunks and staged chunks. Note that we allow duplicates here, whereas we quietly skip
+			// duplicates when doing a chunk-by-chunk build of an archive.
 			aw.seenChunks.Insert(chunkHash)
 
 			// Adjust byte span IDs for the combined archive
@@ -836,7 +785,7 @@ func (aw *archiveWriter) conjoinAll(ctx context.Context, readers []archiveReader
 		}
 	}
 
-	err = indexFinalize(aw, hash.Hash{})
+	err := indexFinalize(aw, hash.Hash{})
 	if err != nil {
 		return fmt.Errorf("failed to finalize archive: %w", err)
 	}

--- a/go/store/nbs/archive_writer.go
+++ b/go/store/nbs/archive_writer.go
@@ -708,3 +708,14 @@ func (asw *ArchiveStreamWriter) convertSnappyAndStage(cc CompressedChunk) (uint3
 
 	return bytesWritten, asw.writer.stageZStdChunk(h, dictId, dataId)
 }
+
+// conjoinAll combines two or more archiveReader instances into a single archive.
+// This method takes a slice of archiveReader instances and merges their contents
+// into the current archiveWriter.
+func (aw *archiveWriter) conjoinAll(readers []archiveReader) (archiveReader, error) {
+	if len(readers) < 2 {
+		return archiveReader{}, fmt.Errorf("conjoinAll requires at least 2 archive readers, got %d", len(readers))
+	}
+
+	return archiveReader{}, fmt.Errorf("conjoinAll not yet implemented")
+}

--- a/go/store/nbs/archive_writer.go
+++ b/go/store/nbs/archive_writer.go
@@ -32,7 +32,6 @@ import (
 	"github.com/dolthub/dolt/go/store/hash"
 )
 
-
 type stagedByteSpanSlice []byteSpan
 
 type stagedChunkRef struct {

--- a/go/store/nbs/archive_writer.go
+++ b/go/store/nbs/archive_writer.go
@@ -723,13 +723,6 @@ func (aw *archiveWriter) conjoinAll(ctx context.Context, readers []archiveReader
 		return fmt.Errorf("conjoinAll requires at least 2 archive readers, got %d", len(readers))
 	}
 
-	// Sort readers by data span length (largest first)
-	sort.Slice(readers, func(i, j int) bool {
-		dataSpanI := readers[i].footer.dataSpan()
-		dataSpanJ := readers[j].footer.dataSpan()
-		return dataSpanI.length > dataSpanJ.length
-	})
-
 	stats := &Stats{}
 
 	for _, reader := range readers {


### PR DESCRIPTION
This PR is for the business logic of conjoining archives. It is not accessible in any way by a user at this point. Just implementation and unit tests using in memory buffers. Materializing to disk and integrating with the GC process is still required.