### PR TITLE
dolthub/dolt#10813 fix(checkout): enforce --no-overwrite-ignore in DOLT_CHECKOUT -b via direct SQL

### DIFF
--- a/go/libraries/doltcore/sqle/dprocedures/dolt_checkout.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_checkout.go
@@ -466,9 +466,17 @@ func checkoutNewBranch(
 		}
 	}
 
+	// Capture current roots before commitTransaction, which starts a new transaction and
+	// resets session state, causing GetRoots to return false afterwards.
+	sess := dsess.DSessFromSess(ctx.Session)
+	var currentRoots doltdb.Roots
+	var hasCurrentRoots bool
+	if !overwriteIgnore && !isMove {
+		currentRoots, hasCurrentRoots = sess.GetRoots(ctx, dbName)
+	}
+
 	// We need to commit the transaction here or else the branch we just created isn't visible to the current transaction,
 	// and we are about to switch to it. So set the new branch head for the new transaction, then commit this one
-	sess := dsess.DSessFromSess(ctx.Session)
 	err = commitTransaction(ctx, sess, rsc)
 	if err != nil {
 		return "", "", err
@@ -480,6 +488,19 @@ func checkoutNewBranch(
 
 	if isMove {
 		return newBranchName, remoteAndBranch, doGlobalCheckout(ctx, newBranchName, apr.Contains(cli.ForceFlag), true, overwriteIgnore)
+	}
+
+	if !overwriteIgnore && hasCurrentRoots {
+		ddb, ok := sess.GetDoltDB(ctx, dbName)
+		if ok {
+			branchHead, err := actions.BranchHeadRoot(ctx, ddb, newBranchName)
+			if err != nil {
+				return "", "", err
+			}
+			if err := actions.CheckOverwrittenIgnoredTables(ctx, currentRoots, branchHead, overwriteIgnore); err != nil {
+				return "", "", err
+			}
+		}
 	}
 
 	wsRef, err := ref.WorkingSetRefForHead(ref.NewBranchRef(newBranchName))

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -3749,6 +3749,52 @@ var DoltCheckoutScripts = []queries.ScriptTest{
 		},
 	},
 	{
+		Name: "dolt_checkout -b with --no-overwrite-ignore aborts when ignored table differs at start point",
+		SetUpScript: []string{
+			"create table ignored_tbl (pk int primary key, val int);",
+			"insert into ignored_tbl values (1, 100);",
+			"insert into dolt_ignore values ('ignored_tbl', true);",
+			"call dolt_add('-A', '--force');",
+			"call dolt_commit('-m', 'add ignored table on main', '--force');",
+			"insert into ignored_tbl values (2, 200);",
+			"call dolt_add('-A', '--force');",
+			"call dolt_commit('-m', 'modify ignored table', '--force');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:       "call dolt_checkout('-b', 'newbranch', '--no-overwrite-ignore', 'HEAD~1');",
+				ExpectedErr: actions.ErrCheckoutWouldOverwriteIgnoredTables,
+			},
+			{
+				Query:    "select active_branch();",
+				Expected: []sql.Row{{"main"}},
+			},
+		},
+	},
+	{
+		Name: "dolt_checkout -b with --overwrite-ignore succeeds when ignored table differs at start point",
+		SetUpScript: []string{
+			"create table ignored_tbl (pk int primary key, val int);",
+			"insert into ignored_tbl values (1, 100);",
+			"insert into dolt_ignore values ('ignored_tbl', true);",
+			"call dolt_add('-A', '--force');",
+			"call dolt_commit('-m', 'add ignored table on main', '--force');",
+			"insert into ignored_tbl values (2, 200);",
+			"call dolt_add('-A', '--force');",
+			"call dolt_commit('-m', 'modify ignored table', '--force');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:            "call dolt_checkout('-b', 'newbranch', '--overwrite-ignore', 'HEAD~1');",
+				SkipResultsCheck: true,
+			},
+			{
+				Query:    "select active_branch();",
+				Expected: []sql.Row{{"newbranch"}},
+			},
+		},
+	},
+	{
 		Name: "dolt_checkout default behavior overwrites ignored tables",
 		SetUpScript: []string{
 			"create table ignored_tbl (pk int primary key, val int);",

--- a/integration-tests/bats/sql-checkout.bats
+++ b/integration-tests/bats/sql-checkout.bats
@@ -379,6 +379,57 @@ SQL
     [[ "$output" =~ "mutually exclusive" ]] || false
 }
 
+@test "sql-checkout: DOLT_CHECKOUT -b with --no-overwrite-ignore aborts when ignored table differs at start point" {
+    dolt sql <<SQL
+CREATE TABLE ignored_tbl (pk int PRIMARY KEY, val int);
+INSERT INTO ignored_tbl VALUES (1, 100);
+INSERT INTO dolt_ignore VALUES ('ignored_tbl', true);
+SQL
+    dolt add -A --force
+    dolt commit -m "add ignored table on main" --force
+
+    dolt sql -q "INSERT INTO ignored_tbl VALUES (2, 200)"
+    dolt add -A --force
+    dolt commit -m "modify ignored table" --force
+
+    # Direct SQL call (no --move): creating branch from HEAD~1 where ignored_tbl differs
+    run dolt sql -q "CALL DOLT_CHECKOUT('-b', 'newbranch', '--no-overwrite-ignore', 'HEAD~1')"
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "ignored tables would be overwritten by checkout" ]] || false
+    [[ "$output" =~ "ignored_tbl" ]] || false
+}
+
+@test "sql-checkout: DOLT_CHECKOUT -b with --overwrite-ignore succeeds when ignored table differs at start point" {
+    dolt sql <<SQL
+CREATE TABLE ignored_tbl (pk int PRIMARY KEY, val int);
+INSERT INTO ignored_tbl VALUES (1, 100);
+INSERT INTO dolt_ignore VALUES ('ignored_tbl', true);
+SQL
+    dolt add -A --force
+    dolt commit -m "add ignored table on main" --force
+
+    dolt sql -q "INSERT INTO ignored_tbl VALUES (2, 200)"
+    dolt add -A --force
+    dolt commit -m "modify ignored table" --force
+
+    run dolt sql -q "CALL DOLT_CHECKOUT('-b', 'newbranch', '--overwrite-ignore', 'HEAD~1')"
+    [ "$status" -eq 0 ]
+}
+
+@test "sql-checkout: DOLT_CHECKOUT -b with --no-overwrite-ignore from HEAD succeeds (hashes identical)" {
+    dolt sql <<SQL
+CREATE TABLE ignored_tbl (pk int PRIMARY KEY, val int);
+INSERT INTO ignored_tbl VALUES (1, 100);
+INSERT INTO dolt_ignore VALUES ('ignored_tbl', true);
+SQL
+    dolt add -A --force
+    dolt commit -m "add ignored table on main" --force
+
+    # Creating from HEAD: hashes always match, no overwrite possible
+    run dolt sql -q "CALL DOLT_CHECKOUT('-b', 'newbranch', '--no-overwrite-ignore')"
+    [ "$status" -eq 0 ]
+}
+
 get_head_commit() {
     dolt log -n 1 | grep -m 1 commit | awk '{print $2}'
 }


### PR DESCRIPTION
## Summary

When calling `DOLT_CHECKOUT('-b', ...)` directly via SQL (without `--move`), the `--no-overwrite-ignore` flag was silently ignored. `CheckOverwrittenIgnoredTables` was never called for the `isMove=false` path in `checkoutNewBranch`, so creating a branch from a non-HEAD start point would succeed even when ignored tables in the working set differed from the start point.

The fix captures the current working roots before `commitTransaction` (which resets session state, making `GetRoots` return false afterward), then runs the ignored table check before switching the working set to the new branch.

## Changes

- Call `CheckOverwrittenIgnoredTables` in the `isMove=false` path of `checkoutNewBranch`
- Capture roots before `commitTransaction` to avoid session state reset
- Add engine script tests and bats tests covering `--no-overwrite-ignore` and
`--overwrite-ignore` with a non-HEAD start point

Closes: #10813
