### PR TITLE
Fix panic when branch tracking has no merge ref

### DIFF
--- a/go/libraries/doltcore/env/remotes.go
+++ b/go/libraries/doltcore/env/remotes.go
@@ -48,6 +48,11 @@ var ErrNoRefSpecForRemote = errors.New("no refspec for remote")
 var ErrInvalidFetchSpec = errors.New("invalid fetch spec")
 var ErrPullWithRemoteNoUpstream = errors.New("You asked to pull from the remote '%s', but did not specify a branch. Because this is not the default configured remote for your current branch, you must specify a branch.")
 var ErrPullWithNoRemoteAndNoUpstream = errors.New("There is no tracking information for the current branch.\nPlease specify which branch you want to merge with.\n\n\tdolt pull <remote> <branch>\n\nIf you wish to set tracking information for this branch you can do so with:\n\n\t dolt push --set-upstream <remote> <branch>\n")
+var ErrPullWithNoUpstreamMergeRef = goerrors.NewKind("there is no tracking information for the current branch '%s'.\n" +
+	"Please specify which branch you want to merge with:\n\n" +
+	"\tdolt pull %s <branch>\n\n" +
+	"If you wish to set tracking information for this branch, run:\n\n" +
+	"\tdolt push --set-upstream %s %s")
 
 var ErrCurrentBranchHasNoUpstream = goerrors.NewKind("fatal: The current branch %s has no upstream branch.\n" +
 	"To push the current branch and set the remote as upstream, use\n" +
@@ -614,8 +619,11 @@ func WithForce(force bool) PullSpecOpt {
 	}
 }
 
-// NewPullSpec returns a PullSpec for the arguments given. This function validates remote and gets remoteRef
-// for given remoteRefName; if it's not defined, it uses current branch to get its upstream branch if it exists.
+// NewPullSpec builds a [PullSpec] for the given remote and branch. When |remoteRefName|
+// is empty, the merge ref is read from the tracking configuration for the current branch.
+// If the tracking entry exists but has no merge ref set, [ErrPullWithNoUpstreamMergeRef] is
+// returned. When |remoteOnly| is true and no tracking configuration exists, an error is
+// returned rather than falling back to a default.
 func NewPullSpec[C doltdb.Context](
 	ctx C,
 	rsr RepoStateReader[C],
@@ -661,6 +669,9 @@ func NewPullSpec[C doltdb.Context](
 		}
 
 		remoteRef = trackedBranch.Merge.Ref
+		if remoteRef == nil {
+			return nil, ErrPullWithNoUpstreamMergeRef.New(branch.GetPath(), remoteName, remoteName, branch.GetPath())
+		}
 	} else {
 		remoteRef = ref.NewBranchRef(remoteRefName)
 	}

--- a/integration-tests/bats/sql-pull.bats
+++ b/integration-tests/bats/sql-pull.bats
@@ -1101,3 +1101,49 @@ SQL
     [[ "$output" =~ "0,0" ]] || false
     [[ "$output" =~ "20,20" ]] || false
 }
+
+# https://github.com/dolthub/dolt/issues/10839
+@test "sql-pull: dolt_pull returns a corrective error when the branch tracking merge ref is unset" {
+    cd repo1
+
+    # Push to the remote without setting upstream tracking, matching the original issue repro.
+    dolt sql -q "call dolt_push('origin', 'main')"
+
+    # Write a tracking entry that has a remote but no merge ref, equivalent to running
+    # git config branch.main.remote origin without a corresponding merge line.
+    # The JSON "head" key is absent, so the Merge field has no ref when the file is loaded.
+    sed -i 's/"branches": {}/"branches": {"main": {"remote": "origin"}}/' .dolt/repo_state.json
+
+    # stderr is merged with stdout so that any runtime crash output is captured in $output.
+    run bash -c "dolt sql -q \"call dolt_pull('origin')\" 2>&1"
+    [ "$status" -eq 1 ]
+    [[ ! "$output" =~ "panic" ]] || false
+    [[ ! "$output" =~ "nil pointer dereference" ]] || false
+    [[ "$output" =~ "there is no tracking information for the current branch" ]] || false
+    [[ "$output" =~ "dolt push --set-upstream origin main" ]] || false
+
+    run bash -c "dolt pull origin 2>&1"
+    [ "$status" -eq 1 ]
+    [[ ! "$output" =~ "panic" ]] || false
+    [[ ! "$output" =~ "nil pointer dereference" ]] || false
+    [[ "$output" =~ "there is no tracking information for the current branch" ]] || false
+    [[ "$output" =~ "dolt push --set-upstream origin main" ]] || false
+
+    # repo1 is at the same commit as the remote here, so the push succeeds in setting
+    # the upstream before repo2 advances the remote.
+    dolt push --set-upstream origin main
+
+    # Push a new commit from repo2 so repo1 has something to pull.
+    cd ../repo2
+    dolt sql -q "call dolt_pull('origin')"
+    dolt sql -q "insert into t1 values (99, 99)"
+    dolt commit -am "new commit for pull test"
+    dolt push origin main
+
+    cd ../repo1
+    run dolt sql -q "call dolt_pull('origin')"
+    [ "$status" -eq 0 ]
+    run dolt sql -q "select * from t1 where a = 99" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "99,99" ]] || false
+}

--- a/integration-tests/bats/sql-pull.bats
+++ b/integration-tests/bats/sql-pull.bats
@@ -1114,18 +1114,13 @@ SQL
     # The JSON "head" key is absent, so the Merge field has no ref when the file is loaded.
     sed -i 's/"branches": {}/"branches": {"main": {"remote": "origin"}}/' .dolt/repo_state.json
 
-    # stderr is merged with stdout so that any runtime crash output is captured in $output.
-    run bash -c "dolt sql -q \"call dolt_pull('origin')\" 2>&1"
+    run dolt sql -q "call dolt_pull('origin')"
     [ "$status" -eq 1 ]
-    [[ ! "$output" =~ "panic" ]] || false
-    [[ ! "$output" =~ "nil pointer dereference" ]] || false
     [[ "$output" =~ "there is no tracking information for the current branch" ]] || false
     [[ "$output" =~ "dolt push --set-upstream origin main" ]] || false
 
-    run bash -c "dolt pull origin 2>&1"
+    run dolt pull origin
     [ "$status" -eq 1 ]
-    [[ ! "$output" =~ "panic" ]] || false
-    [[ ! "$output" =~ "nil pointer dereference" ]] || false
     [[ "$output" =~ "there is no tracking information for the current branch" ]] || false
     [[ "$output" =~ "dolt push --set-upstream origin main" ]] || false
 


### PR DESCRIPTION
 Fixes a `nil` pointer panic in `DOLT_PULL` when a branch has a remote recorded in its tracking configuration but no merge ref set.
Fix dolthub/dolt#10839
