### PR TITLE
Mark `dolt_diff_$TABLENAME` `to_commit` and `from_commit` indexes as non-unique

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_diff.go
@@ -28,6 +28,31 @@ import (
 
 var DiffSystemTableScriptTests = []queries.ScriptTest{
 	{
+		// See https://github.com/dolthub/dolt/issues/11159
+		Name: "dolt_diff_ table to_commit and from_commit indexes are non-unique",
+		SetUpScript: []string{
+			"create table foo (id int primary key, v int);",
+			"insert into foo values (1,1),(2,1),(3,1),(4,1);",
+			"call dolt_commit('-Am', 'seed');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "SELECT COUNT(*) FROM dolt_diff_foo;",
+				Expected: []sql.Row{{4}},
+			},
+			{
+				// The harness skips assertions containing "show indexes from", so this uses the singular synonym.
+				Query: "SHOW INDEX FROM dolt_diff_foo;",
+				Expected: []sql.Row{
+					{"dolt_diff_foo", 0, "to_pks", 1, "to_id", nil, int64(0), nil, nil, "YES", "BTREE", "", "", "YES", nil},
+					{"dolt_diff_foo", 0, "from_pks", 1, "from_id", nil, int64(0), nil, nil, "YES", "BTREE", "", "", "YES", nil},
+					{"dolt_diff_foo", 1, "to_commit", 1, "to_commit", nil, int64(0), nil, nil, "YES", "BTREE", "", "", "YES", nil},
+					{"dolt_diff_foo", 1, "from_commit", 1, "from_commit", nil, int64(0), nil, nil, "YES", "BTREE", "", "", "YES", nil},
+				},
+			},
+		},
+	},
+	{
 		Name: "base case: added rows",
 		SetUpScript: []string{
 			"create table t (pk int primary key, c1 int, c2 int);",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_query_plans.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_query_plans.go
@@ -21,6 +21,35 @@ import (
 // DoltDiffPlanTests are tests that check our query plans for various operations on the dolt diff system tables
 var DoltDiffPlanTests = []queries.QueryPlanTest{
 	{
+		// See https://github.com/dolthub/dolt/issues/11159
+		Query: `select * from dolt_diff_one_pk where to_commit='abc' and to_pk=1`,
+		// A non-unique to_commit index is not a point lookup, so the planner prefers the primary key index.
+		ExpectedPlan: "Filter\n" +
+			" ├─ ((dolt_diff_one_pk.to_commit = 'abc') AND (dolt_diff_one_pk.to_pk = 1))\n" +
+			" └─ IndexedTableAccess(dolt_diff_one_pk)\n" +
+			"     ├─ index: [dolt_diff_one_pk.to_pk]\n" +
+			"     └─ filters: [{[1, 1]}]\n" +
+			"",
+	},
+	{
+		Query: `select a.to_pk from dolt_diff_one_pk a join dolt_diff_one_pk b on a.from_commit = b.from_commit`,
+		// A non-unique from_commit index can match many rows per key, so the planner chooses a hash join over a lookup join.
+		ExpectedPlan: "Project\n" +
+			" ├─ columns: [a.to_pk]\n" +
+			" └─ HashJoin\n" +
+			"     ├─ (a.from_commit = b.from_commit)\n" +
+			"     ├─ TableAlias(a)\n" +
+			"     │   └─ Table\n" +
+			"     │       └─ name: dolt_diff_one_pk\n" +
+			"     └─ HashLookup\n" +
+			"         ├─ left-key: (a.from_commit)\n" +
+			"         ├─ right-key: (b.from_commit)\n" +
+			"         └─ TableAlias(b)\n" +
+			"             └─ Table\n" +
+			"                 └─ name: dolt_diff_one_pk\n" +
+			"",
+	},
+	{
 		Query: `select * from dolt_diff_one_pk where to_pk=1`,
 		ExpectedPlan: "Filter\n" +
 			" ├─ (dolt_diff_one_pk.to_pk = 1)\n" +

--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -184,9 +184,10 @@ func DoltDiffIndexesFromTable(ctx context.Context, db, tbl string, t *doltdb.Tab
 		columns: []schema.Column{
 			schema.NewColumn(ToCommitIndexId, schema.DiffCommitTag, types.StringKind, false),
 		},
-		indexSch:                      sch,
-		tableSch:                      sch,
-		unique:                        true,
+		indexSch: sch,
+		tableSch: sch,
+		// A single commit changes many rows, so the to_commit and from_commit indexes are not unique.
+		unique:                        false,
 		comment:                       "",
 		vrw:                           t.ValueReadWriter(),
 		ns:                            t.NodeStore(),
@@ -202,7 +203,7 @@ func DoltDiffIndexesFromTable(ctx context.Context, db, tbl string, t *doltdb.Tab
 			},
 			indexSch:                      sch,
 			tableSch:                      sch,
-			unique:                        true,
+			unique:                        false,
 			comment:                       "",
 			vrw:                           t.ValueReadWriter(),
 			ns:                            t.NodeStore(),


### PR DESCRIPTION
The `dolt_diff_$TABLENAME` system table marked its `to_commit` and `from_commit` indexes as unique. A single commit changes many rows, so each commit hash maps to many diff rows and these indexes are not unique.
Fix dolthub/dolt#11159