### PR TITLE
go/store/nbs: journal.go: Fix a bug which could result in broken databases after a process crash.

### DIFF
--- a/go/store/nbs/journal.go
+++ b/go/store/nbs/journal.go
@@ -195,6 +195,31 @@ func (j *ChunkJournal) bootstrapJournalWriter(ctx context.Context, warningsCb fu
 		return err
 	}
 
+	if root.IsEmpty() {
+		// The journal file exists but contains no root hash record. This can
+		// happen if the process crashed after the journal file was created but
+		// before its first root hash record was committed. In this case the
+		// journal is not yet a source of truth for the root hash, so we fall
+		// back to the root hash recorded in the manifest rather than truing-up
+		// the manifest to the empty root.
+		var contents manifestContents
+		ok, contents, err = j.backing.ParseIfExists(ctx, &Stats{}, nil)
+		if err != nil {
+			return err
+		}
+		if ok {
+			if canCreate {
+				// commit the manifest root to the journal so that it becomes a
+				// valid source of truth for subsequent bootstraps.
+				if err = j.wr.commitRootHash(ctx, dherrors.FatalBehaviorError, contents.root); err != nil {
+					return err
+				}
+			}
+			j.contents = contents
+		}
+		return
+	}
+
 	mc, err := trueUpBackingManifest(ctx, dherrors.FatalBehaviorError, root, j.backing)
 	if err != nil {
 		return err

--- a/go/store/nbs/journal.go
+++ b/go/store/nbs/journal.go
@@ -76,7 +76,10 @@ var _ manifest = &ChunkJournal{}
 var _ manifestGCGenUpdater = &ChunkJournal{}
 var _ io.Closer = &ChunkJournal{}
 
-func newChunkJournal(ctx context.Context, nbfVers, dir string, m *journalManifest, p *fsTablePersister, warningsCb func(error)) (*ChunkJournal, error) {
+// |behavior| controls how fatal errors encountered during bootstrapping are handled; the
+// NomsBlockStore is not yet constructed at this point, so callers pass FatalBehaviorError to
+// fail store creation rather than crash the process.
+func newChunkJournal(ctx context.Context, nbfVers, dir string, m *journalManifest, p *fsTablePersister, behavior dherrors.FatalBehavior, warningsCb func(error)) (*ChunkJournal, error) {
 	path, err := filepath.Abs(filepath.Join(dir, chunkJournalName))
 	if err != nil {
 		return nil, err
@@ -92,7 +95,7 @@ func newChunkJournal(ctx context.Context, nbfVers, dir string, m *journalManifes
 	} else if ok {
 		// only bootstrap journalWriter if the journal file exists,
 		// otherwise we wait to open in case we're cloning
-		if err = j.bootstrapJournalWriter(ctx, warningsCb); err != nil {
+		if err = j.bootstrapJournalWriter(ctx, behavior, warningsCb); err != nil {
 			return nil, err
 		}
 	}
@@ -143,9 +146,12 @@ func reflogBufferSize() int {
 // As we process journal records, we keep track of the latest root hash record we see
 // and update the manifest file with the last root hash we saw.
 //
+// |behavior| controls how fatal errors encountered while writing to the journal or manifest are
+// handled (returned as an error vs. crashing the process); see dherrors.FatalBehavior.
+//
 // |warningsCb| is a callback function invoked if a recoverable parse error is encountered. Usually used
 // for printing an error message to the user, but also used for fsck to report the error and exit with an error.
-func (j *ChunkJournal) bootstrapJournalWriter(ctx context.Context, warningsCb func(error)) (err error) {
+func (j *ChunkJournal) bootstrapJournalWriter(ctx context.Context, behavior dherrors.FatalBehavior, warningsCb func(error)) (err error) {
 	var ok bool
 	ok, err = fileExists(j.path)
 	if err != nil {
@@ -172,9 +178,7 @@ func (j *ChunkJournal) bootstrapJournalWriter(ctx context.Context, warningsCb fu
 		}
 		if ok {
 			// write the current root hash to the journal file
-			// FatalBehaviorError here reflects the fact that we should fail the create, not
-			// crash the entire process, assuming this database is not already opened for write.
-			if err = j.wr.commitRootHash(ctx, dherrors.FatalBehaviorError, contents.root); err != nil {
+			if err = j.wr.commitRootHash(ctx, behavior, contents.root); err != nil {
 				return
 			}
 			j.contents = contents
@@ -211,7 +215,7 @@ func (j *ChunkJournal) bootstrapJournalWriter(ctx context.Context, warningsCb fu
 			if canCreate {
 				// commit the manifest root to the journal so that it becomes a
 				// valid source of truth for subsequent bootstraps.
-				if err = j.wr.commitRootHash(ctx, dherrors.FatalBehaviorError, contents.root); err != nil {
+				if err = j.wr.commitRootHash(ctx, behavior, contents.root); err != nil {
 					return err
 				}
 			}
@@ -220,7 +224,7 @@ func (j *ChunkJournal) bootstrapJournalWriter(ctx context.Context, warningsCb fu
 		return
 	}
 
-	mc, err := trueUpBackingManifest(ctx, dherrors.FatalBehaviorError, root, j.backing)
+	mc, err := trueUpBackingManifest(ctx, behavior, root, j.backing)
 	if err != nil {
 		return err
 	}
@@ -288,7 +292,7 @@ func (j *ChunkJournal) IterateRoots(f func(root string, timestamp *time.Time) er
 func (j *ChunkJournal) Persist(ctx context.Context, behavior dherrors.FatalBehavior, mt *memTable, haver chunkReader, keeper keeperF, stats *Stats) (chunkSource, gcBehavior, error) {
 	if j.backing.readOnly() {
 		return nil, gcBehavior_Continue, errReadOnlyManifest
-	} else if err := j.maybeInit(ctx, JournalParserLoggingWarningsCb); err != nil {
+	} else if err := j.maybeInit(ctx, behavior, JournalParserLoggingWarningsCb); err != nil {
 		return nil, gcBehavior_Continue, err
 	}
 
@@ -326,7 +330,9 @@ func (j *ChunkJournal) ConjoinAll(ctx context.Context, behavior dherrors.FatalBe
 // Open implements tablePersister.
 func (j *ChunkJournal) Open(ctx context.Context, name hash.Hash, chunkCount uint32, stats *Stats) (chunkSource, error) {
 	if name == journalAddr {
-		if err := j.maybeInit(ctx, JournalParserLoggingWarningsCb); err != nil {
+		// Open is a tablePersister method with no FatalBehavior parameter; if it has to
+		// bootstrap the journal, fail with an error rather than crashing the process.
+		if err := j.maybeInit(ctx, dherrors.FatalBehaviorError, JournalParserLoggingWarningsCb); err != nil {
 			return nil, err
 		}
 		return journalChunkSource{journal: j.wr}, nil
@@ -502,9 +508,9 @@ func (j *ChunkJournal) ParseIfExists(ctx context.Context, stats *Stats, readHook
 	return
 }
 
-func (j *ChunkJournal) maybeInit(ctx context.Context, warningsCb func(error)) (err error) {
+func (j *ChunkJournal) maybeInit(ctx context.Context, behavior dherrors.FatalBehavior, warningsCb func(error)) (err error) {
 	if j.wr == nil {
-		err = j.bootstrapJournalWriter(ctx, warningsCb)
+		err = j.bootstrapJournalWriter(ctx, behavior, warningsCb)
 	}
 	return
 }

--- a/go/store/nbs/journal_test.go
+++ b/go/store/nbs/journal_test.go
@@ -43,7 +43,7 @@ func makeTestChunkJournal(t *testing.T) *ChunkJournal {
 	q := NewUnlimitedMemQuotaProvider()
 	p := newFSTablePersister(dir, q, false)
 	nbf := types.Format_Default.VersionString()
-	j, err := newChunkJournal(ctx, nbf, dir, m, p.(*fsTablePersister), nil)
+	j, err := newChunkJournal(ctx, nbf, dir, m, p.(*fsTablePersister), dherrors.FatalBehaviorError, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { j.Close() })
 	return j
@@ -55,7 +55,7 @@ func openTestChunkJournal(t *testing.T, dir string) *ChunkJournal {
 	q := NewUnlimitedMemQuotaProvider()
 	p := newFSTablePersister(dir, q, false)
 	nbf := types.Format_Default.VersionString()
-	j, err := newChunkJournal(t.Context(), nbf, dir, m, p.(*fsTablePersister), nil)
+	j, err := newChunkJournal(t.Context(), nbf, dir, m, p.(*fsTablePersister), dherrors.FatalBehaviorError, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { j.Close() })
 	return j

--- a/go/store/nbs/journal_test.go
+++ b/go/store/nbs/journal_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,6 +28,7 @@ import (
 	dherrors "github.com/dolthub/dolt/go/libraries/utils/errors"
 	"github.com/dolthub/dolt/go/libraries/utils/file"
 	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/types"
 )
 
@@ -107,6 +109,84 @@ func TestChunkJournalReadOnly(t *testing.T) {
 		_, err := newJournalManifest(t.Context(), rw.backing.dir, true)
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrDatabaseLocked)
+	})
+}
+
+// TestChunkJournalBootstrapMissingRootRecord verifies that when the journal file
+// exists but contains no root hash record, bootstrapping leaves the root recorded
+// in the manifest in place rather than overwriting it with the empty hash. This
+// state can arise from a crash between createJournalWriter and the first
+// commitRootHash, or between Persist flushing chunk records and Update committing
+// the root.
+func TestChunkJournalBootstrapMissingRootRecord(t *testing.T) {
+	cacheOnce.Do(makeGlobalCaches)
+	ctx := context.Background()
+	nbf := types.Format_Default.VersionString()
+
+	// setup creates a journaling store in |dir|, commits a root, and returns it.
+	setup := func(t *testing.T, dir string) hash.Hash {
+		store, err := NewLocalJournalingStore(ctx, nbf, dir, NewUnlimitedMemQuotaProvider(), false, nil)
+		require.NoError(t, err)
+		rootChunk := chunks.NewChunk([]byte("a commit root value"))
+		require.NoError(t, store.Put(ctx, rootChunk, noopGetAddrs))
+		ok, err := store.Commit(ctx, rootChunk.Hash(), hash.Hash{})
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.NoError(t, store.Close())
+		require.False(t, rootChunk.Hash().IsEmpty())
+		return rootChunk.Hash()
+	}
+
+	// reopen opens the journaling store in |dir|, returns its root, and closes it.
+	reopen := func(t *testing.T, dir string) hash.Hash {
+		store, err := NewLocalJournalingStore(ctx, nbf, dir, NewUnlimitedMemQuotaProvider(), false, nil)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, store.Close()) }()
+		root, err := store.Root(ctx)
+		require.NoError(t, err)
+		return root
+	}
+
+	// manifestRoot parses the on-disk manifest file directly and returns its root.
+	manifestRoot := func(t *testing.T, dir string) hash.Hash {
+		ok, mc, err := parseIfExists(ctx, dir, nil)
+		require.NoError(t, err)
+		require.True(t, ok)
+		return mc.root
+	}
+
+	t.Run("EmptyJournal", func(t *testing.T) {
+		dir := t.TempDir()
+		root := setup(t, dir)
+
+		// Simulate a crash between createJournalWriter and the first
+		// commitRootHash: the journal file exists but is empty.
+		require.NoError(t, os.Truncate(filepath.Join(dir, chunkJournalName), 0))
+		require.NoError(t, os.Remove(filepath.Join(dir, journalIndexFileName)))
+
+		// Bootstrapping must keep the manifest root, not overwrite it with 0000...
+		assert.Equal(t, root, reopen(t, dir))
+		assert.Equal(t, root, manifestRoot(t, dir))
+		// The recovered root must survive a subsequent restart.
+		assert.Equal(t, root, reopen(t, dir))
+	})
+
+	t.Run("ChunkRecordsNoRootRecord", func(t *testing.T) {
+		dir := t.TempDir()
+		root := setup(t, dir)
+
+		// Simulate a crash after Persist flushed chunk records but before
+		// Update committed the root: drop the trailing root hash record,
+		// leaving a journal of only chunk records.
+		jp := filepath.Join(dir, chunkJournalName)
+		info, err := os.Stat(jp)
+		require.NoError(t, err)
+		require.NoError(t, os.Truncate(jp, info.Size()-int64(rootHashRecordSize())))
+		require.NoError(t, os.Remove(filepath.Join(dir, journalIndexFileName)))
+
+		assert.Equal(t, root, reopen(t, dir))
+		assert.Equal(t, root, manifestRoot(t, dir))
+		assert.Equal(t, root, reopen(t, dir))
 	})
 }
 

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -819,7 +819,10 @@ func NewLocalJournalingStoreWithOptions(ctx context.Context, nbfVers, dir string
 	}
 	p := newFSTablePersister(dir, q, mmapArchiveIndexes)
 
-	journal, err := newChunkJournal(ctx, nbfVers, dir, m, p.(*fsTablePersister), warningsCb)
+	// The NomsBlockStore is not constructed yet, so bootstrapping errors should fail store
+	// creation rather than crash the process. Callers configure crash behavior afterwards
+	// via SetFatalBehavior.
+	journal, err := newChunkJournal(ctx, nbfVers, dir, m, p.(*fsTablePersister), dherrors.FatalBehaviorError, warningsCb)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If Dolt crashed immediately after creating an empty journal file, and before it wrote the initial set-root record to it, then the next time Dolt ran it would treat the root of the database as `0000...`.

This could also happen for certain observed filesystem states after an operating system crash.