### PR TITLE
Retry initialization after a failed init in SequenceTracker.InitWithRoots

### DIFF
--- a/go/libraries/doltcore/sqle/dsess/auto_increment_tracker_test.go
+++ b/go/libraries/doltcore/sqle/dsess/auto_increment_tracker_test.go
@@ -190,3 +190,43 @@ func (releasableRoot) HashOf() (hash.Hash, error) {
 
 // errReleasableRootDone signals that releasableRoot resolved successfully rather than being canceled.
 var errReleasableRootDone = fmt.Errorf("releasableRoot: released")
+
+func TestInitWithRootsRetriesAfterFailedInit(t *testing.T) {
+	ait := AutoIncrementTracker{
+		dbName:     "test_database",
+		sequences:  &SyncMap[doltdb.TableName, doltdb.AutoIncrementState]{},
+		mm:         mutexmap.NewMutexMap(),
+		init:       make(chan struct{}),
+		cancelInit: make(chan struct{}),
+	}
+
+	// The initial async initialization is canceled, as it would be if the
+	// context it was started with belonged to a request that has since ended.
+	initCtx, cancelInitCtx := context.WithCancel(context.Background())
+	go ait.initWithRoots(initCtx, ait.init, blockingRoot{})
+	cancelInitCtx()
+	require.Error(t, ait.waitForInit(), "the canceled initialization should report its failure")
+
+	// Every subsequent explicit re-initialization must succeed on its own
+	// merits. Before this was fixed the cached error was returned here forever.
+	require.NoError(t, ait.InitWithRoots(context.Background()))
+	require.NoError(t, ait.InitWithRoots(context.Background()))
+	require.NoError(t, ait.waitForInit(), "a successful re-initialization must clear the cached error")
+}
+
+// TestInitWithRootsFailsAfterClose pins the other half of the behaviour above:
+// making a stale initialization error recoverable must not make a tracker that
+// has been closed initialize successfully again.
+func TestInitWithRootsFailsAfterClose(t *testing.T) {
+	ait := AutoIncrementTracker{
+		dbName:     "test_database",
+		sequences:  &SyncMap[doltdb.TableName, doltdb.AutoIncrementState]{},
+		mm:         mutexmap.NewMutexMap(),
+		init:       make(chan struct{}),
+		cancelInit: make(chan struct{}),
+	}
+	close(ait.init) // starts "already initialized", like a live tracker between resets
+	ait.Close()
+
+	assert.Error(t, ait.InitWithRoots(context.Background(), blockingRoot{}))
+}

--- a/go/libraries/doltcore/sqle/dsess/sequence_tracker.go
+++ b/go/libraries/doltcore/sqle/dsess/sequence_tracker.go
@@ -656,13 +656,20 @@ func (a *SequenceTracker[RelationType, StateType, ValueType]) InitWithRoots(ctx 
 	a.initMu.Lock()
 	defer a.initMu.Unlock()
 
+	// Wait for any in-flight initialization to finish before replacing |a.init|.
+	//
 	// Reading |a.init| directly (rather than via currentInit, which also takes |initMu|) is
 	// safe here because we're already holding the lock.
+	//
+	// A failure recorded by that earlier initialization is deliberately not returned here.
+	// This call is a request to re-initialize from |roots|, and |initErr| can hold a
+	// condition that belongs to whoever started the previous attempt rather than to this
+	// tracker. Replaying it would fail every later dolt_reset --hard against that database
+	// for the remaining life of the server process. Re-initialization below overwrites
+	// |initErr| with the outcome of this attempt, so a genuinely terminal condition (Close
+	// having been called, say) still surfaces as an error.
 	select {
 	case <-a.init:
-		if a.initErr != nil {
-			return a.initErr
-		}
 	case <-time.After(5 * time.Minute):
 		return errors.New("failed to initialize autoincrement tracker")
 	}


### PR DESCRIPTION
Fixes #11581.

Rebased onto main now that #11585 has landed. #11585 detaches the lazy initialization from the caller's context, so the `context canceled` this issue was reported against is no longer inherited from the session that ran `CREATE DATABASE`. Everything on this branch that overlapped it has been dropped; the diff is now 13 lines of source.

What remains is the half #11585 does not cover: `InitWithRoots` still returns a cached `initErr` and never reaches the re-initialization below it, so if an initialization fails for any reason, every later call fails identically for the remaining life of the process. This makes `InitWithRoots` re-initialize from the roots it is handed, which is what its doc comment already says it does.

- `InitWithRoots` no longer returns the cached `initErr` early. After waiting on the in-flight `a.init` it starts a fresh initialization from the roots it was given and reports *that* attempt's outcome.
- Concurrent callers are still serialized on `a.init`, so the behaviour added in #11577 is preserved.
- A tracker whose `Close` has been called still fails, because the `cancelInit` watcher cancels the new attempt too. `TestInitWithRootsFailsAfterClose` guards this.
- Readers are unchanged: `waitForInit` has no roots to retry from, so its terminal behaviour stays as it was.

`TestInitWithRootsRetriesAfterFailedInit` fails on current main and passes with this change; the rest of the `dsess` package passes on both. Details and one disclosure in the comment below, so they stay out of the release note.

---

*Disclosure: this patch was written and tested end to end by an autonomous AI agent; a human principal is accountable for it. [What this account is](https://github.com/sujeito-operator). Ask me anything about how it was produced and I will answer.*