### PR TITLE
go: doltcore/remotestorage: Clear our cached repo token when Commit or Rebase are called on the ChunkStore.

### DIFF
--- a/go/libraries/doltcore/remotestorage/chunk_store.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store.go
@@ -750,7 +750,7 @@ func (dcs *DoltChunkStore) AccessMode() chunks.ExclusiveAccessMode {
 // Rebase brings this ChunkStore into sync with the persistent storage's
 // current root.
 func (dcs *DoltChunkStore) Rebase(ctx context.Context) error {
-	dcs.repoToken.Store(nil)
+	dcs.repoToken.Store("")
 	err := dcs.loadRoot(ctx)
 	if err != nil {
 		return err
@@ -857,7 +857,7 @@ func (dcs *DoltChunkStore) Commit(ctx context.Context, current, last hash.Hash) 
 			NbsVersion: nbs.StorageVersion,
 		},
 	}
-	dcs.repoToken.Store(nil)
+	dcs.repoToken.Store("")
 	resp, err = dcs.csClient.Commit(ctx, req)
 	if err != nil {
 		return false, NewRpcError(err, "Commit", dcs.host, req)


### PR DESCRIPTION
doltremoteapi returns RepoTokens on some RPC interactions. When Dolt mirrors the token back to doltremoteapi, doltremoteapi can check if the current repo state matches the token state and if it does, it can avoid doing some I/O work to refresh its current view of the repository.

After a Commit(), the client was not clearing its view of the repoToken, and the server was not returning the new RepoToken on a successful commit. This meant that the client was potentially seeing stale data for the repository if its RepoToken represented the previous committed state and if its requests landed on a doltremoteapi replica where that state was also the state of the repository in memory.

In multi-process concurrency against a ChunkStore, clients are expected to refresh their view of storage after a Commit and after a call to Rebaes. This corresponds to clearing our RepoToken, so that doltremoteapi will Rebase the store and return a new RepoToken which reflects the refreshed state.