### PR TITLE
[no-release-notes] go: fix spelling errors in comments

### DIFF
--- a/go/cmd/dolt/commands/engine/sqlengine.go
+++ b/go/cmd/dolt/commands/engine/sqlengine.go
@@ -385,7 +385,7 @@ func applySystemVariables(vars sql.SystemVariableRegistry, cfg SystemVariables) 
 	return nil
 }
 
-// InitStats initalizes stats threads. We separate construction
+// InitStats initializes stats threads. We separate construction
 // from initialization because the session provider needs the
 // *StatsCoordinator handle (stats and provider are cyclically
 // dependent), but several other initialization steps race on

--- a/go/cmd/dolt/commands/gc.go
+++ b/go/cmd/dolt/commands/gc.go
@@ -37,7 +37,7 @@ var gcDocs = cli.CommandDocumentationContent{
 	LongDesc: `Searches the repository for data that is no longer referenced and no longer needed.
 
 Dolt GC is generational. When a GC is run, everything reachable from any commit on any branch
-is put into the old generation. Data which is only reachable from uncommited branch HEADs is kept in
+is put into the old generation. Data which is only reachable from uncommitted branch HEADs is kept in
 the new generation. By default, Dolt GC will only visit data in the new generation, and so will never
 collect data from deleted branches which has previously made its way to the old generation from being
 copied during a prior garbage collection.

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_applier.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replica_applier.go
@@ -618,7 +618,7 @@ func (a *binlogReplicaApplier) processBinlogEvent(ctx *sql.Context, engine *gms.
 		// For now, create a Dolt commit from every data update. Eventually, we'll want to make this configurable.
 		// We commit to every database that we saw had a dirty session – these identify the databases where we have
 		// run DML commands through the engine. We also commit to every database that was modified through a RowEvent,
-		// which is all tracked through the applier's databasesWithUncommitedChanges property – these don't show up
+		// which is all tracked through the applier's databasesWithUncommittedChanges property – these don't show up
 		// as dirty in our session, since we used TableWriter to update them.
 		a.addDatabasesWithUncommittedChanges(databasesToCommit...)
 		for _, database := range a.databasesWithUncommittedChanges() {

--- a/go/libraries/doltcore/sqle/dtables/workspace_table.go
+++ b/go/libraries/doltcore/sqle/dtables/workspace_table.go
@@ -915,7 +915,7 @@ func getWorkspaceTableRow(
 	return row, nil
 }
 
-// queueWorkspaceRows is similar to prollyDiffIter.queueRows, but for workspaces. It performs two seperate calls
+// queueWorkspaceRows is similar to prollyDiffIter.queueRows, but for workspaces. It performs two separate calls
 // to prolly.DiffMaps, one for staging and one for working. The end result is queueing the rows from both maps
 // into the "rows" channel of the workspaceDiffIter.
 func (itr *workspaceDiffIter) queueWorkspaceRows(ctx context.Context) {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_transaction_commit_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_transaction_commit_test.go
@@ -544,7 +544,7 @@ func TestDoltTransactionCommitLateFkResolution(t *testing.T) {
 // TestDoltTransactionFulltextNullBodyNonFF is a regression test for a hang triggered by two concurrent
 // connections both inserting rows that leave the FULLTEXT-indexed column NULL. When the second
 // commit cannot fast-forward (because the first already advanced the working-set head), Dolt
-// calls rebuildFullTextIndexes, which was unneccessarily rebuilding the fulltext index. This test
+// calls rebuildFullTextIndexes, which was unnecessarily rebuilding the fulltext index. This test
 // asserts that fulltext index is not repeatedly rebuilt.
 func TestDoltTransactionFulltextNullBodyNonFF(t *testing.T) {
 	harness := newDoltHarness(t)

--- a/go/libraries/doltcore/sqle/index/dolt_index.go
+++ b/go/libraries/doltcore/sqle/index/dolt_index.go
@@ -1282,7 +1282,7 @@ func (di *doltIndex) prollyRangesFromSqlRanges(ctx context.Context, ns tree.Node
 
 			nilBound := field.Lo.Value == nil && field.Hi.Value == nil
 			if foundDiscontinuity || nilBound {
-				// A discontinous variable followed by any restriction
+				// A discontinuous variable followed by any restriction
 				// can partition the key space.
 				isContiguous = false
 			}

--- a/go/store/prolly/tree/merge.go
+++ b/go/store/prolly/tree/merge.go
@@ -217,7 +217,7 @@ func SendPatches[K ~[]byte, O Ordering[K]](
 				// Since these are both at level > 0, this means that both patches contain an address pointing to
 				// the same content-addressed chunk.
 				// This necessarily means that their end keys are the same. But if one side has added or removed
-				// an entire chunk that immediately preceeds this chunk, then their start keys may differ.
+				// an entire chunk that immediately precedes this chunk, then their start keys may differ.
 				// If the left side added or removed a chunk, we can safely ignore it. If the right side added a chunk,
 				// then we already encountered it. But if the right side removed a chunk, we need to emit a patch here
 				// that reflects that.


### PR DESCRIPTION
Fix several spelling errors in comments across 7 files: `uncommited` → `uncommitted`, `initalizes` → `initializes`, `seperate` → `separate`, `discontinous` → `discontinuous`, `preceeds` → `precedes`, `databasesWithUncommitedChanges` → `databasesWithUncommittedChanges`, and `unneccessarily` → `unnecessarily`.
Close #11605