### PR TITLE
error early when rebase cli operating against a remote server

### DIFF
--- a/go/cmd/dolt/commands/rebase.go
+++ b/go/cmd/dolt/commands/rebase.go
@@ -93,6 +93,11 @@ func (cmd RebaseCmd) Exec(ctx context.Context, commandStr string, args []string,
 	if err != nil {
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
+	if queryist.IsRemote {
+		msg := fmt.Sprintf(cli.RemoteUnsupportedMsg, commandStr)
+		cli.Println(msg)
+		return 1
+	}
 
 	// Set @@dolt_allow_commit_conflicts in case there are data conflicts that need to be resolved by the caller.
 	// Without this, the conflicts can't be committed to the branch working set, and the caller can't access them.

--- a/integration-tests/bats/sql-local-remote.bats
+++ b/integration-tests/bats/sql-local-remote.bats
@@ -1370,13 +1370,7 @@ SQL
 
     start_sql_server altDB
     run dolt --verbose-engine-setup rebase -i main
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 1 ]
     [[ "$output" =~ "starting remote mode" ]] || false
-    [[ "$output" =~ "Successfully rebased and updated refs/heads/b1" ]] || false
-
-    run dolt log
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ "main commit 3" ]] || false
-    [[ "$output" =~ "main commit 2" ]] || false
-    [[ "$output" =~ "b1 commit 1" ]] || false
+    [[ "$output" =~ "dolt rebase can not currently be used when there is a local server running" ]] || false
 }


### PR DESCRIPTION
We overlooked the rebase cli command when talking to a remote server should error out quickly due to the inability to checkout the branch on the client.