### PR TITLE
go/cmd/dolt: Make movable temp file configuration lazy.

### DIFF
--- a/go/store/util/tempfiles/temp_files.go
+++ b/go/store/util/tempfiles/temp_files.go
@@ -80,6 +80,12 @@ func (tfp *TempFileProviderAt) Clean() {
 	}
 }
 
+// LazyTempFileProvider will load the TempFileProvider from |loader|
+// on first access and then return temp files based on that result
+// going forward. This is configured for the dolt process's data
+// directory to get our process-wide MovableTempFileProvider early in
+// the Dolt process's life cycle, but the required capabilities are
+// not checked for until first use.
 type LazyTempFileProvider struct {
 	once     sync.Once
 	loader   func() (TempFileProvider, error)

--- a/go/store/util/tempfiles/temp_files.go
+++ b/go/store/util/tempfiles/temp_files.go
@@ -128,7 +128,7 @@ func (p *LazyTempFileProvider) NewFile(dir, pattern string) (*os.File, error) {
 	return p.provider.NewFile(dir, pattern)
 }
 
-// MovableTemFile is an object that implements TempFileProvider that is used by the nbs to create temp files that
+// MovableTempFile is an object that implements TempFileProvider that is used by the nbs to create temp files that
 // ultimately will be renamed.  It is important to use this instance rather than using os.TempDir, or os.CreateTemp
 // directly as those may have errors executing a rename against if the volume the default temporary directory lives on
 // is different than the volume of the destination of the rename.


### PR DESCRIPTION
Previously, early in the process life-cycle after dolt was run, dolt would immediately check if a file created in `os.TempDir()` was able to be `os.Rename`d into a subdirectory of the dolt process's data directory, by default `$PWD/.dolt`. If the rename failed, it would configure Dolt to use `.dolt/temptf` as the movable temp file directory instead.

This meant that for many `dolt` invocations, Dolt would do some local filesystem writes, including potentially `Mkdir(.dolt)` before it it was fully loaded. With the advent of things like dolt accessing the running server through sql-server.info and `dolt --host ... sql` this behavior was not ideal. It creates races with concurrently run `dolt` processes that try to use the `.dolt` directory, and it creates odd behavior when running something like `dolt sql` in a non-Dolt directory but on a filesystem mount where this rename from `os.TempDir()` does not work.

This PR changes the check and the configuration of a potential `.dolt/temptf` directory to be delayed until the first temporary movable file is actually requested by Dolt. At that point we know that we have a need for a renamable temp file and it is OK to go ahead and create `.dolt/temptf` if we need it.

This PR changes the error handling around some edge cases like permissions errors on the calling process creating `temptf` within `.dolt`. In particular, some errors which were previously early and fatal are now delayed until use site and may end up being persistent but non-fatal to the process, depending on the operation.