### PR TITLE
[no-release-notes] Move binlog tests to a separate CI job

### DIFF
--- a/.github/workflows/ci-binlog-tests.yaml
+++ b/.github/workflows/ci-binlog-tests.yaml
@@ -1,0 +1,58 @@
+name: Test Binlog
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'go/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ci-binlog-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  binlog-test:
+    name: Binlog tests
+    defaults:
+      run:
+        shell: bash
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go/go.mod
+      id: go
+    - name: Test Binlog
+      working-directory: ./go
+      run: |
+        # Test binlog packages
+        go test -vet=off -timeout 60m ./libraries/doltcore/sqle/binlogreplication/...
+      env:
+        MATRIX_OS: ${{ matrix.os }}
+  binlog-race-test:
+    name: Binlog tests - race
+    defaults:
+      run:
+        shell: bash
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go/go.mod
+      id: go
+    - name: Test Binlog with Race
+      working-directory: ./go
+      run: |
+        # Test binlog packages with race detector
+        go test -vet=off -timeout 60m -race ./libraries/doltcore/sqle/binlogreplication/...
+      env:
+        MATRIX_OS: ubuntu-22.04

--- a/.github/workflows/ci-go-tests.yaml
+++ b/.github/workflows/ci-go-tests.yaml
@@ -40,6 +40,12 @@ jobs:
 
         for (( i=0; i<${#file_arr[@]}; i++ ))
         do
+          # Skip binlog tests as they run in a separate CI job
+          if [[ "${file_arr[$i]}" == *binlogreplication* ]]; then
+            echo "Skipping binlog package: ${file_arr[$i]} (runs in separate CI)"
+            continue
+          fi
+          
           echo "Testing Package: ${file_arr[$i]}"
           if [ "$MATRIX_OS" == 'ubuntu-22.04' ]
           then


### PR DESCRIPTION
The binlog tests take a long time to run, so I pulled them out into a separate CI job. 

When I tested the CI job, the [new binlog job ran in about 40 minutes](https://github.com/dolthub/dolt/actions/runs/16923116715/job/47953453703), and the [ubuntu Go tests ran in about 20 minutes](https://github.com/dolthub/dolt/actions/runs/16923116719/job/47953453846).