### PR TITLE
go: dolt_backup.go: More efficiently restore backups.

### DIFF
--- a/go/libraries/doltcore/env/actions/remotes.go
+++ b/go/libraries/doltcore/env/actions/remotes.go
@@ -831,6 +831,7 @@ func canSyncRootsWithClone(ctx context.Context, srcDb, destDb *doltdb.DoltDB, de
 }
 
 type SyncRootsDBRelationship int
+
 const (
 	SyncRootsDBRelationshipUnknown = iota
 	SyncRootsDBRelationshipUnrelated

--- a/go/libraries/doltcore/env/actions/remotes.go
+++ b/go/libraries/doltcore/env/actions/remotes.go
@@ -800,9 +800,11 @@ func pruneBranches[C doltdb.Context](ctx context.Context, dbData env.DbData[C], 
 //
 // Either way, both dest and source need to be table file stores,
 // since otherwise we need to pull chunks individually.
-func canSyncRootsWithClone(ctx context.Context, srcDb, destDb *doltdb.DoltDB, destDbRoot hash.Hash) (bool, error) {
-	if !destDbRoot.IsEmpty() {
-		return false, nil
+func canSyncRootsWithClone(ctx context.Context, srcDb, destDb *doltdb.DoltDB, destDbRoot hash.Hash, relationship SyncRootsDBRelationship) (bool, error) {
+	if relationship != SyncRootsDBRelationshipUnrelated {
+		if !destDbRoot.IsEmpty() {
+			return false, nil
+		}
 	}
 	if !srcDb.IsTableFileStore() {
 		return false, nil
@@ -828,12 +830,18 @@ func canSyncRootsWithClone(ctx context.Context, srcDb, destDb *doltdb.DoltDB, de
 	return true, nil
 }
 
+type SyncRootsDBRelationship int
+const (
+	SyncRootsDBRelationshipUnknown = iota
+	SyncRootsDBRelationshipUnrelated
+)
+
 // SyncRoots copies the entire chunkstore from srcDb to destDb and rewrites the remote manifest. Used to
 // streamline database backup and restores.
 // TODO: this should read/write a backup lock file specific to the client who created the backup
 // TODO     to prevent "restoring a remote", "cloning a backup", "syncing a remote" and "pushing
 // TODO     a backup." SyncRoots has more destructive potential than push right now.
-func SyncRoots(ctx context.Context, srcDb, destDb *doltdb.DoltDB, tempTableDir string, statsCh chan pull.Stats) error {
+func SyncRoots(ctx context.Context, srcDb, destDb *doltdb.DoltDB, tempTableDir string, relationship SyncRootsDBRelationship, statsCh chan pull.Stats) error {
 	srcRoot, err := srcDb.NomsRoot(ctx)
 	if err != nil {
 		return nil
@@ -848,7 +856,7 @@ func SyncRoots(ctx context.Context, srcDb, destDb *doltdb.DoltDB, tempTableDir s
 		return pull.ErrDBUpToDate
 	}
 
-	canClone, err := canSyncRootsWithClone(ctx, srcDb, destDb, destRoot)
+	canClone, err := canSyncRootsWithClone(ctx, srcDb, destDb, destRoot, relationship)
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_backup.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_backup.go
@@ -277,7 +277,7 @@ func doltBackupRestore(ctx *sql.Context, dbData env.DbData[*sql.Context], dsess 
 	})
 	wg.Go(func() {
 		defer close(statsCh)
-		err = actions.SyncRoots(ctx, remoteDb, newDb.DbData().Ddb, fileSys.TempDir(), statsCh)
+		err = actions.SyncRoots(ctx, remoteDb, newDb.DbData().Ddb, fileSys.TempDir(), actions.SyncRootsDBRelationshipUnrelated, statsCh)
 	})
 	wg.Wait()
 	if err == nil {
@@ -319,7 +319,7 @@ func syncRemote(ctx *sql.Context, dbData env.DbData[*sql.Context], dsess *dsess.
 	})
 	wg.Go(func() {
 		defer close(statsCh)
-		err = actions.SyncRoots(ctx, dbData.Ddb, destDb, dsess.GetFileSystem().TempDir(), statsCh)
+		err = actions.SyncRoots(ctx, dbData.Ddb, destDb, dsess.GetFileSystem().TempDir(), actions.SyncRootsDBRelationshipUnknown, statsCh)
 	})
 	wg.Wait()
 	if err == nil {

--- a/go/store/datas/pull/clone.go
+++ b/go/store/datas/pull/clone.go
@@ -305,30 +305,27 @@ func clone(ctx context.Context, srcTS, sinkTS chunks.TableFileStore, sinkCS chun
 		return err
 	}
 
-	// AddTableFilesToManifest can set the root chunk if there is a chunk
-	// journal which we downloaded in the clone. If that happened, the
-	// chunk journal is actually more accurate on what the current root is
-	// than the result of |Sources| up above. We choose not to touch
-	// anything in that case.
-	err = sinkCS.Rebase(ctx)
-	if err != nil {
-		return err
-	}
-	sinkRoot, err := sinkCS.Root(ctx)
-	if err != nil {
-		return err
-	}
-	if !sinkRoot.IsEmpty() {
-		return nil
+	// Clone always sets the destination database to the Root we saw in srcDb.Sources.
+	// Because we fetched all table files which appeared in Sources, that's a root
+	// which is guaranteed to be in our destination store.
+	numRetries := 0
+	var last hash.Hash
+	for numRetries < 10 {
+		var success bool
+		success, err = sinkTS.Commit(ctx, root, last)
+		if success && err != nil {
+			panic(fmt.Sprintf("runtime error: successful root update with error: %v", err))
+		}
+		if err != nil {
+			return err
+		}
+		last, err = sinkCS.Root(ctx)
+		if err != nil {
+			return err
+		}
+		numRetries += 1
 	}
 
-	success, err := sinkTS.Commit(ctx, root, hash.Hash{})
-	if !success && err == nil {
-		return errors.New("root update failure. optimistic lock failed")
-	}
-	if success && err != nil {
-		panic(fmt.Sprintf("runtime error: successful root update with error: %v", err))
-	}
 	return err
 }
 

--- a/go/store/datas/pull/clone.go
+++ b/go/store/datas/pull/clone.go
@@ -319,6 +319,9 @@ func clone(ctx context.Context, srcTS, sinkTS chunks.TableFileStore, sinkCS chun
 		if err != nil {
 			return err
 		}
+		if success {
+			return nil
+		}
 		last, err = sinkCS.Root(ctx)
 		if err != nil {
 			return err
@@ -326,7 +329,7 @@ func clone(ctx context.Context, srcTS, sinkTS chunks.TableFileStore, sinkCS chun
 		numRetries += 1
 	}
 
-	return err
+	return errors.New("clone left in indeterminate state: unexpected concurrent writes against the destination store prevented clone from setting the root of the database to be the same as source's root")
 }
 
 func convertJournalToTableFile(ctx context.Context, readCloser io.ReadCloser, off int64, tmpDir string) (*nbs.ArchiveStreamWriter, string, error) {

--- a/integration-tests/bats/backup.bats
+++ b/integration-tests/bats/backup.bats
@@ -473,3 +473,65 @@ EOF
 	fi
     done
 }
+
+@test "backup: backup restore pulls table files" {
+    get_table_files() {
+        find "$1" | while read f; do
+	    base=$(basename "$f")
+	    if [ "$base" != "manifest" ] && [ "$base" != "LOCK" ] && [ "$base" != "journal.idx" ] && ! [ -d "$f" ]; then
+	        echo "$base"
+            fi
+	done | sort
+    }
+    # Create many commits and then GC the repo.
+    cd repo1
+    command=""
+    for i in $(seq 128); do command="$command call dolt_commit('--allow-empty', '-Am', 'empty commit');"; done
+    dolt sql -q "$command" > /dev/null
+    dolt gc
+    expected_commits=$(dolt sql -r csv -q 'select count(1) from dolt_log()' | tail -n 1)
+    dolt branch -v
+    cd ..
+
+    # Make a backup.
+    cd repo1
+    dolt backup sync-url file://../repo1_backup
+    cd ..
+
+    # Restore the backup.
+    dolt backup restore file://./repo1_backup repo1_backup_restored
+
+    backup_table_files=( $(get_table_files repo1_backup) )
+    restored_table_files=( $(get_table_files repo1_backup_restored/.dolt/noms) )
+
+    # Check that the restored backup is as expected.
+    cd repo1_backup_restored
+    restored_commits=$(dolt sql -r csv -q 'select count(1) from dolt_log()' | tail -n 1)
+    echo $expected_commits $restored_commits
+    echo ${restored_table_files[*]}
+    find .
+    echo
+    echo
+    find ../repo1_backup
+    dolt branch -v
+    echo
+    cat ../repo1/.dolt/noms/manifest
+    echo
+    cat ../repo1_backup/manifest
+    echo
+    cat ./.dolt/noms/manifest
+    [[ $expected_commits -eq $restored_commits ]] || false
+
+    for tfname in ${backup_table_files[@]}; do
+        found=0
+        for restoredtfname in ${restored_table_files[@]}; do
+	    if [[ "$restoredtfname" == "$tfname" ]]; then
+	        found=1
+	    fi
+	done
+	if [[ "$found" -eq 0 ]]; then
+	    echo "expected to find $tfname in ${_table_files[*]}, but did not"
+	    exit 1
+	fi
+    done
+}


### PR DESCRIPTION
When dolt backup restore was migrated to SQL, it lost the ability to restore from table files. It always did the merkle dag pull instead.

This restores the ability of dolt backup restore to do a table file pull when that is appropriate.