### PR TITLE
Fix `dolt rm --cached` to allow unstaged working changes

### DIFF
--- a/go/libraries/doltcore/sqle/dprocedures/dolt_rm.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_rm.go
@@ -86,16 +86,29 @@ func doDoltRm(ctx *sql.Context, args []string) (int, error) {
 		return 1, err
 	}
 
-	// RemoveTables() validates foreign keys, and the above call will not catch foreign key constraints on tables that
-	// exist only in the working set. So we need to run the below line on each dolt_rm() to avoid wiping constrained tables.
-	newWorking, err := roots.Working.RemoveTables(ctx, false, false, verifiedTables...)
-	if err != nil {
-		return 1, err
-	}
-
-	// If --cached was not used, we want to fully delete the tables, so we remove them from the working set as well.
+	// The staged root check above does not validate FK constraints that only exist in
+	// the working set, so the working set must also be checked.
 	if !checkStaged {
-		roots.Working = newWorking
+		roots.Working, err = roots.Working.RemoveTables(ctx, false, false, verifiedTables...)
+		if err != nil {
+			return 1, err
+		}
+	} else {
+		// With |--cached|, a table may already be absent from working (for example
+		// after a DROP TABLE), so only tables present in working are passed to the FK check.
+		var workingTables []doltdb.TableName
+		for _, tbl := range verifiedTables {
+			ok, err := roots.Working.HasTable(ctx, tbl)
+			if err != nil {
+				return 1, err
+			}
+			if ok {
+				workingTables = append(workingTables, tbl)
+			}
+		}
+		if _, err = roots.Working.RemoveTables(ctx, false, false, workingTables...); err != nil {
+			return 1, err
+		}
 	}
 
 	if err = dSess.SetRoots(ctx, dbName, roots); err != nil {
@@ -110,8 +123,9 @@ func doDoltRm(ctx *sql.Context, args []string) (int, error) {
 func verifyTables(ctx *sql.Context, unqualifiedTables []string, checkStaged bool, roots doltdb.Roots) ([]doltdb.TableName, error) {
 	var missingTables []string
 	var missingStagedTables []string
+	var tableNames []doltdb.TableName
+
 	var unstagedTables []string
-	var TableNames []doltdb.TableName
 
 	for _, name := range unqualifiedTables {
 		_, okHead, err := resolve.TableName(ctx, roots.Head, name)
@@ -123,14 +137,16 @@ func verifyTables(ctx *sql.Context, unqualifiedTables []string, checkStaged bool
 			return nil, err
 		}
 
-		// Does the table have unstaged changes? If so, error out
-		hasChanges, err := hasUnstagedChanges(ctx, roots, name, okStage, okHead)
-		if err != nil {
-			return nil, err
-		}
-		if hasChanges {
-			unstagedTables = append(unstagedTables, name)
-			continue
+		// With |--cached|, the working set is not modified, so unstaged working changes are not a problem.
+		if !checkStaged {
+			hasChanges, err := hasUnstagedChanges(ctx, roots, name, okStage, okHead)
+			if err != nil {
+				return nil, err
+			}
+			if hasChanges {
+				unstagedTables = append(unstagedTables, name)
+				continue
+			}
 		}
 
 		// If the table exists in staged:
@@ -141,13 +157,13 @@ func verifyTables(ctx *sql.Context, unqualifiedTables []string, checkStaged bool
 		// If it isn't in HEAD it doesn't exist, and so we error
 		if okStage {
 			if okHead || checkStaged {
-				TableNames = append(TableNames, tblName)
+				tableNames = append(tableNames, tblName)
 			} else {
 				missingStagedTables = append(missingStagedTables, name)
 			}
 		} else {
 			if okHead {
-				TableNames = append(TableNames, tblName)
+				tableNames = append(tableNames, tblName)
 			} else {
 				missingTables = append(missingTables, name)
 			}
@@ -156,13 +172,13 @@ func verifyTables(ctx *sql.Context, unqualifiedTables []string, checkStaged bool
 
 	if len(missingTables) > 0 {
 		return nil, actions.NewTblNotExistError(doltdb.ToTableNames(missingTables, doltdb.DefaultSchemaName))
-	} else if len(unstagedTables) > 0 {
+	} else if !checkStaged && len(unstagedTables) > 0 {
 		return nil, actions.NewTblUnstagedError(doltdb.ToTableNames(unstagedTables, doltdb.DefaultSchemaName))
 	} else if len(missingStagedTables) > 0 {
 		return nil, actions.NewTblStagedError(doltdb.ToTableNames(missingStagedTables, doltdb.DefaultSchemaName))
 	}
 
-	return TableNames, nil
+	return tableNames, nil
 }
 
 // hasUnstagedChanges checks the HEAD and staged roots for the table, then compares them against the table in the working root.

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_rm.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_rm.go
@@ -81,18 +81,20 @@ func doDoltRm(ctx *sql.Context, args []string) (int, error) {
 		return 1, err
 	}
 
-	roots.Staged, err = roots.Staged.RemoveTables(ctx, false, false, verifiedTables...)
+	staged, err := roots.Staged.RemoveTables(ctx, false, false, verifiedTables...)
 	if err != nil {
 		return 1, err
 	}
+	roots.Staged = staged
 
 	// The staged root check above does not validate FK constraints that only exist in
 	// the working set, so the working set must also be checked.
 	if !checkStaged {
-		roots.Working, err = roots.Working.RemoveTables(ctx, false, false, verifiedTables...)
+		working, err := roots.Working.RemoveTables(ctx, false, false, verifiedTables...)
 		if err != nil {
 			return 1, err
 		}
+		roots.Working = working
 	} else {
 		// With |--cached|, a table may already be absent from working (for example
 		// after a DROP TABLE), so only tables present in working are passed to the FK check.

--- a/integration-tests/bats/rm.bats
+++ b/integration-tests/bats/rm.bats
@@ -91,6 +91,57 @@ teardown() {
     [[ "$output" =~ "new table:" ]] || false
 }
 
+@test "rm: dolt rm --cached succeeds when a committed table has unstaged changes" {
+    # See https://github.com/dolthub/dolt/issues/10987
+    dolt sql -q "CREATE TABLE api_keys (id INT PRIMARY KEY, token VARCHAR(64))"
+    dolt sql -q "INSERT INTO api_keys VALUES (1, 'initial')"
+    dolt commit -A -m "add api_keys"
+
+    dolt sql -q "INSERT INTO api_keys VALUES (2, 'unstaged-change')"
+
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "modified" ]] || false
+    [[ "$output" =~ "api_keys" ]] || false
+
+    run dolt rm --cached api_keys
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "removed 'api_keys' from tracking" ]] || false
+
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "deleted:" ]] || false
+    [[ "$output" =~ "api_keys" ]] || false
+
+    # The --cached flag only removes the table from tracking and does not delete its data.
+    run dolt sql -q "SELECT COUNT(*) FROM api_keys"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "2" ]] || false
+}
+
+@test "rm: dolt rm --cached succeeds when a committed table was dropped from the working set" {
+    # See https://github.com/dolthub/dolt/issues/10987
+    dolt sql -q "CREATE TABLE test (id INT PRIMARY KEY)"
+    dolt sql -q "INSERT INTO test VALUES (1)"
+    dolt commit -A -m "add test"
+
+    dolt sql -q "DROP TABLE test"
+
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "deleted" ]] || false
+    [[ "$output" =~ "test" ]] || false
+
+    run dolt rm --cached test
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "removed 'test' from tracking" ]] || false
+
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "deleted:" ]] || false
+    [[ "$output" =~ "test" ]] || false
+}
+
 @test "rm: dolt rm errors on foreign key constrained table" {
     dolt sql -q "CREATE TABLE parent (pk int primary key, p1 int)"
     dolt sql -q "CREATE TABLE child (pk int primary key, c1 int, FOREIGN KEY (c1) REFERENCES parent (pk))"


### PR DESCRIPTION
`dolt rm --cached` incorrectly rejected tables with unstaged working changes or tables already dropped from the working set.
- `--cached` branch filters tables absent from working via `HasTable` before calling `RemoveTables`.
Fix dolthub/dolt#10987