### PR TITLE
fix: truncate trailing chars when casting string to time

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -208,3 +208,5 @@ require (
 )
 
 go 1.25.6
+
+replace github.com/dolthub/go-mysql-server => /tmp/go-mysql-server


### PR DESCRIPTION
Fixes #10000

Find the string-to-time conversion/cast implementation and modify it to try parsing a valid time prefix from the input string rather than rejecting the whole value when trailing garbage characters are present. Should also emit a warning like MySQL does.

Added a test case to cover the fix.