### PR TITLE
Bug fixes for binlog replication with virtual columns

### DIFF
--- a/go/libraries/doltcore/schema/col_coll.go
+++ b/go/libraries/doltcore/schema/col_coll.go
@@ -146,6 +146,20 @@ func (cc *ColCollection) GetColumnNames() []string {
 	return names
 }
 
+// GetNonSystemHiddenCols returns the subset of columns in this collection that are not SystemHidden, in
+// declared order. SystemHidden columns (e.g. the hidden columns Dolt creates internally to back a
+// functional/expression index) are never visible in DDL, information_schema, or a MySQL server's
+// binlog TableMap/Rows events.
+func (cc *ColCollection) GetNonSystemHiddenCols() []Column {
+	nonSystemHidden := make([]Column, 0, len(cc.cols))
+	for _, col := range cc.cols {
+		if !col.SystemHidden {
+			nonSystemHidden = append(nonSystemHidden, col)
+		}
+	}
+	return nonSystemHidden
+}
+
 // AppendColl returns a new collection with the additional ColCollection's columns appended
 func (cc *ColCollection) AppendColl(colColl *ColCollection) *ColCollection {
 	return cc.Append(colColl.cols...)

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_primary_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_primary_test.go
@@ -401,6 +401,32 @@ func TestBinlogPrimary_FunctionalIndexWithPrimaryKey(t *testing.T) {
 	h.requireReplicaResults("select * from t;", [][]any{})
 }
 
+// TestBinlogPrimary_VirtualColumn tests that inserting, updating, and deleting rows
+// in a table with a user-declared VIRTUAL generated column, interspersed between two stored
+// columns, correctly replicates from a Dolt primary to a real MySQL replica.
+func TestBinlogPrimary_VirtualColumn(t *testing.T) {
+	h := newHarness(t)
+	h.startSqlServersWithDoltSystemVars(doltReplicationPrimarySystemVars)
+	h.setupForDoltToMySqlReplication()
+	h.startReplicationAndCreateTestDb(h.doltPort)
+
+	h.primaryDatabase.MustExec("CREATE TABLE t (pk INT PRIMARY KEY, a VARCHAR(20), g INT GENERATED ALWAYS AS (LENGTH(a)) VIRTUAL, z VARCHAR(20));")
+	h.waitForReplicaToCatchUp()
+	h.requireReplicaResults("show tables;", [][]any{{"t"}})
+
+	h.primaryDatabase.MustExec("INSERT INTO t (pk, a, z) VALUES (1, 'x', 'end');")
+	h.waitForReplicaToCatchUp()
+	h.requireReplicaResults("select pk, a, g, z from t;", [][]any{{"1", "x", "1", "end"}})
+
+	h.primaryDatabase.MustExec("UPDATE t SET a = 'xxx', z = 'end2' WHERE pk = 1;")
+	h.waitForReplicaToCatchUp()
+	h.requireReplicaResults("select pk, a, g, z from t;", [][]any{{"1", "xxx", "3", "end2"}})
+
+	h.primaryDatabase.MustExec("DELETE FROM t WHERE pk = 1;")
+	h.waitForReplicaToCatchUp()
+	h.requireReplicaResults("select pk, a, g, z from t;", [][]any{})
+}
+
 // TestBinlogPrimary_Rotation tests how a Dolt primary server handles rotating the binary log file when the
 // size threshold is reached.
 func TestBinlogPrimary_Rotation(t *testing.T) {

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_primary_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_primary_test.go
@@ -341,6 +341,66 @@ func TestBinlogPrimary_addingAndDroppingColumns(t *testing.T) {
 	})
 }
 
