### PR TITLE
[no-release-notes] Remove redundant beginTableCalled variable

### DIFF
--- a/go/cmd/dolt/commands/diff_filter_test.go
+++ b/go/cmd/dolt/commands/diff_filter_test.go
@@ -402,9 +402,7 @@ func TestLazyRowWriter_NoRowsWritten(t *testing.T) {
 	mockDW := &mockDiffWriter{}
 	realWriter := &mockRowWriter{}
 
-	beginTableCalled := false
 	onFirstWrite := func() error {
-		beginTableCalled = true
 		return mockDW.BeginTable("fromTable", "toTable", false, false)
 	}
 
@@ -417,7 +415,7 @@ func TestLazyRowWriter_NoRowsWritten(t *testing.T) {
 	}
 
 	// BeginTable should NEVER have been called
-	if beginTableCalled {
+	if mockDW.beginTableCalled {
 		t.Error("BeginTable() was called even though no rows were written - should have been lazy!")
 	}
 }


### PR DESCRIPTION
Author @codeaucafe
Remove standalone `beginTableCalled` variable in `TestLazyRowWriter_NoRowsWritten` test function.
Closes #10200