### PR TITLE
Coalesce git remote read fetches, answer absent keys from the cache.

### DIFF
--- a/go/store/blobstore/git_blobstore.go
+++ b/go/store/blobstore/git_blobstore.go
@@ -310,12 +310,20 @@ type GitBlobstore struct {
 	// from the in-memory cache. Protected by writeMu.
 	pendingCacheEvictions []string
 
-	// syncMu guards inFlightSync.
+	// syncMu guards the read-path fetch fields below.
 	syncMu sync.Mutex
 	// inFlightSync is the read-path fetch currently running, which readers
 	// arriving during it wait on instead of starting their own. Nil when none
 	// is running, so the zero value of GitBlobstore needs no initialization.
 	inFlightSync *inFlightSync
+	// drainingSync is a fetch that every waiter gave up on, now canceled. Its
+	// git process may still be exiting, so the next fetch waits for it rather
+	// than run a second one against the same remote-tracking ref.
+	drainingSync *inFlightSync
+	// syncsDisabled is non-zero while no read-path fetch may start: the store is
+	// closed, or a Teardown holds the repository. Reads are answered from
+	// whatever the cache already holds.
+	syncsDisabled int
 
 	// cacheMu guards all cache fields below.
 	cacheMu sync.RWMutex
@@ -690,6 +698,12 @@ func (gbs *GitBlobstore) CleanupOwnedLocalRef(ctx context.Context) error {
 // Teardown best-effort deletes this instance's UUID-owned refs and
 // periodically runs git gc to repack the cache repository.
 func (gbs *GitBlobstore) Teardown(ctx context.Context) error {
+	// The gc below repacks the object store a fetch writes into, and the ref
+	// deletions remove the remote-tracking ref it writes, so no read-path fetch
+	// may be in flight for the rest of this call.
+	gbs.quiesceSyncs(errGitStoreTornDown)
+	defer gbs.resumeSyncs()
+
 	// Best-effort periodic GC to repack the cache repo. Runs outside the
 	// write lock so a slow gc cannot serialize other writers. maybeRunGC
 	// has its own file-based lock for cross-process coordination.
@@ -720,6 +734,10 @@ func (gbs *GitBlobstore) Teardown(ctx context.Context) error {
 }
 
 func (gbs *GitBlobstore) Close() error {
+	// Deliberately not paired with a resumeSyncs: a closed store never fetches
+	// again, and answers reads from what it has already cached. Nothing errors
+	// out on a read after Close today, and this keeps it that way.
+	gbs.quiesceSyncs(errGitStoreClosed)
 	return nil
 }
 
@@ -767,6 +785,17 @@ func (gbs *GitBlobstore) maybeRunGC() {
 	_ = os.WriteFile(markerPath, nil, 0644)
 }
 
+// errGitSyncAbandoned cancels a read-path fetch that every waiting reader has
+// given up on.
+var errGitSyncAbandoned = errors.New("gitblobstore: read fetch abandoned, no readers waiting")
+
+// errGitStoreClosed cancels a read-path fetch when the store is closed under it.
+var errGitStoreClosed = errors.New("gitblobstore: store closed")
+
+// errGitStoreTornDown cancels a read-path fetch when the store is torn down
+// under it.
+var errGitStoreTornDown = errors.New("gitblobstore: store torn down")
+
 func (gbs *GitBlobstore) syncForRead(ctx context.Context) error {
 	if err := gbs.validateRemoteManaged(); err != nil {
 		return err
@@ -784,61 +813,162 @@ func (gbs *GitBlobstore) syncForRead(ctx context.Context) error {
 		return nil
 	}
 
-	// One fetch brings the whole ref, so concurrent readers all want the same
-	// thing, and for an ssh remote every extra fetch is another connection and
-	// another key exchange.
-	sync, owned := gbs.beginSync()
-	if !owned {
-		return sync.wait(ctx)
+	// Dedup concurrent readers.
+	sync, ok, err := gbs.beginSync(ctx)
+	if err != nil {
+		return err
 	}
-	// Deferred: a panic in the fetch must still release the waiters, or every
-	// later reader blocks on a fetch that will never finish.
-	var err error
-	defer func() { gbs.endSync(sync, err) }()
-	err = gbs.fetchAndMergeForRead(ctx)
-	return err
+	if !ok {
+		// Fetching is off for now: the store is closed or being torn down.
+		// Reads can still be sserved from the cache.
+		return nil
+	}
+	defer gbs.doneWaiting(sync)
+
+	select {
+	case <-sync.done:
+		return sync.err
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	}
 }
 
-// inFlightSync is a read-path fetch that other readers can wait on.
+// inFlightSync is a read-path fetch that readers wait on together.
+//
+// It runs on a context of its own rather than on the context of the waiter which
+// spawned it. No single reader's deadline decides the fate of the fetch for the
+// rest. It is canceled once no reader is waiting for it any more.
 type inFlightSync struct {
 	done chan struct{}
 	// err is the result of the fetch, written before |done| is closed.
 	err error
+	// cancel cancels the fetch's own context.
+	cancel context.CancelCauseFunc
+	// waiters is the count of waiting readers readers on this result.
+	// Guarded by GitBlobstore.syncMu.
+	waiters int
 }
 
-// wait returns the result of the in-flight fetch, which is as fresh as one the
-// caller would have started itself.
-//
-// It honors |ctx| because the fetch belongs to another caller, which may have no
-// deadline of its own and may be stuck on a hung connection.
-func (s *inFlightSync) wait(ctx context.Context) error {
-	select {
-	case <-s.done:
-		return s.err
-	case <-ctx.Done():
-		return ctx.Err()
+// beginSync registers the caller as a waiter on a read-path fetch, starting one
+// if none is running. It returns the fetch to wait on. It reports ok=false when
+// no fetch may run at all, which leaves the caller to answer from the cache.
+func (gbs *GitBlobstore) beginSync(ctx context.Context) (sync *inFlightSync, ok bool, err error) {
+	for {
+		gbs.syncMu.Lock()
+		if gbs.syncsDisabled > 0 {
+			gbs.syncMu.Unlock()
+			return nil, false, nil
+		}
+		if gbs.inFlightSync != nil {
+			// A fetch is already running. We add ourself as a waiter.
+			sync = gbs.inFlightSync
+			sync.waiters++
+			gbs.syncMu.Unlock()
+			return sync, true, nil
+		}
+		draining := gbs.drainingSync
+		if draining == nil {
+			// No fetch currently running and nothing to drain.
+			// Start a new sync and return that as what we block on.
+			sync = gbs.startSyncLocked()
+			gbs.syncMu.Unlock()
+			return sync, true, nil
+		}
+		gbs.syncMu.Unlock()
+
+		// An abandoned fetch is still winding down.
+		// Block on that canceled sync finishing before we start a new sync.
+		select {
+		case <-draining.done:
+		case <-ctx.Done():
+			return nil, false, context.Cause(ctx)
+		}
 	}
 }
 
-// beginSync returns the in-flight fetch to wait on, or, when there is none, a
-// new one that the caller owns and must complete with endSync.
-func (gbs *GitBlobstore) beginSync() (sync *inFlightSync, owned bool) {
-	gbs.syncMu.Lock()
-	defer gbs.syncMu.Unlock()
-	if gbs.inFlightSync != nil {
-		return gbs.inFlightSync, false
+// startSyncLocked starts a fetch whose sole waiter is the caller. Called with
+// syncMu held.
+func (gbs *GitBlobstore) startSyncLocked() *inFlightSync {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	sync := &inFlightSync{
+		done:    make(chan struct{}),
+		cancel:  cancel,
+		waiters: 1,
 	}
-	gbs.inFlightSync = &inFlightSync{done: make(chan struct{})}
-	return gbs.inFlightSync, true
+	gbs.inFlightSync = sync
+	// The fetch gets a goroutine of its own because it outlives the reader that
+	// started it whenever another reader is still waiting on it.
+	go func() {
+		defer cancel(nil)
+		defer gbs.finishSync(sync)
+		sync.err = gbs.fetchAndMergeForRead(ctx)
+	}()
+	return sync
 }
 
-// endSync publishes |err| to the waiters and lets the next fetch start.
-func (gbs *GitBlobstore) endSync(sync *inFlightSync, err error) {
+// finishSync publishes the result of a finished fetch to its waiters and retires
+// it, which lets the next fetch start.
+func (gbs *GitBlobstore) finishSync(sync *inFlightSync) {
 	gbs.syncMu.Lock()
-	gbs.inFlightSync = nil
+	if gbs.inFlightSync == sync {
+		gbs.inFlightSync = nil
+	}
+	if gbs.drainingSync == sync {
+		gbs.drainingSync = nil
+	}
 	gbs.syncMu.Unlock()
-	sync.err = err
 	close(sync.done)
+}
+
+// doneWaiting takes the caller out of |sync|'s waiters and cancels the fetch if
+// it was still inflight when the last waiter was removed.
+//
+// Cancellation is asynchronous: waiting for the git process to die is not
+// work a canceled waiter needs to do. GitBlobstore tracks the draining fetch
+// in |drainingSync| and whoever wants the next fetch has to wait for it before
+// starting their own.
+func (gbs *GitBlobstore) doneWaiting(sync *inFlightSync) {
+	gbs.syncMu.Lock()
+	sync.waiters--
+	abandoned := sync.waiters == 0 && gbs.inFlightSync == sync
+	if abandoned {
+		gbs.inFlightSync = nil
+		gbs.drainingSync = sync
+	}
+	gbs.syncMu.Unlock()
+
+	if abandoned {
+		sync.cancel(errGitSyncAbandoned)
+	}
+}
+
+// quiesceSyncs keeps new read-path fetches from starting and waits out any fetch
+// already running. Readers still waiting on a canceled fetch will get |cause|.
+// Pair every call with resumeSyncs, except from Close.
+func (gbs *GitBlobstore) quiesceSyncs(cause error) {
+	gbs.syncMu.Lock()
+	gbs.syncsDisabled++
+	sync, draining := gbs.inFlightSync, gbs.drainingSync
+	if sync != nil {
+		gbs.inFlightSync = nil
+		gbs.drainingSync = sync
+	}
+	gbs.syncMu.Unlock()
+
+	if sync != nil {
+		sync.cancel(cause)
+		<-sync.done
+	}
+	if draining != nil {
+		<-draining.done
+	}
+}
+
+// resumeSyncs undoes one quiesceSyncs, letting read-path fetches start again.
+func (gbs *GitBlobstore) resumeSyncs() {
+	gbs.syncMu.Lock()
+	gbs.syncsDisabled--
+	gbs.syncMu.Unlock()
 }
 
 // fetchAndMergeForRead fetches the remote ref and brings the cache up to date

--- a/go/store/blobstore/git_blobstore.go
+++ b/go/store/blobstore/git_blobstore.go
@@ -310,6 +310,13 @@ type GitBlobstore struct {
 	// from the in-memory cache. Protected by writeMu.
 	pendingCacheEvictions []string
 
+	// syncMu guards inFlightSync.
+	syncMu sync.Mutex
+	// inFlightSync is the read-path fetch currently running, which readers
+	// arriving during it wait on instead of starting their own. Nil when none
+	// is running, so the zero value of GitBlobstore needs no initialization.
+	inFlightSync *inFlightSync
+
 	// cacheMu guards all cache fields below.
 	cacheMu sync.RWMutex
 	// cacheHead is the last commit OID whose tree we merged into the cache.
@@ -558,12 +565,12 @@ func (gbs *GitBlobstore) mergeCacheFromHead(ctx context.Context, head git.OID) e
 		return fmt.Errorf("gitblobstore: cannot merge cache for empty head")
 	}
 
-	gbs.cacheMu.RLock()
-	if gbs.cacheHead == head {
-		gbs.cacheMu.RUnlock()
+	// An unchanged head still means the cache is up to date as of now. Say so,
+	// or the dedup window never renews against a quiet remote and every
+	// cache-missing read fetches again.
+	if gbs.markSyncedIfHeadUnchanged(head) {
 		return nil
 	}
-	gbs.cacheMu.RUnlock()
 
 	entries, err := gbs.api.ListTreeRecursive(ctx, head)
 	if err != nil {
@@ -574,6 +581,7 @@ func (gbs *GitBlobstore) mergeCacheFromHead(ctx context.Context, head git.OID) e
 
 	// Double-check under write lock for concurrent callers.
 	if gbs.cacheHead == head {
+		gbs.lastSyncedAt = time.Now()
 		gbs.cacheMu.Unlock()
 		return nil
 	}
@@ -616,6 +624,37 @@ func (gbs *GitBlobstore) mergeCacheFromHead(ctx context.Context, head git.OID) e
 	gbs.lastSyncedAt = time.Now()
 	gbs.cacheMu.Unlock()
 	return nil
+}
+
+// markSyncedIfHeadUnchanged refreshes the sync timestamp if the cache was
+// already merged from |head|, and reports whether it was.
+func (gbs *GitBlobstore) markSyncedIfHeadUnchanged(head git.OID) bool {
+	gbs.cacheMu.Lock()
+	defer gbs.cacheMu.Unlock()
+	if gbs.cacheHead != head {
+		return false
+	}
+	gbs.lastSyncedAt = time.Now()
+	return true
+}
+
+// syncedWithinTTL reports whether a sync completed recently enough that another
+// one would not tell us anything new.
+func (gbs *GitBlobstore) syncedWithinTTL() bool {
+	ttl := gbs.syncForReadTTL
+	if ttl <= 0 {
+		return false
+	}
+	gbs.cacheMu.RLock()
+	defer gbs.cacheMu.RUnlock()
+	return !gbs.lastSyncedAt.IsZero() && time.Since(gbs.lastSyncedAt) < ttl
+}
+
+// hasSyncedHead reports whether the cache has ever been merged from a commit.
+func (gbs *GitBlobstore) hasSyncedHead() bool {
+	gbs.cacheMu.RLock()
+	defer gbs.cacheMu.RUnlock()
+	return gbs.cacheHead != ""
 }
 
 func (gbs *GitBlobstore) Path() string {
@@ -736,13 +775,8 @@ func (gbs *GitBlobstore) syncForRead(ctx context.Context) error {
 	// Dedup guard: skip the fetch if we synced recently. The write path
 	// (fetchAlignAndMergeForWrite) always does its own unconditional fetch,
 	// so this only affects read-path callers (Get/Exists).
-	if ttl := gbs.syncForReadTTL; ttl > 0 {
-		gbs.cacheMu.RLock()
-		sinceLast := time.Since(gbs.lastSyncedAt)
-		gbs.cacheMu.RUnlock()
-		if sinceLast < ttl {
-			return nil
-		}
+	if gbs.syncedWithinTTL() {
+		return nil
 	}
 
 	// Concurrent fetches contend with an in-progress push on slow remotes.
@@ -750,6 +784,66 @@ func (gbs *GitBlobstore) syncForRead(ctx context.Context) error {
 		return nil
 	}
 
+	// One fetch brings the whole ref, so concurrent readers all want the same
+	// thing, and for an ssh remote every extra fetch is another connection and
+	// another key exchange.
+	sync, owned := gbs.beginSync()
+	if !owned {
+		return sync.wait(ctx)
+	}
+	// Deferred: a panic in the fetch must still release the waiters, or every
+	// later reader blocks on a fetch that will never finish.
+	var err error
+	defer func() { gbs.endSync(sync, err) }()
+	err = gbs.fetchAndMergeForRead(ctx)
+	return err
+}
+
+// inFlightSync is a read-path fetch that other readers can wait on.
+type inFlightSync struct {
+	done chan struct{}
+	// err is the result of the fetch, written before |done| is closed.
+	err error
+}
+
+// wait returns the result of the in-flight fetch, which is as fresh as one the
+// caller would have started itself.
+//
+// It honors |ctx| because the fetch belongs to another caller, which may have no
+// deadline of its own and may be stuck on a hung connection.
+func (s *inFlightSync) wait(ctx context.Context) error {
+	select {
+	case <-s.done:
+		return s.err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// beginSync returns the in-flight fetch to wait on, or, when there is none, a
+// new one that the caller owns and must complete with endSync.
+func (gbs *GitBlobstore) beginSync() (sync *inFlightSync, owned bool) {
+	gbs.syncMu.Lock()
+	defer gbs.syncMu.Unlock()
+	if gbs.inFlightSync != nil {
+		return gbs.inFlightSync, false
+	}
+	gbs.inFlightSync = &inFlightSync{done: make(chan struct{})}
+	return gbs.inFlightSync, true
+}
+
+// endSync publishes |err| to the waiters and lets the next fetch start.
+func (gbs *GitBlobstore) endSync(sync *inFlightSync, err error) {
+	gbs.syncMu.Lock()
+	gbs.inFlightSync = nil
+	gbs.syncMu.Unlock()
+	sync.err = err
+	close(sync.done)
+}
+
+// fetchAndMergeForRead fetches the remote ref and brings the cache up to date
+// with it. Only syncForRead may call it: it is what keeps one running at a time.
+func (gbs *GitBlobstore) fetchAndMergeForRead(ctx context.Context) error {
 	// Fetch remote ref into our remote-tracking ref.
 	err := gbs.api.FetchRef(ctx, gbs.remoteName, gbs.remoteRef, gbs.remoteTrackingRef)
 	if err != nil {
@@ -1002,6 +1096,9 @@ func (gbs *GitBlobstore) Exists(ctx context.Context, key string) (bool, error) {
 		if _, ok := gbs.cacheGetObject(key); ok {
 			return true, nil
 		}
+		if gbs.syncedAbsent(key) {
+			return false, nil
+		}
 	}
 
 	if err := gbs.syncForRead(ctx); err != nil {
@@ -1032,12 +1129,40 @@ func (gbs *GitBlobstore) Get(ctx context.Context, key string, br BlobRange) (io.
 		if _, ok := gbs.cacheGetObject(key); ok {
 			return gbs.getFromCache(ctx, key, br)
 		}
+		if gbs.syncedAbsent(key) {
+			return nil, 0, "", NotFound{Key: key}
+		}
 	}
 
 	if err := gbs.syncForRead(ctx); err != nil {
 		return nil, 0, "", err
 	}
 	return gbs.getFromCache(ctx, key, br)
+}
+
+// syncedAbsent reports that |key| does not exist, on the authority of the cache
+// alone, so the caller can skip fetching to find that out.
+//
+// The cache holds the complete recursive listing of the commit it was merged
+// from, plus this blobstore's own pending writes, so a key missing from it does
+// not exist as of that commit. Answering from the cache puts an absent key on
+// the same footing as a present one, which is already served as of that commit
+// rather than re-checked against the remote.
+//
+// A non-manifest key is content-addressed, so the only thing a fetch could add
+// is a key another writer has since pushed. Callers reach such a key by way of
+// the manifest naming it, and the manifest always fetches because it is never
+// served from the cache, so the sync that delivers a new manifest also delivers
+// the keys it names.
+func (gbs *GitBlobstore) syncedAbsent(key string) bool {
+	if key == gitblobstoreManifestKey {
+		return false
+	}
+	if !gbs.hasSyncedHead() {
+		return false
+	}
+	_, ok := gbs.cacheGetObject(key)
+	return !ok
 }
 
 func (gbs *GitBlobstore) getFromCache(ctx context.Context, key string, br BlobRange) (io.ReadCloser, uint64, string, error) {

--- a/go/store/blobstore/git_blobstore_fetch_coalescing_test.go
+++ b/go/store/blobstore/git_blobstore_fetch_coalescing_test.go
@@ -40,12 +40,17 @@ type countingFetchGitAPI struct {
 	// started is closed when the first fetch begins.
 	started     chan struct{}
 	startedOnce sync.Once
+	// canceled receives the cause of every fetch that ended because its own
+	// context was canceled. Buffered, so a test that ignores it never blocks a
+	// fetch. Its length is also the count of such fetches.
+	canceled chan error
 }
 
 func (c *countingFetchGitAPI) FetchRef(ctx context.Context, remote, srcRef, dstRef string) error {
 	c.total.Add(1)
 	c.startedOnce.Do(func() { close(c.started) })
 	n := c.inFlight.Add(1)
+	defer c.inFlight.Add(-1)
 	for {
 		max := c.maxSeen.Load()
 		if n <= max || c.maxSeen.CompareAndSwap(max, n) {
@@ -53,10 +58,41 @@ func (c *countingFetchGitAPI) FetchRef(ctx context.Context, remote, srcRef, dstR
 		}
 	}
 	if c.delay > 0 {
-		time.Sleep(c.delay)
+		// A real fetch dies when its context is canceled, and the point of a
+		// fetch owning its context is who gets to do that, so stand in for one
+		// faithfully rather than sleeping through cancellation.
+		select {
+		case <-time.After(c.delay):
+		case <-ctx.Done():
+			select {
+			case c.canceled <- context.Cause(ctx):
+			default:
+			}
+			return context.Cause(ctx)
+		}
 	}
-	c.inFlight.Add(-1)
 	return c.GitAPI.FetchRef(ctx, remote, srcRef, dstRef)
+}
+
+// awaitFetchStarted waits until |n| fetches have begun. The count rises before a
+// fetch does anything, so this is the signal that the nth one is in flight.
+func (c *countingFetchGitAPI) awaitFetchStarted(t *testing.T, n int64) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return c.total.Load() >= n
+	}, 5*time.Second, time.Millisecond, "fetch %d never started", n)
+}
+
+// awaitCanceledFetch returns the cause of the next fetch to end in cancellation.
+func (c *countingFetchGitAPI) awaitCanceledFetch(t *testing.T) error {
+	t.Helper()
+	select {
+	case cause := <-c.canceled:
+		return cause
+	case <-time.After(5 * time.Second):
+		t.Fatal("no fetch was canceled")
+		return nil
+	}
 }
 
 // newCountingBlobstore returns a blobstore whose fetches are counted, along with
@@ -75,8 +111,15 @@ func newCountingBlobstore(t *testing.T, ctx context.Context, tree map[string][]b
 	})
 	require.NoError(t, err)
 
-	counting := &countingFetchGitAPI{GitAPI: bs.api, started: make(chan struct{})}
+	counting := &countingFetchGitAPI{
+		GitAPI:   bs.api,
+		started:  make(chan struct{}),
+		canceled: make(chan error, 16),
+	}
 	bs.api = counting
+	// Close cancels and drains any fetch still running, which keeps a fetch
+	// goroutine from reading the repos t.TempDir is about to remove.
+	t.Cleanup(func() { require.NoError(t, bs.Close()) })
 	return bs, remoteRepo, counting
 }
 
@@ -264,4 +307,158 @@ func TestGitBlobstore_WaitingOnAnotherFetchHonorsContext(t *testing.T) {
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	require.Less(t, elapsed, stuckFor/2, "waiter blocked on the stuck fetch")
 	require.Equal(t, int64(1), counting.total.Load(), "the waiter must not start its own fetch")
+	require.Empty(t, counting.canceled, "a waiter leaving must not end a fetch another reader needs")
+}
+
+// A fetch is shared, so it must not answer to any one reader's deadline. The
+// reader that happened to start it giving up cannot be allowed to fail the
+// readers waiting behind it, which still have time of their own.
+func TestGitBlobstore_FetchOutlivesTheReaderThatStartedIt(t *testing.T) {
+	requireGitOnPath(t)
+
+	ctx := context.Background()
+	bs, _, counting := newCountingBlobstore(t, ctx, map[string][]byte{
+		"manifest": []byte("hello\n"),
+	}, time.Nanosecond)
+	// Longer than the first reader's deadline, shorter than the second's.
+	counting.delay = 300 * time.Millisecond
+
+	firstCtx, cancelFirst := context.WithTimeout(ctx, 50*time.Millisecond)
+	defer cancelFirst()
+	firstDone := make(chan error, 1)
+	go func() {
+		_, _, err := GetBytes(firstCtx, bs, "manifest", AllRange)
+		firstDone <- err
+	}()
+	<-counting.started
+
+	// A second reader joins the fetch the first one started, then outlives it.
+	secondCtx, cancelSecond := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelSecond()
+	secondDone := make(chan error, 1)
+	go func() {
+		got, _, err := GetBytes(secondCtx, bs, "manifest", AllRange)
+		if err == nil {
+			require.Equal(t, []byte("hello\n"), got)
+		}
+		secondDone <- err
+	}()
+
+	require.ErrorIs(t, <-firstDone, context.DeadlineExceeded)
+	require.NoError(t, <-secondDone, "the first reader's deadline must not fail a reader that still had time")
+	require.Equal(t, int64(1), counting.total.Load(), "the second reader must not start its own fetch")
+	require.Empty(t, counting.canceled, "the fetch had a waiter throughout and must not have been canceled")
+}
+
+// A fetch nobody is waiting for is work nobody asked for, so the last reader to
+// leave ends it.
+func TestGitBlobstore_LastReaderLeavingEndsTheFetch(t *testing.T) {
+	requireGitOnPath(t)
+
+	ctx := context.Background()
+	bs, _, counting := newCountingBlobstore(t, ctx, map[string][]byte{
+		"manifest": []byte("hello\n"),
+	}, time.Nanosecond)
+	// Stand in for a hung connection: far longer than the only reader will wait.
+	counting.delay = 30 * time.Second
+
+	readCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+	_, err := bs.Exists(readCtx, "manifest")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	require.ErrorIs(t, counting.awaitCanceledFetch(t), errGitSyncAbandoned)
+	require.Equal(t, int64(1), counting.total.Load())
+}
+
+// The abandoned fetch's git process is still exiting when the next reader
+// arrives. Only one fetch may run against the remote-tracking ref at a time, so
+// that reader waits it out rather than starting a second one alongside it.
+func TestGitBlobstore_NextFetchWaitsForTheAbandonedOne(t *testing.T) {
+	requireGitOnPath(t)
+
+	ctx := context.Background()
+	bs, _, counting := newCountingBlobstore(t, ctx, map[string][]byte{
+		"manifest": []byte("hello\n"),
+	}, time.Nanosecond)
+	counting.delay = 30 * time.Second
+
+	readCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+	_, err := bs.Exists(readCtx, "manifest")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	// Arrive while the abandoned fetch is winding down. This read must still be
+	// served, by a fetch of its own.
+	counting.delay = 0
+	got, _, err := GetBytes(ctx, bs, "manifest", AllRange)
+	require.NoError(t, err)
+	require.Equal(t, []byte("hello\n"), got)
+
+	require.Equal(t, int64(2), counting.total.Load(), "the second reader needed a fetch of its own")
+	require.Equal(t, int64(1), counting.maxSeen.Load(), "fetches must not overlap")
+	require.ErrorIs(t, counting.awaitCanceledFetch(t), errGitSyncAbandoned)
+}
+
+// Closing the store ends a fetch running under it, and says so. Afterwards the
+// store answers from the cache it already has and never fetches again.
+func TestGitBlobstore_CloseEndsAndDrainsTheFetch(t *testing.T) {
+	requireGitOnPath(t)
+
+	ctx := context.Background()
+	bs, _, counting := newCountingBlobstore(t, ctx, map[string][]byte{
+		"manifest": []byte("hello\n"),
+		"present":  []byte("abc"),
+	}, time.Nanosecond)
+
+	// Warm the cache, so there is something to answer from after the close.
+	_, _, err := GetBytes(ctx, bs, "manifest", AllRange)
+	require.NoError(t, err)
+
+	// A reader with no deadline of its own, the shape conjoin has.
+	counting.delay = 30 * time.Second
+	readDone := make(chan error, 1)
+	go func() {
+		_, _, err := GetBytes(context.Background(), bs, "manifest", AllRange)
+		readDone <- err
+	}()
+	counting.awaitFetchStarted(t, 2)
+
+	require.NoError(t, bs.Close())
+	require.Zero(t, counting.inFlight.Load(), "Close returned with a fetch still running")
+	require.ErrorIs(t, <-readDone, errGitStoreClosed, "a read caught by Close must say what happened")
+	require.ErrorIs(t, counting.awaitCanceledFetch(t), errGitStoreClosed)
+
+	// The cache outlives the close, and nothing goes to the remote for it.
+	got, _, err := GetBytes(ctx, bs, "present", AllRange)
+	require.NoError(t, err)
+	require.Equal(t, []byte("abc"), got)
+	ok, err := bs.Exists(ctx, "manifest")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, int64(2), counting.total.Load(), "a closed store must not fetch")
+}
+
+// Teardown deletes the remote-tracking ref a fetch writes and repacks the
+// objects it reads, so it must not run alongside one.
+func TestGitBlobstore_TeardownEndsAndDrainsTheFetch(t *testing.T) {
+	requireGitOnPath(t)
+
+	ctx := context.Background()
+	bs, _, counting := newCountingBlobstore(t, ctx, map[string][]byte{
+		"manifest": []byte("hello\n"),
+	}, time.Nanosecond)
+	counting.delay = 30 * time.Second
+
+	readDone := make(chan error, 1)
+	go func() {
+		_, _, err := GetBytes(context.Background(), bs, "manifest", AllRange)
+		readDone <- err
+	}()
+	<-counting.started
+
+	require.NoError(t, bs.Teardown(ctx))
+	require.Zero(t, counting.inFlight.Load(), "Teardown returned with a fetch still running")
+	require.ErrorIs(t, <-readDone, errGitStoreTornDown, "a read caught by Teardown must say what happened")
+	require.ErrorIs(t, counting.awaitCanceledFetch(t), errGitStoreTornDown)
 }

--- a/go/store/blobstore/git_blobstore_fetch_coalescing_test.go
+++ b/go/store/blobstore/git_blobstore_fetch_coalescing_test.go
@@ -1,0 +1,267 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstore
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	git "github.com/dolthub/dolt/go/store/blobstore/internal/git"
+	"github.com/dolthub/dolt/go/store/testutils/gitrepo"
+)
+
+// countingFetchGitAPI counts FetchRef calls and tracks how many ran at once, so
+// tests can assert that a burst of cache-missing reads costs one fetch.
+type countingFetchGitAPI struct {
+	git.GitAPI
+	total    atomic.Int64
+	inFlight atomic.Int64
+	maxSeen  atomic.Int64
+	// delay, when non-zero, holds each fetch open long enough for the rest of a
+	// concurrent burst to reach the coalescing point.
+	delay time.Duration
+	// started is closed when the first fetch begins.
+	started     chan struct{}
+	startedOnce sync.Once
+}
+
+func (c *countingFetchGitAPI) FetchRef(ctx context.Context, remote, srcRef, dstRef string) error {
+	c.total.Add(1)
+	c.startedOnce.Do(func() { close(c.started) })
+	n := c.inFlight.Add(1)
+	for {
+		max := c.maxSeen.Load()
+		if n <= max || c.maxSeen.CompareAndSwap(max, n) {
+			break
+		}
+	}
+	if c.delay > 0 {
+		time.Sleep(c.delay)
+	}
+	c.inFlight.Add(-1)
+	return c.GitAPI.FetchRef(ctx, remote, srcRef, dstRef)
+}
+
+// newCountingBlobstore returns a blobstore whose fetches are counted, along with
+// the counter. |ttl| is the read-side dedup window; a nanosecond effectively
+// disables it.
+func newCountingBlobstore(t *testing.T, ctx context.Context, tree map[string][]byte, ttl time.Duration) (*GitBlobstore, *gitrepo.Repo, *countingFetchGitAPI) {
+	t.Helper()
+
+	remoteRepo, localRepo, _ := newRemoteAndLocalRepos(t, ctx)
+	_, err := remoteRepo.SetRefToTree(ctx, DoltDataRef, tree, "seed remote")
+	require.NoError(t, err)
+
+	bs, err := NewGitBlobstoreWithOptions(localRepo.GitDir, DoltDataRef, GitBlobstoreOptions{
+		RemoteName:     "origin",
+		SyncForReadTTL: ttl,
+	})
+	require.NoError(t, err)
+
+	counting := &countingFetchGitAPI{GitAPI: bs.api, started: make(chan struct{})}
+	bs.api = counting
+	return bs, remoteRepo, counting
+}
+
+// A burst of concurrent readers must not each run its own fetch: one fetch
+// brings the whole ref, and for an ssh remote each extra one is a separate
+// connection and key exchange.
+func TestGitBlobstore_ConcurrentReadsCoalesceIntoOneFetch(t *testing.T) {
+	requireGitOnPath(t)
+
+	ctx := context.Background()
+	bs, _, counting := newCountingBlobstore(t, ctx, map[string][]byte{
+		"manifest": []byte("hello\n"),
+	}, time.Nanosecond)
+	// Hold each fetch open so the whole burst reaches the coalescing point
+	// while the first fetch is still running.
+	counting.delay = 100 * time.Millisecond
+
+	// The manifest is never served from the cache, so every one of these would
+	// fetch if fetches were not coalesced.
+	const readers = 24
+	errs := make([]error, readers)
+	var wg sync.WaitGroup
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _, errs[i] = GetBytes(ctx, bs, "manifest", AllRange)
+		}()
+	}
+	wg.Wait()
+	for _, err := range errs {
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, int64(1), counting.maxSeen.Load(), "fetches must not overlap")
+	require.Less(t, counting.total.Load(), int64(readers),
+		"expected concurrent readers to share a fetch, got %d fetches for %d readers",
+		counting.total.Load(), readers)
+}
+
+// A fetch that finds the remote head unchanged still refreshes the dedup
+// window. Otherwise the window never renews against a quiet remote and every
+// cache-missing read fetches again forever.
+func TestGitBlobstore_UnchangedHeadRenewsDedupWindow(t *testing.T) {
+	requireGitOnPath(t)
+
+	ctx := context.Background()
+	const ttl = 75 * time.Millisecond
+	bs, _, counting := newCountingBlobstore(t, ctx, map[string][]byte{
+		"manifest": []byte("hello\n"),
+	}, ttl)
+
+	_, _, err := GetBytes(ctx, bs, "manifest", AllRange)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), counting.total.Load())
+
+	// Let the window lapse. The next read fetches, and finds the same head.
+	time.Sleep(ttl * 2)
+	_, _, err = GetBytes(ctx, bs, "manifest", AllRange)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), counting.total.Load())
+
+	// That fetch renewed the window, so an immediate read reuses it.
+	_, _, err = GetBytes(ctx, bs, "manifest", AllRange)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), counting.total.Load(), "unchanged head did not renew the dedup window")
+}
+
+// Once the cache has been merged from a commit, it holds that commit's complete
+// listing, so an absent key is answered without going to the remote.
+func TestGitBlobstore_AbsentKeyIsAnsweredWithoutFetching(t *testing.T) {
+	requireGitOnPath(t)
+
+	ctx := context.Background()
+	bs, _, counting := newCountingBlobstore(t, ctx, map[string][]byte{
+		"manifest": []byte("hello\n"),
+		"present":  []byte("abc"),
+	}, time.Nanosecond)
+
+	// Warm the cache.
+	ok, err := bs.Exists(ctx, "manifest")
+	require.NoError(t, err)
+	require.True(t, ok)
+	warm := counting.total.Load()
+	require.Greater(t, warm, int64(0))
+
+	// This is the shape conjoin produces: many existence checks for records
+	// sub-objects that were never written.
+	for i := 0; i < 50; i++ {
+		ok, err := bs.Exists(ctx, "absent.records")
+		require.NoError(t, err)
+		require.False(t, ok)
+
+		_, _, _, err = bs.Get(ctx, "absent.records", AllRange)
+		require.Error(t, err)
+		require.True(t, IsNotFoundError(err))
+	}
+	require.Equal(t, warm, counting.total.Load(), "absent keys must not trigger a fetch")
+
+	// A present key is still served, and still without fetching.
+	got, _, err := GetBytes(ctx, bs, "present", AllRange)
+	require.NoError(t, err)
+	require.Equal(t, []byte("abc"), got)
+	require.Equal(t, warm, counting.total.Load())
+}
+
+// The manifest is the escape hatch that keeps authoritative absence safe: it is
+// never served from the cache, so the sync that delivers a new manifest also
+// delivers the keys that manifest names.
+func TestGitBlobstore_NewRemoteKeysArriveWithTheManifest(t *testing.T) {
+	requireGitOnPath(t)
+
+	ctx := context.Background()
+	bs, remoteRepo, counting := newCountingBlobstore(t, ctx, map[string][]byte{
+		"manifest": []byte("gen1\n"),
+	}, time.Nanosecond)
+
+	// Warm the cache, then confirm the not-yet-pushed table reads as absent
+	// without a fetch.
+	_, _, err := GetBytes(ctx, bs, "manifest", AllRange)
+	require.NoError(t, err)
+	warm := counting.total.Load()
+
+	ok, err := bs.Exists(ctx, "table")
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Equal(t, warm, counting.total.Load())
+
+	// Another writer pushes a new manifest naming a new table file.
+	_, err = remoteRepo.SetRefToTree(ctx, DoltDataRef, map[string][]byte{
+		"manifest": []byte("gen2\n"),
+		"table":    []byte("xyz"),
+	}, "second writer")
+	require.NoError(t, err)
+
+	// Reading the manifest always fetches, which brings the new table with it.
+	got, _, err := GetBytes(ctx, bs, "manifest", AllRange)
+	require.NoError(t, err)
+	require.Equal(t, []byte("gen2\n"), got)
+	require.Greater(t, counting.total.Load(), warm, "the manifest must always fetch")
+
+	ok, err = bs.Exists(ctx, "table")
+	require.NoError(t, err)
+	require.True(t, ok, "a key named by a freshly fetched manifest must be visible")
+
+	gotTable, _, err := GetBytes(ctx, bs, "table", AllRange)
+	require.NoError(t, err)
+	require.Equal(t, []byte("xyz"), gotTable)
+}
+
+// Waiting on another reader's fetch must stay cancellable. That fetch belongs to
+// a different caller, which may have no deadline of its own (conjoin runs on
+// context.Background()), so a hung connection must not be able to block every
+// other reader in the process.
+func TestGitBlobstore_WaitingOnAnotherFetchHonorsContext(t *testing.T) {
+	requireGitOnPath(t)
+
+	ctx := context.Background()
+	bs, _, counting := newCountingBlobstore(t, ctx, map[string][]byte{
+		"manifest": []byte("hello\n"),
+	}, time.Nanosecond)
+	// Stand in for a hung connection, on a caller that will not give up. Long
+	// enough that a blocked waiter is unmistakable, short enough that the test
+	// can wait it out.
+	const stuckFor = 2 * time.Second
+	counting.delay = stuckFor
+
+	stuck := make(chan struct{})
+	go func() {
+		defer close(stuck)
+		_, _, _, _ = bs.Get(context.Background(), "manifest", AllRange)
+	}()
+	// Don't outlive the fetch: it reads the repos that t.TempDir removes.
+	t.Cleanup(func() { <-stuck })
+	<-counting.started
+
+	// A second reader arrives while that fetch is stuck. It must give up on its
+	// own deadline rather than inherit the stuck caller's.
+	waitCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err := bs.Exists(waitCtx, "manifest")
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Less(t, elapsed, stuckFor/2, "waiter blocked on the stuck fetch")
+	require.Equal(t, int64(1), counting.total.Load(), "the waiter must not start its own fetch")
+}


### PR DESCRIPTION
A cache-missing Get or Exists ran its own `git fetch` of the whole data ref, so a burst of concurrent readers opened a connection each and every probe for a key that does not exist fetched again. Concurrent read-path fetches now share one fetch, and a key missing from a cache already merged from a commit is reported absent without fetching. A fetch that finds the head unchanged now also refreshes the dedup window, which previously never renewed against a quiet remote.