### PR TITLE
Enable replication tests on MacOS

### DIFF
--- a/.github/workflows/ci-sql-server-integration-tests.yaml
+++ b/.github/workflows/ci-sql-server-integration-tests.yaml
@@ -19,9 +19,9 @@ jobs:
         shell: bash
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-22.04, macos-latest]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Go toolchain
@@ -29,5 +29,5 @@ jobs:
       - name: Build dolt
         uses: ./.github/actions/build-dolt
       - name: Test all
-        run: go test .
+        run: go test --timeout=30m .
         working-directory: ./integration-tests/go-sql-server-driver

--- a/go/libraries/doltcore/sqle/cluster/controller.go
+++ b/go/libraries/doltcore/sqle/cluster/controller.go
@@ -40,6 +40,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	expcreds "google.golang.org/grpc/experimental/credentials"
+	dnsresolver "google.golang.org/grpc/resolver/dns"
 	"google.golang.org/grpc/status"
 
 	replicationapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/replicationapi/v1alpha1"
@@ -161,10 +162,28 @@ const (
 	DoltClusterRemoteApiAudience = "dolt-cluster-remote-api.dolthub.com"
 )
 
+// grpc's dns resolver blocks RPCs on a channel until its (host + TXT
+// service-config) lookups complete, with a default cap of 30s. A degraded
+// system resolver (observed with mDNSResponder on macOS, which can stall
+// lookups of even "localhost" for 10s+) can therefore starve replication
+// waiters whose budgets are shorter than a single resolution attempt, e.g.
+// the 10s graceful-transition wait. Cap resolution well below those budgets;
+// on timeout the resolver just retries with backoff, so slow-but-working DNS
+// still succeeds on a later attempt. The setting is process-global and must
+// be applied before any ClientConn is created.
+var capDNSResolvingTimeoutOnce sync.Once
+
+func capDNSResolvingTimeout() {
+	capDNSResolvingTimeoutOnce.Do(func() {
+		dnsresolver.SetResolvingTimeout(2 * time.Second)
+	})
+}
+
 func NewController(lgr *logrus.Logger, cfg servercfg.ClusterConfig, pCfg config.ReadWriteConfig) (*Controller, error) {
 	if cfg == nil {
 		return nil, nil
 	}
+	capDNSResolvingTimeout()
 	pCfg = config.NewPrefixConfig(pCfg, PersistentConfigPrefix)
 	role, epoch, err := applyBootstrapClusterConfig(lgr, cfg, pCfg)
 	if err != nil {

--- a/go/libraries/doltcore/sqle/cluster/controller.go
+++ b/go/libraries/doltcore/sqle/cluster/controller.go
@@ -40,7 +40,6 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	expcreds "google.golang.org/grpc/experimental/credentials"
-	dnsresolver "google.golang.org/grpc/resolver/dns"
 	"google.golang.org/grpc/status"
 
 	replicationapi "github.com/dolthub/dolt/go/gen/proto/dolt/services/replicationapi/v1alpha1"
@@ -162,28 +161,10 @@ const (
 	DoltClusterRemoteApiAudience = "dolt-cluster-remote-api.dolthub.com"
 )
 
-// grpc's dns resolver blocks RPCs on a channel until its (host + TXT
-// service-config) lookups complete, with a default cap of 30s. A degraded
-// system resolver (observed with mDNSResponder on macOS, which can stall
-// lookups of even "localhost" for 10s+) can therefore starve replication
-// waiters whose budgets are shorter than a single resolution attempt, e.g.
-// the 10s graceful-transition wait. Cap resolution well below those budgets;
-// on timeout the resolver just retries with backoff, so slow-but-working DNS
-// still succeeds on a later attempt. The setting is process-global and must
-// be applied before any ClientConn is created.
-var capDNSResolvingTimeoutOnce sync.Once
-
-func capDNSResolvingTimeout() {
-	capDNSResolvingTimeoutOnce.Do(func() {
-		dnsresolver.SetResolvingTimeout(2 * time.Second)
-	})
-}
-
 func NewController(lgr *logrus.Logger, cfg servercfg.ClusterConfig, pCfg config.ReadWriteConfig) (*Controller, error) {
 	if cfg == nil {
 		return nil, nil
 	}
-	capDNSResolvingTimeout()
 	pCfg = config.NewPrefixConfig(pCfg, PersistentConfigPrefix)
 	role, epoch, err := applyBootstrapClusterConfig(lgr, cfg, pCfg)
 	if err != nil {

--- a/integration-tests/go-sql-server-driver/auto_gc_test.go
+++ b/integration-tests/go-sql-server-driver/auto_gc_test.go
@@ -170,7 +170,7 @@ listener:
 cluster:
   standby_remotes:
   - name: standby
-    remote_url_template: http://localhost:{{get_port "standby_server_cluster_port"}}/{database}
+    remote_url_template: http://127.0.0.1:{{get_port "standby_server_cluster_port"}}/{database}
   bootstrap_role: primary
   bootstrap_epoch: 1
   remotesapi:
@@ -241,7 +241,7 @@ remotesapi:
 cluster:
   standby_remotes:
   - name: primary
-    remote_url_template: http://localhost:{{get_port "primary_server_cluster_port"}}/{database}
+    remote_url_template: http://127.0.0.1:{{get_port "primary_server_cluster_port"}}/{database}
   bootstrap_role: standby
   bootstrap_epoch: 1
   remotesapi:
@@ -324,7 +324,7 @@ func (s *AutoGCTest) CreateUsersAndRemotes(ctx context.Context, t *testing.T, u 
 	require.NoError(t, err)
 	port, ok := s.Ports.GetPort("standby_remotesapi_port")
 	require.True(t, ok)
-	_, err = conn.ExecContext(ctx, fmt.Sprintf("call dolt_remote('add', 'origin', 'http://localhost:%d/auto_gc_test')", port))
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("call dolt_remote('add', 'origin', 'http://127.0.0.1:%d/auto_gc_test')", port))
 	require.NoError(t, err)
 	require.NoError(t, conn.Close())
 }

--- a/integration-tests/go-sql-server-driver/drop_database_ack_writes_test.go
+++ b/integration-tests/go-sql-server-driver/drop_database_ack_writes_test.go
@@ -57,7 +57,7 @@ listener:
 cluster:
   standby_remotes:
   - name: standby
-    remote_url_template: http://localhost:%d/{database}
+    remote_url_template: http://127.0.0.1:%d/{database}
   bootstrap_role: primary
   bootstrap_epoch: 1
   remotesapi:
@@ -72,7 +72,7 @@ listener:
 cluster:
   standby_remotes:
   - name: standby
-    remote_url_template: http://localhost:%d/{database}
+    remote_url_template: http://127.0.0.1:%d/{database}
   bootstrap_role: standby
   bootstrap_epoch: 1
   remotesapi:

--- a/integration-tests/go-sql-server-driver/drop_database_transition_test.go
+++ b/integration-tests/go-sql-server-driver/drop_database_transition_test.go
@@ -70,7 +70,7 @@ listener:
 cluster:
   standby_remotes:
   - name: standby
-    remote_url_template: http://localhost:%d/{database}
+    remote_url_template: http://127.0.0.1:%d/{database}
   bootstrap_role: primary
   bootstrap_epoch: 1
   remotesapi:
@@ -85,7 +85,7 @@ listener:
 cluster:
   standby_remotes:
   - name: standby
-    remote_url_template: http://localhost:%d/{database}
+    remote_url_template: http://127.0.0.1:%d/{database}
   bootstrap_role: standby
   bootstrap_epoch: 1
   remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster-read-only.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster-read-only.yaml
@@ -13,7 +13,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -32,7 +32,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -60,7 +60,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -79,7 +79,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -105,7 +105,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -124,7 +124,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -157,7 +157,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -176,7 +176,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster-tls.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster-tls.yaml
@@ -13,7 +13,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: https://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: https://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -41,7 +41,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: https://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: https://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -80,7 +80,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: https://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: https://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -108,7 +108,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: https://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: https://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -147,7 +147,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: https://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: https://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -176,7 +176,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: https://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: https://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -215,7 +215,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: https://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: https://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -244,7 +244,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: https://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: https://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -283,7 +283,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: https://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: https://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -311,7 +311,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: https://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: https://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -390,7 +390,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: https://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: https://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -420,7 +420,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: https://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: https://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster-users-and-grants.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster-users-and-grants.yaml
@@ -13,7 +13,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -32,7 +32,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -79,7 +79,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -98,7 +98,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -202,7 +202,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -221,7 +221,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -281,7 +281,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -300,7 +300,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -358,9 +358,9 @@ tests:
         cluster:
           standby_remotes:
           - name: standby1
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           - name: standby2
-            remote_url_template: http://localhost:{{get_port "server3_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server3_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -379,9 +379,9 @@ tests:
         cluster:
           standby_remotes:
           - name: standby1
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           - name: standby2
-            remote_url_template: http://localhost:{{get_port "server3_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server3_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -400,9 +400,9 @@ tests:
         cluster:
           standby_remotes:
           - name: standby1
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           - name: standby2
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
@@ -7,11 +7,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: standby_server.yaml
       contents: |
@@ -22,7 +22,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 10
           remotesapi:
@@ -36,7 +36,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 15
           remotesapi:
@@ -75,11 +75,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
@@ -90,7 +90,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 10
           remotesapi:
@@ -152,11 +152,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
@@ -167,7 +167,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
@@ -183,7 +183,7 @@ tests:
     - query: "select name, url from dolt_remotes"
       result:
         columns: ["name","url"]
-        rows: [["standby","http://localhost:{{get_port \"server2_cluster\"}}/a_new_database"]]
+        rows: [["standby","http://127.0.0.1:{{get_port \"server2_cluster\"}}/a_new_database"]]
 - name: primary comes up and replicates to standby
   multi_repos:
   - name: server1
@@ -191,11 +191,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
@@ -206,7 +206,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
@@ -219,11 +219,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server1_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server1_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server1_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server1_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
@@ -234,7 +234,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 10
           remotesapi:
@@ -276,11 +276,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: standby_server.yaml
       contents: |
@@ -291,7 +291,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 10
           remotesapi:
@@ -312,11 +312,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
@@ -327,7 +327,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
@@ -347,11 +347,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
@@ -362,7 +362,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
@@ -375,11 +375,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server1_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server1_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server1_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server1_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
@@ -390,7 +390,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -458,11 +458,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: standby_server.yaml
       contents: |
@@ -473,7 +473,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 10
           remotesapi:
@@ -506,11 +506,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
@@ -521,7 +521,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
@@ -534,11 +534,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server1_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server1_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server1_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server1_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
@@ -549,7 +549,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 10
           remotesapi:
@@ -583,11 +583,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
@@ -598,7 +598,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
@@ -611,11 +611,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server1_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server1_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server1_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server1_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
@@ -626,7 +626,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
@@ -662,11 +662,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: preserver.yaml
       contents: |
@@ -683,7 +683,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 15
           remotesapi:
@@ -696,11 +696,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server1_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server1_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server1_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server1_cluster"}}/repo2
     with_files:
     - name: preserver.yaml
       contents: |
@@ -717,7 +717,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
@@ -773,11 +773,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: preserver.yaml
       contents: |
@@ -794,7 +794,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
@@ -807,11 +807,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server1_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server1_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server1_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server1_cluster"}}/repo2
     with_files:
     - name: preserver.yaml
       contents: |
@@ -828,7 +828,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 15
           remotesapi:
@@ -889,11 +889,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
@@ -904,7 +904,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
@@ -933,7 +933,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -952,7 +952,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -971,9 +971,9 @@ tests:
       result:
         columns: ["caught_up", "database", "remote", "remote_url"]
         rows:
-        - ["1", "repo1", "standby", "http://localhost:{{get_port \"server2_cluster\"}}/repo1"]
-        - ["1", "mysql", "standby", "http://localhost:{{get_port \"server2_cluster\"}}"]
-        - ["1", "dolt_branch_control", "standby", "http://localhost:{{get_port \"server2_cluster\"}}"]
+        - ["1", "repo1", "standby", "http://127.0.0.1:{{get_port \"server2_cluster\"}}/repo1"]
+        - ["1", "mysql", "standby", "http://127.0.0.1:{{get_port \"server2_cluster\"}}"]
+        - ["1", "dolt_branch_control", "standby", "http://127.0.0.1:{{get_port \"server2_cluster\"}}"]
 - name: dolt_cluster_transition_to_standby too many standbys provided
   multi_repos:
   - name: server1
@@ -987,7 +987,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1006,7 +1006,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1036,7 +1036,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1055,7 +1055,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1125,7 +1125,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1144,7 +1144,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1193,7 +1193,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1212,7 +1212,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1260,7 +1260,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1279,7 +1279,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1411,7 +1411,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1443,7 +1443,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1462,7 +1462,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1515,7 +1515,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1537,7 +1537,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1590,7 +1590,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1609,7 +1609,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1678,7 +1678,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1697,7 +1697,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1747,7 +1747,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1766,7 +1766,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1846,7 +1846,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1865,7 +1865,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1907,7 +1907,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby_one
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1921,9 +1921,9 @@ tests:
         cluster:
           standby_remotes:
           - name: standby_one
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           - name: standby_two
-            remote_url_template: http://localhost:{{get_port "server3_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server3_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1942,7 +1942,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1961,7 +1961,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -2007,11 +2007,11 @@ tests:
         - name: repo1
           with_remotes:
             - name: standby
-              url: http://localhost:{{get_port "server2_cluster"}}/repo1
+              url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
         - name: repo2
           with_remotes:
             - name: standby
-              url: http://localhost:{{get_port "server2_cluster"}}/repo2
+              url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
       with_files:
         - name: server.yaml
           contents: |
@@ -2022,7 +2022,7 @@ tests:
             cluster:
               standby_remotes:
               - name: standby
-                remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+                remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
               bootstrap_role: primary
               remotesapi:
                 port: {{get_port "server1_cluster"}}
@@ -2047,7 +2047,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -2066,7 +2066,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -2118,7 +2118,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -2137,7 +2137,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -2232,7 +2232,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -2253,7 +2253,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-large-blob-replication.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-large-blob-replication.yaml
@@ -17,7 +17,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -39,7 +39,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-large-json-replication.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-large-json-replication.yaml
@@ -17,7 +17,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -39,7 +39,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-large-multi-column-replication.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-large-multi-column-replication.yaml
@@ -17,7 +17,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -39,7 +39,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-large-text-replication.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-large-text-replication.yaml
@@ -17,7 +17,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -39,7 +39,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-large-values-failover.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-large-values-failover.yaml
@@ -17,7 +17,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -39,7 +39,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-large-values-gc.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-large-values-gc.yaml
@@ -17,7 +17,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -39,7 +39,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-remotesapi.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-remotesapi.yaml
@@ -32,7 +32,7 @@ tests:
   - on: server2
     queries:
     - exec: "use repo1"
-    - exec: "call dolt_clone('http://localhost:{{get_port \"remotesapi_port\"}}/repo2')"
+    - exec: "call dolt_clone('http://127.0.0.1:{{get_port \"remotesapi_port\"}}/repo2')"
     - exec: "use repo2"
     - query: "select count(*) from vals"
       result:
@@ -60,7 +60,7 @@ tests:
     - exec: "call dolt_commit('-Am', 'insert some data')"
   - on: server1
     queries:
-    - exec: "call dolt_clone('http://localhost:{{get_port \"remotesapi_port\"}}/repo2', 'repo2_clone')"
+    - exec: "call dolt_clone('http://127.0.0.1:{{get_port \"remotesapi_port\"}}/repo2', 'repo2_clone')"
     - exec: "use repo2_clone"
     - query: "select count(*) from vals"
       result:
@@ -104,7 +104,7 @@ tests:
   - on: server2
     queries:
     - exec: "use repo1"
-    - exec: "call dolt_clone('http://localhost:{{get_port \"remotesapi_port\"}}/repo2')"
+    - exec: "call dolt_clone('http://127.0.0.1:{{get_port \"remotesapi_port\"}}/repo2')"
     - exec: "use repo2"
     - query: "select count(*) from vals"
       result:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-type-diversity.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-type-diversity.yaml
@@ -17,7 +17,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -39,7 +39,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-wide-int-table.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-wide-int-table.yaml
@@ -17,7 +17,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -39,7 +39,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-wide-table-failover.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-wide-table-failover.yaml
@@ -17,7 +17,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -39,7 +39,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-wide-text-table.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-wide-text-table.yaml
@@ -17,7 +17,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -39,7 +39,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-wide-varchar-table.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-wide-varchar-table.yaml
@@ -17,7 +17,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -39,7 +39,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:


### PR DESCRIPTION
DNS lookups on GitHub MacOS runners are very slow, which makes some of these test expectations fail. `localhost` resolves through DNS on MacOS but not on Ubuntu, which doesn't have this problem. This PR changes all `localhost` definitions in the test to the loopback address instead.