### PR TITLE
pin the aborted-rebase state behind ErrRebaseDataConflictsCantBeResolved

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_rebase.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_rebase.go
@@ -578,6 +578,26 @@ var DoltRebaseScriptTests = []queries.ScriptTest{
 				Query:       "call dolt_rebase('--continue');",
 				ExpectedErr: dprocedures.ErrRebaseDataConflictsCantBeResolved,
 			},
+			{
+				// The error says the rebase was aborted; pin that state so the
+				// message stays truthful: back on the original branch, with no
+				// rebase working branch, rebase plan, or conflict rows left
+				// behind (https://github.com/dolthub/dolt/issues/10951).
+				Query:    "select active_branch();",
+				Expected: []sql.Row{{"branch1"}},
+			},
+			{
+				Query:    "select name from dolt_branches;",
+				Expected: []sql.Row{{"branch1"}, {"main"}},
+			},
+			{
+				Query:          "select * from dolt_rebase;",
+				ExpectedErrStr: "table not found: dolt_rebase",
+			},
+			{
+				Query:    "select count(*) from dolt_conflicts;",
+				Expected: []sql.Row{{0}},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Related to #10951 — extends the existing `dolt_rebase` data-conflict enginetest to assert the abort that the error message promises actually happened: original branch restored, the `dolt_rebase_<branch>` working branch and the `dolt_rebase` plan table both gone, and `dolt_conflicts` empty.
