### PR TITLE
go/store/nbs: gcFinalizer: Have Finalize open and carry a chunkSourceSet for the specs.

### DIFF
--- a/go/store/chunks/chunk_store.go
+++ b/go/store/chunks/chunk_store.go
@@ -199,6 +199,7 @@ type MarkAndSweeper interface {
 type GCFinalizer interface {
 	AddChunksToStore(ctx context.Context) (HasManyFunc, error)
 	SwapChunksInStore(ctx context.Context) error
+	Close() error
 }
 
 type GCMode int

--- a/go/store/chunks/memory_store.go
+++ b/go/store/chunks/memory_store.go
@@ -357,6 +357,10 @@ func (mgcf msvGcFinalizer) SwapChunksInStore(ctx context.Context) error {
 	return nil
 }
 
+func (mgcf msvGcFinalizer) Close() error {
+	return nil
+}
+
 type msvMarkAndSweeper struct {
 	ms *MemoryStoreView
 

--- a/go/store/nbs/admin_newgen_to_oldgen.go
+++ b/go/store/nbs/admin_newgen_to_oldgen.go
@@ -101,7 +101,7 @@ func nonAtomicSwap(ctx context.Context, id hash.Hash, src, dst *NomsBlockStore, 
 	// Add the moved table spec to the destination specs
 	newDstSpecs = append(newDstSpecs, movedTs)
 
-	err = src.swapTables(ctx, newSrcSpecs, chunks.GCMode_Default)
+	err = src.swapTables(ctx, newSrcSpecs, chunks.GCMode_Default, nil)
 	if err != nil {
 		return err
 	}
@@ -109,7 +109,7 @@ func nonAtomicSwap(ctx context.Context, id hash.Hash, src, dst *NomsBlockStore, 
 	if err != nil {
 		return err
 	}
-	err = dst.swapTables(ctx, newDstSpecs, chunks.GCMode_Default)
+	err = dst.swapTables(ctx, newDstSpecs, chunks.GCMode_Default, nil)
 	if err != nil {
 		return err
 	}

--- a/go/store/nbs/archive_build.go
+++ b/go/store/nbs/archive_build.go
@@ -130,7 +130,7 @@ func unArchiveSingleBlockStore(ctx context.Context, blockStore *NomsBlockStore, 
 			}
 		}
 
-		err = blockStore.swapTables(ctx, newSpecs, chunks.GCMode_Default)
+		err = blockStore.swapTables(ctx, newSpecs, chunks.GCMode_Default, nil)
 		if err != nil {
 			return err
 		}
@@ -238,7 +238,7 @@ func archiveSingleBlockStore(ctx context.Context, blockStore *NomsBlockStore, da
 			}
 		}
 
-		err = blockStore.swapTables(ctx, newSpecs, chunks.GCMode_Default)
+		err = blockStore.swapTables(ctx, newSpecs, chunks.GCMode_Default, nil)
 		if err != nil {
 			return err
 		}

--- a/go/store/nbs/generational_chunk_store.go
+++ b/go/store/nbs/generational_chunk_store.go
@@ -431,7 +431,7 @@ func (gcs *GenerationalNBS) WriteTableFile(ctx context.Context, fileId string, s
 
 // AddTableFilesToManifest adds table files to the manifest of the newgen cs
 func (gcs *GenerationalNBS) AddTableFilesToManifest(ctx context.Context, fileIdToNumChunks map[string]int, getAddrs chunks.GetAddrsCurry) error {
-	return gcs.newGen.addTableFilesToManifest(ctx, fileIdToNumChunks, getAddrs, gcs.refCheck)
+	return gcs.newGen.addTableFilesToManifest(ctx, fileIdToNumChunks, getAddrs, gcs.refCheck, nil)
 }
 
 // PruneTableFiles deletes old table files that are no longer referenced in the manifest of the new or old gen chunkstores

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -405,7 +405,7 @@ func (nbs *NomsBlockStore) finalizeConjoin(ctx context.Context, err error) {
 
 func (nbs *NomsBlockStore) UpdateManifest(ctx context.Context, updates map[hash.Hash]uint32) (ManifestInfo, error) {
 	valctx.ValidateContext(ctx)
-	sources, err := nbs.openChunkSourcesForAddTableFiles(ctx, updates)
+	sources, err := nbs.openChunkSourcesForManifestUpdateAndRebase(ctx, updates, nil)
 	if err != nil {
 		return manifestContents{}, err
 	}
@@ -547,7 +547,7 @@ func (nbs *NomsBlockStore) updateManifestAddFiles(ctx context.Context, updates m
 
 func (nbs *NomsBlockStore) UpdateManifestWithAppendix(ctx context.Context, updates map[hash.Hash]uint32, option ManifestAppendixOption) (ManifestInfo, error) {
 	valctx.ValidateContext(ctx)
-	sources, err := nbs.openChunkSourcesForAddTableFiles(ctx, updates)
+	sources, err := nbs.openChunkSourcesForManifestUpdateAndRebase(ctx, updates, nil)
 	if err != nil {
 		return manifestContents{}, err
 	}
@@ -1399,39 +1399,6 @@ func (nbs *NomsBlockStore) refCheck(reqs []hasRecord) (hash.HashSet, error) {
 	return absent, nil
 }
 
-// Only used for a generational full GC, where the table files are
-// added to the store and are then used to filter which chunks need to
-// make it to the new generation. In this context, we do not need to
-// worry about taking read dependencies on the requested chunks. Hence
-// our handling of keeperFunc and gcBehavior below.
-func (nbs *NomsBlockStore) hasManyInSources(srcs []hash.Hash, hashes hash.HashSet) (hash.HashSet, error) {
-	if hashes.Size() == 0 {
-		return nil, nil
-	}
-
-	t1 := time.Now()
-	defer nbs.stats.HasLatency.SampleTimeSince(t1)
-	nbs.stats.AddressesPerHas.SampleLen(hashes.Size())
-
-	nbs.mu.RLock()
-	defer nbs.mu.RUnlock()
-
-	records := toHasRecords(hashes)
-
-	_, _, err := nbs.tables.hasManyInSources(srcs, records, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	absent := hash.HashSet{}
-	for _, r := range records {
-		if !r.has {
-			absent.Insert(*r.a)
-		}
-	}
-	return absent, nil
-}
-
 func toHasRecords(hashes hash.HashSet) []hasRecord {
 	reqs := make([]hasRecord, len(hashes))
 	idx := 0
@@ -1902,7 +1869,7 @@ func (nbs *NomsBlockStore) WriteTableFile(ctx context.Context, fileName string, 
 // AddTableFilesToManifest adds table files to the manifest
 func (nbs *NomsBlockStore) AddTableFilesToManifest(ctx context.Context, fileIdToNumChunks map[string]int, getAddrs chunks.GetAddrsCurry) error {
 	valctx.ValidateContext(ctx)
-	return nbs.addTableFilesToManifest(ctx, fileIdToNumChunks, getAddrs, nbs.refCheck)
+	return nbs.addTableFilesToManifest(ctx, fileIdToNumChunks, getAddrs, nbs.refCheck, nil)
 }
 
 // A small helper which returns a composite refCheck function combining |base| and a |hasMany| call against each source in |css|.
@@ -1980,7 +1947,7 @@ func refCheckAllSources(ctx context.Context, getAddrs chunks.GetAddrsCurry, refC
 	return checkErr
 }
 
-func (nbs *NomsBlockStore) addTableFilesToManifest(ctx context.Context, fileIdToNumChunks map[string]int, getAddrs chunks.GetAddrsCurry, genRefCheck func([]hasRecord) (hash.HashSet, error)) error {
+func (nbs *NomsBlockStore) addTableFilesToManifest(ctx context.Context, fileIdToNumChunks map[string]int, getAddrs chunks.GetAddrsCurry, genRefCheck func([]hasRecord) (hash.HashSet, error), srcs chunkSourceSet) error {
 	fileIdHashToNumChunks := make(map[hash.Hash]uint32)
 	for fileId, numChunks := range fileIdToNumChunks {
 		fileIdHash, ok := hash.MaybeParse(fileId)
@@ -2002,7 +1969,7 @@ func (nbs *NomsBlockStore) addTableFilesToManifest(ctx context.Context, fileIdTo
 		// time so that we can ensure our view of the store is still
 		// accurate when we add these files to the store if all the sanity
 		// checks pass.
-		sources, err := nbs.openChunkSourcesForAddTableFiles(ctx, fileIdHashToNumChunks)
+		sources, err := nbs.openChunkSourcesForManifestUpdateAndRebase(ctx, fileIdHashToNumChunks, srcs)
 		if err != nil {
 			return fmt.Errorf("addTableFiles, openChunkSources: %w", err)
 		}
@@ -2054,20 +2021,20 @@ func (nbs *NomsBlockStore) addTableFilesToManifest(ctx context.Context, fileIdTo
 	}
 }
 
-type openChunkSourcesForAddTableFilesResult struct {
+type openChunkSourcesResult struct {
 	sources chunkSourceSet
 	gcGen   hash.Hash
 	root    hash.Hash
 }
 
-func (nbs *NomsBlockStore) openChunkSourcesForAddTableFiles(ctx context.Context, files map[hash.Hash]uint32) (openChunkSourcesForAddTableFilesResult, error) {
+func (nbs *NomsBlockStore) openChunkSourcesForManifestUpdateAndRebase(ctx context.Context, files map[hash.Hash]uint32, existing chunkSourceSet) (openChunkSourcesResult, error) {
 	nbs.mu.Lock()
 	defer nbs.mu.Unlock()
-	sources, err := nbs.tables.openForAdd(ctx, files, nbs.stats)
+	sources, err := nbs.tables.openForAdd(ctx, files, existing, nbs.stats)
 	if err != nil {
-		return openChunkSourcesForAddTableFilesResult{}, err
+		return openChunkSourcesResult{}, err
 	}
-	return openChunkSourcesForAddTableFilesResult{
+	return openChunkSourcesResult{
 		sources: sources,
 		gcGen:   nbs.upstream.gcGen,
 		root:    nbs.upstream.root,
@@ -2382,10 +2349,20 @@ func (i *markAndSweeper) Finalize(ctx context.Context) (chunks.GCFinalizer, erro
 	}
 	i.gcc = nil
 
+	files := make(map[hash.Hash]uint32, len(specs))
+	for _, s := range specs {
+		files[s.name] = s.chunkCount
+	}
+	result, err := i.dest.openChunkSourcesForManifestUpdateAndRebase(ctx, files, nil)
+	if err != nil {
+		return nil, err
+	}
+
 	return gcFinalizer{
 		nbs:   i.dest,
 		specs: specs,
 		mode:  i.mode,
+		srcs:  result.sources,
 	}, nil
 }
 
@@ -2400,24 +2377,42 @@ type gcFinalizer struct {
 	nbs   *NomsBlockStore
 	specs []tableSpec
 	mode  chunks.GCMode
+	srcs  chunkSourceSet
 }
 
 func (gcf gcFinalizer) AddChunksToStore(ctx context.Context) (chunks.HasManyFunc, error) {
 	fileIdToNumChunks := tableSpecsToMap(gcf.specs)
-	var addrs []hash.Hash
-	for _, spec := range gcf.specs {
-		addrs = append(addrs, spec.name)
-	}
 	f := func(ctx context.Context, hashes hash.HashSet) (hash.HashSet, error) {
-		return gcf.nbs.hasManyInSources(addrs, hashes)
+		records := toHasRecords(hashes)
+		for _, src := range gcf.srcs {
+			remaining, _, err := src.hasMany(records, nil)
+			if err != nil {
+				return nil, err
+			}
+			if !remaining {
+				break
+			}
+		}
+		absent := hash.HashSet{}
+		for _, r := range records {
+			if !r.has {
+				absent.Insert(*r.a)
+			}
+		}
+		return absent, nil
 	}
 	// Passing |nil| for getAddrs and |refCheck| means ref checking on
 	// this add is off.
-	return f, gcf.nbs.addTableFilesToManifest(ctx, fileIdToNumChunks, nil, nil)
+	return f, gcf.nbs.addTableFilesToManifest(ctx, fileIdToNumChunks, nil, nil, gcf.srcs)
 }
 
 func (gcf gcFinalizer) SwapChunksInStore(ctx context.Context) error {
-	return gcf.nbs.swapTables(ctx, gcf.specs, gcf.mode)
+	return gcf.nbs.swapTables(ctx, gcf.specs, gcf.mode, gcf.srcs)
+}
+
+func (gcf gcFinalizer) Close() error {
+	gcf.srcs.close()
+	return nil
 }
 
 func (nbs *NomsBlockStore) IterateAllChunks(ctx context.Context, cb func(chunk chunks.Chunk)) error {
@@ -2442,7 +2437,7 @@ func (nbs *NomsBlockStore) IterateAllChunks(ctx context.Context, cb func(chunk c
 	return nil
 }
 
-func (nbs *NomsBlockStore) swapTables(ctx context.Context, specs []tableSpec, mode chunks.GCMode) (err error) {
+func (nbs *NomsBlockStore) swapTables(ctx context.Context, specs []tableSpec, mode chunks.GCMode, srcs chunkSourceSet) (err error) {
 	nbs.mu.Lock()
 	defer nbs.mu.Unlock()
 
@@ -2453,6 +2448,19 @@ func (nbs *NomsBlockStore) swapTables(ctx context.Context, specs []tableSpec, mo
 			err = unlockErr
 		}
 	}()
+
+	// Pre-open chunk sources for the new specs before updating the
+	// manifest. This validates that the table files are on disk and
+	// readable, and provides sources for rebase to clone from.
+	files := make(map[hash.Hash]uint32, len(specs))
+	for _, s := range specs {
+		files[s.name] = s.chunkCount
+	}
+	opened, err := nbs.tables.openForAdd(ctx, files, srcs, nbs.stats)
+	if err != nil {
+		return fmt.Errorf("swapTables, openForAdd: %w", err)
+	}
+	defer opened.close()
 
 	newLock := generateLockHash(nbs.upstream.root, specs, []tableSpec{}, nil)
 	var extra []byte
@@ -2485,7 +2493,7 @@ func (nbs *NomsBlockStore) swapTables(ctx context.Context, specs []tableSpec, mo
 	nbs.hasCache.Purge()
 
 	// replace nbs.tables.upstream with gc compacted tables
-	ts, err := nbs.tables.rebase(ctx, upstream.specs, nil, nbs.stats)
+	ts, err := nbs.tables.rebase(ctx, upstream.specs, opened, nbs.stats)
 	if err != nil {
 		return fmt.Errorf("swapTables, rebase: %w", err)
 	}

--- a/go/store/nbs/table_set.go
+++ b/go/store/nbs/table_set.go
@@ -125,50 +125,6 @@ func (ts *tableSet) hasMany(addrs []hasRecord, keeper keeperF) (bool, gcBehavior
 	return f(ts.upstream)
 }
 
-// Updates the records in |addrs| for whether they exist in this table set, but
-// only consults tables whose names appear in |srcs|, ignoring all other tables
-// in the table set. Returns |remaining| as true if all addresses were not
-// found in the consulted tables, and false otherwise.
-//
-// Intended to be exactly like |hasMany|, except filtering for the files
-// consulted. Only used for part of the GC workflow where we want to have
-// access to all chunks in the store but need to check for existing chunk
-// presence in only a subset of its files.
-func (ts *tableSet) hasManyInSources(srcs []hash.Hash, addrs []hasRecord, keeper keeperF) (bool, gcBehavior, error) {
-	var remaining bool
-	var err error
-	var gcb gcBehavior
-	for _, rec := range addrs {
-		if !rec.has {
-			remaining = true
-			break
-		}
-	}
-	if !remaining {
-		return false, gcBehavior_Continue, nil
-	}
-	for _, srcAddr := range srcs {
-		src, ok := ts.novel[srcAddr]
-		if !ok {
-			src, ok = ts.upstream[srcAddr]
-			if !ok {
-				continue
-			}
-		}
-		remaining, gcb, err = src.hasMany(addrs, keeper)
-		if err != nil {
-			return false, gcb, err
-		}
-		if gcb != gcBehavior_Continue {
-			return false, gcb, nil
-		}
-		if !remaining {
-			break
-		}
-	}
-	return remaining, gcBehavior_Continue, nil
-}
-
 func (ts *tableSet) get(ctx context.Context, h hash.Hash, keeper keeperF, stats *Stats) ([]byte, gcBehavior, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, gcBehavior_Continue, err
@@ -450,7 +406,7 @@ func (ts *tableSet) flatten(ctx context.Context) (*tableSet, error) {
 // For any files which appear in |novel| or |upstream|, this function
 // will return clones of the chunk sources, instead of opening them
 // anew.
-func (ts *tableSet) openForAdd(ctx context.Context, files map[hash.Hash]uint32, stats *Stats) (chunkSourceSet, error) {
+func (ts *tableSet) openForAdd(ctx context.Context, files map[hash.Hash]uint32, existing chunkSourceSet, stats *Stats) (chunkSourceSet, error) {
 	ret := make(chunkSourceSet)
 	cleanup := func() {
 		for _, source := range ret {
@@ -458,7 +414,7 @@ func (ts *tableSet) openForAdd(ctx context.Context, files map[hash.Hash]uint32, 
 		}
 	}
 	// First add clones of all sources that are already present in
-	// ts.novel or ts.upstream.
+	// ts.novel, ts.upstream, or the pre-opened |existing| set.
 	for h := range files {
 		if s, ok := ts.novel[h]; ok {
 			cloned, err := s.clone()
@@ -468,6 +424,13 @@ func (ts *tableSet) openForAdd(ctx context.Context, files map[hash.Hash]uint32, 
 			}
 			ret[h] = cloned
 		} else if s, ok := ts.upstream[h]; ok {
+			cloned, err := s.clone()
+			if err != nil {
+				cleanup()
+				return nil, err
+			}
+			ret[h] = cloned
+		} else if s, ok := existing[h]; ok {
 			cloned, err := s.clone()
 			if err != nil {
 				cleanup()

--- a/go/store/types/value_store.go
+++ b/go/store/types/value_store.go
@@ -626,6 +626,7 @@ func (lvs *ValueStore) GC(ctx context.Context, mode GCMode, cmp chunks.GCArchive
 
 				return err
 			}
+			defer oldGenFinalizer.Close()
 
 			var newFileHasMany chunks.HasManyFunc
 			newFileHasMany, err = oldGenFinalizer.AddChunksToStore(ctx)
@@ -643,6 +644,7 @@ func (lvs *ValueStore) GC(ctx context.Context, mode GCMode, cmp chunks.GCArchive
 			if err != nil {
 				return err
 			}
+			defer newGenFinalizer.Close()
 			callCancelSafepoint = false
 
 			err = newGenFinalizer.SwapChunksInStore(ctx)
@@ -703,6 +705,7 @@ func (lvs *ValueStore) GC(ctx context.Context, mode GCMode, cmp chunks.GCArchive
 			if err != nil {
 				return err
 			}
+			defer finalizer.Close()
 			callCancelSafepoint = false
 
 			err = finalizer.SwapChunksInStore(ctx)


### PR DESCRIPTION
This can be used to avoid opening the files in the `rebase` within swapTables and addTableFiles.

It can also be used to directly implement the correct HasManyFunc result of AddChunksToStore. This is more robust than requiring the table file stay in the destination chunk store exactly as is, for example.

Combined with #10788 opening this file immediately and keeping it open until the rebase makes concurrent destructive operations like PruneTableFiles safer.