### PR TITLE
[no-release-notes] go: doltcore/env: Add DoltEnv.Close.

### DIFF
--- a/go/cmd/dolt/commands/init_test.go
+++ b/go/cmd/dolt/commands/init_test.go
@@ -77,7 +77,7 @@ func TestInit(t *testing.T) {
 			cliCtx, _ := cli.NewCliContext(&apr, dEnv.Config, dEnv.FS, latebind)
 
 			result := InitCmd{}.Exec(ctx, "dolt init", test.Args, dEnv, cliCtx)
-			defer dEnv.DoltDB(ctx).Close()
+			defer dEnv.Close()
 
 			require.Equalf(t, test.ExpectSuccess, result == 0, "- Expected success: %t; result: %t;", test.ExpectSuccess, result == 0)
 
@@ -98,7 +98,7 @@ func TestInitTwice(t *testing.T) {
 	dEnv := createUninitializedEnv()
 	result := InitCmd{}.Exec(ctx, "dolt init", []string{"-name", "Bill Billerson", "-email", "bigbillieb@fake.horse"}, dEnv, nil)
 	require.True(t, result == 0, "First init should succeed")
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 
 	result = InitCmd{}.Exec(ctx, "dolt init", []string{"-name", "Bill Billerson", "-email", "bigbillieb@fake.horse"}, dEnv, nil)
 	require.True(t, result != 0, "Second init should fail")

--- a/go/cmd/dolt/commands/log_test.go
+++ b/go/cmd/dolt/commands/log_test.go
@@ -35,7 +35,7 @@ func TestLog(t *testing.T) {
 	ctx := context.Background()
 	dEnv := createUninitializedEnv()
 	err := dEnv.InitRepo(ctx, types.Format_Default, "Bill Billerson", "bigbillieb@fake.horse", env.DefaultInitBranch)
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 
 	if err != nil {
 		t.Error("Failed to init repo")
@@ -57,7 +57,7 @@ func TestLogSigterm(t *testing.T) {
 	ctx := context.Background()
 	dEnv := createUninitializedEnv()
 	err := dEnv.InitRepo(ctx, types.Format_Default, "Bill Billerson", "bigbillieb@fake.horse", env.DefaultInitBranch)
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 
 	if err != nil {
 		t.Error("Failed to init repo")

--- a/go/cmd/dolt/commands/sql_test.go
+++ b/go/cmd/dolt/commands/sql_test.go
@@ -44,7 +44,7 @@ func DEnvWithSeedDataForTest(ctx context.Context, t *testing.T) *env.DoltEnv {
 	dEnv, err := sqle.CreateEnvWithSeedData()
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		dEnv.DoltDB(ctx).Close()
+		dEnv.Close()
 	})
 	return dEnv
 }
@@ -179,7 +179,7 @@ func TestCreateTable(t *testing.T) {
 
 			dEnv := dtestutils.CreateTestEnv()
 			t.Cleanup(func() {
-				dEnv.DoltDB(ctx).Close()
+				dEnv.Close()
 			})
 			working, err := dEnv.WorkingRoot(context.Background())
 			assert.Nil(t, err, "Unexpected error")

--- a/go/cmd/dolt/commands/sqlserver/server_test.go
+++ b/go/cmd/dolt/commands/sqlserver/server_test.go
@@ -67,12 +67,11 @@ var (
 )
 
 func TestServerArgs(t *testing.T) {
-	ctx := context.Background()
 	controller := svcs.NewController()
 	dEnv, err := sqle.CreateEnvWithSeedData()
 	require.NoError(t, err)
 	defer func() {
-		assert.NoError(t, dEnv.DoltDB(ctx).Close())
+		assert.NoError(t, dEnv.Close())
 	}()
 	go func() {
 		StartServer(context.Background(), "0.0.0", "dolt sql-server", []string{
@@ -100,7 +99,7 @@ func TestDeprecatedUserPasswordServerArgs(t *testing.T) {
 	dEnv, err := sqle.CreateEnvWithSeedData()
 	require.NoError(t, err)
 	defer func() {
-		assert.NoError(t, dEnv.DoltDB(ctx).Close())
+		assert.NoError(t, dEnv.Close())
 	}()
 	err = StartServer(ctx, "0.0.0", "dolt sql-server", []string{
 		"-H", "localhost",
@@ -129,11 +128,10 @@ listener:
     read_timeout_millis: 5000
     write_timeout_millis: 5000
 `
-	ctx := context.Background()
 	dEnv, err := sqle.CreateEnvWithSeedData()
 	require.NoError(t, err)
 	defer func() {
-		assert.NoError(t, dEnv.DoltDB(ctx).Close())
+		assert.NoError(t, dEnv.Close())
 	}()
 	controller := svcs.NewController()
 	go func() {
@@ -155,11 +153,10 @@ listener:
 }
 
 func TestServerBadArgs(t *testing.T) {
-	ctx := context.Background()
 	env, err := sqle.CreateEnvWithSeedData()
 	require.NoError(t, err)
 	defer func() {
-		assert.NoError(t, env.DoltDB(ctx).Close())
+		assert.NoError(t, env.Close())
 	}()
 
 	tests := [][]string{
@@ -185,8 +182,6 @@ func TestServerBadArgs(t *testing.T) {
 }
 
 func TestServerGoodParams(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []servercfg.ServerConfig{
 		DefaultCommandLineServerConfig(),
 		DefaultCommandLineServerConfig().WithHost("127.0.0.1").WithPort(15400),
@@ -210,7 +205,7 @@ func TestServerGoodParams(t *testing.T) {
 			env, err := sqle.CreateEnvWithSeedData()
 			require.NoError(t, err)
 			defer func() {
-				assert.NoError(t, env.DoltDB(ctx).Close())
+				assert.NoError(t, env.Close())
 			}()
 			sc := svcs.NewController()
 			go func(config servercfg.ServerConfig, sc *svcs.Controller) {
@@ -236,11 +231,10 @@ func TestServerGoodParams(t *testing.T) {
 }
 
 func TestServerSelect(t *testing.T) {
-	ctx := context.Background()
 	env, err := sqle.CreateEnvWithSeedData()
 	require.NoError(t, err)
 	defer func() {
-		assert.NoError(t, env.DoltDB(ctx).Close())
+		assert.NoError(t, env.Close())
 	}()
 
 	serverConfig := DefaultCommandLineServerConfig().withLogLevel(servercfg.LogLevel_Fatal).WithPort(15300)
@@ -299,7 +293,6 @@ func TestServerSelect(t *testing.T) {
 
 // If a port is already in use, throw error "Port XXXX already in use."
 func TestServerFailsIfPortInUse(t *testing.T) {
-	ctx := context.Background()
 	controller := svcs.NewController()
 	server := &http.Server{
 		Addr:    ":15200",
@@ -308,7 +301,7 @@ func TestServerFailsIfPortInUse(t *testing.T) {
 	dEnv, err := sqle.CreateEnvWithSeedData()
 	require.NoError(t, err)
 	defer func() {
-		assert.NoError(t, dEnv.DoltDB(ctx).Close())
+		assert.NoError(t, dEnv.Close())
 	}()
 
 	var wg sync.WaitGroup
@@ -424,7 +417,7 @@ func TestReadOnlySystemVariable(t *testing.T) {
 	dEnv, err := sqle.CreateEnvWithSeedData()
 	require.NoError(t, err)
 	defer func() {
-		assert.NoError(t, dEnv.DoltDB(ctx).Close())
+		assert.NoError(t, dEnv.Close())
 	}()
 
 	// Test read-only server with command line flag
@@ -485,7 +478,7 @@ listener:
 	dEnv, err := sqle.CreateEnvWithSeedData()
 	require.NoError(t, err)
 	defer func() {
-		assert.NoError(t, dEnv.DoltDB(ctx).Close())
+		assert.NoError(t, dEnv.Close())
 	}()
 
 	controller := svcs.NewController()
@@ -521,7 +514,7 @@ func TestPortSystemVariable(t *testing.T) {
 	dEnv, err := sqle.CreateEnvWithSeedData()
 	require.NoError(t, err)
 	defer func() {
-		assert.NoError(t, dEnv.DoltDB(ctx).Close())
+		assert.NoError(t, dEnv.Close())
 	}()
 
 	// Pick an ephemeral free port for this test
@@ -572,7 +565,7 @@ func TestReadOnlyEnforcement(t *testing.T) {
 	dEnv, err := sqle.CreateEnvWithSeedData()
 	require.NoError(t, err)
 	defer func() {
-		assert.NoError(t, dEnv.DoltDB(ctx).Close())
+		assert.NoError(t, dEnv.Close())
 	}()
 
 	// Test read-only server with command line flag
@@ -735,11 +728,10 @@ branch_control_file: dir1/dir2/abc.db
 
 // TestServerSetDefaultBranch is placed at the end because it sets global state that pollutes other tests
 func TestServerSetDefaultBranch(t *testing.T) {
-	ctx := context.Background()
 	dEnv, err := sqle.CreateEnvWithSeedData()
 	require.NoError(t, err)
 	defer func() {
-		assert.NoError(t, dEnv.DoltDB(ctx).Close())
+		assert.NoError(t, dEnv.Close())
 	}()
 
 	serverConfig := DefaultCommandLineServerConfig().withLogLevel(servercfg.LogLevel_Fatal).WithPort(15302)

--- a/go/libraries/doltcore/doltdb/feature_version_test.go
+++ b/go/libraries/doltcore/doltdb/feature_version_test.go
@@ -160,7 +160,7 @@ func TestFeatureVersion(t *testing.T) {
 			doltdb.DoltFeatureVersion = oldVersion
 			dEnv := dtestutils.CreateTestEnv()
 			t.Cleanup(func() {
-				dEnv.DoltDB(ctx).Close()
+				dEnv.Close()
 			})
 			doltdb.DoltFeatureVersion = DoltFeatureVersionCopy
 

--- a/go/libraries/doltcore/doltdb/foreign_key_test.go
+++ b/go/libraries/doltcore/doltdb/foreign_key_test.go
@@ -109,7 +109,7 @@ func TestForeignKeyErrors(t *testing.T) {
 	ctx := t.Context()
 	dEnv := dtestutils.CreateTestEnv()
 	t.Cleanup(func() {
-		dEnv.DoltDB(ctx).Close()
+		dEnv.Close()
 	})
 	cliCtx, err := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, err)
@@ -159,7 +159,7 @@ func testForeignKeys(t *testing.T, test foreignKeyTest) {
 	ctx := t.Context()
 	dEnv := dtestutils.CreateTestEnv()
 	t.Cleanup(func() {
-		dEnv.DoltDB(ctx).Close()
+		dEnv.Close()
 	})
 
 	cliCtx, verr := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)

--- a/go/libraries/doltcore/doltdb/gc_test.go
+++ b/go/libraries/doltcore/doltdb/gc_test.go
@@ -122,7 +122,7 @@ func testGarbageCollection(t *testing.T, test gcTest) {
 	ctx := t.Context()
 	dEnv := dtestutils.CreateTestEnv()
 	t.Cleanup(func() {
-		dEnv.DoltDB(ctx).Close()
+		dEnv.Close()
 	})
 
 	cliCtx, verr := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)

--- a/go/libraries/doltcore/env/actions/infer_schema_test.go
+++ b/go/libraries/doltcore/env/actions/infer_schema_test.go
@@ -450,9 +450,8 @@ func TestInferSchema(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
 			dEnv := dtestutils.CreateTestEnv()
-			defer dEnv.DoltDB(ctx).Close()
+			defer dEnv.Close()
 
 			wrCl, err := dEnv.FS.OpenForWrite(importFilePath, os.ModePerm)
 			require.NoError(t, err)

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -124,8 +124,11 @@ func (dEnv *DoltEnv) DoltDB(ctx context.Context) *doltdb.DoltDB {
 	return dEnv.doltDB
 }
 
+// Close closes the *DoltEnv, and in particular the *DoltDB instance, if it has been loaded.
+// After calling this, DoltDB(ctx) will return `nil`. Close does not reset the sync.Once which
+// loading the database is gated behind.
 func (dEnv *DoltEnv) Close() error {
-	if dEnv.doltDB != nil {
+	if dEnv != nil && dEnv.doltDB != nil {
 		err := dEnv.doltDB.Close()
 		dEnv.doltDB = nil
 		return err

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -124,6 +124,15 @@ func (dEnv *DoltEnv) DoltDB(ctx context.Context) *doltdb.DoltDB {
 	return dEnv.doltDB
 }
 
+func (dEnv *DoltEnv) Close() error {
+	if dEnv.doltDB != nil {
+		err := dEnv.doltDB.Close()
+		dEnv.doltDB = nil
+		return err
+	}
+	return nil
+}
+
 func (dEnv *DoltEnv) LoadDoltDBWithParams(ctx context.Context, nbf *types.NomsBinFormat, urlStr string, fs filesys.Filesys, params map[string]interface{}) error {
 	if dEnv.doltDB == nil {
 		if nbf == nil {

--- a/go/libraries/doltcore/env/environment_test.go
+++ b/go/libraries/doltcore/env/environment_test.go
@@ -168,11 +168,10 @@ func TestRepoDirNoLocal(t *testing.T) {
 }
 
 func TestInitRepo(t *testing.T) {
-	ctx := context.Background()
 	dEnv, _ := createTestEnv(false, false)
 	err := dEnv.InitRepo(context.Background(), types.Format_Default, "aoeu aoeu", "aoeu@aoeu.org", DefaultInitBranch)
 	require.NoError(t, err)
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 
 	_, err = dEnv.WorkingRoot(context.Background())
 	require.NoError(t, err)
@@ -198,7 +197,7 @@ func TestMigrateWorkingSet(t *testing.T) {
 
 	err = dEnv.InitRepo(context.Background(), types.Format_Default, "aoeu aoeu", "aoeu@aoeu.org", DefaultInitBranch)
 	require.NoError(t, err)
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 
 	ws, err := dEnv.WorkingSet(context.Background())
 	require.NoError(t, err)

--- a/go/libraries/doltcore/merge/integration_test.go
+++ b/go/libraries/doltcore/merge/integration_test.go
@@ -122,7 +122,7 @@ func TestMerge(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			dEnv := dtu.CreateTestEnv()
-			defer dEnv.DoltDB(ctx).Close()
+			defer dEnv.Close()
 
 			for _, tc := range setupCommon {
 				exit := tc.exec(t, ctx, dEnv)
@@ -244,7 +244,7 @@ func TestMergeConflicts(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			dEnv := dtu.CreateTestEnv()
-			defer dEnv.DoltDB(ctx).Close()
+			defer dEnv.Close()
 
 			for _, tc := range setupCommon {
 				exit := tc.exec(t, ctx, dEnv)
@@ -293,7 +293,7 @@ const (
 func TestMergeConcurrency(t *testing.T) {
 	ctx := context.Background()
 	dEnv := setupConcurrencyTest(t, ctx)
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 	_, eng := engineFromEnvironment(ctx, dEnv)
 
 	eg, ctx := errgroup.WithContext(ctx)

--- a/go/libraries/doltcore/merge/keyless_integration_test.go
+++ b/go/libraries/doltcore/merge/keyless_integration_test.go
@@ -106,7 +106,7 @@ func TestKeylessMerge(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			dEnv := dtu.CreateTestEnv()
-			defer dEnv.DoltDB(ctx).Close()
+			defer dEnv.Close()
 
 			root, err := dEnv.WorkingRoot(ctx)
 			require.NoError(t, err)
@@ -267,7 +267,7 @@ func TestKeylessMergeConflicts(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dEnv := dtu.CreateTestEnv()
-			defer dEnv.DoltDB(ctx).Close()
+			defer dEnv.Close()
 			setupTest(t, ctx, dEnv, test.setup)
 
 			root, err := dEnv.WorkingRoot(ctx)
@@ -281,7 +281,7 @@ func TestKeylessMergeConflicts(t *testing.T) {
 
 		t.Run(test.name+"_resolved_ours", func(t *testing.T) {
 			dEnv := dtu.CreateTestEnv()
-			defer dEnv.DoltDB(ctx).Close()
+			defer dEnv.Close()
 
 			setupTest(t, ctx, dEnv, test.setup)
 			cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
@@ -302,7 +302,7 @@ func TestKeylessMergeConflicts(t *testing.T) {
 		})
 		t.Run(test.name+"_resolved_theirs", func(t *testing.T) {
 			dEnv := dtu.CreateTestEnv()
-			defer dEnv.DoltDB(ctx).Close()
+			defer dEnv.Close()
 
 			setupTest(t, ctx, dEnv, test.setup)
 			cliCtx, verr := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)

--- a/go/libraries/doltcore/merge/schema_integration_test.go
+++ b/go/libraries/doltcore/merge/schema_integration_test.go
@@ -558,7 +558,7 @@ func testMergeSchemas(t *testing.T, test mergeSchemaTest) {
 
 	ctx := context.Background()
 	dEnv := dtestutils.CreateTestEnv()
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 
 	var err error
 	cliCtx, err := commands.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
@@ -608,7 +608,7 @@ func testMergeSchemasWithConflicts(t *testing.T, test mergeSchemaConflictTest) {
 	}
 
 	dEnv := dtestutils.CreateTestEnv()
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 	for _, c := range setupCommon {
 		exit := c.exec(t, ctx, dEnv)
 		require.Equal(t, 0, exit)
@@ -672,7 +672,7 @@ func testMergeSchemasWithConflicts(t *testing.T, test mergeSchemaConflictTest) {
 func testMergeForeignKeys(t *testing.T, test mergeForeignKeyTest) {
 	ctx := context.Background()
 	dEnv := dtestutils.CreateTestEnv()
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 	for _, c := range setupForeignKeyTests {
 		exit := c.exec(t, ctx, dEnv)
 		require.Equal(t, 0, exit)

--- a/go/libraries/doltcore/rebase/filter_branch_test.go
+++ b/go/libraries/doltcore/rebase/filter_branch_test.go
@@ -217,7 +217,7 @@ func setupFilterBranchTests(t *testing.T) *env.DoltEnv {
 func testFilterBranch(t *testing.T, test filterBranchTest) {
 	ctx := context.Background()
 	dEnv := setupFilterBranchTests(t)
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 	cliCtx, err := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)
 	require.NoError(t, err)
 	defer cliCtx.Close()

--- a/go/libraries/doltcore/schema/encoding/integration_test.go
+++ b/go/libraries/doltcore/schema/encoding/integration_test.go
@@ -72,7 +72,7 @@ func testSchemaSerializationFlatbuffers(t *testing.T, sch schema.Schema) {
 func parseSchemaString(t *testing.T, s string) schema.Schema {
 	ctx := context.Background()
 	dEnv := dtestutils.CreateTestEnv()
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 	root, err := dEnv.WorkingRoot(ctx)
 	require.NoError(t, err)
 	eng, db, err := engine.NewSqlEngineForEnv(ctx, dEnv)

--- a/go/libraries/doltcore/sqle/alterschema_test.go
+++ b/go/libraries/doltcore/sqle/alterschema_test.go
@@ -83,7 +83,7 @@ func TestRenameTable(t *testing.T) {
 		t.Run(tt.description, func(t *testing.T) {
 			ctx := context.Background()
 			dEnv := dtestutils.CreateTestEnv()
-			defer dEnv.DoltDB(ctx).Close()
+			defer dEnv.Close()
 			root, err := dEnv.WorkingRoot(ctx)
 			require.NoError(t, err)
 
@@ -222,7 +222,7 @@ func TestAddColumnToTable(t *testing.T) {
 			ctx := context.Background()
 			dEnv, err := makePeopleTable(ctx, dtestutils.CreateTestEnv())
 			require.NoError(t, err)
-			defer dEnv.DoltDB(ctx).Close()
+			defer dEnv.Close()
 
 			root, err := dEnv.WorkingRoot(ctx)
 			require.NoError(t, err)
@@ -426,7 +426,7 @@ func TestDropPks(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			dEnv := dtestutils.CreateTestEnv()
-			defer dEnv.DoltDB(ctx).Close()
+			defer dEnv.Close()
 
 			db, err := NewDatabase(ctx, "dolt", dEnv.DbData(ctx), editor.Options{})
 			require.NoError(t, err)
@@ -736,7 +736,7 @@ func TestModifyColumn(t *testing.T) {
 			ctx := context.Background()
 			dEnv, err := makePeopleTable(ctx, dtestutils.CreateTestEnv())
 			require.NoError(t, err)
-			defer dEnv.DoltDB(ctx).Close()
+			defer dEnv.Close()
 
 			root, err := dEnv.WorkingRoot(ctx)
 			assert.NoError(t, err)

--- a/go/libraries/doltcore/sqle/cluster/commithook_test.go
+++ b/go/libraries/doltcore/sqle/cluster/commithook_test.go
@@ -29,11 +29,11 @@ func TestCommitHookStartsNotCaughtUp(t *testing.T) {
 	srcEnv := dtestutils.CreateTestEnv()
 	ctx := context.Background()
 	t.Cleanup(func() {
-		srcEnv.DoltDB(ctx).Close()
+		srcEnv.Close()
 	})
 	destEnv := dtestutils.CreateTestEnv()
 	t.Cleanup(func() {
-		destEnv.DoltDB(ctx).Close()
+		destEnv.Close()
 	})
 
 	hook := newCommitHook(logrus.StandardLogger(), "origin", "https://localhost:50051/mydb", "mydb", RolePrimary, func(context.Context) (*doltdb.DoltDB, error) {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -1669,11 +1669,10 @@ func TestNullRanges(t *testing.T) {
 }
 
 func TestPersist(t *testing.T) {
-	ctx := sql.NewEmptyContext()
 	harness := newDoltHarness(t)
 	defer harness.Close()
 	dEnv := dtestutils.CreateTestEnv()
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 	localConf, ok := dEnv.Config.GetConfig(env.LocalConfig)
 	require.True(t, ok)
 	globals := config.NewPrefixConfig(localConf, env.SqlServerGlobalsPrefix)

--- a/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
@@ -560,7 +560,7 @@ func (d *DoltHarness) newProvider(ctx context.Context) sql.MutableDatabaseProvid
 	} else {
 		dEnv = dtestutils.CreateTestEnv()
 	}
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 
 	store := dEnv.DoltDB(ctx).ValueReadWriter().(*types.ValueStore)
 	store.SetValidateContentAddresses(true)

--- a/go/libraries/doltcore/sqle/enginetest/dolt_server_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_server_test.go
@@ -15,7 +15,6 @@
 package enginetest
 
 import (
-	"context"
 	"runtime"
 	"strings"
 	"testing"
@@ -52,10 +51,9 @@ func TestDoltServerRunningUnixSocket(t *testing.T) {
 
 	// Running unix socket server
 	dEnv, sc, serverConfig := startServer(t, false, "", defaultUnixSocketPath)
-	ctx := context.Background()
 	err := sc.WaitForStart()
 	require.NoError(t, err)
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 	require.True(t, strings.Contains(servercfg.ConnectionString(serverConfig, "dolt"), "unix"))
 
 	// default unix socket connection works
@@ -104,7 +102,7 @@ func TestDoltServerRunningUnixSocket(t *testing.T) {
 	dEnv, tcpSc, tcpServerConfig := startServer(t, true, "0.0.0.0", "")
 	err = tcpSc.WaitForStart()
 	require.NoError(t, err)
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 	require.False(t, strings.Contains(servercfg.ConnectionString(tcpServerConfig, "dolt"), "unix"))
 
 	t.Run("host and port specified, there should not be unix socket created", func(t *testing.T) {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_server_tests.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_server_tests.go
@@ -477,13 +477,12 @@ var PersistVariableTests = []queries.ScriptTest{
 // stopping the server in between scripts. Unlike other script test executors, scripts may influence later scripts in
 // the block.
 func testSerialSessionScriptTests(t *testing.T, tests []queries.ScriptTest) {
-	ctx := context.Background()
 	dEnv := dtestutils.CreateTestEnv()
 	serverConfig := sqlserver.DefaultCommandLineServerConfig()
 	rand.Seed(time.Now().UnixNano())
 	port := 15403 + rand.Intn(25)
 	serverConfig = serverConfig.WithPort(port)
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
@@ -632,11 +631,10 @@ func assertResultsEqual(t *testing.T, expected []sql.Row, rows *gosql.Rows) {
 func testMultiSessionScriptTests(t *testing.T, tests []queries.ScriptTest) {
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			ctx := context.Background()
 			dEnv, sc, serverConfig := startServer(t, true, "", "")
 			err := sc.WaitForStart()
 			require.NoError(t, err)
-			defer dEnv.DoltDB(ctx).Close()
+			defer dEnv.Close()
 
 			conn1, sess1 := newConnection(t, serverConfig)
 			conn2, sess2 := newConnection(t, serverConfig)

--- a/go/libraries/doltcore/sqle/integration_test/database_revision_test.go
+++ b/go/libraries/doltcore/sqle/integration_test/database_revision_test.go
@@ -150,7 +150,7 @@ func TestDbRevision(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			dEnv := dtestutils.CreateTestEnv()
-			defer dEnv.DoltDB(ctx).Close()
+			defer dEnv.Close()
 
 			var err error
 			cliCtx, err := cmd.NewArgFreeCliContext(ctx, dEnv, dEnv.FS)

--- a/go/libraries/doltcore/sqle/integration_test/dolt_procedures_history_test.go
+++ b/go/libraries/doltcore/sqle/integration_test/dolt_procedures_history_test.go
@@ -29,9 +29,8 @@ import (
 
 func TestDoltProceduresHistoryTable(t *testing.T) {
 	SkipByDefaultInCI(t)
-	ctx := context.Background()
 	dEnv := setupDoltProceduresHistoryTests(t)
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 	for _, test := range doltProceduresHistoryTableTests() {
 		t.Run(test.name, func(t *testing.T) {
 			testDoltProceduresHistoryTable(t, test, dEnv)

--- a/go/libraries/doltcore/sqle/integration_test/dolt_schemas_history_diff_test.go
+++ b/go/libraries/doltcore/sqle/integration_test/dolt_schemas_history_diff_test.go
@@ -30,9 +30,8 @@ import (
 
 func TestDoltSchemasHistoryTable(t *testing.T) {
 	SkipByDefaultInCI(t)
-	ctx := context.Background()
 	dEnv := setupDoltSchemasHistoryTests(t)
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 	for _, test := range doltSchemasHistoryTableTests() {
 		t.Run(test.name, func(t *testing.T) {
 			testDoltSchemasHistoryTable(t, test, dEnv)
@@ -42,9 +41,8 @@ func TestDoltSchemasHistoryTable(t *testing.T) {
 
 func TestDoltSchemasDiffTable(t *testing.T) {
 	SkipByDefaultInCI(t)
-	ctx := context.Background()
 	dEnv := setupDoltSchemasDiffTests(t)
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 	for _, test := range doltSchemasDiffTableTests() {
 		t.Run(test.name, func(t *testing.T) {
 			testDoltSchemasDiffTable(t, test, dEnv)
@@ -336,9 +334,8 @@ func testDoltSchemasDiffTable(t *testing.T, test doltSchemasTableTest, dEnv *env
 
 func TestDoltProceduresDiffTable(t *testing.T) {
 	SkipByDefaultInCI(t)
-	ctx := context.Background()
 	dEnv := setupDoltProceduresDiffTests(t)
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 	for _, test := range doltProceduresDiffTableTests() {
 		t.Run(test.name, func(t *testing.T) {
 			testDoltProceduresDiffTable(t, test, dEnv)

--- a/go/libraries/doltcore/sqle/integration_test/history_table_test.go
+++ b/go/libraries/doltcore/sqle/integration_test/history_table_test.go
@@ -32,9 +32,8 @@ import (
 
 func TestHistoryTable(t *testing.T) {
 	SkipByDefaultInCI(t)
-	ctx := context.Background()
 	dEnv := setupHistoryTests(t)
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 	for _, test := range historyTableTests() {
 		t.Run(test.name, func(t *testing.T) {
 			testHistoryTable(t, test, dEnv)

--- a/go/libraries/doltcore/sqle/kvexec/count_agg_test.go
+++ b/go/libraries/doltcore/sqle/kvexec/count_agg_test.go
@@ -94,7 +94,7 @@ func TestCountAgg(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			dEnv := dtestutils.CreateTestEnv()
-			defer dEnv.DoltDB(ctx).Close()
+			defer dEnv.Close()
 
 			db, err := sqle.NewDatabase(context.Background(), "dolt", dEnv.DbData(ctx), editor.Options{})
 			require.NoError(t, err)

--- a/go/libraries/doltcore/sqle/kvexec/lookup_join_test.go
+++ b/go/libraries/doltcore/sqle/kvexec/lookup_join_test.go
@@ -153,7 +153,7 @@ func TestLookupJoin(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			dEnv := dtestutils.CreateTestEnv()
-			defer dEnv.DoltDB(ctx).Close()
+			defer dEnv.Close()
 
 			db, err := sqle.NewDatabase(context.Background(), "dolt", dEnv.DbData(ctx), editor.Options{})
 			require.NoError(t, err)

--- a/go/libraries/doltcore/sqle/logictest/dolt/doltharness_test.go
+++ b/go/libraries/doltcore/sqle/logictest/dolt/doltharness_test.go
@@ -99,9 +99,8 @@ func TestDoltHarness(t *testing.T) {
 	}
 
 	fs := filesys.NewInMemFS([]string{}, nil, tmp)
-	ctx := context.Background()
 	dEnv := createTestEnvWithFS(fs, wd)
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 
 	// We run this several times in a row to make sure that the same dolt env can be used in multiple setup / teardown
 	// cycles

--- a/go/libraries/doltcore/sqle/remotesrv_hook_test.go
+++ b/go/libraries/doltcore/sqle/remotesrv_hook_test.go
@@ -106,7 +106,7 @@ func makeTestCommit(t *testing.T, ctx context.Context, ddb *doltdb.DoltDB) (oldR
 func TestHooksFiredOnRemoteSrvStoreCommit(t *testing.T) {
 	ctx := t.Context()
 	dEnv := CreateTestEnv()
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 
 	ddb := dEnv.DoltDB(ctx)
 	oldRoot, newRoot := makeTestCommit(t, ctx, ddb)
@@ -136,7 +136,7 @@ func TestHooksFiredOnRemoteSrvStoreCommit(t *testing.T) {
 func TestHooksNotFiredOnFailedRemoteSrvCommit(t *testing.T) {
 	ctx := t.Context()
 	dEnv := CreateTestEnv()
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 
 	ddb := dEnv.DoltDB(ctx)
 	oldRoot, newRoot := makeTestCommit(t, ctx, ddb)
@@ -174,7 +174,7 @@ func TestHooksNotFiredOnFailedRemoteSrvCommit(t *testing.T) {
 func TestHooksFiredOnDeletedDataset(t *testing.T) {
 	ctx := t.Context()
 	dEnv := CreateTestEnv()
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 
 	ddb := dEnv.DoltDB(ctx)
 
@@ -225,7 +225,7 @@ func TestHooksFiredOnDeletedDataset(t *testing.T) {
 func TestOnlyChangedDatasetsFireHooks(t *testing.T) {
 	ctx := t.Context()
 	dEnv := CreateTestEnv()
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 
 	ddb := dEnv.DoltDB(ctx)
 
@@ -272,7 +272,7 @@ var _ doltdb.CommitHook = (*replicaWriteRecordingCommitHook)(nil)
 func TestReplicaWriteFiltersHooks(t *testing.T) {
 	ctx := t.Context()
 	dEnv := CreateTestEnv()
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 
 	ddb := dEnv.DoltDB(ctx)
 	oldRoot, newRoot := makeTestCommit(t, ctx, ddb)

--- a/go/libraries/doltcore/sqle/replication_test.go
+++ b/go/libraries/doltcore/sqle/replication_test.go
@@ -35,7 +35,7 @@ func TestCommitHooksNoErrors(t *testing.T) {
 	ctx := sql.NewEmptyContext()
 	dEnv, err := CreateEnvWithSeedData()
 	require.NoError(t, err)
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 
 	sql.SystemVariables.SetGlobal(ctx, dsess.SkipReplicationErrors, true)
 	sql.SystemVariables.SetGlobal(ctx, dsess.ReplicateToRemote, "unknown")
@@ -56,7 +56,7 @@ func TestCommitHooksBackgroundThreadsUniqueNames(t *testing.T) {
 	ctx := sql.NewEmptyContext()
 	dEnv, err := CreateEnvWithSeedData()
 	require.NoError(t, err)
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 
 	dest := t.TempDir()
 	t.Cleanup(func() {

--- a/go/libraries/doltcore/sqle/table_editor_fk_test.go
+++ b/go/libraries/doltcore/sqle/table_editor_fk_test.go
@@ -152,7 +152,7 @@ func TestTableEditorForeignKeyCascade(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			dEnv := setupEditorFkTest(ctx, t)
-			defer dEnv.DoltDB(ctx).Close()
+			defer dEnv.Close()
 
 			testRoot, err := ExecuteSql(ctx, dEnv, `
 ALTER TABLE two ADD FOREIGN KEY (v1) REFERENCES one(v1) ON DELETE CASCADE ON UPDATE CASCADE;
@@ -203,7 +203,7 @@ func TestTableEditorForeignKeySetNull(t *testing.T) {
 		t.Run(test.sqlStatement, func(t *testing.T) {
 			ctx := context.Background()
 			dEnv := setupEditorFkTest(ctx, t)
-			defer dEnv.DoltDB(ctx).Close()
+			defer dEnv.Close()
 
 			testRoot, err := ExecuteSql(ctx, dEnv, `
 ALTER TABLE two ADD FOREIGN KEY (v1) REFERENCES one(v1) ON DELETE SET NULL ON UPDATE SET NULL;`)
@@ -287,7 +287,7 @@ func TestTableEditorForeignKeyRestrict(t *testing.T) {
 				t.Run(test.setup+test.trigger, func(t *testing.T) {
 					ctx := context.Background()
 					dEnv := setupEditorFkTest(ctx, t)
-					defer dEnv.DoltDB(ctx).Close()
+					defer dEnv.Close()
 
 					_, err := ExecuteSql(ctx, dEnv, fmt.Sprintf(`
 			ALTER TABLE two ADD FOREIGN KEY (v1) REFERENCES one(v1) %s;
@@ -359,7 +359,7 @@ func TestTableEditorForeignKeyViolations(t *testing.T) {
 		t.Run(test.setup+test.trigger, func(t *testing.T) {
 			ctx := context.Background()
 			dEnv := setupEditorFkTest(ctx, t)
-			defer dEnv.DoltDB(ctx).Close()
+			defer dEnv.Close()
 
 			_, err := ExecuteSql(ctx, dEnv, `
 ALTER TABLE two ADD FOREIGN KEY (v1) REFERENCES one(v1) ON DELETE CASCADE ON UPDATE CASCADE;
@@ -381,7 +381,7 @@ ALTER TABLE three ADD FOREIGN KEY (v1, v2) REFERENCES two(v1, v2) ON DELETE CASC
 func TestTableEditorSelfReferentialForeignKeyRestrict(t *testing.T) {
 	ctx := context.Background()
 	dEnv := setupEditorFkTest(ctx, t)
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 
 	sequentialTests := []struct {
 		statement   string
@@ -449,7 +449,7 @@ func TestTableEditorSelfReferentialForeignKeyRestrict(t *testing.T) {
 func TestTableEditorSelfReferentialForeignKeyCascade(t *testing.T) {
 	ctx := context.Background()
 	dEnv := setupEditorFkTest(ctx, t)
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 
 	sequentialTests := []struct {
 		statement   string
@@ -547,7 +547,7 @@ func TestTableEditorSelfReferentialForeignKeyCascade(t *testing.T) {
 func TestTableEditorSelfReferentialForeignKeySetNull(t *testing.T) {
 	ctx := context.Background()
 	dEnv := setupEditorFkTest(ctx, t)
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 
 	sequentialTests := []struct {
 		statement   string
@@ -853,7 +853,7 @@ func TestTableEditorKeylessFKCascade(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			dEnv := setupEditorKeylessFkTest(ctx, t)
-			defer dEnv.DoltDB(ctx).Close()
+			defer dEnv.Close()
 
 			testRoot, err := ExecuteSql(ctx, dEnv, `
 ALTER TABLE two ADD FOREIGN KEY (v1) REFERENCES one(v1) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/go/libraries/doltcore/sqle/views_test.go
+++ b/go/libraries/doltcore/sqle/views_test.go
@@ -32,7 +32,7 @@ import (
 func TestViews(t *testing.T) {
 	ctx := context.Background()
 	dEnv := dtestutils.CreateTestEnv()
-	defer dEnv.DoltDB(ctx).Close()
+	defer dEnv.Close()
 
 	var err error
 	_, err = ExecuteSql(ctx, dEnv, "create table test (a int primary key)")

--- a/go/libraries/doltcore/table/untyped/sqlexport/sqlwriter_test.go
+++ b/go/libraries/doltcore/table/untyped/sqlexport/sqlwriter_test.go
@@ -87,7 +87,7 @@ func TestEndToEnd(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := sql.NewEmptyContext()
 			dEnv := dtestutils.CreateTestEnv()
-			defer dEnv.DoltDB(ctx).Close()
+			defer dEnv.Close()
 			root, err := dEnv.WorkingRoot(ctx)
 			require.NoError(t, err)
 


### PR DESCRIPTION
Lots of tests do something like `t.Cleanup(func() { dEnv.DoltDB(ctx).Close() })`, which is counter-productive if the DoltDB was never loaded or if that dEnv no longer owns the DoltDB and it has been moved away. Add a first class *DoltEnv.Close() which avoids loading the DoltDB if it isn't already present on the DoltEnv.