### PR TITLE
go: git remotes: kill the process group on cancel, bound the wait on inherited pipes.

### DIFF
--- a/go/libraries/doltcore/dbfactory/git_remote.go
+++ b/go/libraries/doltcore/dbfactory/git_remote.go
@@ -439,6 +439,8 @@ func gitCmd(ctx context.Context, args ...string) (*exec.Cmd, error) {
 	cmd := exec.CommandContext(ctx, p, args...) //nolint:gosec // controlled args
 	cmd.Env = append(os.Environ(), "LC_ALL=C")
 	gitauth.CmdSetsid(cmd)
+	gitauth.CmdKillGroupOnCancel(cmd)
+	cmd.WaitDelay = gitauth.CmdWaitDelay
 	return cmd, nil
 }
 

--- a/go/libraries/doltcore/dbfactory/git_remote.go
+++ b/go/libraries/doltcore/dbfactory/git_remote.go
@@ -459,7 +459,7 @@ func runGitInitBare(ctx context.Context, dir string) error {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		base := fmt.Errorf("git init --bare failed: %w\noutput:\n%s", err, strings.TrimSpace(string(out)))
-		return gitauth.NormalizeError(base, out)
+		return gitauth.NormalizeError(ctx, base, out)
 	}
 	return nil
 }
@@ -473,7 +473,7 @@ func runGitInDir(ctx context.Context, gitDir string, args ...string) (string, er
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		base := fmt.Errorf("git %s failed: %w\noutput:\n%s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
-		return "", gitauth.NormalizeError(base, out)
+		return "", gitauth.NormalizeError(ctx, base, out)
 	}
 	return string(out), nil
 }

--- a/go/libraries/utils/gitauth/cmd.go
+++ b/go/libraries/utils/gitauth/cmd.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitauth
+
+import (
+	"os/exec"
+	"time"
+)
+
+// CmdWaitDelay bounds how long Wait blocks on output pipes that are still open
+// after git itself is gone. git's transport runs as a grandchild (ssh, or
+// git-remote-https -> git send-pack) holding the pipe we read, so if it outlives
+// git there is no EOF to wait for. The delay elapses only when something is still
+// holding the pipe; a healthy run sees EOF as the processes exit.
+const CmdWaitDelay = 10 * time.Second
+
+// CmdKillGroupOnCancel makes cancellation of |cmd|'s context kill the whole
+// process group, so the transport processes git spawned go away with it.
+// exec.CommandContext's default Cancel signals one pid and leaves them running.
+//
+// Must be paired with CmdSetsid, which makes the child the group leader. Callers
+// should also set cmd.WaitDelay: a group kill cannot reach a holder that left the
+// group, such as an ssh ControlMaster.
+func CmdKillGroupOnCancel(cmd *exec.Cmd) {
+	cmd.Cancel = func() error {
+		return killProcessGroup(cmd)
+	}
+}

--- a/go/libraries/utils/gitauth/cmd_unix.go
+++ b/go/libraries/utils/gitauth/cmd_unix.go
@@ -17,6 +17,8 @@
 package gitauth
 
 import (
+	"errors"
+	"os"
 	"os/exec"
 	"syscall"
 )
@@ -25,4 +27,19 @@ import (
 // SSH needs /dev/tty to prompt for credentials; without one it exits with an auth error.
 func CmdSetsid(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}
+
+// killProcessGroup SIGKILLs the group |cmd| leads. CmdSetsid made the child a
+// group leader, so its pid is also the group id.
+func killProcessGroup(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return os.ErrProcessDone
+	}
+	err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	if errors.Is(err, syscall.ESRCH) {
+		// Report an empty group the way Process.Kill does, so exec does not treat a
+		// finished command as a failed cancellation.
+		return os.ErrProcessDone
+	}
+	return err
 }

--- a/go/libraries/utils/gitauth/cmd_windows.go
+++ b/go/libraries/utils/gitauth/cmd_windows.go
@@ -17,7 +17,9 @@
 package gitauth
 
 import (
+	"os"
 	"os/exec"
+	"strconv"
 	"syscall"
 
 	"golang.org/x/sys/windows"
@@ -29,4 +31,22 @@ func CmdSetsid(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		CreationFlags: windows.DETACHED_PROCESS,
 	}
+}
+
+// killProcessGroup kills |cmd| and its descendants. Windows has no group to
+// signal -- TerminateProcess takes one process, and DETACHED_PROCESS leaves no
+// console for GenerateConsoleCtrlEvent -- so use `taskkill /T`, which walks the
+// tree down from git while git is still alive.
+func killProcessGroup(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return os.ErrProcessDone
+	}
+	kill := exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(cmd.Process.Pid))
+	kill.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_NO_WINDOW}
+	if err := kill.Run(); err != nil {
+		// taskkill is unavailable or the pid is already gone: stop git itself so
+		// cancellation still takes effect, and let WaitDelay cover its descendants.
+		return cmd.Process.Kill()
+	}
+	return nil
 }

