### PR TITLE
build(deps): bump undici to 6.28.0

### DIFF
--- a/.github/actions/ses-email-action/package-lock.json
+++ b/.github/actions/ses-email-action/package-lock.json
@@ -1321,9 +1321,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.24.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.0.tgz",
-      "integrity": "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"


### PR DESCRIPTION
## Summary

- bump the transitive `undici` dependency from 6.24.0 to 6.28.0 in the SES email action lockfile
- resolve Dependabot alerts #137, #138, #139, #140, #171, #172, and #173

## Validation

- `npm ci --ignore-scripts`
- `npm run build`
- `npm audit --omit=dev` (the undici advisories are resolved; the remaining fast-xml-builder finding is covered by #11022)

[no-release-notes]