### PR TITLE
schema: preserve table metadata when updating column tags

### DIFF
--- a/go/cmd/dolt/commands/schcmds/copy-tags.go
+++ b/go/cmd/dolt/commands/schcmds/copy-tags.go
@@ -334,7 +334,7 @@ func updateRootWithNewColumnTag(ctx context.Context, root doltdb.RootValue, tabl
 	}
 
 	// Update the column tag in the schema
-	updatedSchema, err := updateColumnTag(sch, columnName, tag)
+	updatedSchema, err := schema.WithUpdatedColumnTag(sch, columnName, tag)
 	if err != nil {
 		return nil, err
 	}

--- a/go/cmd/dolt/commands/schcmds/update-tag.go
+++ b/go/cmd/dolt/commands/schcmds/update-tag.go
@@ -16,7 +16,6 @@ package schcmds
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
@@ -99,7 +98,7 @@ func (cmd UpdateTagCmd) Exec(ctx context.Context, commandStr string, args []stri
 		return commands.HandleVErrAndExitCode(errhand.BuildDError("failed to get schema").Build(), usage)
 	}
 
-	newSch, err := updateColumnTag(sch, columnName, tag)
+	newSch, err := schema.WithUpdatedColumnTag(sch, columnName, tag)
 	if err != nil {
 		return commands.HandleVErrAndExitCode(errhand.BuildDError("failed to update column tag").AddCause(err).Build(), usage)
 	}
@@ -120,35 +119,4 @@ func (cmd UpdateTagCmd) Exec(ctx context.Context, commandStr string, args []stri
 	}
 
 	return commands.HandleVErrAndExitCode(nil, usage)
