### PR TITLE
fix: push git-remote info branch outside refs/heads/ (Fixes #11648)

### DIFF
--- a/go/store/blobstore/git_blobstore.go
+++ b/go/store/blobstore/git_blobstore.go
@@ -829,8 +829,16 @@ func (gbs *GitBlobstore) pushInfoBranch(ctx context.Context, headOID git.OID) {
 		return
 	}
 
-	infoRef := "refs/heads/" + gbs.infoBranch
-	localInfoRef := "refs/dolt/info/" + gbs.infoBranch
+	// Push the info branch outside refs/heads/ so it is not swept into every
+	// consumer's default `git fetch` (+refs/heads/*:refs/remotes/origin/*).
+	// Keeping it under refs/dolt/info/ mirrors the local ref name and the
+	// refs/dolt/data layout: it stays visible in `git ls-remote` and forge ref
+	// browsers, but no longer collides with concurrent fetches. Landing this
+	// high-churn, force-pushed ref under refs/heads/ made overlapping fetches in
+	// the same clone race git's compare-and-swap and fail with
+	// "incorrect old value provided", aborting `git fetch` with a non-zero exit.
+	infoRef := "refs/dolt/info/" + gbs.infoBranch
+	localInfoRef := infoRef
 
 	content := formatDoltRemoteInfo(gbs.remoteRef, headOID, time.Now())
 

--- a/go/store/blobstore/git_blobstore_info_branch_test.go
+++ b/go/store/blobstore/git_blobstore_info_branch_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	git "github.com/dolthub/dolt/go/store/blobstore/internal/git"
+	"github.com/dolthub/dolt/go/store/testutils/gitrepo"
+)
+
+// The info branch is force-pushed on every data write. It must NOT land under
+// refs/heads/, or the default fetch refspec (+refs/heads/*:refs/remotes/origin/*)
+// sweeps this high-churn ref into every consumer's `git fetch`, where concurrent
+// fetches race git's compare-and-swap and fail with "incorrect old value
+// provided". It must land under refs/dolt/info/ instead (still visible in
+// `git ls-remote`, but not fetched by default). See dolthub/dolt#11648.
+func TestGitBlobstore_InfoBranch_PushedOutsideRefsHeads(t *testing.T) {
+	requireGitOnPath(t)
+
+	ctx := context.Background()
+	remoteRepo, localRepo, _ := newRemoteAndLocalRepos(t, ctx)
+	_, err := remoteRepo.SetRefToTree(ctx, DoltDataRef, nil, "seed empty")
+	require.NoError(t, err)
+
+	bs, err := NewGitBlobstoreWithOptions(localRepo.GitDir, DoltDataRef, GitBlobstoreOptions{
+		RemoteName: "origin",
+		Identity:   testIdentity(),
+		InfoBranch: DefaultInfoBranch,
+	})
+	require.NoError(t, err)
+
+	// A data write + manifest flush triggers the best-effort info-branch push.
+	_, err = PutBytes(ctx, bs, "k", []byte("v\n"))
+	require.NoError(t, err)
+	_, err = bs.CheckAndPutManifest(ctx, "", []byte("manifest\n"))
+	require.NoError(t, err)
+
+	remoteRunner, err := git.NewRunner(remoteRepo.GitDir)
+	require.NoError(t, err)
+
+	// The info ref must exist under refs/dolt/info/ ...
+	infoRefName := "refs/dolt/info/" + DefaultInfoBranch
+	out, err := remoteRunner.Run(ctx, git.RunOptions{}, "show-ref", "--verify", infoRefName)
+	require.NoError(t, err, "info ref %s should exist on the remote; show-ref out=%q", infoRefName, string(out))
+	require.Contains(t, string(out), infoRefName)
+
+	// ... and must NOT exist under refs/heads/ (where default fetch would sweep it).
+	headsRefName := "refs/heads/" + DefaultInfoBranch
+	_, err = remoteRunner.Run(ctx, git.RunOptions{}, "show-ref", "--verify", "--quiet", headsRefName)
+	require.Error(t, err, "info branch must not be published under %s", headsRefName)
+
+	// No branch should have leaked under refs/heads/ at all from the info push.
+	branches, err := remoteRunner.Run(ctx, git.RunOptions{}, "for-each-ref", "--format=%(refname)", "refs/heads/")
+	require.NoError(t, err)
+	require.NotContains(t, string(branches), DefaultInfoBranch,
+		"no refs/heads/ ref should carry the info branch name")
+}
+
+// A default `git clone` + `git fetch` of the remote must succeed without pulling
+// the info branch into refs/remotes/origin/ (it lives outside refs/heads/), so
+// the concurrent-fetch race on that ref cannot occur.
+func TestGitBlobstore_InfoBranch_NotFetchedByDefault(t *testing.T) {
+	requireGitOnPath(t)
+
+	ctx := context.Background()
+	remoteRepo, localRepo, _ := newRemoteAndLocalRepos(t, ctx)
+	_, err := remoteRepo.SetRefToTree(ctx, DoltDataRef, nil, "seed empty")
+	require.NoError(t, err)
+
+	bs, err := NewGitBlobstoreWithOptions(localRepo.GitDir, DoltDataRef, GitBlobstoreOptions{
+		RemoteName: "origin",
+		Identity:   testIdentity(),
+		InfoBranch: DefaultInfoBranch,
+	})
+	require.NoError(t, err)
+	_, err = PutBytes(ctx, bs, "k", []byte("v\n"))
+	require.NoError(t, err)
+	_, err = bs.CheckAndPutManifest(ctx, "", []byte("manifest\n"))
+	require.NoError(t, err)
+
+	// Fresh bare clone of the remote, then a default fetch.
+	consumerRepo, err := gitrepo.InitBare(ctx, t.TempDir()+"/consumer.git")
+	require.NoError(t, err)
+	consumerRunner, err := git.NewRunner(consumerRepo.GitDir)
+	require.NoError(t, err)
+	_, err = consumerRunner.Run(ctx, git.RunOptions{}, "remote", "add", "origin", remoteRepo.GitDir)
+	require.NoError(t, err)
+	_, err = consumerRunner.Run(ctx, git.RunOptions{}, "fetch", "origin")
+	require.NoError(t, err, "default fetch of a remote with an info branch should succeed")
+
+	// The info branch must not have been swept into refs/remotes/origin/.
+	tracking, err := consumerRunner.Run(ctx, git.RunOptions{}, "for-each-ref", "--format=%(refname)", "refs/remotes/")
+	require.NoError(t, err)
+	require.NotContains(t, string(tracking), DefaultInfoBranch,
+		"info branch should not be fetched into refs/remotes/origin/ by default")
+}


