### PR TITLE
go/libraries/doltcore/dbfactory: Add DOLT_MEMTABLE_SIZE env var for write buffer sizing

### DIFF
--- a/go/libraries/doltcore/dbfactory/factory.go
+++ b/go/libraries/doltcore/dbfactory/factory.go
@@ -18,8 +18,11 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
+	"strconv"
 	"strings"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/dconfig"
 	"github.com/dolthub/dolt/go/libraries/utils/earl"
 	"github.com/dolthub/dolt/go/store/datas"
 	"github.com/dolthub/dolt/go/store/prolly/tree"
@@ -65,9 +68,18 @@ const (
 	GitHTTPSScheme = "git+https"
 	GitSSHScheme   = "git+ssh"
 
-	defaultScheme       = HTTPSScheme
-	defaultMemTableSize = 256 * 1024 * 1024
+	defaultScheme = HTTPSScheme
 )
+
+var defaultMemTableSize uint64 = 256 * 1024 * 1024
+
+func init() {
+	if v := os.Getenv(dconfig.EnvMemTableSize); v != "" {
+		if n, err := strconv.ParseUint(v, 10, 64); err == nil && n > 0 {
+			defaultMemTableSize = n
+		}
+	}
+}
 
 // DBFactory is an interface for creating concrete datas.Database instances from different backing stores
 type DBFactory interface {

--- a/go/libraries/doltcore/dconfig/envvars.go
+++ b/go/libraries/doltcore/dconfig/envvars.go
@@ -54,4 +54,7 @@ const (
 	// Used for tests. If set, Dolt will error if it would rebuild a table's row data.
 	EnvAssertNoTableRewrite         = "DOLT_TEST_ASSERT_NO_TABLE_REWRITE"
 	EnvAssertNoInMemoryArchiveIndex = "DOLT_TEST_ASSERT_NO_IN_MEMORY_ARCHIVE_INDEX"
+
+	// EnvMemTableSize overrides the default write buffer (memtable) size in bytes.
+	EnvMemTableSize = "DOLT_MEMTABLE_SIZE"
 )


### PR DESCRIPTION
The NBS memtable write buffer defaults to 256 MiB in dbfactory and is the second-largest fixed memory allocation in Dolt. This makes it configurable via the `DOLT_MEMTABLE_SIZE` environment variable.

For memory-constrained deployments, tuning this down reduces RSS. For write-heavy workloads on machines with ample RAM, tuning it up can reduce flush frequency.

No default behavior change — without the env var, memtable remains 256 MiB.

- `go/libraries/doltcore/dbfactory/factory.go` — `const defaultMemTableSize` changed to `var`, `init()` reads env var
- `go/libraries/doltcore/dconfig/envvars.go` — `EnvMemTableSize` constant