### PR TITLE
go/store/nbs: store.go: Fix a bug which caused dolt gc --full to not collect new data sometimes.

### DIFF
--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -2255,13 +2255,6 @@ func (nbs *NomsBlockStore) swapTables(ctx context.Context, specs []tableSpec, mo
 		specs:   specs,
 	}
 
-	sameGcGen := newContents.gcGen == nbs.upstream.gcGen
-	hasLocalNovelty := nbs.hasLocalGCNovelty()
-	if sameGcGen && !hasLocalNovelty {
-		// Nothing has changed. Bail early.
-		return nil
-	}
-
 	upstream, err := nbs.manifestMgr.UpdateGCGen(ctx, nbs.upstream.lock, newContents, nbs.stats, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
If `dolt gc --full` was run, and then branches were changed and `dolt gc` was run, possibly multiple times, and then all of the state was returned to the state of the database during the initial `dolt gc --full`, then running `dolt gc --full` anew would falsely conclude that there was nothing to collect.

After the GC work is done, and we are inside swapTables, there is no need to check for whether we should swap the tables. We already have done the work to compute the new files and we should apply them regardless.