### PR TITLE
Initialize a branch's working set when referenced as a branch-revision database

### DIFF
--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -1411,25 +1411,36 @@ func (d *DoltSession) addDB(ctx *sql.Context, db SqlDatabase) error {
 
 	if dbState.Err != nil {
 		sessionState.Err = dbState.Err
-	} else if dbState.WorkingSet != nil {
-		branchState.workingSet = dbState.WorkingSet
-
-		// TODO: this is pretty clunky, there is a silly dependency between InitialDbState and globalstate.StateProvider
-		//  that's hard to express with the current types
-		stateProvider, ok := db.(globalstate.GlobalStateProvider)
-		if !ok {
-			return fmt.Errorf("database does not contain global state store")
+	} else {
+		// If the dbState doesn't have a working set yet, try to
+		// initialize one – this will only initialize a working set
+		// if the database is a branch revision database.
+		if dbState.WorkingSet == nil {
+			if err := initializeBranchWorkingSet(ctx, db, &dbState); err != nil {
+				return err
+			}
 		}
-		sessionState.globalState = stateProvider.GetGlobalState()
 
-		tracker, err := sessionState.globalState.AutoIncrementTracker(ctx)
-		if err != nil {
-			return err
+		if dbState.WorkingSet != nil {
+			branchState.workingSet = dbState.WorkingSet
+
+			// TODO: this is pretty clunky, there is a silly dependency between InitialDbState and globalstate.StateProvider
+			//  that's hard to express with the current types
+			stateProvider, ok := db.(globalstate.GlobalStateProvider)
+			if !ok {
+				return fmt.Errorf("database does not contain global state store")
+			}
+			sessionState.globalState = stateProvider.GetGlobalState()
+
+			tracker, err := sessionState.globalState.AutoIncrementTracker(ctx)
+			if err != nil {
+				return err
+			}
+			branchState.writeSession = d.writeSessProv(nbf, branchState.WorkingSet(), tracker, editOpts)
 		}
-		branchState.writeSession = d.writeSessProv(nbf, branchState.WorkingSet(), tracker, editOpts)
 	}
 
-	// WorkingSet is nil in the case of a read only, detached head DB
+	// WorkingSet is nil in the case of a read-only, detached head DB
 	if dbState.HeadCommit != nil {
 		headRoot, err := dbState.HeadCommit.GetRootValue(ctx)
 		if err != nil {
@@ -1745,6 +1756,41 @@ func (d *DoltSession) Validate() {
 // sql engine through here.
 func (d *DoltSession) GCSafepointController() *gcctx.GCSafepointController {
 	return d.gcSafepointController
+}
+
+// initializeBranchWorkingSet checks if |db| is a branch revision database, and if |dbState|
+// does not have a working set yet, then a new, empty working set is created and set in |dbState|.
+// If |db| is NOT a branch revision database, or |dbState| already has a working set, then this
+// function will not do anything.
+func initializeBranchWorkingSet(ctx *sql.Context, db SqlDatabase, dbState *InitialDbState) error {
+	revisionDb, isRevisionDb := db.(RevisionDatabase)
+	if !isRevisionDb || revisionDb.RevisionType() != RevisionTypeBranch || dbState.WorkingSet != nil {
+		return nil
+	}
+
+	branchRef := ref.NewBranchRef(revisionDb.Revision())
+	wsRef, err := ref.WorkingSetRefForHead(branchRef)
+	if err != nil {
+		return err
+	}
+
+	commit, err := dbState.DbData.Ddb.ResolveCommitRef(ctx, branchRef)
+	if err != nil {
+		return err
+	}
+
+	headRoot, err := commit.GetRootValue(ctx)
+	if err != nil {
+		return err
+	}
+
+	dbState.WorkingSet = doltdb.EmptyWorkingSet(wsRef).
+		WithWorkingRoot(headRoot).WithStagedRoot(headRoot)
+
+	ctx.GetLogger().Warnf("initializing empty working set for branch %s", revisionDb.Revision())
+
+	return dbState.DbData.Ddb.UpdateWorkingSet(ctx, wsRef, dbState.WorkingSet,
+		hash.Hash{}, doltdb.TodoWorkingSetMeta(), nil)
 }
 
 // validatePersistedSysVar checks whether a system variable exists and is dynamic


### PR DESCRIPTION
When a new branch is pushed to a SQL server through the RemotesAPI, that branch will not have its working set initialized yet. If a customer accesses that branch as a branch-revision database (e.g. `mydb/my_new_branch`) and performs a write operation, the lack of a working set will cause an error. This change fixes that case by initializing a branch-revision database's working set if it has not been created yet. 