### PR TITLE
Warn about session-only checkout in noninteractive SQL

### DIFF
--- a/go/cmd/dolt/commands/debug.go
+++ b/go/cmd/dolt/commands/debug.go
@@ -428,5 +428,5 @@ func execDebugMode(ctx *sql.Context, qryist cli.Queryist, queryFile *os.File, co
 	}()
 	input := bufio.NewReader(transform.NewReader(queryFile, textunicode.BOMOverride(transform.Nop)))
 
-	return execBatchMode(ctx, qryist, input, continueOnErr, format, false)
+	return execBatchMode(ctx, qryist, input, continueOnErr, format, false, nil)
 }

--- a/go/cmd/dolt/commands/debug.go
+++ b/go/cmd/dolt/commands/debug.go
@@ -428,5 +428,6 @@ func execDebugMode(ctx *sql.Context, qryist cli.Queryist, queryFile *os.File, co
 	}()
 	input := bufio.NewReader(transform.NewReader(queryFile, textunicode.BOMOverride(transform.Nop)))
 
-	return execBatchMode(ctx, qryist, input, continueOnErr, format, false, nil)
+	_, err = execBatchMode(ctx, qryist, input, continueOnErr, format, false)
+	return err
 }

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -292,7 +292,7 @@ func (cmd SqlCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 			}
 		} else {
 			input = transform.NewReader(input, textunicode.BOMOverride(transform.Nop))
-			err := execBatchMode(queryist.Context, queryist.Queryist, input, continueOnError, format, binaryAsHex)
+			err := execBatchMode(queryist.Context, queryist.Queryist, input, continueOnError, format, binaryAsHex, nil)
 			if err != nil {
 				return sqlHandleVErrAndExitCode(queryist.Queryist, errhand.VerboseErrorFromError(err), usage)
 			}
@@ -405,13 +405,38 @@ func queryMode(
 ) int {
 	_, continueOnError := apr.GetValue(continueFlag)
 
+	var info batchExecInfo
 	input := strings.NewReader(query)
-	err := execBatchMode(ctx, qryist, input, continueOnError, format, binaryAsHex)
+	err := execBatchMode(ctx, qryist, input, continueOnError, format, binaryAsHex, &info)
 	if err != nil {
 		return sqlHandleVErrAndExitCode(qryist, errhand.VerboseErrorFromError(err), usage)
 	}
 
+	if info.isLoneDoltCheckout {
+		cli.PrintErrln(color.YellowString("Warning: dolt_checkout() only changes the branch for the current session."))
+		cli.PrintErrln(color.YellowString("Since `dolt sql -q` starts a new session for each invocation, the checked-out"))
+		cli.PrintErrln(color.YellowString("branch will not persist after this command exits."))
+		cli.PrintErrln(color.YellowString("To change the checked-out branch, use `dolt checkout <branch>` instead."))
+	}
+
 	return 0
+}
+
+// batchExecInfo collects metadata from execBatchMode so callers can
+// inspect what was executed without re-parsing the query string.
+type batchExecInfo struct {
+	stmtCount          int
+	isLoneDoltCheckout bool
+}
+
+// isDoltCheckoutCall returns true when the already-parsed statement
+// is a CALL dolt_checkout(...).
+func isDoltCheckoutCall(stmt sqlparser.Statement) bool {
+	call, ok := stmt.(*sqlparser.Call)
+	if !ok {
+		return false
+	}
+	return strings.EqualFold(call.ProcName.Name.String(), "dolt_checkout")
 }
 
 func SaveQuery(ctx *sql.Context, qryist cli.Queryist, apr *argparser.ArgParseResults, query string, format engine.PrintResultFormat, usage cli.UsagePrinter, binaryAsHex bool) int {
@@ -622,8 +647,9 @@ func validateSqlArgs(apr *argparser.ArgParseResults) error {
 	return nil
 }
 
-// execBatchMode runs all the queries in the input reader
-func execBatchMode(ctx *sql.Context, qryist cli.Queryist, input io.Reader, continueOnErr bool, format engine.PrintResultFormat, binaryAsHex bool) error {
+// execBatchMode runs all the queries in the input reader.
+// If info is non-nil, it is populated with metadata about the executed statements.
+func execBatchMode(ctx *sql.Context, qryist cli.Queryist, input io.Reader, continueOnErr bool, format engine.PrintResultFormat, binaryAsHex bool, info *batchExecInfo) error {
 	scanner := NewStreamScanner(input)
 	var query string
 	for scanner.Scan() {
@@ -652,6 +678,13 @@ func execBatchMode(ctx *sql.Context, qryist cli.Queryist, input io.Reader, conti
 				return err
 			} else {
 				cli.PrintErrln(err.Error())
+			}
+		}
+
+		if info != nil {
+			info.stmtCount++
+			if isDoltCheckoutCall(sqlStatement) {
+				info.isLoneDoltCheckout = true
 			}
 		}
 
@@ -691,6 +724,10 @@ func execBatchMode(ctx *sql.Context, qryist cli.Queryist, input io.Reader, conti
 
 	if err := scanner.Err(); err != nil {
 		return buildBatchSqlErr(scanner.state.statementStartLine, query, err)
+	}
+
+	if info != nil && info.stmtCount != 1 {
+		info.isLoneDoltCheckout = false
 	}
 
 	return nil

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -296,10 +296,11 @@ func (cmd SqlCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 			}
 		} else {
 			input = transform.NewReader(input, textunicode.BOMOverride(transform.Nop))
-			_, err := execBatchMode(queryist.Context, queryist.Queryist, input, continueOnError, format, binaryAsHex)
+			info, err := execBatchMode(queryist.Context, queryist.Queryist, input, continueOnError, format, binaryAsHex)
 			if err != nil {
 				return sqlHandleVErrAndExitCode(queryist.Queryist, errhand.VerboseErrorFromError(err), usage)
 			}
+			warnIfLoneDoltCheckout(info)
 		}
 	}
 
@@ -415,9 +416,7 @@ func queryMode(
 		return sqlHandleVErrAndExitCode(qryist, errhand.VerboseErrorFromError(err), usage)
 	}
 
-	if info.isLoneDoltCheckout {
-		cli.PrintErrln(color.YellowString("Warning: dolt_checkout() in a SQL session only changes the active branch for that SQL session. Your branch in the CLI is unchanged. To change the checked out branch for dolt CLI commands, run `dolt checkout <branch>`."))
-	}
+	warnIfLoneDoltCheckout(info)
 
 	return 0
 }
@@ -426,6 +425,12 @@ func queryMode(
 // inspect what was executed without re-parsing the query string.
 type batchExecInfo struct {
 	isLoneDoltCheckout bool
+}
+
+func warnIfLoneDoltCheckout(info batchExecInfo) {
+	if info.isLoneDoltCheckout {
+		cli.PrintErrln(color.YellowString("Warning: dolt_checkout() in a SQL session only changes the active branch for that SQL session. Your branch in the CLI is unchanged. To change the checked out branch for dolt CLI commands, run `dolt checkout <branch>`."))
+	}
 }
 
 // isDoltCheckoutCall returns true when the already-parsed statement

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -296,7 +296,7 @@ func (cmd SqlCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 			}
 		} else {
 			input = transform.NewReader(input, textunicode.BOMOverride(transform.Nop))
-			err := execBatchMode(queryist.Context, queryist.Queryist, input, continueOnError, format, binaryAsHex, nil)
+			_, err := execBatchMode(queryist.Context, queryist.Queryist, input, continueOnError, format, binaryAsHex)
 			if err != nil {
 				return sqlHandleVErrAndExitCode(queryist.Queryist, errhand.VerboseErrorFromError(err), usage)
 			}
@@ -409,18 +409,14 @@ func queryMode(
 ) int {
 	_, continueOnError := apr.GetValue(continueFlag)
 
-	var info batchExecInfo
 	input := strings.NewReader(query)
-	err := execBatchMode(ctx, qryist, input, continueOnError, format, binaryAsHex, &info)
+	info, err := execBatchMode(ctx, qryist, input, continueOnError, format, binaryAsHex)
 	if err != nil {
 		return sqlHandleVErrAndExitCode(qryist, errhand.VerboseErrorFromError(err), usage)
 	}
 
 	if info.isLoneDoltCheckout {
-		cli.PrintErrln(color.YellowString("Warning: dolt_checkout() only changes the branch for the current session."))
-		cli.PrintErrln(color.YellowString("Since `dolt sql -q` starts a new session for each invocation, the checked-out"))
-		cli.PrintErrln(color.YellowString("branch will not persist after this command exits."))
-		cli.PrintErrln(color.YellowString("To change the checked-out branch, use `dolt checkout <branch>` instead."))
+		cli.PrintErrln(color.YellowString("Warning: dolt_checkout() in a SQL session only changes the active branch for that SQL session. Your branch in the CLI is unchanged. To change the checked out branch for dolt CLI commands, run `dolt checkout <branch>`."))
 	}
 
 	return 0
@@ -429,7 +425,6 @@ func queryMode(
 // batchExecInfo collects metadata from execBatchMode so callers can
 // inspect what was executed without re-parsing the query string.
 type batchExecInfo struct {
-	stmtCount          int
 	isLoneDoltCheckout bool
 }
 
@@ -652,8 +647,10 @@ func validateSqlArgs(apr *argparser.ArgParseResults) error {
 }
 
 // execBatchMode runs all the queries in the input reader.
-// If info is non-nil, it is populated with metadata about the executed statements.
-func execBatchMode(ctx *sql.Context, qryist cli.Queryist, input io.Reader, continueOnErr bool, format engine.PrintResultFormat, binaryAsHex bool, info *batchExecInfo) error {
+// It returns metadata about the executed statements.
+func execBatchMode(ctx *sql.Context, qryist cli.Queryist, input io.Reader, continueOnErr bool, format engine.PrintResultFormat, binaryAsHex bool) (batchExecInfo, error) {
+	var info batchExecInfo
+	var stmtCount int
 	scanner := NewStreamScanner(input)
 	var query string
 	for scanner.Scan() {
@@ -677,28 +674,26 @@ func execBatchMode(ctx *sql.Context, qryist cli.Queryist, input io.Reader, conti
 		if err == sqlparser.ErrEmpty {
 			continue
 		} else if err != nil {
+			info.isLoneDoltCheckout = false
 			err = buildBatchSqlErr(scanner.state.statementStartLine, query, err)
 			if !continueOnErr {
-				return err
+				return batchExecInfo{}, err
 			} else {
 				cli.PrintErrln(err.Error())
 			}
 		}
 
-		if info != nil {
-			info.stmtCount++
-			if isDoltCheckoutCall(sqlStatement) {
-				info.isLoneDoltCheckout = true
-			}
-		}
+		stmtCount++
+		info.isLoneDoltCheckout = stmtCount == 1 && isDoltCheckoutCall(sqlStatement)
 
 		// store start time for query
 		ctx.SetQueryTime(time.Now())
 		sqlSch, rowIter, _, err := processParsedQuery(ctx, query, qryist, sqlStatement)
 		if err != nil {
+			info.isLoneDoltCheckout = false
 			err = buildBatchSqlErr(scanner.state.statementStartLine, query, err)
 			if !continueOnErr {
-				return err
+				return batchExecInfo{}, err
 			} else {
 				cli.PrintErrln(err.Error())
 			}
@@ -715,9 +710,10 @@ func execBatchMode(ctx *sql.Context, qryist cli.Queryist, input io.Reader, conti
 			}
 			err = engine.PrettyPrintResults(ctx, format, sqlSch, rowIter, false, false, false, binaryAsHex)
 			if err != nil {
+				info.isLoneDoltCheckout = false
 				err = buildBatchSqlErr(scanner.state.statementStartLine, query, err)
 				if !continueOnErr {
-					return err
+					return batchExecInfo{}, err
 				} else {
 					cli.PrintErrln(err.Error())
 				}
@@ -727,14 +723,10 @@ func execBatchMode(ctx *sql.Context, qryist cli.Queryist, input io.Reader, conti
 	}
 
 	if err := scanner.Err(); err != nil {
-		return buildBatchSqlErr(scanner.state.statementStartLine, query, err)
+		return batchExecInfo{}, buildBatchSqlErr(scanner.state.statementStartLine, query, err)
 	}
 
-	if info != nil && info.stmtCount != 1 {
-		info.isLoneDoltCheckout = false
-	}
-
-	return nil
+	return info, nil
 }
 
 func buildBatchSqlErr(stmtStartLine int, query string, err error) error {

--- a/go/cmd/dolt/commands/sql_test.go
+++ b/go/cmd/dolt/commands/sql_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	_ "github.com/dolthub/go-mysql-server/sql/variables"
+	"github.com/dolthub/vitess/go/vt/sqlparser"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -506,6 +507,53 @@ func TestUpdate(t *testing.T) {
 					assert.Equal(t, uint32(test.expectedAges[i]), rows[0][2])
 				}
 			}
+		})
+	}
+}
+
+func TestIsDoltCheckoutCall(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    string
+		expected bool
+	}{
+		{
+			name:     "single dolt_checkout call",
+			query:    "call dolt_checkout('main')",
+			expected: true,
+		},
+		{
+			name:     "dolt_checkout uppercase",
+			query:    "CALL DOLT_CHECKOUT('feature-branch')",
+			expected: true,
+		},
+		{
+			name:     "dolt_checkout mixed case",
+			query:    "Call Dolt_Checkout('dev')",
+			expected: true,
+		},
+		{
+			name:     "dolt_checkout with -b flag",
+			query:    "call dolt_checkout('-b', 'new-branch')",
+			expected: true,
+		},
+		{
+			name:     "not a call statement",
+			query:    "select * from people",
+			expected: false,
+		},
+		{
+			name:     "different procedure",
+			query:    "call dolt_commit('-m', 'test')",
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stmt, err := sqlparser.Parse(test.query)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, isDoltCheckoutCall(stmt))
 		})
 	}
 }

--- a/go/cmd/dolt/commands/sql_test.go
+++ b/go/cmd/dolt/commands/sql_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	_ "github.com/dolthub/go-mysql-server/sql/variables"
-	"github.com/dolthub/vitess/go/vt/sqlparser"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -507,53 +506,6 @@ func TestUpdate(t *testing.T) {
 					assert.Equal(t, uint32(test.expectedAges[i]), rows[0][2])
 				}
 			}
-		})
-	}
-}
-
-func TestIsDoltCheckoutCall(t *testing.T) {
-	tests := []struct {
-		name     string
-		query    string
-		expected bool
-	}{
-		{
-			name:     "single dolt_checkout call",
-			query:    "call dolt_checkout('main')",
-			expected: true,
-		},
-		{
-			name:     "dolt_checkout uppercase",
-			query:    "CALL DOLT_CHECKOUT('feature-branch')",
-			expected: true,
-		},
-		{
-			name:     "dolt_checkout mixed case",
-			query:    "Call Dolt_Checkout('dev')",
-			expected: true,
-		},
-		{
-			name:     "dolt_checkout with -b flag",
-			query:    "call dolt_checkout('-b', 'new-branch')",
-			expected: true,
-		},
-		{
-			name:     "not a call statement",
-			query:    "select * from people",
-			expected: false,
-		},
-		{
-			name:     "different procedure",
-			query:    "call dolt_commit('-m', 'test')",
-			expected: false,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			stmt, err := sqlparser.Parse(test.query)
-			require.NoError(t, err)
-			assert.Equal(t, test.expected, isDoltCheckoutCall(stmt))
 		})
 	}
 }

