### PR TITLE
go: sqle/remotesrv.go: remotesapi writes against sql-server now trigger DoltDB commit hooks.

### DIFF
--- a/go/libraries/doltcore/sqle/remotesrv.go
+++ b/go/libraries/doltcore/sqle/remotesrv.go
@@ -23,9 +23,11 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"github.com/dolthub/dolt/go/libraries/doltcore/remotesrv"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"github.com/dolthub/dolt/go/store/datas"
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 type remotesrvStore struct {
@@ -61,13 +63,80 @@ func (s remotesrvStore) Get(ctx context.Context, path, _ string) (remotesrv.Remo
 	if !ok {
 		return nil, remotesrv.ErrUnimplemented
 	}
-	datasdb := doltdb.ExposeDatabaseFromDoltDB(sdb.DbData().Ddb)
+	ddb := sdb.DbData().Ddb
+	datasdb := doltdb.ExposeDatabaseFromDoltDB(ddb)
 	cs := datas.ChunkStoreFromDatabase(datasdb)
 	rss, ok := cs.(remotesrv.RemoteSrvStore)
 	if !ok {
 		return nil, remotesrv.ErrUnimplemented
 	}
-	return rss, nil
+	return hooksFiringRemoteSrvStore{rss, ddb}, nil
+}
+
+// hooksFiringRemoteSrvStore wraps a RemoteSrvStore and fires CommitHooks
+// registered on the associated DoltDB after a successful Commit. This is used
+// when sql-server exposes a remotesapi endpoint so that pushes from remote
+// clients trigger the same hooks (replication, stats, etc.) as writes through
+// the SQL engine.
+type hooksFiringRemoteSrvStore struct {
+	remotesrv.RemoteSrvStore
+	ddb *doltdb.DoltDB
+}
+
+// Commit implements remotesrv.RemoteSrvStore. After a successful commit it
+// fires the DoltDB's registered CommitHooks for every ref-typed dataset whose
+// head address changed between |last| and |current|.
+func (s hooksFiringRemoteSrvStore) Commit(ctx context.Context, current, last hash.Hash) (bool, error) {
+	// Snapshot old dataset head addresses before the commit.
+	oldDatasets, _ := s.ddb.DatasetsByRootHash(ctx, last)
+
+	ok, err := s.RemoteSrvStore.Commit(ctx, current, last)
+	if !ok || err != nil {
+		return ok, err
+	}
+
+	// Snapshot new dataset head addresses after the successful commit.
+	newDatasets, err := s.ddb.DatasetsByRootHash(ctx, current)
+	if err != nil {
+		// Don't fail the commit; hooks are best-effort.
+		return true, nil
+	}
+
+	// Build lookup maps for both old and new dataset head addresses.
+	oldAddrs := make(map[string]hash.Hash)
+	if oldDatasets != nil {
+		_ = oldDatasets.IterAll(ctx, func(id string, addr hash.Hash) error {
+			oldAddrs[id] = addr
+			return nil
+		})
+	}
+	newAddrs := make(map[string]hash.Hash)
+	_ = newDatasets.IterAll(ctx, func(id string, addr hash.Hash) error {
+		newAddrs[id] = addr
+		return nil
+	})
+
+	// Fire hooks for each ref-typed dataset that was added or changed.
+	for id, newAddr := range newAddrs {
+		if !ref.IsRef(id) {
+			continue
+		}
+		if oldAddr, existed := oldAddrs[id]; !existed || oldAddr != newAddr {
+			_ = s.ddb.ExecuteCommitHooks(ctx, id)
+		}
+	}
+
+	// Fire hooks for each ref-typed dataset that was deleted.
+	for id := range oldAddrs {
+		if !ref.IsRef(id) {
+			continue
+		}
+		if _, exists := newAddrs[id]; !exists {
+			_ = s.ddb.ExecuteCommitHooks(ctx, id)
+		}
+	}
+
+	return true, nil
 }
 
 // In the SQL context, the database provider that we use to expose the

--- a/go/libraries/doltcore/sqle/remotesrv_hook_test.go
+++ b/go/libraries/doltcore/sqle/remotesrv_hook_test.go
@@ -1,0 +1,257 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqle
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
+	"github.com/dolthub/dolt/go/libraries/doltcore/remotesrv"
+	"github.com/dolthub/dolt/go/store/datas"
+	"github.com/dolthub/dolt/go/store/hash"
+)
+
+// recordingCommitHook is a CommitHook that records the IDs of all datasets for
+// which it was executed.
+type recordingCommitHook struct {
+	mu    sync.Mutex
+	calls []string
+}
+
+func (h *recordingCommitHook) Execute(_ context.Context, ds datas.Dataset, _ *doltdb.DoltDB) (func(context.Context) error, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.calls = append(h.calls, ds.ID())
+	return nil, nil
+}
+
+func (h *recordingCommitHook) ExecuteForWorkingSets() bool { return false }
+
+func (h *recordingCommitHook) calledFor(datasetID string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return slices.Contains(h.calls, datasetID)
+}
+
+func (h *recordingCommitHook) numCalls() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.calls)
+}
+
+var _ doltdb.CommitHook = (*recordingCommitHook)(nil)
+
+// makeTestCommit creates a second commit on the main branch and returns the
+// old and new noms root hashes. The hook is installed before the commit is
+// replayed via the low-level store, so only the store-level replay should
+// trigger it.
+func makeTestCommit(t *testing.T, ctx context.Context, ddb *doltdb.DoltDB) (oldRoot, newRoot hash.Hash) {
+	t.Helper()
+	rawDB := doltdb.ExposeDatabaseFromDoltDB(ddb)
+	cs := datas.ChunkStoreFromDatabase(rawDB)
+
+	// Record the noms root before the commit.
+	var err error
+	oldRoot, err = cs.Root(ctx)
+	require.NoError(t, err)
+
+	// Create a new commit on main.
+	headCommit, err := ddb.ResolveCommitRef(ctx, ref.NewBranchRef("main"))
+	require.NoError(t, err)
+	rootVal, err := headCommit.GetRootValue(ctx)
+	require.NoError(t, err)
+	valHash, err := rootVal.HashOf()
+	require.NoError(t, err)
+	meta, err := datas.NewCommitMeta("test", "test@test.com", "test commit")
+	require.NoError(t, err)
+	_, err = ddb.Commit(ctx, valHash, ref.NewBranchRef("main"), meta)
+	require.NoError(t, err)
+
+	// Record the noms root after the commit.
+	newRoot, err = cs.Root(ctx)
+	require.NoError(t, err)
+	require.NotEqual(t, oldRoot, newRoot, "noms root must have advanced after commit")
+
+	// Rewind the ChunkStore back to oldRoot so the test can replay the
+	// commit via hooksFiringRemoteSrvStore.
+	rewound, err := cs.Commit(ctx, oldRoot, newRoot)
+	require.NoError(t, err)
+	require.True(t, rewound, "rewind of ChunkStore to oldRoot must succeed")
+
+	return oldRoot, newRoot
+}
+
+// TestHooksFiredOnRemoteSrvStoreCommit verifies that hooksFiringRemoteSrvStore
+// fires the DoltDB's CommitHooks when a push commit succeeds.
+func TestHooksFiredOnRemoteSrvStoreCommit(t *testing.T) {
+	ctx := t.Context()
+	dEnv := CreateTestEnv()
+	defer dEnv.DoltDB(ctx).Close()
+
+	ddb := dEnv.DoltDB(ctx)
+	oldRoot, newRoot := makeTestCommit(t, ctx, ddb)
+
+	// Install recording hook after the rewind so we only capture the
+	// replay via the low-level store path.
+	hook := &recordingCommitHook{}
+	ddb.PrependCommitHooks(ctx, hook)
+
+	rawDB := doltdb.ExposeDatabaseFromDoltDB(ddb)
+	cs := datas.ChunkStoreFromDatabase(rawDB)
+	rss, ok := cs.(remotesrv.RemoteSrvStore)
+	require.True(t, ok, "in-memory NBS must implement RemoteSrvStore")
+
+	store := hooksFiringRemoteSrvStore{rss, ddb}
+	committed, err := store.Commit(ctx, newRoot, oldRoot)
+	require.NoError(t, err)
+	require.True(t, committed)
+
+	assert.True(t, hook.calledFor("refs/heads/main"),
+		"hook must be called for refs/heads/main after a successful push commit")
+}
+
+// TestHooksNotFiredOnFailedRemoteSrvCommit verifies that hooks are NOT fired
+// when the underlying ChunkStore Commit returns false (e.g. CAS failure due
+// to a concurrent update).
+func TestHooksNotFiredOnFailedRemoteSrvCommit(t *testing.T) {
+	ctx := t.Context()
+	dEnv := CreateTestEnv()
+	defer dEnv.DoltDB(ctx).Close()
+
+	ddb := dEnv.DoltDB(ctx)
+	oldRoot, newRoot := makeTestCommit(t, ctx, ddb)
+
+	hook := &recordingCommitHook{}
+	ddb.PrependCommitHooks(ctx, hook)
+
+	rawDB := doltdb.ExposeDatabaseFromDoltDB(ddb)
+	cs := datas.ChunkStoreFromDatabase(rawDB)
+	rss, ok := cs.(remotesrv.RemoteSrvStore)
+	require.True(t, ok)
+
+	store := hooksFiringRemoteSrvStore{rss, ddb}
+
+	// Pass a wrong last hash (zero hash is never a valid noms root for an
+	// initialised repo). The NBS CAS check will reject this because the
+	// actual current root is oldRoot, not hash.Hash{}.
+	var wrongLast hash.Hash
+	committed, err := store.Commit(ctx, newRoot, wrongLast)
+	require.NoError(t, err)
+	assert.False(t, committed, "commit must be rejected when last hash is wrong")
+	assert.Equal(t, 0, hook.numCalls(), "hooks must not fire on a rejected commit")
+
+	// Actual oldRoot → newRoot should still work afterwards.
+	committed, err = store.Commit(ctx, newRoot, oldRoot)
+	require.NoError(t, err)
+	assert.True(t, committed)
+	assert.Equal(t, 1, hook.numCalls(), "hook must fire exactly once after the successful commit")
+}
+
+// TestHooksFiredOnDeletedDataset verifies that a hook fires for a ref-typed
+// dataset that was present at |last| but absent at |current| (i.e. a branch
+// delete pushed via remotesrv). This mirrors the behaviour of
+// hooksDatabase.Delete which also fires hooks for deleted datasets.
+func TestHooksFiredOnDeletedDataset(t *testing.T) {
+	ctx := t.Context()
+	dEnv := CreateTestEnv()
+	defer dEnv.DoltDB(ctx).Close()
+
+	ddb := dEnv.DoltDB(ctx)
+
+	// Create a feature branch so it exists in R_old.
+	headCommit, err := ddb.ResolveCommitRef(ctx, ref.NewBranchRef("main"))
+	require.NoError(t, err)
+	err = ddb.NewBranchAtCommit(ctx, ref.NewBranchRef("feature"), headCommit, nil)
+	require.NoError(t, err)
+
+	rawDB := doltdb.ExposeDatabaseFromDoltDB(ddb)
+	cs := datas.ChunkStoreFromDatabase(rawDB)
+
+	oldRoot, err := cs.Root(ctx)
+	require.NoError(t, err)
+
+	// Delete feature branch via DoltDB; this advances the noms root.
+	err = ddb.DeleteBranch(ctx, ref.NewBranchRef("feature"), nil)
+	require.NoError(t, err)
+
+	newRoot, err := cs.Root(ctx)
+	require.NoError(t, err)
+	require.NotEqual(t, oldRoot, newRoot)
+
+	// Rewind so we can replay via the low-level store path.
+	rewound, err := cs.Commit(ctx, oldRoot, newRoot)
+	require.NoError(t, err)
+	require.True(t, rewound)
+
+	hook := &recordingCommitHook{}
+	ddb.PrependCommitHooks(ctx, hook)
+
+	rss, ok := cs.(remotesrv.RemoteSrvStore)
+	require.True(t, ok)
+
+	store := hooksFiringRemoteSrvStore{rss, ddb}
+	committed, err := store.Commit(ctx, newRoot, oldRoot)
+	require.NoError(t, err)
+	require.True(t, committed)
+
+	assert.True(t, hook.calledFor("refs/heads/feature"),
+		"hook must fire for a branch that was deleted by the push")
+	assert.False(t, hook.calledFor("refs/heads/main"),
+		"hook must not fire for a branch that was unchanged")
+}
+
+// TestOnlyChangedDatasetsFireHooks verifies that hooks are only fired for
+// datasets whose head address actually changed between last and current.
+func TestOnlyChangedDatasetsFireHooks(t *testing.T) {
+	ctx := t.Context()
+	dEnv := CreateTestEnv()
+	defer dEnv.DoltDB(ctx).Close()
+
+	ddb := dEnv.DoltDB(ctx)
+
+	// Create a second branch before recording any hashes so it exists at oldRoot.
+	headCommit, err := ddb.ResolveCommitRef(ctx, ref.NewBranchRef("main"))
+	require.NoError(t, err)
+	err = ddb.NewBranchAtCommit(ctx, ref.NewBranchRef("feature"), headCommit, nil)
+	require.NoError(t, err)
+
+	// Now make a commit only on main; feature branch head stays the same.
+	oldRoot, newRoot := makeTestCommit(t, ctx, ddb)
+
+	hook := &recordingCommitHook{}
+	ddb.PrependCommitHooks(ctx, hook)
+
+	rawDB := doltdb.ExposeDatabaseFromDoltDB(ddb)
+	cs := datas.ChunkStoreFromDatabase(rawDB)
+	rss, ok := cs.(remotesrv.RemoteSrvStore)
+	require.True(t, ok)
+
+	store := hooksFiringRemoteSrvStore{rss, ddb}
+	committed, err := store.Commit(ctx, newRoot, oldRoot)
+	require.NoError(t, err)
+	require.True(t, committed)
+
+	assert.True(t, hook.calledFor("refs/heads/main"),
+		"hook must fire for the branch whose head changed")
+	assert.False(t, hook.calledFor("refs/heads/feature"),
+		"hook must not fire for a branch whose head did not change")
+}

