### PR TITLE
fix(sql): use LEFT JOIN in blame view to handle schema-only reverts

### DIFF
--- a/go/libraries/doltcore/sqle/dtables/blame_view.go
+++ b/go/libraries/doltcore/sqle/dtables/blame_view.go
@@ -42,10 +42,10 @@ const (
 								 diff_type,
 				                 ROW_NUMBER() OVER (
 				                     PARTITION BY 
-										%s  -- pksPartitionByExpression
+											%s  -- pksPartitionByExpression
 				                     ORDER BY 
-										coalesce(to_commit_date, from_commit_date) DESC
-								) row_num
+											coalesce(to_commit_date, from_commit_date) DESC
+									) row_num
 				             FROM
 				                 ` + "`dolt_diff_%s`" + ` -- tableName
 				            )
@@ -57,11 +57,11 @@ const (
 				    dl.email,
 				    dl.message
 				FROM
-				    sorted_diffs_by_pk as sd,
-				    dolt_log as dl
+				    sorted_diffs_by_pk as sd
+				LEFT JOIN
+				    dolt_log as dl ON dl.commit_hash = sd.to_commit
 				WHERE
-				    dl.commit_hash = sd.to_commit
-				    and sd.row_num = 1
+				    sd.row_num = 1
 				    and sd.diff_type <> 'removed'
 				ORDER BY 
 					%s  -- pksOrderByExpression;


### PR DESCRIPTION
## Description

When a schema-only commit (involving DROP TABLE + RENAME TO) is reverted,
`dolt_blame_<table>` returns zero rows even though the table has live data.

## Root Cause

The blame view used an implicit cross join (`FROM a, b WHERE a.x = b.y`) to
join `sorted_diffs_by_pk` with `dolt_log`. After a schema-only revert, the
`to_commit` hash from the diff table may not match any commit in `dolt_log`,
causing all rows to be filtered out.

## Fix

Changed the blame view SQL to use a `LEFT JOIN` between `sorted_diffs_by_pk`
and `dolt_log`, so rows from the diff table are returned even when the commit
hash lookup in `dolt_log` doesn't find a match.

Fixes #10965