### PR TITLE
go: store/nbs,doltdb: When Clone into a destination database, disable Conjoin running as part of landing files into the destination.

### DIFF
--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -2077,9 +2077,7 @@ func (ddb *DoltDB) IsTableFileStore() bool {
 // GenerationalNBS...)
 func (ddb *DoltDB) disableConjoin() {
 	cs := datas.ChunkStoreFromDatabase(ddb.db)
-	if i, ok := cs.(interface {
-		DisableConjoin()
-	}); ok {
+	if i, ok := cs.(nbs.DynamicConjoin); ok {
 		i.DisableConjoin()
 	}
 }
@@ -2089,9 +2087,7 @@ func (ddb *DoltDB) disableConjoin() {
 // GenerationalNBS...).
 func (ddb *DoltDB) restoreDefaultConjoinBehavior() {
 	cs := datas.ChunkStoreFromDatabase(ddb.db)
-	if i, ok := cs.(interface {
-		RestoreDefaultConjoinBehavior()
-	}); ok {
+	if i, ok := cs.(nbs.DynamicConjoin); ok {
 		i.RestoreDefaultConjoinBehavior()
 	}
 }

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -2049,6 +2049,15 @@ func (ddb *DoltDB) getAddrs(c chunks.Chunk) chunks.GetAddrsCb {
 }
 
 func (ddb *DoltDB) Clone(ctx context.Context, tempTableDir string, destDB *DoltDB, eventCh chan<- pull.TableFileEvent) error {
+	// When cloning into destDB, we don't want to immediately conjoin
+	// whatever table files we end copying into destDB. If destDB
+	// goes on to be used as a normal database, then its default
+	// conjoin strategy can prevail, but especially for something
+	// like taking a backup, conjoining immediately just because
+	// newgen + oldgen was near the threshold is contrary to our
+	// immediate goals.
+	destDB.disableConjoin()
+	defer destDB.restoreDefaultConjoinBehavior()
 	return pull.Clone(ctx,
 		datas.ChunkStoreFromDatabase(ddb.db),
 		datas.ChunkStoreFromDatabase(destDB.db),
@@ -2061,6 +2070,30 @@ func (ddb *DoltDB) Clone(ctx context.Context, tempTableDir string, destDB *DoltD
 func (ddb *DoltDB) IsTableFileStore() bool {
 	_, ok := datas.ChunkStoreFromDatabase(ddb.db).(chunks.TableFileStore)
 	return ok
+}
+
+// Internally used to temporarily disable conjoin.  Only works on
+// NomsBlockStore and some friends (MetricsWrapper,
+// GenerationalNBS...)
+func (ddb *DoltDB) disableConjoin() {
+	cs := datas.ChunkStoreFromDatabase(ddb.db)
+	if i, ok := cs.(interface {
+		DisableConjoin()
+	}); ok {
+		i.DisableConjoin()
+	}
+}
+
+// If disableConjoin is called, this will restore the behavior back to
+// its default.  NomsBlockStore and some friends (MetricsWrapper,
+// GenerationalNBS...).
+func (ddb *DoltDB) restoreDefaultConjoinBehavior() {
+	cs := datas.ChunkStoreFromDatabase(ddb.db)
+	if i, ok := cs.(interface {
+		RestoreDefaultConjoinBehavior()
+	}); ok {
+		i.RestoreDefaultConjoinBehavior()
+	}
 }
 
 // Iterates an unspecified number of previous root hashes for this

--- a/go/store/nbs/generational_chunk_store.go
+++ b/go/store/nbs/generational_chunk_store.go
@@ -564,3 +564,13 @@ func (gcs *GenerationalNBS) Count() (uint32, error) {
 	}
 	return newGenCnt + oldGenCnt, nil
 }
+
+func (gcs *GenerationalNBS) DisableConjoin() {
+	gcs.newGen.DisableConjoin()
+	gcs.oldGen.DisableConjoin()
+}
+
+func (gcs *GenerationalNBS) RestoreDefaultConjoinBehavior() {
+	gcs.newGen.RestoreDefaultConjoinBehavior()
+	gcs.oldGen.RestoreDefaultConjoinBehavior()
+}

--- a/go/store/nbs/nbs_metrics_wrapper.go
+++ b/go/store/nbs/nbs_metrics_wrapper.go
@@ -102,3 +102,11 @@ func (nbsMW *NBSMetricWrapper) GetManyCompressed(ctx context.Context, hashes has
 func (nbsMW NBSMetricWrapper) PersistGhostHashes(ctx context.Context, refs hash.HashSet) error {
 	return nbsMW.nbs.PersistGhostHashes(ctx, refs)
 }
+
+func (nbsMW NBSMetricWrapper) DisableConjoin() {
+	nbsMW.nbs.DisableConjoin()
+}
+
+func (nbsMW NBSMetricWrapper) RestoreDefaultConjoinBehavior() {
+	nbsMW.nbs.RestoreDefaultConjoinBehavior()
+}

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -2606,3 +2606,12 @@ func (nbs *NomsBlockStore) RestoreDefaultConjoinBehavior() {
 func (nbs *NomsBlockStore) conjoinDynamicallyDisabled() bool {
 	return atomic.LoadInt32(&nbs.conjoinBlockCnt) != 0
 }
+
+type DynamicConjoin interface {
+	DisableConjoin()
+	RestoreDefaultConjoinBehavior()
+}
+
+var _ DynamicConjoin = (*NomsBlockStore)(nil)
+var _ DynamicConjoin = NBSMetricWrapper{}
+var _ DynamicConjoin = (*GenerationalNBS)(nil)

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -114,6 +114,11 @@ type NomsBlockStore struct {
 	conjoinOp     *conjoinOperation
 	conjoinOpCond *sync.Cond
 
+	// Incremented by DisableConjoin, decremented by
+	// RestoreDefaultConjoinBeahvior. The conjoiner
+	// is only consulted when this value is 0.
+	conjoinBlockCnt int32
+
 	stats    *Stats
 	memtable *memTable
 	// Guarded by |mu|. Notified on gcInProgress and gcOutstandingReads changes.
@@ -323,6 +328,9 @@ func (nbs *NomsBlockStore) handleUnlockedRead(ctx context.Context, gcb gcBehavio
 
 func (nbs *NomsBlockStore) startConjoinIfRequired(ctx context.Context) error {
 	if nbs.conjoinOp != nil {
+		return nil
+	}
+	if nbs.conjoinDynamicallyDisabled() {
 		return nil
 	}
 	if nbs.conjoiner.conjoinRequired(nbs.tables) {
@@ -2585,4 +2593,16 @@ func (nbs *NomsBlockStore) findTableSpec(storageId hash.Hash) (tableSpec, bool) 
 		}
 	}
 	return tableSpec{name: storageId, chunkCount: 0}, false
+}
+
+func (nbs *NomsBlockStore) DisableConjoin() {
+	atomic.AddInt32(&nbs.conjoinBlockCnt, 1)
+}
+
+func (nbs *NomsBlockStore) RestoreDefaultConjoinBehavior() {
+	atomic.AddInt32(&nbs.conjoinBlockCnt, -1)
+}
+
+func (nbs *NomsBlockStore) conjoinDynamicallyDisabled() bool {
+	return atomic.LoadInt32(&nbs.conjoinBlockCnt) != 0
 }

--- a/integration-tests/go-sql-server-driver/clone_no_conjoin_test.go
+++ b/integration-tests/go-sql-server-driver/clone_no_conjoin_test.go
@@ -38,13 +38,13 @@ import (
 //
 // Concretely, to setup the store, this test first creates a new dolt
 // commit on `main` and then runs GC. This creates a new table file in
-// the old gen. It does this 192 times. It then uses a remotesapi
-// endpoint on another running sql-server to do a similar thing. It
+// the old gen. It does this 192 times. It then uses a file remote,
+// populated by another running sql-server, to do a similar thing. It
 // creates a remote to the remote database and then fetches it. It
-// creates a new commit on the remote database and then fetches
-// that. This creates a new table file in the new gen. It does this
-// 192 times. At the end, the new gen has more than 192 table files
-// and the old gen has exactly 192 table files.
+// creates a new commit on the remote database, pushes it, and then
+// fetches that. This creates a new table file in the new gen. It does
+// this 192 times. At the end, the new gen has more than 192 table
+// files and the old gen has exactly 192 table files.
 //
 // Then this test calls dolt_backup(sync-url) to a file remote.
 //
@@ -162,5 +162,5 @@ func TestCloneNoConjoin(t *testing.T) {
 		return nil
 	})
 	t.Logf("found %v table files", numTableFiles)
-	assert.Greater(t, numTableFiles, 256)
+	assert.GreaterOrEqual(t, numTableFiles, 384)
 }

--- a/integration-tests/go-sql-server-driver/clone_no_conjoin_test.go
+++ b/integration-tests/go-sql-server-driver/clone_no_conjoin_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	driver "github.com/dolthub/dolt/go/libraries/doltcore/dtestutils/sql_server_driver"
+	"github.com/dolthub/dolt/go/store/hash"
+)
+
+// TestCloneNoConjoin asserts that a clone (in this case a backup
+// sync-url) of a store with many table files does not conjoin just
+// because of the datas.Clone operation.
+//
+// In order to construct a store with a lot of table files, without it
+// itself being conjoined, this test is tightly coupled with
+// implementation details around GenerationalNBS,
+// nbs.defaultMaxTables, GC oldGenRefs, and how pull works.
+//
+// Concretely, to setup the store, this test first creates a new dolt
+// commit on `main` and then runs GC. This creates a new table file in
+// the old gen. It does this 192 times. It then uses a remotesapi
+// endpoint on another running sql-server to do a similar thing. It
+// creates a remote to the remote database and then fetches it. It
+// creates a new commit on the remote database and then fetches
+// that. This creates a new table file in the new gen. It does this
+// 192 times. At the end, the new gen has more than 192 table files
+// and the old gen has exactly 192 table files.
+//
+// Then this test calls dolt_backup(sync-url) to a file remote.
+//
+// Finally, the test asserts that the destination file remote has at
+// least 384 table files in it. With default settings, if conjoin had
+// been enabled, they would have been conjoined to be below 256 files.
+func TestCloneNoConjoin(t *testing.T) {
+	t.Parallel()
+	var ports DynamicResources
+	ports.global = &GlobalPorts
+	ports.t = t
+	u, err := driver.NewDoltUser()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		u.Cleanup()
+	})
+
+	testRS, err := u.MakeRepoStore()
+	require.NoError(t, err)
+	testRepo, err := testRS.MakeRepo("clone_no_conjoin_test")
+	require.NoError(t, err)
+	testSrvSettings := &driver.Server{
+		Args:        []string{"-P", `{{get_port "server_port"}}`},
+		Envs:        []string{"DOLT_REMOTE_PASSWORD=insecure_password"},
+		DynamicPort: "server_port",
+	}
+	testServer := MakeServer(t, testRepo, testSrvSettings, &ports)
+	testServer.DBName = "clone_no_conjoin_test"
+
+	remoteRS, err := u.MakeRepoStore()
+	require.NoError(t, err)
+	remoteRepo, err := remoteRS.MakeRepo("clone_no_conjoin_remote")
+	require.NoError(t, err)
+	remoteSrvSettings := &driver.Server{
+		Args:        []string{"-P", `{{get_port "remote_server_port"}}`},
+		DynamicPort: "remote_server_port",
+	}
+	remoteServer := MakeServer(t, remoteRepo, remoteSrvSettings, &ports)
+	remoteServer.DBName = "clone_no_conjoin_remote"
+
+	// A file remote which remoteDB pushes to and db pulls from.
+	rendezvousDir := t.TempDir()
+	// The final sync-url destination about which we will make our assertions.
+	finalDestDir := t.TempDir()
+	
+	ctx := t.Context()
+
+	// First make our oldgen table files.
+	db, err := testServer.DB(driver.Connection{User: "root"})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+	func() {
+		conn, err := db.Conn(ctx)
+		require.NoError(t, err)
+		defer conn.Close()
+		for range 192 {
+			_, err = conn.ExecContext(ctx, "CALL DOLT_COMMIT('-A', '--allow-empty', '-m', 'creating a new commit')")
+			require.NoError(t, err)
+			_, err = conn.ExecContext(ctx, "CALL DOLT_GC()")
+			require.NoError(t, err)
+		}
+	}()
+
+	remoteDB, err := remoteServer.DB(driver.Connection{User: "root"})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, remoteDB.Close())
+	}()
+
+	// Now make the newgen table files, pulling from a file remote.
+	func() {
+		remoteConn, err := remoteDB.Conn(ctx)
+		require.NoError(t, err)
+		defer remoteConn.Close()
+		_, err = remoteConn.ExecContext(ctx, "CALL DOLT_REMOTE('add', 'rendezvous', 'file://" + rendezvousDir + "')")
+		require.NoError(t, err)
+		conn, err := db.Conn(ctx)
+		require.NoError(t, err)
+		defer conn.Close()
+		_, err = conn.ExecContext(ctx, "CALL DOLT_REMOTE('add', 'rendezvous', 'file://" + rendezvousDir + "')")
+		require.NoError(t, err)
+		for range 192 {
+			_, err = remoteConn.ExecContext(ctx, "CALL DOLT_COMMIT('-A', '--allow-empty', '-m', 'creating a new commit')")
+			require.NoError(t, err)
+			_, err = remoteConn.ExecContext(ctx, "CALL DOLT_PUSH('rendezvous', 'main:remoteref')")
+			require.NoError(t, err)
+			_, err = conn.ExecContext(ctx, "CALL DOLT_FETCH('rendezvous')")
+			require.NoError(t, err)
+		}
+	}()
+
+	// Now backup sync-url to the finalDestDir
+	func() {
+		conn, err := db.Conn(ctx)
+		require.NoError(t, err)
+		defer conn.Close()
+		_, err = conn.ExecContext(ctx, "CALL DOLT_BACKUP('sync-url', 'file://" + finalDestDir + "')")
+		require.NoError(t, err)
+	}()
+
+	numTableFiles := 0
+	filepath.WalkDir(finalDestDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		n := d.Name()
+		n = strings.TrimSuffix(n, ".darc")
+		_, ok := hash.MaybeParse(n)
+		if ok {
+			t.Logf("found table file %s", n)
+			numTableFiles += 1
+		}
+		return nil
+	})
+	t.Logf("found %v table files", numTableFiles)
+	assert.Greater(t, numTableFiles, 256)
+}


### PR DESCRIPTION
When we land files into a destination database as part of a Clone, by default we used to be able to trigger a conjoin on the destination database. After the change in #10652, we now also block on any of those conjoin operations completing as we closed the DestDB that was created as part of a backup sync/sync-url operation.

In the case of backup, this conjoin behavior is a little contrary to what we are trying to accomplish.

This PR changes it so that we dynamically disable conjoin on the destination while we clone into it. After the clone is finished, we reenable conjoin. At that point, if the database is used as an actual database, conjoin will kick in as expected. But if it is immediately closed, the destination files stay as they were.