### PR TITLE
Distinguish updating a branch from creating one in push output

### DIFF
--- a/go/libraries/doltcore/env/actions/remotes.go
+++ b/go/libraries/doltcore/env/actions/remotes.go
@@ -110,14 +110,31 @@ func Push(ctx context.Context, tempTableDir string, mode ref.UpdateMode, destRef
 func DoPush[C doltdb.Context](ctx C, pushMeta *env.PushOptions[C], statsCh chan pull.Stats) (returnMsg string, err error) {
 	var successPush, setUpstreamPush, failedPush []string
 	for _, targets := range pushMeta.Targets {
+		// Whether the destination branch already exists has to be sampled before the push, because the
+		// push itself creates the ref. It is used only to choose between the "[new branch]" and
+		// "[updated]" status lines below.
+		//
+		// A failure here is deliberately swallowed rather than returned: it affects the wording of a
+		// status message only, and a push that would otherwise succeed must not be failed because we
+		// could not describe it. On error we fall back to the previous behaviour.
+		destExisted := false
+		if targets.SrcRef != ref.EmptyBranchRef {
+			if exists, hasRefErr := pushMeta.DestDb.HasRef(ctx, targets.DestRef); hasRefErr == nil {
+				destExisted = exists
+			}
+		}
+
 		err = push(ctx, pushMeta.Rsr, pushMeta.TmpDir, pushMeta.SrcDb, pushMeta.DestDb, pushMeta.Remote, targets, statsCh)
 		if err == nil {
-			// TODO: we don't have sufficient information here to know what actually happened in the push. Supporting
-			// git behavior of printing the commit ids updated (e.g. 74476cf38..080b073e7  branch1 -> branch1) isn't
-			// currently possible. We need to plumb through results in the return from the Push(). Having just an error
-			// response is not sufficient, as there are many "success" cases that are not errors.
+			// TODO: we still don't have sufficient information here to print the commit ids updated the
+			// way git does (e.g. 74476cf38..080b073e7  branch1 -> branch1). That needs results plumbed
+			// through the return from Push(); an error response alone is not sufficient, as there are
+			// many "success" cases that are not errors. Branch creation vs update is distinguished above,
+			// so the status line is no longer actively misleading, but it remains coarser than git's.
 			if targets.SrcRef == ref.EmptyBranchRef {
 				successPush = append(successPush, fmt.Sprintf(" - [deleted]             %s", targets.DestRef.GetPath()))
+			} else if destExisted {
+				successPush = append(successPush, fmt.Sprintf(" * [updated]             %s -> %s", targets.SrcRef.GetPath(), targets.DestRef.GetPath()))
 			} else {
 				successPush = append(successPush, fmt.Sprintf(" * [new branch]          %s -> %s", targets.SrcRef.GetPath(), targets.DestRef.GetPath()))
 			}

--- a/integration-tests/bats/remotes-push-pull.bats
+++ b/integration-tests/bats/remotes-push-pull.bats
@@ -637,7 +637,8 @@ SQL
     dolt commit -am "add 3s"
     run dolt push --all -u origin   # should set upstream for all branches
     [ "$status" -eq 0 ]
-    [[ "$output" =~ " * [new branch]          branch1 -> branch1" ]] || false
+    # branch1 was already pushed above, so this push updates it rather than creating it
+    [[ "$output" =~ " * [updated]             branch1 -> branch1" ]] || false
     [[ "$output" =~ "branch 'branch1' set up to track 'origin/branch1'." ]] || false
     [[ "$output" =~ "branch 'branch2' set up to track 'origin/branch2'." ]] || false
 }
@@ -737,6 +738,36 @@ SQL
     [[ "$output" =~ " ! [rejected]            branch1 -> branch1 (non-fast-forward)" ]] || false
     [[ "$output" =~ "branch 'branch2' set up to track 'origin/branch2'." ]] || false
     [[ "$output" =~ "Updates were rejected because the tip of your current branch is behind" ]] || false
+}
+
+@test "remotes-push-pull: push reports [new branch] on creation and [updated] on later pushes" {
+    mkdir remote
+    mkdir repo1
+
+    cd repo1
+    dolt init
+    dolt remote add origin file://../remote
+
+    # first push of a branch the remote does not have yet
+    run dolt push origin main
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ " * [new branch]          main -> main" ]] || false
+
+    # the remote now has main, so a later push is an update, not a creation
+    dolt sql -q "CREATE TABLE test (pk INT PRIMARY KEY)"
+    dolt add .
+    dolt commit -am "create table"
+    run dolt push origin main
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ " * [updated]             main -> main" ]] || false
+    [[ ! "$output" =~ "[new branch]" ]] || false
+
+    # and stays an update on subsequent pushes
+    dolt sql -q "INSERT INTO test VALUES (1)"
+    dolt commit -am "add a row"
+    run dolt push origin main
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ " * [updated]             main -> main" ]] || false
 }
 
 @test "remotes-push-pull: pushing empty branch does not panic" {


### PR DESCRIPTION
Fixes #11352.

`dolt push` printed ` * [new branch]          main -> main` for every successful push of an existing branch, so routine updates were reported as branch creations. `[new branch]` is the message git reserves for creation, and seeing it for a long-lived branch reads as "did I just push to the wrong remote?" — the true outcome was only knowable by separately diffing local and remote heads.

## The change

The success message in `DoPush` was hardcoded: any successful non-delete push appended the `[new branch]` line. This samples whether the destination ref exists **before** the push — the push itself creates it — and prints `[updated]` when it did.

```
push 1  →  * [new branch]          main -> main     (branch is new)
push 2  →  * [updated]             main -> main
push 3  →  * [updated]             main -> main
```

Three things worth calling out for review:

1. **A failed existence check is swallowed, not returned.** It affects only the wording of a status line, and a push that would otherwise succeed must not fail because we could not describe it. On error the previous wording is used.
2. **This is the minimal fix (tier 1 in the issue).** Printing git-style commit ranges (`74476cf38..080b073e7`) still needs results plumbed out of `Push()`. I updated the existing TODO rather than removing it, so the remaining gap stays documented.
3. **`HasRef` is a single `GetDataset`**, which is negligible next to what `push()` already does against the destination (`ResolveBranchRoots`, `FastForwardWithWorkspaceCheck`, `SetHeadAndWorkingSetToCommit`).

## Tests

One existing bats assertion encoded the old behaviour. In `remotes-push-pull.bats`, "push --all with remote specified" pushes `branch1` twice and the second push asserted `[new branch]`; it now asserts `[updated]`. Every other `[new branch]` assertion in the suite is a genuine first push and is unchanged — including `sql-server-remotesrv.bats`, where `main:new_branch` really is a creation.

Added a regression test covering creation → update → update, and asserting `[new branch]` does *not* appear on the second push.

## What I verified, and what I did not

Verified against a binary built from this branch: creation prints `[new branch]`, subsequent pushes print `[updated]`, and the branch-deletion (`[deleted]`) and up-to-date paths are unchanged. I also replayed the modified test's exact scenario end to end and confirmed `* [updated]  branch1 -> branch1`.

`go test ./libraries/doltcore/env/...` passes; `gofmt` and `go vet` are clean.

**I was not able to run the bats suite locally** — `bats` isn't installed on this machine. The bats changes are reasoned from the surrounding test bodies and confirmed by reproducing the scenarios by hand against the real binary, but they have not been executed. Worth a careful look in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
