### PR TITLE
store/prolly/tree: fix data race in Node.LoadSubtrees with atomic.Pointer

### DIFF
--- a/go/store/prolly/tree/node.go
+++ b/go/store/prolly/tree/node.go
@@ -180,7 +180,8 @@ func (nd *Node) LoadSubtrees() (*Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	nd.subtrees.CompareAndSwap(nil, (*subtreeCounts)(&sc))
+	stc := subtreeCounts(sc)
+	nd.subtrees.CompareAndSwap(nil, &stc)
 	return nd, nil
 }
 


### PR DESCRIPTION
Fix a [data race](https://github.com/dolthub/dolt/actions/runs/22925389971/job/66534380720?pr=10663#step:6:341) in Node.LoadSubtrees() where concurrent goroutines could read and write the subtrees field simultaneously. This was detected by the Go race detector in TestMergeConcurrency, where a merge path and a write session flush path both traverse shared prolly tree nodes concurrently.

The lazy-init pattern (if nd.subtrees == nil { nd.subtrees = x }) had no synchronization. Replace *subtreeCounts with atomic.Pointer[subtreeCounts] and use Load()/CompareAndSwap() to make the lazy initialization race-free. This also fixes a pre-existing bug where var err error on the outer scope shadowed the err from GetSubtrees, causing LoadSubtrees to always return nil error on the already-loaded path.