-}
-
-func updateColumnTag(sch schema.Schema, name string, tag uint64) (schema.Schema, error) {
-	var found bool
-	columns := sch.GetAllCols().GetColumns()
-	// Find column and update its tag
-	for i, col := range columns {
-		if col.Name == name {
-			col.Tag = tag
-			columns[i] = col
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		return nil, fmt.Errorf("column %s does not exist", name)
-	}
-
-	newSch, err := schema.SchemaFromCols(schema.NewColCollection(columns...))
-	if err != nil {
-		return nil, err
-	}
-
-	err = newSch.SetPkOrdinals(sch.GetPkOrdinals())
-	if err != nil {
-		return nil, err
-	}
-	newSch.SetCollation(sch.GetCollation())
-
-	return newSch, nil
 }

--- a/go/libraries/doltcore/schema/index.go
+++ b/go/libraries/doltcore/schema/index.go
@@ -58,6 +58,8 @@ type Index interface {
 	FullTextProperties() FullTextProperties
 	// VectorProperties returns all properties belonging to a vector index.
 	VectorProperties() VectorProperties
+	// Properties returns the IndexProperties describing this index.
+	Properties() IndexProperties
 }
 
 var _ Index = (*indexImpl)(nil)
@@ -290,6 +292,21 @@ func (ix *indexImpl) FullTextProperties() FullTextProperties {
 // VectorProperties implements Index.
 func (ix *indexImpl) VectorProperties() VectorProperties {
 	return ix.vectorProperties
+}
+
+// Properties implements Index.
+func (ix *indexImpl) Properties() IndexProperties {
+	return IndexProperties{
+		IsUnique:           ix.isUnique,
+		IsSpatial:          ix.isSpatial,
+		IsFullText:         ix.isFullText,
+		IsUserDefined:      ix.isUserDefined,
+		Comment:            ix.comment,
+		Predicate:          ix.predicate,
+		FullTextProperties: ix.fullTextProps,
+		IsVector:           ix.isVector,
+		VectorProperties:   ix.vectorProperties,
+	}
 }
 
 // copy returns an exact copy of the calling index.

--- a/go/libraries/doltcore/schema/schema_impl.go
+++ b/go/libraries/doltcore/schema/schema_impl.go
@@ -133,13 +133,9 @@ func SchemaFromCols(allCols *ColCollection) (Schema, error) {
 }
 
 // WithRemappedColumnTags returns a copy of |sch| with column and index tags rewritten via
-// |tagRemap|. Schema metadata and check constraints are preserved. Returns |sch| unchanged
-// when |tagRemap| is empty.
+// |tagRemap|. Schema metadata and check constraints are preserved. An empty or nil |tagRemap|
+// still returns a fresh schema equivalent to |sch|.
 func WithRemappedColumnTags(sch Schema, tagRemap map[uint64]uint64) (Schema, error) {
-	if len(tagRemap) == 0 {
-		return sch, nil
-	}
-
 	allCols := sch.GetAllCols()
 	cols := allCols.GetColumns()
 	for oldTag, newTag := range tagRemap {

--- a/go/libraries/doltcore/schema/schema_impl.go
+++ b/go/libraries/doltcore/schema/schema_impl.go
@@ -17,6 +17,7 @@ package schema
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -129,6 +130,52 @@ func SchemaFromCols(allCols *ColCollection) (Schema, error) {
 	}
 	sch.SetCollation(Collation_Default)
 	return sch, nil
+}
+
+// WithRemappedColumnTags returns a copy of |sch| with column and index tags rewritten via
+// |tagRemap|. Schema metadata and check constraints are preserved. Returns |sch| unchanged
+// when |tagRemap| is empty.
+func WithRemappedColumnTags(sch Schema, tagRemap map[uint64]uint64) (Schema, error) {
+	if len(tagRemap) == 0 {
+		return sch, nil
+	}
+
+	allCols := sch.GetAllCols()
+	cols := allCols.GetColumns()
+	for oldTag, newTag := range tagRemap {
+		if idx, ok := allCols.TagToIdx[oldTag]; ok {
+			cols[idx].Tag = newTag
+		}
+	}
+
+	pkOrdinals := slices.Clone(sch.GetPkOrdinals())
+	newSch, err := NewSchema(NewColCollection(cols...), pkOrdinals, sch.GetCollation(), nil, sch.Checks().Copy())
+	if err != nil {
+		return nil, err
+	}
+	newSch.SetTargetRowSize(sch.GetTargetRowSize())
+	newSch.SetComment(sch.GetComment())
+
+	err = sch.Indexes().Iter(func(idx Index) (stop bool, err error) {
+		tags := RemapTags(idx.IndexedColumnTags(), tagRemap)
+		_, err = newSch.Indexes().AddIndexByColTags(idx.Name(), tags, idx.PrefixLengths(), idx.Properties())
+		return false, err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return newSch, nil
+}
+
+// WithUpdatedColumnTag returns a copy of |sch| with the tag of the column named |name| set to |tag|.
+// It returns an error if no column named |name| exists.
+func WithUpdatedColumnTag(sch Schema, name string, tag uint64) (Schema, error) {
+	col, ok := sch.GetAllCols().GetByName(name)
+	if !ok {
+		return nil, fmt.Errorf("column %q does not exist", name)
+	}
+	return WithRemappedColumnTags(sch, map[uint64]uint64{col.Tag: tag})
 }
 
 // SchemaFromColCollections creates a schema from the three collections.

--- a/go/libraries/doltcore/schema/schema_test.go
+++ b/go/libraries/doltcore/schema/schema_test.go
@@ -540,15 +540,17 @@ func TestWithRemappedColumnTags(t *testing.T) {
 		require.Equal(t, uint16(4096), remapped.GetTargetRowSize())
 	})
 
-	t.Run("EmptyRemapReturnsInputSchema", func(t *testing.T) {
+	t.Run("EmptyRemapReturnsEquivalentSchema", func(t *testing.T) {
 		sch, _ := newRemapInputs(t)
 
 		remapped, err := WithRemappedColumnTags(sch, nil)
 		require.NoError(t, err)
-		require.Same(t, sch, remapped, "nil remap must short-circuit and return the input schema")
+		require.NotSame(t, sch, remapped, "nil remap must allocate a fresh schema")
+		require.Equal(t, sch.GetAllCols().GetColumns(), remapped.GetAllCols().GetColumns())
 
 		remapped, err = WithRemappedColumnTags(sch, map[uint64]uint64{})
 		require.NoError(t, err)
-		require.Same(t, sch, remapped, "empty remap must short-circuit and return the input schema")
+		require.NotSame(t, sch, remapped, "empty remap must allocate a fresh schema")
+		require.Equal(t, sch.GetAllCols().GetColumns(), remapped.GetAllCols().GetColumns())
 	})
 }

--- a/go/libraries/doltcore/schema/schema_test.go
+++ b/go/libraries/doltcore/schema/schema_test.go
@@ -418,60 +418,35 @@ func validateCols(t *testing.T, cols []Column, colColl *ColCollection, msg strin
 	}
 }
 
-// newRemapInputs builds the schema and tag remap shared by the TestWithRemappedColumnTags subtests.
-func newRemapInputs(t *testing.T) (Schema, map[uint64]uint64) {
-	t.Helper()
-	id, err := NewColumnWithTypeInfo("id", 100, typeinfo.Int64Type, true, "", false, "", NotNullConstraint{})
-	require.NoError(t, err)
-	region, err := NewColumnWithTypeInfo("region", 101, typeinfo.StringDefaultType, true, "", false, "", NotNullConstraint{})
-	require.NoError(t, err)
-	val, err := NewColumnWithTypeInfo("val", 102, typeinfo.StringDefaultType, false, "", false, "")
-	require.NoError(t, err)
-	sch, err := NewSchema(NewColCollection(id, region, val), []int{1, 0}, Collation_utf8mb4_general_ci, nil, nil)
-	require.NoError(t, err)
-	sch.SetComment("test comment")
-	sch.SetTargetRowSize(4096)
-	_, err = sch.Checks().AddCheck("val_nonempty", "val <> ''", true, false)
-	require.NoError(t, err)
-	_, err = sch.Checks().AddCheck("region_nonempty", "region <> ''", true, false)
-	require.NoError(t, err)
-	_, err = sch.Indexes().AddIndexByColTags("val_idx", []uint64{102}, []uint16{16}, IndexProperties{IsUnique: true, IsUserDefined: true, Comment: "idx comment"})
-	require.NoError(t, err)
-	_, err = sch.Indexes().AddIndexByColTags("region_val_idx", []uint64{101, 102}, []uint16{0, 8}, IndexProperties{IsUserDefined: true})
-	require.NoError(t, err)
-	return sch, map[uint64]uint64{100: 200, 102: 202}
-}
-
 func TestWithRemappedColumnTags(t *testing.T) {
 	// See https://github.com/dolthub/dolt/issues/11007
 	t.Run("Rewrites", func(t *testing.T) {
 		sch, remap := newRemapInputs(t)
-		remapped, err := WithRemappedColumnTags(sch, remap)
-		require.NoError(t, err)
+		remapped := mustRemap(t, sch, remap)
+		cols := remapped.GetAllCols()
 
-		require.Equal(t, 3, remapped.GetAllCols().Size(), "no columns must be dropped during retag")
+		require.Equal(t, 3, cols.Size(), "no columns must be dropped during retag")
 
-		gotID, ok := remapped.GetAllCols().GetByName("id")
+		id, ok := cols.GetByName("id")
 		require.True(t, ok)
-		require.Equal(t, uint64(200), gotID.Tag, "id tag must be remapped")
-		_, ok = remapped.GetAllCols().GetByTag(100)
+		require.Equal(t, uint64(200), id.Tag, "id tag must be remapped")
+		_, ok = cols.GetByTag(100)
 		require.False(t, ok, "old id tag must be gone")
 
-		gotVal, ok := remapped.GetAllCols().GetByName("val")
+		val, ok := cols.GetByName("val")
 		require.True(t, ok)
-		require.Equal(t, uint64(202), gotVal.Tag, "val tag must be remapped")
-		_, ok = remapped.GetAllCols().GetByTag(102)
+		require.Equal(t, uint64(202), val.Tag, "val tag must be remapped")
+		_, ok = cols.GetByTag(102)
 		require.False(t, ok, "old val tag must be gone")
 
-		gotRegion, ok := remapped.GetAllCols().GetByName("region")
+		region, ok := cols.GetByName("region")
 		require.True(t, ok)
-		require.Equal(t, uint64(101), gotRegion.Tag, "unremapped region tag must be unchanged")
+		require.Equal(t, uint64(101), region.Tag, "unremapped region tag must be unchanged")
 	})
 
 	t.Run("PreservesPrimaryKeyOrdinals", func(t *testing.T) {
 		sch, remap := newRemapInputs(t)
-		remapped, err := WithRemappedColumnTags(sch, remap)
-		require.NoError(t, err)
+		remapped := mustRemap(t, sch, remap)
 		require.Equal(t, []int{1, 0}, remapped.GetPkOrdinals())
 
 		pkCols := remapped.GetPKCols().GetColumns()
@@ -484,32 +459,28 @@ func TestWithRemappedColumnTags(t *testing.T) {
 
 	t.Run("PreservesIndexes", func(t *testing.T) {
 		sch, remap := newRemapInputs(t)
-		wantValProps := sch.Indexes().GetByName("val_idx").Properties()
-		wantValPrefix := sch.Indexes().GetByName("val_idx").PrefixLengths()
-		wantRegionValProps := sch.Indexes().GetByName("region_val_idx").Properties()
-		wantRegionValPrefix := sch.Indexes().GetByName("region_val_idx").PrefixLengths()
+		wantVal := sch.Indexes().GetByName("val_idx")
+		wantRegionVal := sch.Indexes().GetByName("region_val_idx")
 
-		remapped, err := WithRemappedColumnTags(sch, remap)
-		require.NoError(t, err)
+		remapped := mustRemap(t, sch, remap)
 
 		valIdx := remapped.Indexes().GetByName("val_idx")
 		require.NotNil(t, valIdx)
 		require.Equal(t, "val_idx", valIdx.Name())
 		require.Equal(t, []uint64{202}, valIdx.IndexedColumnTags(), "single-column index tag must be remapped")
-		require.Equal(t, wantValProps, valIdx.Properties(), "index properties must survive the retag")
-		require.Equal(t, wantValPrefix, valIdx.PrefixLengths(), "prefix lengths must survive the retag")
+		require.Equal(t, wantVal.Properties(), valIdx.Properties(), "index properties must survive the retag")
+		require.Equal(t, wantVal.PrefixLengths(), valIdx.PrefixLengths(), "prefix lengths must survive the retag")
 
 		regionValIdx := remapped.Indexes().GetByName("region_val_idx")
 		require.NotNil(t, regionValIdx)
 		require.Equal(t, []uint64{101, 202}, regionValIdx.IndexedColumnTags(), "multi-column index must remap only the changed tag")
-		require.Equal(t, wantRegionValProps, regionValIdx.Properties())
-		require.Equal(t, wantRegionValPrefix, regionValIdx.PrefixLengths(), "multi-column index prefix lengths must survive the retag")
+		require.Equal(t, wantRegionVal.Properties(), regionValIdx.Properties())
+		require.Equal(t, wantRegionVal.PrefixLengths(), regionValIdx.PrefixLengths(), "multi-column index prefix lengths must survive the retag")
 	})
 
 	t.Run("PreservesCheckConstraints", func(t *testing.T) {
 		sch, remap := newRemapInputs(t)
-		remapped, err := WithRemappedColumnTags(sch, remap)
-		require.NoError(t, err)
+		remapped := mustRemap(t, sch, remap)
 
 		checks := remapped.Checks().AllChecks()
 		require.Len(t, checks, 2, "all check constraints must survive")
@@ -532,8 +503,7 @@ func TestWithRemappedColumnTags(t *testing.T) {
 
 	t.Run("PreservesTableMetadata", func(t *testing.T) {
 		sch, remap := newRemapInputs(t)
-		remapped, err := WithRemappedColumnTags(sch, remap)
-		require.NoError(t, err)
+		remapped := mustRemap(t, sch, remap)
 
 		require.Equal(t, Collation_utf8mb4_general_ci, remapped.GetCollation())
 		require.Equal(t, "test comment", remapped.GetComment())
@@ -541,16 +511,53 @@ func TestWithRemappedColumnTags(t *testing.T) {
 	})
 
 	t.Run("EmptyRemapReturnsEquivalentSchema", func(t *testing.T) {
-		sch, _ := newRemapInputs(t)
-
-		remapped, err := WithRemappedColumnTags(sch, nil)
-		require.NoError(t, err)
-		require.NotSame(t, sch, remapped, "nil remap must allocate a fresh schema")
-		require.Equal(t, sch.GetAllCols().GetColumns(), remapped.GetAllCols().GetColumns())
-
-		remapped, err = WithRemappedColumnTags(sch, map[uint64]uint64{})
-		require.NoError(t, err)
-		require.NotSame(t, sch, remapped, "empty remap must allocate a fresh schema")
-		require.Equal(t, sch.GetAllCols().GetColumns(), remapped.GetAllCols().GetColumns())
+		for _, remap := range []map[uint64]uint64{nil, {}} {
+			sch, _ := newRemapInputs(t)
+			remapped := mustRemap(t, sch, remap)
+			require.NotSame(t, sch, remapped, "empty remap must allocate a fresh schema")
+			require.Equal(t, sch.GetAllCols().GetColumns(), remapped.GetAllCols().GetColumns())
+		}
 	})
+}
+
+// newRemapInputs builds the schema and tag remap shared by the TestWithRemappedColumnTags subtests.
+func newRemapInputs(t *testing.T) (Schema, map[uint64]uint64) {
+	t.Helper()
+	cols := NewColCollection(
+		mustCol(t, "id", 100, typeinfo.Int64Type, true, NotNullConstraint{}),
+		mustCol(t, "region", 101, typeinfo.StringDefaultType, true, NotNullConstraint{}),
+		mustCol(t, "val", 102, typeinfo.StringDefaultType, false),
+	)
+	sch, err := NewSchema(cols, []int{1, 0}, Collation_utf8mb4_general_ci, nil, nil)
+	require.NoError(t, err)
+	sch.SetComment("test comment")
+	sch.SetTargetRowSize(4096)
+
+	_, err = sch.Checks().AddCheck("val_nonempty", "val <> ''", true, false)
+	require.NoError(t, err)
+	_, err = sch.Checks().AddCheck("region_nonempty", "region <> ''", true, false)
+	require.NoError(t, err)
+
+	_, err = sch.Indexes().AddIndexByColTags("val_idx", []uint64{102}, []uint16{16}, IndexProperties{IsUnique: true, IsUserDefined: true, Comment: "idx comment"})
+	require.NoError(t, err)
+	_, err = sch.Indexes().AddIndexByColTags("region_val_idx", []uint64{101, 102}, []uint16{0, 8}, IndexProperties{IsUserDefined: true})
+	require.NoError(t, err)
+
+	return sch, map[uint64]uint64{100: 200, 102: 202}
+}
+
+// mustCol builds a typed column, failing the test if construction returns an error.
+func mustCol(t *testing.T, name string, tag uint64, ti typeinfo.TypeInfo, partOfPK bool, constraints ...ColConstraint) Column {
+	t.Helper()
+	col, err := NewColumnWithTypeInfo(name, tag, ti, partOfPK, "", false, "", constraints...)
+	require.NoError(t, err)
+	return col
+}
+
+// mustRemap rewrites the column and index tags of |sch| using |remap|, failing the test if the operation returns an error.
+func mustRemap(t *testing.T, sch Schema, remap map[uint64]uint64) Schema {
+	t.Helper()
+	remapped, err := WithRemappedColumnTags(sch, remap)
+	require.NoError(t, err)
+	return remapped
 }

--- a/go/libraries/doltcore/schema/schema_test.go
+++ b/go/libraries/doltcore/schema/schema_test.go
@@ -418,75 +418,137 @@ func validateCols(t *testing.T, cols []Column, colColl *ColCollection, msg strin
 	}
 }
 
-// TestWithRemappedColumnTagsPreservesMetadata verifies that WithRemappedColumnTags rewrites the
-// column and index tags and carries collation, comment, target row size, check constraints,
-// primary key ordinals, multi-column index partial remap, and index properties onto the
-// returned schema.
-func TestWithRemappedColumnTagsPreservesMetadata(t *testing.T) {
-	// See https://github.com/dolthub/dolt/issues/11007
+// newRemapInputs builds the schema and tag remap shared by the TestWithRemappedColumnTags subtests.
+func newRemapInputs(t *testing.T) (Schema, map[uint64]uint64) {
+	t.Helper()
 	id, err := NewColumnWithTypeInfo("id", 100, typeinfo.Int64Type, true, "", false, "", NotNullConstraint{})
 	require.NoError(t, err)
 	region, err := NewColumnWithTypeInfo("region", 101, typeinfo.StringDefaultType, true, "", false, "", NotNullConstraint{})
 	require.NoError(t, err)
 	val, err := NewColumnWithTypeInfo("val", 102, typeinfo.StringDefaultType, false, "", false, "")
 	require.NoError(t, err)
-	// Multi-column PK with region first so PkOrdinals is not identity.
 	sch, err := NewSchema(NewColCollection(id, region, val), []int{1, 0}, Collation_utf8mb4_general_ci, nil, nil)
 	require.NoError(t, err)
 	sch.SetComment("test comment")
 	sch.SetTargetRowSize(4096)
-	_, err = sch.Checks().AddCheck("val_nonempty", "val <> ''", true)
+	_, err = sch.Checks().AddCheck("val_nonempty", "val <> ''", true, false)
 	require.NoError(t, err)
-	_, err = sch.Indexes().AddIndexByColTags("val_idx", []uint64{102}, nil, IndexProperties{IsUnique: true, IsUserDefined: true, Comment: "idx comment"})
+	_, err = sch.Checks().AddCheck("region_nonempty", "region <> ''", true, false)
 	require.NoError(t, err)
-	// Multi-column index on (region, val) where only val will be remapped, so the index
-	// must keep the unremapped region tag in place alongside the remapped val tag.
-	_, err = sch.Indexes().AddIndexByColTags("region_val_idx", []uint64{101, 102}, nil, IndexProperties{IsUserDefined: true})
+	_, err = sch.Indexes().AddIndexByColTags("val_idx", []uint64{102}, []uint16{16}, IndexProperties{IsUnique: true, IsUserDefined: true, Comment: "idx comment"})
 	require.NoError(t, err)
-	wantValProps := sch.Indexes().GetByName("val_idx").Properties()
-	wantRegionValProps := sch.Indexes().GetByName("region_val_idx").Properties()
-
-	// Remap only id and val so region stays at 101 to exercise the partial-remap path.
-	remapped, err := WithRemappedColumnTags(sch, map[uint64]uint64{100: 200, 102: 202})
+	_, err = sch.Indexes().AddIndexByColTags("region_val_idx", []uint64{101, 102}, []uint16{0, 8}, IndexProperties{IsUserDefined: true})
 	require.NoError(t, err)
+	return sch, map[uint64]uint64{100: 200, 102: 202}
+}
 
-	require.Equal(t, 3, remapped.GetAllCols().Size(), "no columns must be dropped during retag")
+func TestWithRemappedColumnTags(t *testing.T) {
+	// See https://github.com/dolthub/dolt/issues/11007
+	t.Run("Rewrites", func(t *testing.T) {
+		sch, remap := newRemapInputs(t)
+		remapped, err := WithRemappedColumnTags(sch, remap)
+		require.NoError(t, err)
 
-	gotID, ok := remapped.GetAllCols().GetByName("id")
-	require.True(t, ok)
-	require.Equal(t, uint64(200), gotID.Tag, "id tag must be remapped")
-	_, ok = remapped.GetAllCols().GetByTag(100)
-	require.False(t, ok, "old id tag must be gone")
+		require.Equal(t, 3, remapped.GetAllCols().Size(), "no columns must be dropped during retag")
 
-	got, ok := remapped.GetAllCols().GetByName("val")
-	require.True(t, ok)
-	require.Equal(t, uint64(202), got.Tag, "val tag must be remapped")
-	_, ok = remapped.GetAllCols().GetByTag(102)
-	require.False(t, ok, "old val tag must be gone")
-	gotRegion, ok := remapped.GetAllCols().GetByName("region")
-	require.True(t, ok)
-	require.Equal(t, uint64(101), gotRegion.Tag, "unremapped region tag must be unchanged")
+		gotID, ok := remapped.GetAllCols().GetByName("id")
+		require.True(t, ok)
+		require.Equal(t, uint64(200), gotID.Tag, "id tag must be remapped")
+		_, ok = remapped.GetAllCols().GetByTag(100)
+		require.False(t, ok, "old id tag must be gone")
 
-	require.Equal(t, []int{1, 0}, remapped.GetPkOrdinals(), "primary key ordinals must survive WithRemappedColumnTags")
+		gotVal, ok := remapped.GetAllCols().GetByName("val")
+		require.True(t, ok)
+		require.Equal(t, uint64(202), gotVal.Tag, "val tag must be remapped")
+		_, ok = remapped.GetAllCols().GetByTag(102)
+		require.False(t, ok, "old val tag must be gone")
 
-	valIdx := remapped.Indexes().GetByName("val_idx")
-	require.NotNil(t, valIdx)
-	require.Equal(t, "val_idx", valIdx.Name(), "index name must survive the retag")
-	require.Equal(t, []uint64{202}, valIdx.IndexedColumnTags(), "single-column index tag must be remapped")
-	require.Equal(t, wantValProps, valIdx.Properties(), "all index properties must survive the retag")
+		gotRegion, ok := remapped.GetAllCols().GetByName("region")
+		require.True(t, ok)
+		require.Equal(t, uint64(101), gotRegion.Tag, "unremapped region tag must be unchanged")
+	})
 
-	regionValIdx := remapped.Indexes().GetByName("region_val_idx")
-	require.NotNil(t, regionValIdx)
-	require.Equal(t, []uint64{101, 202}, regionValIdx.IndexedColumnTags(), "multi-column index must remap only the changed tag and keep the unchanged tag in place")
-	require.Equal(t, wantRegionValProps, regionValIdx.Properties(), "multi-column index properties must survive the retag")
+	t.Run("PreservesPrimaryKeyOrdinals", func(t *testing.T) {
+		sch, remap := newRemapInputs(t)
+		remapped, err := WithRemappedColumnTags(sch, remap)
+		require.NoError(t, err)
+		require.Equal(t, []int{1, 0}, remapped.GetPkOrdinals())
 
-	checks := remapped.Checks().AllChecks()
-	require.Len(t, checks, 1, "check constraints must survive WithRemappedColumnTags")
-	require.Equal(t, "val_nonempty", checks[0].Name(), "check constraint name must survive")
-	require.Equal(t, "val <> ''", checks[0].Expression(), "check constraint expression must survive")
-	require.True(t, checks[0].Enforced(), "check constraint enforcement flag must survive")
+		pkCols := remapped.GetPKCols().GetColumns()
+		require.Len(t, pkCols, 2)
+		require.Equal(t, "region", pkCols[0].Name)
+		require.Equal(t, uint64(101), pkCols[0].Tag)
+		require.Equal(t, "id", pkCols[1].Name)
+		require.Equal(t, uint64(200), pkCols[1].Tag, "PK column must carry the remapped id tag")
+	})
 
-	require.Equal(t, Collation_utf8mb4_general_ci, remapped.GetCollation(), "collation must survive WithRemappedColumnTags")
-	require.Equal(t, "test comment", remapped.GetComment(), "comment must survive WithRemappedColumnTags")
-	require.Equal(t, uint16(4096), remapped.GetTargetRowSize(), "target row size must survive WithRemappedColumnTags")
+	t.Run("PreservesIndexes", func(t *testing.T) {
+		sch, remap := newRemapInputs(t)
+		wantValProps := sch.Indexes().GetByName("val_idx").Properties()
+		wantValPrefix := sch.Indexes().GetByName("val_idx").PrefixLengths()
+		wantRegionValProps := sch.Indexes().GetByName("region_val_idx").Properties()
+		wantRegionValPrefix := sch.Indexes().GetByName("region_val_idx").PrefixLengths()
+
+		remapped, err := WithRemappedColumnTags(sch, remap)
+		require.NoError(t, err)
+
+		valIdx := remapped.Indexes().GetByName("val_idx")
+		require.NotNil(t, valIdx)
+		require.Equal(t, "val_idx", valIdx.Name())
+		require.Equal(t, []uint64{202}, valIdx.IndexedColumnTags(), "single-column index tag must be remapped")
+		require.Equal(t, wantValProps, valIdx.Properties(), "index properties must survive the retag")
+		require.Equal(t, wantValPrefix, valIdx.PrefixLengths(), "prefix lengths must survive the retag")
+
+		regionValIdx := remapped.Indexes().GetByName("region_val_idx")
+		require.NotNil(t, regionValIdx)
+		require.Equal(t, []uint64{101, 202}, regionValIdx.IndexedColumnTags(), "multi-column index must remap only the changed tag")
+		require.Equal(t, wantRegionValProps, regionValIdx.Properties())
+		require.Equal(t, wantRegionValPrefix, regionValIdx.PrefixLengths(), "multi-column index prefix lengths must survive the retag")
+	})
+
+	t.Run("PreservesCheckConstraints", func(t *testing.T) {
+		sch, remap := newRemapInputs(t)
+		remapped, err := WithRemappedColumnTags(sch, remap)
+		require.NoError(t, err)
+
+		checks := remapped.Checks().AllChecks()
+		require.Len(t, checks, 2, "all check constraints must survive")
+
+		seen := make(map[string]bool, len(checks))
+		for _, c := range checks {
+			require.True(t, c.Enforced(), "%s must remain enforced", c.Name())
+			switch c.Name() {
+			case "val_nonempty":
+				require.Equal(t, "val <> ''", c.Expression())
+			case "region_nonempty":
+				require.Equal(t, "region <> ''", c.Expression())
+			default:
+				t.Fatalf("unexpected check %q after remap", c.Name())
+			}
+			seen[c.Name()] = true
+		}
+		require.Len(t, seen, 2, "every check must appear exactly once")
+	})
+
+	t.Run("PreservesTableMetadata", func(t *testing.T) {
+		sch, remap := newRemapInputs(t)
+		remapped, err := WithRemappedColumnTags(sch, remap)
+		require.NoError(t, err)
+
+		require.Equal(t, Collation_utf8mb4_general_ci, remapped.GetCollation())
+		require.Equal(t, "test comment", remapped.GetComment())
+		require.Equal(t, uint16(4096), remapped.GetTargetRowSize())
+	})
+
+	t.Run("EmptyRemapReturnsInputSchema", func(t *testing.T) {
+		sch, _ := newRemapInputs(t)
+
+		remapped, err := WithRemappedColumnTags(sch, nil)
+		require.NoError(t, err)
+		require.Same(t, sch, remapped, "nil remap must short-circuit and return the input schema")
+
+		remapped, err = WithRemappedColumnTags(sch, map[uint64]uint64{})
+		require.NoError(t, err)
+		require.Same(t, sch, remapped, "empty remap must short-circuit and return the input schema")
+	})
 }

--- a/go/libraries/doltcore/schema/schema_test.go
+++ b/go/libraries/doltcore/schema/schema_test.go
@@ -417,3 +417,76 @@ func validateCols(t *testing.T, cols []Column, colColl *ColCollection, msg strin
 		t.Error()
 	}
 }
+
+// TestWithRemappedColumnTagsPreservesMetadata verifies that WithRemappedColumnTags rewrites the
+// column and index tags and carries collation, comment, target row size, check constraints,
+// primary key ordinals, multi-column index partial remap, and index properties onto the
+// returned schema.
+func TestWithRemappedColumnTagsPreservesMetadata(t *testing.T) {
+	// See https://github.com/dolthub/dolt/issues/11007
+	id, err := NewColumnWithTypeInfo("id", 100, typeinfo.Int64Type, true, "", false, "", NotNullConstraint{})
+	require.NoError(t, err)
+	region, err := NewColumnWithTypeInfo("region", 101, typeinfo.StringDefaultType, true, "", false, "", NotNullConstraint{})
+	require.NoError(t, err)
+	val, err := NewColumnWithTypeInfo("val", 102, typeinfo.StringDefaultType, false, "", false, "")
+	require.NoError(t, err)
+	// Multi-column PK with region first so PkOrdinals is not identity.
+	sch, err := NewSchema(NewColCollection(id, region, val), []int{1, 0}, Collation_utf8mb4_general_ci, nil, nil)
+	require.NoError(t, err)
+	sch.SetComment("test comment")
+	sch.SetTargetRowSize(4096)
+	_, err = sch.Checks().AddCheck("val_nonempty", "val <> ''", true)
+	require.NoError(t, err)
+	_, err = sch.Indexes().AddIndexByColTags("val_idx", []uint64{102}, nil, IndexProperties{IsUnique: true, IsUserDefined: true, Comment: "idx comment"})
+	require.NoError(t, err)
+	// Multi-column index on (region, val) where only val will be remapped, so the index
+	// must keep the unremapped region tag in place alongside the remapped val tag.
+	_, err = sch.Indexes().AddIndexByColTags("region_val_idx", []uint64{101, 102}, nil, IndexProperties{IsUserDefined: true})
+	require.NoError(t, err)
+	wantValProps := sch.Indexes().GetByName("val_idx").Properties()
+	wantRegionValProps := sch.Indexes().GetByName("region_val_idx").Properties()
+
+	// Remap only id and val so region stays at 101 to exercise the partial-remap path.
+	remapped, err := WithRemappedColumnTags(sch, map[uint64]uint64{100: 200, 102: 202})
+	require.NoError(t, err)
+
+	require.Equal(t, 3, remapped.GetAllCols().Size(), "no columns must be dropped during retag")
+
+	gotID, ok := remapped.GetAllCols().GetByName("id")
+	require.True(t, ok)
+	require.Equal(t, uint64(200), gotID.Tag, "id tag must be remapped")
+	_, ok = remapped.GetAllCols().GetByTag(100)
+	require.False(t, ok, "old id tag must be gone")
+
+	got, ok := remapped.GetAllCols().GetByName("val")
+	require.True(t, ok)
+	require.Equal(t, uint64(202), got.Tag, "val tag must be remapped")
+	_, ok = remapped.GetAllCols().GetByTag(102)
+	require.False(t, ok, "old val tag must be gone")
+	gotRegion, ok := remapped.GetAllCols().GetByName("region")
+	require.True(t, ok)
+	require.Equal(t, uint64(101), gotRegion.Tag, "unremapped region tag must be unchanged")
+
+	require.Equal(t, []int{1, 0}, remapped.GetPkOrdinals(), "primary key ordinals must survive WithRemappedColumnTags")
+
+	valIdx := remapped.Indexes().GetByName("val_idx")
+	require.NotNil(t, valIdx)
+	require.Equal(t, "val_idx", valIdx.Name(), "index name must survive the retag")
+	require.Equal(t, []uint64{202}, valIdx.IndexedColumnTags(), "single-column index tag must be remapped")
+	require.Equal(t, wantValProps, valIdx.Properties(), "all index properties must survive the retag")
+
+	regionValIdx := remapped.Indexes().GetByName("region_val_idx")
+	require.NotNil(t, regionValIdx)
+	require.Equal(t, []uint64{101, 202}, regionValIdx.IndexedColumnTags(), "multi-column index must remap only the changed tag and keep the unchanged tag in place")
+	require.Equal(t, wantRegionValProps, regionValIdx.Properties(), "multi-column index properties must survive the retag")
+
+	checks := remapped.Checks().AllChecks()
+	require.Len(t, checks, 1, "check constraints must survive WithRemappedColumnTags")
+	require.Equal(t, "val_nonempty", checks[0].Name(), "check constraint name must survive")
+	require.Equal(t, "val <> ''", checks[0].Expression(), "check constraint expression must survive")
+	require.True(t, checks[0].Enforced(), "check constraint enforcement flag must survive")
+
+	require.Equal(t, Collation_utf8mb4_general_ci, remapped.GetCollation(), "collation must survive WithRemappedColumnTags")
+	require.Equal(t, "test comment", remapped.GetComment(), "comment must survive WithRemappedColumnTags")
+	require.Equal(t, uint16(4096), remapped.GetTargetRowSize(), "target row size must survive WithRemappedColumnTags")
+}

--- a/go/libraries/doltcore/schema/tag.go
+++ b/go/libraries/doltcore/schema/tag.go
@@ -76,6 +76,23 @@ func (tm TagMapping) Size() int {
 	return len(tm)
 }
 
+// RemapTags returns a new slice with each entry of |tags| replaced by its value in
+// |remap|, or kept unchanged when absent. The result is always a fresh allocation that
+// the caller may mutate.
+func RemapTags(tags []uint64, remap map[uint64]uint64) []uint64 {
+	out := make([]uint64, len(tags))
+	copy(out, tags)
+	if len(remap) == 0 {
+		return out
+	}
+	for i, t := range tags {
+		if newTag, ok := remap[t]; ok {
+			out[i] = newTag
+		}
+	}
+	return out
+}
+
 // AutoGenerateTag generates a random tag that doesn't exist in the provided SuperSchema.
 // It uses a deterministic random number generator that is seeded with the NomsKinds of any existing columns in the
 // schema and the NomsKind of the column being added to the schema. Deterministic tag generation means that branches

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_update_column_tag.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_update_column_tag.go
@@ -57,7 +57,7 @@ func doltUpdateColumnTag(ctx *sql.Context, args ...string) (sql.RowIter, error) 
 		return nil, err
 	}
 
-	newSch, err := updateColumnTag(sch, columnName, tag)
+	newSch, err := schema.WithUpdatedColumnTag(sch, columnName, tag)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update column tag: %w", err)
 	}
@@ -99,36 +99,4 @@ func parseUpdateColumnTagArgs(args ...string) (tableName, columnName string, tag
 	}
 
 	return tableName, columnName, tag, nil
-}
-
-// updateColumnTag updates |sch| by setting the tag for the column named |name| to |tag|.
-func updateColumnTag(sch schema.Schema, name string, tag uint64) (schema.Schema, error) {
-	var found bool
-	columns := sch.GetAllCols().GetColumns()
-	// Find column and update its tag
-	for i, col := range columns {
-		if col.Name == name {
-			col.Tag = tag
-			columns[i] = col
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		return nil, fmt.Errorf("column %s does not exist", name)
-	}
-
-	newSch, err := schema.SchemaFromCols(schema.NewColCollection(columns...))
-	if err != nil {
-		return nil, err
-	}
-
-	if err = newSch.SetPkOrdinals(sch.GetPkOrdinals()); err != nil {
-		return nil, err
-	}
-	newSch.SetCollation(sch.GetCollation())
-	newSch.SetTargetRowSize(sch.GetTargetRowSize())
-
-	return newSch, nil
 }

--- a/integration-tests/bats/column_tags.bats
+++ b/integration-tests/bats/column_tags.bats
@@ -355,7 +355,7 @@ CREATE TABLE accounts (
     CONSTRAINT email_format CHECK (email LIKE '%@%')
 );
 SQL
-    # ALTER TABLE COMMENT prints a benign result-type warning but does set the comment.
+    # TODO(elianddb): dolt sql drops CREATE TABLE COMMENT when PRIMARY KEY is a separate clause, and ALTER TABLE COMMENT errors with types.OkResult despite persisting.
     dolt sql -q "ALTER TABLE accounts COMMENT='application accounts'" 2>/dev/null || true
     dolt commit -Am "initial accounts"
 

--- a/integration-tests/bats/column_tags.bats
+++ b/integration-tests/bats/column_tags.bats
@@ -340,3 +340,54 @@ DELIM
     [[ $output =~ "1,1" ]] || false
     [[ $output =~ "2,2" ]] || false
 }
+
+@test "column_tags: update-tag preserves indexes, check constraints, comment, and multi-column primary key" {
+    # See https://github.com/dolthub/dolt/issues/11007
+    dolt sql <<SQL
+CREATE TABLE accounts (
+    id INT NOT NULL,
+    region VARCHAR(8) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    score INT DEFAULT 0,
+    PRIMARY KEY (region, id),
+    UNIQUE KEY email_unique (email),
+    KEY score_idx (score),
+    CONSTRAINT email_format CHECK (email LIKE '%@%')
+);
+SQL
+    # ALTER TABLE COMMENT prints a benign result-type warning but does set the comment.
+    dolt sql -q "ALTER TABLE accounts COMMENT='application accounts'" 2>/dev/null || true
+    dolt commit -Am "initial accounts"
+
+    dolt schema update-tag accounts id 999
+    dolt schema update-tag accounts email 888
+
+    run dolt sql -q "show create table accounts"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "PRIMARY KEY (\`region\`,\`id\`)" ]] || false
+    [[ "$output" =~ "UNIQUE KEY \`email_unique\`" ]] || false
+    [[ "$output" =~ "KEY \`score_idx\`" ]] || false
+    [[ "$output" =~ "CONSTRAINT \`email_format\` CHECK" ]] || false
+    [[ "$output" =~ "COMMENT='application accounts'" ]] || false
+
+    run dolt schema tags accounts
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "999" ]] || false
+    [[ "$output" =~ "888" ]] || false
+
+    run dolt sql -q "INSERT INTO accounts VALUES (1, 'us', 'no-at-sign', 0)"
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "Check constraint" ]] || false
+
+    dolt sql -q "INSERT INTO accounts VALUES (1, 'us', 'alice@example.com', 100)"
+    run dolt sql -q "INSERT INTO accounts VALUES (2, 'eu', 'alice@example.com', 200)"
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "duplicate" ]] || false
+
+    dolt sql -q "INSERT INTO accounts VALUES (1, 'eu', 'bob@example.com', 50)"
+
+    run dolt sql -r csv -q "SELECT region, id FROM accounts ORDER BY region, id"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "eu,1" ]] || false
+    [[ "$output" =~ "us,1" ]] || false
+}

