### PR TITLE
go: statspro: Add a quiesced state.

### DIFF
--- a/go/libraries/doltcore/sqle/dprocedures/stats_funcs.go
+++ b/go/libraries/doltcore/sqle/dprocedures/stats_funcs.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	gmstypes "github.com/dolthub/go-mysql-server/sql/types"
@@ -53,16 +54,17 @@ func statsFunc(fn func(ctx *sql.Context, args ...string) (interface{}, error)) f
 
 // StatsInfo gives a summary of the current coordinator stats.
 type StatsInfo struct {
-	DbCnt             int    `json:"dbCnt"`
-	Active            bool   `json:"active"`
-	StorageBucketCnt  int    `json:"storageBucketCnt"`
-	CachedBucketCnt   int    `json:"cachedBucketCnt"`
-	CachedBoundCnt    int    `json:"cachedBoundCnt"`
-	CachedTemplateCnt int    `json:"cachedTemplateCnt"`
-	StatCnt           int    `json:"statCnt"`
-	GcCnt             int    `json:"gcCnt,omitempty"`
-	GenCnt            int    `json:"genCnt,omitempty"`
-	Backing           string `json:"backing"`
+	DbCnt             int       `json:"dbCnt"`
+	Active            bool      `json:"active"`
+	StorageBucketCnt  int       `json:"storageBucketCnt"`
+	CachedBucketCnt   int       `json:"cachedBucketCnt"`
+	CachedBoundCnt    int       `json:"cachedBoundCnt"`
+	CachedTemplateCnt int       `json:"cachedTemplateCnt"`
+	StatCnt           int       `json:"statCnt"`
+	GcCnt             int       `json:"gcCnt,omitempty"`
+	GenCnt            int       `json:"genCnt,omitempty"`
+	Backing           string    `json:"backing"`
+	LastUpdate        time.Time `json:"lastUpdate"`
 }
 
 // ToJson returns stats info as a json string. Use the |short|

--- a/go/libraries/doltcore/sqle/statspro/controller.go
+++ b/go/libraries/doltcore/sqle/statspro/controller.go
@@ -120,10 +120,10 @@ type rootStats struct {
 	hash            uint64
 	hashes          map[tableIndexesKey]hash.Hash
 	stats           map[tableIndexesKey][]*stats.Statistic
-	DbCnt           int 	  `json:"dbCnt"`
-	BucketWrites    int 	  `json:"bucketWrites"`
-	TablesProcessed int 	  `json:"tablesProcessed"`
-	TablesSkipped   int 	  `json:"tablesSkipped"`
+	DbCnt           int       `json:"dbCnt"`
+	BucketWrites    int       `json:"bucketWrites"`
+	TablesProcessed int       `json:"tablesProcessed"`
+	TablesSkipped   int       `json:"tablesSkipped"`
 	LastUpdate      time.Time `json:"lastUpdate"`
 }
 

--- a/go/libraries/doltcore/sqle/statspro/controller.go
+++ b/go/libraries/doltcore/sqle/statspro/controller.go
@@ -42,6 +42,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
 	"github.com/dolthub/dolt/go/libraries/utils/earl"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
+	"github.com/dolthub/dolt/go/store/datas"
 	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/types"
 	"github.com/dolthub/dolt/go/store/val"
@@ -102,6 +103,17 @@ type StatsController struct {
 	// as last-writer wins
 	genCnt atomic.Uint64
 	gcCnt  int
+
+	// If non-nil, this will be closed when a new write comes in
+	// and it will be nil'd out. It will also be closed when
+	// addListener adds a new listener.
+	//
+	// In turn, when the worker thread reaches the end of its run
+	// and it sees that the stats it just computed are the same
+	// as the stats it started with, it can quiesce by selecting
+	// against the quiescedAwake channel which it installed at
+	// the beginning of that run.
+	quiescedAwake chan struct{}
 }
 
 type rootStats struct {
@@ -629,4 +641,30 @@ func (sc *StatsController) initStorage(ctx context.Context, fs filesys.Filesys) 
 		}, nil
 	}
 	return NewProllyStats(ctx, statsDb)
