### PR TITLE
go: store/datas: database_common: On FastForward with working set checks, create the working set with the correct root hash if it does not already exist.

### DIFF
--- a/go/store/datas/database_common.go
+++ b/go/store/datas/database_common.go
@@ -401,7 +401,12 @@ func (db *database) doFastForward(ctx context.Context, ds Dataset, newHeadAddr h
 			if err != nil {
 				return prolly.AddressMap{}, err
 			}
-			// If the current root has a working set, update it. Do nothing if it doesn't exist.
+			cmtRtHsh, err := GetCommitRootHash(cmtValue)
+			if err != nil {
+				return prolly.AddressMap{}, err
+			}
+			// If the current root has a working set, assert it isn't dirty before updating it.
+			// Otherwise, create a new working set with the incoming root hash.
 			if hasWS {
 				currWSHash, err := am.Get(ctx, workingSetPath)
 				if err != nil {
@@ -438,11 +443,6 @@ func (db *database) doFastForward(ctx context.Context, ds Dataset, newHeadAddr h
 						return prolly.AddressMap{}, ErrDirtyWorkspace
 					}
 
-					cmtRtHsh, err := GetCommitRootHash(cmtValue)
-					if err != nil {
-						return prolly.AddressMap{}, err
-					}
-
 					// TODO - construct new meta instance rather than using the default
 					updateWS := workingset_flatbuffer(cmtRtHsh, &cmtRtHsh, nil, nil, nil)
 					ref, err := db.WriteValue(ctx, types.SerialMessage(updateWS))
@@ -455,6 +455,13 @@ func (db *database) doFastForward(ctx context.Context, ds Dataset, newHeadAddr h
 					// modern storage.
 					return prolly.AddressMap{}, errors.New("Modern Dolt Database required.")
 				}
+			} else {
+				updateWS := workingset_flatbuffer(cmtRtHsh, &cmtRtHsh, nil, nil, nil)
+				ref, err := db.WriteValue(ctx, types.SerialMessage(updateWS))
+				if err != nil {
+					return prolly.AddressMap{}, err
+				}
+				newWSHash = ref.TargetHash()
 			}
 		}
 

--- a/go/store/datas/database_common.go
+++ b/go/store/datas/database_common.go
@@ -279,7 +279,12 @@ func (db *database) doSetHead(ctx context.Context, ds Dataset, addr hash.Hash, w
 			if err != nil {
 				return prolly.AddressMap{}, err
 			}
-			// If the current root has a working set, update it. Do nothing if it doesn't exist.
+			cmtRtHsh, err := GetCommitRootHash(newVal)
+			if err != nil {
+				return prolly.AddressMap{}, err
+			}
+			// If the current root has a working set, assert it isn't dirty and then update it.
+			// If this branch does not have a working set yet, create it to match the commit contents.
 			if hasWS {
 				currWSHash, err := am.Get(ctx, workingSetPath)
 				if err != nil {
@@ -292,11 +297,6 @@ func (db *database) doSetHead(ctx context.Context, ds Dataset, addr hash.Hash, w
 				}
 
 				if _, ok := targetCmt.(types.SerialMessage); ok {
-					cmtRtHsh, err := GetCommitRootHash(newVal)
-					if err != nil {
-						return prolly.AddressMap{}, err
-					}
-
 					// TODO - construct new meta instance rather than using the default
 					updateWS := workingset_flatbuffer(cmtRtHsh, &cmtRtHsh, nil, nil, nil)
 					ref, err := db.WriteValue(ctx, types.SerialMessage(updateWS))
@@ -309,6 +309,14 @@ func (db *database) doSetHead(ctx context.Context, ds Dataset, addr hash.Hash, w
 					// modern storage.
 					return prolly.AddressMap{}, errors.New("Modern Dolt Database required.")
 				}
+			} else {
+				// TODO - construct new meta instance rather than using the default
+				updateWS := workingset_flatbuffer(cmtRtHsh, &cmtRtHsh, nil, nil, nil)
+				ref, err := db.WriteValue(ctx, types.SerialMessage(updateWS))
+				if err != nil {
+					return prolly.AddressMap{}, err
+				}
+				newWSHash = ref.TargetHash()
 			}
 		}
 

--- a/integration-tests/bats/remotesrv.bats
+++ b/integration-tests/bats/remotesrv.bats
@@ -88,6 +88,34 @@ stop_remotesrv() {
     [[ "$output" =~ "5" ]] || false
 }
 
+@test "remotesrv: pushing new branch to remotesrv does not create new working set" {
+    mkdir remote
+    mkdir cloned
+    cd remote
+    dolt init
+    dolt sql -q 'create table vals (i int);'
+    dolt add vals
+    dolt commit -m 'create vals table.'
+
+    remotesrv --http-port 1234 --repo-mode &
+    remotesrv_pid=$!
+
+    cd ../cloned
+    dolt clone http://localhost:50051/test-org/test-repo repo1
+    cd repo1
+    dolt sql -q 'insert into vals values (1), (2), (3), (4), (5);'
+    dolt commit -am 'insert some values'
+    dolt push origin main:new_branch
+
+    stop_remotesrv
+    cd ../../remote
+    run dolt admin show-root
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "workingSets/heads/new_branch" ]] || false
+    [[ "$output" =~ "workingSets/heads/main" ]] || false
+}
+
 @test "remotesrv: can write to remotesrv when repo has a dirty working set" {
     mkdir remote
     mkdir cloned

--- a/integration-tests/bats/sql-server-remotesrv.bats
+++ b/integration-tests/bats/sql-server-remotesrv.bats
@@ -105,7 +105,9 @@ SELECT 'abcdefg';"
     cd ../../cloned_remote
 
     dolt checkout -b new_branch
+    dolt checkout -b new_forced_branch
     dolt push origin new_branch
+    dolt push -f origin new_forced_branch
 
     # Assert that the expected working set exists, in addition to the branch.
     cd ../db/remote
@@ -116,6 +118,7 @@ SELECT 'abcdefg';"
     echo "$output"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "workingSets/heads/new_branch" ]] || false
