### PR TITLE
go: sqle: Improve autotracker update robustness during dolt_reset --hard.

### DIFF
--- a/go/libraries/doltcore/sqle/cluster/controller.go
+++ b/go/libraries/doltcore/sqle/cluster/controller.go
@@ -1151,8 +1151,8 @@ func (c *Controller) refreshAutoIncrementTrackersForSessionDatabases() error {
 			// Not loaded in session; defer to lazy initialization on first use
 			continue
 		}
-		if err := gsp.GetGlobalState().InitWithRoots(sqlCtx, state.WorkingSet()); err != nil {
-			return fmt.Errorf("cluster/controller: auto-inc refresh: %s: init: %w", name, err)
+		if err := gsp.GetGlobalState().MergeRoots(sqlCtx, state.WorkingSet()); err != nil {
+			return fmt.Errorf("cluster/controller: auto-inc refresh: %s: merge: %w", name, err)
 		}
 	}
 	return nil

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -2109,7 +2109,7 @@ func (db Database) createSqlTable(ctx *sql.Context, table string, schemaName str
 		if err != nil {
 			return err
 		}
-		err = ait.AddNewRelation(tableName, doltdb.AutoIncrementState(1))
+		err = ait.AddNewRelation(ctx, tableName, doltdb.AutoIncrementState(1))
 		if err != nil {
 			return err
 		}
@@ -2172,7 +2172,7 @@ func (db Database) createIndexedSqlTable(ctx *sql.Context, table string, schemaN
 		if err != nil {
 			return err
 		}
-		err = ait.AddNewRelation(tableName, doltdb.AutoIncrementState(1))
+		err = ait.AddNewRelation(ctx, tableName, doltdb.AutoIncrementState(1))
 		if err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_reset.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_reset.go
@@ -258,6 +258,15 @@ func resetHard(
 		return err
 	}
 
+	// Raise global sequence state before the new roots become reachable.
+	// Doing this before landing the update ensures the tracker is not
+	// behind immediately after the update lands and it prevents us from
+	// landing the update at all if the tracker update fails.
+	err = dSess.MergeGlobals(ctx, dbName, roots.Working)
+	if err != nil {
+		return err
+	}
+
 	// TODO: this overrides the transaction setting, needs to happen at commit, not here
 	if newHead != nil {
 		headRef, err := dbData.Rsr.CWBHeadRef(ctx)
@@ -275,10 +284,6 @@ func resetHard(
 		return err
 	}
 	err = dSess.SetWorkingSet(ctx, dbName, ws.WithWorkingRoot(roots.Working).WithStagedRoot(roots.Staged).ClearMerge().ClearRebase())
-	if err != nil {
-		return err
-	}
-	err = dSess.ResetGlobals(ctx, dbName, roots.Working)
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/sqle/dsess/auto_increment_tracker_test.go
+++ b/go/libraries/doltcore/sqle/dsess/auto_increment_tracker_test.go
@@ -91,7 +91,7 @@ func TestInitWithRoots(t *testing.T) {
 			cancelInit: make(chan struct{}),
 		}
 		go ait.initWithRoots(context.Background(), ait.init)
-		assert.NoError(t, ait.waitForInit())
+		assert.NoError(t, ait.awaitInit(context.Background()))
 	})
 	t.Run("CloseCancelsInit", func(t *testing.T) {
 		ait := AutoIncrementTracker{
@@ -103,7 +103,7 @@ func TestInitWithRoots(t *testing.T) {
 		}
 		go ait.initWithRoots(context.Background(), ait.init, blockingRoot{})
 		ait.Close()
-		assert.Error(t, ait.waitForInit())
+		assert.Error(t, ait.awaitInit(context.Background()))
 	})
 }
 
@@ -134,7 +134,7 @@ func TestNewSequenceTrackerFromRootsSurvivesCallerContextCancellation(t *testing
 	// Let resolution finish
 	close(root.release)
 
-	require.ErrorIs(t, ait.waitForInit(), errReleasableRootDone)
+	require.ErrorIs(t, ait.awaitInit(context.Background()), errReleasableRootDone)
 }
 
 // releasableRoot blocks ResolveRootValue until |release| is closed, regardless of ctx.
@@ -245,7 +245,7 @@ func TestMergeRootsCallerCancellationIsNotTerminal(t *testing.T) {
 	}
 
 	// Other sessions are unaffected, and a later merge still works.
-	require.NoError(t, ait.waitForInit(), "a canceled dolt_reset --hard poisoned the tracker")
+	require.NoError(t, ait.awaitInit(context.Background()), "a canceled dolt_reset --hard poisoned the tracker")
 	require.NoError(t, ait.MergeRoots(context.Background(), newReleasedGateRoot()))
 }
 
@@ -271,4 +271,50 @@ func TestMergeRootsWaitsForInitialization(t *testing.T) {
 	ait.Close()
 
 	require.Error(t, ait.MergeRoots(context.Background(), newReleasedGateRoot()))
+}
+
+// TestQueryCancellationDuringInitialization pins that a query arriving while the tracker
+// is still reading roots answers KILL QUERY. Initialization is deliberately detached from
+// any one caller's context, which is why the wait for it needs the waiting caller's own
+// context: otherwise a killed session sits in it for up to five minutes.
+func TestQueryCancellationDuringInitialization(t *testing.T) {
+	ait := &AutoIncrementTracker{
+		dbName:         "test_database",
+		sequences:      &SyncMap[doltdb.TableName, doltdb.AutoIncrementState]{},
+		mm:             mutexmap.NewMutexMap(),
+		init:           make(chan struct{}),
+		cancelInit:     make(chan struct{}),
+		relationSource: noRelations{},
+	}
+	go ait.initWithRoots(context.Background(), ait.init, blockingRoot{})
+	defer ait.Close()
+
+	queryCtx, cancelQuery := context.WithCancel(context.Background())
+	queryDone := make(chan error, 1)
+	go func() {
+		_, err := ait.Current(queryCtx, doltdb.TableName{Name: "t"})
+		queryDone <- err
+	}()
+
+	select {
+	case err := <-queryDone:
+		t.Fatalf("Current returned %v while initialization was still in progress", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cancelQuery()
+	select {
+	case err := <-queryDone:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(30 * time.Second):
+		t.Fatal("Current did not return after its query context was canceled")
+	}
+
+	// Giving up is the caller's business only: initialization is still running, and its
+	// outcome is still its own.
+	select {
+	case <-ait.init:
+		t.Fatal("a canceled query ended the tracker's initialization")
+	default:
+	}
 }

--- a/go/libraries/doltcore/sqle/dsess/auto_increment_tracker_test.go
+++ b/go/libraries/doltcore/sqle/dsess/auto_increment_tracker_test.go
@@ -17,8 +17,9 @@ package dsess
 import (
 	"context"
 	"fmt"
-	"sync"
+	"iter"
 	"testing"
+	"time"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/stretchr/testify/assert"
@@ -106,38 +107,6 @@ func TestInitWithRoots(t *testing.T) {
 	})
 }
 
-// TestConcurrentInitWithRoots reproduces a race where overlapping InitWithRoots
-// calls on the same tracker (e.g. from concurrent dolt_reset/dolt_checkout on
-// different sessions against the same database) could each observe the prior
-// |init| channel already closed and then race to install their own
-// replacement channel.
-func TestConcurrentInitWithRoots(t *testing.T) {
-	ait := AutoIncrementTracker{
-		dbName:     "test_database",
-		sequences:  &SyncMap[doltdb.TableName, doltdb.AutoIncrementState]{},
-		mm:         mutexmap.NewMutexMap(),
-		init:       make(chan struct{}),
-		cancelInit: make(chan struct{}),
-	}
-	close(ait.init) // starts "already initialized", like a live tracker between resets
-
-	const numConcurrentCallers = 50
-	errs := make([]error, numConcurrentCallers)
-	var wg sync.WaitGroup
-	for i := 0; i < numConcurrentCallers; i++ {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
-			errs[i] = ait.InitWithRoots(context.Background())
-		}(i)
-	}
-	wg.Wait()
-
-	for _, err := range errs {
-		require.NoError(t, err)
-	}
-}
-
 type blockingRoot struct {
 }
 
@@ -190,3 +159,116 @@ func (releasableRoot) HashOf() (hash.Hash, error) {
 
 // errReleasableRootDone signals that releasableRoot resolved successfully rather than being canceled.
 var errReleasableRootDone = fmt.Errorf("releasableRoot: released")
+
+// noRelations is a doltdb.RelationSource that reports no relations at any root, so that
+// tests can drive a merge with stub roots that never resolve to a real RootValue.
+type noRelations struct{}
+
+var _ doltdb.RelationSource[*doltdb.Table] = noRelations{}
+
+func (noRelations) GetRelation(ctx context.Context, root doltdb.RootValue, tName doltdb.TableName) (*doltdb.Table, string, bool, error) {
+	return nil, "", false, nil
+}
+
+func (noRelations) IterRelations(ctx context.Context, root doltdb.RootValue) iter.Seq2[doltdb.TableName, *doltdb.Table] {
+	return func(yield func(doltdb.TableName, *doltdb.Table) bool) {}
+}
+
+// gateRoot resolves successfully once |release| is closed, recording that resolution was
+// entered by closing |started|. It honors ctx cancellation, like a real root read.
+type gateRoot struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+var _ doltdb.Rootish = (*gateRoot)(nil)
+
+func newGateRoot() *gateRoot {
+	return &gateRoot{started: make(chan struct{}), release: make(chan struct{})}
+}
+
+func (r *gateRoot) ResolveRootValue(ctx context.Context) (doltdb.RootValue, error) {
+	close(r.started)
+	select {
+	case <-r.release:
+		return nil, nil
+	case <-ctx.Done():
+		return nil, context.Cause(ctx)
+	}
+}
+
+func (r *gateRoot) HashOf() (hash.Hash, error) {
+	return hash.Hash{}, nil
+}
+
+// initializedTracker returns a tracker that has finished initializing, like a live
+// database between resets.
+func initializedTracker() *AutoIncrementTracker {
+	ait := &AutoIncrementTracker{
+		dbName:         "test_database",
+		sequences:      &SyncMap[doltdb.TableName, doltdb.AutoIncrementState]{},
+		mm:             mutexmap.NewMutexMap(),
+		init:           make(chan struct{}),
+		cancelInit:     make(chan struct{}),
+		relationSource: noRelations{},
+	}
+	close(ait.init)
+	return ait
+}
+
+// TestMergeRootsCallerCancellationIsNotTerminal covers the mechanism behind
+// dolthub/dolt#11581. dolt_reset --hard tells the tracker about the working set it just
+// moved. When that ran through initialization, a reset whose query context ended while
+// roots were still being read latched "context canceled" as the tracker's initialization
+// error, and every later use of the database's sequences -- from any session, for the
+// rest of the process's life -- failed with it. A merge reports its failure only to the
+// caller that asked for it.
+func TestMergeRootsCallerCancellationIsNotTerminal(t *testing.T) {
+	ait := initializedTracker()
+	root := newGateRoot()
+
+	callerCtx, cancelCaller := context.WithCancel(context.Background())
+	mergeDone := make(chan error, 1)
+	go func() {
+		mergeDone <- ait.MergeRoots(callerCtx, root)
+	}()
+
+	// The reset's query context ends while the merge is still reading roots.
+	<-root.started
+	cancelCaller()
+
+	select {
+	case err := <-mergeDone:
+		require.ErrorIs(t, err, context.Canceled, "the canceled caller should see its own cancellation")
+	case <-time.After(30 * time.Second):
+		t.Fatal("MergeRoots did not return after its caller's context was canceled")
+	}
+
+	// Other sessions are unaffected, and a later merge still works.
+	require.NoError(t, ait.waitForInit(), "a canceled dolt_reset --hard poisoned the tracker")
+	require.NoError(t, ait.MergeRoots(context.Background(), newReleasedGateRoot()))
+}
+
+func newReleasedGateRoot() *gateRoot {
+	root := newGateRoot()
+	close(root.release)
+	return root
+}
+
+// TestMergeRootsWaitsForInitialization pins that a merge against a tracker that never
+// initialized reports the initialization failure rather than silently declaring the
+// tracker healthy on the strength of one working set.
+func TestMergeRootsWaitsForInitialization(t *testing.T) {
+	ait := &AutoIncrementTracker{
+		dbName:         "test_database",
+		sequences:      &SyncMap[doltdb.TableName, doltdb.AutoIncrementState]{},
+		mm:             mutexmap.NewMutexMap(),
+		init:           make(chan struct{}),
+		cancelInit:     make(chan struct{}),
+		relationSource: noRelations{},
+	}
+	go ait.initWithRoots(context.Background(), ait.init, blockingRoot{})
+	ait.Close()
+
+	require.Error(t, ait.MergeRoots(context.Background(), newReleasedGateRoot()))
+}

--- a/go/libraries/doltcore/sqle/dsess/globalstate.go
+++ b/go/libraries/doltcore/sqle/dsess/globalstate.go
@@ -128,9 +128,9 @@ func (g GlobalStateImpl) Close() {
 	}
 }
 
-func (g GlobalStateImpl) InitWithRoots(ctx context.Context, roots ...doltdb.Rootish) error {
+func (g GlobalStateImpl) MergeRoots(ctx context.Context, roots ...doltdb.Rootish) error {
 	for _, tracker := range g.sequenceTrackers {
-		err := tracker.InitWithRoots(ctx, roots...)
+		err := tracker.MergeRoots(ctx, roots...)
 		if err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/sqle/dsess/mutexmap/mutexmap.go
+++ b/go/libraries/doltcore/sqle/dsess/mutexmap/mutexmap.go
@@ -15,6 +15,7 @@
 package mutexmap
 
 import (
+	"context"
 	"sync"
 )
 
@@ -29,38 +30,57 @@ type mapMutex struct {
 	key      interface{}
 	parent   *MutexMap
 	refcount int
-	mu       sync.Mutex
+	// held is a capacity-one channel used as the mutex itself, rather than a sync.Mutex, so
+	// that a waiter can give up on a canceled context. Holds a value when locked.
+	held chan struct{}
 }
 
 func NewMutexMap() *MutexMap {
 	return &MutexMap{keyedMutexes: make(map[interface{}]*mapMutex)}
 }
 
-func (mm *MutexMap) Lock(key interface{}) func() {
-	mm.mu.Lock()
+// Lock acquires the mutex for |key| and returns a callback that releases it, giving up and
+// returning |ctx|'s cause if |ctx| is canceled before the lock can be acquired. It returns
+// a nil callback with a non-nil error in that case.
+//
+// |ctx| governs the wait only: an uncontended lock is granted even to a canceled caller.
+func (mm *MutexMap) Lock(ctx context.Context, key interface{}) (func(), error) {
+	keyedMutex := mm.ref(key)
 
-	var keyedMutex *mapMutex
-	func() {
-		// We must release the parent lock before attempting to acquire the child lock, otherwise if the child lock
-		// is currently held it will never be released.
-		defer mm.mu.Unlock()
-		var hasKey bool
-		keyedMutex, hasKey = mm.keyedMutexes[key]
-		if !hasKey {
-			keyedMutex = &mapMutex{parent: mm, key: key}
-			mm.keyedMutexes[key] = keyedMutex
-		}
-		keyedMutex.refcount++
-	}()
+	select {
+	case keyedMutex.held <- struct{}{}:
+		return keyedMutex.Unlock, nil
+	default:
+	}
 
-	keyedMutex.mu.Lock()
-
-	return func() {
-		keyedMutex.Unlock()
+	select {
+	case keyedMutex.held <- struct{}{}:
+		return keyedMutex.Unlock, nil
+	case <-ctx.Done():
+		keyedMutex.unref()
+		return nil, context.Cause(ctx)
 	}
 }
 
-func (mm *mapMutex) Unlock() {
+// ref returns the mutex for |key|, creating it if necessary, with this caller's reference
+// counted. The mapMutex refcount is what keeps the mutex in the map, and it is guarded by
+// |mm.mu|, just like keyedMutexes itself.
+func (mm *MutexMap) ref(key interface{}) *mapMutex {
+	mm.mu.Lock()
+	defer mm.mu.Unlock()
+
+	keyedMutex, hasKey := mm.keyedMutexes[key]
+	if !hasKey {
+		keyedMutex = &mapMutex{parent: mm, key: key, held: make(chan struct{}, 1)}
+		mm.keyedMutexes[key] = keyedMutex
+	}
+	keyedMutex.refcount++
+	return keyedMutex
+}
+
+// unref drops one reference to |mm|, deleting it from |keyedMutex| once nobody holds or
+// awaits it.
+func (mm *mapMutex) unref() {
 	mutexMap := mm.parent
 	mutexMap.mu.Lock()
 	defer mutexMap.mu.Unlock()
@@ -69,5 +89,14 @@ func (mm *mapMutex) Unlock() {
 	if mm.refcount < 1 {
 		delete(mutexMap.keyedMutexes, mm.key)
 	}
-	mm.mu.Unlock()
+}
+
+func (mm *mapMutex) Unlock() {
+	select {
+	case <-mm.held:
+	default:
+		// Matches sync.Mutex, which throws on unlock of an unlocked mutex.
+		panic("mutexmap: release called for a mutex that is not held")
+	}
+	mm.unref()
 }

--- a/go/libraries/doltcore/sqle/dsess/mutexmap/mutexmap.go
+++ b/go/libraries/doltcore/sqle/dsess/mutexmap/mutexmap.go
@@ -78,8 +78,8 @@ func (mm *MutexMap) ref(key interface{}) *mapMutex {
 	return keyedMutex
 }
 
-// unref drops one reference to |mm|, deleting it from |keyedMutex| once nobody holds or
-// awaits it.
+// unref drops one reference to |mm|, deleting it from |keyedMutexes| once nobody holds
+// or awaits it.
 func (mm *mapMutex) unref() {
 	mutexMap := mm.parent
 	mutexMap.mu.Lock()

--- a/go/libraries/doltcore/sqle/dsess/mutexmap/mutexmap_test.go
+++ b/go/libraries/doltcore/sqle/dsess/mutexmap/mutexmap_test.go
@@ -1,0 +1,175 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mutexmap
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// size reports how many mutexes the map is holding onto. Every mutex should be dropped once
+// nobody holds or awaits it, whether or not the waiters ever acquired it.
+func (mm *MutexMap) size() int {
+	mm.mu.Lock()
+	defer mm.mu.Unlock()
+	return len(mm.keyedMutexes)
+}
+
+// lock acquires |key| with a context that is never canceled, for tests that need a holder
+// rather than a waiter.
+func lock(t *testing.T, mm *MutexMap, key interface{}) func() {
+	t.Helper()
+	release, err := mm.Lock(context.Background(), key)
+	require.NoError(t, err)
+	return release
+}
+
+// lockAsync acquires |key| on another goroutine, reporting the acquisition on the returned
+// channel and releasing immediately. Errors come back to the test goroutine rather than
+// being asserted where a failure would just hang the test.
+func lockAsync(mm *MutexMap, ctx context.Context, key interface{}) <-chan error {
+	acquired := make(chan error, 1)
+	go func() {
+		release, err := mm.Lock(ctx, key)
+		if release != nil {
+			release()
+		}
+		acquired <- err
+	}()
+	return acquired
+}
+
+func TestLockExcludesSameKeyOnly(t *testing.T) {
+	mm := NewMutexMap()
+
+	release := lock(t, mm, "a")
+
+	otherKey := lockAsync(mm, context.Background(), "b")
+	select {
+	case err := <-otherKey:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("Lock on a different key blocked behind an unrelated held lock")
+	}
+
+	sameKey := lockAsync(mm, context.Background(), "a")
+	select {
+	case err := <-sameKey:
+		t.Fatalf("Lock on a held key returned (%v) while the lock was held", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	release()
+	select {
+	case err := <-sameKey:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("Lock did not return after the lock was released")
+	}
+
+	require.Equal(t, 0, mm.size())
+}
+
+func TestLockGivesUpOnCancellation(t *testing.T) {
+	mm := NewMutexMap()
+
+	// A long-running holder, as AcquireLock hands out for the duration of an insert
+	// statement outside interleaved lock mode.
+	release := lock(t, mm, "a")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	blocked := lockAsync(mm, ctx, "a")
+
+	select {
+	case err := <-blocked:
+		t.Fatalf("Lock returned %v while the lock was held", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case err := <-blocked:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(30 * time.Second):
+		t.Fatal("Lock did not return after its context was canceled")
+	}
+
+	// Giving up must not have handed the lock to the abandoned waiter, or taken it from the
+	// holder: the lock is still available to whoever asks next, once released.
+	release()
+	lock(t, mm, "a")()
+
+	require.Equal(t, 0, mm.size())
+}
+
+func TestLockAlreadyCanceledIsGrantedWhenUncontended(t *testing.T) {
+	mm := NewMutexMap()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Nothing to wait for, so the canceled context does not deny the lock. Without the
+	// non-blocking attempt this is a coin flip between the two select cases.
+	for i := 0; i < 100; i++ {
+		release, err := mm.Lock(ctx, "a")
+		require.NoError(t, err)
+		release()
+	}
+	require.Equal(t, 0, mm.size())
+}
+
+func TestLockAlreadyCanceledDoesNotWait(t *testing.T) {
+	mm := NewMutexMap()
+
+	release := lock(t, mm, "a")
+	defer release()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	acquired, err := mm.Lock(ctx, "a")
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, acquired)
+
+	// Only the holder's reference is left; the refused caller did not leak one.
+	require.Equal(t, 1, mm.size())
+}
+
+func TestLockReportsCause(t *testing.T) {
+	mm := NewMutexMap()
+	release := lock(t, mm, "a")
+	defer release()
+
+	cause := errors.New("query killed")
+	ctx, cancel := context.WithCancelCause(context.Background())
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel(cause)
+	}()
+
+	_, err := mm.Lock(ctx, "a")
+	require.ErrorIs(t, err, cause)
+}
+
+func TestUnlockOfUnheldMutexPanics(t *testing.T) {
+	mm := NewMutexMap()
+	release := lock(t, mm, "a")
+	release()
+	require.Panics(t, release)
+}

--- a/go/libraries/doltcore/sqle/dsess/sequence_tracker.go
+++ b/go/libraries/doltcore/sqle/dsess/sequence_tracker.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -51,15 +50,16 @@ type SequenceTracker[
 	StateType sequences.SequenceState[StateType, ValueType],
 	ValueType comparable,
 ] struct {
+	// initErr is written by the lazy initialization started in the constructor, before
+	// it closes |init|, and read only after |init| is closed.
 	initErr   error
 	sequences *SyncMap[doltdb.TableName, StateType]
 	mm        *mutexmap.MutexMap
-	// initMu guards |init| against concurrent callers of InitWithRoots.
-	initMu sync.Mutex
-	// SequenceTracker is lazily initialized by loading
-	// tracker state for every given |root|.  On first access, we
-	// block on initialization being completed and we terminally
-	// return |initErr| if there was any error initializing.
+	// SequenceTracker is lazily initialized by loading tracker state for every given
+	// |root|. On first access, we block on initialization being completed and we
+	// terminally return |initErr| if there was any error initializing. |init| is
+	// created by the constructor and never replaced: re-reading roots into an already
+	// initialized tracker is MergeRoots, which does not disturb initialization state.
 	init chan struct{}
 	// To clean up effectively we need to stop all access to
 	// storage. As part of that, we have the possibility to cancel
@@ -188,7 +188,7 @@ func (a *SequenceTracker[RelationType, StateType, ValueType]) initializeSequence
 
 func (a *SequenceTracker[RelationType, StateType, ValueType]) Close() {
 	close(a.cancelInit)
-	<-a.currentInit()
+	<-a.init
 }
 
 // Current returns the next value to be generated in the auto increment sequence for |relationName|.
@@ -513,21 +513,35 @@ func (a *SequenceTracker[RelationType, StateType, ValueType]) AcquireLock(ctx *s
 		// This shouldn't be possible, it's a serious programming error if it happens
 		panic("Attempted to acquire AutoInc lock for entire insert operation, but lock mode was set to Interleaved")
 	}
-	return a.mm.Lock(relationName), nil
-}
-
-// currentInit returns the current |init| channel under |initMu|, so that it never races
-// with a concurrent InitWithRoots call installing a replacement channel.
-func (a *SequenceTracker[RelationType, StateType, ValueType]) currentInit() chan struct{} {
-	a.initMu.Lock()
-	defer a.initMu.Unlock()
-	return a.init
+	// Normalized like every other use of |mm|, so that the statement-level lock excludes
+	// the same allocations and merges a per-row lock would, whatever case the statement
+	// referred to the relation by.
+	return a.mm.Lock(relationName.ToLower()), nil
 }
 
 func (a *SequenceTracker[RelationType, StateType, ValueType]) waitForInit() error {
+	return a.awaitInit(context.Background())
+}
+
+// awaitInit blocks until the tracker's initialization finishes and returns its result,
+// giving up early if |ctx| is canceled. Initialization is deliberately detached from any
+// one caller's context, so a caller whose query has ended stops waiting rather than
+// recording its own cancellation as the tracker's outcome.
+func (a *SequenceTracker[RelationType, StateType, ValueType]) awaitInit(ctx context.Context) error {
+	// Fast path for the overwhelmingly common case of an already-initialized tracker.
+	// This is on the per-row path of every auto-increment insert, and the timeout below
+	// would otherwise allocate a timer on each one.
 	select {
-	case <-a.currentInit():
+	case <-a.init:
 		return a.initErr
+	default:
+	}
+
+	select {
+	case <-a.init:
+		return a.initErr
+	case <-ctx.Done():
+		return context.Cause(ctx)
 	case <-time.After(5 * time.Minute):
 		return errors.New("failed to initialize autoincrement tracker")
 	}
@@ -536,11 +550,7 @@ func (a *SequenceTracker[RelationType, StateType, ValueType]) waitForInit() erro
 // This method will initialize the SequenceTracker state with all
 // data from the tables found in |roots|.  This method closes the
 // |init| channel when it completes. It is meant to be run in a
-// goroutine, as in `go a.initWithRoots(...)`. |init| must be the
-// channel that the caller just installed as |a.init|: closing that
-// specific channel value (rather than re-reading |a.init|, which a
-// racing InitWithRoots caller may have already replaced) is what
-// makes concurrent InitWithRoots calls safe.
+// goroutine, as in `go a.initWithRoots(...)`.
 //
 // It is the caller's responsibility to ensure that whatever |ctx|
 // |initWithRoots| is called with appropriately outlives the end of
@@ -562,6 +572,29 @@ func (a *SequenceTracker[RelationType, StateType, ValueType]) initWithRoots(ctx 
 		}
 	}()
 
+	a.lockMode = currentLockMode()
+	a.initErr = a.mergeRoots(ctx, roots)
+}
+
+// MergeRoots raises the tracked sequence state for every relation found in |roots| to the
+// value that root records, leaving relations that are already further along alone.
+//
+// This is how a caller that has changed a working set (dolt_reset --hard, a cluster
+// standby taking over) tells the tracker about state it may not have seen. It is
+// deliberately not initialization: it runs synchronously and reports its failure only to
+// the caller, so a merge that fails cannot take the tracker away from other sessions the
+// way a failed initialization does.
+func (a *SequenceTracker[RelationType, StateType, ValueType]) MergeRoots(ctx context.Context, roots ...doltdb.Rootish) error {
+	if err := a.awaitInit(ctx); err != nil {
+		return err
+	}
+	return a.mergeRoots(ctx, roots)
+}
+
+// mergeRoots reads every relation in every root and merges its sequence state into the
+// tracker. Roots are read concurrently; the per-relation merge itself is serialized by
+// the same lock the mutators take.
+func (a *SequenceTracker[RelationType, StateType, ValueType]) mergeRoots(ctx context.Context, roots []doltdb.Rootish) error {
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.SetLimit(128)
 
@@ -588,20 +621,31 @@ func (a *SequenceTracker[RelationType, StateType, ValueType]) initWithRoots(ctx 
 				if err != nil {
 					return err
 				}
-
-				key := relationName.ToLower()
-				if oldValue, loaded := a.sequences.LoadOrStore(key, seq); loaded {
-					for seq.GreaterThan(oldValue) && !a.sequences.CompareAndSwap(key, oldValue, seq) {
-						oldValue, _ = a.sequences.Load(key)
-					}
-				}
+				a.mergeSequenceState(relationName, seq)
 			}
 			return nil
 		})
 	}
 
-	a.lockMode = currentLockMode()
-	a.initErr = eg.Wait()
+	return eg.Wait()
+}
+
+// mergeSequenceState raises the tracked state for |relationName| to |seq| if |seq| is
+// further along, and leaves it alone otherwise.
+//
+// The read-modify-write is done under the per-relation lock that Next, Set, AddNewRelation
+// and DropRelation also take. Without it, an allocation sitting between its own read and
+// write-back overwrites whatever was merged in here, sending the tracker backwards and
+// handing out values another branch has already used.
+func (a *SequenceTracker[RelationType, StateType, ValueType]) mergeSequenceState(relationName doltdb.TableName, seq StateType) {
+	key := relationName.ToLower()
+	release := a.mm.Lock(key)
+	defer release()
+
+	if current, ok := a.sequences.Load(key); ok && !seq.GreaterThan(current) {
+		return
+	}
+	a.sequences.Store(key, seq)
 }
 
 // validateAutoIncrementBounds checks if a value (or value+1 if checkIncrement) is valid for the auto-increment column type
@@ -647,34 +691,4 @@ func (a *SequenceTracker[RelationType, StateType, ValueType]) validateBounds(ctx
 
 	_, inRange, err := sqlType.Convert(ctx, testVal.CurrentValue())
 	return err == nil && inRange == sql.InRange
-}
-
-// InitWithRoots (re)initializes the tracker's state from |roots|. Concurrent calls (e.g. from
-// dolt_reset/dolt_checkout racing on separate sessions against the same database) are serialized
-// by |initMu|.
-func (a *SequenceTracker[RelationType, StateType, ValueType]) InitWithRoots(ctx context.Context, roots ...doltdb.Rootish) error {
-	a.initMu.Lock()
-	defer a.initMu.Unlock()
-
-	// Reading |a.init| directly (rather than via currentInit, which also takes |initMu|) is
-	// safe here because we're already holding the lock.
-	select {
-	case <-a.init:
-		if a.initErr != nil {
-			return a.initErr
-		}
-	case <-time.After(5 * time.Minute):
-		return errors.New("failed to initialize autoincrement tracker")
-	}
-
-	init := make(chan struct{})
-	a.init = init
-	go a.initWithRoots(ctx, init, roots...)
-
-	select {
-	case <-init:
-		return a.initErr
-	case <-time.After(5 * time.Minute):
-		return errors.New("failed to initialize autoincrement tracker")
-	}
 }

--- a/go/libraries/doltcore/sqle/dsess/sequence_tracker.go
+++ b/go/libraries/doltcore/sqle/dsess/sequence_tracker.go
@@ -217,41 +217,24 @@ func (a *SequenceTracker[RelationType, StateType, ValueType]) Next(ctx *sql.Cont
 	// The read-modify-write of the sequence below must be atomic across concurrent inserters. In
 	// interleaved lock mode (the default) the engine holds no statement-level lock, so we take a
 	// short per-table lock here.
-	locked := false
 	if a.lockMode == LockMode_Interleaved {
 		release, err := a.mm.Lock(ctx, relationName)
 		if err != nil {
 			return nextValue, err
 		}
 		defer release()
-		locked = true
 	}
 
 	currState, ok := loadSequenceState(a.sequences, relationName)
 	if !ok {
 		// Missing tracker state after initialization can happen when a running sql-server discovers a database
 		// restored after startup, so initialize it here.
-		if !locked {
-			if a.lockMode == LockMode_Interleaved {
-				release, err := a.mm.Lock(ctx, relationName)
-				if err != nil {
-					return nextValue, err
-				}
-				defer release()
-				locked = true
-			}
-
-			currState, ok = loadSequenceState(a.sequences, relationName)
+		currState, ok, err = a.initializeSequenceState(ctx, relationName, insertVal)
+		if err != nil {
+			return nextValue, err
 		}
-
 		if !ok {
-			currState, ok, err = a.initializeSequenceState(ctx, relationName, insertVal)
-			if err != nil {
-				return nextValue, err
-			}
-			if !ok {
-				return nextValue, fmt.Errorf("autoIncrementTracker: unable to find sequence for table %s", relationName.Name)
-			}
+			return nextValue, fmt.Errorf("autoIncrementTracker: unable to find sequence for table %s", relationName.Name)
 		}
 	}
 

--- a/go/libraries/doltcore/sqle/dsess/sequence_tracker.go
+++ b/go/libraries/doltcore/sqle/dsess/sequence_tracker.go
@@ -192,8 +192,8 @@ func (a *SequenceTracker[RelationType, StateType, ValueType]) Close() {
 }
 
 // Current returns the next value to be generated in the auto increment sequence for |relationName|.
-func (a *SequenceTracker[RelationType, StateType, ValueType]) Current(relationName doltdb.TableName) (current StateType, err error) {
-	err = a.waitForInit()
+func (a *SequenceTracker[RelationType, StateType, ValueType]) Current(ctx context.Context, relationName doltdb.TableName) (current StateType, err error) {
+	err = a.awaitInit(ctx)
 	if err != nil {
 		return current, err
 	}
@@ -207,7 +207,7 @@ func (a *SequenceTracker[RelationType, StateType, ValueType]) Current(relationNa
 // Next returns the next auto increment value for |relationName| using |insertVal| from an insert. If |insertVal| is
 // null or 0, it is generated from the sequence.
 func (a *SequenceTracker[RelationType, StateType, ValueType]) Next(ctx *sql.Context, relationName doltdb.TableName, insertVal interface{}) (nextValue ValueType, err error) {
-	err = a.waitForInit()
+	err = a.awaitInit(ctx)
 	if err != nil {
 		return nextValue, err
 	}
@@ -219,7 +219,10 @@ func (a *SequenceTracker[RelationType, StateType, ValueType]) Next(ctx *sql.Cont
 	// short per-table lock here.
 	locked := false
 	if a.lockMode == LockMode_Interleaved {
-		release := a.mm.Lock(relationName)
+		release, err := a.mm.Lock(ctx, relationName)
+		if err != nil {
+			return nextValue, err
+		}
 		defer release()
 		locked = true
 	}
@@ -230,7 +233,10 @@ func (a *SequenceTracker[RelationType, StateType, ValueType]) Next(ctx *sql.Cont
 		// restored after startup, so initialize it here.
 		if !locked {
 			if a.lockMode == LockMode_Interleaved {
-				release := a.mm.Lock(relationName)
+				release, err := a.mm.Lock(ctx, relationName)
+				if err != nil {
+					return nextValue, err
+				}
 				defer release()
 				locked = true
 			}
@@ -289,14 +295,17 @@ func (a *SequenceTracker[RelationType, StateType, ValueType]) Next(ctx *sql.Cont
 // table. Otherwise, the update is silently disregarded. So far this matches the MySQL behavior, but Dolt uses the
 // maximum value for this table across all branches.
 func (a *SequenceTracker[RelationType, StateType, ValueType]) Set(ctx *sql.Context, relationName doltdb.TableName, table RelationType, ws ref.WorkingSetRef, newSequenceState StateType) (newRelation RelationType, err error) {
-	err = a.waitForInit()
+	err = a.awaitInit(ctx)
 	if err != nil {
 		return newRelation, err
 	}
 
 	relationName = relationName.ToLower()
 
-	release := a.mm.Lock(relationName)
+	release, err := a.mm.Lock(ctx, relationName)
+	if err != nil {
+		return newRelation, err
+	}
 	defer release()
 
 	existing, ok := loadSequenceState(a.sequences, relationName)
@@ -428,15 +437,18 @@ func (a *SequenceTracker[RelationType, StateType, ValueType]) deepSet(ctx *sql.C
 }
 
 // AddNewRelation initializes a new table with an auto increment column to the tracker, as necessary
-func (a *SequenceTracker[RelationType, StateType, ValueType]) AddNewRelation(relationName doltdb.TableName, initialState StateType) error {
+func (a *SequenceTracker[RelationType, StateType, ValueType]) AddNewRelation(ctx context.Context, relationName doltdb.TableName, initialState StateType) error {
 	relationName = relationName.ToLower()
-	err := a.waitForInit()
+	err := a.awaitInit(ctx)
 	if err != nil {
 		return err
 	}
 
 	// only initialize the sequence for this table if no other branch has such a table
-	release := a.mm.Lock(relationName)
+	release, err := a.mm.Lock(ctx, relationName)
+	if err != nil {
+		return err
+	}
 	defer release()
 
 	existingState, hasExisting := a.sequences.Load(relationName)
@@ -452,14 +464,17 @@ func (a *SequenceTracker[RelationType, StateType, ValueType]) AddNewRelation(rel
 // To establish the new auto increment value, callers must also pass all other working sets in scope that may include
 // a table with the same name, omitting the working set that just deleted the table named.
 func (a *SequenceTracker[RelationType, StateType, ValueType]) DropRelation(ctx *sql.Context, relationName doltdb.TableName, wses ...*doltdb.WorkingSet) error {
-	err := a.waitForInit()
+	err := a.awaitInit(ctx)
 	if err != nil {
 		return err
 	}
 
 	relationName = relationName.ToLower()
 
-	release := a.mm.Lock(relationName)
+	release, err := a.mm.Lock(ctx, relationName)
+	if err != nil {
+		return err
+	}
 	defer release()
 
 	// A State representing the "furthest along" state among all working sets.
@@ -504,7 +519,7 @@ func (a *SequenceTracker[RelationType, StateType, ValueType]) DropRelation(ctx *
 }
 
 func (a *SequenceTracker[RelationType, StateType, ValueType]) AcquireLock(ctx *sql.Context, relationName doltdb.TableName) (func(), error) {
-	err := a.waitForInit()
+	err := a.awaitInit(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -516,11 +531,7 @@ func (a *SequenceTracker[RelationType, StateType, ValueType]) AcquireLock(ctx *s
 	// Normalized like every other use of |mm|, so that the statement-level lock excludes
 	// the same allocations and merges a per-row lock would, whatever case the statement
 	// referred to the relation by.
-	return a.mm.Lock(relationName.ToLower()), nil
-}
-
-func (a *SequenceTracker[RelationType, StateType, ValueType]) waitForInit() error {
-	return a.awaitInit(context.Background())
+	return a.mm.Lock(ctx, relationName.ToLower())
 }
 
 // awaitInit blocks until the tracker's initialization finishes and returns its result,
@@ -621,7 +632,9 @@ func (a *SequenceTracker[RelationType, StateType, ValueType]) mergeRoots(ctx con
 				if err != nil {
 					return err
 				}
-				a.mergeSequenceState(relationName, seq)
+				if err := a.mergeSequenceState(ctx, relationName, seq); err != nil {
+					return err
+				}
 			}
 			return nil
 		})
@@ -634,18 +647,20 @@ func (a *SequenceTracker[RelationType, StateType, ValueType]) mergeRoots(ctx con
 // further along, and leaves it alone otherwise.
 //
 // The read-modify-write is done under the per-relation lock that Next, Set, AddNewRelation
-// and DropRelation also take. Without it, an allocation sitting between its own read and
-// write-back overwrites whatever was merged in here, sending the tracker backwards and
-// handing out values another branch has already used.
-func (a *SequenceTracker[RelationType, StateType, ValueType]) mergeSequenceState(relationName doltdb.TableName, seq StateType) {
+// and DropRelation also take.
+func (a *SequenceTracker[RelationType, StateType, ValueType]) mergeSequenceState(ctx context.Context, relationName doltdb.TableName, seq StateType) error {
 	key := relationName.ToLower()
-	release := a.mm.Lock(key)
+	release, err := a.mm.Lock(ctx, key)
+	if err != nil {
+		return err
+	}
 	defer release()
 
 	if current, ok := a.sequences.Load(key); ok && !seq.GreaterThan(current) {
-		return
+		return nil
 	}
 	a.sequences.Store(key, seq)
+	return nil
 }
 
 // validateAutoIncrementBounds checks if a value (or value+1 if checkIncrement) is valid for the auto-increment column type

--- a/go/libraries/doltcore/sqle/dsess/sequence_tracker_test.go
+++ b/go/libraries/doltcore/sqle/dsess/sequence_tracker_test.go
@@ -1,0 +1,224 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dsess
+
+import (
+	"context"
+	"iter"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess/mutexmap"
+	"github.com/dolthub/dolt/go/store/hash"
+)
+
+// The types below instantiate the generic SequenceTracker over stub relations, so that
+// merge behavior can be exercised without building a real database. gatedState doubles as
+// an ordinary counter (when its channels are nil) and as a way to park a Next() call
+// exactly between its read of the tracked state and its write-back of the successor.
+
+type gatedState struct {
+	v       uint64
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (s gatedState) Next() (uint64, bool, gatedState, error) {
+	if s.entered != nil {
+		close(s.entered)
+		<-s.release
+	}
+	return s.v, true, gatedState{v: s.v + 1}, nil
+}
+func (s gatedState) CurrentValue() uint64          { return s.v }
+func (s gatedState) WithValue(v uint64) gatedState { return gatedState{v: v} }
+func (s gatedState) GreaterThan(o gatedState) bool { return s.v > o.v }
+func (s gatedState) AtEnd() bool                   { return false }
+func (s gatedState) Merge(o gatedState) gatedState {
+	if o.v > s.v {
+		return o
+	}
+	return s
+}
+func (s gatedState) WithSQLValue(ctx *sql.Context, v interface{}) (gatedState, error) {
+	return gatedState{v: v.(uint64)}, nil
+}
+
+type stubRelation struct{ state gatedState }
+
+func (r stubRelation) GetSequenceState(ctx context.Context) (gatedState, error) { return r.state, nil }
+func (r stubRelation) HasSequenceState(ctx context.Context) (bool, error)       { return true, nil }
+func (r stubRelation) GetSequenceSqlType(ctx context.Context) (sql.Type, bool, error) {
+	return nil, false, nil
+}
+func (r stubRelation) SetSequenceState(ctx context.Context, v gatedState) (stubRelation, error) {
+	return stubRelation{state: v}, nil
+}
+func (r stubRelation) TrySetSequenceState(ctx *sql.Context, v gatedState) (stubRelation, bool, error) {
+	return stubRelation{state: v}, true, nil
+}
+
+// stubSource reports a single relation, "t", whose recorded value the test controls.
+type stubSource struct{ value uint64 }
+
+func (s *stubSource) GetRelation(ctx context.Context, root doltdb.RootValue, n doltdb.TableName) (stubRelation, string, bool, error) {
+	return stubRelation{state: gatedState{v: s.value}}, n.Name, true, nil
+}
+func (s *stubSource) IterRelations(ctx context.Context, root doltdb.RootValue) iter.Seq2[doltdb.TableName, stubRelation] {
+	return func(yield func(doltdb.TableName, stubRelation) bool) {
+		yield(stubTable, stubRelation{state: gatedState{v: s.value}})
+	}
+}
+
+var stubTable = doltdb.TableName{Name: "t"}
+
+type nilRoot struct{}
+
+func (nilRoot) ResolveRootValue(ctx context.Context) (doltdb.RootValue, error) { return nil, nil }
+func (nilRoot) HashOf() (hash.Hash, error)                                     { return hash.Hash{}, nil }
+
+type stubTracker = SequenceTracker[stubRelation, gatedState, uint64]
+
+func newStubTracker(src *stubSource) *stubTracker {
+	trk := &stubTracker{
+		dbName:         "db",
+		sequences:      &SyncMap[doltdb.TableName, gatedState]{},
+		mm:             mutexmap.NewMutexMap(),
+		init:           make(chan struct{}),
+		cancelInit:     make(chan struct{}),
+		relationSource: src,
+		lockMode:       LockMode_Interleaved,
+	}
+	close(trk.init)
+	return trk
+}
+
+// TestMergeRootsOnlyRaises pins the semantics dolt_reset --hard depends on: global
+// sequence state is a high-water mark across every branch, so telling the tracker about a
+// working set can raise a sequence but never lower it.
+func TestMergeRootsOnlyRaises(t *testing.T) {
+	src := &stubSource{}
+	trk := newStubTracker(src)
+	trk.sequences.Store(stubTable, gatedState{v: 10})
+
+	src.value = 5
+	require.NoError(t, trk.MergeRoots(context.Background(), nilRoot{}))
+	got, _ := trk.sequences.Load(stubTable)
+	require.Equal(t, uint64(10), got.v, "a lower root must not lower the tracked value")
+
+	src.value = 20
+	require.NoError(t, trk.MergeRoots(context.Background(), nilRoot{}))
+	got, _ = trk.sequences.Load(stubTable)
+	require.Equal(t, uint64(20), got.v, "a higher root must raise the tracked value")
+}
+
+// TestMergeRootsAddsUnseenRelations covers the case dolt_reset --hard actually exists for:
+// a table the tracker has no entry for, because it was dropped and the reset brought it
+// back.
+func TestMergeRootsAddsUnseenRelations(t *testing.T) {
+	trk := newStubTracker(&stubSource{value: 7})
+	require.NoError(t, trk.MergeRoots(context.Background(), nilRoot{}))
+
+	got, ok := trk.sequences.Load(stubTable)
+	require.True(t, ok)
+	require.Equal(t, uint64(7), got.v)
+}
+
+// TestMergeRootsDoesNotClobberInFlightAllocation pins the per-relation locking in the
+// merge. Without it, an allocation parked between its read of the tracked state and its
+// write-back overwrites whatever the merge raised the value to, sending the tracker
+// backwards and handing out values another branch has already used.
+func TestMergeRootsDoesNotClobberInFlightAllocation(t *testing.T) {
+	const highWater = uint64(1 << 40)
+	trk := newStubTracker(&stubSource{value: highWater})
+
+	gate := gatedState{v: 1, entered: make(chan struct{}), release: make(chan struct{})}
+	trk.sequences.Store(stubTable, gate)
+
+	// An in-flight insert allocates off the tracker and parks mid-allocation.
+	nextDone := make(chan struct{})
+	go func() {
+		defer close(nextDone)
+		_, err := trk.Next(sql.NewEmptyContext(), stubTable, nil)
+		require.NoError(t, err)
+	}()
+	<-gate.entered
+
+	// dolt_reset --hard merges a much higher value while that insert is parked. It must
+	// block behind the allocation rather than interleave with it.
+	mergeDone := make(chan struct{})
+	go func() {
+		defer close(mergeDone)
+		require.NoError(t, trk.MergeRoots(context.Background(), nilRoot{}))
+	}()
+	select {
+	case <-mergeDone:
+		t.Fatal("merge did not serialize against the in-flight allocation")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(gate.release)
+	<-nextDone
+	<-mergeDone
+
+	got, _ := trk.sequences.Load(stubTable)
+	require.GreaterOrEqual(t, got.v, highWater,
+		"in-flight allocation clobbered the value raised by the concurrent merge")
+}
+
+// TestConcurrentMergeRootsWithReaders runs merges against a database that is being read
+// and written at the same time, which is the dolt_reset/dolt_checkout-on-separate-sessions
+// shape. Under -race it also pins that a merge does not race readers of the tracker's
+// initialization result.
+func TestConcurrentMergeRootsWithReaders(t *testing.T) {
+	trk := newStubTracker(&stubSource{value: 1})
+	trk.sequences.Store(stubTable, gatedState{v: 1})
+
+	stop := make(chan struct{})
+	var workers sync.WaitGroup
+
+	for i := 0; i < 4; i++ {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			var last uint64
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				cur, err := trk.Current(stubTable)
+				require.NoError(t, err)
+				require.GreaterOrEqual(t, cur.v, last, "tracked value went backwards")
+				last = cur.v
+
+				_, err = trk.Next(sql.NewEmptyContext(), stubTable, nil)
+				require.NoError(t, err)
+			}
+		}()
+	}
+
+	for i := 0; i < 200; i++ {
+		require.NoError(t, trk.MergeRoots(context.Background(), nilRoot{}, nilRoot{}))
+	}
+	close(stop)
+	workers.Wait()
+}

--- a/go/libraries/doltcore/sqle/dsess/sequence_tracker_test.go
+++ b/go/libraries/doltcore/sqle/dsess/sequence_tracker_test.go
@@ -205,7 +205,7 @@ func TestConcurrentMergeRootsWithReaders(t *testing.T) {
 					return
 				default:
 				}
-				cur, err := trk.Current(stubTable)
+				cur, err := trk.Current(context.Background(), stubTable)
 				require.NoError(t, err)
 				require.GreaterOrEqual(t, cur.v, last, "tracked value went backwards")
 				last = cur.v
@@ -221,4 +221,78 @@ func TestConcurrentMergeRootsWithReaders(t *testing.T) {
 	}
 	close(stop)
 	workers.Wait()
+}
+
+// TestMergeRootsIsCancellableWhileWaitingForARelationLock pins that a merge blocked behind
+// a long holder of the per-relation lock gives up when its own query is killed. Outside
+// interleaved lock mode that holder is an entire insert statement, so a dolt_reset --hard
+// arriving mid-insert would otherwise park somewhere KILL QUERY cannot reach it.
+func TestMergeRootsIsCancellableWhileWaitingForARelationLock(t *testing.T) {
+	const highWater = uint64(1 << 40)
+	trk := newStubTracker(&stubSource{value: highWater})
+	trk.sequences.Store(stubTable, gatedState{v: 1})
+
+	// The statement-level lock AcquireLock hands to the engine for the duration of an insert.
+	release, err := trk.mm.Lock(context.Background(), stubTable.ToLower())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	mergeErr := make(chan error, 1)
+	go func() { mergeErr <- trk.MergeRoots(ctx, nilRoot{}) }()
+
+	select {
+	case err := <-mergeErr:
+		t.Fatalf("merge returned %v without waiting for the relation lock", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case err := <-mergeErr:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(30 * time.Second):
+		t.Fatal("merge did not return after its context was canceled")
+	}
+
+	got, _ := trk.sequences.Load(stubTable)
+	require.Equal(t, uint64(1), got.v, "an abandoned merge must not have applied")
+
+	release()
+}
+
+// TestAcquireLockIsCancellable pins the same for the statement-level lock itself: an insert
+// waiting on another statement's auto-increment lock answers KILL QUERY.
+func TestAcquireLockIsCancellable(t *testing.T) {
+	trk := newStubTracker(&stubSource{value: 1})
+	trk.lockMode = LockMode_Traditional
+
+	release, err := trk.mm.Lock(context.Background(), stubTable.ToLower())
+	require.NoError(t, err)
+	defer release()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	type result struct {
+		release func()
+		err     error
+	}
+	acquired := make(chan result, 1)
+	go func() {
+		r, err := trk.AcquireLock(sql.NewContext(ctx), stubTable)
+		acquired <- result{release: r, err: err}
+	}()
+
+	select {
+	case r := <-acquired:
+		t.Fatalf("AcquireLock returned (%v) while the lock was held", r.err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case r := <-acquired:
+		require.ErrorIs(t, r.err, context.Canceled)
+		require.Nil(t, r.release)
+	case <-time.After(30 * time.Second):
+		t.Fatal("AcquireLock did not return after its context was canceled")
+	}
 }

--- a/go/libraries/doltcore/sqle/dsess/session.go
+++ b/go/libraries/doltcore/sqle/dsess/session.go
@@ -1208,13 +1208,19 @@ func (d *DoltSession) SetRoots(ctx *sql.Context, dbName string, roots doltdb.Roo
 	return d.SetWorkingSet(ctx, dbName, workingSet)
 }
 
-func (d *DoltSession) ResetGlobals(ctx *sql.Context, dbName string, root doltdb.RootValue) error {
+// MergeGlobals merges the sequence state recorded in |root| into the database's global
+// state, raising any tracked sequence that |root| is further along on.
+//
+// It cannot lower a sequence. Global sequence state is a high-water mark across every
+// branch, so a caller that has moved a working set backwards (dolt_reset --hard) is only
+// telling the tracker about relations it may not have seen, not undoing allocations.
+func (d *DoltSession) MergeGlobals(ctx *sql.Context, dbName string, root doltdb.RootValue) error {
 	sessionState, _, err := d.lookupDbState(ctx, dbName)
 	if err != nil {
 		return err
 	}
 
-	err = sessionState.dbState.globalState.InitWithRoots(ctx, root)
+	err = sessionState.dbState.globalState.MergeRoots(ctx, root)
 	if err != nil {
 		return err
 	}

--- a/go/libraries/doltcore/sqle/globalstate/global_state.go
+++ b/go/libraries/doltcore/sqle/globalstate/global_state.go
@@ -27,8 +27,8 @@ type GlobalState interface {
 	GetSequenceTracker(ctx context.Context, key interface{}) (SequenceTrackerBase, error)
 	// AddSequenceTracker adds a new SequenceTracker to the GlobalState, accessible by the provided key.
 	AddSequenceTracker(ctx context.Context, key interface{}, value SequenceTrackerBase) error
-	// InitWithRoots initializes all of the state's SequenceTrackers
-	InitWithRoots(ctx context.Context, roots ...doltdb.Rootish) error
+	// MergeRoots merges |roots| into all of the state's SequenceTrackers.
+	MergeRoots(ctx context.Context, roots ...doltdb.Rootish) error
 }
 
 // GlobalStateProvider is an optional interface for databases that provide global state tracking

--- a/go/libraries/doltcore/sqle/globalstate/sequence_tracker.go
+++ b/go/libraries/doltcore/sqle/globalstate/sequence_tracker.go
@@ -33,8 +33,10 @@ type SequenceTrackerBase interface {
 	AcquireLock(ctx *sql.Context, tableName doltdb.TableName) (func(), error)
 	// DropRelation removes a relation from the tracker.
 	DropRelation(ctx *sql.Context, tableName doltdb.TableName, wses ...*doltdb.WorkingSet) error
-	// InitWithRoots fills the SequenceTracker with values pulled from each root in order.
-	InitWithRoots(ctx context.Context, roots ...doltdb.Rootish) error
+	// MergeRoots raises the tracked state of every relation in |roots| to the value that
+	// root records. It is not initialization: it runs synchronously and reports failure
+	// only to its caller.
+	MergeRoots(ctx context.Context, roots ...doltdb.Rootish) error
 	// Close releases any resources that might be held by the tracker.
 	Close()
 }

--- a/go/libraries/doltcore/sqle/globalstate/sequence_tracker.go
+++ b/go/libraries/doltcore/sqle/globalstate/sequence_tracker.go
@@ -50,11 +50,11 @@ type SequenceTracker[
 ] interface {
 	SequenceTrackerBase
 	// Current returns the current sequence state for the given relation.
-	Current(tableName doltdb.TableName) (StateType, error)
+	Current(ctx context.Context, tableName doltdb.TableName) (StateType, error)
 	// Next returns the next SQL value produced by the given relation, and advances that relation's state.
 	Next(ctx *sql.Context, tableName doltdb.TableName, insertVal interface{}) (ValueType, error)
 	// AddNewRelation adds a new table to the tracker, initializing the sequence state to the provided |initialState|.
-	AddNewRelation(tableName doltdb.TableName, initialState StateType) error
+	AddNewRelation(ctx context.Context, tableName doltdb.TableName, initialState StateType) error
 	// Set sets the sequence state for the given relation. This operation may silently do nothing if this value is
 	// below the current value for this relation. The relation in the provided working set is assumed to already have the value
 	// given, so the new global maximum is computed without regard for its value in that working set.

--- a/go/libraries/doltcore/sqle/tables.go
+++ b/go/libraries/doltcore/sqle/tables.go
@@ -1580,7 +1580,7 @@ func (t *AlterableDoltTable) AddColumn(ctx *sql.Context, column *sql.Column, ord
 		if err != nil {
 			return err
 		}
-		err = ait.AddNewRelation(t.TableName(), doltdb.AutoIncrementState(1))
+		err = ait.AddNewRelation(ctx, t.TableName(), doltdb.AutoIncrementState(1))
 		if err != nil {
 			return err
 		}
@@ -2291,7 +2291,7 @@ func (t *AlterableDoltTable) ModifyColumn(ctx *sql.Context, columnName string, c
 		}
 
 		// TODO: this isn't transactional, and it should be (but none of the auto increment tracking is)
-		err = ait.AddNewRelation(t.TableName(), doltdb.AutoIncrementState(1))
+		err = ait.AddNewRelation(ctx, t.TableName(), doltdb.AutoIncrementState(1))
 		if err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
@@ -429,7 +429,7 @@ func (w *prollyTableWriter) table(ctx *sql.Context) (tbl *doltdb.Table, err erro
 				return nil, err
 			}
 		} else if w.aiSet {
-			aiVal, err := w.aiTracker.Current(w.tblName)
+			aiVal, err := w.aiTracker.Current(ctx, w.tblName)
 			if err != nil {
 				return nil, err
 			}

--- a/integration-tests/bats/auto_increment.bats
+++ b/integration-tests/bats/auto_increment.bats
@@ -1025,3 +1025,30 @@ SQL
     [ "$status" -ne 0 ]
     [[ "$output" =~ "duplicate primary key given: [9223372036854775807]" ]] || false
 }
+
+@test "auto_increment: dolt_reset --hard restores a sequence lowered by TRUNCATE" {
+    # TRUNCATE drops the table from the tracker and re-derives its sequence from the other
+    # branches in scope, which can leave the tracker below the branch it truncated on. A
+    # hard reset makes those rows live again, so it has to raise the tracker back over them
+    # or the next insert collides with a row it just restored.
+    run dolt sql <<SQL
+CREATE TABLE t (pk int PRIMARY KEY AUTO_INCREMENT, c0 int);
+INSERT INTO t (c0) VALUES (1),(2),(3);
+CALL DOLT_COMMIT('-Am','c1');
+CALL DOLT_CHECKOUT('-b','other');
+CALL DOLT_CHECKOUT('main');
+INSERT INTO t (c0) VALUES (4),(5),(6),(7),(8),(9),(10);
+CALL DOLT_COMMIT('-Am','c2');
+TRUNCATE t;
+CALL DOLT_RESET('--hard');
+INSERT INTO t (c0) VALUES (100);
+SQL
+    [ "$status" -eq 0 ] || false
+    [[ ! "$output" =~ "duplicate primary key" ]] || false
+
+    run dolt sql -q "SELECT pk FROM t ORDER BY pk;" -r csv
+    [ "$status" -eq 0 ]
+    [[ "${lines[1]}" =~ "1" ]] || false
+    [[ "${lines[11]}" =~ "11" ]] || false
+    [ "${#lines[@]}" -eq 12 ]
+}


### PR DESCRIPTION
Get rid of the unnecessary background work, and update the tracker state synchronously as part of the reset itself.