### PR TITLE
fix: warn when duplicate database names are detected

### DIFF
--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -140,7 +140,11 @@ func NewDoltDatabaseProviderWithDatabases(defaultBranch string, fs filesys.Files
 
 	dbs := make(map[string]dsess.SqlDatabase, len(databases))
 	for _, db := range databases {
-		dbs[strings.ToLower(db.Name())] = db
+		dbNameLower := strings.ToLower(db.Name())
+		if _, exists := dbs[dbNameLower]; exists {
+			cli.Printf("warning: duplicate database name '%s' found. Only one will be accessible. Consider renaming databases to avoid conflicts.\n", db.Name())
+		}
+		dbs[dbNameLower] = db
 	}
 
 	dbLocations := make(map[string]filesys.Filesys, len(locations))

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -27,6 +27,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/sirupsen/logrus"
 	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
@@ -142,7 +143,7 @@ func NewDoltDatabaseProviderWithDatabases(defaultBranch string, fs filesys.Files
 	for _, db := range databases {
 		dbNameLower := strings.ToLower(db.Name())
 		if _, exists := dbs[dbNameLower]; exists {
-			cli.Printf("warning: duplicate database name '%s' found. Only one will be accessible. Consider renaming databases to avoid conflicts.\n", db.Name())
+			logrus.Warnf("duplicate database name %q detected; only one will be accessible", db.Name())
 		}
 		dbs[dbNameLower] = db
 	}

--- a/go/libraries/doltcore/sqle/database_provider_test.go
+++ b/go/libraries/doltcore/sqle/database_provider_test.go
@@ -15,11 +15,13 @@
 package sqle
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
 	sqle "github.com/dolthub/go-mysql-server"
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -28,6 +30,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
+	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/store/datas"
 )
 
@@ -151,4 +154,35 @@ func (*snoopingCommitHook) ExecuteForWorkingSets() bool {
 func InstallSnoopingCommitHook(ctx *sql.Context, pro *DoltDatabaseProvider, name string, dEnv *env.DoltEnv, db dsess.SqlDatabase) error {
 	dEnv.DoltDB(ctx).PrependCommitHooks(ctx, &snoopingCommitHook{})
 	return nil
+}
+
+func TestDuplicateDatabaseNameWarning(t *testing.T) {
+	ctx := context.Background()
+
+	dEnv1 := dtestutils.CreateTestEnvWithName("dupdb")
+	db1, err := NewDatabase(ctx, "dupdb", dEnv1.DbData(ctx), editor.Options{})
+	require.NoError(t, err)
+
+	dEnv2 := dtestutils.CreateTestEnvWithName("dupdb2")
+	db2, err := NewDatabase(ctx, "dupdb", dEnv2.DbData(ctx), editor.Options{})
+	require.NoError(t, err)
+
+	// Capture logrus output
+	var buf bytes.Buffer
+	logrus.SetOutput(&buf)
+	defer func() {
+		logrus.SetOutput(nil)
+	}()
+
+	_, err = NewDoltDatabaseProviderWithDatabases(
+		"main",
+		dEnv1.FS,
+		[]dsess.SqlDatabase{db1, db2},
+		[]filesys.Filesys{dEnv1.FS, dEnv2.FS},
+		sql.EngineOverrides{},
+	)
+	require.NoError(t, err)
+
+	assert.Contains(t, buf.String(), "duplicate database name")
+	assert.Contains(t, buf.String(), "dupdb")
 }


### PR DESCRIPTION
## Summary
Fixes #10143 - Adds a warning when duplicate database names are detected during sql-server initialization.

## Problem
When multiple databases with the same name are cloned to different directories:

```sh
$ dolt clone post-no-preference/earnings
$ cd earnings
$ dolt clone post-no-preference/earnings  # Different directory, same name!
$ dolt sql-server
$ dolt sql -q "show databases"
# Only shows one "earnings" - ambiguous!
```

The duplicate names silently overwrite each other in the database map, causing confusion about which database is actually being used.

## Solution
Log a structured warning via `logrus.Warnf` when duplicate database names are detected during `NewDoltDatabaseProviderWithDatabases`. Uses logrus (not cli.Printf) so the warning:
- Goes to stderr in structured form (consistent with the rest of sql-server startup)
- Respects `--log-level` filtering
- Survives in daemonized deployments

## Testing
- Added `TestDuplicateDatabaseNameWarning` in `database_provider_test.go`
- Creates two databases with the same name, asserts the warning fires via logrus output capture

## Changes
- `database_provider.go`: `cli.Printf` → `logrus.Warnf` for duplicate name warning
- `database_provider_test.go`: New test for duplicate detection

Closes #10143