### PR TITLE
Fix performance issue when using large JSON documents in UPDATE statements.

### DIFF
--- a/go/store/prolly/tree/json_indexed_document.go
+++ b/go/store/prolly/tree/json_indexed_document.go
@@ -46,6 +46,7 @@ type IndexedJsonDocument struct {
 
 var _ types.JSONBytes = IndexedJsonDocument{}
 var _ types.MutableJSON = IndexedJsonDocument{}
+var _ types.ComparableJSON = IndexedJsonDocument{}
 var _ fmt.Stringer = IndexedJsonDocument{}
 var _ driver.Valuer = IndexedJsonDocument{}
 
@@ -742,5 +743,28 @@ func (i IndexedJsonDocument) Compare(ctx context.Context, other interface{}) (in
 			return 0, err
 		}
 		return types.CompareJSON(ctx, val, other)
+	}
+}
+
+func (i IndexedJsonDocument) JsonType(ctx context.Context) (string, error) {
+	typeCategory, err := i.getTypeCategory(ctx)
+	if err != nil {
+		return "", err
+	}
+	switch typeCategory {
+	case jsonTypeObject:
+		return "OBJECT", nil
+	case jsonTypeArray:
+		return "ARRAY", nil
+	case jsonTypeNull:
+		return "NULL", nil
+	case jsonTypeBoolean:
+		return "BOOLEAN", nil
+	case jsonTypeString:
+		return "STRING", nil
+	case jsonTypeNumber:
+		return "DOUBLE", nil
+	default:
+		return "", fmt.Errorf("unknown json type category %v", typeCategory)
 	}
 }

--- a/go/store/prolly/tree/json_indexed_document_test.go
+++ b/go/store/prolly/tree/json_indexed_document_test.go
@@ -359,6 +359,12 @@ func TestJsonCompare(t *testing.T) {
 	require.NoError(t, err)
 	largeDocTests := []typetests.JsonCompareTest{
 		{
+			Name:  "identical large objects are equal",
+			Left:  largeObject,
+			Right: largeObject,
+			Cmp:   0,
+		},
+		{
 			Name:  "large object < boolean",
 			Left:  largeObject,
 			Right: true,


### PR DESCRIPTION
UPDATE statements return the number of rows that changed as a result of the operation. This requires comparing the new and old values for the rows.

Because IndexedJsonDocument didn't properly implement the ComparableJSON interface, these values were being fully reconstructed in memory for the comparison, which was needlessly slow. Implementing the interface allows comparing two documents to be logarithmic on document size instead of linear.