### PR TITLE
Rename embedded AGENT.md database doc to AGENTS.md

### DIFF
--- a/go/libraries/doltcore/doltdb/AGENTS.md
+++ b/go/libraries/doltcore/doltdb/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENT.md - Dolt Database Operations Guide
+# AGENTS.md - Dolt Database Operations Guide
 
 This file provides guidance for AI agents working with Dolt databases to maximize productivity and follow best practices.
 

--- a/go/libraries/doltcore/doltdb/system_table.go
+++ b/go/libraries/doltcore/doltdb/system_table.go
@@ -28,7 +28,7 @@ import (
 	"github.com/dolthub/dolt/go/store/types"
 )
 
-//go:embed AGENT.md
+//go:embed AGENTS.md
 var DefaultAgentDocValue string
 
 type ctxKey int
@@ -183,7 +183,7 @@ const (
 	// ReadmeDoc is the key for accessing the readme within the docs table
 	ReadmeDoc = "README.md"
 	// AgentDoc is the key for accessing the agent documentation within the docs table
-	AgentDoc = "AGENT.md"
+	AgentDoc = "AGENTS.md"
 )
 
 // GetDocTableName returns the name of the dolt table containing documents such as the license and readme

--- a/go/libraries/doltcore/sqle/dtables/docs_table.go
+++ b/go/libraries/doltcore/sqle/dtables/docs_table.go
@@ -116,7 +116,7 @@ func (dt *DocsTable) PartitionRows(ctx *sql.Context, partition sql.Partition) (s
 			continue
 		}
 
-		if name == doltdb.AgentDoc {
+		if name == doltdb.AgentDoc || name == "AGENT.md" {
 			found = true
 			break
 		}

--- a/integration-tests/bats/docs.bats
+++ b/integration-tests/bats/docs.bats
@@ -157,7 +157,7 @@ TXT
 }
 
 # AGENT document tests
-@test "docs: AGENT document is created automatically during init" {
+@test "docs: AGENTS document is created automatically during init" {
     # Create a fresh repo to test init behavior
     cd ..
     rm -rf test-agent-init
@@ -167,15 +167,15 @@ TXT
     # Initialize new repo
     dolt init
     
-    # Check that AGENT.md document exists
-    run dolt docs print AGENT.md
+    # Check that AGENTS.md document exists
+    run dolt docs print AGENTS.md
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "# AGENT.md - Dolt Database Operations Guide" ]] || false
+    [[ "$output" =~ "# AGENTS.md - Dolt Database Operations Guide" ]] || false
 
-    # Verify AGENT.md is in the docs table
-    run dolt sql -q "SELECT doc_name FROM dolt_docs WHERE doc_name = 'AGENT.md'" -r csv
+    # Verify AGENTS.md is in the docs table
+    run dolt sql -q "SELECT doc_name FROM dolt_docs WHERE doc_name = 'AGENTS.md'" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "AGENT.md" ]] || false
+    [[ "$output" =~ "AGENTS.md" ]] || false
     
     # CRITICAL: Verify there's no diff after init (clean working tree)
     run dolt diff
@@ -191,15 +191,15 @@ TXT
     cd ../dolt-repo-$$
 }
 
-@test "docs: AGENT document print functionality" {
+@test "docs: AGENTS document print functionality" {
     # Check basic print functionality
-    run dolt docs print AGENT.md
+    run dolt docs print AGENTS.md
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "# AGENT.md - Dolt Database Operations Guide" ]] || false
+    [[ "$output" =~ "# AGENTS.md - Dolt Database Operations Guide" ]] || false
 }
 
