### PR TITLE
fix: for dolt_query_diff, scope privilege checks to tables referenced in queries

### DIFF
--- a/go/libraries/doltcore/sqle/dtablefunctions/dolt_query_diff.go
+++ b/go/libraries/doltcore/sqle/dtablefunctions/dolt_query_diff.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/vitess/go/vt/sqlparser"
 
 	gms "github.com/dolthub/go-mysql-server"
 	"github.com/dolthub/go-mysql-server/sql"
@@ -321,9 +322,72 @@ func (tf *QueryDiffTableFunction) WithChildren(node ...sql.Node) (sql.Node, erro
 
 // CheckAuth implements the interface sql.AuthorizationCheckerNode.
 func (tf *QueryDiffTableFunction) CheckAuth(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
-	baseDB, _ := doltdb.SplitRevisionDbName(tf.database.Name())
-	subject := sql.PrivilegeCheckSubject{Database: baseDB}
-	return opChecker.UserHasPrivileges(ctx, sql.NewPrivilegedOperation(subject, sql.PrivilegeType_Select))
+	const (
+		authTargetDB    = 0
+		authTargetTable = 1
+	)
+
+	checkAuthForQueryExpr := func(queryExpr sql.Expression) (bool, error) {
+		val, err := queryExpr.Eval(ctx, nil)
+		if err != nil {
+			return false, err
+		}
+		query, ok := val.(string)
+		if !ok {
+			return false, fmt.Errorf("query must be a string")
+		}
+
+		var tables []string
+		parsed, err := sqlparser.Parse(query)
+		if err != nil {
+			return false, err
+		}
+
+		_ = sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
+			authNode, ok := node.(sqlparser.AuthNode)
+			if !ok {
+				return true, nil // ret true lets the Walk func continue traversing
+			}
+			info := authNode.GetAuthInformation()
+			if info.AuthType == sqlparser.AuthType_IGNORE {
+				return true, nil
+			}
+			if info.TargetType == sqlparser.AuthTargetType_SingleTableIdentifier {
+				tableName := info.TargetNames[authTargetTable]
+				if tableName != "" {
+					tables = append(tables, tableName)
+				}
+			}
+			return true, nil
+		}, parsed)
+
+		for _, table := range tables {
+			baseDB, _ := doltdb.SplitRevisionDbName(tf.database.Name())
+			subject := sql.PrivilegeCheckSubject{Database: baseDB, Table: table}
+			if hasPrvillege := opChecker.UserHasPrivileges(ctx, sql.NewPrivilegedOperation(subject, sql.PrivilegeType_Select)); !hasPrvillege {
+				return false, nil
+			}
+		}
+		return true, nil
+	}
+
+	query1HasPrivilege, err := checkAuthForQueryExpr(tf.query1)
+	if err != nil {
+		return false
+	}
+	if !query1HasPrivilege {
+		return false
+	}
+
+	query2HasPrivilege, err := checkAuthForQueryExpr(tf.query2)
+	if err != nil {
+		return false
+	}
+	if !query2HasPrivilege {
+		return false
+	}
+
+	return true
 }
 
 // Schema implements the sql.Node interface

