### PR TITLE
reset dolt server between benchmarks

### DIFF
--- a/go/performance/utils/benchmark_runner/dolt.go
+++ b/go/performance/utils/benchmark_runner/dolt.go
@@ -117,6 +117,8 @@ func (b *doltBenchmarkerImpl) Benchmark(ctx context.Context) (Results, error) {
 			if err != nil {
 				return nil, err
 			}
+
+			os.RemoveAll(testRepo)
 		}
 	}
 


### PR DESCRIPTION
It appears that running benchmarks back to back on the same server instance seems to negatively impacts the performance results.
This PR deletes the old database and reinitializes an entirely new one for every benchmark.