### PR TITLE
Fix auto-increment tracker init race

### DIFF
--- a/go/libraries/doltcore/sqle/dsess/auto_increment_tracker_test.go
+++ b/go/libraries/doltcore/sqle/dsess/auto_increment_tracker_test.go
@@ -159,27 +159,21 @@ func TestNewSequenceTrackerFromRootsSurvivesCallerContextCancellation(t *testing
 	ait, err := NewAutoIncrementTracker(callerCtx, "test_database", root)
 	require.NoError(t, err)
 
-	// Simulate the request returning and its context being canceled while our root is still
-	// resolving.
+	// Cancel the caller's context while the root is still resolving.
 	cancel()
 
-	// Now let resolution finish. If initWithRoots is (incorrectly) using the caller's context,
-	// this close is redundant: it would have already observed <-ctx.Done() above and bailed out
-	// with a canceled error.
+	// Let resolution finish
 	close(root.release)
 
-	// releasableRoot returns a distinguishable sentinel (rather than a real RootValue) once
-	// released, so we can assert initialization ran to completion on an uncanceled context
-	// instead of short-circuiting on the caller's cancellation.
 	require.ErrorIs(t, ait.waitForInit(), errReleasableRootDone)
 }
 
-// releasableRoot blocks ResolveRootValue until |release| is closed, independent of the context
-// passed in. This lets tests control exactly when resolution completes relative to context
-// cancellation.
+// releasableRoot blocks ResolveRootValue until |release| is closed, regardless of ctx.
 type releasableRoot struct {
 	release chan struct{}
 }
+
+var _ doltdb.Rootish = releasableRoot{}
 
 func (r releasableRoot) ResolveRootValue(ctx context.Context) (doltdb.RootValue, error) {
 	select {
@@ -194,6 +188,5 @@ func (releasableRoot) HashOf() (hash.Hash, error) {
 	return hash.Hash{}, nil
 }
 
-// errReleasableRootDone is returned by releasableRoot once released, so tests can distinguish
-// "resolution completed" from "resolution was canceled" without needing a real RootValue.
+// errReleasableRootDone signals that releasableRoot resolved successfully rather than being canceled.
 var errReleasableRootDone = fmt.Errorf("releasableRoot: released")

--- a/go/libraries/doltcore/sqle/dsess/auto_increment_tracker_test.go
+++ b/go/libraries/doltcore/sqle/dsess/auto_increment_tracker_test.go
@@ -149,3 +149,51 @@ func (blockingRoot) ResolveRootValue(ctx context.Context) (doltdb.RootValue, err
 func (blockingRoot) HashOf() (hash.Hash, error) {
 	return hash.Hash{}, nil
 }
+
+// TestNewSequenceTrackerFromRootsSurvivesCallerContextCancellation reproduces a race condition
+// with initialization of sequence trackers.
+func TestNewSequenceTrackerFromRootsSurvivesCallerContextCancellation(t *testing.T) {
+	callerCtx, cancel := context.WithCancel(context.Background())
+	root := releasableRoot{release: make(chan struct{})}
+
+	ait, err := NewAutoIncrementTracker(callerCtx, "test_database", root)
+	require.NoError(t, err)
+
+	// Simulate the request returning and its context being canceled while our root is still
+	// resolving.
+	cancel()
+
+	// Now let resolution finish. If initWithRoots is (incorrectly) using the caller's context,
+	// this close is redundant: it would have already observed <-ctx.Done() above and bailed out
+	// with a canceled error.
+	close(root.release)
+
+	// releasableRoot returns a distinguishable sentinel (rather than a real RootValue) once
+	// released, so we can assert initialization ran to completion on an uncanceled context
+	// instead of short-circuiting on the caller's cancellation.
+	require.ErrorIs(t, ait.waitForInit(), errReleasableRootDone)
+}
+
+// releasableRoot blocks ResolveRootValue until |release| is closed, independent of the context
+// passed in. This lets tests control exactly when resolution completes relative to context
+// cancellation.
+type releasableRoot struct {
+	release chan struct{}
+}
+
+func (r releasableRoot) ResolveRootValue(ctx context.Context) (doltdb.RootValue, error) {
+	select {
+	case <-r.release:
+		return nil, errReleasableRootDone
+	case <-ctx.Done():
+		return nil, context.Cause(ctx)
+	}
+}
+
+func (releasableRoot) HashOf() (hash.Hash, error) {
+	return hash.Hash{}, nil
+}
+
+// errReleasableRootDone is returned by releasableRoot once released, so tests can distinguish
+// "resolution completed" from "resolution was canceled" without needing a real RootValue.
+var errReleasableRootDone = fmt.Errorf("releasableRoot: released")

--- a/go/libraries/doltcore/sqle/dsess/sequence_tracker.go
+++ b/go/libraries/doltcore/sqle/dsess/sequence_tracker.go
@@ -109,13 +109,17 @@ func NewSequenceTrackerFromRoots[
 	if gcSafepointController != nil {
 		ctx = gcctx.WithGCSafepointController(ctx, gcSafepointController)
 	}
+	// initWithRoots runs in a background goroutine that can outlive the request that
+	// triggered it (e.g. the CREATE DATABASE statement that creates this tracker). Detach
+	// it from the caller's cancellation so a query returning doesn't cancel initialization.
+	initCtx := context.WithoutCancel(ctx)
 	go func() {
 		if gcSafepointController != nil {
-			defer gcctx.SessionEnd(ctx)
-			gcctx.SessionCommandBegin(ctx)
-			defer gcctx.SessionCommandEnd(ctx)
+			defer gcctx.SessionEnd(initCtx)
+			gcctx.SessionCommandBegin(initCtx)
+			defer gcctx.SessionCommandEnd(initCtx)
 		}
-		ait.initWithRoots(ctx, ait.init, roots...)
+		ait.initWithRoots(initCtx, ait.init, roots...)
 	}()
 	return &ait, nil
 }


### PR DESCRIPTION
`NewSequenceTrackerFromRoots` initializes sequence state in a background goroutine but ran it on the caller's request-scoped context, so it could be canceled as soon as the triggering query (e.g. `CREATE DATABASE`) returned, poisoning the tracker for later callers. Detach that goroutine's context from the caller's cancellation, and add a deterministic regression test.