### PR TITLE
fix dolt push hanging on ssh askpass credential prompts

### DIFF
--- a/go/libraries/doltcore/dbfactory/git_remote.go
+++ b/go/libraries/doltcore/dbfactory/git_remote.go
@@ -377,15 +377,18 @@ func isGitRemoteAlreadyExistsError(err error, remoteName string) bool {
 	return strings.Contains(s, "remote "+strings.ToLower(remoteName)+" already exists")
 }
 
-// gitCmd builds an exec.Cmd for a git invocation. LC_ALL=C forces English error
-// messages; CmdSetsid removes the controlling terminal so SSH cannot prompt.
+// gitCmd builds an exec.Cmd for a git invocation under |ctx| with |args|. The
+// environment is filtered through [gitauth.NonInteractiveEnv] so SSH and git
+// cannot fall back to a GUI credential helper, LC_ALL is forced to C so error
+// messages parse the same in every locale, and [gitauth.CmdSetsid] removes
+// the controlling terminal so SSH cannot prompt on it.
 func gitCmd(ctx context.Context, args ...string) (*exec.Cmd, error) {
 	p, err := exec.LookPath("git")
 	if err != nil {
 		return nil, fmt.Errorf("git not found on PATH: %w", err)
 	}
 	cmd := exec.CommandContext(ctx, p, args...) //nolint:gosec // controlled args
-	cmd.Env = append(os.Environ(), "LC_ALL=C")
+	cmd.Env = append(gitauth.NonInteractiveEnv(os.Environ()), "LC_ALL=C")
 	gitauth.CmdSetsid(cmd)
 	return cmd, nil
 }

--- a/go/libraries/utils/gitauth/env.go
+++ b/go/libraries/utils/gitauth/env.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package gitauth keeps git and ssh subprocesses spawned by dolt from
+// prompting for credentials. It builds environments with every interactive
+// prompt disabled, detaches subprocesses from the controlling terminal, and
+// rewrites the resulting authentication failures into actionable errors.
+package gitauth
+
+import (
+	"maps"
+	"slices"
+	"strings"
+)
+
+// nonInteractiveOverrides lists the env entries that disable every interactive
+// credential prompt reachable through git and ssh. See [SSH_ASKPASS_REQUIRE],
+// [gitcredentials], and [Git Credential Manager].
+//
+// [SSH_ASKPASS_REQUIRE]: https://man.openbsd.org/ssh#SSH_ASKPASS_REQUIRE
+// [gitcredentials]: https://git-scm.com/docs/gitcredentials
+// [Git Credential Manager]: https://github.com/git-ecosystem/git-credential-manager
+var nonInteractiveOverrides = map[string]string{
+	"SSH_ASKPASS_REQUIRE": "never",
+	"SSH_ASKPASS":         "",
+	"GIT_ASKPASS":         "",
+	"GIT_TERMINAL_PROMPT": "0",
+	"GCM_INTERACTIVE":     "Never",
+}
+
+// NonInteractiveEnv returns a copy of |env| with every interactive credential
+// prompt from git and ssh disabled. Entries in |env| whose keys conflict with
+// the overrides are removed so the result is correct regardless of operating
+// system environment deduplication semantics. Overrides are appended in
+// sorted key order so the result is reproducible.
+func NonInteractiveEnv(env []string) []string {
+	out := make([]string, 0, len(env)+len(nonInteractiveOverrides))
+	for _, e := range env {
+		key, _, _ := strings.Cut(e, "=")
+		if _, ok := nonInteractiveOverrides[key]; ok {
+			continue
+		}
+		out = append(out, e)
+	}
+	for _, k := range slices.Sorted(maps.Keys(nonInteractiveOverrides)) {
+		out = append(out, k+"="+nonInteractiveOverrides[k])
+	}
+	return out
+}