--- a/go/libraries/utils/gitauth/normalize.go
+++ b/go/libraries/utils/gitauth/normalize.go
@@ -16,7 +16,9 @@ package gitauth
 
 import (
 	"bytes"
+	"context"
 	"errors"
+	"os/exec"
 	"strings"
 )
 
@@ -47,12 +49,23 @@ func (e *NonInteractiveAuthError) Unwrap() error { return e.Cause }
 
 // NormalizeError wraps |err| in a [NonInteractiveAuthError] so that
 // credential hints are always appended to git remote failures.
-func NormalizeError(err error, output []byte) error {
+//
+// Neither a command |ctx| cancelled nor one whose Wait gave up on pipes an
+// outliving process still holds is an auth failure, so those keep their own error
+// and get no hints. A cancelled command surfaces as the child's kill signal, so
+// |ctx|'s error is joined in for callers that test for it.
+func NormalizeError(ctx context.Context, err error, output []byte) error {
 	if err == nil {
 		return nil
 	}
 	var already *NonInteractiveAuthError
 	if errors.As(err, &already) {
+		return err
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return errors.Join(ctxErr, err)
+	}
+	if errors.Is(err, exec.ErrWaitDelay) {
 		return err
 	}
 	return &NonInteractiveAuthError{

--- a/go/libraries/utils/gitauth/normalize_test.go
+++ b/go/libraries/utils/gitauth/normalize_test.go
@@ -15,7 +15,9 @@
 package gitauth
 
 import (
+	"context"
 	"errors"
+	"os/exec"
 	"strings"
 	"testing"
 )
@@ -35,7 +37,7 @@ func TestNormalizeError_AlwaysWrapsAndAppendsHints(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			got := NormalizeError(errors.New("git failed"), []byte(tt.output))
+			got := NormalizeError(context.Background(), errors.New("git failed"), []byte(tt.output))
 
 			var niae *NonInteractiveAuthError
 			if !errors.As(got, &niae) {
@@ -55,9 +57,44 @@ func TestNormalizeError_AlwaysWrapsAndAppendsHints(t *testing.T) {
 func TestNormalizeError_Idempotent(t *testing.T) {
 	base := errors.New("git failed")
 	authOutput := []byte("Permission denied (publickey).")
-	got1 := NormalizeError(base, authOutput)
-	got2 := NormalizeError(got1, authOutput)
+	got1 := NormalizeError(context.Background(), base, authOutput)
+	got2 := NormalizeError(context.Background(), got1, authOutput)
 	if got1 != got2 {
 		t.Fatalf("expected NormalizeError to be idempotent when already normalized")
+	}
+}
+
+// A cancelled command is not an auth failure: the caller's ctx error has to be
+// visible, and the credential hints have to stay off.
+func TestNormalizeError_CancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	base := errors.New("signal: killed")
+	got := NormalizeError(ctx, base, []byte("Permission denied (publickey)."))
+
+	if !errors.Is(got, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", got)
+	}
+	if !errors.Is(got, base) {
+		t.Fatalf("expected the command error preserved, got %v", got)
+	}
+	var niae *NonInteractiveAuthError
+	if errors.As(got, &niae) {
+		t.Fatalf("expected no credential hints for a cancelled command, got: %v", got)
+	}
+}
+
+// Nor is a Wait that gave up on pipes a process outliving git still holds.
+func TestNormalizeError_WaitDelayExpired(t *testing.T) {
+	base := errors.New("git failed: " + exec.ErrWaitDelay.Error())
+	got := NormalizeError(context.Background(), errors.Join(base, exec.ErrWaitDelay), nil)
+
+	if !errors.Is(got, exec.ErrWaitDelay) {
+		t.Fatalf("expected ErrWaitDelay preserved, got %v", got)
+	}
+	var niae *NonInteractiveAuthError
+	if errors.As(got, &niae) {
+		t.Fatalf("expected no credential hints for an expired wait, got: %v", got)
 	}
 }

--- a/go/store/blobstore/internal/git/impl_test.go
+++ b/go/store/blobstore/internal/git/impl_test.go
@@ -20,9 +20,12 @@ import (
 	"errors"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dolthub/dolt/go/store/testutils/gitrepo"
 )
@@ -44,6 +47,32 @@ func TestMain(m *testing.M) {
 					os.Exit(3)
 				}
 			}
+		case "holdpipe":
+			// Stands in for git's transport: records its pid, then holds the pipes it
+			// inherited for a minute. It never writes to them, so nothing about the
+			// read end being closed can end it early.
+			if err := os.WriteFile(os.Args[2], []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+				os.Exit(1)
+			}
+			time.Sleep(time.Minute)
+			os.Exit(0)
+		case "orphanexit", "orphanwait":
+			// Stands in for git: spawns a "transport" holding our pipes, then either
+			// exits and orphans it, or stays alive to be cancelled.
+			exe, err := os.Executable()
+			if err != nil {
+				os.Exit(1)
+			}
+			child := exec.Command(exe, "holdpipe", os.Args[2])
+			child.Stdout = os.Stdout
+			child.Stderr = os.Stderr
+			if err := child.Start(); err != nil {
+				os.Exit(1)
+			}
+			if os.Args[1] == "orphanwait" {
+				time.Sleep(time.Minute)
+			}
+			os.Exit(0)
 		}
 	}
 	os.Exit(m.Run())

--- a/go/store/blobstore/internal/git/runner.go
+++ b/go/store/blobstore/internal/git/runner.go
@@ -173,16 +173,7 @@ func (r *Runner) Run(ctx context.Context, opts RunOptions, args ...string) ([]by
 		Output:   out,
 		Cause:    err,
 	}
-	// Neither a cancelled command nor an abandoned pipe is an auth failure, so skip
-	// the credential hints NormalizeError appends. Cancellation surfaces as the
-	// child's kill signal, so name ctx.Err() for callers that test for it.
-	if ctxErr := ctx.Err(); ctxErr != nil {
-		return out, errors.Join(ctxErr, cerr)
-	}
-	if errors.Is(err, exec.ErrWaitDelay) {
-		return out, cerr
-	}
-	return out, gitauth.NormalizeError(cerr, out)
+	return out, gitauth.NormalizeError(ctx, cerr, out)
 }
 
 // Start starts "git <args...>" and returns a ReadCloser for stdout.
@@ -213,6 +204,7 @@ func (r *Runner) Start(ctx context.Context, opts RunOptions, args ...string) (io
 
 	// Wrap stdout so that Close also waits to avoid zombies if callers bail early.
 	rc := &cmdReadCloser{
+		ctx:    ctx,
 		r:      stdout,
 		cmd:    cmd,
 		stderr: &stderr,
@@ -223,6 +215,9 @@ func (r *Runner) Start(ctx context.Context, opts RunOptions, args ...string) (io
 }
 
 type cmdReadCloser struct {
+	// ctx is the context the command was started with, so Close can tell a
+	// cancellation from a git failure.
+	ctx     context.Context
 	r       io.ReadCloser
 	cmd     *exec.Cmd
 	stderr  *bytes.Buffer
@@ -263,7 +258,7 @@ func (c *cmdReadCloser) Close() error {
 		Output:   c.stderr.Bytes(),
 		Cause:    err,
 	}
-	return gitauth.NormalizeError(cerr, cerr.Output)
+	return gitauth.NormalizeError(c.ctx, cerr, cerr.Output)
 }
 
 func (r *Runner) env(opts RunOptions) []string {

--- a/go/store/blobstore/internal/git/runner.go
+++ b/go/store/blobstore/internal/git/runner.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/dolthub/dolt/go/libraries/utils/gitauth"
 )
@@ -38,6 +39,8 @@ type Runner struct {
 	gitDir  string
 	// extraEnv is appended to os.Environ() for every command.
 	extraEnv []string
+	// waitDelay is gitauth.CmdWaitDelay in production; tests shorten it.
+	waitDelay time.Duration
 }
 
 // NewRunner creates a Runner using the git binary on PATH.
@@ -52,8 +55,9 @@ func NewRunner(gitDir string) (*Runner, error) {
 // NewRunnerWithGitPath creates a Runner using an explicit git binary path.
 func NewRunnerWithGitPath(gitDir, gitPath string) *Runner {
 	return &Runner{
-		gitPath: gitPath,
-		gitDir:  gitDir,
+		gitPath:   gitPath,
+		gitDir:    gitDir,
+		waitDelay: gitauth.CmdWaitDelay,
 	}
 }
 
@@ -120,6 +124,8 @@ func (r *Runner) buildCmd(ctx context.Context, opts RunOptions, args []string) *
 	}
 	cmd.Env = r.env(opts)
 	gitauth.CmdSetsid(cmd)
+	gitauth.CmdKillGroupOnCancel(cmd)
+	cmd.WaitDelay = r.waitDelay
 	return cmd
 }
 
@@ -166,6 +172,15 @@ func (r *Runner) Run(ctx context.Context, opts RunOptions, args ...string) ([]by
 		ExitCode: exitCode,
 		Output:   out,
 		Cause:    err,
+	}
+	// Neither a cancelled command nor an abandoned pipe is an auth failure, so skip
+	// the credential hints NormalizeError appends. Cancellation surfaces as the
+	// child's kill signal, so name ctx.Err() for callers that test for it.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return out, errors.Join(ctxErr, cerr)
+	}
+	if errors.Is(err, exec.ErrWaitDelay) {
+		return out, cerr
 	}
 	return out, gitauth.NormalizeError(cerr, out)
 }

