### PR TITLE
fix(val): TextStorage/ByteArray WithMaxByteLength drops ctx → nil-ctx panic via Valuer.Value()

### DIFF
--- a/go/store/val/value_store.go
+++ b/go/store/val/value_store.go
@@ -114,6 +114,7 @@ func (t *TextStorage) WithMaxByteLength(maxByteLength int64) *TextStorage {
 	return &TextStorage{
 		ImmutableValue: NewImmutableValue(t.Addr, t.vs),
 		maxByteLength:  maxByteLength,
+		ctx:            t.ctx,
 	}
 }
 
@@ -136,7 +137,14 @@ func (t *TextStorage) Hash() interface{} {
 
 // Value implements driver.Valuer for interoperability with other go libraries
 func (t *TextStorage) Value() (driver.Value, error) {
-	buf, err := t.GetBytes(t.ctx)
+	ctx := t.ctx
+	if ctx == nil {
+		// Defensive: any construction path that fails to populate ctx must not
+		// produce a nil-ctx GetBytes call — that propagates to NomsBlockStore.Get
+		// and panics in OTEL tracing (gastownhall/beads#4049).
+		ctx = context.Background()
+	}
+	buf, err := t.GetBytes(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -225,12 +233,20 @@ func (b *ByteArray) WithMaxByteLength(maxByteLength int64) *ByteArray {
 	return &ByteArray{
 		ImmutableValue: b.ImmutableValue,
 		maxByteLength:  maxByteLength,
+		ctx:            b.ctx,
 	}
 }
 
 // Value implements driver.Valuer for interoperability with other go libraries
 func (b *ByteArray) Value() (driver.Value, error) {
-	return b.GetBytes(b.ctx)
+	ctx := b.ctx
+	if ctx == nil {
+		// Defensive: any construction path that fails to populate ctx must not
+		// produce a nil-ctx GetBytes call — that propagates to NomsBlockStore.Get
+		// and panics in OTEL tracing (gastownhall/beads#4049).
+		ctx = context.Background()
+	}
+	return b.GetBytes(ctx)
 }
 
 // GeometryStorage is a sql.AnyWrapper for geometry values.


### PR DESCRIPTION
## Summary

`TextStorage` and `ByteArray` in `go/store/val/value_store.go` store a `context.Context` field (commented as "bad practice but needed for `driver.Valuer` interoperability"). Their primary constructors (`NewTextStorage`, `NewByteArray`) correctly populate this field, but their `WithMaxByteLength` copy-constructors silently drop it. The returned `*TextStorage` / `*ByteArray` then has a nil `ctx`.

When such a value is later returned from a SQL row iteration and the caller invokes `Value()` (the `database/sql/driver.Valuer` interface, which provides no context parameter), the method calls `GetBytes(t.ctx)` with a nil context. The nil context flows through:

```
TextStorage.Value() → ImmutableValue.GetBytes(nil)
                    → nodeStore.ReadBytes(nil, ...)
                    → nodeStore.Read(nil, ...)
                    → GenerationalNBS.Get(nil, ...)
                    → NomsBlockStore.Get(nil, ...)       ← store.go:1048
                    → tracer.Start(nil, ...)
                    → trace.ContextWithSpan(nil, span)
                    → context.WithValue(nil, ...)        ← panics
```

## Repro

Reproduces consistently when a SQL query through the embedded driver returns rows containing TEXT or BLOB columns large enough to be stored as outlined chunks (i.e. dereferenced lazily via `GetBytes` rather than read inline). Smaller rows don't trigger it because no `GetBytes` call is made — the value comes back inline.

Encountered downstream via [beads (bd)](https://github.com/gastownhall/beads), an issue tracker built on Dolt that iterates `issues` rows via `database/sql`. Full panic stack and bd-side context: [gastownhall/beads#4049](https://github.com/gastownhall/beads/issues/4049).

Confirmed identical-version `dolt sql` works fine on the same database — only the Go SQL-driver row iteration path triggers it, because that path is where `Valuer.Value()` (no-context) gets called on the lazy text/byte wrappers.

## Fix

Two-pronged:

1. **Fix `WithMaxByteLength` on both types to propagate ctx.** This is the actual bug — a missing field in the struct literal. The original constructor stores ctx; the copy constructor should preserve it.

2. **Defensively guard `Value()` on both types** so a nil ctx falls back to `context.Background()`. This covers any other construction path that might not populate ctx (now or in the future) and prevents a regression into the same panic class. The comment on the existing struct field already acknowledges that storing ctx is "bad practice" — defending against the inevitable miss feels consistent with that intent.

## Diff

```diff
 // WithMaxByteLength returns a copy of TextStorage with the given max byte length.
 func (t *TextStorage) WithMaxByteLength(maxByteLength int64) *TextStorage {
        return &TextStorage{
                ImmutableValue: NewImmutableValue(t.Addr, t.vs),
                maxByteLength:  maxByteLength,
+               ctx:            t.ctx,
        }
 }

 // Value implements driver.Valuer for interoperability with other go libraries
 func (t *TextStorage) Value() (driver.Value, error) {
-       buf, err := t.GetBytes(t.ctx)
+       ctx := t.ctx
+       if ctx == nil {
+               ctx = context.Background()
+       }
+       buf, err := t.GetBytes(ctx)
        ...
 }
```

Same shape for `ByteArray`.

## Risk

Low — the changes are confined to two methods on two types, and only widen behaviour (where the old code would panic, the new code returns a real `driver.Value`). No semantic change for callers that already populate ctx correctly.

## Notes

- `context.Background()` (rather than e.g. propagating a stored context from the database connection) is the right fallback because `database/sql/driver.Valuer.Value()` has no place to receive a context from the caller — by the time the method runs, the calling context is no longer accessible through the interface. `context.Background()` correctly conveys "no cancellation, no deadline, do the read."
- Happy to add unit tests if useful — covering `NewTextStorage` → `WithMaxByteLength` → `Value()` and the same for `ByteArray`. Let me know the preferred test location.