### PR TITLE
/{go,integration-tests}: support environment variable interpolation

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -88,7 +88,6 @@ ENVIRONMENT VARIABLE INTERPOLATION:
 SQL server yaml configs support environment variable interpolation:
 
   ${VAR}             Expands to the value of VAR (error if VAR is unset or empty)
-  ${VAR:-default}    Expands to VAR if set and non-empty; otherwise expands to default
   $$                Escapes to a literal '$'
 
 Notes:

--- a/go/libraries/doltcore/servercfg/yaml_config.go
+++ b/go/libraries/doltcore/servercfg/yaml_config.go
@@ -194,7 +194,7 @@ func YamlConfigFromFile(fs filesys.Filesys, path string) (ServerConfig, error) {
 		return nil, fmt.Errorf("Failed to read file '%s'. Error: %s", path, err.Error())
 	}
 
-	data, err = interpolateEnv(data, nil)
+	data, err = interpolateEnv(data)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to interpolate environment variables in yaml file '%s'. Error: %s", path, err.Error())
 	}


### PR DESCRIPTION
Adds support for environment variable interpolation in the `dolt sql-server` configuration file (`config.yaml`).

Users can now reference environment variables using the `${VAR}` syntax, which will be replaced at runtime with the value of the `VAR` environment variable.