### PR TITLE
bug fix for merging tables with vector indexes

### DIFF
--- a/go/libraries/doltcore/merge/merge_prolly_indexes.go
+++ b/go/libraries/doltcore/merge/merge_prolly_indexes.go
@@ -56,19 +56,23 @@ func mergeProllySecondaryIndexes(
 	}
 
 	tryGetIdx := func(sch schema.Schema, iS durable.IndexSet, indexName string) (prolly.Map, bool, error) {
-		ok := sch.Indexes().Contains(indexName)
-		if ok {
-			idx, err := iS.GetIndex(ctx, sch, nil, indexName)
-			if err != nil {
-				return prolly.Map{}, false, err
-			}
-			m, err := durable.ProllyMapFromIndex(idx)
-			if err != nil {
-				return prolly.Map{}, false, err
-			}
-			return m, true, nil
+		idxDef := sch.Indexes().GetByName(indexName)
+		if idxDef == nil {
+			return prolly.Map{}, false, nil
 		}
-		return prolly.Map{}, false, nil
+		// Vector indexes are stored as proximity maps, not prolly maps; they must be rebuilt.
+		if idxDef.IsVector() {
+			return prolly.Map{}, false, nil
+		}
+		idx, err := iS.GetIndex(ctx, sch, nil, indexName)
+		if err != nil {
+			return prolly.Map{}, false, err
+		}
+		m, err := durable.ProllyMapFromIndex(idx)
+		if err != nil {
+			return prolly.Map{}, false, err
+		}
+		return m, true, nil
 	}
 
 	// Schema merge can introduce new constraints/uniqueness checks.

--- a/go/libraries/doltcore/merge/merge_prolly_indexes.go
+++ b/go/libraries/doltcore/merge/merge_prolly_indexes.go
@@ -57,11 +57,8 @@ func mergeProllySecondaryIndexes(
 
 	tryGetIdx := func(sch schema.Schema, iS durable.IndexSet, indexName string) (prolly.Map, bool, error) {
 		idxDef := sch.Indexes().GetByName(indexName)
-		if idxDef == nil {
-			return prolly.Map{}, false, nil
-		}
 		// Vector indexes are stored as proximity maps, not prolly maps; they must be rebuilt.
-		if idxDef.IsVector() {
+		if idxDef == nil || idxDef.IsVector() {
 			return prolly.Map{}, false, nil
 		}
 		idx, err := iS.GetIndex(ctx, sch, nil, indexName)
@@ -110,6 +107,36 @@ func mergeProllySecondaryIndexes(
 	}
 
 	return mergedIndexSet, nil
+}
+
+// RebuildVectorIndexes rebuilds all vector indexes defined in |sch| from
+// scratch using |mergedRows| as the source of truth. Vector indexes are stored
+// as ProximityMaps and cannot be incrementally updated, so they must be fully
+// rebuilt whenever the underlying row data changes outside of a normal write
+// path (e.g. after conflict resolution).
+func RebuildVectorIndexes(
+	ctx *sql.Context,
+	vrw types.ValueReadWriter,
+	ns tree.NodeStore,
+	sch schema.Schema,
+	tblName string,
+	mergedRows prolly.Map,
+	idxSet durable.IndexSet,
+) (durable.IndexSet, error) {
+	for _, idx := range sch.Indexes().AllIndexes() {
+		if !idx.IsVector() {
+			continue
+		}
+		rebuilt, err := creation.BuildSecondaryProllyIndex(ctx, vrw, ns, sch, tblName, idx, mergedRows, nil)
+		if err != nil {
+			return nil, err
+		}
+		idxSet, err = idxSet.PutIndex(ctx, idx.Name(), rebuilt)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return idxSet, nil
 }
 
 func buildIndex(

--- a/go/libraries/doltcore/merge/mutable_secondary_index.go
+++ b/go/libraries/doltcore/merge/mutable_secondary_index.go
@@ -28,9 +28,13 @@ import (
 )
 
 // GetMutableSecondaryIdxs returns a MutableSecondaryIdx for each secondary index in |indexes|.
+// Vector indexes are skipped because they cannot be represented as a prolly.Map.
 func GetMutableSecondaryIdxs(ctx *sql.Context, ourSch, sch schema.Schema, tableName string, indexes durable.IndexSet) ([]MutableSecondaryIdx, error) {
-	mods := make([]MutableSecondaryIdx, sch.Indexes().Count())
-	for i, index := range sch.Indexes().AllIndexes() {
+	mods := make([]MutableSecondaryIdx, 0, sch.Indexes().Count())
+	for _, index := range sch.Indexes().AllIndexes() {
+		if index.IsVector() {
+			continue
+		}
 		idx, err := indexes.GetIndex(ctx, sch, nil, index.Name())
 		if err != nil {
 			return nil, err
@@ -39,10 +43,11 @@ func GetMutableSecondaryIdxs(ctx *sql.Context, ourSch, sch schema.Schema, tableN
 		if err != nil {
 			return nil, err
 		}
-		mods[i], err = NewMutableSecondaryIdx(ctx, m, ourSch, sch, tableName, index)
+		mod, err := NewMutableSecondaryIdx(ctx, m, ourSch, sch, tableName, index)
 		if err != nil {
 			return nil, err
 		}
+		mods = append(mods, mod)
 	}
 	return mods, nil
 }
@@ -54,6 +59,11 @@ func GetMutableSecondaryIdxs(ctx *sql.Context, ourSch, sch schema.Schema, tableN
 func GetMutableSecondaryIdxsWithPending(ctx *sql.Context, ns tree.NodeStore, ourSch, sch schema.Schema, tableName string, indexes durable.IndexSet, pendingSize int) ([]MutableSecondaryIdx, error) {
 	mods := make([]MutableSecondaryIdx, 0, sch.Indexes().Count())
 	for _, index := range sch.Indexes().AllIndexes() {
+		// Vector indexes cannot be incrementally updated as prolly.Maps; they are rebuilt
+		// from scratch in mergeProllySecondaryIndexes after the merge completes.
+		if index.IsVector() {
+			continue
+		}
 
 		// If an index isn't found on the left side, we know it must be a new index added on the right side,
 		// so just skip it, and we'll rebuild the full index at the end of merging when we notice it's missing.

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_conflicts_resolve.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_conflicts_resolve.go
@@ -194,6 +194,14 @@ func resolveProllyConflicts(ctx *sql.Context, tbl *doltdb.Table, tblName doltdb.
 			return nil, err
 		}
 	}
+
+	// Vector indexes cannot be incrementally updated; rebuild them from scratch
+	// using the resolved row data.
+	idxSet, err = merge.RebuildVectorIndexes(ctx, tbl.ValueReadWriter(), tbl.NodeStore(), sch, tblName.Name, newMap, idxSet)
+	if err != nil {
+		return nil, err
+	}
+
 	newTbl, err = newTbl.SetIndexSet(ctx, idxSet)
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
@@ -3317,6 +3317,37 @@ var MergeScripts = []queries.ScriptTest{
 		},
 	},
 	{
+		Name: "dolt_conflicts_resolve keeps vector index consistent with resolved rows",
+		SetUpScript: []string{
+			"SET @@autocommit=0;",
+			"CREATE TABLE chunks (id INT PRIMARY KEY, e VECTOR(2) NOT NULL, VECTOR INDEX vidx (e))",
+			"INSERT INTO chunks VALUES (1, STRING_TO_VECTOR('[50,60]')), (2, STRING_TO_VECTOR('[42,52]')), (3, STRING_TO_VECTOR('[44,54]'))",
+			"CALL DOLT_COMMIT('-Am', 'base rows')",
+			"CALL DOLT_CHECKOUT('-b', 'branch')",
+			"UPDATE chunks SET e = STRING_TO_VECTOR('[0,0]') WHERE id = 1",
+			"CALL DOLT_COMMIT('-am', 'branch moves id 1 to the origin')",
+			"CALL DOLT_CHECKOUT('main')",
+			"UPDATE chunks SET e = STRING_TO_VECTOR('[99,99]') WHERE id = 1",
+			"CALL DOLT_COMMIT('-am', 'main moves id 1 far away')",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "CALL DOLT_MERGE('branch')",
+				Expected: []sql.Row{{"", 0, 1, "conflicts found"}},
+			},
+			{
+				Query:    "CALL DOLT_CONFLICTS_RESOLVE('--theirs', 'chunks')",
+				Expected: []sql.Row{{0}},
+			},
+			{
+				// id 1 was resolved to the origin, so it is the nearest neighbor of '[0,0]'.
+				// The vector index must be rebuilt after conflict resolution — verify it is.
+				Query:    "SELECT id FROM chunks ORDER BY VEC_DISTANCE('[0,0]', e) LIMIT 1",
+				Expected: []sql.Row{{1}},
+			},
+		},
+	},
+	{
 		Name: "no-ff merge commit uses author session variables for author identity",
 		SetUpScript: []string{
 			"CREATE TABLE t (pk INT PRIMARY KEY)",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_merge.go
@@ -3293,6 +3293,30 @@ var MergeScripts = []queries.ScriptTest{
 		},
 	},
 	{
+		Name: "three-way merge of table with vector index",
+		SetUpScript: []string{
+			"CREATE TABLE chunks (id INT PRIMARY KEY, e VECTOR(3) NOT NULL, VECTOR INDEX vidx (e))",
+			"CALL DOLT_ADD('.')",
+			"CALL DOLT_COMMIT('-m', 'base schema')",
+			"CALL DOLT_CHECKOUT('-b', 'branch')",
+			"INSERT INTO chunks VALUES (1, STRING_TO_VECTOR('[1,0,0]')), (2, STRING_TO_VECTOR('[0,1,0]'))",
+			"CALL DOLT_COMMIT('-am', 'rows on branch')",
+			"CALL DOLT_CHECKOUT('main')",
+			"INSERT INTO chunks VALUES (9, STRING_TO_VECTOR('[0.5,0.5,0]'))",
+			"CALL DOLT_COMMIT('-am', 'row on main')",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "CALL DOLT_MERGE('branch')",
+				Expected: []sql.Row{{doltCommit, 0, 0, "merge successful"}},
+			},
+			{
+				Query:    "SELECT id FROM chunks ORDER BY id",
+				Expected: []sql.Row{{1}, {2}, {9}},
+			},
+		},
+	},
+	{
 		Name: "no-ff merge commit uses author session variables for author identity",
 		SetUpScript: []string{
 			"CREATE TABLE t (pk INT PRIMARY KEY)",


### PR DESCRIPTION
Fixes: https://github.com/dolthub/dolt/issues/11180

Related Doltgres update to skip the unsupported `VECTOR` index test: https://github.com/dolthub/doltgresql/pull/2827