### PR TITLE
`backup`: stop writing the working set on sync

### DIFF
--- a/go/libraries/doltcore/sqle/dprocedures/dolt_backup.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_backup.go
@@ -312,10 +312,6 @@ func doltBackupRestore(ctx *sql.Context, dbData env.DbData[*sql.Context], dsess 
 //
 // If |pruneGrace| is non-zero, prune stale table files in the destination before running the sync.
 func syncRemote(ctx *sql.Context, dbData env.DbData[*sql.Context], dsess *dsess.DoltSession, remote env.Remote, pruneGrace time.Duration) error {
-	// Procedures such as merge and rebase move a branch head outside the caller's
-	// transaction, so they commit to get a new one that sees the move. A sync only
-	// reads and has no such need. Committing would make the caller's pending work
-	// durable, and a later rollback could not take it back.
 	params := make(map[string]any, len(remote.Params))
 	for k, v := range remote.Params {
 		params[k] = v

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_backup.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_backup.go
@@ -312,13 +312,8 @@ func doltBackupRestore(ctx *sql.Context, dbData env.DbData[*sql.Context], dsess 
 //
 // If |pruneGrace| is non-zero, prune stale table files in the destination before running the sync.
 func syncRemote(ctx *sql.Context, dbData env.DbData[*sql.Context], dsess *dsess.DoltSession, remote env.Remote, pruneGrace time.Duration) error {
-	// Commit the current session's working set to the persistent chunk store. This ensures that uncommitted transaction
-	// changes (e.g. INSERTs) are usually visible to the backup procedure, which reads directly from the roots.
-	err := dsess.CommitWorkingSet(ctx, ctx.GetCurrentDatabase(), ctx.GetTransaction())
-	if err != nil {
-		return err
-	}
-
+	// Writing the caller's open transaction here would publish work that a
+	// later rollback could not take back.
 	params := make(map[string]any, len(remote.Params))
 	for k, v := range remote.Params {
 		params[k] = v

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_backup.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_backup.go
@@ -312,8 +312,10 @@ func doltBackupRestore(ctx *sql.Context, dbData env.DbData[*sql.Context], dsess 
 //
 // If |pruneGrace| is non-zero, prune stale table files in the destination before running the sync.
 func syncRemote(ctx *sql.Context, dbData env.DbData[*sql.Context], dsess *dsess.DoltSession, remote env.Remote, pruneGrace time.Duration) error {
-	// Writing the caller's open transaction here would publish work that a
-	// later rollback could not take back.
+	// Procedures such as merge and rebase move a branch head outside the caller's
+	// transaction, so they commit to get a new one that sees the move. A sync only
+	// reads and has no such need. Committing would make the caller's pending work
+	// durable, and a later rollback could not take it back.
 	params := make(map[string]any, len(remote.Params))
 	for k, v := range remote.Params {
 		params[k] = v

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_procedures.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_procedures.go
@@ -387,6 +387,7 @@ var DoltBackupProcedureScripts = []queries.ScriptTest{
 		Name: "dolt_backup transactional operations",
 		SetUpScript: []string{
 			"create table t(a int primary key);",
+			"insert into t values (2);",
 			`CREATE PROCEDURE transaction_backup_ops()
 BEGIN
 	START TRANSACTION;
@@ -410,8 +411,9 @@ END`,
 			},
 			{
 				Query: "select * from restored_txn_db.t;",
-				// The insert was never committed, so the backup does not hold it.
-				Expected: []sql.Row{},
+				// [actions.SyncRoots] copies the roots the database holds. A row written
+				// by an open transaction is not yet part of those roots.
+				Expected: []sql.Row{{2}},
 			},
 			{
 				Query:    fmt.Sprintf("call dolt_backup('restore', '%s', 'restored_txn_url_db');", fileUrl("txn_backup_url")),
@@ -419,7 +421,13 @@ END`,
 			},
 			{
 				Query:    "select * from restored_txn_url_db.t;",
-				Expected: []sql.Row{},
+				Expected: []sql.Row{{2}},
+			},
+			{
+				Query: "select * from t;",
+				// The restore creates a database, which commits the caller's transaction.
+				// Its row is part of the roots from that point on.
+				Expected: []sql.Row{{1}, {2}},
 			},
 			{
 				Query:    "select count(*) from dolt_backups where name='txn_bak';",

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries_procedures.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries_procedures.go
@@ -409,8 +409,9 @@ END`,
 				Expected: []sql.Row{{gmstypes.OkResult{}}},
 			},
 			{
-				Query:    "select * from restored_txn_db.t;",
-				Expected: []sql.Row{{1}},
+				Query: "select * from restored_txn_db.t;",
+				// The insert was never committed, so the backup does not hold it.
+				Expected: []sql.Row{},
 			},
 			{
 				Query:    fmt.Sprintf("call dolt_backup('restore', '%s', 'restored_txn_url_db');", fileUrl("txn_backup_url")),
@@ -418,7 +419,7 @@ END`,
 			},
 			{
 				Query:    "select * from restored_txn_url_db.t;",
-				Expected: []sql.Row{{1}},
+				Expected: []sql.Row{},
 			},
 			{
 				Query:    "select count(*) from dolt_backups where name='txn_bak';",

--- a/integration-tests/bats/sql-backup.bats
+++ b/integration-tests/bats/sql-backup.bats
@@ -23,6 +23,16 @@ lower_prune_grace_floor() {
     fi
 }
 
+setup_backup() {
+    backup_dir="$BATS_TEST_TMPDIR/backup"
+    dolt backup add b1 "file://$backup_dir"
+    dolt sql <<SQL
+create table t (pk int primary key);
+insert into t values (1);
+call dolt_commit('-Am', 'init');
+SQL
+}
+
 @test "sql-backup: dolt_backup no argument" {
     run dolt sql -q "call dolt_backup()"
     [ "$status" -ne 0 ]
@@ -407,4 +417,49 @@ SQL
     run dolt sql -q "call dolt_backup('remove', 'hostedapidb-0', '--prune-with-grace-period', '1h')"
     [ "$status" -ne 0 ]
     [[ "$output" =~ "only supported with" ]] || false
+}
+
+@test "sql-backup: dolt_backup sync is a no-op when nothing has changed" {
+    # See https://github.com/dolthub/dolt/issues/11488
+    setup_backup
+    dolt sql -q "call dolt_backup('sync', 'b1');"
+
+    manifest_before=$(cat "$backup_dir/manifest")
+    files_before=$(ls "$backup_dir" | sort)
+
+    # WorkingSetMeta stamps writes with time.Now().Unix(), in seconds.
+    sleep 2
+
+    dolt sql -q "call dolt_backup('sync', 'b1');"
+
+    manifest_after=$(cat "$backup_dir/manifest")
+    files_after=$(ls "$backup_dir" | sort)
+
+    [ "$manifest_before" = "$manifest_after" ] || false
+    [ "$files_before" = "$files_after" ] || false
+}
+
+@test "sql-backup: dolt_backup sync does not commit the session's open transaction" {
+    # See https://github.com/dolthub/dolt/issues/11488
+    setup_backup
+    dolt sql -q "insert into t values (42);"
+
+    dolt sql <<SQL
+set autocommit = 0;
+start transaction;
+insert into t values (99);
+call dolt_backup('sync', 'b1');
+rollback;
+SQL
+
+    run dolt sql -r csv -q "select pk from t"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "42" ]] || false
+    [[ ! "$output" =~ "99" ]] || false
+
+    dolt backup restore "file://$backup_dir" the_restore
+    run dolt sql -r csv -q "use the_restore; select pk from t"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "42" ]] || false
+    [[ ! "$output" =~ "99" ]] || false
 }


### PR DESCRIPTION
`dolt_backup` no longer commits the calling session's open transaction before it copies.
- Syncing an idle database leaves the backup unchanged.
- `ROLLBACK` after sync now works correctly.
Fix dolthub/dolt#11488