### PR TITLE
Bound the session-aware GC pre-finalize safepoint wait (DOLT_GC_SAFEPOINT_MAX_WAIT)

### DIFF
--- a/go/libraries/doltcore/dconfig/envvars.go
+++ b/go/libraries/doltcore/dconfig/envvars.go
@@ -54,6 +54,14 @@ const (
 	// Will go away after session_aware is made default-and-only.
 	EnvGCSafepointControllerChoice = "DOLT_GC_SAFEPOINT_CONTROLLER_CHOICE"
 
+	// Optional Go duration (e.g. "5m"). When set and non-zero, bounds how long
+	// the session-aware GC safepoint will wait for all sessions to quiesce
+	// before the pre-finalize safepoint. On expiry the GC cycle is aborted
+	// (and retried on the next trigger) rather than blocking indefinitely
+	// behind a session that never ends its command. Unset/zero preserves the
+	// original unbounded wait.
+	EnvGCSafepointMaxWait = "DOLT_GC_SAFEPOINT_MAX_WAIT"
+
 	// Used for tests. If set, Dolt will error if it would rebuild a table's row data.
 	EnvAssertNoTableRewrite         = "DOLT_TEST_ASSERT_NO_TABLE_REWRITE"
 	EnvAssertNoInMemoryArchiveIndex = "DOLT_TEST_ASSERT_NO_IN_MEMORY_ARCHIVE_INDEX"

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_gc.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_gc.go
@@ -51,10 +51,22 @@ func init() {
 			panic("Invalid value for " + dconfig.EnvGCSafepointControllerChoice + ". must be session_aware or kill_connections")
 		}
 	}
+	if raw := os.Getenv(dconfig.EnvGCSafepointMaxWait); raw != "" {
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			panic("Invalid value for " + dconfig.EnvGCSafepointMaxWait + ": " + err.Error())
+		}
+		sessionAwareSafepointMaxWait = d
+	}
 }
 
 var DoltGCFeatureFlag = true
 var UseSessionAwareSafepointController = false
+
+// sessionAwareSafepointMaxWait bounds the session-aware pre-finalize safepoint
+// wait. Zero means wait indefinitely (original behavior). Set via
+// dconfig.EnvGCSafepointMaxWait.
+var sessionAwareSafepointMaxWait time.Duration
 
 // doltGC is the stored procedure to run online garbage collection on a database.
 func doltGC(ctx *sql.Context, args ...string) (sql.RowIter, error) {
@@ -192,6 +204,16 @@ func (sc *sessionAwareSafepointController) BeginGC(ctx context.Context, keeper f
 }
 
 func (sc *sessionAwareSafepointController) EstablishPreFinalizeSafepoint(ctx context.Context) error {
+	// This safepoint runs strictly before finalize()/chunk swap, so aborting
+	// here collects nothing: returning an error unwinds the GC via the deferred
+	// EndGC, releasing every parked session. Bounding the wait therefore turns a
+	// session that never quiesces from an indefinite GC stall into a skipped
+	// cycle that retries on the next trigger.
+	if sessionAwareSafepointMaxWait > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, sessionAwareSafepointMaxWait)
+		defer cancel()
+	}
 	return sc.waiter.Wait(ctx)
 }
 

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_gc_test.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_gc_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dprocedures
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb/gcctx"
+	"github.com/dolthub/dolt/go/store/hash"
+)
+
+// gcRootsProviderStub is a no-op gcctx.GCRootsProvider used to register
+// sessions with a GCSafepointController in tests.
+type gcRootsProviderStub struct {
+	// Unused field so that each value gets a distinct address.
+	id int
+}
+
+func (*gcRootsProviderStub) VisitGCRoots(ctx context.Context, db string, keep func(hash.Hash) bool) error {
+	return nil
+}
+
+func TestSessionAwareSafepointMaxWait(t *testing.T) {
+	// These subtests mutate the sessionAwareSafepointMaxWait package global, so
+	// they cannot be run in parallel with one another.
+	noopVisit := func(context.Context, gcctx.GCRootsProvider) error { return nil }
+
+	t.Run("AbortsAfterMaxWait", func(t *testing.T) {
+		defer setSessionAwareSafepointMaxWait(200 * time.Millisecond)()
+
+		controller := gcctx.NewGCSafepointController()
+		running := &gcRootsProviderStub{}
+		require.NoError(t, controller.SessionCommandBegin(running))
+		sc := &sessionAwareSafepointController{
+			waiter: controller.Waiter(context.Background(), nil, noopVisit),
+		}
+
+		// EstablishPreFinalizeSafepoint runs before finalize()/chunk swap, so a
+		// session that never ends its command must not stall it indefinitely
+		// once a max wait is configured. The upper bound is generous (the
+		// running session never quiesces, so an unbounded wait would never
+		// return) to stay reliable on loaded CI rather than asserting precise
+		// timing.
+		start := time.Now()
+		err := sc.EstablishPreFinalizeSafepoint(context.Background())
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Less(t, time.Since(start), 5*time.Second)
+
+		controller.SessionCommandEnd(running)
+		controller.SessionEnd(running)
+	})
+
+	t.Run("UnboundedWhenUnset", func(t *testing.T) {
+		defer setSessionAwareSafepointMaxWait(0)()
+
+		controller := gcctx.NewGCSafepointController()
+		running := &gcRootsProviderStub{}
+		require.NoError(t, controller.SessionCommandBegin(running))
+		sc := &sessionAwareSafepointController{
+			waiter: controller.Waiter(context.Background(), nil, noopVisit),
+		}
+
+		// With no max wait configured, the safepoint keeps the original
+		// behavior: it blocks until every running session quiesces.
+		done := make(chan error, 1)
+		go func() { done <- sc.EstablishPreFinalizeSafepoint(context.Background()) }()
+		select {
+		case <-done:
+			t.Fatal("EstablishPreFinalizeSafepoint returned while a session was still running and no max wait was configured")
+		case <-time.After(100 * time.Millisecond):
+		}
+
+		controller.SessionCommandEnd(running)
+		require.NoError(t, <-done)
+		controller.SessionEnd(running)
+	})
+
+	t.Run("SucceedsWhenSessionsQuiesce", func(t *testing.T) {
+		defer setSessionAwareSafepointMaxWait(time.Minute)()
+
+		controller := gcctx.NewGCSafepointController()
+		quiesced := &gcRootsProviderStub{}
+		require.NoError(t, controller.SessionCommandBegin(quiesced))
+		controller.SessionCommandEnd(quiesced)
+		sc := &sessionAwareSafepointController{
+			waiter: controller.Waiter(context.Background(), nil, noopVisit),
+		}
+
+		// A configured max wait must not interfere with a safepoint that can be
+		// established normally.
+		require.NoError(t, sc.EstablishPreFinalizeSafepoint(context.Background()))
+		controller.SessionEnd(quiesced)
+	})
+}
+
+// setSessionAwareSafepointMaxWait sets the package global for the duration of a
+// test and returns a function that restores its previous value.
+func setSessionAwareSafepointMaxWait(d time.Duration) func() {
+	prev := sessionAwareSafepointMaxWait
+	sessionAwareSafepointMaxWait = d
+	return func() { sessionAwareSafepointMaxWait = prev }
+}


