### PR TITLE
go/store/nbs: For local databases, crash on fatal I/O errors during writes.

### DIFF
--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -49,6 +49,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/statspro"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/writer"
 	"github.com/dolthub/dolt/go/libraries/utils/config"
+	dherrors "github.com/dolthub/dolt/go/libraries/utils/errors"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/libraries/utils/valctx"
 )
@@ -94,6 +95,8 @@ type SqlEngineConfig struct {
 	//
 	// Intended for embedded-driver use-cases that need to influence dbfactory / storage open behavior.
 	DBLoadParams map[string]interface{}
+
+	FatalBehavior dherrors.FatalBehavior
 }
 
 type SqlEngineConfigOption func(*SqlEngineConfig)

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -30,6 +30,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"github.com/dolthub/dolt/go/libraries/utils/earl"
+	dherrors "github.com/dolthub/dolt/go/libraries/utils/errors"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/datas"
@@ -2027,6 +2028,21 @@ func (ddb *DoltDB) IterateRoots(cb func(root string, timestamp *time.Time) error
 		return nbsStore.IterateRoots(cb)
 	} else {
 		return nil
+	}
+}
+
+// SetCrashOnFatalError puts the store into a mode where it will
+// crash the running process is there is a fatal I/O error which
+// prevents Dolt from being able to continue safely while
+// continuing to accept writes to this database. This is typically
+// the correct behavior for a long-lived process working with a
+// local, non-read-only database.
+func (ddb *DoltDB) SetCrashOnFatalError() {
+	cs := datas.ChunkStoreFromDatabase(ddb.db)
+	if nbs, ok := cs.(interface {
+		SetFatalBehavior(dherrors.FatalBehavior)
+	}); ok {
+		nbs.SetFatalBehavior(dherrors.FatalBehaviorCrash)
 	}
 }
 

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -588,6 +588,7 @@ func (p *DoltDatabaseProvider) CreateCollatedDatabase(ctx *sql.Context, name str
 	if err != nil {
 		return err
 	}
+	newEnv.DoltDB(ctx).SetCrashOnFatalError()
 
 	updatedCollation, updatedSchemas := false, false
 

--- a/go/libraries/utils/errors/panic.go
+++ b/go/libraries/utils/errors/panic.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"fmt"
+)
+
+type FatalBehavior int
+
+const (
+	// Returns an error on a fatal error.
+	FatalBehaviorError FatalBehavior = iota
+
+	// Crashes the process immediately and without returning on a fatal error.
+	FatalBehaviorCrash
+)
+
+// Fatalf signals a fatal error, and can be used in situations where the process may
+// be entering an unsafe state due to the encountered error. If |behavior| is
+// FatalBehaviorCrash, this function will never return. Otherwise, an error value is
+// returned, built with fmt.Errorf on |msg| and |args|.
+func Fatalf(behavior FatalBehavior, msg string, args ...any) error {
+	if behavior == FatalBehaviorCrash {
+		go func() {
+			panic(fmt.Sprintf("fatal error: " + msg, args...))
+		}()
+		for {}
+	} else {
+		return fmt.Errorf("fatal error: " + msg, args...)
+	}
+}

--- a/go/libraries/utils/errors/panic.go
+++ b/go/libraries/utils/errors/panic.go
@@ -35,10 +35,11 @@ const (
 func Fatalf(behavior FatalBehavior, msg string, args ...any) error {
 	if behavior == FatalBehaviorCrash {
 		go func() {
-			panic(fmt.Sprintf("fatal error: " + msg, args...))
+			panic(fmt.Sprintf("fatal error: "+msg, args...))
 		}()
-		for {}
+		for {
+		}
 	} else {
-		return fmt.Errorf("fatal error: " + msg, args...)
+		return fmt.Errorf("fatal error: "+msg, args...)
 	}
 }

--- a/go/store/nbs/archive_chunk_source.go
+++ b/go/store/nbs/archive_chunk_source.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
+	dherrors "github.com/dolthub/dolt/go/libraries/utils/errors"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
 )
@@ -175,7 +176,7 @@ func (acs archiveChunkSource) currentSize() uint64 {
 }
 
 // reader returns a reader for the entire archive file.
