### PR TITLE
Bug fix: don't rebuild fulltext indexes unnecessarily 

### DIFF
--- a/go/libraries/doltcore/merge/fulltext_rebuild.go
+++ b/go/libraries/doltcore/merge/fulltext_rebuild.go
@@ -140,6 +140,8 @@ func tableNeedsFullTextIndexRebuild(ctx *sql.Context, tblName string, tbl *doltd
 	// Even if the parent table was not visited, we still need to check every pseudo-index table due to potential
 	// name overlapping between roots. This also applies to checking whether both ours and theirs have changes.
 	_, wasVisited := visitedTables[tblName]
+
+	// The parent table must have changed relative to both roots for a rebuild to be necessary.
 	oursChanged, err := tableChangedFromRoot(ctx, tblName, tbl, ourRoot)
 	if err != nil {
 		return false, err
@@ -148,30 +150,26 @@ func tableNeedsFullTextIndexRebuild(ctx *sql.Context, tblName string, tbl *doltd
 	if err != nil {
 		return false, err
 	}
+
+	// ftDiverged is true when any pseudo-index table differs between ourRoot and theirRoot. If the
+	// pseudo-tables are identical in both roots, the three-way merge already produced correct
+	// pseudo-tables — any parent-table change was to non-indexed columns (e.g. NULL-body inserts)
+	// and no rebuild is needed. When pseudo-tables diverge (different content, or one side renamed
+	// the table so the merged schema's names don't exist in the other root), the three-way merge
+	// of pseudo-tables may be incomplete and we must rebuild from the merged parent table.
+	var ftDiverged bool
 	for _, idx := range sch.Indexes().AllIndexes() {
 		if !idx.IsFullText() {
 			continue
 		}
 		props := idx.FullTextProperties()
 		for _, ftTable := range props.TableNameSlice() {
-			// Add all of the pseudo-index tables to the non-deletion set
 			doNotDeleteTables[ftTable] = struct{}{}
-
-			// Check if the pseudo-index table was visited
 			if !wasVisited {
 				_, wasVisited = visitedTables[ftTable]
 			}
-
-			// Check if the pseudo-index table changed in both our root and their root
-			if !oursChanged {
-				oursChanged, err = tableChangedBetweenRoots(ctx, tblName, ourRoot, mergedRoot)
-				if err != nil {
-					return false, err
-				}
-			}
-
-			if !theirsChanged {
-				theirsChanged, err = tableChangedBetweenRoots(ctx, tblName, theirRoot, mergedRoot)
+			if !ftDiverged {
+				ftDiverged, err = tableChangedBetweenRoots(ctx, ftTable, ourRoot, theirRoot)
 				if err != nil {
 					return false, err
 				}
@@ -179,8 +177,7 @@ func tableNeedsFullTextIndexRebuild(ctx *sql.Context, tblName string, tbl *doltd
 		}
 	}
 
-	// If least one table was visited and something was different in all three roots, we rebuild all the indexes.
-	return wasVisited && oursChanged && theirsChanged, nil
+	return wasVisited && oursChanged && theirsChanged && ftDiverged, nil
 }
 
 func rebuildFullTextIndexesForTable(ctx *sql.Context, tableToRebuild rebuildableFulltextTable, mergedRoot doltdb.RootValue) (doltdb.RootValue, error) {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_transaction_commit_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_transaction_commit_test.go
@@ -16,6 +16,8 @@ package enginetest
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/dolthub/go-mysql-server/enginetest"
@@ -534,6 +536,67 @@ func TestDoltTransactionCommitLateFkResolution(t *testing.T) {
 			{
 				Query:       "/* client b */ INSERT INTO child VALUES (3, 3);",
 				ExpectedErr: sql.ErrForeignKeyChildViolation,
+			},
+		},
+	})
+}
+
+// TestDoltTransactionFulltextNullBodyNonFF is a regression test for a hang triggered by two concurrent
+// connections both inserting rows that leave the FULLTEXT-indexed column NULL. When the second
+// commit cannot fast-forward (because the first already advanced the working-set head), Dolt
+// calls rebuildFullTextIndexes, which was unneccessarily rebuilding the fulltext index. This test
+// asserts that fulltext index is not repeatedly rebuilt.
+func TestDoltTransactionFulltextNullBodyNonFF(t *testing.T) {
+	harness := newDoltHarness(t)
+	defer harness.Close()
+
+	// Seed the table with 500 rows that have populated html_body. The row count matters: without
+	// the fix, the rebuild scans all rows and drives memory.tableIter's recursive Next to O(N²)
+	// depth, which causes this test to time out rather than complete in milliseconds.
+	const seedRows = 500
+	var vals []string
+	for i := 0; i < seedRows; i++ {
+		vals = append(vals, fmt.Sprintf("('seed-%04d','inbox','hello world unique%d content here')", i, i))
+	}
+	bulkInsert := "INSERT INTO emails (id, mailbox_id, html_body) VALUES " + strings.Join(vals, ",")
+
+	enginetest.TestTransactionScript(t, harness, queries.TransactionTest{
+		Name: "concurrent null-body inserts into fulltext table do not trigger unnecessary rebuild",
+		SetUpScript: []string{
+			`CREATE TABLE emails (
+				id         VARCHAR(36) PRIMARY KEY,
+				mailbox_id VARCHAR(36),
+				html_body  LONGTEXT,
+				FULLTEXT KEY ft (html_body)
+			)`,
+			bulkInsert,
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{Query: "/* client a */ SET @@autocommit=0;", Expected: []sql.Row{{types.NewOkResult(0)}}},
+			{Query: "/* client b */ SET @@autocommit=0;", Expected: []sql.Row{{types.NewOkResult(0)}}},
+			{Query: "/* client a */ START TRANSACTION;", Expected: []sql.Row{}},
+			{Query: "/* client b */ START TRANSACTION;", Expected: []sql.Row{}},
+			{
+				Query:    "/* client a */ INSERT INTO emails (id, mailbox_id) VALUES ('tx-a', 'box-a');",
+				Expected: []sql.Row{{types.NewOkResult(1)}},
+			},
+			{
+				Query:    "/* client b */ INSERT INTO emails (id, mailbox_id) VALUES ('tx-b', 'box-b');",
+				Expected: []sql.Row{{types.NewOkResult(1)}},
+			},
+			// Client b commits first, advancing the working-set head.
+			{Query: "/* client b */ COMMIT;", Expected: []sql.Row{}},
+			// Client a commits second: startState != existingWs triggers the non-ff merge path.
+			{Query: "/* client a */ COMMIT;", Expected: []sql.Row{}},
+			{
+				// Both rows landed: 500 seeds + 2 new rows.
+				Query:    "/* client a */ SELECT COUNT(*) FROM emails;",
+				Expected: []sql.Row{{seedRows + 2}},
+			},
+			{
+				// FULLTEXT index is intact — all seeded rows are still searchable.
+				Query:    "/* client a */ SELECT COUNT(*) FROM emails WHERE MATCH(html_body) AGAINST ('hello');",
+				Expected: []sql.Row{{seedRows}},
 			},
 		},
 	})


### PR DESCRIPTION
When two sessions are making changes to a table with a `fulltext` index, the index was unnecessarily getting rebuilt, even when the indexed column wasn't changing in the updates. This change limits when the index is rebuilt to avoid unnecessary rebuilds. 