### PR DESCRIPTION
## What

Adds an optional `DOLT_GC_SAFEPOINT_MAX_WAIT` (a Go duration, e.g. `5m`). When set and non-zero, the **session-aware** safepoint controller bounds how long `EstablishPreFinalizeSafepoint` waits for sessions to quiesce. On expiry the GC cycle aborts and is retried on the next trigger, instead of blocking indefinitely behind a session that never ends its command. Unset/zero preserves today's unbounded behavior exactly.

## Why — #11196

On a `sql-server` with auto-GC enabled (which forces the session-aware controller in `engine/sqlengine.go`), `EstablishPreFinalizeSafepoint` is `GCSafepointWaiter.Wait(ctx)` with no timeout: it waits for every session that was mid-command when the waiter was created to reach `SessionCommandEnd`. A session whose client peer has gone away but whose handler goroutine is wedged mid-command (e.g. blocked writing a result to a non-reading peer under a long `write_timeout`) never quiesces, so the auto-GC cycle stalls indefinitely. While stalled it holds `gcInProgress`, blocks every subsequent GC, and the per-connection accounting (released only when the handler goroutine returns) ratchets `dss_concurrent_connections` toward `max_connections` until new clients are rejected. That is the failure mode in #11196.

We reproduced the stall deterministically against `v2.1.6` with stock clients: with auto-GC on, a single `SELECT SLEEP(N)` session holding an outstanding command stalls `CALL DOLT_GC()`'s pre-finalize safepoint for the full N seconds (vs a ~6s baseline), and a mid-stall `dolt_thread_dump()` shows the GC goroutine parked at `GCSafepointWaiter.Wait` ← `sessionAwareSafepointController.EstablishPreFinalizeSafepoint`.

## Why it's safe

The pre-finalize safepoint runs **strictly before** `finalize()`/the chunk swap in `ValueStore.gc()`, so returning an error there aborts the cycle having collected nothing — the deferred `collector.EndGC` still runs and releases every parked session, exactly as on any other GC error path. The change is a no-op when the env var is unset (the default), so existing deployments are unaffected.

## Testing

`go/libraries/doltcore/sqle/dprocedures/dolt_gc_test.go` (white-box, modeled on `gcctx/gc_safepoint_controller_test.go`):

- `AbortsAfterMaxWait` — a never-quiescing session aborts with `context.DeadlineExceeded` at the bound rather than blocking forever.
- `UnboundedWhenUnset` — with no max wait, the safepoint still blocks until the session quiesces (original behavior preserved).
- `SucceedsWhenSessionsQuiesce` — a configured max wait does not interfere with a safepoint that establishes normally.

Passes under `-race`; `gofmt`/`go vet` clean.

## Scope / intent

This is offered as a **minimal reference mitigation** for the stall half of #11196 — **not** as the prescribed fix. We'll gladly defer to whatever shape you prefer (a config-file knob instead of/in addition to the env var, a different default, an escalation rather than a plain abort, etc.).

It deliberately does **not** address the deeper connection-accounting behavior also described in #11196 — that connection slots and `dss_concurrent_connections` are released only when the handler goroutine returns, and that the OK-result (DML) query path starts no dead-peer poller. That part lives in `go-mysql-server`/`vitess` and is yours to fix properly.

We are running this patch as a fork in our production environment to stop the recurring outages until an upstream fix lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
