### PR TITLE
Fix slow clone/fetch from git remotes

### DIFF
--- a/go/store/blobstore/git_blobstore.go
+++ b/go/store/blobstore/git_blobstore.go
@@ -1011,6 +1011,12 @@ func (gbs *GitBlobstore) Exists(ctx context.Context, key string) (bool, error) {
 	return ok, nil
 }
 
+// RangeReadsStreamWholeBlob reports that a ranged Get streams the whole blob,
+// because git cat-file has no server-side range and must read from byte zero.
+func (gbs *GitBlobstore) RangeReadsStreamWholeBlob() bool {
+	return true
+}
+
 func (gbs *GitBlobstore) Get(ctx context.Context, key string, br BlobRange) (io.ReadCloser, uint64, string, error) {
 	key, err := normalizeGitTreePath(key)
 	if err != nil {

--- a/go/store/blobstore/git_blobstore.go
+++ b/go/store/blobstore/git_blobstore.go
@@ -1011,11 +1011,13 @@ func (gbs *GitBlobstore) Exists(ctx context.Context, key string) (bool, error) {
 	return ok, nil
 }
 
-// RangeReadsStreamWholeBlob reports that a ranged Get streams the whole blob,
-// because git cat-file has no server-side range and must read from byte zero.
-func (gbs *GitBlobstore) RangeReadsStreamWholeBlob() bool {
+// RangeReadsWholeBlob reports that a ranged Get streams the whole blob, because git
+// cat-file has no server-side range and must read from byte zero.
+func (gbs *GitBlobstore) RangeReadsWholeBlob() bool {
 	return true
 }
+
+var _ interface{ RangeReadsWholeBlob() bool } = (*GitBlobstore)(nil)
 
 func (gbs *GitBlobstore) Get(ctx context.Context, key string, br BlobRange) (io.ReadCloser, uint64, string, error) {
 	key, err := normalizeGitTreePath(key)

--- a/go/store/blobstore/git_blobstore.go
+++ b/go/store/blobstore/git_blobstore.go
@@ -1101,6 +1101,7 @@ func (gbs *GitBlobstore) validateAndSizeChunkedParts(ctx context.Context, entrie
 	}
 
 	parts := make([]chunkPartRef, 0, len(entries))
+	oids := make([]git.OID, len(entries))
 	var total uint64
 	for i, e := range entries {
 		if e.Type != git.ObjectTypeBlob {
@@ -1120,11 +1121,20 @@ func (gbs *GitBlobstore) validateAndSizeChunkedParts(ctx context.Context, entrie
 		if want := fmt.Sprintf("%0*d", gitblobstorePartNameWidth, n); want != e.Name {
 			return nil, 0, fmt.Errorf("gitblobstore: invalid part name %q (expected %q)", e.Name, want)
 		}
+		oids[i] = e.OID
+	}
 
-		sz, err := gbs.api.BlobSize(ctx, e.OID)
-		if err != nil {
-			return nil, 0, err
-		}
+	// Size every part in one cat-file process rather than one per part.
+	sizes, err := gbs.api.BlobSizes(ctx, oids)
+	if err != nil {
+		return nil, 0, err
+	}
+	if len(sizes) != len(oids) {
+		return nil, 0, fmt.Errorf("gitblobstore: expected %d part sizes, got %d", len(oids), len(sizes))
+	}
+
+	for i, e := range entries {
+		sz := sizes[i]
 		if sz < 0 {
 			return nil, 0, fmt.Errorf("gitblobstore: invalid part size %d for %q", sz, e.Name)
 		}

--- a/go/store/blobstore/git_blobstore_helpers_test.go
+++ b/go/store/blobstore/git_blobstore_helpers_test.go
@@ -69,6 +69,20 @@ func (f fakeGitAPI) BlobSize(ctx context.Context, oid git.OID) (int64, error) {
 func (f fakeGitAPI) BlobReader(ctx context.Context, oid git.OID) (io.ReadCloser, error) {
 	return f.blobReader(ctx, oid)
 }
+func (f fakeGitAPI) BlobSizes(ctx context.Context, oids []git.OID) ([]int64, error) {
+	if len(oids) == 0 {
+		return nil, nil
+	}
+	sizes := make([]int64, len(oids))
+	for i, oid := range oids {
+		sz, err := f.blobSize(ctx, oid)
+		if err != nil {
+			return nil, err
+		}
+		sizes[i] = sz
+	}
+	return sizes, nil
+}
 func (f fakeGitAPI) HashObject(ctx context.Context, contents io.Reader) (git.OID, error) {
 	panic("unexpected call")
 }

--- a/go/store/blobstore/internal/git/api.go
+++ b/go/store/blobstore/internal/git/api.go
@@ -69,6 +69,9 @@ type GitAPI interface {
 	// BlobReader returns a reader for blob contents.
 	BlobReader(ctx context.Context, oid OID) (io.ReadCloser, error)
 
+	// BlobSizes returns the sizes of |oids| in the same order, and an error if any is missing.
+	BlobSizes(ctx context.Context, oids []OID) ([]int64, error)
+
 	// HashObject writes a new blob object for the provided contents and returns its OID.
 	// Equivalent plumbing:
 	//   GIT_DIR=... git hash-object -w --stdin

--- a/go/store/blobstore/internal/git/impl.go
+++ b/go/store/blobstore/internal/git/impl.go
@@ -15,6 +15,7 @@
 package git
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -194,6 +195,57 @@ func (a *GitAPIImpl) BlobSize(ctx context.Context, oid OID) (int64, error) {
 func (a *GitAPIImpl) BlobReader(ctx context.Context, oid OID) (io.ReadCloser, error) {
 	rc, _, err := a.r.Start(ctx, RunOptions{}, "cat-file", "blob", oid.String())
 	return rc, err
+}
+
+func (a *GitAPIImpl) BlobSizes(ctx context.Context, oids []OID) ([]int64, error) {
+	if len(oids) == 0 {
+		return nil, nil
+	}
+	// git cat-file --batch-check emits one header line per input OID, in order.
+	var in bytes.Buffer
+	for _, oid := range oids {
+		fmt.Fprintln(&in, oid)
+	}
+	rc, _, err := a.r.Start(ctx, RunOptions{Stdin: &in}, "cat-file", "--batch-check=%(objectname) %(objecttype) %(objectsize)")
+	if err != nil {
+		return nil, err
+	}
+	br := bufio.NewReader(rc)
+	sizes := make([]int64, len(oids))
+	for i := range oids {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			return nil, errors.Join(rc.Close(), fmt.Errorf("git cat-file --batch-check: reading size for %s: %w", oids[i], err))
+		}
+		sizes[i], err = parseBatchHeaderSize(line, oids[i])
+		if err != nil {
+			return nil, errors.Join(rc.Close(), err)
+		}
+	}
+	if err := rc.Close(); err != nil {
+		return nil, err
+	}
+	return sizes, nil
+}
+
+// parseBatchHeaderSize parses the size from |header|, a git cat-file --batch or --batch-check
+// line for |oid| of the form "<oid> <type> <size>". A missing or ambiguous object is an error.
+func parseBatchHeaderSize(header string, oid OID) (int64, error) {
+	fields := strings.Fields(header)
+	if len(fields) > 0 && fields[0] != oid.String() {
+		return 0, fmt.Errorf("git cat-file: response for %q does not match requested %s", fields[0], oid)
+	}
+	if len(fields) == 2 {
+		return 0, fmt.Errorf("git cat-file: object %s %s", oid, fields[1])
+	}
+	if len(fields) != 3 {
+		return 0, fmt.Errorf("git cat-file: unexpected header %q for %s", strings.TrimSpace(header), oid)
+	}
+	size, err := strconv.ParseInt(fields[2], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("git cat-file: parse size %q for %s: %w", fields[2], oid, err)
+	}
+	return size, nil
 }
 
 func (a *GitAPIImpl) HashObject(ctx context.Context, contents io.Reader) (OID, error) {

--- a/go/store/blobstore/internal/git/impl_test.go
+++ b/go/store/blobstore/internal/git/impl_test.go
@@ -19,12 +19,46 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/dolthub/dolt/go/store/testutils/gitrepo"
 )
+
+// TestMain allows the test binary to impersonate deterministic helper commands
+// in place of git for the cmdReadCloser tests.
+func TestMain(m *testing.M) {
+	// See https://abhinavg.net/2022/05/15/hijack-testmain/
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "stdoutfail":
+			_, _ = os.Stdout.WriteString("abc")
+			os.Exit(3)
+		case "yes":
+			// Dies of SIGPIPE on Unix once the pipe closes. Windows has no signals,
+			// so exit nonzero by hand when the write fails.
+			for {
+				if _, err := os.Stdout.WriteString("y\n"); err != nil {
+					os.Exit(3)
+				}
+			}
+		}
+	}
+	os.Exit(m.Run())
+}
+
+// helperCommandRunner returns a Runner that re-executes this test binary, so the
+// helper commands in TestMain can act as the child process.
+func helperCommandRunner(t *testing.T) *Runner {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return NewRunnerWithGitPath(t.TempDir(), exe)
+}
 
 func testAuthor() *Identity {
 	return &Identity{Name: "gitapi test", Email: "gitapi@test.invalid"}
@@ -1093,5 +1127,58 @@ func TestParseBatchHeaderSize(t *testing.T) {
 				t.Fatalf("error %q does not contain %q", err, tc.wantErrContains)
 			}
 		})
+	}
+}
+
+func TestCmdReadCloser_EarlyCloseSwallowsWaitError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := helperCommandRunner(t)
+
+	// A writer that never exits is still writing whenever we close, regardless of pipe buffer sizes.
+	rc, cmd, err := r.Start(ctx, RunOptions{}, "yes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadFull(rc, make([]byte, 16)); err != nil {
+		t.Fatal(err)
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatalf("early Close must swallow the broken-pipe exit, got: %v", err)
+	}
+	if cmd.ProcessState == nil {
+		t.Fatal("Close must reap the child process (no zombie)")
+	}
+}
+
+func TestCmdReadCloser_DrainedNonZeroExitSurfaces(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := helperCommandRunner(t)
+
+	rc, _, err := r.Start(ctx, RunOptions{}, "stdoutfail")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "abc" {
+		t.Fatalf("stdout: got %q, want %q", got, "abc")
+	}
+
+	err = rc.Close()
+	if err == nil {
+		t.Fatal("a non-zero exit after a full drain must surface, got nil")
+	}
+	var ce *CmdError
+	if !errors.As(err, &ce) {
+		t.Fatalf("expected a *CmdError in the chain, got %T: %v", err, err)
+	}
+	if ce.ExitCode != 3 {
+		t.Fatalf("exit code: got %d, want 3", ce.ExitCode)
 	}
 }

--- a/go/store/blobstore/internal/git/impl_test.go
+++ b/go/store/blobstore/internal/git/impl_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"io"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/dolthub/dolt/go/store/testutils/gitrepo"
@@ -989,5 +990,108 @@ func TestGitAPIImpl_PushRefWithLease_CreatesWhenMissing(t *testing.T) {
 	}
 	if got != l1 {
 		t.Fatalf("remote ref mismatch after bootstrap push: got %q, want %q", got, l1)
+	}
+}
+
+func TestGitAPIImpl_BlobSizes(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	_, _, api := newTestRepo(t, ctx)
+
+	blobs := [][]byte{
+		[]byte("one"),
+		[]byte("two two"),
+		bytes.Repeat([]byte("x"), 1234),
+	}
+	oids := make([]OID, len(blobs))
+	for i, b := range blobs {
+		oid, err := api.HashObject(ctx, bytes.NewReader(b))
+		if err != nil {
+			t.Fatal(err)
+		}
+		oids[i] = oid
+	}
+
+	sizes, err := api.BlobSizes(ctx, oids)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sizes) != len(blobs) {
+		t.Fatalf("expected %d sizes, got %d", len(blobs), len(sizes))
+	}
+	for i, b := range blobs {
+		if sizes[i] != int64(len(b)) {
+			t.Errorf("size[%d]: got %d, want %d", i, sizes[i], len(b))
+		}
+	}
+
+	got, err := api.BlobSizes(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil for empty input, got %v", got)
+	}
+}
+
+func TestGitAPIImpl_BlobSizes_MissingOID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	_, _, api := newTestRepo(t, ctx)
+
+	present, err := api.HashObject(ctx, bytes.NewReader([]byte("present")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	missing := OID("2222222222222222222222222222222222222222")
+
+	_, err = api.BlobSizes(ctx, []OID{present, missing})
+	if err == nil {
+		t.Fatal("expected an error for a missing oid, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing") {
+		t.Fatalf("error %q does not mention the missing object", err)
+	}
+}
+
+func TestParseBatchHeaderSize(t *testing.T) {
+	t.Parallel()
+
+	oid := OID("1111111111111111111111111111111111111111")
+	other := "2222222222222222222222222222222222222222"
+	cases := []struct {
+		name            string
+		header          string
+		want            int64
+		wantErrContains string // "" means expect success
+	}{
+		{"valid", oid.String() + " blob 5\n", 5, ""},
+		{"missing", oid.String() + " missing\n", 0, "missing"},
+		{"ambiguous", oid.String() + " ambiguous\n", 0, "ambiguous"},
+		{"desync", other + " blob 5\n", 0, "does not match"},
+		{"unparseable", oid.String() + " blob notanumber\n", 0, "parse size"},
+		{"empty", "\n", 0, "unexpected header"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseBatchHeaderSize(tc.header, oid)
+			if tc.wantErrContains == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got != tc.want {
+					t.Fatalf("size: got %d, want %d", got, tc.want)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected an error containing %q, got nil", tc.wantErrContains)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrContains) {
+				t.Fatalf("error %q does not contain %q", err, tc.wantErrContains)
+			}
+		})
 	}
 }

--- a/go/store/blobstore/internal/git/runner.go
+++ b/go/store/blobstore/internal/git/runner.go
@@ -208,19 +208,32 @@ func (r *Runner) Start(ctx context.Context, opts RunOptions, args ...string) (io
 }
 
 type cmdReadCloser struct {
-	r      io.ReadCloser
-	cmd    *exec.Cmd
-	stderr *bytes.Buffer
-	args   []string
-	dir    string
+	r       io.ReadCloser
+	cmd     *exec.Cmd
+	stderr  *bytes.Buffer
+	args    []string
+	dir     string
+	drained bool // set once Read reaches io.EOF, so stdout was fully consumed
 }
 
-func (c *cmdReadCloser) Read(p []byte) (int, error) { return c.r.Read(p) }
+func (c *cmdReadCloser) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	if errors.Is(err, io.EOF) {
+		c.drained = true
+	}
+	return n, err
+}
 
 func (c *cmdReadCloser) Close() error {
 	_ = c.r.Close()
 	err := c.cmd.Wait()
 	if err == nil {
+		return nil
+	}
+	// A close before stdout was drained kills the still writing child with a closed
+	// pipe, which is expected. Checking our own drained flag is portable, while the
+	// child's exit text names the broken pipe signal only on Unix.
+	if !c.drained {
 		return nil
 	}
 	exitCode := 0

--- a/go/store/nbs/archive_reader.go
+++ b/go/store/nbs/archive_reader.go
@@ -554,11 +554,8 @@ func (ar *archiveReader) count() uint32 {
 }
 
 func (ar *archiveReader) close() error {
-	err := ar.indexReader.Close()
-	if err != nil {
-		return err
-	}
-	return ar.reader.Close()
+	// Join the errors so the reader still closes and releases its file when the index close fails.
+	return errors.Join(ar.indexReader.Close(), ar.reader.Close())
 }
 
 // readByteSpan reads the byte span from the archive. This allocates a new byte slice and returns it to the caller.

--- a/go/store/nbs/bs_persister.go
+++ b/go/store/nbs/bs_persister.go
@@ -355,6 +355,10 @@ func (bsTRA *bsTableReaderAt) ReadAtWithStats(ctx context.Context, p []byte, off
 }
 
 func newBSArchiveChunkSource(ctx context.Context, bs blobstore.Blobstore, name hash.Hash, q MemoryQuotaProvider, stats *Stats) (cs chunkSource, err error) {
+	if shouldSpool(bs) {
+		return newSpooledBSArchiveChunkSource(ctx, bs, name, q, stats)
+	}
+
 	rc, sz, _, err := bs.Get(ctx, name.String()+ArchiveFileSuffix, blobstore.NewBlobRange(-int64(archiveFooterSize), 0))
 	if err != nil {
 		return nil, err
@@ -375,6 +379,10 @@ func newBSArchiveChunkSource(ctx context.Context, bs blobstore.Blobstore, name h
 }
 
 func newBSTableChunkSource(ctx context.Context, bs blobstore.Blobstore, name hash.Hash, chunkCount uint32, q MemoryQuotaProvider, stats *Stats) (cs chunkSource, err error) {
+	if shouldSpool(bs) {
+		return newSpooledBSTableChunkSource(ctx, bs, name, chunkCount, q, stats)
+	}
+
 	index, err := loadTableIndex(ctx, stats, chunkCount, q, func(p []byte) error {
 		rc, _, _, err := bs.Get(ctx, name.String(), blobstore.NewBlobRange(-int64(len(p)), 0))
 		if err != nil {

--- a/go/store/nbs/spooling_table_reader.go
+++ b/go/store/nbs/spooling_table_reader.go
@@ -1,0 +1,154 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nbs
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"sync/atomic"
+	"time"
+
+	"github.com/dolthub/dolt/go/libraries/utils/dynassert"
+	"github.com/dolthub/dolt/go/libraries/utils/file"
+	"github.com/dolthub/dolt/go/store/blobstore"
+	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/dolthub/dolt/go/store/util/tempfiles"
+)
+
+// wholeBlobRangeBlobstore is implemented by a Blobstore whose ranged Get streams the
+// whole blob regardless of the requested range, making tables cheaper to spool once.
+type wholeBlobRangeBlobstore interface {
+	RangeReadsStreamWholeBlob() bool
+}
+
+// shouldSpool reports whether |bs| needs its table files spooled to a local temp file.
+func shouldSpool(bs blobstore.Blobstore) bool {
+	s, ok := bs.(wholeBlobRangeBlobstore)
+	return ok && s.RangeReadsStreamWholeBlob()
+}
+
+// spoolingTableReaderAt serves random ReadAt over a blob that cannot do cheap ranged
+// reads. The whole blob is spooled once into a local temp file at construction. Every
+// read is served from that file, whose lifetime is bound to the open chunk source.
+type spoolingTableReaderAt struct {
+	f   *os.File
+	sz  int64
+	cnt *int32 // clone() increments and Close() decrements it. The temp file is removed at zero.
+}
+
+// newSpoolingTableReaderAt streams the whole blob |key| from |bs| into a temp file.
+func newSpoolingTableReaderAt(ctx context.Context, bs blobstore.Blobstore, key string) (*spoolingTableReaderAt, error) {
+	rc, _, _, err := bs.Get(ctx, key, blobstore.AllRange)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+
+	f, err := tempfiles.MovableTempFileProvider.NewFile("", "nbs-spool-")
+	if err != nil {
+		return nil, err
+	}
+	sz, err := io.Copy(f, rc)
+	if err != nil {
+		f.Close()
+		_ = file.Remove(f.Name())
+		return nil, err
+	}
+	cnt := int32(1)
+	return &spoolingTableReaderAt{f: f, sz: sz, cnt: &cnt}, nil
+}
+
+func (s *spoolingTableReaderAt) ReadAtWithStats(ctx context.Context, p []byte, off int64, stats *Stats) (n int, err error) {
+	t1 := time.Now()
+	defer func() {
+		stats.FileBytesPerRead.Sample(uint64(len(p)))
+		stats.FileReadLatency.SampleTimeSince(t1)
+	}()
+	return s.f.ReadAt(p, off)
+}
+
+// Reader returns a reader over the whole spooled file. [os.File.ReadAt] does not move
+// the file offset, so the returned [io.SectionReader] is safe alongside concurrent
+// ReadAt calls. Unlike fileReaderAt.Reader, it shares the open file and is only valid
+// until the owning chunk source is closed.
+func (s *spoolingTableReaderAt) Reader(ctx context.Context) (io.ReadCloser, error) {
+	return io.NopCloser(io.NewSectionReader(s.f, 0, s.sz)), nil
+}
+
+func (s *spoolingTableReaderAt) clone() (tableReaderAt, error) {
+	dynassert.Assert(atomic.AddInt32(s.cnt, 1) > 1, "attempt to clone a closed spoolingTableReaderAt")
+	c := *s
+	return &c, nil
+}
+
+func (s *spoolingTableReaderAt) Close() error {
+	cnt := atomic.AddInt32(s.cnt, -1)
+	dynassert.Assert(cnt >= 0, "invalid cnt on spoolingTableReaderAt")
+	if cnt != 0 {
+		return nil
+	}
+	name := s.f.Name()
+	return errors.Join(s.f.Close(), file.Remove(name))
+}
+
+// newSpooledBSTableChunkSource opens a table file by spooling it whole to a local temp
+// file once, then reading its index and serving chunk reads from that file.
+func newSpooledBSTableChunkSource(ctx context.Context, bs blobstore.Blobstore, name hash.Hash, chunkCount uint32, q MemoryQuotaProvider, stats *Stats) (chunkSource, error) {
+	ra, err := newSpoolingTableReaderAt(ctx, bs, name.String())
+	if err != nil {
+		return nil, err
+	}
+
+	index, err := loadTableIndex(ctx, stats, chunkCount, q, func(p []byte) error {
+		_, err := ra.f.ReadAt(p, ra.sz-int64(len(p)))
+		return err
+	})
+	if err != nil {
+		_ = ra.Close()
+		return nil, err
+	}
+
+	if chunkCount != index.chunkCount() {
+		_ = index.Close()
+		_ = ra.Close()
+		return nil, errors.New("unexpected chunk count")
+	}
+
+	tr, err := newTableReader(ctx, index, ra, s3BlockSize)
+	if err != nil {
+		_ = index.Close()
+		_ = ra.Close()
+		return nil, err
+	}
+	return &chunkSourceAdapter{tr, name}, nil
+}
+
+// newSpooledBSArchiveChunkSource is the archive counterpart of newSpooledBSTableChunkSource.
+// It spools the file whole, reads the footer, and serves chunk reads from the spooled file.
+func newSpooledBSArchiveChunkSource(ctx context.Context, bs blobstore.Blobstore, name hash.Hash, q MemoryQuotaProvider, stats *Stats) (chunkSource, error) {
+	ra, err := newSpoolingTableReaderAt(ctx, bs, name.String()+ArchiveFileSuffix)
+	if err != nil {
+		return nil, err
+	}
+
+	aRdr, err := newArchiveReader(ctx, ra, name, uint64(ra.sz), q, stats)
+	if err != nil {
+		_ = ra.Close()
+		return nil, err
+	}
+	return &archiveChunkSource{aRdr: aRdr, refs: noopRefCounter{}}, nil
+}

--- a/go/store/nbs/spooling_table_reader.go
+++ b/go/store/nbs/spooling_table_reader.go
@@ -75,18 +75,35 @@ func (s *spoolingTableReaderAt) ReadAtWithStats(ctx context.Context, p []byte, o
 	return s.f.ReadAt(p, off)
 }
 
-// Reader returns a reader over the whole spooled file. [os.File.ReadAt] does not move
-// the file offset, so the returned [io.SectionReader] is safe alongside concurrent
-// ReadAt calls. Unlike fileReaderAt.Reader, it shares the open file and is only valid
-// until the owning chunk source is closed.
+// Reader returns an independent reader over the whole spooled file. It holds its own
+// reference, so the reader stays valid until the caller closes it, even after the owning
+// chunk source is closed. [os.File.ReadAt] does not move the file offset, so the reader
+// is safe alongside concurrent ReadAt calls.
 func (s *spoolingTableReaderAt) Reader(ctx context.Context) (io.ReadCloser, error) {
-	return io.NopCloser(io.NewSectionReader(s.f, 0, s.sz)), nil
+	src := s.ref()
+	return &spoolFileReader{Reader: io.NewSectionReader(src.f, 0, src.sz), src: src}, nil
+}
+
+// spoolFileReader streams a spooled file while holding a reference to it, so the temp
+// file is not removed until the reader is closed.
+type spoolFileReader struct {
+	io.Reader
+	src *spoolingTableReaderAt
+}
+
+func (r *spoolFileReader) Close() error {
+	return r.src.Close()
+}
+
+// ref increments the reference count and returns a handle that shares the spooled file.
+func (s *spoolingTableReaderAt) ref() *spoolingTableReaderAt {
+	dynassert.Assert(atomic.AddInt32(s.cnt, 1) > 1, "attempt to reference a closed spoolingTableReaderAt")
+	c := *s
+	return &c
 }
 
 func (s *spoolingTableReaderAt) clone() (tableReaderAt, error) {
-	dynassert.Assert(atomic.AddInt32(s.cnt, 1) > 1, "attempt to clone a closed spoolingTableReaderAt")
-	c := *s
-	return &c, nil
+	return s.ref(), nil
 }
 
 func (s *spoolingTableReaderAt) Close() error {

--- a/go/store/nbs/spooling_table_reader.go
+++ b/go/store/nbs/spooling_table_reader.go
@@ -29,16 +29,10 @@ import (
 	"github.com/dolthub/dolt/go/store/util/tempfiles"
 )
 
-// wholeBlobRangeBlobstore is implemented by a Blobstore whose ranged Get streams the
-// whole blob regardless of the requested range, making tables cheaper to spool once.
-type wholeBlobRangeBlobstore interface {
-	RangeReadsStreamWholeBlob() bool
-}
-
 // shouldSpool reports whether |bs| needs its table files spooled to a local temp file.
 func shouldSpool(bs blobstore.Blobstore) bool {
-	s, ok := bs.(wholeBlobRangeBlobstore)
-	return ok && s.RangeReadsStreamWholeBlob()
+	s, ok := bs.(interface{ RangeReadsWholeBlob() bool })
+	return ok && s.RangeReadsWholeBlob()
 }
 
 // spoolingTableReaderAt serves random ReadAt over a blob that cannot do cheap ranged

--- a/go/store/nbs/spooling_table_reader_test.go
+++ b/go/store/nbs/spooling_table_reader_test.go
@@ -1,0 +1,217 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nbs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"testing/iotest"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/store/blobstore"
+)
+
+// wholeBlobBlobstore wraps an InMemoryBlobstore and advertises the spool capability.
+type wholeBlobBlobstore struct {
+	*blobstore.InMemoryBlobstore
+	spool bool
+}
+
+func (w wholeBlobBlobstore) RangeReadsStreamWholeBlob() bool { return w.spool }
+
+// fakeGetBlobstore overrides Get to return a canned reader and error.
+type fakeGetBlobstore struct {
+	*blobstore.InMemoryBlobstore
+	rc  io.ReadCloser
+	err error
+}
+
+func (f fakeGetBlobstore) Get(context.Context, string, blobstore.BlobRange) (io.ReadCloser, uint64, string, error) {
+	return f.rc, 0, "", f.err
+}
+
+// GitBlobstore must keep satisfying the capability the spool seam asserts, so a signature
+// change to RangeReadsStreamWholeBlob can't silently drop git back to per-range streaming.
+var _ wholeBlobRangeBlobstore = (*blobstore.GitBlobstore)(nil)
+
+// countSpoolFiles counts leftover spool temp files in the provider's temp dir.
+func countSpoolFiles(t *testing.T) int {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(os.TempDir(), "nbs-spool-*"))
+	require.NoError(t, err)
+	return len(matches)
+}
+
+// spoolBytes stores |data| under key "table" in an in-memory blobstore, spools it, and
+// returns the reader and its temp file path.
+func spoolBytes(t *testing.T, ctx context.Context, data []byte) (*spoolingTableReaderAt, string) {
+	t.Helper()
+	bs := blobstore.NewInMemoryBlobstore("")
+	_, err := bs.Put(ctx, "table", int64(len(data)), bytes.NewReader(data))
+	require.NoError(t, err)
+	ra, err := newSpoolingTableReaderAt(ctx, bs, "table")
+	require.NoError(t, err)
+	return ra, ra.f.Name()
+}
+
+func TestShouldSpool(t *testing.T) {
+	inmem := blobstore.NewInMemoryBlobstore("")
+	require.False(t, shouldSpool(inmem), "a blobstore without the capability must not spool")
+	require.True(t, shouldSpool(wholeBlobBlobstore{inmem, true}))
+	require.False(t, shouldSpool(wholeBlobBlobstore{inmem, false}))
+}
+
+func TestNewSpoolingTableReaderAt_GetError(t *testing.T) {
+	before := countSpoolFiles(t)
+	bs := fakeGetBlobstore{blobstore.NewInMemoryBlobstore(""), nil, errors.New("boom")}
+	_, err := newSpoolingTableReaderAt(context.Background(), bs, "table")
+	require.Error(t, err)
+	require.Equal(t, before, countSpoolFiles(t), "no temp file when Get fails up front")
+}
+
+func TestNewSpoolingTableReaderAt_CopyMidStreamError(t *testing.T) {
+	before := countSpoolFiles(t)
+	// A reader that yields some bytes then errors makes io.Copy write a partial temp file and fail.
+	partialThenErr := io.MultiReader(bytes.NewReader(make([]byte, 50)), iotest.ErrReader(errors.New("boom")))
+	bs := fakeGetBlobstore{blobstore.NewInMemoryBlobstore(""), io.NopCloser(partialThenErr), nil}
+	_, err := newSpoolingTableReaderAt(context.Background(), bs, "table")
+	require.Error(t, err)
+	require.Equal(t, before, countSpoolFiles(t), "partial temp file must be removed when io.Copy fails")
+}
+
+func TestNewSpooledBSTableChunkSource_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	data := [][]byte{[]byte("chunk one"), []byte("chunk two"), []byte("chunk three")}
+	tableBytes, tableHash, err := buildTable(data)
+	require.NoError(t, err)
+
+	inmem := blobstore.NewInMemoryBlobstore("")
+	_, err = inmem.Put(ctx, tableHash.String(), int64(len(tableBytes)), bytes.NewReader(tableBytes))
+	require.NoError(t, err)
+	bs := wholeBlobBlobstore{inmem, true}
+
+	before := countSpoolFiles(t)
+	cs, err := newSpooledBSTableChunkSource(ctx, bs, tableHash, uint32(len(data)), NewUnlimitedMemQuotaProvider(), &Stats{})
+	require.NoError(t, err)
+	require.Equal(t, before+1, countSpoolFiles(t), "opening the source spools exactly one temp file")
+
+	for _, c := range data {
+		got, _, err := cs.get(ctx, computeAddr(c), nil, &Stats{})
+		require.NoError(t, err)
+		require.Equal(t, c, got)
+	}
+
+	require.NoError(t, cs.close())
+	require.Equal(t, before, countSpoolFiles(t), "closing the source removes the spool temp file")
+}
+
+func TestNewSpooledBSTableChunkSource_ChunkCountMismatch(t *testing.T) {
+	ctx := context.Background()
+	data := [][]byte{[]byte("a"), []byte("b")}
+	tableBytes, tableHash, err := buildTable(data)
+	require.NoError(t, err)
+
+	inmem := blobstore.NewInMemoryBlobstore("")
+	_, err = inmem.Put(ctx, tableHash.String(), int64(len(tableBytes)), bytes.NewReader(tableBytes))
+	require.NoError(t, err)
+	bs := wholeBlobBlobstore{inmem, true}
+
+	before := countSpoolFiles(t)
+	_, err = newSpooledBSTableChunkSource(ctx, bs, tableHash, uint32(len(data))+1, NewUnlimitedMemQuotaProvider(), &Stats{})
+	require.Error(t, err)
+	require.Equal(t, before, countSpoolFiles(t), "the temp file is removed when open fails")
+}
+
+func TestSpoolingTableReaderAt_ConcurrentClonesAndClose(t *testing.T) {
+	ctx := context.Background()
+	data := bytes.Repeat([]byte("0123456789abcdef"), 4096)
+
+	ra, path := spoolBytes(t, ctx, data)
+
+	const goroutines = 16
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c, err := ra.clone()
+			if err != nil {
+				t.Errorf("clone: %v", err)
+				return
+			}
+			defer c.Close()
+			p := make([]byte, 8)
+			for j := 0; j < 64; j++ {
+				off := int64((j * 37) % (len(data) - len(p)))
+				n, err := c.ReadAtWithStats(ctx, p, off, &Stats{})
+				if err != nil {
+					t.Errorf("read at %d: %v", off, err)
+					return
+				}
+				if !bytes.Equal(p[:n], data[off:off+int64(n)]) {
+					t.Errorf("byte mismatch at %d", off)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	// The original still holds a reference, so the temp file survives every clone's Close.
+	_, err := os.Stat(path)
+	require.NoError(t, err)
+	require.NoError(t, ra.Close())
+	_, err = os.Stat(path)
+	require.True(t, os.IsNotExist(err), "temp file must be removed once the last reference closes")
+}
+
+func TestSpoolingTableReaderAt(t *testing.T) {
+	ctx := context.Background()
+	data := []byte("the quick brown fox jumps over the lazy dog")
+
+	ra, path := spoolBytes(t, ctx, data)
+
+	for _, tc := range []struct{ off, n int }{{0, 5}, {4, 6}, {len(data) - 3, 3}} {
+		p := make([]byte, tc.n)
+		got, err := ra.ReadAtWithStats(ctx, p, int64(tc.off), &Stats{})
+		require.NoError(t, err)
+		require.Equal(t, tc.n, got)
+		require.Equal(t, data[tc.off:tc.off+tc.n], p)
+	}
+
+	rdr, err := ra.Reader(ctx)
+	require.NoError(t, err)
+	all, err := io.ReadAll(rdr)
+	require.NoError(t, err)
+	require.NoError(t, rdr.Close())
+	require.Equal(t, data, all)
+
+	clone, err := ra.clone()
+	require.NoError(t, err)
+	require.NoError(t, clone.Close())
+	_, err = os.Stat(path)
+	require.NoError(t, err, "temp file must survive while a clone is still open")
+
+	require.NoError(t, ra.Close())
+	_, err = os.Stat(path)
+	require.True(t, os.IsNotExist(err), "temp file must be removed once the last reference closes")
+}

--- a/go/store/nbs/spooling_table_reader_test.go
+++ b/go/store/nbs/spooling_table_reader_test.go
@@ -143,7 +143,11 @@ func TestSpoolingTableReaderAt_ConcurrentClonesAndClose(t *testing.T) {
 
 	ra, path := spoolBytes(t, ctx, data)
 
-	const goroutines = 16
+	const (
+		goroutines    = 16
+		readsPerClone = 64
+		offsetStride  = 37 // a prime, so a clone's own reads do not cluster at aligned offsets
+	)
 	var wg sync.WaitGroup
 	for i := 0; i < goroutines; i++ {
 		wg.Add(1)
@@ -156,8 +160,12 @@ func TestSpoolingTableReaderAt_ConcurrentClonesAndClose(t *testing.T) {
 			}
 			defer c.Close()
 			p := make([]byte, 8)
-			for j := 0; j < 64; j++ {
-				off := int64((j * 37) % (len(data) - len(p)))
+			span := int64(len(data) - len(p))
+			// Start each clone at a different base offset so the clones read different
+			// regions of the shared file at the same time.
+			base := int64(i) * span / goroutines
+			for j := 0; j < readsPerClone; j++ {
+				off := (base + int64(j)*offsetStride) % span
 				n, err := c.ReadAtWithStats(ctx, p, off, &Stats{})
 				if err != nil {
 					t.Errorf("read at %d: %v", off, err)

--- a/go/store/nbs/spooling_table_reader_test.go
+++ b/go/store/nbs/spooling_table_reader_test.go
@@ -188,6 +188,29 @@ func TestSpoolingTableReaderAt_ConcurrentClonesAndClose(t *testing.T) {
 	require.True(t, os.IsNotExist(err), "temp file must be removed once the last reference closes")
 }
 
+func TestSpoolingTableReaderAt_ReaderOutlivesSource(t *testing.T) {
+	ctx := context.Background()
+	data := []byte("a reader must own its lifetime")
+
+	ra, path := spoolBytes(t, ctx, data)
+
+	rdr, err := ra.Reader(ctx)
+	require.NoError(t, err)
+
+	// Closing the source while the reader is open must not remove the spooled file.
+	require.NoError(t, ra.Close())
+	_, err = os.Stat(path)
+	require.NoError(t, err, "the reader holds a reference, so the file survives the source close")
+
+	got, err := io.ReadAll(rdr)
+	require.NoError(t, err)
+	require.Equal(t, data, got)
+
+	require.NoError(t, rdr.Close())
+	_, err = os.Stat(path)
+	require.True(t, os.IsNotExist(err), "closing the last reader removes the temp file")
+}
+
 func TestSpoolingTableReaderAt(t *testing.T) {
 	ctx := context.Background()
 	data := []byte("the quick brown fox jumps over the lazy dog")

--- a/go/store/nbs/spooling_table_reader_test.go
+++ b/go/store/nbs/spooling_table_reader_test.go
@@ -36,7 +36,7 @@ type wholeBlobBlobstore struct {
 	spool bool
 }
 
-func (w wholeBlobBlobstore) RangeReadsStreamWholeBlob() bool { return w.spool }
+func (w wholeBlobBlobstore) RangeReadsWholeBlob() bool { return w.spool }
 
 // fakeGetBlobstore overrides Get to return a canned reader and error.
 type fakeGetBlobstore struct {
@@ -48,10 +48,6 @@ type fakeGetBlobstore struct {
 func (f fakeGetBlobstore) Get(context.Context, string, blobstore.BlobRange) (io.ReadCloser, uint64, string, error) {
 	return f.rc, 0, "", f.err
 }
-
-// GitBlobstore must keep satisfying the capability the spool seam asserts, so a signature
-// change to RangeReadsStreamWholeBlob can't silently drop git back to per-range streaming.
-var _ wholeBlobRangeBlobstore = (*blobstore.GitBlobstore)(nil)
 
 // countSpoolFiles counts leftover spool temp files in the provider's temp dir.
 func countSpoolFiles(t *testing.T) int {

--- a/integration-tests/bats/helper/git-ssh-common.bash
+++ b/integration-tests/bats/helper/git-ssh-common.bash
@@ -1,31 +1,45 @@
 load "$BATS_TEST_DIRNAME/helper/query-server-common.bash"
 
-# Helpers for testing dolt against a local bare git repository over SSH.
-# setup_git_repo + setup_git_ssh_wrapper: wrapper transport (env-var tests)
-# setup_git_repo + setup_git_sshd:        real OpenSSH daemon (auth tests)
-# teardown_git cleans up all resources; call from the bats teardown() hook.
+# Helpers for testing dolt against a local bare git repository.
+# setup_git_repo                          bare remote seeded on main (no SSH)
+# setup_git_ssh_wrapper                   SSH transport via a local wrapper
+# setup_git_sshd                          SSH transport via a real sshd
+# setup_git_wrapper                       fake git on PATH for observing local
+#                                         plumbing such as cat-file
+# Each setup has a matching teardown_git_* below. From the bats teardown() hook
+# call the ones your tests used.
 #
-# Variables set by the setup functions:
-#   GIT_SVC_DIR   path to the bare repository
-#   GIT_SVC_HOOKS_DIR  directory sourced before each wrapper invocation
-#   SSHD_PORT     TCP port the real sshd listens on (set by setup_git_sshd)
-GIT_SVC_DIR=""
-GIT_SVC_WRAPPER=""
-GIT_SVC_HOOKS_DIR=""
-SSHD_DIR=""
-SSHD_PID=""
-SSHD_PORT=""
+# Each setup function sets the globals below.
 
-# setup_git_repo initializes a bare git repository seeded with one commit on main.
+# setup_git_repo:
+GIT_REMOTE_DIR=""         # path to the bare remote repository
+
+# setup_git_ssh_wrapper:
+GIT_SSH_WRAPPER=""        # the GIT_SSH_COMMAND script
+GIT_SSH_HOOKS_DIR=""      # snippets sourced per SSH transport call
+
+# setup_git_sshd:
+SSHD_DIR=""               # working dir (config, host key, log)
+SSHD_PID=""               # pid of the running sshd
+SSHD_PORT=""              # loopback TCP port sshd listens on
+
+# setup_git_wrapper:
+GIT_WRAPPER_DIR=""        # dir holding the fake git and its tallies
+GIT_WRAPPER_HOOKS_DIR=""  # snippets sourced per git invocation
+GIT_WRAPPER_SAVED_PATH="" # PATH before the fake git was prepended
+GIT_WRAPPER_REAL_GIT=""   # absolute path to the real git binary
+
+# setup_git_repo initializes a bare git repository seeded with one commit on
+# main.
 setup_git_repo() {
     local parent
-    parent="$(mktemp -d "$BATS_TMPDIR/git-svc.XXXXXX")"
-    GIT_SVC_DIR="$parent/repo.git"
-    git init --bare "$GIT_SVC_DIR" >/dev/null
+    parent="$(mktemp -d "$BATS_TEST_TMPDIR/git-remote.XXXXXX")"
+    GIT_REMOTE_DIR="$parent/repo.git"
+    git init --bare "$GIT_REMOTE_DIR" >/dev/null
 
     # Seed via a local path push so the SSH transport is not involved during setup.
     local seed
-    seed="$(mktemp -d "$BATS_TMPDIR/git-svc-seed.XXXXXX")"
+    seed="$(mktemp -d "$BATS_TEST_TMPDIR/git-remote-seed.XXXXXX")"
     (
         set -euo pipefail
         cd "$seed"
@@ -36,35 +50,53 @@ setup_git_repo() {
         git add README
         git commit -m "seed" >/dev/null
         git branch -M main
-        git push "$GIT_SVC_DIR" main >/dev/null
+        git push "$GIT_REMOTE_DIR" main >/dev/null
     )
     rm -rf "$seed"
+}
+
+# teardown_git_repo removes the bare remote repository from setup_git_repo.
+teardown_git_repo() {
+    [[ -n "$GIT_REMOTE_DIR" ]] && rm -rf "${GIT_REMOTE_DIR%/*}"
+    GIT_REMOTE_DIR=""
 }
 
 # setup_git_ssh_wrapper installs a local SSH transport that routes git commands
 # to the bare repository without a running SSH daemon. A hooks directory is
 # created so hook_* helpers can inject behavior per invocation.
 setup_git_ssh_wrapper() {
-    GIT_SVC_HOOKS_DIR="$(mktemp -d "$BATS_TMPDIR/git-svc-hooks.XXXXXX")"
-    GIT_SVC_WRAPPER="$(mktemp "$BATS_TMPDIR/git-svc-wrapper.XXXXXX")"
+    GIT_SSH_HOOKS_DIR="$(mktemp -d "$BATS_TEST_TMPDIR/git-ssh-hooks.XXXXXX")"
+    GIT_SSH_WRAPPER="$(mktemp "$BATS_TEST_TMPDIR/git-ssh-wrapper.XXXXXX")"
 
-    cat > "$GIT_SVC_WRAPPER" <<'WRAPPER'
+    cat > "$GIT_SSH_WRAPPER" <<'WRAPPER'
 #!/usr/bin/env bash
 set -euo pipefail
 # nullglob prevents the glob from expanding to a literal string when the hooks
 # directory is empty, which would cause the loop to source a nonexistent file.
 shopt -s nullglob
-for _h in "${GIT_SVC_HOOKS_DIR}"/*; do
-    . "$_h"
+for _hook in "${GIT_SSH_HOOKS_DIR}"/*; do
+    . "$_hook"
 done
 # git passes the transport command as the last argument; evaluate it to serve
 # the bare repository locally without a running SSH daemon.
 eval "${@: -1}"
 WRAPPER
 
-    chmod +x "$GIT_SVC_WRAPPER"
-    export GIT_SSH_COMMAND="$GIT_SVC_WRAPPER"
-    export GIT_SVC_HOOKS_DIR
+    chmod +x "$GIT_SSH_WRAPPER"
+    export GIT_SSH_COMMAND="$GIT_SSH_WRAPPER"
+    export GIT_SSH_HOOKS_DIR
+}
+
+# hook_git_ssh_record_env records an environment variable's value on each SSH
+# transport invocation. The value is written to ${BATS_TEST_TMPDIR}/git_env_<var>.
+# Must be called after setup_git_ssh_wrapper.
+# Arguments:
+#   $1  name of the environment variable to record
+hook_git_ssh_record_env() {
+    local env_var="$1"
+    cat > "$GIT_SSH_HOOKS_DIR/env-${env_var}" <<EOF
+printf '%s' "\${${env_var}}" > "\${BATS_TEST_TMPDIR}/git_env_${env_var}"
+EOF
 }
 
 # setup_git_sshd starts a real OpenSSH daemon on a random loopback port.
@@ -74,7 +106,7 @@ setup_git_sshd() {
     local sshd_bin
     sshd_bin="$(command -v sshd 2>/dev/null)" || sshd_bin="/usr/sbin/sshd"
 
-    SSHD_DIR="$(mktemp -d "$BATS_TMPDIR/sshd.XXXXXX")"
+    SSHD_DIR="$(mktemp -d "$BATS_TEST_TMPDIR/sshd.XXXXXX")"
     chmod 700 "$SSHD_DIR"
 
     ssh-keygen -q -t ed25519 -f "$SSHD_DIR/host_key" -N ""
@@ -129,39 +161,104 @@ gen_ssh_key() {
     cat "${keypath}.pub" >> "$SSHD_DIR/authorized_keys"
 }
 
-# teardown_git removes all resources created by the setup_git_* functions.
-# Safe to call even when only some setup functions were called.
-teardown_git() {
-    unset GIT_SSH_COMMAND GIT_SVC_HOOKS_DIR SSH_AUTH_SOCK
+# teardown_git_ssh tears down the SSH transport: the wrapper from
+# setup_git_ssh_wrapper and any real sshd from setup_git_sshd.
+teardown_git_ssh() {
+    unset GIT_SSH_COMMAND GIT_SSH_HOOKS_DIR SSH_AUTH_SOCK
 
-    [[ -n "$GIT_SVC_DIR" ]]       && rm -rf "${GIT_SVC_DIR%/*}"
-    [[ -n "$GIT_SVC_WRAPPER" ]]   && rm -f  "$GIT_SVC_WRAPPER"
-    [[ -n "$GIT_SVC_HOOKS_DIR" ]] && rm -rf "$GIT_SVC_HOOKS_DIR"
-    rm -f "$BATS_TMPDIR"/git_env_*
-
-    GIT_SVC_DIR=""
-    GIT_SVC_WRAPPER=""
-    GIT_SVC_HOOKS_DIR=""
+    [[ -n "$GIT_SSH_WRAPPER" ]]   && rm -f  "$GIT_SSH_WRAPPER"
+    [[ -n "$GIT_SSH_HOOKS_DIR" ]] && rm -rf "$GIT_SSH_HOOKS_DIR"
+    rm -f "$BATS_TEST_TMPDIR"/git_env_*
+    GIT_SSH_WRAPPER=""
+    GIT_SSH_HOOKS_DIR=""
 
     if [[ -n "${SSHD_PID:-}" ]]; then
         kill "$SSHD_PID" 2>/dev/null || true
         wait "$SSHD_PID" 2>/dev/null || true
         SSHD_PID=""
     fi
-
     [[ -n "${SSHD_DIR:-}" ]] && rm -rf "$SSHD_DIR"
     SSHD_DIR=""
     SSHD_PORT=""
 }
 
-# hook_git_record_env records an environment variable's value on each git
-# transport invocation. The value is written to ${BATS_TMPDIR}/git_env_<var>.
-# Must be called after setup_git_ssh_wrapper.
+# setup_git_wrapper puts a fake git first on PATH that sources every snippet in
+# GIT_WRAPPER_HOOKS_DIR on each invocation and then runs the real git. It is the
+# only way to observe local plumbing such as cat-file. teardown_git_wrapper
+# undoes it.
+setup_git_wrapper() {
+    GIT_WRAPPER_DIR="$(mktemp -d "$BATS_TEST_TMPDIR/git-wrapper.XXXXXX")"
+    GIT_WRAPPER_HOOKS_DIR="$GIT_WRAPPER_DIR/hooks"
+    GIT_WRAPPER_SAVED_PATH="$PATH"
+    mkdir -p "$GIT_WRAPPER_HOOKS_DIR"
+    GIT_WRAPPER_REAL_GIT="$(command -v git)"
+    local real_git="$GIT_WRAPPER_REAL_GIT"
+    # Hooks are sourced with the git argv in scope.
+    cat > "$GIT_WRAPPER_DIR/git" << WRAPPER
+#!/usr/bin/env bash
+# No set -e here: a failing hook must not stop the real git from running.
+shopt -s nullglob
+for _hook in "$GIT_WRAPPER_HOOKS_DIR"/*; do
+    . "\$_hook"
+done
+exec "$real_git" "\$@"
+WRAPPER
+    chmod +x "$GIT_WRAPPER_DIR/git"
+    export PATH="$GIT_WRAPPER_DIR:$PATH"
+}
+
+# hook_git_count_subcommand registers a hook that records one byte each time the
+# given git subcommand runs under setup_git_wrapper. Read the total with
+# git_subcommand_count. Dolt passes the repository through GIT_DIR rather than a
+# flag, so the subcommand is always the first argument and matching it exactly
+# keeps a path or ref named like the subcommand out of the count.
 # Arguments:
-#   $1  name of the environment variable to record
-hook_git_record_env() {
-    local var="$1"
-    cat > "$GIT_SVC_HOOKS_DIR/env-${var}" <<EOF
-printf '%s' "\${${var}}" > "\${BATS_TMPDIR}/git_env_${var}"
-EOF
+#   $1  git subcommand to count, e.g. cat-file
+hook_git_count_subcommand() {
+    local subcommand="$1"
+    cat > "$GIT_WRAPPER_HOOKS_DIR/count-${subcommand}" << HOOK
+if [[ "\$1" == "${subcommand}" ]]; then
+    printf '.' >> "$GIT_WRAPPER_DIR/count-${subcommand}"
+fi
+HOOK
+}
+
+# git_subcommand_count prints how many times the given subcommand ran under
+# setup_git_wrapper, or zero if it never ran.
+# Arguments:
+#   $1  git subcommand to read the count for
+git_subcommand_count() {
+    local subcommand="$1"
+    local tally_file="$GIT_WRAPPER_DIR/count-${subcommand}"
+    if [[ -f "$tally_file" ]]; then
+        # Arithmetic expansion drops any whitespace wc may pad, so the count is
+        # a bare integer usable by string-equality callers, not only by -lt.
+        echo "$(( $(wc -c < "$tally_file") ))"
+    else
+        echo 0
+    fi
+}
+
+# teardown_git_wrapper restores PATH and removes the git binary wrapper from
+# setup_git_wrapper.
+teardown_git_wrapper() {
+    [[ -n "$GIT_WRAPPER_SAVED_PATH" ]] && export PATH="$GIT_WRAPPER_SAVED_PATH"
+    [[ -n "$GIT_WRAPPER_DIR" ]] && rm -rf "$GIT_WRAPPER_DIR"
+    GIT_WRAPPER_DIR=""
+    GIT_WRAPPER_HOOKS_DIR=""
+    GIT_WRAPPER_SAVED_PATH=""
+    GIT_WRAPPER_REAL_GIT=""
+}
+
+# largest_data_blob_size prints the size in bytes of the largest blob in a git
+# directory. For a Dolt git remote that is the table file, a cheap proxy for how
+# many chunks the remote holds. It runs the real git directly, so it works
+# whether or not setup_git_wrapper is installed, and its reads are not counted.
+# Arguments:
+#   $1  path to the git directory to inspect
+largest_data_blob_size() {
+    local git_dir="$1"
+    "${GIT_WRAPPER_REAL_GIT:-git}" --git-dir "$git_dir" \
+        cat-file --batch-all-objects --batch-check \
+        | awk '$2 == "blob" && $3 > max { max = $3 } END { if (max != "") print max }'
 }

--- a/integration-tests/bats/remotes-git.bats
+++ b/integration-tests/bats/remotes-git.bats
@@ -15,7 +15,9 @@ setup() {
 }
 
 teardown() {
-    teardown_git
+    teardown_git_wrapper
+    teardown_git_ssh
+    teardown_git_repo
     assert_feature_version
     teardown_common
 }
@@ -598,12 +600,12 @@ _init_repo_with_remote() {
     # See https://github.com/dolthub/dolt/issues/10811.
     setup_git_repo
     setup_git_ssh_wrapper
-    hook_git_record_env "GIT_SSH_COMMAND"
-    _init_repo_with_remote "git@localhost:${GIT_SVC_DIR}"
+    hook_git_ssh_record_env "GIT_SSH_COMMAND"
+    _init_repo_with_remote "git@localhost:${GIT_REMOTE_DIR}"
 
     run dolt push origin main
     [ "$status" -eq 0 ]
-    [ -f "$BATS_TMPDIR/git_env_GIT_SSH_COMMAND" ]
+    [ -f "$BATS_TEST_TMPDIR/git_env_GIT_SSH_COMMAND" ]
 }
 
 # bats test_tags=no_lambda
@@ -614,7 +616,7 @@ _init_repo_with_remote() {
     gen_ssh_key "$BATS_TMPDIR/ssh_key_locked" "test_passphrase"
     export GIT_SSH_COMMAND="ssh -i $BATS_TMPDIR/ssh_key_locked -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
     unset SSH_AUTH_SOCK
-    _init_repo_with_remote "git+ssh://$(whoami)@127.0.0.1:${SSHD_PORT}${GIT_SVC_DIR}"
+    _init_repo_with_remote "git+ssh://$(whoami)@127.0.0.1:${SSHD_PORT}${GIT_REMOTE_DIR}"
 
     # expect allocates a real PTY for the dolt process so the test can verify
     # that git subprocesses cannot reach it to prompt for a passphrase.
@@ -634,7 +636,7 @@ _init_repo_with_remote() {
     # the controlling terminal.
     touch "$BATS_TMPDIR/ssh_known_hosts_empty"
     export GIT_SSH_COMMAND="ssh -i $BATS_TMPDIR/ssh_key_unlocked -o IdentitiesOnly=yes -o UserKnownHostsFile=$BATS_TMPDIR/ssh_known_hosts_empty"
-    _init_repo_with_remote "git+ssh://$(whoami)@127.0.0.1:${SSHD_PORT}${GIT_SVC_DIR}"
+    _init_repo_with_remote "git+ssh://$(whoami)@127.0.0.1:${SSHD_PORT}${GIT_REMOTE_DIR}"
 
     run expect "$BATS_TEST_DIRNAME/remotes-git-ssh-prompt.expect" "The authenticity of host"
     [ "$status" -ne 0 ]
@@ -651,7 +653,7 @@ _init_repo_with_remote() {
     setup_git_sshd
     gen_ssh_key "$BATS_TMPDIR/ssh_key_unlocked" ""
     export GIT_SSH_COMMAND="ssh -i $BATS_TMPDIR/ssh_key_unlocked -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-    _init_repo_with_remote "git+ssh://$(whoami)@127.0.0.1:${SSHD_PORT}${GIT_SVC_DIR}"
+    _init_repo_with_remote "git+ssh://$(whoami)@127.0.0.1:${SSHD_PORT}${GIT_REMOTE_DIR}"
 
     run dolt push origin main
     [ "$status" -eq 0 ]
@@ -794,3 +796,119 @@ EOF
     chmod +x "$BATS_TMPDIR/fakebin/git"
 }
 
+# seed_table_with_many_chunks fills a Dolt table with enough distinct rows to
+# produce a table file of hundreds of storage chunks. Runs in the current
+# repository.
+# Arguments:
+#   $1  table name, defaults to t
+#   $2  value added to every primary key, so separate calls produce distinct
+#       chunks rather than identical ones that the store would dedupe
+seed_table_with_many_chunks() {
+    local table="${1:-t}"
+    local pk_offset="${2:-0}"
+    local csv_file
+    csv_file="$(mktemp "${BATS_TEST_TMPDIR:-$BATS_TMPDIR}/dolt-many-chunks-XXXXXX.csv")"
+    printf 'pk,a,b,c\n' > "$csv_file"
+    # awk represents numbers as doubles, so a hex conversion of a value above
+    # 2^32 saturates and the columns stop varying. Taking the product mod 2^32
+    # keeps each column distinct per row so the rows do not dedupe into a few
+    # chunks.
+    awk -v offset="$pk_offset" 'BEGIN { modulus = 4294967296; for (i = 1; i <= 30000; i++) printf "%d,%064x,%064x,%064x\n", i + offset, (i*2654435761)%modulus, (i*2246822519)%modulus, (i*3266489917)%modulus }' >> "$csv_file"
+    dolt table import -c -pk pk "$table" "$csv_file"
+    rm -f "$csv_file"
+    dolt add .
+    dolt commit -m "import many rows into $table"
+}
+
+# assert_catfile_calls_under runs the given dolt command under a git wrapper that
+# counts cat-file calls and asserts it makes fewer than the given maximum. It
+# first checks that the remote holds a large table, since the count proves
+# nothing otherwise. Run it from the directory where the command should execute.
+# Arguments:
+#   $1  maximum number of git cat-file calls allowed
+#   $@  (rest) the dolt command to run, for example dolt clone <url> <dir>
+assert_catfile_calls_under() {
+    local max_calls="$1"
+    shift
+    local data_blob_size
+    data_blob_size="$(largest_data_blob_size "$GIT_REMOTE_DIR")"
+    [ -n "$data_blob_size" ] || {
+        echo "No data blob found in the remote. Check that the push wrote a table file."
+        false
+    }
+    [ "$data_blob_size" -gt 100000 ] || {
+        echo "Largest data blob is only $data_blob_size bytes, too few chunks to test."
+        echo "Raise the row count in seed_table_with_many_chunks."
+        false
+    }
+
+    setup_git_wrapper
+    hook_git_count_subcommand cat-file
+    run "$@"
+    log_status_eq 0
+
+    local catfile_calls
+    catfile_calls="$(git_subcommand_count cat-file)"
+    [ "$catfile_calls" -lt "$max_calls" ] || {
+        echo "git cat-file ran ${catfile_calls} times (limit ${max_calls})."
+        echo "Reading each chunk must not start its own git process."
+        false
+    }
+}
+
+@test "remotes-git: clone from git remote uses O(1) git cat-file calls" {
+    # See https://github.com/dolthub/dolt/issues/11236
+    setup_git_repo
+    _init_repo_with_remote "git+file://$GIT_REMOTE_DIR"
+    seed_table_with_many_chunks
+    run dolt push --set-upstream origin main
+    [ "$status" -eq 0 ]
+    src_root=$(dolt sql -q "select dolt_hashof_db()" -r csv | tail -n 1)
+    cd ..
+
+    assert_catfile_calls_under 50 \
+        dolt clone --depth 1 "git+file://$GIT_REMOTE_DIR" dolt-repo-clones/repo2
+
+    cd dolt-repo-clones/repo2
+    run dolt sql -q "select dolt_hashof_db()" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "$src_root" ]] || false
+    run dolt sql -q "select count(*) from t" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "30000" ]] || false
+}
+
+@test "remotes-git: fetch from git remote uses O(1) git cat-file calls" {
+    # See https://github.com/dolthub/dolt/issues/11236
+    setup_git_repo
+    _init_repo_with_remote "git+file://$GIT_REMOTE_DIR"
+    seed_table_with_many_chunks
+    run dolt push --set-upstream origin main
+    [ "$status" -eq 0 ]
+    cd ..
+
+    cd dolt-repo-clones
+    run dolt clone "git+file://$GIT_REMOTE_DIR" repo2
+    [ "$status" -eq 0 ]
+    cd ..
+
+    # Push a second large table so the fetch has new chunks to read.
+    cd repo1
+    seed_table_with_many_chunks t2 1000000
+    run dolt push origin main
+    [ "$status" -eq 0 ]
+    src_root=$(dolt sql -q "select dolt_hashof_db()" -r csv | tail -n 1)
+    cd ..
+
+    cd dolt-repo-clones/repo2
+    assert_catfile_calls_under 50 dolt fetch origin
+
+    run dolt merge origin/main
+    [ "$status" -eq 0 ]
+    run dolt sql -q "select dolt_hashof_db()" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "$src_root" ]] || false
+    run dolt sql -q "select count(*) from t2" -r csv
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "30000" ]] || false
+}

--- a/integration-tests/bats/ssh-pid-leak.bats
+++ b/integration-tests/bats/ssh-pid-leak.bats
@@ -35,7 +35,7 @@ setup() {
 
 teardown() {
     stop_sql_server
-    teardown_git
+    teardown_git_ssh
     unset DOLT_SSH_COMMAND DOLT_SSH_EXEC_PATH REMOTE_URL
 }
 


### PR DESCRIPTION
 Reading a git-backed table file went chunk by chunk, and because git cat-file cannot serve a byte range, each read re-streamed the whole object from the start. Fetching a large table spawned thousands of git processes and stalled.
- Spool a git-backed table file to a local temp file on open and serve its chunk reads locally
- Look up the sizes of a chunked object's parts in a single `git cat-file --batch-check` call
- Detect an early reader close by end of stdout, so a partial read is torn down the same way on every platform
Fix #11236