### PR TITLE
go/store/nbs: Fix race in chunk journal initialization.

### DIFF
--- a/go/store/nbs/journal.go
+++ b/go/store/nbs/journal.go
@@ -140,7 +140,9 @@ func (j *ChunkJournal) bootstrapJournalWriter(ctx context.Context) (err error) {
 		return err
 	}
 
-	if !ok { // create new journal file
+	canCreate := !j.backing.readOnly()
+
+	if canCreate && !ok { // create new journal file
 		j.wr, err = createJournalWriter(ctx, j.path)
 		if err != nil {
 			return err

--- a/go/store/nbs/journal_writer.go
+++ b/go/store/nbs/journal_writer.go
@@ -124,7 +124,7 @@ func createJournalWriter(ctx context.Context, path string) (wr *journalWriter, e
 	// Open the journal file and initialize it with 16KB of zero bytes. This is intended to
 	// ensure that we can write to the journal and to allocate space for the first set of
 	// records, but probably isn't strictly necessary.
-	if f, err = os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0666); err != nil {
+	if f, err = os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666); err != nil {
 		return nil, err
 	}
 	const batch = 1024 * 1024


### PR DESCRIPTION
With `dolt gc`, the store journal can be deleted and recreated as part of normal operation. When we bootstrap a new chunk journal, we always write 1MB of 0 bytes and a root hash record, reflecting the current root hash, at offset 0.

ChunkJournal takes an advisory exclusive lock when it opens the database data directory. It will operate in a read-only mode when it cannot take this lock.

Due to a bug, even when operating in read-only mode, the chunk journal bootstrap code would run if the store was requested to open the chunk journal but there were was no existing chunk journal on disk. This meant there was a race condition if a Dolt process opened the store in read-only mode while another process was going to GC the store. If the read-only store tried to open the journal file and did not find it, it could end up overwriting the beginning of the contents of a just-created journal file.

This PR adds two fixes:

1) When we create a journal file, we must be its actual creator. O_EXCL will
   cause os.Open() to return an error if this syscall did not create the file,
   which means we are not in charge and we need to bail.

2) When running in read-only mode, we should never create the journal file. We
   can try to read its contents if we learn of its existence, but if there is
   no file and we have been requested to open it, we should return an error.