### PR TITLE
Add `dolt ci run`

### DIFF
--- a/go/cmd/dolt/commands/ci/ci.go
+++ b/go/cmd/dolt/commands/ci/ci.go
@@ -26,4 +26,5 @@ var Commands = cli.NewSubCommandHandler("ci", "Commands for working with Dolt co
 	ListCmd{},
 	RemoveCmd{},
 	ViewCmd{},
+	RunCmd{},
 })

--- a/go/cmd/dolt/commands/ci/run.go
+++ b/go/cmd/dolt/commands/ci/run.go
@@ -18,15 +18,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/fatih/color"
+
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions/dolt_ci"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
-	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/fatih/color"
-	"strings"
 )
 
 var runDocs = cli.CommandDocumentationContent{

--- a/go/cmd/dolt/commands/ci/run.go
+++ b/go/cmd/dolt/commands/ci/run.go
@@ -1,0 +1,121 @@
+// Copyright 2025 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ci
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/cmd/dolt/commands"
+	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
+	"github.com/dolthub/dolt/go/libraries/doltcore/env"
+	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions/dolt_ci"
+	"github.com/dolthub/dolt/go/libraries/utils/argparser"
+)
+
+var runDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Run a Dolt CI workflow",
+	LongDesc:  "Run a Dolt CI workflow by executing all saved queries and validating their results",
+	Synopsis: []string{
+		"{{.LessThan}}workflow name{{.GreaterThan}}",
+	},
+}
+
+type RunCmd struct{}
+
+// Name implements cli.Command.
+func (cmd RunCmd) Name() string {
+	return "run"
+}
+
+// Description implements cli.Command.
+func (cmd RunCmd) Description() string {
+	return runDocs.ShortDesc
+}
+
+// RequiresRepo implements cli.Command.
+func (cmd RunCmd) RequiresRepo() bool {
+	return true
+}
+
+// Docs implements cli.Command.
+func (cmd RunCmd) Docs() *cli.CommandDocumentation {
+	ap := cmd.ArgParser()
+	return cli.NewCommandDocumentation(runDocs, ap)
+}
+
+// Hidden should return true if this command should be hidden from the help text
+func (cmd RunCmd) Hidden() bool {
+	return false
+}
+
+// ArgParser implements cli.Command.
+func (cmd RunCmd) ArgParser() *argparser.ArgParser {
+	ap := argparser.NewArgParserWithMaxArgs(cmd.Name(), 1)
+	return ap
+}
+
+// Exec implements cli.Command.
+func (cmd RunCmd) Exec(ctx context.Context, commandStr string, args []string, _ *env.DoltEnv, cliCtx cli.CliContext) int {
+	ap := cmd.ArgParser()
+	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, runDocs, ap))
+	_ = cli.ParseArgsOrDie(ap, args, help)
+
+	// Check if workflow name provided
+	if len(args) == 0 {
+		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(fmt.Errorf("workflow name is required")),
+			usage)
+	}
+	workflowName := args[0]
+
+	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	if err != nil {
+		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+	}
+	if closeFunc != nil {
+		defer closeFunc()
+	}
+
+	hasTables, err := dolt_ci.HasDoltCITables(queryist, sqlCtx)
+	if err != nil {
+		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+	}
+
+	if !hasTables {
+		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(fmt.Errorf("dolt ci has not been initialized, please initialize with: dolt ci init")), usage)
+	}
+
+	name, email, err := env.GetNameAndEmail(cliCtx.Config())
+	if err != nil {
+		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+	}
+	wm := dolt_ci.NewWorkflowManager(name, email, queryist.Query)
+
+	config, err := wm.GetWorkflowConfig(sqlCtx, workflowName)
+	if err != nil {
+		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
+	}
+
+	savedQueries, err := 
+
+	for _, job := range config.Jobs {
+		for _, step := range job.Steps {
+			//Do something
+		}
+	}
+
+	return 0
+}

--- a/go/cmd/dolt/commands/ci/view.go
+++ b/go/cmd/dolt/commands/ci/view.go
@@ -62,11 +62,6 @@ func (cmd ViewCmd) Docs() *cli.CommandDocumentation {
 	return cli.NewCommandDocumentation(viewDocs, ap)
 }
 
