### PR TITLE
Fix `diff` and `show` hiding committed tables matching `dolt_ignore`

### DIFF
--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -111,6 +111,14 @@ type diffDatasets struct {
 	toRef   string
 }
 
+// involvesWorkingSet reports whether either side of the diff is the working set or staging area.
+// Ignore patterns from the dolt_ignore table apply to the staging of untracked tables, so they
+// are relevant only when the working set is part of the diff.
+func (d *diffDatasets) involvesWorkingSet() bool {
+	return d.fromRef == doltdb.Working || d.toRef == doltdb.Working ||
+		d.fromRef == doltdb.Staged || d.toRef == doltdb.Staged
+}
+
 type diffArgs struct {
 	*diffDisplaySettings
 	*diffDatasets
@@ -906,14 +914,19 @@ func diffUserTables(queryist cli.Queryist, sqlCtx *sql.Context, dArgs *diffArgs)
 		return printDiffSummary(sqlCtx, deltas, dArgs)
 	}
 
+	// Load ignore patterns only when the diff includes the working set or staging area.
+	// Ignore patterns apply to the staging of untracked tables, not to committed history.
+	var ignoredTablePatterns doltdb.IgnorePatterns
+	if dArgs.involvesWorkingSet() {
+		ignoredTablePatterns, err = getIgnoredTablePatternsFromSql(queryist, sqlCtx)
+		if err != nil {
+			return errhand.VerboseErrorFromError(fmt.Errorf("couldn't get ignored table patterns, cause: %w", err))
+		}
+	}
+
 	dw, err := newDiffWriter(dArgs.diffOutput)
 	if err != nil {
 		return errhand.VerboseErrorFromError(err)
-	}
-
-	ignoredTablePatterns, err := getIgnoredTablePatternsFromSql(queryist, sqlCtx)
-	if err != nil {
-		return errhand.VerboseErrorFromError(fmt.Errorf("couldn't get ignored table patterns, cause: %w", err))
 	}
 
 	doltSchemasChanged := false
@@ -922,8 +935,9 @@ func diffUserTables(queryist cli.Queryist, sqlCtx *sql.Context, dArgs *diffArgs)
 			continue
 		}
 
