### PR TITLE
Preserve tables absent from the index during `checkout`, `reset`, and `rebase`

### DIFF
--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -164,7 +164,7 @@ func CreateCloneArgParser() *argparser.ArgParser {
 func CreateResetArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParserWithVariableArgs("reset")
 	ap.SupportsFlag(HardResetParam, "", "Resets the working tables and staged tables. Any changes to tracked tables in the working tree since {{.LessThan}}commit{{.GreaterThan}} are discarded.")
-	ap.SupportsFlag(SoftResetParam, "", "Does not touch the working tables, but removes all tables staged to be committed.")
+	ap.SupportsFlag(SoftResetParam, "", "Resets HEAD to the specified revision without touching the index or the working tables.")
 	return ap
 }
 

--- a/go/libraries/doltcore/env/actions/reset.go
+++ b/go/libraries/doltcore/env/actions/reset.go
@@ -63,32 +63,25 @@ func resetHardTables[C doltdb.Context](ctx C, dbData env.DbData[C], cSpecStr str
 		}
 	}
 
-	// Tables present only in the working root and absent from the index are left intact on reset --hard.
-	// Save the state of these tables and apply them to |newHead|'s root.
-	newWkRoot, err := RestoreUntrackedTables(ctx, roots.Working, roots.Staged, roots.Head)
+	newWorking, err := MoveUntrackedTables(ctx, roots.Working, roots.Staged, roots.Head)
 	if err != nil {
 		return nil, doltdb.Roots{}, err
 	}
-
-	roots.Working = newWkRoot
-	roots.Staged = roots.Head // the index root must match HEAD because RestoreUntrackedTables only updates the working root
-
-	return newHead, roots, nil
+	return newHead, doltdb.Roots{Head: roots.Head, Working: newWorking, Staged: roots.Head}, nil
 }
 
