### PR TITLE
Fix `fsck` use `earl.Parse` to correctly resolve database path cross-platform

### DIFF
--- a/go/cmd/dolt/commands/fsck.go
+++ b/go/cmd/dolt/commands/fsck.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"path/filepath"
 	"time"
@@ -118,7 +117,7 @@ func (cmd FsckCmd) Exec(ctx context.Context, commandStr string, args []string, d
 	}
 
 	urlStr := earl.FileUrlFromPath(filepath.ToSlash(absPath), os.PathSeparator)
-	u, err := url.Parse(urlStr)
+	u, err := earl.Parse(urlStr)
 	if err != nil {
 		panic(err)
 	}

--- a/integration-tests/bats/fsck.bats
+++ b/integration-tests/bats/fsck.bats
@@ -181,7 +181,6 @@ UPDATE tbl SET guid = UUID() WHERE i >= @random_id LIMIT 1;"
 }
 
 @test "fsck: opens database correctly on Windows paths including spaces" {
-  # See https://github.com/dolthub/dolt/issues/1863
   # Normal path
   dolt init
   dolt sql -q "create table t (i int primary key)"
@@ -189,7 +188,7 @@ UPDATE tbl SET guid = UUID() WHERE i >= @random_id LIMIT 1;"
 
   run dolt fsck
   [ "$status" -eq 0 ]
-  ! [[ "$output" =~ "the filename, directory name, or volume label syntax is incorrect" ]]
+  ! [[ "$output" =~ "the filename, directory name, or volume label syntax is incorrect" ]] || false
 
   # Path with spaces
   local spacedir
@@ -202,5 +201,5 @@ UPDATE tbl SET guid = UUID() WHERE i >= @random_id LIMIT 1;"
 
   run dolt fsck
   [ "$status" -eq 0 ]
-  ! [[ "$output" =~ "the filename, directory name, or volume label syntax is incorrect" ]]
+  ! [[ "$output" =~ "the filename, directory name, or volume label syntax is incorrect" ]] || false
 }

--- a/integration-tests/bats/fsck.bats
+++ b/integration-tests/bats/fsck.bats
@@ -179,3 +179,28 @@ UPDATE tbl SET guid = UUID() WHERE i >= @random_id LIMIT 1;"
   [ "$status" -eq 1 ]
   [[ "$output" =~ "::commit:0vh56jekvb9hs0kqf8e8dc5208s0o0mi: read failure of fthj68monkbgkrb6g4c11php7ht2dib" ]] || false
 }
+
+@test "fsck: opens database correctly on Windows paths including spaces" {
+  # See https://github.com/dolthub/dolt/issues/1863
+  # Normal path
+  dolt init
+  dolt sql -q "create table t (i int primary key)"
+  dolt commit -Am "create t"
+
+  run dolt fsck
+  [ "$status" -eq 0 ]
+  ! [[ "$output" =~ "the filename, directory name, or volume label syntax is incorrect" ]]
+
+  # Path with spaces
+  local spacedir
+  spacedir="$(mktemp -d "$BATS_TMPDIR/fsck spaces XXXXXX")"
+  cd "$spacedir"
+
+  dolt init
+  dolt sql -q "create table t (i int primary key)"
+  dolt commit -Am "create t"
+
+  run dolt fsck
+  [ "$status" -eq 0 ]
+  ! [[ "$output" =~ "the filename, directory name, or volume label syntax is incorrect" ]]
+}


### PR DESCRIPTION
`fsck.go` was using `url.Parse` to parse the database file URL. On Windows, `url.Parse` places the drive letter into the URL Host field rather than Path, causing `dbfactory/file.go` to construct an invalid file path.