### PR TITLE
[no-release-notes] Add tests for invalid UTF-8 import

### DIFF
--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -107,7 +107,7 @@ The schema for the new table can be specified explicitly by providing a SQL sche
 
 If {{.EmphasisLeft}}--update-table | -u{{.EmphasisRight}} is given the operation will update {{.LessThan}}table{{.GreaterThan}} with the contents of file. The table's existing schema will be used, and field names will be used to match file fields with table fields unless a mapping file is specified.
 
-If {{.EmphasisLeft}}--append-table | -a{{.EmphasisRight}} is given the operation will add the contents of the file to {{.LessThan}}table{{.GreaterThan}}, without modifying any of the rows of {{.LessThan}}table{{.GreaterThan}}. If the file contains a row that matches the primary key of a row already in the table, the import will be aborted unless the --continue flag is used (in which case that row will not be imported.) The table's existing schema will be used, and field names will be used to match file fields with table fields unless a mapping file is specified.
+If {{.EmphasisLeft}}--append-table | -a{{.EmphasisRight}} is given the operation will add the contents of the file to {{.LessThan}}table{{.GreaterThan}}, without modifying any of the rows of {{.LessThan}}table{{.GreaterThan}}. If the file contains a row that matches the primary key of a row already in the table, the import will be aborted unless the --continue flag is used. The table's existing schema will be used, and field names will be used to match file fields with table fields unless a mapping file is specified.
 
 If {{.EmphasisLeft}}--replace-table | -r{{.EmphasisRight}} is given the operation will replace {{.LessThan}}table{{.GreaterThan}} with the contents of the file. The table's existing schema will be used, and field names will be used to match file fields with table fields unless a mapping file is specified.
 
@@ -115,7 +115,7 @@ If the schema for the existing table does not match the schema for the new file,
 
 A mapping file can be used to map fields between the file being imported and the table being written to. This can be used when creating a new table, or updating or replacing an existing table.
 
-During import, if there is an error importing any row, the import will be aborted by default. Use the {{.EmphasisLeft}}--continue{{.EmphasisRight}} flag to continue importing when an error is encountered. You can add the {{.EmphasisLeft}}--quiet{{.EmphasisRight}} flag to prevent the import utility from printing all the skipped rows. 
+During import, if there is an error importing any row, the import will be aborted by default. Use the {{.EmphasisLeft}}--continue{{.EmphasisRight}} flag to continue importing when an error is encountered. You can add the {{.EmphasisLeft}}--quiet{{.EmphasisRight}} flag to prevent the import utility from printing all warnings.
 
 ` + schcmds.MappingFileHelp +
 		`

--- a/integration-tests/bats/import-create-tables.bats
+++ b/integration-tests/bats/import-create-tables.bats
@@ -460,6 +460,25 @@ DELIM
     diff compare.csv `batshelper bad-characters.csv`
 }
 
+@test "import-create-tables: import csv with invalid utf8" {
+    # See https://github.com/dolthub/dolt/issues/10924
+    # With --continue, invalid UTF-8 bytes are truncated at the first bad byte matching MySQL behavior.
+    dolt sql -q "CREATE TABLE t (id int NOT NULL, name VARCHAR(255), PRIMARY KEY (id));"
+    cat > data.csv <<EOF
+id,name
+1,"SSD 1TB 2.5$(printf '\x85') NVMe"
+2,"Normal Product"
+EOF
+    run dolt table import -u t data.csv
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "Incorrect string value" ]] || false
+    run dolt table import -u --continue t data.csv
+    [ "$status" -eq 0 ]
+    run dolt sql -r csv -q "SELECT name FROM t WHERE id = 1"
+    [ "$status" -eq 0 ]
+    [ "${lines[1]}" = "SSD 1TB 2.5" ]
+}
+
 @test "import-create-tables: dolt diff on a newly created table" {
     dolt sql <<SQL
 CREATE TABLE test (

--- a/integration-tests/bats/import-update-tables.bats
+++ b/integration-tests/bats/import-update-tables.bats
@@ -1662,3 +1662,22 @@ DELIM
     [ "${lines[1]}" = "1,6" ]
     [ "${lines[2]}" = "2,2" ]
 }
+
+@test "import-update-tables: import csv with invalid utf8" {
+    # See https://github.com/dolthub/dolt/issues/10924
+    # With --continue, invalid UTF-8 bytes are truncated at the first bad byte matching MySQL behavior.
+    dolt sql -q "CREATE TABLE item (id VARCHAR(10) NOT NULL, name VARCHAR(255), PRIMARY KEY (id));"
+    cat > data.csv <<EOF
+id,name
+ITEM1,"Cable 10m"
+ITEM2,"SSD 1TB 2.5$(printf '\x85') NVMe"
+EOF
+    run dolt table import -u item data.csv
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "Incorrect string value" ]] || false
+    run dolt table import -u --continue item data.csv
+    [ "$status" -eq 0 ]
+    run dolt sql -r csv -q "SELECT name FROM item WHERE id = 'ITEM2'"
+    [ "$status" -eq 0 ]
+    [ "${lines[1]}" = "SSD 1TB 2.5" ]
+}


### PR DESCRIPTION
- Updated `--continue` CLI doc to clarify truncation behavior
Fix dolthub/dolt#10924
Depends on dolthub/go-mysql-server#3527