### PR TITLE
go: remotesrv: getUploadUrl: Respect X-Forwarded-Proto so returned URLs work appropriately behind tls-terminating reverse proxies.

### DIFF
--- a/go/libraries/doltcore/remotesrv/grpc.go
+++ b/go/libraries/doltcore/remotesrv/grpc.go
@@ -428,8 +428,9 @@ func (rs *RemoteChunkStore) getUploadUrl(md metadata.MD, repoPath string, tfd *r
 	params.Add("split_offset", strconv.Itoa(int(tfd.SplitOffset)))
 	params.Add("content_length", strconv.Itoa(int(tfd.ContentLength)))
 	params.Add("content_hash", base64.RawURLEncoding.EncodeToString(tfd.ContentHash))
+	scheme := rs.getScheme(md)
 	return &url.URL{
-		Scheme:   rs.httpScheme,
+		Scheme:   scheme,
 		Host:     rs.getHost(md),
 		Path:     fmt.Sprintf("%s/%s", repoPath, fileID),
 		RawQuery: params.Encode(),

--- a/go/libraries/doltcore/remotesrv/grpc_test.go
+++ b/go/libraries/doltcore/remotesrv/grpc_test.go
@@ -15,10 +15,16 @@
 package remotesrv
 
 import (
+	"crypto/rand"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/metadata"
+
+	remotesapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/remotesapi/v1alpha1"
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 func TestGRPCSchemeSelection(t *testing.T) {
@@ -33,4 +39,49 @@ func TestGRPCSchemeSelection(t *testing.T) {
 	md.Append("x-forwarded-proto", "https")
 	scheme = rs.getScheme(md)
 	assert.Equal(t, scheme, "https")
+}
+
+func TestGetUploadDownloadUrl(t *testing.T) {
+	type testCase struct {
+		storeScheme       string
+		forwardedScheme   string
+		expectedUrlScheme string
+	}
+	var id hash.Hash
+	rand.Read(id[:])
+	testCases := []testCase{
+		{"http", "", "http"},
+		{"http", "http", "http"},
+		{"http", "https", "https"},
+		{"https", "", "https"},
+		{"https", "https", "https"},
+		{"https", "http", "http"},
+	}
+	for _, testCase := range testCases {
+		t.Run(fmt.Sprintf("%s,%s", testCase.storeScheme, testCase.forwardedScheme), func(t *testing.T) {
+			rs := &RemoteChunkStore{
+				httpScheme: testCase.storeScheme,
+			}
+			md := metadata.New(nil)
+			md.Append(":authority", "hostname.local")
+			if testCase.forwardedScheme != "" {
+				md.Append("x-forwarded-proto", testCase.forwardedScheme)
+			}
+			db := "databasename"
+			path := db + "/" + id.String() + ".darc"
+			url := rs.getDownloadUrl(md, path)
+			assert.Equal(t, testCase.expectedUrlScheme, url.Scheme)
+			prefix := testCase.expectedUrlScheme + "://hostname.local/" + path
+			assert.True(t, strings.HasPrefix(url.String(), prefix), "%s should have a prefix of %s", url.String(), prefix)
+			url = rs.getUploadUrl(md, "databasename", &remotesapi.TableFileDetails{
+				Id:            id[:],
+				Suffix:        ".darc",
+				NumChunks:     64,
+				SplitOffset:   64 * 1024,
+				ContentLength: 64*1024 + 8*1024,
+			})
+			assert.Equal(t, testCase.expectedUrlScheme, url.Scheme)
+			assert.True(t, strings.HasPrefix(url.String(), prefix), "%s should have a prefix of %s", url.String(), prefix)
+		})
+	}
 }


### PR DESCRIPTION
Adopts the same behavior as download URLs already have. Upload URLs were missed in the original fix.

Fixes #10672.