### PR TITLE
Fix obscure race: make sure that RunF finishes before StopF in sqlServer.Start()

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/mcp.go
+++ b/go/cmd/dolt/commands/sqlserver/mcp.go
@@ -101,7 +101,7 @@ func zapToLogrusLevel(l zapcore.Level) logrus.Level {
 }
 
 // mcpInit validates and reserves the MCP port
-func mcpInit(cfg *Config, state *svcs.ServiceState) func(context.Context) error {
+func mcpInit(cfg *Config) func(context.Context) error {
 	return func(context.Context) error {
 		addr := net.JoinHostPort("0.0.0.0", strconv.Itoa(*cfg.MCP.Port))
 		l, err := net.Listen("tcp", addr)
@@ -109,18 +109,13 @@ func mcpInit(cfg *Config, state *svcs.ServiceState) func(context.Context) error 
 			return err
 		}
 		_ = l.Close()
-		state.Swap(svcs.ServiceState_Init)
 		return nil
 	}
 }
 
 // mcpRun starts the MCP HTTP server and wires lifecycle to errgroup
-func mcpRun(cfg *Config, lgr *logrus.Logger, state *svcs.ServiceState, cancelPtr *context.CancelFunc, groupPtr **errgroup.Group) func(context.Context) {
+func mcpRun(cfg *Config, lgr *logrus.Logger, cancelPtr *context.CancelFunc, groupPtr **errgroup.Group) func(context.Context) {
 	return func(ctx context.Context) {
-		if !state.CompareAndSwap(svcs.ServiceState_Init, svcs.ServiceState_Run) {
-			return
-		}
-
 		// Logger for MCP (prefix and level inherited from logrus)
 		logger := newZapFromLogrusWithPrefix(lgr, "[dolt-mcp] ")
 
@@ -180,17 +175,17 @@ func mcpRun(cfg *Config, lgr *logrus.Logger, state *svcs.ServiceState, cancelPtr
 }
 
 // mcpStop gracefully stops the MCP server by cancelling context and waiting for the errgroup
-func mcpStop(cancel context.CancelFunc, group *errgroup.Group, state *svcs.ServiceState) func() error {
-	return func() error {
-		if cancel != nil {
-			cancel()
+func mcpStop(cancelPtr *context.CancelFunc, groupPtr **errgroup.Group) func(svcs.RunState) error {
+	return func(rs svcs.RunState) error {
+		if rs == svcs.RunNotInvoked {
+			return nil
 		}
-		if group != nil {
-			if err := group.Wait(); err != nil {
-				return err
-			}
+		if *cancelPtr != nil {
+			(*cancelPtr)()
 		}
-		state.Swap(svcs.ServiceState_Stopped)
+		if *groupPtr != nil {
+			return (*groupPtr).Wait()
+		}
 		return nil
 	}
 }
@@ -200,14 +195,13 @@ func registerMCPService(controller *svcs.Controller, cfg *Config, lgr *logrus.Lo
 	if cfg.MCP == nil || cfg.MCP.Port == nil || *cfg.MCP.Port <= 0 {
 		return
 	}
-	var state svcs.ServiceState
 	var cancel context.CancelFunc
 	var group *errgroup.Group
 
 	svc := &svcs.AnonService{
-		InitF: mcpInit(cfg, &state),
-		RunF:  mcpRun(cfg, lgr, &state, &cancel, &group),
-		StopF: mcpStop(cancel, group, &state),
+		InitF: mcpInit(cfg),
+		RunF:  mcpRun(cfg, lgr, &cancel, &group),
+		StopF: mcpStop(&cancel, &group),
 	}
 	_ = controller.Register(svc)
 }

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/dolthub/go-mysql-server/eventscheduler"
@@ -212,7 +211,7 @@ func ConfigureServices(
 			localCreds, err = persistServerLocalCreds(cfg.ServerConfig.Port(), cfg.DoltEnv)
 			return err
 		},
-		StopF: func() error {
+		StopF: func(_ svcs.RunState) error {
 			RemoveLocalCreds(cfg.DoltEnv.FS)
 			return nil
 		},
@@ -329,7 +328,7 @@ func ConfigureServices(
 	// all inflight queries.
 	var mySQLServer *server.Server
 	DrainClientConnectionsOnShutdown := &svcs.AnonService{
-		StopF: func() error {
+		StopF: func(_ svcs.RunState) error {
 			if mySQLServer != nil {
 				mySQLServer.SessionManager().WaitForClosedConnections()
 			}
@@ -368,7 +367,7 @@ func ConfigureServices(
 			}
 			return sql.SystemVariables.SetGlobal(sqlCtx, "read_only", readOnlyValue)
 		},
-		StopF: func() error {
+		StopF: func(_ svcs.RunState) error {
 			sqlEngine.Close()
 			return nil
 		},
@@ -382,7 +381,7 @@ func ConfigureServices(
 	// after they are killed, but it is not currently set up that
 	// way.
 	CloseClientConnectionsOnShutdown := &svcs.AnonService{
-		StopF: func() error {
+		StopF: func(_ svcs.RunState) error {
 			if mySQLServer != nil {
 				sm := mySQLServer.SessionManager()
 				return sm.Iter(func(s sql.Session) (bool, error) {
@@ -547,7 +546,7 @@ func ConfigureServices(
 			metListener, err = newMetricsListener(labels, cfg.Version, path, clusterController, metricsExposed)
 			return err
 		},
-		StopF: func() error {
+		StopF: func(_ svcs.RunState) error {
 			metListener.Close()
 			return nil
 		},
@@ -615,16 +614,16 @@ func ConfigureServices(
 	controller.Register(DisableMySQLDbIfRequired)
 
 	type SQLMetricsService struct {
-		state svcs.ServiceState
-		lis   net.Listener
-		srv   *http.Server
+		enabled bool
+		lis     net.Listener
+		srv     *http.Server
 	}
 
 	var metSrv SQLMetricsService
 	RunMetricsServer := &svcs.AnonService{
 		InitF: func(context.Context) (err error) {
 			if cfg.ServerConfig.MetricsHost() != "" && cfg.ServerConfig.MetricsPort() > 0 {
-				metSrv.state.Swap(svcs.ServiceState_Init)
+				metSrv.enabled = true
 
 				addr := fmt.Sprintf("%s:%d", cfg.ServerConfig.MetricsHost(), cfg.ServerConfig.MetricsPort())
 				metSrv.lis, err = net.Listen("tcp", addr)
@@ -692,7 +691,7 @@ func ConfigureServices(
 			return nil
 		},
 		RunF: func(context.Context) {
-			if metSrv.state.CompareAndSwap(svcs.ServiceState_Init, svcs.ServiceState_Run) {
+			if metSrv.enabled {
 				if metSrv.srv.TLSConfig != nil {
 					_ = metSrv.srv.ServeTLS(metSrv.lis, "", "")
 				} else {
@@ -700,11 +699,13 @@ func ConfigureServices(
 				}
 			}
 		},
-		StopF: func() error {
-			state := metSrv.state.Swap(svcs.ServiceState_Stopped)
-			if state == svcs.ServiceState_Run {
+		StopF: func(rs svcs.RunState) error {
+			if !metSrv.enabled {
+				return nil
+			}
+			if rs == svcs.RunInvoked {
 				metSrv.srv.Close()
-			} else if state == svcs.ServiceState_Init {
+			} else {
 				metSrv.lis.Close()
 			}
 			return nil
@@ -713,9 +714,9 @@ func ConfigureServices(
 	controller.Register(RunMetricsServer)
 
 	type RemoteSrvService struct {
-		state svcs.ServiceState
-		lis   remotesrv.Listeners
-		srv   *remotesrv.Server
+		enabled bool
+		lis     remotesrv.Listeners
+		srv     *remotesrv.Server
 	}
 	var remoteSrv RemoteSrvService
 	RunRemoteSrv := &svcs.AnonService{
@@ -723,7 +724,7 @@ func ConfigureServices(
 			if cfg.ServerConfig.RemotesapiPort() == nil {
 				return nil
 			}
-			remoteSrv.state.Swap(svcs.ServiceState_Init)
+			remoteSrv.enabled = true
 
 			port := *cfg.ServerConfig.RemotesapiPort()
 
@@ -770,15 +771,17 @@ func ConfigureServices(
 			return nil
 		},
 		RunF: func(ctx context.Context) {
-			if remoteSrv.state.CompareAndSwap(svcs.ServiceState_Init, svcs.ServiceState_Run) {
+			if remoteSrv.enabled {
 				remoteSrv.srv.Serve(remoteSrv.lis)
 			}
 		},
-		StopF: func() error {
-			state := remoteSrv.state.Swap(svcs.ServiceState_Stopped)
-			if state == svcs.ServiceState_Run {
+		StopF: func(rs svcs.RunState) error {
+			if !remoteSrv.enabled {
+				return nil
+			}
+			if rs == svcs.RunInvoked {
 				remoteSrv.srv.GracefulStop()
-			} else if state == svcs.ServiceState_Init {
+			} else {
 				remoteSrv.lis.Close()
 			}
 			return nil
@@ -792,7 +795,7 @@ func ConfigureServices(
 			if clusterController == nil {
 				return nil
 			}
-			clusterRemoteSrv.state.Swap(svcs.ServiceState_Init)
+			clusterRemoteSrv.enabled = true
 
 			args, err := clusterController.RemoteSrvServerArgs(sqlEngine.NewDefaultContext, remotesrv.ServerArgs{
 				Logger: logrus.NewEntry(lgr),
@@ -825,15 +828,17 @@ func ConfigureServices(
 			return nil
 		},
 		RunF: func(context.Context) {
-			if clusterRemoteSrv.state.CompareAndSwap(svcs.ServiceState_Init, svcs.ServiceState_Run) {
+			if clusterRemoteSrv.enabled {
 				clusterRemoteSrv.srv.Serve(clusterRemoteSrv.lis)
 			}
 		},
-		StopF: func() error {
-			state := clusterRemoteSrv.state.Swap(svcs.ServiceState_Stopped)
-			if state == svcs.ServiceState_Run {
+		StopF: func(rs svcs.RunState) error {
+			if !clusterRemoteSrv.enabled {
+				return nil
+			}
+			if rs == svcs.RunInvoked {
 				clusterRemoteSrv.srv.GracefulStop()
-			} else if state == svcs.ServiceState_Init {
+			} else {
 				clusterRemoteSrv.lis.Close()
 			}
 			return nil
@@ -879,7 +884,7 @@ func ConfigureServices(
 			}
 			return err
 		},
-		StopF: func() (err error) {
+		StopF: func(_ svcs.RunState) (err error) {
 			if !sqlServerClosed {
 				sqlServerClosed = true
 				return mySQLServer.Close()
@@ -925,7 +930,7 @@ func ConfigureServices(
 			}
 			clusterController.Run()
 		},
-		StopF: func() error {
+		StopF: func(_ svcs.RunState) error {
 			if clusterController == nil {
 				return nil
 			}
@@ -935,21 +940,20 @@ func ConfigureServices(
 	}
 	controller.Register(RunClusterController)
 
-	var serverShutdownWg sync.WaitGroup
+	runDone := make(chan struct{})
 	RunSQLServer := &svcs.AnonService{
 		RunF: func(context.Context) {
-			serverShutdownWg.Add(1)
-			defer func() {
-				serverShutdownWg.Done()
-			}()
+			defer close(runDone)
 			sqlserver.SetRunningServer(mySQLServer)
 			defer sqlserver.UnsetRunningServer()
 			mySQLServer.Start()
 		},
-		StopF: func() error {
+		StopF: func(rs svcs.RunState) error {
 			sqlServerClosed = true
 			closeErr := mySQLServer.Close()
-			serverShutdownWg.Wait()
+			if rs == svcs.RunInvoked {
+				<-runDone
+			}
 			return closeErr
 		},
 	}
@@ -1006,7 +1010,7 @@ func newHeartbeatService(version string, dEnv *env.DoltEnv) *heartbeatService {
 
 func (h *heartbeatService) Init(ctx context.Context) error { return nil }
 
-func (h *heartbeatService) Stop() error {
+func (h *heartbeatService) Stop(_ svcs.RunState) error {
 	if h.closer != nil {
 		return h.closer()
 	}

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/dolthub/go-mysql-server/eventscheduler"
@@ -934,15 +935,22 @@ func ConfigureServices(
 	}
 	controller.Register(RunClusterController)
 
+	var serverShutdownWg sync.WaitGroup
 	RunSQLServer := &svcs.AnonService{
 		RunF: func(context.Context) {
+			serverShutdownWg.Add(1)
+			defer func() {
+				serverShutdownWg.Done()
+			}()
 			sqlserver.SetRunningServer(mySQLServer)
 			defer sqlserver.UnsetRunningServer()
 			mySQLServer.Start()
 		},
 		StopF: func() error {
 			sqlServerClosed = true
-			return mySQLServer.Close()
+			closeErr := mySQLServer.Close()
+			serverShutdownWg.Wait()
+			return closeErr
 		},
 	}
 	controller.Register(RunSQLServer)

--- a/go/libraries/utils/svcs/controller.go
+++ b/go/libraries/utils/svcs/controller.go
@@ -18,7 +18,21 @@ import (
 	"context"
 	"errors"
 	"sync"
-	"sync/atomic"
+)
+
+// RunState indicates whether the controller invoked a service's Run method
+// before calling Stop. Stop implementations should use this to skip cleanup
+// that depends on Run having executed (e.g. waiting on a goroutine that was
+// only started inside Run).
+type RunState int
+
+const (
+	// RunNotInvoked means the controller did not call Run on this service.
+	// This happens when initialization fails before all services are started,
+	// or when the controller is stopped before transitioning to the running state.
+	RunNotInvoked RunState = iota
+	// RunInvoked means the controller called Run on this service.
+	RunInvoked
 )
 
 // A Service is a runnable unit of functionality that a Controller can
@@ -27,10 +41,15 @@ import (
 // bring the service up. It has a |Run| function, which will be called in a
 // separate go-routine and should run and provide the functionality associated
 // with the service until the |Stop| function is called.
+//
+// Stop receives a RunState indicating whether Run was invoked. When
+// RunNotInvoked, Stop should only undo work done in Init (e.g. close a
+// listener that was created). When RunInvoked, Stop should also wait for the
+// Run goroutine to complete if necessary.
 type Service interface {
 	Init(context.Context) error
 	Run(context.Context)
-	Stop() error
+	Stop(RunState) error
 }
 
 // AnonService is a simple struct for building Service instances with lambdas
@@ -38,7 +57,7 @@ type Service interface {
 type AnonService struct {
 	InitF func(context.Context) error
 	RunF  func(context.Context)
-	StopF func() error
+	StopF func(RunState) error
 }
 
 func (a AnonService) Init(ctx context.Context) error {
@@ -55,36 +74,11 @@ func (a AnonService) Run(ctx context.Context) {
 	a.RunF(ctx)
 }
 
-func (a AnonService) Stop() error {
+func (a AnonService) Stop(rs RunState) error {
 	if a.StopF == nil {
 		return nil
 	}
-	return a.StopF()
-}
-
-// ServiceState is a small abstraction so that a service implementation can
-// easily track what state it is in and can make decisions about what to do
-// based on what state it is coming from. In particular, it's not rare for a
-// |Close| implementation to need to do something different based on whether
-// the service is only init'd or if it is running. It's also not rare for a
-// service to decide it needs to do nothing in Init, in which case it can leave
-// the service in Off, and the Run and Close methods can check that to ensure
-// they do not do anything either.
-type ServiceState uint32
-
-const (
-	ServiceState_Off ServiceState = iota
-	ServiceState_Init
-	ServiceState_Run
-	ServiceState_Stopped
-)
-
-func (ss *ServiceState) Swap(new ServiceState) (old ServiceState) {
-	return ServiceState(atomic.SwapUint32((*uint32)(ss), uint32(new)))
-}
-
-func (ss *ServiceState) CompareAndSwap(old, new ServiceState) (swapped bool) {
-	return atomic.CompareAndSwapUint32((*uint32)(ss), uint32(old), uint32(new))
+	return a.StopF(rs)
 }
 
 // A Controller is responsible for initializing a number of registered
@@ -95,16 +89,17 @@ func (ss *ServiceState) CompareAndSwap(old, new ServiceState) (swapped bool) {
 // |Stop| is called, services are stopped in reverse-registration order. |Stop|
 // returns once the corresponding |Stop| method on all successfully |Init|ed
 // services has returned. |Stop| does not explicitly block for the goroutines
-// where the |Run| methods are called to complete.  Typically a Service's
-// |Stop| function should ensure that the |Run| method has completed before
-// returning.
+// where the |Run| methods are called to complete.  A Service's |Stop| function
+// should use the |RunState| parameter to determine whether |Run| was invoked
+// and wait for it to complete if necessary.
 //
 // Any attempt to register a service after |Start| or |Stop| has been called
 // will return an error.
 //
 // If an error occurs when initializing the services of a Controller, the
 // Stop functions of any already initialized Services are called in
-// reverse-order. The error which caused the initialization error is returned.
+// reverse-order with RunNotInvoked. The error which caused the initialization
+// error is returned.
 //
 // In the case that all Services Init successfully, the error returned from
 // |Start| is the first non-nil error which is returned from the |Stop|
@@ -221,7 +216,7 @@ func (c *Controller) Start(ctx context.Context) error {
 		err := s.Init(ctx)
 		if err != nil {
 			for j := i - 1; j >= 0; j-- {
-				svcs[j].Stop()
+				svcs[j].Stop(RunNotInvoked)
 			}
 			c.mu.Lock()
 			c.state = controllerState_stopped
@@ -234,20 +229,26 @@ func (c *Controller) Start(ctx context.Context) error {
 	}
 	close(c.startCh)
 	c.mu.Lock()
+	runInvoked := false
 	if c.state == controllerState_starting {
 		c.state = controllerState_running
 		c.mu.Unlock()
 		for _, s := range svcs {
 			go s.Run(ctx)
 		}
+		runInvoked = true
 		<-c.stopCh
 	} else {
 		// We were stopped while initializing. Start shutting things down.
 		c.mu.Unlock()
 	}
+	rs := RunNotInvoked
+	if runInvoked {
+		rs = RunInvoked
+	}
 	var stopErr error
 	for i := len(svcs) - 1; i >= 0; i-- {
-		err := svcs[i].Stop()
+		err := svcs[i].Stop(rs)
 		if err != nil && stopErr == nil {
 			stopErr = err
 		}

--- a/go/libraries/utils/svcs/controller_test.go
+++ b/go/libraries/utils/svcs/controller_test.go
@@ -43,12 +43,12 @@ func TestController(t *testing.T) {
 			require.NoError(t, c.Register(&AnonService{
 				InitF: func(context.Context) error { return nil },
 				RunF:  func(context.Context) {},
-				StopF: func() error { return errors.New("second") },
+				StopF: func(RunState) error { return errors.New("second") },
 			}))
 			require.NoError(t, c.Register(&AnonService{
 				InitF: func(context.Context) error { return nil },
 				RunF:  func(context.Context) {},
-				StopF: func() error { return err },
+				StopF: func(RunState) error { return err },
 			}))
 			var wg sync.WaitGroup
 			wg.Add(1)
@@ -88,7 +88,7 @@ func TestController(t *testing.T) {
 				require.Error(t, c.Register(&AnonService{
 					InitF: func(context.Context) error { return nil },
 					RunF:  func(context.Context) {},
-					StopF: func() error { return nil },
+					StopF: func(RunState) error { return nil },
 				}))
 				c.Stop()
 			}()
@@ -107,7 +107,7 @@ func TestController(t *testing.T) {
 					return nil
 				},
 				RunF:  func(context.Context) {},
-				StopF: func() error { return nil },
+				StopF: func(RunState) error { return nil },
 			}))
 			require.NoError(t, c.Register(&AnonService{
 				InitF: func(context.Context) error {
@@ -115,7 +115,7 @@ func TestController(t *testing.T) {
 					return nil
 				},
 				RunF:  func(context.Context) {},
-				StopF: func() error { return nil },
+				StopF: func(RunState) error { return nil },
 			}))
 			require.NoError(t, c.Register(&AnonService{
 				InitF: func(context.Context) error {
@@ -123,7 +123,7 @@ func TestController(t *testing.T) {
 					return nil
 				},
 				RunF:  func(context.Context) {},
-				StopF: func() error { return nil },
+				StopF: func(RunState) error { return nil },
 			}))
 			ctx := context.Background()
 			var wg sync.WaitGroup
@@ -148,7 +148,7 @@ func TestController(t *testing.T) {
 					return nil
 				},
 				RunF:  func(context.Context) {},
-				StopF: func() error { return nil },
+				StopF: func(RunState) error { return nil },
 			}))
 			require.NoError(t, c.Register(&AnonService{
 				InitF: func(context.Context) error {
@@ -156,14 +156,14 @@ func TestController(t *testing.T) {
 					return nil
 				},
 				RunF:  func(context.Context) {},
-				StopF: func() error { return nil },
+				StopF: func(RunState) error { return nil },
 			}))
 			require.NoError(t, c.Register(&AnonService{
 				InitF: func(context.Context) error {
 					return err
 				},
 				RunF:  func(context.Context) {},
-				StopF: func() error { return nil },
+				StopF: func(RunState) error { return nil },
 			}))
 			require.NoError(t, c.Register(&AnonService{
 				InitF: func(context.Context) error {
@@ -171,7 +171,7 @@ func TestController(t *testing.T) {
 					return nil
 				},
 				RunF:  func(context.Context) {},
-				StopF: func() error { return nil },
+				StopF: func(RunState) error { return nil },
 			}))
 			ctx := context.Background()
 			var wg sync.WaitGroup
@@ -195,7 +195,7 @@ func TestController(t *testing.T) {
 					return nil
 				},
 				RunF: func(context.Context) {},
-				StopF: func() error {
+				StopF: func(RunState) error {
 					stopped = append(stopped, 0)
 					return nil
 				},
@@ -205,7 +205,7 @@ func TestController(t *testing.T) {
 					return nil
 				},
 				RunF: func(context.Context) {},
-				StopF: func() error {
+				StopF: func(RunState) error {
 					stopped = append(stopped, 1)
 					return nil
 				},
@@ -215,7 +215,7 @@ func TestController(t *testing.T) {
 					return err
 				},
 				RunF: func(context.Context) {},
-				StopF: func() error {
+				StopF: func(RunState) error {
 					stopped = append(stopped, 2)
 					return nil
 				},
@@ -225,7 +225,7 @@ func TestController(t *testing.T) {
 					return nil
 				},
 				RunF: func(context.Context) {},
-				StopF: func() error {
+				StopF: func(RunState) error {
 					stopped = append(stopped, 3)
 					return nil
 				},
@@ -250,12 +250,12 @@ func TestController(t *testing.T) {
 			require.NoError(t, c.Register(&AnonService{
 				InitF: func(context.Context) error { return nil },
 				RunF:  func(context.Context) { wg.Done() },
-				StopF: func() error { return nil },
+				StopF: func(RunState) error { return nil },
 			}))
 			require.NoError(t, c.Register(&AnonService{
 				InitF: func(context.Context) error { return nil },
 				RunF:  func(context.Context) { wg.Done() },
-				StopF: func() error { return nil },
+				StopF: func(RunState) error { return nil },
 			}))
 			ctx := context.Background()
 			var cwg sync.WaitGroup
@@ -278,7 +278,7 @@ func TestController(t *testing.T) {
 			require.NoError(t, c.Register(&AnonService{
 				InitF: func(context.Context) error { return nil },
 				RunF:  func(context.Context) {},
-				StopF: func() error {
+				StopF: func(RunState) error {
 					wg.Done()
 					return errors.New("second error")
 				},
@@ -286,7 +286,7 @@ func TestController(t *testing.T) {
 			require.NoError(t, c.Register(&AnonService{
 				InitF: func(context.Context) error { return nil },
 				RunF:  func(context.Context) {},
-				StopF: func() error {
+				StopF: func(RunState) error {
 					wg.Done()
 					return err
 				},
@@ -303,6 +303,50 @@ func TestController(t *testing.T) {
 			require.ErrorIs(t, c.WaitForStop(), err)
 			wg.Wait()
 			cwg.Wait()
+		})
+	})
+	t.Run("RunState", func(t *testing.T) {
+		t.Run("RunInvokedOnNormalStop", func(t *testing.T) {
+			c := NewController()
+			var receivedState RunState = -1
+			require.NoError(t, c.Register(&AnonService{
+				RunF:  func(context.Context) {},
+				StopF: func(rs RunState) error { receivedState = rs; return nil },
+			}))
+			ctx := context.Background()
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				require.NoError(t, c.WaitForStart())
+				c.Stop()
+			}()
+			require.NoError(t, c.Start(ctx))
+			require.NoError(t, c.WaitForStop())
+			require.Equal(t, RunInvoked, receivedState)
+			wg.Wait()
+		})
+		t.Run("RunNotInvokedOnInitFailure", func(t *testing.T) {
+			c := NewController()
+			var receivedState RunState = -1
+			initErr := errors.New("init failed")
+			require.NoError(t, c.Register(&AnonService{
+				StopF: func(rs RunState) error { receivedState = rs; return nil },
+			}))
+			require.NoError(t, c.Register(&AnonService{
+				InitF: func(context.Context) error { return initErr },
+			}))
+			ctx := context.Background()
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				c.WaitForStart()
+				c.Stop()
+			}()
+			require.ErrorIs(t, c.Start(ctx), initErr)
+			require.Equal(t, RunNotInvoked, receivedState)
+			wg.Wait()
 		})
 	})
 	t.Run("RunStopsControllerExample", func(t *testing.T) {
@@ -325,8 +369,10 @@ func TestController(t *testing.T) {
 				go c.Stop()
 				runWg.Done()
 			},
-			StopF: func() error {
-				runWg.Wait()
+			StopF: func(rs RunState) error {
+				if rs == RunInvoked {
+					runWg.Wait()
+				}
 				return runErr
 			},
 		}


### PR DESCRIPTION
This is a candidate for race conditions leading to nil pointer exceptions in some doltgres harness setups.