### PR TITLE
bug fix: don't error on ignored tables when continuing a rebase

### DIFF
--- a/go/libraries/doltcore/sqle/dprocedures/dolt_rebase.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_rebase.go
@@ -394,26 +394,36 @@ func validateRebaseBranchHasntChanged(ctx *sql.Context, branch string, rebaseSta
 	if !ok {
 		return fmt.Errorf("unable to access doltDB for database %s", ctx.GetCurrentDatabase())
 	}
-
-	wsRef, err := ref.WorkingSetRefForHead(ref.NewBranchRef(branch))
+	roots, err := doltDb.ResolveBranchRoots(ctx, ref.NewBranchRef(branch))
 	if err != nil {
 		return err
 	}
 
-	resolvedWorkingSet, err := doltDb.ResolveWorkingSet(ctx, wsRef)
+	// Diff the changes between the branch's working set and the pre-rebase working set
+	deltas, err := diff.GetTableDeltas(ctx, rebaseState.PreRebaseWorkingRoot(), roots.Working)
 	if err != nil {
 		return err
 	}
-	hash2, err := resolvedWorkingSet.StagedRoot().HashOf()
+	schemas := diff.GetUniqueSchemaNamesFromTableDeltas(deltas)
+	ignorePatternMap, err := doltdb.GetIgnoredTablePatterns(ctx, roots, schemas)
 	if err != nil {
 		return err
 	}
-	hash1, err := rebaseState.PreRebaseWorkingRoot().HashOf()
-	if err != nil {
-		return err
-	}
-	if hash1 != hash2 {
-		return fmt.Errorf("rebase aborted due to changes in branch %s", branch)
+	for _, delta := range deltas {
+		tableName := delta.ToName
+		if delta.ToTable == nil {
+			tableName = delta.FromName
+		}
+
+		// If any table with a diff isn't an ignored table, then return an error
+		patterns := ignorePatternMap[tableName.Schema]
+		ignoreResult, err := (&patterns).IsTableNameIgnored(tableName)
+		if err != nil {
+			return err
+		}
+		if ignoreResult != doltdb.Ignore {
+			return fmt.Errorf("rebase aborted due to changes in branch %s", branch)
+		}
 	}
 
 	return nil

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_rebase.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_rebase.go
@@ -2030,6 +2030,35 @@ commit
 			},
 		},
 	},
+	{
+		Name: "dolt_rebase: ignored tables",
+		SetUpScript: []string{
+			"CREATE TABLE t (id INT PRIMARY KEY)",
+			"INSERT INTO t VALUES (1)",
+			"INSERT INTO dolt_ignore VALUES ('ignored_table', true)",
+			"CALL dolt_commit('-Am', 'Initial table')",
+			"INSERT INTO t VALUES (2)",
+			"CALL dolt_commit('-am', 'More data')",
+			"INSERT INTO dolt_ignore (pattern, ignored) VALUES ('ignored_%', true)",
+			"CALL dolt_commit('-am', 'Ignore rules')",
+			"CREATE TABLE ignored_table (id INT PRIMARY KEY)",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				// status should be empty, because only an ignored table is changed
+				Query:    "select * from dolt_status;",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "CALL dolt_rebase('-i', 'HEAD~2')",
+				Expected: []sql.Row{{0, "interactive rebase started on branch dolt_rebase_main; adjust the rebase plan in the dolt_rebase table, then continue rebasing by calling dolt_rebase('--continue')"}},
+			},
+			{
+				Query:    "CALL dolt_rebase('--continue')",
+				Expected: []sql.Row{{0, "Successfully rebased and updated refs/heads/main"}},
+			},
+		},
+	},
 }
 
 var DoltRebaseMultiSessionScriptTests = []queries.ScriptTest{


### PR DESCRIPTION
When continuing an active rebase, Dolt checks to make sure that the branch being rebased hasn't had other changes applied before it update that branch pointer to the new rebased commits. This logic wasn't taking account of ignored tables before, which preventing users from being able to complete an interactive rebase. 

Fixes: https://github.com/dolthub/dolt/issues/10698