### PR TITLE
go/store: nbs,types: Fix some error paths in GC.

### DIFF
--- a/go/store/nbs/gc_copier.go
+++ b/go/store/nbs/gc_copier.go
@@ -60,6 +60,9 @@ func (gcc *gcCopier) addChunk(ctx context.Context, c ToChunker) error {
 // If the writer should be closed and deleted, instead of being used with
 // copyTablesToDir, call this method.
 func (gcc *gcCopier) cancel(_ context.Context) error {
+	if gcc.writer == nil {
+		return nil
+	}
 	err := gcc.writer.Cancel()
 	if err != nil {
 		return fmt.Errorf("gcCopier cancel err: %w", err)
@@ -79,6 +82,7 @@ func (gcc *gcCopier) copyTablesToDir(ctx context.Context) (ts []tableSpec, pendi
 
 	defer func() {
 		gcc.writer.Cancel()
+		gcc.writer = nil
 	}()
 
 	if gcc.writer.ChunkCount() == 0 {
@@ -239,7 +243,6 @@ func (gcc *rotatingGCCopier) containsChunk(h hash.Hash) bool {
 }
 
 func (gcc *rotatingGCCopier) finalizeChildWriter(ctx context.Context, copier gcCopier) error {
-
 	specs, pending, err := copier.copyTablesToDir(ctx)
 	if err != nil {
 		return err

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -2176,7 +2176,7 @@ func (nbs *NomsBlockStore) hasLocalGCNovelty() bool {
 	return false
 }
 
-func markAndSweepChunks(_ context.Context, nbs *NomsBlockStore, src CompressedChunkStoreForGC, dest chunks.ChunkStore, getAddrs chunks.GetAddrs, filter chunks.HasManyFunc, gcConfig chunks.GCConfig, incrementalUpdateManifest bool) (chunks.MarkAndSweeper, error) {
+func markAndSweepChunks(ctx context.Context, nbs *NomsBlockStore, src CompressedChunkStoreForGC, dest chunks.ChunkStore, getAddrs chunks.GetAddrs, filter chunks.HasManyFunc, gcConfig chunks.GCConfig, incrementalUpdateManifest bool) (chunks.MarkAndSweeper, error) {
 	ops := nbs.SupportedOperations()
 	if !ops.CanGC || !ops.CanPrune {
 		return nil, chunks.ErrUnsupportedOperation
@@ -2251,6 +2251,10 @@ func markAndSweepChunks(_ context.Context, nbs *NomsBlockStore, src CompressedCh
 	// we will write leaf chunks to a different chunk file which is periodically finalized and replaced
 	// with a new writer.
 	incrementalGcc, err := newRotatingGCCopier(gcConfig.ArchiveLevel, tfp, destNBS, gcConfig.IncrementalFileSize, incrementalUpdateManifest)
+	if err != nil {
+		cErr := gcc.cancel(ctx)
+		return nil, errors.Join(err, cErr)
+	}
 
 	return &markAndSweeper{
 		src:            src,
@@ -2423,22 +2427,17 @@ func (i *markAndSweeper) Finalize(ctx context.Context) (chunks.GCFinalizer, erro
 	}, nil
 }
 
-func (i *markAndSweeper) Close(ctx context.Context) (err error) {
+func (i *markAndSweeper) Close(ctx context.Context) error {
+	var err error
 	if i.gcc != nil {
-		err = i.gcc.cancel(ctx)
-		if err != nil {
-			return err
-		}
+		err = errors.Join(err, i.gcc.cancel(ctx))
 		i.gcc = nil
 	}
 	if i.incrementalGcc != nil {
-		err = i.incrementalGcc.cancel(ctx)
-		if err != nil {
-			return err
-		}
+		err = errors.Join(err, i.incrementalGcc.cancel(ctx))
 		i.incrementalGcc = nil
 	}
-	return nil
+	return err
 }
 
 type gcFinalizer struct {

--- a/go/store/types/value_store.go
+++ b/go/store/types/value_store.go
@@ -744,24 +744,26 @@ func (lvs *ValueStore) gc(ctx context.Context,
 	src, dest chunks.ChunkStoreGarbageCollector,
 	safepointController GCSafepointController,
 	finalize func() hash.HashSet,
-	incrementalUpdateManifest bool) (chunks.GCFinalizer, error) {
+	incrementalUpdateManifest bool,
+) (_ chunks.GCFinalizer, retErr error) {
 	sweeper, err := src.MarkAndSweepChunks(ctx, lvs.walkAddrs, hashFilter, dest, gcConfig, incrementalUpdateManifest)
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		retErr = errors.Join(retErr, sweeper.Close(ctx))
+	}()
 
 	err = sweeper.SaveHashes(ctx, toVisit)
 	if err != nil {
-		cErr := sweeper.Close(ctx)
-		return nil, errors.Join(fmt.Errorf("Error in SaveHashes call: %w", err), cErr)
+		return nil, fmt.Errorf("Error in SaveHashes call: %w", err)
 	}
 	toVisit = nil
 
 	if safepointController != nil {
 		err = safepointController.EstablishPreFinalizeSafepoint(ctx)
 		if err != nil {
-			cErr := sweeper.Close(ctx)
-			return nil, errors.Join(err, cErr)
+			return nil, err
 		}
 	}
 
@@ -771,31 +773,28 @@ func (lvs *ValueStore) gc(ctx context.Context,
 	next := lvs.readAndResetNewGenToVisit()
 	err = sweeper.SaveHashes(ctx, next)
 	if err != nil {
-		cErr := sweeper.Close(ctx)
-		return nil, errors.Join(err, cErr)
+		return nil, err
 	}
 	next = nil
 
 	final := finalize()
 	err = sweeper.SaveHashes(ctx, final)
 	if err != nil {
-		cErr := sweeper.Close(ctx)
-		return nil, errors.Join(err, cErr)
+		return nil, err
 	}
 	final = nil
 
 	if safepointController != nil {
 		err = safepointController.EstablishPostFinalizeSafepoint(ctx)
 		if err != nil {
-			cErr := sweeper.Close(ctx)
-			return nil, errors.Join(err, cErr)
+			return nil, err
 		}
 	}
 	finalizer, err := sweeper.Finalize(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return finalizer, sweeper.Close(ctx)
+	return finalizer, nil
 }
 
 func (lvs *ValueStore) PurgeCaches() {


### PR DESCRIPTION
1) If gcCopier.copyTablesToDir failed after its writer.Finish() call succeeded, it would cancel the writer but leave gcc.writer != nil. Then markAndSweeper.Close would call gcc.cancel and get a spurious error from the failed writer.Cancel call.

2) ValueStore.gc would fail to Close MarkAndSweeper if Finalize returned an error. The contract was that Close needed to be called on all paths.

3) markAndSweepChunks dropped an error from newRotatingGCCopier.

4) markAndSweeper Close early returned on an error from gcc.cancel, failing to close and cleanup incrementalGcc in that case.