### PR TITLE
/go/store/{datas,nbs}: cleanup byte sink files on error

### DIFF
--- a/go/store/datas/pull/pull_table_file_writer.go
+++ b/go/store/datas/pull/pull_table_file_writer.go
@@ -16,6 +16,7 @@ package pull
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"strings"
@@ -115,7 +116,23 @@ func (w *PullTableFileWriter) Run(ctx context.Context) error {
 	eg.Go(func() error {
 		return w.addChunkThread(egCtx)
 	})
-	return eg.Wait()
+	err := eg.Wait()
+	// If we are shutting down early, the upload threads stop reading from
+	// newWriterCh and any finished table files still buffered there are
+	// unreachable from anywhere else. Delete their temp files. Every sender and
+	// receiver is done by the time Wait returns, so a non-blocking drain sees
+	// everything that is left, whether or not the channel was closed.
+	for {
+		select {
+		case wr, ok := <-w.newWriterCh:
+			if !ok {
+				return err
+			}
+			_ = wr.Cancel()
+		default:
+			return err
+		}
+	}
 }
 
 func (w *PullTableFileWriter) GetStats() PullTableFileWriterStats {
@@ -227,11 +244,9 @@ func (w *PullTableFileWriter) addChunkThread(ctx context.Context) (err error) {
 	defer func() {
 		if curWr != nil {
 			// Cleanup dangling writer, whose contents will never be used.
-			_, _, _ = curWr.Finish()
-			rd, _ := curWr.Reader()
-			if rd != nil {
-				rd.Close()
-			}
+			// Cancel shuts down the writer and deletes its temp file; without
+			// it the file survives for the life of the process.
+			_ = curWr.Cancel()
 		}
 	}()
 
@@ -325,14 +340,16 @@ func (w *PullTableFileWriter) uploadThread(ctx context.Context, reqCh chan nbs.G
 				return nil
 			}
 
+			// Once we have taken a writer off reqCh we are the only owner of
+			// it, so every path out of here has to remove its temp file.
 			_, id, err := wr.Finish()
 			if err != nil {
-				return err
+				return errors.Join(err, wr.Cancel())
 			}
 
 			chunkData, err := wr.ChunkDataLength()
 			if err != nil {
-				return err
+				return errors.Join(err, wr.Cancel())
 			}
 
 			ttf := tempTblFile{
@@ -346,7 +363,7 @@ func (w *PullTableFileWriter) uploadThread(ctx context.Context, reqCh chan nbs.G
 			ttf.pending, err = w.uploadTempTableFile(ctx, ttf)
 
 			// Always remove the file...
-			wr.Remove()
+			_ = wr.Cancel()
 
 			if err != nil {
 				return err

--- a/go/store/datas/pull/pull_table_file_writer_cleanup_test.go
+++ b/go/store/datas/pull/pull_table_file_writer_cleanup_test.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pull
+
+import (
+	"context"
+	"crypto/rand"
+	"io"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/nbs"
+)
+
+func sinkFiles(t *testing.T, dir string) []string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "buffered_file_byte_sink_*"))
+	require.NoError(t, err)
+	return matches
+}
+
+// blockingTableFileDestStore stalls every upload until the test's context is
+// cancelled, so that finished table files pile up in the writer's newWriterCh
+// buffer.
+type blockingTableFileDestStore struct {
+	uploading chan struct{}
+}
+
+func (s *blockingTableFileDestStore) WriteTableFile(ctx context.Context, id string, splitOffset uint64, numChunks int, contentHash []byte, getRd func() (io.ReadCloser, uint64, error)) (io.Closer, error) {
+	select {
+	case s.uploading <- struct{}{}:
+	default:
+	}
+	<-ctx.Done()
+	return nil, context.Cause(ctx)
+}
+
+func (s *blockingTableFileDestStore) AddTableFilesToManifest(context.Context, map[string]int, chunks.InsertAddrsCurry) error {
+	return nil
+}
+
+// A pull or push that dies partway through --- a cancelled context, a client
+// disconnect, a failed upload --- must not leave its staging files behind. On a
+// long lived sql-server nothing ever comes back to collect them.
+func TestPullTableFileWriterCleansUpTempFiles(t *testing.T) {
+	addChunks := func(ctx context.Context, wr *PullTableFileWriter, n, size int) {
+		for i := 0; i < n; i++ {
+			bs := make([]byte, size)
+			if _, err := rand.Read(bs); err != nil {
+				return
+			}
+			if err := wr.AddToChunker(ctx, nbs.ChunkToCompressedChunk(chunks.NewChunk(bs))); err != nil {
+				return
+			}
+		}
+	}
+
+	// Covers both the in-progress writer and the finished writers stranded in
+	// the newWriterCh buffer once the upload threads stop reading from it.
+	t.Run("CancelledContext", func(t *testing.T) {
+		tempDir := t.TempDir()
+		s := &blockingTableFileDestStore{uploading: make(chan struct{}, 1)}
+		wr := NewPullTableFileWriter(PullTableFileWriterConfig{
+			ConcurrentUploads:    1,
+			TargetFileSize:       1 << 16,
+			MaximumBufferedFiles: 4,
+			TempDir:              tempDir,
+			DestStore:            s,
+		})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		eg, egCtx := errgroup.WithContext(ctx)
+		eg.Go(func() error {
+			return wr.Run(egCtx)
+		})
+
+		var adders sync.WaitGroup
+		adders.Add(1)
+		go func() {
+			defer adders.Done()
+			addChunks(egCtx, wr, 512, 1<<14)
+		}()
+
+		// Wait until an upload is stuck and several table files have been
+		// staged, so cancelling strands writers in the buffer.
+		select {
+		case <-s.uploading:
+		case <-time.After(30 * time.Second):
+			t.Error("timed out waiting for an upload to start")
+		}
+		require.Eventually(t, func() bool {
+			return len(sinkFiles(t, tempDir)) >= 3
+		}, 30*time.Second, 10*time.Millisecond, "expected table files to pile up")
+
+		cancel()
+		adders.Wait()
+		assert.Error(t, eg.Wait())
+
+		assert.Empty(t, sinkFiles(t, tempDir), "leaked table file temp files")
+	})
+
+	// The upload thread owns a writer once it takes it off newWriterCh, so its
+	// error paths have to clean up too.
+	t.Run("UploadError", func(t *testing.T) {
+		tempDir := t.TempDir()
+		var s errTableFileDestStore
+		wr := NewPullTableFileWriter(PullTableFileWriterConfig{
+			ConcurrentUploads:    1,
+			TargetFileSize:       1 << 16,
+			MaximumBufferedFiles: 4,
+			TempDir:              tempDir,
+			DestStore:            &s,
+		})
+
+		eg, ctx := errgroup.WithContext(context.Background())
+		eg.Go(func() error {
+			return wr.Run(ctx)
+		})
+
+		addChunks(ctx, wr, 64, 1<<14)
+		wr.Close()
+		assert.Error(t, eg.Wait())
+
+		assert.Empty(t, sinkFiles(t, tempDir), "leaked table file temp files")
+	})
+}

--- a/go/store/nbs/archive_writer.go
+++ b/go/store/nbs/archive_writer.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -465,13 +466,8 @@ func (aw *archiveWriter) flushToFile(fullPath string) error {
 		return fmt.Errorf("Runtime error: flushToFile called out of order")
 	}
 
-	if bs, ok := aw.output.backingSink.(*BufferedFileByteSink); ok {
-		err := bs.finish()
-		if err != nil {
-			return err
-		}
-	}
-
+	// No need to shut the sink down here: FlushToFile below does that itself,
+	// forwarding through the hashing sinks to the backing sink.
 	aw.finalPath = fullPath
 	err := aw.output.FlushToFile(fullPath)
 	if err != nil {
@@ -614,23 +610,28 @@ func (asw *ArchiveStreamWriter) GetMD5() []byte {
 	return asw.writer.fullMD5[:]
 }
 
+// Cancel the inprogress write and remove the temp file backing it.
+//
+// The temp file is always removed, even if shutting down the sink fails. The
+// sink records the first error its background writer saw and returns it from
+// every subsequent call, so bailing out early here would leak the temp file
+// forever once any write had failed --- exactly when we can least afford it.
 func (asw *ArchiveStreamWriter) Cancel() error {
-	rdr, err := asw.writer.output.Reader()
-	if err != nil {
-		return err
-	}
-	err = rdr.Close()
-	if err != nil {
-		return err
-	}
-	return asw.Remove()
+	return errors.Join(asw.writer.output.finish(), asw.Remove())
 }
 
+// Remove deletes the temp file backing this writer. It is not an error to call
+// Remove after the temp file has already been renamed away by FlushToFile, or
+// to call it more than once.
 func (asw *ArchiveStreamWriter) Remove() error {
 	if asw.writer.path == "" {
 		return nil
 	}
-	return os.Remove(asw.writer.path)
+	err := os.Remove(asw.writer.path)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	return nil
 }
 
 // FlushToFile writes the archive to disk. The input is the directory where the file should be written, the file name

--- a/go/store/nbs/byte_sink.go
+++ b/go/store/nbs/byte_sink.go
@@ -227,7 +227,7 @@ func NewBufferedFileByteSink(tempDir string, blockSize, chBufferSize int) (*Buff
 
 	sink := &BufferedFileByteSink{
 		blockSize:    blockSize,
-		currentBlock: make([]byte, blockSize),
+		currentBlock: make([]byte, 0, blockSize),
 		writeCh:      make(chan []byte, chBufferSize),
 		ae:           atomicerr.New(),
 		wg:           &sync.WaitGroup{},
@@ -285,6 +285,15 @@ func (sink *BufferedFileByteSink) backgroundWrite() {
 	err = sink.wr.Close()
 	sink.ae.SetIfError(err)
 }
+
+// finisher is implemented by ByteSinks which own a background writer that must
+// be shut down before their output can be used or discarded.
+type finisher interface {
+	finish() error
+}
+
+var _ finisher = (*BufferedFileByteSink)(nil)
+var _ finisher = (*HashingByteSink)(nil)
 
 func (sink *BufferedFileByteSink) finish() error {
 	// |finish()| is not thread-safe. We just use writeCh == nil as a
@@ -397,6 +406,15 @@ func (sink *HashingByteSink) FlushToFile(path string) error {
 
 func (sink *HashingByteSink) Reader() (io.ReadCloser, error) {
 	return sink.backingSink.Reader()
+}
+
+// finish shuts down the backing sink if it has anything to shut down. It is a
+// no-op for the purely in-memory sinks.
+func (sink *HashingByteSink) finish() error {
+	if f, ok := sink.backingSink.(finisher); ok {
+		return f.finish()
+	}
+	return nil
 }
 
 // Execute the hasher.Sum() function and return the result

--- a/go/store/nbs/byte_sink_cleanup_test.go
+++ b/go/store/nbs/byte_sink_cleanup_test.go
@@ -1,0 +1,231 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nbs
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/store/chunks"
+	"github.com/dolthub/dolt/go/store/util/tempfiles"
+)
+
+// sinkTempDir points MovableTempFileProvider at a directory owned by the test
+// so that leftover buffered_file_byte_sink_ files can be detected.
+func sinkTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	old := tempfiles.MovableTempFileProvider
+	tempfiles.MovableTempFileProvider = tempfiles.NewTempFileProviderAt(dir)
+	t.Cleanup(func() {
+		tempfiles.MovableTempFileProvider = old
+	})
+	return dir
+}
+
+func assertNoSinkFiles(t *testing.T, dir string) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "buffered_file_byte_sink_*"))
+	require.NoError(t, err)
+	assert.Empty(t, matches, "leaked buffered file byte sink temp files")
+}
+
+// backingFileSink digs the temp-file-backed sink out from under however many
+// layers of HashingByteSink a writer wrapped it in.
+func backingFileSink(t *testing.T, s ByteSink) *BufferedFileByteSink {
+	t.Helper()
+	for {
+		switch sink := s.(type) {
+		case *BufferedFileByteSink:
+			return sink
+		case *HashingByteSink:
+			s = sink.backingSink
+		default:
+			t.Fatalf("no BufferedFileByteSink behind %T", s)
+			return nil
+		}
+	}
+}
+
+// TestBufferedFileByteSinkWritesExactBytes guards against the initial block
+// being allocated with a non-zero length, which would prepend a block of zeros
+// to sinks that are flushed without a full block of real data.
+func TestBufferedFileByteSinkWritesExactBytes(t *testing.T) {
+	sinkTempDir(t)
+
+	t.Run("NoWrites", func(t *testing.T) {
+		sink, err := NewBufferedFileByteSink("", 4096, 4)
+		require.NoError(t, err)
+
+		r, err := sink.Reader()
+		require.NoError(t, err)
+		defer r.Close()
+
+		data, err := io.ReadAll(r)
+		require.NoError(t, err)
+		assert.Empty(t, data)
+	})
+
+	t.Run("ZeroLengthWrite", func(t *testing.T) {
+		sink, err := NewBufferedFileByteSink("", 4096, 4)
+		require.NoError(t, err)
+
+		_, err = sink.Write(nil)
+		require.NoError(t, err)
+		_, err = sink.Write([]byte("hello"))
+		require.NoError(t, err)
+
+		r, err := sink.Reader()
+		require.NoError(t, err)
+		defer r.Close()
+
+		data, err := io.ReadAll(r)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("hello"), data)
+		assert.Equal(t, uint64(5), sink.pos)
+	})
+}
+
+// genericTableWriters returns one of each GenericTableWriter backed by a temp
+// file, so the cleanup tests below cover both implementations.
+func genericTableWriters(t *testing.T) map[string]func() GenericTableWriter {
+	return map[string]func() GenericTableWriter{
+		"CmpChunkTableWriter": func() GenericTableWriter {
+			w, err := NewCmpChunkTableWriter("")
+			require.NoError(t, err)
+			return w
+		},
+		"ArchiveStreamWriter": func() GenericTableWriter {
+			w, err := NewArchiveStreamWriter("")
+			require.NoError(t, err)
+			return w
+		},
+	}
+}
+
+func writerSink(t *testing.T, w GenericTableWriter) *BufferedFileByteSink {
+	t.Helper()
+	switch tw := w.(type) {
+	case *CmpChunkTableWriter:
+		return backingFileSink(t, tw.sink)
+	case *ArchiveStreamWriter:
+		return backingFileSink(t, tw.writer.output)
+	default:
+		t.Fatalf("unexpected writer type %T", w)
+		return nil
+	}
+}
+
+func TestTableWriterCancelRemovesTempFile(t *testing.T) {
+	for name, newWriter := range genericTableWriters(t) {
+		t.Run(name, func(t *testing.T) {
+			t.Run("Clean", func(t *testing.T) {
+				dir := sinkTempDir(t)
+				w := newWriter()
+				_, err := w.AddChunk(ChunkToCompressedChunk(chunks.NewChunk([]byte("some chunk data"))))
+				require.NoError(t, err)
+
+				require.NoError(t, w.Cancel())
+				assertNoSinkFiles(t, dir)
+			})
+
+			// The sink remembers the first error its background writer saw and
+			// returns it from every later call. Cancel must still delete the
+			// temp file: a disk that is filling up is exactly when we cannot
+			// afford to leak one.
+			t.Run("AfterSinkError", func(t *testing.T) {
+				dir := sinkTempDir(t)
+				w := newWriter()
+				_, err := w.AddChunk(ChunkToCompressedChunk(chunks.NewChunk([]byte("some chunk data"))))
+				require.NoError(t, err)
+
+				writerSink(t, w).ae.SetIfError(errors.New("simulated write failure"))
+
+				err = w.Cancel()
+				assert.Error(t, err, "Cancel should surface the sink error")
+				assertNoSinkFiles(t, dir)
+			})
+
+			// Several call sites cancel defensively on paths that may already
+			// have cancelled, so a second Cancel must not report a failure.
+			t.Run("Twice", func(t *testing.T) {
+				dir := sinkTempDir(t)
+				w := newWriter()
+				_, err := w.AddChunk(ChunkToCompressedChunk(chunks.NewChunk([]byte("some chunk data"))))
+				require.NoError(t, err)
+
+				require.NoError(t, w.Cancel())
+				assert.NoError(t, w.Cancel())
+				assertNoSinkFiles(t, dir)
+			})
+
+			// After FlushToFile the temp file has been renamed away. Cancelling
+			// then is a no-op, not an error, so callers that unconditionally
+			// clean up do not report a spurious failure --- gcCopier does
+			// exactly this after a successful TryMoveCmpChunkTableWriter.
+			t.Run("AfterFlushToFile", func(t *testing.T) {
+				dir := sinkTempDir(t)
+				w := newWriter()
+				_, err := w.AddChunk(ChunkToCompressedChunk(chunks.NewChunk([]byte("some chunk data"))))
+				require.NoError(t, err)
+
+				_, name, err := w.Finish()
+				require.NoError(t, err)
+
+				dest := filepath.Join(t.TempDir(), name)
+				require.NoError(t, w.FlushToFile(dest))
+
+				_, err = os.Stat(dest)
+				require.NoError(t, err)
+
+				assert.NoError(t, w.Cancel())
+				assert.NoError(t, w.Remove())
+				assertNoSinkFiles(t, dir)
+			})
+		})
+	}
+}
+
+// copyTablesToDir has to drop the writer's temp file even when Finish fails,
+// because nothing else holds a reference to it once it returns --- for a
+// rotating copier's child, the gcCopier it was handed is a throwaway copy.
+func TestGCCopierCleansUpAfterFinishError(t *testing.T) {
+	dir := sinkTempDir(t)
+	ctx := context.Background()
+
+	persister := newFSTablePersister(t.TempDir(), &UnlimitedQuotaProvider{}, false)
+	gcc, err := newGarbageCollectionCopier(chunks.NoArchive, persister.(tableFilePersister))
+	require.NoError(t, err)
+
+	// Writing the same chunk twice makes Finish fail with
+	// ErrDuplicateChunkWritten.
+	c := ChunkToCompressedChunk(chunks.NewChunk([]byte("some chunk data")))
+	_, err = gcc.writer.AddChunk(c)
+	require.NoError(t, err)
+	_, err = gcc.writer.AddChunk(c)
+	require.NoError(t, err)
+
+	_, _, err = gcc.copyTablesToDir(ctx)
+	require.ErrorIs(t, err, ErrDuplicateChunkWritten)
+
+	assertNoSinkFiles(t, dir)
+}

--- a/go/store/nbs/cmp_chunk_table_writer.go
+++ b/go/store/nbs/cmp_chunk_table_writer.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	gohash "hash"
 	"io"
+	"io/fs"
 	"os"
 	"sort"
 
@@ -242,23 +243,27 @@ func (tw *CmpChunkTableWriter) Reader() (io.ReadCloser, error) {
 	return tw.sink.Reader()
 }
 
+// Remove deletes the temp file backing this writer. It is not an error to call
+// Remove after the temp file has already been renamed away by FlushToFile, or
+// to call it more than once.
 func (tw *CmpChunkTableWriter) Remove() error {
-	return os.Remove(tw.path)
+	err := os.Remove(tw.path)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	return nil
 }
 
 // Cancel the inprogress write and attempt to cleanup any
 // resources associated with it. It is an error to call
 // Flush{,ToFile} or Reader after canceling the writer.
+//
+// The temp file is always removed, even if shutting down the sink fails. The
+// sink records the first error its background writer saw and returns it from
+// every subsequent call, so bailing out early here would leak the temp file
+// forever once any write had failed --- exactly when we can least afford it.
 func (tw *CmpChunkTableWriter) Cancel() error {
-	closer, err := tw.sink.Reader()
-	if err != nil {
-		return err
-	}
-	err = closer.Close()
-	if err != nil {
-		return err
-	}
-	return tw.Remove()
+	return errors.Join(tw.sink.finish(), tw.Remove())
 }
 
 func containsDuplicates(prefixes prefixIndexSlice) bool {

--- a/go/store/nbs/gc_copier.go
+++ b/go/store/nbs/gc_copier.go
@@ -16,6 +16,7 @@ package nbs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -74,16 +75,23 @@ func (gcc *gcCopier) cancel(_ context.Context) error {
 // It returns the table specs and a pending handle that must be kept open until
 // the files are Open'd (added to openFiles). The caller must close the handle.
 func (gcc *gcCopier) copyTablesToDir(ctx context.Context) (ts []tableSpec, pending io.Closer, err error) {
+	// Registered before Finish so that a Finish error still drops the writer's
+	// temp file. Nothing else holds a reference to |gcc.writer| once we return
+	// --- for a rotating copier's child, |gcc| itself is a throwaway copy ---
+	// so a missed Cancel here leaks the temp file for the life of the process.
+	// The error is deliberately dropped: on the success path |ts| and |pending|
+	// are valid and the caller owns the pending handle, so turning a failed
+	// temp-file cleanup into a returned error would strand that handle.
+	defer func() {
+		_ = gcc.writer.Cancel()
+		gcc.writer = nil
+	}()
+
 	var filename string
 	_, filename, err = gcc.writer.Finish()
 	if err != nil {
 		return nil, nil, err
 	}
-
-	defer func() {
-		gcc.writer.Cancel()
-		gcc.writer = nil
-	}()
 
 	if gcc.writer.ChunkCount() == 0 {
 		return []tableSpec{}, noopPendingHandle{}, nil
@@ -275,6 +283,12 @@ func (gcc *rotatingGCCopier) rotate(ctx context.Context) error {
 	// Copy the state of gcc.gcCopier so that the child goroutine will use the current writer,
 	// even after gcc.gcCopier.writer gets reassigned below.
 	previousCopier := gcc.gcCopier
+	// Hand ownership of the old writer to the child goroutine before spawning
+	// it. If the constructor below fails we return with a nil writer rather
+	// than one the child is concurrently finalizing, which a later cancel()
+	// would Cancel a second time --- BufferedFileByteSink.finish is not
+	// thread-safe.
+	gcc.gcCopier.writer = nil
 	gcc.eg.Go(func() error {
 		return gcc.finalizeChildWriter(ctx, previousCopier)
 	})
@@ -292,12 +306,15 @@ func (gcc *rotatingGCCopier) rotate(ctx context.Context) error {
 
 func (gcc *rotatingGCCopier) finalize(ctx context.Context) (*newlyWrittenSources, error) {
 	err := gcc.finalizeChildWriter(ctx, gcc.gcCopier)
-	if err != nil {
-		return nil, err
-	}
-	err = gcc.eg.Wait()
+	// finalizeChildWriter took ownership of the writer and cancelled it.
 	gcc.writer = nil
-	return &gcc.specs, err
+	// Wait even when the final writer failed, so that in-flight rotate
+	// goroutines finish cleaning up their own writers instead of outliving GC.
+	waitErr := gcc.eg.Wait()
+	if err != nil {
+		return nil, errors.Join(err, waitErr)
+	}
+	return &gcc.specs, waitErr
 }
 
 func (gcc *rotatingGCCopier) waitForPendingChunkFiles() error {
@@ -309,12 +326,15 @@ func (gcc *rotatingGCCopier) waitForPendingChunkFiles() error {
 
 func (gcc *rotatingGCCopier) cancel(ctx context.Context) error {
 	gcc.specs.sourceSet.close()
+	var err error
 	if gcc.writer != nil {
-		err := gcc.writer.Cancel()
-		if err != nil {
-			return err
-		}
+		err = gcc.writer.Cancel()
+		// Cleared unconditionally: Cancel always removes the temp file, and
+		// leaving a non-nil writer behind on error just invites a double
+		// Cancel from a later caller.
 		gcc.writer = nil
 	}
-	return nil
+	// Detached rotate goroutines own writers we cannot reach from here, so wait
+	// for them to finish cleaning up rather than letting them outlive the GC.
+	return errors.Join(err, gcc.eg.Wait())
 }


### PR DESCRIPTION
Currently there are some paths where temporary byte sink files may persist on disk despite an error. This PR aims to ensure these are always deleted in such cases.