### PR TITLE
[no-release-notes] ci: fix MinIO download URL

### DIFF
--- a/.github/workflows/ci-bats-unix.yaml
+++ b/.github/workflows/ci-bats-unix.yaml
@@ -124,12 +124,12 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ./.ci_bin/minio
-          key: minio-bin
+          key: minio-community-RELEASE.2025-09-07T16-13-09Z
       - name: Install MinIO
         if: steps.cache_minio.outputs.cache-hit != 'true'
         working-directory: ./.ci_bin
         run: |
-          curl -sSL -o minio https://dl.min.io/server/minio/release/linux-amd64/minio
+          curl -sSLf -o minio https://github.com/minio/minio/releases/download/RELEASE.2025-09-07T16-13-09Z/minio.linux-amd64.RELEASE.2025-09-07T16-13-09Z
           chmod +x minio
       - name: Test all Unix
         if: matrix.sql_engine == 'local-engine' || env.use_credentials == 'true'


### PR DESCRIPTION
[MinIO AIStor release notes](https://dl.min.io/aistor/minio/release/notes/release-notes-RELEASE.2026-06-06T02-44-06Z.md): legacy server builds are archived and no longer served. dl.min.io returns 410 and AIStor needs a license, so use the license-free binary from GitHub Releases (https://github.com/minio/minio/releases/tag/RELEASE.2025-09-07T16-13-09Z).