### PR TITLE
drop remote db cache, Close() after each use

### DIFF
--- a/go/libraries/doltcore/dbfactory/git_remote.go
+++ b/go/libraries/doltcore/dbfactory/git_remote.go
@@ -139,10 +139,8 @@ func (fact GitRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFor
 		return nil, nil, nil, err
 	}
 
-	cacheKey := cacheRepo
-
 	gitRemoteCacheMu.Lock()
-	if entry, ok := gitRemoteCache[cacheKey]; ok {
+	if entry, ok := gitRemoteCache[cacheRepo]; ok {
 		gitRemoteCacheMu.Unlock()
 		return entry.db, entry.vrw, entry.ns, nil
 	}
@@ -195,11 +193,11 @@ func (fact GitRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFor
 	db := datas.NewTypesDatabase(vrw, ns)
 
 	gitRemoteCacheMu.Lock()
-	if entry, ok := gitRemoteCache[cacheKey]; ok {
+	if entry, ok := gitRemoteCache[cacheRepo]; ok {
 		gitRemoteCacheMu.Unlock()
 		return entry.db, entry.vrw, entry.ns, nil
 	}
-	gitRemoteCache[cacheKey] = gitRemoteCacheEntry{db: db, vrw: vrw, ns: ns}
+	gitRemoteCache[cacheRepo] = gitRemoteCacheEntry{db: db, vrw: vrw, ns: ns}
 	gitRemoteCacheMu.Unlock()
 	return db, vrw, ns, nil
 }

--- a/go/libraries/doltcore/dbfactory/git_remote.go
+++ b/go/libraries/doltcore/dbfactory/git_remote.go
@@ -25,6 +25,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/dolthub/fslock"
 
@@ -93,6 +94,25 @@ func (fact GitRemoteFactory) PrepareDB(ctx context.Context, nbf *types.NomsBinFo
 	}
 }
 
+// One shared GitBlobstore per (local db, URL, ref); key is cacheRepoPath.
+type gitRemoteCacheEntry struct {
+	db  datas.Database
+	vrw types.ValueReadWriter
+	ns  tree.NodeStore
+}
+
+var (
+	gitRemoteCacheMu sync.Mutex
+	gitRemoteCache   = map[string]gitRemoteCacheEntry{}
+)
+
+// No-op Close so callers can defer Close() on a shared instance.
+type gitNoopCloseChunkStore struct {
+	*nbs.NomsBlockStore
+}
+
+func (gitNoopCloseChunkStore) Close() error { return nil }
+
 func (fact GitRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, urlObj *url.URL, params map[string]interface{}) (datas.Database, types.ValueReadWriter, tree.NodeStore, error) {
 	remoteURL, ref, err := parseGitRemoteFactoryURL(urlObj, params)
 	if err != nil {
@@ -112,6 +132,15 @@ func (fact GitRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFor
 	if err != nil {
 		return nil, nil, nil, err
 	}
+
+	cacheKey := cacheRepo
+
+	gitRemoteCacheMu.Lock()
+	if entry, ok := gitRemoteCache[cacheKey]; ok {
+		gitRemoteCacheMu.Unlock()
+		return entry.db, entry.vrw, entry.ns, nil
+	}
+	gitRemoteCacheMu.Unlock()
 
 	remoteName := resolveGitRemoteName(params)
 
@@ -144,14 +173,23 @@ func (fact GitRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFor
 	}
 
 	q := nbs.NewUnlimitedMemQuotaProvider()
-	cs, err := nbs.NewGitStore(ctx, nbf.VersionString(), cacheRepo, ref, blobstore.GitBlobstoreOptions{RemoteName: remoteName, InfoBranch: blobstore.DefaultInfoBranch}, memlimit.MemtableSize(), q)
+	nbsCS, err := nbs.NewGitStore(ctx, nbf.VersionString(), cacheRepo, ref, blobstore.GitBlobstoreOptions{RemoteName: remoteName, InfoBranch: blobstore.DefaultInfoBranch}, memlimit.MemtableSize(), q)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
+	cs := gitNoopCloseChunkStore{NomsBlockStore: nbsCS}
 	vrw := types.NewValueStore(cs)
 	ns := tree.NewNodeStore(cs)
 	db := datas.NewTypesDatabase(vrw, ns)
+
+	gitRemoteCacheMu.Lock()
+	if entry, ok := gitRemoteCache[cacheKey]; ok {
+		gitRemoteCacheMu.Unlock()
+		return entry.db, entry.vrw, entry.ns, nil
+	}
+	gitRemoteCache[cacheKey] = gitRemoteCacheEntry{db: db, vrw: vrw, ns: ns}
+	gitRemoteCacheMu.Unlock()
 	return db, vrw, ns, nil
 }
 

--- a/go/libraries/doltcore/dbfactory/git_remote.go
+++ b/go/libraries/doltcore/dbfactory/git_remote.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/dolthub/fslock"
 
@@ -106,6 +107,11 @@ var (
 	gitRemoteCache   = map[string]gitRemoteCacheEntry{}
 )
 
+// gitBlobstoreSyncForReadTTLOverride, when non-zero, is passed as
+// GitBlobstoreOptions.SyncForReadTTL when constructing a new GitBlobstore.
+// Test seam only.
+var gitBlobstoreSyncForReadTTLOverride time.Duration
+
 // No-op Close so callers can defer Close() on a shared instance.
 type gitNoopCloseChunkStore struct {
 	*nbs.NomsBlockStore
@@ -173,7 +179,12 @@ func (fact GitRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFor
 	}
 
 	q := nbs.NewUnlimitedMemQuotaProvider()
-	nbsCS, err := nbs.NewGitStore(ctx, nbf.VersionString(), cacheRepo, ref, blobstore.GitBlobstoreOptions{RemoteName: remoteName, InfoBranch: blobstore.DefaultInfoBranch}, memlimit.MemtableSize(), q)
+	bsOpts := blobstore.GitBlobstoreOptions{
+		RemoteName:     remoteName,
+		InfoBranch:     blobstore.DefaultInfoBranch,
+		SyncForReadTTL: gitBlobstoreSyncForReadTTLOverride,
+	}
+	nbsCS, err := nbs.NewGitStore(ctx, nbf.VersionString(), cacheRepo, ref, bsOpts, memlimit.MemtableSize(), q)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/go/libraries/doltcore/dbfactory/git_remote_test.go
+++ b/go/libraries/doltcore/dbfactory/git_remote_test.go
@@ -25,6 +25,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -216,12 +217,18 @@ func TestGitRemoteFactory_TwoClientsDistinctCacheDirsRoundtrip(t *testing.T) {
 	require.True(t, okCommitB)
 	require.NoError(t, dbB.Close())
 
-	// Client A re-opens and should see B's update.
+	// Cached blobstore: Rebase within syncForRead TTL skips upstream fetch.
 	dbA2, csA2 := open(cacheA)
 	require.NoError(t, csA2.Rebase(ctx))
 	rootA2, err := csA2.Root(ctx)
 	require.NoError(t, err)
-	require.Equal(t, cB.Hash(), rootA2)
+	require.Equal(t, cA.Hash(), rootA2)
+
+	time.Sleep(1100 * time.Millisecond)
+	require.NoError(t, csA2.Rebase(ctx))
+	rootA2After, err := csA2.Root(ctx)
+	require.NoError(t, err)
+	require.Equal(t, cB.Hash(), rootA2After)
 	gotB, err := csA2.Get(ctx, cB.Hash())
 	require.NoError(t, err)
 	require.Equal(t, "clientB\n", string(gotB.Data()))

--- a/go/libraries/doltcore/dbfactory/git_remote_test.go
+++ b/go/libraries/doltcore/dbfactory/git_remote_test.go
@@ -159,9 +159,9 @@ func TestGitRemoteFactory_TwoClientsDistinctCacheDirsRoundtrip(t *testing.T) {
 		t.Skip("git not found on PATH")
 	}
 
-	// Extend the default 1s syncForRead TTL to 2s to account for slow CI machines.
+	// Extend the default 1s syncForRead TTL to 5s to account for slow CI machines.
 	prevTTL := gitBlobstoreSyncForReadTTLOverride
-	gitBlobstoreSyncForReadTTLOverride = 2 * time.Second
+	gitBlobstoreSyncForReadTTLOverride = 5 * time.Second
 	t.Cleanup(func() { gitBlobstoreSyncForReadTTLOverride = prevTTL })
 
 	ctx := context.Background()
@@ -229,7 +229,7 @@ func TestGitRemoteFactory_TwoClientsDistinctCacheDirsRoundtrip(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, cA.Hash(), rootA2)
 
-	time.Sleep(4 * time.Second)
+	time.Sleep(10 * time.Second)
 	require.NoError(t, csA2.Rebase(ctx))
 	rootA2After, err := csA2.Root(ctx)
 	require.NoError(t, err)

--- a/go/libraries/doltcore/dbfactory/git_remote_test.go
+++ b/go/libraries/doltcore/dbfactory/git_remote_test.go
@@ -159,10 +159,10 @@ func TestGitRemoteFactory_TwoClientsDistinctCacheDirsRoundtrip(t *testing.T) {
 		t.Skip("git not found on PATH")
 	}
 
-	// Override the default 1s syncForRead TTL with 5s so the stale-within-TTL
+	// Override the default 1s syncForRead TTL with 2s so the stale-within-TTL
 	// assertion below is deterministic regardless of platform speed.
 	prevTTL := gitBlobstoreSyncForReadTTLOverride
-	gitBlobstoreSyncForReadTTLOverride = 5 * time.Second
+	gitBlobstoreSyncForReadTTLOverride = 2 * time.Second
 	t.Cleanup(func() { gitBlobstoreSyncForReadTTLOverride = prevTTL })
 
 	ctx := context.Background()
@@ -230,7 +230,7 @@ func TestGitRemoteFactory_TwoClientsDistinctCacheDirsRoundtrip(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, cA.Hash(), rootA2)
 
-	time.Sleep(10 * time.Second)
+	time.Sleep(4 * time.Second)
 	require.NoError(t, csA2.Rebase(ctx))
 	rootA2After, err := csA2.Root(ctx)
 	require.NoError(t, err)

--- a/go/libraries/doltcore/dbfactory/git_remote_test.go
+++ b/go/libraries/doltcore/dbfactory/git_remote_test.go
@@ -159,6 +159,12 @@ func TestGitRemoteFactory_TwoClientsDistinctCacheDirsRoundtrip(t *testing.T) {
 		t.Skip("git not found on PATH")
 	}
 
+	// Override the default 1s syncForRead TTL with 5s so the stale-within-TTL
+	// assertion below is deterministic regardless of platform speed.
+	prevTTL := gitBlobstoreSyncForReadTTLOverride
+	gitBlobstoreSyncForReadTTLOverride = 5 * time.Second
+	t.Cleanup(func() { gitBlobstoreSyncForReadTTLOverride = prevTTL })
+
 	ctx := context.Background()
 	remoteRepo, err := gitrepo.InitBare(ctx, filepath.Join(shortTempDir(t), "remote.git"))
 	require.NoError(t, err)
@@ -224,7 +230,7 @@ func TestGitRemoteFactory_TwoClientsDistinctCacheDirsRoundtrip(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, cA.Hash(), rootA2)
 
-	time.Sleep(1100 * time.Millisecond)
+	time.Sleep(10 * time.Second)
 	require.NoError(t, csA2.Rebase(ctx))
 	rootA2After, err := csA2.Root(ctx)
 	require.NoError(t, err)

--- a/go/libraries/doltcore/dbfactory/git_remote_test.go
+++ b/go/libraries/doltcore/dbfactory/git_remote_test.go
@@ -159,8 +159,7 @@ func TestGitRemoteFactory_TwoClientsDistinctCacheDirsRoundtrip(t *testing.T) {
 		t.Skip("git not found on PATH")
 	}
 
-	// Override the default 1s syncForRead TTL with 2s so the stale-within-TTL
-	// assertion below is deterministic regardless of platform speed.
+	// Extend the default 1s syncForRead TTL to 2s to account for slow CI machines.
 	prevTTL := gitBlobstoreSyncForReadTTLOverride
 	gitBlobstoreSyncForReadTTLOverride = 2 * time.Second
 	t.Cleanup(func() { gitBlobstoreSyncForReadTTLOverride = prevTTL })

--- a/go/libraries/doltcore/env/actions/branch.go
+++ b/go/libraries/doltcore/env/actions/branch.go
@@ -248,10 +248,11 @@ func validateBranchMergedIntoUpstream[C doltdb.Context](ctx context.Context, dbd
 		return fmt.Errorf("remote %s not found", remoteName)
 	}
 
-	remoteDb, err := pro.GetRemoteDB(ctx, dbdata.Ddb.ValueReadWriter().Format(), remote, false)
+	remoteDb, err := pro.GetRemoteDB(ctx, dbdata.Ddb.ValueReadWriter().Format(), remote)
 	if err != nil {
 		return err
 	}
+	defer remoteDb.Close()
 
 	cs, err := doltdb.NewCommitSpec(branch.GetPath())
 	if err != nil {

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -152,12 +152,8 @@ func IncompleteEnv(FS filesys.Filesys) *DoltEnv {
 	}
 }
 
-func (dEnv *DoltEnv) GetRemoteDB(ctx context.Context, format *types.NomsBinFormat, r Remote, withCaching bool) (*doltdb.DoltDB, error) {
-	if withCaching {
-		return r.GetRemoteDB(ctx, format, dEnv)
-	} else {
-		return r.GetRemoteDBWithoutCaching(ctx, format, dEnv)
-	}
+func (dEnv *DoltEnv) GetRemoteDB(ctx context.Context, format *types.NomsBinFormat, r Remote) (*doltdb.DoltDB, error) {
+	return r.GetRemoteDBWithoutCaching(ctx, format, dEnv)
 }
 
 func (dEnv *DoltEnv) GetConfig() config.ReadableConfig {

--- a/go/libraries/doltcore/env/repo_state.go
+++ b/go/libraries/doltcore/env/repo_state.go
@@ -54,7 +54,7 @@ type RepoStateReadWriter[C doltdb.Context] interface {
 
 // RemoteDbProvider is an interface for getting a database from a remote
 type RemoteDbProvider interface {
-	GetRemoteDB(ctx context.Context, format *types.NomsBinFormat, r Remote, withCaching bool) (*doltdb.DoltDB, error)
+	GetRemoteDB(ctx context.Context, format *types.NomsBinFormat, r Remote) (*doltdb.DoltDB, error)
 }
 type DbData[C doltdb.Context] struct {
 	Ddb *doltdb.DoltDB

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -79,11 +79,6 @@ type DoltDatabaseProvider struct {
 	// when accessed.
 	deletingDatabases map[string]struct{}
 
-	// remoteDbs caches remote DoltDB instances by URL so that repeated push calls
-	// to the same remote reuse the store (and its already-opened table chunk sources)
-	// instead of re-opening every table file from the blobstore each time.
-	remoteDbs map[string]*doltdb.DoltDB
-
 	txLocks keymutex.Keymutex
 
 	defaultBranch     string
@@ -197,7 +192,6 @@ func NewDoltDatabaseProviderWithDatabases(defaultBranch string, fs filesys.Files
 		isStandby:              new(bool),
 		droppedDatabaseManager: newDroppedDatabaseManager(fs),
 		overrides:              overrides,
-		remoteDbs:              make(map[string]*doltdb.DoltDB),
 		txLocks:                keymutex.NewMapped(),
 	}, nil
 }
@@ -313,19 +307,6 @@ func (p *DoltDatabaseProvider) Close() {
 		}
 	}
 
-	// Close cached remote databases.
-	var remoteDbs []*doltdb.DoltDB
-	func() {
-		p.mu.RLock()
-		defer p.mu.RUnlock()
-		remoteDbs = make([]*doltdb.DoltDB, 0, len(p.remoteDbs))
-		for _, rdb := range p.remoteDbs {
-			remoteDbs = append(remoteDbs, rdb)
-		}
-	}()
-	for _, rdb := range remoteDbs {
-		_ = rdb.Close()
-	}
 }
 
 // Installs an InitDatabaseHook which configures new databases--those
@@ -571,7 +552,7 @@ func (p *DoltDatabaseProvider) allRevisionDbs(ctx *sql.Context, db dsess.SqlData
 	return revDbs, nil
 }
 
-func (p *DoltDatabaseProvider) GetRemoteDB(ctx context.Context, format *types.NomsBinFormat, r env.Remote, withCaching bool) (*doltdb.DoltDB, error) {
+func (p *DoltDatabaseProvider) GetRemoteDB(ctx context.Context, format *types.NomsBinFormat, r env.Remote) (*doltdb.DoltDB, error) {
 	// For git remotes, thread through the initiating database's repo root so git caches can be located under
 	// `<repoRoot>/.dolt/...` instead of a user-global cache dir.
 	dialer := p.remoteDialer
@@ -588,45 +569,6 @@ func (p *DoltDatabaseProvider) GetRemoteDB(ctx context.Context, format *types.No
 		}
 	}
 
-	if withCaching {
-		// Only cache git-backed remote DBs. Other remote types (file://, aws, etc.)
-		// register their underlying NBS in a global singleton cache that is closed
-		// separately by CloseAllLocalDatabases(). Caching those here would cause a
-		// double-close panic on process exit.
-		isGitRemote := strings.HasPrefix(strings.ToLower(r.Url), "git+")
-		if isGitRemote {
-			cached := func() *doltdb.DoltDB {
-				p.mu.RLock()
-				defer p.mu.RUnlock()
-				return p.remoteDbs[r.Url]
-			}()
-			if cached != nil {
-				return cached, nil
-			}
-		}
-
-		remoteDB, err := r.GetRemoteDB(ctx, format, dialer)
-		if err != nil {
-			return nil, err
-		}
-
-		if isGitRemote {
-			cached := func() *doltdb.DoltDB {
-				p.mu.Lock()
-				defer p.mu.Unlock()
-				if existing, ok := p.remoteDbs[r.Url]; ok {
-					return existing
-				}
-				p.remoteDbs[r.Url] = remoteDB
-				return nil
-			}()
-			if cached != nil {
-				_ = remoteDB.Close()
-				return cached, nil
-			}
-		}
-		return remoteDB, nil
-	}
 	return r.GetRemoteDBWithoutCaching(ctx, format, dialer)
 }
 

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_backup.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_backup.go
@@ -228,7 +228,7 @@ func doltBackupRestore(ctx *sql.Context, dbData env.DbData[*sql.Context], dsess 
 		format = dbData.Ddb.Format()
 	}
 
-	remoteDb, err := dsess.Provider().GetRemoteDB(ctx, format, remote, false)
+	remoteDb, err := dsess.Provider().GetRemoteDB(ctx, format, remote)
 	if err != nil {
 		return err
 	}
@@ -304,7 +304,7 @@ func syncRemote(ctx *sql.Context, dbData env.DbData[*sql.Context], dsess *dsess.
 	// We primarily use this to initialize the directory for file URLs without a directory.
 	_ = dbfactory.PrepareDB(ctx, dbData.Ddb.Format(), remote.Url, params)
 
-	destDb, err := dsess.Provider().GetRemoteDB(ctx, dbData.Ddb.Format(), remote, false)
+	destDb, err := dsess.Provider().GetRemoteDB(ctx, dbData.Ddb.Format(), remote)
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_fetch.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_fetch.go
@@ -81,10 +81,11 @@ func doDoltFetch(ctx *sql.Context, args []string) (int, error) {
 		})
 	}
 
-	srcDB, err := sess.Provider().GetRemoteDB(ctx, dbData.Ddb.ValueReadWriter().Format(), remote, false)
+	srcDB, err := sess.Provider().GetRemoteDB(ctx, dbData.Ddb.ValueReadWriter().Format(), remote)
 	if err != nil {
 		return 1, err
 	}
+	defer srcDB.Close()
 
 	err = srcDB.Rebase(ctx)
 	if err != nil {

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_pull.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_pull.go
@@ -148,10 +148,11 @@ func doDoltPull(ctx *sql.Context, args []string) (int, int, string, error) {
 		})
 	}
 
-	srcDB, err := sess.Provider().GetRemoteDB(ctx, dbData.Ddb.ValueReadWriter().Format(), pullSpec.Remote, false)
+	srcDB, err := sess.Provider().GetRemoteDB(ctx, dbData.Ddb.ValueReadWriter().Format(), pullSpec.Remote)
 	if err != nil {
 		return noConflictsOrViolations, threeWayMerge, "", fmt.Errorf("failed to get remote db; %w", err)
 	}
+	defer srcDB.Close()
 
 	err = srcDB.Rebase(ctx)
 	if err != nil {

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_push.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_push.go
@@ -91,10 +91,11 @@ func doDoltPush(ctx *sql.Context, args []string) (int, string, error) {
 		remote = &rmt
 	}
 
-	remoteDB, err := sess.Provider().GetRemoteDB(ctx, dbData.Ddb.ValueReadWriter().Format(), *remote, true)
+	remoteDB, err := sess.Provider().GetRemoteDB(ctx, dbData.Ddb.ValueReadWriter().Format(), *remote)
 	if err != nil {
 		return cmdFailure, "", actions.HandleInitRemoteStorageClientErr(remote.Name, remote.Url, err)
 	}
+	defer remoteDB.Close()
 
 	err = remoteDB.Rebase(ctx)
 	if err != nil {

--- a/go/libraries/doltcore/sqle/dsess/dolt_session_test.go
+++ b/go/libraries/doltcore/sqle/dsess/dolt_session_test.go
@@ -296,7 +296,7 @@ func (e emptyRevisionDatabaseProvider) IsRevisionDatabase(_ *sql.Context, _ stri
 	return false, nil
 }
 
-func (e emptyRevisionDatabaseProvider) GetRemoteDB(ctx context.Context, format *types.NomsBinFormat, r env.Remote, withCaching bool) (*doltdb.DoltDB, error) {
+func (e emptyRevisionDatabaseProvider) GetRemoteDB(ctx context.Context, format *types.NomsBinFormat, r env.Remote) (*doltdb.DoltDB, error) {
 	return nil, nil
 }
 

--- a/go/libraries/doltcore/sqle/dsess/session_db_provider.go
+++ b/go/libraries/doltcore/sqle/dsess/session_db_provider.go
@@ -80,11 +80,16 @@ type DoltDatabaseProvider interface {
 	// of the requested database. If the requested database isn't found, a database not found error
 	// is returned.
 	FileSystemForDatabase(dbname string) (filesys.Filesys, error)
-	// GetRemoteDB returns the remote database for given env.Remote object using the local database's vrw, and
-	// withCaching defines whether the remoteDB gets cached or not.
-	// This function replaces env.Remote's GetRemoteDB method during SQL session to access dialer in order
-	// to get remote database associated to the env.Remote object.
-	GetRemoteDB(ctx context.Context, format *types.NomsBinFormat, r env.Remote, withCaching bool) (*doltdb.DoltDB, error)
+	// GetRemoteDB returns the remote database for the given env.Remote object using
+	// the local database's vrw. This function replaces env.Remote's GetRemoteDB
+	// method during SQL session to access dialer in order to get remote database
+	// associated to the env.Remote object.
+	//
+	// Callers are responsible for calling Close() exactly once on the returned
+	// *doltdb.DoltDB when they are done with it. Close() releases transport-level
+	// resources (e.g. SSH subprocesses, gRPC connections, file descriptors); not
+	// calling it, or calling it more than once, may leak resources or panic.
+	GetRemoteDB(ctx context.Context, format *types.NomsBinFormat, r env.Remote) (*doltdb.DoltDB, error)
 	// CloneDatabaseFromRemote clones the database from the specified remoteURL as a new database in this provider.
 	// dbName is the name for the new database, branch is an optional parameter indicating which branch to clone
 	// (otherwise all branches are cloned), remoteName is the name for the remote created in the new database, and

--- a/go/store/blobstore/git_blobstore.go
+++ b/go/store/blobstore/git_blobstore.go
@@ -386,6 +386,9 @@ type GitBlobstoreOptions struct {
 	// DOLT_REMOTE.md file after each successful data push. The value is the short
 	// branch name (e.g. "__dolt_remote_info__"). Overridden by DOLT_REMOTE_INFO_BRANCH env var.
 	InfoBranch string
+	// SyncForReadTTL overrides the read-side fetch dedup window. Zero means
+	// use defaultSyncForReadTTL.
+	SyncForReadTTL time.Duration
 }
 
 // NewGitBlobstoreWithOptions creates a GitBlobstore rooted at |gitDir| and |ref|.
@@ -412,6 +415,11 @@ func NewGitBlobstoreWithOptions(gitDir, ref string, opts GitBlobstoreOptions) (*
 
 	infoBranch := ResolveInfoBranch(opts.InfoBranch)
 
+	syncForReadTTL := opts.SyncForReadTTL
+	if syncForReadTTL == 0 {
+		syncForReadTTL = defaultSyncForReadTTL
+	}
+
 	return &GitBlobstore{
 		gitDir:            gitDir,
 		remoteRef:         remoteRef,
@@ -424,7 +432,7 @@ func NewGitBlobstoreWithOptions(gitDir, ref string, opts GitBlobstoreOptions) (*
 		maxPartSize:       opts.MaxPartSize,
 		cacheObjects:      make(map[string]cachedGitObject),
 		cacheChildren:     make(map[string][]git.TreeEntry),
-		syncForReadTTL:    defaultSyncForReadTTL,
+		syncForReadTTL:    syncForReadTTL,
 		infoBranch:        infoBranch,
 	}, nil
 }

--- a/integration-tests/bats/ssh-pid-leak.bats
+++ b/integration-tests/bats/ssh-pid-leak.bats
@@ -1,0 +1,158 @@
+#!/usr/bin/env bats
+load $BATS_TEST_DIRNAME/helper/common.bash
+load $BATS_TEST_DIRNAME/helper/query-server-common.bash
+load $BATS_TEST_DIRNAME/helper/git-ssh-common.bash
+
+# Regression tests for https://github.com/dolthub/dolt/issues/10897
+# Verifies that `dolt sql-server` does not leak ssh child processes
+# when CALL dolt_fetch / dolt_pull / dolt_push runs against an ssh://
+# remote. Each remote db must be closed at the end of the procedure,
+# tearing down the spawned ssh subprocess.
+
+setup() {
+    skiponwindows "ssh transport tests are not supported on Windows"
+    if ! command -v sshd >/dev/null 2>&1 && [[ ! -x /usr/sbin/sshd ]]; then
+        skip "sshd not available on this host"
+    fi
+
+    cd "$BATS_TEST_TMPDIR"
+
+    setup_git_sshd
+    gen_ssh_key "$BATS_TEST_TMPDIR/ssh_key" ""
+
+    export DOLT_SSH_COMMAND="ssh -i $BATS_TEST_TMPDIR/ssh_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+    export DOLT_SSH_EXEC_PATH="$(command -v dolt)"
+
+    mkdir "$BATS_TEST_TMPDIR/remote"
+    (
+        cd "$BATS_TEST_TMPDIR/remote"
+        dolt init
+    )
+
+    REMOTE_URL="ssh://$(whoami)@127.0.0.1:${SSHD_PORT}${BATS_TEST_TMPDIR}/remote"
+    export REMOTE_URL
+}
+
+teardown() {
+    stop_sql_server
+    teardown_git
+    unset DOLT_SSH_COMMAND DOLT_SSH_EXEC_PATH REMOTE_URL
+}
+
+count_ssh_kids() {
+    local parent="$1"
+    ps -eo pid,ppid,comm --no-headers 2>/dev/null \
+        | awk -v p="$parent" '$2==p && $3=="ssh"' \
+        | wc -l
+}
+
+# wait_for_no_ssh_kids polls count_ssh_kids until it reports 0 or a short
+# deadline elapses, returning the final count. Close() is synchronous from
+# the SQL caller's perspective but the kernel may take a brief moment to
+# fully reap the exited child.
+wait_for_no_ssh_kids() {
+    local parent="$1"
+    local i
+    for (( i = 0; i < 50; i++ )); do
+        local n
+        n="$(count_ssh_kids "$parent")"
+        if [ "$n" -eq 0 ]; then
+            echo 0
+            return
+        fi
+        sleep 0.1
+    done
+    count_ssh_kids "$parent"
+}
+
+@test "ssh-pid-leak: single fetch leaves no orphan ssh process" {
+    dolt clone "$REMOTE_URL" repo_local
+    cd repo_local
+    start_sql_server
+    server_pid="$SERVER_PID"
+
+    dolt --host=127.0.0.1 --port=$PORT --no-tls sql -q "use repo_local; call dolt_fetch('origin')"
+
+    remaining="$(wait_for_no_ssh_kids "$server_pid")"
+    [ "$remaining" -eq 0 ] || {
+        echo "expected 0 ssh subprocesses after fetch, got $remaining" >&2
+        ps -eo pid,ppid,stat,comm --no-headers | awk -v p="$server_pid" '$2==p' >&2
+        false
+    }
+}
+
+@test "ssh-pid-leak: 10 sequential fetches do not accumulate" {
+    dolt clone "$REMOTE_URL" repo_local
+    cd repo_local
+    start_sql_server
+    server_pid="$SERVER_PID"
+
+    for i in 1 2 3 4 5 6 7 8 9 10; do
+        dolt --host=127.0.0.1 --port=$PORT --no-tls sql -q "use repo_local; call dolt_fetch('origin')"
+    done
+
+    remaining="$(wait_for_no_ssh_kids "$server_pid")"
+    [ "$remaining" -eq 0 ] || {
+        echo "expected 0 ssh subprocesses after 10 fetches, got $remaining" >&2
+        false
+    }
+}
+
+@test "ssh-pid-leak: push leaves no orphan ssh process" {
+    dolt clone "$REMOTE_URL" repo_local
+    cd repo_local
+    dolt sql -q "create table t (id int primary key)"
+    dolt sql -q "call dolt_commit('-Am', 'add table')"
+    start_sql_server
+    server_pid="$SERVER_PID"
+
+    dolt --host=127.0.0.1 --port=$PORT --no-tls sql -q "use repo_local; call dolt_push('origin', 'main')"
+
+    remaining="$(wait_for_no_ssh_kids "$server_pid")"
+    [ "$remaining" -eq 0 ]
+}
+
+@test "ssh-pid-leak: pull leaves no orphan ssh process" {
+    dolt clone "$REMOTE_URL" repo_local
+    cd repo_local
+    start_sql_server
+    server_pid="$SERVER_PID"
+
+    dolt --host=127.0.0.1 --port=$PORT --no-tls sql -q "use repo_local; call dolt_pull('origin', 'main')"
+
+    remaining="$(wait_for_no_ssh_kids "$server_pid")"
+    [ "$remaining" -eq 0 ]
+}
+
+@test "ssh-pid-leak: mixed fetch+pull+push do not accumulate" {
+    dolt clone "$REMOTE_URL" repo_local
+    cd repo_local
+    start_sql_server
+    server_pid="$SERVER_PID"
+
+    dolt --host=127.0.0.1 --port=$PORT --no-tls sql -q "use repo_local; call dolt_fetch('origin')"
+    dolt --host=127.0.0.1 --port=$PORT --no-tls sql -q "use repo_local; call dolt_pull('origin', 'main')"
+    dolt --host=127.0.0.1 --port=$PORT --no-tls sql -q "use repo_local; create table t (id int primary key); call dolt_commit('-Am', 'add table');"
+    dolt --host=127.0.0.1 --port=$PORT --no-tls sql -q "use repo_local; call dolt_push('origin', 'main')"
+    dolt --host=127.0.0.1 --port=$PORT --no-tls sql -q "use repo_local; call dolt_fetch('origin')"
+
+    remaining="$(wait_for_no_ssh_kids "$server_pid")"
+    [ "$remaining" -eq 0 ]
+}
+
+@test "ssh-pid-leak: concurrent fetches all clean up" {
+    dolt clone "$REMOTE_URL" repo_local
+    cd repo_local
+    start_sql_server
+    server_pid="$SERVER_PID"
+
+    pids=()
+    for i in 1 2 3 4 5; do
+        dolt --host=127.0.0.1 --port=$PORT --no-tls sql -q "use repo_local; call dolt_fetch('origin')" &
+        pids+=($!)
+    done
+    for p in "${pids[@]}"; do wait $p; done
+
+    remaining="$(wait_for_no_ssh_kids "$server_pid")"
+    [ "$remaining" -eq 0 ]
+}


### PR DESCRIPTION
SSH subprocesses created by `sql-server` instances were failing to clean up because the `Close()` method was never being called. This was the result of some caching done by GetRemoteDB in the sqle package. Most of this change is to remove `sqle.DoltDatabaseProvider.GetRemoteDB()` caching, allowing for push/pull operations to safely Close() remote databases after use. Thus, preventing the PID leak in the associated issue (#10897)

Git remote database singletons are a special case. Previously the `push` operation only would cache these instances - which are expensive to create initially since they need to perform git operations to get in sync with the remote. There is no reason go Close() them though, so we keep a singleton for the duration of the `sql-server` process.

Fixes: https://github.com/dolthub/dolt/issues/10897