--- a/integration-tests/bats/sql-checkout.bats
+++ b/integration-tests/bats/sql-checkout.bats
@@ -41,6 +41,27 @@ teardown() {
     [[ "$output" =~ "main" ]] || false
 }
 
+@test "sql-checkout: DOLT_CHECKOUT warns when used as lone statement in dolt sql -q" {
+    dolt sql -q "call dolt_checkout('-b', 'feature-branch')"
+
+    run dolt sql -q "call dolt_checkout('feature-branch')"
+    [ $status -eq 0 ]
+    [[ "$output" =~ "Warning" ]] || false
+    [[ "$output" =~ "dolt_checkout()" ]] || false
+    [[ "$output" =~ "dolt checkout" ]] || false
+}
+
+@test "sql-checkout: DOLT_CHECKOUT does not warn when combined with other statements" {
+    dolt sql -q "call dolt_checkout('-b', 'feature-branch')"
+
+    run dolt sql <<SQL
+call dolt_checkout('feature-branch');
+select * from test;
+SQL
+    [ $status -eq 0 ]
+    [[ ! "$output" =~ "Warning" ]] || false
+}
+
 @test "sql-checkout: DOLT_CHECKOUT -b throws error on branches that already exist" {
     run dolt sql -q "call dolt_checkout('-b', 'main')"
     [ $status -eq 1 ]

--- a/integration-tests/bats/sql-checkout.bats
+++ b/integration-tests/bats/sql-checkout.bats
@@ -46,7 +46,6 @@ teardown() {
 @test "sql-checkout: DOLT_CHECKOUT warns when used as lone statement in dolt sql -q" {
     export NO_COLOR=1
     dolt branch feature-branch
-    expected_warning='Warning: dolt_checkout() in a SQL session only changes the active branch for that SQL session. Your branch in the CLI is unchanged. To change the checked out branch for dolt CLI commands, run `dolt checkout <branch>`.'
 
     for query in \
         "call dolt_checkout('feature-branch')" \
@@ -56,7 +55,7 @@ teardown() {
     do
         run --separate-stderr dolt sql -q "$query"
         [ "$status" -eq 0 ]
-        [ "$stderr" = "$expected_warning" ]
+        [[ "$stderr" =~ "Your branch in the CLI is unchanged" ]] || false
         [[ ! "$output" =~ "Warning:" ]] || false
     done
 
@@ -69,7 +68,7 @@ teardown() {
     export NO_COLOR=1
     run --separate-stderr dolt sql -q "call dolt_checkout('-b', 'feature-branch')"
     [ "$status" -eq 0 ]
-    [ "$stderr" = 'Warning: dolt_checkout() in a SQL session only changes the active branch for that SQL session. Your branch in the CLI is unchanged. To change the checked out branch for dolt CLI commands, run `dolt checkout <branch>`.' ]
+    [[ "$stderr" =~ "Your branch in the CLI is unchanged" ]] || false
 
     run dolt branch --show-current
     [ "$status" -eq 0 ]
@@ -128,7 +127,7 @@ teardown() {
 
     run --separate-stderr dolt sql < queries.sql
     [ "$status" -eq 0 ]
-    [ "$stderr" = 'Warning: dolt_checkout() in a SQL session only changes the active branch for that SQL session. Your branch in the CLI is unchanged. To change the checked out branch for dolt CLI commands, run `dolt checkout <branch>`.' ]
+    [[ "$stderr" =~ "Your branch in the CLI is unchanged" ]] || false
     [[ ! "$output" =~ "Warning:" ]] || false
 
     run dolt branch --show-current

--- a/integration-tests/bats/sql-checkout.bats
+++ b/integration-tests/bats/sql-checkout.bats
@@ -121,11 +121,35 @@ teardown() {
     [[ ! "$stderr" =~ "Warning:" ]] || false
 }
 
-@test "sql-checkout: stdin batch checkouts do not warn" {
+@test "sql-checkout: redirected lone checkout warns without changing the CLI branch" {
+    export NO_COLOR=1
     dolt branch feature-branch
-    run --separate-stderr dolt sql <<< "call dolt_checkout('feature-branch');"
+    echo "call dolt_checkout('feature-branch');" > queries.sql
+
+    run --separate-stderr dolt sql < queries.sql
+    [ "$status" -eq 0 ]
+    [ "$stderr" = 'Warning: dolt_checkout() in a SQL session only changes the active branch for that SQL session. Your branch in the CLI is unchanged. To change the checked out branch for dolt CLI commands, run `dolt checkout <branch>`.' ]
+    [[ ! "$output" =~ "Warning:" ]] || false
+
+    run dolt branch --show-current
+    [ "$status" -eq 0 ]
+    [ "$output" = "main" ]
+}
+
+@test "sql-checkout: redirected multiple statements and failed checkouts do not warn" {
+    dolt branch feature-branch
+    echo "call dolt_checkout('feature-branch'); select active_branch();" > queries.sql
+
+    run --separate-stderr dolt sql -r csv < queries.sql
     [ "$status" -eq 0 ]
     [ -z "$stderr" ]
+    [[ "$output" = *$'active_branch()\nfeature-branch' ]] || false
+
+    echo "call dolt_checkout('missing-branch');" > queries.sql
+    run --separate-stderr dolt sql < queries.sql
+    [ "$status" -ne 0 ]
+    [[ "$stderr" =~ "missing-branch" ]] || false
+    [[ ! "$stderr" =~ "Warning:" ]] || false
 }
 
 @test "sql-checkout: DOLT_CHECKOUT -b throws error on branches that already exist" {

--- a/integration-tests/bats/sql-checkout.bats
+++ b/integration-tests/bats/sql-checkout.bats
@@ -1,6 +1,8 @@
 #!/usr/bin/env bats
 load $BATS_TEST_DIRNAME/helper/common.bash
 
+bats_require_minimum_version 1.5.0
+
 setup() {
     setup_common
 
@@ -42,24 +44,88 @@ teardown() {
 }
 
 @test "sql-checkout: DOLT_CHECKOUT warns when used as lone statement in dolt sql -q" {
-    dolt sql -q "call dolt_checkout('-b', 'feature-branch')"
+    export NO_COLOR=1
+    dolt branch feature-branch
+    expected_warning='Warning: dolt_checkout() in a SQL session only changes the active branch for that SQL session. Your branch in the CLI is unchanged. To change the checked out branch for dolt CLI commands, run `dolt checkout <branch>`.'
 
-    run dolt sql -q "call dolt_checkout('feature-branch')"
-    [ $status -eq 0 ]
-    [[ "$output" =~ "Warning" ]] || false
-    [[ "$output" =~ "dolt_checkout()" ]] || false
-    [[ "$output" =~ "dolt checkout" ]] || false
+    for query in \
+        "call dolt_checkout('feature-branch')" \
+        "CALL DOLT_CHECKOUT('feature-branch');" \
+        "/* leading comment */ Call Dolt_Checkout('feature-branch'); /* trailing comment */" \
+        " ; call dolt_checkout('feature-branch'); ; "
+    do
+        run --separate-stderr dolt sql -q "$query"
+        [ "$status" -eq 0 ]
+        [ "$stderr" = "$expected_warning" ]
+        [[ ! "$output" =~ "Warning:" ]] || false
+    done
+
+    run dolt branch --show-current
+    [ "$status" -eq 0 ]
+    [ "$output" = "main" ]
 }
 
-@test "sql-checkout: DOLT_CHECKOUT does not warn when combined with other statements" {
-    dolt sql -q "call dolt_checkout('-b', 'feature-branch')"
+@test "sql-checkout: DOLT_CHECKOUT branch creation warns without changing the CLI branch" {
+    export NO_COLOR=1
+    run --separate-stderr dolt sql -q "call dolt_checkout('-b', 'feature-branch')"
+    [ "$status" -eq 0 ]
+    [ "$stderr" = 'Warning: dolt_checkout() in a SQL session only changes the active branch for that SQL session. Your branch in the CLI is unchanged. To change the checked out branch for dolt CLI commands, run `dolt checkout <branch>`.' ]
 
-    run dolt sql <<SQL
-call dolt_checkout('feature-branch');
-select * from test;
-SQL
-    [ $status -eq 0 ]
-    [[ ! "$output" =~ "Warning" ]] || false
+    run dolt branch --show-current
+    [ "$status" -eq 0 ]
+    [ "$output" = "main" ]
+    run dolt sql -r csv -q "select name from dolt_branches where name = 'feature-branch'"
+    [ "$status" -eq 0 ]
+    [ "$output" = $'name\nfeature-branch' ]
+}
+
+@test "sql-checkout: DOLT_CHECKOUT does not warn when combined with other statements in dolt sql -q" {
+    dolt branch feature-branch
+
+    for query in \
+        "call dolt_checkout('feature-branch'); select active_branch();" \
+        "select 1; call dolt_checkout('feature-branch'); select active_branch();" \
+        "select 1; call dolt_checkout('feature-branch');" \
+        "call dolt_checkout('feature-branch'); call dolt_checkout('main');"
+    do
+        run --separate-stderr dolt sql -r csv -q "$query"
+        [ "$status" -eq 0 ]
+        [ -z "$stderr" ]
+        [[ ! "$output" =~ "Warning:" ]] || false
+        if [[ "$query" =~ "active_branch" ]]; then
+            [[ "$output" = *$'active_branch()\nfeature-branch' ]] || false
+        fi
+    done
+
+    run dolt branch --show-current
+    [ "$status" -eq 0 ]
+    [ "$output" = "main" ]
+}
+
+@test "sql-checkout: unrelated queries and failed checkouts do not warn" {
+    for query in "select 'dolt_checkout'" "call dolt_branch('feature-branch')" "/* only a comment */"
+    do
+        run --separate-stderr dolt sql -q "$query"
+        [ "$status" -eq 0 ]
+        [ -z "$stderr" ]
+    done
+
+    run --separate-stderr dolt sql -q "call dolt_checkout('missing-branch')"
+    [ "$status" -ne 0 ]
+    [[ "$stderr" =~ "missing-branch" ]] || false
+    [[ ! "$stderr" =~ "Warning:" ]] || false
+
+    run --separate-stderr dolt sql --continue -q "call dolt_checkout('missing-branch')"
+    [ "$status" -eq 0 ]
+    [[ "$stderr" =~ "missing-branch" ]] || false
+    [[ ! "$stderr" =~ "Warning:" ]] || false
+}
+
+@test "sql-checkout: stdin batch checkouts do not warn" {
+    dolt branch feature-branch
+    run --separate-stderr dolt sql <<< "call dolt_checkout('feature-branch');"
+    [ "$status" -eq 0 ]
+    [ -z "$stderr" ]
 }
 
 @test "sql-checkout: DOLT_CHECKOUT -b throws error on branches that already exist" {


### PR DESCRIPTION
Warns when a lone `dolt_checkout()` call in noninteractive SQL changes only the SQL session's branch, leaving the CLI branch unchanged.

Fixes https://github.com/dolthub/dolt/issues/6876
