### PR TITLE
go: sqle: Fix concurrent-clone deadlock between two remotesapi sql-servers

### DIFF
--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -79,6 +79,29 @@ type DoltDatabaseProvider struct {
 	// when accessed.
 	deletingDatabases map[string]struct{}
 
+	// Databases named in creatingDatabases are currently being created by a
+	// clone that is fetching its data from a remote. The provider lock is
+	// deliberately NOT held for the duration of that network fetch (see
+	// CloneDatabaseFromRemote), so this set is used to reserve the name and
+	// prevent concurrent CREATE DATABASE / dolt_clone / undrop operations from
+	// racing on the same name while the clone is in progress.
+	//
+	// Names are stored normalized via formatDbMapKeyName, matching p.databases
+	// and deletingDatabases (Dolt database names are case-insensitive).
+	//
+	// Unlike deletingDatabases, this set deliberately does NOT gate database
+	// enumeration (see rlockAwaitingEmptyDeletingDatabases). A clone builds its
+	// database directory in place and non-atomically, so a partially-populated
+	// directory exists on disk for the duration of the fetch. That would be a
+	// hazard only if something enumerated databases by scanning the data
+	// directory at runtime, and nothing does: in a running server all
+	// enumeration goes through the in-memory p.databases map (AllDatabases /
+	// DoltDatabases), the remotesapi resolves databases by exact name, and the
+	// only data-directory scan (MultiEnvForDirectory) runs at startup, before
+	// any clone can be in flight. An in-progress clone is therefore simply
+	// invisible until it finishes and registers under the write lock.
+	creatingDatabases map[string]struct{}
+
 	txLocks keymutex.Keymutex
 
 	defaultBranch     string
@@ -208,6 +231,7 @@ func NewDoltDatabaseProviderWithDatabases(defaultBranch string, fs filesys.Files
 		dbLocations:            dbLocations,
 		databases:              dbs,
 		deletingDatabases:      make(map[string]struct{}),
+		creatingDatabases:      make(map[string]struct{}),
 		functions:              funcs,
 		tableFunctions:         tableFuncs,
 		externalProcedures:     externalProcedures,
@@ -697,17 +721,8 @@ func (p *DoltDatabaseProvider) CreateCollatedDatabase(ctx *sql.Context, name str
 		}
 	}()
 
-	if _, ok := p.deletingDatabases[name]; ok {
-		return sql.ErrDatabaseExists.New(name)
-	}
-	exists, isDir := p.fs.Exists(name)
-	if exists && isDir {
-		if subFs, ferr := p.fs.WithWorkingDir(name); ferr == nil && env.IsIncompleteDatabaseDir(subFs) {
-			return NewErrIncompleteDatabaseDir(name)
-		}
-		return sql.ErrDatabaseExists.New(name)
-	} else if exists {
-		return fmt.Errorf("Cannot create DB, file exists at %s", name)
+	if err = p.databaseNameUnavailableLocked(name, true /* checkDisk */); err != nil {
+		return err
 	}
 
 	err = p.fs.MkDirs(name)
@@ -935,37 +950,36 @@ func NewConfigureReplicationDatabaseHook(bThreads *sql.BackgroundThreads, ctxF f
 	}
 }
 
-// CloneDatabaseFromRemote implements DoltDatabaseProvider interface
+// CloneDatabaseFromRemote implements DoltDatabaseProvider interface.
 //
-// TODO: This holds the database provider lock across the entire duration of
-// the clone, which is much too long to hold this lock.
+// The provider lock is intentionally NOT held for the duration of the clone.
+// The network fetch below (GetRemoteDB + CloneRemote) can be long-running and,
+// when this server is itself serving a remotesapi, that fetch may hit a peer's
+// remotesapi whose handler in turn needs a read lock on this same provider (via
+// SessionDatabase). Holding the provider write lock across the fetch therefore
+// starved this server's own remotesapi handler and deadlocked two sql-servers
+// that clone from each other's remotesapi at the same time. Instead we reserve
+// the database name under the lock (fast), release the lock for the fetch, and
+// re-acquire it only to register the finished database.
 func (p *DoltDatabaseProvider) CloneDatabaseFromRemote(
 	ctx *sql.Context,
 	dbName, branch, remoteName, remoteUrl string,
 	depth int,
 	remoteParams map[string]string,
 ) error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	if _, ok := p.deletingDatabases[dbName]; ok {
-		return sql.ErrDatabaseExists.New(dbName)
+	// Reserve the database name so that concurrent create/clone/undrop of the
+	// same name are still serialized, even though we drop the lock for the fetch.
+	if err := p.reserveCreatingDatabase(dbName); err != nil {
+		return err
 	}
-
-	exists, isDir := p.fs.Exists(dbName)
-	if exists && isDir {
-		if subFs, ferr := p.fs.WithWorkingDir(dbName); ferr == nil && env.IsIncompleteDatabaseDir(subFs) {
-			return NewErrIncompleteDatabaseDir(dbName)
-		}
-		return sql.ErrDatabaseExists.New(dbName)
-	} else if exists {
-		return fmt.Errorf("cannot create DB, file exists at %s", dbName)
-	}
+	defer p.releaseCreatingDatabase(dbName)
 
 	err := p.cloneDatabaseFromRemote(ctx, dbName, remoteName, branch, remoteUrl, depth, remoteParams)
 	if err != nil {
 		// Make a best effort to clean up any artifacts on disk from a failed clone
-		// before we return the error
+		// before we return the error. We are still holding the name reservation
+		// here (released by the deferred call above), so nothing else can be
+		// using this directory.
 		exists, _ := p.fs.Exists(dbName)
 		if exists {
 			deleteErr := p.fs.Delete(dbName, true)
@@ -978,6 +992,70 @@ func (p *DoltDatabaseProvider) CloneDatabaseFromRemote(
 	}
 
 	return nil
+}
+
+// databaseNameUnavailableLocked returns an error if |name| cannot currently be
+// used to register a new database, and nil if the name is free. It must be
+// called with p.mu held.
+//
+// The name is normalized with formatDbMapKeyName so these checks are
+// case-insensitive and consistent with how databases are keyed in p.databases:
+// Dolt treats database names case-insensitively (e.g. "MyDB" and "mydb" are the
+// same database), so they must not race with one another. deletingDatabases and
+// creatingDatabases reserve names for in-flight drops and clones respectively.
+//
+// When |checkDisk| is true the on-disk data directory is also checked; creation
+// paths that materialize a directory pass true, while undrop (which restores
+// from the dropped-database stash rather than creating a directory) passes false.
+func (p *DoltDatabaseProvider) databaseNameUnavailableLocked(name string, checkDisk bool) error {
+	key := formatDbMapKeyName(name)
+	if _, ok := p.deletingDatabases[key]; ok {
+		return sql.ErrDatabaseExists.New(name)
+	}
+	if _, ok := p.creatingDatabases[key]; ok {
+		return sql.ErrDatabaseExists.New(name)
+	}
+	if checkDisk {
+		exists, isDir := p.fs.Exists(name)
+		if exists && isDir {
+			// A directory left behind by an interrupted create/clone carries an
+			// in-progress marker; surface a clearer error than "already exists".
+			if subFs, ferr := p.fs.WithWorkingDir(name); ferr == nil && env.IsIncompleteDatabaseDir(subFs) {
+				return NewErrIncompleteDatabaseDir(name)
+			}
+			return sql.ErrDatabaseExists.New(name)
+		} else if exists {
+			return fmt.Errorf("cannot create DB, file exists at %s", name)
+		}
+	}
+	return nil
+}
+
+// reserveCreatingDatabase briefly takes the provider write lock to verify that
+// |dbName| is available and then records it in p.creatingDatabases, reserving
+// the name for an in-progress clone. The caller MUST call
+// releaseCreatingDatabase once the clone has finished (success or failure).
+// This reserves a name with the same conflict semantics as creating one
+// outright, so that concurrent create/clone/undrop of the same name are still
+// serialized even though the clone drops the lock for its network fetch.
+func (p *DoltDatabaseProvider) reserveCreatingDatabase(dbName string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if err := p.databaseNameUnavailableLocked(dbName, true /* checkDisk */); err != nil {
+		return err
+	}
+
+	p.creatingDatabases[formatDbMapKeyName(dbName)] = struct{}{}
+	return nil
+}
+
+// releaseCreatingDatabase removes the reservation recorded by
+// reserveCreatingDatabase.
+func (p *DoltDatabaseProvider) releaseCreatingDatabase(dbName string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.creatingDatabases, formatDbMapKeyName(dbName))
 }
 
 // cloneDatabaseFromRemote encapsulates the inner logic for cloning a database so that if any error
@@ -1022,10 +1100,18 @@ func (p *DoltDatabaseProvider) cloneDatabaseFromRemote(
 		Remote: remoteName,
 	})
 
+	// The network fetch above ran without the provider lock held. Clear the
+	// in-progress marker (a filesystem operation, so no provider lock is needed)
+	// and then re-acquire the write lock only to register the finished database;
+	// registerNewDatabase requires the lock to be held. The name reservation
+	// taken in CloneDatabaseFromRemote is still in place, so no other creation
+	// path can have registered this name.
 	if err := dbfactory.ClearDatabaseInProgress(dEnv.FS); err != nil {
 		return err
 	}
 
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	return p.registerNewDatabase(ctx, dbName, dEnv)
 }
 
