### PR TITLE
go: Optimize some SELECTs against `dolt_log` for some types of databases.

### DIFF
--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -1268,7 +1268,7 @@ type TagWithHash struct {
 // GetTagsWithHashes returns a list of objects containing Tags with their associated Commit's hashes
 func (ddb *DoltDB) GetTagsWithHashes(ctx context.Context) ([]TagWithHash, error) {
 	var refs []TagWithHash
-	err := ddb.VisitRefsOfType(ctx, tagsRefFilter, func(r ref.DoltRef, _ hash.Hash) error {
+	err := ddb.VisitRefsOfType(ctx, tagsRefFilter, func(r ref.DoltRef, h hash.Hash) error {
 		if tr, ok := r.(ref.TagRef); ok {
 			tag, err := ddb.ResolveTag(ctx, tr)
 			if err != nil {
@@ -1279,6 +1279,38 @@ func (ddb *DoltDB) GetTagsWithHashes(ctx context.Context) ([]TagWithHash, error)
 				return err
 			}
 			refs = append(refs, TagWithHash{tag, h})
+		}
+		return nil
+	})
+	return refs, err
+}
+
+func (ddb *DoltDB) GetTagRefsWithHashes(ctx context.Context) ([]RefWithHash, error) {
+	var refs []RefWithHash
+	resolveTagHash := func(id string) (hash.Hash, error) {
+		ds, err := ddb.db.GetDataset(ctx, id)
+		if err != nil {
+			return hash.Hash{}, errors.New("tag ref not found")
+		}
+		if !ds.HasHead() {
+			return hash.Hash{}, errors.New("tag ref not found")
+		}
+		if !ds.IsTag() {
+			return hash.Hash{}, errors.New("tagRef head is not a tag")
+		}
+		_, addr, err := ds.HeadTag()
+		if err != nil {
+			return hash.Hash{}, err
+		}
+		return addr, nil
+	}
+	err := ddb.VisitRefsOfType(ctx, tagsRefFilter, func(r ref.DoltRef, h hash.Hash) error {
+		if tr, ok := r.(ref.TagRef); ok {
+			addr, err := resolveTagHash(tr.String())
+			if err != nil {
+				return err
+			}
+			refs = append(refs, RefWithHash{tr, addr})
 		}
 		return nil
 	})

--- a/go/libraries/doltcore/sqle/dtablefunctions/dolt_log.go
+++ b/go/libraries/doltcore/sqle/dtablefunctions/dolt_log.go
@@ -613,14 +613,14 @@ func getCommitHashToRefs(ctx *sql.Context, ddb *doltdb.DoltDB, decoration string
 	}
 
 	// Get all tags
-	tags, err := ddb.GetTagsWithHashes(ctx)
+	tags, err := ddb.GetTagRefsWithHashes(ctx)
 	if err != nil {
 		return nil, err
 	}
 	for _, t := range tags {
-		tagName := t.Tag.GetDoltRef().String()
+		tagName := t.Ref.String()
 		if decoration != "full" {
-			tagName = t.Tag.Name // trim out "refs/tags/"
+			tagName = t.Ref.GetPath() // trim out "refs/tags/"
 		}
 		tagName = fmt.Sprintf("tag: %s", tagName)
 		cHashToRefs[t.Hash] = append(cHashToRefs[t.Hash], tagName)


### PR DESCRIPTION
Databases with lots of tags will see a performance improvement on analyzing queries which use `dolt_log`.

An internal cache has been increased in size. Database servers which regularly run queries against `dolt_log` which visit more than 10,000 commits will be able to take advantage of the larger cache and will see the performance of those queries improve.