### PR TITLE
[no-release-notes] Use Server harness for TestScripts

### DIFF
--- a/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_engine_test.go
@@ -537,7 +537,7 @@ func TestConvertPrepared(t *testing.T) {
 }
 
 func TestScripts(t *testing.T) {
-	h := newDoltHarness(t).WithConfigureStats(true)
+	h := newDoltServerTestHarness(t).WithConfigureStats(true)
 	defer h.Close()
 	enginetest.TestScripts(t, h)
 }

--- a/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_harness.go
@@ -148,7 +148,7 @@ func newDoltEnginetestHarness(t *testing.T) DoltEnginetestHarness {
 // newDoltServerTestHarness creates a harness that starts a MySQL server
 // and runs tests by connecting to the server with a driver. This is useful
 // for testing the server's handler.
-func newDoltServerTestHarness(t *testing.T) DoltEnginetestHarness {
+func newDoltServerTestHarness(t *testing.T) *DoltHarness {
 	dh := newDoltHarness(t)
 	dh.server = true
 	return dh


### PR DESCRIPTION
Building off of https://github.com/dolthub/dolt/pull/11603, this PR applies a test harness to TestScripts that runs an actual GMS server, providing test coverage to the server Handler codepaths for these scripts.

We still don't use this Server test harness for all tests because it does not properly implement Dolt-specific functionality like access controls. But it allows us to run against a GMS server using Dolt as a storage backend.