### PR TITLE
go: sqle: auto_gc.go: Remove periodic call to checkForGC in autoGCCommitHook thread.

### DIFF
--- a/go/libraries/doltcore/sqle/auto_gc.go
+++ b/go/libraries/doltcore/sqle/auto_gc.go
@@ -362,7 +362,6 @@ func (h *autoGCCommitHook) ExecuteForWorkingSets() bool {
 	return true
 }
 
-const checkInterval = 1 * time.Second
 const size_128mb = (1 << 27)
 const defaultCheckSizeThreshold = size_128mb
 
@@ -412,8 +411,6 @@ func (h *autoGCCommitHook) checkForGC(ctx context.Context) error {
 func (h *autoGCCommitHook) thread(ctx context.Context) {
 	defer h.wg.Done()
 	defer close(h.stoppedCh)
-	timer := time.NewTimer(checkInterval)
-	defer timer.Stop()
 	for {
 		select {
 		case <-ctx.Done():
@@ -424,9 +421,6 @@ func (h *autoGCCommitHook) thread(ctx context.Context) {
 			// We ignore an error here, which just means we didn't kick
 			// off a GC when we might have wanted to.
 			_ = h.checkForGC(ctx)
-		case <-timer.C:
-			_ = h.checkForGC(ctx)
-			timer.Reset(checkInterval)
 		}
 	}
 }


### PR DESCRIPTION
Previously we wanted standby replicas to run auto gc, but standby replicas did not fire commit hooks when receiving writes over remotesapi. To get autogc working on standby replicas, we had the thread wake up every second and check the database sizes.

The hooks behavior was changed in #10722. As a consequence, we no longer need to wake up every second and check database sizes. It is more efficient to not do so.

One behavior change to note: this periodic check would also apply to long running transactions which generate lots of writes/garbage but which never commit and so never generate database writes. Now that pattern will have to wait for an actual database write to trigger an auto gc. A sequence of transactions which generate a lot of garbage but which always rollback will also fail to trigger auto gc. To fix this, auto gc should be triggering on a table file persister callback, not on a commit callback.

Related to the user request in #10563.