### PR TITLE
Add a dolt checkout section to AGENT.md

### DIFF
--- a/go/libraries/doltcore/doltdb/AGENT.md
+++ b/go/libraries/doltcore/doltdb/AGENT.md
@@ -50,6 +50,7 @@ dolt checkout -b <branch-name>
 - Each SQL session (CLI `dolt sql`, MySQL client, application connection) maintains its own active branch. Run `CALL dolt_checkout('<branch>');` at the beginning of every session or scripted block to ensure you are on the correct branch.
 - Chain branch changes inside scripts: start with `CALL dolt_checkout('<branch>');`, then run your queries. Do not assume a previous checkout persists for new connections.
 - When automating, include the checkout in the same transaction / session context where the data changes execute.
+- A good way to make sure a `dolt sql` session connects to the br1 branch for instance is `dolt --branch br1 sql`.
 
 ### Data Operations
 ```bash


### PR DESCRIPTION
Coding agents seem to assume that `dolt checkout` and `call dolt_checkout()` are sticky across SQL sessions. This causes agents to often write to `main` instead of their intended branch. This is an attempt to mitigate that behavior.