### PR TITLE
Bug fix: correctly copy check constraints

### DIFF
--- a/go/libraries/doltcore/schema/check_coll.go
+++ b/go/libraries/doltcore/schema/check_coll.go
@@ -137,11 +137,11 @@ func NewCheck(name, expression string, enforced bool) check {
 	}
 }
 
-func (c checkCollection) Copy() CheckCollection {
-	checks := make([]check, len(c.checks))
+func (c *checkCollection) Copy() CheckCollection {
+	newC := *c
+	newC.checks = make([]check, len(c.checks))
 	for i, check := range c.checks {
-		checks[i] = NewCheck(check.name, check.expression, check.enforced)
+		newC.checks[i] = NewCheck(check.name, check.expression, check.enforced)
 	}
-
-	return &c
+	return &newC
 }

--- a/go/libraries/doltcore/schema/check_coll_test.go
+++ b/go/libraries/doltcore/schema/check_coll_test.go
@@ -1,0 +1,44 @@
+// Copyright 2025 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCopy(t *testing.T) {
+	var original = &checkCollection{
+		checks: []check{{"check1", "expr1", true},
+			{"check2", "expr2", false}},
+	}
+	var copy = original.Copy()
+
+	// Assert copy doesn't reuse the same check instances
+	original.checks[0].name = "XXX"
+	original.checks[0].expression = "XXX"
+	original.checks[0].enforced = false
+	original.checks[1].name = "XXX"
+	original.checks[1].expression = "XXX"
+	original.checks[1].enforced = true
+
+	assert.Equal(t, "check1", copy.AllChecks()[0].Name())
+	assert.Equal(t, "expr1", copy.AllChecks()[0].Expression())
+	assert.Equal(t, true, copy.AllChecks()[0].Enforced())
+	assert.Equal(t, "check2", copy.AllChecks()[1].Name())
+	assert.Equal(t, "expr2", copy.AllChecks()[1].Expression())
+	assert.Equal(t, false, copy.AllChecks()[1].Enforced())
+}


### PR DESCRIPTION
A customer reported a strange behavior where check constraints were getting corrupted/duplicated. The root cause was a bug in the CheckConstraint.Copy() implementation that wasn't returning a copy of the underlying checks, and allowed another part of engine to modify the check constraints accidentally. 