### PR TITLE
bug fix: stop including all root objects when getting tables on the search path

### DIFF
--- a/go/libraries/doltcore/sqle/resolve/resolve_tables.go
+++ b/go/libraries/doltcore/sqle/resolve/resolve_tables.go
@@ -64,7 +64,7 @@ func TablesOnSearchPath(ctx *sql.Context, root doltdb.RootValue) ([]doltdb.Table
 
 	var tableNames []doltdb.TableName
 	for _, schemaName := range schemasToSearch {
-		names, err := root.GetTableNames(ctx, schemaName, true)
+		names, err := root.GetTableNames(ctx, schemaName, false)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
In Doltgres, `SHOW TABLES` was returning table names as well as other root object names, like sequence names. This PR changes the `TablesOnSearchPath` function to stop returning the other root object names. 

Related to: 
https://github.com/dolthub/doltgresql/issues/1743