-// Hidden should return true if this command should be hidden from the help text
-func (cmd ViewCmd) Hidden() bool {
-	return false
-}
-
 // ArgParser implements cli.Command.
 func (cmd ViewCmd) ArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParserWithMaxArgs(cmd.Name(), 1)

--- a/go/cmd/dolt/commands/ci/view.go
+++ b/go/cmd/dolt/commands/ci/view.go
@@ -203,17 +203,29 @@ func getSavedQueries(sqlCtx *sql.Context, queryist cli.Queryist) (map[string]str
 			return nil, err
 		}
 		for _, row := range rows {
-			queryName, err := row[2].(*val.TextStorage).Unwrap(sqlCtx)
+			var queryName, queryStatement string
+			queryName, err = getStringColAsString(sqlCtx, row[2])
 			if err != nil {
 				return nil, err
 			}
-			queryStatement, err := row[3].(*val.TextStorage).Unwrap(sqlCtx)
+			queryStatement, err := getStringColAsString(sqlCtx, row[3])
 			if err != nil {
 				return nil, err
 			}
 			savedQueries[queryName] = queryStatement
 		}
 	}
-
 	return savedQueries, nil
+}
+
+// The dolt_query_catalog system table returns *val.TextStorage types under certain situations,
+// so we use a special parser to get the correct string values
+func getStringColAsString(sqlCtx *sql.Context, tableValue interface{}) (string, error) {
+	if ts, ok := tableValue.(*val.TextStorage); ok {
+		return ts.Unwrap(sqlCtx)
+	} else if str, ok := tableValue.(string); ok {
+		return str, nil
+	} else {
+		return "", fmt.Errorf("unexpected type %T, was expecting string", tableValue)
+	}
 }

--- a/go/libraries/doltcore/env/actions/dolt_ci/utils.go
+++ b/go/libraries/doltcore/env/actions/dolt_ci/utils.go
@@ -1,0 +1,60 @@
+// Copyright 2025 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dolt_ci
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func ParseSavedQueryExpectedResultString(str string) (WorkflowSavedQueryExpectedRowColumnComparisonType, int64, error) {
+	if str == "" {
+		return WorkflowSavedQueryExpectedRowColumnComparisonTypeUnspecified, 0, nil
+	}
+
+	parts := strings.Split(strings.TrimSpace(str), " ")
+	if len(parts) == 1 {
+		i, err := strconv.ParseInt(parts[0], 10, 64)
+		if err != nil {
+			return 0, 0, err
+		}
+		return WorkflowSavedQueryExpectedRowColumnComparisonTypeEquals, i, nil
+	}
+	if len(parts) == 2 {
+		i, err := strconv.ParseInt(parts[1], 10, 64)
+		if err != nil {
+			return 0, 0, err
+		}
+		switch strings.TrimSpace(parts[0]) {
+		case "==":
+			return WorkflowSavedQueryExpectedRowColumnComparisonTypeEquals, i, nil
+		case "!=":
+			return WorkflowSavedQueryExpectedRowColumnComparisonTypeNotEquals, i, nil
+		case ">":
+			return WorkflowSavedQueryExpectedRowColumnComparisonTypeGreaterThan, i, nil
+		case ">=":
+			return WorkflowSavedQueryExpectedRowColumnComparisonTypeGreaterThanOrEqual, i, nil
+		case "<":
+			return WorkflowSavedQueryExpectedRowColumnComparisonTypeLessThan, i, nil
+		case "<=":
+			return WorkflowSavedQueryExpectedRowColumnComparisonTypeLessThanOrEqual, i, nil
+		default:
+			return 0, 0, errors.New("unknown comparison type")
+		}
+	}
+	return 0, 0, fmt.Errorf("unable to parse comparison string: %s", str)
+}

--- a/go/libraries/doltcore/env/actions/dolt_ci/utils.go
+++ b/go/libraries/doltcore/env/actions/dolt_ci/utils.go
@@ -58,3 +58,36 @@ func ParseSavedQueryExpectedResultString(str string) (WorkflowSavedQueryExpected
 	}
 	return 0, 0, fmt.Errorf("unable to parse comparison string: %s", str)
 }
