### PR TITLE
Fix open Dependabot security alerts

### DIFF
--- a/integration-tests/orm-tests/mikro-orm/package.json
+++ b/integration-tests/orm-tests/mikro-orm/package.json
@@ -13,8 +13,8 @@
     "typescript": "^4.5.2"
   },
   "dependencies": {
-    "@mikro-orm/core": "^5.0.3",
-    "@mikro-orm/mysql": "^5.0.3",
+    "@mikro-orm/core": "^6.6.10",
+    "@mikro-orm/mysql": "^6.6.10",
     "mysql": "^2.14.1"
   }
 }

--- a/integration-tests/orm-tests/mikro-orm/src/index.ts
+++ b/integration-tests/orm-tests/mikro-orm/src/index.ts
@@ -7,9 +7,8 @@ async function connectAndGetOrm() {
 
     const orm = await MikroORM.init<MySqlDriver>({
         entities: [User],
-        type: "mysql",
+        driver: MySqlDriver,
         clientUrl: dbUrl,
-        persistOnCreate: true,
     });
 
     return orm;


### PR DESCRIPTION
Upgrade golang.org/x/image v0.18.0 -> v0.38.0 to address CVE for out-of-memory via crafted TIFF file. Upgrade @mikro-orm/core and @mikro-orm/mysql from v5 to v6.6.10+ to address critical SQL injection and high-severity prototype pollution vulnerabilities.