### PR TITLE
[no-release-notes] Remove uses of context.Background() by threading in context from callers.

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/dolthub/dolt-mcp v0.3.4
 	github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-mysql-server v0.20.1-0.20260501191624-9fe39826fadc
+	github.com/dolthub/go-mysql-server v0.20.1-0.20260501214944-8e27527885cc
 	github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63
 	github.com/edsrzf/mmap-go v1.2.0
 	github.com/esote/minmaxheap v1.0.0

--- a/go/go.mod
+++ b/go/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/dolthub/dolt-mcp v0.3.4
 	github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-mysql-server v0.20.1-0.20260430234618-54db0b76729b
+	github.com/dolthub/go-mysql-server v0.20.1-0.20260501191624-9fe39826fadc
 	github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63
 	github.com/edsrzf/mmap-go v1.2.0
 	github.com/esote/minmaxheap v1.0.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -216,6 +216,8 @@ github.com/dolthub/go-mysql-server v0.20.1-0.20260430234618-54db0b76729b h1:SJIR
 github.com/dolthub/go-mysql-server v0.20.1-0.20260430234618-54db0b76729b/go.mod h1:XHHBMl8dUEt4UeBYDNeEFc3CqwzI6XgPLG74qi/W7MM=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260501191624-9fe39826fadc h1:ben7b7sHr4ULBQJuSJ5bC8f6y48rRi+w3BTPPA7IHc8=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260501191624-9fe39826fadc/go.mod h1:XHHBMl8dUEt4UeBYDNeEFc3CqwzI6XgPLG74qi/W7MM=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260501214944-8e27527885cc h1:63Oxz/p3+vao2ZMki8+1Dfy1wMxQZZ3oGdcxNY0WEMc=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260501214944-8e27527885cc/go.mod h1:XHHBMl8dUEt4UeBYDNeEFc3CqwzI6XgPLG74qi/W7MM=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20260414231531-5f031e3e9037 h1:oIW9HwuWrhxv+4HZxA+QQSKHLqWFyXZ2FmNjUYwkdiM=

--- a/go/go.sum
+++ b/go/go.sum
@@ -214,6 +214,8 @@ github.com/dolthub/go-icu-regex v0.0.0-20260412212219-49724d547866 h1:U6gSf5I0e6
 github.com/dolthub/go-icu-regex v0.0.0-20260412212219-49724d547866/go.mod h1:F3cnm+vMRK1HaU6+rNqQrOCyR03HHhR1GWG2gnPOqaE=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260430234618-54db0b76729b h1:SJIREe/wYf0HJh6D60GVtipBsKiMrpKnvStHDfPDZWE=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260430234618-54db0b76729b/go.mod h1:XHHBMl8dUEt4UeBYDNeEFc3CqwzI6XgPLG74qi/W7MM=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260501191624-9fe39826fadc h1:ben7b7sHr4ULBQJuSJ5bC8f6y48rRi+w3BTPPA7IHc8=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260501191624-9fe39826fadc/go.mod h1:XHHBMl8dUEt4UeBYDNeEFc3CqwzI6XgPLG74qi/W7MM=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20260414231531-5f031e3e9037 h1:oIW9HwuWrhxv+4HZxA+QQSKHLqWFyXZ2FmNjUYwkdiM=

--- a/go/libraries/doltcore/doltdb/durable/index.go
+++ b/go/libraries/doltcore/doltdb/durable/index.go
@@ -297,7 +297,7 @@ func (i prollyIndex) AddColumnToRows(ctx context.Context, newCol string, newSche
 			b.PutRaw(i+1, v.GetField(i))
 		}
 
-		tup, err := b.BuildPermissive(sharePool)
+		tup, err := b.BuildPermissive(ctx, sharePool)
 		if err != nil {
 			return nil, err
 		}

--- a/go/libraries/doltcore/doltdb/gc_test.go
+++ b/go/libraries/doltcore/doltdb/gc_test.go
@@ -259,11 +259,11 @@ func newIntMap(t *testing.T, ctx context.Context, ns tree.NodeStore, k, v int8) 
 
 	tb := val.NewTupleBuilder(desc, ns)
 	tb.PutInt8(0, k)
-	keyTuple, err := tb.Build(ns.Pool())
+	keyTuple, err := tb.Build(ctx, ns.Pool())
 	require.NoError(t, err)
 
 	tb.PutInt8(0, v)
-	valueTuple, err := tb.Build(ns.Pool())
+	valueTuple, err := tb.Build(ctx, ns.Pool())
 	require.NoError(t, err)
 
 	m, err := prolly.NewMapFromTuples(ctx, ns, desc, desc, keyTuple, valueTuple)

--- a/go/libraries/doltcore/merge/fulltext_table.go
+++ b/go/libraries/doltcore/merge/fulltext_table.go
@@ -162,7 +162,7 @@ func (table *fulltextTable) ApplyToTable(ctx *sql.Context) (*doltdb.Table, error
 				return nil, err
 			}
 		}
-		k, err := keyBld.Build(sharePool)
+		k, err := keyBld.Build(ctx, sharePool)
 		if err != nil {
 			return nil, err
 		}
@@ -173,7 +173,7 @@ func (table *fulltextTable) ApplyToTable(ctx *sql.Context) (*doltdb.Table, error
 				return nil, err
 			}
 		}
-		v, err := valBld.Build(sharePool)
+		v, err := valBld.Build(ctx, sharePool)
 		if err != nil {
 			return nil, err
 		}