@@ -1157,8 +1243,8 @@ func (p *DoltDatabaseProvider) UndropDatabase(ctx *sql.Context, name string) (er
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if _, ok := p.deletingDatabases[name]; ok {
-		return sql.ErrDatabaseExists.New(name)
+	if err = p.databaseNameUnavailableLocked(name, false /* checkDisk */); err != nil {
+		return err
 	}
 
 	newFs, exactCaseName, err := p.droppedDatabaseManager.UndropDatabase(ctx, name)

--- a/go/libraries/doltcore/sqle/database_provider_test.go
+++ b/go/libraries/doltcore/sqle/database_provider_test.go
@@ -17,7 +17,9 @@ package sqle
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	sqle "github.com/dolthub/go-mysql-server"
 	"github.com/dolthub/go-mysql-server/sql"
@@ -249,4 +251,103 @@ func TestCreateDatabaseClearsInProgressMarker(t *testing.T) {
 			assert.False(t, dbfactory.IsDatabaseInProgress(newFs), "a completed CREATE DATABASE must clear the marker")
 		})
 	}
+}
+
+// TestCreatingDatabaseReservation covers the name-reservation used by
+// CloneDatabaseFromRemote to hold a database name while it fetches from a remote
+// without the provider lock held. See the deadlock fix in database_provider.go.
+func TestCreatingDatabaseReservation(t *testing.T) {
+	setup := func(t *testing.T) (*sql.Context, *DoltDatabaseProvider) {
+		ctx := context.Background()
+		dEnv := dtestutils.CreateTestEnv()
+
+		db, err := NewDatabase(ctx, "dolt", dEnv.DbData(ctx), editor.Options{})
+		require.NoError(t, err)
+
+		_, sqlCtx, err := NewTestEngine(dEnv, ctx, db)
+		require.NoError(t, err)
+
+		sess := dsess.DSessFromSess(sqlCtx.Session)
+		return sqlCtx, sess.Provider().(*DoltDatabaseProvider)
+	}
+
+	// nameUnavailable runs databaseNameUnavailableLocked under the provider
+	// lock, mirroring how the create (checkDisk=true) and undrop
+	// (checkDisk=false) paths consult it.
+	nameUnavailable := func(pro *DoltDatabaseProvider, name string, checkDisk bool) error {
+		pro.mu.Lock()
+		defer pro.mu.Unlock()
+		return pro.databaseNameUnavailableLocked(name, checkDisk)
+	}
+
+	t.Run("second reservation of the same name conflicts", func(t *testing.T) {
+		_, pro := setup(t)
+		require.NoError(t, pro.reserveCreatingDatabase("clonedb"))
+		defer pro.releaseCreatingDatabase("clonedb")
+
+		err := pro.reserveCreatingDatabase("clonedb")
+		require.Truef(t, sql.ErrDatabaseExists.Is(err), "expected ErrDatabaseExists, got %v", err)
+	})
+
+	t.Run("reservation conflicts case-insensitively across create/clone/undrop", func(t *testing.T) {
+		_, pro := setup(t)
+		require.NoError(t, pro.reserveCreatingDatabase("CloneDB"))
+		defer pro.releaseCreatingDatabase("CloneDB")
+
+		for _, variant := range []string{"clonedb", "CLONEDB", "CloneDB"} {
+			require.Truef(t, sql.ErrDatabaseExists.Is(pro.reserveCreatingDatabase(variant)),
+				"clone of case-variant %q should conflict", variant)
+			require.Truef(t, sql.ErrDatabaseExists.Is(nameUnavailable(pro, variant, true)),
+				"CREATE of case-variant %q should conflict", variant)
+			require.Truef(t, sql.ErrDatabaseExists.Is(nameUnavailable(pro, variant, false)),
+				"UNDROP of case-variant %q should conflict", variant)
+		}
+	})
+
+	t.Run("release frees the name case-insensitively", func(t *testing.T) {
+		_, pro := setup(t)
+		require.NoError(t, pro.reserveCreatingDatabase("clonedb"))
+		// Releasing via a different case must clear the same reservation.
+		pro.releaseCreatingDatabase("CLONEDB")
+		require.NoError(t, nameUnavailable(pro, "clonedb", true))
+		require.NoError(t, pro.reserveCreatingDatabase("clonedb"))
+		pro.releaseCreatingDatabase("clonedb")
+	})
+
+	t.Run("a deleting database also conflicts case-insensitively", func(t *testing.T) {
+		_, pro := setup(t)
+		pro.mu.Lock()
+		pro.deletingDatabases[formatDbMapKeyName("delDB")] = struct{}{}
+		pro.mu.Unlock()
+		t.Cleanup(func() {
+			pro.mu.Lock()
+			delete(pro.deletingDatabases, formatDbMapKeyName("delDB"))
+			pro.mu.Unlock()
+		})
+
+		require.Truef(t, sql.ErrDatabaseExists.Is(nameUnavailable(pro, "DELDB", true)),
+			"CREATE of a case-variant of a deleting database should conflict")
+	})
+
+	t.Run("reservation does not gate database enumeration", func(t *testing.T) {
+		sqlCtx, pro := setup(t)
+		require.NoError(t, pro.reserveCreatingDatabase("clonedb"))
+		defer pro.releaseCreatingDatabase("clonedb")
+
+		// AllDatabases must return promptly (a reserved-but-unregistered clone
+		// must not block enumeration the way a deleting database does) and must
+		// not expose the in-progress clone. The bounded wait turns a regression
+		// (reservation gating enumeration) into a clean failure instead of a hang.
+		done := make(chan []sql.Database, 1)
+		go func() { done <- pro.AllDatabases(sqlCtx) }()
+		select {
+		case dbs := <-done:
+			for _, db := range dbs {
+				require.NotEqualf(t, "clonedb", strings.ToLower(db.Name()),
+					"in-progress clone must not be visible in AllDatabases")
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("AllDatabases blocked while a name was reserved for cloning; reservation must not gate enumeration")
+		}
+	})
 }

--- a/integration-tests/bats/sql-server-remotesrv.bats
+++ b/integration-tests/bats/sql-server-remotesrv.bats
@@ -915,3 +915,116 @@ GRANT CLONE_ADMIN ON *.* TO clone_admin_user@'localhost';
     [[ "$status" -ne 0 ]] || false
     [[ "$output" =~ "target has uncommitted changes" ]] || false
 }
