### PR TITLE
codeaucafe/NOISSUE: remove redundant beginTableCalled variable

### DIFF
--- a/go/cmd/dolt/commands/diff_filter_test.go
+++ b/go/cmd/dolt/commands/diff_filter_test.go
@@ -402,9 +402,7 @@ func TestLazyRowWriter_NoRowsWritten(t *testing.T) {
 	mockDW := &mockDiffWriter{}
 	realWriter := &mockRowWriter{}
 
-	beginTableCalled := false
 	onFirstWrite := func() error {
-		beginTableCalled = true
 		return mockDW.BeginTable("fromTable", "toTable", false, false)
 	}
 
@@ -417,7 +415,7 @@ func TestLazyRowWriter_NoRowsWritten(t *testing.T) {
 	}
 
 	// BeginTable should NEVER have been called
-	if beginTableCalled {
+	if mockDW.beginTableCalled {
 		t.Error("BeginTable() was called even though no rows were written - should have been lazy!")
 	}
 }


### PR DESCRIPTION
As noted by @elianddb in my PR adding `--filter` option to dolt diff I was using a redundant bool variable that was already available on the mockDiffWriter. 

This is a small trivial PR to remove the standalone `beginTableCalled` variable in `TestLazyRowWriter_NoRowsWritten` test function. The test now uses mockDW.beginTableCalled directly, which maintains consistency with other test functions (`TestLazyRowWriter_RowsWritten` and `TestLazyRowWriter_CombinedRowsWritten`) that already follow this pattern.

Note: please feel free to cancel/close this PR if it's not necessary, to small, or something else. I put up the PR because it was fast and the type of thing that will keep bothering me 🤣