### PR TITLE
Fix ssh subprocess leak in `dolt_fetch` and `dolt_push`

### DIFF
--- a/go/libraries/doltcore/sqle/dprocedures/dolt_fetch.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_fetch.go
@@ -85,6 +85,7 @@ func doDoltFetch(ctx *sql.Context, args []string) (int, error) {
 	if err != nil {
 		return 1, err
 	}
+	defer srcDB.Close()
 
 	err = srcDB.Rebase(ctx)
 	if err != nil {

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_pull.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_pull.go
@@ -152,6 +152,7 @@ func doDoltPull(ctx *sql.Context, args []string) (int, int, string, error) {
 	if err != nil {
 		return noConflictsOrViolations, threeWayMerge, "", fmt.Errorf("failed to get remote db; %w", err)
 	}
+	defer srcDB.Close()
 
 	err = srcDB.Rebase(ctx)
 	if err != nil {

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_push.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_push.go
@@ -91,10 +91,11 @@ func doDoltPush(ctx *sql.Context, args []string) (int, string, error) {
 		remote = &rmt
 	}
 
-	remoteDB, err := sess.Provider().GetRemoteDB(ctx, dbData.Ddb.ValueReadWriter().Format(), *remote, true)
+	remoteDB, err := sess.Provider().GetRemoteDB(ctx, dbData.Ddb.ValueReadWriter().Format(), *remote, false)
 	if err != nil {
 		return cmdFailure, "", actions.HandleInitRemoteStorageClientErr(remote.Name, remote.Url, err)
 	}
+	defer remoteDB.Close()
 
 	err = remoteDB.Rebase(ctx)
 	if err != nil {

--- a/integration-tests/bats/ssh-transfer.bats
+++ b/integration-tests/bats/ssh-transfer.bats
@@ -691,3 +691,35 @@ MOCK
     [ "$status" -eq 0 ]
     [[ "$output" =~ "hello" ]] || false
 }
+
+@test "ssh-transfer: dolt_fetch via sql-server does not leak subprocesses" {
+    # See https://github.com/dolthub/dolt/issues/10897
+    mkdir "repo_leak_remote"
+    cd "repo_leak_remote"
+    dolt init --initial-branch main
+    dolt sql -q "CREATE TABLE t (id INT PRIMARY KEY);"
+    dolt sql -q "INSERT INTO t VALUES (1),(2),(3);"
+    dolt add .
+    dolt commit -m "init"
+
+    cd "$BATS_TEST_TMPDIR"
+    mkdir "repo_leak_local"
+    cd "repo_leak_local"
+    dolt init --initial-branch main
+    start_sql_server "repo_leak_local"
+
+    dolt --host 127.0.0.1 --port "$PORT" --no-tls --use-db "repo_leak_local" sql -q \
+        "CALL dolt_remote('add', 'origin', 'ssh://localhost$BATS_TEST_TMPDIR/repo_leak_remote');"
+
+    for i in 1 2 3; do
+        dolt --host 127.0.0.1 --port "$PORT" --no-tls --use-db "repo_leak_local" sql -q \
+            "CALL dolt_fetch('origin', 'main');"
+        sleep 1
+        LEAKED=$(pgrep -P "$SERVER_PID" | wc -l | tr -d ' ')
+        echo "after fetch $i: $LEAKED leaked children of sql-server (PID $SERVER_PID)"
+    done
+
+    sleep 2
+    LEAKED=$(pgrep -P "$SERVER_PID" | wc -l | tr -d ' ')
+    [ "$LEAKED" -eq 0 ]
+}

--- a/integration-tests/bats/ssh-transfer.bats
+++ b/integration-tests/bats/ssh-transfer.bats
@@ -692,9 +692,8 @@ MOCK
     [[ "$output" =~ "hello" ]] || false
 }
 
-# assert_no_ssh_subprocess_leak calls |query| |n| times against the running
-# sql-server over TCP and asserts that no transfer subprocesses remain as
-# children of the server after all calls complete.
+# assert_no_ssh_subprocess_leak runs |query| |n| times via the sql-server and
+# asserts that no transfer subprocesses remain as children of the server.
 assert_no_ssh_subprocess_leak() {
     local n="$1" query="$2" i leaked
     for i in $(seq 1 "$n"); do

--- a/integration-tests/bats/ssh-transfer.bats
+++ b/integration-tests/bats/ssh-transfer.bats
@@ -692,6 +692,22 @@ MOCK
     [[ "$output" =~ "hello" ]] || false
 }
 
+# assert_no_ssh_subprocess_leak calls |query| |n| times against the running
+# sql-server over TCP and asserts that no transfer subprocesses remain as
+# children of the server after all calls complete.
+assert_no_ssh_subprocess_leak() {
+    local n="$1" query="$2" i leaked
+    for i in $(seq 1 "$n"); do
+        dolt --host 127.0.0.1 --port "$PORT" --no-tls --use-db "$DEFAULT_DB" sql -q "$query"
+        sleep 1
+        leaked=$(pgrep -P "$SERVER_PID" | wc -l | tr -d ' ')
+        echo "after call $i: $leaked leaked children (PID $SERVER_PID)"
+    done
+    sleep 2
+    leaked=$(pgrep -P "$SERVER_PID" | wc -l | tr -d ' ')
+    [ "$leaked" -eq 0 ]
+}
+
 @test "ssh-transfer: dolt_fetch via sql-server does not leak subprocesses" {
     # See https://github.com/dolthub/dolt/issues/10897
     mkdir "repo_leak_remote"
@@ -708,18 +724,29 @@ MOCK
     dolt init --initial-branch main
     start_sql_server "repo_leak_local"
 
-    dolt --host 127.0.0.1 --port "$PORT" --no-tls --use-db "repo_leak_local" sql -q \
+    dolt --host 127.0.0.1 --port "$PORT" --no-tls --use-db "$DEFAULT_DB" sql -q \
         "CALL dolt_remote('add', 'origin', 'ssh://localhost$BATS_TEST_TMPDIR/repo_leak_remote');"
 
-    for i in 1 2 3; do
-        dolt --host 127.0.0.1 --port "$PORT" --no-tls --use-db "repo_leak_local" sql -q \
-            "CALL dolt_fetch('origin', 'main');"
-        sleep 1
-        LEAKED=$(pgrep -P "$SERVER_PID" | wc -l | tr -d ' ')
-        echo "after fetch $i: $LEAKED leaked children of sql-server (PID $SERVER_PID)"
-    done
+    assert_no_ssh_subprocess_leak 3 "CALL dolt_fetch('origin', 'main');"
+}
 
-    sleep 2
-    LEAKED=$(pgrep -P "$SERVER_PID" | wc -l | tr -d ' ')
-    [ "$LEAKED" -eq 0 ]
+@test "ssh-transfer: dolt_push via sql-server does not leak subprocesses" {
+    # See https://github.com/dolthub/dolt/issues/10897
+    mkdir "repo_push_remote"
+    cd "repo_push_remote"
+    dolt init --initial-branch main
+    dolt sql -q "CREATE TABLE t (id INT PRIMARY KEY);"
+    dolt sql -q "INSERT INTO t VALUES (1),(2),(3);"
+    dolt add .
+    dolt commit -m "init"
+
+    cd "$BATS_TEST_TMPDIR"
+    dolt clone "ssh://localhost$BATS_TEST_TMPDIR/repo_push_remote" repo_push_local
+    cd "repo_push_local"
+    dolt sql -q "INSERT INTO t VALUES (4);"
+    dolt add .
+    dolt commit -m "add row"
+    start_sql_server "repo_push_local"
+
+    assert_no_ssh_subprocess_leak 3 "CALL dolt_push('origin', 'main');"
 }


### PR DESCRIPTION
`CALL dolt_fetch` and `CALL dolt_push` against `ssh://` remotes were not closing the remote database handle after the operation completed. For SSH remotes this meant the server kept its end of the stdin pipe to the dolt transfer child process open indefinitely.

Fix dolthub/dolt#10897