### PR TITLE
.github/actions/setup-go-toolchain: Make a common toolchain setup action which go test and bats test workflows can depend on.

### DIFF
--- a/.github/actions/setup-go-toolchain/action.yml
+++ b/.github/actions/setup-go-toolchain/action.yml
@@ -1,0 +1,31 @@
+name: 'Set up Go toolchain'
+description: 'Set up Go and platform-specific dependencies (ICU4C) needed to build dolt. On macOS, sets CGO flags pointing at brew icu4c. On Windows, installs MSYS2 with icu/toolchain/pkg-config and exposes the install path via the msys2-location output. On Linux, just sets up Go.'
+
+outputs:
+  msys2-location:
+    description: 'Path to the MSYS2 installation (Windows only).'
+    value: ${{ steps.msys2.outputs.msys2-location }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go/go.mod
+    - name: Install ICU4C (MacOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        dir=$(brew --cellar icu4c)
+        dir="$dir"/$(ls "$dir")
+        echo CGO_CPPFLAGS=-I$dir/include >> $GITHUB_ENV
+        echo CGO_LDFLAGS=-L$dir/lib >> $GITHUB_ENV
+    - name: Install ICU4C (Windows)
+      id: msys2
+      if: runner.os == 'Windows'
+      uses: msys2/setup-msys2@v2
+      with:
+        path-type: inherit
+        msystem: UCRT64
+        pacboy: icu:p toolchain:p pkg-config:p

--- a/.github/workflows/ci-bats-macos.yaml
+++ b/.github/workflows/ci-bats-macos.yaml
@@ -40,11 +40,8 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-duration-seconds: 10800 # 3 hours D:
       - uses: actions/checkout@v6
-      - name: Setup Go 1.x
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go/go.mod
-        id: go
+      - name: Set up Go toolchain
+        uses: ./.github/actions/setup-go-toolchain
       - name: Setup Python 3.x
         uses: actions/setup-python@v5
         with:
@@ -75,10 +72,6 @@ jobs:
       - name: Install Dolt
         working-directory: ./go
         run: |
-          icu4c_dir=$(brew --cellar icu4c)
-          icu4c_dir="$dir"/$(ls "$icu4c_dir")
-          export CGO_CPPFLAGS=-I$icu4c_dir/include
-          export CGO_LDFLAGS=-L$icu4c_dir/lib
           go build -mod=readonly -o ../.ci_bin/dolt ./cmd/dolt/.
           go build -mod=readonly -o ../.ci_bin/remotesrv ./utils/remotesrv/.
           go build -mod=readonly -o ../.ci_bin/noms ./store/cmd/noms/.

--- a/.github/workflows/ci-bats-unix-adaptive.yaml
+++ b/.github/workflows/ci-bats-unix-adaptive.yaml
@@ -55,11 +55,8 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-duration-seconds: 10800 # 3 hours D:
       - uses: actions/checkout@v6
-      - name: Setup Go 1.x
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go/go.mod
-        id: go
+      - name: Set up Go toolchain
+        uses: ./.github/actions/setup-go-toolchain
       - name: Setup Python 3.x
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci-bats-unix-remote.yaml
+++ b/.github/workflows/ci-bats-unix-remote.yaml
@@ -26,12 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         if: ${{ env.use_credentials != 'true' }}
-      - name: Setup Go 1.x
+      - name: Set up Go toolchain
         if: ${{ env.use_credentials != 'true' }}
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go/go.mod
-        id: go
+        uses: ./.github/actions/setup-go-toolchain
       - name: Setup Python 3.x
         if: ${{ env.use_credentials != 'true' }}
         uses: actions/setup-python@v5

--- a/.github/workflows/ci-bats-unix.yaml
+++ b/.github/workflows/ci-bats-unix.yaml
@@ -59,11 +59,8 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-duration-seconds: 10800 # 3 hours D:
       - uses: actions/checkout@v6
-      - name: Setup Go 1.x
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go/go.mod
-        id: go
+      - name: Set up Go toolchain
+        uses: ./.github/actions/setup-go-toolchain
       - name: Setup Python 3.x
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci-bats-windows.yaml
+++ b/.github/workflows/ci-bats-windows.yaml
@@ -96,11 +96,8 @@ jobs:
         if: ${{ github.event_name == 'repository_dispatch' }}
         with:
           ref: ${{ github.event.client_payload.ref }}
-      - name: Setup Go 1.x
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go/go.mod
-        id: go
+      - name: Set up Go toolchain
+        uses: ./.github/actions/setup-go-toolchain
       - name: Setup Python 3.x
         uses: actions/setup-python@v5
         with:
@@ -132,12 +129,6 @@ jobs:
           pip install mysql-connector-python
           pip install pandas
           pip install pyarrow
-      - name: Install ICU4C (Windows)
-        uses: msys2/setup-msys2@v2
-        with:
-          path-type: inherit
-          msystem: UCRT64
-          pacboy: icu:p toolchain:p pkg-config:p
       - name: Install Dolt
         working-directory: ./go
         shell: msys2 {0}

--- a/.github/workflows/ci-binlog-tests.yaml
+++ b/.github/workflows/ci-binlog-tests.yaml
@@ -25,11 +25,8 @@ jobs:
         adaptive_encoding: ["false", "true"]
     steps:
     - uses: actions/checkout@v6
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: go/go.mod
-      id: go
+    - name: Set up Go toolchain
+      uses: ./.github/actions/setup-go-toolchain
     - name: Test Binlog
       working-directory: ./go
       run: |
@@ -53,11 +50,8 @@ jobs:
         adaptive_encoding: ["false"]
     steps:
     - uses: actions/checkout@v6
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: go/go.mod
-      id: go
+    - name: Set up Go toolchain
+      uses: ./.github/actions/setup-go-toolchain
     - name: Test Binlog with Race
       working-directory: ./go
       run: |

--- a/.github/workflows/ci-compatibility-tests.yaml
+++ b/.github/workflows/ci-compatibility-tests.yaml
@@ -22,11 +22,8 @@ jobs:
         adaptive_encoding: [ "false", "true" ]
     steps:
       - uses: actions/checkout@v6
-      - name: Setup Go 1.x
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go/go.mod
-        id: go
+      - name: Set up Go toolchain
+        uses: ./.github/actions/setup-go-toolchain
       - uses: actions/setup-node@v4
         with:
           node-version: ^16

--- a/.github/workflows/ci-go-race-tests.yaml
+++ b/.github/workflows/ci-go-race-tests.yaml
@@ -22,11 +22,8 @@ jobs:
         adaptive_encoding: [ "false", "true" ]
     steps:
     - uses: actions/checkout@v6
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: go/go.mod
-      id: go
+    - name: Set up Go toolchain
+      uses: ./.github/actions/setup-go-toolchain
     - name: Test engine
       working-directory: ./go
       run: |

--- a/.github/workflows/ci-go-tests-adaptive.yaml
+++ b/.github/workflows/ci-go-tests-adaptive.yaml
@@ -23,11 +23,8 @@ jobs:
       DOLT_USE_ADAPTIVE_ENCODING: "true"
     steps:
     - uses: actions/checkout@v6
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: go/go.mod
-      id: go
+    - name: Set up Go toolchain
+      uses: ./.github/actions/setup-go-toolchain
     - name: Test All
       working-directory: ./go
       run: |
@@ -67,11 +64,8 @@ jobs:
       DOLT_USE_ADAPTIVE_ENCODING: "true"
     steps:
     - uses: actions/checkout@v6
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: go/go.mod
-      id: go
+    - name: Set up Go toolchain
+      uses: ./.github/actions/setup-go-toolchain
     - name: Test All
       working-directory: ./go
       run: |

--- a/.github/workflows/ci-go-tests.yaml
+++ b/.github/workflows/ci-go-tests.yaml
@@ -25,26 +25,9 @@ jobs:
         os: [macos-latest, ubuntu-22.04, windows-latest]
     steps:
     - uses: actions/checkout@v6
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: go/go.mod
-      id: go
-    - name: Install ICU4C (MacOS)
-      if: ${{ matrix.os == 'macos-latest' }}
-      run: |
-        dir=$(brew --cellar icu4c)
-        dir="$dir"/$(ls "$dir")
-        echo CGO_CPPFLAGS=-I$dir/include >> $GITHUB_ENV
-        echo CGO_LDFLAGS=-L$dir/lib >> $GITHUB_ENV
-    - name: Install ICU4C (Windows)
-      id: msys2
-      if: ${{ matrix.os == 'windows-latest' }}
-      uses: msys2/setup-msys2@v2
-      with:
-        path-type: inherit
-        msystem: UCRT64
-        pacboy: icu:p toolchain:p pkg-config:p
+    - name: Set up Go toolchain
+      id: toolchain
+      uses: ./.github/actions/setup-go-toolchain
     - name: Test All
       working-directory: ./go
       run: |
@@ -84,7 +67,7 @@ jobs:
         done
       env:
         MATRIX_OS: ${{ matrix.os }}
-        MSYS2_LOCATION: ${{ steps.msys2.outputs.msys2-location }}
+        MSYS2_LOCATION: ${{ steps.toolchain.outputs.msys2-location }}
   noracetest:
     name: Go tests - no race
     defaults:
@@ -97,26 +80,9 @@ jobs:
         os: [macos-latest, ubuntu-22.04, windows-latest]
     steps:
     - uses: actions/checkout@v6
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: go/go.mod
-      id: go
-    - name: Install ICU4C (MacOS)
-      if: ${{ matrix.os == 'macos-latest' }}
-      run: |
-        dir=$(brew --cellar icu4c)
-        dir="$dir"/$(ls "$dir")
-        echo CGO_CPPFLAGS=-I$dir/include >> $GITHUB_ENV
-        echo CGO_LDFLAGS=-L$dir/lib >> $GITHUB_ENV
-    - name: Install ICU4C (Windows)
-      if: ${{ matrix.os == 'windows-latest' }}
-      id: msys2
-      uses: msys2/setup-msys2@v2
-      with:
-        path-type: inherit
-        msystem: UCRT64
-        pacboy: icu:p toolchain:p pkg-config:p
+    - name: Set up Go toolchain
+      id: toolchain
+      uses: ./.github/actions/setup-go-toolchain
     - name: Test All
       working-directory: ./go
       run: |
@@ -127,4 +93,4 @@ jobs:
       env:
         MATRIX_OS: ${{ matrix.os }}
         DOLT_TEST_RUN_NON_RACE_TESTS: "true"
-        MSYS2_LOCATION: ${{ steps.msys2.outputs.msys2-location }}
+        MSYS2_LOCATION: ${{ steps.toolchain.outputs.msys2-location }}

--- a/.github/workflows/ci-sql-server-integration-tests.yaml
+++ b/.github/workflows/ci-sql-server-integration-tests.yaml
@@ -25,11 +25,8 @@ jobs:
         adaptive_encoding: ["false", "true"]
     steps:
       - uses: actions/checkout@v6
-      - name: Setup Go 1.x
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go/go.mod
-        id: go
+      - name: Set up Go toolchain
+        uses: ./.github/actions/setup-go-toolchain
       - name: Create CI Bin
         run: |
           mkdir -p ./.ci_bin


### PR DESCRIPTION
This is responsible for installing Golang toolchain and getting ICU4C in the environment so it can be used.