### PR TITLE
dolthub/dolt#9677 - Fix dolt_patch extra index operations

### DIFF
--- a/go/libraries/doltcore/diff/schema_diff.go
+++ b/go/libraries/doltcore/diff/schema_diff.go
@@ -103,11 +103,9 @@ type IndexDifference struct {
 // It returns matched and unmatched Indexes as a slice of IndexDifferences.
 func DiffSchIndexes(fromSch, toSch schema.Schema) (diffs []IndexDifference) {
 	_ = fromSch.Indexes().Iter(func(fromIdx schema.Index) (stop bool, err error) {
-		// Get all indexes that match the column tags, then find exact match
+		// Find exact matching index by comparing all properties
 		candidateIndexes := toSch.Indexes().GetIndexesByTags(fromIdx.IndexedColumnTags()...)
 		var toIdx schema.Index
-
-		// Find exact match by comparing all properties
 		for _, candidate := range candidateIndexes {
 			if fromIdx.Equals(candidate) {
 				toIdx = candidate
@@ -124,7 +122,7 @@ func DiffSchIndexes(fromSch, toSch schema.Schema) (diffs []IndexDifference) {
 		}
 
 		diffs = append(diffs, IndexDifference{
-			DiffType: SchDiffNone, // They are equal since we found exact match
+			DiffType: SchDiffNone,
 			From:     fromIdx,
 			To:       toIdx,
 		})

--- a/go/libraries/doltcore/diff/schema_diff.go
+++ b/go/libraries/doltcore/diff/schema_diff.go
@@ -107,20 +107,20 @@ func pairColumns(fromSch, toSch schema.Schema) (map[uint64]columnPair, []uint64)
 	// Try name-based pairing for remaining unmatched columns with compatible types
 	if len(unpairedFrom) > 0 && len(unpairedTo) > 0 {
 		checker := typecompatibility.NewTypeCompatabilityCheckerForStorageFormat(storetypes.Format_Default)
-		
+
 		for _, fromCol := range unpairedFrom {
 			for _, toCol := range unpairedTo {
 				if fromCol.Name == toCol.Name {
 					compatInfo := checker.IsTypeChangeCompatible(fromCol.TypeInfo, toCol.TypeInfo)
-					
+
 					if compatInfo.Compatible {
 						// Remove the unpaired entries
 						delete(colPairMap, fromCol.Tag)
 						delete(colPairMap, toCol.Tag)
-						
+
 						// Create a new paired entry using the fromCol tag (preserves original position)
 						colPairMap[fromCol.Tag] = columnPair{&fromCol, &toCol}
-						
+
 						// Remove the toCol tag from unionTags since we're using fromCol tag
 						for i, tag := range unionTags {
 							if tag == toCol.Tag {

--- a/go/libraries/doltcore/schema/index.go
+++ b/go/libraries/doltcore/schema/index.go
@@ -149,6 +149,8 @@ func (ix *indexImpl) Equals(other Index) bool {
 
 	return ix.IsUnique() == other.IsUnique() &&
 		ix.IsSpatial() == other.IsSpatial() &&
+		ix.IsFullText() == other.IsFullText() &&
+		ix.IsVector() == other.IsVector() &&
 		compareUint16Slices(ix.PrefixLengths(), other.PrefixLengths()) &&
 		ix.Comment() == other.Comment() &&
 		ix.Name() == other.Name()

--- a/go/libraries/doltcore/schema/index.go
+++ b/go/libraries/doltcore/schema/index.go
@@ -173,6 +173,8 @@ func (ix *indexImpl) DeepEquals(other Index) bool {
 
 	return ix.IsUnique() == other.IsUnique() &&
 		ix.IsSpatial() == other.IsSpatial() &&
+		ix.IsFullText() == other.IsFullText() &&
+		ix.IsVector() == other.IsVector() &&
 		compareUint16Slices(ix.PrefixLengths(), other.PrefixLengths()) &&
 		ix.Comment() == other.Comment() &&
 		ix.Name() == other.Name()

--- a/go/libraries/doltcore/schema/typecompatibility/type_compatibility.go
+++ b/go/libraries/doltcore/schema/typecompatibility/type_compatibility.go
@@ -116,7 +116,7 @@ func (d doltTypeCompatibilityChecker) IsTypeChangeCompatible(from, to typeinfo.T
 	// If the types are exactly identical, then they are always compatible
 	fromSqlType := from.ToSqlType()
 	toSqlType := to.ToSqlType()
-	
+
 	if fromSqlType.Equals(toSqlType) {
 		res.Compatible = true
 		return res
@@ -153,17 +153,17 @@ func (i integerTypeChangeHandler) canHandle(fromSqlType, toSqlType sql.Type) boo
 
 func (i integerTypeChangeHandler) isCompatible(fromSqlType, toSqlType sql.Type) (res TypeChangeInfo) {
 	// Conservative rule: only allow widenings with same signedness
-	
+
 	fromSize := getIntegerSize(fromSqlType)
 	toSize := getIntegerSize(toSqlType)
 	fromUnsigned := sqltypes.IsUnsigned(fromSqlType.Type())
 	toUnsigned := sqltypes.IsUnsigned(toSqlType.Type())
-	
+
 	// Allow only size increases with same signedness
 	if toSize > fromSize && fromUnsigned == toUnsigned {
 		res.Compatible = true
 	}
-	
+
 	return res
 }
 
@@ -194,8 +194,6 @@ func getIntegerSize(t sql.Type) int {
 	}
 }
 
-
-
 // decimalTypeChangeHandler allows precision/scale expansion without data loss.
 type decimalTypeChangeHandler struct{}
 
@@ -214,9 +212,9 @@ func (dch decimalTypeChangeHandler) isCompatible(fromSqlType, toSqlType sql.Type
 	toIntegerDigits := toDec.Precision() - toDec.Scale()
 
 	// Allow only expansions: precision >=, scale >=, integer digits >=
-	if toDec.Precision() >= fromDec.Precision() && 
-	   toIntegerDigits >= fromIntegerDigits && 
-	   toDec.Scale() >= fromDec.Scale() {
+	if toDec.Precision() >= fromDec.Precision() &&
+		toIntegerDigits >= fromIntegerDigits &&
+		toDec.Scale() >= fromDec.Scale() {
 		res.Compatible = true
 		return res
 	}

--- a/go/libraries/doltcore/schema/typecompatibility/type_compatibility_test.go
+++ b/go/libraries/doltcore/schema/typecompatibility/type_compatibility_test.go
@@ -159,10 +159,10 @@ func TestDoltIsTypeChangeCompatible(t *testing.T) {
 			to:         typeinfo.Int64Type,
 			compatible: true,
 		}, {
-			name:       "int family: small to large type changes are incompatible",
+			name:       "int family: safe widenings with same signedness are compatible",
 			from:       typeinfo.Int8Type,
 			to:         typeinfo.Int16Type,
-			compatible: false,
+			compatible: true,
 		}, {
 			name:       "int family: large to small type changes are incompatible",
 			from:       typeinfo.Int64Type,

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -3941,14 +3941,12 @@ var PatchTableFunctionScriptTests = []queries.ScriptTest{
 		},
 		Assertions: []queries.ScriptTestAssertion{
             {
-                // Customer's first command: with table specified - should only show column change, not index changes
                 Query: "SELECT statement FROM dolt_patch('old', 'new', 'table_name') WHERE diff_type = 'schema' ORDER BY statement_order",
                 Expected: []sql.Row{
                     {"ALTER TABLE `table_name` MODIFY COLUMN `field_change_sign` bigint unsigned DEFAULT NULL;"},
                 },
             },
             {
-                // Customer's second command: without table specified - should only show column change
                 Query: "SELECT statement FROM dolt_patch('old', 'new') WHERE diff_type = 'schema' ORDER BY statement_order",
                 Expected: []sql.Row{
                     {"ALTER TABLE `table_name` MODIFY COLUMN `field_change_sign` bigint unsigned DEFAULT NULL;"},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -3940,30 +3940,20 @@ var PatchTableFunctionScriptTests = []queries.ScriptTest{
 			"CALL dolt_commit('-m', 'table with bigint unsigned column')",
 		},
 		Assertions: []queries.ScriptTestAssertion{
-			{
-				// Customer's first command: with table specified - should only show column change, not index changes
-				Query: "SELECT statement FROM dolt_patch('old', 'new', 'table_name') WHERE diff_type = 'schema' ORDER BY statement_order",
-				Expected: []sql.Row{
-					{"ALTER TABLE `table_name` DROP `field_change_sign`;"},
-					{"ALTER TABLE `table_name` ADD `field_change_sign` bigint unsigned DEFAULT NULL;"},
-					// The following lines should NOT appear (this test will fail initially, showing the bug):
-					// {"ALTER TABLE `table_name` DROP INDEX `fk_field_name_idx`;"},
-					// {"ALTER TABLE `table_name` ADD INDEX `field_name_UNIQUE`(`field_name`);"},
-					// {"ALTER TABLE `table_name` ADD INDEX `fk_field_name_idx`(`field_name`);"},
-				},
-			},
-			{
-				// Customer's second command: without table specified - should only show column change
-				Query: "SELECT statement FROM dolt_patch('old', 'new') WHERE diff_type = 'schema' ORDER BY statement_order",
-				Expected: []sql.Row{
-					{"ALTER TABLE `table_name` DROP `field_change_sign`;"},
-					{"ALTER TABLE `table_name` ADD `field_change_sign` bigint unsigned DEFAULT NULL;"},
-					// The following lines should NOT appear (this test will fail initially, showing the bug):
-					// {"ALTER TABLE `table_name` DROP INDEX `fk_field_name_idx`;"},
-					// {"ALTER TABLE `table_name` ADD INDEX `field_name_UNIQUE`(`field_name`);"},
-					// {"ALTER TABLE `table_name` ADD INDEX `fk_field_name_idx`(`field_name`);"},
-				},
-			},
+            {
+                // Customer's first command: with table specified - should only show column change, not index changes
+                Query: "SELECT statement FROM dolt_patch('old', 'new', 'table_name') WHERE diff_type = 'schema' ORDER BY statement_order",
+                Expected: []sql.Row{
+                    {"ALTER TABLE `table_name` MODIFY COLUMN `field_change_sign` bigint unsigned DEFAULT NULL;"},
+                },
+            },
+            {
+                // Customer's second command: without table specified - should only show column change
+                Query: "SELECT statement FROM dolt_patch('old', 'new') WHERE diff_type = 'schema' ORDER BY statement_order",
+                Expected: []sql.Row{
+                    {"ALTER TABLE `table_name` MODIFY COLUMN `field_change_sign` bigint unsigned DEFAULT NULL;"},
+                },
+            },
 			{
 				// Verify that the indexes are indeed identical on both branches
 				Query: "SELECT COUNT(*) FROM (SELECT index_name, non_unique, column_name FROM INFORMATION_SCHEMA.STATISTICS WHERE table_name = 'table_name' AND table_schema = 'mydb' ORDER BY index_name, seq_in_index) as old_indexes",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -4004,7 +4004,7 @@ var PatchTableFunctionScriptTests = []queries.ScriptTest{
 		},
 	},
 	{
-		Name: "dolt_patch: integer type chain widening generates MODIFY", 
+		Name: "dolt_patch: integer type chain widening generates MODIFY",
 		SetUpScript: []string{
 			"CREATE TABLE chain_test (id INT PRIMARY KEY, col1 TINYINT)",
 			"CALL dolt_add('.')",
@@ -4075,13 +4075,13 @@ var PatchTableFunctionScriptTests = []queries.ScriptTest{
 				},
 			},
 			{
-				Query: "SELECT COUNT(*) FROM dolt_patch('main', 'index_compat_after') WHERE diff_type = 'schema' AND statement LIKE '%INDEX%'",
+				Query:    "SELECT COUNT(*) FROM dolt_patch('main', 'index_compat_after') WHERE diff_type = 'schema' AND statement LIKE '%INDEX%'",
 				Expected: []sql.Row{{0}},
 			},
 		},
 	},
 	{
-		Name: "dolt_patch: incompatible type changes with indexes do not generate spurious index operations", 
+		Name: "dolt_patch: incompatible type changes with indexes do not generate spurious index operations",
 		SetUpScript: []string{
 			"CREATE TABLE idx_incompat_test (id INT PRIMARY KEY, col1 VARCHAR(50), KEY idx_col1 (col1))",
 			"CALL dolt_add('.')",
@@ -4102,7 +4102,7 @@ var PatchTableFunctionScriptTests = []queries.ScriptTest{
 				},
 			},
 			{
-				Query: "SELECT COUNT(*) FROM dolt_patch('main', 'incompat_index_branch') WHERE diff_type = 'schema' AND statement LIKE '%INDEX%'",
+				Query:    "SELECT COUNT(*) FROM dolt_patch('main', 'incompat_index_branch') WHERE diff_type = 'schema' AND statement LIKE '%INDEX%'",
 				Expected: []sql.Row{{1}},
 			},
 		},
@@ -4131,19 +4131,18 @@ var PatchTableFunctionScriptTests = []queries.ScriptTest{
 				},
 			},
 			{
-				Query: "SELECT statement FROM dolt_patch('main', 'customer_unsigned') WHERE diff_type = 'schema' ORDER BY statement_order", 
+				Query: "SELECT statement FROM dolt_patch('main', 'customer_unsigned') WHERE diff_type = 'schema' ORDER BY statement_order",
 				Expected: []sql.Row{
 					{"ALTER TABLE `table_name` DROP `field_change_sign`;"},
 					{"ALTER TABLE `table_name` ADD `field_change_sign` bigint unsigned DEFAULT NULL;"},
 				},
 			},
 			{
-				Query: "SELECT COUNT(*) FROM dolt_patch('main', 'customer_unsigned') WHERE diff_type = 'schema' AND statement LIKE '%INDEX%'",
+				Query:    "SELECT COUNT(*) FROM dolt_patch('main', 'customer_unsigned') WHERE diff_type = 'schema' AND statement LIKE '%INDEX%'",
 				Expected: []sql.Row{{0}},
 			},
 		},
 	},
-
 }
 
 var UnscopedDiffSystemTableScriptTests = []queries.ScriptTest{

--- a/go/libraries/doltcore/sqle/sqlfmt/schema_fmt.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/schema_fmt.go
@@ -110,89 +110,58 @@ func generateNonCreateNonDropTableSqlSchemaDiff(td diff.TableDelta, toSchemas ma
 		return ddlStatements, nil
 	}
 
-    colDiffs, unionTags := diff.DiffSchColumns(fromSch, toSch)
-
-    // Build name-based maps of added and removed columns to enable coalescing DROP+ADD -> MODIFY for same-name columns
-    addedByName := make(map[string]*schema.Column)
-    removedByName := make(map[string]*schema.Column)
-    for _, tag := range unionTags {
-        cd := colDiffs[tag]
-        switch cd.DiffType {
-        case diff.SchDiffAdded:
-            if cd.New != nil {
-                addedByName[cd.New.Name] = cd.New
-            }
-        case diff.SchDiffRemoved:
-            if cd.Old != nil {
-                removedByName[cd.Old.Name] = cd.Old
-            }
-        }
-    }
-
-    // Determine which names can be safely coalesced
-    coalesceNames := make(map[string]*schema.Column) // value is the new column definition to use for MODIFY
-    for name, newCol := range addedByName {
-        if oldCol, ok := removedByName[name]; ok {
-            // Only coalesce when PK membership does not change
-            if oldCol.IsPartOfPK == newCol.IsPartOfPK {
-                coalesceNames[name] = newCol
-            }
-        }
-    }
-
-    // Track which coalesced names have already emitted a MODIFY
-    emittedModify := make(map[string]bool)
-
-    for _, tag := range unionTags {
-        cd := colDiffs[tag]
-        switch cd.DiffType {
-        case diff.SchDiffNone:
-            // no-op
-        case diff.SchDiffAdded:
-            // If this add is paired with a drop of the same name, emit a single MODIFY instead
-            if cd.New != nil {
-                if _, shouldCoalesce := coalesceNames[cd.New.Name]; shouldCoalesce {
-                    if !emittedModify[cd.New.Name] {
-                        ddlStatements = append(ddlStatements, AlterTableModifyColStmt(td.ToName.Name,
-                            GenerateCreateTableColumnDefinition(*cd.New, sql.CollationID(td.ToSch.GetCollation()))))
-                        emittedModify[cd.New.Name] = true
-                    }
-                    // skip emitting ADD
-                    continue
-                }
-            }
-            ddlStatements = append(ddlStatements, AlterTableAddColStmt(td.ToName.Name, GenerateCreateTableColumnDefinition(*cd.New, sql.CollationID(td.ToSch.GetCollation()))))
-        case diff.SchDiffRemoved:
-            // If this drop is paired with an add of the same name, emit a single MODIFY instead
-            if cd.Old != nil {
-                if _, shouldCoalesce := coalesceNames[cd.Old.Name]; shouldCoalesce {
-                    if !emittedModify[cd.Old.Name] {
-                        // Use the "new" column definition for the MODIFY statement
-                        newCol := coalesceNames[cd.Old.Name]
-                        ddlStatements = append(ddlStatements, AlterTableModifyColStmt(td.ToName.Name,
-                            GenerateCreateTableColumnDefinition(*newCol, sql.CollationID(td.ToSch.GetCollation()))))
-                        emittedModify[cd.Old.Name] = true
-                    }
-                    // skip emitting DROP
-                    continue
-                }
-            }
-            ddlStatements = append(ddlStatements, AlterTableDropColStmt(td.ToName.Name, cd.Old.Name))
-        case diff.SchDiffModified:
-            // Ignore any primary key set changes here
-            if cd.Old.IsPartOfPK != cd.New.IsPartOfPK {
-                continue
-            }
-            if cd.Old.Name != cd.New.Name {
-                ddlStatements = append(ddlStatements, AlterTableRenameColStmt(td.ToName.Name, cd.Old.Name, cd.New.Name))
-            }
-            // Only emit MODIFY when properties beyond the name actually change
-            if columnDefinitionChangedExceptName(*cd.Old, *cd.New) {
-                ddlStatements = append(ddlStatements, AlterTableModifyColStmt(td.ToName.Name,
-                    GenerateCreateTableColumnDefinition(*cd.New, sql.CollationID(td.ToSch.GetCollation()))))
-            }
-        }
-    }
+	colDiffs, unionTags := diff.DiffSchColumns(fromSch, toSch)
+	
+	// Build maps to detect same-name column changes (DROP+ADD -> MODIFY)
+	addedByName := make(map[string]*schema.Column)
+	removedByName := make(map[string]*schema.Column)
+	for _, tag := range unionTags {
+		cd := colDiffs[tag]
+		if cd.DiffType == diff.SchDiffAdded && cd.New != nil {
+			addedByName[cd.New.Name] = cd.New
+		} else if cd.DiffType == diff.SchDiffRemoved && cd.Old != nil {
+			removedByName[cd.Old.Name] = cd.Old
+		}
+	}
+	
+	processedNames := make(map[string]bool)
+	for _, tag := range unionTags {
+		cd := colDiffs[tag]
+		switch cd.DiffType {
+		case diff.SchDiffNone:
+		case diff.SchDiffAdded:
+			// Convert DROP+ADD of same name to MODIFY if PK membership unchanged
+			if cd.New != nil && removedByName[cd.New.Name] != nil && !processedNames[cd.New.Name] {
+				if removedByName[cd.New.Name].IsPartOfPK == cd.New.IsPartOfPK {
+					ddlStatements = append(ddlStatements, AlterTableModifyColStmt(td.ToName.Name,
+						GenerateCreateTableColumnDefinition(*cd.New, sql.CollationID(td.ToSch.GetCollation()))))
+					processedNames[cd.New.Name] = true
+					continue
+				}
+			}
+			ddlStatements = append(ddlStatements, AlterTableAddColStmt(td.ToName.Name, GenerateCreateTableColumnDefinition(*cd.New, sql.CollationID(td.ToSch.GetCollation()))))
+		case diff.SchDiffRemoved:
+			// Skip DROP if it pairs with ADD of same name (handled above)
+			if cd.Old != nil && addedByName[cd.Old.Name] != nil && !processedNames[cd.Old.Name] {
+				if cd.Old.IsPartOfPK == addedByName[cd.Old.Name].IsPartOfPK {
+					continue
+				}
+			}
+			ddlStatements = append(ddlStatements, AlterTableDropColStmt(td.ToName.Name, cd.Old.Name))
+		case diff.SchDiffModified:
+			// Ignore any primary key set changes here
+			if cd.Old.IsPartOfPK != cd.New.IsPartOfPK {
+				continue
+			}
+			if cd.Old.Name != cd.New.Name {
+				ddlStatements = append(ddlStatements, AlterTableRenameColStmt(td.ToName.Name, cd.Old.Name, cd.New.Name))
+			}
+			if !cd.Old.TypeInfo.Equals(cd.New.TypeInfo) {
+				ddlStatements = append(ddlStatements, AlterTableModifyColStmt(td.ToName.Name,
+					GenerateCreateTableColumnDefinition(*cd.New, sql.CollationID(td.ToSch.GetCollation()))))
+			}
+		}
+	}
 
 	// Print changes between a primary key set change. It contains an ALTER TABLE DROP and an ALTER TABLE ADD
 	if !schema.ColCollsAreEqual(fromSch.GetPKCols(), toSch.GetPKCols()) {
@@ -205,7 +174,6 @@ func generateNonCreateNonDropTableSqlSchemaDiff(td diff.TableDelta, toSchemas ma
 	for _, idxDiff := range diff.DiffSchIndexes(fromSch, toSch) {
 		switch idxDiff.DiffType {
 		case diff.SchDiffNone:
-			// Skip generating DDL for unchanged indexes
 		case diff.SchDiffAdded:
 			ddlStatements = append(ddlStatements, AlterTableAddIndexStmt(td.ToName.Name, idxDiff.To))
 		case diff.SchDiffRemoved:
@@ -327,34 +295,6 @@ func GenerateCreateTableCheckConstraintClause(check schema.Check) string {
 	return sql.GenerateCreateTableCheckConstraintClause(check.Name(), check.Expression(), check.Enforced())
 }
 
-// columnDefinitionChangedExceptName returns true if any property other than the name differs
-// between the two given columns. This intentionally mirrors the attributes we render in
-// GenerateCreateTableColumnDefinition, without re-checking tags or PK membership here.
-func columnDefinitionChangedExceptName(oldCol schema.Column, newCol schema.Column) bool {
-    if !oldCol.TypeInfo.Equals(newCol.TypeInfo) {
-        return true
-    }
-    if oldCol.Comment != newCol.Comment {
-        return true
-    }
-    if oldCol.IsNullable() != newCol.IsNullable() {
-        return true
-    }
-    if oldCol.AutoIncrement != newCol.AutoIncrement {
-        return true
-    }
-    if oldCol.Default != newCol.Default {
-        return true
-    }
-    if oldCol.Generated != newCol.Generated {
-        return true
-    }
-    if oldCol.OnUpdate != newCol.OnUpdate {
-        return true
-    }
-    return false
-}
-
 func DropTableStmt(tableName string) string {
 	var b strings.Builder
 	b.WriteString("DROP TABLE ")
@@ -455,25 +395,13 @@ func AlterTableAddIndexStmt(tableName string, idx schema.Index) string {
 	var b strings.Builder
 	b.WriteString("ALTER TABLE ")
 	b.WriteString(QuoteIdentifier(tableName))
-	b.WriteString(" ADD ")
-
-	// Generate correct index type based on index properties
-	switch {
-	case idx.IsUnique():
-		b.WriteString("UNIQUE INDEX ")
-	case idx.IsSpatial():
-		b.WriteString("SPATIAL INDEX ")
-	case idx.IsFullText():
-		b.WriteString("FULLTEXT INDEX ")
-	case idx.IsVector():
-		b.WriteString("VECTOR INDEX ")
-	default:
-		b.WriteString("INDEX ")
-	}
-
+	b.WriteString(" ADD INDEX ")
 	b.WriteString(QuoteIdentifier(idx.Name()))
-	b.WriteString("(" + strings.Join(sql.QuoteIdentifiers(idx.ColumnNames()), ",") + ")")
-	b.WriteRune(';')
+	var cols []string
+	for _, cn := range idx.ColumnNames() {
+		cols = append(cols, QuoteIdentifier(cn))
+	}
+	b.WriteString("(" + strings.Join(cols, ",") + ");")
 	return b.String()
 }
 

--- a/go/libraries/doltcore/sqle/sqlfmt/schema_fmt.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/schema_fmt.go
@@ -111,7 +111,7 @@ func generateNonCreateNonDropTableSqlSchemaDiff(td diff.TableDelta, toSchemas ma
 	}
 
 	colDiffs, unionTags := diff.DiffSchColumns(fromSch, toSch)
-	
+
 	for _, tag := range unionTags {
 		cd := colDiffs[tag]
 		switch cd.DiffType {

--- a/integration-tests/bats/sql-diff.bats
+++ b/integration-tests/bats/sql-diff.bats
@@ -911,24 +911,19 @@ EOF
     dolt add .
     dolt commit -m "table with bigint unsigned column"
 
-    # Test customer's first command: with table specified - should only show column change
+    # Test customer's first command: with table specified - should only show a single MODIFY
     run dolt sql --result-format csv -q "SELECT statement FROM dolt_patch('old', 'new', 'table_name') WHERE diff_type = 'schema' ORDER BY statement_order"
     [ "$status" -eq 0 ]
-    # Should only contain column changes, not index changes
     expected_output="statement
-ALTER TABLE \`table_name\` DROP \`field_change_sign\`;
-ALTER TABLE \`table_name\` ADD \`field_change_sign\` bigint unsigned DEFAULT NULL;"
+ALTER TABLE \`table_name\` MODIFY COLUMN \`field_change_sign\` bigint unsigned DEFAULT NULL;"
     [ "$output" = "$expected_output" ]
-    # Should NOT contain these problematic index statements:
     [[ ! "$output" =~ "DROP INDEX" ]] || false
     [[ ! "$output" =~ "ADD INDEX" ]] || false
 
-    # Test customer's second command: without table specified - should only show column change  
+    # Test customer's second command: without table specified - should only show a single MODIFY
     run dolt sql --result-format csv -q "SELECT statement FROM dolt_patch('old', 'new') WHERE diff_type = 'schema' ORDER BY statement_order"
     [ "$status" -eq 0 ]
-    # Should only contain column changes, not index changes
     [ "$output" = "$expected_output" ]
-    # Should NOT contain these problematic index statements:
     [[ ! "$output" =~ "DROP INDEX" ]] || false
     [[ ! "$output" =~ "ADD INDEX" ]] || false
 }

--- a/integration-tests/bats/sql-diff.bats
+++ b/integration-tests/bats/sql-diff.bats
@@ -914,16 +914,16 @@ EOF
     # Test customer's first command: with table specified - should only show a single MODIFY
     run dolt sql --result-format csv -q "SELECT statement FROM dolt_patch('old', 'new', 'table_name') WHERE diff_type = 'schema' ORDER BY statement_order"
     [ "$status" -eq 0 ]
-    expected_output="statement
-ALTER TABLE \`table_name\` MODIFY COLUMN \`field_change_sign\` bigint unsigned DEFAULT NULL;"
-    [ "$output" = "$expected_output" ]
+    [[ "$output" == "statement
+ALTER TABLE \`table_name\` MODIFY COLUMN \`field_change_sign\` bigint unsigned DEFAULT NULL;" ]]
     [[ ! "$output" =~ "DROP INDEX" ]] || false
     [[ ! "$output" =~ "ADD INDEX" ]] || false
 
     # Test customer's second command: without table specified - should only show a single MODIFY
     run dolt sql --result-format csv -q "SELECT statement FROM dolt_patch('old', 'new') WHERE diff_type = 'schema' ORDER BY statement_order"
     [ "$status" -eq 0 ]
-    [ "$output" = "$expected_output" ]
+    [[ "$output" == "statement
+ALTER TABLE \`table_name\` MODIFY COLUMN \`field_change_sign\` bigint unsigned DEFAULT NULL;" ]]
     [[ ! "$output" =~ "DROP INDEX" ]] || false
     [[ ! "$output" =~ "ADD INDEX" ]] || false
 }

--- a/integration-tests/bats/sql-diff.bats
+++ b/integration-tests/bats/sql-diff.bats
@@ -915,7 +915,7 @@ EOF
     run dolt sql --result-format csv -q "SELECT statement FROM dolt_patch('old', 'new', 'table_name') WHERE diff_type = 'schema' ORDER BY statement_order"
     [ "$status" -eq 0 ]
     [[ "$output" == "statement
-ALTER TABLE \`table_name\` MODIFY COLUMN \`field_change_sign\` bigint unsigned DEFAULT NULL;" ]]
+ALTER TABLE \`table_name\` MODIFY COLUMN \`field_change_sign\` bigint unsigned DEFAULT NULL;" ]] || false
     [[ ! "$output" =~ "DROP INDEX" ]] || false
     [[ ! "$output" =~ "ADD INDEX" ]] || false
 
@@ -923,7 +923,7 @@ ALTER TABLE \`table_name\` MODIFY COLUMN \`field_change_sign\` bigint unsigned D
     run dolt sql --result-format csv -q "SELECT statement FROM dolt_patch('old', 'new') WHERE diff_type = 'schema' ORDER BY statement_order"
     [ "$status" -eq 0 ]
     [[ "$output" == "statement
-ALTER TABLE \`table_name\` MODIFY COLUMN \`field_change_sign\` bigint unsigned DEFAULT NULL;" ]]
+ALTER TABLE \`table_name\` MODIFY COLUMN \`field_change_sign\` bigint unsigned DEFAULT NULL;" ]] || false
     [[ ! "$output" =~ "DROP INDEX" ]] || false
     [[ ! "$output" =~ "ADD INDEX" ]] || false
 }

--- a/integration-tests/bats/sql-diff.bats
+++ b/integration-tests/bats/sql-diff.bats
@@ -927,3 +927,4 @@ ALTER TABLE \`table_name\` MODIFY COLUMN \`field_change_sign\` bigint unsigned D
     [[ ! "$output" =~ "DROP INDEX" ]] || false
     [[ ! "$output" =~ "ADD INDEX" ]] || false
 }
+


### PR DESCRIPTION
Fixes dolthub/dolt#9677
Enhanced dolt_patch() to prevent spurious index operations when column types change.
Modified pairColumns() in schema_diff.go to perform name-based matching with type compatibility for unpaired columns. Added conservative integer and decimal type compatibility handlers that only allow safe widenings. Fixed index equality checks and diffing logic to prevent false positives.