### PR TITLE
cmd/dolt: improve connection error reporting and stale server info cleanup

### DIFF
--- a/go/cmd/dolt/commands/sqlserver/creds.go
+++ b/go/cmd/dolt/commands/sqlserver/creds.go
@@ -20,8 +20,10 @@ import (
 	iofs "io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/google/uuid"
 
@@ -31,14 +33,16 @@ import (
 
 const ServerLocalCredsFile = "sql-server.info"
 
-// LocalCreds is a struct that contains information about how to access the
-// locally running server for a CLI process which wants to operate against a
-// database while a sql-server process is running. It contains the pid of the
-// process that created the lockfile, the port that the server is running on
-// and the password to be used connecting to the server.
+// ErrInvalidLockFileFormat indicates a malformed server info file.
+var ErrInvalidLockFileFormat = errors.New("invalid lock file format")
+
+// LocalCreds contains connection information for accessing a locally
+// running sql-server from a CLI process. It contains the pid of the
+// process that created the lockfile, the port the server listens on,
+// and the shared secret for local authentication.
 //
-// Pid is a legacy field which is retained for compatibility but no longer
-// influences the behavior of the running program(s).
+// Pid is used to detect server liveness and automatically clean up
+// stale credentials files when the server process has terminated.
 type LocalCreds struct {
 	Pid    int
 	Port   int
@@ -49,10 +53,15 @@ func NewLocalCreds(port int) *LocalCreds {
 	return &LocalCreds{os.Getpid(), port, uuid.New().String()}
 }
 
+// LocalCredsFilePath returns the server info file path.
+func LocalCredsFilePath() string {
+	return filepath.Join(dbfactory.DoltDir, ServerLocalCredsFile)
+}
+
 // Best effort attempt to remove local creds file persisted as the Filesys
 // rooted there.
 func RemoveLocalCreds(fs filesys.Filesys) {
-	credsFilePath, err := fs.Abs(filepath.Join(dbfactory.DoltDir, ServerLocalCredsFile))
+	credsFilePath, err := fs.Abs(LocalCredsFilePath())
 	if err != nil {
 		return
 	}
@@ -72,7 +81,7 @@ func WriteLocalCreds(fs filesys.Filesys, creds *LocalCreds) error {
 		return err
 	}
 
-	credsFile, err := fs.Abs(filepath.Join(dbfactory.DoltDir, ServerLocalCredsFile))
+	credsFile, err := fs.Abs(LocalCredsFilePath())
 	if err != nil {
 		return err
 	}
@@ -83,6 +92,37 @@ func WriteLocalCreds(fs filesys.Filesys, creds *LocalCreds) error {
 	}
 
 	return fs.WriteFile(credsFile, []byte(fmt.Sprintf("%d:%s:%s", creds.Pid, portStr, creds.Secret)), 0600)
+}
+
+// ProcessExists reports whether a process with pid is running.
+//
+// On Unix systems, [os.FindProcess] always succeeds without verifying
+// whether the process exists, so liveness is tested by sending
+// signal 0 via [os.Process.Signal].
+//
+// On Windows, [os.FindProcess] opens an OS handle that fails if the
+// process is dead; the handle is released immediately using
+// [os.Process.Release] to prevent handle leaks.
+func ProcessExists(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		_ = p.Release()
+		return true
+	}
+	err = p.Signal(syscall.Signal(0))
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, syscall.EPERM) {
+		return true
+	}
+	return false
 }
 
 // Starting at `fs`, look for the a ServerLocalCredsFile in the .dolt directory
@@ -99,7 +139,11 @@ func FindAndLoadLocalCreds(fs filesys.Filesys) (creds *LocalCreds, err error) {
 	for root != "" && root[len(root)-1] != filepath.Separator {
 		creds, err := LoadLocalCreds(fs)
 		if err == nil {
-			return creds, err
+			if !ProcessExists(creds.Pid) {
+				RemoveLocalCreds(fs)
+				return nil, nil
+			}
+			return creds, nil
 		}
 		// If we have an error that is not ErrNotExist, for example, a
 		// permission error opening the credentials file, or an error
@@ -121,7 +165,7 @@ func FindAndLoadLocalCreds(fs filesys.Filesys) (creds *LocalCreds, err error) {
 }
 
 func LoadLocalCreds(fs filesys.Filesys) (creds *LocalCreds, err error) {
-	rd, err := fs.OpenForRead(filepath.Join(dbfactory.DoltDir, ServerLocalCredsFile))
+	rd, err := fs.OpenForRead(LocalCredsFilePath())
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +181,7 @@ func LoadLocalCreds(fs filesys.Filesys) (creds *LocalCreds, err error) {
 
 	parts := strings.Split(data, ":")
 	if len(parts) != 3 {
-		return nil, errors.New("invalid lock file format")
+		return nil, ErrInvalidLockFileFormat
 	}
 
 	pid, err := strconv.Atoi(parts[0])

--- a/go/cmd/dolt/commands/sqlserver/creds.go
+++ b/go/cmd/dolt/commands/sqlserver/creds.go
@@ -20,10 +20,8 @@ import (
 	iofs "io/fs"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/google/uuid"
 
@@ -49,17 +47,21 @@ type LocalCreds struct {
 	Secret string
 }
 
+// NewLocalCreds initializes a new LocalCreds struct for a sql-server
+// listening on the given port, populated with the current process ID
+// and a newly generated authentication secret.
 func NewLocalCreds(port int) *LocalCreds {
 	return &LocalCreds{os.Getpid(), port, uuid.New().String()}
 }
 
-// LocalCredsFilePath returns the server info file path.
+// LocalCredsFilePath returns the relative path to the server info file
+// within the dbfactory.DoltDir.
 func LocalCredsFilePath() string {
 	return filepath.Join(dbfactory.DoltDir, ServerLocalCredsFile)
 }
 
-// Best effort attempt to remove local creds file persisted as the Filesys
-// rooted there.
+// RemoveLocalCreds makes a best-effort attempt to remove the server
+// info file from the provided |fs|.
 func RemoveLocalCreds(fs filesys.Filesys) {
 	credsFilePath, err := fs.Abs(LocalCredsFilePath())
 	if err != nil {
@@ -68,8 +70,8 @@ func RemoveLocalCreds(fs filesys.Filesys) {
 	_ = fs.Delete(credsFilePath, false)
 }
 
-// WriteLocalCreds writes a file containing the contents of LocalCreds to the
-// DoltDir rooted at the provided Filesys.
+// WriteLocalCreds writes a server info file containing the serialized
+// |creds| to the dbfactory.DoltDir of the provided |fs|.
 func WriteLocalCreds(fs filesys.Filesys, creds *LocalCreds) error {
 	// if the DoltDir doesn't exist, create it.
 	doltDir, err := fs.Abs(dbfactory.DoltDir)
@@ -94,43 +96,12 @@ func WriteLocalCreds(fs filesys.Filesys, creds *LocalCreds) error {
 	return fs.WriteFile(credsFile, []byte(fmt.Sprintf("%d:%s:%s", creds.Pid, portStr, creds.Secret)), 0600)
 }
 
-// ProcessExists reports whether a process with pid is running.
+// FindAndLoadLocalCreds traverses upward from |fs| to locate, parse, and
+// validate a server info file.
 //
-// On Unix systems, [os.FindProcess] always succeeds without verifying
-// whether the process exists, so liveness is tested by sending
-// signal 0 via [os.Process.Signal].
-//
-// On Windows, [os.FindProcess] opens an OS handle that fails if the
-// process is dead; the handle is released immediately using
-// [os.Process.Release] to prevent handle leaks.
-func ProcessExists(pid int) bool {
-	if pid <= 0 {
-		return false
-	}
-	p, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	if runtime.GOOS == "windows" {
-		_ = p.Release()
-		return true
-	}
-	err = p.Signal(syscall.Signal(0))
-	if err == nil {
-		return true
-	}
-	if errors.Is(err, syscall.EPERM) {
-		return true
-	}
-	return false
-}
-
-// Starting at `fs`, look for the a ServerLocalCredsFile in the .dolt directory
-// of this directory and every parent directory, until we find one. When we
-// find one, we return its contents if we can open and parse it successfully.
-// Otherwise, we return an error associated with attempting to read it. If we
-// do not find anything all the way up to the root of the filesystem, returns
-// `nil` *LocalCreds and a `nil` error.
+// If a credentials file is found but its recorded process is dead, the
+// stale file is removed automatically. If no valid credentials file is
+// found, nil is returned.
 func FindAndLoadLocalCreds(fs filesys.Filesys) (creds *LocalCreds, err error) {
 	root, err := fs.Abs(".")
 	if err != nil {
@@ -164,6 +135,8 @@ func FindAndLoadLocalCreds(fs filesys.Filesys) (creds *LocalCreds, err error) {
 	return nil, nil
 }
 
+// LoadLocalCreds reads and parses the server info file from the
+// dbfactory.DoltDir directory of the given |fs|.
 func LoadLocalCreds(fs filesys.Filesys) (creds *LocalCreds, err error) {
 	rd, err := fs.OpenForRead(LocalCredsFilePath())
 	if err != nil {

--- a/go/cmd/dolt/commands/sqlserver/creds_test.go
+++ b/go/cmd/dolt/commands/sqlserver/creds_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlserver
+
+import (
+	iofs "io/fs"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/libraries/utils/filesys"
+)
+
+func getDeadPID(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("go", "version")
+	require.NoError(t, cmd.Start())
+	pid := cmd.Process.Pid
+	require.NoError(t, cmd.Wait())
+	return pid
+}
+
+func TestProcessExists(t *testing.T) {
+	require.True(t, ProcessExists(os.Getpid()))
+	require.False(t, ProcessExists(-1))
+	require.False(t, ProcessExists(0))
+
+	deadPID := getDeadPID(t)
+	require.False(t, ProcessExists(deadPID))
+}
+
+func TestFindAndLoadLocalCredsStaleCleanup(t *testing.T) {
+	fs := filesys.EmptyInMemFS(t.TempDir())
+	deadPID := getDeadPID(t)
+	staleCreds := &LocalCreds{Pid: deadPID, Port: 3306, Secret: "secret"}
+	err := WriteLocalCreds(fs, staleCreds)
+	require.NoError(t, err)
+
+	// Dead PID credentials should be cleaned up automatically.
+	creds, err := FindAndLoadLocalCreds(fs)
+	require.NoError(t, err)
+	require.Nil(t, creds)
+
+	// Verify file was deleted.
+	_, err = LoadLocalCreds(fs)
+	require.Error(t, err)
+	require.ErrorIs(t, err, iofs.ErrNotExist)
+
+	// Subsequent lookup cleanly succeeds with nil creds (recovered).
+	creds, err = FindAndLoadLocalCreds(fs)
+	require.NoError(t, err)
+	require.Nil(t, creds)
+}
+
+func TestFindAndLoadLocalCredsLivePID(t *testing.T) {
+	fs := filesys.EmptyInMemFS(t.TempDir())
+	liveCreds := &LocalCreds{Pid: os.Getpid(), Port: 3306, Secret: "secret"}
+	err := WriteLocalCreds(fs, liveCreds)
+	require.NoError(t, err)
+
+	creds, err := FindAndLoadLocalCreds(fs)
+	require.NoError(t, err)
+	require.NotNil(t, creds)
+	require.Equal(t, liveCreds.Pid, creds.Pid)
+	require.Equal(t, liveCreds.Port, creds.Port)
+	require.Equal(t, liveCreds.Secret, creds.Secret)
+}
+
+func TestLoadLocalCredsInvalidFormat(t *testing.T) {
+	fs := filesys.EmptyInMemFS(t.TempDir())
+	filePath, err := fs.Abs(LocalCredsFilePath())
+	require.NoError(t, err)
+	err = fs.WriteFile(filePath, []byte("invalid:format"), 0600)
+	require.NoError(t, err)
+
+	_, err = LoadLocalCreds(fs)
+	require.ErrorIs(t, err, ErrInvalidLockFileFormat)
+}

--- a/go/cmd/dolt/commands/sqlserver/process.go
+++ b/go/cmd/dolt/commands/sqlserver/process.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package sqlserver
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// ProcessExists reports whether a process with pid is running.
+//
+// As documented by [os.FindProcess], on Unix systems FindProcess
+// constructs an [os.Process] struct without verifying existence.
+// Liveness is tested by sending signal 0 via [os.Process.Signal]
+// using the [POSIX.1-2017 kill] convention.
+//
+// [POSIX.1-2017 kill]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/kill.html
+func ProcessExists(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = p.Signal(syscall.Signal(0))
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, syscall.EPERM) {
+		return true
+	}
+	return false
+}

--- a/go/cmd/dolt/commands/sqlserver/process_windows.go
+++ b/go/cmd/dolt/commands/sqlserver/process_windows.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package sqlserver
+
+import (
+	"os"
+)
+
+// ProcessExists reports whether a process with pid is running.
+//
+// On Windows, [os.FindProcess] invokes the Win32 [OpenProcess] API.
+// If the process does not exist, OpenProcess fails. If it succeeds,
+// [os.Process.Release] must be called to close the handle via
+// [CloseHandle] and avoid leaking kernel resources per Microsoft
+// documentation.
+//
+// [CloseHandle]: https://learn.microsoft.com/windows/win32/api/handleapi/nf-handleapi-closehandle
+// [OpenProcess]: https://learn.microsoft.com/windows/win32/api/processthreadsapi/nf-processthreadsapi-openprocess
+// [os.FindProcess]: https://go.dev/src/os/exec_windows.go
+func ProcessExists(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	_ = p.Release()
+	return true
+}

--- a/go/cmd/dolt/commands/sqlserver/queryist_utils.go
+++ b/go/cmd/dolt/commands/sqlserver/queryist_utils.go
@@ -104,6 +104,11 @@ func BuildConnectionStringQueryist(_ context.Context, cwdFS filesys.Filesys, cre
 	queryist := ConnectionQueryist{connection: conn, gatherWarnings: &gatherWarnings}
 
 	var lateBind cli.LateBindQueryist = func(ctx context.Context, opts ...cli.LateBindQueryistOption) (res cli.LateBindQueryistResult, err error) {
+		if err := conn.DB.PingContext(ctx); err != nil {
+			_ = conn.Close()
+			return res, fmt.Errorf("failed to connect to the dolt sql-server at %s:%d: %w", host, port, err)
+		}
+
 		sqlCtx := sql.NewContext(ctx)
 		sqlCtx.SetCurrentDatabase(dbRev)
 

--- a/go/cmd/dolt/commands/sqlserver/queryist_utils.go
+++ b/go/cmd/dolt/commands/sqlserver/queryist_utils.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/tls"
 	sql2 "database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -63,11 +64,19 @@ const (
 	QueryistTLSMode_NoVerify_FallbackToPlaintext
 )
 
-// BuildConnectionStringQueryist returns a [cli.LateBindQueryist] that opens a connection to the
-// server at |host|:|port| using |creds| and |tlsMode|, and selects |dbRev| as the default
-// database. |configName| and |configEmail| are used as the commit identity when the client
-// connects over a loopback address; non-loopback connections read the identity from
-// CURRENT_USER() so the grant host matches whatever the server assigned.
+// ErrServerConnectionFailed is returned when the late-binding
+// queryist fails to connect to the sql-server.
+var ErrServerConnectionFailed = errors.New("failed to connect to the dolt sql-server")
+
+// BuildConnectionStringQueryist returns a [cli.LateBindQueryist]
+// that opens a connection to the server at |host|:|port| using
+// |creds| and |tlsMode|, and selects |dbRev| as the default
+// database.
+//
+// |configName| and |configEmail| are used as the commit identity
+// when the client connects over a loopback address. Non-loopback
+// connections read the identity from CURRENT_USER() so the grant
+// host matches whatever the server assigned.
 func BuildConnectionStringQueryist(_ context.Context, cwdFS filesys.Filesys, creds *cli.UserPassword, apr *argparser.ArgParseResults, host string, port int, tlsMode QueryistTLSMode, dbRev string, configName, configEmail string) (cli.LateBindQueryist, error) {
 	clientConfig, err := GetClientConfig(cwdFS, creds, apr)
 	if err != nil {
@@ -106,7 +115,7 @@ func BuildConnectionStringQueryist(_ context.Context, cwdFS filesys.Filesys, cre
 	var lateBind cli.LateBindQueryist = func(ctx context.Context, opts ...cli.LateBindQueryistOption) (res cli.LateBindQueryistResult, err error) {
 		if err := conn.DB.PingContext(ctx); err != nil {
 			_ = conn.Close()
-			return res, fmt.Errorf("failed to connect to the dolt sql-server at %s:%d: %w", host, port, err)
+			return res, fmt.Errorf("%w at %s:%d: %w", ErrServerConnectionFailed, host, port, err)
 		}
 
 		sqlCtx := sql.NewContext(ctx)

--- a/go/cmd/dolt/commands/sqlserver/queryist_utils_test.go
+++ b/go/cmd/dolt/commands/sqlserver/queryist_utils_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlserver
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/cmd/dolt/cli"
+	"github.com/dolthub/dolt/go/libraries/utils/argparser"
+	"github.com/dolthub/dolt/go/libraries/utils/filesys"
+)
+
+func getRefusedPort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+	return port
+}
+
+func TestBuildConnectionStringQueryistNamesTargetOnConnectFailure(t *testing.T) {
+	port := getRefusedPort(t)
+
+	tests := []struct {
+		name string
+		host string
+	}{
+		{
+			name: "ipv4 loopback",
+			host: "127.0.0.1",
+		},
+		{
+			name: "localhost",
+			host: "localhost",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := filesys.EmptyInMemFS(t.TempDir())
+			creds := &cli.UserPassword{Username: "root", Password: "", Specified: false}
+			apr := argparser.NewEmptyResults()
+
+			lateBind, err := BuildConnectionStringQueryist(context.Background(), fs, creds, apr,
+				tc.host, port, QueryistTLSMode_Disabled, "mydb", "Test User", "test@test.com")
+			require.NoError(t, err)
+
+			_, err = lateBind(context.Background())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "failed to connect to the dolt sql-server at "+tc.host+":"+strconv.Itoa(port))
+		})
+	}
+}

--- a/go/cmd/dolt/commands/sqlserver/queryist_utils_test.go
+++ b/go/cmd/dolt/commands/sqlserver/queryist_utils_test.go
@@ -65,6 +65,7 @@ func TestBuildConnectionStringQueryistNamesTargetOnConnectFailure(t *testing.T) 
 
 			_, err = lateBind(context.Background())
 			require.Error(t, err)
+			require.ErrorIs(t, err, ErrServerConnectionFailed)
 			require.Contains(t, err.Error(), "failed to connect to the dolt sql-server at "+tc.host+":"+strconv.Itoa(port))
 		})
 	}

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -1077,7 +1077,6 @@ func (h *heartbeatService) Run(ctx context.Context) {
 
 var _ svcs.Service = &heartbeatService{}
 
-
 // remotesapiAuth facilitates the implementation remotesrv.AccessControl for the remotesapi server.
 type remotesapiAuth struct {
 	// ctxFactory is a function that returns a new sql.Context. This will create a new context every time it is called,

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -219,18 +219,7 @@ func ConfigureServices(
 	}
 	controller.Register(AssertNoDatabasesInAccessModeReadOnly)
 
-	var localCreds *LocalCreds
-	InitServerLocalCreds := &svcs.AnonService{
-		InitF: func(context.Context) (err error) {
-			localCreds, err = persistServerLocalCreds(cfg.ServerConfig.Port(), cfg.DoltEnv)
-			return err
-		},
-		StopF: func(_ svcs.RunState) error {
-			RemoveLocalCreds(cfg.DoltEnv.FS)
-			return nil
-		},
-	}
-	controller.Register(InitServerLocalCreds)
+	localCreds := NewLocalCreds(cfg.ServerConfig.Port())
 
 	// Persist any system variables that have a non-deterministic default value (i.e. @@server_uuid)
 	// We only do this on sql-server startup initially since we want to keep the persisted server_uuid
@@ -920,6 +909,16 @@ func ConfigureServices(
 		},
 	}
 	controller.Register(InitSQLServer)
+	InitServerLocalCreds := &svcs.AnonService{
+		InitF: func(context.Context) (err error) {
+			return WriteLocalCreds(cfg.DoltEnv.FS, localCreds)
+		},
+		StopF: func(_ svcs.RunState) error {
+			RemoveLocalCreds(cfg.DoltEnv.FS)
+			return nil
+		},
+	}
+	controller.Register(InitServerLocalCreds)
 
 	// Automatically restart binlog replication if replication was enabled when the server was last shut down
 	AutoStartBinlogReplica := &svcs.AnonService{
@@ -1078,14 +1077,6 @@ func (h *heartbeatService) Run(ctx context.Context) {
 
 var _ svcs.Service = &heartbeatService{}
 
-func persistServerLocalCreds(port int, dEnv *env.DoltEnv) (*LocalCreds, error) {
-	creds := NewLocalCreds(port)
-	err := WriteLocalCreds(dEnv.FS, creds)
-	if err != nil {
-		return nil, err
-	}
-	return creds, err
-}
 
 // remotesapiAuth facilitates the implementation remotesrv.AccessControl for the remotesapi server.
 type remotesapiAuth struct {

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -795,7 +795,21 @@ If you're interested in running this command against a remote host, hit us up on
 			}
 			doltConfigName := targetEnv.Config.GetStringOrDefault(config.UserNameKey, env.DefaultName)
 			doltConfigEmail := targetEnv.Config.GetStringOrDefault(config.UserEmailKey, env.DefaultEmail)
-			return sqlserver.BuildConnectionStringQueryist(ctx, cwdFS, creds, apr, "localhost", localCreds.Port, sqlserver.QueryistTLSMode_NoVerify_FallbackToPlaintext, useDb, doltConfigName, doltConfigEmail)
+			lateBind, err := sqlserver.BuildConnectionStringQueryist(ctx, cwdFS, creds, apr, "localhost", localCreds.Port, sqlserver.QueryistTLSMode_NoVerify_FallbackToPlaintext, useDb, doltConfigName, doltConfigEmail)
+			if err != nil {
+				return nil, err
+			}
+			// Connection target came from server info file, so connection
+			// failure explains lock contention and recovery steps.
+			credsFile := sqlserver.LocalCredsFilePath()
+			var withContext cli.LateBindQueryist = func(ctx context.Context, opts ...cli.LateBindQueryistOption) (cli.LateBindQueryistResult, error) {
+				res, err := lateBind(ctx, opts...)
+				if err != nil {
+					return res, fmt.Errorf("database locked; connecting to sql-server on port %d (%s) failed (retry if starting, or delete %s if stale): %w", localCreds.Port, credsFile, credsFile, err)
+				}
+				return res, nil
+			}
+			return withContext, nil
 		}
 	}
 

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -799,15 +799,13 @@ If you're interested in running this command against a remote host, hit us up on
 			if err != nil {
 				return nil, err
 			}
-			// Connection target came from server info file, so connection
-			// failure explains lock contention and recovery steps.
-			credsFile := sqlserver.LocalCredsFilePath()
 			var withContext cli.LateBindQueryist = func(ctx context.Context, opts ...cli.LateBindQueryistOption) (cli.LateBindQueryistResult, error) {
 				res, err := lateBind(ctx, opts...)
-				if err != nil {
+				if errors.Is(err, sqlserver.ErrServerConnectionFailed) {
+					credsFile := sqlserver.LocalCredsFilePath()
 					return res, fmt.Errorf("database locked; connecting to sql-server on port %d (%s) failed (retry if starting, or delete %s if stale): %w", localCreds.Port, credsFile, credsFile, err)
 				}
-				return res, nil
+				return res, err
 			}
 			return withContext, nil
 		}


### PR DESCRIPTION
CLI commands cleanup stale `.dolt/sql-server.info` files left by crashed servers and recover locally, while connection failures provide troubleshooting steps.
- `creds.go`: Add `ProcessExists`.
- `server.go`: Writing `.dolt/sql-server.info` is deferred until after `InitSQLServer` binds the listener.
- `queryist_utils.go`: `PingContext` checks connectivity early and closes `conn` on dial failure.
Fix dolthub/dolt#10856 
Close dolthub/dolt#11474