### PR TITLE
go/libraries/doltcore/servercfg: Add pprof_server to YAML server config

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/command_line_config.go
+++ b/go/cmd/dolt/commands/sqlserver/command_line_config.go
@@ -600,6 +600,10 @@ func (cfg *commandLineServerConfig) ValueSet(value string) bool {
 	return ok
 }
 
+func (cfg *commandLineServerConfig) PprofServer() bool {
+	return false
+}
+
 func (cfg *commandLineServerConfig) AutoGCBehavior() servercfg.AutoGCBehavior {
 	return stubAutoGCBehavior{}
 }

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -169,6 +169,21 @@ func ConfigureServices(
 	}
 	controller.Register(InitLogging)
 
+	if cfg.ServerConfig.PprofServer() {
+		pprofService := &svcs.AnonService{
+			InitF: func(context.Context) error {
+				go func() {
+					logrus.Info("Starting pprof server on port 6060")
+					if err := http.ListenAndServe("0.0.0.0:6060", nil); err != nil {
+						logrus.WithError(err).Warn("pprof server exited with error")
+					}
+				}()
+				return nil
+			},
+		}
+		controller.Register(pprofService)
+	}
+
 	controller.Register(newHeartbeatService(cfg.Version, cfg.DoltEnv))
 
 	fs := cfg.DoltEnv.FS

