### PR TITLE
Fix `dolt status` to report `AUTO_INCREMENT` value changes

### DIFF
--- a/go/libraries/doltcore/diff/table_deltas.go
+++ b/go/libraries/doltcore/diff/table_deltas.go
@@ -470,17 +470,11 @@ func (td TableDelta) HasSchemaChanged(ctx context.Context) (bool, error) {
 		return true, nil
 	}
 
-	fromAutoInc, err := td.FromTable.GetAutoIncrementValue(ctx)
+	aiChanged, err := td.hasAutoIncrementChanged(ctx)
 	if err != nil {
 		return false, err
 	}
-
-	toAutoInc, err := td.ToTable.GetAutoIncrementValue(ctx)
-	if err != nil {
-		return false, err
-	}
-
-	if fromAutoInc != toAutoInc {
+	if aiChanged {
 		return true, nil
 	}
 
@@ -495,6 +489,18 @@ func (td TableDelta) HasSchemaChanged(ctx context.Context) (bool, error) {
 	}
 
 	return !fromSchemaHash.Equal(toSchemaHash), nil
+}
+
+func (td TableDelta) hasAutoIncrementChanged(ctx context.Context) (bool, error) {
+	fromAutoInc, err := td.FromTable.GetAutoIncrementValue(ctx)
+	if err != nil {
+		return false, err
+	}
+	toAutoInc, err := td.ToTable.GetAutoIncrementValue(ctx)
+	if err != nil {
+		return false, err
+	}
+	return fromAutoInc != toAutoInc, nil
 }
 
 func (td TableDelta) HasChangesIgnoringColumnTags(ctx context.Context) (bool, error) {
@@ -523,6 +529,14 @@ func (td TableDelta) HasChangesIgnoringColumnTags(ctx context.Context) (bool, er
 			return false, err
 		}
 		if !fromRowDataHash.Equal(toRowDataHash) {
+			return true, nil
+		}
+
+		aiChanged, err := td.hasAutoIncrementChanged(ctx)
+		if err != nil {
+			return false, err
+		}
+		if aiChanged {
 			return true, nil
 		}
 

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -530,6 +530,49 @@ var DoltScripts = []queries.ScriptTest{
 		},
 	},
 	{
+		Name: "dolt_status reports AUTO_INCREMENT value changes",
+		// See https://github.com/dolthub/dolt/issues/11145
+		SetUpScript: []string{
+			"CREATE TABLE ainc (id int NOT NULL AUTO_INCREMENT, PRIMARY KEY (id));",
+			"INSERT INTO ainc VALUES ();",
+			"CALL DOLT_COMMIT('-Am', 'create ainc');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "ALTER TABLE ainc AUTO_INCREMENT = 100;",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "SELECT table_name, staged, status FROM dolt_status;",
+				Expected: []sql.Row{{"ainc", byte(0), "modified"}},
+			},
+			{
+				Query:    "CALL DOLT_ADD('ainc');",
+				Expected: []sql.Row{{0}},
+			},
+			{
+				Query:    "SELECT table_name, staged, status FROM dolt_status;",
+				Expected: []sql.Row{{"ainc", byte(1), "modified"}},
+			},
+			{
+				Query:    "CALL DOLT_COMMIT('-m', 'bump auto_increment');",
+				Expected: []sql.Row{{doltCommit}},
+			},
+			{
+				Query:    "SELECT COUNT(*) FROM dolt_status;",
+				Expected: []sql.Row{{0}},
+			},
+			{
+				Query:    "ALTER TABLE ainc AUTO_INCREMENT = 100;",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "SELECT COUNT(*) FROM dolt_status;",
+				Expected: []sql.Row{{0}},
+			},
+		},
+	},
+	{
 		Name: "dolt_commit with only ignored table changes closes the transaction",
 		SetUpScript: []string{
 			"INSERT INTO dolt_ignore VALUES ('ignored_*', true)",

--- a/integration-tests/bats/status.bats
+++ b/integration-tests/bats/status.bats
@@ -648,3 +648,35 @@ SQL
     [ "$status" -eq 0 ]
     [[ "$output" =~ "On branch other" ]] || false
 }
+
+@test "status: ALTER TABLE AUTO_INCREMENT value change shows table as modified" {
+    # See https://github.com/dolthub/dolt/issues/11145
+    dolt sql <<SQL
+CREATE TABLE ainc (id int NOT NULL AUTO_INCREMENT, PRIMARY KEY (id));
+INSERT INTO ainc VALUES ();
+SQL
+    dolt add -A && dolt commit -m "create ainc"
+
+    dolt sql -q "ALTER TABLE ainc AUTO_INCREMENT = 100"
+
+    run dolt diff
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "AUTO_INCREMENT=100" ]] || false
+
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Changes not staged for commit:" ]] || false
+    [[ "$output" =~ "modified:         ainc" ]] || false
+    ! [[ "$output" =~ "nothing to commit, working tree clean" ]] || false
+
+    dolt add ainc
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ "modified:         ainc" ]] || false
+
+    dolt commit -m "bump auto_increment"
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "nothing to commit, working tree clean" ]] || false
+}


### PR DESCRIPTION
`ALTER TABLE foo AUTO_CINREMENT = N` updated the table but `dolt status` continued to report "nothing to commit".
- `HasChangesIgnoringColumnTags` now compares `GetAutoIncrementValue` between from and to tables.
Fix dolthub/dolt#11145
