### PR TITLE
[no-release-notes] go/utils/publishrelease/buildpgobinaries.sh: Update release build script to use ICU4C-enabled toolchains.

### DIFF
--- a/.github/workflows/cd-release-pgo.yaml
+++ b/.github/workflows/cd-release-pgo.yaml
@@ -85,9 +85,9 @@ jobs:
         run: |
           latest=$(git rev-parse HEAD)
           echo "commitish=$latest" >> $GITHUB_OUTPUT
-          GO_BUILD_VERSION=1.24.0 go/utils/publishrelease/buildpgobinaries.sh
+          GO_BUILD_VERSION=1.24.6 go/utils/publishrelease/buildpgobinaries.sh
         env:
-          GO_BUILD_VERSION: "1.24.0"
+          GO_BUILD_VERSION: "1.24.6"
           PROFILE: ${{ format('{0}/dolt-cpu-profile.pprof', github.workspace) }}
       - name: Create Release
         id: create_release


### PR DESCRIPTION
We install the statically built ICU4C packages into the sysroots before building.

We pass icu_static as a build tag.

We add CXX support to the Cgo build.

We bump build image to Debian trixie (newer MinGW is necessary) and we pick up cross tools which have built for that base image.

We add -static-libgcc and -static-libstdc++ to the Windows build, as necessary.