### PR TITLE
dolthub/dolt#9582 - Fix cherry-pick timestamp preservation

### DIFF
--- a/go/libraries/doltcore/cherry_pick/cherry_pick.go
+++ b/go/libraries/doltcore/cherry_pick/cherry_pick.go
@@ -159,7 +159,7 @@ func CreateCommitStagedPropsFromCherryPickOptions(ctx *sql.Context, options Cher
 	}
 
 	commitProps := actions.CommitStagedProps{
-		Date:  ctx.QueryTime(),
+		Date:  originalMeta.Time(),
 		Name:  originalMeta.Name,
 		Email: originalMeta.Email,
 	}


### PR DESCRIPTION
Cherry-pick now preserves original commit timestamp during operations.