### PR TITLE
Fix macOS-only bats CI failures

### DIFF
--- a/integration-tests/bats/diff-system.expect
+++ b/integration-tests/bats/diff-system.expect
@@ -2,6 +2,9 @@
 
 set timeout 5
 set env(NO_COLOR) 1
+# less reads keypresses from /dev/tty directly, racing with characters this script types
+# ahead into the pty for the next command and dropping them.
+set env(DOLT_PAGER) "cat"
 
 source  "$env(BATS_CWD)/helper/common_expect_functions.tcl"
 

--- a/integration-tests/bats/docker-entrypoint.bats
+++ b/integration-tests/bats/docker-entrypoint.bats
@@ -8,7 +8,10 @@ load $BATS_TEST_DIRNAME/helper/common.bash
 setup() {
   setup_no_dolt_init
 
-  command -v docker >/dev/null 2>&1 || skip "docker not found on PATH"
+  # Docker isn't available on GitHub's macOS runners
+  if [ "$IS_MAC" = true ]; then
+    command -v docker >/dev/null 2>&1 || skip "docker not found on PATH (expected on macOS runners)"
+  fi
 
   # Compute workspace root from integration-tests/bats directory
   WORKSPACE_ROOT=$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)

--- a/integration-tests/bats/docker-entrypoint.bats
+++ b/integration-tests/bats/docker-entrypoint.bats
@@ -8,6 +8,8 @@ load $BATS_TEST_DIRNAME/helper/common.bash
 setup() {
   setup_no_dolt_init
 
+  command -v docker >/dev/null 2>&1 || skip "docker not found on PATH"
+
   # Compute workspace root from integration-tests/bats directory
   WORKSPACE_ROOT=$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)
   export WORKSPACE_ROOT

--- a/integration-tests/bats/helper/common.bash
+++ b/integration-tests/bats/helper/common.bash
@@ -21,13 +21,6 @@ export DOLT_ENABLE_DYNAMIC_ASSERTS=true
 # racing with a test's teardown removing that same directory. Disable it for bats runs.
 export DOLT_DISABLE_EVENT_FLUSH=true
 
-# The default pager (less) reads keypresses from /dev/tty directly, bypassing dolt's own
-# stdin handling, so it can race with and swallow characters an expect script already typed
-# ahead into the pty (see log.bats: "log: --decorate=auto shows decoration on a tty" for the
-# same workaround on a single test). Default to `cat` for all bats runs; tests that exercise
-# real pager behavior (pager.bats) already override this per-test.
-export DOLT_PAGER=cat
-
 nativebatsdir() { echo `nativepath $BATS_TEST_DIRNAME/$1`; }
 batshelper() { echo `nativebatsdir helper/$1`; }
 

--- a/integration-tests/bats/helper/common.bash
+++ b/integration-tests/bats/helper/common.bash
@@ -9,6 +9,13 @@ fi
 export DOLT_CONTEXT_VALIDATION_ENABLED=true
 export DOLT_ENABLE_DYNAMIC_ASSERTS=true
 
+# Every dolt command that isn't init/config/send-metrics spawns a detached, untracked
+# `dolt send-metrics` child process on exit to flush usage events (see flushEventsDir in
+# cmd/dolt/dolt.go). That process can still be reading/writing/locking files under the
+# global config dir after the parent dolt command (or a killed sql-server) has exited,
+# racing with a test's teardown removing that same directory. Disable it for bats runs.
+export DOLT_DISABLE_EVENT_FLUSH=true
+
 nativebatsdir() { echo `nativepath $BATS_TEST_DIRNAME/$1`; }
 batshelper() { echo `nativebatsdir helper/$1`; }
 

--- a/integration-tests/bats/helper/common.bash
+++ b/integration-tests/bats/helper/common.bash
@@ -16,6 +16,13 @@ export DOLT_ENABLE_DYNAMIC_ASSERTS=true
 # racing with a test's teardown removing that same directory. Disable it for bats runs.
 export DOLT_DISABLE_EVENT_FLUSH=true
 
+# The default pager (less) reads keypresses from /dev/tty directly, bypassing dolt's own
+# stdin handling, so it can race with and swallow characters an expect script already typed
+# ahead into the pty (see log.bats: "log: --decorate=auto shows decoration on a tty" for the
+# same workaround on a single test). Default to `cat` for all bats runs; tests that exercise
+# real pager behavior (pager.bats) already override this per-test.
+export DOLT_PAGER=cat
+
 nativebatsdir() { echo `nativepath $BATS_TEST_DIRNAME/$1`; }
 batshelper() { echo `nativebatsdir helper/$1`; }
 

--- a/integration-tests/bats/helper/common.bash
+++ b/integration-tests/bats/helper/common.bash
@@ -1,6 +1,11 @@
 source "${BASH_SOURCE[0]%/*}/windows-compat.bash"
 source "${BASH_SOURCE[0]%/*}/local-remote.bash"
 
+if [ -z "${IS_MAC+x}" ]; then
+    IS_MAC=false
+    [ "$(uname)" = "Darwin" ] && IS_MAC=true
+fi
+
 if [ -z "$BATS_TMPDIR" ]; then
     export BATS_TMPDIR=$HOME/batstmp/
     mkdir $BATS_TMPDIR

