### PR TITLE
argparser: fix panic on empty-string value for list options

### DIFF
--- a/go/libraries/utils/argparser/parser.go
+++ b/go/libraries/utils/argparser/parser.go
@@ -495,7 +495,6 @@ func getListValues(args []string) []string {
 	var values []string
 
 	for _, arg := range args {
-		// Stop if another option found
 		if arg == "--" || (arg != "" && arg[0] == '-') {
 			return values
 		}

--- a/go/libraries/utils/argparser/parser.go
+++ b/go/libraries/utils/argparser/parser.go
@@ -496,7 +496,7 @@ func getListValues(args []string) []string {
 
 	for _, arg := range args {
 		// Stop if another option found
-		if arg[0] == '-' || arg == "--" {
+		if arg == "--" || (arg != "" && arg[0] == '-') {
 			return values
 		}
 		values = append(values, arg)

--- a/go/libraries/utils/argparser/parser_test.go
+++ b/go/libraries/utils/argparser/parser_test.go
@@ -171,6 +171,27 @@ func TestArgParser(t *testing.T) {
 	}
 }
 
+func TestArgParserListEmptyValue(t *testing.T) {
+	// An empty-string value for a list option must not panic: getListValues
+	// indexed arg[0] without a length check, so `--list ""` (or `-l ""`)
+	// panicked with an index-out-of-range.
+	ap := NewArgParserWithVariableArgs("test").SupportsStringList("list", "l", "vals", "")
+
+	apr, err := ap.Parse([]string{"--list", ""})
+	require.NoError(t, err)
+	v, ok := apr.GetValue("list")
+	assert.True(t, ok)
+	assert.Equal(t, "", v)
+
+	// A subsequent option after the empty value still terminates the list.
+	ap2 := NewArgParserWithVariableArgs("test").
+		SupportsStringList("list", "l", "vals", "").
+		SupportsFlag("flag", "f", "flag")
+	apr2, err := ap2.Parse([]string{"-l", "", "-f"})
+	require.NoError(t, err)
+	assert.True(t, apr2.Contains("flag"))
+}
+
 func TestArgParserSet(t *testing.T) {
 	ap := createParserWithOptionalArgs()
 	apr, err := ap.Parse([]string{"-o", "optional value", "-f", "foo", "bar"})

--- a/go/libraries/utils/argparser/parser_test.go
+++ b/go/libraries/utils/argparser/parser_test.go
@@ -172,9 +172,6 @@ func TestArgParser(t *testing.T) {
 }
 
 func TestArgParserListEmptyValue(t *testing.T) {
-	// An empty-string value for a list option must not panic: getListValues
-	// indexed arg[0] without a length check, so `--list ""` (or `-l ""`)
-	// panicked with an index-out-of-range.
 	ap := NewArgParserWithVariableArgs("test").SupportsStringList("list", "l", "vals", "")
 
 	apr, err := ap.Parse([]string{"--list", ""})
@@ -183,7 +180,6 @@ func TestArgParserListEmptyValue(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, "", v)
 
-	// A subsequent option after the empty value still terminates the list.
 	ap2 := NewArgParserWithVariableArgs("test").
 		SupportsStringList("list", "l", "vals", "").
 		SupportsFlag("flag", "f", "flag")


### PR DESCRIPTION
Passing an empty string as the value of a list-valued option (e.g. `dolt log --not ""`, `dolt diff --include-cols ""`) no longer panics.
Close dolthub/dolt#11347