+    [[ "$output" =~ "workingSets/heads/new_forced_branch" ]] || false
 }
 
 @test "sql-server-remotesrv: can access a created database from sql-server with --remotesapi-port" {

--- a/integration-tests/bats/sql-server-remotesrv.bats
+++ b/integration-tests/bats/sql-server-remotesrv.bats
@@ -83,6 +83,41 @@ SELECT 'abcdefg';"
     [[ "$output" =~ "abcdefg" ]] || false
 }
 
+@test "sql-server-remotesrv: pushing a new branch creates a working set" {
+    mkdir -p db/remote
+    cd db/remote
+    dolt init
+    dolt sql-server --remotesapi-port 50051 &
+    srv_pid=$!
+
+    cd ../..
+
+    # By cloning here, we have a near-at-hand way to wait for the server to be ready.
+    dolt clone http://localhost:50051/remote cloned_remote
+    cd cloned_remote
+
+    cd ../db/remote
+    # If stats is running, it might create
+    # a working set before we inspect.
+    # Stop it to ensure the working set
+    # exists as a result of our push.
+    dolt sql -q 'call dolt_stats_stop()'
+    cd ../../cloned_remote
+
+    dolt checkout -b new_branch
+    dolt push origin new_branch
+
+    # Assert that the expected working set exists, in addition to the branch.
+    cd ../db/remote
+    kill $srv_pid
+    wait $srv_pid
+    srv_pid=
+    run dolt admin show-root
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "workingSets/heads/new_branch" ]] || false
+}
+
 @test "sql-server-remotesrv: can access a created database from sql-server with --remotesapi-port" {
     mkdir -p db/remote
     cd db/remote


### PR DESCRIPTION
Previously, we avoided doing this because there is logic in the SQL server which automatically create the working set if it doesn't already exist. However, that logic cannot work in all cases, such as multi-branch access within a SQL transaction. It's more appropriate and more aligned with Dolt's expectations going forward to always create the working set on the branch write if it does not already exist.

Because of remotesapi.PushConcurrencyControl, this change does not change the behavior of Dolt when writing to a pure remotesapi endpoint, like dolthub.com. In that case, working sets are not typically pushed to the remote and they are not written on a branch write.