### PR TITLE
fix: fix convergent add columns being flagged as conflicts

### DIFF
--- a/go/libraries/doltcore/merge/merge_prolly_rows.go
+++ b/go/libraries/doltcore/merge/merge_prolly_rows.go
@@ -1826,9 +1826,12 @@ type valueMerger struct {
 	keyless                                bool
 	ns                                     tree.NodeStore
 	valueBuilder                           *val.TupleBuilder
+	// tableName is stored so that processColumn can resolve column default expressions
+	// for convergently-added columns (same definition on both sides, absent from base).
+	tableName string
 }
 
-func NewValueMerger(ctx context.Context, merged, leftSch, rightSch, baseSch schema.Schema, syncPool pool.BuffPool, ns tree.NodeStore) *valueMerger {
+func NewValueMerger(ctx context.Context, merged, leftSch, rightSch, baseSch schema.Schema, syncPool pool.BuffPool, ns tree.NodeStore, tableName string) *valueMerger {
 	leftMapping, rightMapping, baseMapping := generateSchemaMappings(merged, leftSch, rightSch, baseSch)
 
 	baseToLeftMapping, baseToRightMapping, baseToResultMapping := generateSchemaMappings(baseSch, leftSch, rightSch, merged)
@@ -1853,7 +1856,50 @@ func NewValueMerger(ctx context.Context, merged, leftSch, rightSch, baseSch sche
 		keyless:             schema.IsKeyless(merged),
 		ns:                  ns,
 		valueBuilder:        val.NewTupleBuilder(resultVD, ns),
+		tableName:           tableName,
 	}
+}
+
+// getConvergentDefault evaluates the default expression for result-schema stored column i when
+// that column was convergently added (same definition on both sides, absent from base). It is
+// called only when left and right have differing values with no base, so the default serves as
+// a synthetic base: a side whose value matches the default made no intentional write. Returns
+// nil if no default applies, the column was not a convergent add, or evaluation fails — in all
+// such cases the caller falls back to reporting a conflict.
+func (m *valueMerger) getConvergentDefault(ctx *sql.Context, i int) interface{} {
+	if m.tableName == "" {
+		return nil
+	}
+
+	// detect if columns are absent on either side
+	if m.leftMapping[i] == -1 || m.rightMapping[i] == -1 {
+		return nil
+	}
+
+	// checks if the columns have the same definition and metadata on both sides
+	leftCol := m.leftSchema.GetNonPKCols().GetByStoredIndex(m.leftMapping[i])
+	rightCol := m.rightSchema.GetNonPKCols().GetByStoredIndex(m.rightMapping[i])
+	if !leftCol.Equals(rightCol) {
+		return nil
+	}
+
+	col := m.resultSchema.GetNonPKCols().GetByStoredIndex(i)
+	if col.Default == "" {
+		return nil
+	}
+	expr, err := expranalysis.ResolveDefaultExpression(ctx, m.tableName, m.resultSchema, col)
+	if err != nil || !expr.Resolved() {
+		return nil
+	}
+	v, err := expr.Eval(ctx, sql.Row{})
+	if err != nil {
+		return nil
+	}
+	v, _, err = col.TypeInfo.ToSqlType().Convert(ctx, v)
+	if err != nil {
+		return nil
+	}
+	return v
 }
 
 // generateSchemaMappings returns three schema mappings: 1) mapping the |leftSch| to |mergedSch|,
@@ -2121,6 +2167,25 @@ func (m *valueMerger) processColumn(ctx *sql.Context, i int, left, right, base v
 		// generated columns will be updated as part of the merge later on, so choose either value for now
 		if generatedColumn {
 			return leftVal, false, err
+		}
+
+		// If the column was convergently added (same definition on both sides, not in base)
+		// and we know its default value, use that default as a synthetic base for three-way merge.
+		// This lets us distinguish a schema-backfill value (== default) from an intentional write.
+		if defaultVal := m.getConvergentDefault(ctx, i); defaultVal != nil {
+			leftEqDefault, err1 := sqlType.Compare(ctx, leftVal, defaultVal)
+			rightEqDefault, err2 := sqlType.Compare(ctx, rightVal, defaultVal)
+			if err1 == nil && err2 == nil {
+				if leftEqDefault == 0 && rightEqDefault != 0 {
+					// Left has the backfill default; right made an explicit change.
+					return rightVal, false, nil
+				}
+				if rightEqDefault == 0 && leftEqDefault != 0 {
+					// Right has the backfill default; left made an explicit change.
+					return leftVal, false, nil
+				}
+				// Both differ from the default with different values — genuine conflict; fall through.
+			}
 		}
 
 		// conflicting inserts

--- a/go/libraries/doltcore/merge/merge_rows.go
+++ b/go/libraries/doltcore/merge/merge_rows.go
@@ -84,7 +84,8 @@ type TableMerger struct {
 }
 
 func (tm TableMerger) GetNewValueMerger(ctx context.Context, mergeSch schema.Schema, leftRows prolly.Map) *valueMerger {
-	return NewValueMerger(ctx, mergeSch, tm.leftSch, tm.rightSch, tm.ancSch, leftRows.Pool(), leftRows.NodeStore())
+	m := NewValueMerger(ctx, mergeSch, tm.leftSch, tm.rightSch, tm.ancSch, leftRows.Pool(), leftRows.NodeStore(), tm.name.Name)
+	return m
 }
 
 func rowsFromTable(ctx context.Context, tbl *doltdb.Table) (prolly.Map, error) {

--- a/go/libraries/doltcore/merge/merge_schema.go
+++ b/go/libraries/doltcore/merge/merge_schema.go
@@ -616,13 +616,15 @@ func checkSchemaConflicts(columnMappings columnMappings) ([]ColConflict, error) 
 					})
 				}
 			case theirs != nil && anc == nil:
