### PR TITLE
[no-release-notes] Add context parameter to call to BuildPermissive

### DIFF
--- a/go/libraries/doltcore/merge/merge_prolly_rows.go
+++ b/go/libraries/doltcore/merge/merge_prolly_rows.go
@@ -1947,7 +1947,7 @@ func (m *valueMerger) TryMerge(ctx *sql.Context, left, right, base val.Tuple) (v
 
 	// We call BuildPermissive so that we don't panic if the merged tuple violates a nullness constraint.
 	// This lets us log it as a violation instead.
-	mergedTuple, err := m.valueBuilder.BuildPermissive(m.syncPool)
+	mergedTuple, err := m.valueBuilder.BuildPermissive(ctx, m.syncPool)
 	if err != nil {
 		return nil, true, err
 	}


### PR DESCRIPTION
This fixes a build failure caused by two concurrent PRs getting merged into main around the same time.