### PR TITLE
gitblobstore: fix premature flush and prune of pending write that was not referenced in current manifest

### DIFF
--- a/go/store/blobstore/git_blobstore.go
+++ b/go/store/blobstore/git_blobstore.go
@@ -1455,12 +1455,34 @@ func (gbs *GitBlobstore) CheckAndPut(ctx context.Context, expectedVersion, key s
 		pending := gbs.pendingWrites
 		gbs.pendingWrites = nil
 		gbs.pendingMu.Unlock()
-		ver, err := gbs.checkAndPutWithRemoteSync(ctx, expectedVersion, key, int64(len(manifestData)), bufferedReader, msg, pending, allowedNames)
-		if err != nil && len(pending) > 0 {
-			gbs.pendingMu.Lock()
-			gbs.pendingWrites = append(pending, gbs.pendingWrites...)
-			gbs.pendingMu.Unlock()
+
+		// Only flush pending writes this manifest references; committing an
+		// unreferenced entry lets a later flush prune it while still live
+		// (dolthub/dolt#11323). Flush everything if names can't be parsed.
+		toFlush := pending
+		var deferred []pendingWrite
+		if allowedNames != nil {
+			toFlush = nil
+			for _, pw := range pending {
+				if isPathReferencedByManifest(pw.key, allowedNames) {
+					toFlush = append(toFlush, pw)
+				} else {
+					deferred = append(deferred, pw)
+				}
+			}
 		}
+
+		ver, err := gbs.checkAndPutWithRemoteSync(ctx, expectedVersion, key, int64(len(manifestData)), bufferedReader, msg, toFlush, allowedNames)
+
+		// On failure, re-queue everything we drained; on success, keep the
+		// deferred (unreferenced) writes pending.
+		gbs.pendingMu.Lock()
+		if err != nil {
+			gbs.pendingWrites = append(pending, gbs.pendingWrites...)
+		} else if len(deferred) > 0 {
+			gbs.pendingWrites = append(deferred, gbs.pendingWrites...)
+		}
+		gbs.pendingMu.Unlock()
 		return ver, err
 	}
 

--- a/go/store/blobstore/git_blobstore.go
+++ b/go/store/blobstore/git_blobstore.go
@@ -1457,8 +1457,8 @@ func (gbs *GitBlobstore) CheckAndPut(ctx context.Context, expectedVersion, key s
 		gbs.pendingMu.Unlock()
 
 		// Only flush pending writes this manifest references; committing an
-		// unreferenced entry lets a later flush prune it while still live
-		// (dolthub/dolt#11323). Flush everything if names can't be parsed.
+		// unreferenced entry lets a later flush prune it while still live.
+		// Flush everything if names can't be parsed.
 		toFlush := pending
 		var deferred []pendingWrite
 		if allowedNames != nil {

--- a/go/store/blobstore/git_blobstore_deferred_write_eviction_test.go
+++ b/go/store/blobstore/git_blobstore_deferred_write_eviction_test.go
@@ -17,6 +17,7 @@ package blobstore
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,6 +25,24 @@ import (
 	git "github.com/dolthub/dolt/go/store/blobstore/internal/git"
 	"github.com/dolthub/dolt/go/store/testutils/gitrepo"
 )
+
+// remoteTreePaths returns the full recursive list of blob/tree paths committed
+// at DoltDataRef in the bare repo at |gitDir|.
+func remoteTreePaths(ctx context.Context, t *testing.T, gitDir string) []string {
+	t.Helper()
+	runner, err := git.NewRunner(gitDir)
+	require.NoError(t, err)
+	api := git.NewGitAPIImpl(runner)
+	commit, err := api.ResolveRefCommit(ctx, DoltDataRef)
+	require.NoError(t, err)
+	entries, err := api.ListTreeRecursive(ctx, commit)
+	require.NoError(t, err)
+	paths := make([]string, len(entries))
+	for i, e := range entries {
+		paths[i] = e.Name
+	}
+	return paths
+}
 
 // A deferred (not-yet-manifested) table file must survive the post-flush cache
 // eviction in remoteManagedWrite.
@@ -79,6 +98,16 @@ func TestGitBlobstore_PostFlushEviction_RacesDeferredWrite(t *testing.T) {
 	m2 := []byte("5:__DOLT__:lock2:root2:gc2:A:10")
 	_, err = bs.CheckAndPut(ctx, ver1, "manifest", int64(len(m2)), bytes.NewReader(m2))
 	require.NoError(t, err)
+
+	// The manifests only ever referenced A, so only A (and the manifest) should
+	// have been committed to the remote. B must be absent from the remote tree:
+	// it stayed pending locally and was never pushed.
+	remoteEntries := remoteTreePaths(ctx, t, remoteRepo.GitDir)
+	require.Contains(t, remoteEntries, "A.darc/0001", "referenced write A should be committed to the remote")
+	for _, name := range remoteEntries {
+		require.NotEqual(t, "B.darc", name, "deferred write B must not be committed to the remote")
+		require.False(t, strings.HasPrefix(name, "B.darc/"), "deferred write B (%q) must not be committed to the remote", name)
+	}
 
 	// B was never committed, so it stays pending and cached and remains readable.
 	// Pre-fix it had been committed then pruned+evicted, failing with

--- a/go/store/blobstore/git_blobstore_deferred_write_eviction_test.go
+++ b/go/store/blobstore/git_blobstore_deferred_write_eviction_test.go
@@ -78,10 +78,10 @@ func TestGitBlobstore_PostFlushEviction_RacesDeferredWrite(t *testing.T) {
 	_, err = bs.CheckAndPut(ctx, ver1, "manifest", int64(len(m2)), bytes.NewReader(m2))
 	require.NoError(t, err)
 
-	// The bug: B.darc is still tracked in cacheObjects as a tree, but its
-	// cacheChildren list was deleted by the eviction loop, so the read fails.
+	// B is unreferenced but never committed, so it stays pending and cached.
+	// Before the fix it was committed then pruned+evicted, failing with
+	// "Blob not found: B.darc".
 	got, _, err = GetBytes(ctx, bs, "B.darc", AllRange)
-	t.Logf("Get(B.darc) after second flush: err=%v", err)
 	require.NoError(t, err, "issue 11323: live table file evicted mid-flight -> Blob not found")
 	require.Equal(t, []byte("bbbbbbbbbb"), got)
 }

--- a/go/store/blobstore/git_blobstore_deferred_write_eviction_test.go
+++ b/go/store/blobstore/git_blobstore_deferred_write_eviction_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstore
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	git "github.com/dolthub/dolt/go/store/blobstore/internal/git"
+	"github.com/dolthub/dolt/go/store/testutils/gitrepo"
+)
+
+// A deferred (not-yet-manifested) table file must survive the post-flush cache
+// eviction in remoteManagedWrite. Regression test for dolthub/dolt#11323.
+func TestGitBlobstore_PostFlushEviction_RacesDeferredWrite(t *testing.T) {
+	requireGitOnPath(t)
+	ctx := context.Background()
+
+	remoteRepo, err := gitrepo.InitBare(ctx, t.TempDir()+"/remote.git")
+	require.NoError(t, err)
+	_, err = remoteRepo.SetRefToTree(ctx, DoltDataRef, nil, "seed empty")
+	require.NoError(t, err)
+
+	localRepo, err := gitrepo.InitBare(ctx, t.TempDir()+"/local.git")
+	require.NoError(t, err)
+	localRunner, err := git.NewRunner(localRepo.GitDir)
+	require.NoError(t, err)
+	_, err = localRunner.Run(ctx, git.RunOptions{}, "remote", "add", "origin", remoteRepo.GitDir)
+	require.NoError(t, err)
+
+	// MaxPartSize forces the chunked-tree representation for table files, matching
+	// the ".darc" archives in the report (stored as <key>/0001, <key>/0002, ...).
+	bs, err := NewGitBlobstoreWithOptions(localRepo.GitDir, DoltDataRef, GitBlobstoreOptions{
+		RemoteName:  "origin",
+		Identity:    testIdentity(),
+		MaxPartSize: 3,
+	})
+	require.NoError(t, err)
+
+	// Upload two chunked table files as deferred writes (like WriteTableFile).
+	_, err = bs.Put(ctx, "A.darc", 10, bytes.NewReader([]byte("aaaaaaaaaa")))
+	require.NoError(t, err)
+	_, err = bs.Put(ctx, "B.darc", 10, bytes.NewReader([]byte("bbbbbbbbbb")))
+	require.NoError(t, err)
+
+	// Sanity: B is readable from cache before any manifest flush.
+	got, _, err := GetBytes(ctx, bs, "B.darc", AllRange)
+	require.NoError(t, err)
+	require.Equal(t, []byte("bbbbbbbbbb"), got)
+
+	// First manifest flush references only A (the "window": B uploaded, not yet
+	// manifested). Both deferred writes land in the tree, so B is now unreferenced.
+	m1 := []byte("5:__DOLT__:lock1:root1:gc1:A:10")
+	_, err = bs.CheckAndPut(ctx, "", "manifest", int64(len(m1)), bytes.NewReader(m1))
+	require.NoError(t, err)
+
+	_, ver1, err := GetBytes(ctx, bs, "manifest", AllRange)
+	require.NoError(t, err)
+
+	// Second manifest flush still references only A. Now B exists in the parent
+	// tree and is unreferenced -> pruned -> orphan commit -> post-flush eviction.
+	m2 := []byte("5:__DOLT__:lock2:root2:gc2:A:10")
+	_, err = bs.CheckAndPut(ctx, ver1, "manifest", int64(len(m2)), bytes.NewReader(m2))
+	require.NoError(t, err)
+
+	// The bug: B.darc is still tracked in cacheObjects as a tree, but its
+	// cacheChildren list was deleted by the eviction loop, so the read fails.
+	got, _, err = GetBytes(ctx, bs, "B.darc", AllRange)
+	t.Logf("Get(B.darc) after second flush: err=%v", err)
+	require.NoError(t, err, "issue 11323: live table file evicted mid-flight -> Blob not found")
+	require.Equal(t, []byte("bbbbbbbbbb"), got)
+}

--- a/go/store/blobstore/git_blobstore_deferred_write_eviction_test.go
+++ b/go/store/blobstore/git_blobstore_deferred_write_eviction_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 // A deferred (not-yet-manifested) table file must survive the post-flush cache
-// eviction in remoteManagedWrite. Regression test for dolthub/dolt#11323.
+// eviction in remoteManagedWrite.
 func TestGitBlobstore_PostFlushEviction_RacesDeferredWrite(t *testing.T) {
 	requireGitOnPath(t)
 	ctx := context.Background()
@@ -82,6 +82,6 @@ func TestGitBlobstore_PostFlushEviction_RacesDeferredWrite(t *testing.T) {
 	// Before the fix it was committed then pruned+evicted, failing with
 	// "Blob not found: B.darc".
 	got, _, err = GetBytes(ctx, bs, "B.darc", AllRange)
-	require.NoError(t, err, "issue 11323: live table file evicted mid-flight -> Blob not found")
+	require.NoError(t, err, "live table file evicted mid-flight -> Blob not found")
 	require.Equal(t, []byte("bbbbbbbbbb"), got)
 }

--- a/go/store/blobstore/git_blobstore_deferred_write_eviction_test.go
+++ b/go/store/blobstore/git_blobstore_deferred_write_eviction_test.go
@@ -64,7 +64,8 @@ func TestGitBlobstore_PostFlushEviction_RacesDeferredWrite(t *testing.T) {
 	require.Equal(t, []byte("bbbbbbbbbb"), got)
 
 	// First manifest flush references only A (the "window": B uploaded, not yet
-	// manifested). Both deferred writes land in the tree, so B is now unreferenced.
+	// manifested). With the fix, B stays pending and is not committed to the tree.
+	// Pre-fix, B was flushed into the tree here as an unreferenced entry.
 	m1 := []byte("5:__DOLT__:lock1:root1:gc1:A:10")
 	_, err = bs.CheckAndPut(ctx, "", "manifest", int64(len(m1)), bytes.NewReader(m1))
 	require.NoError(t, err)
@@ -72,14 +73,15 @@ func TestGitBlobstore_PostFlushEviction_RacesDeferredWrite(t *testing.T) {
 	_, ver1, err := GetBytes(ctx, bs, "manifest", AllRange)
 	require.NoError(t, err)
 
-	// Second manifest flush still references only A. Now B exists in the parent
-	// tree and is unreferenced -> pruned -> orphan commit -> post-flush eviction.
+	// Second manifest flush still references only A. Pre-fix, B now existed in the
+	// parent tree unreferenced, so this flush pruned it -> orphan commit ->
+	// post-flush eviction of B from the cache. With the fix there is nothing to prune.
 	m2 := []byte("5:__DOLT__:lock2:root2:gc2:A:10")
 	_, err = bs.CheckAndPut(ctx, ver1, "manifest", int64(len(m2)), bytes.NewReader(m2))
 	require.NoError(t, err)
 
-	// B is unreferenced but never committed, so it stays pending and cached.
-	// Before the fix it was committed then pruned+evicted, failing with
+	// B was never committed, so it stays pending and cached and remains readable.
+	// Pre-fix it had been committed then pruned+evicted, failing with
 	// "Blob not found: B.darc".
 	got, _, err = GetBytes(ctx, bs, "B.darc", AllRange)
 	require.NoError(t, err, "live table file evicted mid-flight -> Blob not found")


### PR DESCRIPTION
CheckAndPut("manifest") flushed all queued pendingWrites into the commit, regardless of whether the manifest being written referenced them. That commits a table file into the git tree as an unreferenced entry, which a later manifest flush then legitimately prunes and evicts from the in-memory cache — while the file is still live (about to be added, or being re-read by addTableFiles' refCheckAllSources retry loop). The result is Blob not found. Stale pendingWrites from earlier failed pushes in the same process keep the condition sticky, which is why a restart clears it.

This PR only flushes the pending writes the manifest actually references. Unreferenced writes stay pending until a manifest that references them is written, so they're committed and referenced atomically. After this change a live table file is always either pending and cached (not in the tree, so unprunable) or committed and referenced (never pruned) — an unreferenced tree entry can no longer coexist with being live.