+// TestBinlogPrimary_FunctionalIndex tests that inserting a row into a keyless table with a functional/expression
+// index does not panic when binlog replication is active.
+// https://github.com/dolthub/dolt/issues/11475
+func TestBinlogPrimary_FunctionalIndex(t *testing.T) {
+	h := newHarness(t)
+	h.startSqlServersWithDoltSystemVars(doltReplicationPrimarySystemVars)
+	h.setupForDoltToMySqlReplication()
+	h.startReplicationAndCreateTestDb(h.doltPort)
+
+	h.primaryDatabase.MustExec("CREATE TABLE t (id INT);")
+	h.primaryDatabase.MustExec("CREATE INDEX idx_ifzero ON t ((IF(id = 0, 1, 0)));")
+	h.waitForReplicaToCatchUp()
+	h.requireReplicaResults("show tables;", [][]any{{"t"}})
+
+	// The hidden column Dolt creates internally to back the functional index must NOT be replicated to the
+	// real MySQL replica as a normal, visible column; MySQL creates its own equivalent hidden column
+	// automatically as a side effect of the index DDL.
+	h.requireReplicaResults(
+		"select column_name from information_schema.columns where table_schema=database() and table_name='t';",
+		[][]any{{"id"}})
+
+	h.primaryDatabase.MustExec("INSERT INTO t VALUES (0);")
+	h.waitForReplicaToCatchUp()
+	h.requireReplicaResults("select * from t;", [][]any{{"0"}})
+}
+
+// TestBinlogPrimary_FunctionalIndexWithPrimaryKey tests that inserting, updating, and deleting rows in a table
+// with a primary key and a functional/expression index correctly replicates.
+// https://github.com/dolthub/dolt/issues/11475
+func TestBinlogPrimary_FunctionalIndexWithPrimaryKey(t *testing.T) {
+	h := newHarness(t)
+	h.startSqlServersWithDoltSystemVars(doltReplicationPrimarySystemVars)
+	h.setupForDoltToMySqlReplication()
+	h.startReplicationAndCreateTestDb(h.doltPort)
+
+	h.primaryDatabase.MustExec("CREATE TABLE t (pk INT PRIMARY KEY, id INT);")
+	h.primaryDatabase.MustExec("CREATE INDEX idx_ifzero ON t ((IF(id = 0, 1, 0)));")
+	h.waitForReplicaToCatchUp()
+	h.requireReplicaResults("show tables;", [][]any{{"t"}})
+
+	// The hidden column Dolt creates internally to back the functional index must NOT be replicated to the
+	// real MySQL replica as a normal, visible column; MySQL creates its own equivalent hidden column
+	// automatically as a side effect of the index DDL.
+	h.requireReplicaResults(
+		"select column_name from information_schema.columns where table_schema=database() and table_name='t' order by ordinal_position;",
+		[][]any{{"pk"}, {"id"}})
+
+	h.primaryDatabase.MustExec("INSERT INTO t VALUES (1, 0);")
+	h.waitForReplicaToCatchUp()
+	h.requireReplicaResults("select * from t;", [][]any{{"1", "0"}})
+
+	h.primaryDatabase.MustExec("UPDATE t SET id = 1 WHERE pk = 1;")
+	h.waitForReplicaToCatchUp()
+	h.requireReplicaResults("select * from t;", [][]any{{"1", "1"}})
+
+	h.primaryDatabase.MustExec("DELETE FROM t WHERE pk = 1;")
+	h.waitForReplicaToCatchUp()
+	h.requireReplicaResults("select * from t;", [][]any{})
+}
+
 // TestBinlogPrimary_Rotation tests how a Dolt primary server handles rotating the binary log file when the
 // size threshold is reached.
 func TestBinlogPrimary_Rotation(t *testing.T) {

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_producer.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_producer.go
@@ -422,7 +422,7 @@ func (b *binlogProducer) createRowEvents(ctx *sql.Context, tableDeltas []diff.Ta
 			}
 		}
 
-		columns := nonVirtualColumns(sch.GetAllCols().GetColumns())
+		nonSystemHiddenCols := sch.GetAllCols().GetNonSystemHiddenCols()
 		tableId := tablesToId[tableName.Name]
 
 		var tableRowsToWrite []mysql.Row
