### PR TITLE
[no-release-notes] integration-tests/bats: Cleanup some background process lifecycle and teardown ordering warts.

### DIFF
--- a/integration-tests/bats/branch-activity.bats
+++ b/integration-tests/bats/branch-activity.bats
@@ -2,6 +2,8 @@
 load $BATS_TEST_DIRNAME/helper/common.bash
 load $BATS_TEST_DIRNAME/helper/query-server-common.bash
 
+BG_PIDS=()
+
 setup() {
     setup_no_dolt_init
 
@@ -47,6 +49,11 @@ EOF
 
 teardown() {
     stop_sql_server 1
+    for pid in "${BG_PIDS[@]}"; do
+        kill $pid 2>/dev/null || true
+        wait $pid 2>/dev/null || true
+    done
+    BG_PIDS=()
     teardown_common
 }
 
@@ -55,8 +62,8 @@ start_idle_connection() {
     local branch=$1
     [ -n "$branch" ] || fail "Expected non-empty string, got empty"
 
-    # Do nothing connection. These will be killed by the server shutting down.
     dolt --use-db "repo1/$branch" sql -q "SELECT SLEEP(60)" &
+    BG_PIDS+=($!)
 }
 
 @test "branch-activity: last_read set for connections" {
@@ -131,6 +138,7 @@ start_idle_connection() {
     start_idle_connection "feature1"
     # Same for repo2, should result in read on dev
     dolt --use-db "repo2/dev" sql -q "SELECT SLEEP(60)" &
+    BG_PIDS+=($!)
     sleep 1
 
     run dolt --use-db repo1 sql -q "SELECT branch FROM dolt_branch_activity WHERE last_read IS NOT NULL"

--- a/integration-tests/bats/branch-control.bats
+++ b/integration-tests/bats/branch-control.bats
@@ -8,7 +8,7 @@ setup() {
 
 teardown() {
     assert_feature_version
-    stop_sql_server
+    stop_sql_server 1
     teardown_common
 }
 

--- a/integration-tests/bats/cli-hosted.bats
+++ b/integration-tests/bats/cli-hosted.bats
@@ -60,7 +60,7 @@ setup() {
 }
 
 teardown() {
-    stop_sql_server
+    stop_sql_server 1
     teardown_common
 }
 

--- a/integration-tests/bats/clone-drop.bats
+++ b/integration-tests/bats/clone-drop.bats
@@ -6,7 +6,7 @@ setup() {
 }
 
 teardown() {
-  stop_sql_server
+  stop_sql_server 1
   assert_feature_version
   teardown_common
 }

--- a/integration-tests/bats/config.bats
+++ b/integration-tests/bats/config.bats
@@ -10,9 +10,9 @@ setup() {
 }
 
 teardown() {
+    stop_sql_server 1
     teardown_common
     rm -rf "$BATS_TMPDIR/config-test$$"
-    stop_sql_server
 }
 
 function no_stderr {

--- a/integration-tests/bats/debug.bats
+++ b/integration-tests/bats/debug.bats
@@ -32,8 +32,8 @@ SQL
 }
 
 teardown() {
-    teardown_common
     stop_sql_server 1
+    teardown_common
     rm -rf $TMPDIRS
     cd $BATS_TMPDIR
 }

--- a/integration-tests/bats/deleted-branches.bats
+++ b/integration-tests/bats/deleted-branches.bats
@@ -10,8 +10,8 @@ setup() {
 }
 
 teardown() {
+    stop_sql_server 1
     teardown_common
-    stop_sql_server
 }
 
 make_it() {

--- a/integration-tests/bats/garbage_collection.bats
+++ b/integration-tests/bats/garbage_collection.bats
@@ -17,10 +17,10 @@ setup() {
 }
 
 teardown() {
-    teardown_common
     kill $remotesrv_pid
     wait $remotesrv_pid || :
     remotesrv_pid=""
+    teardown_common
     rm -rf $BATS_TMPDIR/remotes-$$
 }
 

--- a/integration-tests/bats/helper/query-server-common.bash
+++ b/integration-tests/bats/helper/query-server-common.bash
@@ -151,11 +151,9 @@ stop_sql_server() {
     wait=$1
     if [ ! -z "$SERVER_PID" ]; then
         # ignore failures of kill command in the case the server is already dead
-        run kill $SERVER_PID
+        kill $SERVER_PID || :
         if [ $wait ]; then
-            while ps -p $SERVER_PID > /dev/null; do
-                sleep .1;
-            done
+            wait $SERVER_PID || :
         fi;
     fi
     SERVER_PID=

--- a/integration-tests/bats/multidb.bats
+++ b/integration-tests/bats/multidb.bats
@@ -21,7 +21,7 @@ init_helper() {
 }
 
 teardown() {
-    stop_sql_server
+    stop_sql_server 1
     teardown_common
     rm -rf $TMPDIRS
     cd $BATS_TMPDIR

--- a/integration-tests/bats/processlist.bats
+++ b/integration-tests/bats/processlist.bats
@@ -5,7 +5,14 @@ setup() {
     setup_common
 }
 
+SLEEP_PID=
+
 teardown() {
+    if [ -n "$SLEEP_PID" ]; then
+        kill $SLEEP_PID 2>/dev/null || true
+        wait $SLEEP_PID 2>/dev/null || true
+        SLEEP_PID=
+    fi
     teardown_common
 }
 
@@ -15,6 +22,7 @@ teardown() {
     fi
 
     dolt sql -q "select sleep(1000)" &
+    SLEEP_PID=$!
     sleep 1
 
     run dolt sql -q "SHOW PROCESSLIST"

--- a/integration-tests/bats/remotes-push-pull.bats
+++ b/integration-tests/bats/remotes-push-pull.bats
@@ -16,10 +16,10 @@ setup() {
 }
 
 teardown() {
-    teardown_common
     kill $remotesrv_pid
     wait $remotesrv_pid || :
     remotesrv_pid=""
+    teardown_common
     rm -rf $BATS_TMPDIR/remotes-$$
 }
 

--- a/integration-tests/bats/remotes.bats
+++ b/integration-tests/bats/remotes.bats
@@ -16,10 +16,10 @@ setup() {
 }
 
 teardown() {
-    teardown_common
     kill $remotesrv_pid
     wait $remotesrv_pid || :
     remotesrv_pid=""
+    teardown_common
     rm -rf $BATS_TMPDIR/remotes-$$
 }
 

--- a/integration-tests/bats/replication-multidb.bats
+++ b/integration-tests/bats/replication-multidb.bats
@@ -46,7 +46,7 @@ push_helper() {
 }
 
 teardown() {
-    stop_sql_server
+    stop_sql_server 1
     teardown_common
     rm -rf $TMPDIRS
     cd $BATS_TMPDIR

--- a/integration-tests/bats/replication.bats
+++ b/integration-tests/bats/replication.bats
@@ -19,11 +19,10 @@ setup() {
 }
 
 teardown() {
+    stop_sql_server 1
     teardown_common
     rm -rf $TMPDIRS
     cd $BATS_TMPDIR
-
-    stop_sql_server
 }
 
 @test "replication: configuration errors" {

--- a/integration-tests/bats/sql-load-data.bats
+++ b/integration-tests/bats/sql-load-data.bats
@@ -7,7 +7,7 @@ setup() {
 }
 
 teardown() {
-    stop_sql_server
+    stop_sql_server 1
     assert_feature_version
     teardown_common
 }

--- a/integration-tests/bats/sql-server-config-file-generation.bats
+++ b/integration-tests/bats/sql-server-config-file-generation.bats
@@ -18,7 +18,7 @@ setup() {
 }
 
 teardown() {
-    stop_sql_server
+    stop_sql_server 1
     teardown_common
 }
 

--- a/integration-tests/bats/sql-server-remotesrv.bats
+++ b/integration-tests/bats/sql-server-remotesrv.bats
@@ -14,14 +14,18 @@ setup() {
 }
 
 teardown() {
-    stop_sql_server
-    teardown_common
+    stop_sql_server 1
     if [ -n "$srv_pid" ]; then
         kill $srv_pid
+        wait $srv_pid || :
+        srv_pid=
     fi
     if [ -n "$srv_two_pid" ]; then
         kill $srv_two_pid
+        wait $srv_two_pid || :
+        srv_two_pid=
     fi
+    teardown_common
 }
 
 @test "sql-server-remotesrv: can read from sql-server with --remotesapi-port" {

--- a/integration-tests/bats/stats.bats
+++ b/integration-tests/bats/stats.bats
@@ -35,8 +35,8 @@ SQL
 }
 
 teardown() {
-    teardown_common
     stop_sql_server 1
+    teardown_common
     rm -rf $TMPDIRS
     cd $BATS_TMPDIR
 }


### PR DESCRIPTION
Every now-and-then a bats test would fail with a panic from a kill'd-and-wait'd background process whose dolt database directory had been deleted out from under it before it was asked to shutdown. This is a cleanup where we make sure to always kill and wait background children we spawn before the test ends, and we do it before teardown_common / rm -rf test dirs happens.