### PR TITLE
[no-release-notes] fix local sysbench scripts to use SSL

### DIFF
--- a/go/performance/scripts/local_sysbench.sh
+++ b/go/performance/scripts/local_sysbench.sh
@@ -51,24 +51,23 @@ fi
 
 # collect custom sysbench scripts
 cp ./sysbench-lua-scripts/*.lua "$WORKING_DIR"
+
+# grab testing SSL pems
+cp ../../libraries/doltcore/servercfg/testdata/chain* "$WORKING_DIR"
+
 cd "$WORKING_DIR"
 
 # make a sql-server config file
 cat <<YAML > dolt-config.yaml
-log_level: "info"
-
-behavior:
-  read_only: false
-  autocommit: true
+log_level: info
 
 listener:
-  host: "0.0.0.0"
+  host: 127.0.0.1
   port: $PORT
-  max_connections: 128
-  read_timeout_millis: 28800000
-  write_timeout_millis: 28800000
+  tls_key: "./chain_key.pem"
+  tls_cert: "./chain_cert.pem"
+  require_secure_transport: true
 
-data_dir: .
 YAML
 
 # start a server
@@ -91,7 +90,7 @@ echo "benchmark $SYSBENCH_TEST bootstrapping at $WORKING_DIR"
 sleep 1
 sysbench \
   --db-driver="mysql" \
-  --mysql-host="0.0.0.0" \
+  --mysql-host="127.0.0.1" \
   --mysql-port="$PORT" \
   --mysql-user="$USER" \
   --mysql-password="$PASS" \
@@ -115,7 +114,7 @@ echo "benchmark $SYSBENCH_TEST starting at $WORKING_DIR"
 
 sysbench \
   --db-driver="mysql" \
-  --mysql-host="0.0.0.0" \
+  --mysql-host="127.0.0.1" \
   --mysql-port="$PORT" \
   --mysql-user="$USER" \
   --mysql-password="$PASS" \

--- a/go/performance/scripts/local_tpcc.sh
+++ b/go/performance/scripts/local_tpcc.sh
@@ -46,22 +46,23 @@ fi
 
 # collect custom sysbench scripts
 cp ./sysbench-tpcc/*.lua "$WORKING_DIR"
+
+# grab testing SSL pems
+cp ../../libraries/doltcore/servercfg/testdata/chain* "$WORKING_DIR"
+
 cd "$WORKING_DIR"
 
 # make a sql-server config file
 cat <<YAML > dolt-config.yaml
-log_level: "debug"
-
-behavior:
-  read_only: false
-  autocommit: true
+log_level: info
 
 listener:
-  host: "0.0.0.0"
+  host: 127.0.0.1
   port: $PORT
-  max_connections: 128
-  read_timeout_millis: 28800000
-  write_timeout_millis: 28800000
+  tls_key: "./chain_key.pem"
+  tls_cert: "./chain_cert.pem"
+  require_secure_transport: true
+
 YAML
 
 # start a server
@@ -80,7 +81,19 @@ echo "benchmark TPC-C bootstrapping at $WORKING_DIR"
 
 sleep 1
 
-./tpcc.lua --db-driver="mysql" --mysql-db="sbtest" --mysql-host="0.0.0.0" --mysql-port="$PORT" --mysql-user="$USER" --mysql-password="$PASS" --time=10 --report_interval=1 --threads=2 --tables=1 --scale=1 --trx_level="RR" prepare
+./tpcc.lua \
+  --db-driver="mysql" \
+  --mysql-db="sbtest" \
+  --mysql-host="127.0.0.1" \
+  --mysql-port="$PORT" \
+  --mysql-user="$USER" \
+  --mysql-password="$PASS" \
+  --time=10 \
+  --report_interval=1 \
+  --threads=2 \
+  --tables=1 \
+  --scale=1 \
+  --trx_level="RR" prepare
 
 # restart server to isolate bench run
 kill -15 "$SERVER_PID"
@@ -97,7 +110,19 @@ sleep 1
 # run benchmark
 echo "benchmark $SYSBENCH_TEST starting at $WORKING_DIR"
 
-./tpcc.lua --db-driver="mysql" --mysql-db="sbtest" --mysql-host="0.0.0.0" --mysql-port="$PORT" --mysql-user="$USER" --mysql-password="$PASS" --time=10 --report_interval=1 --threads=2 --tables=1 --scale=1 --trx_level="RR" run
+./tpcc.lua \
+  --db-driver="mysql" \
+  --mysql-db="sbtest" \
+  --mysql-host="127.0.0.1" \
+  --mysql-port="$PORT" \
+  --mysql-user="$USER" \
+  --mysql-password="$PASS" \
+  --time=10 \
+  --report_interval=1 \
+  --threads=2 \
+  --tables=1 \
+  --scale=1 \
+  --trx_level="RR" run
 
 echo "benchmark TPC-C complete at $WORKING_DIR"
 echo "DOLT_DEFAULT_BIN_FORMAT='$DOLT_DEFAULT_BIN_FORMAT'"


### PR DESCRIPTION
Sysbench requires that dolt specify TLS key and cert for scripts to run locally now.
This PR updates the scripts to copy over our testing `.pem` files from elsewhere in the directory.