-		// Don't print tables if one side of the diff is an ignored table in the working set being added.
-		if len(delta.FromTableName.Name) == 0 {
+		// Skip tables that were added or dropped if they match an ignore pattern. The dolt_ignore
+		// table governs the staging of new tables and does not apply to existing tracked tables.
+		if delta.IsAdd() {
 			ignoreResult, err := ignoredTablePatterns.IsTableNameIgnored(delta.ToTableName)
 			if err != nil {
 				return errhand.VerboseErrorFromError(err)
@@ -933,7 +947,7 @@ func diffUserTables(queryist cli.Queryist, sqlCtx *sql.Context, dArgs *diffArgs)
 			}
 		}
 
-		if len(delta.ToTableName.Name) == 0 {
+		if delta.IsDrop() {
 			ignoreResult, err := ignoredTablePatterns.IsTableNameIgnored(delta.FromTableName)
 			if err != nil {
 				return errhand.VerboseErrorFromError(err)

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -113,8 +113,7 @@ type diffDatasets struct {
 
 // hasWorkingSet reports whether either side of the diff references the working set or staging area.
 func (d *diffDatasets) hasWorkingSet() bool {
-	return d.fromRef == doltdb.Working || d.toRef == doltdb.Working ||
-		d.fromRef == doltdb.Staged || d.toRef == doltdb.Staged
+	return doltdb.IsWorkingSetRef(d.fromRef) || doltdb.IsWorkingSetRef(d.toRef)
 }
 
 type diffArgs struct {
@@ -933,26 +932,12 @@ func diffUserTables(queryist cli.Queryist, sqlCtx *sql.Context, dArgs *diffArgs)
 			continue
 		}
 
-		// Ignore patterns apply only to newly added or dropped tables. Modifications to already
-		// tracked tables are always shown regardless of the current dolt_ignore contents.
-		if delta.IsAdd() {
-			ignoreResult, err := ignoredTablePatterns.IsTableNameIgnored(delta.ToTableName)
-			if err != nil {
-				return errhand.VerboseErrorFromError(err)
-			}
-			if ignoreResult == doltdb.Ignore {
-				continue
-			}
+		ignore, err := ignoredTablePatterns.ShouldIgnoreDelta(delta.IsAdd(), delta.IsDrop(), delta.ToTableName, delta.FromTableName)
+		if err != nil {
+			return errhand.VerboseErrorFromError(err)
 		}
-
-		if delta.IsDrop() {
-			ignoreResult, err := ignoredTablePatterns.IsTableNameIgnored(delta.FromTableName)
-			if err != nil {
-				return errhand.VerboseErrorFromError(err)
-			}
-			if ignoreResult == doltdb.Ignore {
-				continue
-			}
+		if ignore {
+			continue
 		}
 
 		if !shouldPrintTableDelta(dArgs.tableSet, delta.ToTableName.Name, delta.FromTableName.Name) {

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -111,10 +111,8 @@ type diffDatasets struct {
 	toRef   string
 }
 
-// involvesWorkingSet reports whether either side of the diff is the working set or staging area.
-// Ignore patterns from the dolt_ignore table apply to the staging of untracked tables, so they
-// are relevant only when the working set is part of the diff.
-func (d *diffDatasets) involvesWorkingSet() bool {
+// hasWorkingSet reports whether either side of the diff references the working set or staging area.
+func (d *diffDatasets) hasWorkingSet() bool {
 	return d.fromRef == doltdb.Working || d.toRef == doltdb.Working ||
 		d.fromRef == doltdb.Staged || d.toRef == doltdb.Staged
 }
@@ -914,10 +912,10 @@ func diffUserTables(queryist cli.Queryist, sqlCtx *sql.Context, dArgs *diffArgs)
 		return printDiffSummary(sqlCtx, deltas, dArgs)
 	}
 
-	// Load ignore patterns only when the diff includes the working set or staging area.
-	// Ignore patterns apply to the staging of untracked tables, not to committed history.
+	// Ignore patterns govern the staging of untracked tables and do not apply to committed history,
+	// so they are only loaded when the diff references the working set or staging area.
 	var ignoredTablePatterns doltdb.IgnorePatterns
-	if dArgs.involvesWorkingSet() {
+	if dArgs.hasWorkingSet() {
 		ignoredTablePatterns, err = getIgnoredTablePatternsFromSql(queryist, sqlCtx)
 		if err != nil {
 			return errhand.VerboseErrorFromError(fmt.Errorf("couldn't get ignored table patterns, cause: %w", err))
@@ -935,8 +933,8 @@ func diffUserTables(queryist cli.Queryist, sqlCtx *sql.Context, dArgs *diffArgs)
 			continue
 		}
 
-		// Skip tables that were added or dropped if they match an ignore pattern. The dolt_ignore
-		// table governs the staging of new tables and does not apply to existing tracked tables.
+		// Ignore patterns apply only to newly added or dropped tables. Modifications to already
+		// tracked tables are always shown regardless of the current dolt_ignore contents.
 		if delta.IsAdd() {
 			ignoreResult, err := ignoredTablePatterns.IsTableNameIgnored(delta.ToTableName)
 			if err != nil {

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -48,14 +48,6 @@ const (
 	// we expect to resolve a commit spec, but need working or staged
 	Working = "WORKING"
 	Staged  = "STAGED"
-)
-
-// IsWorkingSetRef reports whether |ref| identifies the working set or staging area rather than a commit.
-func IsWorkingSetRef(ref string) bool {
-	return ref == Working || ref == Staged
-}
-
-const (
 
 	CreationBranch = "create"
 
@@ -145,6 +137,11 @@ type DoltDB struct {
 
 	// Keep a LRU Cache of materialized commits to speed up future commit resolutions
 	commitCache *lru.Cache[hash.Hash, *OptionalCommit]
+}
+
+// IsWorkingSetRef reports whether |ref| identifies the working set or staging area rather than a commit.
+func IsWorkingSetRef(ref string) bool {
+	return ref == Working || ref == Staged
 }
 
 // DoltDBFromCS creates a DoltDB from a noms chunks.ChunkStore

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -48,6 +48,14 @@ const (
 	// we expect to resolve a commit spec, but need working or staged
 	Working = "WORKING"
 	Staged  = "STAGED"
+)
+
+// IsWorkingSetRef reports whether |ref| identifies the working set or staging area rather than a commit.
+func IsWorkingSetRef(ref string) bool {
+	return ref == Working || ref == Staged
+}
+
+const (
 
 	CreationBranch = "create"
 

--- a/go/libraries/doltcore/doltdb/ignore.go
+++ b/go/libraries/doltcore/doltdb/ignore.go
@@ -259,6 +259,26 @@ func isDoltRebaseTable(tableName TableName) bool {
 	return tableName.Schema == DoltNamespace && tableName.Name == GetRebaseTableName()
 }
 
+// ShouldIgnoreDelta reports whether a table delta should be excluded from a diff.
+// Only newly added or dropped tables are matched against the patterns; modifications to tracked tables are never filtered.
+func (ip *IgnorePatterns) ShouldIgnoreDelta(isAdd, isDrop bool, toName, fromName TableName) (bool, error) {
+	if isAdd {
+		result, err := ip.IsTableNameIgnored(toName)
+		if err != nil {
+			return false, err
+		}
+		return result == Ignore, nil
+	}
+	if isDrop {
+		result, err := ip.IsTableNameIgnored(fromName)
+		if err != nil {
+			return false, err
+		}
+		return result == Ignore, nil
+	}
+	return false, nil
+}
+
 func (ip *IgnorePatterns) IsTableNameIgnored(tableName TableName) (IgnoreResult, error) {
 	// The dolt_rebase table is automatically ignored by Dolt – it shouldn't ever
 	// be checked in to a Dolt database.

--- a/go/libraries/doltcore/doltdb/ignore.go
+++ b/go/libraries/doltcore/doltdb/ignore.go
@@ -260,7 +260,7 @@ func isDoltRebaseTable(tableName TableName) bool {
 }
 
 // ShouldIgnoreDelta reports whether a table delta should be excluded from a diff.
-// Only newly added or dropped tables are matched against the patterns; modifications to tracked tables are never filtered.
+// Only newly added or dropped tables are matched against the patterns. Changes to already tracked tables are always included.
 func (ip *IgnorePatterns) ShouldIgnoreDelta(isAdd, isDrop bool, toName, fromName TableName) (bool, error) {
 	if isAdd {
 		result, err := ip.IsTableNameIgnored(toName)

--- a/go/libraries/doltcore/sqle/dtablefunctions/dolt_diff_summary.go
+++ b/go/libraries/doltcore/sqle/dtablefunctions/dolt_diff_summary.go
@@ -484,4 +484,3 @@ func getIgnorePatternsFromContext(ctx *sql.Context, database sql.Database) (dolt
 	// Return patterns for default schema
 	return ignorePatternMap[""], nil
 }
-

--- a/go/libraries/doltcore/sqle/dtablefunctions/dolt_diff_summary.go
+++ b/go/libraries/doltcore/sqle/dtablefunctions/dolt_diff_summary.go
@@ -289,16 +289,21 @@ func (ds *DiffSummaryTableFunction) RowIter(ctx *sql.Context, row sql.Row) (sql.
 		return deltas[i].ToName.Less(deltas[j].ToName)
 	})
 
-	ignorePatterns, err := getIgnorePatternsFromContext(ctx, ds.database)
-	if err != nil {
-		return nil, err
+	// Ignore patterns govern the staging of untracked tables and do not apply to committed history,
+	// so they are only loaded when the diff references the working set or staging area.
+	var ignorePatterns doltdb.IgnorePatterns
+	if doltdb.IsWorkingSetRef(fromDetails.hashStr) || doltdb.IsWorkingSetRef(toDetails.hashStr) {
+		ignorePatterns, err = getIgnorePatternsFromContext(ctx, ds.database)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// If tableNameExpr defined, return a single table diff summary result
 	if ds.tableNameExpr != nil {
 		delta := findMatchingDelta(deltas, tableName)
 
-		ignore, err := shouldIgnoreDelta(delta, ignorePatterns)
+		ignore, err := ignorePatterns.ShouldIgnoreDelta(delta.IsAdd(), delta.IsDrop(), delta.ToName, delta.FromName)
 		if err != nil {
 			return nil, err
 		}
@@ -321,7 +326,7 @@ func (ds *DiffSummaryTableFunction) RowIter(ctx *sql.Context, row sql.Row) (sql.
 
 	var diffSummaries []*diff.TableDeltaSummary
 	for _, delta := range deltas {
-		ignore, err := shouldIgnoreDelta(delta, ignorePatterns)
+		ignore, err := ignorePatterns.ShouldIgnoreDelta(delta.IsAdd(), delta.IsDrop(), delta.ToName, delta.FromName)
 		if err != nil {
 			return nil, err
 		}
@@ -462,7 +467,7 @@ func getRowFromSummary(ds *diff.TableDeltaSummary) sql.Row {
 	}
 }
 
-// getIgnorePatternsFromContext retrieves ignore patterns from the dolt_ignore table.
+// getIgnorePatternsFromContext retrieves ignore patterns from the dolt_ignore table in the current working set.
 func getIgnorePatternsFromContext(ctx *sql.Context, database sql.Database) (doltdb.IgnorePatterns, error) {
 	sess := dsess.DSessFromSess(ctx.Session)
 	dbName := database.Name()
@@ -480,26 +485,3 @@ func getIgnorePatternsFromContext(ctx *sql.Context, database sql.Database) (dolt
 	return ignorePatternMap[""], nil
 }
 
-// shouldIgnoreDelta determines if a table delta should be ignored based on dolt_ignore patterns.
-// This follows the same logic as the dolt diff command: only "added" or "dropped" tables
-// can be ignored, not modified/renamed tables.
-func shouldIgnoreDelta(delta diff.TableDelta, ignorePatterns doltdb.IgnorePatterns) (bool, error) {
-	if delta.IsAdd() {
-		ignoreResult, err := ignorePatterns.IsTableNameIgnored(delta.ToName)
-		if err != nil {
-			return false, err
-		}
-		return ignoreResult == doltdb.Ignore, nil
-	}
-
-	if delta.IsDrop() {
-		ignoreResult, err := ignorePatterns.IsTableNameIgnored(delta.FromName)
-		if err != nil {
-			return false, err
-		}
-		return ignoreResult == doltdb.Ignore, nil
-	}
-
-	// For modified/renamed tables, don't ignore (consistent with dolt diff behavior)
-	return false, nil
-}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -1828,6 +1828,25 @@ on a.to_pk = b.to_pk;`,
 			},
 		},
 	},
+	{
+		Name: "dolt_diff commit-to-commit shows tables added to dolt_ignore after the commit",
+		SetUpScript: []string{
+			"CREATE TABLE the_table (pk int primary key, c1 int);",
+			"INSERT INTO the_table VALUES (1, 10), (2, 20);",
+			"CALL DOLT_ADD('.');",
+			"CALL DOLT_COMMIT('-m', 'add the_table');",
+			"INSERT INTO dolt_ignore VALUES ('the_table', true);",
+			"CALL DOLT_ADD('.');",
+			"CALL DOLT_COMMIT('-m', 'ignore the_table');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "SELECT DISTINCT to_table FROM dolt_diff('HEAD~2', 'HEAD~1', 'the_table');",
+				// the_table was committed before the ignore pattern existed, so it must appear.
+				Expected: []sql.Row{{"the_table"}},
+			},
+		},
+	},
 }
 
 var DiffStatTableFunctionScriptTests = []queries.ScriptTest{
@@ -4093,6 +4112,25 @@ var PatchTableFunctionScriptTests = []queries.ScriptTest{
 						"  PRIMARY KEY (`ID`)\n" +
 						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;"},
 				},
+			},
+		},
+	},
+	{
+		Name: "dolt_patch commit-to-commit shows tables added to dolt_ignore after the commit",
+		SetUpScript: []string{
+			"CREATE TABLE the_table (pk int primary key, c1 int);",
+			"INSERT INTO the_table VALUES (1, 10), (2, 20);",
+			"CALL DOLT_ADD('.');",
+			"CALL DOLT_COMMIT('-m', 'add the_table');",
+			"INSERT INTO dolt_ignore VALUES ('the_table', true);",
+			"CALL DOLT_ADD('.');",
+			"CALL DOLT_COMMIT('-m', 'ignore the_table');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "SELECT DISTINCT table_name FROM dolt_patch('HEAD~2', 'HEAD~1', 'the_table');",
+				// the_table was committed before the ignore pattern existed, so it must appear.
+				Expected: []sql.Row{{"the_table"}},
 			},
 		},
 	},
@@ -6932,6 +6970,25 @@ var QueryDiffTableScriptTests = []queries.ScriptTest{
 			{
 				Query:    "SELECT from_table_name, diff_type FROM dolt_diff_summary('HEAD', 'WORKING') ORDER BY from_table_name;",
 				Expected: []sql.Row{{"dolt_ignore", "modified"}, {"will_not_be_ignored", "dropped"}},
+			},
+		},
+	},
+	{
+		Name: "dolt_diff_summary commit-to-commit shows tables added to dolt_ignore after the commit",
+		SetUpScript: []string{
+			"CREATE TABLE the_table (pk int primary key, c1 int);",
+			"INSERT INTO the_table VALUES (1, 10), (2, 20);",
+			"CALL DOLT_ADD('.');",
+			"CALL DOLT_COMMIT('-m', 'add the_table');",
+			"INSERT INTO dolt_ignore VALUES ('the_table', true);",
+			"CALL DOLT_ADD('.');",
+			"CALL DOLT_COMMIT('-m', 'ignore the_table');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "SELECT to_table_name, diff_type FROM dolt_diff_summary('HEAD~2', 'HEAD~1');",
+				// the_table was committed before the ignore pattern existed, so it must appear.
+				Expected: []sql.Row{{"the_table", "added"}},
 			},
 		},
 	},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -1841,9 +1841,9 @@ on a.to_pk = b.to_pk;`,
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
-				Query: "SELECT DISTINCT to_table FROM dolt_diff('HEAD~2', 'HEAD~1', 'the_table');",
+				Query: "SELECT COUNT(*) FROM dolt_diff('HEAD~2', 'HEAD~1', 'the_table');",
 				// the_table was committed before the ignore pattern existed, so it must appear.
-				Expected: []sql.Row{{"the_table"}},
+				Expected: []sql.Row{{2}},
 			},
 		},
 	},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -1841,9 +1841,9 @@ on a.to_pk = b.to_pk;`,
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
-				Query: "SELECT COUNT(*) FROM dolt_diff('HEAD~2', 'HEAD~1', 'the_table');",
+				Query: "SELECT to_pk, to_c1, diff_type FROM dolt_diff('HEAD~2', 'HEAD~1', 'the_table') ORDER BY to_pk;",
 				// the_table was committed before the ignore pattern existed, so it must appear.
-				Expected: []sql.Row{{2}},
+				Expected: []sql.Row{{1, 10, "added"}, {2, 20, "added"}},
 			},
 		},
 	},

--- a/integration-tests/bats/ignore.bats
+++ b/integration-tests/bats/ignore.bats
@@ -516,48 +516,44 @@ SQL
 }
 
 @test "ignore: dolt show should display committed tables even after they are added to dolt_ignore" {
-    # Stage and commit the_table. It does not match any ignore pattern in the test setup,
-    # so it stages without --force.
     dolt sql -q "CREATE TABLE the_table (pk INT PRIMARY KEY, name TEXT);"
     dolt add the_table
     dolt commit -m "add the_table"
 
-    # Verify the diff appears in the commit before the ignore pattern is added.
-    run dolt show HEAD
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ "diff --dolt a/the_table b/the_table" ]] || false
-
-    # The test setup includes a "*_ignore" pattern that matches "dolt_ignore" itself,
-    # so --force is required to stage dolt_ignore.
+    # The setup adds a "*_ignore" pattern which matches "dolt_ignore" itself, so staging
+    # dolt_ignore requires --force.
     dolt sql -q "INSERT INTO dolt_ignore VALUES ('the_table', true);"
     dolt add --force dolt_ignore
     dolt commit -m "ignore the_table"
 
-    # Use --summary to verify the_table is present in the commit.
+    # Confirm the_table is recorded in the earlier commit.
     run dolt show --summary HEAD~1
     [ "$status" -eq 0 ]
     [[ "$output" =~ "the_table" ]] || false
 
-    # The commit predates the ignore pattern, so its diff must show the_table.
+    # the_table was committed before the ignore pattern existed, so its diff must still appear.
     run dolt show HEAD~1
     [ "$status" -eq 0 ]
     [[ "$output" =~ "diff --dolt a/the_table b/the_table" ]] || false
 }
 
 @test "ignore: dolt diff should display committed tables even after they are added to dolt_ignore" {
-    # Stage and commit the_table. It does not match any ignore pattern in the test setup,
-    # so it stages without --force.
     dolt sql -q "CREATE TABLE the_table (pk INT PRIMARY KEY, name TEXT);"
     dolt add the_table
     dolt commit -m "add the_table"
 
-    # The test setup includes a "*_ignore" pattern that matches "dolt_ignore" itself,
-    # so --force is required to stage dolt_ignore.
+    # The setup adds a "*_ignore" pattern which matches "dolt_ignore" itself, so staging
+    # dolt_ignore requires --force.
     dolt sql -q "INSERT INTO dolt_ignore VALUES ('the_table', true);"
     dolt add --force dolt_ignore
     dolt commit -m "ignore the_table"
 
-    # The commit predates the ignore pattern, so the diff between the two commits must show the_table.
+    # Confirm the_table is recorded in the earlier commit.
+    run dolt diff --summary HEAD~2 HEAD~1
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "the_table" ]] || false
+
+    # the_table was committed before the ignore pattern existed, so its diff must still appear.
     run dolt diff HEAD~2 HEAD~1
     [ "$status" -eq 0 ]
     [[ "$output" =~ "diff --dolt a/the_table b/the_table" ]] || false

--- a/integration-tests/bats/ignore.bats
+++ b/integration-tests/bats/ignore.bats
@@ -515,50 +515,6 @@ SQL
     [[ ! "$output" =~ "will_be_ignored" ]] || false
 }
 
-@test "ignore: dolt show should display committed tables even after they are added to dolt_ignore" {
-    dolt sql -q "CREATE TABLE the_table (pk INT PRIMARY KEY, name TEXT);"
-    dolt add the_table
-    dolt commit -m "add the_table"
-
-    # The setup adds a "*_ignore" pattern which matches "dolt_ignore" itself, so staging
-    # dolt_ignore requires --force.
-    dolt sql -q "INSERT INTO dolt_ignore VALUES ('the_table', true);"
-    dolt add --force dolt_ignore
-    dolt commit -m "ignore the_table"
-
-    # Confirm the_table is recorded in the earlier commit.
-    run dolt show --summary HEAD~1
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ "the_table" ]] || false
-
-    # the_table was committed before the ignore pattern existed, so its diff must still appear.
-    run dolt show HEAD~1
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ "diff --dolt a/the_table b/the_table" ]] || false
-}
-
-@test "ignore: dolt diff should display committed tables even after they are added to dolt_ignore" {
-    dolt sql -q "CREATE TABLE the_table (pk INT PRIMARY KEY, name TEXT);"
-    dolt add the_table
-    dolt commit -m "add the_table"
-
-    # The setup adds a "*_ignore" pattern which matches "dolt_ignore" itself, so staging
-    # dolt_ignore requires --force.
-    dolt sql -q "INSERT INTO dolt_ignore VALUES ('the_table', true);"
-    dolt add --force dolt_ignore
-    dolt commit -m "ignore the_table"
-
-    # Confirm the_table is recorded in the earlier commit.
-    run dolt diff --summary HEAD~2 HEAD~1
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ "the_table" ]] || false
-
-    # the_table was committed before the ignore pattern existed, so its diff must still appear.
-    run dolt diff HEAD~2 HEAD~1
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ "diff --dolt a/the_table b/the_table" ]] || false
-}
-
 @test "ignore: dolt_diff_summary specific table query respects ignore patterns" {
     # Create and commit initial table
     dolt sql -q "CREATE TABLE initial_table (pk int primary key)"
@@ -579,4 +535,77 @@ SQL
     run dolt sql -q "SELECT COUNT(*) FROM dolt_diff_summary('HEAD', 'WORKING', 'not_ignored_table')" -r csv
     [ "$status" -eq 0 ]
     [[ "$output" =~ "1" ]] || false
+}
+
+@test "ignore: dolt show should display committed tables even after they are added to dolt_ignore" {
+    dolt sql -q "CREATE TABLE the_table (pk INT PRIMARY KEY, name TEXT);"
+    dolt add the_table
+    dolt commit -m "add the_table"
+
+    # The setup adds a "*_ignore" pattern which matches "dolt_ignore" itself, so staging
+    # dolt_ignore requires --force.
+    dolt sql -q "INSERT INTO dolt_ignore VALUES ('the_table', true);"
+    dolt add --force dolt_ignore
+    dolt commit -m "ignore the_table"
+
+    # Untracked tables matching an ignore pattern are excluded from working set diffs.
+    # This matches git, where ignore patterns apply only to untracked files and untracked files never appear in diffs.
+    dolt sql -q "CREATE TABLE new_ignore (pk INT PRIMARY KEY);"
+    run dolt diff HEAD WORKING
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "new_ignore" ]] || false
+
+    # Commit another table to advance history while the ignore pattern remains active.
+    dolt sql -q "CREATE TABLE another_table (pk INT PRIMARY KEY);"
+    dolt add another_table
+    dolt commit -m "add another_table"
+
+    # new_ignore must still be absent after a subsequent commit.
+    run dolt diff HEAD WORKING
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "new_ignore" ]] || false
+
+    # Confirm the_table is recorded in the earlier commit.
+    run dolt show --summary HEAD~2
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "the_table" ]] || false
+
+    # the_table was committed before the ignore pattern existed, so its diff must still appear.
+    run dolt show HEAD~2
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "diff --dolt a/the_table b/the_table" ]] || false
+}
+
+@test "ignore: dolt diff should display committed tables even after they are added to dolt_ignore" {
+    dolt sql -q "CREATE TABLE the_table (pk INT PRIMARY KEY, name TEXT);"
+    dolt add the_table
+    dolt commit -m "add the_table"
+
+    dolt sql -q "INSERT INTO dolt_ignore VALUES ('the_table', true);"
+    dolt add --force dolt_ignore
+    dolt commit -m "ignore the_table"
+
+    dolt sql -q "CREATE TABLE new_ignore (pk INT PRIMARY KEY);"
+    run dolt diff HEAD WORKING
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "new_ignore" ]] || false
+
+    dolt sql -q "CREATE TABLE another_table (pk INT PRIMARY KEY);"
+    dolt add another_table
+    dolt commit -m "add another_table"
+
+    # new_ignore must still be absent after a subsequent commit.
+    run dolt diff HEAD WORKING
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "new_ignore" ]] || false
+
+    # Confirm the_table is recorded in the earlier commit.
+    run dolt diff --summary HEAD~3 HEAD~2
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "the_table" ]] || false
+
+    # the_table was committed before the ignore pattern existed, so its diff must still appear.
+    run dolt diff HEAD~3 HEAD~2
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "diff --dolt a/the_table b/the_table" ]] || false
 }

--- a/integration-tests/bats/ignore.bats
+++ b/integration-tests/bats/ignore.bats
@@ -515,6 +515,54 @@ SQL
     [[ ! "$output" =~ "will_be_ignored" ]] || false
 }
 
+@test "ignore: dolt show should display committed tables even after they are added to dolt_ignore" {
+    # Stage and commit the_table. It does not match any ignore pattern in the test setup,
+    # so it stages without --force.
+    dolt sql -q "CREATE TABLE the_table (pk INT PRIMARY KEY, name TEXT);"
+    dolt add the_table
+    dolt commit -m "add the_table"
+
+    # Verify the diff appears in the commit before the ignore pattern is added.
+    run dolt show HEAD
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "diff --dolt a/the_table b/the_table" ]] || false
+
+    # The test setup includes a "*_ignore" pattern that matches "dolt_ignore" itself,
+    # so --force is required to stage dolt_ignore.
+    dolt sql -q "INSERT INTO dolt_ignore VALUES ('the_table', true);"
+    dolt add --force dolt_ignore
+    dolt commit -m "ignore the_table"
+
+    # Use --summary to verify the_table is present in the commit.
+    run dolt show --summary HEAD~1
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "the_table" ]] || false
+
+    # The commit predates the ignore pattern, so its diff must show the_table.
+    run dolt show HEAD~1
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "diff --dolt a/the_table b/the_table" ]] || false
+}
+
+@test "ignore: dolt diff should display committed tables even after they are added to dolt_ignore" {
+    # Stage and commit the_table. It does not match any ignore pattern in the test setup,
+    # so it stages without --force.
+    dolt sql -q "CREATE TABLE the_table (pk INT PRIMARY KEY, name TEXT);"
+    dolt add the_table
+    dolt commit -m "add the_table"
+
+    # The test setup includes a "*_ignore" pattern that matches "dolt_ignore" itself,
+    # so --force is required to stage dolt_ignore.
+    dolt sql -q "INSERT INTO dolt_ignore VALUES ('the_table', true);"
+    dolt add --force dolt_ignore
+    dolt commit -m "ignore the_table"
+
+    # The commit predates the ignore pattern, so the diff between the two commits must show the_table.
+    run dolt diff HEAD~2 HEAD~1
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "diff --dolt a/the_table b/the_table" ]] || false
+}
+
 @test "ignore: dolt_diff_summary specific table query respects ignore patterns" {
     # Create and commit initial table
     dolt sql -q "CREATE TABLE initial_table (pk int primary key)"


### PR DESCRIPTION
Ignore patterns apply to staging untracked tables, not committed history. `dolt diff`, `dolt show`, and `dolt_diff_summary()` were incorrectly filtering tables from commit-to-commit diffs when those tables matched a `dolt_ignore` pattern after the commit.
- Add `IsWorkingSetRef` to `doltdb` and `ShouldIgnoreDelta` to `IgnorePatterns` as shared helpers.
- Fix `diffUserTables` to skip ignore pattern evaluation when both refs are commits, using `hasWorkingSet` on `diffDatasets`
- Fix `dolt_diff_summary()` to apply the same gate, correcting commit-to-commit queries.
- Restrict ignore filtering to newly added or dropped tables in both layers; modifications to tracked tables are always shown.
- Add enginetests for `dolt_diff()`, `dolt_patch()` and `dolt_diff_summary()` to lock in correct commit-to-commit behavior across independent implementations.

Fix dolthub/dolt#10782
Related dolthub/docs#2813