### PR TITLE
go: jwtauth: When using auth plugin authentication_dolt_jwt, validate the Subject claim against the expected claims.

### DIFF
--- a/go/cmd/dolt/commands/engine/jwtplugin.go
+++ b/go/cmd/dolt/commands/engine/jwtplugin.go
@@ -37,18 +37,24 @@ func NewAuthenticateDoltJWTPlugin(jwksConfig []servercfg.JwksConfig) mysql_db.Pl
 }
 
 func (p *authenticateDoltJWTPlugin) Authenticate(db *mysql_db.MySQLDb, user string, userEntry *mysql_db.User, pass string) (bool, error) {
-	return validateJWT(p.jwksConfig, user, userEntry.Identity, pass, time.Now())
+	return validateJWT(p.jwksConfig, userEntry.Identity, pass, time.Now())
 }
 
-func validateJWT(config []servercfg.JwksConfig, username, identity, token string, reqTime time.Time) (bool, error) {
+// validateJWT authenticates a token against the claims declared in the user's
+// identity string. The identity string is a comma-separated set of expected
+// claims (jwks, iss, aud, sub); the token authenticates iff it satisfies all
+// of them. The connecting username is deliberately not consulted here: if an
+// operator wants to bind the token subject to the account name, they set
+// sub=<username> in the identity, which is then enforced against the token's
+// sub claim like any other claim.
+func validateJWT(config []servercfg.JwksConfig, identity, token string, reqTime time.Time) (bool, error) {
 	if len(config) == 0 {
 		return false, errors.New("ValidateJWT: JWKS server config not found")
 	}
 
-	expectedClaimsMap := parseUserIdentity(identity)
-	sub, ok := expectedClaimsMap["sub"]
-	if ok && sub != username {
-		return false, errors.New("ValidateJWT: Subjects do not match")
+	expectedClaimsMap, err := parseUserIdentity(identity)
+	if err != nil {
+		return false, err
 	}
 
 	jwksConfig, err := getMatchingJwksConfig(config, expectedClaimsMap["jwks"])
@@ -119,12 +125,15 @@ func getMatchingJwksConfig(config []servercfg.JwksConfig, name string) (*serverc
 	return nil, errors.New("ValidateJWT: Matching JWKS config not found")
 }
 
-func parseUserIdentity(identity string) map[string]string {
+func parseUserIdentity(identity string) (map[string]string, error) {
 	idMap := make(map[string]string)
 	items := strings.Split(identity, ",")
 	for _, item := range items {
-		tup := strings.Split(item, "=")
-		idMap[tup[0]] = tup[1]
+		name, value, ok := strings.Cut(item, "=")
+		if !ok {
+			return nil, fmt.Errorf("ValidateJWT: malformed identity %q: expected comma-separated key=value pairs", identity)
+		}
+		idMap[name] = value
 	}
-	return idMap
+	return idMap, nil
 }

--- a/go/cmd/dolt/commands/engine/jwtplugin_test.go
+++ b/go/cmd/dolt/commands/engine/jwtplugin_test.go
@@ -48,33 +48,38 @@ func TestJWTAuth(t *testing.T) {
 
 	// Success
 	tokenCreated := time.Date(2022, 07, 20, 0, 12, 0, 0, time.UTC) // Update time if creating new token
-	authed, err := validateJWT(jwksConfig, sub, fmt.Sprintf("jwks=%s,sub=%s,iss=%s,aud=%s", jwksName, sub, iss, aud), jwt, tokenCreated)
+	authed, err := validateJWT(jwksConfig, fmt.Sprintf("jwks=%s,sub=%s,iss=%s,aud=%s", jwksName, sub, iss, aud), jwt, tokenCreated)
 	require.NoError(t, err)
 	require.True(t, authed)
 
 	// Token expired
 	now := time.Now()
-	authed, err = validateJWT(jwksConfig, sub, fmt.Sprintf("jwks=%s,sub=%s,iss=%s,aud=%s", jwksName, sub, iss, aud), jwt, now)
+	authed, err = validateJWT(jwksConfig, fmt.Sprintf("jwks=%s,sub=%s,iss=%s,aud=%s", jwksName, sub, iss, aud), jwt, now)
 	require.Error(t, err)
 	require.False(t, authed)
 
-	// Expected sub does not match
-	authed, err = validateJWT(jwksConfig, sub, fmt.Sprintf("jwks=%s,sub=%s,iss=%s,aud=%s", jwksName, "wrong-sub", iss, aud), jwt, tokenCreated)
+	// The token's sub claim does not match the sub claim declared in the identity.
+	authed, err = validateJWT(jwksConfig, fmt.Sprintf("jwks=%s,sub=%s,iss=%s,aud=%s", jwksName, "wrong-sub", iss, aud), jwt, tokenCreated)
 	require.Error(t, err)
 	require.False(t, authed)
 
 	// Jwks config doesn't exist
-	authed, err = validateJWT([]servercfg.JwksConfig{}, sub, fmt.Sprintf("jwks=%s,sub=%s,iss=%s,aud=%s", jwksName, sub, iss, aud), jwt, tokenCreated)
+	authed, err = validateJWT([]servercfg.JwksConfig{}, fmt.Sprintf("jwks=%s,sub=%s,iss=%s,aud=%s", jwksName, sub, iss, aud), jwt, tokenCreated)
 	require.Error(t, err)
 	require.False(t, authed)
 
 	// No token
-	authed, err = validateJWT(jwksConfig, sub, fmt.Sprintf("jwks=%s,sub=%s,iss=%s,aud=%s", jwksName, sub, iss, aud), "", tokenCreated)
+	authed, err = validateJWT(jwksConfig, fmt.Sprintf("jwks=%s,sub=%s,iss=%s,aud=%s", jwksName, sub, iss, aud), "", tokenCreated)
 	require.Error(t, err)
 	require.False(t, authed)
 
 	// Unknown claim in identity string
-	authed, err = validateJWT(jwksConfig, sub, fmt.Sprintf("jwks=%s,sub=%s,iss=%s,unknown=%s", jwksName, sub, iss, aud), "", tokenCreated)
+	authed, err = validateJWT(jwksConfig, fmt.Sprintf("jwks=%s,sub=%s,iss=%s,unknown=%s", jwksName, sub, iss, aud), "", tokenCreated)
+	require.Error(t, err)
+	require.False(t, authed)
+
+	// Malformed identity string (a field with no '=') returns an error rather than panicking.
+	authed, err = validateJWT(jwksConfig, fmt.Sprintf("jwks=%s,sub", jwksName), jwt, tokenCreated)
 	require.Error(t, err)
 	require.False(t, authed)
 }

--- a/go/libraries/utils/jwtauth/validator.go
+++ b/go/libraries/utils/jwtauth/validator.go
@@ -30,7 +30,7 @@ type fetchingJWTValidator struct {
 }
 
 func NewJWTValidator(provider JWTProvider) (JWTValidator, error) {
-	expected := jwt.Expected{Issuer: provider.Issuer, Audience: jwt.Audience{provider.Audience}}
+	expected := jwt.Expected{Issuer: provider.Issuer, Subject: provider.Subject, Audience: jwt.Audience{provider.Audience}}
 	jwks, err := newJWKS(provider)
 	if err != nil {
 		return nil, err

--- a/integration-tests/go-sql-server-driver/genjwt_test.go
+++ b/integration-tests/go-sql-server-driver/genjwt_test.go
@@ -29,7 +29,7 @@ import (
 	"gopkg.in/go-jose/go-jose.v2/jwt"
 )
 
-var sub = "test_user"
+var sub = "test_jwt_user"
 var iss = "dolthub.com"
 var aud = "my_resource"
 var onBehalfOf = "my_user"

--- a/integration-tests/go-sql-server-driver/jwt_sub_validation_test.go
+++ b/integration-tests/go-sql-server-driver/jwt_sub_validation_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	driver "github.com/dolthub/dolt/go/libraries/doltcore/dtestutils/sql_server_driver"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestJWTSubClaimValidation is a regression test for
+// https://github.com/dolthub/dolt/issues/11289.
+//
+// A user created `IDENTIFIED WITH authentication_dolt_jwt AS '...,sub=X,...'`
+// declares a set of expected claims (jwks, iss, aud, sub). A presented token
+// authenticates iff it satisfies all of them, including sub. Historically the
+// token's own `sub` claim was never enforced against the identity's `sub`, so
+// any validly-signed token (correct iss/aud, unexpired) authenticated any
+// JWT-backed user of that JWKS.
+//
+// These subtests assert the intended semantics: the identity string is the
+// source of truth for the claims the token must satisfy, and the token's `sub`
+// is enforced against the identity's `sub` independently of the connecting
+// username.
+func TestJWTSubClaimValidation(t *testing.T) {
+	t.Parallel()
+
+	const (
+		issuer   = "dolthub.com"
+		audience = "my_resource"
+	)
+
+	// Serve the public JWKS that testdata/test_jwks_private.json signs against,
+	// so the running sql-server can fetch it and verify token signatures.
+	jwksPort := GlobalPorts.GetPort(t)
+	t.Cleanup(func() { GlobalPorts.Return(jwksPort) })
+	absJWKS, err := filepath.Abs("./testdata/test_jwks.json")
+	require.NoError(t, err)
+	runJWKSServer(t, absJWKS, jwksPort)
+
+	server := startJWTAuthServer(t, jwksPort, issuer, audience)
+
+	// As root, create JWT-backed users. `alice` and `bob` bind their identity
+	// sub to their own account name; `svc` deliberately declares a sub
+	// (`alice`) that differs from its username, to exercise that the token is
+	// checked against the identity's declared claims, not the username.
+	rootConn := driver.Connection{
+		User:         "root",
+		DriverParams: map[string]string{"allowCleartextPasswords": "true"},
+	}
+	rootDB, err := server.DB(rootConn)
+	require.NoError(t, err)
+	defer rootDB.Close()
+
+	rootSQL, err := rootDB.Conn(context.Background())
+	require.NoError(t, err)
+	defer rootSQL.Close()
+
+	// user -> the sub claim declared in its identity string.
+	identitySub := map[string]string{
+		"alice": "alice",
+		"bob":   "bob",
+		"svc":   "alice",
+	}
+	for user, sub := range identitySub {
+		_, err = rootSQL.ExecContext(context.Background(), fmt.Sprintf(
+			"CREATE USER '%s'@'%%' IDENTIFIED WITH authentication_dolt_jwt "+
+				"AS 'jwks=jwksname,sub=%s,iss=%s,aud=%s'", user, sub, issuer, audience))
+		require.NoError(t, err)
+		_, err = rootSQL.ExecContext(context.Background(), fmt.Sprintf(
+			"GRANT ALL ON *.* TO '%s'@'%%' WITH GRANT OPTION", user))
+		require.NoError(t, err)
+	}
+
+	connectWithToken := func(user, tokenSub string) error {
+		token := createJWT(t, issuer, audience, tokenSub)
+		conn := driver.Connection{
+			User:         user,
+			Pass:         token,
+			DriverParams: map[string]string{"allowCleartextPasswords": "true"},
+		}
+		db, err := server.DB(conn)
+		if db != nil {
+			db.Close()
+		}
+		return err
+	}
+
+	// Positive control: a token whose sub matches the identity's declared sub
+	// authenticates. This also proves the JWKS/issuer/audience/TLS plumbing is
+	// correct, so the rejections below are specifically about the sub claim.
+	t.Run("token matching identity sub authenticates", func(t *testing.T) {
+		require.NoError(t, connectWithToken("bob", "bob"))
+	})
+
+	// The issue #11289 scenario: a token minted for `alice` must not
+	// authenticate as `bob`, whose identity declares sub=bob.
+	t.Run("token not matching identity sub is rejected", func(t *testing.T) {
+		err := connectWithToken("bob", "alice")
+		require.Error(t, err, "a token whose sub is 'alice' must not authenticate 'bob' (identity sub=bob)")
+	})
+
+	// The identity's sub is the source of truth, not the username. `svc`'s
+	// identity declares sub=alice, so an alice token authenticates it and an
+	// svc token (which matches only the username) does not.
+	t.Run("identity sub is enforced against the token, not the username", func(t *testing.T) {
+		require.NoError(t, connectWithToken("svc", "alice"),
+			"svc's identity declares sub=alice, so an alice token must authenticate it")
+		require.Error(t, connectWithToken("svc", "svc"),
+			"a token whose sub is 'svc' must not authenticate 'svc' (identity sub=alice)")
+	})
+}
+
+// startJWTAuthServer starts a dolt sql-server configured with TLS,
+// require_secure_transport, and a single JWKS entry backed by the JWKS server
+// running on jwksPort. It returns the running server; the connecting DBName is
+// set to the repo's database.
+func startJWTAuthServer(t *testing.T, jwksPort int, issuer, audience string) *driver.SqlServer {
+	var ports DynamicResources
+	ports.global = &GlobalPorts
+	ports.t = t
+
+	serverPort := ports.GetOrAllocatePort("server")
+
+	gendir := os.Getenv("TESTGENDIR")
+	require.NotEmpty(t, gendir, "TESTGENDIR must be set by TestMain")
+	tlsKey := filepath.Join(gendir, "rsa_key.pem")
+	tlsCert := filepath.Join(gendir, "rsa_chain.pem")
+
+	config := fmt.Sprintf(`listener:
+  tls_key: %s
+  tls_cert: %s
+  require_secure_transport: true
+  port: %d
+jwks:
+- name: jwksname
+  location_url: http://127.0.0.1:%d/jwks.json
+  claims:
+    alg: RS256
+    aud: %s
+    iss: %s
+  fields_to_log: [sub]
+`, tlsKey, tlsCert, serverPort, jwksPort, audience, issuer)
+
+	u, err := driver.NewDoltUser()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		u.Cleanup()
+	})
+
+	rs, err := u.MakeRepoStore()
+	require.NoError(t, err)
+	repo, err := rs.MakeRepo("jwt_sub_validation")
+	require.NoError(t, err)
+
+	f, err := os.CreateTemp("", "jwt-sub-config-*.yaml")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.Remove(f.Name())
+	})
+	_, err = f.WriteString(config)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	srvSettings := &driver.Server{
+		Args:        []string{"--config", f.Name()},
+		DynamicPort: "server",
+	}
+
+	t.Log("Starting server with config:\n" + config)
+	server := MakeServer(t, repo, srvSettings, &ports)
+	require.NotNil(t, server)
+	server.DBName = "jwt_sub_validation"
+	return server
+}


### PR DESCRIPTION
A bug in JWT token authentication meant that an incoming token's Subject claim was not validated against the set of expected claims listed in the User record.

The end result is that a given, valid JWT token was not scoped to authenticating a single user account. Any valid JWT token bearing the correct signature, audience and issuer could be used to connect as any user account which was configured to accept that JWKS source, issuer and audenience field.

The fungible token behavior is too big of a footgun to leave in place as the default. To restore fungible token behavior, leave the `sub=` claim off the expected claims in the User Identity field.

This is a backward incompatible change. Existing workflows expecting fungible tokens to work may need to change token issuance or User record Identity fields to upgrade.