### PR TITLE
explain the connection failure when a locked db's sql-server is unreachable

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/queryist_utils.go
+++ b/go/cmd/dolt/commands/sqlserver/queryist_utils.go
@@ -104,6 +104,13 @@ func BuildConnectionStringQueryist(_ context.Context, cwdFS filesys.Filesys, cre
 	queryist := ConnectionQueryist{connection: conn, gatherWarnings: &gatherWarnings}
 
 	var lateBind cli.LateBindQueryist = func(ctx context.Context, opts ...cli.LateBindQueryistOption) (res cli.LateBindQueryistResult, err error) {
+		// Surface connection failures here, with the target named, instead of
+		// letting the first query return a bare dial error like
+		// "dial tcp [::1]:3306: connect: connection refused".
+		if err := conn.DB.PingContext(ctx); err != nil {
+			return res, fmt.Errorf("failed to connect to the dolt sql-server at %s:%d: %w", host, port, err)
+		}
+
 		sqlCtx := sql.NewContext(ctx)
 		sqlCtx.SetCurrentDatabase(dbRev)
 

--- a/go/cmd/dolt/commands/sqlserver/queryist_utils_test.go
+++ b/go/cmd/dolt/commands/sqlserver/queryist_utils_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlserver
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/utils/argparser"
+	"github.com/dolthub/dolt/go/libraries/utils/filesys"
+)
+
+// The late binder must fail with an error that names the connection target,
+// not surface a bare dial error from the first query (#10856).
+func TestBuildConnectionStringQueryistNamesTargetOnConnectFailure(t *testing.T) {
+	// Grab a free port, then close the listener so connecting is refused.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+
+	fs := filesys.EmptyInMemFS("/")
+	creds := &cli.UserPassword{Username: "root", Password: "", Specified: false}
+	apr := argparser.NewEmptyResults()
+
+	lateBind, err := BuildConnectionStringQueryist(context.Background(), fs, creds, apr,
+		"127.0.0.1", port, QueryistTLSMode_Disabled, "mydb", "Test User", "test@test.com")
+	require.NoError(t, err)
+
+	_, err = lateBind(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to connect to the dolt sql-server at 127.0.0.1:"+strconv.Itoa(port))
+}

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -795,7 +795,22 @@ If you're interested in running this command against a remote host, hit us up on
 			}
 			doltConfigName := targetEnv.Config.GetStringOrDefault(config.UserNameKey, env.DefaultName)
 			doltConfigEmail := targetEnv.Config.GetStringOrDefault(config.UserEmailKey, env.DefaultEmail)
-			return sqlserver.BuildConnectionStringQueryist(ctx, cwdFS, creds, apr, "localhost", localCreds.Port, sqlserver.QueryistTLSMode_NoVerify_FallbackToPlaintext, useDb, doltConfigName, doltConfigEmail)
+			qi, err := sqlserver.BuildConnectionStringQueryist(ctx, cwdFS, creds, apr, "localhost", localCreds.Port, sqlserver.QueryistTLSMode_NoVerify_FallbackToPlaintext, useDb, doltConfigName, doltConfigEmail)
+			if err != nil {
+				return nil, err
+			}
+			// The connection target came from the running-server info file,
+			// not from the user, so a failure to connect needs to explain
+			// what led here and how to recover (#10856).
+			credsFile := filepath.Join(dbfactory.DoltDir, sqlserver.ServerLocalCredsFile)
+			var withContext cli.LateBindQueryist = func(ctx context.Context, opts ...cli.LateBindQueryistOption) (cli.LateBindQueryistResult, error) {
+				res, err := qi(ctx, opts...)
+				if err != nil {
+					return res, fmt.Errorf("%w\n\nThis database is locked by another dolt process, and its %s file says a dolt sql-server is running on port %d, but connecting to that server failed. If the server is still starting, retry in a moment. If no server is running, the file is stale — delete %s and retry.", err, credsFile, localCreds.Port, credsFile)
+				}
+				return res, nil
+			}
+			return withContext, nil
 		}
 	}
 


### PR DESCRIPTION
Fixes #10856

A CLI command that can't take the write lock routes through the sql-server named in `.dolt/sql-server.info`. When connecting to that server failed — usually a stale info file after an unclean shutdown — the user got a bare `dial tcp [::1]:3306: connect: connection refused` from the first query, with nothing saying where it came from or how to recover.

- `queryist_utils.go` — the late binder in `BuildConnectionStringQueryist` now pings before returning, so a dead server fails at connect time as `failed to connect to the dolt sql-server at <host>:<port>: <cause>` instead of leaking a bare dial error out of the first query.
- `dolt.go` — the implicit lock-detection path wraps that error with why this server was contacted at all (lock held, info file names the port) and how to recover (retry if it is still starting, otherwise delete the stale `.dolt/sql-server.info`), since on that path the user never chose the target.
- `queryist_utils_test.go` — new `TestBuildConnectionStringQueryistNamesTargetOnConnectFailure` binds a port, closes the listener, and asserts the resulting error names the host and port.

Read-only fallback, raised in the issue discussion, is a product decision and left out of scope.
