### PR TITLE
key type conversion during foreign key checks

### DIFF
--- a/go/libraries/doltcore/merge/violations_fk_prolly.go
+++ b/go/libraries/doltcore/merge/violations_fk_prolly.go
@@ -404,8 +404,31 @@ func fkHandlersAreSerializationCompatible(keyDescA, keyDescB *val.TupleDesc) boo
 		if handlerA != nil && handlerB != nil && !handlerA.SerializationCompatible(handlerB) {
 			return false
 		}
+		// When both handlers are nil, check that the underlying native encodings are compatible.
+		// Different encodings may have different byte representations for the same logical value
+		// (e.g. StringEnc vs StringAdaptiveEnc). Adaptive encodings also require normalization
+		// because the same value may be stored inline in one context and out-of-band in another.
+		if handlerA == nil && handlerB == nil {
+			if !nativeEncodingsAreSerializationCompatible(keyDescA.Types[i].Enc, keyDescB.Types[i].Enc) {
+				return false
+			}
+		}
 	}
 	return true
+}
+
+// nativeEncodingsAreSerializationCompatible returns true if two fields with the given native
+// encodings (and no type handlers) produce identical byte representations for equal logical
+// values. Adaptive encodings (StringAdaptiveEnc, BytesAdaptiveEnc, etc.) return false even
+// when both sides share the same encoding, because equal values may be stored inline in one
+// tuple and out-of-band in another, resulting in different bytes.
+func nativeEncodingsAreSerializationCompatible(encA, encB val.Encoding) bool {
+	if encA != encB {
+		return false
+	}
+	// Adaptive encodings require normalization even when both sides use the same encoding,
+	// because a value may be stored inline in one tuple and out-of-band in another.
+	return !val.IsAdaptiveEncoding(encA)
 }
 
 // convertSerializedFkField converts a serialized foreign key value from one type handler to another.
