### PR TITLE
Update docs URLs from docs.dolthub.com to dolthub.com/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Prefer Postgres instead of MySQL? Try [Doltgres](https://github.com/dolthub/dolt
 in its Beta release.
 
 [Join us on Discord](https://discord.com/invite/RFwfYpu) to say hi and
-ask questions, or [check out our roadmap](https://docs.dolthub.com/other/roadmap) 
+ask questions, or [check out our roadmap](https://dolthub.com/docs/other/roadmap) 
 to see what we're building next.
 
 # Video Introduction
@@ -152,7 +152,7 @@ Download the latest Microsoft Installer (`.msi` file) in
 [releases](https://github.com/dolthub/dolt/releases) and run
 it.
 
-For information on running on Windows, see [here](https://docs.dolthub.com/introduction/installation/windows).
+For information on running on Windows, see [here](https://dolthub.com/docs/introduction/installation/windows).
 
 #### Chocolatey
 
@@ -336,9 +336,9 @@ Dolt supports foreign keys, secondary indexes, triggers, check constraints, and 
 
 ## Make a Dolt commit
 
-It's time to use your first Dolt feature. We're going to make a Dolt [commit](https://docs.dolthub.com/concepts/dolt/commits). A Dolt commit allows you to time travel and see lineage. Make a Dolt commit whenever you want to restore or compare to this point in time.
+It's time to use your first Dolt feature. We're going to make a Dolt [commit](https://dolthub.com/docs/concepts/dolt/commits). A Dolt commit allows you to time travel and see lineage. Make a Dolt commit whenever you want to restore or compare to this point in time.
 
-Dolt exposes version control functionality through a Git-style interface. On the command line, Dolt commands map exactly to their Git equivalent with the targets being tables instead of files. In SQL, Dolt exposes version control read operations as [system tables](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables) and version control write operations as [stored procedures](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-procedures). 
+Dolt exposes version control functionality through a Git-style interface. On the command line, Dolt commands map exactly to their Git equivalent with the targets being tables instead of files. In SQL, Dolt exposes version control read operations as [system tables](https://dolthub.com/docs/sql-reference/version-control/dolt-system-tables) and version control write operations as [stored procedures](https://dolthub.com/docs/sql-reference/version-control/dolt-sql-procedures). 
 
 The naming of the system tables and stored procedures follows the `dolt_<command>` pattern. So `dolt add` on the CLI becomes `dolt_add` as a stored procedure. Passing options also follows the command line model. For instance, to specify tables to add, send the table names in as options to the `dolt_add` procedure. For named arguments like sending a message into the `dolt_commit` command use two arguments in sequence like `('-m', 'This is a message')`. If you know Git, the version control procedures and system tables should feel familiar.
 
@@ -373,7 +373,7 @@ mysql> select * from dolt_log;
 
 There you have it. Your schema is created and you have a Dolt commit tracking the creation, as seen in the `dolt_log` system table.
 
-Note, a Dolt commit is different than a standard SQL transaction `COMMIT`. In this case, I am running the database with [`AUTOCOMMIT`](https://dev.mysql.com/doc/refman/5.6/en/innodb-autocommit-commit-rollback.html) on, so each SQL statement is automatically generating a transaction `COMMIT`. If you want system to generate a Dolt commit for every transaction use the system variable, [`@@dolt_transaction_commit`](https://docs.dolthub.com/sql-reference/version-control/dolt-sysvars#dolt_transaction_commit).
+Note, a Dolt commit is different than a standard SQL transaction `COMMIT`. In this case, I am running the database with [`AUTOCOMMIT`](https://dev.mysql.com/doc/refman/5.6/en/innodb-autocommit-commit-rollback.html) on, so each SQL statement is automatically generating a transaction `COMMIT`. If you want system to generate a Dolt commit for every transaction use the system variable, [`@@dolt_transaction_commit`](https://dolthub.com/docs/sql-reference/version-control/dolt-sysvars#dolt_transaction_commit).
 
 ## Insert some data
 
@@ -545,7 +545,7 @@ mysql> show tables;
 3 rows in set (0.01 sec)
 ```
 
-Dolt makes operating databases less error prone. You can always back out changes you have in progress or rewind to a known good state. You also have the ability to undo specific commits using [`dolt_revert()`](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-procedures#dolt_revert). Even if you accidentally run `drop database` on the wrong database, Dolt lets you undo that by calling the [`dolt_undrop()` stored procedure](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-procedures#dolt_undrop).
+Dolt makes operating databases less error prone. You can always back out changes you have in progress or rewind to a known good state. You also have the ability to undo specific commits using [`dolt_revert()`](https://dolthub.com/docs/sql-reference/version-control/dolt-sql-procedures#dolt_revert). Even if you accidentally run `drop database` on the wrong database, Dolt lets you undo that by calling the [`dolt_undrop()` stored procedure](https://dolthub.com/docs/sql-reference/version-control/dolt-sql-procedures#dolt_undrop).
 
 
 ## See the data in a SQL Workbench
@@ -831,7 +831,7 @@ Dolt provides powerful data audit capabilities down to individual cells. When, h
 
 # Additional Reading
 
-Head over to [our documentation](https://docs.dolthub.com/introduction/what-is-dolt) now that you have a feel for Dolt. You can also read about what we've been working on in [our blog](https://www.dolthub.com/blog/).
+Head over to [our documentation](https://dolthub.com/docs/introduction/what-is-dolt) now that you have a feel for Dolt. You can also read about what we've been working on in [our blog](https://www.dolthub.com/blog/).
 
 # Security Policy
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -15,7 +15,7 @@ Dolt databases. We host public data for free. If you want to host
 your own version of DoltHub, we have [DoltLab](https://www.doltlab.com). If you want us to run a Dolt server for you, we have [Hosted Dolt](https://hosted.doltdb.com).
 
 [Join us on Discord](https://discord.com/invite/RFwfYpu) to say hi and
-ask questions, or [check out our roadmap](https://docs.dolthub.com/other/roadmap)
+ask questions, or [check out our roadmap](https://dolthub.com/docs/other/roadmap)
 to see what we're building next.
 
 ## What's it for?
@@ -24,7 +24,7 @@ Lots of things! Dolt is a generally useful tool with countless
 applications. But if you want some ideas, [here's how people are using
 it so far](https://www.dolthub.com/blog/2022-07-11-dolt-case-studies/).
 
-Learn more about Dolt use cases, configuration and guides to use dolt on our [documentation page](https://docs.dolthub.com/introduction/what-is-dolt).
+Learn more about Dolt use cases, configuration and guides to use dolt on our [documentation page](https://dolthub.com/docs/introduction/what-is-dolt).
 
 # How to use this image
 

--- a/docker/serverREADME.md
+++ b/docker/serverREADME.md
@@ -15,7 +15,7 @@ Dolt databases. We host public data for free. If you want to host
 your own version of DoltHub, we have [DoltLab](https://www.doltlab.com). If you want us to run a Dolt server for you, we have [Hosted Dolt](https://hosted.doltdb.com).
 
 [Join us on Discord](https://discord.com/invite/RFwfYpu) to say hi and
-ask questions, or [check out our roadmap](https://docs.dolthub.com/other/roadmap)
+ask questions, or [check out our roadmap](https://dolthub.com/docs/other/roadmap)
 to see what we're building next.
 
 ## What's it for?
@@ -72,7 +72,7 @@ Valid commands for dolt are
                 dump - Export all tables in the working set into a file.
 ```
 
-Learn more about Dolt use cases, configuration and guides to use dolt on our [documentation page](https://docs.dolthub.com/introduction/what-is-dolt).
+Learn more about Dolt use cases, configuration and guides to use dolt on our [documentation page](https://dolthub.com/docs/introduction/what-is-dolt).
 
 # How to use this image
 

--- a/go/cmd/dolt/commands/cherry-pick.go
+++ b/go/cmd/dolt/commands/cherry-pick.go
@@ -39,7 +39,7 @@ Applies the changes from an existing commit and creates a new commit from the cu
 
 Cherry-picking merge commits or commits with table drops/renames is not currently supported. 
 
-If any data conflicts, schema conflicts, or constraint violations are detected during cherry-picking, you can use Dolt's conflict resolution features to resolve them. For more information on resolving conflicts, see: https://docs.dolthub.com/concepts/dolt/git/conflicts.
+If any data conflicts, schema conflicts, or constraint violations are detected during cherry-picking, you can use Dolt's conflict resolution features to resolve them. For more information on resolving conflicts, see: https://dolthub.com/docs/concepts/dolt/git/conflicts.
 `,
 	Synopsis: []string{
 		`[--allow-empty] {{.LessThan}}commit{{.GreaterThan}}`,
@@ -50,7 +50,7 @@ var ErrCherryPickConflictsOrViolations = errors.NewKind("error: Unable to apply 
 	"or constraint violations. Please resolve the conflicts and/or constraint violations, then use `dolt add` " +
 	"to add the tables to the staged set, and `dolt cherry-pick --continue` to complete the cherry-pick. \n" +
 	"To undo all changes from this cherry-pick operation, use `dolt cherry-pick --abort`.\n" +
-	"For more information on handling conflicts, see: https://docs.dolthub.com/concepts/dolt/git/conflicts")
+	"For more information on handling conflicts, see: https://dolthub.com/docs/concepts/dolt/git/conflicts")
 
 var ErrCherryPickVerificationFailed = errors.NewKind("error: Commit verification failed. Your changes are staged " +
 	"in the working set. Fix the failing tests, use `dolt add` to stage your changes, then " +

--- a/go/cmd/dolt/commands/sqlserver/server_test.go
+++ b/go/cmd/dolt/commands/sqlserver/server_test.go
@@ -615,7 +615,7 @@ func TestGenerateYamlConfig(t *testing.T) {
 	expected := `# Dolt SQL server configuration
 #
 # Uncomment and edit lines as necessary to modify your configuration.
-# Full documentation: https://docs.dolthub.com/sql-reference/server/configuration
+# Full documentation: https://dolthub.com/docs/sql-reference/server/configuration
 #
 
 # log_level: info

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -150,7 +150,7 @@ SUPPORTED CONFIG FILE FIELDS:
 
 {{.EmphasisLeft}}user_session_vars{{.EmphasisRight}}: A map of user name to a map of session variables to set on connection for each session.
 
-{{.EmphasisLeft}}cluster{{.EmphasisRight}}: Settings related to running this server in a replicated cluster. For information on setting these values, see https://docs.dolthub.com/sql-reference/server/replication
+{{.EmphasisLeft}}cluster{{.EmphasisRight}}: Settings related to running this server in a replicated cluster. For information on setting these values, see https://dolthub.com/docs/sql-reference/server/replication
 
 If a config file is not provided many of these settings may be configured on the command line.`,
 	Synopsis: []string{
@@ -663,6 +663,6 @@ func generateYamlConfig(serverConfig servercfg.ServerConfig) string {
 	return `# Dolt SQL server configuration
 #
 # Uncomment and edit lines as necessary to modify your configuration.
-# Full documentation: https://docs.dolthub.com/sql-reference/server/configuration
+# Full documentation: https://dolthub.com/docs/sql-reference/server/configuration
 #` + "\n\n" + yamlConfig.VerboseString()
 }


### PR DESCRIPTION
Update references from `docs.dolthub.com` to `dolthub.com/docs` across READMEs and CLI help text.