### PR TITLE
errors: surface ENOSPC instead of crashing under FatalBehaviorCrash

### DIFF
--- a/go/libraries/utils/errors/panic.go
+++ b/go/libraries/utils/errors/panic.go
@@ -15,8 +15,10 @@
 package errors
 
 import (
+	stderrors "errors"
 	"fmt"
 	"runtime/debug"
+	"syscall"
 	"time"
 )
 
@@ -34,8 +36,20 @@ const (
 // be entering an unsafe state due to the encountered error. If |behavior| is
 // FatalBehaviorCrash, this function will never return. Otherwise, an error value is
 // returned, built with fmt.Errorf on |msg| and |args|.
+//
+// As a special case, even when |behavior| is FatalBehaviorCrash, if any of |args|
+// is an error whose chain contains syscall.ENOSPC, Fatalf returns the error
+// instead of crashing the process. Disk-exhaustion is operator-recoverable by
+// freeing space; crashing under ENOSPC and being auto-restarted by a supervisor
+// triggers another write attempt against the still-full filesystem, which
+// fails identically and can leave additional partial files behind. Surfacing
+// the error to the caller lets the failure be reported cleanly without the
+// recovery cycle amplifying it. See https://github.com/dolthub/dolt/issues/11068.
 func Fatalf(behavior FatalBehavior, msg string, args ...any) error {
 	if behavior == FatalBehaviorCrash {
+		if anyArgIsEnospc(args) {
+			return fmt.Errorf("fatal error: "+msg, args...)
+		}
 		stack := string(debug.Stack())
 		args := append([]any{stack}, args...)
 		go func() {
@@ -47,4 +61,16 @@ func Fatalf(behavior FatalBehavior, msg string, args ...any) error {
 	} else {
 		return fmt.Errorf("fatal error: "+msg, args...)
 	}
+}
+
+// anyArgIsEnospc reports whether any of |args| is an error whose unwrap chain
+// contains syscall.ENOSPC. Used by Fatalf to distinguish disk-exhaustion from
+// other fatal conditions.
+func anyArgIsEnospc(args []any) bool {
+	for _, a := range args {
+		if e, ok := a.(error); ok && stderrors.Is(e, syscall.ENOSPC) {
+			return true
+		}
+	}
+	return false
 }

--- a/go/libraries/utils/errors/panic_test.go
+++ b/go/libraries/utils/errors/panic_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	stderrors "errors"
+	"fmt"
+	"io"
+	"syscall"
+	"testing"
+)
+
+// TestFatalf_ENOSPCUnderCrashReturnsError documents the special-case
+// behavior: under FatalBehaviorCrash, an ENOSPC argument causes Fatalf to
+// return an error rather than crashing the process. Disk-exhaustion is
+// recoverable by the operator and the panic-restart cycle amplifies the
+// failure, so callers receive the error and can surface it cleanly.
+func TestFatalf_ENOSPCUnderCrashReturnsError(t *testing.T) {
+	err := Fatalf(FatalBehaviorCrash, "%w: error writing journal", syscall.ENOSPC)
+	if err == nil {
+		t.Fatal("expected returned error on ENOSPC under FatalBehaviorCrash, got nil")
+	}
+	if !stderrors.Is(err, syscall.ENOSPC) {
+		t.Errorf("expected ENOSPC in error chain, got: %v", err)
+	}
+}
+
+// TestFatalf_WrappedENOSPCUnderCrashReturnsError verifies that ENOSPC is
+// detected even when it is wrapped inside another error (the common case
+// when an OS write call produces a syscall error that the caller wraps
+// with its own context before passing it to Fatalf).
+func TestFatalf_WrappedENOSPCUnderCrashReturnsError(t *testing.T) {
+	wrapped := fmt.Errorf("write /tmp/example: %w", syscall.ENOSPC)
+	err := Fatalf(FatalBehaviorCrash, "%w: error during conjoin", wrapped)
+	if err == nil {
+		t.Fatal("expected returned error on wrapped ENOSPC, got nil")
+	}
+	if !stderrors.Is(err, syscall.ENOSPC) {
+		t.Errorf("expected ENOSPC in error chain, got: %v", err)
+	}
+}
+
+// TestFatalf_ErrorModeReturnsErrorAsBefore verifies that the existing
+// FatalBehaviorError contract is unchanged: any error (ENOSPC or not) is
+// returned wrapped.
+func TestFatalf_ErrorModeReturnsErrorAsBefore(t *testing.T) {
+	err := Fatalf(FatalBehaviorError, "%w: some other failure", io.EOF)
+	if err == nil {
+		t.Fatal("expected error in FatalBehaviorError mode")
+	}
+	if !stderrors.Is(err, io.EOF) {
+		t.Errorf("expected EOF in error chain, got: %v", err)
+	}
+}
+
+// TestAnyArgIsEnospc covers the helper directly.
+func TestAnyArgIsEnospc(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []any
+		want bool
+	}{
+		{name: "empty", args: nil, want: false},
+		{name: "no_errors", args: []any{"not an error", 42}, want: false},
+		{name: "unrelated_error", args: []any{io.EOF}, want: false},
+		{name: "direct_enospc", args: []any{syscall.ENOSPC}, want: true},
+		{name: "wrapped_enospc", args: []any{fmt.Errorf("ctx: %w", syscall.ENOSPC)}, want: true},
+		{name: "second_arg_enospc", args: []any{"other", io.EOF, syscall.ENOSPC}, want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := anyArgIsEnospc(tc.args); got != tc.want {
+				t.Errorf("anyArgIsEnospc(%v) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Refs #11068.

Disk-exhaustion (`syscall.ENOSPC`) returned from a write inside an NBS fatal path currently triggers `FatalBehaviorCrash`, which restarts the dolt sql-server. Under any supervisor that auto-restarts the server (systemd, container orchestrator, Gas City, etc.), the restart triggers another write against the still-full filesystem. That second attempt fails identically, can leave another partial `nbs_table_*` file behind in the backup remote, and the cycle repeats every 30s under common health-check cadences. Two independent reports in #11068 observed this consume **~60 GB of free disk overnight on one host and ~7 GB in 3 minutes on another**.

ENOSPC is operator-recoverable by freeing disk space — it is not a data-corruption or invariant-violation condition that requires the process to die. Returning the error to the caller is safe (every existing `Fatalf` callsite already returns or assigns the result, so they handle the error correctly) and prevents the supervisor-restart amplification cycle.

## Change

A single special-case in `Fatalf`: when behavior is `FatalBehaviorCrash` and any of `args` is an error chain containing `syscall.ENOSPC`, return the error rather than crashing. Other fatal conditions continue to crash as before. `FatalBehaviorError` mode is unchanged.

```go
func Fatalf(behavior FatalBehavior, msg string, args ...any) error {
    if behavior == FatalBehaviorCrash {
        if anyArgIsEnospc(args) {
            return fmt.Errorf("fatal error: "+msg, args...)
        }
        // ... existing crash path unchanged ...
    }
    ...
}
```

`anyArgIsEnospc` uses `errors.Is` against `syscall.ENOSPC`, so wrapped errors (the common case — an OS write returns ENOSPC and the caller wraps it before passing) are detected.

## Existing callsites that funnel through this

```
go/store/nbs/journal.go:424         UpdateGCGen
go/store/nbs/store.go:1673          closing table persister
go/store/nbs/file_manifest.go:466   renaming manifest
go/store/nbs/file_manifest.go:470   fsync manifest dir
go/store/nbs/journal_writer.go:471  syncing journal
go/store/nbs/journal_writer.go:544  writing to journal file   <- panic site in #11068
```

All six callsites either return or assign the `Fatalf` result, so each handles a returned error correctly.

## Test plan

- [x] `gofmt -l` clean
- [x] `go vet ./libraries/utils/errors/` clean
- [x] `go build ./libraries/utils/errors/ ./store/nbs/` succeeds
- [x] New unit tests cover the special-case branches:
  - Direct `syscall.ENOSPC` arg under `FatalBehaviorCrash` returns wrapped error
  - Wrapped `ENOSPC` (`fmt.Errorf("%w", syscall.ENOSPC)`) also returns
  - `FatalBehaviorError` mode unchanged
  - `anyArgIsEnospc` helper covered with empty / no-error / unrelated / direct / wrapped / multi-arg cases
- [x] Journal-related tests in `./store/nbs/` pass (`go test -run "Journal" ./store/nbs/`)

The crash-path-for-non-ENOSPC case isn't easily testable in-process without a subprocess fork (since it actually panics the test binary). The existing crash branch is preserved untouched; coverage there would need a separate test infrastructure pattern. Happy to add it if maintainers can point to an existing example.

## Not addressed by this PR

Per #11068, there is a related concern: when `conjoin` fails mid-write with ENOSPC, a partial `nbs_table_*` file is left behind in the target. This PR breaks the panic-restart amplification cycle, which means each ENOSPC produces at most one partial file rather than dozens, but it does not clean up that one file. The cleanup belongs in the conjoin write path (separate code, separate review surface) and should be addressed in a follow-up.

Similarly, the dolt sql-server's internal auto-backup-sync mechanism that triggers conjoin independent of any external scheduler is not changed here — that's an architectural question for the maintainers.

## Risk

Low. The change adds one branch to a single function, gated on an error-chain match for `syscall.ENOSPC`. The non-ENOSPC crash path is byte-for-byte unchanged. The `FatalBehaviorError` path is unchanged. All existing callsites of `Fatalf` already handle the returned-error case (verified by inspection — they return or assign).
