### PR TITLE
Remove no-op AutoIncrement statement

### DIFF
--- a/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
@@ -176,7 +176,6 @@ func (w *prollyTableWriter) Insert(ctx *sql.Context, sqlRow sql.Row) (err error)
 
 	// TODO: need schema name in ai tracker
 	w.aiSet = true
-	w.aiTracker.Next(ctx, w.tblName.Name, sqlRow)
 
 	return nil
 }


### PR DESCRIPTION
A simple cleanup: this line always errors, but the error isn't being checked. It effectively does nothing and isn't needed because:
- the auto increment state is automatically updated by the AutoIncrement node in the plan tree
-as long as the auto_increment as long as `w.aiSet` is true, the correct auto_increment value will be read from the AutoIncrementTracker.