+}
+
+// A hook to go on all DoltDBs stats watches. It just triggers
+// StatsController.quiescedAwake on any incoming write to the database
+// to ensure that the worker thread wakes up and processes stats after
+// that write.
+func (sc *StatsController) commithook() commithook {
+	return commithook{sc}
+}
+
+type commithook struct {
+	sc *StatsController
+}
+
+func (h commithook) Execute(ctx context.Context, ds datas.Dataset, db *doltdb.DoltDB) (func(context.Context) error, error) {
+	h.sc.mu.Lock()
+	defer h.sc.mu.Unlock()
+	if h.sc.quiescedAwake != nil {
+		close(h.sc.quiescedAwake)
+		h.sc.quiescedAwake = nil
+	}
+	return nil, nil
+}
+
+func (h commithook) ExecuteForWorkingSets() bool {
+	return true
 }

--- a/go/libraries/doltcore/sqle/statspro/controller.go
+++ b/go/libraries/doltcore/sqle/statspro/controller.go
@@ -120,10 +120,11 @@ type rootStats struct {
 	hash            uint64
 	hashes          map[tableIndexesKey]hash.Hash
 	stats           map[tableIndexesKey][]*stats.Statistic
-	DbCnt           int `json:"dbCnt"`
-	BucketWrites    int `json:"bucketWrites"`
-	TablesProcessed int `json:"tablesProcessed"`
-	TablesSkipped   int `json:"tablesSkipped"`
+	DbCnt           int 	  `json:"dbCnt"`
+	BucketWrites    int 	  `json:"bucketWrites"`
+	TablesProcessed int 	  `json:"tablesProcessed"`
+	TablesSkipped   int 	  `json:"tablesSkipped"`
+	LastUpdate      time.Time `json:"lastUpdate"`
 }
 
 func newRootStats() *rootStats {
@@ -248,6 +249,7 @@ func (sc *StatsController) Info(ctx context.Context) (dprocedures.StatsInfo, err
 		GenCnt:            int(sc.genCnt.Load()),
 		GcCnt:             sc.gcCnt,
 		Backing:           filepath.Base(backing),
+		LastUpdate:        sc.Stats.LastUpdate,
 	}, nil
 }
 

--- a/go/libraries/doltcore/sqle/statspro/controller.go
+++ b/go/libraries/doltcore/sqle/statspro/controller.go
@@ -206,6 +206,10 @@ func (sc *StatsController) AddFs(ctx *sql.Context, db dsess.SqlDatabase, fs file
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 
+	// Registering the new database wakes stats, just like an incoming write
+	// on an existing registered database.
+	sc.wakeStatsOnNewWriteLocked()
+
 	firstDb := len(sc.dbFs) == 0
 	sc.dbFs[db.AliasedName()] = fs
 	if rotateOk && firstDb {
@@ -658,15 +662,23 @@ type commithook struct {
 }
 
 func (h commithook) Execute(ctx context.Context, ds datas.Dataset, db *doltdb.DoltDB) (func(context.Context) error, error) {
-	h.sc.mu.Lock()
-	defer h.sc.mu.Unlock()
-	if h.sc.quiescedAwake != nil {
-		close(h.sc.quiescedAwake)
-		h.sc.quiescedAwake = nil
-	}
+	h.sc.wakeStatsOnNewWrite()
 	return nil, nil
 }
 
 func (h commithook) ExecuteForWorkingSets() bool {
 	return true
+}
+
+func (sc *StatsController) wakeStatsOnNewWrite() {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.wakeStatsOnNewWriteLocked()
+}
+
+func (sc *StatsController) wakeStatsOnNewWriteLocked() {
+	if sc.quiescedAwake != nil {
+		close(sc.quiescedAwake)
+		sc.quiescedAwake = nil
+	}
 }

--- a/go/libraries/doltcore/sqle/statspro/initdbhook.go
+++ b/go/libraries/doltcore/sqle/statspro/initdbhook.go
@@ -40,6 +40,8 @@ func NewInitDatabaseHook(sc *StatsController) sqle.InitDatabaseHook {
 			return nil
 		}
 
+		denv.DoltDB(ctx).PrependCommitHooks(ctx, sc.commithook())
+
 		// call should only fail if backpressure in secondary queue
 		return sc.AddFs(ctx, sqlDb, denv.FS, true)
 	}

--- a/go/libraries/doltcore/sqle/statspro/listener.go
+++ b/go/libraries/doltcore/sqle/statspro/listener.go
@@ -81,6 +81,10 @@ func (sc *StatsController) addListener(e listenerEvent) (chan listenerEvent, err
 	}
 	l := listener{target: e, c: make(chan listenerEvent, 1)}
 	sc.listeners = append(sc.listeners, l)
+	if sc.quiescedAwake != nil {
+		close(sc.quiescedAwake)
+		sc.quiescedAwake = nil
+	}
 	return l.c, nil
 }
 
