### PR TITLE
chore: fix function name in comment to match actual function

### DIFF
--- a/go/store/prolly/tree/json_indexed_document.go
+++ b/go/store/prolly/tree/json_indexed_document.go
@@ -123,7 +123,7 @@ func getInterfaceFromIndexedJsonMap(ctx context.Context, m StaticJsonMap) (val i
 	return val, nil
 }
 
-// getInterfaceFromIndexedJsonMap extracts the JSON bytes from a StaticJsonMap
+// getBytesFromIndexedJsonMap extracts the JSON bytes from a StaticJsonMap
 func getBytesFromIndexedJsonMap(ctx context.Context, m StaticJsonMap) (bytes []byte, err error) {
 	err = m.WalkNodes(ctx, func(ctx context.Context, n *Node) error {
 		if n.IsLeaf() {

--- a/integration-tests/go-sql-server-driver/concurrent_drop_database_test.go
+++ b/integration-tests/go-sql-server-driver/concurrent_drop_database_test.go
@@ -27,7 +27,7 @@ import (
 	driver "github.com/dolthub/dolt/go/libraries/doltcore/dtestutils/sql_server_driver"
 )
 
-// TestconcurrentDropDatabase is a regression test for #10692.
+// TestConcurrentDropDatabase is a regression test for #10692.
 //
 // A lock-ordering bug between *DatabaseProvider and *DoltSession meant that
 // DROP DATABASE during concurrency could cause the DatabaseProvider to


### PR DESCRIPTION
fix function name in comment to match actual function