### PR TITLE
`branch`: fix `-d` when the upstream does not resolve

### DIFF
--- a/go/libraries/doltcore/env/actions/branch.go
+++ b/go/libraries/doltcore/env/actions/branch.go
@@ -33,7 +33,7 @@ var ErrCOBranchDelete = errorKinds.NewKind("Cannot delete checked out branch '%s
 var ErrUnmergedBranch = errorKinds.NewKind("branch '%s' is not fully merged")
 var ErrWorkingSetsOnBothBranches = errors.New("checkout would overwrite uncommitted changes on target branch")
 
-func RenameBranch[C doltdb.Context](ctx C, dbData env.DbData[C], oldBranch, newBranch string, remoteDbPro env.RemoteDbProvider, force bool, rsc *doltdb.ReplicationStatusController) error {
+func RenameBranch[C doltdb.Context](ctx C, dbData env.DbData[C], oldBranch, newBranch string, force bool, rsc *doltdb.ReplicationStatusController) error {
 	oldRef := ref.NewBranchRef(oldBranch)
 	newRef := ref.NewBranchRef(newBranch)
 
@@ -78,7 +78,7 @@ func RenameBranch[C doltdb.Context](ctx C, dbData env.DbData[C], oldBranch, newB
 
 	// todo: update default branch variable
 
-	return DeleteBranch(ctx, dbData, oldBranch, DeleteOptions{Force: true, AllowDeletingCurrentBranch: true}, remoteDbPro, rsc)
+	return DeleteBranch(ctx, dbData, oldBranch, DeleteOptions{Force: true, AllowDeletingCurrentBranch: true}, rsc)
 }
 
 func CopyBranch(ctx context.Context, dEnv *env.DoltEnv, oldBranch, newBranch string, force bool) error {
@@ -143,7 +143,7 @@ type DeleteOptions struct {
 	AllowDeletingCurrentBranch bool
 }
 
-func DeleteBranch[C doltdb.Context](ctx C, dbData env.DbData[C], brName string, opts DeleteOptions, remoteDbPro env.RemoteDbProvider, rsc *doltdb.ReplicationStatusController) error {
+func DeleteBranch[C doltdb.Context](ctx C, dbData env.DbData[C], brName string, opts DeleteOptions, rsc *doltdb.ReplicationStatusController) error {
 	var branchRef ref.DoltRef
 	if opts.Remote {
 		var err error
@@ -162,10 +162,10 @@ func DeleteBranch[C doltdb.Context](ctx C, dbData env.DbData[C], brName string, 
 		}
 	}
 
-	return DeleteBranchOnDB(ctx, dbData, branchRef, opts, remoteDbPro, rsc)
+	return DeleteBranchOnDB(ctx, dbData, branchRef, opts, rsc)
 }
 
-func DeleteBranchOnDB[C doltdb.Context](ctx C, dbdata env.DbData[C], branchRef ref.DoltRef, opts DeleteOptions, pro env.RemoteDbProvider, rsc *doltdb.ReplicationStatusController) error {
+func DeleteBranchOnDB[C doltdb.Context](ctx C, dbdata env.DbData[C], branchRef ref.DoltRef, opts DeleteOptions, rsc *doltdb.ReplicationStatusController) error {
 	ddb := dbdata.Ddb
 	hasRef, err := ddb.HasRef(ctx, branchRef)
 
@@ -176,23 +176,8 @@ func DeleteBranchOnDB[C doltdb.Context](ctx C, dbdata env.DbData[C], branchRef r
 	}
 
 	if !opts.Force && !opts.Remote {
-		// check to see if the branch is fully merged into its parent
-		trackedBranches, err := dbdata.Rsr.GetBranches()
-		if err != nil {
+		if err := validateBranchMerged(ctx, dbdata, branchRef); err != nil {
 			return err
-		}
-
-		trackedBranch, hasUpstream := trackedBranches.Get(branchRef.GetPath())
-		if hasUpstream {
-			err = validateBranchMergedIntoUpstream(ctx, dbdata, branchRef, trackedBranch.Remote, pro)
-			if err != nil {
-				return err
-			}
-		} else {
-			err = validateBranchMergedIntoCurrentWorkingBranch(ctx, dbdata, branchRef)
-			if err != nil {
-				return err
-			}
 		}
 	}
 
@@ -211,116 +196,68 @@ func DeleteBranchOnDB[C doltdb.Context](ctx C, dbdata env.DbData[C], branchRef r
 	return ddb.DeleteBranch(ctx, branchRef, rsc)
 }
 
-// validateBranchMergedIntoCurrentWorkingBranch returns an error if the given branch is not fully merged into the HEAD of the current branch.
-func validateBranchMergedIntoCurrentWorkingBranch[C doltdb.Context](ctx C, dbdata env.DbData[C], branch ref.DoltRef) error {
-	branchSpec, err := doltdb.NewCommitSpec(branch.GetPath())
+// validateBranchMerged checks that |branch|'s commits are contained
+// by its upstream, or by the current working branch when |branch|
+// has no upstream.
+//
+// It returns ErrUnmergedBranch when they are not.
+func validateBranchMerged[C doltdb.Context](ctx C, dbdata env.DbData[C], branch ref.DoltRef) error {
+	mergedInto, err := upstreamOrHead(ctx, dbdata, branch)
 	if err != nil {
 		return err
 	}
 
-	optCmt, err := dbdata.Ddb.Resolve(ctx, branchSpec, nil)
+	branchHead, err := dbdata.Ddb.ResolveCommitRef(ctx, branch)
 	if err != nil {
 		return err
-	}
-	branchHead, ok := optCmt.ToCommit()
-	if !ok {
-		return doltdb.ErrGhostCommitEncountered
 	}
 
-	cwbCs, err := doltdb.NewCommitSpec("HEAD")
+	merged, err := branchHead.CanFastForwardTo(ctx, mergedInto)
 	if err != nil {
+		if errors.Is(err, doltdb.ErrUpToDate) {
+			return nil
+		}
+		if errors.Is(err, doltdb.ErrIsAhead) {
+			return ErrUnmergedBranch.New(branch.GetPath())
+		}
 		return err
+	}
+	if !merged {
+		return ErrUnmergedBranch.New(branch.GetPath())
+	}
+	return nil
+}
+
+// upstreamOrHead returns the commit at |branch|'s upstream, or the
+// commit at the current working branch when that upstream does
+// not resolve locally.
+//
+// A remote upstream is read from its local tracking ref, so the
+// returned commit is only as current as the last fetch. See
+// [git-branch] and [branch_merged].
+//
+// [git-branch]: https://git-scm.com/docs/git-branch#Documentation/git-branch.txt--d
+// [branch_merged]: https://git.kernel.org/pub/scm/git/git.git/tree/builtin/branch.c?id=010afd3166ddc64c9863b1506f12cbcdda0d4ea1#n146
+func upstreamOrHead[C doltdb.Context](ctx C, dbdata env.DbData[C], branch ref.DoltRef) (*doltdb.Commit, error) {
+	upstream, err := env.UpstreamRef(dbdata.Rsr, branch)
+	if err != nil {
+		return nil, err
+	}
+	if upstream != nil {
+		hasUpstream, err := dbdata.Ddb.HasRef(ctx, upstream)
+		if err != nil {
+			return nil, err
+		}
+		if hasUpstream {
+			return dbdata.Ddb.ResolveCommitRef(ctx, upstream)
+		}
 	}
 
 	headRef, err := dbdata.Rsr.CWBHeadRef(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	optCmt, err = dbdata.Ddb.Resolve(ctx, cwbCs, headRef)
-	if err != nil {
-		return err
-	}
-	cwbHead, ok := optCmt.ToCommit()
-	if !ok {
-		return doltdb.ErrGhostCommitEncountered
-	}
-
-	isMerged, err := branchHead.CanFastForwardTo(ctx, cwbHead)
-	if err != nil {
-		if errors.Is(err, doltdb.ErrUpToDate) {
-			return nil
-		}
-		if errors.Is(err, doltdb.ErrIsAhead) {
-			return ErrUnmergedBranch.New(branch.GetPath())
-		}
-
-		return err
-	}
-
-	if !isMerged {
-		return ErrUnmergedBranch.New(branch.GetPath())
-	}
-
-	return nil
-}
-
-// validateBranchMergedIntoUpstream returns an error if the branch provided is not fully merged into its upstream
-func validateBranchMergedIntoUpstream[C doltdb.Context](ctx context.Context, dbdata env.DbData[C], branch ref.DoltRef, remoteName string, pro env.RemoteDbProvider) error {
-	remotes, err := dbdata.Rsr.GetRemotes()
-	if err != nil {
-		return err
-	}
-	remote, ok := remotes.Get(remoteName)
-	if !ok {
-		// TODO: skip error?
-		return fmt.Errorf("remote %s not found", remoteName)
-	}
-
-	remoteDb, err := pro.GetRemoteDB(ctx, dbdata.Ddb.ValueReadWriter().Format(), remote)
-	if err != nil {
-		return err
-	}
-	defer remoteDb.Close()
-
-	cs, err := doltdb.NewCommitSpec(branch.GetPath())
-	if err != nil {
-		return err
-	}
-
-	optCmt, err := remoteDb.Resolve(ctx, cs, nil)
-	if err != nil {
-		return err
-	}
-	remoteBranchHead, ok := optCmt.ToCommit()
-	if !ok {
-		return doltdb.ErrGhostCommitEncountered
-	}
-
-	optCmt, err = dbdata.Ddb.Resolve(ctx, cs, nil)
-	if err != nil {
-		return err
-	}
-	localBranchHead, ok := optCmt.ToCommit()
-	if !ok {
-		return doltdb.ErrGhostCommitEncountered
-	}
-
-	canFF, err := localBranchHead.CanFastForwardTo(ctx, remoteBranchHead)
-	if err != nil {
-		if errors.Is(err, doltdb.ErrUpToDate) {
-			return nil
-		}
-		if errors.Is(err, doltdb.ErrIsAhead) {
-			return ErrUnmergedBranch.New(branch.GetPath())
-		}
-		return err
-	}
-
-	if !canFF {
-		return ErrUnmergedBranch.New(branch.GetPath())
-	}
-
-	return nil
+	return dbdata.Ddb.ResolveCommitRef(ctx, headRef)
 }
 
 func CreateBranchWithStartPt[C doltdb.Context](ctx C, dbData env.DbData[C], newBranch, startPt string, force bool, rsc *doltdb.ReplicationStatusController) error {

--- a/go/libraries/doltcore/env/remotes.go
+++ b/go/libraries/doltcore/env/remotes.go
@@ -795,6 +795,39 @@ func GetDefaultBranch(dEnv *DoltEnv, branches []ref.DoltRef) string {
 	return branches[0].GetPath()
 }
 
+// UpstreamRef returns the local ref that is |branchRef|'s upstream.
+//
+// It returns nil when |branchRef| has no BranchConfig (upstream)
+// recorded, when the remote field is empty or unknown, or when that
+// remote's fetch specs do not map the merge ref.
+//
+// The returned ref is not checked for existence.
+func UpstreamRef[C doltdb.Context](rsr RepoStateReader[C], branchRef ref.DoltRef) (ref.DoltRef, error) {
+	branchConfigs, err := rsr.GetBranches()
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(elianddb): delete a branch's config entry on remote removal,
+	// so there's no ambiguity with an explicit non-remote merge ref.
+	upstream, hasUpstream := branchConfigs.Get(branchRef.GetPath())
+	if !hasUpstream || upstream.Merge.Ref == nil || upstream.Remote == "" {
+		return nil, nil
+	}
+
+	remotes, err := rsr.GetRemotes()
+	if err != nil {
+		return nil, err
+	}
+
+	remote, ok := remotes.Get(upstream.Remote)
+	if !ok {
+		return nil, nil
+	}
+
+	return GetTrackingRef(upstream.Merge.Ref, remote)
+}
+
 // SetRemoteUpstreamForRefSpec set upstream for given RefSpec, remote name and branch ref. It uses given RepoStateWriter
 // to persist upstream tracking branch information.
 func SetRemoteUpstreamForRefSpec(rsw RepoStateWriter, refSpec ref.RefSpec, remote string, branchRef ref.DoltRef) error {

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_branch.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_branch.go
@@ -160,7 +160,7 @@ func renameBranch(ctx *sql.Context, dbData env.DbData[*sql.Context], apr *argpar
 	}
 	activeSessionBranch := headRef.GetPath()
 
-	err = actions.RenameBranch(ctx, dbData, oldBranchName, newBranchName, sess.Provider(), force, rsc)
+	err = actions.RenameBranch(ctx, dbData, oldBranchName, newBranchName, force, rsc)
 	if err != nil {
 		if existsErr := actions.BranchExistsError(err); existsErr != nil {
 			return existsErr
@@ -275,7 +275,7 @@ func deleteBranches(ctx *sql.Context, dbData env.DbData[*sql.Context], apr *argp
 		err = actions.DeleteBranch(ctx, dbData, branchName, actions.DeleteOptions{
 			Force:  force,
 			Remote: remote,
-		}, dSess.Provider(), rsc)
+		}, rsc)
 		if err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_rebase.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_rebase.go
@@ -496,7 +496,7 @@ func abortRebase(ctx *sql.Context) error {
 	err = actions.DeleteBranch(ctx, dbData, headRef.GetPath(), actions.DeleteOptions{
 		Force:                      true,
 		AllowDeletingCurrentBranch: true,
-	}, doltSession.Provider(), &rsc)
+	}, &rsc)
 	if err != nil {
 		return err
 	}
@@ -839,7 +839,7 @@ func continueRebase(ctx *sql.Context) rebaseResult {
 
 	err = actions.DeleteBranch(ctx, dbData, rebaseWorkingBranch, actions.DeleteOptions{
 		Force: true,
-	}, doltSession.Provider(), nil)
+	}, nil)
 	if err != nil {
 		return newRebaseError(err)
 	}

--- a/integration-tests/bats/branch.bats
+++ b/integration-tests/bats/branch.bats
@@ -646,12 +646,14 @@ setup_origin_remote() {
     dolt fetch -p
 
     run dolt branch -a
+    [ "$status" -eq 0 ]
     [[ "$output" =~ "b1" ]] || false
     [[ ! "$output" =~ "remotes/origin/b1" ]] || false
 
     dolt branch -d b1
 
     run dolt branch
+    [ "$status" -eq 0 ]
     [[ ! "$output" =~ "b1" ]] || false
 }
 
@@ -676,6 +678,7 @@ setup_origin_remote() {
     dolt branch -D b1
 
     run dolt branch
+    [ "$status" -eq 0 ]
     [[ ! "$output" =~ "b1" ]] || false
 }
 
@@ -687,12 +690,14 @@ setup_origin_remote() {
     dolt push -u origin b1:other
 
     run dolt branch -a
+    [ "$status" -eq 0 ]
     [[ "$output" =~ "remotes/origin/other" ]] || false
     [[ ! "$output" =~ "remotes/origin/b1" ]] || false
 
     dolt branch -d b1
 
     run dolt branch
+    [ "$status" -eq 0 ]
     [[ ! "$output" =~ "b1" ]] || false
 }
 
@@ -710,6 +715,7 @@ setup_origin_remote() {
     rm -rf "$BATS_TEST_TMPDIR/remote"
 
     run dolt branch -a
+    [ "$status" -eq 0 ]
     [[ "$output" =~ "remotes/origin/b1" ]] || false
 
     dolt branch -d b1
@@ -721,6 +727,7 @@ setup_origin_remote() {
     dolt branch -D b2
 
     run dolt branch
+    [ "$status" -eq 0 ]
     [[ ! "$output" =~ "b1" ]] || false
     [[ ! "$output" =~ "b2" ]] || false
 }
@@ -744,5 +751,6 @@ setup_origin_remote() {
     dolt branch -D b1
 
     run dolt branch
+    [ "$status" -eq 0 ]
     [[ ! "$output" =~ "b1" ]] || false
 }

--- a/integration-tests/bats/branch.bats
+++ b/integration-tests/bats/branch.bats
@@ -10,6 +10,14 @@ teardown() {
     teardown_common
 }
 
+setup_origin_remote() {
+    mkdir "$BATS_TEST_TMPDIR/remote"
+    dolt remote add origin "file://$BATS_TEST_TMPDIR/remote"
+    dolt sql -q "create table t1 (id int primary key);"
+    dolt commit -Am "initial commit"
+    dolt push origin main
+}
+
 @test "branch: branch --datasets lists all datasets" {
     dolt branch other
     dolt commit --allow-empty -m "empty"
@@ -625,4 +633,116 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"[origin/main: ahead 1, behind 2]"* ]] || false
   [[ "$output" =~ "deviated commit" ]] || false
+}
+
+@test "branch: deleting a merged branch whose upstream was deleted on the remote" {
+    # See https://github.com/dolthub/dolt/issues/11450
+    setup_origin_remote
+
+    dolt branch b1
+    dolt push --set-upstream origin b1
+
+    dolt push origin :b1
+    dolt fetch -p
+
+    run dolt branch -a
+    [[ "$output" =~ "b1" ]] || false
+    [[ ! "$output" =~ "remotes/origin/b1" ]] || false
+
+    dolt branch -d b1
+
+    run dolt branch
+    [[ ! "$output" =~ "b1" ]] || false
+}
+
+@test "branch: deleting an unmerged branch whose upstream was deleted on the remote" {
+    # See https://github.com/dolthub/dolt/issues/11450
+    setup_origin_remote
+
+    dolt branch b1
+    dolt push --set-upstream origin b1
+    dolt --branch b1 sql -q "create table t2 (id int primary key);"
+    dolt --branch b1 commit -Am "new table"
+
+    dolt push origin :b1
+    dolt fetch -p
+
+    run dolt branch -d b1
+    [ "$status" -ne 0 ]
+    [[ ! "$output" =~ "branch not found" ]] || false
+    [[ "$output" =~ "branch 'b1' is not fully merged" ]] || false
+    [[ "$output" =~ "run 'dolt branch -D b1'" ]] || false
+
+    dolt branch -D b1
+
+    run dolt branch
+    [[ ! "$output" =~ "b1" ]] || false
+}
+
+@test "branch: deleting a branch whose upstream has a different name than the branch" {
+    # See https://github.com/dolthub/dolt/issues/11450
+    setup_origin_remote
+
+    dolt branch b1
+    dolt push -u origin b1:other
+
+    run dolt branch -a
+    [[ "$output" =~ "remotes/origin/other" ]] || false
+    [[ ! "$output" =~ "remotes/origin/b1" ]] || false
+
+    dolt branch -d b1
+
+    run dolt branch
+    [[ ! "$output" =~ "b1" ]] || false
+}
+
+@test "branch: deleting a branch with an upstream works while the remote is unreachable" {
+    # See https://github.com/dolthub/dolt/issues/11450
+    setup_origin_remote
+
+    dolt branch b1
+    dolt push --set-upstream origin b1
+    dolt branch b2
+    dolt push --set-upstream origin b2
+    dolt --branch b2 sql -q "create table t2 (id int primary key);"
+    dolt --branch b2 commit -Am "new table"
+
+    rm -rf "$BATS_TEST_TMPDIR/remote"
+
+    run dolt branch -a
+    [[ "$output" =~ "remotes/origin/b1" ]] || false
+
+    dolt branch -d b1
+
+    run dolt branch -d b2
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "branch 'b2' is not fully merged" ]] || false
+
+    dolt branch -D b2
+
+    run dolt branch
+    [[ ! "$output" =~ "b1" ]] || false
+    [[ ! "$output" =~ "b2" ]] || false
+}
+
+
+@test "branch: deleting an unmerged branch after its remote was removed" {
+    # See https://github.com/dolthub/dolt/issues/11450
+    setup_origin_remote
+
+    dolt branch b1
+    dolt push --set-upstream origin b1
+    dolt --branch b1 sql -q "create table t2 (id int primary key);"
+    dolt --branch b1 commit -Am "new table"
+
+    dolt remote remove origin
+
+    run dolt branch -d b1
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "branch 'b1' is not fully merged" ]] || false
+
+    dolt branch -D b1
+
+    run dolt branch
+    [[ ! "$output" =~ "b1" ]] || false
 }


### PR DESCRIPTION
Deleting a branch with `dolt branch -d` could fail with `branch not found` when deleted from a remote. Dolt now compares against the local snapshot of the upstream, not the remote repository, and falls back to the current branch when its copy is gone.
- Add `env.UpstreamRef` to resolve a branch's upstream local ref from `BranchConfig`.
- Add `upstreamOrHead` to decide when to use the upstream branch or switch to current working branch.
- Upstream is searched by the configured merge ref in the `BranchConfig` to support different names.
- Merged predicate reads the remote-tracking ref instead of the live remote state.
- `RemoteDbProvider` parameter dropped because it goes unused.
Fix dolthub/dolt#11450