@@ -175,6 +179,7 @@ func (sc *StatsController) Init(ctx context.Context, pro *sqle.DoltDatabaseProvi
 			if i > 0 || sc.memOnly {
 				continue
 			}
+			db.DbData().Ddb.PrependCommitHooks(ctx, sc.commithook())
 			// attempt to access previously written stats
 			statsFs, err := fs.WithWorkingDir(dbfactory.DoltStatsDir)
 			if err != nil {

--- a/go/libraries/doltcore/sqle/statspro/script_test.go
+++ b/go/libraries/doltcore/sqle/statspro/script_test.go
@@ -19,6 +19,7 @@ import (
 	"log"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/stretchr/testify/require"
@@ -39,6 +40,13 @@ type assertion struct {
 }
 
 func TestStatScripts(t *testing.T) {
+	origTimeSource := mockableTimeSource
+	t.Cleanup(func() {
+		mockableTimeSource = origTimeSource
+	})
+	mockableTimeSource = func() time.Time {
+		return time.Time{}
+	}
 	threads := sql.NewBackgroundThreads()
 	defer threads.Shutdown()
 
@@ -257,6 +265,7 @@ func TestStatScripts(t *testing.T) {
 							CachedBoundCnt:    1,
 							CachedTemplateCnt: 1,
 							StatCnt:           1,
+							LastUpdate:        time.Time{},
 						}},
 					},
 				},
@@ -285,6 +294,7 @@ func TestStatScripts(t *testing.T) {
 							CachedBoundCnt:    2,
 							CachedTemplateCnt: 2,
 							StatCnt:           1,
+							LastUpdate:        time.Time{},
 						}},
 					},
 				},
@@ -313,6 +323,7 @@ func TestStatScripts(t *testing.T) {
 							CachedBoundCnt:    1,
 							CachedTemplateCnt: 1,
 							StatCnt:           1,
+							LastUpdate:        time.Time{},
 						}},
 					},
 				},
@@ -473,6 +484,7 @@ func TestStatScripts(t *testing.T) {
 							CachedBoundCnt:    2,
 							CachedTemplateCnt: 2,
 							StatCnt:           2,
+							LastUpdate:        time.Time{},
 						}},
 					},
 				},
@@ -497,6 +509,7 @@ func TestStatScripts(t *testing.T) {
 							CachedBoundCnt:    2,
 							CachedTemplateCnt: 2,
 							StatCnt:           1,
+							LastUpdate:        time.Time{},
 						},
 						}},
 				},
@@ -521,6 +534,7 @@ func TestStatScripts(t *testing.T) {
 							CachedBoundCnt:    2,
 							CachedTemplateCnt: 2,
 							StatCnt:           1,
+							LastUpdate:        time.Time{},
 						},
 						}},
 				},
@@ -549,6 +563,7 @@ func TestStatScripts(t *testing.T) {
 							CachedBoundCnt:    2,
 							CachedTemplateCnt: 2,
 							StatCnt:           2,
+							LastUpdate:        time.Time{},
 						},
 						}},
 				},
@@ -567,6 +582,7 @@ func TestStatScripts(t *testing.T) {
 							CachedBoundCnt:    2,
 							CachedTemplateCnt: 2,
 							StatCnt:           2,
+							LastUpdate:        time.Time{},
 						},
 						}},
 				},
@@ -585,6 +601,7 @@ func TestStatScripts(t *testing.T) {
 							CachedBoundCnt:    2,
 							CachedTemplateCnt: 2,
 							StatCnt:           2,
+							LastUpdate:        time.Time{},
 						},
 						}},
 				},
@@ -619,6 +636,7 @@ func TestStatScripts(t *testing.T) {
 							CachedBoundCnt:    0,
 							CachedTemplateCnt: 0,
 							StatCnt:           0,
+							LastUpdate:        time.Time{},
 						},
 						}},
 				},
