### PR TITLE
go/cmd/dolt: Add GOMEMLIMIT awareness via automemlimit and server config

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/command_line_config.go
+++ b/go/cmd/dolt/commands/sqlserver/command_line_config.go
@@ -604,6 +604,10 @@ func (cfg *commandLineServerConfig) AutoGCBehavior() servercfg.AutoGCBehavior {
 	return stubAutoGCBehavior{}
 }
 
+func (cfg *commandLineServerConfig) MaxGoMemory() int64 {
+	return 0
+}
+
 func (cfg *commandLineServerConfig) Overrides() sql.EngineOverrides {
 	return sql.EngineOverrides{}
 }

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -118,6 +119,17 @@ func ConfigureServices(
 		},
 	}
 	controller.Register(ValidateConfigStep)
+
+	if memLimit := cfg.ServerConfig.MaxGoMemory(); memLimit > 0 {
+		ApplyMemoryLimit := &svcs.AnonService{
+			InitF: func(context.Context) error {
+				prev := debug.SetMemoryLimit(memLimit)
+				logrus.Infof("GOMEMLIMIT set to %d bytes via server config max_go_memory (previous: %d)", memLimit, prev)
+				return nil
+			},
+		}
+		controller.Register(ApplyMemoryLimit)
+	}
 
 	lgr := logrus.StandardLogger()
 	lgr.SetOutput(cli.CliErr)

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -230,6 +230,10 @@ func runMain() int {
 
 	start := time.Now()
 
+	// Configure GOMEMLIMIT from DOLT_GOMEMLIMIT env var or cgroup auto-detection.
+	// This must happen early, before significant allocations.
+	configureMemoryLimit()
+
 	// Dolt must never block on interactive git credential prompts. Enforce a
 	// non-interactive git policy for the entire process (CLI + sql-server).
 	gitauth.DisableInteractivePrompts()

--- a/go/cmd/dolt/memlimit.go
+++ b/go/cmd/dolt/memlimit.go
@@ -1,0 +1,122 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"runtime/debug"
+	"strconv"
+	"strings"
+
+	"github.com/KimMachineGun/automemlimit/memlimit"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// doltGoMemLimitEnv is the environment variable for explicitly setting GOMEMLIMIT.
+	// Accepts byte values (e.g. "1073741824") or human-readable values (e.g. "1GiB", "512MiB").
+	doltGoMemLimitEnv = "DOLT_GOMEMLIMIT"
+
+	// defaultMemLimitRatio is the fraction of the cgroup memory limit to use as GOMEMLIMIT.
+	// 0.9 is the standard recommendation, matching CockroachDB and other Go services.
+	defaultMemLimitRatio = 0.9
+)
+
+// configureMemoryLimit sets GOMEMLIMIT based on the environment:
+//  1. If DOLT_GOMEMLIMIT is set, use that value explicitly.
+//  2. Otherwise, auto-detect cgroup memory limits and set GOMEMLIMIT to 90% of the limit.
+//  3. If no cgroup limit is detected (bare metal), GOMEMLIMIT remains unset.
+func configureMemoryLimit() {
+	if v := os.Getenv(doltGoMemLimitEnv); v != "" {
+		limit, err := parseMemoryValue(v)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "WARNING: invalid %s value %q: %v\n", doltGoMemLimitEnv, v, err)
+			return
+		}
+		prev := debug.SetMemoryLimit(limit)
+		logrus.Infof("GOMEMLIMIT set to %d bytes via %s (previous: %d)", limit, doltGoMemLimitEnv, prev)
+		return
+	}
+
+	// Auto-detect cgroup memory limit. On bare metal or when no cgroup limit is set,
+	// this returns an error and GOMEMLIMIT stays at its default (math.MaxInt64).
+	limit, err := memlimit.SetGoMemLimitWithOpts(
+		memlimit.WithRatio(defaultMemLimitRatio),
+		memlimit.WithLogger(nil), // suppress automemlimit's own logging
+	)
+	if err != nil {
+		// Not in a cgroup or no memory limit set — this is normal on bare metal.
+		logrus.Debugf("automemlimit: no cgroup memory limit detected: %v", err)
+		return
+	}
+	if limit > 0 {
+		logrus.Infof("GOMEMLIMIT auto-configured to %d bytes (%.0f%% of cgroup limit)", limit, defaultMemLimitRatio*100)
+	}
+}
+
+// parseMemoryValue parses a memory value string. Accepts plain byte counts or
+// human-readable suffixes: B, KiB, MiB, GiB, TiB (case-insensitive).
+func parseMemoryValue(s string) (int64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty value")
+	}
+
+	// Try plain integer first
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+		if n <= 0 {
+			return 0, fmt.Errorf("value must be positive")
+		}
+		return n, nil
+	}
+
+	upper := strings.ToUpper(s)
+	suffixes := []struct {
+		suffix string
+		mult   float64
+	}{
+		{"TIB", 1 << 40},
+		{"GIB", 1 << 30},
+		{"MIB", 1 << 20},
+		{"KIB", 1 << 10},
+		{"TB", 1e12},
+		{"GB", 1e9},
+		{"MB", 1e6},
+		{"KB", 1e3},
+		{"B", 1},
+	}
+
+	for _, sf := range suffixes {
+		if strings.HasSuffix(upper, sf.suffix) {
+			numStr := strings.TrimSpace(s[:len(s)-len(sf.suffix)])
+			n, err := strconv.ParseFloat(numStr, 64)
+			if err != nil {
+				return 0, fmt.Errorf("invalid number %q", numStr)
+			}
+			if n <= 0 {
+				return 0, fmt.Errorf("value must be positive")
+			}
+			result := int64(math.Round(n * sf.mult))
+			if result <= 0 {
+				return 0, fmt.Errorf("value too small")
+			}
+			return result, nil
+		}
+	}
+
+	return 0, fmt.Errorf("unrecognized format %q; use bytes or suffix like MiB, GiB", s)
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -118,6 +118,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.50.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.50.0 // indirect
+	github.com/KimMachineGun/automemlimit v0.7.5 // indirect
 	github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b // indirect
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
@@ -170,6 +171,7 @@ require (
 	github.com/mark3labs/mcp-go v0.34.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pierrec/lz4/v4 v4.1.6 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -86,6 +86,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.50.0/go.mod h1:otE2jQekW/PqXk1Awf5lmfokJx4uwuqcj1ab5SpGeW0=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob0t8PQPMybUNFM=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
+github.com/KimMachineGun/automemlimit v0.7.5 h1:RkbaC0MwhjL1ZuBKunGDjE/ggwAX43DwZrJqVwyveTk=
+github.com/KimMachineGun/automemlimit v0.7.5/go.mod h1:QZxpHaGOQoYvFhv/r4u3U0JTC2ZcOwbSr11UZF46UBM=
 github.com/Shopify/toxiproxy/v2 v2.5.0 h1:i4LPT+qrSlKNtQf5QliVjdP08GyAH8+BUIc9gT0eahc=
 github.com/Shopify/toxiproxy/v2 v2.5.0/go.mod h1:yhM2epWtAmel9CB8r2+L+PCmhH6yH2pITaPAo7jxJl0=
 github.com/abiosoft/readline v0.0.0-20180607040430-155bce2042db h1:CjPUSXOiYptLbTdr1RceuZgSFDQ7U15ITERUGrUORx8=
@@ -454,6 +456,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/oracle/oci-go-sdk/v65 v65.55.0 h1:enKyHVLdJYDJrc9232w33u5F6t2p8Din4593kn3nh/w=
 github.com/oracle/oci-go-sdk/v65 v65.55.0/go.mod h1:IBEV9l1qBzUpo7zgGaRUhbB05BVfcDGYRFBCPlTcPp0=
+github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
+github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pborman/getopt v0.0.0-20180729010549-6fdd0a2c7117/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/phpdave11/gofpdf v1.4.2/go.mod h1:zpO6xFn9yxo3YLyMvW8HcKWVdbNqgIfOOp2dXMnm1mY=
 github.com/phpdave11/gofpdi v1.0.12/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=

--- a/go/libraries/doltcore/servercfg/serverconfig.go
+++ b/go/libraries/doltcore/servercfg/serverconfig.go
@@ -249,6 +249,9 @@ type ServerConfig interface {
 	ValueSet(value string) bool
 	// AutoGCBehavior defines parameters around how auto-GC works for the running server.
 	AutoGCBehavior() AutoGCBehavior
+	// MaxGoMemory returns the GOMEMLIMIT value in bytes, or 0 if not configured.
+	// When set, debug.SetMemoryLimit is called at server startup.
+	MaxGoMemory() int64
 	// Overrides returns any overrides that are defined. This is primarily used by Doltgres.
 	Overrides() sql.EngineOverrides
 }

--- a/go/libraries/doltcore/servercfg/testdata/minver_validation.txt
+++ b/go/libraries/doltcore/servercfg/testdata/minver_validation.txt
@@ -36,6 +36,7 @@ ListenerConfig servercfg.ListenerYAMLConfig 0.0.0 listener,omitempty
 -Socket *string 0.0.0 socket,omitempty
 PerformanceConfig *servercfg.PerformanceYAMLConfig 0.0.0 performance,omitempty
 -QueryParallelism *int 0.0.0 query_parallelism,omitempty
+-GoMemoryLimitBytes *int64 1.80.0 max_go_memory,omitempty
 DataDirStr *string 0.0.0 data_dir,omitempty
 CfgDirStr *string 0.0.0 cfg_dir,omitempty
 RemotesapiConfig servercfg.RemotesapiYAMLConfig 0.0.0 remotesapi,omitempty

--- a/go/libraries/doltcore/servercfg/yaml_config.go
+++ b/go/libraries/doltcore/servercfg/yaml_config.go
@@ -109,6 +109,9 @@ type ListenerYAMLConfig struct {
 type PerformanceYAMLConfig struct {
 	// QueryParallelism is deprecated but still present to prevent breaking YAML config that still uses it
 	QueryParallelism *int `yaml:"query_parallelism,omitempty"`
+	// GoMemoryLimitBytes sets GOMEMLIMIT via runtime/debug.SetMemoryLimit at server startup.
+	// Accepts a byte count. When set, this overrides DOLT_GOMEMLIMIT and cgroup auto-detection.
+	GoMemoryLimitBytes *int64 `yaml:"max_go_memory,omitempty" minver:"1.80.0"`
 }
 
 type MetricsYAMLConfig struct {
@@ -210,6 +213,10 @@ func YamlConfigFromFile(fs filesys.Filesys, path string) (ServerConfig, error) {
 func ServerConfigAsYAMLConfig(cfg ServerConfig) *YAMLConfig {
 	systemVars := cfg.SystemVars()
 	autoGCBehavior := toAutoGCBehaviorYAML(cfg.AutoGCBehavior())
+	var perfCfg *PerformanceYAMLConfig
+	if m := cfg.MaxGoMemory(); m > 0 {
+		perfCfg = &PerformanceYAMLConfig{GoMemoryLimitBytes: ptr(m)}
+	}
 	return &YAMLConfig{
 		LogLevelStr:       ptr(string(cfg.LogLevel())),
 		LogFormatStr:      ptr(string(cfg.LogFormat())),
@@ -238,8 +245,9 @@ func ServerConfigAsYAMLConfig(cfg ServerConfig) *YAMLConfig {
 			AllowCleartextPasswords: nillableBoolPtr(cfg.AllowCleartextPasswords()),
 			Socket:                  nillableStrPtr(cfg.Socket()),
 		},
-		DataDirStr: ptr(cfg.DataDir()),
-		CfgDirStr:  ptr(cfg.CfgDir()),
+		PerformanceConfig: perfCfg,
+		DataDirStr:        ptr(cfg.DataDir()),
+		CfgDirStr:         ptr(cfg.CfgDir()),
 		MetricsConfig: MetricsYAMLConfig{
 			Labels:                  cfg.MetricsLabels(),
 			Host:                    nillableStrPtr(cfg.MetricsHost()),
@@ -1038,6 +1046,13 @@ func (cfg YAMLConfig) EventSchedulerStatus() string {
 	default:
 		return strings.ToUpper(*cfg.BehaviorConfig.EventSchedulerStatus)
 	}
+}
+
+func (cfg YAMLConfig) MaxGoMemory() int64 {
+	if cfg.PerformanceConfig != nil && cfg.PerformanceConfig.GoMemoryLimitBytes != nil {
+		return *cfg.PerformanceConfig.GoMemoryLimitBytes
+	}
+	return 0
 }
 
 func (cfg YAMLConfig) Overrides() sql.EngineOverrides {


### PR DESCRIPTION
Dolt has no GOMEMLIMIT or GOGC awareness. For containerized deployments, this means the Go runtime doesn't know about cgroup memory limits, leading to OOM kills when RSS grows past the container limit.

This adds three-tier memory limit configuration:

1. `DOLT_GOMEMLIMIT` env var — explicit, human-readable values like "1GiB"
2. `automemlimit` cgroup auto-detection — sets GOMEMLIMIT to 90% of the cgroup limit
3. Silent fallthrough on bare metal when neither applies

Also adds `max_go_memory` to the YAML server config, applied at sql-server startup via `debug.SetMemoryLimit()`, and `MaxGoMemory() int64` to the `ServerConfig` interface.

Files changed:
- `go/cmd/dolt/memlimit.go` (new) — `configureMemoryLimit()` with the three-tier logic
- `go/cmd/dolt/dolt.go` — calls `configureMemoryLimit()` early in `runMain()`
- `go/cmd/dolt/commands/sqlserver/server.go` — applies `max_go_memory` at sql-server startup
- `go/libraries/doltcore/servercfg/` — `MaxGoMemory() int64` on interface and implementations