### PR TITLE
[no-release-notes] Run QueryTests tests against a running server

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -46,7 +46,7 @@ import (
 const SkipPreparedsCount = 83
 
 func TestQueries(t *testing.T) {
-	h := newDoltHarness(t)
+	h := newDoltServerTestHarness(t)
 	defer h.Close()
 	enginetest.TestQueries(t, h)
 }
@@ -1747,7 +1747,7 @@ func TestDoltCommitPrepared(t *testing.T) {
 }
 
 func TestQueriesPrepared(t *testing.T) {
-	h := newDoltHarness(t)
+	h := newDoltEnginetestHarness(t)
 	defer h.Close()
 	enginetest.TestQueriesPrepared(t, h)
 }

--- a/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
@@ -67,6 +67,8 @@ type DoltHarness struct {
 	configureStats        bool
 	useLocalFilesystem    bool
 	setupTestProcedures   bool
+	// server indicates whether the harness will create a running MySQL server.
+	server bool
 }
 
 func (d *DoltHarness) UseLocalFileSystem() {
@@ -141,6 +143,15 @@ func newDoltHarness(t *testing.T) *DoltHarness {
 
 func newDoltEnginetestHarness(t *testing.T) DoltEnginetestHarness {
 	return newDoltHarness(t)
+}
+
+// newDoltServerTestHarness creates a harness that starts a MySQL server
+// and runs tests by connecting to the server with a driver. This is useful
+// for testing the server's handler.
+func newDoltServerTestHarness(t *testing.T) DoltEnginetestHarness {
+	dh := newDoltHarness(t)
+	dh.server = true
+	return dh
 }
 
 // newDoltHarnessForLocalFilesystem creates a new harness for testing Dolt, using
@@ -239,6 +250,8 @@ func commitScripts(dbs []string) []setup.SetupScript {
 // engine for reuse.
 func (d *DoltHarness) NewEngine(t *testing.T) (enginetest.QueryEngine, error) {
 	initializeEngine := d.engine == nil
+	var e *gms.Engine
+	var err error
 	if initializeEngine {
 		ctx := sql.NewEmptyContext()
 		d.branchControl = branch_control.CreateDefaultController(ctx)
@@ -271,7 +284,7 @@ func (d *DoltHarness) NewEngine(t *testing.T) (enginetest.QueryEngine, error) {
 		d.session, err = dsess.NewDoltSession(enginetest.NewBaseSession(), d.provider, d.multiRepoEnv.Config(), d.branchControl, d.statsPro, writer.NewWriteSession, d.gcSafepointController, d.branchActivityTracker)
 		require.NoError(t, err)
 
-		e, err := enginetest.NewEngine(t, d, d.provider, d.setupData, d.statsPro)
+		e, err = enginetest.NewEngine(t, d, d.provider, d.setupData, d.statsPro)
 		if err != nil {
 			return nil, err
 		}
@@ -325,32 +338,35 @@ func (d *DoltHarness) NewEngine(t *testing.T) (enginetest.QueryEngine, error) {
 			e, err = enginetest.RunSetupScripts(sqlCtx, d.engine, finalizeStatsAfterSetup, d.SupportsNativeIndexCreation())
 			require.NoError(t, err)
 		}
+	} else {
 
-		return e, nil
-	}
+		// Reset the mysql DB table to a clean state for this new engine
+		ctx := enginetest.NewContext(d)
 
-	// Reset the mysql DB table to a clean state for this new engine
-	ctx := enginetest.NewContext(d)
+		if d.configureStats {
+			err := d.statsPro.Purge(ctx)
+			require.NoError(t, err)
 
-	if d.configureStats {
-		err := d.statsPro.Purge(ctx)
+			err = d.statsPro.Restart(ctx)
+			require.NoError(t, err)
+		}
+
+		d.engine.Analyzer.Catalog.MySQLDb = mysql_db.CreateEmptyMySQLDb()
+		d.engine.Analyzer.Catalog.MySQLDb.AddRootAccount()
+
+		e, err = enginetest.RunSetupScripts(ctx, d.engine, d.resetScripts(), d.SupportsNativeIndexCreation())
 		require.NoError(t, err)
 
-		err = d.statsPro.Restart(ctx)
+		// Get a fresh session after running setup scripts, since some setup scripts can change the session state
+		d.session, err = dsess.NewDoltSession(enginetest.NewBaseSession(), d.provider, d.multiRepoEnv.Config(), d.branchControl, d.statsPro, writer.NewWriteSession, nil, d.branchActivityTracker)
 		require.NoError(t, err)
 	}
 
-	d.engine.Analyzer.Catalog.MySQLDb = mysql_db.CreateEmptyMySQLDb()
-	d.engine.Analyzer.Catalog.MySQLDb.AddRootAccount()
+	if d.server {
+		return enginetest.NewServerQueryEngine(t, e, newSessionBuilder(d))
+	}
 
-	e, err := enginetest.RunSetupScripts(ctx, d.engine, d.resetScripts(), d.SupportsNativeIndexCreation())
-	require.NoError(t, err)
-
-	// Get a fresh session after running setup scripts, since some setup scripts can change the session state
-	d.session, err = dsess.NewDoltSession(enginetest.NewBaseSession(), d.provider, d.multiRepoEnv.Config(), d.branchControl, d.statsPro, writer.NewWriteSession, nil, d.branchActivityTracker)
-	require.NoError(t, err)
-
-	return e, err
+	return e, nil
 }
 
 func filterStatsOnlyQueries(scripts []setup.SetupScript) []setup.SetupScript {


### PR DESCRIPTION
Previously we didn't have any test coverage for running query tests against a running Dolt server. Instead we ran against a DoltHarness, which is an type defined in the enginetests package that can run queries using an in-memory engine. This meant that we didn't get good test coverage for the server Handler.

There are some optimizations such as the `sql.ValueRowIter` interface and its associated codepaths, that are only used by the server Handler and aren't used if the queries are run directly on an engine. These codepaths didn't have the proper test coverage.

https://github.com/dolthub/go-mysql-server/pull/3747 and https://github.com/dolthub/go-mysql-server/pull/3748 fixed bugs that were causing the server to return incorrect results for these queries. This PR modifies QueryTests to connect to a server, creating regression tests for those issues. If you run this PR against a version of GMS from before those fixes, QueryTests will fail.

This PR works by wrapping the engine created by the harness in an `enginetest.ServerQueryEngine`. This still does not 100% match the behavior of an actual running Dolt server, but it's a lot closer. Of note, the server that gets created does not properly implement Dolt's access control permissions. For this reason, we don't use it to test Dolt-specific functionality, we just use it to test MySQL queries for correctness.

We also only use this for QueryTests and not QueryTestsPrepared, because of a limitation in go-sql-driver. go-sql-driver does not support sending decimals as bindings for prepared queries, so the test harness sends them as strings instead. This changes the expected output of some of the queries, so making QueryTestsPrepared use a mysql server and connection would break those tests.