### PR TITLE
include the conflicting ref in ExistingRefError.Error()

### DIFF
--- a/go/libraries/doltcore/doltdb/errors.go
+++ b/go/libraries/doltcore/doltdb/errors.go
@@ -156,9 +156,7 @@ type ExistingRefError struct {
 }
 
 func (e *ExistingRefError) Error() string {
-	// TODO(elianddb): Include Ref in the error message once tags, workspaces,
-	//  and other reference types use their own errors, and update their tests.
-	return "already exists"
+	return fmt.Sprintf("ref '%s' already exists", ref.String(e.Ref))
 }
 
 // DoltIgnoreConflictError is an error that is returned when the user attempts to stage a table that matches conflicting dolt_ignore patterns

--- a/go/libraries/doltcore/env/actions/tag.go
+++ b/go/libraries/doltcore/env/actions/tag.go
@@ -16,8 +16,11 @@ package actions
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
+
+	errorKinds "gopkg.in/src-d/go-errors.v1"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
@@ -26,6 +29,8 @@ import (
 )
 
 const DefaultPageSize = 100
+
+var ErrTagExists = errorKinds.NewKind("fatal: A tag named '%s' already exists.")
 
 type TagProps struct {
 	TaggerName  string
@@ -75,6 +80,15 @@ func CreateTagOnDB(ctx context.Context, ddb *doltdb.DoltDB, tagName, startPoint 
 	meta := datas.NewTagMeta(props.TaggerName, props.TaggerEmail, props.Description)
 
 	return ddb.NewTagAtCommit(ctx, tagRef, cm, meta)
+}
+
+// TagExistsError returns an ErrTagExists naming the existing tag when |err|
+// wraps an doltdb.ExistingRefError, or nil otherwise.
+func TagExistsError(err error) error {
+	if existing, ok := errors.AsType[*doltdb.ExistingRefError](err); ok {
+		return ErrTagExists.New(existing.Ref.GetPath())
+	}
+	return nil
 }
 
 func DeleteTagsOnDB(ctx context.Context, ddb *doltdb.DoltDB, tagNames ...string) error {

--- a/go/libraries/doltcore/env/actions/tag_test.go
+++ b/go/libraries/doltcore/env/actions/tag_test.go
@@ -148,3 +148,31 @@ func TestIterResolvedTagsPaginated(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(earlyTermTags))
 }
+
+func TestCreateTagOnExistingTag(t *testing.T) {
+	dEnv, _ := createTestEnv()
+	ctx := context.Background()
+
+	err := dEnv.InitRepo(ctx, types.Format_DOLT, "test user", "test@test.com", "main")
+	require.NoError(t, err)
+
+	props := TagProps{TaggerName: "test user", TaggerEmail: "test@test.com", Description: "test tag message"}
+	err = CreateTag(ctx, dEnv, "v1", "main", props)
+	require.NoError(t, err)
+
+	// Recreating the tag without deleting it first is an ExistingRefError
+	// naming the conflicting ref.
+	err = CreateTag(ctx, dEnv, "v1", "main", props)
+	var existing *doltdb.ExistingRefError
+	require.ErrorAs(t, err, &existing)
+	require.Equal(t, "v1", existing.Ref.GetPath())
+	require.EqualError(t, err, "ref 'refs/tags/v1' already exists")
+
+	// TagExistsError recovers a tag-specific message for callers.
+	existsErr := TagExistsError(err)
+	require.True(t, ErrTagExists.Is(existsErr))
+	require.EqualError(t, existsErr, "fatal: A tag named 'v1' already exists.")
+
+	// Unrelated errors are not converted.
+	require.Nil(t, TagExistsError(doltdb.ErrTagNotFound))
+}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_tag.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_tag.go
@@ -105,6 +105,9 @@ func doDoltTag(ctx *sql.Context, args []string) (int, error) {
 	}
 	err = actions.CreateTagOnDB(ctx, dbData.Ddb, tagName, startPoint, props, headRef)
 	if err != nil {
+		if existsErr := actions.TagExistsError(err); existsErr != nil {
+			return 1, existsErr
+		}
 		return 1, err
 	}
 


### PR DESCRIPTION
Fixes #11434

`ExistingRefError.Error()` returned a bare `already exists`, so callers that don't recover the detail out of band — tags and workspaces — surfaced an error that never named the conflicting ref:

```sql
mysql> call dolt_tag('v1');
mysql> call dolt_tag('v1');
ERROR 1105 (HY000): already exists
```

## Changes

- `Error()` now includes the ref, as suggested in the issue: `ref 'refs/tags/v1' already exists`. Workspaces (and any other caller that surfaces the raw error) pick this up automatically.
- `dolt_tag()` recovers a tag-specific message via a new `actions.TagExistsError`, mirroring the existing `actions.BranchExistsError` pattern: `fatal: A tag named 'v1' already exists.`
- Added `TestCreateTagOnExistingTag` covering the new `Error()` format, the `TagExistsError` recovery, and that unrelated errors are not converted.

Branch creation is unaffected — it already recovers the detail via `BranchExistsError`, and `branch_case_test.go` asserts with `ErrorAs`/`GetPath()` rather than the message string, so no existing assertions needed updating.

## Testing

`go test ./libraries/doltcore/env/actions/ ./libraries/doltcore/doltdb/` — all pass, including the new test.