### PR TITLE
fix autogc load scheduler to be independent on number of CPUs

### DIFF
--- a/go/libraries/doltcore/sqle/auto_gc.go
+++ b/go/libraries/doltcore/sqle/auto_gc.go
@@ -46,19 +46,26 @@ func (noneGCScheduler) WaitForNextRun(context.Context) error {
 	return nil
 }
 
+// TODO: CPU Threshold should not be used to determine whether or not AutoGC should run
+// DEFAULT_LOAD_THRESHOLD is the minimum CPU Load to prevent AutoGC from running.
+const DEFAULT_LOAD_THRESHOLD = 0.5
+
+// DEFAULT_SKIPPED_THRESHOLD is the number of times AutoGC can be skipped before it just runs.
+const DEFAULT_SKIPPED_THRESHOLD = 30
+
 // loadAvgGCScheduler delays GC until the system load average drops
 // below a per-CPU threshold. Each call to WaitForNextRun checks the
 // current load and backs off in a loop until conditions are favorable.
 type loadAvgGCScheduler struct {
 	fs            procfs.FS
-	loadThreshold float64
+	loadThreshold float64 // TODO: make this configurable?
 	skippedCount  uint8
 }
 
 func (s *loadAvgGCScheduler) WaitForNextRun(ctx context.Context) error {
 	for {
 		loadAvg, err := s.fs.LoadAvg()
-		if err != nil || s.skippedCount >= 30 || loadAvg.Load1 <= s.loadThreshold {
+		if err != nil || s.skippedCount >= DEFAULT_SKIPPED_THRESHOLD || loadAvg.Load1 <= s.loadThreshold {
 			s.skippedCount = 0
 			return nil
 		}
@@ -111,13 +118,10 @@ func NewGCScheduler(gcSchStr string) GCScheduler {
 	case "NONE":
 		return noneGCScheduler{}
 	default:
-		var stat procfs.Stat
 		if fs, err := procfs.NewDefaultFS(); err == nil {
-			if stat, err = fs.Stat(); err == nil {
-				return &loadAvgGCScheduler{
-					fs:            fs,
-					loadThreshold: 0.5 * float64(len(stat.CPU)),
-				}
+			return &loadAvgGCScheduler{
+				fs:            fs,
+				loadThreshold: DEFAULT_LOAD_THRESHOLD,
 			}
 		}
 		return noneGCScheduler{}

--- a/go/libraries/doltcore/sqle/auto_gc.go
+++ b/go/libraries/doltcore/sqle/auto_gc.go
@@ -109,12 +109,9 @@ func NewGCScheduler(gcSchStr string) GCScheduler {
 		return noneGCScheduler{}
 	default:
 		if fs, err := procfs.NewDefaultFS(); err == nil {
-			var stat procfs.Stat
-			if stat, err = fs.Stat(); err == nil {
-				return &loadAvgGCScheduler{
-					fs:            fs,
-					loadThreshold: 10 / float64(len(stat.CPU)),
-				}
+			return &loadAvgGCScheduler{
+				fs:            fs,
+				loadThreshold: 0.1,
 			}
 		}
 		return noneGCScheduler{}

--- a/go/libraries/doltcore/sqle/auto_gc.go
+++ b/go/libraries/doltcore/sqle/auto_gc.go
@@ -111,10 +111,13 @@ func NewGCScheduler(gcSchStr string) GCScheduler {
 	case "NONE":
 		return noneGCScheduler{}
 	default:
+		var stat procfs.Stat
 		if fs, err := procfs.NewDefaultFS(); err == nil {
-			return &loadAvgGCScheduler{
-				fs:            fs,
-				loadThreshold: 0.5,
+			if stat, err = fs.Stat(); err == nil {
+				return &loadAvgGCScheduler{
+					fs:            fs,
+					loadThreshold: 0.5 * float64(len(stat.CPU)),
+				}
 			}
 		}
 		return noneGCScheduler{}

--- a/go/libraries/doltcore/sqle/auto_gc.go
+++ b/go/libraries/doltcore/sqle/auto_gc.go
@@ -52,18 +52,21 @@ func (noneGCScheduler) WaitForNextRun(context.Context) error {
 type loadAvgGCScheduler struct {
 	fs            procfs.FS
 	loadThreshold float64
+	skippedCount  uint8
 }
 
 func (s *loadAvgGCScheduler) WaitForNextRun(ctx context.Context) error {
 	for {
 		loadAvg, err := s.fs.LoadAvg()
-		if err != nil || loadAvg.Load1 <= s.loadThreshold {
+		if err != nil || s.skippedCount >= 30 || loadAvg.Load1 <= s.loadThreshold {
+			s.skippedCount = 0
 			return nil
 		}
 		select {
 		case <-ctx.Done():
 			return context.Cause(ctx)
 		case <-time.After(1 * time.Minute):
+			s.skippedCount++
 		}
 	}
 }

--- a/go/libraries/doltcore/sqle/auto_gc.go
+++ b/go/libraries/doltcore/sqle/auto_gc.go
@@ -114,7 +114,7 @@ func NewGCScheduler(gcSchStr string) GCScheduler {
 		if fs, err := procfs.NewDefaultFS(); err == nil {
 			return &loadAvgGCScheduler{
 				fs:            fs,
-				loadThreshold: 0.1,
+				loadThreshold: 0.5,
 			}
 		}
 		return noneGCScheduler{}


### PR DESCRIPTION
Before, we had a threshold that was incorrectly calculating the threshold based off the number of CPUs.
The original intention is to prevent AutoGC if a single CPU core exceeds 50% usage. 
We've determined that CPU Load itself is not a great metric to schedule AutoGC, but this is a fix for now.

addresses: https://github.com/dolthub/dolt/issues/10944