--- a/go/libraries/utils/gitauth/env_test.go
+++ b/go/libraries/utils/gitauth/env_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitauth
+
+import (
+	"slices"
+	"testing"
+)
+
+// sortedOverrides is the tail NonInteractiveEnv appends to every result.
+var sortedOverrides = []string{
+	"GCM_INTERACTIVE=Never",
+	"GIT_ASKPASS=",
+	"GIT_TERMINAL_PROMPT=0",
+	"SSH_ASKPASS=",
+	"SSH_ASKPASS_REQUIRE=never",
+}
+
+func TestNonInteractiveEnv(t *testing.T) {
+	// See https://github.com/dolthub/dolt/issues/11027.
+	cases := []struct {
+		name string
+		env  []string
+		want []string
+	}{
+		{
+			name: "nil env yields only overrides",
+			env:  nil,
+			want: sortedOverrides,
+		},
+		{
+			name: "unrelated entries preserved in order",
+			env:  []string{"PATH=/usr/bin", "HOME=/home/u"},
+			want: append([]string{"PATH=/usr/bin", "HOME=/home/u"}, sortedOverrides...),
+		},
+		{
+			name: "conflicting keys removed not shadowed",
+			env:  []string{"SSH_ASKPASS=/usr/bin/x11-askpass", "GIT_TERMINAL_PROMPT=1", "PATH=/usr/bin"},
+			want: append([]string{"PATH=/usr/bin"}, sortedOverrides...),
+		},
+		{
+			name: "bare key without equals matching an override is dropped",
+			env:  []string{"SSH_ASKPASS", "PATH=/usr/bin"},
+			want: append([]string{"PATH=/usr/bin"}, sortedOverrides...),
+		},
+		{
+			// Windows stores per drive working directories in env entries
+			// whose names begin with an equals sign. Stripping them would
+			// break the child process so they must pass through.
+			name: "empty entry and leading equals entry are kept",
+			env:  []string{"", "=C:=C:\\Windows"},
+			want: append([]string{"", "=C:=C:\\Windows"}, sortedOverrides...),
+		},
+		{
+			name: "value containing equals does not confuse key match",
+			env:  []string{"GIT_SSH_COMMAND=ssh -o ProxyCommand=nc %h %p"},
+			want: append([]string{"GIT_SSH_COMMAND=ssh -o ProxyCommand=nc %h %p"}, sortedOverrides...),
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			in := slices.Clone(tt.env)
+			got := NonInteractiveEnv(tt.env)
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("NonInteractiveEnv(%q) = %q, want %q", tt.env, got, tt.want)
+			}
+			if !slices.Equal(tt.env, in) {
+				t.Fatalf("input mutated: %q, want %q", tt.env, in)
+			}
+		})
+	}
+}

