### PR TITLE
Add support for functional indexes with multiple expressions

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/dolthub/dolt-mcp v0.3.4
 	github.com/dolthub/eventsapi_schema v0.0.0-20260715220557-d9b4a1c6b4d4
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-mysql-server v0.20.1-0.20260717195005-e77c2d65f1a5
+	github.com/dolthub/go-mysql-server v0.20.1-0.20260720211949-c55c1854f305
 	github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63
 	github.com/edsrzf/mmap-go v1.2.0
 	github.com/esote/minmaxheap v1.0.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -216,6 +216,8 @@ github.com/dolthub/go-icu-regex v0.0.0-20260610153742-72563bc7ca83 h1:FEMjCGEroD
 github.com/dolthub/go-icu-regex v0.0.0-20260610153742-72563bc7ca83/go.mod h1:F3cnm+vMRK1HaU6+rNqQrOCyR03HHhR1GWG2gnPOqaE=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260717195005-e77c2d65f1a5 h1:4kF8QNxodC25HuY+XpcMyv1aQ9bngSlQxCO7SPK9oo4=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260717195005-e77c2d65f1a5/go.mod h1:AnD2jKQZCf09sM2JhV/cTEtsoEhPNg6pVWjRCBox4Zw=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260720211949-c55c1854f305 h1:+o6o1sBHwyHZuRWQlrMpKCG0TnafUzrpIe4ptc466ug=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260720211949-c55c1854f305/go.mod h1:AnD2jKQZCf09sM2JhV/cTEtsoEhPNg6pVWjRCBox4Zw=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20260414231531-5f031e3e9037 h1:oIW9HwuWrhxv+4HZxA+QQSKHLqWFyXZ2FmNjUYwkdiM=

