### PR TITLE
Drop old event messages

### DIFF
--- a/go/libraries/events/emitter.go
+++ b/go/libraries/events/emitter.go
@@ -156,10 +156,7 @@ func (em *GrpcEmitter) LogEventsRequest(ctx context.Context, req *eventsapi.LogE
 // SendLogEventsRequest sends a request using the grpc client
 func (em *GrpcEmitter) sendLogEventsRequest(ctx context.Context, req *eventsapi.LogEventsRequest) error {
 	_, err := em.client.LogEvents(ctx, req)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // FileEmitter saves event requests to files


### PR DESCRIPTION
Changes the event collector/emitter to drop old events and not grow unbounded when events can't be delivered.

The event collector already batched 64 events per request when `LogEvent` messages were being sent successfully. However, when there are issues sending `LogEvent` messages, the events queue up, with no upper bound, and each `LogEvent` request gets larger and larger. This change limits the tracked "unsent" events to that existing 64 event batch size. 