### PR TITLE
Fix SQL engine panic when database is locked

### DIFF
--- a/go/cmd/dolt/commands/dump.go
+++ b/go/cmd/dolt/commands/dump.go
@@ -627,7 +627,11 @@ func getTableWriter(ctx context.Context, dEnv *env.DoltEnv, tblOpts *tableOption
 	if err != nil {
 		return nil, errhand.BuildDError("error: ").AddCause(err).Build()
 	}
-	opts := editor.Options{Deaf: dEnv.DbEaFactory(ctx), Tempdir: tmpDir}
+	deaf, err := dEnv.DbEaFactory(ctx)
+	if err != nil {
+		return nil, errhand.BuildDError("error: ").AddCause(err).Build()
+	}
+	opts := editor.Options{Deaf: deaf, Tempdir: tmpDir}
 
 	writer, err := dEnv.FS.OpenForWriteAppend(filePath, os.ModePerm)
 	if err != nil {

--- a/go/cmd/dolt/commands/engine/utils.go
+++ b/go/cmd/dolt/commands/engine/utils.go
@@ -16,7 +16,6 @@ package engine
 
 import (
 	"context"
-	"errors"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
@@ -52,27 +51,19 @@ func CollectDBs(ctx context.Context, mrEnv *env.MultiRepoEnv, useBulkEditor bool
 }
 
 func newDatabase(ctx context.Context, name string, dEnv *env.DoltEnv, useBulkEditor bool) (sqle.Database, error) {
-	// Force DB load before constructing editor factories. When load fails (e.g. filesystem lock contention),
-	// DoltEnv records the error and returns a nil DoltDB. Callers must propagate that error instead of
-	// dereferencing through DoltDB.
-	ddb := dEnv.DoltDB(ctx)
-	if ddb == nil {
-		if dEnv.DBLoadError != nil {
-			return sqle.Database{}, dEnv.DBLoadError
-		}
-		return sqle.Database{}, errors.New("failed to load doltdb but no error was recorded")
+	var deaf editor.DbEaFactory
+	var err error
+	if useBulkEditor {
+		deaf, err = dEnv.BulkDbEaFactory(ctx)
+	} else {
+		deaf, err = dEnv.DbEaFactory(ctx)
 	}
-
-	tmpDir, err := dEnv.TempTableFilesDir()
 	if err != nil {
 		return sqle.Database{}, err
 	}
-
-	var deaf editor.DbEaFactory
-	if useBulkEditor {
-		deaf = editor.NewBulkImportTEAFactory(ddb.ValueReadWriter(), tmpDir)
-	} else {
-		deaf = editor.NewDbEaFactory(tmpDir, ddb.ValueReadWriter())
+	tmpDir, err := dEnv.TempTableFilesDir()
+	if err != nil {
+		return sqle.Database{}, err
 	}
 	opts := editor.Options{
 		Deaf:    deaf,

--- a/go/cmd/dolt/commands/filter-branch.go
+++ b/go/cmd/dolt/commands/filter-branch.go
@@ -339,7 +339,11 @@ func rebaseSqlEngine(ctx context.Context, dEnv *env.DoltEnv, root doltdb.RootVal
 	if err != nil {
 		return nil, nil, err
 	}
-	opts := editor.Options{Deaf: dEnv.DbEaFactory(ctx), Tempdir: tmpDir}
+	deaf, err := dEnv.DbEaFactory(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	opts := editor.Options{Deaf: deaf, Tempdir: tmpDir}
 	db, err := dsqle.NewDatabase(ctx, filterDbName, dEnv.DbData(ctx), opts)
 	if err != nil {
 		return nil, nil, err

--- a/go/cmd/dolt/commands/indexcmds/rebuild.go
+++ b/go/cmd/dolt/commands/indexcmds/rebuild.go
@@ -91,7 +91,11 @@ func (cmd RebuildCmd) Exec(ctx context.Context, commandStr string, args []string
 	if err != nil {
 		return HandleErr(errhand.BuildDError("error: ").AddCause(err).Build(), nil)
 	}
-	opts := editor.Options{Deaf: dEnv.DbEaFactory(ctx), Tempdir: tmpDir}
+	deaf, err := dEnv.DbEaFactory(ctx)
+	if err != nil {
+		return HandleErr(errhand.BuildDError("error: ").AddCause(err).Build(), nil)
+	}
+	opts := editor.Options{Deaf: deaf, Tempdir: tmpDir}
 	sch, err := table.GetSchema(ctx)
 	if err != nil {
 		return HandleErr(errhand.BuildDError("could not get table schema").AddCause(err).Build(), nil)

--- a/go/cmd/dolt/commands/schcmds/export.go
+++ b/go/cmd/dolt/commands/schcmds/export.go
@@ -138,7 +138,11 @@ func exportSchemas(ctx context.Context, apr *argparser.ArgParseResults, root dol
 		if err != nil {
 			return errhand.BuildDError("error: ").AddCause(err).Build()
 		}
-		opts := editor.Options{Deaf: dEnv.DbEaFactory(ctx), Tempdir: tmpDir}
+		deaf, err := dEnv.DbEaFactory(ctx)
+		if err != nil {
+			return errhand.BuildDError("error: ").AddCause(err).Build()
+		}
+		opts := editor.Options{Deaf: deaf, Tempdir: tmpDir}
 		verr := exportTblSchema(ctx, tn, root, wr, opts)
 		if verr != nil {
 			return verr

--- a/go/cmd/dolt/commands/schcmds/show.go
+++ b/go/cmd/dolt/commands/schcmds/show.go
@@ -137,7 +137,11 @@ func printSchemas(ctx context.Context, apr *argparser.ArgParseResults, dEnv *env
 		if err != nil {
 			return errhand.BuildDError("error: ").AddCause(err).Build()
 		}
-		opts := editor.Options{Deaf: dEnv.DbEaFactory(ctx), Tempdir: tmpDir}
+		deaf, err := dEnv.DbEaFactory(ctx)
+		if err != nil {
+			return errhand.BuildDError("error: ").AddCause(err).Build()
+		}
+		opts := editor.Options{Deaf: deaf, Tempdir: tmpDir}
 		sqlCtx, engine, _ := dsqle.PrepareCreateTableStmt(ctx, dsqle.NewUserSpaceDatabase(root, opts))
 
 		var notFound []string

--- a/go/cmd/dolt/commands/tblcmds/export.go
+++ b/go/cmd/dolt/commands/tblcmds/export.go
@@ -258,7 +258,11 @@ func getTableWriter(ctx context.Context, root doltdb.RootValue, dEnv *env.DoltEn
 		return nil, errhand.BuildDError("Error opening writer for %s.", exOpts.DestName()).AddCause(err).Build()
 	}
 
-	wr, err := exOpts.dest.NewCreatingWriter(ctx, exOpts, root, rdSchema, editor.Options{Deaf: dEnv.DbEaFactory(ctx)}, writer)
+	deaf, err := dEnv.DbEaFactory(ctx)
+	if err != nil {
+		return nil, errhand.BuildDError("Error opening writer for %s.", exOpts.DestName()).AddCause(err).Build()
+	}
+	wr, err := exOpts.dest.NewCreatingWriter(ctx, exOpts, root, rdSchema, editor.Options{Deaf: deaf}, writer)
 	if err != nil {
 		return nil, errhand.BuildDError("Error opening writer for %s.", exOpts.DestName()).AddCause(err).Build()
 	}

--- a/go/libraries/doltcore/mvdata/data_loc_test.go
+++ b/go/libraries/doltcore/mvdata/data_loc_test.go
@@ -224,7 +224,11 @@ func TestCreateRdWr(t *testing.T) {
 		if tdErr != nil {
 			t.Fatal("Unexpected error accessing .dolt directory.", tdErr)
 		}
-		opts := editor.Options{Deaf: dEnv.DbEaFactory(ctx), Tempdir: tmpDir}
+		deaf, err := dEnv.DbEaFactory(ctx)
+		if err != nil {
+			t.Fatal("Unexpected error accessing .dolt directory.", err)
+		}
+		opts := editor.Options{Deaf: deaf, Tempdir: tmpDir}
 
 		filePath, fpErr := dEnv.FS.Abs(strings.Split(loc.String(), ":")[1])
 		if fpErr != nil {

--- a/go/libraries/doltcore/sqle/alterschema_test.go
+++ b/go/libraries/doltcore/sqle/alterschema_test.go
@@ -436,7 +436,9 @@ func TestDropPks(t *testing.T) {
 			defer dEnv.DoltDB(ctx).Close()
 			tmpDir, err := dEnv.TempTableFilesDir()
 			require.NoError(t, err)
-			opts := editor.Options{Deaf: dEnv.DbEaFactory(ctx), Tempdir: tmpDir}
+			deaf, err := dEnv.DbEaFactory(ctx)
+			require.NoError(t, err)
+			opts := editor.Options{Deaf: deaf, Tempdir: tmpDir}
 			db, err := NewDatabase(ctx, "dolt", dEnv.DbData(ctx), opts)
 			require.NoError(t, err)
 

--- a/go/libraries/doltcore/sqle/common_test.go
+++ b/go/libraries/doltcore/sqle/common_test.go
@@ -41,7 +41,9 @@ type SetupFn func(t *testing.T, dEnv *env.DoltEnv)
 func executeSelect(t *testing.T, ctx context.Context, dEnv *env.DoltEnv, root doltdb.RootValue, query string) ([]sql.Row, sql.Schema, error) {
 	tmpDir, err := dEnv.TempTableFilesDir()
 	require.NoError(t, err)
-	opts := editor.Options{Deaf: dEnv.DbEaFactory(ctx), Tempdir: tmpDir}
+	deaf, err := dEnv.DbEaFactory(ctx)
+	require.NoError(t, err)
+	opts := editor.Options{Deaf: deaf, Tempdir: tmpDir}
 	db, err := NewDatabase(ctx, "dolt", dEnv.DbData(ctx), opts)
 	require.NoError(t, err)
 
@@ -72,7 +74,9 @@ func executeSelect(t *testing.T, ctx context.Context, dEnv *env.DoltEnv, root do
 func executeModify(t *testing.T, ctx context.Context, dEnv *env.DoltEnv, root doltdb.RootValue, query string) (doltdb.RootValue, error) {
 	tmpDir, err := dEnv.TempTableFilesDir()
 	require.NoError(t, err)
-	opts := editor.Options{Deaf: dEnv.DbEaFactory(ctx), Tempdir: tmpDir}
+	deaf, err := dEnv.DbEaFactory(ctx)
+	require.NoError(t, err)
+	opts := editor.Options{Deaf: deaf, Tempdir: tmpDir}
 	db, err := NewDatabase(ctx, "dolt", dEnv.DbData(ctx), opts)
 	require.NoError(t, err)
 

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -962,8 +962,13 @@ func (p *DoltDatabaseProvider) registerNewDatabase(ctx *sql.Context, name string
 		return err
 	}
 
+	deaf, err := newEnv.DbEaFactory(ctx)
+	if err != nil {
+		return err
+	}
+
 	opts := editor.Options{
-		Deaf: newEnv.DbEaFactory(ctx),
+		Deaf: deaf,
 		// TODO: this doesn't seem right, why is this getting set in the constructor to the DB
 		ForeignKeyChecksDisabled: fkChecks.(int8) == 0,
 	}

--- a/go/libraries/doltcore/sqle/database_provider_test.go
+++ b/go/libraries/doltcore/sqle/database_provider_test.go
@@ -46,7 +46,9 @@ func TestDatabaseProvider(t *testing.T) {
 		dEnv := dtestutils.CreateTestEnv()
 		tmpDir, err := dEnv.TempTableFilesDir()
 		require.NoError(t, err)
-		opts := editor.Options{Deaf: dEnv.DbEaFactory(ctx), Tempdir: tmpDir}
+		deaf, err := dEnv.DbEaFactory(ctx)
+		require.NoError(t, err)
+		opts := editor.Options{Deaf: deaf, Tempdir: tmpDir}
 		db, err := NewDatabase(context.Background(), "dolt", dEnv.DbData(ctx), opts)
 		require.NoError(t, err)
 

--- a/go/libraries/doltcore/sqle/database_test.go
+++ b/go/libraries/doltcore/sqle/database_test.go
@@ -47,7 +47,9 @@ func TestNeedsToReloadEvents(t *testing.T) {
 	dEnv := dtestutils.CreateTestEnv()
 	tmpDir, err := dEnv.TempTableFilesDir()
 	require.NoError(t, err)
-	opts := editor.Options{Deaf: dEnv.DbEaFactory(ctx), Tempdir: tmpDir}
+	deaf, err := dEnv.DbEaFactory(ctx)
+	require.NoError(t, err)
+	opts := editor.Options{Deaf: deaf, Tempdir: tmpDir}
 
 	timestamp := time.Now().Truncate(time.Minute).UTC()
 

--- a/go/libraries/doltcore/sqle/index/mergeable_indexes_setup_test.go
+++ b/go/libraries/doltcore/sqle/index/mergeable_indexes_setup_test.go
@@ -40,7 +40,9 @@ func setupIndexes(t *testing.T, tableName, insertQuery string) (*sqle.Engine, *s
 	dEnv := dtestutils.CreateTestEnv()
 	tmpDir, err := dEnv.TempTableFilesDir()
 	require.NoError(t, err)
-	opts := editor.Options{Deaf: dEnv.DbEaFactory(ctx), Tempdir: tmpDir}
+	deaf, err := dEnv.DbEaFactory(ctx)
+	require.NoError(t, err)
+	opts := editor.Options{Deaf: deaf, Tempdir: tmpDir}
 	db, err := dsqle.NewDatabase(context.Background(), "dolt", dEnv.DbData(ctx), opts)
 	require.NoError(t, err)
 

--- a/go/libraries/doltcore/sqle/kvexec/count_agg_test.go
+++ b/go/libraries/doltcore/sqle/kvexec/count_agg_test.go
@@ -99,7 +99,9 @@ func TestCountAgg(t *testing.T) {
 			tmpDir, err := dEnv.TempTableFilesDir()
 			require.NoError(t, err)
 
-			opts := editor.Options{Deaf: dEnv.DbEaFactory(ctx), Tempdir: tmpDir}
+			deaf, err := dEnv.DbEaFactory(ctx)
+			require.NoError(t, err)
+			opts := editor.Options{Deaf: deaf, Tempdir: tmpDir}
 			db, err := sqle.NewDatabase(context.Background(), "dolt", dEnv.DbData(ctx), opts)
 			require.NoError(t, err)
 

--- a/go/libraries/doltcore/sqle/kvexec/lookup_join_test.go
+++ b/go/libraries/doltcore/sqle/kvexec/lookup_join_test.go
@@ -167,7 +167,9 @@ func TestLookupJoin(t *testing.T) {
 			tmpDir, err := dEnv.TempTableFilesDir()
 			require.NoError(t, err)
 
-			opts := editor.Options{Deaf: dEnv.DbEaFactory(ctx), Tempdir: tmpDir}
+			deaf, err := dEnv.DbEaFactory(ctx)
+			require.NoError(t, err)
+			opts := editor.Options{Deaf: deaf, Tempdir: tmpDir}
 			db, err := sqle.NewDatabase(context.Background(), "dolt", dEnv.DbData(ctx), opts)
 			require.NoError(t, err)
 

--- a/go/libraries/doltcore/sqle/logictest/dolt/doltharness.go
+++ b/go/libraries/doltcore/sqle/logictest/dolt/doltharness.go
@@ -305,7 +305,11 @@ func sqlNewEngine(ctx context.Context, dEnv *env.DoltEnv) (*sqle.Engine, dsess.D
 	if err != nil {
 		return nil, nil, err
 	}
-	opts := editor.Options{Deaf: dEnv.DbEaFactory(ctx), Tempdir: tmpDir}
+	deaf, err := dEnv.DbEaFactory(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	opts := editor.Options{Deaf: deaf, Tempdir: tmpDir}
 	db, err := dsql.NewDatabase(context.Background(), "dolt", dEnv.DbData(ctx), opts)
 	if err != nil {
 		return nil, nil, err

--- a/go/libraries/doltcore/sqle/procedures_table_test.go
+++ b/go/libraries/doltcore/sqle/procedures_table_test.go
@@ -38,7 +38,9 @@ func TestProceduresMigration(t *testing.T) {
 	dEnv := dtestutils.CreateTestEnv()
 	tmpDir, err := dEnv.TempTableFilesDir()
 	require.NoError(t, err)
-	opts := editor.Options{Deaf: dEnv.DbEaFactory(ctx), Tempdir: tmpDir}
+	deaf, err := dEnv.DbEaFactory(ctx)
+	require.NoError(t, err)
+	opts := editor.Options{Deaf: deaf, Tempdir: tmpDir}
 
 	timestamp := time.Now().Truncate(time.Minute).UTC()
 

--- a/go/libraries/doltcore/sqle/replication.go
+++ b/go/libraries/doltcore/sqle/replication.go
@@ -55,8 +55,13 @@ func GetCommitHooks(ctx context.Context, dEnv *env.DoltEnv, logger io.Writer) ([
 // skip errors related to database construction only and return a partially functional dsqle.ReadReplicaDatabase
 // that will log warnings when attempting to perform replica commands.
 func newReplicaDatabase(ctx context.Context, name string, remoteName string, dEnv *env.DoltEnv) (ReadReplicaDatabase, error) {
+	deaf, err := dEnv.DbEaFactory(ctx)
+	if err != nil {
+		return ReadReplicaDatabase{}, err
+	}
+
 	opts := editor.Options{
-		Deaf: dEnv.DbEaFactory(ctx),
+		Deaf: deaf,
 	}
 
 	db, err := NewDatabase(ctx, name, dEnv.DbData(ctx), opts)

--- a/go/libraries/doltcore/sqle/schema_table_test.go
+++ b/go/libraries/doltcore/sqle/schema_table_test.go
@@ -50,7 +50,9 @@ func TestAncientSchemaTableMigration(t *testing.T) {
 	dEnv := dtestutils.CreateTestEnv()
 	tmpDir, err := dEnv.TempTableFilesDir()
 	require.NoError(t, err)
-	opts := editor.Options{Deaf: dEnv.DbEaFactory(ctx), Tempdir: tmpDir}
+	deaf, err := dEnv.DbEaFactory(ctx)
+	require.NoError(t, err)
+	opts := editor.Options{Deaf: deaf, Tempdir: tmpDir}
 	db, err := NewDatabase(context.Background(), "dolt", dEnv.DbData(ctx), opts)
 	require.NoError(t, err)
 
@@ -113,7 +115,9 @@ func TestV1SchemasTable(t *testing.T) {
 	dEnv := dtestutils.CreateTestEnv()
 	tmpDir, err := dEnv.TempTableFilesDir()
 	require.NoError(t, err)
-	opts := editor.Options{Deaf: dEnv.DbEaFactory(ctx), Tempdir: tmpDir}
+	deaf, err := dEnv.DbEaFactory(ctx)
+	require.NoError(t, err)
+	opts := editor.Options{Deaf: deaf, Tempdir: tmpDir}
 	db, err := NewDatabase(context.Background(), "dolt", dEnv.DbData(ctx), opts)
 	require.NoError(t, err)
 

--- a/go/libraries/doltcore/sqle/statspro/controller.go
+++ b/go/libraries/doltcore/sqle/statspro/controller.go
@@ -611,7 +611,10 @@ func (sc *StatsController) initStorage(ctx context.Context, fs filesys.Filesys) 
 		return nil, err
 	}
 
-	deaf := dEnv.DbEaFactory(ctx)
+	deaf, err := dEnv.DbEaFactory(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	tmpDir, err := dEnv.TempTableFilesDir()
 	if err != nil {

--- a/go/libraries/doltcore/sqle/testutil.go
+++ b/go/libraries/doltcore/sqle/testutil.go
@@ -51,7 +51,11 @@ func ExecuteSql(ctx context.Context, dEnv *env.DoltEnv, root doltdb.RootValue, s
 		return nil, err
 	}
 
-	opts := editor.Options{Deaf: dEnv.DbEaFactory(ctx), Tempdir: tmpDir}
+	deaf, err := dEnv.DbEaFactory(ctx)
+	if err != nil {
+		return nil, err
+	}
+	opts := editor.Options{Deaf: deaf, Tempdir: tmpDir}
 	db, err := NewDatabase(context.Background(), "dolt", dEnv.DbData(ctx), opts)
 	if err != nil {
 		return nil, err
@@ -167,7 +171,11 @@ func ExecuteSelect(ctx context.Context, dEnv *env.DoltEnv, root doltdb.RootValue
 		return nil, err
 	}
 
-	opts := editor.Options{Deaf: dEnv.DbEaFactory(ctx), Tempdir: tmpDir}
+	deaf, err := dEnv.DbEaFactory(ctx)
+	if err != nil {
+		return nil, err
+	}
+	opts := editor.Options{Deaf: deaf, Tempdir: tmpDir}
 	db, err := NewDatabase(context.Background(), "dolt", dbData, opts)
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/sqle/writer/noms_table_writer_test.go
+++ b/go/libraries/doltcore/sqle/writer/noms_table_writer_test.go
@@ -160,7 +160,9 @@ func TestTableEditor(t *testing.T) {
 
 			tmpDir, err := dEnv.TempTableFilesDir()
 			require.NoError(t, err)
-			opts := editor.Options{Deaf: dEnv.DbEaFactory(ctx), Tempdir: tmpDir}
+			deaf, err := dEnv.DbEaFactory(ctx)
+			require.NoError(t, err)
+			opts := editor.Options{Deaf: deaf, Tempdir: tmpDir}
 			db, err := sqle.NewDatabase(context.Background(), "dolt", dEnv.DbData(ctx), opts)
 			require.NoError(t, err)
 


### PR DESCRIPTION
  • Prevent NewSqlEngine from panicking when a repo fails to open due to lock contention.
  • Load-check the underlying DoltDB in engine DB collection and return the recorded load error (e.g.
    nbs.ErrDatabaseLocked) instead of nil-dereferencing.
  • Enables embedded/driver callers to detect “database locked” and safely retry engine initialization.