### PR TITLE
fix: use redirect URL to fetch latest Dolt version

### DIFF
--- a/docker/serverDockerfile
+++ b/docker/serverDockerfile
@@ -43,15 +43,13 @@ FROM base AS download-binary
 ARG DOLT_VERSION
 RUN if [ "$DOLT_VERSION" = "latest" ]; then \
         # Fetch latest version number from GitHub API
-        ACTUAL_VERSION=$(curl -sI https://github.com/dolthub/dolt/releases/latest \
+        DOLT_VERSION=$(curl -sI https://github.com/dolthub/dolt/releases/latest \
             | grep -i location \
             | sed 's|.*/v||' \
             | tr -d '[:space:]'); \
-    else \
-        ACTUAL_VERSION=$DOLT_VERSION; \
     fi && \
-    if [ "$ACTUAL_VERSION" != "source" ]; then \
-        curl -L "https://github.com/dolthub/dolt/releases/download/v${ACTUAL_VERSION}/install.sh" | bash; \
+    if [ "$DOLT_VERSION" != "source" ]; then \
+        curl -L "https://github.com/dolthub/dolt/releases/download/v${DOLT_VERSION}/install.sh" | bash; \
     fi
 
 

--- a/docker/serverDockerfile
+++ b/docker/serverDockerfile
@@ -43,13 +43,16 @@ FROM base AS download-binary
 ARG DOLT_VERSION
 RUN if [ "$DOLT_VERSION" = "latest" ]; then \
         # Fetch latest version number from GitHub API
-        DOLT_VERSION=$(curl -s https://api.github.com/repos/dolthub/dolt/releases/latest \
+        # Use a new variable name so Docker doesn't overwrite it
+        ACTUAL_VERSION=$(curl -s https://api.github.com/repos/dolthub/dolt/releases/latest \
             | grep '"tag_name"' \
             | cut -d'"' -f4 \
             | sed 's/^v//'); \
+    else \
+        ACTUAL_VERSION=$DOLT_VERSION; \
     fi && \
-    if [ "$DOLT_VERSION" != "source" ]; then \
-        curl -L "https://github.com/dolthub/dolt/releases/download/v${DOLT_VERSION}/install.sh" | bash; \
+    if [ "$ACTUAL_VERSION" != "source" ]; then \
+        curl -L "https://github.com/dolthub/dolt/releases/download/v${ACTUAL_VERSION}/install.sh" | bash; \
     fi
 
 

--- a/docker/serverDockerfile
+++ b/docker/serverDockerfile
@@ -43,16 +43,13 @@ FROM base AS download-binary
 ARG DOLT_VERSION
 RUN if [ "$DOLT_VERSION" = "latest" ]; then \
         # Fetch latest version number from GitHub API
-        # Use a new variable name so Docker doesn't overwrite it
-        ACTUAL_VERSION=$(curl -s https://api.github.com/repos/dolthub/dolt/releases/latest \
+        DOLT_VERSION=$(curl -s https://api.github.com/repos/dolthub/dolt/releases/latest \
             | grep '"tag_name"' \
             | cut -d'"' -f4 \
             | sed 's/^v//'); \
-    else \
-        ACTUAL_VERSION=$DOLT_VERSION; \
     fi && \
-    if [ "$ACTUAL_VERSION" != "source" ]; then \
-        curl -L "https://github.com/dolthub/dolt/releases/download/v${ACTUAL_VERSION}/install.sh" | bash; \
+    if [ "$DOLT_VERSION" != "source" ]; then \
+        curl -L "https://github.com/dolthub/dolt/releases/download/v${DOLT_VERSION}/install.sh" | bash; \
     fi
 
 

--- a/docker/serverDockerfile
+++ b/docker/serverDockerfile
@@ -43,13 +43,15 @@ FROM base AS download-binary
 ARG DOLT_VERSION
 RUN if [ "$DOLT_VERSION" = "latest" ]; then \
         # Fetch latest version number from GitHub API
-        DOLT_VERSION=$(curl -sI https://github.com/dolthub/dolt/releases/latest \
+        ACTUAL_VERSION=$(curl -sI https://github.com/dolthub/dolt/releases/latest \
             | grep -i location \
             | sed 's|.*/v||' \
             | tr -d '[:space:]'); \
+    else \
+        ACTUAL_VERSION=$DOLT_VERSION; \
     fi && \
-    if [ "$DOLT_VERSION" != "source" ]; then \
-        curl -L "https://github.com/dolthub/dolt/releases/download/v${DOLT_VERSION}/install.sh" | bash; \
+    if [ "$ACTUAL_VERSION" != "source" ]; then \
+        curl -L "https://github.com/dolthub/dolt/releases/download/v${ACTUAL_VERSION}/install.sh" | bash; \
     fi
 
 

--- a/docker/serverDockerfile
+++ b/docker/serverDockerfile
@@ -43,10 +43,10 @@ FROM base AS download-binary
 ARG DOLT_VERSION
 RUN if [ "$DOLT_VERSION" = "latest" ]; then \
         # Fetch latest version number from GitHub API
-        DOLT_VERSION=$(curl -s https://api.github.com/repos/dolthub/dolt/releases/latest \
-            | grep '"tag_name"' \
-            | cut -d'"' -f4 \
-            | sed 's/^v//'); \
+        DOLT_VERSION=$(curl -sI https://github.com/dolthub/dolt/releases/latest \
+            | grep -i location \
+            | sed 's|.*/v||' \
+            | tr -d '[:space:]'); \
     fi && \
     if [ "$DOLT_VERSION" != "source" ]; then \
         curl -L "https://github.com/dolthub/dolt/releases/download/v${DOLT_VERSION}/install.sh" | bash; \

--- a/integration-tests/bats/docker-entrypoint.bats
+++ b/integration-tests/bats/docker-entrypoint.bats
@@ -925,8 +925,6 @@ EOF
 
 # bats test_tags=no_lambda
 @test "docker-entrypoint: latest binary build from dolt directory" {
-  skip "this is way too flaky in CI and needs investigation into why/ how to stabilize"
-
   BATS_TEST_RETRIES=5 # GitHub ver. retrieval can sometimes return Not Found on CI, could be some form of rate limiting
   cname="${TEST_PREFIX}latest-docker"
 

--- a/integration-tests/bats/docker-entrypoint.bats
+++ b/integration-tests/bats/docker-entrypoint.bats
@@ -929,7 +929,7 @@ EOF
   cname="${TEST_PREFIX}latest-docker"
 
   LATEST_IMAGE="dolt-entrypoint-latest:test"
-  EXPECTED_VERSION=$(curl -s https://api.github.com/repos/dolthub/dolt/releases/latest | grep '"tag_name"' | cut -d'"' -f4 | sed 's/^v//')
+  EXPECTED_VERSION=$(curl -sI https://github.com/dolthub/dolt/releases/latest | grep -i location | sed 's|.*/v||' | tr -d '[:space:]')
   cd "$WORKSPACE_ROOT/dolt"
   docker build --no-cache -f docker/serverDockerfile --build-arg DOLT_VERSION=latest -t "$LATEST_IMAGE" .
 


### PR DESCRIPTION
I saw my PR (#10591) failing to this test.

~~I believe docker is expanding the `DOLT_VERSION` ARG before bash execution. So when set to `latest`, the dynamically fetched version number was being overwritten, causing the script to try and download `/vlatest/install.sh` and fails.~~

~~This commit introduces an internal `ACTUAL_VERSION` variable in the bash script to bypass Docker's string substitution.~~

The `download-binary` stage fetches the latest Dolt version from the GitHub API. In CI, unauthenticated requests to the GitHub API can be rate limited, causing the request to fail silently. The version variable ends up empty, the install script URL is malformed, and the build fails with a confusing `Not: command not found` error.

This is a pre-existing issue unrelated to my other changes.

Hopefully this solves the mystery of the flakey test #10625