### PR TITLE
go/store/nbs: byte_sink.go: Fix an error in non-archive push and GC paths which could result in table files with missing indexes.

### DIFF
--- a/go/store/nbs/byte_sink.go
+++ b/go/store/nbs/byte_sink.go
@@ -251,20 +251,20 @@ func (sink *BufferedFileByteSink) Write(src []byte) (int, error) {
 
 	if remaining >= srcLen {
 		sink.currentBlock = append(sink.currentBlock, src...)
-
 		if remaining == srcLen {
 			sink.writeCh <- sink.currentBlock
 			sink.currentBlock = nil
 		}
 	} else {
-		if remaining > 0 {
-			sink.currentBlock = append(sink.currentBlock, src[:remaining]...)
+		// Fill and hand off the current block.
+		sink.currentBlock = append(sink.currentBlock, src[:remaining]...)
+		if len(sink.currentBlock) > 0 {
 			sink.writeCh <- sink.currentBlock
 		}
-
-		newBlock := make([]byte, 0, sink.blockSize)
-		newBlock = append(newBlock, src[remaining:]...)
-		sink.currentBlock = newBlock
+		// Size the next block to hold all of |rest|, even if that needs more
+		// than |blockSize|.
+		rest := src[remaining:]
+		sink.currentBlock = append(make([]byte, 0, max(sink.blockSize, len(rest))), rest...)
 	}
 
 	sink.pos += uint64(srcLen)

--- a/go/store/nbs/byte_sink_test.go
+++ b/go/store/nbs/byte_sink_test.go
@@ -34,6 +34,7 @@ func TestBlockBufferTableSink(t *testing.T) {
 	}
 
 	suite.Run(t, &TableSinkSuite{createSink, t})
+	suite.Run(t, &TableSinkBlockSizeSuite{createSink, 128, t})
 }
 
 func TestFixedBufferTableSink(t *testing.T) {
@@ -53,6 +54,46 @@ func TestBufferedFileByteSink(t *testing.T) {
 	}
 
 	suite.Run(t, &TableSinkSuite{createSink, t})
+	suite.Run(t, &TableSinkBlockSizeSuite{createSink, 4 * 1024, t})
+
+	// Regression test for dolt#11747, where Write dropped a block it was
+	// replacing if that block had no spare capacity left.
+	t.Run("ExactlyFullBlockIsNotDropped", func(t *testing.T) {
+		const blockSize = 4 * 1024
+
+		// A write of exactly |blockSize| fills its block on allocation,
+		// independent of how the runtime rounds capacities.
+		t.Run("WritesOfExactlyBlockSize", func(t *testing.T) {
+			sink, err := NewBufferedFileByteSink(t.TempDir(), blockSize, 16)
+			require.NoError(t, err)
+			for i := 0; i < 3; i++ {
+				_, err = sink.Write(make([]byte, blockSize))
+				require.NoError(t, err)
+			}
+			assertSinkFileHoldsEverything(t, sink, 3*blockSize)
+		})
+
+		// The shape seen in the wild: a partial block, a write several
+		// blocks long, then the footer's small writes.
+		t.Run("OversizedWriteThenSmallWrite", func(t *testing.T) {
+			for _, tail := range []int{0, 1, 1000, blockSize - 1} {
+				for _, big := range []int{blockSize + 1, 2 * blockSize, 4*blockSize + tail, 16384 + tail} {
+					sink, err := NewBufferedFileByteSink(t.TempDir(), blockSize, 16)
+					require.NoError(t, err)
+					_, err = sink.Write(make([]byte, tail))
+					require.NoError(t, err)
+					_, err = sink.Write(make([]byte, big))
+					require.NoError(t, err)
+					// The footer: chunk count, uncompressed size, magic.
+					for _, n := range []int{4, 8, 8} {
+						_, err = sink.Write(make([]byte, n))
+						require.NoError(t, err)
+					}
+					assertSinkFileHoldsEverything(t, sink, tail+big+20)
+				}
+			}
+		})
+	})
 
 	t.Run("ReaderTwice", func(t *testing.T) {
 		sink, err := NewBufferedFileByteSink("", 4*1024, 16)
@@ -209,4 +250,68 @@ func (suite *TableSinkSuite) TestWriteAndFlushToFile() {
 	require.NoError(suite.t, err)
 
 	verifyContents(suite.t, data)
+}
+
+// assertSinkFileHoldsEverything checks that every byte |sink| accepted reached
+// its backing file. |sink.pos| counts what Write claimed, so comparing it
+// against the file catches bytes Write never passed to the background writer.
+func assertSinkFileHoldsEverything(t *testing.T, sink *BufferedFileByteSink, expected int) {
+	t.Helper()
+	require.NoError(t, sink.finish())
+	require.Equal(t, uint64(expected), sink.pos, "sink did not accept every byte")
+	stat, err := os.Stat(sink.path)
+	require.NoError(t, err)
+	require.Equal(t, int64(expected), stat.Size(), "sink lost %d bytes", expected-int(stat.Size()))
+}
+
+// TableSinkBlockSizeSuite exercises writes sized around a sink's block
+// boundary, including ones larger than a whole block. TableSinkSuite writes 64
+// bytes at a time, so it never splits a write across blocks.
+type TableSinkBlockSizeSuite struct {
+	sinkFactory func() ByteSink
+	blockSize   int
+	t           *testing.T
+}
+
+var _ suite.TestingSuite = (*TableSinkBlockSizeSuite)(nil)
+
+func (suite *TableSinkBlockSizeSuite) SetS(s suite.TestingSuite) {}
+
+func (suite *TableSinkBlockSizeSuite) SetT(t *testing.T) {
+	suite.t = t
+}
+
+func (suite *TableSinkBlockSizeSuite) T() *testing.T {
+	return suite.t
+}
+
+func (suite *TableSinkBlockSizeSuite) TestWritesSpanningBlocks() {
+	bs := suite.blockSize
+	sizes := []int{
+		1, bs - 1, bs, bs + 1, 2 * bs, 2*bs + 1, 3 * bs, 7, 4*bs + 13, 8, 4, 8,
+	}
+
+	// A counter, so dropped or reordered bytes cannot go unnoticed.
+	var expected []byte
+	for _, sz := range sizes {
+		block := make([]byte, sz)
+		for i := range block {
+			block[i] = byte(len(expected) + i)
+		}
+		expected = append(expected, block...)
+	}
+
+	sink := suite.sinkFactory()
+	var written int
+	for _, sz := range sizes {
+		n, err := sink.Write(expected[written : written+sz])
+		require.NoError(suite.t, err)
+		require.Equal(suite.t, sz, n)
+		written += sz
+	}
+
+	bb := bytes.NewBuffer(nil)
+	require.NoError(suite.t, sink.Flush(bb))
+	require.Equal(suite.t, len(expected), bb.Len(), "sink lost bytes")
+	require.True(suite.t, bytes.Equal(expected, bb.Bytes()), "sink corrupted bytes")
 }

--- a/go/store/nbs/cmp_chunk_table_writer_test.go
+++ b/go/store/nbs/cmp_chunk_table_writer_test.go
@@ -17,6 +17,9 @@ package nbs
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
 	"sort"
 	"testing"
 
@@ -162,4 +165,105 @@ func readAllChunks(ctx context.Context, hashes hash.HashSet, reader tableReader)
 	}
 
 	return hashToData, nil
+}
+
+// TestCmpChunkTableWriterLargeIndex is a regression test for dolt#11747, where
+// a GC output file was written missing the tail of its index. Finish writes the
+// whole index in one Write, and the sink dropped the block that write left
+// behind whenever it had no spare capacity.
+func TestCmpChunkTableWriterLargeIndex(t *testing.T) {
+	ctx := context.Background()
+
+	// The runtime's allocation granularity for large objects. Only used to
+	// search for a triggering chunk count; the probe below is what actually
+	// ties this test to the bug.
+	const goPageSize = 8192
+	const contentLen = 16
+	const indexEntrySize = prefixTupleSize + lengthSize + hash.SuffixLen
+
+	// Content this short always encodes as a single snappy literal, so every
+	// chunk contributes the same number of bytes.
+	perChunkData := len(ChunkToCompressedChunk(chunks.NewChunk(make([]byte, contentLen))).FullCompressedChunk)
+
+	// Above 2*blockSize, append() asks for a capacity equal to the leftover's
+	// own length, which the runtime rounds up to a page and no further --- so
+	// a page-aligned leftover gets a block that is full on arrival. blockSize
+	// is itself page aligned, so that happens exactly when the file bar its
+	// footer is. Walk up to a qualifying count; a multiple of goPageSize
+	// always works, so this terminates.
+	minLeftover := 2*defaultTableSinkBlockSize + goPageSize
+	chunkCount := (minLeftover + defaultTableSinkBlockSize + indexEntrySize - 1) / indexEntrySize
+	for (chunkCount*(perChunkData+indexEntrySize))%goPageSize != 0 {
+		chunkCount++
+	}
+
+	dataLen := chunkCount * perChunkData
+	indexLen := chunkCount * indexEntrySize
+	// Room left in the block the sink holds when the index write arrives, or
+	// zero if the chunk data ended flush and the sink holds no block.
+	remaining := (defaultTableSinkBlockSize - dataLen%defaultTableSinkBlockSize) % defaultTableSinkBlockSize
+	leftover := indexLen - remaining
+	require.Greater(t, leftover, 2*defaultTableSinkBlockSize)
+
+	// Ask the runtime rather than assume: the leftover has to land on a block
+	// that comes back exactly full.
+	probe := append(make([]byte, 0, defaultTableSinkBlockSize), make([]byte, leftover)...)
+	require.Equal(t, leftover, cap(probe),
+		"a %d byte leftover does not fill its block exactly on this runtime, so this test cannot reproduce dolt#11747", leftover)
+
+	tw, err := NewCmpChunkTableWriter("")
+	require.NoError(t, err)
+
+	content := make([]byte, contentLen)
+	hashes := make([]hash.Hash, 0, chunkCount)
+	var wroteData int
+	for i := 0; i < chunkCount; i++ {
+		binary.BigEndian.PutUint64(content, uint64(i))
+		c := chunks.NewChunk(content)
+		hashes = append(hashes, c.Hash())
+		n, err := tw.AddChunk(ChunkToCompressedChunk(c))
+		require.NoError(t, err)
+		wroteData += int(n)
+	}
+	require.Equal(t, chunkCount, tw.ChunkCount())
+	// The sizing above assumes every chunk compressed to the same length.
+	require.Equal(t, dataLen, wroteData, "chunks did not all compress to %d bytes", perChunkData)
+
+	_, name, err := tw.Finish()
+	require.NoError(t, err)
+	require.EqualValues(t, dataLen+indexLen+footerSize, tw.FullLength())
+
+	path := filepath.Join(t.TempDir(), name)
+	require.NoError(t, tw.FlushToFile(path))
+
+	// Every byte the writer accounted for has to be on disk. FullLength is
+	// what the persisters report and what push sends, so a short file here is
+	// corruption nothing downstream would notice.
+	stat, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, int64(tw.FullLength()), stat.Size(),
+		"table file is %d bytes short of the %d bytes written",
+		int64(tw.FullLength())-stat.Size(), tw.FullLength())
+
+	// And the file has to actually parse and serve every chunk back.
+	buff, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	ti, err := parseTableIndexByCopy(ctx, buff, &UnlimitedQuotaProvider{})
+	require.NoError(t, err)
+	tr, err := newTableReader(ctx, ti, tableReaderAtFromBytes(buff), fileBlockSize)
+	require.NoError(t, err)
+	defer tr.close()
+	require.EqualValues(t, chunkCount, tr.count())
+
+	// get() reads the prefix map, the suffixes and the lengths, so reading
+	// every chunk back covers all three index regions.
+	for i, h := range hashes {
+		binary.BigEndian.PutUint64(content, uint64(i))
+		data, _, err := tr.get(ctx, h, nil, &Stats{})
+		require.NoError(t, err)
+		if !bytes.Equal(content, data) {
+			t.Fatalf("chunk %d (%s) did not read back: got %x, want %x", i, h.String(), data, content)
+		}
+	}
 }


### PR DESCRIPTION
Failure to properly handle a boundary condition in BufferedFileByteSink meant that a table file writer that was producing a large table file could end up writing it out with a broken index. All chunk data made it to the file, but the file itself was unusable without manual recovery because the index portion of the file was wrong.