### PR TITLE
Let merge-permission users write through dolt_conflicts_<t>

### DIFF
--- a/go/libraries/doltcore/sqle/dprocedures/dolt_conflicts_resolve.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_conflicts_resolve.go
@@ -22,7 +22,6 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
-	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
@@ -375,7 +374,7 @@ func ResolveDataConflicts(ctx *sql.Context, dSess *dsess.DoltSession, root doltd
 }
 
 func DoDoltConflictsResolve(ctx *sql.Context, args []string) (int, error) {
-	if err := branch_control.CheckAccess(ctx, branch_control.Permissions_Write); err != nil {
+	if err := dsess.CheckAccessOrMergeActive(ctx); err != nil {
 		return 1, err
 	}
 	dbName := ctx.GetCurrentDatabase()

--- a/go/libraries/doltcore/sqle/dsess/branch_control.go
+++ b/go/libraries/doltcore/sqle/dsess/branch_control.go
@@ -17,6 +17,8 @@ package dsess
 import (
 	"context"
 
+	"github.com/dolthub/go-mysql-server/sql"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 )
@@ -55,6 +57,49 @@ func CheckAccessForDb(ctx context.Context, db SqlDatabase, flags branch_control.
 	// If either the flags match or the user is an admin for this branch, then we allow access
 	if (perms&flags == flags) || (perms&branch_control.Permissions_Admin == branch_control.Permissions_Admin) {
 		return nil
+	}
+	return branch_control.ErrIncorrectPermissions.New(user, host, branch)
+}
+
+// CheckAccessOrMergeActive returns nil when the caller has Permissions_Write
+// on the current branch, or has Permissions_Merge AND the working set has an
+// active merge AND the working root contains data conflicts. Otherwise it
+// returns the access-denied error from the more specific check.
+//
+// Used by procedures (e.g., DOLT_CONFLICTS_RESOLVE) that should be reachable
+// by merge-permission callers only when there is actually a merge with data
+// conflicts to resolve. Mirrors the rule used by conflicts-table writes.
+func CheckAccessOrMergeActive(ctx *sql.Context) error {
+	if err := branch_control.CheckAccess(ctx, branch_control.Permissions_Write); err == nil {
+		return nil
+	}
+	if err := branch_control.CheckAccess(ctx, branch_control.Permissions_Merge); err != nil {
+		return err
+	}
+	dbName := ctx.GetCurrentDatabase()
+	ws, err := DSessFromSess(ctx.Session).WorkingSet(ctx, dbName)
+	if err != nil {
+		return err
+	}
+	if !ws.MergeActive() {
+		return mergePermDenied(ctx)
+	}
+	hasConflicts, err := doltdb.HasConflicts(ctx, ws.WorkingRoot())
+	if err != nil {
+		return err
+	}
+	if !hasConflicts {
+		return mergePermDenied(ctx)
+	}
+	return nil
+}
+
+func mergePermDenied(ctx *sql.Context) error {
+	bas := branch_control.GetBranchAwareSession(ctx)
+	var user, host, branch string
+	if bas != nil {
+		user, host = bas.GetUser(), bas.GetHost()
+		branch, _ = bas.GetBranch()
 	}
 	return branch_control.ErrIncorrectPermissions.New(user, host, branch)
 }

--- a/go/libraries/doltcore/sqle/dsess/conflicts_bypass.go
+++ b/go/libraries/doltcore/sqle/dsess/conflicts_bypass.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dsess
+
+import (
+	"context"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+)
+
+// ConflictsBypassMarker propagates an already-validated decision to admit a
+// merge-permission caller into the source-table writer that the conflicts
+// table's Updater delegates to. The marker is set on the context only during
+// source-table writer construction inside prollyConflictOurTableUpdater.
+//
+// The source-table Updater factory checks for the marker and, if it matches
+// the table being constructed, skips its own Permissions_Write check. The
+// match is keyed on (db, branch, table) so the marker cannot be used to
+// bypass writes on a different table.
+type ConflictsBypassMarker struct {
+	DbName  string
+	Branch  string
+	TblName doltdb.TableName
+}
+
+type conflictsBypassKeyT struct{}
+
+var conflictsBypassKey conflictsBypassKeyT
+
+// WithConflictsBypass returns a derived context carrying the given bypass
+// marker. Callers should pass this context to the source-table writer
+// factory and discard it immediately after — the marker is intentionally
+// scoped to the factory call.
+func WithConflictsBypass(ctx context.Context, m ConflictsBypassMarker) context.Context {
+	return context.WithValue(ctx, conflictsBypassKey, m)
+}
+
+// ConflictsBypassFor reports whether the context carries a bypass marker
+// matching the given (db, branch, table). Mismatched contexts return false
+// so a marker for table t1 cannot be reused to write to t2.
+func ConflictsBypassFor(ctx context.Context, dbName, branch string, tblName doltdb.TableName) bool {
+	m, ok := ctx.Value(conflictsBypassKey).(ConflictsBypassMarker)
+	if !ok {
+		return false
+	}
+	return m.DbName == dbName && m.Branch == branch && m.TblName == tblName
+}

--- a/go/libraries/doltcore/sqle/dtables/conflicts_table_access.go
+++ b/go/libraries/doltcore/sqle/dtables/conflicts_table_access.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dtables
+
+import (
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
+	"github.com/dolthub/dolt/go/store/prolly"
+)
+
+// checkConflictsTableWriteAccess gates writes that flow through a
+// dolt_conflicts_<t> system table. Allowed when:
+//
+//   - the caller has Permissions_Write on the branch, OR
+//   - the caller has Permissions_Merge AND the working set has an active
+//     merge AND the artifact map contains data conflicts.
+//
+// The merge-permission carve-out exists so that PR reviewers with only
+// merge access can resolve a merge that produced conflicts.
+func checkConflictsTableWriteAccess(ctx *sql.Context, db dsess.SqlDatabase, artM prolly.ArtifactMap) error {
+	if err := dsess.CheckAccessForDb(ctx, db, branch_control.Permissions_Write); err == nil {
+		return nil
+	}
+	if err := dsess.CheckAccessForDb(ctx, db, branch_control.Permissions_Merge); err != nil {
+		return err
+	}
+
+	dSess := dsess.DSessFromSess(ctx.Session)
+	dbName, branch := doltdb.SplitRevisionDbName(db.RevisionQualifiedName())
+	ws, err := dSess.WorkingSet(ctx, dbName)
+	if err != nil {
+		return err
+	}
+	if !ws.MergeActive() {
+		return incorrectPermsErr(ctx, branch)
+	}
+	hasConflicts, err := artM.HasArtifactOfType(ctx, prolly.ArtifactTypeConflict)
+	if err != nil {
+		return err
+	}
+	if !hasConflicts {
+		return incorrectPermsErr(ctx, branch)
+	}
+	return nil
+}
+
+func incorrectPermsErr(ctx *sql.Context, branch string) error {
+	if bas := branch_control.GetBranchAwareSession(ctx); bas != nil {
+		return branch_control.ErrIncorrectPermissions.New(bas.GetUser(), bas.GetHost(), branch)
+	}
+	return branch_control.ErrIncorrectPermissions.New("", "", branch)
+}

--- a/go/libraries/doltcore/sqle/dtables/conflicts_tables_prolly.go
+++ b/go/libraries/doltcore/sqle/dtables/conflicts_tables_prolly.go
@@ -21,7 +21,6 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/zeebo/xxh3"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/durable"
 	"github.com/dolthub/dolt/go/libraries/doltcore/merge"
@@ -127,11 +126,14 @@ func (ct ProllyConflictsTable) PartitionRows(ctx *sql.Context, part sql.Partitio
 }
 
 func (ct ProllyConflictsTable) Updater(ctx *sql.Context) sql.RowUpdater {
+	if err := checkConflictsTableWriteAccess(ctx, ct.db, ct.artM); err != nil {
+		return sqlutil.NewStaticErrorEditor(err)
+	}
 	return newProllyConflictOurTableUpdater(ctx, ct)
 }
 
 func (ct ProllyConflictsTable) Deleter(ctx *sql.Context) sql.RowDeleter {
-	if err := dsess.CheckAccessForDb(ctx, ct.db, branch_control.Permissions_Write); err != nil {
+	if err := checkConflictsTableWriteAccess(ctx, ct.db, ct.artM); err != nil {
 		return sqlutil.NewStaticErrorEditor(err)
 	}
 	return newProllyConflictDeleter(ctx, ct)
@@ -560,7 +562,17 @@ type prollyConflictOurTableUpdater struct {
 }
 
 func newProllyConflictOurTableUpdater(ctx *sql.Context, ct ProllyConflictsTable) *prollyConflictOurTableUpdater {
-	ourUpdater := ct.sqlTable.Updater(ctx)
+	// Set a bypass marker on the context for the duration of the source-table
+	// writer construction. The conflicts-table Updater already admitted the
+	// caller via checkConflictsTableWriteAccess; without this marker the inner
+	// source-table Updater factory would reject a merge-permission caller.
+	dbName, branch := doltdb.SplitRevisionDbName(ct.db.RevisionQualifiedName())
+	markedCtx := ctx.WithContext(dsess.WithConflictsBypass(ctx.Context, dsess.ConflictsBypassMarker{
+		DbName:  dbName,
+		Branch:  branch,
+		TblName: ct.tblName,
+	}))
+	ourUpdater := ct.sqlTable.Updater(markedCtx)
 	return &prollyConflictOurTableUpdater{
 		srcUpdater:      ourUpdater,
 		versionMappings: ct.versionMappings,

--- a/go/libraries/doltcore/sqle/enginetest/branch_control_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/branch_control_test.go
@@ -1674,25 +1674,155 @@ var BranchControlTests = []BranchControlTest{
 				Query:    "SELECT count(*) FROM dolt_conflicts;",
 				Expected: []sql.Row{{int64(1)}},
 			},
+			// Merge permission lets the user edit conflicted rows via
+			// dolt_conflicts_<t> and resolve them.
+			{
+				User:     "testuser",
+				Host:     "localhost",
+				Query:    "UPDATE dolt_conflicts_test SET our_v1 = 50 WHERE our_pk = 1;",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, Info: plan.UpdateInfo{Matched: 1, Updated: 1}}}},
+			},
+			// The UPDATE on the conflicts table writes through to the source
+			// table.
+			{
+				User:     "testuser",
+				Host:     "localhost",
+				Query:    "SELECT v1 FROM test WHERE pk = 1;",
+				Expected: []sql.Row{{int64(50)}},
+			},
+			// DOLT_CONFLICTS_RESOLVE clears the conflict marker.
+			{
+				User:     "testuser",
+				Host:     "localhost",
+				Query:    "CALL DOLT_CONFLICTS_RESOLVE('--ours', 'test');",
+				Expected: []sql.Row{{0}},
+			},
+			{
+				User:     "testuser",
+				Host:     "localhost",
+				Query:    "SELECT count(*) FROM dolt_conflicts;",
+				Expected: []sql.Row{{int64(0)}},
+			},
+			// And the merge-only user can finalize the merge.
+			{
+				User:     "testuser",
+				Host:     "localhost",
+				Query:    "CALL DOLT_COMMIT('-am', 'resolved');",
+				Expected: []sql.Row{{doltCommit}},
+			},
+			// Writes to the source table directly remain rejected — only the
+			// dolt_conflicts_<t> path is open to merge-permission callers.
+			{
+				User:        "testuser",
+				Host:        "localhost",
+				Query:       "UPDATE test SET v1 = 100 WHERE pk = 1;",
+				ExpectedErr: branch_control.ErrIncorrectPermissions,
+			},
+		},
+	},
+	{
+		Name: "Merge permission allows DELETE from dolt_conflicts_<t> to resolve conflicts",
+		SetUpScript: []string{
+			"DELETE FROM dolt_branch_control WHERE user = '%';",
+			"INSERT INTO dolt_branch_control VALUES ('%', '%', 'root', 'localhost', 'admin');",
+			"CREATE USER testuser@localhost;",
+			"GRANT ALL ON *.* TO testuser@localhost;",
+			"REVOKE SUPER ON *.* FROM testuser@localhost;",
+			"CREATE TABLE test (pk BIGINT PRIMARY KEY, v1 BIGINT);",
+			"INSERT INTO test VALUES (1, 1);",
+			"CALL DOLT_ADD('-A');",
+			"CALL DOLT_COMMIT('-m', 'initial commit');",
+			"CALL DOLT_BRANCH('other');",
+			"CALL DOLT_CHECKOUT('other');",
+			"UPDATE test SET v1 = 100 WHERE pk = 1;",
+			"CALL DOLT_ADD('-A');",
+			"CALL DOLT_COMMIT('-m', 'commit on other');",
+			"CALL DOLT_CHECKOUT('main');",
+			"UPDATE test SET v1 = 200 WHERE pk = 1;",
+			"CALL DOLT_ADD('-A');",
+			"CALL DOLT_COMMIT('-m', 'commit on main');",
+			"INSERT INTO dolt_branch_control VALUES ('%', 'other', 'testuser', 'localhost', 'merge');",
+		},
+		Assertions: []BranchControlTestAssertion{
+			{
+				User:     "testuser",
+				Host:     "localhost",
+				Query:    "CALL DOLT_CHECKOUT('other');",
+				Expected: []sql.Row{{0, "Switched to branch 'other'"}},
+			},
+			{
+				User:     "testuser",
+				Host:     "localhost",
+				Query:    "SET @@dolt_allow_commit_conflicts = 1;",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				User:     "testuser",
+				Host:     "localhost",
+				Query:    "CALL DOLT_MERGE('main');",
+				Expected: []sql.Row{{"", 0, 1, "conflicts found"}},
+			},
+			// Merge-only user can DELETE the conflict row directly. This keeps
+			// "our" values on the underlying table.
+			{
+				User:     "testuser",
+				Host:     "localhost",
+				Query:    "DELETE FROM dolt_conflicts_test;",
+				Expected: []sql.Row{{types.NewOkResult(1)}},
+			},
+			{
+				User:     "testuser",
+				Host:     "localhost",
+				Query:    "SELECT count(*) FROM dolt_conflicts;",
+				Expected: []sql.Row{{int64(0)}},
+			},
+			{
+				User:     "testuser",
+				Host:     "localhost",
+				Query:    "SELECT v1 FROM test WHERE pk = 1;",
+				Expected: []sql.Row{{int64(100)}},
+			},
+		},
+	},
+	{
+		Name: "Merge permission does not allow conflicts writes outside an active merge",
+		SetUpScript: []string{
+			"DELETE FROM dolt_branch_control WHERE user = '%';",
+			"INSERT INTO dolt_branch_control VALUES ('%', '%', 'root', 'localhost', 'admin');",
+			"CREATE USER testuser@localhost;",
+			"GRANT ALL ON *.* TO testuser@localhost;",
+			"REVOKE SUPER ON *.* FROM testuser@localhost;",
+			"CREATE TABLE test (pk BIGINT PRIMARY KEY, v1 BIGINT);",
+			"INSERT INTO test VALUES (1, 1);",
+			"CALL DOLT_ADD('-A');",
+			"CALL DOLT_COMMIT('-m', 'initial commit');",
+			"CALL DOLT_BRANCH('other');",
+			"INSERT INTO dolt_branch_control VALUES ('%', 'other', 'testuser', 'localhost', 'merge');",
+		},
+		Assertions: []BranchControlTestAssertion{
+			{
+				User:     "testuser",
+				Host:     "localhost",
+				Query:    "CALL DOLT_CHECKOUT('other');",
+				Expected: []sql.Row{{0, "Switched to branch 'other'"}},
+			},
+			// No merge is in flight, so the merge-only user cannot resolve
+			// conflicts via the procedure. (Direct UPDATE/DELETE on
+			// dolt_conflicts_<t> match zero rows when there are no conflicts,
+			// so they short-circuit before the writer factory's error
+			// surfaces — that's the same behavior as a no-op DELETE on a
+			// regular table under the existing WritableDoltTable gate.)
 			{
 				User:        "testuser",
 				Host:        "localhost",
 				Query:       "CALL DOLT_CONFLICTS_RESOLVE('--ours', 'test');",
 				ExpectedErr: branch_control.ErrIncorrectPermissions,
 			},
-			// Merge permission alone does not allow direct writes to the conflicts table.
-			// DELETE is gated explicitly in ProllyConflictsTable.Deleter; UPDATE inherits the
-			// gate via the source-table updater that prollyConflictOurTableUpdater wraps.
+			// Direct writes to the source table remain rejected.
 			{
 				User:        "testuser",
 				Host:        "localhost",
-				Query:       "DELETE FROM dolt_conflicts_test;",
-				ExpectedErr: branch_control.ErrIncorrectPermissions,
-			},
-			{
-				User:        "testuser",
-				Host:        "localhost",
-				Query:       "UPDATE dolt_conflicts_test SET our_v1 = 999 WHERE our_pk = 1;",
+				Query:       "INSERT INTO test VALUES (2, 2);",
 				ExpectedErr: branch_control.ErrIncorrectPermissions,
 			},
 		},

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -1109,7 +1109,15 @@ func copyConstraintViolationsAndConflicts(ctx context.Context, from, to *doltdb.
 // Updater implements sql.UpdatableTable
 func (t *WritableDoltTable) Updater(ctx *sql.Context) sql.RowUpdater {
 	if err := dsess.CheckAccessForDb(ctx, t.db, branch_control.Permissions_Write); err != nil {
-		return sqlutil.NewStaticErrorEditor(err)
+		// A conflicts-table writer delegating into this source-table writer
+		// will set a bypass marker on the context after admitting the caller
+		// through its own check. Honor that marker so a merge-permission
+		// caller is not rejected here. The marker is keyed by (db, branch,
+		// table), so a marker for a different table will not match.
+		dbName, branch := doltdb.SplitRevisionDbName(t.db.RevisionQualifiedName())
+		if !dsess.ConflictsBypassFor(ctx, dbName, branch, t.TableName()) {
+			return sqlutil.NewStaticErrorEditor(err)
+		}
 	}
 	te, err := t.getTableEditor(ctx)
 	if err != nil {


### PR DESCRIPTION
## Summary

Stacks on top of #11030. Adds a branch-control carve-out so a user with only `Permissions_Merge` on a branch can resolve a merge that produced data conflicts by writing through `dolt_conflicts_<t>` and via `DOLT_CONFLICTS_RESOLVE`. Lets a PR reviewer on the SQL workbench finish a conflicting merge without being granted full write access on the target branch.

Admission rule applied at every entry point — **Write, OR (Merge AND MergeActive AND data conflicts exist)**:

- `ProllyConflictsTable.Updater` (`dtables/conflicts_tables_prolly.go`) — new gate via `checkConflictsTableWriteAccess`.
- `ProllyConflictsTable.Deleter` (same file) — replaces the bare `Write` gate from #11030 with the same helper.
- `DoDoltConflictsResolve` (`dprocedures/dolt_conflicts_resolve.go`) — new `dsess.CheckAccessOrMergeActive` helper; "data conflicts exist" scoped to the working root.

The `Updater` path's source-table `srcUpdater` is constructed eagerly inside `newProllyConflictOurTableUpdater`, so a merge-permission caller admitted at the outer gate would otherwise be rejected by the inner `WritableDoltTable.Updater` Write check. To bridge that delegation chain:

- New `dsess.ConflictsBypassMarker` keyed on `(db, branch, table)`. `prollyConflictOurTableUpdater` sets it on a derived context just for the source-table writer factory call.
- `WritableDoltTable.Updater` honors the marker as a Write-check bypass **only when** it matches the target table. A marker for `t1` cannot leak into a write on `t2`.

## Test plan

- [x] Extended `"Merge permission allows merge with conflicts"` (`branch_control_test.go`) with the full positive workflow: merge-only user runs `UPDATE dolt_conflicts_test` (write goes through to source table), `CALL DOLT_CONFLICTS_RESOLVE`, `CALL DOLT_COMMIT`. Source-table direct writes remain rejected.
- [x] New `"Merge permission allows DELETE from dolt_conflicts_<t> to resolve conflicts"` — exercises the DELETE path end-to-end.
- [x] New `"Merge permission does not allow conflicts writes outside an active merge"` — without an active merge, even a merge-permission user is rejected by `DOLT_CONFLICTS_RESOLVE` and by direct source-table writes.
- [x] `go test ./libraries/doltcore/sqle/enginetest/ -run "TestBranchControl"` passes.
- [x] `go vet ./libraries/doltcore/sqle/...` clean.

## Known limitation

When a merge-only user runs `UPDATE`/`DELETE` on `dolt_conflicts_<t>` with **zero matching rows** (e.g., empty conflicts table outside an active merge), the engine never invokes the writer's per-row methods, so the static error from the factory's permission check never surfaces. This is the same property that affects every `WritableDoltTable` write check — consistent with existing Dolt behavior. The negative test asserts via `DOLT_CONFLICTS_RESOLVE` and a direct source-table write instead, both of which run the gate regardless of matching-row count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)