--- a/integration-tests/bats/column_tags.bats
+++ b/integration-tests/bats/column_tags.bats
@@ -353,10 +353,8 @@ CREATE TABLE accounts (
     UNIQUE KEY email_unique (email),
     KEY score_idx (score),
     CONSTRAINT email_format CHECK (email LIKE '%@%')
-);
+) COMMENT='application accounts';
 SQL
-    # TODO(elianddb): dolt sql drops CREATE TABLE COMMENT when PRIMARY KEY is a separate clause, and ALTER TABLE COMMENT errors with types.OkResult despite persisting.
-    dolt sql -q "ALTER TABLE accounts COMMENT='application accounts'" 2>/dev/null || true
     dolt commit -Am "initial accounts"
 
     dolt schema update-tag accounts id 999

--- a/integration-tests/bats/copy-tags.bats
+++ b/integration-tests/bats/copy-tags.bats
@@ -95,10 +95,8 @@ CREATE TABLE accounts (
     UNIQUE KEY email_unique (email),
     KEY id_idx (id),
     CONSTRAINT email_format CHECK (email LIKE '%@%')
-);
+) COMMENT='application accounts';
 SQL
-    # TODO(elianddb): dolt sql drops CREATE TABLE COMMENT when PRIMARY KEY is a separate clause, and ALTER TABLE COMMENT errors with types.OkResult despite persisting.
-    dolt sql -q "ALTER TABLE accounts COMMENT='application accounts'" 2>/dev/null || true
     dolt commit -Am "accounts on main"
 
     dolt checkout branch1
