### PR TITLE
Fix dump of tables with a generated column

### DIFF
--- a/go/libraries/doltcore/mvdata/engine_table_reader.go
+++ b/go/libraries/doltcore/mvdata/engine_table_reader.go
@@ -20,8 +20,6 @@ import (
 
 	sqle "github.com/dolthub/go-mysql-server"
 	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/go-mysql-server/sql/plan"
-	"github.com/dolthub/go-mysql-server/sql/planbuilder"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/row"
@@ -37,25 +35,14 @@ type sqlEngineTableReader struct {
 }
 
 func NewSqlEngineReader(ctx *sql.Context, engine *sqle.Engine, root doltdb.RootValue, tableName string) (*sqlEngineTableReader, error) {
-	binder := planbuilder.New(ctx, engine.Analyzer.Catalog, engine.EventScheduler)
-	ret, _, _, _, err := binder.Parse(fmt.Sprintf("show create table `%s`", tableName), nil, false)
-	if err != nil {
-		return nil, err
-	}
-
-	create, ok := ret.(*plan.ShowCreateTable)
-	if !ok {
-		return nil, fmt.Errorf("expected *plan.ShowCreate table, found %T", ret)
-	}
-
-	_, iter, _, err := engine.Query(ctx, fmt.Sprintf("SELECT * FROM `%s`", tableName))
+	sch, iter, _, err := engine.Query(ctx, fmt.Sprintf("SELECT * FROM `%s`", tableName))
 	if err != nil {
 		return nil, err
 	}
 
 	// NOTE: We don't support setting a schema name to qualify the table name here, so this code will not work
 	//       correctly with Doltgres yet.
-	doltSchema, err := sqlutil.ToDoltSchema(ctx, root, doltdb.TableName{Name: tableName}, create.PrimaryKeySchema, nil, sql.Collation_Default)
+	doltSchema, err := sqlutil.ToDoltSchema(ctx, root, doltdb.TableName{Name: tableName}, sql.NewPrimaryKeySchema(sch), nil, sql.Collation_Default)
 	if err != nil {
 		return nil, err
 	}
@@ -67,25 +54,13 @@ func NewSqlEngineReader(ctx *sql.Context, engine *sqle.Engine, root doltdb.RootV
 	}, nil
 }
 
-// Used by Dolthub API
+// NewSqlEngineTableReaderWithEngine returns a reader over |tableName|
+// in the same way NewSqlEngineReader does.
+//
+// Nothing in this repository calls it. It is here for the Dolthub
+// API, and |db| goes unused.
 func NewSqlEngineTableReaderWithEngine(sqlCtx *sql.Context, engine *sqle.Engine, db dsqle.Database, root doltdb.RootValue, tableName string) (*sqlEngineTableReader, error) {
-	sch, iter, _, err := engine.Query(sqlCtx, fmt.Sprintf("SELECT * FROM `%s`", tableName))
-	if err != nil {
-		return nil, err
-	}
-
-	// NOTE: We don't support setting a schema name to qualify the table name here, so this code will not work
-	//       correctly with Doltgres yet.
-	doltSchema, err := sqlutil.ToDoltSchema(sqlCtx, root, doltdb.TableName{Name: tableName}, sql.NewPrimaryKeySchema(sch), nil, sql.Collation_Default)
-	if err != nil {
-		return nil, err
-	}
-
-	return &sqlEngineTableReader{
-		sqlCtx: sqlCtx,
-		sch:    doltSchema,
-		iter:   iter,
-	}, nil
+	return NewSqlEngineReader(sqlCtx, engine, root, tableName)
 }
 
 func (s *sqlEngineTableReader) GetSchema() schema.Schema {

--- a/go/libraries/doltcore/schema/column.go
+++ b/go/libraries/doltcore/schema/column.go
@@ -168,6 +168,14 @@ func (c Column) IsNullable() bool {
 	return true
 }
 
+// IsGenerated reports whether the column is computed by the engine.
+//
+// TODO(elianddb): Make Generated private so callers ask interface
+// instead of testing field.
+func (c Column) IsGenerated() bool {
+	return c.Generated != ""
+}
+
 // Equals tests equality between two columns.
 func (c Column) Equals(other Column) bool {
 	return c.Name == other.Name &&

--- a/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
@@ -53,7 +53,14 @@ func QuoteComment(s string) string {
 	return `'` + strings.ReplaceAll(s, `'`, `\'`) + `'`
 }
 
-// InsertStatementPrefix returns the first part of an SQL insert query for a given table
+// InsertStatementPrefix returns the first part of an INSERT statement
+// for |tableName|, up to and including VALUES:
+//
+//	INSERT INTO `t` (`id`,`a`) VALUES
+//
+// Generated columns are skipped here while building the column list.
+// The caller appends one tuple of values per row, along with the
+// closing semicolon. See SqlRowAsTupleString.
 func InsertStatementPrefix(ctx *sql.Context, tableName string, tableSch schema.Schema) (string, error) {
 	var b strings.Builder
 
@@ -63,6 +70,9 @@ func InsertStatementPrefix(ctx *sql.Context, tableName string, tableSch schema.S
 
 	seenOne := false
 	err := tableSch.GetAllCols().Iter(func(tag uint64, col schema.Column) (stop bool, err error) {
+		if isGeneratedColumn(col) {
+			return false, nil
+		}
 		if seenOne {
 			b.WriteRune(',')
 		}
@@ -165,18 +175,34 @@ func SqlRowAsInsertStmt(ctx *sql.Context, r sql.Row, tableName string, tableSch 
 	return b.String(), nil
 }
 
-// SqlRowAsTupleString converts a sql row into it's tuple string representation for SQL insert statements.
+// SqlRowAsTupleString converts |r| into its tuple string
+// representation for INSERT statements, for example (1,'x',NULL).
+//
+// Values for generated columns are left out so that the tuple matches
+// the column list from InsertStatementPrefix.
+//
+// |r| must hold one value per column of |tableSch|, in schema order.
+// A row of any other width is an error because its values would be
+// written against the wrong columns.
 func SqlRowAsTupleString(ctx *sql.Context, r sql.Row, tableSch schema.Schema) (string, error) {
 	var b strings.Builder
 	var err error
 
+	cols := tableSch.GetAllCols()
+	if len(r) != cols.Size() {
+		return "", fmt.Errorf("expected %d values for table schema, got %d", cols.Size(), len(r))
+	}
+
 	b.WriteString("(")
 	seenOne := false
 	for i, val := range r {
+		col := cols.GetByIndex(i)
+		if isGeneratedColumn(col) {
+			continue
+		}
 		if seenOne {
 			b.WriteRune(',')
 		}
-		col := tableSch.GetAllCols().GetByIndex(i)
 		str := "NULL"
 		if val != nil {
 			str, err = interfaceValueAsSqlString(ctx, col.TypeInfo, val)
@@ -255,6 +281,14 @@ func SqlRowAsDeleteStmt(ctx *sql.Context, r sql.Row, tableName string, tableSch 
 	return b.String(), nil
 }
 
+// SqlRowAsUpdateStmt generates an UPDATE statement setting the
+// columns of |r| named by |colsToUpdate|.
+//
+// The row to change is keyed by the primary key columns of
+// |tableSch|, using their values from |r|.
+//
+// TODO(elianddb): Schema isn't recording column's Generated marker
+// correctly, so isGeneratedColumn doesn't filter
 func SqlRowAsUpdateStmt(ctx *sql.Context, r sql.Row, tableName string, tableSch schema.Schema, colsToUpdate *set.StrSet) (string, error) {
 	var b strings.Builder
 	b.WriteString("UPDATE ")
@@ -317,6 +351,13 @@ func SqlRowAsUpdateStmt(ctx *sql.Context, r sql.Row, tableName string, tableSch 
 
 	b.WriteString(";")
 	return b.String(), nil
+}
+
+// isGeneratedColumn reports whether |col| is computed by the engine.
+//
+// The db rejects statements that assign a value to these columns.
+func isGeneratedColumn(col schema.Column) bool {
+	return col.Generated != ""
 }
 
 func interfaceValueAsSqlString(ctx *sql.Context, ti typeinfo.TypeInfo, value interface{}) (string, error) {

--- a/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
@@ -70,7 +70,7 @@ func InsertStatementPrefix(ctx *sql.Context, tableName string, tableSch schema.S
 
 	seenOne := false
 	err := tableSch.GetAllCols().Iter(func(tag uint64, col schema.Column) (stop bool, err error) {
-		if isGeneratedColumn(col) {
+		if col.IsGenerated() {
 			return false, nil
 		}
 		if seenOne {
@@ -197,7 +197,7 @@ func SqlRowAsTupleString(ctx *sql.Context, r sql.Row, tableSch schema.Schema) (s
 	seenOne := false
 	for i, val := range r {
 		col := cols.GetByIndex(i)
-		if isGeneratedColumn(col) {
+		if col.IsGenerated() {
 			continue
 		}
 		if seenOne {
@@ -288,7 +288,7 @@ func SqlRowAsDeleteStmt(ctx *sql.Context, r sql.Row, tableName string, tableSch 
 // |tableSch|, using their values from |r|.
 //
 // TODO(elianddb): Schema isn't recording column's Generated marker
-// correctly, so isGeneratedColumn doesn't filter
+// correctly, so Column.IsGenerated doesn't filter.
 func SqlRowAsUpdateStmt(ctx *sql.Context, r sql.Row, tableName string, tableSch schema.Schema, colsToUpdate *set.StrSet) (string, error) {
 	var b strings.Builder
 	b.WriteString("UPDATE ")
@@ -351,13 +351,6 @@ func SqlRowAsUpdateStmt(ctx *sql.Context, r sql.Row, tableName string, tableSch 
 
 	b.WriteString(";")
 	return b.String(), nil
-}
-
-// isGeneratedColumn reports whether |col| is computed by the engine.
-//
-// The db rejects statements that assign a value to these columns.
-func isGeneratedColumn(col schema.Column) bool {
-	return col.Generated != ""
 }
 
 func interfaceValueAsSqlString(ctx *sql.Context, ti typeinfo.TypeInfo, value interface{}) (string, error) {

--- a/go/libraries/doltcore/sqle/sqlfmt/row_fmt_test.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/row_fmt_test.go
@@ -19,9 +19,14 @@ import (
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/dtestutils"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
+	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
 	_ "github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlfmt"
+	"github.com/dolthub/dolt/go/store/types"
 )
 
 const expectedDropSql = "DROP TABLE `table_name`;"
@@ -66,4 +71,67 @@ func TestRenameTableStmt(t *testing.T) {
 	stmt := sqlfmt.RenameTableStmt(sql.DefaultMySQLSchemaFormatter, "table_name", "new_table_name")
 
 	assert.Equal(t, expectedRenameTableSql, stmt)
+}
+
+func TestInsertStatementPrefixSkipsGeneratedCols(t *testing.T) {
+	// See https://github.com/dolthub/dolt/issues/11439
+	sch := newGeneratedColSchema()
+
+	prefix, err := sqlfmt.InsertStatementPrefix(sql.NewEmptyContext(), "table_name", sch)
+
+	require.NoError(t, err)
+	assert.Equal(t, "INSERT INTO `table_name` (`id`,`a`) VALUES ", prefix)
+}
+
+func TestSqlRowAsTupleString(t *testing.T) {
+	// See https://github.com/dolthub/dolt/issues/11439
+	sch := newGeneratedColSchema()
+
+	tests := []struct {
+		name     string
+		row      sql.Row
+		expected string
+		errStr   string
+	}{
+		{
+			name: "generated column value is omitted",
+			row:  sql.Row{int64(1), "x", "x"},
+			// writing the separator before the skip would trail a comma
+			expected: "(1,'x')",
+		},
+		{
+			name:   "row wider than the schema is an error",
+			row:    sql.Row{int64(1), "x", "x", "extra"},
+			errStr: "expected 3 values for table schema, got 4",
+		},
+		{
+			name:   "row narrower than the schema is an error",
+			row:    sql.Row{int64(1)},
+			errStr: "expected 3 values for table schema, got 1",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tuple, err := sqlfmt.SqlRowAsTupleString(sql.NewEmptyContext(), test.row, sch)
+
+			if test.errStr != "" {
+				require.EqualError(t, err, test.errStr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, tuple)
+		})
+	}
+}
+
+// newGeneratedColSchema returns the schema of a table whose last
+// column is generated.
+func newGeneratedColSchema() schema.Schema {
+	return dtestutils.CreateSchema(
+		schema.Column{Name: "id", Tag: 0, Kind: types.IntKind, IsPartOfPK: true, TypeInfo: typeinfo.Int64Type},
+		schema.Column{Name: "a", Tag: 1, Kind: types.StringKind, TypeInfo: typeinfo.StringDefaultType},
+		schema.Column{Name: "c", Tag: 2, Kind: types.StringKind, TypeInfo: typeinfo.StringDefaultType, Generated: "(coalesce(`a`,'z'))", Virtual: true},
+	)
 }

--- a/integration-tests/bats/dump.bats
+++ b/integration-tests/bats/dump.bats
@@ -985,6 +985,98 @@ SQL
     # need to test binary, bit and blob types
 }
 
+@test "dump: SQL type - with a generated column" {
+    # See https://github.com/dolthub/dolt/issues/11439
+    create_generated_column_table
+
+    run dolt dump -r sql
+    [[ "$output" =~ "Successfully exported data." ]] || false
+    [ -f doltdump.sql ]
+    grep -qF 'DROP TABLE IF EXISTS `repro`;' doltdump.sql
+
+    dolt sql < doltdump.sql
+
+    run dolt sql -r csv -q "SELECT id, a, b, c FROM repro ORDER BY id"
+    [[ "${lines[1]}" = "1,x,,x" ]] || false
+    [[ "${lines[2]}" = "2,,y,y" ]] || false
+}
+
+@test "dump: CSV type - with a generated column" {
+    # See https://github.com/dolthub/dolt/issues/11439
+    create_generated_column_table
+
+    run dolt dump -r csv
+    [[ "$output" =~ "Successfully exported data." ]] || false
+    [ -f doltdump/repro.csv ]
+
+    run cat doltdump/repro.csv
+    [[ "${lines[0]}" = "id,a,b,c" ]] || false
+    [[ "${lines[1]}" = "1,x,,x" ]] || false
+    [[ "${lines[2]}" = "2,,y,y" ]] || false
+}
+
+@test "dump: parquet type - with a generated column" {
+    # See https://github.com/dolthub/dolt/issues/11439
+    create_generated_column_table
+
+    run dolt dump -r parquet
+    [[ "$output" =~ "Successfully exported data." ]] || false
+    [ -f doltdump/repro.parquet ]
+
+    dolt sql -q "CREATE TABLE roundtrip (id INT PRIMARY KEY, a VARCHAR(50), b VARCHAR(50), c VARCHAR(50))"
+    dolt table import -r roundtrip doltdump/repro.parquet
+
+    run dolt sql -r csv -q "SELECT id, a, b, c FROM roundtrip ORDER BY id"
+    [[ "${lines[1]}" = "1,x,,x" ]] || false
+    [[ "${lines[2]}" = "2,,y,y" ]] || false
+}
+
+@test "dump: SQL type - with a stored generated column" {
+    # See https://github.com/dolthub/dolt/issues/11439
+    dolt sql <<'SQL'
+    CREATE TABLE repro (id INT PRIMARY KEY, a INT, b INT GENERATED ALWAYS AS (a + 1) STORED);
+    INSERT INTO repro (id, a) VALUES (1, 10), (2, 20);
+SQL
+
+    run dolt dump -r sql
+    [[ "$output" =~ "Successfully exported data." ]] || false
+    [ -f doltdump.sql ]
+    grep -qF 'DROP TABLE IF EXISTS `repro`;' doltdump.sql
+
+    dolt sql < doltdump.sql
+
+    run dolt sql -r csv -q "SELECT id, a, b FROM repro ORDER BY id"
+    [[ "${lines[1]}" = "1,10,11" ]] || false
+    [[ "${lines[2]}" = "2,20,21" ]] || false
+}
+
+@test "dump: SQL type - with a generated column between two columns" {
+    # See https://github.com/dolthub/dolt/issues/11439
+    dolt sql <<'SQL'
+    CREATE TABLE repro (id INT PRIMARY KEY, a VARCHAR(20), g VARCHAR(20) GENERATED ALWAYS AS (concat(a, '!')), z VARCHAR(20));
+    INSERT INTO repro (id, a, z) VALUES (1, 'x', 'end'), (2, NULL, 'tail');
+SQL
+
+    run dolt dump -r sql
+    [[ "$output" =~ "Successfully exported data." ]] || false
+    [ -f doltdump.sql ]
+    grep -qF 'DROP TABLE IF EXISTS `repro`;' doltdump.sql
+
+    dolt sql < doltdump.sql
+
+    # z holds its own value, so the column after the omitted one did not shift.
+    run dolt sql -r csv -q "SELECT id, a, g, z FROM repro ORDER BY id"
+    [[ "${lines[1]}" = "1,x,x!,end" ]] || false
+    [[ "${lines[2]}" = "2,,,tail" ]] || false
+}
+
+function create_generated_column_table() {
+  dolt sql <<'SQL'
+  CREATE TABLE repro (id INT PRIMARY KEY, a VARCHAR(50), b VARCHAR(50), c VARCHAR(50) GENERATED ALWAYS AS (coalesce(a, b)));
+  INSERT INTO repro (id, a, b) VALUES (1, 'x', NULL), (2, NULL, 'y');
+SQL
+}
+
 function create_tables() {
   dolt sql -q "CREATE TABLE new_table(pk int primary key);"
   dolt sql -q "CREATE TABLE warehouse(warehouse_id int primary key, warehouse_name varchar(100));"


### PR DESCRIPTION
Fixes a panic in `dolt dump` on tables with a generated column which affected `sql`, `csv`, and `parquet` output. The generated `INSERT` statements also were updated to omit generated columns, addressing `STORED` generated columns non-restorable dumps.
- `mvdata/engine_table_reader.go`: `NewSqlEngineReader` took its rows from a `SELECT` statement but its schema from a separate `SHOW CREATE TABLE` plan that was built but never ran. When a table has a generated column, the planbuilder replaces it with `plan.VirtualColumnTable` that does not implement `sql.PrimaryKeyTable`, the interface that plan uses to fill its `PrimaryKeySchema`.  The schema now comes from the same query as the rows to avoid a zero value.
- `NewSqlEngineTableReaderWithEngine` became same as the above and now delegates.
- `sqlfmt/row_fmt.go`: `InsertStatementPrefix` and `SqlRowAsTupleString` both skip generated columns, keeping the column list and the value tuple the same length.
- `SqlRowAsTupleString` returns an error on a row and schema width mismatch.
Fix dolthub/dolt#11439