### PR TITLE
[no-release-notes] Fix ORM Docker build apt mirror resilience 

### DIFF
--- a/.github/workflows/ci-orm-tests.yaml
+++ b/.github/workflows/ci-orm-tests.yaml
@@ -32,6 +32,8 @@ jobs:
           file: dolt/integration-tests/orm-tests/Dockerfile
           tags: orm-tests:latest
           load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Test ORM integrations
         run: docker run --rm orm-tests:latest
       - name: Configure AWS Credentials

--- a/integration-tests/orm-tests/Dockerfile
+++ b/integration-tests/orm-tests/Dockerfile
@@ -13,31 +13,30 @@ RUN go mod download
 COPY dolt/go/ /build/dolt/go/
 RUN go build -tags icu_static -ldflags "$GO_LDFLAGS" -o /build/bin/dolt ./cmd/dolt
 
-FROM --platform=${BUILDPLATFORM} ubuntu:20.04 AS runtime
+FROM --platform=${BUILDPLATFORM} ubuntu:22.04 AS runtime
 
 # install ORM tools and dependencies
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update -y && \
-    apt install -y \
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
     gnupg \
     software-properties-common && \
     curl -sL https://deb.nodesource.com/setup_22.x | bash -
-RUN apt update -y && \
-    apt install -y \
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
     nodejs \
-    python3.9 \
+    python3 \
     python3-pip \
     git \
     mysql-client \
     libmysqlclient-dev \
     netcat-openbsd \
-    # weird issue: installing openjdk-17-jdk errors if `maven` or possibly any other package is not installed after it
     openjdk-17-jdk \
-    # currently, `apt install maven` installs v3.6.0 which does not work with openjdk-17-jdk
     maven && \
-    update-ca-certificates -f
+    update-ca-certificates -f && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN git clone --depth 1 --branch v1.13.0 https://github.com/bats-core/bats-core.git /tmp/bats-core && \
     /tmp/bats-core/install.sh /usr/local && \


### PR DESCRIPTION
- Add Docker layer caching to CI
- Upgrade base image to Ubuntu 22.04 since 20.04 reached EOL
- Use `--no-install-recommends` in `apt install` to avoid transitive dependencies