### PR TITLE
go/store/nbs: archive_writer.go: Make an archive file's name (more) dependent on its contents, more closely matching the behavior of table file names.

### DIFF
--- a/go/store/nbs/archive.go
+++ b/go/store/nbs/archive.go
@@ -18,6 +18,9 @@ import (
 	"crypto/md5"
 	"crypto/sha512"
 	"errors"
+	"time"
+
+	"github.com/dolthub/dolt/go/store/hash"
 )
 
 /*
@@ -222,9 +225,22 @@ const ( //amdk = Archive Metadata Data Key
 	// The id of the table file that the archive was created from. This value can be used during the reverse process
 	// to quickly get back to the original table file if it is still available.
 	amdkOriginTableFile = "origin_table_file"
+	// The names of the source files that were conjoined to create this archive.
+	amdkConjoinedFileNames = "conjoined_file_names"
 	// The timestamp of when the archive was created.
 	amdkConversionTime = "conversion_time"
 )
+
+// archiveOrigin describes the provenance of an archive file.
+type archiveOrigin struct {
+	// ConvertedTableFileName is set when the archive was created by converting a single table file.
+	ConvertedTableFileName hash.Hash
+	// ConjoinedFileNames is set when the archive was created by conjoining multiple files.
+	ConjoinedFileNames []string
+	// ConversionTime is the timestamp of when the archive was created. Only set for
+	// table-file-to-archive conversions. When zero, the field is omitted from metadata.
+	ConversionTime time.Time
+}
 
 var ErrInvalidChunkRange = errors.New("invalid chunk range")
 var ErrInvalidDictionaryRange = errors.New("invalid dictionary range")

--- a/go/store/nbs/archive_build.go
+++ b/go/store/nbs/archive_build.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/dolthub/gozstd"
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -338,7 +339,10 @@ func indexFinalizeFlushArchive(arcW *archiveWriter, archivePath string, originTa
 	if err != nil {
 		return err
 	}
-	err = arcW.indexFinalize(originTableFile)
+	err = arcW.indexFinalize(archiveOrigin{
+		ConvertedTableFileName: originTableFile,
+		ConversionTime:         time.Now(),
+	})
 	if err != nil {
 		return err
 	}

--- a/go/store/nbs/archive_test.go
+++ b/go/store/nbs/archive_test.go
@@ -1177,6 +1177,58 @@ func assertIntBetween(t *testing.T, actual, min, max int) {
 	}
 }
 
+// TestArchiveDifferentByteSpanOrderProducesDifferentName verifies that two archives containing the same chunks but with
+// different byte span layouts produce different archive names. This is important because the archive name must reflect
+// the data layout, not just the set of chunks. If two archives have the same name but different layouts, a cached index
+// from one will issue wrong byte-range requests against the other.
+func TestArchiveDifferentByteSpanOrderProducesDifferentName(t *testing.T) {
+	// Use deterministic hashes so both archives have the exact same chunks.
+	h1 := hash.Parse("00000000000000000001v5dsk056s012")
+	h2 := hash.Parse("00000000000000000002v5dsk056s012")
+
+	dict := defaultDict
+	data1 := []byte{11, 11, 11, 11, 11, 11, 11, 11, 11, 11}
+	data2 := []byte{22, 22, 22, 22, 22, 22, 22, 22, 22, 22}
+
+	// Archive A: write data1 first, then data2.
+	awA := newArchiveWriterWithSink(NewFixedBufferByteSink(make([]byte, 64*1024)))
+	dictIdA, err := awA.writeByteSpan(dict)
+	require.NoError(t, err)
+	d1IdA, err := awA.writeByteSpan(data1)
+	require.NoError(t, err)
+	d2IdA, err := awA.writeByteSpan(data2)
+	require.NoError(t, err)
+	require.NoError(t, awA.stageZStdChunk(h1, dictIdA, d1IdA))
+	require.NoError(t, awA.stageZStdChunk(h2, dictIdA, d2IdA))
+	require.NoError(t, awA.finalizeByteSpans())
+	require.NoError(t, awA.writeIndex())
+	require.NoError(t, awA.writeMetadata([]byte("")))
+	require.NoError(t, awA.writeFooter())
+	nameA, err := awA.getName()
+	require.NoError(t, err)
+
+	// Archive B: write data2 first, then data1 — same chunks, reversed byte span order.
+	awB := newArchiveWriterWithSink(NewFixedBufferByteSink(make([]byte, 64*1024)))
+	dictIdB, err := awB.writeByteSpan(dict)
+	require.NoError(t, err)
+	d2IdB, err := awB.writeByteSpan(data2)
+	require.NoError(t, err)
+	d1IdB, err := awB.writeByteSpan(data1)
+	require.NoError(t, err)
+	require.NoError(t, awB.stageZStdChunk(h1, dictIdB, d1IdB))
+	require.NoError(t, awB.stageZStdChunk(h2, dictIdB, d2IdB))
+	require.NoError(t, awB.finalizeByteSpans())
+	require.NoError(t, awB.writeIndex())
+	require.NoError(t, awB.writeMetadata([]byte("")))
+	require.NoError(t, awB.writeFooter())
+	nameB, err := awB.getName()
+	require.NoError(t, err)
+
+	// The byte span IDs for h1 and h2 differ between A and B because the data was written in
+	// different order. The archive name must reflect this difference.
+	require.NotEqual(t, nameA, nameB, "archives with same chunks but different byte span layouts must have different names")
+}
+
 // Helper functions to create test data below...
 func hashWithPrefix(t *testing.T, prefix uint64) hash.Hash {
 	randomBytes := make([]byte, 20)

--- a/go/store/nbs/archive_writer.go
+++ b/go/store/nbs/archive_writer.go
@@ -78,7 +78,7 @@ type archiveWriter struct {
 	indexLen        uint64
 	chunkDataLength uint64
 	metadataLen     uint32
-	suffixCheckSum  sha512Sum
+	nameCheckSum    sha512Sum
 	fullMD5         md5Sum
 }
 
@@ -120,7 +120,7 @@ func newArchiveWriter(tmpDir string) (*archiveWriter, error) {
 	}, nil
 }
 
-// newArchiveWriter - Create an *archiveWriter with the given output ByteSync.
+// newArchiveWriterWithSink creates an *archiveWriter with the given output ByteSink.
 func newArchiveWriterWithSink(bs ByteSink) *archiveWriter {
 	hbMd5 := NewMD5HashingByteSink(bs)
 	hbSha := NewSHA512HashingByteSink(hbMd5)
@@ -204,18 +204,30 @@ func (aw *archiveWriter) stageSnappyChunk(hash hash.Hash, dataId uint32) error {
 	return nil
 }
 
-func (aw *archiveWriter) indexFinalize(originTableFile hash.Hash) error {
+func (aw *archiveWriter) indexFinalize(origin archiveOrigin) error {
 	err := aw.writeIndex()
 	if err != nil {
 		return err
 	}
 
 	meta := map[string]string{
-		amdkDoltVersion:    doltversion.Version,
-		amdkConversionTime: time.Now().UTC().Format(time.RFC3339),
+		amdkDoltVersion: doltversion.Version,
 	}
-	if !originTableFile.IsEmpty() {
-		meta[amdkOriginTableFile] = originTableFile.String()
+	if !origin.ConversionTime.IsZero() {
+		meta[amdkConversionTime] = origin.ConversionTime.UTC().Format(time.RFC3339)
+	}
+	if !origin.ConvertedTableFileName.IsEmpty() {
+		meta[amdkOriginTableFile] = origin.ConvertedTableFileName.String()
+	}
+	if len(origin.ConjoinedFileNames) > 0 {
+		// Encode the slice as a JSON string value rather than a JSON array so that
+		// the metadata payload stays map[string]string. Older Dolt clients unmarshal
+		// metadata into map[string]string and would fail on a raw JSON array value.
+		joined, err := json.Marshal(origin.ConjoinedFileNames)
+		if err != nil {
+			return err
+		}
+		meta[amdkConjoinedFileNames] = string(joined)
 	}
 
 	jsonData, err := json.Marshal(meta)
@@ -312,8 +324,7 @@ func (aw *archiveWriter) writeIndex() error {
 		}
 	}
 
-	// Suffixes output. This data is used to create the name for this archive.
-	aw.output.ResetHasher()
+	// Suffixes output.
 	for _, scr := range aw.stagedChunks {
 		_, err := aw.output.Write(scr.hash.Suffix())
 		if err != nil {
@@ -323,16 +334,14 @@ func (aw *archiveWriter) writeIndex() error {
 	dataWritten := uint64(len(aw.stagedChunks)) * hash.SuffixLen
 	aw.bytesWritten += dataWritten
 	aw.indexLen = aw.bytesWritten - indexStart
-	aw.suffixCheckSum = sha512Sum(aw.output.GetSum())
 
-	aw.output.ResetHasher()
 	aw.workflowStage = stageMetadata
 
 	return nil
 }
 
-// writeMetadata writes the metadataSpan to the archive. Expects the hasher to be reset before be called, and will reset it.
-// It sets the metadataLen and metadataCheckSum fields on the archiveWriter, and updates the bytesWritten field.
+// writeMetadata writes the metadataSpan to the archive.
+// It sets the metadataLen field on the archiveWriter, and updates the bytesWritten field.
 //
 // Empty input is allowed.
 func (aw *archiveWriter) writeMetadata(data []byte) error {
@@ -406,6 +415,7 @@ func (aw *archiveWriter) writeFooter() error {
 	aw.bytesWritten += archiveFileSigSize
 	aw.workflowStage = stageFlush
 
+	aw.nameCheckSum = sha512Sum(aw.output.GetSum())
 	aw.fullMD5 = md5Sum(aw.md5Summer.GetSum())
 
 	return nil
@@ -477,7 +487,7 @@ func (aw *archiveWriter) getName() (hash.Hash, error) {
 		return hash.Hash{}, fmt.Errorf("Runtime error: getName called out of order")
 	}
 
-	return hash.New(aw.suffixCheckSum[:hash.ByteLen]), nil
+	return hash.New(aw.nameCheckSum[:hash.ByteLen]), nil
 }
 
 // genFileName generates the file name for the archive. The path argument is the directory where the file should be written.
@@ -562,7 +572,7 @@ func (asw *ArchiveStreamWriter) Finish() (uint32, string, error) {
 	if err != nil {
 		return 0, "", err
 	}
-	err = asw.writer.indexFinalize(hash.Hash{})
+	err = asw.writer.indexFinalize(archiveOrigin{})
 	if err != nil {
 		return 0, "", err
 	}
@@ -962,6 +972,12 @@ func planArchiveConjoin(ctx context.Context, sources []sourceWithSize, q MemoryQ
 		aw.bytesWritten += src.dataLen
 	}
 
+	// Collect the names of the conjoined source files.
+	conjoinedNames := make([]string, 0, len(orderedSrcs.sws))
+	for _, src := range orderedSrcs.sws {
+		conjoinedNames = append(conjoinedNames, src.source.hash().String())
+	}
+
 	// Preserve this for stat reporting as aw.bytesWritten will be updated as we write the index.
 	dataBlocksLen := aw.bytesWritten
 
@@ -972,7 +988,7 @@ func planArchiveConjoin(ctx context.Context, sources []sourceWithSize, q MemoryQ
 	// So we set the workflow stage to stageIndex because we skipped the byte span insertion stage.
 	aw.workflowStage = stageIndex
 
-	err = aw.indexFinalize(hash.Hash{})
+	err = aw.indexFinalize(archiveOrigin{ConjoinedFileNames: conjoinedNames})
 	if err != nil {
 		return compactionPlan{}, fmt.Errorf("failed to finalize archive: %w", err)
 	}

--- a/go/store/nbs/archive_writer.go
+++ b/go/store/nbs/archive_writer.go
@@ -78,7 +78,7 @@ type archiveWriter struct {
 	indexLen        uint64
 	chunkDataLength uint64
 	metadataLen     uint32
-	nameCheckSum    sha512Sum
+	nameCheckSum    hash.Hash
 	fullMD5         md5Sum
 }
 
@@ -415,7 +415,8 @@ func (aw *archiveWriter) writeFooter() error {
 	aw.bytesWritten += archiveFileSigSize
 	aw.workflowStage = stageFlush
 
-	aw.nameCheckSum = sha512Sum(aw.output.GetSum())
+	checksum := sha512Sum(aw.output.GetSum())
+	aw.nameCheckSum = hash.New(checksum[:hash.ByteLen])
 	aw.fullMD5 = md5Sum(aw.md5Summer.GetSum())
 
 	return nil
@@ -487,7 +488,7 @@ func (aw *archiveWriter) getName() (hash.Hash, error) {
 		return hash.Hash{}, fmt.Errorf("Runtime error: getName called out of order")
 	}
 
-	return hash.New(aw.nameCheckSum[:hash.ByteLen]), nil
+	return aw.nameCheckSum, nil
 }
 
 // genFileName generates the file name for the archive. The path argument is the directory where the file should be written.


### PR DESCRIPTION
Table files are named based on a hash of their suffixes array. And their suffixes array is stored in insertion order. And their suffixes arrays reflect every "byte span" in the file. So the table files are named based on their chunks and their chunks' order in the file.

Archive files used to be named based on a hash of their suffixes array as well. But their suffixes are stored sorted by chunk address. And they have dictionaries and stuff which aren't reflected in the suffixes array at all. So their names were dependent on the chunks they stored, but not fully dependent on their data section, and not even dependent on the order of their chunks within their data section.

All existing TableFilePersisters are happy to overwrite files. The assumption is that the files themselves are named based on their contents and any version of it is as good as any other. For archives, that meant that two archives containing the same chunks but in a different order or with different dictionaries would get the same name and potentially cause misbehavior when one version changed out for another from underneath a Dolt.

This change makes archive names much more data dependent. Their entire contents go into the file name, including the metadata payload. We changed the metadata payload to record source that contributed to the conjoin, when the archive is the result of a conjoin. The metadata payload also always includes the Dolt version. So this makes archive names much less deterministic across versions and provenance, but with the exact some contents, than their table file counterparts. However, deterministically building table files as part of pull/push or GC is not really a thing, and things are already written in a non-deterministic order on basically all write paths. So this is not deemed to be a concern.