### PR TITLE
Probe pending unique key conflicts

### DIFF
--- a/go/libraries/doltcore/sqle/writer/prolly_index_writer_keyless.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_index_writer_keyless.go
@@ -245,6 +245,33 @@ func (writer prollyKeylessSecondaryWriter) ValidateKeyViolations(ctx context.Con
 	return nil
 }
 
+// validateUniqueKeyViolation checks the mutable unique-index prefix for a conflicting keyless row.
+func (writer prollyKeylessSecondaryWriter) validateUniqueKeyViolation(ctx context.Context, sqlRow sql.Row) error {
+	if writer.predicate != nil {
+		matches, err := writer.predicate.Eval(ctx.(*sql.Context), sqlRow)
+		if err != nil {
+			return err
+		}
+		if !matches.(bool) {
+			return nil
+		}
+	}
+	for to := range writer.prefixBld.Desc.Count() {
+		value, err := writer.keyPartFromRow(ctx, to, sqlRow)
+		if err != nil {
+			return err
+		}
+		if err := tree.PutField(ctx, writer.mut.NodeStore(), writer.prefixBld, to, writer.trimKeyPart(to, value)); err != nil {
+			return err
+		}
+	}
+	prefixKey, err := writer.prefixBld.Build(ctx, sharePool)
+	if err != nil {
+		return err
+	}
+	return writer.checkForUniqueKeyError(ctx, prefixKey, sqlRow)
+}
+
 // trimKeyPart will trim entry into the sql.Row depending on the prefixLengths
 func (writer prollyKeylessSecondaryWriter) trimKeyPart(to int, keyPart interface{}) interface{} {
 	var prefixLength uint16

--- a/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
+++ b/go/libraries/doltcore/sqle/writer/prolly_table_writer.go
@@ -16,6 +16,8 @@ package writer
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
 
@@ -62,6 +64,7 @@ type prollyTableWriter struct {
 }
 
 var _ dsess.TableWriter = &prollyTableWriter{}
+var _ sql.UniqueKeyConflictCheckingRowInserter = &prollyTableWriter{}
 
 var _ UniqueKeyChangeReporter = &prollyTableWriter{}
 var _ AutoIncrementGetter = &prollyTableWriter{}
@@ -183,6 +186,82 @@ func (w *prollyTableWriter) Insert(ctx *sql.Context, sqlRow sql.Row) (err error)
 	w.aiSet = true
 
 	return nil
+}
+
+// HasUniqueKeyConflict implements sql.UniqueKeyConflictCheckingRowInserter.
+func (w *prollyTableWriter) HasUniqueKeyConflict(ctx *sql.Context, sqlRow sql.Row, columns []string) (bool, error) {
+	pkColumns := w.sch.GetPKCols().GetColumns()
+	pkNames := make([]string, len(pkColumns))
+	for idx, column := range pkColumns {
+		pkNames[idx] = column.Name
+	}
+	if len(columns) == 0 || sameColumnNames(columns, pkNames) {
+		conflict, err := isUniqueKeyConflict(w.primary.ValidateKeyViolations(ctx, sqlRow))
+		if err != nil || conflict || len(columns) > 0 {
+			return conflict, err
+		}
+	}
+
+	for _, index := range w.sch.Indexes().AllIndexes() {
+		if !index.IsUnique() || (len(columns) > 0 && (index.Predicate() != "" || !sameColumnNames(columns, index.ColumnNames()))) {
+			continue
+		}
+		indexWriter, ok := w.secondary[index.Name()]
+		if !ok {
+			return false, fmt.Errorf("unique index writer %q not found", index.Name())
+		}
+		if keylessWriter, ok := indexWriter.(prollyKeylessSecondaryWriter); ok {
+			conflict, err := isUniqueKeyConflict(keylessWriter.validateUniqueKeyViolation(ctx, sqlRow))
+			if err != nil || conflict || len(columns) > 0 {
+				return conflict, err
+			}
+			continue
+		}
+		conflict, err := isUniqueKeyConflict(indexWriter.ValidateKeyViolations(ctx, sqlRow))
+		if err != nil || conflict || len(columns) > 0 {
+			return conflict, err
+		}
+	}
+	if len(columns) == 0 {
+		return false, nil
+	}
+	return false, fmt.Errorf("unique key conflict target does not match a unique key")
+}
+
+// isUniqueKeyConflict converts supported duplicate-key errors into a conflict result.
+func isUniqueKeyConflict(err error) (bool, error) {
+	if err == nil {
+		return false, nil
+	}
+	if sql.ErrPrimaryKeyViolation.Is(err) || sql.ErrUniqueKeyViolation.Is(err) {
+		return true, nil
+	}
+	if _, ok := err.(secondaryUniqueKeyError); ok {
+		return true, nil
+	}
+	return false, err
+}
+
+// sameColumnNames reports whether two column-name slices contain the same names regardless of order or case.
+func sameColumnNames(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	matched := make([]bool, len(right))
+	for _, leftName := range left {
+		found := false
+		for idx, rightName := range right {
+			if !matched[idx] && strings.EqualFold(leftName, rightName) {
+				matched[idx] = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 // Update implements TableWriter.


### PR DESCRIPTION
Add writer support for checking pending unique-key conflicts before inserting a row. This gives the query engine the storage-layer information needed to implement PostgreSQL conflict handling without suppressing unrelated errors.

Part of dolthub/doltgresql#3091

Depends on: https://github.com/dolthub/go-mysql-server/pull/3758