### PR TITLE
dolthub/dolt#9556 - Fix JSON path parsing for unnecessarily quoted field names

### DIFF
--- a/go/store/prolly/tree/json_location.go
+++ b/go/store/prolly/tree/json_location.go
@@ -275,6 +275,7 @@ func jsonPathElementsFromMySQLJsonPath(pathBytes []byte) (jsonLocation, error) {
 			}
 		case lexStateKey:
 			if pathBytes[i] == '"' {
+				tok = i // Point tok to the opening quote
 				state = lexStateQuotedKey
 				i += 1
 			} else if pathBytes[i] == '.' || pathBytes[i] == '[' {
@@ -292,7 +293,7 @@ func jsonPathElementsFromMySQLJsonPath(pathBytes []byte) (jsonLocation, error) {
 			}
 		case lexStateQuotedKey:
 			if pathBytes[i] == '"' {
-				if tok+1 == i-1 {
+				if tok+1 == i {
 					return jsonLocation{}, fmt.Errorf("Invalid JSON path expression. Expected field name after '.' at character %v of %s", i, string(pathBytes))
 				}
 				pathKey := unescapeKey(pathBytes[tok+1 : i])


### PR DESCRIPTION
Fixes dolthub/dolt#9556

Fixed dolt's JSON path parser to accept unnecessarily quoted field names like $."a".
The issue was in the lexer logic that incorrectly detected empty quoted strings when processing unnecessarily quoted simple field names.