@@ -640,6 +658,7 @@ func TestStatScripts(t *testing.T) {
 							CachedBoundCnt:    2,
 							CachedTemplateCnt: 2,
 							StatCnt:           2,
+							LastUpdate:        time.Time{},
 						},
 						}},
 				},
@@ -665,6 +684,7 @@ func TestStatScripts(t *testing.T) {
 						CachedTemplateCnt: 4,
 						StatCnt:           2,
 						Backing:           "mydb",
+						LastUpdate:        time.Time{},
 					}}},
 				},
 				{

--- a/go/libraries/doltcore/sqle/statspro/worker.go
+++ b/go/libraries/doltcore/sqle/statspro/worker.go
@@ -68,6 +68,8 @@ func (sc *StatsController) runWorker(ctx context.Context) (err error) {
 		default:
 		}
 
+		wake := sc.newQuiescedAwake()
+
 		gcKv = nil
 		genStart := sc.genCnt.Load()
 
@@ -97,11 +99,33 @@ func (sc *StatsController) runWorker(ctx context.Context) (err error) {
 			} else {
 				sc.descError("swapped stats with flush failure", err)
 			}
-		} else if ok && lastSuccessfulStats != nil && lastSuccessfulStats.hash != newStats.hash {
-			lastSuccessfulStats = newStats
-			sc.logger.Tracef("stats successful swap: %s\n", newStats.String())
+		} else if ok {
+			if lastSuccessfulStats != nil && lastSuccessfulStats.hash == newStats.hash {
+				select {
+				case <-ctx.Done():
+				case <-wake:
+				}
+			} else {
+				lastSuccessfulStats = newStats
+				sc.logger.Tracef("stats successful swap: %s\n", newStats.String())
+			}
 		}
 	}
+}
+
+// Always returns a non-nil chan. Sometimes that channel is already
+// closed, if the worker thread should not quiesce regardless of
+// whether it found novelty in computing stats or not.
+func (sc *StatsController) newQuiescedAwake() chan struct{} {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	ret := make(chan struct{})
+	if len(sc.listeners) == 0 {
+		sc.quiescedAwake = ret
+	} else {
+		close(ret)
+	}
+	return ret
 }
 
 func (sc *StatsController) trySwapStats(ctx context.Context, prevGen uint64, newStats *rootStats, gcKv *memStats) (ok bool, err error) {

--- a/go/libraries/doltcore/sqle/statspro/worker.go
+++ b/go/libraries/doltcore/sqle/statspro/worker.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"runtime/debug"
 	"strings"
+	"time"
 
 	"github.com/cespare/xxhash/v2"
 	"github.com/dolthub/go-mysql-server/sql"
@@ -36,6 +37,8 @@ import (
 	"github.com/dolthub/dolt/go/store/prolly/tree"
 	"github.com/dolthub/dolt/go/store/val"
 )
+
+var mockableTimeSource func() time.Time = time.Now
 
 const collectBatchSize = 20
 
@@ -303,6 +306,7 @@ func (sc *StatsController) newStatsForRoot(ctx *sql.Context, gcKv *memStats, byp
 	}
 
 	newStats.hash = digest.Sum64()
+	newStats.LastUpdate = mockableTimeSource()
 	return newStats, nil
 }
 

--- a/integration-tests/bats/stats.bats
+++ b/integration-tests/bats/stats.bats
@@ -293,7 +293,6 @@ SQL
     start_sql_server
 
     dolt sql -q "call dolt_stats_wait();"
-    dolt sql -q "call dolt_stats_info('--short');"
     run dolt sql -r csv -q "call dolt_stats_info('--short');"
     [ "$status" -eq 0 ]
     [[ "$output" =~ '"{""dbCnt"":2,""active"":true,""storageBucketCnt"":2,""cachedBucketCnt"":2,""cachedBoundCnt"":2,""cachedTemplateCnt"":4,""statCnt"":3,""backing"":""repo1"","' ]] || false
@@ -474,4 +473,56 @@ EOF
     run dolt sql -r csv -q "call dolt_stats_once(); select count(*) from dolt_statistics"
     [ "$status" -eq 0 ]
     [ "${lines[3]}" = "1" ]