-@test "docs: AGENT document can be uploaded and modified" {
-    # Create a custom AGENT.md file
+@test "docs: AGENTS document can be uploaded and modified" {
+    # Create a custom AGENTS.md file
     cat <<TXT > custom_agent.md
 # Custom Agent Documentation
 
@@ -214,10 +214,10 @@ Visit: https://example.com
 TXT
 
     # Upload the custom document
-    dolt docs upload AGENT.md custom_agent.md
+    dolt docs upload AGENTS.md custom_agent.md
     
     # Verify the upload worked
-    run dolt docs print AGENT.md
+    run dolt docs print AGENTS.md
     [ "$status" -eq 0 ]
     [[ "$output" =~ "# Custom Agent Documentation" ]] || false
     [[ "$output" =~ "This is a custom agent document for testing" ]] || false
@@ -225,11 +225,11 @@ TXT
     [[ "$output" =~ "https://example.com" ]] || false
     
     # Verify original content is replaced
-    [[ ! "$output" =~ "# AGENT.md - Dolt Database Operations Guide" ]] || false
+    [[ ! "$output" =~ "# AGENTS.md - Dolt Database Operations Guide" ]] || false
 }
 
-@test "docs: AGENT document diff functionality" {
-    # Create a modified AGENT.md
+@test "docs: AGENTS document diff functionality" {
+    # Create a modified AGENTS.md
     cat <<TXT > modified_agent.md
 # Modified Dolt Database Repository
 
@@ -248,62 +248,62 @@ For more information, visit: https://modified.example.com
 TXT
 
     # Upload the modified document
-    dolt docs upload AGENT.md modified_agent.md
+    dolt docs upload AGENTS.md modified_agent.md
     
     # Test diff functionality
-    run dolt docs diff AGENT.md
+    run dolt docs diff AGENTS.md
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "-# AGENT.md - Dolt Database Operations Guide" ]] || false
+    [[ "$output" =~ "-# AGENTS.md - Dolt Database Operations Guide" ]] || false
     [[ "$output" =~ "+This directory contains a modified Dolt database" ]] || false
 }
 
-@test "docs: AGENT document export to CLAUDE.md functionality" {
-    # Export AGENT.md to CLAUDE.md
-    dolt docs print AGENT.md > CLAUDE.md
+@test "docs: AGENTS document export to CLAUDE.md functionality" {
+    # Export AGENTS.md to CLAUDE.md
+    dolt docs print AGENTS.md > CLAUDE.md
     
     # Verify the file was created
     [ -f CLAUDE.md ]
     
     # Verify the content matches
     run cat CLAUDE.md
-    [[ "$output" =~ "# AGENT.md - Dolt Database Operations Guide" ]] || false
+    [[ "$output" =~ "# AGENTS.md - Dolt Database Operations Guide" ]] || false
 
     # Compare with direct docs print
-    dolt docs print AGENT.md > direct_output.md
+    dolt docs print AGENTS.md > direct_output.md
     run diff CLAUDE.md direct_output.md
     [ "$status" -eq 0 ]
     [[ "${#lines[@]}" = "0" ]] || false
 }
 
-@test "docs: AGENT document is available from SQL" {
-    # Check that AGENT.md is available via SQL
-    run dolt sql -q "SELECT doc_name FROM dolt_docs WHERE doc_name = 'AGENT.md'" -r csv
+@test "docs: AGENTS document is available from SQL" {
+    # Check that AGENTS.md is available via SQL
+    run dolt sql -q "SELECT doc_name FROM dolt_docs WHERE doc_name = 'AGENTS.md'" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "AGENT.md" ]] || false
+    [[ "$output" =~ "AGENTS.md" ]] || false
     
     # Check that we can query the content
-    run dolt sql -q "SELECT doc_text FROM dolt_docs WHERE doc_name = 'AGENT.md'" -r csv
+    run dolt sql -q "SELECT doc_text FROM dolt_docs WHERE doc_name = 'AGENTS.md'" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "# AGENT.md - Dolt Database Operations Guide" ]] || false
+    [[ "$output" =~ "# AGENTS.md - Dolt Database Operations Guide" ]] || false
 }
 