--- a/go/store/blobstore/internal/git/runner_test.go
+++ b/go/store/blobstore/internal/git/runner_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// readHelperPid waits for the holdpipe helper to record its pid in |path| and
+// arranges for it to be killed when the test ends.
+func readHelperPid(t *testing.T, path string) int {
+	t.Helper()
+
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		b, err := os.ReadFile(path)
+		if err == nil && len(b) > 0 {
+			pid, err := strconv.Atoi(strings.TrimSpace(string(b)))
+			if err != nil {
+				t.Fatalf("bad pid file %q: %v", string(b), err)
+			}
+			t.Cleanup(func() {
+				if p, err := os.FindProcess(pid); err == nil {
+					_ = p.Kill()
+				}
+			})
+			return pid
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("helper never recorded its pid at %s", path)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// A process that outlives git holds the pipe Run captures output on, and only
+// WaitDelay stops Wait from blocking on it for as long as that process lives.
+func TestRunner_WaitDelayBoundsAbandonedPipe(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := helperCommandRunner(t)
+	r.waitDelay = 2 * time.Second
+	pidFile := filepath.Join(t.TempDir(), "pid")
+
+	start := time.Now()
+	_, err := r.Run(ctx, RunOptions{}, "orphanexit", pidFile)
+	elapsed := time.Since(start)
+
+	// Returning at all is the point: the orphan holds the pipe for a minute.
+	if !errors.Is(err, exec.ErrWaitDelay) {
+		t.Fatalf("expected ErrWaitDelay while the orphan holds the pipe, got %v", err)
+	}
+	if elapsed < r.waitDelay {
+		t.Fatalf("returned after %v, before the %v delay elapsed", elapsed, r.waitDelay)
+	}
+	readHelperPid(t, pidFile)
+}

--- a/go/store/blobstore/internal/git/runner_unix_test.go
+++ b/go/store/blobstore/internal/git/runner_unix_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package git
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// Cancellation must reach the processes git spawned, not just git: a surviving
+// transport holds the pipe Wait reads.
+func TestRunner_CancelKillsProcessGroup(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := helperCommandRunner(t)
+	pidFile := filepath.Join(t.TempDir(), "pid")
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := r.Run(ctx, RunOptions{}, "orphanwait", pidFile)
+		done <- err
+	}()
+
+	transport := readHelperPid(t, pidFile)
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected a cancellation error, got %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("Run never returned after cancellation")
+	}
+
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		if err := syscall.Kill(transport, 0); errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("pid %d survived cancellation: the kill did not reach the process group", transport)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
A cancelled DOLT_PUSH/DOLT_FETCH wedged sql-server indefinitely (#11741): exec.CommandContext's default Cancel kills only the direct git child, so the transport it spawned survives holding the write end of the pipe Run reads from, and cmd.Wait() waits on an EOF nobody will send. Set cmd.Cancel to kill the whole group -- CmdSetsid already makes git the group leader, and Windows shells out to `taskkill /T` -- and set cmd.WaitDelay as a backstop for a holder that left the group, such as an ssh ControlMaster. Cancellation and expired-wait errors now report ctx.Err() rather than a bare kill signal, and skip the credential hints NormalizeError appends.