### PR TITLE
Add dolt_squash_history procedure

### DIFF
--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -168,6 +168,13 @@ func CreateResetArgParser() *argparser.ArgParser {
 	return ap
 }
 
+func CreateSquashHistoryArgParser() *argparser.ArgParser {
+	ap := argparser.NewArgParserWithMaxArgs("squash-history", 0)
+	ap.SupportsString(MessageArg, "m", "msg", "Use the given {{.LessThan}}msg{{.GreaterThan}} as the commit message for the squashed commit.")
+	ap.SupportsString(FirstParam, "", "commit", "The oldest commit to include in the squash. Everything from {{.LessThan}}commit{{.GreaterThan}} through HEAD is collapsed into a single commit. Defaults to the initial commit's child.")
+	return ap
+}
+
 func CreateRemoteArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParserWithVariableArgs("remote")
 	ap.SupportsString("ref", "", "ref", "Git ref to use as the Dolt data ref for git remotes (default: refs/dolt/data).")

--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -171,7 +171,7 @@ func CreateResetArgParser() *argparser.ArgParser {
 func CreateSquashHistoryArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParserWithMaxArgs("squash-history", 0)
 	ap.SupportsString(MessageArg, "m", "msg", "Use the given {{.LessThan}}msg{{.GreaterThan}} as the commit message for the squashed commit.")
-	ap.SupportsString(FirstParam, "", "commit", "The oldest commit to include in the squash. Everything from {{.LessThan}}commit{{.GreaterThan}} through HEAD is collapsed into a single commit. Defaults to the initial commit's child.")
+	ap.SupportsString(FirstParam, "f", "commit", "The oldest commit to include in the squash. Everything from {{.LessThan}}commit{{.GreaterThan}} through HEAD is collapsed into a single commit. Defaults to the initial commit's child.")
 	return ap
 }
 

