### PR TITLE
[no-release-notes] conjoin prep

### DIFF
--- a/go/libraries/doltcore/remotesrv/grpc.go
+++ b/go/libraries/doltcore/remotesrv/grpc.go
@@ -192,6 +192,10 @@ func (rs *RemoteChunkStore) GetDownloadLocations(ctx context.Context, req *remot
 
 		var ranges []*remotesapi.RangeChunk
 		for h, r := range hashToRange {
+			if r.DictLength != 0 {
+				return nil, status.Error(codes.Aborted, "upgrade your dolt client; it is too old to read these files")
+			}
+
 			hCpy := h
 			ranges = append(ranges, &remotesapi.RangeChunk{Hash: hCpy[:], Offset: r.Offset, Length: r.Length})
 		}

--- a/go/libraries/doltcore/remotesrv/grpc.go
+++ b/go/libraries/doltcore/remotesrv/grpc.go
@@ -193,7 +193,7 @@ func (rs *RemoteChunkStore) GetDownloadLocations(ctx context.Context, req *remot
 		var ranges []*remotesapi.RangeChunk
 		for h, r := range hashToRange {
 			if r.DictLength != 0 {
-				return nil, status.Error(codes.Aborted, "upgrade your dolt client; it is too old to read these files")
+				return nil, status.Error(codes.Unknown, "upgrade your dolt client; it is too old to read these files")
 			}
 
 			hCpy := h

--- a/go/store/nbs/archive.go
+++ b/go/store/nbs/archive.go
@@ -69,12 +69,12 @@ Footer:
        is that we load the larger footer for all versions, but ignore the first 4 bytes for versions 1 and 2.
 
    CheckSums:
-   +----------------------------+-------------------+----------------------+
-   | (64) Sha512 ByteSpan 1 - N | (64) Sha512 Index | (64) Sha512 Metadata |
-   +----------------------------+-------------------+----------------------+
-   - The Sha512 checksums of the ByteSpans, Index, and Metadata. Currently unused, but may be used in the future. Leaves
-     the opening to verify integrity manually at least, but could be used in the future to allow to break the file into
-     parts, and ensure we can verify the integrity of each part.
+   +------------------+
+   | (192) DEAD SPACE |
+   +------------------+
+   - The Sha512 checksums of the ByteSpans, Index, and Metadata were in initial design, but were never used. The ability
+     to calculate was thrown out to support archive conjoins, and leaving the 192 bytes in the foorer allows us to avoid
+     a format bump.
 
 Index:
    The Index is a concatenation of 4 sections, all of which are stored in raw form on disk.
@@ -131,6 +131,7 @@ Index:
 
      - Each Hash Suffix is the last 12 bytes of a Chunk in this Table.
      - Hash Suffix M must correspond to Prefix M and Chunk Record M
+     - The ID, or name, of the artifact is calculated using the truncated Sha512 (first 20 bytes) of the Suffix data.
 
 Metadata:
    The Metadata section is intended to be used for additional information about the Archive. This may include the version
@@ -174,7 +175,7 @@ const (
 	archiveFileSignature = "DOLTARC"
 	archiveFileSigSize   = uint64(len(archiveFileSignature))
 	archiveCheckSumSize  = sha512.Size * 3 // sha512 3 times.
-	archiveFooterSize    = uint64Size +    // index length
+	archiveFooterSize    = uint64Size + // index length
 		uint32Size + // byte span count
 		uint32Size + // chunk count
 		uint32Size + // metadataSpan length

--- a/go/store/nbs/archive.go
+++ b/go/store/nbs/archive.go
@@ -175,7 +175,7 @@ const (
 	archiveFileSignature = "DOLTARC"
 	archiveFileSigSize   = uint64(len(archiveFileSignature))
 	archiveCheckSumSize  = sha512.Size * 3 // sha512 3 times.
-	archiveFooterSize    = uint64Size + // index length
+	archiveFooterSize    = uint64Size +    // index length
 		uint32Size + // byte span count
 		uint32Size + // chunk count
 		uint32Size + // metadataSpan length

--- a/go/store/nbs/archive_build.go
+++ b/go/store/nbs/archive_build.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -600,7 +601,13 @@ func verifyAllChunks(ctx context.Context, idx tableIndex, archiveFile string, pr
 		return err
 	}
 
-	index, err := newArchiveReader(ctx, fra, uint64(fra.sz), stats)
+	id := strings.TrimSuffix(filepath.Base(archiveFile), ArchiveFileSuffix)
+	name, ok := hash.MaybeParse(id)
+	if !ok {
+		return fmt.Errorf("invalid archive file path: %s", archiveFile)
+	}
+
+	index, err := newArchiveReader(ctx, fra, name, uint64(fra.sz), stats)
 	if err != nil {
 		return err
 	}

--- a/go/store/nbs/archive_reader.go
+++ b/go/store/nbs/archive_reader.go
@@ -576,22 +576,6 @@ func (ar archiveReader) getMetadata(ctx context.Context, stats *Stats) ([]byte, 
 	return ar.readByteSpan(ctx, ar.footer.metadataSpan(), stats)
 }
 
-// verifyDataCheckSum verifies the checksum of the data section of the archive. Note - this requires a fully read of
-// the data section, which could be sizable.
-func (ar archiveReader) verifyDataCheckSum(ctx context.Context, stats *Stats) error {
-	return verifyCheckSum(ctx, ar.reader, ar.footer.dataSpan(), ar.footer.dataCheckSum, stats)
-}
-
-// verifyIndexCheckSum verifies the checksum of the index section of the archive.
-func (ar archiveReader) verifyIndexCheckSum(ctx context.Context, stats *Stats) error {
-	return verifyCheckSum(ctx, ar.reader, ar.footer.totalIndexSpan(), ar.footer.indexCheckSum, stats)
-}
-
-// verifyMetaCheckSum verifies the checksum of the metadata section of the archive.
-func (ar archiveReader) verifyMetaCheckSum(ctx context.Context, stats *Stats) error {
-	return verifyCheckSum(ctx, ar.reader, ar.footer.metadataSpan(), ar.footer.metaCheckSum, stats)
-}
-
 func (ar archiveReader) iterate(ctx context.Context, cb func(chunks.Chunk) error, stats *Stats) error {
 	for i := uint32(0); i < ar.footer.chunkCount; i++ {
 		var hasBytes [hash.ByteLen]byte

--- a/go/store/nbs/archive_writer.go
+++ b/go/store/nbs/archive_writer.go
@@ -385,7 +385,7 @@ func (aw *archiveWriter) writeFooter() error {
 		return err
 	}
 
-	err = aw.writeCheckSums()
+	err = aw.writeEmptyCheckSums()
 	if err != nil {
 		return err
 	}
@@ -410,10 +410,10 @@ func (aw *archiveWriter) writeFooter() error {
 	return nil
 }
 
-// writeCheckSums writes 3 empty sha512 checksum of all zeros to the archive output. This is a hold over from previous
+// writeEmptyCheckSums writes 3 empty sha512 checksum of all zeros to the archive output. This is a hold over from previous
 // versions of the archive format that had checksums for data, index, and metadata. It's easier to keep the data empty
 // data in the index than implement a new format version. We've never used these checksums for anything.
-func (aw *archiveWriter) writeCheckSums() error {
+func (aw *archiveWriter) writeEmptyCheckSums() error {
 	var zeros [(3 * sha512.Size)]byte
 	written, err := aw.output.Write(zeros[:])
 	if err != nil {

--- a/go/store/nbs/archive_writer.go
+++ b/go/store/nbs/archive_writer.go
@@ -27,9 +27,9 @@ import (
 	"sort"
 	"time"
 
-	"github.com/dolthub/dolt/go/cmd/dolt/doltversion"
 	"github.com/dolthub/gozstd"
 
+	"github.com/dolthub/dolt/go/cmd/dolt/doltversion"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
 )

--- a/go/store/nbs/aws_table_persister.go
+++ b/go/store/nbs/aws_table_persister.go
@@ -439,7 +439,12 @@ func dividePlan(ctx context.Context, plan compactionPlan, minPartSize, maxPartSi
 			continue
 		}
 
-		// Now, we need to break the data into some number of parts such that for all parts minPartSize <= size(part) <= maxPartSize. This code tries to split the part evenly, such that all new parts satisfy the previous inequality. This gets tricky around edge cases. Consider min = 5b and max = 10b and a data length of 101b. You need to send 11 parts, but you can't just send 10 parts of 10 bytes and 1 part of 1 byte -- the last is too small. You also can't send 10 parts of 9 bytes each and 1 part of 11 bytes, because the last is too big. You have to distribute the extra bytes across all the parts so that all of them fall into the proper size range.
+		// Now, we need to break the data into some number of parts such that for all parts minPartSize <= size(part) <= maxPartSize.
+		// This code tries to split the part evenly, such that all new parts satisfy the previous inequality. This gets
+		// tricky around edge cases. Consider min = 5b and max = 10b and a data length of 101b. You need to send 11 parts,
+		// but you can't just send 10 parts of 10 bytes and 1 part of 1 byte -- the last is too small. You also can't
+		// send 10 parts of 9 bytes each and 1 part of 11 bytes, because the last is too big. You have to distribute the
+		// extra bytes across all the parts so that all of them fall into the proper size range.
 		lens := splitOnMaxSize(sws.dataLen, maxPartSize)
 
 		var srcStart int64

--- a/go/store/nbs/metadata.go
+++ b/go/store/nbs/metadata.go
@@ -231,13 +231,15 @@ func buildArtifact(ctx context.Context, info TableSpecInfo, genPath string, stat
 			return StorageArtifact{}, err
 		}
 
-		arcMetadata, err := newArchiveMetadata(ctx, fra, uint64(fra.sz), stats)
+		id := hash.Parse(tfName)
+
+		arcMetadata, err := newArchiveMetadata(ctx, fra, id, uint64(fra.sz), stats)
 		if err != nil {
 			return StorageArtifact{}, err
 		}
 
 		return StorageArtifact{
-			id:          hash.Parse(tfName),
+			id:          id,
 			path:        fullPath,
 			storageType: TypeArchive,
 			arcMetadata: arcMetadata,


### PR DESCRIPTION
Mostly refactoring to prepare for archive conjoins.

Main change is dropping the use of checksums for datablocks stored in the archive footer. This path is unworkable with cloud conjoin because we create the index in memory without the datablocks to generate the checksums. This also effects how we name artifacts.