### PR TITLE
fix: populate dolt_statistics created_at

### DIFF
--- a/go/libraries/doltcore/sqle/statspro/script_test.go
+++ b/go/libraries/doltcore/sqle/statspro/script_test.go
@@ -732,6 +732,31 @@ func TestStatScripts(t *testing.T) {
 	}
 }
 
+func TestStatisticCreatedAt(t *testing.T) {
+	origTimeSource := mockableTimeSource
+	t.Cleanup(func() {
+		mockableTimeSource = origTimeSource
+	})
+	mockableTimeSource = func() time.Time {
+		return time.Date(2026, time.August, 7, 1, 2, 3, 0, time.UTC)
+	}
+
+	bthreads := sql.NewBackgroundThreads()
+	defer bthreads.Shutdown()
+	ctx, sqlEng, sc := emptySetup(t, bthreads, false, false)
+	defer sqlEng.Close()
+
+	require.NoError(t, sc.Restart(ctx))
+	require.NoError(t, executeQuery(ctx, sqlEng, "create table xy (x int primary key)"))
+	require.NoError(t, executeQuery(ctx, sqlEng, "insert into xy values (1)"))
+	require.NoError(t, executeQuery(ctx, sqlEng, "analyze table xy"))
+	require.NoError(t, executeQuery(ctx, sqlEng, "call dolt_stats_wait()"))
+
+	rows, err := executeQueryResults(ctx, sqlEng, "select count(*) from dolt_statistics where created_at = '2026-08-07 01:02:03'")
+	require.NoError(t, err)
+	require.Equal(t, []sql.Row{{int64(1)}}, rows)
+}
+
 func normalize(cmp, exp []sql.Row) ([]sql.Row, []sql.Row) {
 	for i, r := range exp {
 		for j, v := range r {

--- a/go/libraries/doltcore/sqle/statspro/worker.go
+++ b/go/libraries/doltcore/sqle/statspro/worker.go
@@ -490,6 +490,7 @@ func (sc *StatsController) updateTable(ctx *sql.Context, newStats *rootStats, ta
 			return nil
 		}
 	}
+	createdAt := mockableTimeSource()
 
 	var indexes []sql.Index
 	if err := sc.execWithOptionalRateLimit(ctx, bypassRateLimit, openSessionCmds, func() (err error) {
@@ -525,6 +526,7 @@ func (sc *StatsController) updateTable(ctx *sql.Context, newStats *rootStats, ta
 			RowCnt:      rowCnt,
 			DistinctCnt: rowCnt,
 			AvgRowSize:  avgSize,
+			Created:     createdAt,
 		}
 		newTableStats = append(newTableStats, noIdxStat)
 		return nil
@@ -570,6 +572,7 @@ func (sc *StatsController) updateTable(ctx *sql.Context, newStats *rootStats, ta
 		// TODO: these should all be the same within, so should be set outside of the loop
 		template.Qual.Database = strings.ToLower(sqlDb.AliasedName())
 		template.Qual.Sch = strings.ToLower(schemaName)
+		template.Created = createdAt
 
 		idxLen := len(sqlIdx.Expressions())
 


### PR DESCRIPTION
Sets `Statistic.Created` on newly generated table-scan and index statistics so `dolt_statistics.created_at` reports the collection time instead of Go’s zero value, while cached statistics keep their existing timestamps.
Fix #10168
Close #11647