@@ -629,9 +652,25 @@ func convertKeyBetweenTypes(
 	pool pool.BuffPool,
 ) (val.Tuple, error) {
 	tb := val.NewTupleBuilder(toKeyDesc, ns)
-	for i, fromHandler := range fromKeyDesc.Handlers {
-		toHandler := toKeyDesc.Handlers[i]
-		serialized, err := convertSerializedFkField(ctx, toHandler, fromHandler, key.GetField(i))
+	for i := range toKeyDesc.Types {
+		var fromHandler, toHandler val.TupleTypeHandler
+		if i < len(fromKeyDesc.Handlers) {
+			fromHandler = fromKeyDesc.Handlers[i]
+		}
+		if i < len(toKeyDesc.Handlers) {
+			toHandler = toKeyDesc.Handlers[i]
+		}
+		field := key.GetField(i)
+
+		// When both handlers are nil, use native encoding conversion logic.
+		if fromHandler == nil && toHandler == nil {
+			if err := convertNativeEncodedFkField(ctx, tb, ns, i, field, fromKeyDesc.Types[i].Enc, toKeyDesc.Types[i].Enc); err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		serialized, err := convertSerializedFkField(ctx, toHandler, fromHandler, field)
 		if err != nil {
 			return nil, err
 		}
@@ -640,17 +679,19 @@ func convertKeyBetweenTypes(
 		case val.AdaptiveEncodingTypeHandler:
 			switch toKeyDesc.Types[i].Enc {
 			case val.ExtendedAdaptiveEnc:
-				err := tb.PutAdaptiveExtendedFromInline(ctx, i, serialized)
-				if err != nil {
+				if err := tb.PutAdaptiveExtendedFromInline(ctx, i, serialized); err != nil {
 					return nil, err
 				}
 			case val.BytesAdaptiveEnc:
-				err := tb.PutAdaptiveExtendedFromInline(ctx, i, serialized)
-				if err != nil {
+				if err := tb.PutAdaptiveBytesFromInline(ctx, i, serialized); err != nil {
+					return nil, err
+				}
+			case val.StringAdaptiveEnc:
+				if err := tb.PutAdaptiveStringFromInline(ctx, i, string(serialized)); err != nil {
 					return nil, err
 				}
 			default:
-				panic(fmt.Sprintf("unexpected encoding for adaptive type: %d", fromKeyDesc.Types[i].Enc))
+				panic(fmt.Sprintf("unexpected encoding for adaptive type: %d", toKeyDesc.Types[i].Enc))
 			}
 		default:
 			tb.PutRaw(i, serialized)
@@ -663,6 +704,72 @@ func convertKeyBetweenTypes(
 		return nil, err
 	}
 	return key, nil
+}
+
+// convertNativeEncodedFkField converts a single FK field between native Dolt encodings (no
+// type handler), writing the result directly into |tb| at position |i|.
+//
+// Supported conversions:
+//   - StringEnc  <-> StringAdaptiveEnc : VARCHAR <-> TEXT
+//   - StringAdaptiveEnc -> StringAdaptiveEnc : normalise out-of-band adaptive values to inline
+//   - BytesAdaptiveEnc  -> BytesAdaptiveEnc  : same normalisation for blob types
+//
+// For any encoding pair not explicitly handled the raw bytes are copied unchanged.
+func convertNativeEncodedFkField(
+	ctx context.Context,
+	tb *val.TupleBuilder,
+	ns tree.NodeStore,
+	i int,
+	field []byte,
+	fromEnc, toEnc val.Encoding,
+) error {
+	// Extract the raw string/byte content from the source encoding.
+	var content []byte
+	switch fromEnc {
+	case val.StringEnc:
+		// StringEnc layout: [string bytes][0x00 terminator]
+		if len(field) == 0 {
+			tb.PutRaw(i, nil)
+			return nil
+		}
+		content = field[:len(field)-1] // strip null terminator
+	case val.StringAdaptiveEnc, val.BytesAdaptiveEnc:
+		adaptiveVal := val.AdaptiveValue(field)
+		if adaptiveVal.IsNull() {
+			tb.PutRaw(i, nil)
+			return nil
+		}
+		if adaptiveVal.IsOutOfBand() {
+			// Resolve out-of-band reference to its inline bytes.
+			handler := val.NewAdaptiveTypeHandler(ns, nil)
+			inline, err := handler.ConvertToInline(ctx, adaptiveVal)
+			if err != nil {
+				return err
+			}
+			content = inline[1:] // strip 0x00 inline header byte
+		} else {
+			content = field[1:] // strip 0x00 inline header byte
+		}
+	default:
+		// No known conversion; copy raw bytes as-is.
+		tb.PutRaw(i, field)
+		return nil
+	}
+
+	// Write content into the target encoding.
+	switch toEnc {
+	case val.StringEnc:
+		// StringEnc layout: [string bytes][0x00 terminator]
+		return tb.PutString(i, string(content))
+	case val.StringAdaptiveEnc:
+		return tb.PutAdaptiveStringFromInline(ctx, i, string(content))
+	case val.BytesAdaptiveEnc:
+		return tb.PutAdaptiveBytesFromInline(ctx, i, content)
+	default:
+		// Unsupported target encoding; copy raw bytes as-is.
+		tb.PutRaw(i, field)
+		return nil
+	}
 }
 
 func makePartialKey(kb *val.TupleBuilder, tags []uint64, idxSch schema.Index, tblSch schema.Schema, k, v val.Tuple, pool pool.BuffPool) (val.Tuple, bool, error) {


### PR DESCRIPTION
This PR adds key type conversion for native encodings (encodings that don't have a TupleTypeHandler) for foreign key enforcement during merge. Postgres, but not MySQL, allows different but compatible types for the columns in foreign key constraints, e.g TEXT and VARCHAR. This means that Doltgres, but not Dolt, needs to sometimes convert the bytes of a tuple value from one encoding to another before an index lookup to determine if a constraint violation exists. Previously all such logic happened with TupleTypeHandler (DoltgresType was the main implementor). But with https://github.com/dolthub/doltgresql/pull/2559, Doltgres is now using Dolt's native encodings where possible, e.g. StringEnc, StringAdaptiveEnc. This means this same logic must now work for these native encodings.

Dolt continues to prevent foreign key constraints from being created between different types, following the MySQL behavior, but with this change we could choose to relax this limitation in the future.