### PR TITLE
Set `BATS_TEST_RETRIES` to be higher for flaky `docker-entrypoint.bats` build tests

### DIFF
--- a/integration-tests/bats/docker-entrypoint.bats
+++ b/integration-tests/bats/docker-entrypoint.bats
@@ -901,6 +901,7 @@ EOF
 
 # bats test_tags=no_lambda
 @test "docker-entrypoint: latest binary build from dolt directory" {
+  BATS_TEST_RETRIES=5 # GitHub ver. retrieval can sometimes return Not Found on CI, could be some form of rate limiting
   cname="${TEST_PREFIX}latest-docker"
 
   LATEST_IMAGE="dolt-entrypoint-latest:test"
@@ -926,6 +927,7 @@ EOF
 
 # bats test_tags=no_lambda
 @test "docker-entrypoint: specific version binary build from dolt directory" {
+  BATS_TEST_RETRIES=5
   cname="${TEST_PREFIX}specific-version"
 
   SPECIFIC_IMAGE="dolt-entrypoint-specific:test"


### PR DESCRIPTION
Add [$BATS_TEST_RETRIES](https://bats-core.readthedocs.io/en/stable/writing-tests.html#:~:text=BATS_TEST_RETRIES%20is%20the%20maximum%20number%20of%20additional%20attempts%20that%20will%20be%20made%20on%20a%20failed%20test%20before%20it%20is%20finally%20considered%20failed.%20The%20default%20of%200%20means%20the%20test%20must%20pass%20on%20the%20first%20attempt.) to `latest` and specific version build `bats` tests for page `Not Found` error that sometimes happens from GitHub API call.