### PR TITLE
Update dump-docs to emit headers matching the docs site

### DIFF
--- a/go/cmd/dolt/commands/dump_docs.go
+++ b/go/cmd/dolt/commands/dump_docs.go
@@ -33,7 +33,7 @@ const (
 		"---\n" +
 		"title: CLI\n" +
 		"---\n\n" +
-		"# Command Line Interface Reference\n\n"
+		"# Commands\n\n"
 )
 
 type DumpDocsCmd struct {


### PR DESCRIPTION
## Summary
- `dolt dump-docs` now emits `# Commands` as the h1 instead of `# Command Line Interface Reference`
- Per-command headings and `Global Arguments` stay at h2, matching the dolthub/docs-2 site structure
- Removes the need to manually post-process headings on every dump

## Test plan
- [ ] `dolt dump-docs --file /tmp/cli.md` produces output with `# Commands` h1 and `## ` per-command headings