### PR TITLE
go/store/nbs: Fix possible data loss from Dolt CLI utilization when executing against a running server that was in the process of writing to its journal file.

### DIFF
--- a/go/store/nbs/journal.go
+++ b/go/store/nbs/journal.go
@@ -155,7 +155,7 @@ func (j *ChunkJournal) bootstrapJournalWriter(ctx context.Context, warningsCb fu
 			return err
 		}
 
-		_, err = j.wr.bootstrapJournal(ctx, j.reflogRingBuffer, warningsCb)
+		_, err = j.wr.bootstrapJournal(ctx, canCreate, j.reflogRingBuffer, warningsCb)
 		if err != nil {
 			return err
 		}
@@ -183,7 +183,7 @@ func (j *ChunkJournal) bootstrapJournalWriter(ctx context.Context, warningsCb fu
 	}
 
 	// parse existing journal file
-	root, err := j.wr.bootstrapJournal(ctx, j.reflogRingBuffer, warningsCb)
+	root, err := j.wr.bootstrapJournal(ctx, canCreate, j.reflogRingBuffer, warningsCb)
 	if err != nil {
 		return err
 	}

--- a/go/store/nbs/journal_writer.go
+++ b/go/store/nbs/journal_writer.go
@@ -163,7 +163,7 @@ var _ io.Closer = &journalWriter{}
 // are added to the novel ranges map. If the number of novel lookups exceeds |wr.maxNovel|, we
 // extend the journal index with one metadata flush before existing this function to save indexing
 // progress.
