### PR TITLE
feat: add -C/--directory global flag matching git -C behaviour

### DIFF
--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -392,6 +392,7 @@ func CreateGlobalArgParser(name string) *argparser.ArgParser {
 	ap.SupportsString("port", "", "port", "Defines the port to connect to.")
 	ap.SupportsFlag("no-tls", "", "Disables TLS for the connection to remote databases.")
 	ap.SupportsString("data-dir", "", "data-dir", "Defines a data directory whose subdirectories should all be dolt data repositories accessible as independent databases. Defaults to the current directory.")
+	ap.SupportsString("directory", "C", "dir", "Change to <dir> before executing the subcommand. Equivalent to running dolt from that directory. Matches git -C behaviour.")
 	ap.SupportsString("doltcfg-dir", "", "doltcfg-dir", "Defines a directory that contains configuration files for dolt. Defaults to `$data-dir/.doltcfg`. Will only be created if there is a change to configuration settings.")
 	ap.SupportsString("privilege-file", "", "privilege-file", "Path to a file to load and store users and grants. Defaults to `$doltcfg-dir/privileges.db`. Will only be created if there is a change to privileges.")
 	ap.SupportsString("branch-control-file", "", "branch-control-file", "Path to a file to load and store branch control permissions. Defaults to `$doltcfg-dir/branch_control.db`. Will only be created if there is a change to branch control permissions.")

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -900,13 +900,46 @@ type bootstrapConfig struct {
 // contains all the parsed arguments and other configurations. If there is an error, |cfg| will be nil.
 // |terminate| is set to true if the process should end for any reason. Errors or messages to the user will be printed already.
 // |status| is the exit code to terminate with, and can be ignored if |terminate| is false.
+// preScanDirFlag does a lightweight scan of raw args for -C/--directory before
+// the full arg parse runs, so cwdFs can be set before any filesystem operations.
+// Returns "" if neither flag is present. --chdir is handled separately in runMain.
+func preScanDirFlag(args []string) string {
+	for i, arg := range args {
+		switch arg {
+		case "-C", "--directory":
+			if i+1 < len(args) {
+				return args[i+1]
+			}
+		}
+	}
+	return ""
+}
+
 func createBootstrapConfig(ctx context.Context, args []string) (cfg *bootstrapConfig, terminate bool, status int) {
-	lfs := filesys.LocalFS
-	cwd, err := lfs.Abs("")
-	cwdFs, err := lfs.WithWorkingDir(cwd)
-	if err != nil {
-		cli.PrintErrln(color.RedString("Failed to load the current working directory: %v", err))
-		return nil, true, 1
+	var cwdFs filesys.Filesys
+
+	// Resolve working directory. -C/--directory changes it before any filesystem
+	// operations. --chdir (deprecated) is handled earlier in runMain via os.Chdir,
+	// so by this point the process cwd already reflects it.
+	if targetDir := preScanDirFlag(args); targetDir != "" {
+		var err error
+		cwdFs, err = filesys.LocalFilesysWithWorkingDir(targetDir)
+		if err != nil {
+			cli.PrintErrln(color.RedString("cannot change to directory %q: %v", targetDir, err))
+			return nil, true, 1
+		}
+	} else {
+		lfs := filesys.LocalFS
+		cwd, err := lfs.Abs("")
+		if err != nil {
+			cli.PrintErrln(color.RedString("Failed to load the current working directory: %v", err))
+			return nil, true, 1
+		}
+		cwdFs, err = lfs.WithWorkingDir(cwd)
+		if err != nil {
+			cli.PrintErrln(color.RedString("Failed to load the current working directory: %v", err))
+			return nil, true, 1
+		}
 	}
 
 	tmpEnv := env.LoadWithoutDB(ctx, env.GetCurrentUserHomeDir, cwdFs, "", doltversion.Version)

--- a/go/cmd/dolt/dolt_test.go
+++ b/go/cmd/dolt/dolt_test.go
@@ -1,0 +1,219 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPreScanDirFlag tests the lightweight pre-scan that resolves -C/--directory
+// before the full arg parse runs. --chdir is handled separately in runMain.
+
+func TestPreScanDirFlag(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantDir string
+	}{
+		{
+			name:    "no dir flag",
+			args:    []string{"status"},
+			wantDir: "",
+		},
+		{
+			name:    "-C flag",
+			args:    []string{"-C", "/some/path", "status"},
+			wantDir: "/some/path",
+		},
+		{
+			name:    "--directory flag",
+			args:    []string{"--directory", "/some/path", "status"},
+			wantDir: "/some/path",
+		},
+		{
+			name:    "--chdir not scanned here (handled in runMain)",
+			args:    []string{"--chdir", "/some/path", "status"},
+			wantDir: "",
+		},
+		{
+			name:    "-C with relative path",
+			args:    []string{"-C", "subdir", "status"},
+			wantDir: "subdir",
+		},
+		{
+			name:    "-C flag missing value",
+			args:    []string{"-C"},
+			wantDir: "",
+		},
+		{
+			name:    "--directory flag missing value",
+			args:    []string{"--directory"},
+			wantDir: "",
+		},
+		{
+			name:    "-C flag among other flags",
+			args:    []string{"--user", "root", "-C", "/my/db", "sql"},
+			wantDir: "/my/db",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotDir := preScanDirFlag(tc.args)
+			if gotDir != tc.wantDir {
+				t.Errorf("preScanDirFlag(%v) = %q, want %q", tc.args, gotDir, tc.wantDir)
+			}
+		})
+	}
+}
+
+// buildDolt compiles the dolt binary and returns the path. Results are cached per test binary run.
+var (
+	builtDoltBin  string
+	builtDoltErr  error
+	builtDoltOnce = new(struct{ done bool })
+)
+
+func buildDolt(t *testing.T) string {
+	t.Helper()
+	if os.Getenv("DOLT_TEST_BUILD") != "1" {
+		t.Skip("set DOLT_TEST_BUILD=1 to run dolt binary integration tests")
+	}
+	if !builtDoltOnce.done {
+		builtDoltOnce.done = true
+		bin := filepath.Join(t.TempDir(), "dolt")
+		cmd := exec.Command("go", "build", "-o", bin, ".")
+		cmd.Dir = filepath.Join(mustFindModRoot(t), "cmd/dolt")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			builtDoltErr = err
+			t.Logf("build output: %s", out)
+		}
+		builtDoltBin = bin
+	}
+	if builtDoltErr != nil {
+		t.Fatalf("failed to build dolt: %v", builtDoltErr)
+	}
+	return builtDoltBin
+}
+
+func mustFindModRoot(t *testing.T) string {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Dir(exe)
+	// Walk up to find go.mod
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find go.mod")
+		}
+		dir = parent
+	}
+}
+
+// TestDirectoryFlagIntegration tests the -C/--directory/--chdir flags end-to-end
+// by running the compiled dolt binary. Requires DOLT_TEST_BUILD=1.
+func TestDirectoryFlagIntegration(t *testing.T) {
+	dolt := buildDolt(t)
+
+	// Create a temp directory with a dolt repo initialised inside it.
+	repoDir := t.TempDir()
+	initCmd := exec.Command(dolt, "init")
+	initCmd.Dir = repoDir
+	if out, err := initCmd.CombinedOutput(); err != nil {
+		t.Fatalf("dolt init failed: %v\n%s", err, out)
+	}
+
+	otherDir := t.TempDir()
+
+	t.Run("C_flag_runs_from_target_dir", func(t *testing.T) {
+		cmd := exec.Command(dolt, "-C", repoDir, "status")
+		cmd.Dir = otherDir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("dolt -C status failed: %v\n%s", err, out)
+		}
+		if !strings.Contains(string(out), "On branch") && !strings.Contains(string(out), "nothing to commit") {
+			t.Errorf("unexpected status output: %s", out)
+		}
+	})
+
+	t.Run("directory_long_flag_runs_from_target_dir", func(t *testing.T) {
+		cmd := exec.Command(dolt, "--directory", repoDir, "status")
+		cmd.Dir = otherDir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("dolt --directory status failed: %v\n%s", err, out)
+		}
+		if !strings.Contains(string(out), "On branch") && !strings.Contains(string(out), "nothing to commit") {
+			t.Errorf("unexpected status output: %s", out)
+		}
+	})
+
+	t.Run("chdir_deprecated_flag_warns_and_works", func(t *testing.T) {
+		cmd := exec.Command(dolt, "--chdir", repoDir, "status")
+		cmd.Dir = otherDir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("dolt --chdir status failed: %v\n%s", err, out)
+		}
+		outStr := string(out)
+		if !strings.Contains(outStr, "deprecated") {
+			t.Errorf("expected deprecation warning for --chdir, got: %s", outStr)
+		}
+		if !strings.Contains(outStr, "On branch") && !strings.Contains(outStr, "nothing to commit") {
+			t.Errorf("unexpected status output: %s", outStr)
+		}
+	})
+
+	t.Run("C_flag_nonexistent_dir_errors_cleanly", func(t *testing.T) {
+		cmd := exec.Command(dolt, "-C", "/nonexistent/dolt-C-test-path", "status")
+		cmd.Dir = otherDir
+		out, err := cmd.CombinedOutput()
+		if err == nil {
+			t.Fatalf("expected failure for -C /nonexistent, got: %s", out)
+		}
+		if !strings.Contains(string(out), "cannot change to directory") {
+			t.Errorf("expected error message, got: %s", out)
+		}
+	})
+
+	t.Run("no_C_flag_uses_current_dir", func(t *testing.T) {
+		// Running without -C from repoDir should also work.
+		cmd := exec.Command(dolt, "status")
+		cmd.Dir = repoDir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("dolt status failed: %v\n%s", err, out)
+		}
+	})
+
+	t.Run("C_flag_does_not_mutate_cwd", func(t *testing.T) {
+		// The first invocation uses -C to reach repoDir. The second does NOT use -C
+		// and runs from otherDir (no dolt repo). It must fail — proving -C did not
+		// permanently mutate the process cwd.
+		cmd1 := exec.Command(dolt, "-C", repoDir, "status")
+		cmd1.Dir = otherDir
+		if out, err := cmd1.CombinedOutput(); err != nil {
+			t.Fatalf("first dolt -C status failed: %v\n%s", err, out)
+		}
+
+		cmd2 := exec.Command(dolt, "status")
+		cmd2.Dir = otherDir
+		var stderr2 bytes.Buffer
+		cmd2.Stderr = &stderr2
+		_, err := cmd2.CombinedOutput()
+		if err == nil {
+			t.Fatal("second dolt status (no -C) should have failed in a non-repo dir")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds a `-C <dir>` / `--directory <dir>` global flag so dolt commands can be run against a database directory without cd-ing into it first. This matches the convention established by `git -C` and is useful for scripting and agent-driven workflows where the caller's cwd is not the dolt repo.

The existing `--chdir` flag is unchanged.

## Motivation

`git -C`, `make -C`, and `ninja -C` have established `-C` as the standard short flag for "run as if in this directory." Dolt users coming from git muscle memory expect it. The existing `--chdir` is undocumented and was added as an internal GoLand IDE workaround — it is not a substitute for a user-facing flag.

## Implementation

A lightweight `preScanDirFlag` helper scans raw args for `-C`/`--directory` before `createBootstrapConfig` creates `cwdFs`. The target directory is resolved via `LocalFilesysWithWorkingDir`, which creates a new `Filesys` instance rooted at the target path without mutating the process cwd. All downstream resolution (data-dir, local config, env loading) inherits the correct base directory through `cwdFs`.

## Changes

- `go/cmd/dolt/cli/arg_parser_helpers.go`: adds `--directory`/`-C` to `CreateGlobalArgParser`
- `go/cmd/dolt/dolt.go`: adds `preScanDirFlag` helper and directory resolution in `createBootstrapConfig`
- `go/cmd/dolt/dolt_test.go`: unit tests for `preScanDirFlag` (8 cases); integration tests gated on `DOLT_TEST_BUILD=1`

## Test plan

- [ ] `go test ./cmd/dolt/ -run TestPreScanDirFlag` — unit tests, no binary required
- [ ] `DOLT_TEST_BUILD=1 go test ./cmd/dolt/ -run TestDirectoryFlagIntegration` — end-to-end: valid dir, long form, nonexistent dir error, cwd-isolation guarantee
- [ ] `dolt -C /path/to/db status` works from any directory
- [ ] `dolt -C /nonexistent status` exits with a clean error

Note: the revision history on this PR reflects an overzealous code assistant — the `--chdir` cleanup has been correctly separated into #10957.

🤖 Generated with [Claude Code](https://claude.com/claude-code)