### PR TITLE
Removed root object presence from some locations

### DIFF
--- a/go/cmd/dolt/commands/assist.go
+++ b/go/cmd/dolt/commands/assist.go
@@ -588,7 +588,7 @@ func getCreateTableStatements(ctx *sql.Context, sqlEngine *engine.SqlEngine, dEn
 		return "", err
 	}
 
-	tables, err := root.GetTableNames(ctx, doltdb.DefaultSchemaName)
+	tables, err := root.GetTableNames(ctx, doltdb.DefaultSchemaName, true)
 	for _, table := range tables {
 		_, iter, _, err := sqlEngine.Query(ctx, fmt.Sprintf("SHOW CREATE TABLE %s", sql.QuoteIdentifier(table)))
 		if err != nil {

--- a/go/cmd/dolt/commands/cvcmds/verify_constraints.go
+++ b/go/cmd/dolt/commands/cvcmds/verify_constraints.go
@@ -79,7 +79,7 @@ func (cmd VerifyConstraintsCmd) Exec(ctx context.Context, commandStr string, arg
 	}
 	tableNames := apr.Args
 	if len(tableNames) == 0 {
-		tableNames, err = working.GetTableNames(ctx, doltdb.DefaultSchemaName)
+		tableNames, err = working.GetTableNames(ctx, doltdb.DefaultSchemaName, true)
 		if err != nil {
 			return commands.HandleVErrAndExitCode(errhand.BuildDError("Unable to read table names.").AddCause(err).Build(), nil)
 		}

--- a/go/cmd/dolt/commands/indexcmds/ls.go
+++ b/go/cmd/dolt/commands/indexcmds/ls.go
@@ -72,7 +72,7 @@ func (cmd LsCmd) Exec(ctx context.Context, commandStr string, args []string, dEn
 
 	var tableNames []string
 	if apr.NArg() == 0 {
-		tableNames, err = working.GetTableNames(ctx, doltdb.DefaultSchemaName)
+		tableNames, err = working.GetTableNames(ctx, doltdb.DefaultSchemaName, true)
 		if err != nil {
 			return HandleErr(errhand.BuildDError("Unable to get tables.").AddCause(err).Build(), nil)
 		}

--- a/go/cmd/dolt/commands/read_tables.go
+++ b/go/cmd/dolt/commands/read_tables.go
@@ -144,7 +144,7 @@ func (cmd ReadTablesCmd) Exec(ctx context.Context, commandStr string, args []str
 	}
 
 	if len(tblNames) == 0 {
-		tblNames, err = srcRoot.GetTableNames(ctx, doltdb.DefaultSchemaName)
+		tblNames, err = srcRoot.GetTableNames(ctx, doltdb.DefaultSchemaName, true)
 
 		if err != nil {
 			return BuildVerrAndExit("Unable to read tables.", err)

--- a/go/cmd/dolt/commands/schcmds/show.go
+++ b/go/cmd/dolt/commands/schcmds/show.go
@@ -120,7 +120,7 @@ func printSchemas(ctx context.Context, apr *argparser.ArgParseResults, dEnv *env
 		// show usage and error out if there aren't any
 		if len(tables) == 0 {
 			var err error
-			tables, err = root.GetTableNames(ctx, doltdb.DefaultSchemaName)
+			tables, err = root.GetTableNames(ctx, doltdb.DefaultSchemaName, true)
 
 			if err != nil {
 				return errhand.BuildDError("unable to get table names.").AddCause(err).Build()

--- a/go/cmd/dolt/commands/schcmds/tags.go
+++ b/go/cmd/dolt/commands/schcmds/tags.go
@@ -79,7 +79,7 @@ func (cmd TagsCmd) Exec(ctx context.Context, commandStr string, args []string, d
 
 	if len(tables) == 0 {
 		var err error
-		tables, err = root.GetTableNames(ctx, doltdb.DefaultSchemaName)
+		tables, err = root.GetTableNames(ctx, doltdb.DefaultSchemaName, true)
 
 		if err != nil {
 			return commands.HandleVErrAndExitCode(errhand.BuildDError("unable to get table names.").AddCause(err).Build(), usage)

--- a/go/libraries/doltcore/doltdb/doltdb_test.go
+++ b/go/libraries/doltcore/doltdb/doltdb_test.go
@@ -295,7 +295,7 @@ func TestLDNoms(t *testing.T) {
 
 		assert.NoError(t, err)
 
-		names, err := root.GetTableNames(context.Background(), DefaultSchemaName)
+		names, err := root.GetTableNames(context.Background(), DefaultSchemaName, true)
 		assert.NoError(t, err)
 		if len(names) != 0 {
 			t.Fatal("There should be no tables in empty db")

--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -88,7 +88,7 @@ type RootValue interface {
 	// GetTableSchemaHash returns the hash of the given table's schema.
 	GetTableSchemaHash(ctx context.Context, tName TableName) (hash.Hash, error)
 	// GetTableNames retrieves the lists of all tables and root objects for a RootValue.
-	GetTableNames(ctx context.Context, schemaName string) ([]string, error)
+	GetTableNames(ctx context.Context, schemaName string, includeRootObjects bool) ([]string, error)
 	// HasTable returns whether the root has a table with the given case-sensitive name. This will also return true if a
 	// root object matches the table name, as they occupy the same namespace.
 	HasTable(ctx context.Context, tName TableName) (bool, error)
@@ -624,7 +624,7 @@ func GetTableByColTag(ctx context.Context, root RootValue, tag uint64) (tbl *Tab
 }
 
 // GetTableNames retrieves the lists of all tables for a RootValue
-func (root *rootValue) GetTableNames(ctx context.Context, schemaName string) ([]string, error) {
+func (root *rootValue) GetTableNames(ctx context.Context, schemaName string, _ bool) ([]string, error) {
 	tableMap, err := root.getTableMap(ctx, schemaName)
 	if err != nil {
 		return nil, err
@@ -1271,7 +1271,7 @@ func UnionTableNames(ctx context.Context, roots ...RootValue) ([]TableName, erro
 		}
 
 		for _, schemaName := range schemaNames {
-			rootTblNames, err := root.GetTableNames(ctx, schemaName)
+			rootTblNames, err := root.GetTableNames(ctx, schemaName, true)
 			if err != nil {
 				return nil, err
 			}

--- a/go/libraries/doltcore/doltdb/system_table.go
+++ b/go/libraries/doltcore/doltdb/system_table.go
@@ -99,7 +99,7 @@ func IsNonAlterableSystemTable(name TableName) bool {
 
 // GetNonSystemTableNames gets non-system table names
 func GetNonSystemTableNames(ctx context.Context, root RootValue) ([]string, error) {
-	tn, err := root.GetTableNames(ctx, DefaultSchemaName)
+	tn, err := root.GetTableNames(ctx, DefaultSchemaName, true)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/env/actions/dolt_ci/workflow_manager.go
+++ b/go/libraries/doltcore/env/actions/dolt_ci/workflow_manager.go
@@ -531,7 +531,7 @@ func (d *doltWorkflowManager) validateWorkflowTables(ctx *sql.Context) error {
 
 	root := roots.Working
 
-	tables, err := root.GetTableNames(ctx, doltdb.DefaultSchemaName)
+	tables, err := root.GetTableNames(ctx, doltdb.DefaultSchemaName, true)
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/env/actions/reset.go
+++ b/go/libraries/doltcore/env/actions/reset.go
@@ -277,7 +277,7 @@ func CleanUntracked(ctx *sql.Context, roots doltdb.Roots, tables []string, dryru
 
 	var err error
 	if len(tables) == 0 {
-		tables, err = roots.Working.GetTableNames(ctx, doltdb.DefaultSchemaName)
+		tables, err = roots.Working.GetTableNames(ctx, doltdb.DefaultSchemaName, true)
 		if err != nil {
 			return doltdb.Roots{}, nil
 		}

--- a/go/libraries/doltcore/merge/action.go
+++ b/go/libraries/doltcore/merge/action.go
@@ -184,7 +184,7 @@ func AbortMerge(ctx *sql.Context, workingSet *doltdb.WorkingSet, roots doltdb.Ro
 	}
 
 	preMergeWorkingRoot := workingSet.MergeState().PreMergeWorkingRoot()
-	preMergeWorkingTables, err := preMergeWorkingRoot.GetTableNames(ctx, doltdb.DefaultSchemaName)
+	preMergeWorkingTables, err := preMergeWorkingRoot.GetTableNames(ctx, doltdb.DefaultSchemaName, true)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/merge/fulltext_rebuild.go
+++ b/go/libraries/doltcore/merge/fulltext_rebuild.go
@@ -39,7 +39,7 @@ type rebuildableFulltextTable struct {
 // roots (ours and theirs), or had parents that were modified by both roots.
 func rebuildFullTextIndexes(ctx *sql.Context, mergedRoot, ourRoot, theirRoot doltdb.RootValue, visitedTables map[string]struct{}) (doltdb.RootValue, error) {
 	// Grab a list of all tables on the root
-	allTableNames, err := mergedRoot.GetTableNames(ctx, doltdb.DefaultSchemaName)
+	allTableNames, err := mergedRoot.GetTableNames(ctx, doltdb.DefaultSchemaName, false)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/merge/stash.go
+++ b/go/libraries/doltcore/merge/stash.go
@@ -61,7 +61,7 @@ func (s *violationStash) Empty() bool {
 }
 
 func stashConflicts(ctx context.Context, root doltdb.RootValue) (doltdb.RootValue, *conflictStash, error) {
-	names, err := root.GetTableNames(ctx, doltdb.DefaultSchemaName)
+	names, err := root.GetTableNames(ctx, doltdb.DefaultSchemaName, true)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -92,7 +92,7 @@ func stashConflicts(ctx context.Context, root doltdb.RootValue) (doltdb.RootValu
 }
 
 func stashViolations(ctx context.Context, root doltdb.RootValue) (doltdb.RootValue, *violationStash, error) {
-	names, err := root.GetTableNames(ctx, doltdb.DefaultSchemaName)
+	names, err := root.GetTableNames(ctx, doltdb.DefaultSchemaName, true)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/libraries/doltcore/migrate/transform.go
+++ b/go/libraries/doltcore/migrate/transform.go
@@ -375,12 +375,12 @@ func migrateRoot(ctx context.Context, menv Environment, oldParent, oldRoot, newP
 
 // renames also get returned here
 func getRemovedTableNames(ctx context.Context, prev, curr doltdb.RootValue) ([]string, error) {
-	prevNames, err := prev.GetTableNames(ctx, doltdb.DefaultSchemaName)
+	prevNames, err := prev.GetTableNames(ctx, doltdb.DefaultSchemaName, true)
 	if err != nil {
 		return nil, err
 	}
 	tblNameSet := set.NewStrSet(prevNames)
-	currNames, err := curr.GetTableNames(ctx, doltdb.DefaultSchemaName)
+	currNames, err := curr.GetTableNames(ctx, doltdb.DefaultSchemaName, true)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/migrate/validation.go
+++ b/go/libraries/doltcore/migrate/validation.go
@@ -54,7 +54,7 @@ func validateBranchMapping(ctx context.Context, old, new *doltdb.DoltDB) error {
 }
 
 func validateRootValue(ctx context.Context, oldParent, old, new doltdb.RootValue) error {
-	names, err := old.GetTableNames(ctx, doltdb.DefaultSchemaName)
+	names, err := old.GetTableNames(ctx, doltdb.DefaultSchemaName, true)
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/sqle/commit_hooks_test.go
+++ b/go/libraries/doltcore/sqle/commit_hooks_test.go
@@ -107,7 +107,7 @@ func TestPushOnWriteHook(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	names, err := root.GetTableNames(context.Background(), doltdb.DefaultSchemaName)
+	names, err := root.GetTableNames(context.Background(), doltdb.DefaultSchemaName, true)
 	assert.NoError(t, err)
 	if len(names) != 0 {
 		t.Fatal("There should be no tables in empty db")

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_conflicts_resolve.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_conflicts_resolve.go
@@ -319,7 +319,7 @@ func resolveNomsConflicts(ctx *sql.Context, opts editor.Options, tbl *doltdb.Tab
 }
 
 func validateConstraintViolations(ctx *sql.Context, before, after doltdb.RootValue, table doltdb.TableName) error {
-	tables, err := after.GetTableNames(ctx, table.Schema)
+	tables, err := after.GetTableNames(ctx, table.Schema, true)
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_verify_constraints.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_verify_constraints.go
@@ -176,7 +176,7 @@ func parseTablesToCheck(ctx *sql.Context, workingRoot doltdb.RootValue, apr *arg
 	// If no tables were explicitly specified, then check all tables
 	if tableSet.Size() == 0 {
 		// TODO: schema search path
-		names, err := workingRoot.GetTableNames(ctx, doltdb.DefaultSchemaName)
+		names, err := workingRoot.GetTableNames(ctx, doltdb.DefaultSchemaName, true)
 		if err != nil {
 			return nil, err
 		}

--- a/go/libraries/doltcore/sqle/dtablefunctions/dolt_diff_stat.go
+++ b/go/libraries/doltcore/sqle/dtablefunctions/dolt_diff_stat.go
@@ -385,6 +385,11 @@ func getDiffStatNodeFromDelta(ctx *sql.Context, delta diff.TableDelta, fromRoot,
 			return diffStatNode{}, false, err
 		}
 		oldColLen = len(fromSch.GetAllCols().GetColumns())
+	} else {
+		_, fromTableExists, err = fromRoot.GetRootObject(ctx, tableName)
+		if err != nil {
+			return diffStatNode{}, false, err
+		}
 	}
 
 	toTable, _, toTableExists, err := doltdb.GetTableInsensitive(ctx, toRoot, tableName)
@@ -398,6 +403,11 @@ func getDiffStatNodeFromDelta(ctx *sql.Context, delta diff.TableDelta, fromRoot,
 			return diffStatNode{}, false, err
 		}
 		newColLen = len(toSch.GetAllCols().GetColumns())
+	} else {
+		_, toTableExists, err = toRoot.GetRootObject(ctx, tableName)
+		if err != nil {
+			return diffStatNode{}, false, err
+		}
 	}
 
 	if !fromTableExists && !toTableExists {
@@ -405,7 +415,7 @@ func getDiffStatNodeFromDelta(ctx *sql.Context, delta diff.TableDelta, fromRoot,
 	}
 
 	// no diff from tableDelta
-	if delta.FromTable == nil && delta.ToTable == nil {
+	if delta.FromTable == nil && delta.ToTable == nil && delta.FromRootObject == nil && delta.ToRootObject == nil {
 		return diffStatNode{}, false, nil
 	}
 

--- a/go/libraries/doltcore/sqle/resolve/resolve_tables.go
+++ b/go/libraries/doltcore/sqle/resolve/resolve_tables.go
@@ -64,7 +64,7 @@ func TablesOnSearchPath(ctx *sql.Context, root doltdb.RootValue) ([]doltdb.Table
 
 	var tableNames []doltdb.TableName
 	for _, schemaName := range schemasToSearch {
-		names, err := root.GetTableNames(ctx, schemaName)
+		names, err := root.GetTableNames(ctx, schemaName, true)
 		if err != nil {
 			return nil, err
 		}
@@ -86,7 +86,7 @@ func TableNameWithSearchPath(
 	}
 
 	for _, schemaName := range schemasToSearch {
-		tablesInSchema, err := root.GetTableNames(ctx, schemaName)
+		tablesInSchema, err := root.GetTableNames(ctx, schemaName, true)
 		if err != nil {
 			return doltdb.TableName{}, false, err
 		}

--- a/go/libraries/doltcore/sqle/resolve/search_path.go
+++ b/go/libraries/doltcore/sqle/resolve/search_path.go
@@ -97,7 +97,7 @@ func IsDoltgresSystemTable(ctx *sql.Context, tableName doltdb.TableName, root do
 			return true, nil
 		}
 
-		tablesInSchema, err := root.GetTableNames(ctx, schemaName)
+		tablesInSchema, err := root.GetTableNames(ctx, schemaName, true)
 		if err != nil {
 			return false, err
 		}

--- a/go/libraries/doltcore/sqle/resolve/system_tables.go
+++ b/go/libraries/doltcore/sqle/resolve/system_tables.go
@@ -48,7 +48,7 @@ func GetGeneratedSystemTables(ctx context.Context, root doltdb.RootValue) ([]dol
 	}
 
 	for _, schema := range schemas {
-		tableNames, err := root.GetTableNames(ctx, schema.Name)
+		tableNames, err := root.GetTableNames(ctx, schema.Name, false)
 		if err != nil {
 			return nil, err
 		}

--- a/go/libraries/doltcore/sqle/user_space_database.go
+++ b/go/libraries/doltcore/sqle/user_space_database.go
@@ -74,7 +74,7 @@ func (db *UserSpaceDatabase) GetTableInsensitive(ctx *sql.Context, tableName str
 }
 
 func (db *UserSpaceDatabase) GetTableNames(ctx *sql.Context) ([]string, error) {
-	tableNames, err := db.RootValue.GetTableNames(ctx, doltdb.DefaultSchemaName)
+	tableNames, err := db.RootValue.GetTableNames(ctx, doltdb.DefaultSchemaName, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Root objects occupy the same namespace as tables, however they shouldn't be returned in places that expect to see _only_ tables. This PR allows for a distinction when querying for names, so that locations that only work with tables (such as some system tables) no longer receive root object names.