### PR TITLE
Bug fix: Update secondary index correctly during a merge with a schema change

### DIFF
--- a/go/libraries/doltcore/merge/merge_prolly_rows.go
+++ b/go/libraries/doltcore/merge/merge_prolly_rows.go
@@ -1572,7 +1572,7 @@ func (m *secondaryMerger) merge(ctx *sql.Context, diff tree.ThreeWayDiff, leftSc
 			// If the left-side has the delete, the index is already correct and no work needs to be done.
 			// If the right-side has the delete, remove the key from the index.
 			if diff.Right == nil {
-				err = applyEdit(ctx, idx, diff.Key, diff.Base, nil)
+				err = applyEdit(ctx, idx, diff.Key, diff.Left, nil)
 			}
 		default:
 			// Any changes to the left-side of the merge are not needed, since we currently


### PR DESCRIPTION
During a merge, Dolt applies diffs to existing indexes to sync their data with the changes being merged in. If the table schema has changed between the merge base and the left/right branches of the merge, Dolt was using the incorrect value tuple to remove the row from the index. This resulted in a customer issue where the secondary index still contained rows and the foreign key validation logic was incorrectly detecting FK violations, even though the child table was empty. 

As a follow-up to this, we need to investigate other similar cases in the secondary index merger and see if other diff types have a similar issue. 