### PR TITLE
go: doltcore/sqle: database_provider.go: Fix a deadlock in DROP DATABASE.

### DIFF
--- a/go/libraries/doltcore/dbfactory/file.go
+++ b/go/libraries/doltcore/dbfactory/file.go
@@ -97,6 +97,7 @@ func CloseAllLocalDatabases() (err error) {
 			err = fmt.Errorf("error closing DB %s (%s)", name, cerr)
 		}
 	}
+	singletons = make(map[string]singletonDB)
 	return
 }
 

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/dolthub/go-mysql-server/sql"
 
@@ -70,6 +71,11 @@ type DoltDatabaseProvider struct {
 	mu                     *sync.RWMutex
 	droppedDatabaseManager *droppedDatabaseManager
 	overrides              sql.EngineOverrides
+
+	// Databases named in deletingDatbases are currently undergoing deletion.
+	// Databases with these names cannot created, but also return ErrNoDatabase
+	// when accessed.
+	deletingDatabases map[string]struct{}
 
 	// remoteDbs caches remote DoltDB instances by URL so that repeated push calls
 	// to the same remote reuse the store (and its already-opened table chunk sources)
@@ -176,6 +182,7 @@ func NewDoltDatabaseProviderWithDatabases(defaultBranch string, fs filesys.Files
 	return &DoltDatabaseProvider{
 		dbLocations:            dbLocations,
 		databases:              dbs,
+		deletingDatabases:      make(map[string]struct{}),
 		functions:              funcs,
 		tableFunctions:         tableFuncs,
 		externalProcedures:     externalProcedures,
@@ -263,7 +270,7 @@ func (p *DoltDatabaseProvider) FileSystem() filesys.Filesys {
 }
 
 func (p *DoltDatabaseProvider) Close() {
-	p.mu.RLock()
+	p.rlockAwaitingEmptyDeletingDatabases()
 	closeDoltDBs := p.dbLoadParams != nil
 	if closeDoltDBs {
 		_, closeDoltDBs = p.dbLoadParams[dbfactory.DisableSingletonCacheParam]
@@ -449,15 +456,34 @@ func (p *DoltDatabaseProvider) HasDatabase(ctx *sql.Context, name string) bool {
 	return err == nil
 }
 
+// Grab p.mu.RLock(), but wait until p.deletingDatabases is empty
+// before returning with the lock held.
+//
+// This should be used any time we are enumerating databases for a
+// caller. While databases which are being deleted no longer appear in
+// p.databases, and thus won't be directly enumerated, while they are
+// in the process of being deleted they might be visible in other
+// systems because they are still on the filesystem, still running
+// their dropdatabasehooks, etc.
+func (p *DoltDatabaseProvider) rlockAwaitingEmptyDeletingDatabases() {
+	for {
+		p.mu.RLock()
+		if len(p.deletingDatabases) == 0 {
+			return
+		}
+		p.mu.RUnlock()
+		time.Sleep(1 * time.Millisecond)
+	}
+}
+
 func (p *DoltDatabaseProvider) AllDatabases(ctx *sql.Context) (all []sql.Database) {
 	_, revision := doltdb.SplitRevisionDbName(ctx.GetCurrentDatabase())
-	p.mu.RLock()
-
 	showBranches, err := dsess.GetBooleanSystemVar(ctx, dsess.ShowBranchDatabases)
 	if err != nil {
 		ctx.GetLogger().Warn(err)
 	}
 
+	p.rlockAwaitingEmptyDeletingDatabases()
 	all = make([]sql.Database, 0, len(p.databases))
 	for _, db := range p.databases {
 		all = append(all, db)
@@ -495,15 +521,14 @@ func (p *DoltDatabaseProvider) AllDatabases(ctx *sql.Context) (all []sql.Databas
 
 // DoltDatabases implements the dsess.DoltDatabaseProvider interface
 func (p *DoltDatabaseProvider) DoltDatabases() []dsess.SqlDatabase {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-
+	p.rlockAwaitingEmptyDeletingDatabases()
 	dbs := make([]dsess.SqlDatabase, len(p.databases))
 	i := 0
 	for _, db := range p.databases {
 		dbs[i] = db
 		i++
 	}
+	p.mu.RUnlock()
 
 	sort.Slice(dbs, func(i, j int) bool {
 		return strings.ToLower(dbs[i].Name()) < strings.ToLower(dbs[j].Name())
@@ -655,6 +680,9 @@ func (p *DoltDatabaseProvider) CreateCollatedDatabase(ctx *sql.Context, name str
 		}
 	}()
 
+	if _, ok := p.deletingDatabases[name]; ok {
+		return sql.ErrDatabaseExists.New(name)
+	}
 	exists, isDir := p.fs.Exists(name)
 	if exists && isDir {
 		return sql.ErrDatabaseExists.New(name)
@@ -689,7 +717,6 @@ func (p *DoltDatabaseProvider) CreateCollatedDatabase(ctx *sql.Context, name str
 	if err != nil {
 		return err
 	}
-	newEnv.DoltDB(ctx).SetCrashOnFatalError()
 
 	updatedCollation, updatedSchemas := false, false
 
@@ -875,6 +902,9 @@ func NewConfigureReplicationDatabaseHook(bThreads *sql.BackgroundThreads, ctxF f
 }
 
 // CloneDatabaseFromRemote implements DoltDatabaseProvider interface
+//
+// TODO: This holds the database provider lock across the entire duration of
+// the clone, which is much too long to hold this lock.
 func (p *DoltDatabaseProvider) CloneDatabaseFromRemote(
 	ctx *sql.Context,
 	dbName, branch, remoteName, remoteUrl string,
@@ -883,6 +913,10 @@ func (p *DoltDatabaseProvider) CloneDatabaseFromRemote(
 ) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+
+	if _, ok := p.deletingDatabases[dbName]; ok {
+		return sql.ErrDatabaseExists.New(dbName)
+	}
 
 	exists, isDir := p.fs.Exists(dbName)
 	if exists && isDir {
@@ -959,40 +993,78 @@ func (p *DoltDatabaseProvider) DropDatabase(ctx *sql.Context, name string) error
 		return fmt.Errorf("unable to drop revision database: %s", name)
 	}
 
-	p.mu.Lock()
-	defer p.mu.Unlock()
+	var db dsess.SqlDatabase
+	var dbLoc filesys.Filesys
+	var dbKey, dropDbLoc string
+	err := func() error {
+		p.mu.Lock()
+		defer p.mu.Unlock()
 
-	// get the case-sensitive name for case-sensitive file systems
-	dbKey := formatDbMapKeyName(name)
-	db := p.databases[dbKey]
+		// get the case-sensitive name for case-sensitive file systems
+		dbKey = formatDbMapKeyName(name)
+		db = p.databases[dbKey]
 
-	var database *doltdb.DoltDB
-	if ddb, ok := db.(Database); ok {
-		database = ddb.ddb
-	} else {
-		return fmt.Errorf("unable to drop database: %s", name)
-	}
+		// get location of database that's being dropped
+		dbLoc = p.dbLocations[dbKey]
 
-	err := database.Close()
+		if _, ok := db.(Database); !ok {
+			return fmt.Errorf("unable to drop database: %s", name)
+		}
+
+		if dbLoc == nil {
+			return sql.ErrDatabaseNotFound.New(db.Name())
+		}
+
+		var err error
+		dropDbLoc, err = dbLoc.Abs("")
+		if err != nil {
+			return err
+		}
+		// We not only have to delete tracking metadata for this database, but also for any derivative
+		// ones we've stored as a result of USE or connection strings
+		derivativeNamePrefix := strings.ToLower(dbKey + doltdb.DbRevisionDelimiter)
+		for dbName := range p.databases {
+			if strings.HasPrefix(strings.ToLower(dbName), derivativeNamePrefix) {
+				delete(p.databases, dbName)
+			}
+		}
+		delete(p.databases, dbKey)
+		p.deletingDatabases[dbKey] = struct{}{}
+		return nil
+	}()
 	if err != nil {
 		return err
 	}
+	defer func() {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		delete(p.deletingDatabases, dbKey)
+	}()
 
-	// get location of database that's being dropped
-	dbLoc := p.dbLocations[dbKey]
-	if dbLoc == nil {
-		return sql.ErrDatabaseNotFound.New(db.Name())
+	var retErr error
+
+	// XXX: From this point forward, the database is inaccessible to new sessions in the server
+	// and is soon to be inaccessible to existing sessions.
+	//
+	// We accumulate any errors we see see along the way, but we try to do most of the following work
+	// without returning early.
+
+	err = p.invalidateDbStateInAllSessions(ctx, name)
+	if err != nil {
+		retErr = errors.Join(retErr, err)
 	}
 
-	dropDbLoc, err := dbLoc.Abs("")
-	if err != nil {
-		return err
+	// We run the drop hooks before we close the database.
+	for _, dropHook := range p.DropDatabaseHooks {
+		// For symmetry with InitDatabaseHook and the names we see in
+		// MultiEnv initialization, we use `name` here, not `dbKey`.
+		dropHook(ctx, name)
 	}
 
 	// If this database is re-created, we don't want to return any cached results.
-	err = dbfactory.DeleteFromSingletonCache(filepath.ToSlash(dropDbLoc+"/.dolt/noms"), false)
+	err = dbfactory.DeleteFromSingletonCache(filepath.ToSlash(dropDbLoc+"/.dolt/noms"), true)
 	if err != nil {
-		return err
+		retErr = errors.Join(retErr, err)
 	}
 	err = dbfactory.DeleteFromSingletonCache(filepath.ToSlash(dropDbLoc+"/.dolt/stats/.dolt/noms"), true)
 	if err != nil {
@@ -1003,26 +1075,10 @@ func (p *DoltDatabaseProvider) DropDatabase(ctx *sql.Context, name string) error
 
 	err = p.droppedDatabaseManager.DropDatabase(ctx, name, dropDbLoc)
 	if err != nil {
-		return err
+		retErr = errors.Join(retErr, err)
 	}
 
-	for _, dropHook := range p.DropDatabaseHooks {
-		// For symmetry with InitDatabaseHook and the names we see in
-		// MultiEnv initialization, we use `name` here, not `dbKey`.
-		dropHook(ctx, name)
-	}
-
-	// We not only have to delete tracking metadata for this database, but also for any derivative
-	// ones we've stored as a result of USE or connection strings
-	derivativeNamePrefix := strings.ToLower(dbKey + doltdb.DbRevisionDelimiter)
-	for dbName := range p.databases {
-		if strings.HasPrefix(strings.ToLower(dbName), derivativeNamePrefix) {
-			delete(p.databases, dbName)
-		}
-	}
-	delete(p.databases, dbKey)
-
-	return p.invalidateDbStateInAllSessions(ctx, name)
+	return retErr
 }
 
 func (p *DoltDatabaseProvider) ListDroppedDatabases(ctx *sql.Context) ([]string, error) {
@@ -1039,6 +1095,10 @@ func (p *DoltDatabaseProvider) DbFactoryUrl() string {
 func (p *DoltDatabaseProvider) UndropDatabase(ctx *sql.Context, name string) (err error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+
+	if _, ok := p.deletingDatabases[name]; ok {
+		return sql.ErrDatabaseExists.New(name)
+	}
 
 	newFs, exactCaseName, err := p.droppedDatabaseManager.UndropDatabase(ctx, name)
 	if err != nil {
@@ -1079,6 +1139,12 @@ func (p *DoltDatabaseProvider) registerNewDatabase(ctx *sql.Context, name string
 	// Ensure any provider-supplied DB load params are applied before any lazy DB load occurs.
 	p.applyDBLoadParamsToEnv(newEnv)
 
+	ddb := newEnv.DoltDB(ctx)
+	err = errors.Join(newEnv.DBLoadError, newEnv.CfgLoadErr)
+	if err != nil {
+		return err
+	}
+	ddb.SetCrashOnFatalError()
 	db, err := NewDatabase(ctx, name, newEnv.DbData(ctx), editor.Options{})
 	if err != nil {
 		return err

--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -562,6 +562,8 @@ var ErrDirtyWorkingSets = errors.New("Cannot commit changes on more than one bra
 
 // dirtyWorkingSets returns all dirty working sets for this session
 func (d *DoltSession) dirtyWorkingSets() []*branchState {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	var dirtyStates []*branchState
 	for _, state := range d.dbStates {
 		for _, branchState := range state.heads {
@@ -577,6 +579,8 @@ func (d *DoltSession) dirtyWorkingSets() []*branchState {
 // DirtyDatabases returns the names of databases who have outstanding changes in this session and need to be committed
 // in a SQL transaction before they are visible to other sessions.
 func (d *DoltSession) DirtyDatabases() []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	var dbNames []string
 	for _, dbState := range d.dbStates {
 		for _, branchState := range dbState.heads {

--- a/integration-tests/go-sql-server-driver/concurrent_drop_database_test.go
+++ b/integration-tests/go-sql-server-driver/concurrent_drop_database_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	driver "github.com/dolthub/dolt/go/libraries/doltcore/dtestutils/sql_server_driver"
+)
+
+// TestconcurrentDropDatabase is a regression test for #10692.
+//
+// A lock-ordering bug between *DatabaseProvider and *DoltSession meant that
+// DROP DATABASE during concurrency could cause the DatabaseProvider to
+// deadlock and the server databases to become unavailable.
+func TestConcurrentDropDatabase(t *testing.T) {
+	// Not parallel. Senseitive to timing.
+	var ports DynamicResources
+	ports.global = &GlobalPorts
+	ports.t = t
+	u, err := driver.NewDoltUser()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		u.Cleanup()
+	})
+
+	rs, err := u.MakeRepoStore()
+	require.NoError(t, err)
+
+	repo, err := rs.MakeRepo("concurrent_drop_database_test")
+	require.NoError(t, err)
+
+	srvSettings := &driver.Server{
+		Args:        []string{"-P", `{{get_port "server_port"}}`},
+		DynamicPort: "server_port",
+	}
+	server := MakeServer(t, repo, srvSettings, &ports)
+	server.DBName = "concurrent_drop_database_test"
+
+	db, err := server.DB(driver.Connection{User: "root"})
+	require.NoError(t, err)
+	db.SetMaxIdleConns(0)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+	ctx := t.Context()
+
+	eg, ctx := errgroup.WithContext(ctx)
+	start := time.Now()
+
+	var numcreates int32 = 0
+	const numWriters = 8
+	const testDuration = 8 * time.Second
+	for i := range numWriters {
+		eg.Go(func() error {
+			ctx, cancel := context.WithTimeout(ctx, testDuration*4)
+			defer cancel()
+			conn, err := db.Conn(ctx)
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+			j := 0
+			for {
+				if time.Since(start) > testDuration {
+					return nil
+				}
+				if ctx.Err() != nil {
+					return context.Cause(ctx)
+				}
+				database := fmt.Sprintf("db%08d%08d", i, j)
+				_, err := conn.ExecContext(ctx, "CREATE DATABASE "+database)
+				if err != nil {
+					return err
+				}
+				atomic.AddInt32(&numcreates, 1)
+				_, err = conn.ExecContext(ctx, "DROP DATABASE "+database)
+				if err != nil {
+					return err
+				}
+			}
+		})
+	}
+	require.NoError(t, eg.Wait())
+	ctx, cancel := context.WithTimeout(t.Context(), 2 * time.Second)
+	defer cancel()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close()
+	rows, err := conn.QueryContext(ctx, "SHOW DATABASES")
+	require.NoError(t, err)
+	defer rows.Close()
+	var databases []string
+	for rows.Next() {
+		var db string
+		err = rows.Scan(&db)
+		require.NoError(t, err)
+		databases = append(databases, db)
+	}
+	require.NoError(t, rows.Err())
+	sort.Strings(databases)
+	require.Equal(t, []string{"concurrent_drop_database_test", "information_schema", "mysql"}, databases)
+	t.Logf("created %d databases", numcreates)
+}


### PR DESCRIPTION
A lock-acquisition order error could cause DROP DATABASE to conflict on lock acquisition with a DoltSession's own Mutex. The result was that all sessions would then block indefinitely and irrecoverably on trying to access any database loaded in the server.

This changes the order of operations and the lock acquisition sequencing to not dead lock.

Note: finalization of DROP DATABASE with regards to sessions and ongoing queries which may be accessing the database is still somewhat lacking. To be improved in the future.

Fixes: #10692.