### PR TITLE
[no-release-notes] Skip remote fetch in `syncForRead` during active push

### DIFF
--- a/go/libraries/utils/gitauth/normalize.go
+++ b/go/libraries/utils/gitauth/normalize.go
@@ -32,6 +32,9 @@ func (e *NonInteractiveAuthError) Error() string {
 	if e.Output != "" {
 		b.WriteString(strings.TrimRight(e.Output, "\n"))
 		b.WriteString("\n")
+	} else if e.Cause != nil {
+		b.WriteString(e.Cause.Error())
+		b.WriteString("\n")
 	}
 	b.WriteString("hint: dolt does not support interactive credential prompts\n")
 	b.WriteString("hint: configure git credentials (credential helper, token) for HTTPS remotes\n")

--- a/go/store/blobstore/git_blobstore.go
+++ b/go/store/blobstore/git_blobstore.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -281,6 +282,9 @@ type GitBlobstore struct {
 	// writeMu serializes operations that mutate shared git refs and/or perform
 	// remote-managed write workflows (commit + push + cache update).
 	writeMu sync.Mutex
+	// writeInProgress avoids fetch contention on slow remotes: syncForRead
+	// checks this flag instead of competing with an in-progress push.
+	writeInProgress atomic.Bool
 	// pendingMu guards pendingWrites, which may be appended to by non-manifest Put/Concatenate
 	// while being flushed by CheckAndPut("manifest").
 	pendingMu sync.Mutex
@@ -715,6 +719,11 @@ func (gbs *GitBlobstore) syncForRead(ctx context.Context) error {
 		}
 	}
 
+	// Concurrent fetches contend with an in-progress push on slow remotes.
+	if gbs.writeInProgress.Load() {
+		return nil
+	}
+
 	// Fetch remote ref into our remote-tracking ref.
 	err := gbs.api.FetchRef(ctx, gbs.remoteName, gbs.remoteRef, gbs.remoteTrackingRef)
 	if err != nil {
@@ -783,7 +792,11 @@ func (gbs *GitBlobstore) remoteManagedWrite(ctx context.Context, key, msg string
 	}
 
 	gbs.writeMu.Lock()
-	defer gbs.writeMu.Unlock()
+	gbs.writeInProgress.Store(true)
+	defer func() {
+		gbs.writeInProgress.Store(false)
+		gbs.writeMu.Unlock()
+	}()
 
 	policy := gbs.casRetryPolicy(ctx)
 

--- a/go/store/blobstore/git_blobstore_test.go
+++ b/go/store/blobstore/git_blobstore_test.go
@@ -525,7 +525,6 @@ func TestGitBlobstore_RemoteManaged_ManifestReadsDoNotBlockDuringPush(t *testing
 		Identity:   testIdentity(),
 	})
 	require.NoError(t, err)
-
 	// Prime the manifest version so our write uses the expected version.
 	_, ver, err := GetBytes(ctx, bs, "manifest", AllRange)
 	require.NoError(t, err)
@@ -563,22 +562,27 @@ func TestGitBlobstore_RemoteManaged_ManifestReadsDoNotBlockDuringPush(t *testing
 
 	const readers = 25
 	var wg sync.WaitGroup
-	readErrs := make(chan error, readers)
+	type readResult struct {
+		data []byte
+		err  error
+	}
+	readResults := make(chan readResult, readers)
 	for range readers {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			rctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+			rctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()
-			_, _, err := GetBytes(rctx, bs, "manifest", AllRange)
-			readErrs <- err
+			data, _, err := GetBytes(rctx, bs, "manifest", AllRange)
+			readResults <- readResult{data: data, err: err}
 		}()
 	}
 	wg.Wait()
-	close(readErrs)
+	close(readResults)
 
-	for err := range readErrs {
-		require.NoError(t, err)
+	for r := range readResults {
+		require.NoError(t, r.err)
+		require.Equal(t, []byte("seed\n"), r.data)
 	}
 
 	close(releasePush)


### PR DESCRIPTION
Read-path TTL can expire mid-push. Concurrent manifest readers then race to call `git fetch` while `PushRefWithLease` is in flight.
- Add `writeInProgress` atomic bool to `GitBlobstore`
- In `syncForRead`, skip `FetchRef` when `writeInProgress` is set: readers serve from cache while a push is active
- Fix `NonInteractiveAuthError.Error()` to include `e.Cause.Error()` when stderr is empty
- Increase concurrent-reader test timeout from 250ms to 2s