### PR TITLE
reduce `node.TreeCount()` calls

### DIFF
--- a/go/store/prolly/message/address_map.go
+++ b/go/store/prolly/message/address_map.go
@@ -74,7 +74,7 @@ func (s AddressMapSerializer) Serialize(keys, addrs [][]byte, subtrees []uint64,
 
 	if level > 0 {
 		serial.AddressMapAddSubtreeCounts(b, cardArr)
-		serial.AddressMapAddTreeCount(b, sumSubtrees(subtrees))
+		serial.AddressMapAddTreeCount(b, SumSubtrees(subtrees))
 	} else {
 		serial.AddressMapAddTreeCount(b, uint64(len(keys)))
 	}

--- a/go/store/prolly/message/blob.go
+++ b/go/store/prolly/message/blob.go
@@ -61,7 +61,7 @@ func (s BlobSerializer) Serialize(keys, values [][]byte, subtrees []uint64, leve
 		serial.BlobAddAddressArray(b, addrs)
 		serial.BlobAddSubtreeSizes(b, cards)
 	}
-	serial.BlobAddTreeSize(b, sumSubtrees(subtrees))
+	serial.BlobAddTreeSize(b, SumSubtrees(subtrees))
 	serial.BlobAddTreeLevel(b, uint8(level))
 	return serial.FinishMessage(b, serial.BlobEnd(b), blobFileID)
 }