@@ -111,10 +109,8 @@ CREATE TABLE accounts (
     UNIQUE KEY email_unique (email),
     KEY id_idx (id),
     CONSTRAINT email_format CHECK (email LIKE '%@%')
-);
+) COMMENT='application accounts';
 SQL
-    # TODO(elianddb): dolt sql drops CREATE TABLE COMMENT when PRIMARY KEY is a separate clause, and ALTER TABLE COMMENT errors with types.OkResult despite persisting.
-    dolt sql -q "ALTER TABLE accounts COMMENT='application accounts'" 2>/dev/null || true
     # Diverge the id tag on branch1 so copy-tags has real work to do.
     dolt schema update-tag accounts id 11111
     dolt commit -Am "accounts on branch1"

--- a/integration-tests/bats/copy-tags.bats
+++ b/integration-tests/bats/copy-tags.bats
@@ -83,3 +83,67 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" =~ "initial data" ]] || false
 }
+
+@test "copy-tags: preserves indexes, check constraints, comment, and multi-column primary key" {
+    # See https://github.com/dolthub/dolt/issues/11007
+    dolt sql <<SQL
+CREATE TABLE accounts (
+    id INT NOT NULL,
+    region VARCHAR(8) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    PRIMARY KEY (region, id),
+    UNIQUE KEY email_unique (email),
+    KEY id_idx (id),
+    CONSTRAINT email_format CHECK (email LIKE '%@%')
+);
+SQL
+    dolt sql -q "ALTER TABLE accounts COMMENT='application accounts'" 2>/dev/null || true
+    dolt commit -Am "accounts on main"
+
+    dolt checkout branch1
+    dolt sql <<SQL
+CREATE TABLE accounts (
+    id INT NOT NULL,
+    region VARCHAR(8) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    PRIMARY KEY (region, id),
+    UNIQUE KEY email_unique (email),
+    KEY id_idx (id),
+    CONSTRAINT email_format CHECK (email LIKE '%@%')
+);
+SQL
+    dolt sql -q "ALTER TABLE accounts COMMENT='application accounts'" 2>/dev/null || true
+    # Diverge the id tag on branch1 so copy-tags has real work to do.
+    dolt schema update-tag accounts id 11111
+    dolt commit -Am "accounts on branch1"
+
+    dolt schema copy-tags main
+
+    run dolt schema tags accounts
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "11111" ]] || false
+
+    run dolt sql -q "show create table accounts"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "PRIMARY KEY (\`region\`,\`id\`)" ]] || false
+    [[ "$output" =~ "UNIQUE KEY \`email_unique\`" ]] || false
+    [[ "$output" =~ "KEY \`id_idx\`" ]] || false
+    [[ "$output" =~ "CONSTRAINT \`email_format\` CHECK" ]] || false
+    [[ "$output" =~ "COMMENT='application accounts'" ]] || false
+
+    run dolt sql -q "INSERT INTO accounts VALUES (1, 'us', 'no-at-sign')"
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "Check constraint" ]] || false
+
+    dolt sql -q "INSERT INTO accounts VALUES (1, 'us', 'alice@example.com')"
+    run dolt sql -q "INSERT INTO accounts VALUES (2, 'eu', 'alice@example.com')"
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "duplicate" ]] || false
+
+    dolt sql -q "INSERT INTO accounts VALUES (1, 'eu', 'bob@example.com')"
+
+    run dolt sql -r csv -q "SELECT region, id FROM accounts ORDER BY region, id"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "eu,1" ]] || false
+    [[ "$output" =~ "us,1" ]] || false
+}

