### PR TITLE
go,integration-tests: Enable session aware safepoint controller by default.

### DIFF
--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -805,9 +805,41 @@ func (ddb *DoltDB) WriteRootValue(ctx context.Context, rv RootValue) (RootValue,
 }
 
 func (ddb *DoltDB) writeRootValue(ctx context.Context, rv RootValue) (RootValue, types.Ref, error) {
+	return ddb.doWriteRootValue(ctx, rv, false)
+}
+
+// doWriteRootValue persists |rv| to the database and returns the updated root
+// value (with its FeatureVersion set) and a Ref to it. If |skipIfPresent| is
+// true and the root value is already present in the database, the write is
+// skipped and a Ref to the existing value is returned.
+//
+// |skipIfPresent| is used by GC safepoint root collection (see
+// WorkingSetHashes / DoltSession.VisitGCRoots), where the returned hash is
+// immediately handed to the GC keeper. There, persisting an already-present
+// root value is redundant, and--because it dirties the store's memtable--it
+// defeats the no-op GC fast path (see NomsBlockStore.hasLocalGCNovelty), so
+// that an online GC of an unchanged database would needlessly rewrite the
+// store every time. Skipping the write is safe in that path because the caller
+// keeps the chunk via the keeper whether or not we wrote it. It must NOT be
+// used on a path that relies on the write being observed by an in-progress GC
+// (the keeperFunc), since skipping the Put skips that bookkeeping.
+func (ddb *DoltDB) doWriteRootValue(ctx context.Context, rv RootValue, skipIfPresent bool) (RootValue, types.Ref, error) {
 	rv, err := rv.SetFeatureVersion(DoltFeatureVersion)
 	if err != nil {
 		return nil, types.Ref{}, err
+	}
+	if skipIfPresent {
+		ref, err := types.NewRef(rv.NomsValue(), ddb.db.Format())
+		if err != nil {
+			return nil, types.Ref{}, err
+		}
+		existing, err := ddb.vrw.ReadValue(ctx, ref.TargetHash())
+		if err != nil {
+			return nil, types.Ref{}, err
+		}
+		if existing != nil {
+			return rv, ref, nil
+		}
 	}
 	ref, err := ddb.vrw.WriteValue(ctx, rv.NomsValue())
 	if err != nil {
@@ -819,8 +851,12 @@ func (ddb *DoltDB) writeRootValue(ctx context.Context, rv RootValue) (RootValue,
 // Persists all relevant root values of the WorkingSet to the database and returns all hashes reachable
 // from the working set. This is used in GC, for example, where all dependencies of the in-memory working
 // set value need to be accounted for.
+//
+// Root values that are already present in the database are not rewritten, so
+// that collecting the GC roots of an unchanged working set does not dirty the
+// store and defeat the no-op GC fast path. See doWriteRootValue.
 func (ddb *DoltDB) WorkingSetHashes(ctx context.Context, ws *WorkingSet) ([]hash.Hash, error) {
-	spec, err := ws.writeValues(ctx, ddb, nil)
+	spec, err := ws.writeValues(ctx, ddb, nil, true)
 	if err != nil {
 		return nil, err
 	}
@@ -1832,7 +1868,7 @@ func (ddb *DoltDB) writeWorkingSet(ctx context.Context, workingSetRef ref.Workin
 		branchName = workingSet.Name[len("heads/"):]
 	}
 
-	wsSpec, err = workingSet.writeValues(ctx, ddb, meta)
+	wsSpec, err = workingSet.writeValues(ctx, ddb, meta, false)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/doltdb/workingset.go
+++ b/go/libraries/doltcore/doltdb/workingset.go
@@ -678,18 +678,22 @@ func (ws *WorkingSet) Ref() ref.WorkingSetRef {
 
 // writeValues write the values in this working set to the database and returns a datas.WorkingSetSpec with the
 // new values in it.
-func (ws *WorkingSet) writeValues(ctx context.Context, db *DoltDB, meta *datas.WorkingSetMeta) (spec *datas.WorkingSetSpec, err error) {
+//
+// If |skipIfPresent| is true, root values that are already present in the
+// database are not rewritten. This is only safe when the caller does not rely
+// on these writes being observed by an in-progress GC; see DoltDB.doWriteRootValue.
+func (ws *WorkingSet) writeValues(ctx context.Context, db *DoltDB, meta *datas.WorkingSetMeta, skipIfPresent bool) (spec *datas.WorkingSetSpec, err error) {
 	if ws.stagedRoot == nil || ws.workingRoot == nil {
 		return nil, fmt.Errorf("StagedRoot and workingRoot must be set. This is a bug.")
 	}
 
-	r, workingRoot, err := db.writeRootValue(ctx, ws.workingRoot)
+	r, workingRoot, err := db.doWriteRootValue(ctx, ws.workingRoot, skipIfPresent)
 	if err != nil {
 		return nil, err
 	}
 	ws.workingRoot = r
 
-	r, stagedRoot, err := db.writeRootValue(ctx, ws.stagedRoot)
+	r, stagedRoot, err := db.doWriteRootValue(ctx, ws.stagedRoot, skipIfPresent)
 	if err != nil {
 		return nil, err
 	}
@@ -697,7 +701,7 @@ func (ws *WorkingSet) writeValues(ctx context.Context, db *DoltDB, meta *datas.W
 
 	var mergeState *datas.MergeState
 	if ws.mergeState != nil {
-		r, preMergeWorking, err := db.writeRootValue(ctx, ws.mergeState.preMergeWorking)
+		r, preMergeWorking, err := db.doWriteRootValue(ctx, ws.mergeState.preMergeWorking, skipIfPresent)
 		if err != nil {
 			return nil, err
 		}
@@ -733,7 +737,7 @@ func (ws *WorkingSet) writeValues(ctx context.Context, db *DoltDB, meta *datas.W
 
 	var rebaseState *datas.RebaseState
 	if ws.rebaseState != nil {
-		r, preRebaseWorking, err := db.writeRootValue(ctx, ws.rebaseState.preRebaseWorking)
+		r, preRebaseWorking, err := db.doWriteRootValue(ctx, ws.rebaseState.preRebaseWorking, skipIfPresent)
 		if err != nil {
 			return nil, err
 		}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_gc.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_gc.go
@@ -45,16 +45,16 @@ func init() {
 		DoltGCFeatureFlag = false
 	}
 	if choice := os.Getenv(dconfig.EnvGCSafepointControllerChoice); choice != "" {
-		if choice == "session_aware" {
-			UseSessionAwareSafepointController = true
-		} else if choice != "kill_connections" {
-			panic("Invalid value for " + dconfig.EnvGCSafepointControllerChoice + ". must be session_aware or kill_connections")
+		if choice == "kill_connections" {
+			UseSessionAwareSafepointController = false
+		} else if choice != "session_aware" {
+			panic("Invalid value for " + dconfig.EnvGCSafepointControllerChoice + ": " + choice + ". Must be session_aware or kill_connections")
 		}
 	}
 }
 
 var DoltGCFeatureFlag = true
-var UseSessionAwareSafepointController = false
+var UseSessionAwareSafepointController = true
 
 // doltGC is the stored procedure to run online garbage collection on a database.
 func doltGC(ctx *sql.Context, args ...string) (sql.RowIter, error) {

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
@@ -1556,8 +1556,6 @@ tests:
     - exec: 'insert into vals values (3,3)'
     - exec: 'insert into vals values (4,4)'
     - exec: 'call dolt_gc()'
-    - exec: 'select * from vals'
-      error_match: "this connection can no longer be used"
   - on: server1
     queries:
     - query: "select `database`, standby_remote, role, epoch, replication_lag_millis, current_error from dolt_cluster.dolt_cluster_status order by `database` asc"
@@ -1578,7 +1576,6 @@ tests:
         - [3,3]
         - [4,4]
     - exec: 'call dolt_gc()'
-      error_match: "must be the primary"
     - exec: 'call dolt_gc("--shallow")'
 - name: dropped database is no longer present on replica
   multi_repos:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-large-values-gc.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-large-values-gc.yaml
@@ -64,8 +64,6 @@ tests:
     - exec: "INSERT INTO large_text VALUES (4, REPEAT('4567890abc', 1500))"
     - exec: "INSERT INTO large_text VALUES (5, REPEAT('defghijklm', 1500))"
     - exec: 'CALL DOLT_GC()'
-    - query: 'SELECT COUNT(*) FROM large_text'
-      error_match: "this connection can no longer be used"
   # After GC the connection is invalidated. Open a new connection to the primary
   # and wait for the cluster to finish replicating the post-GC state.
   - on: server1

--- a/integration-tests/go-sql-server-driver/tests/sql-server-wide-varchar-table.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-wide-varchar-table.yaml
@@ -81,8 +81,6 @@ tests:
         columns: ["COUNT(*)"]
         rows: [["3"]]
     - exec: 'CALL DOLT_GC()'
-    - query: 'SELECT COUNT(*) FROM wide_varchar'
-      error_match: "this connection can no longer be used"
   - on: server1
     queries:
     - query: |


### PR DESCRIPTION
Fixes a regression in the session-aware controller where fast-complete no-op GC was not working as intended.