### PR TITLE
couple random splunk improvements

### DIFF
--- a/go/store/cmd/noms/noms_show.go
+++ b/go/store/cmd/noms/noms_show.go
@@ -241,7 +241,15 @@ func outputEncodedValue(ctx context.Context, w io.Writer, value types.Value) err
 			}
 			return tree.OutputAddressMapNode(w, node)
 		case serial.ProllyTreeNodeFileID:
-			fallthrough
+			node, _, err := shim.NodeFromValue(value)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(w, "(rows %d, depth %d) #%s {",
+				node.Count(), node.Level()+1, node.HashOf().String()[:8])
+			err = tree.OutputProllyNodeBytes(w, node)
+			fmt.Fprintf(w, "}\n")
+			return err
 		case serial.AddressMapFileID:
 			node, _, err := shim.NodeFromValue(value)
 			if err != nil {

--- a/go/store/cmd/noms/splunk.pl
+++ b/go/store/cmd/noms/splunk.pl
@@ -84,20 +84,17 @@ sub print_show {
     
     my $noms_show_output = show($hash);
     for my $line (split /\n/, $noms_show_output) {
-        if ($line =~ /#([a-z0-9]{32})/ ) {
-            $h = $1;
-            if ( $1 =~ /[a-z1-9]/ ) {
-                $hashes{$label} = $h;
-                print "$label)   $line\n";
-                $label++;
-            } else {
-                print "     $line\n";
-            }
-        } else {
-            print "     $line\n";
+        my @hashes = $line =~ m/#([a-z0-9]{32})/g;
+        my $pre;
+        foreach my $h ( @hashes ) {
+            $hashes{$label} = $h;
+            $pre .= "$label) ";
+            $label++;
         }
+        $pre .= "    " unless $pre;
+        print "$pre $line\n";
     }
-
+    
     return \%hashes;
 }
 


### PR DESCRIPTION
This fixes the ability of `noms show` to print index data (panicking before this change).

Also patches the splunk tool to allow more than one hash on a single output line to be examined.

Sample output:

```
     Table -  {
1)  	Schema: #q3kfuk6atrj3b6e46ultp97f86gh9crk
2)  	Violations: #00000000000000000000000000000000
3)  	Artifacts: #00000000000000000000000000000000
     	Autoinc: 0
4)  	Primary Index (rows 1, depth 1) #ep59g4n947egeqpqfe7ou4ikjvi81rov {
5) 6)      { key: 7669657700, 6d797600 value:  #jcch47j2ueiiuq31iuuvvbg7ve6inccc,  #53drvdrsgbvfhtnd03tlgbm1ngm72dp4, 4e4f5f454e47494e455f535542535449545554494f4e2c4f4e4c595f46554c4c5f47524f55505f42592c5354524943545f5452414e535f5441424c455300 }
     	}
     	Secondary Indexes (indexes 0, depth 1) o0te4bsh {
     	}
     }
> 5
     SerialMessage - {
     	Blob - create view myv as select * from abc
     }
> ..
     Table -  {
1)  	Schema: #q3kfuk6atrj3b6e46ultp97f86gh9crk
2)  	Violations: #00000000000000000000000000000000
3)  	Artifacts: #00000000000000000000000000000000
     	Autoinc: 0
4)  	Primary Index (rows 1, depth 1) #ep59g4n947egeqpqfe7ou4ikjvi81rov {
5) 6)      { key: 7669657700, 6d797600 value:  #jcch47j2ueiiuq31iuuvvbg7ve6inccc,  #53drvdrsgbvfhtnd03tlgbm1ngm72dp4, 4e4f5f454e47494e455f535542535449545554494f4e2c4f4e4c595f46554c4c5f47524f55505f42592c5354524943545f5452414e535f5441424c455300 }
     	}
     	Secondary Indexes (indexes 0, depth 1) o0te4bsh {
     	}
     }
> 6
     SerialMessage - {
     	Blob - {"CreatedAt":0}
     }
```