--- a/go/libraries/doltcore/sqle/index/multi_expr_index_test.go
+++ b/go/libraries/doltcore/sqle/index/multi_expr_index_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index_test
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/dtestutils"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/index"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlutil"
+)
+
+// findDoltIndex returns the DoltIndex with the given ID among indexes, or nil if not found.
+func findDoltIndex(indexes []sql.Index, id string) index.DoltIndex {
+	for _, i := range indexes {
+		if i.ID() == id {
+			return i.(index.DoltIndex)
+		}
+	}
+	return nil
+}
+
+// TestDoltIndexMultipleFunctionalExpressions verifies that Dolt's real storage stack (secondary key
+// building on write, and index-backed lookups on read) correctly supports a single index containing
+// more than one functional expression mixed with a plain column reference.
+func TestDoltIndexMultipleFunctionalExpressions(t *testing.T) {
+	ctx := context.Background()
+	dEnv := dtestutils.CreateTestEnv()
+	root, err := dEnv.WorkingRoot(ctx)
+	require.NoError(t, err)
+
+	root, err = sqle.ExecuteSql(ctx, dEnv, `
+CREATE TABLE multiexpr (
+  pk BIGINT PRIMARY KEY,
+  c1 BIGINT,
+  c2 BIGINT,
+  c3 BIGINT
+);
+CREATE INDEX idx1 ON multiexpr ((c1 * 10), c2, (c3 * 10));
+INSERT INTO multiexpr VALUES
+  (1, 1, 2, 3),
+  (2, 4, 5, 6),
+  (3, 1, 2, 30);
+`)
+	require.NoError(t, err)
+
+	tbl, ok, err := root.GetTable(ctx, doltdb.TableName{Name: "multiexpr"})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	indexes, err := index.DoltIndexesFromTable(ctx, "dolt", "multiexpr", tbl)
+	require.NoError(t, err)
+
+	idx := findDoltIndex(indexes, "idx1")
+	require.NotNil(t, idx, "expected to find idx1 among the table's indexes")
+
+	// idx1 has three key parts: (c1*10), c2, (c3*10). Confirm all three are present and query each
+	// combination of values to confirm the secondary index was built correctly from the mix of
+	// virtual (expression-backed) and stored (plain column) fields.
+	sqlCtx := sql.NewEmptyContext()
+	exprs := idx.Expressions()
+	require.Len(t, exprs, 3)
+
+	tests := []struct {
+		name     string
+		keys     []interface{}
+		expected []sql.Row
+	}{
+		{
+			// idx.Schema() (and thus pkSch used by RowIterForIndexLookup) includes the two hidden
+			// generated columns backing (c1*10) and (c3*10) as trailing fields; they aren't
+			// projected out at this low level, so expected rows carry two trailing nils.
+			name:     "matches first row",
+			keys:     []interface{}{int64(10), int64(2), int64(30)},
+			expected: []sql.Row{{int64(1), int64(1), int64(2), int64(3), nil, nil}},
+		},
+		{
+			name:     "matches second row",
+			keys:     []interface{}{int64(40), int64(5), int64(60)},
+			expected: []sql.Row{{int64(2), int64(4), int64(5), int64(6), nil, nil}},
+		},
+		{
+			name:     "matches third row despite sharing (c1*10, c2) with the first",
+			keys:     []interface{}{int64(10), int64(2), int64(300)},
+			expected: []sql.Row{{int64(3), int64(1), int64(2), int64(30), nil, nil}},
+		},
+		{
+			name:     "no match when only a prefix of the key parts matches",
+			keys:     []interface{}{int64(10), int64(2), int64(999)},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := sql.NewMySQLIndexBuilder(sqlCtx, idx)
+			for i, key := range tt.keys {
+				builder = builder.Equals(sqlCtx, exprs[i], nil, key)
+			}
+			indexLookup, err := builder.Build(sqlCtx)
+			require.NoError(t, err)
+
+			pkSch, err := sqlutil.FromDoltSchema(sqlCtx, "", "multiexpr", idx.Schema())
+			require.NoError(t, err)
+
+			indexIter, err := index.RowIterForIndexLookup(sqlCtx, NoCacheTableable{tbl}, indexLookup, pkSch, nil)
+			require.NoError(t, err)
+
+			var readRows []sql.Row
+			for {
+				row, err := indexIter.Next(sqlCtx)
+				if err == io.EOF {
+					break
+				}
+				require.NoError(t, err)
+				readRows = append(readRows, row)
+			}
+
+			require.ElementsMatch(t, tt.expected, readRows)
+		})
+	}
+}
+
+// TestDoltIndexMultipleFunctionalExpressionsDropOnlyTargetedIndex verifies that dropping one
+// multi-expression functional index removes only its own hidden columns from Dolt's schema and
+// leaves a second, unrelated functional index on the same table fully intact and queryable.
+func TestDoltIndexMultipleFunctionalExpressionsDropOnlyTargetedIndex(t *testing.T) {
+	ctx := context.Background()
+	dEnv := dtestutils.CreateTestEnv()
+	root, err := dEnv.WorkingRoot(ctx)
+	require.NoError(t, err)
+
+	root, err = sqle.ExecuteSql(ctx, dEnv, `
+CREATE TABLE multiexpr2 (
+  pk BIGINT PRIMARY KEY,
+  c1 BIGINT,
+  c2 BIGINT,
+  c3 BIGINT
+);
+CREATE INDEX idx2 ON multiexpr2 ((c2 * 100));
+CREATE INDEX idx1 ON multiexpr2 ((c1 * 10), c2, (c3 * 10));
+INSERT INTO multiexpr2 VALUES (1, 10, 20, 30);
+`)
+	require.NoError(t, err)
+
+	root, err = sqle.ExecuteSql(ctx, dEnv, `DROP INDEX idx1 ON multiexpr2;`)
+	require.NoError(t, err)
+
+	tbl, ok, err := root.GetTable(ctx, doltdb.TableName{Name: "multiexpr2"})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	sch, err := tbl.GetSchema(ctx)
+	require.NoError(t, err)
+
+	// idx1's two hidden columns must be gone; idx2's single hidden column must remain.
+	var hiddenColNames []string
+	err = sch.GetAllCols().Iter(func(tag uint64, col schema.Column) (stop bool, err error) {
+		if col.Virtual {
+			hiddenColNames = append(hiddenColNames, col.Name)
+		}
+		return false, nil
+	})
+	require.NoError(t, err)
+	require.Len(t, hiddenColNames, 1, "expected only idx2's hidden column to remain: %v", hiddenColNames)
+
+	indexes, err := index.DoltIndexesFromTable(ctx, "dolt", "multiexpr2", tbl)
+	require.NoError(t, err)
+
+	idx2 := findDoltIndex(indexes, "idx2")
+	require.NotNil(t, idx2, "expected idx2 to survive dropping idx1")
+	require.Len(t, idx2.Expressions(), 1)
+}

