### PR TITLE
[no-release-notes] integration-tests/mysql-client-tests: Fix some process lifecycle and test teardown stuff.

### DIFF
--- a/integration-tests/mysql-client-tests/helpers.bash
+++ b/integration-tests/mysql-client-tests/helpers.bash
@@ -21,7 +21,9 @@ setup_dolt_repo() {
 }
 
 teardown_dolt_repo() {
-    kill $SERVER_PID
+    kill $SERVER_PID || :
+    wait $SERVER_PID || :
+    SERVER_PID=
     rm -rf $REPO_NAME
 }
 

--- a/integration-tests/mysql-client-tests/mariadb-binlog.bats
+++ b/integration-tests/mysql-client-tests/mariadb-binlog.bats
@@ -172,7 +172,7 @@ setup() {
 }
 
 teardown() {
-  stop_sql_server
+  stop_sql_server 1
 }
 
 teardown_file() {

--- a/integration-tests/mysql-client-tests/mysql-client-tests.bats
+++ b/integration-tests/mysql-client-tests/mysql-client-tests.bats
@@ -18,8 +18,13 @@ setup() {
 }
 
 teardown() {
+    # Kill and wait the server before cd/rm so the process exits
+    # before its data directory is removed.
+    kill $SERVER_PID || :
+    wait $SERVER_PID || :
+    SERVER_PID=
     cd ..
-    teardown_dolt_repo
+    rm -rf $REPO_NAME
 
     # Check if postgresql is still running. If so stop it
     active=$(service postgresql status)
@@ -90,7 +95,8 @@ assert_mariadb_version_auth_and_db_selection() {
 
 @test "python replication client" {
     # Stop the server that setup launched
-    kill $SERVER_PID
+    kill $SERVER_PID || :
+    wait $SERVER_PID || :
 
     # Configure binlog replication settings
     dolt sql -q "SET @@PERSIST.log_bin=1;"


### PR DESCRIPTION
Makes tests more reliable.

Mimics similar changes we made to integration-tests/bats in 05e98ed61c91bc53d2b410ef4b90bbf5da1f0bc9.