### PR TITLE
Feature: Indexed functional expressions

### DIFF
--- a/go/gen/fb/serial/schema.go
+++ b/go/gen/fb/serial/schema.go
@@ -426,7 +426,19 @@ func (rcv *Column) MutateUsesAdaptiveEncoding(n bool) bool {
 	return rcv._tab.MutateBoolSlot(32, n)
 }
 
-const ColumnNumFields = 15
+func (rcv *Column) HiddenSystem() bool {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(34))
+	if o != 0 {
+		return rcv._tab.GetBool(o + rcv._tab.Pos)
+	}
+	return false
+}
+
+func (rcv *Column) MutateHiddenSystem(n bool) bool {
+	return rcv._tab.MutateBoolSlot(34, n)
+}
+
+const ColumnNumFields = 16
 
 func ColumnStart(builder *flatbuffers.Builder) {
 	builder.StartObject(ColumnNumFields)
@@ -475,6 +487,9 @@ func ColumnAddOnUpdateValue(builder *flatbuffers.Builder, onUpdateValue flatbuff
 }
 func ColumnAddUsesAdaptiveEncoding(builder *flatbuffers.Builder, usesAdaptiveEncoding bool) {
 	builder.PrependBoolSlot(14, usesAdaptiveEncoding, false)
+}
+func ColumnAddHiddenSystem(builder *flatbuffers.Builder, hiddenSystem bool) {
+	builder.PrependBoolSlot(15, hiddenSystem, false)
 }
 func ColumnEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()

--- a/go/go.mod
+++ b/go/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/dolthub/dolt-mcp v0.3.4
 	github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-mysql-server v0.20.1-0.20260422062202-efe7353d35f6
+	github.com/dolthub/go-mysql-server v0.20.1-0.20260422185216-ec754c70a90d
 	github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63
 	github.com/edsrzf/mmap-go v1.2.0
 	github.com/esote/minmaxheap v1.0.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -214,6 +214,8 @@ github.com/dolthub/go-icu-regex v0.0.0-20260412212219-49724d547866 h1:U6gSf5I0e6
 github.com/dolthub/go-icu-regex v0.0.0-20260412212219-49724d547866/go.mod h1:F3cnm+vMRK1HaU6+rNqQrOCyR03HHhR1GWG2gnPOqaE=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260422062202-efe7353d35f6 h1:OSdeHsmaS+ukJrwcywUSe32Ua+OoHlUHGxkw9/c/t2I=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260422062202-efe7353d35f6/go.mod h1:zlONaTcfb/0psjgAvDKY7kNSZ4I3JrYYKV0vMUpL41k=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260422185216-ec754c70a90d h1:c310CB1QRr8le9b0+iv7jP3dibC2GMiPczeB+CEWuHA=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260422185216-ec754c70a90d/go.mod h1:zlONaTcfb/0psjgAvDKY7kNSZ4I3JrYYKV0vMUpL41k=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20260414231531-5f031e3e9037 h1:oIW9HwuWrhxv+4HZxA+QQSKHLqWFyXZ2FmNjUYwkdiM=

--- a/go/libraries/doltcore/schema/column.go
+++ b/go/libraries/doltcore/schema/column.go
@@ -90,6 +90,16 @@ type Column struct {
 
 	// Constraints are rules that can be checked on each column to say if the columns value is valid
 	Constraints []ColConstraint
+
+	// Hidden columns are user created columns that have been marked as not visible. They are not included in * expansion
+	// but can be explicitly queried. Hidden columns still show up in SHOW CREATE TABLE output.
+	Hidden bool
+
+	// SystemHidden columns are hidden columns that are created by the system and cannot be queried directly. They do
+	// not show up in SHOW CREATE TABLE output. They exist as part of the table, but users will never know they are
+	// part of the table. SystemHidden columns are used for storing functional expression results so that they can be
+	// used in secondary indexes.
+	SystemHidden bool
 }
 
 // NewColumn creates a Column instance with the default type info for the NomsKind

--- a/go/libraries/doltcore/schema/encoding/serialization.go
+++ b/go/libraries/doltcore/schema/encoding/serialization.go
@@ -278,7 +278,8 @@ func serializeSchemaColumns(b *fb.Builder, sch schema.Schema) fb.UOffsetT {
 			serial.ColumnAddUsesAdaptiveEncoding(b, true)
 		}
 
-		serial.ColumnAddHidden(b, false)
+		serial.ColumnAddHidden(b, col.Hidden)
+		serial.ColumnAddHiddenSystem(b, col.SystemHidden)
 		offs[i] = serial.ColumnEnd(b)
 	}
 
@@ -392,6 +393,8 @@ func deserializeColumns(ctx context.Context, s *serial.TableSchema) ([]schema.Co
 			AutoIncrement: c.AutoIncrement(),
 			Comment:       string(c.Comment()),
 			Constraints:   constraintsFromSerialColumn(&c),
+			Hidden:        c.Hidden(),
+			SystemHidden:  c.HiddenSystem(),
 		}
 	}
 	return cols, nil

--- a/go/libraries/doltcore/schema/encoding/serialization.go
+++ b/go/libraries/doltcore/schema/encoding/serialization.go
@@ -278,8 +278,13 @@ func serializeSchemaColumns(b *fb.Builder, sch schema.Schema) fb.UOffsetT {
 			serial.ColumnAddUsesAdaptiveEncoding(b, true)
 		}
 
