### PR TITLE
Fix malformed .dolt directories being listed as databases

### DIFF
--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -277,7 +277,7 @@ func GetDefaultInitBranch(cfg config.ReadableConfig) string {
 // Valid returns whether this environment has been properly initialized. This is useful because although every command
 // gets a DoltEnv, not all of them require it, and we allow invalid dolt envs to be passed around for this reason.
 func (dEnv *DoltEnv) Valid() bool {
-	return dEnv != nil && dEnv.CfgLoadErr == nil && dEnv.DBLoadError == nil && dEnv.HasDoltDir() && dEnv.HasDoltDataDir()
+	return dEnv != nil && dEnv.CfgLoadErr == nil && dEnv.DBLoadError == nil && dEnv.RSLoadErr == nil && dEnv.HasDoltDir() && dEnv.HasDoltDataDir()
 }
 
 // initWorkingSetFromRepoState sets the working set for the env's head to mirror the contents of the repo state file.

--- a/integration-tests/bats/sql.bats
+++ b/integration-tests/bats/sql.bats
@@ -1589,11 +1589,6 @@ SQL
     mkdir -p decoy/.dolt/noms/temptf
     echo '{}' > decoy/config.json
 
-    # Not doing this cd ../ results in the teardown method failing on
-    # a skip, not sure why. It's not part of the actual test
-    cd ../
-    skip "This results in a panic right now"
-
     run dolt sql -q "show databases" -r csv
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" -eq 2 ]


### PR DESCRIPTION
Add RSLoadErr check to Valid() method so directories without a valid repo_state.json are not considered valid databases.