### PR TITLE
cluster: wait for outstanding DROP DATABASE replication during graceful transition to standby

### DIFF
--- a/go/libraries/doltcore/sqle/cluster/controller.go
+++ b/go/libraries/doltcore/sqle/cluster/controller.go
@@ -76,6 +76,24 @@ type databaseDropReplication struct {
 	ctx    context.Context
 	cancel func()
 	wg     *sync.WaitGroup
+
+	dbname string
+	// replicas has one entry per replication client that the drop is being
+	// replicated to, in the same order as |Controller.replicationClients| at
+	// the time the drop was initiated. Its contents are fixed at creation time
+	// and each entry's |done| channel is closed by exactly one
+	// replicateDropDatabase goroutine.
+	replicas []*dropDatabaseReplica
+}
+
+// dropDatabaseReplica tracks whether an outstanding DROP DATABASE has been
+// successfully replicated to a single standby.
+type dropDatabaseReplica struct {
+	remote    string
+	remoteUrl string
+	// done is closed once the drop has been successfully replicated to this
+	// standby.
+	done chan struct{}
 }
 
 type SqlContextFactory func(ctx context.Context) (*sql.Context, error)
@@ -393,15 +411,37 @@ func (c *Controller) dropDatabaseHook(_ *sql.Context, dbname string) {
 	wg := &sync.WaitGroup{}
 	wg.Add(len(c.replicationClients))
 	state := &databaseDropReplication{
-		ctx:    ctx,
-		cancel: cancel,
-		wg:     wg,
+		ctx:      ctx,
+		cancel:   cancel,
+		wg:       wg,
+		dbname:   dbname,
+		replicas: make([]*dropDatabaseReplica, len(c.replicationClients)),
+	}
+	for i, client := range c.replicationClients {
+		state.replicas[i] = &dropDatabaseReplica{
+			remote:    client.remote,
+			remoteUrl: client.httpUrl,
+			done:      make(chan struct{}),
+		}
 	}
 	c.outstandingDropDatabases[dbname] = state
 
-	for _, client := range c.replicationClients {
-		go c.replicateDropDatabase(state, client, dbname)
+	for i, client := range c.replicationClients {
+		go c.replicateDropDatabase(state, i, client, dbname)
 	}
+
+	// Once the drop has settled at every replica (successfully replicated,
+	// determined it will never replicate, or cancelled), stop tracking it so
+	// that outstandingDropDatabases does not grow without bound and completed
+	// or abandoned drops do not gate future graceful transitions.
+	go func() {
+		wg.Wait()
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if c.outstandingDropDatabases[dbname] == state {
+			delete(c.outstandingDropDatabases, dbname)
+		}
+	}()
 }
 
 func (c *Controller) cancelDropDatabaseReplication(dbname string) {
@@ -410,10 +450,11 @@ func (c *Controller) cancelDropDatabaseReplication(dbname string) {
 	if s := c.outstandingDropDatabases[dbname]; s != nil {
 		s.cancel()
 		s.wg.Wait()
+		delete(c.outstandingDropDatabases, dbname)
 	}
 }
 
-func (c *Controller) replicateDropDatabase(s *databaseDropReplication, client *replicationServiceClient, dbname string) {
+func (c *Controller) replicateDropDatabase(s *databaseDropReplication, i int, client *replicationServiceClient, dbname string) {
 	defer s.wg.Done()
 	bo := backoff.NewExponentialBackOff()
 	bo.InitialInterval = time.Millisecond
@@ -430,6 +471,7 @@ func (c *Controller) replicateDropDatabase(s *databaseDropReplication, client *r
 		cancel()
 		if err == nil {
 			c.lgr.Tracef("successfully replicated drop of [%s] to %s", dbname, client.remote)
+			close(s.replicas[i].done)
 			return
 		}
 		if status.Code(err) == codes.FailedPrecondition {
@@ -804,11 +846,22 @@ func (c *Controller) gracefulTransitionToStandby(saveConnID, minCaughtUpStandbys
 	c.setProviderIsStandby(true)
 	c.killRunningQueries(saveConnID)
 
-	var hookStates, mysqlStates, bcStates []graceTransitionResult
+	// Snapshot the outstanding DROP DATABASE replications while we hold c.mu.
+	// A standby which has not yet acknowledged a pending drop is not fully
+	// caught up, so we must wait on these along with the other replication
+	// subsystems below. We snapshot here, rather than in the goroutine, so that
+	// only waitForHooksToReplicate touches c.mu concurrently.
+	dropStates := make([]*databaseDropReplication, 0, len(c.outstandingDropDatabases))
+	for _, s := range c.outstandingDropDatabases {
+		dropStates = append(dropStates, s)
+	}
+
+	var hookStates, mysqlStates, bcStates, dropStatesRes []graceTransitionResult
 	var hookErr, mysqlErr, bcErr error
 
-	// We concurrently wait for hooks, mysql and dolt_branch_control replication to true up.
-	// If we encounter any errors while doing this, we fail the graceful transition.
+	// We concurrently wait for hooks, mysql, dolt_branch_control and pending
+	// DROP DATABASE replication to true up. If we encounter any errors while
+	// doing this, we fail the graceful transition.
 
 	var wg sync.WaitGroup
 	wg.Go(func() {
@@ -822,6 +875,9 @@ func (c *Controller) gracefulTransitionToStandby(saveConnID, minCaughtUpStandbys
 	wg.Go(func() {
 		bcStates, bcErr = c.bcReplication.waitForReplication(waitForHooksToReplicateTimeout)
 	})
+	wg.Go(func() {
+		dropStatesRes = waitForDropDatabaseReplication(dropStates, waitForHooksToReplicateTimeout)
+	})
 	wg.Wait()
 
 	err := errors.Join(hookErr, mysqlErr, bcErr)
@@ -834,10 +890,11 @@ func (c *Controller) gracefulTransitionToStandby(saveConnID, minCaughtUpStandbys
 		return nil, errors.New("cluster/controller: failed to transition to standby; the set of replicated databases changed during the transition.")
 	}
 
-	res := make([]graceTransitionResult, 0, len(hookStates)+len(mysqlStates)+len(bcStates))
+	res := make([]graceTransitionResult, 0, len(hookStates)+len(mysqlStates)+len(bcStates)+len(dropStatesRes))
 	res = append(res, hookStates...)
 	res = append(res, mysqlStates...)
 	res = append(res, bcStates...)
+	res = append(res, dropStatesRes...)
 
 	if minCaughtUpStandbys == 0 {
 		for _, state := range res {
@@ -885,6 +942,51 @@ func allCaughtUp(res []graceTransitionResult) bool {
 		}
 	}
 	return true
+}
+
+// waitForDropDatabaseReplication waits, up to |timeout|, for the supplied
+// outstanding DROP DATABASE replications to be acknowledged by each of their
+// standby replicas. It returns one graceTransitionResult per (dropped database,
+// standby) pair, with caughtUp set only if that standby acknowledged the drop
+// before the timeout.
+//
+// Unlike the other waitForReplication routines, this does not touch c.mu: the
+// caller snapshots the outstanding drops while holding c.mu, and each replica's
+// done channel is closed independently by its replicateDropDatabase goroutine.
+func waitForDropDatabaseReplication(states []*databaseDropReplication, timeout time.Duration) []graceTransitionResult {
+	if len(states) == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var res []graceTransitionResult
+	for _, s := range states {
+		for _, r := range s.replicas {
+			caughtUp := false
+			select {
+			case <-r.done:
+				caughtUp = true
+			case <-ctx.Done():
+				// The deadline elapsed. The drop may have completed right as we
+				// timed out, so check once more without blocking. ctx.Done()
+				// stays closed, so later iterations fall through immediately.
+				select {
+				case <-r.done:
+					caughtUp = true
+				default:
+				}
+			}
+			res = append(res, graceTransitionResult{
+				database:  s.dbname,
+				remote:    r.remote,
+				remoteUrl: r.remoteUrl,
+				caughtUp:  caughtUp,
+			})
+		}
+	}
+	return res
 }
 
 // The order of operations is:

--- a/go/libraries/doltcore/sqle/cluster/controller.go
+++ b/go/libraries/doltcore/sqle/cluster/controller.go
@@ -427,7 +427,7 @@ func (c *Controller) dropDatabaseHook(_ *sql.Context, dbname string) {
 	c.outstandingDropDatabases[dbname] = state
 
 	for i, client := range c.replicationClients {
-		go c.replicateDropDatabase(state, i, client, dbname)
+		go c.replicateDropDatabase(state, state.replicas[i].done, client, dbname)
 	}
 
 	// Once the drop has settled at every replica (successfully replicated,
@@ -454,7 +454,7 @@ func (c *Controller) cancelDropDatabaseReplication(dbname string) {
 	}
 }
 
-func (c *Controller) replicateDropDatabase(s *databaseDropReplication, i int, client *replicationServiceClient, dbname string) {
+func (c *Controller) replicateDropDatabase(s *databaseDropReplication, doneCh chan struct{}, client *replicationServiceClient, dbname string) {
 	defer s.wg.Done()
 	bo := backoff.NewExponentialBackOff()
 	bo.InitialInterval = time.Millisecond
@@ -471,7 +471,7 @@ func (c *Controller) replicateDropDatabase(s *databaseDropReplication, i int, cl
 		cancel()
 		if err == nil {
 			c.lgr.Tracef("successfully replicated drop of [%s] to %s", dbname, client.remote)
-			close(s.replicas[i].done)
+			close(doneCh)
 			return
 		}
 		if status.Code(err) == codes.FailedPrecondition {

--- a/integration-tests/go-sql-server-driver/drop_database_transition_test.go
+++ b/integration-tests/go-sql-server-driver/drop_database_transition_test.go
@@ -1,0 +1,250 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	driver "github.com/dolthub/dolt/go/libraries/doltcore/dtestutils/sql_server_driver"
+)
+
+// TestClusterTransitionToStandbyWaitsForDropDatabase asserts that
+// dolt_cluster_transition_to_standby does not consider a standby replica to be
+// fully caught up while a DROP DATABASE has not yet been replicated to it.
+//
+// The scenario:
+//   - A primary (server1) and standby (server2) replicate a database, repo1.
+//     dolt_cluster_ack_writes_timeout_secs is set so the writes block until
+//     they (and users/grants and branch control) have replicated. This ensures
+//     everything except the upcoming drop is fully quiesced and caught up.
+//   - The standby is stopped.
+//   - The primary drops repo1. The drop cannot be replicated to the (stopped)
+//     standby, so it stays outstanding.
+//   - The primary is asked to transition to standby, requiring 1 caught-up
+//     replica.
+//
+// Users/grants and branch control are already replicated and quiesced, so they
+// report caught up even with the standby down. The only outstanding
+// replication is the drop of repo1. A correct implementation must therefore
+// refuse to consider the standby caught up and fail the transition.
+//
+// Before the fix, the transition ignored outstanding DROP DATABASE
+// replications entirely and reported the standby as fully caught up, silently
+// succeeding while the standby still held repo1.
+func TestClusterTransitionToStandbyWaitsForDropDatabase(t *testing.T) {
+	t.Parallel()
+
+	var ports DynamicResources
+	ports.global = &GlobalPorts
+	ports.t = t
+
+	server1Port := ports.GetOrAllocatePort("server1")
+	server1Cluster := ports.GetOrAllocatePort("server1_cluster")
+	server2Port := ports.GetOrAllocatePort("server2")
+	server2Cluster := ports.GetOrAllocatePort("server2_cluster")
+
+	primaryConfig := fmt.Sprintf(`
+log_level: trace
+listener:
+  host: 0.0.0.0
+  port: %d
+cluster:
+  standby_remotes:
+  - name: standby
+    remote_url_template: http://localhost:%d/{database}
+  bootstrap_role: primary
+  bootstrap_epoch: 1
+  remotesapi:
+    port: %d
+`, server1Port, server2Cluster, server1Cluster)
+
+	standbyConfig := fmt.Sprintf(`
+log_level: trace
+listener:
+  host: 0.0.0.0
+  port: %d
+cluster:
+  standby_remotes:
+  - name: standby
+    remote_url_template: http://localhost:%d/{database}
+  bootstrap_role: standby
+  bootstrap_epoch: 1
+  remotesapi:
+    port: %d
+`, server2Port, server1Cluster, server2Cluster)
+
+	primary := makeClusterServer(t, &ports, "server1", "server1", primaryConfig)
+	standby := makeClusterServer(t, &ports, "server2", "server2", standbyConfig)
+
+	ctx := t.Context()
+
+	primaryDB, err := primary.DB(driver.Connection{User: "root"})
+	require.NoError(t, err)
+	t.Cleanup(func() { primaryDB.Close() })
+
+	primaryConn, err := primaryDB.Conn(ctx)
+	require.NoError(t, err)
+	defer primaryConn.Close()
+
+	// Create repo1 with data and touch users/grants and branch control on the
+	// primary. With ack writes enabled, each of these statements blocks until
+	// it has replicated to the standby, so once they return there is no
+	// outstanding repo1/users/grants/branch-control novelty pending
+	// replication.
+	for _, stmt := range []string{
+		"SET @@GLOBAL.dolt_cluster_ack_writes_timeout_secs = 10",
+		"create database repo1",
+		"use repo1",
+		"create table vals (i int primary key)",
+		"insert into vals values (0),(1),(2),(3),(4)",
+		`create user "replprobe"@"%" identified by "replprobepassword"`,
+		`grant all on *.* to "replprobe"@"%"`,
+		"delete from dolt_branch_control",
+		`insert into dolt_branch_control values ("repo1", "main", "replprobe", "%", "admin")`,
+	} {
+		_, err := primaryConn.ExecContext(ctx, stmt)
+		require.NoErrorf(t, err, "statement: %s", stmt)
+	}
+
+	// Sanity check: repo1 has replicated to the standby.
+	standbyDB, err := standby.DB(driver.Connection{User: "root"})
+	require.NoError(t, err)
+	t.Cleanup(func() { standbyDB.Close() })
+	waitForDatabasesOnStandby(t, ctx, standbyDB, []string{"dolt_cluster", "information_schema", "mysql", "repo1"})
+	standbyDB.Close()
+
+	// Stop the standby so that the DROP DATABASE below cannot be replicated.
+	require.NoError(t, standby.GracefulStop())
+
+	// Drop repo1 on the primary. Everything else is already fully replicated
+	// and quiesced, so the only outstanding replication to the standby is this
+	// drop.
+	_, err = primaryConn.ExecContext(ctx, "drop database repo1")
+	require.NoError(t, err)
+
+	// Ask the primary to transition to standby, requiring 1 caught-up replica.
+	// The only standby is down with an outstanding drop, so no replica is
+	// fully caught up and the transition must fail.
+	rows, err := primaryConn.QueryContext(ctx, "call dolt_cluster_transition_to_standby('2', '1')")
+	if err == nil {
+		reported := collectTransitionRows(t, rows)
+		t.Fatalf("expected dolt_cluster_transition_to_standby to fail because the DROP DATABASE of repo1 "+
+			"has not replicated to the (stopped) standby, but it succeeded and reported: %v", reported)
+	}
+	require.ErrorContains(t, err, "could not ensure 1 replicas were caught up")
+}
+
+// makeClusterServer starts a single sql-server in its own repo store, using the
+// provided cluster config written to server.yaml. portName must already be
+// allocated in ports and must match the listener port embedded in config.
+func makeClusterServer(t *testing.T, ports *DynamicResources, name, portName, config string) *driver.SqlServer {
+	u, err := driver.NewDoltUser()
+	require.NoError(t, err)
+	t.Cleanup(func() { u.Cleanup() })
+
+	rs, err := u.MakeRepoStore()
+	require.NoError(t, err)
+
+	f := driver.WithFile{Name: "server.yaml", Contents: config}
+	require.NoError(t, f.WriteAtDir(rs.Dir))
+
+	server := MakeServer(t, rs, &driver.Server{
+		Name:        name,
+		Args:        []string{"--config", "server.yaml"},
+		DynamicPort: portName,
+	}, ports)
+	require.NotNil(t, server)
+	return server
+}
+
+func waitForDatabasesOnStandby(t *testing.T, ctx context.Context, db *sql.DB, want []string) {
+	t.Helper()
+	var last []string
+	require.Eventuallyf(t, func() bool {
+		conn, err := db.Conn(ctx)
+		if err != nil {
+			return false
+		}
+		defer conn.Close()
+		got, err := showDatabases(ctx, conn)
+		if err != nil {
+			return false
+		}
+		last = got
+		if len(got) != len(want) {
+			return false
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				return false
+			}
+		}
+		return true
+	}, 30*time.Second, 100*time.Millisecond, "standby never converged to databases %v; last saw %v", want, &last)
+}
+
+func showDatabases(ctx context.Context, conn *sql.Conn) ([]string, error) {
+	rows, err := conn.QueryContext(ctx, "show databases")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var dbs []string
+	for rows.Next() {
+		var db string
+		if err := rows.Scan(&db); err != nil {
+			return nil, err
+		}
+		dbs = append(dbs, db)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	sort.Strings(dbs)
+	return dbs, nil
+}
+
+func collectTransitionRows(t *testing.T, rows *sql.Rows) []string {
+	t.Helper()
+	defer rows.Close()
+	cols, err := rows.Columns()
+	require.NoError(t, err)
+	var out []string
+	for rows.Next() {
+		vals := make([]sql.NullString, len(cols))
+		ptrs := make([]any, len(cols))
+		for i := range vals {
+			ptrs[i] = &vals[i]
+		}
+		require.NoError(t, rows.Scan(ptrs...))
+		row := ""
+		for i, c := range cols {
+			if i > 0 {
+				row += ", "
+			}
+			row += fmt.Sprintf("%s=%s", c, vals[i].String)
+		}
+		out = append(out, "{"+row+"}")
+	}
+	require.NoError(t, rows.Err())
+	return out
+}


### PR DESCRIPTION
dolt_cluster_transition_to_standby determines whether a standby replica is fully caught up by waiting on three replication subsystems: per-database commit hooks, users/grants, and branch control. It never accounted for outstanding DROP DATABASE replications, which are tracked separately in Controller.outstandingDropDatabases and driven by independent fire-and-forget goroutines.

As a result, the transition could report a standby as fully caught up and succeed while a DROP DATABASE had not yet replicated to it. This PR makes it so that dolt_cluster_transition_to_standby also waits for outstanding DROP DATABASE statements to replicate.