### PR TITLE
/go/cmd/dolt/cli: only emit backspace characters in a tty

### DIFF
--- a/go/cmd/dolt/cli/stdio.go
+++ b/go/cmd/dolt/cli/stdio.go
@@ -23,6 +23,7 @@ import (
 	"sync/atomic"
 
 	"github.com/fatih/color"
+	"github.com/mattn/go-isatty"
 	"github.com/vbauerster/mpb/v8/cwriter"
 
 	"github.com/dolthub/dolt/go/libraries/utils/iohelp"
@@ -33,6 +34,8 @@ var CliOut = colorOutput
 var CliErr = color.Error
 
 var outputClosed uint64
+
+var outputIsTerminal bool
 
 var InStream io.ReadCloser = os.Stdin
 var OutStream io.WriteCloser = os.Stdout
@@ -52,6 +55,8 @@ func SetIOStreams(inStream io.ReadCloser, outStream io.WriteCloser) {
 
 func InitIO() (restoreIO func()) {
 	stdOut, stdErr := os.Stdout, os.Stderr
+
+	outputIsTerminal = isatty.IsTerminal(stdErr.Fd()) || isatty.IsCygwinTerminal(stdErr.Fd())
 
 	f, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
 
@@ -145,6 +150,10 @@ func PrintErrf(format string, a ...interface{}) {
 func DeleteAndPrint(prevMsgLen int, msg string) int {
 	if outputIsClosed() {
 		return 0
+	}
+
+	if !outputIsTerminal {
+		return len(msg)
 	}
 
 	msgLen := len(msg)

--- a/go/cmd/dolt/cli/stdio.go
+++ b/go/cmd/dolt/cli/stdio.go
@@ -142,15 +142,6 @@ func PrintErrf(format string, a ...interface{}) {
 	fmt.Fprintf(CliErr, format, a...)
 }
 
-// DeleteAndPrint prints a new message and deletes the old one given the
-// previous messages length. It returns the length of the printed message that
-// should be passed as prevMsgLen on the next call of DeleteAndPrint.
-//
-// DeleteAndPrint does not work for multiline messages.
-// fdIsTerminal reports whether w is connected to an interactive terminal. It
-// checks w directly when it is an *os.File so that redirections which reassign
-// CliErr (e.g. --stderr <file>) are honored, and falls back to fallback (the
-// real stderr) when w is not a file, such as the colorable wrapper on Windows.
 func fdIsTerminal(w io.Writer, fallback *os.File) bool {
 	f, ok := w.(*os.File)
 	if !ok {
@@ -159,12 +150,18 @@ func fdIsTerminal(w io.Writer, fallback *os.File) bool {
 	return isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
 }
 
+// DeleteAndPrint prints a new message and deletes the old one given the
+// previous messages length. It returns the length of the printed message that
+// should be passed as prevMsgLen on the next call of DeleteAndPrint.
+//
+// DeleteAndPrint does not work for multiline messages.
 func DeleteAndPrint(prevMsgLen int, msg string) int {
 	if outputIsClosed() {
 		return 0
 	}
 
 	if !outputIsTerminal {
+		PrintErr(msg)
 		return len(msg)
 	}
 

--- a/go/cmd/dolt/cli/stdio.go
+++ b/go/cmd/dolt/cli/stdio.go
@@ -56,7 +56,7 @@ func SetIOStreams(inStream io.ReadCloser, outStream io.WriteCloser) {
 func InitIO() (restoreIO func()) {
 	stdOut, stdErr := os.Stdout, os.Stderr
 
-	outputIsTerminal = isatty.IsTerminal(stdErr.Fd()) || isatty.IsCygwinTerminal(stdErr.Fd())
+	outputIsTerminal = fdIsTerminal(CliErr, stdErr)
 
 	f, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
 
@@ -147,6 +147,18 @@ func PrintErrf(format string, a ...interface{}) {
 // should be passed as prevMsgLen on the next call of DeleteAndPrint.
 //
 // DeleteAndPrint does not work for multiline messages.
+// fdIsTerminal reports whether w is connected to an interactive terminal. It
+// checks w directly when it is an *os.File so that redirections which reassign
+// CliErr (e.g. --stderr <file>) are honored, and falls back to fallback (the
+// real stderr) when w is not a file, such as the colorable wrapper on Windows.
+func fdIsTerminal(w io.Writer, fallback *os.File) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		f = fallback
+	}
+	return isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
+}
+
 func DeleteAndPrint(prevMsgLen int, msg string) int {
 	if outputIsClosed() {
 		return 0

--- a/go/cmd/dolt/cli/stdio_test.go
+++ b/go/cmd/dolt/cli/stdio_test.go
@@ -31,13 +31,7 @@ func TestFdIsTerminalHonorsRedirectedCliErr(t *testing.T) {
 	}
 	defer f.Close()
 
-	// A redirected CliErr (e.g. --stderr <file>) is a plain *os.File and must be
-	// detected as non-terminal so no backspaces are written into the file, even
-	// if the real stderr fallback happens to be a terminal.
 	assert.False(t, fdIsTerminal(f, os.Stdout))
-
-	// A non-*os.File writer (e.g. the colorable wrapper on Windows) falls back
-	// to the provided stderr.
 	assert.False(t, fdIsTerminal(&bytes.Buffer{}, f))
 }
 
@@ -53,9 +47,15 @@ func TestDeleteAndPrintSkipsBackspacesWhenNotATTY(t *testing.T) {
 		CliErr = &captured
 		outputIsTerminal = false
 
-		DeleteAndPrint(n, "")
+		DeleteAndPrint(n, "- Uploading...")
 
-		assert.Empty(t, captured.String(), "no bytes should be written to a non-TTY")
+		out := captured.String()
+		assert.Equal(t, "- Uploading...", out)
+		assert.NotContains(t, out, "\b", "no backspaces should be written to a non-TTY")
+
+		captured.Reset()
+		DeleteAndPrint(n, "")
+		assert.Empty(t, captured.String())
 	})
 
 	t.Run("terminal", func(t *testing.T) {

--- a/go/cmd/dolt/cli/stdio_test.go
+++ b/go/cmd/dolt/cli/stdio_test.go
@@ -17,10 +17,58 @@ package cli
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestDeleteAndPrintSkipsBackspacesWhenNotATTY(t *testing.T) {
+	oldErr, oldTerm := CliErr, outputIsTerminal
+	defer func() { CliErr, outputIsTerminal = oldErr, oldTerm }()
+
+	const prevFrame = " Uploading..."
+	n := len(prevFrame) + 1
+
+	t.Run("not a terminal", func(t *testing.T) {
+		var captured bytes.Buffer
+		CliErr = &captured
+		outputIsTerminal = false
+
+		DeleteAndPrint(n, "")
+
+		assert.Empty(t, captured.String(), "no bytes should be written to a non-TTY")
+	})
+
+	t.Run("terminal", func(t *testing.T) {
+		var captured bytes.Buffer
+		CliErr = &captured
+		outputIsTerminal = true
+
+		DeleteAndPrint(n, "")
+
+		want := strings.Repeat("\b", n) + strings.Repeat(" ", n) + strings.Repeat("\b", n)
+		assert.Equal(t, want, captured.String())
+	})
+}
+
+func TestSpinnerDoesNotCorruptCapturedErrorLog(t *testing.T) {
+	oldErr, oldTerm := CliErr, outputIsTerminal
+	defer func() { CliErr, outputIsTerminal = oldErr, oldTerm }()
+
+	var captured bytes.Buffer
+	CliErr = &captured
+	outputIsTerminal = false
+
+	const frame = " Uploading..."
+	DeleteAndPrint(0, "/"+frame)
+	PrintErr("boom: connection reset")
+	DeleteAndPrint(len("boom: connection reset"), "")
+
+	out := captured.String()
+	assert.NotContains(t, out, "\b", "no backspaces should reach a captured log")
+	assert.Contains(t, out, "boom: connection reset", "the error text must survive in the log")
+}
 
 func TestEphemeralPrinter(t *testing.T) {
 	t.Run("DisplayPutsCursorAtLineStart", func(t *testing.T) {

--- a/go/cmd/dolt/cli/stdio_test.go
+++ b/go/cmd/dolt/cli/stdio_test.go
@@ -17,11 +17,29 @@ package cli
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestFdIsTerminalHonorsRedirectedCliErr(t *testing.T) {
+	f, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	// A redirected CliErr (e.g. --stderr <file>) is a plain *os.File and must be
+	// detected as non-terminal so no backspaces are written into the file, even
+	// if the real stderr fallback happens to be a terminal.
+	assert.False(t, fdIsTerminal(f, os.Stdout))
+
+	// A non-*os.File writer (e.g. the colorable wrapper on Windows) falls back
+	// to the provided stderr.
+	assert.False(t, fdIsTerminal(&bytes.Buffer{}, f))
+}
 
 func TestDeleteAndPrintSkipsBackspacesWhenNotATTY(t *testing.T) {
 	oldErr, oldTerm := CliErr, outputIsTerminal

--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -555,8 +555,7 @@ func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string,
 		return commands.HandleVErrAndExitCode(bdr.Build(), usage)
 	}
 
-	cli.DeleteAndPrint(displayStrLen, "")
-	cli.PrintErrln(importStatsDisplay)
+	cli.PrintErrln()
 
 	if skipped > 0 {
 		cli.PrintErrln(color.YellowString("Lines skipped: %d", skipped))
@@ -567,14 +566,12 @@ func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string,
 }
 
 var displayStrLen int
-var importStatsDisplay string
 
 func importStatsCB(stats mvdata.AppliedEditStats) {
 	noEffect := stats.NonExistentDeletes + stats.SameVal
 	total := noEffect + stats.Modifications + stats.Additions
 	p := message.NewPrinter(message.MatchLanguage("en")) // adds commas
 	displayStr := p.Sprintf("Rows Processed: %d, Additions: %d, Modifications: %d, Had No Effect: %d", total, stats.Additions, stats.Modifications, noEffect)
-	importStatsDisplay = displayStr
 	displayStrLen = cli.DeleteAndPrint(displayStrLen, displayStr)
 }
 

--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -555,7 +555,8 @@ func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string,
 		return commands.HandleVErrAndExitCode(bdr.Build(), usage)
 	}
 
-	cli.PrintErrln()
+	cli.DeleteAndPrint(displayStrLen, "")
+	cli.PrintErrln(importStatsDisplay)
 
 	if skipped > 0 {
 		cli.PrintErrln(color.YellowString("Lines skipped: %d", skipped))
@@ -566,12 +567,14 @@ func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string,
 }
 
 var displayStrLen int
+var importStatsDisplay string
 
 func importStatsCB(stats mvdata.AppliedEditStats) {
 	noEffect := stats.NonExistentDeletes + stats.SameVal
 	total := noEffect + stats.Modifications + stats.Additions
 	p := message.NewPrinter(message.MatchLanguage("en")) // adds commas
 	displayStr := p.Sprintf("Rows Processed: %d, Additions: %d, Modifications: %d, Had No Effect: %d", total, stats.Additions, stats.Modifications, noEffect)
+	importStatsDisplay = displayStr
 	displayStrLen = cli.DeleteAndPrint(displayStrLen, displayStr)
 }
 


### PR DESCRIPTION
The CLI's progress spinners (dolt push, pull, fetch, assist, and import/sql progress output) redraw themselves in place by writing backspace  control characters. This was done unconditionally, with no check for whether output was going to a terminal.

When stdout/stderr is captured to a file or pipe — a script, a CI job, dolt push > push.log 2>&1 — those backspaces become literal bytes in the log instead of cursor movements. Rendering the log then "erases" the surrounding text. The worst case: an error is printed while the spinner is active, and the spinner's trailing backspaces overwrite the error text, so the captured log looks empty exactly when something went wrong.

This PR fixes this so that TTY is detected and redraw is gated on it.