### PR TITLE
nbs: bound conjoin's table-file open concurrency

### DIFF
--- a/go/store/nbs/conjoiner.go
+++ b/go/store/nbs/conjoiner.go
@@ -284,8 +284,22 @@ func conjoin(ctx context.Context, behavior dherrors.FatalBehavior, s conjoinStra
 	return mc, op.conjoinedSrc, cf, nil
 }
 
+// conjoinOpenConcurrency bounds how many table files conjoinTables opens at
+// once. Opening a table file is a network round trip for a remote persister,
+// and for a Git remote reached over SSH it costs a separate SSH connection.
+// An unbounded fan-out here therefore scales with the number of conjoinees and
+// can exceed the server's limit on concurrent unauthenticated connections
+// (sshd's MaxStartups defaults to 10), which drops the excess before
+// authentication and fails the conjoin.
+//
+// Local persisters are not meaningfully constrained by this: opening table
+// files is dominated by the index read, and eight in flight already saturates
+// a local disk.
+const conjoinOpenConcurrency = 8
+
 func conjoinTables(ctx context.Context, behavior dherrors.FatalBehavior, conjoinees []tableSpec, p tablePersister, stats *Stats) (conjoined tableSpec, src chunkSource, cleanup cleanupFunc, err error) {
 	eg, ectx := errgroup.WithContext(ctx)
+	eg.SetLimit(conjoinOpenConcurrency)
 	toConjoin := make(chunkSources, len(conjoinees))
 
 	for idx := range conjoinees {


### PR DESCRIPTION
Fixes #11739.

`conjoinTables` starts one goroutine per conjoinee with no limit. Where the persister's `Open`
is a network operation this fans out to an unbounded number of simultaneous connections; over a
Git remote reached by SSH each one is a separate SSH connection, so a single conjoin can exceed
the server's `MaxStartups` (default `10:30:100`) and have its connections dropped during key
exchange. The conjoin then fails while the push reports success, so the table-file count grows
without bound and never compacts.

Measured against a self-hosted Git remote over SSH, sampling concurrent connections locally at
~5ms: **peak 18 concurrent, ~247 connections opened in a single conjoin push**, versus 2 for a
push that triggers no conjoin. 72 of 5,310 samples sat at or above the limit of 10.

This adds `eg.SetLimit(conjoinOpenConcurrency)` with a default of 8 — below the stock
`MaxStartups` so the default configuration works, and ample for local persisters where opening
a table file is dominated by the index read.

Happy to make the value configurable, or to apply the limit only for remote persisters, if
either is preferred.

**Testing:** `go vet ./store/nbs/` clean; `go test ./store/nbs/ -count=1` passes (30.9s).

**Diff:**

```go
+// conjoinOpenConcurrency bounds how many table files conjoinTables opens at
+// once. Opening a table file is a network round trip for a remote persister,
+// and for a Git remote reached over SSH it costs a separate SSH connection.
+// An unbounded fan-out here therefore scales with the number of conjoinees and
+// can exceed the server's limit on concurrent unauthenticated connections
+// (sshd's MaxStartups defaults to 10), which drops the excess before
+// authentication and fails the conjoin.
+//
+// Local persisters are not meaningfully constrained by this: opening table
+// files is dominated by the index read, and eight in flight already saturates
+// a local disk.
+const conjoinOpenConcurrency = 8
+
 func conjoinTables(...) {
 	eg, ectx := errgroup.WithContext(ctx)
+	eg.SetLimit(conjoinOpenConcurrency)
 	toConjoin := make(chunkSources, len(conjoinees))
```
