### PR TITLE
[no-release-notes] Close superseded dependency bumps regardless of CI

### DIFF
--- a/.github/workflows/bump-dependency.yaml
+++ b/.github/workflows/bump-dependency.yaml
@@ -173,32 +173,6 @@ jobs:
 
               if (pull.keepAlive) process.exit(0);
 
-              const checkSuiteRes = await github.rest.checks.listSuitesForRef({
-                owner,
-                repo,
-                ref: pull.headRef,
-              });
-
-              if (checkSuiteRes.data) {
-                const okConclusions = new Set(["success", "neutral", "skipped"]);
-                for (const suite of checkSuiteRes.data.check_suites) {
-                  console.log("suite id:", suite.id);
-                  console.log("suite app slug:", suite.app.slug);
-                  console.log("suite status:", suite.status);
-                  console.log("suite conclusion:", suite.conclusion);
-                  if (suite.app.slug === "github-actions") {
-                    if (suite.status !== "completed") {
-                      console.log(`Leaving pr open due to status:${suite.status} conclusion:${suite.conclusion}`);
-                      process.exit(0);
-                    }
-                    if (!suite.conclusion || !okConclusions.has(suite.conclusion)) {
-                      console.log(`Leaving pr open due to status:${suite.status} conclusion:${suite.conclusion}`);
-                      process.exit(0);
-                    }
-                  }
-                }
-              }
-
               console.log(`Closing open pr ${pull.number}`);
               await github.rest.issues.createComment({
                 issue_number: pull.number,


### PR DESCRIPTION
Simplify stale dependency-bump cleanup: once a newer bump PR is opened, close older bump PRs regardless of their CI result. The `keep-alive` label remains the explicit way to preserve an older bump.