### PR TITLE
[no-release-notes] missing object panic

### DIFF
--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -743,11 +743,11 @@ func execShell(sqlCtx *sql.Context, qryist cli.Queryist, format engine.PrintResu
 	shell.SetMultiPrompt(initialMultilinePrompt)
 	// TODO: update completer on create / drop / alter statements
 	completer, err := newCompleter(sqlCtx, qryist)
-	if err != nil {
-		return err
+	if err == nil {
+		shell.CustomCompleter(completer)
+	} else {
+		cli.PrintErrln("Warning: could not initialize shell completer:", err.Error())
 	}
-
-	shell.CustomCompleter(completer)
 
 	shell.EOF(func(c *ishell.Context) {
 		c.Stop()

--- a/go/libraries/doltcore/schema/encoding/schema_marshaling.go
+++ b/go/libraries/doltcore/schema/encoding/schema_marshaling.go
@@ -466,6 +466,9 @@ func UnmarshalSchemaAtAddr(ctx context.Context, vr types.ValueReader, addr hash.
 	if err != nil {
 		return nil, err
 	}
+	if schemaVal == nil {
+		return nil, fmt.Errorf("database malformed: no schema found at address %s", addr.String())
+	}
 
 	sch, err := UnmarshalSchema(ctx, vr.Format(), schemaVal)
 	if err != nil {

--- a/go/libraries/doltcore/schema/encoding/schema_marshaling_test.go
+++ b/go/libraries/doltcore/schema/encoding/schema_marshaling_test.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/go-mysql-server/sql"
 	gmstypes "github.com/dolthub/go-mysql-server/sql/types"
 	"github.com/dolthub/vitess/go/sqltypes"
@@ -34,6 +33,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/constants"
+	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/marshal"
 	"github.com/dolthub/dolt/go/store/types"
 )

--- a/go/libraries/doltcore/schema/encoding/schema_marshaling_test.go
+++ b/go/libraries/doltcore/schema/encoding/schema_marshaling_test.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/go-mysql-server/sql"
 	gmstypes "github.com/dolthub/go-mysql-server/sql/types"
 	"github.com/dolthub/vitess/go/sqltypes"
@@ -49,6 +50,13 @@ func createTestSchema() schema.Schema {
 	sch := schema.MustSchemaFromCols(colColl)
 	_, _ = sch.Indexes().AddIndexByColTags("idx_age", []uint64{3}, nil, schema.IndexProperties{IsUnique: false, Comment: ""})
 	return sch
+}
+
+func TestSchemaUnmarshal(t *testing.T) {
+	_, vrw, _, err := dbfactory.MemFactory{}.CreateDB(context.Background(), types.Format_Default, nil, nil)
+	val, err := UnmarshalSchemaAtAddr(context.Background(), vrw, hash.Parse("badaddrvvvvvvvvvvvvvvvvvvvvvvvvv"))
+	require.Error(t, err)
+	require.Nil(t, val)
 }
 
 func TestNomsMarshalling(t *testing.T) {


### PR DESCRIPTION
While mangling databases, I discovered that if you remove the schema object from storage, the lookup only checks for errors, not for nil. This resulted in a panic in unmarshalling. In the SQL server case, this would mean the server wouldn't start even if some databases weren't corrupt.

The sql shell chain was tacked on because I noticed that even if you attempted to connect to a working database, the shell errored our because it does a query to initialize the completer which hits all databases.