### PR TITLE
go: cmd/dolt: cli_context: Slightly rework CliContext and LateBinderyQueryist lifecycle.

### DIFF
--- a/go/cmd/dolt/commands/add.go
+++ b/go/cmd/dolt/commands/add.go
@@ -121,21 +121,21 @@ func (cmd AddCmd) Exec(ctx context.Context, commandStr string, args []string, _ 
 		return status
 	}
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		cli.PrintErrln(errhand.VerboseErrorFromError(err))
 		return 1
 	}
 
 	// Allow staging tables with merge conflicts.
-	_, _, _, err = queryist.Query(sqlCtx, "set @@dolt_force_transaction_commit=1;")
+	_, _, _, err = queryist.Queryist.Query(queryist.Context, "set @@dolt_force_transaction_commit=1;")
 	if err != nil {
 		cli.PrintErrln(errhand.VerboseErrorFromError(err))
 		return 1
 	}
 
 	if apr.Contains(cli.PatchFlag) {
-		return patchWorkflow(sqlCtx, queryist, apr.Args)
+		return patchWorkflow(queryist.Context, queryist.Queryist, apr.Args)
 	} else {
 		for _, tableName := range apr.Args {
 			if tableName != "." && !doltdb.IsValidTableName(tableName) {
@@ -143,13 +143,13 @@ func (cmd AddCmd) Exec(ctx context.Context, commandStr string, args []string, _ 
 			}
 		}
 
-		_, rowIter, _, err := queryist.Query(sqlCtx, generateAddSql(apr))
+		_, rowIter, _, err := queryist.Queryist.Query(queryist.Context, generateAddSql(apr))
 		if err != nil {
 			cli.PrintErrln(errhand.VerboseErrorFromError(err))
 			return 1
 		}
 
-		_, err = sql.RowIterToRows(sqlCtx, rowIter)
+		_, err = sql.RowIterToRows(queryist.Context, rowIter)
 		if err != nil {
 			cli.PrintErrln(errhand.VerboseErrorFromError(err))
 			return 1

--- a/go/cmd/dolt/commands/add.go
+++ b/go/cmd/dolt/commands/add.go
@@ -121,13 +121,10 @@ func (cmd AddCmd) Exec(ctx context.Context, commandStr string, args []string, _ 
 		return status
 	}
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		cli.PrintErrln(errhand.VerboseErrorFromError(err))
 		return 1
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	// Allow staging tables with merge conflicts.

--- a/go/cmd/dolt/commands/blame.go
+++ b/go/cmd/dolt/commands/blame.go
@@ -102,13 +102,10 @@ func (cmd BlameCmd) Exec(ctx context.Context, commandStr string, args []string, 
 		return 1
 	}
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		iohelp.WriteLine(cli.CliOut, err.Error())
 		return 1
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	var schema sql.Schema

--- a/go/cmd/dolt/commands/blame.go
+++ b/go/cmd/dolt/commands/blame.go
@@ -102,7 +102,7 @@ func (cmd BlameCmd) Exec(ctx context.Context, commandStr string, args []string, 
 		return 1
 	}
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		iohelp.WriteLine(cli.CliOut, err.Error())
 		return 1
@@ -111,7 +111,7 @@ func (cmd BlameCmd) Exec(ctx context.Context, commandStr string, args []string, 
 	var schema sql.Schema
 	var ri sql.RowIter
 	if apr.NArg() == 1 {
-		schema, ri, _, err = queryist.Query(sqlCtx, fmt.Sprintf(blameQueryTemplate, apr.Arg(0), "HEAD"))
+		schema, ri, _, err = queryist.Queryist.Query(queryist.Context, fmt.Sprintf(blameQueryTemplate, apr.Arg(0), "HEAD"))
 	} else {
 		// validate input
 		ref := apr.Arg(0)
@@ -120,14 +120,14 @@ func (cmd BlameCmd) Exec(ctx context.Context, commandStr string, args []string, 
 			return 1
 		}
 
-		schema, ri, _, err = queryist.Query(sqlCtx, fmt.Sprintf(blameQueryTemplate, apr.Arg(1), apr.Arg(0)))
+		schema, ri, _, err = queryist.Queryist.Query(queryist.Context, fmt.Sprintf(blameQueryTemplate, apr.Arg(1), apr.Arg(0)))
 	}
 	if err != nil {
 		iohelp.WriteLine(cli.CliOut, err.Error())
 		return 1
 	}
 
-	err = engine.PrettyPrintResults(sqlCtx, engine.FormatTabular, schema, ri, false, false, true, false)
+	err = engine.PrettyPrintResults(queryist.Context, engine.FormatTabular, schema, ri, false, false, true, false)
 	if err != nil {
 		iohelp.WriteLine(cli.CliOut, err.Error())
 		return 1

--- a/go/cmd/dolt/commands/branch.go
+++ b/go/cmd/dolt/commands/branch.go
@@ -111,7 +111,7 @@ func (cmd BranchCmd) Exec(ctx context.Context, commandStr string, args []string,
 	}
 
 	errorBuilder := errhand.BuildDError("error: failed to create query engine")
-	queryEngine, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errorBuilder.AddCause(err).Build(), nil)
 	}
@@ -123,25 +123,25 @@ func (cmd BranchCmd) Exec(ctx context.Context, commandStr string, args []string,
 
 	switch {
 	case apr.Contains(cli.MoveFlag):
-		return moveBranch(sqlCtx, queryEngine, apr, args, usage)
+		return moveBranch(queryist.Context, queryist.Queryist, apr, args, usage)
 	case apr.Contains(cli.CopyFlag):
-		return copyBranch(sqlCtx, queryEngine, apr, args, usage)
+		return copyBranch(queryist.Context, queryist.Queryist, apr, args, usage)
 	case apr.Contains(cli.DeleteFlag):
-		return deleteBranches(sqlCtx, queryEngine, apr, args, usage)
+		return deleteBranches(queryist.Context, queryist.Queryist, apr, args, usage)
 	case apr.Contains(cli.DeleteForceFlag):
-		return deleteBranches(sqlCtx, queryEngine, apr, args, usage)
+		return deleteBranches(queryist.Context, queryist.Queryist, apr, args, usage)
 	case apr.Contains(cli.ListFlag):
-		return printBranches(sqlCtx, queryEngine, apr, usage)
+		return printBranches(queryist.Context, queryist.Queryist, apr, usage)
 	case apr.Contains(showCurrentFlag):
-		return printCurrentBranch(sqlCtx, queryEngine)
+		return printCurrentBranch(queryist.Context, queryist.Queryist)
 	case apr.Contains(datasetsFlag):
-		return printAllDatasets(sqlCtx, dEnv)
+		return printAllDatasets(queryist.Context, dEnv)
 	case apr.ContainsAny(cli.SetUpstreamToFlag, cli.TrackFlag):
-		return updateUpstream(sqlCtx, queryEngine, apr, args)
+		return updateUpstream(queryist.Context, queryist.Queryist, apr, args)
 	case apr.NArg() > 0:
-		return createBranch(sqlCtx, queryEngine, apr, args, usage)
+		return createBranch(queryist.Context, queryist.Queryist, apr, args, usage)
 	default:
-		return printBranches(sqlCtx, queryEngine, apr, usage)
+		return printBranches(queryist.Context, queryist.Queryist, apr, usage)
 	}
 }
 

--- a/go/cmd/dolt/commands/branch.go
+++ b/go/cmd/dolt/commands/branch.go
@@ -111,13 +111,9 @@ func (cmd BranchCmd) Exec(ctx context.Context, commandStr string, args []string,
 	}
 
 	errorBuilder := errhand.BuildDError("error: failed to create query engine")
-	queryEngine, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryEngine, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errorBuilder.AddCause(err).Build(), nil)
-	}
-
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	if len(apr.ContainsMany(cli.MoveFlag, cli.CopyFlag, cli.DeleteFlag, cli.DeleteForceFlag, cli.ListFlag, showCurrentFlag)) > 1 {

--- a/go/cmd/dolt/commands/checkout.go
+++ b/go/cmd/dolt/commands/checkout.go
@@ -96,13 +96,11 @@ func (cmd CheckoutCmd) Exec(ctx context.Context, commandStr string, args []strin
 		return status
 	}
 
-	queryEngine, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryEngine, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
-	if closeFunc != nil {
-		defer closeFunc()
-
+	if false { // XXX: Find a way for Checkout to know if this is within another session...
 		// We only check for this case when checkout is the first command in a session. The reason for this is that checkout
 		// when connected to a remote server will not work as it won't set the branch. But when operating within the context
 		// of another session, specifically a \checkout in a dolt sql session, this makes sense. Since no closeFunc would be

--- a/go/cmd/dolt/commands/checkout.go
+++ b/go/cmd/dolt/commands/checkout.go
@@ -99,11 +99,10 @@ func (cmd CheckoutCmd) Exec(ctx context.Context, commandStr string, args []strin
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
-	if queryist.IsFirstUse && queryist.IsRemote {
+	if queryist.IsFirstResult && queryist.IsRemote {
 		// We only check for this case when checkout is the first command in a session. The reason for this is that checkout
 		// when connected to a remote server will not work as it won't set the branch. But when operating within the context
-		// of another session, specifically a \checkout in a dolt sql session, this makes sense. Since no closeFunc would be
-		// returned, we don't need to check for this case.
+		// of another session, specifically a \checkout in a dolt sql session, this makes sense.
 		msg := fmt.Sprintf(cli.RemoteUnsupportedMsg, commandStr)
 		cli.Println(msg)
 		return 1

--- a/go/cmd/dolt/commands/cherry-pick.go
+++ b/go/cmd/dolt/commands/cherry-pick.go
@@ -84,12 +84,9 @@ func (cmd CherryPickCmd) Exec(ctx context.Context, commandStr string, args []str
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, cherryPickDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	// dolt_cherry_pick performs this check as well. Check performed early here to short circuit the operation.

--- a/go/cmd/dolt/commands/ci/destroy.go
+++ b/go/cmd/dolt/commands/ci/destroy.go
@@ -74,12 +74,9 @@ func (cmd DestroyCmd) Exec(ctx context.Context, commandStr string, args []string
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, destroyDocs, ap))
 	cli.ParseArgsOrDie(ap, args, help)
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	name, email, err := env.GetNameAndEmail(cliCtx.Config())

--- a/go/cmd/dolt/commands/ci/destroy.go
+++ b/go/cmd/dolt/commands/ci/destroy.go
@@ -74,7 +74,7 @@ func (cmd DestroyCmd) Exec(ctx context.Context, commandStr string, args []string
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, destroyDocs, ap))
 	cli.ParseArgsOrDie(ap, args, help)
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
@@ -84,6 +84,6 @@ func (cmd DestroyCmd) Exec(ctx context.Context, commandStr string, args []string
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	err = dolt_ci.DestroyDoltCITables(queryist, sqlCtx, name, email)
+	err = dolt_ci.DestroyDoltCITables(queryist.Queryist, queryist.Context, name, email)
 	return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 }

--- a/go/cmd/dolt/commands/ci/export.go
+++ b/go/cmd/dolt/commands/ci/export.go
@@ -88,12 +88,9 @@ func (cmd ExportCmd) Exec(ctx context.Context, commandStr string, args []string,
 
 	workflowName := apr.Arg(0)
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	hasTables, err := dolt_ci.HasDoltCITables(queryist, sqlCtx)

--- a/go/cmd/dolt/commands/ci/export.go
+++ b/go/cmd/dolt/commands/ci/export.go
@@ -88,12 +88,12 @@ func (cmd ExportCmd) Exec(ctx context.Context, commandStr string, args []string,
 
 	workflowName := apr.Arg(0)
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	hasTables, err := dolt_ci.HasDoltCITables(queryist, sqlCtx)
+	hasTables, err := dolt_ci.HasDoltCITables(queryist.Queryist, queryist.Context)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
@@ -106,9 +106,9 @@ func (cmd ExportCmd) Exec(ctx context.Context, commandStr string, args []string,
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
-	wm := dolt_ci.NewWorkflowManager(user, email, queryist.Query)
+	wm := dolt_ci.NewWorkflowManager(user, email, queryist.Queryist.Query)
 
-	config, err := wm.GetWorkflowConfig(sqlCtx, workflowName)
+	config, err := wm.GetWorkflowConfig(queryist.Context, workflowName)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}

--- a/go/cmd/dolt/commands/ci/import.go
+++ b/go/cmd/dolt/commands/ci/import.go
@@ -113,12 +113,9 @@ func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string,
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	hasTables, err := dolt_ci.HasDoltCITables(queryist, sqlCtx)

--- a/go/cmd/dolt/commands/ci/import.go
+++ b/go/cmd/dolt/commands/ci/import.go
@@ -113,12 +113,12 @@ func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string,
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	hasTables, err := dolt_ci.HasDoltCITables(queryist, sqlCtx)
+	hasTables, err := dolt_ci.HasDoltCITables(queryist.Queryist, queryist.Context)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
@@ -140,9 +140,9 @@ func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string,
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
-	wm := dolt_ci.NewWorkflowManager(user, email, queryist.Query)
+	wm := dolt_ci.NewWorkflowManager(user, email, queryist.Queryist.Query)
 
-	err = wm.StoreAndCommit(sqlCtx, workflowConfig)
+	err = wm.StoreAndCommit(queryist.Context, workflowConfig)
 	if err != nil {
 		errorText := err.Error()
 		switch {

--- a/go/cmd/dolt/commands/ci/init.go
+++ b/go/cmd/dolt/commands/ci/init.go
@@ -72,12 +72,9 @@ func (cmd InitCmd) Exec(ctx context.Context, commandStr string, args []string, _
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, initDocs, ap))
 	cli.ParseArgsOrDie(ap, args, help)
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	hasTables, err := dolt_ci.HasDoltCITables(queryist, sqlCtx)

--- a/go/cmd/dolt/commands/ci/init.go
+++ b/go/cmd/dolt/commands/ci/init.go
@@ -72,12 +72,12 @@ func (cmd InitCmd) Exec(ctx context.Context, commandStr string, args []string, _
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, initDocs, ap))
 	cli.ParseArgsOrDie(ap, args, help)
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	hasTables, err := dolt_ci.HasDoltCITables(queryist, sqlCtx)
+	hasTables, err := dolt_ci.HasDoltCITables(queryist.Queryist, queryist.Context)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
@@ -90,6 +90,6 @@ func (cmd InitCmd) Exec(ctx context.Context, commandStr string, args []string, _
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	err = dolt_ci.CreateDoltCITables(queryist, sqlCtx, name, email)
+	err = dolt_ci.CreateDoltCITables(queryist.Queryist, queryist.Context, name, email)
 	return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 }

--- a/go/cmd/dolt/commands/ci/ls.go
+++ b/go/cmd/dolt/commands/ci/ls.go
@@ -76,12 +76,9 @@ func (cmd ListCmd) Exec(ctx context.Context, commandStr string, args []string, _
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, listDocs, ap))
 	cli.ParseArgsOrDie(ap, args, help)
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	hasTables, err := dolt_ci.HasDoltCITables(queryist, sqlCtx)

--- a/go/cmd/dolt/commands/ci/ls.go
+++ b/go/cmd/dolt/commands/ci/ls.go
@@ -76,12 +76,12 @@ func (cmd ListCmd) Exec(ctx context.Context, commandStr string, args []string, _
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, listDocs, ap))
 	cli.ParseArgsOrDie(ap, args, help)
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	hasTables, err := dolt_ci.HasDoltCITables(queryist, sqlCtx)
+	hasTables, err := dolt_ci.HasDoltCITables(queryist.Queryist, queryist.Context)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
@@ -93,9 +93,9 @@ func (cmd ListCmd) Exec(ctx context.Context, commandStr string, args []string, _
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
-	wm := dolt_ci.NewWorkflowManager(user, email, queryist.Query)
+	wm := dolt_ci.NewWorkflowManager(user, email, queryist.Queryist.Query)
 
-	workflows, err := wm.ListWorkflows(sqlCtx)
+	workflows, err := wm.ListWorkflows(queryist.Context)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}

--- a/go/cmd/dolt/commands/ci/remove.go
+++ b/go/cmd/dolt/commands/ci/remove.go
@@ -81,12 +81,9 @@ func (cmd RemoveCmd) Exec(ctx context.Context, commandStr string, args []string,
 
 	workflowName := apr.Arg(0)
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	hasTables, err := dolt_ci.HasDoltCITables(queryist, sqlCtx)

--- a/go/cmd/dolt/commands/ci/remove.go
+++ b/go/cmd/dolt/commands/ci/remove.go
@@ -81,12 +81,12 @@ func (cmd RemoveCmd) Exec(ctx context.Context, commandStr string, args []string,
 
 	workflowName := apr.Arg(0)
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	hasTables, err := dolt_ci.HasDoltCITables(queryist, sqlCtx)
+	hasTables, err := dolt_ci.HasDoltCITables(queryist.Queryist, queryist.Context)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
@@ -98,9 +98,9 @@ func (cmd RemoveCmd) Exec(ctx context.Context, commandStr string, args []string,
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
-	wm := dolt_ci.NewWorkflowManager(user, email, queryist.Query)
+	wm := dolt_ci.NewWorkflowManager(user, email, queryist.Queryist.Query)
 
-	err = wm.RemoveWorkflow(sqlCtx, workflowName)
+	err = wm.RemoveWorkflow(queryist.Context, workflowName)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}

--- a/go/cmd/dolt/commands/ci/run.go
+++ b/go/cmd/dolt/commands/ci/run.go
@@ -79,12 +79,9 @@ func (cmd RunCmd) Exec(ctx context.Context, commandStr string, args []string, _ 
 	}
 	workflowName := args[0]
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	hasTables, err := dolt_ci.HasDoltCITables(queryist, sqlCtx)

--- a/go/cmd/dolt/commands/ci/run.go
+++ b/go/cmd/dolt/commands/ci/run.go
@@ -79,12 +79,12 @@ func (cmd RunCmd) Exec(ctx context.Context, commandStr string, args []string, _ 
 	}
 	workflowName := args[0]
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	hasTables, err := dolt_ci.HasDoltCITables(queryist, sqlCtx)
+	hasTables, err := dolt_ci.HasDoltCITables(queryist.Queryist, queryist.Context)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
@@ -98,19 +98,19 @@ func (cmd RunCmd) Exec(ctx context.Context, commandStr string, args []string, _ 
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	wm := dolt_ci.NewWorkflowManager(name, email, queryist.Query)
+	wm := dolt_ci.NewWorkflowManager(name, email, queryist.Queryist.Query)
 
-	config, err := wm.GetWorkflowConfig(sqlCtx, workflowName)
+	config, err := wm.GetWorkflowConfig(queryist.Context, workflowName)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	savedQueries, err := getSavedQueries(sqlCtx, queryist)
+	savedQueries, err := getSavedQueries(queryist.Context, queryist.Queryist)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 	cli.Println(color.CyanString("Running workflow: %s", workflowName))
-	queryAndPrint(sqlCtx, queryist, config, savedQueries)
+	queryAndPrint(queryist.Context, queryist.Queryist, config, savedQueries)
 
 	return 0
 }

--- a/go/cmd/dolt/commands/ci/view.go
+++ b/go/cmd/dolt/commands/ci/view.go
@@ -82,12 +82,9 @@ func (cmd ViewCmd) Exec(ctx context.Context, commandStr string, args []string, _
 	}
 	workflowName := args[0]
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	hasTables, err := dolt_ci.HasDoltCITables(queryist, sqlCtx)

--- a/go/cmd/dolt/commands/ci/view.go
+++ b/go/cmd/dolt/commands/ci/view.go
@@ -82,12 +82,12 @@ func (cmd ViewCmd) Exec(ctx context.Context, commandStr string, args []string, _
 	}
 	workflowName := args[0]
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	hasTables, err := dolt_ci.HasDoltCITables(queryist, sqlCtx)
+	hasTables, err := dolt_ci.HasDoltCITables(queryist.Queryist, queryist.Context)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
@@ -100,14 +100,14 @@ func (cmd ViewCmd) Exec(ctx context.Context, commandStr string, args []string, _
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
-	wm := dolt_ci.NewWorkflowManager(name, email, queryist.Query)
+	wm := dolt_ci.NewWorkflowManager(name, email, queryist.Queryist.Query)
 
-	config, err := wm.GetWorkflowConfig(sqlCtx, workflowName)
+	config, err := wm.GetWorkflowConfig(queryist.Context, workflowName)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	savedQueries, err := getSavedQueries(sqlCtx, queryist)
+	savedQueries, err := getSavedQueries(queryist.Context, queryist.Queryist)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}

--- a/go/cmd/dolt/commands/clean.go
+++ b/go/cmd/dolt/commands/clean.go
@@ -76,13 +76,10 @@ func (cmd CleanCmd) Exec(ctx context.Context, commandStr string, args []string, 
 	help, _ := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, cleanDocContent, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		cli.Println(err.Error())
 		return 1
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	var params []interface{}

--- a/go/cmd/dolt/commands/clean.go
+++ b/go/cmd/dolt/commands/clean.go
@@ -76,7 +76,7 @@ func (cmd CleanCmd) Exec(ctx context.Context, commandStr string, args []string, 
 	help, _ := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, cleanDocContent, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		cli.Println(err.Error())
 		return 1
@@ -113,7 +113,7 @@ func (cmd CleanCmd) Exec(ctx context.Context, commandStr string, args []string, 
 		}
 	}
 
-	_, err = cli.GetRowsForSql(queryist, sqlCtx, query)
+	_, err = cli.GetRowsForSql(queryist.Queryist, queryist.Context, query)
 	if err != nil {
 		cli.Println(err.Error())
 		return 1

--- a/go/cmd/dolt/commands/cnfcmds/cat.go
+++ b/go/cmd/dolt/commands/cnfcmds/cat.go
@@ -101,12 +101,9 @@ func (cmd CatCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 		return 1
 	}
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	tblNames := args

--- a/go/cmd/dolt/commands/cnfcmds/cat.go
+++ b/go/cmd/dolt/commands/cnfcmds/cat.go
@@ -101,7 +101,7 @@ func (cmd CatCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 		return 1
 	}
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
@@ -113,7 +113,7 @@ func (cmd CatCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 		return 1
 	}
 
-	if err := printConflicts(queryist, sqlCtx, tblNames); err != nil {
+	if err := printConflicts(queryist.Queryist, queryist.Context, tblNames); err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 	return 0

--- a/go/cmd/dolt/commands/cnfcmds/resolve.go
+++ b/go/cmd/dolt/commands/cnfcmds/resolve.go
@@ -95,12 +95,9 @@ func (cmd ResolveCmd) Exec(ctx context.Context, commandStr string, args []string
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, resDocumentation, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	var verr errhand.VerboseError

--- a/go/cmd/dolt/commands/cnfcmds/resolve.go
+++ b/go/cmd/dolt/commands/cnfcmds/resolve.go
@@ -95,14 +95,14 @@ func (cmd ResolveCmd) Exec(ctx context.Context, commandStr string, args []string
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, resDocumentation, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
 	var verr errhand.VerboseError
 	if apr.ContainsAny(autoResolverParams...) {
-		verr = autoResolve(queryist, sqlCtx, apr)
+		verr = autoResolve(queryist.Queryist, queryist.Context, apr)
 	} else {
 		verr = errhand.BuildDError("--ours or --theirs must be supplied").SetPrintUsage().Build()
 	}

--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -112,13 +112,10 @@ func performCommit(ctx context.Context, commandStr string, args []string, cliCtx
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage), false
 	}
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		cli.Println(err.Error())
 		return 1, false
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	// TODO: This is not a nice solution. Currently, the cliCtx parameter's sqlCtx that we get from QueryEngine() is never refreshed.

--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -112,7 +112,7 @@ func performCommit(ctx context.Context, commandStr string, args []string, cliCtx
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage), false
 	}
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		cli.Println(err.Error())
 		return 1, false
@@ -121,11 +121,11 @@ func performCommit(ctx context.Context, commandStr string, args []string, cliCtx
 	// TODO: This is not a nice solution. Currently, the cliCtx parameter's sqlCtx that we get from QueryEngine() is never refreshed.
 	// TODO: It would be ideal to have it generate/regenerate it's sqlCtx more often, as it likely has impacts beyond just the time.
 	if c, ok := ctx.(*sql.Context); ok {
-		sqlCtx.SetQueryTime(c.QueryTime())
+		queryist.Context.SetQueryTime(c.QueryTime())
 	}
 
 	// dolt_commit performs this check as well. This nips the problem in the bud early, but is not required.
-	err = branch_control.CheckAccess(sqlCtx, branch_control.Permissions_Write)
+	err = branch_control.CheckAccess(queryist.Context, branch_control.Permissions_Write)
 	if err != nil {
 		cli.Println(err.Error())
 		return 1, false
@@ -135,28 +135,28 @@ func performCommit(ctx context.Context, commandStr string, args []string, cliCtx
 	if !msgOk {
 		amendStr := ""
 		if apr.Contains(cli.AmendFlag) {
-			_, rowIter, _, err := queryist.Query(sqlCtx, "select message from dolt_log() limit 1")
+			_, rowIter, _, err := queryist.Queryist.Query(queryist.Context, "select message from dolt_log() limit 1")
 			if err != nil {
 				cli.Println(err.Error())
 				return 1, false
 			}
-			row, err := rowIter.Next(sqlCtx)
+			row, err := rowIter.Next(queryist.Context)
 			if err != nil {
 				cli.Println(err.Error())
 				return 1, false
 			}
 			amendStr = row[0].(string)
 		}
-		msg, err = getCommitMessageFromEditor(sqlCtx, queryist, "", amendStr, false, cliCtx)
+		msg, err = getCommitMessageFromEditor(queryist.Context, queryist.Queryist, "", amendStr, false, cliCtx)
 		if err != nil {
-			return handleCommitErr(sqlCtx, queryist, err, usage), false
+			return handleCommitErr(queryist.Context, queryist.Queryist, err, usage), false
 		}
 	}
 
 	// process query through prepared statement to prevent sql injection
 	query, params, err := constructParametrizedDoltCommitQuery(msg, apr, cliCtx)
 	if err != nil {
-		return handleCommitErr(sqlCtx, queryist, err, usage), false
+		return handleCommitErr(queryist.Context, queryist.Queryist, err, usage), false
 	}
 	interpolatedQuery, err := dbr.InterpolateForDialect(query, params, dialect.MySQL)
 	if err != nil {
@@ -164,11 +164,11 @@ func performCommit(ctx context.Context, commandStr string, args []string, cliCtx
 		return 1, false
 	}
 
-	_, rowIter, _, err := queryist.Query(sqlCtx, interpolatedQuery)
+	_, rowIter, _, err := queryist.Queryist.Query(queryist.Context, interpolatedQuery)
 	if err != nil {
-		return handleCommitErr(sqlCtx, queryist, err, usage), false
+		return handleCommitErr(queryist.Context, queryist.Queryist, err, usage), false
 	}
-	resultRow, err := sql.RowIterToRows(sqlCtx, rowIter)
+	resultRow, err := sql.RowIterToRows(queryist.Context, rowIter)
 	if err != nil {
 		cli.Println(err.Error())
 		return 1, false
@@ -177,7 +177,7 @@ func performCommit(ctx context.Context, commandStr string, args []string, cliCtx
 		return 0, true
 	}
 
-	commit, err := getCommitInfo(queryist, sqlCtx, "HEAD")
+	commit, err := getCommitInfo(queryist.Queryist, queryist.Context, "HEAD")
 	if cli.ExecuteWithStdioRestored != nil {
 		cli.ExecuteWithStdioRestored(func() {
 			pager := outputpager.Start()

--- a/go/cmd/dolt/commands/debug.go
+++ b/go/cmd/dolt/commands/debug.go
@@ -136,12 +136,9 @@ func (cmd DebugCmd) Exec(ctx context.Context, commandStr string, args []string, 
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	sqlEng, ok := queryist.(*engine.SqlEngine)

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -200,12 +200,9 @@ func (cmd DiffCmd) Exec(ctx context.Context, commandStr string, args []string, _
 		return HandleVErrAndExitCode(verr, usage)
 	}
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	updateSystemVar, err := cli.SetSystemVar(queryist, sqlCtx, apr.Contains(cli.SystemFlag))

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -200,22 +200,22 @@ func (cmd DiffCmd) Exec(ctx context.Context, commandStr string, args []string, _
 		return HandleVErrAndExitCode(verr, usage)
 	}
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	updateSystemVar, err := cli.SetSystemVar(queryist, sqlCtx, apr.Contains(cli.SystemFlag))
+	updateSystemVar, err := cli.SetSystemVar(queryist.Queryist, queryist.Context, apr.Contains(cli.SystemFlag))
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	dArgs, err := parseDiffArgs(queryist, sqlCtx, apr)
+	dArgs, err := parseDiffArgs(queryist.Queryist, queryist.Context, apr)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	verr = diffUserTables(queryist, sqlCtx, dArgs)
+	verr = diffUserTables(queryist.Queryist, queryist.Context, dArgs)
 	if verr != nil {
 		return HandleVErrAndExitCode(verr, usage)
 	}

--- a/go/cmd/dolt/commands/fetch.go
+++ b/go/cmd/dolt/commands/fetch.go
@@ -80,7 +80,7 @@ func (cmd FetchCmd) Exec(ctx context.Context, commandStr string, args []string, 
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, fetchDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		cli.PrintErrln(err)
 		return 1
@@ -94,7 +94,7 @@ func (cmd FetchCmd) Exec(ctx context.Context, commandStr string, args []string, 
 	errChan := make(chan error)
 	go func() {
 		defer close(errChan)
-		_, _, _, err = queryist.Query(sqlCtx, query)
+		_, _, _, err = queryist.Queryist.Query(queryist.Context, query)
 		if err != nil {
 			errChan <- err
 			return

--- a/go/cmd/dolt/commands/fetch.go
+++ b/go/cmd/dolt/commands/fetch.go
@@ -80,13 +80,10 @@ func (cmd FetchCmd) Exec(ctx context.Context, commandStr string, args []string, 
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, fetchDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		cli.PrintErrln(err)
 		return 1
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	query, err := constructInterpolatedDoltFetchQuery(apr)

--- a/go/cmd/dolt/commands/gc.go
+++ b/go/cmd/dolt/commands/gc.go
@@ -98,12 +98,9 @@ func (cmd GarbageCollectionCmd) Exec(ctx context.Context, commandStr string, arg
 		return HandleVErrAndExitCode(errhand.BuildDError("Invalid Argument: --shallow is not compatible with --full").SetPrintUsage().Build(), usage)
 	}
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	query, err := cmd.constructDoltGCQuery(apr)

--- a/go/cmd/dolt/commands/gc.go
+++ b/go/cmd/dolt/commands/gc.go
@@ -98,7 +98,7 @@ func (cmd GarbageCollectionCmd) Exec(ctx context.Context, commandStr string, arg
 		return HandleVErrAndExitCode(errhand.BuildDError("Invalid Argument: --shallow is not compatible with --full").SetPrintUsage().Build(), usage)
 	}
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
@@ -108,7 +108,7 @@ func (cmd GarbageCollectionCmd) Exec(ctx context.Context, commandStr string, arg
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	_, _, _, err = queryist.Query(sqlCtx, query)
+	_, _, _, err = queryist.Queryist.Query(queryist.Context, query)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}

--- a/go/cmd/dolt/commands/init_test.go
+++ b/go/cmd/dolt/commands/init_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
@@ -72,7 +71,7 @@ func TestInit(t *testing.T) {
 			gCfg, _ := dEnv.Config.GetConfig(env.GlobalConfig)
 			gCfg.SetStrings(test.GlobalConfig)
 			apr := argparser.ArgParseResults{}
-			latebind := func(ctx context.Context) (cli.Queryist, *sql.Context, func(), error) { return nil, nil, func() {}, nil }
+			latebind := func(ctx context.Context) (res cli.LateBindQueryistResult, err error) { return res, nil }
 			cliCtx, _ := cli.NewCliContext(&apr, dEnv.Config, dEnv.FS, latebind)
 
 			result := InitCmd{}.Exec(ctx, "dolt init", test.Args, dEnv, cliCtx)

--- a/go/cmd/dolt/commands/log.go
+++ b/go/cmd/dolt/commands/log.go
@@ -105,21 +105,21 @@ func (cmd LogCmd) logWithLoggerFunc(ctx context.Context, commandStr string, args
 		return status
 	}
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return handleErrAndExit(err)
 	}
 
-	query, err := constructInterpolatedDoltLogQuery(apr, queryist, sqlCtx)
+	query, err := constructInterpolatedDoltLogQuery(apr, queryist.Queryist, queryist.Context)
 	if err != nil {
 		return handleErrAndExit(err)
 	}
-	logRows, err := cli.GetRowsForSql(queryist, sqlCtx, query)
+	logRows, err := cli.GetRowsForSql(queryist.Queryist, queryist.Context, query)
 	if err != nil {
 		return handleErrAndExit(err)
 	}
 
-	return handleErrAndExit(logCommits(apr, logRows, queryist, sqlCtx))
+	return handleErrAndExit(logCommits(apr, logRows, queryist.Queryist, queryist.Context))
 }
 
 func collectRevisions(apr *argparser.ArgParseResults, queryist cli.Queryist, sqlCtx *sql.Context) ([]string, int, error) {

--- a/go/cmd/dolt/commands/log.go
+++ b/go/cmd/dolt/commands/log.go
@@ -105,12 +105,9 @@ func (cmd LogCmd) logWithLoggerFunc(ctx context.Context, commandStr string, args
 		return status
 	}
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return handleErrAndExit(err)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	query, err := constructInterpolatedDoltLogQuery(apr, queryist, sqlCtx)

--- a/go/cmd/dolt/commands/ls.go
+++ b/go/cmd/dolt/commands/ls.go
@@ -85,7 +85,7 @@ func (cmd LsCmd) Exec(ctx context.Context, commandStr string, args []string, dEn
 		return HandleVErrAndExitCode(verr, usage)
 	}
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
@@ -95,15 +95,15 @@ func (cmd LsCmd) Exec(ctx context.Context, commandStr string, args []string, dEn
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	_, _, _, err = queryist.Query(sqlCtx, "set @@dolt_show_system_tables = 1")
+	_, _, _, err = queryist.Queryist.Query(queryist.Context, "set @@dolt_show_system_tables = 1")
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
-	rows, err := cli.GetRowsForSql(queryist, sqlCtx, query)
+	rows, err := cli.GetRowsForSql(queryist.Queryist, queryist.Context, query)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
-	_, _, _, err = queryist.Query(sqlCtx, "set @@dolt_show_system_tables = 0")
+	_, _, _, err = queryist.Queryist.Query(queryist.Context, "set @@dolt_show_system_tables = 0")
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
@@ -120,7 +120,7 @@ func (cmd LsCmd) Exec(ctx context.Context, commandStr string, args []string, dEn
 	}
 
 	if apr.Contains(cli.AllFlag) {
-		err = printUserTables(userTables, apr, queryist, sqlCtx)
+		err = printUserTables(userTables, apr, queryist.Queryist, queryist.Context)
 		if err != nil {
 			return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 		}
@@ -134,7 +134,7 @@ func (cmd LsCmd) Exec(ctx context.Context, commandStr string, args []string, dEn
 			return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 		}
 	} else {
-		err = printUserTables(userTables, apr, queryist, sqlCtx)
+		err = printUserTables(userTables, apr, queryist.Queryist, queryist.Context)
 		if err != nil {
 			return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 		}

--- a/go/cmd/dolt/commands/ls.go
+++ b/go/cmd/dolt/commands/ls.go
@@ -85,12 +85,9 @@ func (cmd LsCmd) Exec(ctx context.Context, commandStr string, args []string, dEn
 		return HandleVErrAndExitCode(verr, usage)
 	}
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	query, err := constructInterpolatedDoltLsQuery(apr)

--- a/go/cmd/dolt/commands/merge.go
+++ b/go/cmd/dolt/commands/merge.go
@@ -99,19 +99,15 @@ func (cmd MergeCmd) Exec(ctx context.Context, commandStr string, args []string, 
 		return status
 	}
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		cli.Println(err.Error())
 		return 1
 	}
-	if closeFunc != nil {
-		defer closeFunc()
-
-		if _, ok := queryist.(*engine.SqlEngine); !ok {
-			msg := fmt.Sprintf(cli.RemoteUnsupportedMsg, commandStr)
-			cli.Println(msg)
-			return 1
-		}
+	if _, ok := queryist.(*engine.SqlEngine); !ok {
+		msg := fmt.Sprintf(cli.RemoteUnsupportedMsg, commandStr)
+		cli.Println(msg)
+		return 1
 	}
 
 	ok := validateDoltMergeArgs(apr, usage, cliCtx)

--- a/go/cmd/dolt/commands/merge_base.go
+++ b/go/cmd/dolt/commands/merge_base.go
@@ -74,12 +74,9 @@ func (cmd MergeBaseCmd) Exec(ctx context.Context, commandStr string, args []stri
 		return HandleVErrAndExitCode(verr, usage)
 	}
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	interpolatedQuery, err := dbr.InterpolateForDialect("SELECT DOLT_MERGE_BASE(?, ?)", []interface{}{apr.Arg(0), apr.Arg(1)}, dialect.MySQL)

--- a/go/cmd/dolt/commands/merge_base.go
+++ b/go/cmd/dolt/commands/merge_base.go
@@ -74,7 +74,7 @@ func (cmd MergeBaseCmd) Exec(ctx context.Context, commandStr string, args []stri
 		return HandleVErrAndExitCode(verr, usage)
 	}
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
@@ -84,7 +84,7 @@ func (cmd MergeBaseCmd) Exec(ctx context.Context, commandStr string, args []stri
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	row, err := cli.GetRowsForSql(queryist, sqlCtx, interpolatedQuery)
+	row, err := cli.GetRowsForSql(queryist.Queryist, queryist.Context, interpolatedQuery)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}

--- a/go/cmd/dolt/commands/pull.go
+++ b/go/cmd/dolt/commands/pull.go
@@ -100,13 +100,10 @@ func (cmd PullCmd) Exec(ctx context.Context, commandStr string, args []string, d
 		return HandleVErrAndExitCode(bdr.Build(), usage)
 	}
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		cli.Println(err.Error())
 		return 1
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	query, err := constructInterpolatedDoltPullQuery(apr)

--- a/go/cmd/dolt/commands/push.go
+++ b/go/cmd/dolt/commands/push.go
@@ -89,7 +89,7 @@ func (cmd PushCmd) Exec(ctx context.Context, commandStr string, args []string, d
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, pushDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
@@ -102,13 +102,13 @@ func (cmd PushCmd) Exec(ctx context.Context, commandStr string, args []string, d
 	errChan := make(chan error)
 	go func() {
 		defer close(errChan)
-		_, rowIter, _, err := queryist.Query(sqlCtx, query)
+		_, rowIter, _, err := queryist.Queryist.Query(queryist.Context, query)
 		if err != nil {
 			errChan <- err
 			return
 		}
 
-		sqlRows, err := sql.RowIterToRows(sqlCtx, rowIter)
+		sqlRows, err := sql.RowIterToRows(queryist.Context, rowIter)
 		if err != nil {
 			errChan <- err
 			return

--- a/go/cmd/dolt/commands/push.go
+++ b/go/cmd/dolt/commands/push.go
@@ -89,12 +89,9 @@ func (cmd PushCmd) Exec(ctx context.Context, commandStr string, args []string, d
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, pushDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	query, err := constructInterpolatedDoltPushQuery(apr)

--- a/go/cmd/dolt/commands/query_diff.go
+++ b/go/cmd/dolt/commands/query_diff.go
@@ -80,7 +80,7 @@ func (q QueryDiff) Exec(ctx context.Context, commandStr string, args []string, d
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
@@ -91,7 +91,7 @@ func (q QueryDiff) Exec(ctx context.Context, commandStr string, args []string, d
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
-	schema, rowIter, _, err := queryist.Query(sqlCtx, query)
+	schema, rowIter, _, err := queryist.Queryist.Query(queryist.Context, query)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
@@ -101,14 +101,14 @@ func (q QueryDiff) Exec(ctx context.Context, commandStr string, args []string, d
 	defer wr.Close(ctx)
 
 	for {
-		row, rerr := rowIter.Next(sqlCtx)
+		row, rerr := rowIter.Next(queryist.Context)
 		if rerr == io.EOF {
 			break
 		}
 		if rerr != nil {
 			return HandleVErrAndExitCode(errhand.VerboseErrorFromError(rerr), usage)
 		}
-		if werr := wr.WriteSqlRow(sqlCtx, row); werr != nil {
+		if werr := wr.WriteSqlRow(queryist.Context, row); werr != nil {
 			return HandleVErrAndExitCode(errhand.VerboseErrorFromError(werr), usage)
 		}
 	}

--- a/go/cmd/dolt/commands/query_diff.go
+++ b/go/cmd/dolt/commands/query_diff.go
@@ -80,12 +80,9 @@ func (q QueryDiff) Exec(ctx context.Context, commandStr string, args []string, d
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	// TODO: prevent create, insert, update, delete, etc. queries

--- a/go/cmd/dolt/commands/rebase.go
+++ b/go/cmd/dolt/commands/rebase.go
@@ -88,12 +88,9 @@ func (cmd RebaseCmd) Exec(ctx context.Context, commandStr string, args []string,
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, rebaseDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	// Set @@dolt_allow_commit_conflicts in case there are data conflicts that need to be resolved by the caller.

--- a/go/cmd/dolt/commands/reflog.go
+++ b/go/cmd/dolt/commands/reflog.go
@@ -82,12 +82,9 @@ func (cmd ReflogCmd) Exec(ctx context.Context, commandStr string, args []string,
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, reflogDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	query, err := constructInterpolatedDoltReflogQuery(apr)

--- a/go/cmd/dolt/commands/reflog.go
+++ b/go/cmd/dolt/commands/reflog.go
@@ -82,7 +82,7 @@ func (cmd ReflogCmd) Exec(ctx context.Context, commandStr string, args []string,
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, reflogDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
@@ -92,12 +92,12 @@ func (cmd ReflogCmd) Exec(ctx context.Context, commandStr string, args []string,
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	rows, err := cli.GetRowsForSql(queryist, sqlCtx, query)
+	rows, err := cli.GetRowsForSql(queryist.Queryist, queryist.Context, query)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	return printReflog(rows, queryist, sqlCtx)
+	return printReflog(rows, queryist.Queryist, queryist.Context)
 }
 
 // constructInterpolatedDoltReflogQuery generates the sql query necessary to call the DOLT_REFLOG() function.

--- a/go/cmd/dolt/commands/remote.go
+++ b/go/cmd/dolt/commands/remote.go
@@ -115,7 +115,7 @@ func (cmd RemoteCmd) Exec(ctx context.Context, commandStr string, args []string,
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, remoteDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
@@ -123,11 +123,11 @@ func (cmd RemoteCmd) Exec(ctx context.Context, commandStr string, args []string,
 	var verr errhand.VerboseError
 	switch {
 	case apr.NArg() == 0:
-		verr = printRemotes(sqlCtx, queryist, apr)
+		verr = printRemotes(queryist.Context, queryist.Queryist, apr)
 	case apr.Arg(0) == addRemoteId:
-		verr = addRemote(sqlCtx, queryist, dEnv, apr)
+		verr = addRemote(queryist.Context, queryist.Queryist, dEnv, apr)
 	case apr.Arg(0) == removeRemoteId, apr.Arg(0) == removeRemoteShortId:
-		verr = removeRemote(sqlCtx, queryist, apr)
+		verr = removeRemote(queryist.Context, queryist.Queryist, apr)
 	default:
 		verr = errhand.BuildDError("").SetPrintUsage().Build()
 	}

--- a/go/cmd/dolt/commands/remote.go
+++ b/go/cmd/dolt/commands/remote.go
@@ -115,12 +115,9 @@ func (cmd RemoteCmd) Exec(ctx context.Context, commandStr string, args []string,
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, remoteDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	var verr errhand.VerboseError

--- a/go/cmd/dolt/commands/reset.go
+++ b/go/cmd/dolt/commands/reset.go
@@ -96,7 +96,7 @@ func (cmd ResetCmd) Exec(ctx context.Context, commandStr string, args []string, 
 		return status
 	}
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		cli.Println(err.Error())
 		return 1
@@ -113,12 +113,12 @@ func (cmd ResetCmd) Exec(ctx context.Context, commandStr string, args []string, 
 
 	// process query through prepared statement to prevent sql injection
 	query, err := constructInterpolatedDoltResetQuery(apr)
-	_, _, _, err = queryist.Query(sqlCtx, query)
+	_, _, _, err = queryist.Queryist.Query(queryist.Context, query)
 	if err != nil {
 		return handleResetError(err, usage)
 	}
 
-	printNotStaged(sqlCtx, queryist)
+	printNotStaged(queryist.Context, queryist.Queryist)
 
 	return 0
 }

--- a/go/cmd/dolt/commands/reset.go
+++ b/go/cmd/dolt/commands/reset.go
@@ -96,13 +96,10 @@ func (cmd ResetCmd) Exec(ctx context.Context, commandStr string, args []string, 
 		return status
 	}
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		cli.Println(err.Error())
 		return 1
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	if apr.ContainsAll(HardResetParam, SoftResetParam) {

--- a/go/cmd/dolt/commands/revert.go
+++ b/go/cmd/dolt/commands/revert.go
@@ -86,13 +86,10 @@ func (cmd RevertCmd) Exec(ctx context.Context, commandStr string, args []string,
 		return 1
 	}
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		cli.Println(err.Error())
 		return 1
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	var author string

--- a/go/cmd/dolt/commands/revert.go
+++ b/go/cmd/dolt/commands/revert.go
@@ -86,7 +86,7 @@ func (cmd RevertCmd) Exec(ctx context.Context, commandStr string, args []string,
 		return 1
 	}
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		cli.Println(err.Error())
 		return 1
@@ -121,18 +121,18 @@ func (cmd RevertCmd) Exec(ctx context.Context, commandStr string, args []string,
 		return 1
 	}
 
-	_, rowIter, _, err := queryist.Query(sqlCtx, query)
+	_, rowIter, _, err := queryist.Queryist.Query(queryist.Context, query)
 	if err != nil {
 		cli.Printf("Failure to execute '%s': %s\n", query, err.Error())
 		return 1
 	}
-	_, err = sql.RowIterToRows(sqlCtx, rowIter)
+	_, err = sql.RowIterToRows(queryist.Context, rowIter)
 	if err != nil {
 		cli.Println(err.Error())
 		return 1
 	}
 
-	commit, err := getCommitInfo(queryist, sqlCtx, "HEAD")
+	commit, err := getCommitInfo(queryist.Queryist, queryist.Context, "HEAD")
 	if err != nil {
 		cli.Printf("Revert completed, but failure to get commit details occurred: %s\n", err.Error())
 		return 1

--- a/go/cmd/dolt/commands/rm.go
+++ b/go/cmd/dolt/commands/rm.go
@@ -74,7 +74,7 @@ func (cmd RmCmd) Exec(ctx context.Context, commandStr string, args []string, _ *
 	}
 
 	errorBuilder := errhand.BuildDError("error: failed to create query engine")
-	queryEngine, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errorBuilder.AddCause(err).Build(), nil)
 	}
@@ -84,12 +84,12 @@ func (cmd RmCmd) Exec(ctx context.Context, commandStr string, args []string, _ *
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), nil)
 	}
 
-	_, rowIter, _, err := queryEngine.Query(sqlCtx, interpolatedQuery)
+	_, rowIter, _, err := queryist.Queryist.Query(queryist.Context, interpolatedQuery)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), nil)
 	}
 
-	_, err = sql.RowIterToRows(sqlCtx, rowIter)
+	_, err = sql.RowIterToRows(queryist.Context, rowIter)
 	if err != nil {
 		cli.PrintErrln(errhand.VerboseErrorFromError(err))
 		return 1

--- a/go/cmd/dolt/commands/rm.go
+++ b/go/cmd/dolt/commands/rm.go
@@ -74,12 +74,9 @@ func (cmd RmCmd) Exec(ctx context.Context, commandStr string, args []string, _ *
 	}
 
 	errorBuilder := errhand.BuildDError("error: failed to create query engine")
-	queryEngine, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryEngine, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errorBuilder.AddCause(err).Build(), nil)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	interpolatedQuery, err := generateRmSql(args)

--- a/go/cmd/dolt/commands/show.go
+++ b/go/cmd/dolt/commands/show.go
@@ -119,12 +119,9 @@ func (cmd ShowCmd) Exec(ctx context.Context, commandStr string, args []string, d
 
 	opts.diffDisplaySettings = parseDiffDisplaySettings(apr)
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	resolvedRefs := make([]string, 0, len(opts.specRefs))

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -227,12 +227,9 @@ func (cmd SqlCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 		return HandleVErrAndExitCode(errhand.BuildDError("cannot use both --%s and --%s", binaryAsHexFlag, skipBinaryAsHexFlag).Build(), usage)
 	}
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	if query, queryOK := apr.GetValue(QueryFlag); queryOK {

--- a/go/cmd/dolt/commands/sql_slash.go
+++ b/go/cmd/dolt/commands/sql_slash.go
@@ -120,13 +120,13 @@ func (s SlashHelp) Exec(ctx context.Context, _ string, args []string, _ *env.Dol
 		return 0
 	}
 
-	qryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		cli.Println(fmt.Sprintf("error getting query engine: %s", err))
 		return 1
 	}
 
-	prompt := generateHelpPrompt(sqlCtx, qryist)
+	prompt := generateHelpPrompt(queryist.Context, queryist.Queryist)
 
 	cli.Println("Dolt SQL Shell Help")
 	cli.Printf("Default behavior is to interpret SQL statements.     (e.g. '%sselect * from my_table;')\n", prompt)

--- a/go/cmd/dolt/commands/sql_slash.go
+++ b/go/cmd/dolt/commands/sql_slash.go
@@ -120,10 +120,7 @@ func (s SlashHelp) Exec(ctx context.Context, _ string, args []string, _ *env.Dol
 		return 0
 	}
 
-	qryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
-	if closeFunc != nil {
-		defer closeFunc()
-	}
+	qryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		cli.Println(fmt.Sprintf("error getting query engine: %s", err))
 		return 1

--- a/go/cmd/dolt/commands/sqlserver/queryist_utils.go
+++ b/go/cmd/dolt/commands/sqlserver/queryist_utils.go
@@ -74,7 +74,7 @@ func BuildConnectionStringQueryist(ctx context.Context, cwdFS filesys.Filesys, c
 		res.Queryist = queryist
 		res.Context = sqlCtx
 		res.Closer = func() {
-			conn.Conn(ctx)
+			conn.Close()
 		}
 		res.IsRemote = true
 		return res, nil

--- a/go/cmd/dolt/commands/sqlserver/queryist_utils.go
+++ b/go/cmd/dolt/commands/sqlserver/queryist_utils.go
@@ -68,12 +68,16 @@ func BuildConnectionStringQueryist(ctx context.Context, cwdFS filesys.Filesys, c
 	gatherWarnings := false
 	queryist := ConnectionQueryist{connection: conn, gatherWarnings: &gatherWarnings}
 
-	var lateBind cli.LateBindQueryist = func(ctx context.Context) (cli.Queryist, *sql.Context, func(), error) {
+	var lateBind cli.LateBindQueryist = func(ctx context.Context) (res cli.LateBindQueryistResult, err error) {
 		sqlCtx := sql.NewContext(ctx)
 		sqlCtx.SetCurrentDatabase(dbRev)
-		return queryist, sqlCtx, func() {
+		res.Queryist = queryist
+		res.Context = sqlCtx
+		res.Closer = func() {
 			conn.Conn(ctx)
-		}, nil
+		}
+		res.IsRemote = true
+		return res, nil
 	}
 
 	return lateBind, nil

--- a/go/cmd/dolt/commands/stash.go
+++ b/go/cmd/dolt/commands/stash.go
@@ -101,7 +101,7 @@ func (cmd StashCmd) Exec(ctx context.Context, commandStr string, args []string, 
 		subcommand = strings.ToLower(apr.Arg(0))
 	}
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		cli.PrintErrln(errhand.VerboseErrorFromError(err))
 		return 1
@@ -118,13 +118,13 @@ func (cmd StashCmd) Exec(ctx context.Context, commandStr string, args []string, 
 
 	switch subcommand {
 	case PushCmdRef:
-		err = stashPush(queryist, sqlCtx, apr, subcommand)
+		err = stashPush(queryist.Queryist, queryist.Context, apr, subcommand)
 	case PopCmdRef, DropCmdRef:
-		err = stashRemove(queryist, sqlCtx, cliCtx, apr, subcommand, idx)
+		err = stashRemove(queryist.Queryist, queryist.Context, cliCtx, apr, subcommand, idx)
 	case ListCmdRef:
 		err = stashList(ctx, cliCtx)
 	case ClearCmdRef:
-		err = stashClear(queryist, sqlCtx, apr, subcommand)
+		err = stashClear(queryist.Queryist, queryist.Context, apr, subcommand)
 	default:
 		err = fmt.Errorf("unknown stash subcommand %s", subcommand)
 	}
@@ -190,12 +190,12 @@ func stashRemove(queryist cli.Queryist, sqlCtx *sql.Context, cliCtx cli.CliConte
 }
 
 func stashList(ctx context.Context, cliCtx cli.CliContext) error {
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return err
 	}
 
-	stashes, err := getStashesSQL(sqlCtx, queryist, 0)
+	stashes, err := getStashesSQL(queryist.Context, queryist.Queryist, 0)
 	if err != nil {
 		return err
 	}

--- a/go/cmd/dolt/commands/stash.go
+++ b/go/cmd/dolt/commands/stash.go
@@ -101,13 +101,10 @@ func (cmd StashCmd) Exec(ctx context.Context, commandStr string, args []string, 
 		subcommand = strings.ToLower(apr.Arg(0))
 	}
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		cli.PrintErrln(errhand.VerboseErrorFromError(err))
 		return 1
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	idx := 0
@@ -193,12 +190,9 @@ func stashRemove(queryist cli.Queryist, sqlCtx *sql.Context, cliCtx cli.CliConte
 }
 
 func stashList(ctx context.Context, cliCtx cli.CliContext) error {
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return err
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	stashes, err := getStashesSQL(sqlCtx, queryist, 0)

--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -111,13 +111,13 @@ func (cmd StatusCmd) Exec(ctx context.Context, commandStr string, args []string,
 	showIgnoredTables := apr.Contains(cli.ShowIgnoredFlag)
 
 	// configure SQL engine
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return handleStatusVErr(err)
 	}
 
 	// get status information from the database
-	pd, err := createPrintData(err, queryist, sqlCtx, showIgnoredTables, cliCtx)
+	pd, err := createPrintData(err, queryist.Queryist, queryist.Context, showIgnoredTables, cliCtx)
 	if err != nil {
 		return handleStatusVErr(err)
 	}

--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -111,12 +111,9 @@ func (cmd StatusCmd) Exec(ctx context.Context, commandStr string, args []string,
 	showIgnoredTables := apr.Contains(cli.ShowIgnoredFlag)
 
 	// configure SQL engine
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return handleStatusVErr(err)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	// get status information from the database

--- a/go/cmd/dolt/commands/tag.go
+++ b/go/cmd/dolt/commands/tag.go
@@ -87,12 +87,9 @@ func (cmd TagCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, tagDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
-	queryist, sqlCtx, closeFunc, err := cliCtx.QueryEngine(ctx)
+	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return handleStatusVErr(err)
-	}
-	if closeFunc != nil {
-		defer closeFunc()
 	}
 
 	// list tags

--- a/go/cmd/dolt/commands/tag.go
+++ b/go/cmd/dolt/commands/tag.go
@@ -87,25 +87,25 @@ func (cmd TagCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, tagDocs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
-	queryist, sqlCtx, err := cliCtx.QueryEngine(ctx)
+	queryist, err := cliCtx.QueryEngine(ctx)
 	if err != nil {
 		return handleStatusVErr(err)
 	}
 
 	// list tags
 	if len(apr.Args) == 0 {
-		err = listTags(queryist, sqlCtx, apr)
+		err = listTags(queryist.Queryist, queryist.Context, apr)
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
 	// delete tag
 	if apr.Contains(cli.DeleteFlag) {
-		err = deleteTags(queryist, sqlCtx, apr)
+		err = deleteTags(queryist.Queryist, queryist.Context, apr)
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
 	// create tag
-	err = createTag(queryist, sqlCtx, apr)
+	err = createTag(queryist.Queryist, queryist.Context, apr)
 	return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 }
 

--- a/go/cmd/dolt/commands/utils.go
+++ b/go/cmd/dolt/commands/utils.go
@@ -321,6 +321,7 @@ func newLateBindingEngine(
 		res.Queryist = se
 		res.Context = sqlCtx
 		res.Closer = close
+		res.IsRemote = false
 		return res, nil
 	}
 

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -531,6 +531,9 @@ or check the docs for questions about usage.`)
 
 	ctx, stop := context.WithCancel(ctx)
 	res := doltCommand.Exec(ctx, "dolt", cfg.remainingArgs, dEnv, cliCtx)
+	if cliCtx != nil {
+		cliCtx.Close()
+	}
 	stop()
 
 	if err = dbfactory.CloseAllLocalDatabases(); err != nil {

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -30,7 +30,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/fatih/color"
 	"github.com/pkg/profile"
 	"github.com/tidwall/gjson"
@@ -665,16 +664,15 @@ If you're interested in running this command against a remote host, hit us up on
 	isValidRepositoryRequired := subcommandName != "init" && subcommandName != "sql" && subcommandName != "sql-server" && subcommandName != "sql-client"
 
 	if noValidRepository && isValidRepositoryRequired {
-		return func(ctx context.Context) (cli.Queryist, *sql.Context, func(), error) {
-			err := errors.New("The current directory is not a valid dolt repository.")
+		return func(ctx context.Context) (res cli.LateBindQueryistResult, err error) {
+			err = errors.New("The current directory is not a valid dolt repository.")
 			if errors.Is(rootEnv.DBLoadError, nbs.ErrUnsupportedTableFileFormat) {
 				// This is fairly targeted and specific to allow for better error messaging. We should consider
 				// breaking this out into its own function if we add more conditions.
 
 				err = errors.New("The data in this database is in an unsupported format. Please upgrade to the latest version of Dolt.")
 			}
-
-			return nil, nil, nil, err
+			return res, err
 		}, nil
 	}
 

--- a/go/libraries/doltcore/doltdb/foreign_key_test.go
+++ b/go/libraries/doltcore/doltdb/foreign_key_test.go
@@ -15,7 +15,6 @@
 package doltdb_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -107,10 +106,16 @@ func TestForeignKeyErrors(t *testing.T) {
 			`CONSTRAINT child_fk FOREIGN KEY (v1) REFERENCES test(v1));`}},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	dEnv := dtestutils.CreateTestEnv()
+	t.Cleanup(func() {
+		dEnv.DoltDB(ctx).Close()
+	})
 	cliCtx, err := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		cliCtx.Close()
+	})
 
 	for _, c := range cmds {
 		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)
@@ -151,11 +156,17 @@ var fkSetupCommon = []testCommand{
 }
 
 func testForeignKeys(t *testing.T, test foreignKeyTest) {
-	ctx := context.Background()
+	ctx := t.Context()
 	dEnv := dtestutils.CreateTestEnv()
+	t.Cleanup(func() {
+		dEnv.DoltDB(ctx).Close()
+	})
 
 	cliCtx, verr := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, verr)
+	t.Cleanup(func() {
+		cliCtx.Close()
+	})
 
 	for _, c := range fkSetupCommon {
 		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)

--- a/go/libraries/doltcore/doltdb/gc_test.go
+++ b/go/libraries/doltcore/doltdb/gc_test.go
@@ -119,12 +119,17 @@ var gcSetupCommon = []testCommand{
 }
 
 func testGarbageCollection(t *testing.T, test gcTest) {
-	ctx := context.Background()
+	ctx := t.Context()
 	dEnv := dtestutils.CreateTestEnv()
-	defer dEnv.DoltDB(ctx).Close()
+	t.Cleanup(func() {
+		dEnv.DoltDB(ctx).Close()
+	})
 
 	cliCtx, verr := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, verr)
+	t.Cleanup(func() {
+		cliCtx.Close()
+	})
 
 	for _, c := range gcSetupCommon {
 		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)

--- a/go/libraries/doltcore/dtestutils/testcommands/multienv.go
+++ b/go/libraries/doltcore/dtestutils/testcommands/multienv.go
@@ -174,11 +174,11 @@ func (mr *MultiRepoTestSetup) CheckoutBranch(dbName, branchName string) {
 		mr.Errhand(err)
 	}
 	defer cliCtx.Close()
-	_, sqlCtx, err := cliCtx.QueryEngine(context.Background())
+	queryist, err := cliCtx.QueryEngine(context.Background())
 	if err != nil {
 		mr.Errhand(err)
 	}
-	err = dprocedures.MoveWorkingSetToBranch(sqlCtx, branchName, false, false)
+	err = dprocedures.MoveWorkingSetToBranch(queryist.Context, branchName, false, false)
 	if err != nil {
 		mr.Errhand(err)
 	}

--- a/go/libraries/doltcore/dtestutils/testcommands/multienv.go
+++ b/go/libraries/doltcore/dtestutils/testcommands/multienv.go
@@ -168,12 +168,16 @@ func (mr *MultiRepoTestSetup) NewBranch(ctx context.Context, dbName, branchName 
 
 func (mr *MultiRepoTestSetup) CheckoutBranch(dbName, branchName string) {
 	dEnv := mr.envs[dbName]
-	cliCtx, _ := cmd.NewArgFreeCliContext(context.Background(), dEnv, dEnv.FS)
-	_, sqlCtx, closeFunc, err := cliCtx.QueryEngine(context.Background())
+	var err error
+	cliCtx, err := cmd.NewArgFreeCliContext(context.Background(), dEnv, dEnv.FS)
 	if err != nil {
 		mr.Errhand(err)
 	}
-	defer closeFunc()
+	defer cliCtx.Close()
+	_, sqlCtx, err := cliCtx.QueryEngine(context.Background())
+	if err != nil {
+		mr.Errhand(err)
+	}
 	err = dprocedures.MoveWorkingSetToBranch(sqlCtx, branchName, false, false)
 	if err != nil {
 		mr.Errhand(err)

--- a/go/libraries/doltcore/merge/keyless_integration_test.go
+++ b/go/libraries/doltcore/merge/keyless_integration_test.go
@@ -116,6 +116,7 @@ func TestKeylessMerge(t *testing.T) {
 			require.NoError(t, err)
 			cliCtx, err := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 			require.NoError(t, err)
+			defer cliCtx.Close()
 
 			for _, c := range test.setup {
 				exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)
@@ -251,6 +252,7 @@ func TestKeylessMergeConflicts(t *testing.T) {
 		require.NoError(t, err)
 		cliCtx, err := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 		require.NoError(t, err)
+		defer cliCtx.Close()
 
 		for _, c := range cc {
 			exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)
@@ -284,6 +286,7 @@ func TestKeylessMergeConflicts(t *testing.T) {
 			setupTest(t, ctx, dEnv, test.setup)
 			cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 			require.NoError(t, verr)
+			defer cliCtx.Close()
 
 			resolve := cnfcmds.ResolveCmd{}
 			args := []string{"--ours", tblName}
@@ -304,6 +307,7 @@ func TestKeylessMergeConflicts(t *testing.T) {
 			setupTest(t, ctx, dEnv, test.setup)
 			cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 			require.NoError(t, verr)
+			defer cliCtx.Close()
 
 			resolve := cnfcmds.ResolveCmd{}
 			args := []string{"--theirs", tblName}

--- a/go/libraries/doltcore/merge/schema_integration_test.go
+++ b/go/libraries/doltcore/merge/schema_integration_test.go
@@ -42,6 +42,7 @@ type testCommand struct {
 func (tc testCommand) exec(t *testing.T, ctx context.Context, dEnv *env.DoltEnv) int {
 	cliCtx, err := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, err)
+	defer cliCtx.Close()
 	return tc.cmd.Exec(ctx, tc.cmd.Name(), tc.args, dEnv, cliCtx)
 }
 
@@ -559,7 +560,10 @@ func testMergeSchemas(t *testing.T, test mergeSchemaTest) {
 	dEnv := dtestutils.CreateTestEnv()
 	defer dEnv.DoltDB(ctx).Close()
 
-	cliCtx, _ := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
+	var err error
+	cliCtx, err := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
+	require.NoError(t, err)
+	defer cliCtx.Close()
 
 	for _, c := range setupCommon {
 		exit := c.exec(t, ctx, dEnv)
@@ -617,7 +621,10 @@ func testMergeSchemasWithConflicts(t *testing.T, test mergeSchemaConflictTest) {
 		require.Equal(t, 0, exit)
 	}
 
-	cliCtx, _ := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
+	var err error
+	cliCtx, err := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
+	require.NoError(t, err)
+	defer cliCtx.Close()
 
 	// assert that we're on main
 	exitCode := commands.CheckoutCmd{}.Exec(ctx, "checkout", []string{env.DefaultInitBranch}, dEnv, cliCtx)
@@ -679,7 +686,9 @@ func testMergeForeignKeys(t *testing.T, test mergeForeignKeyTest) {
 		require.Equal(t, 0, exit)
 	}
 
-	cliCtx, _ := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
+	cliCtx, err := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
+	require.NoError(t, err)
+	defer cliCtx.Close()
 
 	// assert that we're on main
 	exitCode := commands.CheckoutCmd{}.Exec(ctx, "checkout", []string{env.DefaultInitBranch}, dEnv, cliCtx)

--- a/go/libraries/doltcore/migrate/integration_test.go
+++ b/go/libraries/doltcore/migrate/integration_test.go
@@ -172,6 +172,7 @@ func setupMigrationTest(t *testing.T, ctx context.Context, test migrationTest) *
 	}
 	cliCtx, err := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, err)
+	defer cliCtx.Close()
 
 	cmd := commands.SqlCmd{}
 	for _, query := range test.setup {

--- a/go/libraries/doltcore/rebase/filter_branch_test.go
+++ b/go/libraries/doltcore/rebase/filter_branch_test.go
@@ -204,6 +204,7 @@ func setupFilterBranchTests(t *testing.T) *env.DoltEnv {
 	dEnv := dtestutils.CreateTestEnv()
 	cliCtx, err := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, err)
+	defer cliCtx.Close()
 
 	for _, c := range setupCommon {
 		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)
@@ -219,6 +220,7 @@ func testFilterBranch(t *testing.T, test filterBranchTest) {
 	defer dEnv.DoltDB(ctx).Close()
 	cliCtx, err := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, err)
+	defer cliCtx.Close()
 
 	for _, c := range test.setup {
 		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)

--- a/go/libraries/doltcore/schema/integration_test.go
+++ b/go/libraries/doltcore/schema/integration_test.go
@@ -178,6 +178,7 @@ func runTestSql(t *testing.T, ctx context.Context, setup []string) (*doltdb.Dolt
 	cmd := commands.SqlCmd{}
 	cliCtx, verr := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, verr)
+	defer cliCtx.Close()
 
 	for _, query := range setup {
 		code := cmd.Exec(ctx, cmd.Name(), []string{"-q", query}, dEnv, cliCtx)

--- a/go/libraries/doltcore/sqle/integration_test/database_revision_test.go
+++ b/go/libraries/doltcore/sqle/integration_test/database_revision_test.go
@@ -152,7 +152,10 @@ func TestDbRevision(t *testing.T) {
 			dEnv := dtestutils.CreateTestEnv()
 			defer dEnv.DoltDB(ctx).Close()
 
-			cliCtx, _ := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
+			var err error
+			cliCtx, err := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
+			require.NoError(t, err)
+			defer cliCtx.Close()
 
 			setup := append(setupCommon, test.setup...)
 			for _, c := range setup {

--- a/go/libraries/doltcore/sqle/integration_test/dolt_procedures_history_test.go
+++ b/go/libraries/doltcore/sqle/integration_test/dolt_procedures_history_test.go
@@ -161,6 +161,7 @@ func setupDoltProceduresHistoryTests(t *testing.T) *env.DoltEnv {
 	ctx := context.Background()
 	cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, verr)
+	defer cliCtx.Close()
 
 	for _, c := range setupDoltProceduresCommon {
 		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)
@@ -187,6 +188,7 @@ func testDoltProceduresHistoryTable(t *testing.T, test doltProceduresTableTest, 
 	ctx := context.Background()
 	cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, verr)
+	defer cliCtx.Close()
 
 	for _, c := range test.setup {
 		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)

--- a/go/libraries/doltcore/sqle/integration_test/dolt_schemas_history_diff_test.go
+++ b/go/libraries/doltcore/sqle/integration_test/dolt_schemas_history_diff_test.go
@@ -247,6 +247,7 @@ func setupDoltSchemasHistoryTests(t *testing.T) *env.DoltEnv {
 	ctx := context.Background()
 	cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, verr)
+	defer cliCtx.Close()
 
 	for _, c := range setupDoltSchemasCommon {
 		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)
@@ -274,6 +275,7 @@ func setupDoltSchemasDiffTests(t *testing.T) *env.DoltEnv {
 	ctx := context.Background()
 	cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, verr)
+	defer cliCtx.Close()
 
 	for _, c := range setupDoltSchemasDiffCommon {
 		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)
@@ -287,6 +289,7 @@ func testDoltSchemasHistoryTable(t *testing.T, test doltSchemasTableTest, dEnv *
 	ctx := context.Background()
 	cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, verr)
+	defer cliCtx.Close()
 
 	for _, c := range test.setup {
 		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)
@@ -315,6 +318,7 @@ func testDoltSchemasDiffTable(t *testing.T, test doltSchemasTableTest, dEnv *env
 	ctx := context.Background()
 	cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, verr)
+	defer cliCtx.Close()
 
 	for _, c := range test.setup {
 		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)
@@ -436,6 +440,7 @@ func setupDoltProceduresDiffTests(t *testing.T) *env.DoltEnv {
 	ctx := context.Background()
 	cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, verr)
+	defer cliCtx.Close()
 
 	for _, c := range setupDoltProceduresDiffCommon {
 		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)
@@ -449,6 +454,7 @@ func testDoltProceduresDiffTable(t *testing.T, test doltProceduresTableTest, dEn
 	ctx := context.Background()
 	cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, verr)
+	defer cliCtx.Close()
 
 	for _, c := range test.setup {
 		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)

--- a/go/libraries/doltcore/sqle/integration_test/history_table_test.go
+++ b/go/libraries/doltcore/sqle/integration_test/history_table_test.go
@@ -215,6 +215,7 @@ func setupHistoryTests(t *testing.T) *env.DoltEnv {
 	dEnv := dtestutils.CreateTestEnv()
 	cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, verr)
+	defer cliCtx.Close()
 
 	for _, c := range setupCommon {
 		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)
@@ -242,6 +243,7 @@ func testHistoryTable(t *testing.T, test historyTableTest, dEnv *env.DoltEnv) {
 	ctx := context.Background()
 	cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, verr)
+	defer cliCtx.Close()
 
 	for _, c := range test.setup {
 		exitCode := c.cmd.Exec(ctx, c.cmd.Name(), c.args, dEnv, cliCtx)

--- a/go/libraries/doltcore/sqle/integration_test/json_value_test.go
+++ b/go/libraries/doltcore/sqle/integration_test/json_value_test.go
@@ -129,6 +129,7 @@ func testJsonValue(t *testing.T, test jsonValueTest, setupCommon []testCommand) 
 	dEnv := dtestutils.CreateTestEnv()
 	cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, verr)
+	defer cliCtx.Close()
 
 	setup := append(setupCommon, test.setup...)
 	for _, c := range setup {

--- a/go/performance/microsysbench/sysbench_test.go
+++ b/go/performance/microsysbench/sysbench_test.go
@@ -175,14 +175,14 @@ func readTestData(file string) string {
 }
 
 func populateRepo(dEnv *env.DoltEnv, insertData string) {
+	ctx := context.Background()
+	cliCtx, err := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
+	if err != nil {
+		panic(err)
+	}
+	defer cliCtx.Close()
 	execSql := func(dEnv *env.DoltEnv, q string) int {
-		ctx := context.Background()
 		args := []string{"-r", "null", "-q", q}
-		cliCtx, err := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
-		if err != nil {
-			panic(err)
-		}
-
 		return commands.SqlCmd{}.Exec(ctx, "sql", args, dEnv, cliCtx)
 	}
 	execSql(dEnv, createTable)

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -197,7 +197,7 @@ EOF
     [ "$status" -eq 1 ]
     run grep 'Error authenticating user' log.txt
     [ "$status" -eq 0 ]
-    [ "${#lines[@]}" -eq 2 ]
+    [ "${#lines[@]}" -eq 1 ]
 }
 
 @test "sql-server: Database specific system variables should be loaded" {


### PR DESCRIPTION
Rework CliContext and LateBinderyQueryist lifecycle so that CliContext itself is `Close`d when we are done with it. If it instantiated the LateBinderQueryist, it closes it at that time.

Previously LateBinderQueryist was responsible for returning a `closer()`, which a caller of `CliContext.QueryEngine` could see as non-`nil` and call at the end of its work. This works well when a QueryEngine is used exactly one time or when QueryEngine usage is completely nested, as is the case with the backslash command implementations called from `dolt sql`. But in tests, we sometimes use command instances back-to-back, on the same CliContext instance, where it results in using the Queryist after it has already been closed.

This PR also reworks result types so that callers of QueryEngine can know if they are connected locally or remotely and if the QueryEngine interaction they are making is the first one in the session. Some callers need to inspect that state to implement helpful error checks and guard rails, and they were previously using things like a non-nil `closer` and interface casts to concrete types to implement these checks.