### PR TITLE
Fix fsck handling of stash refs

### DIFF
--- a/go/cmd/dolt/commands/fsck.go
+++ b/go/cmd/dolt/commands/fsck.go
@@ -1011,9 +1011,12 @@ func getRawReferencesFromStoreRoot(ctx context.Context, cs chunks.ChunkStore, er
 
 			refType := doltRef.GetType()
 			switch refType {
-			case ref.BranchRefType, ref.RemoteRefType, ref.InternalRefType, ref.WorkspaceRefType, ref.StashRefType:
+			case ref.BranchRefType, ref.RemoteRefType, ref.InternalRefType, ref.WorkspaceRefType:
 				// Address is the commit id.
 				refs[addr] = append(refs[addr], name)
+			case ref.StashRefType:
+				// A stash ref points to a StashList, not a commit.
+				// Its chunks were already validated by the full chunk scan.
 			case ref.TagRefType:
 				if commitHash, ok := resolveTagToCommit(ctx, cs, name, addr, errs); ok {
 					refs[commitHash] = append(refs[commitHash], name)

--- a/integration-tests/bats/fsck.bats
+++ b/integration-tests/bats/fsck.bats
@@ -78,6 +78,24 @@ UPDATE tbl SET guid = UUID() WHERE i >= @random_id LIMIT 1;"
   dolt fsck
 }
 
+@test "fsck: repository with stash" {
+  dolt init
+  dolt sql -q "create table t (i int primary key, value int)"
+  dolt sql -q "insert into t values (1, 1)"
+  dolt commit -Am "Create table t"
+
+  dolt sql -q "update t set value = 2 where i = 1"
+  dolt stash
+
+  run dolt fsck
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "No problems found." ]] || false
+
+  run dolt stash list
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "stash@{0}" ]] || false
+}
+
 @test "fsck: bad journal crc" {
   mkdir .dolt
   cp -R $BATS_CWD/corrupt_dbs/bad_journal_crc/* .dolt/


### PR DESCRIPTION
## Summary

- exclude stash-list refs from commit DAG roots during `dolt fsck`
- add a regression test proving repositories with stashes pass `fsck`
- verify the stash remains present after the integrity check

## Root cause

`getRawReferencesFromStoreRoot` treated `ref.StashRefType` as a commit-pointing ref. A stash ref points to an `SLST` stash-list object, so commit-tree validation attempted to parse that object as `DCMT` and failed.

The full chunk scan still validates and categorizes `SLST` and `STSH` chunks. This change only prevents a non-commit ref from entering commit DAG traversal.

## Validation

- `go test ./cmd/dolt/commands`
- built the patched `dolt` binary from current `main`
- reproduced the original failure in a fresh repository
- verified the patched binary reports `No problems found.` with the stash preserved
- `git diff --check`

Fixes #11292

