### PR TITLE
go: bump github.com/lestrrat-go/strftime to v1.2.0 (fixes DATE_FORMAT lock-leak deadlock)

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -165,7 +165,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.12 // indirect
-	github.com/lestrrat-go/strftime v1.0.4 // indirect
+	github.com/lestrrat-go/strftime v1.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/mark3labs/mcp-go v0.34.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -418,8 +418,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lestrrat-go/envload v0.0.0-20180220234015-a3eb8ddeffcc h1:RKf14vYWi2ttpEmkA4aQ3j4u9dStX2t4M8UM6qqNsG8=
 github.com/lestrrat-go/envload v0.0.0-20180220234015-a3eb8ddeffcc/go.mod h1:kopuH9ugFRkIXf3YoqHKyrJ9YfUFsckUU9S7B+XP+is=
-github.com/lestrrat-go/strftime v1.0.4 h1:T1Rb9EPkAhgxKqbcMIPguPq8glqXTA1koF8n9BHElA8=
-github.com/lestrrat-go/strftime v1.0.4/go.mod h1:E1nN3pCbtMSu1yjSVeyuRFVm/U0xoR76fd03sz+Qz4g=
+github.com/lestrrat-go/strftime v1.2.0 h1:8fAUYOeaJKCuLzNvUWBAo8t6I6hkFfodDTndEzJIun0=
+github.com/lestrrat-go/strftime v1.2.0/go.mod h1:GtsIA/7ddIGJjEdfadUafEb1sbutvlvpMdPCMglykYo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.10.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=


### PR DESCRIPTION
## Problem

Under sustained concurrent `DATE_FORMAT` load, a `dolt sql-server` eventually **deadlocks every `DATE_FORMAT` query** and hangs — sessions pile up holding connections until the pool is exhausted (the production incident in #11196).

## Root cause

`go-mysql-server` pins `github.com/lestrrat-go/strftime` **v1.0.4**, whose `(*specificationSet).Lookup` leaks a read-lock on a process-global `RWMutex` on every call — it does `defer ds.lock.RLock()` instead of `RUnlock()`. gms reaches that buggy path because it compiles `DATE_FORMAT` against a *mutable* spec set, and it recompiles on every call.

There is **no writer**, so the leaked read-count is never reset. It climbs monotonically until it overflows the `int32` `readerCount` and wraps negative, after which `RLock`'s `readerCount.Add(1) < 0` check misreads the overflow as a pending writer and blocks forever on a semaphore nobody will signal. From that point every `DATE_FORMAT` compile hangs. We reproduced the exact mechanism deterministically (no writer): a tight `Lookup` loop deadlocks at ~2³⁰ iterations on v1.0.4 and runs unbounded on the fixed version.

## Fix

strftime fixed this in **v1.2.0** (lestrrat-go/strftime#76, "Fix locking mechanism in Lookup function" — only v1.2.0 contains it; v1.0.5/v1.0.6/v1.1.x still leak). v1.2.0 is API-compatible with v1.0.4 (the exported surface is unchanged; only internal spec-set construction was refactored), so this is a clean `go get github.com/lestrrat-go/strftime@v1.2.0`. dolt builds and `DATE_FORMAT` was verified (`%Y-%m-%d %H:%i:%s`, `%W %M %Y`, etc.).

## Why this PR (interim)

This is an **interim** bump: gms still pins v1.0.4, and forcing the newer strftime in dolt's build (it wins via MVS) unblocks dolt now, **without vendoring strftime or waiting for an upstream gms release**. The proper long-term fix is in gms — dolthub/go-mysql-server#3586 caches the compiled formatter (a perf win that also bounds the leak regardless of strftime version), and/or gms bumping its own strftime pin. Once gms updates and dolt picks it up via the normal gms bump, this explicit strftime pin can be dropped.
