### PR TITLE
`dolt stash apply`

### DIFF
--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -104,24 +104,32 @@ func (cmd StatusCmd) Exec(ctx context.Context, commandStr string, args []string,
 
 	showIgnoredTables := apr.Contains(cli.ShowIgnoredFlag)
 
-	// configure SQL engine
-	queryist, err := cliCtx.QueryEngine(ctx)
-	if err != nil {
-		return handleStatusVErr(err)
-	}
-
-	// get status information from the database
-	pd, err := createPrintData(err, queryist.Queryist, queryist.Context, showIgnoredTables, cliCtx)
-	if err != nil {
-		return handleStatusVErr(err)
-	}
-
-	err = printEverything(pd)
+	err := PrintStatus(ctx, showIgnoredTables, cliCtx)
 	if err != nil {
 		return handleStatusVErr(err)
 	}
 
 	return 0
+}
+
+func PrintStatus(ctx context.Context, showIgnoredTables bool, cliCtx cli.CliContext) error {
+	// configure SQL engine
+	queryist, err := cliCtx.QueryEngine(ctx)
+	if err != nil {
+		return err
+	}
+
+	// get status information from the database
+	pd, err := createPrintData(nil, queryist.Queryist, queryist.Context, showIgnoredTables, cliCtx)
+	if err != nil {
+		return err
+	}
+
+	err = printEverything(pd)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func createPrintData(err error, queryist cli.Queryist, sqlCtx *sql.Context, showIgnoredTables bool, cliCtx cli.CliContext) (*printData, error) {

--- a/integration-tests/bats/stash.bats
+++ b/integration-tests/bats/stash.bats
@@ -676,7 +676,7 @@ teardown() {
     [[ "$output" =~ "Dropped refs/stash@{0}" ]] || false
 }
 
-@test "stash: can apply stashes as specific indices" {
+@test "stash: can apply stashes at specific indices" {
     dolt sql -q "create table test1 (i int)"
     dolt stash -a
     dolt sql -q "create table test2 (i int)"
@@ -685,6 +685,6 @@ teardown() {
     dolt stash -a
     run dolt stash apply 1
     [ "$status" -eq 0 ]
-    run dolt stash apply 2
+    run dolt stash apply stash@{2}
     [ "$status" -eq 0 ]
 }

--- a/integration-tests/bats/stash.bats
+++ b/integration-tests/bats/stash.bats
@@ -117,7 +117,7 @@ teardown() {
 
     run dolt stash pop
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "No stash entries found." ]] || false
+    [[ "$output" =~ "no stash entries found" ]] || false
 
     dolt sql -q "INSERT INTO test VALUES (2, 'b')"
     dolt stash
@@ -674,4 +674,17 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" =~ "nothing to commit, working tree clean" ]] || false
     [[ "$output" =~ "Dropped refs/stash@{0}" ]] || false
+}
+
+@test "stash: can apply stashes as specific indices" {
+    dolt sql -q "create table test1 (i int)"
+    dolt stash -a
+    dolt sql -q "create table test2 (i int)"
+    dolt stash -a
+    dolt sql -q "create table test3 (i int)"
+    dolt stash -a
+    run dolt stash apply 1
+    [ "$status" -eq 0 ]
+    run dolt stash apply 2
+    [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
Adds #10131 

Adds `dolt stash apply`. Functions similar to `drop` and `pop` in usage: accepts no argument for most recent stash, or `int` or `stash@{int}` for non-top stashes. i.e. `dolt stash apply 2` or `dolt stash apply stash@{2}`.