### PR TITLE
fix archive int overflow

### DIFF
--- a/go/libraries/utils/file/mmap.go
+++ b/go/libraries/utils/file/mmap.go
@@ -38,11 +38,11 @@ type MmapData struct {
 
 var mmapAlignment = int64(os.Getpagesize())
 
-func (m MmapData) GetUint64(offset int64) uint64 {
+func (m MmapData) GetUint64(offset uint64) uint64 {
 	return binary.BigEndian.Uint64(m.data[offset : offset+uint64Size])
 }
 
-func (m MmapData) GetUint32(offset int64) uint32 {
+func (m MmapData) GetUint32(offset uint64) uint32 {
 	return binary.BigEndian.Uint32(m.data[offset : offset+uint32Size])
 }
 

--- a/go/store/nbs/archive_reader.go
+++ b/go/store/nbs/archive_reader.go
@@ -326,7 +326,7 @@ func (f *inMemoryArchiveIndexReader) getSuffix(idx uint32) suffix {
 	if idx >= uint32(len(f.suffixes)/hash.SuffixLen) {
 		return suffix{}
 	}
-	start := idx * hash.SuffixLen
+	start := uint64(idx) * hash.SuffixLen
 	return suffix(f.suffixes[start : start+hash.SuffixLen])
 }
 


### PR DESCRIPTION
A integer overflow bug introduced by the mmap work. The bug was in the suffix offset calculation, which took a uint32 and multiplied it by 12 (suffix len), which resulted in the overflow.

This type of bug cropped up a couple times during archive development, but this is the first time we've regressed here. This only manifests if you have more than 357,913,942 chunks in an archive, which is a lot. So many that it would take days run an automated test to find it in CI.
