### PR TITLE
[no-release-notes] proto/Makefile: Fix the generation of _grpc.pb.go files.

### DIFF
--- a/proto/Makefile
+++ b/proto/Makefile
@@ -68,7 +68,7 @@ $(call PROTOC_template,\
   $(1),\
   $(addprefix $(3)/$(2)/,$(notdir $(call PBGO_output,$(1)))),\
 	--go_out=paths=source_relative:$(3) \
-        --go-grpc_out=$(3))
+        --go-grpc_out=paths=source_relative:$(3))
 endef
 
 $(foreach p,$(PBGO_pkgs),\


### PR DESCRIPTION
With the removal of the circular symlink in go/gen/proto/github.com, we need grpc-go_out path to be source relative as well.