### PR TITLE
Optimize commit iterator

### DIFF
--- a/go/cmd/dolt/commands/archive.go
+++ b/go/cmd/dolt/commands/archive.go
@@ -250,7 +250,7 @@ func historicalFuzzyMatching(ctx context.Context, heads hash.HashSet, groupings 
 		return err
 	}
 	for {
-		h, _, err := iterator.Next(ctx)
+		h, _, _, _, err := iterator.Next(ctx)
 		if err != nil {
 			if err == io.EOF {
 				break

--- a/go/libraries/doltcore/doltdb/commit_itr.go
+++ b/go/libraries/doltcore/doltdb/commit_itr.go
@@ -30,7 +30,7 @@ import (
 type CommitItr[C Context] interface {
 	// Next returns the hash of the next commit, and a pointer to that commit.  Implementations of Next must handle
 	// making sure the list of commits returned are unique.  When complete Next will return hash.Hash{}, nil, io.EOF
-	Next(ctx C) (hash.Hash, *OptionalCommit, error)
+	Next(ctx C) (hash.Hash, *OptionalCommit, *datas.CommitMeta, uint64, error)
 
 	// Reset the commit iterator back to the start
 	Reset(ctx context.Context) error
@@ -90,23 +90,23 @@ func (cmItr *commitItr[C]) Reset(ctx context.Context) error {
 
 // Next returns the hash of the next commit, and a pointer to that commit.  It handles making sure the list of commits
 // returned are unique.  When complete Next will return hash.Hash{}, nil, io.EOF
-func (cmItr *commitItr[C]) Next(ctx C) (hash.Hash, *OptionalCommit, error) {
+func (cmItr *commitItr[C]) Next(ctx C) (hash.Hash, *OptionalCommit, *datas.CommitMeta, uint64, error) {
 	for cmItr.curr == nil {
 		if cmItr.currentRoot >= len(cmItr.rootCommits) {
-			return hash.Hash{}, nil, io.EOF
+			return hash.Hash{}, nil, nil, 0, io.EOF
 		}
 
 		cm := cmItr.rootCommits[cmItr.currentRoot]
 		h, err := cm.HashOf()
 
 		if err != nil {
-			return hash.Hash{}, nil, err
+			return hash.Hash{}, nil, nil, 0, err
 		}
 
 		if !cmItr.added[h] {
 			cmItr.added[h] = true
 			cmItr.curr = cm
-			return h, &OptionalCommit{cmItr.curr, h}, nil
+			return h, &OptionalCommit{cmItr.curr, h}, nil, 0, nil
 		}
 
 		cmItr.currentRoot++
@@ -115,7 +115,7 @@ func (cmItr *commitItr[C]) Next(ctx C) (hash.Hash, *OptionalCommit, error) {
 	parents, err := cmItr.curr.ParentHashes(ctx)
 
 	if err != nil {
-		return hash.Hash{}, nil, err
+		return hash.Hash{}, nil, nil, 0, err
 	}
 
 	for _, h := range parents {
@@ -137,13 +137,13 @@ func (cmItr *commitItr[C]) Next(ctx C) (hash.Hash, *OptionalCommit, error) {
 	cmItr.unprocessed = cmItr.unprocessed[:numUnprocessed-1]
 	cmItr.curr, err = HashToCommit(ctx, cmItr.ddb.ValueReadWriter(), cmItr.ddb.ns, next)
 	if err != nil && err != ErrGhostCommitEncountered {
-		return hash.Hash{}, nil, err
+		return hash.Hash{}, nil, nil, 0, err
 	}
 	if err == ErrGhostCommitEncountered {
 		cmItr.curr = nil
 	}
 
-	return next, &OptionalCommit{cmItr.curr, next}, nil
+	return next, &OptionalCommit{cmItr.curr, next}, nil, 0, nil
 }
 
 func HashToCommit(ctx context.Context, vrw types.ValueReadWriter, ns tree.NodeStore, h hash.Hash) (*Commit, error) {
@@ -183,19 +183,18 @@ func NewFilteringCommitItr[C Context](itr CommitItr[C], filter CommitFilter[C]) 
 
 // Next returns the hash of the next commit, and a pointer to that commit.  Implementations of Next must handle
 // making sure the list of commits returned are unique.  When complete Next will return hash.Hash{}, nil, io.EOF
-func (itr FilteringCommitItr[C]) Next(ctx C) (hash.Hash, *OptionalCommit, error) {
+func (itr FilteringCommitItr[C]) Next(ctx C) (hash.Hash, *OptionalCommit, *datas.CommitMeta, uint64, error) {
 	// iteration will terminate on io.EOF or a commit that is !filteredOut
 	for {
-		h, cm, err := itr.itr.Next(ctx)
-
+		h, cm, meta, height, err := itr.itr.Next(ctx)
 		if err != nil {
-			return hash.Hash{}, nil, err
+			return hash.Hash{}, nil, nil, 0, err
 		}
 
 		if filterOut, err := itr.filter(ctx, h, cm); err != nil {
-			return hash.Hash{}, nil, err
+			return hash.Hash{}, nil, nil, 0, err
 		} else if !filterOut {
-			return h, cm, nil
+			return h, cm, meta, height, nil
 		}
 	}
 }
@@ -217,12 +216,12 @@ type CommitSliceIter[C Context] struct {
 
 var _ CommitItr[context.Context] = (*CommitSliceIter[context.Context])(nil)
 
-func (i *CommitSliceIter[C]) Next(ctx C) (hash.Hash, *OptionalCommit, error) {
+func (i *CommitSliceIter[C]) Next(ctx C) (hash.Hash, *OptionalCommit, *datas.CommitMeta, uint64, error) {
 	if i.i >= len(i.h) {
-		return hash.Hash{}, nil, io.EOF
+		return hash.Hash{}, nil, nil, 0, io.EOF
 	}
 	i.i++
-	return i.h[i.i-1], &OptionalCommit{i.cm[i.i-1], i.h[i.i-1]}, nil
+	return i.h[i.i-1], &OptionalCommit{i.cm[i.i-1], i.h[i.i-1]}, nil, 0, nil
 
 }
 
@@ -244,12 +243,12 @@ type OneCommitIter[C Context] struct {
 
 var _ CommitItr[context.Context] = (*OneCommitIter[context.Context])(nil)
 
-func (i *OneCommitIter[C]) Next(_ C) (hash.Hash, *OptionalCommit, error) {
+func (i *OneCommitIter[C]) Next(_ C) (hash.Hash, *OptionalCommit, *datas.CommitMeta, uint64, error) {
 	if i.done {
-		return hash.Hash{}, nil, io.EOF
+		return hash.Hash{}, nil, nil, 0, io.EOF
 	}
 	i.done = true
-	return i.h, i.cm, nil
+	return i.h, i.cm, nil, 0, nil
 
 }
 

--- a/go/libraries/doltcore/env/actions/commitwalk/commitwalk.go
+++ b/go/libraries/doltcore/env/actions/commitwalk/commitwalk.go
@@ -25,13 +25,13 @@ import (
 )
 
 type c struct {
-	ddb    *doltdb.DoltDB
-	commit *doltdb.OptionalCommit
-	meta   *datas.CommitMeta
-	hash   hash.Hash
-	height uint64
-	invisible    bool
-	queued       bool
+	ddb       *doltdb.DoltDB
+	commit    *doltdb.OptionalCommit
+	meta      *datas.CommitMeta
+	hash      hash.Hash
+	height    uint64
+	invisible bool
+	queued    bool
 }
 
 type q struct {

--- a/go/libraries/doltcore/env/actions/commitwalk/commitwalk.go
+++ b/go/libraries/doltcore/env/actions/commitwalk/commitwalk.go
@@ -149,7 +149,6 @@ func (q *q) Get(ctx context.Context, ddb *doltdb.DoltDB, id hash.Hash) (*c, erro
 
 	commit, ok := optCmt.ToCommit()
 	if !ok {
-		// TODO: add this to loaded?
 		return &c{ddb: ddb, commit: optCmt, hash: id}, nil
 	}
 

--- a/go/libraries/doltcore/env/actions/commitwalk/commitwalk.go
+++ b/go/libraries/doltcore/env/actions/commitwalk/commitwalk.go
@@ -130,15 +130,11 @@ func (q *q) SetInvisible(ctx context.Context, ddb *doltdb.DoltDB, id hash.Hash) 
 }
 
 func load(ctx context.Context, ddb *doltdb.DoltDB, h hash.Hash) (*doltdb.OptionalCommit, error) {
-	cs, err := doltdb.NewCommitSpec(h.String())
+	oc, err := ddb.ResolveHash(ctx, h)
 	if err != nil {
 		return nil, err
 	}
-	c, err := ddb.Resolve(ctx, cs, nil)
-	if err != nil {
-		return nil, err
-	}
-	return c, nil
+	return oc, nil
 }
 
 func (q *q) Get(ctx context.Context, ddb *doltdb.DoltDB, id hash.Hash) (*c, error) {

--- a/go/libraries/doltcore/env/actions/commitwalk/commitwalk.go
+++ b/go/libraries/doltcore/env/actions/commitwalk/commitwalk.go
@@ -29,17 +29,17 @@ import (
 var globalCommitCache = make(map[hash.Hash]*loadedCommit)
 
 type loadedCommit struct {
-	ddb       *doltdb.DoltDB
-	commit    *doltdb.OptionalCommit
-	meta      *datas.CommitMeta
-	hash      hash.Hash
-	height    uint64
+	ddb    *doltdb.DoltDB
+	commit *doltdb.OptionalCommit
+	meta   *datas.CommitMeta
+	hash   hash.Hash
+	height uint64
 }
 
 type c struct {
 	loadedCommit *loadedCommit
-	invisible bool
-	queued    bool
+	invisible    bool
+	queued       bool
 }
 
 type q struct {

--- a/go/libraries/doltcore/env/actions/commitwalk/commitwalk.go
+++ b/go/libraries/doltcore/env/actions/commitwalk/commitwalk.go
@@ -24,20 +24,12 @@ import (
 	"github.com/dolthub/dolt/go/store/hash"
 )
 
-// TODO: just load the entire commit graph on start up?
-// TODO: also no way this is safe for concurrent use
-var globalCommitCache = make(map[hash.Hash]*loadedCommit)
-
-type loadedCommit struct {
+type c struct {
 	ddb    *doltdb.DoltDB
 	commit *doltdb.OptionalCommit
 	meta   *datas.CommitMeta
 	hash   hash.Hash
 	height uint64
-}
-
-type c struct {
-	loadedCommit *loadedCommit
 	invisible    bool
 	queued       bool
 }
@@ -45,7 +37,7 @@ type c struct {
 type q struct {
 	pending           []*c
 	numVisiblePending int
-	loaded            map[hash.Hash]struct{}
+	loaded            map[hash.Hash]*c
 }
 
 func (q *q) NumVisiblePending() int {
@@ -77,8 +69,8 @@ func (q *q) Swap(i, j int) {
 // the commit with the newer timestamp is "less". Finally if both commits are ghost commits, we don't really have enough
 // information to compare on, so we just compare the hashes to ensure that the results are stable.
 func (q *q) Less(i, j int) bool {
-	cI := q.pending[i].loadedCommit
-	cJ := q.pending[j].loadedCommit
+	cI := q.pending[i]
+	cJ := q.pending[j]
 	_, okI := cI.commit.ToCommit()
 	_, okJ := cJ.commit.ToCommit()
 
@@ -150,8 +142,8 @@ func load(ctx context.Context, ddb *doltdb.DoltDB, h hash.Hash) (*doltdb.Optiona
 }
 
 func (q *q) Get(ctx context.Context, ddb *doltdb.DoltDB, id hash.Hash) (*c, error) {
-	if cachedCommit, ok := globalCommitCache[id]; ok {
-		return &c{loadedCommit: cachedCommit}, nil
+	if l, ok := q.loaded[id]; ok {
+		return l, nil
 	}
 
 	optCmt, err := load(ctx, ddb, id)
@@ -161,13 +153,8 @@ func (q *q) Get(ctx context.Context, ddb *doltdb.DoltDB, id hash.Hash) (*c, erro
 
 	commit, ok := optCmt.ToCommit()
 	if !ok {
-		lc := &loadedCommit{
-			ddb:    ddb,
-			commit: optCmt,
-			hash:   id,
-		}
-		globalCommitCache[id] = lc
-		return &c{loadedCommit: lc}, nil
+		// TODO: add this to loaded?
+		return &c{ddb: ddb, commit: optCmt, hash: id}, nil
 	}
 
 	h, err := commit.Height()
@@ -180,19 +167,19 @@ func (q *q) Get(ctx context.Context, ddb *doltdb.DoltDB, id hash.Hash) (*c, erro
 		return nil, err
 	}
 
-	lc := &loadedCommit{
+	lc := &c{
 		ddb:    ddb,
 		commit: &doltdb.OptionalCommit{Commit: commit, Addr: id},
 		meta:   meta,
 		height: h,
 		hash:   id,
 	}
-	globalCommitCache[id] = lc
-	return &c{loadedCommit: lc}, nil
+	q.loaded[id] = lc
+	return lc, nil
 }
 
 func newQueue() *q {
-	return &q{loaded: make(map[hash.Hash]struct{})}
+	return &q{loaded: make(map[hash.Hash]*c)}
 }
 
 // GetDotDotRevisions returns the commits reachable from commit at hashes
@@ -260,11 +247,10 @@ func newCommiterator[C doltdb.Context](ctx context.Context, ddb *doltdb.DoltDB, 
 func (iter *commiterator[C]) Next(ctx C) (hash.Hash, *doltdb.OptionalCommit, *datas.CommitMeta, uint64, error) {
 	if iter.q.NumVisiblePending() > 0 {
 		nextC := iter.q.PopPending()
-		nextCommit := nextC.loadedCommit
 
 		var err error
 		var parents []hash.Hash
-		commit, ok := nextCommit.commit.ToCommit()
+		commit, ok := nextC.commit.ToCommit()
 		if ok {
 			parents, err = commit.ParentHashes(ctx)
 			if err != nil {
@@ -273,22 +259,21 @@ func (iter *commiterator[C]) Next(ctx C) (hash.Hash, *doltdb.OptionalCommit, *da
 		}
 
 		for _, parentID := range parents {
-			if err := iter.q.AddPendingIfUnseen(ctx, nextCommit.ddb, parentID); err != nil {
+			if err := iter.q.AddPendingIfUnseen(ctx, nextC.ddb, parentID); err != nil {
 				return hash.Hash{}, nil, nil, 0, err
 			}
 		}
 
 		matches := true
 		if iter.matchFn != nil {
-			matches, err = iter.matchFn(nextCommit.commit)
-
+			matches, err = iter.matchFn(nextC.commit)
 			if err != nil {
 				return hash.Hash{}, nil, nil, 0, err
 			}
 		}
 
 		if matches {
-			return nextCommit.hash, &doltdb.OptionalCommit{Commit: commit, Addr: nextCommit.hash}, nextCommit.meta, nextCommit.height, nil
+			return nextC.hash, &doltdb.OptionalCommit{Commit: commit, Addr: nextC.hash}, nextC.meta, nextC.height, nil
 		}
 
 		return iter.Next(ctx)
@@ -372,11 +357,10 @@ func newDotDotCommiterator[C doltdb.Context](ctx context.Context, includedDdb *d
 func (i *dotDotCommiterator[C]) Next(ctx C) (hash.Hash, *doltdb.OptionalCommit, *datas.CommitMeta, uint64, error) {
 	if i.q.NumVisiblePending() > 0 {
 		nextC := i.q.PopPending()
-		nextCommit := nextC.loadedCommit
 
-		commit, ok := nextCommit.commit.ToCommit()
+		commit, ok := nextC.commit.ToCommit()
 		if !ok {
-			return nextCommit.hash, nextCommit.commit, nextCommit.meta, nextCommit.height, nil
+			return nextC.hash, nextC.commit, nextC.meta, nextC.height, nil
 		}
 
 		parents, err := commit.ParentHashes(ctx)
@@ -386,18 +370,18 @@ func (i *dotDotCommiterator[C]) Next(ctx C) (hash.Hash, *doltdb.OptionalCommit, 
 
 		for _, parentID := range parents {
 			if nextC.invisible {
-				if err := i.q.SetInvisible(ctx, nextCommit.ddb, parentID); err != nil {
+				if err := i.q.SetInvisible(ctx, nextC.ddb, parentID); err != nil {
 					return hash.Hash{}, nil, nil, 0, err
 				}
 			}
-			if err := i.q.AddPendingIfUnseen(ctx, nextCommit.ddb, parentID); err != nil {
+			if err := i.q.AddPendingIfUnseen(ctx, nextC.ddb, parentID); err != nil {
 				return hash.Hash{}, nil, nil, 0, err
 			}
 		}
 
 		matches := true
 		if i.matchFn != nil {
-			matches, err = i.matchFn(nextCommit.commit)
+			matches, err = i.matchFn(nextC.commit)
 			if err != nil {
 				return hash.Hash{}, nil, nil, 0, err
 			}
@@ -405,7 +389,7 @@ func (i *dotDotCommiterator[C]) Next(ctx C) (hash.Hash, *doltdb.OptionalCommit, 
 
 		// If not invisible, return commit. Otherwise, get next commit
 		if !nextC.invisible && matches {
-			return nextCommit.hash, nextCommit.commit, nextCommit.meta, nextCommit.height, nil
+			return nextC.hash, nextC.commit, nextC.meta, nextC.height, nil
 		}
 		return i.Next(ctx)
 	}

--- a/go/libraries/doltcore/rebase/rebase.go
+++ b/go/libraries/doltcore/rebase/rebase.go
@@ -200,7 +200,7 @@ func findRebaseCommits(ctx *sql.Context, currentBranchCommit, upstreamBranchComm
 	// Drain the iterator into a slice so that we can easily reverse the order of the commits
 	// so that the oldest commit is first in the generated rebase plan.
 	for {
-		_, optCmt, err := commitItr.Next(ctx)
+		_, optCmt, _, _, err := commitItr.Next(ctx)
 		if err == io.EOF {
 			return commits, nil
 		} else if err != nil {

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -919,7 +919,7 @@ func resolveAsOfTime(ctx *sql.Context, ddb *doltdb.DoltDB, head ref.DoltRef, asO
 	}
 
 	for {
-		_, optCmt, err := cmItr.Next(ctx)
+		_, optCmt, meta, _, err := cmItr.Next(ctx)
 		if err == io.EOF {
 			break
 		} else if err != nil {
@@ -930,9 +930,11 @@ func resolveAsOfTime(ctx *sql.Context, ddb *doltdb.DoltDB, head ref.DoltRef, asO
 			return nil, nil, doltdb.ErrGhostCommitEncountered
 		}
 
-		meta, err := curr.GetCommitMeta(ctx)
-		if err != nil {
-			return nil, nil, err
+		if meta == nil {
+			meta, err = curr.GetCommitMeta(ctx)
+			if err != nil {
+				return nil, nil, err
+			}
 		}
 
 		if meta.Time().Equal(asOf) || meta.Time().Before(asOf) {

--- a/go/libraries/doltcore/sqle/dolt_procedures_diff_table.go
+++ b/go/libraries/doltcore/sqle/dolt_procedures_diff_table.go
@@ -146,7 +146,7 @@ var _ sql.PartitionIter = (*DoltProceduresDiffPartitionItr)(nil)
 func (dpdp *DoltProceduresDiffPartitionItr) Next(ctx *sql.Context) (sql.Partition, error) {
 	// First iterate through commit history, then add working partition as the final step
 	for {
-		cmHash, optCmt, err := dpdp.cmItr.Next(ctx)
+		cmHash, optCmt, _, _,  err := dpdp.cmItr.Next(ctx)
 		if err == io.EOF {
 			// Finished with commit history, now add working partition if not done
 			if !dpdp.workingPartitionDone {

--- a/go/libraries/doltcore/sqle/dolt_procedures_diff_table.go
+++ b/go/libraries/doltcore/sqle/dolt_procedures_diff_table.go
@@ -146,7 +146,7 @@ var _ sql.PartitionIter = (*DoltProceduresDiffPartitionItr)(nil)
 func (dpdp *DoltProceduresDiffPartitionItr) Next(ctx *sql.Context) (sql.Partition, error) {
 	// First iterate through commit history, then add working partition as the final step
 	for {
-		cmHash, optCmt, _, _,  err := dpdp.cmItr.Next(ctx)
+		cmHash, optCmt, _, _, err := dpdp.cmItr.Next(ctx)
 		if err == io.EOF {
 			// Finished with commit history, now add working partition if not done
 			if !dpdp.workingPartitionDone {

--- a/go/libraries/doltcore/sqle/dolt_schemas_diff_table.go
+++ b/go/libraries/doltcore/sqle/dolt_schemas_diff_table.go
@@ -146,7 +146,7 @@ var _ sql.PartitionIter = (*DoltSchemasDiffPartitionItr)(nil)
 func (dsdp *DoltSchemasDiffPartitionItr) Next(ctx *sql.Context) (sql.Partition, error) {
 	// First iterate through commit history, then add working partition as the final step
 	for {
-		cmHash, optCmt, err := dsdp.cmItr.Next(ctx)
+		cmHash, optCmt, _, _, err := dsdp.cmItr.Next(ctx)
 		if err == io.EOF {
 			// Finished with commit history, now add working partition if not done
 			if !dsdp.workingPartitionDone {

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_count_commits.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_count_commits.go
@@ -146,7 +146,7 @@ func countCommitsInRange(ctx context.Context, ddb *doltdb.DoltDB, startCommitHas
 	}
 	count := 0
 	for {
-		nextHash, _, err := itr.Next(ctx)
+		nextHash, _, _, _, err := itr.Next(ctx)
 		if err == io.EOF {
 			return 0, fmt.Errorf("no match found to ancestor commit")
 		} else if err != nil {

--- a/go/libraries/doltcore/sqle/dtablefunctions/dolt_log.go
+++ b/go/libraries/doltcore/sqle/dtablefunctions/dolt_log.go
@@ -698,7 +698,7 @@ func (itr *logTableFunctionRowIter) Next(ctx *sql.Context) (sql.Row, error) {
 			return nil, err
 		}
 		ok := false
-		commit, ok = optCmt.ToCommit() // TODO: unnecessary? the matchFn already does this
+		commit, ok = optCmt.ToCommit()
 		if !ok {
 			return nil, doltdb.ErrGhostCommitEncountered
 		}

--- a/go/libraries/doltcore/sqle/dtablefunctions/dolt_log.go
+++ b/go/libraries/doltcore/sqle/dtablefunctions/dolt_log.go
@@ -16,8 +16,7 @@ package dtablefunctions
 
 import (
 	"fmt"
-	"github.com/dolthub/dolt/go/store/datas"
-"strings"
+	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
@@ -31,6 +30,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"github.com/dolthub/dolt/go/libraries/utils/gpg"
+	"github.com/dolthub/dolt/go/store/datas"
 	"github.com/dolthub/dolt/go/store/hash"
 )
 

--- a/go/libraries/doltcore/sqle/dtables/column_diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/column_diff_table.go
@@ -337,7 +337,7 @@ func (itr *doltColDiffCommitHistoryRowItr) Next(ctx *sql.Context) (sql.Row, erro
 			}
 			itr.commits = nil
 		} else if itr.child != nil {
-			_, optCmt, err := itr.child.Next(ctx)
+			_, optCmt, _, _, err := itr.child.Next(ctx)
 			if err != nil {
 				return nil, err
 			}

--- a/go/libraries/doltcore/sqle/dtables/commit_ancestors_table.go
+++ b/go/libraries/doltcore/sqle/dtables/commit_ancestors_table.go
@@ -159,7 +159,7 @@ func NewCommitAncestorsRowItr(sqlCtx *sql.Context, ddb *doltdb.DoltDB) (*CommitA
 // After retrieving the last row, Close will be automatically closed.
 func (itr *CommitAncestorsRowItr) Next(ctx *sql.Context) (sql.Row, error) {
 	if len(itr.cache) == 0 {
-		ch, optCmt, err := itr.itr.Next(ctx)
+		ch, optCmt, _, _, err := itr.itr.Next(ctx)
 		if err != nil {
 			// When complete itr.Next will return io.EOF
 			return nil, err

--- a/go/libraries/doltcore/sqle/dtables/commits_table.go
+++ b/go/libraries/doltcore/sqle/dtables/commits_table.go
@@ -152,7 +152,7 @@ func NewCommitsRowItr(ctx *sql.Context, ddb *doltdb.DoltDB) (CommitsRowItr, erro
 // Next retrieves the next row. It will return io.EOF if it's the last row.
 // After retrieving the last row, Close will be automatically closed.
 func (itr CommitsRowItr) Next(ctx *sql.Context) (sql.Row, error) {
-	h, optCmt, err := itr.itr.Next(ctx)
+	h, optCmt, _, _, err := itr.itr.Next(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/dtables/diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/diff_table.go
@@ -183,7 +183,7 @@ func (dt *DiffTable) PartitionRanges(ctx *sql.Context, ranges []prolly.Range) (s
 		return nil, err
 	}
 
-	cmHash, _, err := cmItr.Next(ctx)
+	cmHash, _, _, _, err := cmItr.Next(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -424,7 +424,7 @@ func (dt *DiffTable) scanHeightForChild(ctx *sql.Context, parent hash.Hash, heig
 func (dt *DiffTable) reverseIterForChild(ctx *sql.Context, parent hash.Hash) (*doltdb.Commit, hash.Hash, error) {
 	iter := doltdb.CommitItrForRoots[*sql.Context](dt.ddb, dt.head)
 	for {
-		childHs, optCmt, err := iter.Next(ctx)
+		childHs, optCmt, _, _, err := iter.Next(ctx)
 		if errors.Is(err, io.EOF) {
 			return nil, hash.Hash{}, nil
 		} else if err != nil {
@@ -839,7 +839,7 @@ func (dps *DiffPartitions) Next(ctx *sql.Context) (sql.Partition, error) {
 	}
 
 	for {
-		cmHash, optCmt, err := dps.cmItr.Next(ctx)
+		cmHash, optCmt, _, _, err := dps.cmItr.Next(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/go/libraries/doltcore/sqle/dtables/unscoped_diff_table.go
+++ b/go/libraries/doltcore/sqle/dtables/unscoped_diff_table.go
@@ -338,7 +338,7 @@ func (itr *doltDiffCommitHistoryRowItr) Next(ctx *sql.Context) (sql.Row, error) 
 			}
 			itr.commits = nil
 		} else if itr.child != nil {
-			_, optCmt, err := itr.child.Next(ctx)
+			_, optCmt, _, _, err := itr.child.Next(ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -347,6 +347,7 @@ func (itr *doltDiffCommitHistoryRowItr) Next(ctx *sql.Context) (sql.Row, error) 
 				return nil, io.EOF
 			}
 
+			// TODO: we already have meta and height
 			err = itr.loadTableChanges(ctx, commit)
 			if err == doltdb.ErrGhostCommitEncountered {
 				// When showing the diff table in a shallow clone, we show as much of the dolt_history_{table} as we can,

--- a/go/libraries/doltcore/sqle/history_table.go
+++ b/go/libraries/doltcore/sqle/history_table.go
@@ -456,7 +456,7 @@ type commitPartitioner struct {
 
 // Next returns the next partition and nil, io.EOF when complete
 func (cp commitPartitioner) Next(ctx *sql.Context) (sql.Partition, error) {
-	h, optCmt, err := cp.cmItr.Next(ctx)
+	h, optCmt, _, _, err := cp.cmItr.Next(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/go/performance/dolt_log_bench/.gitignore
+++ b/go/performance/dolt_log_bench/.gitignore
@@ -1,0 +1,5 @@
+*.test
+*.pprof
+*.out
+*.pdf
+*.exe

--- a/go/performance/dolt_log_bench/dolt_log_test.go
+++ b/go/performance/dolt_log_bench/dolt_log_test.go
@@ -20,7 +20,7 @@ import (
 	"io"
 	"testing"
 
-		"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/commands"

--- a/go/performance/dolt_log_bench/dolt_log_test.go
+++ b/go/performance/dolt_log_bench/dolt_log_test.go
@@ -20,8 +20,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/dolthub/go-mysql-server/server"
-	"github.com/dolthub/go-mysql-server/sql"
+		"github.com/dolthub/go-mysql-server/sql"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/commands"
@@ -78,20 +77,12 @@ func BenchmarkDoltLog(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		schema, iter, _, err := eng.Query(ctx, "select * from dolt_log()")
+		_, iter, _, err := eng.Query(ctx, "select * from dolt_log()")
 		require.NoError(b, err)
-		bi := 0
-		buf := sql.NewByteBuffer(16000)
 		for {
-			bi++
-			row, err := iter.Next(ctx)
+			_, err := iter.Next(ctx)
 			if err != nil {
 				break
-			}
-			outputRow, err := server.RowToSQL(ctx, schema, row, nil, buf)
-			_ = outputRow
-			if bi%128 == 0 {
-				buf.Reset()
 			}
 		}
 		require.Error(b, io.EOF)

--- a/go/performance/dolt_log_bench/dolt_log_test.go
+++ b/go/performance/dolt_log_bench/dolt_log_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/dolthub/dolt/go/cmd/dolt/commands"
 	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
 	"github.com/dolthub/dolt/go/libraries/doltcore/dtestutils"
-    "github.com/dolthub/dolt/go/libraries/doltcore/env"
+	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 )
 
 var dEnv *env.DoltEnv

--- a/go/performance/dolt_log_bench/dolt_log_test.go
+++ b/go/performance/dolt_log_bench/dolt_log_test.go
@@ -1,0 +1,103 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dolt_log_bench
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/server"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/cmd/dolt/commands"
+	"github.com/dolthub/dolt/go/cmd/dolt/commands/engine"
+	"github.com/dolthub/dolt/go/libraries/doltcore/dtestutils"
+    "github.com/dolthub/dolt/go/libraries/doltcore/env"
+)
+
+var dEnv *env.DoltEnv
+
+func init() {
+	dEnv = dtestutils.CreateTestEnv()
+	populateCommitGraph(dEnv)
+}
+
+func setupBenchmark(t *testing.B, dEnv *env.DoltEnv) (*sql.Context, *engine.SqlEngine) {
+	ctx := context.Background()
+	config := &engine.SqlEngineConfig{
+		ServerUser: "root",
+		Autocommit: true,
+	}
+
+	mrEnv, err := env.MultiEnvForDirectory(ctx, dEnv.Config.WriteableConfig(), dEnv.FS, dEnv.Version, dEnv)
+	require.NoError(t, err)
+
+	eng, err := engine.NewSqlEngine(ctx, mrEnv, config)
+	require.NoError(t, err)
+
+	sqlCtx, err := eng.NewLocalContext(ctx)
+	require.NoError(t, err)
+
+	sqlCtx.SetCurrentDatabase("dolt")
+	return sqlCtx, eng
+}
+
+func populateCommitGraph(dEnv *env.DoltEnv) {
+	ctx := context.Background()
+	cliCtx, err := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
+	if err != nil {
+		panic(err)
+	}
+	defer cliCtx.Close()
+	execSql := func(dEnv *env.DoltEnv, q string) int {
+		args := []string{"-r", "null", "-q", q}
+		return commands.SqlCmd{}.Exec(ctx, "sql", args, dEnv, cliCtx)
+	}
+	for i := 0; i < 500; i++ {
+		execSql(dEnv, fmt.Sprintf("call dolt_commit('--allow-empty', '-m', '%d') ", i))
+	}
+}
+
+func BenchmarkDoltLog(b *testing.B) {
+	ctx, eng := setupBenchmark(b, dEnv)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		schema, iter, _, err := eng.Query(ctx, "select * from dolt_log()")
+		require.NoError(b, err)
+		bi := 0
+		buf := sql.NewByteBuffer(16000)
+		for {
+			bi++
+			row, err := iter.Next(ctx)
+			if err != nil {
+				break
+			}
+			outputRow, err := server.RowToSQL(ctx, schema, row, nil, buf)
+			_ = outputRow
+			if bi%128 == 0 {
+				buf.Reset()
+			}
+		}
+		require.Error(b, io.EOF)
+		err = iter.Close(ctx)
+		require.NoError(b, err)
+	}
+	_ = eng.Close()
+	b.ReportAllocs()
+}

--- a/go/performance/dolt_log_bench/dolt_log_test.go
+++ b/go/performance/dolt_log_bench/dolt_log_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Dolthub, Inc.
+// Copyright 2025 Dolthub, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/go/store/datas/database_common.go
+++ b/go/store/datas/database_common.go
@@ -40,7 +40,7 @@ type database struct {
 	ns tree.NodeStore
 
 	rootHash hash.Hash
-	dsMap DatasetsMap
+	dsMap    DatasetsMap
 }
 
 const (

--- a/go/store/datas/database_common.go
+++ b/go/store/datas/database_common.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"sync"
 
-
 	"github.com/dolthub/dolt/go/gen/fb/serial"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
@@ -41,7 +40,7 @@ type database struct {
 	rt rootTracker
 	ns tree.NodeStore
 
-	mu sync.RWMutex
+	mu       sync.RWMutex
 	rootHash hash.Hash
 	dsMap    DatasetsMap
 }


### PR DESCRIPTION
Changes:
 - use the commitMetadata and commitHeight (if available) in iterator
 - reduce string and regex operations when resolving a known hash commit spec
 - directly access parent rather than allocating slice

The result of these changes is roughly 1.7x speed up in `select * from dolt_log()` queries.
Addresses: https://github.com/dolthub/dolt/issues/9743