### PR TITLE
go/store/nbs: Delete the in-flight table file in (*fileTablePersister).writeAndProtect when we experience an error on the write.

### DIFF
--- a/go/store/nbs/file_table_persister.go
+++ b/go/store/nbs/file_table_persister.go
@@ -234,6 +234,12 @@ func (ftp *fsTablePersister) TryMoveCmpChunkTableWriter(ctx context.Context, fil
 // renames it to its final name, and adds it to the pending set. The returned
 // handle must be closed after the file has been Open'd or is no longer needed.
 // The pruneMu read lock is held for the entire operation.
+//
+// If writeFn fails, or the temp file cannot be closed or renamed, the inflight
+// temp file is removed before returning the error. This matters for callers
+// like ConjoinAll, where an I/O error reading a source under FatalBehaviorError
+// would otherwise leave the partially written conjoined table/archive file
+// behind until the next PruneTableFiles.
 func (ftp *fsTablePersister) writeAndProtect(finalName string, writeFn func(temp *os.File) error) (*pendingHandle, error) {
 	addr, ok := fileNameToAddr(finalName)
 	if !ok {
@@ -247,15 +253,19 @@ func (ftp *fsTablePersister) writeAndProtect(finalName string, writeFn func(temp
 	if err != nil {
 		return nil, err
 	}
+	tempName := temp.Name()
 
 	if err = writeFn(temp); err != nil {
 		_ = temp.Close()
+		_ = file.Remove(tempName)
 		return nil, err
 	}
 	if err = temp.Close(); err != nil {
+		_ = file.Remove(tempName)
 		return nil, err
 	}
-	if err = file.Rename(temp.Name(), filepath.Join(ftp.dir, finalName)); err != nil {
+	if err = file.Rename(tempName, filepath.Join(ftp.dir, finalName)); err != nil {
+		_ = file.Remove(tempName)
 		return nil, err
 	}
 	return ftp.addPending(addr), nil

--- a/go/store/nbs/file_table_persister_test.go
+++ b/go/store/nbs/file_table_persister_test.go
@@ -24,9 +24,11 @@ package nbs
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	dherrors "github.com/dolthub/dolt/go/libraries/utils/errors"
@@ -292,5 +294,50 @@ func TestFSTablePersisterConjoinAllDups(t *testing.T) {
 		defer tr.close()
 		assertChunksInReader(testChunks, tr, assert)
 		assert.EqualValues(reps*len(testChunks), tr.count())
+	}
+}
+
+// TestFSTablePersisterWriteAndProtectCleansUpTempOnError asserts that the
+// inflight temp file is removed when writeFn fails. This is the I/O-error
+// case for ConjoinAll: when copying a source under FatalBehaviorError fails,
+// the partially written conjoined table/archive file must not be left behind.
+func TestFSTablePersisterWriteAndProtectCleansUpTempOnError(t *testing.T) {
+	hasTempFile := func(t *testing.T, dir string) bool {
+		t.Helper()
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		for _, e := range entries {
+			if strings.HasPrefix(e.Name(), tempTablePrefix) {
+				return true
+			}
+		}
+		return false
+	}
+
+	addr := computeAddr([]byte("conjoined"))
+	cases := []struct {
+		name      string
+		finalName string
+	}{
+		{"table file", addr.String()},
+		{"archive file", addr.String() + ArchiveFileSuffix},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := makeTempDir(t)
+			defer file.RemoveAll(dir)
+			ftp := newFSTablePersister(dir, &UnlimitedQuotaProvider{}, false).(*fsTablePersister)
+
+			wantErr := errors.New("simulated I/O error during conjoin")
+			_, err := ftp.writeAndProtect(c.finalName, func(temp *os.File) error {
+				// Write a partial result, as a conjoin copy would before
+				// hitting an I/O error part way through.
+				_, _ = temp.Write([]byte("partial conjoined data"))
+				return wantErr
+			})
+			require.ErrorIs(t, err, wantErr)
+			assert.False(t, hasTempFile(t, dir), "inflight temp file was not cleaned up after writeFn error")
+		})
 	}
 }


### PR DESCRIPTION
Leaving it behind needlessly wastes disk space. It will never be usable and is in an indeterminate state.

This is currently relevant even when FatalBehaviorFatal, because Conjoin's write is currently allowed to fail before we take the hard dependency on it. There are still some I/O errors which leave the file behind, including a failure at ftp.Open().