### PR TITLE
go: doltcore/merge,prolly/tree: Make merge paths recover from panics encountered during merge and return errors directly, instead of crashing.

### DIFF
--- a/go/libraries/doltcore/merge/merge_prolly_rows.go
+++ b/go/libraries/doltcore/merge/merge_prolly_rows.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"runtime/debug"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
@@ -448,15 +449,24 @@ func mergeProllyTableData(ctx *sql.Context, tm *TableMerger, finalSch schema.Sch
 	}
 	var sec *secondaryMerger
 	var conflicts *conflictMerger
-	eg.Go(func() error {
-		var err error
+	eg.Go(func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("panic computing prolly tree patches during merge: %v\n%s", r, string(debug.Stack()))
+			}
+		}()
 		sec, conflicts, err = computeProllyTreePatches(errCtx, tm, finalSch, mergeTbl, valueMerger, mergeInfo, diffInfo, patchBuffer, s)
 		return err
 	})
 
 	var mergedRoot *tree.Node
 	// consume |patches| and apply them to |left|
-	eg.Go(func() error {
+	eg.Go(func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("panic applying patches during merge: %v\n%s", r, string(debug.Stack()))
+			}
+		}()
 		leftRowData, err := tm.leftTbl.GetRowData(errCtx)
 		if err != nil {
 			return err

--- a/go/libraries/doltcore/merge/merge_rows.go
+++ b/go/libraries/doltcore/merge/merge_rows.go
@@ -17,6 +17,8 @@ package merge
 import (
 	"context"
 	"errors"
+	"fmt"
+	"runtime/debug"
 
 	"github.com/dolthub/go-mysql-server/sql"
 
@@ -523,6 +525,11 @@ func calcTableMergeStats(ctx context.Context, tbl *doltdb.Table, mergeTbl *doltd
 	ch := make(chan diff.DiffStatProgress)
 	go func() {
 		defer close(ch)
+		defer func() {
+			if r := recover(); r != nil {
+				ae.SetIfError(fmt.Errorf("panic computing merge stats: %v\n%s", r, string(debug.Stack())))
+			}
+		}()
 		err := diff.Stat(ctx, ch, rows, mergeRows, sch, mergeSch)
 
 		ae.SetIfError(err)

--- a/go/store/prolly/tree/merge.go
+++ b/go/store/prolly/tree/merge.go
@@ -17,6 +17,8 @@ package tree
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"runtime/debug"
 
 	"golang.org/x/sync/errgroup"
 
@@ -82,6 +84,11 @@ func ThreeWayMerge[K ~[]byte, O Ordering[K], S message.Serializer](
 	// iterate |ld| and |rd| in parallel, populating |patches|
 	eg.Go(func() (err error) {
 		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("panic generating patches during three-way merge: %v\n%s", r, string(debug.Stack()))
+			}
+		}()
+		defer func() {
 			if cerr := patches.Close(); err == nil {
 				err = cerr
 			}
@@ -91,7 +98,12 @@ func ThreeWayMerge[K ~[]byte, O Ordering[K], S message.Serializer](
 	})
 
 	// consume |patches| and apply them to |left|
-	eg.Go(func() error {
+	eg.Go(func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("panic applying patches during three-way merge: %v\n%s", r, string(debug.Stack()))
+			}
+		}()
 		final, err = ApplyPatches[K](ctx, ns, left, order, serializer, patches)
 		return err
 	})


### PR DESCRIPTION
Not recovering while in a goroutine causes the process to crash. Especially in server context, we would rather return the error.