-@test "docs: AGENT document can be modified via SQL" {
-    # Modify AGENT.md via SQL
-    dolt sql -q "UPDATE dolt_docs SET doc_text = '# SQL Modified Agent Doc\n\nThis was modified via SQL.' WHERE doc_name = 'AGENT.md'"
+@test "docs: AGENTS document can be modified via SQL" {
+    # Modify AGENTS.md via SQL
+    dolt sql -q "UPDATE dolt_docs SET doc_text = '# SQL Modified Agent Doc\n\nThis was modified via SQL.' WHERE doc_name = 'AGENTS.md'"
     
     # Verify the modification
-    run dolt docs print AGENT.md
+    run dolt docs print AGENTS.md
     [ "$status" -eq 0 ]
     [[ "$output" =~ "# SQL Modified Agent Doc" ]] || false
     [[ "$output" =~ "This was modified via SQL" ]] || false
     
     # Verify original content is gone
-    [[ ! "$output" =~ "# AGENT.md - Dolt Database Operations Guide" ]] || false
+    [[ ! "$output" =~ "# AGENTS.md - Dolt Database Operations Guide" ]] || false
 }
 
-@test "docs: AGENT document validation works correctly" {
+@test "docs: AGENTS document validation works correctly" {
     # Test valid document name
-    run dolt docs upload AGENT.md README.md
+    run dolt docs upload AGENTS.md README.md
     [ "$status" -eq 0 ]
     
     # Test invalid document name should fail
@@ -311,20 +311,20 @@ TXT
     [ "$status" -ne 0 ]
     [[ "$output" =~ "invalid doc name" ]] || false
     [[ "$output" =~ "valid names are" ]] || false
-    [[ "$output" =~ "AGENT.md" ]] || false
+    [[ "$output" =~ "AGENTS.md" ]] || false
     [[ "$output" =~ "LICENSE.md" ]] || false
     [[ "$output" =~ "README.md" ]] || false
 }
 
-@test "docs: AGENT document can be staged and committed" {
-    # Modify AGENT.md
+@test "docs: AGENTS document can be staged and committed" {
+    # Modify AGENTS.md
     cat <<TXT > test_agent.md
 # Test Agent Document
 
 This is a test modification.
 TXT
 
-    dolt docs upload AGENT.md test_agent.md
+    dolt docs upload AGENTS.md test_agent.md
     
     # Check that dolt_docs table shows up in status
     run dolt status
@@ -333,7 +333,7 @@ TXT
     
     # Stage and commit
     dolt add .
-    dolt commit -m "Modified AGENT.md"
+    dolt commit -m "Modified AGENTS.md"
     
     # Verify clean status
     run dolt status
@@ -341,29 +341,29 @@ TXT
     [[ "$output" =~ "nothing to commit, working tree clean" ]] || false
     
     # Verify the content persists
-    run dolt docs print AGENT.md
+    run dolt docs print AGENTS.md
     [ "$status" -eq 0 ]
     [[ "$output" =~ "# Test Agent Document" ]] || false
     [[ "$output" =~ "This is a test modification" ]] || false
 }
 
-@test "docs: AGENT document works with multiple document types" {
+@test "docs: AGENTS document works with multiple document types" {
     # Upload all three document types
     dolt docs upload README.md README.md
     dolt docs upload LICENSE.md LICENSE.md
-    # AGENT.md is already created during init
+    # AGENTS.md is already created during init
     
     # Verify all three exist
     run dolt sql -q "SELECT doc_name FROM dolt_docs ORDER BY doc_name" -r csv
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "AGENT.md" ]] || false
+    [[ "$output" =~ "AGENTS.md" ]] || false
     [[ "$output" =~ "LICENSE.md" ]] || false
     [[ "$output" =~ "README.md" ]] || false
     
     # Verify each can be printed
-    run dolt docs print AGENT.md
+    run dolt docs print AGENTS.md
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "# AGENT.md - Dolt Database Operations Guide" ]] || false
+    [[ "$output" =~ "# AGENTS.md - Dolt Database Operations Guide" ]] || false
 
     run dolt docs print README.md
     [ "$status" -eq 0 ]

--- a/integration-tests/bats/init.bats
+++ b/integration-tests/bats/init.bats
@@ -283,24 +283,24 @@ assert_valid_repository () {
   [[ "$output" =~ "Initialize data repository" ]] || false
 }
 
-@test "init: creates AGENT.md document automatically" {
+@test "init: creates AGENTS.md document automatically" {
   set_dolt_user "baz", "baz@bash.com"
   
   run dolt init
   [ "$status" -eq 0 ]
   
-  # Check that AGENT.md document was created
-  run dolt docs print AGENT.md
+  # Check that AGENTS.md document was created
+  run dolt docs print AGENTS.md
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "# AGENT.md - Dolt Database Operations Guide" ]] || false
+  [[ "$output" =~ "# AGENTS.md - Dolt Database Operations Guide" ]] || false
 
   # Verify it's in the docs table
-  run dolt sql -q "SELECT doc_name FROM dolt_docs WHERE doc_name = 'AGENT.md'" -r csv
+  run dolt sql -q "SELECT doc_name FROM dolt_docs WHERE doc_name = 'AGENTS.md'" -r csv
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "AGENT.md" ]] || false
+  [[ "$output" =~ "AGENTS.md" ]] || false
   
   # Verify it's version controlled (should be in initial commit)