-				// Column exists on both sides, but not in ancestor
-				// col added on our branch and their branch with different def
-				conflicts = append(conflicts, ColConflict{
-					Kind:   NameCollision,
-					Ours:   *ours,
-					Theirs: *theirs,
-				})
+				// Column exists on both sides, but not in ancestor.
+				// Only flag a conflict if the definitions differ; identical additions converge cleanly.
+				if !ours.Equals(*theirs) {
+					conflicts = append(conflicts, ColConflict{
+						Kind:   NameCollision,
+						Ours:   *ours,
+						Theirs: *theirs,
+					})
+				}
 			case theirs == nil && anc == nil:
 				// column doesn't exist on theirs or in anc – no conflict
 			}

--- a/go/libraries/doltcore/merge/row_merge_test.go
+++ b/go/libraries/doltcore/merge/row_merge_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/store/types"
@@ -165,7 +166,7 @@ func TestRowMerge(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			v := NewValueMerger(ctx, test.mergedSch, test.leftSch, test.rightSch, test.baseSch, syncPool, nil)
+			v := NewValueMerger(ctx, test.mergedSch, test.leftSch, test.rightSch, test.baseSch, syncPool, nil, "")
 
 			merged, ok, err := v.TryMerge(ctx, test.row, test.mergeRow, test.ancRow)
 			assert.NoError(t, err)
@@ -238,4 +239,104 @@ func buildTup(sch schema.Schema, r []*int) val.Tuple {
 		panic(err)
 	}
 	return tup
+}
+
+// intPtr returns a pointer to v, letting test code represent the integer 0 in a []*int slice
+// (the build() helper treats 0 as NULL, so explicit pointers are needed for zero values).
+func intPtr(v int) *int { return &v }
+
+// TestRowMergeConvergentAddColumn tests that when both branches add the same column with an
+// identical definition (convergent DDL), TryMerge uses the column default as a synthetic base
+// so that a schema-backfill value is not treated as an intentional write.
+func TestRowMergeConvergentAddColumn(t *testing.T) {
+	defaultValue := "0"
+	defaultValueInt, err := strconv.Atoi(defaultValue)
+	require.NoError(t, err)
+
+	ctx := sql.NewEmptyContext()
+
+	// baseSch: table before either branch adds "extra"
+	baseSch := calcSchema(1) // PK + 1 non-pk col (tag=1)
+
+	// extSch: same first column plus "extra INTEGER DEFAULT 0" (tag=2)
+	baseCol := schema.NewColumn("1", 1, types.IntKind, false)
+	extraCol, err := schema.NewColumnWithTypeInfo("2", 2, baseCol.TypeInfo, false, defaultValue, false, "")
+	require.NoError(t, err)
+	extSch := schema.MustSchemaFromCols(schema.NewColCollection(
+		schema.NewColumn("primaryKey", 0, types.IntKind, true),
+		baseCol,
+		extraCol,
+	))
+
+	// bv builds a base-schema value tuple (1 non-pk field).
+	bv := func(v int) val.Tuple { return buildTup(baseSch, []*int{intPtr(v)}) }
+	// ev builds an ext-schema value tuple (2 non-pk fields).
+	ev := func(v1, v2 int) val.Tuple { return buildTup(extSch, []*int{intPtr(v1), intPtr(v2)}) }
+
+	tests := []struct {
+		name           string
+		left, right    val.Tuple
+		anc            val.Tuple
+		expected       val.Tuple
+		expectConflict bool
+		noTableName    bool // if true, leave tableName unset to test fallback conflict behaviour
+	}{
+		{
+			name:           "left has backfill default, right has explicit value — right wins",
+			anc:            bv(1),
+			left:           ev(1, defaultValueInt), // extra=0 from schema backfill
+			right:          ev(1, 11),              // extra=11 from explicit UPDATE
+			expected:       ev(1, 11),
+			expectConflict: false,
+		},
+		{
+			name:           "right has backfill default, left has explicit value — left wins",
+			anc:            bv(1),
+			left:           ev(1, 7),               // extra=7 from explicit UPDATE
+			right:          ev(1, defaultValueInt), // extra=0 from schema backfill
+			expected:       ev(1, 7),
+			expectConflict: false,
+		},
+		{
+			name:           "both have same explicit non-default value — converge",
+			anc:            bv(1),
+			left:           ev(1, 5),
+			right:          ev(1, 5),
+			expected:       ev(1, 5),
+			expectConflict: false,
+		},
+		{
+			name:           "both have different explicit non-default values — genuine conflict",
+			anc:            bv(1),
+			left:           ev(1, 7),
+			right:          ev(1, 11),
+			expected:       nil,
+			expectConflict: true,
+		},
+		{
+			name:           "without table name, differing values conflict (fallback behaviour)",
+			anc:            bv(1),
+			left:           ev(1, defaultValueInt),
+			right:          ev(1, 11),
+			expected:       nil,
+			expectConflict: true,
+			noTableName:    true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var tableName string
+			if !test.noTableName {
+				tableName = "t"
+			}
+			m := NewValueMerger(ctx, extSch, extSch, extSch, baseSch, syncPool, nil, tableName)
+
+			merged, ok, err := m.TryMerge(ctx, test.left, test.right, test.anc)
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectConflict, !ok, "conflict mismatch")
+			vD := extSch.GetValueDescriptor(m.ns)
+			assert.Equal(t, vD.Format(ctx, test.expected), vD.Format(ctx, merged))
+		})
+	}
 }


### PR DESCRIPTION
  When both branches run an identical `ALTER TABLE ... ADD COLUMN` with a
  DEFAULT, Dolt was incorrectly flagging the merge as conflicted and
  (under autocommit) silently rolling back any DML the side branch made
  on the new column.

  Two bugs were responsible:

  1. `checkSchemaConflicts` (merge_schema.go) unconditionally appended a
     NameCollision conflict whenever a column existed on both sides but
     not in the ancestor, without first checking whether the definitions
     were identical. Added an `ours.Equals(*theirs)` guard so convergent
     adds are recognised as conflict-free, consistent with `mergeColumns`
     which already handled this correctly.

  2. `processColumn` (merge_prolly_rows.go) treated any divergent values
     for a column absent from the base as a conflict, even when one
     side's value was simply the schema-backfill default. Added
     `getConvergentDefault`, which evaluates the column's default
     expression at conflict-check time and uses the result as a synthetic
     base: a side whose value equals the default made no intentional
     write and loses to the other side's explicit change.


Closes https://github.com/dolthub/dolt/issues/10909