--- a/go/libraries/doltcore/merge/keyless_integration_test.go
+++ b/go/libraries/doltcore/merge/keyless_integration_test.go
@@ -449,7 +449,7 @@ func (e keylessEntry) HashAndValue() ([]byte, val.Tuple, error) {
 	valBld.PutInt64(1, int64(e.c1))
 	valBld.PutInt64(2, int64(e.c2))
 
-	value, err := valBld.Build(sharePool)
+	value, err := valBld.Build(context.Background(), sharePool)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/libraries/doltcore/merge/merge_prolly_indexes.go
+++ b/go/libraries/doltcore/merge/merge_prolly_indexes.go
@@ -135,11 +135,11 @@ func buildIndex(
 		pkMapping := ordinalMappingFromIndex(index)
 
 		mergedMap, err := creation.BuildUniqueProllyIndex(ctx, vrw, ns, postMergeSchema, tblName, index, m, func(ctx context.Context, existingKey, newKey val.Tuple) (err error) {
-			eK, err := getPKFromSecondaryKey(kb, p, pkMapping, existingKey)
+			eK, err := getPKFromSecondaryKey(ctx, kb, p, pkMapping, existingKey)
 			if err != nil {
 				return err
 			}
-			nK, err := getPKFromSecondaryKey(kb, p, pkMapping, newKey)
+			nK, err := getPKFromSecondaryKey(ctx, kb, p, pkMapping, newKey)
 			if err != nil {
 				return err
 			}

--- a/go/libraries/doltcore/merge/merge_prolly_rows.go
+++ b/go/libraries/doltcore/merge/merge_prolly_rows.go
@@ -963,7 +963,7 @@ func (idx uniqIndex) removeRow(ctx *sql.Context, key, value val.Tuple) error {
 		return err
 	}
 
-	clusteredIndexKey, err := idx.clusteredBld.ClusteredKeyFromIndexKey(secondaryIndexKey)
+	clusteredIndexKey, err := idx.clusteredBld.ClusteredKeyFromIndexKey(ctx, secondaryIndexKey)
 	if err != nil {
 		return err
 	}
@@ -999,7 +999,7 @@ func (idx uniqIndex) findCollisions(ctx *sql.Context, key, value val.Tuple, cb c
 	collisionDetected := false
 	for _, collision := range collisions {
 		// Next find the key in the primary (aka clustered) index
-		clusteredKey, err := idx.clusteredBld.ClusteredKeyFromIndexKey(collision)
+		clusteredKey, err := idx.clusteredBld.ClusteredKeyFromIndexKey(ctx, collision)
 		if err != nil {
 			return err
 		}
@@ -1702,7 +1702,7 @@ func remapTupleWithColumnDefaults(
 		}
 	}
 
-	return tb.Build(pool)
+	return tb.Build(ctx, pool)
 }
 
 // writeTupleExpression attempts to evaluate the expression string |exprString| against the row provided and write it

--- a/go/libraries/doltcore/merge/merge_test.go
+++ b/go/libraries/doltcore/merge/merge_test.go
@@ -68,7 +68,7 @@ var syncPool = pool.NewBuffPool()
 func (v rowV) value() val.Tuple {
 	vB.PutInt64(0, int64(v.col1))
 	vB.PutInt64(1, int64(v.col2))
-	tup, err := vB.Build(syncPool)
+	tup, err := vB.Build(context.Background(), syncPool)
 	if err != nil {
 		panic(err)
 	}
@@ -571,7 +571,7 @@ var kB *val.TupleBuilder
 
 func key(i int) val.Tuple {
 	kB.PutInt64(0, int64(i))
-	tup, err := kB.Build(syncPool)
+	tup, err := kB.Build(context.Background(), syncPool)
 	if err != nil {
 		panic(err)
 	}

--- a/go/libraries/doltcore/merge/row_merge_test.go
+++ b/go/libraries/doltcore/merge/row_merge_test.go
@@ -15,6 +15,7 @@
 package merge
 
 import (
+	"context"
 	"strconv"
 	"testing"
 
@@ -232,7 +233,7 @@ func buildTup(sch schema.Schema, r []*int) val.Tuple {
 			vB.PutInt64(i, int64(*v))
 		}
 	}
-	tup, err := vB.Build(syncPool)
+	tup, err := vB.Build(context.Background(), syncPool)
 	if err != nil {
 		panic(err)
 	}

--- a/go/libraries/doltcore/merge/violations_fk_prolly.go
+++ b/go/libraries/doltcore/merge/violations_fk_prolly.go
@@ -83,7 +83,7 @@ func prollyParentSecDiffFkConstraintViolations(
 	err = prolly.DiffMaps(ctx, preParentSecIdx, postParentSecIdx, considerAllRowsModified, func(ctx context.Context, diff tree.Diff) error {
 		switch diff.Type {
 		case tree.RemovedDiff, tree.ModifiedDiff:
-			k, hadNulls, err := makePartialKey(parentIdxKb, foreignKey.ReferencedTableColumns, postParent.Index, postParent.IndexSchema, val.Tuple(diff.Key), val.Tuple(diff.From), preParentSecIdx.Pool())
+			k, hadNulls, err := makePartialKey(ctx, parentIdxKb, foreignKey.ReferencedTableColumns, postParent.Index, postParent.IndexSchema, val.Tuple(diff.Key), val.Tuple(diff.From), preParentSecIdx.Pool())
 			if err != nil {
 				return err
 			}
@@ -178,7 +178,7 @@ func prollyParentPriDiffFkConstraintViolations(
 	err = prolly.DiffMaps(ctx, preParentRowData, postParentRowData, considerAllRowsModified, func(ctx context.Context, diff tree.Diff) error {
 		switch diff.Type {
 		case tree.RemovedDiff, tree.ModifiedDiff:
-			partialKey, hadNulls, err := makePartialKey(partialKB, foreignKey.ReferencedTableColumns, postParent.Index, postParent.Schema, val.Tuple(diff.Key), val.Tuple(diff.From), preParentRowData.Pool())
+			partialKey, hadNulls, err := makePartialKey(ctx, partialKB, foreignKey.ReferencedTableColumns, postParent.Index, postParent.Schema, val.Tuple(diff.Key), val.Tuple(diff.From), preParentRowData.Pool())
 			if err != nil {
 				return err
 			}
@@ -268,6 +268,7 @@ func prollyChildPriDiffFkConstraintViolations(
 		case tree.AddedDiff, tree.ModifiedDiff:
 			k, v := val.Tuple(diff.Key), val.Tuple(diff.To)
 			parentLookupKey, hasNulls, err := makePartialKey(
+				ctx,
 				partialKB,
 				foreignKey.TableColumns,
 				postChild.Index,
@@ -512,7 +513,7 @@ func createCVForSecIdx(
 ) error {
 
 	// convert secondary idx entry to primary row key
-	primaryKey, err := primaryKeyFromSecondaryIndexRow(k, primaryKD, pri, tableSchema, indexSchema)
+	primaryKey, err := primaryKeyFromSecondaryIndexRow(ctx, k, primaryKD, pri, tableSchema, indexSchema)
 	if err != nil {
 		return err
 	}
@@ -532,7 +533,7 @@ func createCVForSecIdx(
 	return receiver.ProllyFKViolationFound(ctx, primaryKey, value)
 }
 
-func primaryKeyFromSecondaryIndexRow(secIndexRow val.Tuple, primaryKD *val.TupleDesc, pri prolly.Map, tableSchema schema.Schema, indexSchema schema.Schema) (val.Tuple, error) {
+func primaryKeyFromSecondaryIndexRow(ctx context.Context, secIndexRow val.Tuple, primaryKD *val.TupleDesc, pri prolly.Map, tableSchema schema.Schema, indexSchema schema.Schema) (val.Tuple, error) {
 	keyMap := makeOrdinalMappingForSchemas(indexSchema, tableSchema)
 
 	kb := val.NewTupleBuilder(primaryKD, pri.NodeStore())
@@ -541,7 +542,7 @@ func primaryKeyFromSecondaryIndexRow(secIndexRow val.Tuple, primaryKD *val.Tuple
 		kb.PutRaw(to, secIndexRow.GetField(from))
 	}
 
-	return kb.Build(pri.Pool())
+	return kb.Build(ctx, pri.Pool())
 }
 
 // makeOrdinalMappingForSchemas creates an ordinal mapping from one schema to another based on column names.
@@ -609,7 +610,7 @@ func createCVsForDanglingChildRows(
 		}
 
 		// convert secondary idx entry to primary row key
-		primaryIdxKey, err := primaryKeyFromSecondaryIndexRow(k, childPrimaryIdx.keyDesc, childPrimaryIdx.index, childPrimaryIdx.schema, childSecIdx.schema)
+		primaryIdxKey, err := primaryKeyFromSecondaryIndexRow(ctx, k, childPrimaryIdx.keyDesc, childPrimaryIdx.index, childPrimaryIdx.schema, childSecIdx.schema)
 		if err != nil {
 			return err
 		}
@@ -703,7 +704,7 @@ func convertKeyBetweenTypes(
 	}
 
 	var err error
-	key, err = tb.Build(pool)
+	key, err = tb.Build(ctx, pool)
 	if err != nil {
 		return nil, err
 	}
@@ -778,7 +779,7 @@ func convertNativeEncodedFkField(
 	}
 }
 
-func makePartialKey(kb *val.TupleBuilder, tags []uint64, idxSch schema.Index, tblSch schema.Schema, k, v val.Tuple, pool pool.BuffPool) (val.Tuple, bool, error) {
+func makePartialKey(ctx context.Context, kb *val.TupleBuilder, tags []uint64, idxSch schema.Index, tblSch schema.Schema, k, v val.Tuple, pool pool.BuffPool) (val.Tuple, bool, error) {
 	// Possible that the parent index (idxSch) is longer than the partial key (tags).
 	if idxSch.Name() != "" && len(idxSch.IndexedColumnTags()) <= len(tags) {
 		tags = idxSch.IndexedColumnTags()
@@ -803,7 +804,7 @@ func makePartialKey(kb *val.TupleBuilder, tags []uint64, idxSch schema.Index, tb
 		}
 	}
 
-	tup, err := kb.Build(pool)
+	tup, err := kb.Build(ctx, pool)
 	return tup, false, err
 }
 

--- a/go/libraries/doltcore/merge/violations_unique_prolly.go
+++ b/go/libraries/doltcore/merge/violations_unique_prolly.go
@@ -108,12 +108,12 @@ func replaceUniqueKeyViolation(ctx context.Context, edt *prolly.ArtifactsEditor,
 	return nil
 }
 
-func getPKFromSecondaryKey(pKB *val.TupleBuilder, pool pool.BuffPool, pkMapping val.OrdinalMapping, k val.Tuple) (val.Tuple, error) {
+func getPKFromSecondaryKey(ctx context.Context, pKB *val.TupleBuilder, pool pool.BuffPool, pkMapping val.OrdinalMapping, k val.Tuple) (val.Tuple, error) {
 	for to := range pkMapping {
 		from := pkMapping.MapOrdinal(to)
 		pKB.PutRaw(to, k.GetField(from))
 	}
-	return pKB.Build(pool)
+	return pKB.Build(ctx, pool)
 }
 
 func ordinalMappingFromIndex(def schema.Index) (m val.OrdinalMapping) {

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_type_serialization_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_type_serialization_test.go
@@ -49,7 +49,7 @@ func TestStringSerializer(t *testing.T) {
 
 	t.Run("VARCHAR 1 byte length encoding", func(t *testing.T) {
 		tupleBuilder.PutString(0, "abc")
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(context.Background(), varchar20, tupleDesc, tuple, 0, nil)
@@ -65,7 +65,7 @@ func TestStringSerializer(t *testing.T) {
 	})
 	t.Run("VARCHAR 2 byte length encoding", func(t *testing.T) {
 		tupleBuilder.PutString(0, "abc")
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(context.Background(), varchar255, tupleDesc, tuple, 0, nil)
@@ -82,7 +82,7 @@ func TestStringSerializer(t *testing.T) {
 	t.Run("CHAR 1 byte length encoding", func(t *testing.T) {
 		typ := gmstypes.MustCreateString(sqltypes.Char, 25, sql.Collation_Default)
 		tupleBuilder.PutString(0, "abc")
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(context.Background(), typ, tupleDesc, tuple, 0, nil)
@@ -99,7 +99,7 @@ func TestStringSerializer(t *testing.T) {
 	t.Run("CHAR 2 byte length encoding", func(t *testing.T) {
 		typ := gmstypes.MustCreateString(sqltypes.Char, 100, sql.Collation_Default)
 		tupleBuilder.PutString(0, "abc")
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(context.Background(), typ, tupleDesc, tuple, 0, nil)
@@ -118,7 +118,7 @@ func TestStringSerializer(t *testing.T) {
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		typ := gmstypes.MustCreateString(sqltypes.VarBinary, 50, sql.Collation_binary)
 		tupleBuilder.PutByteString(0, []byte{'a', 'b', 'c'})
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(context.Background(), typ, tupleDesc, tuple, 0, nil)
@@ -137,7 +137,7 @@ func TestStringSerializer(t *testing.T) {
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		typ := gmstypes.MustCreateString(sqltypes.VarBinary, 420, sql.Collation_binary)
 		tupleBuilder.PutByteString(0, []byte{'a', 'b', 'c'})
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(context.Background(), typ, tupleDesc, tuple, 0, nil)
@@ -157,7 +157,7 @@ func TestStringSerializer(t *testing.T) {
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		typ := gmstypes.MustCreateString(sqltypes.Binary, 25, sql.Collation_binary)
 		tupleBuilder.PutByteString(0, []byte{'a', 'b', 'c'})
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(context.Background(), typ, tupleDesc, tuple, 0, nil)
@@ -184,7 +184,7 @@ func TestFloatSerializer_Float32(t *testing.T) {
 	tupleDesc := val.NewTupleDescriptor(val.Type{Enc: val.Float32Enc})
 	tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 	tupleBuilder.PutFloat32(0, 3.1415927)
-	tuple, err := tupleBuilder.Build(buffPool)
+	tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 	require.NoError(t, err)
 	value, err := s.deserialize(nil, gmstypes.Float32, tupleDesc, tuple, 0, nil)
 	require.NoError(t, err)
@@ -205,7 +205,7 @@ func TestFloatSerializer_Float64(t *testing.T) {
 	tupleDesc := val.NewTupleDescriptor(val.Type{Enc: val.Float64Enc})
 	tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 	tupleBuilder.PutFloat64(0, 3.1415926535)
-	tuple, err := tupleBuilder.Build(buffPool)
+	tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 	require.NoError(t, err)
 
 	value, err := s.deserialize(nil, gmstypes.Float64, tupleDesc, tuple, 0, nil)
@@ -227,7 +227,7 @@ func TestYearSerializer(t *testing.T) {
 	tupleDesc := val.NewTupleDescriptor(val.Type{Enc: val.YearEnc})
 	tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 	tupleBuilder.PutYear(0, 2030)
-	tuple, err := tupleBuilder.Build(buffPool)
+	tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 	require.NoError(t, err)
 
 	value, err := s.deserialize(nil, gmstypes.Year, tupleDesc, tuple, 0, nil)
@@ -253,7 +253,7 @@ func TestDatetimeSerializer(t *testing.T) {
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		tupleBuilder.PutDatetime(0,
 			time.Date(2012, 6, 21, 15, 45, 17, 0, time.UTC))
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, datetimeType, tupleDesc, tuple, 0,
@@ -275,7 +275,7 @@ func TestDatetimeSerializer(t *testing.T) {
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		tupleBuilder.PutDatetime(0,
 			time.Date(2012, 6, 21, 15, 45, 17, .7*1_000_000_000, time.UTC))
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, datetimeType, tupleDesc, tuple, 0, nil)
@@ -296,7 +296,7 @@ func TestDatetimeSerializer(t *testing.T) {
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		tupleBuilder.PutDatetime(0,
 			time.Date(2012, 6, 21, 15, 45, 17, .76*1_000_000_000, time.UTC))
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, datetimeType, tupleDesc, tuple, 0, nil)
@@ -317,7 +317,7 @@ func TestDatetimeSerializer(t *testing.T) {
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		tupleBuilder.PutDatetime(0,
 			time.Date(2012, 6, 21, 15, 45, 17, .765*1_000_000_000, time.UTC))
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, datetimeType, tupleDesc, tuple, 0, nil)
@@ -338,7 +338,7 @@ func TestDatetimeSerializer(t *testing.T) {
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		tupleBuilder.PutDatetime(0,
 			time.Date(2012, 6, 21, 15, 45, 17, .7654*1_000_000_000, time.UTC))
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, datetimeType, tupleDesc, tuple, 0, nil)
@@ -359,7 +359,7 @@ func TestDatetimeSerializer(t *testing.T) {
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		tupleBuilder.PutDatetime(0,
 			time.Date(2012, 6, 21, 15, 45, 17, .76543*1_000_000_000, time.UTC))
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, datetimeType, tupleDesc, tuple, 0, nil)
@@ -380,7 +380,7 @@ func TestDatetimeSerializer(t *testing.T) {
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		tupleBuilder.PutDatetime(0,
 			time.Date(2012, 6, 21, 15, 45, 17, .765432*1_000_000_000, time.UTC))
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, datetimeType, tupleDesc, tuple, 0, nil)
@@ -407,7 +407,7 @@ func TestTimestampSerializer(t *testing.T) {
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		tupleBuilder.PutDatetime(0,
 			time.Date(2017, 03, 21, 14, 25, 9, 0.0*1_000_000_000, time.UTC))
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, timestampType, tupleDesc, tuple, 0, nil)
@@ -428,7 +428,7 @@ func TestTimestampSerializer(t *testing.T) {
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		tupleBuilder.PutDatetime(0,
 			time.Date(2017, 03, 21, 14, 25, 9, 0.7*1_000_000_000, time.UTC))
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, timestampType, tupleDesc, tuple, 0, nil)
@@ -449,7 +449,7 @@ func TestTimestampSerializer(t *testing.T) {
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		tupleBuilder.PutDatetime(0,
 			time.Date(2017, 03, 21, 14, 25, 9, 0.76*1_000_000_000, time.UTC))
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, timestampType, tupleDesc, tuple, 0, nil)
@@ -470,7 +470,7 @@ func TestTimestampSerializer(t *testing.T) {
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		tupleBuilder.PutDatetime(0,
 			time.Date(2017, 03, 21, 14, 25, 9, 0.765*1_000_000_000, time.UTC))
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, timestampType, tupleDesc, tuple, 0, nil)
@@ -491,7 +491,7 @@ func TestTimestampSerializer(t *testing.T) {
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		tupleBuilder.PutDatetime(0,
 			time.Date(2017, 03, 21, 14, 25, 9, 0.7654*1_000_000_000, time.UTC))
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, timestampType, tupleDesc, tuple, 0, nil)
@@ -512,7 +512,7 @@ func TestTimestampSerializer(t *testing.T) {
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		tupleBuilder.PutDatetime(0,
 			time.Date(2017, 03, 21, 14, 25, 9, 0.76543*1_000_000_000, time.UTC))
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, timestampType, tupleDesc, tuple, 0, nil)
@@ -533,7 +533,7 @@ func TestTimestampSerializer(t *testing.T) {
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		tupleBuilder.PutDatetime(0,
 			time.Date(2017, 03, 21, 14, 25, 9, 0.765432*1_000_000_000, time.UTC))
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, timestampType, tupleDesc, tuple, 0, nil)
@@ -558,7 +558,7 @@ func TestDateSerializer(t *testing.T) {
 	tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 	tupleBuilder.PutDate(0,
 		time.Date(2010, 10, 03, 0, 0, 0, 0.0*1_000_000_000, time.UTC))
-	tuple, err := tupleBuilder.Build(buffPool)
+	tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 	require.NoError(t, err)
 
 	value, err := s.deserialize(nil, gmstypes.Date, tupleDesc, tuple, 0, nil)
@@ -582,7 +582,7 @@ func TestTimeSerializer(t *testing.T) {
 		tupleDesc := val.NewTupleDescriptor(val.Type{Enc: val.TimeEnc})
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		tupleBuilder.PutSqlTime(0, (0 * time.Second).Microseconds())
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -601,7 +601,7 @@ func TestTimeSerializer(t *testing.T) {
 		tupleDesc := val.NewTupleDescriptor(val.Type{Enc: val.TimeEnc})
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		tupleBuilder.PutSqlTime(0, (-1 * time.Microsecond).Microseconds())
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -620,7 +620,7 @@ func TestTimeSerializer(t *testing.T) {
 		tupleDesc := val.NewTupleDescriptor(val.Type{Enc: val.TimeEnc})
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		tupleBuilder.PutSqlTime(0, (-99 * time.Microsecond).Microseconds())
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -639,7 +639,7 @@ func TestTimeSerializer(t *testing.T) {
 		tupleDesc := val.NewTupleDescriptor(val.Type{Enc: val.TimeEnc})
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		tupleBuilder.PutSqlTime(0, -1*(time.Second).Microseconds())
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -658,7 +658,7 @@ func TestTimeSerializer(t *testing.T) {
 		tupleDesc := val.NewTupleDescriptor(val.Type{Enc: val.TimeEnc})
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		tupleBuilder.PutSqlTime(0, -1*(time.Second+time.Microsecond).Microseconds())
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -677,7 +677,7 @@ func TestTimeSerializer(t *testing.T) {
 		tupleDesc := val.NewTupleDescriptor(val.Type{Enc: val.TimeEnc})
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		tupleBuilder.PutSqlTime(0, -1*(time.Second+10*time.Microsecond).Microseconds())
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -696,7 +696,7 @@ func TestTimeSerializer(t *testing.T) {
 		tupleDesc := val.NewTupleDescriptor(val.Type{Enc: val.TimeEnc})
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		tupleBuilder.PutSqlTime(0, (15*time.Hour + 34*time.Minute + 54*time.Second).Microseconds())
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -715,7 +715,7 @@ func TestTimeSerializer(t *testing.T) {
 		tupleDesc := val.NewTupleDescriptor(val.Type{Enc: val.TimeEnc})
 		tupleBuilder := val.NewTupleBuilder(tupleDesc, ns)
 		tupleBuilder.PutSqlTime(0, (time.Second + 100*time.Millisecond).Microseconds())
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -738,7 +738,7 @@ func TestIntegerSerializer(t *testing.T) {
 		typ := gmstypes.Int8
 		tupleDesc, tupleBuilder := newTupleBuilderForEncoding(val.Int8Enc)
 		tupleBuilder.PutInt8(0, -2)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -756,7 +756,7 @@ func TestIntegerSerializer(t *testing.T) {
 		typ := gmstypes.Uint8
 		tupleDesc, tupleBuilder := newTupleBuilderForEncoding(val.Uint8Enc)
 		tupleBuilder.PutUint8(0, 130)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -774,7 +774,7 @@ func TestIntegerSerializer(t *testing.T) {
 		typ := gmstypes.Int16
 		tupleDesc, tupleBuilder := newTupleBuilderForEncoding(val.Int16Enc)
 		tupleBuilder.PutInt16(0, int16(-2))
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -792,7 +792,7 @@ func TestIntegerSerializer(t *testing.T) {
 		typ := gmstypes.Uint16
 		tupleDesc, tupleBuilder := newTupleBuilderForEncoding(val.Uint16Enc)
 		tupleBuilder.PutUint16(0, 0x8182)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -810,7 +810,7 @@ func TestIntegerSerializer(t *testing.T) {
 		typ := gmstypes.Int24
 		tupleDesc, tupleBuilder := newTupleBuilderForEncoding(val.Int32Enc)
 		tupleBuilder.PutInt32(0, -259)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -828,7 +828,7 @@ func TestIntegerSerializer(t *testing.T) {
 		typ := gmstypes.Uint24
 		tupleDesc, tupleBuilder := newTupleBuilderForEncoding(val.Uint32Enc)
 		tupleBuilder.PutUint32(0, 0x818283)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -846,7 +846,7 @@ func TestIntegerSerializer(t *testing.T) {
 		typ := gmstypes.Int32
 		tupleDesc, tupleBuilder := newTupleBuilderForEncoding(val.Int32Enc)
 		tupleBuilder.PutInt32(0, -66052)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -864,7 +864,7 @@ func TestIntegerSerializer(t *testing.T) {
 		typ := gmstypes.Uint32
 		tupleDesc, tupleBuilder := newTupleBuilderForEncoding(val.Uint32Enc)
 		tupleBuilder.PutUint32(0, 0x81828384)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -882,7 +882,7 @@ func TestIntegerSerializer(t *testing.T) {
 		typ := gmstypes.Int64
 		tupleDesc, tupleBuilder := newTupleBuilderForEncoding(val.Int64Enc)
 		tupleBuilder.PutInt64(0, -283686952306184)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -900,7 +900,7 @@ func TestIntegerSerializer(t *testing.T) {
 		typ := gmstypes.Uint64
 		tupleDesc, tupleBuilder := newTupleBuilderForEncoding(val.Uint64Enc)
 		tupleBuilder.PutUint64(0, 0x8182838485868788)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -925,7 +925,7 @@ func TestDecimalSerializer(t *testing.T) {
 		dec, err := decimal.NewFromString("0")
 		require.NoError(t, err)
 		tupleBuilder.PutDecimal(0, dec)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -945,7 +945,7 @@ func TestDecimalSerializer(t *testing.T) {
 		dec, err := decimal.NewFromString("100")
 		require.NoError(t, err)
 		tupleBuilder.PutDecimal(0, dec)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -965,7 +965,7 @@ func TestDecimalSerializer(t *testing.T) {
 		dec, err := decimal.NewFromString("1.1")
 		require.NoError(t, err)
 		tupleBuilder.PutDecimal(0, dec)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -985,7 +985,7 @@ func TestDecimalSerializer(t *testing.T) {
 		dec, err := decimal.NewFromString("100")
 		require.NoError(t, err)
 		tupleBuilder.PutDecimal(0, dec)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -1005,7 +1005,7 @@ func TestDecimalSerializer(t *testing.T) {
 		dec, err := decimal.NewFromString("1234567890.1234")
 		require.NoError(t, err)
 		tupleBuilder.PutDecimal(0, dec)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -1025,7 +1025,7 @@ func TestDecimalSerializer(t *testing.T) {
 		dec, err := decimal.NewFromString("-1234567890.1234")
 		require.NoError(t, err)
 		tupleBuilder.PutDecimal(0, dec)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -1045,7 +1045,7 @@ func TestDecimalSerializer(t *testing.T) {
 		dec, err := decimal.NewFromString("1234567890.0001")
 		require.NoError(t, err)
 		tupleBuilder.PutDecimal(0, dec)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -1067,7 +1067,7 @@ func TestBitSerializer(t *testing.T) {
 	typ := gmstypes.MustCreateBitType(15)
 	tupleDesc, tupleBuilder := newTupleBuilderForEncoding(val.Uint64Enc)
 	tupleBuilder.PutUint64(0, 0x0301)
-	tuple, err := tupleBuilder.Build(buffPool)
+	tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 	require.NoError(t, err)
 
 	value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -1089,7 +1089,7 @@ func TestEnumSerializer(t *testing.T) {
 		typ := gmstypes.MustCreateEnumType([]string{"red", "green", "blue"}, sql.Collation_Default)
 		tupleDesc, tupleBuilder := newTupleBuilderForEncoding(val.EnumEnc)
 		tupleBuilder.PutEnum(0, 0x03)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -1107,7 +1107,7 @@ func TestEnumSerializer(t *testing.T) {
 		typ := gmstypes.MustCreateEnumType(createTestStringSlice(267), sql.Collation_Default)
 		tupleDesc, tupleBuilder := newTupleBuilderForEncoding(val.EnumEnc)
 		tupleBuilder.PutEnum(0, 0x0102)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -1129,7 +1129,7 @@ func TestSetSerializer(t *testing.T) {
 	typ := gmstypes.MustCreateSetType(createTestStringSlice(12), sql.Collation_Default)
 	tupleDesc, tupleBuilder := newTupleBuilderForEncoding(val.SetEnc)
 	tupleBuilder.PutSet(0, 0x0102)
-	tuple, err := tupleBuilder.Build(buffPool)
+	tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 	require.NoError(t, err)
 
 	value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -1152,7 +1152,7 @@ func TestBlobSerializer(t *testing.T) {
 		tupleDesc, tupleBuilder := newTupleBuilderForEncoding(val.BytesAddrEnc)
 		ns, addr := createTestBlob(t, []byte(`abc`))
 		tupleBuilder.PutBytesAddr(0, addr)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -1171,7 +1171,7 @@ func TestBlobSerializer(t *testing.T) {
 		tupleDesc, tupleBuilder := newTupleBuilderForEncoding(val.BytesAddrEnc)
 		ns, addr := createTestBlob(t, []byte(`abc`))
 		tupleBuilder.PutBytesAddr(0, addr)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -1190,7 +1190,7 @@ func TestBlobSerializer(t *testing.T) {
 		tupleDesc, tupleBuilder := newTupleBuilderForEncoding(val.BytesAddrEnc)
 		ns, addr := createTestBlob(t, []byte(`abc`))
 		tupleBuilder.PutBytesAddr(0, addr)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -1209,7 +1209,7 @@ func TestBlobSerializer(t *testing.T) {
 		tupleDesc, tupleBuilder := newTupleBuilderForEncoding(val.BytesAddrEnc)
 		ns, addr := createTestBlob(t, []byte(`abc`))
 		tupleBuilder.PutBytesAddr(0, addr)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -1232,7 +1232,7 @@ func TestJsonSerializer(t *testing.T) {
 	tupleDesc, tupleBuilder := newTupleBuilderForEncoding(val.JSONAddrEnc)
 	ns, addr := createTestBlob(t, []byte(`{"a":"b"}`))
 	tupleBuilder.PutJSONAddr(0, addr)
-	tuple, err := tupleBuilder.Build(buffPool)
+	tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 	require.NoError(t, err)
 
 	value, err := s.deserialize(context.Background(), typ, tupleDesc, tuple, 0, ns)
@@ -1256,7 +1256,7 @@ func TestTextSerializer(t *testing.T) {
 		tupleDesc, tupleBuilder := newTupleBuilderForEncoding(val.StringAddrEnc)
 		ns, addr := createTestBlob(t, []byte("abcde"))
 		tupleBuilder.PutStringAddr(0, addr)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -1275,7 +1275,7 @@ func TestTextSerializer(t *testing.T) {
 		tupleDesc, tupleBuilder := newTupleBuilderForEncoding(val.StringAddrEnc)
 		ns, addr := createTestBlob(t, []byte("abcde"))
 		tupleBuilder.PutStringAddr(0, addr)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -1294,7 +1294,7 @@ func TestTextSerializer(t *testing.T) {
 		tupleDesc, tupleBuilder := newTupleBuilderForEncoding(val.StringAddrEnc)
 		ns, addr := createTestBlob(t, []byte("abcde"))
 		tupleBuilder.PutStringAddr(0, addr)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -1313,7 +1313,7 @@ func TestTextSerializer(t *testing.T) {
 		tupleDesc, tupleBuilder := newTupleBuilderForEncoding(val.StringAddrEnc)
 		ns, addr := createTestBlob(t, []byte("abcde"))
 		tupleBuilder.PutStringAddr(0, addr)
-		tuple, err := tupleBuilder.Build(buffPool)
+		tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 		require.NoError(t, err)
 
 		value, err := s.deserialize(nil, typ, tupleDesc, tuple, 0, nil)
@@ -1339,7 +1339,7 @@ func TestGeometrySerializer(t *testing.T) {
 		0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0xF0, 0x3F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0xBF})
 	tupleBuilder.PutGeometryAddr(0, addr)
-	tuple, err := tupleBuilder.Build(buffPool)
+	tuple, err := tupleBuilder.Build(context.Background(), buffPool)
 	require.NoError(t, err)
 
 	value, err := s.deserialize(context.Background(), typ, tupleDesc, tuple, 0, ns)

--- a/go/libraries/doltcore/sqle/dtables/conflicts_tables_prolly.go
+++ b/go/libraries/doltcore/sqle/dtables/conflicts_tables_prolly.go
@@ -657,7 +657,7 @@ func (cd *prollyConflictDeleter) Delete(ctx *sql.Context, r sql.Row) (err error)
 	cd.kB.PutUint8(numSourceKeyFields+1, uint8(prolly.ArtifactTypeConflict))
 	cd.kB.PutByteString(numSourceKeyFields+2, make([]byte, hash.ByteLen))
 
-	key, err := cd.kB.Build(cd.pool)
+	key, err := cd.kB.Build(ctx, cd.pool)
 	if err != nil {
 		return err
 	}
@@ -712,7 +712,7 @@ func (cd *prollyConflictDeleter) putKeylessHash(ctx *sql.Context, r sql.Row) err
 		}
 	}
 
-	v, err := cd.vB.Build(cd.pool)
+	v, err := cd.vB.Build(ctx, cd.pool)
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/sqle/dtables/constraint_violations_prolly.go
+++ b/go/libraries/doltcore/sqle/dtables/constraint_violations_prolly.go
@@ -350,7 +350,7 @@ func (d *prollyCVDeleter) Delete(ctx *sql.Context, r sql.Row) error {
 	}
 	d.kb.PutByteString(numPks+2, prolly.ConstraintViolationInfoHash(violationInfoBytes))
 
-	newKey, err := d.kb.Build(d.pool)
+	newKey, err := d.kb.Build(ctx, d.pool)
 	if err != nil {
 		return err
 	}
@@ -364,7 +364,7 @@ func (d *prollyCVDeleter) Delete(ctx *sql.Context, r sql.Row) error {
 	if err := fillArtifactKeyPrefix(ctx, nodeStore, legacyKeyBuilder, r, numPks, rootHash, artifactType); err != nil {
 		return err
 	}
-	legacyKey, err := legacyKeyBuilder.Build(d.pool)
+	legacyKey, err := legacyKeyBuilder.Build(ctx, d.pool)
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/sqle/enginetest/validation.go
+++ b/go/libraries/doltcore/sqle/enginetest/validation.go
@@ -222,7 +222,7 @@ func validateKeylessIndex(ctx context.Context, sch schema.Schema, def schema.Ind
 			builder.PutRaw(i, field)
 		}
 		builder.PutRaw(idxDesc.Count()-1, hashId.GetField(0))
-		k, err := builder.Build(primary.Pool())
+		k, err := builder.Build(ctx, primary.Pool())
 		if err != nil {
 			return err
 		}
@@ -320,7 +320,7 @@ func validatePkIndex(ctx context.Context, sch schema.Schema, def schema.Index, p
 				builder.PutRaw(i, field)
 			}
 		}
-		k, err := builder.Build(primary.Pool())
+		k, err := builder.Build(ctx, primary.Pool())
 		if err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -696,7 +696,7 @@ func (di *doltIndex) prollyRanges(ctx *sql.Context, ns tree.NodeStore, ranges ..
 	// really not rely on the integrator to maintain this tenuous relationship.
 	var err error
 	if !di.spatial {
-		ranges, err = pruneEmptyRanges(ranges)
+		ranges, err = pruneEmptyRanges(ctx, ranges)
 		if err != nil {
 			return nil, err
 		}
@@ -947,12 +947,12 @@ func keyBuilderForIndex(idx durable.Index) *val.TupleBuilder {
 	return val.NewTupleBuilder(kd, m.NodeStore())
 }
 
-func pruneEmptyRanges(sqlRanges []sql.MySQLRange) (pruned []sql.MySQLRange, err error) {
+func pruneEmptyRanges(ctx context.Context, sqlRanges []sql.MySQLRange) (pruned []sql.MySQLRange, err error) {
 	pruned = make([]sql.MySQLRange, 0, len(sqlRanges))
 	for _, sr := range sqlRanges {
 		empty := false
 		for _, colExpr := range sr {
-			empty, err = colExpr.IsEmpty()
+			empty, err = colExpr.IsEmpty(ctx)
 			if err != nil {
 				return nil, err
 			} else if empty {
@@ -1058,7 +1058,7 @@ func (di *doltIndex) prollySpatialRanges(ranges []sql.MySQLRange) ([]prolly.Rang
 func (di *doltIndex) prollyRangesFromSqlRanges(ctx context.Context, ns tree.NodeStore, ranges []sql.MySQLRange, tb *val.TupleBuilder) ([]prolly.Range, error) {
 	var err error
 	if !di.spatial {
-		ranges, err = pruneEmptyRanges(ranges)
+		ranges, err = pruneEmptyRanges(ctx, ranges)
 		if err != nil {
 			return nil, err
 		}
@@ -1209,18 +1209,18 @@ func getRangeCutValue(ctx context.Context, cut sql.MySQLRangeCut, typ sql.Type) 
 //
 // This is for building physical scans against storage which does not store
 // NULL contiguous and ordered < non-NULL values.
-func SplitNullsFromRange(r sql.MySQLRange) ([]sql.MySQLRange, error) {
+func SplitNullsFromRange(ctx context.Context, r sql.MySQLRange) ([]sql.MySQLRange, error) {
 	res := []sql.MySQLRange{{}}
 
 	for _, rce := range r {
 		if _, ok := rce.LowerBound.(sql.BelowNull); ok {
 			// May include NULL. Split it and add each non-empty range.
-			withnull, nullok, err := rce.TryIntersect(sql.NullRangeColumnExpr(rce.Typ))
+			withnull, nullok, err := rce.TryIntersect(ctx, sql.NullRangeColumnExpr(rce.Typ))
 			if err != nil {
 				return nil, err
 			}
 			fornull := res[:]
-			withoutnull, withoutnullok, err := rce.TryIntersect(sql.NotNullRangeColumnExpr(rce.Typ))
+			withoutnull, withoutnullok, err := rce.TryIntersect(ctx, sql.NotNullRangeColumnExpr(rce.Typ))
 			if err != nil {
 				return nil, err
 			}

--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -1099,7 +1099,7 @@ func (di *doltIndex) prollyRangesFromSqlRanges(ctx context.Context, ns tree.Node
 			}
 		}
 		// BuildPermissive() allows nulls in non-null fields
-		tup, err := tb.BuildPermissive(sharePool)
+		tup, err := tb.BuildPermissive(ctx, sharePool)
 		if err != nil {
 			return nil, err
 		}
@@ -1135,7 +1135,7 @@ func (di *doltIndex) prollyRangesFromSqlRanges(ctx context.Context, ns tree.Node
 			}
 		}
 
-		tup, err = tb.BuildPermissive(sharePool)
+		tup, err = tb.BuildPermissive(ctx, sharePool)
 		if err != nil {
 			return nil, err
 		}

--- a/go/libraries/doltcore/sqle/index/dolt_index_test.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index_test.go
@@ -1462,7 +1462,7 @@ func convertSqlRowToInt64(sqlRows []sql.Row) []sql.Row {
 
 func TestSplitNullsFromRange(t *testing.T) {
 	t.Run("EmptyRange", func(t *testing.T) {
-		r, err := index.SplitNullsFromRange(sql.MySQLRange{})
+		r, err := index.SplitNullsFromRange(context.Background(), sql.MySQLRange{})
 		assert.NoError(t, err)
 		assert.NotNil(t, r)
 		assert.Len(t, r, 1)
@@ -1471,7 +1471,7 @@ func TestSplitNullsFromRange(t *testing.T) {
 
 	t.Run("ThreeColumnNoNullsRange", func(t *testing.T) {
 		r := sql.MySQLRange{sql.LessThanRangeColumnExpr(10, types.Int8), sql.GreaterThanRangeColumnExpr(16, types.Int8), sql.NotNullRangeColumnExpr(types.Int8)}
-		rs, err := index.SplitNullsFromRange(r)
+		rs, err := index.SplitNullsFromRange(context.Background(), r)
 		assert.NoError(t, err)
 		assert.NotNil(t, rs)
 		assert.Len(t, rs, 1)
@@ -1481,7 +1481,7 @@ func TestSplitNullsFromRange(t *testing.T) {
 
 	t.Run("LastColumnOnlyNull", func(t *testing.T) {
 		r := sql.MySQLRange{sql.LessThanRangeColumnExpr(10, types.Int8), sql.GreaterThanRangeColumnExpr(16, types.Int8), sql.NullRangeColumnExpr(types.Int8)}
-		rs, err := index.SplitNullsFromRange(r)
+		rs, err := index.SplitNullsFromRange(context.Background(), r)
 		assert.NoError(t, err)
 		assert.NotNil(t, rs)
 		assert.Len(t, rs, 1)
@@ -1491,7 +1491,7 @@ func TestSplitNullsFromRange(t *testing.T) {
 
 	t.Run("LastColumnAll", func(t *testing.T) {
 		r := sql.MySQLRange{sql.LessThanRangeColumnExpr(10, types.Int8), sql.GreaterThanRangeColumnExpr(16, types.Int8), sql.AllRangeColumnExpr(types.Int8)}
-		rs, err := index.SplitNullsFromRange(r)
+		rs, err := index.SplitNullsFromRange(context.Background(), r)
 		assert.NoError(t, err)
 		assert.NotNil(t, rs)
 		assert.Len(t, rs, 2)
@@ -1505,7 +1505,7 @@ func TestSplitNullsFromRange(t *testing.T) {
 
 	t.Run("FirstColumnAll", func(t *testing.T) {
 		r := sql.MySQLRange{sql.AllRangeColumnExpr(types.Int8), sql.LessThanRangeColumnExpr(10, types.Int8), sql.GreaterThanRangeColumnExpr(16, types.Int8)}
-		rs, err := index.SplitNullsFromRange(r)
+		rs, err := index.SplitNullsFromRange(context.Background(), r)
 		assert.NoError(t, err)
 		assert.NotNil(t, rs)
 		assert.Len(t, rs, 2)
@@ -1519,7 +1519,7 @@ func TestSplitNullsFromRange(t *testing.T) {
 
 	t.Run("AllColumnAll", func(t *testing.T) {
 		r := sql.MySQLRange{sql.AllRangeColumnExpr(types.Int8), sql.AllRangeColumnExpr(types.Int8), sql.AllRangeColumnExpr(types.Int8)}
-		rs, err := index.SplitNullsFromRange(r)
+		rs, err := index.SplitNullsFromRange(context.Background(), r)
 		assert.NoError(t, err)
 		assert.NotNil(t, rs)
 		assert.Len(t, rs, 8)

--- a/go/libraries/doltcore/sqle/index/index_reader.go
+++ b/go/libraries/doltcore/sqle/index/index_reader.go
@@ -608,7 +608,7 @@ func (i *nonCoveringMapIter) Next(ctx context.Context) (val.Tuple, val.Tuple, er
 		from := i.pkMap.MapOrdinal(to)
 		i.pkBld.PutRaw(to, idxKey.GetField(from))
 	}
-	pk, err := i.pkBld.Build(sharePool)
+	pk, err := i.pkBld.Build(ctx, sharePool)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/libraries/doltcore/sqle/index/key_builder.go
+++ b/go/libraries/doltcore/sqle/index/key_builder.go
@@ -15,6 +15,7 @@
 package index
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -170,7 +171,7 @@ func (b SecondaryKeyBuilder) SecondaryKeyFromRow(ctx *sql.Context, k, v val.Tupl
 			}
 		}
 	}
-	return b.builder.Build(b.pool)
+	return b.builder.Build(ctx, b.pool)
 }
 
 // BuildRow returns a sql.Row for the given key/value tuple pair
@@ -226,9 +227,9 @@ type ClusteredKeyBuilder struct {
 }
 
 // ClusteredKeyFromIndexKey builds a clustered index key from a secondary index key.
-func (b ClusteredKeyBuilder) ClusteredKeyFromIndexKey(k val.Tuple) (val.Tuple, error) {
+func (b ClusteredKeyBuilder) ClusteredKeyFromIndexKey(ctx context.Context, k val.Tuple) (val.Tuple, error) {
 	for to, from := range b.mapping {
 		b.builder.PutRaw(to, k.GetField(from))
 	}
-	return b.builder.Build(b.pool)
+	return b.builder.Build(ctx, b.pool)
 }

--- a/go/libraries/doltcore/sqle/index/prolly_index_iter.go
+++ b/go/libraries/doltcore/sqle/index/prolly_index_iter.go
@@ -104,7 +104,7 @@ func (p prollyIndexIter) Next(ctx *sql.Context) (sql.Row, error) {
 		from := p.pkMap.MapOrdinal(to)
 		p.pkBld.PutRaw(to, idxKey.GetField(from))
 	}
-	pk, err := p.pkBld.Build(sharePool)
+	pk, err := p.pkBld.Build(ctx, sharePool)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +129,7 @@ func (p prollyIndexIter) NextValueRow(ctx *sql.Context) (sql.ValueRow, error) {
 		from := p.pkMap.MapOrdinal(to)
 		p.pkBld.PutRaw(to, idxKey.GetField(from))
 	}
-	pk, err := p.pkBld.Build(sharePool)
+	pk, err := p.pkBld.Build(ctx, sharePool)
 	if err != nil {
 		return nil, err
 	}
@@ -482,7 +482,7 @@ func (p prollyKeylessIndexIter) queueRows(ctx context.Context) error {
 			from := p.clusteredMap.MapOrdinal(to)
 			p.clusteredBld.PutRaw(to, idxKey.GetField(from))
 		}
-		pk, err := p.clusteredBld.Build(sharePool)
+		pk, err := p.clusteredBld.Build(ctx, sharePool)
 		if err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/sqle/index/secondary_iter.go
+++ b/go/libraries/doltcore/sqle/index/secondary_iter.go
@@ -138,7 +138,7 @@ func (c *nonCovStrictSecondaryLookupGen) New(ctx context.Context, k val.Tuple) (
 		from := c.pkMap.MapOrdinal(to)
 		c.pkBld.PutRaw(to, idxKey.GetField(from))
 	}
-	pk, err := c.pkBld.Build(sharePool)
+	pk, err := c.pkBld.Build(ctx, sharePool)
 	if err != nil {
 		return nil, err
 	}
@@ -365,7 +365,7 @@ func (i *keylessLookupIter) Next(ctx context.Context) (k, v val.Tuple, err error
 		from := i.pkMap.MapOrdinal(to)
 		i.pkBld.PutRaw(to, idxKey.GetField(from))
 	}
-	i.k, err = i.pkBld.Build(sharePool)
+	i.k, err = i.pkBld.Build(ctx, sharePool)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/libraries/doltcore/sqle/kvexec/builder.go
+++ b/go/libraries/doltcore/sqle/kvexec/builder.go
@@ -636,7 +636,7 @@ func getMergeKv(ctx *sql.Context, n sql.Node) (mergeState, error) {
 				from := pkMap.MapOrdinal(to)
 				pkBld.PutRaw(to, ms.idxMap.KeyDesc().GetField(from, key))
 			}
-			pk, err := pkBld.Build(ms.idxMap.Pool())
+			pk, err := pkBld.Build(ctx, ms.idxMap.Pool())
 			if err != nil {
 				return nil, nil, err
 			}

--- a/go/libraries/doltcore/sqle/kvexec/lookup_join.go
+++ b/go/libraries/doltcore/sqle/kvexec/lookup_join.go
@@ -15,6 +15,7 @@
 package kvexec
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -112,7 +113,7 @@ func (l *lookupJoinKvIter) Next(ctx *sql.Context) (sql.Row, error) {
 				return nil, io.EOF
 			}
 
-			l.dstKey, err = l.keyTupleMapper.dstKeyTuple(l.srcKey, l.srcVal)
+			l.dstKey, err = l.keyTupleMapper.dstKeyTuple(ctx, l.srcKey, l.srcVal)
 			if err != nil {
 				return nil, err
 			}
@@ -267,7 +268,7 @@ func newLookupKeyMapping(
 	var litTuple val.Tuple
 	var err error
 	if litDesc.Count() > 0 {
-		litTuple, err = litTb.Build(ns.Pool())
+		litTuple, err = litTb.Build(ctx, ns.Pool())
 		if err != nil {
 			return nil, err
 		}
@@ -342,7 +343,7 @@ func (m *lookupMapping) valid(ctx *sql.Context) bool {
 	return true
 }
 
-func (m *lookupMapping) dstKeyTuple(srcKey, srcVal val.Tuple) (val.Tuple, error) {
+func (m *lookupMapping) dstKeyTuple(ctx context.Context, srcKey, srcVal val.Tuple) (val.Tuple, error) {
 	var litIdx int
 	for to := range m.srcMapping {
 		from := m.srcMapping.MapOrdinal(to)
@@ -372,5 +373,5 @@ func (m *lookupMapping) dstKeyTuple(srcKey, srcVal val.Tuple) (val.Tuple, error)
 		}
 	}
 
-	return m.targetKb.BuildPermissive(m.pool)
+	return m.targetKb.BuildPermissive(ctx, m.pool)
 }

--- a/go/libraries/doltcore/sqle/statspro/bucket_builder.go
+++ b/go/libraries/doltcore/sqle/statspro/bucket_builder.go
@@ -54,7 +54,7 @@ func firstRowForIndex(ctx *sql.Context, idxLen int, prollyMap prolly.Map, keyBui
 		keyBuilder.PutRaw(i, keyBytes.GetField(i))
 	}
 
-	firstKey, err := keyBuilder.Build(buffPool)
+	firstKey, err := keyBuilder.Build(ctx, buffPool)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/statspro/bucket_builder_test.go
+++ b/go/libraries/doltcore/sqle/statspro/bucket_builder_test.go
@@ -16,6 +16,7 @@ package statspro
 
 import (
 	"container/heap"
+	"context"
 	"fmt"
 	"testing"
 
@@ -198,7 +199,7 @@ func TestBucketBuilder(t *testing.T) {
 					err := tree.PutField(ctx, nil, kb, i, v)
 					assert.NoError(t, err)
 				}
-				tup, err := kb.Build(pool)
+				tup, err := kb.Build(context.Background(), pool)
 				assert.NoError(t, err)
 				b.add(ctx, tup)
 			}

--- a/go/libraries/doltcore/sqle/statspro/stats_kv.go
+++ b/go/libraries/doltcore/sqle/statspro/stats_kv.go
@@ -249,7 +249,7 @@ func (p *prollyStats) PutBucket(ctx context.Context, h hash.Hash, b *stats.Bucke
 		return err
 	}
 
-	k, err := p.encodeHash(h, tupB.Desc.Count())
+	k, err := p.encodeHash(ctx, h, tupB.Desc.Count())
 	if err != nil {
 		return err
 	}
@@ -276,7 +276,7 @@ func (p *prollyStats) GetBucket(ctx context.Context, h hash.Hash, tupB *val.Tupl
 	}
 
 	// missing bucket and not GC'ing, try disk
-	k, err := p.encodeHash(h, tupB.Desc.Count())
+	k, err := p.encodeHash(ctx, h, tupB.Desc.Count())
 	if err != nil {
 		return nil, false, err
 	}
@@ -325,7 +325,7 @@ func (p *prollyStats) LoadFromMem(ctx context.Context) error {
 			if !ok {
 				return fmt.Errorf("memory KV inconsistent, missing bucket for: %s", key)
 			}
-			tupK, err := p.encodeHash(hash.New(key[:hash.ByteLen]), tb.Desc.Count())
+			tupK, err := p.encodeHash(ctx, hash.New(key[:hash.ByteLen]), tb.Desc.Count())
 			tupV, err := p.encodeBucket(ctx, b, tb)
 			if err != nil {
 				return err
@@ -361,14 +361,14 @@ func (p *prollyStats) Flush(ctx context.Context) (int, error) {
 	return cnt, err
 }
 
-func (p *prollyStats) encodeHash(h hash.Hash, len int) (val.Tuple, error) {
+func (p *prollyStats) encodeHash(ctx context.Context, h hash.Hash, len int) (val.Tuple, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.kb.PutInt64(0, int64(len))
 	if err := p.kb.PutString(1, h.String()); err != nil {
 		return nil, err
 	}
-	return p.kb.Build(p.m.NodeStore().Pool())
+	return p.kb.Build(ctx, p.m.NodeStore().Pool())
 }
 
 func (p *prollyStats) decodeHashTuple(v val.Tuple) (int, hash.Hash, error) {
@@ -468,7 +468,7 @@ func (p *prollyStats) encodeBucket(ctx context.Context, b *stats.Bucket, tupB *v
 	}
 	p.vb.PutString(10, stats.StringifyKey(mcvCntsRow, mcvTypes[:len(mcvCntsRow)]))
 
-	return p.vb.Build(p.m.NodeStore().Pool())
+	return p.vb.Build(ctx, p.m.NodeStore().Pool())
 }
 
 func (p *prollyStats) NewEmpty(ctx context.Context) (StatsKv, error) {
@@ -491,7 +491,7 @@ func EncodeRow(ctx context.Context, ns tree.NodeStore, r sql.Row, tb *val.TupleB
 			return nil, err
 		}
 	}
-	return tb.Build(ns.Pool())
+	return tb.Build(ctx, ns.Pool())
 }
 
 func DecodeRow(ctx context.Context, ns tree.NodeStore, s string, tb *val.TupleBuilder) (sql.Row, error) {

--- a/go/libraries/doltcore/sqle/writer/prolly_fk_indexer.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_fk_indexer.go
@@ -140,7 +140,7 @@ func (iter prollyFkPkRowIter) Next(ctx *sql.Context) (sql.Row, error) {
 		for pkPos, idxPos := range iter.pkToIdxMap {
 			pkBld.PutRaw(pkPos, k.GetField(idxPos))
 		}
-		pkTup, err := pkBld.BuildPermissive(sharePool)
+		pkTup, err := pkBld.BuildPermissive(ctx, sharePool)
 		if err != nil {
 			return nil, err
 		}
@@ -204,7 +204,7 @@ func (iter prollyFkKeylessRowIter) Next(ctx *sql.Context) (sql.Row, error) {
 	}
 	hashId := k.GetField(k.Count() - 1)
 	iter.primary.keyBld.PutHash128(0, hashId)
-	primaryKey, err := iter.primary.keyBld.Build(sharePool)
+	primaryKey, err := iter.primary.keyBld.Build(ctx, sharePool)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/writer/prolly_index_writer.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_index_writer.go
@@ -126,7 +126,7 @@ func (m prollyIndexWriter) keyFromRow(ctx context.Context, sqlRow sql.Row) (val.
 			return nil, err
 		}
 	}
-	return m.keyBld.BuildPermissive(sharePool)
+	return m.keyBld.BuildPermissive(ctx, sharePool)
 }
 
 func (m prollyIndexWriter) ValidateKeyViolations(ctx context.Context, sqlRow sql.Row) error {
@@ -161,7 +161,7 @@ func (m prollyIndexWriter) Insert(ctx context.Context, sqlRow sql.Row) error {
 			return err
 		}
 	}
-	v, err := m.valBld.Build(sharePool)
+	v, err := m.valBld.Build(ctx, sharePool)
 	if err != nil {
 		return err
 	}
@@ -217,7 +217,7 @@ func (m prollyIndexWriter) Update(ctx context.Context, oldRow sql.Row, newRow sq
 			return err
 		}
 	}
-	v, err := m.valBld.Build(sharePool)
+	v, err := m.valBld.Build(ctx, sharePool)
 	if err != nil {
 		return err
 	}
@@ -336,7 +336,7 @@ func (m prollySecondaryIndexWriter) keyFromRow(ctx context.Context, sqlRow sql.R
 			return nil, err
 		}
 	}
-	return m.keyBld.Build(sharePool)
+	return m.keyBld.Build(ctx, sharePool)
 }
 
 func (m prollySecondaryIndexWriter) VisitGCRoots(ctx context.Context, roots func(hash.Hash) bool) error {
@@ -389,7 +389,7 @@ func (m prollySecondaryIndexWriter) checkForUniqueKeyErr(ctx context.Context, sq
 		from := m.pkMap.MapOrdinal(to)
 		m.pkBld.PutRaw(to, idxDesc.GetField(from, idxKey))
 	}
-	existingPK, err := m.pkBld.Build(sharePool)
+	existingPK, err := m.pkBld.Build(ctx, sharePool)
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/sqle/writer/prolly_index_writer_keyless.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_index_writer_keyless.go
@@ -147,7 +147,7 @@ func (k prollyKeylessWriter) tuplesFromRow(ctx context.Context, sqlRow sql.Row) 
 		}
 	}
 
-	value, err = k.valBld.Build(sharePool)
+	value, err = k.valBld.Build(ctx, sharePool)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -265,13 +265,13 @@ func (writer prollyKeylessSecondaryWriter) Insert(ctx context.Context, sqlRow sq
 		return err
 	}
 	writer.keyBld.PutHash128(len(writer.keyBld.Desc.Types)-1, hashId.GetField(0))
-	indexKey, err := writer.keyBld.Build(sharePool)
+	indexKey, err := writer.keyBld.Build(ctx, sharePool)
 	if err != nil {
 		return err
 	}
 
 	if writer.unique {
-		prefixKey, err := writer.prefixBld.Build(sharePool)
+		prefixKey, err := writer.prefixBld.Build(ctx, sharePool)
 		if err != nil {
 			return err
 		}
@@ -310,7 +310,7 @@ func (writer prollyKeylessSecondaryWriter) checkForUniqueKeyError(ctx context.Co
 		}
 		keyStr := FormatKeyForUniqKeyErr(ctx, prefixKey, writer.prefixBld.Desc, remappedSqlRow)
 		writer.hashBld.PutRaw(0, k.GetField(k.Count()-1))
-		existingKey, err := writer.hashBld.Build(sharePool)
+		existingKey, err := writer.hashBld.Build(ctx, sharePool)
 		if err != nil {
 			return err
 		}
@@ -343,7 +343,7 @@ func (writer prollyKeylessSecondaryWriter) Delete(ctx context.Context, sqlRow sq
 		}
 	}
 	writer.keyBld.PutHash128(len(writer.keyBld.Desc.Types)-1, hashId.GetField(0))
-	indexKey, err := writer.keyBld.Build(sharePool)
+	indexKey, err := writer.keyBld.Build(ctx, sharePool)
 	if err != nil {
 		return err
 	}

--- a/go/store/datas/pull/puller_test.go
+++ b/go/store/datas/pull/puller_test.go
@@ -125,7 +125,7 @@ type testTuple struct {
 func buildKeyTuple(ns tree.NodeStore, k int64) val.Tuple {
 	tb := val.NewTupleBuilder(testKeyDesc, ns)
 	tb.PutInt64(0, k)
-	tup, _ := tb.Build(ns.Pool())
+	tup, _ := tb.Build(context.Background(), ns.Pool())
 	return tup
 }
 
@@ -133,7 +133,7 @@ func buildValTuple(ns tree.NodeStore, v0, v1 string) val.Tuple {
 	tb := val.NewTupleBuilder(testValDesc, ns)
 	tb.PutString(0, v0)
 	tb.PutString(1, v1)
-	tup, _ := tb.Build(ns.Pool())
+	tup, _ := tb.Build(context.Background(), ns.Pool())
 	return tup
 }
 

--- a/go/store/prolly/artifact_map.go
+++ b/go/store/prolly/artifact_map.go
@@ -357,7 +357,7 @@ type ArtifactsEditor struct {
 // |violationInfoHash|. For foreign key, unique index, check constraint, and not null violations pass
 // [ConstraintViolationInfoHash] with |meta.VInfo| so multiple violations of the same type for the same row get distinct
 // keys. For conflicts pass nil (zeros). Old keys without the violation-info hash suffix are still valid.
-func (wr *ArtifactsEditor) BuildArtifactKey(_ context.Context, srcKey val.Tuple, srcRootish hash.Hash, artType ArtifactType, violationInfoHash []byte) (val.Tuple, error) {
+func (wr *ArtifactsEditor) BuildArtifactKey(ctx context.Context, srcKey val.Tuple, srcRootish hash.Hash, artType ArtifactType, violationInfoHash []byte) (val.Tuple, error) {
 	for i := 0; i < srcKey.Count(); i++ {
 		wr.artKB.PutRaw(i, srcKey.GetField(i))
 	}
@@ -368,7 +368,7 @@ func (wr *ArtifactsEditor) BuildArtifactKey(_ context.Context, srcKey val.Tuple,
 	} else {
 		wr.artKB.PutByteString(srcKey.Count()+2, make([]byte, violationInfoHashSize))
 	}
-	return wr.artKB.Build(wr.pool)
+	return wr.artKB.Build(ctx, wr.pool)
 }
 
 // Add adds an artifact entry. The key includes |srcKey|, |srcRootish|, |artType|, and |violationInfoHash|.
@@ -381,7 +381,7 @@ func (wr *ArtifactsEditor) Add(ctx context.Context, srcKey val.Tuple, srcRootish
 	}
 
 	wr.artVB.PutJSON(0, meta)
-	value, err := wr.artVB.Build(wr.pool)
+	value, err := wr.artVB.Build(ctx, wr.pool)
 	if err != nil {
 		return err
 	}
@@ -642,7 +642,7 @@ func (itr artifactIterImpl) Next(ctx context.Context) (Artifact, error) {
 		return Artifact{}, err
 	}
 
-	srcKey, err := itr.getSrcKeyFromArtKey(artKey)
+	srcKey, err := itr.getSrcKeyFromArtKey(ctx, artKey)
 	if err != nil {
 		return Artifact{}, err
 	}
@@ -659,11 +659,11 @@ func (itr artifactIterImpl) Next(ctx context.Context) (Artifact, error) {
 	}, nil
 }
 
-func (itr artifactIterImpl) getSrcKeyFromArtKey(k val.Tuple) (val.Tuple, error) {
+func (itr artifactIterImpl) getSrcKeyFromArtKey(ctx context.Context, k val.Tuple) (val.Tuple, error) {
 	for i := 0; i < itr.numPks; i++ {
 		itr.tb.PutRaw(i, k.GetField(i))
 	}
-	return itr.tb.Build(itr.pool)
+	return itr.tb.Build(ctx, itr.pool)
 }
 
 // Artifact is a struct representing an artifact in the artifacts table

--- a/go/store/prolly/artifact_map_test.go
+++ b/go/store/prolly/artifact_map_test.go
@@ -46,7 +46,7 @@ func TestArtifactMapEditing(t *testing.T) {
 			edt := am.Editor()
 			for i := 0; i < n; i++ {
 				srcKb.PutInt16(0, int16(i))
-				key1, err := srcKb.Build(sharedPool)
+				key1, err := srcKb.Build(context.Background(), sharedPool)
 				require.NoError(t, err)
 				err = edt.Add(ctx, key1, addr, ArtifactTypeConflict, []byte("{}"), nil)
 				require.NoError(t, err)
@@ -101,7 +101,7 @@ func TestMergeArtifactMaps(t *testing.T) {
 	rightEdt := right.Editor()
 
 	srcKb.PutInt16(0, 1)
-	key1, err := srcKb.Build(sharedPool)
+	key1, err := srcKb.Build(context.Background(), sharedPool)
 	require.NoError(t, err)
 	err = leftEdt.Add(ctx, key1, addr, ArtifactTypeConflict, []byte("{}"), nil)
 	require.NoError(t, err)
@@ -109,7 +109,7 @@ func TestMergeArtifactMaps(t *testing.T) {
 	require.NoError(t, err)
 
 	srcKb.PutInt16(0, 2)
-	key2, err := srcKb.Build(sharedPool)
+	key2, err := srcKb.Build(context.Background(), sharedPool)
 	require.NoError(t, err)
 	err = rightEdt.Add(ctx, key2, addr, ArtifactTypeConflict, []byte("{}"), nil)
 	require.NoError(t, err)

--- a/go/store/prolly/benchmark/benchmark_read_test.go
+++ b/go/store/prolly/benchmark/benchmark_read_test.go
@@ -217,7 +217,7 @@ func makeGoMap(scale uint64) map[uint64]val.Tuple {
 		vb.PutInt64(3, src.Int63())
 		vb.PutInt64(4, src.Int63())
 		var err error
-		kv[i], err = vb.Build(shared)
+		kv[i], err = vb.Build(context.Background(), shared)
 		if err != nil {
 			panic(err)
 		}
@@ -243,7 +243,7 @@ func makeSyncMap(scale uint64) *sync.Map {
 		vb.PutInt64(2, src.Int63())
 		vb.PutInt64(3, src.Int63())
 		vb.PutInt64(4, src.Int63())
-		tup, err := vb.Build(shared)
+		tup, err := vb.Build(context.Background(), shared)
 		if err != nil {
 			panic(err)
 		}

--- a/go/store/prolly/benchmark/utils_test.go
+++ b/go/store/prolly/benchmark/utils_test.go
@@ -91,7 +91,7 @@ func generateProllyTuples(kd, vd *val.TupleDesc, size uint64, ns tree.NodeStore)
 	for i := range tups {
 		// key
 		kb.PutUint64(0, uint64(i))
-		tups[i][0], err = kb.Build(shared)
+		tups[i][0], err = kb.Build(context.Background(), shared)
 		if err != nil {
 			panic(err)
 		}
@@ -102,7 +102,7 @@ func generateProllyTuples(kd, vd *val.TupleDesc, size uint64, ns tree.NodeStore)
 		vb.PutInt64(2, src.Int63())
 		vb.PutInt64(3, src.Int63())
 		vb.PutInt64(4, src.Int63())
-		tups[i][1], err = vb.Build(shared)
+		tups[i][1], err = vb.Build(context.Background(), shared)
 		if err != nil {
 			panic(err)
 		}

--- a/go/store/prolly/mutable_map_write_test.go
+++ b/go/store/prolly/mutable_map_write_test.go
@@ -476,7 +476,7 @@ func testInternalNodeSplits(t *testing.T) {
 	for i := range tuples {
 		bld.PutInt32(0, int32(i))
 		bld.PutInt32(1, int32(0))
-		tuples[i][0], err = bld.Build(sharedPool)
+		tuples[i][0], err = bld.Build(context.Background(), sharedPool)
 		require.NoError(t, err)
 		tuples[i][1] = val.EmptyTuple
 	}
@@ -490,7 +490,7 @@ func testInternalNodeSplits(t *testing.T) {
 		for j := 1; j <= k; j++ {
 			bld.PutInt32(0, int32(j))
 			bld.PutInt32(1, int32(j))
-			key, err := bld.Build(sharedPool)
+			key, err := bld.Build(context.Background(), sharedPool)
 			require.NoError(t, err)
 			err = mut.Put(ctx, key, val.EmptyTuple)
 			require.NoError(t, err)
@@ -539,11 +539,11 @@ func makePut(k, v int64) (key, value val.Tuple) {
 	mutKeyBuilder.PutInt64(0, k)
 	mutValBuilder.PutInt64(0, v)
 	var err error
-	key, err = mutKeyBuilder.Build(sharedPool)
+	key, err = mutKeyBuilder.Build(context.Background(), sharedPool)
 	if err != nil {
 		panic(err)
 	}
-	value, err = mutValBuilder.Build(sharedPool)
+	value, err = mutValBuilder.Build(context.Background(), sharedPool)
 	if err != nil {
 		panic(err)
 	}
@@ -553,7 +553,7 @@ func makePut(k, v int64) (key, value val.Tuple) {
 func makeDelete(k int64) (key val.Tuple) {
 	mutKeyBuilder.PutInt64(0, k)
 	var err error
-	key, err = mutKeyBuilder.Build(sharedPool)
+	key, err = mutKeyBuilder.Build(context.Background(), sharedPool)
 	if err != nil {
 		panic(err)
 	}

--- a/go/store/prolly/patch_based_merging_test.go
+++ b/go/store/prolly/patch_based_merging_test.go
@@ -270,10 +270,10 @@ func mutate(t *testing.T, ctx context.Context, baseRoot *tree.Node, keyDesc, val
 		var newValue val.Tuple
 		if m.value != nil {
 			valBld.PutUint32(0, *m.value)
-			newValue, err = valBld.Build(sharedPool)
+			newValue, err = valBld.Build(context.Background(), sharedPool)
 			require.NoError(t, err)
 		}
-		newKey, err := keyBld.Build(sharedPool)
+		newKey, err := keyBld.Build(context.Background(), sharedPool)
 		require.NoError(t, err)
 
 		err = mutMap.Put(ctx, newKey, newValue)
@@ -299,10 +299,10 @@ func mutateStrings(t *testing.T, ctx context.Context, baseRoot *tree.Node, keyDe
 		if m.value != nil {
 			err = valBld.PutString(0, *m.value)
 			require.NoError(t, err)
-			newValue, err = valBld.Build(sharedPool)
+			newValue, err = valBld.Build(context.Background(), sharedPool)
 			require.NoError(t, err)
 		}
-		newKey, err := keyBld.Build(sharedPool)
+		newKey, err := keyBld.Build(context.Background(), sharedPool)
 		require.NoError(t, err)
 
 		err = mutMap.Put(ctx, newKey, newValue)
@@ -1360,7 +1360,7 @@ func TestPatchBasedMerging(t *testing.T) {
 		collide := func(left, right tree.Diff) (tree.Diff, bool) {
 			tupleBuilder := val.NewTupleBuilder(desc, ns)
 			tupleBuilder.PutUint32(0, valueOnCollision)
-			newVal, err := tupleBuilder.Build(sharedPool)
+			newVal, err := tupleBuilder.Build(context.Background(), sharedPool)
 			require.NoError(t, err)
 			// Resolve conflicts by returning a special value that we check for
 			return tree.Diff{
@@ -1429,11 +1429,11 @@ func TestPatchBasedMerging(t *testing.T) {
 		for i := range tuples {
 			err = bld.PutString(0, "long_string_key_goes_here_"+strconv.Itoa(i))
 			require.NoError(t, err)
-			tuples[i][0], err = bld.Build(sharedPool)
+			tuples[i][0], err = bld.Build(context.Background(), sharedPool)
 			require.NoError(t, err)
 			err = bld.PutString(0, "long_string_value_goes_here_"+strconv.Itoa(i))
 			require.NoError(t, err)
-			tuples[i][1], err = bld.Build(sharedPool)
+			tuples[i][1], err = bld.Build(context.Background(), sharedPool)
 			require.NoError(t, err)
 		}
 		baseRoot, err := tree.MakeTreeForTest(tuples)

--- a/go/store/prolly/proximity_map.go
+++ b/go/store/prolly/proximity_map.go
@@ -292,7 +292,7 @@ func (b *ProximityMapBuilder) Insert(ctx context.Context, key, value []byte) err
 	levelMapKeyBuilder := val.NewTupleBuilder(proximitylevelMapKeyDesc, b.ns)
 	levelMapKeyBuilder.PutUint8(0, 255-keyLevel)
 	levelMapKeyBuilder.PutByteString(1, key)
-	tup, err := levelMapKeyBuilder.Build(b.ns.Pool())
+	tup, err := levelMapKeyBuilder.Build(ctx, b.ns.Pool())
 	if err != nil {
 		return err
 	}
@@ -318,7 +318,7 @@ func (b *ProximityMapBuilder) InsertAtLevel(ctx context.Context, key, value []by
 	levelMapKeyBuilder := val.NewTupleBuilder(proximitylevelMapKeyDesc, b.ns)
 	levelMapKeyBuilder.PutUint8(0, 255-keyLevel)
 	levelMapKeyBuilder.PutByteString(1, key)
-	tup, err := levelMapKeyBuilder.Build(b.ns.Pool())
+	tup, err := levelMapKeyBuilder.Build(ctx, b.ns.Pool())
 	if err != nil {
 		return err
 	}

--- a/go/store/prolly/proximity_map_test.go
+++ b/go/store/prolly/proximity_map_test.go
@@ -70,7 +70,7 @@ func buildTuple(t *testing.T, ctx context.Context, ns tree.NodeStore, pool pool.
 		err := tree.PutField(ctx, ns, builder, i, column)
 		require.NoError(t, err)
 	}
-	tup, err := builder.Build(pool)
+	tup, err := builder.Build(context.Background(), pool)
 	require.NoError(t, err)
 	return tup
 }
@@ -632,11 +632,11 @@ func testIncrementalUpdates(t *testing.T, keyDesc *val.TupleDesc) {
 		// update leaf node
 		{
 			putVector(t, keyBuilder, encodeVector(t, keyDesc, 0.0, 1.0))
-			nextKey, err := keyBuilder.Build(bp)
+			nextKey, err := keyBuilder.Build(context.Background(), bp)
 			require.NoError(t, err)
 
 			valueBuilder.PutInt64(0, 5)
-			nextValue, err := valueBuilder.Build(bp)
+			nextValue, err := valueBuilder.Build(context.Background(), bp)
 			require.NoError(t, err)
 
 			err = mutableMap.Put(ctx, nextKey, nextValue)
@@ -668,11 +668,11 @@ func testIncrementalUpdates(t *testing.T, keyDesc *val.TupleDesc) {
 		// update root node
 		{
 			putVector(t, keyBuilder, encodeVector(t, keyDesc, 5.0, 6.0))
-			nextKey, err := keyBuilder.Build(bp)
+			nextKey, err := keyBuilder.Build(context.Background(), bp)
 			require.NoError(t, err)
 
 			valueBuilder.PutInt64(0, 6)
-			nextValue, err := valueBuilder.Build(bp)
+			nextValue, err := valueBuilder.Build(context.Background(), bp)
 			require.NoError(t, err)
 
 			err = mutableMap.Put(ctx, nextKey, nextValue)
@@ -727,7 +727,7 @@ func testIncrementalDeletes(t *testing.T, keyDesc *val.TupleDesc) {
 		// delete leaf node
 		{
 			putVector(t, keyBuilder, encodeVector(t, keyDesc, 0.0, 1.0))
-			nextKey, err := keyBuilder.Build(bp)
+			nextKey, err := keyBuilder.Build(context.Background(), bp)
 			require.NoError(t, err)
 
 			err = mutableMap.Put(ctx, nextKey, nil)
@@ -752,7 +752,7 @@ func testIncrementalDeletes(t *testing.T, keyDesc *val.TupleDesc) {
 		// delete root node
 		{
 			putVector(t, keyBuilder, encodeVector(t, keyDesc, 5.0, 6.0))
-			nextKey, err := keyBuilder.Build(bp)
+			nextKey, err := keyBuilder.Build(context.Background(), bp)
 			require.NoError(t, err)
 
 			err = mutableMap.Put(ctx, nextKey, nil)

--- a/go/store/prolly/tree/addr_diff_test.go
+++ b/go/store/prolly/tree/addr_diff_test.go
@@ -15,6 +15,7 @@
 package tree
 
 import (
+	"context"
 	"io"
 	"testing"
 
@@ -41,7 +42,7 @@ func TestAddressDifferFromRootsOneLayer(t *testing.T) {
 	bld := val.NewTupleBuilder(desc, ns)
 	// modify value in the first half of the tree
 	bld.PutUint32(0, uint32(42))
-	toTups[23][1], err = bld.Build(sharedPool)
+	toTups[23][1], err = bld.Build(context.Background(), sharedPool)
 	assert.NoError(t, err)
 	toRoot, err := MakeTreeForTest(toTups)
 	assert.NoError(t, err)
@@ -72,7 +73,7 @@ func TestAddressDifferFromRootsTwoLayer(t *testing.T) {
 	bld := val.NewTupleBuilder(desc, ns)
 	// modify value early in the tree, to ensure the modification happens on the first child of the root.
 	bld.PutUint32(0, uint32(42))
-	toTups[23][1], err = bld.Build(sharedPool)
+	toTups[23][1], err = bld.Build(context.Background(), sharedPool)
 	assert.NoError(t, err)
 	toRoot, err := MakeTreeForTest(toTups)
 	assert.NoError(t, err)
@@ -111,7 +112,7 @@ func TestAddressDifferFromRootsThreeLayer(t *testing.T) {
 	bld := val.NewTupleBuilder(desc, ns)
 	// modify value in the second half of the tree
 	bld.PutUint32(0, uint32(42))
-	toTups[23700][1], err = bld.Build(sharedPool)
+	toTups[23700][1], err = bld.Build(context.Background(), sharedPool)
 	assert.NoError(t, err)
 	toRoot, err := MakeTreeForTest(toTups)
 	assert.NoError(t, err)

--- a/go/store/prolly/tree/blob_builder_test.go
+++ b/go/store/prolly/tree/blob_builder_test.go
@@ -357,14 +357,14 @@ func newTree(t *testing.T, ns NodeStore, keyCnt, blobLen, chunkSize int) *Node {
 	var err error
 	for i := range tuples {
 		keyBld.PutUint32(0, uint32(i))
-		tuples[i][0], err = keyBld.Build(sharedPool)
+		tuples[i][0], err = keyBld.Build(context.Background(), sharedPool)
 		if err != nil {
 			panic(err)
 		}
 
 		addr := mustNewBlob(ctx, ns, blobLen, chunkSize)
 		valBld.PutBytesAddr(0, addr)
-		tuples[i][1], err = valBld.Build(sharedPool)
+		tuples[i][1], err = valBld.Build(context.Background(), sharedPool)
 		if err != nil {
 			panic(err)
 		}

--- a/go/store/prolly/tree/diff_test.go
+++ b/go/store/prolly/tree/diff_test.go
@@ -15,6 +15,7 @@
 package tree
 
 import (
+	"context"
 	"io"
 	"testing"
 
@@ -40,7 +41,7 @@ func TestDifferFromRoots(t *testing.T) {
 	copy(toTups, fromTups)
 	bld := val.NewTupleBuilder(desc, ns)
 	bld.PutUint32(0, uint32(42))
-	toTups[23][1], err = bld.Build(sharedPool) // modify value at index 23.
+	toTups[23][1], err = bld.Build(context.Background(), sharedPool) // modify value at index 23.
 	assert.NoError(t, err)
 	toRoot, err := MakeTreeForTest(toTups)
 	assert.NoError(t, err)

--- a/go/store/prolly/tree/node_cursor_test.go
+++ b/go/store/prolly/tree/node_cursor_test.go
@@ -15,6 +15,7 @@
 package tree
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -115,7 +116,7 @@ func testGetOrdinalOfCursor(t *testing.T, count int) {
 
 	b := val.NewTupleBuilder(desc, ns)
 	b.PutUint32(0, uint32(len(tuples)))
-	aboveItem, err := b.Build(sharedPool)
+	aboveItem, err := b.Build(context.Background(), sharedPool)
 	require.NoError(t, err)
 
 	curr, err := newCursorAtKey(ctx, ns, nd, aboveItem, desc)

--- a/go/store/prolly/tree/patch_test.go
+++ b/go/store/prolly/tree/patch_test.go
@@ -40,7 +40,7 @@ func TestPatchGeneratorFromRoots(t *testing.T) {
 		copy(toTups, fromTups)
 		bld := val.NewTupleBuilder(desc, ns)
 		bld.PutUint32(0, uint32(42))
-		toTups[23][1], err = bld.Build(sharedPool) // modify value at index 23.
+		toTups[23][1], err = bld.Build(context.Background(), sharedPool) // modify value at index 23.
 		assert.NoError(t, err)
 		toRoot, err := MakeTreeForTest(toTups)
 		assert.NoError(t, err)

--- a/go/store/prolly/tree/prolly_fields.go
+++ b/go/store/prolly/tree/prolly_fields.go
@@ -158,7 +158,7 @@ func GetField(ctx context.Context, td *val.TupleDesc, i int, tup val.Tuple, ns N
 	case val.BytesAdaptiveEnc:
 		v, ok, err = td.GetBytesAdaptiveValue(ctx, i, ns, tup)
 	case val.StringAdaptiveEnc:
-		v, ok, err = td.GetStringAdaptiveValue(i, ns, tup)
+		v, ok, err = td.GetStringAdaptiveValue(ctx, i, ns, tup)
 	case val.CommitAddrEnc:
 		v, ok = td.GetCommitAddr(i, tup)
 	case val.CellEnc:
@@ -403,7 +403,7 @@ func Serialize(ctx context.Context, ns NodeStore, t val.Type, v interface{}) (re
 	if err != nil {
 		return nil, err
 	}
-	tup, err := tb.Build(pool.NewBuffPool())
+	tup, err := tb.Build(ctx, pool.NewBuffPool())
 	if err != nil {
 		return nil, err
 	}

--- a/go/store/prolly/tree/prolly_fields_test.go
+++ b/go/store/prolly/tree/prolly_fields_test.go
@@ -213,7 +213,7 @@ func testRoundTripProllyFields(t *testing.T, test prollyFieldTest) {
 	err := PutField(ctx, ns, builder, 0, test.value)
 	require.NoError(t, err)
 
-	tup, err := builder.Build(testPool)
+	tup, err := builder.Build(context.Background(), testPool)
 	require.NoError(t, err)
 
 	v, err := GetField(ctx, desc, 0, tup, ns)
@@ -314,7 +314,7 @@ func TestGeometryEncoding(t *testing.T) {
 			builder := val.NewTupleBuilder(oldDesc, ns)
 			b := serializeGeometry(test.value)
 			builder.PutGeometry(0, b)
-			tup, err := builder.Build(testPool)
+			tup, err := builder.Build(context.Background(), testPool)
 			require.NoError(t, err)
 
 			var v interface{}

--- a/go/store/prolly/tree/testutils.go
+++ b/go/store/prolly/tree/testutils.go
@@ -131,12 +131,12 @@ func AscendingUintTuples(count int) (tuples [][2]val.Tuple, desc *val.TupleDesc)
 	var err error
 	for i := range tuples {
 		bld.PutUint32(0, uint32(i))
-		tuples[i][0], err = bld.Build(sharedPool)
+		tuples[i][0], err = bld.Build(context.Background(), sharedPool)
 		if err != nil {
 			panic(err)
 		}
 		bld.PutUint32(0, uint32(i+count))
-		tuples[i][1], err = bld.Build(sharedPool)
+		tuples[i][1], err = bld.Build(context.Background(), sharedPool)
 		if err != nil {
 			panic(err)
 		}
@@ -153,12 +153,12 @@ func AscendingUintTuplesWithStep(count int, keyStart int, valStart int, step int
 	value := valStart
 	for i := range tuples {
 		bld.PutUint32(0, uint32(key))
-		tuples[i][0], err = bld.Build(sharedPool)
+		tuples[i][0], err = bld.Build(context.Background(), sharedPool)
 		if err != nil {
 			panic(err)
 		}
 		bld.PutUint32(0, uint32(value))
-		tuples[i][1], err = bld.Build(sharedPool)
+		tuples[i][1], err = bld.Build(context.Background(), sharedPool)
 		if err != nil {
 			panic(err)
 		}
@@ -172,7 +172,7 @@ func RandomTuple(tb *val.TupleBuilder, ns NodeStore) (tup val.Tuple, err error) 
 	for i, typ := range tb.Desc.Types {
 		randomField(tb, i, typ, ns)
 	}
-	return tb.Build(sharedPool)
+	return tb.Build(context.Background(), sharedPool)
 }
 
 func CloneRandomTuples(items [][2]val.Tuple) (clone [][2]val.Tuple) {

--- a/go/store/prolly/tree/three_way_differ_test.go
+++ b/go/store/prolly/tree/three_way_differ_test.go
@@ -249,7 +249,7 @@ func testResolver(t *testing.T, ns NodeStore, valDesc *val.TupleDesc, valBuilder
 				valBuilder.PutInt64(i, base)
 			}
 		}
-		tup, err := valBuilder.Build(ns.Pool())
+		tup, err := valBuilder.Build(context.Background(), ns.Pool())
 		return tup, true, err
 	}
 }
@@ -302,13 +302,13 @@ func newTestMap(t *testing.T, ctx context.Context, rows [][]int, ns NodeStore, v
 
 	for _, row := range rows {
 		keyBuilder.PutInt64(0, int64(row[0]))
-		key, err := keyBuilder.Build(ns.Pool())
+		key, err := keyBuilder.Build(context.Background(), ns.Pool())
 		require.NoError(t, err)
 		for j := 1; j < len(row); j++ {
 			valBuilder.PutInt64(j-1, int64(row[j]))
 			require.NoError(t, err)
 		}
-		val, err := valBuilder.Build(ns.Pool())
+		val, err := valBuilder.Build(context.Background(), ns.Pool())
 		require.NoError(t, err)
 		err = chkr.AddPair(ctx, Item(key), Item(val))
 		require.NoError(t, err)

--- a/go/store/prolly/tuple_range.go
+++ b/go/store/prolly/tuple_range.go
@@ -339,7 +339,7 @@ func IncrementTuple(ctx context.Context, start val.Tuple, n int, desc *val.Tuple
 	default:
 		return nil, false, nil
 	}
-	stop, err := tb.Build(pool)
+	stop, err := tb.Build(ctx, pool)
 	if err != nil {
 		return nil, false, err
 	}

--- a/go/store/prolly/tuple_range_iter_test.go
+++ b/go/store/prolly/tuple_range_iter_test.go
@@ -219,7 +219,7 @@ func getKeyPrefix(key val.Tuple, desc *val.TupleDesc) (partial val.Tuple, err er
 	for i := range desc.Types {
 		tb.PutRaw(i, key.GetField(i))
 	}
-	return tb.Build(sharedPool)
+	return tb.Build(context.Background(), sharedPool)
 }
 
 // computes expected range on full tuples set
@@ -431,7 +431,7 @@ func intTuple(ints ...int32) val.Tuple {
 	for i := range ints {
 		tb.PutInt32(i, ints[i])
 	}
-	tup, err := tb.Build(sharedPool)
+	tup, err := tb.Build(context.Background(), sharedPool)
 	if err != nil {
 		panic(err)
 	}

--- a/go/store/prolly/tuple_range_test.go
+++ b/go/store/prolly/tuple_range_test.go
@@ -238,7 +238,7 @@ func intNullTuple(ints ...*int32) val.Tuple {
 			tb.PutInt32(i, *val)
 		}
 	}
-	tup, err := tb.Build(sharedPool)
+	tup, err := tb.Build(context.Background(), sharedPool)
 	if err != nil {
 		panic(err)
 	}

--- a/go/store/val/tuple_builder.go
+++ b/go/store/val/tuple_builder.go
@@ -85,20 +85,18 @@ func NewTupleBuilder(desc *TupleDesc, vs ValueStore) *TupleBuilder {
 }
 
 // Build materializes a Tuple from the fields written to the TupleBuilder.
-func (tb *TupleBuilder) Build(pool pool.BuffPool) (tup Tuple, err error) {
+func (tb *TupleBuilder) Build(ctx context.Context, pool pool.BuffPool) (tup Tuple, err error) {
 	for i, typ := range tb.Desc.Types {
 		if !typ.Nullable && tb.fields[i] == nil {
 			panic("cannot write NULL to non-NULL field: " + strconv.Itoa(i))
 		}
 	}
-	return tb.BuildPermissive(pool)
+	return tb.BuildPermissive(ctx, pool)
 }
 
 // BuildPermissive materializes a Tuple from the fields
 // written to the TupleBuilder without validating nullability.
-func (tb *TupleBuilder) BuildPermissive(pool pool.BuffPool) (tup Tuple, err error) {
-	// TODO: add context parameter
-	ctx := context.Background()
+func (tb *TupleBuilder) BuildPermissive(ctx context.Context, pool pool.BuffPool) (tup Tuple, err error) {
 	// Values may get passed into the tuple builder in either in-band or out-of-band form.
 	// In the best case, we don't need to convert any of them, so the TupleBuilder initially stores them in the form they're given.
 	// But we track the tuple size if they're all inlined vs the tuple size if they're all out-of-band,

--- a/go/store/val/tuple_builder_test.go
+++ b/go/store/val/tuple_builder_test.go
@@ -81,7 +81,7 @@ func smokeTestTupleBuilder(t *testing.T) {
 	tb.PutString(10, "123")
 	tb.PutByteString(11, []byte("abc"))
 
-	tup, err := tb.Build(testPool)
+	tup, err := tb.Build(context.Background(), testPool)
 	assert.NoError(t, err)
 	i8, ok := desc.GetInt8(0, tup)
 	assert.True(t, ok)
@@ -165,7 +165,7 @@ func testRoundTripInts(t *testing.T) {
 		for idx, value := range test.data {
 			bld.PutInt64(idx, value)
 		}
-		tup, err := bld.Build(testPool)
+		tup, err := bld.Build(context.Background(), testPool)
 		assert.NoError(t, err)
 
 		// verify
@@ -303,7 +303,7 @@ func TestTupleBuilderJsonAdaptiveEncoding(t *testing.T) {
 
 		err := tb.PutAdaptiveJsonFromInline(ctx, 0, smallJson)
 		require.NoError(t, err)
-		tup, err := tb.Build(testPool)
+		tup, err := tb.Build(context.Background(), testPool)
 		require.NoError(t, err)
 
 		result, ok, err := td.GetJsonAdaptiveValue(ctx, 0, vs, tup)
@@ -328,7 +328,7 @@ func TestTupleBuilderJsonAdaptiveEncoding(t *testing.T) {
 		storage := NewJsonStorageOutOfBand(h, vs, int64(len(largeJson)))
 		tb.PutAdaptiveJsonFromOutline(0, storage)
 
-		tup, err := tb.Build(testPool)
+		tup, err := tb.Build(context.Background(), testPool)
 		require.NoError(t, err)
 
 		result, ok, err := td.GetJsonAdaptiveValue(ctx, 0, vs, tup)
@@ -355,7 +355,7 @@ func TestTupleBuilderJsonAdaptiveEncoding(t *testing.T) {
 		err = tb.PutAdaptiveJsonFromInline(ctx, 1, largeJson)
 		require.NoError(t, err)
 
-		tup, err := tb.Build(testPool)
+		tup, err := tb.Build(context.Background(), testPool)
 		require.NoError(t, err)
 
 		// Column 0 (small) should stay inline.
@@ -388,7 +388,7 @@ func TestTupleBuilderJsonAdaptiveEncoding(t *testing.T) {
 		tb := NewTupleBuilder(td, vs)
 
 		// Don't write any value – the field should be NULL.
-		tup, err := tb.Build(testPool)
+		tup, err := tb.Build(context.Background(), testPool)
 		require.NoError(t, err)
 
 		result, ok, err := td.GetJsonAdaptiveValue(ctx, 0, vs, tup)
@@ -405,7 +405,7 @@ func TestTupleBuilderJsonAdaptiveEncoding(t *testing.T) {
 
 		err := tb.PutAdaptiveJsonFromInline(ctx, 0, largeJson)
 		require.NoError(t, err)
-		tup, err := tb.Build(testPool)
+		tup, err := tb.Build(context.Background(), testPool)
 		require.NoError(t, err)
 
 		result, ok, err := td.GetJsonAdaptiveValue(ctx, 0, vs, tup)
@@ -433,7 +433,7 @@ func TestTupleBuilderJsonAdaptiveEncoding(t *testing.T) {
 
 		err := tb.PutAdaptiveJsonFromInline(ctx, 0, largeJson)
 		require.NoError(t, err)
-		tup, err := tb.Build(testPool)
+		tup, err := tb.Build(context.Background(), testPool)
 		require.NoError(t, err)
 
 		outOfBandResult, ok, err := td.GetJsonAdaptiveValue(ctx, 0, vs, tup)
@@ -446,7 +446,7 @@ func TestTupleBuilderJsonAdaptiveEncoding(t *testing.T) {
 		// Put the out-of-band JsonStorage back into a new tuple (pass-through).
 		tb2 := NewTupleBuilder(td, vs)
 		tb2.PutAdaptiveJsonFromOutline(0, outOfBandResult.(*JsonAdaptiveStorage))
-		tup2, err := tb2.Build(testPool)
+		tup2, err := tb2.Build(context.Background(), testPool)
 		require.NoError(t, err)
 
 		// The value should still be readable after the pass-through.
@@ -476,7 +476,7 @@ func TestTupleBuilderAdaptiveEncodings(t *testing.T) {
 			shortByteArray := make([]byte, defaultTupleLengthTarget/2)
 			err := tb.PutAdaptiveBytesFromInline(ctx, 0, shortByteArray)
 			require.NoError(t, err)
-			tup, err := tb.Build(testPool)
+			tup, err := tb.Build(context.Background(), testPool)
 			require.NoError(t, err)
 
 			adaptiveEncodingBytes, _, err := td.GetBytesAdaptiveValue(ctx, 0, vs, tup)
@@ -491,7 +491,7 @@ func TestTupleBuilderAdaptiveEncodings(t *testing.T) {
 			byteArray := NewByteArray(ctx, h, vs).WithMaxByteLength(int64(len(longByteArray)))
 			tb.PutAdaptiveBytesFromOutline(0, byteArray)
 
-			tup, err := tb.Build(testPool)
+			tup, err := tb.Build(context.Background(), testPool)
 			require.NoError(t, err)
 
 			adaptiveEncodingBytes, _, err := td.GetBytesAdaptiveValue(ctx, 0, vs, tup)
@@ -523,7 +523,7 @@ func TestTupleBuilderAdaptiveEncodings(t *testing.T) {
 			err = tb.PutAdaptiveBytesFromInline(ctx, 1, mediumByteArray)
 			require.NoError(t, err)
 
-			tup, err := tb.Build(testPool)
+			tup, err := tb.Build(context.Background(), testPool)
 			require.NoError(t, err)
 
 			{
@@ -557,7 +557,7 @@ func TestTupleBuilderAdaptiveEncodings(t *testing.T) {
 			err = tb.PutAdaptiveBytesFromInline(ctx, 1, largeByteArray)
 			require.NoError(t, err)
 
-			tup, err := tb.Build(testPool)
+			tup, err := tb.Build(context.Background(), testPool)
 			require.NoError(t, err)
 
 			{
@@ -609,7 +609,7 @@ func TestTupleBuilderAdaptiveEncodings(t *testing.T) {
 			err = tb.PutAdaptiveBytesFromInline(ctx, 2, largeByteArray)
 			require.NoError(t, err)
 
-			tup, err := tb.Build(testPool)
+			tup, err := tb.Build(context.Background(), testPool)
 			require.NoError(t, err)
 
 			{

--- a/go/store/val/tuple_descriptor.go
+++ b/go/store/val/tuple_descriptor.go
@@ -599,9 +599,7 @@ func GetBytesAdaptiveValue(ctx context.Context, vs ValueStore, val []byte) (inte
 }
 
 // GetStringAdaptiveValue returns either a string or a StringWrapper, but Go doesn't allow us to use a single type for that.
-func (td *TupleDesc) GetStringAdaptiveValue(i int, vs ValueStore, tup Tuple) (interface{}, bool, error) {
-	// TODO: Add context parameter
-	ctx := context.Background()
+func (td *TupleDesc) GetStringAdaptiveValue(ctx context.Context, i int, vs ValueStore, tup Tuple) (interface{}, bool, error) {
 	td.ExpectEncoding(i, StringAdaptiveEnc)
 	adaptiveValue := AdaptiveValue(td.GetField(i, tup))
 	if len(adaptiveValue) == 0 {
@@ -864,7 +862,7 @@ func (handler AddressTypeHandler) SerializeValue(ctx context.Context, val any) (
 	if len(b) == 0 {
 		return nil, nil
 	}
-	h, err := handler.vs.WriteBytes(context.Background(), b)
+	h, err := handler.vs.WriteBytes(ctx, b)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We've done a lot of work lately to make sure that all business logic has access to a proper context, but there's some lingering places that fell through the cracks. This cleans some of those up.