-// RestoreUntrackedTables copies tables that exist in |workingRoot| but not in |stagedRoot|
-// into |newRoot|. A table is absent from the index when it has never been added to |stagedRoot|.
-// Such tables are left intact across hard resets and rebases. Tables whose
-// column tags collide with a table already in |newRoot| are silently omitted to avoid schema
-// conflicts caused by table renames. Tables whose name already exists in |newRoot| are also
-// omitted to avoid overwriting tables added by the target commit.
-func RestoreUntrackedTables(ctx context.Context, workingRoot, stagedRoot, newRoot doltdb.RootValue) (doltdb.RootValue, error) {
-	untracked, err := doltdb.GetAllSchemas(ctx, workingRoot)
+// MoveUntrackedTables copies tables present in |sourceWorking| but absent from |sourceStaged|
+// onto |target|, returning the resulting root. Tables that name-collide with one already in
+// |target| are skipped so the target version wins. Tables whose column tags collide with one
+// in |target| are dropped silently.
+// TODO(elianddb): retag colliding columns instead of dropping the table.
+func MoveUntrackedTables(ctx context.Context, sourceWorking, sourceStaged, target doltdb.RootValue) (doltdb.RootValue, error) {
+	untracked, err := doltdb.GetAllSchemas(ctx, sourceWorking)
 	if err != nil {
 		return nil, err
 	}
 
-	staged, err := doltdb.GetAllSchemas(ctx, stagedRoot)
+	staged, err := doltdb.GetAllSchemas(ctx, sourceStaged)
 	if err != nil {
 		return nil, err
 	}
@@ -96,19 +89,20 @@ func RestoreUntrackedTables(ctx context.Context, workingRoot, stagedRoot, newRoo
 		delete(untracked, name)
 	}
 
-	schemas, err := doltdb.GetAllSchemas(ctx, newRoot)
+	targetSchemas, err := doltdb.GetAllSchemas(ctx, target)
 	if err != nil {
 		return nil, err
 	}
-	// Column tags are stable cross-rename identifiers. A tag collision means this table's
-	// schema conflicts with a renamed table already in |newRoot|, so we drop it silently.
-	// TODO(elianddb): instead of dropping the table, reassign fresh tags to its columns so
-	// it can coexist with the renamed table, preserving the user's data.
-	tags := mapColumnTags(schemas)
+	targetTags := make(map[uint64]struct{})
+	for _, sch := range targetSchemas {
+		for _, tag := range sch.GetAllCols().Tags {
+			targetTags[tag] = struct{}{}
+		}
+	}
 
 	for name, sch := range untracked {
 		for _, col := range sch.GetAllCols().GetColumns() {
-			if _, ok := tags[col.Tag]; ok {
+			if _, ok := targetTags[col.Tag]; ok {
 				delete(untracked, name)
 				break
 			}
@@ -116,26 +110,24 @@ func RestoreUntrackedTables(ctx context.Context, workingRoot, stagedRoot, newRoo
 	}
 
 	for name := range untracked {
-		// Skip tables whose name is already occupied in |newRoot|. The tag check above handles
-		// conflicting schemas, but a table with entirely different tags and the same name must
-		// also be left alone to avoid overwriting it silently.
-		if _, exists := schemas[name]; exists {
+		// Skip when target has a table of the same name so the target version wins.
+		if _, exists := targetSchemas[name]; exists {
 			continue
 		}
-		tbl, exists, err := workingRoot.GetTable(ctx, name)
+		tbl, exists, err := sourceWorking.GetTable(ctx, name)
 		if err != nil {
 			return nil, err
 		}
 		if !exists {
 			return nil, fmt.Errorf("untracked table %s does not exist in working set", name)
 		}
-		newRoot, err = newRoot.PutTable(ctx, name, tbl)
+		target, err = target.PutTable(ctx, name, tbl)
 		if err != nil {
 			return nil, fmt.Errorf("failed to write table back to database: %s", err)
 		}
 	}
 
-	return newRoot, nil
+	return target, nil
 }
 
 func GetAllTableNames(ctx context.Context, root doltdb.RootValue) []doltdb.TableName {
@@ -222,9 +214,10 @@ func ResetSoftTables(ctx context.Context, tableNames []doltdb.TableName, roots d
 	return roots, nil
 }
 
-// ResetSoftToRef matches the `git reset --soft <REF>` pattern. It returns a new Roots with the Staged and Head values
-// set to the commit specified by the spec string. The Working root is not set
-func ResetSoftToRef[C doltdb.Context](ctx C, dbData env.DbData[C], cSpecStr string) (doltdb.Roots, error) {
+// MoveHeadToRef resolves |cSpecStr| to a commit and moves the current branch HEAD to it. The
+// returned Roots has Head and Staged set to the resolved commit's root, available for callers
+// composing further reset semantics on top of the HEAD move.
+func MoveHeadToRef[C doltdb.Context](ctx C, dbData env.DbData[C], cSpecStr string) (doltdb.Roots, error) {
 	cs, err := doltdb.NewCommitSpec(cSpecStr)
 	if err != nil {
 		return doltdb.Roots{}, err
@@ -343,14 +336,3 @@ func CleanUntracked(ctx *sql.Context, roots doltdb.Roots, tables []string, dryru
 	return roots, nil
 }
 
-// mapColumnTags takes a map from table name to schema.Schema and generates
-// a map from column tags to table names (see RootValue.GetAllSchemas).
-func mapColumnTags(tables map[doltdb.TableName]schema.Schema) (m map[uint64]string) {
-	m = make(map[uint64]string, len(tables))
-	for tbl, sch := range tables {
-		for _, tag := range sch.GetAllCols().Tags {
-			m[tag] = tbl.Name
-		}
-	}
-	return
-}

--- a/go/libraries/doltcore/env/actions/reset.go
+++ b/go/libraries/doltcore/env/actions/reset.go
@@ -63,77 +63,79 @@ func resetHardTables[C doltdb.Context](ctx C, dbData env.DbData[C], cSpecStr str
 		}
 	}
 
-	// mirroring Git behavior, untracked tables are ignored on 'reset --hard',
-	// save the state of these tables and apply them to |newHead|'s root.
-	//
-	// as a special case, if an untracked table has a tag collision with any
-	// tables in |newHead| we silently drop it from the new working set.
-	// these tag collision is typically cause by table renames (bug #751).
-
-	untracked, err := doltdb.GetAllSchemas(ctx, roots.Working)
+	// Tables present only in the working root and absent from the index are left intact on reset --hard.
+	// Save the state of these tables and apply them to |newHead|'s root.
+	newWkRoot, err := RestoreUntrackedTables(ctx, roots.Working, roots.Staged, roots.Head)
 	if err != nil {
 		return nil, doltdb.Roots{}, err
 	}
 
-	// untracked tables exist in |working| but not in |staged|
-	staged := GetAllTableNames(ctx, roots.Staged)
-	for _, name := range staged {
+	roots.Working = newWkRoot
+	roots.Staged = roots.Head // the index root must match HEAD because RestoreUntrackedTables only updates the working root
+
+	return newHead, roots, nil
+}
+
+// RestoreUntrackedTables copies tables that exist in |workingRoot| but not in |stagedRoot|
+// into |newRoot|. A table is absent from the index when it has never been added to |stagedRoot|.
+// Such tables are left intact across hard resets and rebases. Tables whose
+// column tags collide with a table already in |newRoot| are silently omitted to avoid schema
+// conflicts caused by table renames. Tables whose name already exists in |newRoot| are also
+// omitted to avoid overwriting tables added by the target commit.
+func RestoreUntrackedTables(ctx context.Context, workingRoot, stagedRoot, newRoot doltdb.RootValue) (doltdb.RootValue, error) {
+	untracked, err := doltdb.GetAllSchemas(ctx, workingRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	staged, err := doltdb.GetAllSchemas(ctx, stagedRoot)
+	if err != nil {
+		return nil, err
+	}
+	for name := range staged {
 		delete(untracked, name)
 	}
 
-	newWkRoot := roots.Head
-
-	ws, err := doltdb.GetAllSchemas(ctx, newWkRoot)
+	schemas, err := doltdb.GetAllSchemas(ctx, newRoot)
 	if err != nil {
-		return nil, doltdb.Roots{}, err
+		return nil, err
 	}
-	tags := mapColumnTags(ws)
+	// Column tags are stable cross-rename identifiers. A tag collision means this table's
+	// schema conflicts with a renamed table already in |newRoot|, so we drop it silently.
+	// TODO(elianddb): instead of dropping the table, reassign fresh tags to its columns so
+	// it can coexist with the renamed table, preserving the user's data.
+	tags := mapColumnTags(schemas)
 
 	for name, sch := range untracked {
-		for _, pk := range sch.GetAllCols().GetColumns() {
-			if _, ok := tags[pk.Tag]; ok {
-				// |pk.Tag| collides with a schema in |newWkRoot|
+		for _, col := range sch.GetAllCols().GetColumns() {
+			if _, ok := tags[col.Tag]; ok {
 				delete(untracked, name)
+				break
 			}
 		}
 	}
 
 	for name := range untracked {
-		tbl, exists, err := roots.Working.GetTable(ctx, name)
+		// Skip tables whose name is already occupied in |newRoot|. The tag check above handles
+		// conflicting schemas, but a table with entirely different tags and the same name must
+		// also be left alone to avoid overwriting it silently.
+		if _, exists := schemas[name]; exists {
+			continue
+		}
+		tbl, exists, err := workingRoot.GetTable(ctx, name)
 		if err != nil {
-			return nil, doltdb.Roots{}, err
+			return nil, err
 		}
 		if !exists {
-			return nil, doltdb.Roots{}, fmt.Errorf("untracked table %s does not exist in working set", name)
+			return nil, fmt.Errorf("untracked table %s does not exist in working set", name)
 		}
-
-		newWkRoot, err = newWkRoot.PutTable(ctx, name, tbl)
+		newRoot, err = newRoot.PutTable(ctx, name, tbl)
 		if err != nil {
-			return nil, doltdb.Roots{}, fmt.Errorf("failed to write table back to database: %s", err)
+			return nil, fmt.Errorf("failed to write table back to database: %s", err)
 		}
 	}
 
-	// need to save the state of files that aren't tracked
-	untrackedTables := make(map[doltdb.TableName]*doltdb.Table)
-	wTblNames := GetAllTableNames(ctx, roots.Working)
-
-	for _, tblName := range wTblNames {
-		untrackedTables[tblName], _, err = roots.Working.GetTable(ctx, tblName)
-
-		if err != nil {
-			return nil, doltdb.Roots{}, err
-		}
-	}
-
-	headTblNames := GetAllTableNames(ctx, roots.Staged)
-	for _, tblName := range headTblNames {
-		delete(untrackedTables, tblName)
-	}
-
-	roots.Working = newWkRoot
-	roots.Staged = roots.Head
-
-	return newHead, roots, nil
+	return newRoot, nil
 }
 
 func GetAllTableNames(ctx context.Context, root doltdb.RootValue) []doltdb.TableName {

--- a/go/libraries/doltcore/env/actions/reset.go
+++ b/go/libraries/doltcore/env/actions/reset.go
@@ -335,4 +335,3 @@ func CleanUntracked(ctx *sql.Context, roots doltdb.Roots, tables []string, dryru
 	roots.Working = newRoot
 	return roots, nil
 }
-

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_checkout.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_checkout.go
@@ -673,7 +673,9 @@ func checkoutTablesFromCommit(
 
 	var tableNames []doltdb.TableName
 	if len(tables) == 1 && tables[0] == "." {
-		tableNames, err = doltdb.UnionTableNames(ctx, ws.WorkingRoot())
+		// Only include tables present in HEAD or the index. Tables that exist only
+		// in the working set are left untouched.
+		tableNames, err = doltdb.UnionTableNames(ctx, headRoot, ws.StagedRoot())
 		if err != nil {
 			return err
 		}
@@ -686,19 +688,25 @@ func checkoutTablesFromCommit(
 				return err
 			}
 			if !tableExistsInHead {
-				return fmt.Errorf("tablespec '%s' did not match any table(s) known to dolt", table) // commitref not mentioned in git
+				return fmt.Errorf("tablespec '%s' did not match any table(s) known to dolt", table)
 			}
 			tableNames[i] = name
 		}
 	}
 
-	newRoot, err := actions.MoveTablesBetweenRoots(ctx, tableNames, headRoot, ws.WorkingRoot())
+	// Apply the table change to working and staged roots independently so that tables
+	// which exist only in the working root (absent from the index) are not added to the index.
+	newWorkingRoot, err := actions.MoveTablesBetweenRoots(ctx, tableNames, headRoot, ws.WorkingRoot())
+	if err != nil {
+		return err
+	}
+	newStagedRoot, err := actions.MoveTablesBetweenRoots(ctx, tableNames, headRoot, ws.StagedRoot())
 	if err != nil {
 		return err
 	}
 
 	dsess.WaitForReplicationController(ctx, *rsc)
-	return dSess.SetWorkingSet(ctx, databaseName, ws.WithStagedRoot(newRoot).WithWorkingRoot(newRoot))
+	return dSess.SetWorkingSet(ctx, databaseName, ws.WithWorkingRoot(newWorkingRoot).WithStagedRoot(newStagedRoot))
 }
 
 // doGlobalCheckout implements the behavior of the `dolt checkout` command line, moving the working set into
@@ -713,15 +721,17 @@ func doGlobalCheckout(ctx *sql.Context, branchName string, isForce bool, isNewBr
 }
 
 // checkoutTablesFromHead checks out the tables named from the current head and overwrites those tables in the
-// working root. The working root is then set as the new staged root. Necessary since tables may exist outside
-// of HEAD commit
+// working root. The working root is then set as the new staged root so that the checked-out tables are not
+// shown as pending staged changes. This is necessary because tables may exist outside of the HEAD commit.
 func checkoutTablesFromHead(ctx *sql.Context, roots doltdb.Roots, name string, tables []string) error {
 	var tableNames []doltdb.TableName
 	var warningMsg strings.Builder
 	var err error
 
 	if len(tables) == 1 && tables[0] == "." {
-		tableNames, err = doltdb.UnionTableNames(ctx, roots.Working)
+		// Only include tables present in HEAD or the index. Tables that exist only
+		// in the working set are left untouched.
+		tableNames, err = doltdb.UnionTableNames(ctx, roots.Head, roots.Staged)
 		if err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_rebase.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_rebase.go
@@ -770,8 +770,8 @@ func continueRebase(ctx *sql.Context) rebaseResult {
 		return newRebaseError(err)
 	}
 
-	// Save the working/staged roots of the branch being rebased before copyABranch overwrites them.
-	// Tables that exist only in the working set and are absent from the index must be restored afterward.
+	// Save the rebase branch's pre-copy roots so tables present only in Working can be restored
+	// after copyABranch overwrites it with the onto state.
 	rebaseBranchWSRef, err := ref.WorkingSetRefForHead(ref.NewBranchRef(rebaseBranch))
 	if err != nil {
 		return newRebaseError(err)
@@ -794,6 +794,28 @@ func continueRebase(ctx *sql.Context) rebaseResult {
 		return newRebaseError(err)
 	}
 
+	// Apply the working-set-only restoration to the rebase branch in doltdb before switching the
+	// session to it. This keeps the rebase transaction shape intact and avoids a session-level
+	// SetWorkingSet after StartTransaction.
+	postCopyWS, err := dbData.Ddb.ResolveWorkingSet(ctx, rebaseBranchWSRef)
+	if err != nil {
+		return newRebaseError(err)
+	}
+	postCopyHash, err := postCopyWS.HashOf()
+	if err != nil {
+		return newRebaseError(err)
+	}
+	restoredWorking, err := actions.MoveUntrackedTables(ctx, preRebaseWorkingRoot, preRebaseStagedRoot, postCopyWS.WorkingRoot())
+	if err != nil {
+		return newRebaseError(err)
+	}
+	err = dbData.Ddb.UpdateWorkingSet(ctx, rebaseBranchWSRef,
+		postCopyWS.WithWorkingRoot(restoredWorking),
+		postCopyHash, doltdb.TodoWorkingSetMeta(), nil)
+	if err != nil {
+		return newRebaseError(err)
+	}
+
 	// Checkout the branch being rebased
 	err = doltSession.SwitchWorkingSet(ctx, ctx.GetCurrentDatabase(), rebaseBranchWSRef)
 	if err != nil {
@@ -801,23 +823,7 @@ func continueRebase(ctx *sql.Context) rebaseResult {
 	}
 
 	// Start a new transaction so the session will see the changes to the branch pointer.
-	// StartTransaction clears in-memory session state, so restoration of working-root-only tables
-	// must happen after this point.
 	if _, err = doltSession.StartTransaction(ctx, sql.ReadWrite); err != nil {
-		return newRebaseError(err)
-	}
-
-	// Restore tables that existed only in the working set before the rebase overwrote it.
-	finalWS, err := doltSession.WorkingSet(ctx, ctx.GetCurrentDatabase())
-	if err != nil {
-		return newRebaseError(err)
-	}
-	restoredRoot, err := actions.RestoreUntrackedTables(ctx, preRebaseWorkingRoot, preRebaseStagedRoot, finalWS.WorkingRoot())
-	if err != nil {
-		return newRebaseError(err)
-	}
-	err = doltSession.SetWorkingSet(ctx, ctx.GetCurrentDatabase(), finalWS.WithWorkingRoot(restoredRoot))
-	if err != nil {
 		return newRebaseError(err)
 	}
 

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_rebase.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_rebase.go
@@ -770,6 +770,19 @@ func continueRebase(ctx *sql.Context) rebaseResult {
 		return newRebaseError(err)
 	}
 
+	// Save the working/staged roots of the branch being rebased before copyABranch overwrites them.
+	// Tables that exist only in the working set and are absent from the index must be restored afterward.
+	rebaseBranchWSRef, err := ref.WorkingSetRefForHead(ref.NewBranchRef(rebaseBranch))
+	if err != nil {
+		return newRebaseError(err)
+	}
+	preRebaseWS, err := dbData.Ddb.ResolveWorkingSet(ctx, rebaseBranchWSRef)
+	if err != nil {
+		return newRebaseError(err)
+	}
+	preRebaseWorkingRoot := preRebaseWS.WorkingRoot()
+	preRebaseStagedRoot := preRebaseWS.StagedRoot()
+
 	// TODO: copyABranch (and the underlying call to doltdb.NewBranchAtCommit) has a race condition
 	//       where another session can set the branch head AFTER doltdb.NewBranchAtCommit updates
 	//       the branch head, but BEFORE doltdb.NewBranchAtCommit retrieves the working set for the
@@ -782,17 +795,29 @@ func continueRebase(ctx *sql.Context) rebaseResult {
 	}
 
 	// Checkout the branch being rebased
-	previousBranchWorkingSetRef, err := ref.WorkingSetRefForHead(ref.NewBranchRef(rebaseBranchWorkingSet.RebaseState().Branch()))
-	if err != nil {
-		return newRebaseError(err)
-	}
-	err = doltSession.SwitchWorkingSet(ctx, ctx.GetCurrentDatabase(), previousBranchWorkingSetRef)
+	err = doltSession.SwitchWorkingSet(ctx, ctx.GetCurrentDatabase(), rebaseBranchWSRef)
 	if err != nil {
 		return newRebaseError(err)
 	}
 
-	// Start a new transaction so the session will see the changes to the branch pointer
+	// Start a new transaction so the session will see the changes to the branch pointer.
+	// StartTransaction clears in-memory session state, so restoration of working-root-only tables
+	// must happen after this point.
 	if _, err = doltSession.StartTransaction(ctx, sql.ReadWrite); err != nil {
+		return newRebaseError(err)
+	}
+
+	// Restore tables that existed only in the working set before the rebase overwrote it.
+	finalWS, err := doltSession.WorkingSet(ctx, ctx.GetCurrentDatabase())
+	if err != nil {
+		return newRebaseError(err)
+	}
+	restoredRoot, err := actions.RestoreUntrackedTables(ctx, preRebaseWorkingRoot, preRebaseStagedRoot, finalWS.WorkingRoot())
+	if err != nil {
+		return newRebaseError(err)
+	}
+	err = doltSession.SetWorkingSet(ctx, ctx.GetCurrentDatabase(), finalWS.WithWorkingRoot(restoredRoot))
+	if err != nil {
 		return newRebaseError(err)
 	}
 

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_reset.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_reset.go
@@ -111,7 +111,7 @@ func doDoltReset(ctx *sql.Context, args []string) (int, error) {
 					return 1, err
 				}
 			} else {
-				err := resetSoftToRef(ctx, dbData, apr.Arg(0), dSess, dbName)
+				err := resetMixedToRef(ctx, dbData, apr.Arg(0), dSess, dbName)
 				if err != nil {
 					return 1, err
 				}
@@ -126,15 +126,16 @@ func doDoltReset(ctx *sql.Context, args []string) (int, error) {
 	return 0, nil
 }
 
-// resetSoftToRef resets the session HEAD to the commit ref given
-func resetSoftToRef(
+// resetMixedToRef implements git reset with no flag (default --mixed): moves the current branch
+// HEAD to |firstArg| and resets the index to that commit, leaving the working tree alone.
+func resetMixedToRef(
 	ctx *sql.Context,
 	dbData env.DbData[*sql.Context],
 	firstArg string,
 	dSess *dsess.DoltSession,
 	dbName string,
 ) error {
-	roots, err := actions.ResetSoftToRef(ctx, dbData, firstArg)
+	roots, err := actions.MoveHeadToRef(ctx, dbData, firstArg)
 	if err != nil {
 		return err
 	}
@@ -215,7 +216,8 @@ func resetSoft(
 
 	// If ref is "" that means HEAD, which makes reset --soft a no-op
 	if arg != "" {
-		roots, err := actions.ResetSoftToRef(ctx, dbData, arg)
+		// MoveHeadToRef returns Roots usable for --mixed. The --soft path ignores them per https://git-scm.com/docs/git-reset.
+		_, err := actions.MoveHeadToRef(ctx, dbData, arg)
 		if err != nil {
 			return err
 		}
@@ -223,7 +225,7 @@ func resetSoft(
 		if err != nil {
 			return err
 		}
-		err = dSess.SetWorkingSet(ctx, dbName, ws.WithStagedRoot(roots.Staged).ClearMerge().ClearRebase())
+		err = dSess.SetWorkingSet(ctx, dbName, ws.ClearMerge().ClearRebase())
 		if err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -3902,6 +3902,90 @@ var DoltCheckoutScripts = []queries.ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "dolt_checkout('.') preserves untracked tables",
+		SetUpScript: []string{
+			"create table tracked (pk int primary key);",
+			"call dolt_commit('-Am', 'add tracked');",
+			"insert into tracked values (1);",
+			"create table untracked (pk int primary key);",
+			"insert into untracked values (9);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "call dolt_checkout('.');",
+				Expected: []sql.Row{{0, ""}},
+			},
+			{
+				Query:    "select * from tracked;",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "select * from untracked;",
+				Expected: []sql.Row{{9}},
+			},
+		},
+	},
+	{
+		Name: "dolt_checkout('.') preserves ignored tables",
+		SetUpScript: []string{
+			"insert into dolt_ignore values ('private_*', true);",
+			"call dolt_commit('-Am', 'commit ignore rule');",
+			"create table mytable (pk int primary key, val int);",
+			"insert into mytable values (1, 10);",
+			"call dolt_commit('-Am', 'add mytable');",
+			"create table private_data (pk int primary key, secret varchar(100));",
+			"insert into private_data values (1, 'secret');",
+			"insert into mytable values (2, 20);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "call dolt_checkout('.');",
+				Expected: []sql.Row{{0, ""}},
+			},
+			{
+				Query:    "select pk, secret from private_data;",
+				Expected: []sql.Row{{1, "secret"}},
+			},
+			{
+				Query:    "select * from mytable;",
+				Expected: []sql.Row{{1, 10}},
+			},
+		},
+	},
+	{
+		Name: "dolt_checkout('HEAD', table) does not stage other ignored tables",
+		SetUpScript: []string{
+			"insert into dolt_ignore values ('private_*', true);",
+			"call dolt_commit('-Am', 'commit ignore rule');",
+			"create table mytable (pk int primary key, val int);",
+			"insert into mytable values (1, 10);",
+			"call dolt_commit('-Am', 'add mytable');",
+			"create table private_data (pk int primary key, secret varchar(100));",
+			"insert into private_data values (1, 'secret');",
+			"update mytable set val = 99 where pk = 1;",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "call dolt_checkout('HEAD', 'mytable');",
+				Expected: []sql.Row{{0, ""}},
+			},
+			{
+				Query:    "select * from mytable;",
+				Expected: []sql.Row{{1, 10}},
+			},
+			{
+				Query: "select staged from dolt_status where table_name = 'private_data';",
+				// Empty result confirms private_data was not staged as a side effect of the
+				// checkout that named only mytable.
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "select pk, secret from private_data;",
+				Expected: []sql.Row{{1, "secret"}},
+			},
+		},
+	},
 }
 
 var DoltCheckoutReadOnlyScripts = []queries.ScriptTest{
@@ -4464,9 +4548,10 @@ var DoltResetTestScripts = []queries.ScriptTest{
 				Expected: []sql.Row{{0}},
 			},
 			{
-				// dolt_status should only show the unstaged table t being added
-				Query:    "select * from dolt_status",
-				Expected: []sql.Row{{"t", byte(0), "new table"}},
+				Query: "select * from dolt_status",
+				// The index is left untouched by --soft, so table t is still staged against the
+				// new HEAD which no longer contains it. See https://git-scm.com/docs/git-reset.
+				Expected: []sql.Row{{"t", byte(1), "new table"}},
 			},
 		},
 	},
@@ -4490,6 +4575,96 @@ var DoltResetTestScripts = []queries.ScriptTest{
 				// dolt_status should only show the unstaged table t being added
 				Query:    "select * from dolt_status",
 				Expected: []sql.Row{{"t", byte(0), "new table"}},
+			},
+		},
+	},
+	{
+		// See https://git-scm.com/docs/git-reset
+		Name: "dolt_reset(rev) moves HEAD, resets the index, and leaves the working tree alone",
+		SetUpScript: []string{
+			"CREATE TABLE t (pk int PRIMARY KEY, v int);",
+			"INSERT INTO t VALUES (1, 10);",
+			"call dolt_commit('-Am', 'c1');",
+			"INSERT INTO t VALUES (2, 20);",
+			"call dolt_commit('-am', 'c2');",
+			"INSERT INTO t VALUES (3, 30);",
+			"call dolt_add('.');",
+			"INSERT INTO t VALUES (4, 40);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "call dolt_reset('HEAD~');",
+				Expected: []sql.Row{{0}},
+			},
+			{
+				Query: "SELECT pk, v FROM t AS OF STAGED ORDER BY pk",
+				// Index resets to the new HEAD which only has pk=1.
+				Expected: []sql.Row{{1, 10}},
+			},
+			{
+				Query: "SELECT pk, v FROM t ORDER BY pk",
+				// Working tree is preserved across the reset, including the staged pk=3 and
+				// the unstaged pk=4 from before the reset.
+				Expected: []sql.Row{{1, 10}, {2, 20}, {3, 30}, {4, 40}},
+			},
+		},
+	},
+	{
+		// See https://git-scm.com/docs/git-reset
+		Name: "dolt_reset('--soft', rev) leaves staged tables untouched",
+		SetUpScript: []string{
+			"CREATE TABLE t (pk int PRIMARY KEY, v int);",
+			"INSERT INTO t VALUES (1, 10);",
+			"call dolt_commit('-Am', 'c1');",
+			"INSERT INTO t VALUES (2, 20);",
+			"call dolt_commit('-am', 'c2');",
+			"INSERT INTO t VALUES (3, 30);",
+			"call dolt_add('.');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "call dolt_reset('--soft', 'HEAD~');",
+				Expected: []sql.Row{{0}},
+			},
+			{
+				Query:    "SELECT pk FROM t AS OF STAGED ORDER BY pk",
+				Expected: []sql.Row{{1}, {2}, {3}},
+			},
+			{
+				Query:    "SELECT pk FROM t ORDER BY pk",
+				Expected: []sql.Row{{1}, {2}, {3}},
+			},
+			{
+				Query: "SELECT * FROM dolt_status",
+				// The byte indicates whether the table is staged (1) or unstaged (0).
+				Expected: []sql.Row{{"t", byte(1), "modified"}},
+			},
+		},
+	},
+	{
+		Name: "dolt_reset('--hard') preserves ignored tables when ignore rule is committed",
+		SetUpScript: []string{
+			"insert into dolt_ignore values ('private_data', true);",
+			"call dolt_commit('-Am', 'add ignore rule');",
+			"create table mytable (pk int primary key, val int);",
+			"insert into mytable values (1, 10);",
+			"call dolt_commit('-Am', 'add mytable');",
+			"create table private_data (pk int primary key, secret varchar(100));",
+			"insert into private_data values (1, 'secret');",
+			"insert into mytable values (2, 20);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "call dolt_reset('--hard');",
+				Expected: []sql.Row{{0}},
+			},
+			{
+				Query:    "select pk, secret from private_data;",
+				Expected: []sql.Row{{1, "secret"}},
+			},
+			{
+				Query:    "select * from mytable;",
+				Expected: []sql.Row{{1, 10}},
 			},
 		},
 	},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_rebase.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_rebase.go
@@ -2059,6 +2059,35 @@ commit
 			},
 		},
 	},
+	{
+		Name: "dolt_rebase('--continue') preserves ignored tables in the working set",
+		SetUpScript: []string{
+			"CREATE TABLE t (pk int PRIMARY KEY)",
+			"CALL dolt_commit('-Am', 'create t')",
+			"INSERT INTO dolt_ignore VALUES ('private_data', true)",
+			"CALL dolt_commit('-Am', 'add ignore rule')",
+			"INSERT INTO t VALUES (1)",
+			"CALL dolt_commit('-am', 'insert 1')",
+			"INSERT INTO t VALUES (2)",
+			"CALL dolt_commit('-am', 'insert 2')",
+			"CREATE TABLE private_data (pk int PRIMARY KEY, secret varchar(100))",
+			"INSERT INTO private_data VALUES (1, 'secret')",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "CALL dolt_rebase('-i', 'HEAD~2')",
+				Expected: []sql.Row{{0, "interactive rebase started on branch dolt_rebase_main; adjust the rebase plan in the dolt_rebase table, then continue rebasing by calling dolt_rebase('--continue')"}},
+			},
+			{
+				Query:    "CALL dolt_rebase('--continue')",
+				Expected: []sql.Row{{0, "Successfully rebased and updated refs/heads/main"}},
+			},
+			{
+				Query:    "select pk, secret from private_data",
+				Expected: []sql.Row{{1, "secret"}},
+			},
+		},
+	},
 }
 
 var DoltRebaseMultiSessionScriptTests = []queries.ScriptTest{

--- a/integration-tests/bats/checkout.bats
+++ b/integration-tests/bats/checkout.bats
@@ -1462,41 +1462,13 @@ SQL
     run dolt checkout .
     [ "$status" -eq 0 ]
 
-    run dolt sql -q "SELECT count(*) FROM normal_tbl" -r csv
+    run dolt sql -q "SELECT pk FROM normal_tbl" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "0" ]] || false
+    [[ ! "$output" =~ "99" ]] || false
 
-    run dolt sql -q "SHOW TABLES" -r csv
+    run dolt sql -q "SELECT pk, val FROM ignored_tbl" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "ignored_tbl" ]] || false
-
-    run dolt sql -q "SELECT count(*) FROM ignored_tbl" -r csv
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ "1" ]] || false
-}
-
-@test "checkout: dolt checkout . preserves tables matched by a wildcard ignore pattern" {
-    dolt sql -q "INSERT INTO dolt_ignore VALUES ('tmp_%', true)"
-    dolt add dolt_ignore
-    dolt commit -m "wildcard ignore rule"
-
-    dolt sql -q "CREATE TABLE normal_tbl (pk int PRIMARY KEY)"
-    dolt add normal_tbl
-    dolt commit -m "add normal_tbl"
-
-    # Create a table whose name matches the wildcard. It is never committed.
-    dolt sql -q "CREATE TABLE tmp_scratch (pk int PRIMARY KEY, val int)"
-    dolt sql -q "INSERT INTO tmp_scratch VALUES (1, 42)"
-
-    dolt sql -q "INSERT INTO normal_tbl VALUES (99)"
-
-    run dolt checkout .
-    [ "$status" -eq 0 ]
-
-    # Wildcard patterns protect tables the same as exact matches.
-    run dolt sql -q "SELECT count(*) FROM tmp_scratch" -r csv
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ "1" ]] || false
+    [[ "$output" =~ "1,100" ]] || false
 }
 
 @test "checkout: dolt checkout . preserves untracked tables" {
@@ -1514,12 +1486,11 @@ SQL
     run dolt checkout .
     [ "$status" -eq 0 ]
 
-    run dolt sql -q "SELECT count(*) FROM normal_tbl" -r csv
+    run dolt sql -q "SELECT pk FROM normal_tbl" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "0" ]] || false
+    [[ ! "$output" =~ "99" ]] || false
 
