### PR TITLE
go: store/pull,remotestorage: Add optional logging to `dolt pull/fetch/push`.

### DIFF
--- a/go/libraries/doltcore/remotestorage/chunk_fetcher.go
+++ b/go/libraries/doltcore/remotestorage/chunk_fetcher.go
@@ -91,7 +91,10 @@ const (
 	reliableCallDeliverRespTimeout = 15 * time.Second
 )
 
-func NewChunkFetcher(ctx context.Context, dcs *DoltChunkStore) *ChunkFetcher {
+// NewChunkFetcher creates a ChunkFetcher for |dcs|. If |recorder| is non-nil,
+// it receives per-download statistics in addition to the process-global stats
+// recorder configured via StatsFactory.
+func NewChunkFetcher(ctx context.Context, dcs *DoltChunkStore, recorder nbs.StatsRecorder) *ChunkFetcher {
 	eg, ctx := errgroup.WithContext(ctx)
 	ret := &ChunkFetcher{
 		eg:    eg,
@@ -101,7 +104,7 @@ func NewChunkFetcher(ctx context.Context, dcs *DoltChunkStore) *ChunkFetcher {
 		resCh:   make(chan nbs.ToChunker),
 
 		abortCh: make(chan struct{}),
-		stats:   StatsFactory(),
+		stats:   teeStatsRecorder(StatsFactory(), recorder),
 	}
 
 	downloadLocCh := make(chan []*remotesapi.DownloadLoc)

--- a/go/libraries/doltcore/remotestorage/chunk_fetcher.go
+++ b/go/libraries/doltcore/remotestorage/chunk_fetcher.go
@@ -147,7 +147,7 @@ func NewChunkFetcher(ctx context.Context, dcs *DoltChunkStore, recorder nbs.Stat
 		return fetcherDownloadRangesThread(ctx, downloadLocCh, fetchReqCh, locDoneCh)
 	})
 	eg.Go(func() error {
-		return fetcherDownloadURLThreads(ctx, fetchReqCh, locDoneCh, ret.resCh, dcs.csClient, ret.stats, dcs.httpFetcher, dcs.params)
+		return fetcherDownloadURLThreads(ctx, fetchReqCh, locDoneCh, ret.resCh, dcs.csClient, ret.stats, dcs.httpFetcher, dcs.params, dcs.logf)
 	})
 
 	return ret
@@ -759,13 +759,13 @@ func (cc *ConcurrencyControl) Run(ctx context.Context, done <-chan struct{}, ss 
 	}
 }
 
-func fetcherDownloadURLThreads(ctx context.Context, fetchReqCh chan fetchReq, doneCh chan struct{}, chunkCh chan nbs.ToChunker, client remotesapi.ChunkStoreServiceClient, stats StatsRecorder, fetcher HTTPFetcher, params NetworkRequestParams) error {
+func fetcherDownloadURLThreads(ctx context.Context, fetchReqCh chan fetchReq, doneCh chan struct{}, chunkCh chan nbs.ToChunker, client remotesapi.ChunkStoreServiceClient, stats StatsRecorder, fetcher HTTPFetcher, params NetworkRequestParams, logf func(string, ...interface{})) error {
 	eg, ctx := errgroup.WithContext(ctx)
 	cc := &ConcurrencyControl{
 		MaxConcurrency: params.MaximumConcurrentDownloads,
 	}
 	f := func(ctx context.Context, shutdownCh <-chan struct{}) error {
-		return fetcherDownloadURLThread(ctx, fetchReqCh, shutdownCh, chunkCh, client, stats, cc, fetcher, params)
+		return fetcherDownloadURLThread(ctx, fetchReqCh, shutdownCh, chunkCh, client, stats, cc, fetcher, params, logf)
 	}
 	threads := pool.NewDynamic(ctx, f, params.StartingConcurrentDownloads)
 	eg.Go(func() error {
@@ -834,7 +834,7 @@ func setDictionaryCallback(dictCache *dictionaryCache, path string) func(context
 	}
 }
 
-func fetcherDownloadURLThread(ctx context.Context, fetchReqCh chan fetchReq, doneCh <-chan struct{}, chunkCh chan nbs.ToChunker, client remotesapi.ChunkStoreServiceClient, stats StatsRecorder, health reliable.HealthRecorder, fetcher HTTPFetcher, params NetworkRequestParams) error {
+func fetcherDownloadURLThread(ctx context.Context, fetchReqCh chan fetchReq, doneCh <-chan struct{}, chunkCh chan nbs.ToChunker, client remotesapi.ChunkStoreServiceClient, stats StatsRecorder, health reliable.HealthRecorder, fetcher HTTPFetcher, params NetworkRequestParams, logf func(string, ...interface{})) error {
 	respCh := make(chan fetchResp, 1)
 	for {
 		select {
@@ -853,7 +853,7 @@ func fetcherDownloadURLThread(ctx context.Context, fetchReqCh chan fetchReq, don
 				} else {
 					cb = setDictionaryCallback(fetchResp.dictCache, fetchResp.path)
 				}
-				f := fetchResp.get.GetDownloadFunc(ctx, stats, health, fetcher, params, cb, func(ctx context.Context, lastError error, resourcePath string) (string, error) {
+				f := fetchResp.get.GetDownloadFunc(ctx, stats, health, fetcher, params, logf, cb, func(ctx context.Context, lastError error, resourcePath string) (string, error) {
 					return fetchResp.refresh(ctx, lastError, client)
 				})
 				err := f()

--- a/go/libraries/doltcore/remotestorage/chunk_store.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store.go
@@ -435,7 +435,7 @@ func sortRangesBySize(ranges []*GetRange) {
 
 type resourcePathToUrlFunc func(ctx context.Context, lastError error, resourcePath string) (url string, err error)
 
-func (gr *GetRange) GetDownloadFunc(ctx context.Context, stats StatsRecorder, health reliable.HealthRecorder, fetcher HTTPFetcher, params NetworkRequestParams, resCb func(context.Context, []byte, *Range) error, pathToUrl resourcePathToUrlFunc) func() error {
+func (gr *GetRange) GetDownloadFunc(ctx context.Context, stats StatsRecorder, health reliable.HealthRecorder, fetcher HTTPFetcher, params NetworkRequestParams, logf func(string, ...interface{}), resCb func(context.Context, []byte, *Range) error, pathToUrl resourcePathToUrlFunc) func() error {
 	if len(gr.Ranges) == 0 {
 		return func() error { return nil }
 	}
@@ -459,6 +459,7 @@ func (gr *GetRange) GetDownloadFunc(ctx context.Context, stats StatsRecorder, he
 			UrlFact: urlF,
 			Stats:   stats,
 			Health:  health,
+			Logf:    logf,
 			BackOffFact: func(ctx context.Context) backoff.BackOff {
 				return downloadBackOff(ctx, params.DownloadRetryCount)
 			},

--- a/go/libraries/doltcore/remotestorage/chunk_store.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store.go
@@ -282,8 +282,8 @@ type CacheStats interface {
 	CacheHits() uint32
 }
 
-func (dcs *DoltChunkStore) ChunkFetcher(ctx context.Context) nbs.ChunkFetcher {
-	return NewChunkFetcher(ctx, dcs)
+func (dcs *DoltChunkStore) ChunkFetcher(ctx context.Context, recorder nbs.StatsRecorder) nbs.ChunkFetcher {
+	return NewChunkFetcher(ctx, dcs, recorder)
 }
 
 // Get the Chunk for the value of the hash in the store. If the hash is absent from the store EmptyChunk is returned.
@@ -597,7 +597,7 @@ type RepoRequest interface {
 func (dcs *DoltChunkStore) readChunksAndCache(ctx context.Context, hashes []hash.Hash, found func(context.Context, nbs.ToChunker)) (err error) {
 	toSend := hash.NewHashSet(hashes...)
 
-	fetcher := dcs.ChunkFetcher(ctx)
+	fetcher := dcs.ChunkFetcher(ctx, nil)
 	defer func() {
 		cerr := fetcher.Close()
 		if err == nil {

--- a/go/libraries/doltcore/remotestorage/internal/reliable/http.go
+++ b/go/libraries/doltcore/remotestorage/internal/reliable/http.go
@@ -79,6 +79,10 @@ type StreamingRangeRequest struct {
 	BackOffFact        BackOffFactory
 	Throughput         MinimumThroughputCheck
 	RespHeadersTimeout time.Duration
+	// Logf, if non-nil, is called to log each download failure: every
+	// transient failure that will be retried, and any terminal failure that
+	// aborts the request. It must be safe for concurrent use.
+	Logf func(string, ...interface{})
 }
 
 // |StreamingRangeDownload| makes an immediate GET request to the URL returned
@@ -249,8 +253,16 @@ func StreamingRangeDownload(ctx context.Context, req StreamingRangeRequest) Stre
 			}
 		}
 		start := time.Now()
-		err := backoff.Retry(op, req.BackOffFact(ctx))
+		notify := func(err error, d time.Duration) {
+			if req.Logf != nil {
+				req.Logf("reliable: retrying range download bytes=%d-%d after failed attempt %d (backoff %s): %v", offset, rangeEnd, retry, d, err)
+			}
+		}
+		err := backoff.RetryNotify(op, req.BackOffFact(ctx), notify)
 		if err != nil {
+			if req.Logf != nil {
+				req.Logf("reliable: range download bytes=%d-%d failed permanently after %d attempt(s): %v", req.Offset, rangeEnd, retry, err)
+			}
 			w.CloseWithError(err)
 		} else {
 			req.Stats.RecordDownloadComplete(retry, req.Length, time.Since(start))

--- a/go/libraries/doltcore/remotestorage/internal/reliable/http_test.go
+++ b/go/libraries/doltcore/remotestorage/internal/reliable/http_test.go
@@ -17,9 +17,11 @@ package reliable
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"runtime"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -270,5 +272,73 @@ func TestStreamingRangeDownload(t *testing.T) {
 
 		assert.Equal(t, int64(0), health.failures.Load(), "consumer-close cancel mid-range must not record a failure")
 		assert.Equal(t, int64(0), health.successes.Load(), "consumer-close cancel mid-range must not record a success")
+	})
+
+	t.Run("LogfReportsRetriedFailures", func(t *testing.T) {
+		// A transient failure that is retried and then succeeds should be
+		// reported via Logf, even though it never surfaces as a returned
+		// error.
+		const size = 1024
+		payload := make([]byte, size)
+		for i := range payload {
+			payload[i] = byte(i)
+		}
+
+		var calls atomic.Int64
+		fetcher := fetcherFunc(func(req *http.Request) (*http.Response, error) {
+			if calls.Add(1) == 1 {
+				// First attempt fails with a 503.
+				return &http.Response{
+					StatusCode: http.StatusServiceUnavailable,
+					Body:       io.NopCloser(bytes.NewReader(nil)),
+					Request:    req,
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusPartialContent,
+				Body:       io.NopCloser(bytes.NewReader(payload)),
+				Request:    req,
+			}, nil
+		})
+
+		var mu sync.Mutex
+		var logged []string
+		logf := func(format string, args ...interface{}) {
+			mu.Lock()
+			defer mu.Unlock()
+			logged = append(logged, fmt.Sprintf(format, args...))
+		}
+
+		health := &countingHealth{}
+		resp := StreamingRangeDownload(context.Background(), StreamingRangeRequest{
+			Fetcher: fetcher,
+			Offset:  0,
+			Length:  size,
+			UrlFact: func(error) (string, error) { return "http://example.test/file", nil },
+			Stats:   noopStats{},
+			Health:  health,
+			BackOffFact: func(ctx context.Context) backoff.BackOff {
+				return backoff.NewConstantBackOff(0)
+			},
+			Throughput: MinimumThroughputCheck{
+				CheckInterval: time.Hour,
+				BytesPerCheck: 1,
+				NumIntervals:  1,
+			},
+			RespHeadersTimeout: time.Hour,
+			Logf:               logf,
+		})
+
+		got := make([]byte, size)
+		_, err := io.ReadFull(resp.Body, got)
+		require.NoError(t, err)
+		require.Equal(t, payload, got)
+		require.NoError(t, resp.Close())
+
+		mu.Lock()
+		defer mu.Unlock()
+		require.Len(t, logged, 1, "expected exactly one retried-failure log line")
+		assert.Contains(t, logged[0], "retrying range download")
+		assert.Contains(t, logged[0], "503")
 	})
 }

--- a/go/libraries/doltcore/remotestorage/stats.go
+++ b/go/libraries/doltcore/remotestorage/stats.go
@@ -25,6 +25,7 @@ import (
 	"github.com/fatih/color"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/dconfig"
+	"github.com/dolthub/dolt/go/store/nbs"
 )
 
 var StatsFactory func() StatsRecorder = NullStatsRecorderFactory
@@ -54,6 +55,44 @@ type StatsRecorder interface {
 	RecordDownloadAttemptStart(retry int, offset, size uint64)
 	RecordDownloadComplete(retry int, size uint64, d time.Duration)
 	WriteSummaryTo(io.Writer) error
+}
+
+// teeStatsRecorder returns a StatsRecorder that forwards every record callback
+// to |primary| (the process-global recorder, which also backs WriteSummaryTo)
+// and, when non-nil, to |extra| (a per-operation recorder threaded in by the
+// caller, e.g. the puller's push-log stats). When |extra| is nil, |primary| is
+// returned directly to avoid any per-callback overhead.
+func teeStatsRecorder(primary StatsRecorder, extra nbs.StatsRecorder) StatsRecorder {
+	if extra == nil {
+		return primary
+	}
+	return teeRecorder{primary: primary, extra: extra}
+}
+
+type teeRecorder struct {
+	primary StatsRecorder
+	extra   nbs.StatsRecorder
+}
+
+var _ StatsRecorder = teeRecorder{}
+
+func (t teeRecorder) RecordTimeToFirstByte(retry int, size uint64, d time.Duration) {
+	t.primary.RecordTimeToFirstByte(retry, size, d)
+	t.extra.RecordTimeToFirstByte(retry, size, d)
+}
+
+func (t teeRecorder) RecordDownloadAttemptStart(retry int, offset, size uint64) {
+	t.primary.RecordDownloadAttemptStart(retry, offset, size)
+	t.extra.RecordDownloadAttemptStart(retry, offset, size)
+}
+
+func (t teeRecorder) RecordDownloadComplete(retry int, size uint64, d time.Duration) {
+	t.primary.RecordDownloadComplete(retry, size, d)
+	t.extra.RecordDownloadComplete(retry, size, d)
+}
+
+func (t teeRecorder) WriteSummaryTo(w io.Writer) error {
+	return t.primary.WriteSummaryTo(w)
 }
 
 var _ StatsRecorder = NullStatsRecorder{}

--- a/go/store/datas/pull/fetch_stats.go
+++ b/go/store/datas/pull/fetch_stats.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pull
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/dolthub/dolt/go/store/nbs"
+)
+
+// fetchStatsRecorder is a per-pull implementation of nbs.StatsRecorder. It
+// accumulates aggregate counters about the byte ranges a remote ChunkFetcher
+// downloads, so they can be reported to the push log alongside the puller's own
+// stats.
+//
+// The bytes counted here are the lengths of the (possibly coalesced) ranges
+// downloaded over the wire, which include any "dark" bytes fetched between
+// requested chunks as a result of range coalescing. Contrast this with the
+// puller's fetchedSourceBytes, which counts only the decompressed bytes of the
+// chunks that were actually wanted; the difference between the two is the
+// coalescing + compression overhead.
+type fetchStatsRecorder struct {
+	completedDownloads atomic.Uint64
+	retries            atomic.Uint64
+	downloadedBytes    atomic.Uint64
+	inFlight           atomic.Int64
+	peakInFlight       atomic.Int64
+}
+
+var _ nbs.StatsRecorder = (*fetchStatsRecorder)(nil)
+
+func (s *fetchStatsRecorder) RecordTimeToFirstByte(retry int, size uint64, d time.Duration) {}
+
+func (s *fetchStatsRecorder) RecordDownloadAttemptStart(retry int, offset, size uint64) {
+	if retry == 0 {
+		// First attempt for a range: a logical download is now in flight,
+		// which (with one HTTP request per download goroutine at a time) is a
+		// proxy for the number of concurrent connections open.
+		n := s.inFlight.Add(1)
+		for {
+			peak := s.peakInFlight.Load()
+			if n <= peak || s.peakInFlight.CompareAndSwap(peak, n) {
+				break
+			}
+		}
+	} else {
+		s.retries.Add(1)
+	}
+}
+
+func (s *fetchStatsRecorder) RecordDownloadComplete(retry int, size uint64, d time.Duration) {
+	s.completedDownloads.Add(1)
+	s.downloadedBytes.Add(size)
+	// NB: a range download that fails terminally never reaches here, so a
+	// failed pull may leave inFlight overcounted. That is acceptable: a
+	// terminal failure aborts the whole pull, so no further stats are logged.
+	s.inFlight.Add(-1)
+}
+
+// fetchStats is an immutable snapshot of a fetchStatsRecorder.
+type fetchStats struct {
+	CompletedDownloads uint64
+	Retries            uint64
+	// DownloadedBytes is the total bytes downloaded over the wire, including
+	// dark bytes fetched as part of range coalescing.
+	DownloadedBytes uint64
+	InFlight        int64
+	PeakInFlight    int64
+}
+
+func (s *fetchStatsRecorder) read() fetchStats {
+	return fetchStats{
+		CompletedDownloads: s.completedDownloads.Load(),
+		Retries:            s.retries.Load(),
+		DownloadedBytes:    s.downloadedBytes.Load(),
+		InFlight:           s.inFlight.Load(),
+		PeakInFlight:       s.peakInFlight.Load(),
+	}
+}

--- a/go/store/datas/pull/pull_chunk_fetcher.go
+++ b/go/store/datas/pull/pull_chunk_fetcher.go
@@ -29,12 +29,17 @@ type GetManyer interface {
 }
 
 type ChunkFetcherable interface {
-	ChunkFetcher(ctx context.Context) nbs.ChunkFetcher
+	ChunkFetcher(ctx context.Context, recorder nbs.StatsRecorder) nbs.ChunkFetcher
 }
 
-func GetChunkFetcher(ctx context.Context, cs GetManyer) nbs.ChunkFetcher {
+// GetChunkFetcher returns a ChunkFetcher for |cs|. If |cs| is capable of
+// producing its own fetcher (e.g. a remote chunk store with range coalescing
+// and concurrent downloads), |recorder|, if non-nil, is threaded into it to
+// receive per-download statistics. The fallback PullChunkFetcher does no
+// ranged downloads, so |recorder| is unused in that case.
+func GetChunkFetcher(ctx context.Context, cs GetManyer, recorder nbs.StatsRecorder) nbs.ChunkFetcher {
 	if fable, ok := cs.(ChunkFetcherable); ok {
-		return fable.ChunkFetcher(ctx)
+		return fable.ChunkFetcher(ctx, recorder)
 	}
 	return NewPullChunkFetcher(cs)
 }

--- a/go/store/datas/pull/puller.go
+++ b/go/store/datas/pull/puller.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"math"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -55,6 +54,7 @@ type Puller struct {
 
 	wr *PullTableFileWriter
 
+	tempDir string
 	pushLog *log.Logger
 
 	statsCh chan Stats
@@ -121,23 +121,13 @@ func NewPuller(
 		GetAddrs:             getAddrs,
 	})
 
-	var pushLogger *log.Logger
-	if dbg, ok := os.LookupEnv(dconfig.EnvPushLog); ok && strings.EqualFold(dbg, "true") {
-		logFilePath := filepath.Join(tempDir, "push.log")
-		f, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.ModePerm)
-
-		if err == nil {
-			pushLogger = log.New(f, "", log.Lmicroseconds)
-		}
-	}
-
 	p := &Puller{
 		waf:           walkAddrs,
 		srcChunkStore: srcChunkStore,
 		sinkDBCS:      sinkCS,
 		hashes:        hash.NewHashSet(hashes...),
 		wr:            wr,
-		pushLog:       pushLogger,
+		tempDir:       tempDir,
 		statsCh:       statsCh,
 		stats: &stats{
 			wrStatsGetter: wr.GetStats,
@@ -183,7 +173,7 @@ func (c countingReader) Read(p []byte) (int, error) {
 	return n, err
 }
 
-func emitStats(s *stats, ch chan Stats) (cancel func()) {
+func emitStats(s *stats, ch chan Stats, logf func(string, ...interface{})) (cancel func()) {
 	done := make(chan struct{})
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -248,12 +238,20 @@ func emitStats(s *stats, ch chan Stats) (cancel func()) {
 		updateduration := 1 * time.Second
 		ticker := time.NewTicker(updateduration)
 		defer ticker.Stop()
+		emit := func(st Stats) {
+			if ch != nil {
+				ch <- st
+			}
+			logf("stats: fetched %d/%d chunks, %d bytes (%.0f B/s); sent %d bytes, buffered %d bytes (%.0f B/s)",
+				st.FetchedSourceChunks, st.TotalSourceChunks, st.FetchedSourceBytes, st.FetchedSourceBytesPerSec,
+				st.FinishedSendBytes, st.BufferedSendBytes, st.SendBytesPerSec)
+		}
 		for {
 			select {
 			case <-ticker.C:
-				ch <- s.read()
+				emit(s.read())
 			case <-done:
-				ch <- s.read()
+				emit(s.read())
 				return
 			}
 		}
@@ -314,8 +312,24 @@ func WithDiscardingStatsCh(cb func(statsCh chan Stats)) {
 
 // Pull executes the sync operation
 func (p *Puller) Pull(ctx context.Context) error {
-	if p.statsCh != nil {
-		c := emitStats(p.stats, p.statsCh)
+	// If push logging is enabled, create a unique log file for this pull
+	// operation and close it when the pull completes.
+	if dbg, ok := os.LookupEnv(dconfig.EnvPushLog); ok && strings.EqualFold(dbg, "true") {
+		f, err := os.CreateTemp(p.tempDir, "push-*.log")
+		if err == nil {
+			p.pushLog = log.New(f, "", log.LstdFlags|log.Lmicroseconds)
+			p.Logf("starting pull of %d hashes", p.hashes.Size())
+			defer func() {
+				p.Logf("pull complete")
+				f.Close()
+			}()
+		}
+	}
+
+	// Run stats emission if anyone is consuming the stats channel or if we are
+	// logging stats to the push log.
+	if p.statsCh != nil || p.pushLog != nil {
+		c := emitStats(p.stats, p.statsCh, p.Logf)
 		defer c()
 	}
 

--- a/go/store/datas/pull/puller.go
+++ b/go/store/datas/pull/puller.go
@@ -131,10 +131,17 @@ func NewPuller(
 		statsCh:       statsCh,
 		stats: &stats{
 			wrStatsGetter: wr.GetStats,
+			fetcher:       &fetchStatsRecorder{},
 		},
 	}
 
+	// Route chunk store debug logging into the push log. For a push, the sink
+	// is the remote store; for a fetch, the source is. Wire both so either
+	// operation's remote-side messages are captured.
 	if lcs, ok := sinkCS.(chunks.LoggingChunkStore); ok {
+		lcs.SetLogger(p)
+	}
+	if lcs, ok := srcCS.(chunks.LoggingChunkStore); ok {
 		lcs.SetLogger(p)
 	}
 
@@ -242,8 +249,25 @@ func emitStats(s *stats, ch chan Stats, logf func(string, ...interface{})) (canc
 			if ch != nil {
 				ch <- st
 			}
-			logf("stats: fetched %d/%d chunks, %d bytes (%.0f B/s); sent %d bytes, buffered %d bytes (%.0f B/s)",
-				st.FetchedSourceChunks, st.TotalSourceChunks, st.FetchedSourceBytes, st.FetchedSourceBytesPerSec,
+			fs := s.fetcher.read()
+			compBytes := atomic.LoadUint64(&s.fetchedSourceCompBytes)
+			// Source side counters:
+			//   chunks            - wanted chunks received / total requested
+			//   uncompressed      - decompressed size of the wanted chunks
+			//   compressed        - on-wire (snappy) size of just the wanted chunks
+			//   wire              - bytes actually downloaded, including dark bytes
+			//                       pulled in by range coalescing (wire - compressed
+			//                       ~= coalescing overhead)
+			//   fetch_rate        - uncompressed bytes/sec
+			//   range_downloads   - completed coalesced range downloads (and retries)
+			//   inflight/peak     - concurrent range downloads in flight
+			// Sink side counters:
+			//   sent/buffered     - table file bytes written to / queued for the dest
+			//   send_rate         - sent bytes/sec
+			logf("stats: source[chunks=%d/%d uncompressed=%dB compressed=%dB wire=%dB fetch_rate=%.0fB/s range_downloads=%d retries=%d inflight=%d peak=%d] sink[sent=%dB buffered=%dB send_rate=%.0fB/s]",
+				st.FetchedSourceChunks, st.TotalSourceChunks,
+				st.FetchedSourceBytes, compBytes, fs.DownloadedBytes, st.FetchedSourceBytesPerSec,
+				fs.CompletedDownloads, fs.Retries, fs.InFlight, fs.PeakInFlight,
 				st.FinishedSendBytes, st.BufferedSendBytes, st.SendBytesPerSec)
 		}
 		for {
@@ -266,9 +290,14 @@ type stats struct {
 	totalSourceChunks         uint64
 	fetchedSourceChunks       uint64
 	fetchedSourceBytes        uint64
+	fetchedSourceCompBytes    uint64
 	fetchedSourceBytesPerSec  uint64
 	sendBytesPerSecF          float64
 	fetchedSourceBytesPerSecF float64
+
+	// fetcher accumulates download stats reported by the source ChunkFetcher
+	// (bytes fetched over the wire including dark bytes, download concurrency).
+	fetcher *fetchStatsRecorder
 }
 
 type Stats struct {
@@ -335,7 +364,7 @@ func (p *Puller) Pull(ctx context.Context) error {
 
 	eg, ctx := errgroup.WithContext(ctx)
 
-	rd := GetChunkFetcher(ctx, p.srcChunkStore)
+	rd := GetChunkFetcher(ctx, p.srcChunkStore, p.stats.fetcher)
 
 	const batchSize = 64 * 1024
 	tracker := NewPullChunkTracker(TrackerConfig{
@@ -407,6 +436,10 @@ func (p *Puller) Pull(ctx context.Context) error {
 			}
 
 			atomic.AddUint64(&p.stats.fetchedSourceChunks, uint64(1))
+			// CompressedSize is the on-the-wire (snappy-compressed) size of
+			// just this wanted chunk, excluding any dark bytes pulled in by
+			// range coalescing (those are tracked by the fetcher recorder).
+			atomic.AddUint64(&p.stats.fetchedSourceCompBytes, uint64(cChk.CompressedSize()))
 
 			chnk, err := cChk.ToChunk()
 			if err != nil {

--- a/go/store/nbs/chunk_fetcher.go
+++ b/go/store/nbs/chunk_fetcher.go
@@ -16,6 +16,7 @@ package nbs
 
 import (
 	"context"
+	"time"
 
 	"github.com/dolthub/dolt/go/store/hash"
 )
@@ -49,4 +50,32 @@ type ChunkFetcher interface {
 	Recv(context.Context) (ToChunker, error)
 
 	Close() error
+}
+
+// StatsRecorder is an optional sink, supplied by the caller that creates a
+// ChunkFetcher, which receives callbacks as the fetcher downloads byte ranges
+// from the underlying ChunkStore. It is defined here, in a package both the
+// puller (store/datas/pull) and the remote chunk store
+// (libraries/doltcore/remotestorage) depend on, so that a per-operation
+// recorder can be threaded into the fetcher without an import cycle.
+//
+// The |size| reported to these callbacks is the length of the (possibly
+// coalesced) byte range being downloaded, which includes any "dark" bytes
+// fetched between requested chunks as a result of range coalescing. This is
+// distinct from the number of decompressed chunk bytes ultimately delivered to
+// the caller.
+//
+// Implementations must be safe for concurrent use; callbacks fire from multiple
+// download goroutines.
+type StatsRecorder interface {
+	// RecordTimeToFirstByte is called once per download attempt, after the
+	// response headers for the range request have been received.
+	RecordTimeToFirstByte(retry int, size uint64, d time.Duration)
+	// RecordDownloadAttemptStart is called at the start of every download
+	// attempt for a range. |retry| is 0 for the first attempt and increments
+	// for each subsequent retry of the same range.
+	RecordDownloadAttemptStart(retry int, offset, size uint64)
+	// RecordDownloadComplete is called once per range, after the entire range
+	// has been successfully downloaded (across any retries).
+	RecordDownloadComplete(retry int, size uint64, d time.Duration)
 }


### PR DESCRIPTION
If you set `PUSH_LOG=true` when running `dolt pull`, `dolt fetch` or `dolt push`, some extra logging output will appear in `.dolt/temptf/push-*.log`.