@@ -512,40 +512,41 @@ func (b *binlogProducer) createRowEvents(ctx *sql.Context, tableDeltas []diff.Ta
 
 		if tableRowsToWrite != nil {
 			rows := mysql.Rows{
-				DataColumns: mysql.NewServerBitmap(len(columns)),
+				DataColumns: mysql.NewServerBitmap(len(nonSystemHiddenCols)),
 				Rows:        tableRowsToWrite,
 			}
-			// All columns are included
-			for i := 0; i < len(columns); i++ {
-				rows.DataColumns.Set(i, true)
+			for i, col := range nonSystemHiddenCols {
+				if !col.Virtual {
+					rows.DataColumns.Set(i, true)
+				}
 			}
 			events = append(events, b.newWriteRowsEvent(tableId, rows))
 		}
 
 		if tableRowsToDelete != nil {
 			rows := mysql.Rows{
-				IdentifyColumns: mysql.NewServerBitmap(len(columns)),
+				IdentifyColumns: mysql.NewServerBitmap(len(nonSystemHiddenCols)),
 				Rows:            tableRowsToDelete,
 			}
-			// All identity columns are included
-			for i := 0; i < len(columns); i++ {
-				rows.IdentifyColumns.Set(i, true)
+			for i, col := range nonSystemHiddenCols {
+				if !col.Virtual {
+					rows.IdentifyColumns.Set(i, true)
+				}
 			}
 			events = append(events, b.newDeleteRowsEvent(tableId, rows))
 		}
 
 		if tableRowsToUpdate != nil {
 			rows := mysql.Rows{
-				DataColumns:     mysql.NewServerBitmap(len(columns)),
-				IdentifyColumns: mysql.NewServerBitmap(len(columns)),
+				DataColumns:     mysql.NewServerBitmap(len(nonSystemHiddenCols)),
+				IdentifyColumns: mysql.NewServerBitmap(len(nonSystemHiddenCols)),
 				Rows:            tableRowsToUpdate,
 			}
-			// All columns are included for data and identify fields
-			for i := 0; i < len(columns); i++ {
-				rows.DataColumns.Set(i, true)
-			}
-			for i := 0; i < len(columns); i++ {
-				rows.IdentifyColumns.Set(i, true)
+			for i, col := range nonSystemHiddenCols {
+				if !col.Virtual {
+					rows.DataColumns.Set(i, true)
+					rows.IdentifyColumns.Set(i, true)
+				}
 			}
 			events = append(events, b.newUpdateRowsEvent(tableId, rows))
 		}
@@ -709,19 +710,6 @@ func extractRowCountAndDiffType(ctx *sql.Context, sch schema.Schema, diff tree.D
 	}
 }
 
-// nonVirtualColumns returns the subset of |columns| that are not virtual. Virtual columns (e.g. the
-// hidden columns Dolt creates to back a functional/expression index) are never stored in a row's value
-// tuple, so they must be excluded whenever binlog events are constructed from a table's full column set.
-func nonVirtualColumns(columns []schema.Column) []schema.Column {
-	nonVirtual := make([]schema.Column, 0, len(columns))
-	for _, col := range columns {
-		if !col.Virtual {
-			nonVirtual = append(nonVirtual, col)
-		}
-	}
-	return nonVirtual
-}
-
 // createTableMapFromDoltTable creates a binlog TableMap for the given Dolt table. If
 // |includeOptionalMetadata| is set to true, then additional, optional metadata such as
 // column names and column collations will also be included in the TableMap.
@@ -731,10 +719,12 @@ func createTableMapFromDoltTable(ctx *sql.Context, databaseName, tableName strin
 		return nil, err
 	}
 
-	columns := nonVirtualColumns(sch.GetAllCols().GetColumns())
-	types := make([]byte, len(columns))
-	metadata := make([]uint16, len(columns))
-	canBeNullMap := mysql.NewServerBitmap(len(columns))
+	// Include all non-system-hidden columns. Virtual generated columns still pass metadata, but
+	// don't ever pass a value, since the value isn't stored in a row tuple.
+	nonSystemHiddenCols := sch.GetAllCols().GetNonSystemHiddenCols()
+	types := make([]byte, len(nonSystemHiddenCols))
+	metadata := make([]uint16, len(nonSystemHiddenCols))
+	canBeNullMap := mysql.NewServerBitmap(len(nonSystemHiddenCols))
 
 	var columnNames []string
 	var columnCollationIds []uint64
@@ -742,11 +732,11 @@ func createTableMapFromDoltTable(ctx *sql.Context, databaseName, tableName strin
 	var setValues [][]string
 	var enumAndSetCollationIds []uint64
 	if includeOptionalMetadata {
-		columnNames = make([]string, len(columns))
-		columnCollationIds = make([]uint64, len(columns))
+		columnNames = make([]string, len(nonSystemHiddenCols))
+		columnCollationIds = make([]uint64, len(nonSystemHiddenCols))
 	}
 
-	for i, col := range columns {
+	for i, col := range nonSystemHiddenCols {
 		if includeOptionalMetadata {
 			columnNames[i] = col.Name
 			columnCollationIds[i] = uint64(schema.Collation_Unspecified)

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_producer.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_producer.go
@@ -422,7 +422,7 @@ func (b *binlogProducer) createRowEvents(ctx *sql.Context, tableDeltas []diff.Ta
 			}
 		}
 
-		columns := sch.GetAllCols().GetColumns()
+		columns := nonVirtualColumns(sch.GetAllCols().GetColumns())
 		tableId := tablesToId[tableName.Name]
 
 		var tableRowsToWrite []mysql.Row
@@ -709,6 +709,19 @@ func extractRowCountAndDiffType(ctx *sql.Context, sch schema.Schema, diff tree.D
 	}
 }
 
+// nonVirtualColumns returns the subset of |columns| that are not virtual. Virtual columns (e.g. the
+// hidden columns Dolt creates to back a functional/expression index) are never stored in a row's value
+// tuple, so they must be excluded whenever binlog events are constructed from a table's full column set.
+func nonVirtualColumns(columns []schema.Column) []schema.Column {
+	nonVirtual := make([]schema.Column, 0, len(columns))
+	for _, col := range columns {
+		if !col.Virtual {
+			nonVirtual = append(nonVirtual, col)
+		}
+	}
+	return nonVirtual
+}
+
 // createTableMapFromDoltTable creates a binlog TableMap for the given Dolt table. If
 // |includeOptionalMetadata| is set to true, then additional, optional metadata such as
 // column names and column collations will also be included in the TableMap.
@@ -718,7 +731,7 @@ func createTableMapFromDoltTable(ctx *sql.Context, databaseName, tableName strin
 		return nil, err
 	}
 
-	columns := sch.GetAllCols().GetColumns()
+	columns := nonVirtualColumns(sch.GetAllCols().GetColumns())
 	types := make([]byte, len(columns))
 	metadata := make([]uint16, len(columns))
 	canBeNullMap := mysql.NewServerBitmap(len(columns))

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_test.go
@@ -205,6 +205,59 @@ func TestBinlogReplicationSanityCheck(t *testing.T) {
 	h.requireReplicaResults("select * from db01.tableT", [][]any{{"300"}})
 }
 
+// TestBinlogReplicationFunctionalIndex tests that a MySQL primary with a table containing a functional/expression
+// index correctly replicates inserts, updates, and deletes to a Dolt replica.
+// https://github.com/dolthub/dolt/issues/11475
+func TestBinlogReplicationFunctionalIndex(t *testing.T) {
+	h := newHarness(t)
+	h.startSqlServersWithDoltSystemVars(doltReplicaSystemVars)
+	h.startReplicationAndCreateTestDb(h.mySqlPort)
+
+	h.primaryDatabase.MustExec("create table t (pk int primary key, id int)")
+	h.primaryDatabase.MustExec("create index idx_ifzero on t ((if(id = 0, 1, 0)))")
+	h.waitForReplicaToCatchUp()
+
+	h.primaryDatabase.MustExec("insert into t values (1, 0), (2, 5)")
+	h.waitForReplicaToCatchUp()
+	h.requireReplicaResults("select * from db01.t order by pk", [][]any{{"1", "0"}, {"2", "5"}})
+
+	h.primaryDatabase.MustExec("update t set id = 1 where pk = 1")
+	h.waitForReplicaToCatchUp()
+	h.requireReplicaResults("select * from db01.t order by pk", [][]any{{"1", "1"}, {"2", "5"}})
+
+	h.primaryDatabase.MustExec("delete from t where pk = 2")
+	h.waitForReplicaToCatchUp()
+	h.requireReplicaResults("select * from db01.t order by pk", [][]any{{"1", "1"}})
+}
+
+// TestBinlogReplicationVirtualColumn tests that a MySQL primary with a table containing a VIRTUAL generated column
+// positioned BETWEEN two stored columns correctly replicates inserts to a Dolt replica.
+// https://github.com/dolthub/dolt/issues/11475
+func TestBinlogReplicationVirtualColumn(t *testing.T) {
+	h := newHarness(t)
+	h.startSqlServersWithDoltSystemVars(doltReplicaSystemVars)
+	h.startReplicationAndCreateTestDb(h.mySqlPort)
+
+	h.primaryDatabase.MustExec(
+		"create table t (pk int primary key, a varchar(20), g varchar(20) generated always as (concat(a, '!')), z varchar(20))")
+	h.waitForReplicaToCatchUp()
+
+	h.primaryDatabase.MustExec("insert into t (pk, a, z) values (1, 'x', 'end'), (2, 'y', 'tail')")
+	h.waitForReplicaToCatchUp()
+	// z holds its own value, so the stored column after the virtual one must not shift.
+	h.requireReplicaResults("select pk, a, g, z from db01.t order by pk",
+		[][]any{{"1", "x", "x!", "end"}, {"2", "y", "y!", "tail"}})
+
+	h.primaryDatabase.MustExec("update t set a = 'xx', z = 'end2' where pk = 1")
+	h.waitForReplicaToCatchUp()
+	h.requireReplicaResults("select pk, a, g, z from db01.t order by pk",
+		[][]any{{"1", "xx", "xx!", "end2"}, {"2", "y", "y!", "tail"}})
+
+	h.primaryDatabase.MustExec("delete from t where pk = 2")
+	h.waitForReplicaToCatchUp()
+	h.requireReplicaResults("select pk, a, g, z from db01.t order by pk", [][]any{{"1", "xx", "xx!", "end2"}})
+}
+
 // TestBinlogReplicationWithHundredsOfDatabases asserts that we can efficiently replicate the creation of hundreds of databases.
 func TestBinlogReplicationWithHundredsOfDatabases(t *testing.T) {
 	h := newHarness(t)

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_test.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_replication_test.go
@@ -239,23 +239,23 @@ func TestBinlogReplicationVirtualColumn(t *testing.T) {
 	h.startReplicationAndCreateTestDb(h.mySqlPort)
 
 	h.primaryDatabase.MustExec(
-		"create table t (pk int primary key, a varchar(20), g varchar(20) generated always as (concat(a, '!')), z varchar(20))")
+		"create table t (pk int primary key, a varchar(20), g int generated always as (length(a)), z varchar(20))")
 	h.waitForReplicaToCatchUp()
 
-	h.primaryDatabase.MustExec("insert into t (pk, a, z) values (1, 'x', 'end'), (2, 'y', 'tail')")
+	h.primaryDatabase.MustExec("insert into t (pk, a, z) values (1, 'x', 'end'), (2, 'yy', 'tail')")
 	h.waitForReplicaToCatchUp()
 	// z holds its own value, so the stored column after the virtual one must not shift.
 	h.requireReplicaResults("select pk, a, g, z from db01.t order by pk",
-		[][]any{{"1", "x", "x!", "end"}, {"2", "y", "y!", "tail"}})
+		[][]any{{"1", "x", "1", "end"}, {"2", "yy", "2", "tail"}})
 
-	h.primaryDatabase.MustExec("update t set a = 'xx', z = 'end2' where pk = 1")
+	h.primaryDatabase.MustExec("update t set a = 'xxx', z = 'end2' where pk = 1")
 	h.waitForReplicaToCatchUp()
 	h.requireReplicaResults("select pk, a, g, z from db01.t order by pk",
-		[][]any{{"1", "xx", "xx!", "end2"}, {"2", "y", "y!", "tail"}})
+		[][]any{{"1", "xxx", "3", "end2"}, {"2", "yy", "2", "tail"}})
 
 	h.primaryDatabase.MustExec("delete from t where pk = 2")
 	h.waitForReplicaToCatchUp()
-	h.requireReplicaResults("select pk, a, g, z from db01.t order by pk", [][]any{{"1", "xx", "xx!", "end2"}})
+	h.requireReplicaResults("select pk, a, g, z from db01.t order by pk", [][]any{{"1", "xxx", "3", "end2"}})
 }
 
 // TestBinlogReplicationWithHundredsOfDatabases asserts that we can efficiently replicate the creation of hundreds of databases.

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_row_serialization.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_row_serialization.go
@@ -29,16 +29,15 @@ import (
 // the data for a row, so that callers can ask for the next column information and get the right descriptor, tuple,
 // and tuple index to use to load that column's data.
 type rowSerializationIter struct {
-	fromSch schema.Schema   // The schema representing the start of the diff being serialized
-	toSch   schema.Schema   // The schema representing the end of the diff row being serialized
-	toCols  []schema.Column // The non-virtual columns of toSch, in order; virtual columns are never stored in a row
+	fromSch schema.Schema // The schema representing the start of the diff being serialized
+	toSch   schema.Schema // The schema representing the end of the diff row being serialized
 
 	keyDesc   *val.TupleDesc // The descriptor for the key tuple (from fromSch)
 	valueDesc *val.TupleDesc // The descriptor for the value tuple (from fromSch)
 	key       val.Tuple      // The key tuple for the row being serialized
 	value     val.Tuple      // The value tuple for the row being serialized
 
-	colIdx int // The position in toCols for the current column
+	colIdx int // The stored (non-virtual) column index in toSch for the current column
 }
 
 // newRowSerializationIter creates a new rowSerializationIter using the |fromSch|, which describes the format of the
@@ -49,7 +48,6 @@ func newRowSerializationIter(ctx *sql.Context, fromSch, toSch schema.Schema, key
 	return &rowSerializationIter{
 		fromSch:   fromSch,
 		toSch:     toSch,
-		toCols:    nonVirtualColumns(toSch.GetAllCols().GetColumns()),
 		key:       val.Tuple(key),
 		keyDesc:   fromSch.GetKeyDescriptor(ns),
 		value:     val.Tuple(value),
@@ -60,7 +58,7 @@ func newRowSerializationIter(ctx *sql.Context, fromSch, toSch schema.Schema, key
 
 // hasNext returns true if this iterator has more columns to provide and the |nextColumn| method can be called.
 func (rsi *rowSerializationIter) hasNext() bool {
-	return rsi.colIdx < len(rsi.toCols)
+	return rsi.colIdx < rsi.toSch.GetAllCols().StoredSize()
 }
 
 // nextColumn provides the data needed to process the next column in a row, including the column from the "from" schema,
@@ -73,7 +71,7 @@ func (rsi *rowSerializationIter) nextColumn() (*schema.Column, *schema.Column, *
 	// Ultimately, we are serializing to the "to" schema so that we can send a binlog encoded row to a replica, so
 	// we iterate over the "to" schema's non-virtual columns to assemble the serialized row in the format the
 	// replica is expecting.
-	toCol := rsi.toCols[rsi.colIdx]
+	toCol := rsi.toSch.GetAllCols().GetByStoredIndex(rsi.colIdx)
 	rsi.colIdx++
 
 	// Look up the matching, non-virtual column in the "from" schema.
@@ -134,8 +132,7 @@ func (rsi *rowSerializationIter) findFromTupleIndex(pFromCol *schema.Column) int
 // out-of-band data. This function returns the binary representation of the row, as well as a bitmap that indicates
 // which fields of the row are null (and therefore don't contribute any bytes to the returned binary data).
 func serializeRowToBinlogBytes(ctx *sql.Context, fromSch, toSch schema.Schema, key, value tree.Item, ns tree.NodeStore) (data []byte, nullBitmap mysql.Bitmap, err error) {
-	columns := nonVirtualColumns(toSch.GetAllCols().GetColumns())
-	nullBitmap = mysql.NewServerBitmap(len(columns))
+	nullBitmap = mysql.NewServerBitmap(toSch.GetAllCols().StoredSize())
 
 	iter := newRowSerializationIter(ctx, fromSch, toSch, key, value, ns)
 	rowIdx := -1

--- a/go/libraries/doltcore/sqle/binlogreplication/binlog_row_serialization.go
+++ b/go/libraries/doltcore/sqle/binlogreplication/binlog_row_serialization.go
@@ -29,15 +29,16 @@ import (
 // the data for a row, so that callers can ask for the next column information and get the right descriptor, tuple,
 // and tuple index to use to load that column's data.
 type rowSerializationIter struct {
-	fromSch schema.Schema // The schema representing the start of the diff being serialized
-	toSch   schema.Schema // The schema representing the end of the diff row being serialized
+	fromSch schema.Schema   // The schema representing the start of the diff being serialized
+	toSch   schema.Schema   // The schema representing the end of the diff row being serialized
+	toCols  []schema.Column // The non-virtual columns of toSch, in order; virtual columns are never stored in a row
 
 	keyDesc   *val.TupleDesc // The descriptor for the key tuple (from fromSch)
 	valueDesc *val.TupleDesc // The descriptor for the value tuple (from fromSch)
 	key       val.Tuple      // The key tuple for the row being serialized
 	value     val.Tuple      // The value tuple for the row being serialized
 
-	colIdx int // The position in the schema for the current column
+	colIdx int // The position in toCols for the current column
 }
 
 // newRowSerializationIter creates a new rowSerializationIter using the |fromSch|, which describes the format of the
@@ -48,6 +49,7 @@ func newRowSerializationIter(ctx *sql.Context, fromSch, toSch schema.Schema, key
 	return &rowSerializationIter{
 		fromSch:   fromSch,
 		toSch:     toSch,
+		toCols:    nonVirtualColumns(toSch.GetAllCols().GetColumns()),
 		key:       val.Tuple(key),
 		keyDesc:   fromSch.GetKeyDescriptor(ns),
 		value:     val.Tuple(value),
@@ -58,7 +60,7 @@ func newRowSerializationIter(ctx *sql.Context, fromSch, toSch schema.Schema, key
 
 // hasNext returns true if this iterator has more columns to provide and the |nextColumn| method can be called.
 func (rsi *rowSerializationIter) hasNext() bool {
-	return rsi.colIdx < rsi.toSch.GetAllCols().Size()
+	return rsi.colIdx < len(rsi.toCols)
 }
 
 // nextColumn provides the data needed to process the next column in a row, including the column from the "from" schema,
@@ -69,18 +71,19 @@ func (rsi *rowSerializationIter) hasNext() bool {
 // safe to call.
 func (rsi *rowSerializationIter) nextColumn() (*schema.Column, *schema.Column, *val.TupleDesc, val.Tuple, int) {
 	// Ultimately, we are serializing to the "to" schema so that we can send a binlog encoded row to a replica, so
-	// we iterate over the "to" schema to assemble the serialized row in the format the replica is expecting.
-	toCol := rsi.toSch.GetAllCols().GetColumns()[rsi.colIdx]
+	// we iterate over the "to" schema's non-virtual columns to assemble the serialized row in the format the
+	// replica is expecting.
+	toCol := rsi.toCols[rsi.colIdx]
 	rsi.colIdx++
 
-	// Look up the matching column in the "from" schema
+	// Look up the matching, non-virtual column in the "from" schema.
 	var pFromCol *schema.Column
-	if fromCol, ok := rsi.fromSch.GetAllCols().GetByTag(toCol.Tag); ok {
+	if fromCol, ok := rsi.fromSch.GetAllCols().GetByTag(toCol.Tag); ok && !fromCol.Virtual {
 		pFromCol = &fromCol
 	} else {
 		// Try to look up by name in case we don't find by tag?
 		// The tag can change in some cases, such as type changes... need to test this
-		if fromCol, ok = rsi.fromSch.GetAllCols().GetByName(toCol.Name); ok {
+		if fromCol, ok = rsi.fromSch.GetAllCols().GetByName(toCol.Name); ok && !fromCol.Virtual {
 			pFromCol = &fromCol
 		}
 	}
@@ -101,27 +104,25 @@ func (rsi *rowSerializationIter) nextColumn() (*schema.Column, *schema.Column, *
 	}
 }
 
-// findFromTupleIndex searches the "from" schema in this iterator for the column |pFromCol| and returns the
-// index of that field into the tuple it is stored in (i.e. either the key tuple or the value tuple). If
-// |pFromCol| is nil, then -1 is returned. Callers must use this to find the correct index to load from the
-// tuple, because fields may be skipped over if a column was dropped or reordered as part of the transaction.
+// findFromTupleIndex returns the index of |pFromCol| into the tuple it is stored in (i.e. either the key tuple or
+// the value tuple). If |pFromCol| is nil, then -1 is returned. This uses the storage index (via StoredIndexByTag),
+// rather than the column's position.
 func (rsi *rowSerializationIter) findFromTupleIndex(pFromCol *schema.Column) int {
 	if pFromCol == nil {
 		return -1
 	}
 
-	fromTupleIdx := -1
-	for _, col := range rsi.fromSch.GetAllCols().GetColumns() {
-		// Make sure we're indexing into the correct tuple: either the key or the value tuple
-		if col.IsPartOfPK != pFromCol.IsPartOfPK {
-			continue
-		}
-		fromTupleIdx++
-		if col.Equals(*pFromCol) {
-			break
-		}
+	var idx int
+	var ok bool
+	if pFromCol.IsPartOfPK {
+		idx, ok = rsi.fromSch.GetPKCols().StoredIndexByTag(pFromCol.Tag)
+	} else {
+		idx, ok = rsi.fromSch.GetNonPKCols().StoredIndexByTag(pFromCol.Tag)
 	}
-	return fromTupleIdx
+	if !ok {
+		return -1
+	}
+	return idx
 }
 
 // serializeRowToBinlogBytes serializes the row formed by |key| and |value| into a binlog encoded row. The |fromSch| is
@@ -133,7 +134,7 @@ func (rsi *rowSerializationIter) findFromTupleIndex(pFromCol *schema.Column) int
 // out-of-band data. This function returns the binary representation of the row, as well as a bitmap that indicates
 // which fields of the row are null (and therefore don't contribute any bytes to the returned binary data).
 func serializeRowToBinlogBytes(ctx *sql.Context, fromSch, toSch schema.Schema, key, value tree.Item, ns tree.NodeStore) (data []byte, nullBitmap mysql.Bitmap, err error) {
-	columns := toSch.GetAllCols().GetColumns()
+	columns := nonVirtualColumns(toSch.GetAllCols().GetColumns())
 	nullBitmap = mysql.NewServerBitmap(len(columns))
 
 	iter := newRowSerializationIter(ctx, fromSch, toSch, key, value, ns)

--- a/go/libraries/doltcore/sqle/dtablefunctions/dolt_schema_diff.go
+++ b/go/libraries/doltcore/sqle/dtablefunctions/dolt_schema_diff.go
@@ -317,14 +317,14 @@ func (ds *SchemaDiffTableFunction) RowIter(ctx *sql.Context, row sql.Row) (sql.R
 		var fromCreate, toCreate string
 
 		if delta.FromTable != nil {
-			fromCreate, err = sqlfmt.GenerateCreateTableStatement(ctx, delta.FromName.Name, delta.FromSch, delta.FromFks, delta.FromFksParentSch)
+			fromCreate, err = sqlfmt.GenerateCreateTableStatement(ctx, delta.FromName.Name, delta.FromSch, delta.FromFks, delta.FromFksParentSch, false)
 			if err != nil {
 				return nil, err
 			}
 		}
 
 		if delta.ToTable != nil {
-			toCreate, err = sqlfmt.GenerateCreateTableStatement(ctx, delta.ToName.Name, delta.ToSch, delta.ToFks, delta.ToFksParentSch)
+			toCreate, err = sqlfmt.GenerateCreateTableStatement(ctx, delta.ToName.Name, delta.ToSch, delta.ToFks, delta.ToFksParentSch, false)
 			if err != nil {
 				return nil, err
 			}

--- a/go/libraries/doltcore/sqle/dtables/schema_conflicts_table.go
+++ b/go/libraries/doltcore/sqle/dtables/schema_conflicts_table.go
@@ -238,7 +238,7 @@ func newSchemaConflict(ctx *sql.Context, table doltdb.TableName, baseRoot doltdb
 }
 
 func getCreateTableStatement(ctx *sql.Context, table string, sch schema.Schema, fks []doltdb.ForeignKey, parents map[doltdb.TableName]schema.Schema) (string, error) {
-	return sqlfmt.GenerateCreateTableStatement(ctx, table, sch, fks, parents)
+	return sqlfmt.GenerateCreateTableStatement(ctx, table, sch, fks, parents, false)
 }
 
 func getSchemaConflictDescription(ctx *sql.Context, table doltdb.TableName, base, ours, theirs schema.Schema) (string, error) {

--- a/go/libraries/doltcore/sqle/expranalysis/expranalysis.go
+++ b/go/libraries/doltcore/sqle/expranalysis/expranalysis.go
@@ -134,7 +134,9 @@ type SessionDbProvider interface {
 }
 
 func parseCreateTable(ctx *sql.Context, tableName string, sch schema.Schema) (*plan.CreateTable, error) {
-	createTable, err := sqlfmt.GenerateCreateTableStatement(ctx, tableName, sch, nil, nil)
+	// This is a pseudo CREATE TABLE, used only to resolve default/generated/check expressions via the
+	// engine's own SQL parser and analyzer, so SystemHidden columns are included here.
+	createTable, err := sqlfmt.GenerateCreateTableStatement(ctx, tableName, sch, nil, nil, true)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/sqlfmt/schema_fmt.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/schema_fmt.go
@@ -78,7 +78,7 @@ func GenerateSqlPatchSchemaStatements(ctx *sql.Context, toRoot doltdb.RootValue,
 	if td.IsDrop() {
 		ddlStatements = append(ddlStatements, DropTableStmt(formatter, td.FromName.Name))
 	} else if td.IsAdd() {
-		stmt, err := GenerateCreateTableStatement(ctx, td.ToName.Name, td.ToSch, td.ToFks, td.ToFksParentSch)
+		stmt, err := GenerateCreateTableStatement(ctx, td.ToName.Name, td.ToSch, td.ToFks, td.ToFksParentSch, false)
 		if err != nil {
 			return nil, errhand.VerboseErrorFromError(err)
 		}
@@ -115,6 +115,11 @@ func generateNonCreateNonDropTableSqlSchemaDiff(ctx *sql.Context, formatter sql.
 	colDiffs, unionTags := diff.DiffSchColumns(fromSch, toSch)
 	for _, tag := range unionTags {
 		cd := colDiffs[tag]
+		// SystemHidden columns are the hidden columns Dolt creates internally to back a
+		// functional/expression index, so we don't include them here.
+		if (cd.Old != nil && cd.Old.SystemHidden) || (cd.New != nil && cd.New.SystemHidden) {
+			continue
+		}
 		switch cd.DiffType {
 		case diff.SchDiffNone:
 		case diff.SchDiffAdded:
@@ -224,19 +229,39 @@ func GenerateCreateTableIndentedColumnDefinition(ctx *sql.Context, formatter sql
 			Comment:       col.Comment,
 			Generated:     genVal,
 			Virtual:       col.Virtual,
+			Hidden:        col.Hidden,
+			HiddenSystem:  col.SystemHidden,
 			OnUpdate:      onUpdateVal,
 		}, col.Default, col.OnUpdate, tableCollation)
 }
 
-// GenerateCreateTableIndexDefinition returns index definition for CREATE TABLE statement with indentation of 2 spaces
-func GenerateCreateTableIndexDefinition(formatter sql.SchemaFormatter, index schema.Index) (string, bool) {
+// indexColumnDDLExpressions returns the SQL expression to use for each column in |index|'s column list when
+// generating CREATE TABLE / ALTER TABLE DDL. For a normal column, this is just the quoted column name. For the
+// hidden column backing a functional/expression index, the hidden column's name must never be referenced
+// directly in DDL sent to a real MySQL server.
+func indexColumnDDLExpressions(formatter sql.SchemaFormatter, index schema.Index) []string {
+	tags := index.IndexedColumnTags()
+	exprs := make([]string, len(tags))
+	for i, tag := range tags {
+		col, _ := index.GetColumn(tag)
+		if col.SystemHidden && col.Generated != "" {
+			exprs[i] = col.Generated
+		} else {
+			exprs[i] = formatter.QuoteIdentifier(col.Name)
+		}
+	}
+	return exprs
+}
+
+// indexColumnNames returns the quoted name of each column in |index|'s column list, unconditionally, including
+// columns backing a functional/expression index.
+func indexColumnNames(formatter sql.SchemaFormatter, index schema.Index) []string {
 	colNames := index.ColumnNames()
 	quotedColNames := make([]string, len(colNames))
-	for i, id := range colNames {
-		quotedColNames[i] = formatter.QuoteIdentifier(id)
+	for i, name := range colNames {
+		quotedColNames[i] = formatter.QuoteIdentifier(name)
 	}
-	return formatter.GenerateCreateTableIndexDefinition(index.IsUnique(), index.IsSpatial(), index.IsFullText(),
-		index.IsVector(), index.Name(), quotedColNames, index.Comment())
+	return quotedColNames
 }
 
 // GenerateCreateTableForeignKeyDefinition returns foreign key definition for CREATE TABLE statement with indentation of 2 spaces
@@ -383,11 +408,7 @@ func AlterTableAddIndexStmt(formatter sql.SchemaFormatter, tableName string, idx
 	b.WriteString(formatter.QuoteIdentifier(tableName))
 	b.WriteString(" ADD INDEX ")
 	b.WriteString(formatter.QuoteIdentifier(idx.Name()))
-	var cols []string
-	for _, cn := range idx.ColumnNames() {
-		cols = append(cols, formatter.QuoteIdentifier(cn))
-	}
-	b.WriteString("(" + strings.Join(cols, ",") + ");")
+	b.WriteString("(" + strings.Join(indexColumnDDLExpressions(formatter, idx), ",") + ");")
 	return b.String()
 }
 
@@ -456,15 +477,21 @@ func AlterTableDropForeignKeyStmt(formatter sql.SchemaFormatter, tableName doltd
 // GenerateCreateTableStatement returns a CREATE TABLE statement for given table. This is a reasonable approximation of
 // `SHOW CREATE TABLE` in the engine, but may have some differences. Callers are advised to use the engine when
 // possible.
-func GenerateCreateTableStatement(ctx *sql.Context, tblName string, sch schema.Schema, fks []doltdb.ForeignKey, fksParentSch map[doltdb.TableName]schema.Schema) (string, error) {
+//
+// |includeSystemHiddenColumns| controls how SystemHidden columns (the hidden columns Dolt creates internally to
+// back a functional/expression index) are rendered. Most callers want false: SystemHidden columns never appear
+// in real DDL output.
+func GenerateCreateTableStatement(ctx *sql.Context, tblName string, sch schema.Schema, fks []doltdb.ForeignKey, fksParentSch map[doltdb.TableName]schema.Schema, includeSystemHiddenColumns bool) (string, error) {
 	formatter := overrides.SchemaFormatterFromContext(ctx)
-	colStmts := make([]string, sch.GetAllCols().Size())
+	colStmts := make([]string, 0, sch.GetAllCols().Size())
 
 	schemaFormatter := overrides.SchemaFormatterFromContext(ctx)
 
-	// Statement creation parts for each column
-	for i, col := range sch.GetAllCols().GetColumns() {
-		colStmts[i] = GenerateCreateTableIndentedColumnDefinition(ctx, formatter, col, sql.CollationID(sch.GetCollation()))
+	for _, col := range sch.GetAllCols().GetColumns() {
+		if col.SystemHidden && !includeSystemHiddenColumns {
+			continue
+		}
+		colStmts = append(colStmts, GenerateCreateTableIndentedColumnDefinition(ctx, formatter, col, sql.CollationID(sch.GetCollation())))
 	}
 
 	primaryKeyCols := sch.GetPKCols().GetColumnNames()
@@ -480,7 +507,14 @@ func GenerateCreateTableStatement(ctx *sql.Context, tblName string, sch schema.S
 			continue
 		}
 
-		definition, shouldInclude := GenerateCreateTableIndexDefinition(formatter, index)
+		var indexCols []string
+		if includeSystemHiddenColumns {
+			indexCols = indexColumnNames(formatter, index)
+		} else {
+			indexCols = indexColumnDDLExpressions(formatter, index)
+		}
+		definition, shouldInclude := formatter.GenerateCreateTableIndexDefinition(index.IsUnique(), index.IsSpatial(),
+			index.IsFullText(), index.IsVector(), index.Name(), indexCols, index.Comment())
 		if shouldInclude {
 			colStmts = append(colStmts, definition)
 		}


### PR DESCRIPTION
Adds support for correctly handling virtual columns and functional indexes in binlog replication, both when Dolt is acting as the replication primary and when Dolt is acting as a replica. 

Fixes: https://github.com/dolthub/dolt/issues/11475