-func (acs archiveChunkSource) reader(ctx context.Context) (io.ReadCloser, uint64, error) {
+func (acs archiveChunkSource) reader(ctx context.Context, _ dherrors.FatalBehavior) (io.ReadCloser, uint64, error) {
 	rd, err := acs.aRdr.reader.Reader(ctx)
 	if err != nil {
 		return nil, 0, err
@@ -198,7 +199,7 @@ func (acs archiveChunkSource) clone() (chunkSource, error) {
 	return archiveChunkSource{reader, acs.file}, nil
 }
 
-func (acs archiveChunkSource) getRecordRanges(_ context.Context, records []getRecord, keeper keeperF) (map[hash.Hash]Range, gcBehavior, error) {
+func (acs archiveChunkSource) getRecordRanges(_ context.Context, _ dherrors.FatalBehavior, records []getRecord, keeper keeperF) (map[hash.Hash]Range, gcBehavior, error) {
 	result := make(map[hash.Hash]Range, len(records))
 	for i, req := range records {
 		if req.found {

--- a/go/store/nbs/archive_test.go
+++ b/go/store/nbs/archive_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
+	dherrors "github.com/dolthub/dolt/go/libraries/utils/errors"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
 )
@@ -948,11 +949,11 @@ func TestArchiveGetRecordRanges(t *testing.T) {
 	records = append(records, getRecord{a: &h2[0], prefix: h2[0].Prefix(), found: false})
 	records = append(records, getRecord{a: &sharedHash, prefix: sharedHash.Prefix(), found: false})
 
-	rang1, _, err := src1.getRecordRanges(context.Background(), records, nil)
+	rang1, _, err := src1.getRecordRanges(context.Background(), dherrors.FatalBehaviorError, records, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(rang1))
 
-	rang2, _, err := src2.getRecordRanges(context.Background(), records, nil)
+	rang2, _, err := src2.getRecordRanges(context.Background(), dherrors.FatalBehaviorError, records, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(rang2))
 	_, ok := rang2[sharedHash]
@@ -962,11 +963,11 @@ func TestArchiveGetRecordRanges(t *testing.T) {
 	for i := range records {
 		records[i].found = false
 	}
-	rang1, _, err = src2.getRecordRanges(context.Background(), records, nil)
+	rang1, _, err = src2.getRecordRanges(context.Background(), dherrors.FatalBehaviorError, records, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(rang1))
 
-	rang2, _, err = src1.getRecordRanges(context.Background(), records, nil)
+	rang2, _, err = src1.getRecordRanges(context.Background(), dherrors.FatalBehaviorError, records, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(rang2))
 	_, ok = rang2[sharedHash]
@@ -1299,11 +1300,11 @@ func (tcs *testChunkSource) suffix() string {
 	panic("never used")
 }
 
-func (tcs *testChunkSource) reader(ctx context.Context) (io.ReadCloser, uint64, error) {
+func (tcs *testChunkSource) reader(ctx context.Context, _ dherrors.FatalBehavior) (io.ReadCloser, uint64, error) {
 	panic("never used")
 }
 
-func (tcs *testChunkSource) getRecordRanges(ctx context.Context, requests []getRecord, keeper keeperF) (map[hash.Hash]Range, gcBehavior, error) {
+func (tcs *testChunkSource) getRecordRanges(ctx context.Context, _ dherrors.FatalBehavior, requests []getRecord, keeper keeperF) (map[hash.Hash]Range, gcBehavior, error) {
 	panic("never used")
 }
 

--- a/go/store/nbs/bs_persister.go
+++ b/go/store/nbs/bs_persister.go
@@ -23,6 +23,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	dherrors "github.com/dolthub/dolt/go/libraries/utils/errors"
 	"github.com/dolthub/dolt/go/store/blobstore"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
@@ -44,7 +45,7 @@ var _ tableFilePersister = &blobstorePersister{}
 
 // Persist makes the contents of mt durable. Chunks already present in
 // |haver| may be dropped in the process.
-func (bsp *blobstorePersister) Persist(ctx context.Context, mt *memTable, haver chunkReader, keeper keeperF, stats *Stats) (chunkSource, gcBehavior, error) {
+func (bsp *blobstorePersister) Persist(ctx context.Context, behavior dherrors.FatalBehavior, mt *memTable, haver chunkReader, keeper keeperF, stats *Stats) (chunkSource, gcBehavior, error) {
 	address, data, splitOffset, chunkCount, gcb, err := mt.write(haver, keeper, stats)
 	if err != nil {
 		return emptyChunkSource{}, gcBehavior_Continue, err
@@ -90,7 +91,7 @@ func (bsp *blobstorePersister) Persist(ctx context.Context, mt *memTable, haver 
 }
 
 // ConjoinAll implements tablePersister.
-func (bsp *blobstorePersister) ConjoinAll(ctx context.Context, sources chunkSources, stats *Stats) (chunkSource, cleanupFunc, error) {
+func (bsp *blobstorePersister) ConjoinAll(ctx context.Context, behavior dherrors.FatalBehavior, sources chunkSources, stats *Stats) (chunkSource, cleanupFunc, error) {
 	plan, err := planRangeCopyConjoin(ctx, sources, bsp.q, stats)
 	if err != nil {
 		return nil, nil, err

--- a/go/store/nbs/dynamo_manifest.go
+++ b/go/store/nbs/dynamo_manifest.go
@@ -32,6 +32,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 
+	dherrors "github.com/dolthub/dolt/go/libraries/utils/errors"
 	"github.com/dolthub/dolt/go/store/d"
 	"github.com/dolthub/dolt/go/store/hash"
 )
@@ -165,7 +166,7 @@ func validateManifest(item map[string]ddbtypes.AttributeValue) (valid, hasSpecs,
 	return len(item) == 5, false, false
 }
 
-func (dm dynamoManifest) Update(ctx context.Context, lastLock hash.Hash, newContents manifestContents, stats *Stats, writeHook func() error) (manifestContents, error) {
+func (dm dynamoManifest) Update(ctx context.Context, behavior dherrors.FatalBehavior, lastLock hash.Hash, newContents manifestContents, stats *Stats, writeHook func() error) (manifestContents, error) {
 	t1 := time.Now()
 	defer func() { stats.WriteManifestLatency.SampleTimeSince(t1) }()
 

--- a/go/store/nbs/dynamo_manifest_test.go
+++ b/go/store/nbs/dynamo_manifest_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	dherrors "github.com/dolthub/dolt/go/libraries/utils/errors"
 	"github.com/dolthub/dolt/go/store/constants"
 	"github.com/dolthub/dolt/go/store/hash"
 )
@@ -99,7 +100,7 @@ func TestDynamoManifestUpdateWontClobberOldVersion(t *testing.T) {
 	badRoot := hash.Of([]byte("bad root"))
 	ddb.putRecord(db, lock[:], badRoot[:], "0", "", "")
 
-	_, err := mm.Update(context.Background(), lock, manifestContents{nbfVers: constants.FormatLD1String}, stats, nil)
+	_, err := mm.Update(context.Background(), dherrors.FatalBehaviorError, lock, manifestContents{nbfVers: constants.FormatLD1String}, stats, nil)
 	assert.Error(err)
 }
 
@@ -110,7 +111,7 @@ func TestDynamoManifestUpdate(t *testing.T) {
 
 	// First, test winning the race against another process.
 	contents := makeContents("locker", "nuroot", []tableSpec{{computeAddr([]byte("a")), 3}}, nil)
-	upstream, err := mm.Update(context.Background(), hash.Hash{}, contents, stats, func() error {
+	upstream, err := mm.Update(context.Background(), dherrors.FatalBehaviorError, hash.Hash{}, contents, stats, func() error {
 		// This should fail to get the lock, and therefore _not_ clobber the manifest. So the Update should succeed.
 		lock := computeAddr([]byte("nolock"))
 		newRoot2 := hash.Of([]byte("noroot"))
@@ -124,12 +125,12 @@ func TestDynamoManifestUpdate(t *testing.T) {
 
 	// Now, test the case where the optimistic lock fails, and someone else updated the root since last we checked.
 	rejected := makeContents("locker 2", "new root 2", nil, nil)
-	upstream, err = mm.Update(context.Background(), hash.Hash{}, rejected, stats, nil)
+	upstream, err = mm.Update(context.Background(), dherrors.FatalBehaviorError, hash.Hash{}, rejected, stats, nil)
 	require.NoError(t, err)
 	assert.Equal(contents.lock, upstream.lock)
 	assert.Equal(contents.root, upstream.root)
 	assert.Equal(contents.specs, upstream.specs)
-	upstream, err = mm.Update(context.Background(), upstream.lock, rejected, stats, nil)
+	upstream, err = mm.Update(context.Background(), dherrors.FatalBehaviorError, upstream.lock, rejected, stats, nil)
 	require.NoError(t, err)
 	assert.Equal(rejected.lock, upstream.lock)
 	assert.Equal(rejected.root, upstream.root)
@@ -141,7 +142,7 @@ func TestDynamoManifestUpdate(t *testing.T) {
 	ddb.putRecord(db, jerkLock[:], upstream.root[:], constants.FormatLD1String, tableName.String()+":1", "")
 
 	newContents3 := makeContents("locker 3", "new root 3", nil, nil)
-	upstream, err = mm.Update(context.Background(), upstream.lock, newContents3, stats, nil)
+	upstream, err = mm.Update(context.Background(), dherrors.FatalBehaviorError, upstream.lock, newContents3, stats, nil)
 	require.NoError(t, err)
 	assert.Equal(jerkLock, upstream.lock)
 	assert.Equal(rejected.root, upstream.root)
@@ -162,7 +163,7 @@ func TestDynamoManifestUpdateAppendix(t *testing.T) {
 	app := []tableSpec{{computeAddr([]byte("app-a")), 3}}
 	contents := makeContents("locker", "nuroot", specs, app)
 
-	upstream, err := mm.Update(context.Background(), hash.Hash{}, contents, stats, func() error {
+	upstream, err := mm.Update(context.Background(), dherrors.FatalBehaviorError, hash.Hash{}, contents, stats, func() error {
 		// This should fail to get the lock, and therefore _not_ clobber the manifest. So the Update should succeed.
 		lock := computeAddr([]byte("nolock"))
 		newRoot2 := hash.Of([]byte("noroot"))
@@ -177,14 +178,14 @@ func TestDynamoManifestUpdateAppendix(t *testing.T) {
 
 	// Now, test the case where the optimistic lock fails, and someone else updated the root since last we checked.
 	rejected := makeContents("locker 2", "new root 2", nil, nil)
-	upstream, err = mm.Update(context.Background(), hash.Hash{}, rejected, stats, nil)
+	upstream, err = mm.Update(context.Background(), dherrors.FatalBehaviorError, hash.Hash{}, rejected, stats, nil)
 	require.NoError(t, err)
 	assert.Equal(contents.lock, upstream.lock)
 	assert.Equal(contents.root, upstream.root)
 	assert.Equal(contents.specs, upstream.specs)
 	assert.Equal(contents.appendix, upstream.appendix)
 
-	upstream, err = mm.Update(context.Background(), upstream.lock, rejected, stats, nil)
+	upstream, err = mm.Update(context.Background(), dherrors.FatalBehaviorError, upstream.lock, rejected, stats, nil)
 	require.NoError(t, err)
 	assert.Equal(rejected.lock, upstream.lock)
 	assert.Equal(rejected.root, upstream.root)
@@ -200,7 +201,7 @@ func TestDynamoManifestUpdateAppendix(t *testing.T) {
 	ddb.putRecord(db, jerkLock[:], upstream.root[:], constants.FormatLD1String, specsStr, appStr)
 
 	newContents3 := makeContents("locker 3", "new root 3", nil, nil)
-	upstream, err = mm.Update(context.Background(), upstream.lock, newContents3, stats, nil)
+	upstream, err = mm.Update(context.Background(), dherrors.FatalBehaviorError, upstream.lock, newContents3, stats, nil)
 	require.NoError(t, err)
 	assert.Equal(jerkLock, upstream.lock)
 	assert.Equal(rejected.root, upstream.root)
@@ -232,14 +233,14 @@ func TestDynamoManifestCaching(t *testing.T) {
 	// When failing the optimistic lock, we should hit persistent storage.
 	reads = ddb.NumGets()
 	contents := makeContents("lock2", "nuroot", []tableSpec{{computeAddr([]byte("a")), 3}}, nil)
-	upstream, err := mm.Update(context.Background(), hash.Hash{}, contents, stats, nil)
+	upstream, err := mm.Update(context.Background(), dherrors.FatalBehaviorError, hash.Hash{}, contents, stats, nil)
 	require.NoError(t, err)
 	assert.NotEqual(contents.lock, upstream.lock)
 	assert.Equal(reads+1, ddb.NumGets())
 
 	// Successful update should NOT hit persistent storage.
 	reads = ddb.NumGets()
-	upstream, err = mm.Update(context.Background(), upstream.lock, contents, stats, nil)
+	upstream, err = mm.Update(context.Background(), dherrors.FatalBehaviorError, upstream.lock, contents, stats, nil)
 	require.NoError(t, err)
 	assert.Equal(contents.lock, upstream.lock)
 	assert.Equal(reads, ddb.NumGets())
@@ -251,7 +252,7 @@ func TestDynamoManifestUpdateEmpty(t *testing.T) {
 	stats := &Stats{}
 
 	contents := manifestContents{nbfVers: constants.FormatLD1String, lock: computeAddr([]byte{0x01})}
-	upstream, err := mm.Update(context.Background(), hash.Hash{}, contents, stats, nil)
+	upstream, err := mm.Update(context.Background(), dherrors.FatalBehaviorError, hash.Hash{}, contents, stats, nil)
 	require.NoError(t, err)
 	assert.Equal(contents.lock, upstream.lock)
 	assert.True(upstream.root.IsEmpty())

--- a/go/store/nbs/empty_chunk_source.go
+++ b/go/store/nbs/empty_chunk_source.go
@@ -28,6 +28,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	dherrors "github.com/dolthub/dolt/go/libraries/utils/errors"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
 )
@@ -74,11 +75,11 @@ func (ecs emptyChunkSource) index() (tableIndex, error) {
 	return onHeapTableIndex{}, nil
 }
 
-func (ecs emptyChunkSource) reader(context.Context) (io.ReadCloser, uint64, error) {
+func (ecs emptyChunkSource) reader(context.Context, dherrors.FatalBehavior) (io.ReadCloser, uint64, error) {
 	return io.NopCloser(&bytes.Buffer{}), 0, nil
 }
 
-func (ecs emptyChunkSource) getRecordRanges(ctx context.Context, requests []getRecord, keeper keeperF) (map[hash.Hash]Range, gcBehavior, error) {
+func (ecs emptyChunkSource) getRecordRanges(ctx context.Context, _ dherrors.FatalBehavior, requests []getRecord, keeper keeperF) (map[hash.Hash]Range, gcBehavior, error) {
 	return map[hash.Hash]Range{}, gcBehavior_Continue, nil
 }
 

--- a/go/store/nbs/file_table_persister_test.go
+++ b/go/store/nbs/file_table_persister_test.go
@@ -29,6 +29,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	dherrors "github.com/dolthub/dolt/go/libraries/utils/errors"
 	"github.com/dolthub/dolt/go/libraries/utils/file"
 	"github.com/dolthub/dolt/go/store/hash"
 
@@ -96,7 +97,7 @@ func persistTableData(p tablePersister, chunx ...[]byte) (src chunkSource, err e
 			return nil, fmt.Errorf("memTable too full to add %s", computeAddr(c))
 		}
 	}
-	src, _, err = p.Persist(context.Background(), mt, nil, nil, &Stats{})
+	src, _, err = p.Persist(context.Background(), dherrors.FatalBehaviorError, mt, nil, nil, &Stats{})
 	return src, err
 }
 
@@ -114,7 +115,7 @@ func TestFSTablePersisterPersistNoData(t *testing.T) {
 	defer file.RemoveAll(dir)
 	fts := newFSTablePersister(dir, &UnlimitedQuotaProvider{}, false)
 
-	src, _, err := fts.Persist(context.Background(), mt, existingTable, nil, &Stats{})
+	src, _, err := fts.Persist(context.Background(), dherrors.FatalBehaviorError, mt, existingTable, nil, &Stats{})
 	require.NoError(t, err)
 	assert.True(mustUint32(src.count()) == 0)
 
@@ -147,7 +148,7 @@ func TestFSTablePersisterConjoinAll(t *testing.T) {
 		}
 	}()
 
-	src, _, err := fts.ConjoinAll(ctx, sources, &Stats{})
+	src, _, err := fts.ConjoinAll(ctx, dherrors.FatalBehaviorError, sources, &Stats{})
 	require.NoError(t, err)
 	defer src.close()
 
@@ -178,14 +179,14 @@ func TestFSTablePersisterConjoinAllDups(t *testing.T) {
 	}
 
 	var err error
-	sources[0], _, err = fts.Persist(ctx, mt, nil, nil, &Stats{})
+	sources[0], _, err = fts.Persist(ctx, dherrors.FatalBehaviorError, mt, nil, nil, &Stats{})
 	require.NoError(t, err)
 	sources[1], err = sources[0].clone()
 	require.NoError(t, err)
 	sources[2], err = sources[0].clone()
 	require.NoError(t, err)
 
-	src, cleanup, err := fts.ConjoinAll(ctx, sources, &Stats{})
+	src, cleanup, err := fts.ConjoinAll(ctx, dherrors.FatalBehaviorError, sources, &Stats{})
 	require.NoError(t, err)
 	defer src.close()
 

--- a/go/store/nbs/generational_chunk_store.go
+++ b/go/store/nbs/generational_chunk_store.go
@@ -25,9 +25,9 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	dherrors "github.com/dolthub/dolt/go/libraries/utils/errors"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
-	dherrors "github.com/dolthub/dolt/go/libraries/utils/errors"
 )
 
 var _ chunks.ChunkStore = (*GenerationalNBS)(nil)

--- a/go/store/nbs/generational_chunk_store.go
+++ b/go/store/nbs/generational_chunk_store.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
+	dherrors "github.com/dolthub/dolt/go/libraries/utils/errors"
 )
 
 var _ chunks.ChunkStore = (*GenerationalNBS)(nil)
@@ -281,6 +282,11 @@ func (gcs *GenerationalNBS) AccessMode() chunks.ExclusiveAccessMode {
 	newGenMode := gcs.newGen.AccessMode()
 	oldGenMode := gcs.oldGen.AccessMode()
 	return max(oldGenMode, newGenMode)
+}
+
+func (gcs *GenerationalNBS) SetFatalBehavior(behavior dherrors.FatalBehavior) {
+	gcs.newGen.SetFatalBehavior(behavior)
+	gcs.oldGen.SetFatalBehavior(behavior)
 }
 
 // Rebase brings this ChunkStore into sync with the persistent storage's

--- a/go/store/nbs/journal_test.go
+++ b/go/store/nbs/journal_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	dherrors "github.com/dolthub/dolt/go/libraries/utils/errors"
 	"github.com/dolthub/dolt/go/libraries/utils/file"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/types"
@@ -117,7 +118,7 @@ func TestChunkJournalPersist(t *testing.T) {
 	haver := emptyChunkSource{}
 	for i := 0; i < iters; i++ {
 		memTbl, chunkMap := randomMemTable(16)
-		source, _, err := j.Persist(ctx, memTbl, haver, nil, stats)
+		source, _, err := j.Persist(ctx, dherrors.FatalBehaviorError, memTbl, haver, nil, stats)
 		assert.NoError(t, err)
 
 		for h, ch := range chunkMap {
@@ -146,10 +147,10 @@ func TestReadRecordRanges(t *testing.T) {
 		gets = append(gets, getRecord{a: &h, prefix: h.Prefix()})
 	}
 
-	jcs, _, err := j.Persist(ctx, mt, emptyChunkSource{}, nil, &Stats{})
+	jcs, _, err := j.Persist(ctx, dherrors.FatalBehaviorError, mt, emptyChunkSource{}, nil, &Stats{})
 	require.NoError(t, err)
 
-	rdr, sz, err := jcs.(journalChunkSource).journal.snapshot(context.Background())
+	rdr, sz, err := jcs.(journalChunkSource).journal.snapshot(context.Background(), dherrors.FatalBehaviorError)
 	require.NoError(t, err)
 	defer rdr.Close()
 
@@ -158,7 +159,7 @@ func TestReadRecordRanges(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int(sz), n)
 
-	ranges, _, err := jcs.getRecordRanges(ctx, gets, nil)
+	ranges, _, err := jcs.getRecordRanges(ctx, dherrors.FatalBehaviorError, gets, nil)
 	require.NoError(t, err)
 
 	for h, rng := range ranges {

--- a/go/store/nbs/journal_writer_test.go
+++ b/go/store/nbs/journal_writer_test.go
@@ -349,7 +349,7 @@ func TestJournalIndexBootstrap(t *testing.T) {
 						assert.NoError(t, j.commitRootHash(context.Background(), dherrors.FatalBehaviorError, cc.H))
 					}
 				}
-				o := j.offset()                                                   // precommit offset
+				o := j.offset()                                                                                // precommit offset
 				assert.NoError(t, j.commitRootHash(context.Background(), dherrors.FatalBehaviorError, e.last)) // commit |e.last|
 				if i == len(epochs) {
 					break // don't index |test.novel|

--- a/go/store/nbs/journal_writer_test.go
+++ b/go/store/nbs/journal_writer_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	dherrors "github.com/dolthub/dolt/go/libraries/utils/errors"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
 )
@@ -163,13 +164,13 @@ func TestJournalWriterReadWrite(t *testing.T) {
 					assert.Equal(t, op.buf, act, "operation %d failed", i)
 				case writeOp:
 					var p []byte
-					p, err = j.getBytes(context.Background(), len(op.buf))
+					p, err = j.getBytes(context.Background(), dherrors.FatalBehaviorError, len(op.buf))
 					require.NoError(t, err, "operation %d errored", i)
 					n := copy(p, op.buf)
 					assert.Equal(t, len(op.buf), n, "operation %d failed", i)
 					off += int64(n)
 				case flushOp:
-					err = j.flush(context.Background())
+					err = j.flush(context.Background(), dherrors.FatalBehaviorError)
 					assert.NoError(t, err, "operation %d errored", i)
 				default:
 					t.Fatal("unknown opKind")
@@ -195,7 +196,7 @@ func TestJournalWriterWriteCompressedChunk(t *testing.T) {
 	j := newTestJournalWriter(t, path)
 	data := randomCompressedChunks(1024)
 	for a, cc := range data {
-		err := j.writeCompressedChunk(context.Background(), cc)
+		err := j.writeCompressedChunk(context.Background(), dherrors.FatalBehaviorError, cc)
 		require.NoError(t, err)
 		r, _ := j.ranges.get(a)
 		validateLookup(t, j, r, cc)
@@ -210,11 +211,11 @@ func TestJournalWriterBootstrap(t *testing.T) {
 	data := randomCompressedChunks(1024)
 	var last hash.Hash
 	for _, cc := range data {
-		err := j.writeCompressedChunk(context.Background(), cc)
+		err := j.writeCompressedChunk(context.Background(), dherrors.FatalBehaviorError, cc)
 		require.NoError(t, err)
 		last = cc.Hash()
 	}
-	require.NoError(t, j.commitRootHash(context.Background(), last))
+	require.NoError(t, j.commitRootHash(context.Background(), dherrors.FatalBehaviorError, last))
 	require.NoError(t, j.Close())
 
 	j, _, err := openJournalWriter(ctx, path)
@@ -272,10 +273,10 @@ func TestJournalWriterSyncClose(t *testing.T) {
 	path := newTestFilePath(t)
 	j := newTestJournalWriter(t, path)
 	p := []byte("sit")
-	buf, err := j.getBytes(context.Background(), len(p))
+	buf, err := j.getBytes(context.Background(), dherrors.FatalBehaviorError, len(p))
 	require.NoError(t, err)
 	copy(buf, p)
-	j.flush(context.Background())
+	j.flush(context.Background(), dherrors.FatalBehaviorError)
 	assert.Equal(t, 0, len(j.buf))
 	assert.Equal(t, 3, int(j.off))
 }
@@ -343,13 +344,13 @@ func TestJournalIndexBootstrap(t *testing.T) {
 			for i, e := range epochs {
 				for _, cc := range e.records {
 					recordCnt++
-					assert.NoError(t, j.writeCompressedChunk(context.Background(), cc))
+					assert.NoError(t, j.writeCompressedChunk(context.Background(), dherrors.FatalBehaviorError, cc))
 					if rand.Int()%10 == 0 { // periodic commits
-						assert.NoError(t, j.commitRootHash(context.Background(), cc.H))
+						assert.NoError(t, j.commitRootHash(context.Background(), dherrors.FatalBehaviorError, cc.H))
 					}
 				}
 				o := j.offset()                                                   // precommit offset
-				assert.NoError(t, j.commitRootHash(context.Background(), e.last)) // commit |e.last|
+				assert.NoError(t, j.commitRootHash(context.Background(), dherrors.FatalBehaviorError, e.last)) // commit |e.last|
 				if i == len(epochs) {
 					break // don't index |test.novel|
 				}

--- a/go/store/nbs/no_conjoin_bs_persister.go
+++ b/go/store/nbs/no_conjoin_bs_persister.go
@@ -23,6 +23,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	dherrors "github.com/dolthub/dolt/go/libraries/utils/errors"
 	"github.com/dolthub/dolt/go/store/blobstore"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
@@ -39,7 +40,7 @@ var _ tableFilePersister = &noConjoinBlobstorePersister{}
 
 // Persist makes the contents of mt durable. Chunks already present in
 // |haver| may be dropped in the process.
-func (bsp *noConjoinBlobstorePersister) Persist(ctx context.Context, mt *memTable, haver chunkReader, keeper keeperF, stats *Stats) (chunkSource, gcBehavior, error) {
+func (bsp *noConjoinBlobstorePersister) Persist(ctx context.Context, behavior dherrors.FatalBehavior, mt *memTable, haver chunkReader, keeper keeperF, stats *Stats) (chunkSource, gcBehavior, error) {
 	address, data, _, chunkCount, gcb, err := mt.write(haver, keeper, stats)
 	if err != nil {
 		return emptyChunkSource{}, gcBehavior_Continue, err
@@ -68,7 +69,7 @@ func (bsp *noConjoinBlobstorePersister) Persist(ctx context.Context, mt *memTabl
 }
 
 // ConjoinAll implements tablePersister.
-func (bsp *noConjoinBlobstorePersister) ConjoinAll(ctx context.Context, sources chunkSources, stats *Stats) (chunkSource, cleanupFunc, error) {
+func (bsp *noConjoinBlobstorePersister) ConjoinAll(ctx context.Context, behavior dherrors.FatalBehavior, sources chunkSources, stats *Stats) (chunkSource, cleanupFunc, error) {
 	return emptyChunkSource{}, func() {}, fmt.Errorf("no conjoin blobstore persister does not implement ConjoinAll")
 }
 

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -45,9 +45,9 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 
+	dherrors "github.com/dolthub/dolt/go/libraries/utils/errors"
 	"github.com/dolthub/dolt/go/libraries/utils/valctx"
 	"github.com/dolthub/dolt/go/store/blobstore"
-	dherrors "github.com/dolthub/dolt/go/libraries/utils/errors"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
 )

--- a/go/store/nbs/store_test.go
+++ b/go/store/nbs/store_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
+	dherrors "github.com/dolthub/dolt/go/libraries/utils/errors"
 	"github.com/dolthub/dolt/go/libraries/utils/set"
 	"github.com/dolthub/dolt/go/libraries/utils/test"
 	"github.com/dolthub/dolt/go/store/chunks"
@@ -50,7 +51,7 @@ func makeTestLocalStore(t *testing.T, maxTableFiles int) (st *NomsBlockStore, no
 	// create a v5 manifest
 	fm, err := getFileManifest(ctx, nomsDir)
 	require.NoError(t, err)
-	_, err = fm.Update(ctx, hash.Hash{}, manifestContents{
+	_, err = fm.Update(ctx, dherrors.FatalBehaviorError, hash.Hash{}, manifestContents{
 		nbfVers: constants.FormatDoltString,
 		lock:    journalAddr, // Any valid address will do here
 	}, &Stats{}, nil)
@@ -386,7 +387,7 @@ func persistTableFileSources(t *testing.T, p tablePersister, numTableFiles int) 
 		require.True(t, ok)
 		tableFileMap[fileIDHash] = uint32(i + 1)
 		mapIds[i] = fileIDHash
-		cs, _, err := p.Persist(context.Background(), createMemTable(chunkData), nil, nil, &Stats{})
+		cs, _, err := p.Persist(context.Background(), dherrors.FatalBehaviorError, createMemTable(chunkData), nil, nil, &Stats{})
 		require.NoError(t, err)
 		require.NoError(t, cs.close())
 

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -29,6 +29,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	dherrors "github.com/dolthub/dolt/go/libraries/utils/errors"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
 )
@@ -247,10 +248,10 @@ type chunkSource interface {
 	suffix() string
 
 	// opens a Reader to the first byte of the chunkData segment of this table.
-	reader(context.Context) (io.ReadCloser, uint64, error)
+	reader(context.Context, dherrors.FatalBehavior) (io.ReadCloser, uint64, error)
 
 	// getRecordRanges sets getRecord.found to true, and returns a Range for each present getRecord query.
-	getRecordRanges(ctx context.Context, requests []getRecord, keeper keeperF) (map[hash.Hash]Range, gcBehavior, error)
+	getRecordRanges(ctx context.Context, _ dherrors.FatalBehavior, requests []getRecord, keeper keeperF) (map[hash.Hash]Range, gcBehavior, error)
 
 	// index returns the tableIndex of this chunkSource.
 	index() (tableIndex, error)

--- a/go/store/nbs/table_persister.go
+++ b/go/store/nbs/table_persister.go
@@ -31,6 +31,7 @@ import (
 	"sort"
 	"time"
 
+	dherrors "github.com/dolthub/dolt/go/libraries/utils/errors"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
 )
@@ -47,13 +48,13 @@ type cleanupFunc func()
 type tablePersister interface {
 	// Persist makes the contents of mt durable. Chunks already present in
 	// |haver| may be dropped in the process.
-	Persist(ctx context.Context, mt *memTable, haver chunkReader, keeper keeperF, stats *Stats) (chunkSource, gcBehavior, error)
+	Persist(ctx context.Context, behavior dherrors.FatalBehavior, mt *memTable, haver chunkReader, keeper keeperF, stats *Stats) (chunkSource, gcBehavior, error)
 
 	// ConjoinAll conjoins all chunks in |sources| into a single, new
 	// chunkSource. It returns a |cleanupFunc| which can be called to
 	// potentially release resources associated with the |sources| once
 	// they are no longer needed.
-	ConjoinAll(ctx context.Context, sources chunkSources, stats *Stats) (chunkSource, cleanupFunc, error)
+	ConjoinAll(ctx context.Context, behavior dherrors.FatalBehavior, sources chunkSources, stats *Stats) (chunkSource, cleanupFunc, error)
 
 	// Open a table named |name|, containing |chunkCount| chunks.
 	Open(ctx context.Context, name hash.Hash, chunkCount uint32, stats *Stats) (chunkSource, error)

--- a/go/store/nbs/table_reader.go
+++ b/go/store/nbs/table_reader.go
@@ -33,6 +33,7 @@ import (
 	"github.com/golang/snappy"
 	"golang.org/x/sync/errgroup"
 
+	dherrors "github.com/dolthub/dolt/go/libraries/utils/errors"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
 )
@@ -719,7 +720,7 @@ func (tr tableReader) extract(ctx context.Context, chunks chan<- extractRecord) 
 	return nil
 }
 
-func (tr tableReader) reader(ctx context.Context) (io.ReadCloser, uint64, error) {
+func (tr tableReader) reader(ctx context.Context, _ dherrors.FatalBehavior) (io.ReadCloser, uint64, error) {
 	i, _ := tr.index()
 	sz := i.tableFileSize()
 	r, err := tr.r.Reader(ctx)
@@ -729,7 +730,7 @@ func (tr tableReader) reader(ctx context.Context) (io.ReadCloser, uint64, error)
 	return r, sz, nil
 }
 
-func (tr tableReader) getRecordRanges(ctx context.Context, requests []getRecord, keeper keeperF) (map[hash.Hash]Range, gcBehavior, error) {
+func (tr tableReader) getRecordRanges(ctx context.Context, behavior dherrors.FatalBehavior, requests []getRecord, keeper keeperF) (map[hash.Hash]Range, gcBehavior, error) {
 	// findOffsets sets getRecord.found
 	recs, _, gcb, err := tr.findOffsets(requests, keeper)
 	if err != nil {

--- a/go/store/nbs/table_set_test.go
+++ b/go/store/nbs/table_set_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	dherrors "github.com/dolthub/dolt/go/libraries/utils/errors"
 	"github.com/dolthub/dolt/go/store/hash"
 )
 
@@ -41,7 +42,7 @@ var hasManyHasAll = func([]hasRecord) (hash.HashSet, error) {
 func TestTableSetPrependEmpty(t *testing.T) {
 	hasCache, err := lru.New2Q[hash.Hash, struct{}](1024)
 	require.NoError(t, err)
-	ts, _, err := newFakeTableSet(&UnlimitedQuotaProvider{}).append(context.Background(), newMemTable(testMemTableSize), hasManyHasAll, nil, hasCache, &Stats{})
+	ts, _, err := newFakeTableSet(&UnlimitedQuotaProvider{}).append(context.Background(), dherrors.FatalBehaviorError, newMemTable(testMemTableSize), hasManyHasAll, nil, hasCache, &Stats{})
 	require.NoError(t, err)
 	specs, err := ts.toSpecs()
 	require.NoError(t, err)
@@ -61,7 +62,7 @@ func TestTableSetPrepend(t *testing.T) {
 	mt.addChunk(computeAddr(testChunks[0]), testChunks[0])
 	hasCache, err := lru.New2Q[hash.Hash, struct{}](1024)
 	require.NoError(t, err)
-	ts, _, err = ts.append(context.Background(), mt, hasManyHasAll, nil, hasCache, &Stats{})
+	ts, _, err = ts.append(context.Background(), dherrors.FatalBehaviorError, mt, hasManyHasAll, nil, hasCache, &Stats{})
 	require.NoError(t, err)
 
 	firstSpecs, err := ts.toSpecs()
@@ -71,7 +72,7 @@ func TestTableSetPrepend(t *testing.T) {
 	mt = newMemTable(testMemTableSize)
 	mt.addChunk(computeAddr(testChunks[1]), testChunks[1])
 	mt.addChunk(computeAddr(testChunks[2]), testChunks[2])
-	ts, _, err = ts.append(context.Background(), mt, hasManyHasAll, nil, hasCache, &Stats{})
+	ts, _, err = ts.append(context.Background(), dherrors.FatalBehaviorError, mt, hasManyHasAll, nil, hasCache, &Stats{})
 	require.NoError(t, err)
 
 	secondSpecs, err := ts.toSpecs()
@@ -93,17 +94,17 @@ func TestTableSetToSpecsExcludesEmptyTable(t *testing.T) {
 	mt.addChunk(computeAddr(testChunks[0]), testChunks[0])
 	hasCache, err := lru.New2Q[hash.Hash, struct{}](1024)
 	require.NoError(t, err)
-	ts, _, err = ts.append(context.Background(), mt, hasManyHasAll, nil, hasCache, &Stats{})
+	ts, _, err = ts.append(context.Background(), dherrors.FatalBehaviorError, mt, hasManyHasAll, nil, hasCache, &Stats{})
 	require.NoError(t, err)
 
 	mt = newMemTable(testMemTableSize)
-	ts, _, err = ts.append(context.Background(), mt, hasManyHasAll, nil, hasCache, &Stats{})
+	ts, _, err = ts.append(context.Background(), dherrors.FatalBehaviorError, mt, hasManyHasAll, nil, hasCache, &Stats{})
 	require.NoError(t, err)
 
 	mt = newMemTable(testMemTableSize)
 	mt.addChunk(computeAddr(testChunks[1]), testChunks[1])
 	mt.addChunk(computeAddr(testChunks[2]), testChunks[2])
-	ts, _, err = ts.append(context.Background(), mt, hasManyHasAll, nil, hasCache, &Stats{})
+	ts, _, err = ts.append(context.Background(), dherrors.FatalBehaviorError, mt, hasManyHasAll, nil, hasCache, &Stats{})
 	require.NoError(t, err)
 
 	specs, err = ts.toSpecs()
@@ -124,17 +125,17 @@ func TestTableSetFlattenExcludesEmptyTable(t *testing.T) {
 	mt.addChunk(computeAddr(testChunks[0]), testChunks[0])
 	hasCache, err := lru.New2Q[hash.Hash, struct{}](1024)
 	require.NoError(t, err)
-	ts, _, err = ts.append(context.Background(), mt, hasManyHasAll, nil, hasCache, &Stats{})
+	ts, _, err = ts.append(context.Background(), dherrors.FatalBehaviorError, mt, hasManyHasAll, nil, hasCache, &Stats{})
 	require.NoError(t, err)
 
 	mt = newMemTable(testMemTableSize)
-	ts, _, err = ts.append(context.Background(), mt, hasManyHasAll, nil, hasCache, &Stats{})
+	ts, _, err = ts.append(context.Background(), dherrors.FatalBehaviorError, mt, hasManyHasAll, nil, hasCache, &Stats{})
 	require.NoError(t, err)
 
 	mt = newMemTable(testMemTableSize)
 	mt.addChunk(computeAddr(testChunks[1]), testChunks[1])
 	mt.addChunk(computeAddr(testChunks[2]), testChunks[2])
-	ts, _, err = ts.append(context.Background(), mt, hasManyHasAll, nil, hasCache, &Stats{})
+	ts, _, err = ts.append(context.Background(), dherrors.FatalBehaviorError, mt, hasManyHasAll, nil, hasCache, &Stats{})
 	require.NoError(t, err)
 
 	ts, err = ts.flatten(context.Background())
@@ -146,7 +147,7 @@ func persist(t *testing.T, p tablePersister, chunks ...[]byte) {
 	for _, c := range chunks {
 		mt := newMemTable(testMemTableSize)
 		mt.addChunk(computeAddr(c), c)
-		cs, _, err := p.Persist(context.Background(), mt, nil, nil, &Stats{})
+		cs, _, err := p.Persist(context.Background(), dherrors.FatalBehaviorError, mt, nil, nil, &Stats{})
 		require.NoError(t, err)
 		require.NoError(t, cs.close())
 	}
@@ -164,7 +165,7 @@ func TestTableSetRebase(t *testing.T) {
 		for _, c := range chunks {
 			mt := newMemTable(testMemTableSize)
 			mt.addChunk(computeAddr(c), c)
-			ts, _, err = ts.append(context.Background(), mt, hasManyHasAll, nil, hasCache, &Stats{})
+			ts, _, err = ts.append(context.Background(), dherrors.FatalBehaviorError, mt, hasManyHasAll, nil, hasCache, &Stats{})
 			require.NoError(t, err)
 		}
 		return ts
@@ -213,13 +214,13 @@ func TestTableSetPhysicalLen(t *testing.T) {
 	mt.addChunk(computeAddr(testChunks[0]), testChunks[0])
 	hasCache, err := lru.New2Q[hash.Hash, struct{}](1024)
 	require.NoError(t, err)
-	ts, _, err = ts.append(context.Background(), mt, hasManyHasAll, nil, hasCache, &Stats{})
+	ts, _, err = ts.append(context.Background(), dherrors.FatalBehaviorError, mt, hasManyHasAll, nil, hasCache, &Stats{})
 	require.NoError(t, err)
 
 	mt = newMemTable(testMemTableSize)
 	mt.addChunk(computeAddr(testChunks[1]), testChunks[1])
 	mt.addChunk(computeAddr(testChunks[2]), testChunks[2])
-	ts, _, err = ts.append(context.Background(), mt, hasManyHasAll, nil, hasCache, &Stats{})
+	ts, _, err = ts.append(context.Background(), dherrors.FatalBehaviorError, mt, hasManyHasAll, nil, hasCache, &Stats{})
 	require.NoError(t, err)
 
 	assert.True(mustUint64(ts.physicalLen()) > indexSize(mustUint32(ts.count())))


### PR DESCRIPTION
If an fsync fails, or if a critical write(2) calls returns an error against a shared mutable file, it is not safe for the server to keep running because it cannot necessarily guarantee the state of the files as they exist on disk and will exist on disk in the future.

Implement functionality so that the Dolt process cashes in such cases.