### PR TITLE
bug fix: dolt pull origin <branch> is pulling all branches

### DIFF
--- a/go/libraries/doltcore/sqle/dprocedures/dolt_pull.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_pull.go
@@ -173,7 +173,16 @@ func doDoltPull(ctx *sql.Context, args []string) (int, int, string, error) {
 			fmt.Errorf("branch %q not found on remote", pullSpec.Branch.GetPath())
 	}
 
-	// Fetch all references
+	// Fetch references. When a specific branch is given, only fetch that branch
+	// to avoid unnecessarily downloading data for all remote branches.
+	fetchRefSpecs := pullSpec.RefSpecs
+	if remoteRefName != "" {
+		specificRefSpecs, specErr := env.ParseRSFromArgs(pullSpec.Remote.Name, []string{remoteRefName})
+		if specErr == nil && len(specificRefSpecs) > 0 {
+			fetchRefSpecs = specificRefSpecs
+		}
+	}
+
 	branchRefs, err := srcDB.GetHeadRefs(ctx)
 	if err != nil {
 		return noConflictsOrViolations, threeWayMerge, "", fmt.Errorf("%w: %s", env.ErrFailedToReadDb, err.Error())
@@ -181,7 +190,7 @@ func doDoltPull(ctx *sql.Context, args []string) (int, int, string, error) {
 	prune := apr.Contains(cli.PruneFlag)
 	mode := ref.UpdateMode{Force: true, Prune: prune}
 	pull.WithDiscardingStatsCh(func(statsCh chan pull.Stats) {
-		err = actions.FetchRefSpecs(ctx, dbData, srcDB, pullSpec.RefSpecs, false, &pullSpec.Remote, mode, statsCh)
+		err = actions.FetchRefSpecs(ctx, dbData, srcDB, fetchRefSpecs, false, &pullSpec.Remote, mode, statsCh)
 	})
 	if err != nil {
 		return noConflictsOrViolations, threeWayMerge, "", fmt.Errorf("fetch failed: %w", err)

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_pull.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_pull.go
@@ -178,7 +178,10 @@ func doDoltPull(ctx *sql.Context, args []string) (int, int, string, error) {
 	fetchRefSpecs := pullSpec.RefSpecs
 	if remoteRefName != "" {
 		specificRefSpecs, specErr := env.ParseRSFromArgs(pullSpec.Remote.Name, []string{remoteRefName})
-		if specErr == nil && len(specificRefSpecs) > 0 {
+		if specErr != nil {
+			return 0, 0, "", fmt.Errorf("invalid remote ref argument %q: %w", remoteRefName, specErr)
+		}
+		if len(specificRefSpecs) > 0 {
 			fetchRefSpecs = specificRefSpecs
 		}
 	}

--- a/integration-tests/bats/sql-fetch.bats
+++ b/integration-tests/bats/sql-fetch.bats
@@ -292,6 +292,41 @@ teardown() {
     [[ "$output" =~ "invalid ref spec: 'unknown'" ]] || false
 }
 
+@test "sql-fetch: dolt_fetch with specific branch does not fetch other branches" {
+    cd repo1
+    dolt checkout -b other
+    dolt push --set-upstream origin other
+    dolt checkout main
+
+    cd ../repo2
+    dolt fetch
+    dolt checkout other
+    dolt checkout main
+
+    # Make changes on both branches in repo1
+    cd ../repo1
+    dolt sql -q "insert into t1 values (10, 10)"
+    dolt commit -am "new commit on main"
+    dolt push origin main
+    dolt checkout other
+    dolt commit --allow-empty -m "new commit on other"
+    dolt push origin other
+
+    # Fetch only main in repo2
+    cd ../repo2
+    dolt sql -q "call dolt_fetch('origin', 'main')"
+
+    # main's remote tracking ref should be updated
+    run dolt log --oneline remotes/origin/main -n 1
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "new commit on main" ]] || false
+
+    # other's remote tracking ref should NOT be updated
+    run dolt log --oneline remotes/origin/other -n 1
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "new commit on other" ]] || false
+}
+
 @test "sql-fetch: dolt_fetch empty remote fails" {
     cd repo2
     dolt remote remove origin

--- a/integration-tests/bats/sql-pull.bats
+++ b/integration-tests/bats/sql-pull.bats
@@ -356,6 +356,46 @@ SQL
     [[ "$output" =~ "behind 'origin/other' by 1 commit" ]] || false
 }
 
+@test "sql-pull: dolt_pull with specific branch does not fetch other branches" {
+    cd repo1
+    dolt checkout -b other
+    dolt push --set-upstream origin other
+    dolt checkout main
+
+    cd ../repo2
+    dolt fetch
+    dolt checkout other
+    dolt checkout main
+
+    # Make changes on both branches in repo1
+    cd ../repo1
+    dolt sql -q "insert into t1 values (10, 10)"
+    dolt commit -am "new commit on main"
+    dolt push origin main
+    dolt checkout other
+    dolt commit --allow-empty -m "new commit on other"
+    dolt push origin other
+
+    # Pull only main in repo2
+    cd ../repo2
+    dolt sql -q "call dolt_pull('origin', 'main')"
+
+    # main should be updated
+    run dolt log --oneline -n 1
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "new commit on main" ]] || false
+
+    # other's remote tracking ref should NOT be updated
+    dolt checkout other
+    run dolt log --oneline -n 1
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "new commit on other" ]] || false
+
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "behind" ]] || false
+}
+
 @test "sql-pull: dolt_pull commits successful merge on current branch" {
     cd repo1
     dolt checkout -b other

--- a/integration-tests/bats/sql-pull.bats
+++ b/integration-tests/bats/sql-pull.bats
@@ -425,7 +425,7 @@ SQL
     dolt checkout main
 
     cd ../repo1
-    dolt pull origin main
+    dolt fetch origin b1
     dolt checkout b1
     dolt pull origin b1
 
@@ -485,7 +485,7 @@ SQL
     dolt checkout main
 
     cd ../repo1
-    dolt pull origin main
+    dolt fetch origin b1
     dolt checkout b1
     dolt pull origin b1
 


### PR DESCRIPTION
`dolt_pull('origin', 'main');` - was pulling all branches. Now it's not.

Fixes: https://github.com/dolthub/dolt/issues/10728
