### PR TITLE
Support bare format with ssh transport

### DIFF
--- a/go/cmd/dolt/commands/transfer.go
+++ b/go/cmd/dolt/commands/transfer.go
@@ -16,6 +16,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -23,6 +24,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -40,7 +42,10 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/remotesrv"
 	"github.com/dolthub/dolt/go/libraries/utils/argparser"
+	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/store/datas"
+	"github.com/dolthub/dolt/go/store/nbs"
+	"github.com/dolthub/dolt/go/store/types"
 )
 
 // TransferCmd serves repository data over stdin/stdout for SSH remote operations.
@@ -106,10 +111,73 @@ func (cmd TransferCmd) Exec(ctx context.Context, commandStr string, args []strin
 	// Ignore SIGPIPE to prevent broken pipe crashes during SSH disconnect.
 	signal.Ignore(syscall.SIGPIPE)
 
+	// Resolve the chunk store and the filesystem root for HTTP file serving.
+	//
+	// There are two supported on-disk formats:
+	//
+	// 1. Normal dolt repository (.dolt/noms/ with a GenerationalNBS): dEnv.DoltDB loads successfully.
+	//    The FS is rooted at the repo directory; cs.Path() returns .dolt/noms/ inside it.
+	//    The gRPC handler computes prefix = ".dolt/noms", so HTTP paths are ".dolt/noms/<hash>".
+	//
+	// 2. Bare repository: the --data-dir path is an NBS directory without .dolt/noms/ structure.
+	//    This is the format produced by `dolt backup sync`
+	//
+	//    For bare repos the FS root must be the *parent* of the bare directory, not the directory
+	//    itself. The gRPC handler computes prefix = filepath.Rel(fsRoot, cs.Path()). If the FS root
+	//    equals cs.Path(), the prefix is "." and HTTP file paths lack a "/" component, which causes
+	//    the file handler to return HTTP 400. Using the parent gives prefix = "<dirName>", so paths
+	//    are "<dirName>/<hash>" which the file handler resolves correctly.
+	var cs remotesrv.RemoteSrvStore
+	serverFS := dEnv.FS // used as the filesystem root for HTTP serving
 	ddb := dEnv.DoltDB(ctx)
-
-	// Database should already be loaded by the caller. Being very safe since there are some late binding checks.
-	if ddb == nil || dEnv.DBLoadError != nil {
+	if ddb != nil && dEnv.DBLoadError == nil {
+		// Normal dolt repository.
+		db := doltdb.ExposeDatabaseFromDoltDB(ddb)
+		rawCS := datas.ChunkStoreFromDatabase(db)
+		rss, ok := rawCS.(remotesrv.RemoteSrvStore)
+		if !ok {
+			return HandleVErrAndExitCode(errhand.BuildDError("chunk store does not implement RemoteSrvStore").Build(), usage)
+		}
+		cs = rss
+	} else if errors.Is(dEnv.DBLoadError, doltdb.ErrMissingDoltDataDir) {
+		// Bare repository: the path is an NBS directory without the normal .dolt/noms/ structure.
+		// This is the format produced by dolt backup sync and by the standalone remotesrv binary.
+		// Two sub-cases:
+		//   - Backup format: GenerationalNBS at root (has newgen NBS files + oldgen/ subdirectory).
+		//   - Flat NBS: no oldgen/ subdirectory (standalone remotesrv style).
+		absPath, err := dEnv.FS.Abs(".")
+		if err != nil {
+			return HandleVErrAndExitCode(errhand.BuildDError("failed to resolve bare repository path").AddCause(err).Build(), usage)
+		}
+		q := nbs.NewUnlimitedMemQuotaProvider()
+		newGenSt, err := nbs.NewLocalStore(ctx, types.Format_Default.VersionString(), absPath, 128*1024*1024, q, false)
+		if err != nil {
+			return HandleVErrAndExitCode(errhand.BuildDError("failed to open bare repository at %s", absPath).AddCause(err).Build(), usage)
+		}
+		oldgenPath := filepath.Join(absPath, "oldgen")
+		if info, serr := os.Stat(oldgenPath); serr == nil && info.IsDir() {
+			// Backup format: open as GenerationalNBS so oldgen chunks are accessible.
+			oldGenSt, serr := nbs.NewLocalStore(ctx, newGenSt.Version(), oldgenPath, 128*1024*1024, q, false)
+			if serr != nil {
+				return HandleVErrAndExitCode(errhand.BuildDError("failed to open oldgen at %s", oldgenPath).AddCause(serr).Build(), usage)
+			}
+			ghostGen, serr := nbs.NewGhostBlockStore(absPath)
+			if serr != nil {
+				return HandleVErrAndExitCode(errhand.BuildDError("failed to open ghost store at %s", absPath).AddCause(serr).Build(), usage)
+			}
+			cs = nbs.NewGenerationalCS(oldGenSt, newGenSt, ghostGen)
+		} else {
+			// Flat NBS format (standalone remotesrv style): no oldgen.
+			cs = newGenSt
+		}
+		// Root the HTTP filesystem at the parent so that cs.Path() is a named
+		// subdirectory of the FS root, giving HTTP paths like "<dirName>/<hash>".
+		parentPath := filepath.Dir(absPath)
+		serverFS, err = filesys.LocalFilesysWithWorkingDir(parentPath)
+		if err != nil {
+			return HandleVErrAndExitCode(errhand.BuildDError("failed to set up file server root at %s", parentPath).AddCause(err).Build(), usage)
+		}
+	} else {
 		if dEnv.DBLoadError != nil {
 			return HandleVErrAndExitCode(errhand.BuildDError("failed to load database").AddCause(dEnv.DBLoadError).Build(), usage)
 		}
@@ -128,15 +196,7 @@ func (cmd TransferCmd) Exec(ctx context.Context, commandStr string, args []strin
 	}
 	defer session.Close()
 
-	// Set up gRPC chunk store service backed by this database.
-	db := doltdb.ExposeDatabaseFromDoltDB(ddb)
-	cs := datas.ChunkStoreFromDatabase(db)
-
-	// GenerationalChunkStore implements RemoteSrvStore, so this is going to work for any "normal" Dolt db.
-	if _, ok := cs.(remotesrv.RemoteSrvStore); !ok {
-		return HandleVErrAndExitCode(errhand.BuildDError("chunk store does not implement RemoteSrvStore").Build(), usage)
-	}
-	dbCache := &singletonDBCache{cs: cs.(remotesrv.RemoteSrvStore)}
+	dbCache := &singletonDBCache{cs: cs}
 
 	logger := logrus.New()
 	logger.SetOutput(os.Stderr)
@@ -147,7 +207,7 @@ func (cmd TransferCmd) Exec(ctx context.Context, commandStr string, args []strin
 		logEntry,
 		transferHost,
 		dbCache,
-		dEnv.FS,
+		serverFS,
 		"http",
 		remotesapi.PushConcurrencyControl_PUSH_CONCURRENCY_CONTROL_UNSPECIFIED,
 		sealer,
@@ -161,7 +221,7 @@ func (cmd TransferCmd) Exec(ctx context.Context, commandStr string, args []strin
 	remotesapi.RegisterChunkStoreServiceServer(grpcServer, chunkStoreService)
 
 	// Http handler for storage file transfers -- reuse remotesrv's filehandler.
-	fileServer := remotesrv.NewFileHandler(logEntry, dbCache, dEnv.FS, false, sealer, true)
+	fileServer := remotesrv.NewFileHandler(logEntry, dbCache, serverFS, false, sealer, true)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc") {

--- a/go/cmd/dolt/commands/transfer.go
+++ b/go/cmd/dolt/commands/transfer.go
@@ -111,77 +111,9 @@ func (cmd TransferCmd) Exec(ctx context.Context, commandStr string, args []strin
 	// Ignore SIGPIPE to prevent broken pipe crashes during SSH disconnect.
 	signal.Ignore(syscall.SIGPIPE)
 
-	// Resolve the chunk store and the filesystem root for HTTP file serving.
-	//
-	// There are two supported on-disk formats:
-	//
-	// 1. Normal dolt repository (.dolt/noms/ with a GenerationalNBS): dEnv.DoltDB loads successfully.
-	//    The FS is rooted at the repo directory; cs.Path() returns .dolt/noms/ inside it.
-	//    The gRPC handler computes prefix = ".dolt/noms", so HTTP paths are ".dolt/noms/<hash>".
-	//
-	// 2. Bare repository: the --data-dir path is an NBS directory without .dolt/noms/ structure.
-	//    This is the format produced by `dolt backup sync`
-	//
-	//    For bare repos the FS root must be the *parent* of the bare directory, not the directory
-	//    itself. The gRPC handler computes prefix = filepath.Rel(fsRoot, cs.Path()). If the FS root
-	//    equals cs.Path(), the prefix is "." and HTTP file paths lack a "/" component, which causes
-	//    the file handler to return HTTP 400. Using the parent gives prefix = "<dirName>", so paths
-	//    are "<dirName>/<hash>" which the file handler resolves correctly.
-	var cs remotesrv.RemoteSrvStore
-	serverFS := dEnv.FS // used as the filesystem root for HTTP serving
-	ddb := dEnv.DoltDB(ctx)
-	if ddb != nil && dEnv.DBLoadError == nil {
-		// Normal dolt repository.
-		db := doltdb.ExposeDatabaseFromDoltDB(ddb)
-		rawCS := datas.ChunkStoreFromDatabase(db)
-		rss, ok := rawCS.(remotesrv.RemoteSrvStore)
-		if !ok {
-			return HandleVErrAndExitCode(errhand.BuildDError("chunk store does not implement RemoteSrvStore").Build(), usage)
-		}
-		cs = rss
-	} else if errors.Is(dEnv.DBLoadError, doltdb.ErrMissingDoltDataDir) {
-		// Bare repository: the path is an NBS directory without the normal .dolt/noms/ structure.
-		// This is the format produced by dolt backup sync and by the standalone remotesrv binary.
-		// Two sub-cases:
-		//   - Backup format: GenerationalNBS at root (has newgen NBS files + oldgen/ subdirectory).
-		//   - Flat NBS: no oldgen/ subdirectory (standalone remotesrv style).
-		absPath, err := dEnv.FS.Abs(".")
-		if err != nil {
-			return HandleVErrAndExitCode(errhand.BuildDError("failed to resolve bare repository path").AddCause(err).Build(), usage)
-		}
-		q := nbs.NewUnlimitedMemQuotaProvider()
-		newGenSt, err := nbs.NewLocalStore(ctx, types.Format_Default.VersionString(), absPath, 128*1024*1024, q, false)
-		if err != nil {
-			return HandleVErrAndExitCode(errhand.BuildDError("failed to open bare repository at %s", absPath).AddCause(err).Build(), usage)
-		}
-		oldgenPath := filepath.Join(absPath, "oldgen")
-		if info, serr := os.Stat(oldgenPath); serr == nil && info.IsDir() {
-			// Backup format: open as GenerationalNBS so oldgen chunks are accessible.
-			oldGenSt, serr := nbs.NewLocalStore(ctx, newGenSt.Version(), oldgenPath, 128*1024*1024, q, false)
-			if serr != nil {
-				return HandleVErrAndExitCode(errhand.BuildDError("failed to open oldgen at %s", oldgenPath).AddCause(serr).Build(), usage)
-			}
-			ghostGen, serr := nbs.NewGhostBlockStore(absPath)
-			if serr != nil {
-				return HandleVErrAndExitCode(errhand.BuildDError("failed to open ghost store at %s", absPath).AddCause(serr).Build(), usage)
-			}
-			cs = nbs.NewGenerationalCS(oldGenSt, newGenSt, ghostGen)
-		} else {
-			// Flat NBS format (standalone remotesrv style): no oldgen.
-			cs = newGenSt
-		}
-		// Root the HTTP filesystem at the parent so that cs.Path() is a named
-		// subdirectory of the FS root, giving HTTP paths like "<dirName>/<hash>".
-		parentPath := filepath.Dir(absPath)
-		serverFS, err = filesys.LocalFilesysWithWorkingDir(parentPath)
-		if err != nil {
-			return HandleVErrAndExitCode(errhand.BuildDError("failed to set up file server root at %s", parentPath).AddCause(err).Build(), usage)
-		}
-	} else {
-		if dEnv.DBLoadError != nil {
-			return HandleVErrAndExitCode(errhand.BuildDError("failed to load database").AddCause(dEnv.DBLoadError).Build(), usage)
-		}
-		return HandleVErrAndExitCode(errhand.BuildDError("failed to load database").Build(), usage)
+	cs, serverFS, err := resolveDatabaseChunkStore(ctx, dEnv)
+	if err != nil {
+		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
 	// Create SMUX session (server mode) over stdin/stdout.
@@ -254,6 +186,63 @@ func (cmd TransferCmd) Exec(ctx context.Context, commandStr string, args []strin
 	case <-ctx.Done():
 		return 0
 	}
+}
+
+// resolveDatabaseChunkStore inspects the environment loaded from --data-dir and
+// returns the RemoteSrvStore to serve and the filesystem root to use for HTTP
+// file serving.
+//
+// Two on-disk formats are supported:
+//
+//  1. Normal dolt repository (.dolt/noms/ present): dEnv.DoltDB loads successfully.
+//     The FS is already rooted at the repo directory and cs.Path() resolves to
+//     .dolt/noms/ inside it, giving HTTP paths like ".dolt/noms/<hash>".
+//
+//  2. Bare repository (no .dolt/noms/): the --data-dir path is a flat NBS directory
+//     (a NomsBlockStore). This is the format produced by pushing to an empty directory
+//     or by the standalone remotesrv binary.
+//
+//     For bare repos the HTTP filesystem root is set to the *parent* of the bare
+//     directory so that cs.Path() is a named subdirectory of the root. The gRPC
+//     handler computes prefix = filepath.Rel(fsRoot, cs.Path()); with the parent
+//     as root this yields "<dirName>", so HTTP paths are "<dirName>/<hash>". If
+//     the root equalled cs.Path() the prefix would be "." and the file handler
+//     would return HTTP 400 because it requires at least one "/" in the path.
+func resolveDatabaseChunkStore(ctx context.Context, dEnv *env.DoltEnv) (remotesrv.RemoteSrvStore, filesys.Filesys, error) {
+	ddb := dEnv.DoltDB(ctx)
+	if ddb != nil && dEnv.DBLoadError == nil {
+		// Normal dolt repository.
+		db := doltdb.ExposeDatabaseFromDoltDB(ddb)
+		rawCS := datas.ChunkStoreFromDatabase(db)
+		rss, ok := rawCS.(remotesrv.RemoteSrvStore)
+		if !ok {
+			return nil, nil, fmt.Errorf("chunk store does not implement RemoteSrvStore")
+		}
+		return rss, dEnv.FS, nil
+	}
+
+	if !errors.Is(dEnv.DBLoadError, doltdb.ErrMissingDoltDataDir) {
+		return nil, nil, fmt.Errorf("failed to load database: %w", dEnv.DBLoadError)
+	}
+
+	// Bare repository: a flat NBS directory with no .dolt/ structure.
+	absPath, err := dEnv.FS.Abs(".")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to resolve bare repository path: %w", err)
+	}
+	q := nbs.NewUnlimitedMemQuotaProvider()
+	cs, err := nbs.NewLocalStore(ctx, types.Format_Default.VersionString(), absPath, remotesrv.MaxGRPCMessageSize, q, false)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to open bare repository at %s: %w", absPath, err)
+	}
+
+	// Root the HTTP filesystem at the parent so cs.Path() is a named subdirectory.
+	parentPath := filepath.Dir(absPath)
+	serverFS, err := filesys.LocalFilesysWithWorkingDir(parentPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to set up file server root at %s: %w", parentPath, err)
+	}
+	return cs, serverFS, nil
 }
 
 // transferHost is the virtual hostname used for HTTP requests routed through

--- a/integration-tests/bats/ssh-transfer.bats
+++ b/integration-tests/bats/ssh-transfer.bats
@@ -555,3 +555,98 @@ MOCK
     [ "$status" -ne 0 ]
     [[ "$output" =~ "database is read only" ]] || false
 }
+@test "ssh-transfer: clone from bare backup repository" {
+    mkdir "repo_bare_src"
+    cd "repo_bare_src"
+    dolt init
+    dolt sql -q "CREATE TABLE items (id INT PRIMARY KEY, name TEXT);"
+    dolt sql -q "INSERT INTO items VALUES (1, 'alpha'), (2, 'beta');"
+    dolt add .
+    dolt commit -m "initial bare test"
+
+    dolt backup add bac1 "file://$BATS_TEST_TMPDIR/bare_backup"
+    dolt backup sync bac1
+
+    cd "$BATS_TEST_TMPDIR"
+    run dolt clone "ssh://localhost$BATS_TEST_TMPDIR/bare_backup" bare_clone
+    [ "$status" -eq 0 ]
+
+    cd "bare_clone"
+    run dolt sql -r csv -q "SELECT COUNT(*) FROM items;"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "2" ]] || false
+
+    run dolt sql -r csv -q "SELECT name FROM items ORDER BY id;"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "alpha" ]] || false
+    [[ "$output" =~ "beta" ]] || false
+}
+
+@test "ssh-transfer: pull from bare backup repository" {
+    mkdir "repo_bare_pull_src"
+    cd "repo_bare_pull_src"
+    dolt init
+    dolt sql -q "CREATE TABLE t (id INT PRIMARY KEY, v TEXT);"
+    dolt sql -q "INSERT INTO t VALUES (1, 'first');"
+    dolt add .
+    dolt commit -m "initial"
+
+    dolt backup add bac1 "file://$BATS_TEST_TMPDIR/bare_pull_backup"
+    dolt backup sync bac1
+
+    cd "$BATS_TEST_TMPDIR"
+
+    dolt clone "ssh://localhost$BATS_TEST_TMPDIR/bare_pull_backup" bare_pull_clone
+
+    # Add more data to source and re-sync to the backup.
+    cd "repo_bare_pull_src"
+    dolt sql -q "INSERT INTO t VALUES (2, 'second');"
+    dolt add .
+    dolt commit -m "add second row"
+    dolt backup sync bac1
+
+    cd "$BATS_TEST_TMPDIR/bare_pull_clone"
+    run dolt pull origin
+    [ "$status" -eq 0 ]
+
+    run dolt sql -r csv -q "SELECT COUNT(*) FROM t;"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "2" ]] || false
+}
+
+@test "ssh-transfer: push to bare backup repository" {
+    mkdir "repo_bare_push_src"
+    cd "repo_bare_push_src"
+    dolt init
+    dolt sql -q "CREATE TABLE widgets (id INT PRIMARY KEY, color TEXT);"
+    dolt sql -q "INSERT INTO widgets VALUES (1, 'red');"
+    dolt add .
+    dolt commit -m "initial"
+
+    dolt backup add bac1 "file://$BATS_TEST_TMPDIR/bare_push_backup"
+    dolt backup sync bac1
+
+    cd "$BATS_TEST_TMPDIR"
+
+    dolt clone "ssh://localhost$BATS_TEST_TMPDIR/bare_push_backup" bare_push_clone
+    cd "bare_push_clone"
+    dolt sql -q "INSERT INTO widgets VALUES (2, 'blue');"
+    dolt add .
+    dolt commit -m "add blue widget"
+
+    PUSHED_COMMIT=$(dolt log --oneline -n 1 | awk '{print $1}')
+    run dolt push origin main
+    [ "$status" -eq 0 ]
+
+    cd "$BATS_TEST_TMPDIR"
+    dolt clone "ssh://localhost$BATS_TEST_TMPDIR/bare_push_backup" bare_push_verify
+    cd "bare_push_verify"
+
+    run dolt sql -r csv -q "SELECT COUNT(*) FROM widgets;"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "2" ]] || false
+
+    run dolt log --oneline -n 1
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "$PUSHED_COMMIT" ]] || false
+}

