### PR TITLE
Fix panic merging a changed unique index

### DIFF
--- a/go/libraries/doltcore/merge/merge_prolly_rows.go
+++ b/go/libraries/doltcore/merge/merge_prolly_rows.go
@@ -746,8 +746,13 @@ func newUniqValidator(ctx *sql.Context, sch schema.Schema, tm *TableMerger, vm *
 	for _, def := range sch.Indexes().AllIndexes() {
 		if !def.IsUnique() {
 			continue
-		} else if !tm.leftSch.Indexes().Contains(def.Name()) {
-			continue // todo: how do we validate in this case?
+		}
+
+		leftDef := tm.leftSch.Indexes().GetByName(def.Name())
+		if leftDef == nil || !leftDef.Equals(def) {
+			// mergeProllySecondaryIndexes rebuilds it from the final merged table and
+			// records any violations there.
+			continue
 		}
 
 		idx, err := indexes.GetIndex(ctx, sch, nil, def.Name())

--- a/go/libraries/doltcore/merge/mutable_secondary_index.go
+++ b/go/libraries/doltcore/merge/mutable_secondary_index.go
@@ -47,9 +47,10 @@ func GetMutableSecondaryIdxs(ctx *sql.Context, ourSch, sch schema.Schema, tableN
 	return mods, nil
 }
 
-// GetMutableSecondaryIdxsWithPending returns a MutableSecondaryIdx for each secondary index in |indexes|. If an index
-// is listed in the given |sch|, but does not exist in the given |indexes|, then it is skipped. This is useful when
-// merging a schema that has a new index, but the index does not exist on the index set being modified.
+// GetMutableSecondaryIdxsWithPending returns a [MutableSecondaryIdx] for each secondary index in |indexes|
+// whose definition in |ourSch| matches the corresponding definition in |sch|. Indexes present in |sch| but
+// absent from |indexes|, or whose definition has changed between |ourSch| and |sch|, are skipped. The
+// caller is responsible for rebuilding those indexes from scratch after the merge completes.
 func GetMutableSecondaryIdxsWithPending(ctx *sql.Context, ns tree.NodeStore, ourSch, sch schema.Schema, tableName string, indexes durable.IndexSet, pendingSize int) ([]MutableSecondaryIdx, error) {
 	mods := make([]MutableSecondaryIdx, 0, sch.Indexes().Count())
 	for _, index := range sch.Indexes().AllIndexes() {
@@ -80,11 +81,15 @@ func GetMutableSecondaryIdxsWithPending(ctx *sql.Context, ns tree.NodeStore, our
 		// TODO: This isn't technically required, but correctly handling updating secondary indexes when only some
 		// of the table's rows have been updated is difficult to get right.
 		// Dropping the index is potentially slower but guaranteed to be correct.
+		ourIndex := ourSch.Indexes().GetByName(index.Name())
+		if ourIndex == nil || !ourIndex.Equals(index) {
+			continue
+		}
+
 		idxKeyDesc := m.KeyDesc()
 		if schema.IsKeyless(sch) {
 			idxKeyDesc = idxKeyDesc.PrefixDesc(idxKeyDesc.Count() - 1)
 		}
-
 		if !idxKeyDesc.Equals(index.Schema().GetKeyDescriptor(ns)) {
 			continue
 		}

--- a/go/libraries/doltcore/merge/mutable_secondary_index.go
+++ b/go/libraries/doltcore/merge/mutable_secondary_index.go
@@ -68,6 +68,11 @@ func GetMutableSecondaryIdxsWithPending(ctx *sql.Context, ns tree.NodeStore, our
 			continue
 		}
 
+		ourIndex := ourSch.Indexes().GetByName(index.Name())
+		if ourIndex == nil || !ourIndex.Equals(index) {
+			continue
+		}
+
 		idx, err := indexes.GetIndex(ctx, sch, nil, index.Name())
 		if err != nil {
 			return nil, err
@@ -81,15 +86,11 @@ func GetMutableSecondaryIdxsWithPending(ctx *sql.Context, ns tree.NodeStore, our
 		// TODO: This isn't technically required, but correctly handling updating secondary indexes when only some
 		// of the table's rows have been updated is difficult to get right.
 		// Dropping the index is potentially slower but guaranteed to be correct.
-		ourIndex := ourSch.Indexes().GetByName(index.Name())
-		if ourIndex == nil || !ourIndex.Equals(index) {
-			continue
-		}
-
 		idxKeyDesc := m.KeyDesc()
 		if schema.IsKeyless(sch) {
 			idxKeyDesc = idxKeyDesc.PrefixDesc(idxKeyDesc.Count() - 1)
 		}
+
 		if !idxKeyDesc.Equals(index.Schema().GetKeyDescriptor(ns)) {
 			continue
 		}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_schema_merge.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_schema_merge.go
@@ -1428,6 +1428,98 @@ var SchemaChangeTestsConstraints = []MergeScriptTest{
 			},
 		},
 	},
+	{
+		// https://github.com/dolthub/dolt/issues/10753.
+		Name: "adding a column to a unique index where merged rows violate the new index",
+		AncSetUpScript: []string{
+			"set autocommit = 0;",
+			"CREATE TABLE t (pk INT PRIMARY KEY, a INT, b TINYINT, UNIQUE KEY uq (a));",
+			"INSERT INTO t VALUES (1, 10, 1);",
+		},
+		RightSetUpScript: []string{
+			"ALTER TABLE t DROP INDEX uq;",
+			"ALTER TABLE t ADD UNIQUE KEY uq (a, b);",
+			"INSERT INTO t VALUES (2, 20, 2);",
+		},
+		LeftSetUpScript: []string{
+			"INSERT INTO t VALUES (3, 20, 2);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "call dolt_merge('right');",
+				Expected: []sql.Row{{"", 0, 1, "conflicts found"}},
+			},
+			{
+				Query:    "select * from dolt_conflicts;",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "select * from dolt_constraint_violations;",
+				Expected: []sql.Row{{"t", uint(2)}},
+			},
+			{
+				Query: "select violation_type, pk, a, b, violation_info from dolt_constraint_violations_t order by pk;",
+				Expected: []sql.Row{
+					{"unique index", 2, 20, int8(2), merge.UniqCVMeta{Columns: []string{"a", "b"}, Name: "uq"}},
+					{"unique index", 3, 20, int8(2), merge.UniqCVMeta{Columns: []string{"a", "b"}, Name: "uq"}},
+				},
+			},
+			{
+				Query:    "select * from dolt_status;",
+				Expected: []sql.Row{{"t", byte(0), "constraint violation"}},
+			},
+			{
+				Query:    "UPDATE t SET a = 30 WHERE pk = 3;",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, Info: plan.UpdateInfo{Matched: 1, Updated: 1}}}},
+			},
+			{
+				Query:    "DELETE FROM dolt_constraint_violations_t;",
+				Expected: []sql.Row{{types.NewOkResult(2)}},
+			},
+			{
+				Query:    "call dolt_commit('-am', 'merge right, resolve unique index violation');",
+				Expected: []sql.Row{{doltCommit}},
+			},
+			{
+				Query: "SELECT * FROM t ORDER BY pk;",
+				Expected: []sql.Row{
+					{1, 10, int8(1)},
+					{2, 20, int8(2)},
+					{3, 30, int8(2)},
+				},
+			},
+		},
+	},
+	{
+		// https://github.com/dolthub/dolt/issues/10753.
+		Name: "adding a column to a unique index and inserting data valid only under the new index",
+		AncSetUpScript: []string{
+			"CREATE TABLE t (pk INT PRIMARY KEY, a INT, b TINYINT, UNIQUE KEY uq (a));",
+			"INSERT INTO t VALUES (1, 10, 1);",
+		},
+		RightSetUpScript: []string{
+			"ALTER TABLE t DROP INDEX uq;",
+			"ALTER TABLE t ADD UNIQUE KEY uq (a, b);",
+			"INSERT INTO t VALUES (2, 10, 2);",
+		},
+		LeftSetUpScript: []string{
+			"INSERT INTO t VALUES (3, 30, 3);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "call dolt_merge('right');",
+				Expected: []sql.Row{{doltCommit, 0, 0, "merge successful"}},
+			},
+			{
+				Query: "SELECT * FROM t ORDER BY pk;",
+				Expected: []sql.Row{
+					{1, 10, int8(1)},
+					{2, 10, int8(2)},
+					{3, 30, int8(3)},
+				},
+			},
+		},
+	},
 }
 
 // SchemaChangeTestsTypeChanges holds test scripts for schema merge where column types have changed. Note that


### PR DESCRIPTION
When a unique index's definition changed on one branch (e.g. a column was added to it), merging would panic with `byte slice is not of expected size`. This happened because the uniqueness checker loaded the index's old binary data and tried to read it under the new schema's layout.
- Unique constraint violations produced by the changed index are now surfaced as inspectable conflict artifacts.

Fix dolthub/dolt#10753