### PR TITLE
go: sqle/cluster: Improve dolt_cluster_ack_writes_timeout_secs circuit breaker behavior.

### DIFF
--- a/go/libraries/doltcore/sqle/cluster/commithook.go
+++ b/go/libraries/doltcore/sqle/cluster/commithook.go
@@ -76,6 +76,20 @@ type commithook struct {
 	// actually indicated we are caught up. This is set to by a call to
 	// NotifyWaitFailed(), an optional interface on CommitHook.
 	fastFailReplicationWait bool
+
+	// Circuit breaker probe scheduling. While fastFailReplicationWait is
+	// true, most commits fast-fail their replication wait. Periodically we
+	// let one commit through as a real wait (a "probe"); if it replicates
+	// within the ack timeout, we close the breaker. nextProbeAt is the
+	// earliest time the next probe may be issued. probeBudget is the most
+	// recently observed replication-wait timeout. We learn it by observation
+	// so that we appropriately space probes without needing to plumb the
+	// dolt_cluster_ack_writes_timeout_secs sysvar into the hook.
+	nextProbeAt time.Time
+	probeBudget time.Duration
+	// nowFunc returns the current time. It is time.Now in production and is
+	// overridable in tests to make probe scheduling deterministic.
+	nowFunc func() time.Time
 }
 
 var errDestDBRootHashMoved error = errors.New("cluster/commithook: standby replication: destination database root hash moved during our write, while it is assumed we are the only writer.")
@@ -94,6 +108,7 @@ func newCommitHook(lgr *logrus.Logger, remotename, remoteurl, dbname string, rol
 	ret.destDBF = destDBF
 	ret.srcDB = srcDB
 	ret.tempDir = tempDir
+	ret.nowFunc = time.Now
 	ret.cond = sync.NewCond(&ret.mu)
 	return &ret
 }
