### PR TITLE
Fix `show tables` to show singular name when local table name conflicts with a non-local table name

### DIFF
--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -1690,6 +1690,7 @@ func (db Database) GetAllTableNames(ctx *sql.Context, showSystemTables bool) ([]
 func (db Database) getAllTableNames(ctx *sql.Context, root doltdb.RootValue, includeGeneratedSystemTables bool, includeRootObjects bool, includeNonlocalTables readNonlocalTablesFlag) ([]string, error) {
 	var err error
 	var result []string
+	localNameSet := map[string]any{}
 	// If we are in a schema-enabled session and the schema name is not set, we need to union all table names in all
 	// schemas in the search_path
 	if resolve.UseSearchPath && db.schemaName == "" {
@@ -1704,6 +1705,9 @@ func (db Database) getAllTableNames(ctx *sql.Context, root doltdb.RootValue, inc
 		result, err = root.GetTableNames(ctx, db.schemaName, includeRootObjects)
 		if err != nil {
 			return nil, err
+		}
+		for _, nameStr := range result {
+			localNameSet[nameStr] = nil
 		}
 	}
 
@@ -1722,7 +1726,12 @@ func (db Database) getAllTableNames(ctx *sql.Context, root doltdb.RootValue, inc
 		if err != nil {
 			return nil, err
 		}
-		result = append(result, nonlocalTableNames...)
+		for _, nonLocalTableName := range nonlocalTableNames {
+			_, ok := localNameSet[nonLocalTableName]
+			if !ok {
+				result = append(result, nonLocalTableName)
+			}
+		}
 	}
 
 	return result, nil

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -1690,7 +1690,7 @@ func (db Database) GetAllTableNames(ctx *sql.Context, showSystemTables bool) ([]
 func (db Database) getAllTableNames(ctx *sql.Context, root doltdb.RootValue, includeGeneratedSystemTables bool, includeRootObjects bool, includeNonlocalTables readNonlocalTablesFlag) ([]string, error) {
 	var err error
 	var result []string
-	localNameSet := map[string]any{}
+	localNameSet := map[string]struct{}{}
 	// If we are in a schema-enabled session and the schema name is not set, we need to union all table names in all
 	// schemas in the search_path
 	if resolve.UseSearchPath && db.schemaName == "" {
@@ -1707,7 +1707,7 @@ func (db Database) getAllTableNames(ctx *sql.Context, root doltdb.RootValue, inc
 			return nil, err
 		}
 		for _, nameStr := range result {
-			localNameSet[nameStr] = nil
+			localNameSet[nameStr] = struct{}{}
 		}
 	}
 

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -1728,6 +1728,9 @@ func (db Database) getAllTableNames(ctx *sql.Context, root doltdb.RootValue, inc
 		}
 		for _, nonLocalTableName := range nonlocalTableNames {
 			_, ok := localNameSet[nonLocalTableName]
+			// The semantics here are a little backwards, in reality the non-local table is prioritized. Since the names
+			// happen to match, we avoid the extra modification of shifting the name position. This does result in some
+			// non-local table names to not be grouped together, however.
 			if !ok {
 				result = append(result, nonLocalTableName)
 			}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_nonlocal.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_nonlocal.go
@@ -183,4 +183,30 @@ var NonlocalScripts = []queries.ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "nonlocal table appears once in show tables when local table exists",
+		SetUpScript: []string{
+			"CREATE TABLE foo (id int auto_increment primary key);",
+			"CALL dolt_commit('-Am', 'create table foo');",
+			"CALL dolt_branch('test');",
+			"INSERT INTO foo values (1);",
+			`INSERT INTO dolt_nonlocal_tables (table_name, target_ref, options) VALUES ('foo', 'main', 'immediate');`,
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "show tables;",
+				Expected: []sql.Row{{"foo"}},
+			},
+			{
+				Query: "call dolt_checkout('test');",
+			},
+			// TODO(elianddb): Add an indicator that the current local table (not part of the target reference for the
+			//  non-local pattern) is currently shadowed. This would provide actionable feedback, but for now only show
+			//  a singular name for the non-local table, as it's the only queryable one.
+			{
+				Query:    "show tables;",
+				Expected: []sql.Row{{"foo"}},
+			},
+		},
+	},
 }


### PR DESCRIPTION
Fix dolthub/dolt#10283