### PR TITLE
[no-release-notes] datas: add CollectGarbage entry point for non-SQL GC consumers

### DIFF
--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -1925,50 +1925,28 @@ func (ddb *DoltDB) Rebase(ctx context.Context) error {
 // certain in-progress operations which cannot be finalized in a timely manner,
 // etc.
 func (ddb *DoltDB) GC(ctx context.Context, gcConfig chunks.GCConfig, safepointController types.GCSafepointController) error {
-	collector, ok := ddb.db.Database.(datas.GarbageCollector)
-	if !ok {
-		return fmt.Errorf("this database does not support garbage collection")
-	}
-
 	err := ddb.pruneUnreferencedDatasets(ctx)
 	if err != nil {
 		return err
 	}
 
-	datasets, err := ddb.db.Datasets(ctx)
-	if err != nil {
-		return err
+	return datas.CollectGarbage(ctx, ddb.db.Database, gcConfig, DoltRefClassifier, safepointController)
+}
+
+// DoltRefClassifier is a datas.RefClassifier that uses Dolt's ref conventions.
+// It classifies branches, remotes, and internal refs as old generation (stable,
+// long-lived) and everything else (tags, workspaces, stashes, etc.) as new
+// generation (ephemeral).
+func DoltRefClassifier(datasetID string) bool {
+	if !ref.IsRef(datasetID) {
+		return false
 	}
-
-	newGen := make(hash.HashSet)
-	oldGen := make(hash.HashSet)
-	err = datasets.IterAll(ctx, func(keyStr string, h hash.Hash) error {
-		var isOldGen bool
-		switch {
-		case ref.IsRef(keyStr):
-			parsed, err := ref.Parse(keyStr)
-			if err != nil && !errors.Is(err, ref.ErrUnknownRefType) {
-				return err
-			}
-
-			refType := parsed.GetType()
-			isOldGen = refType == ref.BranchRefType || refType == ref.RemoteRefType || refType == ref.InternalRefType
-		}
-
-		if isOldGen {
-			oldGen.Insert(h)
-		} else {
-			newGen.Insert(h)
-		}
-
-		return nil
-	})
-
+	parsed, err := ref.Parse(datasetID)
 	if err != nil {
-		return err
+		return false
 	}
-
-	return collector.GC(ctx, gcConfig, oldGen, newGen, safepointController)
+	refType := parsed.GetType()
+	return refType == ref.BranchRefType || refType == ref.RemoteRefType || refType == ref.InternalRefType
 }
 
 func (ddb *DoltDB) ShallowGC(ctx context.Context) error {

--- a/go/store/datas/gc_helpers.go
+++ b/go/store/datas/gc_helpers.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datas
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/dolthub/dolt/go/store/types"
+)
+
+// RefClassifier is a function that determines whether a dataset ID represents
+// an "old generation" reference. Old generation refs are stable, long-lived
+// references (e.g., branches, remotes) while new generation refs are ephemeral
+// (e.g., tags, workspaces). The GC uses this distinction to run a two-phase
+// collection: conservative sweep of oldgen first, then aggressive sweep of
+// newgen.
+//
+// Returns true if the dataset ID should be classified as old generation.
+// Returns false for new generation or if the ref type is unknown.
+type RefClassifier func(datasetID string) (isOldGen bool)
+
+// CollectGarbage runs garbage collection on a Database. It iterates all
+// datasets, classifies each into oldGen or newGen using the provided
+// classifier, then invokes the underlying GC.
+//
+// The classifier function determines which refs are stable (oldGen) vs
+// ephemeral (newGen). Callers that use Dolt's ref conventions should
+// classify branches, remotes, and internal refs as oldGen. Callers with
+// custom ref schemes can provide their own classification logic.
+//
+// If classifier is nil, all refs are treated as newGen (safe but less
+// efficient - the GC will do a single-phase collection).
+func CollectGarbage(ctx context.Context, db Database, gcConfig chunks.GCConfig, classifier RefClassifier, safepointController types.GCSafepointController) error {
+	collector, ok := db.(GarbageCollector)
+	if !ok {
+		return fmt.Errorf("this database does not support garbage collection")
+	}
+
+	datasets, err := db.Datasets(ctx)
+	if err != nil {
+		return err
+	}
+
+	newGen := make(hash.HashSet)
+	oldGen := make(hash.HashSet)
+	err = datasets.IterAll(ctx, func(datasetID string, h hash.Hash) error {
+		if classifier != nil && classifier(datasetID) {
+			oldGen.Insert(h)
+		} else {
+			newGen.Insert(h)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return collector.GC(ctx, gcConfig, oldGen, newGen, safepointController)
+}

--- a/go/store/datas/gc_helpers_test.go
+++ b/go/store/datas/gc_helpers_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datas
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/dolthub/dolt/go/store/types"
+)
+
+// recordingSafepointController tracks which methods were called and in what order.
+type recordingSafepointController struct {
+	calls  []string
+	keeper func(hash.Hash) bool
+}
+
+var _ types.GCSafepointController = (*recordingSafepointController)(nil)
+
+func (r *recordingSafepointController) BeginGC(_ context.Context, keeper func(hash.Hash) bool) error {
+	r.calls = append(r.calls, "BeginGC")
+	r.keeper = keeper
+	return nil
+}
+func (r *recordingSafepointController) EstablishPreFinalizeSafepoint(context.Context) error {
+	r.calls = append(r.calls, "PreFinalize")
+	return nil
+}
+func (r *recordingSafepointController) EstablishPostFinalizeSafepoint(context.Context) error {
+	r.calls = append(r.calls, "PostFinalize")
+	return nil
+}
+func (r *recordingSafepointController) CancelSafepoint() {
+	r.calls = append(r.calls, "Cancel")
+}
+
+func TestCollectGarbageCollectsUnreferencedChunks(t *testing.T) {
+	ctx := context.Background()
+	storage := &chunks.TestStorage{}
+	db := NewDatabase(storage.NewView())
+	defer db.Close()
+
+	vrw := db.(*database).ValueStore
+
+	// Create a dataset with a committed value (reachable).
+	ds, err := db.GetDataset(ctx, "refs/heads/main")
+	require.NoError(t, err)
+	ds, err = CommitValue(ctx, db, ds, types.String("keep"))
+	require.NoError(t, err)
+
+	// Write an unreferenced value directly to the value store.
+	unreferencedRef, err := vrw.WriteValue(ctx, types.String("discard"))
+	require.NoError(t, err)
+	unreferencedHash := unreferencedRef.TargetHash()
+
+	// Confirm both are readable before GC.
+	val, err := vrw.ReadValue(ctx, unreferencedHash)
+	require.NoError(t, err)
+	assert.NotNil(t, val)
+
+	headAddr, hasHead := ds.MaybeHeadAddr()
+	require.True(t, hasHead)
+	val, err = vrw.ReadValue(ctx, headAddr)
+	require.NoError(t, err)
+	assert.NotNil(t, val)
+
+	// Run GC with nil classifier (all newGen).
+	sc := &recordingSafepointController{}
+	gcConfig := chunks.GCConfig{
+		Mode:                chunks.GCMode_Full,
+		ArchiveLevel:        chunks.NoArchive,
+		IncrementalFileSize: chunks.IncrementalGCTablesDisabled,
+	}
+	err = CollectGarbage(ctx, db, gcConfig, nil, sc)
+	require.NoError(t, err)
+	vrw.PurgeCaches()
+
+	// Verify safepoint controller was called in the correct order.
+	require.True(t, len(sc.calls) >= 3, "expected at least 3 safepoint calls, got %v", sc.calls)
+	assert.Equal(t, "BeginGC", sc.calls[0])
+	assert.Equal(t, "PreFinalize", sc.calls[1])
+	assert.Equal(t, "PostFinalize", sc.calls[2])
+
+	// Committed value still reachable.
+	val, err = vrw.ReadValue(ctx, headAddr)
+	require.NoError(t, err)
+	assert.NotNil(t, val)
+
+	// Unreferenced value collected.
+	val, err = vrw.ReadValue(ctx, unreferencedHash)
+	require.NoError(t, err)
+	assert.Nil(t, val)
+}
+
+func TestCollectGarbageWithRefClassifier(t *testing.T) {
+	ctx := context.Background()
+	storage := &chunks.TestStorage{}
+	db := NewDatabase(storage.NewView())
+	defer db.Close()
+
+	vrw := db.(*database).ValueStore
+
+	ds1, err := db.GetDataset(ctx, "refs/heads/main")
+	require.NoError(t, err)
+	ds1, err = CommitValue(ctx, db, ds1, types.String("branch-data"))
+	require.NoError(t, err)
+
+	ds2, err := db.GetDataset(ctx, "refs/tags/v1.0")
+	require.NoError(t, err)
+	ds2, err = CommitValue(ctx, db, ds2, types.String("tag-data"))
+	require.NoError(t, err)
+
+	// Only "refs/heads/" are old gen.
+	classifier := func(datasetID string) bool {
+		return len(datasetID) > 11 && datasetID[:11] == "refs/heads/"
+	}
+
+	sc := &recordingSafepointController{}
+	gcConfig := chunks.GCConfig{
+		Mode:                chunks.GCMode_Full,
+		ArchiveLevel:        chunks.NoArchive,
+		IncrementalFileSize: chunks.IncrementalGCTablesDisabled,
+	}
+	err = CollectGarbage(ctx, db, gcConfig, classifier, sc)
+	require.NoError(t, err)
+	vrw.PurgeCaches()
+
+	// Verify safepoint controller was exercised.
+	assert.Contains(t, sc.calls, "BeginGC")
+	assert.Contains(t, sc.calls, "PreFinalize")
+	assert.Contains(t, sc.calls, "PostFinalize")
+
+	// Both datasets still reachable after GC.
+	headAddr1, hasHead := ds1.MaybeHeadAddr()
+	require.True(t, hasHead)
+	val, err := vrw.ReadValue(ctx, headAddr1)
+	require.NoError(t, err)
+	assert.NotNil(t, val)
+
+	headAddr2, hasHead := ds2.MaybeHeadAddr()
+	require.True(t, hasHead)
+	val, err = vrw.ReadValue(ctx, headAddr2)
+	require.NoError(t, err)
+	assert.NotNil(t, val)
+}


### PR DESCRIPTION
Extract ref classification and GC invocation from DoltDB.GC() into datas.CollectGarbage(), which accepts a RefClassifier callback so callers with custom ref schemes (like DumboDB) can provide their own oldGen/newGen classification without importing doltcore/ref.

DoltDB.GC() now delegates to CollectGarbage with DoltRefClassifier.