### PR TITLE
sqle: repair stale working set after remotesapi push from older clients

### DIFF
--- a/go/libraries/doltcore/sqle/remotesrv.go
+++ b/go/libraries/doltcore/sqle/remotesrv.go
@@ -122,6 +122,10 @@ func (s hooksFiringRemoteSrvStore) Commit(ctx context.Context, current, last has
 		return nil
 	})
 
+	// Repair stale working sets left behind by older clients before firing
+	// hooks, so hooks see the consistent post-repair state.
+	s.repairStaleWorkingSets(ctx, oldAddrs, newAddrs)
+
 	executeHooks := s.ddb.ExecuteCommitHooks
 	if s.replicaWrite {
 		executeHooks = s.ddb.ExecuteReplicaCommitHooks
@@ -148,6 +152,102 @@ func (s hooksFiringRemoteSrvStore) Commit(ctx context.Context, current, last has
 	}
 
 	return true, nil
+}
+
+// repairStaleWorkingSets advances any working set ref whose corresponding
+// branch HEAD was updated by this commit but whose own value was unchanged.
+// Older Dolt clients (pre PR #10810) skip the working set update when pushing
+// to a remote whose working set has no diff from HEAD, leaving the server's
+// working set ref pointing at a working set object whose staged root no
+// longer matches HEAD. Subsequent pushes from any client then fail with
+// "target has uncommitted changes" until the working set is reset.
+//
+// Repairs are best-effort: failures are swallowed so the push response is
+// not affected. The next push that observes the staleness will retry the
+// repair (and the hard-reset workaround remains available).
+func (s hooksFiringRemoteSrvStore) repairStaleWorkingSets(
+	ctx context.Context,
+	oldAddrs, newAddrs map[string]hash.Hash,
+) {
+	for id, newHeadAddr := range newAddrs {
+		if !ref.IsRef(id) {
+			continue
+		}
+		dref, err := ref.Parse(id)
+		if err != nil || dref.GetType() != ref.BranchRefType {
+			continue
+		}
+
+		// Skip branches whose HEAD did not change in this commit.
+		if oldAddrs[id] == newHeadAddr {
+			continue
+		}
+
+		wsRef, err := ref.WorkingSetRefForHead(dref)
+		if err != nil {
+			continue
+		}
+		wsID := wsRef.String()
+
+		// If the client also updated the working set ref in this commit,
+		// it's a modern client and there is nothing to repair.
+		if oldAddrs[wsID] != newAddrs[wsID] {
+			continue
+		}
+
+		s.advanceWorkingSetToHead(ctx, wsRef, newHeadAddr)
+	}
+}
+
+// advanceWorkingSetToHead updates the working set at |wsRef| so that its
+// working and staged roots both match the root of the commit at |headAddr|.
+// No-op if the working set does not exist, has already been advanced, or
+// the CAS fails (e.g. due to a concurrent writer).
+func (s hooksFiringRemoteSrvStore) advanceWorkingSetToHead(
+	ctx context.Context,
+	wsRef ref.WorkingSetRef,
+	headAddr hash.Hash,
+) {
+	currWs, err := s.ddb.ResolveWorkingSet(ctx, wsRef)
+	if errors.Is(err, doltdb.ErrWorkingSetNotFound) || err != nil {
+		return
+	}
+	currWsHash, err := currWs.HashOf()
+	if err != nil {
+		return
+	}
+
+	optCmt, err := s.ddb.ReadCommit(ctx, headAddr)
+	if err != nil {
+		return
+	}
+	newCommit, ok := optCmt.ToCommit()
+	if !ok {
+		return
+	}
+	newRoot, err := newCommit.GetRootValue(ctx)
+	if err != nil {
+		return
+	}
+	newRootHash, err := newRoot.HashOf()
+	if err != nil {
+		return
+	}
+
+	currWorkingHash, err := currWs.WorkingRoot().HashOf()
+	if err != nil {
+		return
+	}
+	currStagedHash, err := currWs.StagedRoot().HashOf()
+	if err != nil {
+		return
+	}
+	if currWorkingHash == newRootHash && currStagedHash == newRootHash {
+		return
+	}
+
+	newWs := currWs.WithWorkingRoot(newRoot).WithStagedRoot(newRoot)
+	_ = s.ddb.UpdateWorkingSet(ctx, wsRef, newWs, currWsHash, doltdb.TodoWorkingSetMeta(), nil)
 }
 
 // In the SQL context, the database provider that we use to expose the

