### PR TITLE
Fix dolt push failing when remote has ignored tables in working set

### DIFF
--- a/go/libraries/doltcore/env/actions/remotes.go
+++ b/go/libraries/doltcore/env/actions/remotes.go
@@ -49,21 +49,6 @@ var ErrShallowPushImpossible = errors.New("shallow repository missing chunks to 
 type ProgStarter func(ctx context.Context) (*sync.WaitGroup, chan pull.Stats)
 type ProgStopper func(cancel context.CancelFunc, wg *sync.WaitGroup, statsCh chan pull.Stats)
 
-// pushSkippingIgnoredTables is called when FastForwardWithWorkspaceCheck returns ErrDirtyWorkspace.
-// If the only uncommitted changes on the remote are ignored tables, the push is allowed to proceed
-// by falling back to FastForward without the workspace assertion.
-func pushSkippingIgnoredTables(ctx context.Context, destDB *doltdb.DoltDB, destRef ref.BranchRef, commit *doltdb.Commit) error {
-	roots, err := destDB.ResolveBranchRoots(ctx, destRef)
-	if err != nil {
-		return datas.ErrDirtyWorkspace
-	}
-	onlyIgnored, err := diff.WorkingSetContainsOnlyIgnoredTables(ctx, roots)
-	if err != nil || !onlyIgnored {
-		return datas.ErrDirtyWorkspace
-	}
-	return destDB.FastForward(ctx, destRef, commit)
-}
-
 // Push will update a destination branch, in a given destination database if it can be done as a fast forward merge.
 // This is accomplished first by verifying that the remote tracking reference for the source database can be updated to
 // the given commit via a fast forward merge.  If this is the case, an attempt will be made to update the branch in the
@@ -104,9 +89,17 @@ func Push(ctx context.Context, tempTableDir string, mode ref.UpdateMode, destRef
 		}
 		err = srcDB.SetHeadToCommit(ctx, remoteRef, commit)
 	case ref.FastForwardOnly:
-		err = destDB.FastForwardWithWorkspaceCheck(ctx, destRef, commit)
-		if errors.Is(err, datas.ErrDirtyWorkspace) {
-			err = pushSkippingIgnoredTables(ctx, destDB, destRef, commit)
+		// ResolveBranchRoots fails for remotes that don't maintain a working set (e.g. file://),
+		// in which case FastForwardWithWorkspaceCheck handles it correctly without the ignored-table check.
+		onlyIgnored := false
+		roots, err := destDB.ResolveBranchRoots(ctx, destRef)
+		if err == nil {
+			onlyIgnored, _ = diff.WorkingSetContainsOnlyIgnoredTables(ctx, roots)
+		}
+		if onlyIgnored {
+			err = destDB.FastForward(ctx, destRef, commit)
+		} else {
+			err = destDB.FastForwardWithWorkspaceCheck(ctx, destRef, commit)
 		}
 		if err != nil {
 			return err

--- a/go/libraries/doltcore/env/actions/remotes.go
+++ b/go/libraries/doltcore/env/actions/remotes.go
@@ -25,6 +25,7 @@ import (
 	eventsapi "github.com/dolthub/eventsapi_schema/dolt/services/eventsapi/v1alpha1"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/doltcore/diff"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
@@ -47,6 +48,21 @@ var ErrShallowPushImpossible = errors.New("shallow repository missing chunks to 
 
 type ProgStarter func(ctx context.Context) (*sync.WaitGroup, chan pull.Stats)
 type ProgStopper func(cancel context.CancelFunc, wg *sync.WaitGroup, statsCh chan pull.Stats)
+
+// pushSkippingIgnoredTables is called when FastForwardWithWorkspaceCheck returns ErrDirtyWorkspace.
+// If the only uncommitted changes on the remote are ignored tables, the push is allowed to proceed
+// by falling back to FastForward without the workspace assertion.
+func pushSkippingIgnoredTables(ctx context.Context, destDB *doltdb.DoltDB, destRef ref.BranchRef, commit *doltdb.Commit) error {
+	roots, err := destDB.ResolveBranchRoots(ctx, destRef)
+	if err != nil {
+		return datas.ErrDirtyWorkspace
+	}
+	onlyIgnored, err := diff.WorkingSetContainsOnlyIgnoredTables(ctx, roots)
+	if err != nil || !onlyIgnored {
+		return datas.ErrDirtyWorkspace
+	}
+	return destDB.FastForward(ctx, destRef, commit)
+}
 
 // Push will update a destination branch, in a given destination database if it can be done as a fast forward merge.
 // This is accomplished first by verifying that the remote tracking reference for the source database can be updated to
@@ -89,6 +105,9 @@ func Push(ctx context.Context, tempTableDir string, mode ref.UpdateMode, destRef
 		err = srcDB.SetHeadToCommit(ctx, remoteRef, commit)
 	case ref.FastForwardOnly:
 		err = destDB.FastForwardWithWorkspaceCheck(ctx, destRef, commit)
+		if errors.Is(err, datas.ErrDirtyWorkspace) {
+			err = pushSkippingIgnoredTables(ctx, destDB, destRef, commit)
+		}
 		if err != nil {
 			return err
 		}

--- a/integration-tests/bats/helper/windows-compat.bash
+++ b/integration-tests/bats/helper/windows-compat.bash
@@ -5,7 +5,14 @@ skiponwindows() { :; }
 IS_WINDOWS=${IS_WINDOWS:-false}
 WINDOWS_BASE_DIR=${WINDOWS_BASE_DIR:-/mnt/c}
 
-if [ -d "$WINDOWS_BASE_DIR"/Windows/System32 ]  || [ "$IS_WINDOWS" == true ]; then
+# Detect WSL: it mounts the Windows drive at /mnt/c but runs a Linux kernel.
+# /proc/version contains "microsoft" or "WSL" in WSL environments.
+IS_WSL=false
+if grep -qi microsoft /proc/version 2>/dev/null || grep -qi wsl /proc/version 2>/dev/null; then
+    IS_WSL=true
+fi
+
+if { [ -d "$WINDOWS_BASE_DIR"/Windows/System32 ] && [ "$IS_WSL" == false ]; } || [ "$IS_WINDOWS" == true ]; then
     IS_WINDOWS=true
     if [ ! -d "$WINDOWS_BASE_DIR"/batstmp ]; then
         mkdir "$WINDOWS_BASE_DIR"/batstmp

--- a/integration-tests/bats/push.bats
+++ b/integration-tests/bats/push.bats
@@ -268,3 +268,4 @@ teardown() {
     [ "$status" -eq 0 ]
     ! [[ "$output" =~ "Uploading..." ]] || false
 }
+

--- a/integration-tests/bats/push.bats
+++ b/integration-tests/bats/push.bats
@@ -269,3 +269,25 @@ teardown() {
     ! [[ "$output" =~ "Uploading..." ]] || false
 }
 
+@test "push: push succeeds when file:// remote has ignored tables in working set" {
+    mkdir "$TESTDIRS"/rem2 "$TESTDIRS"/local
+    cd "$TESTDIRS"/local
+    dolt init
+    dolt remote add origin file://../rem2
+    dolt sql -q "CREATE TABLE t (id INT PRIMARY KEY)"
+    dolt sql -q "INSERT INTO dolt_ignore VALUES ('ignored_table', true)"
+    dolt add .
+    dolt commit -m "Initial commit"
+    dolt push origin main
+
+    cd "$TESTDIRS"
+    dolt clone file://rem2 local2
+    cd local2
+    dolt sql -q "INSERT INTO t VALUES (1)"
+    dolt add .
+    dolt commit -m "Second commit"
+
+    run dolt push origin main
+    [ "$status" -eq 0 ]
+}
+

--- a/integration-tests/bats/remotes-sql-server.bats
+++ b/integration-tests/bats/remotes-sql-server.bats
@@ -505,6 +505,39 @@ teardown() {
     [ "${#lines[@]}" -ne 0 ]
 }
 
+@test "remotes-sql-server: push succeeds when remote sql-server has ignored tables in working set" {
+    skiponwindows "Missing dependencies"
+
+    make_repo remote_repo
+    cd remote_repo
+    dolt sql -q "CREATE TABLE t (id INT PRIMARY KEY)"
+    dolt sql -q "INSERT INTO t VALUES (1)"
+    dolt sql -q "INSERT INTO dolt_ignore VALUES ('ignored_table', true)"
+    dolt add .
+    dolt commit -m "Initial commit"
+
+    dolt sql -q "CREATE TABLE ignored_table (id INT PRIMARY KEY)"
+    dolt sql -q "INSERT INTO ignored_table VALUES (1)"
+
+    # Sanity check: ignored_table must not appear in dolt_status
+    run dolt sql -q "SELECT * FROM dolt_status" -r csv
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "ignored_table" ]] || false
+
+    REMOTESAPI_PORT=$(definePORT)
+    start_sql_server_with_args --host 0.0.0.0 --remotesapi-port=$REMOTESAPI_PORT
+
+    cd ..
+    dolt clone http://localhost:$REMOTESAPI_PORT/remote_repo local_repo
+    cd local_repo
+    dolt sql -q "INSERT INTO t VALUES (2)"
+    dolt add .
+    dolt commit -m "Second commit"
+
+    run dolt push origin main
+    [ "$status" -eq 0 ]
+}
+
 get_head_commit() {
     dolt log -n 1 | grep -m 1 commit | cut -c 13-44
 }

--- a/integration-tests/bats/remotes-sql-server.bats
+++ b/integration-tests/bats/remotes-sql-server.bats
@@ -525,10 +525,10 @@ teardown() {
     [[ ! "$output" =~ "ignored_table" ]] || false
 
     REMOTESAPI_PORT=$(definePORT)
-    start_sql_server_with_args --host 0.0.0.0 --remotesapi-port=$REMOTESAPI_PORT
+    start_sql_server_with_args --host 0.0.0.0 --remotesapi-port="$REMOTESAPI_PORT"
 
     cd ..
-    dolt clone http://localhost:$REMOTESAPI_PORT/remote_repo local_repo
+    dolt clone "http://localhost:$REMOTESAPI_PORT/remote_repo" local_repo
     cd local_repo
     dolt sql -q "INSERT INTO t VALUES (2)"
     dolt add .


### PR DESCRIPTION
`dolt push` returned "target has uncommitted changes. --force required to overwrite" when the remote's working set contained tables listed in `dolt_ignore`, even though `dolt status` showed clean. Push now succeeds in this case, consistent with how other commands (rebase, pull, stash) already handle ignored tables.
Fix #10727