### PR TITLE
[no-release-notes] Fix `mysql-client-tests` entry point to report status of all `bats` runs

### DIFF
--- a/integration-tests/mysql-client-tests/mysql-client-tests-entrypoint.sh
+++ b/integration-tests/mysql-client-tests/mysql-client-tests-entrypoint.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+status=0
+run_bats() {
+  bats "$1" || status=1
+}
+
 echo "Updating dolt config for tests:"
 dolt config --global --add metrics.disabled true
 dolt config --global --add metrics.host localhost
@@ -7,10 +12,12 @@ dolt config --global --add user.name mysql-test-runner
 dolt config --global --add user.email mysql-test-runner@liquidata.co
 
 echo "Running mysql-client-tests:"
-bats /build/bin/bats/mysql-client-tests.bats
+run_bats /build/bin/bats/mysql-client-tests.bats
 
 # We run mariadb-binlog integration in this suite same as with mysqldump in mysql-client-tests.bats.
 # However, there's a bit more setup necessary to pipe the output from the dump in a mariadb client, so it's been
 # separated into a separate bats.
 echo "Running mariadb-binlog tests:"
-bats /build/bin/bats/mariadb-binlog.bats
+run_bats /build/bin/bats/mariadb-binlog.bats
+
+exit "$status"

--- a/integration-tests/mysql-client-tests/node/mariadb-connector.js
+++ b/integration-tests/mysql-client-tests/node/mariadb-connector.js
@@ -1,4 +1,4 @@
-import mariadb from "mariadb";
+import * as mariadb from "mariadb";
 import { getArgs } from "./helpers.js";
 
 const tests = [

--- a/integration-tests/mysql-client-tests/node/workbenchTests/branches.js
+++ b/integration-tests/mysql-client-tests/node/workbenchTests/branches.js
@@ -39,11 +39,8 @@ export const branchTests = [
     },
   },
   {
-    q: `CALL DOLT_COMMIT("-A", "-m", :commitMsg, "--author", :authorName)`,
-    p: {
-      commitMsg: "Create table test",
-      authorName: "Dolt <dolt@dolthub.com>",
-    },
+    q: `CALL DOLT_COMMIT('-A', '-m', ?, '--author', ?)`,
+    values: ["Create table test", "Dolt <dolt@dolthub.com>"],
     res: [{ hash: "" }],
   },
   {

--- a/integration-tests/mysql-client-tests/node/workbenchTests/merge.js
+++ b/integration-tests/mysql-client-tests/node/workbenchTests/merge.js
@@ -12,8 +12,8 @@ export const mergeTests = [
     res: [],
   },
   {
-    q: `CALL DOLT_MERGE(:branchName, "--no-ff", "-m", :commitMsg)`,
-    p: { branchName: "mybranch", commitMsg: "Merge mybranch into main" },
+    q: `CALL DOLT_MERGE(?, '--no-ff', '-m', ?)`,
+    values: ["mybranch", "Merge mybranch into main"],
     res: [{ hash: "", fast_forward: 0, conflicts: 0, message: "merge successful" }],
     matcher: mergeMatcher,
   },


### PR DESCRIPTION
The entry point was only reporting the failure of the last bats test ran. This left the failing `node` client tests unreported, these have also been fixed.