+}
+
+@test "stats: worker thread quiesces and then runs again on new writes" {
+    get_stats_time() {
+        dolt sql -r csv -q 'call dolt_stats_info()' | tail -n 1 | sed -e 's|.*lastUpdate"":""||' -e 's|""}"$||'
+    }
+    newtime=
+    wait_for_new_time() {
+        # We don't use dolt_stats_wait here, because that would
+	# trigger a stats run on its own. Here we want to assert
+	# that an incoming write triggered the run.
+        cnt=0
+        while [[ "$newtime" == "$origtime" ]]; do
+	    newtime=$(get_stats_time)
+            if [ "$cnt" -eq 8 ]; then
+                echo "took too long to run stats after a write" 1>&2
+                exit 1
+            fi
+	    sleep 1
+	done
+    }
+    wait_for_quiesced() {
+        dolt sql -q 'call dolt_stats_wait();'
+        origtime=$(get_stats_time)
+        cnt=0
+        while [[ ! "$cnt" -eq 8 ]]; do
+            newtime=$(get_stats_time)
+            [[ "$newtime" == "$origtime" ]] || false
+            cnt=$((cnt+1))
+        done
+    }
+
+    start_sql_server
+
+    # After it runs, stats quiesces until a new write.
+    wait_for_quiesced
+
+    # Doing a write makes it run again
+    dolt sql -q 'create table vals (id int primary key)'
+    wait_for_new_time
+
+    wait_for_quiesced
+
+    # Creating a new database makes it run again
+    dolt sql -q 'create database newdb'
+    wait_for_new_time
+
+    wait_for_quiesced
+
+    # Writing against the new database makes it run again
+    dolt sql -q 'create table `newdb`.`newtable` (id int primary key)'
+    wait_for_new_time
 }

--- a/integration-tests/bats/stats.bats
+++ b/integration-tests/bats/stats.bats
@@ -48,7 +48,7 @@ teardown() {
 
     run dolt sql -r csv -q "call dolt_stats_once()"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ '{""dbCnt"":1,""bucketWrites"":2,""tablesProcessed"":2,""tablesSkipped"":0}"' ]] || false
+    [[ "$output" =~ '{""dbCnt"":1,""bucketWrites"":2,""tablesProcessed"":2,""tablesSkipped"":0,"' ]] || false
 }
 
 
@@ -59,7 +59,7 @@ teardown() {
 
     run dolt sql -r csv -q "call dolt_stats_once(); call dolt_stats_once()"
     [ "$status" -eq 0 ]
-    [[ "${lines[3]}" =~ '{""dbCnt"":1,""bucketWrites"":0,""tablesProcessed"":0,""tablesSkipped"":2}"' ]] || false
+    [[ "${lines[3]}" =~ '{""dbCnt"":1,""bucketWrites"":0,""tablesProcessed"":0,""tablesSkipped"":2,"' ]] || false
 }
 
 @test "stats: once after reload does no incremental work" {
@@ -70,7 +70,7 @@ teardown() {
     dolt sql -r csv -q "call dolt_stats_once();"
     run dolt sql -r csv -q "call dolt_stats_once();"
     [ "$status" -eq 0 ]
-    [[ "${lines[1]}" =~ '{""dbCnt"":1,""bucketWrites"":0,""tablesProcessed"":2,""tablesSkipped"":0}"' ]] || false
+    [[ "${lines[1]}" =~ '{""dbCnt"":1,""bucketWrites"":0,""tablesProcessed"":2,""tablesSkipped"":0,"' ]] || false
 }
 
 @test "stats: dolt_stats_wait" {
@@ -93,7 +93,7 @@ EOF
 
     run dolt sql -r csv -q "call dolt_stats_once(); call dolt_stats_info('--short')"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ '"{""dbCnt"":1,""active"":false,""storageBucketCnt"":2,""cachedBucketCnt"":2,""cachedBoundCnt"":2,""cachedTemplateCnt"":4,""statCnt"":2,""backing"":""repo2""}"' ]] || false
