### PR TITLE
Gate DOLT_CHECKOUT('<table>') with branch_control Write permission

### DIFF
--- a/go/libraries/doltcore/sqle/dprocedures/dolt_checkout.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_checkout.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
+	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
@@ -632,6 +633,9 @@ func checkoutTablesFromCommit(
 	tables []string,
 	rsc *doltdb.ReplicationStatusController,
 ) error {
+	if err := branch_control.CheckAccess(ctx, branch_control.Permissions_Write); err != nil {
+		return err
+	}
 	dSess := dsess.DSessFromSess(ctx.Session)
 	dbData, ok := dSess.GetDbData(ctx, databaseName)
 	if !ok {
@@ -724,6 +728,9 @@ func doGlobalCheckout(ctx *sql.Context, branchName string, isForce bool, isNewBr
 // working root. The working root is then set as the new staged root so that the checked-out tables are not
 // shown as pending staged changes. This is necessary because tables may exist outside of the HEAD commit.
 func checkoutTablesFromHead(ctx *sql.Context, roots doltdb.Roots, name string, tables []string) error {
+	if err := branch_control.CheckAccess(ctx, branch_control.Permissions_Write); err != nil {
+		return err
+	}
 	var tableNames []doltdb.TableName
 	var warningMsg strings.Builder
 	var err error

--- a/go/libraries/doltcore/sqle/enginetest/branch_control_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/branch_control_test.go
@@ -1625,6 +1625,93 @@ var BranchControlTests = []BranchControlTest{
 		},
 	},
 	{
+		// DOLT_CHECKOUT has two forms:
+		//   DOLT_CHECKOUT('<branch>') — switches the current session's branch (read-ish)
+		//   DOLT_CHECKOUT('<table>')  — restores <table>'s working set from HEAD, discarding
+		//                               uncommitted changes (a write to the working set)
+		// A user with only read or merge permission on main should be able to switch
+		// branches, but should not be able to clear working-set changes on main.
+		Name: "Merge permission allows DOLT_CHECKOUT('<branch>') but blocks DOLT_CHECKOUT('<table>')",
+		SetUpScript: []string{
+			"DELETE FROM dolt_branch_control WHERE user = '%';",
+			"INSERT INTO dolt_branch_control VALUES ('%', '%', 'root', 'localhost', 'admin');",
+			"CREATE USER testuser@localhost;",
+			"GRANT ALL ON *.* TO testuser@localhost;",
+			"REVOKE SUPER ON *.* FROM testuser@localhost;",
+			"CREATE TABLE test (pk BIGINT PRIMARY KEY, v1 BIGINT);",
+			"INSERT INTO test VALUES (1, 1);",
+			"CALL DOLT_ADD('-A');",
+			"CALL DOLT_COMMIT('-m', 'initial commit');",
+			"CALL DOLT_BRANCH('other');",
+			// Dirty working set on main that a checkout-of-table would clear.
+			"UPDATE test SET v1 = 2 WHERE pk = 1;",
+			// testuser has only merge permission on main.
+			"INSERT INTO dolt_branch_control VALUES ('%', 'main', 'testuser', 'localhost', 'merge');",
+		},
+		Assertions: []BranchControlTestAssertion{
+			// Switching branches is allowed.
+			{
+				User:     "testuser",
+				Host:     "localhost",
+				Query:    "CALL DOLT_CHECKOUT('other');",
+				Expected: []sql.Row{{0, "Switched to branch 'other'"}},
+			},
+			{
+				User:     "testuser",
+				Host:     "localhost",
+				Query:    "CALL DOLT_CHECKOUT('main');",
+				Expected: []sql.Row{{0, "Switched to branch 'main'"}},
+			},
+			// Clearing a table's working-set changes is a write — should be rejected.
+			{
+				User:        "testuser",
+				Host:        "localhost",
+				Query:       "CALL DOLT_CHECKOUT('test');",
+				ExpectedErr: branch_control.ErrIncorrectPermissions,
+			},
+		},
+	},
+	{
+		// Same scenario as the merge-permission case above, but with read-only
+		// permission. Switching branches should still work; clearing working-set
+		// changes on a table should still be rejected.
+		Name: "Read permission allows DOLT_CHECKOUT('<branch>') but blocks DOLT_CHECKOUT('<table>')",
+		SetUpScript: []string{
+			"DELETE FROM dolt_branch_control WHERE user = '%';",
+			"INSERT INTO dolt_branch_control VALUES ('%', '%', 'root', 'localhost', 'admin');",
+			"CREATE USER testuser@localhost;",
+			"GRANT ALL ON *.* TO testuser@localhost;",
+			"REVOKE SUPER ON *.* FROM testuser@localhost;",
+			"CREATE TABLE test (pk BIGINT PRIMARY KEY, v1 BIGINT);",
+			"INSERT INTO test VALUES (1, 1);",
+			"CALL DOLT_ADD('-A');",
+			"CALL DOLT_COMMIT('-m', 'initial commit');",
+			"CALL DOLT_BRANCH('other');",
+			"UPDATE test SET v1 = 2 WHERE pk = 1;",
+			"INSERT INTO dolt_branch_control VALUES ('%', 'main', 'testuser', 'localhost', 'read');",
+		},
+		Assertions: []BranchControlTestAssertion{
+			{
+				User:     "testuser",
+				Host:     "localhost",
+				Query:    "CALL DOLT_CHECKOUT('other');",
+				Expected: []sql.Row{{0, "Switched to branch 'other'"}},
+			},
+			{
+				User:     "testuser",
+				Host:     "localhost",
+				Query:    "CALL DOLT_CHECKOUT('main');",
+				Expected: []sql.Row{{0, "Switched to branch 'main'"}},
+			},
+			{
+				User:        "testuser",
+				Host:        "localhost",
+				Query:       "CALL DOLT_CHECKOUT('test');",
+				ExpectedErr: branch_control.ErrIncorrectPermissions,
+			},
+		},
+	},
+	{
 		Name: "Merge permission allows merge with conflicts",
 		SetUpScript: []string{
 			"DELETE FROM dolt_branch_control WHERE user = '%';",


### PR DESCRIPTION
`dolt_checkout(<table>)` was previously ungated, so a user with a `read` or `merge` permission on a branch could clear working set changes. This gates `dolt_checkout(<table>)` while leaving `dolt_checkout(<branch>)` ungated