--- a/go/store/prolly/message/commit_closure.go
+++ b/go/store/prolly/message/commit_closure.go
@@ -167,7 +167,7 @@ func (s CommitClosureSerializer) Serialize(keys, addrs [][]byte, subtrees []uint
 	if level > 0 {
 		serial.CommitClosureAddAddressArray(b, addrArr)
 		serial.CommitClosureAddSubtreeCounts(b, cardArr)
-		serial.CommitClosureAddTreeCount(b, sumSubtrees(subtrees))
+		serial.CommitClosureAddTreeCount(b, SumSubtrees(subtrees))
 	} else {
 		serial.CommitClosureAddTreeCount(b, uint64(len(keys)))
 	}

--- a/go/store/prolly/message/merge_artifacts.go
+++ b/go/store/prolly/message/merge_artifacts.go
@@ -99,7 +99,7 @@ func (s MergeArtifactSerializer) Serialize(keys, values [][]byte, subtrees []uin
 	} else {
 		serial.MergeArtifactsAddAddressArray(b, refArr)
 		serial.MergeArtifactsAddSubtreeCounts(b, cardArr)
-		serial.MergeArtifactsAddTreeCount(b, sumSubtrees(subtrees))
+		serial.MergeArtifactsAddTreeCount(b, SumSubtrees(subtrees))
 	}
 	serial.MergeArtifactsAddTreeLevel(b, uint8(level))
 

--- a/go/store/prolly/message/prolly_map.go
+++ b/go/store/prolly/message/prolly_map.go
@@ -95,7 +95,7 @@ func (s ProllyMapSerializer) Serialize(keys, values [][]byte, subtrees []uint64,
 	} else {
 		serial.ProllyTreeNodeAddAddressArray(b, refArr)
 		serial.ProllyTreeNodeAddSubtreeCounts(b, cardArr)
-		serial.ProllyTreeNodeAddTreeCount(b, sumSubtrees(subtrees))
+		serial.ProllyTreeNodeAddTreeCount(b, SumSubtrees(subtrees))
 	}
 	serial.ProllyTreeNodeAddKeyType(b, serial.ItemTypeTupleFormatAlpha)
 	serial.ProllyTreeNodeAddValueType(b, serial.ItemTypeTupleFormatAlpha)

--- a/go/store/prolly/message/serialize.go
+++ b/go/store/prolly/message/serialize.go
@@ -135,7 +135,7 @@ func writeCountArray(b *fb.Builder, counts []uint64) fb.UOffsetT {
 	return b.CreateByteVector(encodeVarints(counts, buf))
 }
 
-func sumSubtrees(subtrees []uint64) (sum uint64) {
+func SumSubtrees(subtrees []uint64) (sum uint64) {
 	for i := range subtrees {
 		sum += subtrees[i]
 	}

--- a/go/store/prolly/message/varint_test.go
+++ b/go/store/prolly/message/varint_test.go
@@ -130,7 +130,7 @@ func testRoundTripVarints(t *testing.T, c codec) {
 			counts[i] = c
 			sum += c
 		}
-		assert.Equal(t, sum, sumSubtrees(counts))
+		assert.Equal(t, sum, SumSubtrees(counts))
 
 		// round trip the array
 		buf := make([]byte, c.maxSize(len(counts)))

--- a/go/store/prolly/message/vector_index.go
+++ b/go/store/prolly/message/vector_index.go
@@ -97,7 +97,7 @@ func (s VectorIndexSerializer) Serialize(keys, values [][]byte, subtrees []uint6
 	} else {
 		serial.VectorIndexNodeAddAddressArray(b, refArr)
 		serial.VectorIndexNodeAddSubtreeCounts(b, cardArr)
-		serial.VectorIndexNodeAddTreeCount(b, sumSubtrees(subtrees))
+		serial.VectorIndexNodeAddTreeCount(b, SumSubtrees(subtrees))
 	}
 	serial.VectorIndexNodeAddTreeLevel(b, uint8(level))
 	serial.VectorIndexNodeAddLogChunkSize(b, s.logChunkSize)

--- a/go/store/prolly/tree/chunker.go
+++ b/go/store/prolly/tree/chunker.go
@@ -528,7 +528,7 @@ func getCanonicalRoot[S message.Serializer](ctx context.Context, ns NodeStore, b
 	cnt := builder.count()
 	assertTrue(cnt == 1, "in-progress chunk must be non-canonical to call getCanonicalRoot")
 
-	nd, err := builder.build()
+	nd, _, err := builder.build()
 	if err != nil {
 		return nil, err
 	}

--- a/go/store/prolly/tree/node_builder.go
+++ b/go/store/prolly/tree/node_builder.go
@@ -16,11 +16,12 @@ package tree
 
 import (
 	"context"
+	"fmt"
+	"github.com/dolthub/dolt/go/gen/fb/serial"
 	"sync"
 
-	"github.com/dolthub/dolt/go/store/prolly/message"
-
 	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/dolthub/dolt/go/store/prolly/message"
 )
 
 type novelNode struct {
@@ -31,7 +32,7 @@ type novelNode struct {
 }
 
 func writeNewNode[S message.Serializer](ctx context.Context, ns NodeStore, bld *nodeBuilder[S]) (novelNode, error) {
-	node, err := bld.build()
+	node, treeCnt, err := bld.build()
 	if err != nil {
 		return novelNode{}, err
 	}
@@ -48,16 +49,16 @@ func writeNewNode[S message.Serializer](ctx context.Context, ns NodeStore, bld *
 		copy(lastKey, k)
 	}
 
-	cnt, err := node.TreeCount()
-	if err != nil {
-		return novelNode{}, err
+	otherTreeCnt, err := node.TreeCount()
+	if treeCnt != uint64(otherTreeCnt) {
+		panic(fmt.Sprintf("node tree count mismatch: %d != %d", treeCnt, otherTreeCnt))
 	}
 
 	return novelNode{
 		addr:      addr,
 		node:      node,
 		lastKey:   lastKey,
-		treeCount: uint64(cnt),
+		treeCount: treeCnt,
 	}, nil
 }
 
@@ -99,11 +100,17 @@ func (nb *nodeBuilder[S]) count() int {
 	return len(nb.keys)
 }
 
-func (nb *nodeBuilder[S]) build() (node *Node, err error) {
+func (nb *nodeBuilder[S]) build() (node *Node, treeCount uint64, err error) {
 	msg := nb.serializer.Serialize(nb.keys, nb.values, nb.subtrees, nb.level)
+	var fileID string
+	node, fileID, err = NodeFromBytes(msg)
+	if nb.level == 0 && fileID != serial.BlobFileID {
+		treeCount = uint64(len(nb.keys))
+	} else {
+		treeCount = message.SumSubtrees(nb.subtrees)
+	}
 	nb.recycleBuffers()
 	nb.size = 0
-	node, _, err = NodeFromBytes(msg)
 	return
 }
 

--- a/go/store/prolly/tree/node_builder.go
+++ b/go/store/prolly/tree/node_builder.go
@@ -16,10 +16,9 @@ package tree
 
 import (
 	"context"
-	"fmt"
-	"github.com/dolthub/dolt/go/gen/fb/serial"
 	"sync"
 
+	"github.com/dolthub/dolt/go/gen/fb/serial"
 	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/prolly/message"
 )
@@ -47,11 +46,6 @@ func writeNewNode[S message.Serializer](ctx context.Context, ns NodeStore, bld *
 		k := getLastKey(node)
 		lastKey = ns.Pool().Get(uint64(len(k)))
 		copy(lastKey, k)
-	}
-
-	otherTreeCnt, err := node.TreeCount()
-	if treeCnt != uint64(otherTreeCnt) {
-		panic(fmt.Sprintf("node tree count mismatch: %d != %d", treeCnt, otherTreeCnt))
 	}
 
 	return novelNode{


### PR DESCRIPTION
Immediately after building a new node, we call `node.TreeCount()`, which triggers deserialization of the message we just created. Prior to node serialization, we can already calculate the TreeCount and avoid this extra flatbuffer deserialization.