--- a/go/cmd/dolt/cli/flags.go
+++ b/go/cmd/dolt/cli/flags.go
@@ -38,6 +38,7 @@ const (
 	DryRunFlag             = "dry-run"
 	EmptyParam             = "empty"
 	ExcludeIgnoreRulesFlag = "x"
+	FirstParam             = "first"
 	ForceFlag              = "force"
 	FullFlag               = "full"
 	GraphFlag              = "graph"

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_squash_history.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_squash_history.go
@@ -34,7 +34,7 @@ import (
 // doltSquashHistory is the stored procedure for CALL dolt_squash_history(...). It collapses a
 // suffix of the current branch's history into a single new commit that carries HEAD's tree,
 // reparented onto the parents of the --first commit. This is a pointer rewrite, not a replay:
-// the operation is constant time regardless of how many commits are collapsed.
+// it does not create new commits by replaying diffs, and is typically much faster than rebasing.
 func doltSquashHistory(ctx *sql.Context, args ...string) (sql.RowIter, error) {
 	commitHash, err := doDoltSquashHistory(ctx, args)
 	if err != nil {

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_squash_history.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_squash_history.go
@@ -1,0 +1,282 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dprocedures
+
+import (
+	"fmt"
+
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions/commitwalk"
+	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
+	"github.com/dolthub/dolt/go/libraries/utils/argparser"
+	"github.com/dolthub/dolt/go/store/datas"
+	"github.com/dolthub/dolt/go/store/hash"
+)
+
+// doltSquashHistory is the stored procedure for CALL dolt_squash_history(...). It collapses a
+// suffix of the current branch's history into a single new commit that carries HEAD's tree,
+// reparented onto the parents of the --first commit. This is a pointer rewrite, not a replay:
+// the operation is constant time regardless of how many commits are collapsed.
+func doltSquashHistory(ctx *sql.Context, args ...string) (sql.RowIter, error) {
+	commitHash, err := doDoltSquashHistory(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+	return rowToIter(commitHash), nil
+}
+
+func doDoltSquashHistory(ctx *sql.Context, args []string) (string, error) {
+	dbName := ctx.GetCurrentDatabase()
+	if len(dbName) == 0 {
+		return "", fmt.Errorf("Empty database name.")
+	}
+	if err := branch_control.CheckAccess(ctx, branch_control.Permissions_Write); err != nil {
+		return "", err
+	}
+
+	isReadOnly, err := isReadOnlyDatabase(ctx, dbName)
+	if err != nil {
+		return "", err
+	}
+	if isReadOnly {
+		return "", fmt.Errorf("unable to squash history in read-only databases")
+	}
+
+	apr, err := cli.CreateSquashHistoryArgParser().Parse(args)
+	if err != nil {
+		return "", err
+	}
+
+	msg, ok := apr.GetValue(cli.MessageArg)
+	if !ok || msg == "" {
+		return "", fmt.Errorf("must provide a commit message with --%s", cli.MessageArg)
+	}
+
+	dSess := dsess.DSessFromSess(ctx.Session)
+	dbData, ok := dSess.GetDbData(ctx, dbName)
+	if !ok {
+		return "", fmt.Errorf("Could not load database %s", dbName)
+	}
+	ddb := dbData.Ddb
+
+	roots, ok := dSess.GetRoots(ctx, dbName)
+	if !ok {
+		return "", fmt.Errorf("Could not load database %s", dbName)
+	}
+	if err = checkWorkingSetClean(ctx, roots); err != nil {
+		return "", err
+	}
+
+	headRef, err := dbData.Rsr.CWBHeadRef(ctx)
+	if err != nil {
+		return "", err
+	}
+	headCommit, err := dSess.GetHeadCommit(ctx, dbName)
+	if err != nil {
+		return "", err
+	}
+
+	firstCommit, err := resolveFirstCommit(ctx, ddb, headRef, headCommit, apr)
+	if err != nil {
+		return "", err
+	}
+	// The initial commit has no parents to reparent onto and must survive as the permanent merge
+	// base, so it can never be squashed away.
+	if firstCommit.NumParents() == 0 {
+		return "", fmt.Errorf("--%s cannot be the initial commit", cli.FirstParam)
+	}
+
+	newCommit, err := buildSquashedCommit(ctx, ddb, headCommit, firstCommit, msg)
+	if err != nil {
+		return "", err
+	}
+
+	if err = ddb.SetHeadToCommit(ctx, headRef, newCommit); err != nil {
+		return "", err
+	}
+
+	// HEAD's tree is unchanged, so the working set stays clean; point it at the new commit's root.
+	newRoot, err := newCommit.GetRootValue(ctx)
+	if err != nil {
+		return "", err
+	}
+	ws, err := dSess.WorkingSet(ctx, dbName)
+	if err != nil {
+		return "", err
+	}
+	if err = dSess.SetWorkingSet(ctx, dbName, ws.WithWorkingRoot(newRoot).WithStagedRoot(newRoot).ClearMerge().ClearRebase()); err != nil {
+		return "", err
+	}
+
+	if err = commitTransaction(ctx, dSess, nil); err != nil {
+		return "", err
+	}
+
+	newHash, err := newCommit.HashOf()
+	if err != nil {
+		return "", err
+	}
+	return newHash.String(), nil
+}
+
+// checkWorkingSetClean returns an error if the working or staged root differs from HEAD. Squash
+// is a pure history rewrite and refuses to run against uncommitted changes.
+func checkWorkingSetClean(ctx *sql.Context, roots doltdb.Roots) error {
+	headHash, err := roots.Head.HashOf()
+	if err != nil {
+		return err
+	}
+	stagedHash, err := roots.Staged.HashOf()
+	if err != nil {
+		return err
+	}
+	workingHash, err := roots.Working.HashOf()
+	if err != nil {
+		return err
+	}
+	if headHash != stagedHash || headHash != workingHash {
+		return fmt.Errorf("cannot squash history with uncommitted changes")
+	}
+	return nil
+}
+
+// resolveFirstCommit returns the oldest commit to include in the squash. When --first is supplied
+// it is resolved and verified to be an ancestor of HEAD; otherwise it defaults to the initial
+// commit's only child.
+func resolveFirstCommit(ctx *sql.Context, ddb *doltdb.DoltDB, headRef ref.DoltRef, headCommit *doltdb.Commit, apr *argparser.ArgParseResults) (*doltdb.Commit, error) {
+	firstArg, ok := apr.GetValue(cli.FirstParam)
+	if !ok {
+		return defaultFirstCommit(ctx, ddb, headCommit)
+	}
+
+	cs, err := doltdb.NewCommitSpec(firstArg)
+	if err != nil {
+		return nil, err
+	}
+	optCommit, err := ddb.Resolve(ctx, cs, headRef)
+	if err != nil {
+		return nil, err
+	}
+	firstCommit, ok := optCommit.ToCommit()
+	if !ok {
+		return nil, doltdb.ErrGhostCommitEncountered
+	}
+
+	firstHash, err := firstCommit.HashOf()
+	if err != nil {
+		return nil, err
+	}
+	optAncestor, err := doltdb.GetCommitAncestor(ctx, firstCommit, headCommit)
+	if err != nil {
+		return nil, err
+	}
+	if optAncestor.Addr != firstHash {
+		return nil, fmt.Errorf("--%s must be an ancestor of HEAD", cli.FirstParam)
+	}
+	return firstCommit, nil
+}
+
+// defaultFirstCommit walks HEAD's ancestry, identifies the initial commit (the unique parentless
+// commit), and returns its single child. If the initial commit has more than one child reachable
+// from HEAD there is no unambiguous default, and the caller must supply --first.
+func defaultFirstCommit(ctx *sql.Context, ddb *doltdb.DoltDB, headCommit *doltdb.Commit) (*doltdb.Commit, error) {
+	headHash, err := headCommit.HashOf()
+	if err != nil {
+		return nil, err
+	}
+	ancestors, err := commitwalk.GetTopNTopoOrderedCommitsMatching(ctx, ddb, []hash.Hash{headHash}, -1,
+		func(*doltdb.OptionalCommit) (bool, error) { return true, nil })
+	if err != nil {
+		return nil, err
+	}
+
+	var initHash hash.Hash
+	initCount := 0
+	for _, c := range ancestors {
+		if c.NumParents() == 0 {
+			if initHash, err = c.HashOf(); err != nil {
+				return nil, err
+			}
+			initCount++
+		}
+	}
+	if initCount != 1 {
+		return nil, fmt.Errorf("cannot determine a unique initial commit; specify --%s", cli.FirstParam)
+	}
+
+	var children []*doltdb.Commit
+	for _, c := range ancestors {
+		parentHashes, err := c.ParentHashes(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, ph := range parentHashes {
+			if ph == initHash {
+				children = append(children, c)
+				break
+			}
+		}
+	}
+	switch len(children) {
+	case 0:
+		return nil, fmt.Errorf("nothing to squash: the branch contains only the initial commit")
+	case 1:
+		return children[0], nil
+	default:
+		return nil, fmt.Errorf("the initial commit has multiple children; specify --%s with the commit to squash from", cli.FirstParam)
+	}
+}
+
+// buildSquashedCommit writes a dangling commit that carries |headCommit|'s tree and whose parents
+// are exactly |firstCommit|'s parents, authored by the current session user with |msg|.
+func buildSquashedCommit(ctx *sql.Context, ddb *doltdb.DoltDB, headCommit, firstCommit *doltdb.Commit, msg string) (*doltdb.Commit, error) {
+	headRoot, err := headCommit.GetRootValue(ctx)
+	if err != nil {
+		return nil, err
+	}
+	_, valHash, err := ddb.WriteRootValue(ctx, headRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	parents := make([]*doltdb.Commit, 0, firstCommit.NumParents())
+	for i := 0; i < firstCommit.NumParents(); i++ {
+		optParent, err := firstCommit.GetParent(ctx, i)
+		if err != nil {
+			return nil, err
+		}
+		parent, ok := optParent.ToCommit()
+		if !ok {
+			return nil, doltdb.ErrGhostCommitEncountered
+		}
+		parents = append(parents, parent)
+	}
+
+	name, email, _, _, err := dsess.ResolveNameEmail(ctx, dsess.DoltAuthorName, dsess.DoltAuthorEmail)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := datas.NewCommitMeta(name, email, msg)
+	if err != nil {
+		return nil, err
+	}
+
+	return ddb.CommitDanglingWithParentCommits(ctx, valHash, parents, meta)
+}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_squash_history.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_squash_history.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dolthub/dolt/go/cmd/dolt/cli"
 	"github.com/dolthub/dolt/go/libraries/doltcore/branch_control"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env/actions/commitwalk"
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
@@ -91,8 +92,12 @@ func doDoltSquashHistory(ctx *sql.Context, args []string) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("Could not load database %s", dbName)
 	}
-	if err = checkWorkingSetClean(ctx, roots); err != nil {
+	hasChanges, _, _, err := actions.RootHasUncommittedChanges(roots)
+	if err != nil {
 		return "", err
+	}
+	if hasChanges {
+		return "", fmt.Errorf("cannot squash history with uncommitted changes")
 	}
 
 	headRef, err := dbData.Rsr.CWBHeadRef(ctx)
@@ -135,27 +140,6 @@ func doDoltSquashHistory(ctx *sql.Context, args []string) (string, error) {
 		return "", err
 	}
 	return newHash.String(), nil
-}
-
-// checkWorkingSetClean returns an error if the working or staged root differs from HEAD. Squash
-// is a pure history rewrite and refuses to run against uncommitted changes.
-func checkWorkingSetClean(ctx *sql.Context, roots doltdb.Roots) error {
-	headHash, err := roots.Head.HashOf()
-	if err != nil {
-		return err
-	}
-	stagedHash, err := roots.Staged.HashOf()
-	if err != nil {
-		return err
-	}
-	workingHash, err := roots.Working.HashOf()
-	if err != nil {
-		return err
-	}
-	if headHash != stagedHash || headHash != workingHash {
-		return fmt.Errorf("cannot squash history with uncommitted changes")
-	}
-	return nil
 }
 
 // resolveFirstCommit returns the oldest commit to include in the squash. When --first is supplied

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_squash_history.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_squash_history.go
@@ -76,6 +76,17 @@ func doDoltSquashHistory(ctx *sql.Context, args []string) (string, error) {
 	}
 	ddb := dbData.Ddb
 
+	ws, err := dSess.WorkingSet(ctx, dbName)
+	if err != nil {
+		return "", err
+	}
+	if ws.MergeActive() {
+		return "", fmt.Errorf("cannot squash history while a merge is in progress; abort the merge first")
+	}
+	if ws.RebaseActive() {
+		return "", fmt.Errorf("cannot squash history while a rebase is in progress; abort the rebase first")
+	}
+
 	roots, ok := dSess.GetRoots(ctx, dbName)
 	if !ok {
 		return "", fmt.Errorf("Could not load database %s", dbName)
@@ -112,19 +123,9 @@ func doDoltSquashHistory(ctx *sql.Context, args []string) (string, error) {
 		return "", err
 	}
 
-	// HEAD's tree is unchanged, so the working set stays clean; point it at the new commit's root.
-	newRoot, err := newCommit.GetRootValue(ctx)
-	if err != nil {
-		return "", err
-	}
-	ws, err := dSess.WorkingSet(ctx, dbName)
-	if err != nil {
-		return "", err
-	}
-	if err = dSess.SetWorkingSet(ctx, dbName, ws.WithWorkingRoot(newRoot).WithStagedRoot(newRoot).ClearMerge().ClearRebase()); err != nil {
-		return "", err
-	}
-
+	// HEAD's tree is preserved, so the working and staged roots already match the new HEAD and need
+	// no modification. Committing the transaction starts a fresh one so the session observes the
+	// moved HEAD.
 	if err = commitTransaction(ctx, dSess, nil); err != nil {
 		return "", err
 	}

--- a/go/libraries/doltcore/sqle/dprocedures/init.go
+++ b/go/libraries/doltcore/sqle/dprocedures/init.go
@@ -47,6 +47,7 @@ var DoltProcedures = []sql.ExternalStoredProcedureDetails{
 	{Name: "dolt_remote", Schema: int64Schema("status"), Function: doltRemote, AdminOnly: true},
 	{Name: "dolt_reset", Schema: int64Schema("status"), Function: doltReset},
 	{Name: "dolt_revert", Schema: doltRevertSchema, Function: doltRevert},
+	{Name: "dolt_squash_history", Schema: stringSchema("hash"), Function: doltSquashHistory},
 	{Name: "dolt_stash", Schema: int64Schema("status"), Function: doltStash},
 	{Name: "dolt_tag", Schema: int64Schema("status"), Function: doltTag},
 	{Name: "dolt_verify_constraints", Schema: int64Schema("violations"), Function: doltVerifyConstraints},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -1301,6 +1301,16 @@ func TestDoltRebasePrepared(t *testing.T) {
 	RunDoltRebasePreparedTests(t, h)
 }
 
+func TestDoltSquashHistory(t *testing.T) {
+	h := newDoltEnginetestHarness(t)
+	RunDoltSquashHistoryTests(t, h)
+}
+
+func TestDoltSquashHistoryPrepared(t *testing.T) {
+	h := newDoltEnginetestHarness(t)
+	RunDoltSquashHistoryPreparedTests(t, h)
+}
+
 func TestDoltRevert(t *testing.T) {
 	h := newDoltEnginetestHarness(t)
 	RunDoltRevertTests(t, h)

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_tests.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_tests.go
@@ -1170,6 +1170,28 @@ func RunDoltResetTest(t *testing.T, h DoltEnginetestHarness) {
 	}
 }
 
+func RunDoltSquashHistoryTests(t *testing.T, h DoltEnginetestHarness) {
+	for _, script := range DoltSquashHistoryScriptTests {
+		func() {
+			h := h.NewHarness(t)
+			defer h.Close()
+			h.SkipSetupCommit()
+			enginetest.TestScript(t, h, script)
+		}()
+	}
+}
+
+func RunDoltSquashHistoryPreparedTests(t *testing.T, h DoltEnginetestHarness) {
+	for _, script := range DoltSquashHistoryScriptTests {
+		func() {
+			h := h.NewHarness(t)
+			defer h.Close()
+			h.SkipSetupCommit()
+			enginetest.TestScriptPrepared(t, h, script)
+		}()
+	}
+}
+
 func RunDoltCheckoutTests(t *testing.T, h DoltEnginetestHarness) {
 	for _, script := range DoltCheckoutScripts {
 		func() {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_squash_history.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_squash_history.go
@@ -101,6 +101,100 @@ var DoltSquashHistoryScriptTests = []queries.ScriptTest{
 		},
 	},
 	{
+		Name: "dolt_squash_history: --first accepts a relative ref (HEAD~N)",
+		SetUpScript: []string{
+			"create table t (pk int primary key);",
+			"insert into t values (1);",
+			"call dolt_commit('-Am', 'c1');",
+			"insert into t values (2);",
+			"call dolt_commit('-am', 'c2');",
+			"insert into t values (3);",
+			"call dolt_commit('-am', 'c3');",
+			"insert into t values (4);",
+			"call dolt_commit('-am', 'c4');",
+			"insert into t values (5);",
+			"call dolt_commit('-am', 'c5');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				// HEAD~4 resolves to c1, collapsing c1..c5 onto the initial commit.
+				Query:    "call dolt_squash_history('--message', 'sq', '--first', 'HEAD~4');",
+				Expected: []sql.Row{{doltCommit}},
+			},
+			{
+				Query:    "select message from dolt_log;",
+				Expected: []sql.Row{{"sq"}, {"Initialize data repository"}},
+			},
+			{
+				Query:    "select * from t order by pk;",
+				Expected: []sql.Row{{1}, {2}, {3}, {4}, {5}},
+			},
+		},
+	},
+	{
+		Name: "dolt_squash_history: --first accepts a branch name",
+		SetUpScript: []string{
+			"create table t (pk int primary key);",
+			"insert into t values (1);",
+			"call dolt_commit('-Am', 'c1');",
+			"insert into t values (2);",
+			"call dolt_commit('-am', 'c2');",
+			"insert into t values (3);",
+			"call dolt_commit('-am', 'c3');",
+			"set @c1 = (select commit_hash from dolt_log where message = 'c1');",
+			"call dolt_branch('base', @c1);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				// The 'base' branch points at c1, so it collapses c1..c3 onto the initial commit.
+				Query:    "call dolt_squash_history('--message', 'sq', '--first', 'base');",
+				Expected: []sql.Row{{doltCommit}},
+			},
+			{
+				Query:    "select message from dolt_log;",
+				Expected: []sql.Row{{"sq"}, {"Initialize data repository"}},
+			},
+			{
+				// The other branch is untouched and still resolves to its commit.
+				Query:    "select count(*) from dolt_log as of 'base';",
+				Expected: []sql.Row{{2}},
+			},
+			{
+				Query:    "select * from t order by pk;",
+				Expected: []sql.Row{{1}, {2}, {3}},
+			},
+		},
+	},
+	{
+		Name: "dolt_squash_history: --first accepts a tag",
+		SetUpScript: []string{
+			"create table t (pk int primary key);",
+			"insert into t values (1);",
+			"call dolt_commit('-Am', 'c1');",
+			"insert into t values (2);",
+			"call dolt_commit('-am', 'c2');",
+			"insert into t values (3);",
+			"call dolt_commit('-am', 'c3');",
+			"set @c1 = (select commit_hash from dolt_log where message = 'c1');",
+			"call dolt_tag('v1', @c1);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				// The 'v1' tag points at c1, so it collapses c1..c3 onto the initial commit.
+				Query:    "call dolt_squash_history('--message', 'sq', '--first', 'v1');",
+				Expected: []sql.Row{{doltCommit}},
+			},
+			{
+				Query:    "select message from dolt_log;",
+				Expected: []sql.Row{{"sq"}, {"Initialize data repository"}},
+			},
+			{
+				Query:    "select * from t order by pk;",
+				Expected: []sql.Row{{1}, {2}, {3}},
+			},
+		},
+	},
+	{
 		Name: "dolt_squash_history: --first that is a merge commit keeps both parents",
 		SetUpScript: []string{
 			"create table t (pk int primary key);",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_squash_history.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_squash_history.go
@@ -116,6 +116,11 @@ var DoltSquashHistoryScriptTests = []queries.ScriptTest{
 			"call dolt_merge('b', '--no-commit');",
 			"call dolt_commit('-Am', 'M');",
 			"set @merge = dolt_hashof('HEAD');",
+			// Commits above the merge, so squashing from the merge actually collapses a range.
+			"insert into t values (3);",
+			"call dolt_commit('-am', 'N');",
+			"insert into t values (4);",
+			"call dolt_commit('-am', 'O');",
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
@@ -128,12 +133,26 @@ var DoltSquashHistoryScriptTests = []queries.ScriptTest{
 				Expected: []sql.Row{{2}},
 			},
 			{
+				// The merge and everything above it (M, N, O) collapse into a single commit
+				// on top of A and C, leaving 4 reachable commits: collapsed, A, C, init.
+				Query:    "select count(*) from dolt_log;",
+				Expected: []sql.Row{{4}},
+			},
+			{
 				Query:    "select message from dolt_log limit 1;",
 				Expected: []sql.Row{{"collapsed"}},
 			},
 			{
+				Query:    "select count(*) from dolt_log where message in ('M', 'N', 'O');",
+				Expected: []sql.Row{{0}},
+			},
+			{
+				Query:    "select count(*) from dolt_log where message in ('A', 'C');",
+				Expected: []sql.Row{{2}},
+			},
+			{
 				Query:    "select * from t order by pk;",
-				Expected: []sql.Row{{1}, {2}},
+				Expected: []sql.Row{{1}, {2}, {3}, {4}},
 			},
 		},
 	},

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_squash_history.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_squash_history.go
@@ -1,0 +1,273 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enginetest
+
+import (
+	"github.com/dolthub/go-mysql-server/enginetest/queries"
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+var DoltSquashHistoryScriptTests = []queries.ScriptTest{
+	{
+		Name: "dolt_squash_history: default collapses history to init <- HEAD",
+		SetUpScript: []string{
+			"create table t (pk int primary key);",
+			"insert into t values (1);",
+			"call dolt_commit('-Am', 'c1');",
+			"insert into t values (2);",
+			"call dolt_commit('-am', 'c2');",
+			"insert into t values (3);",
+			"call dolt_commit('-am', 'c3');",
+			"set @init = (select commit_hash from dolt_log where message = 'Initialize data repository');",
+			"set @user = (select committer from dolt_log where message = 'c1');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "select count(*) from dolt_log;",
+				Expected: []sql.Row{{4}},
+			},
+			{
+				Query:    "call dolt_squash_history('--message', 'squashed');",
+				Expected: []sql.Row{{doltCommit}},
+			},
+			{
+				Query:    "select count(*) from dolt_log;",
+				Expected: []sql.Row{{2}},
+			},
+			{
+				Query:    "select message from dolt_log;",
+				Expected: []sql.Row{{"squashed"}, {"Initialize data repository"}},
+			},
+			{
+				// The initial commit must be preserved unchanged as the merge base.
+				Query:    "select count(*) from dolt_log where commit_hash = @init;",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				// Author is the current session user, matching earlier commits.
+				Query:    "select count(*) from dolt_log where message = 'squashed' and committer = @user;",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				Query:    "select * from t order by pk;",
+				Expected: []sql.Row{{1}, {2}, {3}},
+			},
+			{
+				Query:    "select count(*) from dolt_status;",
+				Expected: []sql.Row{{0}},
+			},
+		},
+	},
+	{
+		Name: "dolt_squash_history: explicit --first collapses a suffix",
+		SetUpScript: []string{
+			"create table t (pk int primary key);",
+			"insert into t values (1);",
+			"call dolt_commit('-Am', 'c1');",
+			"insert into t values (2);",
+			"call dolt_commit('-am', 'c2');",
+			"insert into t values (3);",
+			"call dolt_commit('-am', 'c3');",
+			"insert into t values (4);",
+			"call dolt_commit('-am', 'c4');",
+			"set @c3 = (select commit_hash from dolt_log where message = 'c3');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "call dolt_squash_history('--message', 'sq', '--first', @c3);",
+				Expected: []sql.Row{{doltCommit}},
+			},
+			{
+				// c3 and c4 collapse onto c2; init, c1, c2, sq remain.
+				Query:    "select message from dolt_log;",
+				Expected: []sql.Row{{"sq"}, {"c2"}, {"c1"}, {"Initialize data repository"}},
+			},
+			{
+				Query:    "select * from t order by pk;",
+				Expected: []sql.Row{{1}, {2}, {3}, {4}},
+			},
+		},
+	},
+	{
+		Name: "dolt_squash_history: --first that is a merge commit keeps both parents",
+		SetUpScript: []string{
+			"create table t (pk int primary key);",
+			"insert into t values (1);",
+			"call dolt_commit('-Am', 'A');",
+			"set @init = (select commit_hash from dolt_log where message = 'Initialize data repository');",
+			"call dolt_branch('b', @init);",
+			"call dolt_checkout('b');",
+			"create table t (pk int primary key);",
+			"insert into t values (2);",
+			"call dolt_commit('-Am', 'C');",
+			"call dolt_checkout('main');",
+			"call dolt_merge('b', '--no-commit');",
+			"call dolt_commit('-Am', 'M');",
+			"set @merge = dolt_hashof('HEAD');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "call dolt_squash_history('--message', 'collapsed', '--first', @merge);",
+				Expected: []sql.Row{{doltCommit}},
+			},
+			{
+				// The collapsed commit keeps exactly the merge commit's two parents.
+				Query:    "select count(*) from dolt_commit_ancestors where commit_hash = dolt_hashof('HEAD');",
+				Expected: []sql.Row{{2}},
+			},
+			{
+				Query:    "select message from dolt_log limit 1;",
+				Expected: []sql.Row{{"collapsed"}},
+			},
+			{
+				Query:    "select * from t order by pk;",
+				Expected: []sql.Row{{1}, {2}},
+			},
+		},
+	},
+	{
+		Name: "dolt_squash_history: merge inside the collapsed range succeeds",
+		SetUpScript: []string{
+			"create table t (pk int primary key);",
+			"insert into t values (1);",
+			"call dolt_commit('-Am', 'A');",
+			"set @a = dolt_hashof('HEAD');",
+			"set @init = (select commit_hash from dolt_log where message = 'Initialize data repository');",
+			"call dolt_branch('b', @init);",
+			"call dolt_checkout('b');",
+			"create table t (pk int primary key);",
+			"insert into t values (2);",
+			"call dolt_commit('-Am', 'C');",
+			"call dolt_checkout('main');",
+			"call dolt_merge('b', '--no-commit');",
+			"call dolt_commit('-Am', 'M');",
+			"insert into t values (3);",
+			"call dolt_commit('-am', 'N');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				// --first = A reparents onto init; the merge commit M is inside the collapsed range.
+				Query:    "call dolt_squash_history('--message', 'flattened', '--first', @a);",
+				Expected: []sql.Row{{doltCommit}},
+			},
+			{
+				Query:    "select message from dolt_log;",
+				Expected: []sql.Row{{"flattened"}, {"Initialize data repository"}},
+			},
+			{
+				Query:    "select * from t order by pk;",
+				Expected: []sql.Row{{1}, {2}, {3}},
+			},
+		},
+	},
+	{
+		Name: "dolt_squash_history: error when --message is omitted",
+		SetUpScript: []string{
+			"create table t (pk int primary key);",
+			"call dolt_commit('-Am', 'c1');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:          "call dolt_squash_history();",
+				ExpectedErrStr: "must provide a commit message with --message",
+			},
+		},
+	},
+	{
+		Name: "dolt_squash_history: error when --first is the initial commit",
+		SetUpScript: []string{
+			"create table t (pk int primary key);",
+			"call dolt_commit('-Am', 'c1');",
+			"set @init = (select commit_hash from dolt_log where message = 'Initialize data repository');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:          "call dolt_squash_history('--message', 'x', '--first', @init);",
+				ExpectedErrStr: "--first cannot be the initial commit",
+			},
+		},
+	},
+	{
+		Name: "dolt_squash_history: error with uncommitted changes",
+		SetUpScript: []string{
+			"create table t (pk int primary key);",
+			"call dolt_commit('-Am', 'c1');",
+			"insert into t values (1);",
+			"call dolt_commit('-am', 'c2');",
+			"insert into t values (2);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:          "call dolt_squash_history('--message', 'x');",
+				ExpectedErrStr: "cannot squash history with uncommitted changes",
+			},
+		},
+	},
+	{
+		Name: "dolt_squash_history: error when --first is not an ancestor of HEAD",
+		SetUpScript: []string{
+			"create table t (pk int primary key);",
+			"call dolt_commit('-Am', 'c1');",
+			"insert into t values (1);",
+			"call dolt_commit('-am', 'c2');",
+			"call dolt_checkout('-b', 'side');",
+			"insert into t values (50);",
+			"call dolt_commit('-am', 'sidecommit');",
+			"set @side = dolt_hashof('HEAD');",
+			"call dolt_checkout('main');",
+			"insert into t values (2);",
+			"call dolt_commit('-am', 'main3');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:          "call dolt_squash_history('--message', 'x', '--first', @side);",
+				ExpectedErrStr: "--first must be an ancestor of HEAD",
+			},
+		},
+	},
+	{
+		Name: "dolt_squash_history: error when the initial commit has multiple children and no --first",
+		SetUpScript: []string{
+			"create table t (pk int primary key);",
+			"insert into t values (1);",
+			"call dolt_commit('-Am', 'A');",
+			"set @init = (select commit_hash from dolt_log where message = 'Initialize data repository');",
+			"call dolt_branch('b', @init);",
+			"call dolt_checkout('b');",
+			"create table t (pk int primary key);",
+			"insert into t values (2);",
+			"call dolt_commit('-Am', 'C');",
+			"call dolt_checkout('main');",
+			"call dolt_merge('b', '--no-commit');",
+			"call dolt_commit('-Am', 'M');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:          "call dolt_squash_history('--message', 'x');",
+				ExpectedErrStr: "the initial commit has multiple children; specify --first with the commit to squash from",
+			},
+		},
+	},
+	{
+		Name:        "dolt_squash_history: error when the branch has only the initial commit",
+		SetUpScript: []string{},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:          "call dolt_squash_history('--message', 'x');",
+				ExpectedErrStr: "nothing to squash: the branch contains only the initial commit",
+			},
+		},
+	},
+}

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_squash_history.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_squash_history.go
@@ -479,6 +479,47 @@ var DoltSquashHistoryScriptTests = []queries.ScriptTest{
 		},
 	},
 	{
+		// The initial commit has two children (A on main, C on 'other'), but only A is
+		// reachable from HEAD, so the default first commit is unambiguous and squash succeeds.
+		Name: "dolt_squash_history: default resolves when only one child of the initial commit is reachable",
+		SetUpScript: []string{
+			"create table t (pk int primary key);",
+			"insert into t values (1);",
+			"call dolt_commit('-Am', 'A');",
+			"set @init = (select commit_hash from dolt_log where message = 'Initialize data repository');",
+			"call dolt_branch('other', @init);",
+			"call dolt_checkout('other');",
+			"create table t (pk int primary key);",
+			"insert into t values (99);",
+			"call dolt_commit('-Am', 'C');",
+			"call dolt_checkout('main');",
+			"insert into t values (2);",
+			"call dolt_commit('-am', 'B');",
+			"insert into t values (3);",
+			"call dolt_commit('-am', 'D');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "call dolt_squash_history('--message', 'sq');",
+				Expected: []sql.Row{{doltCommit}},
+			},
+			{
+				// A, B, D collapse onto the initial commit.
+				Query:    "select message from dolt_log;",
+				Expected: []sql.Row{{"sq"}, {"Initialize data repository"}},
+			},
+			{
+				// The unrelated 'other' branch (the second child of init) is untouched.
+				Query:    "select message from dolt_log as of 'other';",
+				Expected: []sql.Row{{"C"}, {"Initialize data repository"}},
+			},
+			{
+				Query:    "select * from t order by pk;",
+				Expected: []sql.Row{{1}, {2}, {3}},
+			},
+		},
+	},
+	{
 		Name:        "dolt_squash_history: error when the branch has only the initial commit",
 		SetUpScript: []string{},
 		Assertions: []queries.ScriptTestAssertion{

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_squash_history.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_squash_history.go
@@ -216,6 +216,111 @@ var DoltSquashHistoryScriptTests = []queries.ScriptTest{
 		},
 	},
 	{
+		Name: "dolt_squash_history: aborts when a merge is in progress",
+		SetUpScript: []string{
+			"create table t (pk int primary key, v int);",
+			"insert into t values (1, 1);",
+			"call dolt_commit('-Am', 'c1');",
+			"call dolt_branch('other');",
+			"update t set v = 2 where pk = 1;",
+			"call dolt_commit('-am', 'main change');",
+			"call dolt_checkout('other');",
+			"update t set v = 3 where pk = 1;",
+			"call dolt_commit('-am', 'other change');",
+			"call dolt_checkout('main');",
+			"set @@autocommit = 0;",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "call dolt_merge('other');",
+				Expected: []sql.Row{{"", 0, 1, "conflicts found"}},
+			},
+			{
+				Query:          "call dolt_squash_history('--message', 'x');",
+				ExpectedErrStr: "cannot squash history while a merge is in progress; abort the merge first",
+			},
+		},
+	},
+	{
+		// Cherry-pick and revert use the merge state, so MergeActive covers them too.
+		Name: "dolt_squash_history: aborts when a cherry-pick is in progress",
+		SetUpScript: []string{
+			"set @@autocommit = 0;",
+			"create table t (pk int primary key, v int);",
+			"insert into t values (1, 1);",
+			"call dolt_commit('-Am', 'c1');",
+			"call dolt_checkout('-b', 'feature');",
+			"update t set v = 2 where pk = 1;",
+			"call dolt_commit('-am', 'feature change');",
+			"call dolt_checkout('main');",
+			"update t set v = 3 where pk = 1;",
+			"call dolt_commit('-am', 'main change');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:            "call dolt_cherry_pick(dolt_hashof('feature'));",
+				SkipResultsCheck: true,
+			},
+			{
+				Query:          "call dolt_squash_history('--message', 'x');",
+				ExpectedErrStr: "cannot squash history while a merge is in progress; abort the merge first",
+			},
+		},
+	},
+	{
+		Name: "dolt_squash_history: aborts when a revert is in progress",
+		SetUpScript: []string{
+			"set @@autocommit = 0;",
+			"create table t (pk int primary key, v int);",
+			"insert into t values (1, 1);",
+			"call dolt_commit('-Am', 'c1');",
+			"update t set v = 2 where pk = 1;",
+			"call dolt_commit('-am', 'c2');",
+			"set @c2 = dolt_hashof('HEAD');",
+			"update t set v = 99 where pk = 1;",
+			"call dolt_commit('-am', 'c3');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:            "call dolt_revert(@c2);",
+				SkipResultsCheck: true,
+			},
+			{
+				Query:          "call dolt_squash_history('--message', 'x');",
+				ExpectedErrStr: "cannot squash history while a merge is in progress; abort the merge first",
+			},
+		},
+	},
+	{
+		// A rebase that has started but not continued leaves a CLEAN working set, so the
+		// clean-working-set check cannot catch it -- RebaseActive is required here.
+		Name: "dolt_squash_history: aborts when a rebase is in progress",
+		SetUpScript: []string{
+			"create table t (pk int primary key, v int);",
+			"insert into t values (1, 1);",
+			"call dolt_commit('-Am', 'c1');",
+			"insert into t values (2, 2);",
+			"call dolt_commit('-am', 'c2');",
+			"insert into t values (3, 3);",
+			"call dolt_commit('-am', 'c3');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:            "call dolt_rebase('-i', 'HEAD~2');",
+				SkipResultsCheck: true,
+			},
+			{
+				// The working set is clean at this point, so this abort comes from RebaseActive.
+				Query:    "select count(*) from dolt_status;",
+				Expected: []sql.Row{{0}},
+			},
+			{
+				Query:          "call dolt_squash_history('--message', 'x');",
+				ExpectedErrStr: "cannot squash history while a rebase is in progress; abort the rebase first",
+			},
+		},
+	},
+	{
 		Name: "dolt_squash_history: error when --first is not an ancestor of HEAD",
 		SetUpScript: []string{
 			"create table t (pk int primary key);",


### PR DESCRIPTION
This new procedure will take the content of HEAD, and squash history before it. Default behavior is to squash every commit from height 2 (commit right after initial commit) to HEAD. It is impossible to rewrite the initial commit.

This will be much faster than rebasing all history.