### PR TITLE
Run gofmt and goimports on generated protobuf files to ensure clean diffs

### DIFF
--- a/.github/workflows/ci-check-repo.yaml
+++ b/.github/workflows/ci-check-repo.yaml
@@ -159,7 +159,9 @@ jobs:
           (cd third_party/protobuf && bazel build //:protoc)
           (cd third_party/protobuf-go && go build -o ._protoc-gen-go ./cmd/protoc-gen-go)
           (cd third_party/grpc-go/cmd/protoc-gen-go-grpc && go build -o ._protoc-gen-go-grpc .)
-          make clean all
+          make clean 
+          find ../go/gen/proto -name '*.pb.go' -exec gofmt -s -w {} +
+          find ../go/gen/proto -name '*.pb.go' -exec goimports -w {} +
           changes=$(git status --porcelain)
           diff=$(git diff)
           if [ ! -z "$changes" ]; then

--- a/.github/workflows/ci-check-repo.yaml
+++ b/.github/workflows/ci-check-repo.yaml
@@ -159,7 +159,7 @@ jobs:
           (cd third_party/protobuf && bazel build //:protoc)
           (cd third_party/protobuf-go && go build -o ._protoc-gen-go ./cmd/protoc-gen-go)
           (cd third_party/grpc-go/cmd/protoc-gen-go-grpc && go build -o ._protoc-gen-go-grpc .)
-          make clean 
+          make clean all
           find ../go/gen/proto -name '*.pb.go' -exec gofmt -s -w {} +
           find ../go/gen/proto -name '*.pb.go' -exec goimports -w {} +
           changes=$(git status --porcelain)


### PR DESCRIPTION
This change adds `gofmt` and `goimports` steps to the protobuf generation process to ensure that generated `.pb.go` files are consistently formatted.
