### PR TITLE
Db/git remote UI

### DIFF
--- a/go/libraries/doltcore/dbfactory/git_remote.go
+++ b/go/libraries/doltcore/dbfactory/git_remote.go
@@ -144,7 +144,7 @@ func (fact GitRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFor
 	}
 
 	q := nbs.NewUnlimitedMemQuotaProvider()
-	cs, err := nbs.NewGitStore(ctx, nbf.VersionString(), cacheRepo, ref, blobstore.GitBlobstoreOptions{RemoteName: remoteName}, memlimit.MemtableSize(), q)
+	cs, err := nbs.NewGitStore(ctx, nbf.VersionString(), cacheRepo, ref, blobstore.GitBlobstoreOptions{RemoteName: remoteName, InfoBranch: blobstore.DefaultInfoBranch}, memlimit.MemtableSize(), q)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/go/store/blobstore/git_blobstore.go
+++ b/go/store/blobstore/git_blobstore.go
@@ -327,6 +327,11 @@ type GitBlobstore struct {
 	// syncForRead will skip the fetch if the last sync completed within this duration.
 	// Defaults to defaultSyncForReadTTL. Set to 0 to disable dedup (useful in tests).
 	syncForReadTTL time.Duration
+
+	// infoBranch, when non-empty, is the short branch name (e.g. "__dolt_remote_info__")
+	// for a visible info branch pushed after each successful data write. The branch
+	// contains a single DOLT_REMOTE.md file with remote metadata. Empty means disabled.
+	infoBranch string
 }
 
 var _ Blobstore = (*GitBlobstore)(nil)
@@ -377,6 +382,10 @@ type GitBlobstoreOptions struct {
 	// RemoteName is the git remote name to use for remote-managed mode (e.g. "origin").
 	// If empty, it defaults to "origin".
 	RemoteName string
+	// InfoBranch, when non-empty, enables pushing a visible branch containing a
+	// DOLT_REMOTE.md file after each successful data push. The value is the short
+	// branch name (e.g. "__dolt_remote_info__"). Overridden by DOLT_REMOTE_INFO_BRANCH env var.
+	InfoBranch string
 }
 
 // NewGitBlobstoreWithOptions creates a GitBlobstore rooted at |gitDir| and |ref|.
