### PR TITLE
go: statspro: Ensure we Close() the DoltDB associated used for stats storage when we rotate storage.

### DIFF
--- a/go/libraries/doltcore/dbfactory/file.go
+++ b/go/libraries/doltcore/dbfactory/file.go
@@ -85,11 +85,17 @@ func CloseAllLocalDatabases() (err error) {
 	return
 }
 
-func DeleteFromSingletonCache(path string) error {
+func DeleteFromSingletonCache(path string, closeIt bool) error {
 	singletonLock.Lock()
 	defer singletonLock.Unlock()
+	var err error
+	if closeIt {
+		if s, ok := singletons[path]; ok {
+			err = s.ddb.Close()
+		}
+	}
 	delete(singletons, path)
-	return nil
+	return err
 }
 
 // PrepareDB creates the directory for the DB if it doesn't exist, and returns an error if a file or symlink is at the

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -798,13 +798,15 @@ func (p *DoltDatabaseProvider) DropDatabase(ctx *sql.Context, name string) error
 	}
 
 	// If this database is re-created, we don't want to return any cached results.
-	err = dbfactory.DeleteFromSingletonCache(filepath.ToSlash(dropDbLoc + "/.dolt/noms"))
+	err = dbfactory.DeleteFromSingletonCache(filepath.ToSlash(dropDbLoc+"/.dolt/noms"), false)
 	if err != nil {
 		return err
 	}
-	err = dbfactory.DeleteFromSingletonCache(filepath.ToSlash(dropDbLoc + "/.dolt/stats/.dolt/noms"))
+	err = dbfactory.DeleteFromSingletonCache(filepath.ToSlash(dropDbLoc+"/.dolt/stats/.dolt/noms"), true)
 	if err != nil {
-		return err
+		// Swallow the error closing `stats` database.
+		// TODO: Log this.
+		err = nil
 	}
 
 	err = p.droppedDatabaseManager.DropDatabase(ctx, name, dropDbLoc)

--- a/go/libraries/doltcore/sqle/statspro/controller.go
+++ b/go/libraries/doltcore/sqle/statspro/controller.go
@@ -542,22 +542,21 @@ func (sc *StatsController) rm(fs filesys.Filesys) error {
 		return err
 	}
 
+	dropDbLoc, err := statsFs.Abs("")
+	if err != nil {
+		return err
+	}
+
+	if err = dbfactory.DeleteFromSingletonCache(filepath.ToSlash(dropDbLoc+"/.dolt/noms"), true); err != nil {
+		// Swallow this error for now. This only comes from closing the database, and closing is not always successful.
+	}
+
 	if ok, _ := statsFs.Exists(""); ok {
 		if err := statsFs.Delete("", true); err != nil {
 			return err
 		}
 	}
 
-	dropDbLoc, err := statsFs.Abs("")
-	if err != nil {
-		return err
-	}
-
-	//log.Println("rm", dropDbLoc)
-
-	if err = dbfactory.DeleteFromSingletonCache(filepath.ToSlash(dropDbLoc + "/.dolt/noms")); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/go/libraries/doltcore/sqle/statspro/worker_leak_test.go
+++ b/go/libraries/doltcore/sqle/statspro/worker_leak_test.go
@@ -1,0 +1,60 @@
+// Copyright 2025 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unix
+// +build unix
+
+package statspro
+
+import (
+	"os"
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGCDoesNotLeakFd(t *testing.T) {
+	threads := sql.NewBackgroundThreads()
+	defer threads.Shutdown()
+	ctx, sqlEng, _ := defaultSetupDetail(t, threads, false, true, true)
+
+	{
+		runBlock(t, ctx, sqlEng,
+			"create database otherdb",
+			"use otherdb",
+			"create table t (i int primary key)",
+			"insert into t values (0), (1)",
+			"call dolt_stats_gc()",
+		)
+
+		nextFd := getNextFd(t)
+		sanityNextFd := getNextFd(t)
+		require.Equal(t, nextFd, sanityNextFd)
+
+		for i := 0; i < 64; i++ {
+			runBlock(t, ctx, sqlEng, "call dolt_stats_gc()")
+		}
+
+		finalNextFd := getNextFd(t)
+		require.Equal(t, nextFd, finalNextFd)
+	}
+}
+
+func getNextFd(t *testing.T) uintptr {
+	f, err := os.Open("/dev/null")
+	require.NoError(t, err)
+	defer f.Close()
+	return f.Fd()
+}

--- a/go/libraries/doltcore/sqle/statspro/worker_test.go
+++ b/go/libraries/doltcore/sqle/statspro/worker_test.go
@@ -641,7 +641,16 @@ func newStatsCoord(t *testing.T, bthreads *sql.BackgroundThreads) *StatsControll
 }
 
 func emptySetup(t *testing.T, threads *sql.BackgroundThreads, memOnly bool, gcEnabled bool) (*sql.Context, *gms.Engine, *StatsController) {
-	dEnv := dtestutils.CreateTestEnv()
+	return emptySetupDetail(t, threads, memOnly, gcEnabled, false)
+}
+
+func emptySetupDetail(t *testing.T, threads *sql.BackgroundThreads, memOnly bool, gcEnabled bool, fsEnabled bool) (*sql.Context, *gms.Engine, *StatsController) {
+	var dEnv *env.DoltEnv
+	if fsEnabled {
+		dEnv = dtestutils.CreateTestEnvForLocalFilesystem()
+	} else {
+		dEnv = dtestutils.CreateTestEnv()
+	}
 	sqlEng, ctx := newTestEngine(context.Background(), t, dEnv, threads)
 	ctx.Session.SetClient(sql.Client{
 		User:    "billy boy",
@@ -703,7 +712,11 @@ func emptySetup(t *testing.T, threads *sql.BackgroundThreads, memOnly bool, gcEn
 }
 
 func defaultSetup(t *testing.T, threads *sql.BackgroundThreads, memOnly bool, gcEnabled bool) (*sql.Context, *gms.Engine, *StatsController) {
-	ctx, sqlEng, sc := emptySetup(t, threads, memOnly, gcEnabled)
+	return defaultSetupDetail(t, threads, memOnly, gcEnabled, false)
+}
+
+func defaultSetupDetail(t *testing.T, threads *sql.BackgroundThreads, memOnly bool, gcEnabled bool, fsEnabled bool) (*sql.Context, *gms.Engine, *StatsController) {
+	ctx, sqlEng, sc := emptySetupDetail(t, threads, memOnly, gcEnabled, fsEnabled)
 	//sc.Debug = true
 
 	require.NoError(t, executeQuery(ctx, sqlEng, "create table xy (x int primary key, y int, key (y,x))"))


### PR DESCRIPTION
Dolt previously leaked a file descriptor on certain platforms every time stats was garbage collected. By closing the DoltDB, we no longer leak the descriptor.

Closing is currently best effort, since certain in-flight file operations can actually cause closing to fail.