### PR TITLE
go: sqle: autoincrement_tracker: When we close the engine.SqlEngine, finalize any ongoing initialization of AutoIncrementTrackers.

### DIFF
--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -54,7 +54,7 @@ import (
 
 // SqlEngine packages up the context necessary to run sql queries against dsqle.
 type SqlEngine struct {
-	provider       sql.DatabaseProvider
+	provider       *dsqle.DoltDatabaseProvider
 	ContextFactory sql.ContextFactory
 	dsessFactory   sessionFactory
 	engine         *gms.Engine
@@ -435,13 +435,17 @@ func (se *SqlEngine) FileSystem() filesys.Filesys {
 }
 
 func (se *SqlEngine) Close() error {
+	var err error
 	if se.engine != nil {
 		if se.engine.Analyzer.Catalog.BinlogReplicaController != nil {
 			dblr.DoltBinlogReplicaController.Close()
 		}
-		return se.engine.Close()
+		err = se.engine.Close()
 	}
-	return nil
+	if se.provider != nil {
+		se.provider.Close()
+	}
+	return err
 }
 
 // configureBinlogReplicaController configures the binlog replication controller with the |engine|.

--- a/go/libraries/doltcore/sqle/clusterdb/database.go
+++ b/go/libraries/doltcore/sqle/clusterdb/database.go
@@ -49,6 +49,9 @@ func (db database) Schema() string {
 	return ""
 }
 
+func (db database) Close() {
+}
+
 func (db database) GetTableInsensitive(ctx *sql.Context, tblName string) (sql.Table, bool, error) {
 	tblName = strings.ToLower(tblName)
 	if tblName == StatusTableName {

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -140,6 +140,10 @@ func (db Database) ValidateSchema(sch sql.Schema) error {
 	return nil
 }
 
+func (db Database) Close() {
+	db.gs.Close()
+}
+
 // Revision implements dsess.RevisionDatabase
 func (db Database) Revision() string {
 	return db.revision

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -210,6 +210,12 @@ func (p *DoltDatabaseProvider) FileSystem() filesys.Filesys {
 	return p.fs
 }
 
+func (p *DoltDatabaseProvider) Close() {
+	for _, db := range p.databases {
+		db.Close()
+	}
+}
+
 // Installs an InitDatabaseHook which configures new databases--those
 // created with `CREATE DATABASE` and `call dolt_clone` for
 // example--for push replication. Pull-on-read replication is already

--- a/go/libraries/doltcore/sqle/dsess/auto_increment_tracker_test.go
+++ b/go/libraries/doltcore/sqle/dsess/auto_increment_tracker_test.go
@@ -15,9 +15,14 @@
 package dsess
 
 import (
+	"context"
 	"fmt"
+	"sync"
 	"testing"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess/mutexmap"
+	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/stretchr/testify/assert"
@@ -72,4 +77,42 @@ func TestCoerceAutoIncrementValue(t *testing.T) {
 			assert.Equal(t, test.exp, act)
 		})
 	}
+}
+
+func TestInitWithRoots(t *testing.T) {
+	t.Run("EmptyRoots", func(t *testing.T) {
+		ait := AutoIncrementTracker{
+			dbName:     "test_database",
+			sequences:  &sync.Map{},
+			mm:         mutexmap.NewMutexMap(),
+			init:       make(chan struct{}),
+			cancelInit: make(chan struct{}),
+		}
+		go ait.initWithRoots(context.Background())
+		assert.NoError(t, ait.waitForInit())
+	})
+	t.Run("CloseCancelsInit", func(t *testing.T) {
+		ait := AutoIncrementTracker{
+			dbName:     "test_database",
+			sequences:  &sync.Map{},
+			mm:         mutexmap.NewMutexMap(),
+			init:       make(chan struct{}),
+			cancelInit: make(chan struct{}),
+		}
+		go ait.initWithRoots(context.Background(), blockingRoot{})
+		ait.Close()
+		assert.Error(t, ait.waitForInit())
+	})
+}
+
+type blockingRoot struct {
+}
+
+func (blockingRoot) ResolveRootValue(ctx context.Context) (doltdb.RootValue, error) {
+	<-ctx.Done()
+	return nil, context.Cause(ctx)
+}
+
+func (blockingRoot) HashOf() (hash.Hash, error) {
+	return hash.Hash{}, nil
 }

--- a/go/libraries/doltcore/sqle/dsess/auto_increment_tracker_test.go
+++ b/go/libraries/doltcore/sqle/dsess/auto_increment_tracker_test.go
@@ -20,12 +20,12 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess/mutexmap"
 	"github.com/dolthub/dolt/go/store/hash"
-	"github.com/dolthub/go-mysql-server/sql"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCoerceAutoIncrementValue(t *testing.T) {

--- a/go/libraries/doltcore/sqle/dsess/globalstate.go
+++ b/go/libraries/doltcore/sqle/dsess/globalstate.go
@@ -100,7 +100,7 @@ func NewGlobalStateStoreForDb(ctx context.Context, dbName string, db *doltdb.Dol
 }
 
 type GlobalStateImpl struct {
-	aiTracker globalstate.AutoIncrementTracker
+	aiTracker *AutoIncrementTracker
 	mu        *sync.Mutex
 }
 
@@ -108,4 +108,8 @@ var _ globalstate.GlobalState = GlobalStateImpl{}
 
 func (g GlobalStateImpl) AutoIncrementTracker(ctx *sql.Context) (globalstate.AutoIncrementTracker, error) {
 	return g.aiTracker, nil
+}
+
+func (g GlobalStateImpl) Close() {
+	g.aiTracker.Close()
 }

--- a/go/libraries/doltcore/sqle/dsess/session_db_provider.go
+++ b/go/libraries/doltcore/sqle/dsess/session_db_provider.go
@@ -138,4 +138,12 @@ type SqlDatabase interface {
 	DoltDatabases() []*doltdb.DoltDB
 	// Schema returns the schema of the database.
 	Schema() string
+
+	// Clean up any global resources associated with the
+	// SqlDatabase itself.  For DoltDatabases, this notably does
+	// not close the DoltDB, for example, but should shut down
+	// background threads not managed through
+	// sql.BackgroundThreads but which could be accessing or
+	// mutating database state.
+	Close()
 }

--- a/go/libraries/doltcore/sqle/user_space_database.go
+++ b/go/libraries/doltcore/sqle/user_space_database.go
@@ -47,6 +47,9 @@ func (db *UserSpaceDatabase) Schema() string {
 	return ""
 }
 
+func (db *UserSpaceDatabase) Close() {
+}
+
 func (db *UserSpaceDatabase) GetTableInsensitive(ctx *sql.Context, tableName string) (sql.Table, bool, error) {
 	tname := doltdb.TableName{Name: tableName}
 	if doltdb.IsReadOnlySystemTable(tname) {


### PR DESCRIPTION
This lets us more cleanly close DoltDB instances, which we should not be accessed after we close them.