### PR TITLE
[RFC] conjoin selection

### DIFF
--- a/go/store/nbs/conjoiner.go
+++ b/go/store/nbs/conjoiner.go
@@ -66,6 +66,10 @@ func (c inlineConjoiner) chooseConjoinees(upstream []tableSpec) (conjoinees, kee
 		// Need at least 2 tables to conjoin
 		return nil, upstream, fmt.Errorf("runtime error: cannot conjoin fewer than 2 tables, got %d", len(upstream))
 	}
+	if c.maxTables < 2 {
+		// If maxTables is 0, we don't conjoin at all
+		return nil, upstream, fmt.Errorf("runtime error: cannot conjoin with maxTables set to %d", c.maxTables)
+	}
 
 	sorted := make([]tableSpec, len(upstream))
 	copy(sorted, upstream)
@@ -80,7 +84,7 @@ func (c inlineConjoiner) chooseConjoinees(upstream []tableSpec) (conjoinees, kee
 	for i < len(sorted) {
 		// Check maxTables constraint first: after conjoining, we'd have (len(sorted)-i)+1 total tables
 		tablesAfterConjoining := (len(sorted) - i) + 1
-		if c.maxTables > 0 && tablesAfterConjoining < c.maxTables {
+		if tablesAfterConjoining < c.maxTables {
 			break
 		}
 

--- a/go/store/nbs/conjoiner_test.go
+++ b/go/store/nbs/conjoiner_test.go
@@ -286,16 +286,6 @@ func testConjoin(t *testing.T, factory func(t *testing.T) tablePersister) {
 		{"log, max 3", 5, []uint32{1, 2}, []uint32{1, 2, 4, 8, 16, 32, 64}, []uint32{1, 2, 12, 16, 32, 64}},
 		{"almost log, max 3", 3, []uint32{9, 10, 11, 12}, []uint32{9, 10, 11, 12, 2, 3, 4, 8, 16, 32, 64}, []uint32{4, 5, 8, 9, 10, 11, 12, 16, 32, 64}},
 	}
-	/*
-			{"uniform", 3, []uint32{1, 1, 1, 1, 1}, []uint32{1, 1, 1, 2}},
-		{"one outlier", 3, []uint32{1, 1, 1, 1, 5}, []uint32{1, 1, 2, 5}},
-		{"all", 2, []uint32{5, 5, 5}, []uint32{15}},
-		{"first two", 4, []uint32{5, 6, 10, 11, 35, 64}, []uint32{10, 11, 11, 35, 64}},
-		{"log, max 5", 5, []uint32{1, 2, 4, 8, 16, 32, 64}, []uint32{15, 16, 32, 64}},
-		{"log, max 3", 3, []uint32{1, 2, 4, 8, 16, 32, 64}, []uint32{63, 64}},
-		{"almost log", 3, []uint32{2, 3, 4, 8, 16, 32, 64}, []uint32{4, 5, 8, 16, 32, 64}},
-
-	*/
 
 	t.Run("SuccessAppendix", func(t *testing.T) {
 		// Compact some tables, no one interrupts

--- a/go/store/nbs/conjoiner_test.go
+++ b/go/store/nbs/conjoiner_test.go
@@ -188,15 +188,17 @@ func testConjoin(t *testing.T, factory func(t *testing.T) tablePersister) {
 
 	tc := []struct {
 		name        string
+		maxTables   int
 		precompact  []uint32
 		postcompact []uint32
 	}{
-		{"uniform", []uint32{1, 1, 1, 1, 1}, []uint32{5}},
-		{"all but last", []uint32{1, 1, 1, 1, 5}, []uint32{4, 5}},
-		{"all", []uint32{5, 5, 5}, []uint32{15}},
-		{"first four", []uint32{5, 6, 10, 11, 35, 64}, []uint32{32, 35, 64}},
-		{"log, first two", []uint32{1, 2, 4, 8, 16, 32, 64}, []uint32{3, 4, 8, 16, 32, 64}},
-		{"log, all", []uint32{2, 3, 4, 8, 16, 32, 64}, []uint32{129}},
+		{"uniform", 3, []uint32{1, 1, 1, 1, 1}, []uint32{1, 1, 1, 2}},
+		{"one outlier", 3, []uint32{1, 1, 1, 1, 5}, []uint32{1, 1, 2, 5}},
+		{"all", 2, []uint32{5, 5, 5}, []uint32{15}},
+		{"first two", 4, []uint32{5, 6, 10, 11, 35, 64}, []uint32{10, 11, 11, 35, 64}},
+		{"log, max 5", 5, []uint32{1, 2, 4, 8, 16, 32, 64}, []uint32{15, 16, 32, 64}},
+		{"log, max 3", 3, []uint32{1, 2, 4, 8, 16, 32, 64}, []uint32{63, 64}},
+		{"almost log", 3, []uint32{2, 3, 4, 8, 16, 32, 64}, []uint32{4, 5, 8, 16, 32, 64}},
 	}
 
 	startLock, startRoot := computeAddr([]byte("lock")), hash.Of([]byte("root"))
@@ -206,7 +208,7 @@ func testConjoin(t *testing.T, factory func(t *testing.T) tablePersister) {
 			t.Run(c.name, func(t *testing.T) {
 				fm, p, upstream := setup(startLock, startRoot, c.precompact)
 
-				_, _, err := conjoin(context.Background(), inlineConjoiner{}, upstream, fm, p, stats)
+				_, _, err := conjoin(context.Background(), inlineConjoiner{maxTables: c.maxTables}, upstream, fm, p, stats)
 				require.NoError(t, err)
 				exists, newUpstream, err := fm.ParseIfExists(context.Background(), stats, nil)
 				require.NoError(t, err)
@@ -227,7 +229,7 @@ func testConjoin(t *testing.T, factory func(t *testing.T) tablePersister) {
 					specs := append([]tableSpec{}, upstream.specs...)
 					fm.set(constants.FormatLD1String, computeAddr([]byte("lock2")), startRoot, append(specs, newTable), nil)
 				}}
-				_, _, err := conjoin(context.Background(), inlineConjoiner{}, upstream, u, p, stats)
+				_, _, err := conjoin(context.Background(), inlineConjoiner{maxTables: c.maxTables}, upstream, u, p, stats)
 				require.NoError(t, err)
 				exists, newUpstream, err := fm.ParseIfExists(context.Background(), stats, nil)
 				require.NoError(t, err)
@@ -247,7 +249,7 @@ func testConjoin(t *testing.T, factory func(t *testing.T) tablePersister) {
 				u := updatePreemptManifest{fm, func() {
 					fm.set(constants.FormatLD1String, computeAddr([]byte("lock2")), startRoot, upstream.specs[1:], nil)
 				}}
-				_, _, err := conjoin(context.Background(), inlineConjoiner{}, upstream, u, p, stats)
+				_, _, err := conjoin(context.Background(), inlineConjoiner{c.maxTables}, upstream, u, p, stats)
 				require.NoError(t, err)
 				exists, newUpstream, err := fm.ParseIfExists(context.Background(), stats, nil)
 				require.NoError(t, err)
@@ -271,17 +273,29 @@ func testConjoin(t *testing.T, factory func(t *testing.T) tablePersister) {
 
 	tca := []struct {
 		name        string
+		maxTables   int
 		appendix    []uint32
 		precompact  []uint32
 		postcompact []uint32
 	}{
-		{"uniform", []uint32{1}, []uint32{1, 1, 1, 1, 1}, []uint32{1, 4}},
-		{"all but last", []uint32{2}, []uint32{2, 1, 1, 1, 1, 5}, []uint32{2, 4, 5}},
-		{"all", []uint32{1, 2, 3}, []uint32{1, 2, 3, 5, 5, 5}, []uint32{1, 2, 3, 15}},
-		{"first four", []uint32{8, 9, 10}, []uint32{8, 9, 10, 5, 6, 10, 11, 35, 64}, []uint32{8, 9, 10, 32, 35, 64}},
-		{"log, first two", nil, []uint32{1, 2, 4, 8, 16, 32, 64}, []uint32{3, 4, 8, 16, 32, 64}},
-		{"log, all", []uint32{9, 10, 11, 12}, []uint32{9, 10, 11, 12, 2, 3, 4, 8, 16, 32, 64}, []uint32{9, 10, 11, 12, 129}},
+		{"uniform", 3, []uint32{1}, []uint32{1, 1, 1, 1, 1}, []uint32{1, 1, 1, 2}},
+		{"one outlier", 3, []uint32{2}, []uint32{2, 1, 1, 1, 1, 5}, []uint32{1, 1, 2, 2, 5}},
+		{"all", 2, []uint32{1, 2, 3}, []uint32{1, 2, 3, 5, 5, 5}, []uint32{1, 2, 3, 15}},
+		{"first two", 4, []uint32{8, 9, 10}, []uint32{8, 9, 10, 5, 6, 10, 11, 35, 64}, []uint32{8, 9, 10, 10, 11, 11, 35, 64}},
+		{"log, max 5", 5, nil, []uint32{1, 2, 4, 8, 16, 32, 64}, []uint32{15, 16, 32, 64}},
+		{"log, max 3", 5, []uint32{1, 2}, []uint32{1, 2, 4, 8, 16, 32, 64}, []uint32{1, 2, 12, 16, 32, 64}},
+		{"almost log, max 3", 3, []uint32{9, 10, 11, 12}, []uint32{9, 10, 11, 12, 2, 3, 4, 8, 16, 32, 64}, []uint32{4, 5, 8, 9, 10, 11, 12, 16, 32, 64}},
 	}
+	/*
+			{"uniform", 3, []uint32{1, 1, 1, 1, 1}, []uint32{1, 1, 1, 2}},
+		{"one outlier", 3, []uint32{1, 1, 1, 1, 5}, []uint32{1, 1, 2, 5}},
+		{"all", 2, []uint32{5, 5, 5}, []uint32{15}},
+		{"first two", 4, []uint32{5, 6, 10, 11, 35, 64}, []uint32{10, 11, 11, 35, 64}},
+		{"log, max 5", 5, []uint32{1, 2, 4, 8, 16, 32, 64}, []uint32{15, 16, 32, 64}},
+		{"log, max 3", 3, []uint32{1, 2, 4, 8, 16, 32, 64}, []uint32{63, 64}},
+		{"almost log", 3, []uint32{2, 3, 4, 8, 16, 32, 64}, []uint32{4, 5, 8, 16, 32, 64}},
+
+	*/
 
 	t.Run("SuccessAppendix", func(t *testing.T) {
 		// Compact some tables, no one interrupts
@@ -289,7 +303,7 @@ func testConjoin(t *testing.T, factory func(t *testing.T) tablePersister) {
 			t.Run(c.name, func(t *testing.T) {
 				fm, p, upstream := setupAppendix(startLock, startRoot, c.precompact, c.appendix)
 
-				_, _, err := conjoin(context.Background(), inlineConjoiner{}, upstream, fm, p, stats)
+				_, _, err := conjoin(context.Background(), inlineConjoiner{c.maxTables}, upstream, fm, p, stats)
 				require.NoError(t, err)
 				exists, newUpstream, err := fm.ParseIfExists(context.Background(), stats, nil)
 				require.NoError(t, err)
@@ -313,7 +327,7 @@ func testConjoin(t *testing.T, factory func(t *testing.T) tablePersister) {
 					fm.set(constants.FormatLD1String, computeAddr([]byte("lock2")), startRoot, append(specs, newTable), upstream.appendix)
 				}}
 
-				_, _, err := conjoin(context.Background(), inlineConjoiner{}, upstream, u, p, stats)
+				_, _, err := conjoin(context.Background(), inlineConjoiner{c.maxTables}, upstream, u, p, stats)
 				require.NoError(t, err)
 				exists, newUpstream, err := fm.ParseIfExists(context.Background(), stats, nil)
 				require.NoError(t, err)
@@ -338,7 +352,7 @@ func testConjoin(t *testing.T, factory func(t *testing.T) tablePersister) {
 					fm.set(constants.FormatLD1String, computeAddr([]byte("lock2")), startRoot, append(specs, upstream.specs...), append(app, newTable))
 				}}
 
-				_, _, err := conjoin(context.Background(), inlineConjoiner{}, upstream, u, p, stats)
+				_, _, err := conjoin(context.Background(), inlineConjoiner{c.maxTables}, upstream, u, p, stats)
 				require.NoError(t, err)
 				exists, newUpstream, err := fm.ParseIfExists(context.Background(), stats, nil)
 				require.NoError(t, err)
@@ -362,7 +376,7 @@ func testConjoin(t *testing.T, factory func(t *testing.T) tablePersister) {
 				u := updatePreemptManifest{fm, func() {
 					fm.set(constants.FormatLD1String, computeAddr([]byte("lock2")), startRoot, upstream.specs[len(c.appendix)+1:], upstream.appendix[:])
 				}}
-				_, _, err := conjoin(context.Background(), inlineConjoiner{}, upstream, u, p, stats)
+				_, _, err := conjoin(context.Background(), inlineConjoiner{c.maxTables}, upstream, u, p, stats)
 				require.NoError(t, err)
 				exists, newUpstream, err := fm.ParseIfExists(context.Background(), stats, nil)
 				require.NoError(t, err)
@@ -386,7 +400,7 @@ func testConjoin(t *testing.T, factory func(t *testing.T) tablePersister) {
 					fm.set(constants.FormatLD1String, computeAddr([]byte("lock2")), startRoot, specs, append([]tableSpec{}, newTable))
 				}}
 
-				_, _, err := conjoin(context.Background(), inlineConjoiner{}, upstream, u, p, stats)
+				_, _, err := conjoin(context.Background(), inlineConjoiner{c.maxTables}, upstream, u, p, stats)
 				require.NoError(t, err)
 				exists, newUpstream, err := fm.ParseIfExists(context.Background(), stats, nil)
 				require.NoError(t, err)


### PR DESCRIPTION
The existing chooseConjoinees behavior doesn't seem to behave like the documentation says it should. Specifically, we will conjoin all tables aggressively if they are all very similar sizes (`sum <= next` is false so we never break from the loop).

This change doesn't pass CI because there are tests which depend on the old behavior. This makes me wonder if the description of the behavior is incorrect or the tests are incorrect. Feedback appreciated.