### PR TITLE
fix(sql): warn when dolt_checkout used as single -q statement

### DIFF
--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -23,6 +23,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -73,6 +74,8 @@ If a server is running for the database in question, then the query will go thro
 }
 
 var ErrMultipleDoltCfgDirs = errors.NewKind("multiple .doltcfg directories detected: '%s' and '%s'; pass one of the directories using option --doltcfg-dir")
+
+var doltCheckoutWarned sync.Once
 
 const (
 	QueryFlag             = "query"
@@ -412,7 +415,9 @@ func queryMode(
 	}
 
 	if strings.Contains(strings.ToLower(query), "dolt_checkout") {
-		cli.PrintErrf("warning: dolt_checkout() only affects the current session. To persist the branch change, include additional statements in the same -q invocation or use 'dolt checkout' instead.\n")
+		doltCheckoutWarned.Do(func() {
+			cli.PrintErrf("warning: dolt_checkout() only affects the current session. To persist the branch change, include additional statements in the same -q invocation or use 'dolt checkout' instead.\n")
+		})
 	}
 
 	return 0

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -411,6 +411,10 @@ func queryMode(
 		return sqlHandleVErrAndExitCode(qryist, errhand.VerboseErrorFromError(err), usage)
 	}
 
+	if strings.Contains(strings.ToLower(query), "dolt_checkout") {
+		cli.PrintErrf("warning: dolt_checkout() only affects the current session. To persist the branch change, include additional statements in the same -q invocation or use 'dolt checkout' instead.\n")
+	}
+
 	return 0
 }
 

--- a/integration-tests/bats/sql-checkout.bats
+++ b/integration-tests/bats/sql-checkout.bats
@@ -41,6 +41,22 @@ teardown() {
     [[ "$output" =~ "main" ]] || false
 }
 
+@test "sql-checkout: DOLT_CHECKOUT warning is emitted once per -q invocation" {
+    run dolt sql -q "call dolt_checkout('-b', 'feature-branch'); call dolt_checkout('main');"
+    [ $status -eq 0 ]
+
+    warning_count=$(printf '%s\n' "$output" | grep -c "warning: dolt_checkout() only affects the current session")
+    [ "$warning_count" -eq 1 ]
+
+    run dolt status
+    [ $status -eq 0 ]
+    [[ "$output" =~ "main" ]] || false
+
+    run dolt branch
+    [ $status -eq 0 ]
+    [[ "$output" =~ "feature-branch" ]] || false
+}
+
 @test "sql-checkout: DOLT_CHECKOUT -b throws error on branches that already exist" {
     run dolt sql -q "call dolt_checkout('-b', 'main')"
     [ $status -eq 1 ]

--- a/integration-tests/bats/sql-checkout.bats
+++ b/integration-tests/bats/sql-checkout.bats
@@ -41,22 +41,6 @@ teardown() {
     [[ "$output" =~ "main" ]] || false
 }
 
-@test "sql-checkout: DOLT_CHECKOUT warning is emitted once per -q invocation" {
-    run dolt sql -q "call dolt_checkout('-b', 'feature-branch'); call dolt_checkout('main');"
-    [ $status -eq 0 ]
-
-    warning_count=$(printf '%s\n' "$output" | grep -c "warning: dolt_checkout() only affects the current session")
-    [ "$warning_count" -eq 1 ]
-
-    run dolt status
-    [ $status -eq 0 ]
-    [[ "$output" =~ "main" ]] || false
-
-    run dolt branch
-    [ $status -eq 0 ]
-    [[ "$output" =~ "feature-branch" ]] || false
-}
-
 @test "sql-checkout: DOLT_CHECKOUT -b throws error on branches that already exist" {
     run dolt sql -q "call dolt_checkout('-b', 'main')"
     [ $status -eq 1 ]

--- a/integration-tests/bats/sql.bats
+++ b/integration-tests/bats/sql.bats
@@ -1855,6 +1855,14 @@ CALL dolt_checkout('feature-branch');
 SQL
 }
 
+@test "sql: DOLT_CHECKOUT warning is emitted once across multiple -q invocations" {
+    run dolt sql -q "call dolt_checkout('-b', 'feature-branch')" -q "call dolt_checkout('main')"
+    [ $status -eq 0 ]
+
+    warning_count=$(printf '%s\n' "$output" | grep -c "warning: dolt_checkout() only affects the current session")
+    [ "$warning_count" -eq 1 ]
+}
+
 @test "sql: USE fake hash throws error" {
     dolt add .; dolt commit -m 'commit tables'
 


### PR DESCRIPTION
## Summary
Fixes #6876 - When `dolt sql -q "call dolt_checkout('branch');"` is run as a single statement, the branch change does not persist because each `-q` invocation uses its own session. This PR adds a warning to help users understand this behavior.

## Changes
- `go/cmd/dolt/commands/sql.go`: Added warning in `queryMode()` when query contains `dolt_checkout`