### PR TITLE
Reverted Extended encoding from adaptive to ref

### DIFF
--- a/go/libraries/doltcore/schema/serial_encoding.go
+++ b/go/libraries/doltcore/schema/serial_encoding.go
@@ -30,8 +30,8 @@ func EncodingFromSqlType(typ sql.Type) serial.Encoding {
 		case sql.ExtendedTypeSerializedWidth_64K:
 			return serial.EncodingExtended
 		case sql.ExtendedTypeSerializedWidth_Unbounded:
-			// Always uses adaptive encoding for extended types, regardless of the setting of UseAdaptiveEncoding below.
-			return serial.EncodingExtendedAdaptive
+			// TODO: should use serial.EncodingExtendedAdaptive, but it's currently broken
+			return serial.EncodingExtendedAddr
 		default:
 			panic(fmt.Errorf("unknown serialization width"))
 		}


### PR DESCRIPTION
While working on importing dumps in Doltgres, I found out that data wasn't being written correctly in some circumstances. Turns out that the new adaptive encoding is incomplete, and therefore broken, and any columns over the inline threshold will be truncated. This truncation results in a panic whenever the field is read, since the serialized size does not match the data, causing OOB access.

This should be safe to change since existing databases will simply swap to using the old ref approach until adaptive is fixed, where we can then swap back to the adaptive encoding (since the ref code is still in the codebase). I've already spoken to Nick who will lead the fix once he has returned next week.