### PR TITLE
[no-release-notes] go: actions/remotes.go: SyncRoots: Pass a fully read chan pull.Stats, instead of trying to use Prog{Starter,Stopper}.

### DIFF
--- a/go/libraries/doltcore/env/actions/clone.go
+++ b/go/libraries/doltcore/env/actions/clone.go
@@ -261,17 +261,15 @@ func getSrcRefs(ctx context.Context, branch string, srcDB *doltdb.DoltDB, dEnv *
 func fullClone(ctx context.Context, srcDB *doltdb.DoltDB, dEnv *env.DoltEnv, srcRefHashes []doltdb.RefWithHash, branch, remoteName string, singleBranch bool) (*doltdb.Commit, error) {
 	eventCh := make(chan pull.TableFileEvent, 128)
 	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		clonePrint(eventCh)
-	}()
-
-	err := srcDB.Clone(ctx, dEnv.DoltDB(ctx), eventCh)
-
-	close(eventCh)
+	})
+	var err error
+	wg.Go(func() {
+		defer close(eventCh)
+		err = srcDB.Clone(ctx, dEnv.DoltDB(ctx), eventCh)
+	})
 	wg.Wait()
-
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/env/actions/remotes.go
+++ b/go/libraries/doltcore/env/actions/remotes.go
@@ -824,7 +824,7 @@ func canSyncRootsWithClone(ctx context.Context, srcDb, destDb *doltdb.DoltDB, de
 // TODO: this should read/write a backup lock file specific to the client who created the backup
 // TODO     to prevent "restoring a remote", "cloning a backup", "syncing a remote" and "pushing
 // TODO     a backup." SyncRoots has more destructive potential than push right now.
-func SyncRoots(ctx context.Context, srcDb, destDb *doltdb.DoltDB, tempTableDir string, progStarter ProgStarter, progStopper ProgStopper) error {
+func SyncRoots(ctx context.Context, srcDb, destDb *doltdb.DoltDB, tempTableDir string, statsCh chan pull.Stats) error {
 	srcRoot, err := srcDb.NomsRoot(ctx)
 	if err != nil {
 		return nil
@@ -839,15 +839,6 @@ func SyncRoots(ctx context.Context, srcDb, destDb *doltdb.DoltDB, tempTableDir s
 		return pull.ErrDBUpToDate
 	}
 
-	newCtx, cancelFunc := context.WithCancel(ctx)
-	wg, statsCh := progStarter(newCtx)
-	defer func() {
-		progStopper(cancelFunc, wg, statsCh)
-		if err == nil {
-			cli.Println()
-		}
-	}()
-
 	canClone, err := canSyncRootsWithClone(ctx, srcDb, destDb, destRoot)
 	if err != nil {
 		return err
@@ -855,53 +846,49 @@ func SyncRoots(ctx context.Context, srcDb, destDb *doltdb.DoltDB, tempTableDir s
 
 	if canClone {
 		tfCh := make(chan pull.TableFileEvent)
-		go func() {
+		var wg sync.WaitGroup
+		wg.Go(func() {
 			start := time.Now()
 			stats := make(map[string]iohelp.ReadStats)
-			for {
-				select {
-				case tfe, ok := <-tfCh:
-					if !ok {
-						return
-					}
-					if tfe.EventType == pull.DownloadStats {
-						stats[tfe.TableFiles[0].FileID()] = tfe.Stats[0]
+			for tfe := range tfCh {
+				if tfe.EventType == pull.DownloadStats {
+					stats[tfe.TableFiles[0].FileID()] = tfe.Stats[0]
 
-						totalSentBytes := uint64(0)
-						totalBytes := uint64(0)
+					totalSentBytes := uint64(0)
+					totalBytes := uint64(0)
 
-						for _, v := range stats {
-							if v.Percent > 0.001 {
-								totalSentBytes += v.Read
-								totalBytes += uint64(float64(v.Read) / v.Percent)
-							}
-						}
-
-						// We fake some of these values.
-						toEmit := pull.Stats{
-							FinishedSendBytes: totalSentBytes,
-							BufferedSendBytes: totalSentBytes,
-							SendBytesPerSec:   float64(totalSentBytes) / (time.Since(start).Seconds()),
-
-							// estimate the number of chunks based on an average chunk size of 4096.
-							TotalSourceChunks:   totalBytes / 4096,
-							FetchedSourceChunks: totalSentBytes / 4096,
-
-							FetchedSourceBytes:       totalSentBytes,
-							FetchedSourceBytesPerSec: float64(totalSentBytes) / (time.Since(start).Seconds()),
-						}
-
-						// TODO: This looks wrong without a ctx.Done() select, but Puller does not conditionally send here...
-						select {
-						case statsCh <- toEmit:
+					for _, v := range stats {
+						if v.Percent > 0.001 {
+							totalSentBytes += v.Read
+							totalBytes += uint64(float64(v.Read) / v.Percent)
 						}
 					}
+
+					// We fake some of these values.
+					toEmit := pull.Stats{
+						FinishedSendBytes: totalSentBytes,
+						BufferedSendBytes: totalSentBytes,
+						SendBytesPerSec:   float64(totalSentBytes) / (time.Since(start).Seconds()),
+
+						// estimate the number of chunks based on an average chunk size of 4096.
+						TotalSourceChunks:   totalBytes / 4096,
+						FetchedSourceChunks: totalSentBytes / 4096,
+
+						FetchedSourceBytes:       totalSentBytes,
+						FetchedSourceBytesPerSec: float64(totalSentBytes) / (time.Since(start).Seconds()),
+					}
+
+					// TODO: This looks wrong without a ctx.Done() select, but Puller does not conditionally send here...
+					statsCh <- toEmit
 				}
 			}
-		}()
-
-		err := srcDb.Clone(ctx, destDb, tfCh)
-		close(tfCh)
+		})
+		var err error
+		wg.Go(func() {
+			defer close(tfCh)
+			err = srcDb.Clone(ctx, destDb, tfCh)
+		})
+		wg.Wait()
 		if err == nil {
 			return nil
 		}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_backup.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_backup.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/dolthub/go-mysql-server/sql"
 
@@ -268,7 +269,22 @@ func doltBackupRestore(ctx *sql.Context, dbData env.DbData[*sql.Context], dsess 
 	}
 
 	// Unlike CloneDatabaseFromRemote which clones tracking branches (remote refs), we need all local changes.
-	return actions.SyncRoots(ctx, remoteDb, newDb.DbData().Ddb, fileSys.TempDir(), runProgFuncs, stopProgFuncs)
+	statsCh := make(chan pull.Stats)
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for range statsCh {
+		}
+	})
+	wg.Go(func() {
+		defer close(statsCh)
+		err = actions.SyncRoots(ctx, remoteDb, newDb.DbData().Ddb, fileSys.TempDir(), statsCh)
+	})
+	wg.Wait()
+	if err == nil {
+		// XXX: Old SyncRoots ProgStarter behavior.
+		cli.Println()
+	}
+	return err
 }
 
 // syncRemote syncs the roots from |dbData| to the remote specified by |remote|. It prepares the remote database
@@ -295,7 +311,21 @@ func syncRemote(ctx *sql.Context, dbData env.DbData[*sql.Context], dsess *dsess.
 		return err
 	}
 
-	err = actions.SyncRoots(ctx, dbData.Ddb, destDb, dsess.GetFileSystem().TempDir(), runProgFuncs, stopProgFuncs)
+	statsCh := make(chan pull.Stats)
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for range statsCh {
+		}
+	})
+	wg.Go(func() {
+		defer close(statsCh)
+		err = actions.SyncRoots(ctx, dbData.Ddb, destDb, dsess.GetFileSystem().TempDir(), statsCh)
+	})
+	wg.Wait()
+	if err == nil {
+		// XXX: Old SyncRoots ProgStarter behavior.
+		cli.Println()
+	}
 	if err != nil && !errors.Is(err, pull.ErrDBUpToDate) {
 		return err
 	}


### PR DESCRIPTION
Existing implementations of and uses of Prog{Starter,Stopper} are generally incorrect.