-    # checkout . only resets tables present in the index or HEAD.
-    run dolt sql -q "SELECT count(*) FROM untracked_tbl" -r csv
+    run dolt sql -q "SELECT pk, val FROM untracked_tbl" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "1" ]] || false
+    [[ "$output" =~ "1,42" ]] || false
 }

--- a/integration-tests/bats/checkout.bats
+++ b/integration-tests/bats/checkout.bats
@@ -1413,3 +1413,113 @@ SQL
     [ "$status" -eq 0 ]
 }
 
+@test "checkout: dolt checkout HEAD <table> leaves ignored tables unstaged" {
+    # Commit the ignore rule first so it is in effect
+    dolt sql -q "INSERT INTO dolt_ignore VALUES ('private_data', true)"
+    dolt add dolt_ignore
+    dolt commit -m "add ignore rule for private_data"
+
+    dolt sql -q "CREATE TABLE mytable (pk int PRIMARY KEY, val int)"
+    dolt sql -q "INSERT INTO mytable VALUES (1, 10)"
+    dolt add mytable
+    dolt commit -m "add mytable"
+
+    # Create private_data only in the working tree, never committed
+    dolt sql -q "CREATE TABLE private_data (pk int PRIMARY KEY, secret varchar(100))"
+    dolt sql -q "INSERT INTO private_data VALUES (1, 'secret')"
+
+    # Modify mytable so checkout HEAD -- mytable has something to restore
+    dolt sql -q "INSERT INTO mytable VALUES (2, 20)"
+
+    run dolt checkout HEAD -- mytable
+    [ "$status" -eq 0 ]
+
+    # dolt_status is queried directly because dolt status hides ignored tables
+    # regardless of whether they are in the index, so the CLI output cannot detect index state.
+    run dolt sql -q "SELECT table_name FROM dolt_status WHERE table_name = 'private_data'" -r csv
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "private_data" ]] || false
+}
+
+@test "checkout: dolt checkout . preserves ignored tables" {
+    # Commit the ignore rule so it is in effect
+    dolt sql -q "INSERT INTO dolt_ignore VALUES ('ignored_tbl', true)"
+    dolt add dolt_ignore
+    dolt commit -m "add ignore rule"
+
+    # Create a normal table and commit it so there is a HEAD to restore to
+    dolt sql -q "CREATE TABLE normal_tbl (pk int PRIMARY KEY)"
+    dolt add normal_tbl
+    dolt commit -m "add normal table"
+
+    # Create the ignored table in the working tree. It is never committed.
+    dolt sql -q "CREATE TABLE ignored_tbl (pk int PRIMARY KEY, val int)"
+    dolt sql -q "INSERT INTO ignored_tbl VALUES (1, 100)"
+
+    # Make a working-tree change to the normal table so checkout . has work to do
+    dolt sql -q "INSERT INTO normal_tbl VALUES (99)"
+
+    run dolt checkout .
+    [ "$status" -eq 0 ]
+
+    run dolt sql -q "SELECT count(*) FROM normal_tbl" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "0" ]] || false
+
+    run dolt sql -q "SHOW TABLES" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "ignored_tbl" ]] || false
+
+    run dolt sql -q "SELECT count(*) FROM ignored_tbl" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "1" ]] || false
+}
+
+@test "checkout: dolt checkout . preserves tables matched by a wildcard ignore pattern" {
+    dolt sql -q "INSERT INTO dolt_ignore VALUES ('tmp_%', true)"
+    dolt add dolt_ignore
+    dolt commit -m "wildcard ignore rule"
+
+    dolt sql -q "CREATE TABLE normal_tbl (pk int PRIMARY KEY)"
+    dolt add normal_tbl
+    dolt commit -m "add normal_tbl"
+
+    # Create a table whose name matches the wildcard. It is never committed.
+    dolt sql -q "CREATE TABLE tmp_scratch (pk int PRIMARY KEY, val int)"
+    dolt sql -q "INSERT INTO tmp_scratch VALUES (1, 42)"
+
+    dolt sql -q "INSERT INTO normal_tbl VALUES (99)"
+
+    run dolt checkout .
+    [ "$status" -eq 0 ]
+
+    # Wildcard patterns protect tables the same as exact matches.
+    run dolt sql -q "SELECT count(*) FROM tmp_scratch" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "1" ]] || false
+}
+
+@test "checkout: dolt checkout . preserves untracked tables" {
+    dolt sql -q "CREATE TABLE normal_tbl (pk int PRIMARY KEY)"
+    dolt add normal_tbl
+    dolt commit -m "add normal_tbl"
+
+    # Create a table that has never been added to the index or committed
+    dolt sql -q "CREATE TABLE untracked_tbl (pk int PRIMARY KEY, val int)"
+    dolt sql -q "INSERT INTO untracked_tbl VALUES (1, 42)"
+
+    # Dirty normal_tbl so checkout . has something to restore
+    dolt sql -q "INSERT INTO normal_tbl VALUES (99)"
+
+    run dolt checkout .
+    [ "$status" -eq 0 ]
+
+    run dolt sql -q "SELECT count(*) FROM normal_tbl" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "0" ]] || false
+
+    # checkout . only resets tables present in the index or HEAD.
+    run dolt sql -q "SELECT count(*) FROM untracked_tbl" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "1" ]] || false
+}