--- a/integration-tests/bats/copy-tags.bats
+++ b/integration-tests/bats/copy-tags.bats
@@ -97,6 +97,7 @@ CREATE TABLE accounts (
     CONSTRAINT email_format CHECK (email LIKE '%@%')
 );
 SQL
+    # TODO(elianddb): dolt sql drops CREATE TABLE COMMENT when PRIMARY KEY is a separate clause, and ALTER TABLE COMMENT errors with types.OkResult despite persisting.
     dolt sql -q "ALTER TABLE accounts COMMENT='application accounts'" 2>/dev/null || true
     dolt commit -Am "accounts on main"
 
@@ -112,6 +113,7 @@ CREATE TABLE accounts (
     CONSTRAINT email_format CHECK (email LIKE '%@%')
 );
 SQL
+    # TODO(elianddb): dolt sql drops CREATE TABLE COMMENT when PRIMARY KEY is a separate clause, and ALTER TABLE COMMENT errors with types.OkResult despite persisting.
     dolt sql -q "ALTER TABLE accounts COMMENT='application accounts'" 2>/dev/null || true
     # Diverge the id tag on branch1 so copy-tags has real work to do.
     dolt schema update-tag accounts id 11111

--- a/integration-tests/bats/sql-update-column-tag.bats
+++ b/integration-tests/bats/sql-update-column-tag.bats
@@ -78,10 +78,8 @@ CREATE TABLE accounts (
     UNIQUE KEY email_unique (email),
     KEY id_idx (id),
     CONSTRAINT email_format CHECK (email LIKE '%@%')
-);
+) COMMENT='application accounts';
 SQL
