### PR TITLE
Have fsTablePersister implement movingTableFilePersister

### DIFF
--- a/go/store/nbs/archive_writer.go
+++ b/go/store/nbs/archive_writer.go
@@ -622,6 +622,12 @@ func (asw *ArchiveStreamWriter) Remove() error {
 	return os.Remove(asw.writer.path)
 }
 
+// FlushToFile writes the archive to disk. The input is the directory where the file should be written, the file name
+// will be the footer hash + ".darc" as a suffix.
+func (asw *ArchiveStreamWriter) FlushToFile(fullPath string) error {
+	return asw.writer.flushToFile(fullPath)
+}
+
 func (asw *ArchiveStreamWriter) writeArchiveToChunker(chunker ArchiveToChunker) (uint32, error) {
 	dict := chunker.dict
 

--- a/go/store/nbs/cmp_chunk_table_writer.go
+++ b/go/store/nbs/cmp_chunk_table_writer.go
@@ -61,6 +61,8 @@ type GenericTableWriter interface {
 	Remove() error
 	// Terminate the inprogress write and attempt to cleanup any resources.
 	Cancel() error
+	// FlushToFile writes the archive to disk. The input is the directory where the file should be written.
+	FlushToFile(fullPath string) error
 }
 
 const defaultTableSinkBlockSize = 2 * 1024 * 1024

--- a/go/store/nbs/file_table_persister.go
+++ b/go/store/nbs/file_table_persister.go
@@ -69,6 +69,7 @@ type fsTablePersister struct {
 
 var _ tablePersister = &fsTablePersister{}
 var _ tableFilePersister = &fsTablePersister{}
+var _ movingTableFilePersister = &fsTablePersister{}
 
 func (ftp *fsTablePersister) Open(ctx context.Context, name hash.Hash, chunkCount uint32, stats *Stats) (chunkSource, error) {
 	return newFileTableReader(ctx, ftp.dir, name, chunkCount, ftp.q, ftp.mmapArchiveIndexes, stats)
@@ -166,7 +167,7 @@ func (ftp *fsTablePersister) CopyTableFile(_ context.Context, r io.Reader, fileI
 	return file.Rename(tn, path)
 }
 
-func (ftp *fsTablePersister) TryMoveCmpChunkTableWriter(ctx context.Context, filename string, w *CmpChunkTableWriter) error {
+func (ftp *fsTablePersister) TryMoveCmpChunkTableWriter(ctx context.Context, filename string, w GenericTableWriter) error {
 	path := filepath.Join(ftp.dir, filename)
 	ftp.removeMu.Lock()
 	if ftp.toKeep != nil {


### PR DESCRIPTION
The `movingTableFilePersister` interface is for tablePersister implementations that build a temporary table file and have the ability to move the temporary file into the final location instead of copying the contents into a new one.

https://github.com/dolthub/dolt/pull/9118 added support for persisting archive files. As part of this change, the signature of a method on `movingTableFilePersister` was changed to accept the more generic `GenericTableWriter` interface instead of the more specific `CmpChunkTableWriter`.

Unfortunately, the signature was not also updated on the `fsTablePersister` implementation, resulting in it no longer implementing the interface. As a result, we lost the ability move table files during garbage collection. This had no impact on correctness, but potentially had a performance impact.

This PR fixes this issue.