### PR TITLE
[no-release-notes] go/store/nbs: Remove unused keepers return on conjoiner.chooseConjoinees interface.

### DIFF
--- a/go/store/nbs/block_store_test.go
+++ b/go/store/nbs/block_store_test.go
@@ -546,7 +546,7 @@ func testBlockStoreConjoinOnCommit(t *testing.T, factory func(t *testing.T) tabl
 		fm.set(constants.FormatDoltString, computeAddr([]byte{0xbe}), hash.Of([]byte{0xef}), upstream, nil)
 		c := &fakeConjoiner{
 			[]cannedConjoin{
-				{conjoinees: upstream[:2], keepers: upstream[2:]},
+				{conjoinees: upstream[:2]},
 			},
 		}
 
@@ -582,8 +582,8 @@ func testBlockStoreConjoinOnCommit(t *testing.T, factory func(t *testing.T) tabl
 		fm.set(constants.FormatDoltString, computeAddr([]byte{0xbe}), hash.Of([]byte{0xef}), upstream, nil)
 		c := &fakeConjoiner{
 			[]cannedConjoin{
-				{conjoinees: upstream[:2], keepers: upstream[2:]},
-				{conjoinees: upstream[:4], keepers: upstream[4:]},
+				{conjoinees: upstream[:2]},
+				{conjoinees: upstream[:4]},
 			},
 		}
 
@@ -611,7 +611,7 @@ func testBlockStoreConjoinOnCommit(t *testing.T, factory func(t *testing.T) tabl
 
 type cannedConjoin struct {
 	// Must name tables that are already persisted
-	conjoinees, keepers []tableSpec
+	conjoinees []tableSpec
 }
 
 type fakeConjoiner struct {
@@ -625,11 +625,11 @@ func (fc *fakeConjoiner) conjoinRequired(ts *tableSet) bool {
 	return true
 }
 
-func (fc *fakeConjoiner) chooseConjoinees(specs []tableSpec) (conjoinees, keepers []tableSpec, err error) {
+func (fc *fakeConjoiner) chooseConjoinees(specs []tableSpec) (conjoinees []tableSpec, err error) {
 	d.PanicIfTrue(len(fc.canned) == 0)
 	cur := fc.canned[0]
 	fc.canned = fc.canned[1:]
-	conjoinees, keepers = cur.conjoinees, cur.keepers
+	conjoinees = cur.conjoinees
 	return
 }
 

--- a/go/store/nbs/conjoiner.go
+++ b/go/store/nbs/conjoiner.go
@@ -39,7 +39,7 @@ type conjoinStrategy interface {
 	conjoinRequired(ts *tableSet) bool
 
 	// chooseConjoinees chooses which chunkSources to conjoin from |sources|
-	chooseConjoinees(specs []tableSpec) (conjoinees, keepers []tableSpec, err error)
+	chooseConjoinees(specs []tableSpec) (conjoinees []tableSpec, err error)
 }
 
 type inlineConjoiner struct {
@@ -55,9 +55,9 @@ func (c inlineConjoiner) conjoinRequired(ts *tableSet) bool {
 // chooseConjoinees implements conjoinStrategy. Current approach is to choose the smallest N tables which,
 // when removed and replaced with the conjoinment, will leave the conjoinment as the smallest table.
 // We also keep taking table files until we get below maxTables.
-func (c inlineConjoiner) chooseConjoinees(upstream []tableSpec) (conjoinees, keepers []tableSpec, err error) {
+func (c inlineConjoiner) chooseConjoinees(upstream []tableSpec) (conjoinees []tableSpec, err error) {
 	if c.maxTables < 2 {
-		return nil, upstream, fmt.Errorf("runtime error: cannot conjoin with maxTables set to %d", c.maxTables)
+		return nil, fmt.Errorf("runtime error: cannot conjoin with maxTables set to %d", c.maxTables)
 	}
 	sorted := make([]tableSpec, len(upstream))
 	copy(sorted, upstream)
@@ -78,7 +78,7 @@ func (c inlineConjoiner) chooseConjoinees(upstream []tableSpec) (conjoinees, kee
 		sum += next
 		i++
 	}
-	return sorted[:i], sorted[i:], nil
+	return sorted[:i], nil
 }
 
 type noopConjoiner struct{}
@@ -89,8 +89,7 @@ func (c noopConjoiner) conjoinRequired(ts *tableSet) bool {
 	return false
 }
 
-func (c noopConjoiner) chooseConjoinees(sources []tableSpec) (conjoinees, keepers []tableSpec, err error) {
-	keepers = sources
+func (c noopConjoiner) chooseConjoinees(sources []tableSpec) (conjoinees []tableSpec, err error) {
 	return
 }
 
@@ -105,23 +104,20 @@ func (s *specificFilesConjoiner) conjoinRequired(ts *tableSet) bool {
 	return len(s.targetStorageIds) > 0
 }
 
-func (s *specificFilesConjoiner) chooseConjoinees(specs []tableSpec) (conjoinees, keepers []tableSpec, err error) {
+func (s *specificFilesConjoiner) chooseConjoinees(specs []tableSpec) (conjoinees []tableSpec, err error) {
 	// Convert target storage IDs to a set for efficient lookup
 	targetSet := make(map[hash.Hash]bool)
 	for _, id := range s.targetStorageIds {
 		targetSet[id] = true
 	}
 
-	// Separate specs into conjoinees and keepers
 	for _, spec := range specs {
 		if targetSet[spec.name] {
 			conjoinees = append(conjoinees, spec)
-		} else {
-			keepers = append(keepers, spec)
 		}
 	}
 
-	return conjoinees, keepers, nil
+	return conjoinees, nil
 }
 
 // A conjoinOperation is a multi-step process that a NomsBlockStore runs to
@@ -165,7 +161,7 @@ func (op *conjoinOperation) prepareConjoin(ctx context.Context, strat conjoinStr
 		upstream, _ = upstream.removeAppendixSpecs()
 	}
 	var err error
-	op.conjoinees, _, err = strat.chooseConjoinees(upstream.specs)
+	op.conjoinees, err = strat.chooseConjoinees(upstream.specs)
 	if err != nil {
 		return err
 	}

--- a/go/store/nbs/journal.go
+++ b/go/store/nbs/journal.go
@@ -531,24 +531,14 @@ func (c journalConjoiner) conjoinRequired(ts *tableSet) bool {
 	return c.child.conjoinRequired(ts)
 }
 
-func (c journalConjoiner) chooseConjoinees(upstream []tableSpec) (conjoinees, keepers []tableSpec, err error) {
-	var stash tableSpec // don't conjoin journal
+func (c journalConjoiner) chooseConjoinees(upstream []tableSpec) (conjoinees []tableSpec, err error) {
 	pruned := make([]tableSpec, 0, len(upstream))
 	for _, ts := range upstream {
-		if isJournalAddr(ts.name) {
-			stash = ts
-		} else {
+		if !isJournalAddr(ts.name) {
 			pruned = append(pruned, ts)
 		}
 	}
-	conjoinees, keepers, err = c.child.chooseConjoinees(pruned)
-	if err != nil {
-		return nil, nil, err
-	}
-	if !stash.name.IsEmpty() {
-		keepers = append(keepers, stash)
-	}
-	return
+	return c.child.chooseConjoinees(pruned)
 }
 
 // newJournalManifest makes a new file manifest.


### PR DESCRIPTION
Just a small cleanup.