### PR TITLE
Ensure that errors are displayed in interactive mode

### DIFF
--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -857,8 +857,7 @@ func execShell(sqlCtx *sql.Context, qryist cli.Queryist, format engine.PrintResu
 							cli.Println("Database Changed")
 						}
 					}
-				}
-				if err != nil {
+				} else {
 					shell.Println(color.RedString(err.Error()))
 				}
 			}

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -841,7 +841,9 @@ func execShell(sqlCtx *sql.Context, qryist cli.Queryist, format engine.PrintResu
 				sqlStmt, err := sqlparser.Parse(query)
 				// silently skip empty statements
 				if err == nil || err == sqlparser.ErrEmpty {
-					sqlSch, rowIter, _, err := processParsedQuery(sqlCtx, query, qryist, sqlStmt)
+					var sqlSch sql.Schema
+					var rowIter sql.RowIter
+					sqlSch, rowIter, _, err = processParsedQuery(sqlCtx, query, qryist, sqlStmt)
 					if err != nil {
 						verr := formatQueryError("", err)
 						shell.Println(verr.Verbose())
@@ -851,6 +853,10 @@ func execShell(sqlCtx *sql.Context, qryist cli.Queryist, format engine.PrintResu
 							err = engine.PrettyPrintResultsExtended(sqlCtx, closureFormat, sqlSch, rowIter, pagerEnabled, toggleWarnings, true, binaryAsHex)
 						default:
 							err = engine.PrettyPrintResults(sqlCtx, closureFormat, sqlSch, rowIter, pagerEnabled, toggleWarnings, true, binaryAsHex)
+						}
+						if err != nil {
+							verr := formatQueryError("", err)
+							shell.Println(verr.Verbose())
 						}
 					} else {
 						if _, isUseStmt := sqlStmt.(*sqlparser.Use); isUseStmt {

--- a/integration-tests/bats/sql-shell-error.expect
+++ b/integration-tests/bats/sql-shell-error.expect
@@ -1,0 +1,17 @@
+#!/usr/bin/expect
+
+set timeout 5
+set env(NO_COLOR) 1
+
+source  "$env(BATS_CWD)/helper/common_expect_functions.tcl"
+
+spawn dolt sql
+
+expect_with_defaults                                                    {dolt-repo-[0-9]+/main\*> }   { send "SELECT DOES_NOT_EXIST();\r" }
+
+expect_with_defaults_2 "function: 'does_not_exist' not found\r" {dolt-repo-[0-9]+/main\*> } { send "SELECT JSON_PRETTY(\"INVALID\");\r" }
+
+expect_with_defaults_2 "Invalid JSON text in argument 1 to function json_pretty: \"INVALID\"\r" {dolt-repo-[0-9]+/main\*> }  { send "quit\r" }
+
+expect eof
+exit

--- a/integration-tests/bats/sql-shell.bats
+++ b/integration-tests/bats/sql-shell.bats
@@ -32,6 +32,17 @@ teardown() {
 }
 
 # bats test_tags=no_lambda
+@test "sql-shell: Query errors are printed in interactive shell" {
+    skiponwindows "Need to install expect and make this script work on windows."
+    if [ "$SQL_ENGINE" = "remote-engine" ]; then
+        skip "shell on server returns Empty Set instead of OkResult"
+    fi
+    run $BATS_TEST_DIRNAME/sql-shell-error.expect
+    echo "$output"
+    [ "$status" -eq 0 ]
+}
+
+# bats test_tags=no_lambda
 @test "sql-shell: database changed is printed in interactive shell" {
     skiponwindows "Need to install expect and make this script work on windows."
     if [ "$SQL_ENGINE" = "remote-engine" ]; then


### PR DESCRIPTION
Due to an accidental variable showing, error messages that occurred when iterating over query results wouldn't be displayed if the user runs `dolt sql` in interactive mode.

Prior behavior:
```
db/main*> SELECT JSON_PRETTY("not valid json");
db/main*>
```

Fixed behavior:

```
db/main*> SELECT JSON_PRETTY("not valid json");
Invalid JSON text in argument 1 to function json_pretty: "not valid json"
db/main*>
```