--- a/integration-tests/bats/rebase.bats
+++ b/integration-tests/bats/rebase.bats
@@ -769,3 +769,27 @@ message"
     [ "$status" -ne 0 ]
     [[ "$output" =~ "unknown action in rebase plan: invalid" ]] || false
 }
+
+@test "rebase: dolt rebase preserves ignored tables in the working set" {
+    # Commit the ignore rule on main so private_data is invisible to status
+    dolt sql -q "INSERT INTO dolt_ignore VALUES ('private_data', true)"
+    dolt add dolt_ignore
+    dolt commit -m "add ignore rule for private_data"
+
+    # Create private_data only in the working tree, never committed
+    dolt sql -q "CREATE TABLE private_data (pk int PRIMARY KEY, secret varchar(100))"
+    dolt sql -q "INSERT INTO private_data VALUES (1, 'secret')"
+
+    # Confirm private_data is invisible to status and rebase will not reject a dirty working tree.
+    # Rebase rejects uncommitted non-ignored changes, so this verifies the ignore rule is active.
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "private_data" ]] || false
+
+    run dolt rebase b1
+    [ "$status" -eq 0 ]
+
+    run dolt sql -q "SELECT count(*) FROM private_data" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "1" ]] || false
+}

--- a/integration-tests/bats/rebase.bats
+++ b/integration-tests/bats/rebase.bats
@@ -789,7 +789,7 @@ message"
     run dolt rebase b1
     [ "$status" -eq 0 ]
 
