### PR TITLE
[no-release-notes] go: sqle: statspro,database_provider: Simplify and improve (*DoltDB).Close behavior.

### DIFF
--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -1001,8 +1001,10 @@ func (p *DoltDatabaseProvider) DropDatabase(ctx *sql.Context, name string) error
 	}
 
 	var db dsess.SqlDatabase
+	var derivativeDbs []dsess.SqlDatabase
 	var dbLoc filesys.Filesys
 	var dbKey, dropDbLoc string
+	var closeDoltDBs bool
 	err := func() error {
 		p.mu.Lock()
 		defer p.mu.Unlock()
@@ -1032,11 +1034,17 @@ func (p *DoltDatabaseProvider) DropDatabase(ctx *sql.Context, name string) error
 		derivativeNamePrefix := strings.ToLower(dbKey + doltdb.DbRevisionDelimiter)
 		for dbName := range p.databases {
 			if strings.HasPrefix(strings.ToLower(dbName), derivativeNamePrefix) {
+				derivativeDbs = append(derivativeDbs, p.databases[dbName])
 				delete(p.databases, dbName)
 			}
 		}
 		delete(p.databases, dbKey)
 		p.deletingDatabases[dbKey] = struct{}{}
+
+		closeDoltDBs = p.dbLoadParams != nil
+		if closeDoltDBs {
+			_, closeDoltDBs = p.dbLoadParams[dbfactory.DisableSingletonCacheParam]
+		}
 		return nil
 	}()
 	if err != nil {
@@ -1068,16 +1076,26 @@ func (p *DoltDatabaseProvider) DropDatabase(ctx *sql.Context, name string) error
 		dropHook(ctx, name)
 	}
 
+	// Close the database and any derivative databases.
+	db.Close()
+	for _, ddb := range derivativeDbs {
+		ddb.Close()
+	}
+
+	// In embedded / nocache mode, the underlying DoltDBs are not tracked by the singleton cache, so
+	// the provider is responsible for closing them to release filesystem locks.
+	if closeDoltDBs {
+		for _, ddb := range db.DoltDatabases() {
+			if ddb != nil {
+				_ = ddb.Close()
+			}
+		}
+	}
+
 	// If this database is re-created, we don't want to return any cached results.
 	err = dbfactory.DeleteFromSingletonCache(filepath.ToSlash(dropDbLoc+"/.dolt/noms"), true)
 	if err != nil {
 		retErr = errors.Join(retErr, err)
-	}
-	err = dbfactory.DeleteFromSingletonCache(filepath.ToSlash(dropDbLoc+"/.dolt/stats/.dolt/noms"), true)
-	if err != nil {
-		// Swallow the error closing `stats` database.
-		// TODO: Log this.
-		err = nil
 	}
 
 	err = p.droppedDatabaseManager.DropDatabase(ctx, name, dropDbLoc)

--- a/go/libraries/doltcore/sqle/statspro/controller.go
+++ b/go/libraries/doltcore/sqle/statspro/controller.go
@@ -39,7 +39,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dprocedures"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
-	"github.com/dolthub/dolt/go/libraries/doltcore/table/editor"
 	"github.com/dolthub/dolt/go/libraries/utils/earl"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/store/datas"
@@ -505,10 +504,17 @@ func (sc *StatsController) rotateStorage(ctx context.Context) error {
 	return sc.lockedRotateStorage(sqlCtx)
 }
 