--- a/go/libraries/doltcore/sqle/remotesrv_hook_test.go
+++ b/go/libraries/doltcore/sqle/remotesrv_hook_test.go
@@ -297,3 +297,203 @@ func TestReplicaWriteFiltersHooks(t *testing.T) {
 	assert.True(t, firedHook.calledFor("refs/heads/main"),
 		"hook with ExecuteForReplicaWrite()=true must fire on replica writes")
 }
+
+// TestRepairStaleWorkingSetAfterPush verifies the server-side repair path:
+// when an older client (pre-PR #10810) pushes by advancing the branch HEAD
+// without updating the corresponding working set ref, hooksFiringRemoteSrvStore
+// detects the stale state and advances the working set so subsequent pushes
+// succeed.
+func TestRepairStaleWorkingSetAfterPush(t *testing.T) {
+	ctx := t.Context()
+	dEnv := CreateTestEnv()
+	defer dEnv.Close()
+
+	ddb := dEnv.DoltDB(ctx)
+	branchRef := ref.NewBranchRef("main")
+	wsRef, err := ref.WorkingSetRefForHead(branchRef)
+	require.NoError(t, err)
+
+	// Establish an initial working set whose working/staged roots match the
+	// initial HEAD's root. Without this, there is no working set to leave
+	// stale and the repair is a no-op.
+	headCommit, err := ddb.ResolveCommitRef(ctx, branchRef)
+	require.NoError(t, err)
+	initialRoot, err := headCommit.GetRootValue(ctx)
+	require.NoError(t, err)
+	initialRootHash, err := initialRoot.HashOf()
+	require.NoError(t, err)
+
+	// CreateTestEnv may or may not have created a working set; use whatever
+	// hash is already there as |prevHash| for the CAS.
+	var initialPrevHash hash.Hash
+	if existingWs, err := ddb.ResolveWorkingSet(ctx, wsRef); err == nil {
+		initialPrevHash, err = existingWs.HashOf()
+		require.NoError(t, err)
+	}
+	initialWs := doltdb.EmptyWorkingSet(wsRef).
+		WithWorkingRoot(initialRoot).
+		WithStagedRoot(initialRoot)
+	err = ddb.UpdateWorkingSet(ctx, wsRef, initialWs, initialPrevHash, doltdb.TodoWorkingSetMeta(), nil)
+	require.NoError(t, err)
+
+	// Build a new root that differs from |initialRoot| by adding a table, so
+	// the staleness check (ws.staged != HEAD's root) actually fires.
+	tSchema := createTestSchema(t)
+	rowData := createTestRowData(t, ddb.ValueReadWriter(), ddb.NodeStore(), tSchema)
+	tbl, err := createHooksTestTable(ddb.ValueReadWriter(), ddb.NodeStore(), tSchema, rowData)
+	require.NoError(t, err)
+	newRoot, err := initialRoot.PutTable(ctx, doltdb.TableName{Name: "added"}, tbl)
+	require.NoError(t, err)
+	_, newRootHash, err := ddb.WriteRootValue(ctx, newRoot)
+	require.NoError(t, err)
+
+	rawDB := doltdb.ExposeDatabaseFromDoltDB(ddb)
+	cs := datas.ChunkStoreFromDatabase(rawDB)
+
+	// Snapshot the noms root before creating the stale state, so we can
+	// rewind and replay through hooksFiringRemoteSrvStore.Commit.
+	preCommitRoot, err := cs.Root(ctx)
+	require.NoError(t, err)
+
+	// ddb.Commit advances only the branch HEAD ref, leaving the working set
+	// ref pointing at the now-stale |initialWs|. This mirrors what older
+	// Dolt clients do during push.
+	meta, err := datas.NewCommitMeta("test", "test@test.com", "advance head only")
+	require.NoError(t, err)
+	_, err = ddb.Commit(ctx, newRootHash, branchRef, meta)
+	require.NoError(t, err)
+
+	staleCommitRoot, err := cs.Root(ctx)
+	require.NoError(t, err)
+	require.NotEqual(t, preCommitRoot, staleCommitRoot)
+
+	// Confirm the stale state is observable: ws.staged still points at
+	// |initialRootHash| even though HEAD has advanced.
+	staleWs, err := ddb.ResolveWorkingSet(ctx, wsRef)
+	require.NoError(t, err)
+	staleStagedHash, err := staleWs.StagedRoot().HashOf()
+	require.NoError(t, err)
+	require.Equal(t, initialRootHash, staleStagedHash,
+		"setup precondition: working set staged root must still be at the initial root")
+
+	// Rewind the chunk store so we can replay the stale-creating commit
+	// through hooksFiringRemoteSrvStore.Commit.
+	rewound, err := cs.Commit(ctx, preCommitRoot, staleCommitRoot)
+	require.NoError(t, err)
+	require.True(t, rewound)
+
+	rss, ok := cs.(remotesrv.RemoteSrvStore)
+	require.True(t, ok)
+	store := hooksFiringRemoteSrvStore{RemoteSrvStore: rss, ddb: ddb}
+
+	committed, err := store.Commit(ctx, staleCommitRoot, preCommitRoot)
+	require.NoError(t, err)
+	require.True(t, committed)
+
+	// After the repair, ws.working and ws.staged must both point at the new
+	// HEAD's root.
+	repairedWs, err := ddb.ResolveWorkingSet(ctx, wsRef)
+	require.NoError(t, err)
+	repairedWorkingHash, err := repairedWs.WorkingRoot().HashOf()
+	require.NoError(t, err)
+	repairedStagedHash, err := repairedWs.StagedRoot().HashOf()
+	require.NoError(t, err)
+	assert.Equal(t, newRootHash, repairedWorkingHash,
+		"after repair, ws.working must match the new HEAD's root")
+	assert.Equal(t, newRootHash, repairedStagedHash,
+		"after repair, ws.staged must match the new HEAD's root")
+}
+
+// TestRepairWorkingSetSkippedWhenClientUpdated verifies that the repair logic
+// is a no-op when the client included the working set update in its push
+// (modern client behavior).
+func TestRepairWorkingSetSkippedWhenClientUpdated(t *testing.T) {
+	ctx := t.Context()
+	dEnv := CreateTestEnv()
+	defer dEnv.Close()
+
+	ddb := dEnv.DoltDB(ctx)
+	branchRef := ref.NewBranchRef("main")
+	wsRef, err := ref.WorkingSetRefForHead(branchRef)
+	require.NoError(t, err)
+
+	headCommit, err := ddb.ResolveCommitRef(ctx, branchRef)
+	require.NoError(t, err)
+	initialRoot, err := headCommit.GetRootValue(ctx)
+	require.NoError(t, err)
+
+	// CreateTestEnv may or may not have created a working set; use whatever
+	// hash is already there as |prevHash| for the CAS.
+	var initialPrevHash hash.Hash
+	if existingWs, err := ddb.ResolveWorkingSet(ctx, wsRef); err == nil {
+		initialPrevHash, err = existingWs.HashOf()
+		require.NoError(t, err)
+	}
+	initialWs := doltdb.EmptyWorkingSet(wsRef).
+		WithWorkingRoot(initialRoot).
+		WithStagedRoot(initialRoot)
+	err = ddb.UpdateWorkingSet(ctx, wsRef, initialWs, initialPrevHash, doltdb.TodoWorkingSetMeta(), nil)
+	require.NoError(t, err)
+
+	rawDB := doltdb.ExposeDatabaseFromDoltDB(ddb)
+	cs := datas.ChunkStoreFromDatabase(rawDB)
+	preCommitRoot, err := cs.Root(ctx)
+	require.NoError(t, err)
+
+	// Modern client behavior: advance both HEAD and the working set ref. We
+	// simulate this by calling ddb.Commit (advances HEAD) and then
+	// UpdateWorkingSet (advances ws ref) before rewinding and replaying.
+	tSchema := createTestSchema(t)
+	rowData := createTestRowData(t, ddb.ValueReadWriter(), ddb.NodeStore(), tSchema)
+	tbl, err := createHooksTestTable(ddb.ValueReadWriter(), ddb.NodeStore(), tSchema, rowData)
+	require.NoError(t, err)
+	newRoot, err := initialRoot.PutTable(ctx, doltdb.TableName{Name: "added"}, tbl)
+	require.NoError(t, err)
+	_, newRootHash, err := ddb.WriteRootValue(ctx, newRoot)
+	require.NoError(t, err)
+
+	meta, err := datas.NewCommitMeta("test", "test@test.com", "advance both")
+	require.NoError(t, err)
+	_, err = ddb.Commit(ctx, newRootHash, branchRef, meta)
+	require.NoError(t, err)
+
+	// Update the working set to match the new HEAD (modern client behavior).
+	currWs, err := ddb.ResolveWorkingSet(ctx, wsRef)
+	require.NoError(t, err)
+	currWsHash, err := currWs.HashOf()
+	require.NoError(t, err)
+	updatedWs := currWs.WithWorkingRoot(newRoot).WithStagedRoot(newRoot)
+	err = ddb.UpdateWorkingSet(ctx, wsRef, updatedWs, currWsHash, doltdb.TodoWorkingSetMeta(), nil)
+	require.NoError(t, err)
+
+	postCommitRoot, err := cs.Root(ctx)
+	require.NoError(t, err)
+
+	// Capture the working set hash that the modern client wrote — this is
+	// the value the repair must NOT overwrite.
+	expectedWs, err := ddb.ResolveWorkingSet(ctx, wsRef)
+	require.NoError(t, err)
+	expectedWsHash, err := expectedWs.HashOf()
+	require.NoError(t, err)
+
+	// Rewind and replay through the hook.
+	rewound, err := cs.Commit(ctx, preCommitRoot, postCommitRoot)
+	require.NoError(t, err)
+	require.True(t, rewound)
+
+	rss, ok := cs.(remotesrv.RemoteSrvStore)
+	require.True(t, ok)
+	store := hooksFiringRemoteSrvStore{RemoteSrvStore: rss, ddb: ddb}
+
+	committed, err := store.Commit(ctx, postCommitRoot, preCommitRoot)
+	require.NoError(t, err)
+	require.True(t, committed)
+
+	// The working set should be unchanged from what the modern client wrote.
+	finalWs, err := ddb.ResolveWorkingSet(ctx, wsRef)
+	require.NoError(t, err)
+	finalWsHash, err := finalWs.HashOf()
+	require.NoError(t, err)
+	assert.Equal(t, expectedWsHash, finalWsHash,
+		"repair must not overwrite a working set the client already updated")
+}


