### PR TITLE
go: remotestorage: reliable/http: Fix some misbehavior when ChunkFetcher is working against HTTP/2 endpoints.

### DIFF
--- a/go/libraries/doltcore/remotestorage/internal/reliable/http.go
+++ b/go/libraries/doltcore/remotestorage/internal/reliable/http.go
@@ -213,7 +213,19 @@ func StreamingRangeDownload(ctx context.Context, req StreamingRangeRequest) Stre
 				// Reader closed; bail.
 				return backoff.Permanent(err)
 			} else {
-				if cerr := context.Cause(ctx); errors.Is(err, context.Canceled) && cerr != nil {
+				cerr := context.Cause(ctx)
+				if errors.Is(err, context.Canceled) && (cerr == nil || errors.Is(cerr, context.Canceled)) {
+					// The consumer closed the
+					// StreamingResponse (or the caller's
+					// context was canceled) before
+					// io.Copy returned. No cCause was
+					// set, so this isn't a transport
+					// failure — treat it the same as
+					// io.ErrClosedPipe: bail without
+					// recording a health signal.
+					return backoff.Permanent(err)
+				}
+				if errors.Is(err, context.Canceled) && cerr != nil {
 					// HTTP Body reader will return
 					// context.Canceled even if we cancel
 					// with a cause. Convert to the cause

--- a/go/libraries/doltcore/remotestorage/internal/reliable/http.go
+++ b/go/libraries/doltcore/remotestorage/internal/reliable/http.go
@@ -190,6 +190,21 @@ func StreamingRangeDownload(ctx context.Context, req StreamingRangeRequest) Stre
 			cleanup()
 			// We successfully wrote this many bytes to |w|. Update |offset|.
 			offset += uint64(n)
+			if offset == req.Offset+req.Length {
+				// All requested bytes were delivered to the
+				// consumer. Treat this as success regardless of
+				// any error returned from io.Copy. With HTTP/2,
+				// Body.Read may not return io.EOF until an
+				// END_STREAM frame arrives; a consumer that
+				// closes the StreamingResponse right after
+				// reading its last byte races with that frame
+				// and surfaces here as context.Canceled even
+				// though the actual data transfer succeeded.
+				// Letting that fall through to RecordFailure
+				// erroneously halves fetch concurrency.
+				req.Health.RecordSuccess()
+				return nil
+			}
 			if err == nil {
 				// Success! We read until Body returned EOF.
 				req.Health.RecordSuccess()

--- a/go/libraries/doltcore/remotestorage/internal/reliable/http.go
+++ b/go/libraries/doltcore/remotestorage/internal/reliable/http.go
@@ -35,10 +35,15 @@ type UrlFactoryFunc func(error) (string, error)
 type StreamingResponse struct {
 	Body   io.Reader
 	cancel func()
+	done   <-chan struct{}
 }
 
+// Close cancels the outstanding download (if any) and blocks until the
+// producer goroutine has fully exited. After Close returns, no further
+// Health or Stats callbacks will fire for this response.
 func (r StreamingResponse) Close() error {
 	r.cancel()
+	<-r.done
 	return nil
 }
 
@@ -111,8 +116,14 @@ func StreamingRangeDownload(ctx context.Context, req StreamingRangeRequest) Stre
 	// This is the overall context for the operation, encompassing all of its retries. When StreamingResponse is closed, this is canceled.
 	ctx, cancel := context.WithCancel(ctx)
 
+	// |done| is closed when the producer goroutine below has fully exited.
+	// |StreamingResponse.Close| blocks on this to ensure no further Health
+	// or Stats callbacks will fire after Close returns.
+	done := make(chan struct{})
+
 	// This naked go routine makes retried HTTP requests for the byte range, writing the HTTP response bodies to |w|.
 	go func() {
+		defer close(done)
 		origOffset := req.Offset
 		// |offset| starts at |req.Offset| but may be updated if we
 		// make retries and have already delivered some bytes.
@@ -253,6 +264,7 @@ func StreamingRangeDownload(ctx context.Context, req StreamingRangeRequest) Stre
 			r.Close()
 			cancel()
 		},
+		done: done,
 	}
 }
 

--- a/go/libraries/doltcore/remotestorage/internal/reliable/http_test.go
+++ b/go/libraries/doltcore/remotestorage/internal/reliable/http_test.go
@@ -93,9 +93,9 @@ func (c *countingHealth) RecordFailure() { c.failures.Add(1) }
 
 type noopStats struct{}
 
-func (noopStats) RecordTimeToFirstByte(retry int, size uint64, d time.Duration)   {}
-func (noopStats) RecordDownloadAttemptStart(retry int, offset, size uint64)       {}
-func (noopStats) RecordDownloadComplete(retry int, size uint64, d time.Duration)  {}
+func (noopStats) RecordTimeToFirstByte(retry int, size uint64, d time.Duration)  {}
+func (noopStats) RecordDownloadAttemptStart(retry int, offset, size uint64)      {}
+func (noopStats) RecordDownloadComplete(retry int, size uint64, d time.Duration) {}
 
 // http2LikeBody simulates an HTTP/2 response body where the transport has
 // delivered all content bytes but has not yet observed the END_STREAM frame.

--- a/go/libraries/doltcore/remotestorage/internal/reliable/http_test.go
+++ b/go/libraries/doltcore/remotestorage/internal/reliable/http_test.go
@@ -179,12 +179,11 @@ func TestStreamingRangeDownload(t *testing.T) {
 		assert.Equal(t, int64(1), health.successes.Load(), "consumer close after full read should record one success")
 	})
 
-	t.Run("EarlyConsumerCloseDoesNotRecordFailure", func(t *testing.T) {
-		// Sanity check of the existing behavior: if the consumer
-		// closes before the full range is delivered, io.Copy fails
-		// with io.ErrClosedPipe and we take the backoff.Permanent
-		// path — no health signal is recorded (neither success nor
-		// failure).
+	t.Run("EarlyConsumerCloseOnBlockedWriteRecordsNothing", func(t *testing.T) {
+		// When the consumer closes before the full range is
+		// delivered and the producer is blocked on writing to the
+		// pipe, io.Copy fails with io.ErrClosedPipe and we take the
+		// backoff.Permanent path without recording a health signal.
 		const size = 1024
 		payload := make([]byte, size)
 
@@ -215,18 +214,79 @@ func TestStreamingRangeDownload(t *testing.T) {
 			RespHeadersTimeout: time.Hour,
 		})
 
-		// Read just one byte, then close.
 		one := make([]byte, 1)
 		_, err := io.ReadFull(resp.Body, one)
 		require.NoError(t, err)
 		require.NoError(t, resp.Close())
 
-		// Let the producer unwind.
-		start := time.Now()
-		for health.successes.Load() == 0 && health.failures.Load() == 0 && time.Since(start) < 500*time.Millisecond {
-			time.Sleep(time.Millisecond)
-		}
+		waitForHealth(health, 500*time.Millisecond)
 
 		assert.Equal(t, int64(0), health.failures.Load(), "early consumer close must not record a failure")
+		assert.Equal(t, int64(0), health.successes.Load(), "early consumer close must not record a success")
 	})
+
+	t.Run("EarlyConsumerCloseOnBlockedReadRecordsNothing", func(t *testing.T) {
+		// Consumer closes before the full range is delivered while
+		// the producer is blocked on Body.Read (not on a pipe Write).
+		// The cancel() triggered by Close() surfaces as
+		// context.Canceled from io.Copy. Because the per-attempt
+		// context's Cause is also context.Canceled (no cCause was
+		// called, the parent ctx was plain-canceled), this must be
+		// treated the same way as io.ErrClosedPipe: backoff.Permanent
+		// with no health signal.
+		const total = 1024
+		const delivered = 256
+		payload := make([]byte, delivered)
+		for i := range payload {
+			payload[i] = byte(i)
+		}
+
+		fetcher := fetcherFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusPartialContent,
+				Body: &http2LikeBody{
+					buf: bytes.NewReader(payload),
+					ctx: req.Context(),
+				},
+				Request: req,
+			}, nil
+		})
+
+		health := &countingHealth{}
+		resp := StreamingRangeDownload(context.Background(), StreamingRangeRequest{
+			Fetcher: fetcher,
+			Offset:  0,
+			Length:  total,
+			UrlFact: func(error) (string, error) { return "http://example.test/file", nil },
+			Stats:   noopStats{},
+			Health:  health,
+			BackOffFact: func(ctx context.Context) backoff.BackOff {
+				return &backoff.StopBackOff{}
+			},
+			Throughput: MinimumThroughputCheck{
+				CheckInterval: time.Hour,
+				BytesPerCheck: 1,
+				NumIntervals:  1,
+			},
+			RespHeadersTimeout: time.Hour,
+		})
+
+		got := make([]byte, delivered)
+		_, err := io.ReadFull(resp.Body, got)
+		require.NoError(t, err)
+		require.Equal(t, payload, got)
+		require.NoError(t, resp.Close())
+
+		waitForHealth(health, 500*time.Millisecond)
+
+		assert.Equal(t, int64(0), health.failures.Load(), "consumer-close cancel mid-range must not record a failure")
+		assert.Equal(t, int64(0), health.successes.Load(), "consumer-close cancel mid-range must not record a success")
+	})
+}
+
+func waitForHealth(h *countingHealth, d time.Duration) {
+	start := time.Now()
+	for h.successes.Load() == 0 && h.failures.Load() == 0 && time.Since(start) < d {
+		time.Sleep(time.Millisecond)
+	}
 }