+
+# Regression test for a concurrent-clone deadlock: two sql-servers, each
+# running a --remotesapi-port, that CALL DOLT_CLONE from each other's
+# remotesapi at the same time must not deadlock.
+#
+# The bug: CloneDatabaseFromRemote held the database-provider write lock
+# across the entire network fetch. That fetch pulls chunks from the peer's
+# remotesapi, whose handler needs a *read* lock on the peer's provider. When
+# both servers clone from each other simultaneously, each holds its own write
+# lock while waiting on the peer's remotesapi, and the peer can't take the read
+# lock to answer -> mutual starvation that only a server restart recovers.
+@test "sql-server-remotesrv: concurrent DOLT_CLONE between two remotesapi servers does not deadlock" {
+    local aSqlPort aRemPort bSqlPort bRemPort
+    aSqlPort=$( definePORT )
+    aRemPort=$( definePORT )
+    bSqlPort=$( definePORT )
+    bRemPort=$( definePORT )
+
+    mkdir dirA dirB
+
+    # Start server A (serves database "da" over its remotesapi) and server B
+    # (serves database "db"). We start each with --data-dir so that $! is the
+    # dolt process itself (not a subshell), letting us force-kill it later even
+    # if it wedges. A deadlocked server does not shut down on SIGTERM, so we
+    # must SIGKILL it before the test finishes or teardown would hang.
+    dolt sql-server --data-dir dirA -H 127.0.0.1 -P $aSqlPort --remotesapi-port $aRemPort --loglevel=warning > serverA.log 2>&1 &
+    srv_pid=$!
+    dolt sql-server --data-dir dirB -H 127.0.0.1 -P $bSqlPort --remotesapi-port $bRemPort --loglevel=warning > serverB.log 2>&1 &
+    srv_two_pid=$!
+
+    query_port() {
+        dolt --host 127.0.0.1 --port "$1" --user root --password '' --no-tls sql -q "$2"
+    }
+
+    # Force-kill both servers and clear the pids so the shared teardown (which
+    # sends a graceful SIGTERM and waits) can't block on a wedged server.
+    kill_servers() {
+        [ -n "$srv_pid" ] && kill -9 "$srv_pid" 2>/dev/null
+        [ -n "$srv_two_pid" ] && kill -9 "$srv_two_pid" 2>/dev/null
+        wait "$srv_pid" 2>/dev/null || :
+        wait "$srv_two_pid" 2>/dev/null || :
+        srv_pid=
+        srv_two_pid=
+    }
+
+    # Wait for both servers to accept connections.
+    local ok=""
+    for i in $(seq 1 40); do
+        if query_port $aSqlPort "SELECT 1" >/dev/null 2>&1 && query_port $bSqlPort "SELECT 1" >/dev/null 2>&1; then
+            ok=1; break
+        fi
+        sleep 0.5
+    done
+    if [ -z "$ok" ]; then kill_servers; echo "servers did not come up"; false; fi
+
+    # Seed each server with a small committed database.
+    query_port $aSqlPort "CREATE DATABASE da; USE da; CREATE TABLE t(i int primary key); INSERT INTO t VALUES(1); CALL DOLT_COMMIT('-Am','seed');"
+    query_port $bSqlPort "CREATE DATABASE db; USE db; CREATE TABLE t(i int primary key); INSERT INTO t VALUES(2); CALL DOLT_COMMIT('-Am','seed');"
+
+    # Fire many simultaneous cross-clones at once. The deadlock only occurs
+    # when server A is fetching from B while B is fetching from A at the same
+    # instant. With the buggy code each server holds its provider write lock for
+    # the whole duration of a clone, so launching a batch of concurrent clones
+    # in both directions keeps both write locks held near-continuously and makes
+    # the overlap (and thus the deadlock) reliable rather than a rare race.
+    #
+    # Each clone is wrapped in `timeout`; a hung clone exits 124, which is the
+    # deadlock signature. On a fixed server every clone completes quickly. Each
+    # clone targets a unique database name, so on a correct server every clone
+    # is expected to succeed (exit 0); we assert that too, so the test cannot
+    # pass merely because the clones failed fast for some non-deadlock reason.
+    local n=12
+    local clone_timeout=25
+    local pids=() logs=() i
+    for i in $(seq 1 $n); do
+        timeout $clone_timeout dolt --host 127.0.0.1 --port $aSqlPort --user root --password '' --no-tls \
+            sql -q "CALL DOLT_CLONE('http://127.0.0.1:$bRemPort/db','cloneB_$i')" > "cloneB_$i.log" 2>&1 &
+        pids+=($!); logs+=("cloneB_$i.log")
+        timeout $clone_timeout dolt --host 127.0.0.1 --port $bSqlPort --user root --password '' --no-tls \
+            sql -q "CALL DOLT_CLONE('http://127.0.0.1:$aRemPort/da','cloneA_$i')" > "cloneA_$i.log" 2>&1 &
+        pids+=($!); logs+=("cloneA_$i.log")
+    done
+
+    local hung=0 failed=0 p st
+    for p in "${pids[@]}"; do
+        st=0; wait "$p" || st=$?
+        if [ $st -eq 124 ]; then
+            # 124 == `timeout` killed a clone that never returned (the deadlock).
+            hung=$((hung+1))
+        elif [ $st -ne 0 ]; then
+            # Any other non-zero exit means the clone itself errored.
+            failed=$((failed+1))
+        fi
+    done
+
+    # Stop the servers before asserting, so teardown never has to touch a
+    # possibly-wedged server.
+    kill_servers
+
+    if [ $hung -ne 0 ]; then
+        echo "DEADLOCK detected: $hung clone(s) timed out (never returned)"
+        cat "${logs[@]}" 2>/dev/null || :
+        false
+    fi
+
+    # Guard against the test silently passing if the clones were broken (rather
+    # than deadlocked): a non-deadlock clone failure should also fail the test.
+    if [ $failed -ne 0 ]; then
+        echo "clone failure: $failed clone(s) exited non-zero (not a timeout)"
+        cat "${logs[@]}" 2>/dev/null || :
+        false
+    fi
+}


