### PR TITLE
Fix duplicate key errors with expression indexes

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/ddl_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/ddl_queries.go
@@ -721,6 +721,65 @@ var BrokenDDLScripts = []queries.ScriptTest{
 
 var AddIndexScripts = []queries.ScriptTest{
 	{
+		Name: "duplicate key after adding a column to a table with an expression index",
+		SetUpScript: []string{
+			"CREATE TABLE test (id int PRIMARY KEY, name text UNIQUE);",
+			"CREATE INDEX lower_name ON test ((lower(name)));",
+			"CREATE INDEX upper_name ON test ((upper(name)));",
+			"ALTER TABLE test ADD COLUMN extra datetime;",
+			"INSERT INTO test (id, name) VALUES (1, 'v1');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:       "INSERT INTO test (id, name) VALUES (1, 'duplicate');",
+				ExpectedErr: sql.ErrPrimaryKeyViolation,
+			},
+			{
+				Query:       "INSERT INTO test (id, name) VALUES (2, 'v1');",
+				ExpectedErr: sql.ErrUniqueKeyViolation,
+			},
+			{
+				Query:    "INSERT IGNORE INTO test (id, name) VALUES (1, 'ignored');",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    "INSERT INTO test (id, name) VALUES (1, 'updated') ON DUPLICATE KEY UPDATE name = VALUES(name);",
+				Expected: []sql.Row{{types.NewOkResult(2)}},
+			},
+			{
+				Query:    "SELECT id, name, extra FROM test;",
+				Expected: []sql.Row{{1, "updated", nil}},
+			},
+		},
+	},
+	{
+		Name: "duplicate unique key on keyless table after adding a column with an expression index",
+		SetUpScript: []string{
+			"CREATE TABLE keyless_test (id int, name text UNIQUE);",
+			"CREATE INDEX keyless_lower_name ON keyless_test ((lower(name)));",
+			"ALTER TABLE keyless_test ADD COLUMN extra datetime;",
+			"INSERT INTO keyless_test (id, name) VALUES (1, 'v1');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:       "INSERT INTO keyless_test (id, name) VALUES (2, 'v1');",
+				ExpectedErr: sql.ErrUniqueKeyViolation,
+			},
+			{
+				Query:    "INSERT IGNORE INTO keyless_test (id, name) VALUES (2, 'v1');",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    "INSERT INTO keyless_test (id, name) VALUES (3, 'v1') ON DUPLICATE KEY UPDATE id = VALUES(id);",
+				Expected: []sql.Row{{types.NewOkResult(2)}},
+			},
+			{
+				Query:    "SELECT id, name, extra FROM keyless_test;",
+				Expected: []sql.Row{{3, "v1", nil}},
+			},
+		},
+	},
+	{
 		Name: "add unique constraint on keyless table",
 		SetUpScript: []string{
 			"CREATE TABLE test (uk int);",

--- a/go/libraries/doltcore/sqle/writer/prolly_index_writer.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_index_writer.go
@@ -257,21 +257,21 @@ func (m prollyIndexWriter) errForSecondaryUniqueKeyError(ctx context.Context, er
 // uniqueKeyError builds a sql.UniqueKeyError. It fetches the existing row using
 // |key| and passes it as the |existing| row.
 func (m prollyIndexWriter) uniqueKeyError(ctx context.Context, keyStr string, key val.Tuple, isPk bool) error {
-	existing := make(sql.Row, len(m.keyMap)+len(m.valMap))
+	existing := make(sql.Row, mappedRowSize(m.keyMap, m.valMap))
 
 	_ = m.mut.Get(ctx, key, func(key, value val.Tuple) (err error) {
 		kd := m.keyBld.Desc
-		for from := range m.keyMap {
-			to := m.keyMap.MapOrdinal(from)
-			if existing[to], err = tree.GetField(ctx, kd, from, key, m.mut.NodeStore()); err != nil {
+		for tupleOrdinal := range m.keyMap {
+			rowOrdinal := m.keyMap.MapOrdinal(tupleOrdinal)
+			if existing[rowOrdinal], err = tree.GetField(ctx, kd, tupleOrdinal, key, m.mut.NodeStore()); err != nil {
 				return err
 			}
 		}
 
 		vd := m.valBld.Desc
-		for from := range m.valMap {
-			to := m.valMap.MapOrdinal(from)
-			if existing[to], err = tree.GetField(ctx, vd, from, value, m.mut.NodeStore()); err != nil {
+		for tupleOrdinal := range m.valMap {
+			rowOrdinal := m.valMap.MapOrdinal(tupleOrdinal)
+			if existing[rowOrdinal], err = tree.GetField(ctx, vd, tupleOrdinal, value, m.mut.NodeStore()); err != nil {
 				return err
 			}
 		}
@@ -279,6 +279,25 @@ func (m prollyIndexWriter) uniqueKeyError(ctx context.Context, keyStr string, ke
 	})
 
 	return sql.NewUniqueKeyErr(keyStr, isPk, existing)
+}
+
+// mappedRowSize returns the minimum SQL row length required to address every mapped SQL row
+// ordinal across the supplied tuple-to-row mappings. Mapping values may be sparse when the SQL
+// row contains system-hidden virtual columns, so len(mapping) only counts tuple fields and is not
+// sufficient to size the destination row.
+func mappedRowSize(mappings ...val.OrdinalMapping) int {
+	var maxRowOrdinal int
+	var found bool
+	for _, mapping := range mappings {
+		for tupleOrdinal := range mapping {
+			maxRowOrdinal = max(maxRowOrdinal, mapping.MapOrdinal(tupleOrdinal))
+			found = true
+		}
+	}
+	if !found {
+		return 0
+	}
+	return maxRowOrdinal + 1
 }
 
 type prollySecondaryIndexWriter struct {

--- a/go/libraries/doltcore/sqle/writer/prolly_index_writer_keyless.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_index_writer_keyless.go
@@ -163,14 +163,14 @@ func (k prollyKeylessWriter) errForSecondaryUniqueKeyError(ctx context.Context, 
 // UniqueKeyError builds a sql.UniqueKeyError. It fetches the existing row using
 // |key| and passes it as the |existing| row.
 func (k prollyKeylessWriter) uniqueKeyError(ctx context.Context, keyStr string, key val.Tuple, isPk bool) error {
-	existing := make(sql.Row, len(k.valMap))
+	existing := make(sql.Row, mappedRowSize(k.valMap))
 
 	_ = k.mut.Get(ctx, key, func(key, value val.Tuple) (err error) {
 		vd := k.valBld.Desc
-		for from := range k.valMap {
-			to := k.valMap.MapOrdinal(from)
+		for tupleOrdinal := range k.valMap {
+			rowOrdinal := k.valMap.MapOrdinal(tupleOrdinal)
 			// offset from index for keyless rows, as first field is the count
-			if existing[to], err = tree.GetField(ctx, vd, from+1, value, k.mut.NodeStore()); err != nil {
+			if existing[rowOrdinal], err = tree.GetField(ctx, vd, tupleOrdinal+1, value, k.mut.NodeStore()); err != nil {
 				return err
 			}
 		}

--- a/go/libraries/doltcore/sqle/writer/prolly_index_writer_test.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_index_writer_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package writer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/store/val"
+)
+
+func TestMappedRowSize(t *testing.T) {
+	tests := []struct {
+		name     string
+		mappings []val.OrdinalMapping
+		expected int
+	}{
+		{name: "no mappings", expected: 0},
+		{name: "one empty mapping", mappings: []val.OrdinalMapping{{}}, expected: 0},
+		{name: "multiple empty mappings", mappings: []val.OrdinalMapping{{}, {}}, expected: 0},
+		{name: "empty mixed with non-empty", mappings: []val.OrdinalMapping{{}, {2}, {}}, expected: 3},
+		{name: "identity", mappings: []val.OrdinalMapping{{0, 1, 2}}, expected: 3},
+		{name: "hidden gap", mappings: []val.OrdinalMapping{{0}, {1, 3}}, expected: 4},
+		{name: "multiple hidden gaps", mappings: []val.OrdinalMapping{{0}, {1, 4}}, expected: 5},
+		{name: "highest ordinal in first mapping", mappings: []val.OrdinalMapping{{5}, {1, 2}}, expected: 6},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.expected, mappedRowSize(test.mappings...))
+		})
+	}
+}


### PR DESCRIPTION
Sizes reconstructed rows from mapped SQL ordinals so system-hidden expression-index columns cannot leave out-of-range gaps after schema changes. Covers keyed and keyless tables across duplicate errors, ignored inserts, and duplicate-key updates.

Supports [doltgresql #3082](https://github.com/dolthub/doltgresql/issues/3082).