### PR DESCRIPTION
## Summary

`pushInfoBranch` (`go/store/blobstore/git_blobstore.go`) force-pushes the info branch to `refs/heads/<name>` on **every data write**. Because it lands under `refs/heads/`, the default fetch refspec `+refs/heads/*:refs/remotes/origin/*` sweeps it into **every** bare `git fetch` by every consumer of the repository — including people who have no idea Dolt is involved.

Since it is force-pushed on every write, it is the highest-churn ref in the repo. Git updates each remote-tracking ref with a compare-and-swap whose expected-old-value is read when the fetch begins, so two fetches overlapping in the same clone race it and the loser gets:

```
error: fetching ref refs/remotes/origin/__dolt_remote_info__ failed: incorrect old value provided
```

and `git fetch` **exits non-zero** — for a ref that has nothing to do with the consumer's work. This is the failure mode reported in #11648.

## Fix

Push the info branch to `refs/dolt/info/<name>` instead of `refs/heads/<name>`. That is already the local ref name in `pushInfoBranch`, so the remote layout simply becomes symmetric with the local one and with `refs/dolt/data`. It keeps the visibility goal of #10525 — the ref still shows in `git ls-remote` and forge ref browsers — but it is no longer fetched by default and no longer collides with concurrent fetches.

The info branch is write-only on Dolt's side (only `pushInfoBranch` touches it; nothing reads it back from `refs/heads/`), so moving the push target is safe.

Fixes #11648.

## Testing

Added `go/store/blobstore/git_blobstore_info_branch_test.go` (real git, mirrors the existing `requireGitOnPath` / `newRemoteAndLocalRepos` harness):

- `TestGitBlobstore_InfoBranch_PushedOutsideRefsHeads` — after a data write + manifest flush, the info ref exists on the remote under `refs/dolt/info/__dolt_remote_info__` and **not** under `refs/heads/`.
- `TestGitBlobstore_InfoBranch_NotFetchedByDefault` — a fresh clone doing a default `git fetch origin` succeeds and does **not** pull the info branch into `refs/remotes/origin/`.

Both fail before the change and pass after (verified by reverting the one-line fix):

```
# before the fix
--- FAIL: TestGitBlobstore_InfoBranch_PushedOutsideRefsHeads
    info ref refs/dolt/info/__dolt_remote_info__ should exist on the remote; ... 'not a valid ref'
--- FAIL: TestGitBlobstore_InfoBranch_NotFetchedByDefault
    info branch should not be fetched into refs/remotes/origin/ by default

# after the fix
ok  github.com/dolthub/dolt/go/store/blobstore
```

Full package: `go test ./store/blobstore/` — `ok` (12.3s). `gofmt` and `go vet ./store/blobstore/` clean. Verified locally with Go 1.26.

---

First-time contributor here. The issue also suggested an alternative (letting `DOLT_REMOTE_INFO_BRANCH` accept a full `refs/...` path); I went with moving the default because it fixes every existing deployment without operator action, but happy to adjust if you'd prefer the opt-in shape or a migration note for remotes that already carry the old `refs/heads/` branch.