--- a/integration-tests/bats/sql-server-remotesrv.bats
+++ b/integration-tests/bats/sql-server-remotesrv.bats
@@ -787,3 +787,55 @@ GRANT CLONE_ADMIN ON *.* TO clone_admin_user@'localhost';
     [[ "$output" =~ "new_branch" ]] || false
     [[ "$output" =~ "main" ]] || false
 }
+
+# Verifies that commit hooks installed on a sql-server DoltDB (e.g. push-on-write
+# replication) are triggered when a push is received via the --remotesapi-port
+# endpoint, not just when writes come through the SQL engine.
+@test "sql-server-remotesrv: push via remotesapi port triggers push-on-write replication" {
+    mkdir server_db replication_remote
+    cd server_db
+    dolt init
+    dolt sql -q 'create table t1 (a int primary key);'
+    dolt add t1
+    dolt commit -m 'initial commit'
+
+    # Set up a file remote as the push-on-write replication target and seed
+    # it with the initial state of the server database.
+    dolt remote add replication_target file://../replication_remote
+    dolt push replication_target main
+
+    # Configure push-on-write replication so that commit hooks push to the
+    # file remote whenever a branch is updated.
+    dolt config --local --add sqlserver.global.dolt_replicate_to_remote replication_target
+
+    # Create a SQL user so the remotesapi endpoint requires credentials.
+    dolt sql -q "CREATE USER root@'%' IDENTIFIED BY 'rootpass'; GRANT ALL ON *.* TO root@'%';"
+    export DOLT_REMOTE_PASSWORD="rootpass"
+    export SQL_USER="root"
+
+    APIPORT=$( definePORT )
+    start_sql_server_with_args --remotesapi-port $APIPORT
+
+    # Clone the server database via the remotesapi endpoint.
+    cd ..
+    dolt clone http://localhost:$APIPORT/server_db client_clone -u root
+    cd client_clone
+
+    # Push a new commit from the client back to the sql-server via the
+    # remotesapi endpoint. This exercises the hooksFiringRemoteSrvStore
+    # code path that fires commit hooks after a low-level ChunkStore commit.
+    dolt sql -q 'insert into t1 values (1), (2), (3);'
+    dolt commit -am 'add rows via remotesapi push'
+    run dolt push origin main:main --user root
+    [ "$status" -eq 0 ]
+
+    # The commit hooks on the server's DoltDB should have fired and
+    # replicated the new commit to the file remote. Clone the replication
+    # target and verify the replicated commit is present.
+    cd ..
+    dolt clone file://./replication_remote replication_clone
+    cd replication_clone
+    run dolt log -n 1
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "add rows via remotesapi push" ]] || false
+}


