### PR TITLE
[no-release-notes] go/store/nbs: Fix test helper genChunks so it does not (try to) generate 0-size chunks.

### DIFF
--- a/go/store/nbs/generational_chunk_store_test.go
+++ b/go/store/nbs/generational_chunk_store_test.go
@@ -31,7 +31,7 @@ var randGen = rand.New(rand.NewSource(0))
 func genChunks(t *testing.T, count int, max int) []chunks.Chunk {
 	chnks := make([]chunks.Chunk, count)
 	for i := 0; i < count; i++ {
-		bytes := make([]byte, randGen.Int()%max)
+		bytes := make([]byte, 1+randGen.Int()%max)
 		n, err := randGen.Read(bytes)
 		require.NoError(t, err)
 		chnks[i] = chunks.NewChunk(bytes[:n])


### PR DESCRIPTION
Concretely, fixes

`go test ./store/nbs -test.run TestGenerationalCS -count 10`