### PR TITLE
Set version string in initial server response

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -1226,8 +1226,11 @@ func getConfigFromServerConfig(serverConfig servercfg.ServerConfig, plf server.P
 		return server.Config{}, err
 	}
 
-	// Do not set the value of Version.  Let it default to what go-mysql-server uses.  This should be equivalent
-	// to the value of mysql that we support.
+	// The server config is created before system variables are initialized, so we have to use
+	// the config to inform its responses.
+	if verstionString, hasVersionString := serverConfig.SystemVars()["version"]; hasVersionString {
+		serverConf.Version = fmt.Sprint(verstionString)
+	}
 	serverConf.ConnReadTimeout = readTimeout
 	serverConf.ConnWriteTimeout = writeTimeout
 	serverConf.MaxConnections = serverConfig.MaxConnections()

--- a/integration-tests/mysql-client-tests/Dockerfile
+++ b/integration-tests/mysql-client-tests/Dockerfile
@@ -80,6 +80,7 @@ RUN pyinstaller --onefile --collect-all mysql.connector sqlalchemy-test.py
 RUN pyinstaller --onefile --collect-all mysql.connector mysql-connector-test.py
 RUN pyinstaller --onefile mariadb-connector-test.py
 RUN pyinstaller --onefile python-replication-test.py
+RUN pyinstaller --onefile custom-version-string-test.py
 
 FROM elixir:1.18.3-slim AS elixir_clients_build
 RUN apt-get update && apt-get install -y ca-certificates xz-utils curl && rm -rf /var/lib/apt/lists/*

--- a/integration-tests/mysql-client-tests/custom-version-string-test.bats
+++ b/integration-tests/mysql-client-tests/custom-version-string-test.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+load helpers.bash
+
+# MySQL client tests are set up to test Dolt as a MySQL server and
+# standard MySQL Clients in a wide array of languages. I used BATS because
+# it was easy to set up the Dolt piece using the command line.
+#
+# We create a Dolt database and start a server in the setup(). Then, each test
+# will attempt to access the server through a client. We'll do some basic
+# reads and writes to make sure the client works. As we discover any
+# gotchas, we can add tests for that specific language.
+
+setup() {
+    setup_dolt_repo '1.2.3-MariaDB'
+
+    export MYSQL_TCP_PORT=$PORT
+    export MYSQL_HOST=127.0.0.1
+}
+
+teardown() {
+    # Kill and wait the server before cd/rm so the process exits
+    # before its data directory is removed.
+    kill $SERVER_PID || :
+    wait $SERVER_PID || :
+    SERVER_PID=
+    cd ..
+    rm -rf $REPO_NAME
+}
+
+@test "python pymysql client" {
+    /build/bin/python/custom-version-string-test $USER $PORT $REPO_NAME '1.2.3-MariaDB'
+}

--- a/integration-tests/mysql-client-tests/helpers.bash
+++ b/integration-tests/mysql-client-tests/helpers.bash
@@ -13,8 +13,22 @@ setup_dolt_repo() {
 
     PORT=$( definePORT )
     USER="dolt"
+    VERSION_STRING="$1"
     dolt sql -q "CREATE USER dolt@'%' IDENTIFIED BY ''; GRANT ALL ON *.* TO dolt@'%';"
-    dolt sql-server --host 0.0.0.0 --port="$PORT" --loglevel=trace &
+    if [[ -n "$VERSION_STRING" ]]; then
+        cat << YAML > config.yaml
+listener:
+  host: "0.0.0.0"
+  port: $PORT
+system_variables:
+  version: '$VERSION_STRING'
+YAML
+        echo "config" "$1"
+        dolt sql-server --host 0.0.0.0 --port="$PORT" --loglevel=trace --config config.yaml &
+    else
+        echo "config" "$1"
+        dolt sql-server --host 0.0.0.0 --port="$PORT" --loglevel=trace &
+    fi
     SERVER_PID=$!
     # Give the server a chance to start
     sleep 1

--- a/integration-tests/mysql-client-tests/mysql-client-tests-entrypoint.sh
+++ b/integration-tests/mysql-client-tests/mysql-client-tests-entrypoint.sh
@@ -14,6 +14,12 @@ dolt config --global --add user.email mysql-test-runner@liquidata.co
 echo "Running mysql-client-tests:"
 run_bats /build/bin/bats/mysql-client-tests.bats
 
+# We need to test that setting the version variable is reflected in the info received
+# when a client connects. Many drivers ignore this info, including go's SQL driver.
+# So we need to use a client test to check this.
+echo "Running custom-version-string-test"
+run_bats /build/bin/bats/custom-version-string-test.bats
+
 # We run mariadb-binlog integration in this suite same as with mysqldump in mysql-client-tests.bats.
 # However, there's a bit more setup necessary to pipe the output from the dump in a mariadb client, so it's been
 # separated into a separate bats.

--- a/integration-tests/mysql-client-tests/python/custom-version-string-test.py
+++ b/integration-tests/mysql-client-tests/python/custom-version-string-test.py
@@ -1,0 +1,22 @@
+import pymysql
+import sys
+
+def main():
+    user = sys.argv[1]
+    port = int(sys.argv[2])
+    db = sys.argv[3]
+    expected_version_string = sys.argv[4]
+
+    connection = pymysql.connect(host="127.0.0.1",
+                                 port=port,
+                                 user=user,
+                                 db=db)
+
+    if connection.server_version != expected_version_string:
+        print(f"Unexpected server version, expected {expected_version_string}, got {connection.server_version}")
+        sys.exit(1)
+
+    connection.close()
+    sys.exit(0)
+
+main()


### PR DESCRIPTION
MySQL servers return a version string in the initial connection response. Some clients read this and expect certain versions of MySQL or MariaDB. We return `8.0.31` by default, since that corresponds with the MySQL version we advertise feature parity with.

Currently, we use the `@@version` system variable as the source of truth for the version string, and this can be configued via a server config file. But we extract the config for the listener before we initialize system variables. Previously this meant that the version string on connection defaulted to the value specified in our vitess dependency, which was hardcoded to `8.0.31`.

This PR changes the behavior to extract a string from the config if it exists.

We need to use a client integration test for this, since the Go SQL driver ignores the version in the connection info and does not provide a way to view it.