### PR TITLE
Fix spurious unique key error when staging workspace rows

### DIFF
--- a/go/libraries/doltcore/sqle/dtables/workspace_table.go
+++ b/go/libraries/doltcore/sqle/dtables/workspace_table.go
@@ -194,9 +194,7 @@ func (wtu *WorkspaceTableUpdater) Update(ctx *sql.Context, old sql.Row, new sql.
 		return tableWriter.Delete(ctx, fromRow)
 	}
 
-	if r, ok := tableWriter.(interface {
-		UpdateChangesUniqueKey(oldRow, newRow sql.Row) bool
-	}); ok && !r.UpdateChangesUniqueKey(fromRow, toRow) {
+	if r, ok := tableWriter.(writer.UniqueKeyChangeReporter); ok && !r.UpdateChangesUniqueKey(fromRow, toRow) {
 		return tableWriter.Update(ctx, fromRow, toRow)
 	}
 

--- a/go/libraries/doltcore/sqle/dtables/workspace_table.go
+++ b/go/libraries/doltcore/sqle/dtables/workspace_table.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/analyzer"
@@ -85,6 +86,7 @@ type WorkspaceTableModifier struct {
 
 type WorkspaceTableUpdater struct {
 	WorkspaceTableModifier
+	deferredPuts []sql.Row
 }
 
 var _ sql.RowUpdater = (*WorkspaceTableUpdater)(nil)
@@ -182,25 +184,59 @@ func (wtu *WorkspaceTableUpdater) Update(ctx *sql.Context, old sql.Row, new sql.
 		toRow, fromRow = fromRow, toRow
 	}
 
-	// It's a delete if all the values in toRow are nil.
-	isDelete := true
-	for _, val := range toRow {
-		if val != nil {
-			isDelete = false
-			break
-		}
-	}
-
 	tableWriter := (*wtu.tableWriter)
 	if tableWriter == nil {
 		return fmt.Errorf("Runtime error: table writer is nil")
 	}
 
-	if isDelete {
+	// It's a delete if all the values in toRow are nil.
+	if rowIsAllNulls(toRow) {
 		return tableWriter.Delete(ctx, fromRow)
-	} else {
+	}
+
+	if r, ok := tableWriter.(interface {
+		UpdateChangesUniqueKey(oldRow, newRow sql.Row) bool
+	}); ok && !r.UpdateChangesUniqueKey(fromRow, toRow) {
 		return tableWriter.Update(ctx, fromRow, toRow)
 	}
+
+	// Applying deletes now and puts at statement end lets a unique key freed by one row be taken by another.
+	if !rowIsAllNulls(fromRow) {
+		if err := tableWriter.Delete(ctx, fromRow); err != nil {
+			return err
+		}
+	}
+	wtu.deferredPuts = append(wtu.deferredPuts, slices.Clone(toRow))
+	return nil
+}
+
+func rowIsAllNulls(row sql.Row) bool {
+	return !slices.ContainsFunc(row, func(val interface{}) bool { return val != nil })
+}
+
+// StatementComplete applies the deferred puts and then flushes as usual. A failed put discards the partially
+// applied statement so the roots stay untouched.
+func (wtu *WorkspaceTableUpdater) StatementComplete(ctx *sql.Context) error {
+	if wtu.err != nil {
+		return *wtu.err
+	}
+	puts := wtu.deferredPuts
+	wtu.deferredPuts = nil
+	for _, row := range puts {
+		if err := (*wtu.tableWriter).Insert(ctx, row); err != nil {
+			// The put error is the one to report, so the discard error is dropped.
+			_ = (*wtu.tableWriter).DiscardChanges(ctx, err)
+			wtu.tableWriter = nil
+			wtu.sessionWriter = nil
+			return err
+		}
+	}
+	return wtu.statementComplete(ctx)
+}
+
+func (wtu *WorkspaceTableUpdater) DiscardChanges(ctx *sql.Context, errorEncountered error) error {
+	wtu.deferredPuts = nil
+	return wtu.WorkspaceTableModifier.DiscardChanges(ctx, errorEncountered)
 }
 
 func (wtu *WorkspaceTableUpdater) Close(c *sql.Context) error {
@@ -520,7 +556,7 @@ func (wt *WorkspaceTable) Updater(ctx *sql.Context) sql.RowUpdater {
 	}
 
 	return &WorkspaceTableUpdater{
-		modifier,
+		WorkspaceTableModifier: modifier,
 	}
 }
 

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_workspace.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_workspace.go
@@ -17,6 +17,8 @@ package enginetest
 import (
 	"github.com/dolthub/go-mysql-server/enginetest/queries"
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/plan"
+	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
 var DoltWorkspaceScriptTests = []queries.ScriptTest{
@@ -1176,6 +1178,178 @@ var DoltWorkspaceScriptTests = []queries.ScriptTest{
 			{
 				Query:    "select id from list_entries order by id",
 				Expected: []sql.Row{},
+			},
+		},
+	},
+	{
+		// See https://github.com/dolthub/dolt/issues/11195.
+		Name: "dolt_workspace_* stage a delete and insert that reuse a unique key",
+		SetUpScript: []string{
+			"create table t (id int primary key, u int, unique index ix (u));",
+			"call dolt_commit('-Am', 'creating table t');",
+			"insert into t values (5, 10);",
+			"call dolt_commit('-am', 'insert row with u=10');",
+			"delete from t where id = 5;",
+			"insert into t values (1, 10);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "update dolt_workspace_t set staged = 1 where diff_type = 'added'",
+				// Staging only the added row leaves both the old and the new u=10 row in staging.
+				ExpectedErr: sql.ErrUniqueKeyViolation,
+			},
+			{
+				Query: "select diff_type, staged from dolt_workspace_t order by diff_type",
+				// The failed staging must not stage anything.
+				Expected: []sql.Row{{"added", false}, {"removed", false}},
+			},
+			{
+				Query:    "select id, u from t as of 'STAGED'",
+				Expected: []sql.Row{{5, 10}},
+			},
+			{
+				Query:    "update dolt_workspace_t set staged = 1",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 2, Info: plan.UpdateInfo{Matched: 2, Updated: 2}}}},
+			},
+			{
+				Query:    "select id, u from t as of 'STAGED'",
+				Expected: []sql.Row{{1, 10}},
+			},
+			{
+				Query: "select id from t as of 'STAGED' where u = 10",
+				// A lookup through the unique index must find the staged row, proving the index is consistent.
+				Expected: []sql.Row{{1}},
+			},
+		},
+	},
+	{
+		// See https://github.com/dolthub/dolt/issues/11195.
+		Name: "dolt_workspace_* stage a delete and insert that reuse a composite unique key",
+		SetUpScript: []string{
+			"create table foo (id varchar(36) primary key);",
+			"create table bar (id varchar(36) primary key, foo_id varchar(36) not null, sequence int, " +
+				"foreign key (foo_id) references foo(id) on delete cascade on update cascade, " +
+				"unique index idx_foo_id_sequence (foo_id, sequence));",
+			"call dolt_commit('-Am', 'creating tables foo and bar');",
+			"insert into foo values ('f1');",
+			"insert into bar values ('b1', 'f1', 10);",
+			"call dolt_commit('-am', 'insert foo and bar with sequence 10');",
+			"delete from bar where id = 'b1';",
+			"insert into bar values ('b2', 'f1', 10);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "update dolt_workspace_bar set staged = 1",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 2, Info: plan.UpdateInfo{Matched: 2, Updated: 2}}}},
+			},
+			{
+				Query:    "select id, sequence from bar as of 'STAGED'",
+				Expected: []sql.Row{{"b2", 10}},
+			},
+		},
+	},
+	{
+		// See https://github.com/dolthub/dolt/issues/11195.
+		Name: "dolt_workspace_* stage two modifies that swap a unique key",
+		SetUpScript: []string{
+			"create table t (id int primary key, u int, unique index ix (u));",
+			"call dolt_commit('-Am', 'creating table t');",
+			"insert into t values (1, 10), (2, 20);",
+			"call dolt_commit('-am', 'insert two rows');",
+			"update t set u = 99 where id = 1;",
+			"update t set u = 10 where id = 2;",
+			"update t set u = 20 where id = 1;",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "update dolt_workspace_t set staged = 1",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 2, Info: plan.UpdateInfo{Matched: 2, Updated: 2}}}},
+			},
+			{
+				Query:    "select id, u from t as of 'STAGED' order by id",
+				Expected: []sql.Row{{1, 20}, {2, 10}},
+			},
+		},
+	},
+	{
+		// See https://github.com/dolthub/dolt/issues/11195.
+		Name: "dolt_workspace_* keyless table stage a delete and insert that reuse a unique key",
+		SetUpScript: []string{
+			"create table t (a int, u int, unique index ix (u));",
+			"call dolt_commit('-Am', 'creating keyless table t');",
+			"insert into t values (1, 10);",
+			"call dolt_commit('-am', 'insert row with u=10');",
+			"delete from t where a = 1;",
+			"insert into t values (2, 10);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "update dolt_workspace_t set staged = 1 where diff_type = 'added'",
+				// Staging only the added row leaves both the old and the new u=10 row in staging.
+				ExpectedErr: sql.ErrUniqueKeyViolation,
+			},
+			{
+				Query: "select diff_type, staged from dolt_workspace_t order by diff_type",
+				// The failed staging must not stage anything.
+				Expected: []sql.Row{{"added", false}, {"removed", false}},
+			},
+			{
+				Query:    "select a, u from t as of 'STAGED'",
+				Expected: []sql.Row{{1, 10}},
+			},
+			{
+				Query:    "update dolt_workspace_t set staged = 1",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 2, Info: plan.UpdateInfo{Matched: 2, Updated: 2}}}},
+			},
+			{
+				Query:    "select a, u from t as of 'STAGED'",
+				Expected: []sql.Row{{2, 10}},
+			},
+		},
+	},
+	{
+		// See https://github.com/dolthub/dolt/issues/11195.
+		Name: "dolt_workspace_* stage a modify that leaves the unique key untouched",
+		SetUpScript: []string{
+			"create table t (id int primary key, u int, v int, unique index ix (u));",
+			"call dolt_commit('-Am', 'creating table t');",
+			"insert into t values (1, 10, 100), (2, 20, 200);",
+			"call dolt_commit('-am', 'insert two rows');",
+			"update t set v = 101 where id = 1;",
+			"delete from t where id = 2;",
+			"insert into t values (3, 20, 300);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "update dolt_workspace_t set staged = 1",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 3, Info: plan.UpdateInfo{Matched: 3, Updated: 3}}}},
+			},
+			{
+				Query:    "select id, u, v from t as of 'STAGED' order by id",
+				Expected: []sql.Row{{1, 10, 101}, {3, 20, 300}},
+			},
+		},
+	},
+	{
+		// See https://github.com/dolthub/dolt/issues/11195.
+		Name: "dolt_workspace_* stage rows that share a null unique key",
+		SetUpScript: []string{
+			"create table t (id int primary key, u int, unique index ix (u));",
+			"call dolt_commit('-Am', 'creating table t');",
+			"insert into t values (1, 10);",
+			"call dolt_commit('-am', 'insert row with u=10');",
+			"update t set u = null where id = 1;",
+			"insert into t values (2, null);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "update dolt_workspace_t set staged = 1",
+				// NULLs do not collide under a unique index.
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 2, Info: plan.UpdateInfo{Matched: 2, Updated: 2}}}},
+			},
+			{
+				Query:    "select id, u from t as of 'STAGED' order by id",
+				Expected: []sql.Row{{1, nil}, {2, nil}},
 			},
 		},
 	},

