### PR TITLE
 dolthub/dolt#9530 - Fix auto-increment display for SHOW CREATE TABLE

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -199,4 +199,6 @@ require (
 
 replace github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi => ./gen/proto/dolt/services/eventsapi
 
+replace github.com/dolthub/go-mysql-server => ../../go-mysql-server
+
 go 1.24.0

--- a/go/go.mod
+++ b/go/go.mod
@@ -199,6 +199,4 @@ require (
 
 replace github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi => ./gen/proto/dolt/services/eventsapi
 
-replace github.com/dolthub/go-mysql-server => ../../go-mysql-server
-
 go 1.24.0

--- a/go/libraries/doltcore/sqle/dsess/autoincrement_tracker.go
+++ b/go/libraries/doltcore/sqle/dsess/autoincrement_tracker.go
@@ -526,27 +526,27 @@ func (a *AutoIncrementTracker) canIncrementAutoIncVal(ctx *sql.Context, tbl stri
 	sess := DSessFromSess(ctx.Session)
 	db, ok := sess.Provider().BaseDatabase(ctx, a.dbName)
 	if !ok || !db.Versioned() {
-		return true
+		return false
 	}
 
 	ws, err := sess.WorkingSet(ctx, a.dbName)
 	if err != nil {
-		return true
+		return false
 	}
 
 	table, _, ok, err := doltdb.GetTableInsensitive(ctx, ws.WorkingRoot(), doltdb.TableName{Name: tbl})
 	if err != nil || !ok {
-		return true
+		return false
 	}
 
 	sch, err := table.GetSchema(ctx)
 	if err != nil {
-		return true
+		return false
 	}
 
 	aiCol, ok := schema.GetAutoIncrementColumn(sch)
 	if !ok {
-		return true
+		return false
 	}
 
 	sqlType := aiCol.TypeInfo.ToSqlType()

--- a/go/libraries/doltcore/sqle/dsess/autoincrement_tracker.go
+++ b/go/libraries/doltcore/sqle/dsess/autoincrement_tracker.go
@@ -526,22 +526,22 @@ func (a *AutoIncrementTracker) canIncrementAutoIncVal(ctx *sql.Context, tbl stri
 	sess := DSessFromSess(ctx.Session)
 	db, ok := sess.Provider().BaseDatabase(ctx, a.dbName)
 	if !ok || !db.Versioned() {
-		return false
+		return true
 	}
 
 	ws, err := sess.WorkingSet(ctx, a.dbName)
 	if err != nil {
-		return false
+		return true
 	}
 
 	table, _, ok, err := doltdb.GetTableInsensitive(ctx, ws.WorkingRoot(), doltdb.TableName{Name: tbl})
 	if err != nil || !ok {
-		return false
+		return true
 	}
 
 	sch, err := table.GetSchema(ctx)
 	if err != nil {
-		return false
+		return true
 	}
 
 	aiCol, ok := schema.GetAutoIncrementColumn(sch)

--- a/go/libraries/doltcore/sqle/dsess/autoincrement_tracker.go
+++ b/go/libraries/doltcore/sqle/dsess/autoincrement_tracker.go
@@ -139,7 +139,7 @@ func (a *AutoIncrementTracker) Next(ctx *sql.Context, tbl string, insertVal inte
 
 	if given >= curr {
 		nextVal := given
-		if a.canIncrementAutoIncVal(ctx, tbl, given) {
+		if a.incrementAutoIncVal(ctx, tbl, given) {
 			nextVal++
 		}
 		a.sequences.Store(tbl, nextVal)
@@ -522,36 +522,44 @@ func (a *AutoIncrementTracker) initWithRoots(ctx context.Context, roots ...doltd
 	return eg.Wait()
 }
 
-func (a *AutoIncrementTracker) canIncrementAutoIncVal(ctx *sql.Context, tbl string, currentVal uint64) bool {
+func (a *AutoIncrementTracker) incrementAutoIncVal(ctx *sql.Context, tbl string, currentVal uint64) bool {
 	sess := DSessFromSess(ctx.Session)
 	db, ok := sess.Provider().BaseDatabase(ctx, a.dbName)
 	if !ok || !db.Versioned() {
+		// Database not found or not versioned - fail-open for infrastructure errors
 		return true
 	}
 
 	ws, err := sess.WorkingSet(ctx, a.dbName)
 	if err != nil {
+		// Working set access error - fail-open for infrastructure errors
 		return true
 	}
 
 	table, _, ok, err := doltdb.GetTableInsensitive(ctx, ws.WorkingRoot(), doltdb.TableName{Name: tbl})
 	if err != nil || !ok {
+		// Table access error or table not found - fail-open for infrastructure errors
 		return true
 	}
 
 	sch, err := table.GetSchema(ctx)
 	if err != nil {
+		// Schema access error - fail-open for infrastructure errors
 		return true
 	}
 
 	aiCol, ok := schema.GetAutoIncrementColumn(sch)
 	if !ok {
-		return false
+		// No auto-increment column found - fail-open to allow ALTER TABLE operations
+		// where the auto-increment column is being added in a transitional state
+		return true
 	}
 
 	sqlType := aiCol.TypeInfo.ToSqlType()
 	nextVal := currentVal + 1
 	_, inRange, err := sqlType.Convert(ctx, nextVal)
+	// The only return false case is when we have a definitive auto-increment column 
+	// and can verify type overflow would occur - this is the fail-closed for protection scenario
 	return err == nil && inRange == sql.InRange
 }
 

--- a/go/libraries/doltcore/sqle/dsess/autoincrement_tracker.go
+++ b/go/libraries/doltcore/sqle/dsess/autoincrement_tracker.go
@@ -138,7 +138,11 @@ func (a *AutoIncrementTracker) Next(ctx *sql.Context, tbl string, insertVal inte
 	}
 
 	if given >= curr {
-		a.sequences.Store(tbl, given+1)
+		nextVal := given
+		if a.canIncrementAutoIncVal(ctx, tbl, given) {
+			nextVal++
+		}
+		a.sequences.Store(tbl, nextVal)
 		return given, nil
 	}
 
@@ -516,6 +520,39 @@ func (a *AutoIncrementTracker) initWithRoots(ctx context.Context, roots ...doltd
 	}
 
 	return eg.Wait()
+}
+
+func (a *AutoIncrementTracker) canIncrementAutoIncVal(ctx *sql.Context, tbl string, currentVal uint64) bool {
+	sess := DSessFromSess(ctx.Session)
+	db, ok := sess.Provider().BaseDatabase(ctx, a.dbName)
+	if !ok || !db.Versioned() {
+		return true
+	}
+
+	ws, err := sess.WorkingSet(ctx, a.dbName)
+	if err != nil {
+		return true
+	}
+
+	table, _, ok, err := doltdb.GetTableInsensitive(ctx, ws.WorkingRoot(), doltdb.TableName{Name: tbl})
+	if err != nil || !ok {
+		return true
+	}
+
+	sch, err := table.GetSchema(ctx)
+	if err != nil {
+		return true
+	}
+
+	aiCol, ok := schema.GetAutoIncrementColumn(sch)
+	if !ok {
+		return true
+	}
+
+	sqlType := aiCol.TypeInfo.ToSqlType()
+	nextVal := currentVal + 1
+	_, inRange, err := sqlType.Convert(ctx, nextVal)
+	return err == nil && inRange == sql.InRange
 }
 
 func (a *AutoIncrementTracker) InitWithRoots(ctx context.Context, roots ...doltdb.Rootish) error {

--- a/integration-tests/bats/auto_increment.bats
+++ b/integration-tests/bats/auto_increment.bats
@@ -933,3 +933,95 @@ SQL
     [ "$status" -ne 0 ]
     [[ "$output" =~ "duplicate primary key given: [127]" ]] || false
 }
+
+@test "auto_increment: overflow protection for SMALLINT" {
+    dolt sql <<SQL
+CREATE TABLE smallint_overflow (
+    id SMALLINT AUTO_INCREMENT PRIMARY KEY,
+    data VARCHAR(50)
+);
+SQL
+
+    # Insert value at max SMALLINT (32767)
+    run dolt sql -q "INSERT INTO smallint_overflow (id, data) VALUES (32767, 'max_value');"
+    [ "$status" -eq 0 ]
+    
+    # Verify SHOW CREATE TABLE shows correct AUTO_INCREMENT value
+    run dolt sql -q "SHOW CREATE TABLE smallint_overflow;" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "AUTO_INCREMENT=32767" ]] || false
+    
+    # Try to insert without specifying id - should fail with duplicate key error
+    run dolt sql -q "INSERT INTO smallint_overflow (data) VALUES ('should_fail');"
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "duplicate primary key given: [32767]" ]] || false
+}
+
+@test "auto_increment: overflow protection for MEDIUMINT" {
+    dolt sql <<SQL
+CREATE TABLE mediumint_overflow (
+    id MEDIUMINT AUTO_INCREMENT PRIMARY KEY,
+    data VARCHAR(50)
+);
+SQL
+
+    # Insert value at max MEDIUMINT (8388607)
+    run dolt sql -q "INSERT INTO mediumint_overflow (id, data) VALUES (8388607, 'max_value');"
+    [ "$status" -eq 0 ]
+    
+    # Verify SHOW CREATE TABLE shows correct AUTO_INCREMENT value
+    run dolt sql -q "SHOW CREATE TABLE mediumint_overflow;" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "AUTO_INCREMENT=8388607" ]] || false
+    
+    # Try to insert without specifying id - should fail with duplicate key error
+    run dolt sql -q "INSERT INTO mediumint_overflow (data) VALUES ('should_fail');"
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "duplicate primary key given: [8388607]" ]] || false
+}
+
+@test "auto_increment: overflow protection for INT" {
+    dolt sql <<SQL
+CREATE TABLE int_overflow (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    data VARCHAR(50)
+);
+SQL
+
+    # Insert value at max INT (2147483647)
+    run dolt sql -q "INSERT INTO int_overflow (id, data) VALUES (2147483647, 'max_value');"
+    [ "$status" -eq 0 ]
+    
+    # Verify SHOW CREATE TABLE shows correct AUTO_INCREMENT value
+    run dolt sql -q "SHOW CREATE TABLE int_overflow;" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "AUTO_INCREMENT=2147483647" ]] || false
+    
+    # Try to insert without specifying id - should fail with duplicate key error
+    run dolt sql -q "INSERT INTO int_overflow (data) VALUES ('should_fail');"
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "duplicate primary key given: [2147483647]" ]] || false
+}
+
+@test "auto_increment: overflow protection for BIGINT" {
+    dolt sql <<SQL
+CREATE TABLE bigint_overflow (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    data VARCHAR(50)
+);
+SQL
+
+    # Insert value at max BIGINT (9223372036854775807)
+    run dolt sql -q "INSERT INTO bigint_overflow (id, data) VALUES (9223372036854775807, 'max_value');"
+    [ "$status" -eq 0 ]
+    
+    # Verify SHOW CREATE TABLE shows correct AUTO_INCREMENT value
+    run dolt sql -q "SHOW CREATE TABLE bigint_overflow;" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "AUTO_INCREMENT=9223372036854775807" ]] || false
+    
+    # Try to insert without specifying id - should fail with duplicate key error
+    run dolt sql -q "INSERT INTO bigint_overflow (data) VALUES ('should_fail');"
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "duplicate primary key given: [9223372036854775807]" ]] || false
+}


### PR DESCRIPTION
Fixes dolthub/dolt#9530
Companion PR: dolthub/go-mysql-server#3103
Fixed auto-increment display discrepancy in SHOW CREATE TABLE by adding type checking to prevent incrementing beyond integer type maximums.
