### PR TITLE
dbfactory: git remotes with more flexible cache dir name

### DIFF
--- a/go/libraries/doltcore/dbfactory/git_remote.go
+++ b/go/libraries/doltcore/dbfactory/git_remote.go
@@ -40,11 +40,11 @@ import (
 )
 
 const (
-	// GitCacheDirParam is the directory that holds the per-remote local cache
-	// repositories, used as given: <git_cache_dir>/<hash>/repo.git. Callers choose
+	// GitCacheRootParam is the directory that holds the per-remote local cache
+	// repositories, used as given: <git_cache_root>/<hash>/repo.git. Callers choose
 	// the layout: the Dolt CLI passes <repoRoot>/.dolt/git-remote-cache (see
 	// GitRemoteCacheDirName), while other embedders can pass any directory.
-	GitCacheDirParam = "git_cache_dir"
+	GitCacheRootParam = "git_cache_root"
 	// GitRemoteCacheDirName is the conventional directory, under a Dolt repository's
 	// `.dolt/`, that the Dolt CLI uses for git remote caches.
 	GitRemoteCacheDirName = "git-remote-cache"
@@ -193,15 +193,15 @@ func (fact GitRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFor
 		return nil, nil, nil, err
 	}
 
-	cacheDir, ok, err := resolveGitCacheDir(params)
+	cacheRoot, ok, err := resolveGitCacheRoot(params)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 	if !ok {
-		return nil, nil, nil, fmt.Errorf("%s is required for git remotes", GitCacheDirParam)
+		return nil, nil, nil, fmt.Errorf("%s is required for git remotes", GitCacheRootParam)
 	}
 
-	cacheRepo, err := cacheRepoPath(cacheDir, remoteURL.String(), ref)
+	cacheRepo, err := cacheRepoPath(cacheRoot, remoteURL.String(), ref)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -352,22 +352,22 @@ func resolveGitRemoteName(params map[string]interface{}) string {
 	return defaultGitRemoteName
 }
 
-// resolveGitCacheDir parses and validates GitCacheDirParam.
+// resolveGitCacheRoot parses and validates GitCacheRootParam.
 // It returns ok=false when the param is not present.
-func resolveGitCacheDir(params map[string]interface{}) (dir string, ok bool, err error) {
+func resolveGitCacheRoot(params map[string]interface{}) (root string, ok bool, err error) {
 	if params == nil {
 		return "", false, nil
 	}
-	v, ok := params[GitCacheDirParam]
+	v, ok := params[GitCacheRootParam]
 	if !ok || v == nil {
 		return "", false, nil
 	}
 	s, ok := v.(string)
 	if !ok {
-		return "", false, fmt.Errorf("%s must be a string", GitCacheDirParam)
+		return "", false, fmt.Errorf("%s must be a string", GitCacheRootParam)
 	}
 	if strings.TrimSpace(s) == "" {
-		return "", false, fmt.Errorf("%s cannot be empty", GitCacheDirParam)
+		return "", false, fmt.Errorf("%s cannot be empty", GitCacheRootParam)
 	}
 	return s, true, nil
 }

--- a/go/libraries/doltcore/dbfactory/git_remote.go
+++ b/go/libraries/doltcore/dbfactory/git_remote.go
@@ -193,7 +193,7 @@ func (fact GitRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFor
 		return nil, nil, nil, err
 	}
 
-	cacheDir, ok, err := stringParam(params, GitCacheDirParam)
+	cacheDir, ok, err := resolveGitCacheDir(params)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -352,21 +352,22 @@ func resolveGitRemoteName(params map[string]interface{}) string {
 	return defaultGitRemoteName
 }
 
-// stringParam reads a required-non-empty string param, ok=false when absent.
-func stringParam(params map[string]interface{}, key string) (string, bool, error) {
+// resolveGitCacheDir parses and validates GitCacheDirParam.
+// It returns ok=false when the param is not present.
+func resolveGitCacheDir(params map[string]interface{}) (dir string, ok bool, err error) {
 	if params == nil {
 		return "", false, nil
 	}
-	v, ok := params[key]
+	v, ok := params[GitCacheDirParam]
 	if !ok || v == nil {
 		return "", false, nil
 	}
 	s, ok := v.(string)
 	if !ok {
-		return "", false, fmt.Errorf("%s must be a string", key)
+		return "", false, fmt.Errorf("%s must be a string", GitCacheDirParam)
 	}
 	if strings.TrimSpace(s) == "" {
-		return "", false, fmt.Errorf("%s cannot be empty", key)
+		return "", false, fmt.Errorf("%s cannot be empty", GitCacheDirParam)
 	}
 	return s, true, nil
 }

--- a/go/libraries/doltcore/dbfactory/git_remote.go
+++ b/go/libraries/doltcore/dbfactory/git_remote.go
@@ -40,12 +40,13 @@ import (
 )
 
 const (
-	// GitCacheRootParam is the absolute path to the local Dolt repository root (the directory that contains `.dolt/`).
-	// Required for git remotes. GitRemoteFactory stores its local cache repo under:
-	// `<git_cache_root>/.dolt/git-remote-cache/<sha256(remoteURL|remoteRef)>/repo.git`.
-	GitCacheRootParam = "git_cache_root"
-	// GitRemoteCacheDirName is the directory under a Dolt repository's `.dolt/` which holds the local
-	// cache repositories for git remotes.
+	// GitCacheDirParam is the directory that holds the per-remote local cache
+	// repositories, used as given: <git_cache_dir>/<hash>/repo.git. Callers choose
+	// the layout: the Dolt CLI passes <repoRoot>/.dolt/git-remote-cache (see
+	// GitRemoteCacheDirName), while other embedders can pass any directory.
+	GitCacheDirParam = "git_cache_dir"
+	// GitRemoteCacheDirName is the conventional directory, under a Dolt repository's
+	// `.dolt/`, that the Dolt CLI uses for git remote caches.
 	GitRemoteCacheDirName = "git-remote-cache"
 	GitRefParam           = "git_ref"
 	GitRemoteNameParam    = "git_remote_name"
@@ -192,16 +193,15 @@ func (fact GitRemoteFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFor
 		return nil, nil, nil, err
 	}
 
-	cacheRoot, ok, err := resolveGitCacheRoot(params)
+	cacheDir, ok, err := stringParam(params, GitCacheDirParam)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 	if !ok {
-		return nil, nil, nil, fmt.Errorf("%s is required for git remotes", GitCacheRootParam)
+		return nil, nil, nil, fmt.Errorf("%s is required for git remotes", GitCacheDirParam)
 	}
-	cacheBase := filepath.Join(cacheRoot, DoltDir, GitRemoteCacheDirName)
 
-	cacheRepo, err := cacheRepoPath(cacheBase, remoteURL.String(), ref)
+	cacheRepo, err := cacheRepoPath(cacheDir, remoteURL.String(), ref)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -352,22 +352,21 @@ func resolveGitRemoteName(params map[string]interface{}) string {
 	return defaultGitRemoteName
 }
 
-// resolveGitCacheRoot parses and validates GitCacheRootParam.
-// It returns ok=false when the param is not present.
-func resolveGitCacheRoot(params map[string]interface{}) (root string, ok bool, err error) {
+// stringParam reads a required-non-empty string param, ok=false when absent.
+func stringParam(params map[string]interface{}, key string) (string, bool, error) {
 	if params == nil {
 		return "", false, nil
 	}
-	v, ok := params[GitCacheRootParam]
+	v, ok := params[key]
 	if !ok || v == nil {
 		return "", false, nil
 	}
 	s, ok := v.(string)
 	if !ok {
-		return "", false, fmt.Errorf("%s must be a string", GitCacheRootParam)
+		return "", false, fmt.Errorf("%s must be a string", key)
 	}
 	if strings.TrimSpace(s) == "" {
-		return "", false, fmt.Errorf("%s cannot be empty", GitCacheRootParam)
+		return "", false, fmt.Errorf("%s cannot be empty", key)
 	}
 	return s, true, nil
 }

--- a/go/libraries/doltcore/dbfactory/git_remote_test.go
+++ b/go/libraries/doltcore/dbfactory/git_remote_test.go
@@ -420,4 +420,3 @@ func TestGitRemoteFactory_GitCacheDirParamUsedVerbatim(t *testing.T) {
 	}
 	require.True(t, found, "expected the cache repo directly under <git_cache_dir>/<hash>/repo.git")
 }
-

--- a/go/libraries/doltcore/dbfactory/git_remote_test.go
+++ b/go/libraries/doltcore/dbfactory/git_remote_test.go
@@ -88,11 +88,11 @@ func TestGitRemoteURLString(t *testing.T) {
 	}
 }
 
-func TestGitRemoteFactory_GitFile_RequiresGitCacheRootParam(t *testing.T) {
+func TestGitRemoteFactory_GitFile_RequiresGitCacheDirParam(t *testing.T) {
 	ctx := context.Background()
 	_, _, _, err := CreateDB(ctx, types.Format_DOLT, "git+file:///tmp/remote.git", map[string]interface{}{})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), GitCacheRootParam)
+	require.Contains(t, err.Error(), GitCacheDirParam)
 }
 
 func TestGitRemoteFactory_GitFile_CachesUnderRepoDoltDirAndCanWrite(t *testing.T) {
@@ -111,17 +111,17 @@ func TestGitRemoteFactory_GitFile_CachesUnderRepoDoltDirAndCanWrite(t *testing.T
 	remotePath := filepath.ToSlash(remoteRepo.GitDir)
 	remoteURL := "file://" + remotePath
 	urlStr := "git+file://" + remotePath
+	// The Dolt CLI stores caches under <repoRoot>/.dolt/git-remote-cache; the
+	// factory uses git_cache_dir verbatim, so the caller composes that path.
+	cacheBase := filepath.Join(localRepoRoot, DoltDir, GitRemoteCacheDirName)
 	params := map[string]interface{}{
-		GitCacheRootParam: localRepoRoot,
+		GitCacheDirParam: cacheBase,
 	}
 
 	db, vrw, _, err := CreateDB(ctx, types.Format_DOLT, urlStr, params)
 	require.NoError(t, err)
 	require.NotNil(t, db)
 	require.NotNil(t, vrw)
-
-	// Ensure cache repo created under <repoRoot>/.dolt/git-remote-cache.
-	cacheBase := filepath.Join(localRepoRoot, DoltDir, GitRemoteCacheDirName)
 
 	sum := sha256.Sum256([]byte(remoteURL + "|" + "refs/dolt/data"))
 	h := hex.EncodeToString(sum[:])
@@ -179,7 +179,7 @@ func TestGitRemoteFactory_TwoClientsDistinctCacheDirsRoundtrip(t *testing.T) {
 
 	open := func(cacheRoot string) (db datas.Database, cs chunks.ChunkStore) {
 		params := map[string]interface{}{
-			GitCacheRootParam: cacheRoot,
+			GitCacheDirParam: cacheRoot,
 		}
 		d, vrw, _, err := CreateDB(ctx, types.Format_DOLT, urlStr, params)
 		require.NoError(t, err)
@@ -253,7 +253,7 @@ func TestGitRemoteFactory_GitFile_RemoteWithNoBranchesFails(t *testing.T) {
 	remotePath := filepath.ToSlash(remoteRepo.GitDir)
 	urlStr := "git+file://" + remotePath
 	params := map[string]interface{}{
-		GitCacheRootParam: localRepoRoot,
+		GitCacheDirParam: localRepoRoot,
 	}
 
 	_, _, _, err = CreateDB(ctx, types.Format_DOLT, urlStr, params)
@@ -303,7 +303,7 @@ func TestCloseGitRemotesUnderRoot(t *testing.T) {
 
 	urlStr := "git+file://" + filepath.ToSlash(remoteRepo.GitDir)
 	open := func(root string) datas.Database {
-		db, _, _, err := CreateDB(ctx, types.Format_DOLT, urlStr, map[string]interface{}{GitCacheRootParam: root})
+		db, _, _, err := CreateDB(ctx, types.Format_DOLT, urlStr, map[string]interface{}{GitCacheDirParam: filepath.Join(root, DoltDir, GitRemoteCacheDirName)})
 		require.NoError(t, err)
 		return db
 	}
@@ -343,7 +343,7 @@ func TestGitRemoteFactory_ReopenSeesOtherCacheRootsPush(t *testing.T) {
 
 	urlStr := "git+file://" + filepath.ToSlash(remoteRepo.GitDir)
 	open := func(root string) (datas.Database, chunks.ChunkStore) {
-		db, vrw, _, err := CreateDB(ctx, types.Format_DOLT, urlStr, map[string]interface{}{GitCacheRootParam: root})
+		db, vrw, _, err := CreateDB(ctx, types.Format_DOLT, urlStr, map[string]interface{}{GitCacheDirParam: filepath.Join(root, DoltDir, GitRemoteCacheDirName)})
 		require.NoError(t, err)
 		vs, ok := vrw.(*types.ValueStore)
 		require.True(t, ok, "expected ValueReadWriter to be *types.ValueStore, got %T", vrw)
@@ -384,3 +384,40 @@ func TestGitRemoteFactory_ReopenSeesOtherCacheRootsPush(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "cacheRootB\n", string(got.Data()))
 }
+
+func TestGitRemoteFactory_GitCacheDirParamUsedVerbatim(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found on PATH")
+	}
+	ctx := context.Background()
+	t.Cleanup(func() { TeardownGitRemotes(ctx) })
+
+	remoteRepo, err := gitrepo.InitBare(ctx, filepath.Join(shortTempDir(t), "remote.git"))
+	require.NoError(t, err)
+	_, err = remoteRepo.SetRefToTree(ctx, "refs/heads/main", map[string][]byte{"README": []byte("seed\n")}, "seed")
+	require.NoError(t, err)
+	urlStr := "git+file://" + filepath.ToSlash(remoteRepo.GitDir)
+
+	// GitCacheDirParam is used as the cache base verbatim: no .dolt/git-remote-cache
+	// is appended, so a non-Dolt embedder gets a clean cache location.
+	cacheDir := shortTempDir(t)
+	db, _, _, err := CreateDB(ctx, types.Format_DOLT, urlStr, map[string]interface{}{GitCacheDirParam: cacheDir})
+	require.NoError(t, err)
+	require.NotNil(t, db)
+
+	_, statErr := os.Stat(filepath.Join(cacheDir, DoltDir))
+	require.True(t, os.IsNotExist(statErr), "cache dir must not contain a .dolt directory")
+
+	entries, err := os.ReadDir(cacheDir)
+	require.NoError(t, err)
+	found := false
+	for _, e := range entries {
+		if e.IsDir() {
+			if _, err := os.Stat(filepath.Join(cacheDir, e.Name(), "repo.git")); err == nil {
+				found = true
+			}
+		}
+	}
+	require.True(t, found, "expected the cache repo directly under <git_cache_dir>/<hash>/repo.git")
+}
+

--- a/go/libraries/doltcore/dbfactory/git_remote_test.go
+++ b/go/libraries/doltcore/dbfactory/git_remote_test.go
@@ -88,11 +88,11 @@ func TestGitRemoteURLString(t *testing.T) {
 	}
 }
 
-func TestGitRemoteFactory_GitFile_RequiresGitCacheDirParam(t *testing.T) {
+func TestGitRemoteFactory_GitFile_RequiresGitCacheRootParam(t *testing.T) {
 	ctx := context.Background()
 	_, _, _, err := CreateDB(ctx, types.Format_DOLT, "git+file:///tmp/remote.git", map[string]interface{}{})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), GitCacheDirParam)
+	require.Contains(t, err.Error(), GitCacheRootParam)
 }
 
 func TestGitRemoteFactory_GitFile_CachesUnderRepoDoltDirAndCanWrite(t *testing.T) {
@@ -112,10 +112,10 @@ func TestGitRemoteFactory_GitFile_CachesUnderRepoDoltDirAndCanWrite(t *testing.T
 	remoteURL := "file://" + remotePath
 	urlStr := "git+file://" + remotePath
 	// The Dolt CLI stores caches under <repoRoot>/.dolt/git-remote-cache; the
-	// factory uses git_cache_dir verbatim, so the caller composes that path.
+	// factory uses git_cache_root verbatim, so the caller composes that path.
 	cacheBase := filepath.Join(localRepoRoot, DoltDir, GitRemoteCacheDirName)
 	params := map[string]interface{}{
-		GitCacheDirParam: cacheBase,
+		GitCacheRootParam: cacheBase,
 	}
 
 	db, vrw, _, err := CreateDB(ctx, types.Format_DOLT, urlStr, params)
@@ -179,7 +179,7 @@ func TestGitRemoteFactory_TwoClientsDistinctCacheDirsRoundtrip(t *testing.T) {
 
 	open := func(cacheRoot string) (db datas.Database, cs chunks.ChunkStore) {
 		params := map[string]interface{}{
-			GitCacheDirParam: cacheRoot,
+			GitCacheRootParam: cacheRoot,
 		}
 		d, vrw, _, err := CreateDB(ctx, types.Format_DOLT, urlStr, params)
 		require.NoError(t, err)
@@ -253,7 +253,7 @@ func TestGitRemoteFactory_GitFile_RemoteWithNoBranchesFails(t *testing.T) {
 	remotePath := filepath.ToSlash(remoteRepo.GitDir)
 	urlStr := "git+file://" + remotePath
 	params := map[string]interface{}{
-		GitCacheDirParam: localRepoRoot,
+		GitCacheRootParam: localRepoRoot,
 	}
 
 	_, _, _, err = CreateDB(ctx, types.Format_DOLT, urlStr, params)
@@ -303,7 +303,7 @@ func TestCloseGitRemotesUnderRoot(t *testing.T) {
 
 	urlStr := "git+file://" + filepath.ToSlash(remoteRepo.GitDir)
 	open := func(root string) datas.Database {
-		db, _, _, err := CreateDB(ctx, types.Format_DOLT, urlStr, map[string]interface{}{GitCacheDirParam: filepath.Join(root, DoltDir, GitRemoteCacheDirName)})
+		db, _, _, err := CreateDB(ctx, types.Format_DOLT, urlStr, map[string]interface{}{GitCacheRootParam: filepath.Join(root, DoltDir, GitRemoteCacheDirName)})
 		require.NoError(t, err)
 		return db
 	}
@@ -343,7 +343,7 @@ func TestGitRemoteFactory_ReopenSeesOtherCacheRootsPush(t *testing.T) {
 
 	urlStr := "git+file://" + filepath.ToSlash(remoteRepo.GitDir)
 	open := func(root string) (datas.Database, chunks.ChunkStore) {
-		db, vrw, _, err := CreateDB(ctx, types.Format_DOLT, urlStr, map[string]interface{}{GitCacheDirParam: filepath.Join(root, DoltDir, GitRemoteCacheDirName)})
+		db, vrw, _, err := CreateDB(ctx, types.Format_DOLT, urlStr, map[string]interface{}{GitCacheRootParam: filepath.Join(root, DoltDir, GitRemoteCacheDirName)})
 		require.NoError(t, err)
 		vs, ok := vrw.(*types.ValueStore)
 		require.True(t, ok, "expected ValueReadWriter to be *types.ValueStore, got %T", vrw)
@@ -385,7 +385,7 @@ func TestGitRemoteFactory_ReopenSeesOtherCacheRootsPush(t *testing.T) {
 	require.Equal(t, "cacheRootB\n", string(got.Data()))
 }
 
-func TestGitRemoteFactory_GitCacheDirParamUsedVerbatim(t *testing.T) {
+func TestGitRemoteFactory_GitCacheRootParamUsedVerbatim(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not found on PATH")
 	}
@@ -398,10 +398,10 @@ func TestGitRemoteFactory_GitCacheDirParamUsedVerbatim(t *testing.T) {
 	require.NoError(t, err)
 	urlStr := "git+file://" + filepath.ToSlash(remoteRepo.GitDir)
 
-	// GitCacheDirParam is used as the cache base verbatim: no .dolt/git-remote-cache
+	// GitCacheRootParam is used as the cache base verbatim: no .dolt/git-remote-cache
 	// is appended, so a non-Dolt embedder gets a clean cache location.
 	cacheDir := shortTempDir(t)
-	db, _, _, err := CreateDB(ctx, types.Format_DOLT, urlStr, map[string]interface{}{GitCacheDirParam: cacheDir})
+	db, _, _, err := CreateDB(ctx, types.Format_DOLT, urlStr, map[string]interface{}{GitCacheRootParam: cacheDir})
 	require.NoError(t, err)
 	require.NotNil(t, db)
 
@@ -418,5 +418,5 @@ func TestGitRemoteFactory_GitCacheDirParamUsedVerbatim(t *testing.T) {
 			}
 		}
 	}
-	require.True(t, found, "expected the cache repo directly under <git_cache_dir>/<hash>/repo.git")
+	require.True(t, found, "expected the cache repo directly under <git_cache_root>/<hash>/repo.git")
 }

--- a/go/libraries/doltcore/env/remotes.go
+++ b/go/libraries/doltcore/env/remotes.go
@@ -113,7 +113,7 @@ func (r *Remote) GetRemoteDB(ctx context.Context, nbf *types.NomsBinFormat, dial
 		params[dbfactory.GitRemoteNameParam] = r.Name
 		if p, ok := dialer.(dbfactory.GitCacheRootProvider); ok {
 			if root, ok := p.GitCacheRoot(); ok {
-				params[dbfactory.GitCacheRootParam] = root
+				params[dbfactory.GitCacheDirParam] = filepath.Join(root, dbfactory.DoltDir, dbfactory.GitRemoteCacheDirName)
 			}
 		}
 	}
@@ -134,7 +134,7 @@ func (r *Remote) Prepare(ctx context.Context, nbf *types.NomsBinFormat, dialer d
 		params[dbfactory.GitRemoteNameParam] = r.Name
 		if p, ok := dialer.(dbfactory.GitCacheRootProvider); ok {
 			if root, ok := p.GitCacheRoot(); ok {
-				params[dbfactory.GitCacheRootParam] = root
+				params[dbfactory.GitCacheDirParam] = filepath.Join(root, dbfactory.DoltDir, dbfactory.GitRemoteCacheDirName)
 			}
 		}
 	}
@@ -166,7 +166,7 @@ func (r *Remote) GetRemoteDBWithoutCaching(ctx context.Context, nbf *types.NomsB
 		params[dbfactory.GitRemoteNameParam] = r.Name
 		if p, ok := dialer.(dbfactory.GitCacheRootProvider); ok {
 			if root, ok := p.GitCacheRoot(); ok {
-				params[dbfactory.GitCacheRootParam] = root
+				params[dbfactory.GitCacheDirParam] = filepath.Join(root, dbfactory.DoltDir, dbfactory.GitRemoteCacheDirName)
 			}
 		}
 	}

--- a/go/libraries/doltcore/env/remotes.go
+++ b/go/libraries/doltcore/env/remotes.go
@@ -113,7 +113,7 @@ func (r *Remote) GetRemoteDB(ctx context.Context, nbf *types.NomsBinFormat, dial
 		params[dbfactory.GitRemoteNameParam] = r.Name
 		if p, ok := dialer.(dbfactory.GitCacheRootProvider); ok {
 			if root, ok := p.GitCacheRoot(); ok {
-				params[dbfactory.GitCacheDirParam] = filepath.Join(root, dbfactory.DoltDir, dbfactory.GitRemoteCacheDirName)
+				params[dbfactory.GitCacheRootParam] = filepath.Join(root, dbfactory.DoltDir, dbfactory.GitRemoteCacheDirName)
 			}
 		}
 	}
@@ -134,7 +134,7 @@ func (r *Remote) Prepare(ctx context.Context, nbf *types.NomsBinFormat, dialer d
 		params[dbfactory.GitRemoteNameParam] = r.Name
 		if p, ok := dialer.(dbfactory.GitCacheRootProvider); ok {
 			if root, ok := p.GitCacheRoot(); ok {
-				params[dbfactory.GitCacheDirParam] = filepath.Join(root, dbfactory.DoltDir, dbfactory.GitRemoteCacheDirName)
+				params[dbfactory.GitCacheRootParam] = filepath.Join(root, dbfactory.DoltDir, dbfactory.GitRemoteCacheDirName)
 			}
 		}
 	}
@@ -166,7 +166,7 @@ func (r *Remote) GetRemoteDBWithoutCaching(ctx context.Context, nbf *types.NomsB
 		params[dbfactory.GitRemoteNameParam] = r.Name
 		if p, ok := dialer.(dbfactory.GitCacheRootProvider); ok {
 			if root, ok := p.GitCacheRoot(); ok {
-				params[dbfactory.GitCacheDirParam] = filepath.Join(root, dbfactory.DoltDir, dbfactory.GitRemoteCacheDirName)
+				params[dbfactory.GitCacheRootParam] = filepath.Join(root, dbfactory.DoltDir, dbfactory.GitRemoteCacheDirName)
 			}
 		}
 	}


### PR DESCRIPTION
Enable DumboDB to use git* remotes, but under a different cache directory, that doesn't include `.dolt`