@@ -453,6 +468,8 @@ func (h *commithook) setRole(role Role) {
 	h.lastPushedHead = hash.Hash{}
 	h.lastSuccess = time.Time{}
 	h.nextPushAttempt = time.Time{}
+	h.nextProbeAt = time.Time{}
+	h.probeBudget = 0
 	h.role = role
 	h.lgr.Store(h.rootLgr.WithField(logFieldRole, string(role)))
 	if h.cancelReplicate != nil {
@@ -506,12 +523,50 @@ func (h *commithook) Execute(ctx context.Context, ds datas.Dataset, db *doltdb.D
 	}
 	var waitF func(context.Context) error
 	if !h.isCaughtUp() {
-		if h.fastFailReplicationWait {
+		now := h.nowFunc()
+		if h.fastFailReplicationWait && now.Before(h.nextProbeAt) {
+			// The breaker is open and it is not yet time to probe;
+			// fast-fail this commit's replication wait.
 			waitF = func(ctx context.Context) error {
 				return fmt.Errorf("circuit breaker for replication to %s/%s is open. this commit did not necessarily replicate successfully.", h.remotename, h.dbname)
 			}
 		} else {
-			waitF = h.progressNotifier.Wait()
+			// Either the breaker is closed and this is a normal
+			// replication wait, or the breaker is open and this commit
+			// is our periodic probe. In both cases we block on real
+			// replication progress.
+			//
+			// If we are probing, push nextProbeAt out now, before we
+			// release h.mu, so that a burst of commits arriving at the
+			// probe boundary do not all become probes. The wait closure
+			// refines nextProbeAt when it completes.
+			probing := h.fastFailReplicationWait
+			if probing {
+				h.nextProbeAt = now.Add(h.probeBudget)
+			}
+			start := now
+			inner := h.progressNotifier.Wait()
+			waitF = func(ctx context.Context) error {
+				err := inner(ctx)
+				h.mu.Lock()
+				defer h.mu.Unlock()
+				if err == nil {
+					// Replication made progress within the ack
+					// timeout. If this was a probe, close the
+					// breaker.
+					if probing {
+						h.fastFailReplicationWait = false
+					}
+				} else if errors.Is(err, doltdb.ErrReplicationWaitFailed) {
+					// We waited the full ack timeout without seeing
+					// progress. Learn that budget by observation and
+					// use it to schedule the next probe.
+					end := h.nowFunc()
+					h.probeBudget = end.Sub(start)
+					h.nextProbeAt = end.Add(h.probeBudget)
+				}
+				return err
+			}
 		}
 	}
 	return waitF, nil

--- a/go/libraries/doltcore/sqle/cluster/commithook_test.go
+++ b/go/libraries/doltcore/sqle/cluster/commithook_test.go
@@ -16,13 +16,16 @@ package cluster
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/dtestutils"
+	"github.com/dolthub/dolt/go/store/datas"
 )
 
 func TestCommitHookStartsNotCaughtUp(t *testing.T) {
@@ -41,4 +44,148 @@ func TestCommitHookStartsNotCaughtUp(t *testing.T) {
 	}, srcEnv.DoltDB(ctx), t.TempDir())
 
 	require.False(t, hook.isCaughtUp())
+}
+
+// fakeClock is a manually-advanced clock used to make the commithook's probe
+// scheduling deterministic in tests. It is safe for concurrent use because the
+// wait closure reads it from a separate goroutine.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) set(t time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+// failWait deterministically simulates a replication wait that times out after
+// the ack timeout: it runs waitF, advances the clock by budget, then cancels
+// the context with doltdb.ErrReplicationWaitFailed exactly as the ack-writes
+// machinery does. The clock is advanced before the cancel, and the closure only
+// reads its end time after the context is canceled, so the observed budget is
+// deterministic.
+func failWait(c *fakeClock, waitF func(context.Context) error, budget time.Duration) error {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	errc := make(chan error, 1)
+	go func() {
+		errc <- waitF(ctx)
+	}()
+	c.advance(budget)
+	cancel(doltdb.ErrReplicationWaitFailed)
+	return <-errc
+}
+
+// progressWait deterministically simulates a replication push completing within
+// the ack timeout: it runs waitF and delivers replication progress via the
+// progress notifier. The waiter's channel is registered synchronously in
+// Execute before waitF is run here, so RecordSuccess reliably wakes it.
+func progressWait(hook *commithook, waitF func(context.Context) error) error {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(context.Canceled)
+	errc := make(chan error, 1)
+	go func() {
+		errc <- waitF(ctx)
+	}()
+	hook.mu.Lock()
+	a := hook.progressNotifier.BeginAttempt()
+	hook.progressNotifier.RecordSuccess(a)
+	hook.mu.Unlock()
+	return <-errc
+}
+
+// TestCommitHookCircuitBreakerClosesWhileBusy proves the circuit breaker can
+// close once replication is progressing within the ack timeout, even though the
+// replication thread never fully quiesces because writes keep arriving.
+//
+// The hook is a primary that has never fully trued up its standby, so it is
+// never "caught up" for the duration of the test. We drive Execute() directly
+// and simulate replication *progress* (a completed push) without ever marking
+// ourselves caught up, modeling a continuously-written-to primary.
+//
+// Before the probe change, once the breaker opened it could only close when the
+// replication thread fully quiesced (nextHead == lastPushedHead), which never
+// happens here -- so every subsequent commit fast-failed forever and the final
+// probe assertion (require.NoError) fails. That is the red/green boundary.
+func TestCommitHookCircuitBreakerClosesWhileBusy(t *testing.T) {
+	srcEnv := dtestutils.CreateTestEnv()
+	ctx := context.Background()
+	t.Cleanup(func() { srcEnv.Close() })
+	destEnv := dtestutils.CreateTestEnv()
+	t.Cleanup(func() { destEnv.Close() })
+
+	clock := &fakeClock{t: time.Unix(1000, 0)}
+
+	hook := newCommitHook(logrus.StandardLogger(), "origin", "https://localhost:50051/mydb", "mydb", RolePrimary, func(context.Context) (*doltdb.DoltDB, error) {
+		return destEnv.DoltDB(ctx), nil
+	}, srcEnv.DoltDB(ctx), t.TempDir())
+	hook.nowFunc = clock.now
+
+	// A primary that has never pushed is not caught up, and stays that way
+	// for the whole test: we never set lastPushedHead, so we model writes
+	// that arrive faster than the standby fully trues up.
+	require.False(t, hook.isCaughtUp())
+
+	const ackBudget = 5 * time.Second
+
+	// 1. The first commit's replication wait times out. In production this is
+	//    what opens the breaker: the wait returns ErrReplicationWaitFailed and
+	//    the ack-writes machinery then calls NotifyWaitFailed().
+	waitF, err := hook.Execute(ctx, datas.Dataset{}, srcEnv.DoltDB(ctx))
+	require.NoError(t, err)
+	require.NotNil(t, waitF)
+	require.ErrorIs(t, failWait(clock, waitF, ackBudget), doltdb.ErrReplicationWaitFailed)
+	hook.NotifyWaitFailed()
+
+	hook.mu.Lock()
+	require.True(t, hook.fastFailReplicationWait)
+	probeAt := hook.nextProbeAt
+	hook.mu.Unlock()
+	// The probe was scheduled in the future, spaced by the observed budget.
+	require.True(t, probeAt.After(clock.now()))
+
+	// 2. While the breaker is open and before the next probe is due, commits
+	//    fast-fail immediately without blocking, even given a live context.
+	waitF, err = hook.Execute(ctx, datas.Dataset{}, srcEnv.DoltDB(ctx))
+	require.NoError(t, err)
+	require.NotNil(t, waitF)
+	require.Error(t, waitF(context.Background()))
+
+	// 3. Advance the clock past the scheduled probe time.
+	clock.set(probeAt.Add(time.Nanosecond))
+
+	// 4. The next commit is issued as a real probe. Replication makes progress
+	//    (a push completes) but we never mark ourselves caught up. The probe
+	//    observes that progress within the ack timeout and closes the breaker.
+	waitF, err = hook.Execute(ctx, datas.Dataset{}, srcEnv.DoltDB(ctx))
+	require.NoError(t, err)
+	require.NotNil(t, waitF)
+	require.NoError(t, progressWait(hook, waitF))
+
+	// The improvement: the breaker is closed even though we never fully
+	// quiesced.
+	require.False(t, hook.isCaughtUp())
+	hook.mu.Lock()
+	require.False(t, hook.fastFailReplicationWait)
+	hook.mu.Unlock()
+
+	// 5. With the breaker closed, subsequent commits block on real progress
+	//    again rather than fast-failing.
+	waitF, err = hook.Execute(ctx, datas.Dataset{}, srcEnv.DoltDB(ctx))
+	require.NoError(t, err)
+	require.NotNil(t, waitF)
+	require.ErrorIs(t, failWait(clock, waitF, ackBudget), doltdb.ErrReplicationWaitFailed)
 }


### PR DESCRIPTION
Previously, the circuit breaker only had an open and a closed state. It would only go from open to closed when the replication thread fully quiesced. This PR adds a half-open state, where it lets a single commit probe for replication success within the configured timeout. If that wait succeeds, the circuit breaker closes.

This lets high write throughput use cases reenable their configured replication waits even when writes arrive more requently than their typical replication delay.