--- a/integration-tests/bats/helper/sql-diff.bash
+++ b/integration-tests/bats/helper/sql-diff.bash
@@ -7,13 +7,12 @@ _dbg_block() { [ -n "$SQL_DIFF_DEBUG" ] && { printf '%s\n' "$1" >&2; printf '%s\
 # first table header row from CLI diff (data section), as newline list
 _cli_header_cols() {
     awk '
-        /^\s*\|\s*[-+<>]\s*\|/ && last_header != "" { print last_header; exit }
-        /^\s*\|/ { last_header = $0 }
+        /^[[:space:]]*\|[[:space:]]*[-+<>][[:space:]]*\|/ && last_header != "" { print last_header; exit }
+        /^[[:space:]]*\|/ { last_header = $0 }
     ' <<<"$1" \
       | tr '|' '\n' \
       | sed -e 's/^[[:space:]]*//;s/[[:space:]]*$//' \
-      | grep -v -E '^(<|>|)$' \
-      | grep -v '^$'
+      | grep -v -E '^[<>]?$'
 }
 
 # first table header row from SQL diff, strip to_/from_, drop metadata, as newline list
@@ -32,7 +31,7 @@ _sql_data_header_cols() {
 _cli_change_count() {
     awk -F'|' '
         # start counting once we see a data row marker
-        /^\s*\|\s*[-+<>]\s*\|/ { in_table=1 }
+        /^[[:space:]]*\|[[:space:]]*[-+<>][[:space:]]*\|/ { in_table=1 }
         in_table && $2 ~ /^[[:space:]]*[-+<>][[:space:]]*$/ {
             pk=$3
             gsub(/^[[:space:]]+|[[:space:]]+$/, "", pk)

--- a/integration-tests/bats/sql-pull.bats
+++ b/integration-tests/bats/sql-pull.bats
@@ -1152,7 +1152,9 @@ SQL
     # Write a tracking entry that has a remote but no merge ref, equivalent to running
     # git config branch.main.remote origin without a corresponding merge line.
     # The JSON "head" key is absent, so the Merge field has no ref when the file is loaded.
-    sed -i 's/"branches": {}/"branches": {"main": {"remote": "origin"}}/' .dolt/repo_state.json
+    # -i.bak (with a suffix glued to -i) is the syntax both GNU sed and BSD/macOS sed accept.
+    sed -i.bak 's/"branches": {}/"branches": {"main": {"remote": "origin"}}/' .dolt/repo_state.json
+    rm -f .dolt/repo_state.json.bak
 
     run dolt sql -q "call dolt_pull('origin')"
     [ "$status" -eq 1 ]

--- a/integration-tests/bats/sql-shell-commit-time.expect
+++ b/integration-tests/bats/sql-shell-commit-time.expect
@@ -2,6 +2,9 @@
 
 set timeout 5
 set env(NO_COLOR) 1
+# less reads keypresses from /dev/tty directly, racing with characters this script types
+# ahead into the pty for the next command and dropping them.
+set env(DOLT_PAGER) "cat"
 
 source  "$env(BATS_CWD)/helper/common_expect_functions.tcl"
 

--- a/integration-tests/bats/sql-shell-slash-cmds.expect
+++ b/integration-tests/bats/sql-shell-slash-cmds.expect
@@ -2,6 +2,9 @@
 
 set timeout 5
 set env(NO_COLOR) 1
+# less reads keypresses from /dev/tty directly, racing with characters this script types
+# ahead into the pty for the next command and dropping them.
+set env(DOLT_PAGER) "cat"
 
 source  "$env(BATS_CWD)/helper/common_expect_functions.tcl"
 

--- a/integration-tests/bats/tzdata.bats
+++ b/integration-tests/bats/tzdata.bats
@@ -9,7 +9,10 @@ TEST_NAME="dolt-tzdata"
 TEST_IMAGE="$TEST_NAME:bookworm-slim"
 
 setup_file() {
-    command -v docker >/dev/null 2>&1 || skip "docker not found on PATH"
+    # Docker isn't available on GitHub's macOS runners
+    if [ "$IS_MAC" = true ]; then
+        command -v docker >/dev/null 2>&1 || skip "docker not found on PATH (expected on macOS runners)"
+    fi
 
     WORKSPACE_ROOT=$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)
     export WORKSPACE_ROOT

--- a/integration-tests/bats/tzdata.bats
+++ b/integration-tests/bats/tzdata.bats
@@ -9,6 +9,8 @@ TEST_NAME="dolt-tzdata"
 TEST_IMAGE="$TEST_NAME:bookworm-slim"
 
 setup_file() {
+    command -v docker >/dev/null 2>&1 || skip "docker not found on PATH"
+
     WORKSPACE_ROOT=$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)
     export WORKSPACE_ROOT
 
@@ -45,6 +47,7 @@ dolt init"
 }
 
 teardown() {
+    command -v docker >/dev/null 2>&1 || return 0
     docker rm -f "$TEST_CONTAINER" >/dev/null 2>&1
 }
 


### PR DESCRIPTION
Fixes the long-standing macOS-only bats CI failures (verified: 38 → 0 failures across two full nightly-workflow runs).

- Skip docker-entrypoint.bats/tzdata.bats for MacOS (no docker available on PATH in MacOS runners)
- Fix BSD awk/grep incompatibilities in sql-diff.bash and GNU-only `sed -i` in sql-pull.bats
- Disable the detached `dolt send-metrics` process during bats runs (raced with test teardown cleanup)
- Default `DOLT_PAGER=cat` (less races with expect scripts typing ahead, dropping keystrokes)