### PR TITLE
Fix nil pointer panic in workspace table Update and Delete methods

### DIFF
--- a/go/libraries/doltcore/sqle/dtables/workspace_table.go
+++ b/go/libraries/doltcore/sqle/dtables/workspace_table.go
@@ -148,6 +148,10 @@ func (wtm *WorkspaceTableModifier) statementComplete(ctx *sql.Context) error {
 }
 
 func (wtu *WorkspaceTableUpdater) Update(ctx *sql.Context, old sql.Row, new sql.Row) error {
+	if wtu.err != nil {
+		return *wtu.err
+	}
+
 	if old == nil || new == nil {
 		return fmt.Errorf("Runtime error: expected non-nil inputs to WorkspaceTableUpdater.Update")
 	}
@@ -210,6 +214,10 @@ func (wtd *WorkspaceTableDeleter) StatementBegin(ctx *sql.Context) {
 }
 
 func (wtd *WorkspaceTableDeleter) Delete(c *sql.Context, row sql.Row) error {
+	if wtd.err != nil {
+		return *wtd.err
+	}
+
 	if !wtd.modifiable {
 		return errors.New(fmt.Sprintf("%s table is not modifiable due to schema change", wtd.workspaceTableName))
 	}


### PR DESCRIPTION
When StatementBegin encounters an error (e.g., table not found in staging root), it stores the error in wtu.err but leaves tableWriter as nil. The Update and Delete methods were dereferencing tableWriter before checking if it was nil, causing a panic.

This fix adds an early return to check for errors from StatementBegin before attempting to use tableWriter, preventing the nil pointer dereference.