### PR TITLE
go: sqle: Fix a dolt_branch_control bypass involving the session table cache.

### DIFF
--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -1517,7 +1517,11 @@ func (db Database) getTable(ctx *sql.Context, root doltdb.RootValue, tableName s
 
 		cachedTable, ok := dbState.SessionCache().GetCachedTable(key, dsess.TableCacheKey{Name: tableName, Schema: db.schemaName})
 		if ok {
-			return cachedTable, true, nil
+			rebound, err := cachedTable.RebindDatabase(ctx, db)
+			if err != nil {
+				return nil, false, err
+			}
+			return rebound, true, nil
 		}
 	}
 
@@ -1664,14 +1668,14 @@ func (db Database) tableInsensitive(ctx *sql.Context, root doltdb.RootValue, tab
 	return tableName, tbl, true, nil
 }
 
-func (db Database) newDoltTable(ctx *sql.Context, tableName string, sch schema.Schema, tbl *doltdb.Table) (sql.Table, error) {
+func (db Database) newDoltTable(ctx *sql.Context, tableName string, sch schema.Schema, tbl *doltdb.Table) (dsess.CacheableDoltTable, error) {
 	readonlyTable, err := NewDoltTable(ctx, tableName, sch, tbl, db, db.editOpts)
 	if err != nil {
 		return nil, err
 	}
 
 	tname := doltdb.TableName{Name: tableName, Schema: db.schemaName}
-	var table sql.Table
+	var table dsess.CacheableDoltTable
 	if doltdb.IsReadOnlySystemTable(tname) {
 		table = readonlyTable
 	} else if doltdb.IsDoltCITable(tableName) && !doltdb.IsFullTextTable(tableName) {

--- a/go/libraries/doltcore/sqle/dsess/session_cache.go
+++ b/go/libraries/doltcore/sqle/dsess/session_cache.go
@@ -24,12 +24,24 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/index"
 )
 
+// CacheableDoltTable what tables that lands in SessionCache.tables
+// implement. The cache is keyed only by root hash + table name +
+// schema, but each table implementation carries more state, and in
+// particular a sqle.Database that's captured at construction time.
+// RebindDatabase returns an instance whose db references match the
+// caller's view. getTable calls this to rebind the cached instance to
+// the correct Database instance.
+type CacheableDoltTable interface {
+	sql.Table
+	RebindDatabase(ctx *sql.Context, newDb SqlDatabase) (CacheableDoltTable, error)
+}
+
 // SessionCache caches various pieces of expensive to compute information to speed up future lookups in the session.
 type SessionCache struct {
 	// indexes is keyed by table schema hash
 	indexes map[doltdb.DataCacheKey]map[string][]sql.Index
 	// tables is keyed by table root value
-	tables map[doltdb.DataCacheKey]map[TableCacheKey]sql.Table
+	tables map[doltdb.DataCacheKey]map[TableCacheKey]CacheableDoltTable
 	// tableMaps is keyed by a digest of the table list of table names
 	tableMaps map[uint64]map[string]string
 
@@ -128,13 +140,13 @@ func (c *SessionCache) GetTableIndexesCache(key doltdb.DataCacheKey, table strin
 	return indexes, ok
 }
 
-// CacheTable caches a sql.Table implementation for the table named
-func (c *SessionCache) CacheTable(key doltdb.DataCacheKey, tableName TableCacheKey, table sql.Table) {
+// CacheTable caches a CacheableDoltTable implementation for the table named
+func (c *SessionCache) CacheTable(key doltdb.DataCacheKey, tableName TableCacheKey, table CacheableDoltTable) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	if c.tables == nil {
-		c.tables = make(map[doltdb.DataCacheKey]map[TableCacheKey]sql.Table)
+		c.tables = make(map[doltdb.DataCacheKey]map[TableCacheKey]CacheableDoltTable)
 	}
 	if len(c.tables) > maxCachedKeys {
 		for k := range c.tables {
@@ -144,7 +156,7 @@ func (c *SessionCache) CacheTable(key doltdb.DataCacheKey, tableName TableCacheK
 
 	tablesForKey, ok := c.tables[key]
 	if !ok {
-		tablesForKey = make(map[TableCacheKey]sql.Table)
+		tablesForKey = make(map[TableCacheKey]CacheableDoltTable)
 		c.tables[key] = tablesForKey
 	}
 
@@ -171,8 +183,8 @@ func (k TableCacheKey) ToLower() TableCacheKey {
 	}
 }
 
-// GetCachedTable returns the cached sql.Table for the table named, and whether the cache was present
-func (c *SessionCache) GetCachedTable(key doltdb.DataCacheKey, tableName TableCacheKey) (sql.Table, bool) {
+// GetCachedTable returns the cached CacheableDoltTable for the table named, and whether the cache was present
+func (c *SessionCache) GetCachedTable(key doltdb.DataCacheKey, tableName TableCacheKey) (CacheableDoltTable, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 

--- a/go/libraries/doltcore/sqle/dsess/session_cache.go
+++ b/go/libraries/doltcore/sqle/dsess/session_cache.go
@@ -24,13 +24,13 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/index"
 )
 
-// CacheableDoltTable what tables that lands in SessionCache.tables
-// implement. The cache is keyed only by root hash + table name +
-// schema, but each table implementation carries more state, and in
-// particular a sqle.Database that's captured at construction time.
-// RebindDatabase returns an instance whose db references match the
-// caller's view. getTable calls this to rebind the cached instance to
-// the correct Database instance.
+// CacheableDoltTable is implemented by tables in SessionCache.tables.
+// The cache is keyed only by root hash + table name + schema, but
+// each table implementation carries more state, and in particular a
+// sqle.Database that's captured at construction time.  RebindDatabase
+// returns an instance whose db references match the caller's
+// view. getTable calls this to rebind the cached instance to the
+// correct Database instance.
 type CacheableDoltTable interface {
 	sql.Table
 	RebindDatabase(ctx *sql.Context, newDb SqlDatabase) (CacheableDoltTable, error)

--- a/go/libraries/doltcore/sqle/enginetest/branch_control_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/branch_control_test.go
@@ -2164,3 +2164,81 @@ func TestBranchControlBlocks(t *testing.T) {
 		})
 	}
 }
+
+// TestInformationSchemaDoesNotBypassBranchControl is a regression
+// test for a cache pollution bug where a SELECT against
+// information_schema in a fresh user session would let the next write
+// in that session bypass branch_control.
+//
+// The root cause was that a select against information_Schema.columns
+// or tables would DoltDatabaseProvider.AllDatabases and would
+// populate the session cache with sqle.DoltTable instances that
+// embedded the wrong Database instance (non revision-scoped). This
+// was fixed by rebinding Table values to the correct Database
+// instance anytime we pull them out of the cache.
+//
+// The setup must run in a separate session from the writer's session
+// so that the table cache is genuinely cold when the writer queries
+// information_schema. Otherwise the SetUpScript's CREATE TABLE warms
+// the cache with the revisioned db and the pollution path is never
+// exercised.  TestBranchControl shares a session between setup and
+// assertions, so this test doesn't fit that harness.
+func TestInformationSchemaDoesNotBypassBranchControl(t *testing.T) {
+	harness := newDoltHarness(t)
+	defer harness.Close()
+
+	engine, err := harness.NewEngine(t)
+	require.NoError(t, err)
+	defer engine.Close()
+
+	rootCtx := enginetest.NewContext(harness)
+	rootCtx.WithClient(sql.Client{User: "root", Address: "localhost"})
+	engine.EngineAnalyzer().Catalog.MySQLDb.AddRootAccount()
+	engine.EngineAnalyzer().Catalog.MySQLDb.SetPersister(&mysql_db.NoopPersister{})
+
+	setup := []string{
+		"DELETE FROM dolt_branch_control WHERE user = '%';",
+		"INSERT INTO dolt_branch_control VALUES ('%', '%', 'root', 'localhost', 'admin');",
+		"CREATE USER testuser@localhost;",
+		"GRANT SELECT, INSERT, UPDATE, DELETE ON *.* TO testuser@localhost;",
+		"CREATE TABLE vals (id INT PRIMARY KEY, val INT);",
+	}
+	for _, q := range setup {
+		enginetest.RunQueryWithContext(t, engine, harness, rootCtx, q)
+	}
+
+	// Cases differ only in which information_schema table primes the cache;
+	// both produce the same un-revisioned WritableDoltTable for `vals` in
+	// the session cache. Each case gets its own fresh writer session so
+	// nothing pre-warms the cache with a revisioned db.
+	cases := []struct {
+		name      string
+		readQuery string
+	}{
+		{"information_schema.columns", "SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = 'mydb' AND table_name = 'vals';"},
+		{"information_schema.tables", "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'mydb' AND table_name = 'vals';"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			userCtx := enginetest.NewContextWithClient(harness, sql.Client{
+				User:    "testuser",
+				Address: "localhost",
+			})
+
+			// Read first to make the cache pollution happen.
+			_, iter, _, err := engine.Query(userCtx, c.readQuery)
+			require.NoError(t, err)
+			_, err = sql.RowIterToRows(userCtx, iter)
+			require.NoError(t, err)
+
+			// Pre-fix the first write silently succeeded.
+			enginetest.AssertErrWithCtx(t, engine, harness, userCtx,
+				"INSERT INTO vals VALUES (1, 1);", nil, branch_control.ErrIncorrectPermissions)
+			// Control: the second write at the (now-changed) root would
+			// have been caught even pre-fix. Asserting it pins behavior
+			// against future regressions that flip the polarity.
+			enginetest.AssertErrWithCtx(t, engine, harness, userCtx,
+				"INSERT INTO vals VALUES (2, 2);", nil, branch_control.ErrIncorrectPermissions)
+		})
+	}
+}

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -3220,6 +3220,47 @@ func (t *WritableDoltTable) SetWriteSession(session dsess.WriteSession) {
 	t.pinnedWriteSession = session
 }
 
+var _ dsess.CacheableDoltTable = (*DoltTable)(nil)
+var _ dsess.CacheableDoltTable = (*WritableDoltTable)(nil)
+var _ dsess.CacheableDoltTable = (*AlterableDoltTable)(nil)
+
+// RebindDatabase implements dsess.CacheableDoltTable.
+// Shallow-copies the table and refreshes the db-derived fields.
+func (t *DoltTable) RebindDatabase(ctx *sql.Context, newDb dsess.SqlDatabase) (dsess.CacheableDoltTable, error) {
+	db := newDb.(Database)
+	sqlSch, err := sqlutil.FromDoltSchema(ctx, db.Name(), t.tableName, t.sch)
+	if err != nil {
+		return nil, err
+	}
+	cp := *t
+	cp.db = db
+	cp.opts = db.editOpts
+	cp.sqlSch = sqlSch
+	return &cp, nil
+}
+
+// RebindDatabase implements dsess.CacheableDoltTable.
+func (t *WritableDoltTable) RebindDatabase(ctx *sql.Context, newDb dsess.SqlDatabase) (dsess.CacheableDoltTable, error) {
+	db := newDb.(Database)
+	inner, err := t.DoltTable.RebindDatabase(ctx, newDb)
+	if err != nil {
+		return nil, err
+	}
+	cp := *t
+	cp.DoltTable = inner.(*DoltTable)
+	cp.db = db
+	return &cp, nil
+}
+
+// RebindDatabase implements dsess.CacheableDoltTable.
+func (t *AlterableDoltTable) RebindDatabase(ctx *sql.Context, newDb dsess.SqlDatabase) (dsess.CacheableDoltTable, error) {
+	inner, err := t.WritableDoltTable.RebindDatabase(ctx, newDb)
+	if err != nil {
+		return nil, err
+	}
+	return &AlterableDoltTable{WritableDoltTable: *inner.(*WritableDoltTable)}, nil
+}
+
 func FindIndexWithPrefix(sch schema.Schema, prefixCols []string) (schema.Index, bool, error) {
 	type idxWithLen struct {
 		schema.Index

--- a/integration-tests/mysql-client-tests/node/workbenchTests/table.js
+++ b/integration-tests/mysql-client-tests/node/workbenchTests/table.js
@@ -138,7 +138,7 @@ export const tableTests = [
         COLUMN_NAME: "test_pk",
         ORDINAL_POSITION: 1,
         POSITION_IN_UNIQUE_CONSTRAINT: 1,
-        REFERENCED_TABLE_SCHEMA: dbName,
+        REFERENCED_TABLE_SCHEMA: `${dbName}/main`,
         REFERENCED_TABLE_NAME: "test",
         REFERENCED_COLUMN_NAME: "pk",
       },


### PR DESCRIPTION
On a new connection, a SELECT against information_schema.tables or information_schema.columns would populate the session's table cache is a Table value that embedded a revision-less Database value. An incoming write request against the cached table would run its permissions check against the revision-less database, instead of the revisioned database which correctly encoded the branch the write was running against. This allowed connections to bypass dolt_branch_control, elevating to `write` permissions on all branches.