### PR TITLE
fix: harden --chdir error handling; add deprecation warning

### DIFF
--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -392,6 +392,7 @@ func CreateGlobalArgParser(name string) *argparser.ArgParser {
 	ap.SupportsString("port", "", "port", "Defines the port to connect to.")
 	ap.SupportsFlag("no-tls", "", "Disables TLS for the connection to remote databases.")
 	ap.SupportsString("data-dir", "", "data-dir", "Defines a data directory whose subdirectories should all be dolt data repositories accessible as independent databases. Defaults to the current directory.")
+	ap.SupportsString("chdir", "", "dir", "[deprecated] Change to directory before executing subcommand.")
 	ap.SupportsString("doltcfg-dir", "", "doltcfg-dir", "Defines a directory that contains configuration files for dolt. Defaults to `$data-dir/.doltcfg`. Will only be created if there is a change to configuration settings.")
 	ap.SupportsString("privilege-file", "", "privilege-file", "Path to a file to load and store users and grants. Defaults to `$doltcfg-dir/privileges.db`. Will only be created if there is a change to privileges.")
 	ap.SupportsString("branch-control-file", "", "branch-control-file", "Path to a file to load and store branch control permissions. Defaults to `$doltcfg-dir/branch_control.db`. Will only be created if there is a change to branch control permissions.")

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -348,12 +348,14 @@ func runMain() int {
 			// This is a hack that allows a different working directory to be set after the application starts using
 			// chdir=<DIR>.  The syntax is not flexible and must match exactly this.
 			case chdirFlag:
-				err := os.Chdir(args[1])
-
-				if err != nil {
-					panic(err)
+				if len(args) < 2 {
+					cli.PrintErrln(color.RedString("--chdir requires a directory argument"))
+					return 1
 				}
-
+				if err := os.Chdir(args[1]); err != nil {
+					cli.PrintErrln(color.RedString("cannot change to directory %q: %v", args[1], err))
+					return 1
+				}
 				args = args[2:]
 
 			case stdInFlag:

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -344,14 +344,14 @@ func runMain() int {
 					defer tp.Shutdown(context.Background())
 					args = args[1:]
 				}
-			// Currently goland doesn't support running with a different working directory when using go modules.
-			// This is a hack that allows a different working directory to be set after the application starts using
-			// chdir=<DIR>.  The syntax is not flexible and must match exactly this.
+			// --chdir is a GoLand IDE workaround retained for backward compatibility.
+			// Deprecated: will be removed in a future release. Use -C instead (see #10956).
 			case chdirFlag:
 				if len(args) < 2 {
 					cli.PrintErrln(color.RedString("--chdir requires a directory argument"))
 					return 1
 				}
+				cli.PrintErrln(color.YellowString("Warning: --chdir is deprecated and will be removed in a future release. Use -C instead."))
 				if err := os.Chdir(args[1]); err != nil {
 					cli.PrintErrln(color.RedString("cannot change to directory %q: %v", args[1], err))
 					return 1


### PR DESCRIPTION
## Summary

Two independent commits — cherry-pick either or both:

**Commit 1 — bug fixes (uncontroversial):**
- `--chdir` without a following argument previously read `args[1]` out of bounds; now exits with a clear error
- `os.Chdir()` failure previously called `panic(err)`; now exits cleanly with a readable message

**Commit 2 — deprecation (for maintainers to evaluate):**
- Emits a yellow warning to stderr when `--chdir` is used, pointing users to `-C` (PR #10956)
- Registers `--chdir` in the global arg parser so it appears in `--help` with a `[deprecated]` note

**Note on commit 2:** `--chdir` is handled in the debug-flags pre-pass in `runMain()`, not by the global arg parser — so the parser registration is for help-text visibility only. The underlying `os.Chdir()` behaviour is unchanged. The tradeoffs for maintainers to consider:
- The runtime warning on stderr could break GoLand or any tooling that reads combined output — though `--chdir` was explicitly a GoLand workaround, so this risk may be low
- Registering in the arg parser makes `--chdir` visible in `--help` for the first time, which may be undesirable if the intent is to quietly retire it
- The deprecation message references `-C` which lands in #10956 — if this PR is merged first, the message still makes sense as a forward reference

We have what we came for with #10956. This PR is offered as a housekeeping contribution — accept, reject, or cherry-pick the bug-fix commit only as you see fit.

Note: the revision history on this and #10956 reflects an overzealous code assistant. The PRs were correctly separated and structured on reflection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)