### PR TITLE
Omit generated columns from SQL diff assignments

### DIFF
--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -1146,9 +1146,9 @@ func schemaFromCreateTableStmt(createTableStmt string) (schema.Schema, error) {
 			IsPartOfPK:    primaryCols[col.Name.Lowered()],
 			TypeInfo:      typeInfo,
 			Default:       defBuf.String(),
-			Generated:     "",    // TODO
-			OnUpdate:      "",    // TODO
-			Virtual:       false, // TODO
+			Generated:     genBuf.String(),
+			OnUpdate:      onUpBuf.String(),
+			Virtual:       col.Type.GeneratedExpr != nil && !bool(col.Type.Stored),
 			AutoIncrement: col.Type.Autoincrement == true,
 			Comment:       comment,
 		}

--- a/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
@@ -287,8 +287,8 @@ func SqlRowAsDeleteStmt(ctx *sql.Context, r sql.Row, tableName string, tableSch 
 // The row to change is keyed by the primary key columns of
 // |tableSch|, using their values from |r|.
 //
-// TODO(elianddb): Schema isn't recording column's Generated marker
-// correctly, so Column.IsGenerated doesn't filter.
+// Generated columns are skipped, matching InsertStatementPrefix and
+// SqlRowAsTupleString.
 func SqlRowAsUpdateStmt(ctx *sql.Context, r sql.Row, tableName string, tableSch schema.Schema, colsToUpdate *set.StrSet) (string, error) {
 	var b strings.Builder
 	b.WriteString("UPDATE ")
@@ -300,7 +300,7 @@ func SqlRowAsUpdateStmt(ctx *sql.Context, r sql.Row, tableName string, tableSch 
 	i := 0
 	seenOne := false
 	err := tableSch.GetAllCols().Iter(func(_ uint64, col schema.Column) (stop bool, err error) {
-		if colsToUpdate.Contains(col.Name) {
+		if colsToUpdate.Contains(col.Name) && !col.IsGenerated() {
 			if seenOne {
 				b.WriteRune(',')
 			}

--- a/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/row_fmt.go
@@ -284,11 +284,11 @@ func SqlRowAsDeleteStmt(ctx *sql.Context, r sql.Row, tableName string, tableSch 
 // SqlRowAsUpdateStmt generates an UPDATE statement setting the
 // columns of |r| named by |colsToUpdate|.
 //
+// Generated columns are skipped. If no columns remain to update,
+// an empty string is returned.
+//
 // The row to change is keyed by the primary key columns of
 // |tableSch|, using their values from |r|.
-//
-// Generated columns are skipped, matching InsertStatementPrefix and
-// SqlRowAsTupleString.
 func SqlRowAsUpdateStmt(ctx *sql.Context, r sql.Row, tableName string, tableSch schema.Schema, colsToUpdate *set.StrSet) (string, error) {
 	var b strings.Builder
 	b.WriteString("UPDATE ")
@@ -320,6 +320,10 @@ func SqlRowAsUpdateStmt(ctx *sql.Context, r sql.Row, tableName string, tableSch 
 
 	if err != nil {
 		return "", err
+	}
+
+	if !seenOne {
+		return "", nil
 	}
 
 	b.WriteString(" WHERE ")

--- a/go/libraries/doltcore/sqle/sqlfmt/row_fmt_test.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/row_fmt_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/schema/typeinfo"
 	_ "github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/sqlfmt"
+	"github.com/dolthub/dolt/go/libraries/utils/set"
 	"github.com/dolthub/dolt/go/store/types"
 )
 
@@ -81,6 +82,17 @@ func TestInsertStatementPrefixSkipsGeneratedCols(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "INSERT INTO `table_name` (`id`,`a`) VALUES ", prefix)
+}
+
+func TestSqlRowAsUpdateStmtSkipsGeneratedCols(t *testing.T) {
+	// See https://github.com/dolthub/dolt/issues/11445
+	sch := newGeneratedColSchema()
+	colsToUpdate := set.NewStrSet([]string{"a", "c"})
+
+	stmt, err := sqlfmt.SqlRowAsUpdateStmt(sql.NewEmptyContext(), sql.Row{int64(1), "x", "x!"}, "table_name", sch, colsToUpdate)
+
+	require.NoError(t, err)
+	assert.Equal(t, "UPDATE `table_name` SET `a`='x' WHERE `id`=1;", stmt)
 }
 
 func TestSqlRowAsTupleString(t *testing.T) {

--- a/go/libraries/doltcore/sqle/sqlfmt/row_fmt_test.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/row_fmt_test.go
@@ -93,6 +93,12 @@ func TestSqlRowAsUpdateStmtSkipsGeneratedCols(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "UPDATE `table_name` SET `a`='x' WHERE `id`=1;", stmt)
+
+	colsToUpdate = set.NewStrSet([]string{"c"})
+	stmt, err = sqlfmt.SqlRowAsUpdateStmt(sql.NewEmptyContext(), sql.Row{int64(1), "x", "x!"}, "table_name", sch, colsToUpdate)
+
+	require.NoError(t, err)
+	assert.Empty(t, stmt)
 }
 
 func TestSqlRowAsTupleString(t *testing.T) {

--- a/go/libraries/doltcore/sqle/sqlfmt/schema_fmt.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/schema_fmt.go
@@ -43,7 +43,11 @@ func GenerateDataDiffStatement(ctx *sql.Context, tableName string, sch schema.Sc
 		updatedCols := set.NewEmptyStrSet()
 		for i, diffType := range colDiffTypes {
 			if diffType != diff.None {
-				updatedCols.Add(sch.GetAllCols().GetByIndex(i).Name)
+				col := sch.GetAllCols().GetByIndex(i)
+				if col.IsGenerated() {
+					continue
+				}
+				updatedCols.Add(col.Name)
 			}
 		}
 		if updatedCols.Size() == 0 {

--- a/go/libraries/doltcore/sqle/sqlfmt/schema_fmt.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/schema_fmt.go
@@ -43,11 +43,7 @@ func GenerateDataDiffStatement(ctx *sql.Context, tableName string, sch schema.Sc
 		updatedCols := set.NewEmptyStrSet()
 		for i, diffType := range colDiffTypes {
 			if diffType != diff.None {
-				col := sch.GetAllCols().GetByIndex(i)
-				if col.IsGenerated() {
-					continue
-				}
-				updatedCols.Add(col.Name)
+				updatedCols.Add(sch.GetAllCols().GetByIndex(i).Name)
 			}
 		}
 		if updatedCols.Size() == 0 {

--- a/integration-tests/bats/sql-diff.bats
+++ b/integration-tests/bats/sql-diff.bats
@@ -971,3 +971,36 @@ SQL
   ! [[ "$output" =~ "ignore_table" ]] || false
 
 }
+
+@test "sql-diff: stored generated columns omitted from INSERT and UPDATE" {
+  # See https://github.com/dolthub/dolt/issues/11445
+  dolt sql <<SQL
+CREATE TABLE t (
+  id INT PRIMARY KEY,
+  a INT,
+  g INT GENERATED ALWAYS AS (a + 1) STORED
+);
+SQL
+  dolt add -A
+  dolt commit -m "create table with stored generated column"
+  dolt sql -q "INSERT INTO t (id, a) VALUES (1, 10)"
+  dolt add -A
+  dolt commit -m "seed row"
+  dolt sql -q "UPDATE t SET a=99 WHERE id=1"
+  dolt sql -q "INSERT INTO t (id, a) VALUES (2, 20)"
+
+  run dolt diff -r sql
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "UPDATE \`t\` SET \`a\`=99 WHERE \`id\`=1;" ]] || false
+  [[ "$output" =~ "INSERT INTO \`t\` (\`id\`,\`a\`) VALUES (2,20);" ]] || false
+  ! [[ "$output" =~ "\`g\`" ]] || false
+
+  dolt diff -r sql > query
+  dolt reset --hard
+  run dolt sql < query
+  [ "$status" -eq 0 ]
+  run dolt sql -r csv -q "SELECT id, a, g FROM t ORDER BY id"
+  [ "$status" -eq 0 ]
+  [[ "${lines[1]}" = "1,99,100" ]] || false
+  [[ "${lines[2]}" = "2,20,21" ]] || false
+}


### PR DESCRIPTION
Omits generated columns from SQL diff assignments and suppresses updates with no assignable columns, carrying forward #11476 with Elian's review feedback addressed.

Fixes https://github.com/dolthub/dolt/issues/11445
