### PR TITLE
Cache materialized commits on `doltdb`

### DIFF
--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -27,9 +27,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru/v2"
-
 	"github.com/dolthub/go-mysql-server/sql"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/sirupsen/logrus"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"

--- a/go/libraries/doltcore/env/memory.go
+++ b/go/libraries/doltcore/env/memory.go
@@ -52,11 +52,14 @@ func NewMemoryDbData(ctx context.Context, cfg config.ReadableConfig) (DbData[con
 func NewMemoryDoltDB(ctx context.Context, initBranch string) (*doltdb.DoltDB, error) {
 	ts := &chunks.TestStorage{}
 	cs := ts.NewViewWithDefaultFormat()
-	ddb := doltdb.DoltDBFromCS(cs, "")
+	ddb, err := doltdb.DoltDBFromCS(cs, "")
+	if err != nil {
+		return nil, err
+	}
 
 	m := "memory"
 	branchRef := ref.NewBranchRef(initBranch)
-	err := ddb.WriteEmptyRepoWithCommitTimeAndDefaultBranch(ctx, m, m, datas.CommitterDate(), branchRef)
+	err = ddb.WriteEmptyRepoWithCommitTimeAndDefaultBranch(ctx, m, m, datas.CommitterDate(), branchRef)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/migrate/integration_test.go
+++ b/go/libraries/doltcore/migrate/integration_test.go
@@ -254,5 +254,10 @@ func initTestMigrationDB(ctx context.Context) (*doltdb.DoltDB, error) {
 	if err != nil {
 		return nil, err
 	}
-	return doltdb.DoltDBFromCS(cs, ""), nil
+
+	ddb, err := doltdb.DoltDBFromCS(cs, "")
+	if err != nil {
+		return nil, err
+	}
+	return ddb, nil
 }


### PR DESCRIPTION
Changes:
 - store a cache of all resolved commit hashes on doltdb

This results in another ~2.3x speed up, so ~4.7x in total.