### PR TITLE
go: store/datas/pull: pull_chunk_tracker.go: Optimize memory use when backing up to an AWS remote.

### DIFF
--- a/go/store/datas/pull/pull_chunk_fetcher_test.go
+++ b/go/store/datas/pull/pull_chunk_fetcher_test.go
@@ -190,15 +190,25 @@ func TestPop(t *testing.T) {
 		backing[i] = new(int)
 		*backing[i] = i
 	}
+	// s is pointers of [0, 1, 2, ..., 16]
 	s := backing[:]
+	assert.Len(t, s, 16)
+	// pop continuously and assert that we see
+	// the sequence 0, 1, 2, ..., 16 and each
+	// prior element at the end of the list is
+	// |nil|.
 	for i := range 16 {
-		assert.Len(t, s, 16-i)
 		var p *int
 		p, s = pop(s)
 		assert.Len(t, s, 16-i-1)
 		assert.Equal(t, i, *p)
+		// One off the end of the new |s| is now nil.
 		assert.Nil(t, backing[16-i-1], "i is %d", i)
 	}
+	// pop has a precondition of len > 0. This should panic.
+	assert.Panics(t, func() {
+		pop(backing[:0])
+	})
 }
 
 func TestAppendAbsent(t *testing.T) {


### PR DESCRIPTION
PullChunkTracker is responsible for making the HasMany calls against the destination and batching up absent hashes into HashSets which will be delivered to GetManyCompressed and eventually written into table files which are uploaded. This code is used for both pull and push, when the destination is the "local" database or when destination is the remote database respectively. It is used when the remote is both doltremoteapi, thus every HasMany call is an RPC, and when the remote is something like file:// or aws://, thus the table file indexes for the remote are in memory and HasMany calls are very quick.

Different operational characteristics of the various dependencies mean that sometimes a Pull is prone to build up large sets of hashes waiting for HasMany calls, whereas other times it is prone to build up large sets of absent hashes which are waiting for the fetcher thread(s) to take them.

Previously, PullChunkTracker was structured to accumulate HasMany responses and wait to batch them into appropriately-sized batches for GetManyCompressed until the fetcher threads asked for them. This meant that if HasMany batches were very small, because HasMany was very fast, we would accumulate a large number of very small HashSets. These HashSets would take up large amounts of memory. Accumulating the batches as the HasMany responses come in is more memory efficient and should be no slower - we will always accumulate the full batches, and in basically the same order.

Tested by pushing a large database to an AWS remote and memory profiling the result.