### PR TITLE
Name the conflicting ref in ExistingRefError

### DIFF
--- a/go/libraries/doltcore/doltdb/errors.go
+++ b/go/libraries/doltcore/doltdb/errors.go
@@ -149,16 +149,18 @@ func GetUnreachableRootCause(err error) error {
 // [ref.DoltRef], such as a branch or tag, conflicts with one or more
 // existing names.
 //
-// Ref identifies one exsiting conflict so callers can produce
+// Ref identifies one existing conflict so callers can produce
 // context-specific errors, such as actions.BranchExistsError.
 type ExistingRefError struct {
 	Ref ref.DoltRef
 }
 
+// Error names the conflicting ref. A caller that reaches the user should still
+// wrap this with a message for its own ref type; this is the fallback for one
+// that does not, and it must say which ref was already taken. The full ref path
+// disambiguates a name that exists as more than one type.
 func (e *ExistingRefError) Error() string {
-	// TODO(elianddb): Include Ref in the error message once tags, workspaces,
-	//  and other reference types use their own errors, and update their tests.
-	return "already exists"
+	return fmt.Sprintf("ref '%s' already exists", e.Ref.String())
 }
 
 // DoltIgnoreConflictError is an error that is returned when the user attempts to stage a table that matches conflicting dolt_ignore patterns

--- a/go/libraries/doltcore/doltdb/errors_test.go
+++ b/go/libraries/doltcore/doltdb/errors_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package doltdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
+)
+
+func TestExistingRefErrorNamesTheRef(t *testing.T) {
+	// See https://github.com/dolthub/dolt/issues/11434. A caller that does not
+	// wrap this error shows it verbatim, so it has to say which ref was taken.
+	// Two ref types may share a name, so the message carries the full path.
+	for _, r := range []ref.DoltRef{
+		ref.NewBranchRef("br"),
+		ref.NewTagRef("br"),
+		ref.NewWorkspaceRef("br"),
+	} {
+		err := &ExistingRefError{Ref: r}
+		require.Equal(t, "ref '"+r.String()+"' already exists", err.Error())
+	}
+}

--- a/go/libraries/doltcore/env/actions/tag.go
+++ b/go/libraries/doltcore/env/actions/tag.go
@@ -19,11 +19,15 @@ import (
 	"fmt"
 	"sort"
 
+	errorKinds "gopkg.in/src-d/go-errors.v1"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
 	"github.com/dolthub/dolt/go/store/datas"
 )
+
+var ErrTagExists = errorKinds.NewKind("fatal: A tag named '%s' already exists.")
 
 const DefaultPageSize = 100
 
@@ -51,7 +55,7 @@ func CreateTagOnDB(ctx context.Context, ddb *doltdb.DoltDB, tagName, startPoint 
 	}
 
 	if hasRef {
-		return &doltdb.ExistingRefError{Ref: tagRef}
+		return ErrTagExists.New(tagName)
 	}
 
 	if !ref.IsValidTagName(tagName) {

--- a/go/libraries/doltcore/env/actions/workspace.go
+++ b/go/libraries/doltcore/env/actions/workspace.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"errors"
 
+	errorKinds "gopkg.in/src-d/go-errors.v1"
+
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
@@ -26,6 +28,7 @@ import (
 var ErrUnmergedWorkspaceDelete = errors.New("attempted to delete a workspace that is not fully merged into its parent; use `-f` to force")
 var ErrCOWorkspaceDelete = errors.New("attempted to delete checked out workspace")
 var ErrBranchNameExists = errors.New("workspace name must not be existing branch name")
+var ErrWorkspaceExists = errorKinds.NewKind("fatal: A workspace named '%s' already exists.")
 
 func CreateWorkspace(ctx context.Context, dEnv *env.DoltEnv, name, startPoint string) error {
 	headRef, err := dEnv.RepoStateReader().CWBHeadRef(ctx)
@@ -55,7 +58,7 @@ func CreateWorkspaceOnDB(ctx context.Context, ddb *doltdb.DoltDB, name, startPoi
 		return err
 	}
 	if hasRef {
-		return &doltdb.ExistingRefError{Ref: workRef}
+		return ErrWorkspaceExists.New(name)
 	}
 
 	cs, err := doltdb.NewCommitSpec(startPoint)


### PR DESCRIPTION
Fixes #11434

`ExistingRefError.Error()` returned a bare `already exists`. A user seeing it learns neither which ref was taken nor what kind it was. The `TODO(elianddb)` on it said the ref could only be named once tags and workspaces used their own errors, since they surfaced this message verbatim.

## Changes

- `actions.ErrTagExists` / `actions.ErrWorkspaceExists`, mirroring the existing `ErrBranchExists` wording.
- `CreateTagOnDB` and `CreateWorkspaceOnDB` return those instead of `&doltdb.ExistingRefError{...}`.
- `ExistingRefError.Error()` now returns `ref 'refs/heads/br' already exists`; the `TODO` is gone.

## Why tags and workspaces return their error at the source

`BranchExistsError` exists because `failOnCaseConflict` raises `ExistingRefError` deep inside branch creation, where the ref that actually collides differs from the one the caller asked for; the caller has to unwrap to learn the real name. Tag and workspace creation instead detect the duplicate with an explicit `ddb.HasRef` check that already has the name in scope, and neither path runs `failOnCaseConflict`. An unwrapper for them would only re-derive a name the raising function held, so they return the typed error directly. `CreateWorkspace` currently has no callers, which also makes an unwrapper dead code.

That leaves `ExistingRefError` raised only on branch paths, whose callers already wrap it. Its own message is the fallback for a caller that does not, so it uses `Ref.String()` rather than `GetPath()`: a name can exist as more than one ref type, and an unwrapped error should not be ambiguous about which one it means.

## Compatibility

No test asserted the bare string. `branch_case_test.go` matches on the error type and `Ref.GetPath()`, both unchanged. No enginetest or bats case asserts a tag- or workspace-exists message; the bats suites that grep for `already exists` cover tables, foreign keys, and files, and the new messages still contain that substring.

## Testing

`go test` passes for `./libraries/doltcore/doltdb/...`, `./libraries/doltcore/env/...`, and `-run 'TestDoltTag|TestDoltBranch|TestDoltCheckout'` in `./libraries/doltcore/sqle/enginetest/`. `go vet` is clean on the touched packages. Added `TestExistingRefErrorNamesTheRef` to pin the message across branch, tag, and workspace refs.