--- a/go/libraries/doltcore/remotestorage/internal/reliable/http_test.go
+++ b/go/libraries/doltcore/remotestorage/internal/reliable/http_test.go
@@ -15,12 +15,18 @@
 package reliable
 
 import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
 	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEnforceThroughput(t *testing.T) {
@@ -68,5 +74,159 @@ func TestEnforceThroughput(t *testing.T) {
 		case <-time.After(time.Second * 3):
 			assert.FailNow(t, "EnforceThroughput did not cancel operation after 3 seconds.")
 		}
+	})
+}
+
+type fetcherFunc func(*http.Request) (*http.Response, error)
+
+func (f fetcherFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type countingHealth struct {
+	successes atomic.Int64
+	failures  atomic.Int64
+}
+
+func (c *countingHealth) RecordSuccess() { c.successes.Add(1) }
+func (c *countingHealth) RecordFailure() { c.failures.Add(1) }
+
+type noopStats struct{}
+
+func (noopStats) RecordTimeToFirstByte(retry int, size uint64, d time.Duration)   {}
+func (noopStats) RecordDownloadAttemptStart(retry int, offset, size uint64)       {}
+func (noopStats) RecordDownloadComplete(retry int, size uint64, d time.Duration)  {}
+
+// http2LikeBody simulates an HTTP/2 response body where the transport has
+// delivered all content bytes but has not yet observed the END_STREAM frame.
+// After the payload is drained, subsequent Read calls block until the request
+// context is canceled, at which point they return context.Canceled — the same
+// behavior Go's http2 transport exhibits in that situation.
+type http2LikeBody struct {
+	buf *bytes.Reader
+	ctx context.Context
+}
+
+func (b *http2LikeBody) Read(p []byte) (int, error) {
+	if b.buf.Len() > 0 {
+		return b.buf.Read(p)
+	}
+	<-b.ctx.Done()
+	return 0, context.Canceled
+}
+
+func (b *http2LikeBody) Close() error { return nil }
+
+func TestStreamingRangeDownload(t *testing.T) {
+	t.Run("ConsumerCloseAfterFullReadIsNotAFailure", func(t *testing.T) {
+		// Regression: With HTTP/2, Body.Read may not return io.EOF
+		// until an END_STREAM frame arrives. If the consumer closes
+		// the StreamingResponse immediately after reading the last
+		// byte, io.Copy on the producer side returns context.Canceled
+		// even though the transfer succeeded. That must not be
+		// recorded as a health failure.
+		const size = 1024
+		payload := make([]byte, size)
+		for i := range payload {
+			payload[i] = byte(i)
+		}
+
+		fetcher := fetcherFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusPartialContent,
+				Body: &http2LikeBody{
+					buf: bytes.NewReader(payload),
+					ctx: req.Context(),
+				},
+				Request: req,
+			}, nil
+		})
+
+		health := &countingHealth{}
+		resp := StreamingRangeDownload(context.Background(), StreamingRangeRequest{
+			Fetcher: fetcher,
+			Offset:  0,
+			Length:  size,
+			UrlFact: func(error) (string, error) { return "http://example.test/file", nil },
+			Stats:   noopStats{},
+			Health:  health,
+			BackOffFact: func(ctx context.Context) backoff.BackOff {
+				return &backoff.StopBackOff{}
+			},
+			Throughput: MinimumThroughputCheck{
+				CheckInterval: time.Hour,
+				BytesPerCheck: 1,
+				NumIntervals:  1,
+			},
+			RespHeadersTimeout: time.Hour,
+		})
+
+		got := make([]byte, size)
+		_, err := io.ReadFull(resp.Body, got)
+		require.NoError(t, err)
+		require.Equal(t, payload, got)
+
+		require.NoError(t, resp.Close())
+
+		// Give the producer goroutine a moment to unwind after
+		// cancel() and either record its (non-)outcome.
+		start := time.Now()
+		for health.successes.Load() == 0 && health.failures.Load() == 0 && time.Since(start) < 2*time.Second {
+			time.Sleep(time.Millisecond)
+		}
+
+		assert.Equal(t, int64(0), health.failures.Load(), "consumer close after full read must not record a failure")
+		assert.Equal(t, int64(1), health.successes.Load(), "consumer close after full read should record one success")
+	})
+
+	t.Run("EarlyConsumerCloseDoesNotRecordFailure", func(t *testing.T) {
+		// Sanity check of the existing behavior: if the consumer
+		// closes before the full range is delivered, io.Copy fails
+		// with io.ErrClosedPipe and we take the backoff.Permanent
+		// path — no health signal is recorded (neither success nor
+		// failure).
+		const size = 1024
+		payload := make([]byte, size)
+
+		fetcher := fetcherFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusPartialContent,
+				Body:       io.NopCloser(bytes.NewReader(payload)),
+				Request:    req,
+			}, nil
+		})
+
+		health := &countingHealth{}
+		resp := StreamingRangeDownload(context.Background(), StreamingRangeRequest{
+			Fetcher: fetcher,
+			Offset:  0,
+			Length:  size,
+			UrlFact: func(error) (string, error) { return "http://example.test/file", nil },
+			Stats:   noopStats{},
+			Health:  health,
+			BackOffFact: func(ctx context.Context) backoff.BackOff {
+				return &backoff.StopBackOff{}
+			},
+			Throughput: MinimumThroughputCheck{
+				CheckInterval: time.Hour,
+				BytesPerCheck: 1,
+				NumIntervals:  1,
+			},
+			RespHeadersTimeout: time.Hour,
+		})
+
+		// Read just one byte, then close.
+		one := make([]byte, 1)
+		_, err := io.ReadFull(resp.Body, one)
+		require.NoError(t, err)
+		require.NoError(t, resp.Close())
+
+		// Let the producer unwind.
+		start := time.Now()
+		for health.successes.Load() == 0 && health.failures.Load() == 0 && time.Since(start) < 500*time.Millisecond {
+			time.Sleep(time.Millisecond)
+		}
+
+		assert.Equal(t, int64(0), health.failures.Load(), "early consumer close must not record a failure")
 	})
 }

