### PR TITLE
ssh transport support

### DIFF
--- a/go/Godeps/LICENSES
+++ b/go/Godeps/LICENSES
@@ -17578,6 +17578,34 @@ For more information, please refer to <http://unlicense.org/>
 ================================================================================
 
 ================================================================================
+= github.com/xtaci/smux licensed under: =
+
+MIT License
+
+Copyright (c) 2016-2017 xtaci
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+= LICENSE 8b6088f256bcaacc06637993851a60f84d334540771913bb8efd9985 =
+================================================================================
+
+================================================================================
 = github.com/yosida95/uritemplate/v3 licensed under: =
 
 Copyright (C) 2016, Kohei YOSHIDA <https://yosida95.com/>. All rights reserved.

--- a/go/cmd/dolt/commands/admin/conjoin.go
+++ b/go/cmd/dolt/commands/admin/conjoin.go
@@ -109,7 +109,7 @@ func (cmd ConjoinCmd) Exec(ctx context.Context, commandStr string, args []string
 
 	// Get the ChunkStore from DoltDB
 	ddb := dEnv.DoltDB(ctx)
-	db := doltdb.HackDatasDatabaseFromDoltDB(ddb)
+	db := doltdb.ExposeDatabaseFromDoltDB(ddb)
 	cs := datas.ChunkStoreFromDatabase(db)
 
 	var targetNBS *nbs.NomsBlockStore

--- a/go/cmd/dolt/commands/admin/newgen_to_oldgen.go
+++ b/go/cmd/dolt/commands/admin/newgen_to_oldgen.go
@@ -63,7 +63,7 @@ func (cmd NewGenToOldGenCmd) Hidden() bool {
 }
 
 func (cmd NewGenToOldGenCmd) Exec(ctx context.Context, _ string, _ []string, dEnv *env.DoltEnv, _ cli.CliContext) int {
-	db := doltdb.HackDatasDatabaseFromDoltDB(dEnv.DoltDB(ctx))
+	db := doltdb.ExposeDatabaseFromDoltDB(dEnv.DoltDB(ctx))
 	cs := datas.ChunkStoreFromDatabase(db)
 	if _, ok := cs.(*nbs.GenerationalNBS); !ok {
 		cli.PrintErrln("compare-and-swap-storage command requires a GenerationalNBS")

--- a/go/cmd/dolt/commands/admin/showroot.go
+++ b/go/cmd/dolt/commands/admin/showroot.go
@@ -66,7 +66,7 @@ func (cmd ShowRootCmd) Exec(ctx context.Context, commandStr string, args []strin
 
 	cli.ParseArgsOrDie(ap, args, usage)
 
-	db := doltdb.HackDatasDatabaseFromDoltDB(dEnv.DoltDB(ctx))
+	db := doltdb.ExposeDatabaseFromDoltDB(dEnv.DoltDB(ctx))
 	dss, err := db.Datasets(ctx)
 	if err != nil {
 		verr := errhand.BuildDError("failed to get database datasets").AddCause(err).Build()

--- a/go/cmd/dolt/commands/archive.go
+++ b/go/cmd/dolt/commands/archive.go
@@ -86,7 +86,7 @@ func (cmd ArchiveCmd) Exec(ctx context.Context, commandStr string, args []string
 	help, _ := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, docs, ap))
 	apr := cli.ParseArgsOrDie(ap, args, help)
 
-	db := doltdb.HackDatasDatabaseFromDoltDB(dEnv.DoltDB(ctx))
+	db := doltdb.ExposeDatabaseFromDoltDB(dEnv.DoltDB(ctx))
 	cs := datas.ChunkStoreFromDatabase(db)
 	if _, ok := cs.(*nbs.GenerationalNBS); !ok {
 		cli.PrintErrln("archive command requires a GenerationalNBS")

--- a/go/cmd/dolt/commands/transfer.go
+++ b/go/cmd/dolt/commands/transfer.go
@@ -1,0 +1,79 @@
+// Copyright 2025 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"context"
+
+	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
+	"github.com/dolthub/dolt/go/libraries/doltcore/env"
+	"github.com/dolthub/dolt/go/libraries/utils/argparser"
+)
+
+type TransferCmd struct{}
+
+func (cmd TransferCmd) Name() string {
+	return "transfer"
+}
+
+func (cmd TransferCmd) Description() string {
+	return "Transfer data to/from remote over stdin/stdout"
+}
+
+func (cmd TransferCmd) RequiresRepo() bool {
+	return false
+}
+
+func (cmd TransferCmd) Hidden() bool {
+	return true
+}
+
+func (cmd TransferCmd) InstallsSignalHandlers() bool {
+	return true
+}
+
+var transferDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Internal command for SSH remote operations",
+	LongDesc: `The transfer command is used internally by Dolt for SSH remote operations.
+It serves repository data over stdin/stdout using multiplexed gRPC and HTTP protocols.
+
+This command is typically invoked by SSH when cloning or pushing to SSH remotes:
+  ssh user@host "dolt transfer /path/to/repo"
+
+This is a low-level command not intended for direct use.`,
+	Synopsis: []string{
+		"<path>",
+	},
+}
+
+func (cmd TransferCmd) Docs() *cli.CommandDocumentation {
+	ap := cmd.ArgParser()
+	return cli.NewCommandDocumentation(transferDocs, ap)
+}
+
+func (cmd TransferCmd) ArgParser() *argparser.ArgParser {
+	ap := argparser.NewArgParserWithVariableArgs(cmd.Name())
+	return ap
+}
+
+func (cmd TransferCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
+	ap := cmd.ArgParser()
+	help, _ := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, transferDocs, ap))
+	_ = cli.ParseArgsOrDie(ap, args, help)
+
+	// TODO: implement transfer command (serves gRPC + HTTP over stdio via SMUX)
+	return HandleVErrAndExitCode(errhand.BuildDError("transfer command not yet implemented").Build(), nil)
+}

--- a/go/cmd/dolt/commands/transfer.go
+++ b/go/cmd/dolt/commands/transfer.go
@@ -16,13 +16,35 @@ package commands
 
 import (
 	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/xtaci/smux"
+	"google.golang.org/grpc"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
+	remotesapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/remotesapi/v1alpha1"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
+	"github.com/dolthub/dolt/go/libraries/doltcore/remotesrv"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
+	"github.com/dolthub/dolt/go/libraries/utils/filesys"
+	"github.com/dolthub/dolt/go/store/datas"
 )
 
+// TransferCmd serves repository data over stdin/stdout for SSH remote operations.
 type TransferCmd struct{}
 
 func (cmd TransferCmd) Name() string {
@@ -51,7 +73,13 @@ var transferDocs = cli.CommandDocumentationContent{
 It serves repository data over stdin/stdout using multiplexed gRPC and HTTP protocols.
 
 This command is typically invoked by SSH when cloning or pushing to SSH remotes:
-  ssh user@host "dolt transfer /path/to/repo"
+  ssh user@host "dolt --data-dir /path/to/repo transfer"
+
+The transfer command:
+  - Loads the Dolt database at the specified path
+  - Starts a gRPC server for chunk store operations
+  - Starts an HTTP server for table file transfers
+  - Multiplexes both protocols over stdin/stdout using SMUX
 
 This is a low-level command not intended for direct use.`,
 	Synopsis: []string{
@@ -71,9 +99,316 @@ func (cmd TransferCmd) ArgParser() *argparser.ArgParser {
 
 func (cmd TransferCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, cliCtx cli.CliContext) int {
 	ap := cmd.ArgParser()
-	help, _ := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, transferDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.CommandDocsForCommandString(commandStr, transferDocs, ap))
 	_ = cli.ParseArgsOrDie(ap, args, help)
 
-	// TODO: implement transfer command (serves gRPC + HTTP over stdio via SMUX)
-	return HandleVErrAndExitCode(errhand.BuildDError("transfer command not yet implemented").Build(), nil)
+	// Ignore SIGPIPE to prevent broken pipe crashes during SSH disconnect.
+	signal.Ignore(syscall.SIGPIPE)
+
+	// Load the database from the data directory set via --data-dir.
+	ddb := dEnv.DoltDB(ctx)
+	if ddb == nil || dEnv.DBLoadError != nil {
+		if dEnv.DBLoadError != nil {
+			return HandleVErrAndExitCode(errhand.BuildDError("failed to load database").AddCause(dEnv.DBLoadError).Build(), usage)
+		}
+		return HandleVErrAndExitCode(errhand.BuildDError("failed to load database").Build(), usage)
+	}
+
+	// Create SMUX session (server mode) over stdin/stdout.
+	conn := newStdioConn(os.Stdin, os.Stdout)
+	smuxConfig := smux.DefaultConfig()
+	smuxConfig.MaxReceiveBuffer = 128 * 1024 * 1024
+	smuxConfig.MaxStreamBuffer = 128 * 1024 * 1024
+
+	session, err := smux.Server(conn, smuxConfig)
+	if err != nil {
+		return HandleVErrAndExitCode(errhand.BuildDError("failed to create SMUX session").AddCause(err).Build(), usage)
+	}
+	defer session.Close()
+
+	// Set up gRPC chunk store service backed by this database.
+	db := doltdb.HackDatasDatabaseFromDoltDB(ddb)
+	cs := datas.ChunkStoreFromDatabase(db)
+	dbCache := &singletonDBCache{cs: cs.(remotesrv.RemoteSrvStore)}
+
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	logEntry := logrus.NewEntry(logger)
+
+	sealer := &identitySealer{}
+	chunkStoreService := remotesrv.NewHttpFSBackedChunkStore(
+		logEntry,
+		transferHost,
+		dbCache,
+		dEnv.FS,
+		"http",
+		remotesapi.PushConcurrencyControl_PUSH_CONCURRENCY_CONTROL_UNSPECIFIED,
+		sealer,
+	)
+
+	grpcServer := grpc.NewServer(
+		grpc.MaxRecvMsgSize(128*1024*1024),
+		grpc.MaxSendMsgSize(128*1024*1024),
+	)
+	remotesapi.RegisterChunkStoreServiceServer(grpcServer, chunkStoreService)
+
+	// Set up HTTP handler for table file transfers.
+	httpHandler := newTransferFileHandler(dbCache, dEnv.FS, logEntry, sealer)
+	httpServer := &http.Server{Handler: httpHandler}
+
+	// Create SMUX-backed listeners for gRPC and HTTP.
+	grpcListener := &smuxListener{session: session}
+	httpListener := &smuxListener{session: session}
+
+	// Start both servers.
+	errCh := make(chan error, 2)
+	go func() {
+		if err := grpcServer.Serve(grpcListener); err != nil {
+			errCh <- fmt.Errorf("gRPC server error: %w", err)
+		}
+	}()
+	go func() {
+		if err := httpServer.Serve(httpListener); err != nil && err != http.ErrServerClosed {
+			errCh <- fmt.Errorf("HTTP server error: %w", err)
+		}
+	}()
+
+	// Wait for session close, server error, or context cancellation.
+	select {
+	case <-errCh:
+		return 1
+	case <-session.CloseChan():
+		return 0
+	case <-ctx.Done():
+		return 0
+	}
+}
+
+// transferHost is the virtual hostname used for HTTP requests routed through
+// the SMUX transport. The client registers a custom HTTP transport for this
+// host so requests are routed through the SSH connection rather than the network.
+const transferHost = "transfer.local"
+
+// identitySealer is a no-op Sealer for the local stdio transport where URL
+// sealing/unsealing is unnecessary.
+type identitySealer struct{}
+
+func (identitySealer) Seal(u *url.URL) (*url.URL, error)   { return u, nil }
+func (identitySealer) Unseal(u *url.URL) (*url.URL, error) { return u, nil }
+
+// singletonDBCache implements remotesrv.DBCache for a single database,
+// always returning the same chunk store regardless of path.
+type singletonDBCache struct {
+	cs remotesrv.RemoteSrvStore
+}
+
+func (s *singletonDBCache) Get(_ context.Context, _, _ string) (remotesrv.RemoteSrvStore, error) {
+	return s.cs, nil
+}
+
+// --- stdioConn: net.Conn over stdin/stdout ---
+
+// stdioConn wraps an io.Reader and io.Writer as a net.Conn for use with SMUX.
+type stdioConn struct {
+	r io.Reader
+	w io.Writer
+}
+
+func newStdioConn(r io.Reader, w io.Writer) *stdioConn {
+	return &stdioConn{r: r, w: w}
+}
+
+func (c *stdioConn) Read(p []byte) (int, error)  { return c.r.Read(p) }
+func (c *stdioConn) Write(p []byte) (int, error) { return c.w.Write(p) }
+func (c *stdioConn) Close() error                { return nil }
+
+func (c *stdioConn) LocalAddr() net.Addr                { return stdioAddr{} }
+func (c *stdioConn) RemoteAddr() net.Addr               { return stdioAddr{} }
+func (c *stdioConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *stdioConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *stdioConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+type stdioAddr struct{}
+
+func (stdioAddr) Network() string { return "stdio" }
+func (stdioAddr) String() string  { return "stdio" }
+
+// --- smuxListener: net.Listener over SMUX session ---
+
+// smuxListener implements net.Listener by accepting SMUX streams from a session.
+type smuxListener struct {
+	session *smux.Session
+}
+
+func (l *smuxListener) Accept() (net.Conn, error) {
+	return l.session.AcceptStream()
+}
+
+func (l *smuxListener) Close() error   { return nil }
+func (l *smuxListener) Addr() net.Addr { return stdioAddr{} }
+
+// --- transferFileHandler: HTTP handler for table file serving ---
+
+// transferFileHandler serves table files over HTTP through the SMUX transport.
+// It handles GET requests for downloading table files and POST/PUT for uploads.
+type transferFileHandler struct {
+	dbCache remotesrv.DBCache
+	fs      filesys.Filesys
+	lgr     *logrus.Entry
+	sealer  remotesrv.Sealer
+}
+
+func newTransferFileHandler(dbCache remotesrv.DBCache, fs filesys.Filesys, lgr *logrus.Entry, sealer remotesrv.Sealer) *transferFileHandler {
+	return &transferFileHandler{
+		dbCache: dbCache,
+		fs:      fs,
+		lgr:     lgr,
+		sealer:  sealer,
+	}
+}
+
+func (fh *transferFileHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	url, err := fh.sealer.Unseal(r.URL)
+	if err != nil {
+		fh.lgr.WithError(err).Warn("could not unseal URL")
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+
+	path := strings.TrimLeft(url.Path, "/")
+
+	switch r.Method {
+	case http.MethodGet:
+		fh.handleGet(w, r, path)
+	case http.MethodPost, http.MethodPut:
+		fh.handleUpload(w, r, path)
+	default:
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (fh *transferFileHandler) handleGet(w http.ResponseWriter, r *http.Request, path string) {
+	reader, err := fh.fs.OpenForRead(path)
+	if err != nil {
+		http.Error(w, "Not Found", http.StatusNotFound)
+		return
+	}
+	defer reader.Close()
+
+	rangeHeader := r.Header.Get("Range")
+	if rangeHeader != "" {
+		fh.handleRangeGet(w, reader, path, rangeHeader)
+		return
+	}
+
+	// Full file response.
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		fh.lgr.WithError(err).Error("failed to read file")
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+	w.Write(data)
+}
+
+func (fh *transferFileHandler) handleRangeGet(w http.ResponseWriter, reader io.ReadCloser, path string, rangeHeader string) {
+	var start, end int64
+	if _, err := fmt.Sscanf(rangeHeader, "bytes=%d-%d", &start, &end); err != nil {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		fh.lgr.WithError(err).Error("failed to read file")
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	fileSize := int64(len(data))
+	if start < 0 || start >= fileSize || end >= fileSize || start > end {
+		http.Error(w, "Requested Range Not Satisfiable", http.StatusRequestedRangeNotSatisfiable)
+		return
+	}
+
+	rangeData := data[start : end+1]
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Length", strconv.Itoa(len(rangeData)))
+	w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, fileSize))
+	w.WriteHeader(http.StatusPartialContent)
+	w.Write(rangeData)
+}
+
+func (fh *transferFileHandler) handleUpload(w http.ResponseWriter, r *http.Request, path string) {
+	i := strings.LastIndex(path, "/")
+	if i < 0 {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+
+	dbPath := path[:i]
+	filename := path[i+1:]
+	q := r.URL.Query()
+
+	numChunksStr := q.Get("num_chunks")
+	if numChunksStr == "" {
+		http.Error(w, "Bad Request: num_chunks required", http.StatusBadRequest)
+		return
+	}
+	numChunks, err := strconv.Atoi(numChunksStr)
+	if err != nil {
+		http.Error(w, "Bad Request: invalid num_chunks", http.StatusBadRequest)
+		return
+	}
+
+	contentLengthStr := q.Get("content_length")
+	if contentLengthStr == "" {
+		http.Error(w, "Bad Request: content_length required", http.StatusBadRequest)
+		return
+	}
+	contentLength, err := strconv.ParseUint(contentLengthStr, 10, 64)
+	if err != nil {
+		http.Error(w, "Bad Request: invalid content_length", http.StatusBadRequest)
+		return
+	}
+
+	contentHashStr := q.Get("content_hash")
+	if contentHashStr == "" {
+		http.Error(w, "Bad Request: content_hash required", http.StatusBadRequest)
+		return
+	}
+	contentHash, err := base64.RawURLEncoding.DecodeString(contentHashStr)
+	if err != nil {
+		http.Error(w, "Bad Request: invalid content_hash", http.StatusBadRequest)
+		return
+	}
+
+	splitOffset := uint64(0)
+	if splitOffsetStr := q.Get("split_offset"); splitOffsetStr != "" {
+		splitOffset, err = strconv.ParseUint(splitOffsetStr, 10, 64)
+		if err != nil {
+			http.Error(w, "Bad Request: invalid split_offset", http.StatusBadRequest)
+			return
+		}
+	}
+
+	cs, err := fh.dbCache.Get(r.Context(), dbPath, "")
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	err = cs.WriteTableFile(r.Context(), filename, splitOffset, numChunks, contentHash, func() (io.ReadCloser, uint64, error) {
+		return r.Body, contentLength, nil
+	})
+	if err != nil {
+		fh.lgr.WithError(err).Error("failed to write table file")
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }

--- a/go/cmd/dolt/commands/transfer.go
+++ b/go/cmd/dolt/commands/transfer.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Dolthub, Inc.
+// Copyright 2026 Dolthub, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/go/cmd/dolt/commands/transfer.go
+++ b/go/cmd/dolt/commands/transfer.go
@@ -128,7 +128,7 @@ func (cmd TransferCmd) Exec(ctx context.Context, commandStr string, args []strin
 	defer session.Close()
 
 	// Set up gRPC chunk store service backed by this database.
-	db := doltdb.HackDatasDatabaseFromDoltDB(ddb)
+	db := doltdb.ExposeDatabaseFromDoltDB(ddb)
 	cs := datas.ChunkStoreFromDatabase(db)
 	dbCache := &singletonDBCache{cs: cs.(remotesrv.RemoteSrvStore)}
 

--- a/go/cmd/dolt/commands/transfer.go
+++ b/go/cmd/dolt/commands/transfer.go
@@ -133,8 +133,10 @@ func (cmd TransferCmd) Exec(ctx context.Context, commandStr string, args []strin
 	dbCache := &singletonDBCache{cs: cs.(remotesrv.RemoteSrvStore)}
 
 	logger := logrus.New()
-	logger.SetOutput(io.Discard)
+	logger.SetOutput(os.Stderr)
 	logEntry := logrus.NewEntry(logger)
+
+	logEntry.Info("transfer: serving repository")
 
 	sealer := &identitySealer{}
 	chunkStoreService := remotesrv.NewHttpFSBackedChunkStore(

--- a/go/cmd/dolt/commands/transfer.go
+++ b/go/cmd/dolt/commands/transfer.go
@@ -363,7 +363,7 @@ func (fh *transferFileHandler) handleUpload(w http.ResponseWriter, r *http.Reque
 	})
 	if err != nil {
 		fh.lgr.WithError(err).Error("failed to write table file")
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 

--- a/go/cmd/dolt/commands/transfer.go
+++ b/go/cmd/dolt/commands/transfer.go
@@ -82,9 +82,6 @@ The transfer command:
   - Multiplexes both protocols over stdin/stdout using SMUX
 
 This is a low-level command not intended for direct use.`,
-	Synopsis: []string{
-		"<path>",
-	},
 }
 
 func (cmd TransferCmd) Docs() *cli.CommandDocumentation {

--- a/go/cmd/dolt/commands/transfer.go
+++ b/go/cmd/dolt/commands/transfer.go
@@ -138,7 +138,7 @@ func (cmd TransferCmd) Exec(ctx context.Context, commandStr string, args []strin
 	logger.SetOutput(os.Stderr)
 	logEntry := logrus.NewEntry(logger)
 
-	sealer := &identitySealer{}
+	sealer := &passThruSealer{}
 	chunkStoreService := remotesrv.NewHttpFSBackedChunkStore(
 		logEntry,
 		transferHost,
@@ -159,7 +159,6 @@ func (cmd TransferCmd) Exec(ctx context.Context, commandStr string, args []strin
 	httpHandler := newTransferFileHandler(dbCache, dEnv.FS, logEntry)
 	httpServer := &http.Server{Handler: httpHandler}
 
-	// Create SMUX-backed listeners for gRPC and HTTP.
 	listener := &smuxListener{session: session}
 
 	// Start both servers.
@@ -193,12 +192,12 @@ func (cmd TransferCmd) Exec(ctx context.Context, commandStr string, args []strin
 // host so requests are routed through the SSH connection rather than the network.
 const transferHost = "transfer.local"
 
-// identitySealer is a no-op Sealer for the local stdio transport where URL
+// passThruSealer is a no-op Sealer for the local stdio transport where URL
 // sealing/unsealing is unnecessary.
-type identitySealer struct{}
+type passThruSealer struct{}
 
-func (identitySealer) Seal(u *url.URL) (*url.URL, error)   { return u, nil }
-func (identitySealer) Unseal(u *url.URL) (*url.URL, error) { return u, nil }
+func (passThruSealer) Seal(u *url.URL) (*url.URL, error)   { return u, nil }
+func (passThruSealer) Unseal(u *url.URL) (*url.URL, error) { return u, nil }
 
 // singletonDBCache implements remotesrv.DBCache for a single database,
 // always returning the same chunk store regardless of path.

--- a/go/cmd/dolt/commands/transfer.go
+++ b/go/cmd/dolt/commands/transfer.go
@@ -169,7 +169,7 @@ func (cmd TransferCmd) Exec(ctx context.Context, commandStr string, args []strin
 		}
 	}()
 	go func() {
-		if err := httpServer.Serve(listener); err != nil && err != http.ErrServerClosed {
+		if err := httpServer.Serve(listener); err != nil {
 			errCh <- fmt.Errorf("HTTP server error: %w", err)
 		}
 	}()

--- a/go/cmd/dolt/commands/transfer.go
+++ b/go/cmd/dolt/commands/transfer.go
@@ -31,6 +31,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/xtaci/smux"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
@@ -149,28 +151,32 @@ func (cmd TransferCmd) Exec(ctx context.Context, commandStr string, args []strin
 		sealer,
 	)
 
+	// gRPC for chunk store operations.
 	grpcServer := grpc.NewServer(
 		grpc.MaxRecvMsgSize(remotesrv.MaxGRPCMessageSize),
 		grpc.MaxSendMsgSize(remotesrv.MaxGRPCMessageSize),
 	)
 	remotesapi.RegisterChunkStoreServiceServer(grpcServer, chunkStoreService)
 
-	// Set up HTTP handler for table file transfers.
-	httpHandler := newTransferFileHandler(dbCache, dEnv.FS, logEntry)
-	httpServer := &http.Server{Handler: httpHandler}
+	// Http handler for storage file transfers.
+	fileServer := newTransferFileHandler(dbCache, dEnv.FS, logEntry)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc") {
+			grpcServer.ServeHTTP(w, r)
+		} else {
+			fileServer.ServeHTTP(w, r)
+		}
+	})
+	h2s := &http2.Server{}
+	httpServer := &http.Server{Handler: h2c.NewHandler(handler, h2s)}
 
 	listener := &smuxListener{session: session}
 
-	// Start both servers.
-	errCh := make(chan error, 2)
-	go func() {
-		if err := grpcServer.Serve(listener); err != nil {
-			errCh <- fmt.Errorf("gRPC server error: %w", err)
-		}
-	}()
+	errCh := make(chan error, 1)
 	go func() {
 		if err := httpServer.Serve(listener); err != nil {
-			errCh <- fmt.Errorf("HTTP server error: %w", err)
+			errCh <- fmt.Errorf("server error: %w", err)
 		}
 	}()
 

--- a/go/cmd/dolt/commands/transfer.go
+++ b/go/cmd/dolt/commands/transfer.go
@@ -80,6 +80,11 @@ The transfer command:
   - Starts an HTTP server for table file transfers
   - Multiplexes both protocols over stdin/stdout using SMUX
 
+The exit code of the transfer command is not meaningful to callers. All errors
+are surfaced through the gRPC and HTTP responses on the multiplexed IO streams.
+The client detects a failed subprocess via pipe EOF, which closes the SMUX
+session and cancels in-flight operations.
+
 This is a low-level command not intended for direct use.`,
 }
 
@@ -182,7 +187,8 @@ func (cmd TransferCmd) Exec(ctx context.Context, commandStr string, args []strin
 	case err := <-errCh:
 		// We get away with printing directly to stderr here since transfer command is special-cased to leave IO streams alone.
 		fmt.Fprintf(os.Stderr, "%v\n", err)
-		return 1
+		// Transfer command exit code is not meaningful to callers. HTTP/gRPC Errors rule.
+		return 0
 	case <-session.CloseChan():
 		return 0
 	case <-ctx.Done():
@@ -253,4 +259,3 @@ func (l *smuxListener) Accept() (net.Conn, error) {
 
 func (l *smuxListener) Close() error   { return nil }
 func (l *smuxListener) Addr() net.Addr { return stdioAddr{} }
-

--- a/go/cmd/dolt/commands/transfer.go
+++ b/go/cmd/dolt/commands/transfer.go
@@ -16,7 +16,6 @@ package commands
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"io"
 	"net"
@@ -24,7 +23,6 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -42,7 +40,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/remotesrv"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
-	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/store/datas"
 )
 
@@ -158,8 +155,8 @@ func (cmd TransferCmd) Exec(ctx context.Context, commandStr string, args []strin
 	)
 	remotesapi.RegisterChunkStoreServiceServer(grpcServer, chunkStoreService)
 
-	// Http handler for storage file transfers.
-	fileServer := newTransferFileHandler(dbCache, dEnv.FS, logEntry)
+	// Http handler for storage file transfers -- reuse remotesrv's filehandler.
+	fileServer := remotesrv.NewFileHandler(logEntry, dbCache, dEnv.FS, false, sealer, true)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc") {
@@ -257,121 +254,3 @@ func (l *smuxListener) Accept() (net.Conn, error) {
 func (l *smuxListener) Close() error   { return nil }
 func (l *smuxListener) Addr() net.Addr { return stdioAddr{} }
 
-// transferFileHandler serves table files over HTTP through the SMUX transport.
-type transferFileHandler struct {
-	dbCache remotesrv.DBCache
-	fs      filesys.Filesys
-	lgr     *logrus.Entry
-}
-
-func newTransferFileHandler(dbCache remotesrv.DBCache, fs filesys.Filesys, lgr *logrus.Entry) *transferFileHandler {
-	return &transferFileHandler{
-		dbCache: dbCache,
-		fs:      fs,
-		lgr:     lgr,
-	}
-}
-
-func (fh *transferFileHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	path := strings.TrimLeft(r.URL.Path, "/")
-
-	switch r.Method {
-	case http.MethodGet:
-		fh.handleGet(w, r, path)
-	case http.MethodPost, http.MethodPut:
-		fh.handleUpload(w, r, path)
-	default:
-		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
-	}
-}
-
-func (fh *transferFileHandler) handleGet(w http.ResponseWriter, r *http.Request, path string) {
-	reader, err := fh.fs.OpenForRead(path)
-	if err != nil {
-		http.Error(w, "Not Found", http.StatusNotFound)
-		return
-	}
-	defer reader.Close()
-
-	// The underlying reader is an *os.File which implements io.ReadSeeker.
-	// http.ServeContent handles full and range requests with streaming.
-	rs, ok := reader.(io.ReadSeeker)
-	if !ok {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/octet-stream")
-	http.ServeContent(w, r, "", time.Time{}, rs)
-}
-
-func (fh *transferFileHandler) handleUpload(w http.ResponseWriter, r *http.Request, path string) {
-	i := strings.LastIndex(path, "/")
-	if i < 0 {
-		http.Error(w, "Bad Request", http.StatusBadRequest)
-		return
-	}
-
-	dbPath := path[:i]
-	filename := path[i+1:]
-	q := r.URL.Query()
-
-	numChunksStr := q.Get("num_chunks")
-	if numChunksStr == "" {
-		http.Error(w, "Bad Request: num_chunks required", http.StatusBadRequest)
-		return
-	}
-	numChunks, err := strconv.Atoi(numChunksStr)
-	if err != nil {
-		http.Error(w, "Bad Request: invalid num_chunks", http.StatusBadRequest)
-		return
-	}
-
-	contentLengthStr := q.Get("content_length")
-	if contentLengthStr == "" {
-		http.Error(w, "Bad Request: content_length required", http.StatusBadRequest)
-		return
-	}
-	contentLength, err := strconv.ParseUint(contentLengthStr, 10, 64)
-	if err != nil {
-		http.Error(w, "Bad Request: invalid content_length", http.StatusBadRequest)
-		return
-	}
-
-	contentHashStr := q.Get("content_hash")
-	if contentHashStr == "" {
-		http.Error(w, "Bad Request: content_hash required", http.StatusBadRequest)
-		return
-	}
-	contentHash, err := base64.RawURLEncoding.DecodeString(contentHashStr)
-	if err != nil {
-		http.Error(w, "Bad Request: invalid content_hash", http.StatusBadRequest)
-		return
-	}
-
-	splitOffset := uint64(0)
-	if splitOffsetStr := q.Get("split_offset"); splitOffsetStr != "" {
-		splitOffset, err = strconv.ParseUint(splitOffsetStr, 10, 64)
-		if err != nil {
-			http.Error(w, "Bad Request: invalid split_offset", http.StatusBadRequest)
-			return
-		}
-	}
-
-	cs, err := fh.dbCache.Get(r.Context(), dbPath, "")
-	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-
-	err = cs.WriteTableFile(r.Context(), filename, splitOffset, numChunks, contentHash, func() (io.ReadCloser, uint64, error) {
-		return r.Body, contentLength, nil
-	})
-	if err != nil {
-		fh.lgr.WithError(err).Error("failed to write table file")
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
-}

--- a/go/cmd/dolt/commands/transfer.go
+++ b/go/cmd/dolt/commands/transfer.go
@@ -130,7 +130,7 @@ func (cmd TransferCmd) Exec(ctx context.Context, commandStr string, args []strin
 	db := doltdb.ExposeDatabaseFromDoltDB(ddb)
 	cs := datas.ChunkStoreFromDatabase(db)
 
-	// GenerationalChunkStore implements RemoteSrvStore, so this is going to work for any "normal" Dole db.
+	// GenerationalChunkStore implements RemoteSrvStore, so this is going to work for any "normal" Dolt db.
 	if _, ok := cs.(remotesrv.RemoteSrvStore); !ok {
 		return HandleVErrAndExitCode(errhand.BuildDError("chunk store does not implement RemoteSrvStore").Build(), usage)
 	}

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -435,10 +435,19 @@ func runMain() int {
 	seedGlobalRand()
 
 	// Peek at the subcommand name to determine if IO redirect is needed.
-	// At this point debug flags have been consumed, so args[0] is the subcommand.
+	// At this point debug flags have been consumed, but global args like
+	// --data-dir may precede the subcommand. Scan for the first non-flag arg.
 	subCmd := ""
-	if len(args) > 0 {
-		subCmd = args[0]
+	for i := 0; i < len(args); i++ {
+		if strings.HasPrefix(args[i], "-") {
+			// Skip the flag's value if it's a --key value style flag
+			if i+1 < len(args) && !strings.Contains(args[i], "=") {
+				i++
+			}
+			continue
+		}
+		subCmd = args[i]
+		break
 	}
 
 	if needsIORedirect(subCmd) {

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -453,7 +453,7 @@ func runMain() int {
 
 	warnIfMaxFilesTooLow()
 
-	if ok, exit := interceptSendMetrics(ctx, args); ok {
+	if ok, exit := interceptSendMetrics(ctx, cfg.remainingArgs); ok {
 		return exit
 	}
 

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -441,10 +441,15 @@ func runMain() int {
 	}
 	args = nil
 
+	var restoreIO func()
 	if needsIORedirect(cfg.subCommand) {
-		restoreIO := cli.InitIO()
-		defer restoreIO()
+		restoreIO = cli.InitIO()
 	}
+	defer func() {
+		if restoreIO != nil {
+			restoreIO()
+		}
+	}()
 
 	warnIfMaxFilesTooLow()
 

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -441,15 +441,10 @@ func runMain() int {
 	}
 	args = nil
 
-	var restoreIO func()
 	if needsIORedirect(cfg.subCommand) {
-		restoreIO = cli.InitIO()
+		restoreIO := cli.InitIO()
+		defer restoreIO()
 	}
-	defer func() {
-		if restoreIO != nil {
-			restoreIO()
-		}
-	}()
 
 	warnIfMaxFilesTooLow()
 

--- a/go/cmd/dolt/doltcmd/doltcmd.go
+++ b/go/cmd/dolt/doltcmd/doltcmd.go
@@ -91,6 +91,7 @@ var doltSubCommands = []cli.Command{
 	ci.Commands,
 	commands.DebugCmd{},
 	commands.RmCmd{},
+	commands.TransferCmd{},
 }
 
 var DoltCommand = cli.NewSubCommandHandler("dolt", "it's git for data", doltSubCommands)

--- a/go/go.mod
+++ b/go/go.mod
@@ -87,6 +87,7 @@ require (
 	github.com/vbauerster/mpb/v8 v8.0.2
 	github.com/xitongsys/parquet-go v1.6.1
 	github.com/xitongsys/parquet-go-source v0.0.0-20211010230925-397910c5e371
+	github.com/xtaci/smux v1.5.56
 	github.com/zeebo/blake3 v0.2.3
 	github.com/zeebo/xxh3 v1.0.2
 	go.etcd.io/bbolt v1.3.6
@@ -184,7 +185,6 @@ require (
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
-	github.com/xtaci/smux v1.5.56 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/go/go.mod
+++ b/go/go.mod
@@ -184,6 +184,7 @@ require (
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
+	github.com/xtaci/smux v1.5.56 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -559,6 +559,8 @@ github.com/xitongsys/parquet-go-source v0.0.0-20190524061010-2b72cbee77d5/go.mod
 github.com/xitongsys/parquet-go-source v0.0.0-20200817004010-026bad9b25d0/go.mod h1:HYhIKsdns7xz80OgkbgJYrtQY7FjHWHKH6cvN7+czGE=
 github.com/xitongsys/parquet-go-source v0.0.0-20211010230925-397910c5e371 h1:RfGiOP/lWKBeNgpXmCeandYGV4pAnZsl42kX50p1UgE=
 github.com/xitongsys/parquet-go-source v0.0.0-20211010230925-397910c5e371/go.mod h1:qLb2Itmdcp7KPa5KZKvhE9U1q5bYSOmgeOckF/H2rQA=
+github.com/xtaci/smux v1.5.56 h1:Eyv/dUULmkGZZNucLUisnkzJ/4UQ5YZTschhugFBM0U=
+github.com/xtaci/smux v1.5.56/go.mod h1:IGQ9QYrBphmb/4aTnLEcJby0TNr3NV+OslIOMrX825Q=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go/libraries/doltcore/dbfactory/factory.go
+++ b/go/libraries/doltcore/dbfactory/factory.go
@@ -51,6 +51,9 @@ const (
 	// HTTPScheme
 	HTTPScheme = "http"
 
+	// SSHScheme
+	SSHScheme = "ssh"
+
 	// LocalFS Blobstore Scheme
 	LocalBSScheme = "localbs"
 
@@ -92,6 +95,7 @@ var DBFactories = map[string]DBFactory{
 	GitHTTPScheme:  GitRemoteFactory{},
 	GitHTTPSScheme: GitRemoteFactory{},
 	GitSSHScheme:   GitRemoteFactory{},
+	SSHScheme:      SSHRemoteFactory{},
 }
 
 // CreateDB creates a database based on the supplied urlStr, and creation params.  The DBFactory used for creation is

--- a/go/libraries/doltcore/dbfactory/ssh.go
+++ b/go/libraries/doltcore/dbfactory/ssh.go
@@ -55,6 +55,9 @@ func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, 
 	path := urlObj.Path
 	user := ""
 
+	// Strip trailing /.dolt if provided.
+	path = strings.TrimSuffix(path, "/.dolt")
+
 	if urlObj.User != nil {
 		user = urlObj.User.Username()
 	}

--- a/go/libraries/doltcore/dbfactory/ssh.go
+++ b/go/libraries/doltcore/dbfactory/ssh.go
@@ -33,6 +33,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	remotesapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/remotesapi/v1alpha1"
+	"github.com/dolthub/dolt/go/libraries/doltcore/remotesrv"
 	"github.com/dolthub/dolt/go/libraries/doltcore/remotestorage"
 	"github.com/dolthub/dolt/go/store/datas"
 	"github.com/dolthub/dolt/go/store/prolly/tree"
@@ -118,8 +119,8 @@ func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, 
 		stdin: stdin,
 	}
 	smuxConfig := smux.DefaultConfig()
-	smuxConfig.MaxReceiveBuffer = 128 * 1024 * 1024
-	smuxConfig.MaxStreamBuffer = 128 * 1024 * 1024
+	smuxConfig.MaxReceiveBuffer = remotesrv.MaxGRPCMessageSize
+	smuxConfig.MaxStreamBuffer = remotesrv.MaxGRPCMessageSize
 
 	session, err := smux.Client(pConn, smuxConfig)
 	if err != nil {

--- a/go/libraries/doltcore/dbfactory/ssh.go
+++ b/go/libraries/doltcore/dbfactory/ssh.go
@@ -99,6 +99,9 @@ func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, 
 	select {
 	case err := <-processDone:
 		errMsg := strings.TrimSpace(stderrBuf.String())
+		if strings.Contains(errMsg, "no such file or directory") || strings.Contains(errMsg, "failed to load database") {
+			return nil, nil, nil, fmt.Errorf("repository not found at %s", path)
+		}
 		if errMsg != "" {
 			return nil, nil, nil, fmt.Errorf("ssh remote error: %s", errMsg)
 		}

--- a/go/libraries/doltcore/dbfactory/ssh.go
+++ b/go/libraries/doltcore/dbfactory/ssh.go
@@ -187,8 +187,8 @@ func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, 
 	return db, vrw, ns, nil
 }
 
-// sshRemoteError builds an error message for SSH remote failures. It waits
-// for the remote's stderr to be fully read (signaled by stderrDone) and
+// sshRemoteError builds an error message for SSH remote failures. It first uses
+// the text of stderr, and if there is none if returns the provided error.
 // uses it to produce a more informative message than the raw gRPC/SMUX error.
 func sshRemoteError(stderrDone <-chan struct{}, stderrBuf *bytes.Buffer, path, msg string, err error) error {
 	<-stderrDone
@@ -199,6 +199,7 @@ func sshRemoteError(stderrDone <-chan struct{}, stderrBuf *bytes.Buffer, path, m
 		}
 		return fmt.Errorf("%s: remote: %s", msg, errMsg)
 	}
+	// If no stderr output, return the original error.
 	return fmt.Errorf("%s: %w", msg, err)
 }
 
@@ -257,14 +258,12 @@ func buildTransferCommand(host, port, path, user string) (*exec.Cmd, error) {
 		return nil, fmt.Errorf("invalid %s: empty", EnvSSHCommand)
 	}
 
-	args := append(sshArgs[1:], "-p", port, sshTarget, remoteCmd)
-	if port == "" {
-		args = append(sshArgs[1:], sshTarget, remoteCmd)
+	args := append(sshArgs[1:], sshTarget, remoteCmd)
+	if port != "" {
+		args = append(sshArgs[1:], "-p", port, sshTarget, remoteCmd)
 	}
 	return exec.Command(sshArgs[0], args...), nil
 }
-
-// --- sshConnection: lifecycle management ---
 
 // sshConnection holds all resources for an SSH transfer connection and
 // implements coordinated cleanup.
@@ -298,8 +297,6 @@ func (c *sshConnection) Close() error {
 	return nil
 }
 
-// --- sshChunkStore: wraps DoltChunkStore with cleanup ---
-
 // sshChunkStore wraps a DoltChunkStore and closes the SSH connection when
 // the chunk store is closed.
 type sshChunkStore struct {
@@ -315,8 +312,6 @@ func (s *sshChunkStore) Close() error {
 	}
 	return connErr
 }
-
-// --- smuxHTTPTransport: http.RoundTripper over SMUX ---
 
 // smuxHTTPTransport implements http.RoundTripper by sending HTTP requests
 // over SMUX streams. Each request gets its own stream.
@@ -358,8 +353,6 @@ func (s *streamBodyCloser) Close() error {
 	s.stream.Close()
 	return err
 }
-
-// --- pipeConn: net.Conn over subprocess pipes ---
 
 // pipeConn implements net.Conn over a subprocess's stdin/stdout pipes.
 type pipeConn struct {

--- a/go/libraries/doltcore/dbfactory/ssh.go
+++ b/go/libraries/doltcore/dbfactory/ssh.go
@@ -82,6 +82,8 @@ func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, 
 		close(stderrDone)
 	}()
 
+	// Start the subprocess. From this point forward we must ensure that we call conn.CloseAndTerminate()
+	// on all error paths to avoid leaking subprocesses.
 	if err := cmd.Start(); err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to start transfer subprocess: %w", err)
 	}
@@ -296,8 +298,16 @@ func (c *sshConnection) Close() error {
 		c.stdin.Close()
 	}
 	if c.cmd != nil && c.cmd.Process != nil {
-		c.cmd.Process.Kill()
-		c.cmd.Wait()
+		// Kill the subprocess and reap it. If Kill succeeds, Wait will
+		// return a "signal: killed" error which we ignore since we
+		// initiated the kill. If Kill fails (process already exited),
+		// Wait returns the real exit status -- surface that since it
+		// means SSH itself failed (auth error, connection refused, etc.).
+		killErr := c.cmd.Process.Kill()
+		waitErr := c.cmd.Wait()
+		if killErr != nil && waitErr != nil {
+			return waitErr
+		}
 	}
 	return nil
 }

--- a/go/libraries/doltcore/dbfactory/ssh.go
+++ b/go/libraries/doltcore/dbfactory/ssh.go
@@ -78,7 +78,7 @@ func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, 
 	}
 	var stderrBuf bytes.Buffer
 	go func() {
-		io.Copy(io.MultiWriter(os.Stderr, &stderrBuf), stderrPipe)
+		io.Copy(&stderrBuf, stderrPipe)
 		close(stderrDone)
 	}()
 
@@ -88,7 +88,25 @@ func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, 
 		return nil, nil, nil, fmt.Errorf("failed to start transfer subprocess: %w", err)
 	}
 
+	// Wait for the subprocess in a background goroutine so we can be
+	// notified of exit via a channel. cmd.Wait() can only be called once,
+	// so this goroutine owns that call.
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- cmd.Wait()
+		close(waitCh)
+	}()
+
 	procCtx, procCancel := context.WithCancelCause(ctx)
+
+	// Construct sshConnection early so error paths can use conn.CloseWithErr()
+	// for coordinated cleanup regardless of how far initialization got.
+	conn := &sshConnection{
+		cmd:        cmd,
+		stdin:      stdin,
+		procCancel: procCancel,
+		waitCh:     waitCh,
+	}
 
 	// Create SMUX client session over the subprocess pipes.
 	pConn := &pipeConn{
@@ -101,10 +119,10 @@ func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, 
 
 	session, err := smux.Client(pConn, smuxConfig)
 	if err != nil {
-		cmd.Process.Kill()
-		procCancel(err)
+		conn.CloseWithErr(err)
 		return nil, nil, nil, sshRemoteError(stderrDone, &stderrBuf, path, "failed to create SMUX client session", err)
 	}
+	conn.session = session
 
 	// Monitor the SMUX session in a background goroutine. When the remote
 	// subprocess exits (bad path, missing dolt, SSH failure, etc.), the pipe
@@ -135,37 +153,20 @@ func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, 
 		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 	)
 	if err != nil {
-		session.Close()
-		cmd.Process.Kill()
-		procCancel(err)
+		conn.CloseWithErr(err)
 		return nil, nil, nil, sshRemoteError(stderrDone, &stderrBuf, path, "failed to create gRPC client", err)
 	}
+	conn.grpcConn = grpcConn
 
 	// Create chunk store backed by the remote gRPC service.
 	client := remotesapi.NewChunkStoreServiceClient(grpcConn)
 	cs, err := remotestorage.NewDoltChunkStoreFromPath(procCtx, nbf, urlObj.Path, path, false, client)
 	if err != nil {
-		procCancel(err)
-		grpcConn.Close()
-		session.Close()
-		stdin.Close()
-		if cmd.Process != nil {
-			cmd.Process.Kill()
-		}
+		conn.CloseWithErr(err)
 		return nil, nil, nil, sshRemoteError(stderrDone, &stderrBuf, path, "failed to create chunk store", err)
 	}
 
 	cs = cs.WithHTTPFetcher(httpClient)
-
-	// Wrap the chunk store with cleanup so resources are released when the
-	// database is closed.
-	conn := &sshConnection{
-		cmd:        cmd,
-		session:    session,
-		grpcConn:   grpcConn,
-		stdin:      stdin,
-		procCancel: procCancel,
-	}
 	wrappedCS := &sshChunkStore{DoltChunkStore: cs, conn: conn}
 
 	vrw := types.NewValueStore(wrappedCS)
@@ -280,13 +281,21 @@ type sshConnection struct {
 	grpcConn   *grpc.ClientConn
 	stdin      io.WriteCloser
 	procCancel context.CancelCauseFunc
+	waitCh     <-chan error
 }
 
-// Close releases all resources: unregisters the custom transport, closes
-// the SMUX session, gRPC connection, and kills the subprocess.
+// Close releases all resources: cancels the context, closes the SMUX
+// session, gRPC connection, stdin pipe, and waits for the subprocess to terminate.
 func (c *sshConnection) Close() error {
+	c.CloseWithErr(fmt.Errorf("connection closed"))
+	return nil
+}
+
+// CloseWithErr is like Close but provides a specific cause for the context
+// cancellation, which surfaces in gRPC errors and diagnostics.
+func (c *sshConnection) CloseWithErr(err error) {
 	if c.procCancel != nil {
-		c.procCancel(fmt.Errorf("connection closed"))
+		c.procCancel(err)
 	}
 	if c.session != nil {
 		c.session.Close()
@@ -297,19 +306,18 @@ func (c *sshConnection) Close() error {
 	if c.stdin != nil {
 		c.stdin.Close()
 	}
-	if c.cmd != nil && c.cmd.Process != nil {
-		// Kill the subprocess and reap it. If Kill succeeds, Wait will
-		// return a "signal: killed" error which we ignore since we
-		// initiated the kill. If Kill fails (process already exited),
-		// Wait returns the real exit status -- surface that since it
-		// means SSH itself failed (auth error, connection refused, etc.).
-		killErr := c.cmd.Process.Kill()
-		waitErr := c.cmd.Wait()
-		if killErr != nil && waitErr != nil {
-			return waitErr
+	if c.waitCh != nil {
+		// Wait for the subprocess to exit gracefully. If it hangs,
+		// forcefully kill it after a short timeout because it's really supposed to be done when we reach this point.
+		select {
+		case <-c.waitCh:
+		case <-time.After(1 * time.Second):
+			if c.cmd != nil && c.cmd.Process != nil {
+				c.cmd.Process.Kill()
+			}
+			<-c.waitCh
 		}
 	}
-	return nil
 }
 
 // sshChunkStore wraps a DoltChunkStore and closes the SSH connection when

--- a/go/libraries/doltcore/dbfactory/ssh.go
+++ b/go/libraries/doltcore/dbfactory/ssh.go
@@ -57,7 +57,7 @@ func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, 
 	path := urlObj.Path
 	user := ""
 
-	// Strip trailing /.dolt if provided.
+	path = strings.TrimSuffix(path, "/")
 	path = strings.TrimSuffix(path, "/.dolt")
 
 	if urlObj.User != nil {

--- a/go/libraries/doltcore/dbfactory/ssh.go
+++ b/go/libraries/doltcore/dbfactory/ssh.go
@@ -51,7 +51,8 @@ func (SSHRemoteFactory) PrepareDB(ctx context.Context, nbf *types.NomsBinFormat,
 // (either SSH or dolt transfer directly for localhost) and multiplexes gRPC
 // and HTTP over the subprocess's stdin/stdout using SMUX.
 func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, urlObj *url.URL, params map[string]interface{}) (datas.Database, types.ValueReadWriter, tree.NodeStore, error) {
-	host := urlObj.Host
+	host := urlObj.Hostname()
+	port := urlObj.Port()
 	path := urlObj.Path
 	user := ""
 
@@ -66,7 +67,7 @@ func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, 
 		host = host[atIdx+1:]
 	}
 
-	cmd, err := buildTransferCommand(host, path, user)
+	cmd, err := buildTransferCommand(host, port, path, user)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -176,10 +177,10 @@ func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, 
 }
 
 // buildTransferCommand constructs the exec.Cmd for the transfer subprocess.
-// It runs ssh [user@]host "<dolt> --data-dir <path> transfer", using DOLT_SSH
-// as the SSH binary if set (default "ssh"), and DOLT_SSH_EXEC_PATH as the
-// remote dolt binary path if set (default "dolt").
-func buildTransferCommand(host, path, user string) (*exec.Cmd, error) {
+// It runs ssh [-p port] [user@]host "<dolt> --data-dir <path> transfer",
+// using DOLT_SSH as the SSH binary if set (default "ssh"), and
+// DOLT_SSH_EXEC_PATH as the remote dolt binary path if set (default "dolt").
+func buildTransferCommand(host, port, path, user string) (*exec.Cmd, error) {
 	sshCommand := os.Getenv("DOLT_SSH")
 	if sshCommand == "" {
 		sshCommand = "ssh"
@@ -201,7 +202,10 @@ func buildTransferCommand(host, path, user string) (*exec.Cmd, error) {
 		return nil, fmt.Errorf("invalid DOLT_SSH command: empty")
 	}
 
-	args := append(sshArgs[1:], sshTarget, remoteCmd)
+	args := append(sshArgs[1:], "-p", port, sshTarget, remoteCmd)
+	if port == "" {
+		args = append(sshArgs[1:], sshTarget, remoteCmd)
+	}
 	return exec.Command(sshArgs[0], args...), nil
 }
 

--- a/go/libraries/doltcore/dbfactory/ssh.go
+++ b/go/libraries/doltcore/dbfactory/ssh.go
@@ -1,0 +1,312 @@
+// Copyright 2025 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dbfactory
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/xtaci/smux"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	remotesapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/remotesapi/v1alpha1"
+	"github.com/dolthub/dolt/go/libraries/doltcore/remotestorage"
+	"github.com/dolthub/dolt/go/store/datas"
+	"github.com/dolthub/dolt/go/store/prolly/tree"
+	"github.com/dolthub/dolt/go/store/types"
+)
+
+// SSHRemoteFactory creates databases backed by SSH remotes using the dolt
+// transfer command for multiplexed gRPC+HTTP over stdin/stdout.
+type SSHRemoteFactory struct{}
+
+func (SSHRemoteFactory) PrepareDB(ctx context.Context, nbf *types.NomsBinFormat, urlObj *url.URL, params map[string]interface{}) error {
+	return fmt.Errorf("ssh scheme does not support PrepareDB")
+}
+
+// CreateDB creates a database backed by an SSH remote. It spawns a subprocess
+// (either SSH or dolt transfer directly for localhost) and multiplexes gRPC
+// and HTTP over the subprocess's stdin/stdout using SMUX.
+func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, urlObj *url.URL, params map[string]interface{}) (datas.Database, types.ValueReadWriter, tree.NodeStore, error) {
+	host := urlObj.Host
+	path := urlObj.Path
+	user := ""
+
+	if urlObj.User != nil {
+		user = urlObj.User.Username()
+	}
+	if atIdx := strings.LastIndex(host, "@"); atIdx != -1 {
+		user = host[:atIdx]
+		host = host[atIdx+1:]
+	}
+
+	cmd, err := buildTransferCommand(host, path, user)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create stdin pipe: %w", err)
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create stdout pipe: %w", err)
+	}
+
+	cmd.Stderr = io.Discard
+
+	if err := cmd.Start(); err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to start transfer subprocess: %w", err)
+	}
+
+	// Check for early exit (non-blocking).
+	processDone := make(chan error, 1)
+	go func() { processDone <- cmd.Wait() }()
+
+	// Brief pause to detect immediate failures (e.g., bad path, missing dolt).
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case err := <-processDone:
+		return nil, nil, nil, fmt.Errorf("transfer subprocess exited immediately: %w", err)
+	default:
+	}
+
+	// Create SMUX client session over the subprocess pipes.
+	pConn := &pipeConn{
+		r:     stdout,
+		w:     stdin,
+		cmd:   cmd,
+		stdin: stdin,
+	}
+	smuxConfig := smux.DefaultConfig()
+	smuxConfig.MaxReceiveBuffer = 128 * 1024 * 1024
+	smuxConfig.MaxStreamBuffer = 128 * 1024 * 1024
+
+	session, err := smux.Client(pConn, smuxConfig)
+	if err != nil {
+		cmd.Process.Kill()
+		return nil, nil, nil, fmt.Errorf("failed to create SMUX client session: %w", err)
+	}
+	// Create a per-connection HTTP client that routes table file requests
+	// through the SMUX session. This is injected into the chunk store via
+	// WithHTTPFetcher so each SSH connection has its own transport.
+	httpClient := &http.Client{Transport: &smuxHTTPTransport{session: session}}
+
+	// Create gRPC client connection through SMUX streams.
+	grpcConn, err := grpc.NewClient(
+		"passthrough:///stdio",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(ctx context.Context, target string) (net.Conn, error) {
+			return session.OpenStream()
+		}),
+		grpc.WithDisableHealthCheck(),
+		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
+	)
+	if err != nil {
+		session.Close()
+		cmd.Process.Kill()
+		return nil, nil, nil, fmt.Errorf("failed to create gRPC client: %w", err)
+	}
+
+	// Create chunk store backed by the remote gRPC service.
+	client := remotesapi.NewChunkStoreServiceClient(grpcConn)
+	cs, err := remotestorage.NewDoltChunkStoreFromPath(ctx, nbf, urlObj.Path, path, false, client)
+	if err != nil {
+		grpcConn.Close()
+		session.Close()
+		cmd.Process.Kill()
+		return nil, nil, nil, fmt.Errorf("failed to create chunk store: %w", err)
+	}
+
+	cs = cs.WithHTTPFetcher(httpClient)
+
+	// Wrap the chunk store with cleanup so resources are released when the
+	// database is closed.
+	conn := &sshConnection{
+		cmd:      cmd,
+		session:  session,
+		grpcConn: grpcConn,
+		stdin:    stdin,
+	}
+	wrappedCS := &sshChunkStore{DoltChunkStore: cs, conn: conn}
+
+	vrw := types.NewValueStore(wrappedCS)
+	ns := tree.NewNodeStore(wrappedCS)
+	db := datas.NewTypesDatabase(vrw, ns)
+
+	return db, vrw, ns, nil
+}
+
+// buildTransferCommand constructs the exec.Cmd for the transfer subprocess.
+// For localhost without DOLT_SSH, it runs dolt transfer directly.
+// For remote hosts, it runs ssh [user@]host "dolt --data-dir <path> transfer".
+func buildTransferCommand(host, path, user string) (*exec.Cmd, error) {
+	sshCommand := os.Getenv("DOLT_SSH")
+
+	if host == "localhost" && sshCommand == "" {
+		// Local testing mode: run dolt transfer directly.
+		doltPath, err := os.Executable()
+		if err != nil {
+			doltPath = "dolt"
+		}
+		return exec.Command(doltPath, "--data-dir", path, "transfer"), nil
+	}
+
+	// Real SSH mode.
+	if sshCommand == "" {
+		sshCommand = "ssh"
+	}
+
+	sshTarget := host
+	if user != "" {
+		sshTarget = user + "@" + host
+	}
+
+	remoteCmd := fmt.Sprintf("dolt --data-dir %s transfer", path)
+	sshArgs := strings.Fields(sshCommand)
+	if len(sshArgs) == 0 {
+		return nil, fmt.Errorf("invalid DOLT_SSH command: empty")
+	}
+
+	args := append(sshArgs[1:], sshTarget, remoteCmd)
+	return exec.Command(sshArgs[0], args...), nil
+}
+
+// --- sshConnection: lifecycle management ---
+
+// sshConnection holds all resources for an SSH transfer connection and
+// implements coordinated cleanup.
+type sshConnection struct {
+	cmd      *exec.Cmd
+	session  *smux.Session
+	grpcConn *grpc.ClientConn
+	stdin    io.WriteCloser
+}
+
+// Close releases all resources: unregisters the custom transport, closes
+// the SMUX session, gRPC connection, and kills the subprocess.
+func (c *sshConnection) Close() error {
+	if c.session != nil {
+		c.session.Close()
+	}
+	if c.grpcConn != nil {
+		c.grpcConn.Close()
+	}
+	if c.stdin != nil {
+		c.stdin.Close()
+	}
+	if c.cmd != nil && c.cmd.Process != nil {
+		c.cmd.Process.Kill()
+		c.cmd.Wait()
+	}
+	return nil
+}
+
+// --- sshChunkStore: wraps DoltChunkStore with cleanup ---
+
+// sshChunkStore wraps a DoltChunkStore and closes the SSH connection when
+// the chunk store is closed.
+type sshChunkStore struct {
+	*remotestorage.DoltChunkStore
+	conn *sshConnection
+}
+
+func (s *sshChunkStore) Close() error {
+	err := s.DoltChunkStore.Close()
+	connErr := s.conn.Close()
+	if err != nil {
+		return err
+	}
+	return connErr
+}
+
+// --- smuxHTTPTransport: http.RoundTripper over SMUX ---
+
+// smuxHTTPTransport implements http.RoundTripper by sending HTTP requests
+// over SMUX streams. Each request gets its own stream.
+type smuxHTTPTransport struct {
+	session *smux.Session
+}
+
+func (t *smuxHTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	stream, err := t.session.OpenStream()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open SMUX stream for HTTP: %w", err)
+	}
+
+	if err := req.Write(stream); err != nil {
+		stream.Close()
+		return nil, fmt.Errorf("failed to write HTTP request: %w", err)
+	}
+
+	resp, err := http.ReadResponse(bufio.NewReader(stream), req)
+	if err != nil {
+		stream.Close()
+		return nil, fmt.Errorf("failed to read HTTP response: %w", err)
+	}
+
+	// Wrap the response body to close the SMUX stream when the body is closed.
+	resp.Body = &streamBodyCloser{ReadCloser: resp.Body, stream: stream}
+	return resp, nil
+}
+
+// streamBodyCloser wraps a response body and closes the underlying SMUX
+// stream when the body is closed.
+type streamBodyCloser struct {
+	io.ReadCloser
+	stream net.Conn
+}
+
+func (s *streamBodyCloser) Close() error {
+	err := s.ReadCloser.Close()
+	s.stream.Close()
+	return err
+}
+
+// --- pipeConn: net.Conn over subprocess pipes ---
+
+// pipeConn implements net.Conn over a subprocess's stdin/stdout pipes.
+type pipeConn struct {
+	r     io.ReadCloser
+	w     io.WriteCloser
+	cmd   *exec.Cmd       // prevents GC of subprocess
+	stdin io.WriteCloser  // prevents GC of stdin pipe
+}
+
+func (c *pipeConn) Read(p []byte) (int, error)         { return c.r.Read(p) }
+func (c *pipeConn) Write(p []byte) (int, error)        { return c.w.Write(p) }
+func (c *pipeConn) Close() error                       { return nil }
+func (c *pipeConn) LocalAddr() net.Addr                { return pipeAddr{} }
+func (c *pipeConn) RemoteAddr() net.Addr               { return pipeAddr{} }
+func (c *pipeConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *pipeConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *pipeConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+type pipeAddr struct{}
+
+func (pipeAddr) Network() string { return "pipe" }
+func (pipeAddr) String() string  { return "pipe" }

--- a/go/libraries/doltcore/dbfactory/ssh.go
+++ b/go/libraries/doltcore/dbfactory/ssh.go
@@ -84,15 +84,13 @@ func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, 
 	}
 
 	// Read stderr via a pipe so we control when it is fully consumed.
-	// stderrDone is closed once all stderr has been read, giving
-	// downstream error handlers a concrete event to wait on instead of
-	// a racy sleep.
+	// stderrDone channel is closed once all stderr has been read, sending signal that the subcommand has terminated.
+	stderrDone := make(chan struct{})
 	stderrPipe, err := cmd.StderrPipe()
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create stderr pipe: %w", err)
 	}
 	var stderrBuf bytes.Buffer
-	stderrDone := make(chan struct{})
 	go func() {
 		io.Copy(io.MultiWriter(os.Stderr, &stderrBuf), stderrPipe)
 		close(stderrDone)
@@ -106,10 +104,8 @@ func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, 
 
 	// Create SMUX client session over the subprocess pipes.
 	pConn := &pipeConn{
-		r:     stdout,
-		w:     stdin,
-		cmd:   cmd,
-		stdin: stdin,
+		r: stdout,
+		w: stdin,
 	}
 	smuxConfig := smux.DefaultConfig()
 	smuxConfig.MaxReceiveBuffer = remotesrv.MaxGRPCMessageSize
@@ -355,10 +351,8 @@ func (s *streamBodyCloser) Close() error {
 
 // pipeConn implements net.Conn over a subprocess's stdin/stdout pipes.
 type pipeConn struct {
-	r     io.ReadCloser
-	w     io.WriteCloser
-	cmd   *exec.Cmd      // prevents GC of subprocess
-	stdin io.WriteCloser // prevents GC of stdin pipe
+	r io.ReadCloser
+	w io.WriteCloser
 }
 
 func (c *pipeConn) Read(p []byte) (int, error)         { return c.r.Read(p) }

--- a/go/libraries/doltcore/dbfactory/ssh.go
+++ b/go/libraries/doltcore/dbfactory/ssh.go
@@ -170,12 +170,18 @@ func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, 
 }
 
 // buildTransferCommand constructs the exec.Cmd for the transfer subprocess.
-// It runs ssh [user@]host "dolt --data-dir <path> transfer", using DOLT_SSH
-// as the SSH binary if set, otherwise defaulting to "ssh".
+// It runs ssh [user@]host "<dolt> --data-dir <path> transfer", using DOLT_SSH
+// as the SSH binary if set (default "ssh"), and DOLT_SSH_EXEC_PATH as the
+// remote dolt binary path if set (default "dolt").
 func buildTransferCommand(host, path, user string) (*exec.Cmd, error) {
 	sshCommand := os.Getenv("DOLT_SSH")
 	if sshCommand == "" {
 		sshCommand = "ssh"
+	}
+
+	remoteDolt := os.Getenv("DOLT_SSH_EXEC_PATH")
+	if remoteDolt == "" {
+		remoteDolt = "dolt"
 	}
 
 	sshTarget := host
@@ -183,7 +189,7 @@ func buildTransferCommand(host, path, user string) (*exec.Cmd, error) {
 		sshTarget = user + "@" + host
 	}
 
-	remoteCmd := fmt.Sprintf("dolt --data-dir %s transfer", path)
+	remoteCmd := fmt.Sprintf("%s --data-dir %s transfer", remoteDolt, path)
 	sshArgs := strings.Fields(sshCommand)
 	if len(sshArgs) == 0 {
 		return nil, fmt.Errorf("invalid DOLT_SSH command: empty")

--- a/go/libraries/doltcore/dbfactory/ssh.go
+++ b/go/libraries/doltcore/dbfactory/ssh.go
@@ -219,17 +219,29 @@ func filterSSHNoise(s string) string {
 	return strings.Join(lines, "\n")
 }
 
+const (
+	// EnvSSHCommand is the environment variable for the SSH command/script
+	// used to connect to remote hosts. Mirrors git's GIT_SSH_COMMAND.
+	// Supports a full command with arguments (split on whitespace).
+	// Default: "ssh".
+	EnvSSHCommand = "DOLT_SSH_COMMAND"
+
+	// EnvSSHExecPath is the environment variable for the path to the dolt
+	// binary on the remote host. Default: "dolt".
+	EnvSSHExecPath = "DOLT_SSH_EXEC_PATH"
+)
+
 // buildTransferCommand constructs the exec.Cmd for the transfer subprocess.
 // It runs ssh [-p port] [user@]host "<dolt> --data-dir <path> transfer",
-// using DOLT_SSH as the SSH binary if set (default "ssh"), and
+// using DOLT_SSH_COMMAND as the SSH command if set (default "ssh"), and
 // DOLT_SSH_EXEC_PATH as the remote dolt binary path if set (default "dolt").
 func buildTransferCommand(host, port, path, user string) (*exec.Cmd, error) {
-	sshCommand := os.Getenv("DOLT_SSH")
+	sshCommand := os.Getenv(EnvSSHCommand)
 	if sshCommand == "" {
 		sshCommand = "ssh"
 	}
 
-	remoteDolt := os.Getenv("DOLT_SSH_EXEC_PATH")
+	remoteDolt := os.Getenv(EnvSSHExecPath)
 	if remoteDolt == "" {
 		remoteDolt = "dolt"
 	}
@@ -242,7 +254,7 @@ func buildTransferCommand(host, port, path, user string) (*exec.Cmd, error) {
 	remoteCmd := fmt.Sprintf("%s --data-dir %s transfer", remoteDolt, path)
 	sshArgs := strings.Fields(sshCommand)
 	if len(sshArgs) == 0 {
-		return nil, fmt.Errorf("invalid DOLT_SSH command: empty")
+		return nil, fmt.Errorf("invalid %s: empty", EnvSSHCommand)
 	}
 
 	args := append(sshArgs[1:], "-p", port, sshTarget, remoteCmd)

--- a/go/libraries/doltcore/dbfactory/ssh.go
+++ b/go/libraries/doltcore/dbfactory/ssh.go
@@ -77,7 +77,7 @@ func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, 
 		return nil, nil, nil, fmt.Errorf("failed to create stdout pipe: %w", err)
 	}
 
-	cmd.Stderr = io.Discard
+	cmd.Stderr = os.Stderr
 
 	if err := cmd.Start(); err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to start transfer subprocess: %w", err)
@@ -162,21 +162,10 @@ func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, 
 }
 
 // buildTransferCommand constructs the exec.Cmd for the transfer subprocess.
-// For localhost without DOLT_SSH, it runs dolt transfer directly.
-// For remote hosts, it runs ssh [user@]host "dolt --data-dir <path> transfer".
+// It runs ssh [user@]host "dolt --data-dir <path> transfer", using DOLT_SSH
+// as the SSH binary if set, otherwise defaulting to "ssh".
 func buildTransferCommand(host, path, user string) (*exec.Cmd, error) {
 	sshCommand := os.Getenv("DOLT_SSH")
-
-	if host == "localhost" && sshCommand == "" {
-		// Local testing mode: run dolt transfer directly.
-		doltPath, err := os.Executable()
-		if err != nil {
-			doltPath = "dolt"
-		}
-		return exec.Command(doltPath, "--data-dir", path, "transfer"), nil
-	}
-
-	// Real SSH mode.
 	if sshCommand == "" {
 		sshCommand = "ssh"
 	}

--- a/go/libraries/doltcore/dbfactory/ssh.go
+++ b/go/libraries/doltcore/dbfactory/ssh.go
@@ -83,33 +83,26 @@ func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, 
 		return nil, nil, nil, fmt.Errorf("failed to create stdout pipe: %w", err)
 	}
 
-	// Capture stderr so we can include remote errors in failure messages.
+	// Read stderr via a pipe so we control when it is fully consumed.
+	// stderrDone is closed once all stderr has been read, giving
+	// downstream error handlers a concrete event to wait on instead of
+	// a racy sleep.
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create stderr pipe: %w", err)
+	}
 	var stderrBuf bytes.Buffer
-	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
+	stderrDone := make(chan struct{})
+	go func() {
+		io.Copy(io.MultiWriter(os.Stderr, &stderrBuf), stderrPipe)
+		close(stderrDone)
+	}()
 
 	if err := cmd.Start(); err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to start transfer subprocess: %w", err)
 	}
 
-	// Check for early exit (non-blocking).
-	processDone := make(chan error, 1)
-	go func() { processDone <- cmd.Wait() }()
-
-	// Brief pause to detect immediate failures (e.g., bad path, missing dolt).
-	// SSH connection + shell startup can take over 100ms, so we use 500ms.
-	time.Sleep(500 * time.Millisecond)
-	select {
-	case err := <-processDone:
-		errMsg := strings.TrimSpace(stderrBuf.String())
-		if strings.Contains(errMsg, "no such file or directory") || strings.Contains(errMsg, "failed to load database") {
-			return nil, nil, nil, fmt.Errorf("repository not found at %s", path)
-		}
-		if errMsg != "" {
-			return nil, nil, nil, fmt.Errorf("ssh remote error: %s", errMsg)
-		}
-		return nil, nil, nil, fmt.Errorf("transfer subprocess exited immediately: %w", err)
-	default:
-	}
+	procCtx, procCancel := context.WithCancelCause(ctx)
 
 	// Create SMUX client session over the subprocess pipes.
 	pConn := &pipeConn{
@@ -125,8 +118,23 @@ func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, 
 	session, err := smux.Client(pConn, smuxConfig)
 	if err != nil {
 		cmd.Process.Kill()
-		return nil, nil, nil, fmt.Errorf("failed to create SMUX client session: %w", err)
+		procCancel(err)
+		return nil, nil, nil, sshRemoteError(stderrDone, &stderrBuf, path, "failed to create SMUX client session", err)
 	}
+
+	// Monitor the SMUX session in a background goroutine. When the remote
+	// subprocess exits (bad path, missing dolt, SSH failure, etc.), the pipe
+	// gets EOF and SMUX closes the session. This cancels our context so that
+	// gRPC calls unblock immediately instead of hanging forever.
+	//
+	// AcceptStream forces SMUX to actively read the connection. Without it,
+	// SMUX only discovers EOF on the next read/write attempt -- which never
+	// comes while gRPC is stuck in the WaitForReady picker loop.
+	go func() {
+		session.AcceptStream()
+		procCancel(fmt.Errorf("remote process exited"))
+	}()
+
 	// Create a per-connection HTTP client that routes table file requests
 	// through the SMUX session. This is injected into the chunk store via
 	// WithHTTPFetcher so each SSH connection has its own transport.
@@ -145,17 +153,22 @@ func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, 
 	if err != nil {
 		session.Close()
 		cmd.Process.Kill()
-		return nil, nil, nil, fmt.Errorf("failed to create gRPC client: %w", err)
+		procCancel(err)
+		return nil, nil, nil, sshRemoteError(stderrDone, &stderrBuf, path, "failed to create gRPC client", err)
 	}
 
 	// Create chunk store backed by the remote gRPC service.
 	client := remotesapi.NewChunkStoreServiceClient(grpcConn)
-	cs, err := remotestorage.NewDoltChunkStoreFromPath(ctx, nbf, urlObj.Path, path, false, client)
+	cs, err := remotestorage.NewDoltChunkStoreFromPath(procCtx, nbf, urlObj.Path, path, false, client)
 	if err != nil {
+		procCancel(err)
 		grpcConn.Close()
 		session.Close()
-		cmd.Process.Kill()
-		return nil, nil, nil, fmt.Errorf("failed to create chunk store: %w", err)
+		stdin.Close()
+		if cmd.Process != nil {
+			cmd.Process.Kill()
+		}
+		return nil, nil, nil, sshRemoteError(stderrDone, &stderrBuf, path, "failed to create chunk store", err)
 	}
 
 	cs = cs.WithHTTPFetcher(httpClient)
@@ -163,10 +176,11 @@ func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, 
 	// Wrap the chunk store with cleanup so resources are released when the
 	// database is closed.
 	conn := &sshConnection{
-		cmd:      cmd,
-		session:  session,
-		grpcConn: grpcConn,
-		stdin:    stdin,
+		cmd:        cmd,
+		session:    session,
+		grpcConn:   grpcConn,
+		stdin:      stdin,
+		procCancel: procCancel,
 	}
 	wrappedCS := &sshChunkStore{DoltChunkStore: cs, conn: conn}
 
@@ -175,6 +189,38 @@ func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, 
 	db := datas.NewTypesDatabase(vrw, ns)
 
 	return db, vrw, ns, nil
+}
+
+// sshRemoteError builds an error message for SSH remote failures. It waits
+// for the remote's stderr to be fully read (signaled by stderrDone) and
+// uses it to produce a more informative message than the raw gRPC/SMUX error.
+func sshRemoteError(stderrDone <-chan struct{}, stderrBuf *bytes.Buffer, path, msg string, err error) error {
+	<-stderrDone
+	errMsg := filterSSHNoise(stderrBuf.String())
+	if errMsg != "" {
+		if strings.Contains(errMsg, "no such file or directory") || strings.Contains(errMsg, "failed to load database") {
+			return fmt.Errorf("repository not found at %s", path)
+		}
+		return fmt.Errorf("%s: remote: %s", msg, errMsg)
+	}
+	return fmt.Errorf("%s: %w", msg, err)
+}
+
+// filterSSHNoise removes common SSH informational messages from stderr output
+// so they are not mistaken for real errors.
+func filterSSHNoise(s string) string {
+	var lines []string
+	for _, line := range strings.Split(s, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "Warning: Permanently added") {
+			continue
+		}
+		lines = append(lines, trimmed)
+	}
+	return strings.Join(lines, "\n")
 }
 
 // buildTransferCommand constructs the exec.Cmd for the transfer subprocess.
@@ -215,15 +261,19 @@ func buildTransferCommand(host, port, path, user string) (*exec.Cmd, error) {
 // sshConnection holds all resources for an SSH transfer connection and
 // implements coordinated cleanup.
 type sshConnection struct {
-	cmd      *exec.Cmd
-	session  *smux.Session
-	grpcConn *grpc.ClientConn
-	stdin    io.WriteCloser
+	cmd        *exec.Cmd
+	session    *smux.Session
+	grpcConn   *grpc.ClientConn
+	stdin      io.WriteCloser
+	procCancel context.CancelCauseFunc
 }
 
 // Close releases all resources: unregisters the custom transport, closes
 // the SMUX session, gRPC connection, and kills the subprocess.
 func (c *sshConnection) Close() error {
+	if c.procCancel != nil {
+		c.procCancel(fmt.Errorf("connection closed"))
+	}
 	if c.session != nil {
 		c.session.Close()
 	}
@@ -307,8 +357,8 @@ func (s *streamBodyCloser) Close() error {
 type pipeConn struct {
 	r     io.ReadCloser
 	w     io.WriteCloser
-	cmd   *exec.Cmd       // prevents GC of subprocess
-	stdin io.WriteCloser  // prevents GC of stdin pipe
+	cmd   *exec.Cmd      // prevents GC of subprocess
+	stdin io.WriteCloser // prevents GC of stdin pipe
 }
 
 func (c *pipeConn) Read(p []byte) (int, error)         { return c.r.Read(p) }

--- a/go/libraries/doltcore/dbfactory/ssh.go
+++ b/go/libraries/doltcore/dbfactory/ssh.go
@@ -52,21 +52,7 @@ func (SSHRemoteFactory) PrepareDB(ctx context.Context, nbf *types.NomsBinFormat,
 // (either SSH or dolt transfer directly for localhost) and multiplexes gRPC
 // and HTTP over the subprocess's stdin/stdout using SMUX.
 func (SSHRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, urlObj *url.URL, params map[string]interface{}) (datas.Database, types.ValueReadWriter, tree.NodeStore, error) {
-	host := urlObj.Hostname()
-	port := urlObj.Port()
-	path := urlObj.Path
-	user := ""
-
-	path = strings.TrimSuffix(path, "/")
-	path = strings.TrimSuffix(path, "/.dolt")
-
-	if urlObj.User != nil {
-		user = urlObj.User.Username()
-	}
-	if atIdx := strings.LastIndex(host, "@"); atIdx != -1 {
-		user = host[:atIdx]
-		host = host[atIdx+1:]
-	}
+	host, port, path, user := parseSSHURL(urlObj)
 
 	cmd, err := buildTransferCommand(host, port, path, user)
 	if err != nil {
@@ -231,6 +217,25 @@ const (
 	// binary on the remote host. Default: "dolt".
 	EnvSSHExecPath = "DOLT_SSH_EXEC_PATH"
 )
+
+// parseSSHURL extracts host, port, path, and user from an SSH remote URL.
+// It strips trailing "/" and "/.dolt" from the path, and handles user info
+// from both the standard URL userinfo and user@host formats.
+func parseSSHURL(urlObj *url.URL) (host, port, path, user string) {
+	host = urlObj.Hostname()
+	port = urlObj.Port()
+	path = urlObj.Path
+	path = strings.TrimSuffix(path, "/")
+	path = strings.TrimSuffix(path, "/.dolt")
+	if urlObj.User != nil {
+		user = urlObj.User.Username()
+	}
+	if atIdx := strings.LastIndex(host, "@"); atIdx != -1 {
+		user = host[:atIdx]
+		host = host[atIdx+1:]
+	}
+	return
+}
 
 // buildTransferCommand constructs the exec.Cmd for the transfer subprocess.
 // It runs ssh [-p port] [user@]host "<dolt> --data-dir <path> transfer",

--- a/go/libraries/doltcore/dbfactory/ssh_test.go
+++ b/go/libraries/doltcore/dbfactory/ssh_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -293,6 +292,12 @@ func TestSSHURLParsing(t *testing.T) {
 			wantUser: "neil",
 		},
 		{
+			name:     "trailing slash stripped",
+			url:      "ssh://myhost/data/repo/",
+			wantHost: "myhost",
+			wantPath: "/data/repo",
+		},
+		{
 			name:     ".dolt suffix stripped",
 			url:      "ssh://myhost/data/repo/.dolt",
 			wantHost: "myhost",
@@ -315,48 +320,14 @@ func TestSSHURLParsing(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Replicate the URL parsing from CreateDB.
-			urlObj, err := parseSSHURL(tt.url)
+			urlObj, err := url.Parse(tt.url)
 			require.NoError(t, err)
 
-			assert.Equal(t, tt.wantHost, urlObj.host, "host")
-			assert.Equal(t, tt.wantPort, urlObj.port, "port")
-			assert.Equal(t, tt.wantPath, urlObj.path, "path")
-			assert.Equal(t, tt.wantUser, urlObj.user, "user")
+			host, port, path, user := parseSSHURL(urlObj)
+			assert.Equal(t, tt.wantHost, host, "host")
+			assert.Equal(t, tt.wantPort, port, "port")
+			assert.Equal(t, tt.wantPath, path, "path")
+			assert.Equal(t, tt.wantUser, user, "user")
 		})
 	}
-}
-
-// sshURLParts holds the parsed components of an SSH URL.
-// This is a test helper that mirrors the parsing logic in CreateDB.
-type sshURLParts struct {
-	host string
-	port string
-	path string
-	user string
-}
-
-// parseSSHURL replicates the URL parsing logic from SSHRemoteFactory.CreateDB.
-func parseSSHURL(rawURL string) (sshURLParts, error) {
-	urlObj, err := url.Parse(rawURL)
-	if err != nil {
-		return sshURLParts{}, err
-	}
-
-	host := urlObj.Hostname()
-	port := urlObj.Port()
-	path := urlObj.Path
-	user := ""
-
-	path = strings.TrimSuffix(path, "/.dolt")
-
-	if urlObj.User != nil {
-		user = urlObj.User.Username()
-	}
-	if atIdx := strings.LastIndex(host, "@"); atIdx != -1 {
-		user = host[:atIdx]
-		host = host[atIdx+1:]
-	}
-
-	return sshURLParts{host: host, port: port, path: path, user: user}, nil
 }

--- a/go/libraries/doltcore/dbfactory/ssh_test.go
+++ b/go/libraries/doltcore/dbfactory/ssh_test.go
@@ -1,0 +1,362 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dbfactory
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildTransferCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		port     string
+		path     string
+		user     string
+		envSSH   string
+		envExec  string
+		wantArgs []string
+		wantErr  string
+	}{
+		{
+			name:     "basic host and path",
+			host:     "example.com",
+			path:     "/data/myrepo",
+			wantArgs: []string{"ssh", "example.com", "dolt --data-dir /data/myrepo transfer"},
+		},
+		{
+			name:     "with user",
+			host:     "example.com",
+			path:     "/data/myrepo",
+			user:     "neil",
+			wantArgs: []string{"ssh", "neil@example.com", "dolt --data-dir /data/myrepo transfer"},
+		},
+		{
+			name:     "with port",
+			host:     "example.com",
+			port:     "2222",
+			path:     "/data/myrepo",
+			wantArgs: []string{"ssh", "-p", "2222", "example.com", "dolt --data-dir /data/myrepo transfer"},
+		},
+		{
+			name:     "with user and port",
+			host:     "example.com",
+			port:     "2222",
+			path:     "/data/myrepo",
+			user:     "neil",
+			wantArgs: []string{"ssh", "-p", "2222", "neil@example.com", "dolt --data-dir /data/myrepo transfer"},
+		},
+		{
+			name:     "custom SSH command",
+			host:     "example.com",
+			path:     "/data/myrepo",
+			envSSH:   "/usr/bin/my-ssh",
+			wantArgs: []string{"/usr/bin/my-ssh", "example.com", "dolt --data-dir /data/myrepo transfer"},
+		},
+		{
+			name:     "SSH command with arguments",
+			host:     "example.com",
+			path:     "/data/myrepo",
+			envSSH:   "ssh -i /path/to/key -o StrictHostKeyChecking=no",
+			wantArgs: []string{"ssh", "-i", "/path/to/key", "-o", "StrictHostKeyChecking=no", "example.com", "dolt --data-dir /data/myrepo transfer"},
+		},
+		{
+			name:     "custom remote dolt path",
+			host:     "example.com",
+			path:     "/data/myrepo",
+			envExec:  "/usr/local/bin/dolt",
+			wantArgs: []string{"ssh", "example.com", "/usr/local/bin/dolt --data-dir /data/myrepo transfer"},
+		},
+		{
+			name:     "custom SSH and remote dolt",
+			host:     "example.com",
+			path:     "/data/myrepo",
+			user:     "ubuntu",
+			envSSH:   "/path/to/wrapper.sh",
+			envExec:  "/opt/dolt/bin/dolt",
+			wantArgs: []string{"/path/to/wrapper.sh", "ubuntu@example.com", "/opt/dolt/bin/dolt --data-dir /data/myrepo transfer"},
+		},
+		{
+			name:    "empty SSH command errors",
+			host:    "example.com",
+			path:    "/data/myrepo",
+			envSSH:  "   ",
+			wantErr: "invalid DOLT_SSH_COMMAND: empty",
+		},
+		{
+			name:     "EC2 instance ID as host",
+			host:     "i-0abc123def456",
+			path:     "/home/ubuntu/mydb",
+			envSSH:   "/path/to/ssm-wrapper.sh",
+			wantArgs: []string{"/path/to/ssm-wrapper.sh", "i-0abc123def456", "dolt --data-dir /home/ubuntu/mydb transfer"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envSSH != "" {
+				t.Setenv(EnvSSHCommand, tt.envSSH)
+			}
+			if tt.envExec != "" {
+				t.Setenv(EnvSSHExecPath, tt.envExec)
+			}
+
+			cmd, err := buildTransferCommand(tt.host, tt.port, tt.path, tt.user)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+
+			// cmd.Args includes argv[0] (the program) followed by the arguments.
+			assert.Equal(t, tt.wantArgs, cmd.Args)
+		})
+	}
+}
+
+func TestFilterSSHNoise(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "only whitespace",
+			input: "   \n\n   \n",
+			want:  "",
+		},
+		{
+			name:  "permanently added warning removed",
+			input: "Warning: Permanently added '[127.0.0.1]:2222' (ED25519) to the list of known hosts.\nactual error\n",
+			want:  "actual error",
+		},
+		{
+			name:  "multiple warnings removed",
+			input: "Warning: Permanently added 'host1' (RSA) to the list of known hosts.\nWarning: Permanently added 'host2' (ED25519) to the list of known hosts.\nreal error here\n",
+			want:  "real error here",
+		},
+		{
+			name:  "only warnings produces empty result",
+			input: "Warning: Permanently added 'host' (ED25519) to the list of known hosts.\n",
+			want:  "",
+		},
+		{
+			name:  "real errors preserved",
+			input: "failed to load database\ncause: missing dolt data directory\n",
+			want:  "failed to load database\ncause: missing dolt data directory",
+		},
+		{
+			name:  "mixed warnings and errors",
+			input: "Warning: Permanently added 'host' (ED25519) to the list of known hosts.\nfailed to load database\n\ncause: missing dolt data directory\n",
+			want:  "failed to load database\ncause: missing dolt data directory",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterSSHNoise(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSSHRemoteError(t *testing.T) {
+	tests := []struct {
+		name      string
+		stderr    string
+		path      string
+		msg       string
+		err       error
+		wantMsg   string
+		wantExact bool
+	}{
+		{
+			name:    "no stderr falls back to wrapped error",
+			stderr:  "",
+			path:    "/data/myrepo",
+			msg:     "failed to create chunk store",
+			err:     fmt.Errorf("connection refused"),
+			wantMsg: "failed to create chunk store: connection refused",
+		},
+		{
+			name:    "only SSH warnings falls back to wrapped error",
+			stderr:  "Warning: Permanently added 'host' (ED25519) to the list of known hosts.\n",
+			path:    "/data/myrepo",
+			msg:     "failed to create chunk store",
+			err:     fmt.Errorf("EOF"),
+			wantMsg: "failed to create chunk store: EOF",
+		},
+		{
+			name:    "missing dolt data directory gives repo not found",
+			stderr:  "Warning: Permanently added 'host' (ED25519) to the list of known hosts.\nfailed to load database\ncause: missing dolt data directory\n",
+			path:    "/data/myrepo",
+			msg:     "failed to create SMUX client session",
+			err:     fmt.Errorf("EOF"),
+			wantMsg: "repository not found at /data/myrepo",
+		},
+		{
+			name:    "no such file or directory gives repo not found",
+			stderr:  "stat /nonexistent/path: no such file or directory\n",
+			path:    "/nonexistent/path",
+			msg:     "failed to create chunk store",
+			err:     fmt.Errorf("EOF"),
+			wantMsg: "repository not found at /nonexistent/path",
+		},
+		{
+			name:    "other stderr error forwarded",
+			stderr:  "dolt: command not found\n",
+			path:    "/data/myrepo",
+			msg:     "failed to create SMUX client session",
+			err:     fmt.Errorf("EOF"),
+			wantMsg: "failed to create SMUX client session: remote: dolt: command not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stderrDone := make(chan struct{})
+			var stderrBuf bytes.Buffer
+			stderrBuf.WriteString(tt.stderr)
+			close(stderrDone)
+
+			got := sshRemoteError(stderrDone, &stderrBuf, tt.path, tt.msg, tt.err)
+			assert.Equal(t, tt.wantMsg, got.Error())
+		})
+	}
+}
+
+func TestSSHURLParsing(t *testing.T) {
+	// Test the URL parsing logic from CreateDB by checking the arguments
+	// that buildTransferCommand would receive for various SSH URLs.
+	// This mirrors how CreateDB extracts host, port, path, and user.
+	tests := []struct {
+		name     string
+		url      string
+		wantHost string
+		wantPort string
+		wantPath string
+		wantUser string
+	}{
+		{
+			name:     "simple host and path",
+			url:      "ssh://myhost/data/repo",
+			wantHost: "myhost",
+			wantPath: "/data/repo",
+		},
+		{
+			name:     "user in URL userinfo",
+			url:      "ssh://neil@myhost/data/repo",
+			wantHost: "myhost",
+			wantPath: "/data/repo",
+			wantUser: "neil",
+		},
+		{
+			name:     "port in URL",
+			url:      "ssh://myhost:2222/data/repo",
+			wantHost: "myhost",
+			wantPort: "2222",
+			wantPath: "/data/repo",
+		},
+		{
+			name:     "user and port",
+			url:      "ssh://neil@myhost:2222/data/repo",
+			wantHost: "myhost",
+			wantPort: "2222",
+			wantPath: "/data/repo",
+			wantUser: "neil",
+		},
+		{
+			name:     ".dolt suffix stripped",
+			url:      "ssh://myhost/data/repo/.dolt",
+			wantHost: "myhost",
+			wantPath: "/data/repo",
+		},
+		{
+			name:     "EC2 instance ID as host",
+			url:      "ssh://i-0abc123def456/home/ubuntu/mydb",
+			wantHost: "i-0abc123def456",
+			wantPath: "/home/ubuntu/mydb",
+		},
+		{
+			name:     "user with EC2 instance ID",
+			url:      "ssh://ubuntu@i-0abc123def456/home/ubuntu/mydb",
+			wantHost: "i-0abc123def456",
+			wantPath: "/home/ubuntu/mydb",
+			wantUser: "ubuntu",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Replicate the URL parsing from CreateDB.
+			urlObj, err := parseSSHURL(tt.url)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantHost, urlObj.host, "host")
+			assert.Equal(t, tt.wantPort, urlObj.port, "port")
+			assert.Equal(t, tt.wantPath, urlObj.path, "path")
+			assert.Equal(t, tt.wantUser, urlObj.user, "user")
+		})
+	}
+}
+
+// sshURLParts holds the parsed components of an SSH URL.
+// This is a test helper that mirrors the parsing logic in CreateDB.
+type sshURLParts struct {
+	host string
+	port string
+	path string
+	user string
+}
+
+// parseSSHURL replicates the URL parsing logic from SSHRemoteFactory.CreateDB.
+func parseSSHURL(rawURL string) (sshURLParts, error) {
+	urlObj, err := url.Parse(rawURL)
+	if err != nil {
+		return sshURLParts{}, err
+	}
+
+	host := urlObj.Hostname()
+	port := urlObj.Port()
+	path := urlObj.Path
+	user := ""
+
+	path = strings.TrimSuffix(path, "/.dolt")
+
+	if urlObj.User != nil {
+		user = urlObj.User.Username()
+	}
+	if atIdx := strings.LastIndex(host, "@"); atIdx != -1 {
+		user = host[:atIdx]
+		host = host[atIdx+1:]
+	}
+
+	return sshURLParts{host: host, port: port, path: path, user: user}, nil
+}

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -165,9 +165,10 @@ func (ddb *DoltDB) GetDatabaseName() string {
 	return ddb.databaseName
 }
 
-// HackDatasDatabaseFromDoltDB unwraps a DoltDB to a datas.Database.
-// Deprecated: only for use in dolt migrate.
-func HackDatasDatabaseFromDoltDB(ddb *DoltDB) datas.Database {
+// ExposeDatabaseFromDoltDB unwraps a DoltDB to a datas.Database.
+// This method should really only be used in cases where we need to get to the internals of the database, such
+// as scanning for corruption or migrating data formats. Generally avoid this function.
+func ExposeDatabaseFromDoltDB(ddb *DoltDB) datas.Database {
 	return ddb.db
 }
 

--- a/go/libraries/doltcore/env/grpc_dial_provider.go
+++ b/go/libraries/doltcore/env/grpc_dial_provider.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/creds"
 	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
+	"github.com/dolthub/dolt/go/libraries/doltcore/remotesrv"
 	"github.com/dolthub/dolt/go/libraries/doltcore/dconfig"
 	"github.com/dolthub/dolt/go/libraries/doltcore/grpcendpoint"
 )
@@ -117,7 +118,7 @@ func (p GRPCDialProvider) GetGRPCDialParams(config grpcendpoint.Config) (dbfacto
 		opts = append(opts, grpc.WithTransportCredentials(tc))
 	}
 
-	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(128*1024*1024)))
+	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(remotesrv.MaxGRPCMessageSize)))
 	opts = append(opts, grpc.WithUserAgent(p.getUserAgentString()))
 
 	if config.Creds != nil {

--- a/go/libraries/doltcore/env/grpc_dial_provider.go
+++ b/go/libraries/doltcore/env/grpc_dial_provider.go
@@ -32,9 +32,9 @@ import (
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/creds"
 	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
-	"github.com/dolthub/dolt/go/libraries/doltcore/remotesrv"
 	"github.com/dolthub/dolt/go/libraries/doltcore/dconfig"
 	"github.com/dolthub/dolt/go/libraries/doltcore/grpcendpoint"
+	"github.com/dolthub/dolt/go/libraries/doltcore/remotesrv"
 )
 
 var defaultDialer = &net.Dialer{

--- a/go/libraries/doltcore/remotesrv/http.go
+++ b/go/libraries/doltcore/remotesrv/http.go
@@ -45,22 +45,33 @@ var (
 )
 
 type filehandler struct {
-	dbCache  DBCache
-	fs       filesys.Filesys
-	readOnly bool
-	lgr      *logrus.Entry
-	sealer   Sealer
+	dbCache       DBCache
+	fs            filesys.Filesys
+	readOnly      bool
+	lgr           *logrus.Entry
+	sealer        Sealer
+	writeErrBody  bool
+}
+
+// NewFileHandler returns an http.Handler that serves table file downloads
+// and uploads backed by the given DBCache and filesystem. When writeErrBody
+// is true, upload errors are written to the response body so clients can
+// surface descriptive error messages (used by the SSH transfer path).
+func NewFileHandler(lgr *logrus.Entry, dbCache DBCache, fs filesys.Filesys, readOnly bool, sealer Sealer, writeErrBody bool) http.Handler {
+	fh := newFileHandler(lgr, dbCache, fs, readOnly, sealer)
+	fh.writeErrBody = writeErrBody
+	return fh
 }
 
 func newFileHandler(lgr *logrus.Entry, dbCache DBCache, fs filesys.Filesys, readOnly bool, sealer Sealer) filehandler {
 	return filehandler{
-		dbCache,
-		fs,
-		readOnly,
-		lgr.WithFields(logrus.Fields{
+		dbCache:  dbCache,
+		fs:       fs,
+		readOnly: readOnly,
+		lgr: lgr.WithFields(logrus.Fields{
 			"service": "dolt.services.remotesapi.v1alpha1.HttpFileServer",
 		}),
-		sealer,
+		sealer: sealer,
 	}
 }
 
@@ -188,7 +199,12 @@ func (fh filehandler) ServeHTTP(respWr http.ResponseWriter, req *http.Request) {
 			}
 		}
 
-		logger, statusCode = writeTableFile(req.Context(), logger, fh.dbCache, filepath, file, splitOffset, numChunks, contentHash, uint64(contentLength), req.Body)
+		var writeErr error
+		logger, statusCode, writeErr = writeTableFile(req.Context(), logger, fh.dbCache, filepath, file, splitOffset, numChunks, contentHash, uint64(contentLength), req.Body)
+		if writeErr != nil && fh.writeErrBody {
+			http.Error(respWr, writeErr.Error(), statusCode)
+			return
+		}
 	}
 
 	if statusCode != -1 {
@@ -298,18 +314,18 @@ func (u *uploadreader) Close() error {
 	return nil
 }
 
-func writeTableFile(ctx context.Context, logger *logrus.Entry, dbCache DBCache, path, fileId string, splitOffset uint64, numChunks int, contentHash []byte, contentLength uint64, body io.ReadCloser) (*logrus.Entry, int) {
+func writeTableFile(ctx context.Context, logger *logrus.Entry, dbCache DBCache, path, fileId string, splitOffset uint64, numChunks int, contentHash []byte, contentLength uint64, body io.ReadCloser) (*logrus.Entry, int, error) {
 	if !validateFileName(fileId) {
 		logger = logger.WithField("status", http.StatusBadRequest)
 		logger.Warnf("%s is not a valid hash", fileId)
-		return logger, http.StatusBadRequest
+		return logger, http.StatusBadRequest, fmt.Errorf("%s is not a valid hash", fileId)
 	}
 
 	cs, err := dbCache.Get(ctx, path, types.Format_Default.VersionString())
 	if err != nil {
 		logger = logger.WithField("status", http.StatusInternalServerError)
 		logger.WithError(err).Error("failed to get repository")
-		return logger, http.StatusInternalServerError
+		return logger, http.StatusInternalServerError, err
 	}
 
 	err = cs.WriteTableFile(ctx, fileId, splitOffset, numChunks, contentHash, func() (io.ReadCloser, uint64, error) {
@@ -328,19 +344,19 @@ func writeTableFile(ctx context.Context, logger *logrus.Entry, dbCache DBCache, 
 		if errors.Is(err, errBodyLengthTFDMismatch) {
 			logger = logger.WithField("status", http.StatusBadRequest)
 			logger.Warn("bad request: body length mismatch")
-			return logger, http.StatusBadRequest
+			return logger, http.StatusBadRequest, err
 		}
 		if errors.Is(err, errBodyHashTFDMismatch) {
 			logger = logger.WithField("status", http.StatusBadRequest)
 			logger.Warn("bad request: body hash mismatch")
-			return logger, http.StatusBadRequest
+			return logger, http.StatusBadRequest, err
 		}
 		logger = logger.WithField("status", http.StatusInternalServerError)
 		logger.WithError(err).Error("failed to write upload to table file")
-		return logger, http.StatusInternalServerError
+		return logger, http.StatusInternalServerError, err
 	}
 
-	return logger, http.StatusOK
+	return logger, http.StatusOK, nil
 }
 
 func offsetAndLenFromRange(rngStr string) (int64, int64, string, error) {

--- a/go/libraries/doltcore/remotesrv/http.go
+++ b/go/libraries/doltcore/remotesrv/http.go
@@ -45,12 +45,12 @@ var (
 )
 
 type filehandler struct {
-	dbCache       DBCache
-	fs            filesys.Filesys
-	readOnly      bool
-	lgr           *logrus.Entry
-	sealer        Sealer
-	writeErrBody  bool
+	dbCache      DBCache
+	fs           filesys.Filesys
+	readOnly     bool
+	lgr          *logrus.Entry
+	sealer       Sealer
+	writeErrBody bool
 }
 
 // NewFileHandler returns an http.Handler that serves table file downloads

--- a/go/libraries/doltcore/remotesrv/server.go
+++ b/go/libraries/doltcore/remotesrv/server.go
@@ -31,6 +31,10 @@ import (
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 )
 
+// MaxGRPCMessageSize is the maximum gRPC message size used for chunk store
+// operations. This applies to both send and receive directions.
+const MaxGRPCMessageSize = 128 * 1024 * 1024
+
 type Server struct {
 	wg       sync.WaitGroup
 	stopChan chan struct{}
@@ -94,7 +98,7 @@ func NewServer(args ServerArgs) (*Server, error) {
 
 	s.wg.Add(2)
 	s.grpcListenAddr = args.GrpcListenAddr
-	s.grpcSrv = grpc.NewServer(append([]grpc.ServerOption{grpc.MaxRecvMsgSize(128 * 1024 * 1024)}, args.Options...)...)
+	s.grpcSrv = grpc.NewServer(append([]grpc.ServerOption{grpc.MaxRecvMsgSize(MaxGRPCMessageSize)}, args.Options...)...)
 	var chnkSt remotesapi.ChunkStoreServiceServer = NewHttpFSBackedChunkStore(args.Logger, args.HttpHost, args.DBCache, args.FS, scheme, args.ConcurrencyControl, sealer)
 
 	if args.ReadOnly {

--- a/go/libraries/doltcore/remotestorage/chunk_store.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store.go
@@ -135,7 +135,13 @@ type DoltChunkStore struct {
 	wsValidate  bool
 }
 
-func NewDoltChunkStoreFromPath(ctx context.Context, nbf *types.NomsBinFormat, path, host string, wsval bool, csClient remotesapi.ChunkStoreServiceClient) (*DoltChunkStore, error) {
+func NewDoltChunkStoreFromPath(
+	ctx context.Context,
+	nbf *types.NomsBinFormat,
+	path, host string,
+	wsval bool,
+	csClient remotesapi.ChunkStoreServiceClient,
+) (*DoltChunkStore, error) {
 	var repoId *remotesapi.RepoId
 
 	path = strings.Trim(path, "/")

--- a/go/libraries/doltcore/sqle/cluster/commithook.go
+++ b/go/libraries/doltcore/sqle/cluster/commithook.go
@@ -153,7 +153,7 @@ func (h *commithook) replicate(ctx context.Context) {
 				defer sql.SessionCommandEnd(sqlCtx.Session)
 
 				// When the replicate thread comes up, it attempts to replicate the current head.
-				datasDB := doltdb.HackDatasDatabaseFromDoltDB(h.srcDB)
+				datasDB := doltdb.ExposeDatabaseFromDoltDB(h.srcDB)
 				cs := datas.ChunkStoreFromDatabase(datasDB)
 				h.nextHead, err = cs.Root(sqlCtx)
 				if err != nil {
@@ -269,7 +269,7 @@ func (h *commithook) attemptHeartbeat(ctx context.Context) {
 	// sql Session lifecycle events are for
 	// accessing srcDB, not destDB.
 	h.mu.Unlock()
-	datasDB := doltdb.HackDatasDatabaseFromDoltDB(destDB)
+	datasDB := doltdb.ExposeDatabaseFromDoltDB(destDB)
 	cs := datas.ChunkStoreFromDatabase(datasDB)
 	cs.Commit(ctx, head, head)
 	h.mu.Lock()
@@ -336,7 +336,7 @@ func (h *commithook) attemptReplicate(ctx context.Context) {
 	err = destDB.PullChunks(sqlCtx, h.tempDir, h.srcDB, []hash.Hash{toPush}, nil, nil)
 	if err == nil {
 		lgr.Tracef("cluster/commithook: successfully pushed chunks, setting root")
-		datasDB := doltdb.HackDatasDatabaseFromDoltDB(destDB)
+		datasDB := doltdb.ExposeDatabaseFromDoltDB(destDB)
 		cs := datas.ChunkStoreFromDatabase(datasDB)
 		var curRootHash hash.Hash
 		if err = cs.Rebase(sqlCtx); err == nil {

--- a/go/libraries/doltcore/sqle/commit_hooks.go
+++ b/go/libraries/doltcore/sqle/commit_hooks.go
@@ -72,7 +72,7 @@ func pushDataset(ctx context.Context, destDB, srcDB *doltdb.DoltDB, ds datas.Dat
 	addr, ok := ds.MaybeHeadAddr()
 	if !ok {
 		// TODO: fix up hack usage.
-		_, err := doltdb.HackDatasDatabaseFromDoltDB(destDB).Delete(ctx, ds, "")
+		_, err := doltdb.ExposeDatabaseFromDoltDB(destDB).Delete(ctx, ds, "")
 		return err
 	}
 

--- a/go/libraries/doltcore/sqle/commit_hooks_test.go
+++ b/go/libraries/doltcore/sqle/commit_hooks_test.go
@@ -141,7 +141,7 @@ func TestPushOnWriteHook(t *testing.T) {
 		srcCommit, err := ddb.Commit(context.Background(), valHash, ref.NewBranchRef(defaultBranch), meta)
 		require.NoError(t, err)
 
-		ds, err := doltdb.HackDatasDatabaseFromDoltDB(ddb).GetDataset(ctx, "refs/heads/main")
+		ds, err := doltdb.ExposeDatabaseFromDoltDB(ddb).GetDataset(ctx, "refs/heads/main")
 		require.NoError(t, err)
 
 		_, err = hook.Execute(ctx, ds, ddb)
@@ -268,7 +268,7 @@ func TestAsyncPushOnWrite(t *testing.T) {
 
 			_, err = ddb.Commit(context.Background(), valHash, ref.NewBranchRef(defaultBranch), meta)
 			require.NoError(t, err)
-			ds, err := doltdb.HackDatasDatabaseFromDoltDB(ddb).GetDataset(ctx, "refs/heads/main")
+			ds, err := doltdb.ExposeDatabaseFromDoltDB(ddb).GetDataset(ctx, "refs/heads/main")
 			require.NoError(t, err)
 			_, err = hook.Execute(ctx, ds, ddb)
 			require.NoError(t, err)
@@ -297,13 +297,13 @@ func TestAsyncPushOnWrite(t *testing.T) {
 		})
 
 		// Pretend we replicate a HEAD which does exist.
-		ds, err := doltdb.HackDatasDatabaseFromDoltDB(ddb).GetDataset(ctx, "refs/heads/main")
+		ds, err := doltdb.ExposeDatabaseFromDoltDB(ddb).GetDataset(ctx, "refs/heads/main")
 		require.NoError(t, err)
 		_, err = hook.Execute(ctx, ds, ddb)
 		require.NoError(t, err)
 
 		// Pretend we replicate a HEAD which does not exist, i.e., a branch delete.
-		ds, err = doltdb.HackDatasDatabaseFromDoltDB(ddb).GetDataset(ctx, "refs/heads/does_not_exist")
+		ds, err = doltdb.ExposeDatabaseFromDoltDB(ddb).GetDataset(ctx, "refs/heads/does_not_exist")
 		require.NoError(t, err)
 		_, err = hook.Execute(ctx, ds, ddb)
 		require.NoError(t, err)

--- a/go/libraries/doltcore/sqle/database_provider_test.go
+++ b/go/libraries/doltcore/sqle/database_provider_test.go
@@ -82,7 +82,7 @@ func TestDatabaseProvider(t *testing.T) {
 				require.NoError(t, err)
 				ddbs := sqlDb.(Database).DoltDatabases()
 				require.Len(t, ddbs, 1)
-				hooks := doltdb.HackDatasDatabaseFromDoltDB(ddbs[0]).(interface {
+				hooks := doltdb.ExposeDatabaseFromDoltDB(ddbs[0]).(interface {
 					PostCommitHooks() []doltdb.CommitHook
 				}).PostCommitHooks()
 				assert.Len(t, hooks, 1)
@@ -101,7 +101,7 @@ func TestDatabaseProvider(t *testing.T) {
 				require.NoError(t, err)
 				ddbs := sqlDb.(Database).DoltDatabases()
 				require.Len(t, ddbs, 1)
-				hooks := doltdb.HackDatasDatabaseFromDoltDB(ddbs[0]).(interface {
+				hooks := doltdb.ExposeDatabaseFromDoltDB(ddbs[0]).(interface {
 					PostCommitHooks() []doltdb.CommitHook
 				}).PostCommitHooks()
 				require.Len(t, hooks, 2)
@@ -124,7 +124,7 @@ func TestDatabaseProvider(t *testing.T) {
 				require.NoError(t, err)
 				ddbs := sqlDb.(Database).DoltDatabases()
 				require.Len(t, ddbs, 1)
-				hooks := doltdb.HackDatasDatabaseFromDoltDB(ddbs[0]).(interface {
+				hooks := doltdb.ExposeDatabaseFromDoltDB(ddbs[0]).(interface {
 					PostCommitHooks() []doltdb.CommitHook
 				}).PostCommitHooks()
 				require.Len(t, hooks, 2)

--- a/go/libraries/doltcore/sqle/remotesrv.go
+++ b/go/libraries/doltcore/sqle/remotesrv.go
@@ -61,7 +61,7 @@ func (s remotesrvStore) Get(ctx context.Context, path, _ string) (remotesrv.Remo
 	if !ok {
 		return nil, remotesrv.ErrUnimplemented
 	}
-	datasdb := doltdb.HackDatasDatabaseFromDoltDB(sdb.DbData().Ddb)
+	datasdb := doltdb.ExposeDatabaseFromDoltDB(sdb.DbData().Ddb)
 	cs := datas.ChunkStoreFromDatabase(datasdb)
 	rss, ok := cs.(remotesrv.RemoteSrvStore)
 	if !ok {

--- a/go/utils/remotesrv/main.go
+++ b/go/utils/remotesrv/main.go
@@ -83,7 +83,7 @@ func main() {
 		if !dEnv.Valid() {
 			log.Fatalln("repo-mode failed to load repository")
 		}
-		db := doltdb.HackDatasDatabaseFromDoltDB(dEnv.DoltDB(ctx))
+		db := doltdb.ExposeDatabaseFromDoltDB(dEnv.DoltDB(ctx))
 		cs := datas.ChunkStoreFromDatabase(db)
 		dbCache = SingletonCSCache{cs.(remotesrv.RemoteSrvStore)}
 	} else {

--- a/integration-tests/bats/ssh-transfer.bats
+++ b/integration-tests/bats/ssh-transfer.bats
@@ -100,6 +100,26 @@ teardown() {
     [[ "$output" =~ "2" ]]
 }
 
+@test "ssh-transfer: clone with .dolt suffix in URL path" {
+    mkdir "repo_dotsuffix"
+    cd "repo_dotsuffix"
+    dolt init
+    dolt sql -q "CREATE TABLE test (id INT PRIMARY KEY);"
+    dolt sql -q "INSERT INTO test VALUES (1), (2), (3);"
+    dolt add .
+    dolt commit -m "test data"
+
+    cd ..
+    run dolt clone "ssh://localhost$BATS_TEST_TMPDIR/repo_dotsuffix/.dolt" repo_dotsuffix_clone
+    [ "$status" -eq 0 ]
+    [ -d repo_dotsuffix_clone ]
+
+    cd repo_dotsuffix_clone
+    run dolt sql -q "SELECT COUNT(*) FROM test;" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "3" ]]
+}
+
 @test "ssh-transfer: clone with user@host format" {
     mkdir "repo_usertest"
     cd "repo_usertest"

--- a/integration-tests/bats/ssh-transfer.bats
+++ b/integration-tests/bats/ssh-transfer.bats
@@ -1,0 +1,284 @@
+#!/usr/bin/env bats
+load $BATS_TEST_DIRNAME/helper/common.bash
+
+# Tests for SSH transfer operations (clone, pull, push via SSH URLs)
+# Uses mock SSH to avoid requiring an SSH server
+
+setup() {
+    cd "$BATS_TEST_TMPDIR"
+    
+    # Create mock SSH script
+    cat > "$BATS_TMPDIR/mock_ssh" <<'EOF'
+#!/bin/bash
+# Mock SSH script - executes dolt transfer locally
+# Parses: mock_ssh [options] [user@]host command args...
+
+COMMAND=""
+HOST=""
+SKIP_NEXT=false
+
+for arg in "$@"; do
+    if [[ "$SKIP_NEXT" == "true" ]]; then
+        SKIP_NEXT=false
+        continue
+    fi
+    
+    case "$arg" in
+        -*)
+            # Skip SSH options
+            if [[ "$arg" == "-o" ]] || [[ "$arg" == "-i" ]]; then
+                SKIP_NEXT=true
+            fi
+            ;;
+        *@*)
+            # user@host format
+            HOST="${arg#*@}"
+            ;;
+        *)
+            if [[ -z "$HOST" ]] && [[ -z "$COMMAND" ]]; then
+                # First non-option arg is host
+                HOST="$arg"
+            else
+                # Rest is the command
+                if [[ -z "$COMMAND" ]]; then
+                    COMMAND="$arg"
+                else
+                    COMMAND="$COMMAND $arg"
+                fi
+            fi
+            ;;
+    esac
+done
+
+# Log and execute the command locally with proper stdio
+echo "Mock SSH executing: $COMMAND" >> "$BATS_TMPDIR/mock_ssh.log"
+# Use exec to replace the shell process and preserve stdio connections
+exec $COMMAND
+EOF
+    chmod +x "$BATS_TMPDIR/mock_ssh"
+    
+    # Set environment for SSH operations
+    export DOLT_SSH="$BATS_TMPDIR/mock_ssh"
+}
+
+teardown() {
+    unset DOLT_SSH
+}
+
+@test "ssh-transfer: transfer command works with --data-dir" {
+    mkdir "repo1"
+    cd "repo1"
+    dolt init
+    dolt sql -q "CREATE TABLE test (id INT PRIMARY KEY, val TEXT);"
+    dolt sql -q "INSERT INTO test VALUES (1, 'hello');"
+    dolt add .
+    dolt commit -m "initial commit"
+    
+    cd ..
+    run timeout 2s dolt --data-dir="repo1" transfer
+    # We expect it to timeout since it's waiting for input, but it should start
+    [ "$status" -eq 124 ] || [ "$status" -eq 143 ]  # timeout exit codes
+}
+
+@test "ssh-transfer: clone via SSH URL" {
+    mkdir "repo_source"
+    cd "repo_source"
+    dolt init
+    dolt sql -q "CREATE TABLE products (id VARCHAR(36) DEFAULT (UUID()) PRIMARY KEY, name TEXT, price DECIMAL(10,2));"
+    dolt sql -q "INSERT INTO products (name, price) VALUES ('Widget', 19.99), ('Gadget', 29.99);"
+    dolt add .
+    dolt commit -m "initial data"
+    
+    cd ..
+    run dolt clone "ssh://localhost$BATS_TEST_TMPDIR/repo_source" repo_clone
+    [ "$status" -eq 0 ]
+    [ -d repo_clone ]
+    
+    cd repo_clone
+    run dolt sql -q "SELECT COUNT(*) FROM products;" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "2" ]]
+}
+
+@test "ssh-transfer: clone with user@host format" {
+    mkdir "repo_usertest"
+    cd "repo_usertest"
+    dolt init
+    dolt sql -q "CREATE TABLE test (id INT PRIMARY KEY);"
+    dolt sql -q "INSERT INTO test VALUES (1), (2), (3);"
+    dolt add .
+    dolt commit -m "test data"
+    
+    cd ..
+    run dolt clone "ssh://testuser@localhost$BATS_TEST_TMPDIR/repo_usertest" repo_clone_user
+    [ "$status" -eq 0 ]
+    [ -d repo_clone_user ]
+    
+    cd repo_clone_user
+    run dolt sql -q "SELECT COUNT(*) FROM test;" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "3" ]]
+}
+
+@test "ssh-transfer: pull changes from remote" {
+    mkdir "repo_pull_source"
+    cd "repo_pull_source"
+    dolt init
+    dolt sql -q "CREATE TABLE items (id INT PRIMARY KEY, name TEXT);"
+    dolt sql -q "INSERT INTO items VALUES (1, 'item1');"
+    dolt add .
+    dolt commit -m "initial"
+    
+    cd ..
+    run dolt clone "ssh://localhost$BATS_TEST_TMPDIR/repo_pull_source" repo_pull_clone
+    [ "$status" -eq 0 ]
+    
+    cd "repo_pull_source"
+    dolt sql -q "INSERT INTO items VALUES (2, 'item2');"
+    dolt add .
+    dolt commit -m "add item2"
+    
+    cd "../repo_pull_clone"
+    run dolt pull origin
+    [ "$status" -eq 0 ]
+    
+    run dolt sql -q "SELECT COUNT(*) FROM items;" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "2" ]]
+}
+
+@test "ssh-transfer: push changes to remote" {
+    mkdir "repo_push_source"
+    cd "repo_push_source"
+    dolt init
+    dolt sql -q "CREATE TABLE data (id INT PRIMARY KEY, val TEXT);"
+    dolt sql -q "INSERT INTO data VALUES (1, 'original');"
+    dolt add .
+    dolt commit -m "initial"
+    
+    cd ..
+    run dolt clone "ssh://localhost$BATS_TEST_TMPDIR/repo_push_source" repo_push_clone
+    [ "$status" -eq 0 ]
+    
+    cd "repo_push_clone"
+    dolt sql -q "INSERT INTO data VALUES (2, 'from_clone');"
+    dolt add .
+    dolt commit -m "add from clone"
+    
+    run dolt push origin main
+    [ "$status" -eq 0 ]
+    
+    cd "../repo_push_source"
+    run dolt sql -q "SELECT COUNT(*) FROM data;" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "2" ]]
+    
+    run dolt sql -q "SELECT val FROM data WHERE id = 2;" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "from_clone" ]]
+}
+
+@test "ssh-transfer: handle branch operations" {
+    mkdir "repo_branch_source"
+    cd "repo_branch_source"
+    dolt init
+    dolt sql -q "CREATE TABLE main_table (id INT PRIMARY KEY);"
+    dolt sql -q "INSERT INTO main_table VALUES (1);"
+    dolt add .
+    dolt commit -m "main commit"
+    
+    dolt checkout -b feature
+    dolt sql -q "CREATE TABLE feature_table (id INT PRIMARY KEY);"
+    dolt sql -q "INSERT INTO feature_table VALUES (1);"
+    dolt add .
+    dolt commit -m "feature commit"
+    dolt checkout main
+    
+    cd ..
+    run dolt clone "ssh://localhost$BATS_TEST_TMPDIR/repo_branch_source" repo_branch_clone
+    [ "$status" -eq 0 ]
+    
+    cd "repo_branch_clone"
+    run dolt fetch origin feature
+    [ "$status" -eq 0 ]
+    
+    run dolt checkout feature
+    [ "$status" -eq 0 ]
+    
+    run dolt sql -q "SHOW TABLES;" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "feature_table" ]]
+}
+
+@test "ssh-transfer: concurrent clone operations" {
+    mkdir "repo_concurrent_source"
+    cd "repo_concurrent_source"
+    dolt init
+    dolt sql -q "CREATE TABLE test (id INT PRIMARY KEY);"
+    dolt sql -q "INSERT INTO test VALUES (1), (2), (3), (4), (5);"
+    dolt add .
+    dolt commit -m "test data"
+    
+    # Start multiple clones concurrently
+    cd ..
+    dolt clone "ssh://localhost$BATS_TEST_TMPDIR/repo_concurrent_source" repo_concurrent_1 &
+    PID1=$!
+    dolt clone "ssh://localhost$BATS_TEST_TMPDIR/repo_concurrent_source" repo_concurrent_2 &
+    PID2=$!
+    dolt clone "ssh://localhost$BATS_TEST_TMPDIR/repo_concurrent_source" repo_concurrent_3 &
+    PID3=$!
+    
+    # Wait for all to complete
+    wait $PID1
+    STATUS1=$?
+    wait $PID2
+    STATUS2=$?
+    wait $PID3
+    STATUS3=$?
+    
+    [ "$STATUS1" -eq 0 ]
+    [ "$STATUS2" -eq 0 ]
+    [ "$STATUS3" -eq 0 ]
+    
+    # Verify all have correct data
+    for dir in repo_concurrent_1 repo_concurrent_2 repo_concurrent_3; do
+        cd "$dir"
+        run dolt sql -q "SELECT COUNT(*) FROM test;" -r csv
+        [ "$status" -eq 0 ]
+        [[ "$output" =~ "5" ]]
+        cd ..
+    done
+}
+
+@test "ssh-transfer: error handling for non-existent repository" {
+    run dolt clone "ssh://localhost/nonexistent/repo" should_fail
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "repository not found" ]] || false
+}
+
+@test "ssh-transfer: verify DOLT_SSH environment variable works" {
+    # Create a custom mock SSH that logs calls
+    cat > "$BATS_TMPDIR/mock_ssh_logger" <<'EOF'
+#!/bin/bash
+echo "CUSTOM_SSH_CALLED" >> "$BATS_TMPDIR/ssh_calls.log"
+exec "$BATS_TMPDIR/mock_ssh" "$@"
+EOF
+    chmod +x "$BATS_TMPDIR/mock_ssh_logger"
+    
+    export DOLT_SSH="$BATS_TMPDIR/mock_ssh_logger"
+    
+    mkdir "repo_env_test"
+    cd "repo_env_test"
+    dolt init
+    dolt sql -q "CREATE TABLE test (id INT PRIMARY KEY);"
+    dolt add .
+    dolt commit -m "test"
+    
+    cd ..
+    run dolt clone "ssh://localhost$BATS_TEST_TMPDIR/repo_env_test" repo_env_clone
+    [ "$status" -eq 0 ]
+    
+    # Verify custom SSH was used
+    [ -f "$BATS_TMPDIR/ssh_calls.log" ]
+    grep -q "CUSTOM_SSH_CALLED" "$BATS_TMPDIR/ssh_calls.log"
+}

--- a/integration-tests/bats/ssh-transfer.bats
+++ b/integration-tests/bats/ssh-transfer.bats
@@ -187,12 +187,18 @@ teardown() {
     
     run dolt push origin main
     [ "$status" -eq 0 ]
-    
-    cd "../repo_push_source"
+
+    # Verify by cloning the source again -- push updates the branch ref
+    # but not the working set, so dolt sql on the source would be stale.
+    cd ..
+    run dolt clone "ssh://localhost$BATS_TEST_TMPDIR/repo_push_source" repo_push_verify
+    [ "$status" -eq 0 ]
+
+    cd repo_push_verify
     run dolt sql -q "SELECT COUNT(*) FROM data;" -r csv
     [ "$status" -eq 0 ]
     [[ "$output" =~ "2" ]]
-    
+
     run dolt sql -q "SELECT val FROM data WHERE id = 2;" -r csv
     [ "$status" -eq 0 ]
     [[ "$output" =~ "from_clone" ]]

--- a/integration-tests/bats/ssh-transfer.bats
+++ b/integration-tests/bats/ssh-transfer.bats
@@ -408,6 +408,14 @@ MOCK
 
     cd "$BATS_TEST_TMPDIR"
     run dolt clone "ssh://localhost$BATS_TEST_TMPDIR/repo_locked_read" repo_locked_read_clone
+    [ "$status" -eq 0 ]
+
+    cd "repo_locked_read_clone"
+    run dolt sql -r csv  -q "SELECT * FROM test;"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "1,one" ]]
+    [[ "$output" =~ "2,two" ]]
+    [[ "$output" =~ "3,three" ]]
 }
 
 @test "ssh-transfer: push fails while sql-server is running" {
@@ -436,5 +444,6 @@ MOCK
     run dolt push origin main
     # Push must fail when sql-server holds the lock.
     [ "$status" -ne 0 ]
-    [[ "$output" =~ "failed to acquire manifest lock" ]] || false
+    # The transfer command logs the real error to stderr; verify it.
+    grep -q "database is read only" "$BATS_TMPDIR/transfer_stderr.log"
 }

--- a/integration-tests/bats/ssh-transfer.bats
+++ b/integration-tests/bats/ssh-transfer.bats
@@ -75,9 +75,10 @@ teardown() {
     dolt commit -m "initial commit"
     
     cd ..
-    run timeout 2s dolt --data-dir="repo1" transfer
-    # We expect it to timeout since it's waiting for input, but it should start
-    [ "$status" -eq 124 ] || [ "$status" -eq 143 ]  # timeout exit codes
+    run dolt --data-dir="repo1" transfer </dev/null
+    # Transfer exits non-zero when stdin closes immediately, but it should
+    # start without crashing. Exit code 1 means it ran and shut down cleanly.
+    [ "$status" -eq 1 ]
 }
 
 @test "ssh-transfer: clone via SSH URL" {

--- a/integration-tests/bats/ssh-transfer.bats
+++ b/integration-tests/bats/ssh-transfer.bats
@@ -366,32 +366,6 @@ MOCK
     [[ "$output" =~ "2" ]] || false
 }
 
-@test "ssh-transfer: server-side logs are visible on stderr" {
-    mkdir "repo_stderr"
-    cd "repo_stderr"
-    dolt init
-    dolt sql -q "CREATE TABLE test (id INT PRIMARY KEY);"
-    dolt sql -q "INSERT INTO test VALUES (1);"
-    dolt add .
-    dolt commit -m "test"
-
-    cd ..
-    dolt clone "ssh://localhost$BATS_TEST_TMPDIR/repo_stderr" repo_stderr_clone
-
-    # The mock SSH tees remote stderr to transfer_stderr.log.
-    # Verify the transfer command's startup log appeared.
-    [ -f "$BATS_TMPDIR/transfer_stderr.log" ]
-
-    echo "------------------"
-    env | sort
-    echo "******************"
-    cat "$BATS_TMPDIR/transfer_stderr.log"
-    echo "------------------"
-
-
-    grep -q "transfer: serving repository" "$BATS_TMPDIR/transfer_stderr.log"
-}
-
 @test "ssh-transfer: clone succeeds while sql-server is running" {
     mkdir "repo_locked_read"
     cd "repo_locked_read"

--- a/integration-tests/bats/ssh-transfer.bats
+++ b/integration-tests/bats/ssh-transfer.bats
@@ -60,11 +60,11 @@ EOF
     chmod +x "$BATS_TMPDIR/mock_ssh"
     
     # Set environment for SSH operations
-    export DOLT_SSH="$BATS_TMPDIR/mock_ssh"
+    export DOLT_SSH_COMMAND="$BATS_TMPDIR/mock_ssh"
 }
 
 teardown() {
-  unset DOLT_SSH
+  unset DOLT_SSH_COMMAND
   stop_sql_server
 }
 
@@ -160,7 +160,7 @@ echo "$@" >> "$BATS_TMPDIR/ssh_port_args.log"
 exec "$BATS_TMPDIR/mock_ssh" "$@"
 PORTEOF
     chmod +x "$BATS_TMPDIR/mock_ssh_port"
-    export DOLT_SSH="$BATS_TMPDIR/mock_ssh_port"
+    export DOLT_SSH_COMMAND="$BATS_TMPDIR/mock_ssh_port"
 
     cd ..
     run dolt clone "ssh://localhost:9999$BATS_TEST_TMPDIR/repo_porttest" repo_port_clone
@@ -312,7 +312,7 @@ PORTEOF
     [[ "$output" =~ "repository not found" ]] || false
 }
 
-@test "ssh-transfer: verify DOLT_SSH environment variable works" {
+@test "ssh-transfer: verify DOLT_SSH_COMMAND environment variable works" {
     # Create a custom mock SSH that logs calls
     cat > "$BATS_TMPDIR/mock_ssh_logger" <<'EOF'
 #!/bin/bash
@@ -321,7 +321,7 @@ exec "$BATS_TMPDIR/mock_ssh" "$@"
 EOF
     chmod +x "$BATS_TMPDIR/mock_ssh_logger"
     
-    export DOLT_SSH="$BATS_TMPDIR/mock_ssh_logger"
+    export DOLT_SSH_COMMAND="$BATS_TMPDIR/mock_ssh_logger"
     
     mkdir "repo_env_test"
     cd "repo_env_test"
@@ -391,7 +391,7 @@ exec $COMMAND
 MOCK
     chmod +x "$BATS_TMPDIR/mock_ssh_exec"
 
-    export DOLT_SSH="$BATS_TMPDIR/mock_ssh_exec"
+    export DOLT_SSH_COMMAND="$BATS_TMPDIR/mock_ssh_exec"
     export DOLT_SSH_EXEC_PATH="/custom/path/to/dolt"
 
     cd ..

--- a/integration-tests/bats/ssh-transfer.bats
+++ b/integration-tests/bats/ssh-transfer.bats
@@ -11,11 +11,12 @@ setup() {
     # Create mock SSH script that executes the remote command locally.
     # Real SSH runs its last argument as a command on the remote host.
     # buildTransferCommand always passes the dolt transfer invocation as
-    # the final argument, so we just exec that.
+    # the final argument, so we just exec that.  All args are logged so
+    # tests can verify user@host, -p port, etc.
     cat > "$BATS_TMPDIR/mock_ssh" <<'EOF'
 #!/bin/bash
+echo "$@" >> "$BATS_TMPDIR/mock_ssh.log"
 COMMAND="${@: -1}"
-echo "Mock SSH executing: $COMMAND" >> "$BATS_TMPDIR/mock_ssh.log"
 exec $COMMAND 2> >(tee -a "$BATS_TMPDIR/transfer_stderr.log" >&2)
 EOF
     chmod +x "$BATS_TMPDIR/mock_ssh"
@@ -111,7 +112,10 @@ teardown() {
     run dolt clone "ssh://testuser@localhost$BATS_TEST_TMPDIR/repo_usertest" repo_clone_user
     [ "$status" -eq 0 ]
     [ -d repo_clone_user ]
-    
+
+    # Verify mock SSH received testuser@localhost
+    grep -q "testuser@localhost" "$BATS_TMPDIR/mock_ssh.log"
+
     cd repo_clone_user
     run dolt sql -q "SELECT COUNT(*) FROM test;" -r csv
     [ "$status" -eq 0 ]
@@ -127,22 +131,13 @@ teardown() {
     dolt add .
     dolt commit -m "test data"
 
-    # Use a mock SSH that logs the -p flag for verification
-    cat > "$BATS_TMPDIR/mock_ssh_port" <<'PORTEOF'
-#!/bin/bash
-echo "$@" >> "$BATS_TMPDIR/ssh_port_args.log"
-exec "$BATS_TMPDIR/mock_ssh" "$@"
-PORTEOF
-    chmod +x "$BATS_TMPDIR/mock_ssh_port"
-    export DOLT_SSH_COMMAND="$BATS_TMPDIR/mock_ssh_port"
-
     cd ..
     run dolt clone "ssh://localhost:9999$BATS_TEST_TMPDIR/repo_porttest" repo_port_clone
     [ "$status" -eq 0 ]
     [ -d repo_port_clone ]
 
-    # Verify -p 9999 was passed to SSH
-    grep -q "\-p 9999" "$BATS_TMPDIR/ssh_port_args.log"
+    # Verify -p 9999 was passed to mock SSH
+    grep -q "\-p 9999" "$BATS_TMPDIR/mock_ssh.log"
 
     cd repo_port_clone
     run dolt sql -q "SELECT COUNT(*) FROM test;" -r csv
@@ -287,30 +282,30 @@ PORTEOF
 }
 
 @test "ssh-transfer: verify DOLT_SSH_COMMAND environment variable works" {
-    # Create a custom mock SSH that logs calls
-    cat > "$BATS_TMPDIR/mock_ssh_logger" <<'EOF'
+    # Create a separate mock SSH to prove DOLT_SSH_COMMAND is honored
+    cat > "$BATS_TMPDIR/custom_ssh" <<'EOF'
 #!/bin/bash
-echo "CUSTOM_SSH_CALLED" >> "$BATS_TMPDIR/ssh_calls.log"
-exec "$BATS_TMPDIR/mock_ssh" "$@"
+echo "CUSTOM_SSH $@" >> "$BATS_TMPDIR/custom_ssh.log"
+COMMAND="${@: -1}"
+exec $COMMAND 2>/dev/null
 EOF
-    chmod +x "$BATS_TMPDIR/mock_ssh_logger"
-    
-    export DOLT_SSH_COMMAND="$BATS_TMPDIR/mock_ssh_logger"
-    
+    chmod +x "$BATS_TMPDIR/custom_ssh"
+    export DOLT_SSH_COMMAND="$BATS_TMPDIR/custom_ssh"
+
     mkdir "repo_env_test"
     cd "repo_env_test"
     dolt init
     dolt sql -q "CREATE TABLE test (id INT PRIMARY KEY);"
     dolt add .
     dolt commit -m "test"
-    
+
     cd ..
     run dolt clone "ssh://localhost$BATS_TEST_TMPDIR/repo_env_test" repo_env_clone
     [ "$status" -eq 0 ]
-    
-    # Verify custom SSH was used
-    [ -f "$BATS_TMPDIR/ssh_calls.log" ]
-    grep -q "CUSTOM_SSH_CALLED" "$BATS_TMPDIR/ssh_calls.log"
+
+    # Verify the custom SSH was used
+    [ -f "$BATS_TMPDIR/custom_ssh.log" ]
+    grep -q "CUSTOM_SSH.*localhost" "$BATS_TMPDIR/custom_ssh.log"
 }
 
 @test "ssh-transfer: DOLT_SSH_EXEC_PATH overrides remote dolt path" {
@@ -322,44 +317,12 @@ EOF
     dolt add .
     dolt commit -m "test"
 
-    # Create a mock SSH that logs the remote command it receives
+    # Create a mock SSH that logs the remote command and rewrites the
+    # custom dolt path back to the real binary so it can execute locally.
     cat > "$BATS_TMPDIR/mock_ssh_exec" <<'MOCK'
 #!/bin/bash
-COMMAND=""
-HOST=""
-SKIP_NEXT=false
-
-for arg in "$@"; do
-    if [[ "$SKIP_NEXT" == "true" ]]; then
-        SKIP_NEXT=false
-        continue
-    fi
-    case "$arg" in
-        -*)
-            if [[ "$arg" == "-o" ]] || [[ "$arg" == "-i" ]] || [[ "$arg" == "-p" ]]; then
-                SKIP_NEXT=true
-            fi
-            ;;
-        *@*)
-            HOST="${arg#*@}"
-            ;;
-        *)
-            if [[ -z "$HOST" ]] && [[ -z "$COMMAND" ]]; then
-                HOST="$arg"
-            else
-                if [[ -z "$COMMAND" ]]; then
-                    COMMAND="$arg"
-                else
-                    COMMAND="$COMMAND $arg"
-                fi
-            fi
-            ;;
-    esac
-done
-
-# Log the remote command for verification
+COMMAND="${@: -1}"
 echo "$COMMAND" >> "$BATS_TMPDIR/exec_path.log"
-# Execute locally, replacing the custom path with the real dolt
 COMMAND=$(echo "$COMMAND" | sed "s|/custom/path/to/dolt|$(which dolt)|")
 exec $COMMAND
 MOCK

--- a/integration-tests/bats/ssh-transfer.bats
+++ b/integration-tests/bats/ssh-transfer.bats
@@ -479,3 +479,142 @@ MOCK
     # The transfer command logs the real error to stderr; verify it.
     grep -q "database is read only" "$BATS_TMPDIR/transfer_stderr.log"
 }
+
+@test "ssh-transfer: sql dolt_clone() via SSH URL" {
+    mkdir "repo_sql_clone_src"
+    cd "repo_sql_clone_src"
+    dolt init
+    dolt sql -q "CREATE TABLE test (id INT PRIMARY KEY, val TEXT);"
+    dolt sql -q "INSERT INTO test VALUES (1, 'a'), (2, 'b'), (3, 'c');"
+    dolt add .
+    dolt commit -m "initial"
+
+    # Start sql-server in a fresh directory (no pre-existing databases)
+    cd "$BATS_TEST_TMPDIR"
+    mkdir "sql_clone_server"
+    cd "sql_clone_server"
+    start_sql_server
+
+    dolt sql -q "CALL dolt_clone('ssh://localhost$BATS_TEST_TMPDIR/repo_sql_clone_src', 'sql_cloned');"
+
+    # Verify cloned data
+    run dolt --use-db sql_cloned sql -r csv -q "SELECT COUNT(*) FROM test;"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "3" ]]
+}
+
+@test "ssh-transfer: sql dolt_push() to SSH remote" {
+    mkdir "repo_sql_push_src"
+    cd "repo_sql_push_src"
+    dolt init
+    dolt sql -q "CREATE TABLE test (id INT PRIMARY KEY);"
+    dolt sql -q "INSERT INTO test VALUES (1);"
+    dolt add .
+    dolt commit -m "initial"
+
+    cd "$BATS_TEST_TMPDIR"
+    dolt clone "ssh://localhost$BATS_TEST_TMPDIR/repo_sql_push_src" repo_sql_push_clone
+
+    cd "repo_sql_push_clone"
+    start_sql_server repo_sql_push_clone
+
+    dolt sql -q "INSERT INTO test VALUES (10);"
+    dolt sql -q "CALL dolt_commit('-a','-m', 'sql push 123');"
+    dolt sql -q "CALL dolt_push('origin', 'main');"
+    stop_sql_server 1
+
+    cd "$BATS_TEST_TMPDIR/repo_sql_push_src"
+    run dolt log --oneline -n 1
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "sql push 123" ]]
+}
+
+@test "ssh-transfer: sql dolt_pull() from SSH remote" {
+    mkdir "repo_sql_pull_src"
+    cd "repo_sql_pull_src"
+    dolt init
+    dolt sql -q "CREATE TABLE items (id INT PRIMARY KEY, name TEXT);"
+    dolt sql -q "INSERT INTO items VALUES (1, 'original');"
+    dolt add .
+    dolt commit -m "initial"
+
+    cd "$BATS_TEST_TMPDIR"
+    dolt clone "ssh://localhost$BATS_TEST_TMPDIR/repo_sql_pull_src" repo_sql_pull_clone
+
+    # Add new data to source
+    cd "repo_sql_pull_src"
+    dolt sql -q "INSERT INTO items VALUES (99, 'new_item');"
+    dolt add .
+    dolt commit -m "add new item"
+
+    cd "$BATS_TEST_TMPDIR/repo_sql_pull_clone"
+    start_sql_server repo_sql_pull_clone
+    dolt sql -q "CALL dolt_pull('origin');"
+
+    run dolt sql -r csv -q "SELECT * FROM items WHERE id=99;"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "new_item" ]]
+}
+
+@test "ssh-transfer: sql dolt_remote(add) with SSH URL then push" {
+    mkdir "repo_sql_remote_src"
+    cd "repo_sql_remote_src"
+    dolt init
+    dolt sql -q "CREATE TABLE data (id INT PRIMARY KEY);"
+    dolt sql -q "INSERT INTO data VALUES (1), (2), (3);"
+    dolt add .
+    dolt commit -m "initial data"
+
+    cd "$BATS_TEST_TMPDIR"
+    dolt clone "ssh://localhost$BATS_TEST_TMPDIR/repo_sql_remote_src" repo_sql_remote_target
+
+    # Create a second clone as the local working copy
+    dolt clone "ssh://localhost$BATS_TEST_TMPDIR/repo_sql_remote_src" repo_sql_remote_local
+    cd "repo_sql_remote_local"
+
+    start_sql_server repo_sql_remote_local
+    dolt sql -q "CALL dolt_remote('add', 'target', 'ssh://localhost$BATS_TEST_TMPDIR/repo_sql_remote_target');"
+    dolt sql -q "INSERT INTO data VALUES (10);"
+    dolt sql -q "CALL dolt_commit('-a', '-m', 'push to target');"
+    dolt sql -q "CALL dolt_push('target', 'main');"
+
+    cd "$BATS_TEST_TMPDIR/repo_sql_remote_target"
+    run dolt log --oneline -n 1
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "push to target" ]]
+}
+
+@test "ssh-transfer: sql dolt_clone() fails for non-existent SSH repo" {
+    mkdir "sql_err_server"
+    cd "sql_err_server"
+    start_sql_server
+
+    # Attempt clone of non-existent path
+    run dolt sql -q "CALL dolt_clone('ssh://localhost/nonexistent/repo_does_not_exist');"
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "repository not found" ]] || false
+}
+
+@test "ssh-transfer: sql dolt_push() fails while sql-server locks target" {
+    mkdir "repo_sql_lockpush_src"
+    cd "repo_sql_lockpush_src"
+    dolt init
+    dolt sql -q "CREATE TABLE test (id INT PRIMARY KEY);"
+    dolt sql -q "INSERT INTO test VALUES (1);"
+    dolt add .
+    dolt commit -m "initial"
+
+    cd "$BATS_TEST_TMPDIR"
+    dolt clone "ssh://localhost$BATS_TEST_TMPDIR/repo_sql_lockpush_src" repo_sql_lockpush_clone
+
+    # Lock source with sql-server
+    cd "repo_sql_lockpush_src"
+    start_sql_server repo_sql_lockpush_src
+
+    cd "$BATS_TEST_TMPDIR/repo_sql_lockpush_clone"
+    dolt sql -q "INSERT INTO test VALUES (99);"
+    dolt sql -q "CALL dolt_commit('-a', '-m', 'should fail');"
+    run dolt sql -q "CALL dolt_push('origin', 'main');"
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "database is read only" ]] || false
+}

--- a/integration-tests/bats/ssh-transfer.bats
+++ b/integration-tests/bats/ssh-transfer.bats
@@ -63,7 +63,7 @@ teardown() {
     cd repo_clone
     run dolt sql -q "SELECT COUNT(*) FROM products;" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "2" ]]
+    [[ "$output" =~ "2" ]] || false
 }
 
 @test "ssh-transfer: clone with .dolt suffix in URL path" {
@@ -83,12 +83,11 @@ teardown() {
     cd repo_dotsuffix_clone
     run dolt sql -q "SELECT COUNT(*) FROM test;" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "3" ]]
-    cd ..
+    [[ "$output" =~ "3" ]] || false
+    cd "$BATS_TEST_TMPDIR"
     rm -rf repo_dotsuffix_clone
 
     # repeat with /.dolt/ (trailing slash).
-    cd ..
     run dolt clone "ssh://localhost$BATS_TEST_TMPDIR/repo_dotsuffix/.dolt/" repo_dotsuffix_clone
     [ "$status" -eq 0 ]
     [ -d repo_dotsuffix_clone ]
@@ -96,7 +95,7 @@ teardown() {
     cd repo_dotsuffix_clone
     run dolt sql -q "SELECT COUNT(*) FROM test;" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "3" ]]
+    [[ "$output" =~ "3" ]] || false
 }
 
 @test "ssh-transfer: clone with user@host format" {
@@ -119,7 +118,7 @@ teardown() {
     cd repo_clone_user
     run dolt sql -q "SELECT COUNT(*) FROM test;" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "3" ]]
+    [[ "$output" =~ "3" ]] || false
 }
 
 @test "ssh-transfer: clone with custom port in URL" {
@@ -142,7 +141,7 @@ teardown() {
     cd repo_port_clone
     run dolt sql -q "SELECT COUNT(*) FROM test;" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "3" ]]
+    [[ "$output" =~ "3" ]] || false
 }
 
 @test "ssh-transfer: clone of GCed repo" {
@@ -163,7 +162,7 @@ teardown() {
     cd repo_gc_clone
     run dolt sql -q "SELECT COUNT(*) FROM test;" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "3" ]]
+    [[ "$output" =~ "3" ]] || false
 }
 
 @test "ssh-transfer: pull changes from remote" {
@@ -190,7 +189,7 @@ teardown() {
     
     run dolt sql -q "SELECT COUNT(*) FROM items;" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "2" ]]
+    [[ "$output" =~ "2" ]] || false
 }
 
 @test "ssh-transfer: push changes to remote" {
@@ -221,7 +220,7 @@ teardown() {
     # match the commit we just pushed.
     run dolt log --oneline -n 1 origin/main
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "$PUSH_COMMIT" ]]
+    [[ "$output" =~ "$PUSH_COMMIT" ]] || false
 }
 
 @test "ssh-transfer: handle branch operations" {
@@ -253,7 +252,7 @@ teardown() {
     
     run dolt sql -q "SHOW TABLES;" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "feature_table" ]]
+    [[ "$output" =~ "feature_table" ]] || false
 }
 
 @test "ssh-transfer: concurrent clone operations" {
@@ -291,7 +290,7 @@ teardown() {
         cd "$dir"
         run dolt sql -q "SELECT COUNT(*) FROM test;" -r csv
         [ "$status" -eq 0 ]
-        [[ "$output" =~ "5" ]]
+        [[ "$output" =~ "5" ]] || false
         cd ..
     done
 }
@@ -364,7 +363,7 @@ MOCK
     cd repo_exec_clone
     run dolt sql -q "SELECT COUNT(*) FROM test;" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "2" ]]
+    [[ "$output" =~ "2" ]] || false
 }
 
 @test "ssh-transfer: server-side logs are visible on stderr" {
@@ -411,9 +410,9 @@ MOCK
     cd "repo_locked_read_clone"
     run dolt sql -r csv  -q "SELECT * FROM test;"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "1,one" ]]
-    [[ "$output" =~ "2,two" ]]
-    [[ "$output" =~ "3,three" ]]
+    [[ "$output" =~ "1,one" ]] || false
+    [[ "$output" =~ "2,two" ]] || false
+    [[ "$output" =~ "3,three" ]] || false
 }
 
 @test "ssh-transfer: push fails while sql-server is running" {
@@ -466,7 +465,7 @@ MOCK
     # Verify cloned data
     run dolt --use-db sql_cloned sql -r csv -q "SELECT COUNT(*) FROM test;"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "3" ]]
+    [[ "$output" =~ "3" ]] || false
 }
 
 @test "ssh-transfer: sql dolt_push() to SSH remote" {
@@ -492,7 +491,7 @@ MOCK
     cd "$BATS_TEST_TMPDIR/repo_sql_push_src"
     run dolt log --oneline -n 1
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "sql push 123" ]]
+    [[ "$output" =~ "sql push 123" ]] || false
 }
 
 @test "ssh-transfer: sql dolt_pull() from SSH remote" {
@@ -519,7 +518,7 @@ MOCK
 
     run dolt sql -r csv -q "SELECT * FROM items WHERE id=99;"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "new_item" ]]
+    [[ "$output" =~ "new_item" ]] || false
 }
 
 @test "ssh-transfer: sql dolt_remote(add) with SSH URL then push" {
@@ -547,7 +546,7 @@ MOCK
     cd "$BATS_TEST_TMPDIR/repo_sql_remote_target"
     run dolt log --oneline -n 1
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "push to target" ]]
+    [[ "$output" =~ "push to target" ]] || false
 }
 
 @test "ssh-transfer: sql dolt_clone() fails for non-existent SSH repo" {

--- a/integration-tests/bats/ssh-transfer.bats
+++ b/integration-tests/bats/ssh-transfer.bats
@@ -145,6 +145,27 @@ teardown() {
     [[ "$output" =~ "3" ]]
 }
 
+@test "ssh-transfer: clone of GCed repo" {
+    mkdir "repo_gc"
+    cd "repo_gc"
+    dolt init
+    dolt sql -q "CREATE TABLE test (id INT PRIMARY KEY);"
+    dolt sql -q "INSERT INTO test VALUES (1), (2), (3);"
+    dolt add .
+    dolt commit -m "test data"
+    dolt gc
+
+    cd ..
+    run dolt clone "ssh://localhost$BATS_TEST_TMPDIR/repo_gc" repo_gc_clone
+    [ "$status" -eq 0 ]
+    [ -d repo_gc_clone ]
+
+    cd repo_gc_clone
+    run dolt sql -q "SELECT COUNT(*) FROM test;" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "3" ]]
+}
+
 @test "ssh-transfer: pull changes from remote" {
     mkdir "repo_pull_source"
     cd "repo_pull_source"

--- a/integration-tests/bats/ssh-transfer.bats
+++ b/integration-tests/bats/ssh-transfer.bats
@@ -80,7 +80,7 @@ teardown() {
     cd ..
     run dolt --data-dir="repo1" transfer </dev/null
     # Transfer exits non-zero when stdin closes immediately, but it should
-    # start without crashing. Exit code 1 means it ran and shut down cleanly.
+    # start without crashing. Exit code 1 means it ran and shut down without a panic.
     [ "$status" -eq 1 ]
 }
 
@@ -115,6 +115,19 @@ teardown() {
 
     cd ..
     run dolt clone "ssh://localhost$BATS_TEST_TMPDIR/repo_dotsuffix/.dolt" repo_dotsuffix_clone
+    [ "$status" -eq 0 ]
+    [ -d repo_dotsuffix_clone ]
+
+    cd repo_dotsuffix_clone
+    run dolt sql -q "SELECT COUNT(*) FROM test;" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "3" ]]
+    cd ..
+    rm -rf repo_dotsuffix_clone
+
+    # repeat with /.dolt/ (trailing slash).
+    cd ..
+    run dolt clone "ssh://localhost$BATS_TEST_TMPDIR/repo_dotsuffix/.dolt/" repo_dotsuffix_clone
     [ "$status" -eq 0 ]
     [ -d repo_dotsuffix_clone ]
 
@@ -424,6 +437,14 @@ MOCK
     # The mock SSH tees remote stderr to transfer_stderr.log.
     # Verify the transfer command's startup log appeared.
     [ -f "$BATS_TMPDIR/transfer_stderr.log" ]
+
+    echo "------------------"
+    env | sort
+    echo "******************"
+    cat "$BATS_TMPDIR/transfer_stderr.log"
+    echo "------------------"
+
+
     grep -q "transfer: serving repository" "$BATS_TMPDIR/transfer_stderr.log"
 }
 

--- a/integration-tests/bats/ssh-transfer.bats
+++ b/integration-tests/bats/ssh-transfer.bats
@@ -40,9 +40,11 @@ teardown() {
     
     cd ..
     run dolt --data-dir="repo1" transfer </dev/null
-    # Transfer exits non-zero when stdin closes immediately, but it should
-    # start without crashing. Exit code 1 means it ran and shut down without a panic.
-    [ "$status" -eq 1 ]
+    # transfer command is kind of strange in that it always exits with status 0. It will even show an odd error
+    # here. That's all fine. We don't expect people to run this directly. We'll look at messages more closely from
+    # dolt clone, dolt push, dolt pull.
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "server error: EOF" ]] || false
 }
 
 @test "ssh-transfer: clone via SSH URL" {

--- a/integration-tests/bats/ssh-transfer.bats
+++ b/integration-tests/bats/ssh-transfer.bats
@@ -13,16 +13,15 @@ setup() {
     # buildTransferCommand always passes the dolt transfer invocation as
     # the final argument, so we just exec that.  All args are logged so
     # tests can verify user@host, -p port, etc.
-    cat > "$BATS_TMPDIR/mock_ssh" <<'EOF'
+    cat > "$BATS_TEST_TMPDIR/mock_ssh" <<'EOF'
 #!/bin/bash
-echo "$@" >> "$BATS_TMPDIR/mock_ssh.log"
+echo "$@" >> "$BATS_TEST_TMPDIR/mock_ssh.log"
 COMMAND="${@: -1}"
-exec $COMMAND 2> >(tee -a "$BATS_TMPDIR/transfer_stderr.log" >&2)
+exec $COMMAND 2> >(tee -a "$BATS_TEST_TMPDIR/transfer_stderr.log" >&2)
 EOF
-    chmod +x "$BATS_TMPDIR/mock_ssh"
-    
-    # Set environment for SSH operations
-    export DOLT_SSH_COMMAND="$BATS_TMPDIR/mock_ssh"
+    chmod +x "$BATS_TEST_TMPDIR/mock_ssh"
+
+    export DOLT_SSH_COMMAND="$BATS_TEST_TMPDIR/mock_ssh"
 }
 
 teardown() {
@@ -113,7 +112,7 @@ teardown() {
     [ -d repo_clone_user ]
 
     # Verify mock SSH received testuser@localhost
-    grep -q "testuser@localhost" "$BATS_TMPDIR/mock_ssh.log"
+    grep -q "testuser@localhost" "$BATS_TEST_TMPDIR/mock_ssh.log"
 
     cd repo_clone_user
     run dolt sql -q "SELECT COUNT(*) FROM test;" -r csv
@@ -136,7 +135,7 @@ teardown() {
     [ -d repo_port_clone ]
 
     # Verify -p 9999 was passed to mock SSH
-    grep -q "\-p 9999" "$BATS_TMPDIR/mock_ssh.log"
+    grep -q "\-p 9999" "$BATS_TEST_TMPDIR/mock_ssh.log"
 
     cd repo_port_clone
     run dolt sql -q "SELECT COUNT(*) FROM test;" -r csv
@@ -302,15 +301,15 @@ teardown() {
 }
 
 @test "ssh-transfer: verify DOLT_SSH_COMMAND environment variable works" {
-    # Create a separate mock SSH to prove DOLT_SSH_COMMAND is honored
-    cat > "$BATS_TMPDIR/custom_ssh" <<'EOF'
+    # All tests use DOLT_SSH_COMMAND, so this is kind of a sanity check to ensure that your can change it.
+    cat > "$BATS_TEST_TMPDIR/custom_ssh" <<'EOF'
 #!/bin/bash
-echo "CUSTOM_SSH $@" >> "$BATS_TMPDIR/custom_ssh.log"
+echo "CUSTOM_SSH $@" >> "$BATS_TEST_TMPDIR/custom_ssh.log"
 COMMAND="${@: -1}"
 exec $COMMAND 2>/dev/null
 EOF
-    chmod +x "$BATS_TMPDIR/custom_ssh"
-    export DOLT_SSH_COMMAND="$BATS_TMPDIR/custom_ssh"
+    chmod +x "$BATS_TEST_TMPDIR/custom_ssh"
+    export DOLT_SSH_COMMAND="$BATS_TEST_TMPDIR/custom_ssh"
 
     mkdir "repo_env_test"
     cd "repo_env_test"
@@ -324,8 +323,8 @@ EOF
     [ "$status" -eq 0 ]
 
     # Verify the custom SSH was used
-    [ -f "$BATS_TMPDIR/custom_ssh.log" ]
-    grep -q "CUSTOM_SSH.*localhost" "$BATS_TMPDIR/custom_ssh.log"
+    [ -f "$BATS_TEST_TMPDIR/custom_ssh.log" ]
+    grep -q "CUSTOM_SSH.*localhost" "$BATS_TEST_TMPDIR/custom_ssh.log"
 }
 
 @test "ssh-transfer: DOLT_SSH_EXEC_PATH overrides remote dolt path" {
@@ -338,32 +337,29 @@ EOF
     dolt commit -m "test"
 
     # Create a mock SSH that logs the remote command and rewrites the
-    # custom dolt path back to the real binary so it can execute locally.
-    cat > "$BATS_TMPDIR/mock_ssh_exec" <<'MOCK'
+    # custom dolt path back to the real binary so it can actually execute.
+    export REAL_DOLT_BIN="$(command -v dolt)"
+    [ -n "$REAL_DOLT_BIN" ]
+
+    cat > "$BATS_TEST_TMPDIR/mock_ssh_exec" <<'MOCK'
 #!/bin/bash
 COMMAND="${@: -1}"
-echo "$COMMAND" >> "$BATS_TMPDIR/exec_path.log"
-COMMAND=$(echo "$COMMAND" | sed "s|/custom/path/to/dolt|$(which dolt)|")
+echo "$COMMAND" >> "$BATS_TEST_TMPDIR/exec_path.log"
+COMMAND=$(echo "$COMMAND" | sed "s|/nonsense/path/to/dolt|$REAL_DOLT_BIN|")
 exec $COMMAND
 MOCK
-    chmod +x "$BATS_TMPDIR/mock_ssh_exec"
+    chmod +x "$BATS_TEST_TMPDIR/mock_ssh_exec"
 
-    export DOLT_SSH_COMMAND="$BATS_TMPDIR/mock_ssh_exec"
-    export DOLT_SSH_EXEC_PATH="/custom/path/to/dolt"
+    export DOLT_SSH_COMMAND="$BATS_TEST_TMPDIR/mock_ssh_exec"
+    export DOLT_SSH_EXEC_PATH="/nonsense/path/to/dolt"
 
     cd ..
     run dolt clone "ssh://localhost$BATS_TEST_TMPDIR/repo_exec_path" repo_exec_clone
     [ "$status" -eq 0 ]
 
     # Verify the custom exec path was used in the remote command
-    [ -f "$BATS_TMPDIR/exec_path.log" ]
-    grep -q "/custom/path/to/dolt --data-dir" "$BATS_TMPDIR/exec_path.log"
-
-    # Verify data is correct
-    cd repo_exec_clone
-    run dolt sql -q "SELECT COUNT(*) FROM test;" -r csv
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ "2" ]] || false
+    [ -f "$BATS_TEST_TMPDIR/exec_path.log" ]
+    grep -q "/nonsense/path/to/dolt --data-dir" "$BATS_TEST_TMPDIR/exec_path.log"
 }
 
 @test "ssh-transfer: clone succeeds while sql-server is running" {
@@ -416,7 +412,7 @@ MOCK
     # Push must fail when sql-server holds the lock.
     [ "$status" -ne 0 ]
     # The transfer command logs the real error to stderr; verify it.
-    grep -q "database is read only" "$BATS_TMPDIR/transfer_stderr.log"
+    grep -q "database is read only" "$BATS_TEST_TMPDIR/transfer_stderr.log"
 }
 
 @test "ssh-transfer: sql dolt_clone() via SSH URL" {

--- a/integration-tests/bats/ssh-transfer.bats
+++ b/integration-tests/bats/ssh-transfer.bats
@@ -8,53 +8,14 @@ load $BATS_TEST_DIRNAME/helper/query-server-common.bash
 setup() {
     cd "$BATS_TEST_TMPDIR"
     
-    # Create mock SSH script
+    # Create mock SSH script that executes the remote command locally.
+    # Real SSH runs its last argument as a command on the remote host.
+    # buildTransferCommand always passes the dolt transfer invocation as
+    # the final argument, so we just exec that.
     cat > "$BATS_TMPDIR/mock_ssh" <<'EOF'
 #!/bin/bash
-# Mock SSH script - executes dolt transfer locally
-# Parses: mock_ssh [options] [user@]host command args...
-
-COMMAND=""
-HOST=""
-SKIP_NEXT=false
-
-for arg in "$@"; do
-    if [[ "$SKIP_NEXT" == "true" ]]; then
-        SKIP_NEXT=false
-        continue
-    fi
-    
-    case "$arg" in
-        -*)
-            # Skip SSH options
-            if [[ "$arg" == "-o" ]] || [[ "$arg" == "-i" ]] || [[ "$arg" == "-p" ]]; then
-                SKIP_NEXT=true
-            fi
-            ;;
-        *@*)
-            # user@host format
-            HOST="${arg#*@}"
-            ;;
-        *)
-            if [[ -z "$HOST" ]] && [[ -z "$COMMAND" ]]; then
-                # First non-option arg is host
-                HOST="$arg"
-            else
-                # Rest is the command
-                if [[ -z "$COMMAND" ]]; then
-                    COMMAND="$arg"
-                else
-                    COMMAND="$COMMAND $arg"
-                fi
-            fi
-            ;;
-    esac
-done
-
-# Log and execute the command locally with proper stdio
+COMMAND="${@: -1}"
 echo "Mock SSH executing: $COMMAND" >> "$BATS_TMPDIR/mock_ssh.log"
-# Use exec to replace the shell process and preserve stdio connections.
-# Tee stderr to a log file so tests can verify server-side log output.
 exec $COMMAND 2> >(tee -a "$BATS_TMPDIR/transfer_stderr.log" >&2)
 EOF
     chmod +x "$BATS_TMPDIR/mock_ssh"


### PR DESCRIPTION
This change adds a new command, `dolt transfer` which is enables ssh remotes. It's similar to git upload-pack, in that it is intended to be executed by SSH with a few parameters in order to perform clone,push, and fetch operations.

Dolt's native replication is over a combination of gRPC and HTTP operations. `dolt transfer` uses SMUX to perform those transports over a bi-directional byte stream. We use the stdin / stdout of the SSH connection as that stream.

Fixes: https://github.com/dolthub/dolt/issues/1027