### PR TITLE
go.mod,.github: Bump Go version to 1.25.6.

### DIFF
--- a/.github/workflows/cd-release-pgo.yaml
+++ b/.github/workflows/cd-release-pgo.yaml
@@ -85,9 +85,9 @@ jobs:
         run: |
           latest=$(git rev-parse HEAD)
           echo "commitish=$latest" >> $GITHUB_OUTPUT
-          GO_BUILD_VERSION=1.25.3 go/utils/publishrelease/buildpgobinaries.sh
+          GO_BUILD_VERSION=1.25.6 go/utils/publishrelease/buildpgobinaries.sh
         env:
-          GO_BUILD_VERSION: "1.25.3"
+          GO_BUILD_VERSION: "1.25.6"
           PROFILE: ${{ format('{0}/dolt-cpu-profile.pprof', github.workspace) }}
       - name: Create Release
         id: create_release

--- a/go/go.mod
+++ b/go/go.mod
@@ -202,4 +202,4 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 )
 
-go 1.25.3
+go 1.25.6

--- a/go/utils/devbuild/build.sh
+++ b/go/utils/devbuild/build.sh
@@ -6,7 +6,7 @@ set -o pipefail
 script_dir=$(dirname "$0")
 cd $script_dir/../..
 
-GO_BUILD_VERSION=1.25.3
+GO_BUILD_VERSION=1.25.6
 
 if (( $# != 1 )); then
   echo "usage: build.sh linux-arm64|linux-amd64|darwin-arm64|darwin-amd64|windows-amd64"

--- a/integration-tests/go-sql-server-driver/go.mod
+++ b/integration-tests/go-sql-server-driver/go.mod
@@ -1,6 +1,6 @@
 module github.com/dolthub/dolt/integration-tests/go-sql-server-driver
 
-go 1.25.3
+go 1.25.6
 
 require (
 	github.com/dolthub/dolt/go v0.40.4


### PR DESCRIPTION
Fixes potential impact in some configurations from CVE-2025-61729.