### PR TITLE
[no-release-notes] Add CompressedSize method to ToChunker

### DIFF
--- a/go/store/nbs/archive_chunker.go
+++ b/go/store/nbs/archive_chunker.go
@@ -99,3 +99,8 @@ func (a ArchiveToChunker) IsGhost() bool {
 	// archives are never ghosts. They are only instantiated when the chunk is found.
 	return false
 }
+
+// CompressedSize returns the size of the compressed chunk data, but does not include the size of the dictionary.
+func (a ArchiveToChunker) CompressedSize() uint32 {
+	return uint32(len(a.chunkData))
+}

--- a/go/store/nbs/table_reader.go
+++ b/go/store/nbs/table_reader.go
@@ -42,6 +42,7 @@ type ToChunker interface {
 	Hash() hash.Hash
 	ToChunk() (chunks.Chunk, error)
 	IsEmpty() bool
+	CompressedSize() uint32
 	IsGhost() bool
 }
 
@@ -118,9 +119,9 @@ func (cmp CompressedChunk) IsGhost() bool {
 	return cmp.ghost
 }
 
-// CompressedSize returns the size of this CompressedChunk.
-func (cmp CompressedChunk) CompressedSize() int {
-	return len(cmp.CompressedData)
+// CompressedSize returns on disk size of the compressed chunk. Includes crc.
+func (cmp CompressedChunk) CompressedSize() uint32 {
+	return uint32(len(cmp.FullCompressedChunk))
 }
 
 var EmptyCompressedChunk CompressedChunk


### PR DESCRIPTION
This interface enables us to use ToChunker instances in the chunk cache of doltremoteapi (LD change staged depends on this)

Worth calling out that the CompressedSize() method on CompressedChunks wasn't called by anyone. It's new behavior will return a different value that it would before (+4 bytes).