### PR TITLE
fsck better

### DIFF
--- a/go/cmd/dolt/commands/fsck.go
+++ b/go/cmd/dolt/commands/fsck.go
@@ -126,13 +126,13 @@ func (cmd FsckCmd) Exec(ctx context.Context, commandStr string, args []string, d
 	// over a channel to a separate goroutine that handles printing them (so that progress can be reported while fsck is running).
 	// The error report is built up in a slice of errors that is passed around and appended to as issues are found.
 	progress := make(chan FsckProgressMessage, 32)
-	var errs Errs
+	var report FsckReport
 
 	params := make(map[string]interface{})
 	params[dbfactory.ChunkJournalParam] = struct{}{}
 	dbFact := dbfactory.FileFactory{}
 	ddb, _, _, err := dbFact.CreateDbNoCache(ctx, types.Format_Default, u, params, func(vErr error) {
-		errs.AppendE(vErr)
+		report.ScanErrs.AppendE(vErr)
 	})
 	if err != nil {
 		if errors.Is(err, nbs.ErrJournalDataLoss) {
@@ -160,7 +160,7 @@ func (cmd FsckCmd) Exec(ctx context.Context, commandStr string, args []string, d
 
 	terminate = func() bool {
 		defer close(progress)
-		err := fsckOnChunkStore(ctx, gs, &errs, progress)
+		err := fsckOnChunkStore(ctx, gs, &report, progress)
 		if err != nil {
 			// When FSCK errors, it's unexpected. As in corruption can be found and we shouldn't get an error here.
 			// So we print the error and not the report.
@@ -183,7 +183,7 @@ func (cmd FsckCmd) Exec(ctx context.Context, commandStr string, args []string, d
 		return 1
 	}
 
-	return errs.PrintAll()
+	return report.Print()
 }
 
 func reviveJournalWithDataLoss(dEnv *env.DoltEnv) int {
@@ -224,18 +224,51 @@ func (e *Errs) AppendE(err error) {
 	*e = append(*e, err)
 }
 
-func (e *Errs) PrintAll() int {
-	if len(*e) == 0 {
-		cli.Println("No problems found.")
-		return 0
-	} else {
-		for _, err := range *e {
-			cli.Println(color.RedString("------ Corruption Found ------"))
+// FsckReport collects errors from each phase of the fsck scan and prints them in a structured order:
+// first individual chunk errors, then a per-file summary, then commit-level errors, then the scan summary.
+type FsckReport struct {
+	ScanErrs      Errs
+	FileErrCounts map[string]int // physical file name -> number of corrupt chunks
+	CommitErrs    Errs
+	Summary       []string // informational summary lines printed last
+}
+
+func (r *FsckReport) AppendSummary(format string, args ...any) {
+	r.Summary = append(r.Summary, fmt.Sprintf(format, args...))
+}
+
+func (r *FsckReport) Print() int {
+	hasErrors := len(r.ScanErrs) > 0 || len(r.CommitErrs) > 0
+
+	if len(r.ScanErrs) > 0 {
+		cli.Println(color.RedString("============ Corrupt Chunks ============"))
+		for _, err := range r.ScanErrs {
 			cli.Println(err.Error())
 		}
+	}
 
+	if len(r.CommitErrs) > 0 {
+		cli.Println(color.RedString("============ Commit Errors ============"))
+		for _, err := range r.CommitErrs {
+			cli.Println(err.Error())
+		}
+	}
+
+	if len(r.Summary) > 0 {
+		cli.Println("============ Summary ============")
+		for _, line := range r.Summary {
+			cli.Println(line)
+		}
+	}
+
+	if !hasErrors {
+		cli.Println("No problems found.")
+	}
+
+	if hasErrors {
 		return 1
 	}
+	return 0
 }
 
 // ProgressReporter is a channel for reporting progress messages during fsck. There is a dedicated goroutine that
@@ -369,8 +402,9 @@ func fsckHandleProgress(ctx context.Context, progress ProgressReporter, quiet bo
 // so that a full report can be generated. Errors encountered during processing are appended to the |errs| object. Only
 // when there is an unexpected failure (such as inability to open a storage file) is an error returned. In that situation,
 // we halt processing.
-func fsckOnChunkStore(ctx context.Context, gs *nbs.GenerationalNBS, errs *Errs, progress ProgressReporter) error {
-	rt, err := newRoundTripper(ctx, gs, progress, errs)
+func fsckOnChunkStore(ctx context.Context, gs *nbs.GenerationalNBS, report *FsckReport, progress ProgressReporter) error {
+	report.FileErrCounts = make(map[string]int)
+	rt, err := newRoundTripper(ctx, gs, progress, &report.ScanErrs, report.FileErrCounts)
 	if err != nil {
 		return fmt.Errorf("failed to initialize FSCK round tripper: %w", err)
 	}
@@ -382,27 +416,15 @@ func fsckOnChunkStore(ctx context.Context, gs *nbs.GenerationalNBS, errs *Errs, 
 	chunkCount := rt.chunkCount
 	chunksByType := rt.chunksByType
 
-	// Report chunk type summary
-	progress.Milestone(ctx, "--------------- Chunk Type Summary ---------------")
-	for chunkType, hashes := range chunksByType {
-		progress.Milestonef(ctx, "Found %d chunks of type: %s", len(hashes), chunkType)
-	}
-
-	// Perform commit DAG validation from all branch HEADs and tags to identify unreachable chunks
-	progress.Milestone(ctx, "--------------- All Objects scanned. Starting commit validation ---------------")
-
 	// Find all commit objects from our scanned chunks
 	allCommitsSet := make(hash.HashSet)
 	if commitChunks, hasCommits := chunksByType[serial.CommitFileID]; hasCommits {
 		for _, commitHash := range commitChunks {
 			allCommitsSet.Insert(commitHash)
 		}
-		progress.Milestonef(ctx, "Found %d commit objects", len(allCommitsSet))
-	} else {
-		progress.Milestone(ctx, "No commit objects found during chunk scan")
 	}
 
-	reachableCommits, err := walkCommitDAGFromRefs(ctx, gs, &allCommitsSet, progress, errs)
+	reachableCommits, err := walkCommitDAGFromRefs(ctx, gs, &allCommitsSet, progress, &report.CommitErrs, report)
 	if err != nil {
 		return fmt.Errorf("commit DAG walking failed: %w", err)
 	}
@@ -413,12 +435,12 @@ func fsckOnChunkStore(ctx context.Context, gs *nbs.GenerationalNBS, errs *Errs, 
 
 		vs := types.NewValueStore(gs)
 
-		commitReachableChunks, err := validateCommitTrees(ctx, vs, gs, &reachableCommits, progress, errs)
+		commitReachableChunks, err := validateCommitTrees(ctx, vs, gs, &reachableCommits, progress, &report.CommitErrs)
 		if err != nil {
 			return fmt.Errorf("commit tree validation failed: %w", err)
 		}
 
-		// Report which commits are reachable vs unreachable from branches/tags.
+		// Collect summary stats.
 		unreachableCommits := 0
 		for commitHash := range allCommitsSet {
 			if !reachableCommits.Has(commitHash) {
@@ -427,10 +449,29 @@ func fsckOnChunkStore(ctx context.Context, gs *nbs.GenerationalNBS, errs *Errs, 
 		}
 		unreachableChunks := chunkCount - uint32(commitReachableChunks.Size())
 
-		progress.Milestonef(ctx, "Found %d unreachable commits (not reachable from any branch/tag)", unreachableCommits)
-		progress.Milestonef(ctx, "Validated %d chunks reachable by branches and tags (unreachable: %d)", commitReachableChunks.Size(), unreachableChunks)
+		report.AppendSummary("Commit objects found: %d (%d reachable from branches/tags, %d unreachable)", len(allCommitsSet), len(reachableCommits), unreachableCommits)
+		report.AppendSummary("Chunks reachable from branches/tags: %d (unreachable: %d)", commitReachableChunks.Size(), unreachableChunks)
+		if len(report.FileErrCounts) > 0 {
+			report.AppendSummary("Files with corruption:")
+			for fileName, count := range report.FileErrCounts {
+				report.AppendSummary("  %s: %d chunk(s) with checksum errors", fileName, count)
+			}
+		}
+		report.AppendSummary("Chunk type breakdown:")
+		for chunkType, hashes := range chunksByType {
+			report.AppendSummary("  %s: %d", chunkType, len(hashes))
+		}
 	} else {
-		progress.Milestone(ctx, "No branches or tags found. Skipping tree validation.")
+		report.AppendSummary("No branches or tags found.")
+		if len(report.FileErrCounts) > 0 {
+			report.AppendSummary("Files with corruption:")
+			for fileName, count := range report.FileErrCounts {
+				report.AppendSummary("  %s: %d chunk(s) with checksum errors", fileName, count)
+			}
+		}
+		for chunkType, hashes := range chunksByType {
+			report.AppendSummary("  %s: %d", chunkType, len(hashes))
+		}
 	}
 
 	return nil
@@ -444,12 +485,13 @@ type roundTripper struct {
 	chunkCount    uint32
 	progress      ProgressReporter
 	errs          *Errs
+	fileErrCounts map[string]int
 	allChunks     hash.HashSet
 	chunksByType  map[string][]hash.Hash
 	proccessedCnt uint32
 }
 
-func newRoundTripper(ctx context.Context, gs *nbs.GenerationalNBS, progress chan FsckProgressMessage, errs *Errs) (*roundTripper, error) {
+func newRoundTripper(ctx context.Context, gs *nbs.GenerationalNBS, progress chan FsckProgressMessage, errs *Errs, fileErrCounts map[string]int) (*roundTripper, error) {
 	chunkCount, err := gs.OldGen().Count()
 	if err != nil {
 		return nil, err
@@ -463,20 +505,22 @@ func newRoundTripper(ctx context.Context, gs *nbs.GenerationalNBS, progress chan
 	vs := types.NewValueStore(gs)
 
 	return &roundTripper{
-		ctx:          ctx,
-		vs:           vs,
-		gs:           gs,
-		chunkCount:   chunkCount,
-		progress:     progress,
-		errs:         errs,
-		allChunks:    make(hash.HashSet),
-		chunksByType: make(map[string][]hash.Hash),
+		ctx:           ctx,
+		vs:            vs,
+		gs:            gs,
+		chunkCount:    chunkCount,
+		progress:      progress,
+		errs:          errs,
+		fileErrCounts: fileErrCounts,
+		allChunks:     make(hash.HashSet),
+		chunksByType:  make(map[string][]hash.Hash),
 	}, nil
 }
 
 func (rt *roundTripper) scanAll(ctx context.Context) error {
-	rt.gs.TolerantIterateAllChunks(ctx, rt.roundTripAndCategorizeChunk, func(err error) {
-		rt.errs.AppendE(fmt.Errorf("chunk read error: %w", err))
+	rt.gs.TolerantIterateAllChunks(ctx, rt.roundTripAndCategorizeChunk, func(sourceFile string, err error) {
+		rt.errs.AppendE(err)
+		rt.fileErrCounts[sourceFile]++
 	})
 	return ctx.Err()
 }
@@ -615,6 +659,10 @@ func validateCommitTrees(
 		}
 	}
 
+	for closureCommit := range treeScnr.unreachableClosureCommits {
+		errs.AppendF("commit %s: unreachable but referenced in parent closure of reachable commits", closureCommit.String())
+	}
+
 	return reachableChunks, nil
 }
 
@@ -622,22 +670,27 @@ func validateCommitTrees(
 type treeScanner struct {
 	vs *types.ValueStore
 	ns tree.NodeStore
-	// avoid re-validation of chunks we've already seen. If the chunk hash is in this map, we've already validated it.
-	// If the value is non-nil, it indicates an error was found during prior validation.
-	history         map[hash.Hash]*error
+	// history tracks every chunk hash that has been enqueued for processing (or already processed).
+	// A hash present here means we've already visited it; skip it to avoid redundant validation and duplicate error messages.
+	history         hash.HashSet
 	errs            *Errs
 	reachableChunks *hash.HashSet
 	progress        chan FsckProgressMessage
+	// unreachableClosureCommits collects commits that appear in a reachable commit's parent closure but are not
+	// themselves reachable. Each such commit is gathered here rather than reported once per referencing ancestor,
+	// to avoid a flood of duplicate messages.
+	unreachableClosureCommits hash.HashSet
 }
 
 func newTreeScanner(vs *types.ValueStore, ns tree.NodeStore, reachableChunks *hash.HashSet, errs *Errs, progress chan FsckProgressMessage) *treeScanner {
 	return &treeScanner{
-		vs:              vs,
-		ns:              ns,
-		history:         make(map[hash.Hash]*error),
-		errs:            errs,
-		reachableChunks: reachableChunks,
-		progress:        progress,
+		vs:                        vs,
+		ns:                        ns,
+		history:                   make(hash.HashSet),
+		errs:                      errs,
+		reachableChunks:           reachableChunks,
+		progress:                  progress,
+		unreachableClosureCommits: make(hash.HashSet),
 	}
 }
 
@@ -727,7 +780,7 @@ func (ts *treeScanner) processCommitContent(
 
 							closureCommitAddr := key.Addr()
 							if !reachableCommits.Has(closureCommitAddr) {
-								_ = ts.errs.CmtAppendF(commitHash, "parent closure references unreachable commit %s", closureCommitAddr.String())
+								ts.unreachableClosureCommits.Insert(closureCommitAddr)
 							}
 						}
 					}
@@ -755,17 +808,14 @@ func (ts *treeScanner) validateTreeRoot(
 	treeHash hash.Hash,
 ) error {
 	// Skip if already processed. Root hashes rarely repeat, but possible if you revert to a previous state.
-	if e, ok := ts.history[treeHash]; ok {
-		if e != nil {
-			ts.errs.CmtAppendF(commitHash, "referenced chunk %s (duplicate error)", treeHash.String())
-		}
+	if ts.history.Has(treeHash) {
 		return nil
 	}
+	ts.history.Insert(treeHash)
 
 	treeValue, err := ts.vs.ReadValue(ctx, treeHash)
 	if err != nil || treeValue == nil {
-		err2 := ts.errs.CmtAppendF(commitHash, "failed to read tree %s: %w", treeHash.String(), err)
-		ts.history[treeHash] = &err2
+		_ = ts.errs.CmtAppendF(commitHash, "failed to read tree %s: %w", treeHash.String(), err)
 		return nil
 	}
 
@@ -798,37 +848,33 @@ func (ts *treeScanner) validateTree(
 		currentChunkHash := elem.Value.(hash.Hash)
 		workQueue.Remove(elem)
 
+		// Mark visited immediately so re-queued references from sibling nodes are skipped.
+		if ts.history.Has(currentChunkHash) {
+			continue
+		}
+		ts.history.Insert(currentChunkHash)
+
 		ts.reachableChunks.Insert(currentChunkHash)
 
 		value, err := ts.vs.MustReadValue(ctx, currentChunkHash)
 		if err != nil {
-			err2 := ts.errs.CmtAppendF(commitHash, "read failure of %s: %w", currentChunkHash.String(), err)
-			ts.history[currentChunkHash] = &err2
+			_ = ts.errs.CmtAppendF(commitHash, "read failure of %s: %w", currentChunkHash.String(), err)
 			continue
 		}
 
 		if serialMsg, ok := value.(types.SerialMessage); ok {
 			err := serialMsg.WalkAddrs(ts.vs.Format(), func(addr hash.Hash) error {
-				if e, ok := ts.history[addr]; ok {
-					if e != nil {
-						_ = ts.errs.CmtAppendF(commitHash, "referenced chunk %s (duplicate error)", addr.String())
-					}
-					// Already processed this chunk
+				if ts.history.Has(addr) {
+					// Already visited; skip.
 					return nil
 				}
-
 				workQueue.PushBack(addr)
-
 				return nil
 			})
 			if err != nil {
 				// We intentionally never return errors from WalkAddrs, so any error here is unexpected. Halt.
 				return fmt.Errorf("failed to walk references in tree %s: %w", treeHash.String(), err)
 			}
-
-			// We managed to load the current value and walk its references without error. Mark it as successfully processed.
-			ts.history[currentChunkHash] = nil
-
 		} else {
 			panic(fmt.Sprintf("commit::%s: referenced chunk %s from tree %s is not a SerialMessage, got type %T", commitHash.String(), currentChunkHash.String(), treeHash.String(), value))
 		}
@@ -839,7 +885,7 @@ func (ts *treeScanner) validateTree(
 
 // walkCommitDAGFromRefs loads all branches/tags and walks the commit DAG to find reachable commits
 // This is lightweight - only validates commit objects, parent closures, and parent hashes (no trees)
-func walkCommitDAGFromRefs(ctx context.Context, gs *nbs.GenerationalNBS, allCommits *hash.HashSet, progress ProgressReporter, errs *Errs) (hash.HashSet, error) {
+func walkCommitDAGFromRefs(ctx context.Context, gs *nbs.GenerationalNBS, allCommits *hash.HashSet, progress ProgressReporter, errs *Errs, report *FsckReport) (hash.HashSet, error) {
 	startingCommits, err := getRawReferencesFromStoreRoot(ctx, gs, errs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get references from store root: %w", err)
@@ -849,10 +895,9 @@ func walkCommitDAGFromRefs(ctx context.Context, gs *nbs.GenerationalNBS, allComm
 	for _, refs := range startingCommits {
 		refCount += len(refs)
 	}
-	progress.Milestonef(ctx, "Found %d refs pointing to %d unique starting commits", refCount, len(startingCommits))
+	report.AppendSummary("Refs found: %d pointing to %d unique starting commits", refCount, len(startingCommits))
 
 	if len(startingCommits) == 0 {
-		progress.Milestone(ctx, "No refs found - no commits are reachable")
 		return hash.HashSet{}, nil
 	}
 
@@ -900,8 +945,6 @@ func walkCommitDAGFromRefs(ctx context.Context, gs *nbs.GenerationalNBS, allComm
 			panic(fmt.Sprintf("::commit:%s: is not a SerialMessage, got type %T", commitHash.String(), commitValue))
 		}
 	}
-	progress.Milestonef(ctx, "Found %d commits reachable from branches/tags", len(reachableCommits))
-
 	return reachableCommits, nil
 }
 

--- a/go/cmd/dolt/commands/fsck.go
+++ b/go/cmd/dolt/commands/fsck.go
@@ -670,9 +670,9 @@ func validateCommitTrees(
 type treeScanner struct {
 	vs *types.ValueStore
 	ns tree.NodeStore
-	// history tracks every chunk hash that has been enqueued for processing (or already processed).
+	// visited tracks every chunk hash that has been enqueued for processing (or already processed).
 	// A hash present here means we've already visited it; skip it to avoid redundant validation and duplicate error messages.
-	history         hash.HashSet
+	visited         hash.HashSet
 	errs            *Errs
 	reachableChunks *hash.HashSet
 	progress        chan FsckProgressMessage
@@ -686,7 +686,7 @@ func newTreeScanner(vs *types.ValueStore, ns tree.NodeStore, reachableChunks *ha
 	return &treeScanner{
 		vs:                        vs,
 		ns:                        ns,
-		history:                   make(hash.HashSet),
+		visited:                   make(hash.HashSet),
 		errs:                      errs,
 		reachableChunks:           reachableChunks,
 		progress:                  progress,
@@ -808,10 +808,10 @@ func (ts *treeScanner) validateTreeRoot(
 	treeHash hash.Hash,
 ) error {
 	// Skip if already processed. Root hashes rarely repeat, but possible if you revert to a previous state.
-	if ts.history.Has(treeHash) {
+	if ts.visited.Has(treeHash) {
 		return nil
 	}
-	ts.history.Insert(treeHash)
+	ts.visited.Insert(treeHash)
 
 	treeValue, err := ts.vs.ReadValue(ctx, treeHash)
 	if err != nil || treeValue == nil {
@@ -849,10 +849,10 @@ func (ts *treeScanner) validateTree(
 		workQueue.Remove(elem)
 
 		// Mark visited immediately so re-queued references from sibling nodes are skipped.
-		if ts.history.Has(currentChunkHash) {
+		if ts.visited.Has(currentChunkHash) {
 			continue
 		}
-		ts.history.Insert(currentChunkHash)
+		ts.visited.Insert(currentChunkHash)
 
 		ts.reachableChunks.Insert(currentChunkHash)
 
@@ -864,7 +864,7 @@ func (ts *treeScanner) validateTree(
 
 		if serialMsg, ok := value.(types.SerialMessage); ok {
 			err := serialMsg.WalkAddrs(ts.vs.Format(), func(addr hash.Hash) error {
-				if ts.history.Has(addr) {
+				if ts.visited.Has(addr) {
 					// Already visited; skip.
 					return nil
 				}

--- a/go/cmd/dolt/commands/fsck.go
+++ b/go/cmd/dolt/commands/fsck.go
@@ -811,10 +811,11 @@ func (ts *treeScanner) validateTreeRoot(
 	if ts.visited.Has(treeHash) {
 		return nil
 	}
-	ts.visited.Insert(treeHash)
 
 	treeValue, err := ts.vs.ReadValue(ctx, treeHash)
 	if err != nil || treeValue == nil {
+		// Mark visited on error so a second commit sharing this root doesn't re-report the same error.
+		ts.visited.Insert(treeHash)
 		_ = ts.errs.CmtAppendF(commitHash, "failed to read tree %s: %w", treeHash.String(), err)
 		return nil
 	}

--- a/go/cmd/dolt/commands/fsck.go
+++ b/go/cmd/dolt/commands/fsck.go
@@ -475,15 +475,10 @@ func newRoundTripper(ctx context.Context, gs *nbs.GenerationalNBS, progress chan
 }
 
 func (rt *roundTripper) scanAll(ctx context.Context) error {
-	err := rt.gs.OldGen().IterateAllChunks(ctx, rt.roundTripAndCategorizeChunk)
-	if err != nil {
-		return err
-	}
-	err = rt.gs.NewGen().IterateAllChunks(ctx, rt.roundTripAndCategorizeChunk)
-	if err != nil {
-		return err
-	}
-	return nil
+	rt.gs.TolerantIterateAllChunks(ctx, rt.roundTripAndCategorizeChunk, func(err error) {
+		rt.errs.AppendE(fmt.Errorf("chunk read error: %w", err))
+	})
+	return ctx.Err()
 }
 
 // roundTripAndCategorizeChunk verifies the chunk's hash matches its content, categorizes it by type. This method is

--- a/go/store/chunks/chunk_store.go
+++ b/go/store/chunks/chunk_store.go
@@ -262,9 +262,10 @@ type ChunkStoreGarbageCollector interface {
 // TolerantChunkIterator is implemented by chunk stores that support fault-tolerant chunk
 // iteration for diagnostic purposes. Unlike IterateAllChunks, TolerantIterateAllChunks does
 // not halt on per-chunk errors; instead it reports them via errCb and continues iterating.
+// sourceFile identifies which physical file (table, archive, journal) the error came from.
 // This interface is intended exclusively for use by fsck.
 type TolerantChunkIterator interface {
-	TolerantIterateAllChunks(ctx context.Context, cb func(chunk Chunk), errCb func(err error))
+	TolerantIterateAllChunks(ctx context.Context, cb func(chunk Chunk), errCb func(sourceFile string, err error))
 }
 
 type PrefixChunkStore interface {

--- a/go/store/chunks/chunk_store.go
+++ b/go/store/chunks/chunk_store.go
@@ -263,7 +263,8 @@ type ChunkStoreGarbageCollector interface {
 // iteration for diagnostic purposes. Unlike IterateAllChunks, TolerantIterateAllChunks does
 // not halt on per-chunk errors; instead it reports them via errCb and continues iterating.
 // sourceFile identifies which physical file (table, archive, journal) the error came from.
-// This interface is intended exclusively for use by fsck.
+//
+// INTENDED FOR USE IN FSCK ONLY. The errors diagnosed by this method should result in application errors generally.
 type TolerantChunkIterator interface {
 	TolerantIterateAllChunks(ctx context.Context, cb func(chunk Chunk), errCb func(sourceFile string, err error))
 }

--- a/go/store/chunks/chunk_store.go
+++ b/go/store/chunks/chunk_store.go
@@ -259,6 +259,14 @@ type ChunkStoreGarbageCollector interface {
 	IterateAllChunks(context.Context, func(chunk Chunk)) error
 }
 
+// TolerantChunkIterator is implemented by chunk stores that support fault-tolerant chunk
+// iteration for diagnostic purposes. Unlike IterateAllChunks, TolerantIterateAllChunks does
+// not halt on per-chunk errors; instead it reports them via errCb and continues iterating.
+// This interface is intended exclusively for use by fsck.
+type TolerantChunkIterator interface {
+	TolerantIterateAllChunks(ctx context.Context, cb func(chunk Chunk), errCb func(err error))
+}
+
 type PrefixChunkStore interface {
 	ChunkStore
 

--- a/go/store/nbs/archive_chunk_source.go
+++ b/go/store/nbs/archive_chunk_source.go
@@ -273,3 +273,7 @@ func (acs *archiveChunkSource) iterateAllChunks(ctx context.Context, cb func(chu
 
 	return acs.aRdr.iterate(ctx, ncb, stats)
 }
+
+func (acs *archiveChunkSource) tolerantIterateAllChunks(ctx context.Context, cb func(chunks.Chunk), errCb func(error), stats *Stats) {
+	acs.aRdr.tolerantIterate(ctx, cb, errCb, stats)
+}

--- a/go/store/nbs/archive_reader.go
+++ b/go/store/nbs/archive_reader.go
@@ -750,6 +750,124 @@ func (ar *archiveReader) iterate(ctx context.Context, cb func(chunks.Chunk) erro
 	return nil
 }
 
+// tolerantIterate is like iterate but routes per-chunk errors through errCb and continues rather than halting.
+// Only stream-level read failures (where the sequential read position is lost) cause early termination.
+// Dictionary load failures are tracked so that chunks referencing a broken dictionary are skipped with an error
+// rather than panicking.
+// Intended for use by fsck only.
+func (ar *archiveReader) tolerantIterate(ctx context.Context, cb func(chunks.Chunk), errCb func(error), stats *Stats) {
+	dictReverseIndex := make(map[uint32]struct{})
+	dataReverseIndex := make(map[uint32]uint32)
+
+	for chunkRefIdx := uint32(0); chunkRefIdx < ar.footer.chunkCount; chunkRefIdx++ {
+		dictId, dataId := ar.getChunkRef(int(chunkRefIdx))
+		if dictId != 0 {
+			dictReverseIndex[dictId] = struct{}{}
+		}
+		dataReverseIndex[dataId] = chunkRefIdx
+	}
+
+	dataSpan := ar.footer.dataSpan()
+	dataReader := io.NewSectionReader(&bridgeReaderAt{
+		rdr:   ar.reader,
+		ctx:   ctx,
+		stats: stats,
+	}, int64(dataSpan.offset), int64(dataSpan.length))
+	bufReader := bufio.NewReader(dataReader)
+	byteSpanCounter := uint32(1)
+
+	buf := make([]byte, 4*1024*1024)
+	loadedDictionaries := make(map[uint32]*gozstd.DDict)
+	failedDictionaries := make(map[uint32]struct{})
+
+	for byteSpanCounter <= ar.footer.byteSpanCount {
+		if ctx.Err() != nil {
+			return
+		}
+
+		span := ar.getByteSpanByID(byteSpanCounter)
+		for cap(buf) < int(span.length) {
+			buf = append(buf, make([]byte, cap(buf))...)
+		}
+
+		_, readErr := io.ReadFull(bufReader, buf[:span.length])
+		if readErr != nil {
+			// Stream position is unknown; cannot safely continue sequential read.
+			errCb(fmt.Errorf("error reading archive file at span %d: %w", byteSpanCounter, readErr))
+			return
+		}
+		spanData := buf[:span.length]
+
+		if _, exists := dictReverseIndex[byteSpanCounter]; exists {
+			dict, err := NewDecompBundle(spanData)
+			if err != nil {
+				errCb(fmt.Errorf("failure loading archive dictionary span %d: %w", byteSpanCounter, err))
+				failedDictionaries[byteSpanCounter] = struct{}{}
+			} else {
+				loadedDictionaries[byteSpanCounter] = dict.dDict
+			}
+		} else if chunkId, exists := dataReverseIndex[byteSpanCounter]; exists {
+			dictId, dataId := ar.getChunkRef(int(chunkId))
+			if byteSpanCounter != dataId {
+				panic("Reverse Index incorrect: ByteSpan ID does not match data ID in chunk reference")
+			}
+
+			prefix := ar.indexReader.getPrefix(chunkId)
+			suffix := ar.indexReader.getSuffix(chunkId)
+			h := reconstructHashFromPrefixAndSuffix(prefix, suffix)
+
+			var chunkData []byte
+			chunkOk := true
+
+			if dictId == 0 {
+				if ar.footer.formatVersion >= archiveVersionSnappySupport {
+					cc, err := NewCompressedChunk(h, spanData)
+					if err != nil {
+						errCb(fmt.Errorf("chunk %s: %w", h.String(), err))
+						chunkOk = false
+					} else {
+						chk, err := cc.ToChunk()
+						if err != nil {
+							errCb(fmt.Errorf("chunk %s: decompress error: %w", h.String(), err))
+							chunkOk = false
+						} else {
+							chunkData = chk.Data()
+						}
+					}
+				} else {
+					errCb(fmt.Errorf("chunk %s: no dictionary for old format version", h.String()))
+					chunkOk = false
+				}
+			} else {
+				if _, failed := failedDictionaries[dictId]; failed {
+					errCb(fmt.Errorf("chunk %s: skipped due to failed dictionary span %d", h.String(), dictId))
+					chunkOk = false
+				} else {
+					dict, ok := loadedDictionaries[dictId]
+					if !ok {
+						errCb(fmt.Errorf("chunk %s: dictionary span %d not loaded", h.String(), dictId))
+						chunkOk = false
+					} else {
+						var decompErr error
+						chunkData, decompErr = gozstd.DecompressDict(nil, spanData, dict)
+						if decompErr != nil {
+							errCb(fmt.Errorf("chunk %s: decompression error: %w", h.String(), decompErr))
+							chunkOk = false
+						}
+					}
+				}
+			}
+
+			if chunkOk {
+				cb(chunks.NewChunkWithHash(h, chunkData))
+			}
+		} else {
+			errCb(fmt.Errorf("archive span %d not found in dictionary or data reverse index", byteSpanCounter))
+		}
+		byteSpanCounter++
+	}
+}
+
 // prollyBinSearch is a search that returns the _best_ index of the target in the input slice. If the target exists,
 // one or more times, the index of the first instance is returned. If the target does not exist, the index which it
 // would be inserted at is returned.

--- a/go/store/nbs/archive_reader.go
+++ b/go/store/nbs/archive_reader.go
@@ -750,12 +750,6 @@ func (ar *archiveReader) iterate(ctx context.Context, cb func(chunks.Chunk) erro
 	return nil
 }
 
-// tolerantIterate is like iterate but routes per-chunk errors through errCb and continues rather than halting.
-// Only stream-level read failures (where the sequential read position is lost) cause early termination.
-// Dictionary load failures are tracked so that chunks referencing a broken dictionary are skipped with an error
-// rather than panicking.
-//
-// INTENDED FOR USE IN FSCK ONLY.
 func (ar *archiveReader) tolerantIterate(ctx context.Context, cb func(chunks.Chunk), errCb func(error), stats *Stats) {
 	dictReverseIndex := make(map[uint32]struct{})
 	dataReverseIndex := make(map[uint32]uint32)

--- a/go/store/nbs/archive_reader.go
+++ b/go/store/nbs/archive_reader.go
@@ -754,7 +754,8 @@ func (ar *archiveReader) iterate(ctx context.Context, cb func(chunks.Chunk) erro
 // Only stream-level read failures (where the sequential read position is lost) cause early termination.
 // Dictionary load failures are tracked so that chunks referencing a broken dictionary are skipped with an error
 // rather than panicking.
-// Intended for use by fsck only.
+//
+// INTENDED FOR USE IN FSCK ONLY.
 func (ar *archiveReader) tolerantIterate(ctx context.Context, cb func(chunks.Chunk), errCb func(error), stats *Stats) {
 	dictReverseIndex := make(map[uint32]struct{})
 	dataReverseIndex := make(map[uint32]uint32)

--- a/go/store/nbs/archive_test.go
+++ b/go/store/nbs/archive_test.go
@@ -1376,6 +1376,10 @@ func (tcs *testChunkSource) iterateAllChunks(_ context.Context, _ func(chunks.Ch
 	panic("never used")
 }
 
+func (tcs *testChunkSource) tolerantIterateAllChunks(_ context.Context, _ func(chunks.Chunk), _ func(error), _ *Stats) {
+	panic("never used")
+}
+
 // createTestArchive creates a test archive with the specified chunks and returns an archiveReader and the fake hashes
 // created for the chunks (in the same order).
 func createTestArchive(t *testing.T, prefix uint64, chunks [][]byte, metadata string) (archiveReader, []hash.Hash) {

--- a/go/store/nbs/empty_chunk_source.go
+++ b/go/store/nbs/empty_chunk_source.go
@@ -102,3 +102,6 @@ func (ecs emptyChunkSource) clone() (chunkSource, error) {
 func (ecs emptyChunkSource) iterateAllChunks(_ context.Context, _ func(chunks.Chunk), _ *Stats) error {
 	return nil
 }
+
+func (ecs emptyChunkSource) tolerantIterateAllChunks(_ context.Context, _ func(chunks.Chunk), _ func(error), _ *Stats) {
+}

--- a/go/store/nbs/generational_chunk_store.go
+++ b/go/store/nbs/generational_chunk_store.go
@@ -553,7 +553,7 @@ func (gcs *GenerationalNBS) IterateAllChunks(ctx context.Context, cb func(chunk 
 	return nil
 }
 
-func (gcs *GenerationalNBS) TolerantIterateAllChunks(ctx context.Context, cb func(chunks.Chunk), errCb func(error)) {
+func (gcs *GenerationalNBS) TolerantIterateAllChunks(ctx context.Context, cb func(chunks.Chunk), errCb func(sourceFile string, err error)) {
 	gcs.newGen.TolerantIterateAllChunks(ctx, cb, errCb)
 	if ctx.Err() != nil {
 		return

--- a/go/store/nbs/generational_chunk_store.go
+++ b/go/store/nbs/generational_chunk_store.go
@@ -553,6 +553,14 @@ func (gcs *GenerationalNBS) IterateAllChunks(ctx context.Context, cb func(chunk 
 	return nil
 }
 
+func (gcs *GenerationalNBS) TolerantIterateAllChunks(ctx context.Context, cb func(chunks.Chunk), errCb func(error)) {
+	gcs.newGen.TolerantIterateAllChunks(ctx, cb, errCb)
+	if ctx.Err() != nil {
+		return
+	}
+	gcs.oldGen.TolerantIterateAllChunks(ctx, cb, errCb)
+}
+
 func (gcs *GenerationalNBS) Count() (uint32, error) {
 	newGenCnt, err := gcs.newGen.Count()
 	if err != nil {

--- a/go/store/nbs/journal_chunk_source.go
+++ b/go/store/nbs/journal_chunk_source.go
@@ -286,6 +286,47 @@ func (s journalChunkSource) iterateAllChunks(ctx context.Context, cb func(chunks
 	return nil
 }
 
+func (s journalChunkSource) tolerantIterateAllChunks(ctx context.Context, cb func(chunks.Chunk), errCb func(error), _ *Stats) {
+	s.journal.lock.RLock()
+	defer s.journal.lock.RUnlock()
+
+	for h, r := range s.journal.ranges.novel {
+		if ctx.Err() != nil {
+			return
+		}
+		cchk, err := s.journal.getCompressedChunkAtRange(r, h)
+		if err != nil {
+			errCb(fmt.Errorf("chunk %s: %w", h.String(), err))
+			continue
+		}
+		chunk, err := cchk.ToChunk()
+		if err != nil {
+			errCb(fmt.Errorf("chunk %s: decompress error: %w", h.String(), err))
+			continue
+		}
+		cb(chunk)
+	}
+
+	for a16, r := range s.journal.ranges.cached {
+		if ctx.Err() != nil {
+			return
+		}
+		var h hash.Hash
+		copy(h[:], a16[:])
+		cchk, err := s.journal.getCompressedChunkAtRange(r, h)
+		if err != nil {
+			errCb(fmt.Errorf("chunk %s: %w", h.String(), err))
+			continue
+		}
+		chunk, err := cchk.ToChunk()
+		if err != nil {
+			errCb(fmt.Errorf("chunk %s: decompress error: %w", h.String(), err))
+			continue
+		}
+		cb(chunk)
+	}
+}
+
 func equalSpecs(left, right []tableSpec) bool {
 	if len(left) != len(right) {
 		return false

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -2425,15 +2425,17 @@ func (nbs *NomsBlockStore) IterateAllChunks(ctx context.Context, cb func(chunk c
 	return nil
 }
 
-func (nbs *NomsBlockStore) TolerantIterateAllChunks(ctx context.Context, cb func(chunks.Chunk), errCb func(error)) {
+func (nbs *NomsBlockStore) TolerantIterateAllChunks(ctx context.Context, cb func(chunks.Chunk), errCb func(sourceFile string, err error)) {
 	for _, v := range nbs.tables.novel {
-		v.tolerantIterateAllChunks(ctx, cb, errCb, nbs.stats)
+		fileName := v.hash().String() + v.suffix()
+		v.tolerantIterateAllChunks(ctx, cb, func(err error) { errCb(fileName, err) }, nbs.stats)
 		if ctx.Err() != nil {
 			return
 		}
 	}
 	for _, v := range nbs.tables.upstream {
-		v.tolerantIterateAllChunks(ctx, cb, errCb, nbs.stats)
+		fileName := v.hash().String() + v.suffix()
+		v.tolerantIterateAllChunks(ctx, cb, func(err error) { errCb(fileName, err) }, nbs.stats)
 		if ctx.Err() != nil {
 			return
 		}

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -2425,6 +2425,21 @@ func (nbs *NomsBlockStore) IterateAllChunks(ctx context.Context, cb func(chunk c
 	return nil
 }
 
+func (nbs *NomsBlockStore) TolerantIterateAllChunks(ctx context.Context, cb func(chunks.Chunk), errCb func(error)) {
+	for _, v := range nbs.tables.novel {
+		v.tolerantIterateAllChunks(ctx, cb, errCb, nbs.stats)
+		if ctx.Err() != nil {
+			return
+		}
+	}
+	for _, v := range nbs.tables.upstream {
+		v.tolerantIterateAllChunks(ctx, cb, errCb, nbs.stats)
+		if ctx.Err() != nil {
+			return
+		}
+	}
+}
+
 func (nbs *NomsBlockStore) swapTables(ctx context.Context, specs []tableSpec, mode chunks.GCMode, srcs chunkSourceSet) (err error) {
 	nbs.mu.Lock()
 	defer nbs.mu.Unlock()

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -277,6 +277,12 @@ type chunkSource interface {
 	// the scan, and will likely mean that the scan didn't complete. Note that errors returned by this method are not
 	// related to the callback - if the callback discovers an error, it must manage that out of band.
 	iterateAllChunks(context.Context, func(chunk chunks.Chunk), *Stats) error
+
+	// tolerantIterateAllChunks is like iterateAllChunks but reports per-chunk errors via errCb
+	// instead of halting. This allows callers to continue past corrupted chunks. Unrecoverable
+	// errors (e.g. stream-level I/O failures where the read position is unknown) still terminate
+	// iteration of the current source after calling errCb. Intended for use by fsck only.
+	tolerantIterateAllChunks(context.Context, func(chunk chunks.Chunk), func(err error), *Stats)
 }
 
 type chunkSources []chunkSource

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -278,10 +278,7 @@ type chunkSource interface {
 	// related to the callback - if the callback discovers an error, it must manage that out of band.
 	iterateAllChunks(context.Context, func(chunk chunks.Chunk), *Stats) error
 
-	// tolerantIterateAllChunks is like iterateAllChunks but reports per-chunk errors via errCb
-	// instead of halting. This allows callers to continue past corrupted chunks. Unrecoverable
-	// errors (e.g. stream-level I/O failures where the read position is unknown) still terminate
-	// iteration of the current source after calling errCb. Intended for use by fsck only.
+	// tolerantIterateAllChunks is for [TolerantChunkIterator.TolerantIterateAllChunks]
 	tolerantIterateAllChunks(context.Context, func(chunk chunks.Chunk), func(err error), *Stats)
 }
 

--- a/go/store/nbs/table_reader.go
+++ b/go/store/nbs/table_reader.go
@@ -518,9 +518,9 @@ func (tr tableReader) getManyAtOffsetsWithReadFunc(
 	offsetRecords offsetRecSlice,
 	stats *Stats,
 	readAtOffsets func(
-	ctx context.Context,
-	rb readBatch,
-	stats *Stats) error,
+		ctx context.Context,
+		rb readBatch,
+		stats *Stats) error,
 ) error {
 	batches := toReadBatches(offsetRecords, tr.blockSize)
 	for i := range batches {

--- a/go/store/nbs/table_reader.go
+++ b/go/store/nbs/table_reader.go
@@ -518,9 +518,9 @@ func (tr tableReader) getManyAtOffsetsWithReadFunc(
 	offsetRecords offsetRecSlice,
 	stats *Stats,
 	readAtOffsets func(
-		ctx context.Context,
-		rb readBatch,
-		stats *Stats) error,
+	ctx context.Context,
+	rb readBatch,
+	stats *Stats) error,
 ) error {
 	batches := toReadBatches(offsetRecords, tr.blockSize)
 	for i := range batches {
@@ -783,6 +783,12 @@ func (tr tableReader) clone() (tableReader, error) {
 	}, nil
 }
 
+type chunkRecord struct {
+	offset uint64
+	length uint32
+	hash   hash.Hash
+}
+
 func (tr tableReader) iterateAllChunks(ctx context.Context, cb func(chunk chunks.Chunk), stats *Stats) error {
 	count := tr.idx.chunkCount()
 	if count == 0 {
@@ -791,11 +797,6 @@ func (tr tableReader) iterateAllChunks(ctx context.Context, cb func(chunk chunks
 
 	// Collect all chunk info then sort by offset.
 	// The index is sorted by prefix, but we need to process chunkRecs in storage order (by offset)
-	type chunkRecord struct {
-		offset uint64
-		length uint32
-		hash   hash.Hash
-	}
 	chunkRecs := make([]chunkRecord, 0, count)
 	for i := uint32(0); i < count; i++ {
 		var h hash.Hash
@@ -860,11 +861,6 @@ func (tr tableReader) tolerantIterateAllChunks(ctx context.Context, cb func(chun
 		return
 	}
 
-	type chunkRecord struct {
-		offset uint64
-		length uint32
-		hash   hash.Hash
-	}
 	chunkRecs := make([]chunkRecord, 0, count)
 	for i := uint32(0); i < count; i++ {
 		var h hash.Hash

--- a/go/store/nbs/table_reader.go
+++ b/go/store/nbs/table_reader.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"sort"
 	"sync/atomic"
@@ -851,4 +852,78 @@ func (tr tableReader) iterateAllChunks(ctx context.Context, cb func(chunk chunks
 	}
 
 	return nil
+}
+
+func (tr tableReader) tolerantIterateAllChunks(ctx context.Context, cb func(chunk chunks.Chunk), errCb func(error), stats *Stats) {
+	count := tr.idx.chunkCount()
+	if count == 0 {
+		return
+	}
+
+	type chunkRecord struct {
+		offset uint64
+		length uint32
+		hash   hash.Hash
+	}
+	chunkRecs := make([]chunkRecord, 0, count)
+	for i := uint32(0); i < count; i++ {
+		var h hash.Hash
+		ie, err := tr.idx.indexEntry(i, &h)
+		if err != nil {
+			errCb(fmt.Errorf("chunk index entry %d: %w", i, err))
+			continue
+		}
+		chunkRecs = append(chunkRecs, chunkRecord{
+			offset: ie.Offset(),
+			length: ie.Length(),
+			hash:   h,
+		})
+	}
+	if len(chunkRecs) == 0 {
+		return
+	}
+	sort.Slice(chunkRecs, func(i, j int) bool {
+		return chunkRecs[i].offset < chunkRecs[j].offset
+	})
+
+	lastChunk := chunkRecs[len(chunkRecs)-1]
+	totalDataSize := lastChunk.offset + uint64(lastChunk.length)
+
+	dataReader := io.NewSectionReader(&bridgeReaderAt{
+		rdr:   tr.r,
+		ctx:   ctx,
+		stats: stats,
+	}, int64(0), int64(totalDataSize))
+	bufReader := bufio.NewReader(dataReader)
+
+	buf := make([]byte, 4*1024*1024)
+	for _, chunk := range chunkRecs {
+		if ctx.Err() != nil {
+			return
+		}
+
+		_, readErr := io.ReadFull(bufReader, buf[:chunk.length])
+		chunkData := buf[:chunk.length]
+
+		if readErr != nil {
+			// Stream position is unknown after a read failure; cannot safely continue sequential read.
+			errCb(fmt.Errorf("chunk %s: read error: %w", chunk.hash.String(), readErr))
+			return
+		}
+
+		cchk, err := NewCompressedChunk(chunk.hash, chunkData)
+		if err != nil {
+			// Bytes were already consumed from the stream, so we can continue to the next chunk.
+			errCb(fmt.Errorf("chunk %s: %w", chunk.hash.String(), err))
+			continue
+		}
+
+		chk, err := cchk.ToChunk()
+		if err != nil {
+			errCb(fmt.Errorf("chunk %s: decompress error: %w", chunk.hash.String(), err))
+			continue
+		}
+
+		cb(chk)
+	}
 }


### PR DESCRIPTION
`dolt fsck` is now more resilient to corruption errors which could cause the iterateAllChunks methods to halt.

This change add a tolerant iterator to our three primary storage interfaces. These interfaces don't return errors, but instead call an error callback and continue to the best of their ability to iterate chunks after errors are found.