### PR TITLE
go: sqle/expranalysis: Have ResolveExpression take a schema-qualified TableName.

### DIFF
--- a/go/libraries/doltcore/sqle/expranalysis/expranalysis.go
+++ b/go/libraries/doltcore/sqle/expranalysis/expranalysis.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/planbuilder"
 	"github.com/dolthub/go-mysql-server/sql/transform"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/overrides"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlfmt"
@@ -88,9 +89,9 @@ func ResolveCheckExpression(ctx *sql.Context, tableName string, sch schema.Schem
 // ResolveExpression compiles a predicate or check constraint string into a sql.Expression resolved.
 // Used to re-hydrate partial index predicates and check expressions from their string representation.
 // It uses SELECT statement on the expression FROM given table.
-func ResolveExpression(ctx *sql.Context, tableName string, predicateStr string) (sql.Expression, error) {
+func ResolveExpression(ctx *sql.Context, tableName doltdb.TableName, predicateStr string) (sql.Expression, error) {
 	// TODO: added * in SELECT stmt to avoid pruning columns during analyzer.
-	parsed, err := parseQuery(ctx, fmt.Sprintf("SELECT *, %s FROM %s", predicateStr, tableName))
+	parsed, err := parseQuery(ctx, fmt.Sprintf("SELECT *, %s FROM %s", predicateStr, queryTableName(ctx, tableName)))
 	if err != nil {
 		return nil, err
 	}
@@ -116,6 +117,17 @@ func ResolveExpression(ctx *sql.Context, tableName string, predicateStr string) 
 		expr = alias.Child
 	}
 	return expr, nil
+}
+
+// queryTableName renders |tableName| for use in the FROM clause of a query built for the analyzer. The schema, where
+// there is one, must survive into the parsed statement: an unqualified name is resolved against the session's
+// search_path, which need not reach the table's own schema, and may name a different table of the same name first.
+func queryTableName(ctx *sql.Context, tableName doltdb.TableName) string {
+	if tableName.Schema == "" {
+		return tableName.Name
+	}
+	formatter := overrides.SchemaFormatterFromContext(ctx)
+	return fmt.Sprintf("%s.%s", formatter.QuoteIdentifier(tableName.Schema), formatter.QuoteIdentifier(tableName.Name))
 }
 
 func stripTableNamesFromExpression(ctx *sql.Context, formatter sql.SchemaFormatter, expr sql.Expression, quoted bool) sql.Expression {

--- a/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
@@ -347,7 +347,7 @@ func (w *prollyTableWriter) VisitGCRoots(ctx context.Context, roots func(hash.Ha
 
 // Reset puts the writer into a fresh state, updating the schema and index writers according to the newly given table.
 func (w *prollyTableWriter) Reset(ctx *sql.Context, tbl *doltdb.Table) error {
-	schState, err := writerSchema(ctx, tbl, w.tblName.Name, w.dbName)
+	schState, err := writerSchema(ctx, tbl, w.tblName, w.dbName)
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/sqle/writer/schema_cache.go
+++ b/go/libraries/doltcore/sqle/writer/schema_cache.go
@@ -29,7 +29,7 @@ import (
 
 // writerSchema returns the state required to map logical sql.Row values to
 // primary and secondary val.Tuple that will be written to disk.
-func writerSchema(ctx *sql.Context, t *doltdb.Table, tableName string, dbName string) (*dsess.WriterState, error) {
+func writerSchema(ctx *sql.Context, t *doltdb.Table, tableName doltdb.TableName, dbName string) (*dsess.WriterState, error) {
 	sess, ok := ctx.Session.(*dsess.DoltSession)
 	if !ok {
 		return newWriterSchema(ctx, t, tableName, dbName)
@@ -63,7 +63,7 @@ func writerSchema(ctx *sql.Context, t *doltdb.Table, tableName string, dbName st
 	return schState, nil
 }
 
-func newWriterSchema(ctx *sql.Context, t *doltdb.Table, tableName string, dbName string) (*dsess.WriterState, error) {
+func newWriterSchema(ctx *sql.Context, t *doltdb.Table, tableName doltdb.TableName, dbName string) (*dsess.WriterState, error) {
 	var err error
 	schState := new(dsess.WriterState)
 	schState.DoltSchema, err = t.GetSchema(ctx)
@@ -71,7 +71,7 @@ func newWriterSchema(ctx *sql.Context, t *doltdb.Table, tableName string, dbName
 		return nil, err
 	}
 	schState.PkKeyDesc, schState.PkValDesc = schState.DoltSchema.GetMapDescriptors(t.NodeStore())
-	schState.PkSchema, err = sqlutil.FromDoltSchema(ctx, dbName, tableName, schState.DoltSchema)
+	schState.PkSchema, err = sqlutil.FromDoltSchema(ctx, dbName, tableName.Name, schState.DoltSchema)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func newWriterSchema(ctx *sql.Context, t *doltdb.Table, tableName string, dbName
 
 	// Resolved once for the whole table: rows read directly from stored data omit virtual columns
 	// entirely, so any write path that needs a virtual column's value evaluates these to fill it in.
-	schState.VirtualExpressions, err = resolveVirtualExpressions(ctx, tableName, schState.DoltSchema)
+	schState.VirtualExpressions, err = resolveVirtualExpressions(ctx, tableName.Name, schState.DoltSchema)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,6 @@ func newWriterSchema(ctx *sql.Context, t *doltdb.Table, tableName string, dbName
 			KeyVirtualExprs: keyVirtualExprs,
 		}
 		if predStr := def.Predicate(); predStr != "" {
-			// TODO: need to set the schema in search_path? it cannot find tables and types.
 			predExpr, err := expranalysis.ResolveExpression(ctx, tableName, predStr)
 			if err != nil {
 				return nil, fmt.Errorf("failed to compile partial index predicate for %s: %w", def.Name(), err)


### PR DESCRIPTION
Allows for fixing some partial-index creation failures in doltgres.