### PR TITLE
sqle: reclaim incomplete/abandoned database directories on create/clone instead of erroring

### DIFF
--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -304,15 +304,20 @@ func (dEnv *DoltEnv) Valid() bool {
 	return dEnv != nil && dEnv.CfgLoadErr == nil && dEnv.RSLoadErr == nil && dEnv.DBLoadError == nil && dEnv.HasDoltDir() && dEnv.HasDoltDataDir()
 }
 
-// IsIncompleteDatabaseDir reports whether the database directory rooted at |fs| holds a database whose creation
-// never finished, either because it carries the in-progress marker or because it has Dolt storage without the
-// repo state file that every complete database has. Discovery ignores such a directory, so it cannot be served.
+// IsIncompleteDatabaseDir reports whether the directory rooted at |fs| is NOT a complete, servable Dolt
+// database, so discovery ignores it and a create/clone may reclaim its name instead of colliding with it.
+// This holds when the directory carries the in-progress marker, has Dolt storage without the repo state
+// file that every complete database has, or holds no Dolt storage at all — a bare or non-database leftover,
+// e.g. an early-cancelled clone interrupted before .dolt was written. A complete database (Dolt storage
+// plus its repo state file, marker cleared) returns false.
 func IsIncompleteDatabaseDir(fs filesys.Filesys) bool {
 	if dbfactory.IsDatabaseInProgress(fs) {
 		return true
 	}
 	if exists, isDir := fs.Exists(dbfactory.DoltDir); !exists || !isDir {
-		return false
+		// No Dolt storage at all: not a database, only a bare or non-database directory squatting on the
+		// name. Discovery would never serve it, so it is safe to reclaim.
+		return true
 	}
 	exists, _ := fs.Exists(getRepoStateFile())
 	return !exists

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -675,12 +675,6 @@ func commitTransaction(ctx *sql.Context, dSess *dsess.DoltSession, rsc *doltdb.R
 	return nil
 }
 
-var ErrIncompleteDatabaseDir = errors.New("incomplete database directory from an interrupted create already exists; remove the directory and try again")
-
-func NewErrIncompleteDatabaseDir(db string) error {
-	return fmt.Errorf("cannot create database %s: %w", db, ErrIncompleteDatabaseDir)
-}
-
 func (p *DoltDatabaseProvider) CreateCollatedDatabase(ctx *sql.Context, name string, collation sql.CollationID) (err error) {
 	// We have to validate the name before attempting to create a directory. If a directory contains a delimiter, when
 	// registerNewDatabase errors out a directory with the exact name will be leftover due to a process lock. This then
@@ -980,8 +974,10 @@ func (p *DoltDatabaseProvider) CloneDatabaseFromRemote(
 // held. Names are normalized with formatDbMapKeyName because Dolt database names
 // are case-insensitive.
 //
-// When |checkDisk| is true the on-disk directory is also checked; creation paths
-// pass true, while undrop (which restores from the stash) passes false.
+// When |checkDisk| is true the on-disk directory is also checked; creation paths pass true, while undrop
+// (which restores from the stash) passes false. A complete database directory on disk conflicts, but an
+// INCOMPLETE leftover (an interrupted create/clone that discovery ignores) is quarantined into the
+// dropped-database holding area and the name reported available, so a retry is never wedged behind junk.
 func (p *DoltDatabaseProvider) checkDatabaseNameAvailableLocked(name string, checkDisk bool) error {
 	key := formatDbMapKeyName(name)
 	if _, ok := p.deletingDatabases[key]; ok {
@@ -993,10 +989,21 @@ func (p *DoltDatabaseProvider) checkDatabaseNameAvailableLocked(name string, che
 	if checkDisk {
 		exists, isDir := p.fs.Exists(name)
 		if exists && isDir {
-			// A directory left behind by an interrupted create/clone carries an
-			// in-progress marker; surface a clearer error than "already exists".
+			// A directory left behind by an interrupted create/clone — an in-progress marker, Dolt storage
+			// without the repo-state file every complete database has, or no Dolt storage at all (a bare
+			// early-cancel leftover) — is ignored by discovery, so it is not a live database: it only squats
+			// on the name and blocks a retry with "database exists". Quarantine it into the dropped-database
+			// holding area (recoverable via dolt_undrop, purged by DOLT_PURGE_DROPPED_DATABASES) so this
+			// create/clone can proceed. A COMPLETE database directory is a real database and still conflicts.
 			if subFs, ferr := p.fs.WithWorkingDir(name); ferr == nil && env.IsIncompleteDatabaseDir(subFs) {
-				return NewErrIncompleteDatabaseDir(name)
+				dropDbLoc, err := p.fs.Abs(name)
+				if err != nil {
+					return err
+				}
+				if err := p.droppedDatabaseManager.quarantineIncompleteDatabase(name, dropDbLoc); err != nil {
+					return fmt.Errorf("unable to reclaim incomplete database directory %q: %w", name, err)
+				}
+				return nil
 			}
 			return sql.ErrDatabaseExists.New(name)
 		} else if exists {

--- a/go/libraries/doltcore/sqle/database_provider_test.go
+++ b/go/libraries/doltcore/sqle/database_provider_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -163,7 +164,9 @@ func InstallSnoopingCommitHook(ctx *sql.Context, pro *DoltDatabaseProvider, name
 	return nil
 }
 
-// orphanCases are the two on-disk remains an interrupted creation can leave behind.
+// orphanCases are the on-disk remains an interrupted creation can leave behind: an in-progress marker,
+// partial Dolt storage without a repo-state file, or a bare directory with no Dolt storage at all (an
+// early-cancelled clone interrupted before .dolt was written).
 var orphanCases = []struct {
 	name       string
 	makeOrphan func(t *testing.T, fs filesys.Filesys)
@@ -173,6 +176,10 @@ var orphanCases = []struct {
 	}},
 	{"missing repo state", func(t *testing.T, fs filesys.Filesys) {
 		require.NoError(t, fs.MkDirs(filepath.Join(dbfactory.DoltDir, dbfactory.DataDir)))
+	}},
+	{"no dolt storage", func(*testing.T, filesys.Filesys) {
+		// providerWithOrphanedDir already created an empty directory at the name; leave it bare (no
+		// .dolt), modelling a clone cancelled before any storage was written.
 	}},
 }
 
@@ -201,33 +208,108 @@ func providerWithOrphanedDir(t *testing.T, makeOrphan func(t *testing.T, fs file
 }
 
 func TestCreateDatabaseOverIncompleteDirectory(t *testing.T) {
+	// An interrupted create/clone leaves a directory that discovery ignores; a later CREATE must reclaim
+	// it (quarantine to the dropped-database holding area) and succeed, rather than wedging on "database
+	// exists" (murmur-zsyi [a]). IF NOT EXISTS behaves the same: the database genuinely does not exist yet.
 	for _, tc := range orphanCases {
-		t.Run(tc.name, func(t *testing.T) {
-			engine, sqlCtx, _ := providerWithOrphanedDir(t, tc.makeOrphan)
+		for _, q := range []string{"CREATE DATABASE foo;", "CREATE DATABASE IF NOT EXISTS foo;"} {
+			t.Run(tc.name+" / "+q, func(t *testing.T) {
+				engine, sqlCtx, pro := providerWithOrphanedDir(t, tc.makeOrphan)
 
-			// IF NOT EXISTS must not be silently suppressed, because the database does not exist and a
-			// client that believes it does cannot use it.
-			for _, q := range []string{"CREATE DATABASE foo;", "CREATE DATABASE IF NOT EXISTS foo;"} {
-				err := ExecuteSqlOnEngine(sqlCtx, engine, q)
-				require.Error(t, err)
-				assert.ErrorIs(t, err, ErrIncompleteDatabaseDir, "query %q", q)
-			}
-		})
+				require.NoError(t, ExecuteSqlOnEngine(sqlCtx, engine, q))
+
+				// foo is now a real, usable database...
+				_, err := pro.Database(sqlCtx, "foo")
+				require.NoError(t, err)
+
+				// ...and the incomplete leftover was quarantined (recoverable), not deleted or left in place.
+				dropped, err := pro.ListDroppedDatabases(sqlCtx)
+				require.NoError(t, err)
+				found, _ := hasCaseInsensitiveMatch(dropped, "foo")
+				require.Truef(t, found, "incomplete dir should have been quarantined; dropped=%v", dropped)
+			})
+		}
 	}
 }
 
 func TestCloneDatabaseOverIncompleteDirectory(t *testing.T) {
-	// A retried clone must not be stuck behind a directory it can neither use nor recreate.
+	// A retried clone must reclaim the incomplete leftover and get PAST the on-disk check to the remote,
+	// rather than being stuck behind a directory it can neither use nor recreate (murmur-zsyi [a]).
 	for _, tc := range orphanCases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, sqlCtx, pro := providerWithOrphanedDir(t, tc.makeOrphan)
 
-			// The orphaned directory is detected before any remote work, so the unreachable remote is never contacted.
+			// The remote is unreachable, so the clone still fails — but only AFTER quarantining the orphan
+			// and getting past the directory check (it now reaches the remote instead of wedging on the dir).
 			err := pro.CloneDatabaseFromRemote(sqlCtx, "foo", "", "origin", "file://unreachable", -1, nil)
 			require.Error(t, err)
-			assert.ErrorIs(t, err, ErrIncompleteDatabaseDir)
+
+			dropped, derr := pro.ListDroppedDatabases(sqlCtx)
+			require.NoError(t, derr)
+			found, _ := hasCaseInsensitiveMatch(dropped, "foo")
+			require.Truef(t, found, "incomplete dir should have been quarantined; dropped=%v", dropped)
 		})
 	}
+}
+
+// TestReserveQuarantinesIncompleteDirectory exercises the shared reserve gate directly (murmur-zsyi [a]):
+// checkDatabaseNameAvailableLocked quarantines an incomplete on-disk leftover and reports the name
+// available, a complete database directory still conflicts, and concurrent reservations of the same name
+// over a leftover are serialized so exactly one wins.
+func TestReserveQuarantinesIncompleteDirectory(t *testing.T) {
+	for _, tc := range orphanCases {
+		t.Run("incomplete leftover is reclaimed: "+tc.name, func(t *testing.T) {
+			_, sqlCtx, pro := providerWithOrphanedDir(t, tc.makeOrphan)
+
+			require.NoError(t, pro.reserveCreatingDatabase("foo"))
+			pro.releaseCreatingDatabase("foo")
+
+			// the leftover no longer squats on the live name...
+			exists, _ := pro.fs.Exists("foo")
+			require.False(t, exists, "incomplete dir must be moved out of the live path")
+
+			// ...it was quarantined (recoverable), not deleted.
+			dropped, err := pro.ListDroppedDatabases(sqlCtx)
+			require.NoError(t, err)
+			found, _ := hasCaseInsensitiveMatch(dropped, "foo")
+			require.Truef(t, found, "incomplete dir should have been quarantined; dropped=%v", dropped)
+		})
+	}
+
+	t.Run("a complete database directory still conflicts", func(t *testing.T) {
+		engine, sqlCtx, pro, _ := newProviderEngine(t)
+		require.NoError(t, ExecuteSqlOnEngine(sqlCtx, engine, "CREATE DATABASE bar;"))
+
+		// bar is a real, complete database — a clone/create over it must still conflict, never quarantine.
+		require.Truef(t, sql.ErrDatabaseExists.Is(pro.reserveCreatingDatabase("bar")),
+			"a complete database must not be quarantined")
+	})
+
+	t.Run("concurrent reservations over a leftover: exactly one wins", func(t *testing.T) {
+		_, _, pro := providerWithOrphanedDir(t, orphanCases[0].makeOrphan)
+
+		const n = 8
+		var wg sync.WaitGroup
+		errs := make([]error, n)
+		wg.Add(n)
+		for i := range n {
+			go func(i int) {
+				defer wg.Done()
+				errs[i] = pro.reserveCreatingDatabase("foo")
+			}(i)
+		}
+		wg.Wait()
+
+		wins := 0
+		for _, err := range errs {
+			if err == nil {
+				wins++
+				continue
+			}
+			require.Truef(t, sql.ErrDatabaseExists.Is(err), "a losing reservation must get ErrDatabaseExists, got %v", err)
+		}
+		require.Equalf(t, 1, wins, "exactly one concurrent reservation may win; got %d", wins)
+	})
 }
 
 func TestCreateDatabaseClearsInProgressMarker(t *testing.T) {

--- a/go/libraries/doltcore/sqle/dropped_databases.go
+++ b/go/libraries/doltcore/sqle/dropped_databases.go
@@ -92,7 +92,31 @@ func (dd *droppedDatabaseManager) DropDatabase(ctx *sql.Context, name string, dr
 	base = dbfactory.DirToDBName(file)
 	destinationDirectory = filepath.Join(dir, base)
 
-	if err := dd.prepareToMoveDroppedDatabase(ctx, destinationDirectory); err != nil {
+	if err := dd.prepareToMoveDroppedDatabase(destinationDirectory); err != nil {
+		return err
+	}
+
+	return dd.fs.MoveDir(dropDbLoc, destinationDirectory)
+}
+
+// quarantineIncompleteDatabase moves an abandoned, never-completed database directory — an interrupted
+// create/clone leftover that discovery ignores (see env.IsIncompleteDatabaseDir): an in-progress marker,
+// Dolt storage without the repo-state file every complete database has, or no Dolt storage at all — from
+// |dropDbLoc| into the
+// dropped-database holding area, so a fresh create/clone of |name| can proceed instead of failing with
+// "database exists". Unlike DropDatabase it needs no *sql.Context because the directory was never a live
+// database; the move is otherwise identical, and the leftover stays recoverable via dolt_undrop (and is
+// purged by DOLT_PURGE_DROPPED_DATABASES). |dropDbLoc| MUST be the absolute path of the <name> directory.
+func (dd *droppedDatabaseManager) quarantineIncompleteDatabase(name string, dropDbLoc string) error {
+	if err := dd.initializeDeletedDatabaseDirectory(); err != nil {
+		return fmt.Errorf("unable to quarantine incomplete database %s: %w", name, err)
+	}
+
+	// Normalize the physical directory name to the logical/SQL database name, matching DropDatabase.
+	_, file := filepath.Split(dropDbLoc)
+	destinationDirectory := filepath.Join(droppedDatabaseDirectoryName, dbfactory.DirToDBName(file))
+
+	if err := dd.prepareToMoveDroppedDatabase(destinationDirectory); err != nil {
 		return err
 	}
 
@@ -257,7 +281,7 @@ func hasCaseInsensitiveMatch(candidates []string, target string) (bool, string) 
 // prepareToMoveDroppedDatabase checks the specified |targetPath| to make sure there is not already a dropped database
 // there, and if so, the existing dropped database will be renamed with a unique suffix. If any problems are encountered,
 // such as not being able to rename an existing dropped database, this function will return an error.
-func (dd *droppedDatabaseManager) prepareToMoveDroppedDatabase(_ *sql.Context, targetPath string) error {
+func (dd *droppedDatabaseManager) prepareToMoveDroppedDatabase(targetPath string) error {
 	if exists, _ := dd.fs.Exists(targetPath); !exists {
 		// If there's nothing at the desired targetPath, we're all set
 		return nil

--- a/integration-tests/bats/clone-drop.bats
+++ b/integration-tests/bats/clone-drop.bats
@@ -44,9 +44,56 @@ teardown() {
   dolt clone file://../pushed cli_cloned
   [ ! -f cli_cloned/.dolt_safe_to_ignore ]
 
+  # A directory left behind by an interrupted clone carries the in-progress marker and squats on the
+  # name. A retried clone must reclaim it -- quarantine the leftover into the dropped-database holding
+  # area and proceed -- rather than wedging on it. See https://github.com/dolthub/dolt/issues/11533
   mkdir stuck
   touch stuck/.dolt_safe_to_ignore
   run dolt sql -q 'call dolt_clone("file://../pushed", "stuck");'
-  [ "$status" -ne 0 ]
-  [[ "$output" =~ "incomplete database directory" ]] || false
+  [ "$status" -eq 0 ]
+
+  # stuck is now a real clone with the in-progress marker cleared...
+  [ ! -f stuck/.dolt_safe_to_ignore ]
+  run dolt sql -q 'use stuck;'
+  [ "$status" -eq 0 ]
+
+  # ...and the reclaimed leftover was quarantined (recoverable via dolt_undrop), not deleted.
+  [ -d .dolt_dropped_databases/stuck ]
+}
+
+# An interrupted create/clone can leave a directory that discovery ignores in three shapes: an
+# in-progress marker, partial .dolt storage without a repo-state file, or a bare directory with no
+# .dolt storage at all. A retried clone must reclaim any of them (quarantine to the dropped-database
+# holding area) and succeed. See https://github.com/dolthub/dolt/issues/11533
+@test "clone-drop: clone reclaims an incomplete leftover directory" {
+  mkdir repo
+  cd repo
+  dolt init
+  dolt remote add pushed 'file://../pushed'
+  dolt push pushed main:main
+
+  make_incomplete_dir() {
+    case "$2" in
+      marker)  mkdir -p "$1" && touch "$1/.dolt_safe_to_ignore" ;;
+      partial) mkdir -p "$1/.dolt/noms" ;;
+      bare)    mkdir -p "$1" ;;
+    esac
+  }
+
+  for shape in marker partial bare; do
+    echo "clone reclaim shape: $shape"
+    name="reclaimed_$shape"
+    make_incomplete_dir "$name" "$shape"
+
+    run dolt sql -q "call dolt_clone('file://../pushed', '$name');"
+    [ "$status" -eq 0 ]
+
+    # the target is now a real clone with any in-progress marker cleared...
+    [ ! -f "$name/.dolt_safe_to_ignore" ]
+    run dolt sql -q "use $name;"
+    [ "$status" -eq 0 ]
+
+    # ...and the reclaimed leftover was quarantined (recoverable via dolt_undrop), not deleted.
+    [ -d ".dolt_dropped_databases/$name" ]
+  done
 }

--- a/integration-tests/bats/sql-create-database.bats
+++ b/integration-tests/bats/sql-create-database.bats
@@ -196,6 +196,41 @@ SQL
     [[ "$output" =~ "database exists" ]] || false
 }
 
+# An interrupted CREATE/CLONE can leave a directory that discovery ignores but that still occupies the
+# name, in three shapes: an in-progress marker, partial .dolt storage without a repo-state file, or a
+# bare directory with no .dolt storage. A later CREATE must reclaim any of them -- quarantine the
+# leftover into the dropped-database holding area and create a fresh database -- instead of failing with
+# "database exists" / "incomplete database directory". A complete database still conflicts (test above).
+# See https://github.com/dolthub/dolt/issues/11533
+@test "sql-create-database: CREATE reclaims an incomplete leftover directory" {
+    make_incomplete_dir() {
+        case "$2" in
+            marker)  mkdir -p "$1" && touch "$1/.dolt_safe_to_ignore" ;;
+            partial) mkdir -p "$1/.dolt/noms" ;;
+            bare)    mkdir -p "$1" ;;
+        esac
+    }
+
+    for shape in marker partial bare; do
+        echo "create reclaim shape: $shape"
+        db="reclaimed_$shape"
+        make_incomplete_dir "$db" "$shape"
+
+        run dolt sql -q "CREATE DATABASE $db;"
+        [ "$status" -eq 0 ]
+
+        # the name is now a real, usable database...
+        run dolt sql -b -q "USE $db; CREATE TABLE t (pk int primary key); INSERT INTO t VALUES (1); SELECT count(*) FROM t;"
+        [ "$status" -eq 0 ]
+        [[ "$output" =~ "1" ]] || false
+
+        # ...and the incomplete leftover was quarantined (recoverable via dolt_undrop), not deleted.
+        [ -d ".dolt_dropped_databases/$db" ]
+        run dolt sql -q "CALL dolt_undrop();"
+        [[ "$output" =~ "$db" ]] || false
+    done
+}
+
 @test "sql-create-database: create database IF NOT EXISTS on database that already exists doesn't throw an error" {
     dolt sql -q "CREATE DATABASE mydb"
     run dolt sql -q "CREATE DATABASE IF NOT EXISTS mydb"


### PR DESCRIPTION
Fixes #11533

## Problem

An interrupted `CREATE DATABASE` or `CALL DOLT_CLONE(...)` can leave a directory on disk that discovery ignores:

- one carrying the in-progress marker (`.dolt_safe_to_ignore`),
- one with `.dolt` storage but no repo-state file, or
- a bare directory created before any `.dolt` storage was written (a clone cancelled very early).

A subsequent `CREATE`/`CLONE` of the same name then fails and cannot recover in-process: the leftover has to be removed out of band, which races a live server. On released dolt the marker / partial-`.dolt` cases fail with `incomplete database directory from an interrupted create already exists; remove the directory and try again`, and the bare no-`.dolt` case fails with `database exists` (Error 1007).

## Fix

At name-reservation time (under `p.mu`), when a directory occupies the name but is **not** a complete, servable database, move it into the `.dolt_dropped_databases` holding area (recoverable via `dolt_undrop`, purged by `dolt_purge_dropped_databases`) and report the name available. A complete database still conflicts. Because the quarantine runs under the provider lock it is atomic with the reservation, so it is safe against a concurrent same-name create/clone (exactly one wins).

`IsIncompleteDatabaseDir` now also reports a directory with **no `.dolt` storage at all** as non-servable, covering an early-cancelled clone interrupted before `.dolt` was written. Transient/ambiguous cases still bias to `ErrDatabaseExists`, so a healthy database is never quarantined.

## Repro

```sql
-- An interrupted create/clone left a directory squatting on the name "foo". Any of:
--   mkdir foo && touch foo/.dolt_safe_to_ignore   -- in-progress marker
--   mkdir -p foo/.dolt/noms                        -- partial .dolt, no repo_state.json
--   mkdir foo                                      -- bare, no .dolt

-- Before this change (released dolt) the retry is wedged, with no in-process recovery:
CREATE DATABASE foo;
--   ERROR: incomplete database directory from an interrupted create already exists; remove the directory and try again
--   (bare shape: can't create database foo; database exists)

-- After this change the retry reclaims the name:
CREATE DATABASE foo;   -- OK: foo is a fresh, usable database
CALL dolt_undrop();    -- lists foo: the reclaimed leftover was quarantined, not deleted
```

`CALL DOLT_CLONE('<remote>', 'foo')` behaves the same: it quarantines the leftover and proceeds to clone from the remote.

## Tests

- **Go unit tests** — `go test -race ./go/libraries/doltcore/sqle/`: new `DoltDatabaseProvider` tests cover all three leftover shapes (in-progress marker / partial `.dolt` without repo-state / no `.dolt`) across `CREATE`, `CLONE`, and the shared reserve gate; assert a complete database still returns `ErrDatabaseExists`; and run 8 concurrent same-name reservations that serialize to exactly one winner.
- **BATS integration tests** — `integration-tests/bats/`: `sql-create-database.bats` and `clone-drop.bats` cover reclaim over all three leftover shapes for `CREATE DATABASE` and `CALL DOLT_CLONE` (name reclaimed, resulting database usable, leftover quarantined and recoverable via `dolt_undrop`). The existing `clone-drop: in-progress marker lifecycle on clone` test — which asserted the removed error — is updated to the new reclaim behavior.
