### PR TITLE
dolthub/dolt#7128 - Remove old test for string to number errors

### DIFF
--- a/go/libraries/doltcore/sqle/sqlupdate_test.go
+++ b/go/libraries/doltcore/sqle/sqlupdate_test.go
@@ -323,21 +323,6 @@ var BasicUpdateTests = []UpdateTest{
 		UpdateQuery: `update people set first_name = ("one", "two") where id = 0`,
 		ExpectedErr: "Type mismatch",
 	},
-	{
-		Name:        "type mismatch string -> int",
-		UpdateQuery: `update people set age = "pretty old" where id = 0`,
-		ExpectedErr: "Type mismatch",
-	},
-	{
-		Name:        "type mismatch string -> float",
-		UpdateQuery: `update people set rating = "great" where id = 0`,
-		ExpectedErr: "Type mismatch",
-	},
-	{
-		Name:        "type mismatch string -> uint",
-		UpdateQuery: `update people set num_episodes = "all of them" where id = 0`,
-		ExpectedErr: "Type mismatch",
-	},
 }
 
 func TestExecuteUpdate(t *testing.T) {


### PR DESCRIPTION
Fixes #7128
Companion dolthub/go-mysql-server#3136
Remove old tests for expected string to number errors