### PR TITLE
[no-release-notes] go/store/nbs: Improve the speed of tests in this package.

### DIFF
--- a/go/store/nbs/conjoiner_test.go
+++ b/go/store/nbs/conjoiner_test.go
@@ -115,12 +115,15 @@ func makeTestTableSpecs(t *testing.T, tableSizes []uint32, p tableFilePersister,
 
 func TestConjoin(t *testing.T) {
 	t.Run("fake table persister", func(t *testing.T) {
+		t.Parallel()
 		testConjoin(t, testConjoinModeTableFile, func(*testing.T) tableFilePersister {
 			return newFakeTablePersister(&UnlimitedQuotaProvider{})
 		})
 	})
 	t.Run("in-memory blobstore persister", func(t *testing.T) {
+		t.Parallel()
 		t.Run("table file", func(t *testing.T) {
+			t.Parallel()
 			testConjoin(t, testConjoinModeTableFile, func(*testing.T) tableFilePersister {
 				return &blobstorePersister{
 					bs:        blobstore.NewInMemoryBlobstore(""),
@@ -130,6 +133,7 @@ func TestConjoin(t *testing.T) {
 			})
 		})
 		t.Run("archive", func(t *testing.T) {
+			t.Parallel()
 			testConjoin(t, testConjoinModeArchive, func(*testing.T) tableFilePersister {
 				return &blobstorePersister{
 					bs:        blobstore.NewInMemoryBlobstore(""),
@@ -140,7 +144,9 @@ func TestConjoin(t *testing.T) {
 		})
 	})
 	t.Run("local fs blobstore persister", func(t *testing.T) {
+		t.Parallel()
 		t.Run("table file", func(t *testing.T) {
+			t.Parallel()
 			testConjoin(t, testConjoinModeTableFile, func(*testing.T) tableFilePersister {
 				return &blobstorePersister{
 					bs:        blobstore.NewLocalBlobstore(t.TempDir()),
@@ -150,6 +156,7 @@ func TestConjoin(t *testing.T) {
 			})
 		})
 		t.Run("archive", func(t *testing.T) {
+			t.Parallel()
 			testConjoin(t, testConjoinModeArchive, func(*testing.T) tableFilePersister {
 				return &blobstorePersister{
 					bs:        blobstore.NewLocalBlobstore(t.TempDir()),
@@ -169,8 +176,7 @@ const (
 )
 
 func testConjoin(t *testing.T, mode testConjoinMode, factory func(t *testing.T) tableFilePersister) {
-	stats := &Stats{}
-	setup := func(lock hash.Hash, root hash.Hash, sizes []uint32) (fm *fakeManifest, p tableFilePersister, upstream manifestContents) {
+	setup := func(t *testing.T, lock hash.Hash, root hash.Hash, sizes []uint32) (fm *fakeManifest, p tableFilePersister, upstream manifestContents) {
 		p = factory(t)
 		fm = &fakeManifest{}
 		fm.set(constants.FormatDoltString, lock, root, makeTestTableSpecs(t, sizes, p, mode), nil)
@@ -191,6 +197,7 @@ func testConjoin(t *testing.T, mode testConjoinMode, factory func(t *testing.T) 
 	}
 
 	assertContainAll := func(t *testing.T, p tableFilePersister, expect, actual []tableSpec) {
+		stats := &Stats{}
 		open := func(specs []tableSpec) (sources chunkSources) {
 			for _, sp := range specs {
 				cs, err := p.Open(context.Background(), sp.name, sp.chunkCount, stats)
@@ -235,7 +242,7 @@ func testConjoin(t *testing.T, mode testConjoinMode, factory func(t *testing.T) 
 	}
 
 	// Compact some tables, interloper slips in a new table
-	makeExtra := func(p tableFilePersister) tableSpec {
+	makeExtra := func(t *testing.T, p tableFilePersister) tableSpec {
 		mt := newMemTable(testMemTableSize)
 		data := []byte{0xde, 0xad}
 		mt.addChunk(computeAddr(data), data)
@@ -262,13 +269,14 @@ func testConjoin(t *testing.T, mode testConjoinMode, factory func(t *testing.T) 
 	startLock, startRoot := computeAddr([]byte("lock")), hash.Of([]byte("root"))
 	t.Run("Success", func(t *testing.T) {
 		// Compact some tables, no one interrupts
+		t.Parallel()
 		for _, c := range tc {
 			t.Run(c.name, func(t *testing.T) {
-				fm, p, upstream := setup(startLock, startRoot, c.precompact)
+				fm, p, upstream := setup(t, startLock, startRoot, c.precompact)
 
-				_, _, _, err := conjoin(context.Background(), dherrors.FatalBehaviorError, inlineConjoiner{c.maxTables}, upstream, fm, p, stats)
+				_, _, _, err := conjoin(context.Background(), dherrors.FatalBehaviorError, inlineConjoiner{c.maxTables}, upstream, fm, p, &Stats{})
 				require.NoError(t, err)
-				exists, newUpstream, err := fm.ParseIfExists(context.Background(), stats, nil)
+				exists, newUpstream, err := fm.ParseIfExists(context.Background(), &Stats{}, nil)
 				require.NoError(t, err)
 				assert.True(t, exists)
 				assert.Equal(t, c.postcompact, getSortedSizes(newUpstream.specs))
@@ -278,18 +286,19 @@ func testConjoin(t *testing.T, mode testConjoinMode, factory func(t *testing.T) 
 	})
 
 	t.Run("Retry", func(t *testing.T) {
+		t.Parallel()
 		for _, c := range tc {
 			t.Run(c.name, func(t *testing.T) {
-				fm, p, upstream := setup(startLock, startRoot, c.precompact)
+				fm, p, upstream := setup(t, startLock, startRoot, c.precompact)
 
-				newTable := makeExtra(p)
+				newTable := makeExtra(t, p)
 				u := updatePreemptManifest{fm, func() {
 					specs := append([]tableSpec{}, upstream.specs...)
 					fm.set(constants.FormatDoltString, computeAddr([]byte("lock2")), startRoot, append(specs, newTable), nil)
 				}}
-				_, _, _, err := conjoin(context.Background(), dherrors.FatalBehaviorError, inlineConjoiner{c.maxTables}, upstream, u, p, stats)
+				_, _, _, err := conjoin(context.Background(), dherrors.FatalBehaviorError, inlineConjoiner{c.maxTables}, upstream, u, p, &Stats{})
 				require.NoError(t, err)
-				exists, newUpstream, err := fm.ParseIfExists(context.Background(), stats, nil)
+				exists, newUpstream, err := fm.ParseIfExists(context.Background(), &Stats{}, nil)
 				require.NoError(t, err)
 				assert.True(t, exists)
 				assert.Equal(t, append([]uint32{1}, c.postcompact...), getSortedSizes(newUpstream.specs))
@@ -299,17 +308,18 @@ func testConjoin(t *testing.T, mode testConjoinMode, factory func(t *testing.T) 
 	})
 
 	t.Run("TablesDroppedUpstream", func(t *testing.T) {
+		t.Parallel()
 		// Interloper drops some compactees
 		for _, c := range tc {
 			t.Run(c.name, func(t *testing.T) {
-				fm, p, upstream := setup(startLock, startRoot, c.precompact)
+				fm, p, upstream := setup(t, startLock, startRoot, c.precompact)
 
 				u := updatePreemptManifest{fm, func() {
 					fm.set(constants.FormatDoltString, computeAddr([]byte("lock2")), startRoot, upstream.specs[1:], nil)
 				}}
-				_, _, _, err := conjoin(context.Background(), dherrors.FatalBehaviorError, inlineConjoiner{c.maxTables}, upstream, u, p, stats)
+				_, _, _, err := conjoin(context.Background(), dherrors.FatalBehaviorError, inlineConjoiner{c.maxTables}, upstream, u, p, &Stats{})
 				require.NoError(t, err)
-				exists, newUpstream, err := fm.ParseIfExists(context.Background(), stats, nil)
+				exists, newUpstream, err := fm.ParseIfExists(context.Background(), &Stats{}, nil)
 				require.NoError(t, err)
 				assert.True(t, exists)
 				assert.Equal(t, c.precompact[1:], getSortedSizes(newUpstream.specs))
@@ -317,7 +327,7 @@ func testConjoin(t *testing.T, mode testConjoinMode, factory func(t *testing.T) 
 		}
 	})
 
-	setupAppendix := func(lock hash.Hash, root hash.Hash, specSizes, appendixSizes []uint32) (fm *fakeManifest, p tableFilePersister, upstream manifestContents) {
+	setupAppendix := func(t *testing.T, lock hash.Hash, root hash.Hash, specSizes, appendixSizes []uint32) (fm *fakeManifest, p tableFilePersister, upstream manifestContents) {
 		p = factory(t)
 		fm = &fakeManifest{}
 		fm.set(constants.FormatDoltString, lock, root, makeTestTableSpecs(t, specSizes, p, mode), makeTestTableSpecs(t, appendixSizes, p, mode))
@@ -345,14 +355,15 @@ func testConjoin(t *testing.T, mode testConjoinMode, factory func(t *testing.T) 
 	}
 
 	t.Run("SuccessAppendix", func(t *testing.T) {
+		t.Parallel()
 		// Compact some tables, no one interrupts
 		for _, c := range tca {
 			t.Run(c.name, func(t *testing.T) {
-				fm, p, upstream := setupAppendix(startLock, startRoot, c.precompact, c.appendix)
+				fm, p, upstream := setupAppendix(t, startLock, startRoot, c.precompact, c.appendix)
 
-				_, _, _, err := conjoin(context.Background(), dherrors.FatalBehaviorError, inlineConjoiner{c.maxTables}, upstream, fm, p, stats)
+				_, _, _, err := conjoin(context.Background(), dherrors.FatalBehaviorError, inlineConjoiner{c.maxTables}, upstream, fm, p, &Stats{})
 				require.NoError(t, err)
-				exists, newUpstream, err := fm.ParseIfExists(context.Background(), stats, nil)
+				exists, newUpstream, err := fm.ParseIfExists(context.Background(), &Stats{}, nil)
 				require.NoError(t, err)
 				assert.True(t, exists)
 				assert.Equal(t, c.postcompact, getSortedSizes(newUpstream.specs))
@@ -364,19 +375,20 @@ func testConjoin(t *testing.T, mode testConjoinMode, factory func(t *testing.T) 
 	})
 
 	t.Run("RetryAppendixSpecsChange", func(t *testing.T) {
+		t.Parallel()
 		for _, c := range tca {
 			t.Run(c.name, func(t *testing.T) {
-				fm, p, upstream := setupAppendix(startLock, startRoot, c.precompact, c.appendix)
+				fm, p, upstream := setupAppendix(t, startLock, startRoot, c.precompact, c.appendix)
 
-				newTable := makeExtra(p)
+				newTable := makeExtra(t, p)
 				u := updatePreemptManifest{fm, func() {
 					specs := append([]tableSpec{}, upstream.specs...)
 					fm.set(constants.FormatDoltString, computeAddr([]byte("lock2")), startRoot, append(specs, newTable), upstream.appendix)
 				}}
 
-				_, _, _, err := conjoin(context.Background(), dherrors.FatalBehaviorError, inlineConjoiner{c.maxTables}, upstream, u, p, stats)
+				_, _, _, err := conjoin(context.Background(), dherrors.FatalBehaviorError, inlineConjoiner{c.maxTables}, upstream, u, p, &Stats{})
 				require.NoError(t, err)
-				exists, newUpstream, err := fm.ParseIfExists(context.Background(), stats, nil)
+				exists, newUpstream, err := fm.ParseIfExists(context.Background(), &Stats{}, nil)
 				require.NoError(t, err)
 				assert.True(t, exists)
 				assert.Equal(t, append([]uint32{1}, c.postcompact...), getSortedSizes(newUpstream.specs))
@@ -388,20 +400,21 @@ func testConjoin(t *testing.T, mode testConjoinMode, factory func(t *testing.T) 
 	})
 
 	t.Run("RetryAppendixAppendixChange", func(t *testing.T) {
+		t.Parallel()
 		for _, c := range tca {
 			t.Run(c.name, func(t *testing.T) {
-				fm, p, upstream := setupAppendix(startLock, startRoot, c.precompact, c.appendix)
+				fm, p, upstream := setupAppendix(t, startLock, startRoot, c.precompact, c.appendix)
 
-				newTable := makeExtra(p)
+				newTable := makeExtra(t, p)
 				u := updatePreemptManifest{fm, func() {
 					app := append([]tableSpec{}, upstream.appendix...)
 					specs := append([]tableSpec{}, newTable)
 					fm.set(constants.FormatDoltString, computeAddr([]byte("lock2")), startRoot, append(specs, upstream.specs...), append(app, newTable))
 				}}
 
-				_, _, _, err := conjoin(context.Background(), dherrors.FatalBehaviorError, inlineConjoiner{c.maxTables}, upstream, u, p, stats)
+				_, _, _, err := conjoin(context.Background(), dherrors.FatalBehaviorError, inlineConjoiner{c.maxTables}, upstream, u, p, &Stats{})
 				require.NoError(t, err)
-				exists, newUpstream, err := fm.ParseIfExists(context.Background(), stats, nil)
+				exists, newUpstream, err := fm.ParseIfExists(context.Background(), &Stats{}, nil)
 				require.NoError(t, err)
 				assert.True(t, exists)
 				if newUpstream.appendix != nil {
@@ -415,17 +428,18 @@ func testConjoin(t *testing.T, mode testConjoinMode, factory func(t *testing.T) 
 	})
 
 	t.Run("TablesDroppedUpstreamAppendixSpecChanges", func(t *testing.T) {
+		t.Parallel()
 		// Interloper drops some compactees
 		for _, c := range tca {
 			t.Run(c.name, func(t *testing.T) {
-				fm, p, upstream := setupAppendix(startLock, startRoot, c.precompact, c.appendix)
+				fm, p, upstream := setupAppendix(t, startLock, startRoot, c.precompact, c.appendix)
 
 				u := updatePreemptManifest{fm, func() {
 					fm.set(constants.FormatDoltString, computeAddr([]byte("lock2")), startRoot, upstream.specs[len(c.appendix)+1:], upstream.appendix[:])
 				}}
-				_, _, _, err := conjoin(context.Background(), dherrors.FatalBehaviorError, inlineConjoiner{c.maxTables}, upstream, u, p, stats)
+				_, _, _, err := conjoin(context.Background(), dherrors.FatalBehaviorError, inlineConjoiner{c.maxTables}, upstream, u, p, &Stats{})
 				require.NoError(t, err)
-				exists, newUpstream, err := fm.ParseIfExists(context.Background(), stats, nil)
+				exists, newUpstream, err := fm.ParseIfExists(context.Background(), &Stats{}, nil)
 				require.NoError(t, err)
 				assert.True(t, exists)
 				assert.Equal(t, c.precompact[len(c.appendix)+1:], getSortedSizes(newUpstream.specs))
@@ -435,21 +449,22 @@ func testConjoin(t *testing.T, mode testConjoinMode, factory func(t *testing.T) 
 	})
 
 	t.Run("TablesDroppedUpstreamAppendixAppendixChanges", func(t *testing.T) {
+		t.Parallel()
 		// Interloper drops some compactees
 		for _, c := range tca {
 			t.Run(c.name, func(t *testing.T) {
-				fm, p, upstream := setupAppendix(startLock, startRoot, c.precompact, c.appendix)
+				fm, p, upstream := setupAppendix(t, startLock, startRoot, c.precompact, c.appendix)
 
-				newTable := makeExtra(p)
+				newTable := makeExtra(t, p)
 				u := updatePreemptManifest{fm, func() {
 					specs := append([]tableSpec{}, newTable)
 					specs = append(specs, upstream.specs[len(c.appendix)+1:]...)
 					fm.set(constants.FormatDoltString, computeAddr([]byte("lock2")), startRoot, specs, append([]tableSpec{}, newTable))
 				}}
 
-				_, _, _, err := conjoin(context.Background(), dherrors.FatalBehaviorError, inlineConjoiner{c.maxTables}, upstream, u, p, stats)
+				_, _, _, err := conjoin(context.Background(), dherrors.FatalBehaviorError, inlineConjoiner{c.maxTables}, upstream, u, p, &Stats{})
 				require.NoError(t, err)
-				exists, newUpstream, err := fm.ParseIfExists(context.Background(), stats, nil)
+				exists, newUpstream, err := fm.ParseIfExists(context.Background(), &Stats{}, nil)
 				require.NoError(t, err)
 				assert.True(t, exists)
 				assert.Equal(t, append([]uint32{1}, c.precompact[len(c.appendix)+1:]...), getSortedSizes(newUpstream.specs))

--- a/go/store/nbs/journal_record.go
+++ b/go/store/nbs/journal_record.go
@@ -324,7 +324,7 @@ func processJournalRecordsReader(ctx context.Context, r io.Reader, offin int64, 
 	// to scan to the end of the file in these cases to ensure there is no indication of data loss.
 	recovered = false
 
-	rdr = bufio.NewReaderSize(r, journalWriterBuffSize)
+	rdr = bufio.NewReaderSize(r, int(journalWriterBuffSize))
 	for {
 		if ctx.Err() != nil {
 			err = ctx.Err()
@@ -494,7 +494,7 @@ func possibleDataLossCheck(reader *bufio.Reader) (dataLoss bool, err error) {
 	atEOF := false
 
 	bufferPrefix := 0
-	const buffSize = journalWriterBuffSize * 2
+	buffSize := journalWriterBuffSize * 2
 
 	buf := make([]byte, buffSize)
 

--- a/go/store/nbs/journal_record_test.go
+++ b/go/store/nbs/journal_record_test.go
@@ -290,12 +290,14 @@ func TestJournalTruncated(t *testing.T) {
 }
 
 func TestJournalForDataLossOnBoundary(t *testing.T) {
+	origBuffSize := journalWriterBuffSize
+	journalWriterBuffSize = 8192
+	t.Cleanup(func() { journalWriterBuffSize = origBuffSize })
+
 	r := rand.New(rand.NewSource(987654321))
 	// The data loss detection logic has some special cases around buffer boundaries to avoid reading all data into
 	// memory at once. This test constructs a journal which starts with a few valid records, then a bunch of garbage
 	// data, then we'll stick two records which constitute data loss on the buffer boundary at each byte of the valid buffer.
-	//
-	// The data loss code uses a 10 Mb buffer, so we'll make a 10 Mb journal plus 1 Kb.
 	bufSz := 2*journalWriterBuffSize + (1 << 10)
 
 	// Pre generate random buffer to speed this process up.
@@ -349,7 +351,7 @@ func TestJournalForDataLossOnBoundary(t *testing.T) {
 		t.Run(backer.name, func(t *testing.T) {
 			// startPoint and endPoint define the range of offsets to test for data loss on the boundary.
 			startPoint := (2 * journalWriterBuffSize) - uint32(len(lostData)) - uint32(rootHashRecordSize())
-			// endPoint puts the fist byte of lostData 10 bytes after the 10 Mb read.
+			// endPoint puts the first byte of lostData past the 2*journalWriterBuffSize boundary.
 			endPoint := (2 * journalWriterBuffSize) + uint32(rootHashRecordSize())
 
 			for startPoint <= endPoint {
@@ -364,8 +366,7 @@ func TestJournalForDataLossOnBoundary(t *testing.T) {
 				// Reset the journal buffer to original status.
 				copy(journalBuf[startPoint:startPoint+uint32(len(lostData))], backer.buf[startPoint:startPoint+uint32(len(lostData))])
 
-				// Testing every option takes a couple hours. Don't use `r` because we want this to be non-deterministic.
-				startPoint += uint32(rand.Intn(38) + 1) // Don't want to skip rootHashRecordSize() entirely.
+				startPoint++
 			}
 		})
 	}

--- a/go/store/nbs/journal_writer.go
+++ b/go/store/nbs/journal_writer.go
@@ -34,14 +34,14 @@ import (
 	"github.com/dolthub/dolt/go/store/hash"
 )
 
-const (
-	// journalWriterBuffSize is the size of the statically allocated buffer where journal records are
-	// built before being written to the journal file on disk. There is not a hard limit on the size
-	// of records – specifically, some newer data chunking formats (i.e. optimized JSON storage) can
-	// produce chunks (and therefore chunk records) that are megabytes in size. The current limit of
-	// 5MB should be large enough to cover all but the most extreme cases.
-	journalWriterBuffSize = 5 * 1024 * 1024
+// journalWriterBuffSize is the size of the statically allocated buffer where journal records are
+// built before being written to the journal file on disk. There is not a hard limit on the size
+// of records – specifically, some newer data chunking formats (i.e. optimized JSON storage) can
+// produce chunks (and therefore chunk records) that are megabytes in size. The current limit of
+// 5MB should be large enough to cover all but the most extreme cases.
+var journalWriterBuffSize uint32 = 5 * 1024 * 1024
 
+const (
 	chunkJournalAddr = chunks.JournalFileID
 
 	journalIndexFileName = "journal.idx"


### PR DESCRIPTION
Make journal loss detection tests run against a smaller write buffer.

Make conjoin tests run in parallel.

No loss in test coverage. Tests go from > 120s -> ~15s locally.