--- a/integration-tests/bats/functional-indexes.bats
+++ b/integration-tests/bats/functional-indexes.bats
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+load $BATS_TEST_DIRNAME/helper/common.bash
+
+setup() {
+    setup_common
+}
+
+teardown() {
+    assert_feature_version
+    teardown_common
+}
+
+@test "functional-indexes: create index with multiple expressions mixed with a plain column" {
+    dolt sql <<SQL
+CREATE TABLE t (pk INT PRIMARY KEY, name VARCHAR(100), age INT, c1 INT, c2 INT);
+INSERT INTO t VALUES (1, 'alice', 30, 1, 2), (2, 'bob', 40, 3, 4);
+CREATE INDEX idx1 ON t ((UPPER(name)), age, (c1 + c2));
+SQL
+
+    run dolt sql -q "SELECT pk FROM t WHERE UPPER(name) = 'ALICE' AND age = 30 AND c1 + c2 = 3;" -r csv
+    [ "$status" -eq "0" ]
+    [[ "${lines[1]}" =~ "1" ]] || false
+
+    run dolt sql -q "SELECT pk FROM t WHERE UPPER(name) = 'BOB' AND age = 40 AND c1 + c2 = 7;" -r csv
+    [ "$status" -eq "0" ]
+    [[ "${lines[1]}" =~ "2" ]] || false
+
+    run dolt sql -q "EXPLAIN FORMAT=TREE SELECT pk FROM t WHERE UPPER(name) = 'ALICE' AND age = 30 AND c1 + c2 = 3;"
+    [ "$status" -eq "0" ]
+    [[ "$output" =~ "IndexedTableAccess(t)" ]] || false
+    [[ "$output" =~ "!hidden!idx1!0!0" ]] || false
+    [[ "$output" =~ "!hidden!idx1!2!0" ]] || false
+}
+
+@test "functional-indexes: hidden generated columns are not visible in schema output" {
+    dolt sql <<SQL
+CREATE TABLE t (pk INT PRIMARY KEY, c1 INT, c2 INT, c3 INT);
+CREATE UNIQUE INDEX idx1 ON t ((c1 * 10), c2, (c3 * 10));
+SQL
+
+    run dolt schema show t
+    [ "$status" -eq "0" ]
+    [[ "$output" =~ "UNIQUE KEY \`idx1\` (((c1 * 10)),\`c2\`,((c3 * 10)))" ]] || false
+    [[ ! "$output" =~ "!hidden!" ]] || false
+
+    run dolt sql -q "SHOW CREATE TABLE t;"
+    [ "$status" -eq "0" ]
+    [[ ! "$output" =~ "!hidden!" ]] || false
+}
+
+@test "functional-indexes: UNIQUE constraint is enforced across all expressions" {
+    dolt sql <<SQL
+CREATE TABLE t (pk INT PRIMARY KEY, c1 INT, c2 INT, c3 INT);
+CREATE UNIQUE INDEX idx1 ON t ((c1 * 10), c2, (c3 * 10));
+INSERT INTO t VALUES (1, 1, 2, 3);
+SQL
+
+    run dolt sql -q "INSERT INTO t VALUES (2, 1, 2, 3);"
+    [ "$status" -ne "0" ]
+    [[ "$output" =~ "duplicate" ]] || false
+
+    run dolt sql -q "INSERT INTO t VALUES (3, 1, 3, 3);"
+    [ "$status" -eq "0" ]
+}
+
+@test "functional-indexes: DROP INDEX removes only its own hidden columns" {
+    dolt sql <<SQL
+CREATE TABLE t (pk INT PRIMARY KEY, c1 INT, c2 INT, c3 INT);
+INSERT INTO t VALUES (1, 10, 20, 30);
+CREATE INDEX idx2 ON t ((c2 * 100));
+CREATE INDEX idx1 ON t ((c1 * 10), c2, (c3 * 10));
+SQL
+
+    run dolt sql -q "SHOW EXTENDED COLUMNS FROM t;"
+    [ "$status" -eq "0" ]
+    [[ "$output" =~ "!hidden!idx1!0!0" ]] || false
+    [[ "$output" =~ "!hidden!idx1!2!0" ]] || false
+    [[ "$output" =~ "!hidden!idx2!0!0" ]] || false
+
+    run dolt sql -q "DROP INDEX idx1 ON t;"
+    [ "$status" -eq "0" ]
+
+    run dolt sql -q "SHOW EXTENDED COLUMNS FROM t;"
+    [ "$status" -eq "0" ]
+    [[ ! "$output" =~ "!hidden!idx1!0!0" ]] || false
+    [[ ! "$output" =~ "!hidden!idx1!2!0" ]] || false
+    [[ "$output" =~ "!hidden!idx2!0!0" ]] || false
+
+    run dolt sql -q "DROP INDEX idx2 ON t;"
+    [ "$status" -eq "0" ]
+
+    run dolt sql -q "SHOW EXTENDED COLUMNS FROM t;"
+    [ "$status" -eq "0" ]
+    [[ ! "$output" =~ "!hidden!" ]] || false
+}
+
+@test "functional-indexes: DROP COLUMN blocked for columns referenced by an expression" {
+    dolt sql <<SQL
+CREATE TABLE t (pk INT PRIMARY KEY, c1 INT, c2 INT, c3 INT);
+CREATE INDEX idx1 ON t ((c1 * 10), c2, (c3 * 10));
+SQL
+
+    run dolt sql -q "ALTER TABLE t DROP COLUMN c1;"
+    [ "$status" -ne "0" ]
+    [[ "$output" =~ "functional index dependency" ]] || false
+
+    run dolt sql -q "ALTER TABLE t DROP COLUMN c3;"
+    [ "$status" -ne "0" ]
+    [[ "$output" =~ "functional index dependency" ]] || false
+}
+
+@test "functional-indexes: survives dolt commit and diff" {
+    dolt sql <<SQL
+CREATE TABLE t (pk INT PRIMARY KEY, name VARCHAR(100), age INT, c1 INT, c2 INT);
+CREATE INDEX idx1 ON t ((UPPER(name)), age, (c1 + c2));
+SQL
+    dolt add .
+    dolt commit -m "create table with multi-expression functional index"
+
+    dolt sql -q "INSERT INTO t VALUES (1, 'alice', 30, 1, 2);"
+
+    run dolt diff
+    [ "$status" -eq "0" ]
+    [[ "$output" =~ "alice" ]] || false
+
+    dolt add .
+    dolt commit -m "insert row"
+
+    run dolt sql -q "SELECT pk FROM t WHERE UPPER(name) = 'ALICE' AND age = 30 AND c1 + c2 = 3;" -r csv
+    [ "$status" -eq "0" ]
+    [[ "${lines[1]}" =~ "1" ]] || false
+}


### PR DESCRIPTION
Picks up support for functional indexes with multiple expressions from GMS (https://github.com/dolthub/go-mysql-server/pull/3634) and adds additional tests for Dolt. 

Depends on: https://github.com/dolthub/go-mysql-server/pull/3634