### PR TITLE
Get generated sys tables correctly

### DIFF
--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -1744,9 +1744,8 @@ func (db Database) getAllTableNames(ctx *sql.Context, root doltdb.RootValue, inc
 	}
 
 	if includeGeneratedSystemTables {
-		// TODO: this should work on the current schema only, if there is one
 		// TODO: this is getting called with showSystemTables = true, which seems wrong in most cases
-		systemTables, err := resolve.GetGeneratedSystemTables(ctx, root)
+		systemTables, err := resolve.GetGeneratedSystemTablesBySchema(ctx, root, schema.DatabaseSchema{Name: db.schemaName})
 		if err != nil {
 			return nil, err
 		}

--- a/go/libraries/doltcore/sqle/resolve/system_tables.go
+++ b/go/libraries/doltcore/sqle/resolve/system_tables.go
@@ -80,3 +80,52 @@ func GetGeneratedSystemTables(ctx context.Context, root doltdb.RootValue) ([]dol
 
 	return s.AsSlice(), nil
 }
+
+func GetGeneratedSystemTablesBySchema(ctx context.Context, root doltdb.RootValue, schema schema.DatabaseSchema) ([]doltdb.TableName, error) {
+	s := doltdb.NewTableNameSet(nil)
+
+	// Depending on whether the search path is used, the generated system tables will either be in the dolt namespace
+	// or the empty (default) namespace.
+	if !UseSearchPath || schema.Name == doltdb.DoltNamespace {
+
+		for _, tableName := range doltdb.GeneratedSystemTableNames() {
+			adapter, ok := adapters.DoltTableAdapterRegistry.Adapters[tableName]
+			if ok {
+				tableName = adapter.TableName()
+			}
+
+			tableUnique := doltdb.TableName{Name: tableName}
+			if UseSearchPath {
+				tableUnique.Schema = doltdb.DoltNamespace
+			}
+
+			s.Add(tableUnique)
+		}
+	}
+
+	tableNames, err := root.GetTableNames(ctx, schema.Name, false)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, pre := range doltdb.GeneratedSystemTablePrefixes {
+		for _, tableName := range tableNames {
+			s.Add(doltdb.TableName{
+				Name:   pre + tableName,
+				Schema: schema.Name,
+			})
+		}
+	}
+
+	// For doltgres, we also support the legacy dolt_ table names, addressable in any user schema
+	if UseSearchPath && schema.Name != "pg_catalog" && schema.Name != doltdb.DoltNamespace {
+		for _, name := range doltdb.DoltGeneratedTableNames {
+			s.Add(doltdb.TableName{
+				Name:   name,
+				Schema: schema.Name,
+			})
+		}
+	}
+
+	return s.AsSlice(), nil
+}

--- a/go/libraries/doltcore/sqle/resolve/system_tables.go
+++ b/go/libraries/doltcore/sqle/resolve/system_tables.go
@@ -81,6 +81,8 @@ func GetGeneratedSystemTables(ctx context.Context, root doltdb.RootValue) ([]dol
 	return s.AsSlice(), nil
 }
 
+// GetGeneratedSystemTablesBySchema returns table names of all generated system tables within the specified schema.
+// In Dolt, this is synonymous with getting all tables names in the connected database.
 func GetGeneratedSystemTablesBySchema(ctx context.Context, root doltdb.RootValue, schema schema.DatabaseSchema) ([]doltdb.TableName, error) {
 	s := doltdb.NewTableNameSet(nil)
 
@@ -117,7 +119,7 @@ func GetGeneratedSystemTablesBySchema(ctx context.Context, root doltdb.RootValue
 		}
 	}
 
-	// For doltgres, we also support the legacy dolt_ table names, addressable in any user schema
+	// For Doltgres, we also support the legacy dolt_ table names, addressable in any user schema
 	if UseSearchPath && schema.Name != "pg_catalog" && schema.Name != doltdb.DoltNamespace {
 		for _, name := range doltdb.DoltGeneratedTableNames {
 			s.Add(doltdb.TableName{


### PR DESCRIPTION
Some current issues where when looking a specific scheme, we call `getGeneratedSytemTables`, which gets system tables from all schemas, resulting in trying to check for tables that don't exist in scope.
