### PR TITLE
go/store/prolly/tree: Add DOLT_NODE_CACHE_SIZE env var for prolly node cache

### DIFF
--- a/go/libraries/doltcore/dconfig/envvars.go
+++ b/go/libraries/doltcore/dconfig/envvars.go
@@ -46,6 +46,7 @@ const (
 	EnvDoltRootHost                  = "DOLT_ROOT_HOST"
 	EnvDoltRootPassword              = "DOLT_ROOT_PASSWORD"
 	EnvDoltGCScheduler               = "DOLT_GC_SCHEDULER"
+	EnvNodeCacheSize                 = "DOLT_NODE_CACHE_SIZE"
 
 	// If set, must be "kill_connections" or "session_aware"
 	// Will go away after session_aware is made default-and-only.

--- a/go/store/prolly/tree/node_cache_test.go
+++ b/go/store/prolly/tree/node_cache_test.go
@@ -15,9 +15,12 @@
 package tree
 
 import (
+	"os"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/dolt/go/store/hash"
 )
@@ -45,5 +48,67 @@ func TestNodeCache(t *testing.T) {
 			_, ok := cache.get(addr)
 			assert.False(t, ok)
 		}
+	})
+}
+
+func TestNodeCacheSizeEnvVar(t *testing.T) {
+	// Save original value and restore after test
+	origCacheSize := cacheSize
+	t.Cleanup(func() {
+		cacheSize = origCacheSize
+	})
+
+	t.Run("valid value overrides default", func(t *testing.T) {
+		cacheSize = 256 * 1024 * 1024 // reset to default
+		expected := 512 * 1024 * 1024
+		t.Setenv("DOLT_NODE_CACHE_SIZE", strconv.Itoa(expected))
+
+		// Simulate what init() does
+		if v := os.Getenv("DOLT_NODE_CACHE_SIZE"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				cacheSize = n
+			}
+		}
+		require.Equal(t, expected, cacheSize)
+
+		// Verify the cache can be created with the new size
+		cache := newChunkCache(cacheSize)
+		assert.NotNil(t, cache)
+	})
+
+	t.Run("invalid value keeps default", func(t *testing.T) {
+		cacheSize = 256 * 1024 * 1024 // reset to default
+		t.Setenv("DOLT_NODE_CACHE_SIZE", "not-a-number")
+
+		if v := os.Getenv("DOLT_NODE_CACHE_SIZE"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				cacheSize = n
+			}
+		}
+		require.Equal(t, 256*1024*1024, cacheSize)
+	})
+
+	t.Run("zero value keeps default", func(t *testing.T) {
+		cacheSize = 256 * 1024 * 1024 // reset to default
+		t.Setenv("DOLT_NODE_CACHE_SIZE", "0")
+
+		if v := os.Getenv("DOLT_NODE_CACHE_SIZE"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				cacheSize = n
+			}
+		}
+		require.Equal(t, 256*1024*1024, cacheSize)
+	})
+
+	t.Run("negative value keeps default", func(t *testing.T) {
+		cacheSize = 256 * 1024 * 1024 // reset to default
+		t.Setenv("DOLT_NODE_CACHE_SIZE", "-100")
+
+		if v := os.Getenv("DOLT_NODE_CACHE_SIZE"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				cacheSize = n
+			}
+		}
+		require.Equal(t, 256*1024*1024, cacheSize)
 	})
 }

--- a/go/store/prolly/tree/node_store.go
+++ b/go/store/prolly/tree/node_store.go
@@ -17,6 +17,8 @@ package tree
 import (
 	"bytes"
 	"context"
+	"os"
+	"strconv"
 	"sync"
 
 	"github.com/dolthub/dolt/go/store/chunks"
@@ -27,9 +29,19 @@ import (
 	"github.com/dolthub/dolt/go/store/val"
 )
 
-const (
+var (
+	// cacheSize is the maximum size in bytes for the prolly tree node cache.
+	// Defaults to 256 MiB; overridable via DOLT_NODE_CACHE_SIZE env var.
 	cacheSize = 256 * 1024 * 1024
 )
+
+func init() {
+	if v := os.Getenv("DOLT_NODE_CACHE_SIZE"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cacheSize = n
+		}
+	}
+}
 
 // NodeStore reads and writes prolly tree Nodes.
 type NodeStore interface {


### PR DESCRIPTION
The prolly tree node cache is hardcoded at 256 MiB and is the dominant memory consumer in Dolt. This makes it configurable via the `DOLT_NODE_CACHE_SIZE` environment variable, following the exact same pattern as the existing `DOLT_COMMIT_CACHE_SIZE` env var.

For memory-constrained deployments (containers, small VMs), setting `DOLT_NODE_CACHE_SIZE=33554432` (32 MiB) significantly reduces RSS with minimal performance impact for small datasets.

No default behavior change — without the env var, cache remains 256 MiB.

- `go/store/prolly/tree/node_store.go` — `const cacheSize` changed to `var`, `init()` reads env var
- `go/libraries/doltcore/dconfig/envvars.go` — `EnvNodeCacheSize` constant
- `go/store/prolly/tree/node_cache_test.go` — tests for valid, invalid, zero, and negative values