### PR TITLE
fix: clear upstreams when removing a remote

### DIFF
--- a/go/libraries/doltcore/env/remotes.go
+++ b/go/libraries/doltcore/env/remotes.go
@@ -808,8 +808,6 @@ func UpstreamRef[C doltdb.Context](rsr RepoStateReader[C], branchRef ref.DoltRef
 		return nil, err
 	}
 
-	// TODO(elianddb): delete a branch's config entry on remote removal,
-	// so there's no ambiguity with an explicit non-remote merge ref.
 	upstream, hasUpstream := branchConfigs.Get(branchRef.GetPath())
 	if !hasUpstream || upstream.Merge.Ref == nil || upstream.Remote == "" {
 		return nil, nil

--- a/go/libraries/doltcore/env/repo_state.go
+++ b/go/libraries/doltcore/env/repo_state.go
@@ -232,12 +232,17 @@ func (rs *RepoState) AddRemote(r Remote) {
 
 func (rs *RepoState) RemoveRemote(r Remote) {
 	rs.Remotes.Delete(r.Name)
-	if rs.Branches == nil {
+	ClearTrackingBranches(rs.Branches, r.Name)
+}
+
+// ClearTrackingBranches removes tracking configurations for the named remote.
+func ClearTrackingBranches(branches *concurrentmap.Map[string, BranchConfig], remoteName string) {
+	if branches == nil {
 		return
 	}
-	for branchName, branch := range rs.Branches.Snapshot() {
-		if branch.Remote == r.Name {
-			rs.Branches.Delete(branchName)
+	for branchName, branch := range branches.Snapshot() {
+		if branch.Remote == remoteName {
+			branches.Delete(branchName)
 		}
 	}
 }

--- a/go/libraries/doltcore/env/repo_state.go
+++ b/go/libraries/doltcore/env/repo_state.go
@@ -232,6 +232,11 @@ func (rs *RepoState) AddRemote(r Remote) {
 
 func (rs *RepoState) RemoveRemote(r Remote) {
 	rs.Remotes.Delete(r.Name)
+	for branchName, branch := range rs.Branches.Snapshot() {
+		if branch.Remote == r.Name {
+			rs.Branches.Delete(branchName)
+		}
+	}
 }
 
 func (rs *RepoState) AddBackup(r Remote) {

--- a/go/libraries/doltcore/env/repo_state.go
+++ b/go/libraries/doltcore/env/repo_state.go
@@ -232,6 +232,9 @@ func (rs *RepoState) AddRemote(r Remote) {
 
 func (rs *RepoState) RemoveRemote(r Remote) {
 	rs.Remotes.Delete(r.Name)
+	if rs.Branches == nil {
+		return
+	}
 	for branchName, branch := range rs.Branches.Snapshot() {
 		if branch.Remote == r.Name {
 			rs.Branches.Delete(branchName)

--- a/go/libraries/doltcore/env/repo_state_test.go
+++ b/go/libraries/doltcore/env/repo_state_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/ref"
+	"github.com/dolthub/dolt/go/libraries/utils/concurrentmap"
+)
+
+func TestRemoveRemoteClearsTrackingBranches(t *testing.T) {
+	remotes := concurrentmap.New[string, Remote]()
+	remotes.Set("origin", Remote{Name: "origin"})
+	branches := concurrentmap.New[string, BranchConfig]()
+	branches.Set("tracked", BranchConfig{
+		Merge:  ref.MarshalableRef{Ref: ref.NewBranchRef("main")},
+		Remote: "origin",
+	})
+	branches.Set("other", BranchConfig{
+		Merge:  ref.MarshalableRef{Ref: ref.NewBranchRef("main")},
+		Remote: "upstream",
+	})
+
+	repoState := RepoState{Remotes: remotes, Branches: branches}
+	repoState.RemoveRemote(Remote{Name: "origin"})
+
+	_, found := repoState.Branches.Get("tracked")
+	require.False(t, found)
+	_, found = repoState.Branches.Get("other")
+	require.True(t, found)
+}

--- a/go/libraries/doltcore/env/repo_state_test.go
+++ b/go/libraries/doltcore/env/repo_state_test.go
@@ -44,3 +44,15 @@ func TestRemoveRemoteClearsTrackingBranches(t *testing.T) {
 	_, found = repoState.Branches.Get("other")
 	require.True(t, found)
 }
+
+func TestRemoveRemoteWithUninitializedBranches(t *testing.T) {
+	remotes := concurrentmap.New[string, Remote]()
+	remotes.Set("origin", Remote{Name: "origin"})
+	repoState := RepoState{Remotes: remotes}
+
+	require.NotPanics(t, func() {
+		repoState.RemoveRemote(Remote{Name: "origin"})
+	})
+	_, found := repoState.Remotes.Get("origin")
+	require.False(t, found)
+}

--- a/go/libraries/doltcore/env/repo_state_test.go
+++ b/go/libraries/doltcore/env/repo_state_test.go
@@ -56,3 +56,9 @@ func TestRemoveRemoteWithUninitializedBranches(t *testing.T) {
 	_, found := repoState.Remotes.Get("origin")
 	require.False(t, found)
 }
+
+func TestClearTrackingBranchesWithUninitializedBranches(t *testing.T) {
+	require.NotPanics(t, func() {
+		ClearTrackingBranches(nil, "origin")
+	})
+}

--- a/go/libraries/doltcore/sqle/dprocedures/dolt_remote.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_remote.go
@@ -157,32 +157,5 @@ func removeRemote(ctx *sql.Context, dbd env.DbData[*sql.Context], apr *argparser
 		}
 	}
 
-	// Remove branch configurations that reference the removed remote
-	branches, err := dbd.Rsr.GetBranches()
-	if err != nil {
-		return fmt.Errorf("failed to get branches: %w", err)
-	}
-
-	var branchesToUpdate []string
-	branches.Iter(func(branchName string, config env.BranchConfig) bool {
-		if config.Remote == remote.Name {
-			branchesToUpdate = append(branchesToUpdate, branchName)
-		}
-		return true
-	})
-
-	// Clear the remote tracking for these branches by updating their configs
-	for _, branchName := range branchesToUpdate {
-		currentConfig, _ := branches.Get(branchName)
-		updatedConfig := env.BranchConfig{
-			Merge:  currentConfig.Merge,
-			Remote: "", // Clear the remote reference
-		}
-		err = dbd.Rsw.UpdateBranch(branchName, updatedConfig)
-		if err != nil {
-			return fmt.Errorf("failed to update branch config for %s: %w", branchName, err)
-		}
-	}
-
 	return dbd.Rsw.RemoveRemote(ctx, remote.Name)
 }

--- a/go/libraries/doltcore/sqle/dsess/session_state_adapter.go
+++ b/go/libraries/doltcore/sqle/dsess/session_state_adapter.go
@@ -202,11 +202,7 @@ func (s SessionStateAdapter) RemoveRemote(_ context.Context, name string) error 
 	}
 
 	s.remotes.Delete(remote.Name)
-	for branchName, branch := range s.branches.Snapshot() {
-		if branch.Remote == remote.Name {
-			s.branches.Delete(branchName)
-		}
-	}
+	env.ClearTrackingBranches(s.branches, remote.Name)
 	return nil
 }
 

--- a/go/libraries/doltcore/sqle/dsess/session_state_adapter.go
+++ b/go/libraries/doltcore/sqle/dsess/session_state_adapter.go
@@ -180,7 +180,6 @@ func (s SessionStateAdapter) RemoveRemote(_ context.Context, name string) error 
 	if !ok {
 		return env.ErrRemoteNotFound
 	}
-	s.remotes.Delete(remote.Name)
 
 	fs, err := s.session.Provider().FileSystemForDatabase(s.dbName)
 	if err != nil {
@@ -197,8 +196,18 @@ func (s SessionStateAdapter) RemoveRemote(_ context.Context, name string) error 
 		// sanity check
 		return env.ErrRemoteNotFound
 	}
-	repoState.Remotes.Delete(name)
-	return repoState.Save(fs)
+	repoState.RemoveRemote(remote)
+	if err := repoState.Save(fs); err != nil {
+		return err
+	}
+
+	s.remotes.Delete(remote.Name)
+	for branchName, branch := range s.branches.Snapshot() {
+		if branch.Remote == remote.Name {
+			s.branches.Delete(branchName)
+		}
+	}
+	return nil
 }
 
 func (s SessionStateAdapter) RemoveBackup(_ context.Context, name string) error {

--- a/integration-tests/bats/pull.bats
+++ b/integration-tests/bats/pull.bats
@@ -95,6 +95,8 @@ teardown() {
 @test "pull: pull default custom remote" {
     cd repo2
     dolt remote remove origin
+    dolt fetch test-remote
+    dolt branch --set-upstream-to test-remote/main
 
     setup_remote_server
 

--- a/integration-tests/bats/remote-cmd.bats
+++ b/integration-tests/bats/remote-cmd.bats
@@ -121,7 +121,6 @@ teardown() {
     run dolt status
     [ "$status" -eq 0 ]
     [[ ! "$output" =~ "origin" ]] || false
-    [[ ! "$output" =~ "Your branch is up to date with 'origin/main'" ]] || false
     [[ ! "$output" =~ "Your branch is up to date with 'main'" ]] || false
 
     run grep -q 'origin' .dolt/repo_state.json
@@ -150,7 +149,6 @@ teardown() {
     run dolt status
     [ "$status" -eq 0 ]
     [[ ! "$output" =~ "origin" ]] || false
-    [[ ! "$output" =~ "Your branch is up to date with 'origin/main'" ]] || false
     [[ ! "$output" =~ "Your branch is up to date with 'main'" ]] || false
 
     run grep -q 'origin' .dolt/repo_state.json

--- a/integration-tests/bats/remote-cmd.bats
+++ b/integration-tests/bats/remote-cmd.bats
@@ -122,6 +122,36 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ ! "$output" =~ "origin" ]] || false
     [[ ! "$output" =~ "Your branch is up to date with 'origin/main'" ]] || false
+    [[ ! "$output" =~ "Your branch is up to date with 'main'" ]] || false
+
+    run grep -q 'origin' .dolt/repo_state.json
+    [ "$status" -eq 1 ]
+}
+
+@test "remote-cmd: SQL remove origin and verify tracking is gone" {
+    mkdir remote_repo
+    mkdir initter
+    cd initter
+    dolt init
+    dolt remote add origin file://../remote_repo
+    dolt push origin main
+    cd ../
+    rm -rf initter
+
+    dolt clone file://remote_repo cloned_repo
+    cd cloned_repo
+
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Your branch is up to date with 'origin/main'" ]] || false
+
+    dolt sql -q "CALL DOLT_REMOTE('remove','origin')"
+
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "origin" ]] || false
+    [[ ! "$output" =~ "Your branch is up to date with 'origin/main'" ]] || false
+    [[ ! "$output" =~ "Your branch is up to date with 'main'" ]] || false
 
     run grep -q 'origin' .dolt/repo_state.json
     [ "$status" -eq 1 ]

--- a/integration-tests/bats/sql-pull.bats
+++ b/integration-tests/bats/sql-pull.bats
@@ -72,6 +72,8 @@ teardown() {
 @test "sql-pull: dolt_pull default custom remote" {
     cd repo2
     dolt remote remove origin
+    dolt fetch test-remote
+    dolt branch --set-upstream-to test-remote/main
     dolt sql -q "call dolt_pull()"
     run dolt sql -q "show tables" -r csv
     [ "$status" -eq 0 ]


### PR DESCRIPTION
`dolt remote remove` now clears branch upstream configurations that reference the deleted remote, matching Git and preventing stale merge refs in `repo_state.json`. The regression preserves branches tracking other remotes; the `env/...` and CLI command suites, focused race test, vet, formatting, diff check, and CLI build pass.
Fixes #11529.
Close #11760 