### PR TITLE
more cleanup for `prollyWriteSession`

### DIFF
--- a/go/libraries/doltcore/merge/schema_merge_test.go
+++ b/go/libraries/doltcore/merge/schema_merge_test.go
@@ -1910,7 +1910,8 @@ func makeEmptyRoot(t *testing.T, ddb *doltdb.DoltDB, eo editor.Options) doltdb.R
 
 	gst, err := dsess.NewAutoIncrementTracker(ctx, "dolt", ws)
 	require.NoError(t, err)
-	sess := writer.NewWriteSession(ws, gst, eo)
+	noop := func(ctx *sql.Context, dbName string, root doltdb.RootValue) (err error) { return }
+	sess := writer.NewWriteSession("test", ws, gst, noop, eo)
 
 	ws, err = sess.Flush(sql.NewContext(ctx))
 	require.NoError(t, err)
@@ -1932,8 +1933,8 @@ func makeRootWithTable(t *testing.T, ddb *doltdb.DoltDB, eo editor.Options, tbl 
 	gst, err := dsess.NewAutoIncrementTracker(ctx, "dolt", ws)
 	require.NoError(t, err)
 	noop := func(ctx *sql.Context, dbName string, root doltdb.RootValue) (err error) { return }
-	sess := writer.NewWriteSession(ws, gst, eo)
-	wr, err := sess.GetTableWriter(sql.NewContext(ctx), doltdb.TableName{Name: tbl.ns.name}, "test", noop, false)
+	sess := writer.NewWriteSession("test", ws, gst, noop, eo)
+	wr, err := sess.GetTableWriter(sql.NewContext(ctx), doltdb.TableName{Name: tbl.ns.name})
 	require.NoError(t, err)
 
 	columns := tbl.ns.sch.GetAllCols().GetColumns()

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_applier.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_applier.go
@@ -839,12 +839,11 @@ func getTableWriter(ctx *sql.Context, engine *gms.Engine, tableName, databaseNam
 		return nil, nil, err
 	}
 
-	writeSession := writer.NewWriteSession(ws, tracker, sqlDatabase.EditOptions())
-
 	ds := dsess.DSessFromSess(ctx.Session)
 	setter := ds.SetWorkingRoot
+	writeSession := writer.NewWriteSession(databaseName, ws, tracker, setter, sqlDatabase.EditOptions())
 
-	tableWriter, err := writeSession.GetTableWriter(ctx, doltdb.TableName{Name: tableName}, databaseName, setter, false)
+	tableWriter, err := writeSession.GetTableWriter(ctx, doltdb.TableName{Name: tableName})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -1416,13 +1416,7 @@ func (d *DoltSession) addDB(ctx *sql.Context, db SqlDatabase) error {
 			if err != nil {
 				return err
 			}
-			var setter SessionRootSetter
-			if editOpts.TargetStaging {
-				setter = d.SetStagingRoot
-			} else {
-				setter = d.SetWorkingRoot
-			}
-			branchState.writeSession = d.writeSessProv(revisionQualifiedName, branchState.workingSet, tracker, setter, editOpts)
+			branchState.writeSession = d.writeSessProv(revisionQualifiedName, branchState.workingSet, tracker, d.SetWorkingRoot, editOpts)
 		}
 	}
 

--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -1374,17 +1374,16 @@ func (d *DoltSession) addDB(ctx *sql.Context, db SqlDatabase) error {
 		}
 	}
 
-	branchState := sessionState.NewEmptyBranchState(db.Revision(), db.RevisionType())
-
 	// TODO: get rid of all repo state reader / writer stuff. Until we do, swap out the reader with one of our own, and
 	//  the writer with one that errors out
 	// TODO: this no longer gets called at session creation time, so the error handling below never occurs when a
 	//  database is deleted out from under a running server
-	branchState.dbData = dbState.DbData
 	adapter := NewSessionStateAdapter(d, db.Name(), dbState.Remotes, dbState.Branches, dbState.Backups)
+	branchState := sessionState.NewEmptyBranchState(db.Revision(), db.RevisionType())
+	branchState.readOnly = dbState.ReadOnly
+	branchState.dbData = dbState.DbData
 	branchState.dbData.Rsr = adapter
 	branchState.dbData.Rsw = adapter
-	branchState.readOnly = dbState.ReadOnly
 
 	// TODO: figure out how to cast this to dsqle.SqlDatabase without creating import cycles
 	// Or better yet, get rid of EditOptions from the database, it's a session setting
