### PR TITLE
[no-release-notes] Don't special case maxTable == 0 in conjoin testing

### DIFF
--- a/go/store/nbs/conjoiner.go
+++ b/go/store/nbs/conjoiner.go
@@ -24,6 +24,7 @@ package nbs
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sort"
 	"time"
 
@@ -54,6 +55,9 @@ func (c inlineConjoiner) conjoinRequired(ts tableSet) bool {
 // when removed and replaced with the conjoinment, will leave the conjoinment as the smallest table.
 // We also keep taking table files until we get below maxTables.
 func (c inlineConjoiner) chooseConjoinees(upstream []tableSpec) (conjoinees, keepers []tableSpec, err error) {
+	if c.maxTables < 2 {
+		return nil, upstream, fmt.Errorf("runtime error: cannot conjoin with maxTables set to %d", c.maxTables)
+	}
 	sorted := make([]tableSpec, len(upstream))
 	copy(sorted, upstream)
 
@@ -66,7 +70,7 @@ func (c inlineConjoiner) chooseConjoinees(upstream []tableSpec) (conjoinees, kee
 	for i < len(sorted) {
 		next := sorted[i].chunkCount
 		if sum <= next {
-			if c.maxTables == 0 || len(sorted)-i < c.maxTables {
+			if len(sorted)-i < c.maxTables {
 				break
 			}
 		}


### PR DESCRIPTION
Currently conjoin tests aren't reflecting real usage. Fix to address.