### PR TITLE
Bump go-mysql-server dependency

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/dolthub/fslock v0.0.5
 	github.com/dolthub/ishell v0.0.0-20260414231531-5f031e3e9037
 	github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216
-	github.com/dolthub/vitess v0.0.0-20260901210329-5364bf844382
+	github.com/dolthub/vitess v0.0.0-20260902192558-0bc4b5f59705
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.13.0
 	github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568
@@ -65,7 +65,7 @@ require (
 	github.com/dolthub/dolt-mcp v0.3.4
 	github.com/dolthub/eventsapi_schema v0.0.0-20260715220557-d9b4a1c6b4d4
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-mysql-server v0.20.1-0.20260901230631-da4d8ec733de
+	github.com/dolthub/go-mysql-server v0.20.1-0.20260902231447-9281b64ae97b
 	github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63
 	github.com/edsrzf/mmap-go v1.2.0
 	github.com/esote/minmaxheap v1.0.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -217,6 +217,8 @@ github.com/dolthub/go-icu-regex v0.0.0-20260610153742-72563bc7ca83 h1:FEMjCGEroD
 github.com/dolthub/go-icu-regex v0.0.0-20260610153742-72563bc7ca83/go.mod h1:F3cnm+vMRK1HaU6+rNqQrOCyR03HHhR1GWG2gnPOqaE=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260901230631-da4d8ec733de h1:h5mTCGOjSZ886gleNiafQalepvdbgcc630oum4QKByw=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260901230631-da4d8ec733de/go.mod h1:rE1T7c/Mh3vJ+kjDLzXagy0URUqbUj0Zt3bOcF1v6PE=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260902231447-9281b64ae97b h1:/URGM0BLFLkN1iRJLLFHPa+7YRLNlXFA4KhbTLv8dIc=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260902231447-9281b64ae97b/go.mod h1:5f1YZ3D3SRyZFiuLM+6oAKzPS2nLoGTaZ/vViztS/Cw=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20260414231531-5f031e3e9037 h1:oIW9HwuWrhxv+4HZxA+QQSKHLqWFyXZ2FmNjUYwkdiM=
@@ -227,6 +229,8 @@ github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216 h1:JWkKRE4
 github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216/go.mod h1:e/FIZVvT2IR53HBCAo41NjqgtEnjMJGKca3Y/dAmZaA=
 github.com/dolthub/vitess v0.0.0-20260901210329-5364bf844382 h1:2uQ6y+HfjzyEZ5CcZY3Q5LNhoNuIlrtmdPirXS/ASqA=
 github.com/dolthub/vitess v0.0.0-20260901210329-5364bf844382/go.mod h1:5SVEJgAhw5nnQUFnGgKI1Svqes1Mw+zKUsalyxmOuG0=
+github.com/dolthub/vitess v0.0.0-20260902192558-0bc4b5f59705 h1:PTtW48CS94lLfZkcyWQa88LqWgOnlo4ltiwzcd0phq4=
+github.com/dolthub/vitess v0.0.0-20260902192558-0bc4b5f59705/go.mod h1:5SVEJgAhw5nnQUFnGgKI1Svqes1Mw+zKUsalyxmOuG0=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/ebitengine/purego v0.9.1 h1:a/k2f2HQU3Pi399RPW1MOaZyhKJL9w/xFpKAg4q1s0A=


### PR DESCRIPTION
Updates go-mysql-server to include the INFORMATION_SCHEMA utf8mb4 collation fix; companion GMS PR: https://github.com/dolthub/go-mysql-server/pull/3775.