### PR TITLE
/go/libraries/doltcore/sqle/{dsess,enginetest}: add regression test and lazy load db

### DIFF
--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -1320,7 +1320,9 @@ func (d *DoltSession) addDB(ctx *sql.Context, db SqlDatabase) error {
 	// If this database isn't part of the transaction's start-point snapshot, it became visible to this session after the
 	// transaction began (e.g. another session created it concurrently, or it was cloned on first reference). Register it
 	// now with its current root so that TransactionRoot and friends can resolve it, instead of erroring out. See AddDb.
-	if usingDoltTransaction {
+	// We only do this for databases backed by a DoltDB, matching StartTransaction, which skips databases with a nil Ddb
+	// (e.g. UserSpaceDatabase, clusterDatabase) when taking its snapshot.
+	if usingDoltTransaction && db.DbData().Ddb != nil {
 		if _, ok := tx.GetInitialRoot(baseName); !ok {
 			if err := tx.AddDb(ctx, db); err != nil {
 				return err

--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -1317,6 +1317,17 @@ func (d *DoltSession) addDB(ctx *sql.Context, db SqlDatabase) error {
 
 	tx, usingDoltTransaction := d.GetTransaction().(*DoltTransaction)
 
+	// If this database isn't part of the transaction's start-point snapshot, it became visible to this session after the
+	// transaction began (e.g. another session created it concurrently, or it was cloned on first reference). Register it
+	// now with its current root so that TransactionRoot and friends can resolve it, instead of erroring out. See AddDb.
+	if usingDoltTransaction {
+		if _, ok := tx.GetInitialRoot(baseName); !ok {
+			if err := tx.AddDb(ctx, db); err != nil {
+				return err
+			}
+		}
+	}
+
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	sessionState, sessionStateExists := d.dbStates[baseName]

--- a/go/libraries/doltcore/sqle/dsess/transactions.go
+++ b/go/libraries/doltcore/sqle/dsess/transactions.go
@@ -127,16 +127,20 @@ func NewDoltTransaction(
 	}, nil
 }
 
-// AddDb adds the database named to the transaction. Only necessary in the case when new databases are added to an
-// existing transaction (as when cloning a database on a read replica when it is first referenced).
+// AddDb adds the database named to the transaction, establishing a start-point root for it. Necessary when a database
+// becomes visible to a session after its transaction has already begun: when cloning a database on a read replica as it
+// is first referenced, or when another session created the database concurrently after this transaction's snapshot was
+// taken. The key is normalized to the base (non-revision-qualified, lowercased) name to match NewDoltTransaction and
+// GetInitialRoot, since db.Name() returns the user-requested name, which may be revision-qualified or differently cased.
 func (tx DoltTransaction) AddDb(ctx *sql.Context, db SqlDatabase) error {
 	nomsRoot, err := db.DbData().Ddb.NomsRoot(ctx)
 	if err != nil {
 		return err
 	}
 
-	tx.dbStartPoints[strings.ToLower(db.Name())] = dbRoot{
-		dbName:   db.Name(),
+	baseName, _ := doltdb.SplitRevisionDbName(db.Name())
+	tx.dbStartPoints[strings.ToLower(baseName)] = dbRoot{
+		dbName:   baseName,
 		rootHash: nomsRoot,
 		db:       db.DbData().Ddb,
 	}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_transaction_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_transaction_queries.go
@@ -845,6 +845,49 @@ var DoltTransactionTests = []queries.TransactionTest{
 			},
 		},
 	},
+	{
+		// Regression test: a database created by one session after another session's transaction has already begun
+		// must still be usable in that already-open transaction. The transaction's start-point snapshot is taken when
+		// it begins and does not include the later-created database, so resolving it used to fail with
+		// "could not resolve initial root for database newdb". We now lazily register the database into the
+		// transaction on first reference (see DoltSession.addDB / DoltTransaction.AddDb). This reproduces the race hit
+		// when many databases are created concurrently and then queried concurrently across sessions.
+		Name:        "database created by another session is usable in an already-open transaction",
+		SetUpScript: []string{},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				// client a opens a transaction; its snapshot predates newdb's existence
+				Query:    "/* client a */ start transaction",
+				Expected: []sql.Row{},
+			},
+			{
+				// client b creates and populates newdb, registering it in the shared provider
+				Query:            "/* client b */ create database newdb",
+				SkipResultsCheck: true,
+			},
+			{
+				Query:            "/* client b */ use newdb",
+				SkipResultsCheck: true,
+			},
+			{
+				Query:    "/* client b */ create table t (x int primary key)",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    "/* client b */ insert into t values (1)",
+				Expected: []sql.Row{{types.NewOkResult(1)}},
+			},
+			{
+				// client a references newdb inside its already-open transaction; previously errored on initial root
+				Query:            "/* client a */ use newdb",
+				SkipResultsCheck: true,
+			},
+			{
+				Query:    "/* client a */ select * from t",
+				Expected: []sql.Row{{1}},
+			},
+		},
+	},
 }
 
 var DoltConflictHandlingTests = []queries.TransactionTest{


### PR DESCRIPTION
Creating databases and then querying them across multiple sessions intermittently fails with could not resolve initial root for database <db>/<branch>.

A DoltTransaction snapshots the noms root of every known database when it begins. If one session creates a database after another session's transaction has started, the second session can resolve that database from the shared provider, but its transaction has no start-point for it, so TransactionRoot errors. The only code that added late-appearing databases to a transaction was the read-replica clone path; nothing handled the concurrent-create case.
 
This PR makes it so that in DoltSession.addDB, if a database isn't in the transaction's snapshot, lazily register it (tx.AddDb) with its current root on first reference — same behavior the clone path already relies on. Also normalized AddDb's map key to the base name to match NewDoltTransaction/GetInitialRoot.