### PR DESCRIPTION
## Summary

Fixes #10945. When an older Dolt client (pre PR #10810 — e.g. beads v1.0.3, which pins `dolt@005921bdd8ca`, 166 commits before the fix) pushes to a `dolt-sql-server` over remotesapi, it advances only the branch HEAD ref and leaves the working set ref pointing at the pre-push `WorkingSet`. The server's `staged` root no longer matches `HEAD`, and subsequent pushes from any client — including up-to-date ones — fail with `target has uncommitted changes. --force required to overwrite`. The only recovery today is `CALL DOLT_RESET('--hard')` on the server.

The root cause on the old-client side: `WorkingSetContainsOnlyIgnoredTables` returns `true` for an empty diff (the remote's working set is clean, which is the normal case), so the old `Push()` takes the `FastForward` branch that does not include a working set update. PR #10810 fixed this client-side by always going through `FastForwardWithWorkspaceCheck`, but clients on older versions remain affected. This change makes the server tolerant of those clients.

## What changes

In `hooksFiringRemoteSrvStore.Commit` (the layer the `dolt-sql-server` wraps every remotesapi commit with), after the underlying chunk store commit succeeds, walk the post-commit dataset map and, for each branch whose HEAD advanced but whose corresponding working set ref was unchanged in the same commit, advance the working set so its `working` and `staged` roots both match the new HEAD's root. Implemented via `DoltDB.UpdateWorkingSet` with the existing CAS.

The repair is a no-op when:
- The client also updated the working set ref (modern client) — detected via `oldAddrs[wsID] != newAddrs[wsID]`
- No working set exists at the ref (file:// remotes, freshly created branches)
- The working set is already in sync with HEAD
- The CAS loses a race with another writer (best-effort; the next push will retry)

The repair runs **before** firing commit hooks so hooks observe the consistent post-repair state.

Real dirty workspaces from concurrent SQL writes still reject pushes — the dirty check fires client-side in `doFastForward` before the Commit RPC ever reaches the server, so the repair never runs in that path and the AssertWorkingSet contract is preserved.

## Test plan

- [x] New `TestRepairStaleWorkingSetAfterPush` constructs the stale state via `ddb.Commit` (which advances only HEAD, mirroring old-client behavior), replays the commit through `hooksFiringRemoteSrvStore.Commit`, and asserts the working set's `working`/`staged` roots end up at the new HEAD's root.
- [x] New `TestRepairWorkingSetSkippedWhenClientUpdated` verifies the repair leaves the working set untouched when the client already updated it (regression guard for modern clients).
- [x] Existing `TestHooks*` and `TestOnlyChangedDatasetsFireHooks` / `TestReplicaWriteFiltersHooks` still pass.
- [x] `./libraries/doltcore/sqle`, `./libraries/doltcore/env/actions`, `./libraries/doltcore/doltdb`, `./store/datas` test suites pass.
- [x] End-to-end manual repro against a patched `dolt-sql-server`:
  - Built `dolt` at `005921bdd8ca` (beads' pinned commit) as the "old" client.
  - Old-client push: succeeds, server `dolt_status` is empty (was: showed `staged | modified` for every changed table).
  - Subsequent old-client and modern-client pushes: succeed (was: all failed with `target has uncommitted changes`).
  - Real SQL-induced dirty workspace on the server: push still rejected (regression preserved).