### PR TITLE
Do not make `dolt_diff` table indexes on nil schemas

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -6857,6 +6857,25 @@ left join dolt_commit_diff_xy cd
 			},
 		},
 	},
+	{
+		name: "indexes work when table doesn't exist on one branch",
+		setup: []string{
+			"call dolt_checkout('-b', 'mod')",
+			"create table newTable(id int)",
+			"call dolt_add('newTable')",
+			"call dolt_commit('-am', 'added new table')",
+		},
+		queries: []systabQuery{
+			{
+				query: "select count(*) from dolt_diff('main', 'mod', 'newTable') where to_commit='def'",
+				exp:   []sql.Row{{0}},
+			},
+			{
+				query: "select count(*) from dolt_diff('mod', 'main', 'newTable') where to_commit='def'",
+				exp:   []sql.Row{{0}},
+			},
+		},
+	},
 }
 
 var QueryDiffTableScriptTests = []queries.ScriptTest{

--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -240,10 +240,14 @@ func MakeDiffTableIndex(tableName string, prefix string, sch schema.Schema, incl
 }
 
 func MakeDiffTableIndexes(tbl string, toSchema, fromSchema schema.Schema, includeCommits bool) (indexes []sql.Index) {
-	return []sql.Index{
-		MakeDiffTableIndex(tbl, "to", toSchema, includeCommits),
-		MakeDiffTableIndex(tbl, "from", fromSchema, includeCommits),
+	indexes = make([]sql.Index, 0)
+	if toSchema != nil {
+		indexes = append(indexes, MakeDiffTableIndex(tbl, "to", toSchema, includeCommits))
 	}
+	if fromSchema != nil {
+		indexes = append(indexes, MakeDiffTableIndex(tbl, "from", fromSchema, includeCommits))
+	}
+	return indexes
 }
 
 // MockIndex returns a sql.Index that is not backed by an actual datastore. It's useful for system tables and


### PR DESCRIPTION
Calling `MakeDiffTableIndex` on a nil schema was causing a panic. This would happen if a table existed on one branch but not on the other.