### PR TITLE
dolthub/dolt#9606 - Add tests for ALTER TABLE MODIFY COLUMN row count reporting

### DIFF
--- a/integration-tests/bats/alter-table-modify-rows-affected.expect
+++ b/integration-tests/bats/alter-table-modify-rows-affected.expect
@@ -1,0 +1,20 @@
+#!/usr/bin/expect
+
+set timeout 5
+set env(NO_COLOR) 1
+
+source  "$env(BATS_CWD)/helper/common_expect_functions.tcl"
+
+spawn dolt sql
+
+# Simple isolated test of ALTER TABLE MODIFY COLUMN row count
+expect_with_defaults                               {dolt-repo-[0-9]+/main\*>}   { send "create table test_alter (id int primary key, data varchar(10));\r" }
+
+expect_with_defaults                               {dolt-repo-[0-9]+/main\*>}   { send "insert into test_alter values (1, 'a'), (2, 'b');\r" }
+
+expect_with_defaults_2 {Query OK, 2 rows affected} {dolt-repo-[0-9]+/main\*> }  { send "alter table test_alter modify column data varchar(50);\r" }
+
+expect_with_defaults                               {dolt-repo-[0-9]+/main\*>}   { send "quit\r" }
+
+expect eof
+exit

--- a/integration-tests/bats/sql-shell-ok-result.expect
+++ b/integration-tests/bats/sql-shell-ok-result.expect
@@ -13,6 +13,8 @@ expect_with_defaults_2 {Query OK, 0 rows affected} {dolt-repo-[0-9]+/main\*> }  
 
 expect_with_defaults_2 {Query OK, 0 rows affected} {dolt-repo-[0-9]+/main\*> }  { send "insert into t values (1, 2), (3, 4);\r" }
 
+expect_with_defaults_2 {Query OK, 2 rows affected} {dolt-repo-[0-9]+/main\*> }  { send "alter table t modify column j bigint;\r" }
+
 expect_with_defaults_2 {Query OK, 2 rows affected} {dolt-repo-[0-9]+/main\*> }  { send "update t set j = 20 where i = 1;\r" }
 
 expect_with_defaults_2 {Query OK, 1 row affected} {dolt-repo-[0-9]+/main\*> }  { send "delete from t where i > 0;\r" }

--- a/integration-tests/bats/sql-shell.bats
+++ b/integration-tests/bats/sql-shell.bats
@@ -1070,3 +1070,15 @@ expect eof
         run $BATS_TEST_DIRNAME/sql-shell-commit-time.expect
         [ "$status" -eq 0 ]
 }
+
+# bats test_tags=no_lambda
+@test "sql-shell: ALTER TABLE MODIFY COLUMN reports correct row count" {
+    skiponwindows "Need to install expect and make this script work on windows."
+    if [ "$SQL_ENGINE" = "remote-engine" ]; then
+        skip "shell on server returns Empty Set instead of OkResult"
+    fi
+    
+    # Test for Issue #9606: ALTER TABLE MODIFY COLUMN should report actual row count
+    run $BATS_TEST_DIRNAME/alter-table-modify-rows-affected.expect
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Fixes dolthub/dolt#9606
Companion: dolthub/go-mysql-server#3132
Adds comprehensive bats tests to verify that ALTER TABLE MODIFY COLUMN reports the correct number of rows affected instead of "Query OK, 0 rows affected".