@@ -1417,7 +1416,13 @@ func (d *DoltSession) addDB(ctx *sql.Context, db SqlDatabase) error {
 			if err != nil {
 				return err
 			}
-			branchState.writeSession = d.writeSessProv(branchState.WorkingSet(), tracker, editOpts)
+			var setter SessionRootSetter
+			if editOpts.TargetStaging {
+				setter = d.SetStagingRoot
+			} else {
+				setter = d.SetWorkingRoot
+			}
+			branchState.writeSession = d.writeSessProv(revisionQualifiedName, branchState.workingSet, tracker, setter, editOpts)
 		}
 	}
 
@@ -2081,4 +2086,4 @@ func DefaultHead(ctx *sql.Context, baseName string, db SqlDatabase) (string, err
 // WriteSessFunc is a constructor that session builders use to
 // create fresh table editors.
 // The indirection avoids a writer/dsess package import cycle.
-type WriteSessFunc func(ws *doltdb.WorkingSet, aiTracker globalstate.AutoIncrementTracker, opts editor.Options) WriteSession
+type WriteSessFunc func(dbName string, ws *doltdb.WorkingSet, aiTracker globalstate.AutoIncrementTracker, setter SessionRootSetter, opts editor.Options) WriteSession

--- a/go/libraries/doltcore/sqle/dsess/table_writer.go
+++ b/go/libraries/doltcore/sqle/dsess/table_writer.go
@@ -30,7 +30,7 @@ import (
 // It's responsible for creating and managing the lifecycle of TableWriter's.
 type WriteSession interface {
 	// GetTableWriter creates a TableWriter and adds it to the WriteSession.
-	GetTableWriter(ctx *sql.Context, table doltdb.TableName, db string, setter SessionRootSetter, targetStaging bool) (TableWriter, error)
+	GetTableWriter(ctx *sql.Context, table doltdb.TableName) (TableWriter, error)
 
 	// GetWorkingSet returns the session's current working set.
 	GetWorkingSet() *doltdb.WorkingSet

--- a/go/libraries/doltcore/sqle/dtables/user_space_system_table.go
+++ b/go/libraries/doltcore/sqle/dtables/user_space_system_table.go
@@ -271,7 +271,7 @@ func createWriteableSystemTable(ctx *sql.Context, tblName doltdb.TableName, tblS
 
 	var tableWriter dsess.TableWriter
 	if ws := dbState.WriteSession(); ws != nil {
-		tableWriter, err = ws.GetTableWriter(ctx, tblName, dbName, dSess.SetWorkingRoot, false)
+		tableWriter, err = ws.GetTableWriter(ctx, tblName)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/go/libraries/doltcore/sqle/dtables/workspace_table.go
+++ b/go/libraries/doltcore/sqle/dtables/workspace_table.go
@@ -269,11 +269,9 @@ func (wtd *WorkspaceTableDeleter) Close(c *sql.Context) error {
 
 func (wtm *WorkspaceTableModifier) getWorkspaceTableWriter(ctx *sql.Context, targetStaging bool) (dsess.WriteSession, dsess.TableWriter, error) {
 	ds := dsess.DSessFromSess(ctx.Session)
-
-	setter := ds.SetWorkingRoot
+	var setter dsess.SessionRootSetter
 	if targetStaging {
 		setter = ds.SetStagingRoot
-
 		// Ensure table exists in staging root before getting writer.
 		// This is necessary when staging rows from a new table that exists
 		// in working but not yet in staging (e.g., 'dolt add -p' on a new table).
@@ -281,6 +279,8 @@ func (wtm *WorkspaceTableModifier) getWorkspaceTableWriter(ctx *sql.Context, tar
 		if err != nil {
 			return nil, nil, err
 		}
+	} else {
+		setter = ds.SetWorkingRoot
 	}
 
 	gst, err := dsess.NewAutoIncrementTracker(ctx, "dolt", wtm.ws)
@@ -288,13 +288,11 @@ func (wtm *WorkspaceTableModifier) getWorkspaceTableWriter(ctx *sql.Context, tar
 		return nil, nil, err
 	}
 
-	writeSession := writer.NewWriteSession(wtm.ws, gst, editor.Options{TargetStaging: targetStaging})
-
-	tableWriter, err := writeSession.GetTableWriter(ctx, wtm.tableName, ctx.GetCurrentDatabase(), setter, targetStaging)
+	writeSession := writer.NewWriteSession(ctx.GetCurrentDatabase(), wtm.ws, gst, setter, editor.Options{TargetStaging: targetStaging})
+	tableWriter, err := writeSession.GetTableWriter(ctx, wtm.tableName)
 	if err != nil {
 		return nil, nil, err
 	}
-
 	return writeSession, tableWriter, nil
 }
 

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -1856,6 +1856,9 @@ func fullTextRewriteEditor(
 		return nil, err
 	}
 
+	// We need our own write session for the rewrite operation. The connection's session must continue to return rows of
+	// the table as it existed before the rewrite operation began until it completes, at which point we update the
+	// session with the rewritten table.
 	writeSession := writer.NewWriteSession(t.db.RevisionQualifiedName(), newWs, ait, sess.SetWorkingRoot, dbState.WriteSession().GetOptions())
 	parentEditor, err := writeSession.GetTableWriter(ctx, t.TableName())
 	if err != nil {

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -723,7 +723,6 @@ func (t *WritableDoltTable) Inserter(ctx *sql.Context) sql.RowInserter {
 
 func (t *WritableDoltTable) getTableEditor(ctx *sql.Context) (ed dsess.TableWriter, err error) {
 	ds := dsess.DSessFromSess(ctx.Session)
-
 	var writeSession dsess.WriteSession
 	if t.pinnedWriteSession != nil {
 		writeSession = t.pinnedWriteSession
@@ -735,9 +734,7 @@ func (t *WritableDoltTable) getTableEditor(ctx *sql.Context) (ed dsess.TableWrit
 		writeSession = state.WriteSession()
 	}
 
-	setter := ds.SetWorkingRoot
-
-	ed, err = writeSession.GetTableWriter(ctx, t.TableName(), t.db.RevisionQualifiedName(), setter, false)
+	ed, err = writeSession.GetTableWriter(ctx, t.TableName())
 	if err != nil {
 		return nil, err
 	}
@@ -752,9 +749,8 @@ func (t *WritableDoltTable) getTableEditor(ctx *sql.Context) (ed dsess.TableWrit
 			return nil, err
 		}
 		return multiEditor.(dsess.TableWriter), nil
-	} else {
-		return ed, nil
 	}
+	return ed, nil
 }
 
 // getFullTextEditor gathers all pseudo-index tables for a Full-Text index and returns an editor that will write
@@ -1750,14 +1746,15 @@ func (t *AlterableDoltTable) RewriteInserter(
 	}
 
 	// If we have an auto increment column, we need to set it here before we begin the rewrite process (it may have changed)
-	if schema.HasAutoIncrement(newSch) {
-		newSch.GetAllCols().Iter(func(tag uint64, col schema.Column) (stop bool, err error) {
-			if col.AutoIncrement {
-				t.autoIncCol = col
-				return true, nil
-			}
-			return false, nil
-		})
+	err = newSch.GetAllCols().Iter(func(tag uint64, col schema.Column) (stop bool, err error) {
+		if col.AutoIncrement {
+			t.autoIncCol = col
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	// Grab the next auto_increment value before we call truncate, since truncate will delete the table
@@ -1816,9 +1813,8 @@ func (t *AlterableDoltTable) RewriteInserter(
 		return nil, fmt.Errorf("cannot rebuild index on a headless branch")
 	}
 
-	writeSession := writer.NewWriteSession(newWs, ait, dbState.WriteSession().GetOptions())
-
-	ed, err := writeSession.GetTableWriter(ctx, t.TableName(), t.db.RevisionQualifiedName(), sess.SetWorkingRoot, false)
+	writeSession := writer.NewWriteSession(t.db.RevisionQualifiedName(), newWs, ait, sess.SetWorkingRoot, dbState.WriteSession().GetOptions())
+	ed, err := writeSession.GetTableWriter(ctx, t.TableName())
 	if err != nil {
 		return nil, err
 	}
@@ -1836,16 +1832,22 @@ func fullTextRewriteEditor(
 	dbState dsess.SessionState,
 	workingRoot doltdb.RootValue,
 ) (sql.RowInserter, error) {
+	// We need our own write session for the rewrite operation. The connection's session must continue to return rows of
+	// the table as it existed before the rewrite operation began until it completes, at which point we update the
+	// session with the rewritten table.
+	if ws := dbState.WriteSession(); ws == nil {
+		return nil, fmt.Errorf("cannot rebuild index on read only database %s", t.Name())
+	}
 
 	newTable, err := t.db.newDoltTable(ctx, t.Name(), newSch, dt)
 	if err != nil {
 		return nil, err
 	}
-
 	updatedRoot, configTable, tableSets, err := newTable.(*AlterableDoltTable).tableSetsForRewrite(ctx, workingRoot)
 	if err != nil {
 		return nil, err
 	}
+	newWs := ws.WithWorkingRoot(updatedRoot)
 
 	// TODO: figure out locking. Other DBs automatically lock a table during this kind of operation, we should probably
 	//  do the same. We're messing with global auto-increment values here and it's not safe.
@@ -1854,18 +1856,8 @@ func fullTextRewriteEditor(
 		return nil, err
 	}
 
-	newWs := ws.WithWorkingRoot(updatedRoot)
-
-	// We need our own write session for the rewrite operation. The connection's session must continue to return rows of
-	// the table as it existed before the rewrite operation began until it completes, at which point we update the
-	// session with the rewritten table.
-	if ws := dbState.WriteSession(); ws == nil {
-		return nil, fmt.Errorf("cannot rebuild index on read only database %s", t.Name())
-	}
-
-	writeSession := writer.NewWriteSession(newWs, ait, dbState.WriteSession().GetOptions())
-
-	parentEditor, err := writeSession.GetTableWriter(ctx, t.TableName(), t.db.RevisionQualifiedName(), sess.SetWorkingRoot, false)
+	writeSession := writer.NewWriteSession(t.db.RevisionQualifiedName(), newWs, ait, sess.SetWorkingRoot, dbState.WriteSession().GetOptions())
+	parentEditor, err := writeSession.GetTableWriter(ctx, t.TableName())
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/temp_table.go
+++ b/go/libraries/doltcore/sqle/temp_table.go
@@ -136,8 +136,6 @@ func NewTempTable(
 		return nil, err
 	}
 
-	writeSession := writer.NewWriteSession(newWs, ait, opts)
-
 	tempTable := &TempTable{
 		tableName: name,
 		dbName:    db,
@@ -147,7 +145,8 @@ func NewTempTable(
 		opts:      opts,
 	}
 
-	tempTable.ed, err = writeSession.GetTableWriter(ctx, doltdb.TableName{Name: name}, db, setTempTableRoot(tempTable), false)
+	writeSession := writer.NewWriteSession(db, newWs, ait, setTempTableRoot(tempTable), opts)
+	tempTable.ed, err = writeSession.GetTableWriter(ctx, doltdb.TableName{Name: name})
 	if err != nil {
 		return nil, err
 	}
@@ -186,8 +185,8 @@ func setTempTableRoot(t *TempTable) func(ctx *sql.Context, dbName string, newRoo
 			return err
 		}
 
-		writeSession := writer.NewWriteSession(newWs, ait, t.opts)
-		t.ed, err = writeSession.GetTableWriter(ctx, doltdb.TableName{Name: t.tableName}, t.dbName, setTempTableRoot(t), false)
+		writeSession := writer.NewWriteSession(t.dbName, newWs, ait, setTempTableRoot(t), t.opts)
+		t.ed, err = writeSession.GetTableWriter(ctx, doltdb.TableName{Name: t.tableName})
 		if err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
@@ -45,12 +45,10 @@ type prollyTableWriter struct {
 	primary   indexWriter
 	secondary map[string]indexWriter
 
-	dbName  string
-	tblName doltdb.TableName
-	sch     schema.Schema
-	sqlSch  sql.Schema
-
-	setter    dsess.SessionRootSetter
+	dbName    string
+	tblName   doltdb.TableName
+	sch       schema.Schema
+	sqlSch    sql.Schema
 	writeSess dsess.WriteSession
 
 	aiCol      schema.Column
@@ -421,13 +419,9 @@ func (w *prollyTableWriter) flush(ctx *sql.Context) error {
 	if err != nil {
 		return err
 	}
-	newRoot, err := w.writeSess.FlushTable(ctx, w.tblName, tbl)
+	_, err = w.writeSess.FlushTable(ctx, w.tblName, tbl)
 	if err != nil {
 		return err
 	}
-	err = w.Reset(ctx, tbl)
-	if err != nil {
-		return err
-	}
-	return w.setter(ctx, w.dbName, newRoot)
+	return w.Reset(ctx, tbl)
 }

--- a/go/libraries/doltcore/sqle/writer/prolly_write_session.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_write_session.go
@@ -31,12 +31,13 @@ import (
 // NewWriteSession creates and returns a WriteSession. Inserting a nil root is not an error, as there are
 // locations that do not have a root at the time of this call. However, a root must be set through SetWorkingRoot before any
 // table editors are returned.
-func NewWriteSession(ws *doltdb.WorkingSet, aiTracker globalstate.AutoIncrementTracker, opts editor.Options) dsess.WriteSession {
+func NewWriteSession(dbName string, ws *doltdb.WorkingSet, aiTracker globalstate.AutoIncrementTracker, setter dsess.SessionRootSetter, opts editor.Options) dsess.WriteSession {
 	return &prollyWriteSession{
-		workingSet:    ws,
+		dbName:        dbName,
 		tables:        make(map[doltdb.TableName]*prollyTableWriter),
 		aiTracker:     aiTracker,
-		mut:           &sync.RWMutex{},
+		workingSet:    ws,
+		setter:        setter,
 		targetStaging: opts.TargetStaging,
 	}
 }
@@ -44,10 +45,11 @@ func NewWriteSession(ws *doltdb.WorkingSet, aiTracker globalstate.AutoIncrementT
 // prollyWriteSession handles all edit operations on a table that may also update other tables.
 // Serves as coordination for SessionedTableEditors.
 type prollyWriteSession struct {
-	workingSet    *doltdb.WorkingSet
+	dbName        string
 	tables        map[doltdb.TableName]*prollyTableWriter
 	aiTracker     globalstate.AutoIncrementTracker
-	mut           *sync.RWMutex
+	workingSet    *doltdb.WorkingSet
+	setter        dsess.SessionRootSetter
 	targetStaging bool
 }
 
@@ -58,8 +60,6 @@ func (s *prollyWriteSession) GetWorkingSet() *doltdb.WorkingSet {
 }
 
 func (s *prollyWriteSession) VisitGCRoots(ctx context.Context, roots func(hash.Hash) bool) error {
-	s.mut.Lock()
-	defer s.mut.Unlock()
 	for _, writer := range s.tables {
 		err := writer.VisitGCRoots(ctx, roots)
 		if err != nil {
@@ -70,10 +70,7 @@ func (s *prollyWriteSession) VisitGCRoots(ctx context.Context, roots func(hash.H
 }
 
 // GetTableWriter implements WriteSession
-func (s *prollyWriteSession) GetTableWriter(ctx *sql.Context, tblName doltdb.TableName, db string, setter dsess.SessionRootSetter, targetStaging bool) (dsess.TableWriter, error) {
-	s.mut.Lock()
-	defer s.mut.Unlock()
-
+func (s *prollyWriteSession) GetTableWriter(ctx *sql.Context, tblName doltdb.TableName) (dsess.TableWriter, error) {
 	if tw, ok := s.tables[tblName]; ok {
 		return tw, nil
 	}
@@ -83,7 +80,7 @@ func (s *prollyWriteSession) GetTableWriter(ctx *sql.Context, tblName doltdb.Tab
 	// the old version of the data while fulltext indexes are rebuilt
 	// using this hidden empty workingSet.
 	var root doltdb.RootValue
-	if targetStaging {
+	if s.targetStaging {
 		root = s.workingSet.StagedRoot()
 	} else {
 		root = s.workingSet.WorkingRoot()
@@ -99,10 +96,9 @@ func (s *prollyWriteSession) GetTableWriter(ctx *sql.Context, tblName doltdb.Tab
 
 	tblWriter := &prollyTableWriter{
 		tblName:   tblName,
-		dbName:    db,
+		dbName:    s.dbName,
 		aiTracker: s.aiTracker,
 		writeSess: s,
-		setter:    setter,
 	}
 	err = tblWriter.Reset(ctx, tbl)
 	if err != nil {
@@ -115,9 +111,6 @@ func (s *prollyWriteSession) GetTableWriter(ctx *sql.Context, tblName doltdb.Tab
 
 // SetWorkingSet implements WriteSession
 func (s *prollyWriteSession) SetWorkingSet(ctx *sql.Context, ws *doltdb.WorkingSet) error {
-	s.mut.Lock()
-	defer s.mut.Unlock()
-
 	root := ws.WorkingRoot()
 	rootHash, err := root.HashOf()
 	if err != nil {
@@ -152,18 +145,16 @@ func (s *prollyWriteSession) SetWorkingSet(ctx *sql.Context, ws *doltdb.WorkingS
 
 // GetOptions implements WriteSession
 func (s *prollyWriteSession) GetOptions() editor.Options {
-	return editor.Options{}
+	return editor.Options{} // TODO: remove?
 }
 
 // SetOptions implements WriteSession
 func (s *prollyWriteSession) SetOptions(opts editor.Options) {
-	return
+	return // TODO: remove?
 }
 
 // Flush implements WriteSessionFlusher
 func (s *prollyWriteSession) Flush(ctx *sql.Context) (*doltdb.WorkingSet, error) {
-	s.mut.Lock()
-	defer s.mut.Unlock()
 	_, err := s.flushAllTables(ctx)
 	if err != nil {
 		return nil, err
@@ -188,7 +179,11 @@ func (s *prollyWriteSession) FlushTable(ctx *sql.Context, tblName doltdb.TableNa
 		}
 		s.workingSet = s.workingSet.WithWorkingRoot(flushed)
 	}
-
+	// TODO: avoid prollyWriteSession.SetWorkingSet here
+	err = s.setter(ctx, s.dbName, flushed)
+	if err != nil {
+		return nil, err
+	}
 	return flushed, nil
 }
 
@@ -227,13 +222,14 @@ func (s *prollyWriteSession) flushAllTablesOld(ctx *sql.Context) (doltdb.RootVal
 		}()
 	}
 
-	// Drain from the flushedTables channel and update RootValue with updated table
 	var flushed doltdb.RootValue
 	if s.targetStaging {
 		flushed = s.workingSet.StagedRoot()
 	} else {
 		flushed = s.workingSet.WorkingRoot()
 	}
+
+	// Drain from the flushedTables channel and update RootValue with updated table
 	eg := errgroup.Group{}
 	eg.Go(func() error {
 		var err error
@@ -264,5 +260,6 @@ func (s *prollyWriteSession) flushAllTablesOld(ctx *sql.Context) (doltdb.RootVal
 	} else {
 		s.workingSet = s.workingSet.WithWorkingRoot(flushed)
 	}
+
 	return flushed, nil
 }

--- a/go/libraries/doltcore/sqle/writer/prolly_write_session.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_write_session.go
@@ -194,6 +194,17 @@ func (s *prollyWriteSession) FlushTable(ctx *sql.Context, tblName doltdb.TableNa
 
 // flushAllTables is the inner implementation for Flush that does not acquire any locks
 func (s *prollyWriteSession) flushAllTables(ctx *sql.Context) (doltdb.RootValue, error) {
+	for _, tblWriter := range s.tables {
+		err := tblWriter.flush(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return s.workingSet.WorkingRoot(), nil
+}
+
+// flushAllTables is the inner implementation for Flush that does not acquire any locks
+func (s *prollyWriteSession) flushAllTablesOld(ctx *sql.Context) (doltdb.RootValue, error) {
 	type flushedTable struct {
 		tblName doltdb.TableName
 		tbl     *doltdb.Table

--- a/go/libraries/doltcore/sqle/writer/prolly_write_session.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_write_session.go
@@ -189,17 +189,6 @@ func (s *prollyWriteSession) FlushTable(ctx *sql.Context, tblName doltdb.TableNa
 
 // flushAllTables is the inner implementation for Flush that does not acquire any locks
 func (s *prollyWriteSession) flushAllTables(ctx *sql.Context) (doltdb.RootValue, error) {
-	for _, tblWriter := range s.tables {
-		err := tblWriter.flush(ctx)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return s.workingSet.WorkingRoot(), nil
-}
-
-// flushAllTables is the inner implementation for Flush that does not acquire any locks
-func (s *prollyWriteSession) flushAllTablesOld(ctx *sql.Context) (doltdb.RootValue, error) {
 	type flushedTable struct {
 		tblName doltdb.TableName
 		tbl     *doltdb.Table
@@ -259,6 +248,10 @@ func (s *prollyWriteSession) flushAllTablesOld(ctx *sql.Context) (doltdb.RootVal
 		s.workingSet = s.workingSet.WithStagedRoot(flushed)
 	} else {
 		s.workingSet = s.workingSet.WithWorkingRoot(flushed)
+	}
+
+	if err := s.setter(ctx, s.dbName, flushed); err != nil {
+		return nil, err
 	}
 
 	return flushed, nil

--- a/go/libraries/doltcore/sqle/writer/prolly_write_session.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_write_session.go
@@ -265,8 +265,8 @@ func (s *prollyWriteSession) flushAllTables(ctx *sql.Context) (doltdb.RootValue,
 	// Need to unlock here because s.setter() is DoltSession.SetWorkingSet(), which calls
 	// prollyWriteSession.SetWorkingSet(), and we don't want to double lock.
 	s.mut.Unlock()
-	if err := s.setter(ctx, s.dbName, flushed); err != nil {
-		return nil, err
-	}
+	//if err := s.setter(ctx, s.dbName, flushed); err != nil {
+	//	return nil, err
+	//}
 	return flushed, nil
 }

--- a/go/libraries/doltcore/sqle/writer/prolly_write_session.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_write_session.go
@@ -36,7 +36,6 @@ func NewWriteSession(dbName string, ws *doltdb.WorkingSet, aiTracker globalstate
 		dbName:        dbName,
 		tables:        make(map[doltdb.TableName]*prollyTableWriter),
 		aiTracker:     aiTracker,
-		mut:           &sync.RWMutex{},
 		workingSet:    ws,
 		setter:        setter,
 		targetStaging: opts.TargetStaging,
@@ -49,7 +48,6 @@ type prollyWriteSession struct {
 	dbName        string
 	tables        map[doltdb.TableName]*prollyTableWriter
 	aiTracker     globalstate.AutoIncrementTracker
-	mut           *sync.RWMutex
 	workingSet    *doltdb.WorkingSet
 	setter        dsess.SessionRootSetter
 	targetStaging bool
@@ -62,8 +60,6 @@ func (s *prollyWriteSession) GetWorkingSet() *doltdb.WorkingSet {
 }
 
 func (s *prollyWriteSession) VisitGCRoots(ctx context.Context, roots func(hash.Hash) bool) error {
-	s.mut.RLock()
-	defer s.mut.RUnlock()
 	for _, writer := range s.tables {
 		err := writer.VisitGCRoots(ctx, roots)
 		if err != nil {
@@ -75,8 +71,6 @@ func (s *prollyWriteSession) VisitGCRoots(ctx context.Context, roots func(hash.H
 
 // GetTableWriter implements WriteSession
 func (s *prollyWriteSession) GetTableWriter(ctx *sql.Context, tblName doltdb.TableName) (dsess.TableWriter, error) {
-	s.mut.RLock()
-	defer s.mut.RUnlock()
 	if tw, ok := s.tables[tblName]; ok {
 		return tw, nil
 	}
@@ -117,8 +111,6 @@ func (s *prollyWriteSession) GetTableWriter(ctx *sql.Context, tblName doltdb.Tab
 
 // SetWorkingSet implements WriteSession
 func (s *prollyWriteSession) SetWorkingSet(ctx *sql.Context, ws *doltdb.WorkingSet) error {
-	s.mut.Lock()
-	defer s.mut.Unlock()
 	root := ws.WorkingRoot()
 	rootHash, err := root.HashOf()
 	if err != nil {
@@ -172,7 +164,6 @@ func (s *prollyWriteSession) Flush(ctx *sql.Context) (*doltdb.WorkingSet, error)
 
 // FlushTable puts the already materialized table into the working set
 func (s *prollyWriteSession) FlushTable(ctx *sql.Context, tblName doltdb.TableName, tbl *doltdb.Table) (flushed doltdb.RootValue, err error) {
-	s.mut.Lock()
 	if s.targetStaging {
 		flushed = s.workingSet.StagedRoot()
 		flushed, err = flushed.PutTable(ctx, tblName, tbl)
@@ -188,9 +179,6 @@ func (s *prollyWriteSession) FlushTable(ctx *sql.Context, tblName doltdb.TableNa
 		}
 		s.workingSet = s.workingSet.WithWorkingRoot(flushed)
 	}
-	// Need to unlock here because s.setter() is DoltSession.SetWorkingSet(), which calls
-	// prollyWriteSession.SetWorkingSet(), and we don't want to double lock.
-	s.mut.Unlock()
 	err = s.setter(ctx, s.dbName, flushed)
 	if err != nil {
 		return nil, err
@@ -223,7 +211,6 @@ func (s *prollyWriteSession) flushAllTables(ctx *sql.Context) (doltdb.RootValue,
 	}
 
 	var flushed doltdb.RootValue
-	s.mut.Lock()
 	if s.targetStaging {
 		flushed = s.workingSet.StagedRoot()
 	} else {
@@ -262,11 +249,7 @@ func (s *prollyWriteSession) flushAllTables(ctx *sql.Context) (doltdb.RootValue,
 		s.workingSet = s.workingSet.WithWorkingRoot(flushed)
 	}
 
-	// Need to unlock here because s.setter() is DoltSession.SetWorkingSet(), which calls
-	// prollyWriteSession.SetWorkingSet(), and we don't want to double lock.
-	s.mut.Unlock()
-	//if err := s.setter(ctx, s.dbName, flushed); err != nil {
-	//	return nil, err
-	//}
+	// TODO: seems like we should call s.setter to update the working set in the branch state,
+	//  but doing so causes Binlog replication tests to fail?
 	return flushed, nil
 }

--- a/go/libraries/doltcore/sqle/writer/prolly_write_session.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_write_session.go
@@ -62,6 +62,8 @@ func (s *prollyWriteSession) GetWorkingSet() *doltdb.WorkingSet {
 }
 
 func (s *prollyWriteSession) VisitGCRoots(ctx context.Context, roots func(hash.Hash) bool) error {
+	s.mut.RLock()
+	defer s.mut.RUnlock()
 	for _, writer := range s.tables {
 		err := writer.VisitGCRoots(ctx, roots)
 		if err != nil {

--- a/go/libraries/doltcore/sqle/writer/prolly_write_session.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_write_session.go
@@ -36,6 +36,7 @@ func NewWriteSession(dbName string, ws *doltdb.WorkingSet, aiTracker globalstate
 		dbName:        dbName,
 		tables:        make(map[doltdb.TableName]*prollyTableWriter),
 		aiTracker:     aiTracker,
+		mut:           &sync.Mutex{},
 		workingSet:    ws,
 		setter:        setter,
 		targetStaging: opts.TargetStaging,
@@ -48,6 +49,7 @@ type prollyWriteSession struct {
 	dbName        string
 	tables        map[doltdb.TableName]*prollyTableWriter
 	aiTracker     globalstate.AutoIncrementTracker
+	mut           *sync.RWMutex
 	workingSet    *doltdb.WorkingSet
 	setter        dsess.SessionRootSetter
 	targetStaging bool
@@ -71,6 +73,8 @@ func (s *prollyWriteSession) VisitGCRoots(ctx context.Context, roots func(hash.H
 
 // GetTableWriter implements WriteSession
 func (s *prollyWriteSession) GetTableWriter(ctx *sql.Context, tblName doltdb.TableName) (dsess.TableWriter, error) {
+	s.mut.RLock()
+	defer s.mut.RUnlock()
 	if tw, ok := s.tables[tblName]; ok {
 		return tw, nil
 	}
@@ -111,6 +115,8 @@ func (s *prollyWriteSession) GetTableWriter(ctx *sql.Context, tblName doltdb.Tab
 
 // SetWorkingSet implements WriteSession
 func (s *prollyWriteSession) SetWorkingSet(ctx *sql.Context, ws *doltdb.WorkingSet) error {
+	s.mut.Lock()
+	defer s.mut.Unlock()
 	root := ws.WorkingRoot()
 	rootHash, err := root.HashOf()
 	if err != nil {
@@ -164,6 +170,7 @@ func (s *prollyWriteSession) Flush(ctx *sql.Context) (*doltdb.WorkingSet, error)
 
 // FlushTable puts the already materialized table into the working set
 func (s *prollyWriteSession) FlushTable(ctx *sql.Context, tblName doltdb.TableName, tbl *doltdb.Table) (flushed doltdb.RootValue, err error) {
+	s.mut.Lock()
 	if s.targetStaging {
 		flushed = s.workingSet.StagedRoot()
 		flushed, err = flushed.PutTable(ctx, tblName, tbl)
@@ -179,7 +186,9 @@ func (s *prollyWriteSession) FlushTable(ctx *sql.Context, tblName doltdb.TableNa
 		}
 		s.workingSet = s.workingSet.WithWorkingRoot(flushed)
 	}
-	// TODO: avoid prollyWriteSession.SetWorkingSet here
+	// Need to unlock here because s.setter() is DoltSession.SetWorkingSet(), which calls
+	// prollyWriteSession.SetWorkingSet(), and we don't want to double lock.
+	s.mut.Unlock()
 	err = s.setter(ctx, s.dbName, flushed)
 	if err != nil {
 		return nil, err
@@ -212,6 +221,7 @@ func (s *prollyWriteSession) flushAllTables(ctx *sql.Context) (doltdb.RootValue,
 	}
 
 	var flushed doltdb.RootValue
+	s.mut.Lock()
 	if s.targetStaging {
 		flushed = s.workingSet.StagedRoot()
 	} else {
@@ -250,9 +260,11 @@ func (s *prollyWriteSession) flushAllTables(ctx *sql.Context) (doltdb.RootValue,
 		s.workingSet = s.workingSet.WithWorkingRoot(flushed)
 	}
 
+	// Need to unlock here because s.setter() is DoltSession.SetWorkingSet(), which calls
+	// prollyWriteSession.SetWorkingSet(), and we don't want to double lock.
+	s.mut.Unlock()
 	if err := s.setter(ctx, s.dbName, flushed); err != nil {
 		return nil, err
 	}
-
 	return flushed, nil
 }

--- a/go/libraries/doltcore/sqle/writer/prolly_write_session.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_write_session.go
@@ -145,12 +145,15 @@ func (s *prollyWriteSession) SetWorkingSet(ctx *sql.Context, ws *doltdb.WorkingS
 
 // GetOptions implements WriteSession
 func (s *prollyWriteSession) GetOptions() editor.Options {
-	return editor.Options{} // TODO: remove?
+	return editor.Options{
+		TargetStaging: s.targetStaging,
+	}
 }
 
 // SetOptions implements WriteSession
 func (s *prollyWriteSession) SetOptions(opts editor.Options) {
-	return // TODO: remove?
+	s.targetStaging = opts.TargetStaging
+	return
 }
 
 // Flush implements WriteSessionFlusher

--- a/go/libraries/doltcore/sqle/writer/prolly_write_session.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_write_session.go
@@ -36,7 +36,7 @@ func NewWriteSession(dbName string, ws *doltdb.WorkingSet, aiTracker globalstate
 		dbName:        dbName,
 		tables:        make(map[doltdb.TableName]*prollyTableWriter),
 		aiTracker:     aiTracker,
-		mut:           &sync.Mutex{},
+		mut:           &sync.RWMutex{},
 		workingSet:    ws,
 		setter:        setter,
 		targetStaging: opts.TargetStaging,


### PR DESCRIPTION
This PR moves logic for updating the branch state from `prollyTableWriter` to `prollyWriteSession`.
Additionally, it completely removes the mutex "protecting" `prollyWriteSession.workingSet` because it is unnecessary; there's no way the same `prollyWriteSession` is accessed by multiple threads.