### PR TITLE
fix missed `context canceled` error for `dolt_test_run()`

### DIFF
--- a/go/libraries/doltcore/sqle/dtablefunctions/dolt_test_run.go
+++ b/go/libraries/doltcore/sqle/dtablefunctions/dolt_test_run.go
@@ -224,6 +224,7 @@ func (trtf *TestsRunTableFunction) queryAndAssert(row sql.Row) (result testResul
 	if err != nil {
 		return
 	}
+
 	message, err := validateQuery(trtf.ctx, trtf.catalog, *query)
 	if err != nil && message == "" {
 		message = fmt.Sprintf("query error: %s", err.Error())
@@ -235,7 +236,7 @@ func (trtf *TestsRunTableFunction) queryAndAssert(row sql.Row) (result testResul
 		if err != nil {
 			message = fmt.Sprintf("Query error: %s", err.Error())
 		} else {
-			testPassed, message, err = actions.AssertData(trtf.ctx, *assertion, *comparison, value, &queryResult)
+			testPassed, message, err = actions.AssertData(trtf.ctx, *assertion, *comparison, value, queryResult)
 			if err != nil {
 				return testResult{}, err
 			}

--- a/integration-tests/bats/dolt-test-run.bats
+++ b/integration-tests/bats/dolt-test-run.bats
@@ -20,5 +20,6 @@ teardown() {
     dolt sql -q "insert into dolt_tests values ('test2', 'test2', 'select 2', 'expected_single_value', '==', '2');"
     run dolt sql -q "select * from dolt_test_run()"
     [ $status -eq 0 ]
-    [[ $output =~ "| test      | test            | select 1 | PASS   |         |" ]] || false
+    [[ $output =~ "| test1     | test1           | select 1 | PASS   |         |" ]] || false
+    [[ $output =~ "| test2     | test2           | select 2 | PASS   |         |" ]] || false
 }

--- a/integration-tests/bats/dolt-test-run.bats
+++ b/integration-tests/bats/dolt-test-run.bats
@@ -16,7 +16,8 @@ teardown() {
 @test "dolt-test-run: sanity test on sql-server" {
     start_sql_server
 
-    dolt sql -q "insert into dolt_tests values ('test', 'test', 'select 1', 'expected_rows', '==', '1');"
+    dolt sql -q "insert into dolt_tests values ('test1', 'test1', 'select 1', 'expected_rows', '==', '1');"
+    dolt sql -q "insert into dolt_tests values ('test2', 'test2', 'select 2', 'expected_single_value', '==', '2');"
     run dolt sql -q "select * from dolt_test_run()"
     [ $status -eq 0 ]
     [[ $output =~ "| test      | test            | select 1 | PASS   |         |" ]] || false


### PR DESCRIPTION
Changes: 
 - delete  `Close()` calls missed in https://github.com/dolthub/dolt/pull/9811
 - adds a test for single result assertion
 - add missing cases for int types
