### PR TITLE
[no-release-notes] refactor commit hook interface

### DIFF
--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -148,11 +148,6 @@ func NewSqlEngine(
 	all := make([]dsess.SqlDatabase, len(dbs))
 	copy(all, dbs)
 
-	// this is overwritten only for server sessions
-	for _, db := range dbs {
-		db.DbData().Ddb.SetCommitHookLogger(ctx, cli.CliOut)
-	}
-
 	clusterDB := config.ClusterController.ClusterDatabase()
 	if clusterDB != nil {
 		all = append(all, clusterDB.(dsess.SqlDatabase))

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -2069,13 +2068,6 @@ func (ddb *DoltDB) DatasetsByRootHash(ctx context.Context, hashof hash.Hash) (da
 
 func (ddb *DoltDB) PrependCommitHooks(ctx context.Context, hooks ...CommitHook) *DoltDB {
 	ddb.db = ddb.db.SetCommitHooks(ctx, append(hooks, ddb.db.PostCommitHooks()...))
-	return ddb
-}
-
-func (ddb *DoltDB) SetCommitHookLogger(ctx context.Context, wr io.Writer) *DoltDB {
-	if ddb.db.Database != nil {
-		ddb.db = ddb.db.SetCommitHookLogger(ctx, wr)
-	}
 	return ddb
 }
 

--- a/go/libraries/doltcore/doltdb/hooksdatabase.go
+++ b/go/libraries/doltcore/doltdb/hooksdatabase.go
@@ -32,10 +32,9 @@ type hooksDatabase struct {
 
 // CommitHook is an abstraction for executing arbitrary commands after atomic database commits
 type CommitHook interface {
-	// Execute is arbitrary read-only function whose arguments are new Dataset commit into a specific Database
+	// Execute is arbitrary read-only function whose arguments are new Dataset commit into a specific Database.
+	// NM4 - gDoc Update.
 	Execute(ctx context.Context, ds datas.Dataset, db *DoltDB) (func(context.Context) error, error)
-	// HandleError is an bridge function to handle Execute errors
-	HandleError(ctx context.Context, err error) error
 	// ExecuteForWorkingSets returns whether or not the hook should be executed for working set updates
 	ExecuteForWorkingSets() bool
 }
@@ -81,10 +80,9 @@ func (db hooksDatabase) ExecuteCommitHooks(ctx context.Context, ds datas.Dataset
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				f, err := hook.Execute(ctx, ds, db.db)
-				if err != nil {
-					hook.HandleError(ctx, err)
-				}
+				// The error is intentionally ignored here. Hooks are expected to log errors themselves. The interface returns
+				// the error primarily for testing purposes.
+				f, _ := hook.Execute(ctx, ds, db.db)
 				if rsc != nil {
 					rsc.Wait[i+ioff] = f
 					if nf, ok := hook.(NotifyWaitFailedCommitHook); ok {

--- a/go/libraries/doltcore/doltdb/hooksdatabase.go
+++ b/go/libraries/doltcore/doltdb/hooksdatabase.go
@@ -16,7 +16,6 @@ package doltdb
 
 import (
 	"context"
-	"io"
 	"sync"
 
 	"github.com/dolthub/dolt/go/store/datas"
@@ -37,8 +36,6 @@ type CommitHook interface {
 	Execute(ctx context.Context, ds datas.Dataset, db *DoltDB) (func(context.Context) error, error)
 	// HandleError is an bridge function to handle Execute errors
 	HandleError(ctx context.Context, err error) error
-	// SetLogger lets clients specify an output stream for HandleError
-	SetLogger(ctx context.Context, wr io.Writer) error
 	// ExecuteForWorkingSets returns whether or not the hook should be executed for working set updates
 	ExecuteForWorkingSets() bool
 }
@@ -54,13 +51,6 @@ type NotifyWaitFailedCommitHook interface {
 func (db hooksDatabase) SetCommitHooks(ctx context.Context, postHooks []CommitHook) hooksDatabase {
 	db.hooks = make([]CommitHook, len(postHooks))
 	copy(db.hooks, postHooks)
-	return db
-}
-
-func (db hooksDatabase) SetCommitHookLogger(ctx context.Context, wr io.Writer) hooksDatabase {
-	for _, h := range db.hooks {
-		h.SetLogger(ctx, wr)
-	}
 	return db
 }
 

--- a/go/libraries/doltcore/sqle/auto_gc.go
+++ b/go/libraries/doltcore/sqle/auto_gc.go
@@ -17,7 +17,6 @@ package sqle
 import (
 	"context"
 	"errors"
-	"io"
 	"sync"
 	"time"
 
@@ -304,10 +303,6 @@ func (h *autoGCCommitHook) requestGC(ctx context.Context) error {
 }
 
 func (h *autoGCCommitHook) HandleError(ctx context.Context, err error) error {
-	return nil
-}
-
-func (h *autoGCCommitHook) SetLogger(ctx context.Context, wr io.Writer) error {
 	return nil
 }
 

--- a/go/libraries/doltcore/sqle/auto_gc.go
+++ b/go/libraries/doltcore/sqle/auto_gc.go
@@ -302,10 +302,6 @@ func (h *autoGCCommitHook) requestGC(ctx context.Context) error {
 	}
 }
 
-func (h *autoGCCommitHook) HandleError(ctx context.Context, err error) error {
-	return nil
-}
-
 func (h *autoGCCommitHook) ExecuteForWorkingSets() bool {
 	return true
 }

--- a/go/libraries/doltcore/sqle/cluster/commithook.go
+++ b/go/libraries/doltcore/sqle/cluster/commithook.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -525,10 +524,6 @@ func (h *commithook) NotifyWaitFailed() {
 }
 
 func (h *commithook) HandleError(ctx context.Context, err error) error {
-	return nil
-}
-
-func (h *commithook) SetLogger(ctx context.Context, wr io.Writer) error {
 	return nil
 }
 

--- a/go/libraries/doltcore/sqle/cluster/commithook.go
+++ b/go/libraries/doltcore/sqle/cluster/commithook.go
@@ -523,10 +523,6 @@ func (h *commithook) NotifyWaitFailed() {
 	h.fastFailReplicationWait = true
 }
 
-func (h *commithook) HandleError(ctx context.Context, err error) error {
-	return nil
-}
-
 func (h *commithook) ExecuteForWorkingSets() bool {
 	return true
 }

--- a/go/libraries/doltcore/sqle/commit_hooks_test.go
+++ b/go/libraries/doltcore/sqle/commit_hooks_test.go
@@ -351,9 +351,11 @@ func (c *countingCommitHook) HandleError(ctx context.Context, err error) error {
 	return nil
 }
 
+/*
 func (c *countingCommitHook) SetLogger(ctx context.Context, wr io.Writer) error {
 	return nil
 }
+*/
 
 func (c *countingCommitHook) ExecuteForWorkingSets() bool {
 	return false

--- a/go/libraries/doltcore/sqle/database_provider_test.go
+++ b/go/libraries/doltcore/sqle/database_provider_test.go
@@ -146,10 +146,6 @@ func (*snoopingCommitHook) Execute(ctx context.Context, ds datas.Dataset, db *do
 	return nil, nil
 }
 
-func (*snoopingCommitHook) HandleError(ctx context.Context, err error) error {
-	return nil
-}
-
 func (*snoopingCommitHook) ExecuteForWorkingSets() bool {
 	return true
 }

--- a/go/libraries/doltcore/sqle/database_provider_test.go
+++ b/go/libraries/doltcore/sqle/database_provider_test.go
@@ -16,7 +16,6 @@ package sqle
 
 import (
 	"context"
-	"io"
 	"testing"
 
 	sqle "github.com/dolthub/go-mysql-server"
@@ -148,10 +147,6 @@ func (*snoopingCommitHook) Execute(ctx context.Context, ds datas.Dataset, db *do
 }
 
 func (*snoopingCommitHook) HandleError(ctx context.Context, err error) error {
-	return nil
-}
-
-func (*snoopingCommitHook) SetLogger(ctx context.Context, wr io.Writer) error {
 	return nil
 }
 

--- a/go/libraries/doltcore/sqle/replication.go
+++ b/go/libraries/doltcore/sqle/replication.go
@@ -67,7 +67,7 @@ func getPushOnWriteHook(ctx context.Context, dEnv *env.DoltEnv, logger io.Writer
 		return hook, runThreads, nil
 	}
 
-	return NewPushOnWriteHook(ddb, tmpDir), nil, nil
+	return NewPushOnWriteHook(ddb, tmpDir, logger), nil, nil
 }
 
 type RunAsyncThreads func(*sql.BackgroundThreads, func(context.Context) (*sql.Context, error)) error
@@ -80,14 +80,11 @@ func GetCommitHooks(ctx context.Context, dEnv *env.DoltEnv, logger io.Writer) ([
 	if err != nil {
 		path, _ := dEnv.FS.Abs(".")
 		logrus.Errorf("error loading replication for database at %s, replication disabled: %v", path, err)
-		postCommitHooks = append(postCommitHooks, NewLogHook([]byte(err.Error()+"\n")))
+		postCommitHooks = append(postCommitHooks, NewLogHook([]byte(err.Error()+"\n"), logger))
 	} else if hook != nil {
 		postCommitHooks = append(postCommitHooks, hook)
 	}
 
-	for _, h := range postCommitHooks {
-		_ = h.SetLogger(ctx, logger)
-	}
 	return postCommitHooks, runThreads, nil
 }
 


### PR DESCRIPTION
The CommitHook interface is overly complex. The SetLogger and HandleError methods aren't really required based on they current implementations. HandleError in every case just prints a message to the logger. SetLogger isn't actually needed because we have the logger available when we construct the instances (and most implementations don't even use it).

This is just a refactor which should not have any changes in behavior. No tests were updated to ensure this.