+    [[ "$output" =~ '"{""dbCnt"":1,""active"":false,""storageBucketCnt"":2,""cachedBucketCnt"":2,""cachedBoundCnt"":2,""cachedTemplateCnt"":4,""statCnt"":2,""backing"":""repo2"","' ]] || false
 }
 
 @test "stats: dolt_stats_server_wait" {
@@ -137,7 +137,7 @@ EOF
 
     run dolt sql -r csv -q "call dolt_stats_once(); call dolt_stats_purge(); call dolt_stats_info('--short')"
     [ "$status" -eq 0 ]
-    [[ "${lines[5]}" =~ '"{""dbCnt"":0,""active"":false,""storageBucketCnt"":0,""cachedBucketCnt"":0,""cachedBoundCnt"":0,""cachedTemplateCnt"":0,""statCnt"":0,""backing"":""repo2""}"' ]] || false
+    [[ "${lines[5]}" =~ '"{""dbCnt"":0,""active"":false,""storageBucketCnt"":0,""cachedBucketCnt"":0,""cachedBoundCnt"":0,""cachedTemplateCnt"":0,""statCnt"":0,""backing"":""repo2"","' ]] || false
 }
 
 @test "stats: dolt_stats_purge server" {
@@ -151,7 +151,7 @@ EOF
     dolt sql -q "call dolt_stats_purge()"
     run dolt sql -r csv -q "call dolt_stats_info('--short')"
     [ "$status" -eq 0 ]
-    [[ "${lines[1]}" =~ '"{""dbCnt"":0,""active"":false,""storageBucketCnt"":0,""cachedBucketCnt"":0,""cachedBoundCnt"":0,""cachedTemplateCnt"":0,""statCnt"":0,""backing"":""repo2""}"' ]] || false
+    [[ "${lines[1]}" =~ '"{""dbCnt"":0,""active"":false,""storageBucketCnt"":0,""cachedBucketCnt"":0,""cachedBoundCnt"":0,""cachedTemplateCnt"":0,""statCnt"":0,""backing"":""repo2"","' ]] || false
 }
 
 @test "stats: dolt_stats_gc fails in shell" {
@@ -168,7 +168,7 @@ SQL
 
     run dolt sql -r csv -q "call dolt_stats_info('--short')"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ '"{""dbCnt"":0,""active"":false,""storageBucketCnt"":4,""cachedBucketCnt"":0,""cachedBoundCnt"":0,""cachedTemplateCnt"":0,""statCnt"":0,""backing"":""repo2""}"' ]] || false
+    [[ "$output" =~ '"{""dbCnt"":0,""active"":false,""storageBucketCnt"":4,""cachedBucketCnt"":0,""cachedBoundCnt"":0,""cachedTemplateCnt"":0,""statCnt"":0,""backing"":""repo2"","' ]] || false
 }
 
 @test "stats: dolt_stats_gc server" {
@@ -210,14 +210,14 @@ SQL
     # stats: repo2:[xy,ab,toDelete]*3, other:[ot]*1
     run dolt sql -r csv -q "call dolt_stats_info('--short');"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ '"{""dbCnt"":4,""active"":true,""storageBucketCnt"":6,""cachedBucketCnt"":6,""cachedBoundCnt"":6,""cachedTemplateCnt"":6,""statCnt"":10,""backing"":""repo2""}"' ]] || false
+    [[ "$output" =~ '"{""dbCnt"":4,""active"":true,""storageBucketCnt"":6,""cachedBucketCnt"":6,""cachedBoundCnt"":6,""cachedTemplateCnt"":6,""statCnt"":10,""backing"":""repo2"","' ]] || false
 
     # clear invalid xy
     dolt sql -q "call dolt_stats_gc()"
     dolt sql -q "call dolt_stats_info('--short')"
     run dolt sql -r csv -q "call dolt_stats_info('--short')"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ '"{""dbCnt"":4,""active"":true,""storageBucketCnt"":4,""cachedBucketCnt"":4,""cachedBoundCnt"":4,""cachedTemplateCnt"":6,""statCnt"":10,""backing"":""repo2""}"' ]] || false
+    [[ "$output" =~ '"{""dbCnt"":4,""active"":true,""storageBucketCnt"":4,""cachedBucketCnt"":4,""cachedBoundCnt"":4,""cachedTemplateCnt"":6,""statCnt"":10,""backing"":""repo2"","' ]] || false
 
     # remove toDelete table from 2/3 branches and gc
     dolt sql -q "use repo2; call dolt_checkout('feat1'); drop table toDelete"
@@ -226,7 +226,7 @@ SQL
     dolt sql -q "call dolt_stats_info('--short')"
     run dolt sql -r csv -q "call dolt_stats_info('--short')"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ '"{""dbCnt"":4,""active"":true,""storageBucketCnt"":4,""cachedBucketCnt"":4,""cachedBoundCnt"":4,""cachedTemplateCnt"":6,""statCnt"":8,""backing"":""repo2""}"' ]] || false