-func (wr *journalWriter) bootstrapJournal(ctx context.Context, reflogRingBuffer *reflogRingBuffer, warningsCb func(error)) (last hash.Hash, err error) {
+func (wr *journalWriter) bootstrapJournal(ctx context.Context, canWrite bool, reflogRingBuffer *reflogRingBuffer, warningsCb func(error)) (last hash.Hash, err error) {
 	wr.lock.Lock()
 	defer wr.lock.Unlock()
 
@@ -276,7 +276,7 @@ func (wr *journalWriter) bootstrapJournal(ctx context.Context, reflogRingBuffer 
 	// process the non-indexed portion of the journal starting at |wr.indexed|,
 	// at minimum the non-indexed portion will include a root hash record.
 	// Index lookups are added to the ongoing batch to re-synchronize.
-	wr.off, err = processJournalRecords(ctx, wr.journal, wr.indexed, func(o int64, r journalRec) error {
+	wr.off, err = processJournalRecords(ctx, wr.journal, canWrite, wr.indexed, func(o int64, r journalRec) error {
 		switch r.kind {
 		case chunkJournalRecKind:
 			rng := Range{

--- a/go/store/nbs/journal_writer_test.go
+++ b/go/store/nbs/journal_writer_test.go
@@ -185,7 +185,7 @@ func newTestJournalWriter(t *testing.T, path string) *journalWriter {
 	j, err := createJournalWriter(ctx, path)
 	require.NoError(t, err)
 	require.NotNil(t, j)
-	_, err = j.bootstrapJournal(ctx, nil, nil)
+	_, err = j.bootstrapJournal(ctx, true, nil, nil)
 	require.NoError(t, err)
 	return j
 }
@@ -220,7 +220,7 @@ func TestJournalWriterBootstrap(t *testing.T) {
 	j, _, err := openJournalWriter(ctx, path)
 	require.NoError(t, err)
 	reflogBuffer := newReflogRingBuffer(10)
-	last, err = j.bootstrapJournal(ctx, reflogBuffer, nil)
+	last, err = j.bootstrapJournal(ctx, true, reflogBuffer, nil)
 	require.NoError(t, err)
 	assertExpectedIterationOrder(t, reflogBuffer, []string{last.String()})
 
@@ -363,7 +363,7 @@ func TestJournalIndexBootstrap(t *testing.T) {
 				require.NoError(t, err)
 				require.True(t, ok)
 				// bootstrap journal and validate chunk records
-				last, err := journal.bootstrapJournal(ctx, nil, nil)
+				last, err := journal.bootstrapJournal(ctx, true, nil, nil)
 				assert.NoError(t, err)
 				for _, e := range expected {
 					var act CompressedChunk
@@ -398,7 +398,7 @@ func TestJournalIndexBootstrap(t *testing.T) {
 			jnl, ok, err := openJournalWriter(ctx, idxPath)
 			require.NoError(t, err)
 			require.True(t, ok)
-			_, err = jnl.bootstrapJournal(ctx, nil, nil)
+			_, err = jnl.bootstrapJournal(ctx, true, nil, nil)
 			assert.Error(t, err)
 		})
 	}

--- a/integration-tests/go-sql-server-driver/repro_10331_test.go
+++ b/integration-tests/go-sql-server-driver/repro_10331_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	//	"context"
+	//	"database/sql"
+	//	sqldriver "database/sql/driver"
+	//	"fmt"
+	//	"strings"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	//	"time"
+
+	//	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	//	"golang.org/x/sync/errgroup"
+
+	driver "github.com/dolthub/dolt/go/libraries/doltcore/dtestutils/sql_server_driver"
+)
+
+// TestRegression10331 tests for the checksum error caused by concurrent executions of `dolt sql`
+// while dolt sql-server is processing writes.
+//
+// https://github.com/dolthub/dolt/issues/10331
+func TestRegression10331(t *testing.T) {
+	t.Parallel()
+	// This test is not 100% reliable at detecting errors quickly, so we run it a few times.
+	const testCount = 4
+	for i := range testCount {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var ports DynamicResources
+			ports.global = &GlobalPorts
+			ports.t = t
+			u, err := driver.NewDoltUser()
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				u.Cleanup()
+			})
+
+			rs, err := u.MakeRepoStore()
+			require.NoError(t, err)
+
+			repo, err := rs.MakeRepo("regression_10331_test")
+			require.NoError(t, err)
+
+			srvSettings := &driver.Server{
+				Args:        []string{"-P", `{{get_port "server_port"}}`},
+				DynamicPort: "server_port",
+			}
+			server := MakeServer(t, repo, srvSettings, &ports)
+			server.DBName = "regression_10331_test"
+
+			db, err := server.DB(driver.Connection{User: "root"})
+			require.NoError(t, err)
+			defer db.Close()
+
+			ctx := t.Context()
+
+			func() {
+				conn, err := db.Conn(ctx)
+				require.NoError(t, err)
+				defer conn.Close()
+
+				// Create table and initial data.
+				_, err = conn.ExecContext(ctx, "CREATE TABLE data (id INT PRIMARY KEY AUTO_INCREMENT, val LONGTEXT)")
+				require.NoError(t, err)
+				for i := 0; i <= 50; i++ {
+					var bs [10240]byte
+					rand.Read(bs[:])
+					data := base64.StdEncoding.EncodeToString(bs[:])
+					_, err = conn.ExecContext(ctx, "INSERT INTO data (val) VALUES (?)", data)
+					require.NoError(t, err)
+				}
+				_, err = conn.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', 'init with data')")
+				require.NoError(t, err)
+			}()
+
+			eg, ctx := errgroup.WithContext(ctx)
+			start := time.Now()
+
+			var successfulWrites, successfulReads int32
+			var errWrites, errReads int32
+			const numWriters = 8
+			const numReaders = 16
+			const testDuration = 8 * time.Second
+			for i := range numWriters {
+				eg.Go(func() error {
+					var bs [1024]byte
+					rand.Read(bs[:])
+					data := base64.StdEncoding.EncodeToString(bs[:])
+					j := 0
+					for {
+						if time.Since(start) > testDuration {
+							return nil
+						}
+						if ctx.Err() != nil {
+							return nil
+						}
+						out, err := func() (string, error) {
+							cmd := repo.DoltCmd("sql", "-r", "csv", "-q", fmt.Sprintf("INSERT INTO data (val) VALUES ('%s'); CALL DOLT_COMMIT('--allow-empty', '-Am', 'w%d c%d')", data, i, j))
+							out, err := cmd.CombinedOutput()
+							return string(out), err
+						}()
+						if err != nil {
+							t.Logf("error writing, %v", err)
+							atomic.AddInt32(&errWrites, 1)
+							if strings.Contains(out, "checksum") || strings.Contains(out, " EOF") {
+								return fmt.Errorf("error writing values %d: %s, %w", i, out, err)
+							}
+						} else {
+							atomic.AddInt32(&successfulWrites, 1)
+						}
+						j += 1
+					}
+				})
+			}
+			for i := range numReaders {
+				eg.Go(func() error {
+					j := 0
+					for {
+						if time.Since(start) > testDuration {
+							return nil
+						}
+						if ctx.Err() != nil {
+							return nil
+						}
+						out, err := func() (string, error) {
+							cmd := repo.DoltCmd("sql", "-r", "csv", "-q", "SELECT COUNT(*) FROM data; SELECT * FROM dolt_log LIMIT 20")
+							out, err := cmd.CombinedOutput()
+							return string(out), err
+						}()
+						if err != nil {
+							t.Logf("error reading, %v", err)
+							atomic.AddInt32(&errReads, 1)
+							if strings.Contains(out, "checksum") || strings.Contains(out, " EOF") {
+								return fmt.Errorf("READER error %d: %s, %w", i, out, err)
+							}
+						} else {
+							atomic.AddInt32(&successfulReads, 1)
+						}
+						j += 1
+					}
+				})
+			}
+
+			require.NoError(t, eg.Wait())
+			t.Logf("err writes: %d, err reads: %d", errWrites, errReads)
+			t.Logf("successful writes: %d, successful reads: %d", successfulWrites, successfulReads)
+		})
+	}
+}


### PR DESCRIPTION
Since Dolt v1.78.5, Dolt has truncated the journal file to the latest successfully loaded record when it successfully loads a database. This is the correct behavior when the CLI is operating as the exclusive writer to the database. However, Dolt also has a mode where it can load the database in read-only mode. Due to a bug, Dolt was also truncating the journal file when it was operating in this mode. The end result was the running something like `dolt sql -r csv -q ...` against a Dolt database that was running a sql-server and was currently accepting writes could incorrectly truncate the journal file. The Dolt sql-server process would go ahead writing into the journal at its previously extended offset and the space between the truncation and the next write offset would be 0 filled by the operating system. Attempting to load the database later or accessing the chunks located at that corrupted portion of the journal file would result in checksum errors or failure to load messages.

This change correctly updates Dolt to only Truncate the journal file when we are loading it in read-write mode.