### PR TITLE
sqle: skip dolt commit path for read-only transactions

### DIFF
--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -478,6 +478,18 @@ func (d *DoltSession) CommitTransaction(ctx *sql.Context, tx sql.Transaction) (e
 	}
 
 	dirtyBranchState := dirties[0]
+
+	// Skip the dolt commit path for read-only transactions. When dolt_transaction_commit=1,
+	// every transaction close attempts PendingCommitAllStaged (which stages all tables and
+	// checks for changes). For read-only queries this is wasted work — there are never
+	// changes to commit. In high-frequency read workloads (e.g. monitoring agents polling
+	// every few seconds), this overhead compounds: each read-only query pays the cost of
+	// StageAllTables + newPendingCommit only to get nil back and fall through to
+	// commitWorkingSet anyway. Short-circuiting here avoids that entirely.
+	if dtx, ok := tx.(*DoltTransaction); ok && dtx.IsReadOnly() {
+		return d.commitWorkingSet(ctx, dirtyBranchState, tx)
+	}
+
 	if peformDoltCommitInt == 1 {
 		// if the dirty working set doesn't belong to the currently checked out branch, that's an error
 		err = d.validateDoltCommit(ctx, dirtyBranchState)


### PR DESCRIPTION
## Summary

- Skip the expensive `PendingCommitAllStaged` path for read-only transactions when `dolt_transaction_commit=true`
- Read-only transactions (SELECTs) go directly to `commitWorkingSet`, matching the behavior they'd get anyway but without staging overhead
- Prevents empty commit attempt storm in high-frequency read workloads

## Problem

When `dolt_transaction_commit=true`, every transaction close—including read-only SELECTs—runs `PendingCommitAllStaged` which calls `StageAllTables` and `newPendingCommit`. For read-only queries there are never changes to stage, so `pendingCommit` always returns nil and the code falls through to `commitWorkingSet` anyway.

In production with 6 agents polling every 30 seconds, we observed:
- 100k+ empty commit attempts over 5 hours  
- Connection IDs reaching 717,000+
- Server eventually returning `database not found` errors then crashing

## Fix

Check `DoltTransaction.IsReadOnly()` before entering the dolt commit path. The `IsReadOnly()` method already exists on `DoltTransaction` and checks `tx.tCharacteristic == sql.ReadOnly`. Read-only transactions short-circuit directly to `commitWorkingSet`.

## Test plan

- [ ] Existing `TestDoltTransactionCommitOneClient` and related tests pass (write transactions still commit)
- [ ] Read-only queries with `dolt_transaction_commit=1` no longer trigger `PendingCommitAllStaged`

Fixes #10685

🤖 Generated with [Claude Code](https://claude.com/claude-code)