+    [[ "$output" =~ '"{""dbCnt"":4,""active"":true,""storageBucketCnt"":4,""cachedBucketCnt"":4,""cachedBoundCnt"":4,""cachedTemplateCnt"":6,""statCnt"":8,""backing"":""repo2"","' ]] || false
 
     # remove branch stats and gc
     dolt sql -q "use repo2; call dolt_branch('-D', 'feat1', 'feat2')"
@@ -235,7 +235,7 @@ SQL
     dolt sql -q "call dolt_stats_info('--short')"
     run dolt sql -r csv -q "call dolt_stats_info('--short')"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ '"{""dbCnt"":2,""active"":true,""storageBucketCnt"":3,""cachedBucketCnt"":3,""cachedBoundCnt"":3,""cachedTemplateCnt"":5,""statCnt"":3,""backing"":""repo2""}"' ]] || false
+    [[ "$output" =~ '"{""dbCnt"":2,""active"":true,""storageBucketCnt"":3,""cachedBucketCnt"":3,""cachedBoundCnt"":3,""cachedTemplateCnt"":5,""statCnt"":3,""backing"":""repo2"","' ]] || false
 
     # delete whole db and gc
     dolt sql -q "drop database other;"
@@ -244,7 +244,7 @@ SQL
     dolt sql -r csv -q "call dolt_stats_info('--short')"
     run dolt sql -r csv -q "call dolt_stats_info('--short')"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ '"{""dbCnt"":1,""active"":true,""storageBucketCnt"":2,""cachedBucketCnt"":2,""cachedBoundCnt"":2,""cachedTemplateCnt"":4,""statCnt"":2,""backing"":""repo2""}"' ]] || false
+    [[ "$output" =~ '"{""dbCnt"":1,""active"":true,""storageBucketCnt"":2,""cachedBucketCnt"":2,""cachedBoundCnt"":2,""cachedTemplateCnt"":4,""statCnt"":2,""backing"":""repo2"","' ]] || false
 }
 
 @test "stats: delete database clean swap" {
@@ -276,7 +276,7 @@ SQL
     dolt sql -q "call dolt_stats_info('--short');"
     run dolt sql -r csv -q "call dolt_stats_info('--short');"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ '"{""dbCnt"":1,""active"":true,""storageBucketCnt"":1,""cachedBucketCnt"":1,""cachedBoundCnt"":1,""cachedTemplateCnt"":1,""statCnt"":1,""backing"":""other""}"' ]] || false
+    [[ "$output" =~ '"{""dbCnt"":1,""active"":true,""storageBucketCnt"":1,""cachedBucketCnt"":1,""cachedBoundCnt"":1,""cachedTemplateCnt"":1,""statCnt"":1,""backing"":""other"","' ]] || false
 }
 
 @test "stats: multiple stats dbs at start is OK" {
@@ -296,7 +296,7 @@ SQL
     dolt sql -q "call dolt_stats_info('--short');"
     run dolt sql -r csv -q "call dolt_stats_info('--short');"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ '"{""dbCnt"":2,""active"":true,""storageBucketCnt"":2,""cachedBucketCnt"":2,""cachedBoundCnt"":2,""cachedTemplateCnt"":4,""statCnt"":3,""backing"":""repo1""}"' ]] || false
+    [[ "$output" =~ '"{""dbCnt"":2,""active"":true,""storageBucketCnt"":2,""cachedBucketCnt"":2,""cachedBoundCnt"":2,""cachedTemplateCnt"":4,""statCnt"":3,""backing"":""repo1"","' ]] || false
 }
 
 @test "stats: dolt_stats_stop_restart" {
@@ -311,14 +311,14 @@ SQL
     dolt sql -q "call dolt_stats_info('--short')"
     run dolt sql -r csv -q "call dolt_stats_info('--short')"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ '"{""dbCnt"":1,""active"":true,""storageBucketCnt"":2,""cachedBucketCnt"":2,""cachedBoundCnt"":2,""cachedTemplateCnt"":4,""statCnt"":2,""backing"":""repo2""}"' ]] || false
