### PR TITLE
go: Optimize backups to more often transit existing table files instead of doing a merkle dag walk to push missing chunks.

### DIFF
--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -2166,10 +2166,11 @@ func (ddb *DoltDB) TableFileStoreHasJournal(ctx context.Context) (bool, error) {
 	if !ok {
 		return false, errors.New("unsupported operation, doltDB.TableFileStoreHasManifest on non-TableFileStore")
 	}
-	_, tableFiles, _, err := tableFileStore.Sources(ctx)
+	tfsources, err := tableFileStore.Sources(ctx)
 	if err != nil {
 		return false, err
 	}
+	tableFiles := tfsources.TableFiles
 	for _, tableFile := range tableFiles {
 		if tableFile.FileID() == chunks.JournalFileID {
 			return true, nil

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -2047,10 +2047,12 @@ func (ddb *DoltDB) getAddrs(c chunks.Chunk) chunks.GetAddrsCb {
 	}
 }
 
-func (ddb *DoltDB) Clone(ctx context.Context, destDB *DoltDB, eventCh chan<- pull.TableFileEvent) error {
-	return pull.Clone(ctx, datas.ChunkStoreFromDatabase(ddb.db),
+func (ddb *DoltDB) Clone(ctx context.Context, tempTableDir string, destDB *DoltDB, eventCh chan<- pull.TableFileEvent) error {
+	return pull.Clone(ctx,
+		datas.ChunkStoreFromDatabase(ddb.db),
 		datas.ChunkStoreFromDatabase(destDB.db),
 		ddb.getAddrs,
+		tempTableDir,
 		eventCh)
 }
 
@@ -2159,24 +2161,6 @@ func (ddb *DoltDB) StoreSizes(ctx context.Context) (StoreSizes, error) {
 			TotalBytes: totalSz,
 		}, nil
 	}
-}
-
-func (ddb *DoltDB) TableFileStoreHasJournal(ctx context.Context) (bool, error) {
-	tableFileStore, ok := datas.ChunkStoreFromDatabase(ddb.db).(chunks.TableFileStore)
-	if !ok {
-		return false, errors.New("unsupported operation, doltDB.TableFileStoreHasManifest on non-TableFileStore")
-	}
-	tfsources, err := tableFileStore.Sources(ctx)
-	if err != nil {
-		return false, err
-	}
-	tableFiles := tfsources.TableFiles
-	for _, tableFile := range tableFiles {
-		if tableFile.FileID() == chunks.JournalFileID {
-			return true, nil
-		}
-	}
-	return false, nil
 }
 
 // DatasetsByRootHash returns the DatasetsMap for the specified root |hashof|.

--- a/go/libraries/doltcore/env/actions/clone.go
+++ b/go/libraries/doltcore/env/actions/clone.go
@@ -260,14 +260,17 @@ func getSrcRefs(ctx context.Context, branch string, srcDB *doltdb.DoltDB, dEnv *
 
 func fullClone(ctx context.Context, srcDB *doltdb.DoltDB, dEnv *env.DoltEnv, srcRefHashes []doltdb.RefWithHash, branch, remoteName string, singleBranch bool) (*doltdb.Commit, error) {
 	eventCh := make(chan pull.TableFileEvent, 128)
+	tfdir, err := dEnv.TempTableFilesDir()
+	if err != nil {
+		return nil, err
+	}
 	wg := &sync.WaitGroup{}
 	wg.Go(func() {
 		clonePrint(eventCh)
 	})
-	var err error
 	wg.Go(func() {
 		defer close(eventCh)
-		err = srcDB.Clone(ctx, dEnv.DoltDB(ctx), eventCh)
+		err = srcDB.Clone(ctx, tfdir, dEnv.DoltDB(ctx), eventCh)
 	})
 	wg.Wait()
 	if err != nil {

--- a/go/libraries/doltcore/env/actions/remotes.go
+++ b/go/libraries/doltcore/env/actions/remotes.go
@@ -329,11 +329,6 @@ func FetchTag(ctx context.Context, tempTableDir string, srcDB, destDB *doltdb.Do
 	return destDB.PullChunks(ctx, tempTableDir, srcDB, []hash.Hash{addr}, statsCh, nil)
 }
 
-// Clone pulls all data from a remote source database to a local destination database.
-func Clone(ctx context.Context, srcDB, destDB *doltdb.DoltDB, eventCh chan<- pull.TableFileEvent) error {
-	return srcDB.Clone(ctx, destDB, eventCh)
-}
-
 // FetchFollowTags fetches all tags from the source DB whose commits have already
 // been fetched into the destination DB.
 // todo: potentially too expensive to iterate over all srcDB tags
@@ -790,15 +785,21 @@ func pruneBranches[C doltdb.Context](ctx context.Context, dbData env.DbData[C], 
 	return nil
 }
 
-// SyncRoots is going to copy the root hash of the database from srcDb to destDb.
-// We can do this |Clone| if (1) destDb is empty, (2) destDb and srcDb are both
-// |TableFileStore|s, and (3) srcDb does *not* have a journal file. The most
-// common scenario where this occurs is when we are restoring a backup.
+// SyncRoots is going to copy the root hash of the database from srcDb
+// to destDb.  Technically we should always be able to do this by
+// copying table files from the source. If we see a journal file in
+// the srcDb, we can convert it to table file on the fly. If we have a
+// non-empty destDb, it does not technically matter - the full set of
+// table files in the source are all we need at the end of the
+// sync. However, it might be more efficient to Pull instead of copy
+// table files if there is a non-empty dest.
 //
-// The journal's interaction with TableFileStore is not great currently ---
-// when accessing a journal file through TableFileStore, the Reader() should in
-// reality return something which is going to result in reading an actual table
-// file. For now, we avoid the |Clone| path when the journal file is present.
+// For now, we only clone into an empty dest. We use some heuristics
+// on the size of the source store vs. the source journal, if there is
+// one, to decide if we use clone or merkle dag walk.
+//
+// Either way, both dest and source need to be table file stores,
+// since otherwise we need to pull chunks individually.
 func canSyncRootsWithClone(ctx context.Context, srcDb, destDb *doltdb.DoltDB, destDbRoot hash.Hash) (bool, error) {
 	if !destDbRoot.IsEmpty() {
 		return false, nil
@@ -809,11 +810,19 @@ func canSyncRootsWithClone(ctx context.Context, srcDb, destDb *doltdb.DoltDB, de
 	if !destDb.IsTableFileStore() {
 		return false, nil
 	}
-	srcHasJournal, err := srcDb.TableFileStoreHasJournal(ctx)
+	sizes, err := srcDb.StoreSizes(ctx)
 	if err != nil {
 		return false, err
 	}
-	if srcHasJournal {
+	if sizes.JournalBytes >= (sizes.TotalBytes/5) {
+		// The journal is more than 20% of the entire source.
+		// For now we do a merkle walk instead of converting
+		// all the chunks.
+		return false, nil
+	}
+	if sizes.JournalBytes > 16 * 1024 * 1024 * 1024 {
+		// The journal is larger than 16GB.  For now we do a
+		// merkle walk instead of converting all the chunks.
 		return false, nil
 	}
 	return true, nil
@@ -886,7 +895,7 @@ func SyncRoots(ctx context.Context, srcDb, destDb *doltdb.DoltDB, tempTableDir s
 		var err error
 		wg.Go(func() {
 			defer close(tfCh)
-			err = srcDb.Clone(ctx, destDb, tfCh)
+			err = srcDb.Clone(ctx, tempTableDir, destDb, tfCh)
 		})
 		wg.Wait()
 		if err == nil {

--- a/go/libraries/doltcore/env/actions/remotes.go
+++ b/go/libraries/doltcore/env/actions/remotes.go
@@ -814,13 +814,13 @@ func canSyncRootsWithClone(ctx context.Context, srcDb, destDb *doltdb.DoltDB, de
 	if err != nil {
 		return false, err
 	}
-	if sizes.JournalBytes >= (sizes.TotalBytes/5) {
+	if sizes.JournalBytes >= (sizes.TotalBytes / 5) {
 		// The journal is more than 20% of the entire source.
 		// For now we do a merkle walk instead of converting
 		// all the chunks.
 		return false, nil
 	}
-	if sizes.JournalBytes > 16 * 1024 * 1024 * 1024 {
+	if sizes.JournalBytes > 16*1024*1024*1024 {
 		// The journal is larger than 16GB.  For now we do a
 		// merkle walk instead of converting all the chunks.
 		return false, nil

--- a/go/libraries/doltcore/remotesrv/grpc.go
+++ b/go/libraries/doltcore/remotesrv/grpc.go
@@ -569,11 +569,12 @@ func (rs *RemoteChunkStore) ListTableFiles(ctx context.Context, req *remotesapi.
 		return nil, err
 	}
 
-	root, tables, appendixTables, err := cs.Sources(ctx)
+	tfsources, err := cs.Sources(ctx)
 	if err != nil {
 		logger.WithError(err).Error("error getting chunk store Sources")
 		return nil, status.Error(codes.Internal, "failed to get sources")
 	}
+	root, tables, appendixTables := tfsources.Root, tfsources.TableFiles, tfsources.AppendixTableFiles
 
 	md, _ := metadata.FromIncomingContext(ctx)
 

--- a/go/libraries/doltcore/remotestorage/chunk_store.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store.go
@@ -1130,19 +1130,23 @@ func (dcs *DoltChunkStore) PruneTableFiles(ctx context.Context) error {
 
 // Sources retrieves the current root hash, a list of all the table files (which may include appendix table files)
 // and a list of only appendix table files
-func (dcs *DoltChunkStore) Sources(ctx context.Context) (hash.Hash, []chunks.TableFile, []chunks.TableFile, error) {
+func (dcs *DoltChunkStore) Sources(ctx context.Context) (chunks.TableFileSources, error) {
 	id, token := dcs.getRepoId()
 	req := &remotesapi.ListTableFilesRequest{RepoId: id, RepoPath: dcs.repoPath, RepoToken: token}
 	resp, err := dcs.csClient.ListTableFiles(ctx, req)
 	if err != nil {
-		return hash.Hash{}, nil, nil, NewRpcError(err, "ListTableFiles", dcs.host, req)
+		return chunks.TableFileSources{}, NewRpcError(err, "ListTableFiles", dcs.host, req)
 	}
 	if resp.RepoToken != "" {
 		dcs.repoToken.Store(resp.RepoToken)
 	}
 	sourceFiles := getTableFiles(dcs, resp.TableFileInfo)
 	appendixFiles := getTableFiles(dcs, resp.AppendixTableFileInfo)
-	return hash.New(resp.RootHash), sourceFiles, appendixFiles, nil
+	return chunks.TableFileSources{
+		Root:               hash.New(resp.RootHash),
+		TableFiles:         sourceFiles,
+		AppendixTableFiles: appendixFiles,
+	}, nil
 }
 
 func getTableFiles(dcs *DoltChunkStore, infoList []*remotesapi.TableFileInfo) []chunks.TableFile {

--- a/go/libraries/doltcore/remotestorage/chunk_store.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store.go
@@ -958,6 +958,7 @@ func (dcs *DoltChunkStore) uploadTableFileWithRetries(ctx context.Context, table
 		if err != nil {
 			return err
 		}
+		defer body.Close()
 
 		tbfd := &remotesapi.TableFileDetails{
 			Id:            tableFileId[:],

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_backup.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_backup.go
@@ -298,7 +298,7 @@ func syncRemote(ctx *sql.Context, dbData env.DbData[*sql.Context], dsess *dsess.
 		return err
 	}
 
-	params := map[string]interface{}{}
+	params := make(map[string]any, len(remote.Params))
 	for k, v := range remote.Params {
 		params[k] = v
 	}

--- a/go/libraries/utils/iohelp/read_with_stats.go
+++ b/go/libraries/utils/iohelp/read_with_stats.go
@@ -86,7 +86,6 @@ func (rws *ReaderWithStats) Close() error {
 	if closer, ok := rws.rd.(io.Closer); ok {
 		return closer.Close()
 	}
-
 	return nil
 }
 

--- a/go/store/chunks/tablefilestore.go
+++ b/go/store/chunks/tablefilestore.go
@@ -70,7 +70,7 @@ type TableFileStoreOps struct {
 type TableFileStore interface {
 	// Sources retrieves the current root hash, a list of all the table files (which may include appendix table files),
 	// and a second list containing only appendix table files.
-	Sources(ctx context.Context) (hash.Hash, []TableFile, []TableFile, error)
+	Sources(ctx context.Context) (TableFileSources, error)
 
 	// Size  returns the total size, in bytes, of the table files in this Store.
 	Size(ctx context.Context) (uint64, error)
@@ -89,4 +89,10 @@ type TableFileStore interface {
 
 	// SupportedOperations returns a description of the support TableFile operations. Some stores only support reading table files, not writing.
 	SupportedOperations() TableFileStoreOps
+}
+
+type TableFileSources struct {
+	Root               hash.Hash
+	TableFiles         []TableFile
+	AppendixTableFiles []TableFile
 }

--- a/go/store/datas/pull/clone.go
+++ b/go/store/datas/pull/clone.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/cenkalti/backoff/v4"
 	"golang.org/x/sync/errgroup"
@@ -27,12 +28,13 @@ import (
 	"github.com/dolthub/dolt/go/libraries/utils/iohelp"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/dolthub/dolt/go/store/nbs"
 )
 
 var ErrNoData = errors.New("no data")
 var ErrCloneUnsupported = errors.New("clone unsupported")
 
-func Clone(ctx context.Context, srcCS, sinkCS chunks.ChunkStore, getAddrs chunks.GetAddrsCurry, eventCh chan<- TableFileEvent) error {
+func Clone(ctx context.Context, srcCS, sinkCS chunks.ChunkStore, getAddrs chunks.GetAddrsCurry, tempTableDir string, eventCh chan<- TableFileEvent) error {
 	srcTS, srcOK := srcCS.(chunks.TableFileStore)
 
 	if !srcOK {
@@ -55,7 +57,7 @@ func Clone(ctx context.Context, srcCS, sinkCS chunks.ChunkStore, getAddrs chunks
 		return fmt.Errorf("%w: sink db is not a Table File Store", ErrCloneUnsupported)
 	}
 
-	return clone(ctx, srcTS, sinkTS, sinkCS, getAddrs, eventCh)
+	return clone(ctx, srcTS, sinkTS, sinkCS, getAddrs, tempTableDir, eventCh)
 }
 
 type CloneTableFileEvent int
@@ -93,7 +95,7 @@ func mapTableFiles(tblFiles []chunks.TableFile) ([]string, map[string]chunks.Tab
 
 const concurrentTableFileDownloads = 3
 
-func clone(ctx context.Context, srcTS, sinkTS chunks.TableFileStore, sinkCS chunks.ChunkStore, getAddrs chunks.GetAddrsCurry, eventCh chan<- TableFileEvent) error {
+func clone(ctx context.Context, srcTS, sinkTS chunks.TableFileStore, sinkCS chunks.ChunkStore, getAddrs chunks.GetAddrsCurry, tempTableDir string, eventCh chan<- TableFileEvent) error {
 	sources, err := srcTS.Sources(ctx)
 	if err != nil {
 		return err
@@ -120,7 +122,7 @@ func clone(ctx context.Context, srcTS, sinkTS chunks.TableFileStore, sinkCS chun
 	download := func(ctx context.Context) error {
 		sem := semaphore.NewWeighted(concurrentTableFileDownloads)
 		eg, ctx := errgroup.WithContext(ctx)
-		for i := 0; i < len(desiredFiles); i++ {
+		for i := range desiredFiles {
 			if completed[i] {
 				continue
 			}
@@ -129,11 +131,10 @@ func clone(ctx context.Context, srcTS, sinkTS chunks.TableFileStore, sinkCS chun
 				// return the error from wg.Wait() below.
 				break
 			}
-			idx := i
 			eg.Go(func() (err error) {
 				defer sem.Release(1)
 
-				fileID := desiredFiles[idx]
+				fileID := desiredFiles[i]
 				tblFile, ok := fileIDToTF[fileID]
 				if !ok {
 					// conjoin happened during clone
@@ -142,13 +143,18 @@ func clone(ctx context.Context, srcTS, sinkTS chunks.TableFileStore, sinkCS chun
 
 				report(TableFileEvent{EventType: DownloadStart, TableFiles: []chunks.TableFile{tblFile}})
 
-				err = sinkTS.WriteTableFile(ctx, tblFile.FileID()+tblFile.LocationSuffix(), tblFile.SplitOffset(), tblFile.NumChunks(), nil, func() (io.ReadCloser, uint64, error) {
+				// XXX: This is not the best place to do this conversion.
+				// Some issues:
+				// 1) We have to reconvert the file if this conversion gets retried.
+				// 2) The stats we post through rdStats only reflect the initial read, instead
+				// of reflecting the read + (approximate) upload progress, which the other
+				// branch handles.
+				if tblFile.FileID() == chunks.JournalFileID {
 					rd, contentLength, err := tblFile.Open(ctx)
 					if err != nil {
-						return nil, 0, err
+						return err
 					}
 					rdStats := iohelp.NewReaderWithStats(rd, int64(contentLength))
-
 					rdStats.Start(func(s iohelp.ReadStats) {
 						report(TableFileEvent{
 							EventType:  DownloadStats,
@@ -156,17 +162,72 @@ func clone(ctx context.Context, srcTS, sinkTS chunks.TableFileStore, sinkCS chun
 							Stats:      []iohelp.ReadStats{s},
 						})
 					})
+					writer, uploadFileID, err := convertJournalToTableFile(ctx, rdStats, 0, tempTableDir)
+					rdStats.Close()
+					if err != nil {
+						return err
+					}
+					defer writer.Cancel()
+					splitOff, err := writer.ChunkDataLength()
+					if err != nil {
+						return err
+					}
+					err = sinkTS.WriteTableFile(ctx, uploadFileID, splitOff, writer.ChunkCount(), writer.GetMD5(), func() (io.ReadCloser, uint64, error) {
+						rdr, err := writer.Reader()
+						if err != nil {
+							return nil, 0, err
+						}
+						return rdr, writer.FullLength(), nil
+					})
+					if err != nil {
+						report(TableFileEvent{EventType: DownloadFailed, TableFiles: []chunks.TableFile{tblFile}})
+						return err
+					} else {
+						report(TableFileEvent{EventType: DownloadSuccess, TableFiles: []chunks.TableFile{tblFile}})
+						completed[i] = true
 
-					return rdStats, contentLength, nil
-				})
-				if err != nil {
-					report(TableFileEvent{EventType: DownloadFailed, TableFiles: []chunks.TableFile{tblFile}})
-					return err
+						// XXX: A gross hack. fileIDToNumChunks is our input to AddTableFiles. Update it here
+						// so we add the uploaded archive file to the store, not a non-existant table file with
+						// the `vvv...` name.
+						//
+						// We can mutate fileIDToNumChunks safely here because we are the only goroutine
+						// which will ever mutate it and it is not read until after the eg.Wait() on the errgroup
+						// in which we are running.
+						delete(fileIDToNumChunks, chunks.JournalFileID)
+						fileIDToNumChunks[strings.TrimSuffix(uploadFileID, nbs.ArchiveFileSuffix)] = writer.ChunkCount()
+
+						return nil
+					}
+				} else {
+					uploadFileID := tblFile.FileID() + tblFile.LocationSuffix()
+					splitOff := tblFile.SplitOffset()
+					numChunks := tblFile.NumChunks()
+					err = sinkTS.WriteTableFile(ctx, uploadFileID, splitOff, numChunks, nil, func() (io.ReadCloser, uint64, error) {
+						rd, contentLength, err := tblFile.Open(ctx)
+						if err != nil {
+							return nil, 0, err
+						}
+						rdStats := iohelp.NewReaderWithStats(rd, int64(contentLength))
+
+						rdStats.Start(func(s iohelp.ReadStats) {
+							report(TableFileEvent{
+								EventType:  DownloadStats,
+								TableFiles: []chunks.TableFile{tblFile},
+								Stats:      []iohelp.ReadStats{s},
+							})
+						})
+
+						return rdStats, contentLength, nil
+					})
+					if err != nil {
+						report(TableFileEvent{EventType: DownloadFailed, TableFiles: []chunks.TableFile{tblFile}})
+						return err
+					} else {
+						report(TableFileEvent{EventType: DownloadSuccess, TableFiles: []chunks.TableFile{tblFile}})
+						completed[i] = true
+						return nil
+					}
 				}
-
-				report(TableFileEvent{EventType: DownloadSuccess, TableFiles: []chunks.TableFile{tblFile}})
-				completed[idx] = true
-				return nil
 			})
 		}
 
@@ -269,6 +330,25 @@ func clone(ctx context.Context, srcTS, sinkTS chunks.TableFileStore, sinkCS chun
 		panic(fmt.Sprintf("runtime error: successful root update with error: %v", err))
 	}
 	return err
+}
+
+func convertJournalToTableFile(ctx context.Context, readCloser io.ReadCloser, off int64, tmpDir string) (*nbs.ArchiveStreamWriter, string, error) {
+	writer, err := nbs.NewArchiveStreamWriter(tmpDir)
+	if err != nil {
+		return nil, "", err
+	}
+	err = nbs.VisitJournalReaderChunks(ctx, readCloser, off, func(cb nbs.CompressedChunk) error {
+		_, err := writer.AddChunk(cb)
+		return err
+	})
+	if err != nil {
+		return nil, "", errors.Join(err, writer.Cancel())
+	}
+	_, name, err := writer.Finish()
+	if err != nil {
+		return nil, "", errors.Join(err, writer.Cancel())
+	}
+	return writer, name, nil
 }
 
 func filterAppendicesFromSourceFiles(appendixFiles []chunks.TableFile, sourceFiles []chunks.TableFile) []chunks.TableFile {

--- a/go/store/datas/pull/clone.go
+++ b/go/store/datas/pull/clone.go
@@ -94,10 +94,13 @@ func mapTableFiles(tblFiles []chunks.TableFile) ([]string, map[string]chunks.Tab
 const concurrentTableFileDownloads = 3
 
 func clone(ctx context.Context, srcTS, sinkTS chunks.TableFileStore, sinkCS chunks.ChunkStore, getAddrs chunks.GetAddrsCurry, eventCh chan<- TableFileEvent) error {
-	root, sourceFiles, appendixFiles, err := srcTS.Sources(ctx)
+	sources, err := srcTS.Sources(ctx)
 	if err != nil {
 		return err
 	}
+	root := sources.Root
+	sourceFiles := sources.TableFiles
+	appendixFiles := sources.AppendixTableFiles
 
 	tblFiles := filterAppendicesFromSourceFiles(appendixFiles, sourceFiles)
 	report := func(e TableFileEvent) {
@@ -205,10 +208,10 @@ func clone(ctx context.Context, srcTS, sinkTS chunks.TableFileStore, sinkCS chun
 		if failureCount >= maxAttempts {
 			return err
 		}
-		if _, refreshedSourceFiles, refreshedAppendixFiles, err := srcTS.Sources(ctx); err != nil {
+		if refreshSources, err := srcTS.Sources(ctx); err != nil {
 			return err
 		} else {
-			refreshedTblFiles := filterAppendicesFromSourceFiles(refreshedAppendixFiles, refreshedSourceFiles)
+			refreshedTblFiles := filterAppendicesFromSourceFiles(refreshSources.AppendixTableFiles, refreshSources.TableFiles)
 			_, refreshedFileIDToTF, _ := mapTableFiles(refreshedTblFiles)
 			// Sources() will refresh remote table file
 			// sources with new download URLs. However, it

--- a/go/store/nbs/generational_chunk_store.go
+++ b/go/store/nbs/generational_chunk_store.go
@@ -383,27 +383,28 @@ func (p prefixedTableFile) LocationPrefix() string {
 
 // Sources retrieves the current root hash, a list of all the table files (which may include appendix table files),
 // and a second list containing only appendix table files for both the old gen and new gen stores.
-func (gcs *GenerationalNBS) Sources(ctx context.Context) (hash.Hash, []chunks.TableFile, []chunks.TableFile, error) {
-	root, tFiles, appFiles, err := gcs.newGen.Sources(ctx)
+func (gcs *GenerationalNBS) Sources(ctx context.Context) (chunks.TableFileSources, error) {
+	newgensources, err := gcs.newGen.Sources(ctx)
 	if err != nil {
-		return hash.Hash{}, nil, nil, err
+		return chunks.TableFileSources{}, err
+	}
+	oldgensources, err := gcs.oldGen.Sources(ctx)
+	if err != nil {
+		return chunks.TableFileSources{}, err
 	}
 
-	_, oldTFiles, oldAppFiles, err := gcs.oldGen.Sources(ctx)
-	if err != nil {
-		return hash.Hash{}, nil, nil, err
-	}
-
+	var ret chunks.TableFileSources
+	ret.Root = newgensources.Root
+	ret.TableFiles = append([]chunks.TableFile{}, newgensources.TableFiles...)
+	ret.AppendixTableFiles = append([]chunks.TableFile{}, newgensources.AppendixTableFiles...)
 	prefix := gcs.RelativeOldGenPath()
-
-	for _, tf := range oldTFiles {
-		tFiles = append(tFiles, prefixedTableFile{tf, prefix})
+	for _, tf := range oldgensources.TableFiles {
+		ret.TableFiles = append(ret.TableFiles, prefixedTableFile{tf, prefix})
 	}
-	for _, tf := range oldAppFiles {
-		appFiles = append(appFiles, prefixedTableFile{tf, prefix})
+	for _, tf := range oldgensources.AppendixTableFiles {
+		ret.AppendixTableFiles = append(ret.AppendixTableFiles, prefixedTableFile{tf, prefix})
 	}
-
-	return root, tFiles, appFiles, nil
+	return ret, nil
 }
 
 // Size  returns the total size, in bytes, of the table files in the new and old gen stores combined

--- a/go/store/nbs/journal_record.go
+++ b/go/store/nbs/journal_record.go
@@ -423,8 +423,8 @@ func processJournalRecordsReader(ctx context.Context, r io.Reader, offin int64, 
 func processJournalRecords(ctx context.Context, r io.ReadSeeker, tryTruncate bool, off int64, cb func(o int64, r journalRec) error, warningsCb func(error)) (int64, error) {
 	var (
 		recovered bool
-		rdr *bufio.Reader
-		err error
+		rdr       *bufio.Reader
+		err       error
 	)
 
 	// start processing records from |off|

--- a/go/store/nbs/journal_record.go
+++ b/go/store/nbs/journal_record.go
@@ -16,6 +16,7 @@ package nbs
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -315,35 +316,21 @@ func ReviveJournalWithDataLoss(nomsDir string) (preservePath string, err error) 
 	return preservePath, nil
 }
 
-// processJournalRecords iterates over a chunk journal's records by reading from disk using |r|, starting at
-// offset |off|, and calls the callback function |cb| with each journal record. The offset where reading was stopped
-// is returned, or any error encountered along the way.
-// If an invalid journal record is found, it is not included and this function stops processing journal
-// entries, but does not return an error. Journal records may be incomplete if the system crashes while
-// records are being persisted to disk. This isn't likely, but the OS filesystem write is not an atomic
-// operation, so it's possible to leave the journal in a corrupted state. We must gracefully recover
-// without preventing the server from starting up, so we are careful to only return the journal file
-// offset that points to end of the last valid record.
-//
-// The |warningsCb| callback is called with any errors encountered that we automatically recover from. This allows the caller
-// to handle the situation in a context specific way.
-func processJournalRecords(ctx context.Context, r io.ReadSeeker, tryTruncate bool, off int64, cb func(o int64, r journalRec) error, warningsCb func(error)) (int64, error) {
-	var (
-		buf []byte
-		err error
-	)
-
-	// start processing records from |off|
-	if _, err = r.Seek(off, io.SeekStart); err != nil {
-		return 0, err
-	}
+func processJournalRecordsReader(ctx context.Context, r io.Reader, offin int64, cb func(o int64, r journalRec) error, warningsCb func(error)) (rdr *bufio.Reader, off int64, recovered bool, err error) {
+	var buf []byte
+	off = offin
 
 	// There are a few ways we can recover from journals which seem truncated or corrupted, but we want to be sure
 	// to scan to the end of the file in these cases to ensure there is no indication of data loss.
-	recovered := false
+	recovered = false
 
-	rdr := bufio.NewReaderSize(r, journalWriterBuffSize)
+	rdr = bufio.NewReaderSize(r, journalWriterBuffSize)
 	for {
+		if ctx.Err() != nil {
+			err = ctx.Err()
+			return
+		}
+
 		// peek to read next record size
 		if buf, err = rdr.Peek(uint32Size); err != nil {
 			// If we hit EOF here, it's expected. We can have no more than 3 bytes of data left, and we don't really have
@@ -417,6 +404,35 @@ func processJournalRecords(ctx context.Context, r io.ReadSeeker, tryTruncate boo
 		}
 		off += int64(len(buf))
 	}
+
+	return
+}
+
+// processJournalRecords iterates over a chunk journal's records by reading from disk using |r|, starting at
+// offset |off|, and calls the callback function |cb| with each journal record. The offset where reading was stopped
+// is returned, or any error encountered along the way.
+// If an invalid journal record is found, it is not included and this function stops processing journal
+// entries, but does not return an error. Journal records may be incomplete if the system crashes while
+// records are being persisted to disk. This isn't likely, but the OS filesystem write is not an atomic
+// operation, so it's possible to leave the journal in a corrupted state. We must gracefully recover
+// without preventing the server from starting up, so we are careful to only return the journal file
+// offset that points to end of the last valid record.
+//
+// The |warningsCb| callback is called with any errors encountered that we automatically recover from. This allows the caller
+// to handle the situation in a context specific way.
+func processJournalRecords(ctx context.Context, r io.ReadSeeker, tryTruncate bool, off int64, cb func(o int64, r journalRec) error, warningsCb func(error)) (int64, error) {
+	var (
+		recovered bool
+		rdr *bufio.Reader
+		err error
+	)
+
+	// start processing records from |off|
+	if _, err = r.Seek(off, io.SeekStart); err != nil {
+		return 0, err
+	}
+
+	rdr, off, recovered, err = processJournalRecordsReader(ctx, r, off, cb, warningsCb)
 
 	// If a non-EOF error was captured while processing journal records, return a
 	// journal offset of 0 and the error, which will cause startup to halt.
@@ -609,4 +625,40 @@ func readUint64(buf []byte) uint64 {
 
 func writeUint64(buf []byte, u uint64) {
 	binary.BigEndian.PutUint64(buf, u)
+}
+
+// Given an io.Reader which reads the bytes of a chunk journal and is
+// currently positioned at the beginning of a chunk record, call |cb|
+// for each compressed chunk which appears in the journal.
+//
+// Returns any errors or warnings encountered when reading the bytes
+// and interpretting them as journal records.
+func VisitJournalReaderChunks(ctx context.Context, r io.Reader, off int64, cb func(chk CompressedChunk) error) error {
+	var warningErr error
+	_, _, _, err := processJournalRecordsReader(ctx, r, off, func(off int64, rec journalRec) error {
+		if warningErr != nil {
+			return warningErr
+		}
+		if rec.kind == chunkJournalRecKind {
+			// We are going to pass the payload along and it might outlive
+			// this call. The buffer which appears in the record is mutable
+			// and is going to be reused by our caller. Copy it here.
+			buf := bytes.Clone(rec.payload)
+			cchk, err := NewCompressedChunk(rec.address, buf)
+			if err != nil {
+				return fmt.Errorf("error making compressed chunk at off %v for address %v: %w", off, rec.address, err)
+			}
+			err = cb(cchk)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}, func(err error) {
+		warningErr = err
+	})
+	if err == io.EOF {
+		err = nil
+	}
+	return errors.Join(err, warningErr)
 }

--- a/go/store/nbs/nbs_metrics_wrapper.go
+++ b/go/store/nbs/nbs_metrics_wrapper.go
@@ -43,7 +43,7 @@ var _ chunks.ChunkStoreGarbageCollector = &NBSMetricWrapper{}
 
 // Sources retrieves the current root hash, a list of all the table files,
 // and a list of the appendix table files.
-func (nbsMW *NBSMetricWrapper) Sources(ctx context.Context) (hash.Hash, []chunks.TableFile, []chunks.TableFile, error) {
+func (nbsMW *NBSMetricWrapper) Sources(ctx context.Context) (chunks.TableFileSources, error) {
 	return nbsMW.nbs.Sources(ctx)
 }
 

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -1700,8 +1700,8 @@ func (nbs *NomsBlockStore) Sources(ctx context.Context) (chunks.TableFileSources
 	}
 
 	return chunks.TableFileSources{
-		Root: contents.GetRoot(),
-		TableFiles: allTableFiles,
+		Root:               contents.GetRoot(),
+		TableFiles:         allTableFiles,
 		AppendixTableFiles: appendixTableFiles,
 	}, nil
 }

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -1665,7 +1665,7 @@ func (tf tableFile) Open(ctx context.Context) (io.ReadCloser, uint64, error) {
 
 // Sources retrieves the current root hash, a list of all table files (which may include appendix tablefiles),
 // and a second list of only the appendix table files
-func (nbs *NomsBlockStore) Sources(ctx context.Context) (hash.Hash, []chunks.TableFile, []chunks.TableFile, error) {
+func (nbs *NomsBlockStore) Sources(ctx context.Context) (chunks.TableFileSources, error) {
 	valctx.ValidateContext(ctx)
 	nbs.mu.Lock()
 	defer nbs.mu.Unlock()
@@ -1673,33 +1673,37 @@ func (nbs *NomsBlockStore) Sources(ctx context.Context) (hash.Hash, []chunks.Tab
 	exists, contents, err := nbs.manifestMgr.m.ParseIfExists(ctx, nbs.stats, nil)
 
 	if err != nil {
-		return hash.Hash{}, nil, nil, err
+		return chunks.TableFileSources{}, err
 	}
 
 	if !exists {
-		return hash.Hash{}, nil, nil, nil
+		return chunks.TableFileSources{}, nil
 	}
 
 	css, err := nbs.chunkSourcesByAddr()
 	if err != nil {
-		return hash.Hash{}, nil, nil, err
+		return chunks.TableFileSources{}, err
 	}
 
 	appendixTableFiles, err := getTableFiles(css, nbs.fatalBehavior, contents, contents.NumAppendixSpecs(), func(mc manifestContents, idx int) tableSpec {
 		return mc.getAppendixSpec(idx)
 	})
 	if err != nil {
-		return hash.Hash{}, nil, nil, err
+		return chunks.TableFileSources{}, err
 	}
 
 	allTableFiles, err := getTableFiles(css, nbs.fatalBehavior, contents, contents.NumTableSpecs(), func(mc manifestContents, idx int) tableSpec {
 		return mc.getSpec(idx)
 	})
 	if err != nil {
-		return hash.Hash{}, nil, nil, err
+		return chunks.TableFileSources{}, err
 	}
 
-	return contents.GetRoot(), allTableFiles, appendixTableFiles, nil
+	return chunks.TableFileSources{
+		Root: contents.GetRoot(),
+		TableFiles: allTableFiles,
+		AppendixTableFiles: appendixTableFiles,
+	}, nil
 }
 
 func getTableFiles(css map[hash.Hash]chunkSource, behavior dherrors.FatalBehavior, contents manifestContents, numSpecs int, specFunc func(mc manifestContents, idx int) tableSpec) ([]chunks.TableFile, error) {

--- a/go/store/nbs/store_test.go
+++ b/go/store/nbs/store_test.go
@@ -107,11 +107,11 @@ func TestNBSAsTableFileStore(t *testing.T) {
 	}()
 	fileToData := populateLocalStore(t, st, numTableFiles)
 
-	_, sources, _, err := st.Sources(ctx)
+	tfsources, err := st.Sources(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, numTableFiles, len(sources))
+	assert.Equal(t, numTableFiles, len(tfsources.TableFiles))
 
-	for _, src := range sources {
+	for _, src := range tfsources.TableFiles {
 		fileID := src.FileID()
 		expected, ok := fileToData[fileID]
 		require.True(t, ok)
@@ -187,9 +187,9 @@ func (s tableFileSet) findAbsent(ftd fileToData) (absent []string) {
 	return absent
 }
 
-func tableFileSetFromSources(sources []chunks.TableFile) (s tableFileSet) {
-	s = make(tableFileSet, len(sources))
-	for _, src := range sources {
+func tableFileSetFromSources(sources chunks.TableFileSources) (s tableFileSet) {
+	s = make(tableFileSet, len(sources.TableFiles))
+	for _, src := range sources.TableFiles {
 		s[src.FileID()] = src
 	}
 	return s
@@ -225,12 +225,12 @@ func TestNBSPruneTableFiles(t *testing.T) {
 
 	waitForConjoin(st)
 
-	_, sources, _, err := st.Sources(ctx)
+	tfsources, err := st.Sources(ctx)
 	require.NoError(t, err)
-	assert.Greater(t, numTableFiles, len(sources))
+	assert.Greater(t, numTableFiles, len(tfsources.TableFiles))
 
 	// find which input table files were conjoined
-	tfSet := tableFileSetFromSources(sources)
+	tfSet := tableFileSetFromSources(tfsources)
 	absent := tfSet.findAbsent(fileToData)
 	// assert some input table files were conjoined
 	assert.NotEmpty(t, absent)
@@ -251,7 +251,7 @@ func TestNBSPruneTableFiles(t *testing.T) {
 	}
 
 	preGC := currTableFiles(nomsDir)
-	for _, tf := range sources {
+	for _, tf := range tfsources.TableFiles {
 		assert.True(t, preGC.Contains(tf.FileID()))
 	}
 	for _, fileName := range toDelete {
@@ -262,7 +262,7 @@ func TestNBSPruneTableFiles(t *testing.T) {
 	require.NoError(t, err)
 
 	postGC := currTableFiles(nomsDir)
-	for _, tf := range sources {
+	for _, tf := range tfsources.TableFiles {
 		assert.True(t, postGC.Contains(tf.FileID()))
 	}
 	for _, fileName := range absent {
@@ -276,7 +276,7 @@ func TestNBSPruneTableFiles(t *testing.T) {
 
 	// assert that we only have files for current sources,
 	// the manifest, and the lock file
-	assert.Equal(t, len(sources)+2, len(infos))
+	assert.Equal(t, len(tfsources.TableFiles)+2, len(infos))
 
 	size, err := st.Size(ctx)
 	require.NoError(t, err)

--- a/integration-tests/bats/backup.bats
+++ b/integration-tests/bats/backup.bats
@@ -402,3 +402,74 @@ EOF
     run dolt sql -r csv -q "select * from t"
     [[ "$output" =~ i.*2.*1 ]] || false
 }
+
+@test "backup: backup pushes table files when journal is small relative to store size" {
+    get_table_files() {
+        find "$1" | while read f; do
+	    base=$(basename "$f")
+	    if [ "$base" != "manifest" ] && [ "$base" != "LOCK" ] && [ "$base" != "journal.idx" ] && ! [ -d "$f" ]; then
+	        echo "$base"
+            fi
+	done | sort
+    }
+    # Create many empty commits to make the journal slightly bigger.
+    cd repo1
+    dolt checkout -b newbranch
+    command=""
+    for i in $(seq 128); do command="$command call dolt_commit('--allow-empty', '-Am', 'empty commit');"; done
+    dolt sql -q "$command" > /dev/null
+    dolt checkout main
+    dolt branch -D newbranch
+    cd ..
+
+    # At the beginning of the test, repo1 should only be a journal file.
+    start_table_files=( $(get_table_files repo1/.dolt/noms) )
+    [[ ${#start_table_files[*]} -eq 1 ]] || false
+    [[ ${start_table_files[0]} == "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv" ]] || false
+    start_journal_size=$( wc -c repo1/.dolt/noms/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv | awk '{print $1}')
+
+    # Take a file backup of repo1.
+    cd repo1
+    dolt backup sync-url file://../repo1_start_backup
+    cd ..
+
+    # We should have pushed a table file.
+    backup_table_files=( $(get_table_files repo1_start_backup) )
+    [[ ${#backup_table_files[*]} -eq 1 ]] || false
+    [[ ${backup_table_files[0]} != "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv" ]] || false
+    backup_tablefile_size=$( wc -c repo1_start_backup/"${backup_table_files[0]}" | awk '{print $1}')
+
+    # And that table file should be much smaller than our journal.
+    upper_limit=$(( ${start_journal_size} / 5 ))
+    [[ "$backup_tablefile_size" -lt "$upper_limit" ]] || false
+
+    # Add lots of commits again, this time to main, and GC repo1
+    cd repo1
+    dolt sql -q "$command" > /dev/null
+    dolt gc
+    cd ..
+
+    postgc_table_files=( $(get_table_files repo1/.dolt/noms) )
+
+    # Take another backup of repo1
+    cd repo1
+    dolt backup sync-url file://../repo1_postgc_backup
+    cd ..
+
+    postgc_backup_table_files=( $(get_table_files repo1_postgc_backup) )
+
+    # Because we pushed table files, every table file in the source should be in the destination.
+    [[ ${#postgc_backup_table_files[*]} -ge ${#postgc_table_files[*]} ]] || false
+    for tfname in ${postgc_table_files[@]}; do
+        found=0
+        for backuptfname in ${postgc_backup_table_files[@]}; do
+	    if [[ "$backuptfname" == "$tfname" ]]; then
+	        found=1
+	    fi
+	done
+	if [[ "$found" -eq 0 ]]; then
+	    echo "expected to find $tfname in ${postgc_backup_table_files[*]}, but did not"
+	    exit 1
+	fi
+    done
+}


### PR DESCRIPTION
There are two code paths for taking a logical backup of a Dolt database. One pushes all the existing table files to the backup destination and then sets it up so that it points at the same root value as the existing database. The other code path does the merkle dag walk to push all the missing chunks to the destination store, starting from the desired root value chunk.

If the destination store is missing a lot of data, this later path currently requires a lot of bookkeeping to keep track of what has been pushed so far and what still needs to be pushed. This is expensive in memory. It requires walking large portions of the existing database, chunk by chunk, which can be expensive in CPU and in I/O seeks.

This code change seeks to use the code path which uploads existing table files more often when it is the best choice. In order to do so, the code path is now willing to convert a journal file, which should never be pushed to a remote or a backup, into a table file. It will do this on the fly, and will only upload the resulting table file to the destination. The table file does not become part of the source store, and this code path has no interaction with GC.

For now, there are some hardcoded heuristics for when to prefer pushing existing table files rather than trying to build the upload chunk-by-chunk. This PR uses existing table files when: the destination store is empty (has a zero root hash value) and there is no existing journal file or the existing journal file is less than 20% of the total repo size and the existing journal file is less than 16GB.