--- a/go/libraries/doltcore/sqle/enginetest/dolt_privilege_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_privilege_test.go
@@ -1389,34 +1389,9 @@ var DoltOnlyRevisionTableFunctionPrivilegeTests = []queries.UserPrivilegeTest{
 				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
-				User:  "tester",
-				Host:  "localhost",
-				Query: "SELECT * FROM dolt_query_diff('SELECT pk FROM test', 'SELECT pk FROM test');",
-				// TODO(elianddb): Add privilege checks scoped to tables touched in query args.
-				ExpectedErr: sql.ErrPrivilegeCheckFailed,
-			},
-			{
-				User:        "tester",
-				Host:        "localhost",
-				Query:       "SELECT * FROM dolt_query_diff('SELECT 1 AS pk', 'SELECT 2 AS pk');",
-				ExpectedErr: sql.ErrPrivilegeCheckFailed,
-			},
-			{
-				User:        "tester",
-				Host:        "localhost",
-				Query:       "SELECT * FROM dolt_query_diff('SELECT t.pk FROM test t JOIN test2 t2 ON t.pk = t2.pk', 'SELECT t.pk FROM test t JOIN test2 t2 ON t.pk = t2.pk');",
-				ExpectedErr: sql.ErrTableAccessDeniedForUser,
-			},
-			{
-				User:        "tester",
-				Host:        "localhost",
-				Query:       "SELECT * FROM dolt_query_diff('SELECT pk FROM (SELECT pk FROM test2) s', 'SELECT pk FROM (SELECT pk FROM test) s');",
-				ExpectedErr: sql.ErrTableAccessDeniedForUser,
-			},
-			{
 				User:     "root",
 				Host:     "localhost",
-				Query:    "GRANT SELECT ON mydb.* TO tester@localhost;",
+				Query:    "GRANT SELECT ON mydb.test2 TO tester@localhost;",
 				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
@@ -1435,13 +1410,191 @@ var DoltOnlyRevisionTableFunctionPrivilegeTests = []queries.UserPrivilegeTest{
 				User:  "tester",
 				Host:  "localhost",
 				Query: "SELECT * FROM dolt_query_diff('SELECT pk FROM test limit 1', 'SELECT pk FROM test2 limit 1');",
-				// TODO(elianddb): Add privilege checks scoped to tables touched in query args.
 				Expected: []sql.Row{{1, nil, "deleted"}, {nil, 1, "added"}},
 			},
 			{
 				User:     "tester",
 				Host:     "localhost",
 				Query:    "SELECT * FROM dolt_query_diff('SELECT pk FROM (SELECT pk FROM test2) s', 'SELECT pk FROM (SELECT pk FROM test) s');",
+				Expected: []sql.Row{},
+			},
+		},
+	},
+	{
+		Name: "dolt_query_diff per-table privilege checking with revision database",
+		SetUpScript: []string{
+			"CREATE TABLE test (pk BIGINT PRIMARY KEY, col1 varchar(20));",
+			"INSERT INTO test VALUES (1, 'first row'), (2, 'second row');",
+			"CREATE TABLE test2 (pk BIGINT PRIMARY KEY, col1 varchar(20));",
+			"INSERT INTO test2 VALUES (1, 'a'), (2, 'b');",
+			"call dolt_commit('-Am', 'first commit');",
+			"CREATE USER tester@localhost;",
+			"call dolt_branch('b1');",
+			"use mydb/b1;",
+		},
+		Assertions: []queries.UserPrivilegeTestAssertion{
+			// Grant SELECT only on test, not test2
+			{
+				User:     "root",
+				Host:     "localhost",
+				Query:    "GRANT SELECT ON mydb.test TO tester@localhost;",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			// Query touching only test -> allowed
+			{
+				User:     "tester",
+				Host:     "localhost",
+				Query:    "SELECT * FROM dolt_query_diff('SELECT pk FROM test', 'SELECT pk FROM test');",
+				Expected: []sql.Row{},
+			},
+			// Query touching test2 which tester has no access to -> denied
+			{
+				User:        "tester",
+				Host:        "localhost",
+				Query:       "SELECT * FROM dolt_query_diff('SELECT pk FROM test2', 'SELECT pk FROM test2');",
+				ExpectedErr: sql.ErrTableAccessDeniedForUser,
+			},
+			// JOIN touching both tables, but only test is granted -> denied
+			{
+				User:        "tester",
+				Host:        "localhost",
+				Query:       "SELECT * FROM dolt_query_diff('SELECT t.pk FROM test t JOIN test2 t2 ON t.pk = t2.pk', 'SELECT t.pk FROM test t JOIN test2 t2 ON t.pk = t2.pk');",
+				ExpectedErr: sql.ErrTableAccessDeniedForUser,
+			},
+			// query1 touches test (allowed), query2 touches test2 (denied) -> denied
+			{
+				User:        "tester",
+				Host:        "localhost",
+				Query:       "SELECT * FROM dolt_query_diff('SELECT pk FROM test', 'SELECT pk FROM test2');",
+				ExpectedErr: sql.ErrTableAccessDeniedForUser,
+			},
+			// Subquery referencing test2 -> denied
+			{
+				User:        "tester",
+				Host:        "localhost",
+				Query:       "SELECT * FROM dolt_query_diff('SELECT pk FROM (SELECT pk FROM test2) s', 'SELECT pk FROM test');",
+				ExpectedErr: sql.ErrTableAccessDeniedForUser,
+			},
+			// Query with no table references -> allowed
+			{
+				User:     "tester",
+				Host:     "localhost",
+				Query:    "SELECT * FROM dolt_query_diff('SELECT 1 AS pk', 'SELECT 2 AS pk');",
+				Expected: []sql.Row{{1, 2, "modified"}},
+			},
+			// Now grant test2 as well
+			{
+				User:     "root",
+				Host:     "localhost",
+				Query:    "GRANT SELECT ON mydb.test2 TO tester@localhost;",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			// JOIN touching both tables -> now allowed
+			{
+				User:     "tester",
+				Host:     "localhost",
+				Query:    "SELECT * FROM dolt_query_diff('SELECT t.pk FROM test t JOIN test2 t2 ON t.pk = t2.pk', 'SELECT t.pk FROM test t JOIN test2 t2 ON t.pk = t2.pk');",
+				Expected: []sql.Row{},
+			},
+			// Cross-table query args -> now allowed
+			{
+				User:  "tester",
+				Host:  "localhost",
+				Query: "SELECT * FROM dolt_query_diff('SELECT pk FROM test limit 1', 'SELECT pk FROM test2 limit 1');",
+				Expected: []sql.Row{{1, nil, "deleted"}, {nil, 1, "added"}},
+			},
+			// Subquery referencing test2 -> now allowed
+			{
+				User:     "tester",
+				Host:     "localhost",
+				Query:    "SELECT * FROM dolt_query_diff('SELECT pk FROM (SELECT pk FROM test2) s', 'SELECT pk FROM (SELECT pk FROM test) s');",
+				Expected: []sql.Row{},
+			},
+			// Revoke test2, verify denial again
+			{
+				User:     "root",
+				Host:     "localhost",
+				Query:    "REVOKE SELECT ON mydb.test2 FROM tester@localhost;",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				User:        "tester",
+				Host:        "localhost",
+				Query:       "SELECT * FROM dolt_query_diff('SELECT pk FROM test2', 'SELECT pk FROM test2');",
+				ExpectedErr: sql.ErrTableAccessDeniedForUser,
+			},
+		},
+	},
+	{
+		Name: "dolt_query_diff privilege checking with qualified table names",
+		SetUpScript: []string{
+			"CREATE TABLE test (pk BIGINT PRIMARY KEY, col1 varchar(20));",
+			"INSERT INTO test VALUES (1, 'first row'), (2, 'second row');",
+			"CREATE TABLE test2 (pk BIGINT PRIMARY KEY, col1 varchar(20));",
+			"INSERT INTO test2 VALUES (1, 'a'), (2, 'b');",
+			"call dolt_commit('-Am', 'first commit');",
+			"CREATE USER tester@localhost;",
+			"call dolt_branch('b1');",
+			"use mydb/b1;",
+			"GRANT SELECT ON mydb.test TO tester@localhost;",
+		},
+		Assertions: []queries.UserPrivilegeTestAssertion{
+			// Database-qualified table name: mydb.test -> allowed
+			{
+				User:     "tester",
+				Host:     "localhost",
+				Query:    "SELECT * FROM dolt_query_diff('SELECT pk FROM mydb.test', 'SELECT pk FROM mydb.test');",
+				Expected: []sql.Row{},
+			},
+			// Database-qualified table name: mydb.test2 -> denied
+			{
+				User:        "tester",
+				Host:        "localhost",
+				Query:       "SELECT * FROM dolt_query_diff('SELECT pk FROM mydb.test2', 'SELECT pk FROM mydb.test2');",
+				ExpectedErr: sql.ErrTableAccessDeniedForUser,
+			},
+			// Branch-qualified table name using backticks: `mydb/b1`.test -> allowed
+			{
+				User:     "tester",
+				Host:     "localhost",
+				Query:    "SELECT * FROM dolt_query_diff('SELECT pk FROM `mydb/b1`.test', 'SELECT pk FROM `mydb/b1`.test');",
+				Expected: []sql.Row{},
+			},
+			// Branch-qualified table name for denied table: `mydb/b1`.test2 -> denied
+			{
+				User:        "tester",
+				Host:        "localhost",
+				Query:       "SELECT * FROM dolt_query_diff('SELECT pk FROM `mydb/b1`.test2', 'SELECT pk FROM `mydb/b1`.test2');",
+				ExpectedErr: sql.ErrTableAccessDeniedForUser,
+			},
+			// Mixed: one arg qualified, one unqualified
+			{
+				User:  "tester",
+				Host:  "localhost",
+				Query: "SELECT * FROM dolt_query_diff('SELECT pk FROM mydb.test', 'SELECT pk FROM test');",
+				Expected: []sql.Row{
+					{1, nil, "deleted"}, {2, nil, "deleted"},
+					{nil, 1, "added"}, {nil, 2, "added"},
+				},
+			},
+			// JOIN with database-qualified table names, missing test2 privilege
+			{
+				User:        "tester",
+				Host:        "localhost",
+				Query:       "SELECT * FROM dolt_query_diff('SELECT t.pk FROM mydb.test t JOIN mydb.test2 t2 ON t.pk = t2.pk', 'SELECT t.pk FROM mydb.test t JOIN mydb.test2 t2 ON t.pk = t2.pk');",
+				ExpectedErr: sql.ErrTableAccessDeniedForUser,
+			},
+			// Grant test2 and verify qualified JOIN works
+			{
+				User:     "root",
+				Host:     "localhost",
+				Query:    "GRANT SELECT ON mydb.test2 TO tester@localhost;",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				User:     "tester",
+				Host:     "localhost",
+				Query:    "SELECT * FROM dolt_query_diff('SELECT t.pk FROM mydb.test t JOIN mydb.test2 t2 ON t.pk = t2.pk', 'SELECT t.pk FROM mydb.test t JOIN mydb.test2 t2 ON t.pk = t2.pk');",
 				Expected: []sql.Row{},
 			},
 		},


### PR DESCRIPTION
- This PR modifies the auth checks of `dolt_query_diff` to scope them to only the tables referenced in queries.
- This is done by walking through both of the expressions in the input, getting the tables referenced in these expressions, and finally checking if the user is able to access the aforementioned tables

Also adds new tests, specifically those that include input queries involving revision qualified tables

Closes https://github.com/dolthub/dolt/issues/10701