### PR TITLE
[no-release-notes] go: dtestutils/sql_server_driver: Small fix for capturing the result of Cmd.Wait in a less race-y way.

### DIFF
--- a/go/libraries/doltcore/dtestutils/sql_server_driver/cmd.go
+++ b/go/libraries/doltcore/dtestutils/sql_server_driver/cmd.go
@@ -208,6 +208,7 @@ type SqlServer struct {
 	Name        string
 	Done        chan struct{}
 	Cmd         *exec.Cmd
+	CmdWaitErr  error
 	Port        int
 	DebugPort   int
 	Output      *bytes.Buffer
@@ -309,7 +310,10 @@ func runSqlServerCommand(dc DoltCmdable, opts []SqlServerOpt, cmd *exec.Cmd) (*S
 	}
 
 	go func() {
-		defer close(done)
+		defer func() {
+			server.CmdWaitErr = server.Cmd.Wait()
+			close(done)
+		}()
 		logw := server.LogWriter
 		if logw == nil {
 			logw = os.Stdout
@@ -338,7 +342,7 @@ func runSqlServerCommand(dc DoltCmdable, opts []SqlServerOpt, cmd *exec.Cmd) (*S
 
 func (s *SqlServer) ErrorStop() error {
 	<-s.Done
-	return s.Cmd.Wait()
+	return s.CmdWaitErr
 }
 
 func multiCopyWithNamePrefix(stdout, captured io.Writer, in io.Reader, name string, visitor func(string)) {
@@ -395,10 +399,14 @@ func (s *SqlServer) Restart(newargs *[]string, newenvs *[]string) error {
 	if err != nil {
 		return err
 	}
+	s.CmdWaitErr = nil
 	s.Cmd.Stderr = s.Cmd.Stdout
 	s.Done = make(chan struct{})
 	go func() {
-		defer close(s.Done)
+		defer func() {
+			s.CmdWaitErr = s.Cmd.Wait()
+			close(s.Done)
+		}()
 		logw := s.LogWriter
 		if logw == nil {
 			logw = os.Stdout

--- a/go/libraries/doltcore/dtestutils/sql_server_driver/cmd_unix.go
+++ b/go/libraries/doltcore/dtestutils/sql_server_driver/cmd_unix.go
@@ -29,11 +29,7 @@ func ApplyCmdAttributes(cmd *exec.Cmd) {
 func (s *SqlServer) GracefulStop() error {
 	select {
 	case <-s.Done:
-		if s.Cmd.ProcessState.Success() {
-			return nil
-		} else {
-			return &exec.ExitError{ProcessState: s.Cmd.ProcessState}
-		}
+		return s.CmdWaitErr
 	default:
 	}
 	err := s.Cmd.Process.Signal(syscall.SIGTERM)
@@ -41,5 +37,5 @@ func (s *SqlServer) GracefulStop() error {
 		return err
 	}
 	<-s.Done
-	return s.Cmd.Wait()
+	return s.CmdWaitErr
 }

--- a/integration-tests/go-sql-server-driver/concurrent_gc_test.go
+++ b/integration-tests/go-sql-server-driver/concurrent_gc_test.go
@@ -325,6 +325,6 @@ func (gct gcTest) run(t *testing.T) {
 	db.Close()
 	db, err = server.DB(driver.Connection{User: "root"})
 	require.NoError(t, err)
-
 	gct.finalize(t, context.Background(), db)
+	db.Close()
 }


### PR DESCRIPTION
The previous read in of ProcessState in GracefulStop() could occur without Cmd.Wait actually being called. It's cleaner to always call it from the output copying routine and to always block on that routine being finished before reading it.