### PR TITLE
fix stats functions to include schema

### DIFF
--- a/go/libraries/doltcore/sqle/statspro/controller.go
+++ b/go/libraries/doltcore/sqle/statspro/controller.go
@@ -446,7 +446,7 @@ func (sc *StatsController) DropDbStats(ctx *sql.Context, dbName string, flush bo
 	}
 
 	var deleteKeys []tableIndexesKey
-	for k, _ := range sc.Stats.stats {
+	for k := range sc.Stats.stats {
 		if strings.EqualFold(dbName, k.db) {
 			deleteKeys = append(deleteKeys, k)
 		}

--- a/go/libraries/doltcore/sqle/statspro/controller.go
+++ b/go/libraries/doltcore/sqle/statspro/controller.go
@@ -427,7 +427,7 @@ func (sc *StatsController) DropStats(ctx *sql.Context, qual sql.StatQualifier, c
 	return nil
 }
 
-func (sc *StatsController) DropDbStats(ctx *sql.Context, dbName string, flush bool) error {
+func (sc *StatsController) DropDbStats(ctx *sql.Context, sch, dbName string, flush bool) error {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 

--- a/go/libraries/doltcore/sqle/statspro/controller.go
+++ b/go/libraries/doltcore/sqle/statspro/controller.go
@@ -55,13 +55,9 @@ type tableIndexesKey struct {
 	db     string
 	branch string
 	table  string
-	schema string
 }
 
 func (k tableIndexesKey) String() string {
-	if k.table != "" {
-		return k.schema + "/" + k.db + "/" + k.branch + "/" + k.table
-	}
 	return k.db + "/" + k.branch + "/" + k.table
 }
 
@@ -405,7 +401,6 @@ func (sc *StatsController) GetTableDoltStats(ctx *sql.Context, branch, db, schem
 		db:     strings.ToLower(db),
 		branch: strings.ToLower(branch),
 		table:  strings.ToLower(table),
-		schema: strings.ToLower(schema),
 	}
 	sc.mu.Lock()
 	defer sc.mu.Unlock()

--- a/go/libraries/doltcore/sqle/statspro/controller.go
+++ b/go/libraries/doltcore/sqle/statspro/controller.go
@@ -55,9 +55,13 @@ type tableIndexesKey struct {
 	db     string
 	branch string
 	table  string
+	schema string
 }
 
 func (k tableIndexesKey) String() string {
+	if k.table != "" {
+		return k.schema + "/" + k.db + "/" + k.branch + "/" + k.table
+	}
 	return k.db + "/" + k.branch + "/" + k.table
 }
 
@@ -290,8 +294,8 @@ func (sc *StatsController) descError(d string, err error) {
 	sc.logger.Debug(b.String())
 }
 
-func (sc *StatsController) GetTableStats(ctx *sql.Context, db string, table sql.Table) ([]sql.Statistic, error) {
-	key, err := sc.statsKey(ctx, db, table.Name())
+func (sc *StatsController) GetTableStats(ctx *sql.Context, sch, db string, table sql.Table) ([]sql.Statistic, error) {
+	key, err := sc.statsKey(ctx, sch, db, table.Name())
 	if err != nil {
 		return nil, err
 	}
@@ -364,7 +368,8 @@ func (sc *StatsController) SetStats(ctx *sql.Context, s sql.Statistic) error {
 	if !ok {
 		return fmt.Errorf("expected *stats.Statistics, found %T", s)
 	}
-	key, err := sc.statsKey(ctx, ss.Qualifier().Db(), ss.Qualifier().Table())
+	qual := ss.Qualifier()
+	key, err := sc.statsKey(ctx, qual.Schema(), qual.Db(), qual.Table())
 	if err != nil {
 		return err
 	}
@@ -384,7 +389,7 @@ func (sc *StatsController) SetStats(ctx *sql.Context, s sql.Statistic) error {
 func (sc *StatsController) GetStats(ctx *sql.Context, qual sql.StatQualifier, cols []string) (sql.Statistic, bool) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
-	key, err := sc.statsKey(ctx, qual.Database, qual.Table())
+	key, err := sc.statsKey(ctx, qual.Schema(), qual.Db(), qual.Table())
 	if err != nil {
 		return nil, false
 	}
@@ -401,6 +406,7 @@ func (sc *StatsController) GetTableDoltStats(ctx *sql.Context, branch, db, schem
 		db:     strings.ToLower(db),
 		branch: strings.ToLower(branch),
 		table:  strings.ToLower(table),
+		schema: strings.ToLower(schema),
 	}
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
@@ -411,7 +417,7 @@ func (sc *StatsController) GetTableDoltStats(ctx *sql.Context, branch, db, schem
 }
 
 func (sc *StatsController) DropStats(ctx *sql.Context, qual sql.StatQualifier, cols []string) error {
-	key, err := sc.statsKey(ctx, qual.Database, qual.Table())
+	key, err := sc.statsKey(ctx, qual.Schema(), qual.Db(), qual.Table())
 	if err != nil {
 		return err
 	}
@@ -451,7 +457,7 @@ func (sc *StatsController) DropDbStats(ctx *sql.Context, dbName string, flush bo
 	return nil
 }
 
-func (sc *StatsController) statsKey(ctx *sql.Context, dbName, table string) (tableIndexesKey, error) {
+func (sc *StatsController) statsKey(ctx *sql.Context, schema, dbName, table string) (tableIndexesKey, error) {
 	dSess := dsess.DSessFromSess(ctx.Session)
 	branch, err := dSess.GetBranch(ctx)
 	if err != nil {
@@ -461,12 +467,13 @@ func (sc *StatsController) statsKey(ctx *sql.Context, dbName, table string) (tab
 		db:     strings.ToLower(dbName),
 		branch: strings.ToLower(branch),
 		table:  strings.ToLower(table),
+		schema: strings.ToLower(schema),
 	}
 	return key, nil
 }
 
-func (sc *StatsController) RowCount(ctx *sql.Context, dbName string, table sql.Table) (uint64, error) {
-	key, err := sc.statsKey(ctx, dbName, table.Name())
+func (sc *StatsController) RowCount(ctx *sql.Context, schema, dbName string, table sql.Table) (uint64, error) {
+	key, err := sc.statsKey(ctx, schema, dbName, table.Name())
 	if err != nil {
 		return 0, err
 	}
@@ -480,8 +487,8 @@ func (sc *StatsController) RowCount(ctx *sql.Context, dbName string, table sql.T
 	return 0, nil
 }
 
-func (sc *StatsController) DataLength(ctx *sql.Context, dbName string, table sql.Table) (uint64, error) {
-	key, err := sc.statsKey(ctx, dbName, table.Name())
+func (sc *StatsController) DataLength(ctx *sql.Context, schema, dbName string, table sql.Table) (uint64, error) {
+	key, err := sc.statsKey(ctx, schema, dbName, table.Name())
 	if err != nil {
 		return 0, err
 	}

--- a/go/libraries/doltcore/sqle/statspro/initdbhook.go
+++ b/go/libraries/doltcore/sqle/statspro/initdbhook.go
@@ -50,7 +50,7 @@ func NewInitDatabaseHook(sc *StatsController) sqle.InitDatabaseHook {
 
 func NewDropDatabaseHook(sc *StatsController) sqle.DropDatabaseHook {
 	return func(ctx *sql.Context, name string) {
-		if err := sc.DropDbStats(ctx, name, false); err != nil {
+		if err := sc.DropDbStats(ctx, "", name, false); err != nil {
 			ctx.GetLogger().Debugf("failed to close stats database: %s", err)
 		}
 	}

--- a/go/libraries/doltcore/sqle/statspro/noop_controller.go
+++ b/go/libraries/doltcore/sqle/statspro/noop_controller.go
@@ -23,7 +23,7 @@ import (
 
 type StatsNoop struct{}
 
-func (s StatsNoop) GetTableStats(ctx *sql.Context, db string, table sql.Table) ([]sql.Statistic, error) {
+func (s StatsNoop) GetTableStats(ctx *sql.Context, sch, db string, table sql.Table) ([]sql.Statistic, error) {
 	return nil, nil
 }
 
@@ -43,15 +43,15 @@ func (s StatsNoop) DropStats(ctx *sql.Context, qual sql.StatQualifier, cols []st
 	return nil
 }
 
-func (s StatsNoop) DropDbStats(ctx *sql.Context, db string, flush bool) error {
+func (s StatsNoop) DropDbStats(ctx *sql.Context, sch, db string, flush bool) error {
 	return nil
 }
 
-func (s StatsNoop) RowCount(ctx *sql.Context, db string, table sql.Table) (uint64, error) {
+func (s StatsNoop) RowCount(ctx *sql.Context, sch, db string, table sql.Table) (uint64, error) {
 	return 0, nil
 }
 
-func (s StatsNoop) DataLength(ctx *sql.Context, db string, table sql.Table) (uint64, error) {
+func (s StatsNoop) DataLength(ctx *sql.Context, sch, db string, table sql.Table) (uint64, error) {
 	return 0, nil
 }
 

--- a/go/libraries/doltcore/sqle/statspro/noop_controller.go
+++ b/go/libraries/doltcore/sqle/statspro/noop_controller.go
@@ -43,7 +43,7 @@ func (s StatsNoop) DropStats(ctx *sql.Context, qual sql.StatQualifier, cols []st
 	return nil
 }
 
-func (s StatsNoop) DropDbStats(ctx *sql.Context, sch, db string, flush bool) error {
+func (s StatsNoop) DropDbStats(ctx *sql.Context, db string, flush bool) error {
 	return nil
 }
 

--- a/go/libraries/doltcore/sqle/statspro/noop_controller.go
+++ b/go/libraries/doltcore/sqle/statspro/noop_controller.go
@@ -43,7 +43,7 @@ func (s StatsNoop) DropStats(ctx *sql.Context, qual sql.StatQualifier, cols []st
 	return nil
 }
 
-func (s StatsNoop) DropDbStats(ctx *sql.Context, db string, flush bool) error {
+func (s StatsNoop) DropDbStats(ctx *sql.Context, sch, db string, flush bool) error {
 	return nil
 }
 

--- a/go/libraries/doltcore/sqle/statspro/worker.go
+++ b/go/libraries/doltcore/sqle/statspro/worker.go
@@ -469,10 +469,13 @@ func (sc *StatsController) updateTable(ctx *sql.Context, newStats *rootStats, ta
 		return err
 	}
 
+	schemaName := sqlTable.DatabaseSchema().SchemaName()
+
 	tableKey := tableIndexesKey{
 		db:     strings.ToLower(sqlDb.AliasedName()),
 		branch: strings.ToLower(sqlDb.Revision()),
 		table:  strings.ToLower(tableName),
+		schema: strings.ToLower(schemaName),
 	}
 
 	tableHash, err := dTab.HashOf()

--- a/go/libraries/doltcore/sqle/statspro/worker.go
+++ b/go/libraries/doltcore/sqle/statspro/worker.go
@@ -469,13 +469,10 @@ func (sc *StatsController) updateTable(ctx *sql.Context, newStats *rootStats, ta
 		return err
 	}
 
-	schemaName := sqlTable.DatabaseSchema().SchemaName()
-
 	tableKey := tableIndexesKey{
 		db:     strings.ToLower(sqlDb.AliasedName()),
 		branch: strings.ToLower(sqlDb.Revision()),
 		table:  strings.ToLower(tableName),
-		schema: strings.ToLower(schemaName),
 	}
 
 	tableHash, err := dTab.HashOf()

--- a/go/libraries/doltcore/sqle/statspro/worker.go
+++ b/go/libraries/doltcore/sqle/statspro/worker.go
@@ -535,6 +535,7 @@ func (sc *StatsController) updateTable(ctx *sql.Context, newStats *rootStats, ta
 		}
 
 		template.Qual.Database = sqlDb.AliasedName()
+		template.Qual.Sch = sqlDb.SchemaName()
 
 		idxLen := len(sqlIdx.Expressions())
 


### PR DESCRIPTION
We lookup stats with empty string for schema. Since this is not always the case, we sometimes miss stats.