### PR TITLE
disable `only_full_group_by` in sysbench

### DIFF
--- a/go/performance/scripts/local_sysbench.sh
+++ b/go/performance/scripts/local_sysbench.sh
@@ -2,7 +2,7 @@
 set -e
 set -o pipefail
 
-SYSBENCH_TEST="oltp_point_select"
+SYSBENCH_TEST="groupby_scan"
 WORKING_DIR=`mktemp -d`
 PPROF=0
 PORT=3366
@@ -67,6 +67,10 @@ listener:
   tls_key: "./chain_key.pem"
   tls_cert: "./chain_cert.pem"
   require_secure_transport: true
+
+system_variables: {
+  sql_mode: ""
+}
 
 YAML
 

--- a/go/performance/scripts/local_sysbench.sh
+++ b/go/performance/scripts/local_sysbench.sh
@@ -2,7 +2,7 @@
 set -e
 set -o pipefail
 
-SYSBENCH_TEST="groupby_scan"
+SYSBENCH_TEST="oltp_point_select"
 WORKING_DIR=`mktemp -d`
 PPROF=0
 PORT=3366

--- a/go/performance/scripts/local_tpcc.sh
+++ b/go/performance/scripts/local_tpcc.sh
@@ -63,6 +63,10 @@ listener:
   tls_cert: "./chain_cert.pem"
   require_secure_transport: true
 
+system_variables: {
+  sql_mode: ""
+}
+
 YAML
 
 # start a server

--- a/go/performance/utils/benchmark_runner/dolt_server_config.go
+++ b/go/performance/utils/benchmark_runner/dolt_server_config.go
@@ -116,14 +116,16 @@ func (sc *doltServerConfigImpl) GetServerExec() string {
 func (sc *doltServerConfigImpl) GetServerArgs() ([]string, error) {
 	params := make([]string, 0)
 	params = append(params, defaultDoltServerParams...)
-	params = append(params, fmt.Sprintf("%s=%s", configFlag, sc.ConfigFilePath))
-
-	//if sc.Host != "" {
-	//	params = append(params, fmt.Sprintf("%s=%s", hostFlag, sc.Host))
-	//}
-	//if sc.Port != 0 {
-	//	params = append(params, fmt.Sprintf("%s=%d", portFlag, sc.Port))
-	//}
+	if sc.ConfigFilePath != "" {
+		params = append(params, fmt.Sprintf("%s=%s", configFlag, sc.ConfigFilePath))
+	} else {
+		if sc.Host != "" {
+			params = append(params, fmt.Sprintf("%s=%s", hostFlag, sc.Host))
+		}
+		if sc.Port != 0 {
+			params = append(params, fmt.Sprintf("%s=%d", portFlag, sc.Port))
+		}
+	}
 
 	params = append(params, sc.ServerArgs...)
 	return params, nil
@@ -158,9 +160,6 @@ func (sc *doltServerConfigImpl) Validate() error {
 		if sc.ServerProfile != CpuServerProfile {
 			return fmt.Errorf("unsupported server profile: %s", sc.ServerProfile)
 		}
-	}
-	if sc.ConfigFilePath == "" {
-		return getMustSupplyError("config file path")
 	}
 	return CheckExec(sc.ServerExec, "server exec")
 }

--- a/go/performance/utils/benchmark_runner/results_test.go
+++ b/go/performance/utils/benchmark_runner/results_test.go
@@ -320,6 +320,48 @@ func TestFromOutputResults(t *testing.T) {
 				LatencySumMS:             10000.87,
 			},
 		},
+		{
+			description: "should parse with config provided",
+			output:      []byte(sampleOutput1),
+			config: &sysbenchRunnerConfigImpl{
+				RuntimeOS:     testOS,
+				RuntimeGoArch: testGoArch,
+			},
+			serverConfig: &doltServerConfigImpl{
+				Version:        testServerVersion,
+				ServerExec:     "test-exec",
+				ConfigFilePath: "config.yaml",
+			},
+			test: &sysbenchTestImpl{
+				Name:   testTestName,
+				Params: params,
+			},
+			expectedResult: &Result{
+				Id:                       testId,
+				SuiteId:                  testSuiteId,
+				RuntimeOS:                testOS,
+				RuntimeGoArch:            testGoArch,
+				ServerName:               string(Dolt),
+				ServerParams:             strings.Join(append(defaultDoltServerParams, fmt.Sprintf("%s=%s", configFlag, "config.yaml")), " "),
+				ServerVersion:            testServerVersion,
+				TestName:                 testTestName,
+				TestParams:               testTestParams,
+				SqlReadQueries:           9464,
+				SqlWriteQueries:          0,
+				SqlOtherQueries:          1352,
+				SqlTotalQueries:          10816,
+				SqlTotalQueriesPerSecond: 1081.14,
+				TransactionsTotal:        676,
+				TransactionsPerSecond:    67.57,
+				TotalTimeSeconds:         10.0030,
+				TotalNumberOfEvents:      676,
+				LatencyMinMS:             12.26,
+				LatencyAvgMS:             14.79,
+				LatencyMaxMS:             26.08,
+				LatencyPercentile:        17.01,
+				LatencySumMS:             10000.87,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/go/performance/utils/benchmark_runner/run_test.go
+++ b/go/performance/utils/benchmark_runner/run_test.go
@@ -42,7 +42,7 @@ var tpccLuaScripts = os.Getenv("BENCHMARK_RUNNER_TPCC_LUA_SCRIPTS")
 
 func TestRunner(t *testing.T) {
 	if runTests == "" {
-		//t.Skip()
+		t.Skip()
 	}
 	dir := t.TempDir()
 	log.Println(dir)

--- a/go/performance/utils/benchmark_runner/run_test.go
+++ b/go/performance/utils/benchmark_runner/run_test.go
@@ -42,7 +42,7 @@ var tpccLuaScripts = os.Getenv("BENCHMARK_RUNNER_TPCC_LUA_SCRIPTS")
 
 func TestRunner(t *testing.T) {
 	if runTests == "" {
-		t.Skip()
+		//t.Skip()
 	}
 	dir := t.TempDir()
 	log.Println(dir)


### PR DESCRIPTION
Since our group validation much more closely aligns with MySQL, we discovered that sysbench script `groupby_scan.lua` is not valid in MySQL without disabling `ONLY_FULL_GROUP_BY` in `sql_mode`. This PR fixes the local test scripts and the benchmark runners to accept a `config.yaml` with the `sql_mode` set.