--- a/go/store/blobstore/internal/git/runner.go
+++ b/go/store/blobstore/internal/git/runner.go
@@ -239,7 +239,7 @@ func (c *cmdReadCloser) Close() error {
 }
 
 func (r *Runner) env(opts RunOptions) []string {
-	env := append([]string(nil), os.Environ()...)
+	env := gitauth.NonInteractiveEnv(os.Environ())
 	env = append(env, "GIT_DIR="+r.gitDir)
 	// Force English output so error-message parsing (e.g. isRemoteRefNotFoundErr)
 	// works regardless of the user's locale.

--- a/integration-tests/bats/helper/git-ssh-common.bash
+++ b/integration-tests/bats/helper/git-ssh-common.bash
@@ -9,12 +9,18 @@ load "$BATS_TEST_DIRNAME/helper/query-server-common.bash"
 #   GIT_SVC_DIR   path to the bare repository
 #   GIT_SVC_HOOKS_DIR  directory sourced before each wrapper invocation
 #   SSHD_PORT     TCP port the real sshd listens on (set by setup_git_sshd)
+#   SSH_ASKPASS_SCRIPT  path to the recording askpass script (set by setup_git_ssh_askpass_recorder)
+#   SSH_ASKPASS_MARKER  file the recording askpass script writes when invoked
+#   SSH_SHIM_DIR  directory holding the ssh shim (set by setup_git_ssh_path_shim)
 GIT_SVC_DIR=""
 GIT_SVC_WRAPPER=""
 GIT_SVC_HOOKS_DIR=""
 SSHD_DIR=""
 SSHD_PID=""
 SSHD_PORT=""
+SSH_ASKPASS_SCRIPT=""
+SSH_ASKPASS_MARKER=""
+SSH_SHIM_DIR=""
 
 # setup_git_repo initializes a bare git repository seeded with one commit on main.
 setup_git_repo() {
@@ -129,19 +135,66 @@ gen_ssh_key() {
     cat "${keypath}.pub" >> "$SSHD_DIR/authorized_keys"
 }
 
+# setup_git_ssh_askpass_recorder installs an SSH_ASKPASS program that writes
+# the prompt it received to SSH_ASKPASS_MARKER and exits nonzero so ssh
+# aborts instead of blocking. Tests assert on the marker to prove whether an
+# askpass prompt was raised. The script sheds the inherited stderr and bats
+# pipe descriptors so it cannot delay output capture.
+setup_git_ssh_askpass_recorder() {
+    SSH_ASKPASS_SCRIPT="$(mktemp "$BATS_TMPDIR/askpass-recorder.XXXXXX")"
+    SSH_ASKPASS_MARKER="$(mktemp -u "$BATS_TMPDIR/askpass-invoked.XXXXXX")"
+    cat > "$SSH_ASKPASS_SCRIPT" <<RECORD
+#!/usr/bin/env bash
+exec 2>/dev/null 3>&-
+printf '%s' "\$*" > "$SSH_ASKPASS_MARKER"
+exit 1
+RECORD
+    chmod +x "$SSH_ASKPASS_SCRIPT"
+    export SSH_ASKPASS="$SSH_ASKPASS_SCRIPT"
+    # ssh only launches an askpass program when DISPLAY is set.
+    export DISPLAY=":99"
+}
+
+# setup_git_ssh_path_shim places an ssh shim ahead of the real ssh on PATH
+# that injects the key and host options the test sshd needs. git resolves
+# its default transport by searching PATH for ssh, so tests can reach the
+# sshd with no GIT_SSH_COMMAND set. A scratch config file cannot do this
+# because ssh reads its config from the password database home directory,
+# not the HOME env var.
+# Arguments:
+#   $1  path to the private key the shim passes to ssh
+setup_git_ssh_path_shim() {
+    local keypath="$1"
+    local real_ssh
+    real_ssh="$(command -v ssh)"
+    SSH_SHIM_DIR="$(mktemp -d "$BATS_TMPDIR/ssh-shim.XXXXXX")"
+    cat > "$SSH_SHIM_DIR/ssh" <<SHIM
+#!/usr/bin/env bash
+exec "$real_ssh" -i "$keypath" -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "\$@"
+SHIM
+    chmod +x "$SSH_SHIM_DIR/ssh"
+    export PATH="$SSH_SHIM_DIR:$PATH"
+}
+
 # teardown_git removes all resources created by the setup_git_* functions.
 # Safe to call even when only some setup functions were called.
 teardown_git() {
-    unset GIT_SSH_COMMAND GIT_SVC_HOOKS_DIR SSH_AUTH_SOCK
+    unset GIT_SSH_COMMAND GIT_SVC_HOOKS_DIR SSH_AUTH_SOCK SSH_ASKPASS
 
     [[ -n "$GIT_SVC_DIR" ]]       && rm -rf "${GIT_SVC_DIR%/*}"
     [[ -n "$GIT_SVC_WRAPPER" ]]   && rm -f  "$GIT_SVC_WRAPPER"
     [[ -n "$GIT_SVC_HOOKS_DIR" ]] && rm -rf "$GIT_SVC_HOOKS_DIR"
+    [[ -n "$SSH_ASKPASS_SCRIPT" ]] && rm -f "$SSH_ASKPASS_SCRIPT"
+    [[ -n "$SSH_ASKPASS_MARKER" ]] && rm -f "$SSH_ASKPASS_MARKER"
+    [[ -n "$SSH_SHIM_DIR" ]]       && rm -rf "$SSH_SHIM_DIR"
     rm -f "$BATS_TMPDIR"/git_env_*
 
     GIT_SVC_DIR=""
     GIT_SVC_WRAPPER=""
     GIT_SVC_HOOKS_DIR=""
+    SSH_ASKPASS_SCRIPT=""
+    SSH_ASKPASS_MARKER=""
+    SSH_SHIM_DIR=""
 
     if [[ -n "${SSHD_PID:-}" ]]; then
         kill "$SSHD_PID" 2>/dev/null || true

--- a/integration-tests/bats/remotes-git.bats
+++ b/integration-tests/bats/remotes-git.bats
@@ -604,6 +604,10 @@ _init_repo_with_remote() {
     run dolt push origin main
     [ "$status" -eq 0 ]
     [ -f "$BATS_TMPDIR/git_env_GIT_SSH_COMMAND" ]
+    # Byte equality catches a dolt that appends, prepends, or rewrites the
+    # user's GIT_SSH_COMMAND.
+    recorded="$(cat "$BATS_TMPDIR/git_env_GIT_SSH_COMMAND")"
+    [ "$recorded" = "$GIT_SVC_WRAPPER" ] || (echo "recorded GIT_SSH_COMMAND: $recorded, expected: $GIT_SVC_WRAPPER" >&2; false)
 }
 
 # bats test_tags=no_lambda

--- a/integration-tests/bats/remotes-git.bats
+++ b/integration-tests/bats/remotes-git.bats
@@ -675,6 +675,42 @@ _setup_askpass_probe() {
     unset GIT_SSH_COMMAND GIT_SSH SSH_AUTH_SOCK SSH_AGENT_PID SSH_ASKPASS_REQUIRE
 }
 
+# _push_fails_without_askpass pushes with a backstop timeout and asserts dolt
+# failed on ssh auth without the askpass recorder firing.
+_push_fails_without_askpass() {
+    run timeout -k 5 15 dolt push origin main 3>&-
+    [ ! -f "$SSH_ASKPASS_MARKER" ] || (echo "askpass invoked with: $(cat "$SSH_ASKPASS_MARKER")" >&2; false)
+    [ "$status" -ne 0 ]
+    # The hint proves the push failed on ssh auth rather than unrelated
+    # breakage such as a port collision or a timeout kill.
+    [[ "$output" =~ "hint: dolt does not support interactive credential prompts" ]] || false
+}
+
+# bats test_tags=no_lambda
+@test "remotes-git: ssh push does not invoke the SSH_ASKPASS program" {
+    # See https://github.com/dolthub/dolt/issues/11027.
+    setup_git_repo
+    _setup_askpass_probe
+    setup_git_ssh_wrapper
+    # The wrapper transport succeeds without ssh, so if core.sshCommand ever
+    # won over GIT_SSH_COMMAND the push would succeed and fail the test. The
+    # variant tells git the wrapper accepts a port flag like real ssh.
+    export GIT_CONFIG_COUNT=2 GIT_CONFIG_KEY_0=core.sshCommand GIT_CONFIG_VALUE_0="$GIT_SVC_WRAPPER"
+    export GIT_CONFIG_KEY_1=ssh.variant GIT_CONFIG_VALUE_1=ssh
+    export GIT_SSH_COMMAND="$SSH_SHIM_DIR/ssh"
+    _init_repo_with_remote "git+ssh://$(whoami)@127.0.0.1:${SSHD_PORT}${GIT_SVC_DIR}"
+    _push_fails_without_askpass
+}
+
+# bats test_tags=no_lambda
+@test "remotes-git: ssh push with the default ssh transport does not invoke the SSH_ASKPASS program" {
+    # See https://github.com/dolthub/dolt/issues/11027.
+    setup_git_repo
+    _setup_askpass_probe
+    _init_repo_with_remote "git+ssh://$(whoami)@127.0.0.1:${SSHD_PORT}${GIT_SVC_DIR}"
+    _push_fails_without_askpass
+}
+
 # bats test_tags=no_lambda
 @test "remotes-git: askpass recorder control fires under raw ssh" {
     # Positive control proving the recorder can observe an askpass launch, so

--- a/integration-tests/bats/remotes-git.bats
+++ b/integration-tests/bats/remotes-git.bats
@@ -661,6 +661,40 @@ _init_repo_with_remote() {
     [ "$status" -eq 0 ]
 }
 
+# _setup_askpass_probe arranges an sshd, a passphrase locked key, the askpass
+# recorder, and the ssh shim, then clears every variable that could bypass or
+# mask an askpass prompt.
+_setup_askpass_probe() {
+    if ! command -v timeout >/dev/null 2>&1; then
+        skip "timeout not installed"
+    fi
+    setup_git_sshd
+    gen_ssh_key "$BATS_TMPDIR/ssh_key_locked" "test_passphrase"
+    setup_git_ssh_askpass_recorder
+    setup_git_ssh_path_shim "$BATS_TMPDIR/ssh_key_locked"
+    unset GIT_SSH_COMMAND GIT_SSH SSH_AUTH_SOCK SSH_AGENT_PID SSH_ASKPASS_REQUIRE
+}
+
+# bats test_tags=no_lambda
+@test "remotes-git: askpass recorder control fires under raw ssh" {
+    # Positive control proving the recorder can observe an askpass launch, so
+    # a marker that stays absent under dolt means dolt suppressed the prompt.
+    # See https://github.com/dolthub/dolt/issues/11027.
+    if ! command -v setsid >/dev/null 2>&1; then
+        skip "setsid not installed"
+    fi
+    _setup_askpass_probe
+    # setsid removes the controlling terminal the way dolt does. With one
+    # present ssh would prompt there instead of launching askpass.
+    run timeout -k 5 15 setsid -w ssh -p "$SSHD_PORT" "$(whoami)@127.0.0.1" true 3>&-
+    [ -f "$SSH_ASKPASS_MARKER" ] || (echo "raw ssh did not invoke askpass, the regression trap is broken" >&2; false)
+    # The recorded prompt must be the passphrase request for the locked key,
+    # not some other prompt that happened to launch askpass.
+    marker="$(cat "$SSH_ASKPASS_MARKER")"
+    [ "$marker" = "Enter passphrase for key '$BATS_TMPDIR/ssh_key_locked': " ] || (echo "unexpected askpass prompt: $marker" >&2; false)
+    [ "$status" -ne 0 ]
+}
+
 
 install_fake_git_url_recorder() {
     # Fake git that records the URL passed to `git remote add` so tests can


### PR DESCRIPTION
 `dolt push` over git+ssh could hang forever when ssh routed a credential prompt to an SSH_ASKPASS program.
- Remove askpass and prompt related environment keys from git subprocess environment.
Fix dolthub/dolt#11027