--- a/go/libraries/doltcore/sqle/writer/prolly_index_writer.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_index_writer.go
@@ -321,7 +321,7 @@ func (m prollySecondaryIndexWriter) matchesPredicate(ctx context.Context, sqlRow
 }
 
 var _ indexWriter = prollySecondaryIndexWriter{}
-var _ uniqueKeyChangeReporter = prollySecondaryIndexWriter{}
+var _ UniqueKeyChangeReporter = prollySecondaryIndexWriter{}
 
 func (m prollySecondaryIndexWriter) Name() string {
 	return m.name
@@ -519,7 +519,8 @@ func (m prollySecondaryIndexWriter) Update(ctx context.Context, oldRow sql.Row, 
 	return nil
 }
 
-func (m prollySecondaryIndexWriter) updateChangesUniqueKey(oldRow sql.Row, newRow sql.Row) bool {
+// UpdateChangesUniqueKey implements UniqueKeyChangeReporter for this index.
+func (m prollySecondaryIndexWriter) UpdateChangesUniqueKey(oldRow sql.Row, newRow sql.Row) bool {
 	return m.unique && (m.predicate != nil || !isNoopUpdate(oldRow, newRow, m.keyMap[:m.idxCols]))
 }
 

--- a/go/libraries/doltcore/sqle/writer/prolly_index_writer.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_index_writer.go
@@ -321,6 +321,7 @@ func (m prollySecondaryIndexWriter) matchesPredicate(ctx context.Context, sqlRow
 }
 
 var _ indexWriter = prollySecondaryIndexWriter{}
+var _ uniqueKeyChangeReporter = prollySecondaryIndexWriter{}
 
 func (m prollySecondaryIndexWriter) Name() string {
 	return m.name
@@ -516,6 +517,10 @@ func (m prollySecondaryIndexWriter) Update(ctx context.Context, oldRow sql.Row, 
 	}
 
 	return nil
+}
+
+func (m prollySecondaryIndexWriter) updateChangesUniqueKey(oldRow sql.Row, newRow sql.Row) bool {
+	return m.unique && (m.predicate != nil || !isNoopUpdate(oldRow, newRow, m.keyMap[:m.idxCols]))
 }
 
 func (m prollySecondaryIndexWriter) Commit(ctx context.Context) error {

--- a/go/libraries/doltcore/sqle/writer/prolly_index_writer_keyless.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_index_writer_keyless.go
@@ -203,7 +203,7 @@ type prollyKeylessSecondaryWriter struct {
 }
 
 var _ indexWriter = prollyKeylessSecondaryWriter{}
-var _ uniqueKeyChangeReporter = prollyKeylessSecondaryWriter{}
+var _ UniqueKeyChangeReporter = prollyKeylessSecondaryWriter{}
 
 // Name implements the interface indexWriter.
 func (writer prollyKeylessSecondaryWriter) Name() string {
@@ -384,7 +384,8 @@ func (writer prollyKeylessSecondaryWriter) Update(ctx context.Context, oldRow sq
 	return
 }
 
-func (writer prollyKeylessSecondaryWriter) updateChangesUniqueKey(oldRow sql.Row, newRow sql.Row) bool {
+// UpdateChangesUniqueKey implements UniqueKeyChangeReporter for this index.
+func (writer prollyKeylessSecondaryWriter) UpdateChangesUniqueKey(oldRow sql.Row, newRow sql.Row) bool {
 	return writer.unique && (writer.predicate != nil || !isNoopUpdate(oldRow, newRow, writer.keyMap))
 }
 

--- a/go/libraries/doltcore/sqle/writer/prolly_index_writer_keyless.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_index_writer_keyless.go
@@ -203,6 +203,7 @@ type prollyKeylessSecondaryWriter struct {
 }
 
 var _ indexWriter = prollyKeylessSecondaryWriter{}
+var _ uniqueKeyChangeReporter = prollyKeylessSecondaryWriter{}
 
 // Name implements the interface indexWriter.
 func (writer prollyKeylessSecondaryWriter) Name() string {
@@ -381,6 +382,10 @@ func (writer prollyKeylessSecondaryWriter) Update(ctx context.Context, oldRow sq
 		return err
 	}
 	return
+}
+
+func (writer prollyKeylessSecondaryWriter) updateChangesUniqueKey(oldRow sql.Row, newRow sql.Row) bool {
+	return writer.unique && (writer.predicate != nil || !isNoopUpdate(oldRow, newRow, writer.keyMap))
 }
 
 // Commit implements the interface indexWriter.

--- a/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
@@ -61,6 +61,10 @@ type prollyTableWriter struct {
 }
 
 var _ dsess.TableWriter = &prollyTableWriter{}
+
+var _ interface {
+	UpdateChangesUniqueKey(oldRow, newRow sql.Row) bool
+} = &prollyTableWriter{}
 var _ AutoIncrementGetter = &prollyTableWriter{}
 
 func getSecondaryProllyIndexWriters(ctx context.Context, t *doltdb.Table, schState *dsess.WriterState) (map[string]indexWriter, error) {
@@ -197,6 +201,25 @@ func (w *prollyTableWriter) Update(ctx *sql.Context, oldRow sql.Row, newRow sql.
 
 	w.aiSet = true
 	return nil
+}
+
+// uniqueKeyChangeReporter is an index writer that reports whether an update frees or takes a unique key.
+type uniqueKeyChangeReporter interface {
+	// updateChangesUniqueKey reports whether updating |oldRow| to |newRow| frees or takes a unique key of this
+	// index. Any change can move a row in or out of a partial index, so a unique partial index always reports one.
+	updateChangesUniqueKey(oldRow sql.Row, newRow sql.Row) bool
+}
+
+// UpdateChangesUniqueKey reports whether updating |oldRow| to |newRow| frees or takes a key in a unique index of
+// the table, erring toward reporting a change. The primary key is not considered.
+func (w *prollyTableWriter) UpdateChangesUniqueKey(oldRow sql.Row, newRow sql.Row) bool {
+	for _, wr := range w.secondary {
+		r, ok := wr.(uniqueKeyChangeReporter)
+		if !ok || r.updateChangesUniqueKey(oldRow, newRow) {
+			return true
+		}
+	}
+	return false
 }
 
 // Delete implements TableWriter.

--- a/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
@@ -62,9 +62,7 @@ type prollyTableWriter struct {
 
 var _ dsess.TableWriter = &prollyTableWriter{}
 
-var _ interface {
-	UpdateChangesUniqueKey(oldRow, newRow sql.Row) bool
-} = &prollyTableWriter{}
+var _ UniqueKeyChangeReporter = &prollyTableWriter{}
 var _ AutoIncrementGetter = &prollyTableWriter{}
 
 func getSecondaryProllyIndexWriters(ctx context.Context, t *doltdb.Table, schState *dsess.WriterState) (map[string]indexWriter, error) {
@@ -203,19 +201,19 @@ func (w *prollyTableWriter) Update(ctx *sql.Context, oldRow sql.Row, newRow sql.
 	return nil
 }
 
-// uniqueKeyChangeReporter is an index writer that reports whether an update frees or takes a unique key.
-type uniqueKeyChangeReporter interface {
-	// updateChangesUniqueKey reports whether updating |oldRow| to |newRow| frees or takes a unique key of this
-	// index. Any change can move a row in or out of a partial index, so a unique partial index always reports one.
-	updateChangesUniqueKey(oldRow sql.Row, newRow sql.Row) bool
+// UniqueKeyChangeReporter is a writer that reports whether an update frees or takes a unique key.
+type UniqueKeyChangeReporter interface {
+	// UpdateChangesUniqueKey reports whether updating |oldRow| to |newRow| frees or takes a key in a unique index,
+	// erring toward reporting a change. The primary key is not considered, and a unique partial index always
+	// reports a change since any change can move a row in or out of it.
+	UpdateChangesUniqueKey(oldRow sql.Row, newRow sql.Row) bool
 }
 
-// UpdateChangesUniqueKey reports whether updating |oldRow| to |newRow| frees or takes a key in a unique index of
-// the table, erring toward reporting a change. The primary key is not considered.
+// UpdateChangesUniqueKey implements UniqueKeyChangeReporter for the whole table by asking each secondary index.
 func (w *prollyTableWriter) UpdateChangesUniqueKey(oldRow sql.Row, newRow sql.Row) bool {
 	for _, wr := range w.secondary {
-		r, ok := wr.(uniqueKeyChangeReporter)
-		if !ok || r.updateChangesUniqueKey(oldRow, newRow) {
+		r, ok := wr.(UniqueKeyChangeReporter)
+		if !ok || r.UpdateChangesUniqueKey(oldRow, newRow) {
 			return true
 		}
 	}


### PR DESCRIPTION
Staging a delete and an insert that reuse the same unique key via `dolt_workspace_*` failed with a spurious duplicate unique key error, because rows were applied in workspace order and checked per row.
- Updater now applies all deletes first and defers the puts to statement completion
Fix #11195 