### PR TITLE
Preserve raw JSON bytes on storage reads

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/dolthub/dolt-mcp v0.3.4
 	github.com/dolthub/eventsapi_schema v0.0.0-20260715220557-d9b4a1c6b4d4
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-mysql-server v0.20.1-0.20260827194013-baefbed57445
+	github.com/dolthub/go-mysql-server v0.20.1-0.20260827195059-69dc4447f79d
 	github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63
 	github.com/edsrzf/mmap-go v1.2.0
 	github.com/esote/minmaxheap v1.0.0

--- a/go/go.mod
+++ b/go/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/dolthub/dolt-mcp v0.3.4
 	github.com/dolthub/eventsapi_schema v0.0.0-20260715220557-d9b4a1c6b4d4
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-mysql-server v0.20.1-0.20260826232105-2476e46ebc77
+	github.com/dolthub/go-mysql-server v0.20.1-0.20260827194013-baefbed57445
 	github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63
 	github.com/edsrzf/mmap-go v1.2.0
 	github.com/esote/minmaxheap v1.0.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -219,6 +219,8 @@ github.com/dolthub/go-mysql-server v0.20.1-0.20260826232105-2476e46ebc77 h1:VW2z
 github.com/dolthub/go-mysql-server v0.20.1-0.20260826232105-2476e46ebc77/go.mod h1:7Z71DCeZPBuG92QTM7KvQbpWCeNGZEL7chOHuSD4TOo=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260827194013-baefbed57445 h1:k3Z3cjLp1+pC0A+MOAb3HR97JVYRIYaWro3vafqXPDk=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260827194013-baefbed57445/go.mod h1:7Z71DCeZPBuG92QTM7KvQbpWCeNGZEL7chOHuSD4TOo=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260827195059-69dc4447f79d h1:mJRLM6HPGku+Pj8qZe7O05RJbXJLKoxsB99PeqfU29M=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260827195059-69dc4447f79d/go.mod h1:7Z71DCeZPBuG92QTM7KvQbpWCeNGZEL7chOHuSD4TOo=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20260414231531-5f031e3e9037 h1:oIW9HwuWrhxv+4HZxA+QQSKHLqWFyXZ2FmNjUYwkdiM=

--- a/go/go.sum
+++ b/go/go.sum
@@ -217,6 +217,8 @@ github.com/dolthub/go-icu-regex v0.0.0-20260610153742-72563bc7ca83 h1:FEMjCGEroD
 github.com/dolthub/go-icu-regex v0.0.0-20260610153742-72563bc7ca83/go.mod h1:F3cnm+vMRK1HaU6+rNqQrOCyR03HHhR1GWG2gnPOqaE=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260826232105-2476e46ebc77 h1:VW2z70lyE+vvjNa20yAkkoLm13h9cJTa5LxlcMVnMOw=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260826232105-2476e46ebc77/go.mod h1:7Z71DCeZPBuG92QTM7KvQbpWCeNGZEL7chOHuSD4TOo=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260827194013-baefbed57445 h1:k3Z3cjLp1+pC0A+MOAb3HR97JVYRIYaWro3vafqXPDk=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260827194013-baefbed57445/go.mod h1:7Z71DCeZPBuG92QTM7KvQbpWCeNGZEL7chOHuSD4TOo=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20260414231531-5f031e3e9037 h1:oIW9HwuWrhxv+4HZxA+QQSKHLqWFyXZ2FmNjUYwkdiM=

--- a/go/store/prolly/tree/json_type_categories.go
+++ b/go/store/prolly/tree/json_type_categories.go
@@ -46,7 +46,7 @@ func getTypeCategoryOfValue(val interface{}) (jsonTypeCategory, error) {
 		return jsonTypeBoolean, nil
 	case string:
 		return jsonTypeString, nil
-	case *apd.Decimal, int8, int16, int32, int64, uint8, uint16, uint32, uint64, float32, float64:
+	case *apd.Decimal, apd.Decimal, int8, int16, int32, int64, uint8, uint16, uint32, uint64, float32, float64:
 		return jsonTypeNumber, nil
 	}
 	return 0, fmt.Errorf("expected json value, got %v", val)

--- a/go/store/prolly/tree/prolly_fields.go
+++ b/go/store/prolly/tree/prolly_fields.go
@@ -89,9 +89,7 @@ func GetField(ctx context.Context, td *val.TupleDesc, i int, tup val.Tuple, ns N
 		var buf []byte
 		buf, ok = td.GetJSON(i, tup)
 		if ok {
-			var doc types.JSONDocument
-			err = types.JsonUnmarshal(buf, &doc.Val)
-			v = doc
+			v = types.NewLazyJSONDocument(buf)
 		}
 	// GeometryEnc is no longer written by new columns, but could be used by older databases
 	case val.GeometryEnc:

--- a/go/store/prolly/tree/prolly_fields_test.go
+++ b/go/store/prolly/tree/prolly_fields_test.go
@@ -239,6 +239,51 @@ func testRoundTripProllyFields(t *testing.T, test prollyFieldTest) {
 
 }
 
+var benchmarkJSONFieldValue interface{}
+
+// BenchmarkJSONFieldReadPolicies measures normalized and exact decoding after tuple retrieval.
+func BenchmarkJSONFieldReadPolicies(b *testing.B) {
+	ctx := context.Background()
+	desc := val.NewTupleDescriptor(val.Type{Enc: val.JSONAddrEnc})
+	ns := NewTestNodeStore()
+	builder := val.NewTupleBuilder(desc, ns)
+	document := types.NewLazyJSONDocument([]byte(`{"id":42,"ratio":12345678901234567890.123456789,"items":[1.1,2.2,3.3,4.4]}`))
+	require.NoError(b, PutField(ctx, ns, builder, 0, document))
+	tuple, err := builder.Build(ctx, testPool)
+	require.NoError(b, err)
+
+	b.Run("mysql_normalized", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			field, err := GetField(ctx, desc, 0, tuple, ns)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchmarkJSONFieldValue, err = field.(sql.JSONWrapper).ToInterface(ctx)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("exact_decode_from_storage_bytes", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			field, err := GetField(ctx, desc, 0, tuple, ns)
+			if err != nil {
+				b.Fatal(err)
+			}
+			bytes, err := field.(types.JSONBytes).GetBytes(ctx)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if err = types.JsonUnmarshalPreserveNumberPrecision(bytes, &benchmarkJSONFieldValue); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
 func mustParseGeometryType(t *testing.T, s string) (v interface{}) {
 	// Determine type, and get data
 	geomType, data, _, err := spatial.ParseWKTHeader(s)


### PR DESCRIPTION
Keep stored JSON bytes available through lazy documents while preserving existing MySQL normalization through ToInterface. This lets PostgreSQL callers opt into exact numeric decoding without changing the default MySQL behavior.

Part of https://github.com/dolthub/doltgresql/issues/3099