### PR TITLE
Fix `BIT` value display in `dolt sql` and `dolt diff -r sql`

### DIFF
--- a/go/cmd/dolt/commands/engine/sql_print.go
+++ b/go/cmd/dolt/commands/engine/sql_print.go
@@ -243,7 +243,7 @@ func (iter *binaryHexIterator) Next(ctx *sql.Context) (sql.Row, error) {
 				switch v := val.(type) {
 				case string: // sql-server sends bit values as bytes sized to the declared bit width
 					rowData[i] = sqlutil.BinaryAsHexDisplayValue(fmt.Sprintf("0x%X", []byte(v)))
-				default: // local engine values are integers, Type.SQL produces width-sized bytes
+				default: // local engine values are integers, so Type.SQL encodes them to width-sized bytes
 					sqlVal, err := iter.schema[i].Type.SQL(ctx, nil, val)
 					if err != nil {
 						return nil, fmt.Errorf("unexpected value %v for bit column %s: %w", val, iter.schema[i].Name, err)

--- a/go/cmd/dolt/commands/engine/sql_print.go
+++ b/go/cmd/dolt/commands/engine/sql_print.go
@@ -226,7 +226,7 @@ func (iter *binaryHexIterator) Next(ctx *sql.Context) (sql.Row, error) {
 		return nil, err
 	}
 
-	// TODO: Add support for BLOB types (TINYBLOB, BLOB, MEDIUMBLOB, LONGBLOB) and BIT type
+	// TODO: Add support for BLOB types (TINYBLOB, BLOB, MEDIUMBLOB, LONGBLOB)
 	for i, val := range rowData {
 		if val != nil && i < len(iter.schema) {
 			switch iter.schema[i].Type.Type() {
@@ -238,6 +238,21 @@ func (iter *binaryHexIterator) Next(ctx *sql.Context) (sql.Row, error) {
 					rowData[i] = sqlutil.BinaryAsHexDisplayValue(fmt.Sprintf("0x%X", []byte(v)))
 				default:
 					return nil, fmt.Errorf("unexpected type %T for binary column %s", val, iter.schema[i].Name)
+				}
+			case sqltypes.Bit:
+				switch v := val.(type) {
+				case string:
+					// A sql-server sends bit values as bytes already sized
+					// to the declared bit width.
+					rowData[i] = sqlutil.BinaryAsHexDisplayValue(fmt.Sprintf("0x%X", []byte(v)))
+				default:
+					// Local engine values are integers, so Type.SQL is needed
+					// to produce bytes sized to the declared bit width.
+					sqlVal, err := iter.schema[i].Type.SQL(ctx, nil, val)
+					if err != nil {
+						return nil, fmt.Errorf("unexpected value %v for bit column %s: %w", val, iter.schema[i].Name, err)
+					}
+					rowData[i] = sqlutil.BinaryAsHexDisplayValue(fmt.Sprintf("0x%X", sqlVal.Raw()))
 				}
 			}
 		}

--- a/go/cmd/dolt/commands/engine/sql_print.go
+++ b/go/cmd/dolt/commands/engine/sql_print.go
@@ -241,13 +241,9 @@ func (iter *binaryHexIterator) Next(ctx *sql.Context) (sql.Row, error) {
 				}
 			case sqltypes.Bit:
 				switch v := val.(type) {
-				case string:
-					// A sql-server sends bit values as bytes already sized
-					// to the declared bit width.
+				case string: // sql-server sends bit values as bytes sized to the declared bit width
 					rowData[i] = sqlutil.BinaryAsHexDisplayValue(fmt.Sprintf("0x%X", []byte(v)))
-				default:
-					// Local engine values are integers, so Type.SQL is needed
-					// to produce bytes sized to the declared bit width.
+				default: // local engine values are integers, Type.SQL produces width-sized bytes
 					sqlVal, err := iter.schema[i].Type.SQL(ctx, nil, val)
 					if err != nil {
 						return nil, fmt.Errorf("unexpected value %v for bit column %s: %w", val, iter.schema[i].Name, err)

--- a/go/cmd/dolt/commands/engine/sql_print.go
+++ b/go/cmd/dolt/commands/engine/sql_print.go
@@ -232,24 +232,19 @@ func (iter *binaryHexIterator) Next(ctx *sql.Context) (sql.Row, error) {
 			switch iter.schema[i].Type.Type() {
 			case sqltypes.Binary, sqltypes.VarBinary:
 				switch v := val.(type) {
-				case []byte: // hex fmt is explicitly upper case
-					rowData[i] = sqlutil.BinaryAsHexDisplayValue(fmt.Sprintf("0x%X", v))
+				case []byte:
+					rowData[i] = sqlutil.NewBinaryAsHexDisplayValue(v)
 				case string: // handles results from sql-server; MySQL wire protocol returns strings
-					rowData[i] = sqlutil.BinaryAsHexDisplayValue(fmt.Sprintf("0x%X", []byte(v)))
+					rowData[i] = sqlutil.NewBinaryAsHexDisplayValue([]byte(v))
 				default:
 					return nil, fmt.Errorf("unexpected type %T for binary column %s", val, iter.schema[i].Name)
 				}
 			case sqltypes.Bit:
-				switch v := val.(type) {
-				case string: // sql-server sends bit values as bytes sized to the declared bit width
-					rowData[i] = sqlutil.BinaryAsHexDisplayValue(fmt.Sprintf("0x%X", []byte(v)))
-				default: // local engine values are integers, so Type.SQL encodes them to width-sized bytes
-					sqlVal, err := iter.schema[i].Type.SQL(ctx, nil, val)
-					if err != nil {
-						return nil, fmt.Errorf("unexpected value %v for bit column %s: %w", val, iter.schema[i].Name, err)
-					}
-					rowData[i] = sqlutil.BinaryAsHexDisplayValue(fmt.Sprintf("0x%X", sqlVal.Raw()))
+				bits, err := sqlutil.BitValueBytes(ctx, iter.schema[i].Type, val)
+				if err != nil {
+					return nil, fmt.Errorf("unexpected value %v for bit column %s: %w", val, iter.schema[i].Name, err)
 				}
+				rowData[i] = sqlutil.NewBinaryAsHexDisplayValue(bits)
 			}
 		}
 	}

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -229,6 +229,13 @@ func (cmd SqlCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 	if binaryAsHex && apr.Contains(skipBinaryAsHexFlag) { // We stray from MYSQL here to make usage clear for users
 		return HandleVErrAndExitCode(errhand.BuildDError("cannot use both --%s and --%s", binaryAsHexFlag, skipBinaryAsHexFlag).Build(), usage)
 	}
+	// Like the mysql client, default to hex display when connected to a terminal.
+	// Only terminal display formats get the default, data export formats need the
+	// explicit flag.
+	if !binaryAsHex && !apr.Contains(skipBinaryAsHexFlag) &&
+		(format == engine.FormatTabular || format == engine.FormatVertical) {
+		binaryAsHex = checkIsTerminal()
+	}
 
 	enableAutoGC := true
 	if apr.Contains(disableAutoGCFlag) {

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -230,8 +230,7 @@ func (cmd SqlCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 		return HandleVErrAndExitCode(errhand.BuildDError("cannot use both --%s and --%s", binaryAsHexFlag, skipBinaryAsHexFlag).Build(), usage)
 	}
 	// Like the mysql client, default to hex display when connected to a terminal.
-	// Only terminal display formats get the default, data export formats need the
-	// explicit flag.
+	// Data export formats need the explicit flag.
 	if !binaryAsHex && !apr.Contains(skipBinaryAsHexFlag) &&
 		(format == engine.FormatTabular || format == engine.FormatVertical) {
 		binaryAsHex = checkIsTerminal()

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -224,7 +224,7 @@ func (cmd SqlCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 		return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 	}
 
-	// Determine binary-as-hex behavior from flags (default false for non-interactive modes)
+	// Determine binary-as-hex behavior from flags
 	binaryAsHex := apr.Contains(binaryAsHexFlag)
 	if binaryAsHex && apr.Contains(skipBinaryAsHexFlag) { // We stray from MYSQL here to make usage clear for users
 		return HandleVErrAndExitCode(errhand.BuildDError("cannot use both --%s and --%s", binaryAsHexFlag, skipBinaryAsHexFlag).Build(), usage)

--- a/go/go.mod
+++ b/go/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/dolthub/dolt-mcp v0.3.4
 	github.com/dolthub/eventsapi_schema v0.0.0-20260715220557-d9b4a1c6b4d4
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-mysql-server v0.20.1-0.20260722221430-72b291a45818
+	github.com/dolthub/go-mysql-server v0.20.1-0.20260727211809-90e50efe0153
 	github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63
 	github.com/edsrzf/mmap-go v1.2.0
 	github.com/esote/minmaxheap v1.0.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -216,6 +216,8 @@ github.com/dolthub/go-icu-regex v0.0.0-20260610153742-72563bc7ca83 h1:FEMjCGEroD
 github.com/dolthub/go-icu-regex v0.0.0-20260610153742-72563bc7ca83/go.mod h1:F3cnm+vMRK1HaU6+rNqQrOCyR03HHhR1GWG2gnPOqaE=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260722221430-72b291a45818 h1:SBMmRLC0PM2ZCha4mNlChMD9XXcLokn/iz7gE0989S8=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260722221430-72b291a45818/go.mod h1:AnD2jKQZCf09sM2JhV/cTEtsoEhPNg6pVWjRCBox4Zw=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260727211809-90e50efe0153 h1:dwvlMB3y8yBJf2oWC5zbWt/n9ZoJOIJQ3c3ekDdGxi0=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260727211809-90e50efe0153/go.mod h1:AnD2jKQZCf09sM2JhV/cTEtsoEhPNg6pVWjRCBox4Zw=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20260414231531-5f031e3e9037 h1:oIW9HwuWrhxv+4HZxA+QQSKHLqWFyXZ2FmNjUYwkdiM=

--- a/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
@@ -348,7 +348,7 @@ func interfaceValueAsSqlString(ctx *sql.Context, ti typeinfo.TypeInfo, value int
 	case querypb.Type_TIME, querypb.Type_YEAR, querypb.Type_DATETIME, querypb.Type_TIMESTAMP, querypb.Type_DATE:
 		return singleQuote + str + singleQuote, nil
 	case querypb.Type_BIT:
-		// str holds the value's raw bytes, written as hex so the statement parses back
+		// str contains the value's raw bytes rather than a decimal string
 		return hexEncodeBytes([]byte(str)), nil
 	case querypb.Type_BINARY, querypb.Type_VARBINARY, querypb.Type_VECTOR:
 		value, err := sql.UnwrapAny(ctx, value)

--- a/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
@@ -347,6 +347,9 @@ func interfaceValueAsSqlString(ctx *sql.Context, ti typeinfo.TypeInfo, value int
 		}
 	case querypb.Type_TIME, querypb.Type_YEAR, querypb.Type_DATETIME, querypb.Type_TIMESTAMP, querypb.Type_DATE:
 		return singleQuote + str + singleQuote, nil
+	case querypb.Type_BIT:
+		// str holds the value's raw bytes, written as hex so the statement parses back
+		return hexEncodeBytes([]byte(str)), nil
 	case querypb.Type_BINARY, querypb.Type_VARBINARY, querypb.Type_VECTOR:
 		value, err := sql.UnwrapAny(ctx, value)
 		if err != nil {

--- a/go/libraries/doltcore/sqle/sqlfmt/row_fmt_test.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/row_fmt_test.go
@@ -18,8 +18,12 @@ import (
 	"testing"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	gmstypes "github.com/dolthub/go-mysql-server/sql/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
 	_ "github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlfmt"
 )
@@ -30,6 +34,31 @@ const expectedAddColSql = "ALTER TABLE `table_name` ADD `c0` BIGINT NOT NULL;"
 const expectedDropColSql = "ALTER TABLE `table_name` DROP `first_name`;"
 const expectedRenameColSql = "ALTER TABLE `table_name` RENAME COLUMN `id` TO `pk`;"
 const expectedRenameTableSql = "RENAME TABLE `table_name` TO `new_table_name`;"
+
+func TestSqlRowAsInsertStmtBit(t *testing.T) {
+	// See https://github.com/dolthub/dolt/issues/10132
+	bit3, err := typeinfo.FromSqlType(gmstypes.MustCreateBitType(3))
+	require.NoError(t, err)
+	bit64, err := typeinfo.FromSqlType(gmstypes.MustCreateBitType(64))
+	require.NoError(t, err)
+	idCol, err := schema.NewColumnWithTypeInfo("id", 0, typeinfo.Int32Type, true, "", false, "")
+	require.NoError(t, err)
+	b3Col, err := schema.NewColumnWithTypeInfo("b3", 1, bit3, false, "", false, "")
+	require.NoError(t, err)
+	b64Col, err := schema.NewColumnWithTypeInfo("b64", 2, bit64, false, "", false, "")
+	require.NoError(t, err)
+	sch, err := schema.SchemaFromCols(schema.NewColCollection(idCol, b3Col, b64Col))
+	require.NoError(t, err)
+
+	ctx := sql.NewEmptyContext()
+	stmt, err := sqlfmt.SqlRowAsInsertStmt(ctx, sql.Row{int32(0), uint64(0), nil}, "t", sch)
+	require.NoError(t, err)
+	assert.Equal(t, "INSERT INTO `t` (`id`,`b3`,`b64`) VALUES (0,0x00,NULL);", stmt)
+
+	stmt, err = sqlfmt.SqlRowAsInsertStmt(ctx, sql.Row{int32(1), uint64(2), uint64(18446744073709551615)}, "t", sch)
+	require.NoError(t, err)
+	assert.Equal(t, "INSERT INTO `t` (`id`,`b3`,`b64`) VALUES (1,0x02,0xffffffffffffffff);", stmt)
+}
 
 func TestTableDropStmt(t *testing.T) {
 	stmt := sqlfmt.DropTableStmt(sql.DefaultMySQLSchemaFormatter, "table_name")

--- a/go/libraries/doltcore/sqle/sqlfmt/row_fmt_test.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/row_fmt_test.go
@@ -35,31 +35,6 @@ const expectedDropColSql = "ALTER TABLE `table_name` DROP `first_name`;"
 const expectedRenameColSql = "ALTER TABLE `table_name` RENAME COLUMN `id` TO `pk`;"
 const expectedRenameTableSql = "RENAME TABLE `table_name` TO `new_table_name`;"
 
-func TestSqlRowAsInsertStmtBit(t *testing.T) {
-	// See https://github.com/dolthub/dolt/issues/10132
-	bit3, err := typeinfo.FromSqlType(gmstypes.MustCreateBitType(3))
-	require.NoError(t, err)
-	bit64, err := typeinfo.FromSqlType(gmstypes.MustCreateBitType(64))
-	require.NoError(t, err)
-	idCol, err := schema.NewColumnWithTypeInfo("id", 0, typeinfo.Int32Type, true, "", false, "")
-	require.NoError(t, err)
-	b3Col, err := schema.NewColumnWithTypeInfo("b3", 1, bit3, false, "", false, "")
-	require.NoError(t, err)
-	b64Col, err := schema.NewColumnWithTypeInfo("b64", 2, bit64, false, "", false, "")
-	require.NoError(t, err)
-	sch, err := schema.SchemaFromCols(schema.NewColCollection(idCol, b3Col, b64Col))
-	require.NoError(t, err)
-
-	ctx := sql.NewEmptyContext()
-	stmt, err := sqlfmt.SqlRowAsInsertStmt(ctx, sql.Row{int32(0), uint64(0), nil}, "t", sch)
-	require.NoError(t, err)
-	assert.Equal(t, "INSERT INTO `t` (`id`,`b3`,`b64`) VALUES (0,0x00,NULL);", stmt)
-
-	stmt, err = sqlfmt.SqlRowAsInsertStmt(ctx, sql.Row{int32(1), uint64(2), uint64(18446744073709551615)}, "t", sch)
-	require.NoError(t, err)
-	assert.Equal(t, "INSERT INTO `t` (`id`,`b3`,`b64`) VALUES (1,0x02,0xffffffffffffffff);", stmt)
-}
-
 func TestTableDropStmt(t *testing.T) {
 	stmt := sqlfmt.DropTableStmt(sql.DefaultMySQLSchemaFormatter, "table_name")
 
@@ -95,4 +70,29 @@ func TestRenameTableStmt(t *testing.T) {
 	stmt := sqlfmt.RenameTableStmt(sql.DefaultMySQLSchemaFormatter, "table_name", "new_table_name")
 
 	assert.Equal(t, expectedRenameTableSql, stmt)
+}
+
+func TestSqlRowAsInsertStmtBit(t *testing.T) {
+	// See https://github.com/dolthub/dolt/issues/10132
+	bit3, err := typeinfo.FromSqlType(gmstypes.MustCreateBitType(3))
+	require.NoError(t, err)
+	bit64, err := typeinfo.FromSqlType(gmstypes.MustCreateBitType(64))
+	require.NoError(t, err)
+	idCol, err := schema.NewColumnWithTypeInfo("id", 0, typeinfo.Int32Type, true, "", false, "")
+	require.NoError(t, err)
+	b3Col, err := schema.NewColumnWithTypeInfo("b3", 1, bit3, false, "", false, "")
+	require.NoError(t, err)
+	b64Col, err := schema.NewColumnWithTypeInfo("b64", 2, bit64, false, "", false, "")
+	require.NoError(t, err)
+	sch, err := schema.SchemaFromCols(schema.NewColCollection(idCol, b3Col, b64Col))
+	require.NoError(t, err)
+
+	ctx := sql.NewEmptyContext()
+	stmt, err := sqlfmt.SqlRowAsInsertStmt(ctx, sql.Row{int32(0), uint64(0), nil}, "t", sch)
+	require.NoError(t, err)
+	assert.Equal(t, "INSERT INTO `t` (`id`,`b3`,`b64`) VALUES (0,0x00,NULL);", stmt)
+
+	stmt, err = sqlfmt.SqlRowAsInsertStmt(ctx, sql.Row{int32(1), uint64(2), uint64(18446744073709551615)}, "t", sch)
+	require.NoError(t, err)
+	assert.Equal(t, "INSERT INTO `t` (`id`,`b3`,`b64`) VALUES (1,0x02,0xffffffffffffffff);", stmt)
 }

--- a/go/libraries/doltcore/sqle/sqlutil/sql_row.go
+++ b/go/libraries/doltcore/sqle/sqlutil/sql_row.go
@@ -66,8 +66,7 @@ func SqlColToStr(ctx *sql.Context, sqlType sql.Type, col interface{}) (string, e
 // DatabaseTypeNameToSqlType converts a MySQL wire protocol database type name
 // to a go-mysql-server sql.Type. This uses the same type mapping logic as the existing
 // Dolt type system for consistency.
-// TODO: Add support for BLOB types (TINYBLOB, BLOB, MEDIUMBLOB, LONGBLOB) and BIT type
-// as confirmed by testing MySQL 8.4+ binary-as-hex behavior
+// TODO: Add support for BLOB types (TINYBLOB, BLOB, MEDIUMBLOB, LONGBLOB)
 func DatabaseTypeNameToSqlType(databaseTypeName string) sql.Type {
 	typeName := strings.ToLower(databaseTypeName)
 	switch typeName {
@@ -75,6 +74,12 @@ func DatabaseTypeNameToSqlType(databaseTypeName string) sql.Type {
 		return gmstypes.MustCreateBinary(sqltypes.Binary, 255)
 	case "varbinary":
 		return gmstypes.MustCreateBinary(sqltypes.VarBinary, 255)
+	case "bit":
+		// The driver does not report the declared bit width, so use the widest
+		// BIT type. Display paths size their output from the value bytes instead.
+		// TODO(elianddb): Use the declared width if the driver exposes column
+		// lengths. See https://pkg.go.dev/database/sql#ColumnType.Length.
+		return gmstypes.MustCreateBitType(gmstypes.BitTypeMaxBits)
 	default:
 		// Default to LongText for all other types (as was done before)
 		return gmstypes.LongText

--- a/go/libraries/doltcore/sqle/sqlutil/sql_row.go
+++ b/go/libraries/doltcore/sqle/sqlutil/sql_row.go
@@ -37,6 +37,12 @@ func SqlColToStr(ctx *sql.Context, sqlType sql.Type, col interface{}) (string, e
 			return string(hexVal), nil
 		}
 
+		// BIT values arrive from sql-server as bytes already sized to the
+		// declared bit width, so pass them through instead of re-encoding.
+		if s, ok := col.(string); ok && gmstypes.IsBit(sqlType) {
+			return s, nil
+		}
+
 		switch typedCol := col.(type) {
 		case bool:
 			if typedCol {

--- a/go/libraries/doltcore/sqle/sqlutil/sql_row.go
+++ b/go/libraries/doltcore/sqle/sqlutil/sql_row.go
@@ -29,6 +29,26 @@ import (
 // BinaryAsHexDisplayValue is a wrapper for binary values that should be displayed as hex strings.
 type BinaryAsHexDisplayValue string
 
+// NewBinaryAsHexDisplayValue formats the given bytes as a hex literal such as
+// 0x1F. The mysql client prints the digits in upper case, so we match it.
+func NewBinaryAsHexDisplayValue(b []byte) BinaryAsHexDisplayValue {
+	return BinaryAsHexDisplayValue(fmt.Sprintf("0x%X", b))
+}
+
+// BitValueBytes returns a BIT value as the bytes that carry its declared width.
+// A sql-server connection sends those bytes as a string, while the local engine
+// sends a number that the column type encodes to the same width.
+func BitValueBytes(ctx *sql.Context, bitType sql.Type, val interface{}) ([]byte, error) {
+	if s, ok := val.(string); ok {
+		return []byte(s), nil
+	}
+	res, err := bitType.SQL(ctx, nil, val)
+	if err != nil {
+		return nil, err
+	}
+	return res.Raw(), nil
+}
+
 // SqlColToStr is a utility function for converting a sql column of type interface{} to a string.
 // NULL values are treated as empty strings. Handle nil separately if you require other behavior.
 func SqlColToStr(ctx *sql.Context, sqlType sql.Type, col interface{}) (string, error) {
@@ -37,10 +57,12 @@ func SqlColToStr(ctx *sql.Context, sqlType sql.Type, col interface{}) (string, e
 			return string(hexVal), nil
 		}
 
-		// BIT values arrive from sql-server as bytes already sized to the
-		// declared bit width, so pass them through instead of re-encoding.
-		if s, ok := col.(string); ok && gmstypes.IsBit(sqlType) {
-			return s, nil
+		if gmstypes.IsBit(sqlType) {
+			b, err := BitValueBytes(ctx, sqlType, col)
+			if err != nil {
+				return "", err
+			}
+			return string(b), nil
 		}
 
 		switch typedCol := col.(type) {
@@ -52,11 +74,10 @@ func SqlColToStr(ctx *sql.Context, sqlType sql.Type, col interface{}) (string, e
 			}
 		case sql.SpatialColumnType:
 			res, err := sqlType.SQL(ctx, nil, col)
-			hexRes := fmt.Sprintf("0x%X", res.Raw())
 			if err != nil {
 				return "", err
 			}
-			return hexRes, nil
+			return string(NewBinaryAsHexDisplayValue(res.Raw())), nil
 		default:
 			res, err := sqlType.SQL(ctx, nil, col)
 			if err != nil {

--- a/go/libraries/doltcore/table/untyped/csv/writer.go
+++ b/go/libraries/doltcore/table/untyped/csv/writer.go
@@ -128,7 +128,6 @@ func (csvw *CSVWriter) WriteSqlRow(ctx *sql.Context, r sql.Row) error {
 func toCsvString(ctx *sql.Context, colType sql.Type, val interface{}) (string, error) {
 	// For BIT, emit base-10 int, instead of bytes
 	if _, ok := colType.(types.BitType); ok {
-		// Hex display values are already formatted strings
 		if hexVal, ok := val.(sqlutil.BinaryAsHexDisplayValue); ok {
 			return string(hexVal), nil
 		}

--- a/go/libraries/doltcore/table/untyped/csv/writer.go
+++ b/go/libraries/doltcore/table/untyped/csv/writer.go
@@ -126,17 +126,18 @@ func (csvw *CSVWriter) WriteSqlRow(ctx *sql.Context, r sql.Row) error {
 }
 
 func toCsvString(ctx *sql.Context, colType sql.Type, val interface{}) (string, error) {
-	// For BIT, emit base-10 int, instead of bytes. Hex display values are
-	// already formatted strings, which SqlColToStr passes through.
+	// For BIT, emit base-10 int, instead of bytes
 	if _, ok := colType.(types.BitType); ok {
-		if _, isHex := val.(sqlutil.BinaryAsHexDisplayValue); !isHex {
-			// Normalize to handle UNION type generalization (e.g., int64 -> uint64)
-			norm, _, err := colType.Convert(ctx, val)
-			if err != nil {
-				return "", err
-			}
-			return strconv.FormatUint(norm.(uint64), 10), nil
+		// Hex display values are already formatted strings
+		if hexVal, ok := val.(sqlutil.BinaryAsHexDisplayValue); ok {
+			return string(hexVal), nil
 		}
+		// Normalize to handle UNION type generalization (e.g., int64 -> uint64)
+		norm, _, err := colType.Convert(ctx, val)
+		if err != nil {
+			return "", err
+		}
+		return strconv.FormatUint(norm.(uint64), 10), nil
 	}
 
 	return sqlutil.SqlColToStr(ctx, colType, val)

--- a/go/libraries/doltcore/table/untyped/csv/writer.go
+++ b/go/libraries/doltcore/table/untyped/csv/writer.go
@@ -126,14 +126,17 @@ func (csvw *CSVWriter) WriteSqlRow(ctx *sql.Context, r sql.Row) error {
 }
 
 func toCsvString(ctx *sql.Context, colType sql.Type, val interface{}) (string, error) {
-	// For BIT, emit base-10 int, instead of bytes
+	// For BIT, emit base-10 int, instead of bytes. Hex display values are
+	// already formatted strings, which SqlColToStr passes through.
 	if _, ok := colType.(types.BitType); ok {
-		// Normalize to handle UNION type generalization (e.g., int64 -> uint64)
-		norm, _, err := colType.Convert(ctx, val)
-		if err != nil {
-			return "", err
+		if _, isHex := val.(sqlutil.BinaryAsHexDisplayValue); !isHex {
+			// Normalize to handle UNION type generalization (e.g., int64 -> uint64)
+			norm, _, err := colType.Convert(ctx, val)
+			if err != nil {
+				return "", err
+			}
+			return strconv.FormatUint(norm.(uint64), 10), nil
 		}
-		return strconv.FormatUint(norm.(uint64), 10), nil
 	}
 
 	return sqlutil.SqlColToStr(ctx, colType, val)

--- a/integration-tests/bats/helper/common_expect_functions.tcl
+++ b/integration-tests/bats/helper/common_expect_functions.tcl
@@ -102,3 +102,15 @@ proc expect_with_defaults_after {output_marker expected_prompt action} {
         eof     { _fail "<<EOF while expecting prompt>>" }
     }
 }
+
+# Waits for the spawned process to exit. A timeout means the process is still
+# running, which fails the test instead of passing silently.
+proc expect_eof_with_defaults {} {
+    expect {
+        eof {}
+        timeout {
+            puts "<<Timeout waiting for the spawned process to exit>>"
+            exit 1
+        }
+    }
+}

--- a/integration-tests/bats/sql-diff.bats
+++ b/integration-tests/bats/sql-diff.bats
@@ -971,3 +971,27 @@ SQL
   ! [[ "$output" =~ "ignore_table" ]] || false
 
 }
+@test "sql-diff: output reconciles BIT(n) columns" {
+    # See https://github.com/dolthub/dolt/issues/10132
+    dolt sql -q "CREATE TABLE t (id INT PRIMARY KEY, some_bitval BIT(3))"
+    dolt commit -Am "empty table with BIT column"
+
+    dolt checkout -b newbranch
+    dolt sql -q "INSERT INTO t VALUES (0, b'000'), (1, b'010')"
+    dolt commit -am "insert BIT rows"
+
+    # confirm a difference exists
+    run dolt diff -r sql main newbranch
+    [ "$status" -eq 0 ]
+    [ ! "$output" = "" ]
+
+    dolt diff -r sql main newbranch > query
+    dolt checkout main
+    dolt sql < query
+    dolt commit -am "reconciled with newbranch"
+
+    # confirm that both branches have the same content
+    run dolt diff -r sql main newbranch
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}

--- a/integration-tests/bats/sql-server-mysql-bit.expect
+++ b/integration-tests/bats/sql-server-mysql-bit.expect
@@ -1,0 +1,26 @@
+#!/usr/bin/expect
+# See https://github.com/dolthub/dolt/issues/10132
+#
+# Usage:
+#   expect sql-server-mysql-bit.expect <port> <database>
+
+source "$env(BATS_CWD)/helper/common_expect_functions.tcl"
+
+set timeout 10
+
+set port [lindex $argv 0];
+set database [lindex $argv 1];
+
+spawn mysql --host 0.0.0.0 --port $port --user root $database
+
+expect_with_defaults {mysql> } { send "SELECT * FROM test_bit ORDER BY id;\r" }
+
+# The mysql client renders bit values as hex sized to the declared bit width
+expect_with_defaults_2 {0x00} {0x0000000000000000} {}
+expect_with_defaults_2 {0x02} {0xFFFFFFFFFFFFFFFF} {}
+expect_with_defaults_2 {0x07} {NULL}               {}
+
+expect_with_defaults {mysql> } { send "exit\r" }
+
+expect eof
+exit 0

--- a/integration-tests/bats/sql-server-mysql-bit.expect
+++ b/integration-tests/bats/sql-server-mysql-bit.expect
@@ -8,8 +8,8 @@ source "$env(BATS_CWD)/helper/common_expect_functions.tcl"
 
 set timeout 10
 
-set port [lindex $argv 0];
-set database [lindex $argv 1];
+set port [lindex $argv 0]
+set database [lindex $argv 1]
 
 spawn mysql --host 0.0.0.0 --port $port --user root $database
 
@@ -22,5 +22,5 @@ expect_with_defaults_2 {0x07} {NULL}               {}
 
 expect_with_defaults {mysql> } { send "exit\r" }
 
-expect eof
+expect_eof_with_defaults
 exit 0

--- a/integration-tests/bats/sql-server.bats
+++ b/integration-tests/bats/sql-server.bats
@@ -2350,3 +2350,20 @@ EOF
   start_sql_server > server_log.txt 2>&1 && sleep 0.5
   grep -F "permission denied" server_log.txt
 }
+
+# bats test_tags=no_lambda
+@test "sql-server: mysql client renders BIT columns as hex" {
+    skiponwindows "Missing dependencies"
+
+    # See https://github.com/dolthub/dolt/issues/10132
+    cd repo1
+    dolt sql -q "create table test_bit (id int primary key, b BIT(3), b64 BIT(64));"
+    dolt sql -q "insert into test_bit values (1, b'000', b'0'), (2, b'010', 18446744073709551615), (3, b'111', NULL);"
+    dolt commit -Am "create bit table"
+
+    cd ..
+    start_sql_server repo1
+
+    run expect $BATS_TEST_DIRNAME/sql-server-mysql-bit.expect $PORT repo1
+    [ "$status" -eq 0 ]
+}

--- a/integration-tests/bats/sql-shell-binary-as-hex.expect
+++ b/integration-tests/bats/sql-shell-binary-as-hex.expect
@@ -113,4 +113,17 @@ run_query "SELECT * FROM test_bit;" {
 }
 
 run_query "exit;" { expect eof }
+
+# -q from a terminal defaults to hex like mysql -e
+if {[llength $argv] == 0} {
+    spawn dolt sql -q "SELECT b FROM test_bit WHERE id = 1;"
+    expect_with_defaults {0x41} {}
+    expect eof
+}
+if {$has_skip_hex} {
+    spawn dolt sql --skip-binary-as-hex -q "SELECT b FROM test_bit WHERE id = 1;"
+    # expect_without_pattern consumes eof while scanning for the bad pattern
+    expect_without_pattern {0x[0-9A-F]+} {}
+}
+
 exit 0

--- a/integration-tests/bats/sql-shell-binary-as-hex.expect
+++ b/integration-tests/bats/sql-shell-binary-as-hex.expect
@@ -7,8 +7,8 @@
 #   expect binary-hex-test.expect [flags...]
 #
 # Tracked flags:
-#   --binary-as-hex:        Use binary as hex encoding for VARBINARY and BINARY types.
-#   --skip-binary-as-hex:   Skip binary as hex encoding for VARBINARY and BINARY types.
+#   --binary-as-hex:        Use binary as hex encoding for VARBINARY, BINARY, and BIT types.
+#   --skip-binary-as-hex:   Skip binary as hex encoding for VARBINARY, BINARY, and BIT types.
 
 source "$env(BATS_CWD)/helper/common_expect_functions.tcl"
 
@@ -95,6 +95,20 @@ run_query "SELECT *, LENGTH(b) FROM test_bin;" {
         expect_with_defaults_2 {0x61626300000000000000} {\| 10 } {}
         expect_with_defaults_2 {0x0A000000001000112233} {\| 10 } {}
         expect_with_defaults_2 {0x00000000000000000000} {\| 10 } {}
+    }
+}
+
+# See https://github.com/dolthub/dolt/issues/10132
+run_query "DROP TABLE IF EXISTS test_bit;" {}
+run_query "CREATE TABLE test_bit (id INT PRIMARY KEY, b BIT(8), b64 BIT(64));" {}
+run_query "INSERT INTO test_bit VALUES (1, b'01000001', b'0'), (2, b'11111111', 18446744073709551615), (3, b'0', NULL);" {}
+run_query "SELECT * FROM test_bit;" {
+    if {$has_skip_hex} {
+        expect_without_pattern {0x[0-9A-F]+} {}
+    } else {
+        expect_with_defaults_2 {0x41} {0x0000000000000000} {}
+        expect_with_defaults_2 {0xFF} {0xFFFFFFFFFFFFFFFF} {}
+        expect_with_defaults_2 {0x00} {NULL} {}
     }
 }
 

--- a/integration-tests/bats/sql-shell-binary-as-hex.expect
+++ b/integration-tests/bats/sql-shell-binary-as-hex.expect
@@ -118,7 +118,7 @@ run_query "exit;" { expect eof }
 if {[llength $argv] == 0} {
     spawn dolt sql -q "SELECT b FROM test_bit WHERE id = 1;"
     expect_with_defaults {0x41} {}
-    expect eof
+    expect_eof_with_defaults
 }
 if {$has_skip_hex} {
     spawn dolt sql --skip-binary-as-hex -q "SELECT b FROM test_bit WHERE id = 1;"

--- a/integration-tests/bats/sql-shell.bats
+++ b/integration-tests/bats/sql-shell.bats
@@ -1162,6 +1162,21 @@ expect eof
     [[ "$output" =~ "1,0x61626300000000000000" ]] || false
     [[ "$output" =~ "2,0x0A000000001000112233" ]] || false
     [[ "$output" =~ "3,0x00000000000000000000" ]] || false
+
+    # See https://github.com/dolthub/dolt/issues/10132
+    run dolt sql -q "SELECT * FROM test_bit" --binary-as-hex
+    [ "$status" -eq 0 ]
+    [[ $output =~ 1.*0x41.*0x0000000000000000 ]] || false
+    [[ $output =~ 2.*0xFF.*0xFFFFFFFFFFFFFFFF ]] || false
+    [[ $output =~ 3.*0x00.*NULL ]] || false
+
+    run dolt sql -q "SELECT * FROM test_bit" --skip-binary-as-hex
+    [ "$status" -eq 0 ]
+    [[ ! $output =~ 0x[0-9A-F]+ ]] || false
+
+    run dolt sql -r csv -q "SELECT * FROM test_bit WHERE id = 1;" --binary-as-hex
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "1,0x41,0x0000000000000000" ]] || false
 }
 
 # bats test_tags=no_lambda


### PR DESCRIPTION
`BIT(n)` values were printed as raw bytes, producing empty or corrupt SQL patches visually. `BIT` was also missing from the `--binary-as-hex` display path.
- `--binary-as-hex` now supports `BIT` for local and sql-server connections
- `dolt sql -q` now defaults to hex display for binary values when attached to a terminal (i.e., `mysql` client)
Fix dolthub/dolt#10132
Blocked by dolthub/go-mysql-server#3625
> Note: The driver does not report declared `BIT` widths: display paths size hex output from the value bytes the server already pads to `ceil(bits/8)`.