### PR TITLE
go: remotestorage: Stamp our remotesapi ClientCapabilities on outgoing requests.

### DIFF
--- a/go/libraries/doltcore/remotestorage/capabilities.go
+++ b/go/libraries/doltcore/remotestorage/capabilities.go
@@ -1,0 +1,29 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remotestorage
+
+import (
+	remotesapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/remotesapi/v1alpha1"
+)
+
+// clientCapabilities is the set of capabilities this dolt client
+// declares on every outbound remotesapi request that carries a
+// client_capabilities field. Centralized here so the answer to
+// "what does this client advertise?" lives in one place and
+// adding a new capability is a one-line change. Treat as
+// immutable once the package is loaded.
+var clientCapabilities = []remotesapi.ClientCapability{
+	remotesapi.ClientCapability_CLIENT_CAPABILITY_HTTP2_DOWNLOAD,
+}

--- a/go/libraries/doltcore/remotestorage/chunk_fetcher.go
+++ b/go/libraries/doltcore/remotestorage/chunk_fetcher.go
@@ -122,7 +122,7 @@ func NewChunkFetcher(ctx context.Context, dcs *DoltChunkStore) *ChunkFetcher {
 					flat = append(flat, h...)
 				}
 				id, token := dcs.getRepoId()
-				return &remotesapi.StreamChunkLocationsRequest{RepoId: id, RepoPath: dcs.repoPath, RepoToken: token, ChunkHashes: flat}
+				return &remotesapi.StreamChunkLocationsRequest{RepoId: id, RepoPath: dcs.repoPath, RepoToken: token, ChunkHashes: flat, ClientCapabilities: clientCapabilities}
 			})
 		})
 		eg.Go(func() error {
@@ -133,7 +133,7 @@ func NewChunkFetcher(ctx context.Context, dcs *DoltChunkStore) *ChunkFetcher {
 		eg.Go(func() error {
 			return fetcherHashSetToReqsThread(ctx, ret.toGetCh, ret.abortCh, locsReqCh, getLocsBatchSize, func(hashes [][]byte) *remotesapi.GetDownloadLocsRequest {
 				id, token := dcs.getRepoId()
-				return &remotesapi.GetDownloadLocsRequest{RepoId: id, RepoPath: dcs.repoPath, RepoToken: token, ChunkHashes: hashes}
+				return &remotesapi.GetDownloadLocsRequest{RepoId: id, RepoPath: dcs.repoPath, RepoToken: token, ChunkHashes: hashes, ClientCapabilities: clientCapabilities}
 			})
 		})
 		eg.Go(func() error {
@@ -507,10 +507,11 @@ func translateChunkLocations(req *remotesapi.StreamChunkLocationsRequest, locati
 			},
 			RefreshAfter: rec.RefreshAfter,
 			RefreshRequest: &remotesapi.RefreshTableFileUrlRequest{
-				RepoId:    repoId,
-				RepoToken: repoToken,
-				RepoPath:  repoPath,
-				FileId:    rec.FileId,
+				RepoId:             repoId,
+				RepoToken:          repoToken,
+				RepoPath:           repoPath,
+				FileId:             rec.FileId,
+				ClientCapabilities: clientCapabilities,
 			},
 		})
 	}

--- a/go/libraries/doltcore/remotestorage/chunk_fetcher_test.go
+++ b/go/libraries/doltcore/remotestorage/chunk_fetcher_test.go
@@ -128,7 +128,7 @@ func testIdFunc() (*remotesapi.RepoId, string) {
 
 func testBuildDlReq(hashes [][]byte) *remotesapi.GetDownloadLocsRequest {
 	id, token := testIdFunc()
-	return &remotesapi.GetDownloadLocsRequest{RepoId: id, RepoToken: token, ChunkHashes: hashes}
+	return &remotesapi.GetDownloadLocsRequest{RepoId: id, RepoToken: token, ChunkHashes: hashes, ClientCapabilities: clientCapabilities}
 }
 
 // buildFlatHashBuf returns a |nHashes|*20-byte buffer where hash |i|
@@ -207,6 +207,7 @@ func TestTranslateChunkLocations(t *testing.T) {
 		assert.Equal(t, "token", locs[0].RefreshRequest.RepoToken)
 		assert.Equal(t, repoPath, locs[0].RefreshRequest.RepoPath)
 		assert.Equal(t, "file-1", locs[0].RefreshRequest.FileId)
+		assert.Equal(t, clientCapabilities, locs[0].RefreshRequest.ClientCapabilities)
 	})
 
 	t.Run("CrossResponseReuse", func(t *testing.T) {

--- a/go/libraries/doltcore/remotestorage/chunk_store.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store.go
@@ -569,6 +569,11 @@ func (r *locationRefresh) GetURL(ctx context.Context, lastError error, client re
 		wantsRefresh := now.After(r.RefreshAfter) || errors.Is(lastError, HttpError)
 		canRefresh := time.Since(r.lastRefresh) > refreshTableFileURLRetryDuration
 		if wantsRefresh && canRefresh {
+			// The request was prebuilt by the server (echo pattern);
+			// the client is authoritative for its own capability set
+			// and must stamp it at send time. See the ClientCapability
+			// enum comment in chunkstore.proto.
+			r.RefreshRequest.ClientCapabilities = clientCapabilities
 			ctx, cancel := context.WithTimeout(ctx, refreshTableFileURLTimeout)
 			resp, err := client.RefreshTableFileUrl(ctx, r.RefreshRequest)
 			cancel()
@@ -1154,7 +1159,7 @@ func (dcs *DoltChunkStore) PruneTableFiles(ctx context.Context) error {
 // and a list of only appendix table files
 func (dcs *DoltChunkStore) Sources(ctx context.Context) (chunks.TableFileSources, error) {
 	id, token := dcs.getRepoId()
-	req := &remotesapi.ListTableFilesRequest{RepoId: id, RepoPath: dcs.repoPath, RepoToken: token}
+	req := &remotesapi.ListTableFilesRequest{RepoId: id, RepoPath: dcs.repoPath, RepoToken: token, ClientCapabilities: clientCapabilities}
 	resp, err := dcs.csClient.ListTableFiles(ctx, req)
 	if err != nil {
 		return chunks.TableFileSources{}, NewRpcError(err, "ListTableFiles", dcs.host, req)
@@ -1245,7 +1250,12 @@ func sanitizeSignedUrl(url string) string {
 
 // Open returns an io.ReadCloser which can be used to read the bytes of a table file.
 func (drtf DoltRemoteTableFile) Open(ctx context.Context) (io.ReadCloser, uint64, error) {
-	if drtf.info.RefreshAfter != nil && time.Now().After(drtf.info.RefreshAfter.AsTime()) {
+	if drtf.info.RefreshRequest != nil && drtf.info.RefreshAfter != nil && time.Now().After(drtf.info.RefreshAfter.AsTime()) {
+		// The request was prebuilt by the server (echo pattern);
+		// the client is authoritative for its own capability set
+		// and must stamp it at send time. See the ClientCapability
+		// enum comment in chunkstore.proto.
+		drtf.info.RefreshRequest.ClientCapabilities = clientCapabilities
 		resp, err := drtf.dcs.csClient.RefreshTableFileUrl(ctx, drtf.info.RefreshRequest)
 		if err == nil {
 			drtf.info.Url = resp.Url

--- a/go/libraries/doltcore/remotestorage/chunk_store_test.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store_test.go
@@ -102,8 +102,9 @@ func TestDoltRemoteTableFile(t *testing.T) {
 					csClient: &csClient,
 				},
 				info: &remotesapi.TableFileInfo{
-					Url:          "http://localhost/example_url/fileid",
-					RefreshAfter: timestamppb.Now(),
+					Url:            "http://localhost/example_url/fileid",
+					RefreshAfter:   timestamppb.Now(),
+					RefreshRequest: &remotesapi.RefreshTableFileUrlRequest{FileId: "file-id"},
 				},
 			}
 			f.info.RefreshAfter.Seconds -= 10
@@ -111,6 +112,12 @@ func TestDoltRemoteTableFile(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, seenUrl, "http://localhost/example_url/fileid&refreshed")
 			require.Equal(t, f.info.RefreshAfter, csClient.resp.RefreshAfter)
+			// The client must stamp its capability set onto the
+			// server-echoed RefreshTableFileUrlRequest at send time,
+			// even though the echo arrived empty. See the
+			// ClientCapability enum comment in chunkstore.proto.
+			require.NotNil(t, csClient.lastIn)
+			require.Equal(t, clientCapabilities, csClient.lastIn.ClientCapabilities)
 		})
 		t.Run("404", func(t *testing.T) {
 			var buf bytes.Buffer
@@ -160,6 +167,39 @@ func TestDoltRemoteTableFile(t *testing.T) {
 	})
 }
 
+// TestLocationRefresh_StampsClientCapabilities covers the
+// locationRefresh.GetURL echo path: when the server-prebuilt
+// RefreshTableFileUrlRequest embedded in a DownloadLoc arrives with
+// ClientCapabilities empty, the client must stamp its own capability
+// set onto the request before making the refresh RPC.
+func TestLocationRefresh_StampsClientCapabilities(t *testing.T) {
+	var csClient refreshClient
+	csClient.resp = &remotesapi.RefreshTableFileUrlResponse{
+		Url:          "http://example.com/refreshed",
+		RefreshAfter: timestamppb.Now(),
+	}
+	csClient.resp.RefreshAfter.Seconds += 10
+
+	past := timestamppb.Now()
+	past.Seconds -= 10
+
+	r := &locationRefresh{
+		URL:          "http://example.com/original",
+		RefreshAfter: past.AsTime(),
+		// Empty ClientCapabilities mirrors a server that
+		// correctly leaves the field unset on the echoed
+		// RefreshRequest.
+		RefreshRequest: &remotesapi.RefreshTableFileUrlRequest{FileId: "file-id"},
+	}
+
+	url, err := r.GetURL(context.Background(), nil, &csClient)
+	require.NoError(t, err)
+	require.Equal(t, "http://example.com/refreshed", url)
+	require.True(t, csClient.called)
+	require.NotNil(t, csClient.lastIn)
+	require.Equal(t, clientCapabilities, csClient.lastIn.ClientCapabilities)
+}
+
 type fetcher func(*http.Request) (*http.Response, error)
 
 func (f fetcher) Do(req *http.Request) (*http.Response, error) {
@@ -168,6 +208,7 @@ func (f fetcher) Do(req *http.Request) (*http.Response, error) {
 
 type refreshClient struct {
 	called bool
+	lastIn *remotesapi.RefreshTableFileUrlRequest
 	resp   *remotesapi.RefreshTableFileUrlResponse
 }
 
@@ -203,6 +244,7 @@ func (f refreshClient) ListTableFiles(ctx context.Context, in *remotesapi.ListTa
 }
 func (f *refreshClient) RefreshTableFileUrl(ctx context.Context, in *remotesapi.RefreshTableFileUrlRequest, opts ...grpc.CallOption) (*remotesapi.RefreshTableFileUrlResponse, error) {
 	f.called = true
+	f.lastIn = in
 	return f.resp, nil
 }
 func (f refreshClient) AddTableFiles(ctx context.Context, in *remotesapi.AddTableFilesRequest, opts ...grpc.CallOption) (*remotesapi.AddTableFilesResponse, error) {


### PR DESCRIPTION
For now, we advertise that we handle HTTP/2 table file URL endpoints well.