### PR TITLE
When DB files can't be read off disk, fail with a clear error rather than a panic

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -192,7 +192,11 @@ func ConfigureServices(
 	AssertNoDatabasesInAccessModeReadOnly := &svcs.AnonService{
 		InitF: func(ctx context.Context) (err error) {
 			return mrEnv.Iter(func(name string, dEnv *env.DoltEnv) (stop bool, err error) {
-				if dEnv.IsAccessModeReadOnly(ctx) {
+				readOnly, err := dEnv.IsAccessModeReadOnly(ctx)
+				if err != nil {
+					return true, err
+				}
+				if readOnly {
 					return true, ErrCouldNotLockDatabase.New(name)
 				}
 				return false, nil

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -2265,3 +2265,25 @@ EOF
     [ "$status" -eq 0 ]
     [[ ! "$output" =~ "Empty database name" ]] || false
 }
+
+@test "sql-server: read permission failure clearly communicated" {
+  start_sql_server > server_log.txt 2>&1 && sleep 0.5
+
+  stop_sql_server 1 && sleep 0.5
+
+  # Server log should say nothing about permissions.
+  run grep -F "permission denied" server_log.txt
+  [ $status -eq 1 ]
+
+  chmod 0000 repo1/.dolt/noms/manifest
+  start_sql_server > server_log.txt 2>&1 && sleep 0.5
+
+  grep -F "permission denied" server_log.txt
+
+  # revert, and do the same with the journal file.
+  chmod 0600 repo1/.dolt/noms/manifest
+  chmod 0000 repo1/.dolt/noms/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+
+  start_sql_server > server_log.txt 2>&1 && sleep 0.5
+  grep -F "permission denied" server_log.txt
+}


### PR DESCRIPTION
For reasons not fully understood yet, a hosted instance ended up with a .dolt/noms/manifest file which was not readable by the DB process. This caused a panic, which should never happen. This change provides a clear error message stating what file you're lacking permissions to.