### PR TITLE
go: sqle/dsess/session.go: VisitGCRoots: Do not visit StaticMap Roots for inflight write sessions.

### DIFF
--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -847,10 +847,6 @@ func (d *DoltSession) VisitGCRoots(ctx context.Context, dbName string, keep func
 						panic("gc safepoint establishment found inconsistent state; process could not guarantee it would be able to keep a chunk if we continue")
 					}
 				}
-				err = head.writeSession.VisitGCRoots(ctx, keep)
-				if err != nil {
-					return err
-				}
 			}
 		}
 	}


### PR DESCRIPTION
The current design of GC will always visit session GC roots in between two SQL statements. This means that long-running SQL statements prevent GC from completing and collecting the garbage. In an attempt to improve this, we added preliminary support for visiting the GC roots of in-flight write sessions.

However, this implementation currently has an issue where it can request to retain materialized but unflushed values, causing a GC run to fail and resulting in log messages about missing chunks. Since this code is not needed yet, remove it for now.