### PR TITLE
go/cmd/dolt: Allow the Dolt CLI to connect to a running dolt sql-server which is configured with require_secure_transport: true.

### DIFF
--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -623,8 +623,11 @@ If you're interested in running this command against a remote host, hit us up on
 		if !hasPort {
 			port = 3306
 		}
-		useTLS := !apr.Contains(cli.NoTLSFlag)
-		return sqlserver.BuildConnectionStringQueryist(ctx, cwdFS, creds, apr, host, port, useTLS, useDb)
+		tlsMode := sqlserver.QueryistTLSMode_Enabled
+		if apr.Contains(cli.NoTLSFlag) {
+			tlsMode = sqlserver.QueryistTLSMode_Disabled
+		}
+		return sqlserver.BuildConnectionStringQueryist(ctx, cwdFS, creds, apr, host, port, tlsMode, useDb)
 	} else {
 		_, hasPort := apr.GetInt(cli.PortFlag)
 		if hasPort {
@@ -712,7 +715,7 @@ If you're interested in running this command against a remote host, hit us up on
 			if !creds.Specified {
 				creds = &cli.UserPassword{Username: sqlserver.LocalConnectionUser, Password: localCreds.Secret, Specified: false}
 			}
-			return sqlserver.BuildConnectionStringQueryist(ctx, cwdFS, creds, apr, "localhost", localCreds.Port, false, useDb)
+			return sqlserver.BuildConnectionStringQueryist(ctx, cwdFS, creds, apr, "localhost", localCreds.Port, sqlserver.QueryistTLSMode_NoVerify_FallbackToPlaintext, useDb)
 		}
 	}
 


### PR DESCRIPTION
When Dolt CLI is running in a directory with a corresponding running sql-server process, it will connect to the server process and complete its work using SQL statements. Previously, the Dolt CLI was configured to always connect on a plaintext TCP connection for these connections. That meant it did not work for servers configured with require_secure_transport: true. One consequence was that the published Dolt dockerhub image did not work with require_secure_transport: true, since that image runs `dolt sql` against the running server as part of its entrypoint.

This changes `dolt` CLI to connect over (non-verified) TLS if such as an option is presented by the server. The CLI still falls back to plaintext as well.

Dolt CLI still does not work when the server is configured with require_client_certificate, since Dolt CLI does not currently have a way to configure its presented client certificate and private key. As a consequence, at least for the time being, the published DockerHub images for Dolt do not work with require_client_certificate: true.