### PR TITLE
go: sqle: txLocks: Move txLocks to be on the DatabaseProvider.

### DIFF
--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -44,6 +44,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
 	"github.com/dolthub/dolt/go/libraries/utils/concurrentmap"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
+	"github.com/dolthub/dolt/go/libraries/utils/keymutex"
 	"github.com/dolthub/dolt/go/libraries/utils/lockutil"
 	"github.com/dolthub/dolt/go/libraries/utils/valctx"
 	"github.com/dolthub/dolt/go/store/datas"
@@ -81,6 +82,8 @@ type DoltDatabaseProvider struct {
 	// to the same remote reuse the store (and its already-opened table chunk sources)
 	// instead of re-opening every table file from the blobstore each time.
 	remoteDbs map[string]*doltdb.DoltDB
+
+	txLocks keymutex.Keymutex
 
 	defaultBranch     string
 	dbFactoryUrl      string
@@ -194,6 +197,7 @@ func NewDoltDatabaseProviderWithDatabases(defaultBranch string, fs filesys.Files
 		droppedDatabaseManager: newDroppedDatabaseManager(fs),
 		overrides:              overrides,
 		remoteDbs:              make(map[string]*doltdb.DoltDB),
+		txLocks:                keymutex.NewMapped(),
 	}, nil
 }
 
@@ -1699,6 +1703,10 @@ func (p *DoltDatabaseProvider) ensureReplicaHeadExists(ctx *sql.Context, branch 
 // EngineOverrides returns the overrides that were given during the creation of the provider.
 func (p *DoltDatabaseProvider) EngineOverrides() sql.EngineOverrides {
 	return p.overrides
+}
+
+func (p *DoltDatabaseProvider) TxLocks() keymutex.Keymutex {
+	return p.txLocks
 }
 
 // isBranch returns whether a branch with the given name is in scope for the database given

--- a/go/libraries/doltcore/sqle/dsess/dolt_session_test.go
+++ b/go/libraries/doltcore/sqle/dsess/dolt_session_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/utils/config"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
+	"github.com/dolthub/dolt/go/libraries/utils/keymutex"
 	"github.com/dolthub/dolt/go/store/types"
 )
 
@@ -321,4 +322,8 @@ func (e emptyRevisionDatabaseProvider) RevisionDbState(_ *sql.Context, revDB str
 
 func (e emptyRevisionDatabaseProvider) EngineOverrides() sql.EngineOverrides {
 	return sql.EngineOverrides{}
+}
+
+func (e emptyRevisionDatabaseProvider) TxLocks() keymutex.Keymutex {
+	return keymutex.NewMapped()
 }

--- a/go/libraries/doltcore/sqle/dsess/session_db_provider.go
+++ b/go/libraries/doltcore/sqle/dsess/session_db_provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
+	"github.com/dolthub/dolt/go/libraries/utils/keymutex"
 	"github.com/dolthub/dolt/go/store/types"
 )
 
@@ -113,6 +114,9 @@ type DoltDatabaseProvider interface {
 	PurgeDroppedDatabases(ctx *sql.Context) error
 	// EngineOverrides returns the overrides that were given during the creation of the provider.
 	EngineOverrides() sql.EngineOverrides
+	// TxLocks returns the per-engine keymutex used to serialize
+	// transaction commits by working-set reference.
+	TxLocks() keymutex.Keymutex
 }
 
 type SessionDatabaseBranchSpec struct {

--- a/go/libraries/doltcore/sqle/dsess/transactions.go
+++ b/go/libraries/doltcore/sqle/dsess/transactions.go
@@ -32,7 +32,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
 	"github.com/dolthub/dolt/go/libraries/doltcore/merge"
 	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
-	"github.com/dolthub/dolt/go/libraries/utils/keymutex"
 	"github.com/dolthub/dolt/go/store/datas"
 	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/prolly"
@@ -161,8 +160,6 @@ func (tx DoltTransaction) GetInitialRoot(dbName string) (hash.Hash, bool) {
 	startPoint, ok := tx.dbStartPoints[strings.ToLower(dbName)]
 	return startPoint.rootHash, ok
 }
-
-var txLocks = keymutex.NewMapped()
 
 // Commit attempts to merge the working set given into the current working set.
 // Uses the same algorithm as merge.RootMerger:
@@ -413,11 +410,11 @@ func (tx *DoltTransaction) doCommit(
 	for i := 0; i < maxTxCommitRetries; i++ {
 		updatedWs, newCommit, err := func() (*doltdb.WorkingSet, *doltdb.Commit, error) {
 			// Serialize commits, since only one can possibly succeed at a time anyway
-			err := txLocks.Lock(ctx, lockID)
+			err := sess.Provider().TxLocks().Lock(ctx, lockID)
 			if err != nil {
 				return nil, nil, err
 			}
-			defer txLocks.Unlock(lockID)
+			defer sess.Provider().TxLocks().Unlock(lockID)
 
 			newWorkingSet := false
 


### PR DESCRIPTION
This has no real impact on `dolt` itself. Removing global state is part of improving dolthub/driver support.