### PR TITLE
[no-release-notes] go/store/nbs: Change chunkReader count() so that it cannot fail. No existing implementations ever return errors.

### DIFF
--- a/go/store/nbs/archive_build.go
+++ b/go/store/nbs/archive_build.go
@@ -83,10 +83,7 @@ func unArchiveSingleBlockStore(ctx context.Context, blockStore *NomsBlockStore, 
 			continue
 		}
 
-		chkCnt, err := arc.count()
-		if err != nil {
-			return fmt.Errorf("failed to count chunks in archive %s: %w", id.String(), err)
-		}
+		chkCnt := arc.count()
 
 		var newTF hash.Hash
 		classicTable, err := NewCmpChunkTableWriter("")

--- a/go/store/nbs/archive_chunk_source.go
+++ b/go/store/nbs/archive_chunk_source.go
@@ -155,8 +155,8 @@ func (acs archiveChunkSource) iterate(ctx context.Context, cb func(chunks.Chunk)
 	return acs.aRdr.iterate(ctx, cb, stats)
 }
 
-func (acs archiveChunkSource) count() (uint32, error) {
-	return acs.aRdr.count(), nil
+func (acs archiveChunkSource) count() uint32 {
+	return acs.aRdr.count()
 }
 
 func (acs archiveChunkSource) close() error {

--- a/go/store/nbs/archive_test.go
+++ b/go/store/nbs/archive_test.go
@@ -1280,7 +1280,7 @@ func (tcs *testChunkSource) getManyCompressed(ctx context.Context, eg *errgroup.
 	panic("never used")
 }
 
-func (tcs *testChunkSource) count() (uint32, error) {
+func (tcs *testChunkSource) count() uint32 {
 	panic("never used")
 }
 

--- a/go/store/nbs/aws_table_persister_test.go
+++ b/go/store/nbs/aws_table_persister_test.go
@@ -91,7 +91,7 @@ func TestAWSTablePersisterPersist(t *testing.T) {
 				require.NoError(t, err)
 				defer src.close()
 
-				if assert.True(mustUint32(src.count()) > 0) {
+				if assert.True(src.count() > 0) {
 					if r, err := s3svc.readerForTableWithNamespace(ctx, ns, src.hash()); assert.NotNil(r) && assert.NoError(err) {
 						assertChunksInReader(testChunks, r, assert)
 						r.close()
@@ -108,7 +108,7 @@ func TestAWSTablePersisterPersist(t *testing.T) {
 				src, _, err := s3p.Persist(context.Background(), dherrors.FatalBehaviorError, mt, nil, nil, &Stats{})
 				require.NoError(t, err)
 				defer src.close()
-				if assert.True(mustUint32(src.count()) > 0) {
+				if assert.True(src.count() > 0) {
 					if r, err := s3svc.readerForTableWithNamespace(ctx, ns, src.hash()); assert.NotNil(r) && assert.NoError(err) {
 						assertChunksInReader(testChunks, r, assert)
 						r.close()
@@ -133,7 +133,7 @@ func TestAWSTablePersisterPersist(t *testing.T) {
 				src, _, err := s3p.Persist(context.Background(), dherrors.FatalBehaviorError, mt, existingTable, nil, &Stats{})
 				require.NoError(t, err)
 				defer src.close()
-				assert.True(mustUint32(src.count()) == 0)
+				assert.True(src.count() == 0)
 
 				_, present := s3svc.data[src.hash().String()]
 				assert.False(present)
@@ -302,7 +302,7 @@ func TestAWSTablePersisterConjoinAll(t *testing.T) {
 				s.close()
 			}
 
-			if assert.True(mustUint32(src.count()) > 0) {
+			if assert.True(src.count() > 0) {
 				if r, err := s3svc.readerForTable(ctx, src.hash()); assert.NotNil(r) && assert.NoError(err) {
 					assertChunksInReader(chunks, r, assert)
 					r.close()
@@ -323,7 +323,7 @@ func TestAWSTablePersisterConjoinAll(t *testing.T) {
 				s.close()
 			}
 
-			if assert.True(mustUint32(src.count()) > 0) {
+			if assert.True(src.count() > 0) {
 				if r, err := s3svc.readerForTable(ctx, src.hash()); assert.NotNil(r) && assert.NoError(err) {
 					assertChunksInReader(smallChunks, r, assert)
 					r.close()
@@ -364,7 +364,7 @@ func TestAWSTablePersisterConjoinAll(t *testing.T) {
 			s.close()
 		}
 
-		if assert.True(mustUint32(src.count()) > 0) {
+		if assert.True(src.count() > 0) {
 			if r, err := s3svc.readerForTable(ctx, src.hash()); assert.NotNil(r) && assert.NoError(err) {
 				assertChunksInReader(bigUns1, r, assert)
 				assertChunksInReader(bigUns2, r, assert)
@@ -405,7 +405,7 @@ func TestAWSTablePersisterConjoinAll(t *testing.T) {
 			s.close()
 		}
 
-		if assert.True(mustUint32(src.count()) > 0) {
+		if assert.True(src.count() > 0) {
 			if r, err := s3svc.readerForTable(ctx, src.hash()); assert.NotNil(r) && assert.NoError(err) {
 				assertChunksInReader(bigUns1, r, assert)
 				assertChunksInReader(medChunks, r, assert)
@@ -460,7 +460,7 @@ func TestAWSTablePersisterConjoinAll(t *testing.T) {
 			s.close()
 		}
 
-		if assert.True(mustUint32(src.count()) > 0) {
+		if assert.True(src.count() > 0) {
 			if r, err := s3svc.readerForTable(ctx, src.hash()); assert.NotNil(r) && assert.NoError(err) {
 				assertChunksInReader(smallChunks, r, assert)
 				assertChunksInReader(bigUns1, r, assert)

--- a/go/store/nbs/bs_persister.go
+++ b/go/store/nbs/bs_persister.go
@@ -166,10 +166,7 @@ func (bsp *blobstorePersister) getRecordsSubObject(ctx context.Context, cs chunk
 }
 
 func (bsp *blobstorePersister) hotCreateTableRecords(ctx context.Context, cs chunkSource) error {
-	cnt, err := cs.count()
-	if err != nil {
-		return err
-	}
+	cnt := cs.count()
 	off := tableTailOffset(cs.currentSize(), cnt)
 	l := int64(off)
 	rng := blobstore.NewBlobRange(0, l)

--- a/go/store/nbs/conjoiner.go
+++ b/go/store/nbs/conjoiner.go
@@ -312,36 +312,23 @@ func conjoinTables(ctx context.Context, behavior dherrors.FatalBehavior, conjoin
 	stats.ConjoinLatency.SampleTimeSince(t1)
 	stats.TablesPerConjoin.SampleLen(len(toConjoin))
 
-	cnt, err := conjoinedSrc.count()
-	if err != nil {
-		return tableSpec{}, nil, err
-	}
+	cnt := conjoinedSrc.count()
 
 	stats.ChunksPerConjoin.Sample(uint64(cnt))
 
 	h := conjoinedSrc.hash()
-	cnt, err = conjoinedSrc.count()
-	if err != nil {
-		return tableSpec{}, nil, err
-	}
 	return tableSpec{h, cnt}, cleanup, nil
 }
 
 func toSpecs(srcs chunkSources) ([]tableSpec, error) {
 	specs := make([]tableSpec, len(srcs))
 	for i, src := range srcs {
-		cnt, err := src.count()
-		if err != nil {
-			return nil, err
-		} else if cnt <= 0 {
+		cnt := src.count()
+		if cnt <= 0 {
 			return nil, errors.New("invalid table spec has no sources")
 		}
 
 		h := src.hash()
-		cnt, err = src.count()
-		if err != nil {
-			return nil, err
-		}
 		specs[i] = tableSpec{h, cnt}
 	}
 

--- a/go/store/nbs/conjoiner_test.go
+++ b/go/store/nbs/conjoiner_test.go
@@ -105,7 +105,7 @@ func makeTestSrcs(t *testing.T, tableSizes []uint32, p tableFilePersister, mode 
 // Makes a tableSet with len(tableSizes) upstream tables containing tableSizes[N] unique chunks
 func makeTestTableSpecs(t *testing.T, tableSizes []uint32, p tableFilePersister, mode testConjoinMode) (specs []tableSpec) {
 	for _, src := range makeTestSrcs(t, tableSizes, p, mode) {
-		specs = append(specs, tableSpec{src.hash(), mustUint32(src.count())})
+		specs = append(specs, tableSpec{src.hash(), src.count()})
 		err := src.close()
 		require.NoError(t, err)
 	}
@@ -241,7 +241,7 @@ func testConjoin(t *testing.T, mode testConjoinMode, factory func(t *testing.T) 
 		src, _, err := p.Persist(context.Background(), dherrors.FatalBehaviorError, mt, nil, nil, &Stats{})
 		require.NoError(t, err)
 		defer src.close()
-		return tableSpec{src.hash(), mustUint32(src.count())}
+		return tableSpec{src.hash(), src.count()}
 	}
 
 	tc := []struct {

--- a/go/store/nbs/empty_chunk_source.go
+++ b/go/store/nbs/empty_chunk_source.go
@@ -55,8 +55,8 @@ func (ecs emptyChunkSource) getManyCompressed(ctx context.Context, eg *errgroup.
 	return true, gcBehavior_Continue, nil
 }
 
-func (ecs emptyChunkSource) count() (uint32, error) {
-	return 0, nil
+func (ecs emptyChunkSource) count() uint32 {
+	return 0
 }
 
 func (ecs emptyChunkSource) uncompressedLen() (uint64, error) {

--- a/go/store/nbs/file_table_persister_test.go
+++ b/go/store/nbs/file_table_persister_test.go
@@ -78,7 +78,7 @@ func TestFSTablePersisterPersist(t *testing.T) {
 	src, err := persistTableData(fts, testChunks...)
 	require.NoError(t, err)
 	defer src.close()
-	if assert.True(mustUint32(src.count()) > 0) {
+	if assert.True(src.count() > 0) {
 		buff, err := os.ReadFile(filepath.Join(dir, src.hash().String()))
 		require.NoError(t, err)
 		ti, err := parseTableIndexByCopy(ctx, buff, &UnlimitedQuotaProvider{})
@@ -117,7 +117,7 @@ func TestFSTablePersisterPersistNoData(t *testing.T) {
 
 	src, _, err := fts.Persist(context.Background(), dherrors.FatalBehaviorError, mt, existingTable, nil, &Stats{})
 	require.NoError(t, err)
-	assert.True(mustUint32(src.count()) == 0)
+	assert.True(src.count() == 0)
 
 	_, err = os.Stat(filepath.Join(dir, src.hash().String()))
 	assert.True(os.IsNotExist(err), "%v", err)
@@ -152,7 +152,7 @@ func TestFSTablePersisterConjoinAll(t *testing.T) {
 	require.NoError(t, err)
 	defer src.close()
 
-	if assert.True(mustUint32(src.count()) > 0) {
+	if assert.True(src.count() > 0) {
 		buff, err := os.ReadFile(filepath.Join(dir, src.hash().String()))
 		require.NoError(t, err)
 		ti, err := parseTableIndexByCopy(ctx, buff, &UnlimitedQuotaProvider{})
@@ -197,7 +197,7 @@ func TestFSTablePersisterConjoinAllDups(t *testing.T) {
 	}
 	cleanup()
 
-	if assert.True(mustUint32(src.count()) > 0) {
+	if assert.True(src.count() > 0) {
 		buff, err := os.ReadFile(filepath.Join(dir, src.hash().String()))
 		require.NoError(t, err)
 		ti, err := parseTableIndexByCopy(ctx, buff, &UnlimitedQuotaProvider{})
@@ -206,6 +206,6 @@ func TestFSTablePersisterConjoinAllDups(t *testing.T) {
 		require.NoError(t, err)
 		defer tr.close()
 		assertChunksInReader(testChunks, tr, assert)
-		assert.EqualValues(reps*len(testChunks), mustUint32(tr.count()))
+		assert.EqualValues(reps*len(testChunks), tr.count())
 	}
 }

--- a/go/store/nbs/journal_chunk_source.go
+++ b/go/store/nbs/journal_chunk_source.go
@@ -174,8 +174,8 @@ func (s journalChunkSource) getManyCompressed(ctx context.Context, eg *errgroup.
 	return remaining, gcBehavior_Continue, nil
 }
 
-func (s journalChunkSource) count() (uint32, error) {
-	return s.journal.recordCount(), nil
+func (s journalChunkSource) count() uint32 {
+	return s.journal.recordCount()
 }
 
 func (s journalChunkSource) uncompressedLen() (uint64, error) {

--- a/go/store/nbs/mem_table.go
+++ b/go/store/nbs/mem_table.go
@@ -127,8 +127,8 @@ func (mt *memTable) addChildRefs(addrs hash.HashSet) {
 	}
 }
 
-func (mt *memTable) count() (uint32, error) {
-	return uint32(len(mt.order)), nil
+func (mt *memTable) count() uint32 {
+	return uint32(len(mt.order))
 }
 
 func (mt *memTable) uncompressedLen() (uint64, error) {

--- a/go/store/nbs/mem_table_test.go
+++ b/go/store/nbs/mem_table_test.go
@@ -319,9 +319,9 @@ func (crg chunkReaderGroup) getManyCompressed(ctx context.Context, eg *errgroup.
 	return true, gcBehavior_Continue, nil
 }
 
-func (crg chunkReaderGroup) count() (count uint32, err error) {
+func (crg chunkReaderGroup) count() (count uint32) {
 	for _, haver := range crg {
-		count += mustUint32(haver.count())
+		count += haver.count()
 	}
 	return
 }

--- a/go/store/nbs/root_tracker_test.go
+++ b/go/store/nbs/root_tracker_test.go
@@ -509,7 +509,7 @@ type fakeTablePersister struct {
 var _ tablePersister = fakeTablePersister{}
 
 func (ftp fakeTablePersister) Persist(ctx context.Context, behavior dherrors.FatalBehavior, mt *memTable, haver chunkReader, keeper keeperF, stats *Stats) (chunkSource, gcBehavior, error) {
-	if mustUint32(mt.count()) == 0 {
+	if mt.count() == 0 {
 		return emptyChunkSource{}, gcBehavior_Continue, nil
 	}
 
@@ -573,7 +573,7 @@ func (ftp fakeTablePersister) ConjoinAll(ctx context.Context, _ dherrors.FatalBe
 func compactSourcesToBuffer(sources chunkSources) (name hash.Hash, data []byte, chunkCount uint32, err error) {
 	totalData := uint64(0)
 	for _, src := range sources {
-		chunkCount += mustUint32(src.count())
+		chunkCount += src.count()
 		totalData += mustUint64(src.uncompressedLen())
 	}
 	if chunkCount == 0 {

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -1198,31 +1198,17 @@ func toGetRecords(hashes hash.HashSet) []getRecord {
 }
 
 func (nbs *NomsBlockStore) Count() (uint32, error) {
-	count, tables, err := func() (count uint32, tables chunkReader, err error) {
+	count, tables := func() (count uint32, tables chunkReader) {
 		nbs.mu.RLock()
 		defer nbs.mu.RUnlock()
 		if nbs.memtable != nil {
-			count, err = nbs.memtable.count()
+			count = nbs.memtable.count()
 		}
 
-		if err != nil {
-			return 0, nil, err
-		}
-
-		return count, nbs.tables, nil
+		return count, nbs.tables
 	}()
 
-	if err != nil {
-		return 0, err
-	}
-
-	tablesCount, err := tables.count()
-
-	if err != nil {
-		return 0, err
-	}
-
-	return count + tablesCount, nil
+	return count + tables.count(), nil
 }
 
 func (nbs *NomsBlockStore) Has(ctx context.Context, h hash.Hash) (bool, error) {
@@ -1584,11 +1570,7 @@ func (nbs *NomsBlockStore) updateManifest(ctx context.Context, current, last has
 
 	for {
 		if nbs.memtable != nil {
-			cnt, err := nbs.memtable.count()
-			if err != nil {
-				return err
-			}
-			if cnt > 0 {
+			if nbs.memtable.count() > 0 {
 				ts, gcb, err := nbs.tables.append(ctx, nbs.fatalBehavior, nbs.memtable, checker, nbs.keeperFunc, nbs.hasCache, nbs.stats)
 				if err != nil {
 					nbs.handlePossibleDanglingRefError(err)
@@ -1704,7 +1686,7 @@ func (nbs *NomsBlockStore) Stats() interface{} {
 func (nbs *NomsBlockStore) StatsSummary() string {
 	nbs.mu.Lock()
 	defer nbs.mu.Unlock()
-	cnt, _ := nbs.tables.count()
+	cnt := nbs.tables.count()
 	physLen, _ := nbs.tables.physicalLen()
 	return fmt.Sprintf("Root: %s; Chunk Count %d; Physical Bytes %s", nbs.upstream.root, cnt, humanize.Bytes(physLen))
 }
@@ -2613,11 +2595,7 @@ func (nbs *NomsBlockStore) findTableSpec(storageId hash.Hash) (tableSpec, bool) 
 	}
 	for _, tf := range nbs.tables.upstream {
 		if tf.hash() == storageId {
-			count, err := tf.count()
-			if err != nil {
-				return tableSpec{name: storageId, chunkCount: 0}, false
-			}
-			return tableSpec{name: storageId, chunkCount: count}, true
+			return tableSpec{name: storageId, chunkCount: tf.count()}, true
 		}
 	}
 	return tableSpec{name: storageId, chunkCount: 0}, false

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -230,7 +230,7 @@ type chunkReader interface {
 	getManyCompressed(ctx context.Context, eg *errgroup.Group, reqs []getRecord, found func(context.Context, ToChunker), keeper keeperF, stats *Stats) (bool, gcBehavior, error)
 
 	// count returns the chunk count for this chunkReader.
-	count() (uint32, error)
+	count() uint32
 
 	// uncompressedLen returns the total uncompressed length this chunkReader.
 	uncompressedLen() (uint64, error)

--- a/go/store/nbs/table_persister.go
+++ b/go/store/nbs/table_persister.go
@@ -249,13 +249,7 @@ func planTableConjoin(ctx context.Context, sources []sourceWithSize, q MemoryQuo
 			prefixIndexRecs = append(prefixIndexRecs, rec)
 		}
 
-		var cnt uint32
-		cnt, err = sws.source.count()
-		if err != nil {
-			return compactionPlan{}, err
-		}
-
-		ordinalOffset += cnt
+		ordinalOffset += sws.source.count()
 
 		if onHeap, ok := index.(onHeapTableIndex); ok {
 			// TODO: copy the lengths and suffixes as a byte-copy from src BUG #3438

--- a/go/store/nbs/table_persister_test.go
+++ b/go/store/nbs/table_persister_test.go
@@ -56,7 +56,7 @@ func TestPlanCompaction(t *testing.T) {
 		require.NoError(t, err)
 		src := chunkSourceAdapter{tr, name}
 		t.Cleanup(func() { src.close() })
-		dataLens = append(dataLens, uint64(len(data))-indexSize(mustUint32(src.count()))-footerSize)
+		dataLens = append(dataLens, uint64(len(data))-indexSize(src.count())-footerSize)
 		sources = append(sources, src)
 	}
 
@@ -67,7 +67,7 @@ func TestPlanCompaction(t *testing.T) {
 	var totalChunks uint32
 	for i, src := range sources {
 		assert.Equal(dataLens[i], plan.sources.sws[i].dataLen)
-		totalChunks += mustUint32(src.count())
+		totalChunks += src.count()
 	}
 
 	idx, err := parseTableIndexByCopy(ctx, plan.mergedIndex, q)

--- a/go/store/nbs/table_reader.go
+++ b/go/store/nbs/table_reader.go
@@ -262,8 +262,8 @@ func (tr tableReader) hasMany(addrs []hasRecord, keeper keeperF) (bool, gcBehavi
 	return remaining, gcBehavior_Continue, nil
 }
 
-func (tr tableReader) count() (uint32, error) {
-	return tr.idx.chunkCount(), nil
+func (tr tableReader) count() uint32 {
+	return tr.idx.chunkCount()
 }
 
 func (tr tableReader) uncompressedLen() (uint64, error) {

--- a/go/store/nbs/table_set.go
+++ b/go/store/nbs/table_set.go
@@ -265,33 +265,15 @@ func (ts *tableSet) getManyCompressed(ctx context.Context, eg *errgroup.Group, r
 	return f(ts.upstream)
 }
 
-func (ts *tableSet) count() (uint32, error) {
-	f := func(css chunkSourceSet) (count uint32, err error) {
+func (ts *tableSet) count() uint32 {
+	f := func(css chunkSourceSet) (count uint32) {
 		for _, haver := range css {
-			thisCount, err := haver.count()
-
-			if err != nil {
-				return 0, err
-			}
-
-			count += thisCount
+			count += haver.count()
 		}
 		return
 	}
 
-	novelCount, err := f(ts.novel)
-
-	if err != nil {
-		return 0, err
-	}
-
-	upCount, err := f(ts.upstream)
-
-	if err != nil {
-		return 0, err
-	}
-
-	return novelCount + upCount, nil
+	return f(ts.novel) + f(ts.upstream)
 }
 
 func (ts *tableSet) uncompressedLen() (uint64, error) {
@@ -432,10 +414,7 @@ func (ts *tableSet) flatten(ctx context.Context) (*tableSet, error) {
 	}
 
 	for _, src := range ts.novel {
-		cnt, err := src.count()
-		if err != nil {
-			return nil, err
-		} else if cnt > 0 {
+		if src.count() > 0 {
 			flattened.upstream[src.hash()] = src
 		}
 	}
@@ -533,11 +512,7 @@ func (ts *tableSet) rebase(ctx context.Context, specs []tableSpec, srcs chunkSou
 	// (usually due to de-duping during table compaction)
 	novel := make(chunkSourceSet, len(ts.novel))
 	for _, t := range ts.novel {
-		cnt, err := t.count()
-		if err != nil {
-			closeAll(novel)
-			return nil, err
-		} else if cnt == 0 {
+		if t.count() == 0 {
 			continue
 		}
 		t2, err := t.clone()
@@ -598,19 +573,14 @@ func (ts *tableSet) toSpecs() ([]tableSpec, error) {
 			continue
 		}
 
-		cnt, err := src.count()
-		if err != nil {
-			return nil, err
-		} else if cnt > 0 {
+		if cnt := src.count(); cnt > 0 {
 			h := src.hash()
 			tableSpecs = append(tableSpecs, tableSpec{h, cnt})
 		}
 	}
 	for _, src := range ts.upstream {
-		cnt, err := src.count()
-		if err != nil {
-			return nil, err
-		} else if cnt <= 0 {
+		cnt := src.count()
+		if cnt <= 0 {
 			return nil, errors.New("no upstream chunks")
 		}
 		h := src.hash()

--- a/go/store/nbs/table_set_test.go
+++ b/go/store/nbs/table_set_test.go
@@ -223,7 +223,7 @@ func TestTableSetPhysicalLen(t *testing.T) {
 	ts, _, err = ts.append(context.Background(), dherrors.FatalBehaviorError, mt, hasManyHasAll, nil, hasCache, &Stats{})
 	require.NoError(t, err)
 
-	assert.True(mustUint64(ts.physicalLen()) > indexSize(mustUint32(ts.count())))
+	assert.True(mustUint64(ts.physicalLen()) > indexSize(ts.count()))
 }
 
 func TestTableSetClosesOpenedChunkSourcesOnErr(t *testing.T) {


### PR DESCRIPTION
Cleanup call sites.