### PR TITLE
go: store/nbs: reject a file manifest update that references a missing table file

### DIFF
--- a/go/store/nbs/file_manifest.go
+++ b/go/store/nbs/file_manifest.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -191,7 +192,7 @@ func (fm fileManifest) Update(ctx context.Context, behavior dherrors.FatalBehavi
 		if contents.gcGen != upstream.gcGen {
 			return chunks.ErrGCGenerationExpired
 		}
-		return nil
+		return checkNewSpecsPresent(fm.dir, upstream, contents)
 	}
 
 	return updateWithChecker(ctx, behavior, fm.dir, checker, lastLock, newContents, writeHook)
@@ -211,7 +212,80 @@ func (fm fileManifest) UpdateGCGen(ctx context.Context, behavior dherrors.FatalB
 		}
 	}()
 
-	return updateWithChecker(ctx, behavior, fm.dir, updateGCGenManifestCheck, lastLock, newContents, writeHook)
+	checker := func(upstream, contents manifestContents) error {
+		if err := updateGCGenManifestCheck(upstream, contents); err != nil {
+			return err
+		}
+		return checkNewSpecsPresent(fm.dir, upstream, contents)
+	}
+
+	return updateWithChecker(ctx, behavior, fm.dir, checker, lastLock, newContents, writeHook)
+}
+
+// ErrManifestSpecMissingTableFile is returned by a manifest update that would
+// have published a dependency on a table file that is not in the directory.
+var ErrManifestSpecMissingTableFile = errors.New("refusing to write a manifest referencing a table file that is not present")
+
+// checkNewSpecsPresent verifies that every table file |contents| newly depends
+// on is present in |dir|. Callers hold the manifest file lock, and this runs
+// after the on-disk manifest has been read and before the new one is renamed
+// into place, so a file that passes here cannot be removed by a lock-respecting
+// process before the manifest naming it is committed.
+//
+// Nothing is expected to trip this: every path that adds a spec either renames
+// the file into place first or opens it first. It catches a file that went
+// missing in between, which our own open file descriptor would not notice.
+//
+// Only specs |upstream| does not already carry are checked; re-verifying the
+// whole set would make every manifest write a directory-sized stat storm.
+func checkNewSpecsPresent(dir string, upstream, contents manifestContents) error {
+	existing := upstream.getSpecSet()
+	for h := range upstream.getAppendixSet() {
+		existing[h] = struct{}{}
+	}
+
+	var missing []string
+	checked := make(map[hash.Hash]struct{})
+	for _, specs := range [][]tableSpec{contents.specs, contents.appendix} {
+		for _, s := range specs {
+			if _, ok := existing[s.name]; ok {
+				continue
+			}
+			if _, ok := checked[s.name]; ok {
+				continue
+			}
+			checked[s.name] = struct{}{}
+
+			ok, err := tableFileOrArchiveExists(dir, s.name)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				missing = append(missing, s.name.String())
+			}
+		}
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("%w: %s in %s", ErrManifestSpecMissingTableFile, strings.Join(missing, ", "), dir)
+	}
+	return nil
+}
+
+// tableFileOrArchiveExists reports whether |h| is present in |dir| as either a
+// table file or an archive. A tableSpec records only the address, so which of
+// the two it is has to be discovered by looking.
+func tableFileOrArchiveExists(dir string, h hash.Hash) (bool, error) {
+	for _, name := range []string{h.String(), h.String() + ArchiveFileSuffix} {
+		_, err := os.Stat(filepath.Join(dir, name))
+		if err == nil {
+			return true, nil
+		}
+		if !errors.Is(err, fs.ErrNotExist) {
+			return false, err
+		}
+	}
+	return false, nil
 }
 
 // parseV5Manifest parses the v5 manifest from the Reader given. Assumes the first field (the manifest version and

