### PR TITLE
[no-release-notes] Refactor commitwalk. skip SQL engine dependency

### DIFF
--- a/go/libraries/doltcore/commitgraph/commitgraph.go
+++ b/go/libraries/doltcore/commitgraph/commitgraph.go
@@ -234,12 +234,12 @@ func (it *topoIter) Reset(ctx context.Context) error {
 // --- dot-dot iterator ------------------------------------------------------
 
 type dotDotIter struct {
-	includedResolver  HashResolver
-	excludedResolver  HashResolver
-	startHashes       []hash.Hash
-	excludedHashes    []hash.Hash
-	matchFn           func(*CommitInfo) (bool, error)
-	q                 *pq
+	includedResolver HashResolver
+	excludedResolver HashResolver
+	startHashes      []hash.Hash
+	excludedHashes   []hash.Hash
+	matchFn          func(*CommitInfo) (bool, error)
+	q                *pq
 }
 
 func newDotDotIter(ctx context.Context, inclR HashResolver, inclH []hash.Hash, exclR HashResolver, exclH []hash.Hash, matchFn func(*CommitInfo) (bool, error)) (*dotDotIter, error) {

--- a/go/libraries/doltcore/commitgraph/commitgraph.go
+++ b/go/libraries/doltcore/commitgraph/commitgraph.go
@@ -1,0 +1,305 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package commitgraph provides a lightweight topological commit graph iterator.
+//
+// Unlike env/actions/commitwalk, this package does NOT depend on the doltdb
+// package and therefore does not transitively pull in go-mysql-server or
+// go-icu-regex. It depends only on store/datas and store/hash.
+//
+// Consumers inside Dolt that already import doltdb should continue using
+// commitwalk. This package is for lightweight consumers (such as DumboDB) that
+// only need commit graph traversal without the full SQL engine dependency.
+package commitgraph
+
+import (
+	"container/heap"
+	"context"
+	"io"
+
+	"github.com/dolthub/dolt/go/store/datas"
+	"github.com/dolthub/dolt/go/store/hash"
+)
+
+// HashResolver resolves a commit hash to its CommitInfo. Implementations
+// should return a CommitInfo with IsGhost=true for ghost (placeholder) commits.
+type HashResolver interface {
+	ResolveCommitHash(ctx context.Context, h hash.Hash) (*CommitInfo, error)
+}
+
+// CommitInfo holds the commit data needed for graph traversal.
+type CommitInfo struct {
+	Hash    hash.Hash
+	Height  uint64
+	Meta    *datas.CommitMeta
+	Parents []hash.Hash // parent1, parent2, ...
+	IsGhost bool
+}
+
+// Iterator walks commits in reverse topological order.
+type Iterator interface {
+	// Next returns the next commit. Returns io.EOF when exhausted.
+	Next(ctx context.Context) (*CommitInfo, error)
+	// Reset restarts the walk from the original start hashes.
+	Reset(ctx context.Context) error
+}
+
+// GetTopologicalOrderIterator returns an Iterator that walks every commit
+// reachable from startHashes in reverse topological order (highest/newest
+// first). Ties at the same height are broken by timestamp (newer first).
+// Ghost commits sort before resolved commits.
+//
+// The optional matchFn filters commits: return true to include, false to skip.
+func GetTopologicalOrderIterator(
+	ctx context.Context,
+	resolver HashResolver,
+	startHashes []hash.Hash,
+	matchFn func(*CommitInfo) (bool, error),
+) (Iterator, error) {
+	return newTopoIter(ctx, resolver, startHashes, matchFn)
+}
+
+// GetDotDotIterator returns an Iterator that yields commits reachable from
+// includedHashes but NOT reachable from excludedHashes, analogous to
+// `git log excluded..included`.
+func GetDotDotIterator(
+	ctx context.Context,
+	includedResolver HashResolver,
+	includedHashes []hash.Hash,
+	excludedResolver HashResolver,
+	excludedHashes []hash.Hash,
+	matchFn func(*CommitInfo) (bool, error),
+) (Iterator, error) {
+	return newDotDotIter(ctx, includedResolver, includedHashes, excludedResolver, excludedHashes, matchFn)
+}
+
+// --- priority queue --------------------------------------------------------
+
+type entry struct {
+	resolver  HashResolver
+	info      *CommitInfo
+	invisible bool
+	queued    bool
+}
+
+type pq struct {
+	pending           []*entry
+	numVisiblePending int
+	loaded            map[hash.Hash]*entry
+}
+
+func newPQ() *pq { return &pq{loaded: make(map[hash.Hash]*entry)} }
+
+func (q *pq) Len() int      { return len(q.pending) }
+func (q *pq) Swap(i, j int) { q.pending[i], q.pending[j] = q.pending[j], q.pending[i] }
+
+func (q *pq) Push(x interface{}) { q.pending = append(q.pending, x.(*entry)) }
+func (q *pq) Pop() interface{} {
+	old := q.pending
+	ret := old[len(old)-1]
+	q.pending = old[:len(old)-1]
+	return ret
+}
+
+func (q *pq) Less(i, j int) bool {
+	ei, ej := q.pending[i], q.pending[j]
+	if ei.info.IsGhost && !ej.info.IsGhost {
+		return true
+	}
+	if !ei.info.IsGhost && ej.info.IsGhost {
+		return false
+	}
+	if ei.info.IsGhost && ej.info.IsGhost {
+		return ei.info.Hash.String() < ej.info.Hash.String()
+	}
+	if ei.info.Height > ej.info.Height {
+		return true
+	}
+	if ei.info.Height == ej.info.Height && ei.info.Meta != nil && ej.info.Meta != nil {
+		return ei.info.Meta.UserTimestamp > ej.info.Meta.UserTimestamp
+	}
+	return false
+}
+
+func (q *pq) get(ctx context.Context, r HashResolver, h hash.Hash) (*entry, error) {
+	if e, ok := q.loaded[h]; ok {
+		return e, nil
+	}
+	info, err := r.ResolveCommitHash(ctx, h)
+	if err != nil {
+		return nil, err
+	}
+	e := &entry{resolver: r, info: info}
+	q.loaded[h] = e
+	return e, nil
+}
+
+func (q *pq) addIfUnseen(ctx context.Context, r HashResolver, h hash.Hash) error {
+	e, err := q.get(ctx, r, h)
+	if err != nil {
+		return err
+	}
+	if !e.queued {
+		e.queued = true
+		heap.Push(q, e)
+		if !e.invisible {
+			q.numVisiblePending++
+		}
+	}
+	return nil
+}
+
+func (q *pq) setInvisible(ctx context.Context, r HashResolver, h hash.Hash) error {
+	e, err := q.get(ctx, r, h)
+	if err != nil {
+		return err
+	}
+	if !e.invisible {
+		e.invisible = true
+		if e.queued {
+			q.numVisiblePending--
+		}
+	}
+	return nil
+}
+
+func (q *pq) popPending() *entry {
+	e := heap.Pop(q).(*entry)
+	if !e.invisible {
+		q.numVisiblePending--
+	}
+	return e
+}
+
+// --- topological iterator --------------------------------------------------
+
+type topoIter struct {
+	resolver    HashResolver
+	startHashes []hash.Hash
+	matchFn     func(*CommitInfo) (bool, error)
+	q           *pq
+}
+
+func newTopoIter(ctx context.Context, resolver HashResolver, startHashes []hash.Hash, matchFn func(*CommitInfo) (bool, error)) (*topoIter, error) {
+	it := &topoIter{resolver: resolver, startHashes: startHashes, matchFn: matchFn}
+	if err := it.Reset(ctx); err != nil {
+		return nil, err
+	}
+	return it, nil
+}
+
+func (it *topoIter) Next(ctx context.Context) (*CommitInfo, error) {
+	for it.q.numVisiblePending > 0 {
+		e := it.q.popPending()
+		for _, ph := range e.info.Parents {
+			if err := it.q.addIfUnseen(ctx, e.resolver, ph); err != nil {
+				return nil, err
+			}
+		}
+		if it.matchFn != nil {
+			ok, err := it.matchFn(e.info)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				continue
+			}
+		}
+		return e.info, nil
+	}
+	return nil, io.EOF
+}
+
+func (it *topoIter) Reset(ctx context.Context) error {
+	it.q = newPQ()
+	for _, h := range it.startHashes {
+		if err := it.q.addIfUnseen(ctx, it.resolver, h); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// --- dot-dot iterator ------------------------------------------------------
+
+type dotDotIter struct {
+	includedResolver  HashResolver
+	excludedResolver  HashResolver
+	startHashes       []hash.Hash
+	excludedHashes    []hash.Hash
+	matchFn           func(*CommitInfo) (bool, error)
+	q                 *pq
+}
+
+func newDotDotIter(ctx context.Context, inclR HashResolver, inclH []hash.Hash, exclR HashResolver, exclH []hash.Hash, matchFn func(*CommitInfo) (bool, error)) (*dotDotIter, error) {
+	it := &dotDotIter{
+		includedResolver: inclR,
+		excludedResolver: exclR,
+		startHashes:      inclH,
+		excludedHashes:   exclH,
+		matchFn:          matchFn,
+	}
+	if err := it.Reset(ctx); err != nil {
+		return nil, err
+	}
+	return it, nil
+}
+
+func (it *dotDotIter) Next(ctx context.Context) (*CommitInfo, error) {
+	for it.q.numVisiblePending > 0 {
+		e := it.q.popPending()
+		for _, ph := range e.info.Parents {
+			if e.invisible {
+				if err := it.q.setInvisible(ctx, e.resolver, ph); err != nil {
+					return nil, err
+				}
+			}
+			if err := it.q.addIfUnseen(ctx, e.resolver, ph); err != nil {
+				return nil, err
+			}
+		}
+		if e.invisible {
+			continue
+		}
+		if it.matchFn != nil {
+			ok, err := it.matchFn(e.info)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				continue
+			}
+		}
+		return e.info, nil
+	}
+	return nil, io.EOF
+}
+
+func (it *dotDotIter) Reset(ctx context.Context) error {
+	it.q = newPQ()
+	for _, h := range it.excludedHashes {
+		if err := it.q.setInvisible(ctx, it.excludedResolver, h); err != nil {
+			return err
+		}
+		if err := it.q.addIfUnseen(ctx, it.excludedResolver, h); err != nil {
+			return err
+		}
+	}
+	for _, h := range it.startHashes {
+		if err := it.q.addIfUnseen(ctx, it.includedResolver, h); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/go/libraries/doltcore/env/actions/commitwalk/commitwalk.go
+++ b/go/libraries/doltcore/env/actions/commitwalk/commitwalk.go
@@ -12,169 +12,67 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package commitwalk provides topological commit graph iterators that return
+// doltdb types. The walk algorithm is implemented in the lightweight
+// commitgraph package; this package adapts it to *doltdb.DoltDB.
 package commitwalk
 
 import (
-	"container/heap"
 	"context"
 	"io"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/commitgraph"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/store/datas"
 	"github.com/dolthub/dolt/go/store/hash"
 )
 
-type c struct {
-	ddb       *doltdb.DoltDB
-	commit    *doltdb.OptionalCommit
-	meta      *datas.CommitMeta
-	hash      hash.Hash
-	height    uint64
-	invisible bool
-	queued    bool
+// doltDBResolver adapts *doltdb.DoltDB to commitgraph.HashResolver.
+type doltDBResolver struct {
+	ddb *doltdb.DoltDB
+	// cache maps hashes to resolved OptionalCommits so the adapter layer
+	// can return them alongside commitgraph.CommitInfo results.
+	cache map[hash.Hash]*doltdb.OptionalCommit
 }
 
-type q struct {
-	pending           []*c
-	numVisiblePending int
-	loaded            map[hash.Hash]*c
+func newResolver(ddb *doltdb.DoltDB) *doltDBResolver {
+	return &doltDBResolver{ddb: ddb, cache: make(map[hash.Hash]*doltdb.OptionalCommit)}
 }
 
-func (q *q) NumVisiblePending() int {
-	return q.numVisiblePending
-}
-
-func (q *q) Push(x interface{}) {
-	q.pending = append(q.pending, x.(*c))
-}
-
-func (q *q) Pop() interface{} {
-	old := q.pending
-	ret := old[len(old)-1]
-	q.pending = old[:len(old)-1]
-	return ret
-}
-
-func (q *q) Len() int {
-	return len(q.pending)
-}
-
-func (q *q) Swap(i, j int) {
-	q.pending[i], q.pending[j] = q.pending[j], q.pending[i]
-}
-
-// Less returns true if the commit at index i is "less" than the commit at index j. It may be the case that you are comparing
-// two resolved commits, two ghost commits, or a resolved commit and a ghost commit. Ghost commits will always be "less" than
-// resolved commits. If both commits are resolved, then the commit with the higher height is "less". If the heights are equal, then
-// the commit with the newer timestamp is "less". Finally if both commits are ghost commits, we don't really have enough
-// information to compare on, so we just compare the hashes to ensure that the results are stable.
-func (q *q) Less(i, j int) bool {
-	cI := q.pending[i]
-	cJ := q.pending[j]
-	_, okI := cI.commit.ToCommit()
-	_, okJ := cJ.commit.ToCommit()
-
-	if !okI && okJ {
-		return true
-	} else if okI && !okJ {
-		return false
-	} else if !okI && !okJ {
-		return cI.hash.String() < cJ.hash.String()
-	}
-
-	if cI.height > cJ.height {
-		return true
-	}
-
-	if cI.height == cJ.height {
-		return cI.meta.UserTimestamp > cJ.meta.UserTimestamp
-	}
-	return false
-}
-
-func (q *q) PopPending() *c {
-	c := heap.Pop(q).(*c)
-	if !c.invisible {
-		q.numVisiblePending--
-	}
-	return c
-}
-
-func (q *q) AddPendingIfUnseen(ctx context.Context, ddb *doltdb.DoltDB, id hash.Hash) error {
-	c, err := q.Get(ctx, ddb, id)
-	if err != nil {
-		return err
-	}
-	if !c.queued {
-		c.queued = true
-		heap.Push(q, c)
-		if !c.invisible {
-			q.numVisiblePending++
-		}
-	}
-	return nil
-}
-
-func (q *q) SetInvisible(ctx context.Context, ddb *doltdb.DoltDB, id hash.Hash) error {
-	c, err := q.Get(ctx, ddb, id)
-	if err != nil {
-		return err
-	}
-	if !c.invisible {
-		c.invisible = true
-		if c.queued {
-			q.numVisiblePending--
-		}
-	}
-	return nil
-}
-
-func load(ctx context.Context, ddb *doltdb.DoltDB, h hash.Hash) (*doltdb.OptionalCommit, error) {
-	oc, err := ddb.ResolveHash(ctx, h)
-	if err != nil {
-		return nil, err
-	}
-	return oc, nil
-}
-
-func (q *q) Get(ctx context.Context, ddb *doltdb.DoltDB, id hash.Hash) (*c, error) {
-	if l, ok := q.loaded[id]; ok {
-		return l, nil
-	}
-
-	optCmt, err := load(ctx, ddb, id)
+func (r *doltDBResolver) ResolveCommitHash(ctx context.Context, h hash.Hash) (*commitgraph.CommitInfo, error) {
+	oc, err := r.ddb.ResolveHash(ctx, h)
 	if err != nil {
 		return nil, err
 	}
 
-	commit, ok := optCmt.ToCommit()
+	r.cache[h] = oc
+
+	info := &commitgraph.CommitInfo{Hash: h}
+	commit, ok := oc.ToCommit()
 	if !ok {
-		return &c{ddb: ddb, commit: optCmt, hash: id}, nil
+		info.IsGhost = true
+		return info, nil
 	}
 
-	h, err := commit.Height()
+	info.Height, err = commit.Height()
 	if err != nil {
 		return nil, err
 	}
 
-	meta, err := commit.GetCommitMeta(ctx)
+	info.Meta, err = commit.GetCommitMeta(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	lc := &c{
-		ddb:    ddb,
-		commit: &doltdb.OptionalCommit{Commit: commit, Addr: id},
-		meta:   meta,
-		height: h,
-		hash:   id,
+	for _, p := range commit.DatasParents() {
+		info.Parents = append(info.Parents, p.Addr())
 	}
-	q.loaded[id] = lc
-	return lc, nil
+
+	return info, nil
 }
 
-func newQueue() *q {
-	return &q{loaded: make(map[hash.Hash]*c)}
+func (r *doltDBResolver) lookupOptionalCommit(h hash.Hash) *doltdb.OptionalCommit {
+	return r.cache[h]
 }
 
 // GetDotDotRevisions returns the commits reachable from commit at hashes
@@ -208,83 +106,77 @@ func GetDotDotRevisions(ctx context.Context, includedDB *doltdb.DoltDB, included
 	return commitList, nil
 }
 
-// GetTopologicalOrderCommitIterator returns an iterator for commits generated with the same semantics as
-// GetTopologicalOrderCommits
+// GetTopologicalOrderIterator returns an iterator for commits in reverse
+// topological order, wrapping the lightweight commitgraph.Iterator.
 func GetTopologicalOrderIterator[C doltdb.Context](ctx context.Context, ddb *doltdb.DoltDB, startCommitHashes []hash.Hash, matchFn func(*doltdb.OptionalCommit) (bool, error)) (doltdb.CommitItr[C], error) {
-	return newCommiterator[C](ctx, ddb, startCommitHashes, matchFn)
+	r := newResolver(ddb)
+	var cgMatchFn func(*commitgraph.CommitInfo) (bool, error)
+	if matchFn != nil {
+		cgMatchFn = func(ci *commitgraph.CommitInfo) (bool, error) {
+			oc := r.lookupOptionalCommit(ci.Hash)
+			if oc == nil {
+				return true, nil
+			}
+			return matchFn(oc)
+		}
+	}
+	inner, err := commitgraph.GetTopologicalOrderIterator(ctx, r, startCommitHashes, cgMatchFn)
+	if err != nil {
+		return nil, err
+	}
+	return &commiterator[C]{resolver: r, inner: inner}, nil
 }
 
 type commiterator[C doltdb.Context] struct {
-	ddb               *doltdb.DoltDB
-	startCommitHashes []hash.Hash
-	matchFn           func(*doltdb.OptionalCommit) (bool, error)
-	q                 *q
+	resolver *doltDBResolver
+	inner    commitgraph.Iterator
 }
 
 var _ doltdb.CommitItr[context.Context] = (*commiterator[context.Context])(nil)
 
-func newCommiterator[C doltdb.Context](ctx context.Context, ddb *doltdb.DoltDB, startCommitHashes []hash.Hash, matchFn func(*doltdb.OptionalCommit) (bool, error)) (*commiterator[C], error) {
-	itr := &commiterator[C]{
-		ddb:               ddb,
-		startCommitHashes: startCommitHashes,
-		matchFn:           matchFn,
-	}
-
-	err := itr.Reset(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return itr, nil
-}
-
 // Next implements doltdb.CommitItr
 func (iter *commiterator[C]) Next(ctx C) (hash.Hash, *doltdb.OptionalCommit, *datas.CommitMeta, uint64, error) {
-	if iter.q.NumVisiblePending() > 0 {
-		nextC := iter.q.PopPending()
-		commit, ok := nextC.commit.ToCommit()
-		if ok {
-			for _, parentCommit := range commit.DatasParents() {
-				if err := iter.q.AddPendingIfUnseen(ctx, nextC.ddb, parentCommit.Addr()); err != nil {
-					return hash.Hash{}, nil, nil, 0, err
-				}
-			}
-		}
-
-		var err error
-		matches := true
-		if iter.matchFn != nil {
-			matches, err = iter.matchFn(nextC.commit)
-			if err != nil {
-				return hash.Hash{}, nil, nil, 0, err
-			}
-		}
-
-		if matches {
-			return nextC.hash, &doltdb.OptionalCommit{Commit: commit, Addr: nextC.hash}, nextC.meta, nextC.height, nil
-		}
-
-		return iter.Next(ctx)
+	ci, err := iter.inner.Next(ctx)
+	if err != nil {
+		return hash.Hash{}, nil, nil, 0, err
 	}
-
-	return hash.Hash{}, nil, nil, 0, io.EOF
+	oc := iter.resolver.lookupOptionalCommit(ci.Hash)
+	if oc == nil {
+		oc = &doltdb.OptionalCommit{Addr: ci.Hash}
+	}
+	return ci.Hash, oc, ci.Meta, ci.Height, nil
 }
 
 // Reset implements doltdb.CommitItr
-func (i *commiterator[C]) Reset(ctx context.Context) error {
-	i.q = newQueue()
-	for _, startCommitHash := range i.startCommitHashes {
-		if err := i.q.AddPendingIfUnseen(ctx, i.ddb, startCommitHash); err != nil {
-			return err
-		}
-	}
-	return nil
+func (iter *commiterator[C]) Reset(ctx context.Context) error {
+	return iter.inner.Reset(ctx)
 }
 
-// GetDotDotRevisionsIterator returns an iterator for commits generated with the same semantics as
-// GetDotDotRevisions
+// GetDotDotRevisionsIterator returns an iterator for commits generated with
+// the same semantics as GetDotDotRevisions.
 func GetDotDotRevisionsIterator[C doltdb.Context](ctx context.Context, includedDdb *doltdb.DoltDB, startCommitHashes []hash.Hash, excludedDdb *doltdb.DoltDB, excludingCommitHashes []hash.Hash, matchFn func(*doltdb.OptionalCommit) (bool, error)) (doltdb.CommitItr[C], error) {
-	return newDotDotCommiterator[C](ctx, includedDdb, startCommitHashes, excludedDdb, excludingCommitHashes, matchFn)
+	inclR := newResolver(includedDdb)
+	exclR := newResolver(excludedDdb)
+
+	var cgMatchFn func(*commitgraph.CommitInfo) (bool, error)
+	if matchFn != nil {
+		cgMatchFn = func(ci *commitgraph.CommitInfo) (bool, error) {
+			oc := inclR.lookupOptionalCommit(ci.Hash)
+			if oc == nil {
+				oc = exclR.lookupOptionalCommit(ci.Hash)
+			}
+			if oc == nil {
+				return true, nil
+			}
+			return matchFn(oc)
+		}
+	}
+
+	inner, err := commitgraph.GetDotDotIterator(ctx, inclR, startCommitHashes, exclR, excludingCommitHashes, cgMatchFn)
+	if err != nil {
+		return nil, err
+	}
+	return &dotDotCommiterator[C]{inclResolver: inclR, exclResolver: exclR, inner: inner}, nil
 }
 
 // GetTopNTopoOrderedCommitsMatching returns the first N commits (If N <= 0 then all commits) reachable from the commits in
@@ -314,92 +206,30 @@ func GetTopNTopoOrderedCommitsMatching(ctx context.Context, ddb *doltdb.DoltDB, 
 }
 
 type dotDotCommiterator[C doltdb.Context] struct {
-	includedDdb           *doltdb.DoltDB
-	excludedDdb           *doltdb.DoltDB
-	startCommitHashes     []hash.Hash
-	excludingCommitHashes []hash.Hash
-	matchFn               func(*doltdb.OptionalCommit) (bool, error)
-	q                     *q
+	inclResolver *doltDBResolver
+	exclResolver *doltDBResolver
+	inner        commitgraph.Iterator
 }
 
 var _ doltdb.CommitItr[context.Context] = (*dotDotCommiterator[context.Context])(nil)
 
-func newDotDotCommiterator[C doltdb.Context](ctx context.Context, includedDdb *doltdb.DoltDB, startCommitHashes []hash.Hash, excludedDdb *doltdb.DoltDB, excludingCommitHashes []hash.Hash, matchFn func(*doltdb.OptionalCommit) (bool, error)) (*dotDotCommiterator[C], error) {
-	itr := &dotDotCommiterator[C]{
-		includedDdb:           includedDdb,
-		excludedDdb:           excludedDdb,
-		startCommitHashes:     startCommitHashes,
-		excludingCommitHashes: excludingCommitHashes,
-		matchFn:               matchFn,
-	}
-
-	err := itr.Reset(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return itr, nil
-}
-
 // Next implements doltdb.CommitItr
 func (i *dotDotCommiterator[C]) Next(ctx C) (hash.Hash, *doltdb.OptionalCommit, *datas.CommitMeta, uint64, error) {
-	if i.q.NumVisiblePending() > 0 {
-		nextC := i.q.PopPending()
-
-		commit, ok := nextC.commit.ToCommit()
-		if !ok {
-			return nextC.hash, nextC.commit, nextC.meta, nextC.height, nil
-		}
-
-		parents, err := commit.ParentHashes(ctx)
-		if err != nil {
-			return hash.Hash{}, nil, nil, 0, err
-		}
-
-		for _, parentID := range parents {
-			if nextC.invisible {
-				if err := i.q.SetInvisible(ctx, nextC.ddb, parentID); err != nil {
-					return hash.Hash{}, nil, nil, 0, err
-				}
-			}
-			if err := i.q.AddPendingIfUnseen(ctx, nextC.ddb, parentID); err != nil {
-				return hash.Hash{}, nil, nil, 0, err
-			}
-		}
-
-		matches := true
-		if i.matchFn != nil {
-			matches, err = i.matchFn(nextC.commit)
-			if err != nil {
-				return hash.Hash{}, nil, nil, 0, err
-			}
-		}
-
-		// If not invisible, return commit. Otherwise, get next commit
-		if !nextC.invisible && matches {
-			return nextC.hash, nextC.commit, nextC.meta, nextC.height, nil
-		}
-		return i.Next(ctx)
+	ci, err := i.inner.Next(ctx)
+	if err != nil {
+		return hash.Hash{}, nil, nil, 0, err
 	}
-
-	return hash.Hash{}, nil, nil, 0, io.EOF
+	oc := i.inclResolver.lookupOptionalCommit(ci.Hash)
+	if oc == nil {
+		oc = i.exclResolver.lookupOptionalCommit(ci.Hash)
+	}
+	if oc == nil {
+		oc = &doltdb.OptionalCommit{Addr: ci.Hash}
+	}
+	return ci.Hash, oc, ci.Meta, ci.Height, nil
 }
 
 // Reset implements doltdb.CommitItr
 func (i *dotDotCommiterator[C]) Reset(ctx context.Context) error {
-	i.q = newQueue()
-	for _, excludingCommitHash := range i.excludingCommitHashes {
-		if err := i.q.SetInvisible(ctx, i.excludedDdb, excludingCommitHash); err != nil {
-			return err
-		}
-		if err := i.q.AddPendingIfUnseen(ctx, i.excludedDdb, excludingCommitHash); err != nil {
-			return err
-		}
-	}
-	for _, startCommitHash := range i.startCommitHashes {
-		if err := i.q.AddPendingIfUnseen(ctx, i.includedDdb, startCommitHash); err != nil {
-			return err
-		}
-	}
-	return nil
+	return i.inner.Reset(ctx)
 }


### PR DESCRIPTION
DumboDB is attempting to use the commitwalk package in doltdb, and it's pulling in the SQL engine as a result.

This change is a refactor to make the commit walking code stand alone.