### PR TITLE
Small fixes to ci, --help & valid branch names

### DIFF
--- a/go/cmd/dolt/commands/ci/import.go
+++ b/go/cmd/dolt/commands/ci/import.go
@@ -33,13 +33,29 @@ import (
 
 var importDocs = cli.CommandDocumentationContent{
 	ShortDesc: "Import a Dolt continuous integration workflow file into the database",
-	LongDesc: "Import a Dolt continuous integration workflow file into the database and create a Dolt commit" +
-		"\nWorkflow YAML Specification:\n\n\t  name: <workflow-name>\n\n\t  on:\n\t    push:\n\t      " +
-		"branches: [<branch-name>, ...]\n\t    pull_request:\n\t      branches: [<branch-name>, ...]\n\t      " +
-		"activities: [opened, closed, reopened, synchronized]\n\t    workflow_dispatch: {}\n\n\t  jobs:\n\t    " +
-		"- name: <job-name>\n\t      steps:\n\t        - name: <step-name>\n\t          " +
-		"saved_query_name: <query-name>\n\t          saved_query_statement: <optional-sql-statement>\n\t          " +
-		"expected_columns: <optional-expected-columns>\n\t          expected_rows: <optional-expected-rows>",
+	LongDesc: `Import a Dolt continuous integration workflow file into the database 
+and create a Dolt commit.
+
+Workflow YAML Specification:
+
+  name: <workflow-name>
+
+  on:
+    push:
+      branches: [<branch-name>, ...]
+    pull_request:
+      branches: [<branch-name>, ...]
+      activities: [opened, closed, reopened, synchronized]
+    workflow_dispatch: {}
+
+  jobs:
+    - name: <job-name>
+      steps:
+        - name: <step-name>
+          saved_query_name: <query-name>
+          saved_query_statement: <optional-sql-statement>
+          expected_columns: <optional-expected-columns>
+          expected_rows: <optional-expected-rows>`,
 	Synopsis: []string{
 		"{{.LessThan}}file{{.GreaterThan}}",
 	},

--- a/go/cmd/dolt/commands/ci/import.go
+++ b/go/cmd/dolt/commands/ci/import.go
@@ -33,7 +33,13 @@ import (
 
 var importDocs = cli.CommandDocumentationContent{
 	ShortDesc: "Import a Dolt continuous integration workflow file into the database",
-	LongDesc:  "Import a Dolt continuous integration workflow file into the database and create a Dolt commit",
+	LongDesc: "Import a Dolt continuous integration workflow file into the database and create a Dolt commit" +
+		"\nWorkflow YAML Specification:\n\n\t  name: <workflow-name>\n\n\t  on:\n\t    push:\n\t      " +
+		"branches: [<branch-name>, ...]\n\t    pull_request:\n\t      branches: [<branch-name>, ...]\n\t      " +
+		"activities: [opened, closed, reopened, synchronized]\n\t    workflow_dispatch: {}\n\n\t  jobs:\n\t    " +
+		"- name: <job-name>\n\t      steps:\n\t        - name: <step-name>\n\t          " +
+		"saved_query_name: <query-name>\n\t          saved_query_statement: <optional-sql-statement>\n\t          " +
+		"expected_columns: <optional-expected-columns>\n\t          expected_rows: <optional-expected-rows>",
 	Synopsis: []string{
 		"{{.LessThan}}file{{.GreaterThan}}",
 	},

--- a/go/libraries/doltcore/env/actions/dolt_ci/workflow_config.go
+++ b/go/libraries/doltcore/env/actions/dolt_ci/workflow_config.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"io"
 
 	"gopkg.in/yaml.v3"
@@ -99,9 +100,11 @@ func ValidateWorkflowConfig(workflow *WorkflowConfig) error {
 			_, ok := branches[branch.Value]
 			if ok {
 				return fmt.Errorf("invalid config: on push branch duplicated: %s", branch.Value)
-			} else {
-				branches[branch.Value] = true
 			}
+			if !ref.IsValidBranchName(branch.Value) {
+				return fmt.Errorf("invalid branch name: %s", branch.Value)
+			}
+			branches[branch.Value] = true
 		}
 	}
 
@@ -111,9 +114,11 @@ func ValidateWorkflowConfig(workflow *WorkflowConfig) error {
 			_, ok := branches[branch.Value]
 			if ok {
 				return fmt.Errorf("invalid config: on pull request branch duplicated: %s", branch.Value)
-			} else {
-				branches[branch.Value] = true
 			}
+			if !ref.IsValidBranchName(branch.Value) {
+				return fmt.Errorf("invalid branch name: %s", branch.Value)
+			}
+			branches[branch.Value] = true
 		}
 
 		activities := make(map[string]bool)

--- a/go/libraries/doltcore/env/actions/dolt_ci/workflow_config.go
+++ b/go/libraries/doltcore/env/actions/dolt_ci/workflow_config.go
@@ -18,8 +18,9 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"io"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 
 	"gopkg.in/yaml.v3"
 )

--- a/integration-tests/bats/ci.bats
+++ b/integration-tests/bats/ci.bats
@@ -156,6 +156,41 @@ EOF
     [ "$status" -eq 1 ]
 }
 
+@test "ci: import command will error on invalid branches" {
+    cat > workflow.yaml <<EOF
+name: my_workflow
+on:
+  push:
+    branches:
+      - ..invalid
+jobs:
+  - name: test job
+    steps:
+      - name: test step
+        saved_query_name: test query
+EOF
+    cat > workflow2.yaml <<EOF
+name: workflow
+on:
+  push:
+    branches:
+      - "*"
+jobs:
+  - name: test job
+    steps:
+      - name: test step
+        saved_query_name: test query
+EOF
+
+    dolt ci init
+    run dolt ci import workflow.yaml
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "invalid branch name: ..invalid" ]] || false
+    run dolt ci import workflow2.yaml
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "invalid branch name: *" ]] || false
+}
+
 @test "ci: import command will update existing workflow" {
     cat > workflow_1.yaml <<EOF
 name: workflow_1


### PR DESCRIPTION
Two small changes to CI:

1. `dolt ci import` now requires that the branches you list under `on.action`, `on.pull_request` are valid branch names. This also blocks off attempting to use the `*` wildcard identifier, which we do not support.
2. I also expanded the `dolt ci import --help` page to include the specification for the workflow yaml files.