-    run dolt sql -q "SELECT count(*) FROM private_data" -r csv
+    run dolt sql -q "SELECT pk, secret FROM private_data" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "1" ]] || false
+    [[ "$output" =~ "1,secret" ]] || false
 }

--- a/integration-tests/bats/reset.bats
+++ b/integration-tests/bats/reset.bats
@@ -360,9 +360,78 @@ SQL
     run dolt reset --hard
     [ "$status" -eq 0 ]
 
-    # private_data must still exist. It was never committed and reset --hard
-    # must not delete working-tree tables that were never added to the index.
-    run dolt sql -q "SELECT count(*) FROM private_data" -r csv
+    run dolt sql -q "SELECT pk, secret FROM private_data" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "1" ]] || false
+    [[ "$output" =~ "1,secret" ]] || false
+
+    run dolt sql -q "SELECT pk, val FROM mytable ORDER BY pk" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "1,10" ]] || false
+    [[ ! "$output" =~ "2,20" ]] || false
+}
+
+@test "reset: --soft <rev> moves HEAD only and leaves staged tables untouched" {
+    # See https://git-scm.com/docs/git-reset
+    dolt sql -q "CREATE TABLE t (pk int PRIMARY KEY, v int);"
+    dolt sql -q "INSERT INTO t VALUES (1, 10);"
+    dolt add .
+    dolt commit -m "c1"
+
+    dolt sql -q "INSERT INTO t VALUES (2, 20);"
+    dolt add .
+    dolt commit -m "c2"
+
+    dolt sql -q "INSERT INTO t VALUES (3, 30);"
+    dolt add .
+
+    run dolt reset --soft HEAD~
+    [ "$status" -eq 0 ]
+
+    run dolt sql -q "SELECT pk, v FROM t AS OF STAGED ORDER BY pk" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "1,10" ]] || false
+    [[ "$output" =~ "2,20" ]] || false
+    [[ "$output" =~ "3,30" ]] || false
+
+    run dolt sql -q "SELECT pk, v FROM t ORDER BY pk" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "1,10" ]] || false
+    [[ "$output" =~ "2,20" ]] || false
+    [[ "$output" =~ "3,30" ]] || false
+
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Changes to be committed:" ]] || false
+}
+
+@test "reset: <rev> moves HEAD, resets the index, and leaves the working tree alone" {
+    # See https://git-scm.com/docs/git-reset
+    dolt sql -q "CREATE TABLE t (pk int PRIMARY KEY, v int);"
+    dolt sql -q "INSERT INTO t VALUES (1, 10);"
+    dolt add .
+    dolt commit -m "c1"
+
+    dolt sql -q "INSERT INTO t VALUES (2, 20);"
+    dolt add .
+    dolt commit -m "c2"
+
+    dolt sql -q "INSERT INTO t VALUES (3, 30);"
+    dolt add .
+    dolt sql -q "INSERT INTO t VALUES (4, 40);"
+
+    run dolt reset HEAD~
+    [ "$status" -eq 0 ]
+
+    run dolt sql -q "SELECT pk, v FROM t AS OF STAGED ORDER BY pk" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "1,10" ]] || false
+    [[ ! "$output" =~ "2,20" ]] || false
+    [[ ! "$output" =~ "3,30" ]] || false
+
+    run dolt sql -q "SELECT pk, v FROM t ORDER BY pk" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "1,10" ]] || false
+    [[ "$output" =~ "2,20" ]] || false
+    [[ "$output" =~ "3,30" ]] || false
+    [[ "$output" =~ "4,40" ]] || false
 }