-		serial.ColumnAddHidden(b, col.Hidden)
-		serial.ColumnAddHiddenSystem(b, col.SystemHidden)
+		if col.Hidden {
+			serial.ColumnAddHidden(b, col.Hidden)
+		}
+
+		if col.SystemHidden {
+			serial.ColumnAddHiddenSystem(b, col.SystemHidden)
+		}
 		offs[i] = serial.ColumnEnd(b)
 	}
 

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -772,6 +772,12 @@ func TestIndexes(t *testing.T) {
 	enginetest.TestIndexes(t, harness)
 }
 
+func TestIndexedExpressions(t *testing.T) {
+	harness := newDoltHarness(t)
+	defer harness.Close()
+	enginetest.TestIndexedExpressions(t, harness)
+}
+
 func TestVectorIndexes(t *testing.T) {
 	harness := newDoltHarness(t)
 	defer harness.Close()

--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -556,6 +556,9 @@ type LookupMeta struct {
 	Ordinals []int
 }
 
+// GetStrictLookups searches |indexes| and returns a slice of LookupMeta that indicates which indexes can be used
+// for strict lookups. Indexes may be used for strict lookups if they are a unique index and the columns they
+// cover are not nullable.
 func GetStrictLookups(ctx *sql.Context, schCols *schema.ColCollection, indexes []sql.Index) []LookupMeta {
 	var lookups []LookupMeta
 	for _, i := range indexes {

--- a/go/libraries/doltcore/sqle/index/key_builder.go
+++ b/go/libraries/doltcore/sqle/index/key_builder.go
@@ -15,6 +15,8 @@
 package index
 
 import (
+	"fmt"
+
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
@@ -63,11 +65,19 @@ func NewSecondaryKeyBuilder(ctx *sql.Context, tableName string, sch schema.Schem
 
 				virtualExpressions[i] = expr
 				j = -1
-			} else if keyless {
-				// Skip cardinality column
-				j = b.split + 1 + sch.GetNonPKCols().TagToIdx[tag]
 			} else {
-				j = b.split + sch.GetNonPKCols().TagToIdx[tag]
+				// Use StoredIndexByTag (not TagToIdx) so that virtual columns
+				// don't offset the tuple index
+				storedIdx, ok := sch.GetNonPKCols().StoredIndexByTag(tag)
+				if !ok {
+					return SecondaryKeyBuilder{}, fmt.Errorf("tag %d not found in stored non-PK columns", tag)
+				}
+				// keyless tables have an extra cardinality column before the value fields
+				if keyless {
+					j = b.split + 1 + storedIdx
+				} else {
+					j = b.split + storedIdx
+				}
 			}
 		}
 		b.mapping[i] = j

--- a/go/libraries/doltcore/sqle/sqlutil/convert.go
+++ b/go/libraries/doltcore/sqle/sqlutil/convert.go
@@ -66,6 +66,8 @@ func FromDoltSchema(ctx context.Context, dbName, tableName string, sch schema.Sc
 			Comment:        col.Comment,
 			Virtual:        col.Virtual,
 			Extra:          extra,
+			Hidden:         col.Hidden,
+			HiddenSystem:   col.SystemHidden,
 		}
 		i++
 		return false, nil
@@ -149,7 +151,7 @@ func ToDoltCol(tag uint64, col *sql.Column) (schema.Column, error) {
 	var defaultVal, generatedVal, onUpdateVal string
 	if col.Default != nil {
 		defaultVal = col.Default.String()
-	} else {
+	} else if col.Generated != nil {
 		generatedVal = col.Generated.String()
 	}
 
@@ -170,6 +172,8 @@ func ToDoltCol(tag uint64, col *sql.Column) (schema.Column, error) {
 		AutoIncrement: col.AutoIncrement,
 		Comment:       col.Comment,
 		Constraints:   constraints,
+		Hidden:        col.Hidden,
+		SystemHidden:  col.HiddenSystem,
 	}
 
 	err = schema.ValidateColumn(c)

--- a/go/serial/schema.fbs
+++ b/go/serial/schema.fbs
@@ -68,10 +68,14 @@ table Column {
 
   // sql on update value
   on_update_value:string;
-  
+
   // a marker value only written when the column uses adaptive encoding, which will force older clients to upgrade
   // before reading this data.
   uses_adaptive_encoding:bool;
+
+  // hidden system columns are not directly accessible or visible by users, and are used to
+  // store functional expression results for use in secondary indexes
+  hidden_system:bool;
 }
 
 table Index {


### PR DESCRIPTION
Adds support for secondary indexes to contain functional expressions, which are then used to optimize queries with filters and join conditions that use that indexed functional expression. 

Initial performance testing between Dolt and MySQL shows that Dolt matches, or in some cases beats, MySQL's performance when these indexes are used. 

This initial implementation only supports a single expression in a functional index. Next steps for this work after this PR are: 
1) adding support to Doltgres
2) extending support to multiple expressions in an index (functional expressions mixed with column names)
3) add a sysbench test to compare query performance with indexed expression for Dolt and MySQL