### PR TITLE
fix: join hint doesn't work when table names are quoted

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -208,4 +208,6 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 )
 
+replace github.com/dolthub/go-mysql-server => github.com/majiayu000/go-mysql-server v0.20.1-0.20260321223822-d93f4fe6386e
+
 go 1.25.6

--- a/go/go.sum
+++ b/go/go.sum
@@ -212,8 +212,6 @@ github.com/dolthub/fslock v0.0.0-20251215194149-ef20baba2318 h1:n+vdH5G5Db+1qnDC
 github.com/dolthub/fslock v0.0.0-20251215194149-ef20baba2318/go.mod h1:QWql+P17oAAMLnL4HGB5tiovtDuAjdDTPbuqx7bYfa0=
 github.com/dolthub/go-icu-regex v0.0.0-20250916051405-78a38d478790 h1:zxMsH7RLiG+dlZ/y0LgJHTV26XoiSJcuWq+em6t6VVc=
 github.com/dolthub/go-icu-regex v0.0.0-20250916051405-78a38d478790/go.mod h1:F3cnm+vMRK1HaU6+rNqQrOCyR03HHhR1GWG2gnPOqaE=
-github.com/dolthub/go-mysql-server v0.20.1-0.20260319021557-3b1ba29f1e79 h1:zN/+1a2tCSoNNARJa21dH8x8/Q/p9YvqXbx3wjPzRSo=
-github.com/dolthub/go-mysql-server v0.20.1-0.20260319021557-3b1ba29f1e79/go.mod h1:ZPKRptEeXSk9Ytb9LhB+8tB4BkltxuNYiYDFvIqXD/4=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20240701202509-2b217167d718 h1:lT7hE5k+0nkBdj/1UOSFwjWpNxf+LCApbRHgnCA17XE=
@@ -424,6 +422,8 @@ github.com/lib/pq v1.10.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/lyft/protoc-gen-star v0.5.2/go.mod h1:9toiA3cC7z5uVbODF7kEQ91Xn7XNFkVUl+SrEe+ZORU=
+github.com/majiayu000/go-mysql-server v0.20.1-0.20260321223822-d93f4fe6386e h1:1SgFvk5szmLaMml3gHYMlqtK0PTDhf61TD55MRw8p84=
+github.com/majiayu000/go-mysql-server v0.20.1-0.20260321223822-d93f4fe6386e/go.mod h1:ZPKRptEeXSk9Ytb9LhB+8tB4BkltxuNYiYDFvIqXD/4=
 github.com/mark3labs/mcp-go v0.34.0 h1:eWy7WBGvhk6EyAAyVzivTCprE52iXJwNtvHV6Cv3bR0=
 github.com/mark3labs/mcp-go v0.34.0/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=


### PR DESCRIPTION
Fixes #10528

## Summary

Join hints like `LOOKUP_JOIN(t1, `t2`)` silently fail when table names are backtick-quoted. The `argsRegex` in `parseJoinHints()` captures backticks as part of the argument value, but the AST table name (from the parser) has backticks already stripped. The `strings.EqualFold` comparison in `SetJoinOp()` fails, so the hint is ignored.

**Fix**: Strip surrounding backticks from parsed hint arguments using `strings.Trim(arg[1], "`")` in `go-mysql-server/sql/memo/select_hints.go`.

The actual code change is in go-mysql-server: dolthub/go-mysql-server#3477

This PR points the `go-mysql-server` dependency to the fork with the fix via a `replace` directive. The replace directive should be removed and replaced with a proper version bump once the upstream PR is merged.

## Test plan

- 4 new unit tests added upstream for backtick-quoted args in `LOOKUP_JOIN`, `HASH_JOIN`, `MERGE_JOIN`, and `JOIN_ORDER`
- All 28 existing + new hint parsing tests pass