+
+func ValidateQueryExpectedRowOrColumnCount(countReal int64, countExpected int64, comp WorkflowSavedQueryExpectedRowColumnComparisonType, RowColumnType string) error {
+	switch comp {
+	case WorkflowSavedQueryExpectedRowColumnComparisonTypeEquals:
+		if countReal != countExpected {
+			return fmt.Errorf("expected %s count %d, got %d", RowColumnType, countExpected, countReal)
+		}
+	case WorkflowSavedQueryExpectedRowColumnComparisonTypeNotEquals:
+		if countReal == countExpected {
+			return fmt.Errorf("expected %s count not %d and got %d", RowColumnType, countExpected, countReal)
+		}
+	case WorkflowSavedQueryExpectedRowColumnComparisonTypeGreaterThan:
+		if countReal <= countExpected {
+			return fmt.Errorf("expected %s count greater than %d, got %d", RowColumnType, countExpected, countReal)
+		}
+	case WorkflowSavedQueryExpectedRowColumnComparisonTypeGreaterThanOrEqual:
+		if countReal < countExpected {
+			return fmt.Errorf("expected %s count greater than or equal to %d, got %d", RowColumnType, countExpected, countReal)
+		}
+	case WorkflowSavedQueryExpectedRowColumnComparisonTypeLessThan:
+		if countReal >= countExpected {
+			return fmt.Errorf("expected %s count less than %d, got %d", RowColumnType, countExpected, countReal)
+		}
+	case WorkflowSavedQueryExpectedRowColumnComparisonTypeLessThanOrEqual:
+		if countReal > countExpected {
+			return fmt.Errorf("expected %s count less than or equal to %d, got %d", RowColumnType, countExpected, countReal)
+		}
+	default:
+		return fmt.Errorf("no assertion run")
+	}
+
+	return nil
+}

