### PR TITLE
go: libraries/doltcore/dbfactory: Do not use EventsUnaryClientInterceptor when interacting with remotestorage.

### DIFF
--- a/go/libraries/doltcore/dbfactory/grpc.go
+++ b/go/libraries/doltcore/dbfactory/grpc.go
@@ -25,7 +25,6 @@ import (
 	remotesapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/remotesapi/v1alpha1"
 	"github.com/dolthub/dolt/go/libraries/doltcore/grpcendpoint"
 	"github.com/dolthub/dolt/go/libraries/doltcore/remotestorage"
-	"github.com/dolthub/dolt/go/libraries/events"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/datas"
 	"github.com/dolthub/dolt/go/store/prolly/tree"
@@ -117,8 +116,7 @@ func (fact DoltRemoteFactory) newChunkStore(ctx context.Context, nbf *types.Noms
 		return nil, err
 	}
 
-	opts := append(cfg.DialOptions, grpc.WithChainUnaryInterceptor(remotestorage.EventsUnaryClientInterceptor(events.GlobalCollector())))
-	opts = append(opts, grpc.WithChainUnaryInterceptor(remotestorage.RetryingUnaryClientInterceptor))
+	opts := append(cfg.DialOptions, grpc.WithChainUnaryInterceptor(remotestorage.RetryingUnaryClientInterceptor))
 
 	conn, err := grpc.Dial(cfg.Endpoint, opts...)
 	if err != nil {


### PR DESCRIPTION
This events source is too detailed and emits too many events to be appropriate for our usage metrics. It is useful in an operational context for DoltHub and Hosted, but it should be used by default in Dolt itself. We will revisit this events source if we need it for internal infrastructure, but for now we should disable it.