-    # TODO(elianddb): dolt sql drops CREATE TABLE COMMENT when PRIMARY KEY is a separate clause, and ALTER TABLE COMMENT errors with types.OkResult despite persisting.
-    dolt sql -q "ALTER TABLE accounts COMMENT='application accounts'" 2>/dev/null || true
 
     dolt sql -q "call dolt_update_column_tag('accounts', 'id', 999);"
     dolt sql -q "call dolt_update_column_tag('accounts', 'email', 888);"

--- a/integration-tests/bats/sql-update-column-tag.bats
+++ b/integration-tests/bats/sql-update-column-tag.bats
@@ -80,6 +80,7 @@ CREATE TABLE accounts (
     CONSTRAINT email_format CHECK (email LIKE '%@%')
 );
 SQL
+    # TODO(elianddb): dolt sql drops CREATE TABLE COMMENT when PRIMARY KEY is a separate clause, and ALTER TABLE COMMENT errors with types.OkResult despite persisting.
     dolt sql -q "ALTER TABLE accounts COMMENT='application accounts'" 2>/dev/null || true
 
     dolt sql -q "call dolt_update_column_tag('accounts', 'id', 999);"

--- a/integration-tests/bats/sql-update-column-tag.bats
+++ b/integration-tests/bats/sql-update-column-tag.bats
@@ -66,3 +66,51 @@ teardown() {
     [ "$status" -eq 1 ]
     [[ "$output" =~ "failed to parse tag" ]] || false
 }
