### PR TITLE
dolt_commit respects foreign key checks

### DIFF
--- a/go/libraries/doltcore/env/actions/commit.go
+++ b/go/libraries/doltcore/env/actions/commit.go
@@ -106,7 +106,7 @@ func GetCommitStaged(
 			return nil, err
 		}
 
-		if fkChecks.(int8) == 1 {
+		if intValue, ok := fkChecks.(int8); ok && intValue == 1 {
 			roots.Staged, err = doltdb.ValidateForeignKeysOnSchemas(ctx, tableResolver, roots.Staged)
 			if err != nil {
 				return nil, err

--- a/go/libraries/doltcore/env/actions/commit.go
+++ b/go/libraries/doltcore/env/actions/commit.go
@@ -101,9 +101,16 @@ func GetCommitStaged(
 			}
 		}
 
-		roots.Staged, err = doltdb.ValidateForeignKeysOnSchemas(ctx, tableResolver, roots.Staged)
+		fkChecks, err := ctx.GetSessionVariable(ctx, "foreign_key_checks")
 		if err != nil {
 			return nil, err
+		}
+
+		if fkChecks.(int8) == 1 {
+			roots.Staged, err = doltdb.ValidateForeignKeysOnSchemas(ctx, tableResolver, roots.Staged)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -8253,6 +8253,19 @@ var DoltCommitTests = []queries.ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "DOLT_COMMIT respects foreign_key_checks=0",
+		SetUpScript: []string{
+			"SET @@foreign_key_checks=0;",
+			"CREATE TABLE invalidFK (id int primary key, constraint fk foreign key (id) references invalidTable(id))",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "CALL DOLT_COMMIT('-A', '-m', 'Table with foreign key violation');",
+				Expected: []sql.Row{{doltCommit}},
+			},
+		},
+	},
 }
 
 var DoltIndexPrefixScripts = []queries.ScriptTest{


### PR DESCRIPTION
When `foreign_key_checks` is set to 0, `dolt_commit` should allow staged working states with foreign key violations. 

Fixes issue #5605