@@ -401,6 +410,8 @@ func NewGitBlobstoreWithOptions(gitDir, ref string, opts GitBlobstoreOptions) (*
 	remoteTrackingRef := RemoteTrackingRef(remoteName, remoteRef, instanceID)
 	localRef := OwnedLocalRef(remoteName, remoteRef, instanceID)
 
+	infoBranch := ResolveInfoBranch(opts.InfoBranch)
+
 	return &GitBlobstore{
 		gitDir:            gitDir,
 		remoteRef:         remoteRef,
@@ -414,6 +425,7 @@ func NewGitBlobstoreWithOptions(gitDir, ref string, opts GitBlobstoreOptions) (*
 		cacheObjects:      make(map[string]cachedGitObject),
 		cacheChildren:     make(map[string][]git.TreeEntry),
 		syncForReadTTL:    defaultSyncForReadTTL,
+		infoBranch:        infoBranch,
 	}, nil
 }
 
@@ -786,6 +798,65 @@ func (gbs *GitBlobstore) fetchAlignAndMergeForWrite(ctx context.Context) (remote
 	return remoteHead, true, nil
 }
 
+const infoBranchFileName = "DOLT_REMOTE.md"
+
+func formatDoltRemoteInfo(remoteRef string, headOID git.OID, ts time.Time) []byte {
+	return []byte(fmt.Sprintf(
+		"This repository is being used as a Dolt remote.\n\nref=%s\nhead=%s\ntimestamp=%s\n",
+		remoteRef, headOID, ts.UTC().Format(time.RFC3339),
+	))
+}
+
+// pushInfoBranch creates and force-pushes a visible branch containing a single
+// DOLT_REMOTE.md file with metadata about the Dolt remote. This is best-effort:
+// failures are silently ignored and never affect the data write path.
+func (gbs *GitBlobstore) pushInfoBranch(ctx context.Context, headOID git.OID) {
+	if gbs.infoBranch == "" {
+		return
+	}
+
+	infoRef := "refs/heads/" + gbs.infoBranch
+	localInfoRef := "refs/dolt/info/" + gbs.infoBranch
+
+	content := formatDoltRemoteInfo(gbs.remoteRef, headOID, time.Now())
+
+	blobOID, err := gbs.api.HashObject(ctx, bytes.NewReader(content))
+	if err != nil {
+		return
+	}
+
+	_, indexFile, cleanup, err := git.NewTempIndex()
+	if err != nil {
+		return
+	}
+	defer cleanup()
+
+	if err := gbs.api.ReadTreeEmpty(ctx, indexFile); err != nil {
+		return
+	}
+	if err := gbs.api.UpdateIndexCacheInfo(ctx, indexFile, "100644", blobOID, infoBranchFileName); err != nil {
+		return
+	}
+	treeOID, err := gbs.api.WriteTree(ctx, indexFile)
+	if err != nil {
+		return
+	}
+
+	commitOID, err := gbs.api.CommitTree(ctx, treeOID, nil, "dolt remote info", gbs.identity)
+	if err != nil && gbs.identity == nil && isMissingGitIdentityErr(err) {
+		commitOID, err = gbs.api.CommitTree(ctx, treeOID, nil, "dolt remote info", defaultGitBlobstoreIdentity())
+	}
+	if err != nil {
+		return
+	}
+
+	if err := gbs.api.UpdateRef(ctx, localInfoRef, commitOID, "dolt remote info"); err != nil {
+		return
+	}
+
+	_ = gbs.api.ForcePushRef(ctx, gbs.remoteName, localInfoRef, infoRef)
+}
+
 func (gbs *GitBlobstore) remoteManagedWrite(ctx context.Context, key, msg string, build func(parent git.OID, ok bool) (git.OID, error)) (string, error) {
 	if err := gbs.validateRemoteManaged(); err != nil {
 		return "", err
@@ -825,6 +896,9 @@ func (gbs *GitBlobstore) remoteManagedWrite(ctx context.Context, key, msg string
 		if err := gbs.api.PushRefWithLease(ctx, gbs.remoteName, gbs.localRef, gbs.remoteRef, remoteHead); err != nil {
 			return err
 		}
+
+		// Best-effort: update the visible info branch with current remote metadata.
+		gbs.pushInfoBranch(ctx, newCommit)
 
 		// Merge cache additively to reflect the new head after a successful push.
 		if err := gbs.mergeCacheFromHead(ctx, newCommit); err != nil {

--- a/go/store/blobstore/git_blobstore.go
+++ b/go/store/blobstore/git_blobstore.go
@@ -802,7 +802,7 @@ const infoBranchFileName = "DOLT_REMOTE.md"
 
 func formatDoltRemoteInfo(remoteRef string, headOID git.OID, ts time.Time) []byte {
 	return []byte(fmt.Sprintf(
-		"This repository is being used as a Dolt remote.\n\nref=%s\nhead=%s\ntimestamp=%s\n",
+		"This repository is being used as a Dolt remote.\n\nref=%s\n\nhead=%s\n\ntimestamp=%s\n",
 		remoteRef, headOID, ts.UTC().Format(time.RFC3339),
 	))
 }

--- a/go/store/blobstore/git_blobstore_helpers_test.go
+++ b/go/store/blobstore/git_blobstore_helpers_test.go
@@ -36,6 +36,7 @@ type fakeGitAPI struct {
 	blobReader          func(ctx context.Context, oid git.OID) (io.ReadCloser, error)
 	fetchRef            func(ctx context.Context, remote string, srcRef string, dstRef string) error
 	pushRefWithLease    func(ctx context.Context, remote string, srcRef string, dstRef string, expectedDstOID git.OID) error
+	forcePushRef        func(ctx context.Context, remote, srcRef, dstRef string) error
 }
 
 func (f fakeGitAPI) TryResolveRefCommit(ctx context.Context, ref string) (git.OID, bool, error) {
@@ -109,6 +110,12 @@ func (f fakeGitAPI) PushRefWithLease(ctx context.Context, remote string, srcRef 
 		panic("unexpected call")
 	}
 	return f.pushRefWithLease(ctx, remote, srcRef, dstRef, expectedDstOID)
+}
+func (f fakeGitAPI) ForcePushRef(ctx context.Context, remote, srcRef, dstRef string) error {
+	if f.forcePushRef == nil {
+		return nil
+	}
+	return f.forcePushRef(ctx, remote, srcRef, dstRef)
 }
 
 func TestGitBlobstoreHelpers_validateAndSizeChunkedParts(t *testing.T) {

--- a/go/store/blobstore/git_refs.go
+++ b/go/store/blobstore/git_refs.go
@@ -16,11 +16,29 @@ package blobstore
 
 import (
 	"fmt"
+	"os"
 	"strings"
 )
 
 // DoltDataRef is the default remote ref backing a git-object-db dolt blobstore.
 const DoltDataRef = "refs/dolt/data"
+
+// DefaultInfoBranch is the default short branch name for the visible info branch
+// that indicates a repository is being used as a Dolt remote.
+const DefaultInfoBranch = "__dolt_remote_info__"
+
+// InfoBranchEnvVar is the environment variable that overrides the info branch name.
+// Set to an empty string to disable the info branch entirely.
+const InfoBranchEnvVar = "DOLT_REMOTE_INFO_BRANCH"
+
+// ResolveInfoBranch returns the info branch name from the environment, falling
+// back to the provided default. An empty return value means "disabled".
+func ResolveInfoBranch(defaultBranch string) string {
+	if v, ok := os.LookupEnv(InfoBranchEnvVar); ok {
+		return strings.TrimSpace(v)
+	}
+	return defaultBranch
+}
 
 func trimRefsPrefix(ref string) string {
 	return strings.TrimPrefix(ref, "refs/")

--- a/go/store/blobstore/internal/git/api.go
+++ b/go/store/blobstore/internal/git/api.go
@@ -131,6 +131,10 @@ type GitAPI interface {
 	// the remote |dstRef| is missing (bootstrap / create-if-missing semantics).
 	// Equivalent plumbing: GIT_DIR=... git push --force-with-lease=<dstRef>:<expectedDstOID> <remote> <srcRef>:<dstRef>
 	PushRefWithLease(ctx context.Context, remote string, srcRef string, dstRef string, expectedDstOID OID) error
+
+	// ForcePushRef force-pushes |srcRef| to |dstRef| on |remote| unconditionally.
+	// Equivalent plumbing: GIT_DIR=... git push --force <remote> <srcRef>:<dstRef>
+	ForcePushRef(ctx context.Context, remote, srcRef, dstRef string) error
 }
 
 // TreeEntry describes one entry in a git tree listing.

--- a/go/store/blobstore/internal/git/impl.go
+++ b/go/store/blobstore/internal/git/impl.go
@@ -362,6 +362,22 @@ func (a *GitAPIImpl) PushRefWithLease(ctx context.Context, remote string, srcRef
 	return err
 }
 
+func (a *GitAPIImpl) ForcePushRef(ctx context.Context, remote, srcRef, dstRef string) error {
+	if remote == "" {
+		return fmt.Errorf("git push: remote is required")
+	}
+	if srcRef == "" {
+		return fmt.Errorf("git push: src ref is required")
+	}
+	if dstRef == "" {
+		return fmt.Errorf("git push: dst ref is required")
+	}
+	srcRef = strings.TrimPrefix(srcRef, "+")
+	refspec := srcRef + ":" + dstRef
+	_, err := a.r.Run(ctx, RunOptions{}, "push", "--force", remote, refspec)
+	return err
+}
+
 func isRefNotFoundErr(err error) bool {
 	var ce *CmdError
 	if !errors.As(err, &ce) {


### PR DESCRIPTION
This PR updates git remotes to push a branch visible on the Git remote's UI that contains a file with some info about the git ref used as the dolt remote. Addresses https://github.com/dolthub/dolt/issues/10525