### PR TITLE
build(deps): upgrade Hibernate to 6.6.55

### DIFF
--- a/integration-tests/orm-tests/hibernate/DoltHibernateSmokeTest/pom.xml
+++ b/integration-tests/orm-tests/hibernate/DoltHibernateSmokeTest/pom.xml
@@ -10,20 +10,15 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
   <dependencies>
     <!-- Hibernate -->
-    <!-- [5.6.14,) fails as it gets the latest version but including beta builds that does not work -->
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
-      <version>5.6.14.Final</version>
-    </dependency>
-    <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-entitymanager</artifactId>
-      <version>5.6.14.Final</version>
+      <version>6.6.55.Final</version>
     </dependency>
 
     <!-- MySQL -->
@@ -42,8 +37,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.10.1</version>
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
+            <release>${maven.compiler.release}</release>
           </configuration>
         </plugin>
         <plugin>

--- a/integration-tests/orm-tests/hibernate/DoltHibernateSmokeTest/src/main/java/com/dolt/hibernate/model/Student.java
+++ b/integration-tests/orm-tests/hibernate/DoltHibernateSmokeTest/src/main/java/com/dolt/hibernate/model/Student.java
@@ -2,12 +2,12 @@ package com.dolt.hibernate.model;
 
 import java.io.Serializable;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "STUDENT")


### PR DESCRIPTION
## Summary

- replace the vulnerable Hibernate 5.6 dependency with Hibernate ORM 6.6.55.Final
- migrate the smoke-test entity annotations from `javax.persistence` to `jakarta.persistence`
- remove the obsolete `hibernate-entitymanager` dependency and target Java 11, as required by Hibernate 6
- resolve Dependabot alert #122 / CVE-2026-0603

## Validation

- `mvn -B -ntp clean compile`
- `mvn -B -ntp dependency:tree -Dincludes=org.hibernate:hibernate-core,org.hibernate.orm:hibernate-core`

[no-release-notes]