--- a/go/cmd/dolt/commands/sqlserver/server_test.go
+++ b/go/cmd/dolt/commands/sqlserver/server_test.go
@@ -642,6 +642,7 @@ func TestGenerateYamlConfig(t *testing.T) {
   # auto_gc_behavior:
     # enable: true
     # archive_level: 1
+  # pprof_server: false
 
 listener:
   # host: localhost

--- a/go/libraries/doltcore/servercfg/serverconfig.go
+++ b/go/libraries/doltcore/servercfg/serverconfig.go
@@ -249,6 +249,8 @@ type ServerConfig interface {
 	ValueSet(value string) bool
 	// AutoGCBehavior defines parameters around how auto-GC works for the running server.
 	AutoGCBehavior() AutoGCBehavior
+	// PprofServer returns whether the pprof HTTP server should be started on port 6060.
+	PprofServer() bool
 	// Overrides returns any overrides that are defined. This is primarily used by Doltgres.
 	Overrides() sql.EngineOverrides
 }
@@ -378,6 +380,7 @@ const (
 	RemotesapiReadOnlyKey             = "remotesapi_read_only"
 	ClusterConfigKey                  = "cluster_config"
 	EventSchedulerKey                 = "event_scheduler"
+	PprofServerKey                    = "pprof_server"
 )
 
 type SystemVariableTarget interface {

--- a/go/libraries/doltcore/servercfg/testdata/minver_validation.txt
+++ b/go/libraries/doltcore/servercfg/testdata/minver_validation.txt
@@ -16,6 +16,7 @@ BehaviorConfig servercfg.BehaviorYAMLConfig 0.0.0 behavior,omitempty
 --Enable_ *bool 1.50.0 enable,omitempty
 --ArchiveLevel_ *int 1.52.1 archive_level,omitempty
 -BranchActivityTracking *bool 1.77.0 branch_activity_tracking,omitempty
+-PprofServer *bool TBD pprof_server,omitempty
 UserConfig servercfg.UserYAMLConfig 0.0.0 user,omitempty
 -Name *string 0.0.0 name,omitempty
 -Password *string 0.0.0 password,omitempty

--- a/go/libraries/doltcore/servercfg/yaml_config.go
+++ b/go/libraries/doltcore/servercfg/yaml_config.go
@@ -71,6 +71,8 @@ type BehaviorYAMLConfig struct {
 	AutoGCBehavior *AutoGCBehaviorYAMLConfig `yaml:"auto_gc_behavior,omitempty" minver:"1.50.0"`
 
 	BranchActivityTracking *bool `yaml:"branch_activity_tracking,omitempty" minver:"1.77.0"`
+
+	PprofServer *bool `yaml:"pprof_server,omitempty" minver:"TBD"`
 }
 
 // UserYAMLConfig contains server configuration regarding the user account clients must use to connect
@@ -223,6 +225,7 @@ func ServerConfigAsYAMLConfig(cfg ServerConfig) *YAMLConfig {
 			BranchActivityTracking:       ptr(cfg.BranchActivityTracking()),
 			EventSchedulerStatus:         ptr(cfg.EventSchedulerStatus()),
 			AutoGCBehavior:               autoGCBehavior,
+			PprofServer:                  nillableBoolPtr(cfg.PprofServer()),
 		},
 		ListenerConfig: ListenerYAMLConfig{
 			HostStr:                 ptr(cfg.Host()),
@@ -301,6 +304,7 @@ func ServerConfigSetValuesAsYAMLConfig(cfg ServerConfig) *YAMLConfig {
 			DoltTransactionCommit:        zeroIf(ptr(cfg.DoltTransactionCommit()), !cfg.ValueSet(DoltTransactionCommitKey)),
 			BranchActivityTracking:       zeroIf(ptr(cfg.BranchActivityTracking()), !cfg.ValueSet(BranchActivityTrackingKey)),
 			EventSchedulerStatus:         zeroIf(ptr(cfg.EventSchedulerStatus()), !cfg.ValueSet(EventSchedulerKey)),
+			PprofServer:                  zeroIf(ptr(cfg.PprofServer()), !cfg.ValueSet(PprofServerKey)),
 		},
 		ListenerConfig: ListenerYAMLConfig{
 			HostStr:                 zeroIf(ptr(cfg.Host()), !cfg.ValueSet(HostKey)),
@@ -403,6 +407,9 @@ func (cfg YAMLConfig) withPlaceholdersFilledIn() YAMLConfig {
 	}
 	if withPlaceholders.BehaviorConfig.EventSchedulerStatus == nil {
 		withPlaceholders.BehaviorConfig.EventSchedulerStatus = ptr("OFF")
+	}
+	if withPlaceholders.BehaviorConfig.PprofServer == nil {
+		withPlaceholders.BehaviorConfig.PprofServer = ptr(false)
 	}
 
 	if withPlaceholders.ListenerConfig.TLSKey == nil {
@@ -709,6 +716,15 @@ func (cfg YAMLConfig) BranchActivityTracking() bool {
 	}
 
 	return *cfg.BehaviorConfig.BranchActivityTracking
+}
+
+// PprofServer returns whether the pprof HTTP server should be started on port 6060.
+func (cfg YAMLConfig) PprofServer() bool {
+	if cfg.BehaviorConfig.PprofServer == nil {
+		return false
+	}
+
+	return *cfg.BehaviorConfig.PprofServer
 }
 
 // LogLevel returns the level of logging that the server will use.
@@ -1136,6 +1152,8 @@ func (cfg YAMLConfig) ValueSet(value string) bool {
 		return cfg.ListenerConfig.MaxConnectionsTimeoutMs != nil
 	case EventSchedulerKey:
 		return cfg.BehaviorConfig.EventSchedulerStatus != nil
+	case PprofServerKey:
+		return cfg.BehaviorConfig.PprofServer != nil
 	}
 	return false
 }


### PR DESCRIPTION
The `--pprof-server` CLI flag exists but there is no way to enable it via YAML config. This adds `pprof_server` as a boolean field in the server config, following the same pattern as existing bool fields like `read_only`.

- `PprofServer() bool` added to the `ServerConfig` interface
- YAML implementation: struct field, getter, `ValueSet`, serialization helpers, placeholder default
- `command_line_config` returns `false` (CLI has its own flag path via `--pprof-server`)
- `server.go` wires `cfg.ServerConfig.PprofServer()` into `ConfigureServices` to start pprof
- `testdata/minver_validation.txt` updated with the new field