-  run dolt sql -q "SELECT COUNT(*) FROM dolt_docs WHERE doc_name = 'AGENT.md'" -r csv
+  run dolt sql -q "SELECT COUNT(*) FROM dolt_docs WHERE doc_name = 'AGENTS.md'" -r csv
   [ "$status" -eq 0 ]
   [[ "$output" =~ "1" ]] || false
   
@@ -317,7 +317,7 @@ assert_valid_repository () {
   assert_valid_repository
 }
 
-@test "init: --fun flag creates AGENT.md document with fun hash" {
+@test "init: --fun flag creates AGENTS.md document with fun hash" {
   set_dolt_user "baz", "baz@bash.com"
   
   run dolt init --fun
@@ -328,15 +328,15 @@ assert_valid_repository () {
   [ "$status" -eq 0 ]
   [[ "$output" =~ "commit dolt" ]] || [[ "$output" =~ "commit do1t" ]] || [[ "$output" =~ "commit d0lt" ]] || [[ "$output" =~ "commit d01t" ]] || false
   
-  # Check that AGENT.md document was still created
-  run dolt docs print AGENT.md
+  # Check that AGENTS.md document was still created
+  run dolt docs print AGENTS.md
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "# AGENT.md - Dolt Database Operations Guide" ]] || false
+  [[ "$output" =~ "# AGENTS.md - Dolt Database Operations Guide" ]] || false
 
   # Verify it's in the docs table
-  run dolt sql -q "SELECT doc_name FROM dolt_docs WHERE doc_name = 'AGENT.md'" -r csv
+  run dolt sql -q "SELECT doc_name FROM dolt_docs WHERE doc_name = 'AGENTS.md'" -r csv
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "AGENT.md" ]] || false
+  [[ "$output" =~ "AGENTS.md" ]] || false
   
   # Verify there's no diff after init --fun (clean working tree)
   run dolt diff

--- a/integration-tests/mysql-client-tests/node/workbenchTests/docs.js
+++ b/integration-tests/mysql-client-tests/node/workbenchTests/docs.js
@@ -11,7 +11,7 @@ export const docsTests = [
   {
     q: "INSERT INTO dolt_docs VALUES (:docName, :docText);",
     p: {
-      docName: "AGENT.md",
+      docName: "AGENTS.md",
       docText: agentText,
     },
     res: {
@@ -26,7 +26,7 @@ export const docsTests = [
   },
   {
     q: "select * from dolt_docs",
-    res: [{doc_name: "AGENT.md", doc_text: agentText}],
+    res: [{doc_name: "AGENTS.md", doc_text: agentText}],
   },
   {
     q: "REPLACE INTO dolt_docs VALUES (:docName, :docText);",


### PR DESCRIPTION
## Summary

- Renames the auto-created `dolt_docs` entry from `AGENT.md` to `AGENTS.md` to follow the emerging agents-file convention
- Existing databases with a legacy `AGENT.md` row are handled: the auto-add logic treats the old name as "found" so no duplicate `AGENTS.md` row gets inserted beside it

## Changes

- `go/libraries/doltcore/doltdb/AGENT.md` → `AGENTS.md` — renamed embedded file, updated title line
- `go/libraries/doltcore/doltdb/system_table.go` — updated `//go:embed` directive and `AgentDoc` constant to `"AGENTS.md"`
- `go/libraries/doltcore/sqle/dtables/docs_table.go` — back-compat: auto-add check now accepts either `AGENTS.md` or legacy `AGENT.md` as "found"
- `integration-tests/bats/init.bats` — updated 2 test cases
- `integration-tests/bats/docs.bats` — updated 9 test cases
- `integration-tests/mysql-client-tests/node/workbenchTests/docs.js` — updated hardcoded doc name

The `enginetest/dolt_queries.go` test uses `doltdb.AgentDoc` constant so it updates automatically.

## Test plan

- [x] `go vet` on all changed packages — clean
- [x] All changed packages compile
- [ ] CI: BATS `init` and `docs` suites
- [ ] CI: Node workbench tests

**Note on back-compat:** The auto-add logic in `docs_table.go` checks for either name so that existing databases with a legacy `AGENT.md` row don't get a duplicate `AGENTS.md` auto-inserted. Legacy rows are not migrated — this seemed like the least-surprise approach. Happy to adjust if you'd prefer migration or a different strategy.

Closes #11138

Made with [Cursor](https://cursor.com)