### PR TITLE
go: grpcreresolve: Add a load balancer implementation which requests ResolveNow for endpoints when we see Unavailable or DeadlineExceeded.

### DIFF
--- a/go/cmd/dolt/commands/credcmds/check.go
+++ b/go/cmd/dolt/commands/credcmds/check.go
@@ -154,7 +154,7 @@ func checkCredAndPrintSuccess(ctx context.Context, dEnv *env.DoltEnv, dc creds.D
 	if err != nil {
 		return errhand.BuildDError("error: unable to build server endpoint options.").AddCause(err).Build()
 	}
-	conn, err := grpc.Dial(cfg.Endpoint, cfg.DialOptions...)
+	conn, err := grpc.NewClient("dns:///"+cfg.Endpoint, cfg.DialOptions...)
 	if err != nil {
 		return errhand.BuildDError("error: unable to connect to server with credentials.").AddCause(err).Build()
 	}
@@ -169,7 +169,7 @@ func checkCredAndPrintSuccess(ctx context.Context, dEnv *env.DoltEnv, dc creds.D
 	var whoAmI *remotesapi.WhoAmIResponse
 	whoAmI, err = grpcClient.WhoAmI(ctx, &remotesapi.WhoAmIRequest{})
 	if err != nil {
-		return errhand.BuildDError("error: calling doltremoteapi with credentials.").AddCause(err).Build()
+		return errhand.BuildDError("error: calling doltremoteapi at %s with credentials.", endpoint).AddCause(err).Build()
 	}
 
 	cli.Printf("\nSuccess.\n")

--- a/go/cmd/dolt/commands/credcmds/import.go
+++ b/go/cmd/dolt/commands/credcmds/import.go
@@ -169,7 +169,7 @@ func updateProfileWithCredentials(ctx context.Context, dEnv *env.DoltEnv, c cred
 	if err != nil {
 		return fmt.Errorf("error: unable to build dial options server with credentials: %w", err)
 	}
-	conn, err := grpc.Dial(cfg.Endpoint, cfg.DialOptions...)
+	conn, err := grpc.NewClient("dns:///"+cfg.Endpoint, cfg.DialOptions...)
 	if err != nil {
 		return fmt.Errorf("error: unable to connect to server with credentials: %w", err)
 	}
@@ -177,7 +177,7 @@ func updateProfileWithCredentials(ctx context.Context, dEnv *env.DoltEnv, c cred
 	grpcClient := remotesapi.NewCredentialsServiceClient(conn)
 	resp, err := grpcClient.WhoAmI(ctx, &remotesapi.WhoAmIRequest{})
 	if err != nil {
-		return fmt.Errorf("error: unable to call WhoAmI endpoint: %w", err)
+		return fmt.Errorf("error: unable to call WhoAmI endpoint at %s: %w", hostAndPort, err)
 	}
 	userUpdates := map[string]string{
 		config.UserNameKey:  resp.DisplayName,

--- a/go/cmd/dolt/commands/login.go
+++ b/go/cmd/dolt/commands/login.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/skratchdot/open-golang/open"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/cmd/dolt/errhand"
@@ -206,6 +208,9 @@ func loginWithCreds(ctx context.Context, dEnv *env.DoltEnv, dc creds.DoltCreds, 
 	var err error
 	if behavior == checkCredentialsThenOpenBrowser {
 		whoAmI, err = grpcClient.WhoAmI(ctx, &remotesapi.WhoAmIRequest{})
+		if err != nil && status.Code(err) == codes.Unavailable {
+			return errhand.BuildDError("error: unable to reach doltremoteapi at %s.", authEndpoint).AddCause(err).Build()
+		}
 	}
 
 	if whoAmI == nil {
@@ -225,6 +230,13 @@ func loginWithCreds(ctx context.Context, dEnv *env.DoltEnv, dc creds.DoltCreds, 
 		linePrinter("requesting update")
 		whoAmI, err = grpcClient.WhoAmI(ctx, &remotesapi.WhoAmIRequest{})
 		if err != nil {
+			// Unavailable means the endpoint can't be reached (DNS failure,
+			// connection refused, 503); waiting for a key association won't fix
+			// that, so bail instead of looping forever. Other codes indicate the
+			// key isn't associated yet, which is what we're polling for.
+			if status.Code(err) == codes.Unavailable {
+				return errhand.BuildDError("error: unable to reach doltremoteapi at %s.", authEndpoint).AddCause(err).Build()
+			}
 			for i := 0; i < loginRetryInterval; i++ {
 				linePrinter(fmt.Sprintf("Retrying in %d", loginRetryInterval-i))
 				time.Sleep(time.Second)
@@ -259,7 +271,7 @@ func getCredentialsClient(dEnv *env.DoltEnv, dc creds.DoltCreds, authHost, authE
 	if err != nil {
 		return nil, errhand.BuildDError("error: unable to build dial options for connecting to server with credentials.").AddCause(err).Build()
 	}
-	conn, err := grpc.Dial(cfg.Endpoint, cfg.DialOptions...)
+	conn, err := grpc.NewClient("dns:///"+cfg.Endpoint, cfg.DialOptions...)
 	if err != nil {
 		return nil, errhand.BuildDError("error: unable to connect to server with credentials.").AddCause(err).Build()
 	}

--- a/go/cmd/dolt/commands/send_metrics.go
+++ b/go/cmd/dolt/commands/send_metrics.go
@@ -164,7 +164,7 @@ func GRPCEmitterForConfig(pro EmitterConfigProvider, opts ...events.GrpcEmitterO
 		return nil, nil, err
 	}
 
-	conn, err := grpc.Dial(cfg.Endpoint, cfg.DialOptions...)
+	conn, err := grpc.NewClient("dns:///"+cfg.Endpoint, cfg.DialOptions...)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/libraries/doltcore/dbfactory/grpc.go
+++ b/go/libraries/doltcore/dbfactory/grpc.go
@@ -118,7 +118,11 @@ func (fact DoltRemoteFactory) newChunkStore(ctx context.Context, nbf *types.Noms
 
 	opts := append(cfg.DialOptions, grpc.WithChainUnaryInterceptor(remotestorage.RetryingUnaryClientInterceptor))
 
-	conn, err := grpc.Dial(cfg.Endpoint, opts...)
+	// Dial through the dns resolver (the dns:/// prefix) rather than the default
+	// passthrough resolver so the re-resolving load-balancing policy can recover
+	// when the endpoint moves to a new IP. Passthrough never re-resolves. See
+	// grpcreresolve.
+	conn, err := grpc.NewClient("dns:///"+cfg.Endpoint, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/dbfactory/grpcreresolve/balancer.go
+++ b/go/libraries/doltcore/dbfactory/grpcreresolve/balancer.go
@@ -1,0 +1,189 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package grpcreresolve provides a gRPC load-balancing policy that
+// asks gRPC to re-resolve the endpoint on Unavailable and
+// DeadlineExceeded responses. This fixes a potential sticky-fault
+// scenario when behind an L7 proxy or service mesh (e.g. Istio in
+// K8s), where gRPC's default resolver only re-resolves on transport
+// level failures and the service mesh side car does not terminate the
+// connection when delivering the no-upstream response. When an
+// upstream moves or dies, a gRPC ClientConn can be left with a
+// SubChannel indefinitely resolved to the stale IP address.
+//
+// Implemented as a thin wrapper over pick_first which uses the Done
+// signal to call ClientConn.ResolveNow when we see failures. dns
+// resolver ResolveNow already de-bounces resolution requests.
+package grpcreresolve
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/balancer/pickfirst"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/serviceconfig"
+	"google.golang.org/grpc/status"
+)
+
+// Name is the name under which this load-balancing policy is registered. Select
+// it on a ClientConn with grpc.WithDefaultServiceConfig(ServiceConfigJSON).
+const Name = "dolt_reresolve_pick_first"
+
+// defaultFailureThreshold is the number of consecutive connectivity
+// failures (see isConnectivityFailure) that triggers a
+// re-resolution. See isConnectivityFailure.  Because the resolver
+// already debounces ResolveNow requests, it is better to be
+// responsive here rather than conservative.
+const defaultFailureThreshold = 1
+
+// ServiceConfigJSON selects this policy. Pass it to
+// grpc.WithDefaultServiceConfig when dialing.
+const ServiceConfigJSON = `{"loadBalancingConfig":[{"` + Name + `":{}}]}`
+
+func init() {
+	balancer.Register(builder{})
+}
+
+type builder struct{}
+
+func (builder) Name() string { return Name }
+
+func (builder) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
+	b := &reResolveBalancer{cc: cc}
+	b.threshold.Store(defaultFailureThreshold)
+	// The child is a stock pick_first. We hand it a wrapped ClientConn so we can
+	// intercept the pickers it publishes; everything else passes through.
+	wrapped := &ccWrapper{ClientConn: cc, b: b}
+	b.Balancer = balancer.Get(pickfirst.Name).Build(wrapped, opts)
+	return b
+}
+
+// lbConfig is the parsed form of this policy's service-config entry. The only
+// knob is an optional failureThreshold override.
+type lbConfig struct {
+	serviceconfig.LoadBalancingConfig `json:"-"`
+	FailureThreshold                  uint32 `json:"failureThreshold,omitempty"`
+}
+
+func (builder) ParseConfig(j json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
+	cfg := &lbConfig{}
+	if err := json.Unmarshal(j, cfg); err != nil {
+		return nil, fmt.Errorf("%s: invalid load balancing config %q: %w", Name, string(j), err)
+	}
+	return cfg, nil
+}
+
+// reResolveBalancer embeds a child pick_first balancer and adds failure-driven
+// re-resolution. All balancer.Balancer methods except UpdateClientConnState are
+// satisfied by the embedded child.
+type reResolveBalancer struct {
+	balancer.Balancer
+
+	cc        balancer.ClientConn
+	threshold atomic.Uint32
+	failures  atomic.Uint32
+}
+
+func (b *reResolveBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
+	threshold := uint32(defaultFailureThreshold)
+	if cfg, ok := s.BalancerConfig.(*lbConfig); ok && cfg.FailureThreshold > 0 {
+		threshold = cfg.FailureThreshold
+	}
+	b.threshold.Store(threshold)
+
+	// pick_first rejects any non-nil BalancerConfig it does not
+	// recognize.  Let it run with default behavior.
+	s.BalancerConfig = nil
+	return b.Balancer.UpdateClientConnState(s)
+}
+
+// onRPCDone is called for every completed RPC picked through this balancer's
+// picker. It counts consecutive connectivity failures and asks gRPC to
+// re-resolve once the threshold is reached.
+func (b *reResolveBalancer) onRPCDone(err error) {
+	if err == nil {
+		b.failures.Store(0)
+		return
+	}
+	if !isConnectivityFailure(err) {
+		// A non-connectivity outcome (an application-level code) does not signal a
+		// moved endpoint, but neither does it signal health: leave the consecutive
+		// streak untouched so interleaved application errors don't mask a genuine
+		// run of connectivity failures.
+		return
+	}
+	if b.failures.Add(1) >= b.threshold.Load() {
+		b.failures.Store(0)
+		b.cc.ResolveNow(resolver.ResolveNowOptions{})
+	}
+}
+
+// isConnectivityFailure reports whether err is the kind of failure that, behind
+// an L7 proxy / service mesh, indicates the endpoint may have moved and a
+// re-resolution is warranted.
+//
+// Use trigger on both Unavailable and DeadlineExceeded because a mesh can
+// surface a stale endpoint in two phases: an RPC to a dead ORIGINAL_DST first
+// blackholes and trips the caller's deadline (DeadlineExceeded), and only once
+// the sidecar's endpoint discovery drops the gone upstream does it return
+// 503 / "upstream request timeout" (Unavailable).
+func isConnectivityFailure(err error) bool {
+	switch status.Code(err) {
+	case codes.Unavailable, codes.DeadlineExceeded:
+		return true
+	default:
+		return false
+	}
+}
+
+// ccWrapper intercepts the pickers published by the child balancer so we can
+// observe RPC outcomes. Every other ClientConn method is inherited unchanged
+// from the embedded real ClientConn.
+type ccWrapper struct {
+	balancer.ClientConn
+	b *reResolveBalancer
+}
+
+func (w *ccWrapper) UpdateState(s balancer.State) {
+	if s.Picker != nil {
+		s.Picker = &picker{Picker: s.Picker, b: w.b}
+	}
+	w.ClientConn.UpdateState(s)
+}
+
+// picker delegates selection to the child picker and wraps the result's Done
+// callback to feed RPC outcomes back to the balancer.
+type picker struct {
+	balancer.Picker
+	b *reResolveBalancer
+}
+
+func (p *picker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
+	res, err := p.Picker.Pick(info)
+	if err != nil {
+		return res, err
+	}
+	orig := res.Done
+	res.Done = func(di balancer.DoneInfo) {
+		if orig != nil {
+			orig(di)
+		}
+		p.b.onRPCDone(di.Err)
+	}
+	return res, nil
+}

--- a/go/libraries/doltcore/dbfactory/grpcreresolve/balancer_test.go
+++ b/go/libraries/doltcore/dbfactory/grpcreresolve/balancer_test.go
@@ -1,0 +1,269 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcreresolve
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/resolver/manual"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// fakeCC is a minimal balancer.ClientConn that only records ResolveNow calls.
+type fakeCC struct {
+	balancer.ClientConn
+	resolveNow atomic.Int32
+}
+
+func (f *fakeCC) ResolveNow(resolver.ResolveNowOptions) { f.resolveNow.Add(1) }
+
+func TestOnRPCDoneThresholdAndReset(t *testing.T) {
+	cc := &fakeCC{}
+	b := &reResolveBalancer{cc: cc}
+	b.threshold.Store(3)
+
+	unavail := func() { b.onRPCDone(status.Error(codes.Unavailable, "down")) }
+
+	// Below the threshold: no re-resolve.
+	unavail()
+	unavail()
+	require.Equal(t, int32(0), cc.resolveNow.Load())
+
+	// Hitting the threshold fires exactly one ResolveNow and resets the counter.
+	unavail()
+	require.Equal(t, int32(1), cc.resolveNow.Load())
+
+	unavail()
+	unavail()
+	require.Equal(t, int32(1), cc.resolveNow.Load())
+	unavail()
+	require.Equal(t, int32(2), cc.resolveNow.Load())
+
+	// A success resets the consecutive-failure streak.
+	unavail()
+	unavail()
+	b.onRPCDone(nil)
+	unavail()
+	require.Equal(t, int32(2), cc.resolveNow.Load(), "success should have reset the streak")
+}
+
+func TestOnRPCDoneIgnoresApplicationCodes(t *testing.T) {
+	cc := &fakeCC{}
+	b := &reResolveBalancer{cc: cc}
+	b.threshold.Store(2)
+
+	// Application-level codes must never trigger re-resolution, no matter how many
+	// of them arrive.
+	b.onRPCDone(status.Error(codes.NotFound, "missing"))
+	b.onRPCDone(status.Error(codes.PermissionDenied, "no"))
+	b.onRPCDone(status.Error(codes.Canceled, "ctx"))
+	b.onRPCDone(status.Error(codes.InvalidArgument, "bad"))
+	require.Equal(t, int32(0), cc.resolveNow.Load())
+}
+
+func TestOnRPCDoneCountsConnectivityFailures(t *testing.T) {
+	// Both codes.Unavailable and codes.DeadlineExceeded are connectivity failures:
+	// behind a mesh a stale endpoint first trips the deadline, then turns into
+	// Unavailable, and we want recovery to begin in the first phase.
+	for _, code := range []codes.Code{codes.Unavailable, codes.DeadlineExceeded} {
+		t.Run(code.String(), func(t *testing.T) {
+			cc := &fakeCC{}
+			b := &reResolveBalancer{cc: cc}
+			b.threshold.Store(2)
+
+			b.onRPCDone(status.Error(code, "fail"))
+			require.Equal(t, int32(0), cc.resolveNow.Load())
+			b.onRPCDone(status.Error(code, "fail"))
+			require.Equal(t, int32(1), cc.resolveNow.Load())
+		})
+	}
+}
+
+func TestOnRPCDoneMixedConnectivityFailures(t *testing.T) {
+	// A run of connectivity failures counts even when the codes alternate, and an
+	// interleaved application error neither counts nor resets the streak.
+	cc := &fakeCC{}
+	b := &reResolveBalancer{cc: cc}
+	b.threshold.Store(3)
+
+	b.onRPCDone(status.Error(codes.DeadlineExceeded, "blackhole"))
+	b.onRPCDone(status.Error(codes.NotFound, "app error, ignored"))
+	b.onRPCDone(status.Error(codes.Unavailable, "upstream request timeout"))
+	require.Equal(t, int32(0), cc.resolveNow.Load())
+	b.onRPCDone(status.Error(codes.Unavailable, "upstream request timeout"))
+	require.Equal(t, int32(1), cc.resolveNow.Load())
+}
+
+func TestParseConfig(t *testing.T) {
+	cfg, err := builder{}.ParseConfig([]byte(`{}`))
+	require.NoError(t, err)
+	require.Equal(t, uint32(0), cfg.(*lbConfig).FailureThreshold)
+
+	cfg, err = builder{}.ParseConfig([]byte(`{"failureThreshold":5}`))
+	require.NoError(t, err)
+	require.Equal(t, uint32(5), cfg.(*lbConfig).FailureThreshold)
+
+	_, err = builder{}.ParseConfig([]byte(`{bad`))
+	require.Error(t, err)
+}
+
+// recordingBalancer captures the ClientConnState handed to the child.
+type recordingBalancer struct {
+	balancer.Balancer
+	last balancer.ClientConnState
+}
+
+func (r *recordingBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
+	r.last = s
+	return nil
+}
+
+func TestUpdateClientConnStateStripsConfigAndSetsThreshold(t *testing.T) {
+	child := &recordingBalancer{}
+	b := &reResolveBalancer{cc: &fakeCC{}}
+	b.Balancer = child
+
+	// A config with a threshold override is applied to us and stripped before
+	// reaching the child pick_first (which rejects configs it doesn't recognize).
+	require.NoError(t, b.UpdateClientConnState(balancer.ClientConnState{BalancerConfig: &lbConfig{FailureThreshold: 7}}))
+	require.Nil(t, child.last.BalancerConfig)
+	require.Equal(t, uint32(7), b.threshold.Load())
+
+	// With no config we fall back to the default threshold.
+	b.threshold.Store(99)
+	require.NoError(t, b.UpdateClientConnState(balancer.ClientConnState{}))
+	require.Equal(t, uint32(defaultFailureThreshold), b.threshold.Load())
+}
+
+type unavailableHealth struct {
+	grpc_health_v1.UnimplementedHealthServer
+}
+
+func (unavailableHealth) Check(context.Context, *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	// Connectable server whose RPCs fail at L7 — mimics an Envoy sidecar that
+	// stays up while the real upstream is gone. The subchannel stays READY, so
+	// stock gRPC never re-resolves on its own.
+	return nil, status.Error(codes.Unavailable, "upstream unavailable")
+}
+
+type servingHealth struct {
+	grpc_health_v1.UnimplementedHealthServer
+}
+
+func (servingHealth) Check(context.Context, *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
+}
+
+func serveHealth(t *testing.T, impl grpc_health_v1.HealthServer) *bufconn.Listener {
+	t.Helper()
+	lis := bufconn.Listen(1024 * 1024)
+	srv := grpc.NewServer()
+	grpc_health_v1.RegisterHealthServer(srv, impl)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+	return lis
+}
+
+// TestReResolveRecoversFromMovedEndpoint reproduces the mesh mechanism end to
+// end: server A is reachable (subchannel READY) but every RPC returns
+// Unavailable, so stock gRPC would never re-resolve. Our policy observes the
+// failures and calls ResolveNow; the resolver then returns server B and
+// pick_first switches to it.
+func TestReResolveRecoversFromMovedEndpoint(t *testing.T) {
+	const addrA, addrB = "server-a", "server-b"
+
+	aLis := serveHealth(t, unavailableHealth{})
+	bLis := serveHealth(t, servingHealth{})
+
+	dialer := func(ctx context.Context, s string) (net.Conn, error) {
+		switch s {
+		case addrA:
+			return aLis.DialContext(ctx)
+		case addrB:
+			return bLis.DialContext(ctx)
+		}
+		return nil, fmt.Errorf("unknown address %q", s)
+	}
+
+	r := manual.NewBuilderWithScheme("grpcreresolvetest")
+	r.InitialState(resolver.State{Addresses: []resolver.Address{{Addr: addrA}}})
+
+	var allowSwitch atomic.Bool
+	var switched atomic.Bool
+	var resolveNowCount atomic.Int32
+	r.ResolveNowCallback = func(resolver.ResolveNowOptions) {
+		resolveNowCount.Add(1)
+		if allowSwitch.Load() && switched.CompareAndSwap(false, true) {
+			// Mirror the dns resolver: deliver the new state asynchronously.
+			go r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: addrB}}})
+		}
+	}
+
+	cc, err := grpc.NewClient(
+		r.Scheme()+":///ignored",
+		grpc.WithResolvers(r),
+		grpc.WithContextDialer(dialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultServiceConfig(ServiceConfigJSON),
+	)
+	require.NoError(t, err)
+	defer cc.Close()
+
+	client := grpc_health_v1.NewHealthClient(cc)
+	check := func() (*grpc_health_v1.HealthCheckResponse, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		return client.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+	}
+
+	// Phase 1: only A exists and switching is disabled. Confirm RPCs actually
+	// reach A and fail Unavailable, proving the subchannel is READY (so stock
+	// gRPC is not re-resolving) before we test our trigger.
+	sawUnavailable := false
+	for i := 0; i < 50 && !sawUnavailable; i++ {
+		if _, err := check(); status.Code(err) == codes.Unavailable {
+			sawUnavailable = true
+		}
+	}
+	require.True(t, sawUnavailable, "expected RPCs to reach server A and return Unavailable")
+
+	// Phase 2: allow the endpoint to move. Our policy must drive ResolveNow,
+	// the resolver returns B, and pick_first switches so RPCs succeed.
+	allowSwitch.Store(true)
+	var lastErr error
+	served := false
+	for i := 0; i < 100 && !served; i++ {
+		resp, err := check()
+		lastErr = err
+		if err == nil && resp.Status == grpc_health_v1.HealthCheckResponse_SERVING {
+			served = true
+		}
+	}
+	require.True(t, served, "expected recovery to server B; last err: %v", lastErr)
+	require.Greater(t, resolveNowCount.Load(), int32(0), "our policy should have triggered ResolveNow")
+}

--- a/go/libraries/doltcore/env/grpc_dial_provider.go
+++ b/go/libraries/doltcore/env/grpc_dial_provider.go
@@ -34,6 +34,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/credentialhelper"
 	"github.com/dolthub/dolt/go/libraries/doltcore/creds"
 	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
+	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory/grpcreresolve"
 	"github.com/dolthub/dolt/go/libraries/doltcore/dconfig"
 	"github.com/dolthub/dolt/go/libraries/doltcore/grpcendpoint"
 	"github.com/dolthub/dolt/go/libraries/doltcore/remotesrv"
@@ -123,6 +124,9 @@ func (p GRPCDialProvider) GetGRPCDialParams(grpcConfig grpcendpoint.Config) (dbf
 
 	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(remotesrv.MaxGRPCMessageSize)))
 	opts = append(opts, grpc.WithUserAgent(p.getUserAgentString()))
+
+	// Use the failure-driven re-resolving load-balancing policy.
+	opts = append(opts, grpc.WithDefaultServiceConfig(grpcreresolve.ServiceConfigJSON))
 
 	if grpcConfig.Creds != nil {
 		opts = append(opts, grpc.WithPerRPCCredentials(grpcConfig.Creds))

--- a/go/libraries/doltcore/sqle/cluster/branch_control_replica.go
+++ b/go/libraries/doltcore/sqle/cluster/branch_control_replica.go
@@ -246,7 +246,7 @@ func (p *branchControlReplication) waitForReplication(timeout time.Duration) ([]
 	for i := range res {
 		res[i].database = "dolt_branch_control"
 		res[i].remote = replicas[i].client.remote
-		res[i].remoteUrl = replicas[i].client.httpUrl()
+		res[i].remoteUrl = replicas[i].client.httpUrl
 	}
 	var wg sync.WaitGroup
 	wg.Add(len(replicas))

--- a/go/libraries/doltcore/sqle/cluster/controller.go
+++ b/go/libraries/doltcore/sqle/cluster/controller.go
@@ -46,6 +46,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/creds"
 	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory"
+	"github.com/dolthub/dolt/go/libraries/doltcore/dbfactory/grpcreresolve"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/remotesrv"
@@ -1196,8 +1197,10 @@ type replicationServiceClient struct {
 	client replicationapi.ReplicationServiceClient
 	closer func() error
 	remote string
-	url    string
-	tls    bool
+	// httpUrl is the Dolt remote URL (e.g. http://53.78.2.1:3832) matching this
+	// client's endpoint. It is derived from the same remote URL as the gRPC dial
+	// target, so it stays correct regardless of the grpc target's scheme/format.
+	httpUrl string
 }
 
 func (c *Controller) replicationServiceDialOptions() []grpc.DialOption {
@@ -1213,6 +1216,9 @@ func (c *Controller) replicationServiceDialOptions() []grpc.DialOption {
 
 	ret = append(ret, grpc.WithPerRPCCredentials(c.grpcCreds))
 
+	// Use the failure-driven re-resolving load-balancing policy.
+	ret = append(ret, grpc.WithDefaultServiceConfig(grpcreresolve.ServiceConfigJSON))
+
 	return ret
 }
 
@@ -1224,30 +1230,24 @@ func (c *Controller) replicationServiceClients(ctx context.Context) ([]*replicat
 		if err != nil {
 			return nil, fmt.Errorf("could not parse remote url template [%s] for remote %s: %w", r.RemoteURLTemplate(), r.Name(), err)
 		}
-		grpcTarget := "dns:" + url.Hostname() + ":" + url.Port()
-		cc, err := grpc.DialContext(ctx, grpcTarget, c.replicationServiceDialOptions()...)
+		hostPort := url.Hostname() + ":" + url.Port()
+		grpcTarget := "dns:///" + hostPort
+		cc, err := grpc.NewClient(grpcTarget, c.replicationServiceDialOptions()...)
 		if err != nil {
 			return nil, fmt.Errorf("could not dial grpc endpoint [%s] for remote %s: %w", grpcTarget, r.Name(), err)
 		}
+		httpScheme := "http://"
+		if c.tlsCfg != nil {
+			httpScheme = "https://"
+		}
 		client := replicationapi.NewReplicationServiceClient(cc)
 		ret = append(ret, &replicationServiceClient{
-			remote: r.Name(),
-			url:    grpcTarget,
-			tls:    c.tlsCfg != nil,
-			client: client,
-			closer: cc.Close,
+			remote:  r.Name(),
+			httpUrl: httpScheme + hostPort,
+			client:  client,
+			closer:  cc.Close,
 		})
 	}
 	return ret, nil
 }
 
-// Generally r.url is a gRPC dial endpoint and will be something like "dns:53.78.2.1:3832", or something like that.
-//
-// We want to match these endpoints up with Dolt remotes URLs, which will typically be something like http://53.78.2.1:3832.
-func (r *replicationServiceClient) httpUrl() string {
-	prefix := "https://"
-	if !r.tls {
-		prefix = "http://"
-	}
-	return prefix + strings.TrimPrefix(r.url, "dns:")
-}

--- a/go/libraries/doltcore/sqle/cluster/controller.go
+++ b/go/libraries/doltcore/sqle/cluster/controller.go
@@ -1250,4 +1250,3 @@ func (c *Controller) replicationServiceClients(ctx context.Context) ([]*replicat
 	}
 	return ret, nil
 }
-

--- a/go/libraries/doltcore/sqle/cluster/mysqldb_persister.go
+++ b/go/libraries/doltcore/sqle/cluster/mysqldb_persister.go
@@ -279,7 +279,7 @@ func (p *replicatingMySQLDbPersister) waitForReplication(timeout time.Duration) 
 	for i := range replicas {
 		res[i].database = "mysql"
 		res[i].remote = replicas[i].client.remote
-		res[i].remoteUrl = replicas[i].client.httpUrl()
+		res[i].remoteUrl = replicas[i].client.httpUrl
 	}
 	var wg sync.WaitGroup
 	wg.Add(len(replicas))

--- a/go/libraries/events/emitter.go
+++ b/go/libraries/events/emitter.go
@@ -116,6 +116,7 @@ func (we WriterEmitter) LogEventsRequest(ctx context.Context, req *eventsapi.Log
 // GrpcEmitter sends events to a GRPC service implementing the eventsapi
 type GrpcEmitter struct {
 	client      eventsapi.ClientEventsServiceClient
+	target      string
 	application eventsapi.AppID
 }
 
@@ -134,6 +135,7 @@ func NewGrpcEmitter(conn *grpc.ClientConn, opts ...GrpcEmitterOption) *GrpcEmitt
 	client := eventsapi.NewClientEventsServiceClient(conn)
 	g := &GrpcEmitter{
 		client:      client,
+		target:      conn.Target(),
 		application: Application,
 	}
 	for _, opt := range opts {
@@ -174,7 +176,12 @@ func (em *GrpcEmitter) LogEventsRequest(ctx context.Context, req *eventsapi.LogE
 // SendLogEventsRequest sends a request using the grpc client
 func (em *GrpcEmitter) sendLogEventsRequest(ctx context.Context, req *eventsapi.LogEventsRequest) error {
 	_, err := em.client.LogEvents(ctx, req)
-	return err
+	if err != nil {
+		// Include the dial target in the error. The dns resolver reports failures
+		// as "produced zero addresses" without the hostname, so surface it here.
+		return fmt.Errorf("error sending events to %s: %w", em.target, err)
+	}
+	return nil
 }
 
 // FileEmitter saves event requests to files


### PR DESCRIPTION
When running Dolt within a k8s cluster with a service mesh like Istio, the L4 connection to the first-hop load balancer can stay open even when the endpoint associated with that name moves on. gRPC's default pick_first load balancer will not reresolve the endpoints associated with the name unless the L4 connection is lost, which causes persistent failures instead of quick recovery.

Here we implement a new load balancer strategy which just wraps pick_first. It listens for Done on the RPCs, and it calls resolver.ResolveNow if it sees Unavailable or DeadlineExceeded. The DNS resolver in gRPC already debounces resolve requests, so this does not spam reresolves too quickly in the case of true upstream unavailability.