### PR TITLE
Update docker-entrypoint.sh

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -191,8 +191,7 @@ docker_process_init_files() {
       ;;
     *.sql)
       mysql_note "$0: running $f"
-      sql=$(cat "$f")
-      exec_mysql "$sql" "Failed to execute $f: "
+      dolt sql < "$f"
       ;;
     *.sql.bz2)
       mysql_note "$0: running $f"


### PR DESCRIPTION
I suspect you need to do more than this, as this is only the sql file, but without it, the command is too large to be sent in, and if you have a large enough file, you end up with something like this

Failed to execute /docker-entrypoint-initdb.d/nautobot.sql: /usr/local/bin/docker-entrypoint.sh: line 63: /usr/local/bin/dolt: Argument list too long