### PR TITLE
Fix dolt_log system table on shallow clones

### DIFF
--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -2537,11 +2537,7 @@ func (ddb *DoltDB) IsShallow() bool {
 	if !ok {
 		return false
 	}
-	ghostGen, ok := gcs.GhostGen().(chunks.GhostChunkStore)
-	if !ok {
-		return false
-	}
-	return ghostGen.HasGhosts()
+	return gcs.GhostGen().HasGhosts()
 }
 
 // Purge in-memory read caches associated with this DoltDB. This needs

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -2529,6 +2529,21 @@ func (ddb *DoltDB) PersistGhostCommits(ctx context.Context, ghostCommits hash.Ha
 	return ddb.db.Database.PersistGhostCommitIDs(ctx, ghostCommits)
 }
 
+// IsShallow reports whether this database is a shallow clone, meaning some of
+// its history was never fetched and is represented by ghost commits. Storage
+// formats that do not support shallow clones always report false.
+func (ddb *DoltDB) IsShallow() bool {
+	gcs, ok := datas.ChunkStoreFromDatabase(ddb.db).(chunks.GenerationalCS)
+	if !ok {
+		return false
+	}
+	ghostGen, ok := gcs.GhostGen().(chunks.GhostChunkStore)
+	if !ok {
+		return false
+	}
+	return ghostGen.HasGhosts()
+}
+
 // Purge in-memory read caches associated with this DoltDB. This needs
 // to be done at a specific point during a GC operation to ensure that
 // everything the application layer sees still exists in the database

--- a/go/libraries/doltcore/sqle/dtables/log_table.go
+++ b/go/libraries/doltcore/sqle/dtables/log_table.go
@@ -34,8 +34,6 @@ import (
 	"github.com/dolthub/dolt/go/store/prolly"
 )
 
