### PR TITLE
support `mcp_server` in the the `dolt sql-server` configuration file

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/command_line_config.go
+++ b/go/cmd/dolt/commands/sqlserver/command_line_config.go
@@ -63,6 +63,18 @@ type commandLineServerConfig struct {
 
 var _ servercfg.ServerConfig = (*commandLineServerConfig)(nil)
 
+// MCPPort returns nil for command-line config, which does not persist MCP settings.
+func (cfg *commandLineServerConfig) MCPPort() *int { return nil }
+
+// MCPUser returns nil for command-line config.
+func (cfg *commandLineServerConfig) MCPUser() *string { return nil }
+
+// MCPPassword returns nil for command-line config.
+func (cfg *commandLineServerConfig) MCPPassword() *string { return nil }
+
+// MCPDatabase returns nil for command-line config.
+func (cfg *commandLineServerConfig) MCPDatabase() *string { return nil }
+
 // DefaultCommandLineServerConfig creates a `*ServerConfig` that has all of the options set to their default values.
 func DefaultCommandLineServerConfig() *commandLineServerConfig {
 	return &commandLineServerConfig{

--- a/go/cmd/dolt/commands/sqlserver/server_test.go
+++ b/go/cmd/dolt/commands/sqlserver/server_test.go
@@ -665,6 +665,12 @@ listener:
   # port: 8000
   # read_only: false
 
+# mcp_server:
+  # port: 7007
+  # user: root
+  # password: ""
+  # database: ""
+
 # privilege_file: ` + privilegeFilePath +
 		`
 

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -305,45 +305,19 @@ func StartServer(ctx context.Context, versionStr, commandStr string, args []stri
 	// Validate and prepare MCP options in dedicated helper
 	// Fill MCP options from YAML config (if present) for any unset CLI values.
 	// CLI always has precedence over config file.
-	switch cfg := serverConfig.(type) {
-	case servercfg.YAMLConfig:
-		if cfg.MCPServer != nil {
-			if mcpPortPtr == nil && cfg.MCPServer.Port != nil {
-				m := *cfg.MCPServer.Port
-				mcpPortPtr = &m
-			}
-			if mcpUserPtr == nil && cfg.MCPServer.User != nil {
-				u := *cfg.MCPServer.User
-				mcpUserPtr = &u
-			}
-			if mcpPasswordPtr == nil && cfg.MCPServer.Password != nil {
-				p := *cfg.MCPServer.Password
-				mcpPasswordPtr = &p
-			}
-			if mcpDatabasePtr == nil && cfg.MCPServer.Database != nil {
-				d := *cfg.MCPServer.Database
-				mcpDatabasePtr = &d
-			}
-		}
-	case *servercfg.YAMLConfig:
-		if cfg != nil && cfg.MCPServer != nil {
-			if mcpPortPtr == nil && cfg.MCPServer.Port != nil {
-				m := *cfg.MCPServer.Port
-				mcpPortPtr = &m
-			}
-			if mcpUserPtr == nil && cfg.MCPServer.User != nil {
-				u := *cfg.MCPServer.User
-				mcpUserPtr = &u
-			}
-			if mcpPasswordPtr == nil && cfg.MCPServer.Password != nil {
-				p := *cfg.MCPServer.Password
-				mcpPasswordPtr = &p
-			}
-			if mcpDatabasePtr == nil && cfg.MCPServer.Database != nil {
-				d := *cfg.MCPServer.Database
-				mcpDatabasePtr = &d
-			}
-		}
+
+	// Prefer CLI values; fall back to ServerConfig interface (e.g., YAML config)
+	if mcpPortPtr == nil {
+		mcpPortPtr = serverConfig.MCPPort()
+	}
+	if mcpUserPtr == nil {
+		mcpUserPtr = serverConfig.MCPUser()
+	}
+	if mcpPasswordPtr == nil {
+		mcpPasswordPtr = serverConfig.MCPPassword()
+	}
+	if mcpDatabasePtr == nil {
+		mcpDatabasePtr = serverConfig.MCPDatabase()
 	}
 	if err := validateAndPrepareMCP(serverConfig, mcpPortPtr, mcpUserPtr, mcpPasswordPtr, mcpDatabasePtr); err != nil {
 		return err

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -303,6 +303,48 @@ func StartServer(ctx context.Context, versionStr, commandStr string, args []stri
 	}
 
 	// Validate and prepare MCP options in dedicated helper
+	// Fill MCP options from YAML config (if present) for any unset CLI values.
+	// CLI always has precedence over config file.
+	switch cfg := serverConfig.(type) {
+	case servercfg.YAMLConfig:
+		if cfg.MCPServer != nil {
+			if mcpPortPtr == nil && cfg.MCPServer.Port != nil {
+				m := *cfg.MCPServer.Port
+				mcpPortPtr = &m
+			}
+			if mcpUserPtr == nil && cfg.MCPServer.User != nil {
+				u := *cfg.MCPServer.User
+				mcpUserPtr = &u
+			}
+			if mcpPasswordPtr == nil && cfg.MCPServer.Password != nil {
+				p := *cfg.MCPServer.Password
+				mcpPasswordPtr = &p
+			}
+			if mcpDatabasePtr == nil && cfg.MCPServer.Database != nil {
+				d := *cfg.MCPServer.Database
+				mcpDatabasePtr = &d
+			}
+		}
+	case *servercfg.YAMLConfig:
+		if cfg != nil && cfg.MCPServer != nil {
+			if mcpPortPtr == nil && cfg.MCPServer.Port != nil {
+				m := *cfg.MCPServer.Port
+				mcpPortPtr = &m
+			}
+			if mcpUserPtr == nil && cfg.MCPServer.User != nil {
+				u := *cfg.MCPServer.User
+				mcpUserPtr = &u
+			}
+			if mcpPasswordPtr == nil && cfg.MCPServer.Password != nil {
+				p := *cfg.MCPServer.Password
+				mcpPasswordPtr = &p
+			}
+			if mcpDatabasePtr == nil && cfg.MCPServer.Database != nil {
+				d := *cfg.MCPServer.Database
+				mcpDatabasePtr = &d
+			}
+		}
+	}
 	if err := validateAndPrepareMCP(serverConfig, mcpPortPtr, mcpUserPtr, mcpPasswordPtr, mcpDatabasePtr); err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/servercfg/serverconfig.go
+++ b/go/libraries/doltcore/servercfg/serverconfig.go
@@ -214,6 +214,14 @@ type ServerConfig interface {
 	RemotesapiPort() *int
 	// RemotesapiReadOnly is true if the remotesapi interface should be read only.
 	RemotesapiReadOnly() *bool
+	// MCPPort returns the port for the MCP HTTP server if configured.
+	MCPPort() *int
+	// MCPUser returns the SQL user MCP should connect as if configured.
+	MCPUser() *string
+	// MCPPassword returns the SQL password MCP should use if configured.
+	MCPPassword() *string
+	// MCPDatabase returns the SQL database name MCP should connect to if configured.
+	MCPDatabase() *string
 	// ClusterConfig is the configuration for clustering in this sql-server.
 	ClusterConfig() ClusterConfig
 	// EventSchedulerStatus is the configuration for enabling or disabling the event scheduler in this server.

--- a/go/libraries/doltcore/servercfg/serverconfig.go
+++ b/go/libraries/doltcore/servercfg/serverconfig.go
@@ -70,6 +70,7 @@ const (
 	DefaultBranchControlFilePath     = "branch_control.db"
 	DefaultMetricsHost               = ""
 	DefaultMetricsPort               = -1
+	DefaultMCPPort                   = 7007
 	DefaultAllowCleartextPasswords   = false
 	DefaultMySQLUnixSocketFilePath   = "/tmp/mysql.sock"
 	DefaultMaxLoggedQueryLen         = 0

--- a/go/libraries/doltcore/servercfg/testdata/minver_validation.txt
+++ b/go/libraries/doltcore/servercfg/testdata/minver_validation.txt
@@ -38,6 +38,11 @@ CfgDirStr *string 0.0.0 cfg_dir,omitempty
 RemotesapiConfig servercfg.RemotesapiYAMLConfig 0.0.0 remotesapi,omitempty
 -Port_ *int 0.0.0 port,omitempty
 -ReadOnly_ *bool 1.30.5 read_only,omitempty
+MCPServer *servercfg.MCPServerYAMLConfig TBD mcp_server,omitempty
+-Port *int 0.0.0 port,omitempty
+-User *string 0.0.0 user,omitempty
+-Password *string 0.0.0 password,omitempty
+-Database *string 0.0.0 database,omitempty
 PrivilegeFile *string 0.0.0 privilege_file,omitempty
 BranchControlFile *string 0.0.0 branch_control_file,omitempty
 Vars []servercfg.UserSessionVars 0.0.0 user_session_vars

--- a/go/libraries/doltcore/servercfg/yaml_config.go
+++ b/go/libraries/doltcore/servercfg/yaml_config.go
@@ -755,7 +755,7 @@ func (cfg YAMLConfig) RemotesapiReadOnly() *bool {
 // MCPPort returns the configured MCP HTTP port, if any.
 func (cfg YAMLConfig) MCPPort() *int {
 	if cfg.MCPServer == nil {
-		return ptr(DefaultMCPPort)
+		return nil
 	}
 	return cfg.MCPServer.Port
 }
@@ -763,7 +763,7 @@ func (cfg YAMLConfig) MCPPort() *int {
 // MCPUser returns the configured MCP SQL user, if any.
 func (cfg YAMLConfig) MCPUser() *string {
 	if cfg.MCPServer == nil {
-		return ptr(DefaultUser)
+		return nil
 	}
 	return cfg.MCPServer.User
 }

--- a/go/libraries/doltcore/servercfg/yaml_config.go
+++ b/go/libraries/doltcore/servercfg/yaml_config.go
@@ -130,7 +130,6 @@ type MCPServerYAMLConfig struct {
 	Database *string `yaml:"database,omitempty"`
 }
 
-
 type UserSessionVars struct {
 	Name string                 `yaml:"name"`
 	Vars map[string]interface{} `yaml:"vars"`
@@ -751,6 +750,38 @@ func (cfg YAMLConfig) RemotesapiPort() *int {
 
 func (cfg YAMLConfig) RemotesapiReadOnly() *bool {
 	return cfg.RemotesapiConfig.ReadOnly_
+}
+
+// MCPPort returns the configured MCP HTTP port, if any.
+func (cfg YAMLConfig) MCPPort() *int {
+	if cfg.MCPServer == nil {
+		return nil
+	}
+	return cfg.MCPServer.Port
+}
+
+// MCPUser returns the configured MCP SQL user, if any.
+func (cfg YAMLConfig) MCPUser() *string {
+	if cfg.MCPServer == nil {
+		return nil
+	}
+	return cfg.MCPServer.User
+}
+
+// MCPPassword returns the configured MCP SQL password, if any.
+func (cfg YAMLConfig) MCPPassword() *string {
+	if cfg.MCPServer == nil {
+		return nil
+	}
+	return cfg.MCPServer.Password
+}
+
+// MCPDatabase returns the configured MCP SQL database, if any.
+func (cfg YAMLConfig) MCPDatabase() *string {
+	if cfg.MCPServer == nil {
+		return nil
+	}
+	return cfg.MCPServer.Database
 }
 
 // PrivilegeFilePath returns the path to the file which contains all needed privilege information in the form of a

--- a/go/libraries/doltcore/servercfg/yaml_config.go
+++ b/go/libraries/doltcore/servercfg/yaml_config.go
@@ -406,6 +406,15 @@ func (cfg YAMLConfig) withPlaceholdersFilledIn() YAMLConfig {
 		withPlaceholders.RemotesapiConfig.ReadOnly_ = ptr(false)
 	}
 
+	// MCP server placeholders: show keys and example values in generated config
+	if withPlaceholders.MCPServer == nil {
+		withPlaceholders.MCPServer = &MCPServerYAMLConfig{
+			Port:     ptr(8080),
+			User:     ptr("root"),
+			Password: ptr(""),
+			Database: ptr(""),
+		}
+	}
 	if withPlaceholders.ClusterCfg == nil {
 		withPlaceholders.ClusterCfg = &ClusterYAMLConfig{
 			StandbyRemotes_: []StandbyRemoteYAMLConfig{

--- a/go/libraries/doltcore/servercfg/yaml_config.go
+++ b/go/libraries/doltcore/servercfg/yaml_config.go
@@ -409,7 +409,7 @@ func (cfg YAMLConfig) withPlaceholdersFilledIn() YAMLConfig {
 	// MCP server placeholders: show keys and example values in generated config
 	if withPlaceholders.MCPServer == nil {
 		withPlaceholders.MCPServer = &MCPServerYAMLConfig{
-			Port:     ptr(8080),
+			Port:     ptr(7007),
 			User:     ptr("root"),
 			Password: ptr(""),
 			Database: ptr(""),

--- a/go/libraries/doltcore/servercfg/yaml_config.go
+++ b/go/libraries/doltcore/servercfg/yaml_config.go
@@ -148,7 +148,7 @@ type YAMLConfig struct {
 	DataDirStr        *string                `yaml:"data_dir,omitempty"`
 	CfgDirStr         *string                `yaml:"cfg_dir,omitempty"`
 	RemotesapiConfig  RemotesapiYAMLConfig   `yaml:"remotesapi,omitempty"`
-	MCPServer         *MCPServerYAMLConfig   `yaml:"mcp_server,omitempty"`
+	MCPServer         *MCPServerYAMLConfig   `yaml:"mcp_server,omitempty" minver:"TBD"`
 	PrivilegeFile     *string                `yaml:"privilege_file,omitempty"`
 	BranchControlFile *string                `yaml:"branch_control_file,omitempty"`
 	// TODO: Rename to UserVars_

--- a/go/libraries/doltcore/servercfg/yaml_config.go
+++ b/go/libraries/doltcore/servercfg/yaml_config.go
@@ -122,6 +122,15 @@ func (r RemotesapiYAMLConfig) ReadOnly() bool {
 	return *r.ReadOnly_
 }
 
+// MCPServerYAMLConfig contains configuration for running an MCP HTTP server alongside sql-server
+type MCPServerYAMLConfig struct {
+	Port     *int    `yaml:"port,omitempty"`
+	User     *string `yaml:"user,omitempty"`
+	Password *string `yaml:"password,omitempty"`
+	Database *string `yaml:"database,omitempty"`
+}
+
+
 type UserSessionVars struct {
 	Name string                 `yaml:"name"`
 	Vars map[string]interface{} `yaml:"vars"`
@@ -140,6 +149,7 @@ type YAMLConfig struct {
 	DataDirStr        *string                `yaml:"data_dir,omitempty"`
 	CfgDirStr         *string                `yaml:"cfg_dir,omitempty"`
 	RemotesapiConfig  RemotesapiYAMLConfig   `yaml:"remotesapi,omitempty"`
+	MCPServer         *MCPServerYAMLConfig   `yaml:"mcp_server,omitempty"`
 	PrivilegeFile     *string                `yaml:"privilege_file,omitempty"`
 	BranchControlFile *string                `yaml:"branch_control_file,omitempty"`
 	// TODO: Rename to UserVars_

--- a/go/libraries/doltcore/servercfg/yaml_config.go
+++ b/go/libraries/doltcore/servercfg/yaml_config.go
@@ -755,7 +755,8 @@ func (cfg YAMLConfig) RemotesapiReadOnly() *bool {
 // MCPPort returns the configured MCP HTTP port, if any.
 func (cfg YAMLConfig) MCPPort() *int {
 	if cfg.MCPServer == nil {
-		return nil
+		port := DefaultMCPPort
+		return &port
 	}
 	return cfg.MCPServer.Port
 }
@@ -763,7 +764,8 @@ func (cfg YAMLConfig) MCPPort() *int {
 // MCPUser returns the configured MCP SQL user, if any.
 func (cfg YAMLConfig) MCPUser() *string {
 	if cfg.MCPServer == nil {
-		return nil
+		user := DefaultUser
+		return &user
 	}
 	return cfg.MCPServer.User
 }

--- a/go/libraries/doltcore/servercfg/yaml_config.go
+++ b/go/libraries/doltcore/servercfg/yaml_config.go
@@ -408,8 +408,8 @@ func (cfg YAMLConfig) withPlaceholdersFilledIn() YAMLConfig {
 	// MCP server placeholders: show keys and example values in generated config
 	if withPlaceholders.MCPServer == nil {
 		withPlaceholders.MCPServer = &MCPServerYAMLConfig{
-			Port:     ptr(7007),
-			User:     ptr("root"),
+			Port:     ptr(DefaultMCPPort),
+			User:     ptr(DefaultUser),
 			Password: ptr(""),
 			Database: ptr(""),
 		}
@@ -755,8 +755,7 @@ func (cfg YAMLConfig) RemotesapiReadOnly() *bool {
 // MCPPort returns the configured MCP HTTP port, if any.
 func (cfg YAMLConfig) MCPPort() *int {
 	if cfg.MCPServer == nil {
-		port := DefaultMCPPort
-		return &port
+		return ptr(DefaultMCPPort)
 	}
 	return cfg.MCPServer.Port
 }
@@ -764,8 +763,7 @@ func (cfg YAMLConfig) MCPPort() *int {
 // MCPUser returns the configured MCP SQL user, if any.
 func (cfg YAMLConfig) MCPUser() *string {
 	if cfg.MCPServer == nil {
-		user := DefaultUser
-		return &user
+		return ptr(DefaultUser)
 	}
 	return cfg.MCPServer.User
 }

--- a/integration-tests/bats/sql-server-mcp-config.bats
+++ b/integration-tests/bats/sql-server-mcp-config.bats
@@ -1,0 +1,181 @@
+#!/usr/bin/env bats
+load $BATS_TEST_DIRNAME/helper/common.bash
+load $BATS_TEST_DIRNAME/helper/query-server-common.bash
+
+make_repo() {
+  mkdir "$1"
+  cd "$1"
+  dolt init
+  cd ..
+}
+
+setup() {
+  skiponwindows "tests are flaky on Windows"
+  setup_no_dolt_init
+  make_repo repo1
+}
+
+teardown() {
+  stop_sql_server 1 && sleep 0.5
+  rm -rf $BATS_TMPDIR/sql-server-mcp-config-test$$
+  teardown_common
+}
+
+# Helper: wait for an MCP HTTP server to accept TCP connections on the given port
+# wait_for_mcp_port <PORT> <TIMEOUT_MS>
+wait_for_mcp_port() {
+  port=$1
+  timeout_ms=$2
+  end_time=$((SECONDS+($timeout_ms/1000)))
+  while [ $SECONDS -lt $end_time ]; do
+    nc -z localhost "$port" >/dev/null 2>&1 && return 0
+    sleep 1
+  done
+  return 1
+}
+
+@test "sql-server-mcp-config: starts MCP via config file mcp_server" {
+  skip "MCP YAML config (mcp_server) not implemented yet"
+  cd repo1
+
+  SQL_PORT=$( definePORT )
+  MCP_PORT=$( definePORT )
+
+  # Prepare config that includes an mcp_server section
+  cat > config.yml <<EOF2
+listener:
+  host: "0.0.0.0"
+  port: ${SQL_PORT}
+
+mcp_server:
+  port: ${MCP_PORT}
+  user: root
+EOF2
+
+  # Start server from config file
+  if [ "$IS_WINDOWS" == true ]; then
+    PORT=$SQL_PORT dolt sql-server --config ./config.yml &
+  else
+    PORT=$SQL_PORT dolt sql-server --config ./config.yml --socket "dolt.$SQL_PORT.sock" &
+  fi
+  SERVER_PID=$!
+
+  # Wait for MCP to open
+  run wait_for_mcp_port "$MCP_PORT" 8500
+  [ $status -eq 0 ]
+}
+
+@test "sql-server-mcp-config: mcp_server.database selects DB for MCP connection" {
+  skip "MCP YAML config (mcp_server) not implemented yet"
+  cd repo1
+
+  dolt sql -q "CREATE DATABASE mcpdb"
+
+  SQL_PORT=$( definePORT )
+  MCP_PORT=$( definePORT )
+
+  cat > config.yml <<EOF2
+listener:
+  host: "0.0.0.0"
+  port: ${SQL_PORT}
+
+mcp_server:
+  port: ${MCP_PORT}
+  user: root
+  database: mcpdb
+EOF2
+
+  if [ "$IS_WINDOWS" == true ]; then
+    PORT=$SQL_PORT dolt sql-server --config ./config.yml &
+  else
+    PORT=$SQL_PORT dolt sql-server --config ./config.yml --socket "dolt.$SQL_PORT.sock" &
+  fi
+  SERVER_PID=$!
+
+  run wait_for_mcp_port "$MCP_PORT" 8500
+  [ $status -eq 0 ]
+
+  # Optionally initialize and call a primitive tool endpoint via HTTP
+  if command -v curl >/dev/null 2>&1; then
+    INIT_FILE=$BATS_TMPDIR/mcp_init_cfgdb_$$.json
+    OUT_INIT=$BATS_TMPDIR/mcp_out_init_cfgdb_$$.json
+    echo '{"jsonrpc":"2.0","id":"1","method":"initialize","params":{"clientInfo":{"name":"bats","version":"0.0.0"},"capabilities":{}}}' > "$INIT_FILE"
+    run bash -c "curl -sS -D $BATS_TMPDIR/mcp_headers_cfgdb_$$.txt -H 'Content-Type: application/json' --data-binary @'$INIT_FILE' http://127.0.0.1:${MCP_PORT}/ > '$OUT_INIT'"
+    [ $status -eq 0 ]
+
+    SESSION=$(grep -i '^Mcp-Session-Id:' $BATS_TMPDIR/mcp_headers_cfgdb_$$.txt | awk -F': ' '{print $2}' | tr -d '\r')
+    [ -n "$SESSION" ]
+
+    CALL_FILE=$BATS_TMPDIR/mcp_call_cfgdb_$$.json
+    OUT_CALL=$BATS_TMPDIR/mcp_out_call_cfgdb_$$.json
+    echo '{"jsonrpc":"2.0","id":"2","method":"tools/call","params":{"name":"list_databases","arguments":{}}}' > "$CALL_FILE"
+    run bash -c "curl -sS -H 'Content-Type: application/json' -H 'Mcp-Session-Id: '$SESSION --data-binary @'$CALL_FILE' http://127.0.0.1:${MCP_PORT}/ > '$OUT_CALL'"
+    [ $status -eq 0 ]
+    run grep -E "mcpdb" "$OUT_CALL"
+    [ $status -eq 0 ]
+  fi
+}
+
+@test "sql-server-mcp-config: missing mcp_server.user with mcp_server.port fails" {
+  skip "MCP YAML config (mcp_server) not implemented yet"
+  cd repo1
+
+  SQL_PORT=$( definePORT )
+  MCP_PORT=$( definePORT )
+
+  cat > config.yml <<EOF2
+listener:
+  host: "0.0.0.0"
+  port: ${SQL_PORT}
+
+mcp_server:
+  port: ${MCP_PORT}
+  # user intentionally omitted
+EOF2
+
+  if [ "$IS_WINDOWS" == true ]; then
+    run env PORT=$SQL_PORT dolt sql-server --config ./config.yml
+  else
+    run env PORT=$SQL_PORT dolt sql-server --config ./config.yml --socket "dolt.$SQL_PORT.sock"
+  fi
+  [ $status -ne 0 ]
+}
+
+@test "sql-server-mcp-config: CLI flags override config mcp_server" {
+  skip "MCP YAML config (mcp_server) not implemented yet"
+  cd repo1
+
+  SQL_PORT=$( definePORT )
+  MCP_PORT_YAML=$( definePORT )
+  MCP_PORT_CLI=$( definePORT )
+
+  # Write config with one MCP port
+  cat > config.yml <<EOF2
+listener:
+  host: "0.0.0.0"
+  port: ${SQL_PORT}
+
+mcp_server:
+  port: ${MCP_PORT_YAML}
+  user: root
+EOF2
+
+  # Start with CLI override for MCP port
+  if [ "$IS_WINDOWS" == true ]; then
+    PORT=$SQL_PORT dolt sql-server --config ./config.yml --mcp-port ${MCP_PORT_CLI} --mcp-user root &
+  else
+    PORT=$SQL_PORT dolt sql-server --config ./config.yml --socket "dolt.$SQL_PORT.sock" --mcp-port ${MCP_PORT_CLI} --mcp-user root &
+  fi
+  SERVER_PID=$!
+
+  # SQL should accept connections
+  run wait_for_connection $SQL_PORT 8500
+  [ $status -eq 0 ]
+
+  # MCP should be listening on CLI port, not YAML port
+  run wait_for_mcp_port "$MCP_PORT_CLI" 8500
+  [ $status -eq 0 ]
+
+  run nc -z localhost "$MCP_PORT_YAML"
+  [ $status -ne 0 ]
+}

--- a/integration-tests/bats/sql-server-mcp-config.bats
+++ b/integration-tests/bats/sql-server-mcp-config.bats
@@ -35,7 +35,6 @@ wait_for_mcp_port() {
 }
 
 @test "sql-server-mcp-config: starts MCP via config file mcp_server" {
-  # skip "MCP YAML config (mcp_server) not implemented yet"
   cd repo1
 
   SQL_PORT=$( definePORT )
@@ -66,7 +65,6 @@ EOF2
 }
 
 @test "sql-server-mcp-config: mcp_server.database selects DB for MCP connection" {
-  # skip "MCP YAML config (mcp_server) not implemented yet"
   cd repo1
 
   dolt sql -q "CREATE DATABASE mcpdb"
@@ -117,7 +115,6 @@ EOF2
 }
 
 @test "sql-server-mcp-config: missing mcp_server.user with mcp_server.port fails" {
-  # skip "MCP YAML config (mcp_server) not implemented yet"
   cd repo1
 
   SQL_PORT=$( definePORT )
@@ -142,7 +139,6 @@ EOF2
 }
 
 @test "sql-server-mcp-config: CLI flags override config mcp_server" {
-  # skip "MCP YAML config (mcp_server) not implemented yet"
   cd repo1
 
   SQL_PORT=$( definePORT )

--- a/integration-tests/bats/sql-server-mcp-config.bats
+++ b/integration-tests/bats/sql-server-mcp-config.bats
@@ -35,7 +35,7 @@ wait_for_mcp_port() {
 }
 
 @test "sql-server-mcp-config: starts MCP via config file mcp_server" {
-  skip "MCP YAML config (mcp_server) not implemented yet"
+  # skip "MCP YAML config (mcp_server) not implemented yet"
   cd repo1
 
   SQL_PORT=$( definePORT )
@@ -66,7 +66,7 @@ EOF2
 }
 
 @test "sql-server-mcp-config: mcp_server.database selects DB for MCP connection" {
-  skip "MCP YAML config (mcp_server) not implemented yet"
+  # skip "MCP YAML config (mcp_server) not implemented yet"
   cd repo1
 
   dolt sql -q "CREATE DATABASE mcpdb"
@@ -117,7 +117,7 @@ EOF2
 }
 
 @test "sql-server-mcp-config: missing mcp_server.user with mcp_server.port fails" {
-  skip "MCP YAML config (mcp_server) not implemented yet"
+  # skip "MCP YAML config (mcp_server) not implemented yet"
   cd repo1
 
   SQL_PORT=$( definePORT )
@@ -142,7 +142,7 @@ EOF2
 }
 
 @test "sql-server-mcp-config: CLI flags override config mcp_server" {
-  skip "MCP YAML config (mcp_server) not implemented yet"
+  # skip "MCP YAML config (mcp_server) not implemented yet"
   cd repo1
 
   SQL_PORT=$( definePORT )

--- a/integration-tests/bats/sql-server-mcp-config.bats
+++ b/integration-tests/bats/sql-server-mcp-config.bats
@@ -136,6 +136,9 @@ EOF2
     run env PORT=$SQL_PORT dolt sql-server --config ./config.yml --socket "dolt.$SQL_PORT.sock"
   fi
   [ $status -ne 0 ]
+  # Verify error message surfaced to the user
+  log_output_has "--mcp-user is required when --mcp-port is specified"
+
 }
 
 @test "sql-server-mcp-config: CLI flags override config mcp_server" {

--- a/integration-tests/bats/sql-server-mcp-config.bats
+++ b/integration-tests/bats/sql-server-mcp-config.bats
@@ -94,7 +94,7 @@ EOF2
   [ $status -eq 0 ]
 
   # Optionally initialize and call a primitive tool endpoint via HTTP
-  if command -v curl >/dev/null 2>&1; then
+  if [ "$IS_WINDOWS" != true ]; then
     INIT_FILE=$BATS_TMPDIR/mcp_init_cfgdb_$$.json
     OUT_INIT=$BATS_TMPDIR/mcp_out_init_cfgdb_$$.json
     echo '{"jsonrpc":"2.0","id":"1","method":"initialize","params":{"clientInfo":{"name":"bats","version":"0.0.0"},"capabilities":{}}}' > "$INIT_FILE"


### PR DESCRIPTION
This PR is part two of supporting mcp directly in Dolt. This one adds the `mcp_server` key to the `dolt sql-server` `config.yaml`, allowing users to start/configure the http dolt-mcp server here, instead of only with cli arguments. If both the config file defines `mcp_server` and mcp related cli arguments are supplied, the cli args take precendence over the config file definitions.