### PR TITLE
go/store/nbs: boostrapJournal: Improve journal bootstraping resiliency in the face of errors in journal.idx.

### DIFF
--- a/go/store/nbs/journal_index_record.go
+++ b/go/store/nbs/journal_index_record.go
@@ -106,9 +106,19 @@ const (
 
 // processIndexRecords reads batches of chunk index lookups into the journal.
 // An index batch looks like |lookup|lookup|...|meta|. The first byte of a record
-// indicates whether it is a |lookup| or |meta|. Only callback errors are returned.
-// The caller is expected to track the latest lookupMeta end offset and truncate
-// the index to compensate for partially written batches.
+// indicates whether it is a |lookup| or |meta|.
+//
+// |off| tracks the end of the last fully-read batch; the caller truncates the
+// index to |off| to discard a partially written trailing batch. The returned
+// error distinguishes the two ways reading can stop short:
+//
+//   - A clean io.EOF at a record boundary, or an io.ErrUnexpectedEOF from a record
+//     that was only partially written before a crash, is the expected end of a
+//     crash-truncated index. These return a nil error; reading simply stops at the
+//     last complete batch.
+//   - Any other read error (a genuine I/O fault), a callback (validation) failure,
+//     or an unrecognized record tag returns a non-nil error so the caller can
+//     surface it and rebuild from the journal.
 func processIndexRecords(rd *bufio.Reader, sz int64, cb func(lookupMeta, []lookup, uint32) error) (off int64, err error) {
 	var batchCrc uint32
 	var batch []lookup
@@ -116,7 +126,7 @@ func processIndexRecords(rd *bufio.Reader, sz int64, cb func(lookupMeta, []looku
 	for off < sz {
 		recTag, err := rd.ReadByte()
 		if err != nil {
-			return off, nil
+			return off, ignoreBenignIndexEOF(err)
 		}
 		batchOff += 1
 
@@ -124,7 +134,7 @@ func processIndexRecords(rd *bufio.Reader, sz int64, cb func(lookupMeta, []looku
 		case indexRecChunk:
 			l, err := readIndexLookup(rd)
 			if err != nil {
-				return off, nil
+				return off, ignoreBenignIndexEOF(err)
 			}
 			batchOff += lookupSz
 			batch = append(batch, l)
@@ -133,7 +143,7 @@ func processIndexRecords(rd *bufio.Reader, sz int64, cb func(lookupMeta, []looku
 		case indexRecMeta:
 			m, err := readIndexMeta(rd)
 			if err != nil {
-				return off, nil
+				return off, ignoreBenignIndexEOF(err)
 			}
 			if err := cb(m, batch, batchCrc); err != nil {
 				return off, err
@@ -147,6 +157,17 @@ func processIndexRecords(rd *bufio.Reader, sz int64, cb func(lookupMeta, []looku
 		}
 	}
 	return off, nil
+}
+
+// ignoreBenignIndexEOF maps the expected end-of-index conditions to a nil error: a
+// clean io.EOF at a record boundary, or an io.ErrUnexpectedEOF from a record that
+// was only partially written before a crash. Both simply mean the readable index
+// ends here. Any other error is a genuine I/O fault and is returned unchanged.
+func ignoreBenignIndexEOF(err error) error {
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return nil
+	}
+	return err
 }
 
 var ErrMalformedIndex = errors.New("journal index is malformed")

--- a/go/store/nbs/journal_index_record_test.go
+++ b/go/store/nbs/journal_index_record_test.go
@@ -17,7 +17,9 @@ package nbs
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"hash/crc32"
+	"io"
 	"math"
 	"math/rand"
 	"testing"
@@ -60,6 +62,71 @@ func TestRoundTripIndexLookups(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, batches*chunksPerBatch, lookupCnt)
 	require.Equal(t, batches, metaCnt)
+}
+
+// errAfterReader yields |data| until exhausted, then returns |err| on every
+// subsequent Read. It injects a read fault at a known position.
+type errAfterReader struct {
+	data []byte
+	pos  int
+	err  error
+}
+
+func (r *errAfterReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, r.err
+	}
+	n := copy(p, r.data[r.pos:])
+	r.pos += n
+	return n, nil
+}
+
+// TestProcessIndexRecordsReadError verifies that processIndexRecords distinguishes
+// a crash-truncated index (benign EOF) from a genuine I/O fault. The former stops
+// cleanly at the last complete batch; the latter is surfaced so the caller can
+// rebuild from the journal rather than silently trusting a partial read.
+func TestProcessIndexRecordsReadError(t *testing.T) {
+	// build a single valid batch: lookups followed by a meta record
+	buf := new(bytes.Buffer)
+	w := bufio.NewWriter(buf)
+	lookups, meta := newLookups(t, 4, 0)
+	for _, l := range lookups {
+		require.NoError(t, writeIndexLookup(w, l))
+	}
+	require.NoError(t, writeJournalIndexMeta(w, meta.latestHash, meta.batchStart, meta.batchEnd, meta.checkSum))
+	require.NoError(t, w.Flush())
+	valid := buf.Bytes()
+	batchEnd := int64(len(valid)) // index offset after the one complete batch
+
+	cb := func(m lookupMeta, ls []lookup, checksum uint32) error {
+		require.Equal(t, m.checkSum, checksum)
+		return nil
+	}
+
+	errBoom := errors.New("simulated I/O error")
+
+	for _, tc := range []struct {
+		name    string
+		readErr error
+		wantErr error
+	}{
+		{name: "clean EOF after a batch is benign", readErr: io.EOF, wantErr: nil},
+		{name: "partial trailing record is benign", readErr: io.ErrUnexpectedEOF, wantErr: nil},
+		{name: "genuine I/O error is surfaced", readErr: errBoom, wantErr: errBoom},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rd := bufio.NewReader(&errAfterReader{data: valid, err: tc.readErr})
+			// sz is one past the valid batch so the loop attempts another read and
+			// hits the injected error
+			off, err := processIndexRecords(rd, batchEnd+1, cb)
+			require.Equal(t, batchEnd, off, "off must point at the end of the last complete batch")
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.wantErr)
+			}
+		})
+	}
 }
 
 func newLookups(t *testing.T, n int, start uint64) ([]lookup, lookupMeta) {

--- a/go/store/nbs/journal_writer.go
+++ b/go/store/nbs/journal_writer.go
@@ -72,6 +72,10 @@ func fileExists(path string) (bool, error) {
 	info, err := os.Stat(path)
 	if errors.Is(err, os.ErrNotExist) {
 		return false, nil
+	} else if err != nil {
+		// some other I/O error (e.g. EIO, EACCES); surface it rather than
+		// dereferencing the nil |info| below
+		return false, err
 	} else if info.IsDir() {
 		return true, fmt.Errorf("expected file %s, found directory", path)
 	}
@@ -173,103 +177,13 @@ func (wr *journalWriter) bootstrapJournal(ctx context.Context, canWrite bool, re
 	}
 	wr.ranges = newRangeIndex()
 
-	p := filepath.Join(filepath.Dir(wr.path), journalIndexFileName)
-	var ok bool
-	ok, err = fileExists(p)
-	if err != nil {
-		return
-	} else if ok {
-		wr.index, err = os.OpenFile(p, os.O_RDWR, 0666)
-	} else {
-		wr.index, err = os.OpenFile(p, os.O_RDWR|os.O_CREATE, 0666)
-	}
-	if err != nil {
-		return
-	}
-	wr.indexWriter = bufio.NewWriterSize(wr.index, journalIndexDefaultMaxNovel)
-
-	if ok {
-		var info os.FileInfo
-		if info, err = wr.index.Stat(); err != nil {
-			return hash.Hash{}, err
-		}
-
-		// initialize range index with enough capacity to
-		// avoid rehashing during bootstrapping
-		cnt := estimateRangeCount(info)
-		wr.ranges.cached = make(map[addr16]Range, cnt)
-
-		eg, ectx := errgroup.WithContext(ctx)
-		ch := make(chan []lookup, 4)
-
-		// process the indexed portion of the journal
-		var safeIndexOffset int64
-		var prev int64
-
-		eg.Go(func() error {
-			defer close(ch)
-			safeIndexOffset, err = processIndexRecords(bufio.NewReader(wr.index), info.Size(), func(m lookupMeta, batch []lookup, batchChecksum uint32) error {
-				if m.checkSum != batchChecksum {
-					return fmt.Errorf("invalid index checksum (%d != %d)", batchChecksum, m.checkSum)
-				}
-
-				if m.batchStart != prev {
-					return fmt.Errorf("index records do not cover contiguous region (%d != %d)", m.batchStart, prev)
-				}
-				prev = m.batchEnd
-
-				// |r.end| is expected to point to a root hash record in |wr.journal|
-				// containing a hash equal to |r.lastRoot|, validate this here
-				if h, err := peekRootHashAt(wr.journal, int64(m.batchEnd)); err != nil {
-					return err
-				} else if h != m.latestHash {
-					return fmt.Errorf("invalid index record hash (%s != %s)", h.String(), m.latestHash.String())
-				}
-
-				select {
-				case <-ectx.Done():
-					return ectx.Err()
-				case ch <- batch:
-					// record a high-water-mark for the indexed portion of the journal
-					wr.indexed = int64(m.batchEnd)
-				}
-				return nil
-			})
-			return err
-		})
-		// populate range hashmap
-		eg.Go(func() error {
-			for {
-				select {
-				case <-ectx.Done():
-					return nil
-				case ll, ok := <-ch:
-					if !ok {
-						return nil
-					}
-					for _, l := range ll {
-						wr.ranges.putCached(l.a, l.r)
-					}
-				}
-			}
-		})
-
-		err = eg.Wait()
-		if err != nil {
-			err = fmt.Errorf("error bootstrapping chunk journal: %s", err.Error())
-			if cerr := wr.corruptIndexRecovery(); cerr != nil {
-				err = fmt.Errorf("error recovering corrupted chunk journal index: %s", err.Error())
-			}
-			return hash.Hash{}, err
-		}
-
-		// rewind index to last safe point. Note that |safeIndexOffset| refers
-		// to a location in the index file, while |wr.indexed| refers to a position
-		// in the journal file.
-		if err := wr.truncateIndex(safeIndexOffset); err != nil {
-			return hash.Hash{}, err
-		}
-		wr.ranges = wr.ranges.flatten(ctx)
+	// Load the out-of-band journal index, which lets us skip replaying the
+	// already-indexed prefix of the journal. The index is a rebuildable
+	// optimization, so index I/O errors and corruption are non-fatal and fall back
+	// to a full journal replay; see loadJournalIndex for the lone fatal case
+	// (obtaining a writable index handle in read-write mode).
+	if err = wr.loadJournalIndex(ctx, canWrite, warningsCb); err != nil {
+		return hash.Hash{}, err
 	}
 
 	var lastOffset int64
@@ -277,7 +191,7 @@ func (wr *journalWriter) bootstrapJournal(ctx context.Context, canWrite bool, re
 	// process the non-indexed portion of the journal starting at |wr.indexed|,
 	// at minimum the non-indexed portion will include a root hash record.
 	// Index lookups are added to the ongoing batch to re-synchronize.
-	wr.off, err = processJournalRecords(ctx, p, wr.journal, canWrite, wr.indexed, func(o int64, r journalRec) error {
+	wr.off, err = processJournalRecords(ctx, wr.path, wr.journal, canWrite, wr.indexed, func(o int64, r journalRec) error {
 		switch r.kind {
 		case chunkJournalRecKind:
 			rng := Range{
@@ -287,11 +201,14 @@ func (wr *journalWriter) bootstrapJournal(ctx context.Context, canWrite bool, re
 			wr.ranges.put(r.address, rng)
 			wr.uncmpSz += r.uncompressedPayloadSize()
 
-			a := toAddr16(r.address)
-			if err := writeIndexLookup(wr.indexWriter, lookup{a: a, r: rng}); err != nil {
-				return err
+			// re-index this lookup, unless we're read-only and must not write
+			if canWrite {
+				a := toAddr16(r.address)
+				if err := writeIndexLookup(wr.indexWriter, lookup{a: a, r: rng}); err != nil {
+					return err
+				}
+				wr.batchCrc = crc32.Update(wr.batchCrc, crcTable, a[:])
 			}
-			wr.batchCrc = crc32.Update(wr.batchCrc, crcTable, a[:])
 
 		case rootHashJournalRecKind:
 			lastOffset = o
@@ -312,8 +229,8 @@ func (wr *journalWriter) bootstrapJournal(ctx context.Context, canWrite bool, re
 		return hash.Hash{}, err
 	}
 
-	if wr.ranges.novelCount() > wr.maxNovel {
-		// save bootstrap progress
+	if canWrite && wr.ranges.novelCount() > wr.maxNovel {
+		// save bootstrap progress (never write the index in read-only mode)
 		if err := wr.flushIndexRecord(ctx, last, lastOffset); err != nil {
 			return hash.Hash{}, err
 		}
@@ -324,12 +241,182 @@ func (wr *journalWriter) bootstrapJournal(ctx context.Context, canWrite bool, re
 	return
 }
 
-// corruptIndexRecovery handles a corrupted or malformed journal index by truncating
-// the index file and restarting the journal bootstrapping process without an index.
-// todo: make backup file?
-func (wr *journalWriter) corruptIndexRecovery() error {
-	if err := wr.truncateIndex(0); err != nil {
+// loadJournalIndex prepares |wr.index|/|wr.indexWriter| and, when an index file
+// already exists, reads it to pre-populate |wr.ranges| and |wr.indexed| so the
+// subsequent journal replay can skip the indexed prefix.
+//
+// The journal index is a rebuildable optimization derived entirely from the
+// journal; the database's correctness and ability to open depend only on the
+// journal. Index I/O errors are therefore classified into exactly one fatal case
+// and an otherwise-recoverable rest:
+//
+//   - Obtaining a writable index handle (read-write mode only) is the lone fatal
+//     case. Continued operation requires persisting new index records, so if we
+//     cannot open or create the index for writing we fail rather than run in a
+//     state where we silently cannot maintain the index.
+//   - Everything else about an existing index — checking for it, opening it
+//     read-only, statting it, and reading or parsing its contents (transient I/O
+//     faults and on-disk corruption alike) — is non-fatal. We surface the problem
+//     via |warningsCb| and bootstrap from the journal as if the index were absent.
+//
+// In read-only mode (we do not hold the lock) we additionally never mutate
+// on-disk state: the index is opened read-only and |wr.indexWriter| is left nil,
+// which is the signal throughout this type that index writes are disabled.
+func (wr *journalWriter) loadJournalIndex(ctx context.Context, canWrite bool, warningsCb func(error)) error {
+	p := filepath.Join(filepath.Dir(wr.path), journalIndexFileName)
+
+	exists, err := fileExists(p)
+	if err != nil {
+		if canWrite {
+			return err
+		}
+		if warningsCb != nil {
+			warningsCb(fmt.Errorf("error checking for chunk journal index %s, bootstrapping from journal: %w", p, err))
+		}
+		return nil
+	}
+
+	if canWrite {
+		flag := os.O_RDWR
+		if !exists {
+			flag |= os.O_CREATE
+		}
+		if wr.index, err = os.OpenFile(p, flag, 0666); err != nil {
+			return err
+		}
+		wr.indexWriter = bufio.NewWriterSize(wr.index, journalIndexDefaultMaxNovel)
+	} else {
+		if !exists {
+			return nil
+		}
+		if wr.index, err = os.OpenFile(p, os.O_RDONLY, 0666); err != nil {
+			if warningsCb != nil {
+				warningsCb(fmt.Errorf("error opening chunk journal index %s read-only, bootstrapping from journal: %w", p, err))
+			}
+			wr.index = nil
+			return nil
+		}
+	}
+
+	if !exists {
+		// freshly created read-write index; there is nothing to read yet
+		return nil
+	}
+
+	// Read and apply the existing index. Any failure here — a transient I/O fault
+	// or on-disk corruption — is recoverable: discard the index and rebuild from
+	// the journal.
+	if rerr := wr.readJournalIndex(ctx, canWrite); rerr != nil {
+		if warningsCb != nil {
+			warningsCb(fmt.Errorf("error reading chunk journal index %s, rebuilding from journal: %w", p, rerr))
+		}
+		if cerr := wr.corruptIndexRecovery(canWrite); cerr != nil {
+			return fmt.Errorf("error recovering corrupted chunk journal index: %w", cerr)
+		}
+	}
+	return nil
+}
+
+// readJournalIndex reads the existing index file referenced by |wr.index|,
+// validating each batch and populating |wr.ranges| and |wr.indexed|. On success,
+// and only when |canWrite|, the index is rewound to discard any partial trailing
+// batch. It returns an error if the index cannot be read or fails validation; the
+// caller is responsible for recovery.
+func (wr *journalWriter) readJournalIndex(ctx context.Context, canWrite bool) error {
+	info, err := wr.index.Stat()
+	if err != nil {
 		return err
+	}
+
+	// initialize range index with enough capacity to
+	// avoid rehashing during bootstrapping
+	cnt := estimateRangeCount(info)
+	wr.ranges.cached = make(map[addr16]Range, cnt)
+
+	eg, ectx := errgroup.WithContext(ctx)
+	ch := make(chan []lookup, 4)
+
+	// process the indexed portion of the journal
+	var safeIndexOffset int64
+	var prev int64
+
+	eg.Go(func() error {
+		defer close(ch)
+		var perr error
+		safeIndexOffset, perr = processIndexRecords(bufio.NewReader(wr.index), info.Size(), func(m lookupMeta, batch []lookup, batchChecksum uint32) error {
+			if m.checkSum != batchChecksum {
+				return fmt.Errorf("invalid index checksum (%d != %d)", batchChecksum, m.checkSum)
+			}
+
+			if m.batchStart != prev {
+				return fmt.Errorf("index records do not cover contiguous region (%d != %d)", m.batchStart, prev)
+			}
+			prev = m.batchEnd
+
+			// |r.end| is expected to point to a root hash record in |wr.journal|
+			// containing a hash equal to |r.lastRoot|, validate this here
+			if h, err := peekRootHashAt(wr.journal, int64(m.batchEnd)); err != nil {
+				return err
+			} else if h != m.latestHash {
+				return fmt.Errorf("invalid index record hash (%s != %s)", h.String(), m.latestHash.String())
+			}
+
+			select {
+			case <-ectx.Done():
+				return ectx.Err()
+			case ch <- batch:
+				// record a high-water-mark for the indexed portion of the journal
+				wr.indexed = int64(m.batchEnd)
+			}
+			return nil
+		})
+		return perr
+	})
+	// populate range hashmap
+	eg.Go(func() error {
+		for {
+			select {
+			case <-ectx.Done():
+				return nil
+			case ll, ok := <-ch:
+				if !ok {
+					return nil
+				}
+				for _, l := range ll {
+					wr.ranges.putCached(l.a, l.r)
+				}
+			}
+		}
+	})
+
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+
+	// rewind index to last safe point. Note that |safeIndexOffset| refers to a
+	// location in the index file, while |wr.indexed| refers to a position in the
+	// journal file. Only mutate the on-disk index when we hold the lock; in
+	// read-only mode we keep the in-memory state and leave the file untouched.
+	if canWrite {
+		if err := wr.truncateIndex(safeIndexOffset); err != nil {
+			return err
+		}
+	}
+	wr.ranges = wr.ranges.flatten(ctx)
+	return nil
+}
+
+// corruptIndexRecovery handles a corrupted or malformed journal index by resetting
+// the bootstrapping state so that the journal is replayed from offset 0 without an
+// index. When |canWrite| is true, the on-disk index is also truncated so the stale
+// data is discarded; in read-only mode we leave the file untouched and only reset
+// the in-memory state.
+// todo: make backup file?
+func (wr *journalWriter) corruptIndexRecovery(canWrite bool) error {
+	if canWrite {
+		if err := wr.truncateIndex(0); err != nil {
+			return err
+		}
 	}
 	// reset bootstrapping state
 	wr.off, wr.indexed, wr.uncmpSz = 0, 0, 0
@@ -628,7 +715,10 @@ func (wr *journalWriter) Close() (err error) {
 		return err
 	}
 	if wr.index != nil {
-		_ = wr.indexWriter.Flush()
+		// indexWriter is nil when the journal was opened read-only
+		if wr.indexWriter != nil {
+			_ = wr.indexWriter.Flush()
+		}
 		_ = wr.index.Close()
 	}
 	if cerr := wr.journal.Sync(); cerr != nil {

--- a/go/store/nbs/journal_writer_test.go
+++ b/go/store/nbs/journal_writer_test.go
@@ -15,6 +15,7 @@
 package nbs
 
 import (
+	"bytes"
 	"context"
 	"math/rand"
 	"os"
@@ -393,15 +394,155 @@ func TestJournalIndexBootstrap(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, before.Size(), info.Size())
 
-			// bootstrap journal with corrupted index
+			// a corrupted index must not prevent the journal from opening;
+			// the journal writer rebuilds its state from the journal file itself.
 			corruptJournalIndex(t, idxPath)
-			jnl, ok, err := openJournalWriter(ctx, idxPath)
-			require.NoError(t, err)
-			require.True(t, ok)
-			_, err = jnl.bootstrapJournal(ctx, true, nil, nil)
-			assert.Error(t, err)
+			validateJournal(path, epochs)
 		})
 	}
+}
+
+// TestJournalIndexCorruptionRecovery verifies that a corrupt journal index does
+// not prevent the database from opening. The journal index (journal.idx) is an
+// optimization that is written without the same atomicity guarantees as the
+// journal itself, so a process or OS crash can leave it truncated, with trailing
+// garbage, or with garbage spliced into the middle. In all of those cases the
+// journal must still bootstrap successfully by rebuilding its state from the
+// journal file directly, which has its own per-record checksums.
+func TestJournalIndexCorruptionRecovery(t *testing.T) {
+	// writeIndexedJournal writes a journal with |indexed| flushed index records
+	// followed by a final un-indexed ("novel") epoch, then closes it. It returns
+	// the path to the journal, the chunks written, and the final root hash.
+	writeIndexedJournal := func(t *testing.T, indexed int) (path string, data map[hash.Hash]CompressedChunk, last hash.Hash) {
+		ctx := context.Background()
+		path = newTestFilePath(t)
+		j := newTestJournalWriter(t, path)
+		data = make(map[hash.Hash]CompressedChunk)
+
+		writeEpoch := func() hash.Hash {
+			var epochLast hash.Hash
+			for h, cc := range randomCompressedChunks(8) {
+				require.NoError(t, j.writeCompressedChunk(ctx, dherrors.FatalBehaviorError, cc))
+				data[h] = cc
+				epochLast = h
+			}
+			return epochLast
+		}
+
+		for i := 0; i < indexed; i++ {
+			epochLast := writeEpoch()
+			o := j.offset() // offset of the root hash record written below
+			require.NoError(t, j.commitRootHash(ctx, dherrors.FatalBehaviorError, epochLast))
+			require.NoError(t, j.flushIndexRecord(ctx, epochLast, o))
+			last = epochLast
+		}
+
+		// a final novel epoch that is committed but not written to the index
+		last = writeEpoch()
+		require.NoError(t, j.commitRootHash(ctx, dherrors.FatalBehaviorError, last))
+		require.NoError(t, j.Close())
+		return path, data, last
+	}
+
+	// validateOpen reopens the journal at |path|, bootstraps it (which must
+	// succeed despite a corrupt index), and verifies every chunk is readable
+	// and the final root hash is recovered.
+	validateOpen := func(t *testing.T, path string, data map[hash.Hash]CompressedChunk, last hash.Hash) {
+		ctx := context.Background()
+		j, ok, err := openJournalWriter(ctx, path)
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		got, err := j.bootstrapJournal(ctx, true, nil, nil)
+		require.NoError(t, err, "corrupt journal index should not prevent the journal from opening")
+		require.Equal(t, last, got)
+
+		for h, cc := range data {
+			act, err := j.getCompressedChunk(h)
+			require.NoError(t, err)
+			require.Equal(t, cc, act)
+		}
+		require.NoError(t, j.Close())
+	}
+
+	idxPath := func(path string) string {
+		return filepath.Join(filepath.Dir(path), journalIndexFileName)
+	}
+
+	t.Run("truncated index", func(t *testing.T) {
+		path, data, last := writeIndexedJournal(t, 3)
+		// truncate the index in the middle of a batch
+		info, err := os.Stat(idxPath(path))
+		require.NoError(t, err)
+		require.NoError(t, os.Truncate(idxPath(path), info.Size()/2))
+		validateOpen(t, path, data, last)
+	})
+
+	t.Run("trailing garbage", func(t *testing.T) {
+		path, data, last := writeIndexedJournal(t, 3)
+		// append junk after the last valid index record. A 0xff lead byte is an
+		// unknown index record tag, which today fails the open with
+		// ErrMalformedIndex.
+		f, err := os.OpenFile(idxPath(path), os.O_WRONLY|os.O_APPEND, 0666)
+		require.NoError(t, err)
+		_, err = f.Write(bytes.Repeat([]byte{0xff}, 37))
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+		validateOpen(t, path, data, last)
+	})
+
+	t.Run("spliced garbage", func(t *testing.T) {
+		path, data, last := writeIndexedJournal(t, 3)
+		// overwrite bytes in the middle of the index, corrupting a batch. This
+		// fails either a batch checksum or the record tag validation today.
+		f, err := os.OpenFile(idxPath(path), os.O_RDWR, 0666)
+		require.NoError(t, err)
+		info, err := f.Stat()
+		require.NoError(t, err)
+		_, err = f.WriteAt(bytes.Repeat([]byte{0xff}, 32), info.Size()/2)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+		validateOpen(t, path, data, last)
+	})
+
+	// When opened read-only (canWrite == false, i.e. we do not hold the database
+	// lock), bootstrapping a corrupt index must never mutate on-disk state. The
+	// journal must still open and serve reads by rebuilding from the journal.
+	t.Run("read-only never mutates the index", func(t *testing.T) {
+		path, data, last := writeIndexedJournal(t, 3)
+		// splice garbage into the middle of the index
+		f, err := os.OpenFile(idxPath(path), os.O_RDWR, 0666)
+		require.NoError(t, err)
+		info, err := f.Stat()
+		require.NoError(t, err)
+		_, err = f.WriteAt(bytes.Repeat([]byte{0xff}, 32), info.Size()/2)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		// snapshot the (corrupt) index bytes before the read-only open
+		before, err := os.ReadFile(idxPath(path))
+		require.NoError(t, err)
+
+		ctx := context.Background()
+		j, ok, err := openJournalWriter(ctx, path)
+		require.NoError(t, err)
+		require.True(t, ok)
+		// canWrite == false: read-only open
+		got, err := j.bootstrapJournal(ctx, false, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, last, got)
+		for h, cc := range data {
+			act, err := j.getCompressedChunk(h)
+			require.NoError(t, err)
+			require.Equal(t, cc, act)
+		}
+		require.NoError(t, j.Close())
+
+		// the index file must be byte-for-byte unchanged
+		after, err := os.ReadFile(idxPath(path))
+		require.NoError(t, err)
+		require.Equal(t, before, after, "read-only open must not mutate journal.idx")
+	})
 }
 
 func randomCompressedChunks(cnt int) (compressed map[hash.Hash]CompressedChunk) {


### PR DESCRIPTION
journal.idx is an optimization to make opening the database faster. Errors in reading it should never cause opening the database to fail. Make it so that we gracefully handle data and I/O errors in accessing journal.idx so that database opening proceeds as expected.

There is still one fatal error associated with journal.idx: when we are in read-write mode, we must be able to open journal.idx for writing.