--- a/go/store/nbs/file_manifest.go
+++ b/go/store/nbs/file_manifest.go
@@ -232,12 +232,9 @@ var ErrManifestSpecMissingTableFile = errors.New("refusing to write a manifest r
 // into place, so a file that passes here cannot be removed by a lock-respecting
 // process before the manifest naming it is committed.
 //
-// Nothing is expected to trip this: every path that adds a spec either renames
-// the file into place first or opens it first. It catches a file that went
-// missing in between, which our own open file descriptor would not notice.
-//
-// Only specs |upstream| does not already carry are checked; re-verifying the
-// whole set would make every manifest write a directory-sized stat storm.
+// Only specs |upstream| does not already carry are checked. If |upstream| is
+// stale, we need to rebase regardless, and this manifest update is doomed. When
+// it is not stale, only the new specs need to be asserted as still present.
 func checkNewSpecsPresent(dir string, upstream, contents manifestContents) error {
 	existing := upstream.getSpecSet()
 	for h := range upstream.getAppendixSet() {

--- a/go/store/nbs/file_manifest_test.go
+++ b/go/store/nbs/file_manifest_test.go
@@ -131,11 +131,13 @@ func TestFileManifestUpdate(t *testing.T) {
 	stats := &Stats{}
 
 	// First, test winning the race against another process.
+	specA := computeAddr([]byte("a"))
+	touchTableFile(t, fm.dir, specA)
 	contents := manifestContents{
 		nbfVers: constants.FormatDoltString,
 		lock:    computeAddr([]byte("locker")),
 		root:    hash.Of([]byte("new root")),
-		specs:   []tableSpec{{computeAddr([]byte("a")), 3}},
+		specs:   []tableSpec{{specA, 3}},
 	}
 	upstream, err := fm.Update(context.Background(), dherrors.FatalBehaviorError, hash.Hash{}, contents, stats, func() error {
 		// This should fail to get the lock, and therefore _not_ clobber the manifest. So the Update should succeed.
@@ -203,4 +205,169 @@ func runClobber(dir, contents string) ([]byte, error) {
 
 	c := exec.Command("go", "run", clobber, mkPath(lockFileName), mkPath(manifestFileName), contents)
 	return c.CombinedOutput()
+}
+
+// touchTableFile creates an empty stand-in for the table file named |h| in
+// |dir|, so that a manifest update may take a dependency on it.
+func touchTableFile(t *testing.T, dir string, h hash.Hash) string {
+	t.Helper()
+	p := filepath.Join(dir, h.String())
+	require.NoError(t, os.WriteFile(p, nil, 0666))
+	return p
+}
+
+// TestFileManifestUpdateRejectsMissingTableFile asserts that a manifest update
+// refuses to publish a dependency on a table file that is not in the
+// directory. A writer that committed such a manifest would leave the store
+// broken for every other process, while continuing to read the file through
+// its own already-open descriptor.
+func TestFileManifestUpdateRejectsMissingTableFile(t *testing.T) {
+	ctx := context.Background()
+	fm := makeFileManifestTempDir(t)
+	defer file.RemoveAll(fm.dir)
+	stats := &Stats{}
+
+	present := computeAddr([]byte("present"))
+	absent := computeAddr([]byte("absent"))
+	touchTableFile(t, fm.dir, present)
+
+	contents := manifestContents{
+		nbfVers: constants.FormatDoltString,
+		lock:    computeAddr([]byte("lock")),
+		root:    hash.Of([]byte("root")),
+		specs:   []tableSpec{{present, 1}, {absent, 1}},
+	}
+
+	_, err := fm.Update(ctx, dherrors.FatalBehaviorError, hash.Hash{}, contents, stats, nil)
+	require.ErrorIs(t, err, ErrManifestSpecMissingTableFile)
+	require.ErrorContains(t, err, absent.String())
+
+	// The manifest must not have been committed.
+	exists, _, err := fm.ParseIfExists(ctx, stats, nil)
+	require.NoError(t, err)
+	require.False(t, exists, "a rejected update must not publish a manifest")
+}
+
+// TestFileManifestUpdateAcceptsArchive asserts an archive satisfies a spec.
+// A tableSpec records only the address, so both spellings must be tried.
+func TestFileManifestUpdateAcceptsArchive(t *testing.T) {
+	ctx := context.Background()
+	fm := makeFileManifestTempDir(t)
+	defer file.RemoveAll(fm.dir)
+	stats := &Stats{}
+
+	archive := computeAddr([]byte("archive"))
+	require.NoError(t, os.WriteFile(filepath.Join(fm.dir, archive.String()+ArchiveFileSuffix), nil, 0666))
+
+	contents := manifestContents{
+		nbfVers: constants.FormatDoltString,
+		lock:    computeAddr([]byte("lock")),
+		root:    hash.Of([]byte("root")),
+		specs:   []tableSpec{{archive, 1}},
+	}
+
+	upstream, err := fm.Update(ctx, dherrors.FatalBehaviorError, hash.Hash{}, contents, stats, nil)
+	require.NoError(t, err)
+	require.Equal(t, contents.lock, upstream.lock)
+}
+
+// TestFileManifestUpdateAcceptsAppendix asserts appendix specs are checked too;
+// they name table files the same way the main spec list does.
+func TestFileManifestUpdateAcceptsAppendix(t *testing.T) {
+	ctx := context.Background()
+	fm := makeFileManifestTempDir(t)
+	defer file.RemoveAll(fm.dir)
+	stats := &Stats{}
+
+	appendix := computeAddr([]byte("appendix"))
+	contents := manifestContents{
+		nbfVers:  constants.FormatDoltString,
+		lock:     computeAddr([]byte("lock")),
+		root:     hash.Of([]byte("root")),
+		specs:    []tableSpec{{appendix, 1}},
+		appendix: []tableSpec{{appendix, 1}},
+	}
+
+	_, err := fm.Update(ctx, dherrors.FatalBehaviorError, hash.Hash{}, contents, stats, nil)
+	require.ErrorIs(t, err, ErrManifestSpecMissingTableFile)
+
+	touchTableFile(t, fm.dir, appendix)
+	upstream, err := fm.Update(ctx, dherrors.FatalBehaviorError, hash.Hash{}, contents, stats, nil)
+	require.NoError(t, err)
+	require.Equal(t, contents.lock, upstream.lock)
+}
+
+// TestFileManifestUpdateSkipsExistingSpecs asserts only newly added specs are
+// checked. Re-verifying the whole set on every write would cost a stat per
+// table file, and those files were vouched for when they were added.
+func TestFileManifestUpdateSkipsExistingSpecs(t *testing.T) {
+	ctx := context.Background()
+	fm := makeFileManifestTempDir(t)
+	defer file.RemoveAll(fm.dir)
+	stats := &Stats{}
+
+	first := computeAddr([]byte("first"))
+	firstPath := touchTableFile(t, fm.dir, first)
+	contents := manifestContents{
+		nbfVers: constants.FormatDoltString,
+		lock:    computeAddr([]byte("lock 1")),
+		root:    hash.Of([]byte("root")),
+		specs:   []tableSpec{{first, 1}},
+	}
+	upstream, err := fm.Update(ctx, dherrors.FatalBehaviorError, hash.Hash{}, contents, stats, nil)
+	require.NoError(t, err)
+
+	// Something removes the already-referenced file out from under us. The
+	// store is broken, but that is not this update's doing and not its job to
+	// notice.
+	require.NoError(t, os.Remove(firstPath))
+
+	second := computeAddr([]byte("second"))
+	touchTableFile(t, fm.dir, second)
+	contents2 := manifestContents{
+		nbfVers: constants.FormatDoltString,
+		lock:    computeAddr([]byte("lock 2")),
+		root:    hash.Of([]byte("root")),
+		specs:   []tableSpec{{first, 1}, {second, 1}},
+	}
+	upstream, err = fm.Update(ctx, dherrors.FatalBehaviorError, upstream.lock, contents2, stats, nil)
+	require.NoError(t, err)
+	require.Equal(t, contents2.lock, upstream.lock)
+}
+
+// TestFileManifestUpdateGCGenRejectsMissingTableFile asserts the GC generation
+// update path is checked as well; it publishes a wholly new spec list.
+func TestFileManifestUpdateGCGenRejectsMissingTableFile(t *testing.T) {
+	ctx := context.Background()
+	fm := makeFileManifestTempDir(t)
+	defer file.RemoveAll(fm.dir)
+	stats := &Stats{}
+
+	root := hash.Of([]byte("root"))
+	present := computeAddr([]byte("present"))
+	touchTableFile(t, fm.dir, present)
+	contents := manifestContents{
+		nbfVers: constants.FormatDoltString,
+		lock:    computeAddr([]byte("lock 1")),
+		root:    root,
+		specs:   []tableSpec{{present, 1}},
+	}
+	upstream, err := fm.Update(ctx, dherrors.FatalBehaviorError, hash.Hash{}, contents, stats, nil)
+	require.NoError(t, err)
+
+	collected := computeAddr([]byte("collected"))
+	gcContents := manifestContents{
+		nbfVers: constants.FormatDoltString,
+		lock:    computeAddr([]byte("lock 2")),
+		root:    root,
+		gcGen:   computeAddr([]byte("gcgen")),
+		specs:   []tableSpec{{collected, 1}},
+	}
+	_, err = fm.UpdateGCGen(ctx, dherrors.FatalBehaviorError, upstream.lock, gcContents, stats, nil)
+	require.ErrorIs(t, err, ErrManifestSpecMissingTableFile)
+
+	touchTableFile(t, fm.dir, collected)
+	after, err := fm.UpdateGCGen(ctx, dherrors.FatalBehaviorError, upstream.lock, gcContents, stats, nil)
+	require.NoError(t, err)
+	require.Equal(t, gcContents.lock, after.lock)
 }

--- a/go/store/nbs/file_manifest_test.go
+++ b/go/store/nbs/file_manifest_test.go
@@ -249,7 +249,8 @@ func TestFileManifestUpdateRejectsMissingTableFile(t *testing.T) {
 }
 
 // TestFileManifestUpdateAcceptsArchive asserts an archive satisfies a spec.
-// A tableSpec records only the address, so both spellings must be tried.
+// A tableSpec records only the address. This is just exercising the file
+// existence check on the archive file name.
 func TestFileManifestUpdateAcceptsArchive(t *testing.T) {
 	ctx := context.Background()
 	fm := makeFileManifestTempDir(t)
@@ -271,8 +272,8 @@ func TestFileManifestUpdateAcceptsArchive(t *testing.T) {
 	require.Equal(t, contents.lock, upstream.lock)
 }
 
-// TestFileManifestUpdateAcceptsAppendix asserts appendix specs are checked too;
-// they name table files the same way the main spec list does.
+// TestFileManifestUpdateAcceptsAppendix asserts appendix specs are checked
+// as part of the file existence check in a file manifest update.
 func TestFileManifestUpdateAcceptsAppendix(t *testing.T) {
 	ctx := context.Background()
 	fm := makeFileManifestTempDir(t)
@@ -298,8 +299,11 @@ func TestFileManifestUpdateAcceptsAppendix(t *testing.T) {
 }
 
 // TestFileManifestUpdateSkipsExistingSpecs asserts only newly added specs are
-// checked. Re-verifying the whole set on every write would cost a stat per
-// table file, and those files were vouched for when they were added.
+// checked. Existence checks are not required for table files which are already
+// open in the store. If the manifest is stale, it will need to be rebased
+// regardless before landing an update. If it is not stale, no correctly
+// behaving removal logic should be removing files which are referenced in the
+// manifest. Thus, it is not this logic's job to detect such a case.
 func TestFileManifestUpdateSkipsExistingSpecs(t *testing.T) {
 	ctx := context.Background()
 	fm := makeFileManifestTempDir(t)
@@ -336,7 +340,7 @@ func TestFileManifestUpdateSkipsExistingSpecs(t *testing.T) {
 }
 
 // TestFileManifestUpdateGCGenRejectsMissingTableFile asserts the GC generation
-// update path is checked as well; it publishes a wholly new spec list.
+// update path checks newly added files for existence.
 func TestFileManifestUpdateGCGenRejectsMissingTableFile(t *testing.T) {
 	ctx := context.Background()
 	fm := makeFileManifestTempDir(t)


### PR DESCRIPTION
A bare local store takes no cross-process lock while a table file is landing, so between the moment a writer opens or renames a table file and the moment it commits a manifest naming it, another process can unlink it.  The writer does not notice, since its own file descriptor keeps working, and it publishes a manifest that is broken for everyone else.

Add a sanity check where we Stat the newly added files under the manifest LOCK. This allows other Dolt processes which want to safely unlink unreferenced files from the directory to do so under the same LOCK. While a write may transiently fail if an about-to-be-referenced file is deleted out from under it, it won't cause database corruption by writing a manifest which references a non-existant table file.

This PR adds the add-files sanity check. It does not add the machinery to safely remove any files yet.

Journaled stores are unaffected: ChunkJournal goes through journalManifest, not fileManifest.