### PR TITLE
dump-docs: emit a description: field in the generated cli.md frontmatter

### DIFF
--- a/go/cmd/dolt/commands/dump_docs.go
+++ b/go/cmd/dolt/commands/dump_docs.go
@@ -28,12 +28,7 @@ import (
 )
 
 const (
-	fileParamName = "file"
-	// Frontmatter emitted at the top of cli.md. The dolt docs site consumes
-	// title + description from frontmatter (title becomes the <title> and on-
-	// page H1; description powers OG/Twitter cards and the per-entry summary
-	// in llms.txt). Keep description as a single line of plain YAML — the
-	// docs site's frontmatter checker accepts unquoted strings here.
+	fileParamName  = "file"
 	cliMdDocHeader = "" +
 		"---\n" +
 		"title: CLI\n" +

--- a/go/cmd/dolt/commands/dump_docs.go
+++ b/go/cmd/dolt/commands/dump_docs.go
@@ -28,10 +28,16 @@ import (
 )
 
 const (
-	fileParamName  = "file"
+	fileParamName = "file"
+	// Frontmatter emitted at the top of cli.md. The dolt docs site consumes
+	// title + description from frontmatter (title becomes the <title> and on-
+	// page H1; description powers OG/Twitter cards and the per-entry summary
+	// in llms.txt). Keep description as a single line of plain YAML — the
+	// docs site's frontmatter checker accepts unquoted strings here.
 	cliMdDocHeader = "" +
 		"---\n" +
 		"title: CLI\n" +
+		"description: Full reference for the dolt command-line interface — every command, every flag, with examples. Generated from `dolt dump-docs`.\n" +
 		"---\n\n" +
 		"# Command Line Interface Reference\n\n"
 )

--- a/go/cmd/dolt/commands/dump_docs.go
+++ b/go/cmd/dolt/commands/dump_docs.go
@@ -37,7 +37,7 @@ const (
 	cliMdDocHeader = "" +
 		"---\n" +
 		"title: CLI\n" +
-		"description: Full reference for the dolt command-line interface — every command, every flag, with examples. Generated from `dolt dump-docs`.\n" +
+		"description: Full reference for the dolt command-line interface — every command, every flag, with examples.\n" +
 		"---\n\n" +
 		"# Command Line Interface Reference\n\n"
 )


### PR DESCRIPTION
The dolt docs site ([dolthub/docs-2](https://github.com/dolthub/docs-2)) now reads `description:` from each page's frontmatter — it powers the per-entry summary in [`llms.txt`](https://llmstxt.org) (the agent-readable docs index) and is wired up for OG/Twitter cards.

`cli.md` is generated by `dolt dump-docs`, so any `description:` added by hand to the docs repo gets overwritten on the next regeneration. Baking it into the constant header so it survives every regen.

The description string matches what dolthub/docs-2#103 has for `site/dolt/src/content/reference/cli/cli.md`, so a regen after this merges won't introduce any diff to cli.md beyond the usual command-output churn.

## Generated frontmatter

```yaml
---
title: CLI
description: Full reference for the dolt command-line interface — every command, every flag, with examples.
---
```

## Verified

- `go build ./cmd/dolt` clean.
- Ran the built binary against `/tmp/cli-test.md`.
- Substituted that file into the docs-2 tree and ran `npm run build:dolt` — clean.
- The description carries through to the docs site's `llms.txt` entry for the CLI page.