### PR TITLE
Correctly convert foreign key lookups across encoding type boundaries

### DIFF
--- a/go/libraries/doltcore/merge/violations_fk_prolly.go
+++ b/go/libraries/doltcore/merge/violations_fk_prolly.go
@@ -672,7 +672,7 @@ func convertKeyBetweenTypes(
 
 		// If one or both handlers are nil, at least one field has a native encoding and needs special handling
 		if fromHandler == nil || toHandler == nil {
-			if err := convertNativeEncodedFkField(ctx, tb, ns, i, field, fromKeyDesc.Types[i].Enc, toKeyDesc.Types[i].Enc, fromKeyDesc.Handlers[i], toKeyDesc.Handlers[i]); err != nil {
+			if err := convertNativeEncodedFkField(ctx, tb, ns, i, field, fromKeyDesc, toKeyDesc); err != nil {
 				return nil, err
 			}
 			continue
@@ -718,48 +718,34 @@ func convertKeyBetweenTypes(
 	return key, nil
 }
 
-// convertNativeEncodedFkField converts a single FK field between encodings where at
-// least one side has no type handler (i.e. uses a Dolt-native encoding), writing the
-// result directly into |tb| at position |i|.
-//
-// The conversion happens in two steps:
-//  1. Reduce the source to a "raw content" byte slice — the underlying string or byte
-//     payload of the value with no encoding-specific framing.  Extended sources also
-//     produce a deserialised Go value (via |fromHandler|) that extended targets can
-//     re-serialise with |toHandler|.
-//  2. Write the raw content (native targets) or a re-serialised Go value (extended
-//     targets) into |tb| using the appropriate encoding-specific writer.
-//
-// Extended targets need a Go value, and when the source was native we lift the raw
-// content back to a value shape the target handler expects — string for text-shaped
-// handlers, []byte for byte-shaped ones — using the source encoding as the hint.
-//
-// This asymmetry (native side has no handler; extended side does) is what makes FK
-// validation across a doltgres version boundary work when one release stored a column
-// as ExtendedEnc + DoltgresType handler and a later release switched to a native
-// encoding for the same logical type.
+// convertNativeEncodedFkField converts a single FK field between encodings where at least one side uses a
+// Dolt-native encoding, writing the result directly into |tb| at position |i|.
 func convertNativeEncodedFkField(
 		ctx context.Context,
 		tb *val.TupleBuilder,
 		ns tree.NodeStore,
 		i int,
 		field []byte,
-		fromEnc, toEnc val.Encoding,
-		fromHandler, toHandler val.TupleTypeHandler,
+		fromKeyDesc, toKeyDesc *val.TupleDesc,
 ) error {
+	fromEnc := fromKeyDesc.Types[i].Enc
+	toEnc := toKeyDesc.Types[i].Enc
+	fromHandler := fromKeyDesc.Handlers[i]
+	toHandler := toKeyDesc.Handlers[i]
+
 	// Step 1: reduce the source to raw content bytes.  For extended sources we also
 	// hold on to the deserialised Go value so that an extended target can re-serialise
 	// it without a lossy round-trip through raw bytes.
-	var content []byte
+	var byteContent []byte
 	var fieldVal any
+
 	switch fromEnc {
 	case val.StringEnc:
-		// StringEnc layout: [string bytes][0x00 terminator]
 		if len(field) == 0 {
 			tb.PutRaw(i, nil)
 			return nil
 		}
-		content = field[:len(field)-1]
+		byteContent = field[:len(field)-1]
 	case val.StringAdaptiveEnc, val.BytesAdaptiveEnc, val.JsonAdaptiveEnc, val.ExtendedAdaptiveEnc:
 		adaptiveVal := val.AdaptiveValue(field)
 		if adaptiveVal.IsNull() {
@@ -772,18 +758,17 @@ func convertNativeEncodedFkField(
 			if err != nil {
 				return err
 			}
-			content = inline[1:] // strip 0x00 inline header byte
+			byteContent = inline[1:] // strip 0x00 inline header byte
 		} else {
-			content = field[1:] // strip 0x00 inline header byte
+			byteContent = field[1:] // strip 0x00 inline header byte
 		}
+
 		if fromEnc == val.ExtendedAdaptiveEnc {
-			// The inline bytes are handler-serialised; reduce to raw content.
-			v, err := fromHandler.DeserializeValue(ctx, content)
+			v, err := fromHandler.DeserializeValue(ctx, byteContent)
 			if err != nil {
 				return err
 			}
 			fieldVal = v
-			content = fkValueToRawContent(v)
 		}
 	case val.ExtendedEnc:
 		if len(field) == 0 {
@@ -795,7 +780,7 @@ func convertNativeEncodedFkField(
 			return err
 		}
 		fieldVal = v
-		content = fkValueToRawContent(v)
+		byteContent = field
 	default:
 		// No known conversion; copy raw bytes as-is.
 		tb.PutRaw(i, field)
@@ -806,18 +791,18 @@ func convertNativeEncodedFkField(
 	// extended targets need a Go value fed into |toHandler|.
 	switch toEnc {
 	case val.StringEnc:
-		return tb.PutString(i, string(content))
+		return tb.PutString(i, string(byteContent))
 	case val.StringAdaptiveEnc:
-		return tb.PutAdaptiveStringFromInline(ctx, i, string(content))
+		return tb.PutAdaptiveStringFromInline(ctx, i, string(byteContent))
 	case val.BytesAdaptiveEnc:
-		return tb.PutAdaptiveBytesFromInline(ctx, i, content)
+		return tb.PutAdaptiveBytesFromInline(ctx, i, byteContent)
 	case val.JsonAdaptiveEnc:
-		return tb.PutAdaptiveJsonFromInline(ctx, i, content)
+		return tb.PutAdaptiveJsonFromInline(ctx, i, byteContent)
 	case val.ExtendedAdaptiveEnc, val.ExtendedEnc:
 		v := fieldVal
 		if v == nil {
 			// Source was native; lift raw content to the Go shape |toHandler| expects.
-			v = fkRawContentToValue(fromEnc, content)
+			v = bytesToGoValue(fromEnc, byteContent)
 		}
 		serialized, err := toHandler.SerializeValue(ctx, v)
 		if err != nil {
@@ -835,30 +820,11 @@ func convertNativeEncodedFkField(
 	}
 }
 
-// fkValueToRawContent reduces a value returned by an extended type handler to the raw
-// content bytes that native encodings store — a string's UTF-8 bytes, or a byte slice
-// as-is.  Doltgres string types (bpchar / char / name / text / varchar / json / jsonb)
-// deserialise to a Go string; bytea deserialises to []byte.  fmt.Stringer is a
-// last-resort fallback for unknown extended types.
-func fkValueToRawContent(v any) []byte {
-	switch x := v.(type) {
-	case nil:
-		return nil
-	case string:
-		return []byte(x)
-	case []byte:
-		return x
-	case fmt.Stringer:
-		return []byte(x.String())
-	}
-	return nil
-}
-
-// fkRawContentToValue lifts raw content bytes to the Go value shape an extended type
+// bytesToGoValue lifts raw content bytes to the Go value shape an extended type
 // handler expects.  BytesAdaptiveEnc sources hold []byte payloads; every other native
 // encoding we handle here (StringEnc, StringAdaptiveEnc, JsonAdaptiveEnc) holds a UTF-8
 // string.
-func fkRawContentToValue(sourceEnc val.Encoding, content []byte) any {
+func bytesToGoValue(sourceEnc val.Encoding, content []byte) any {
 	if sourceEnc == val.BytesAdaptiveEnc {
 		return content
 	}

--- a/go/libraries/doltcore/merge/violations_fk_prolly.go
+++ b/go/libraries/doltcore/merge/violations_fk_prolly.go
@@ -319,7 +319,6 @@ func prollyChildSecDiffFkConstraintViolations(
 		postParent, postChild *constraintViolationsLoadedTable,
 		preChildSecIdx prolly.Map,
 		receiver FKViolationReceiver) error {
-
 	postChildRowData, err := durable.ProllyMapFromIndex(postChild.RowData)
 	if err != nil {
 		return err
@@ -719,16 +718,26 @@ func convertKeyBetweenTypes(
 	return key, nil
 }
 
-// convertNativeEncodedFkField converts a single FK field between native Dolt encodings (no
-// type handler), writing the result directly into |tb| at position |i|.
+// convertNativeEncodedFkField converts a single FK field between encodings where at
+// least one side has no type handler (i.e. uses a Dolt-native encoding), writing the
+// result directly into |tb| at position |i|.
 //
-// Supported conversions:
-//   - StringEnc  <-> StringAdaptiveEnc : VARCHAR <-> TEXT
-//   - StringAdaptiveEnc -> StringAdaptiveEnc : normalise out-of-band adaptive values to inline
-//   - BytesAdaptiveEnc  -> BytesAdaptiveEnc  : same normalisation for blob types
-//   - ExtendedEnc / ExtendedAdaptiveEnc <-> native types: convert via type handler serialization
+// The conversion happens in two steps:
+//  1. Reduce the source to a "raw content" byte slice — the underlying string or byte
+//     payload of the value with no encoding-specific framing.  Extended sources also
+//     produce a deserialised Go value (via |fromHandler|) that extended targets can
+//     re-serialise with |toHandler|.
+//  2. Write the raw content (native targets) or a re-serialised Go value (extended
+//     targets) into |tb| using the appropriate encoding-specific writer.
 //
-// For any encoding pair not explicitly handled the raw bytes are copied unchanged.
+// Extended targets need a Go value, and when the source was native we lift the raw
+// content back to a value shape the target handler expects — string for text-shaped
+// handlers, []byte for byte-shaped ones — using the source encoding as the hint.
+//
+// This asymmetry (native side has no handler; extended side does) is what makes FK
+// validation across a doltgres version boundary work when one release stored a column
+// as ExtendedEnc + DoltgresType handler and a later release switched to a native
+// encoding for the same logical type.
 func convertNativeEncodedFkField(
 		ctx context.Context,
 		tb *val.TupleBuilder,
@@ -738,7 +747,9 @@ func convertNativeEncodedFkField(
 		fromEnc, toEnc val.Encoding,
 		fromHandler, toHandler val.TupleTypeHandler,
 ) error {
-	// Extract the raw string/byte content from the source encoding.
+	// Step 1: reduce the source to raw content bytes.  For extended sources we also
+	// hold on to the deserialised Go value so that an extended target can re-serialise
+	// it without a lossy round-trip through raw bytes.
 	var content []byte
 	var fieldVal any
 	switch fromEnc {
@@ -748,7 +759,7 @@ func convertNativeEncodedFkField(
 			tb.PutRaw(i, nil)
 			return nil
 		}
-		content = field[:len(field)-1] // strip null terminator
+		content = field[:len(field)-1]
 	case val.StringAdaptiveEnc, val.BytesAdaptiveEnc, val.JsonAdaptiveEnc, val.ExtendedAdaptiveEnc:
 		adaptiveVal := val.AdaptiveValue(field)
 		if adaptiveVal.IsNull() {
@@ -756,7 +767,6 @@ func convertNativeEncodedFkField(
 			return nil
 		}
 		if adaptiveVal.IsOutOfBand() {
-			// Resolve out-of-band reference to its inline bytes.
 			handler := val.NewAdaptiveTypeHandler(ns, fromHandler)
 			inline, err := handler.ConvertToInline(ctx, adaptiveVal)
 			if err != nil {
@@ -766,31 +776,36 @@ func convertNativeEncodedFkField(
 		} else {
 			content = field[1:] // strip 0x00 inline header byte
 		}
+		if fromEnc == val.ExtendedAdaptiveEnc {
+			// The inline bytes are handler-serialised; reduce to raw content.
+			v, err := fromHandler.DeserializeValue(ctx, content)
+			if err != nil {
+				return err
+			}
+			fieldVal = v
+			content = fkValueToRawContent(v)
+		}
 	case val.ExtendedEnc:
-		// This is an edge case present only due to the evolving serialization decisions in Doltgres. Some customers
-		// ended up, after an upgrade, with fields in one table with an ExtendedEnc and fields in another table with
-		// StringEnc or similar. For this kind of mixed case, we need to deserialize the ExtendedEnc value and then
-		// re-serialize it into the target encoding.
-		// This cannot be removed after Doltgres 1.0 without breaking customers with tables from earlier releases.
-		var err error
-		fieldVal, err = fromHandler.DeserializeValue(ctx, content)
+		if len(field) == 0 {
+			tb.PutRaw(i, nil)
+			return nil
+		}
+		v, err := fromHandler.DeserializeValue(ctx, field)
 		if err != nil {
 			return err
 		}
-		content, err = fromHandler.SerializeValue(ctx, fieldVal)
-		if err != nil {
-			return err
-		}
+		fieldVal = v
+		content = fkValueToRawContent(v)
 	default:
 		// No known conversion; copy raw bytes as-is.
 		tb.PutRaw(i, field)
 		return nil
 	}
 
-	// Write content into the target encoding.
+	// Step 2: emit into the target encoding.  Native targets take |content| directly;
+	// extended targets need a Go value fed into |toHandler|.
 	switch toEnc {
 	case val.StringEnc:
-		// StringEnc layout: [string bytes][0x00 terminator]
 		return tb.PutString(i, string(content))
 	case val.StringAdaptiveEnc:
 		return tb.PutAdaptiveStringFromInline(ctx, i, string(content))
@@ -798,12 +813,18 @@ func convertNativeEncodedFkField(
 		return tb.PutAdaptiveBytesFromInline(ctx, i, content)
 	case val.JsonAdaptiveEnc:
 		return tb.PutAdaptiveJsonFromInline(ctx, i, content)
-	case val.ExtendedAdaptiveEnc:
-		return tb.PutAdaptiveExtendedFromInline(ctx, i, content)
-	case val.ExtendedEnc:
-		serialized, err := toHandler.SerializeValue(ctx, fieldVal)
+	case val.ExtendedAdaptiveEnc, val.ExtendedEnc:
+		v := fieldVal
+		if v == nil {
+			// Source was native; lift raw content to the Go shape |toHandler| expects.
+			v = fkRawContentToValue(fromEnc, content)
+		}
+		serialized, err := toHandler.SerializeValue(ctx, v)
 		if err != nil {
 			return err
+		}
+		if toEnc == val.ExtendedAdaptiveEnc {
+			return tb.PutAdaptiveExtendedFromInline(ctx, i, serialized)
 		}
 		tb.PutRaw(i, serialized)
 		return nil
@@ -812,6 +833,36 @@ func convertNativeEncodedFkField(
 		tb.PutRaw(i, field)
 		return nil
 	}
+}
+
+// fkValueToRawContent reduces a value returned by an extended type handler to the raw
+// content bytes that native encodings store — a string's UTF-8 bytes, or a byte slice
+// as-is.  Doltgres string types (bpchar / char / name / text / varchar / json / jsonb)
+// deserialise to a Go string; bytea deserialises to []byte.  fmt.Stringer is a
+// last-resort fallback for unknown extended types.
+func fkValueToRawContent(v any) []byte {
+	switch x := v.(type) {
+	case nil:
+		return nil
+	case string:
+		return []byte(x)
+	case []byte:
+		return x
+	case fmt.Stringer:
+		return []byte(x.String())
+	}
+	return nil
+}
+
+// fkRawContentToValue lifts raw content bytes to the Go value shape an extended type
+// handler expects.  BytesAdaptiveEnc sources hold []byte payloads; every other native
+// encoding we handle here (StringEnc, StringAdaptiveEnc, JsonAdaptiveEnc) holds a UTF-8
+// string.
+func fkRawContentToValue(sourceEnc val.Encoding, content []byte) any {
+	if sourceEnc == val.BytesAdaptiveEnc {
+		return content
+	}
+	return string(content)
 }
 
 func makePartialKey(ctx context.Context, kb *val.TupleBuilder, tags []uint64, idxSch schema.Index, tblSch schema.Schema, k, v val.Tuple, pool pool.BuffPool) (val.Tuple, bool, error) {

--- a/go/libraries/doltcore/merge/violations_fk_prolly.go
+++ b/go/libraries/doltcore/merge/violations_fk_prolly.go
@@ -37,11 +37,11 @@ import (
 // removed or modified row, it checks whether an equivalent parent value still exists, then
 // scans the child's secondary index for child rows that reference the removed value.
 func prollyParentSecDiffFkConstraintViolations(
-		ctx context.Context,
-		foreignKey doltdb.ForeignKey,
-		postParent, postChild *constraintViolationsLoadedTable,
-		preParentSecIdx prolly.Map,
-		receiver FKViolationReceiver) error {
+	ctx context.Context,
+	foreignKey doltdb.ForeignKey,
+	postParent, postChild *constraintViolationsLoadedTable,
+	preParentSecIdx prolly.Map,
+	receiver FKViolationReceiver) error {
 	postParentRowData, err := durable.ProllyMapFromIndex(postParent.RowData)
 	if err != nil {
 		return err
@@ -132,11 +132,11 @@ func prollyParentSecDiffFkConstraintViolations(
 // diffs |preParentRowData| against |postParent|'s primary index and applies the same
 // checks as prollyParentSecDiffFkConstraintViolations.
 func prollyParentPriDiffFkConstraintViolations(
-		ctx context.Context,
-		foreignKey doltdb.ForeignKey,
-		postParent, postChild *constraintViolationsLoadedTable,
-		preParentRowData prolly.Map,
-		receiver FKViolationReceiver) error {
+	ctx context.Context,
+	foreignKey doltdb.ForeignKey,
+	postParent, postChild *constraintViolationsLoadedTable,
+	preParentRowData prolly.Map,
+	receiver FKViolationReceiver) error {
 	postParentRowData, err := durable.ProllyMapFromIndex(postParent.RowData)
 	if err != nil {
 		return err
@@ -240,11 +240,11 @@ func prollyParentPriDiffFkConstraintViolations(
 // row, it builds a parent lookup key from the FK columns and verifies that a matching parent
 // row exists.
 func prollyChildPriDiffFkConstraintViolations(
-		ctx context.Context,
-		foreignKey doltdb.ForeignKey,
-		postParent, postChild *constraintViolationsLoadedTable,
-		preChildRowData prolly.Map,
-		receiver FKViolationReceiver) error {
+	ctx context.Context,
+	foreignKey doltdb.ForeignKey,
+	postParent, postChild *constraintViolationsLoadedTable,
+	preChildRowData prolly.Map,
+	receiver FKViolationReceiver) error {
 	postChildRowData, err := durable.ProllyMapFromIndex(postChild.RowData)
 	if err != nil {
 		return err
@@ -314,11 +314,11 @@ func prollyChildPriDiffFkConstraintViolations(
 // in the child table. It diffs |preChildSecIdx| against |postChild|'s secondary index. For
 // each new or changed row, it verifies that a matching parent row exists.
 func prollyChildSecDiffFkConstraintViolations(
-		ctx context.Context,
-		foreignKey doltdb.ForeignKey,
-		postParent, postChild *constraintViolationsLoadedTable,
-		preChildSecIdx prolly.Map,
-		receiver FKViolationReceiver) error {
+	ctx context.Context,
+	foreignKey doltdb.ForeignKey,
+	postParent, postChild *constraintViolationsLoadedTable,
+	preChildSecIdx prolly.Map,
+	receiver FKViolationReceiver) error {
 	postChildRowData, err := durable.ProllyMapFromIndex(postChild.RowData)
 	if err != nil {
 		return err
@@ -441,9 +441,9 @@ func nativeEncodingsAreSerializationCompatible(encA, encB val.Encoding) bool {
 
 // convertSerializedFkField converts a serialized foreign key value from one type handler to another.
 func convertSerializedFkField(
-		ctx context.Context,
-		toHandler, fromHandler val.TupleTypeHandler,
-		field []byte,
+	ctx context.Context,
+	toHandler, fromHandler val.TupleTypeHandler,
+	field []byte,
 ) ([]byte, error) {
 	convertingHandler := toHandler
 	convertedHandler := fromHandler
@@ -490,11 +490,11 @@ func convertSerializedFkField(
 }
 
 func createCVIfNoPartialKeyMatchesPri(
-		ctx context.Context,
-		k, v, partialKey val.Tuple,
-		partialKeyDesc *val.TupleDesc,
-		idx prolly.Map,
-		receiver FKViolationReceiver) error {
+	ctx context.Context,
+	k, v, partialKey val.Tuple,
+	partialKeyDesc *val.TupleDesc,
+	idx prolly.Map,
+	receiver FKViolationReceiver) error {
 	itr, err := creation.NewPrefixItr(ctx, partialKey, partialKeyDesc, idx)
 	if err != nil {
 		return err
@@ -511,12 +511,12 @@ func createCVIfNoPartialKeyMatchesPri(
 }
 
 func createCVForSecIdx(
-		ctx context.Context,
-		k val.Tuple,
-		primaryKD *val.TupleDesc,
-		pri prolly.Map,
-		tableSchema, indexSchema schema.Schema,
-		receiver FKViolationReceiver,
+	ctx context.Context,
+	k val.Tuple,
+	primaryKD *val.TupleDesc,
+	pri prolly.Map,
+	tableSchema, indexSchema schema.Schema,
+	receiver FKViolationReceiver,
 ) error {
 
 	// convert secondary idx entry to primary row key
@@ -586,13 +586,13 @@ type indexAndKeyDescriptor struct {
 // createCVsForDanglingChildRows finds all rows in the childIdx that match the given parent key and creates constraint
 // violations for each of them using the provided receiver.
 func createCVsForDanglingChildRows(
-		ctx context.Context,
-		partialKey val.Tuple,
-		partialKeyDesc *val.TupleDesc,
-		childPrimaryIdx *indexAndKeyDescriptor,
-		childSecIdx *indexAndKeyDescriptor,
-		receiver FKViolationReceiver,
-		compatibleTypes bool,
+	ctx context.Context,
+	partialKey val.Tuple,
+	partialKeyDesc *val.TupleDesc,
+	childPrimaryIdx *indexAndKeyDescriptor,
+	childSecIdx *indexAndKeyDescriptor,
+	receiver FKViolationReceiver,
+	compatibleTypes bool,
 ) error {
 
 	// We allow foreign keys between types that don't have the same serialization bytes for the same logical values
@@ -652,12 +652,12 @@ func createCVsForDanglingChildRows(
 // convertKeyBetweenTypes converts a partial key from one tuple descriptor's types to another. This is only necessary
 // when the keys are of different types that are not serialization identical.
 func convertKeyBetweenTypes(
-		ctx context.Context,
-		key val.Tuple,
-		fromKeyDesc *val.TupleDesc,
-		toKeyDesc *val.TupleDesc,
-		ns tree.NodeStore,
-		pool pool.BuffPool,
+	ctx context.Context,
+	key val.Tuple,
+	fromKeyDesc *val.TupleDesc,
+	toKeyDesc *val.TupleDesc,
+	ns tree.NodeStore,
+	pool pool.BuffPool,
 ) (val.Tuple, error) {
 	tb := val.NewTupleBuilder(toKeyDesc, ns)
 	for i := range toKeyDesc.Types {
@@ -721,12 +721,12 @@ func convertKeyBetweenTypes(
 // convertNativeEncodedFkField converts a single FK field between encodings where at least one side uses a
 // Dolt-native encoding, writing the result directly into |tb| at position |i|.
 func convertNativeEncodedFkField(
-		ctx context.Context,
-		tb *val.TupleBuilder,
-		ns tree.NodeStore,
-		i int,
-		field []byte,
-		fromKeyDesc, toKeyDesc *val.TupleDesc,
+	ctx context.Context,
+	tb *val.TupleBuilder,
+	ns tree.NodeStore,
+	i int,
+	field []byte,
+	fromKeyDesc, toKeyDesc *val.TupleDesc,
 ) error {
 	fromEnc := fromKeyDesc.Types[i].Enc
 	toEnc := toKeyDesc.Types[i].Enc
@@ -900,15 +900,15 @@ func (m FkCVMeta) ToInterface(context.Context) (interface{}, error) {
 // output which includes additional whitespace between keys, values, and array elements.
 func (m FkCVMeta) PrettyPrint() string {
 	jsonStr := fmt.Sprintf(`{`+
-			`"Index": "%s", `+
-			`"Table": "%s", `+
-			`"Columns": ["%s"], `+
-			`"OnDelete": "%s", `+
-			`"OnUpdate": "%s", `+
-			`"ForeignKey": "%s", `+
-			`"ReferencedIndex": "%s", `+
-			`"ReferencedTable": "%s", `+
-			`"ReferencedColumns": ["%s"]}`,
+		`"Index": "%s", `+
+		`"Table": "%s", `+
+		`"Columns": ["%s"], `+
+		`"OnDelete": "%s", `+
+		`"OnUpdate": "%s", `+
+		`"ForeignKey": "%s", `+
+		`"ReferencedIndex": "%s", `+
+		`"ReferencedTable": "%s", `+
+		`"ReferencedColumns": ["%s"]}`,
 		m.Index,
 		m.Table,
 		strings.Join(m.Columns, `', '`),

--- a/go/libraries/doltcore/merge/violations_fk_prolly.go
+++ b/go/libraries/doltcore/merge/violations_fk_prolly.go
@@ -764,7 +764,16 @@ func convertNativeEncodedFkField(
 		}
 
 		if fromEnc == val.ExtendedAdaptiveEnc {
-			v, err := fromHandler.DeserializeValue(ctx, byteContent)
+			// byteContent above has already been stripped of the 0x00 inline header, so
+			// use the child (non-adaptive) handler to deserialise those raw payload bytes.
+			// AdaptiveEncodingTypeHandler.DeserializeValue expects the full adaptive value
+			// (with header) and will panic trying to parse the payload as an out-of-band
+			// reference.
+			deserializingHandler := fromHandler
+			if h, ok := fromHandler.(val.AdaptiveEncodingTypeHandler); ok {
+				deserializingHandler = h.ChildHandler()
+			}
+			v, err := deserializingHandler.DeserializeValue(ctx, byteContent)
 			if err != nil {
 				return err
 			}
@@ -804,7 +813,15 @@ func convertNativeEncodedFkField(
 			// Source was native; lift raw content to the Go shape |toHandler| expects.
 			v = bytesToGoValue(fromEnc, byteContent)
 		}
-		serialized, err := toHandler.SerializeValue(ctx, v)
+		// For an adaptive target we need the child (non-adaptive) handler's serialisation
+		// bytes: PutAdaptiveExtendedFromInline prepends the 0x00 inline marker itself, and
+		// AdaptiveEncodingTypeHandler.SerializeValue would also prepend one, producing a
+		// double-header inline value that fails to compare against stored parent keys.
+		serializingHandler := toHandler
+		if h, ok := toHandler.(val.AdaptiveEncodingTypeHandler); ok {
+			serializingHandler = h.ChildHandler()
+		}
+		serialized, err := serializingHandler.SerializeValue(ctx, v)
 		if err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/merge/violations_fk_prolly.go
+++ b/go/libraries/doltcore/merge/violations_fk_prolly.go
@@ -37,11 +37,11 @@ import (
 // removed or modified row, it checks whether an equivalent parent value still exists, then
 // scans the child's secondary index for child rows that reference the removed value.
 func prollyParentSecDiffFkConstraintViolations(
-	ctx context.Context,
-	foreignKey doltdb.ForeignKey,
-	postParent, postChild *constraintViolationsLoadedTable,
-	preParentSecIdx prolly.Map,
-	receiver FKViolationReceiver) error {
+		ctx context.Context,
+		foreignKey doltdb.ForeignKey,
+		postParent, postChild *constraintViolationsLoadedTable,
+		preParentSecIdx prolly.Map,
+		receiver FKViolationReceiver) error {
 	postParentRowData, err := durable.ProllyMapFromIndex(postParent.RowData)
 	if err != nil {
 		return err
@@ -132,11 +132,11 @@ func prollyParentSecDiffFkConstraintViolations(
 // diffs |preParentRowData| against |postParent|'s primary index and applies the same
 // checks as prollyParentSecDiffFkConstraintViolations.
 func prollyParentPriDiffFkConstraintViolations(
-	ctx context.Context,
-	foreignKey doltdb.ForeignKey,
-	postParent, postChild *constraintViolationsLoadedTable,
-	preParentRowData prolly.Map,
-	receiver FKViolationReceiver) error {
+		ctx context.Context,
+		foreignKey doltdb.ForeignKey,
+		postParent, postChild *constraintViolationsLoadedTable,
+		preParentRowData prolly.Map,
+		receiver FKViolationReceiver) error {
 	postParentRowData, err := durable.ProllyMapFromIndex(postParent.RowData)
 	if err != nil {
 		return err
@@ -240,11 +240,11 @@ func prollyParentPriDiffFkConstraintViolations(
 // row, it builds a parent lookup key from the FK columns and verifies that a matching parent
 // row exists.
 func prollyChildPriDiffFkConstraintViolations(
-	ctx context.Context,
-	foreignKey doltdb.ForeignKey,
-	postParent, postChild *constraintViolationsLoadedTable,
-	preChildRowData prolly.Map,
-	receiver FKViolationReceiver) error {
+		ctx context.Context,
+		foreignKey doltdb.ForeignKey,
+		postParent, postChild *constraintViolationsLoadedTable,
+		preChildRowData prolly.Map,
+		receiver FKViolationReceiver) error {
 	postChildRowData, err := durable.ProllyMapFromIndex(postChild.RowData)
 	if err != nil {
 		return err
@@ -314,11 +314,11 @@ func prollyChildPriDiffFkConstraintViolations(
 // in the child table. It diffs |preChildSecIdx| against |postChild|'s secondary index. For
 // each new or changed row, it verifies that a matching parent row exists.
 func prollyChildSecDiffFkConstraintViolations(
-	ctx context.Context,
-	foreignKey doltdb.ForeignKey,
-	postParent, postChild *constraintViolationsLoadedTable,
-	preChildSecIdx prolly.Map,
-	receiver FKViolationReceiver) error {
+		ctx context.Context,
+		foreignKey doltdb.ForeignKey,
+		postParent, postChild *constraintViolationsLoadedTable,
+		preChildSecIdx prolly.Map,
+		receiver FKViolationReceiver) error {
 
 	postChildRowData, err := durable.ProllyMapFromIndex(postChild.RowData)
 	if err != nil {
@@ -405,6 +405,11 @@ func fkIdxKeyDescs(idx durable.Index, n int) (prolly.Map, *val.TupleDesc, *val.T
 func fkHandlersAreSerializationCompatible(keyDescA, keyDescB *val.TupleDesc) bool {
 	for i, handlerA := range keyDescA.Handlers {
 		handlerB := keyDescB.Handlers[i]
+		// Mixing dolt-native encoding with an extended encoding is by definition incompatible.
+		if (handlerA == nil) != (handlerB == nil) {
+			return false
+		}
+
 		if handlerA != nil && handlerB != nil && !handlerA.SerializationCompatible(handlerB) {
 			return false
 		}
@@ -416,11 +421,6 @@ func fkHandlersAreSerializationCompatible(keyDescA, keyDescB *val.TupleDesc) boo
 			if !nativeEncodingsAreSerializationCompatible(keyDescA.Types[i].Enc, keyDescB.Types[i].Enc) {
 				return false
 			}
-		}
-		// If one handler is nil, then we're mixing native encoding with handlers
-		// TODO: fix this, this exists only to fix a customer issue
-		if handlerA == nil && handlerB != nil {
-			return false
 		}
 	}
 	return true
@@ -442,9 +442,9 @@ func nativeEncodingsAreSerializationCompatible(encA, encB val.Encoding) bool {
 
 // convertSerializedFkField converts a serialized foreign key value from one type handler to another.
 func convertSerializedFkField(
-	ctx context.Context,
-	toHandler, fromHandler val.TupleTypeHandler,
-	field []byte,
+		ctx context.Context,
+		toHandler, fromHandler val.TupleTypeHandler,
+		field []byte,
 ) ([]byte, error) {
 	convertingHandler := toHandler
 	convertedHandler := fromHandler
@@ -491,11 +491,11 @@ func convertSerializedFkField(
 }
 
 func createCVIfNoPartialKeyMatchesPri(
-	ctx context.Context,
-	k, v, partialKey val.Tuple,
-	partialKeyDesc *val.TupleDesc,
-	idx prolly.Map,
-	receiver FKViolationReceiver) error {
+		ctx context.Context,
+		k, v, partialKey val.Tuple,
+		partialKeyDesc *val.TupleDesc,
+		idx prolly.Map,
+		receiver FKViolationReceiver) error {
 	itr, err := creation.NewPrefixItr(ctx, partialKey, partialKeyDesc, idx)
 	if err != nil {
 		return err
@@ -512,12 +512,12 @@ func createCVIfNoPartialKeyMatchesPri(
 }
 
 func createCVForSecIdx(
-	ctx context.Context,
-	k val.Tuple,
-	primaryKD *val.TupleDesc,
-	pri prolly.Map,
-	tableSchema, indexSchema schema.Schema,
-	receiver FKViolationReceiver,
+		ctx context.Context,
+		k val.Tuple,
+		primaryKD *val.TupleDesc,
+		pri prolly.Map,
+		tableSchema, indexSchema schema.Schema,
+		receiver FKViolationReceiver,
 ) error {
 
 	// convert secondary idx entry to primary row key
@@ -587,13 +587,13 @@ type indexAndKeyDescriptor struct {
 // createCVsForDanglingChildRows finds all rows in the childIdx that match the given parent key and creates constraint
 // violations for each of them using the provided receiver.
 func createCVsForDanglingChildRows(
-	ctx context.Context,
-	partialKey val.Tuple,
-	partialKeyDesc *val.TupleDesc,
-	childPrimaryIdx *indexAndKeyDescriptor,
-	childSecIdx *indexAndKeyDescriptor,
-	receiver FKViolationReceiver,
-	compatibleTypes bool,
+		ctx context.Context,
+		partialKey val.Tuple,
+		partialKeyDesc *val.TupleDesc,
+		childPrimaryIdx *indexAndKeyDescriptor,
+		childSecIdx *indexAndKeyDescriptor,
+		receiver FKViolationReceiver,
+		compatibleTypes bool,
 ) error {
 
 	// We allow foreign keys between types that don't have the same serialization bytes for the same logical values
@@ -653,12 +653,12 @@ func createCVsForDanglingChildRows(
 // convertKeyBetweenTypes converts a partial key from one tuple descriptor's types to another. This is only necessary
 // when the keys are of different types that are not serialization identical.
 func convertKeyBetweenTypes(
-	ctx context.Context,
-	key val.Tuple,
-	fromKeyDesc *val.TupleDesc,
-	toKeyDesc *val.TupleDesc,
-	ns tree.NodeStore,
-	pool pool.BuffPool,
+		ctx context.Context,
+		key val.Tuple,
+		fromKeyDesc *val.TupleDesc,
+		toKeyDesc *val.TupleDesc,
+		ns tree.NodeStore,
+		pool pool.BuffPool,
 ) (val.Tuple, error) {
 	tb := val.NewTupleBuilder(toKeyDesc, ns)
 	for i := range toKeyDesc.Types {
@@ -671,9 +671,9 @@ func convertKeyBetweenTypes(
 		}
 		field := key.GetField(i)
 
-		// When both handlers are nil, use native encoding conversion logic.
-		if fromHandler == nil && toHandler == nil {
-			if err := convertNativeEncodedFkField(ctx, tb, ns, i, field, fromKeyDesc.Types[i].Enc, toKeyDesc.Types[i].Enc); err != nil {
+		// If one or both handlers are nil, at least one field has a native encoding and needs special handling
+		if fromHandler == nil || toHandler == nil {
+			if err := convertNativeEncodedFkField(ctx, tb, ns, i, field, fromKeyDesc.Types[i].Enc, toKeyDesc.Types[i].Enc, fromKeyDesc.Handlers[i], toKeyDesc.Handlers[i]); err != nil {
 				return nil, err
 			}
 			continue
@@ -726,18 +726,21 @@ func convertKeyBetweenTypes(
 //   - StringEnc  <-> StringAdaptiveEnc : VARCHAR <-> TEXT
 //   - StringAdaptiveEnc -> StringAdaptiveEnc : normalise out-of-band adaptive values to inline
 //   - BytesAdaptiveEnc  -> BytesAdaptiveEnc  : same normalisation for blob types
+//   - ExtendedEnc / ExtendedAdaptiveEnc <-> native types: convert via type handler serialization
 //
 // For any encoding pair not explicitly handled the raw bytes are copied unchanged.
 func convertNativeEncodedFkField(
-	ctx context.Context,
-	tb *val.TupleBuilder,
-	ns tree.NodeStore,
-	i int,
-	field []byte,
-	fromEnc, toEnc val.Encoding,
+		ctx context.Context,
+		tb *val.TupleBuilder,
+		ns tree.NodeStore,
+		i int,
+		field []byte,
+		fromEnc, toEnc val.Encoding,
+		fromHandler, toHandler val.TupleTypeHandler,
 ) error {
 	// Extract the raw string/byte content from the source encoding.
 	var content []byte
+	var fieldVal any
 	switch fromEnc {
 	case val.StringEnc:
 		// StringEnc layout: [string bytes][0x00 terminator]
@@ -746,7 +749,7 @@ func convertNativeEncodedFkField(
 			return nil
 		}
 		content = field[:len(field)-1] // strip null terminator
-	case val.StringAdaptiveEnc, val.BytesAdaptiveEnc, val.JsonAdaptiveEnc:
+	case val.StringAdaptiveEnc, val.BytesAdaptiveEnc, val.JsonAdaptiveEnc, val.ExtendedAdaptiveEnc:
 		adaptiveVal := val.AdaptiveValue(field)
 		if adaptiveVal.IsNull() {
 			tb.PutRaw(i, nil)
@@ -754,7 +757,7 @@ func convertNativeEncodedFkField(
 		}
 		if adaptiveVal.IsOutOfBand() {
 			// Resolve out-of-band reference to its inline bytes.
-			handler := val.NewAdaptiveTypeHandler(ns, nil)
+			handler := val.NewAdaptiveTypeHandler(ns, fromHandler)
 			inline, err := handler.ConvertToInline(ctx, adaptiveVal)
 			if err != nil {
 				return err
@@ -762,6 +765,21 @@ func convertNativeEncodedFkField(
 			content = inline[1:] // strip 0x00 inline header byte
 		} else {
 			content = field[1:] // strip 0x00 inline header byte
+		}
+	case val.ExtendedEnc:
+		// This is an edge case present only due to the evolving serialization decisions in Doltgres. Some customers
+		// ended up, after an upgrade, with fields in one table with an ExtendedEnc and fields in another table with
+		// StringEnc or similar. For this kind of mixed case, we need to deserialize the ExtendedEnc value and then
+		// re-serialize it into the target encoding.
+		// This cannot be removed after Doltgres 1.0 without breaking customers with tables from earlier releases.
+		var err error
+		fieldVal, err = fromHandler.DeserializeValue(ctx, content)
+		if err != nil {
+			return err
+		}
+		content, err = fromHandler.SerializeValue(ctx, fieldVal)
+		if err != nil {
+			return err
 		}
 	default:
 		// No known conversion; copy raw bytes as-is.
@@ -780,6 +798,15 @@ func convertNativeEncodedFkField(
 		return tb.PutAdaptiveBytesFromInline(ctx, i, content)
 	case val.JsonAdaptiveEnc:
 		return tb.PutAdaptiveJsonFromInline(ctx, i, content)
+	case val.ExtendedAdaptiveEnc:
+		return tb.PutAdaptiveExtendedFromInline(ctx, i, content)
+	case val.ExtendedEnc:
+		serialized, err := toHandler.SerializeValue(ctx, fieldVal)
+		if err != nil {
+			return err
+		}
+		tb.PutRaw(i, serialized)
+		return nil
 	default:
 		// Unsupported target encoding; copy raw bytes as-is.
 		tb.PutRaw(i, field)
@@ -856,15 +883,15 @@ func (m FkCVMeta) ToInterface(context.Context) (interface{}, error) {
 // output which includes additional whitespace between keys, values, and array elements.
 func (m FkCVMeta) PrettyPrint() string {
 	jsonStr := fmt.Sprintf(`{`+
-		`"Index": "%s", `+
-		`"Table": "%s", `+
-		`"Columns": ["%s"], `+
-		`"OnDelete": "%s", `+
-		`"OnUpdate": "%s", `+
-		`"ForeignKey": "%s", `+
-		`"ReferencedIndex": "%s", `+
-		`"ReferencedTable": "%s", `+
-		`"ReferencedColumns": ["%s"]}`,
+			`"Index": "%s", `+
+			`"Table": "%s", `+
+			`"Columns": ["%s"], `+
+			`"OnDelete": "%s", `+
+			`"OnUpdate": "%s", `+
+			`"ForeignKey": "%s", `+
+			`"ReferencedIndex": "%s", `+
+			`"ReferencedTable": "%s", `+
+			`"ReferencedColumns": ["%s"]}`,
 		m.Index,
 		m.Table,
 		strings.Join(m.Columns, `', '`),


### PR DESCRIPTION
Tests are in Doltgres, should be a no-op for Dolt

Companion PR: https://github.com/dolthub/doltgresql/pull/2914