### PR TITLE
dbfactory: add `open_read_only` to open journaling stores without exclusive lock

### DIFF
--- a/go/libraries/doltcore/dbfactory/file.go
+++ b/go/libraries/doltcore/dbfactory/file.go
@@ -70,6 +70,13 @@ const (
 	//
 	// Intended for embedded-driver usage so higher layers can implement their own retry/backoff policy.
 	FailOnJournalLockTimeoutParam = "fail_on_journal_lock_timeout"
+
+	// OpenReadOnlyParam opens the journaling store in read-only mode without attempting to acquire (or hold)
+	// the exclusive journal manifest lock. This allows a read-only open to proceed concurrently with another
+	// process holding the lock, and ensures the read-only open does not block a subsequent writer.
+	//
+	// This parameter is only applicable when using the chunk journal (ChunkJournalParam).
+	OpenReadOnlyParam = "open_read_only"
 )
 
 // DoltDataDir is the directory where noms files will be stored
@@ -206,6 +213,9 @@ func (fact FileFactory) CreateDbNoCache(ctx context.Context, nbf *types.NomsBinF
 		if params != nil {
 			if _, ok := params[FailOnJournalLockTimeoutParam]; ok {
 				opts.FailOnLockTimeout = true
+			}
+			if _, ok := params[OpenReadOnlyParam]; ok {
+				opts.ReadOnly = true
 			}
 		}
 		newGenSt, err = nbs.NewLocalJournalingStoreWithOptions(ctx, nbf.VersionString(), path, q, mmapArchiveIndexes, recCb, opts)

--- a/go/libraries/doltcore/dbfactory/file_cache_test.go
+++ b/go/libraries/doltcore/dbfactory/file_cache_test.go
@@ -16,6 +16,7 @@ package dbfactory
 
 import (
 	"context"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -23,6 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/dolt/go/libraries/utils/earl"
+	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/datas"
 	"github.com/dolthub/dolt/go/store/nbs"
 	"github.com/dolthub/dolt/go/store/types"
 )
@@ -95,4 +98,76 @@ func TestFileFactory_CreateDB_FailOnJournalLockTimeoutParam(t *testing.T) {
 	_, _, _, err = CreateDB(ctx, nbf, urlStr, params)
 	require.Error(t, err)
 	require.ErrorIs(t, err, nbs.ErrDatabaseLocked)
+}
+
+func TestFileFactory_CreateDB_OpenReadOnlyParam_DoesNotHoldExclusiveLock(t *testing.T) {
+	ctx := context.Background()
+	nbf := types.Format_Default
+
+	root := t.TempDir()
+	nomsDir := filepath.Join(root, "noms")
+	require.NoError(t, os.MkdirAll(nomsDir, 0o755))
+
+	urlStr := earl.FileUrlFromPath(filepath.ToSlash(nomsDir), os.PathSeparator)
+
+	// First open takes the journal manifest lock and holds it until closed.
+	rwParams := map[string]interface{}{
+		ChunkJournalParam:          struct{}{},
+		DisableSingletonCacheParam: struct{}{},
+	}
+	db1, _, _, err := CreateDB(ctx, nbf, urlStr, rwParams)
+	require.NoError(t, err)
+
+	// Read-only open should succeed while db1 holds the lock.
+	roParams := map[string]interface{}{
+		ChunkJournalParam:          struct{}{},
+		DisableSingletonCacheParam: struct{}{},
+		OpenReadOnlyParam:          struct{}{},
+	}
+	db2, _, _, err := CreateDB(ctx, nbf, urlStr, roParams)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db2.Close() })
+
+	// Closing the writer should release the lock; a new writer open should succeed even while db2 is still open
+	// if db2 did not acquire/hold the exclusive lock.
+	require.NoError(t, db1.Close())
+
+	db3, _, _, err := CreateDB(ctx, nbf, urlStr, rwParams)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db3.Close() })
+}
+
+func TestFileFactory_CreateDB_OpenReadOnlyParam_WorksWithoutOtherParams(t *testing.T) {
+	ctx := context.Background()
+	nbf := types.Format_Default
+
+	root := t.TempDir()
+	nomsDir := filepath.Join(root, "noms")
+	require.NoError(t, os.MkdirAll(nomsDir, 0o755))
+
+	urlStr := earl.FileUrlFromPath(filepath.ToSlash(nomsDir), os.PathSeparator)
+	u, err := url.Parse(urlStr)
+	require.NoError(t, err)
+
+	// Open a writer that holds the exclusive journal manifest lock.
+	db1, _, _, err := CreateDB(ctx, nbf, urlStr, map[string]interface{}{
+		ChunkJournalParam: struct{}{},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db1.Close() })
+	require.EqualValues(t, chunks.ExclusiveAccessMode_Exclusive, datas.ChunkStoreFromDatabase(db1).AccessMode())
+
+	// NOTE: CreateDB uses an in-process singleton cache keyed by URL path and does not currently
+	// include params in the cache key. To ensure this test exercises the parameter plumbing,
+	// remove the writer from the singleton cache while keeping it open (and holding the lock).
+	require.NoError(t, DeleteFromSingletonCache(u.Path, false))
+
+	// Now open a second handle using only open_read_only (no fail-fast, no cache-bypass).
+	db2, _, _, err := CreateDB(ctx, nbf, urlStr, map[string]interface{}{
+		ChunkJournalParam: struct{}{},
+		OpenReadOnlyParam: struct{}{},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db2.Close() })
+	require.EqualValues(t, chunks.ExclusiveAccessMode_ReadOnly, datas.ChunkStoreFromDatabase(db2).AccessMode())
 }

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -675,6 +675,11 @@ type JournalingStoreOptions struct {
 	// FailOnLockTimeout returns an error if the exclusive journal manifest lock cannot be acquired
 	// within Dolt's internal lock timeout, instead of falling back to opening in read-only mode.
 	FailOnLockTimeout bool
+
+	// ReadOnly opens the journaling store in read-only mode without attempting to acquire (or hold)
+	// the exclusive journal manifest lock. This allows read-only opens to proceed concurrently with
+	// a writer that holds the lock, and also ensures read-only opens do not block a subsequent writer.
+	ReadOnly bool
 }
 
 func NewLocalJournalingStoreWithOptions(ctx context.Context, nbfVers, dir string, q MemoryQuotaProvider, mmapArchiveIndexes bool, warningsCb func(error), opts JournalingStoreOptions) (*NomsBlockStore, error) {
@@ -683,7 +688,7 @@ func NewLocalJournalingStoreWithOptions(ctx context.Context, nbfVers, dir string
 		return nil, err
 	}
 
-	m, err := newJournalManifest(ctx, dir, opts.FailOnLockTimeout)
+	m, err := newJournalManifest(ctx, dir, opts.FailOnLockTimeout, opts.ReadOnly)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
  • Adds an explicit open_read_only DB-load param for local file-backed databases using the chunk journal.
  • Plumbs open_read_only through dbfactory into nbs so journaling stores can be opened read-only without acquiring/holding
    the exclusive journal manifest lock.
  • Extends nbs.JournalingStoreOptions with a ReadOnly flag and makes newJournalManifest skip locking when requested.
  • Adds tests covering:
    • explicit read-only open while a writer holds the lock
    • read-only open does not block a subsequent writer
    • open_read_only works even when not combined with fail_on_journal_lock_timeout or disable_singleton_cache (with a
      singleton-cache eviction step to ensure params are exercised)