### PR TITLE
go: utils/config: file_config.go: Make concurrent reads and writes safe.

### DIFF
--- a/go/libraries/utils/config/file_config.go
+++ b/go/libraries/utils/config/file_config.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 )
@@ -28,6 +29,7 @@ type FileConfig struct {
 	// The path of the config file in the filesystem
 	Path string
 
+	mu         sync.RWMutex
 	fs         filesys.ReadWriteFS
 	properties map[string]string
 }
@@ -46,7 +48,7 @@ func NewFileConfig(path string, fs filesys.ReadWriteFS, properties map[string]st
 		return nil, err
 	}
 
-	fc := &FileConfig{path, fs, properties}
+	fc := &FileConfig{Path: path, fs: fs, properties: properties}
 	err = fc.write()
 
 	if err != nil {
@@ -72,11 +74,13 @@ func FromFile(path string, fs filesys.ReadWriteFS) (*FileConfig, error) {
 		return nil, err
 	}
 
-	return &FileConfig{path, fs, properties}, nil
+	return &FileConfig{Path: path, fs: fs, properties: properties}, nil
 }
 
 // GetString retrieves a string from the cached config state
 func (fc *FileConfig) GetString(k string) (string, error) {
+	fc.mu.RLock()
+	defer fc.mu.RUnlock()
 	if val, ok := fc.properties[k]; ok {
 		return val, nil
 	}
@@ -86,6 +90,8 @@ func (fc *FileConfig) GetString(k string) (string, error) {
 
 // GetString retrieves a string from the cached config state
 func (fc *FileConfig) GetStringOrDefault(k, defStr string) string {
+	fc.mu.RLock()
+	defer fc.mu.RUnlock()
 	if val, ok := fc.properties[k]; ok {
 		return val
 	}
@@ -95,6 +101,8 @@ func (fc *FileConfig) GetStringOrDefault(k, defStr string) string {
 
 // SetStrings will set the value of configuration parameters in memory, and persist any changes to the backing file.
 func (fc *FileConfig) SetStrings(updates map[string]string) error {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
 	modified := false
 	for k, v := range updates {
 		if val, ok := fc.properties[k]; !ok || val != v {
@@ -113,6 +121,8 @@ func (fc *FileConfig) SetStrings(updates map[string]string) error {
 // Iter will perform a callback for ech value in a config until all values have been exhausted or until the
 // callback returns true indicating that it should stop.
 func (fc *FileConfig) Iter(cb func(string, string) (stop bool)) {
+	fc.mu.RLock()
+	defer fc.mu.RUnlock()
 	for k, v := range fc.properties {
 		stop := cb(k, v)
 
@@ -134,6 +144,8 @@ func (fc *FileConfig) write() error {
 
 // Unset removes a configuration parameter from the config
 func (fc *FileConfig) Unset(params []string) error {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
 	for _, param := range params {
 		if _, ok := fc.properties[param]; !ok {
 			return errors.New("key does not exist on this configuration")
@@ -147,5 +159,7 @@ func (fc *FileConfig) Unset(params []string) error {
 
 // Size returns the number of properties contained within the config
 func (fc *FileConfig) Size() int {
+	fc.mu.RLock()
+	defer fc.mu.RUnlock()
 	return len(fc.properties)
 }

--- a/go/libraries/utils/config/file_config_test.go
+++ b/go/libraries/utils/config/file_config_test.go
@@ -15,10 +15,23 @@
 package config
 
 import (
+	"fmt"
+	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 )
+
+func newTestFileConfig(t *testing.T) *FileConfig {
+	t.Helper()
+	fs := filesys.NewInMemFS([]string{}, map[string][]byte{}, "/")
+	cfg, err := NewFileConfig(cfgPath, fs, map[string]string{})
+	require.NoError(t, err)
+	return cfg
+}
 
 const (
 	cfgPath = "/home/bheni/.ld/config.json"
@@ -68,4 +81,180 @@ func TestGetAndSet(t *testing.T) {
 	}
 
 	testIteration(t, map[string]string{"string": "this is a string", "uint": "1234567"}, cfg)
+}
+
+func TestConcurrentSetStrings(t *testing.T) {
+	cfg := newTestFileConfig(t)
+	const goroutines = 50
+	const keysPerGoroutine = 20
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < keysPerGoroutine; j++ {
+				k := fmt.Sprintf("g%d_k%d", id, j)
+				err := cfg.SetStrings(map[string]string{k: fmt.Sprintf("v%d", j)})
+				assert.NoError(t, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Equal(t, goroutines*keysPerGoroutine, cfg.Size())
+}
+
+func TestConcurrentGetString(t *testing.T) {
+	cfg := newTestFileConfig(t)
+	require.NoError(t, cfg.SetStrings(map[string]string{"key": "value"}))
+
+	const goroutines = 100
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			v, err := cfg.GetString("key")
+			assert.NoError(t, err)
+			assert.Equal(t, "value", v)
+		}()
+	}
+	wg.Wait()
+}
+
+func TestConcurrentReadsAndWrites(t *testing.T) {
+	cfg := newTestFileConfig(t)
+	require.NoError(t, cfg.SetStrings(map[string]string{"shared": "init"}))
+
+	const goroutines = 50
+	const iterations = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 4) // 4 operation types
+
+	// Concurrent SetStrings
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				err := cfg.SetStrings(map[string]string{
+					"shared":               fmt.Sprintf("writer%d_iter%d", id, j),
+					fmt.Sprintf("w%d", id): fmt.Sprintf("%d", j),
+				})
+				assert.NoError(t, err)
+			}
+		}(i)
+	}
+
+	// Concurrent GetString
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				_, _ = cfg.GetString("shared")
+			}
+		}()
+	}
+
+	// Concurrent GetStringOrDefault
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				v := cfg.GetStringOrDefault("shared", "default")
+				assert.NotEmpty(t, v)
+			}
+		}()
+	}
+
+	// Concurrent Iter
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				cfg.Iter(func(k, v string) bool {
+					return false
+				})
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestConcurrentSetAndUnset(t *testing.T) {
+	cfg := newTestFileConfig(t)
+
+	// Pre-populate keys that will be unset.
+	keys := make([]string, 100)
+	init := make(map[string]string)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("key%d", i)
+		init[keys[i]] = "val"
+	}
+	require.NoError(t, cfg.SetStrings(init))
+
+	var wg sync.WaitGroup
+
+	// Half the goroutines set new keys, the other half unset existing ones.
+	const setters = 25
+	const unsetters = 25
+	wg.Add(setters + unsetters)
+
+	for i := 0; i < setters; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				k := fmt.Sprintf("new_%d_%d", id, j)
+				err := cfg.SetStrings(map[string]string{k: "v"})
+				assert.NoError(t, err)
+			}
+		}(i)
+	}
+
+	for i := 0; i < unsetters; i++ {
+		go func(id int) {
+			defer wg.Done()
+			// Each unsetter removes distinct keys so no double-delete conflicts.
+			for j := 0; j < 4; j++ {
+				idx := id*4 + j
+				err := cfg.Unset([]string{keys[idx]})
+				assert.NoError(t, err)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// 100 original - 100 unset + 500 new = 500
+	assert.Equal(t, 500, cfg.Size())
+}
+
+func TestConcurrentSize(t *testing.T) {
+	cfg := newTestFileConfig(t)
+
+	var wg sync.WaitGroup
+	const goroutines = 50
+	wg.Add(goroutines * 2)
+
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			err := cfg.SetStrings(map[string]string{fmt.Sprintf("k%d", id): "v"})
+			assert.NoError(t, err)
+		}(i)
+	}
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			s := cfg.Size()
+			assert.GreaterOrEqual(t, s, 0)
+			assert.LessOrEqual(t, s, goroutines)
+		}()
+	}
+
+	wg.Wait()
+	assert.Equal(t, goroutines, cfg.Size())
 }


### PR DESCRIPTION
Persisted SQL session variables land in at an instance of *FileConfig. It needs to be thread-safe.

Fixes some transient crashes which can occur while under load and switching dolt_cluster role, for example.