### PR TITLE
fix: make findCommonCommit deterministic for criss-cross merges

### DIFF
--- a/go/store/datas/commit.go
+++ b/go/store/datas/commit.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 
 	flatbuffers "github.com/dolthub/flatbuffers/v23/go"
@@ -536,12 +537,21 @@ func findCommonCommit(a, b []*Commit) (*Commit, bool) {
 	}
 
 	as, bs := toAddrMap(a), toAddrMap(b)
+	var common []*Commit
 	for s, c := range as {
 		if _, present := bs[s]; present {
-			return c, true
+			common = append(common, c)
 		}
 	}
-	return nil, false
+	if len(common) == 0 {
+		return nil, false
+	}
+	// Sort by address to ensure deterministic selection when multiple
+	// common ancestors exist at the same height (e.g., criss-cross merges).
+	sort.Slice(common, func(i, j int) bool {
+		return common[i].Addr().Less(common[j].Addr())
+	})
+	return common[0], true
 }
 
 func firstError(l, r error) error {

--- a/go/store/datas/commit_test.go
+++ b/go/store/datas/commit_test.go
@@ -435,6 +435,62 @@ func TestFindCommonAncestor(t *testing.T) {
 	})
 }
 
+func TestFindCommonAncestorCrissCrossDeterministic(t *testing.T) {
+	// Criss-cross merge with two maximal common ancestors at the same height.
+	// Verifies that findCommonCommit returns deterministically.
+	//
+	//       base
+	//       /  \
+	//      A    B
+	//      |    |
+	//     a1    b1
+	//      |\  /|
+	//      | \/ |
+	//      | /\ |
+	//      |/  \|
+	//      C    D
+	//
+	// Maximal common ancestors of C and D: {a1, b1}
+	// findCommonCommit must pick the same one every time.
+
+	storage := &chunks.TestStorage{}
+	db := NewDatabase(storage.NewViewWithDefaultFormat()).(*database)
+	defer db.Close()
+
+	a, b, c, d := "ds-a", "ds-b", "ds-c", "ds-d"
+	base, _ := addCommit(t, db, a, "base")
+	a1, _ := addCommit(t, db, a, "a1", base)
+	b1, _ := addCommit(t, db, b, "b1", base)
+	c1, _ := addCommit(t, db, c, "c1", a1, b1)
+	d1, _ := addCommit(t, db, d, "d1", a1, b1)
+
+	// Verify determinism: run 20 times, expect the same result every time.
+	ctx := context.Background()
+	c1c, err := LoadCommitRef(ctx, db, mustRef(types.NewRef(c1, db.Format())))
+	require.NoError(t, err)
+	d1c, err := LoadCommitRef(ctx, db, mustRef(types.NewRef(d1, db.Format())))
+	require.NoError(t, err)
+
+	var firstHash hash.Hash
+	for i := 0; i < 20; i++ {
+		found, ok, err := findCommonAncestorUsingParentsList(ctx, c1c, d1c, db, db, db.ns, db.ns)
+		require.NoError(t, err)
+		require.True(t, ok, "should find common ancestor")
+		if i == 0 {
+			firstHash = found
+		} else {
+			assert.Equal(t, firstHash, found,
+				"run %d: expected deterministic result, got different hash", i)
+		}
+	}
+
+	// Also verify it's one of {a1, b1} (both are valid maximal LCAs).
+	a1Addr := mustRef(types.NewRef(a1, db.Format())).TargetHash()
+	b1Addr := mustRef(types.NewRef(b1, db.Format())).TargetHash()
+	assert.True(t, firstHash == a1Addr || firstHash == b1Addr,
+		"result should be one of the maximal common ancestors")
+}
+
 func TestPersistedCommitConsts(t *testing.T) {
 	// changing constants that are persisted requires a migration strategy
 	assert.Equal(t, "parents", parentsField)


### PR DESCRIPTION
## Problem

`dolt_merge_base(C, D)` returns different results on repeated invocations when `C` and `D` have multiple maximal common ancestors (criss-cross merge topology). As reported in #11042, across 10 runs the function returned different commits — both valid maximal LCAs, but the result was unstable.

## Root Cause

`findCommonCommit()` in `go/store/datas/commit.go` converts one set of commits to a Go map and iterates over the other to find matches:

```go
for s, c := range as {
    if _, present := bs[s]; present {
        return c, true
    }
}
```

Go map iteration order is non-deterministic. When multiple common ancestors exist at the same height, the first match found varies between runs.

## Fix

Collect all common ancestors, sort by hash address, and return the first one deterministically:

```go
var common []*Commit
for s, c := range as {
    if _, present := bs[s]; present {
        common = append(common, c)
    }
}
sort.Slice(common, func(i, j int) bool {
    return common[i].Addr().Less(common[j].Addr())
})
return common[0], true
```

## Testing

- All existing `TestFindCommonAncestor` tests pass
- Added `TestFindCommonAncestorCrissCrossDeterministic` that creates a criss-cross merge topology and verifies the result is identical across 20 runs
- `go vet ./store/datas/` passes

Fixes #11042