### PR TITLE
bug fix for race condition in acquiring auto increment locks

### DIFF
--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -107,9 +107,9 @@ type SqlEngineConfigOption func(*SqlEngineConfig)
 
 // NewSqlEngine returns a SqlEngine
 func NewSqlEngine(
-	ctx context.Context,
-	mrEnv *env.MultiRepoEnv,
-	config *SqlEngineConfig,
+		ctx context.Context,
+		mrEnv *env.MultiRepoEnv,
+		config *SqlEngineConfig,
 ) (*SqlEngine, error) {
 	// Context validation is a testing mode that we run Dolt in
 	// during integration tests. It asserts that `context.Context`
@@ -144,6 +144,12 @@ func NewSqlEngine(
 		})
 	}
 
+	// Some database initialization logic depends on system variables, load them before the databases
+	err := applySystemVariables(sql.SystemVariables, config.SystemVariables)
+	if err != nil {
+		return nil, err
+	}
+
 	dbs, locations, err := CollectDBs(ctx, mrEnv)
 	if err != nil {
 		return nil, err
@@ -159,11 +165,6 @@ func NewSqlEngine(
 	config.ClusterController.ManageSystemVariables(sql.SystemVariables)
 
 	err = config.ClusterController.ApplyStandbyReplicationConfig(ctx, mrEnv, dbs...)
-	if err != nil {
-		return nil, err
-	}
-
-	err = applySystemVariables(sql.SystemVariables, config.SystemVariables)
 	if err != nil {
 		return nil, err
 	}
@@ -597,13 +598,13 @@ func sqlContextFactory(ctx context.Context, opts ...sql.ContextOption) *sql.Cont
 
 // doltSessionFactory returns a sessionFactory that creates a new DoltSession
 func doltSessionFactory(
-	pro *sqle.DoltDatabaseProvider,
-	statsPro sql.StatsProvider,
-	config config.ReadWriteConfig,
-	bc *branch_control.Controller,
-	gcSafepointController *gcctx.GCSafepointController,
-	autocommit bool,
-	tracker *doltdb.BranchActivityTracker) sessionFactory {
+		pro *sqle.DoltDatabaseProvider,
+		statsPro sql.StatsProvider,
+		config config.ReadWriteConfig,
+		bc *branch_control.Controller,
+		gcSafepointController *gcctx.GCSafepointController,
+		autocommit bool,
+		tracker *doltdb.BranchActivityTracker) sessionFactory {
 	return func(mysqlSess *sql.BaseSession, provider sql.DatabaseProvider) (*dsess.DoltSession, error) {
 		doltSession, err := dsess.NewDoltSession(mysqlSess, pro, config, bc, statsPro, writer.NewWriteSession, gcSafepointController, tracker)
 		if err != nil {

--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -107,9 +107,9 @@ type SqlEngineConfigOption func(*SqlEngineConfig)
 
 // NewSqlEngine returns a SqlEngine
 func NewSqlEngine(
-		ctx context.Context,
-		mrEnv *env.MultiRepoEnv,
-		config *SqlEngineConfig,
+	ctx context.Context,
+	mrEnv *env.MultiRepoEnv,
+	config *SqlEngineConfig,
 ) (*SqlEngine, error) {
 	// Context validation is a testing mode that we run Dolt in
 	// during integration tests. It asserts that `context.Context`
@@ -598,13 +598,13 @@ func sqlContextFactory(ctx context.Context, opts ...sql.ContextOption) *sql.Cont
 
 // doltSessionFactory returns a sessionFactory that creates a new DoltSession
 func doltSessionFactory(
-		pro *sqle.DoltDatabaseProvider,
-		statsPro sql.StatsProvider,
-		config config.ReadWriteConfig,
-		bc *branch_control.Controller,
-		gcSafepointController *gcctx.GCSafepointController,
-		autocommit bool,
-		tracker *doltdb.BranchActivityTracker) sessionFactory {
+	pro *sqle.DoltDatabaseProvider,
+	statsPro sql.StatsProvider,
+	config config.ReadWriteConfig,
+	bc *branch_control.Controller,
+	gcSafepointController *gcctx.GCSafepointController,
+	autocommit bool,
+	tracker *doltdb.BranchActivityTracker) sessionFactory {
 	return func(mysqlSess *sql.BaseSession, provider sql.DatabaseProvider) (*dsess.DoltSession, error) {
 		doltSession, err := dsess.NewDoltSession(mysqlSess, pro, config, bc, statsPro, writer.NewWriteSession, gcSafepointController, tracker)
 		if err != nil {

--- a/go/go.sum
+++ b/go/go.sum
@@ -210,8 +210,6 @@ github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69 h1:JShhbq
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69/go.mod h1:SSLraQS/jGLYFgff3vuZ+JbVUct6vyEeMzjLBqWqoyM=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2/go.mod h1:mIEZOHnFx4ZMQeawhw9rhsj+0zwQj7adVsnBX7t+eKY=
-github.com/dolthub/fslock v0.0.4 h1:p0FcUPu81bO53349qPT1im7XyGu3CwZDsB0PEVdFcaE=
-github.com/dolthub/fslock v0.0.4/go.mod h1:895XJNoMTlL5N1TjOJbd9Pnpjtv1DW/Ddw9qShcAYsM=
 github.com/dolthub/fslock v0.0.5 h1:QoXhBhgY1oumHE26qyE7tgmXUT8qjJwxsIzo54O/B/k=
 github.com/dolthub/fslock v0.0.5/go.mod h1:sdofYYqE0D79zNZyB4/kmlnsQOVap1C2yByjGKSirEM=
 github.com/dolthub/go-icu-regex v0.0.0-20260412212219-49724d547866 h1:U6gSf5I0e6h6GP1/5Sa7D2lWW1CWfcVPtY5wkyHq6jY=
@@ -747,8 +745,6 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4 h1:bTLqdHv7xrGlFbvf5/TXNxy/iUwwdkjhqQTJDjW7aj0=

--- a/go/libraries/doltcore/sqle/dsess/autoincrement_tracker.go
+++ b/go/libraries/doltcore/sqle/dsess/autoincrement_tracker.go
@@ -60,6 +60,9 @@ type AutoIncrementTracker struct {
 	// async initialization and block on the process completing.
 	cancelInit chan struct{}
 	dbName     string
+	// lockMode is the effective @@innodb_autoinc_lock_mode at the time of AutoIncrementTracker initialization.
+	// This value can only be set by config and cannot be changed in a running server.
+	lockMode LockMode
 }
 
 // currentLockMode returns the effective @@innodb_autoinc_lock_mode stored in global server vars
@@ -197,7 +200,7 @@ func (a *AutoIncrementTracker) Next(ctx *sql.Context, tbl string, insertVal inte
 	// interleaved lock mode (the default) the engine holds no statement-level lock, so we take a
 	// short per-table lock here.
 	locked := false
-	if currentLockMode() == LockMode_Interleaved {
+	if a.lockMode == LockMode_Interleaved {
 		release := a.mm.Lock(tbl)
 		defer release()
 		locked = true
@@ -208,7 +211,7 @@ func (a *AutoIncrementTracker) Next(ctx *sql.Context, tbl string, insertVal inte
 		// Missing tracker state after initialization can happen when a running sql-server discovers a database
 		// restored after startup, so initialize it here.
 		if !locked {
-			if currentLockMode() == LockMode_Interleaved {
+			if a.lockMode == LockMode_Interleaved {
 				release := a.mm.Lock(tbl)
 				defer release()
 				locked = true
@@ -560,7 +563,8 @@ func (a *AutoIncrementTracker) AcquireTableLock(ctx *sql.Context, tableName stri
 		return nil, err
 	}
 
-	if currentLockMode() == LockMode_Interleaved {
+	if a.lockMode == LockMode_Interleaved {
+		// This shouldn't be possible, it's a serious programming error if it happens
 		panic("Attempted to acquire AutoInc lock for entire insert operation, but lock mode was set to Interleaved")
 	}
 	return a.mm.Lock(tableName), nil
@@ -640,6 +644,7 @@ func (a *AutoIncrementTracker) initWithRoots(ctx context.Context, roots ...doltd
 		})
 	}
 
+	a.lockMode = currentLockMode()
 	a.initErr = eg.Wait()
 }
 

--- a/go/libraries/doltcore/sqle/dsess/autoincrement_tracker.go
+++ b/go/libraries/doltcore/sqle/dsess/autoincrement_tracker.go
@@ -17,6 +17,7 @@ package dsess
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"math"
 	"strings"
@@ -41,7 +42,7 @@ type LockMode int64
 
 var (
 	LockMode_Traditional LockMode = 0
-	LockMode_Concurret   LockMode = 1
+	LockMode_Concurrent  LockMode = 1
 	LockMode_Interleaved LockMode = 2
 )
 
@@ -59,7 +60,15 @@ type AutoIncrementTracker struct {
 	// async initialization and block on the process completing.
 	cancelInit chan struct{}
 	dbName     string
-	lockMode   LockMode
+}
+
+// currentLockMode returns the effective @@innodb_autoinc_lock_mode stored in global server vars
+func currentLockMode() LockMode {
+	_, i, _ := sql.SystemVariables.GetGlobal("innodb_autoinc_lock_mode")
+	if mode, ok := i.(int64); ok {
+		return LockMode(mode)
+	}
+	return LockMode_Interleaved
 }
 
 var _ globalstate.AutoIncrementTracker = &AutoIncrementTracker{}
@@ -184,8 +193,11 @@ func (a *AutoIncrementTracker) Next(ctx *sql.Context, tbl string, insertVal inte
 		return 0, err
 	}
 
+	// The read-modify-write of the sequence below must be atomic across concurrent inserters. In
+	// interleaved lock mode (the default) the engine holds no statement-level lock, so we take a
+	// short per-table lock here.
 	locked := false
-	if a.lockMode == LockMode_Interleaved {
+	if currentLockMode() == LockMode_Interleaved {
 		release := a.mm.Lock(tbl)
 		defer release()
 		locked = true
@@ -193,24 +205,25 @@ func (a *AutoIncrementTracker) Next(ctx *sql.Context, tbl string, insertVal inte
 
 	curr, ok := loadAutoIncValue(a.sequences, tbl)
 	if !ok {
+		// Missing tracker state after initialization can happen when a running sql-server discovers a database
+		// restored after startup, so initialize it here.
 		if !locked {
-			// Missing tracker state is unusual after initialization, but can happen when
-			// a running sql-server discovers a database restored after startup. Lock before
-			// rechecking so concurrent first users do not initialize the same table twice.
-			release := a.mm.Lock(tbl)
-			defer release()
+			if currentLockMode() == LockMode_Interleaved {
+				release := a.mm.Lock(tbl)
+				defer release()
+				locked = true
+			}
+
+			curr, ok = loadAutoIncValue(a.sequences, tbl)
 		}
 
-		curr, ok = loadAutoIncValue(a.sequences, tbl)
 		if !ok {
-			// The table metadata is the source of truth for a restored database that is
-			// missing from the in-memory tracker.
-			seq, found, err := a.initializeTableAutoIncrement(ctx, tbl)
+			curr, ok, err = a.initializeTableAutoIncrement(ctx, tbl)
 			if err != nil {
 				return 0, err
 			}
-			if found {
-				curr = seq
+			if !ok {
+				return 0, fmt.Errorf("autoIncrementTracker: unable to find sequence for table %s", tbl)
 			}
 		}
 	}
@@ -547,12 +560,9 @@ func (a *AutoIncrementTracker) AcquireTableLock(ctx *sql.Context, tableName stri
 		return nil, err
 	}
 
-	_, i, _ := sql.SystemVariables.GetGlobal("innodb_autoinc_lock_mode")
-	lockMode := LockMode(i.(int64))
-	if lockMode == LockMode_Interleaved {
+	if currentLockMode() == LockMode_Interleaved {
 		panic("Attempted to acquire AutoInc lock for entire insert operation, but lock mode was set to Interleaved")
 	}
-	a.lockMode = lockMode
 	return a.mm.Lock(tableName), nil
 }
 

--- a/go/libraries/doltcore/sqle/enginetest/dolt_concurrent_autoincrement_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_concurrent_autoincrement_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enginetest
+
+import (
+	gosql "database/sql"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/servercfg"
+)
+
+func TestConcurrentAutoIncrementInserts(t *testing.T) {
+	const (
+		dbName      = "dolt_concurrency_repro"
+		tableName   = "global_audit_log"
+		threadCount = 100
+	)
+
+	dEnv, sc, serverConfig := startServer(t, true, "", "")
+	require.NoError(t, sc.WaitForStart())
+	defer dEnv.Close()
+	defer func() {
+		sc.Stop()
+		require.NoError(t, sc.WaitForStop())
+	}()
+
+	// openDB opens a connection pool to the named database. multiStatements is enabled so the
+	// batched setup below can be executed verbatim.
+	openDB := func(database string) *gosql.DB {
+		dsn := servercfg.ConnectionString(serverConfig, database)
+		if strings.Contains(dsn, "?") {
+			dsn += "&multiStatements=true"
+		} else {
+			dsn += "?multiStatements=true"
+		}
+		db, err := gosql.Open("mysql", dsn)
+		require.NoError(t, err)
+		return db
+	}
+
+	{
+		conn := openDB("dolt")
+		_, err := conn.Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", dbName))
+		require.NoError(t, err)
+		require.NoError(t, conn.Close())
+	}
+
+	{
+		conn := openDB(dbName)
+		_, err := conn.Exec(fmt.Sprintf("DROP TABLE IF EXISTS `%s`", tableName))
+		require.NoError(t, err)
+		_, err = conn.Exec(fmt.Sprintf(
+			"CREATE TABLE `%s` (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, message TEXT)", tableName))
+		require.NoError(t, err)
+	}
+
+	var (
+		mu       sync.Mutex
+		failures []string
+		wg       sync.WaitGroup
+	)
+	for i := 1; i <= threadCount; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			conn := openDB(dbName)
+			defer conn.Close()
+			_, err := conn.Exec(
+				fmt.Sprintf("INSERT INTO `%s` (message) VALUES (?)", tableName),
+				fmt.Sprintf("message %d", i))
+			if err != nil {
+				mu.Lock()
+				failures = append(failures, fmt.Sprintf("%T: %v", err, err))
+				mu.Unlock()
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	report := openDB(dbName)
+	defer report.Close()
+
+	var rowCount, distinctIds int
+	var maxID gosql.NullInt64
+	require.NoError(t, report.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM `%s`", tableName)).Scan(&rowCount))
+	require.NoError(t, report.QueryRow(fmt.Sprintf("SELECT COUNT(DISTINCT id) FROM `%s`", tableName)).Scan(&distinctIds))
+	require.NoError(t, report.QueryRow(fmt.Sprintf("SELECT MAX(id) FROM `%s`", tableName)).Scan(&maxID))
+
+	t.Logf("Attempted inserts : %d", threadCount)
+	t.Logf("Rows persisted    : %d", rowCount)
+	t.Logf("Distinct ids      : %d", distinctIds)
+	t.Logf("Max id            : %v", maxID.Int64)
+	t.Logf("Failed inserts    : %d", len(failures))
+
+	groups := map[string]int{}
+	for _, f := range failures {
+		groups[f]++
+	}
+	grouped := make([]string, 0, len(groups))
+	for msg := range groups {
+		grouped = append(grouped, msg)
+	}
+	sort.Slice(grouped, func(i, j int) bool { return groups[grouped[i]] > groups[grouped[j]] })
+	for _, msg := range grouped {
+		t.Logf("  %dx  %s", groups[msg], msg)
+	}
+
+	require.Emptyf(t, failures, "expected no failed inserts, got %d", len(failures))
+	require.Equalf(t, distinctIds, rowCount,
+		"duplicate auto-increment ids detected: %d rows but only %d distinct ids", rowCount, distinctIds)
+	require.Equalf(t, threadCount, rowCount, "expected %d rows persisted, got %d", threadCount, rowCount)
+}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_tests.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_tests.go
@@ -1855,11 +1855,11 @@ func RunAddDropPrimaryKeysTests(t *testing.T, harness DoltEnginetestHarness) {
 					Query: "show create table test",
 					Expected: []sql.Row{
 						{"test", "CREATE TABLE `test` (\n" +
-								"  `id` int NOT NULL,\n" +
-								"  `c1` int,\n" +
-								"  PRIMARY KEY (`id`),\n" +
-								"  KEY `c1_idx` (`c1`)\n" +
-								") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+							"  `id` int NOT NULL,\n" +
+							"  `c1` int,\n" +
+							"  PRIMARY KEY (`id`),\n" +
+							"  KEY `c1_idx` (`c1`)\n" +
+							") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 					},
 				},
 			},
@@ -1905,12 +1905,12 @@ func RunAddDropPrimaryKeysTests(t *testing.T, harness DoltEnginetestHarness) {
 					Query: "show create table test",
 					Expected: []sql.Row{
 						{"test", "CREATE TABLE `test` (\n" +
-								"  `id` int NOT NULL,\n" +
-								"  `c1` int,\n" +
-								"  PRIMARY KEY (`id`),\n" +
-								"  KEY `c1_idx` (`c1`),\n" +
-								"  CONSTRAINT `test_check` CHECK ((`c1` > 0))\n" +
-								") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+							"  `id` int NOT NULL,\n" +
+							"  `c1` int,\n" +
+							"  PRIMARY KEY (`id`),\n" +
+							"  KEY `c1_idx` (`c1`),\n" +
+							"  CONSTRAINT `test_check` CHECK ((`c1` > 0))\n" +
+							") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 					},
 				},
 				{
@@ -1982,10 +1982,10 @@ func RunAddDropPrimaryKeysTests(t *testing.T, harness DoltEnginetestHarness) {
 					Query: "show create table test",
 					Expected: []sql.Row{
 						{"test", "CREATE TABLE `test` (\n" +
-								"  `id` int NOT NULL,\n" +
-								"  `c1` int,\n" +
-								"  KEY `c1_idx` (`c1`)\n" +
-								") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+							"  `id` int NOT NULL,\n" +
+							"  `c1` int,\n" +
+							"  KEY `c1_idx` (`c1`)\n" +
+							") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 					},
 				},
 				{

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_tests.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_tests.go
@@ -641,6 +641,17 @@ func RunTransactionTests(t *testing.T, h DoltEnginetestHarness, prepared bool) {
 			}
 		}()
 	}
+	for _, script := range AutoIncrementTransactionTests {
+		func() {
+			h := h.NewHarness(t)
+			defer h.Close()
+			if prepared {
+				enginetest.TestTransactionScriptPrepared(t, h, script)
+			} else {
+				enginetest.TestTransactionScript(t, h, script)
+			}
+		}()
+	}
 }
 
 func RunBranchTransactionTest(t *testing.T, h DoltEnginetestHarness) {
@@ -1844,11 +1855,11 @@ func RunAddDropPrimaryKeysTests(t *testing.T, harness DoltEnginetestHarness) {
 					Query: "show create table test",
 					Expected: []sql.Row{
 						{"test", "CREATE TABLE `test` (\n" +
-							"  `id` int NOT NULL,\n" +
-							"  `c1` int,\n" +
-							"  PRIMARY KEY (`id`),\n" +
-							"  KEY `c1_idx` (`c1`)\n" +
-							") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+								"  `id` int NOT NULL,\n" +
+								"  `c1` int,\n" +
+								"  PRIMARY KEY (`id`),\n" +
+								"  KEY `c1_idx` (`c1`)\n" +
+								") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 					},
 				},
 			},
@@ -1894,12 +1905,12 @@ func RunAddDropPrimaryKeysTests(t *testing.T, harness DoltEnginetestHarness) {
 					Query: "show create table test",
 					Expected: []sql.Row{
 						{"test", "CREATE TABLE `test` (\n" +
-							"  `id` int NOT NULL,\n" +
-							"  `c1` int,\n" +
-							"  PRIMARY KEY (`id`),\n" +
-							"  KEY `c1_idx` (`c1`),\n" +
-							"  CONSTRAINT `test_check` CHECK ((`c1` > 0))\n" +
-							") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+								"  `id` int NOT NULL,\n" +
+								"  `c1` int,\n" +
+								"  PRIMARY KEY (`id`),\n" +
+								"  KEY `c1_idx` (`c1`),\n" +
+								"  CONSTRAINT `test_check` CHECK ((`c1` > 0))\n" +
+								") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 					},
 				},
 				{
@@ -1971,10 +1982,10 @@ func RunAddDropPrimaryKeysTests(t *testing.T, harness DoltEnginetestHarness) {
 					Query: "show create table test",
 					Expected: []sql.Row{
 						{"test", "CREATE TABLE `test` (\n" +
-							"  `id` int NOT NULL,\n" +
-							"  `c1` int,\n" +
-							"  KEY `c1_idx` (`c1`)\n" +
-							") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+								"  `id` int NOT NULL,\n" +
+								"  `c1` int,\n" +
+								"  KEY `c1_idx` (`c1`)\n" +
+								") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 					},
 				},
 				{

--- a/go/libraries/doltcore/sqle/enginetest/dolt_transaction_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_transaction_queries.go
@@ -3410,3 +3410,43 @@ var MultiDbSavepointTests = []queries.TransactionTest{
 		},
 	},
 }
+
+var AutoIncrementTransactionTests = []queries.TransactionTest{
+	{
+		Name: "two auto increment values in two transactions",
+		SetUpScript: []string{
+			"create table t (x int primary key auto_increment, y text)",
+			"insert into t (y) values ('abc123')",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "/* client a */ start transaction",
+			},
+			{
+				Query: "/* client b */ start transaction",
+			},
+			{
+				Query:    "/* client a */ insert into t (y) values ('client a')",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 0x1, InsertID: 0x2}}},
+			},
+			{
+				Query:    "/* client b */ insert into t (y) values ('client b')",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 0x1, InsertID: 0x3}}},
+			},
+			{
+				Query: "/* client a */ commit",
+			},
+			{
+				Query: "/* client b */ commit",
+			},
+			{
+				Query: "/* client a */ select * from t order by x",
+				Expected: []sql.Row{
+					{1, "abc123"},
+					{2, "client a"},
+					{3, "client b"},
+				},
+			},
+		},
+	},
+}


### PR DESCRIPTION
The global auto increment tracker had a race condition in Next(). In interleaved mode (the default), a necessary table-level lock was not being taken, leading to a non-atomic get-increment-set race between two concurrent sessions. This was due to the lock mode being stored in the struct itself and only set during some code paths.  The fix sets the lock mode value at startup.

The new test reliably reproduced the race condition before this patch.