### PR TITLE
go: store/nbs: Disable conjoin when the store is being garbage collected.

### DIFF
--- a/go/libraries/doltcore/dtestutils/sql_server_driver/cmd.go
+++ b/go/libraries/doltcore/dtestutils/sql_server_driver/cmd.go
@@ -27,7 +27,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sync"
 	"time"
 
 	"github.com/go-sql-driver/mysql"
@@ -214,6 +213,12 @@ type SqlServer struct {
 	Output      *bytes.Buffer
 	DBName      string
 	RecreateCmd func(args ...string) *exec.Cmd
+
+	// Called on every write to the output stream, if it is
+	// non-nil.  This is not often needed. This is O(n^2) because
+	// it makes a new string of the entire output on every write
+	// to the output.
+	OutputVisitor func(string)
 }
 
 type SqlServerOpt func(s *SqlServer)
@@ -239,6 +244,12 @@ func WithEnvs(envs ...string) SqlServerOpt {
 func WithPort(port int) SqlServerOpt {
 	return func(s *SqlServer) {
 		s.Port = port
+	}
+}
+
+func WithOutputVisitor(f func(string)) SqlServerOpt {
+	return func(s *SqlServer) {
+		s.OutputVisitor = f
 	}
 }
 
@@ -278,13 +289,7 @@ func runSqlServerCommand(dc DoltCmdable, opts []SqlServerOpt, cmd *exec.Cmd) (*S
 	}
 	cmd.Stderr = cmd.Stdout
 	output := new(bytes.Buffer)
-	var wg sync.WaitGroup
-	wg.Add(1)
 	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
 
 	server := &SqlServer{
 		Done:   done,
@@ -297,8 +302,9 @@ func runSqlServerCommand(dc DoltCmdable, opts []SqlServerOpt, cmd *exec.Cmd) (*S
 	}
 
 	go func() {
-		defer wg.Done()
-		multiCopyWithNamePrefix(os.Stdout, output, stdout, server.Name)
+		defer close(done)
+		wr := buildVisitorWriter(output, server.OutputVisitor)
+		multiCopyWithNamePrefix(os.Stdout, wr, stdout, server.Name)
 	}()
 
 	server.RecreateCmd = func(args ...string) *exec.Cmd {
@@ -349,6 +355,27 @@ func multiCopyWithNamePrefix(stdout, captured io.Writer, in io.Reader, name stri
 	}
 }
 
+func buildVisitorWriter(buf *bytes.Buffer, visitor func(string)) io.Writer {
+	if visitor == nil {
+		return buf
+	}
+	return &visitorWriter{
+		f:   visitor,
+		buf: buf,
+	}
+}
+
+type visitorWriter struct {
+	f   func(string)
+	buf *bytes.Buffer
+}
+
+func (w *visitorWriter) Write(bs []byte) (int, error) {
+	n, err := w.buf.Write(bs)
+	w.f(w.buf.String())
+	return n, err
+}
+
 func (s *SqlServer) Restart(newargs *[]string, newenvs *[]string) error {
 	err := s.GracefulStop()
 	if err != nil {
@@ -367,16 +394,11 @@ func (s *SqlServer) Restart(newargs *[]string, newenvs *[]string) error {
 		return err
 	}
 	s.Cmd.Stderr = s.Cmd.Stdout
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		multiCopyWithNamePrefix(os.Stdout, s.Output, stdout, s.Name)
-	}()
 	s.Done = make(chan struct{})
 	go func() {
-		wg.Wait()
-		close(s.Done)
+		defer close(s.Done)
+		wr := buildVisitorWriter(s.Output, s.OutputVisitor)
+		multiCopyWithNamePrefix(os.Stdout, wr, stdout, s.Name)
 	}()
 	return s.Cmd.Start()
 }

--- a/go/libraries/doltcore/dtestutils/sql_server_driver/cmd_unix.go
+++ b/go/libraries/doltcore/dtestutils/sql_server_driver/cmd_unix.go
@@ -27,6 +27,15 @@ func ApplyCmdAttributes(cmd *exec.Cmd) {
 }
 
 func (s *SqlServer) GracefulStop() error {
+	select {
+	case <-s.Done:
+		if s.Cmd.ProcessState.Success() {
+			return nil
+		} else {
+			return &exec.ExitError{ProcessState: s.Cmd.ProcessState}
+		}
+	default:
+	}
 	err := s.Cmd.Process.Signal(syscall.SIGTERM)
 	if err != nil {
 		return err

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -330,10 +330,11 @@ func (nbs *NomsBlockStore) startConjoinIfRequired(ctx context.Context) error {
 	if nbs.conjoinOp != nil {
 		return nil
 	}
-	if nbs.conjoinDynamicallyDisabled() {
-		return nil
-	}
 	if nbs.conjoiner.conjoinRequired(nbs.tables) {
+		if nbs.conjoinDynamicallyDisabled() {
+			nbs.logger.Info("conjoin dynamically disabled. not conjoining.")
+			return nil
+		}
 		nbs.logger.WithField("upstream_len", len(nbs.tables.upstream)).Info("beginning conjoin of database")
 		var op = &conjoinOperation{}
 		err := op.prepareConjoin(ctx, nbs.conjoiner, nbs.upstream)
@@ -2098,6 +2099,7 @@ func (nbs *NomsBlockStore) pruneTableFiles(ctx context.Context) (err error) {
 func (nbs *NomsBlockStore) BeginGC(keeper func(hash.Hash) bool, _ chunks.GCMode) error {
 	nbs.mu.Lock()
 	defer nbs.mu.Unlock()
+
 	// Block until there is no ongoing conjoin...
 	for nbs.conjoinOp != nil {
 		nbs.conjoinOpCond.Wait()
@@ -2105,6 +2107,30 @@ func (nbs *NomsBlockStore) BeginGC(keeper func(hash.Hash) bool, _ chunks.GCMode)
 	if nbs.gcInProgress {
 		return errors.New("gc already in progress")
 	}
+
+	// Disable conjoin during GC. The GC process can land new
+	// table files in the store, can continue to reference them by
+	// their file id, and can later ask the store to swap
+	// exclusively to them. In order for all of that to work
+	// without too much complication, it is simplest to prevent
+	// conjoin while GC is ongoing.
+	//
+	// Doing this here does _not_ prevent conjoin from running
+	// against the OldGen during a normal generation collection,
+	// because the OldGen is not in |gcInProgress| during that
+	// operation. That's because nothing is actually being
+	// collected from the old gen - things are only being added.
+	// In that case, we don't need to refer to any specific files
+	// that have been added to the store later in the process,
+	// either in HasMany filters or in SwapTables.
+	//
+	// The end result is that BeginGC/EndGC gets called on
+	// NomsBlockStore only when we are getting ready to build a
+	// table file and swap to it. In such a case, conjoin is
+	// likely to be wasted work anyway. Most table files are about
+	// to be deleted.
+	nbs.DisableConjoin()
+
 	nbs.gcInProgress = true
 	nbs.keeperFunc = keeper
 	nbs.gcCond.Broadcast()
@@ -2120,6 +2146,7 @@ func (nbs *NomsBlockStore) EndGC(_ chunks.GCMode) {
 	for nbs.gcOutstandingReads > 0 {
 		nbs.gcCond.Wait()
 	}
+	nbs.RestoreDefaultConjoinBehavior()
 	nbs.gcInProgress = false
 	nbs.keeperFunc = nil
 	nbs.gcCond.Broadcast()
@@ -2538,6 +2565,7 @@ func (nbs *NomsBlockStore) ConjoinTableFiles(ctx context.Context, storageIds []h
 	// record the original manifest for comparison below.
 	originalUpstream := nbs.upstream
 
+	nbs.logger.Info("ConjoinTableFiles was called")
 	strategy := &specificFilesConjoiner{targetStorageIds: storageIds}
 	newUpstream, finalCleanup, err := conjoin(ctx, nbs.fatalBehavior, strategy, nbs.upstream, nbs.manifestMgr, nbs.persister, nbs.stats)
 	if err != nil {

--- a/integration-tests/go-sql-server-driver/clone_no_conjoin_test.go
+++ b/integration-tests/go-sql-server-driver/clone_no_conjoin_test.go
@@ -15,16 +15,12 @@
 package main
 
 import (
-	"io/fs"
-	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	driver "github.com/dolthub/dolt/go/libraries/doltcore/dtestutils/sql_server_driver"
-	"github.com/dolthub/dolt/go/store/hash"
 )
 
 // TestCloneNoConjoin asserts that a clone (in this case a backup
@@ -147,20 +143,7 @@ func TestCloneNoConjoin(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	numTableFiles := 0
-	filepath.WalkDir(finalDestDir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		n := d.Name()
-		n = strings.TrimSuffix(n, ".darc")
-		_, ok := hash.MaybeParse(n)
-		if ok {
-			t.Logf("found table file %s", n)
-			numTableFiles += 1
-		}
-		return nil
-	})
+	numTableFiles := CountTableFiles(t, finalDestDir)
 	t.Logf("found %v table files", numTableFiles)
 	assert.GreaterOrEqual(t, numTableFiles, 384)
 }

--- a/integration-tests/go-sql-server-driver/full_gc_no_conjoin_test.go
+++ b/integration-tests/go-sql-server-driver/full_gc_no_conjoin_test.go
@@ -82,6 +82,11 @@ func TestFullGCNoOldgenConjoin(t *testing.T) {
 	var conjoinStarted, conjoinFinished atomic.Bool
 	upstreamLenOnConjoin := 0
 	server := MakeServer(t, repo, srvSettings, &ports, driver.WithOutputVisitor(func(out string) {
+		// Matching a line like:
+		// time="2026-03-28T11:57:31-07:00" level=info msg="beginning conjoin of database" database=full_gc_no_oldgen_conjoin_test generation=old pkg=store.noms upstream_len=257
+		// Extracting its upstream_len to see exactly when the conjoin was triggered.
+		// This line is logged as part of the conjoin strategy deciding to do the conjoin,
+		// and so reflects the state of the tableSet which triggers the conjoin.
 		if upstreamLenOnConjoin <= 0 && strings.Contains(out, "beginning conjoin of database") {
 			if i := strings.Index(out, "upstream_len="); i != -1 {
 				i += len("upstream_len=")
@@ -91,13 +96,16 @@ func TestFullGCNoOldgenConjoin(t *testing.T) {
 			}
 			conjoinStarted.Store(true)
 		}
+		// Matching the line:
+		// time="2026-03-28T11:57:32-07:00" level=info msg="conjoin completed successfully" database=full_gc_no_oldgen_conjoin_test generation=old new_upstream_len=2 pkg=store.noms
+		// So we can block on further operations until conjoin is done.
 		if strings.Contains(out, "conjoin completed successfully") {
 			conjoinFinished.Store(true)
 		}
 	}))
 	server.DBName = dbname
 
-	oldgendir := filepath.Join(filepath.Join(rs.Dir, dbname), "/.dolt/noms/oldgen")
+	oldgendir := filepath.Join(repo.Dir, "/.dolt/noms/oldgen")
 
 	CommitAndGCUntilConjoin(t, server, &conjoinStarted, oldgendir)
 	require.Greater(t, upstreamLenOnConjoin, 0)
@@ -114,6 +122,9 @@ func TestFullGCNoOldgenConjoin(t *testing.T) {
 	require.NoError(t, server.GracefulStop())
 	output := server.Output.String()
 	assert.Equal(t, 1, strings.Count(output, "beginning conjoin of database"))
+	// The line for triggering a conjoin on policy but not proceeding because
+	// conjoin is dynamically disabled looks like:
+	// time="2026-03-28T12:01:48-07:00" level=info msg="conjoin dynamically disabled. not conjoining." database=full_gc_no_oldgen_conjoin_test generation=old pkg=store.noms
 	assert.Equal(t, 1, strings.Count(output, "conjoin dynamically disabled"))
 	cnt = CountTableFiles(t, oldgendir)
 	assert.Equal(t, 1, cnt)

--- a/integration-tests/go-sql-server-driver/full_gc_no_conjoin_test.go
+++ b/integration-tests/go-sql-server-driver/full_gc_no_conjoin_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"fmt"
 	"io/fs"
 	"path/filepath"
 	"strings"
@@ -28,19 +29,6 @@ import (
 	driver "github.com/dolthub/dolt/go/libraries/doltcore/dtestutils/sql_server_driver"
 	"github.com/dolthub/dolt/go/store/hash"
 )
-
-// After this, we expect a conjoin.
-// This test is tightly coupled with /go/store/nbs/store.go and
-// how its inline conjoiner is configured. This test could be
-// robust against that if it knew when conjoin was running or
-// could sniff log lines from when it started, but we don't do
-// that currently.
-//
-// This is defaultMaxTables + 2 because starting a conjoin on a new
-// add is checked before the add itself and needs to be strictly >
-// defaultMaxTables. So there is one more file already in the manifest
-// and one which is about to be.
-const ExpectedTableFilesHighWaterMark = 258
 
 // This test asserts that running a full gc into the old gen at the
 // point that it is at its conjoin limit will not generate a conjoin
@@ -92,8 +80,15 @@ func TestFullGCNoOldgenConjoin(t *testing.T) {
 		DynamicPort: "server",
 	}
 	var conjoinStarted, conjoinFinished atomic.Bool
+	upstreamLenOnConjoin := 0
 	server := MakeServer(t, repo, srvSettings, &ports, driver.WithOutputVisitor(func(out string) {
-		if strings.Contains(out, "beginning conjoin of database") {
+		if upstreamLenOnConjoin <= 0 && strings.Contains(out, "beginning conjoin of database") {
+			if i := strings.Index(out, "upstream_len="); i != -1 {
+				i += len("upstream_len=")
+				if _, err := fmt.Sscanf(out[i:], "%d", &upstreamLenOnConjoin); err != nil {
+					upstreamLenOnConjoin = -1
+				}
+			}
 			conjoinStarted.Store(true)
 		}
 		if strings.Contains(out, "conjoin completed successfully") {
@@ -104,14 +99,13 @@ func TestFullGCNoOldgenConjoin(t *testing.T) {
 
 	oldgendir := filepath.Join(filepath.Join(rs.Dir, dbname), "/.dolt/noms/oldgen")
 
-	hwm := GetOldGenTableFilesHighWaterMark(t, server, &conjoinStarted, oldgendir)
-	t.Logf("found high water mark of %v files", hwm)
-	require.Equal(t, ExpectedTableFilesHighWaterMark, hwm)
+	CommitAndGCUntilConjoin(t, server, &conjoinStarted, oldgendir)
+	require.Greater(t, upstreamLenOnConjoin, 0)
 	require.Eventually(t, func() bool {
 		return conjoinFinished.Load()
 	}, 5 * time.Second, 32 * time.Millisecond)
 
-	CreateToJustBelowHighWaterMark(t, server, oldgendir, hwm)
+	CreateUpToNumFiles(t, server, oldgendir, upstreamLenOnConjoin)
 	cnt := CountTableFiles(t, oldgendir)
 	t.Logf("now there are %d", cnt)
 
@@ -150,8 +144,7 @@ func CountTableFiles(t *testing.T, dir string) int {
 	return count
 }
 
-func GetOldGenTableFilesHighWaterMark(t *testing.T, srv *driver.SqlServer, conjoinStarted *atomic.Bool, path string) int {
-	var hwm int
+func CommitAndGCUntilConjoin(t *testing.T, srv *driver.SqlServer, conjoinStarted *atomic.Bool, path string) {
 	ctx := t.Context()
 	db, err := srv.DB(driver.Connection{User: "root"})
 	require.NoError(t, err)
@@ -165,19 +158,13 @@ func GetOldGenTableFilesHighWaterMark(t *testing.T, srv *driver.SqlServer, conjo
 		require.NoError(t, err)
 		_, err = conn.ExecContext(ctx, "CALL DOLT_GC()")
 		require.NoError(t, err)
-		cnt := CountTableFiles(t, path)
-		if cnt > hwm {
-			hwm = cnt
-		} else if cnt < hwm {
-			return hwm
-		}
 		if conjoinStarted.Load() {
-			return hwm
+			return
 		}
 	}
 }
 
-func CreateToJustBelowHighWaterMark(t *testing.T, srv *driver.SqlServer, path string, hwm int) {
+func CreateUpToNumFiles(t *testing.T, srv *driver.SqlServer, path string, numFiles int) {
 	ctx := t.Context()
 	db, err := srv.DB(driver.Connection{User: "root"})
 	require.NoError(t, err)
@@ -186,15 +173,16 @@ func CreateToJustBelowHighWaterMark(t *testing.T, srv *driver.SqlServer, path st
 	conn, err := db.Conn(ctx)
 	require.NoError(t, err)
 	defer conn.Close()
-	cnt := CountTableFiles(t, path)
-	for range (hwm-cnt-1) {
+	for {
+		cnt := CountTableFiles(t, path)
+		if cnt == numFiles {
+			return
+		}
 		_, err = conn.ExecContext(ctx, "CALL DOLT_COMMIT('-A', '--allow-empty', '-m', 'creating a new commit')")
 		require.NoError(t, err)
 		_, err = conn.ExecContext(ctx, "CALL DOLT_GC()")
 		require.NoError(t, err)
 	}
-	cnt = CountTableFiles(t, path)
-	require.Equal(t, hwm-1, cnt)
 }
 
 func RunGCFull(t *testing.T, srv *driver.SqlServer, path string) {

--- a/integration-tests/go-sql-server-driver/full_gc_no_conjoin_test.go
+++ b/integration-tests/go-sql-server-driver/full_gc_no_conjoin_test.go
@@ -1,0 +1,213 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	driver "github.com/dolthub/dolt/go/libraries/doltcore/dtestutils/sql_server_driver"
+	"github.com/dolthub/dolt/go/store/hash"
+)
+
+// After this, we expect a conjoin.
+// This test is tightly coupled with /go/store/nbs/store.go and
+// how its inline conjoiner is configured. This test could be
+// robust against that if it knew when conjoin was running or
+// could sniff log lines from when it started, but we don't do
+// that currently.
+//
+// This is defaultMaxTables + 2 because starting a conjoin on a new
+// add is checked before the add itself and needs to be strictly >
+// defaultMaxTables. So there is one more file already in the manifest
+// and one which is about to be.
+const ExpectedTableFilesHighWaterMark = 258
+
+// This test asserts that running a full gc into the old gen at the
+// point that it is at its conjoin limit will not generate a conjoin
+// in the middle of the GC.
+//
+// It first generates empty commits and runs GC in a loop. After every
+// GC, it checks how many table files are in the oldgen. When it sees
+// them get conjoined, it assumes max table files is the observed high
+// water mark.
+//
+// It then creates exactly that many table files in oldgen by creating
+// empty commits and running gc however many times it needs to.
+//
+// Then it needs to create one more commit and run a
+// dolt_gc(--full). Currently dolt sql-server logs whenever it beings
+// a conjoin, and that determination is made synchronously on the
+// write path. So, no real attempt is made to get a theoretically
+// started conjoin to win the race against the newgen collection, for
+// example.
+//
+// As described above, this test is tightly coupled with
+// GenerationalNBS, NomsBlockStore and the file persisters, with
+// conjoin strategy behavior.
+//
+// At the end of the test, there should be one file in the oldgen, the
+// results of the --full. There should be exactly one "beginning
+// conjoin of database" in the server logs and it should correspond to
+// when we measured the high water mark. After shutting down the
+// server should happily start again.
+func TestFullGCNoOldgenConjoin(t *testing.T) {
+	t.Parallel()
+	var ports DynamicResources
+	ports.global = &GlobalPorts
+	ports.t = t
+	u, err := driver.NewDoltUser()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		u.Cleanup()
+	})
+
+	dbname := "full_gc_no_oldgen_conjoin_test"
+
+	rs, err := u.MakeRepoStore()
+	require.NoError(t, err)
+	repo, err := rs.MakeRepo(dbname)
+	require.NoError(t, err)
+	srvSettings := &driver.Server{
+		Args:        []string{"--port", `{{get_port "server"}}`},
+		DynamicPort: "server",
+	}
+	var conjoinStarted, conjoinFinished atomic.Bool
+	server := MakeServer(t, repo, srvSettings, &ports, driver.WithOutputVisitor(func(out string) {
+		if strings.Contains(out, "beginning conjoin of database") {
+			conjoinStarted.Store(true)
+		}
+		if strings.Contains(out, "conjoin completed successfully") {
+			conjoinFinished.Store(true)
+		}
+	}))
+	server.DBName = dbname
+
+	oldgendir := filepath.Join(filepath.Join(rs.Dir, dbname), "/.dolt/noms/oldgen")
+
+	hwm := GetOldGenTableFilesHighWaterMark(t, server, &conjoinStarted, oldgendir)
+	t.Logf("found high water mark of %v files", hwm)
+	require.Equal(t, ExpectedTableFilesHighWaterMark, hwm)
+	require.Eventually(t, func() bool {
+		return conjoinFinished.Load()
+	}, 5 * time.Second, 32 * time.Millisecond)
+
+	CreateToJustBelowHighWaterMark(t, server, oldgendir, hwm)
+	cnt := CountTableFiles(t, oldgendir)
+	t.Logf("now there are %d", cnt)
+
+	RunGCFull(t, server, oldgendir)
+
+	require.NoError(t, server.GracefulStop())
+	output := server.Output.String()
+	assert.Equal(t, 1, strings.Count(output, "beginning conjoin of database"))
+	assert.Equal(t, 1, strings.Count(output, "conjoin dynamically disabled"))
+	cnt = CountTableFiles(t, oldgendir)
+	assert.Equal(t, 1, cnt)
+
+	newServer := MakeServer(t, repo, srvSettings, &ports)
+	newServer.DBName = dbname
+	db, err := newServer.DB(driver.Connection{User: "root"})
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.PingContext(t.Context()))
+}
+
+func CountTableFiles(t *testing.T, dir string) int {
+	var count int
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		n := d.Name()
+		n = strings.TrimSuffix(n, ".darc")
+		_, ok := hash.MaybeParse(n)
+		if ok {
+			count += 1
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	return count
+}
+
+func GetOldGenTableFilesHighWaterMark(t *testing.T, srv *driver.SqlServer, conjoinStarted *atomic.Bool, path string) int {
+	var hwm int
+	ctx := t.Context()
+	db, err := srv.DB(driver.Connection{User: "root"})
+	require.NoError(t, err)
+	defer db.Close()
+
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close()
+	for {
+		_, err = conn.ExecContext(ctx, "CALL DOLT_COMMIT('-A', '--allow-empty', '-m', 'creating a new commit')")
+		require.NoError(t, err)
+		_, err = conn.ExecContext(ctx, "CALL DOLT_GC()")
+		require.NoError(t, err)
+		cnt := CountTableFiles(t, path)
+		if cnt > hwm {
+			hwm = cnt
+		} else if cnt < hwm {
+			return hwm
+		}
+		if conjoinStarted.Load() {
+			return hwm
+		}
+	}
+}
+
+func CreateToJustBelowHighWaterMark(t *testing.T, srv *driver.SqlServer, path string, hwm int) {
+	ctx := t.Context()
+	db, err := srv.DB(driver.Connection{User: "root"})
+	require.NoError(t, err)
+	defer db.Close()
+
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close()
+	cnt := CountTableFiles(t, path)
+	for range (hwm-cnt-1) {
+		_, err = conn.ExecContext(ctx, "CALL DOLT_COMMIT('-A', '--allow-empty', '-m', 'creating a new commit')")
+		require.NoError(t, err)
+		_, err = conn.ExecContext(ctx, "CALL DOLT_GC()")
+		require.NoError(t, err)
+	}
+	cnt = CountTableFiles(t, path)
+	require.Equal(t, hwm-1, cnt)
+}
+
+func RunGCFull(t *testing.T, srv *driver.SqlServer, path string) {
+	ctx := t.Context()
+	db, err := srv.DB(driver.Connection{User: "root"})
+	require.NoError(t, err)
+	defer db.Close()
+
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close()
+	_ = CountTableFiles(t, path)
+	_, err = conn.ExecContext(ctx, "CALL DOLT_GC('--full')")
+	cnt := CountTableFiles(t, path)
+	require.Equal(t, 1, cnt)
+}

--- a/integration-tests/go-sql-server-driver/gc_oldgen_conjoin_test.go
+++ b/integration-tests/go-sql-server-driver/gc_oldgen_conjoin_test.go
@@ -17,7 +17,6 @@ package main
 import (
 	"context"
 	sqldriver "database/sql/driver"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -129,11 +128,10 @@ func TestGCConjoinsOldgen(t *testing.T) {
 				}(i)
 			}
 
-			entries, err := os.ReadDir(filepath.Join(repo.Dir, ".dolt/noms/oldgen"))
-			require.NoError(t, err)
-			require.Greater(t, len(entries), 2)
-			// defaultMaxTables == 256, plus a few files extra like |manifest| and |LOCK|.
-			require.Less(t, len(entries), 272)
+			count := CountTableFiles(t, filepath.Join(repo.Dir, ".dolt/noms/oldgen"))
+			require.Greater(t, count, 2)
+			// defaultMaxTables == 256, conjoin is triggered on trying to land the 258.
+			require.Less(t, count, 258)
 		})
 	}
 }

--- a/integration-tests/go-sql-server-driver/testdef.go
+++ b/integration-tests/go-sql-server-driver/testdef.go
@@ -235,7 +235,7 @@ func (d *DynamicResources) ApplyTemplate(s string) string {
 	return buf.String()
 }
 
-func MakeServer(t *testing.T, dc driver.DoltCmdable, s *driver.Server, resources *DynamicResources) *driver.SqlServer {
+func MakeServer(t *testing.T, dc driver.DoltCmdable, s *driver.Server, resources *DynamicResources, manualOps ...driver.SqlServerOpt) *driver.SqlServer {
 	if s == nil {
 		return nil
 	}
@@ -262,6 +262,7 @@ func MakeServer(t *testing.T, dc driver.DoltCmdable, s *driver.Server, resources
 		t.Fatalf("cannot find dynamic port %s after expanding server config, requested as dynamic server port", s.DynamicPort)
 	}
 	opts = append(opts, driver.WithPort(port))
+	opts = append(opts, manualOps...)
 
 	var server *driver.SqlServer
 	var err error
@@ -275,7 +276,7 @@ func MakeServer(t *testing.T, dc driver.DoltCmdable, s *driver.Server, resources
 	if len(s.ErrorMatches) > 0 {
 		err := server.ErrorStop()
 		require.Error(t, err)
-		output := string(server.Output.Bytes())
+		output := server.Output.String()
 		for _, a := range s.ErrorMatches {
 			require.Regexp(t, a, output)
 		}
@@ -286,7 +287,7 @@ func MakeServer(t *testing.T, dc driver.DoltCmdable, s *driver.Server, resources
 			// a Cleanup does not make sense.
 			err := server.GracefulStop()
 			if assert.NoError(t, err) {
-				output := string(server.Output.Bytes())
+				output := server.Output.String()
 				for _, a := range s.LogMatches {
 					assert.Regexp(t, a, output)
 				}


### PR DESCRIPTION
A conjoin running during GC could violate the assumptions made by the garbage collector about which files it has created and were safe to reference in the future. A separate issue on a specialized write path which GC uses to interact with the store means that the store can be updated to reference files which no longer exist. The end result was that the GC would fail and the database would enter a state that would require expert manual invervention to recover.

Trigger this path requires a dolt_gc('--full') to be called when the oldgen is already in a very particular state.

This path does not effect auto_gc.