### PR TITLE
refactor: remove redundant variable declarations in for loops

### DIFF
--- a/go/libraries/doltcore/remotestorage/chunk_fetcher.go
+++ b/go/libraries/doltcore/remotestorage/chunk_fetcher.go
@@ -205,7 +205,6 @@ func fetcherHashSetToGetDlLocsReqsThread(ctx context.Context, reqCh chan hash.Ha
 				break
 			}
 			for h := range hs {
-				h := h
 				addrs = append(addrs, h[:])
 			}
 		case thisResCh <- thisRes:

--- a/go/performance/utils/dolt_builder/run.go
+++ b/go/performance/utils/dolt_builder/run.go
@@ -82,7 +82,6 @@ func Run(parentCtx context.Context, commitList []string, profilePath string) err
 	}()
 
 	for _, commit := range commitList {
-		commit := commit // https://golang.org/doc/faq#closures_and_goroutines
 		g.Go(func() error {
 			return buildBinaries(ctx, tempDir, repoDir, doltBin, profilePath, commit)
 		})

--- a/go/store/blobstore/oci.go
+++ b/go/store/blobstore/oci.go
@@ -327,7 +327,6 @@ func uploadParts(ctx context.Context, objectName, uploadID string, numParts, con
 	for {
 		if batchSize >= maxBatchSize {
 			for _, u := range batch {
-				u := u
 				eg.Go(func() error {
 					cp, err := uploadF(egCtx, objectName, uploadID, u.partNum, int64(len(u.b)), bytes.NewReader(u.b))
 					if err != nil {
@@ -364,7 +363,6 @@ func uploadParts(ctx context.Context, objectName, uploadID string, numParts, con
 
 	if batchSize > 0 && len(batch) > 0 {
 		for _, u := range batch {
-			u := u
 			eg.Go(func() error {
 				cp, err := uploadF(egCtx, objectName, uploadID, u.partNum, int64(len(u.b)), bytes.NewReader(u.b))
 				if err != nil {

--- a/go/store/nbs/mem_table.go
+++ b/go/store/nbs/mem_table.go
@@ -119,7 +119,6 @@ func (mt *memTable) addGetChildRefs(getAddrs chunks.GetAddrsCb) {
 
 func (mt *memTable) addChildRefs(addrs hash.HashSet) {
 	for h := range addrs {
-		h := h
 		mt.pendingRefs = append(mt.pendingRefs, hasRecord{
 			a:      &h,
 			prefix: h.Prefix(),

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -1047,7 +1047,6 @@ func toGetRecords(hashes hash.HashSet) []getRecord {
 	reqs := make([]getRecord, len(hashes))
 	idx := 0
 	for h := range hashes {
-		h := h
 		reqs[idx] = getRecord{
 			a:      &h,
 			prefix: h.Prefix(),
@@ -1272,7 +1271,6 @@ func toHasRecords(hashes hash.HashSet) []hasRecord {
 	reqs := make([]hasRecord, len(hashes))
 	idx := 0
 	for h := range hashes {
-		h := h
 		reqs[idx] = hasRecord{
 			a:      &h,
 			prefix: h.Prefix(),


### PR DESCRIPTION
The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore