### PR TITLE
store/val: return error on malformed adaptive value

### DIFF
--- a/go/store/prolly/tree/blob_builder_test.go
+++ b/go/store/prolly/tree/blob_builder_test.go
@@ -499,6 +499,13 @@ func mustOOBAddr(t *testing.T, v val.AdaptiveValue) hash.Hash {
 	return addr
 }
 
+func mustNewOutOfBandValue(t *testing.T, ctx context.Context, vs val.ValueStore, data []byte) val.AdaptiveValue {
+	t.Helper()
+	v, err := val.NewOutOfBandAdaptiveValue(ctx, vs, data)
+	require.NoError(t, err)
+	return v
+}
+
 // TestCompareAdaptiveValueStreamsChunks verifies that comparing two out-of-band AdaptiveValues
 // through TupleDesc.Comparator returns the correct ordering and stops loading nodes once the
 // ordering is decided. The streaming path is the entire reason this test exists; if it were
@@ -531,10 +538,8 @@ func TestCompareAdaptiveValueStreamsChunks(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			cns := &countingNodeStore{NodeStore: NewTestNodeStore()}
-			lVal, err := val.NewOutOfBandAdaptiveValue(ctx, cns, c.l)
-			require.NoError(t, err)
-			rVal, err := val.NewOutOfBandAdaptiveValue(ctx, cns, c.r)
-			require.NoError(t, err)
+			lVal := mustNewOutOfBandValue(t, ctx, cns, c.l)
+			rVal := mustNewOutOfBandValue(t, ctx, cns, c.r)
 
 			td := val.NewTupleDescriptorWithArgs(
 				val.TupleDescriptorArgs{ValueStore: cns},
@@ -604,10 +609,8 @@ func TestCompareAdaptiveTextWithCollation(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ns := NewTestNodeStore()
-			lVal, err := val.NewOutOfBandAdaptiveValue(ctx, ns, []byte(c.l))
-			require.NoError(t, err)
-			rVal, err := val.NewOutOfBandAdaptiveValue(ctx, ns, []byte(c.r))
-			require.NoError(t, err)
+			lVal := mustNewOutOfBandValue(t, ctx, ns, []byte(c.l))
+			rVal := mustNewOutOfBandValue(t, ctx, ns, []byte(c.r))
 
 			cmp := schema.CollationTupleComparator{
 				Collations: []sql.CollationID{c.collation},
@@ -627,4 +630,58 @@ func getBlobValues(msg serial.Message) []byte {
 		panic(err)
 	}
 	return b.PayloadBytes()
+}
+
+func TestCompareAdaptiveValueMalformedAddress(t *testing.T) {
+	ctx := context.Background()
+	ns := NewTestNodeStore()
+
+	validVal := mustNewOutOfBandValue(t, ctx, ns, []byte("valid out-of-band content"))
+	td := val.NewTupleDescriptorWithArgs(
+		val.TupleDescriptorArgs{ValueStore: ns},
+		val.Type{Enc: val.BytesAdaptiveEnc},
+	)
+	collCmp := schema.CollationTupleComparator{
+		Collations: []sql.CollationID{sql.Collation_utf8mb4_0900_ai_ci},
+	}.WithValueStore(ns).Validated([]val.Type{{Enc: val.StringAdaptiveEnc}})
+
+	testCases := []struct {
+		name        string
+		data        []byte
+		expectedErr error
+	}{
+		{"3-byte tail", []byte{0x15, 0x01, 0x02, 0x03}, val.ErrInvalidAddressLen},
+		{"19-byte tail", append([]byte{0x15}, make([]byte, 19)...), val.ErrInvalidAddressLen},
+		{"21-byte tail", append([]byte{0x15}, make([]byte, 21)...), val.ErrInvalidAddressLen},
+	}
+
+	comparators := []struct {
+		name string
+		cmp  func(l, r val.AdaptiveValue) error
+	}{
+		{"bytes cmp left-valid", func(l, r val.AdaptiveValue) error {
+			_, err := td.Comparator().CompareValues(ctx, 0, l, r, val.Type{Enc: val.BytesAdaptiveEnc})
+			return err
+		}},
+		{"bytes cmp left-corrupt", func(l, r val.AdaptiveValue) error {
+			_, err := td.Comparator().CompareValues(ctx, 0, r, l, val.Type{Enc: val.BytesAdaptiveEnc})
+			return err
+		}},
+		{"collated cmp", func(l, r val.AdaptiveValue) error {
+			_, err := collCmp.CompareValues(ctx, 0, l, r, val.Type{Enc: val.StringAdaptiveEnc})
+			return err
+		}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mVal := val.AdaptiveValue(tc.data)
+			for _, c := range comparators {
+				t.Run(c.name, func(t *testing.T) {
+					err := c.cmp(validVal, mVal)
+					assert.ErrorIs(t, err, tc.expectedErr)
+				})
+			}
+		})
+	}
 }

--- a/go/store/prolly/tree/blob_builder_test.go
+++ b/go/store/prolly/tree/blob_builder_test.go
@@ -632,11 +632,14 @@ func getBlobValues(msg serial.Message) []byte {
 	return b.PayloadBytes()
 }
 
-func TestCompareAdaptiveValueMalformedAddress(t *testing.T) {
+func TestCompareAdaptiveValue_MalformedAndMismatchedAddress(t *testing.T) {
 	ctx := context.Background()
 	ns := NewTestNodeStore()
 
 	validVal := mustNewOutOfBandValue(t, ctx, ns, []byte("valid out-of-band content"))
+	validAddr, err := validVal.OutOfBandAddr()
+	require.NoError(t, err)
+
 	td := val.NewTupleDescriptorWithArgs(
 		val.TupleDescriptorArgs{ValueStore: ns},
 		val.Type{Enc: val.BytesAdaptiveEnc},
@@ -653,6 +656,8 @@ func TestCompareAdaptiveValueMalformedAddress(t *testing.T) {
 		{"3-byte tail", []byte{0x15, 0x01, 0x02, 0x03}, val.ErrInvalidAddressLen},
 		{"19-byte tail", append([]byte{0x15}, make([]byte, 19)...), val.ErrInvalidAddressLen},
 		{"21-byte tail", append([]byte{0x15}, make([]byte, 21)...), val.ErrInvalidAddressLen},
+		{"truncated varint", []byte{241}, val.ErrTruncatedVarint},
+		{"mismatched varint length", val.NewOutOfBandAdaptiveValueWithAddr(9999, validAddr), nil},
 	}
 
 	comparators := []struct {
@@ -679,7 +684,11 @@ func TestCompareAdaptiveValueMalformedAddress(t *testing.T) {
 			for _, c := range comparators {
 				t.Run(c.name, func(t *testing.T) {
 					err := c.cmp(validVal, mVal)
-					assert.ErrorIs(t, err, tc.expectedErr)
+					if tc.expectedErr != nil {
+						assert.ErrorIs(t, err, tc.expectedErr)
+					} else {
+						assert.NoError(t, err)
+					}
 				})
 			}
 		})

--- a/go/store/val/adaptive_value.go
+++ b/go/store/val/adaptive_value.go
@@ -244,8 +244,8 @@ func (v AdaptiveValue) convertToJsonStorage(ctx context.Context, vs ValueStore) 
 	return NewJsonStorageOutOfBand(addr, vs, length), nil
 }
 
-// OutOfBandAddr returns the content address embedded in an out-of-band
-// AdaptiveValue.
+// OutOfBandAddr returns the content address embedded in an
+// out-of-band AdaptiveValue.
 //
 // If |v| is NULL, inlined, or contains a malformed address whose
 // length is not exactly 20 bytes, OutOfBandAddr returns an error.
@@ -329,6 +329,14 @@ func InlineValueBytes(val []byte) ([]byte, bool) {
 // outside the TupleBuilder (e.g. in the merge path).
 func NewOutOfBandAdaptiveValue(ctx context.Context, vs ValueStore, data []byte) (AdaptiveValue, error) {
 	return convertBytesToOutOfBand(ctx, data, vs, nil)
+}
+
+// NewOutOfBandAdaptiveValueWithAddr returns an out-of-band AdaptiveValue
+// encoding [varint(|length|) | |addr|].
+func NewOutOfBandAdaptiveValueWithAddr(length uint64, addr hash.Hash) AdaptiveValue {
+	var buf [29]byte
+	n := uvarint.Encode(buf[:], length)
+	return AdaptiveValue(append(buf[:n], addr[:]...))
 }
 
 // AdaptiveEncodingTypeHandler is an implementation of TypeHandler for adaptive encoding types,

--- a/go/store/val/adaptive_value.go
+++ b/go/store/val/adaptive_value.go
@@ -17,12 +17,20 @@ package val
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/mohae/uvarint"
 
 	"github.com/dolthub/dolt/go/store/hash"
+)
+
+var (
+	ErrNullAdaptiveValue   = errors.New("cannot get address from null adaptive value")
+	ErrInlineAdaptiveValue = errors.New("cannot get address from inline adaptive value")
+	ErrTruncatedVarint     = errors.New("malformed out-of-band adaptive value: truncated length varint")
+	ErrInvalidAddressLen   = errors.New("malformed out-of-band adaptive value: invalid address length")
 )
 
 // A AdaptiveValue is a byte sequence that can represent:
@@ -151,9 +159,11 @@ func (v AdaptiveValue) convertToInline(ctx context.Context, vs ValueStore, dest 
 	if v.isInlined() {
 		return v, nil
 	}
-	_, lengthBytes := uvarint.Uvarint(v)
-	addr := v[lengthBytes:]
-	blob, err := vs.ReadBytes(ctx, hash.New(addr))
+	addr, err := v.OutOfBandAddr()
+	if err != nil {
+		return nil, err
+	}
+	blob, err := vs.ReadBytes(ctx, addr)
 	if err != nil {
 		return nil, err
 	}
@@ -175,32 +185,37 @@ func (v AdaptiveValue) getUnderlyingBytes(ctx context.Context, vs ValueStore) ([
 	if v.isInlined() {
 		return v[1:], nil
 	}
-	// else value is stored out-of-band
-	_, lengthBytes := uvarint.Uvarint(v)
-	addr := v[lengthBytes:]
-	return vs.ReadBytes(ctx, hash.New(addr))
+	addr, err := v.OutOfBandAddr()
+	if err != nil {
+		return nil, err
+	}
+	return vs.ReadBytes(ctx, addr)
 }
 
 func (v AdaptiveValue) convertToByteArray(ctx context.Context, vs ValueStore, buf []byte) (*ByteArray, error) {
 	// Only out-of-band values can be converted to a ByteArray
 	outOfBandValue, err := v.convertToOutOfBand(ctx, vs, buf)
 	if err != nil {
-		return &ByteArray{}, err
+		return nil, err
 	}
-	length, lengthBytes := uvarint.Uvarint(outOfBandValue)
-	address := hash.New(outOfBandValue[lengthBytes:])
-	return NewByteArray(address, vs).WithMaxByteLength(int64(length)), nil
+	addr, length, err := outOfBandValue.outOfBandAddressAndLength()
+	if err != nil {
+		return nil, err
+	}
+	return NewByteArray(addr, vs).WithMaxByteLength(length), nil
 }
 
 func (v AdaptiveValue) convertToTextStorage(ctx context.Context, vs ValueStore, buf []byte) (*TextStorage, error) {
 	// Only out-of-band values can be converted to a TextStorage
 	outOfBandValue, err := v.convertToOutOfBand(ctx, vs, buf)
 	if err != nil {
-		return &TextStorage{}, err
+		return nil, err
 	}
-	length, lengthBytes := uvarint.Uvarint(outOfBandValue)
-	address := hash.New(outOfBandValue[lengthBytes:])
-	return NewTextStorage(address, vs).WithMaxByteLength(int64(length)), nil
+	addr, length, err := outOfBandValue.outOfBandAddressAndLength()
+	if err != nil {
+		return nil, err
+	}
+	return NewTextStorage(addr, vs).WithMaxByteLength(length), nil
 }
 
 func (v AdaptiveValue) convertToGeometryStorage(ctx context.Context, vs ValueStore) (*GeometryStorage, error) {
@@ -209,9 +224,11 @@ func (v AdaptiveValue) convertToGeometryStorage(ctx context.Context, vs ValueSto
 	if err != nil {
 		return nil, err
 	}
-	length, lengthBytes := uvarint.Uvarint(outOfBandValue)
-	addr := hash.New(outOfBandValue[lengthBytes:])
-	return NewGeometryStorageOutOfBand(addr, vs, int64(length)), nil
+	addr, length, err := outOfBandValue.outOfBandAddressAndLength()
+	if err != nil {
+		return nil, err
+	}
+	return NewGeometryStorageOutOfBand(addr, vs, length), nil
 }
 
 func (v AdaptiveValue) convertToJsonStorage(ctx context.Context, vs ValueStore) (*JsonAdaptiveStorage, error) {
@@ -220,22 +237,59 @@ func (v AdaptiveValue) convertToJsonStorage(ctx context.Context, vs ValueStore) 
 	if err != nil {
 		return nil, err
 	}
-	length, lengthBytes := uvarint.Uvarint(outOfBandValue)
-	addr := hash.New(outOfBandValue[lengthBytes:])
-	return NewJsonStorageOutOfBand(addr, vs, int64(length)), nil
+	addr, length, err := outOfBandValue.outOfBandAddressAndLength()
+	if err != nil {
+		return nil, err
+	}
+	return NewJsonStorageOutOfBand(addr, vs, length), nil
 }
 
-// OutOfBandAddr returns the content address embedded in an out-of-band AdaptiveValue. It
-// returns an error if v is NULL or inline.
+// OutOfBandAddr returns the content address embedded in an out-of-band
+// AdaptiveValue.
+//
+// If |v| is NULL, inlined, or contains a malformed address whose
+// length is not exactly 20 bytes, OutOfBandAddr returns an error.
+//
+// Out-of-band values encode the payload length as a [SQLite4 Varint]
+// followed by a 20-byte content address.
+//
+// [SQLite4 Varint]: https://sqlite.org/src4/doc/trunk/www/varint.wiki
 func (v AdaptiveValue) OutOfBandAddr() (hash.Hash, error) {
+	addr, _, err := v.outOfBandAddressAndLength()
+	return addr, err
+}
+
+func (v AdaptiveValue) outOfBandAddressAndLength() (hash.Hash, int64, error) {
 	if v.IsNull() {
-		return hash.Hash{}, fmt.Errorf("cannot get address from NULL adaptive value")
+		return hash.Hash{}, 0, ErrNullAdaptiveValue
 	}
 	if v.isInlined() {
-		return hash.Hash{}, fmt.Errorf("cannot get address from inline adaptive value")
+		return hash.Hash{}, 0, ErrInlineAdaptiveValue
 	}
-	_, lengthBytes := uvarint.Uvarint(v)
-	return hash.New(v[lengthBytes:]), nil
+	if len(v) < varintPrefixLen(v[0]) {
+		return hash.Hash{}, 0, ErrTruncatedVarint
+	}
+	length, lengthBytes := uvarint.Uvarint(v)
+	addr := v[lengthBytes:]
+	if len(addr) != hash.ByteLen {
+		return hash.Hash{}, 0, fmt.Errorf("%w: expected %d-byte address, got %d", ErrInvalidAddressLen, hash.ByteLen, len(addr))
+	}
+	return hash.New(addr), int64(length), nil
+}
+
+// varintPrefixLen returns the number of prefix bytes required by a
+// [SQLite4 Varint] based on its leading byte |b|.
+//
+// [SQLite4 Varint]: https://sqlite.org/src4/doc/trunk/www/varint.wiki
+func varintPrefixLen(b byte) int {
+	switch {
+	case b <= 240:
+		return 1
+	case b <= 248:
+		return 2
+	default:
+		return int(b - 246)
+	}
 }
 
 // AdaptiveValueInlineBytes returns the inline encoding of the adaptive value given as a byte slice.
@@ -376,12 +430,13 @@ func (handler AdaptiveEncodingTypeHandler) DeserializeValue(ctx context.Context,
 	if adaptiveValue.isInlined() {
 		return handler.childHandler.DeserializeValue(ctx, adaptiveValue[1:])
 	}
-	// else adaptiveValue is stored out-of-band
-	length, lengthBytes := uvarint.Uvarint(adaptiveValue)
-	addr := hash.New(adaptiveValue[lengthBytes:])
+	addr, length, err := adaptiveValue.outOfBandAddressAndLength()
+	if err != nil {
+		return nil, err
+	}
 	return &ExtendedValueWrapper{
 		ImmutableValue:  NewImmutableValue(addr, handler.vs),
-		outOfBandLength: int64(length),
+		outOfBandLength: length,
 		typeHandler:     handler.childHandler,
 	}, nil
 }

--- a/go/store/val/adaptive_value_test.go
+++ b/go/store/val/adaptive_value_test.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package val
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/store/hash"
+	"github.com/dolthub/dolt/go/store/pool"
+)
+
+type mockTupleTypeHandler struct{}
+
+func (m mockTupleTypeHandler) SerializedCompare(ctx context.Context, v1, v2 []byte) (int, error) {
+	return 0, nil
+}
+func (m mockTupleTypeHandler) SerializeValue(ctx context.Context, val any) ([]byte, error) {
+	return nil, nil
+}
+func (m mockTupleTypeHandler) DeserializeValue(ctx context.Context, val []byte) (any, error) {
+	return string(val), nil
+}
+func (m mockTupleTypeHandler) FormatValue(val any) (string, error)                 { return "", nil }
+func (m mockTupleTypeHandler) SerializationCompatible(other TupleTypeHandler) bool { return true }
+func (m mockTupleTypeHandler) ConvertSerialized(ctx context.Context, other TupleTypeHandler, val []byte) ([]byte, error) {
+	return val, nil
+}
+
+type mockValueStore struct{}
+
+func (m *mockValueStore) ReadBytes(ctx context.Context, h hash.Hash) ([]byte, error) { return nil, nil }
+func (m *mockValueStore) WriteBytes(ctx context.Context, val []byte) (hash.Hash, error) {
+	return hash.Hash{1}, nil
+}
+func (m *mockValueStore) CompareAdaptive(ctx context.Context, l, r AdaptiveValue, encoding Encoding) (int, error) {
+	return 0, nil
+}
+func (m *mockValueStore) CompareAdaptiveCollatedStrings(ctx context.Context, l, r AdaptiveValue, collation sql.CollationID) (int, error) {
+	return 0, nil
+}
+
+func TestAdaptiveValueMalformedAddress(t *testing.T) {
+	ctx := context.Background()
+	vs := &mockValueStore{}
+	buffPool := pool.NewBuffPool()
+	handler := NewAdaptiveTypeHandler(vs, mockTupleTypeHandler{})
+	stringDesc := NewTupleDescriptor(Type{Enc: StringAdaptiveEnc})
+
+	testCases := []struct {
+		name        string
+		data        []byte
+		expectedErr error
+	}{
+		{
+			name:        "3-byte address tail",
+			data:        []byte{0x15, 0x01, 0x02, 0x03},
+			expectedErr: ErrInvalidAddressLen,
+		},
+		{
+			name:        "19-byte address tail",
+			data:        append([]byte{0x15}, make([]byte, 19)...),
+			expectedErr: ErrInvalidAddressLen,
+		},
+		{
+			name:        "21-byte address tail",
+			data:        append([]byte{0x15}, make([]byte, 21)...),
+			expectedErr: ErrInvalidAddressLen,
+		},
+		{
+			name:        "truncated varint header",
+			data:        []byte{241},
+			expectedErr: ErrTruncatedVarint,
+		},
+	}
+
+	decodeOps := []struct {
+		name string
+		call func(v AdaptiveValue) error
+	}{
+		{"OutOfBandAddr", func(v AdaptiveValue) error {
+			_, err := v.OutOfBandAddr()
+			return err
+		}},
+		{"convertToInline", func(v AdaptiveValue) error {
+			_, err := v.convertToInline(ctx, vs, nil)
+			return err
+		}},
+		{"getUnderlyingBytes", func(v AdaptiveValue) error {
+			_, err := v.getUnderlyingBytes(ctx, vs)
+			return err
+		}},
+		{"convertToByteArray", func(v AdaptiveValue) error {
+			_, err := v.convertToByteArray(ctx, vs, nil)
+			return err
+		}},
+		{"convertToTextStorage", func(v AdaptiveValue) error {
+			_, err := v.convertToTextStorage(ctx, vs, nil)
+			return err
+		}},
+		{"convertToGeometryStorage", func(v AdaptiveValue) error {
+			_, err := v.convertToGeometryStorage(ctx, vs)
+			return err
+		}},
+		{"convertToJsonStorage", func(v AdaptiveValue) error {
+			_, err := v.convertToJsonStorage(ctx, vs)
+			return err
+		}},
+		{"DeserializeValue", func(v AdaptiveValue) error {
+			_, err := handler.DeserializeValue(ctx, v)
+			return err
+		}},
+		{"GetBytesAdaptiveValue", func(v AdaptiveValue) error {
+			_, _, err := GetBytesAdaptiveValue(ctx, vs, v)
+			return err
+		}},
+		{"GetStringAdaptiveValue", func(v AdaptiveValue) error {
+			_, _, err := stringDesc.GetStringAdaptiveValue(ctx, 0, vs, NewTuple(buffPool, v))
+			return err
+		}},
+		{"GetJsonAdaptiveValue", func(v AdaptiveValue) error {
+			_, _, err := GetJsonAdaptiveValue(ctx, vs, v)
+			return err
+		}},
+		{"getGeomAdaptiveValue", func(v AdaptiveValue) error {
+			_, _, err := getGeomAdaptiveValue(ctx, vs, v)
+			return err
+		}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := AdaptiveValue(tc.data)
+			require.False(t, v.IsNull())
+			require.True(t, v.IsOutOfBand())
+
+			for _, op := range decodeOps {
+				t.Run(op.name, func(t *testing.T) {
+					err := op.call(v)
+					assert.ErrorIs(t, err, tc.expectedErr)
+				})
+			}
+		})
+	}
+}
+
+func TestAdaptiveValueOutOfBandAddrInvalidCases(t *testing.T) {
+	var nullVal AdaptiveValue
+	addr, err := nullVal.OutOfBandAddr()
+	assert.ErrorIs(t, err, ErrNullAdaptiveValue)
+	assert.True(t, addr.IsEmpty())
+
+	inlineVal := AdaptiveValue([]byte{0x00, 0x01, 0x02})
+	addr, err = inlineVal.OutOfBandAddr()
+	assert.ErrorIs(t, err, ErrInlineAdaptiveValue)
+	assert.True(t, addr.IsEmpty())
+}
+
+func TestAdaptiveValueOutOfBandAddrValid(t *testing.T) {
+	ctx := context.Background()
+	vs := &mockValueStore{}
+	v, err := NewOutOfBandAdaptiveValue(ctx, vs, []byte("valid content"))
+	require.NoError(t, err)
+	addr, err := v.OutOfBandAddr()
+	require.NoError(t, err)
+	assert.False(t, addr.IsEmpty())
+}

--- a/go/store/val/adaptive_value_test.go
+++ b/go/store/val/adaptive_value_test.go
@@ -56,7 +56,7 @@ func (m *mockValueStore) CompareAdaptiveCollatedStrings(ctx context.Context, l, 
 	return 0, nil
 }
 
-func TestAdaptiveValueMalformedAddress(t *testing.T) {
+func TestAdaptiveValue_OutOfBandDecode(t *testing.T) {
 	ctx := context.Background()
 	vs := &mockValueStore{}
 	buffPool := pool.NewBuffPool()
@@ -87,6 +87,11 @@ func TestAdaptiveValueMalformedAddress(t *testing.T) {
 			name:        "truncated varint header",
 			data:        []byte{241},
 			expectedErr: ErrTruncatedVarint,
+		},
+		{
+			name:        "mismatched varint length",
+			data:        NewOutOfBandAdaptiveValueWithAddr(1000, hash.Hash{1}),
+			expectedErr: nil,
 		},
 	}
 
@@ -153,31 +158,39 @@ func TestAdaptiveValueMalformedAddress(t *testing.T) {
 			for _, op := range decodeOps {
 				t.Run(op.name, func(t *testing.T) {
 					err := op.call(v)
-					assert.ErrorIs(t, err, tc.expectedErr)
+					if tc.expectedErr != nil {
+						assert.ErrorIs(t, err, tc.expectedErr)
+					} else {
+						assert.NoError(t, err)
+					}
 				})
 			}
 		})
 	}
 }
 
-func TestAdaptiveValueOutOfBandAddrInvalidCases(t *testing.T) {
-	var nullVal AdaptiveValue
-	addr, err := nullVal.OutOfBandAddr()
-	assert.ErrorIs(t, err, ErrNullAdaptiveValue)
-	assert.True(t, addr.IsEmpty())
+func TestAdaptiveValue_OutOfBandAddr(t *testing.T) {
+	t.Run("null", func(t *testing.T) {
+		var nullVal AdaptiveValue
+		addr, err := nullVal.OutOfBandAddr()
+		assert.ErrorIs(t, err, ErrNullAdaptiveValue)
+		assert.True(t, addr.IsEmpty())
+	})
 
-	inlineVal := AdaptiveValue([]byte{0x00, 0x01, 0x02})
-	addr, err = inlineVal.OutOfBandAddr()
-	assert.ErrorIs(t, err, ErrInlineAdaptiveValue)
-	assert.True(t, addr.IsEmpty())
-}
+	t.Run("inline", func(t *testing.T) {
+		inlineVal := AdaptiveValue([]byte{0x00, 0x01, 0x02})
+		addr, err := inlineVal.OutOfBandAddr()
+		assert.ErrorIs(t, err, ErrInlineAdaptiveValue)
+		assert.True(t, addr.IsEmpty())
+	})
 
-func TestAdaptiveValueOutOfBandAddrValid(t *testing.T) {
-	ctx := context.Background()
-	vs := &mockValueStore{}
-	v, err := NewOutOfBandAdaptiveValue(ctx, vs, []byte("valid content"))
-	require.NoError(t, err)
-	addr, err := v.OutOfBandAddr()
-	require.NoError(t, err)
-	assert.False(t, addr.IsEmpty())
+	t.Run("valid out-of-band", func(t *testing.T) {
+		ctx := context.Background()
+		vs := &mockValueStore{}
+		v, err := NewOutOfBandAdaptiveValue(ctx, vs, []byte("valid content"))
+		require.NoError(t, err)
+		addr, err := v.OutOfBandAddr()
+		require.NoError(t, err)
+		assert.False(t, addr.IsEmpty())
+	})
 }

--- a/go/store/val/tuple_descriptor.go
+++ b/go/store/val/tuple_descriptor.go
@@ -530,14 +530,10 @@ func getGeomAdaptiveValue(ctx context.Context, vs ValueStore, val []byte) (any, 
 	}
 	if adaptiveValue.isInlined() {
 		bytes, err := adaptiveValue.getUnderlyingBytes(ctx, vs)
-		if err != nil {
-			return nil, false, err
-		}
-		return bytes, true, nil
-	} else {
-		gs, err := adaptiveValue.convertToGeometryStorage(ctx, vs)
-		return gs, true, err
+		return bytes, err == nil, err
 	}
+	gs, err := adaptiveValue.convertToGeometryStorage(ctx, vs)
+	return gs, err == nil, err
 }
 
 func (td *TupleDesc) GetHash128(i int, tup Tuple) (v []byte, ok bool) {
@@ -598,11 +594,10 @@ func GetBytesAdaptiveValue(ctx context.Context, vs ValueStore, val []byte) (inte
 	}
 	if adaptiveValue.isInlined() {
 		val, err := adaptiveValue.getUnderlyingBytes(ctx, vs)
-		return val, true, err
-	} else {
-		val, err := adaptiveValue.convertToByteArray(ctx, vs, nil)
-		return val, true, err
+		return val, err == nil, err
 	}
+	valBytes, err := adaptiveValue.convertToByteArray(ctx, vs, nil)
+	return valBytes, err == nil, err
 }
 
 // GetStringAdaptiveValue returns either a string or a StringWrapper, but Go doesn't allow us to use a single type for that.
@@ -614,11 +609,10 @@ func (td *TupleDesc) GetStringAdaptiveValue(ctx context.Context, i int, vs Value
 	}
 	if adaptiveValue.isInlined() {
 		val, err := adaptiveValue.getUnderlyingBytes(ctx, vs)
-		return encodings.BytesToString(val), true, err
-	} else {
-		val, err := adaptiveValue.convertToTextStorage(ctx, vs, nil)
-		return val, true, err
+		return encodings.BytesToString(val), err == nil, err
 	}
+	valText, err := adaptiveValue.convertToTextStorage(ctx, vs, nil)
+	return valText, err == nil, err
 }
 
 // GetJsonAdaptiveValue reads a JSON value from an adaptive-encoded field, returning a *JsonAdaptiveStorage
@@ -636,13 +630,10 @@ func GetJsonAdaptiveValue(ctx context.Context, vs ValueStore, field []byte) (any
 	}
 	if adaptiveValue.isInlined() {
 		bytes, err := adaptiveValue.getUnderlyingBytes(ctx, vs)
-		if err != nil {
-			return nil, false, err
-		}
-		return bytes, true, nil
+		return bytes, err == nil, err
 	}
 	gs, err := adaptiveValue.convertToJsonStorage(ctx, vs)
-	return gs, true, err
+	return gs, err == nil, err
 }
 
 func (td *TupleDesc) GetCommitAddr(i int, tup Tuple) (v hash.Hash, ok bool) {


### PR DESCRIPTION
Fix panic when reading corrupted or truncated off-page storage chunks to return a SQL error.
- Malformed addresses that aren't exactly 20 bytes now return `ErrInvalidAddressLen`.
- Add `varintPrefixLen` to assert buffer length before reading varints, preventing out-of-bounds slice panics on truncated multi-byte headers.
- Add `ErrNullAdaptiveValue`, `ErrInlineAdaptiveValue`, `ErrTruncatedVarint`, and `ErrInvalidAddressLen` for callers and tests.
Fix #11641