--- a/go/libraries/doltcore/env/actions/dolt_ci/workflow_manager.go
+++ b/go/libraries/doltcore/env/actions/dolt_ci/workflow_manager.go
@@ -1319,7 +1319,7 @@ func (d *doltWorkflowManager) updateExistingWorkflow(ctx *sql.Context, config *W
 								newExpectedColumnComparisonType := WorkflowSavedQueryExpectedRowColumnComparisonTypeUnspecified
 								var newExpectedColumnCount int64
 								if configStep.ExpectedColumns.Value != "" {
-									newExpectedColumnComparisonType, newExpectedColumnCount, err = d.parseSavedQueryExpectedResultString(configStep.ExpectedColumns.Value)
+									newExpectedColumnComparisonType, newExpectedColumnCount, err = ParseSavedQueryExpectedResultString(configStep.ExpectedColumns.Value)
 									if err != nil {
 										return err
 									}
@@ -1328,7 +1328,7 @@ func (d *doltWorkflowManager) updateExistingWorkflow(ctx *sql.Context, config *W
 								newExpectedRowComparisonType := WorkflowSavedQueryExpectedRowColumnComparisonTypeUnspecified
 								var newExpectedRowCount int64
 								if configStep.ExpectedRows.Value != "" {
-									newExpectedRowComparisonType, newExpectedRowCount, err = d.parseSavedQueryExpectedResultString(configStep.ExpectedRows.Value)
+									newExpectedRowComparisonType, newExpectedRowCount, err = ParseSavedQueryExpectedResultString(configStep.ExpectedRows.Value)
 									if err != nil {
 										return err
 									}
@@ -1369,12 +1369,12 @@ func (d *doltWorkflowManager) updateExistingWorkflow(ctx *sql.Context, config *W
 					return err
 				}
 
-				expectedColumnComparisonType, expectedColumnCount, err := d.parseSavedQueryExpectedResultString(step.ExpectedColumns.Value)
+				expectedColumnComparisonType, expectedColumnCount, err := ParseSavedQueryExpectedResultString(step.ExpectedColumns.Value)
 				if err != nil {
 					return err
 				}
 
-				expectedRowComparisonType, expectedRowCount, err := d.parseSavedQueryExpectedResultString(step.ExpectedRows.Value)
+				expectedRowComparisonType, expectedRowCount, err := ParseSavedQueryExpectedResultString(step.ExpectedRows.Value)
 				if err != nil {
 					return err
 				}
@@ -1409,12 +1409,12 @@ func (d *doltWorkflowManager) updateExistingWorkflow(ctx *sql.Context, config *W
 				return err
 			}
 
-			expectedColumnComparisonType, expectedColumnCount, err := d.parseSavedQueryExpectedResultString(step.ExpectedColumns.Value)
+			expectedColumnComparisonType, expectedColumnCount, err := ParseSavedQueryExpectedResultString(step.ExpectedColumns.Value)
 			if err != nil {
 				return err
 			}
 
-			expectedRowComparisonType, expectedRowCount, err := d.parseSavedQueryExpectedResultString(step.ExpectedRows.Value)
+			expectedRowComparisonType, expectedRowCount, err := ParseSavedQueryExpectedResultString(step.ExpectedRows.Value)
 			if err != nil {
 				return err
 			}
@@ -1561,10 +1561,6 @@ func (d *doltWorkflowManager) writeWorkflowSavedQueryStepExpectedRowColumnResult
 		return "", err
 	}
 	return WorkflowSavedQueryExpectedRowColumnResultId(resultID), nil
-}
-
-func (d *doltWorkflowManager) parseSavedQueryExpectedResultString(str string) (WorkflowSavedQueryExpectedRowColumnComparisonType, int64, error) {
-	return ParseSavedQueryExpectedResultString(str)
 }
 
 func (d *doltWorkflowManager) toSavedQueryExpectedResultString(comparisonType WorkflowSavedQueryExpectedRowColumnComparisonType, count int64) (string, error) {
@@ -1723,12 +1719,12 @@ func (d *doltWorkflowManager) createWorkflow(ctx *sql.Context, config *WorkflowC
 
 				if resultType == WorkflowSavedQueryExpectedResultsTypeRowColumnCount {
 					// insert into expected results
-					expectedColumnComparisonType, expectedColumnCount, err := d.parseSavedQueryExpectedResultString(step.ExpectedColumns.Value)
+					expectedColumnComparisonType, expectedColumnCount, err := ParseSavedQueryExpectedResultString(step.ExpectedColumns.Value)
 					if err != nil {
 						return err
 					}
 
-					expectedRowComparisonType, expectedRowCount, err := d.parseSavedQueryExpectedResultString(step.ExpectedRows.Value)
+					expectedRowComparisonType, expectedRowCount, err := ParseSavedQueryExpectedResultString(step.ExpectedRows.Value)
 					if err != nil {
 						return err
 					}

--- a/go/libraries/doltcore/env/actions/dolt_ci/workflow_manager.go
+++ b/go/libraries/doltcore/env/actions/dolt_ci/workflow_manager.go
@@ -1564,41 +1564,7 @@ func (d *doltWorkflowManager) writeWorkflowSavedQueryStepExpectedRowColumnResult
 }
 
 func (d *doltWorkflowManager) parseSavedQueryExpectedResultString(str string) (WorkflowSavedQueryExpectedRowColumnComparisonType, int64, error) {
-	if str == "" {
-		return WorkflowSavedQueryExpectedRowColumnComparisonTypeUnspecified, 0, nil
-	}
-
-	parts := strings.Split(strings.TrimSpace(str), " ")
-	if len(parts) == 1 {
-		i, err := strconv.ParseInt(parts[0], 10, 64)
-		if err != nil {
-			return 0, 0, err
-		}
-		return WorkflowSavedQueryExpectedRowColumnComparisonTypeEquals, i, nil
-	}
-	if len(parts) == 2 {
-		i, err := strconv.ParseInt(parts[1], 10, 64)
-		if err != nil {
-			return 0, 0, err
-		}
-		switch strings.TrimSpace(parts[0]) {
-		case "==":
-			return WorkflowSavedQueryExpectedRowColumnComparisonTypeEquals, i, nil
-		case "!=":
-			return WorkflowSavedQueryExpectedRowColumnComparisonTypeNotEquals, i, nil
-		case ">":
-			return WorkflowSavedQueryExpectedRowColumnComparisonTypeGreaterThan, i, nil
-		case ">=":
-			return WorkflowSavedQueryExpectedRowColumnComparisonTypeGreaterThanOrEqual, i, nil
-		case "<":
-			return WorkflowSavedQueryExpectedRowColumnComparisonTypeLessThan, i, nil
-		case "<=":
-			return WorkflowSavedQueryExpectedRowColumnComparisonTypeLessThanOrEqual, i, nil
-		default:
-			return 0, 0, errors.New("unknown comparison type")
-		}
-	}
-	return 0, 0, fmt.Errorf("unable to parse comparison string: %s", str)
+	return ParseSavedQueryExpectedResultString(str)
 }
 
 func (d *doltWorkflowManager) toSavedQueryExpectedResultString(comparisonType WorkflowSavedQueryExpectedRowColumnComparisonType, count int64) (string, error) {

--- a/integration-tests/bats/ci.bats
+++ b/integration-tests/bats/ci.bats
@@ -554,7 +554,6 @@ EOF
     dolt ci import ./workflow.yaml
     dolt sql --save "main" -q "select * from dolt_commits;"
     run dolt ci run "workflow"
-    echo "$output"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Running workflow: workflow" ]] || false
     [[ "$output" =~ "Step: expect rows - FAIL" ]] || false

--- a/integration-tests/bats/ci.bats
+++ b/integration-tests/bats/ci.bats
@@ -458,3 +458,12 @@ EOF
     [ "$status" -eq 1 ]
     [[ "$output" =~ "cannot find job with name: invalid job" ]] || false
 }
+
+
+# TESTS FOR CI RUN
+# RUN W EXPECTED COLUMNS
+# RUN W EXPECTED ROWS
+# RUN WITH EXPECTED ROWS AND COLUMNS
+# ONLY/ALL ASSERTIONS FAILS
+# SOME ASSERTIONS PASS, SOME ASSERTIONS FAIL
+# RUN ON INVALID WORKFLOW

--- a/integration-tests/bats/ci.bats
+++ b/integration-tests/bats/ci.bats
@@ -456,9 +456,9 @@ name: workflow
 on:
   push: {}
 jobs:
-  - name: verify initial commit
+  - name: verify initial commits
     steps:
-      - name: "verify initial commit"
+      - name: "verify initial commits"
         saved_query_name: check dolt commit
         expected_rows: "== 3"
 EOF
@@ -468,8 +468,8 @@ EOF
     run dolt ci run "workflow"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Running workflow: workflow" ]] || false
-    [[ "$output" =~ "Running job: verify initial commit" ]] || false
-    [[ "$output" =~ "Step: verify initial commit - PASS" ]] || false
+    [[ "$output" =~ "Running job: verify initial commits" ]] || false
+    [[ "$output" =~ "Step: verify initial commits - PASS" ]] || false
 }
 
 @test "ci: ci run with expected columns" {
@@ -478,9 +478,9 @@ name: workflow
 on:
   push: {}
 jobs:
-  - name: verify initial commit
+  - name: verify dolt commit
     steps:
-      - name: "verify initial commit"
+      - name: "verify dolt commit"
         saved_query_name: check dolt commit
         expected_columns: "== 5"
 EOF
@@ -490,8 +490,8 @@ EOF
     run dolt ci run "workflow"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Running workflow: workflow" ]] || false
-    [[ "$output" =~ "Running job: verify initial commit" ]] || false
-    [[ "$output" =~ "Step: verify initial commit - PASS" ]] || false
+    [[ "$output" =~ "Running job: verify dolt commit" ]] || false
+    [[ "$output" =~ "Step: verify dolt commit - PASS" ]] || false
 }
 
 @test "ci: each assertion type can be used" {

--- a/integration-tests/bats/ci.bats
+++ b/integration-tests/bats/ci.bats
@@ -557,8 +557,10 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Running workflow: workflow" ]] || false
     [[ "$output" =~ "Step: expect rows - FAIL" ]] || false
+    [[ "$output" =~ "Ran query: select * from dolt_commits;" ]] || false
     [[ "$output" =~ "Assertion failed: expected row count 2, got 3" ]] || false
     [[ "$output" =~ "Step: expect columns - FAIL" ]] || false
+    [[ "$output" =~ "Ran query: select * from dolt_commits;" ]] || false
     [[ "$output" =~ "Assertion failed: expected column count less than 5, got 5" ]] || false
 }
 
@@ -582,6 +584,7 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Running workflow: workflow" ]] || false
     [[ "$output" =~ "Step: should fail, bad table name - FAIL" ]] || false
+    [[ "$output" =~ "Ran query: select * from invalid" ]] || false
     [[ "$output" =~ "Query error" ]] || false
     [[ "$output" =~ "table not found: invalid" ]] || false
 }


### PR DESCRIPTION
Adds `dolt ci run`:

Usage: `dolt ci run <workflow name>`

Runs all defined saved queries and asserts the given column or row count against those queries.