### PR TITLE
Fix SchemaTable.Updater panic on direct UPDATE dolt_schemas

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/branch_control_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/branch_control_test.go
@@ -335,6 +335,21 @@ var BranchControlBlockTests = []BranchControlBlockTest{
 		ExpectedErr: branch_control.ErrIncorrectPermissions,
 	},
 	{
+		// A direct UPDATE on dolt_schemas reaches SchemaTable.Updater, which
+		// delegates to the gated backing table. (It used to panic, which an
+		// unprivileged user could trigger.) INSERT/DELETE aren't covered
+		// because SchemaTable only implements sql.UpdatableTable — the engine
+		// rejects those as unsupported, not a branch_control concern. The
+		// real view/trigger paths are covered by the CREATE/DROP VIEW/TRIGGER
+		// cases above.
+		Name: "UPDATE dolt_schemas",
+		SetUpScript: []string{
+			"CREATE VIEW v1 AS SELECT 1;",
+		},
+		Query:       "UPDATE dolt_schemas SET name = 'v9' WHERE name = 'v1';",
+		ExpectedErr: branch_control.ErrIncorrectPermissions,
+	},
+	{
 		Name:        "CREATE EVENT",
 		Query:       "CREATE EVENT ev1 ON SCHEDULE EVERY 1 DAY DO INSERT INTO test VALUES (99, 99);",
 		ExpectedErr: branch_control.ErrIncorrectPermissions,

--- a/go/libraries/doltcore/sqle/enginetest/branch_control_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/branch_control_test.go
@@ -335,21 +335,6 @@ var BranchControlBlockTests = []BranchControlBlockTest{
 		ExpectedErr: branch_control.ErrIncorrectPermissions,
 	},
 	{
-		// A direct UPDATE on dolt_schemas reaches SchemaTable.Updater, which
-		// delegates to the gated backing table. (It used to panic, which an
-		// unprivileged user could trigger.) INSERT/DELETE aren't covered
-		// because SchemaTable only implements sql.UpdatableTable — the engine
-		// rejects those as unsupported, not a branch_control concern. The
-		// real view/trigger paths are covered by the CREATE/DROP VIEW/TRIGGER
-		// cases above.
-		Name: "UPDATE dolt_schemas",
-		SetUpScript: []string{
-			"CREATE VIEW v1 AS SELECT 1;",
-		},
-		Query:       "UPDATE dolt_schemas SET name = 'v9' WHERE name = 'v1';",
-		ExpectedErr: branch_control.ErrIncorrectPermissions,
-	},
-	{
 		Name:        "CREATE EVENT",
 		Query:       "CREATE EVENT ev1 ON SCHEDULE EVERY 1 DAY DO INSERT INTO test VALUES (99, 99);",
 		ExpectedErr: branch_control.ErrIncorrectPermissions,

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -1279,6 +1279,12 @@ var DoltScripts = []queries.ScriptTest{
 					{"view", "view2", "CREATE VIEW view2 AS SELECT v2 FROM viewtest"},
 				},
 			},
+			{
+				// dolt_schemas is not directly modifiable; a direct UPDATE
+				// must return a clean error, not panic.
+				Query:          "UPDATE dolt_schemas SET name = 'x' WHERE name = 'view1'",
+				ExpectedErrStr: "the dolt_schemas table cannot be modified directly",
+			},
 		},
 	},
 	{

--- a/go/libraries/doltcore/sqle/schema_table.go
+++ b/go/libraries/doltcore/sqle/schema_table.go
@@ -113,15 +113,12 @@ func (st *SchemaTable) PreciseMatch() bool {
 }
 
 // Updater implements sql.UpdatableTable. Internal schema modifications go
-// through the wrapped backing table directly (see UnWrap); a direct
-// UPDATE dolt_schemas reaches here. Delegate to the backing table so the
-// write is branch_control-gated like any other table write, rather than
-// panicking (which an unprivileged user could otherwise trigger).
+// through the wrapped backing table directly (see UnWrap); the dolt_schemas
+// table is not directly modifiable via SQL. A direct UPDATE dolt_schemas
+// reaches here and must return a clean error rather than panicking (which
+// an unprivileged user could otherwise trigger).
 func (st *SchemaTable) Updater(ctx *sql.Context) sql.RowUpdater {
-	if st.backingTable == nil {
-		return sqlutil.NewStaticErrorEditor(fmt.Errorf("%s table does not exist", doltdb.SchemasTableName))
-	}
-	return st.backingTable.Updater(ctx)
+	return sqlutil.NewStaticErrorEditor(fmt.Errorf("the %s table cannot be modified directly", doltdb.SchemasTableName))
 }
 
 func (st *SchemaTable) UnWrap() *WritableDoltTable {

--- a/go/libraries/doltcore/sqle/schema_table.go
+++ b/go/libraries/doltcore/sqle/schema_table.go
@@ -112,9 +112,16 @@ func (st *SchemaTable) PreciseMatch() bool {
 	return true
 }
 
-// Updater implements sql.UpdatableTable. The SchemaTable is only every modified by using it's wrapped backing table.
+// Updater implements sql.UpdatableTable. Internal schema modifications go
+// through the wrapped backing table directly (see UnWrap); a direct
+// UPDATE dolt_schemas reaches here. Delegate to the backing table so the
+// write is branch_control-gated like any other table write, rather than
+// panicking (which an unprivileged user could otherwise trigger).
 func (st *SchemaTable) Updater(ctx *sql.Context) sql.RowUpdater {
-	panic("Runtime error: SchemaTable.Updater() should never be called")
+	if st.backingTable == nil {
+		return sqlutil.NewStaticErrorEditor(fmt.Errorf("%s table does not exist", doltdb.SchemasTableName))
+	}
+	return st.backingTable.Updater(ctx)
 }
 
 func (st *SchemaTable) UnWrap() *WritableDoltTable {


### PR DESCRIPTION
A direct UPDATE dolt_schemas reached SchemaTable.Updater, which panicked with "should never be called" — an unprivileged user could crash the SQL server with it. dolt_schemas is not directly modifiable via SQL, so this returns a clean error unconditionally instead of panicking; adds a regression test.