### PR TITLE
test: reproduce JSON bugs from issue #11210 as failing tests

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -1082,6 +1082,11 @@ func TestLargeJsonObjects(t *testing.T) {
 	RunLargeJsonObjectsTest(t, harness)
 }
 
+func TestJsonValidScripts(t *testing.T) {
+	harness := newDoltEnginetestHarness(t)
+	RunJsonValidScriptsTest(t, harness)
+}
+
 // TestJsonAdaptiveEncoding exercises the JsonAdaptiveEnc storage path end-to-end,
 // covering small (inlined) and large (out-of-band) JSON documents.
 func TestJsonAdaptiveEncoding(t *testing.T) {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_tests.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_tests.go
@@ -571,6 +571,13 @@ func RunLargeJsonObjectsTest(t *testing.T, harness DoltEnginetestHarness) {
 	}
 }
 
+func RunJsonValidScriptsTest(t *testing.T, harness DoltEnginetestHarness) {
+	defer harness.Close()
+	for _, script := range JsonValidScriptTests {
+		enginetest.TestScript(t, harness, script)
+	}
+}
+
 func RunJsonAdaptiveEncodingTests(t *testing.T, harness DoltEnginetestHarness) {
 	defer harness.Close()
 	for _, script := range JsonAdaptiveEncodingScriptTests {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_json_bugs_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_json_bugs_test.go
@@ -1,0 +1,135 @@
+package enginetest
+
+import (
+	gosql "database/sql"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/servercfg"
+)
+
+// TestConcurrentJsonReads reproduces Bug 3 from GitHub issue #11210: concurrent JSON reads
+// return corrupted data. A data race exists in unescapeHTMLCodepoints (blob_builder.go) which
+// modifies the backing slice in place while other goroutines may be reading it.
+// Run with -race to reliably detect the race; without -race, corruption is non-deterministic.
+func TestConcurrentJsonReads(t *testing.T) {
+	const (
+		dbName     = "dolt_json_concurrent"
+		tableName  = "repro_test"
+		numWorkers = 8
+		numOps     = 50
+		ctrlCharN  = 666
+	)
+
+	dEnv, sc, serverConfig := startServer(t, true, "", "")
+	require.NoError(t, sc.WaitForStart())
+	defer dEnv.Close()
+	defer func() {
+		sc.Stop()
+		require.NoError(t, sc.WaitForStop())
+	}()
+
+	dsn := servercfg.ConnectionString(serverConfig, dbName)
+	if strings.Contains(dsn, "?") {
+		dsn += "&multiStatements=true"
+	} else {
+		dsn += "?multiStatements=true"
+	}
+
+	setupDSN := servercfg.ConnectionString(serverConfig, "")
+	if strings.Contains(setupDSN, "?") {
+		setupDSN += "&multiStatements=true"
+	} else {
+		setupDSN += "?multiStatements=true"
+	}
+	setupDB, err := gosql.Open("mysql", setupDSN)
+	require.NoError(t, err)
+	defer setupDB.Close()
+
+	_, err = setupDB.Exec("CREATE DATABASE IF NOT EXISTS " + dbName)
+	require.NoError(t, err)
+	_, err = setupDB.Exec("USE " + dbName)
+	require.NoError(t, err)
+
+	_, err = setupDB.Exec(fmt.Sprintf(`CREATE TABLE %s (
+		id INT AUTO_INCREMENT PRIMARY KEY,
+		label TEXT NOT NULL,
+		data_json JSON,
+		data_text LONGTEXT
+	)`, tableName))
+	require.NoError(t, err)
+
+	// Insert rows with and without HTML-like codepoints (triggers unescapeHTMLCodepoints path)
+	_, err = setupDB.Exec(fmt.Sprintf(`INSERT INTO %s (label, data_json, data_text) VALUES ('small', '{"d":"hello"}', '{"d":"hello"}')`, tableName))
+	require.NoError(t, err)
+	largeJSON := fmt.Sprintf(`{"d":"%s"}`, strings.Repeat(`\u000b`, ctrlCharN))
+	_, err = setupDB.Exec(fmt.Sprintf(`INSERT INTO %s (label, data_json, data_text) VALUES ('large', '%s', '{"d":"hello"}')`, tableName, largeJSON))
+	require.NoError(t, err)
+
+	// Worker pool: each worker opens its own *sql.DB (separate connection pool)
+	type result struct {
+		garbled int
+		ok      int
+	}
+	results := make(chan result, numWorkers)
+	work := make(chan int, numOps)
+	for i := 0; i < numOps; i++ {
+		work <- i
+	}
+	close(work)
+
+	var wg sync.WaitGroup
+	for w := 0; w < numWorkers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			db, err := gosql.Open("mysql", dsn)
+			if err != nil {
+				t.Errorf("worker open: %v", err)
+				return
+			}
+			defer db.Close()
+
+			var garbled, ok int
+			for range work {
+				rows, err := db.Query(fmt.Sprintf("SELECT label, CAST(data_json AS CHAR) AS raw_json FROM %s ORDER BY id", tableName))
+				if err != nil {
+					t.Errorf("worker query: %v", err)
+					continue
+				}
+				for rows.Next() {
+					var label, rawJSON string
+					if err := rows.Scan(&label, &rawJSON); err != nil {
+						t.Errorf("worker scan: %v", err)
+						continue
+					}
+					if rawJSON == "" || rawJSON == "null" || !strings.HasPrefix(rawJSON, "{") {
+						garbled++
+					} else {
+						ok++
+					}
+				}
+				rows.Close()
+			}
+			results <- result{garbled, ok}
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	totalGarbled, totalOK := 0, 0
+	for r := range results {
+		totalGarbled += r.garbled
+		totalOK += r.ok
+	}
+	t.Logf("JSON reads: %d OK, %d garbled/null", totalOK, totalGarbled)
+
+	assert.Equal(t, 0, totalGarbled, "concurrent JSON reads returned corrupted data (Bug 3)")
+	assert.Greater(t, totalOK, 0, "at least some JSON reads should succeed")
+}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -6210,6 +6210,173 @@ var LargeJsonObjectScriptTests = []queries.ScriptTest{
 
 func init() {
 	LargeJsonObjectScriptTests = append(LargeJsonObjectScriptTests, generateLargeJsonRoundTripTests()...)
+	LargeJsonObjectScriptTests = append(LargeJsonObjectScriptTests, generateLargeJsonControlCharTests()...)
+}
+
+func generateLargeJsonControlCharTests() []queries.ScriptTest {
+	// Construct a JSON value where the string value is a repetition of \u000b (VT) characters.
+	// Each \u000b in JSON output expands from 1 internal byte to 6 bytes, causing the
+	// serialized form to exceed the expected output buffer if not handled correctly.
+	// Bug: values > ~4004 bytes with these characters are silently stored as NULL.
+	const controlCharReps = 666
+
+	// Build the expected JSON using Go's json.Unmarshal so \u000b is interpreted correctly
+	jsonStr := `{"d":"` + strings.Repeat(`\u000b`, controlCharReps) + `"}`
+
+	return []queries.ScriptTest{
+		{
+			Name: "JSON large value with control chars should not silently store NULL",
+			SetUpScript: []string{
+				"create table t (pk int primary key, j json)",
+				"insert into t values (1, JSON_OBJECT('d', REPEAT(CHAR(11), 666)))",
+			},
+			Assertions: []queries.ScriptTestAssertion{
+				{
+					Query:    "select j is not null from t where pk = 1",
+					Expected: []sql.Row{{true}},
+				},
+				{
+					Query:    "select JSON_TYPE(j) from t where pk = 1",
+					Expected: []sql.Row{{"OBJECT"}},
+				},
+				{
+					Query:    "select JSON_LENGTH(j) from t where pk = 1",
+					Expected: []sql.Row{{1}},
+				},
+				{
+					Query:    "select length(JSON_UNQUOTE(JSON_EXTRACT(j, '$.d'))) from t where pk = 1",
+					Expected: []sql.Row{{666}},
+				},
+			},
+		},
+		{
+			Name: "JSON large value with control chars round-trips correctly",
+			SetUpScript: []string{
+				"create table t2 (pk int primary key, j json)",
+				"insert into t2 values (1, JSON_OBJECT('d', REPEAT(CHAR(11), 666)))",
+			},
+			Assertions: []queries.ScriptTestAssertion{
+				{
+					Query:    "select pk, j from t2",
+					Expected: []sql.Row{{1, types.MustJSON(jsonStr)}},
+				},
+				{
+					Query:    "select JSON_EXTRACT(j, '$.d') from t2 where pk = 1",
+					Expected: []sql.Row{{types.MustJSON(`"` + strings.Repeat(`\u000b`, 666) + `"`)}},
+				},
+			},
+		},
+		{
+			Name: "JSON small value with control chars round-trips correctly",
+			SetUpScript: []string{
+				"create table t3 (pk int primary key, j json)",
+				"insert into t3 values (1, JSON_OBJECT('d', REPEAT(CHAR(11), 3)))",
+			},
+			Assertions: []queries.ScriptTestAssertion{
+				{
+					Query:    "select length(JSON_UNQUOTE(JSON_EXTRACT(j, '$.d'))) from t3 where pk = 1",
+					Expected: []sql.Row{{3}},
+				},
+			},
+		},
+		{
+			Name: "JSON large plain string (no control chars) round-trips correctly",
+			SetUpScript: []string{
+				"create table t4 (pk int primary key, j json)",
+				fmt.Sprintf(`insert into t4 values (1, JSON_OBJECT('d', REPEAT('x', %d)))`, 6666),
+			},
+			Assertions: []queries.ScriptTestAssertion{
+				{
+					Query:    "select length(JSON_UNQUOTE(JSON_EXTRACT(j, '$.d'))) from t4 where pk = 1",
+					Expected: []sql.Row{{6666}},
+				},
+			},
+		},
+	}
+}
+
+// JsonValidScriptTests tests JSON_VALID behavior, particularly with large LONGTEXT values
+// in keyless tables. Bug: JSON_VALID returns 0 for valid JSON stored in LONGTEXT columns
+// when the value exceeds ~2040 bytes and the table has no PRIMARY KEY.
+var JsonValidScriptTests = []queries.ScriptTest{
+	{
+		Name: "JSON_VALID on short LONGTEXT without PK",
+		SetUpScript: []string{
+			"create table nopk_short (j longtext)",
+			fmt.Sprintf("insert into nopk_short values (CONCAT('{\"d\":\"', REPEAT('x', %d), '\"}'))", 2031), // total 2039 bytes
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "select JSON_VALID(j) from nopk_short",
+				Expected: []sql.Row{{true}},
+			},
+		},
+	},
+	{
+		Name: "JSON_VALID on long LONGTEXT without PK (Bug 2)",
+		SetUpScript: []string{
+			"create table nopk_long (j longtext)",
+			fmt.Sprintf("insert into nopk_long values (CONCAT('{\"d\":\"', REPEAT('x', %d), '\"}'))", 2032), // total 2040 bytes
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "select JSON_VALID(j) from nopk_long",
+				Expected: []sql.Row{{true}}, // Bug: currently returns 0/false
+			},
+		},
+	},
+	{
+		Name: "JSON_VALID on very long LONGTEXT without PK (Bug 2)",
+		SetUpScript: []string{
+			"create table nopk_vlong (j longtext)",
+			fmt.Sprintf("insert into nopk_vlong values (CONCAT('{\"d\":\"', REPEAT('x', %d), '\"}'))", 10000), // ~10008 bytes
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "select JSON_VALID(j) from nopk_vlong",
+				Expected: []sql.Row{{true}}, // Bug: currently returns 0/false
+			},
+		},
+	},
+	{
+		Name: "JSON_VALID on long LONGTEXT WITH PK (control test)",
+		SetUpScript: []string{
+			"create table withpk_long (id int primary key, j longtext)",
+			fmt.Sprintf("insert into withpk_long values (1, CONCAT('{\"d\":\"', REPEAT('x', %d), '\"}'))", 2032), // total 2040 bytes
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "select JSON_VALID(j) from withpk_long where id = 1",
+				Expected: []sql.Row{{true}}, // Should work because of PK
+			},
+		},
+	},
+	{
+		Name: "JSON_VALID on short LONGTEXT with PK",
+		SetUpScript: []string{
+			"create table withpk_short (id int primary key, j longtext)",
+			fmt.Sprintf("insert into withpk_short values (1, CONCAT('{\"d\":\"', REPEAT('x', %d), '\"}'))", 2031), // total 2039 bytes
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "select JSON_VALID(j) from withpk_short where id = 1",
+				Expected: []sql.Row{{true}},
+			},
+		},
+	},
+	{
+		Name: "JSON_VALID literal works at all sizes (control test)",
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    fmt.Sprintf("SELECT JSON_VALID(CONCAT('{\"d\":\"', REPEAT('x', %d), '\"}'))", 2032),
+				Expected: []sql.Row{{true}},
+			},
+			{
+				Query:    fmt.Sprintf("SELECT JSON_VALID(CONCAT('{\"d\":\"', REPEAT('x', %d), '\"}'))", 10000),
+				Expected: []sql.Row{{true}},
+			},
+		},
+	},
 }
 
 func generateLargeJsonRoundTripTests() []queries.ScriptTest {


### PR DESCRIPTION
Reproduces all three bugs from GitHub issue #11210 as failing unit tests:

**Bug 1** — Large JSON values with control characters (U+0000–U+001F) are silently stored as NULL or become invalid when the serialized representation exceeds ~4004 bytes. Tests verify that JSON_TYPE, JSON_LENGTH, and JSON_UNQUOTE(JSON_EXTRACT) all fail.

**Bug 2** — JSON_VALID() returns 0 for valid JSON strings stored in LONGTEXT columns without a primary key when the value exceeds ~2040 bytes.

**Bug 3** — Concurrent JSON reads return corrupted data due to a data race in unescapeHTMLCodepoints() (blob_builder.go), which modifies the backing byte slice in place without synchronization.

All three tests pass on the expected buggy behavior (they fail on the current codebase, demonstrating the bugs).