### PR TITLE
Fixed anyMatch operator

### DIFF
--- a/go/libraries/doltcore/branch_control/branch_control.go
+++ b/go/libraries/doltcore/branch_control/branch_control.go
@@ -362,7 +362,7 @@ func GetBranchAwareSession(ctx context.Context) Context {
 	return nil
 }
 
-// GetBranchAwareSession will return a context converted from this if
+// ContextConvertible will return a context converted from this if
 // the Session supports this GetBranch call instead.
 type ContextConvertible interface {
 	GetBranch(*sql.Context) (string, error)


### PR DESCRIPTION
There was a bug during matching where we did not consider the children of a node when we encountered the `anyMatch` operator. Interestingly, this was never found as we never mixed the singular operator (`%`) with a diverging match (`'%wy`) in a test scenario, so the column marker (separates each column) was _always_ in the sort order slice instead of being a child.