### PR TITLE
go: sqle: replication.go: Use unique thread names in BackgroundThreads for each async replication background thread.

### DIFF
--- a/go/libraries/doltcore/sqle/commit_hooks.go
+++ b/go/libraries/doltcore/sqle/commit_hooks.go
@@ -117,10 +117,10 @@ const (
 var _ doltdb.CommitHook = (*AsyncPushOnWriteHook)(nil)
 
 // NewAsyncPushOnWriteHook creates a AsyncReplicateHook
-func NewAsyncPushOnWriteHook(tmpDir string, logger io.Writer) (*AsyncPushOnWriteHook, RunAsyncThreads) {
+func NewAsyncPushOnWriteHook(nameSuffix string, tmpDir string, logger io.Writer) (*AsyncPushOnWriteHook, RunAsyncThreads) {
 	ch := make(chan PushArg, asyncPushBufferSize)
-	runThreads := func(bThreads *sql.BackgroundThreads, ctxF func(context.Context) (*sql.Context, error)) error {
-		return RunAsyncReplicationThreads(bThreads, ctxF, ch, tmpDir, logger)
+	runThreads := func(bThreads BackgroundThreads, ctxF func(context.Context) (*sql.Context, error)) error {
+		return RunAsyncReplicationThreads(bThreads, nameSuffix, ctxF, ch, tmpDir, logger)
 	}
 	return &AsyncPushOnWriteHook{ch: ch}, runThreads
 }
@@ -173,7 +173,7 @@ func (*LogHook) ExecuteForWorkingSets() bool {
 	return false
 }
 
-func RunAsyncReplicationThreads(bThreads *sql.BackgroundThreads, ctxF func(context.Context) (*sql.Context, error), ch chan PushArg, tmpDir string, logger io.Writer) error {
+func RunAsyncReplicationThreads(bThreads BackgroundThreads, nameSuffix string, ctxF func(context.Context) (*sql.Context, error), ch chan PushArg, tmpDir string, logger io.Writer) error {
 	mu := &sync.Mutex{}
 	var newHeads = make(map[string]PushArg, asyncPushBufferSize)
 
@@ -193,7 +193,7 @@ func RunAsyncReplicationThreads(bThreads *sql.BackgroundThreads, ctxF func(conte
 	// We do not track sequential commits because push follows historical
 	// dependencies. This does not account for reset --force, which
 	// breaks historical dependence.
-	err := bThreads.Add(asyncPushProcessCommit, func(ctx context.Context) {
+	err := bThreads.Add(asyncPushProcessCommit+nameSuffix, func(ctx context.Context) {
 		for {
 			select {
 			case p, ok := <-ch:
@@ -258,7 +258,7 @@ func RunAsyncReplicationThreads(bThreads *sql.BackgroundThreads, ctxF func(conte
 	// The second goroutine pushes updates to a remote chunkstore.
 	// This goroutine waits for first goroutine to drain before closing
 	// the channel and exiting.
-	err = bThreads.Add(asyncPushSyncReplica, func(ctx context.Context) {
+	err = bThreads.Add(asyncPushSyncReplica+nameSuffix, func(ctx context.Context) {
 		defer close(ch)
 		var latestHeads = make(map[string]hash.Hash, asyncPushBufferSize)
 		ticker := time.NewTicker(asyncPushInterval)
@@ -304,7 +304,7 @@ var _ doltdb.CommitHook = (*DynamicPushOnWriteHook)(nil)
 // NewDynamicPushOnWriteHook creates a DynamicPushOnWriteHook, parameterized by the environment and a logger. The configuration
 // options at this time can result in errors, for example if the provided remote does not exist. This is not the case
 // when the process is up and running. If bad configuration is detected at execution time, the error is logged and replication is skipped.
-func NewDynamicPushOnWriteHook(ctx context.Context, dEnv *env.DoltEnv, logger io.Writer) (*DynamicPushOnWriteHook, RunAsyncThreads, error) {
+func NewDynamicPushOnWriteHook(ctx context.Context, nameSuffix string, dEnv *env.DoltEnv, logger io.Writer) (*DynamicPushOnWriteHook, RunAsyncThreads, error) {
 	remote, async, err := getReplicationVals()
 	if err != nil {
 		return nil, nil, err
@@ -315,7 +315,7 @@ func NewDynamicPushOnWriteHook(ctx context.Context, dEnv *env.DoltEnv, logger io
 		return nil, nil, err
 	}
 
-	a, newThreads := NewAsyncPushOnWriteHook(tmpDir, logger)
+	a, newThreads := NewAsyncPushOnWriteHook(nameSuffix, tmpDir, logger)
 	p := NewPushOnWriteHook(tmpDir, logger)
 
 	if remote != "" {

--- a/go/libraries/doltcore/sqle/commit_hooks_test.go
+++ b/go/libraries/doltcore/sqle/commit_hooks_test.go
@@ -216,7 +216,7 @@ func TestAsyncPushOnWrite(t *testing.T) {
 	t.Run("replicate to remote", func(t *testing.T) {
 		bThreads := sql.NewBackgroundThreads()
 		defer bThreads.Shutdown()
-		hook, runThreads := NewAsyncPushOnWriteHook(tmpDir, &buffer.Buffer{})
+		hook, runThreads := NewAsyncPushOnWriteHook("[TestReplicationDest]", tmpDir, &buffer.Buffer{})
 		hook.destDb = destDB
 		require.NotNil(t, hook)
 		require.NotNil(t, runThreads)
@@ -290,7 +290,7 @@ func TestAsyncPushOnWrite(t *testing.T) {
 		destDB.PrependCommitHooks(context.Background(), counts)
 
 		bThreads := sql.NewBackgroundThreads()
-		hook, runThreads := NewAsyncPushOnWriteHook(tmpDir, &buffer.Buffer{})
+		hook, runThreads := NewAsyncPushOnWriteHook("[TestReplicationDest]", tmpDir, &buffer.Buffer{})
 		hook.destDb = destDB
 		runThreads(bThreads, func(ctx context.Context) (*sql.Context, error) {
 			return sql.NewContext(ctx), nil

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -885,7 +885,7 @@ func NewConfigureReplicationDatabaseHook(bThreads *sql.BackgroundThreads, ctxF f
 			return err
 		}
 
-		commitHooks, startAsyncThreads, err := GetCommitHooks(ctx, newEnv, cli.CliErr)
+		commitHooks, startAsyncThreads, err := GetCommitHooks(ctx, "["+name+"]", newEnv, cli.CliErr)
 		if err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/sqle/replication.go
+++ b/go/libraries/doltcore/sqle/replication.go
@@ -29,17 +29,21 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
 )
 
-func getPushOnWriteHook(ctx context.Context, dEnv *env.DoltEnv, logger io.Writer) (doltdb.CommitHook, RunAsyncThreads, error) {
-	return NewDynamicPushOnWriteHook(ctx, dEnv, logger)
+func getPushOnWriteHook(ctx context.Context, nameSuffix string, dEnv *env.DoltEnv, logger io.Writer) (doltdb.CommitHook, RunAsyncThreads, error) {
+	return NewDynamicPushOnWriteHook(ctx, nameSuffix, dEnv, logger)
 }
 
-type RunAsyncThreads func(*sql.BackgroundThreads, func(context.Context) (*sql.Context, error)) error
+type BackgroundThreads interface {
+	Add(string, func(context.Context)) error
+}
+
+type RunAsyncThreads func(BackgroundThreads, func(context.Context) (*sql.Context, error)) error
 
 // GetCommitHooks creates a list of hooks to execute on database commit. Hooks that cannot be created because of an
 // error in configuration will not prevent the server from starting, and will instead log errors.
-func GetCommitHooks(ctx context.Context, dEnv *env.DoltEnv, logger io.Writer) ([]doltdb.CommitHook, RunAsyncThreads, error) {
+func GetCommitHooks(ctx context.Context, nameSuffix string, dEnv *env.DoltEnv, logger io.Writer) ([]doltdb.CommitHook, RunAsyncThreads, error) {
 	postCommitHooks := make([]doltdb.CommitHook, 0)
-	hook, runThreads, err := getPushOnWriteHook(ctx, dEnv, logger)
+	hook, runThreads, err := getPushOnWriteHook(ctx, nameSuffix, dEnv, logger)
 	if err != nil {
 		path, _ := dEnv.FS.Abs(".")
 		logrus.Errorf("error loading replication for database at %s, replication disabled: %v", path, err)
@@ -103,7 +107,8 @@ func ApplyReplicationConfig(ctx context.Context, mrEnv *env.MultiRepoEnv, logger
 			outputDbs[i] = db
 			continue
 		}
-		postCommitHooks, runAsyncThreads, err := GetCommitHooks(ctx, dEnv, logger)
+		nameSuffix := "[" + db.Name() + "]"
+		postCommitHooks, runAsyncThreads, err := GetCommitHooks(ctx, nameSuffix, dEnv, logger)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -116,7 +121,7 @@ func ApplyReplicationConfig(ctx context.Context, mrEnv *env.MultiRepoEnv, logger
 
 		asyncRunners[i] = runAsyncThreads
 	}
-	runAsyncThreads := func(bThreads *sql.BackgroundThreads, ctxF func(context.Context) (*sql.Context, error)) error {
+	runAsyncThreads := func(bThreads BackgroundThreads, ctxF func(context.Context) (*sql.Context, error)) error {
 		var err error
 		for _, f := range asyncRunners {
 			if f != nil {

--- a/go/libraries/doltcore/sqle/replication_test.go
+++ b/go/libraries/doltcore/sqle/replication_test.go
@@ -16,6 +16,7 @@ package sqle
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -23,7 +24,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/buffer"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 )
@@ -36,7 +39,7 @@ func TestCommitHooksNoErrors(t *testing.T) {
 
 	sql.SystemVariables.SetGlobal(ctx, dsess.SkipReplicationErrors, true)
 	sql.SystemVariables.SetGlobal(ctx, dsess.ReplicateToRemote, "unknown")
-	hooks, _, err := GetCommitHooks(context.Background(), dEnv, &buffer.Buffer{})
+	hooks, _, err := GetCommitHooks(context.Background(), "", dEnv, &buffer.Buffer{})
 	assert.NoError(t, err)
 	if len(hooks) < 1 {
 		t.Error("failed to produce noop hook")
@@ -47,6 +50,46 @@ func TestCommitHooksNoErrors(t *testing.T) {
 			t.Errorf("expected LogHook, found: %s", h)
 		}
 	}
+}
+
+func TestCommitHooksBackgroundThreadsUniqueNames(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	dEnv, err := CreateEnvWithSeedData()
+	require.NoError(t, err)
+	defer dEnv.DoltDB(ctx).Close()
+
+	dest := t.TempDir()
+	t.Cleanup(func() {
+		dbfactory.DeleteFromSingletonCache(dest, true)
+	})
+
+	err = dEnv.AddRemote(env.NewRemote("origin", "file://"+dest, map[string]string{
+		dbfactory.DisableSingletonCacheParam: "true",
+	}))
+	require.NoError(t, err)
+
+	sql.SystemVariables.SetGlobal(ctx, dsess.ReplicateToRemote, "origin")
+	sql.SystemVariables.SetGlobal(ctx, dsess.AsyncReplication, "true")
+	_, runThreads, err := GetCommitHooks(context.Background(), "[dbname]", dEnv, &buffer.Buffer{})
+	require.NoError(t, err)
+	require.NotNil(t, runThreads)
+	bt := &testBackgroundThreads{make(map[string]func(context.Context))}
+	runThreads(bt, func(ctx context.Context) (*sql.Context, error) {
+		return sql.NewEmptyContext(), nil
+	})
+	assert.Len(t, bt.threads, 2)
+	for k := range bt.threads {
+		assert.True(t, strings.HasSuffix(k, "[dbname]"), "the requested suffix appears in the registered thread name")
+	}
+}
+
+type testBackgroundThreads struct {
+	threads map[string]func(context.Context)
+}
+
+func (t *testBackgroundThreads) Add(name string, f func(context.Context)) error {
+	t.threads[name] = f
+	return nil
 }
 
 func TestReplicationBranches(t *testing.T) {


### PR DESCRIPTION
While this does not impact behavior today, because BackgroundThreads is happy to overwrite existing map entries and leave the old threads still running, if BackgroundThreads adds more requirements or instrospection in the future, having unique names will be nice.