+
+@test "sql-update-column-tag: preserves indexes, check constraints, comment, and multi-column primary key" {
+    # See https://github.com/dolthub/dolt/issues/11007
+    dolt sql <<SQL
+CREATE TABLE accounts (
+    id INT NOT NULL,
+    region VARCHAR(8) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    PRIMARY KEY (region, id),
+    UNIQUE KEY email_unique (email),
+    KEY id_idx (id),
+    CONSTRAINT email_format CHECK (email LIKE '%@%')
+);
+SQL
+    dolt sql -q "ALTER TABLE accounts COMMENT='application accounts'" 2>/dev/null || true
+
+    dolt sql -q "call dolt_update_column_tag('accounts', 'id', 999);"
+    dolt sql -q "call dolt_update_column_tag('accounts', 'email', 888);"
+
+    run dolt sql -q "show create table accounts"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "PRIMARY KEY (\`region\`,\`id\`)" ]] || false
+    [[ "$output" =~ "UNIQUE KEY \`email_unique\`" ]] || false
+    [[ "$output" =~ "KEY \`id_idx\`" ]] || false
+    [[ "$output" =~ "CONSTRAINT \`email_format\` CHECK" ]] || false
+    [[ "$output" =~ "COMMENT='application accounts'" ]] || false
+
+    run dolt schema tags accounts
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "999" ]] || false
+    [[ "$output" =~ "888" ]] || false
+
+    run dolt sql -q "INSERT INTO accounts VALUES (1, 'us', 'no-at-sign')"
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "Check constraint" ]] || false
+
+    dolt sql -q "INSERT INTO accounts VALUES (1, 'us', 'alice@example.com')"
+    run dolt sql -q "INSERT INTO accounts VALUES (2, 'eu', 'alice@example.com')"
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "duplicate" ]] || false
+
+    dolt sql -q "INSERT INTO accounts VALUES (1, 'eu', 'bob@example.com')"
+
+    run dolt sql -r csv -q "SELECT region, id FROM accounts ORDER BY region, id"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "eu,1" ]] || false
+    [[ "$output" =~ "us,1" ]] || false
+}


### PR DESCRIPTION
`updateColumnTag` was duplicated as a private helper in `schcmds/update-tag.go` and `dprocedures/dolt_update_column_tag.go`, and rebuilt the schema without preserving a schema's secondary indexes, CHECK constraints, table comment, and target row size.
- Add `schema.WithRemappedColumnTags` and `schema.WithUpdatedColumnTag` to rebuild schema with all metadata: indexes, CHECK constraints, comment, target row size, PK ordinals, and collation.
- Add `Index.Properties()` so indexes can be re-added on the rebuilt schema with their full property set.
Refs: #11007 