### PR TITLE
Sort adaptive encoding columns by size for out-of-band storage

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/blob_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/blob_queries.go
@@ -58,12 +58,26 @@ const (
 	AdaptiveEncodingTestType_Text
 )
 
+func (a AdaptiveEncodingTestColumnType) String() string {
+	if a == AdaptiveEncodingTestType_Blob {
+		return "Blob"
+	}
+	return "Text"
+}
+
 type AdaptiveEncodingTestPurpose byte
 
 const (
 	AdaptiveEncodingTestPurpose_Representation AdaptiveEncodingTestPurpose = iota
 	AdaptiveEncodingTestPurpose_Correctness
 )
+
+func (a AdaptiveEncodingTestPurpose) String() string {
+	if a == AdaptiveEncodingTestPurpose_Representation {
+		return "Representation"
+	}
+	return "Correctness"
+}
 
 func MakeBigAdaptiveEncodingQueriesSetup(columnType AdaptiveEncodingTestColumnType) []setup.SetupScript {
 	var typename string
@@ -154,13 +168,13 @@ func MakeBigAdaptiveEncodingQueries(columnType AdaptiveEncodingTestColumnType, t
 			WrapBehavior: wrapBehavior,
 		},
 		{
-			// When a tuple with multiple adaptive columns is too large, columns are moved out-of-band from left to right.
+			// When a tuple with multiple adaptive columns is too large, columns are moved out-of-band from largest to smallest.
 			// However, strings smaller than the address size (20 bytes) are never stored out-of-band.
 			Query:        "select i, b1, b2 from blobt2",
 			WrapBehavior: wrapBehavior,
 			Expected: []sql.Row{
 				{"FF", fullSizeOutOfLineRepr, fullSizeOutOfLineRepr},
-				{"HF", halfSizeOutOfLineRepr, fullSizeOutOfLineRepr},
+				{"HF", halfSize, fullSizeOutOfLineRepr},
 				{"TF", tiny, fullSizeOutOfLineRepr},
 				{"NF", nil, fullSizeOutOfLineRepr},
 				{"FH", fullSizeOutOfLineRepr, halfSize},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_tests.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_tests.go
@@ -348,11 +348,13 @@ func RunBigBlobsTest(t *testing.T, h DoltEnginetestHarness) {
 
 func RunTestAdaptiveEncoding(t *testing.T, h DoltEnginetestHarness, columnType AdaptiveEncodingTestColumnType, testPurpose AdaptiveEncodingTestPurpose) {
 	defer h.Close()
-	h.Setup(setup.MydbData, MakeBigAdaptiveEncodingQueriesSetup(columnType))
-	enginetest.RunQueryTests(t, h, MakeBigAdaptiveEncodingQueries(columnType, testPurpose))
-	for _, tt := range MakeBigAdaptiveEncodingWriteQueries(columnType, testPurpose) {
-		enginetest.RunWriteQueryTest(t, h, tt)
-	}
+	t.Run(fmt.Sprintf("%v, %v", columnType, testPurpose), func(t *testing.T) {
+		h.Setup(setup.MydbData, MakeBigAdaptiveEncodingQueriesSetup(columnType))
+		enginetest.RunQueryTests(t, h, MakeBigAdaptiveEncodingQueries(columnType, testPurpose))
+		for _, tt := range MakeBigAdaptiveEncodingWriteQueries(columnType, testPurpose) {
+			enginetest.RunWriteQueryTest(t, h, tt)
+		}
+	})
 }
 
 func RunDropEngineTest(t *testing.T, h DoltEnginetestHarness) {

--- a/go/store/val/tuple_builder.go
+++ b/go/store/val/tuple_builder.go
@@ -16,6 +16,7 @@ package val
 
 import (
 	"context"
+	"sort"
 	"strconv"
 	"time"
 
@@ -93,6 +94,12 @@ func (tb *TupleBuilder) Build(pool pool.BuffPool) (tup Tuple, err error) {
 	return tb.BuildPermissive(pool)
 }
 
+// adaptiveCandidate represents an adaptive encoding column that could be moved out-of-band.
+type adaptiveCandidate struct {
+	index   int   // column index
+	savings int64 // inlineSize - outOfBandSize (positive means out-of-band is smaller)
+}
+
 // BuildPermissive materializes a Tuple from the fields
 // written to the TupleBuilder without validating nullability.
 func (tb *TupleBuilder) BuildPermissive(pool pool.BuffPool) (tup Tuple, err error) {
@@ -104,7 +111,9 @@ func (tb *TupleBuilder) BuildPermissive(pool pool.BuffPool) (tup Tuple, err erro
 	// Then use this to determine which values need to be stored out of band.
 	totalSize := tb.inlineSize
 	if totalSize > tb.tupleLengthTarget {
-		// We're above the size limit, begin converting to out-of-band storage.
+		// Collect all adaptive columns that would benefit from out-of-band storage,
+		// then sort by savings descending so we move the largest values out-of-band first.
+		var candidates []adaptiveCandidate
 		for i, descType := range tb.Desc.Types {
 			if IsAdaptiveEncoding(descType.Enc) {
 				adaptiveValue := AdaptiveValue(tb.fields[i])
@@ -113,36 +122,48 @@ func (tb *TupleBuilder) BuildPermissive(pool pool.BuffPool) (tup Tuple, err erro
 				}
 				outOfBandSize := adaptiveValue.outOfBandSize()
 				inlineSize := adaptiveValue.inlineSize()
-
-				// We only store a field out-of-band if it makes the tuple shorter.
-				if outOfBandSize < inlineSize {
-					if !adaptiveValue.IsOutOfBand() {
-						outOfBandValue, err := adaptiveValue.convertToOutOfBand(ctx, tb.vs, nil)
-						if err != nil {
-							return nil, err
-						}
-						tb.PutRaw(i, outOfBandValue)
-					}
-
-					totalSize += outOfBandSize - inlineSize
+				savings := inlineSize - outOfBandSize
+				if savings > 0 {
+					candidates = append(candidates, adaptiveCandidate{index: i, savings: savings})
 				}
 			}
+		}
 
-			if totalSize <= tb.tupleLengthTarget {
-				// We have enough space, mark all the remaining columns as inline
-				for j, descType := range tb.Desc.Types[i+1:] {
-					if IsAdaptiveEncoding(descType.Enc) {
-						adaptiveValue := AdaptiveValue(tb.fields[j+i+1])
-						if adaptiveValue.IsOutOfBand() {
-							inline, err := adaptiveValue.convertToInline(ctx, tb.vs, nil)
-							if err != nil {
-								return nil, err
-							}
-							tb.PutRaw(j+i+1, inline)
-						}
-					}
+		// Sort candidates by savings descending (largest values first).
+		// Use stable sort to preserve column order for equal-sized values.
+		sort.SliceStable(candidates, func(a, b int) bool {
+			return candidates[a].savings > candidates[b].savings
+		})
+
+		// Convert to out-of-band in order of largest savings until we're under the target.
+		outOfBandSet := make(map[int]bool)
+		for _, c := range candidates {
+			adaptiveValue := AdaptiveValue(tb.fields[c.index])
+			if !adaptiveValue.IsOutOfBand() {
+				outOfBandValue, err := adaptiveValue.convertToOutOfBand(ctx, tb.vs, nil)
+				if err != nil {
+					return nil, err
 				}
+				tb.PutRaw(c.index, outOfBandValue)
+			}
+			outOfBandSet[c.index] = true
+			totalSize -= c.savings
+			if totalSize <= tb.tupleLengthTarget {
 				break
+			}
+		}
+
+		// Ensure any remaining adaptive columns that were not selected for out-of-band are inline.
+		for i, descType := range tb.Desc.Types {
+			if IsAdaptiveEncoding(descType.Enc) && !outOfBandSet[i] {
+				adaptiveValue := AdaptiveValue(tb.fields[i])
+				if adaptiveValue.IsOutOfBand() {
+					inline, err := adaptiveValue.convertToInline(ctx, tb.vs, nil)
+					if err != nil {
+						return nil, err
+					}
+					tb.PutRaw(i, inline)
+				}
 			}
 		}
 	}

--- a/go/store/val/tuple_builder.go
+++ b/go/store/val/tuple_builder.go
@@ -94,12 +94,6 @@ func (tb *TupleBuilder) Build(pool pool.BuffPool) (tup Tuple, err error) {
 	return tb.BuildPermissive(pool)
 }
 
-// adaptiveCandidate represents an adaptive encoding column that could be moved out-of-band.
-type adaptiveCandidate struct {
-	index   int   // column index
-	savings int64 // inlineSize - outOfBandSize (positive means out-of-band is smaller)
-}
-
 // BuildPermissive materializes a Tuple from the fields
 // written to the TupleBuilder without validating nullability.
 func (tb *TupleBuilder) BuildPermissive(pool pool.BuffPool) (tup Tuple, err error) {
@@ -109,6 +103,11 @@ func (tb *TupleBuilder) BuildPermissive(pool pool.BuffPool) (tup Tuple, err erro
 	// In the best case, we don't need to convert any of them, so the TupleBuilder initially stores them in the form they're given.
 	// But we track the tuple size if they're all inlined vs the tuple size if they're all out-of-band,
 	// Then use this to determine which values need to be stored out of band.
+
+	type adaptiveCandidate struct {
+		columnIndex int
+		savings     int64 // inlineSize - outOfBandSize
+	}
 	totalSize := tb.inlineSize
 	if totalSize > tb.tupleLengthTarget {
 		// Collect all adaptive columns that would benefit from out-of-band storage,
@@ -124,7 +123,7 @@ func (tb *TupleBuilder) BuildPermissive(pool pool.BuffPool) (tup Tuple, err erro
 				inlineSize := adaptiveValue.inlineSize()
 				savings := inlineSize - outOfBandSize
 				if savings > 0 {
-					candidates = append(candidates, adaptiveCandidate{index: i, savings: savings})
+					candidates = append(candidates, adaptiveCandidate{columnIndex: i, savings: savings})
 				}
 			}
 		}
@@ -138,15 +137,15 @@ func (tb *TupleBuilder) BuildPermissive(pool pool.BuffPool) (tup Tuple, err erro
 		// Convert to out-of-band in order of largest savings until we're under the target.
 		outOfBandSet := make(map[int]bool)
 		for _, c := range candidates {
-			adaptiveValue := AdaptiveValue(tb.fields[c.index])
+			adaptiveValue := AdaptiveValue(tb.fields[c.columnIndex])
 			if !adaptiveValue.IsOutOfBand() {
 				outOfBandValue, err := adaptiveValue.convertToOutOfBand(ctx, tb.vs, nil)
 				if err != nil {
 					return nil, err
 				}
-				tb.PutRaw(c.index, outOfBandValue)
+				tb.PutRaw(c.columnIndex, outOfBandValue)
 			}
-			outOfBandSet[c.index] = true
+			outOfBandSet[c.columnIndex] = true
 			totalSize -= c.savings
 			if totalSize <= tb.tupleLengthTarget {
 				break

--- a/go/store/val/tuple_builder_test.go
+++ b/go/store/val/tuple_builder_test.go
@@ -321,8 +321,9 @@ func TestTupleBuilderAdaptiveEncodings(t *testing.T) {
 		td := NewTupleDescriptor(types...)
 		tb := NewTupleBuilder(td, vs)
 
-		t.Run("inline one of two columns", func(t *testing.T) {
-			// In this test, the strings are sized such that one is stored out-of-band and the other can be stored inline.
+		t.Run("inline larger of two columns", func(t *testing.T) {
+			// In this test, only one of two equally sized columns needs to be stored out of band.
+			// Only the first column should be stored out-of-band.
 
 			columnSize := defaultTupleLengthTarget / 2
 			mediumByteArray := make([]byte, columnSize)
@@ -352,21 +353,6 @@ func TestTupleBuilderAdaptiveEncodings(t *testing.T) {
 				require.Equal(t, mediumByteArray, adaptiveEncodingByteArray)
 			}
 		})
-	}
-
-	{
-		// Test that the largest value is moved out-of-band first, regardless of column order.
-		// Column 0 has a small value and column 1 has a large value.
-		// Only one needs to go out-of-band to fit under the target.
-		// The builder should pick column 1 (the larger one) to go out-of-band,
-		// keeping column 0 inline.
-		types := []Type{
-			{Enc: BytesAdaptiveEnc},
-			{Enc: BytesAdaptiveEnc},
-		}
-		vs := &TestValueStore{}
-		td := NewTupleDescriptor(types...)
-		tb := NewTupleBuilder(td, vs)
 
 		t.Run("largest value moved out-of-band first", func(t *testing.T) {
 			// Column 0: small value (1/4 of the target)

--- a/go/store/val/tuple_builder_test.go
+++ b/go/store/val/tuple_builder_test.go
@@ -322,7 +322,7 @@ func TestTupleBuilderAdaptiveEncodings(t *testing.T) {
 		tb := NewTupleBuilder(td, vs)
 
 		t.Run("inline one of two columns", func(t *testing.T) {
-			// In this test, the strings are sized such that the first is stored out-of-band but the second can be stored inline.
+			// In this test, the strings are sized such that one is stored out-of-band and the other can be stored inline.
 
 			columnSize := defaultTupleLengthTarget / 2
 			mediumByteArray := make([]byte, columnSize)
@@ -350,6 +350,115 @@ func TestTupleBuilderAdaptiveEncodings(t *testing.T) {
 				require.NoError(t, err)
 				adaptiveEncodingByteArray := adaptiveEncodingBytes.([]byte)
 				require.Equal(t, mediumByteArray, adaptiveEncodingByteArray)
+			}
+		})
+	}
+
+	{
+		// Test that the largest value is moved out-of-band first, regardless of column order.
+		// Column 0 has a small value and column 1 has a large value.
+		// Only one needs to go out-of-band to fit under the target.
+		// The builder should pick column 1 (the larger one) to go out-of-band,
+		// keeping column 0 inline.
+		types := []Type{
+			{Enc: BytesAdaptiveEnc},
+			{Enc: BytesAdaptiveEnc},
+		}
+		vs := &TestValueStore{}
+		td := NewTupleDescriptor(types...)
+		tb := NewTupleBuilder(td, vs)
+
+		t.Run("largest value moved out-of-band first", func(t *testing.T) {
+			// Column 0: small value (1/4 of the target)
+			// Column 1: large value (the full target)
+			// Combined inline size exceeds the target, but only moving column 1
+			// out-of-band is sufficient to fit.
+			smallByteArray := make([]byte, defaultTupleLengthTarget/4)
+			largeByteArray := make([]byte, defaultTupleLengthTarget)
+			err := tb.PutAdaptiveBytesFromInline(ctx, 0, smallByteArray)
+			require.NoError(t, err)
+			err = tb.PutAdaptiveBytesFromInline(ctx, 1, largeByteArray)
+			require.NoError(t, err)
+
+			tup, err := tb.Build(testPool)
+			require.NoError(t, err)
+
+			{
+				// Column 0 (small) should be stored inline
+				adaptiveEncodingBytes, _, err := td.GetBytesAdaptiveValue(ctx, 0, vs, tup)
+				require.NoError(t, err)
+				adaptiveEncodingByteArray := adaptiveEncodingBytes.([]byte)
+				require.Equal(t, smallByteArray, adaptiveEncodingByteArray)
+			}
+
+			{
+				// Column 1 (large) should be stored out-of-band
+				adaptiveEncodingBytes, _, err := td.GetBytesAdaptiveValue(ctx, 1, vs, tup)
+				require.NoError(t, err)
+				adaptiveEncodingByteArray := adaptiveEncodingBytes.(*ByteArray)
+				outBytes, err := adaptiveEncodingByteArray.ToBytes(ctx)
+				require.NoError(t, err)
+				require.Equal(t, largeByteArray, outBytes)
+			}
+		})
+	}
+
+	{
+		// Test with three columns of varying sizes: the builder should move the
+		// largest values out-of-band first and keep the smallest inline.
+		types := []Type{
+			{Enc: BytesAdaptiveEnc},
+			{Enc: BytesAdaptiveEnc},
+			{Enc: BytesAdaptiveEnc},
+		}
+		vs := &TestValueStore{}
+		td := NewTupleDescriptor(types...)
+		tb := NewTupleBuilder(td, vs)
+
+		t.Run("three columns largest first ordering", func(t *testing.T) {
+			// Column 0: medium value (1/3 of target)
+			// Column 1: small value (1/4 of target)
+			// Column 2: large value (3/4 of target)
+			// Combined they exceed the target. Moving only column 2 (largest) out-of-band
+			// should be enough. Column 0 and 1 should remain inline.
+			smallByteArray := make([]byte, defaultTupleLengthTarget/4)
+			mediumByteArray := make([]byte, defaultTupleLengthTarget/3)
+			largeByteArray := make([]byte, defaultTupleLengthTarget*3/4)
+
+			err := tb.PutAdaptiveBytesFromInline(ctx, 0, mediumByteArray)
+			require.NoError(t, err)
+			err = tb.PutAdaptiveBytesFromInline(ctx, 1, smallByteArray)
+			require.NoError(t, err)
+			err = tb.PutAdaptiveBytesFromInline(ctx, 2, largeByteArray)
+			require.NoError(t, err)
+
+			tup, err := tb.Build(testPool)
+			require.NoError(t, err)
+
+			{
+				// Column 0 (medium) should be inline
+				adaptiveEncodingBytes, _, err := td.GetBytesAdaptiveValue(ctx, 0, vs, tup)
+				require.NoError(t, err)
+				_, ok := adaptiveEncodingBytes.([]byte)
+				require.True(t, ok, "column 0 should be stored inline")
+			}
+
+			{
+				// Column 1 (small) should be inline
+				adaptiveEncodingBytes, _, err := td.GetBytesAdaptiveValue(ctx, 1, vs, tup)
+				require.NoError(t, err)
+				_, ok := adaptiveEncodingBytes.([]byte)
+				require.True(t, ok, "column 1 should be stored inline")
+			}
+
+			{
+				// Column 2 (large) should be out-of-band
+				adaptiveEncodingBytes, _, err := td.GetBytesAdaptiveValue(ctx, 2, vs, tup)
+				require.NoError(t, err)
+				adaptiveEncodingByteArray := adaptiveEncodingBytes.(*ByteArray)
+				outBytes, err := adaptiveEncodingByteArray.ToBytes(ctx)
+				require.NoError(t, err)
+				require.Equal(t, largeByteArray, outBytes)
 			}
 		})
 	}


### PR DESCRIPTION
Note: This will currently change how we write rows with adaptive encoding columns. Rows written on older versions of Dolt can still be read, but writing them back will result in a new chunk hash. But since Dolt currently doesn't use adaptive encoding and Doltgres is in beta, that's acceptable.

Claude's Summary

  - BuildPermissive now sorts adaptive encoding columns by size savings (largest first) before deciding which to move out-of-band, instead of visiting columns in sequential order
  - This keeps smaller values inline when possible, producing shorter tuples when columns have varying sizes
  - Added two new test cases verifying the largest-first ordering with 2 and 3 columns of different sizes

  Test plan

  - Existing TestTupleBuilderAdaptiveEncodings tests pass (including inline one of two columns)
  - New test largest value moved out-of-band first: two columns where column 0 is small and column 1 is large — verifies column 1 goes out-of-band while column 0 stays inline
  - New test three columns largest first ordering: three columns (medium, small, large) — verifies only the largest goes out-of-band
  - Full store/val package tests pass