### PR TITLE
go: sqle/clusterdb: Fix spurious error logs. Interact with quiescable events database protocol.

### DIFF
--- a/go/libraries/doltcore/sqle/clusterdb/database.go
+++ b/go/libraries/doltcore/sqle/clusterdb/database.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/dolthub/go-mysql-server/sql"
 
@@ -85,6 +86,48 @@ func (database) SaveStoredProcedure(ctx *sql.Context, spd sql.StoredProcedureDet
 
 func (database) DropStoredProcedure(ctx *sql.Context, name string) error {
 	return errors.New("unimplemented")
+}
+
+// Implement EventDatabase (and QuiescableEventDatabase) as no-ops. The cluster database never has
+// events, but the event scheduler wraps every catalog database in a mysql_db.PrivilegedDatabase,
+// which exposes the sql.EventDatabase interface unconditionally and returns
+// sql.ErrEventsNotSupported when the underlying database doesn't implement events. Without these
+// no-op implementations the event executor logs "unable to determine if events need to be
+// reloaded: database 'dolt_cluster' doesn't support events", short-circuits its reload check for
+// every database iterated after dolt_cluster, and is prevented from ever quiescing.
+var _ sql.EventDatabase = database{}
+var _ sql.QuiescableEventDatabase = database{}
+
+func (database) GetEvent(ctx *sql.Context, name string) (sql.EventDefinition, bool, error) {
+	return sql.EventDefinition{}, false, nil
+}
+
+func (database) GetEvents(ctx *sql.Context) ([]sql.EventDefinition, interface{}, error) {
+	return nil, nil, nil
+}
+
+func (database) SaveEvent(ctx *sql.Context, ed sql.EventDefinition) (bool, error) {
+	return false, errors.New("unimplemented")
+}
+
+func (database) DropEvent(ctx *sql.Context, name string) error {
+	return errors.New("unimplemented")
+}
+
+func (database) UpdateEvent(ctx *sql.Context, originalName string, ed sql.EventDefinition) (bool, error) {
+	return false, errors.New("unimplemented")
+}
+
+func (database) UpdateLastExecuted(ctx *sql.Context, eventName string, lastExecuted time.Time) error {
+	return errors.New("unimplemented")
+}
+
+func (database) NeedsToReloadEvents(ctx *sql.Context, token interface{}) (bool, error) {
+	return false, nil
+}
+
+func (database) QuiescableEvents() bool {
+	return true
 }
 
 var _ sql.ViewDatabase = database{}

--- a/go/libraries/doltcore/sqle/clusterdb/database_test.go
+++ b/go/libraries/doltcore/sqle/clusterdb/database_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterdb
+
+import (
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/mysql_db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClusterDatabaseEventsDoNotError asserts that the dolt_cluster database does not cause the
+// event scheduler to log:
+//
+//	"unable to determine if events need to be reloaded: database 'dolt_cluster' doesn't support events"
+//
+// The event executor iterates the catalog's databases, each wrapped in a
+// mysql_db.PrivilegedDatabase. PrivilegedDatabase exposes the sql.EventDatabase interface
+// unconditionally, returning sql.ErrEventsNotSupported when the underlying database does not
+// implement events. That error is logged (and short-circuits the reload check for all databases
+// iterated after dolt_cluster, and disables event-executor quiescing). The cluster database must
+// therefore implement sql.EventDatabase as a no-op so NeedsToReloadEvents returns (false, nil).
+func TestClusterDatabaseEventsDoNotError(t *testing.T) {
+	db := NewClusterDatabase(nil)
+
+	// The cluster database must implement sql.EventDatabase as a no-op. Without this, the
+	// PrivilegedDatabase wrapper returns ErrEventsNotSupported for dolt_cluster.
+	edb, ok := db.(sql.EventDatabase)
+	require.True(t, ok, "cluster database must implement sql.EventDatabase so the event scheduler does not error")
+
+	needsReload, err := edb.NeedsToReloadEvents(nil, nil)
+	require.NoError(t, err)
+	assert.False(t, needsReload)
+
+	events, _, err := edb.GetEvents(nil)
+	require.NoError(t, err)
+	assert.Empty(t, events)
+
+	// Reproduce the exact path the event executor takes: it wraps databases in a
+	// PrivilegedDatabase, which is the actual source of the ErrEventsNotSupported error seen in
+	// the logs. NeedsToReloadEvents must not return an error (that error is what gets logged).
+	pdb := mysql_db.NewPrivilegedDatabase(nil, db, nil)
+
+	pedb, ok := pdb.(sql.EventDatabase)
+	require.True(t, ok)
+	needsReload, err = pedb.NeedsToReloadEvents(nil, nil)
+	require.NoError(t, err, "PrivilegedDatabase wrapping dolt_cluster must not error on NeedsToReloadEvents")
+	assert.False(t, needsReload)
+
+	// dolt_cluster must not prevent the event executor from quiescing when there are no events.
+	qedb, ok := pdb.(sql.QuiescableEventDatabase)
+	require.True(t, ok)
+	assert.True(t, qedb.QuiescableEvents(), "dolt_cluster must not block event-executor quiescing")
+}


### PR DESCRIPTION
This also enables quiesced event reloads even when cluster replication is enabled.