### PR TITLE
dolt status doesn't require both --use-db and --branch

### DIFF
--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -134,7 +134,9 @@ func createPrintData(queryist cli.Queryist, sqlCtx *sql.Context, showIgnoredTabl
 		branchName = brName
 	} else if useDb, hasUseDb := cliCtx.GlobalArgs().GetValue(UseDbFlag); hasUseDb {
 		_, branchName = doltdb.SplitRevisionDbName(useDb)
-	} else {
+	}
+
+	if branchName == "" {
 		var err error
 		branchName, err = getActiveBranchName(sqlCtx, queryist)
 		if err != nil {

--- a/integration-tests/bats/sql-shell-slash-status.expect
+++ b/integration-tests/bats/sql-shell-slash-status.expect
@@ -1,0 +1,32 @@
+#!/usr/bin/expect
+# Regression coverage for the interactive \status backslash command in the
+# dolt sql shell. The bug in GH#11137 surfaced against a remote host, but
+# the interactive \status path shares the same createPrintData code, so we
+# exercise it both with and without the --branch global flag.
+#
+# Usage:
+#   sql-shell-slash-status.expect <expected-branch> [extra dolt global flags...]
+#
+# argv[0] is the branch name we expect \status to report. Any remaining
+# arguments are passed through to dolt before the `sql` subcommand, so the
+# caller can supply flags like --branch=br1.
+
+set timeout 10
+set env(NO_COLOR) 1
+
+source "$env(BATS_CWD)/helper/common_expect_functions.tcl"
+
+set expected_branch [lindex $argv 0]
+set extra_args [lrange $argv 1 end]
+
+spawn dolt {*}$extra_args sql
+
+expect_with_defaults                                                    {dolt-repo-[0-9]+/[a-zA-Z0-9_]+\*?> } { send "\\status\r"; }
+
+expect_with_defaults_2 "On branch $expected_branch"                     {dolt-repo-[0-9]+/[a-zA-Z0-9_]+\*?> } { send "exit\r"; }
+
+expect eof
+
+set waitval [wait -i $spawn_id]
+set exval [lindex $waitval 3]
+exit $exval

--- a/integration-tests/bats/sql-shell.bats
+++ b/integration-tests/bats/sql-shell.bats
@@ -155,6 +155,26 @@ teardown() {
     [ "$status" -eq 0 ]
 }
 
+# Regression coverage for https://github.com/dolthub/dolt/issues/11137
+# bats test_tags=no_lambda
+@test "sql-shell: status slash command works without --branch flag" {
+    skiponwindows "Need to install expect and make this script work on windows."
+    if [ "$SQL_ENGINE" = "remote-engine" ]; then
+      skip "Test exercises the local sql shell path."
+    fi
+    $BATS_TEST_DIRNAME/sql-shell-slash-status.expect main
+}
+
+# bats test_tags=no_lambda
+@test "sql-shell: status slash command works with --branch flag" {
+    skiponwindows "Need to install expect and make this script work on windows."
+    if [ "$SQL_ENGINE" = "remote-engine" ]; then
+      skip "Test exercises the local sql shell path."
+    fi
+    dolt branch br1
+    $BATS_TEST_DIRNAME/sql-shell-slash-status.expect br1 --branch=br1
+}
+
 # bats test_tags=no_lambda
 @test "sql-shell: sql shell prompt updates" {
     skiponwindows "Need to install expect and make this script work on windows."

--- a/integration-tests/bats/status.bats
+++ b/integration-tests/bats/status.bats
@@ -619,3 +619,32 @@ SQL
     [ "$status" -eq 0 ]
     [[ "$output" =~ "On branch main" ]] || false
 }
+
+# Regression test for https://github.com/dolthub/dolt/issues/11137
+# `dolt --use-db=<db> status` (no @branch revision suffix) should resolve
+# the current branch from the server rather than failing with
+# "could not find current branch commit".
+@test "status: --use-db without branch revision resolves active branch" {
+    dolt sql -q "create table t (a int primary key, b int);"
+    dolt add .
+    dolt commit -m "init"
+    dolt sql -q "insert into t values (1, 2);"
+
+    dbname="dolt-repo-$$"
+
+    run dolt --use-db="$dbname" status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "On branch main" ]] || false
+    [[ "$output" =~ "modified:" ]] || false
+    [[ "$output" =~ "t" ]] || false
+
+    run dolt --use-db="$dbname/main" status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "On branch main" ]] || false
+    [[ "$output" =~ "modified:" ]] || false
+
+    dolt branch other
+    run dolt --use-db="$dbname/other" status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "On branch other" ]] || false
+}


### PR DESCRIPTION
There was a gap in testing for the status command when you specify only --use-db, but no --branch name. This resulted in getting the error "could not find current branch commit"

Fixes: https://github.com/dolthub/dolt/issues/11137