+// lockedRotateStorage closes the current prolly stats DoltDB, removes its on-disk
+// stats directory, and picks a new database from dbFs to host the stats backing
+// store. The stats controller owns the lifecycle of these DoltDB instances (they
+// always bypass the singleton cache), so it is safe to close and rm unconditionally.
 func (sc *StatsController) lockedRotateStorage(ctx context.Context) error {
 	if sc.memOnly {
 		return nil
 	}
+
+	sc.kv.Close()
+
 	if sc.statsBackingDb != nil {
 		if err := sc.rm(sc.statsBackingDb); err != nil {
 			return err
@@ -561,15 +567,6 @@ func (sc *StatsController) rm(fs filesys.Filesys) error {
 		return err
 	}
 
-	dropDbLoc, err := statsFs.Abs("")
-	if err != nil {
-		return err
-	}
-
-	if err = dbfactory.DeleteFromSingletonCache(filepath.ToSlash(dropDbLoc+"/.dolt/noms"), true); err != nil {
-		// Swallow this error for now. This only comes from closing the database, and closing is not always successful.
-	}
-
 	if ok, _ := statsFs.Exists(""); ok {
 		if err := statsFs.Delete("", true); err != nil {
 			return err
@@ -599,6 +596,16 @@ func (sc *StatsController) initStorage(ctx context.Context, fs filesys.Filesys) 
 		return nil, err
 	}
 
+	// Build DB load params for the stats DoltDB. Always bypass the singleton cache:
+	// the stats controller owns the lifecycle of its DoltDB instances directly.
+	var dbLoadParams map[string]interface{}
+	if sc.hdpEnv != nil && len(sc.hdpEnv.DBLoadParams) > 0 {
+		dbLoadParams = maps.Clone(sc.hdpEnv.DBLoadParams)
+	} else {
+		dbLoadParams = make(map[string]interface{})
+	}
+	dbLoadParams[dbfactory.DisableSingletonCacheParam] = struct{}{}
+
 	var dEnv *env.DoltEnv
 	exists, isDir := statsFs.Exists("")
 	if !exists {
@@ -609,9 +616,7 @@ func (sc *StatsController) initStorage(ctx context.Context, fs filesys.Filesys) 
 
 		// Use LoadWithoutDB so DB load params can be applied before any DB is opened.
 		dEnv = env.LoadWithoutDB(ctx, sc.hdpEnv.GetUserHomeDir, statsFs, urlPath, doltversion.Version)
-		if sc.hdpEnv != nil && len(sc.hdpEnv.DBLoadParams) > 0 {
-			dEnv.DBLoadParams = maps.Clone(sc.hdpEnv.DBLoadParams)
-		}
+		dEnv.DBLoadParams = dbLoadParams
 		err = dEnv.InitRepo(ctx, types.Format_Default, "stats", "stats@stats.com", env.DefaultInitBranch)
 		if err != nil {
 			return nil, err
@@ -620,33 +625,28 @@ func (sc *StatsController) initStorage(ctx context.Context, fs filesys.Filesys) 
 		return nil, fmt.Errorf("file exists where the dolt stats directory should be")
 	} else {
 		dEnv = env.LoadWithoutDB(ctx, sc.hdpEnv.GetUserHomeDir, statsFs, "", doltversion.Version)
-		if sc.hdpEnv != nil && len(sc.hdpEnv.DBLoadParams) > 0 {
-			dEnv.DBLoadParams = maps.Clone(sc.hdpEnv.DBLoadParams)
-		}
+		dEnv.DBLoadParams = dbLoadParams
 	}
 
 	if err := dEnv.LoadDoltDBWithParams(ctx, types.Format_Default, urlPath, statsFs, params); err != nil {
 		return nil, err
 	}
 
-	statsDb, err := sqle.NewDatabase(ctx, "stats", dEnv.DbData(ctx), editor.Options{})
-	if err != nil {
-		return nil, err
-	}
-	m, err := dEnv.DbData(ctx).Ddb.GetStatistics(ctx)
+	statsDdb := dEnv.DbData(ctx).Ddb
+	m, err := statsDdb.GetStatistics(ctx)
 	if err == nil {
 		// use preexisting map
 		kd, vd := m.Descriptors()
 		return &prollyStats{
-			mu:     sync.Mutex{},
-			destDb: statsDb,
-			kb:     val.NewTupleBuilder(kd, m.NodeStore()),
-			vb:     val.NewTupleBuilder(vd, m.NodeStore()),
-			m:      m.Mutate(),
-			mem:    NewMemStats(),
+			mu:  sync.Mutex{},
+			ddb: statsDdb,
+			kb:  val.NewTupleBuilder(kd, m.NodeStore()),
+			vb:  val.NewTupleBuilder(vd, m.NodeStore()),
+			m:   m.Mutate(),
+			mem: NewMemStats(),
 		}, nil
 	}
-	return NewProllyStats(ctx, statsDb)
+	return NewProllyStats(ctx, statsDdb)
 }
 
 // A hook to go on all DoltDBs stats watches. It just triggers

--- a/go/libraries/doltcore/sqle/statspro/listener.go
+++ b/go/libraries/doltcore/sqle/statspro/listener.go
@@ -282,14 +282,7 @@ func (sc *StatsController) Close() {
 		}
 	}
 
-	// If we're using a prolly-backed stats store, it owns a DoltDB with its own filesystem locks.
-	// Close it best-effort on shutdown so embedded callers can reopen without contention.
-	if ps, ok := kv.(*prollyStats); ok && ps != nil && ps.destDb != nil {
-		for _, ddb := range ps.destDb.DoltDatabases() {
-			if ddb != nil {
-				_ = ddb.Close()
-			}
-		}
-	}
-	return
+	// Close the KV's underlying DoltDB (if any) so embedded callers can reopen
+	// without contention on filesystem locks.
+	kv.Close()
 }

--- a/go/libraries/doltcore/sqle/statspro/stats_kv.go
+++ b/go/libraries/doltcore/sqle/statspro/stats_kv.go
@@ -27,8 +27,8 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/stats"
 	"github.com/dolthub/go-mysql-server/sql/types"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/prolly"
 	"github.com/dolthub/dolt/go/store/prolly/tree"
@@ -47,6 +47,7 @@ type StatsKv interface {
 	GetBound(h hash.Hash, len int) (sql.Row, bool)
 	PutBound(h hash.Hash, r sql.Row, l int)
 	Flush(ctx context.Context) (int, error)
+	Close()
 	Len() int
 	GcGen() uint64
 }
@@ -143,6 +144,8 @@ func (m *memStats) GcMark(from StatsKv, nodes []*tree.Node, buckets []*stats.Buc
 	return true
 }
 
+func (m *memStats) Close() {}
+
 func (m *memStats) GcGen() uint64 {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -183,11 +186,11 @@ func (m *memStats) Flush(context.Context) (int, error) {
 	return 0, nil
 }
 
-func NewProllyStats(ctx context.Context, destDb dsess.SqlDatabase) (*prollyStats, error) {
+func NewProllyStats(ctx context.Context, ddb *doltdb.DoltDB) (*prollyStats, error) {
 	sch := schema.StatsTableDoltSchema
 	kd, vd := sch.GetMapDescriptors(nil)
 
-	nodeStore := destDb.DbData().Ddb.NodeStore()
+	nodeStore := ddb.NodeStore()
 	keyBuilder := val.NewTupleBuilder(kd, nodeStore)
 	valueBuilder := val.NewTupleBuilder(vd, nodeStore)
 	newMap, err := prolly.NewMapFromTuples(ctx, nodeStore, kd, vd)
@@ -196,23 +199,29 @@ func NewProllyStats(ctx context.Context, destDb dsess.SqlDatabase) (*prollyStats
 	}
 
 	return &prollyStats{
-		mu:     sync.Mutex{},
-		destDb: destDb,
-		kb:     keyBuilder,
-		vb:     valueBuilder,
-		m:      newMap.Mutate().WithMaxPending(defaultMaxStatsPending),
-		mem:    NewMemStats(),
+		mu:  sync.Mutex{},
+		ddb: ddb,
+		kb:  keyBuilder,
+		vb:  valueBuilder,
+		m:   newMap.Mutate().WithMaxPending(defaultMaxStatsPending),
+		mem: NewMemStats(),
 	}, nil
 }
 
 type prollyStats struct {
-	destDb dsess.SqlDatabase
-	kb     *val.TupleBuilder
-	vb     *val.TupleBuilder
-	m      *prolly.MutableMap
-	newM   *prolly.MutableMap
-	mem    *memStats
-	mu     sync.Mutex
+	ddb  *doltdb.DoltDB
+	kb   *val.TupleBuilder
+	vb   *val.TupleBuilder
+	m    *prolly.MutableMap
+	newM *prolly.MutableMap
+	mem  *memStats
+	mu   sync.Mutex
+}
+
+func (p *prollyStats) Close() {
+	if p.ddb != nil {
+		_ = p.ddb.Close()
+	}
 }
 
 func (p *prollyStats) Len() int {
@@ -342,7 +351,7 @@ func (p *prollyStats) Flush(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	if err := p.destDb.DbData().Ddb.SetStatistics(ctx, "main", flushedMap.HashOf()); err != nil {
+	if err := p.ddb.SetStatistics(ctx, "main", flushedMap.HashOf()); err != nil {
 		return 0, err
 	}
 
@@ -464,12 +473,12 @@ func (p *prollyStats) encodeBucket(ctx context.Context, b *stats.Bucket, tupB *v
 
 func (p *prollyStats) NewEmpty(ctx context.Context) (StatsKv, error) {
 	kd, vd := schema.StatsTableDoltSchema.GetMapDescriptors(nil)
-	newMap, err := prolly.NewMapFromTuples(ctx, p.destDb.DbData().Ddb.NodeStore(), kd, vd)
+	newMap, err := prolly.NewMapFromTuples(ctx, p.ddb.NodeStore(), kd, vd)
 	if err != nil {
 		return nil, err
 	}
 	m := newMap.Mutate().WithMaxPending(defaultMaxStatsPending)
-	return &prollyStats{m: m, destDb: p.destDb, kb: p.kb, vb: p.vb}, nil
+	return &prollyStats{m: m, ddb: p.ddb, kb: p.kb, vb: p.vb}, nil
 }
 
 func EncodeRow(ctx context.Context, ns tree.NodeStore, r sql.Row, tb *val.TupleBuilder) ([]byte, error) {

--- a/go/libraries/doltcore/sqle/statspro/stats_kv_test.go
+++ b/go/libraries/doltcore/sqle/statspro/stats_kv_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/dtestutils"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"github.com/dolthub/dolt/go/store/chunks"
 	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/prolly/message"
@@ -34,8 +33,7 @@ import (
 )
 
 func TestProllyKv(t *testing.T) {
-	threads := sql.NewBackgroundThreads()
-	prollyKv := newTestProllyKv(t, threads)
+	prollyKv := newTestProllyKv(t)
 
 	h := hash.Parse(strings.Repeat("a", hash.StringLen))
 	h2 := hash.Parse(strings.Repeat("b", hash.StringLen))
@@ -128,8 +126,7 @@ func TestProllyKv(t *testing.T) {
 	})
 	t.Run("TestGcMarkFlush", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
-		bthreads := sql.NewBackgroundThreads()
-		defer bthreads.Shutdown()
+
 		prev := NewMemStats()
 		nodes1, bucks1 := testNodes(t, 10, 1)
 		nodes2, bucks2 := testNodes(t, 10, 2)
@@ -154,7 +151,7 @@ func TestProllyKv(t *testing.T) {
 		require.Equal(t, 20, len(to.gcFlusher[tupB]))
 		require.Equal(t, 20, to.Len())
 
-		kv := newTestProllyKv(t, bthreads)
+		kv := newTestProllyKv(t)
 		kv.mem = to
 		cnt, err := kv.Flush(ctx)
 		require.NoError(t, err)
@@ -164,22 +161,11 @@ func TestProllyKv(t *testing.T) {
 	})
 }
 
-func newTestProllyKv(t *testing.T, threads *sql.BackgroundThreads) *prollyStats {
+func newTestProllyKv(t *testing.T) *prollyStats {
 	dEnv := dtestutils.CreateTestEnv()
-
-	sqlEng, ctx := newTestEngine(context.Background(), t, dEnv, threads)
-	ctx.Session.SetClient(sql.Client{
-		User:    "billy boy",
-		Address: "bigbillie@fake.horse",
-	})
-	require.NoError(t, executeQuery(ctx, sqlEng, "create database mydb"))
-	require.NoError(t, executeQuery(ctx, sqlEng, "use mydb"))
-
-	startDbs := sqlEng.Analyzer.Catalog.DbProvider.AllDatabases(ctx)
-
-	kv, err := NewProllyStats(ctx, startDbs[0].(dsess.SqlDatabase))
+	ctx := context.Background()
+	kv, err := NewProllyStats(ctx, dEnv.DoltDB(ctx))
 	require.NoError(t, err)
-
 	return kv
 }
 

--- a/go/libraries/doltcore/sqle/statspro/worker.go
+++ b/go/libraries/doltcore/sqle/statspro/worker.go
@@ -166,6 +166,11 @@ func (sc *StatsController) trySwapStats(ctx context.Context, prevGen uint64, new
 			}
 			sc.doGc = false
 			sc.gcCnt++
+			// Close the current KV's DoltDB before replacing sc.kv with the
+			// in-memory gcKv. rotateStorage below will open a fresh DoltDB, but
+			// by then sc.kv is already the memStats gcKv whose Close is a no-op,
+			// so the old DoltDB's file descriptors would leak without this.
+			sc.kv.Close()
 			sc.kv = gcKv
 			ok = true
 			if !sc.memOnly {


### PR DESCRIPTION
- DropDatabase closes DoltDBs when bypassing the singleton cache, same as Close() does.

- StatsController prollyStats carries a DoltDB instance, instead of sqle.Database.

- StatsController always bypasses the singleton cache and owns its own DoltDB instance.

- StatsController always closes its DoltDB instance, in both rotateStorage and in Close.