### PR TITLE
fix: reject vector indexes on nullable columns at DDL time

### DIFF
--- a/go/libraries/doltcore/schema/index_coll.go
+++ b/go/libraries/doltcore/schema/index_coll.go
@@ -214,7 +214,7 @@ func (ixc *indexCollectionImpl) AddIndexByColTags(indexName string, tags []uint6
 	for _, tag := range tags {
 		// we already validated the tag exists
 		c, _ := ixc.colColl.GetByTag(tag)
-		err := validateColumnIndexable(c)
+		err := validateColumnIndexable(c, props.IsVector)
 		if err != nil {
 			return nil, err
 		}
@@ -243,7 +243,10 @@ func (ixc *indexCollectionImpl) AddIndexByColTags(indexName string, tags []uint6
 }
 
 // validateColumnIndexable returns an error if the column given cannot be used in an index
-func validateColumnIndexable(c Column) error {
+func validateColumnIndexable(c Column, isVector bool) error {
+	if isVector && c.IsNullable() {
+		return fmt.Errorf("all parts of a VECTOR index must be NOT NULL")
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Reject `CREATE VECTOR INDEX` on nullable columns at DDL time, matching MariaDB ERROR 1252 behavior. This replaces the previous nil-guard approach (7-site runtime checks) with a single DDL constraint that makes the invalid state unrepresentable.

### Maintainer Direction

Per @nicktobey's [review](https://github.com/dolthub/dolt/pull/10449#issuecomment-2942498498):

> "It looks like the real issue is that we're allowing vector indexes on a nullable vector column at all. MariaDB would reject this with ERROR 1252."

### Changes (2 files)

**`go/libraries/doltcore/schema/index_coll.go`**

`validateColumnIndexable()` (currently a no-op) now checks for vector + nullable:

```go
func validateColumnIndexable(c Column, isVector bool) error {
    if isVector && c.IsNullable() {
        return fmt.Errorf("all parts of a VECTOR index must be NOT NULL")
    }
    return nil
}
```

Call site in `AddIndexByColTags()` updated to pass `props.IsVector`. `UnsafeAddIndexByColTags` is unaffected (bypasses validation by design).

**`go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go`**

- New `TestVectorIndexDDL` with 3 test cases:
  - `CREATE VECTOR INDEX` on nullable column → error
  - `CREATE VECTOR INDEX` on NOT NULL column → success
  - `ALTER TABLE ADD VECTOR INDEX` on nullable column → error
- `TestVectorIndexes` updated to skip 2 GMS tests that create vector indexes on nullable columns (now correctly rejected)

### What's NOT in this PR (vs previous version)

The previous version had 7 nil-guard sites in `proximity_map.go` and `proximity_mutable_map.go`, plus a separate test file. All of that is removed — this PR is just the DDL constraint.

### Open question: pre-existing databases

Databases created before this fix may have vector indexes on nullable columns. The DDL constraint only blocks *new* index creation. Existing indexes would surface errors during `OPTIMIZE TABLE` or index rebuild. Should we add a runtime guard for this case, or is the DDL constraint sufficient for now?

Asked in [this comment](https://github.com/dolthub/dolt/pull/10449#issuecomment-3874798301).

### Test Plan

- [x] `TestVectorIndexDDL` — 3 new DDL constraint tests pass
- [x] `TestVectorIndexes` — existing error tests pass, 2 nullable-column tests correctly skipped
- [x] Local binary smoke test confirms constraint works end-to-end

Fixes #10448