### PR DESCRIPTION
`DoltDatabaseProvider.CloneDatabaseFromRemote` held the provider `RWMutex` write lock across the entire clone, including the network fetch of all chunks from the remote. When a server serves a `--remotesapi-port`, that fetch hits a peer's remotesapi whose handler needs a **read** lock on this same provider (via `SessionDatabase`). Two sql-servers that `CALL DOLT_CLONE` from each other's remotesapi at the same time therefore deadlock: each holds its own provider write lock while blocked on the peer, and neither peer can take the read lock needed to answer. `DOLT_PULL` is immune because it operates on an already-registered database and does not hold the write lock across its fetch. This is the lock the existing `// TODO: This holds the database provider lock across the entire duration of the clone ...` was warning about.

The fix narrows the lock scope so the network fetch does not run under the provider write lock:

- Reserve the database name under a brief lock acquisition (a new `creatingDatabases` set), release the lock for the fetch, then re-acquire it only to register the finished database (`registerNewDatabase` still requires the lock).
- The reservation keeps concurrent `CREATE DATABASE` / `dolt_clone` / `undrop` of the same name mutually exclusive, so those races behave as before even though the lock is dropped for the fetch.
- A shared `databaseNameUnavailableLocked` helper performs the availability checks for all creation paths and preserves the interrupted-create in-progress marker behaviour (`ErrIncompleteDatabaseDir` / `dbfactory.MarkDatabaseInProgress`). The in-memory reservation and the on-disk marker are complementary: the marker guards crash recovery across processes, while `creatingDatabases` serialises concurrent in-process operations while the lock is dropped.
- Names in `creatingDatabases` and `deletingDatabases` are normalised with `formatDbMapKeyName` (Dolt database names are case-insensitive), matching how `p.databases` is keyed. Unlike `deletingDatabases`, `creatingDatabases` deliberately does **not** gate database enumeration: an in-progress clone is simply invisible until it registers, so enumeration / remotesapi reads never block on it.

Tests:

- `integration-tests/bats/sql-server-remotesrv.bats`: a regression test that starts two `--remotesapi-port` servers cloning from each other concurrently. It hangs (clones time out) on the buggy build and passes on the fixed build; it also fails if a clone errors for any non-deadlock reason.
- `go/libraries/doltcore/sqle/database_provider_test.go`: `TestCreatingDatabaseReservation` covering the reservation semantics — conflict, case-insensitivity across create/clone/undrop, release, and that a reservation does not block `AllDatabases`.

Verified with `go test -race ./libraries/doltcore/sqle/` and the new bats test; `gofmt` / `goimports` clean.

Fixes #11280