--- a/integration-tests/bats/reset.bats
+++ b/integration-tests/bats/reset.bats
@@ -338,3 +338,31 @@ SQL
     [ "$status" -eq 0 ]
     [[ "$output" =~ "9" ]] || false
 }
+
+@test "reset: dolt reset --hard preserves ignored tables when the ignore rule is committed" {
+    # Commit the ignore rule so it is tracked in HEAD
+    dolt sql -q "INSERT INTO dolt_ignore VALUES ('private_data', true)"
+    dolt add dolt_ignore
+    dolt commit -m "add ignore rule for private_data"
+
+    dolt sql -q "CREATE TABLE mytable (pk int PRIMARY KEY, val int)"
+    dolt sql -q "INSERT INTO mytable VALUES (1, 10)"
+    dolt add mytable
+    dolt commit -m "add mytable"
+
+    # Create private_data only in the working tree, never added to the index or committed
+    dolt sql -q "CREATE TABLE private_data (pk int PRIMARY KEY, secret varchar(100))"
+    dolt sql -q "INSERT INTO private_data VALUES (1, 'secret')"
+
+    # Make a working-tree change so there is something for reset --hard to discard
+    dolt sql -q "INSERT INTO mytable VALUES (2, 20)"
+
+    run dolt reset --hard
+    [ "$status" -eq 0 ]
+
+    # private_data must still exist. It was never committed and reset --hard
+    # must not delete working-tree tables that were never added to the index.
+    run dolt sql -q "SELECT count(*) FROM private_data" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "1" ]] || false
+}


### PR DESCRIPTION
Tables present only in the working tree (never added to staging) were being deleted or incorrectly staged by the three commands.
- Scope `checkout .` table list to HEAD and staged root
- Update working and staged roots independently in the specific-table checkout case
- Add `MoveUntrackedTables` helper for the working-tree preservation step in reset `--hard` and
  rebase
- Apply rebase preservation via direct `UpdateWorkingSet` before `SwitchWorkingSet`
- Fix `dolt reset --soft <rev>` to leave the index untouched
- Rename `ResetSoftToRef` to `MoveHeadToRef` and `resetSoftToRef` to `resetMixedToRef` so names match
  behavior
