### PR TITLE
Fix dolt_log system table timezone handling

### DIFF
--- a/go/store/datas/commit_meta.go
+++ b/go/store/datas/commit_meta.go
@@ -200,7 +200,7 @@ func (cm *CommitMeta) toNomsStruct(nbf *types.NomsBinFormat) (types.Struct, erro
 
 // Time returns the time at which the commit occurred
 func (cm *CommitMeta) Time() time.Time {
-	return time.UnixMilli(cm.UserTimestamp)
+	return time.UnixMilli(cm.UserTimestamp).In(CommitLoc)
 }
 
 // FormatTS takes the internal timestamp and turns it into a human readable string in the time.RubyDate format


### PR DESCRIPTION
The dolt_log system table was returning timestamps in time.Local instead of respecting the configurable CommitLoc timezone. This caused test failures when comparing expected UTC timestamps with actual Local timestamps.

Changed CommitMeta.Time() to use CommitLoc timezone instead of defaulting to time.Local.