### PR TITLE
[no-release-notes] go/store/nbs: Expose ChunkJournalSize directly on NomsBlockStore.

### DIFF
--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -2016,10 +2016,10 @@ func (ddb *DoltDB) StoreSizes(ctx context.Context) (StoreSizes, error) {
 		if err != nil {
 			return StoreSizes{}, err
 		}
-		journal := newGenNBS.ChunkJournal()
-		if journal != nil {
+		journalSz, ok := newGenNBS.ChunkJournalSize()
+		if ok {
 			return StoreSizes{
-				JournalBytes: uint64(journal.Size()),
+				JournalBytes: uint64(journalSz),
 				NewGenBytes:  newgenSz,
 				TotalBytes:   totalSz,
 			}, nil

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -163,6 +163,15 @@ func (nbs *NomsBlockStore) ChunkJournal() *ChunkJournal {
 	return nil
 }
 
+func (nbs *NomsBlockStore) ChunkJournalSize() (int64, bool) {
+	nbs.mu.Lock()
+	defer nbs.mu.Unlock()
+	if cj, ok := nbs.persister.(*ChunkJournal); ok {
+		return cj.Size(), true
+	}
+	return 0, false
+}
+
 func (nbs *NomsBlockStore) GetChunkLocationsWithPaths(ctx context.Context, hashes hash.HashSet) (map[string]map[hash.Hash]Range, error) {
 	valctx.ValidateContext(ctx)
 	sourcesToRanges, err := nbs.getChunkLocations(ctx, hashes)


### PR DESCRIPTION
Going through ChunkJournal() meant we had unserialized accessed to the journal.wr to check its size. We don't want to add locking to the journal or the writer just to support inspecting the size. It makes more sense to utilize the NomsBlockStore.mu lock, which we already do to check the sizes of it as a table file store.