### PR TITLE
[no-release-notes] go: remotestorage: Add WithoutHTTP2DownloadCapability to DoltChunkStore.

### DIFF
--- a/go/libraries/doltcore/remotestorage/capabilities.go
+++ b/go/libraries/doltcore/remotestorage/capabilities.go
@@ -18,12 +18,13 @@ import (
 	remotesapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/remotesapi/v1alpha1"
 )
 
-// clientCapabilities is the set of capabilities this dolt client
-// declares on every outbound remotesapi request that carries a
-// client_capabilities field. Centralized here so the answer to
-// "what does this client advertise?" lives in one place and
-// adding a new capability is a one-line change. Treat as
-// immutable once the package is loaded.
-var clientCapabilities = []remotesapi.ClientCapability{
+// defaultClientCapabilities is the set of capabilities this dolt
+// client declares on every outbound remotesapi request that carries
+// a client_capabilities field. Centralized here so the answer to
+// "what does this client advertise?" lives in one place and adding
+// a new capability is a one-line change. Treat as immutable once
+// the package is loaded; per-store overrides (e.g.
+// WithoutHTTP2DownloadCapability) clone before mutating.
+var defaultClientCapabilities = []remotesapi.ClientCapability{
 	remotesapi.ClientCapability_CLIENT_CAPABILITY_HTTP2_DOWNLOAD,
 }

--- a/go/libraries/doltcore/remotestorage/chunk_fetcher.go
+++ b/go/libraries/doltcore/remotestorage/chunk_fetcher.go
@@ -122,18 +122,18 @@ func NewChunkFetcher(ctx context.Context, dcs *DoltChunkStore) *ChunkFetcher {
 					flat = append(flat, h...)
 				}
 				id, token := dcs.getRepoId()
-				return &remotesapi.StreamChunkLocationsRequest{RepoId: id, RepoPath: dcs.repoPath, RepoToken: token, ChunkHashes: flat, ClientCapabilities: clientCapabilities}
+				return &remotesapi.StreamChunkLocationsRequest{RepoId: id, RepoPath: dcs.repoPath, RepoToken: token, ChunkHashes: flat, ClientCapabilities: dcs.clientCapabilities}
 			})
 		})
 		eg.Go(func() error {
-			return fetcherRPCChunkLocationsThread(ctx, locsReqCh, downloadLocCh, dcs.csClient, storeRepoToken, ret.resCh, dcs.host, dcs.getRepoId, dcs.repoPath)
+			return fetcherRPCChunkLocationsThread(ctx, locsReqCh, downloadLocCh, dcs.csClient, storeRepoToken, ret.resCh, dcs.host, dcs.getRepoId, dcs.repoPath, dcs.clientCapabilities)
 		})
 	} else {
 		locsReqCh := make(chan *remotesapi.GetDownloadLocsRequest)
 		eg.Go(func() error {
 			return fetcherHashSetToReqsThread(ctx, ret.toGetCh, ret.abortCh, locsReqCh, getLocsBatchSize, func(hashes [][]byte) *remotesapi.GetDownloadLocsRequest {
 				id, token := dcs.getRepoId()
-				return &remotesapi.GetDownloadLocsRequest{RepoId: id, RepoPath: dcs.repoPath, RepoToken: token, ChunkHashes: hashes, ClientCapabilities: clientCapabilities}
+				return &remotesapi.GetDownloadLocsRequest{RepoId: id, RepoPath: dcs.repoPath, RepoToken: token, ChunkHashes: hashes, ClientCapabilities: dcs.clientCapabilities}
 			})
 		})
 		eg.Go(func() error {
@@ -141,7 +141,7 @@ func NewChunkFetcher(ctx context.Context, dcs *DoltChunkStore) *ChunkFetcher {
 		})
 	}
 	eg.Go(func() error {
-		return fetcherDownloadRangesThread(ctx, downloadLocCh, fetchReqCh, locDoneCh)
+		return fetcherDownloadRangesThread(ctx, downloadLocCh, fetchReqCh, locDoneCh, dcs.clientCapabilities)
 	})
 	eg.Go(func() error {
 		return fetcherDownloadURLThreads(ctx, fetchReqCh, locDoneCh, ret.resCh, dcs.csClient, ret.stats, dcs.httpFetcher, dcs.params)
@@ -365,7 +365,7 @@ func fetcherRPCDownloadLocsThread(ctx context.Context, reqCh chan *remotesapi.Ge
 // assignment and re-introduces any id it reuses with a fresh
 // TableFileRecord, which we overwrite into |tfByID| before resolving
 // any ChunkLocation that references it. See the proto file.
-func fetcherRPCChunkLocationsThread(ctx context.Context, reqCh chan *remotesapi.StreamChunkLocationsRequest, resCh chan []*remotesapi.DownloadLoc, client remotesapi.ChunkStoreServiceClient, storeRepoToken func(string), missingChunkCh chan nbs.ToChunker, host string, getRepoId func() (*remotesapi.RepoId, string), repoPath string) error {
+func fetcherRPCChunkLocationsThread(ctx context.Context, reqCh chan *remotesapi.StreamChunkLocationsRequest, resCh chan []*remotesapi.DownloadLoc, client remotesapi.ChunkStoreServiceClient, storeRepoToken func(string), missingChunkCh chan nbs.ToChunker, host string, getRepoId func() (*remotesapi.RepoId, string), repoPath string, clientCapabilities []remotesapi.ClientCapability) error {
 	stream, err := reliable.MakeCall(
 		ctx,
 		reliable.CallOptions[*remotesapi.StreamChunkLocationsRequest, *remotesapi.StreamChunkLocationsResponse]{
@@ -443,7 +443,7 @@ func fetcherRPCChunkLocationsThread(ctx context.Context, reqCh chan *remotesapi.
 				}
 			}
 
-			locs, err := translateChunkLocations(req, resp.Locations, tfByID, getRepoId, repoPath)
+			locs, err := translateChunkLocations(req, resp.Locations, tfByID, getRepoId, repoPath, clientCapabilities)
 			if err != nil {
 				return NewRpcError(err, "StreamChunkLocations", host, req)
 			}
@@ -465,7 +465,7 @@ func fetcherRPCChunkLocationsThread(ctx context.Context, reqCh chan *remotesapi.
 // file_id plus the DoltChunkStore's current (repo_id, repo_token,
 // repo_path) — the server no longer sends a per-DownloadLoc
 // RefreshTableFileUrlRequest.
-func translateChunkLocations(req *remotesapi.StreamChunkLocationsRequest, locations []*chunkLoc, tfByID map[uint32]*tableFileRec, getRepoId func() (*remotesapi.RepoId, string), repoPath string) ([]*remotesapi.DownloadLoc, error) {
+func translateChunkLocations(req *remotesapi.StreamChunkLocationsRequest, locations []*chunkLoc, tfByID map[uint32]*tableFileRec, getRepoId func() (*remotesapi.RepoId, string), repoPath string, clientCapabilities []remotesapi.ClientCapability) ([]*remotesapi.DownloadLoc, error) {
 	if len(locations) == 0 {
 		return nil, nil
 	}
@@ -582,14 +582,19 @@ type downloads struct {
 	// ranges that have gone into |chunkRanges|.
 	dictCache *dictionaryCache
 	refreshes map[string]*locationRefresh
+	// clientCapabilities is propagated onto every locationRefresh
+	// this set produces, so URL refreshes carry the per-store
+	// capability set.
+	clientCapabilities []remotesapi.ClientCapability
 }
 
-func newDownloads() downloads {
+func newDownloads(clientCapabilities []remotesapi.ClientCapability) downloads {
 	return downloads{
-		chunkRanges: ranges.NewTree(chunkAggDistance),
-		dictRanges:  ranges.NewTree(chunkAggDistance),
-		dictCache:   &dictionaryCache{},
-		refreshes:   make(map[string]*locationRefresh),
+		chunkRanges:        ranges.NewTree(chunkAggDistance),
+		dictRanges:         ranges.NewTree(chunkAggDistance),
+		dictCache:          &dictionaryCache{},
+		refreshes:          make(map[string]*locationRefresh),
+		clientCapabilities: clientCapabilities,
 	}
 }
 
@@ -599,7 +604,7 @@ func (d downloads) Add(resp *remotesapi.DownloadLoc) {
 	if v, ok := d.refreshes[path]; ok {
 		v.Add(resp)
 	} else {
-		refresh := new(locationRefresh)
+		refresh := &locationRefresh{clientCapabilities: d.clientCapabilities}
 		refresh.Add(resp)
 		d.refreshes[path] = refresh
 	}
@@ -637,8 +642,8 @@ const (
 )
 
 // Reads off |locCh| and assembles DownloadLocs into download ranges.
-func fetcherDownloadRangesThread(ctx context.Context, locCh chan []*remotesapi.DownloadLoc, fetchReqCh chan fetchReq, doneCh chan struct{}) error {
-	downloads := newDownloads()
+func fetcherDownloadRangesThread(ctx context.Context, locCh chan []*remotesapi.DownloadLoc, fetchReqCh chan fetchReq, doneCh chan struct{}, clientCapabilities []remotesapi.ClientCapability) error {
+	downloads := newDownloads(clientCapabilities)
 	for {
 		hasWork := downloads.dictRanges.Len() > 0 || downloads.chunkRanges.Len() > 0
 		if !hasWork && locCh == nil {

--- a/go/libraries/doltcore/remotestorage/chunk_fetcher_test.go
+++ b/go/libraries/doltcore/remotestorage/chunk_fetcher_test.go
@@ -128,7 +128,7 @@ func testIdFunc() (*remotesapi.RepoId, string) {
 
 func testBuildDlReq(hashes [][]byte) *remotesapi.GetDownloadLocsRequest {
 	id, token := testIdFunc()
-	return &remotesapi.GetDownloadLocsRequest{RepoId: id, RepoToken: token, ChunkHashes: hashes, ClientCapabilities: clientCapabilities}
+	return &remotesapi.GetDownloadLocsRequest{RepoId: id, RepoToken: token, ChunkHashes: hashes, ClientCapabilities: defaultClientCapabilities}
 }
 
 // buildFlatHashBuf returns a |nHashes|*20-byte buffer where hash |i|
@@ -182,7 +182,7 @@ func TestTranslateChunkLocations(t *testing.T) {
 	}
 
 	t.Run("EmptyLocations", func(t *testing.T) {
-		locs, err := translateChunkLocations(buildReq(0), nil, nil, getRepoId, repoPath)
+		locs, err := translateChunkLocations(buildReq(0), nil, nil, getRepoId, repoPath, defaultClientCapabilities)
 		require.NoError(t, err)
 		assert.Nil(t, locs)
 	})
@@ -196,7 +196,7 @@ func TestTranslateChunkLocations(t *testing.T) {
 			{TableFileId: 1, RequestIndex: 0, Offset: 0, Length: 10},
 			{TableFileId: 1, RequestIndex: 1, Offset: 10, Length: 20},
 		}
-		locs, err := translateChunkLocations(req, locations, tfByID, getRepoId, repoPath)
+		locs, err := translateChunkLocations(req, locations, tfByID, getRepoId, repoPath, defaultClientCapabilities)
 		require.NoError(t, err)
 		require.Len(t, locs, 1)
 		hgr := locs[0].Location.(*remotesapi.DownloadLoc_HttpGetRange).HttpGetRange
@@ -207,7 +207,7 @@ func TestTranslateChunkLocations(t *testing.T) {
 		assert.Equal(t, "token", locs[0].RefreshRequest.RepoToken)
 		assert.Equal(t, repoPath, locs[0].RefreshRequest.RepoPath)
 		assert.Equal(t, "file-1", locs[0].RefreshRequest.FileId)
-		assert.Equal(t, clientCapabilities, locs[0].RefreshRequest.ClientCapabilities)
+		assert.Equal(t, defaultClientCapabilities, locs[0].RefreshRequest.ClientCapabilities)
 	})
 
 	t.Run("CrossResponseReuse", func(t *testing.T) {
@@ -218,7 +218,7 @@ func TestTranslateChunkLocations(t *testing.T) {
 			1: {TableFileId: 1, Url: "urlA", FileId: "file-1"},
 		}
 		locations := []*chunkLoc{{TableFileId: 1, RequestIndex: 0}}
-		locs, err := translateChunkLocations(req, locations, tfByID, getRepoId, repoPath)
+		locs, err := translateChunkLocations(req, locations, tfByID, getRepoId, repoPath, defaultClientCapabilities)
 		require.NoError(t, err)
 		require.Len(t, locs, 1)
 		hgr := locs[0].Location.(*remotesapi.DownloadLoc_HttpGetRange).HttpGetRange
@@ -235,7 +235,7 @@ func TestTranslateChunkLocations(t *testing.T) {
 			1: {TableFileId: 1, Url: "urlB", FileId: "file-1-b"},
 		}
 		locations := []*chunkLoc{{TableFileId: 1, RequestIndex: 0}}
-		locs, err := translateChunkLocations(req, locations, tfByID, getRepoId, repoPath)
+		locs, err := translateChunkLocations(req, locations, tfByID, getRepoId, repoPath, defaultClientCapabilities)
 		require.NoError(t, err)
 		require.Len(t, locs, 1)
 		hgr := locs[0].Location.(*remotesapi.DownloadLoc_HttpGetRange).HttpGetRange
@@ -247,7 +247,7 @@ func TestTranslateChunkLocations(t *testing.T) {
 		req := buildReq(1)
 		tfByID := map[uint32]*tableFileRec{}
 		locations := []*chunkLoc{{TableFileId: 42, RequestIndex: 0}}
-		locs, err := translateChunkLocations(req, locations, tfByID, getRepoId, repoPath)
+		locs, err := translateChunkLocations(req, locations, tfByID, getRepoId, repoPath, defaultClientCapabilities)
 		assert.Nil(t, locs)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "table_file_id 42")
@@ -259,7 +259,7 @@ func TestTranslateChunkLocations(t *testing.T) {
 			1: {TableFileId: 1, Url: "u"},
 		}
 		locations := []*chunkLoc{{TableFileId: 1, RequestIndex: 2}}
-		locs, err := translateChunkLocations(req, locations, tfByID, getRepoId, repoPath)
+		locs, err := translateChunkLocations(req, locations, tfByID, getRepoId, repoPath, defaultClientCapabilities)
 		assert.Nil(t, locs)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "out of range")
@@ -277,7 +277,7 @@ func TestTranslateChunkLocations(t *testing.T) {
 			{TableFileId: 5, RequestIndex: 1},
 			{TableFileId: 7, RequestIndex: 2},
 		}
-		locs, err := translateChunkLocations(req, locations, tfByID, getRepoId, repoPath)
+		locs, err := translateChunkLocations(req, locations, tfByID, getRepoId, repoPath, defaultClientCapabilities)
 		require.NoError(t, err)
 		require.Len(t, locs, 2)
 
@@ -297,7 +297,7 @@ func TestTranslateChunkLocations(t *testing.T) {
 			1: {TableFileId: 1, Url: "u", FileId: "f", RefreshAfter: now},
 		}
 		locations := []*chunkLoc{{TableFileId: 1, RequestIndex: 0}}
-		locs, err := translateChunkLocations(req, locations, tfByID, getRepoId, repoPath)
+		locs, err := translateChunkLocations(req, locations, tfByID, getRepoId, repoPath, defaultClientCapabilities)
 		require.NoError(t, err)
 		require.Len(t, locs, 1)
 		assert.Equal(t, now, locs[0].RefreshAfter)
@@ -311,7 +311,7 @@ func TestTranslateChunkLocations(t *testing.T) {
 			1: {TableFileId: 1, Url: "u"},
 		}
 		locations := []*chunkLoc{{TableFileId: 1, RequestIndex: 2, Offset: 0, Length: 10}}
-		locs, err := translateChunkLocations(req, locations, tfByID, getRepoId, repoPath)
+		locs, err := translateChunkLocations(req, locations, tfByID, getRepoId, repoPath, defaultClientCapabilities)
 		require.NoError(t, err)
 		require.Len(t, locs, 1)
 		hgr := locs[0].Location.(*remotesapi.DownloadLoc_HttpGetRange).HttpGetRange
@@ -417,7 +417,7 @@ func startRPCThread(t *testing.T) *rpcTestHarness {
 	getRepoId := func() (*remotesapi.RepoId, string) { return repoId, "tok" }
 	go func() {
 		defer close(h.done)
-		h.finalErr = fetcherRPCChunkLocationsThread(ctx, h.reqCh, h.resCh, client, func(string) {}, h.missingCh, "host", getRepoId, "repoPath")
+		h.finalErr = fetcherRPCChunkLocationsThread(ctx, h.reqCh, h.resCh, client, func(string) {}, h.missingCh, "host", getRepoId, "repoPath", defaultClientCapabilities)
 	}()
 
 	// Backstop: make sure the RPC goroutine is torn down no matter

--- a/go/libraries/doltcore/remotestorage/chunk_store.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store.go
@@ -134,6 +134,12 @@ type DoltChunkStore struct {
 	stats       cacheStats
 	logger      chunks.DebugLogger
 	wsValidate  bool
+	// clientCapabilities is what this store advertises in
+	// outbound requests' client_capabilities fields. Initialized
+	// to defaultClientCapabilities; per-store overrides (e.g.
+	// WithoutHTTP2DownloadCapability) return a clone with this
+	// field replaced.
+	clientCapabilities []remotesapi.ClientCapability
 }
 
 // hasFeature reports whether |f| appears in |md|'s advertised
@@ -184,19 +190,20 @@ func NewDoltChunkStoreFromPath(
 	}
 
 	cs := &DoltChunkStore{
-		repoId:      repoId,
-		repoPath:    path,
-		repoToken:   repoToken,
-		host:        host,
-		csClient:    csClient,
-		finalizer:   func() error { return nil },
-		cache:       newMapChunkCache(),
-		wb:          newMapWriteBuffer(),
-		metadata:    metadata,
-		nbf:         nbf,
-		httpFetcher: globalHttpFetcher,
-		params:      defaultRequestParams,
-		wsValidate:  wsval,
+		repoId:             repoId,
+		repoPath:           path,
+		repoToken:          repoToken,
+		host:               host,
+		csClient:           csClient,
+		finalizer:          func() error { return nil },
+		cache:              newMapChunkCache(),
+		wb:                 newMapWriteBuffer(),
+		metadata:           metadata,
+		nbf:                nbf,
+		httpFetcher:        globalHttpFetcher,
+		params:             defaultRequestParams,
+		wsValidate:         wsval,
+		clientCapabilities: defaultClientCapabilities,
 	}
 	err = cs.loadRoot(ctx)
 	if err != nil {
@@ -214,6 +221,24 @@ func (dcs *DoltChunkStore) clone() *DoltChunkStore {
 func (dcs *DoltChunkStore) WithHTTPFetcher(fetcher HTTPFetcher) *DoltChunkStore {
 	ret := dcs.clone()
 	ret.httpFetcher = fetcher
+	return ret
+}
+
+// WithoutHTTP2DownloadCapability returns a clone of |dcs| whose
+// advertised client_capabilities omit
+// CLIENT_CAPABILITY_HTTP2_DOWNLOAD. Use it for clients whose HTTP
+// transport cannot satisfy HTTP/2-only download URLs and that need
+// the server to fall back to capability sets that exclude it.
+func (dcs *DoltChunkStore) WithoutHTTP2DownloadCapability() *DoltChunkStore {
+	ret := dcs.clone()
+	filtered := make([]remotesapi.ClientCapability, 0, len(dcs.clientCapabilities))
+	for _, c := range dcs.clientCapabilities {
+		if c == remotesapi.ClientCapability_CLIENT_CAPABILITY_HTTP2_DOWNLOAD {
+			continue
+		}
+		filtered = append(filtered, c)
+	}
+	ret.clientCapabilities = filtered
 	return ret
 }
 
@@ -536,8 +561,12 @@ type locationRefresh struct {
 	RefreshAfter   time.Time
 	RefreshRequest *remotesapi.RefreshTableFileUrlRequest
 	URL            string
-	lastRefresh    time.Time
-	mu             sync.Mutex
+	// clientCapabilities is the per-store capability set stamped
+	// onto RefreshRequest at send time. Carried on the refresh so
+	// GetURL does not need a back-pointer to the DoltChunkStore.
+	clientCapabilities []remotesapi.ClientCapability
+	lastRefresh        time.Time
+	mu                 sync.Mutex
 }
 
 func (r *locationRefresh) Add(resp *remotesapi.DownloadLoc) {
@@ -573,7 +602,7 @@ func (r *locationRefresh) GetURL(ctx context.Context, lastError error, client re
 			// the client is authoritative for its own capability set
 			// and must stamp it at send time. See the ClientCapability
 			// enum comment in chunkstore.proto.
-			r.RefreshRequest.ClientCapabilities = clientCapabilities
+			r.RefreshRequest.ClientCapabilities = r.clientCapabilities
 			ctx, cancel := context.WithTimeout(ctx, refreshTableFileURLTimeout)
 			resp, err := client.RefreshTableFileUrl(ctx, r.RefreshRequest)
 			cancel()
@@ -1159,7 +1188,7 @@ func (dcs *DoltChunkStore) PruneTableFiles(ctx context.Context) error {
 // and a list of only appendix table files
 func (dcs *DoltChunkStore) Sources(ctx context.Context) (chunks.TableFileSources, error) {
 	id, token := dcs.getRepoId()
-	req := &remotesapi.ListTableFilesRequest{RepoId: id, RepoPath: dcs.repoPath, RepoToken: token, ClientCapabilities: clientCapabilities}
+	req := &remotesapi.ListTableFilesRequest{RepoId: id, RepoPath: dcs.repoPath, RepoToken: token, ClientCapabilities: dcs.clientCapabilities}
 	resp, err := dcs.csClient.ListTableFiles(ctx, req)
 	if err != nil {
 		return chunks.TableFileSources{}, NewRpcError(err, "ListTableFiles", dcs.host, req)
@@ -1255,7 +1284,7 @@ func (drtf DoltRemoteTableFile) Open(ctx context.Context) (io.ReadCloser, uint64
 		// the client is authoritative for its own capability set
 		// and must stamp it at send time. See the ClientCapability
 		// enum comment in chunkstore.proto.
-		drtf.info.RefreshRequest.ClientCapabilities = clientCapabilities
+		drtf.info.RefreshRequest.ClientCapabilities = drtf.dcs.clientCapabilities
 		resp, err := drtf.dcs.csClient.RefreshTableFileUrl(ctx, drtf.info.RefreshRequest)
 		if err == nil {
 			drtf.info.Url = resp.Url

--- a/go/libraries/doltcore/remotestorage/chunk_store_test.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store_test.go
@@ -99,7 +99,8 @@ func TestDoltRemoteTableFile(t *testing.T) {
 							StatusCode: 200,
 						}, nil
 					}),
-					csClient: &csClient,
+					csClient:           &csClient,
+					clientCapabilities: defaultClientCapabilities,
 				},
 				info: &remotesapi.TableFileInfo{
 					Url:            "http://localhost/example_url/fileid",
@@ -117,7 +118,7 @@ func TestDoltRemoteTableFile(t *testing.T) {
 			// even though the echo arrived empty. See the
 			// ClientCapability enum comment in chunkstore.proto.
 			require.NotNil(t, csClient.lastIn)
-			require.Equal(t, clientCapabilities, csClient.lastIn.ClientCapabilities)
+			require.Equal(t, defaultClientCapabilities, csClient.lastIn.ClientCapabilities)
 		})
 		t.Run("404", func(t *testing.T) {
 			var buf bytes.Buffer
@@ -189,7 +190,8 @@ func TestLocationRefresh_StampsClientCapabilities(t *testing.T) {
 		// Empty ClientCapabilities mirrors a server that
 		// correctly leaves the field unset on the echoed
 		// RefreshRequest.
-		RefreshRequest: &remotesapi.RefreshTableFileUrlRequest{FileId: "file-id"},
+		RefreshRequest:     &remotesapi.RefreshTableFileUrlRequest{FileId: "file-id"},
+		clientCapabilities: defaultClientCapabilities,
 	}
 
 	url, err := r.GetURL(context.Background(), nil, &csClient)
@@ -197,7 +199,7 @@ func TestLocationRefresh_StampsClientCapabilities(t *testing.T) {
 	require.Equal(t, "http://example.com/refreshed", url)
 	require.True(t, csClient.called)
 	require.NotNil(t, csClient.lastIn)
-	require.Equal(t, clientCapabilities, csClient.lastIn.ClientCapabilities)
+	require.Equal(t, defaultClientCapabilities, csClient.lastIn.ClientCapabilities)
 }
 
 type fetcher func(*http.Request) (*http.Response, error)


### PR DESCRIPTION
In some contexts, and in particular in doltremoteapi, we want to still use the non-POP URLs for chunk fetches.