### PR TITLE
[no-release-notes] Remove duplicate GetEmptyPort functions and call shared util

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -1073,16 +1073,6 @@ func LoadClusterTLSConfig(cfg servercfg.ClusterConfig) (*tls.Config, error) {
 	}, nil
 }
 
-func portInUse(hostPort string) bool {
-	timeout := time.Second
-	conn, _ := net.DialTimeout("tcp", hostPort, timeout)
-	if conn != nil {
-		defer conn.Close()
-		return true
-	}
-	return false
-}
-
 func newSessionBuilder(se *engine.SqlEngine, config servercfg.ServerConfig) server.SessionBuilder {
 	userToSessionVars := make(map[string]map[string]interface{})
 	userVars := config.UserVars()
@@ -1164,7 +1154,7 @@ func handleProtocolAndAddress(serverConfig servercfg.ServerConfig) (server.Confi
 
 	portAsString := strconv.Itoa(serverConfig.Port())
 	hostPort := net.JoinHostPort(serverConfig.Host(), portAsString)
-	if portInUse(hostPort) {
+	if server.PortInUse(hostPort) {
 		portInUseError := fmt.Errorf("Port %s already in use.", portAsString)
 		return server.Config{}, portInUseError
 	}

--- a/go/cmd/dolt/commands/sqlserver/server_test.go
+++ b/go/cmd/dolt/commands/sqlserver/server_test.go
@@ -16,7 +16,7 @@ package sqlserver
 
 import (
 	"fmt"
-	"net"
+	"github.com/dolthub/go-mysql-server/sql"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -525,7 +525,7 @@ func TestPortSystemVariable(t *testing.T) {
 	}()
 
 	// Pick an ephemeral free port for this test
-	listenPort, err := findEmptyPort()
+	listenPort, err := sql.GetEmptyPort()
 	require.NoError(t, err)
 	serverConfig := DefaultCommandLineServerConfig().WithPort(listenPort)
 	sc := svcs.NewController()
@@ -563,16 +563,6 @@ func TestPortSystemVariable(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, globalPortVal, 1)
 	assert.Equal(t, listenPort, globalPortVal[0].Value)
-}
-
-// findEmptyPort finds an available TCP port by asking the OS for an ephemeral port
-func findEmptyPort() (int, error) {
-	l, err := net.Listen("tcp", ":0")
-	if err != nil {
-		return -1, err
-	}
-	defer l.Close()
-	return l.Addr().(*net.TCPAddr).Port, nil
 }
 
 func TestReadOnlyEnforcement(t *testing.T) {

--- a/go/go.mod
+++ b/go/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12
 	github.com/dolthub/eventsapi_schema v0.0.0-20250725194025-a087efa1ee55
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-mysql-server v0.20.1-0.20250814220230-9590ef7ae7e7
+	github.com/dolthub/go-mysql-server v0.20.1-0.20250814231409-bd7c32efb99a
 	github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63
 	github.com/edsrzf/mmap-go v1.2.0
 	github.com/esote/minmaxheap v1.0.0
@@ -196,7 +196,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 )
-
-replace github.com/dolthub/go-mysql-server => /Users/amx/dolt_workspace/go-mysql-server
 
 go 1.24.0

--- a/go/go.mod
+++ b/go/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/dolthub/fslock v0.0.3
 	github.com/dolthub/ishell v0.0.0-20240701202509-2b217167d718
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20250813175212-45844169a751
+	github.com/dolthub/vitess v0.0.0-20250814204310-c749d213f235
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.13.0
 	github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568
@@ -196,5 +196,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 )
+
+replace github.com/dolthub/go-mysql-server => /Users/amx/dolt_workspace/go-mysql-server
 
 go 1.24.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -217,6 +217,8 @@ github.com/dolthub/go-mysql-server v0.20.1-0.20250814184129-adb3dad26072 h1:YtJL
 github.com/dolthub/go-mysql-server v0.20.1-0.20250814184129-adb3dad26072/go.mod h1:nR895qqNcXnySptw6EPmGsUE0fxQA+WIsCtQeXYJe58=
 github.com/dolthub/go-mysql-server v0.20.1-0.20250814220230-9590ef7ae7e7 h1:f7mK3HLTF9EcFULoh5xDZDWnO152nFxcfWPyY2zVXZw=
 github.com/dolthub/go-mysql-server v0.20.1-0.20250814220230-9590ef7ae7e7/go.mod h1:nR895qqNcXnySptw6EPmGsUE0fxQA+WIsCtQeXYJe58=
+github.com/dolthub/go-mysql-server v0.20.1-0.20250814231409-bd7c32efb99a h1:JNLf1g4wSpO8iyGus37nuJxLDYlDsbcMQ8h1ktLJrv8=
+github.com/dolthub/go-mysql-server v0.20.1-0.20250814231409-bd7c32efb99a/go.mod h1:J+ixF8s/kL8x8W8sQh4UNmufcyFOeIi/FPo+MwAjUcU=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20240701202509-2b217167d718 h1:lT7hE5k+0nkBdj/1UOSFwjWpNxf+LCApbRHgnCA17XE=
@@ -227,6 +229,7 @@ github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9X
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
 github.com/dolthub/vitess v0.0.0-20250813175212-45844169a751 h1:BBQKyvyODewdQxS+ICklMn1d/fFj2pVlkmMN1QFY4ms=
 github.com/dolthub/vitess v0.0.0-20250813175212-45844169a751/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
+github.com/dolthub/vitess v0.0.0-20250814204310-c749d213f235 h1:uXrK+xn8rCwz/8jWDKaDyqZG1HbZI9F4V4HJ7zXFPMY=
 github.com/dolthub/vitess v0.0.0-20250814204310-c749d213f235/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=

--- a/go/go.sum
+++ b/go/go.sum
@@ -227,6 +227,7 @@ github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9X
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
 github.com/dolthub/vitess v0.0.0-20250813175212-45844169a751 h1:BBQKyvyODewdQxS+ICklMn1d/fFj2pVlkmMN1QFY4ms=
 github.com/dolthub/vitess v0.0.0-20250813175212-45844169a751/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
+github.com/dolthub/vitess v0.0.0-20250814204310-c749d213f235/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/edsrzf/mmap-go v1.2.0 h1:hXLYlkbaPzt1SaQk+anYwKSRNhufIDCchSPkUD6dD84=

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_test.go
@@ -18,8 +18,8 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"github.com/dolthub/go-mysql-server/sql"
 	"io"
-	"net"
 	"os"
 	"os/exec"
 	"os/user"
@@ -926,26 +926,6 @@ func sanitizeCreateTableString(statement string) string {
 	return regex.ReplaceAllString(statement, " ")
 }
 
-// findFreePort returns an available port that can be used for a server. If any errors are
-// encountered, this function will panic and fail the current test.
-func findFreePort() int {
-	listener, err := net.Listen("tcp", ":0")
-	if err != nil {
-		panic(fmt.Sprintf("unable to find available TCP port: %v", err.Error()))
-	}
-	freePort := listener.Addr().(*net.TCPAddr).Port
-	err = listener.Close()
-	if err != nil {
-		panic(fmt.Sprintf("unable to find available TCP port: %v", err.Error()))
-	}
-
-	if freePort < 0 {
-		panic(fmt.Sprintf("unable to find available TCP port; found port %v", freePort))
-	}
-
-	return freePort
-}
-
 // startMySqlServer configures a starts a fresh MySQL server instance and returns the port it is running on,
 // and the os.Process handle. If unable to start up the MySQL server, an error is returned.
 func (h *harness) startMySqlServer() (int, *os.Process, error) {
@@ -956,7 +936,10 @@ func (h *harness) startMySqlServer() (int, *os.Process, error) {
 		return -1, nil, err
 	}
 
-	h.mySqlPort = findFreePort()
+	h.mySqlPort, err = sql.GetEmptyPort()
+	if err != nil {
+		panic(fmt.Sprintf("unable to find available TCP port: %v", err.Error()))
+	}
 
 	// Log the mysqld version
 	versionCmd := exec.CommandContext(commandCtx, "mysqld", "--version")
@@ -1076,7 +1059,10 @@ func (h *harness) startDoltSqlServer(doltPersistentSystemVars map[string]string)
 	// If we already assigned a port, re-use it. This is useful when testing restarting a primary, since
 	// we want the primary to come back up on the same port, so the replica can reconnect.
 	if h.doltPort < 1 {
-		h.doltPort = findFreePort()
+		h.doltPort, err = sql.GetEmptyPort()
+		if err != nil {
+			panic(fmt.Sprintf("unable to find available TCP port: %v", err.Error()))
+		}
 	}
 	h.t.Logf("Starting Dolt sql-server on port: %d, with data dir %s\n", h.doltPort, dir)
 


### PR DESCRIPTION
relies on dolthub/go-mysql-server#3163