### PR TITLE
Validate vector index creation without restricting schema loading

### DIFF
--- a/go/libraries/doltcore/schema/encoding/schema_marshaling_test.go
+++ b/go/libraries/doltcore/schema/encoding/schema_marshaling_test.go
@@ -193,7 +193,7 @@ func TestVectorIndexMarshalling(t *testing.T) {
 			require.NoError(t, err)
 			vecTi, err := typeinfo.FromSqlType(gmstypes.JSON)
 			require.NoError(t, err)
-			vecCol, err := schema.NewColumnWithTypeInfo("vec", 2, vecTi, false, "", false, "")
+			vecCol, err := schema.NewColumnWithTypeInfo("vec", 2, vecTi, false, "", false, "", schema.NotNullConstraint{})
 			require.NoError(t, err)
 			sch, err := schema.SchemaFromCols(schema.NewColCollection(pkCol, vecCol))
 			require.NoError(t, err)

--- a/go/libraries/doltcore/schema/index_coll.go
+++ b/go/libraries/doltcore/schema/index_coll.go
@@ -214,7 +214,7 @@ func (ixc *indexCollectionImpl) AddIndexByColTags(indexName string, tags []uint6
 	for _, tag := range tags {
 		// we already validated the tag exists
 		c, _ := ixc.colColl.GetByTag(tag)
-		err := validateColumnIndexable(c)
+		err := validateColumnIndexable(c, props.IsVector)
 		if err != nil {
 			return nil, err
 		}
@@ -243,7 +243,10 @@ func (ixc *indexCollectionImpl) AddIndexByColTags(indexName string, tags []uint6
 }
 
 // validateColumnIndexable returns an error if the column given cannot be used in an index
-func validateColumnIndexable(c Column) error {
+func validateColumnIndexable(c Column, isVector bool) error {
+	if isVector && c.IsNullable() {
+		return fmt.Errorf("all parts of a VECTOR index must be NOT NULL")
+	}
 	return nil
 }
 

--- a/go/libraries/doltcore/schema/index_coll.go
+++ b/go/libraries/doltcore/schema/index_coll.go
@@ -254,7 +254,7 @@ func (ixc *indexCollectionImpl) AddIndexByColTags(indexName string, tags []uint6
 // validateColumnIndexable returns an error if the column given cannot be used in an index
 func validateColumnIndexable(c Column, isVector bool) error {
 	if isVector && c.IsNullable() {
-		return fmt.Errorf("all parts of a VECTOR index must be NOT NULL")
+		return sql.ErrNullableVectorIdx.New()
 	}
 	return nil
 }

--- a/go/libraries/doltcore/schema/index_coll.go
+++ b/go/libraries/doltcore/schema/index_coll.go
@@ -216,16 +216,6 @@ func (ixc *indexCollectionImpl) AddIndexByColTags(indexName string, tags []uint6
 		return nil, fmt.Errorf("tags %v do not exist on this table", tags)
 	}
 
-	// TAGS: Use of tags here is safe since it's constrained to a single table
-	for _, tag := range tags {
-		// we already validated the tag exists
-		c, _ := ixc.colColl.GetByTag(tag)
-		err := validateColumnIndexable(c, props.IsVector)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	index := &indexImpl{
 		indexColl:        ixc,
 		name:             indexName,
@@ -249,14 +239,6 @@ func (ixc *indexCollectionImpl) AddIndexByColTags(indexName string, tags []uint6
 		ixc.colTagToIndex[tag] = append(ixc.colTagToIndex[tag], index)
 	}
 	return index, nil
-}
-
-// validateColumnIndexable returns an error if the column given cannot be used in an index
-func validateColumnIndexable(c Column, isVector bool) error {
-	if isVector && c.IsNullable() {
-		return sql.ErrNullableVectorIdx.New()
-	}
-	return nil
 }
 
 func (ixc *indexCollectionImpl) UnsafeAddIndexByColTags(indexName string, tags []uint64, prefixLengths []uint16, props IndexProperties) (Index, error) {

--- a/go/libraries/doltcore/schema/index_test.go
+++ b/go/libraries/doltcore/schema/index_test.go
@@ -17,7 +17,6 @@ package schema
 import (
 	"testing"
 
-	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -290,37 +289,6 @@ func TestIndexCollectionAddIndexByColTags(t *testing.T) {
 		_, err = indexColl.AddIndexByColTags("nonsense", []uint64{3, 4, 10}, nil, IndexProperties{IsUnique: false, Comment: ""})
 		assert.Error(t, err)
 	})
-}
-
-func TestIndexCollectionVectorIndexNullability(t *testing.T) {
-	for _, test := range []struct {
-		name     string
-		nullable bool
-		isVector bool
-	}{
-		{"nullable vector index", true, true},
-		{"not null vector index", false, true},
-		{"nullable ordinary index", true, false},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			col := NewColumn("v", 1, types.JSONKind, false)
-			if !test.nullable {
-				col.Constraints = append(col.Constraints, NotNullConstraint{})
-			}
-			indexes := NewIndexCollection(NewColCollection(col), nil)
-			idx, err := indexes.AddIndexByColTags("v_idx", []uint64{1}, nil, IndexProperties{IsVector: test.isVector})
-			if test.nullable && test.isVector {
-				require.Error(t, err)
-				assert.True(t, sql.ErrNullableVectorIdx.Is(err))
-				assert.Nil(t, idx)
-				assert.False(t, indexes.Contains("v_idx"))
-			} else {
-				require.NoError(t, err)
-				assert.NotNil(t, idx)
-				assert.True(t, indexes.Contains("v_idx"))
-			}
-		})
-	}
 }
 
 func TestIndexCollectionAllIndexes(t *testing.T) {

--- a/go/libraries/doltcore/schema/index_test.go
+++ b/go/libraries/doltcore/schema/index_test.go
@@ -17,6 +17,7 @@ package schema
 import (
 	"testing"
 
+	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -289,6 +290,37 @@ func TestIndexCollectionAddIndexByColTags(t *testing.T) {
 		_, err = indexColl.AddIndexByColTags("nonsense", []uint64{3, 4, 10}, nil, IndexProperties{IsUnique: false, Comment: ""})
 		assert.Error(t, err)
 	})
+}
+
+func TestIndexCollectionVectorIndexNullability(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		nullable bool
+		isVector bool
+	}{
+		{"nullable vector index", true, true},
+		{"not null vector index", false, true},
+		{"nullable ordinary index", true, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			col := NewColumn("v", 1, types.JSONKind, false)
+			if !test.nullable {
+				col.Constraints = append(col.Constraints, NotNullConstraint{})
+			}
+			indexes := NewIndexCollection(NewColCollection(col), nil)
+			idx, err := indexes.AddIndexByColTags("v_idx", []uint64{1}, nil, IndexProperties{IsVector: test.isVector})
+			if test.nullable && test.isVector {
+				require.Error(t, err)
+				assert.True(t, sql.ErrNullableVectorIdx.Is(err))
+				assert.Nil(t, idx)
+				assert.False(t, indexes.Contains("v_idx"))
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, idx)
+				assert.True(t, indexes.Contains("v_idx"))
+			}
+		})
+	}
 }
 
 func TestIndexCollectionAllIndexes(t *testing.T) {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -781,64 +781,7 @@ func TestIndexedExpressions(t *testing.T) {
 func TestVectorIndexes(t *testing.T) {
 	harness := newDoltHarness(t)
 	defer harness.Close()
-	// GMS VectorIndexQueries includes tests that create vector indexes on nullable columns.
-	// Dolt now rejects this at DDL time (see TestVectorIndexDDL), so we skip those tests here
-	// and only run the ones that are compatible with the NOT NULL constraint.
-	for _, script := range queries.VectorIndexQueries {
-		if script.Name == "basic JSON vector index" || script.Name == "basic VECTOR vector index" {
-			t.Run(script.Name, func(t *testing.T) {
-				t.Skip("Dolt rejects vector indexes on nullable columns; see TestVectorIndexDDL")
-			})
-			continue
-		}
-		enginetest.TestScript(t, harness, script)
-	}
-}
-
-func TestVectorIndexDDL(t *testing.T) {
-	harness := newDoltHarness(t)
-	defer harness.Close()
-	scripts := []queries.ScriptTest{
-		{
-			Name: "vector index on nullable column rejected",
-			SetUpScript: []string{
-				"CREATE TABLE t (id INT PRIMARY KEY, v VECTOR(3))",
-			},
-			Assertions: []queries.ScriptTestAssertion{
-				{
-					Query:          "CREATE VECTOR INDEX idx ON t (v)",
-					ExpectedErrStr: "all parts of a VECTOR index must be NOT NULL",
-				},
-			},
-		},
-		{
-			Name: "vector index on NOT NULL column succeeds",
-			SetUpScript: []string{
-				"CREATE TABLE t (id INT PRIMARY KEY, v VECTOR(3) NOT NULL)",
-			},
-			Assertions: []queries.ScriptTestAssertion{
-				{
-					Query:    "CREATE VECTOR INDEX idx ON t (v)",
-					Expected: []sql.Row{{gmstypes.OkResult{RowsAffected: 0}}},
-				},
-			},
-		},
-		{
-			Name: "ALTER TABLE add vector index on nullable column rejected",
-			SetUpScript: []string{
-				"CREATE TABLE t (id INT PRIMARY KEY, v VECTOR(3))",
-			},
-			Assertions: []queries.ScriptTestAssertion{
-				{
-					Query:          "ALTER TABLE t ADD VECTOR INDEX idx (v)",
-					ExpectedErrStr: "all parts of a VECTOR index must be NOT NULL",
-				},
-			},
-		},
-	}
-	for _, script := range scripts {
-		enginetest.TestScript(t, harness, script)
-	}
+	enginetest.TestVectorIndexes(t, harness)
 }
 
 func TestVectorFunctions(t *testing.T) {

--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -784,6 +784,114 @@ func TestVectorIndexes(t *testing.T) {
 	enginetest.TestVectorIndexes(t, harness)
 }
 
+func TestVectorIndexNullability(t *testing.T) {
+	for _, colType := range []string{"JSON", "VECTOR(2)"} {
+		t.Run(colType, func(t *testing.T) {
+			harness := newDoltHarness(t)
+			defer harness.Close()
+			value := "'[1,2]'"
+			if colType == "VECTOR(2)" {
+				value = "STRING_TO_VECTOR('[1,2]')"
+			}
+			enginetest.TestScript(t, harness, queries.ScriptTest{
+				Name: "vector index validation across working set and committed schemas",
+				SetUpScript: []string{
+					fmt.Sprintf("CREATE TABLE vectors (id INT PRIMARY KEY, v %s)", colType),
+					"INSERT INTO vectors VALUES (1, NULL)",
+					"CALL DOLT_COMMIT('-Am', 'nullable vector column')",
+					"CALL DOLT_BRANCH('nullable')",
+				},
+				Assertions: []queries.ScriptTestAssertion{
+					{
+						Query:       "CREATE VECTOR INDEX v_idx ON vectors(v)",
+						ExpectedErr: sql.ErrNullableVectorIdx,
+					},
+					{
+						Query:       "ALTER TABLE vectors ADD VECTOR INDEX v_idx(v)",
+						ExpectedErr: sql.ErrNullableVectorIdx,
+					},
+					{
+						Query:    "SELECT * FROM vectors",
+						Expected: []sql.Row{{1, nil}},
+					},
+					{
+						// Failed DDL must not leave a partial index or dirty the working set.
+						Query:    "SELECT count(*) FROM information_schema.statistics WHERE table_name = 'vectors' AND index_name = 'v_idx'",
+						Expected: []sql.Row{{0}},
+					},
+					{
+						Query:    "SELECT count(*) FROM dolt_status",
+						Expected: []sql.Row{{0}},
+					},
+					{
+						Query:    "DELETE FROM vectors WHERE id = 1",
+						Expected: []sql.Row{{gmstypes.OkResult{RowsAffected: 1}}},
+					},
+					{
+						// Removing NULL rows does not make a nullable column indexable.
+						Query:       "CREATE VECTOR INDEX v_idx ON vectors(v)",
+						ExpectedErr: sql.ErrNullableVectorIdx,
+					},
+					{
+						Query:    fmt.Sprintf("ALTER TABLE vectors MODIFY COLUMN v %s NOT NULL", colType),
+						Expected: []sql.Row{{gmstypes.OkResult{}}},
+					},
+					{
+						Query:    fmt.Sprintf("INSERT INTO vectors VALUES (2, %s)", value),
+						Expected: []sql.Row{{gmstypes.OkResult{RowsAffected: 1}}},
+					},
+					{
+						Query:    "ALTER TABLE vectors ADD VECTOR INDEX v_idx(v)",
+						Expected: []sql.Row{{gmstypes.OkResult{}}},
+					},
+					{
+						Query:       "INSERT INTO vectors VALUES (2, NULL)",
+						ExpectedErr: sql.ErrInsertIntoNonNullableProvidedNull,
+					},
+					{
+						Query:            "CALL DOLT_COMMIT('-Am', 'not null vector index')",
+						SkipResultsCheck: true,
+					},
+					{
+						Query:    "CALL DOLT_BRANCH('indexed')",
+						Expected: []sql.Row{{0}},
+					},
+					{
+						Query:    "CALL DOLT_RESET('--hard', 'nullable')",
+						Expected: []sql.Row{{0}},
+					},
+					{
+						// Re-loading the old schema must preserve its nullability.
+						Query:       "CREATE VECTOR INDEX v_idx ON vectors(v)",
+						ExpectedErr: sql.ErrNullableVectorIdx,
+					},
+					{
+						Query:    "SELECT * FROM vectors",
+						Expected: []sql.Row{{1, nil}},
+					},
+					{
+						Query:    "CALL DOLT_RESET('--hard', 'indexed')",
+						Expected: []sql.Row{{0}},
+					},
+					{
+						Query:    "SELECT count(*) FROM information_schema.statistics WHERE table_name = 'vectors' AND index_name = 'v_idx'",
+						Expected: []sql.Row{{1}},
+					},
+					{
+						Query:           "SELECT id FROM vectors ORDER BY VEC_DISTANCE('[1,2]', v) LIMIT 1",
+						Expected:        []sql.Row{{2}},
+						ExpectedIndexes: []string{"v_idx"},
+					},
+					{
+						Query:       "INSERT INTO vectors VALUES (3, NULL)",
+						ExpectedErr: sql.ErrInsertIntoNonNullableProvidedNull,
+					},
+				},
+			})
+		})
+	}
+}
+
 func TestVectorFunctions(t *testing.T) {
 	harness := newDoltHarness(t)
 	defer harness.Close()


### PR DESCRIPTION
Preserves existing vector index schemas while validating new index creation, with Dolt commit/reset regression tests and shared DDL coverage in https://github.com/dolthub/go-mysql-server/pull/3858.

Fixes https://github.com/dolthub/dolt/issues/10448
