### PR TITLE
go/libraries/doltcore/env, sqle: handle duplicate database directories

### DIFF
--- a/go/libraries/doltcore/env/multi_repo_env.go
+++ b/go/libraries/doltcore/env/multi_repo_env.go
@@ -191,6 +191,8 @@ func multiEnvForConfigDirectoryEnv(ctx context.Context, config config.ReadWriteC
 	envSet := map[string]*DoltEnv{}
 	var openedEnvs []*DoltEnv
 
+	seenDbNames := make(map[string]string)
+
 	// Anything that looks like it has a dolt database belongs here.
 	if dEnv.HasDoltDataDir() && dbfactory.IsDatabaseInProgress(dEnv.FS) {
 		path, _ := dEnv.FS.Abs("")
@@ -213,6 +215,7 @@ func multiEnvForConfigDirectoryEnv(ctx context.Context, config config.ReadWriteC
 			}
 		}
 		envSet[dbName] = dEnv
+		seenDbNames[strings.ToLower(dbName)] = dbName
 		openedEnvs = append(openedEnvs, dEnv)
 	}
 
@@ -249,7 +252,14 @@ func multiEnvForConfigDirectoryEnv(ctx context.Context, config config.ReadWriteC
 			newEnv.DBLoadParams = maps.Clone(dbLoadParams)
 		}
 		if newEnv.Valid() {
-			envSet[dbfactory.DirToDBName(dir)] = newEnv
+			subDbName := dbfactory.DirToDBName(dir)
+			subDbNameLower := strings.ToLower(subDbName)
+			if existing, exists := seenDbNames[subDbNameLower]; exists {
+				WarnDuplicateDatabase(subDbName, existing, path)
+				return false
+			}
+			seenDbNames[subDbNameLower] = subDbName
+			envSet[subDbName] = newEnv
 			openedEnvs = append(openedEnvs, newEnv)
 		} else {
 			if cfgErr := newEnv.CfgLoadErr; cfgErr != nil {
@@ -403,6 +413,20 @@ func (mrEnv *MultiRepoEnv) GetFirstDatabase() string {
 	return currentDb
 }
 
+// WarnDuplicateDatabase emits a structured warning when a duplicate
+// database is detected and skipped.
+func WarnDuplicateDatabase(name, existing, path string) {
+	entry := logrus.WithFields(logrus.Fields{
+		"database":          name,
+		"existing_database": existing,
+	})
+	if path != "" {
+		entry.WithField("path", path).Warn("skipping duplicate database directory")
+		return
+	}
+	entry.Warn("skipping duplicate database")
+}
+
 func getRepoRootDir(path, pathSeparator string) string {
 	if pathSeparator != "/" {
 		path = strings.ReplaceAll(path, pathSeparator, "/")
@@ -421,7 +445,9 @@ func getRepoRootDir(path, pathSeparator string) string {
 		return ""
 	}
 
-	if tokens[len(tokens)-1] == dbfactory.DataDir && tokens[len(tokens)-2] == dbfactory.DoltDir {
+	// Strip trailing .dolt/noms directory tokens to locate the repository
+	// root folder name.
+	if len(tokens) >= 2 && tokens[len(tokens)-1] == dbfactory.DataDir && tokens[len(tokens)-2] == dbfactory.DoltDir {
 		tokens = tokens[:len(tokens)-2]
 	}
 

--- a/go/libraries/doltcore/env/multi_repo_env_test.go
+++ b/go/libraries/doltcore/env/multi_repo_env_test.go
@@ -258,3 +258,16 @@ func TestMultiEnvForDirectorySkipsOrphanedDatabase(t *testing.T) {
 		})
 	}
 }
+
+func TestMultiEnvDuplicateDatabaseName(t *testing.T) {
+	rootPath, hdp, envs := initMultiEnv(t, "TestMultiEnvDuplicateDatabaseName", []string{"main_db"})
+	dEnv := envs["main_db"]
+
+	_ = initRepoWithRelativePath(t, filepath.Join(rootPath, "main_db", "main_db"), hdp)
+
+	mrEnv, err := MultiEnvForDirectory(context.Background(), dEnv.FS, dEnv)
+	require.NoError(t, err)
+
+	assert.Len(t, mrEnv.envs, 1)
+	assert.Equal(t, dEnv, mrEnv.GetEnv("main_db"))
+}

--- a/go/libraries/doltcore/sqle/database_provider.go
+++ b/go/libraries/doltcore/sqle/database_provider.go
@@ -181,13 +181,15 @@ func NewDoltDatabaseProviderWithDatabases(defaultBranch string, fs filesys.Files
 	}
 
 	dbs := make(map[string]dsess.SqlDatabase, len(databases))
-	for _, db := range databases {
-		dbs[strings.ToLower(db.Name())] = db
-	}
-
 	dbLocations := make(map[string]filesys.Filesys, len(locations))
-	for i, dbLocation := range locations {
-		dbLocations[strings.ToLower(databases[i].Name())] = dbLocation
+	for i, db := range databases {
+		key := formatDbMapKeyName(db.Name())
+		if existing, exists := dbs[key]; exists {
+			env.WarnDuplicateDatabase(db.Name(), existing.Name(), "")
+			continue
+		}
+		dbs[key] = db
+		dbLocations[key] = locations[i]
 	}
 
 	funcs := make(map[string]sql.Function, len(dfunctions.DoltFunctions))
@@ -1020,6 +1022,9 @@ func (p *DoltDatabaseProvider) CloneDatabaseFromRemote(
 // pass true, while undrop (which restores from the stash) passes false.
 func (p *DoltDatabaseProvider) checkDatabaseNameAvailableLocked(name string, checkDisk bool) error {
 	key := formatDbMapKeyName(name)
+	if _, ok := p.databases[key]; ok {
+		return sql.ErrDatabaseExists.New(name)
+	}
 	if _, ok := p.deletingDatabases[key]; ok {
 		return sql.ErrDatabaseExists.New(name)
 	}
@@ -1269,10 +1274,6 @@ func (p *DoltDatabaseProvider) UndropDatabase(ctx *sql.Context, name string) (er
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if err = p.checkDatabaseNameAvailableLocked(name, false /* checkDisk */); err != nil {
-		return err
-	}
-
 	newFs, exactCaseName, err := p.droppedDatabaseManager.UndropDatabase(ctx, name)
 	if err != nil {
 		return err
@@ -1345,9 +1346,12 @@ func (p *DoltDatabaseProvider) registerNewDatabase(ctx *sql.Context, name string
 		return err
 	}
 
-	formattedName := formatDbMapKeyName(db.Name())
-	p.databases[formattedName] = sdb
-	p.dbLocations[formattedName] = newEnv.FS
+	key := formatDbMapKeyName(db.Name())
+	if _, exists := p.databases[key]; exists {
+		return sql.ErrDatabaseExists.New(name)
+	}
+	p.databases[key] = sdb
+	p.dbLocations[key] = newEnv.FS
 	return nil
 }
 

--- a/go/libraries/doltcore/sqle/database_provider_test.go
+++ b/go/libraries/doltcore/sqle/database_provider_test.go
@@ -453,3 +453,40 @@ func TestCreateDatabaseFailureLeavesNothingBehind(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, ok, "the retried database's table must be on disk in its own directory")
 }
+
+func TestDuplicateDatabaseNameSkipped(t *testing.T) {
+	ctx := context.Background()
+
+	dEnv1 := dtestutils.CreateTestEnvWithName("dupdb")
+	db1, err := NewDatabase(ctx, "dupdb", dEnv1.DbData(ctx), editor.Options{})
+	require.NoError(t, err)
+
+	dEnv2 := dtestutils.CreateTestEnvWithName("dupdb2")
+	db2, err := NewDatabase(ctx, "dupdb", dEnv2.DbData(ctx), editor.Options{})
+	require.NoError(t, err)
+
+	pro, err := NewDoltDatabaseProviderWithDatabases(
+		"main",
+		dEnv1.FS,
+		[]dsess.SqlDatabase{db1, db2},
+		[]filesys.Filesys{dEnv1.FS, dEnv2.FS},
+		sql.EngineOverrides{},
+	)
+	require.NoError(t, err)
+
+	config, _ := dEnv1.Config.GetConfig(env.GlobalConfig)
+	sqlCtx := NewTestSQLCtxWithProvider(ctx, pro, config, nil, nil)
+	dbs := pro.AllDatabases(sqlCtx)
+	assert.Len(t, dbs, 1)
+
+	db, err := pro.Database(sqlCtx, "dupdb")
+	require.NoError(t, err)
+	assert.Same(t, db1.GetDoltDB(), db.(Database).GetDoltDB())
+}
+
+func TestCloneDatabaseDuplicateNameRejected(t *testing.T) {
+	_, sqlCtx, pro, _ := newProviderEngine(t)
+	err := pro.CloneDatabaseFromRemote(sqlCtx, "DOLT", "main", "origin", "file:///nonexistent", -1, nil)
+	require.Error(t, err)
+	assert.True(t, sql.ErrDatabaseExists.Is(err))
+}

--- a/integration-tests/bats/sql-multi-db.bats
+++ b/integration-tests/bats/sql-multi-db.bats
@@ -129,3 +129,28 @@ seed_repos_with_tables_with_use_statements() {
         USE repo2;
         call dolt_fetch();" -r csv
 }
+
+@test "sql-multi-db: duplicate database directories are skipped with a warning and outer database is preserved" {
+    mkdir dupdb
+    (
+        cd dupdb
+        dolt init
+        dolt sql -q "CREATE TABLE outer_tbl (pk int primary key);"
+
+        mkdir dupdb
+        (
+            cd dupdb
+            dolt init
+            dolt sql -q "CREATE TABLE inner_tbl (pk int primary key);"
+        )
+
+        run dolt sql -r csv -q "SHOW DATABASES; SHOW TABLES;"
+        [ "$status" -eq 0 ]
+        [[ "$output" =~ "skipping duplicate database directory" ]] || false
+        [[ "$output" =~ "database=dupdb" ]] || false
+        [[ "$output" =~ "existing_database=dupdb" ]] || false
+
+        [[ "$output" =~ "outer_tbl" ]] || false
+        [[ ! "$output" =~ "inner_tbl" ]] || false
+    )
+}


### PR DESCRIPTION
Log warning to skip duplicate database folders when scanning for databases to prevent overwriting an existing database.
- Add shared warning helper that logs duplicate database.
- Check active databases before clone or create operations.
Fix dolthub/dolt#10143
Close dolthub/dolt#10678