--- a/go/libraries/doltcore/remotestorage/internal/reliable/http_test.go
+++ b/go/libraries/doltcore/remotestorage/internal/reliable/http_test.go
@@ -168,13 +168,6 @@ func TestStreamingRangeDownload(t *testing.T) {
 
 		require.NoError(t, resp.Close())
 
-		// Give the producer goroutine a moment to unwind after
-		// cancel() and either record its (non-)outcome.
-		start := time.Now()
-		for health.successes.Load() == 0 && health.failures.Load() == 0 && time.Since(start) < 2*time.Second {
-			time.Sleep(time.Millisecond)
-		}
-
 		assert.Equal(t, int64(0), health.failures.Load(), "consumer close after full read must not record a failure")
 		assert.Equal(t, int64(1), health.successes.Load(), "consumer close after full read should record one success")
 	})
@@ -218,8 +211,6 @@ func TestStreamingRangeDownload(t *testing.T) {
 		_, err := io.ReadFull(resp.Body, one)
 		require.NoError(t, err)
 		require.NoError(t, resp.Close())
-
-		waitForHealth(health, 500*time.Millisecond)
 
 		assert.Equal(t, int64(0), health.failures.Load(), "early consumer close must not record a failure")
 		assert.Equal(t, int64(0), health.successes.Load(), "early consumer close must not record a success")
@@ -277,16 +268,7 @@ func TestStreamingRangeDownload(t *testing.T) {
 		require.Equal(t, payload, got)
 		require.NoError(t, resp.Close())
 
-		waitForHealth(health, 500*time.Millisecond)
-
 		assert.Equal(t, int64(0), health.failures.Load(), "consumer-close cancel mid-range must not record a failure")
 		assert.Equal(t, int64(0), health.successes.Load(), "consumer-close cancel mid-range must not record a success")
 	})
-}
-
-func waitForHealth(h *countingHealth, d time.Duration) {
-	start := time.Now()
-	for h.successes.Load() == 0 && h.failures.Load() == 0 && time.Since(start) < d {
-		time.Sleep(time.Millisecond)
-	}
 }


### PR DESCRIPTION
HTTP/2 frames responses differently from HTTP/1 and we see io.EOF on the response at slightly different times. A race in ChunkFetcher meant that it treated read-to-end-of-range-caller-wanted-and-was-Closed as a failure if the Close came in before the io.EOF from the read against the http.Response.Body.

Fix that race and fix some behavior around our fetch health tracking related to it.