### PR TITLE
dolt_tests system table

### DIFF
--- a/go/libraries/doltcore/doltdb/system_table.go
+++ b/go/libraries/doltcore/doltdb/system_table.go
@@ -122,6 +122,7 @@ var getWriteableSystemTables = func() []string {
 		IgnoreTableName,
 		GetRebaseTableName(),
 		GetQueryCatalogTableName(),
+		GetTestsTableName(),
 
 		// TODO: find way to make these writable by the dolt process
 		// TODO: but not by user
@@ -880,6 +881,10 @@ var GetStashesTableName = func() string {
 
 var GetQueryCatalogTableName = func() string { return DoltQueryCatalogTableName }
 
+var GetTestsTableName = func() string {
+	return TestsTableName
+}
+
 const (
 	// LogTableName is the log system table name
 	LogTableName = "dolt_log"
@@ -934,6 +939,9 @@ const (
 
 	// StashesTableName is the stashes system table name
 	StashesTableName = "dolt_stashes"
+
+	// TestsTableName is the tests system table name
+	TestsTableName = "dolt_tests"
 )
 
 // DoltGeneratedTableNames is a list of all the generated dolt system tables that are not specific to a user table.

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -828,6 +828,17 @@ func (db Database) getTableInsensitive(ctx *sql.Context, head *doltdb.Commit, ds
 			versionableTable := backingTable.(dtables.VersionableTable)
 			dt, found = dtables.NewQueryCatalogTable(ctx, versionableTable), true
 		}
+	case doltdb.GetTestsTableName():
+		backingTable, _, err := db.getTable(ctx, root, doltdb.GetTestsTableName())
+		if err != nil {
+			return nil, false, err
+		}
+		if backingTable == nil {
+			dt, found = dtables.NewEmptyTestsTable(ctx), true
+		} else {
+			versionableTable := backingTable.(dtables.VersionableTable)
+			dt, found = dtables.NewTestsTable(ctx, versionableTable), true
+		}
 	}
 
 	if found {

--- a/go/libraries/doltcore/sqle/dtables/query_catalog_table.go
+++ b/go/libraries/doltcore/sqle/dtables/query_catalog_table.go
@@ -38,11 +38,11 @@ type QueryCatalogTable struct {
 	backingTable VersionableTable
 }
 
-func (i *QueryCatalogTable) Name() string {
+func (qt *QueryCatalogTable) Name() string {
 	return doltdb.DoltQueryCatalogTableName
 }
 
-func (i *QueryCatalogTable) String() string {
+func (qt *QueryCatalogTable) String() string {
 	return doltdb.DoltQueryCatalogTableName
 }
 
@@ -58,28 +58,28 @@ func doltQueryCatalogSchema() sql.Schema {
 
 var GetDoltQueryCatalogSchema = doltQueryCatalogSchema
 
-func (i *QueryCatalogTable) Schema() sql.Schema {
+func (qt *QueryCatalogTable) Schema() sql.Schema {
 	return GetDoltQueryCatalogSchema()
 }
 
-func (i *QueryCatalogTable) Collation() sql.CollationID {
+func (qt *QueryCatalogTable) Collation() sql.CollationID {
 	return sql.Collation_Default
 }
 
-func (i *QueryCatalogTable) Partitions(context *sql.Context) (sql.PartitionIter, error) {
-	if i.backingTable == nil {
+func (qt *QueryCatalogTable) Partitions(context *sql.Context) (sql.PartitionIter, error) {
+	if qt.backingTable == nil {
 		// no backing table; return an empty iter.
 		return index.SinglePartitionIterFromNomsMap(nil), nil
 	}
-	return i.backingTable.Partitions(context)
+	return qt.backingTable.Partitions(context)
 }
 
-func (i *QueryCatalogTable) PartitionRows(context *sql.Context, partition sql.Partition) (sql.RowIter, error) {
-	if i.backingTable == nil {
+func (qt *QueryCatalogTable) PartitionRows(context *sql.Context, partition sql.Partition) (sql.RowIter, error) {
+	if qt.backingTable == nil {
 		// no backing table; return an empty iter.
 		return sql.RowsToRowIter(), nil
 	}
-	return i.backingTable.PartitionRows(context, partition)
+	return qt.backingTable.PartitionRows(context, partition)
 }
 
 // NewQueryCatalogTable creates a QueryCatalogTable

--- a/go/libraries/doltcore/sqle/dtables/query_catalog_table.go
+++ b/go/libraries/doltcore/sqle/dtables/query_catalog_table.go
@@ -38,11 +38,11 @@ type QueryCatalogTable struct {
 	backingTable VersionableTable
 }
 
-func (qt *QueryCatalogTable) Name() string {
+func (qct *QueryCatalogTable) Name() string {
 	return doltdb.DoltQueryCatalogTableName
 }
 
-func (qt *QueryCatalogTable) String() string {
+func (qct *QueryCatalogTable) String() string {
 	return doltdb.DoltQueryCatalogTableName
 }
 
@@ -58,28 +58,28 @@ func doltQueryCatalogSchema() sql.Schema {
 
 var GetDoltQueryCatalogSchema = doltQueryCatalogSchema
 
-func (qt *QueryCatalogTable) Schema() sql.Schema {
+func (qct *QueryCatalogTable) Schema() sql.Schema {
 	return GetDoltQueryCatalogSchema()
 }
 
-func (qt *QueryCatalogTable) Collation() sql.CollationID {
+func (qct *QueryCatalogTable) Collation() sql.CollationID {
 	return sql.Collation_Default
 }
 
-func (qt *QueryCatalogTable) Partitions(context *sql.Context) (sql.PartitionIter, error) {
-	if qt.backingTable == nil {
+func (qct *QueryCatalogTable) Partitions(context *sql.Context) (sql.PartitionIter, error) {
+	if qct.backingTable == nil {
 		// no backing table; return an empty iter.
 		return index.SinglePartitionIterFromNomsMap(nil), nil
 	}
-	return qt.backingTable.Partitions(context)
+	return qct.backingTable.Partitions(context)
 }
 
-func (qt *QueryCatalogTable) PartitionRows(context *sql.Context, partition sql.Partition) (sql.RowIter, error) {
-	if qt.backingTable == nil {
+func (qct *QueryCatalogTable) PartitionRows(context *sql.Context, partition sql.Partition) (sql.RowIter, error) {
+	if qct.backingTable == nil {
 		// no backing table; return an empty iter.
 		return sql.RowsToRowIter(), nil
 	}
-	return qt.backingTable.PartitionRows(context, partition)
+	return qct.backingTable.PartitionRows(context, partition)
 }
 
 // NewQueryCatalogTable creates a QueryCatalogTable
@@ -92,47 +92,47 @@ func NewEmptyQueryCatalogTable(_ *sql.Context) sql.Table {
 	return &QueryCatalogTable{}
 }
 
-func (qt *QueryCatalogTable) Replacer(_ *sql.Context) sql.RowReplacer {
-	return newQueryCatalogWriter(qt)
+func (qct *QueryCatalogTable) Replacer(_ *sql.Context) sql.RowReplacer {
+	return newQueryCatalogWriter(qct)
 }
 
 // Updater returns a RowUpdater for this table. The RowUpdater will have Update called once for each row to be
 // updated, followed by a call to Close() when all rows have been processed.
-func (qt *QueryCatalogTable) Updater(_ *sql.Context) sql.RowUpdater {
-	return newQueryCatalogWriter(qt)
+func (qct *QueryCatalogTable) Updater(_ *sql.Context) sql.RowUpdater {
+	return newQueryCatalogWriter(qct)
 }
 
 // Inserter returns an Inserter for this table. The Inserter will get one call to Insert() for each row to be
 // inserted, and will end with a call to Close() to finalize the insert operation.
-func (qt *QueryCatalogTable) Inserter(*sql.Context) sql.RowInserter {
-	return newQueryCatalogWriter(qt)
+func (qct *QueryCatalogTable) Inserter(*sql.Context) sql.RowInserter {
+	return newQueryCatalogWriter(qct)
 }
 
 // Deleter returns a RowDeleter for this table. The RowDeleter will get one call to Delete for each row to be deleted,
 // and will end with a call to Close() to finalize the delete operation.
-func (qt *QueryCatalogTable) Deleter(*sql.Context) sql.RowDeleter {
-	return newQueryCatalogWriter(qt)
+func (qct *QueryCatalogTable) Deleter(*sql.Context) sql.RowDeleter {
+	return newQueryCatalogWriter(qct)
 }
 
-func (qt *QueryCatalogTable) LockedToRoot(ctx *sql.Context, root doltdb.RootValue) (sql.IndexAddressableTable, error) {
-	if qt.backingTable == nil {
-		return qt, nil
+func (qct *QueryCatalogTable) LockedToRoot(ctx *sql.Context, root doltdb.RootValue) (sql.IndexAddressableTable, error) {
+	if qct.backingTable == nil {
+		return qct, nil
 	}
-	return qt.backingTable.LockedToRoot(ctx, root)
+	return qct.backingTable.LockedToRoot(ctx, root)
 }
 
 // IndexedAccess implements IndexAddressableTable, but QueryCatalogTable has no indexes.
 // Thus, this should never be called.
-func (qt *QueryCatalogTable) IndexedAccess(ctx *sql.Context, lookup sql.IndexLookup) sql.IndexedTable {
+func (qct *QueryCatalogTable) IndexedAccess(ctx *sql.Context, lookup sql.IndexLookup) sql.IndexedTable {
 	panic("Unreachable")
 }
 
 // GetIndexes implements IndexAddressableTable, but QueryCatalogTable has no indexes.
-func (qt *QueryCatalogTable) GetIndexes(ctx *sql.Context) ([]sql.Index, error) {
+func (qct *QueryCatalogTable) GetIndexes(ctx *sql.Context) ([]sql.Index, error) {
 	return nil, nil
 }
 
-func (qt *QueryCatalogTable) PreciseMatch() bool {
+func (qct *QueryCatalogTable) PreciseMatch() bool {
 	return true
 }
 
@@ -142,14 +142,14 @@ var _ sql.RowInserter = (*queryCatalogWriter)(nil)
 var _ sql.RowDeleter = (*queryCatalogWriter)(nil)
 
 type queryCatalogWriter struct {
-	qt                      *QueryCatalogTable
+	qct                      *QueryCatalogTable
 	errDuringStatementBegin error
 	prevHash                *hash.Hash
 	tableWriter             dsess.TableWriter
 }
 
-func newQueryCatalogWriter(qt *QueryCatalogTable) *queryCatalogWriter {
-	return &queryCatalogWriter{qt, nil, nil, nil}
+func newQueryCatalogWriter(qct *QueryCatalogTable) *queryCatalogWriter {
+	return &queryCatalogWriter{qct, nil, nil, nil}
 }
 
 // Insert inserts the row given, returning an error if it cannot. Insert will be called once for each row to process
@@ -184,7 +184,7 @@ func (qw *queryCatalogWriter) Delete(ctx *sql.Context, r sql.Row) error {
 // in some way that it may be returned to in the case of an error.
 func (qw *queryCatalogWriter) StatementBegin(ctx *sql.Context) {
 	name := getDoltQueryCatalogTableName()
-	prevHash, tableWriter, err := createWriteableSystemTable(ctx, name, qw.qt.Schema())
+	prevHash, tableWriter, err := createWriteableSystemTable(ctx, name, qw.qct.Schema())
 	if err != nil {
 		qw.errDuringStatementBegin = err
 		return

--- a/go/libraries/doltcore/sqle/dtables/query_catalog_table.go
+++ b/go/libraries/doltcore/sqle/dtables/query_catalog_table.go
@@ -142,7 +142,7 @@ var _ sql.RowInserter = (*queryCatalogWriter)(nil)
 var _ sql.RowDeleter = (*queryCatalogWriter)(nil)
 
 type queryCatalogWriter struct {
-	qct                      *QueryCatalogTable
+	qct                     *QueryCatalogTable
 	errDuringStatementBegin error
 	prevHash                *hash.Hash
 	tableWriter             dsess.TableWriter

--- a/go/libraries/doltcore/sqle/dtables/tests_table.go
+++ b/go/libraries/doltcore/sqle/dtables/tests_table.go
@@ -47,8 +47,8 @@ func (tt *TestsTable) String() string {
 
 func doltTestsSchema() sql.Schema {
 	return []*sql.Column{
-		{Name: "test_group", Type: sqlTypes.Text, Source: doltdb.TestsTableName, PrimaryKey: false, Nullable: true},
 		{Name: "test_name", Type: sqlTypes.Text, Source: doltdb.TestsTableName, PrimaryKey: true},
+		{Name: "test_group", Type: sqlTypes.Text, Source: doltdb.TestsTableName, PrimaryKey: false, Nullable: true},
 		{Name: "test_query", Type: sqlTypes.Text, Source: doltdb.TestsTableName, PrimaryKey: false, Nullable: false},
 		{Name: "assertion_type", Type: sqlTypes.Text, Source: doltdb.TestsTableName, PrimaryKey: false, Nullable: false},
 		{Name: "assertion_comparator", Type: sqlTypes.Text, Source: doltdb.TestsTableName, PrimaryKey: false, Nullable: false},

--- a/go/libraries/doltcore/sqle/dtables/tests_table.go
+++ b/go/libraries/doltcore/sqle/dtables/tests_table.go
@@ -50,7 +50,9 @@ func doltTestsSchema() sql.Schema {
 		{Name: "test_group", Type: sqlTypes.Text, Source: doltdb.TestsTableName, PrimaryKey: true},
 		{Name: "test_name", Type: sqlTypes.Text, Source: doltdb.TestsTableName, PrimaryKey: true},
 		{Name: "test_query", Type: sqlTypes.Text, Source: doltdb.TestsTableName, PrimaryKey: false, Nullable: false},
-		{Name: "test_assertion", Type: sqlTypes.Text, Source: doltdb.TestsTableName, PrimaryKey: false, Nullable: false},
+		{Name: "assertion_type", Type: sqlTypes.Text, Source: doltdb.TestsTableName, PrimaryKey: false, Nullable: false},
+		{Name: "assertion_comparator", Type: sqlTypes.Text, Source: doltdb.TestsTableName, PrimaryKey: false, Nullable: false},
+		{Name: "assertion_value", Type: sqlTypes.Text, Source: doltdb.TestsTableName, PrimaryKey: false, Nullable: false},
 	}
 }
 

--- a/go/libraries/doltcore/sqle/dtables/tests_table.go
+++ b/go/libraries/doltcore/sqle/dtables/tests_table.go
@@ -1,0 +1,230 @@
+// Copyright 2025 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dtables
+
+import (
+	"github.com/dolthub/go-mysql-server/sql"
+	sqlTypes "github.com/dolthub/go-mysql-server/sql/types"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/index"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/resolve"
+	"github.com/dolthub/dolt/go/store/hash"
+)
+
+var _ sql.Table = (*TestsTable)(nil)
+var _ sql.UpdatableTable = (*TestsTable)(nil)
+var _ sql.DeletableTable = (*TestsTable)(nil)
+var _ sql.InsertableTable = (*TestsTable)(nil)
+var _ sql.ReplaceableTable = (*TestsTable)(nil)
+var _ sql.IndexAddressableTable = (*TestsTable)(nil)
+
+// TestsTable is the system table that stores test definitions.
+type TestsTable struct {
+	backingTable VersionableTable
+}
+
+func (tt *TestsTable) Name() string {
+	return doltdb.TestsTableName
+}
+
+func (tt *TestsTable) String() string {
+	return doltdb.TestsTableName
+}
+
+func doltTestsSchema() sql.Schema {
+	return []*sql.Column{
+		{Name: "test_group", Type: sqlTypes.Text, Source: doltdb.TestsTableName, PrimaryKey: true},
+		{Name: "test_name", Type: sqlTypes.Text, Source: doltdb.TestsTableName, PrimaryKey: true},
+		{Name: "test_query", Type: sqlTypes.Text, Source: doltdb.TestsTableName, PrimaryKey: false, Nullable: false},
+		{Name: "test_assertion", Type: sqlTypes.Text, Source: doltdb.TestsTableName, PrimaryKey: false, Nullable: false},
+	}
+}
+
+// GetDoltTestsSchema returns the schema of the dolt_tests system table. This is used
+// by Doltgres to update the dolt_tests schema using Doltgres types.
+var GetDoltTestsSchema = doltTestsSchema
+
+// Schema is a sql.Table interface function that gets the sql.Schema of the dolt_tests system table.
+func (tt *TestsTable) Schema() sql.Schema {
+	return GetDoltTestsSchema()
+}
+
+func (tt *TestsTable) Collation() sql.CollationID {
+	return sql.Collation_Default
+}
+
+// Partitions is a sql.Table interface function that returns a partition of the data.
+func (tt *TestsTable) Partitions(context *sql.Context) (sql.PartitionIter, error) {
+	if tt.backingTable == nil {
+		// no backing table; return an empty iter.
+		return index.SinglePartitionIterFromNomsMap(nil), nil
+	}
+	return tt.backingTable.Partitions(context)
+}
+
+func (tt *TestsTable) PartitionRows(context *sql.Context, partition sql.Partition) (sql.RowIter, error) {
+	if tt.backingTable == nil {
+		return sql.RowsToRowIter(), nil
+	}
+
+	return tt.backingTable.PartitionRows(context, partition)
+}
+
+// NewTestsTable creates a TestsTable
+func NewTestsTable(_ *sql.Context, backingTable VersionableTable) sql.Table {
+	return &TestsTable{backingTable: backingTable}
+}
+
+// NewEmptyTestsTable creates an empty TestsTable
+func NewEmptyTestsTable(_ *sql.Context) sql.Table {
+	return &TestsTable{}
+}
+
+// Replacer returns a RowReplacer for this table. The RowReplacer will have Insert and optionally Delete
+// called once for each row, followed by a call to Close() when all rows have been processed.
+func (tt *TestsTable) Replacer(ctx *sql.Context) sql.RowReplacer {
+	return newTestsWriter(tt)
+}
+
+// Updater returns a RowUpdater for this table. The RowUpdater will have Update called once for each row
+// to be updated, followed by a call to Close() when all rows have been processed.
+func (tt *TestsTable) Updater(ctx *sql.Context) sql.RowUpdater {
+	return newTestsWriter(tt)
+}
+
+// Inserter returns an Inserter for this table. The Inserter will get one call to Insert() for each row to
+// be inserted, and will end with a call to Close() to finalize the insert operation.
+func (tt *TestsTable) Inserter(*sql.Context) sql.RowInserter {
+	return newTestsWriter(tt)
+}
+
+// Deleter returns a RowDeleter for this table. The RowDeleter will get one call to Delete for each row to
+// be deleted, and will end with a call to Close() to finalize the delete operation.
+func (tt *TestsTable) Deleter(*sql.Context) sql.RowDeleter {
+	return newTestsWriter(tt)
+}
+
+func (tt *TestsTable) LockedToRoot(ctx *sql.Context, root doltdb.RootValue) (sql.IndexAddressableTable, error) {
+	if tt.backingTable == nil {
+		return tt, nil
+	}
+	return tt.backingTable.LockedToRoot(ctx, root)
+}
+
+// IndexedAccess implements IndexAddressableTable, but TestsTable has no indexes.
+// Thus, this should never be called.
+func (tt *TestsTable) IndexedAccess(_ *sql.Context, _ sql.IndexLookup) sql.IndexedTable {
+	panic("Unreachable")
+}
+
+// GetIndexes implements IndexAddressableTable, but TestsTable has no indexes.
+func (tt *TestsTable) GetIndexes(_ *sql.Context) ([]sql.Index, error) {
+	return nil, nil
+}
+
+func (tt *TestsTable) PreciseMatch() bool {
+	return true
+}
+
+var _ sql.RowReplacer = (*testsWriter)(nil)
+var _ sql.RowUpdater = (*testsWriter)(nil)
+var _ sql.RowInserter = (*testsWriter)(nil)
+var _ sql.RowDeleter = (*testsWriter)(nil)
+
+type testsWriter struct {
+	tt                      *TestsTable
+	errDuringStatementBegin error
+	prevHash                *hash.Hash
+	tableWriter             dsess.TableWriter
+}
+
+func newTestsWriter(tt *TestsTable) *testsWriter {
+	return &testsWriter{tt, nil, nil, nil}
+}
+
+// Insert inserts the row given, returning an error if it cannot. Insert will be called once for each row to process
+// for the insert operation, which may involve many rows. After all rows in an operation have been processed, Close
+// is called.
+func (tw *testsWriter) Insert(ctx *sql.Context, r sql.Row) error {
+	if err := tw.errDuringStatementBegin; err != nil {
+		return err
+	}
+	return tw.tableWriter.Insert(ctx, r)
+}
+
+// Update the given row. Provides both the old and new rows.
+func (tw *testsWriter) Update(ctx *sql.Context, old sql.Row, new sql.Row) error {
+	if err := tw.errDuringStatementBegin; err != nil {
+		return err
+	}
+	return tw.tableWriter.Update(ctx, old, new)
+}
+
+// Delete deletes the given row. Returns ErrDeleteRowNotFound if the row was not found. Delete will be called once for each
+// row to process for the delete operation, which may involve many rows. After all rows have been processed, Close is called.
+func (tw *testsWriter) Delete(ctx *sql.Context, r sql.Row) error {
+	if err := tw.errDuringStatementBegin; err != nil {
+		return err
+	}
+	return tw.tableWriter.Delete(ctx, r)
+}
+
+// StatementBegin is called before the first operation of a statement. Integrators should mark the state of the data
+// in some way that it may be returned to in the case of an error.
+func (tw *testsWriter) StatementBegin(ctx *sql.Context) {
+	name := getDoltTestsTableName()
+	prevHash, tableWriter, err := createWriteableSystemTable(ctx, name, tw.tt.Schema())
+	if err != nil {
+		tw.errDuringStatementBegin = err
+		return
+	}
+	tw.prevHash = prevHash
+	tw.tableWriter = tableWriter
+}
+
+func getDoltTestsTableName() doltdb.TableName {
+	if resolve.UseSearchPath {
+		return doltdb.TableName{Schema: doltdb.DoltNamespace, Name: doltdb.TestsTableName}
+	}
+	return doltdb.TableName{Name: doltdb.GetTestsTableName()}
+}
+
+// DiscardChanges is called if a statement encounters an error, and all current changes since the
+// statement beginning should be discarded.
+func (tw *testsWriter) DiscardChanges(ctx *sql.Context, errorEncountered error) error {
+	if tw.tableWriter != nil {
+		return tw.tableWriter.DiscardChanges(ctx, errorEncountered)
+	}
+	return nil
+}
+
+// StatementComplete is called after the last operation of the statement, indicating that it has successfully completed.
+// The mark set in StatementBegin may be removed, and a new one should be created on the next StatementBegin.
+func (tw *testsWriter) StatementComplete(ctx *sql.Context) error {
+	if tw.tableWriter != nil {
+		return tw.tableWriter.StatementComplete(ctx)
+	}
+	return nil
+}
+
+// Close finalizes the delete operation, persisting the result.
+func (tw *testsWriter) Close(ctx *sql.Context) error {
+	if tw.tableWriter != nil {
+		return tw.tableWriter.Close(ctx)
+	}
+	return nil
+}

--- a/go/libraries/doltcore/sqle/dtables/tests_table.go
+++ b/go/libraries/doltcore/sqle/dtables/tests_table.go
@@ -47,7 +47,7 @@ func (tt *TestsTable) String() string {
 
 func doltTestsSchema() sql.Schema {
 	return []*sql.Column{
-		{Name: "test_group", Type: sqlTypes.Text, Source: doltdb.TestsTableName, PrimaryKey: true},
+		{Name: "test_group", Type: sqlTypes.Text, Source: doltdb.TestsTableName, PrimaryKey: false, Nullable: true},
 		{Name: "test_name", Type: sqlTypes.Text, Source: doltdb.TestsTableName, PrimaryKey: true},
 		{Name: "test_query", Type: sqlTypes.Text, Source: doltdb.TestsTableName, PrimaryKey: false, Nullable: false},
 		{Name: "assertion_type", Type: sqlTypes.Text, Source: doltdb.TestsTableName, PrimaryKey: false, Nullable: false},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -2153,3 +2153,9 @@ func TestDoltQueryCatalogSystemTable(t *testing.T) {
 	defer harness.Close()
 	RunDoltQueryCatalogTests(t, harness)
 }
+
+func TestDoltTestsSystemTable(t *testing.T) {
+	harness := newDoltEnginetestHarness(t)
+	defer harness.Close()
+	RunDoltTestsTableTests(t, harness)
+}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_tests.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_tests.go
@@ -2066,3 +2066,15 @@ func RunDoltQueryCatalogTests(t *testing.T, harness DoltEnginetestHarness) {
 		})
 	}
 }
+
+func RunDoltTestsTableTests(t *testing.T, harness DoltEnginetestHarness) {
+	dtables.DoltCommand = doltcmd.DoltCommand
+
+	for _, scripte := range DoltTestTableScripts {
+		t.Run(scripte.Name, func(t *testing.T) {
+			harness = harness.NewHarness(t)
+			defer harness.Close()
+			enginetest.TestScript(t, harness, scripte)
+		})
+	}
+}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_test_table.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_test_table.go
@@ -1,0 +1,131 @@
+// Copyright 2025 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enginetest
+
+import (
+	"github.com/dolthub/go-mysql-server/enginetest/queries"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+)
+
+var DoltTestTableScripts = []queries.ScriptTest{
+	{
+		Name: "can insert into dolt tests",
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "INSERT INTO dolt_tests VALUES ('validate tables', 'no tables', 'show tables;', 'expected_rows == 0;')",
+			},
+		},
+	},
+	{
+		Name: "can drop dolt tests table, cannot drop twice",
+		SetUpScript: []string{
+			"INSERT INTO dolt_tests VALUES ('validate tables', 'no tables', 'show tables;', 'expected_rows == 0;')",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "DROP TABLE dolt_tests;",
+				Expected: []sql.Row{
+					{types.NewOkResult(0)},
+				},
+			},
+			{
+				Query:          "DROP TABLE dolt_tests;",
+				ExpectedErrStr: "table not found: dolt_tests",
+			},
+		},
+	},
+	{
+		Name: "can call delete from on dolt tests table",
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "DELETE FROM dolt_tests;",
+				Expected: []sql.Row{
+					{types.NewOkResult(0)},
+				},
+			},
+		},
+	},
+	{
+		Name: "select from dolt_tests tables",
+		SetUpScript: []string{
+			"INSERT INTO dolt_tests VALUES ('validate tables', 'one table', 'show tables;', 'expected_rows == 1');",
+			"INSERT INTO dolt_tests VALUES ('validate tables', 'numbers table exists', 'show tables like ''numbers''', 'expected_rows == 1')",
+			"INSERT INTO dolt_tests VALUES ('numbers table validation', 'numbers schema', 'describe numbers', 'expected_rows == 1')",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "SELECT * FROM dolt_tests;",
+				Expected: []sql.Row{
+					{"validate tables", "one table", "show tables;", "expected_rows == 1"},
+					{"validate tables", "numbers table exists", "show tables like 'numbers'", "expected_rows == 1"},
+					{"numbers table validation", "numbers schema", "describe numbers", "expected_rows == 1"},
+				},
+			},
+			{
+				Query: "SELECT * FROM dolt_tests where test_group = 'validate tables'",
+				Expected: []sql.Row{
+					{"validate tables", "one table", "show tables;", "expected_rows == 1"},
+					{"validate tables", "numbers table exists", "show tables like 'numbers'", "expected_rows == 1"},
+				},
+			},
+		},
+	},
+	{
+		Name: "can replace row in dolt_tests table",
+		SetUpScript: []string{
+			"INSERT INTO dolt_tests VALUES ('validate tables', 'one table', 'show tables;', 'expected_rows == 1')",
+			"INSERT INTO dolt_tests VALUES ('validate tables', 'numbers table exists', 'show tables like ''numbers'';', 'expected_rows == 0')",
+			"REPLACE INTO dolt_tests VALUES ('validate tables', 'numbers table exists', 'show tables like ''numbers'';', 'expected_rows == 1')",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "SELECT * FROM dolt_tests",
+				Expected: []sql.Row{
+					{"validate tables", "numbers table exists", "show tables like 'numbers';", "expected_rows == 1"},
+					{"validate tables", "one table", "show tables;", "expected_rows == 1"},
+				},
+			},
+		},
+	},
+	{
+		Name: "can use 'as of' on dolt_tests table",
+		SetUpScript: []string{
+			"INSERT INTO dolt_tests VALUES ('validate tables', 'one table', 'show tables;', 'expected_rows == 1')",
+			"CALL DOLT_COMMIT('-A','-m', 'first commit')",
+			"INSERT INTO dolt_tests VALUES ('validate tables', 'numbers table exists', 'show tables like ''numbers'';', 'expected_rows == 1')",
+			"CALL DOLT_COMMIT('-A', '-m', 'second commit')",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "SELECT * FROM dolt_tests as of 'HEAD~2'",
+				Expected: []sql.Row{},
+			},
+			{
+				Query: "SELECT * FROM dolt_tests as of 'HEAD~1'",
+				Expected: []sql.Row{
+					{"validate tables", "one table", "show tables;", "expected_rows == 1"},
+				},
+			},
+			{
+				Query: "SELECT * FROM dolt_tests as of 'HEAD'",
+				Expected: []sql.Row{
+					{"validate tables", "one table", "show tables;", "expected_rows == 1"},
+					{"validate tables", "numbers table exists", "show tables like 'numbers';", "expected_rows == 1"},
+				},
+			},
+		},
+	},
+}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_test_table.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_test_table.go
@@ -25,14 +25,14 @@ var DoltTestTableScripts = []queries.ScriptTest{
 		Name: "can insert into dolt tests",
 		Assertions: []queries.ScriptTestAssertion{
 			{
-				Query: "INSERT INTO dolt_tests VALUES ('validate tables', 'no tables', 'show tables;', 'expected_rows', '==', '0')",
+				Query: "INSERT INTO dolt_tests VALUES ('no tables', 'validate tables' , 'show tables;', 'expected_rows', '==', '0')",
 			},
 		},
 	},
 	{
 		Name: "can drop dolt tests table, cannot drop twice",
 		SetUpScript: []string{
-			"INSERT INTO dolt_tests VALUES ('validate tables', 'no tables', 'show tables;', 'expected_rows', '==', '0')",
+			"INSERT INTO dolt_tests VALUES ('no tables', 'validate tables', 'show tables;', 'expected_rows', '==', '0')",
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
@@ -61,24 +61,24 @@ var DoltTestTableScripts = []queries.ScriptTest{
 	{
 		Name: "select from dolt_tests tables",
 		SetUpScript: []string{
-			"INSERT INTO dolt_tests VALUES ('validate tables', 'one table', 'show tables;', 'expected_rows', '==', '1');",
-			"INSERT INTO dolt_tests VALUES ('validate tables', 'numbers table exists', 'show tables like ''numbers''', 'expected_rows', '==', '1')",
-			"INSERT INTO dolt_tests VALUES ('numbers table validation', 'numbers schema', 'describe numbers', 'expected_rows', '==', '1')",
+			"INSERT INTO dolt_tests VALUES ('one table', 'validate tables', 'show tables;', 'expected_rows', '==', '1');",
+			"INSERT INTO dolt_tests VALUES ('numbers table exists', 'validate tables', 'show tables like ''numbers''', 'expected_rows', '==', '1')",
+			"INSERT INTO dolt_tests VALUES ('numbers schema', 'numbers table validation', 'describe numbers', 'expected_rows', '==', '1')",
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query: "SELECT * FROM dolt_tests;",
 				Expected: []sql.Row{
-					{"validate tables", "one table", "show tables;", "expected_rows", "==", "1"},
-					{"validate tables", "numbers table exists", "show tables like 'numbers'", "expected_rows", "==", "1"},
-					{"numbers table validation", "numbers schema", "describe numbers", "expected_rows", "==", "1"},
+					{"one table", "validate tables", "show tables;", "expected_rows", "==", "1"},
+					{"numbers table exists", "validate tables", "show tables like 'numbers'", "expected_rows", "==", "1"},
+					{"numbers schema", "numbers table validation", "describe numbers", "expected_rows", "==", "1"},
 				},
 			},
 			{
 				Query: "SELECT * FROM dolt_tests where test_group = 'validate tables'",
 				Expected: []sql.Row{
-					{"validate tables", "one table", "show tables;", "expected_rows", "==", "1"},
-					{"validate tables", "numbers table exists", "show tables like 'numbers'", "expected_rows", "==", "1"},
+					{"one table", "validate tables", "show tables;", "expected_rows", "==", "1"},
+					{"numbers table exists", "validate tables", "show tables like 'numbers'", "expected_rows", "==", "1"},
 				},
 			},
 		},
@@ -86,16 +86,16 @@ var DoltTestTableScripts = []queries.ScriptTest{
 	{
 		Name: "can replace row in dolt_tests table",
 		SetUpScript: []string{
-			"INSERT INTO dolt_tests VALUES ('validate tables', 'one table', 'show tables;', 'expected_rows', '==', '1')",
-			"INSERT INTO dolt_tests VALUES ('validate tables', 'numbers table exists', 'show tables like ''numbers'';', 'expected_rows', '==', '1')",
-			"REPLACE INTO dolt_tests VALUES ('validate tables', 'numbers table exists', 'show tables like ''numbers'';', 'expected_rows', '==', '1')",
+			"INSERT INTO dolt_tests VALUES ('one table', 'validate tables', 'show tables;', 'expected_rows', '==', '1')",
+			"INSERT INTO dolt_tests VALUES ('numbers table exists', 'validate tables', 'show tables like ''numbers'';', 'expected_rows', '==', '1')",
+			"REPLACE INTO dolt_tests VALUES ('numbers table exists', 'validate tables', 'show tables like ''numbers'';', 'expected_rows', '==', '1')",
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query: "SELECT * FROM dolt_tests",
 				Expected: []sql.Row{
-					{"validate tables", "numbers table exists", "show tables like 'numbers';", "expected_rows", "==", "1"},
-					{"validate tables", "one table", "show tables;", "expected_rows", "==", "1"},
+					{"numbers table exists", "validate tables", "show tables like 'numbers';", "expected_rows", "==", "1"},
+					{"one table", "validate tables", "show tables;", "expected_rows", "==", "1"},
 				},
 			},
 		},
@@ -103,9 +103,9 @@ var DoltTestTableScripts = []queries.ScriptTest{
 	{
 		Name: "can use 'as of' on dolt_tests table",
 		SetUpScript: []string{
-			"INSERT INTO dolt_tests VALUES ('validate tables', 'one table', 'show tables;', 'expected_rows', '==', '1')",
+			"INSERT INTO dolt_tests VALUES ('one table', 'validate tables', 'show tables;', 'expected_rows', '==', '1')",
 			"CALL DOLT_COMMIT('-A','-m', 'first commit')",
-			"INSERT INTO dolt_tests VALUES ('validate tables', 'numbers table exists', 'show tables like ''numbers'';', 'expected_rows', '==', '1')",
+			"INSERT INTO dolt_tests VALUES ('numbers table exists', 'validate tables', 'show tables like ''numbers'';', 'expected_rows', '==', '1')",
 			"CALL DOLT_COMMIT('-A', '-m', 'second commit')",
 		},
 		Assertions: []queries.ScriptTestAssertion{
@@ -116,14 +116,14 @@ var DoltTestTableScripts = []queries.ScriptTest{
 			{
 				Query: "SELECT * FROM dolt_tests as of 'HEAD~1'",
 				Expected: []sql.Row{
-					{"validate tables", "one table", "show tables;", "expected_rows", "==", "1"},
+					{"one table", "validate tables", "show tables;", "expected_rows", "==", "1"},
 				},
 			},
 			{
 				Query: "SELECT * FROM dolt_tests as of 'HEAD'",
 				Expected: []sql.Row{
-					{"validate tables", "one table", "show tables;", "expected_rows", "==", "1"},
-					{"validate tables", "numbers table exists", "show tables like 'numbers';", "expected_rows", "==", "1"},
+					{"one table", "validate tables", "show tables;", "expected_rows", "==", "1"},
+					{"numbers table exists", "validate tables", "show tables like 'numbers';", "expected_rows", "==", "1"},
 				},
 			},
 		},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_test_table.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_test_table.go
@@ -25,14 +25,14 @@ var DoltTestTableScripts = []queries.ScriptTest{
 		Name: "can insert into dolt tests",
 		Assertions: []queries.ScriptTestAssertion{
 			{
-				Query: "INSERT INTO dolt_tests VALUES ('validate tables', 'no tables', 'show tables;', 'expected_rows == 0;')",
+				Query: "INSERT INTO dolt_tests VALUES ('validate tables', 'no tables', 'show tables;', 'expected_rows', '==', '0')",
 			},
 		},
 	},
 	{
 		Name: "can drop dolt tests table, cannot drop twice",
 		SetUpScript: []string{
-			"INSERT INTO dolt_tests VALUES ('validate tables', 'no tables', 'show tables;', 'expected_rows == 0;')",
+			"INSERT INTO dolt_tests VALUES ('validate tables', 'no tables', 'show tables;', 'expected_rows', '==', '0')",
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
@@ -61,24 +61,24 @@ var DoltTestTableScripts = []queries.ScriptTest{
 	{
 		Name: "select from dolt_tests tables",
 		SetUpScript: []string{
-			"INSERT INTO dolt_tests VALUES ('validate tables', 'one table', 'show tables;', 'expected_rows == 1');",
-			"INSERT INTO dolt_tests VALUES ('validate tables', 'numbers table exists', 'show tables like ''numbers''', 'expected_rows == 1')",
-			"INSERT INTO dolt_tests VALUES ('numbers table validation', 'numbers schema', 'describe numbers', 'expected_rows == 1')",
+			"INSERT INTO dolt_tests VALUES ('validate tables', 'one table', 'show tables;', 'expected_rows', '==', '1');",
+			"INSERT INTO dolt_tests VALUES ('validate tables', 'numbers table exists', 'show tables like ''numbers''', 'expected_rows', '==', '1')",
+			"INSERT INTO dolt_tests VALUES ('numbers table validation', 'numbers schema', 'describe numbers', 'expected_rows', '==', '1')",
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query: "SELECT * FROM dolt_tests;",
 				Expected: []sql.Row{
-					{"validate tables", "one table", "show tables;", "expected_rows == 1"},
-					{"validate tables", "numbers table exists", "show tables like 'numbers'", "expected_rows == 1"},
-					{"numbers table validation", "numbers schema", "describe numbers", "expected_rows == 1"},
+					{"validate tables", "one table", "show tables;", "expected_rows", "==", "1"},
+					{"validate tables", "numbers table exists", "show tables like 'numbers'", "expected_rows", "==", "1"},
+					{"numbers table validation", "numbers schema", "describe numbers", "expected_rows", "==", "1"},
 				},
 			},
 			{
 				Query: "SELECT * FROM dolt_tests where test_group = 'validate tables'",
 				Expected: []sql.Row{
-					{"validate tables", "one table", "show tables;", "expected_rows == 1"},
-					{"validate tables", "numbers table exists", "show tables like 'numbers'", "expected_rows == 1"},
+					{"validate tables", "one table", "show tables;", "expected_rows", "==", "1"},
+					{"validate tables", "numbers table exists", "show tables like 'numbers'", "expected_rows", "==", "1"},
 				},
 			},
 		},
@@ -86,16 +86,16 @@ var DoltTestTableScripts = []queries.ScriptTest{
 	{
 		Name: "can replace row in dolt_tests table",
 		SetUpScript: []string{
-			"INSERT INTO dolt_tests VALUES ('validate tables', 'one table', 'show tables;', 'expected_rows == 1')",
-			"INSERT INTO dolt_tests VALUES ('validate tables', 'numbers table exists', 'show tables like ''numbers'';', 'expected_rows == 0')",
-			"REPLACE INTO dolt_tests VALUES ('validate tables', 'numbers table exists', 'show tables like ''numbers'';', 'expected_rows == 1')",
+			"INSERT INTO dolt_tests VALUES ('validate tables', 'one table', 'show tables;', 'expected_rows', '==', '1')",
+			"INSERT INTO dolt_tests VALUES ('validate tables', 'numbers table exists', 'show tables like ''numbers'';', 'expected_rows', '==', '1')",
+			"REPLACE INTO dolt_tests VALUES ('validate tables', 'numbers table exists', 'show tables like ''numbers'';', 'expected_rows', '==', '1')",
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
 				Query: "SELECT * FROM dolt_tests",
 				Expected: []sql.Row{
-					{"validate tables", "numbers table exists", "show tables like 'numbers';", "expected_rows == 1"},
-					{"validate tables", "one table", "show tables;", "expected_rows == 1"},
+					{"validate tables", "numbers table exists", "show tables like 'numbers';", "expected_rows", "==", "1"},
+					{"validate tables", "one table", "show tables;", "expected_rows", "==", "1"},
 				},
 			},
 		},
@@ -103,9 +103,9 @@ var DoltTestTableScripts = []queries.ScriptTest{
 	{
 		Name: "can use 'as of' on dolt_tests table",
 		SetUpScript: []string{
-			"INSERT INTO dolt_tests VALUES ('validate tables', 'one table', 'show tables;', 'expected_rows == 1')",
+			"INSERT INTO dolt_tests VALUES ('validate tables', 'one table', 'show tables;', 'expected_rows', '==', '1')",
 			"CALL DOLT_COMMIT('-A','-m', 'first commit')",
-			"INSERT INTO dolt_tests VALUES ('validate tables', 'numbers table exists', 'show tables like ''numbers'';', 'expected_rows == 1')",
+			"INSERT INTO dolt_tests VALUES ('validate tables', 'numbers table exists', 'show tables like ''numbers'';', 'expected_rows', '==', '1')",
 			"CALL DOLT_COMMIT('-A', '-m', 'second commit')",
 		},
 		Assertions: []queries.ScriptTestAssertion{
@@ -116,14 +116,14 @@ var DoltTestTableScripts = []queries.ScriptTest{
 			{
 				Query: "SELECT * FROM dolt_tests as of 'HEAD~1'",
 				Expected: []sql.Row{
-					{"validate tables", "one table", "show tables;", "expected_rows == 1"},
+					{"validate tables", "one table", "show tables;", "expected_rows", "==", "1"},
 				},
 			},
 			{
 				Query: "SELECT * FROM dolt_tests as of 'HEAD'",
 				Expected: []sql.Row{
-					{"validate tables", "one table", "show tables;", "expected_rows == 1"},
-					{"validate tables", "numbers table exists", "show tables like 'numbers';", "expected_rows == 1"},
+					{"validate tables", "one table", "show tables;", "expected_rows", "==", "1"},
+					{"validate tables", "numbers table exists", "show tables like 'numbers';", "expected_rows", "==", "1"},
 				},
 			},
 		},


### PR DESCRIPTION
Adds `dolt_tests` system table. The table currently has no functionality, but behaves similarly to the other writable system tables like `dolt_ignore` and `dolt_query_catalog`.