### PR TITLE
Fixed branch control insertion bug

### DIFF
--- a/go/libraries/doltcore/branch_control/access.go
+++ b/go/libraries/doltcore/branch_control/access.go
@@ -69,7 +69,8 @@ func newAccess() *Access {
 }
 
 // Match returns whether any entries match the given database, branch, user, and host, along with their permissions.
-// Requires external synchronization handling, therefore manually manage the RWMutex.
+// This will match subsets against their superset as well. Requires external synchronization handling, therefore
+// manually manage the RWMutex.
 func (tbl *Access) Match(database string, branch string, user string, host string) (bool, Permissions) {
 	results := tbl.Root.Match(database, branch, user, host)
 	// We use the result(s) with the longest length
@@ -84,6 +85,12 @@ func (tbl *Access) Match(database string, branch string, user string, host strin
 		}
 	}
 	return len(results) > 0, perms
+}
+
+// ExactMatch returns whether any entries exactly match the given database, branch, user, and host. Requires external
+// synchronization handling, therefore manually manage the RWMutex.
+func (tbl *Access) ExactMatch(database string, branch string, user string, host string) bool {
+	return tbl.Root.ExactMatch(database, branch, user, host)
 }
 
 // GetBinlog returns the table's binlog.

--- a/go/libraries/doltcore/sqle/enginetest/branch_control_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/branch_control_test.go
@@ -1361,6 +1361,25 @@ var BranchControlTests = []BranchControlTest{
 			},
 		},
 	},
+	{
+		Name: "Cannot insert an exact match even with elevated permissions",
+		Assertions: []BranchControlTestAssertion{
+			{
+				User:        "root",
+				Host:        "localhost",
+				Query:       "INSERT INTO dolt_branch_control VALUES ('%', '%', '%', '%', 'admin');",
+				ExpectedErr: sql.ErrPrimaryKeyViolation,
+			},
+			{ // This will fail if the above succeeded, so kind of a redundant check but ultimately harmless
+				User:  "root",
+				Host:  "localhost",
+				Query: "DELETE FROM dolt_branch_control WHERE permissions='admin';",
+				Expected: []sql.Row{
+					{types.NewOkResult(0)},
+				},
+			},
+		},
+	},
 }
 
 func TestBranchControl(t *testing.T) {


### PR DESCRIPTION
A user reported that their `dolt_branch_control` table was in a corrupted state, as they could not delete a row even though running the appropriate `DELETE FROM dolt_branch_control` would report that 1 row was affected. Running `SELECT` showed that it was still there.

I was able to replicate a way of getting the table into that state, which is to insert the exact same row as an existing row but with a larger permission set. `dolt_branch_control` handles primary key conflicts differently than other tables, as we throw a conflict when a subset is inserted. For example, `'%'` will match all entries that `'s%'` can match, so `'s%'` is a subset of `'%'`. Of course, when taking permissions into account, `'s%'` may not be a subset if it has a broader permission set than `'%'`, in which case we want to allow the insertion of `'s%'`.

The failure case was with _exact_ matches. An exact match is still a subset when the permissions are as restrictive or more restrictive than the original, however it's _not_ a subset when the permissions are broader, and this would result in allowing the insertion of the exact match. We convert all expressions into a specialized integer format, and store those integers in a prefix tree. Since the format will be the exact same, we end up overwriting the old entry, which is an implicit deletion without the accompanying bookkeeping in the rest of the data structure. This is what causes the mismatch, and creates the failure state.

To prevent this, we never allow insertion when there's an exact match, so you must use an `UPDATE` in such cases. This will prevent that failure mode from occurring.