### PR DESCRIPTION
When dolt sql-server runs with --remotesapi-port, incoming dolt push operations write directly to the underlying ChunkStore, bypassing the hooksDatabase wrapper on DoltDB. This meant commit hooks — including push-on-write replication, stats, cluster sync, and auto-GC — were silently skipped for any write that arrived via the remotesapi endpoint rather than through the SQL engine.

Changes

sqle/remotesrv.go — the DBCache implementation used by sql-server's remotesrv — previously discarded the *doltdb.DoltDB (with its registered hooks) after extracting the raw ChunkStore. It now returns a hooksFiringRemoteSrvStore wrapper instead of the bare store.

After a successful Commit(), the wrapper:
1. Diffs the dataset map at last vs current noms root hashes
2. Fires ddb.ExecuteCommitHooks() for every ref-typed dataset (refs/heads/*, refs/tags/*, etc.) whose head address changed or was deleted — matching the behaviour of hooksDatabase

No changes to remotesrv, doltdb, or the gRPC layer were required.

Tests

- sqle/remotesrv_hook_test.go — unit tests covering the basic behavior of firing hooks on an incoming commit; hooks fire for successful commit, hooks do not fire on a rejected (CAS-failed) commit; hooks fire for deleted datasets (matching hooksDatabase.Delete); hooks only fire for datasets that actually changed.
- integration-tests/bats/sql-server-remotesrv.bats — end-to-end test: starts a sql-server with push-on-write replication to a file remote and --remotesapi-port, performs a dolt push from a client, and asserts the replication remote is updated.