+    [[ "$output" =~ '"{""dbCnt"":1,""active"":true,""storageBucketCnt"":2,""cachedBucketCnt"":2,""cachedBoundCnt"":2,""cachedTemplateCnt"":4,""statCnt"":2,""backing"":""repo2"","' ]] || false
 
     # stop turns stats off
     dolt sql -q "call dolt_stats_stop()"
     dolt sql -r csv -q "call dolt_stats_info('--short')"
     run dolt sql -r csv -q "call dolt_stats_info('--short')"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ '"{""dbCnt"":1,""active"":false,""storageBucketCnt"":2,""cachedBucketCnt"":2,""cachedBoundCnt"":2,""cachedTemplateCnt"":4,""statCnt"":2,""backing"":""repo2""}"' ]] || false
+    [[ "$output" =~ '"{""dbCnt"":1,""active"":false,""storageBucketCnt"":2,""cachedBucketCnt"":2,""cachedBoundCnt"":2,""cachedTemplateCnt"":4,""statCnt"":2,""backing"":""repo2"","' ]] || false
 
 
     # don't pick up changes when stopped
@@ -329,14 +329,14 @@ SQL
 
     run dolt sql -r csv -q "call dolt_stats_info('--short')"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ '"{""dbCnt"":1,""active"":false,""storageBucketCnt"":2,""cachedBucketCnt"":2,""cachedBoundCnt"":2,""cachedTemplateCnt"":4,""statCnt"":2,""backing"":""repo2""}"' ]] || false
+    [[ "$output" =~ '"{""dbCnt"":1,""active"":false,""storageBucketCnt"":2,""cachedBucketCnt"":2,""cachedBoundCnt"":2,""cachedTemplateCnt"":4,""statCnt"":2,""backing"":""repo2"","' ]] || false
 
     dolt sql -r csv -q "call dolt_stats_restart()"
     dolt sql -r csv -q "call dolt_stats_wait()"
     dolt sql -q "call dolt_stats_info('--short')"
     run dolt sql -r csv -q "call dolt_stats_info('--short')"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ '"{""dbCnt"":1,""active"":true,""storageBucketCnt"":4,""cachedBucketCnt"":4,""cachedBoundCnt"":4,""cachedTemplateCnt"":4,""statCnt"":2,""backing"":""repo2""}"' ]] || false
+    [[ "$output" =~ '"{""dbCnt"":1,""active"":true,""storageBucketCnt"":4,""cachedBucketCnt"":4,""cachedBoundCnt"":4,""cachedTemplateCnt"":4,""statCnt"":2,""backing"":""repo2"","' ]] || false
 }
 
 @test "stats: memory only doesn't write to disk" {
@@ -351,7 +351,7 @@ SQL
     dolt sql -q "call dolt_stats_info('--short')"
     run dolt sql -r csv -q "call dolt_stats_info('--short')"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ '"{""dbCnt"":1,""active"":true,""storageBucketCnt"":0,""cachedBucketCnt"":2,""cachedBoundCnt"":2,""cachedTemplateCnt"":4,""statCnt"":2,""backing"":""memory""}"' ]] || false
+    [[ "$output" =~ '"{""dbCnt"":1,""active"":true,""storageBucketCnt"":0,""cachedBucketCnt"":2,""cachedBoundCnt"":2,""cachedTemplateCnt"":4,""statCnt"":2,""backing"":""memory"","' ]] || false
 
     run dolt sql -r csv -q "select count(*) from dolt_statistics"
     [ "$status" -eq 0 ]
@@ -361,7 +361,7 @@ SQL
 
     run dolt sql -r csv -q "call dolt_stats_once(); call dolt_stats_info('--short')"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ '"{""dbCnt"":1,""active"":false,""storageBucketCnt"":0,""cachedBucketCnt"":2,""cachedBoundCnt"":2,""cachedTemplateCnt"":4,""statCnt"":2,""backing"":""memory""}"' ]] || false
+    [[ "$output" =~ '"{""dbCnt"":1,""active"":false,""storageBucketCnt"":0,""cachedBucketCnt"":2,""cachedBoundCnt"":2,""cachedTemplateCnt"":4,""statCnt"":2,""backing"":""memory"","' ]] || false
 }
 
 


### PR DESCRIPTION
Stats should not continuously consume CPU resources scanning database roots when it knows that stats are up to date and no intervening writes have occurred.