### PR TITLE
Add UUID key recommendation to default AGENT.md

### DIFF
--- a/go/libraries/doltcore/doltdb/system_table.go
+++ b/go/libraries/doltcore/doltdb/system_table.go
@@ -534,6 +534,28 @@ SELECT * FROM dolt_ignore;
 - Examining system tables (dolt_log, dolt_status, etc.)
 - When already in an active SQL session
 
+## Schema Design Recommendations
+
+### Use UUID Keys Instead of Auto-Increment
+
+For Dolt's version control features, use UUID primary keys instead of auto-increment:
+
+` + "```sql" + `
+-- Recommended
+CREATE TABLE users (
+    id varchar(36) default(uuid()) primary key,
+    name varchar(255)
+);
+
+-- Avoid auto-increment with Dolt
+-- id int auto_increment primary key
+` + "```" + `
+
+**Benefits:**
+- Prevents merge conflicts across branches and database clones
+- Automatic generation with ` + "`default(uuid())`" + `
+- Works seamlessly in distributed environments
+
 ## Best Practices for Agents
 
 ### 1. Always Work on Feature Branches


### PR DESCRIPTION
I notice that Claude Code likes auto_increment primary keys but Dolt likes UUID keys better. So, I added a section to AGENT.md.