### PR TITLE
Add s3:// remote scheme for generic S3-compatible object stores (#509)

### DIFF
--- a/go/cmd/dolt/cli/arg_parser_helpers.go
+++ b/go/cmd/dolt/cli/arg_parser_helpers.go
@@ -156,6 +156,9 @@ func CreateCloneArgParser() *argparser.ArgParser {
 	ap.SupportsString(dbfactory.AWSCredsProfile, "", "profile", "AWS profile to use.")
 	ap.SupportsString(dbfactory.OSSCredsFileParam, "", "file", "OSS credentials file.")
 	ap.SupportsString(dbfactory.OSSCredsProfile, "", "profile", "OSS profile to use.")
+	ap.SupportsString(dbfactory.S3EndpointParam, "", "endpoint", "S3-compatible endpoint url (e.g. Cloudflare R2 or MinIO); only valid for s3 remotes.")
+	ap.SupportsString(dbfactory.S3RegionParam, "", "region", "Signing region for s3 remotes.")
+	ap.SupportsString(dbfactory.S3PathStyleParam, "", "true|false", "Use path-style addressing for s3 remotes.")
 	ap.SupportsString(UserFlag, "u", "user", "User name to use when authenticating with the remote. Gets password from the environment variable {{.EmphasisLeft}}DOLT_REMOTE_PASSWORD{{.EmphasisRight}}.")
 	ap.SupportsFlag(SingleBranchFlag, "", "Clone only the history leading to the tip of a single branch, either specified by --branch or the remote's HEAD (default).")
 	return ap
@@ -430,6 +433,7 @@ func CreateGlobalArgParser(name string) *argparser.ArgParser {
 
 var AwsParams = []string{dbfactory.AWSRegionParam, dbfactory.AWSCredsTypeParam, dbfactory.AWSCredsFileParam, dbfactory.AWSCredsProfile}
 var ossParams = []string{dbfactory.OSSCredsFileParam, dbfactory.OSSCredsProfile}
+var s3Params = []string{dbfactory.S3EndpointParam, dbfactory.S3RegionParam, dbfactory.S3PathStyleParam}
 
 func AddAWSParams(remoteUrl string, apr *argparser.ArgParseResults, params map[string]string) error {
 	isAWS := strings.HasPrefix(remoteUrl, "aws")
@@ -463,6 +467,26 @@ func AddOSSParams(remoteUrl string, apr *argparser.ArgParseResults, params map[s
 	}
 
 	for _, p := range ossParams {
+		if val, ok := apr.GetValue(p); ok {
+			params[p] = val
+		}
+	}
+
+	return nil
+}
+
+func AddS3Params(remoteUrl string, apr *argparser.ArgParseResults, params map[string]string) error {
+	isS3 := strings.HasPrefix(remoteUrl, "s3:")
+
+	if !isS3 {
+		for _, p := range s3Params {
+			if _, ok := apr.GetValue(p); ok {
+				return fmt.Errorf("%s param is only valid for s3 remotes in the format s3://bucket/database", p)
+			}
+		}
+	}
+
+	for _, p := range s3Params {
 		if val, ok := apr.GetValue(p); ok {
 			params[p] = val
 		}

--- a/go/cmd/dolt/commands/remote.go
+++ b/go/cmd/dolt/commands/remote.go
@@ -43,7 +43,7 @@ var remoteDocs = cli.CommandDocumentationContent{
 {{.EmphasisLeft}}add{{.EmphasisRight}}
 Adds a remote named {{.LessThan}}name{{.GreaterThan}} for the repository at {{.LessThan}}url{{.GreaterThan}}. The command dolt fetch {{.LessThan}}name{{.GreaterThan}} can then be used to create and update remote-tracking branches {{.EmphasisLeft}}<name>/<branch>{{.EmphasisRight}}.
 
-The {{.LessThan}}url{{.GreaterThan}} parameter supports url schemes of http, https, aws, gs, and file. The url prefix defaults to https. If the {{.LessThan}}url{{.GreaterThan}} parameter is in the format {{.EmphasisLeft}}<organization>/<repository>{{.EmphasisRight}} then dolt will use the {{.EmphasisLeft}}remotes.default_host{{.EmphasisRight}} from your configuration file (Which will be dolthub.com unless changed).
+The {{.LessThan}}url{{.GreaterThan}} parameter supports url schemes of http, https, aws, s3, gs, and file. The url prefix defaults to https. If the {{.LessThan}}url{{.GreaterThan}} parameter is in the format {{.EmphasisLeft}}<organization>/<repository>{{.EmphasisRight}} then dolt will use the {{.EmphasisLeft}}remotes.default_host{{.EmphasisRight}} from your configuration file (Which will be dolthub.com unless changed).
 
 AWS cloud remote urls should be of the form {{.EmphasisLeft}}aws://[dynamo-table:s3-bucket]/database{{.EmphasisRight}}.  You may configure your aws cloud remote using the optional parameters {{.EmphasisLeft}}aws-region{{.EmphasisRight}}, {{.EmphasisLeft}}aws-creds-type{{.EmphasisRight}}, {{.EmphasisLeft}}aws-creds-file{{.EmphasisRight}}.
 
@@ -53,6 +53,8 @@ aws-creds-type specifies the means by which credentials should be retrieved in o
 	env: Looks for environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
 	file: Uses the credentials file specified by the parameter aws-creds-file
 	
+S3-compatible remote urls should be of the form {{.EmphasisLeft}}s3://bucket/database{{.EmphasisRight}}. They work against any object store implementing the S3 API with conditional writes, including AWS S3, Cloudflare R2, and MinIO, and require no DynamoDB table. Credentials come from the standard AWS SDK chain (environment variables, shared config, SSO). Optional parameters: {{.EmphasisLeft}}s3-endpoint{{.EmphasisRight}} (e.g. an R2 or MinIO endpoint; the AWS_ENDPOINT_URL_S3 environment variable is also honored), {{.EmphasisLeft}}s3-region{{.EmphasisRight}}, and {{.EmphasisLeft}}s3-path-style{{.EmphasisRight}} (true/false, for providers requiring path-style addressing).
+
 GCP remote urls should be of the form gs://gcs-bucket/database and will use the credentials setup using the gcloud command line available from Google.
 
 The local filesystem can be used as a remote by providing a repository url in the format file://absolute path. See https://en.wikipedia.org/wiki/File_URI_scheme
@@ -102,6 +104,10 @@ func (cmd RemoteCmd) ArgParser() *argparser.ArgParser {
 
 	ap.SupportsString(dbfactory.OSSCredsFileParam, "", "file", "OSS credentials file")
 	ap.SupportsString(dbfactory.OSSCredsProfile, "", "profile", "OSS profile to use")
+
+	ap.SupportsString(dbfactory.S3EndpointParam, "", "endpoint", "S3-compatible endpoint url (e.g. Cloudflare R2 or MinIO); only valid for s3 remotes")
+	ap.SupportsString(dbfactory.S3RegionParam, "", "region", "Signing region for s3 remotes")
+	ap.SupportsString(dbfactory.S3PathStyleParam, "", "true|false", "Use path-style addressing for s3 remotes")
 	return ap
 }
 
@@ -219,6 +225,8 @@ func parseRemoteArgs(apr *argparser.ArgParseResults, scheme, remoteUrl string) (
 		err = cli.AddAWSParams(remoteUrl, apr, params)
 	case dbfactory.OSSScheme:
 		err = cli.AddOSSParams(remoteUrl, apr, params)
+	case dbfactory.S3Scheme:
+		err = cli.AddS3Params(remoteUrl, apr, params)
 	case dbfactory.GitFileScheme, dbfactory.GitHTTPScheme, dbfactory.GitHTTPSScheme, dbfactory.GitSSHScheme:
 		verr := addGitRemoteParams(apr, params)
 		if verr != nil {

--- a/go/libraries/doltcore/dbfactory/factory.go
+++ b/go/libraries/doltcore/dbfactory/factory.go
@@ -30,6 +30,11 @@ const (
 	// AWSScheme
 	AWSScheme = "aws"
 
+	// S3Scheme is for generic S3-compatible stores (AWS S3, Cloudflare R2,
+	// MinIO, ...) using conditional PutObject for the manifest, with no
+	// DynamoDB dependency. See S3Factory.
+	S3Scheme = "s3"
+
 	// GSScheme
 	GSScheme = "gs"
 
@@ -81,6 +86,7 @@ type DBFactory interface {
 // from external packages.
 var DBFactories = map[string]DBFactory{
 	AWSScheme:      AWSFactory{},
+	S3Scheme:       S3Factory{},
 	OSSScheme:      OSSFactory{},
 	GSScheme:       GSFactory{},
 	AzScheme:       AzureDBFactory{},

--- a/go/libraries/doltcore/dbfactory/s3.go
+++ b/go/libraries/doltcore/dbfactory/s3.go
@@ -1,0 +1,134 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dbfactory
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/memlimit"
+	"github.com/dolthub/dolt/go/store/blobstore"
+	"github.com/dolthub/dolt/go/store/datas"
+	"github.com/dolthub/dolt/go/store/nbs"
+	"github.com/dolthub/dolt/go/store/prolly/tree"
+	"github.com/dolthub/dolt/go/store/types"
+)
+
+const (
+	// S3EndpointParam is a creation parameter that overrides the S3 endpoint.
+	// Use it to target S3-compatible stores such as Cloudflare R2
+	// (https://<account>.r2.cloudflarestorage.com) or MinIO. When absent, the
+	// AWS SDK's standard resolution applies, including the AWS_ENDPOINT_URL_S3
+	// environment variable.
+	S3EndpointParam = "s3-endpoint"
+
+	// S3RegionParam is a creation parameter that overrides the signing region.
+	// Some S3-compatible providers accept any value here (R2 uses "auto").
+	S3RegionParam = "s3-region"
+
+	// S3PathStyleParam is a creation parameter ("true"/"false") that forces
+	// path-style addressing (https://endpoint/bucket/key) instead of
+	// virtual-hosted style. Most non-AWS providers require or prefer it.
+	S3PathStyleParam = "s3-path-style"
+)
+
+// S3Factory is a DBFactory implementation for databases backed by generic
+// S3-compatible object stores (AWS S3, Cloudflare R2, MinIO, ...) that
+// support conditional writes (If-Match / If-None-Match on PutObject).
+//
+// Unlike the aws:// scheme, which pairs an S3 bucket with a DynamoDB table
+// for the manifest, s3:// stores the manifest as an ordinary object and
+// relies on conditional PutObject for the atomic check-and-set. Credentials
+// come from the standard AWS SDK chain (environment variables, shared
+// config/credentials files, SSO, IMDS).
+//
+// URL format: s3://bucket/path/to/db
+type S3Factory struct {
+}
+
+// PrepareDB prepares an S3-compatible backed database
+func (fact S3Factory) PrepareDB(ctx context.Context, nbf *types.NomsBinFormat, urlObj *url.URL, params map[string]interface{}) error {
+	// nothing to prepare
+	return nil
+}
+
+// CreateDB creates a database backed by a generic S3-compatible object store
+func (fact S3Factory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, urlObj *url.URL, params map[string]interface{}) (datas.Database, types.ValueReadWriter, tree.NodeStore, error) {
+	bucket := urlObj.Hostname()
+	if bucket == "" {
+		return nil, nil, nil, errors.New("s3 url must be of the form s3://bucket/path")
+	}
+	prefix := urlObj.Path
+
+	client, err := newS3Client(ctx, params)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	bs := blobstore.NewS3Blobstore(client, bucket, prefix)
+
+	q := nbs.NewUnlimitedMemQuotaProvider()
+	// The S3 blobstore has no server-side compose operation, so use the
+	// no-conjoin store: table files are written whole and never concatenated
+	// through the blobstore.
+	s3Store, err := nbs.NewNoConjoinBSStore(ctx, nbf.VersionString(), bs, memlimit.MemtableSize(), q)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	vrw := types.NewValueStore(s3Store)
+	ns := tree.NewNodeStore(s3Store)
+	db := datas.NewTypesDatabase(vrw, ns)
+
+	return db, vrw, ns, nil
+}
+
+func newS3Client(ctx context.Context, params map[string]interface{}) (*s3.Client, error) {
+	var loadOpts []func(*config.LoadOptions) error
+	if region, ok := paramString(params, S3RegionParam); ok {
+		loadOpts = append(loadOpts, config.WithRegion(region))
+	}
+
+	cfg, err := config.LoadDefaultConfig(ctx, loadOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return s3.NewFromConfig(cfg, func(o *s3.Options) {
+		if endpoint, ok := paramString(params, S3EndpointParam); ok {
+			o.BaseEndpoint = aws.String(endpoint)
+		}
+		if ps, ok := paramString(params, S3PathStyleParam); ok {
+			if b, err := strconv.ParseBool(ps); err == nil {
+				o.UsePathStyle = b
+			}
+		}
+	}), nil
+}
+
+func paramString(params map[string]interface{}, key string) (string, bool) {
+	if v, ok := params[key]; ok {
+		if s, ok := v.(string); ok && s != "" {
+			return s, true
+		}
+	}
+	return "", false
+}

--- a/go/store/blobstore/s3.go
+++ b/go/store/blobstore/s3.go
@@ -1,0 +1,216 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+)
+
+// S3Blobstore provides an S3-compatible implementation of the Blobstore
+// interface. It works against any object store that implements the S3 API
+// including conditional writes (If-Match / If-None-Match on PutObject):
+// AWS S3, Cloudflare R2, and MinIO among others.
+//
+// Version tokens are object ETags, treated as opaque strings and passed back
+// to the server exactly as received. CheckAndPut relies on conditional
+// PutObject: If-None-Match:* when no version is expected (create), and
+// If-Match:<etag> otherwise (replace). A failed precondition (HTTP 412), a
+// conditional-write conflict (HTTP 409, AWS "ConditionalRequestConflict"),
+// or a missing key under If-Match are all surfaced as CheckAndPutError so
+// the NBS manifest layer rereads and retries.
+//
+// CheckAndPut always uses a direct single-part PutObject: ETags of multipart
+// uploads are not content-stable across providers, and conditional headers on
+// CompleteMultipartUpload are not universally supported. This is intended for
+// small objects such as the NBS manifest. Ordinary Put uses the SDK upload
+// manager, which switches to multipart automatically for large objects.
+type S3Blobstore struct {
+	client     *s3.Client
+	uploader   *manager.Uploader
+	bucketName string
+	prefix     string
+}
+
+var _ Blobstore = &S3Blobstore{}
+
+// NewS3Blobstore creates a new instance of an S3Blobstore.
+func NewS3Blobstore(client *s3.Client, bucketName, prefix string) *S3Blobstore {
+	for len(prefix) > 0 && prefix[0] == '/' {
+		prefix = prefix[1:]
+	}
+	uploader := manager.NewUploader(client)
+	return &S3Blobstore{client, uploader, bucketName, prefix}
+}
+
+func (bs *S3Blobstore) Path() string {
+	return path.Join(bs.bucketName, bs.prefix)
+}
+
+func (bs *S3Blobstore) Teardown(ctx context.Context) error {
+	return nil
+}
+
+// Exists returns true if a blob exists for the given key, and false if it does not.
+func (bs *S3Blobstore) Exists(ctx context.Context, key string) (bool, error) {
+	absKey := path.Join(bs.prefix, key)
+	_, err := bs.client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(bs.bucketName),
+		Key:    aws.String(absKey),
+	})
+	if err == nil {
+		return true, nil
+	}
+	var notFound *s3types.NotFound
+	if errors.As(err, &notFound) || s3HTTPStatus(err) == 404 {
+		return false, nil
+	}
+	return false, err
+}
+
+// Get retrieves an io.ReadCloser for the portion of a blob specified by br along with its version.
+func (bs *S3Blobstore) Get(ctx context.Context, key string, br BlobRange) (io.ReadCloser, uint64, string, error) {
+	absKey := path.Join(bs.prefix, key)
+	req := &s3.GetObjectInput{
+		Bucket: aws.String(bs.bucketName),
+		Key:    aws.String(absKey),
+	}
+
+	byteRange := br.asHttpRangeHeader()
+	if byteRange != "" {
+		req.Range = aws.String(byteRange)
+	}
+
+	res, err := bs.client.GetObject(ctx, req)
+	if err != nil {
+		var noSuchKey *s3types.NoSuchKey
+		if errors.As(err, &noSuchKey) || s3HTTPStatus(err) == 404 {
+			return nil, 0, "", NotFound{"s3://" + path.Join(bs.bucketName, absKey)}
+		}
+		return nil, 0, "", err
+	}
+
+	var size uint64
+	// For range requests the total size comes from the Content-Range header.
+	if res.ContentRange != nil {
+		size = parseContentRangeSize(*res.ContentRange)
+	}
+	if size == 0 && res.ContentLength != nil {
+		size = uint64(*res.ContentLength)
+	}
+
+	// handle negative offset and positive length
+	if br.offset < 0 && br.length > 0 {
+		lr := io.LimitReader(res.Body, br.length)
+		return struct {
+			io.Reader
+			io.Closer
+		}{lr, res.Body}, size, fmtstr(res.ETag), nil
+	}
+
+	return res.Body, size, fmtstr(res.ETag), nil
+}
+
+// Put stores a blob from |reader| keyed by |key|, returning the new version.
+// Large objects are uploaded via multipart automatically.
+func (bs *S3Blobstore) Put(ctx context.Context, key string, totalSize int64, reader io.Reader) (string, error) {
+	absKey := path.Join(bs.prefix, key)
+	res, err := bs.uploader.Upload(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bs.bucketName),
+		Key:    aws.String(absKey),
+		Body:   reader,
+	})
+	if err != nil {
+		return "", err
+	}
+	return fmtstr(res.ETag), nil
+}
+
+// CheckAndPut updates the blob keyed by |key| using a conditional PutObject
+// on |expectedVersion| (an ETag). See the type comment for the protocol.
+func (bs *S3Blobstore) CheckAndPut(ctx context.Context, expectedVersion, key string, totalSize int64, reader io.Reader) (string, error) {
+	absKey := path.Join(bs.prefix, key)
+	req := &s3.PutObjectInput{
+		Bucket:        aws.String(bs.bucketName),
+		Key:           aws.String(absKey),
+		Body:          reader,
+		ContentLength: aws.Int64(totalSize),
+	}
+
+	if expectedVersion != "" {
+		req.IfMatch = aws.String(expectedVersion)
+	} else {
+		req.IfNoneMatch = aws.String("*")
+	}
+
+	res, err := bs.client.PutObject(ctx, req)
+	if err != nil {
+		status := s3HTTPStatus(err)
+		switch {
+		case status == 412:
+			// Precondition failed: another writer won the race.
+			return "", CheckAndPutError{Key: key, ExpectedVersion: expectedVersion, ActualVersion: "unknown"}
+		case isS3ConditionalConflict(err):
+			// AWS returns 409 ConditionalRequestConflict when concurrent
+			// conditional writes collide; the caller must reread and retry,
+			// which is exactly the CheckAndPutError contract.
+			return "", CheckAndPutError{Key: key, ExpectedVersion: expectedVersion, ActualVersion: "unknown"}
+		case expectedVersion != "" && status == 404:
+			// If-Match against a missing key: the expected version cannot
+			// match a nonexistent object.
+			return "", CheckAndPutError{Key: key, ExpectedVersion: expectedVersion, ActualVersion: ""}
+		}
+		return "", err
+	}
+
+	return fmtstr(res.ETag), nil
+}
+
+// Concatenate is unimplemented: generic S3-compatible stores have no
+// server-side compose operation. Use an NBS constructor that never conjoins
+// through the blobstore (e.g. nbs.NewNoConjoinBSStore).
+func (bs *S3Blobstore) Concatenate(ctx context.Context, key string, sources []string) (string, error) {
+	return "", fmt.Errorf("concatenate is unimplemented on the s3 blobstore")
+}
+
+// s3HTTPStatus extracts the HTTP status code from an SDK error, or 0.
+func s3HTTPStatus(err error) int {
+	var re *awshttp.ResponseError
+	if errors.As(err, &re) {
+		return re.HTTPStatusCode()
+	}
+	return 0
+}
+
+// isS3ConditionalConflict reports whether err is AWS's conditional-write
+// conflict (HTTP 409, code "ConditionalRequestConflict"). Only this specific
+// 409 maps to CheckAndPutError; generic 409s do not.
+func isS3ConditionalConflict(err error) bool {
+	var ae smithy.APIError
+	if errors.As(err, &ae) {
+		return ae.ErrorCode() == "ConditionalRequestConflict"
+	}
+	return false
+}

--- a/go/store/blobstore/s3_test.go
+++ b/go/store/blobstore/s3_test.go
@@ -1,0 +1,196 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstore
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Integration tests for the S3-compatible blobstore. They run only when
+// TEST_S3_BUCKET is set, following the convention of the GCS/OCI tests.
+// TEST_S3_ENDPOINT (optional) points them at an S3-compatible provider such
+// as Cloudflare R2 or MinIO; TEST_S3_PATH_STYLE=true forces path-style
+// addressing. Credentials come from the standard AWS SDK chain.
+const (
+	envTestS3Bucket    = "TEST_S3_BUCKET"
+	envTestS3Endpoint  = "TEST_S3_ENDPOINT"
+	envTestS3PathStyle = "TEST_S3_PATH_STYLE"
+)
+
+func newTestS3Blobstore(t *testing.T) *S3Blobstore {
+	bucket := os.Getenv(envTestS3Bucket)
+	if bucket == "" {
+		t.Skipf("skipping: %s not set", envTestS3Bucket)
+	}
+
+	cfg, err := config.LoadDefaultConfig(context.Background())
+	require.NoError(t, err)
+
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		if ep := os.Getenv(envTestS3Endpoint); ep != "" {
+			o.BaseEndpoint = aws.String(ep)
+		}
+		if os.Getenv(envTestS3PathStyle) == "true" {
+			o.UsePathStyle = true
+		}
+	})
+
+	return NewS3Blobstore(client, bucket, "dolt-s3-blobstore-test/"+uuid.New().String())
+}
+
+func TestS3PutGetExists(t *testing.T) {
+	bs := newTestS3Blobstore(t)
+	ctx := context.Background()
+
+	data := []byte("s3 blobstore test payload")
+	ver, err := PutBytes(ctx, bs, "obj", data)
+	require.NoError(t, err)
+	assert.NotEmpty(t, ver)
+
+	ok, err := bs.Exists(ctx, "obj")
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = bs.Exists(ctx, "absent")
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	read, gotVer, err := GetBytes(ctx, bs, "obj", AllRange)
+	require.NoError(t, err)
+	assert.Equal(t, data, read)
+	assert.Equal(t, ver, gotVer)
+
+	// ranged read: bytes 3..7
+	rangeRead, _, err := GetBytes(ctx, bs, "obj", NewBlobRange(3, 4))
+	require.NoError(t, err)
+	assert.Equal(t, data[3:7], rangeRead)
+
+	_, _, err = GetBytes(ctx, bs, "absent", AllRange)
+	assert.True(t, IsNotFoundError(err))
+}
+
+func TestS3CheckAndPut(t *testing.T) {
+	bs := newTestS3Blobstore(t)
+	ctx := context.Background()
+
+	// create with no expected version
+	v1, err := bs.CheckAndPut(ctx, "", "manifest", 4, bytes.NewReader([]byte("one1")))
+	require.NoError(t, err)
+	require.NotEmpty(t, v1)
+
+	// create again must fail: key exists
+	_, err = bs.CheckAndPut(ctx, "", "manifest", 4, bytes.NewReader([]byte("two2")))
+	assert.True(t, IsCheckAndPutError(err), "expected CheckAndPutError, got %v", err)
+
+	// update with the correct version succeeds
+	v2, err := bs.CheckAndPut(ctx, v1, "manifest", 4, bytes.NewReader([]byte("two2")))
+	require.NoError(t, err)
+	require.NotEmpty(t, v2)
+	require.NotEqual(t, v1, v2)
+
+	// update with a stale version fails
+	_, err = bs.CheckAndPut(ctx, v1, "manifest", 6, bytes.NewReader([]byte("three3")))
+	assert.True(t, IsCheckAndPutError(err), "expected CheckAndPutError, got %v", err)
+
+	// If-Match against a missing key fails and must not create it
+	_, err = bs.CheckAndPut(ctx, v1, "no-such-key", 4, bytes.NewReader([]byte("nope")))
+	assert.True(t, IsCheckAndPutError(err), "expected CheckAndPutError, got %v", err)
+	ok, err := bs.Exists(ctx, "no-such-key")
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	// the winning contents survived
+	read, _, err := GetBytes(ctx, bs, "manifest", AllRange)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("two2"), read)
+}
+
+func TestS3CheckAndPutConcurrent(t *testing.T) {
+	bs := newTestS3Blobstore(t)
+	ctx := context.Background()
+
+	base, err := bs.CheckAndPut(ctx, "", "race", 4, bytes.NewReader([]byte("base")))
+	require.NoError(t, err)
+
+	const racers = 8
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	successes, conflicts := 0, 0
+
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			body := []byte(fmt.Sprintf("racer-%02d", n))
+			_, err := bs.CheckAndPut(ctx, base, "race", int64(len(body)), bytes.NewReader(body))
+			mu.Lock()
+			defer mu.Unlock()
+			if err == nil {
+				successes++
+			} else if IsCheckAndPutError(err) {
+				conflicts++
+			} else {
+				t.Errorf("unexpected error: %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Equal(t, 1, successes, "exactly one racer must win")
+	assert.Equal(t, racers-1, conflicts, "every loser must see CheckAndPutError")
+}
+
+func TestS3Concatenate(t *testing.T) {
+	bs := newTestS3Blobstore(t)
+	_, err := bs.Concatenate(context.Background(), "cat", []string{"a", "b"})
+	assert.Error(t, err)
+}
+
+func TestS3LargePut(t *testing.T) {
+	bs := newTestS3Blobstore(t)
+	ctx := context.Background()
+
+	// large enough to cross the upload manager's default multipart threshold (5MiB parts)
+	size := 6 * 1024 * 1024
+	data := make([]byte, size)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+
+	ver, err := bs.Put(ctx, "big", int64(size), bytes.NewReader(data))
+	require.NoError(t, err)
+	assert.NotEmpty(t, ver)
+
+	rc, sz, _, err := bs.Get(ctx, "big", AllRange)
+	require.NoError(t, err)
+	defer rc.Close()
+	assert.Equal(t, uint64(size), sz)
+	read, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, data, read)
+}

--- a/go/store/nbs/no_conjoin_bs_persister.go
+++ b/go/store/nbs/no_conjoin_bs_persister.go
@@ -74,7 +74,23 @@ func (bsp *noConjoinBlobstorePersister) ConjoinAll(ctx context.Context, behavior
 
 // Open a table named |name|, containing |chunkCount| chunks.
 func (bsp *noConjoinBlobstorePersister) Open(ctx context.Context, name hash.Hash, chunkCount uint32, stats *Stats) (chunkSource, error) {
-	return newBSTableChunkSource(ctx, bsp.bs, name, chunkCount, bsp.q, stats)
+	cs, err := newBSTableChunkSource(ctx, bsp.bs, name, chunkCount, bsp.q, stats)
+	if err == nil {
+		return cs, nil
+	}
+
+	// The table may exist in archive format (<name>.darc), e.g. when table
+	// files written by a local archive-enabled store are copied to this
+	// blobstore during a push. Mirror blobstorePersister.Open's fallback.
+	if blobstore.IsNotFoundError(err) {
+		source, err := newBSArchiveChunkSource(ctx, bsp.bs, name, bsp.q, stats)
+		if err != nil {
+			return nil, err
+		}
+		return source, nil
+	}
+
+	return nil, err
 }
 
 func (bsp *noConjoinBlobstorePersister) Exists(ctx context.Context, name string, chunkCount uint32, stats *Stats) (bool, io.Closer, error) {


### PR DESCRIPTION
## Motivation

#509 asks for S3-compatible storage support. The historical blocker was the manifest: `aws://` pairs S3 with a DynamoDB table for the atomic check-and-set, which generic S3-compatible stores cannot provide. That blocker is gone: AWS S3 supports conditional writes (`If-None-Match: *` for create since Aug 2024, `If-Match: <ETag>` CAS since Nov 2024), and Cloudflare R2 and current MinIO AIStor document both headers on `PutObject`.

## Design

A new `s3://bucket/path` scheme backed by an endpoint-configurable `S3Blobstore`:

- The manifest ETag is an opaque version token. `CheckAndPut` issues a direct single-part conditional `PutObject` (`If-None-Match: *` on create, `If-Match` on replace). HTTP 412, AWS's conditional `409 ConditionalRequestConflict`, and `If-Match` against a missing key all map to the unwrapped `blobstore.CheckAndPutError`, so the existing NBS manifest reread/retry path handles races unchanged. 429/5xx are left to the caller's retry with the original condition preserved.
- `CheckAndPut` never uses multipart (multipart ETags are not content-stable across providers, and conditional headers on `CompleteMultipartUpload` are not universally supported). Ordinary `Put` uses the SDK upload manager, which switches to multipart automatically for large table files.
- The factory wires `nbs.NewNoConjoinBSStore`, so `Concatenate` is never invoked — no server-side compose operation is required, following the Git-remote backend precedent.
- Credentials come from the standard AWS SDK chain. New optional remote params: `s3-endpoint`, `s3-region`, `s3-path-style` (the `AWS_ENDPOINT_URL_S3` env var is honored when params are omitted).

The first commit fixes a pre-existing gap this work surfaced: `noConjoinBlobstorePersister.Open` lacked the archive-format (`.darc`) fallback that `blobstorePersister.Open` has, so pushing archive table files into a no-conjoin blobstore store failed at `openChunkSources`.

## Verification

- Integration tests (env-gated on `TEST_S3_BUCKET`/`TEST_S3_ENDPOINT`/`TEST_S3_PATH_STYLE`, following the GCS/OCI convention) cover put/get/exists/ranged reads, conditional create/update/stale-version/missing-key semantics, an 8-writer concurrent `CheckAndPut` race asserting exactly one winner, multipart `Put`, and unsupported `Concatenate`. All pass against live Cloudflare R2.
- End-to-end against R2: `remote add` → `push` → `clone` → data verified → second `push` → `pull` round-trip verified.
- Caveat stated plainly: the concurrent-race test is a smoke test, not a proof of provider-side CAS linearization. R2 documents the conditional headers but not an explicit exactly-one-winner guarantee, and R2 rate-limits ~1 write/sec per key (relevant to the hot manifest). A more rigorous conformance harness (synchronized independent clients, disabled SDK retries, raw timing/status capture, repetition) is planned; providers lacking conditional writes should eventually get a fast capability-probe error.

## Open questions

1. Is this design shape acceptable, and is the work planned under the current #509 assignment far enough along that this PR conflicts? Happy to adapt or hand off.
2. Naming/config bikeshed: `s3://` scheme and `s3-endpoint`/`s3-region`/`s3-path-style` param names.
3. Whether a startup capability probe (fail-fast on providers without conditional-write support) should land in this PR or a follow-up.

Known cosmetic issue: a second push to an existing branch prints `[new branch]` instead of a fast-forward line; investigating.