### PR TITLE
Add a global credential helper for remotesapi

### DIFF
--- a/go/cmd/dolt/commands/config.go
+++ b/go/cmd/dolt/commands/config.go
@@ -67,7 +67,19 @@ Valid configuration variables:
 
 	- remotes.default_port - sets default port for authenticating with doltremoteapi.
 
+	- remotesapi.credential_helper - sets a global credential helper for remotesapi requests. This option is ignored in repository local config.
+
 	- push.autoSetupRemote - if set to "true" assume --set-upstream on default push when no upstream tracking exists for the current branch.
+
+Credential helpers use the Bazel credential helper protocol. Dolt invokes the configured executable with the {{.EmphasisLeft}}get{{.EmphasisRight}} argument and sends the canonical remotesapi origin on stdin:
+
+	{"uri":"https://example.com:443"}
+
+The helper returns additive HTTP headers and, optionally, an RFC 3339 expiration time:
+
+	{"headers":{"Proxy-Authorization":["Bearer TOKEN"]},"expires":"2026-06-24T20:00:00Z"}
+
+Dolt caches headers until shortly before their expiration. Responses without an expiration are used once. The helper is responsible for returning credentials only for origins it trusts. It cannot replace Dolt's own Authorization header or transport-controlled headers.
 `,
 
 	Synopsis: []string{

--- a/go/libraries/doltcore/credentialhelper/credential_helper.go
+++ b/go/libraries/doltcore/credentialhelper/credential_helper.go
@@ -1,0 +1,353 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package credentialhelper
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/net/http/httpguts"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/grpcendpoint"
+)
+
+const (
+	getCommand  = "get"
+	refreshSkew = 30 * time.Second
+)
+
+var reservedHeaders = map[string]struct{}{
+	"authorization":     {},
+	"connection":        {},
+	"content-length":    {},
+	"content-type":      {},
+	"host":              {},
+	"proxy-connection":  {},
+	"te":                {},
+	"trailer":           {},
+	"transfer-encoding": {},
+	"upgrade":           {},
+	"user-agent":        {},
+}
+
+type getCredentialsRequest struct {
+	URI string `json:"uri"`
+}
+
+type getCredentialsResponse struct {
+	Headers map[string][]string `json:"headers"`
+	Expires *time.Time          `json:"expires"`
+}
+
+type getCredentialsFunc func(context.Context, string, string) (getCredentialsResponse, error)
+
+// Helper obtains and caches headers for one remotesapi origin.
+// It follows Bazel's credential helper protocol so existing helpers can be
+// adapted without inventing another secret exchange format.
+type Helper struct {
+	executable string
+	origin     string
+	get        getCredentialsFunc
+	now        func() time.Time
+
+	mu      sync.Mutex
+	headers http.Header
+	expires time.Time
+}
+
+// New returns a helper for a single canonical remotesapi origin.
+func New(executable, origin string) (*Helper, error) {
+	executable = strings.TrimSpace(executable)
+	if executable == "" {
+		return nil, fmt.Errorf("credential helper executable cannot be empty")
+	}
+
+	origin, err := canonicalOrigin(origin)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Helper{
+		executable: executable,
+		origin:     origin,
+		get:        runCredentialHelper,
+		now:        time.Now,
+	}, nil
+}
+
+// DialOptions returns interceptors which attach helper headers to unary and
+// streaming RPCs without replacing Dolt's existing per-RPC credentials.
+func (h *Helper) DialOptions() []grpc.DialOption {
+	return []grpc.DialOption{
+		grpc.WithChainUnaryInterceptor(h.unaryClientInterceptor),
+		grpc.WithChainStreamInterceptor(h.streamClientInterceptor),
+	}
+}
+
+// WrapHTTPFetcher adds helper headers only when a remotesapi request uses the
+// same origin. In particular, credentials must not follow signed URLs to an
+// object store returned by the remotesapi server.
+func (h *Helper) WrapHTTPFetcher(fetcher grpcendpoint.HTTPFetcher) grpcendpoint.HTTPFetcher {
+	return helperHTTPFetcher{
+		fetcher: fetcher,
+		helper:  h,
+	}
+}
+
+func (h *Helper) unaryClientInterceptor(
+	ctx context.Context,
+	method string,
+	req, reply any,
+	cc *grpc.ClientConn,
+	invoker grpc.UnaryInvoker,
+	opts ...grpc.CallOption,
+) error {
+	ctx, err := h.withOutgoingMetadata(ctx)
+	if err != nil {
+		return err
+	}
+	return invoker(ctx, method, req, reply, cc, opts...)
+}
+
+func (h *Helper) streamClientInterceptor(
+	ctx context.Context,
+	desc *grpc.StreamDesc,
+	cc *grpc.ClientConn,
+	method string,
+	streamer grpc.Streamer,
+	opts ...grpc.CallOption,
+) (grpc.ClientStream, error) {
+	ctx, err := h.withOutgoingMetadata(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return streamer(ctx, desc, cc, method, opts...)
+}
+
+func (h *Helper) withOutgoingMetadata(ctx context.Context) (context.Context, error) {
+	headers, err := h.getHeaders(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	existing, _ := metadata.FromOutgoingContext(ctx)
+	keyValues := make([]string, 0, len(headers)*2)
+	for name, values := range headers {
+		if _, ok := existing[name]; ok {
+			return nil, fmt.Errorf("credential helper header %q conflicts with existing gRPC metadata", name)
+		}
+		for _, value := range values {
+			keyValues = append(keyValues, name, value)
+		}
+	}
+
+	return metadata.AppendToOutgoingContext(ctx, keyValues...), nil
+}
+
+func (h *Helper) getHeaders(ctx context.Context) (http.Header, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	now := h.now()
+	if h.headers != nil && now.Add(refreshSkew).Before(h.expires) {
+		return cloneHeaders(h.headers), nil
+	}
+
+	response, err := h.get(ctx, h.executable, h.origin)
+	if err != nil {
+		return nil, err
+	}
+	now = h.now()
+
+	headers, err := normalizeHeaders(response.Headers)
+	if err != nil {
+		return nil, err
+	}
+
+	h.headers = nil
+	h.expires = time.Time{}
+	if response.Expires != nil {
+		if !response.Expires.After(now) {
+			return nil, fmt.Errorf("credential helper returned credentials that expired at %s", response.Expires.Format(time.RFC3339))
+		}
+		if now.Add(refreshSkew).Before(*response.Expires) {
+			h.headers = cloneHeaders(headers)
+			h.expires = *response.Expires
+		}
+	}
+
+	return headers, nil
+}
+
+func runCredentialHelper(ctx context.Context, executable, origin string) (getCredentialsResponse, error) {
+	request, err := json.Marshal(getCredentialsRequest{URI: origin})
+	if err != nil {
+		return getCredentialsResponse{}, err
+	}
+
+	cmd := exec.CommandContext(ctx, executable, getCommand)
+	cmd.Stdin = bytes.NewReader(request)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		message := strings.TrimSpace(stderr.String())
+		if message != "" {
+			return getCredentialsResponse{}, fmt.Errorf("credential helper %q failed: %w: %s", executable, err, message)
+		}
+		return getCredentialsResponse{}, fmt.Errorf("credential helper %q failed: %w", executable, err)
+	}
+
+	var response getCredentialsResponse
+	decoder := json.NewDecoder(&stdout)
+	if err := decoder.Decode(&response); err != nil {
+		return getCredentialsResponse{}, fmt.Errorf("credential helper %q returned invalid JSON: %w", executable, err)
+	}
+
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return getCredentialsResponse{}, fmt.Errorf("credential helper %q returned more than one JSON value", executable)
+		}
+		return getCredentialsResponse{}, fmt.Errorf("credential helper %q returned invalid trailing data: %w", executable, err)
+	}
+
+	return response, nil
+}
+
+func normalizeHeaders(headers map[string][]string) (http.Header, error) {
+	normalized := make(http.Header, len(headers))
+	for name, values := range headers {
+		lowerName := strings.ToLower(name)
+		if !httpguts.ValidHeaderFieldName(lowerName) {
+			return nil, fmt.Errorf("credential helper returned invalid header name %q", name)
+		}
+		if strings.HasPrefix(lowerName, "grpc-") {
+			return nil, fmt.Errorf("credential helper cannot set reserved gRPC header %q", name)
+		}
+		if _, ok := reservedHeaders[lowerName]; ok {
+			return nil, fmt.Errorf("credential helper cannot set reserved header %q", name)
+		}
+		if _, ok := normalized[lowerName]; ok {
+			return nil, fmt.Errorf("credential helper returned duplicate header %q", name)
+		}
+
+		for _, value := range values {
+			if !httpguts.ValidHeaderFieldValue(value) {
+				return nil, fmt.Errorf("credential helper returned an invalid value for header %q", name)
+			}
+			normalized[lowerName] = append(normalized[lowerName], value)
+		}
+	}
+	return normalized, nil
+}
+
+func canonicalOrigin(rawURL string) (string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid credential helper origin %q: %w", rawURL, err)
+	}
+
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return "", fmt.Errorf("credential helper origin must use http or https, got %q", parsed.Scheme)
+	}
+
+	host := strings.ToLower(parsed.Hostname())
+	if host == "" {
+		return "", fmt.Errorf("credential helper origin %q has no host", rawURL)
+	}
+
+	port := parsed.Port()
+	if port == "" {
+		if scheme == "http" {
+			port = "80"
+		} else {
+			port = "443"
+		}
+	}
+
+	return (&url.URL{
+		Scheme: scheme,
+		Host:   net.JoinHostPort(host, port),
+	}).String(), nil
+}
+
+func cloneHeaders(headers http.Header) http.Header {
+	cloned := make(http.Header, len(headers))
+	for name, values := range headers {
+		cloned[name] = append([]string(nil), values...)
+	}
+	return cloned
+}
+
+type helperHTTPFetcher struct {
+	fetcher grpcendpoint.HTTPFetcher
+	helper  *Helper
+}
+
+func (f helperHTTPFetcher) Do(req *http.Request) (*http.Response, error) {
+	origin, err := canonicalOrigin(req.URL.String())
+	if err != nil {
+		return nil, err
+	}
+	if origin != f.helper.origin {
+		return f.fetcher.Do(req)
+	}
+
+	headers, err := f.helper.getHeaders(req.Context())
+	if err != nil {
+		return nil, err
+	}
+
+	cloned := req.Clone(req.Context())
+	cloned.Header = req.Header.Clone()
+	if cloned.Header == nil {
+		cloned.Header = make(http.Header)
+	}
+	for name, values := range headers {
+		if hasHeader(cloned.Header, name) {
+			return nil, fmt.Errorf("credential helper header %q conflicts with existing HTTP header", name)
+		}
+		for _, value := range values {
+			cloned.Header.Add(name, value)
+		}
+	}
+	return f.fetcher.Do(cloned)
+}
+
+func hasHeader(headers http.Header, name string) bool {
+	for existing := range headers {
+		if strings.EqualFold(existing, name) {
+			return true
+		}
+	}
+	return false
+}

--- a/go/libraries/doltcore/credentialhelper/credential_helper_test.go
+++ b/go/libraries/doltcore/credentialhelper/credential_helper_test.go
@@ -1,0 +1,337 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package credentialhelper
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+func TestHelperCachesHeadersUntilExpiration(t *testing.T) {
+	now := time.Date(2026, time.June, 24, 12, 0, 0, 0, time.UTC)
+	calls := 0
+
+	helper := newTestHelper(t, "https://example.com", func(context.Context, string, string) (getCredentialsResponse, error) {
+		calls++
+		expires := now.Add(time.Hour)
+		return getCredentialsResponse{
+			Headers: map[string][]string{
+				"Proxy-Authorization": {"Bearer token"},
+			},
+			Expires: &expires,
+		}, nil
+	})
+	helper.now = func() time.Time { return now }
+
+	first, err := helper.getHeaders(context.Background())
+	require.NoError(t, err)
+	second, err := helper.getHeaders(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"Bearer token"}, first["proxy-authorization"])
+	assert.Equal(t, first, second)
+	assert.Equal(t, 1, calls)
+
+	now = now.Add(time.Hour - refreshSkew)
+	_, err = helper.getHeaders(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls)
+}
+
+func TestHelperDoesNotCacheHeadersWithoutExpiration(t *testing.T) {
+	calls := 0
+	helper := newTestHelper(t, "https://example.com", func(context.Context, string, string) (getCredentialsResponse, error) {
+		calls++
+		return getCredentialsResponse{
+			Headers: map[string][]string{"x-test": {"value"}},
+		}, nil
+	})
+
+	_, err := helper.getHeaders(context.Background())
+	require.NoError(t, err)
+	_, err = helper.getHeaders(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls)
+}
+
+func TestHelperCoalescesConcurrentRefreshes(t *testing.T) {
+	var calls atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var startOnce sync.Once
+
+	helper := newTestHelper(t, "https://example.com", func(context.Context, string, string) (getCredentialsResponse, error) {
+		calls.Add(1)
+		startOnce.Do(func() {
+			close(started)
+		})
+		<-release
+
+		expires := time.Now().Add(time.Hour)
+		return getCredentialsResponse{
+			Headers: map[string][]string{"x-test": {"value"}},
+			Expires: &expires,
+		}, nil
+	})
+
+	const requestCount = 10
+	var wg sync.WaitGroup
+	errs := make(chan error, requestCount)
+	for range requestCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := helper.getHeaders(context.Background())
+			errs <- err
+		}()
+	}
+
+	<-started
+	close(release)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func TestHelperRejectsExpiredCredentials(t *testing.T) {
+	now := time.Date(2026, time.June, 24, 12, 0, 0, 0, time.UTC)
+	expires := now.Add(-time.Second)
+	helper := newTestHelper(t, "https://example.com", func(context.Context, string, string) (getCredentialsResponse, error) {
+		return getCredentialsResponse{Expires: &expires}, nil
+	})
+	helper.now = func() time.Time { return now }
+
+	_, err := helper.getHeaders(context.Background())
+	require.ErrorContains(t, err, "expired")
+}
+
+func TestHelperChecksExpirationAfterCommandReturns(t *testing.T) {
+	now := time.Date(2026, time.June, 24, 12, 0, 0, 0, time.UTC)
+	expires := now.Add(time.Minute)
+	helper := newTestHelper(t, "https://example.com", func(context.Context, string, string) (getCredentialsResponse, error) {
+		now = now.Add(2 * time.Minute)
+		return getCredentialsResponse{Expires: &expires}, nil
+	})
+	helper.now = func() time.Time { return now }
+
+	_, err := helper.getHeaders(context.Background())
+	require.ErrorContains(t, err, "expired")
+}
+
+func TestRunCredentialHelperProtocol(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test helper uses a POSIX shell")
+	}
+
+	executable := filepath.Join(t.TempDir(), "credential-helper")
+	err := os.WriteFile(executable, []byte(`#!/bin/sh
+if [ "$1" != "get" ]; then
+  echo "expected get command" >&2
+  exit 1
+fi
+request=$(cat)
+if [ "$request" != '{"uri":"https://example.com:443"}' ]; then
+  echo "unexpected request: $request" >&2
+  exit 1
+fi
+printf '%s' '{"headers":{"Proxy-Authorization":["Bearer proxy-token"]},"expires":"2026-06-24T20:00:00Z"}'
+`), 0700)
+	require.NoError(t, err)
+
+	response, err := runCredentialHelper(context.Background(), executable, "https://example.com:443")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Bearer proxy-token"}, response.Headers["Proxy-Authorization"])
+	require.NotNil(t, response.Expires)
+	assert.Equal(t, "2026-06-24T20:00:00Z", response.Expires.Format(time.RFC3339))
+}
+
+func TestGRPCRequestPreservesDoltAuthorization(t *testing.T) {
+	helper := newTestHelper(t, "https://example.com", staticResponse(map[string][]string{
+		"Proxy-Authorization": {"Bearer proxy-token"},
+	}))
+
+	listener := bufconn.Listen(1024 * 1024)
+	server := grpc.NewServer(grpc.UnaryInterceptor(func(
+		ctx context.Context,
+		req any,
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (any, error) {
+		md, _ := metadata.FromIncomingContext(ctx)
+		assert.Equal(t, []string{"Basic dolt-credentials"}, md.Get("authorization"))
+		assert.Equal(t, []string{"Bearer proxy-token"}, md.Get("proxy-authorization"))
+		return handler(ctx, req)
+	}))
+	healthpb.RegisterHealthServer(server, health.NewServer())
+
+	go func() {
+		_ = server.Serve(listener)
+	}()
+	t.Cleanup(server.Stop)
+
+	dialOptions := []grpc.DialOption{
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithPerRPCCredentials(staticRPCCredentials{
+			"authorization": "Basic dolt-credentials",
+		}),
+	}
+	dialOptions = append(dialOptions, helper.DialOptions()...)
+
+	conn, err := grpc.DialContext(context.Background(), "bufnet", dialOptions...)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = conn.Close()
+	})
+
+	_, err = healthpb.NewHealthClient(conn).Check(context.Background(), &healthpb.HealthCheckRequest{})
+	require.NoError(t, err)
+}
+
+func TestStreamInterceptorAddsHelperMetadata(t *testing.T) {
+	helper := newTestHelper(t, "https://example.com", staticResponse(map[string][]string{
+		"Proxy-Authorization": {"Bearer proxy-token"},
+	}))
+
+	_, err := helper.streamClientInterceptor(
+		context.Background(),
+		&grpc.StreamDesc{},
+		nil,
+		"/test.Service/Stream",
+		func(ctx context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
+			md, _ := metadata.FromOutgoingContext(ctx)
+			assert.Equal(t, []string{"Bearer proxy-token"}, md.Get("proxy-authorization"))
+			return nil, nil
+		},
+	)
+	require.NoError(t, err)
+}
+
+func TestHTTPFetcherAddsHeadersOnlyToMatchingOrigin(t *testing.T) {
+	var requests []*http.Request
+	fetcher := fetcherFunc(func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req)
+		return &http.Response{StatusCode: http.StatusOK}, nil
+	})
+	helper := newTestHelper(t, "https://example.com", staticResponse(map[string][]string{
+		"Proxy-Authorization": {"Bearer proxy-token"},
+	}))
+	wrapped := helper.WrapHTTPFetcher(fetcher)
+
+	matching, err := http.NewRequest(http.MethodGet, "https://example.com/chunks/1", nil)
+	require.NoError(t, err)
+	_, err = wrapped.Do(matching)
+	require.NoError(t, err)
+
+	signedURL, err := http.NewRequest(http.MethodGet, "https://objects.example.net/chunks/1?signature=abc", nil)
+	require.NoError(t, err)
+	_, err = wrapped.Do(signedURL)
+	require.NoError(t, err)
+
+	require.Len(t, requests, 2)
+	assert.Equal(t, "Bearer proxy-token", requests[0].Header.Get("proxy-authorization"))
+	assert.Empty(t, requests[1].Header.Get("proxy-authorization"))
+	assert.Empty(t, matching.Header.Get("proxy-authorization"))
+}
+
+func TestHelperRejectsAuthorizationHeader(t *testing.T) {
+	helper := newTestHelper(t, "https://example.com", staticResponse(map[string][]string{
+		"Authorization": {"Bearer replacement"},
+	}))
+
+	_, err := helper.getHeaders(context.Background())
+	require.ErrorContains(t, err, "reserved header")
+}
+
+func TestCanonicalOrigin(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"https://EXAMPLE.com/repository/path", "https://example.com:443"},
+		{"http://example.com/path", "http://example.com:80"},
+		{"https://example.com:8443/path?query=value", "https://example.com:8443"},
+		{"https://[::1]/path", "https://[::1]:443"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			actual, err := canonicalOrigin(test.input)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func newTestHelper(t *testing.T, origin string, get getCredentialsFunc) *Helper {
+	t.Helper()
+
+	helper, err := New("test-helper", origin)
+	require.NoError(t, err)
+	helper.get = get
+	return helper
+}
+
+func staticResponse(headers map[string][]string) getCredentialsFunc {
+	return func(context.Context, string, string) (getCredentialsResponse, error) {
+		expires := time.Now().Add(time.Hour)
+		return getCredentialsResponse{
+			Headers: headers,
+			Expires: &expires,
+		}, nil
+	}
+}
+
+type staticRPCCredentials map[string]string
+
+func (c staticRPCCredentials) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
+	return c, nil
+}
+
+func (staticRPCCredentials) RequireTransportSecurity() bool {
+	return false
+}
+
+var _ credentials.PerRPCCredentials = staticRPCCredentials{}
+
+type fetcherFunc func(*http.Request) (*http.Response, error)
+
+func (f fetcherFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/go/libraries/doltcore/env/grpc_dial_provider.go
+++ b/go/libraries/doltcore/env/grpc_dial_provider.go
@@ -17,6 +17,7 @@ package env
 import (
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -30,11 +31,13 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	expcreds "google.golang.org/grpc/experimental/credentials"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/credentialhelper"
 	"github.com/dolthub/dolt/go/libraries/doltcore/creds"
 	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
 	"github.com/dolthub/dolt/go/libraries/doltcore/dconfig"
 	"github.com/dolthub/dolt/go/libraries/doltcore/grpcendpoint"
 	"github.com/dolthub/dolt/go/libraries/doltcore/remotesrv"
+	"github.com/dolthub/dolt/go/libraries/utils/config"
 )
 
 var defaultDialer = &net.Dialer{
@@ -80,10 +83,10 @@ func NewGRPCDialProviderFromDoltEnv(dEnv *DoltEnv) *GRPCDialProvider {
 }
 
 // GetGRPCDialParams implements dbfactory.GRPCDialProvider
-func (p GRPCDialProvider) GetGRPCDialParams(config grpcendpoint.Config) (dbfactory.GRPCRemoteConfig, error) {
-	endpoint := config.Endpoint
+func (p GRPCDialProvider) GetGRPCDialParams(grpcConfig grpcendpoint.Config) (dbfactory.GRPCRemoteConfig, error) {
+	endpoint := grpcConfig.Endpoint
 	if strings.IndexRune(endpoint, ':') == -1 {
-		if config.Insecure {
+		if grpcConfig.Insecure {
 			endpoint += ":80"
 		} else {
 			endpoint += ":443"
@@ -93,8 +96,8 @@ func (p GRPCDialProvider) GetGRPCDialParams(config grpcendpoint.Config) (dbfacto
 	var httpfetcher grpcendpoint.HTTPFetcher = defaultHttpFetcher
 
 	var opts []grpc.DialOption
-	if config.TLSConfig != nil {
-		tc := expcreds.NewTLSWithALPNDisabled(config.TLSConfig)
+	if grpcConfig.TLSConfig != nil {
+		tc := expcreds.NewTLSWithALPNDisabled(grpcConfig.TLSConfig)
 		opts = append(opts, grpc.WithTransportCredentials(tc))
 
 		transport := &http.Transport{
@@ -104,14 +107,14 @@ func (p GRPCDialProvider) GetGRPCDialParams(config grpcendpoint.Config) (dbfacto
 			MaxIdleConns:          1024,
 			MaxIdleConnsPerHost:   256,
 			IdleConnTimeout:       90 * time.Second,
-			TLSClientConfig:       config.TLSConfig,
+			TLSClientConfig:       grpcConfig.TLSConfig,
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
 		}
 		httpfetcher = &http.Client{
 			Transport: transport,
 		}
-	} else if config.Insecure {
+	} else if grpcConfig.Insecure {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	} else {
 		tc := expcreds.NewTLSWithALPNDisabled(&tls.Config{})
@@ -121,13 +124,13 @@ func (p GRPCDialProvider) GetGRPCDialParams(config grpcendpoint.Config) (dbfacto
 	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(remotesrv.MaxGRPCMessageSize)))
 	opts = append(opts, grpc.WithUserAgent(p.getUserAgentString()))
 
-	if config.Creds != nil {
-		opts = append(opts, grpc.WithPerRPCCredentials(config.Creds))
-	} else if config.WithEnvCreds {
+	if grpcConfig.Creds != nil {
+		opts = append(opts, grpc.WithPerRPCCredentials(grpcConfig.Creds))
+	} else if grpcConfig.WithEnvCreds {
 		var rpcCreds credentials.PerRPCCredentials
 		var err error
-		if config.UserIdForOsEnvAuth != "" {
-			rpcCreds, err = p.getRPCCredsFromOSEnv(config.UserIdForOsEnvAuth)
+		if grpcConfig.UserIdForOsEnvAuth != "" {
+			rpcCreds, err = p.getRPCCredsFromOSEnv(grpcConfig.UserIdForOsEnvAuth)
 			if err != nil {
 				return dbfactory.GRPCRemoteConfig{}, err
 			}
@@ -142,11 +145,53 @@ func (p GRPCDialProvider) GetGRPCDialParams(config grpcendpoint.Config) (dbfacto
 		}
 	}
 
+	helper, err := p.getCredentialHelper(grpcConfig, endpoint)
+	if err != nil {
+		return dbfactory.GRPCRemoteConfig{}, err
+	}
+	if helper != nil {
+		opts = append(opts, helper.DialOptions()...)
+		httpfetcher = helper.WrapHTTPFetcher(httpfetcher)
+	}
+
 	return dbfactory.GRPCRemoteConfig{
 		Endpoint:    endpoint,
 		DialOptions: opts,
 		HTTPFetcher: httpfetcher,
 	}, nil
+}
+
+func (p GRPCDialProvider) getCredentialHelper(grpcConfig grpcendpoint.Config, endpoint string) (*credentialhelper.Helper, error) {
+	executable, ok, err := p.globalCredentialHelper()
+	if err != nil || !ok {
+		return nil, err
+	}
+
+	scheme := "https"
+	if grpcConfig.TLSConfig == nil && grpcConfig.Insecure {
+		scheme = "http"
+	}
+	return credentialhelper.New(executable, fmt.Sprintf("%s://%s", scheme, endpoint))
+}
+
+func (p GRPCDialProvider) globalCredentialHelper() (string, bool, error) {
+	if p.dEnv == nil || p.dEnv.Config == nil {
+		return "", false, nil
+	}
+
+	global, ok := p.dEnv.Config.GetConfig(GlobalConfig)
+	if !ok {
+		return "", false, nil
+	}
+
+	executable, err := global.GetString(config.RemotesApiCredentialHelper)
+	if errors.Is(err, config.ErrConfigParamNotFound) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return executable, true, nil
 }
 
 // getRPCCredsFromOSEnv returns RPC Credentials for the specified username, using the DOLT_REMOTE_PASSWORD

--- a/go/libraries/doltcore/env/grpc_dial_provider_test.go
+++ b/go/libraries/doltcore/env/grpc_dial_provider_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/creds"
+	"github.com/dolthub/dolt/go/libraries/doltcore/grpcendpoint"
+	"github.com/dolthub/dolt/go/libraries/utils/config"
+)
+
+func TestCredentialHelperUsesGlobalConfig(t *testing.T) {
+	dEnv, _ := createTestEnv(true, true)
+	global, _ := dEnv.Config.GetConfig(GlobalConfig)
+	local, _ := dEnv.Config.GetConfig(LocalConfig)
+
+	require.NoError(t, global.SetStrings(map[string]string{
+		config.RemotesApiCredentialHelper: "global-helper",
+	}))
+	require.NoError(t, local.SetStrings(map[string]string{
+		config.RemotesApiCredentialHelper: "local-helper",
+	}))
+
+	executable, ok, err := NewGRPCDialProviderFromDoltEnv(dEnv).globalCredentialHelper()
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "global-helper", executable)
+}
+
+func TestCredentialHelperIgnoresLocalConfig(t *testing.T) {
+	dEnv, _ := createTestEnv(true, true)
+	local, _ := dEnv.Config.GetConfig(LocalConfig)
+	require.NoError(t, local.SetStrings(map[string]string{
+		config.RemotesApiCredentialHelper: "local-helper",
+	}))
+
+	_, ok, err := NewGRPCDialProviderFromDoltEnv(dEnv).globalCredentialHelper()
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestCredentialHelperIsAppliedByGRPCDialProvider(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test helper uses a POSIX shell")
+	}
+
+	executable := filepath.Join(t.TempDir(), "credential-helper")
+	err := os.WriteFile(executable, []byte(`#!/bin/sh
+request=$(cat)
+if [ "$1" != "get" ] || [ "$request" != '{"uri":"http://bufnet:80"}' ]; then
+  exit 1
+fi
+printf '%s' '{"headers":{"Proxy-Authorization":["Bearer proxy-token"]},"expires":"2099-01-01T00:00:00Z"}'
+`), 0700)
+	require.NoError(t, err)
+
+	dEnv, _ := createTestEnv(true, true)
+	global, _ := dEnv.Config.GetConfig(GlobalConfig)
+	require.NoError(t, global.SetStrings(map[string]string{
+		config.RemotesApiCredentialHelper: executable,
+	}))
+	dEnv.UserPassConfig = &creds.DoltCredsForPass{
+		Username: "user",
+		Password: "password",
+	}
+
+	dialConfig, err := NewGRPCDialProviderFromDoltEnv(dEnv).GetGRPCDialParams(grpcendpoint.Config{
+		Endpoint:     "bufnet:80",
+		Insecure:     true,
+		WithEnvCreds: true,
+	})
+	require.NoError(t, err)
+
+	listener := bufconn.Listen(1024 * 1024)
+	server := grpc.NewServer(grpc.UnaryInterceptor(func(
+		ctx context.Context,
+		req any,
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (any, error) {
+		md, _ := metadata.FromIncomingContext(ctx)
+		assert.Equal(t, []string{"Basic dXNlcjpwYXNzd29yZA=="}, md.Get("authorization"))
+		assert.Equal(t, []string{"Bearer proxy-token"}, md.Get("proxy-authorization"))
+		return handler(ctx, req)
+	}))
+	healthpb.RegisterHealthServer(server, health.NewServer())
+
+	go func() {
+		_ = server.Serve(listener)
+	}()
+	t.Cleanup(server.Stop)
+
+	dialOptions := append(dialConfig.DialOptions, grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return listener.Dial()
+	}))
+	conn, err := grpc.DialContext(context.Background(), dialConfig.Endpoint, dialOptions...)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = conn.Close()
+	})
+
+	_, err = healthpb.NewHealthClient(conn).Check(context.Background(), &healthpb.HealthCheckRequest{})
+	require.NoError(t, err)
+}

--- a/go/libraries/utils/config/keys.go
+++ b/go/libraries/utils/config/keys.go
@@ -15,23 +15,24 @@
 package config
 
 var ConfigOptions = map[string]struct{}{
-	UserEmailKey:          {},
-	UserNameKey:           {},
-	UserCreds:             {},
-	DoltEditor:            {},
-	InitBranchName:        {},
-	RemotesApiHostKey:     {},
-	RemotesApiHostPortKey: {},
-	AddCredsUrlKey:        {},
-	DoltLabInsecureKey:    {},
-	MetricsDisabled:       {},
-	MetricsHost:           {},
-	MetricsPort:           {},
-	MetricsInsecure:       {},
-	PushAutoSetupRemote:   {},
-	ProfileKey:            {},
-	VersionCheckDisabled:  {},
-	MmapArchiveIndexes:    {},
+	UserEmailKey:               {},
+	UserNameKey:                {},
+	UserCreds:                  {},
+	DoltEditor:                 {},
+	InitBranchName:             {},
+	RemotesApiHostKey:          {},
+	RemotesApiHostPortKey:      {},
+	RemotesApiCredentialHelper: {},
+	AddCredsUrlKey:             {},
+	DoltLabInsecureKey:         {},
+	MetricsDisabled:            {},
+	MetricsHost:                {},
+	MetricsPort:                {},
+	MetricsInsecure:            {},
+	PushAutoSetupRemote:        {},
+	ProfileKey:                 {},
+	VersionCheckDisabled:       {},
+	MmapArchiveIndexes:         {},
 }
 
 const UserEmailKey = "user.email"
@@ -47,6 +48,8 @@ const InitBranchName = "init.defaultbranch"
 const RemotesApiHostKey = "remotes.default_host"
 
 const RemotesApiHostPortKey = "remotes.default_port"
+
+const RemotesApiCredentialHelper = "remotesapi.credential_helper"
 
 const AddCredsUrlKey = "creds.add_url"
 


### PR DESCRIPTION
## Why

Some `remotesapi` deployments sit behind an identity-aware proxy or gateway which needs its own short-lived credential. In that setup there are two separate auth layers:

- the gateway expects something like `Proxy-Authorization: Bearer ...`
- Dolt still expects its normal `Authorization` metadata

The gRPC transport itself already works. The missing piece is a supported way to add the gateway header without replacing Dolt's own credentials.

Our current workaround is a local HTTP/2 proxy which obtains the gateway token, forwards the full gRPC stream, and injects the additional header. It works, but it is a lot of transport machinery for what is ultimately a credential lookup.

This PR adds a global credential helper for `remotesapi` interactions so Dolt can make that request directly.

## How it works

The helper is configured globally:

```bash
dolt config --global --add remotesapi.credential_helper /path/to/helper
```

Dolt uses the Bazel credential helper protocol. It invokes `<helper> get` and sends only the canonical origin on stdin:

```json
{"uri":"https://example.com:443"}
```

The helper returns additive headers and an optional expiration:

```json
{
  "headers": {
    "Proxy-Authorization": ["Bearer TOKEN"]
  },
  "expires": "2026-06-24T20:00:00Z"
}
```

Those headers are added to unary and streaming gRPC calls while Dolt's existing per-RPC credentials remain in place. They are also added to HTTP requests which match the same origin. They are deliberately not forwarded to signed object-store URLs returned by the remote.

Responses are cached until shortly before expiration. A response without an expiration is used once.

## Why global

The executable is read directly from global config, not from the repository config or per-remote parameters. This keeps repository contents and `dolt_remote("add", ...)` from selecting a local binary to execute.

The helper still sees the destination origin and is responsible for returning credentials only for destinations it trusts. This allows one global helper to multiplex safely, for example by using a strict host allowlist or minting audience-bound credentials.

Helper headers are additive. Dolt rejects attempts to replace its `Authorization` header or set transport-controlled headers.

## Validation

- A real gRPC request carries both Dolt's Basic `Authorization` and the helper's `Proxy-Authorization`
- Unary and streaming RPCs are covered
- Expiration, refresh, expired credentials, header validation, and concurrent access are covered
- Same-origin HTTP requests receive helper headers
- Signed URLs on another origin do not receive helper headers
- Repository-local helper configuration is ignored
- The Bazel-compatible subprocess request and response are exercised with an executable test helper
- `go test -race ./libraries/doltcore/credentialhelper`
- `go test ./libraries/doltcore/env`
- `go test ./cmd/dolt/commands -run '^TestConfig'`
- `go test ./libraries/doltcore/dbfactory ./libraries/utils/config`
- `go vet ./libraries/doltcore/credentialhelper`
- `go run ./utils/copyrightshdrs`
- `./utils/repofmt/check_fmt.sh`
- Full `dolt` CLI build

I also ran the full `cmd/dolt/commands` package. Its only failure locally was the signed-commit test because `gpg` is not installed.

Closes #11244.

## AI disclosure

I used OpenAI Codex extensively (using an undisclosed model) to investigate the existing credential path, implement the change, and write tests and documentation. I reviewed the resulting design and code, ran the validation above, and take responsibility for the contribution.