-const logsDefaultRowCount = 100
-
 // LogTable is a sql.Table implementation that implements a system table which shows the dolt commit log
 type LogTable struct {
 	ddb               *doltdb.DoltDB
@@ -171,11 +169,10 @@ func (dt *LogTable) DataLength(ctx *sql.Context) (uint64, error) {
 }
 
 // RowCount implements sql.StatisticsTable
-func (dt *LogTable) RowCount(ctx *sql.Context) (uint64, bool, error) {
+func (dt *LogTable) RowCount(ctx *sql.Context) (rowCount uint64, exact bool, err error) {
 	cc, err := dt.head.GetCommitClosure(ctx)
 	if err != nil {
-		// TODO: remove this when we deprecate LD
-		return logsDefaultRowCount, false, nil
+		return 0, false, err
 	}
 	if cc.IsEmpty() {
 		return 1, true, nil

--- a/go/libraries/doltcore/sqle/dtables/log_table.go
+++ b/go/libraries/doltcore/sqle/dtables/log_table.go
@@ -181,9 +181,10 @@ func (dt *LogTable) RowCount(ctx *sql.Context) (uint64, bool, error) {
 		return 1, true, nil
 	}
 	cnt, err := cc.Count()
-	// A shallow clone's closure counts ancestors it never fetched, so mark the
-	// total inexact and let the engine recount the rows actually present.
-	return uint64(cnt + 1), false, err
+	// A shallow clone's closure counts ancestors it never fetched, so its total
+	// is too high. Report it as inexact only in that case, which makes count(*)
+	// recount the rows actually present while full clones keep the exact fast path.
+	return uint64(cnt + 1), !dt.ddb.IsShallow(), err
 }
 
 // Name is a sql.Table interface function which returns the name of the table

--- a/go/libraries/doltcore/sqle/dtables/log_table.go
+++ b/go/libraries/doltcore/sqle/dtables/log_table.go
@@ -181,7 +181,9 @@ func (dt *LogTable) RowCount(ctx *sql.Context) (uint64, bool, error) {
 		return 1, true, nil
 	}
 	cnt, err := cc.Count()
-	return uint64(cnt + 1), true, err
+	// A shallow clone's closure counts ancestors it never fetched, so mark the
+	// total inexact and let the engine recount the rows actually present.
+	return uint64(cnt + 1), false, err
 }
 
 // Name is a sql.Table interface function which returns the name of the table
@@ -420,7 +422,14 @@ func (dt *LogTable) NewLogItr(ctx *sql.Context, ddb *doltdb.DoltDB, head *doltdb
 		return nil, err
 	}
 
-	child, err := commitwalk.GetTopologicalOrderIterator[*sql.Context](ctx, ddb, []hash.Hash{h}, nil)
+	// Returning false for ghost commits, which stand in for ancestors a shallow
+	// clone never fetched, stops the walk at the boundary of the available history.
+	matchFn := func(optCmt *doltdb.OptionalCommit) (bool, error) {
+		_, ok := optCmt.ToCommit()
+		return ok, nil
+	}
+
+	child, err := commitwalk.GetTopologicalOrderIterator[*sql.Context](ctx, ddb, []hash.Hash{h}, matchFn)
 	if err != nil {
 		return nil, err
 	}

--- a/go/store/chunks/chunk_store.go
+++ b/go/store/chunks/chunk_store.go
@@ -313,6 +313,13 @@ type GenerationalCS interface {
 	OldGenGCFilter() HasManyFunc
 }
 
+// GhostChunkStore is implemented by chunk stores that track the addresses of
+// chunks a shallow clone deliberately did not fetch.
+type GhostChunkStore interface {
+	// HasGhosts reports whether any ghost chunks are recorded.
+	HasGhosts() bool
+}
+
 var ErrUnsupportedOperation = errors.New("operation not supported")
 
 var ErrGCGenerationExpired = errors.New("garbage collection generation expired")

--- a/go/store/chunks/chunk_store.go
+++ b/go/store/chunks/chunk_store.go
@@ -304,7 +304,7 @@ type PrefixChunkStore interface {
 type GenerationalCS interface {
 	NewGen() ChunkStoreGarbageCollector
 	OldGen() ChunkStoreGarbageCollector
-	GhostGen() ChunkStore
+	GhostGen() GhostChunkStore
 
 	// Has the same return values as OldGen().HasMany, but should be used by a
 	// generational GC process as the filter function instead of
@@ -313,11 +313,13 @@ type GenerationalCS interface {
 	OldGenGCFilter() HasManyFunc
 }
 
-// GhostChunkStore is implemented by chunk stores that track the addresses of
-// chunks a shallow clone deliberately did not fetch.
+// GhostChunkStore is the ghost store of a generational chunk store. It tracks
+// the addresses of chunks a shallow clone deliberately did not fetch.
 type GhostChunkStore interface {
 	// HasGhosts reports whether any ghost chunks are recorded.
 	HasGhosts() bool
+	// PersistGhostHashes records the given addresses as ghost chunks.
+	PersistGhostHashes(ctx context.Context, refs hash.HashSet) error
 }
 
 var ErrUnsupportedOperation = errors.New("operation not supported")

--- a/go/store/nbs/generational_chunk_store.go
+++ b/go/store/nbs/generational_chunk_store.go
@@ -52,7 +52,7 @@ func (gcs *GenerationalNBS) PersistGhostHashes(ctx context.Context, refs hash.Ha
 	return fmt.Errorf("runtime error. ghostGen is nil but an attempt to persist ghost hashes was made")
 }
 
-func (gcs *GenerationalNBS) GhostGen() chunks.ChunkStore {
+func (gcs *GenerationalNBS) GhostGen() chunks.GhostChunkStore {
 	return gcs.ghostGen
 }
 

--- a/go/store/nbs/ghost_store.go
+++ b/go/store/nbs/ghost_store.go
@@ -135,6 +135,13 @@ func (g GhostBlockStore) Has(ctx context.Context, h hash.Hash) (bool, error) {
 	return false, nil
 }
 
+// HasGhosts reports whether any ghost chunks are recorded, which is the case
+// for a shallow clone whose unfetched history is represented by ghost chunks. A
+// generational store may hold a nil ghost store, which reports no ghosts.
+func (g *GhostBlockStore) HasGhosts() bool {
+	return g != nil && g.skippedRefs != nil && g.skippedRefs.Size() > 0
+}
+
 func (g GhostBlockStore) HasMany(ctx context.Context, hashes hash.HashSet) (absent hash.HashSet, err error) {
 	return g.hasMany(hashes)
 }

--- a/go/store/nbs/ghost_store_test.go
+++ b/go/store/nbs/ghost_store_test.go
@@ -83,4 +83,16 @@ func TestGhostBlockStore(t *testing.T) {
 		require.True(t, got[0].IsGhost())
 		require.Equal(t, ghost, got[0].Hash())
 	})
+	t.Run("HasGhosts", func(t *testing.T) {
+		require.True(t, bs.HasGhosts())
+		empty, err := NewGhostBlockStore(t.TempDir())
+		require.NoError(t, err)
+		require.False(t, empty.HasGhosts())
+	})
+}
+
+func TestGhostBlockStoreHasGhostsNil(t *testing.T) {
+	// GenerationalNBS may hold a nil ghost store, so HasGhosts must not panic.
+	var bs *GhostBlockStore
+	require.False(t, bs.HasGhosts())
 }

--- a/integration-tests/bats/shallow-clone.bats
+++ b/integration-tests/bats/shallow-clone.bats
@@ -79,6 +79,38 @@ seed_and_start_serial_remote() {
     [[ "$output" =~ "15" ]] || false # 1+2+3+4+5 = 15.
 }
 
+@test "shallow-clone: select from dolt_log system table on depth 1 clone" {
+    # See https://github.com/dolthub/dolt/issues/11230
+    seed_and_start_serial_remote
+
+    mkdir clones
+    cd clones
+
+    dolt sql -q "call dolt_clone('--depth', '1','http://localhost:50051/test-org/test-repo')"
+    cd test-repo
+
+    run dolt log --oneline --decorate=no
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 1 ]
+
+    run dolt sql -q "select count(*) = 1 from dolt_log()"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "true" ]] || false
+
+    run dolt sql -q "select * from dolt_log"
+    [ "$status" -eq 0 ]
+    ! [[ "$output" =~ "Ghost commit encountered" ]] || false
+
+    run dolt sql -q "select count(*) from (select * from dolt_log) t" -r csv
+    [ "$status" -eq 0 ]
+    [[ "${lines[1]}" = "1" ]] || false
+
+    # count(*) is served from table statistics, not a row scan, so it needs its own check.
+    run dolt sql -q "select count(*) = 1 from dolt_log"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "true" ]] || false
+}
+
 @test "shallow-clone: dolt_clone depth 2" {
     seed_and_start_serial_remote
 
@@ -250,11 +282,18 @@ seed_and_start_serial_remote() {
     [ "$status" -eq 0 ]
     [[ "$output" =~ "true" ]] || false
 
-#   NM4 - system table bug.
-#    run dolt sql -q "select count(*) = 3 from dolt_log"
-#    [ "$status" -eq 0 ]
-#    [[ "$output" =~ "true" ]] || false
-#
+    # See https://github.com/dolthub/dolt/issues/11230
+    run dolt sql -q "select * from dolt_log"
+    [ "$status" -eq 0 ]
+    ! [[ "$output" =~ "Ghost commit encountered" ]] || false
+
+    run dolt sql -q "select count(*) from (select * from dolt_log) t" -r csv
+    [ "$status" -eq 0 ]
+    [[ "${lines[1]}" = "3" ]] || false
+
+    run dolt sql -q "select count(*) = 3 from dolt_log"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "true" ]] || false
 
     # dolt_diff table will show two rows, because each row is a delta.
     run dolt sql -q "select * from dolt_diff"


### PR DESCRIPTION
On a shallow clone, the `DOLT_LOG` system table failed to properly show commits when ghost commits were encountered. The table now skips ghost commits so it stops at the shallow boundary.
- Skip ghost commits in `DOLT_LOG` walk
- Report the row count as inexact only on shallow clones; full clones keep the existing O(1) fast count
- Add `DoltDB.IsShallow()`, backed by a new `chunks.GhostChunkStore` interface
Fix dolthub/dolt#11230