--- a/integration-tests/bats/ssh-transfer.bats
+++ b/integration-tests/bats/ssh-transfer.bats
@@ -650,3 +650,34 @@ MOCK
     [ "$status" -eq 0 ]
     [[ "$output" =~ "$PUSHED_COMMIT" ]] || false
 }
+
+@test "ssh-transfer: push to empty directory creates bare repository" {
+    mkdir "repo_push_to_empty_src"
+    cd "repo_push_to_empty_src"
+    dolt init
+    dolt sql -q "CREATE TABLE t (id INT PRIMARY KEY, v TEXT);"
+    dolt sql -q "INSERT INTO t VALUES (1, 'hello');"
+    dolt add .
+    dolt commit -m "initial"
+
+    # Create an empty target directory and push to it via SSH.
+    mkdir "$BATS_TEST_TMPDIR/empty_bare_target"
+    dolt remote add bare "ssh://localhost$BATS_TEST_TMPDIR/empty_bare_target"
+    run dolt push bare main
+    [ "$status" -eq 0 ]
+
+    # The target should now be a bare repository: NBS files directly in the
+    # directory with no .dolt/ subdirectory.
+    [ -f "$BATS_TEST_TMPDIR/empty_bare_target/manifest" ] || false
+    [ ! -d "$BATS_TEST_TMPDIR/empty_bare_target/.dolt" ] || false
+
+    # Clone from the bare target to verify the data is intact.
+    cd "$BATS_TEST_TMPDIR"
+    run dolt clone "ssh://localhost$BATS_TEST_TMPDIR/empty_bare_target" bare_from_push
+    [ "$status" -eq 0 ]
+
+    cd "bare_from_push"
+    run dolt sql -r csv -q "SELECT v FROM t WHERE id=1;"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "hello" ]] || false
+}

--- a/integration-tests/bats/ssh-transfer.bats
+++ b/integration-tests/bats/ssh-transfer.bats
@@ -680,4 +680,14 @@ MOCK
     run dolt sql -r csv -q "SELECT v FROM t WHERE id=1;"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "hello" ]] || false
+
+    # Restore from the bare repository using dolt backup restore.
+    cd "$BATS_TEST_TMPDIR"
+    run dolt backup restore "file://$BATS_TEST_TMPDIR/empty_bare_target" bare_restored
+    [ "$status" -eq 0 ]
+
+    cd "bare_restored"
+    run dolt sql -r csv -q "SELECT v FROM t WHERE id=1;"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "hello" ]] || false
 }


### PR DESCRIPTION
Altered the `dolt transfer` command to determine if we are pushing to a bare repository or a full fledge generational repository. Also added the ability to push to an empty directory - which results in a bare repository.