### PR TITLE
go,proto: remotesapi: Add a more efficient RPC, StreamChunkLocations, to use for fetch and pull.

### DIFF
--- a/go/cmd/dolt/commands/transfer.go
+++ b/go/cmd/dolt/commands/transfer.go
@@ -143,6 +143,7 @@ func (cmd TransferCmd) Exec(ctx context.Context, commandStr string, args []strin
 		"http",
 		remotesapi.PushConcurrencyControl_PUSH_CONCURRENCY_CONTROL_UNSPECIFIED,
 		sealer,
+		nil,
 	)
 
 	// gRPC for chunk store operations.

--- a/go/gen/proto/dolt/services/remotesapi/v1alpha1/chunkstore.pb.go
+++ b/go/gen/proto/dolt/services/remotesapi/v1alpha1/chunkstore.pb.go
@@ -2971,6 +2971,10 @@ type ChunkStoreServiceClient interface {
 	// Get the download locations for a list of chunk hashes. Streaming to
 	// support large and incrementally available payloads. Results are generated
 	// as requests come in.
+	//
+	// Deprecated: prefer StreamChunkLocations, which deduplicates
+	// table-file metadata across the stream. Kept on the wire
+	// indefinitely so old clients continue to work.
 	StreamDownloadLocations(ctx context.Context, opts ...grpc.CallOption) (ChunkStoreService_StreamDownloadLocationsClient, error)
 	// Get the download locations for a list of chunk hashes. Streaming
 	// variant that deduplicates table-file metadata across the stream.
@@ -3158,6 +3162,10 @@ type ChunkStoreServiceServer interface {
 	// Get the download locations for a list of chunk hashes. Streaming to
 	// support large and incrementally available payloads. Results are generated
 	// as requests come in.
+	//
+	// Deprecated: prefer StreamChunkLocations, which deduplicates
+	// table-file metadata across the stream. Kept on the wire
+	// indefinitely so old clients continue to work.
 	StreamDownloadLocations(ChunkStoreService_StreamDownloadLocationsServer) error
 	// Get the download locations for a list of chunk hashes. Streaming
 	// variant that deduplicates table-file metadata across the stream.

--- a/go/gen/proto/dolt/services/remotesapi/v1alpha1/chunkstore.pb.go
+++ b/go/gen/proto/dolt/services/remotesapi/v1alpha1/chunkstore.pb.go
@@ -928,10 +928,16 @@ type StreamChunkLocationsRequest struct {
 	// and replay any unacked requests against a freshly opened stream,
 	// so the server must never need prior in-stream state to interpret
 	// a request.
-	RepoId        *RepoId  `protobuf:"bytes,1,opt,name=repo_id,json=repoId,proto3" json:"repo_id,omitempty"`
-	RepoToken     string   `protobuf:"bytes,2,opt,name=repo_token,json=repoToken,proto3" json:"repo_token,omitempty"`
-	RepoPath      string   `protobuf:"bytes,3,opt,name=repo_path,json=repoPath,proto3" json:"repo_path,omitempty"`
-	ChunkHashes   [][]byte `protobuf:"bytes,4,rep,name=chunk_hashes,json=chunkHashes,proto3" json:"chunk_hashes,omitempty"`
+	RepoId    *RepoId `protobuf:"bytes,1,opt,name=repo_id,json=repoId,proto3" json:"repo_id,omitempty"`
+	RepoToken string  `protobuf:"bytes,2,opt,name=repo_token,json=repoToken,proto3" json:"repo_token,omitempty"`
+	RepoPath  string  `protobuf:"bytes,3,opt,name=repo_path,json=repoPath,proto3" json:"repo_path,omitempty"`
+	// Flat, packed buffer of 20-byte chunk hashes: hash N occupies
+	// bytes [N*20 : (N+1)*20]. Not a |repeated bytes| because every
+	// element is exactly 20 bytes and the 2-byte per-element
+	// tag/length overhead of |repeated bytes| is ~10% of the whole
+	// request in a 512-hash batch. Servers MUST reject requests
+	// where len(chunk_hashes) is not a multiple of 20.
+	ChunkHashes   []byte `protobuf:"bytes,4,opt,name=chunk_hashes,json=chunkHashes,proto3" json:"chunk_hashes,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -987,7 +993,7 @@ func (x *StreamChunkLocationsRequest) GetRepoPath() string {
 	return ""
 }
 
-func (x *StreamChunkLocationsRequest) GetChunkHashes() [][]byte {
+func (x *StreamChunkLocationsRequest) GetChunkHashes() []byte {
 	if x != nil {
 		return x.ChunkHashes
 	}
@@ -1008,12 +1014,11 @@ type StreamChunkLocationsResponse struct {
 	// Chunk locations for the hashes in the corresponding request.
 	// Response ordering is 1:1 with requests.
 	Locations []*StreamChunkLocationsResponse_ChunkLocation `protobuf:"bytes,3,rep,name=locations,proto3" json:"locations,omitempty"`
-	// Semantic indices into the corresponding request's chunk_hashes
-	// |repeated bytes| that the server could not find: i.e., a value
-	// of N here means "chunk_hashes[N] (the N'th 20-byte hash) was not
-	// found," not "the 20-byte run starting at byte offset N was not
-	// found." Sent explicitly so the client does not have to diff
-	// requested vs. returned.
+	// Hash indices into the corresponding request's chunk_hashes
+	// buffer that the server could not find: a value of N here means
+	// the N'th 20-byte hash (bytes [N*20 : (N+1)*20]) was not found.
+	// Not a byte offset. Sent explicitly so the client does not have
+	// to diff requested vs. returned.
 	MissingIndexes []uint32 `protobuf:"varint,4,rep,packed,name=missing_indexes,json=missingIndexes,proto3" json:"missing_indexes,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
@@ -2486,11 +2491,10 @@ type StreamChunkLocationsResponse_ChunkLocation struct {
 	// message on this same stream, or in the same response message
 	// as this ChunkLocation.
 	TableFileId uint32 `protobuf:"varint,1,opt,name=table_file_id,json=tableFileId,proto3" json:"table_file_id,omitempty"`
-	// Semantic index into the corresponding request's chunk_hashes
-	// |repeated bytes|: a value of N refers to chunk_hashes[N] (the
-	// N'th 20-byte hash element), not to a byte offset within a
-	// flattened hash buffer. Avoids re-transmitting the 20-byte
-	// hash on the wire.
+	// Hash index into the corresponding request's chunk_hashes
+	// buffer: a value of N refers to the N'th 20-byte hash, i.e.
+	// bytes [N*20 : (N+1)*20]. Not a byte offset. Avoids
+	// re-transmitting the 20-byte hash on the wire.
 	RequestIndex uint32 `protobuf:"varint,2,opt,name=request_index,json=requestIndex,proto3" json:"request_index,omitempty"`
 	Offset       uint64 `protobuf:"varint,3,opt,name=offset,proto3" json:"offset,omitempty"`
 	Length       uint32 `protobuf:"varint,4,opt,name=length,proto3" json:"length,omitempty"`
@@ -2634,7 +2638,7 @@ const file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDesc = "" +
 	"\n" +
 	"repo_token\x18\x02 \x01(\tR\trepoToken\x12\x1b\n" +
 	"\trepo_path\x18\x03 \x01(\tR\brepoPath\x12!\n" +
-	"\fchunk_hashes\x18\x04 \x03(\fR\vchunkHashes\"\xce\x05\n" +
+	"\fchunk_hashes\x18\x04 \x01(\fR\vchunkHashes\"\xce\x05\n" +
 	"\x1cStreamChunkLocationsResponse\x12\x1d\n" +
 	"\n" +
 	"repo_token\x18\x01 \x01(\tR\trepoToken\x12p\n" +

--- a/go/gen/proto/dolt/services/remotesapi/v1alpha1/chunkstore.pb.go
+++ b/go/gen/proto/dolt/services/remotesapi/v1alpha1/chunkstore.pb.go
@@ -107,6 +107,67 @@ func (PushConcurrencyControl) EnumDescriptor() ([]byte, []int) {
 	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{0}
 }
 
+// Optional, additive capability flags advertised by the server in
+// GetRepoMetadataResponse.features. Use this for pure "does the
+// server implement X?" booleans. Mode selectors with more than two
+// states (such as the existing PushConcurrencyControl) keep their
+// own typed fields; this list is only for flag-shaped capabilities.
+//
+// Guidelines for growth:
+//   - Add new values at the end; never reuse a removed value's
+//     number. If a feature is retired, reserve its number rather
+//     than re-purposing it.
+//   - FEATURE_UNSPECIFIED = 0 is never sent; presence of the zero
+//     value in a received list should be ignored by the client.
+type Feature int32
+
+const (
+	Feature_FEATURE_UNSPECIFIED Feature = 0
+	// Server implements the StreamChunkLocations RPC. Clients should
+	// prefer it to StreamDownloadLocations when this feature is
+	// present.
+	Feature_FEATURE_STREAM_CHUNK_LOCATIONS Feature = 1
+)
+
+// Enum value maps for Feature.
+var (
+	Feature_name = map[int32]string{
+		0: "FEATURE_UNSPECIFIED",
+		1: "FEATURE_STREAM_CHUNK_LOCATIONS",
+	}
+	Feature_value = map[string]int32{
+		"FEATURE_UNSPECIFIED":            0,
+		"FEATURE_STREAM_CHUNK_LOCATIONS": 1,
+	}
+)
+
+func (x Feature) Enum() *Feature {
+	p := new(Feature)
+	*p = x
+	return p
+}
+
+func (x Feature) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (Feature) Descriptor() protoreflect.EnumDescriptor {
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_enumTypes[1].Descriptor()
+}
+
+func (Feature) Type() protoreflect.EnumType {
+	return &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_enumTypes[1]
+}
+
+func (x Feature) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use Feature.Descriptor instead.
+func (Feature) EnumDescriptor() ([]byte, []int) {
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{1}
+}
+
 type ManifestAppendixOption int32
 
 const (
@@ -140,11 +201,11 @@ func (x ManifestAppendixOption) String() string {
 }
 
 func (ManifestAppendixOption) Descriptor() protoreflect.EnumDescriptor {
-	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_enumTypes[1].Descriptor()
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_enumTypes[2].Descriptor()
 }
 
 func (ManifestAppendixOption) Type() protoreflect.EnumType {
-	return &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_enumTypes[1]
+	return &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_enumTypes[2]
 }
 
 func (x ManifestAppendixOption) Number() protoreflect.EnumNumber {
@@ -153,7 +214,7 @@ func (x ManifestAppendixOption) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ManifestAppendixOption.Descriptor instead.
 func (ManifestAppendixOption) EnumDescriptor() ([]byte, []int) {
-	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{1}
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{2}
 }
 
 // RepoId is how repositories are represented on dolthub, for example
@@ -858,6 +919,164 @@ func (x *GetDownloadLocsResponse) GetRepoToken() string {
 	return ""
 }
 
+type StreamChunkLocationsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Every request must populate RepoId/repo_token/repo_path on the
+	// wire. This matches what the current StreamDownloadLocations
+	// client already does and is load-bearing for retry correctness:
+	// the reliable-RPC layer may tear down the underlying gRPC stream
+	// and replay any unacked requests against a freshly opened stream,
+	// so the server must never need prior in-stream state to interpret
+	// a request.
+	RepoId        *RepoId  `protobuf:"bytes,1,opt,name=repo_id,json=repoId,proto3" json:"repo_id,omitempty"`
+	RepoToken     string   `protobuf:"bytes,2,opt,name=repo_token,json=repoToken,proto3" json:"repo_token,omitempty"`
+	RepoPath      string   `protobuf:"bytes,3,opt,name=repo_path,json=repoPath,proto3" json:"repo_path,omitempty"`
+	ChunkHashes   [][]byte `protobuf:"bytes,4,rep,name=chunk_hashes,json=chunkHashes,proto3" json:"chunk_hashes,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StreamChunkLocationsRequest) Reset() {
+	*x = StreamChunkLocationsRequest{}
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StreamChunkLocationsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StreamChunkLocationsRequest) ProtoMessage() {}
+
+func (x *StreamChunkLocationsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StreamChunkLocationsRequest.ProtoReflect.Descriptor instead.
+func (*StreamChunkLocationsRequest) Descriptor() ([]byte, []int) {
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *StreamChunkLocationsRequest) GetRepoId() *RepoId {
+	if x != nil {
+		return x.RepoId
+	}
+	return nil
+}
+
+func (x *StreamChunkLocationsRequest) GetRepoToken() string {
+	if x != nil {
+		return x.RepoToken
+	}
+	return ""
+}
+
+func (x *StreamChunkLocationsRequest) GetRepoPath() string {
+	if x != nil {
+		return x.RepoPath
+	}
+	return ""
+}
+
+func (x *StreamChunkLocationsRequest) GetChunkHashes() [][]byte {
+	if x != nil {
+		return x.ChunkHashes
+	}
+	return nil
+}
+
+type StreamChunkLocationsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// If non-empty, advertises a new repo_token that the client should
+	// use on future requests on this service.
+	RepoToken string `protobuf:"bytes,1,opt,name=repo_token,json=repoToken,proto3" json:"repo_token,omitempty"`
+	// Zero or more table-file records introduced by this response.
+	// Valid for the remainder of this server-side stream. Clients MUST
+	// integrate these into their table_file_id map (inserting or
+	// overwriting) before resolving any |locations| in this same
+	// response.
+	TableFiles []*StreamChunkLocationsResponse_TableFileRecord `protobuf:"bytes,2,rep,name=table_files,json=tableFiles,proto3" json:"table_files,omitempty"`
+	// Chunk locations for the hashes in the corresponding request.
+	// Response ordering is 1:1 with requests.
+	Locations []*StreamChunkLocationsResponse_ChunkLocation `protobuf:"bytes,3,rep,name=locations,proto3" json:"locations,omitempty"`
+	// Semantic indices into the corresponding request's chunk_hashes
+	// |repeated bytes| that the server could not find: i.e., a value
+	// of N here means "chunk_hashes[N] (the N'th 20-byte hash) was not
+	// found," not "the 20-byte run starting at byte offset N was not
+	// found." Sent explicitly so the client does not have to diff
+	// requested vs. returned.
+	MissingIndexes []uint32 `protobuf:"varint,4,rep,packed,name=missing_indexes,json=missingIndexes,proto3" json:"missing_indexes,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *StreamChunkLocationsResponse) Reset() {
+	*x = StreamChunkLocationsResponse{}
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StreamChunkLocationsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StreamChunkLocationsResponse) ProtoMessage() {}
+
+func (x *StreamChunkLocationsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StreamChunkLocationsResponse.ProtoReflect.Descriptor instead.
+func (*StreamChunkLocationsResponse) Descriptor() ([]byte, []int) {
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *StreamChunkLocationsResponse) GetRepoToken() string {
+	if x != nil {
+		return x.RepoToken
+	}
+	return ""
+}
+
+func (x *StreamChunkLocationsResponse) GetTableFiles() []*StreamChunkLocationsResponse_TableFileRecord {
+	if x != nil {
+		return x.TableFiles
+	}
+	return nil
+}
+
+func (x *StreamChunkLocationsResponse) GetLocations() []*StreamChunkLocationsResponse_ChunkLocation {
+	if x != nil {
+		return x.Locations
+	}
+	return nil
+}
+
+func (x *StreamChunkLocationsResponse) GetMissingIndexes() []uint32 {
+	if x != nil {
+		return x.MissingIndexes
+	}
+	return nil
+}
+
 type TableFileDetails struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            []byte                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -872,7 +1091,7 @@ type TableFileDetails struct {
 
 func (x *TableFileDetails) Reset() {
 	*x = TableFileDetails{}
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[11]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -884,7 +1103,7 @@ func (x *TableFileDetails) String() string {
 func (*TableFileDetails) ProtoMessage() {}
 
 func (x *TableFileDetails) ProtoReflect() protoreflect.Message {
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[11]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -897,7 +1116,7 @@ func (x *TableFileDetails) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TableFileDetails.ProtoReflect.Descriptor instead.
 func (*TableFileDetails) Descriptor() ([]byte, []int) {
-	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{11}
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *TableFileDetails) GetId() []byte {
@@ -956,7 +1175,7 @@ type GetUploadLocsRequest struct {
 
 func (x *GetUploadLocsRequest) Reset() {
 	*x = GetUploadLocsRequest{}
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[12]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -968,7 +1187,7 @@ func (x *GetUploadLocsRequest) String() string {
 func (*GetUploadLocsRequest) ProtoMessage() {}
 
 func (x *GetUploadLocsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[12]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -981,7 +1200,7 @@ func (x *GetUploadLocsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUploadLocsRequest.ProtoReflect.Descriptor instead.
 func (*GetUploadLocsRequest) Descriptor() ([]byte, []int) {
-	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{12}
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *GetUploadLocsRequest) GetRepoId() *RepoId {
@@ -1030,7 +1249,7 @@ type GetUploadLocsResponse struct {
 
 func (x *GetUploadLocsResponse) Reset() {
 	*x = GetUploadLocsResponse{}
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[13]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1042,7 +1261,7 @@ func (x *GetUploadLocsResponse) String() string {
 func (*GetUploadLocsResponse) ProtoMessage() {}
 
 func (x *GetUploadLocsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[13]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1055,7 +1274,7 @@ func (x *GetUploadLocsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUploadLocsResponse.ProtoReflect.Descriptor instead.
 func (*GetUploadLocsResponse) Descriptor() ([]byte, []int) {
-	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{13}
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *GetUploadLocsResponse) GetLocs() []*UploadLoc {
@@ -1083,7 +1302,7 @@ type RebaseRequest struct {
 
 func (x *RebaseRequest) Reset() {
 	*x = RebaseRequest{}
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[14]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1095,7 +1314,7 @@ func (x *RebaseRequest) String() string {
 func (*RebaseRequest) ProtoMessage() {}
 
 func (x *RebaseRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[14]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1108,7 +1327,7 @@ func (x *RebaseRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RebaseRequest.ProtoReflect.Descriptor instead.
 func (*RebaseRequest) Descriptor() ([]byte, []int) {
-	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{14}
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *RebaseRequest) GetRepoId() *RepoId {
@@ -1141,7 +1360,7 @@ type RebaseResponse struct {
 
 func (x *RebaseResponse) Reset() {
 	*x = RebaseResponse{}
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[15]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1153,7 +1372,7 @@ func (x *RebaseResponse) String() string {
 func (*RebaseResponse) ProtoMessage() {}
 
 func (x *RebaseResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[15]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1166,7 +1385,7 @@ func (x *RebaseResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RebaseResponse.ProtoReflect.Descriptor instead.
 func (*RebaseResponse) Descriptor() ([]byte, []int) {
-	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{15}
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *RebaseResponse) GetRepoToken() string {
@@ -1187,7 +1406,7 @@ type RootRequest struct {
 
 func (x *RootRequest) Reset() {
 	*x = RootRequest{}
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[16]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1199,7 +1418,7 @@ func (x *RootRequest) String() string {
 func (*RootRequest) ProtoMessage() {}
 
 func (x *RootRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[16]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1212,7 +1431,7 @@ func (x *RootRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RootRequest.ProtoReflect.Descriptor instead.
 func (*RootRequest) Descriptor() ([]byte, []int) {
-	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{16}
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *RootRequest) GetRepoId() *RepoId {
@@ -1246,7 +1465,7 @@ type RootResponse struct {
 
 func (x *RootResponse) Reset() {
 	*x = RootResponse{}
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[17]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1258,7 +1477,7 @@ func (x *RootResponse) String() string {
 func (*RootResponse) ProtoMessage() {}
 
 func (x *RootResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[17]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1271,7 +1490,7 @@ func (x *RootResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RootResponse.ProtoReflect.Descriptor instead.
 func (*RootResponse) Descriptor() ([]byte, []int) {
-	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{17}
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *RootResponse) GetRootHash() []byte {
@@ -1298,7 +1517,7 @@ type ChunkTableInfo struct {
 
 func (x *ChunkTableInfo) Reset() {
 	*x = ChunkTableInfo{}
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[18]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1310,7 +1529,7 @@ func (x *ChunkTableInfo) String() string {
 func (*ChunkTableInfo) ProtoMessage() {}
 
 func (x *ChunkTableInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[18]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1323,7 +1542,7 @@ func (x *ChunkTableInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChunkTableInfo.ProtoReflect.Descriptor instead.
 func (*ChunkTableInfo) Descriptor() ([]byte, []int) {
-	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{18}
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ChunkTableInfo) GetHash() []byte {
@@ -1354,7 +1573,7 @@ type CommitRequest struct {
 
 func (x *CommitRequest) Reset() {
 	*x = CommitRequest{}
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[19]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1366,7 +1585,7 @@ func (x *CommitRequest) String() string {
 func (*CommitRequest) ProtoMessage() {}
 
 func (x *CommitRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[19]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1379,7 +1598,7 @@ func (x *CommitRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CommitRequest.ProtoReflect.Descriptor instead.
 func (*CommitRequest) Descriptor() ([]byte, []int) {
-	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{19}
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *CommitRequest) GetRepoId() *RepoId {
@@ -1433,7 +1652,7 @@ type CommitResponse struct {
 
 func (x *CommitResponse) Reset() {
 	*x = CommitResponse{}
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[20]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1445,7 +1664,7 @@ func (x *CommitResponse) String() string {
 func (*CommitResponse) ProtoMessage() {}
 
 func (x *CommitResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[20]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1458,7 +1677,7 @@ func (x *CommitResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CommitResponse.ProtoReflect.Descriptor instead.
 func (*CommitResponse) Descriptor() ([]byte, []int) {
-	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{20}
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *CommitResponse) GetSuccess() bool {
@@ -1480,7 +1699,7 @@ type GetRepoMetadataRequest struct {
 
 func (x *GetRepoMetadataRequest) Reset() {
 	*x = GetRepoMetadataRequest{}
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[21]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1492,7 +1711,7 @@ func (x *GetRepoMetadataRequest) String() string {
 func (*GetRepoMetadataRequest) ProtoMessage() {}
 
 func (x *GetRepoMetadataRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[21]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1505,7 +1724,7 @@ func (x *GetRepoMetadataRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRepoMetadataRequest.ProtoReflect.Descriptor instead.
 func (*GetRepoMetadataRequest) Descriptor() ([]byte, []int) {
-	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{21}
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *GetRepoMetadataRequest) GetRepoId() *RepoId {
@@ -1549,13 +1768,17 @@ type GetRepoMetadataResponse struct {
 	StorageSize            uint64                 `protobuf:"varint,3,opt,name=storage_size,json=storageSize,proto3" json:"storage_size,omitempty"`
 	RepoToken              string                 `protobuf:"bytes,4,opt,name=repo_token,json=repoToken,proto3" json:"repo_token,omitempty"`
 	PushConcurrencyControl PushConcurrencyControl `protobuf:"varint,5,opt,name=push_concurrency_control,json=pushConcurrencyControl,proto3,enum=dolt.services.remotesapi.v1alpha1.PushConcurrencyControl" json:"push_concurrency_control,omitempty"`
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
+	// Optional capability flags advertised by the server. See the
+	// Feature enum above. Order is not significant; duplicates
+	// should be treated the same as a single occurrence.
+	Features      []Feature `protobuf:"varint,6,rep,packed,name=features,proto3,enum=dolt.services.remotesapi.v1alpha1.Feature" json:"features,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetRepoMetadataResponse) Reset() {
 	*x = GetRepoMetadataResponse{}
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[22]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1567,7 +1790,7 @@ func (x *GetRepoMetadataResponse) String() string {
 func (*GetRepoMetadataResponse) ProtoMessage() {}
 
 func (x *GetRepoMetadataResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[22]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1580,7 +1803,7 @@ func (x *GetRepoMetadataResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRepoMetadataResponse.ProtoReflect.Descriptor instead.
 func (*GetRepoMetadataResponse) Descriptor() ([]byte, []int) {
-	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{22}
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *GetRepoMetadataResponse) GetNbfVersion() string {
@@ -1618,6 +1841,13 @@ func (x *GetRepoMetadataResponse) GetPushConcurrencyControl() PushConcurrencyCon
 	return PushConcurrencyControl_PUSH_CONCURRENCY_CONTROL_UNSPECIFIED
 }
 
+func (x *GetRepoMetadataResponse) GetFeatures() []Feature {
+	if x != nil {
+		return x.Features
+	}
+	return nil
+}
+
 type ClientRepoFormat struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	NbfVersion    string                 `protobuf:"bytes,1,opt,name=nbf_version,json=nbfVersion,proto3" json:"nbf_version,omitempty"`
@@ -1628,7 +1858,7 @@ type ClientRepoFormat struct {
 
 func (x *ClientRepoFormat) Reset() {
 	*x = ClientRepoFormat{}
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[23]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1640,7 +1870,7 @@ func (x *ClientRepoFormat) String() string {
 func (*ClientRepoFormat) ProtoMessage() {}
 
 func (x *ClientRepoFormat) ProtoReflect() protoreflect.Message {
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[23]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1653,7 +1883,7 @@ func (x *ClientRepoFormat) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClientRepoFormat.ProtoReflect.Descriptor instead.
 func (*ClientRepoFormat) Descriptor() ([]byte, []int) {
-	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{23}
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *ClientRepoFormat) GetNbfVersion() string {
@@ -1683,7 +1913,7 @@ type ListTableFilesRequest struct {
 
 func (x *ListTableFilesRequest) Reset() {
 	*x = ListTableFilesRequest{}
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[24]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1695,7 +1925,7 @@ func (x *ListTableFilesRequest) String() string {
 func (*ListTableFilesRequest) ProtoMessage() {}
 
 func (x *ListTableFilesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[24]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1708,7 +1938,7 @@ func (x *ListTableFilesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTableFilesRequest.ProtoReflect.Descriptor instead.
 func (*ListTableFilesRequest) Descriptor() ([]byte, []int) {
-	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{24}
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *ListTableFilesRequest) GetRepoId() *RepoId {
@@ -1754,7 +1984,7 @@ type TableFileInfo struct {
 
 func (x *TableFileInfo) Reset() {
 	*x = TableFileInfo{}
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[25]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1766,7 +1996,7 @@ func (x *TableFileInfo) String() string {
 func (*TableFileInfo) ProtoMessage() {}
 
 func (x *TableFileInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[25]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1779,7 +2009,7 @@ func (x *TableFileInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TableFileInfo.ProtoReflect.Descriptor instead.
 func (*TableFileInfo) Descriptor() ([]byte, []int) {
-	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{25}
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *TableFileInfo) GetFileId() string {
@@ -1836,7 +2066,7 @@ type RefreshTableFileUrlRequest struct {
 
 func (x *RefreshTableFileUrlRequest) Reset() {
 	*x = RefreshTableFileUrlRequest{}
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[26]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1848,7 +2078,7 @@ func (x *RefreshTableFileUrlRequest) String() string {
 func (*RefreshTableFileUrlRequest) ProtoMessage() {}
 
 func (x *RefreshTableFileUrlRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[26]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1861,7 +2091,7 @@ func (x *RefreshTableFileUrlRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshTableFileUrlRequest.ProtoReflect.Descriptor instead.
 func (*RefreshTableFileUrlRequest) Descriptor() ([]byte, []int) {
-	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{26}
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *RefreshTableFileUrlRequest) GetRepoId() *RepoId {
@@ -1903,7 +2133,7 @@ type RefreshTableFileUrlResponse struct {
 
 func (x *RefreshTableFileUrlResponse) Reset() {
 	*x = RefreshTableFileUrlResponse{}
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[27]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1915,7 +2145,7 @@ func (x *RefreshTableFileUrlResponse) String() string {
 func (*RefreshTableFileUrlResponse) ProtoMessage() {}
 
 func (x *RefreshTableFileUrlResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[27]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1928,7 +2158,7 @@ func (x *RefreshTableFileUrlResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshTableFileUrlResponse.ProtoReflect.Descriptor instead.
 func (*RefreshTableFileUrlResponse) Descriptor() ([]byte, []int) {
-	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{27}
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *RefreshTableFileUrlResponse) GetUrl() string {
@@ -1964,7 +2194,7 @@ type ListTableFilesResponse struct {
 
 func (x *ListTableFilesResponse) Reset() {
 	*x = ListTableFilesResponse{}
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[28]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1976,7 +2206,7 @@ func (x *ListTableFilesResponse) String() string {
 func (*ListTableFilesResponse) ProtoMessage() {}
 
 func (x *ListTableFilesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[28]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1989,7 +2219,7 @@ func (x *ListTableFilesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTableFilesResponse.ProtoReflect.Descriptor instead.
 func (*ListTableFilesResponse) Descriptor() ([]byte, []int) {
-	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{28}
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ListTableFilesResponse) GetRootHash() []byte {
@@ -2040,7 +2270,7 @@ type AddTableFilesRequest struct {
 
 func (x *AddTableFilesRequest) Reset() {
 	*x = AddTableFilesRequest{}
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[29]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2052,7 +2282,7 @@ func (x *AddTableFilesRequest) String() string {
 func (*AddTableFilesRequest) ProtoMessage() {}
 
 func (x *AddTableFilesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[29]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2065,7 +2295,7 @@ func (x *AddTableFilesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddTableFilesRequest.ProtoReflect.Descriptor instead.
 func (*AddTableFilesRequest) Descriptor() ([]byte, []int) {
-	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{29}
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *AddTableFilesRequest) GetRepoId() *RepoId {
@@ -2120,7 +2350,7 @@ type AddTableFilesResponse struct {
 
 func (x *AddTableFilesResponse) Reset() {
 	*x = AddTableFilesResponse{}
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[30]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2132,7 +2362,7 @@ func (x *AddTableFilesResponse) String() string {
 func (*AddTableFilesResponse) ProtoMessage() {}
 
 func (x *AddTableFilesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[30]
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2145,7 +2375,7 @@ func (x *AddTableFilesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddTableFilesResponse.ProtoReflect.Descriptor instead.
 func (*AddTableFilesResponse) Descriptor() ([]byte, []int) {
-	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{30}
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *AddTableFilesResponse) GetSuccess() bool {
@@ -2160,6 +2390,188 @@ func (x *AddTableFilesResponse) GetRepoToken() string {
 		return x.RepoToken
 	}
 	return ""
+}
+
+// TableFileRecord and ChunkLocation are nested inside the response
+// rather than free-standing at package level. Their invariants
+// (table_file_id is stream-scoped; request_index is scoped to one
+// request's chunk_hashes) only hold in the context of this
+// response.
+type StreamChunkLocationsResponse_TableFileRecord struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Opaque id assigned by the server, scoped to the current
+	// server-side stream. The server MUST emit a TableFileRecord
+	// for any id on its first use within a given server-side
+	// stream, before (or in the same response as) any
+	// ChunkLocation that references the id. Clients MUST overwrite
+	// any prior entry for the same id when a new TableFileRecord
+	// arrives.
+	TableFileId uint32 `protobuf:"varint,1,opt,name=table_file_id,json=tableFileId,proto3" json:"table_file_id,omitempty"`
+	// Signed URL the client should issue byte-range requests
+	// against.
+	Url string `protobuf:"bytes,2,opt,name=url,proto3" json:"url,omitempty"`
+	// When the client should consider |url| stale and call
+	// RefreshTableFileUrl.
+	RefreshAfter *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=refresh_after,json=refreshAfter,proto3" json:"refresh_after,omitempty"`
+	// The file_id to use when calling RefreshTableFileUrl. All the
+	// other fields of RefreshTableFileUrlRequest (repo_id,
+	// repo_token, repo_path) are already known to the client.
+	FileId        string `protobuf:"bytes,4,opt,name=file_id,json=fileId,proto3" json:"file_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StreamChunkLocationsResponse_TableFileRecord) Reset() {
+	*x = StreamChunkLocationsResponse_TableFileRecord{}
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StreamChunkLocationsResponse_TableFileRecord) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StreamChunkLocationsResponse_TableFileRecord) ProtoMessage() {}
+
+func (x *StreamChunkLocationsResponse_TableFileRecord) ProtoReflect() protoreflect.Message {
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StreamChunkLocationsResponse_TableFileRecord.ProtoReflect.Descriptor instead.
+func (*StreamChunkLocationsResponse_TableFileRecord) Descriptor() ([]byte, []int) {
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{12, 0}
+}
+
+func (x *StreamChunkLocationsResponse_TableFileRecord) GetTableFileId() uint32 {
+	if x != nil {
+		return x.TableFileId
+	}
+	return 0
+}
+
+func (x *StreamChunkLocationsResponse_TableFileRecord) GetUrl() string {
+	if x != nil {
+		return x.Url
+	}
+	return ""
+}
+
+func (x *StreamChunkLocationsResponse_TableFileRecord) GetRefreshAfter() *timestamppb.Timestamp {
+	if x != nil {
+		return x.RefreshAfter
+	}
+	return nil
+}
+
+func (x *StreamChunkLocationsResponse_TableFileRecord) GetFileId() string {
+	if x != nil {
+		return x.FileId
+	}
+	return ""
+}
+
+type StreamChunkLocationsResponse_ChunkLocation struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Refers to a TableFileRecord.table_file_id introduced in the
+	// current server-side stream -- either in an earlier response
+	// message on this same stream, or in the same response message
+	// as this ChunkLocation.
+	TableFileId uint32 `protobuf:"varint,1,opt,name=table_file_id,json=tableFileId,proto3" json:"table_file_id,omitempty"`
+	// Semantic index into the corresponding request's chunk_hashes
+	// |repeated bytes|: a value of N refers to chunk_hashes[N] (the
+	// N'th 20-byte hash element), not to a byte offset within a
+	// flattened hash buffer. Avoids re-transmitting the 20-byte
+	// hash on the wire.
+	RequestIndex uint32 `protobuf:"varint,2,opt,name=request_index,json=requestIndex,proto3" json:"request_index,omitempty"`
+	Offset       uint64 `protobuf:"varint,3,opt,name=offset,proto3" json:"offset,omitempty"`
+	Length       uint32 `protobuf:"varint,4,opt,name=length,proto3" json:"length,omitempty"`
+	// zStd dictionary span within the same table file. Same
+	// semantics as the existing RangeChunk.dictionary_{offset,length}.
+	DictionaryOffset uint64 `protobuf:"varint,5,opt,name=dictionary_offset,json=dictionaryOffset,proto3" json:"dictionary_offset,omitempty"`
+	DictionaryLength uint32 `protobuf:"varint,6,opt,name=dictionary_length,json=dictionaryLength,proto3" json:"dictionary_length,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *StreamChunkLocationsResponse_ChunkLocation) Reset() {
+	*x = StreamChunkLocationsResponse_ChunkLocation{}
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StreamChunkLocationsResponse_ChunkLocation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StreamChunkLocationsResponse_ChunkLocation) ProtoMessage() {}
+
+func (x *StreamChunkLocationsResponse_ChunkLocation) ProtoReflect() protoreflect.Message {
+	mi := &file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StreamChunkLocationsResponse_ChunkLocation.ProtoReflect.Descriptor instead.
+func (*StreamChunkLocationsResponse_ChunkLocation) Descriptor() ([]byte, []int) {
+	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP(), []int{12, 1}
+}
+
+func (x *StreamChunkLocationsResponse_ChunkLocation) GetTableFileId() uint32 {
+	if x != nil {
+		return x.TableFileId
+	}
+	return 0
+}
+
+func (x *StreamChunkLocationsResponse_ChunkLocation) GetRequestIndex() uint32 {
+	if x != nil {
+		return x.RequestIndex
+	}
+	return 0
+}
+
+func (x *StreamChunkLocationsResponse_ChunkLocation) GetOffset() uint64 {
+	if x != nil {
+		return x.Offset
+	}
+	return 0
+}
+
+func (x *StreamChunkLocationsResponse_ChunkLocation) GetLength() uint32 {
+	if x != nil {
+		return x.Length
+	}
+	return 0
+}
+
+func (x *StreamChunkLocationsResponse_ChunkLocation) GetDictionaryOffset() uint64 {
+	if x != nil {
+		return x.DictionaryOffset
+	}
+	return 0
+}
+
+func (x *StreamChunkLocationsResponse_ChunkLocation) GetDictionaryLength() uint32 {
+	if x != nil {
+		return x.DictionaryLength
+	}
+	return 0
 }
 
 var File_dolt_services_remotesapi_v1alpha1_chunkstore_proto protoreflect.FileDescriptor
@@ -2216,7 +2628,32 @@ const file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDesc = "" +
 	"\x17GetDownloadLocsResponse\x12B\n" +
 	"\x04locs\x18\x01 \x03(\v2..dolt.services.remotesapi.v1alpha1.DownloadLocR\x04locs\x12\x1d\n" +
 	"\n" +
-	"repo_token\x18\x02 \x01(\tR\trepoToken\"\xc6\x01\n" +
+	"repo_token\x18\x02 \x01(\tR\trepoToken\"\xc0\x01\n" +
+	"\x1bStreamChunkLocationsRequest\x12B\n" +
+	"\arepo_id\x18\x01 \x01(\v2).dolt.services.remotesapi.v1alpha1.RepoIdR\x06repoId\x12\x1d\n" +
+	"\n" +
+	"repo_token\x18\x02 \x01(\tR\trepoToken\x12\x1b\n" +
+	"\trepo_path\x18\x03 \x01(\tR\brepoPath\x12!\n" +
+	"\fchunk_hashes\x18\x04 \x03(\fR\vchunkHashes\"\xce\x05\n" +
+	"\x1cStreamChunkLocationsResponse\x12\x1d\n" +
+	"\n" +
+	"repo_token\x18\x01 \x01(\tR\trepoToken\x12p\n" +
+	"\vtable_files\x18\x02 \x03(\v2O.dolt.services.remotesapi.v1alpha1.StreamChunkLocationsResponse.TableFileRecordR\n" +
+	"tableFiles\x12k\n" +
+	"\tlocations\x18\x03 \x03(\v2M.dolt.services.remotesapi.v1alpha1.StreamChunkLocationsResponse.ChunkLocationR\tlocations\x12'\n" +
+	"\x0fmissing_indexes\x18\x04 \x03(\rR\x0emissingIndexes\x1a\xa1\x01\n" +
+	"\x0fTableFileRecord\x12\"\n" +
+	"\rtable_file_id\x18\x01 \x01(\rR\vtableFileId\x12\x10\n" +
+	"\x03url\x18\x02 \x01(\tR\x03url\x12?\n" +
+	"\rrefresh_after\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\frefreshAfter\x12\x17\n" +
+	"\afile_id\x18\x04 \x01(\tR\x06fileId\x1a\xe2\x01\n" +
+	"\rChunkLocation\x12\"\n" +
+	"\rtable_file_id\x18\x01 \x01(\rR\vtableFileId\x12#\n" +
+	"\rrequest_index\x18\x02 \x01(\rR\frequestIndex\x12\x16\n" +
+	"\x06offset\x18\x03 \x01(\x04R\x06offset\x12\x16\n" +
+	"\x06length\x18\x04 \x01(\rR\x06length\x12+\n" +
+	"\x11dictionary_offset\x18\x05 \x01(\x04R\x10dictionaryOffset\x12+\n" +
+	"\x11dictionary_length\x18\x06 \x01(\rR\x10dictionaryLength\"\xc6\x01\n" +
 	"\x10TableFileDetails\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\fR\x02id\x12%\n" +
 	"\x0econtent_length\x18\x02 \x01(\x04R\rcontentLength\x12!\n" +
@@ -2271,7 +2708,7 @@ const file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDesc = "" +
 	"\x12client_repo_format\x18\x0e \x01(\v23.dolt.services.remotesapi.v1alpha1.ClientRepoFormatR\x10clientRepoFormat\x12\x1d\n" +
 	"\n" +
 	"repo_token\x18\x02 \x01(\tR\trepoToken\x12\x1b\n" +
-	"\trepo_path\x18\x03 \x01(\tR\brepoPath\"\x92\x02\n" +
+	"\trepo_path\x18\x03 \x01(\tR\brepoPath\"\xda\x02\n" +
 	"\x17GetRepoMetadataResponse\x12\x1f\n" +
 	"\vnbf_version\x18\x01 \x01(\tR\n" +
 	"nbfVersion\x12\x1f\n" +
@@ -2280,7 +2717,8 @@ const file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDesc = "" +
 	"\fstorage_size\x18\x03 \x01(\x04R\vstorageSize\x12\x1d\n" +
 	"\n" +
 	"repo_token\x18\x04 \x01(\tR\trepoToken\x12s\n" +
-	"\x18push_concurrency_control\x18\x05 \x01(\x0e29.dolt.services.remotesapi.v1alpha1.PushConcurrencyControlR\x16pushConcurrencyControl\"T\n" +
+	"\x18push_concurrency_control\x18\x05 \x01(\x0e29.dolt.services.remotesapi.v1alpha1.PushConcurrencyControlR\x16pushConcurrencyControl\x12F\n" +
+	"\bfeatures\x18\x06 \x03(\x0e2*.dolt.services.remotesapi.v1alpha1.FeatureR\bfeatures\"T\n" +
 	"\x10ClientRepoFormat\x12\x1f\n" +
 	"\vnbf_version\x18\x01 \x01(\tR\n" +
 	"nbfVersion\x12\x1f\n" +
@@ -2332,16 +2770,20 @@ const file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDesc = "" +
 	"\x16PushConcurrencyControl\x12(\n" +
 	"$PUSH_CONCURRENCY_CONTROL_UNSPECIFIED\x10\x00\x12/\n" +
 	"+PUSH_CONCURRENCY_CONTROL_IGNORE_WORKING_SET\x10\x01\x12/\n" +
-	"+PUSH_CONCURRENCY_CONTROL_ASSERT_WORKING_SET\x10\x02*\x89\x01\n" +
+	"+PUSH_CONCURRENCY_CONTROL_ASSERT_WORKING_SET\x10\x02*F\n" +
+	"\aFeature\x12\x17\n" +
+	"\x13FEATURE_UNSPECIFIED\x10\x00\x12\"\n" +
+	"\x1eFEATURE_STREAM_CHUNK_LOCATIONS\x10\x01*\x89\x01\n" +
 	"\x16ManifestAppendixOption\x12(\n" +
 	"$MANIFEST_APPENDIX_OPTION_UNSPECIFIED\x10\x00\x12 \n" +
 	"\x1cMANIFEST_APPENDIX_OPTION_SET\x10\x01\x12#\n" +
-	"\x1fMANIFEST_APPENDIX_OPTION_APPEND\x10\x022\xb2\v\n" +
+	"\x1fMANIFEST_APPENDIX_OPTION_APPEND\x10\x022\xd0\f\n" +
 	"\x11ChunkStoreService\x12\x88\x01\n" +
 	"\x0fGetRepoMetadata\x129.dolt.services.remotesapi.v1alpha1.GetRepoMetadataRequest\x1a:.dolt.services.remotesapi.v1alpha1.GetRepoMetadataResponse\x12v\n" +
 	"\tHasChunks\x123.dolt.services.remotesapi.v1alpha1.HasChunksRequest\x1a4.dolt.services.remotesapi.v1alpha1.HasChunksResponse\x12\x8d\x01\n" +
 	"\x14GetDownloadLocations\x129.dolt.services.remotesapi.v1alpha1.GetDownloadLocsRequest\x1a:.dolt.services.remotesapi.v1alpha1.GetDownloadLocsResponse\x12\x94\x01\n" +
-	"\x17StreamDownloadLocations\x129.dolt.services.remotesapi.v1alpha1.GetDownloadLocsRequest\x1a:.dolt.services.remotesapi.v1alpha1.GetDownloadLocsResponse(\x010\x01\x12\x87\x01\n" +
+	"\x17StreamDownloadLocations\x129.dolt.services.remotesapi.v1alpha1.GetDownloadLocsRequest\x1a:.dolt.services.remotesapi.v1alpha1.GetDownloadLocsResponse(\x010\x01\x12\x9b\x01\n" +
+	"\x14StreamChunkLocations\x12>.dolt.services.remotesapi.v1alpha1.StreamChunkLocationsRequest\x1a?.dolt.services.remotesapi.v1alpha1.StreamChunkLocationsResponse(\x010\x01\x12\x87\x01\n" +
 	"\x12GetUploadLocations\x127.dolt.services.remotesapi.v1alpha1.GetUploadLocsRequest\x1a8.dolt.services.remotesapi.v1alpha1.GetUploadLocsResponse\x12m\n" +
 	"\x06Rebase\x120.dolt.services.remotesapi.v1alpha1.RebaseRequest\x1a1.dolt.services.remotesapi.v1alpha1.RebaseResponse\x12g\n" +
 	"\x04Root\x12..dolt.services.remotesapi.v1alpha1.RootRequest\x1a/.dolt.services.remotesapi.v1alpha1.RootResponse\x12m\n" +
@@ -2362,103 +2804,115 @@ func file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescGZIP() []byt
 	return file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDescData
 }
 
-var file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
+var file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+var file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
 var file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_goTypes = []any{
-	(PushConcurrencyControl)(0),         // 0: dolt.services.remotesapi.v1alpha1.PushConcurrencyControl
-	(ManifestAppendixOption)(0),         // 1: dolt.services.remotesapi.v1alpha1.ManifestAppendixOption
-	(*RepoId)(nil),                      // 2: dolt.services.remotesapi.v1alpha1.RepoId
-	(*HasChunksRequest)(nil),            // 3: dolt.services.remotesapi.v1alpha1.HasChunksRequest
-	(*HasChunksResponse)(nil),           // 4: dolt.services.remotesapi.v1alpha1.HasChunksResponse
-	(*HttpGetChunk)(nil),                // 5: dolt.services.remotesapi.v1alpha1.HttpGetChunk
-	(*RangeChunk)(nil),                  // 6: dolt.services.remotesapi.v1alpha1.RangeChunk
-	(*HttpGetRange)(nil),                // 7: dolt.services.remotesapi.v1alpha1.HttpGetRange
-	(*DownloadLoc)(nil),                 // 8: dolt.services.remotesapi.v1alpha1.DownloadLoc
-	(*HttpPostTableFile)(nil),           // 9: dolt.services.remotesapi.v1alpha1.HttpPostTableFile
-	(*UploadLoc)(nil),                   // 10: dolt.services.remotesapi.v1alpha1.UploadLoc
-	(*GetDownloadLocsRequest)(nil),      // 11: dolt.services.remotesapi.v1alpha1.GetDownloadLocsRequest
-	(*GetDownloadLocsResponse)(nil),     // 12: dolt.services.remotesapi.v1alpha1.GetDownloadLocsResponse
-	(*TableFileDetails)(nil),            // 13: dolt.services.remotesapi.v1alpha1.TableFileDetails
-	(*GetUploadLocsRequest)(nil),        // 14: dolt.services.remotesapi.v1alpha1.GetUploadLocsRequest
-	(*GetUploadLocsResponse)(nil),       // 15: dolt.services.remotesapi.v1alpha1.GetUploadLocsResponse
-	(*RebaseRequest)(nil),               // 16: dolt.services.remotesapi.v1alpha1.RebaseRequest
-	(*RebaseResponse)(nil),              // 17: dolt.services.remotesapi.v1alpha1.RebaseResponse
-	(*RootRequest)(nil),                 // 18: dolt.services.remotesapi.v1alpha1.RootRequest
-	(*RootResponse)(nil),                // 19: dolt.services.remotesapi.v1alpha1.RootResponse
-	(*ChunkTableInfo)(nil),              // 20: dolt.services.remotesapi.v1alpha1.ChunkTableInfo
-	(*CommitRequest)(nil),               // 21: dolt.services.remotesapi.v1alpha1.CommitRequest
-	(*CommitResponse)(nil),              // 22: dolt.services.remotesapi.v1alpha1.CommitResponse
-	(*GetRepoMetadataRequest)(nil),      // 23: dolt.services.remotesapi.v1alpha1.GetRepoMetadataRequest
-	(*GetRepoMetadataResponse)(nil),     // 24: dolt.services.remotesapi.v1alpha1.GetRepoMetadataResponse
-	(*ClientRepoFormat)(nil),            // 25: dolt.services.remotesapi.v1alpha1.ClientRepoFormat
-	(*ListTableFilesRequest)(nil),       // 26: dolt.services.remotesapi.v1alpha1.ListTableFilesRequest
-	(*TableFileInfo)(nil),               // 27: dolt.services.remotesapi.v1alpha1.TableFileInfo
-	(*RefreshTableFileUrlRequest)(nil),  // 28: dolt.services.remotesapi.v1alpha1.RefreshTableFileUrlRequest
-	(*RefreshTableFileUrlResponse)(nil), // 29: dolt.services.remotesapi.v1alpha1.RefreshTableFileUrlResponse
-	(*ListTableFilesResponse)(nil),      // 30: dolt.services.remotesapi.v1alpha1.ListTableFilesResponse
-	(*AddTableFilesRequest)(nil),        // 31: dolt.services.remotesapi.v1alpha1.AddTableFilesRequest
-	(*AddTableFilesResponse)(nil),       // 32: dolt.services.remotesapi.v1alpha1.AddTableFilesResponse
-	(*timestamppb.Timestamp)(nil),       // 33: google.protobuf.Timestamp
+	(PushConcurrencyControl)(0),                          // 0: dolt.services.remotesapi.v1alpha1.PushConcurrencyControl
+	(Feature)(0),                                         // 1: dolt.services.remotesapi.v1alpha1.Feature
+	(ManifestAppendixOption)(0),                          // 2: dolt.services.remotesapi.v1alpha1.ManifestAppendixOption
+	(*RepoId)(nil),                                       // 3: dolt.services.remotesapi.v1alpha1.RepoId
+	(*HasChunksRequest)(nil),                             // 4: dolt.services.remotesapi.v1alpha1.HasChunksRequest
+	(*HasChunksResponse)(nil),                            // 5: dolt.services.remotesapi.v1alpha1.HasChunksResponse
+	(*HttpGetChunk)(nil),                                 // 6: dolt.services.remotesapi.v1alpha1.HttpGetChunk
+	(*RangeChunk)(nil),                                   // 7: dolt.services.remotesapi.v1alpha1.RangeChunk
+	(*HttpGetRange)(nil),                                 // 8: dolt.services.remotesapi.v1alpha1.HttpGetRange
+	(*DownloadLoc)(nil),                                  // 9: dolt.services.remotesapi.v1alpha1.DownloadLoc
+	(*HttpPostTableFile)(nil),                            // 10: dolt.services.remotesapi.v1alpha1.HttpPostTableFile
+	(*UploadLoc)(nil),                                    // 11: dolt.services.remotesapi.v1alpha1.UploadLoc
+	(*GetDownloadLocsRequest)(nil),                       // 12: dolt.services.remotesapi.v1alpha1.GetDownloadLocsRequest
+	(*GetDownloadLocsResponse)(nil),                      // 13: dolt.services.remotesapi.v1alpha1.GetDownloadLocsResponse
+	(*StreamChunkLocationsRequest)(nil),                  // 14: dolt.services.remotesapi.v1alpha1.StreamChunkLocationsRequest
+	(*StreamChunkLocationsResponse)(nil),                 // 15: dolt.services.remotesapi.v1alpha1.StreamChunkLocationsResponse
+	(*TableFileDetails)(nil),                             // 16: dolt.services.remotesapi.v1alpha1.TableFileDetails
+	(*GetUploadLocsRequest)(nil),                         // 17: dolt.services.remotesapi.v1alpha1.GetUploadLocsRequest
+	(*GetUploadLocsResponse)(nil),                        // 18: dolt.services.remotesapi.v1alpha1.GetUploadLocsResponse
+	(*RebaseRequest)(nil),                                // 19: dolt.services.remotesapi.v1alpha1.RebaseRequest
+	(*RebaseResponse)(nil),                               // 20: dolt.services.remotesapi.v1alpha1.RebaseResponse
+	(*RootRequest)(nil),                                  // 21: dolt.services.remotesapi.v1alpha1.RootRequest
+	(*RootResponse)(nil),                                 // 22: dolt.services.remotesapi.v1alpha1.RootResponse
+	(*ChunkTableInfo)(nil),                               // 23: dolt.services.remotesapi.v1alpha1.ChunkTableInfo
+	(*CommitRequest)(nil),                                // 24: dolt.services.remotesapi.v1alpha1.CommitRequest
+	(*CommitResponse)(nil),                               // 25: dolt.services.remotesapi.v1alpha1.CommitResponse
+	(*GetRepoMetadataRequest)(nil),                       // 26: dolt.services.remotesapi.v1alpha1.GetRepoMetadataRequest
+	(*GetRepoMetadataResponse)(nil),                      // 27: dolt.services.remotesapi.v1alpha1.GetRepoMetadataResponse
+	(*ClientRepoFormat)(nil),                             // 28: dolt.services.remotesapi.v1alpha1.ClientRepoFormat
+	(*ListTableFilesRequest)(nil),                        // 29: dolt.services.remotesapi.v1alpha1.ListTableFilesRequest
+	(*TableFileInfo)(nil),                                // 30: dolt.services.remotesapi.v1alpha1.TableFileInfo
+	(*RefreshTableFileUrlRequest)(nil),                   // 31: dolt.services.remotesapi.v1alpha1.RefreshTableFileUrlRequest
+	(*RefreshTableFileUrlResponse)(nil),                  // 32: dolt.services.remotesapi.v1alpha1.RefreshTableFileUrlResponse
+	(*ListTableFilesResponse)(nil),                       // 33: dolt.services.remotesapi.v1alpha1.ListTableFilesResponse
+	(*AddTableFilesRequest)(nil),                         // 34: dolt.services.remotesapi.v1alpha1.AddTableFilesRequest
+	(*AddTableFilesResponse)(nil),                        // 35: dolt.services.remotesapi.v1alpha1.AddTableFilesResponse
+	(*StreamChunkLocationsResponse_TableFileRecord)(nil), // 36: dolt.services.remotesapi.v1alpha1.StreamChunkLocationsResponse.TableFileRecord
+	(*StreamChunkLocationsResponse_ChunkLocation)(nil),   // 37: dolt.services.remotesapi.v1alpha1.StreamChunkLocationsResponse.ChunkLocation
+	(*timestamppb.Timestamp)(nil),                        // 38: google.protobuf.Timestamp
 }
 var file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_depIdxs = []int32{
-	2,  // 0: dolt.services.remotesapi.v1alpha1.HasChunksRequest.repo_id:type_name -> dolt.services.remotesapi.v1alpha1.RepoId
-	6,  // 1: dolt.services.remotesapi.v1alpha1.HttpGetRange.ranges:type_name -> dolt.services.remotesapi.v1alpha1.RangeChunk
-	5,  // 2: dolt.services.remotesapi.v1alpha1.DownloadLoc.http_get:type_name -> dolt.services.remotesapi.v1alpha1.HttpGetChunk
-	7,  // 3: dolt.services.remotesapi.v1alpha1.DownloadLoc.http_get_range:type_name -> dolt.services.remotesapi.v1alpha1.HttpGetRange
-	33, // 4: dolt.services.remotesapi.v1alpha1.DownloadLoc.refresh_after:type_name -> google.protobuf.Timestamp
-	28, // 5: dolt.services.remotesapi.v1alpha1.DownloadLoc.refresh_request:type_name -> dolt.services.remotesapi.v1alpha1.RefreshTableFileUrlRequest
-	9,  // 6: dolt.services.remotesapi.v1alpha1.UploadLoc.http_post:type_name -> dolt.services.remotesapi.v1alpha1.HttpPostTableFile
-	2,  // 7: dolt.services.remotesapi.v1alpha1.GetDownloadLocsRequest.repo_id:type_name -> dolt.services.remotesapi.v1alpha1.RepoId
-	8,  // 8: dolt.services.remotesapi.v1alpha1.GetDownloadLocsResponse.locs:type_name -> dolt.services.remotesapi.v1alpha1.DownloadLoc
-	2,  // 9: dolt.services.remotesapi.v1alpha1.GetUploadLocsRequest.repo_id:type_name -> dolt.services.remotesapi.v1alpha1.RepoId
-	13, // 10: dolt.services.remotesapi.v1alpha1.GetUploadLocsRequest.table_file_details:type_name -> dolt.services.remotesapi.v1alpha1.TableFileDetails
-	10, // 11: dolt.services.remotesapi.v1alpha1.GetUploadLocsResponse.locs:type_name -> dolt.services.remotesapi.v1alpha1.UploadLoc
-	2,  // 12: dolt.services.remotesapi.v1alpha1.RebaseRequest.repo_id:type_name -> dolt.services.remotesapi.v1alpha1.RepoId
-	2,  // 13: dolt.services.remotesapi.v1alpha1.RootRequest.repo_id:type_name -> dolt.services.remotesapi.v1alpha1.RepoId
-	2,  // 14: dolt.services.remotesapi.v1alpha1.CommitRequest.repo_id:type_name -> dolt.services.remotesapi.v1alpha1.RepoId
-	20, // 15: dolt.services.remotesapi.v1alpha1.CommitRequest.chunk_table_info:type_name -> dolt.services.remotesapi.v1alpha1.ChunkTableInfo
-	25, // 16: dolt.services.remotesapi.v1alpha1.CommitRequest.client_repo_format:type_name -> dolt.services.remotesapi.v1alpha1.ClientRepoFormat
-	2,  // 17: dolt.services.remotesapi.v1alpha1.GetRepoMetadataRequest.repo_id:type_name -> dolt.services.remotesapi.v1alpha1.RepoId
-	25, // 18: dolt.services.remotesapi.v1alpha1.GetRepoMetadataRequest.client_repo_format:type_name -> dolt.services.remotesapi.v1alpha1.ClientRepoFormat
-	0,  // 19: dolt.services.remotesapi.v1alpha1.GetRepoMetadataResponse.push_concurrency_control:type_name -> dolt.services.remotesapi.v1alpha1.PushConcurrencyControl
-	2,  // 20: dolt.services.remotesapi.v1alpha1.ListTableFilesRequest.repo_id:type_name -> dolt.services.remotesapi.v1alpha1.RepoId
-	33, // 21: dolt.services.remotesapi.v1alpha1.TableFileInfo.refresh_after:type_name -> google.protobuf.Timestamp
-	28, // 22: dolt.services.remotesapi.v1alpha1.TableFileInfo.refresh_request:type_name -> dolt.services.remotesapi.v1alpha1.RefreshTableFileUrlRequest
-	2,  // 23: dolt.services.remotesapi.v1alpha1.RefreshTableFileUrlRequest.repo_id:type_name -> dolt.services.remotesapi.v1alpha1.RepoId
-	33, // 24: dolt.services.remotesapi.v1alpha1.RefreshTableFileUrlResponse.refresh_after:type_name -> google.protobuf.Timestamp
-	27, // 25: dolt.services.remotesapi.v1alpha1.ListTableFilesResponse.table_file_info:type_name -> dolt.services.remotesapi.v1alpha1.TableFileInfo
-	27, // 26: dolt.services.remotesapi.v1alpha1.ListTableFilesResponse.appendix_table_file_info:type_name -> dolt.services.remotesapi.v1alpha1.TableFileInfo
-	2,  // 27: dolt.services.remotesapi.v1alpha1.AddTableFilesRequest.repo_id:type_name -> dolt.services.remotesapi.v1alpha1.RepoId
-	25, // 28: dolt.services.remotesapi.v1alpha1.AddTableFilesRequest.client_repo_format:type_name -> dolt.services.remotesapi.v1alpha1.ClientRepoFormat
-	20, // 29: dolt.services.remotesapi.v1alpha1.AddTableFilesRequest.chunk_table_info:type_name -> dolt.services.remotesapi.v1alpha1.ChunkTableInfo
-	1,  // 30: dolt.services.remotesapi.v1alpha1.AddTableFilesRequest.appendix_option:type_name -> dolt.services.remotesapi.v1alpha1.ManifestAppendixOption
-	23, // 31: dolt.services.remotesapi.v1alpha1.ChunkStoreService.GetRepoMetadata:input_type -> dolt.services.remotesapi.v1alpha1.GetRepoMetadataRequest
-	3,  // 32: dolt.services.remotesapi.v1alpha1.ChunkStoreService.HasChunks:input_type -> dolt.services.remotesapi.v1alpha1.HasChunksRequest
-	11, // 33: dolt.services.remotesapi.v1alpha1.ChunkStoreService.GetDownloadLocations:input_type -> dolt.services.remotesapi.v1alpha1.GetDownloadLocsRequest
-	11, // 34: dolt.services.remotesapi.v1alpha1.ChunkStoreService.StreamDownloadLocations:input_type -> dolt.services.remotesapi.v1alpha1.GetDownloadLocsRequest
-	14, // 35: dolt.services.remotesapi.v1alpha1.ChunkStoreService.GetUploadLocations:input_type -> dolt.services.remotesapi.v1alpha1.GetUploadLocsRequest
-	16, // 36: dolt.services.remotesapi.v1alpha1.ChunkStoreService.Rebase:input_type -> dolt.services.remotesapi.v1alpha1.RebaseRequest
-	18, // 37: dolt.services.remotesapi.v1alpha1.ChunkStoreService.Root:input_type -> dolt.services.remotesapi.v1alpha1.RootRequest
-	21, // 38: dolt.services.remotesapi.v1alpha1.ChunkStoreService.Commit:input_type -> dolt.services.remotesapi.v1alpha1.CommitRequest
-	26, // 39: dolt.services.remotesapi.v1alpha1.ChunkStoreService.ListTableFiles:input_type -> dolt.services.remotesapi.v1alpha1.ListTableFilesRequest
-	28, // 40: dolt.services.remotesapi.v1alpha1.ChunkStoreService.RefreshTableFileUrl:input_type -> dolt.services.remotesapi.v1alpha1.RefreshTableFileUrlRequest
-	31, // 41: dolt.services.remotesapi.v1alpha1.ChunkStoreService.AddTableFiles:input_type -> dolt.services.remotesapi.v1alpha1.AddTableFilesRequest
-	24, // 42: dolt.services.remotesapi.v1alpha1.ChunkStoreService.GetRepoMetadata:output_type -> dolt.services.remotesapi.v1alpha1.GetRepoMetadataResponse
-	4,  // 43: dolt.services.remotesapi.v1alpha1.ChunkStoreService.HasChunks:output_type -> dolt.services.remotesapi.v1alpha1.HasChunksResponse
-	12, // 44: dolt.services.remotesapi.v1alpha1.ChunkStoreService.GetDownloadLocations:output_type -> dolt.services.remotesapi.v1alpha1.GetDownloadLocsResponse
-	12, // 45: dolt.services.remotesapi.v1alpha1.ChunkStoreService.StreamDownloadLocations:output_type -> dolt.services.remotesapi.v1alpha1.GetDownloadLocsResponse
-	15, // 46: dolt.services.remotesapi.v1alpha1.ChunkStoreService.GetUploadLocations:output_type -> dolt.services.remotesapi.v1alpha1.GetUploadLocsResponse
-	17, // 47: dolt.services.remotesapi.v1alpha1.ChunkStoreService.Rebase:output_type -> dolt.services.remotesapi.v1alpha1.RebaseResponse
-	19, // 48: dolt.services.remotesapi.v1alpha1.ChunkStoreService.Root:output_type -> dolt.services.remotesapi.v1alpha1.RootResponse
-	22, // 49: dolt.services.remotesapi.v1alpha1.ChunkStoreService.Commit:output_type -> dolt.services.remotesapi.v1alpha1.CommitResponse
-	30, // 50: dolt.services.remotesapi.v1alpha1.ChunkStoreService.ListTableFiles:output_type -> dolt.services.remotesapi.v1alpha1.ListTableFilesResponse
-	29, // 51: dolt.services.remotesapi.v1alpha1.ChunkStoreService.RefreshTableFileUrl:output_type -> dolt.services.remotesapi.v1alpha1.RefreshTableFileUrlResponse
-	32, // 52: dolt.services.remotesapi.v1alpha1.ChunkStoreService.AddTableFiles:output_type -> dolt.services.remotesapi.v1alpha1.AddTableFilesResponse
-	42, // [42:53] is the sub-list for method output_type
-	31, // [31:42] is the sub-list for method input_type
-	31, // [31:31] is the sub-list for extension type_name
-	31, // [31:31] is the sub-list for extension extendee
-	0,  // [0:31] is the sub-list for field type_name
+	3,  // 0: dolt.services.remotesapi.v1alpha1.HasChunksRequest.repo_id:type_name -> dolt.services.remotesapi.v1alpha1.RepoId
+	7,  // 1: dolt.services.remotesapi.v1alpha1.HttpGetRange.ranges:type_name -> dolt.services.remotesapi.v1alpha1.RangeChunk
+	6,  // 2: dolt.services.remotesapi.v1alpha1.DownloadLoc.http_get:type_name -> dolt.services.remotesapi.v1alpha1.HttpGetChunk
+	8,  // 3: dolt.services.remotesapi.v1alpha1.DownloadLoc.http_get_range:type_name -> dolt.services.remotesapi.v1alpha1.HttpGetRange
+	38, // 4: dolt.services.remotesapi.v1alpha1.DownloadLoc.refresh_after:type_name -> google.protobuf.Timestamp
+	31, // 5: dolt.services.remotesapi.v1alpha1.DownloadLoc.refresh_request:type_name -> dolt.services.remotesapi.v1alpha1.RefreshTableFileUrlRequest
+	10, // 6: dolt.services.remotesapi.v1alpha1.UploadLoc.http_post:type_name -> dolt.services.remotesapi.v1alpha1.HttpPostTableFile
+	3,  // 7: dolt.services.remotesapi.v1alpha1.GetDownloadLocsRequest.repo_id:type_name -> dolt.services.remotesapi.v1alpha1.RepoId
+	9,  // 8: dolt.services.remotesapi.v1alpha1.GetDownloadLocsResponse.locs:type_name -> dolt.services.remotesapi.v1alpha1.DownloadLoc
+	3,  // 9: dolt.services.remotesapi.v1alpha1.StreamChunkLocationsRequest.repo_id:type_name -> dolt.services.remotesapi.v1alpha1.RepoId
+	36, // 10: dolt.services.remotesapi.v1alpha1.StreamChunkLocationsResponse.table_files:type_name -> dolt.services.remotesapi.v1alpha1.StreamChunkLocationsResponse.TableFileRecord
+	37, // 11: dolt.services.remotesapi.v1alpha1.StreamChunkLocationsResponse.locations:type_name -> dolt.services.remotesapi.v1alpha1.StreamChunkLocationsResponse.ChunkLocation
+	3,  // 12: dolt.services.remotesapi.v1alpha1.GetUploadLocsRequest.repo_id:type_name -> dolt.services.remotesapi.v1alpha1.RepoId
+	16, // 13: dolt.services.remotesapi.v1alpha1.GetUploadLocsRequest.table_file_details:type_name -> dolt.services.remotesapi.v1alpha1.TableFileDetails
+	11, // 14: dolt.services.remotesapi.v1alpha1.GetUploadLocsResponse.locs:type_name -> dolt.services.remotesapi.v1alpha1.UploadLoc
+	3,  // 15: dolt.services.remotesapi.v1alpha1.RebaseRequest.repo_id:type_name -> dolt.services.remotesapi.v1alpha1.RepoId
+	3,  // 16: dolt.services.remotesapi.v1alpha1.RootRequest.repo_id:type_name -> dolt.services.remotesapi.v1alpha1.RepoId
+	3,  // 17: dolt.services.remotesapi.v1alpha1.CommitRequest.repo_id:type_name -> dolt.services.remotesapi.v1alpha1.RepoId
+	23, // 18: dolt.services.remotesapi.v1alpha1.CommitRequest.chunk_table_info:type_name -> dolt.services.remotesapi.v1alpha1.ChunkTableInfo
+	28, // 19: dolt.services.remotesapi.v1alpha1.CommitRequest.client_repo_format:type_name -> dolt.services.remotesapi.v1alpha1.ClientRepoFormat
+	3,  // 20: dolt.services.remotesapi.v1alpha1.GetRepoMetadataRequest.repo_id:type_name -> dolt.services.remotesapi.v1alpha1.RepoId
+	28, // 21: dolt.services.remotesapi.v1alpha1.GetRepoMetadataRequest.client_repo_format:type_name -> dolt.services.remotesapi.v1alpha1.ClientRepoFormat
+	0,  // 22: dolt.services.remotesapi.v1alpha1.GetRepoMetadataResponse.push_concurrency_control:type_name -> dolt.services.remotesapi.v1alpha1.PushConcurrencyControl
+	1,  // 23: dolt.services.remotesapi.v1alpha1.GetRepoMetadataResponse.features:type_name -> dolt.services.remotesapi.v1alpha1.Feature
+	3,  // 24: dolt.services.remotesapi.v1alpha1.ListTableFilesRequest.repo_id:type_name -> dolt.services.remotesapi.v1alpha1.RepoId
+	38, // 25: dolt.services.remotesapi.v1alpha1.TableFileInfo.refresh_after:type_name -> google.protobuf.Timestamp
+	31, // 26: dolt.services.remotesapi.v1alpha1.TableFileInfo.refresh_request:type_name -> dolt.services.remotesapi.v1alpha1.RefreshTableFileUrlRequest
+	3,  // 27: dolt.services.remotesapi.v1alpha1.RefreshTableFileUrlRequest.repo_id:type_name -> dolt.services.remotesapi.v1alpha1.RepoId
+	38, // 28: dolt.services.remotesapi.v1alpha1.RefreshTableFileUrlResponse.refresh_after:type_name -> google.protobuf.Timestamp
+	30, // 29: dolt.services.remotesapi.v1alpha1.ListTableFilesResponse.table_file_info:type_name -> dolt.services.remotesapi.v1alpha1.TableFileInfo
+	30, // 30: dolt.services.remotesapi.v1alpha1.ListTableFilesResponse.appendix_table_file_info:type_name -> dolt.services.remotesapi.v1alpha1.TableFileInfo
+	3,  // 31: dolt.services.remotesapi.v1alpha1.AddTableFilesRequest.repo_id:type_name -> dolt.services.remotesapi.v1alpha1.RepoId
+	28, // 32: dolt.services.remotesapi.v1alpha1.AddTableFilesRequest.client_repo_format:type_name -> dolt.services.remotesapi.v1alpha1.ClientRepoFormat
+	23, // 33: dolt.services.remotesapi.v1alpha1.AddTableFilesRequest.chunk_table_info:type_name -> dolt.services.remotesapi.v1alpha1.ChunkTableInfo
+	2,  // 34: dolt.services.remotesapi.v1alpha1.AddTableFilesRequest.appendix_option:type_name -> dolt.services.remotesapi.v1alpha1.ManifestAppendixOption
+	38, // 35: dolt.services.remotesapi.v1alpha1.StreamChunkLocationsResponse.TableFileRecord.refresh_after:type_name -> google.protobuf.Timestamp
+	26, // 36: dolt.services.remotesapi.v1alpha1.ChunkStoreService.GetRepoMetadata:input_type -> dolt.services.remotesapi.v1alpha1.GetRepoMetadataRequest
+	4,  // 37: dolt.services.remotesapi.v1alpha1.ChunkStoreService.HasChunks:input_type -> dolt.services.remotesapi.v1alpha1.HasChunksRequest
+	12, // 38: dolt.services.remotesapi.v1alpha1.ChunkStoreService.GetDownloadLocations:input_type -> dolt.services.remotesapi.v1alpha1.GetDownloadLocsRequest
+	12, // 39: dolt.services.remotesapi.v1alpha1.ChunkStoreService.StreamDownloadLocations:input_type -> dolt.services.remotesapi.v1alpha1.GetDownloadLocsRequest
+	14, // 40: dolt.services.remotesapi.v1alpha1.ChunkStoreService.StreamChunkLocations:input_type -> dolt.services.remotesapi.v1alpha1.StreamChunkLocationsRequest
+	17, // 41: dolt.services.remotesapi.v1alpha1.ChunkStoreService.GetUploadLocations:input_type -> dolt.services.remotesapi.v1alpha1.GetUploadLocsRequest
+	19, // 42: dolt.services.remotesapi.v1alpha1.ChunkStoreService.Rebase:input_type -> dolt.services.remotesapi.v1alpha1.RebaseRequest
+	21, // 43: dolt.services.remotesapi.v1alpha1.ChunkStoreService.Root:input_type -> dolt.services.remotesapi.v1alpha1.RootRequest
+	24, // 44: dolt.services.remotesapi.v1alpha1.ChunkStoreService.Commit:input_type -> dolt.services.remotesapi.v1alpha1.CommitRequest
+	29, // 45: dolt.services.remotesapi.v1alpha1.ChunkStoreService.ListTableFiles:input_type -> dolt.services.remotesapi.v1alpha1.ListTableFilesRequest
+	31, // 46: dolt.services.remotesapi.v1alpha1.ChunkStoreService.RefreshTableFileUrl:input_type -> dolt.services.remotesapi.v1alpha1.RefreshTableFileUrlRequest
+	34, // 47: dolt.services.remotesapi.v1alpha1.ChunkStoreService.AddTableFiles:input_type -> dolt.services.remotesapi.v1alpha1.AddTableFilesRequest
+	27, // 48: dolt.services.remotesapi.v1alpha1.ChunkStoreService.GetRepoMetadata:output_type -> dolt.services.remotesapi.v1alpha1.GetRepoMetadataResponse
+	5,  // 49: dolt.services.remotesapi.v1alpha1.ChunkStoreService.HasChunks:output_type -> dolt.services.remotesapi.v1alpha1.HasChunksResponse
+	13, // 50: dolt.services.remotesapi.v1alpha1.ChunkStoreService.GetDownloadLocations:output_type -> dolt.services.remotesapi.v1alpha1.GetDownloadLocsResponse
+	13, // 51: dolt.services.remotesapi.v1alpha1.ChunkStoreService.StreamDownloadLocations:output_type -> dolt.services.remotesapi.v1alpha1.GetDownloadLocsResponse
+	15, // 52: dolt.services.remotesapi.v1alpha1.ChunkStoreService.StreamChunkLocations:output_type -> dolt.services.remotesapi.v1alpha1.StreamChunkLocationsResponse
+	18, // 53: dolt.services.remotesapi.v1alpha1.ChunkStoreService.GetUploadLocations:output_type -> dolt.services.remotesapi.v1alpha1.GetUploadLocsResponse
+	20, // 54: dolt.services.remotesapi.v1alpha1.ChunkStoreService.Rebase:output_type -> dolt.services.remotesapi.v1alpha1.RebaseResponse
+	22, // 55: dolt.services.remotesapi.v1alpha1.ChunkStoreService.Root:output_type -> dolt.services.remotesapi.v1alpha1.RootResponse
+	25, // 56: dolt.services.remotesapi.v1alpha1.ChunkStoreService.Commit:output_type -> dolt.services.remotesapi.v1alpha1.CommitResponse
+	33, // 57: dolt.services.remotesapi.v1alpha1.ChunkStoreService.ListTableFiles:output_type -> dolt.services.remotesapi.v1alpha1.ListTableFilesResponse
+	32, // 58: dolt.services.remotesapi.v1alpha1.ChunkStoreService.RefreshTableFileUrl:output_type -> dolt.services.remotesapi.v1alpha1.RefreshTableFileUrlResponse
+	35, // 59: dolt.services.remotesapi.v1alpha1.ChunkStoreService.AddTableFiles:output_type -> dolt.services.remotesapi.v1alpha1.AddTableFilesResponse
+	48, // [48:60] is the sub-list for method output_type
+	36, // [36:48] is the sub-list for method input_type
+	36, // [36:36] is the sub-list for extension type_name
+	36, // [36:36] is the sub-list for extension extendee
+	0,  // [0:36] is the sub-list for field type_name
 }
 
 func init() { file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_init() }
@@ -2478,8 +2932,8 @@ func file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDesc), len(file_dolt_services_remotesapi_v1alpha1_chunkstore_proto_rawDesc)),
-			NumEnums:      2,
-			NumMessages:   31,
+			NumEnums:      3,
+			NumMessages:   35,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
@@ -2514,6 +2968,11 @@ type ChunkStoreServiceClient interface {
 	// support large and incrementally available payloads. Results are generated
 	// as requests come in.
 	StreamDownloadLocations(ctx context.Context, opts ...grpc.CallOption) (ChunkStoreService_StreamDownloadLocationsClient, error)
+	// Get the download locations for a list of chunk hashes. Streaming
+	// variant that deduplicates table-file metadata across the stream.
+	// Preferred over StreamDownloadLocations when the server advertises
+	// FEATURE_STREAM_CHUNK_LOCATIONS in GetRepoMetadataResponse.features.
+	StreamChunkLocations(ctx context.Context, opts ...grpc.CallOption) (ChunkStoreService_StreamChunkLocationsClient, error)
 	// Get upload locations for a list of table file hashes.
 	// NOTE: We upload full table files but download individual chunks.
 	GetUploadLocations(ctx context.Context, in *GetUploadLocsRequest, opts ...grpc.CallOption) (*GetUploadLocsResponse, error)
@@ -2585,6 +3044,37 @@ func (x *chunkStoreServiceStreamDownloadLocationsClient) Send(m *GetDownloadLocs
 
 func (x *chunkStoreServiceStreamDownloadLocationsClient) Recv() (*GetDownloadLocsResponse, error) {
 	m := new(GetDownloadLocsResponse)
+	if err := x.ClientStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func (c *chunkStoreServiceClient) StreamChunkLocations(ctx context.Context, opts ...grpc.CallOption) (ChunkStoreService_StreamChunkLocationsClient, error) {
+	stream, err := c.cc.NewStream(ctx, &_ChunkStoreService_serviceDesc.Streams[1], "/dolt.services.remotesapi.v1alpha1.ChunkStoreService/StreamChunkLocations", opts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &chunkStoreServiceStreamChunkLocationsClient{stream}
+	return x, nil
+}
+
+type ChunkStoreService_StreamChunkLocationsClient interface {
+	Send(*StreamChunkLocationsRequest) error
+	Recv() (*StreamChunkLocationsResponse, error)
+	grpc.ClientStream
+}
+
+type chunkStoreServiceStreamChunkLocationsClient struct {
+	grpc.ClientStream
+}
+
+func (x *chunkStoreServiceStreamChunkLocationsClient) Send(m *StreamChunkLocationsRequest) error {
+	return x.ClientStream.SendMsg(m)
+}
+
+func (x *chunkStoreServiceStreamChunkLocationsClient) Recv() (*StreamChunkLocationsResponse, error) {
+	m := new(StreamChunkLocationsResponse)
 	if err := x.ClientStream.RecvMsg(m); err != nil {
 		return nil, err
 	}
@@ -2665,6 +3155,11 @@ type ChunkStoreServiceServer interface {
 	// support large and incrementally available payloads. Results are generated
 	// as requests come in.
 	StreamDownloadLocations(ChunkStoreService_StreamDownloadLocationsServer) error
+	// Get the download locations for a list of chunk hashes. Streaming
+	// variant that deduplicates table-file metadata across the stream.
+	// Preferred over StreamDownloadLocations when the server advertises
+	// FEATURE_STREAM_CHUNK_LOCATIONS in GetRepoMetadataResponse.features.
+	StreamChunkLocations(ChunkStoreService_StreamChunkLocationsServer) error
 	// Get upload locations for a list of table file hashes.
 	// NOTE: We upload full table files but download individual chunks.
 	GetUploadLocations(context.Context, *GetUploadLocsRequest) (*GetUploadLocsResponse, error)
@@ -2691,6 +3186,9 @@ func (*UnimplementedChunkStoreServiceServer) GetDownloadLocations(context.Contex
 }
 func (*UnimplementedChunkStoreServiceServer) StreamDownloadLocations(ChunkStoreService_StreamDownloadLocationsServer) error {
 	return status.Errorf(codes.Unimplemented, "method StreamDownloadLocations not implemented")
+}
+func (*UnimplementedChunkStoreServiceServer) StreamChunkLocations(ChunkStoreService_StreamChunkLocationsServer) error {
+	return status.Errorf(codes.Unimplemented, "method StreamChunkLocations not implemented")
 }
 func (*UnimplementedChunkStoreServiceServer) GetUploadLocations(context.Context, *GetUploadLocsRequest) (*GetUploadLocsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetUploadLocations not implemented")
@@ -2792,6 +3290,32 @@ func (x *chunkStoreServiceStreamDownloadLocationsServer) Send(m *GetDownloadLocs
 
 func (x *chunkStoreServiceStreamDownloadLocationsServer) Recv() (*GetDownloadLocsRequest, error) {
 	m := new(GetDownloadLocsRequest)
+	if err := x.ServerStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func _ChunkStoreService_StreamChunkLocations_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(ChunkStoreServiceServer).StreamChunkLocations(&chunkStoreServiceStreamChunkLocationsServer{stream})
+}
+
+type ChunkStoreService_StreamChunkLocationsServer interface {
+	Send(*StreamChunkLocationsResponse) error
+	Recv() (*StreamChunkLocationsRequest, error)
+	grpc.ServerStream
+}
+
+type chunkStoreServiceStreamChunkLocationsServer struct {
+	grpc.ServerStream
+}
+
+func (x *chunkStoreServiceStreamChunkLocationsServer) Send(m *StreamChunkLocationsResponse) error {
+	return x.ServerStream.SendMsg(m)
+}
+
+func (x *chunkStoreServiceStreamChunkLocationsServer) Recv() (*StreamChunkLocationsRequest, error) {
+	m := new(StreamChunkLocationsRequest)
 	if err := x.ServerStream.RecvMsg(m); err != nil {
 		return nil, err
 	}
@@ -2973,6 +3497,12 @@ var _ChunkStoreService_serviceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "StreamDownloadLocations",
 			Handler:       _ChunkStoreService_StreamDownloadLocations_Handler,
+			ServerStreams: true,
+			ClientStreams: true,
+		},
+		{
+			StreamName:    "StreamChunkLocations",
+			Handler:       _ChunkStoreService_StreamChunkLocations_Handler,
 			ServerStreams: true,
 			ClientStreams: true,
 		},

--- a/go/libraries/doltcore/remotesrv/grpc.go
+++ b/go/libraries/doltcore/remotesrv/grpc.go
@@ -331,6 +331,150 @@ func (rs *RemoteChunkStore) StreamDownloadLocations(stream remotesapi.ChunkStore
 	}
 }
 
+func (rs *RemoteChunkStore) StreamChunkLocations(stream remotesapi.ChunkStoreService_StreamChunkLocationsServer) error {
+	ologger := getReqLogger(rs.lgr, "StreamChunkLocations")
+	numMessages := 0
+	numHashes := 0
+	numNewTableFiles := 0
+	numLocations := 0
+	numMissing := 0
+	defer func() {
+		ologger.WithFields(logrus.Fields{
+			"num_messages":        numMessages,
+			"num_requested":       numHashes,
+			"num_new_table_files": numNewTableFiles,
+			"num_locations":       numLocations,
+			"num_missing":         numMissing,
+		}).Trace("finished")
+	}()
+	logger := ologger
+
+	md, _ := metadata.FromIncomingContext(stream.Context())
+
+	var repoPath string
+	var cs RemoteSrvStore
+	var prefix string
+
+	// Stream-local table-file-path -> table_file_id map. Scoped to this
+	// handler invocation. Discarded on handler exit; a fresh handler
+	// after a client-side reliable reconnect starts from an empty map
+	// and re-introduces any id it reuses. The client relies on
+	// TableFileRecord overwrite semantics to make that transparent.
+	tfByPath := make(map[string]uint32)
+	var nextTFID uint32
+
+	for {
+		req, err := stream.Recv()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+
+		numMessages++
+
+		if err := ValidateStreamChunkLocationsRequest(req); err != nil {
+			return status.Error(codes.InvalidArgument, err.Error())
+		}
+
+		nextPath := getRepoPath(req)
+		if nextPath != repoPath {
+			repoPath = nextPath
+			logger = ologger.WithField(RepoPathField, repoPath)
+			cs, err = rs.getStore(stream.Context(), logger, repoPath)
+			if err != nil {
+				return err
+			}
+			prefix, err = rs.getRelativeStorePath(cs)
+			if err != nil {
+				logger.WithError(err).Error("error getting file store path for chunk store")
+				return err
+			}
+		}
+
+		// ParseByteSlices gives us both a HashSet to pass to
+		// GetChunkLocationsWithPaths and the position-in-request
+		// index lookup used for request_index / missing_indexes.
+		hashes, hashToIndex := remotestorage.ParseByteSlices(req.ChunkHashes)
+		numHashes += len(hashes)
+
+		// GetChunkLocationsWithPaths deletes found hashes from
+		// |hashes|; the remainder is exactly the set the server
+		// could not find.
+		locations, err := cs.GetChunkLocationsWithPaths(stream.Context(), hashes)
+		if err != nil {
+			logger.WithError(err).Error("error getting chunk locations for hashes")
+			return err
+		}
+
+		var tableFiles []*remotesapi.StreamChunkLocationsResponse_TableFileRecord
+		var chunkLocs []*remotesapi.StreamChunkLocationsResponse_ChunkLocation
+
+		for path, hashToRange := range locations {
+			if len(hashToRange) == 0 {
+				continue
+			}
+
+			id, seen := tfByPath[path]
+			if !seen {
+				id = nextTFID
+				nextTFID++
+				tfByPath[path] = id
+
+				u := rs.getDownloadUrl(md, prefix+"/"+path)
+				preurl := u.String()
+				u, err = rs.sealer.Seal(u)
+				if err != nil {
+					logger.WithError(err).Error("error sealing download url")
+					return err
+				}
+				logger.WithFields(logrus.Fields{
+					"url":           preurl,
+					"sealed_url":    u.String(),
+					"table_file_id": id,
+				}).Trace("introducing table file record")
+
+				tableFiles = append(tableFiles, &remotesapi.StreamChunkLocationsResponse_TableFileRecord{
+					TableFileId: id,
+					Url:         u.String(),
+					FileId:      path,
+				})
+				numNewTableFiles++
+			}
+
+			for h, r := range hashToRange {
+				chunkLocs = append(chunkLocs, &remotesapi.StreamChunkLocationsResponse_ChunkLocation{
+					TableFileId:      id,
+					RequestIndex:     uint32(hashToIndex[h]),
+					Offset:           r.Offset,
+					Length:           r.Length,
+					DictionaryOffset: r.DictOffset,
+					DictionaryLength: r.DictLength,
+				})
+				numLocations++
+			}
+		}
+
+		var missing []uint32
+		if len(hashes) > 0 {
+			missing = make([]uint32, 0, len(hashes))
+			for h := range hashes {
+				missing = append(missing, uint32(hashToIndex[h]))
+			}
+			numMissing += len(missing)
+		}
+
+		if err := stream.Send(&remotesapi.StreamChunkLocationsResponse{
+			TableFiles:     tableFiles,
+			Locations:      chunkLocs,
+			MissingIndexes: missing,
+		}); err != nil {
+			return err
+		}
+	}
+}
+
 func (rs *RemoteChunkStore) getHost(md metadata.MD) string {
 	host := rs.HttpHost
 	if strings.HasPrefix(rs.HttpHost, ":") {

--- a/go/libraries/doltcore/remotesrv/grpc.go
+++ b/go/libraries/doltcore/remotesrv/grpc.go
@@ -697,6 +697,9 @@ func (rs *RemoteChunkStore) GetRepoMetadata(ctx context.Context, req *remotesapi
 		NbsVersion:             req.ClientRepoFormat.NbsVersion,
 		StorageSize:            size,
 		PushConcurrencyControl: rs.concurrencyControl,
+		Features: []remotesapi.Feature{
+			remotesapi.Feature_FEATURE_STREAM_CHUNK_LOCATIONS,
+		},
 	}, nil
 }
 

--- a/go/libraries/doltcore/remotesrv/grpc.go
+++ b/go/libraries/doltcore/remotesrv/grpc.go
@@ -393,11 +393,21 @@ func (rs *RemoteChunkStore) StreamChunkLocations(stream remotesapi.ChunkStoreSer
 			}
 		}
 
-		// ParseByteSlices gives us both a HashSet to pass to
+		// req.ChunkHashes is a flat 20-byte-per-hash buffer (validated
+		// above). Walk it to build a HashSet to pass to
 		// GetChunkLocationsWithPaths and the position-in-request
 		// index lookup used for request_index / missing_indexes.
-		hashes, hashToIndex := remotestorage.ParseByteSlices(req.ChunkHashes)
-		numHashes += len(hashes)
+		// hash.New copies each 20-byte sub-slice into a Hash value,
+		// so no heap allocation per element.
+		n := len(req.ChunkHashes) / hash.ByteLen
+		hashes := make(hash.HashSet, n)
+		hashToIndex := make(map[hash.Hash]int, n)
+		for i := 0; i < n; i++ {
+			h := hash.New(req.ChunkHashes[i*hash.ByteLen : (i+1)*hash.ByteLen])
+			hashes[h] = struct{}{}
+			hashToIndex[h] = i
+		}
+		numHashes += n
 
 		// GetChunkLocationsWithPaths deletes found hashes from
 		// |hashes|; the remainder is exactly the set the server

--- a/go/libraries/doltcore/remotesrv/grpc.go
+++ b/go/libraries/doltcore/remotesrv/grpc.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/url"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -55,10 +56,18 @@ type RemoteChunkStore struct {
 	fs      filesys.Filesys
 	lgr     *logrus.Entry
 	sealer  Sealer
+
+	// Feature flags this server implements but will not advertise in
+	// GetRepoMetadataResponse.features. The RPCs themselves stay
+	// enabled — this only suppresses capability advertisement, so
+	// older-client fallback paths can be exercised in tests against
+	// a fully-capable server. See the plan's step 7 for rationale.
+	disabledFeatures []remotesapi.Feature
+
 	remotesapi.UnimplementedChunkStoreServiceServer
 }
 
-func NewHttpFSBackedChunkStore(lgr *logrus.Entry, httpHost string, csCache DBCache, fs filesys.Filesys, scheme string, concurrencyControl remotesapi.PushConcurrencyControl, sealer Sealer) *RemoteChunkStore {
+func NewHttpFSBackedChunkStore(lgr *logrus.Entry, httpHost string, csCache DBCache, fs filesys.Filesys, scheme string, concurrencyControl remotesapi.PushConcurrencyControl, sealer Sealer, disabledFeatures []remotesapi.Feature) *RemoteChunkStore {
 	if concurrencyControl == remotesapi.PushConcurrencyControl_PUSH_CONCURRENCY_CONTROL_UNSPECIFIED {
 		concurrencyControl = remotesapi.PushConcurrencyControl_PUSH_CONCURRENCY_CONTROL_IGNORE_WORKING_SET
 	}
@@ -72,7 +81,8 @@ func NewHttpFSBackedChunkStore(lgr *logrus.Entry, httpHost string, csCache DBCac
 		lgr: lgr.WithFields(logrus.Fields{
 			"service": "dolt.services.remotesapi.v1alpha1.ChunkStoreServiceServer",
 		}),
-		sealer: sealer,
+		sealer:           sealer,
+		disabledFeatures: disabledFeatures,
 	}
 }
 
@@ -707,10 +717,29 @@ func (rs *RemoteChunkStore) GetRepoMetadata(ctx context.Context, req *remotesapi
 		NbsVersion:             req.ClientRepoFormat.NbsVersion,
 		StorageSize:            size,
 		PushConcurrencyControl: rs.concurrencyControl,
-		Features: []remotesapi.Feature{
-			remotesapi.Feature_FEATURE_STREAM_CHUNK_LOCATIONS,
-		},
+		Features:               rs.advertisedFeatures(),
 	}, nil
+}
+
+// supportedFeatures is the canonical list of Feature flags this build
+// of remotesrv implements. Advertised set is this list minus
+// rs.disabledFeatures. Append new features here when they land; do not
+// hand-roll per-feature booleans.
+var supportedFeatures = []remotesapi.Feature{
+	remotesapi.Feature_FEATURE_STREAM_CHUNK_LOCATIONS,
+}
+
+func (rs *RemoteChunkStore) advertisedFeatures() []remotesapi.Feature {
+	if len(rs.disabledFeatures) == 0 {
+		return supportedFeatures
+	}
+	out := make([]remotesapi.Feature, 0, len(supportedFeatures))
+	for _, f := range supportedFeatures {
+		if !slices.Contains(rs.disabledFeatures, f) {
+			out = append(out, f)
+		}
+	}
+	return out
 }
 
 func (rs *RemoteChunkStore) ListTableFiles(ctx context.Context, req *remotesapi.ListTableFilesRequest) (*remotesapi.ListTableFilesResponse, error) {

--- a/go/libraries/doltcore/remotesrv/interceptors.go
+++ b/go/libraries/doltcore/remotesrv/interceptors.go
@@ -49,6 +49,7 @@ var CLONE_ADMIN_RPC_METHODS = map[string]bool{
 	"/dolt.services.remotesapi.v1alpha1.ChunkStoreService/RefreshTableFileUrl":     true,
 	"/dolt.services.remotesapi.v1alpha1.ChunkStoreService/Root":                    true,
 	"/dolt.services.remotesapi.v1alpha1.ChunkStoreService/StreamDownloadLocations": true,
+	"/dolt.services.remotesapi.v1alpha1.ChunkStoreService/StreamChunkLocations":    true,
 }
 
 // AccessControl is an interface that provides authentication and authorization for the gRPC server.

--- a/go/libraries/doltcore/remotesrv/server.go
+++ b/go/libraries/doltcore/remotesrv/server.go
@@ -17,8 +17,10 @@ package remotesrv
 import (
 	"context"
 	"crypto/tls"
+	"log"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 
@@ -30,6 +32,16 @@ import (
 	remotesapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/remotesapi/v1alpha1"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 )
+
+// disabledFeaturesEnvVar is an undocumented internal test hook. If
+// set, its value is parsed as a comma-separated list of
+// remotesapi.Feature enum names; each resolved feature is appended to
+// ServerArgs.DisabledFeatures before the server starts. Used by
+// integration tests to force clients down legacy-RPC fallback paths
+// against a server that actually supports the new RPC. Unknown names
+// cause NewServer to log.Fatalln — loud failure on typos is the right
+// default for a test hook.
+const disabledFeaturesEnvVar = "DOLT_REMOTESAPI_DISABLED_FEATURES"
 
 // MaxGRPCMessageSize is the maximum gRPC message size used for chunk store
 // operations. This applies to both send and receive directions.
@@ -69,6 +81,15 @@ type ServerArgs struct {
 
 	ConcurrencyControl remotesapi.PushConcurrencyControl
 
+	// Feature flags this server implements but will not advertise in
+	// GetRepoMetadataResponse.features. Internal test hook — used by
+	// integration tests to force clients down the older-RPC fallback
+	// against a server that actually supports the new RPC. Go-level
+	// tests set this directly; process-level tests set it indirectly
+	// via the DOLT_REMOTESAPI_DISABLED_FEATURES env var, which
+	// NewServer appends to this field at startup.
+	DisabledFeatures []remotesapi.Feature
+
 	HttpInterceptor func(http.Handler) http.Handler
 
 	// If supplied, the listener(s) returned from Listeners() will be TLS
@@ -78,6 +99,20 @@ type ServerArgs struct {
 }
 
 func NewServer(args ServerArgs) (*Server, error) {
+	if v := os.Getenv(disabledFeaturesEnvVar); v != "" {
+		for _, name := range strings.Split(v, ",") {
+			name = strings.TrimSpace(name)
+			if name == "" {
+				continue
+			}
+			id, ok := remotesapi.Feature_value[name]
+			if !ok {
+				log.Fatalln(disabledFeaturesEnvVar + ": unknown feature name: " + name)
+			}
+			args.DisabledFeatures = append(args.DisabledFeatures, remotesapi.Feature(id))
+		}
+	}
+
 	if args.Logger == nil {
 		args.Logger = logrus.NewEntry(logrus.StandardLogger())
 	}
@@ -99,7 +134,7 @@ func NewServer(args ServerArgs) (*Server, error) {
 	s.wg.Add(2)
 	s.grpcListenAddr = args.GrpcListenAddr
 	s.grpcSrv = grpc.NewServer(append([]grpc.ServerOption{grpc.MaxRecvMsgSize(MaxGRPCMessageSize)}, args.Options...)...)
-	var chnkSt remotesapi.ChunkStoreServiceServer = NewHttpFSBackedChunkStore(args.Logger, args.HttpHost, args.DBCache, args.FS, scheme, args.ConcurrencyControl, sealer)
+	var chnkSt remotesapi.ChunkStoreServiceServer = NewHttpFSBackedChunkStore(args.Logger, args.HttpHost, args.DBCache, args.FS, scheme, args.ConcurrencyControl, sealer, args.DisabledFeatures)
 
 	if args.ReadOnly {
 		chnkSt = ReadOnlyChunkStore{chnkSt}

--- a/go/libraries/doltcore/remotesrv/validate.go
+++ b/go/libraries/doltcore/remotesrv/validate.go
@@ -96,7 +96,10 @@ func ValidateStreamChunkLocationsRequest(req *remotesapi.StreamChunkLocationsReq
 	if err := validateRepoRequest(req); err != nil {
 		return err
 	}
-	return validateHashes("chunk_hashes", req.ChunkHashes)
+	if len(req.ChunkHashes)%hash.ByteLen != 0 {
+		return fmt.Errorf("expected chunk_hashes to be a multiple of %d bytes, was %d", hash.ByteLen, len(req.ChunkHashes))
+	}
+	return nil
 }
 
 func ValidateGetUploadLocsRequest(req *remotesapi.GetUploadLocsRequest) error {

--- a/go/libraries/doltcore/remotesrv/validate.go
+++ b/go/libraries/doltcore/remotesrv/validate.go
@@ -92,6 +92,13 @@ func ValidateGetDownloadLocsRequest(req *remotesapi.GetDownloadLocsRequest) erro
 	return validateHashes("chunk_hashes", req.ChunkHashes)
 }
 
+func ValidateStreamChunkLocationsRequest(req *remotesapi.StreamChunkLocationsRequest) error {
+	if err := validateRepoRequest(req); err != nil {
+		return err
+	}
+	return validateHashes("chunk_hashes", req.ChunkHashes)
+}
+
 func ValidateGetUploadLocsRequest(req *remotesapi.GetUploadLocsRequest) error {
 	if err := validateRepoRequest(req); err != nil {
 		return err

--- a/go/libraries/doltcore/remotestorage/chunk_fetcher.go
+++ b/go/libraries/doltcore/remotestorage/chunk_fetcher.go
@@ -17,6 +17,7 @@ package remotestorage
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"sync"
 	"sync/atomic"
@@ -31,6 +32,13 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/remotestorage/internal/reliable"
 	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/nbs"
+)
+
+// Local aliases for the deeply nested generated message types so the
+// rest of this file stays readable.
+type (
+	tableFileRec = remotesapi.StreamChunkLocationsResponse_TableFileRecord
+	chunkLoc     = remotesapi.StreamChunkLocationsResponse_ChunkLocation
 )
 
 // A remotestorage.ChunkFetcher is a pipelined chunk fetcher for fetching a
@@ -82,17 +90,35 @@ func NewChunkFetcher(ctx context.Context, dcs *DoltChunkStore) *ChunkFetcher {
 		stats:   StatsFactory(),
 	}
 
-	locsReqCh := make(chan *remotesapi.GetDownloadLocsRequest)
 	downloadLocCh := make(chan []*remotesapi.DownloadLoc)
 	locDoneCh := make(chan struct{})
 	fetchReqCh := make(chan fetchReq)
 
-	eg.Go(func() error {
-		return fetcherHashSetToGetDlLocsReqsThread(ctx, ret.toGetCh, ret.abortCh, locsReqCh, getLocsBatchSize, dcs.repoPath, dcs.getRepoId)
-	})
-	eg.Go(func() error {
-		return fetcherRPCDownloadLocsThread(ctx, locsReqCh, downloadLocCh, dcs.csClient, func(s string) { dcs.repoToken.Store(s) }, ret.resCh, dcs.host)
-	})
+	storeRepoToken := func(s string) { dcs.repoToken.Store(s) }
+
+	if hasFeature(dcs.metadata, remotesapi.Feature_FEATURE_STREAM_CHUNK_LOCATIONS) {
+		locsReqCh := make(chan *remotesapi.StreamChunkLocationsRequest)
+		eg.Go(func() error {
+			return fetcherHashSetToReqsThread(ctx, ret.toGetCh, ret.abortCh, locsReqCh, getLocsBatchSize, func(hashes [][]byte) *remotesapi.StreamChunkLocationsRequest {
+				id, token := dcs.getRepoId()
+				return &remotesapi.StreamChunkLocationsRequest{RepoId: id, RepoPath: dcs.repoPath, RepoToken: token, ChunkHashes: hashes}
+			})
+		})
+		eg.Go(func() error {
+			return fetcherRPCChunkLocationsThread(ctx, locsReqCh, downloadLocCh, dcs.csClient, storeRepoToken, ret.resCh, dcs.host, dcs.getRepoId, dcs.repoPath)
+		})
+	} else {
+		locsReqCh := make(chan *remotesapi.GetDownloadLocsRequest)
+		eg.Go(func() error {
+			return fetcherHashSetToReqsThread(ctx, ret.toGetCh, ret.abortCh, locsReqCh, getLocsBatchSize, func(hashes [][]byte) *remotesapi.GetDownloadLocsRequest {
+				id, token := dcs.getRepoId()
+				return &remotesapi.GetDownloadLocsRequest{RepoId: id, RepoPath: dcs.repoPath, RepoToken: token, ChunkHashes: hashes}
+			})
+		})
+		eg.Go(func() error {
+			return fetcherRPCDownloadLocsThread(ctx, locsReqCh, downloadLocCh, dcs.csClient, storeRepoToken, ret.resCh, dcs.host)
+		})
+	}
 	eg.Go(func() error {
 		return fetcherDownloadRangesThread(ctx, downloadLocCh, fetchReqCh, locDoneCh)
 	})
@@ -158,16 +184,20 @@ func (f *ChunkFetcher) Close() error {
 }
 
 // Reads HashSets from reqCh and batches all the received addresses
-// into |GetDownloadLocsRequest| messages with up to |batchSize| chunk hashes
-// in them. It delivers the batched messages to |resCh|.
-func fetcherHashSetToGetDlLocsReqsThread(ctx context.Context, reqCh chan hash.HashSet, abortCh chan struct{}, resCh chan *remotesapi.GetDownloadLocsRequest, batchSize int, repoPath string, idFunc func() (*remotesapi.RepoId, string)) error {
-	// This is the buffer of received that we haven't sent to |resCh| yet.
+// into request messages with up to |batchSize| chunk hashes in them.
+// |build| constructs the outbound request from a slice of wire-encoded
+// hashes. Delivers the batched messages to |resCh|.
+//
+// Parameterized on the request type so the same batching logic works
+// for both StreamDownloadLocations (legacy) and StreamChunkLocations
+// (new), which share the same wire shape for requests.
+func fetcherHashSetToReqsThread[R any](ctx context.Context, reqCh chan hash.HashSet, abortCh chan struct{}, resCh chan R, batchSize int, build func(chunkHashes [][]byte) R) error {
+	// This is the buffer of received hashes that we haven't sent to |resCh| yet.
 	var addrs [][]byte
-	// This is the current slice we're trying to send in a
-	// |GetDownloadLocsRequest|.  After we send it successfully, we will
-	// need to allocate a new one for the next message, but we can reuse
-	// its memory when we fail to send on |resCh| to form the next download
-	// request we try to send.
+	// This is the current slice we're trying to send in a request. After
+	// we send it successfully, we will need to allocate a new one for the
+	// next message, but we can reuse its memory when we fail to send on
+	// |resCh| to form the next request we try to send.
 	var outbound [][]byte
 	for {
 		if reqCh == nil && len(addrs) == 0 {
@@ -175,14 +205,14 @@ func fetcherHashSetToGetDlLocsReqsThread(ctx context.Context, reqCh chan hash.Ha
 			return nil
 		}
 
-		var thisResCh chan *remotesapi.GetDownloadLocsRequest
-		var thisRes *remotesapi.GetDownloadLocsRequest
+		var thisResCh chan R
+		var thisRes R
+		var thisLen int
 
-		// Each time through the loop, we build a new
-		// |GetDownloadLocsRequest| to send. It contains up to
-		// |batchSize| hashes from the end of |addrs|. If we
-		// successfully send it, then we will drop those addresses from
-		// the end of |addrs|.
+		// Each time through the loop, we build a new request to send.
+		// It contains up to |batchSize| hashes from the end of
+		// |addrs|. If we successfully send it, then we will drop those
+		// addresses from the end of |addrs|.
 		if len(addrs) > 0 {
 			end := len(addrs)
 			st := end - batchSize
@@ -193,8 +223,8 @@ func fetcherHashSetToGetDlLocsReqsThread(ctx context.Context, reqCh chan hash.Ha
 				outbound = make([][]byte, end-st)
 			}
 			outbound = append(outbound[:0], addrs[st:end]...)
-			id, token := idFunc()
-			thisRes = &remotesapi.GetDownloadLocsRequest{RepoId: id, RepoPath: repoPath, RepoToken: token, ChunkHashes: outbound[:]}
+			thisRes = build(outbound[:])
+			thisLen = end - st
 			thisResCh = resCh
 		}
 
@@ -208,7 +238,7 @@ func fetcherHashSetToGetDlLocsReqsThread(ctx context.Context, reqCh chan hash.Ha
 				addrs = append(addrs, h[:])
 			}
 		case thisResCh <- thisRes:
-			addrs = addrs[:len(addrs)-len(thisRes.ChunkHashes)]
+			addrs = addrs[:len(addrs)-thisLen]
 			outbound = nil
 		case <-ctx.Done():
 			return context.Cause(ctx)
@@ -300,6 +330,168 @@ func fetcherRPCDownloadLocsThread(ctx context.Context, reqCh chan *remotesapi.Ge
 		}
 	})
 	return eg.Wait()
+}
+
+// Peer of fetcherRPCDownloadLocsThread for the new StreamChunkLocations
+// RPC. Reads request messages off |reqCh| and drives the streaming RPC,
+// translating the deduplicated response shape back into
+// []*remotesapi.DownloadLoc so the downstream coalescing thread is
+// reused verbatim.
+//
+// Maintains |tfByID|, a long-lived table_file_id -> TableFileRecord map
+// that is never reset. reliable.MakeCall may tear the underlying stream
+// down and reopen it behind our back; a fresh handler restarts id
+// assignment and re-introduces any id it reuses with a fresh
+// TableFileRecord, which we overwrite into |tfByID| before resolving
+// any ChunkLocation that references it. See the proto file.
+func fetcherRPCChunkLocationsThread(ctx context.Context, reqCh chan *remotesapi.StreamChunkLocationsRequest, resCh chan []*remotesapi.DownloadLoc, client remotesapi.ChunkStoreServiceClient, storeRepoToken func(string), missingChunkCh chan nbs.ToChunker, host string, getRepoId func() (*remotesapi.RepoId, string), repoPath string) error {
+	stream, err := reliable.MakeCall(
+		ctx,
+		reliable.CallOptions[*remotesapi.StreamChunkLocationsRequest, *remotesapi.StreamChunkLocationsResponse]{
+			Open: func(ctx context.Context, opts ...grpc.CallOption) (reliable.ClientStream[*remotesapi.StreamChunkLocationsRequest, *remotesapi.StreamChunkLocationsResponse], error) {
+				return client.StreamChunkLocations(ctx, opts...)
+			},
+			ErrF:               processGrpcErr,
+			BackOffF:           grpcBackOff,
+			ReadRequestTimeout: reliableCallReadRequestTimeout,
+			DeliverRespTimeout: reliableCallDeliverRespTimeout,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	tfByID := make(map[uint32]*tableFileRec)
+
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		for {
+			select {
+			case req, ok := <-reqCh:
+				if !ok {
+					return stream.CloseSend()
+				}
+				if err := stream.Send(req); err != nil {
+					return NewRpcError(err, "StreamChunkLocations", host, req)
+				}
+			case <-ctx.Done():
+				return context.Cause(ctx)
+			}
+		}
+	})
+	eg.Go(func() error {
+		for {
+			resp, err := stream.Recv()
+			if err == io.EOF {
+				close(resCh)
+				return nil
+			}
+			req := stream.AssociatedReq()
+
+			if err != nil {
+				return NewRpcError(err, "StreamChunkLocations", host, req)
+			}
+			if resp == nil {
+				return NewRpcError(errors.New("no stream response"), "StreamChunkLocations", host, req)
+			}
+			if resp.RepoToken != "" {
+				storeRepoToken(resp.RepoToken)
+			}
+
+			// Integrate table-file records before resolving
+			// locations: a ChunkLocation in this response may
+			// reference an id introduced by a TableFileRecord in
+			// the same response.
+			for _, rec := range resp.TableFiles {
+				tfByID[rec.TableFileId] = rec
+			}
+
+			if missingChunkCh != nil {
+				for _, idx := range resp.MissingIndexes {
+					if int(idx) >= len(req.ChunkHashes) {
+						return NewRpcError(errors.New("server returned missing_index out of range"), "StreamChunkLocations", host, req)
+					}
+					var h hash.Hash
+					copy(h[:], req.ChunkHashes[idx])
+					select {
+					case missingChunkCh <- nbs.CompressedChunk{H: h}:
+					case <-ctx.Done():
+						return context.Cause(ctx)
+					}
+				}
+			}
+
+			locs, err := translateChunkLocations(req, resp.Locations, tfByID, getRepoId, repoPath)
+			if err != nil {
+				return NewRpcError(err, "StreamChunkLocations", host, req)
+			}
+
+			select {
+			case resCh <- locs:
+			case <-ctx.Done():
+				return context.Cause(ctx)
+			}
+		}
+	})
+	return eg.Wait()
+}
+
+// Group the ChunkLocations in a response by table_file_id and emit one
+// *remotesapi.DownloadLoc per group, so the downstream
+// fetcherDownloadRangesThread pipeline is reused without modification.
+// RefreshRequest is synthesized locally from the TableFileRecord's
+// file_id plus the DoltChunkStore's current (repo_id, repo_token,
+// repo_path) — the server no longer sends a per-DownloadLoc
+// RefreshTableFileUrlRequest.
+func translateChunkLocations(req *remotesapi.StreamChunkLocationsRequest, locations []*chunkLoc, tfByID map[uint32]*tableFileRec, getRepoId func() (*remotesapi.RepoId, string), repoPath string) ([]*remotesapi.DownloadLoc, error) {
+	if len(locations) == 0 {
+		return nil, nil
+	}
+
+	// Group by table_file_id, preserving first-seen order so the
+	// output is deterministic.
+	idOrder := make([]uint32, 0, len(tfByID))
+	rangesByID := make(map[uint32][]*remotesapi.RangeChunk)
+	for _, cl := range locations {
+		if int(cl.RequestIndex) >= len(req.ChunkHashes) {
+			return nil, errors.New("server returned ChunkLocation.request_index out of range")
+		}
+		if _, ok := tfByID[cl.TableFileId]; !ok {
+			return nil, fmt.Errorf("server referenced unknown table_file_id %d", cl.TableFileId)
+		}
+		if _, seen := rangesByID[cl.TableFileId]; !seen {
+			idOrder = append(idOrder, cl.TableFileId)
+		}
+		rangesByID[cl.TableFileId] = append(rangesByID[cl.TableFileId], &remotesapi.RangeChunk{
+			Hash:             req.ChunkHashes[cl.RequestIndex],
+			Offset:           cl.Offset,
+			Length:           cl.Length,
+			DictionaryOffset: cl.DictionaryOffset,
+			DictionaryLength: cl.DictionaryLength,
+		})
+	}
+
+	repoId, repoToken := getRepoId()
+	out := make([]*remotesapi.DownloadLoc, 0, len(idOrder))
+	for _, id := range idOrder {
+		rec := tfByID[id]
+		out = append(out, &remotesapi.DownloadLoc{
+			Location: &remotesapi.DownloadLoc_HttpGetRange{
+				HttpGetRange: &remotesapi.HttpGetRange{
+					Url:    rec.Url,
+					Ranges: rangesByID[id],
+				},
+			},
+			RefreshAfter: rec.RefreshAfter,
+			RefreshRequest: &remotesapi.RefreshTableFileUrlRequest{
+				RepoId:    repoId,
+				RepoToken: repoToken,
+				RepoPath:  repoPath,
+				FileId:    rec.FileId,
+			},
+		})
+	}
+	return out, nil
 }
 
 func getMissingChunks(req *remotesapi.GetDownloadLocsRequest, resp *remotesapi.GetDownloadLocsResponse) (hash.HashSet, error) {

--- a/go/libraries/doltcore/remotestorage/chunk_fetcher.go
+++ b/go/libraries/doltcore/remotestorage/chunk_fetcher.go
@@ -41,6 +41,20 @@ type (
 	chunkLoc     = remotesapi.StreamChunkLocationsResponse_ChunkLocation
 )
 
+// hashAtIndex returns the 20-byte sub-slice of |buf| at hash index
+// |idx| (i.e. buf[idx*20 : (idx+1)*20]), or ok=false if |idx| is
+// out of range for |buf| viewed as a flat 20-byte-per-hash buffer.
+// Used to decode request_index / missing_indexes returned by the
+// server against the request's chunk_hashes buffer.
+func hashAtIndex(buf []byte, idx uint32) ([]byte, bool) {
+	start := int(idx) * hash.ByteLen
+	end := start + hash.ByteLen
+	if end > len(buf) {
+		return nil, false
+	}
+	return buf[start:end], true
+}
+
 // A remotestorage.ChunkFetcher is a pipelined chunk fetcher for fetching a
 // large number of chunks where the downloads may benefit from range
 // coalescing, hedging, automatic retries, pipelining of download location
@@ -100,8 +114,15 @@ func NewChunkFetcher(ctx context.Context, dcs *DoltChunkStore) *ChunkFetcher {
 		locsReqCh := make(chan *remotesapi.StreamChunkLocationsRequest)
 		eg.Go(func() error {
 			return fetcherHashSetToReqsThread(ctx, ret.toGetCh, ret.abortCh, locsReqCh, getLocsBatchSize, func(hashes [][]byte) *remotesapi.StreamChunkLocationsRequest {
+				// StreamChunkLocationsRequest.chunk_hashes is a
+				// flat 20-byte-per-hash buffer, not repeated bytes
+				// (see the proto file for rationale).
+				flat := make([]byte, 0, hash.ByteLen*len(hashes))
+				for _, h := range hashes {
+					flat = append(flat, h...)
+				}
 				id, token := dcs.getRepoId()
-				return &remotesapi.StreamChunkLocationsRequest{RepoId: id, RepoPath: dcs.repoPath, RepoToken: token, ChunkHashes: hashes}
+				return &remotesapi.StreamChunkLocationsRequest{RepoId: id, RepoPath: dcs.repoPath, RepoToken: token, ChunkHashes: flat}
 			})
 		})
 		eg.Go(func() error {
@@ -408,11 +429,12 @@ func fetcherRPCChunkLocationsThread(ctx context.Context, reqCh chan *remotesapi.
 
 			if missingChunkCh != nil {
 				for _, idx := range resp.MissingIndexes {
-					if int(idx) >= len(req.ChunkHashes) {
+					bs, ok := hashAtIndex(req.ChunkHashes, idx)
+					if !ok {
 						return NewRpcError(errors.New("server returned missing_index out of range"), "StreamChunkLocations", host, req)
 					}
 					var h hash.Hash
-					copy(h[:], req.ChunkHashes[idx])
+					copy(h[:], bs)
 					select {
 					case missingChunkCh <- nbs.CompressedChunk{H: h}:
 					case <-ctx.Done():
@@ -453,7 +475,8 @@ func translateChunkLocations(req *remotesapi.StreamChunkLocationsRequest, locati
 	idOrder := make([]uint32, 0, len(tfByID))
 	rangesByID := make(map[uint32][]*remotesapi.RangeChunk)
 	for _, cl := range locations {
-		if int(cl.RequestIndex) >= len(req.ChunkHashes) {
+		bs, ok := hashAtIndex(req.ChunkHashes, cl.RequestIndex)
+		if !ok {
 			return nil, errors.New("server returned ChunkLocation.request_index out of range")
 		}
 		if _, ok := tfByID[cl.TableFileId]; !ok {
@@ -463,7 +486,7 @@ func translateChunkLocations(req *remotesapi.StreamChunkLocationsRequest, locati
 			idOrder = append(idOrder, cl.TableFileId)
 		}
 		rangesByID[cl.TableFileId] = append(rangesByID[cl.TableFileId], &remotesapi.RangeChunk{
-			Hash:             req.ChunkHashes[cl.RequestIndex],
+			Hash:             bs,
 			Offset:           cl.Offset,
 			Length:           cl.Length,
 			DictionaryOffset: cl.DictionaryOffset,

--- a/go/libraries/doltcore/remotestorage/chunk_fetcher_test.go
+++ b/go/libraries/doltcore/remotestorage/chunk_fetcher_test.go
@@ -25,14 +25,14 @@ import (
 	"github.com/dolthub/dolt/go/store/hash"
 )
 
-func TestFetcherHashSetToGetDlLocsReqsThread(t *testing.T) {
+func TestFetcherHashSetToReqsThread(t *testing.T) {
 	t.Run("ImmediateClose", func(t *testing.T) {
 		reqCh := make(chan hash.HashSet)
 		close(reqCh)
 
 		resCh := make(chan *remotesapi.GetDownloadLocsRequest)
 
-		err := fetcherHashSetToGetDlLocsReqsThread(context.Background(), reqCh, nil, resCh, 32, "", testIdFunc)
+		err := fetcherHashSetToReqsThread(context.Background(), reqCh, nil, resCh, 32, testBuildDlReq)
 		assert.NoError(t, err)
 		_, ok := <-resCh
 		assert.False(t, ok)
@@ -45,7 +45,7 @@ func TestFetcherHashSetToGetDlLocsReqsThread(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		err := fetcherHashSetToGetDlLocsReqsThread(ctx, reqCh, nil, resCh, 32, "", testIdFunc)
+		err := fetcherHashSetToReqsThread(ctx, reqCh, nil, resCh, 32, testBuildDlReq)
 		assert.Error(t, err)
 	})
 
@@ -55,7 +55,7 @@ func TestFetcherHashSetToGetDlLocsReqsThread(t *testing.T) {
 
 		eg, ctx := errgroup.WithContext(context.Background())
 		eg.Go(func() error {
-			return fetcherHashSetToGetDlLocsReqsThread(ctx, reqCh, nil, resCh, 8, "", testIdFunc)
+			return fetcherHashSetToReqsThread(ctx, reqCh, nil, resCh, 8, testBuildDlReq)
 		})
 
 		// First send a batch of 16 hashes.
@@ -116,4 +116,9 @@ func TestFetcherHashSetToGetDlLocsReqsThread(t *testing.T) {
 
 func testIdFunc() (*remotesapi.RepoId, string) {
 	return new(remotesapi.RepoId), ""
+}
+
+func testBuildDlReq(hashes [][]byte) *remotesapi.GetDownloadLocsRequest {
+	id, token := testIdFunc()
+	return &remotesapi.GetDownloadLocsRequest{RepoId: id, RepoToken: token, ChunkHashes: hashes}
 }

--- a/go/libraries/doltcore/remotestorage/chunk_fetcher_test.go
+++ b/go/libraries/doltcore/remotestorage/chunk_fetcher_test.go
@@ -16,13 +16,21 @@ package remotestorage
 
 import (
 	"context"
+	"io"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	remotesapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/remotesapi/v1alpha1"
 	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/dolthub/dolt/go/store/nbs"
 )
 
 func TestFetcherHashSetToReqsThread(t *testing.T) {
@@ -121,4 +129,536 @@ func testIdFunc() (*remotesapi.RepoId, string) {
 func testBuildDlReq(hashes [][]byte) *remotesapi.GetDownloadLocsRequest {
 	id, token := testIdFunc()
 	return &remotesapi.GetDownloadLocsRequest{RepoId: id, RepoToken: token, ChunkHashes: hashes}
+}
+
+// buildFlatHashBuf returns a |nHashes|*20-byte buffer where hash |i|
+// has byte[0] = i+1 as a distinct marker. Used by tests that need to
+// assert a ChunkLocation.RequestIndex correctly decodes into the
+// request's chunk_hashes buffer.
+func buildFlatHashBuf(nHashes int) []byte {
+	buf := make([]byte, hash.ByteLen*nHashes)
+	for i := 0; i < nHashes; i++ {
+		buf[i*hash.ByteLen] = byte(i + 1)
+	}
+	return buf
+}
+
+func TestHashAtIndex(t *testing.T) {
+	buf := buildFlatHashBuf(3)
+
+	t.Run("InRange", func(t *testing.T) {
+		bs, ok := hashAtIndex(buf, 0)
+		require.True(t, ok)
+		assert.Len(t, bs, hash.ByteLen)
+		assert.Equal(t, byte(1), bs[0])
+
+		bs, ok = hashAtIndex(buf, 2)
+		require.True(t, ok)
+		assert.Equal(t, byte(3), bs[0])
+	})
+	t.Run("OutOfRange", func(t *testing.T) {
+		_, ok := hashAtIndex(buf, 3)
+		assert.False(t, ok)
+		_, ok = hashAtIndex(buf, 100)
+		assert.False(t, ok)
+	})
+	t.Run("EmptyBuffer", func(t *testing.T) {
+		_, ok := hashAtIndex(nil, 0)
+		assert.False(t, ok)
+		_, ok = hashAtIndex([]byte{}, 0)
+		assert.False(t, ok)
+	})
+}
+
+func TestTranslateChunkLocations(t *testing.T) {
+	repoId := &remotesapi.RepoId{Org: "dolthub", RepoName: "repo"}
+	getRepoId := func() (*remotesapi.RepoId, string) {
+		return repoId, "token"
+	}
+	const repoPath = "dolthub/repo"
+
+	buildReq := func(nHashes int) *remotesapi.StreamChunkLocationsRequest {
+		return &remotesapi.StreamChunkLocationsRequest{ChunkHashes: buildFlatHashBuf(nHashes)}
+	}
+
+	t.Run("EmptyLocations", func(t *testing.T) {
+		locs, err := translateChunkLocations(buildReq(0), nil, nil, getRepoId, repoPath)
+		require.NoError(t, err)
+		assert.Nil(t, locs)
+	})
+
+	t.Run("SameResponseRecord", func(t *testing.T) {
+		req := buildReq(2)
+		tfByID := map[uint32]*tableFileRec{
+			1: {TableFileId: 1, Url: "https://example.com/tf-1", FileId: "file-1"},
+		}
+		locations := []*chunkLoc{
+			{TableFileId: 1, RequestIndex: 0, Offset: 0, Length: 10},
+			{TableFileId: 1, RequestIndex: 1, Offset: 10, Length: 20},
+		}
+		locs, err := translateChunkLocations(req, locations, tfByID, getRepoId, repoPath)
+		require.NoError(t, err)
+		require.Len(t, locs, 1)
+		hgr := locs[0].Location.(*remotesapi.DownloadLoc_HttpGetRange).HttpGetRange
+		assert.Equal(t, "https://example.com/tf-1", hgr.Url)
+		require.Len(t, hgr.Ranges, 2)
+		require.NotNil(t, locs[0].RefreshRequest)
+		assert.Equal(t, repoId, locs[0].RefreshRequest.RepoId)
+		assert.Equal(t, "token", locs[0].RefreshRequest.RepoToken)
+		assert.Equal(t, repoPath, locs[0].RefreshRequest.RepoPath)
+		assert.Equal(t, "file-1", locs[0].RefreshRequest.FileId)
+	})
+
+	t.Run("CrossResponseReuse", func(t *testing.T) {
+		// tfByID carries an entry from an earlier response; this
+		// response references it without a fresh TableFileRecord.
+		req := buildReq(1)
+		tfByID := map[uint32]*tableFileRec{
+			1: {TableFileId: 1, Url: "urlA", FileId: "file-1"},
+		}
+		locations := []*chunkLoc{{TableFileId: 1, RequestIndex: 0}}
+		locs, err := translateChunkLocations(req, locations, tfByID, getRepoId, repoPath)
+		require.NoError(t, err)
+		require.Len(t, locs, 1)
+		hgr := locs[0].Location.(*remotesapi.DownloadLoc_HttpGetRange).HttpGetRange
+		assert.Equal(t, "urlA", hgr.Url)
+	})
+
+	t.Run("OverwriteSimulation", func(t *testing.T) {
+		// Simulates a reconnect: the RPC thread has integrated a
+		// fresh TableFileRecord{id=1, url=urlB} into tfByID,
+		// overwriting an earlier urlA. Subsequent translation must
+		// use urlB.
+		req := buildReq(1)
+		tfByID := map[uint32]*tableFileRec{
+			1: {TableFileId: 1, Url: "urlB", FileId: "file-1-b"},
+		}
+		locations := []*chunkLoc{{TableFileId: 1, RequestIndex: 0}}
+		locs, err := translateChunkLocations(req, locations, tfByID, getRepoId, repoPath)
+		require.NoError(t, err)
+		require.Len(t, locs, 1)
+		hgr := locs[0].Location.(*remotesapi.DownloadLoc_HttpGetRange).HttpGetRange
+		assert.Equal(t, "urlB", hgr.Url)
+		assert.Equal(t, "file-1-b", locs[0].RefreshRequest.FileId)
+	})
+
+	t.Run("ProtocolViolationUnknownTableFileId", func(t *testing.T) {
+		req := buildReq(1)
+		tfByID := map[uint32]*tableFileRec{}
+		locations := []*chunkLoc{{TableFileId: 42, RequestIndex: 0}}
+		locs, err := translateChunkLocations(req, locations, tfByID, getRepoId, repoPath)
+		assert.Nil(t, locs)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "table_file_id 42")
+	})
+
+	t.Run("ProtocolViolationRequestIndexOutOfRange", func(t *testing.T) {
+		req := buildReq(2) // valid indices: 0 and 1
+		tfByID := map[uint32]*tableFileRec{
+			1: {TableFileId: 1, Url: "u"},
+		}
+		locations := []*chunkLoc{{TableFileId: 1, RequestIndex: 2}}
+		locs, err := translateChunkLocations(req, locations, tfByID, getRepoId, repoPath)
+		assert.Nil(t, locs)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "out of range")
+	})
+
+	t.Run("MultipleTableFilesPreservesFirstSeenOrder", func(t *testing.T) {
+		req := buildReq(3)
+		tfByID := map[uint32]*tableFileRec{
+			5: {TableFileId: 5, Url: "url-5"},
+			7: {TableFileId: 7, Url: "url-7"},
+		}
+		// First-seen order in locations: id=7, then id=5.
+		locations := []*chunkLoc{
+			{TableFileId: 7, RequestIndex: 0},
+			{TableFileId: 5, RequestIndex: 1},
+			{TableFileId: 7, RequestIndex: 2},
+		}
+		locs, err := translateChunkLocations(req, locations, tfByID, getRepoId, repoPath)
+		require.NoError(t, err)
+		require.Len(t, locs, 2)
+
+		hgr0 := locs[0].Location.(*remotesapi.DownloadLoc_HttpGetRange).HttpGetRange
+		assert.Equal(t, "url-7", hgr0.Url)
+		assert.Len(t, hgr0.Ranges, 2)
+
+		hgr1 := locs[1].Location.(*remotesapi.DownloadLoc_HttpGetRange).HttpGetRange
+		assert.Equal(t, "url-5", hgr1.Url)
+		assert.Len(t, hgr1.Ranges, 1)
+	})
+
+	t.Run("RefreshAfterPropagated", func(t *testing.T) {
+		req := buildReq(1)
+		now := timestamppb.Now()
+		tfByID := map[uint32]*tableFileRec{
+			1: {TableFileId: 1, Url: "u", FileId: "f", RefreshAfter: now},
+		}
+		locations := []*chunkLoc{{TableFileId: 1, RequestIndex: 0}}
+		locs, err := translateChunkLocations(req, locations, tfByID, getRepoId, repoPath)
+		require.NoError(t, err)
+		require.Len(t, locs, 1)
+		assert.Equal(t, now, locs[0].RefreshAfter)
+	})
+
+	t.Run("RangeChunkHashDecodedFromRequestBuffer", func(t *testing.T) {
+		// RequestIndex=2 should pull bytes [40:60] from the
+		// flat 3*20-byte buffer, where byte[0]=3.
+		req := buildReq(3)
+		tfByID := map[uint32]*tableFileRec{
+			1: {TableFileId: 1, Url: "u"},
+		}
+		locations := []*chunkLoc{{TableFileId: 1, RequestIndex: 2, Offset: 0, Length: 10}}
+		locs, err := translateChunkLocations(req, locations, tfByID, getRepoId, repoPath)
+		require.NoError(t, err)
+		require.Len(t, locs, 1)
+		hgr := locs[0].Location.(*remotesapi.DownloadLoc_HttpGetRange).HttpGetRange
+		require.Len(t, hgr.Ranges, 1)
+		assert.Len(t, hgr.Ranges[0].Hash, hash.ByteLen)
+		assert.Equal(t, byte(3), hgr.Ranges[0].Hash[0])
+	})
+}
+
+// fakeStreamChunkLocationsClient is a minimal in-memory fake of the
+// generated ChunkStoreService_StreamChunkLocationsClient interface.
+// The reliable-RPC layer only calls Send/Recv/CloseSend; the
+// embedded grpc.ClientStream is nil and unused.
+type fakeStreamChunkLocationsClient struct {
+	grpc.ClientStream
+
+	ctx    context.Context
+	sentCh chan *remotesapi.StreamChunkLocationsRequest
+	recvCh chan fakeStreamResult
+}
+
+type fakeStreamResult struct {
+	resp *remotesapi.StreamChunkLocationsResponse
+	err  error
+}
+
+func newFakeStream(ctx context.Context) *fakeStreamChunkLocationsClient {
+	return &fakeStreamChunkLocationsClient{
+		ctx:    ctx,
+		sentCh: make(chan *remotesapi.StreamChunkLocationsRequest, 64),
+		recvCh: make(chan fakeStreamResult, 64),
+	}
+}
+
+func (s *fakeStreamChunkLocationsClient) Send(req *remotesapi.StreamChunkLocationsRequest) error {
+	select {
+	case s.sentCh <- req:
+		return nil
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	}
+}
+
+func (s *fakeStreamChunkLocationsClient) Recv() (*remotesapi.StreamChunkLocationsResponse, error) {
+	select {
+	case r, ok := <-s.recvCh:
+		if !ok {
+			return nil, io.EOF
+		}
+		return r.resp, r.err
+	case <-s.ctx.Done():
+		return nil, s.ctx.Err()
+	}
+}
+
+func (s *fakeStreamChunkLocationsClient) CloseSend() error { return nil }
+
+// fakeCSClient is just enough of remotesapi.ChunkStoreServiceClient to
+// open the StreamChunkLocations stream under test. Other methods
+// inherit nil behavior from the embedded interface and will panic if
+// called (which they aren't, by the RPC thread).
+type fakeCSClient struct {
+	remotesapi.ChunkStoreServiceClient
+	stream *fakeStreamChunkLocationsClient
+}
+
+func (c *fakeCSClient) StreamChunkLocations(ctx context.Context, opts ...grpc.CallOption) (remotesapi.ChunkStoreService_StreamChunkLocationsClient, error) {
+	return c.stream, nil
+}
+
+// rpcTestHarness wraps fetcherRPCChunkLocationsThread and the fake
+// stream so individual tests can drive requests and responses.
+type rpcTestHarness struct {
+	t         *testing.T
+	cancel    context.CancelFunc
+	stream    *fakeStreamChunkLocationsClient
+	reqCh     chan *remotesapi.StreamChunkLocationsRequest
+	resCh     chan []*remotesapi.DownloadLoc
+	missingCh chan nbs.ToChunker
+
+	// done closes when the RPC thread has exited; finalErr holds its
+	// terminal error. Read via wait().
+	done     chan struct{}
+	finalErr error
+}
+
+func startRPCThread(t *testing.T) *rpcTestHarness {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	stream := newFakeStream(ctx)
+	client := &fakeCSClient{stream: stream}
+
+	h := &rpcTestHarness{
+		t:         t,
+		cancel:    cancel,
+		stream:    stream,
+		reqCh:     make(chan *remotesapi.StreamChunkLocationsRequest, 16),
+		resCh:     make(chan []*remotesapi.DownloadLoc, 16),
+		missingCh: make(chan nbs.ToChunker, 16),
+		done:      make(chan struct{}),
+	}
+	repoId := &remotesapi.RepoId{Org: "org", RepoName: "repo"}
+	getRepoId := func() (*remotesapi.RepoId, string) { return repoId, "tok" }
+	go func() {
+		defer close(h.done)
+		h.finalErr = fetcherRPCChunkLocationsThread(ctx, h.reqCh, h.resCh, client, func(string) {}, h.missingCh, "host", getRepoId, "repoPath")
+	}()
+
+	// Backstop: make sure the RPC goroutine is torn down no matter
+	// how the test ends (pass, fail, require.* abort, panic). If the
+	// test already drove a clean shutdown, h.done is already closed
+	// and this is a no-op. Otherwise cancelling the context unblocks
+	// Send/Recv on the fake stream and the reliable-layer goroutines
+	// so the RPC thread exits before the next test starts.
+	t.Cleanup(func() {
+		h.cancel()
+		select {
+		case <-h.done:
+		case <-time.After(5 * time.Second):
+			t.Errorf("RPC thread did not exit within 5s of cleanup")
+		}
+	})
+	return h
+}
+
+// wait blocks until the RPC thread has exited and returns its
+// terminal error. Typical use:
+//   - Happy-path tests close h.reqCh and h.stream.recvCh to drive a
+//     clean EOF shutdown, then assert require.NoError(t, h.wait()).
+//   - Error-path tests inject an error response, then check
+//     require.Error(t, h.wait()).
+//
+// Times out so a stuck test fails fast rather than hanging the suite.
+func (h *rpcTestHarness) wait() error {
+	h.t.Helper()
+	select {
+	case <-h.done:
+		return h.finalErr
+	case <-time.After(5 * time.Second):
+		h.cancel()
+		h.t.Fatal("RPC thread did not exit within 5s of wait()")
+		return nil
+	}
+}
+
+func recvLocs(t *testing.T, ch <-chan []*remotesapi.DownloadLoc) []*remotesapi.DownloadLoc {
+	t.Helper()
+	select {
+	case locs := <-ch:
+		return locs
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for DownloadLocs on resCh")
+		return nil
+	}
+}
+
+func recvMissing(t *testing.T, ch <-chan nbs.ToChunker) nbs.CompressedChunk {
+	t.Helper()
+	select {
+	case c := <-ch:
+		cc, ok := c.(nbs.CompressedChunk)
+		require.True(t, ok, "expected nbs.CompressedChunk on missingCh")
+		return cc
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for missing chunk on missingCh")
+		return nbs.CompressedChunk{}
+	}
+}
+
+func TestFetcherRPCChunkLocationsThread_HappyPath(t *testing.T) {
+	h := startRPCThread(t)
+
+	// Send a request with 2 hashes; the stream should see it
+	// after the reliable layer forwards it.
+	req := &remotesapi.StreamChunkLocationsRequest{ChunkHashes: buildFlatHashBuf(2)}
+	h.reqCh <- req
+
+	select {
+	case sent := <-h.stream.sentCh:
+		assert.Equal(t, req, sent)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Send never happened on the fake stream")
+	}
+
+	// Push a response that introduces table_file_id=1 and places
+	// both hashes in it.
+	h.stream.recvCh <- fakeStreamResult{resp: &remotesapi.StreamChunkLocationsResponse{
+		TableFiles: []*tableFileRec{{TableFileId: 1, Url: "url-1", FileId: "f-1"}},
+		Locations: []*chunkLoc{
+			{TableFileId: 1, RequestIndex: 0, Offset: 0, Length: 10},
+			{TableFileId: 1, RequestIndex: 1, Offset: 100, Length: 20},
+		},
+	}}
+
+	locs := recvLocs(t, h.resCh)
+	require.Len(t, locs, 1)
+	hgr := locs[0].Location.(*remotesapi.DownloadLoc_HttpGetRange).HttpGetRange
+	assert.Equal(t, "url-1", hgr.Url)
+	assert.Len(t, hgr.Ranges, 2)
+
+	close(h.reqCh)
+	close(h.stream.recvCh)
+	require.NoError(t, h.wait())
+}
+
+func TestFetcherRPCChunkLocationsThread_CrossResponseReuse(t *testing.T) {
+	h := startRPCThread(t)
+
+	// Request 1.
+	req1 := &remotesapi.StreamChunkLocationsRequest{ChunkHashes: buildFlatHashBuf(1)}
+	h.reqCh <- req1
+	<-h.stream.sentCh
+
+	h.stream.recvCh <- fakeStreamResult{resp: &remotesapi.StreamChunkLocationsResponse{
+		TableFiles: []*tableFileRec{{TableFileId: 1, Url: "url-1"}},
+		Locations:  []*chunkLoc{{TableFileId: 1, RequestIndex: 0}},
+	}}
+
+	locs := recvLocs(t, h.resCh)
+	require.Len(t, locs, 1)
+	assert.Equal(t, "url-1", locs[0].Location.(*remotesapi.DownloadLoc_HttpGetRange).HttpGetRange.Url)
+
+	// Request 2: server references id=1 without re-sending the
+	// TableFileRecord. The long-lived tfByID map in the RPC thread
+	// must still resolve it.
+	req2 := &remotesapi.StreamChunkLocationsRequest{ChunkHashes: buildFlatHashBuf(1)}
+	h.reqCh <- req2
+	<-h.stream.sentCh
+
+	h.stream.recvCh <- fakeStreamResult{resp: &remotesapi.StreamChunkLocationsResponse{
+		Locations: []*chunkLoc{{TableFileId: 1, RequestIndex: 0}},
+	}}
+
+	locs = recvLocs(t, h.resCh)
+	require.Len(t, locs, 1)
+	assert.Equal(t, "url-1", locs[0].Location.(*remotesapi.DownloadLoc_HttpGetRange).HttpGetRange.Url)
+
+	close(h.reqCh)
+	close(h.stream.recvCh)
+	require.NoError(t, h.wait())
+}
+
+func TestFetcherRPCChunkLocationsThread_OverwriteSemantics(t *testing.T) {
+	// Two responses, same table_file_id, different URLs. The second
+	// TableFileRecord must overwrite the first so subsequent
+	// ChunkLocations resolve to urlB. This is the "reconnect
+	// simulation" — a fresh server handler re-uses id=1 with a new
+	// URL, which the client must handle transparently.
+	h := startRPCThread(t)
+
+	req1 := &remotesapi.StreamChunkLocationsRequest{ChunkHashes: buildFlatHashBuf(1)}
+	h.reqCh <- req1
+	<-h.stream.sentCh
+
+	h.stream.recvCh <- fakeStreamResult{resp: &remotesapi.StreamChunkLocationsResponse{
+		TableFiles: []*tableFileRec{{TableFileId: 1, Url: "urlA"}},
+		Locations:  []*chunkLoc{{TableFileId: 1, RequestIndex: 0}},
+	}}
+
+	locs := recvLocs(t, h.resCh)
+	require.Len(t, locs, 1)
+	assert.Equal(t, "urlA", locs[0].Location.(*remotesapi.DownloadLoc_HttpGetRange).HttpGetRange.Url)
+
+	req2 := &remotesapi.StreamChunkLocationsRequest{ChunkHashes: buildFlatHashBuf(1)}
+	h.reqCh <- req2
+	<-h.stream.sentCh
+
+	h.stream.recvCh <- fakeStreamResult{resp: &remotesapi.StreamChunkLocationsResponse{
+		TableFiles: []*tableFileRec{{TableFileId: 1, Url: "urlB"}},
+		Locations:  []*chunkLoc{{TableFileId: 1, RequestIndex: 0}},
+	}}
+
+	locs = recvLocs(t, h.resCh)
+	require.Len(t, locs, 1)
+	assert.Equal(t, "urlB", locs[0].Location.(*remotesapi.DownloadLoc_HttpGetRange).HttpGetRange.Url)
+
+	close(h.reqCh)
+	close(h.stream.recvCh)
+	require.NoError(t, h.wait())
+}
+
+func TestFetcherRPCChunkLocationsThread_MissingIndexes(t *testing.T) {
+	h := startRPCThread(t)
+
+	// Request with 3 hashes. Server returns no locations and lists
+	// all three indices as missing.
+	req := &remotesapi.StreamChunkLocationsRequest{ChunkHashes: buildFlatHashBuf(3)}
+	h.reqCh <- req
+	<-h.stream.sentCh
+
+	h.stream.recvCh <- fakeStreamResult{resp: &remotesapi.StreamChunkLocationsResponse{
+		MissingIndexes: []uint32{0, 2},
+	}}
+
+	// Expect two empty CompressedChunks with hashes decoded from
+	// buf[0:20] and buf[40:60].
+	missing0 := recvMissing(t, h.missingCh)
+	missing1 := recvMissing(t, h.missingCh)
+
+	var expect0, expect1 hash.Hash
+	copy(expect0[:], req.ChunkHashes[0*hash.ByteLen:1*hash.ByteLen])
+	copy(expect1[:], req.ChunkHashes[2*hash.ByteLen:3*hash.ByteLen])
+
+	got := map[hash.Hash]bool{missing0.Hash(): true, missing1.Hash(): true}
+	assert.True(t, got[expect0])
+	assert.True(t, got[expect1])
+
+	// The response is still delivered on resCh (with no locs) to
+	// preserve the 1:1 req/resp ordering the reliable layer expects.
+	locs := recvLocs(t, h.resCh)
+	assert.Nil(t, locs)
+
+	close(h.reqCh)
+	close(h.stream.recvCh)
+	require.NoError(t, h.wait())
+}
+
+func TestFetcherRPCChunkLocationsThread_ProtocolViolationUnknownTableFileId(t *testing.T) {
+	h := startRPCThread(t)
+
+	req := &remotesapi.StreamChunkLocationsRequest{ChunkHashes: buildFlatHashBuf(1)}
+	h.reqCh <- req
+	<-h.stream.sentCh
+
+	// Server references id=42 without ever introducing it.
+	h.stream.recvCh <- fakeStreamResult{resp: &remotesapi.StreamChunkLocationsResponse{
+		Locations: []*chunkLoc{{TableFileId: 42, RequestIndex: 0}},
+	}}
+
+	err := h.wait()
+	require.Error(t, err)
+	// NewRpcError wraps the underlying message.
+	assert.Contains(t, err.Error(), "table_file_id 42")
+}
+
+func TestFetcherRPCChunkLocationsThread_PermanentStreamError(t *testing.T) {
+	// A permanent gRPC error (e.g. PermissionDenied) on Recv is
+	// classified as non-retriable by processGrpcErr and should
+	// surface from the thread directly rather than loop forever.
+	h := startRPCThread(t)
+
+	req := &remotesapi.StreamChunkLocationsRequest{ChunkHashes: buildFlatHashBuf(1)}
+	h.reqCh <- req
+	<-h.stream.sentCh
+
+	h.stream.recvCh <- fakeStreamResult{err: status.Error(codes.PermissionDenied, "nope")}
+
+	err := h.wait()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nope")
 }

--- a/go/libraries/doltcore/remotestorage/chunk_store.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -133,6 +134,16 @@ type DoltChunkStore struct {
 	stats       cacheStats
 	logger      chunks.DebugLogger
 	wsValidate  bool
+}
+
+// hasFeature reports whether |f| appears in |md|'s advertised
+// features list. FEATURE_UNSPECIFIED is treated as always absent.
+// |md| may be nil.
+func hasFeature(md *remotesapi.GetRepoMetadataResponse, f remotesapi.Feature) bool {
+	if md == nil || f == remotesapi.Feature_FEATURE_UNSPECIFIED {
+		return false
+	}
+	return slices.Contains(md.Features, f)
 }
 
 func NewDoltChunkStoreFromPath(

--- a/go/libraries/doltcore/remotestorage/chunk_store_test.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store_test.go
@@ -208,3 +208,56 @@ func (f *refreshClient) RefreshTableFileUrl(ctx context.Context, in *remotesapi.
 func (f refreshClient) AddTableFiles(ctx context.Context, in *remotesapi.AddTableFilesRequest, opts ...grpc.CallOption) (*remotesapi.AddTableFilesResponse, error) {
 	return nil, nil
 }
+
+func TestHasFeature(t *testing.T) {
+	const known = remotesapi.Feature_FEATURE_STREAM_CHUNK_LOCATIONS
+
+	t.Run("NilMetadata", func(t *testing.T) {
+		assert.False(t, hasFeature(nil, known))
+	})
+	t.Run("NilFeaturesList", func(t *testing.T) {
+		md := &remotesapi.GetRepoMetadataResponse{}
+		assert.False(t, hasFeature(md, known))
+	})
+	t.Run("FeaturePresent", func(t *testing.T) {
+		md := &remotesapi.GetRepoMetadataResponse{
+			Features: []remotesapi.Feature{known},
+		}
+		assert.True(t, hasFeature(md, known))
+	})
+	t.Run("FeatureAbsent", func(t *testing.T) {
+		md := &remotesapi.GetRepoMetadataResponse{
+			Features: []remotesapi.Feature{remotesapi.Feature_FEATURE_UNSPECIFIED},
+		}
+		assert.False(t, hasFeature(md, known))
+	})
+	t.Run("UnspecifiedAlwaysAbsent", func(t *testing.T) {
+		// Even if a server somehow sent FEATURE_UNSPECIFIED, the
+		// helper must report it as absent.
+		md := &remotesapi.GetRepoMetadataResponse{
+			Features: []remotesapi.Feature{remotesapi.Feature_FEATURE_UNSPECIFIED},
+		}
+		assert.False(t, hasFeature(md, remotesapi.Feature_FEATURE_UNSPECIFIED))
+	})
+	t.Run("DuplicateEntry", func(t *testing.T) {
+		md := &remotesapi.GetRepoMetadataResponse{
+			Features: []remotesapi.Feature{known, known},
+		}
+		assert.True(t, hasFeature(md, known))
+	})
+	t.Run("UnknownFutureEnumCoexistsWithKnown", func(t *testing.T) {
+		// An older client reading a newer server's response will
+		// see unknown enum values carried through as bare integers.
+		// The known feature must still be detected correctly.
+		md := &remotesapi.GetRepoMetadataResponse{
+			Features: []remotesapi.Feature{remotesapi.Feature(999), known},
+		}
+		assert.True(t, hasFeature(md, known))
+	})
+	t.Run("OnlyUnknownFutureEnum", func(t *testing.T) {
+		md := &remotesapi.GetRepoMetadataResponse{
+			Features: []remotesapi.Feature{remotesapi.Feature(999)},
+		}
+		assert.False(t, hasFeature(md, known))
+	})
+}

--- a/go/libraries/doltcore/remotestorage/chunk_store_test.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store_test.go
@@ -183,6 +183,9 @@ func (f refreshClient) GetDownloadLocations(ctx context.Context, in *remotesapi.
 func (f refreshClient) StreamDownloadLocations(ctx context.Context, opts ...grpc.CallOption) (remotesapi.ChunkStoreService_StreamDownloadLocationsClient, error) {
 	return nil, nil
 }
+func (f refreshClient) StreamChunkLocations(ctx context.Context, opts ...grpc.CallOption) (remotesapi.ChunkStoreService_StreamChunkLocationsClient, error) {
+	return nil, nil
+}
 func (f refreshClient) GetUploadLocations(ctx context.Context, in *remotesapi.GetUploadLocsRequest, opts ...grpc.CallOption) (*remotesapi.GetUploadLocsResponse, error) {
 	return nil, nil
 }

--- a/integration-tests/bats/remotes-push-pull.bats
+++ b/integration-tests/bats/remotes-push-pull.bats
@@ -9,18 +9,42 @@ setup() {
     mkdir remotes-$$
     mkdir remotes-$$/empty
     echo remotesrv log available here $BATS_TMPDIR/remotes-$$/remotesrv.log
-    remotesrv --http-port 1234 --dir ./remotes-$$ &> ./remotes-$$/remotesrv.log 3>&- &
-    remotesrv_pid=$!
     cd dolt-repo-$$
     mkdir "dolt-repo-clones"
 }
 
 teardown() {
-    kill $remotesrv_pid
-    wait $remotesrv_pid || :
-    remotesrv_pid=""
+    if [ -n "$remotesrv_pid" ]; then
+        kill $remotesrv_pid
+        wait $remotesrv_pid || :
+        remotesrv_pid=""
+    fi
     teardown_common
     rm -rf $BATS_TMPDIR/remotes-$$
+}
+
+# Spawn remotesrv for the current @test, optionally suppressing
+# advertisement of a feature so the legacy-RPC fallback path is
+# exercised. Pass "" to use the server's default features, or the
+# name of a Feature enum value (e.g. "FEATURE_STREAM_CHUNK_LOCATIONS")
+# to suppress it. This used to live in setup(), but to let paired
+# @tests flip feature advertisement via DOLT_REMOTESAPI_DISABLED_FEATURES
+# we spawn remotesrv per-test instead. Every @test in this file that
+# hits http://localhost:50051 must call setup_remotesrv at its top.
+setup_remotesrv() {
+    local disabled_features="$1"
+    if [ -n "$disabled_features" ]; then
+        export DOLT_REMOTESAPI_DISABLED_FEATURES="$disabled_features"
+    else
+        unset DOLT_REMOTESAPI_DISABLED_FEATURES
+    fi
+    # Spawn from $BATS_TMPDIR so the `--dir ./remotes-$$` relative
+    # path resolves the same way it did under the old setup(), then
+    # return to the caller's cwd.
+    pushd "$BATS_TMPDIR" > /dev/null
+    remotesrv --http-port 1234 --dir ./remotes-$$ &> ./remotes-$$/remotesrv.log 3>&- &
+    remotesrv_pid=$!
+    popd > /dev/null
 }
 
 @test "remotes-push-pull: pull also fetches" {
@@ -115,6 +139,7 @@ teardown() {
 }
 
 @test "remotes-push-pull: push and pull an unknown remote" {
+    setup_remotesrv ""
     dolt remote add test-remote http://localhost:50051/test-org/test-repo
     run dolt push poop main
     [ "$status" -eq 1 ]
@@ -125,6 +150,7 @@ teardown() {
 }
 
 @test "remotes-push-pull: push with only one argument" {
+    setup_remotesrv ""
     dolt remote add test-remote http://localhost:50051/test-org/test-repo
     run dolt push test-remote
     [ "$status" -eq 1 ]
@@ -136,6 +162,7 @@ teardown() {
 }
 
 @test "remotes-push-pull: push without set-upstream works with autoSetUpRemote set to true" {
+    setup_remotesrv ""
     dolt config --local --add push.autoSetUpRemote true
     dolt remote add test-remote http://localhost:50051/test-org/test-repo
     run dolt push test-remote main
@@ -147,7 +174,8 @@ teardown() {
     [[ "$output" =~ "Everything up-to-date" ]] || false
 }
 
-@test "remotes-push-pull: push and pull main branch from a remote" {
+_do_push_and_pull_main_branch_from_remote_scenario() {
+    setup_remotesrv "$1"
     dolt remote add test-remote http://localhost:50051/test-org/test-repo
     run dolt push --set-upstream test-remote main
     [ "$status" -eq 0 ]
@@ -157,7 +185,16 @@ teardown() {
     [[ "$output" =~ "Everything up-to-date" ]] || false
 }
 
+@test "remotes-push-pull: push and pull main branch from a remote, new RPC" {
+    _do_push_and_pull_main_branch_from_remote_scenario ""
+}
+
+@test "remotes-push-pull: push and pull main branch from a remote, legacy RPC" {
+    _do_push_and_pull_main_branch_from_remote_scenario "FEATURE_STREAM_CHUNK_LOCATIONS"
+}
+
 @test "remotes-push-pull: push and pull non-main branch from remote" {
+    setup_remotesrv ""
     dolt remote add test-remote http://localhost:50051/test-org/test-repo
     dolt checkout -b test-branch
     run dolt push --set-upstream test-remote test-branch
@@ -167,7 +204,8 @@ teardown() {
     [[ "$output" =~ "Everything up-to-date" ]] || false
 }
 
-@test "remotes-push-pull: pull with explicit remote and branch" {
+_do_pull_with_explicit_remote_and_branch_scenario() {
+    setup_remotesrv "$1"
     dolt remote add test-remote http://localhost:50051/test-org/test-repo
     dolt checkout -b test-branch
     dolt sql -q "create table t1(c0 varchar(100));"
@@ -207,7 +245,16 @@ teardown() {
     [[ "$output" =~ "table with same name 't1' added in 2 commits can't be merged" ]] || false
 }
 
+@test "remotes-push-pull: pull with explicit remote and branch, new RPC" {
+    _do_pull_with_explicit_remote_and_branch_scenario ""
+}
+
+@test "remotes-push-pull: pull with explicit remote and branch, legacy RPC" {
+    _do_pull_with_explicit_remote_and_branch_scenario "FEATURE_STREAM_CHUNK_LOCATIONS"
+}
+
 @test "remotes-push-pull: push and pull from non-main branch and use --set-upstream" {
+    setup_remotesrv ""
     dolt remote add test-remote http://localhost:50051/test-org/test-repo
     dolt checkout -b test-branch
     run dolt push --set-upstream test-remote test-branch
@@ -221,6 +268,7 @@ teardown() {
 }
 
 @test "remotes-push-pull: push output" {
+    setup_remotesrv ""
     dolt remote add test-remote http://localhost:50051/test-org/test-repo
     dolt checkout -b test-branch
     dolt sql -q "create table test (pk int, c1 int, primary key(pk))"
@@ -232,6 +280,7 @@ teardown() {
 }
 
 @test "remotes-push-pull: push and pull with docs from remote" {
+    setup_remotesrv ""
     dolt remote add test-remote http://localhost:50051/test-org/test-repo
     echo "license-text" > LICENSE.md
     dolt docs upload LICENSE.md LICENSE.md
@@ -269,6 +318,7 @@ teardown() {
 }
 
 @test "remotes-push-pull: push and pull tags to/from remote" {
+    setup_remotesrv ""
     dolt remote add test-remote http://localhost:50051/test-org/test-repo
     dolt sql <<SQL
 CREATE TABLE test (pk int PRIMARY KEY);
@@ -293,6 +343,7 @@ SQL
 }
 
 @test "remotes-push-pull: tags are fetched when pulling" {
+    setup_remotesrv ""
     dolt remote add test-remote http://localhost:50051/test-org/test-repo
     dolt sql <<SQL
 CREATE TABLE test (pk int PRIMARY KEY);
@@ -326,6 +377,7 @@ SQL
 }
 
 @test "remotes-push-pull: try to push a remote that is behind tip" {
+    setup_remotesrv ""
     dolt remote add test-remote http://localhost:50051/test-org/test-repo
     dolt push test-remote main
     cd dolt-repo-clones
@@ -353,6 +405,7 @@ SQL
 }
 
 @test "remotes-push-pull: dolt_pull() with divergent head" {
+    setup_remotesrv ""
     dolt remote add test-remote http://localhost:50051/test-org/test-repo
     dolt push test-remote main
     dolt sql <<SQL
@@ -390,6 +443,7 @@ SQL
 }
 
 @test "remotes-push-pull: dolt pull onto a dirty working set fails" {
+    setup_remotesrv ""
     dolt remote add test-remote http://localhost:50051/test-org/test-repo
     dolt sql <<SQL
 CREATE TABLE test (
@@ -420,6 +474,7 @@ SQL
 }
 
 @test "remotes-push-pull: force push to main" {
+    setup_remotesrv ""
     dolt remote add test-remote http://localhost:50051/test-org/test-repo
     dolt push test-remote main
 
@@ -487,6 +542,7 @@ SQL
 }
 
 @test "remotes-push-pull: push not specifying a branch throws error on default remote" {
+    setup_remotesrv ""
     dolt remote add origin http://localhost:50051/test-org/test-repo
     run dolt remote -v
     [[ "$output" =~  origin ]] || false
@@ -496,6 +552,7 @@ SQL
 }
 
 @test "remotes-push-pull: push not specifying a branch create new remote branch without setting upstream on non-default remote" {
+    setup_remotesrv ""
     dolt remote add origin http://localhost:50051/test-org/test-repo
     dolt remote add test-remote http://localhost:50051/test-org/test-repo
     run dolt remote -v
@@ -510,6 +567,7 @@ SQL
 }
 
 @test "remotes-push-pull: push not specifying a branch creates new remote branch and sets upstream on non-default remote when -u is used" {
+    setup_remotesrv ""
     dolt remote add origin http://localhost:50051/test-org/test-repo
     dolt remote add test-remote http://localhost:50051/test-org/test-repo
     run dolt remote -v
@@ -532,6 +590,7 @@ SQL
 }
 
 @test "remotes-push-pull: push --all with no remote or refspec specified" {
+    setup_remotesrv ""
     dolt remote add origin http://localhost:50051/test-org/test-repo
     run dolt remote -v
     [[ "$output" =~  origin ]] || false
@@ -687,6 +746,7 @@ SQL
 }
 
 @test "remotes-push-pull: push set upstream succeeds even if up to date" {
+    setup_remotesrv ""
     dolt remote add origin http://localhost:50051/test-org/test-repo
     dolt push origin main
     dolt checkout -b feature
@@ -771,6 +831,7 @@ SQL
 }
 
 @test "remotes-push-pull: validate that a config is needed for a pull." {
+    setup_remotesrv ""
     dolt remote add test-remote http://localhost:50051/test-org/test-repo
     dolt push test-remote main
     dolt fetch test-remote

--- a/integration-tests/bats/remotesrv.bats
+++ b/integration-tests/bats/remotesrv.bats
@@ -26,7 +26,13 @@ stop_remotesrv() {
     fi
 }
 
-@test "remotesrv: can read from remotesrv in repo-mode" {
+_do_read_from_remotesrv_repo_mode_scenario() {
+    local disabled_features="$1"
+    if [ -n "$disabled_features" ]; then
+        export DOLT_REMOTESAPI_DISABLED_FEATURES="$disabled_features"
+    else
+        unset DOLT_REMOTESAPI_DISABLED_FEATURES
+    fi
     mkdir remote
     mkdir cloned
     cd remote
@@ -61,7 +67,21 @@ stop_remotesrv() {
     [[ "$output" =~ "10" ]] || false
 }
 
-@test "remotesrv: can write to remotesrv in repo-mode" {
+@test "remotesrv: can read from remotesrv in repo-mode, new RPC" {
+    _do_read_from_remotesrv_repo_mode_scenario ""
+}
+
+@test "remotesrv: can read from remotesrv in repo-mode, legacy RPC" {
+    _do_read_from_remotesrv_repo_mode_scenario "FEATURE_STREAM_CHUNK_LOCATIONS"
+}
+
+_do_write_to_remotesrv_repo_mode_scenario() {
+    local disabled_features="$1"
+    if [ -n "$disabled_features" ]; then
+        export DOLT_REMOTESAPI_DISABLED_FEATURES="$disabled_features"
+    else
+        unset DOLT_REMOTESAPI_DISABLED_FEATURES
+    fi
     mkdir remote
     mkdir cloned
     cd remote
@@ -86,6 +106,14 @@ stop_remotesrv() {
     dolt reset --hard
     run dolt sql -q 'select count(*) from vals;'
     [[ "$output" =~ "5" ]] || false
+}
+
+@test "remotesrv: can write to remotesrv in repo-mode, new RPC" {
+    _do_write_to_remotesrv_repo_mode_scenario ""
+}
+
+@test "remotesrv: can write to remotesrv in repo-mode, legacy RPC" {
+    _do_write_to_remotesrv_repo_mode_scenario "FEATURE_STREAM_CHUNK_LOCATIONS"
 }
 
 @test "remotesrv: pushing new branch to remotesrv does not create new working set" {
@@ -176,7 +204,13 @@ stop_remotesrv() {
     [[ "$status" != 0 ]] || false
 }
 
-@test "remotesrv: can run grpc and http on same port" {
+_do_grpc_and_http_same_port_scenario() {
+    local disabled_features="$1"
+    if [ -n "$disabled_features" ]; then
+        export DOLT_REMOTESAPI_DISABLED_FEATURES="$disabled_features"
+    else
+        unset DOLT_REMOTESAPI_DISABLED_FEATURES
+    fi
     mkdir remote
     mkdir cloned
     cd remote
@@ -190,4 +224,12 @@ stop_remotesrv() {
 
     cd ../cloned
     dolt clone http://localhost:1234/test-org/test-repo repo1
+}
+
+@test "remotesrv: can run grpc and http on same port, new RPC" {
+    _do_grpc_and_http_same_port_scenario ""
+}
+
+@test "remotesrv: can run grpc and http on same port, legacy RPC" {
+    _do_grpc_and_http_same_port_scenario "FEATURE_STREAM_CHUNK_LOCATIONS"
 }

--- a/integration-tests/bats/sql-server-remotesrv.bats
+++ b/integration-tests/bats/sql-server-remotesrv.bats
@@ -28,7 +28,13 @@ teardown() {
     teardown_common
 }
 
-@test "sql-server-remotesrv: can read from sql-server with --remotesapi-port" {
+_do_read_from_sql_server_remotesapi_port_scenario() {
+    local disabled_features="$1"
+    if [ -n "$disabled_features" ]; then
+        export DOLT_REMOTESAPI_DISABLED_FEATURES="$disabled_features"
+    else
+        unset DOLT_REMOTESAPI_DISABLED_FEATURES
+    fi
     mkdir -p db/remote
     cd db/remote
     dolt init
@@ -60,9 +66,23 @@ call dolt_commit('-am', 'add some vals');
     [[ "$output" =~ "10" ]] || false
 }
 
+@test "sql-server-remotesrv: can read from sql-server with --remotesapi-port, new RPC" {
+    _do_read_from_sql_server_remotesapi_port_scenario ""
+}
+
+@test "sql-server-remotesrv: can read from sql-server with --remotesapi-port, legacy RPC" {
+    _do_read_from_sql_server_remotesapi_port_scenario "FEATURE_STREAM_CHUNK_LOCATIONS"
+}
+
 # Asserts we can use dolt_checkout() to check out a new branch that was pushed to a running
 # sql-server, and that the branch has a valid, writeable working set.
-@test "sql-server-remotesrv: can checkout a new branch pushed to a sql-server remote" {
+_do_checkout_new_branch_pushed_to_sql_server_scenario() {
+    local disabled_features="$1"
+    if [ -n "$disabled_features" ]; then
+        export DOLT_REMOTESAPI_DISABLED_FEATURES="$disabled_features"
+    else
+        unset DOLT_REMOTESAPI_DISABLED_FEATURES
+    fi
     mkdir -p db/remote
     cd db/remote
     dolt init
@@ -85,6 +105,14 @@ CREATE TABLE t123 (pk int primary key);
 SELECT 'abcdefg';"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "abcdefg" ]] || false
+}
+
+@test "sql-server-remotesrv: can checkout a new branch pushed to a sql-server remote, new RPC" {
+    _do_checkout_new_branch_pushed_to_sql_server_scenario ""
+}
+
+@test "sql-server-remotesrv: can checkout a new branch pushed to a sql-server remote, legacy RPC" {
+    _do_checkout_new_branch_pushed_to_sql_server_scenario "FEATURE_STREAM_CHUNK_LOCATIONS"
 }
 
 @test "sql-server-remotesrv: pushing a new branch creates a working set" {

--- a/proto/dolt/services/remotesapi/v1alpha1/chunkstore.proto
+++ b/proto/dolt/services/remotesapi/v1alpha1/chunkstore.proto
@@ -32,6 +32,10 @@ service ChunkStoreService {
   // Get the download locations for a list of chunk hashes. Streaming to
   // support large and incrementally available payloads. Results are generated
   // as requests come in.
+  //
+  // Deprecated: prefer StreamChunkLocations, which deduplicates
+  // table-file metadata across the stream. Kept on the wire
+  // indefinitely so old clients continue to work.
   rpc StreamDownloadLocations(stream GetDownloadLocsRequest) returns (stream GetDownloadLocsResponse);
 
   // Get the download locations for a list of chunk hashes. Streaming

--- a/proto/dolt/services/remotesapi/v1alpha1/chunkstore.proto
+++ b/proto/dolt/services/remotesapi/v1alpha1/chunkstore.proto
@@ -155,7 +155,13 @@ message StreamChunkLocationsRequest {
   string repo_token = 2;
   string repo_path = 3;
 
-  repeated bytes chunk_hashes = 4;
+  // Flat, packed buffer of 20-byte chunk hashes: hash N occupies
+  // bytes [N*20 : (N+1)*20]. Not a |repeated bytes| because every
+  // element is exactly 20 bytes and the 2-byte per-element
+  // tag/length overhead of |repeated bytes| is ~10% of the whole
+  // request in a 512-hash batch. Servers MUST reject requests
+  // where len(chunk_hashes) is not a multiple of 20.
+  bytes chunk_hashes = 4;
 }
 
 message StreamChunkLocationsResponse {
@@ -195,11 +201,10 @@ message StreamChunkLocationsResponse {
     // as this ChunkLocation.
     uint32 table_file_id = 1;
 
-    // Semantic index into the corresponding request's chunk_hashes
-    // |repeated bytes|: a value of N refers to chunk_hashes[N] (the
-    // N'th 20-byte hash element), not to a byte offset within a
-    // flattened hash buffer. Avoids re-transmitting the 20-byte
-    // hash on the wire.
+    // Hash index into the corresponding request's chunk_hashes
+    // buffer: a value of N refers to the N'th 20-byte hash, i.e.
+    // bytes [N*20 : (N+1)*20]. Not a byte offset. Avoids
+    // re-transmitting the 20-byte hash on the wire.
     uint32 request_index = 2;
 
     uint64 offset = 3;
@@ -226,12 +231,11 @@ message StreamChunkLocationsResponse {
   // Response ordering is 1:1 with requests.
   repeated ChunkLocation locations = 3;
 
-  // Semantic indices into the corresponding request's chunk_hashes
-  // |repeated bytes| that the server could not find: i.e., a value
-  // of N here means "chunk_hashes[N] (the N'th 20-byte hash) was not
-  // found," not "the 20-byte run starting at byte offset N was not
-  // found." Sent explicitly so the client does not have to diff
-  // requested vs. returned.
+  // Hash indices into the corresponding request's chunk_hashes
+  // buffer that the server could not find: a value of N here means
+  // the N'th 20-byte hash (bytes [N*20 : (N+1)*20]) was not found.
+  // Not a byte offset. Sent explicitly so the client does not have
+  // to diff requested vs. returned.
   repeated uint32 missing_indexes = 4;
 }
 

--- a/proto/dolt/services/remotesapi/v1alpha1/chunkstore.proto
+++ b/proto/dolt/services/remotesapi/v1alpha1/chunkstore.proto
@@ -34,6 +34,12 @@ service ChunkStoreService {
   // as requests come in.
   rpc StreamDownloadLocations(stream GetDownloadLocsRequest) returns (stream GetDownloadLocsResponse);
 
+  // Get the download locations for a list of chunk hashes. Streaming
+  // variant that deduplicates table-file metadata across the stream.
+  // Preferred over StreamDownloadLocations when the server advertises
+  // FEATURE_STREAM_CHUNK_LOCATIONS in GetRepoMetadataResponse.features.
+  rpc StreamChunkLocations(stream StreamChunkLocationsRequest) returns (stream StreamChunkLocationsResponse);
+
   // Get upload locations for a list of table file hashes.
   // NOTE: We upload full table files but download individual chunks.
   rpc GetUploadLocations(GetUploadLocsRequest) returns (GetUploadLocsResponse);
@@ -137,6 +143,98 @@ message GetDownloadLocsResponse {
   string repo_token = 2;
 }
 
+message StreamChunkLocationsRequest {
+  // Every request must populate RepoId/repo_token/repo_path on the
+  // wire. This matches what the current StreamDownloadLocations
+  // client already does and is load-bearing for retry correctness:
+  // the reliable-RPC layer may tear down the underlying gRPC stream
+  // and replay any unacked requests against a freshly opened stream,
+  // so the server must never need prior in-stream state to interpret
+  // a request.
+  RepoId repo_id = 1;
+  string repo_token = 2;
+  string repo_path = 3;
+
+  repeated bytes chunk_hashes = 4;
+}
+
+message StreamChunkLocationsResponse {
+  // TableFileRecord and ChunkLocation are nested inside the response
+  // rather than free-standing at package level. Their invariants
+  // (table_file_id is stream-scoped; request_index is scoped to one
+  // request's chunk_hashes) only hold in the context of this
+  // response.
+  message TableFileRecord {
+    // Opaque id assigned by the server, scoped to the current
+    // server-side stream. The server MUST emit a TableFileRecord
+    // for any id on its first use within a given server-side
+    // stream, before (or in the same response as) any
+    // ChunkLocation that references the id. Clients MUST overwrite
+    // any prior entry for the same id when a new TableFileRecord
+    // arrives.
+    uint32 table_file_id = 1;
+
+    // Signed URL the client should issue byte-range requests
+    // against.
+    string url = 2;
+
+    // When the client should consider |url| stale and call
+    // RefreshTableFileUrl.
+    google.protobuf.Timestamp refresh_after = 3;
+
+    // The file_id to use when calling RefreshTableFileUrl. All the
+    // other fields of RefreshTableFileUrlRequest (repo_id,
+    // repo_token, repo_path) are already known to the client.
+    string file_id = 4;
+  }
+
+  message ChunkLocation {
+    // Refers to a TableFileRecord.table_file_id introduced in the
+    // current server-side stream -- either in an earlier response
+    // message on this same stream, or in the same response message
+    // as this ChunkLocation.
+    uint32 table_file_id = 1;
+
+    // Semantic index into the corresponding request's chunk_hashes
+    // |repeated bytes|: a value of N refers to chunk_hashes[N] (the
+    // N'th 20-byte hash element), not to a byte offset within a
+    // flattened hash buffer. Avoids re-transmitting the 20-byte
+    // hash on the wire.
+    uint32 request_index = 2;
+
+    uint64 offset = 3;
+    uint32 length = 4;
+
+    // zStd dictionary span within the same table file. Same
+    // semantics as the existing RangeChunk.dictionary_{offset,length}.
+    uint64 dictionary_offset = 5;
+    uint32 dictionary_length = 6;
+  }
+
+  // If non-empty, advertises a new repo_token that the client should
+  // use on future requests on this service.
+  string repo_token = 1;
+
+  // Zero or more table-file records introduced by this response.
+  // Valid for the remainder of this server-side stream. Clients MUST
+  // integrate these into their table_file_id map (inserting or
+  // overwriting) before resolving any |locations| in this same
+  // response.
+  repeated TableFileRecord table_files = 2;
+
+  // Chunk locations for the hashes in the corresponding request.
+  // Response ordering is 1:1 with requests.
+  repeated ChunkLocation locations = 3;
+
+  // Semantic indices into the corresponding request's chunk_hashes
+  // |repeated bytes| that the server could not find: i.e., a value
+  // of N here means "chunk_hashes[N] (the N'th 20-byte hash) was not
+  // found," not "the 20-byte run starting at byte offset N was not
+  // found." Sent explicitly so the client does not have to diff
+  // requested vs. returned.
+  repeated uint32 missing_indexes = 4;
+}
+
 message TableFileDetails {
   bytes id = 1;
   uint64 content_length = 2;
@@ -233,6 +331,27 @@ enum PushConcurrencyControl {
   PUSH_CONCURRENCY_CONTROL_ASSERT_WORKING_SET = 2;
 }
 
+// Optional, additive capability flags advertised by the server in
+// GetRepoMetadataResponse.features. Use this for pure "does the
+// server implement X?" booleans. Mode selectors with more than two
+// states (such as the existing PushConcurrencyControl) keep their
+// own typed fields; this list is only for flag-shaped capabilities.
+//
+// Guidelines for growth:
+// - Add new values at the end; never reuse a removed value's
+//   number. If a feature is retired, reserve its number rather
+//   than re-purposing it.
+// - FEATURE_UNSPECIFIED = 0 is never sent; presence of the zero
+//   value in a received list should be ignored by the client.
+enum Feature {
+  FEATURE_UNSPECIFIED = 0;
+
+  // Server implements the StreamChunkLocations RPC. Clients should
+  // prefer it to StreamDownloadLocations when this feature is
+  // present.
+  FEATURE_STREAM_CHUNK_LOCATIONS = 1;
+}
+
 message GetRepoMetadataResponse {
   // Version string of the noms binary format for this repository.
   // See types.NomsBinFormat.
@@ -247,6 +366,11 @@ message GetRepoMetadataResponse {
   string repo_token = 4;
 
   PushConcurrencyControl push_concurrency_control = 5;
+
+  // Optional capability flags advertised by the server. See the
+  // Feature enum above. Order is not significant; duplicates
+  // should be treated the same as a single occurrence.
+  repeated Feature features = 6;
 }
 
 message ClientRepoFormat {


### PR DESCRIPTION
The current streaming RPC, `StreamDownloadLocations`, was a straight translation of the unary RPC `GetDownloadLocations`. We added streaming because it found it interacted much better with TCP and HTTP/2 window scaling. At the time, the RPCs were no reworked to take advantage of the stateful nature of the stream. Since then, the pipelined ChunkFetcher machinery has been added, which makes opportunities for reuse on the individual streaming RPC even better. We also added the `RefreshTableFileUrl` endpoint, which decouples a client's ability to continue using previously communicated table files from its need to see them in a GetDownloadLocsResponse in particular.

`StreamChunkLocations` is transiting the exact same semantic payloads as `StreamDownloadLocations`. It's just not re-transmitting a bunch of stuff it does not need to. In particular:

1) We transit table file URLs separately from the chunk locations. A table_file_id is assigned to a table file the first time the server tells the client about it. Then that same table_file_id is used to refer to that table file for all communicated chunk locations in all response messages on the same stream.

2) We do not re-transit chunk hashes. The responses refer to the chunk hashes which were provided in the corresponding request by index. The client already knows them.

3) We do not need to transit `RefreshTableFileUrlRequest` messages for the table files. The client can build these with its own knowledge.

Those are three major improvements for bandwidth utilization. There are also some smaller things, like sending `chunk_hashes` as `bytes` instead of `repeated bytes`.

This PR adds a `features` field in `GetRepoMetadataResponse`. That field lets a client know that it can call the new available endpoint. Otherwise the client continues calling `StreamDownloadLocations`.

This PR adds both server-side and client-side implementations for the new endpoint. The server-side implementation ends up looking a lot like the existing `StreamDownloadLocations` code. It keeps some local maps so it can include the appropriate reference ids in the outgoing messages. The client-side implementation intentionally remains about as minimal as possible. In particular, it does not touch range coalescing or most aspects of the fetch pipeline. It targets just generating the `StreamChunkLocationsRequest` and handling the `StreamChunkLocationsResponse` messages. It translates the responses back into what StreamDownloadLocations would have generated before handing those pieces off to the rest of the fetch pipeline.

In addition to unit tests, some machinery in `remotesrv` is updated so we can optionally disable advertising support for `StreamChunkLocations`. This allows us to update some integration tests so that they continue to exercise the `StreamDownloadLocations` code paths on both the client and the server.