### PR TITLE
go: cmd/dolt: sqlserver: metrics_listener.go: Only run the background goroutine for updating system metrics and cluster state if we actually have a metrics port configured.

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/metrics_listener.go
+++ b/go/cmd/dolt/commands/sqlserver/metrics_listener.go
@@ -70,7 +70,7 @@ type metricsListener struct {
 	clusterSeenDbs map[string]struct{}
 }
 
-func newMetricsListener(labels prometheus.Labels, versionStr, storagePath string, clusterStatus clusterdb.ClusterStatusProvider) (*metricsListener, error) {
+func newMetricsListener(labels prometheus.Labels, versionStr, storagePath string, clusterStatus clusterdb.ClusterStatusProvider, metricsExposed bool) (*metricsListener, error) {
 	mountPoint := ""
 
 	if storagePath != "" {
@@ -185,11 +185,13 @@ func newMetricsListener(labels prometheus.Labels, versionStr, storagePath string
 	prometheus.MustRegister(ml.diskUsage)
 	prometheus.MustRegister(ml.memUsage)
 
-	go func() {
-		for ml.pollMetrics() {
-			time.Sleep(metricsUpdateInterval)
-		}
-	}()
+	if metricsExposed {
+		go func() {
+			for ml.pollMetrics() {
+				time.Sleep(metricsUpdateInterval)
+			}
+		}()
+	}
 
 	ml.gaugeVersion.Set(f64Version)
 	return ml, nil

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -537,7 +537,8 @@ func ConfigureServices(
 				path = ""
 			}
 
-			metListener, err = newMetricsListener(labels, cfg.Version, path, clusterController)
+			metricsExposed := cfg.ServerConfig.MetricsHost() != "" && cfg.ServerConfig.MetricsPort() > 0
+			metListener, err = newMetricsListener(labels, cfg.Version, path, clusterController, metricsExposed)
 			return err
 		},
 		StopF: func() error {


### PR DESCRIPTION
Related to feature request #10563.