### PR TITLE
go/store/nbs: Fix a race between the journal persister and PruneTableFiles.

### DIFF
--- a/go/libraries/doltcore/dtestutils/sql_server_driver/cmd.go
+++ b/go/libraries/doltcore/dtestutils/sql_server_driver/cmd.go
@@ -387,6 +387,43 @@ func (s *SqlServer) Restart(newargs *[]string, newenvs *[]string) error {
 	if err != nil {
 		return err
 	}
+	return s.respawn(newargs, newenvs)
+}
+
+// KillStop hard-kills the running server process (SIGKILL on unix,
+// TerminateProcess on windows) and waits for it to exit. It reports whether the
+// process had already exited before we killed it: if exitedEarly is true,
+// waitErr is that exit's status (non-nil means the process crashed); otherwise
+// waitErr is the expected kill-induced status and should be ignored.
+func (s *SqlServer) KillStop() (exitedEarly bool, waitErr error) {
+	select {
+	case <-s.Done:
+		return true, s.CmdWaitErr
+	default:
+	}
+	if err := s.Cmd.Process.Kill(); err != nil {
+		// Kill errors only if the process has already finished.
+		<-s.Done
+		return true, s.CmdWaitErr
+	}
+	<-s.Done
+	return false, s.CmdWaitErr
+}
+
+// KillRestart is like Restart but hard-kills the current process (see KillStop)
+// instead of stopping it gracefully. It returns an error only if the killed
+// process had already crashed on its own, or the replacement failed to start.
+func (s *SqlServer) KillRestart(newargs *[]string, newenvs *[]string) error {
+	exitedEarly, waitErr := s.KillStop()
+	if exitedEarly && waitErr != nil {
+		return waitErr
+	}
+	return s.respawn(newargs, newenvs)
+}
+
+// respawn recreates and starts the server command, reusing the previous args
+// (or newargs/newenvs when provided).
+func (s *SqlServer) respawn(newargs *[]string, newenvs *[]string) error {
 	args := s.Cmd.Args[1:]
 	if newargs != nil {
 		args = append([]string{"sql-server"}, (*newargs)...)

--- a/go/store/nbs/journal.go
+++ b/go/store/nbs/journal.go
@@ -162,8 +162,7 @@ func (j *ChunkJournal) bootstrapJournalWriter(ctx context.Context, behavior dher
 	canCreate := !j.backing.readOnly()
 
 	if canCreate && !ok { // create new journal file
-		j.wr, err = createJournalWriter(ctx, j.path)
-		if err != nil {
+		if err = j.createProtectedJournalWriter(ctx); err != nil {
 			return err
 		}
 
@@ -187,7 +186,7 @@ func (j *ChunkJournal) bootstrapJournalWriter(ctx context.Context, behavior dher
 		return
 	}
 
-	j.wr, ok, err = openJournalWriter(ctx, j.path)
+	ok, err = j.openProtectedJournalWriter(ctx)
 	if err != nil {
 		return err
 	} else if !ok {
@@ -231,6 +230,44 @@ func (j *ChunkJournal) bootstrapJournalWriter(ctx context.Context, behavior dher
 	}
 	j.contents = mc
 	return
+}
+
+// createProtectedJournalWriter creates the journal file and registers it in the
+// persister's protected set. The journal file lives in the same directory and
+// naming namespace as regular table files (its address is |journalAddr|), so
+// without this registration PruneTableFiles would treat it as an orphaned table
+// file and delete it. Because journal creation happens under the NomsBlockStore
+// mutex while PruneTableFiles runs under the persister's pruneMu, the two are
+// otherwise unsynchronized; we hold pruneMu here so that a concurrent prune
+// cannot observe the newly created journal file before it has been protected.
+func (j *ChunkJournal) createProtectedJournalWriter(ctx context.Context) error {
+	j.persister.pruneMu.RLock()
+	defer j.persister.pruneMu.RUnlock()
+	wr, err := createJournalWriter(ctx, j.path)
+	if err != nil {
+		return err
+	}
+	j.wr = wr
+	j.persister.addProtected(journalAddr)
+	return nil
+}
+
+// openProtectedJournalWriter opens the existing journal file and registers it in
+// the persister's protected set under pruneMu, for the same reasons as
+// createProtectedJournalWriter. It returns false if the journal file does not
+// exist.
+func (j *ChunkJournal) openProtectedJournalWriter(ctx context.Context) (bool, error) {
+	j.persister.pruneMu.RLock()
+	defer j.persister.pruneMu.RUnlock()
+	wr, ok, err := openJournalWriter(ctx, j.path)
+	if err != nil {
+		return false, err
+	} else if !ok {
+		return false, nil
+	}
+	j.wr = wr
+	j.persister.addProtected(journalAddr)
+	return true, nil
 }
 
 // the journal file is the source of truth for the root hash, true-up persisted manifest
@@ -351,13 +388,13 @@ func (j *ChunkJournal) PruneTableFiles(ctx context.Context) error {
 	if j.backing.readOnly() {
 		return errReadOnlyManifest
 	}
-	// If the journal is active, protect its file from pruning by adding
-	// it to pending for the duration of the prune. When the journal is
-	// inactive (j.wr == nil), the file should be prunable.
-	if j.wr != nil {
-		ph := j.persister.addPending(journalAddr)
-		defer ph.Close()
-	}
+	// While the journal is active, its file is kept in the persister's
+	// protected set for the lifetime of the journal writer (see
+	// createProtectedJournalWriter / openProtectedJournalWriter and
+	// dropJournalWriter), so PruneTableFiles will not remove it. When the
+	// journal is inactive (j.wr == nil) it is not protected and the file, if
+	// any, is prunable. No per-call protection is needed or safe here: reading
+	// j.wr outside the NomsBlockStore mutex would race journal creation.
 	return j.persister.PruneTableFiles(ctx)
 }
 
@@ -484,10 +521,19 @@ func (j *ChunkJournal) flushToBackingManifest(ctx context.Context, behavior dher
 
 func (j *ChunkJournal) dropJournalWriter(ctx context.Context) error {
 	curr := j.wr
-	if j.wr == nil {
+	if curr == nil {
 		return nil
 	}
 	j.wr = nil
+	// Balance the protection registered when the writer was opened, and
+	// serialize with PruneTableFiles via pruneMu so that deregistering the
+	// journal file and deleting it happen atomically with respect to a
+	// concurrent prune. Deregister unconditionally: once the writer is dropped
+	// the journal file is no longer a dependency of the store, so even if the
+	// deletion below fails a leftover file should be prunable.
+	j.persister.pruneMu.RLock()
+	defer j.persister.pruneMu.RUnlock()
+	defer j.persister.removeProtected(journalAddr)
 	if err := curr.Close(); err != nil {
 		return err
 	}

--- a/go/store/nbs/journal_test.go
+++ b/go/store/nbs/journal_test.go
@@ -19,6 +19,8 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -217,6 +219,123 @@ func TestChunkJournalPersist(t *testing.T) {
 		assert.NotNil(t, cs)
 		assert.NoError(t, err)
 	}
+}
+
+// protectedRefCount returns the current prune-protection ref count for |h| in
+// the persister's protected set.
+func protectedRefCount(ftp *fsTablePersister, h hash.Hash) int32 {
+	ftp.mu.Lock()
+	defer ftp.mu.Unlock()
+	return ftp.protected[h]
+}
+
+// TestChunkJournalActiveFileProtectedFromPruning is a regression test for a bug
+// where PruneTableFiles could delete the journal file out from under an active
+// journal writer. The journal file lives in the table-file namespace (its name
+// is journalAddr), so the generic pruner would treat it as a prunable table
+// file. Protection used to be a racy, per-call `j.wr != nil` check inside
+// ChunkJournal.PruneTableFiles, decided under the persister's pruneMu while the
+// journal writer is created/dropped under the NomsBlockStore mutex — two
+// disjoint lock domains. The fix registers the journal file in the persister's
+// protected set for the entire lifetime of the writer, under pruneMu. This test
+// asserts that lifetime protection; it fails against the pre-fix code, whose
+// protection did not persist beyond a PruneTableFiles call.
+func TestChunkJournalActiveFileProtectedFromPruning(t *testing.T) {
+	ctx := context.Background()
+	j := makeTestChunkJournal(t)
+	journalPath := filepath.Join(j.persister.dir, chunkJournalName)
+
+	// Before any writes there is no journal writer, file, or protection.
+	require.Nil(t, j.wr)
+	require.Zero(t, protectedRefCount(j.persister, journalAddr))
+	ok, err := fileExists(journalPath)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	// Persisting a memtable activates the journal writer, which must create the
+	// journal file and register it as protected.
+	mt, _ := randomMemTable(8)
+	_, _, err = j.Persist(ctx, dherrors.FatalBehaviorError, mt, emptyChunkSource{}, nil, &Stats{})
+	require.NoError(t, err)
+	require.NotNil(t, j.wr)
+
+	ok, err = fileExists(journalPath)
+	require.NoError(t, err)
+	require.True(t, ok, "journal file should exist while the writer is active")
+
+	// The active journal file must be protected for the lifetime of the writer,
+	// not just transiently during a prune call.
+	require.Positive(t, protectedRefCount(j.persister, journalAddr),
+		"active journal file must be protected from pruning")
+
+	// A prune while the journal is active must not delete the journal file.
+	require.NoError(t, j.PruneTableFiles(ctx))
+	ok, err = fileExists(journalPath)
+	require.NoError(t, err)
+	require.True(t, ok, "PruneTableFiles must not delete the active journal file")
+
+	// Dropping the writer releases the protection and deletes the file, so it
+	// becomes prunable again.
+	require.NoError(t, j.dropJournalWriter(ctx))
+	require.Nil(t, j.wr)
+	require.Zero(t, protectedRefCount(j.persister, journalAddr),
+		"journal protection must be released when the writer is dropped")
+	ok, err = fileExists(journalPath)
+	require.NoError(t, err)
+	require.False(t, ok, "dropped journal file should be deleted")
+}
+
+// TestChunkJournalPruneConcurrentWithJournalRecreation is a regression test for
+// the race between PruneTableFiles and (re)creation of the journal file. A
+// commit that recreates the journal (after a prior GC dropped it) runs under
+// the NomsBlockStore mutex, while PruneTableFiles runs under the persister's
+// pruneMu; before the fix these disjoint lock domains let a prune delete a live
+// journal file, and left ChunkJournal.PruneTableFiles reading j.wr without
+// synchronization. Run under `-race` this reliably catches the unsynchronized
+// access; without it, it catches the erroneous deletion probabilistically.
+func TestChunkJournalPruneConcurrentWithJournalRecreation(t *testing.T) {
+	ctx := context.Background()
+	j := makeTestChunkJournal(t)
+	journalPath := filepath.Join(j.persister.dir, chunkJournalName)
+
+	stop := make(chan struct{})
+	var pruneErr atomic.Value
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if err := j.PruneTableFiles(ctx); err != nil {
+				pruneErr.Store(err)
+				return
+			}
+		}
+	}()
+
+	const iters = 300
+	for i := 0; i < iters; i++ {
+		// Recreate the journal, as a commit persisting after a GC drop would.
+		mt, _ := randomMemTable(8)
+		_, _, err := j.Persist(ctx, dherrors.FatalBehaviorError, mt, emptyChunkSource{}, nil, &Stats{})
+		require.NoError(t, err)
+
+		// While the writer is active the file must not have been pruned.
+		ok, err := fileExists(journalPath)
+		require.NoError(t, err)
+		require.Truef(t, ok, "journal file was pruned while the writer was active (iter %d)", i)
+
+		// Drop the journal, as a GC finalize dropping it would.
+		require.NoError(t, j.dropJournalWriter(ctx))
+	}
+
+	close(stop)
+	wg.Wait()
+	require.Nil(t, pruneErr.Load(), "PruneTableFiles failed: %v", pruneErr.Load())
 }
 
 func TestReadRecordRanges(t *testing.T) {

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -444,6 +444,9 @@ func (nbs *NomsBlockStore) UpdateManifest(ctx context.Context, updates map[hash.
 func (nbs *NomsBlockStore) updateManifestAddFiles(ctx context.Context, updates map[hash.Hash]uint32, appendixOption *ManifestAppendixOption, gcGen *hash.Hash, sources chunkSourceSet) (mi ManifestInfo, gcGenDifferent bool, err error) {
 	nbs.mu.Lock()
 	defer nbs.mu.Unlock()
+	if nbs.closed {
+		return manifestContents{}, false, errors.New("*NomsBlockStore is closed")
+	}
 
 	err = nbs.startConjoinIfRequired(ctx)
 	if err != nil {
@@ -2156,6 +2159,9 @@ type openChunkSourcesResult struct {
 func (nbs *NomsBlockStore) openChunkSourcesForManifestUpdateAndRebase(ctx context.Context, files map[hash.Hash]uint32, existing chunkSourceSet) (openChunkSourcesResult, error) {
 	nbs.mu.Lock()
 	defer nbs.mu.Unlock()
+	if nbs.closed {
+		return openChunkSourcesResult{}, errors.New("*NomsBlockStore is closed")
+	}
 	sources, err := nbs.tables.openForAdd(ctx, files, existing, nbs.stats)
 	if err != nil {
 		return openChunkSourcesResult{}, err
@@ -2640,6 +2646,9 @@ func (nbs *NomsBlockStore) TolerantIterateAllChunks(ctx context.Context, cb func
 func (nbs *NomsBlockStore) swapTables(ctx context.Context, specs []tableSpec, mode chunks.GCMode, srcs chunkSourceSet) (err error) {
 	nbs.mu.Lock()
 	defer nbs.mu.Unlock()
+	if nbs.closed {
+		return errors.New("*NomsBlockStore is closed")
+	}
 
 	// Pre-open chunk sources for the new specs before updating the
 	// manifest. This validates that the table files are on disk and

--- a/integration-tests/go-sql-server-driver/gc_shutdown_panic_test.go
+++ b/integration-tests/go-sql-server-driver/gc_shutdown_panic_test.go
@@ -1,0 +1,349 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math/rand/v2"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	driver "github.com/dolthub/dolt/go/libraries/doltcore/dtestutils/sql_server_driver"
+)
+
+// TestGCShutdownPanic reproduces a reported failure where a `dolt_gc()` that is
+// finalizing when the sql-server process is shut down (NomsBlockStore.Close())
+// leaves the on-disk store in an inconsistent state instead of shutting down
+// cleanly.
+//
+// The observed failure mode is store corruption: GC updates the manifest to a
+// new root but the chunks backing that root are not durably persisted before
+// the process goes away (or the old table files are removed too early). The
+// next time the server starts and tries to load the database it fails with
+//
+//	root hash doesn't exist: <hash>
+//
+// and exits non-zero, because the manifest's root chunk cannot be found in the
+// table files. (A crash during Close() itself, i.e. a panic, is the other
+// possible symptom of the same race.)
+//
+// The test spins up a single sql-server hosting several databases, drives
+// continual writes (with commits, to produce garbage) against every database,
+// runs serial `call dolt_gc()` invocations against every database in a tight
+// loop, and periodically restarts the sql-server process. Each restart is a
+// SIGTERM-driven graceful shutdown; Restart()/GracefulStop() surfaces the error
+// from cmd.Wait() on the stopped process, so a non-zero exit (whether the
+// corrupt process failed on the way down or the freshly-started process failed
+// to load the corrupted store) fails the test. We additionally scan the merged
+// server output for the corruption message and for panic stack traces so that a
+// failure produces an actionable diagnostic.
+//
+// This is a stress/race reproduction: a clean run does not prove the bug is
+// absent, but a failing run demonstrates it. Set
+// DOLT_GC_SHUTDOWN_PANIC_STRESS to a Go duration (e.g. "5m") to run each
+// variant longer when hunting for the race locally.
+func TestGCShutdownPanic(t *testing.T) {
+	t.Parallel()
+
+	duration := 25 * time.Second
+	if v := os.Getenv("DOLT_GC_SHUTDOWN_PANIC_STRESS"); v != "" {
+		d, err := time.ParseDuration(v)
+		require.NoError(t, err)
+		duration = d
+	}
+
+	// The safepoint controller governs how in-flight sessions are handled
+	// while GC runs; the shutdown-vs-finalize race is independent of it, but
+	// the two implementations reach NomsBlockStore.Close() along different
+	// paths, so we exercise both.
+	for _, controller := range []string{"session_aware", "kill_connections"} {
+		t.Run(controller, func(t *testing.T) {
+			t.Parallel()
+			gcShutdownPanicTest{
+				numDatabases:    3,
+				writersPerDB:    2,
+				duration:        duration,
+				minRestartWait:  150 * time.Millisecond,
+				maxRestartWait:  600 * time.Millisecond,
+				safepointChoice: controller,
+			}.run(t)
+		})
+	}
+}
+
+type gcShutdownPanicTest struct {
+	numDatabases    int
+	writersPerDB    int
+	duration        time.Duration
+	minRestartWait  time.Duration
+	maxRestartWait  time.Duration
+	safepointChoice string
+}
+
+func (gct gcShutdownPanicTest) dbNames() []string {
+	names := make([]string, gct.numDatabases)
+	for i := range names {
+		names[i] = fmt.Sprintf("gcdb%d", i)
+	}
+	return names
+}
+
+func (gct gcShutdownPanicTest) run(t *testing.T) {
+	var ports DynamicResources
+	ports.global = &GlobalPorts
+	ports.t = t
+
+	u, err := driver.NewDoltUser()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		u.Cleanup()
+	})
+
+	rs, err := u.MakeRepoStore()
+	require.NoError(t, err)
+
+	// Create each database as its own dolt repo under a single repo store.
+	// The sql-server started on the repo store hosts them all as sibling
+	// databases.
+	for _, name := range gct.dbNames() {
+		_, err := rs.MakeRepo(name)
+		require.NoError(t, err)
+	}
+
+	// Watch the server output for evidence that a GC left the store on-disk in
+	// a bad state. The signature is a (re)started server that cannot find the
+	// manifest's root chunk in the table files ("root hash doesn't exist"), or a
+	// GC that fails while dropping the journal file. Either indicates the store
+	// was corrupted by an interrupted GC finalize, so we fail the test.
+	//
+	// A hard process crash (e.g. the FatalBehaviorCrash panic that used to fire
+	// from dropJournalWriter) makes the process exit non-zero, which is caught
+	// separately by asserting on the Restart/GracefulStop error, so we do not
+	// scan for it here.
+	var sawCorruption atomic.Bool
+	var corruptionLine atomic.Value
+	corruptionLine.Store("")
+	// Recovered per-query panics (go-mysql-server catches these and logs
+	// "caught panic") do not crash the process or corrupt the store, so they are
+	// not what this test targets. We count them for diagnostics only.
+	var recoveredPanics atomic.Int32
+	var firstRecoveredPanic atomic.Value
+	firstRecoveredPanic.Store("")
+	visitor := func(line string) {
+		if strings.Contains(line, "root hash doesn't exist") ||
+			strings.Contains(line, "error dropping journal writer") {
+			if sawCorruption.CompareAndSwap(false, true) {
+				corruptionLine.Store(line)
+			}
+		}
+		if strings.Contains(line, "caught panic") {
+			if recoveredPanics.Add(1) == 1 {
+				firstRecoveredPanic.Store(line)
+			}
+		}
+	}
+
+	srvSettings := &driver.Server{
+		Args:        []string{"-P", `{{get_port "server_port"}}`},
+		DynamicPort: "server_port",
+		Envs:        []string{"DOLT_GC_SAFEPOINT_CONTROLLER_CHOICE=" + gct.safepointChoice},
+	}
+	server := MakeServer(t, rs, srvSettings, &ports, driver.WithOutputVisitor(visitor))
+	require.NotNil(t, server)
+
+	// Open a connection pool per database. Because the server is repeatedly
+	// restarted on the same port, these pools transparently reconnect; we
+	// disable idle connection reuse so we don't hand out connections that were
+	// severed by a restart.
+	pass, err := driver.Connection{User: "root"}.Password()
+	require.NoError(t, err)
+	dbs := make(map[string]*sql.DB, gct.numDatabases)
+	for _, name := range gct.dbNames() {
+		db, err := driver.ConnectDB("root", pass, name, "127.0.0.1", server.Port, nil)
+		require.NoError(t, err)
+		db.SetMaxIdleConns(0)
+		dbs[name] = db
+		t.Cleanup(func() {
+			db.Close()
+		})
+	}
+
+	// Bootstrap a table with some rows in every database.
+	for _, name := range gct.dbNames() {
+		gct.createTable(t, dbs[name])
+	}
+
+	// Workload goroutines run until their context is cancelled. They swallow
+	// all query errors: connections are expected to break on every restart,
+	// and only the process exit status is a signal of the bug. They must never
+	// fail the test off the main goroutine.
+	baseCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	eg, egCtx := errgroup.WithContext(baseCtx)
+
+	for _, name := range gct.dbNames() {
+		db := dbs[name]
+		for w := 0; w < gct.writersPerDB; w++ {
+			row := w
+			eg.Go(func() error {
+				gct.writeLoop(egCtx, db, row)
+				return nil
+			})
+		}
+	}
+
+	// One goroutine issuing serial dolt_gc() calls, cycling across databases.
+	eg.Go(func() error {
+		for egCtx.Err() == nil {
+			for _, name := range gct.dbNames() {
+				if egCtx.Err() != nil {
+					break
+				}
+				gct.gcOnce(egCtx, dbs[name])
+			}
+		}
+		return nil
+	})
+
+	// Main loop: periodically restart the server. Restart() gracefully stops
+	// the currently running process (SIGTERM + wait) and returns the error from
+	// cmd.Wait() on that process. A clean shutdown exits 0 (nil error); a panic
+	// on the way down exits non-zero and shows up here.
+	restarts := 0
+	start := time.Now()
+	for time.Since(start) < gct.duration {
+		gct.sleepJitter(egCtx)
+		if egCtx.Err() != nil {
+			break
+		}
+		err := server.Restart(nil, nil)
+		restarts++
+		require.NoErrorf(t, err, "server exited non-zero across restart #%d (corruption log line: %q)",
+			restarts, corruptionLine.Load())
+		require.Falsef(t, sawCorruption.Load(), "server logged store corruption across restart #%d: %q",
+			restarts, corruptionLine.Load())
+		// Wait for the freshly-started process to come up before doing anything
+		// else, so that it has installed its signal handler and a subsequent
+		// SIGTERM exercises a graceful shutdown rather than hard-killing a
+		// still-booting process.
+		gct.waitReady(egCtx, dbs[gct.dbNames()[0]])
+	}
+
+	// Stop the workload and drain the goroutines before the final shutdown so
+	// the last GracefulStop (run by MakeServer's cleanup) is asserted cleanly.
+	cancel()
+	require.NoError(t, eg.Wait())
+
+	// Explicitly perform a final graceful stop while asserting a clean exit,
+	// rather than relying solely on the cleanup's assertion.
+	err = server.GracefulStop()
+	require.NoErrorf(t, err, "server exited non-zero on final shutdown (corruption log line: %q)", corruptionLine.Load())
+	require.Falsef(t, sawCorruption.Load(), "server logged store corruption: %q", corruptionLine.Load())
+
+	if n := recoveredPanics.Load(); n > 0 {
+		// These are recovered by the server (no crash, no corruption) and are
+		// out of scope for this test, but worth surfacing. The first was:
+		// firstRecoveredPanic.
+		t.Logf("note: server logged %d recovered per-query panic(s) during the run (first: %q)",
+			n, firstRecoveredPanic.Load())
+	}
+	t.Logf("completed %d restarts over %v with no shutdown corruption", restarts, time.Since(start).Round(time.Millisecond))
+}
+
+func (gct gcShutdownPanicTest) createTable(t *testing.T, db *sql.DB) {
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = conn.ExecContext(ctx, "create table vals (id int primary key, val int)")
+	require.NoError(t, err)
+	vals := make([]string, gct.writersPerDB)
+	for i := range vals {
+		vals[i] = fmt.Sprintf("(%d,0)", i)
+	}
+	_, err = conn.ExecContext(ctx, "insert into vals values "+strings.Join(vals, ","))
+	require.NoError(t, err)
+	_, err = conn.ExecContext(ctx, "call dolt_commit('-Am', 'create vals table')")
+	require.NoError(t, err)
+}
+
+// writeLoop performs update+commit against a single row until ctx is cancelled.
+// All errors are ignored: restarts routinely sever connections and GC with the
+// kill_connections controller intentionally kills sessions.
+func (gct gcShutdownPanicTest) writeLoop(ctx context.Context, db *sql.DB, row int) {
+	for ctx.Err() == nil {
+		func() {
+			conn, err := db.Conn(ctx)
+			if err != nil {
+				return
+			}
+			defer conn.Close()
+			_, err = conn.ExecContext(ctx, "update vals set val = val+1 where id = ?", row)
+			if err != nil {
+				return
+			}
+			_, _ = conn.ExecContext(ctx, fmt.Sprintf("call dolt_commit('-am', 'increment id %d')", row))
+		}()
+	}
+}
+
+// gcOnce runs a single dolt_gc() against db, ignoring all errors.
+func (gct gcShutdownPanicTest) gcOnce(ctx context.Context, db *sql.DB) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+	_, _ = conn.ExecContext(ctx, "call dolt_gc()")
+}
+
+// waitReady pings db until the server responds or ctx is cancelled, so callers
+// can be sure a just-(re)started server is fully up.
+func (gct gcShutdownPanicTest) waitReady(ctx context.Context, db *sql.DB) {
+	for i := 0; i < 200 && ctx.Err() == nil; i++ {
+		pingCtx, cancel := context.WithTimeout(ctx, time.Second)
+		err := db.PingContext(pingCtx)
+		cancel()
+		if err == nil {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(25 * time.Millisecond):
+		}
+	}
+}
+
+func (gct gcShutdownPanicTest) sleepJitter(ctx context.Context) {
+	span := gct.maxRestartWait - gct.minRestartWait
+	wait := gct.minRestartWait
+	if span > 0 {
+		wait += time.Duration(rand.Int64N(int64(span)))
+	}
+	select {
+	case <-ctx.Done():
+	case <-time.After(wait):
+	}
+}

--- a/integration-tests/go-sql-server-driver/gc_shutdown_panic_test.go
+++ b/integration-tests/go-sql-server-driver/gc_shutdown_panic_test.go
@@ -48,15 +48,16 @@ import (
 // possible symptom of the same race.)
 //
 // The test spins up a single sql-server hosting several databases, drives
-// continual writes (with commits, to produce garbage) against every database,
-// runs serial `call dolt_gc()` invocations against every database in a tight
-// loop, and periodically restarts the sql-server process. Each restart is a
-// SIGTERM-driven graceful shutdown; Restart()/GracefulStop() surfaces the error
-// from cmd.Wait() on the stopped process, so a non-zero exit (whether the
-// corrupt process failed on the way down or the freshly-started process failed
-// to load the corrupted store) fails the test. We additionally scan the merged
-// server output for the corruption message and for panic stack traces so that a
-// failure produces an actionable diagnostic.
+// continual writes (with commits, to produce garbage), runs serial
+// `call dolt_gc()` across every database in a tight loop, and periodically
+// restarts the process, choosing at random between a graceful SIGTERM shutdown
+// and an abrupt SIGKILL. Dolt must be robust across both. A graceful shutdown
+// must exit 0; a SIGKILL is expected to exit non-zero, so we do not assert on
+// it. Either way the freshly-started server must reload the store: if an
+// interrupted GC corrupted it, the next startup fails with "root hash doesn't
+// exist" and exits non-zero, which we catch via the following stop's exit
+// status, the server failing to become ready, and an output visitor scanning
+// the server log.
 //
 // This is a stress/race reproduction: a clean run does not prove the bug is
 // absent, but a failing run demonstrates it. Set
@@ -136,10 +137,10 @@ func (gct gcShutdownPanicTest) run(t *testing.T) {
 	// GC that fails while dropping the journal file. Either indicates the store
 	// was corrupted by an interrupted GC finalize, so we fail the test.
 	//
-	// A hard process crash (e.g. the FatalBehaviorCrash panic that used to fire
-	// from dropJournalWriter) makes the process exit non-zero, which is caught
-	// separately by asserting on the Restart/GracefulStop error, so we do not
-	// scan for it here.
+	// A hard crash of the process makes it exit non-zero. On a graceful restart
+	// that is caught by the Restart/GracefulStop error; on a SIGKILL restart the
+	// process is expected to exit non-zero, so there we rely on the next process
+	// failing to come up (and on this scan) instead.
 	var sawCorruption atomic.Bool
 	var corruptionLine atomic.Value
 	corruptionLine.Store("")
@@ -225,28 +226,49 @@ func (gct gcShutdownPanicTest) run(t *testing.T) {
 		return nil
 	})
 
-	// Main loop: periodically restart the server. Restart() gracefully stops
-	// the currently running process (SIGTERM + wait) and returns the error from
-	// cmd.Wait() on that process. A clean shutdown exits 0 (nil error); a panic
-	// on the way down exits non-zero and shows up here.
+	// Main loop: periodically restart the server. The first two restarts are
+	// forced abrupt then graceful so both are exercised even in a very short
+	// run; the rest are random, interleaving the two shutdown kinds.
 	restarts := 0
+	var gracefulRestarts, abruptRestarts int
 	start := time.Now()
 	for time.Since(start) < gct.duration {
 		gct.sleepJitter(egCtx)
 		if egCtx.Err() != nil {
 			break
 		}
-		err := server.Restart(nil, nil)
+		var abrupt bool
+		switch restarts {
+		case 0:
+			abrupt = true
+		case 1:
+			abrupt = false
+		default:
+			abrupt = rand.IntN(2) == 0
+		}
 		restarts++
-		require.NoErrorf(t, err, "server exited non-zero across restart #%d (corruption log line: %q)",
-			restarts, corruptionLine.Load())
+		if abrupt {
+			abruptRestarts++
+			err := server.KillRestart(nil, nil)
+			require.NoErrorf(t, err, "server crashed before SIGKILL or failed to restart after abrupt shutdown #%d (corruption log line: %q)",
+				restarts, corruptionLine.Load())
+		} else {
+			gracefulRestarts++
+			err := server.Restart(nil, nil)
+			require.NoErrorf(t, err, "server exited non-zero across graceful restart #%d (corruption log line: %q)",
+				restarts, corruptionLine.Load())
+		}
 		require.Falsef(t, sawCorruption.Load(), "server logged store corruption across restart #%d: %q",
 			restarts, corruptionLine.Load())
-		// Wait for the freshly-started process to come up before doing anything
-		// else, so that it has installed its signal handler and a subsequent
-		// SIGTERM exercises a graceful shutdown rather than hard-killing a
-		// still-booting process.
-		gct.waitReady(egCtx, dbs[gct.dbNames()[0]])
+		// The freshly-started process must load the store and come up; if it
+		// cannot, an interrupted GC left the store inconsistent. Waiting also
+		// ensures the new process has installed its signal handler before a
+		// subsequent SIGTERM.
+		ready := gct.waitReady(egCtx, dbs[gct.dbNames()[0]])
+		if egCtx.Err() == nil {
+			require.Truef(t, ready, "server did not become ready after restart #%d (%s shutdown); corruption log line: %q",
+				restarts, shutdownKind(abrupt), corruptionLine.Load())
+		}
 	}
 
 	// Stop the workload and drain the goroutines before the final shutdown so
@@ -267,7 +289,8 @@ func (gct gcShutdownPanicTest) run(t *testing.T) {
 		t.Logf("note: server logged %d recovered per-query panic(s) during the run (first: %q)",
 			n, firstRecoveredPanic.Load())
 	}
-	t.Logf("completed %d restarts over %v with no shutdown corruption", restarts, time.Since(start).Round(time.Millisecond))
+	t.Logf("completed %d restarts (%d graceful, %d abrupt/SIGKILL) over %v with no shutdown corruption",
+		restarts, gracefulRestarts, abruptRestarts, time.Since(start).Round(time.Millisecond))
 }
 
 func (gct gcShutdownPanicTest) createTable(t *testing.T, db *sql.DB) {
@@ -318,22 +341,34 @@ func (gct gcShutdownPanicTest) gcOnce(ctx context.Context, db *sql.DB) {
 	_, _ = conn.ExecContext(ctx, "call dolt_gc()")
 }
 
-// waitReady pings db until the server responds or ctx is cancelled, so callers
-// can be sure a just-(re)started server is fully up.
-func (gct gcShutdownPanicTest) waitReady(ctx context.Context, db *sql.DB) {
-	for i := 0; i < 200 && ctx.Err() == nil; i++ {
+// waitReady pings db until the server responds, ctx is cancelled, or the
+// deadline elapses, reporting whether the server became ready. A just-started
+// server that never loads its store gets flagged; the deadline is generous
+// because journal recovery after a SIGKILL (and a loaded CI host) take time.
+func (gct gcShutdownPanicTest) waitReady(ctx context.Context, db *sql.DB) bool {
+	deadline := time.Now().Add(30 * time.Second)
+	for ctx.Err() == nil && time.Now().Before(deadline) {
 		pingCtx, cancel := context.WithTimeout(ctx, time.Second)
 		err := db.PingContext(pingCtx)
 		cancel()
 		if err == nil {
-			return
+			return true
 		}
 		select {
 		case <-ctx.Done():
-			return
+			return false
 		case <-time.After(25 * time.Millisecond):
 		}
 	}
+	return false
+}
+
+// shutdownKind labels a restart's shutdown type for diagnostics.
+func shutdownKind(abrupt bool) string {
+	if abrupt {
+		return "abrupt/SIGKILL"
+	}
+	return "graceful/SIGTERM"
 }
 
 func (gct gcShutdownPanicTest) sleepJitter(ctx context.Context) {


### PR DESCRIPTION
When PruneTableFiles runs, it is willing to delete the journal file if there is no longer a reference to it in the manifest. This can race with bootstrapJournal making a new journal file. The journal file can be on disk, and seen by PruneTableFiles and thus selected for removal, before the journal has been added to the chunk store proper.

This change makes the journal writer participate in the retained files machinery, same as the table file persister, so that the journal is correctly considered not-safe-for-delete-by-PruneTableFiles before it is ever created on disk and potentially selected for deletion by PruneTableFiles.